### PR TITLE
Port Kubernetes securityContext hardening into Helm API/worker templates

### DIFF
--- a/deploy/helm/identrail/templates/api-deployment.yaml
+++ b/deploy/helm/identrail/templates/api-deployment.yaml
@@ -21,10 +21,18 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.api.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: api
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          {{- with .Values.api.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/helm/identrail/templates/worker-deployment.yaml
+++ b/deploy/helm/identrail/templates/worker-deployment.yaml
@@ -21,10 +21,18 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.worker.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: worker
           image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}"
           imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
+          {{- with .Values.worker.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "identrail.fullname" . }}-config

--- a/deploy/helm/identrail/values.yaml
+++ b/deploy/helm/identrail/values.yaml
@@ -9,6 +9,14 @@ api:
     repository: identrail/api
     tag: latest
     pullPolicy: IfNotPresent
+  podSecurityContext:
+    runAsNonRoot: true
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
   service:
     type: ClusterIP
     port: 8080
@@ -20,6 +28,14 @@ worker:
     repository: identrail/worker
     tag: latest
     pullPolicy: IfNotPresent
+  podSecurityContext:
+    runAsNonRoot: true
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
   resources: {}
 
 web:


### PR DESCRIPTION
## Summary
- add pod-level securityContext defaults (runAsNonRoot true) for Helm API and worker deployments
- add container-level securityContext defaults (allowPrivilegeEscalation false, readOnlyRootFilesystem true, drop all capabilities)
- expose these defaults in values.yaml so operators can override intentionally

## Validation
- helm lint deploy/helm/identrail
- helm template identrail deploy/helm/identrail | rg -n securityContext
- go test ./... -count=1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the Helm `api` and `worker` deployments by adding default pod- and container-level Kubernetes `securityContext` settings, exposed in `values.yaml` for easy override. This reduces privileges by default and brings Helm charts to our hardened baseline.

- **New Features**
  - Pod defaults: `runAsNonRoot: true` for both `api` and `worker`.
  - Container defaults: `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, and drop `ALL` capabilities; configurable via `values.yaml`.

- **Migration**
  - Ensure images run as non-root and work with a read-only root filesystem; override in `values.yaml` if needed.
  - Set any required UIDs or extra permissions via `.Values.api|worker.podSecurityContext` or `.Values.api|worker.securityContext`.

<sup>Written for commit c3df6c9f826ae4be2fc676c8d68406662fd9f0e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

