### PR TITLE
Return 400 for invalid repo_scan_id UUID inputs

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Oluwatobi-Mustapha/identrail/internal/domain"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/telemetry"
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
@@ -422,7 +423,12 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 	})
 
 	v1.GET("/repo-scans/:repo_scan_id", func(c *gin.Context) {
-		item, err := svc.GetRepoScan(c.Request.Context(), strings.TrimSpace(c.Param("repo_scan_id")))
+		repoScanID := strings.TrimSpace(c.Param("repo_scan_id"))
+		if !isValidUUID(repoScanID) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid repo_scan_id"})
+			return
+		}
+		item, err := svc.GetRepoScan(c.Request.Context(), repoScanID)
 		if err != nil {
 			if errors.Is(err, db.ErrNotFound) {
 				c.JSON(http.StatusNotFound, gin.H{"error": "repo scan not found"})
@@ -439,11 +445,16 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		limit := parseLimit(c.Query("limit"), defaultFindingsLimit, maxListLimit)
 		offset := parseCursor(c.Query("cursor"))
 		sortBy, sortDesc := parseSortParams(c.Query("sort_by"), c.Query("sort_order"), "created_at")
+		repoScanID := strings.TrimSpace(c.Query("repo_scan_id"))
+		if repoScanID != "" && !isValidUUID(repoScanID) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid repo_scan_id"})
+			return
+		}
 		items, err := svc.ListRepoFindings(
 			c.Request.Context(),
 			pageFetchLimit(offset, limit),
 			db.RepoFindingFilter{
-				RepoScanID: strings.TrimSpace(c.Query("repo_scan_id")),
+				RepoScanID: repoScanID,
 				Severity:   strings.TrimSpace(c.Query("severity")),
 				Type:       strings.TrimSpace(c.Query("type")),
 			},
@@ -624,6 +635,14 @@ func parseSortParams(rawBy string, rawOrder string, fallbackBy string) (string, 
 		return by, false
 	}
 	return by, true
+}
+
+func isValidUUID(raw string) bool {
+	if strings.TrimSpace(raw) == "" {
+		return false
+	}
+	_, err := uuid.Parse(strings.TrimSpace(raw))
+	return err == nil
 }
 
 func sortFindings(items []domain.Finding, sortBy string, desc bool) {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1154,6 +1154,28 @@ func TestRouterScanDiffAndEventsNotFound(t *testing.T) {
 	}
 }
 
+func TestRouterRejectsInvalidRepoScanUUIDInputs(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+	r := NewRouter(logger, metrics, svc, RouterOptions{})
+
+	repoScanReq := httptest.NewRequest(http.MethodGet, "/v1/repo-scans/not-a-uuid", nil)
+	repoScanW := httptest.NewRecorder()
+	r.ServeHTTP(repoScanW, repoScanReq)
+	if repoScanW.Code != http.StatusBadRequest {
+		t.Fatalf("expected repo scan detail 400 for invalid repo_scan_id, got %d", repoScanW.Code)
+	}
+
+	repoFindingsReq := httptest.NewRequest(http.MethodGet, "/v1/repo-findings?repo_scan_id=not-a-uuid", nil)
+	repoFindingsW := httptest.NewRecorder()
+	r.ServeHTTP(repoFindingsW, repoFindingsReq)
+	if repoFindingsW.Code != http.StatusBadRequest {
+		t.Fatalf("expected repo findings 400 for invalid repo_scan_id filter, got %d", repoFindingsW.Code)
+	}
+}
+
 func TestRouterPaginationHelpers(t *testing.T) {
 	if got := parseCursor(""); got != 0 {
 		t.Fatalf("expected empty cursor to parse as 0, got %d", got)


### PR DESCRIPTION
## Summary
- validate repo_scan_id path parameter on GET /v1/repo-scans/:repo_scan_id
- validate optional repo_scan_id query filter on GET /v1/repo-findings
- return 400 with "invalid repo_scan_id" before service/DB calls for malformed UUIDs
- add router regression tests for both invalid path/query UUID inputs

## Validation
- go test ./internal/api -count=1
- go vet ./...
- go test ./... -count=1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 400 Bad Request when `repo_scan_id` is not a valid UUID on GET `/v1/repo-scans/:repo_scan_id` and GET `/v1/repo-findings`. Prevents unnecessary service/DB calls and gives a clear error.

- **Bug Fixes**
  - Validate UUIDs with `github.com/google/uuid`; return 400 with {"error":"invalid repo_scan_id"}.
  - Applies to the path param on `/v1/repo-scans/:repo_scan_id` and the `repo_scan_id` query filter on `/v1/repo-findings`.
  - Added router tests for both invalid inputs.

<sup>Written for commit 526fc93a45b4ec3b823bdc16577b3e8fc263117b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

