### PR TITLE
Split Dependabot security updates from version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,16 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - dependencies
-      - go
+      - deps/go
+    groups:
+      go-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      go-version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: npm
     directory: "/web"
@@ -22,7 +31,16 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - dependencies
-      - web
+      - deps/npm
+    groups:
+      npm-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      npm-version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -34,4 +52,13 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - dependencies
-      - ci
+      - deps/github-actions
+    groups:
+      gha-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      gha-version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## What changed
- Updated `.github/dependabot.yml` for all ecosystems (`gomod`, `npm`, `github-actions`).
- Added explicit groups that split:
  - `*-security-updates` (`applies-to: security-updates`)
  - `*-version-updates` (`applies-to: version-updates`)
- Normalized labels to ecosystem labels (`deps/go`, `deps/npm`, `deps/github-actions`).

## Why
- Separates urgent security remediation from routine dependency churn.
- Improves review speed by giving clearer PR streams and intent.

## Impact
- Dependabot configuration only.
- No runtime behavior changes.

## Validation
- Verified branch changes only `.github/dependabot.yml`.
- Confirmed grouping is applied to all three configured ecosystems.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split Dependabot PRs into separate security vs version update groups for `gomod`, `npm`, and `github-actions` so urgent fixes stand out. Standardized labels to `deps/go`, `deps/npm`, and `deps/github-actions`; config-only changes in `.github/dependabot.yml` with no runtime impact.

<sup>Written for commit 66caf889ca2ee795ffaa8b04d84639b01ad3afcd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

