### PR TITLE
Add enforceable main-branch protection policy for CI gates

### DIFF
--- a/.github/branch-protection/main.json
+++ b/.github/branch-protection/main.json
@@ -1,0 +1,29 @@
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "Go Quality",
+      "Go Tests",
+      "Go Integration (Postgres)",
+      "CLI Smoke",
+      "Web Build",
+      "Infra Validate",
+      "Deploy Portability",
+      "Analyze (go)",
+      "Analyze (javascript-typescript)"
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 1,
+    "require_last_push_approval": false
+  },
+  "restrictions": null,
+  "required_conversation_resolution": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_linear_history": true,
+  "block_creations": false
+}

--- a/.github/workflows/enforce-branch-protection.yml
+++ b/.github/workflows/enforce-branch-protection.yml
@@ -1,0 +1,63 @@
+name: Enforce Branch Protection
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Run mode"
+        type: choice
+        required: true
+        default: dry-run
+        options:
+          - dry-run
+          - apply
+
+permissions:
+  contents: read
+
+jobs:
+  enforce:
+    name: Enforce main branch protection
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Validate config JSON
+        run: jq empty .github/branch-protection/main.json
+
+      - name: Print protection plan (dry-run)
+        if: inputs.mode == 'dry-run'
+        run: |
+          echo "Branch protection payload for main:"
+          cat .github/branch-protection/main.json
+
+      - name: Apply protection via GitHub API
+        if: inputs.mode == 'apply'
+        uses: actions/github-script@v7
+        env:
+          REPO_ADMIN_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
+        with:
+          script: |
+            const fs = require('fs');
+            const token = process.env.REPO_ADMIN_TOKEN;
+            if (!token) {
+              core.setFailed('Missing REPO_ADMIN_TOKEN secret (repo admin scope required).');
+              return;
+            }
+
+            const payload = JSON.parse(
+              fs.readFileSync('.github/branch-protection/main.json', 'utf8')
+            );
+
+            const octokit = github.getOctokit(token);
+            await octokit.rest.repos.updateBranchProtection({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: 'main',
+              ...payload,
+            });
+
+            core.info('Branch protection updated for main.');


### PR DESCRIPTION
## What changed
- Added `.github/branch-protection/main.json` with branch-protection settings for `main`.
- Added `.github/workflows/enforce-branch-protection.yml` to apply protection via GitHub API.

## Protection policy in this PR
- Require strict status checks before merge (branch up-to-date requirement).
- Require CI + CodeQL checks:
  - `Go Quality`
  - `Go Tests`
  - `Go Integration (Postgres)`
  - `CLI Smoke`
  - `Web Build`
  - `Infra Validate`
  - `Deploy Portability`
  - `Analyze (go)`
  - `Analyze (javascript-typescript)`
- Require 1 approving review.
- Enforce conversation resolution.
- Enforce linear history.
- Prevent force-push and deletion on `main`.

## Why
- Ensures Dependabot PRs cannot merge unless CI gates pass.
- Makes branch protection reproducible and auditable in-repo.

## Operational note
- To apply policy, run workflow **Enforce Branch Protection** with `mode=apply`.
- Requires repository secret `REPO_ADMIN_TOKEN` with admin access.

## Impact
- Governance/CI policy only.
- No application runtime changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an enforceable branch protection policy for `main` and a workflow to apply it, so PRs (including Dependabot) can’t merge unless CI gates pass. Policy lives in-repo for easy auditing and repeatable enforcement.

- **New Features**
  - Add `.github/branch-protection/main.json` with strict status checks (branch up-to-date) and `enforce_admins: true`.
  - Require checks: Go Quality, Go Tests, Go Integration (Postgres), CLI Smoke, Web Build, Infra Validate, Deploy Portability, Analyze (go), Analyze (javascript-typescript).
  - Require 1 approval, dismiss stale reviews, and resolve all conversations.
  - Enforce linear history; block force-push and deletion on `main`.
  - Add `Enforce Branch Protection` workflow (`.github/workflows/enforce-branch-protection.yml`) with `mode` input (`dry-run` or `apply`) using `actions/checkout@v6` and `actions/github-script@v7`; validates JSON and prints the plan in dry-run.

- **Migration**
  - Add repo secret `REPO_ADMIN_TOKEN` with admin access.
  - Run the `Enforce Branch Protection` workflow with `mode=apply` to update `main`.

<sup>Written for commit f0694e3f5ad889b0a5dad7b1bdc249edd55b9c49. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

