### PR TITLE
Reject placeholder auth keys and harden Helm secret defaults

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -10,16 +10,18 @@ This chart is the Kubernetes deployment baseline for Identrail.
 
 1. Copy default values:
    - `cp deploy/helm/identrail/values.yaml /tmp/identrail-values.yaml`
-2. Set production secrets in `/tmp/identrail-values.yaml` under `secret.data`.
-3. Install or upgrade:
+2. Create the runtime secret referenced by default (`identrail-secrets`):
+   - `kubectl -n identrail create secret generic identrail-secrets --from-literal=IDENTRAIL_API_KEYS=<read-key>,<write-key> --from-literal=IDENTRAIL_WRITE_API_KEYS=<write-key> --from-literal=IDENTRAIL_DATABASE_URL='postgres://identrail:password@postgres:5432/identrail?sslmode=require'`
+3. (Optional) If you want Helm to create the secret instead, set `secret.create=true` and provide `secret.data`.
+4. Install or upgrade:
    - `helm upgrade --install identrail deploy/helm/identrail -n identrail --create-namespace -f /tmp/identrail-values.yaml`
-4. Verify:
+5. Verify:
    - `kubectl -n identrail get pods`
    - `kubectl -n identrail get svc`
 
 ## Notes
 
-- For production, prefer `secret.existingSecret` and set `secret.create=false`.
+- Default mode uses `secret.existingSecret=identrail-secrets` with `secret.create=false`.
 - Enable web deployment by setting `web.enabled=true`.
 - Enable ingress by setting `ingress.enabled=true`.
 - `IDENTRAIL_AUDIT_LOG_FILE` is empty by default. If you enable it, mount a writable path for the container user.

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -11,7 +11,7 @@ This chart is the Kubernetes deployment baseline for Identrail.
 1. Copy default values:
    - `cp deploy/helm/identrail/values.yaml /tmp/identrail-values.yaml`
 2. Create the runtime secret referenced by default (`identrail-secrets`):
-   - `kubectl -n identrail create secret generic identrail-secrets --from-literal=IDENTRAIL_API_KEYS='READ_KEY,WRITE_KEY' --from-literal=IDENTRAIL_WRITE_API_KEYS='WRITE_KEY' --from-literal=IDENTRAIL_DATABASE_URL='postgres://identrail:password@postgres:5432/identrail?sslmode=require'`
+   - `READ_KEY=$(openssl rand -hex 24); WRITE_KEY=$(openssl rand -hex 24); kubectl -n identrail create secret generic identrail-secrets --from-literal=IDENTRAIL_API_KEYS="${READ_KEY},${WRITE_KEY}" --from-literal=IDENTRAIL_WRITE_API_KEYS="${WRITE_KEY}" --from-literal=IDENTRAIL_DATABASE_URL='postgres://identrail:password@postgres:5432/identrail?sslmode=require'`
 3. (Optional) If you want Helm to create the secret instead, set `secret.create=true` and provide `secret.data`.
 4. Install or upgrade:
    - `helm upgrade --install identrail deploy/helm/identrail -n identrail --create-namespace -f /tmp/identrail-values.yaml`

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -11,7 +11,7 @@ This chart is the Kubernetes deployment baseline for Identrail.
 1. Copy default values:
    - `cp deploy/helm/identrail/values.yaml /tmp/identrail-values.yaml`
 2. Create the runtime secret referenced by default (`identrail-secrets`):
-   - `kubectl -n identrail create secret generic identrail-secrets --from-literal=IDENTRAIL_API_KEYS=<read-key>,<write-key> --from-literal=IDENTRAIL_WRITE_API_KEYS=<write-key> --from-literal=IDENTRAIL_DATABASE_URL='postgres://identrail:password@postgres:5432/identrail?sslmode=require'`
+   - `kubectl -n identrail create secret generic identrail-secrets --from-literal=IDENTRAIL_API_KEYS='READ_KEY,WRITE_KEY' --from-literal=IDENTRAIL_WRITE_API_KEYS='WRITE_KEY' --from-literal=IDENTRAIL_DATABASE_URL='postgres://identrail:password@postgres:5432/identrail?sslmode=require'`
 3. (Optional) If you want Helm to create the secret instead, set `secret.create=true` and provide `secret.data`.
 4. Install or upgrade:
    - `helm upgrade --install identrail deploy/helm/identrail -n identrail --create-namespace -f /tmp/identrail-values.yaml`

--- a/deploy/helm/identrail/values.yaml
+++ b/deploy/helm/identrail/values.yaml
@@ -89,11 +89,11 @@ config:
   IDENTRAIL_K8S_FIXTURES: /app/testdata/kubernetes/service_account_payments.json,/app/testdata/kubernetes/cluster_role_cluster_admin.json,/app/testdata/kubernetes/role_binding_cluster_admin.json,/app/testdata/kubernetes/pod_payments.json
 
 secret:
-  create: true
-  existingSecret: ""
+  create: false
+  existingSecret: identrail-secrets
   data:
-    IDENTRAIL_API_KEYS: "replace-read-key,replace-write-key"
-    IDENTRAIL_WRITE_API_KEYS: "replace-write-key"
+    IDENTRAIL_API_KEYS: ""
+    IDENTRAIL_WRITE_API_KEYS: ""
     IDENTRAIL_DATABASE_URL: "postgres://identrail:replace-password@postgres:5432/identrail?sslmode=require"
     IDENTRAIL_API_KEY_SCOPES: ""
     IDENTRAIL_ALERT_WEBHOOK_URL: ""

--- a/internal/config/security.go
+++ b/internal/config/security.go
@@ -250,8 +250,16 @@ func ValidateSecurity(cfg Config) error {
 	if len(cfg.APIKeys) == 0 && len(cfg.APIKeyScopes) == 0 && oidcIssuer == "" {
 		return fmt.Errorf("no authentication configured: set API keys or OIDC configuration")
 	}
-	if key, found := findPlaceholderAPIKey(cfg.APIKeys, cfg.WriteAPIKeys, cfg.APIKeyScopes); found {
-		return fmt.Errorf("placeholder API key %q is not allowed in runtime configuration; provision real secrets", key)
+	// Placeholder validation follows the active API key mode.
+	// Scoped keys take precedence over legacy API_KEYS/WRITE_API_KEYS.
+	if len(cfg.APIKeyScopes) > 0 {
+		if key, found := findPlaceholderAPIKey(nil, nil, cfg.APIKeyScopes); found {
+			return fmt.Errorf("placeholder API key %q is not allowed in runtime configuration; provision real secrets", key)
+		}
+	} else {
+		if key, found := findPlaceholderAPIKey(cfg.APIKeys, cfg.WriteAPIKeys, nil); found {
+			return fmt.Errorf("placeholder API key %q is not allowed in runtime configuration; provision real secrets", key)
+		}
 	}
 	for _, trustedProxy := range cfg.TrustedProxies {
 		normalized := strings.TrimSpace(trustedProxy)

--- a/internal/config/security.go
+++ b/internal/config/security.go
@@ -54,6 +54,13 @@ var allowedProviders = map[string]struct{}{
 	"kubernetes": {},
 }
 
+var placeholderAPIKeys = map[string]struct{}{
+	"replace-read-key":              {},
+	"replace-write-key":             {},
+	"replace-with-strong-read-key":  {},
+	"replace-with-strong-write-key": {},
+}
+
 // ValidateSecurity checks hard-fail security misconfigurations.
 func ValidateSecurity(cfg Config) error {
 	provider := strings.ToLower(strings.TrimSpace(cfg.Provider))
@@ -243,6 +250,9 @@ func ValidateSecurity(cfg Config) error {
 	if len(cfg.APIKeys) == 0 && len(cfg.APIKeyScopes) == 0 && oidcIssuer == "" {
 		return fmt.Errorf("no authentication configured: set API keys or OIDC configuration")
 	}
+	if key, found := findPlaceholderAPIKey(cfg.APIKeys, cfg.WriteAPIKeys, cfg.APIKeyScopes); found {
+		return fmt.Errorf("placeholder API key %q is not allowed in runtime configuration; provision real secrets", key)
+	}
 	for _, trustedProxy := range cfg.TrustedProxies {
 		normalized := strings.TrimSpace(trustedProxy)
 		if normalized == "" {
@@ -307,6 +317,37 @@ func hasShortAPIKey(keys []string, scoped map[string][]string) bool {
 		}
 	}
 	return false
+}
+
+func findPlaceholderAPIKey(keys []string, writeKeys []string, scoped map[string][]string) (string, bool) {
+	for _, key := range keys {
+		normalized := strings.ToLower(strings.TrimSpace(key))
+		if normalized == "" {
+			continue
+		}
+		if _, exists := placeholderAPIKeys[normalized]; exists {
+			return key, true
+		}
+	}
+	for _, key := range writeKeys {
+		normalized := strings.ToLower(strings.TrimSpace(key))
+		if normalized == "" {
+			continue
+		}
+		if _, exists := placeholderAPIKeys[normalized]; exists {
+			return key, true
+		}
+	}
+	for key := range scoped {
+		normalized := strings.ToLower(strings.TrimSpace(key))
+		if normalized == "" {
+			continue
+		}
+		if _, exists := placeholderAPIKeys[normalized]; exists {
+			return key, true
+		}
+	}
+	return "", false
 }
 
 func validateForwardURL(raw string) error {

--- a/internal/config/security_test.go
+++ b/internal/config/security_test.go
@@ -332,6 +332,27 @@ func TestValidateSecurityAcceptsTrustedProxyEntries(t *testing.T) {
 	}
 }
 
+func TestValidateSecurityRejectsPlaceholderAPIKeys(t *testing.T) {
+	cfg := Config{
+		APIKeys:      []string{"replace-read-key", "real-reader-key-123456789012"},
+		WriteAPIKeys: []string{"real-reader-key-123456789012"},
+	}
+	if err := ValidateSecurity(cfg); err == nil {
+		t.Fatal("expected placeholder api key validation error")
+	}
+}
+
+func TestValidateSecurityRejectsPlaceholderScopedAPIKey(t *testing.T) {
+	cfg := Config{
+		APIKeyScopes: map[string][]string{
+			"replace-with-strong-read-key": {"read"},
+		},
+	}
+	if err := ValidateSecurity(cfg); err == nil {
+		t.Fatal("expected placeholder scoped api key validation error")
+	}
+}
+
 func TestSecurityWarningsInMemoryLockInDatabaseMode(t *testing.T) {
 	cfg := Config{
 		APIKeys:         []string{"reader"},

--- a/internal/config/security_test.go
+++ b/internal/config/security_test.go
@@ -353,6 +353,29 @@ func TestValidateSecurityRejectsPlaceholderScopedAPIKey(t *testing.T) {
 	}
 }
 
+func TestValidateSecurityAllowsLegacyPlaceholderKeysWhenScopedKeysAreConfigured(t *testing.T) {
+	cfg := Config{
+		APIKeys:      []string{"replace-read-key"},
+		WriteAPIKeys: []string{"replace-write-key"},
+		APIKeyScopes: map[string][]string{
+			"real-scoped-key-123456789012345678901234": {"read"},
+		},
+	}
+	if err := ValidateSecurity(cfg); err != nil {
+		t.Fatalf("expected scoped key mode to ignore legacy placeholder keys, got %v", err)
+	}
+}
+
+func TestValidateSecurityRejectsPlaceholderWriteKeyInLegacyMode(t *testing.T) {
+	cfg := Config{
+		APIKeys:      []string{"real-reader-key-123456789012"},
+		WriteAPIKeys: []string{"replace-write-key"},
+	}
+	if err := ValidateSecurity(cfg); err == nil {
+		t.Fatal("expected placeholder write key validation error in legacy mode")
+	}
+}
+
 func TestSecurityWarningsInMemoryLockInDatabaseMode(t *testing.T) {
 	cfg := Config{
 		APIKeys:         []string{"reader"},


### PR DESCRIPTION
## Summary
- fail startup when placeholder API keys are configured in API keys or scoped API key maps
- switch Helm chart defaults to existingSecret mode instead of shipping active placeholder auth keys
- update Helm README quickstart to create identrail-secrets before install

## Validation
- go test ./internal/config -count=1
- helm lint deploy/helm/identrail
- go test ./... -count=1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject placeholder API keys at startup and default Helm to use an existing secret. Quickstart now creates `identrail-secrets` with generated random API keys via a shell-safe command.

- **Bug Fixes**
  - Hard-fail on placeholder keys with scoped-key precedence: if `APIKeyScopes` is set, only scoped keys are validated; otherwise `APIKeys`/`WriteAPIKeys` are validated.
  - Added tests for placeholder rejection and precedence behavior.

- **Migration**
  - Helm now defaults to `secret.create=false` with `secret.existingSecret=identrail-secrets`. Create the secret first or set `secret.create=true` and provide `secret.data`.
  - Quickstart generates random read/write keys using `openssl rand -hex 24` and sets them via `--from-literal` for `IDENTRAIL_API_KEYS` and `IDENTRAIL_WRITE_API_KEYS`.

<sup>Written for commit 7727bf2117b7f63d8a5d0156f06714b6f3b21511. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

