### PR TITLE
Align Kubernetes fixture defaults across deploy profiles

### DIFF
--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -31,4 +31,4 @@ data:
   IDENTRAIL_TRUSTED_PROXIES: ""
   # Fixture mode defaults for deterministic scans.
   IDENTRAIL_AWS_FIXTURES: "/app/testdata/aws/role_with_policies.json,/app/testdata/aws/role_with_urlencoded_trust.json"
-  IDENTRAIL_K8S_FIXTURES: "/app/testdata/kubernetes/service_account_payments.json,/app/testdata/kubernetes/role_binding_cluster_admin.json,/app/testdata/kubernetes/pod_payments.json"
+  IDENTRAIL_K8S_FIXTURES: "/app/testdata/kubernetes/service_account_payments.json,/app/testdata/kubernetes/cluster_role_cluster_admin.json,/app/testdata/kubernetes/role_binding_cluster_admin.json,/app/testdata/kubernetes/pod_payments.json"


### PR DESCRIPTION
## Summary
- add missing cluster_role_cluster_admin.json fixture to raw Kubernetes ConfigMap default list
- align raw Kubernetes fixture defaults with Docker, Helm, and systemd profiles
- keep behavior deterministic across deployment methods

## Validation
- rg -n IDENTRAIL_K8S_FIXTURES deploy/...
- go test ./... -count=1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing cluster role fixture to the Kubernetes ConfigMap defaults so all deploy profiles use the same K8s fixtures. This keeps scan behavior deterministic across Kubernetes, Docker, Helm, and systemd.

- Added /app/testdata/kubernetes/cluster_role_cluster_admin.json to IDENTRAIL_K8S_FIXTURES in deploy/kubernetes/configmap.yaml.

<sup>Written for commit fb91b7f5b7ef182d0349071e2ed45ccb2157b078. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

