### PR TITLE
Bound API rate limiter cache and evict stale IP entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Hardened API rate limiter memory behavior:
+  - bounded per-IP limiter cache with deterministic max-cap eviction
+  - stale IP limiter entries now expire automatically
+  - added regression tests for stale-entry and oldest-entry eviction paths
 - Hardened API client IP handling against spoofed `X-Forwarded-For` by default:
   - added trusted proxy configuration (`IDENTRAIL_TRUSTED_PROXIES`)
   - default behavior now trusts no proxy hops unless explicitly configured

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -29,6 +29,9 @@ const (
 	maxCursorFetchLimit    = 5000
 	scanRequestTimeout     = 2 * time.Minute
 	repoScanRequestTimeout = 5 * time.Minute
+	rateLimiterEntryTTL    = 15 * time.Minute
+	rateLimiterMaxEntries  = 10000
+	rateLimiterCleanupTick = 256
 	scopeRead              = "read"
 	scopeWrite             = "write"
 	scopeAdmin             = "admin"
@@ -1080,35 +1083,119 @@ func requireReadableScopeMiddleware(scopedKeys map[string][]string) gin.HandlerF
 }
 
 type ipRateLimiter struct {
-	mu       sync.Mutex
-	limiters map[string]*rate.Limiter
-	rate     rate.Limit
-	burst    int
+	mu           sync.Mutex
+	limiters     map[string]ipLimiterEntry
+	rate         rate.Limit
+	burst        int
+	now          func() time.Time
+	entryTTL     time.Duration
+	maxEntries   int
+	cleanupEvery uint64
+	allowCount   uint64
+}
+
+type ipLimiterEntry struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
 }
 
 func newIPRateLimiter(rpm int, burst int) *ipRateLimiter {
+	return newIPRateLimiterWithClock(rpm, burst, time.Now, rateLimiterEntryTTL, rateLimiterMaxEntries, rateLimiterCleanupTick)
+}
+
+func newIPRateLimiterWithClock(
+	rpm int,
+	burst int,
+	now func() time.Time,
+	entryTTL time.Duration,
+	maxEntries int,
+	cleanupEvery uint64,
+) *ipRateLimiter {
 	if rpm <= 0 {
 		rpm = 120
 	}
 	if burst <= 0 {
 		burst = 20
 	}
+	if now == nil {
+		now = time.Now
+	}
+	if entryTTL <= 0 {
+		entryTTL = rateLimiterEntryTTL
+	}
+	if maxEntries <= 0 {
+		maxEntries = rateLimiterMaxEntries
+	}
+	if cleanupEvery == 0 {
+		cleanupEvery = rateLimiterCleanupTick
+	}
 	return &ipRateLimiter{
-		limiters: map[string]*rate.Limiter{},
-		rate:     rate.Every(time.Minute / time.Duration(rpm)),
-		burst:    burst,
+		limiters:     map[string]ipLimiterEntry{},
+		rate:         rate.Every(time.Minute / time.Duration(rpm)),
+		burst:        burst,
+		now:          now,
+		entryTTL:     entryTTL,
+		maxEntries:   maxEntries,
+		cleanupEvery: cleanupEvery,
 	}
 }
 
 func (l *ipRateLimiter) allow(ip string) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	limiter, ok := l.limiters[ip]
-	if !ok {
-		limiter = rate.NewLimiter(l.rate, l.burst)
-		l.limiters[ip] = limiter
+	now := l.now()
+	l.allowCount++
+	if l.cleanupEvery > 0 && l.allowCount%l.cleanupEvery == 0 {
+		l.evictExpiredLocked(now)
 	}
-	return limiter.Allow()
+
+	entry, ok := l.limiters[ip]
+	if !ok {
+		if len(l.limiters) >= l.maxEntries {
+			l.evictExpiredLocked(now)
+		}
+		if len(l.limiters) >= l.maxEntries {
+			l.evictOldestLocked()
+		}
+		entry = ipLimiterEntry{
+			limiter:  rate.NewLimiter(l.rate, l.burst),
+			lastSeen: now,
+		}
+		l.limiters[ip] = entry
+	} else {
+		entry.lastSeen = now
+		l.limiters[ip] = entry
+	}
+	return entry.limiter.Allow()
+}
+
+func (l *ipRateLimiter) evictExpiredLocked(now time.Time) {
+	if len(l.limiters) == 0 {
+		return
+	}
+	cutoff := now.Add(-l.entryTTL)
+	for ip, entry := range l.limiters {
+		if entry.lastSeen.Before(cutoff) {
+			delete(l.limiters, ip)
+		}
+	}
+}
+
+func (l *ipRateLimiter) evictOldestLocked() {
+	if len(l.limiters) == 0 {
+		return
+	}
+	var oldestIP string
+	var oldestTime time.Time
+	for ip, entry := range l.limiters {
+		if oldestIP == "" || entry.lastSeen.Before(oldestTime) {
+			oldestIP = ip
+			oldestTime = entry.lastSeen
+		}
+	}
+	if oldestIP != "" {
+		delete(l.limiters, oldestIP)
+	}
 }
 
 func rateLimitMiddleware(rpm int, burst int) gin.HandlerFunc {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -948,6 +948,72 @@ func TestRouterRateLimitExceeded(t *testing.T) {
 	}
 }
 
+func TestIPRateLimiterEvictsExpiredEntries(t *testing.T) {
+	now := time.Date(2026, 3, 20, 10, 0, 0, 0, time.UTC)
+	limiter := newIPRateLimiterWithClock(
+		60,
+		1,
+		func() time.Time { return now },
+		1*time.Second,
+		2,
+		1,
+	)
+
+	if !limiter.allow("10.0.0.1") {
+		t.Fatal("expected first request to pass")
+	}
+	if len(limiter.limiters) != 1 {
+		t.Fatalf("expected one tracked ip, got %d", len(limiter.limiters))
+	}
+
+	now = now.Add(2 * time.Second)
+	if !limiter.allow("10.0.0.2") {
+		t.Fatal("expected new request to pass")
+	}
+	if len(limiter.limiters) != 1 {
+		t.Fatalf("expected stale entry eviction to keep one tracked ip, got %d", len(limiter.limiters))
+	}
+	if _, exists := limiter.limiters["10.0.0.1"]; exists {
+		t.Fatal("expected expired ip entry to be evicted")
+	}
+}
+
+func TestIPRateLimiterEvictsOldestEntryWhenCapacityReached(t *testing.T) {
+	now := time.Date(2026, 3, 20, 10, 0, 0, 0, time.UTC)
+	limiter := newIPRateLimiterWithClock(
+		60,
+		1,
+		func() time.Time { return now },
+		1*time.Hour,
+		2,
+		1,
+	)
+
+	if !limiter.allow("10.0.0.1") {
+		t.Fatal("expected first request to pass")
+	}
+	now = now.Add(100 * time.Millisecond)
+	if !limiter.allow("10.0.0.2") {
+		t.Fatal("expected second request to pass")
+	}
+	now = now.Add(100 * time.Millisecond)
+	if !limiter.allow("10.0.0.3") {
+		t.Fatal("expected third request to pass")
+	}
+	if len(limiter.limiters) != 2 {
+		t.Fatalf("expected limiter size to stay bounded at 2, got %d", len(limiter.limiters))
+	}
+	if _, exists := limiter.limiters["10.0.0.1"]; exists {
+		t.Fatal("expected oldest entry to be evicted when capacity is reached")
+	}
+	if _, exists := limiter.limiters["10.0.0.2"]; !exists {
+		t.Fatal("expected newer entry to remain in limiter cache")
+	}
+	if _, exists := limiter.limiters["10.0.0.3"]; !exists {
+		t.Fatal("expected most recent entry to remain in limiter cache")
+	}
+}
+
 func TestParseLimit(t *testing.T) {
 	if got := parseLimit("", 10, 500); got != 10 {
 		t.Fatalf("expected fallback 10, got %d", got)


### PR DESCRIPTION
## Summary
- bound in-memory per-IP rate limiter state to prevent unbounded growth
- evict stale entries by TTL and evict oldest entry when capacity is reached
- add regression tests for stale-entry and capacity eviction behavior

## Validation
- go test ./internal/api -count=1
- go test ./... -count=1
- go vet ./...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the per‑IP rate limiter cache and added TTL eviction to prevent unbounded memory growth. Stale IPs now expire automatically, and the oldest entry is evicted when capacity is reached.

- **Bug Fixes**
  - Added TTL-based expiry for IP limiter entries (default 15m).
  - Capped cache at 10,000 entries; evict oldest on capacity.
  - Periodic cleanup runs every 256 allow calls to purge expired entries.
  - Added regression tests for TTL and capacity eviction paths.

<sup>Written for commit 43b09c360cc2175d605278e474e4ca72a5eaf473. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

