### PR TITLE
Add automated tag-driven release pipeline with binaries, images, and notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
             tag="${{ inputs.tag }}"
           fi
 
-          if ! [[ "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-].+)?$ ]]; then
+          if ! [[ "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
             echo "Invalid release tag: ${tag}" >&2
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ on:
         description: "Existing git tag to release (for example v1.2.3)"
         required: true
         type: string
+      web_api_url:
+        description: "Public HTTPS API URL for the web image build (for example https://api.identrail.io)"
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -44,7 +48,8 @@ jobs:
 
           prerelease="false"
           publish_latest="true"
-          if [[ "${tag}" == *-* ]]; then
+          tag_without_build="${tag%%+*}"
+          if [[ "${tag_without_build}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+- ]]; then
             prerelease="true"
             publish_latest="false"
           fi
@@ -159,6 +164,23 @@ jobs:
           base="ghcr.io/${owner}/identrail"
           tag="${{ needs.prepare.outputs.tag }}"
           publish_latest="${{ needs.prepare.outputs.publish_latest }}"
+          web_api_url="${{ vars.IDENTRAIL_WEB_API_URL }}"
+          input_web_api_url="${{ inputs.web_api_url }}"
+
+          if [ -n "${input_web_api_url}" ]; then
+            web_api_url="${input_web_api_url}"
+          fi
+
+          if [ -z "${web_api_url}" ]; then
+            echo "Web image build requires an API URL." >&2
+            echo "Set repository variable IDENTRAIL_WEB_API_URL or provide workflow_dispatch input web_api_url." >&2
+            exit 1
+          fi
+
+          if [[ ! "${web_api_url}" =~ ^https:// ]]; then
+            echo "web_api_url must start with https:// for release images: ${web_api_url}" >&2
+            exit 1
+          fi
 
           mkdir -p dist
 
@@ -185,7 +207,7 @@ jobs:
 
           build_and_push "api" -f deploy/docker/Dockerfile.backend --build-arg TARGET=server .
           build_and_push "worker" -f deploy/docker/Dockerfile.backend --build-arg TARGET=worker .
-          build_and_push "web" -f deploy/docker/Dockerfile.web --build-arg VITE_IDENTRAIL_API_URL=https://api.identrail.example .
+          build_and_push "web" -f deploy/docker/Dockerfile.web --build-arg "VITE_IDENTRAIL_API_URL=${web_api_url}" .
 
       - name: Upload image metadata
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,223 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing git tag to release (for example v1.2.3)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  prepare:
+    name: Prepare Release Context
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
+      prerelease: ${{ steps.meta.outputs.prerelease }}
+      publish_latest: ${{ steps.meta.outputs.publish_latest }}
+
+    steps:
+      - name: Resolve release metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            tag="${GITHUB_REF_NAME}"
+          else
+            tag="${{ inputs.tag }}"
+          fi
+
+          if ! [[ "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-].+)?$ ]]; then
+            echo "Invalid release tag: ${tag}" >&2
+            exit 1
+          fi
+
+          prerelease="false"
+          publish_latest="true"
+          if [[ "${tag}" == *-* ]]; then
+            prerelease="true"
+            publish_latest="false"
+          fi
+
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+          echo "prerelease=${prerelease}" >> "${GITHUB_OUTPUT}"
+          echo "publish_latest=${publish_latest}" >> "${GITHUB_OUTPUT}"
+
+  build-binaries:
+    name: Build Release Binaries
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: refs/tags/${{ needs.prepare.outputs.tag }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build archives and checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ needs.prepare.outputs.tag }}"
+          mkdir -p dist
+
+          targets=(
+            "linux/amd64"
+            "linux/arm64"
+            "darwin/amd64"
+            "darwin/arm64"
+            "windows/amd64"
+          )
+
+          commands=("cli" "server" "worker")
+
+          for target in "${targets[@]}"; do
+            goos="${target%/*}"
+            goarch="${target#*/}"
+
+            for cmd in "${commands[@]}"; do
+              ext=""
+              if [ "${goos}" = "windows" ]; then
+                ext=".exe"
+              fi
+
+              bin_name="identrail-${cmd}-${tag}-${goos}-${goarch}${ext}"
+              out_path="dist/${bin_name}"
+
+              CGO_ENABLED=0 GOOS="${goos}" GOARCH="${goarch}" \
+                go build -trimpath -ldflags="-s -w" -o "${out_path}" "./cmd/${cmd}"
+
+              if [ "${goos}" = "windows" ]; then
+                archive="dist/identrail-${cmd}-${tag}-${goos}-${goarch}.zip"
+                zip -j "${archive}" "${out_path}" >/dev/null
+              else
+                archive="dist/identrail-${cmd}-${tag}-${goos}-${goarch}.tar.gz"
+                tar -czf "${archive}" -C dist "${bin_name}"
+              fi
+
+              rm -f "${out_path}"
+            done
+          done
+
+          (
+            cd dist
+            shasum -a 256 *.tar.gz *.zip > checksums.txt
+          )
+
+      - name: Upload release binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-binaries
+          path: dist/*
+          if-no-files-found: error
+
+  publish-images:
+    name: Build and Publish Images
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: refs/tags/${{ needs.prepare.outputs.tag }}
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push images
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          owner="$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
+          base="ghcr.io/${owner}/identrail"
+          tag="${{ needs.prepare.outputs.tag }}"
+          publish_latest="${{ needs.prepare.outputs.publish_latest }}"
+
+          mkdir -p dist
+
+          build_and_push() {
+            local name="$1"
+            shift
+            local image="${base}-${name}"
+            local args=("$@")
+
+            local tags=("-t" "${image}:${tag}")
+            if [ "${publish_latest}" = "true" ]; then
+              tags+=("-t" "${image}:latest")
+            fi
+
+            docker buildx build \
+              --platform linux/amd64,linux/arm64 \
+              --push \
+              "${tags[@]}" \
+              "${args[@]}"
+
+            digest="$(docker buildx imagetools inspect "${image}:${tag}" --format '{{json .Manifest.Digest}}' | tr -d '"')"
+            printf '%s\n' "${image}:${tag}@${digest}" >> dist/image-digests.txt
+          }
+
+          build_and_push "api" -f deploy/docker/Dockerfile.backend --build-arg TARGET=server .
+          build_and_push "worker" -f deploy/docker/Dockerfile.backend --build-arg TARGET=worker .
+          build_and_push "web" -f deploy/docker/Dockerfile.web --build-arg VITE_IDENTRAIL_API_URL=https://api.identrail.example .
+
+      - name: Upload image metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-image-metadata
+          path: dist/image-digests.txt
+          if-no-files-found: error
+
+  publish-release:
+    name: Publish GitHub Release
+    needs: [prepare, build-binaries, publish-images]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Download release binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: release-binaries
+          path: dist
+
+      - name: Download image metadata
+        uses: actions/download-artifact@v4
+        with:
+          name: release-image-metadata
+          path: dist
+
+      - name: Publish release with generated notes
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.prepare.outputs.tag }}
+          generate_release_notes: true
+          prerelease: ${{ needs.prepare.outputs.prerelease == 'true' }}
+          files: |
+            dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
             tag="${GITHUB_REF_NAME}"
           else
-            tag="${{ inputs.tag }}"
+            tag="${{ github.event.inputs.tag }}"
           fi
 
           if ! [[ "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
@@ -165,7 +165,7 @@ jobs:
           tag="${{ needs.prepare.outputs.tag }}"
           publish_latest="${{ needs.prepare.outputs.publish_latest }}"
           web_api_url="${{ vars.IDENTRAIL_WEB_API_URL }}"
-          input_web_api_url="${{ inputs.web_api_url }}"
+          input_web_api_url="${{ github.event.inputs.web_api_url }}"
 
           if [ -n "${input_web_api_url}" ]; then
             web_api_url="${input_web_api_url}"

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -1,0 +1,32 @@
+# Release Pipeline
+
+Identrail release automation is defined in:
+- `.github/workflows/release.yml`
+
+## Trigger Modes
+
+- Tag push: `v*.*.*` (for example `v1.2.3`)
+- Manual dispatch with an existing tag input
+
+## What the Pipeline Publishes
+
+1. Cross-platform binaries (`cli`, `server`, `worker`) as archives.
+2. SHA-256 checksum manifest (`checksums.txt`).
+3. Container images to GHCR:
+   - `ghcr.io/<owner>/identrail-api:<tag>`
+   - `ghcr.io/<owner>/identrail-worker:<tag>`
+   - `ghcr.io/<owner>/identrail-web:<tag>`
+4. Auto-generated GitHub Release notes.
+
+## Image Tag Rules
+
+- Stable tags (`vX.Y.Z`) publish `<tag>` and `latest`.
+- Pre-release tags (`vX.Y.Z-rc.1`, etc.) publish only `<tag>`.
+
+## Recommended Usage
+
+1. Merge all release-ready PRs into `main`.
+2. Create and push a SemVer tag:
+   - `git tag v1.2.3`
+   - `git push origin v1.2.3`
+3. Verify release assets and image digests on GitHub Releases.

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -6,7 +6,15 @@ Identrail release automation is defined in:
 ## Trigger Modes
 
 - Tag push: `v*.*.*` (for example `v1.2.3`)
-- Manual dispatch with an existing tag input
+- Manual dispatch with:
+  - `tag` (required)
+  - `web_api_url` (optional override for web image build)
+
+## Required Configuration
+
+- Set repository variable `IDENTRAIL_WEB_API_URL` to the public HTTPS API base URL
+  used by production web builds (for example `https://api.identrail.io`).
+- For manual runs, you can override this with the `web_api_url` dispatch input.
 
 ## What the Pipeline Publishes
 


### PR DESCRIPTION
## What changed
- Added `.github/workflows/release.yml`.
- Added release runbook `docs/release-pipeline.md`.

## Release pipeline capabilities
- Trigger on SemVer tags (`v*.*.*`) or manual dispatch.
- Build and package release binaries (`cli`, `server`, `worker`) for multiple OS/arch targets.
- Generate and publish `checksums.txt`.
- Build and push multi-arch container images to GHCR (`api`, `worker`, `web`).
- Publish GitHub Release with generated release notes and attached assets.

## Why
- Establishes a repeatable release process from tag -> release artifacts/images -> release notes.
- Reduces manual release overhead and release drift.

## Impact
- CI/release automation only.
- No runtime behavior changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an automated, tag-driven release pipeline that builds cross-platform binaries, publishes multi-arch images to `ghcr.io`, generates checksums, and creates GitHub Releases with notes and assets. CI-only; no runtime changes.

- **New Features**
  - Triggers on SemVer tags (`v*.*.*`) or manual dispatch with an existing tag; strict SemVer validation; pre-release tags skip `latest`.
  - Builds and archives `cli`, `server`, `worker` for Linux/macOS/Windows; writes `checksums.txt`.
  - Builds and pushes multi-arch images (`linux/amd64`, `linux/arm64`) to `ghcr.io/<owner>/identrail-{api,worker,web}`; captures digests in `image-digests.txt`; `web` uses an HTTPS API URL from `IDENTRAIL_WEB_API_URL` or the `web_api_url` input (enforced; fails if missing/invalid).
  - Publishes a GitHub Release with generated notes and attached artifacts.
  - Adds runbook at `docs/release-pipeline.md`.

<sup>Written for commit 4907c2614244e110b752e1cb96f164998076c847. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

