### PR TITLE
Harden legacy write authorization to require explicit write keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Hardened write authorization defaults to remove implicit write access in legacy API-key mode:
+  - write endpoints now reject API-key-authenticated requests when `IDENTRAIL_WRITE_API_KEYS` is not configured
+  - startup security validation now requires explicit `IDENTRAIL_WRITE_API_KEYS` when using `IDENTRAIL_API_KEYS` without scoped keys
+  - added router and security regression tests for empty-write-key misconfiguration paths
 - Hardened AWS deterministic ID hashing for findings and relationships:
   - replaced truncated SHA-1 IDs with SHA-256-derived 128-bit ID prefixes
   - reduced collision risk in large multi-account datasets

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1038,6 +1038,12 @@ func requireWriteKeyMiddleware(writeKeys []string, scopedKeys map[string][]strin
 		}
 
 		if len(allowed) == 0 {
+			// When auth middleware is disabled (test/local stubs), keep route behavior unchanged.
+			// In authenticated API-key mode, empty write-key config must not grant write access.
+			if _, exists := c.Get("auth.api_key"); exists {
+				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+				return
+			}
 			c.Next()
 			return
 		}

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -811,6 +811,24 @@ func TestRouterWriteAuthorization(t *testing.T) {
 	}
 }
 
+func TestRouterWriteAuthorizationRequiresConfiguredWriteKeys(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+	r := NewRouter(logger, metrics, svc, RouterOptions{
+		APIKeys: []string{"read-key"},
+	})
+
+	writeReq := httptest.NewRequest(http.MethodPost, "/v1/scans", nil)
+	writeReq.Header.Set("X-API-Key", "read-key")
+	writeW := httptest.NewRecorder()
+	r.ServeHTTP(writeW, writeReq)
+	if writeW.Code != http.StatusForbidden {
+		t.Fatalf("expected write to be forbidden when no write keys are configured, got %d", writeW.Code)
+	}
+}
+
 func TestRouterScopedAuthorizationPrefersScopeMap(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	metrics := telemetry.NewMetrics()

--- a/internal/config/security.go
+++ b/internal/config/security.go
@@ -122,6 +122,9 @@ func ValidateSecurity(cfg Config) error {
 			}
 		}
 	}
+	if len(cfg.APIKeyScopes) == 0 && len(cfg.APIKeys) > 0 && len(cfg.WriteAPIKeys) == 0 {
+		return fmt.Errorf("IDENTRAIL_WRITE_API_KEYS must include at least one key when using IDENTRAIL_API_KEYS without scoped keys")
+	}
 
 	if cfg.AlertMaxFindings > maxAlertFindingsLimit {
 		return fmt.Errorf("IDENTRAIL_ALERT_MAX_FINDINGS must be <= %d", maxAlertFindingsLimit)

--- a/internal/config/security_test.go
+++ b/internal/config/security_test.go
@@ -42,6 +42,15 @@ func TestValidateSecurityWriteKeyMustBeInAPIKeys(t *testing.T) {
 	}
 }
 
+func TestValidateSecurityRejectsLegacyAPIKeysWithoutWriteKeys(t *testing.T) {
+	cfg := Config{
+		APIKeys: []string{"reader"},
+	}
+	if err := ValidateSecurity(cfg); err == nil {
+		t.Fatal("expected error when legacy API keys are configured without write keys")
+	}
+}
+
 func TestValidateSecurityWriteKeyCheckSkippedWhenScopedKeysPresent(t *testing.T) {
 	cfg := Config{
 		WriteAPIKeys: []string{"writer"},
@@ -87,10 +96,11 @@ func TestValidateSecurityRejectsEmptyAWSRegionInSDKMode(t *testing.T) {
 
 func TestValidateSecurityAcceptsAWSSDKMode(t *testing.T) {
 	cfg := Config{
-		Provider:  "aws",
-		AWSSource: "sdk",
-		AWSRegion: "us-east-1",
-		APIKeys:   []string{"reader"},
+		Provider:     "aws",
+		AWSSource:    "sdk",
+		AWSRegion:    "us-east-1",
+		APIKeys:      []string{"reader", "writer"},
+		WriteAPIKeys: []string{"writer"},
 	}
 	if err := ValidateSecurity(cfg); err != nil {
 		t.Fatalf("expected aws sdk mode to be valid, got %v", err)
@@ -125,7 +135,8 @@ func TestValidateSecurityAcceptsKubectlMode(t *testing.T) {
 		Provider:         "kubernetes",
 		KubernetesSource: "kubectl",
 		KubectlPath:      "/usr/bin/kubectl",
-		APIKeys:          []string{"reader"},
+		APIKeys:          []string{"reader", "writer"},
+		WriteAPIKeys:     []string{"writer"},
 	}
 	if err := ValidateSecurity(cfg); err != nil {
 		t.Fatalf("expected kubectl mode to be valid, got %v", err)
@@ -276,7 +287,8 @@ func TestValidateSecurityWorkerRepoScanAllowlistEnforced(t *testing.T) {
 
 func TestValidateSecurityWorkerRepoScanSuccess(t *testing.T) {
 	cfg := Config{
-		APIKeys:                 []string{"reader"},
+		APIKeys:                 []string{"reader", "writer"},
+		WriteAPIKeys:            []string{"writer"},
 		RepoScanEnabled:         true,
 		RepoScanAllowlist:       []string{"trusted/*"},
 		RepoScanHistoryLimitMax: 5000,
@@ -324,7 +336,8 @@ func TestValidateSecurityRejectsInvalidTrustedProxyEntry(t *testing.T) {
 
 func TestValidateSecurityAcceptsTrustedProxyEntries(t *testing.T) {
 	cfg := Config{
-		APIKeys:        []string{"reader"},
+		APIKeys:        []string{"reader", "writer"},
+		WriteAPIKeys:   []string{"writer"},
 		TrustedProxies: []string{"10.0.0.0/8", "127.0.0.1"},
 	}
 	if err := ValidateSecurity(cfg); err != nil {


### PR DESCRIPTION
## Summary
- confirm and fix permissive legacy write authorization behavior
- enforce explicit `IDENTRAIL_WRITE_API_KEYS` when using legacy `IDENTRAIL_API_KEYS` mode
- block write routes for API-key-authenticated requests when write keys are not configured
- add regression tests for router and security validation behavior

## Why this is a true positive
In legacy API-key mode (`API_KEYS` configured, no scoped keys), write middleware previously allowed writes when `WRITE_API_KEYS` was empty. This came from an allow-all branch in `requireWriteKeyMiddleware` for `len(allowed) == 0`.

## Changes
- `internal/config/security.go`
  - add validation error when `API_KEYS` is set without scoped keys and `WRITE_API_KEYS` is empty
- `internal/api/router.go`
  - deny write requests from authenticated API-key clients when write keys are not configured
  - keep no-auth test/local stub behavior unchanged
- tests
  - add `TestValidateSecurityRejectsLegacyAPIKeysWithoutWriteKeys`
  - add `TestRouterWriteAuthorizationRequiresConfiguredWriteKeys`
  - update validation success tests to include explicit write key config
- changelog
  - document the hardening in `Unreleased`

## Verification
- `go test ./...` passes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened legacy API-key write authorization to remove implicit write access. When using `IDENTRAIL_API_KEYS` without scopes, write endpoints now require configured `IDENTRAIL_WRITE_API_KEYS` and return 403 otherwise.

- **Bug Fixes**
  - Router: forbid writes for API-key-authenticated requests when write keys are missing; keep no-auth test/local stubs unchanged.
  - Config: add startup validation requiring `IDENTRAIL_WRITE_API_KEYS` when using unscoped `IDENTRAIL_API_KEYS`.
  - Tests: add router and security regression tests for the empty-write-key path.

<sup>Written for commit 8b7db72e827805d02d55c4ded028d4082bc76f93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

