### PR TITLE
Reject insecure HTTP repository clone targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Hardened repository exposure scanner clone target validation:
+  - reject insecure `http://` repository clone URLs
+  - allow `https://`, `ssh://`, and `git@` forms
+  - added regression tests to ensure insecure targets are blocked before clone execution
 - Hardened API rate limiter memory behavior:
   - bounded per-IP limiter cache with deterministic max-cap eviction
   - stale IP limiter entries now expire automatically

--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -225,6 +226,9 @@ func (s *Scanner) prepareRepository(ctx context.Context, target string) (reposit
 	}
 
 	cloneURL := normalizeRepositoryInput(target)
+	if err := validateCloneURL(cloneURL); err != nil {
+		return repositoryLocation{}, nil, err
+	}
 	workdir, err := os.MkdirTemp("", "identrail-repo-*")
 	if err != nil {
 		return repositoryLocation{}, nil, fmt.Errorf("create temp repository directory: %w", err)
@@ -406,6 +410,32 @@ func normalizeRepositoryInput(target string) string {
 		return "https://github.com/" + strings.TrimSuffix(trimmed, ".git") + ".git"
 	}
 	return trimmed
+}
+
+func validateCloneURL(cloneURL string) error {
+	trimmed := strings.TrimSpace(cloneURL)
+	if trimmed == "" {
+		return fmt.Errorf("repository target is required")
+	}
+
+	lower := strings.ToLower(trimmed)
+	if strings.HasPrefix(lower, "http://") {
+		return fmt.Errorf("insecure repository url scheme http is not allowed; use https or ssh")
+	}
+	if !strings.Contains(lower, "://") {
+		return nil
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return fmt.Errorf("parse repository target: %w", err)
+	}
+	switch strings.ToLower(parsed.Scheme) {
+	case "https", "ssh":
+		return nil
+	default:
+		return fmt.Errorf("unsupported repository url scheme %q", parsed.Scheme)
+	}
 }
 
 func redactMatch(line string, value string) string {

--- a/internal/repoexposure/scanner_test.go
+++ b/internal/repoexposure/scanner_test.go
@@ -165,6 +165,54 @@ func TestPrepareRepositoryCloneFailure(t *testing.T) {
 	}
 }
 
+func TestPrepareRepositoryRejectsInsecureHTTPRepositoryURL(t *testing.T) {
+	cloneCalled := false
+	scanner := NewScanner(func(context.Context, string, ...string) ([]byte, error) {
+		cloneCalled = true
+		return nil, nil
+	})
+
+	_, cleanup, err := scanner.prepareRepository(context.Background(), "http://github.com/owner/repo.git")
+	if cleanup != nil {
+		cleanup()
+	}
+	if err == nil {
+		t.Fatal("expected insecure repository URL to be rejected")
+	}
+	if !strings.Contains(err.Error(), "insecure repository url scheme http is not allowed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cloneCalled {
+		t.Fatal("expected clone command not to run for insecure repository URL")
+	}
+}
+
+func TestValidateCloneURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		target    string
+		expectErr bool
+	}{
+		{name: "github shorthand", target: "https://github.com/owner/repo.git"},
+		{name: "ssh url", target: "ssh://git@github.com/owner/repo.git"},
+		{name: "git scp form", target: "git@github.com:owner/repo.git"},
+		{name: "insecure http", target: "http://github.com/owner/repo.git", expectErr: true},
+		{name: "unsupported file scheme", target: "file:///tmp/repo.git", expectErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateCloneURL(tc.target)
+			if tc.expectErr && err == nil {
+				t.Fatalf("expected error for %q", tc.target)
+			}
+			if !tc.expectErr && err != nil {
+				t.Fatalf("expected no error for %q, got %v", tc.target, err)
+			}
+		})
+	}
+}
+
 func TestGitInvocationModes(t *testing.T) {
 	var got [][]string
 	scanner := NewScanner(func(_ context.Context, name string, args ...string) ([]byte, error) {


### PR DESCRIPTION
## Summary
- block insecure HTTP clone targets in repository exposure scanner
- keep HTTPS, SSH URL, and git-at clone forms supported
- add regression tests to reject insecure targets before clone execution

## Validation
- go test ./internal/repoexposure -count=1
- go test ./... -count=1
- go vet ./...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block insecure HTTP clone targets in the repository exposure scanner. Only `https://`, `ssh://`, and `git@` forms are allowed; insecure targets fail fast before any clone runs.

- **Bug Fixes**
  - Added URL validation in `internal/repoexposure` before invoking clone.
  - Reject `http://` and unsupported schemes; keep `https://`, `ssh://`, and `git@`.
  - Added regression tests to ensure insecure targets are blocked and no clone is executed.

<sup>Written for commit dea655e0715b83e24918e1996f613c93b136bd58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

