### PR TITLE
Standardize local developer workflow with Makefile, Taskfile, and pre-commit

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.go]
+indent_style = tab
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yaml,yml,json,tf,hcl}]
+indent_style = space
+indent_size = 2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: local
+    hooks:
+      - id: gofmt-check
+        name: gofmt check
+        entry: bash -c 'set -euo pipefail; files="$(git ls-files "*.go")"; [ -z "$files" ] && exit 0; unformatted="$(echo "$files" | xargs gofmt -l)"; [ -z "$unformatted" ] || { echo "Go files not formatted:"; echo "$unformatted"; exit 1; }'
+        language: system
+        pass_filenames: false
+
+      - id: go-vet
+        name: go vet
+        entry: go vet ./...
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,58 @@
+SHELL := /usr/bin/env bash
+.DEFAULT_GOAL := help
+
+.PHONY: help bootstrap fmt fmt-check vet test test-integration web-install web-test web-build helm-lint tfmt-check ci pre-commit
+
+help: ## Show available targets
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z0-9_-]+:.*##/ {printf "%-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+bootstrap: ## Install local dependencies for Go and web
+	go mod download
+	npm ci --prefix web
+
+fmt: ## Auto-format Go and Terraform files
+	@if git ls-files '*.go' | grep -q .; then \
+		git ls-files '*.go' | xargs gofmt -w; \
+	fi
+	@terraform fmt -recursive deploy/terraform >/dev/null 2>&1 || true
+
+fmt-check: ## Check formatting without modifying files
+	@set -euo pipefail; \
+	if git ls-files '*.go' | grep -q .; then \
+		unformatted="$$(git ls-files '*.go' | xargs gofmt -l)"; \
+		if [ -n "$$unformatted" ]; then \
+			echo "Go files not formatted:"; \
+			echo "$$unformatted"; \
+			exit 1; \
+		fi; \
+	fi
+	@terraform fmt -check -recursive deploy/terraform >/dev/null 2>&1 || true
+
+vet: ## Run go vet
+	go vet ./...
+
+test: ## Run Go unit and package tests
+	go test ./... -coverprofile=coverage.out
+
+test-integration: ## Run integration tests (requires local Postgres)
+	go test -tags=integration ./internal/integration -count=1 -v
+
+web-install: ## Install web dependencies
+	npm ci --prefix web
+
+web-test: ## Run web test suite in CI mode
+	npm run test:ci --prefix web
+
+web-build: ## Build web frontend
+	npm run build --prefix web
+
+helm-lint: ## Lint Helm chart
+	helm lint deploy/helm/identrail
+
+tfmt-check: ## Check Terraform formatting
+	terraform fmt -check -recursive deploy/terraform
+
+ci: fmt-check vet test web-test web-build ## Run core local CI checks
+
+pre-commit: ## Run pre-commit hooks across the repository
+	pre-commit run --all-files

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,57 @@
+version: "3"
+
+tasks:
+  default:
+    desc: Show task list
+    cmds:
+      - task --list
+
+  bootstrap:
+    desc: Install local dependencies for Go and web
+    cmds:
+      - make bootstrap
+
+  fmt:
+    desc: Auto-format Go and Terraform files
+    cmds:
+      - make fmt
+
+  fmt-check:
+    desc: Check formatting without modifying files
+    cmds:
+      - make fmt-check
+
+  vet:
+    desc: Run go vet
+    cmds:
+      - make vet
+
+  test:
+    desc: Run Go tests
+    cmds:
+      - make test
+
+  test-integration:
+    desc: Run Go integration tests
+    cmds:
+      - make test-integration
+
+  web-test:
+    desc: Run web tests
+    cmds:
+      - make web-test
+
+  web-build:
+    desc: Build web frontend
+    cmds:
+      - make web-build
+
+  ci:
+    desc: Run core local CI checks
+    cmds:
+      - make ci
+
+  pre-commit:
+    desc: Run pre-commit hooks across repository
+    cmds:
+      - make pre-commit

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -1,0 +1,45 @@
+# Development Workflow
+
+Identrail now provides standardized local developer workflows through:
+- `Makefile`
+- `Taskfile.yml`
+- `.editorconfig`
+- `.pre-commit-config.yaml` (optional)
+
+## Recommended Setup
+
+1. Install prerequisites:
+   - Go (version from `go.mod`)
+   - Node.js 24+ and npm
+   - Optional: Terraform, Helm, pre-commit, go-task
+2. Bootstrap dependencies:
+   - `make bootstrap`
+
+## Common Commands
+
+- `make help`: list available make targets.
+- `make ci`: run core local CI checks (format checks, vet, Go tests, web tests, web build).
+- `make fmt`: format Go and Terraform files.
+- `make fmt-check`: verify formatting only.
+- `make test`: run Go tests.
+- `make web-test`: run frontend tests.
+- `make web-build`: build frontend assets.
+
+If you use `go-task`, equivalent commands are available via `task`.
+
+## Optional Pre-commit Hooks
+
+To enable optional hooks:
+
+1. Install pre-commit (`pipx install pre-commit` or package-manager equivalent).
+2. Install hooks in this repo:
+   - `pre-commit install`
+   - `pre-commit install --hook-type pre-push`
+3. Run hooks manually on demand:
+   - `make pre-commit`
+
+Configured hooks include:
+- YAML and merge-conflict checks
+- trailing whitespace and EOF normalization
+- Go formatting check
+- Go vet on pre-push


### PR DESCRIPTION
## What changed
- Added `Makefile` with common local targets for formatting, tests, web build, and CI parity checks.
- Added `Taskfile.yml` wrappers for teams that use `go-task`.
- Added `.editorconfig` to standardize editor behavior across contributors.
- Added optional `.pre-commit-config.yaml` hooks for YAML/whitespace checks, Go formatting checks, and `go vet` on pre-push.
- Added `docs/development-workflow.md` to document setup and usage.

## Why
- Reduces contributor setup drift and command inconsistency.
- Makes local validation more consistent with CI expectations.

## Impact
- Developer tooling/documentation only.
- No runtime behavior changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes the local developer workflow with a `Makefile`, `Taskfile.yml`, and optional `pre-commit` hooks to align local checks with CI. Developer tooling only; no runtime changes.

- **New Features**
  - Added `Makefile` targets for fmt, fmt-check, vet, tests, web build/test, Helm lint, and Terraform fmt-check.
  - Added `Taskfile.yml` wrappers for teams using `go-task`.
  - Added `.editorconfig` to enforce consistent indentation, EOLs, and newline rules.
  - Added optional `.pre-commit-config.yaml` for YAML/whitespace checks, Go fmt check, and `go vet` on pre-push.
  - Added `docs/development-workflow.md` with setup and common commands.

- **Migration**
  - Run `make bootstrap` to install deps.
  - Optionally enable hooks: `pre-commit install && pre-commit install --hook-type pre-push`.
  - Use `make ci` locally to mirror CI checks.

<sup>Written for commit 20c4310ac1608e8c107b9a67a52bdceede4e8213. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

