### PR TITLE
fix: enforce auth and HTTPS as hard requirements (Critical C1, C2)

### DIFF
--- a/internal/config/security.go
+++ b/internal/config/security.go
@@ -104,6 +104,9 @@ func ValidateSecurity(cfg Config) error {
 			return fmt.Errorf("invalid IDENTRAIL_ALERT_MIN_SEVERITY %q", cfg.AlertMinSeverity)
 		}
 	}
+	if len(cfg.APIKeys) == 0 && len(cfg.APIKeyScopes) == 0 {
+		return fmt.Errorf("no API keys configured: set IDENTRAIL_API_KEYS or IDENTRAIL_API_KEY_SCOPES to enable authentication")
+	}
 	return nil
 }
 
@@ -112,9 +115,6 @@ func SecurityWarnings(cfg Config) []string {
 	warnings := []string{}
 	if len(cfg.APIKeys) > 0 && len(cfg.APIKeyScopes) > 0 {
 		warnings = append(warnings, "IDENTRAIL_API_KEYS is ignored when IDENTRAIL_API_KEY_SCOPES is configured")
-	}
-	if len(cfg.APIKeys) == 0 && len(cfg.APIKeyScopes) == 0 {
-		warnings = append(warnings, "v1 API authentication is disabled (no API keys configured)")
 	}
 	if strings.TrimSpace(cfg.AuditLogFile) == "" {
 		warnings = append(warnings, "audit file sink is disabled; configure IDENTRAIL_AUDIT_LOG_FILE for durable local audit records")

--- a/internal/config/security_test.go
+++ b/internal/config/security_test.go
@@ -5,6 +5,13 @@ import (
 	"time"
 )
 
+func TestValidateSecurityRejectsNoAPIKeys(t *testing.T) {
+	cfg := Config{} // no APIKeys or APIKeyScopes
+	if err := ValidateSecurity(cfg); err == nil {
+		t.Fatal("expected error when no API keys configured")
+	}
+}
+
 func TestValidateSecurityWriteKeyMustBeInAPIKeys(t *testing.T) {
 	cfg := Config{
 		APIKeys:      []string{"reader"},

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -77,7 +77,17 @@ export type ScanEvent = {
   created_at: string;
 };
 
-const baseURL = (import.meta.env.VITE_IDENTRAIL_API_URL as string | undefined) ?? 'http://localhost:8080';
+const configuredURL = import.meta.env.VITE_IDENTRAIL_API_URL as string | undefined;
+if (import.meta.env.PROD) {
+  if (!configuredURL) {
+    throw new Error('VITE_IDENTRAIL_API_URL must be set in production builds');
+  }
+  const parsed = new URL(configuredURL);
+  if (parsed.protocol === 'http:' && parsed.hostname !== 'localhost') {
+    throw new Error('VITE_IDENTRAIL_API_URL must use HTTPS in production (HTTP only allowed for localhost)');
+  }
+}
+const baseURL = configuredURL ?? 'http://localhost:8080';
 
 async function request<T>(path: string, apiKey?: string): Promise<T> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };


### PR DESCRIPTION
## Summary

Fixes the two **Critical** findings from the security audit.

- **C1 — Frontend transmits API keys over plaintext HTTP** (`web/src/api/client.ts`): In production builds (`import.meta.env.PROD`), the client now throws at module initialisation if `VITE_IDENTRAIL_API_URL` is unset or uses `http://` for a non-localhost host. Dev builds retain the existing `http://localhost:8080` fallback.

- **C2 — Auth middleware silently becomes no-op when no keys configured** (`internal/config/security.go`): Promoted the "no API keys configured" check from a soft `SecurityWarnings` entry to a hard `ValidateSecurity` error. The server now refuses to start unless `IDENTRAIL_API_KEYS` or `IDENTRAIL_API_KEY_SCOPES` is set. A new test (`TestValidateSecurityRejectsNoAPIKeys`) covers this path.

## Test plan
- [x] `go test ./internal/config/... ./internal/api/...` passes with no regressions
- [ ] Manual: start server without any API key env vars set → should fail startup with a clear error
- [ ] Manual: build frontend without `VITE_IDENTRAIL_API_URL` set (`NODE_ENV=production`) → browser console should throw on load
- [ ] Manual: set `VITE_IDENTRAIL_API_URL=http://example.com` in a production build → should throw (non-localhost HTTP rejected)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces authentication and HTTPS as hard requirements to address critical audit findings C1 and C2. Production builds now require a HTTPS API URL, and the server won't start without API keys.

- **Bug Fixes**
  - Frontend (`web/src/api/client.ts`): In production, throw if `VITE_IDENTRAIL_API_URL` is unset or uses `http://` for non-localhost; dev keeps `http://localhost:8080` fallback.
  - Backend (`internal/config/security.go`): `ValidateSecurity` now errors when no API keys are configured; added `TestValidateSecurityRejectsNoAPIKeys`.

- **Migration**
  - Set `VITE_IDENTRAIL_API_URL` to an HTTPS URL in production (HTTP allowed only for `localhost`).
  - Configure `IDENTRAIL_API_KEYS` or `IDENTRAIL_API_KEY_SCOPES` before starting the server.

<sup>Written for commit abdccbc368e1cc758b31495ecae48c68855fdbc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

