### PR TITLE
Add configurable CORS middleware to API router

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -33,6 +33,9 @@ const (
 	rateLimiterEntryTTL    = 15 * time.Minute
 	rateLimiterMaxEntries  = 10000
 	rateLimiterCleanupTick = 256
+	corsAllowMethods       = "GET,POST,OPTIONS"
+	corsAllowHeaders       = "Authorization,Content-Type,X-API-Key"
+	corsMaxAgeSeconds      = "600"
 	scopeRead              = "read"
 	scopeWrite             = "write"
 	scopeAdmin             = "admin"
@@ -40,15 +43,16 @@ const (
 
 // RouterOptions controls API middleware behavior.
 type RouterOptions struct {
-	APIKeys           []string
-	WriteAPIKeys      []string
-	APIKeyScopes      map[string][]string
-	OIDCTokenVerifier TokenVerifier
-	OIDCWriteScopes   []string
-	RateLimitRPM      int
-	RateLimitBurst    int
-	AuditSink         AuditSink
-	TrustedProxies    []string
+	APIKeys            []string
+	WriteAPIKeys       []string
+	APIKeyScopes       map[string][]string
+	OIDCTokenVerifier  TokenVerifier
+	OIDCWriteScopes    []string
+	RateLimitRPM       int
+	RateLimitBurst     int
+	AuditSink          AuditSink
+	TrustedProxies     []string
+	CORSAllowedOrigins []string
 }
 
 // VerifiedToken contains normalized claims extracted from a validated OIDC token.
@@ -69,6 +73,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 	configureTrustedProxies(r, logger, opts.TrustedProxies)
 	r.Use(gin.Recovery())
 	r.Use(securityHeadersMiddleware())
+	r.Use(corsMiddleware(opts.CORSAllowedOrigins))
 
 	registry := prometheus.NewRegistry()
 	registry.MustRegister(
@@ -924,6 +929,81 @@ func pageWithCursor[T any](items []T, offset int, limit int) ([]T, string) {
 		next = strconv.Itoa(end)
 	}
 	return items[offset:end], next
+}
+
+func corsMiddleware(allowedOrigins []string) gin.HandlerFunc {
+	allowAll := false
+	allowed := map[string]struct{}{}
+	for _, origin := range allowedOrigins {
+		trimmed := strings.TrimSpace(origin)
+		if trimmed == "" {
+			continue
+		}
+		if trimmed == "*" {
+			allowAll = true
+			continue
+		}
+		allowed[trimmed] = struct{}{}
+	}
+
+	if !allowAll && len(allowed) == 0 {
+		return func(c *gin.Context) { c.Next() }
+	}
+
+	return func(c *gin.Context) {
+		origin := strings.TrimSpace(c.GetHeader("Origin"))
+		if origin == "" {
+			c.Next()
+			return
+		}
+
+		allowedOrigin := ""
+		if allowAll {
+			allowedOrigin = "*"
+		} else if _, ok := allowed[origin]; ok {
+			allowedOrigin = origin
+		}
+		if allowedOrigin == "" {
+			c.Next()
+			return
+		}
+
+		addVaryHeader(c.Writer.Header(), "Origin")
+		c.Header("Access-Control-Allow-Origin", allowedOrigin)
+		c.Header("Access-Control-Allow-Methods", corsAllowMethods)
+		c.Header("Access-Control-Allow-Headers", corsAllowHeaders)
+		c.Header("Access-Control-Max-Age", corsMaxAgeSeconds)
+
+		if c.Request.Method == http.MethodOptions && strings.TrimSpace(c.GetHeader("Access-Control-Request-Method")) != "" {
+			addVaryHeader(c.Writer.Header(), "Access-Control-Request-Method")
+			addVaryHeader(c.Writer.Header(), "Access-Control-Request-Headers")
+			c.AbortWithStatus(http.StatusNoContent)
+			return
+		}
+
+		c.Next()
+	}
+}
+
+func addVaryHeader(headers http.Header, value string) {
+	if headers == nil {
+		return
+	}
+	normalized := strings.TrimSpace(value)
+	if normalized == "" {
+		return
+	}
+	for _, existing := range strings.Split(headers.Get("Vary"), ",") {
+		if strings.EqualFold(strings.TrimSpace(existing), normalized) {
+			return
+		}
+	}
+	current := strings.TrimSpace(headers.Get("Vary"))
+	if current == "" {
+		headers.Set("Vary", normalized)
+		return
+	}
+	headers.Set("Vary", current+", "+normalized)
 }
 
 func securityHeadersMiddleware() gin.HandlerFunc {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -87,6 +88,97 @@ func TestRouterHealthz(t *testing.T) {
 	}
 	if got := w.Header().Get("X-Content-Type-Options"); got != "nosniff" {
 		t.Fatalf("expected security header nosniff, got %q", got)
+	}
+}
+
+func TestRouterCORSDisabledByDefault(t *testing.T) {
+	logger := zap.NewNop()
+	metrics := telemetry.NewMetrics()
+	r := NewRouter(logger, metrics, nil, RouterOptions{})
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req.Header.Set("Origin", "https://app.identrail.io")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("expected no cors allow origin header, got %q", got)
+	}
+}
+
+func TestRouterCORSAllowsConfiguredOrigin(t *testing.T) {
+	logger := zap.NewNop()
+	metrics := telemetry.NewMetrics()
+	r := NewRouter(logger, metrics, nil, RouterOptions{
+		CORSAllowedOrigins: []string{"https://app.identrail.io"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req.Header.Set("Origin", "https://app.identrail.io")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://app.identrail.io" {
+		t.Fatalf("expected cors allow origin header, got %q", got)
+	}
+	if !varyHeaderContains(w.Header().Get("Vary"), "Origin") {
+		t.Fatalf("expected Vary header to include Origin, got %q", w.Header().Get("Vary"))
+	}
+}
+
+func TestRouterCORSPreflightBypassesAuth(t *testing.T) {
+	logger := zap.NewNop()
+	metrics := telemetry.NewMetrics()
+	r := NewRouter(logger, metrics, nil, RouterOptions{
+		APIKeys:            []string{"reader-key"},
+		WriteAPIKeys:       []string{"reader-key"},
+		CORSAllowedOrigins: []string{"https://app.identrail.io"},
+	})
+
+	req := httptest.NewRequest(http.MethodOptions, "/v1/findings", nil)
+	req.Header.Set("Origin", "https://app.identrail.io")
+	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+	req.Header.Set("Access-Control-Request-Headers", "Authorization,X-API-Key")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://app.identrail.io" {
+		t.Fatalf("expected cors allow origin header, got %q", got)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Methods"); !strings.Contains(got, http.MethodGet) {
+		t.Fatalf("expected allow methods header to include GET, got %q", got)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Headers"); !strings.Contains(strings.ToLower(got), "x-api-key") {
+		t.Fatalf("expected allow headers to include x-api-key, got %q", got)
+	}
+}
+
+func TestRouterCORSSkipsUnlistedOrigin(t *testing.T) {
+	logger := zap.NewNop()
+	metrics := telemetry.NewMetrics()
+	r := NewRouter(logger, metrics, nil, RouterOptions{
+		CORSAllowedOrigins: []string{"https://app.identrail.io"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("expected no cors allow origin for unlisted origin, got %q", got)
 	}
 }
 
@@ -753,6 +845,15 @@ func TestSecureKeyHelpers(t *testing.T) {
 	if scopes, ok := scopedKeyLookup(scoped, "writer"); !ok || !scopes.has("write") {
 		t.Fatalf("expected writer scopes to resolve, got ok=%t scopes=%+v", ok, scopes)
 	}
+}
+
+func varyHeaderContains(varyHeader string, value string) bool {
+	for _, token := range strings.Split(varyHeader, ",") {
+		if strings.EqualFold(strings.TrimSpace(token), strings.TrimSpace(value)) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestRouterRequiresAPIKeyForV1(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	Provider                 string
 	ServiceName              string
 	TrustedProxies           []string
+	CORSAllowedOrigins       []string
 	DatabaseURL              string
 	AWSSource                string
 	AWSRegion                string
@@ -98,6 +99,7 @@ func Load() Config {
 		Provider:                 strings.ToLower(getEnv("IDENTRAIL_PROVIDER", defaultProvider)),
 		ServiceName:              getEnv("IDENTRAIL_SERVICE_NAME", defaultServiceName),
 		TrustedProxies:           parseCommaSeparated(getEnv("IDENTRAIL_TRUSTED_PROXIES", "")),
+		CORSAllowedOrigins:       parseCommaSeparated(getEnv("IDENTRAIL_CORS_ALLOWED_ORIGINS", "")),
 		DatabaseURL:              getEnv("IDENTRAIL_DATABASE_URL", ""),
 		AWSSource:                strings.ToLower(getEnv("IDENTRAIL_AWS_SOURCE", defaultAWSSource)),
 		AWSRegion:                getEnv("IDENTRAIL_AWS_REGION", defaultAWSRegion),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,6 +12,7 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("IDENTRAIL_PROVIDER", "")
 	t.Setenv("IDENTRAIL_SERVICE_NAME", "")
 	t.Setenv("IDENTRAIL_TRUSTED_PROXIES", "")
+	t.Setenv("IDENTRAIL_CORS_ALLOWED_ORIGINS", "")
 	t.Setenv("IDENTRAIL_DATABASE_URL", "")
 	t.Setenv("IDENTRAIL_AWS_SOURCE", "")
 	t.Setenv("IDENTRAIL_AWS_REGION", "")
@@ -73,6 +74,9 @@ func TestLoadDefaults(t *testing.T) {
 	}
 	if len(cfg.TrustedProxies) != 0 {
 		t.Fatalf("expected no trusted proxies by default, got %+v", cfg.TrustedProxies)
+	}
+	if len(cfg.CORSAllowedOrigins) != 0 {
+		t.Fatalf("expected no cors allowed origins by default, got %+v", cfg.CORSAllowedOrigins)
 	}
 	if cfg.DatabaseURL != "" {
 		t.Fatalf("expected empty database url, got %q", cfg.DatabaseURL)
@@ -223,6 +227,7 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("IDENTRAIL_PROVIDER", "AWS")
 	t.Setenv("IDENTRAIL_SERVICE_NAME", "identrail-dev")
 	t.Setenv("IDENTRAIL_TRUSTED_PROXIES", "10.0.0.0/8,127.0.0.1")
+	t.Setenv("IDENTRAIL_CORS_ALLOWED_ORIGINS", "https://app.identrail.io,https://console.identrail.io")
 	t.Setenv("IDENTRAIL_DATABASE_URL", "postgres://example")
 	t.Setenv("IDENTRAIL_AWS_SOURCE", "sdk")
 	t.Setenv("IDENTRAIL_AWS_REGION", "eu-west-1")
@@ -287,6 +292,9 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if len(cfg.TrustedProxies) != 2 || cfg.TrustedProxies[0] != "10.0.0.0/8" || cfg.TrustedProxies[1] != "127.0.0.1" {
 		t.Fatalf("unexpected trusted proxies: %+v", cfg.TrustedProxies)
+	}
+	if len(cfg.CORSAllowedOrigins) != 2 || cfg.CORSAllowedOrigins[0] != "https://app.identrail.io" || cfg.CORSAllowedOrigins[1] != "https://console.identrail.io" {
+		t.Fatalf("unexpected cors allowed origins: %+v", cfg.CORSAllowedOrigins)
 	}
 	if cfg.DatabaseURL != "postgres://example" {
 		t.Fatalf("unexpected database url: %q", cfg.DatabaseURL)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -104,15 +104,16 @@ func NewBootstrap(ctx context.Context, cfg config.Config) (Bootstrap, error) {
 	}
 
 	router := api.NewRouter(logger, metrics, svc, api.RouterOptions{
-		APIKeys:           cfg.APIKeys,
-		WriteAPIKeys:      cfg.WriteAPIKeys,
-		APIKeyScopes:      cfg.APIKeyScopes,
-		OIDCTokenVerifier: tokenVerifier,
-		OIDCWriteScopes:   cfg.OIDCWriteScopes,
-		RateLimitRPM:      cfg.RateLimitRPM,
-		RateLimitBurst:    cfg.RateLimitBurst,
-		AuditSink:         auditSink,
-		TrustedProxies:    cfg.TrustedProxies,
+		APIKeys:            cfg.APIKeys,
+		WriteAPIKeys:       cfg.WriteAPIKeys,
+		APIKeyScopes:       cfg.APIKeyScopes,
+		OIDCTokenVerifier:  tokenVerifier,
+		OIDCWriteScopes:    cfg.OIDCWriteScopes,
+		RateLimitRPM:       cfg.RateLimitRPM,
+		RateLimitBurst:     cfg.RateLimitBurst,
+		AuditSink:          auditSink,
+		TrustedProxies:     cfg.TrustedProxies,
+		CORSAllowedOrigins: cfg.CORSAllowedOrigins,
 	})
 	return Bootstrap{
 		Logger:        logger,


### PR DESCRIPTION
## Summary
- add configurable CORS middleware for API routes
- support preflight OPTIONS requests before auth middleware
- add `IDENTRAIL_CORS_ALLOWED_ORIGINS` config and tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable CORS middleware to the API router with proper preflight handling before auth. This enables browser clients to call the API safely without proxies.

- **New Features**
  - CORS middleware configurable via router options; disabled by default.
  - Preflight OPTIONS is handled before auth and returns 204.
  - Sends Access-Control headers (methods GET, POST, OPTIONS; headers Authorization, Content-Type, X-API-Key; max-age 600) and sets Vary headers.
  - End-to-end tests cover disabled default, allowed origin, preflight, and unlisted origin.

- **Migration**
  - Set IDENTRAIL_CORS_ALLOWED_ORIGINS to "*" or a comma-separated list of allowed origins (e.g., https://app.identrail.io).
  - If unset, CORS stays disabled and behavior is unchanged.

<sup>Written for commit 84f818342653f68f3dc6f2a5bfc9d1e2c0dd4438. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

