### PR TITLE
Adopt Keycloak-style issue and PR label taxonomy with automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,8 +2,8 @@ name: Bug report
 description: Report a reproducible defect in Identrail
 title: "[Bug]: "
 labels:
-  - bug
-  - needs-triage
+  - kind/bug
+  - action/needs-triage
 body:
   - type: markdown
     attributes:
@@ -24,18 +24,23 @@ body:
           required: true
 
   - type: dropdown
-    id: component
+    id: area
     attributes:
-      label: Component
-      description: Where does the bug occur?
+      label: Area
+      description: Select the main area affected.
       options:
+        - iam
+        - ui
         - api
-        - worker
         - cli
-        - web
+        - worker
+        - storage
         - deploy
         - docs
-        - other
+        - dependencies
+        - observability
+        - security
+        - workflows
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,8 +2,8 @@ name: Feature request
 description: Propose an improvement with clear problem framing
 title: "[Feature]: "
 labels:
-  - enhancement
-  - needs-triage
+  - kind/enhancement
+  - action/needs-triage
 body:
   - type: checkboxes
     id: preflight
@@ -28,6 +28,27 @@ body:
     attributes:
       label: Proposed solution
       description: Describe your preferred solution and why.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Select the area primarily affected by this request.
+      options:
+        - iam
+        - ui
+        - api
+        - cli
+        - worker
+        - storage
+        - deploy
+        - docs
+        - dependencies
+        - observability
+        - security
+        - workflows
     validations:
       required: true
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,84 @@
+area/ui:
+  - changed-files:
+      - any-glob-to-any-file:
+          - web/**
+
+area/iam:
+  - changed-files:
+      - any-glob-to-any-file:
+          - internal/providers/**
+          - internal/findings/**
+          - docs/threat_model.md
+
+area/api:
+  - changed-files:
+      - any-glob-to-any-file:
+          - internal/api/**
+          - cmd/server/**
+          - docs/openapi-v1.yaml
+
+area/cli:
+  - changed-files:
+      - any-glob-to-any-file:
+          - internal/cli/**
+          - cmd/cli/**
+
+area/worker:
+  - changed-files:
+      - any-glob-to-any-file:
+          - internal/worker/**
+          - cmd/worker/**
+          - internal/scheduler/**
+
+area/storage:
+  - changed-files:
+      - any-glob-to-any-file:
+          - internal/db/**
+          - migrations/**
+          - sqlc/**
+
+area/deploy:
+  - changed-files:
+      - any-glob-to-any-file:
+          - deploy/**
+
+area/docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/**
+          - README.md
+          - CONTRIBUTING.md
+          - SECURITY.md
+          - CODE_OF_CONDUCT.md
+
+area/security:
+  - changed-files:
+      - any-glob-to-any-file:
+          - SECURITY.md
+          - internal/config/security.go
+          - internal/config/security_test.go
+          - internal/api/oidc.go
+          - internal/api/oidc_test.go
+
+area/dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - go.mod
+          - go.sum
+          - web/package.json
+          - web/package-lock.json
+          - .github/dependabot.yml
+
+area/workflows:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/workflows/**
+
+kind/docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/**
+          - README.md
+          - CONTRIBUTING.md
+          - SECURITY.md
+          - CODE_OF_CONDUCT.md

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,94 @@
+- name: action/needs-triage
+  color: "ededed"
+  description: New issue/PR awaiting triage
+- name: action/missing-info
+  color: "f9d0c4"
+  description: More information is required before work can proceed
+- name: action/question
+  color: "d4c5f9"
+  description: Clarification is needed
+- name: action/invalid
+  color: "e4e669"
+  description: Report or request is not valid for this project
+
+- name: kind/bug
+  color: "d73a4a"
+  description: Something is not working correctly
+- name: kind/enhancement
+  color: "a2eeef"
+  description: Improvement to existing behavior
+- name: kind/feature
+  color: "7057ff"
+  description: New capability request
+- name: kind/task
+  color: "0e8a16"
+  description: Maintenance or implementation task
+- name: kind/docs
+  color: "0075ca"
+  description: Documentation-only change
+- name: kind/cve
+  color: "b60205"
+  description: Security vulnerability issue
+
+- name: priority/blocker
+  color: "b60205"
+  description: Release-blocking issue
+- name: priority/important
+  color: "d93f0b"
+  description: High-priority work item
+- name: priority/normal
+  color: "fbca04"
+  description: Normal priority
+- name: priority/low
+  color: "0e8a16"
+  description: Nice-to-have or low urgency
+
+- name: area/iam
+  color: "5319e7"
+  description: Identity and access management rules or behavior
+- name: area/ui
+  color: "1d76db"
+  description: Frontend and user experience
+- name: area/api
+  color: "0052cc"
+  description: HTTP API surface and contracts
+- name: area/cli
+  color: "006b75"
+  description: CLI commands and UX
+- name: area/worker
+  color: "c2e0c6"
+  description: Background scan scheduling and worker runtime
+- name: area/storage
+  color: "bfdadc"
+  description: Database, migrations, and persistence
+- name: area/deploy
+  color: "bfd4f2"
+  description: Deployment assets and infrastructure
+- name: area/docs
+  color: "0366d6"
+  description: Documentation and runbooks
+- name: area/dependencies
+  color: "1f883d"
+  description: Third-party dependency updates
+- name: area/security
+  color: "b60205"
+  description: Security hardening and vulnerability handling
+- name: area/observability
+  color: "5319e7"
+  description: Metrics, tracing, and logging
+- name: area/workflows
+  color: "c5def5"
+  description: CI/CD and GitHub workflows
+
+- name: dependencies
+  color: "1f883d"
+  description: Dependency update pull request
+- name: good first issue
+  color: "7057ff"
+  description: Suitable for first-time contributors
+- name: help wanted
+  color: "008672"
+  description: Extra attention is needed
+- name: question
+  color: "d876e3"
+  description: Further information is requested

--- a/.github/workflows/issue-area-labeler.yml
+++ b/.github/workflows/issue-area-labeler.yml
@@ -1,0 +1,81 @@
+name: Issue Area Labeler
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  label:
+    name: Label issue area
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Apply area label from issue form
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const body = issue.body || "";
+            const areaMatch = body.match(/### Area\s*\n+([^\n]+)/i);
+
+            if (!areaMatch) {
+              core.info(`No area field found for issue #${issue.number}.`);
+              return;
+            }
+
+            const selectedArea = areaMatch[1].trim().toLowerCase();
+            const areaMap = {
+              iam: "area/iam",
+              ui: "area/ui",
+              api: "area/api",
+              cli: "area/cli",
+              worker: "area/worker",
+              storage: "area/storage",
+              deploy: "area/deploy",
+              docs: "area/docs",
+              dependencies: "area/dependencies",
+              observability: "area/observability",
+              security: "area/security",
+              workflows: "area/workflows"
+            };
+
+            const label = areaMap[selectedArea];
+            if (!label) {
+              core.info(`Area '${selectedArea}' does not map to a managed label.`);
+              return;
+            }
+
+            const currentLabels = issue.labels.map((item) => item.name);
+            const currentAreaLabels = currentLabels.filter((name) => name.startsWith("area/"));
+
+            for (const existing of currentAreaLabels) {
+              if (existing === label) {
+                continue;
+              }
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  name: existing,
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }
+
+            if (!currentLabels.includes(label)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: [label],
+              });
+            }

--- a/.github/workflows/issue-area-labeler.yml
+++ b/.github/workflows/issue-area-labeler.yml
@@ -22,13 +22,10 @@ jobs:
             const issue = context.payload.issue;
             const body = issue.body || "";
             const areaMatch = body.match(/### Area\s*\n+([^\n]+)/i);
+            const currentLabels = issue.labels.map((item) => item.name);
+            const currentAreaLabels = currentLabels.filter((name) => name.startsWith("area/"));
 
-            if (!areaMatch) {
-              core.info(`No area field found for issue #${issue.number}.`);
-              return;
-            }
-
-            const selectedArea = areaMatch[1].trim().toLowerCase();
+            const selectedArea = areaMatch ? areaMatch[1].trim().toLowerCase() : "";
             const areaMap = {
               iam: "area/iam",
               ui: "area/ui",
@@ -44,14 +41,7 @@ jobs:
               workflows: "area/workflows"
             };
 
-            const label = areaMap[selectedArea];
-            if (!label) {
-              core.info(`Area '${selectedArea}' does not map to a managed label.`);
-              return;
-            }
-
-            const currentLabels = issue.labels.map((item) => item.name);
-            const currentAreaLabels = currentLabels.filter((name) => name.startsWith("area/"));
+            const label = selectedArea ? areaMap[selectedArea] : undefined;
 
             for (const existing of currentAreaLabels) {
               if (existing === label) {
@@ -69,6 +59,16 @@ jobs:
                   throw error;
                 }
               }
+            }
+
+            if (!areaMatch) {
+              core.info(`No area field found for issue #${issue.number}; removed stale area labels.`);
+              return;
+            }
+
+            if (!label) {
+              core.info(`Area '${selectedArea}' does not map to a managed label; removed stale area labels.`);
+              return;
             }
 
             if (!currentLabels.includes(label)) {

--- a/.github/workflows/pr-area-labeler.yml
+++ b/.github/workflows/pr-area-labeler.yml
@@ -1,0 +1,23 @@
+name: PR Area Labeler
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Label PR by changed files
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Label PR
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: false

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,29 @@
+name: Sync Labels
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+    paths:
+      - .github/labels.yml
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sync:
+    name: Sync repository labels
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Sync labels from manifest
+        uses: crazy-max/ghaction-github-labeler@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          yaml-file: .github/labels.yml
+          skip-delete: true

--- a/deploy/docker/Dockerfile.web
+++ b/deploy/docker/Dockerfile.web
@@ -1,4 +1,4 @@
-FROM node:24-alpine AS builder
+FROM node:24-bookworm-slim AS builder
 WORKDIR /web
 
 COPY web/package*.json ./


### PR DESCRIPTION
## What changed
- Added Keycloak-style label taxonomy manifest: `.github/labels.yml`
  - `area/...` labels (including `area/iam`, `area/ui`, `area/api`, etc.)
  - `kind/...`, `priority/...`, and `action/...` labels
- Added label sync workflow: `.github/workflows/sync-labels.yml`
- Added PR path-based area labeling config and workflow:
  - `.github/labeler.yml`
  - `.github/workflows/pr-area-labeler.yml`
- Added issue area auto-labeling workflow:
  - `.github/workflows/issue-area-labeler.yml`
- Updated issue forms to align with taxonomy:
  - `.github/ISSUE_TEMPLATE/bug_report.yml`
  - `.github/ISSUE_TEMPLATE/feature_request.yml`
  - default labels now use `kind/...` and `action/needs-triage`
  - both forms now collect `Area` for automatic `area/...` labeling

## Why
- Matches the label style used in Keycloak (`area/...`, `kind/...`, etc.).
- Improves triage and ownership routing for both issues and PRs.
- Makes filtering by IAM/UI/API areas straightforward.

## Impact
- Repository triage/workflow automation only.
- No runtime behavior changes.

## Rollout note
- After merge, run workflow **Sync Labels** once (or wait for push-to-main trigger) to create/update labels in GitHub.

## Validation
- Verified new workflow files and issue templates are present and wired together for issue/PR area labeling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts Keycloak-style `area/...`, `kind/...`, and `priority/...` labels with automation to sync labels and auto-apply area labels to issues and PRs. Also updates issue forms and switches the web builder base to `node:24-bookworm-slim`; no runtime changes.

- **New Features**
  - Manage labels via `.github/labels.yml` and `.github/workflows/sync-labels.yml`.
  - Auto-label PRs by changed paths using `.github/labeler.yml` and `.github/workflows/pr-area-labeler.yml` with `actions/labeler`.
  - Auto-label issues from the Area field via `.github/workflows/issue-area-labeler.yml` with `actions/github-script`; cleans up stale `area/...` labels and no-ops if Area is unset.
  - Update bug/feature forms to default `kind/...` and `action/needs-triage`, and add an Area dropdown.
  - Switch `deploy/docker/Dockerfile.web` builder base to `node:24-bookworm-slim`.

- **Migration**
  - After merge, run “Sync Labels” (or wait for the push-to-`main` trigger) to create/update labels.

<sup>Written for commit 0009cd1e6f2f63c00a39c92cf0d266bdd2725240. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

