### PR TITLE
Add Dependabot auto-triage labeling workflow

### DIFF
--- a/.github/workflows/dependabot-auto-triage.yml
+++ b/.github/workflows/dependabot-auto-triage.yml
@@ -1,0 +1,104 @@
+name: Dependabot Auto Triage
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  label:
+    name: Label Dependabot PR
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Fetch Dependabot Metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Apply triage labels
+        uses: actions/github-script@v7
+        env:
+          PACKAGE_ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCY_TYPE: ${{ steps.metadata.outputs.dependency-type }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueNumber = context.payload.pull_request.number;
+
+            const ecosystemRaw = process.env.PACKAGE_ECOSYSTEM || "";
+            const updateTypeRaw = process.env.UPDATE_TYPE || "";
+            const dependencyTypeRaw = process.env.DEPENDENCY_TYPE || "";
+
+            const ecosystemMap = {
+              gomod: "deps/go",
+              npm: "deps/npm",
+              "github-actions": "deps/github-actions",
+            };
+
+            const updateTypeMap = {
+              "version-update:semver-patch": "deps/update-patch",
+              "version-update:semver-minor": "deps/update-minor",
+              "version-update:semver-major": "deps/update-major",
+            };
+
+            const dependencyTypeMap = {
+              "direct:production": "deps/direct-production",
+              "direct:development": "deps/direct-development",
+              indirect: "deps/indirect",
+            };
+
+            const labels = new Set(["dependencies", "needs-triage"]);
+            labels.add(ecosystemMap[ecosystemRaw] || "deps/other");
+            labels.add(updateTypeMap[updateTypeRaw] || "deps/update-unknown");
+            if (dependencyTypeRaw) {
+              labels.add(dependencyTypeMap[dependencyTypeRaw] || "deps/other-type");
+            }
+
+            const labelConfig = {
+              "dependencies": "1f883d",
+              "needs-triage": "ededed",
+              "deps/go": "0e8a16",
+              "deps/npm": "5319e7",
+              "deps/github-actions": "1d76db",
+              "deps/other": "c2e0c6",
+              "deps/update-patch": "2ea44f",
+              "deps/update-minor": "fbca04",
+              "deps/update-major": "d93f0b",
+              "deps/update-unknown": "bfd4f2",
+              "deps/direct-production": "b60205",
+              "deps/direct-development": "7f52ff",
+              "deps/indirect": "6f42c1",
+              "deps/other-type": "d4c5f9",
+            };
+
+            for (const name of labels) {
+              try {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name,
+                  color: labelConfig[name] || "ededed",
+                });
+              } catch (error) {
+                if (error.status !== 422) {
+                  throw error;
+                }
+              }
+            }
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              labels: Array.from(labels),
+            });


### PR DESCRIPTION
## What changed
- Added `.github/workflows/dependabot-auto-triage.yml`.
- New workflow runs on Dependabot PR events and auto-applies triage labels.
- Labels are derived from Dependabot metadata:
  - ecosystem (`deps/go`, `deps/npm`, `deps/github-actions`)
  - update type (`deps/update-patch|minor|major`)
  - dependency type (`deps/direct-production`, etc.)
- Workflow creates missing triage labels automatically if they do not already exist.

## Why
- Standardizes dependency PR routing and triage.
- Makes review queues easier to filter by risk and ownership.

## Impact
- Automation/configuration only.
- No runtime behavior changes.

## Validation
- Verified branch contains only the new workflow file.
- Workflow uses `dependabot/fetch-metadata` and applies labels via GitHub API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow to auto-label Dependabot PRs based on metadata, and creates any missing triage labels. This standardizes dependency PR routing and makes review queues easier to filter.

- **New Features**
  - Adds `.github/workflows/dependabot-auto-triage.yml` to label Dependabot PRs on `opened`, `reopened`, `synchronize`, `ready_for_review`.
  - Derives labels from ecosystem, update type, and dependency type (e.g., `deps/npm`, `deps/update-minor`, `deps/direct-production`); always adds `dependencies` and `needs-triage`.
  - Creates missing labels automatically; implemented with `dependabot/fetch-metadata@v2` and `actions/github-script@v7`.

<sup>Written for commit 0b4cfc44cfc0dba3c867be96a177860123cf891f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

