### PR TITLE
Replace SHA-1 deterministic finding IDs with SHA-256

### DIFF
--- a/internal/providers/kubernetes/rules.go
+++ b/internal/providers/kubernetes/rules.go
@@ -2,7 +2,7 @@ package kubernetes
 
 import (
 	"context"
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"sort"
@@ -294,6 +294,6 @@ func severityRank(severity domain.FindingSeverity) int {
 }
 
 func findingID(parts ...string) string {
-	sum := sha1.Sum([]byte(strings.Join(parts, "|")))
+	sum := sha256.Sum256([]byte(strings.Join(parts, "|")))
 	return "k8s:finding:" + hex.EncodeToString(sum[:])
 }

--- a/internal/providers/kubernetes/rules_test.go
+++ b/internal/providers/kubernetes/rules_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -247,8 +248,15 @@ func TestUtilityHelpers(t *testing.T) {
 	if severityRank(domain.SeverityCritical) >= severityRank(domain.SeverityHigh) {
 		t.Fatal("expected critical rank to be higher priority than high")
 	}
-	if findingID("a", "b") == findingID("a", "c") {
+	idAB := findingID("a", "b")
+	if idAB == findingID("a", "c") {
 		t.Fatal("expected different ids for different finding parts")
+	}
+	if !strings.HasPrefix(idAB, "k8s:finding:") {
+		t.Fatalf("expected k8s finding prefix, got %q", idAB)
+	}
+	if len(strings.TrimPrefix(idAB, "k8s:finding:")) != 64 {
+		t.Fatalf("expected sha256 hash length 64, got id %q", idAB)
 	}
 }
 

--- a/internal/repoexposure/rules.go
+++ b/internal/repoexposure/rules.go
@@ -149,7 +149,7 @@ func detectSecretFindings(repo string, commit string, path string, line int, tex
 		}
 		sanitized := redactMatch(normalized, match)
 		fingerprint := hashSHA256(match)
-		id := hashSHA1("repo-secret", repo, commit, path, strconv.Itoa(line), rule.ID, fingerprint)
+		id := hashDeterministicID("repo-secret", repo, commit, path, strconv.Itoa(line), rule.ID, fingerprint)
 		findings = append(findings, domain.Finding{
 			ID:           "finding:" + id,
 			Type:         domain.FindingSecretExposure,
@@ -193,7 +193,7 @@ func detectMisconfigFindings(repo string, path string, content []byte, detectedA
 				continue
 			}
 			seen[key] = struct{}{}
-			id := hashSHA1("repo-misconfig", repo, path, strconv.Itoa(lineNumber), rule.ID, line)
+			id := hashDeterministicID("repo-misconfig", repo, path, strconv.Itoa(lineNumber), rule.ID, line)
 			findings = append(findings, domain.Finding{
 				ID:           "finding:" + id,
 				Type:         domain.FindingRepoMisconfig,
@@ -232,7 +232,7 @@ func detectMisconfigFindings(repo string, path string, content []byte, detectedA
 			continue
 		}
 		seen[key] = struct{}{}
-		id := hashSHA1("repo-misconfig", repo, path, strconv.Itoa(lineNumber), rule.ID, matchText)
+		id := hashDeterministicID("repo-misconfig", repo, path, strconv.Itoa(lineNumber), rule.ID, matchText)
 		findings = append(findings, domain.Finding{
 			ID:           "finding:" + id,
 			Type:         domain.FindingRepoMisconfig,

--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -3,7 +3,6 @@ package repoexposure
 import (
 	"bufio"
 	"context"
-	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -460,8 +459,8 @@ func redactedToken(value string) string {
 	return fmt.Sprintf("[REDACTED:%s...%s]", value[:4], value[len(value)-4:])
 }
 
-func hashSHA1(parts ...string) string {
-	h := sha1.New()
+func hashDeterministicID(parts ...string) string {
+	h := sha256.New()
 	for _, part := range parts {
 		_, _ = h.Write([]byte(part))
 		_, _ = h.Write([]byte("|"))

--- a/internal/repoexposure/scanner_test.go
+++ b/internal/repoexposure/scanner_test.go
@@ -266,6 +266,15 @@ func TestHelperFunctions(t *testing.T) {
 	if severityRank(domain.SeverityCritical) >= severityRank(domain.SeverityHigh) {
 		t.Fatal("expected critical severity to rank above high")
 	}
+	if id := hashDeterministicID("repo", "path", "1"); len(id) != 64 {
+		t.Fatalf("expected sha256 deterministic id length 64, got %d", len(id))
+	}
+	if hashDeterministicID("repo", "path", "1") != hashDeterministicID("repo", "path", "1") {
+		t.Fatal("expected deterministic id hash output for same inputs")
+	}
+	if hashDeterministicID("repo", "path", "1") == hashDeterministicID("repo", "path", "2") {
+		t.Fatal("expected different deterministic id hashes for different inputs")
+	}
 }
 
 func initTestRepoWithHistorySecret(t *testing.T) (string, string) {


### PR DESCRIPTION
Replace SHA-1 with SHA-256 for deterministic finding IDs in Kubernetes and repo exposure paths.

Adds tests for deterministic ID behavior and hash length.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced SHA-1 with SHA-256 for deterministic finding IDs in the Kubernetes provider and repo exposure scanner to reduce collision risk. Added tests to verify deterministic output and expected hash length.

- **Refactors**
  - Kubernetes: `findingID` now uses SHA-256; IDs keep the `k8s:finding:` prefix.
  - Repo exposure: replaced `hashSHA1` with `hashDeterministicID` (SHA-256) and updated call sites.
  - Added unit tests for ID determinism and hash length.

- **Migration**
  - Finding IDs will change; reindex or remap any stored references keyed by old IDs.
  - Update any validations or UI that assume 40-character hex hashes.

<sup>Written for commit e99e476438b35310e33f3ca48391798dd92dc293. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

