### PR TITLE
Add GitHub Sponsors funding configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# Funding links displayed by GitHub in the repository sponsor button.
+github: [Oluwatobi-Mustapha]


### PR DESCRIPTION
## What changed
- Added `.github/FUNDING.yml`.
- Configured GitHub sponsorship handle: `Oluwatobi-Mustapha`.

## Why
- Enables GitHub's Sponsor button and funding metadata on the repository.
- Makes it easy for users to sponsor ongoing open-source work.

## Impact
- Repository metadata/configuration only.
- No runtime behavior changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `.github/FUNDING.yml` to enable the Sponsor button and funding metadata for `Oluwatobi-Mustapha`. Metadata-only change with no code, build, or runtime impact.

<sup>Written for commit c4ace412144df63ae7bf8c71f3bd78443fa5e6cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

