### PR TITLE
Enable patch-only auto-merge policy for Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-patch-automerge.yml
+++ b/.github/workflows/dependabot-patch-automerge.yml
@@ -1,0 +1,52 @@
+name: Dependabot Patch Auto-Merge
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  patch-automerge:
+    name: Enable Auto-Merge for Patch Updates
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Fetch Dependabot Metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' && !github.event.pull_request.draft
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            if (pr.auto_merge) {
+              core.info(`Auto-merge is already enabled for PR #${pr.number}.`);
+              return;
+            }
+
+            try {
+              await github.graphql(
+                `mutation($pullRequestId: ID!) {
+                  enablePullRequestAutoMerge(input: {
+                    pullRequestId: $pullRequestId,
+                    mergeMethod: SQUASH
+                  }) {
+                    pullRequest { number }
+                  }
+                }`,
+                { pullRequestId: pr.node_id },
+              );
+              core.info(`Enabled auto-merge for Dependabot patch PR #${pr.number}.`);
+            } catch (error) {
+              core.warning(`Could not enable auto-merge for PR #${pr.number}: ${error.message}`);
+            }

--- a/.github/workflows/dependabot-patch-automerge.yml
+++ b/.github/workflows/dependabot-patch-automerge.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   patch-automerge:
     name: Enable Auto-Merge for Patch Updates
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
## Policy decision
- Chosen policy: **auto-merge patch updates only**.
- Minor and major updates remain manual-review PRs.

## What changed
- Added `.github/workflows/dependabot-patch-automerge.yml`.
- Workflow runs for Dependabot pull requests.
- It enables GitHub auto-merge only when Dependabot metadata reports `version-update:semver-patch`.
- Auto-merge uses `SQUASH` strategy.

## Why
- Reduces maintenance load for low-risk patch updates.
- Keeps higher-risk changes (minor/major) in manual review.

## Impact
- Workflow/config only.
- No runtime behavior changes.

## Validation
- Verified branch contains only the new patch auto-merge workflow.
- Metadata gating is explicit on Dependabot update type.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables auto-merge for Dependabot PRs that are semver patch updates to reduce maintenance load. CI-only change; minor and major updates remain manual.

- **New Features**
  - Add `.github/workflows/dependabot-patch-automerge.yml` triggered on `pull_request_target` events to auto-enable merge on patch updates from `dependabot[bot]`; skips drafts, no-op if already enabled; uses minimal permissions (`contents: read`, `pull-requests: write`).
  - Use `dependabot/fetch-metadata@v2` to detect `version-update:semver-patch` and `actions/github-script@v7` to enable `SQUASH` auto-merge; warn on failures.

<sup>Written for commit 0c0bf3cb89eb25a9c55468e0af765aa3862c058e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

