### PR TITLE
Potential fix for code scanning alert no. 7: Clear-text logging of sensitive information

### DIFF
--- a/internal/config/security.go
+++ b/internal/config/security.go
@@ -93,12 +93,14 @@ func ValidateSecurity(cfg Config) error {
 					continue
 				}
 				if _, ok := allowedKeyScopes[normalizedScope]; !ok {
-					return fmt.Errorf("invalid scope %q for api key %q", normalizedScope, trimmedKey)
+					// Do not include sensitive API key material or scope values in the error.
+					return fmt.Errorf("invalid API key scope configured")
 				}
 				validScopeCount++
 			}
 			if validScopeCount == 0 {
-				return fmt.Errorf("api key %q has no valid scopes", trimmedKey)
+				// Do not include the API key itself in the error to avoid leaking secrets.
+				return fmt.Errorf("API key configured without any valid scopes")
 			}
 		}
 	}
@@ -118,7 +120,8 @@ func ValidateSecurity(cfg Config) error {
 				continue
 			}
 			if _, ok := allowed[trimmed]; !ok {
-				return fmt.Errorf("write api key %q must also exist in IDENTRAIL_API_KEYS", trimmed)
+				// Avoid including the specific write API key value in the error.
+				return fmt.Errorf("configured write API key must also exist in IDENTRAIL_API_KEYS")
 			}
 		}
 	}
@@ -259,12 +262,14 @@ func ValidateSecurity(cfg Config) error {
 	// Placeholder validation follows the active API key mode.
 	// Scoped keys take precedence over legacy API_KEYS/WRITE_API_KEYS.
 	if len(cfg.APIKeyScopes) > 0 {
-		if key, found := findPlaceholderAPIKey(nil, nil, cfg.APIKeyScopes); found {
-			return fmt.Errorf("placeholder API key %q is not allowed in runtime configuration; provision real secrets", key)
+		if _, found := findPlaceholderAPIKey(nil, nil, cfg.APIKeyScopes); found {
+			// Do not echo the placeholder key value; just indicate that placeholders are not allowed.
+			return fmt.Errorf("placeholder API key is not allowed in runtime configuration; provision real secrets")
 		}
 	} else {
-		if key, found := findPlaceholderAPIKey(cfg.APIKeys, cfg.WriteAPIKeys, nil); found {
-			return fmt.Errorf("placeholder API key %q is not allowed in runtime configuration; provision real secrets", key)
+		if _, found := findPlaceholderAPIKey(cfg.APIKeys, cfg.WriteAPIKeys, nil); found {
+			// Do not echo the placeholder key value; just indicate that placeholders are not allowed.
+			return fmt.Errorf("placeholder API key is not allowed in runtime configuration; provision real secrets")
 		}
 	}
 	for _, trustedProxy := range cfg.TrustedProxies {


### PR DESCRIPTION
Potential fix for [https://github.com/Oluwatobi-Mustapha/identrail/security/code-scanning/7](https://github.com/Oluwatobi-Mustapha/identrail/security/code-scanning/7)

In general, to fix clear-text secret logging you either (a) avoid logging the secret entirely, or (b) replace it with a redacted/summary representation before it ever reaches any logger or error chain. Here, the only actual logging is `log.Fatalf("server failed: %v", err)` in `cmd/server/main.go`; the secrets are introduced earlier in `internal/config/security.go` when constructing `fmt.Errorf` messages that embed API keys and scopes. The best fix is to change those specific error messages so they no longer contain raw API keys or scopes, while preserving enough context (like key length, index, or a short hash) for debugging if desired.

Concretely:

- In `internal/config/security.go`:
  - Change `fmt.Errorf("invalid scope %q for api key %q", normalizedScope, trimmedKey)` to avoid including `normalizedScope` and the full key; use a generic message such as `"invalid API key scope"` or, if needed, include only non-secret safe data (e.g., index).
  - Change `fmt.Errorf("api key %q has no valid scopes", trimmedKey)` to a generalized message without the key value.
  - Change `fmt.Errorf("write api key %q must also exist in IDENTRAIL_API_KEYS", trimmed)` likewise to omit the key text.
  - Change `fmt.Errorf("placeholder API key %q is not allowed in runtime configuration; provision real secrets", key)` calls to avoid embedding the placeholder key itself.
- Leave other error messages that use non-secret configuration values (like provider names, URLs, counts) unchanged.

With these changes, the propagated `err` that reaches `log.Fatalf` will no longer contain sensitive data, addressing all reported variants in one go without altering overall control flow or behavior of the server beyond error text.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts sensitive data from security validation errors to prevent secrets from appearing in logs, addressing Code Scanning Alert #7 (clear-text logging).

- **Bug Fixes**
  - In `internal/config/security.go`, replaced error messages that embedded API keys or scopes with generic, non-sensitive text.
  - Covered: invalid scope, key with no valid scopes, write key missing from `IDENTRAIL_API_KEYS`, and placeholder keys in both scoped and legacy modes.
  - Prevents secret material from propagating to fatal logs.

<sup>Written for commit ce6a91460c2f59b7411d85bd6600caf10d67147e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

