### PR TITLE
Fix code-scanning autofix workflow input handling and pagination

### DIFF
--- a/.github/workflows/code-scanning-autofix.yml
+++ b/.github/workflows/code-scanning-autofix.yml
@@ -43,19 +43,20 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            const inputs = context.payload.inputs || {};
 
             const isScheduled = context.eventName === "schedule";
-            const applyInput = core.getInput("apply_changes");
+            const applyInput = String(inputs.apply_changes ?? "false").toLowerCase();
             const applyChanges = isScheduled || applyInput === "true";
 
-            const maxAlertsInput = core.getInput("max_alerts") || "3";
+            const maxAlertsInput = String(inputs.max_alerts ?? "3");
             const maxAlerts = Number.parseInt(maxAlertsInput, 10);
             if (!Number.isFinite(maxAlerts) || maxAlerts <= 0) {
               core.setFailed(`Invalid max_alerts value: ${maxAlertsInput}`);
               return;
             }
 
-            const severitiesInput = core.getInput("severities") || "critical,high";
+            const severitiesInput = String(inputs.severities ?? "critical,high");
             const severities = severitiesInput
               .split(",")
               .map((value) => value.trim().toLowerCase())
@@ -63,7 +64,7 @@ jobs:
 
             const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-            const alertsResp = await github.request("GET /repos/{owner}/{repo}/code-scanning/alerts", {
+            const allOpenAlerts = await github.paginate("GET /repos/{owner}/{repo}/code-scanning/alerts", {
               owner,
               repo,
               state: "open",
@@ -71,7 +72,7 @@ jobs:
               per_page: 100,
             });
 
-            const matchingAlerts = alertsResp.data
+            const matchingAlerts = allOpenAlerts
               .filter((alert) => {
                 const sev = (alert.rule?.security_severity_level || alert.rule?.severity || "").toLowerCase();
                 return severities.includes(sev);


### PR DESCRIPTION
## Follow-up to merged PR #60
This PR addresses two review findings reported after #60 was merged.

## What changed
- Updated `.github/workflows/code-scanning-autofix.yml` to read manual inputs from `context.payload.inputs` instead of `core.getInput()` inside `actions/github-script`.
- Replaced single-page alert fetch with paginated retrieval using `github.paginate(...)`.

## Why
- `core.getInput()` in `github-script` does not read `workflow_dispatch` inputs reliably in this script context, causing manual runs to ignore supplied values.
- Single request (`per_page: 100`) could miss alerts beyond the first page.

## Impact
- Manual dispatch values (`apply_changes`, `max_alerts`, `severities`) are now respected.
- All open matching CodeQL alerts are considered before filtering/limiting.

## Validation
- Workflow YAML parses successfully.
- Removed `core.getInput(...)` usage from script logic.
- Added paginated listing path for code-scanning alerts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes manual input handling and adds alert pagination in the code-scanning autofix workflow so supplied parameters are respected and no alerts are missed.

- **Bug Fixes**
  - Read `workflow_dispatch` inputs via `context.payload.inputs` inside `actions/github-script` (replaces `core.getInput`).
  - Use `github.paginate` to fetch all open CodeQL alerts before filtering and limiting.

<sup>Written for commit 3d37a476aaef7425597d73fb3774d82aa724dfca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

