### PR TITLE
Add CODEOWNERS to request @Oluwatobi-Mustapha review on all PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default code owner for the entire repository.
+# This requests review from @Oluwatobi-Mustapha on every pull request.
+* @Oluwatobi-Mustapha


### PR DESCRIPTION
## What changed
- Added `.github/CODEOWNERS` with a default repository-wide rule:
  - `* @Oluwatobi-Mustapha`

## Why
- Ensures pull requests automatically request your review as code owner, matching the owner-ping workflow you referenced.

## Impact
- Governance/review routing only.
- No runtime behavior changes.

## Note
- If GitHub repository setting **Automatically request review from code owners** is disabled, enable it in repository settings for this to trigger review requests automatically on each PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.github/CODEOWNERS` to auto-request reviews from `@Oluwatobi-Mustapha` on all pull requests. This standardizes review routing with no runtime changes.

- **Migration**
  - Enable "Automatically request review from code owners" in repository settings.

<sup>Written for commit 39c47166ba8763cf5bb883a6abe0f59e798018e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

