### PR TITLE
Async API scan queue with worker draining

### DIFF
--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -43,6 +43,12 @@ Portable deployment profiles:
   - `IDENTRAIL_WORKER_REPO_SCAN_ENABLED=true`
   - `IDENTRAIL_WORKER_REPO_SCAN_TARGETS` has intended repositories
   - targets are covered by `IDENTRAIL_REPO_SCAN_ALLOWLIST` when allowlist is set
+- Confirm API queue controls:
+  - `IDENTRAIL_SCAN_QUEUE_MAX_PENDING`
+  - `IDENTRAIL_REPO_SCAN_QUEUE_MAX_PENDING`
+  - `IDENTRAIL_WORKER_API_JOB_QUEUE_ENABLED=true`
+  - `IDENTRAIL_WORKER_API_JOB_QUEUE_INTERVAL`
+  - `IDENTRAIL_WORKER_API_JOB_QUEUE_BATCH_SIZE`
 
 ## 2) Deploy Sequence
 
@@ -53,11 +59,12 @@ Portable deployment profiles:
 5. Deploy worker with same DB + provider config.
 6. Trigger one scan (`POST /v1/scans`) with write-authorized key.
 7. Verify:
-   - findings list (`GET /v1/findings`)
-   - findings summary (`GET /v1/findings/summary`)
-   - findings trends (`GET /v1/findings/trends`)
-   - scan diff (`GET /v1/scans/:scan_id/diff`)
-   - scan events (`GET /v1/scans/:scan_id/events`)
+  - scan is accepted as queued (`202`) then completed by worker
+  - findings list (`GET /v1/findings`)
+  - findings summary (`GET /v1/findings/summary`)
+  - findings trends (`GET /v1/findings/trends`)
+  - scan diff (`GET /v1/scans/:scan_id/diff`)
+  - scan events (`GET /v1/scans/:scan_id/events`)
 8. If repo scan is enabled:
    - trigger `POST /v1/repo-scans`
    - verify `GET /v1/repo-scans`

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -178,7 +178,7 @@ paths:
       operationId: runScan
       responses:
         "202":
-          description: Scan started
+          description: Scan enqueued
           content:
             application/json:
               schema:
@@ -186,14 +186,8 @@ paths:
                 properties:
                   scan:
                     $ref: "#/components/schemas/ScanRecord"
-                  assets:
-                    type: integer
-                  finding_count:
-                    type: integer
-                  partial_source_run:
-                    type: boolean
-        "409":
-          description: Scan already running for provider
+        "429":
+          description: Scan queue is full
   /v1/scans/{scan_id}/diff:
     get:
       tags: [Scans]
@@ -352,7 +346,7 @@ paths:
               $ref: "#/components/schemas/RepoScanRequest"
       responses:
         "202":
-          description: Repo scan started
+          description: Repo scan enqueued
           content:
             application/json:
               schema:
@@ -360,9 +354,16 @@ paths:
                 properties:
                   repo_scan:
                     $ref: "#/components/schemas/RepoScanRecord"
-                  result:
-                    type: object
-                    additionalProperties: true
+        "400":
+          description: Invalid repository scan request
+        "403":
+          description: Repo target not allowed
+        "409":
+          description: Repo scan already in progress for target
+        "429":
+          description: Repo scan queue is full
+        "503":
+          description: Repo scan is disabled
   /v1/repo-scans/{repo_scan_id}:
     get:
       tags: [RepositoryExposure]

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -9,7 +9,7 @@ Prevent overlapping scans and support periodic scan runs.
 - `internal/scheduler/lock.go`: keyed in-memory lock
 - `internal/scheduler/postgres_lock.go`: distributed advisory lock backend for multi-instance runs
 - `internal/scheduler/runner.go`: periodic loop executor
-- `cmd/worker`: process that runs scheduled scans
+- `cmd/worker`: process that runs scheduled scans and API queue-drain ticks
 
 ## How safety works
 

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -2,12 +2,13 @@
 
 ## What it does
 
-The worker runs scans on a schedule.
+The worker runs scans on a schedule and drains API-enqueued jobs.
 
 - Binary: `cmd/worker`
 - Loop: `internal/scheduler/runner.go`
 - Scan call: `api.Service.RunScan`
 - Optional repo scan call: `api.Service.RunRepoScanPersisted`
+- API queue drain call: `api.Service.ProcessNextQueuedScan` + `api.Service.ProcessNextQueuedRepoScan`
 
 ## Config
 
@@ -23,6 +24,9 @@ The worker runs scans on a schedule.
 - `IDENTRAIL_WORKER_REPO_SCAN_TARGETS` (comma-separated repos, required when enabled)
 - `IDENTRAIL_WORKER_REPO_SCAN_HISTORY_LIMIT` (optional override; `0` uses service default)
 - `IDENTRAIL_WORKER_REPO_SCAN_MAX_FINDINGS` (optional override; `0` uses service default)
+- `IDENTRAIL_WORKER_API_JOB_QUEUE_ENABLED` (default `true`)
+- `IDENTRAIL_WORKER_API_JOB_QUEUE_INTERVAL` (default `2s`)
+- `IDENTRAIL_WORKER_API_JOB_QUEUE_BATCH_SIZE` (default `5`)
 
 ## Behavior
 
@@ -31,5 +35,7 @@ The worker runs scans on a schedule.
 - Uses same persistence flow as API-triggered scan
 - Skips overlapping runs via existing service lock
 - Optional repo scan scheduler is additive and disabled by default
+- API `POST /v1/scans` and `POST /v1/repo-scans` enqueue work; worker queue runner executes queued jobs asynchronously
+- Queue runner applies bounded batch processing per tick (`IDENTRAIL_WORKER_API_JOB_QUEUE_BATCH_SIZE`)
 - Repo scans use per-target lock key (`repo-scan:<target>`) to avoid overlap between API and worker triggers
 - In database mode, `IDENTRAIL_LOCK_BACKEND=auto` uses PostgreSQL advisory locks for multi-instance safety

--- a/internal/api/contract_snapshot_test.go
+++ b/internal/api/contract_snapshot_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -30,6 +31,13 @@ func TestAPIV1ContractSnapshots(t *testing.T) {
 	postBody := decodeJSONMap(t, postW.Body.Bytes())
 	scanID := normalizeScanTriggerResponse(postBody)
 	assertContractSnapshot(t, "api_v1_scan_trigger_response", postBody)
+	processed, processErr := svc.ProcessNextQueuedScan(context.Background())
+	if processErr != nil {
+		t.Fatalf("process queued scan: %v", processErr)
+	}
+	if !processed {
+		t.Fatal("expected queued scan to be processed")
+	}
 
 	findingsReq := httptest.NewRequest(http.MethodGet, "/v1/findings?limit=5", nil)
 	findingsW := httptest.NewRecorder()

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -28,8 +28,6 @@ const (
 	defaultEventsLimit     = 100
 	maxListLimit           = 500
 	maxCursorFetchLimit    = 5000
-	scanRequestTimeout     = 2 * time.Minute
-	repoScanRequestTimeout = 5 * time.Minute
 	rateLimiterEntryTTL    = 15 * time.Minute
 	rateLimiterMaxEntries  = 10000
 	rateLimiterCleanupTick = 256
@@ -491,31 +489,20 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			metrics.ScanDurationMS.Observe(float64(time.Since(start).Milliseconds()))
 		}()
 
-		requestCtx, cancel := context.WithTimeout(c.Request.Context(), scanRequestTimeout)
-		defer cancel()
-
-		result, err := svc.RunScan(requestCtx)
+		scan, err := svc.EnqueueScan(c.Request.Context())
 		if err != nil {
 			metrics.ScanFailureTotal.Inc()
-			if errors.Is(err, ErrScanInProgress) {
-				c.JSON(http.StatusConflict, gin.H{"error": "scan already in progress"})
+			if errors.Is(err, ErrScanQueueFull) {
+				c.JSON(http.StatusTooManyRequests, gin.H{"error": "scan queue is full"})
 				return
 			}
-			logger.Error("run scan", telemetry.ZapError(err))
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to run scan"})
+			logger.Error("enqueue scan", telemetry.ZapError(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to enqueue scan"})
 			return
 		}
 
-		metrics.ScanSuccessTotal.Inc()
-		if result.PartialSourceRun {
-			metrics.ScanPartialTotal.Inc()
-		}
-		metrics.FindingsGenerated.Add(float64(result.FindingCount))
 		c.JSON(http.StatusAccepted, gin.H{
-			"scan":               result.Scan,
-			"assets":             result.Assets,
-			"finding_count":      result.FindingCount,
-			"partial_source_run": result.PartialSourceRun,
+			"scan": scan,
 		})
 	})
 
@@ -533,10 +520,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			return
 		}
 
-		requestCtx, cancel := context.WithTimeout(c.Request.Context(), repoScanRequestTimeout)
-		defer cancel()
-
-		result, err := svc.RunRepoScanPersisted(requestCtx, request)
+		record, err := svc.EnqueueRepoScan(c.Request.Context(), request)
 		if err != nil {
 			metrics.RepoScanFailureTotal.Inc()
 			if errors.Is(err, ErrInvalidRepoScanRequest) {
@@ -555,14 +539,17 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 				c.JSON(http.StatusServiceUnavailable, gin.H{"error": "repo scan is disabled"})
 				return
 			}
-			logger.Error("run repo scan", telemetry.ZapError(err))
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to run repo scan"})
+			if errors.Is(err, ErrRepoScanQueueFull) {
+				c.JSON(http.StatusTooManyRequests, gin.H{"error": "repo scan queue is full"})
+				return
+			}
+			logger.Error("enqueue repo scan", telemetry.ZapError(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to enqueue repo scan"})
 			return
 		}
 
 		c.JSON(http.StatusAccepted, gin.H{
-			"repo_scan": result.RepoScan,
-			"result":    result.Result,
+			"repo_scan": record,
 		})
 	})
 

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -295,6 +295,15 @@ func TestRouterRunsScanAndListsData(t *testing.T) {
 	if postBody2.Scan.ID == "" {
 		t.Fatal("expected second scan id in post response")
 	}
+	for i := 0; i < 2; i++ {
+		processed, err := svc.ProcessNextQueuedScan(context.Background())
+		if err != nil {
+			t.Fatalf("process queued scan: %v", err)
+		}
+		if !processed {
+			t.Fatalf("expected queued scan %d to be processed", i+1)
+		}
+	}
 
 	findingsReq := httptest.NewRequest(http.MethodGet, "/v1/findings", nil)
 	findingsW := httptest.NewRecorder()
@@ -425,6 +434,13 @@ func TestRouterRunsScanAndListsData(t *testing.T) {
 	r.ServeHTTP(repoW, repoReq)
 	if repoW.Code != http.StatusAccepted {
 		t.Fatalf("expected repo scan 202, got %d", repoW.Code)
+	}
+	processedRepo, processRepoErr := svc.ProcessNextQueuedRepoScan(context.Background())
+	if processRepoErr != nil {
+		t.Fatalf("process queued repo scan: %v", processRepoErr)
+	}
+	if !processedRepo {
+		t.Fatal("expected queued repo scan to be processed")
 	}
 
 	repoScansReq := httptest.NewRequest(http.MethodGet, "/v1/repo-scans", nil)
@@ -565,7 +581,7 @@ func TestRouterUnavailableWhenServiceMissing(t *testing.T) {
 	}
 }
 
-func TestRouterScanConflictWhenLocked(t *testing.T) {
+func TestRouterScanEnqueueSucceedsWhenExecutionLockIsHeld(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	metrics := telemetry.NewMetrics()
 	store := db.NewMemoryStore()
@@ -584,12 +600,12 @@ func TestRouterScanConflictWhenLocked(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	if w.Code != http.StatusConflict {
-		t.Fatalf("expected status 409, got %d", w.Code)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected status 202, got %d", w.Code)
 	}
 }
 
-func TestRouterRepoScanConflictWhenLocked(t *testing.T) {
+func TestRouterRepoScanEnqueueSucceedsWhenExecutionLockIsHeld(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	metrics := telemetry.NewMetrics()
 	store := db.NewMemoryStore()
@@ -609,8 +625,65 @@ func TestRouterRepoScanConflictWhenLocked(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	if w.Code != http.StatusConflict {
-		t.Fatalf("expected status 409, got %d", w.Code)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected status 202, got %d", w.Code)
+	}
+}
+
+func TestRouterScanQueueBackpressure(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+	svc.ScanQueueMaxPending = 1
+	r := NewRouter(logger, metrics, svc, RouterOptions{})
+
+	firstReq := httptest.NewRequest(http.MethodPost, "/v1/scans", nil)
+	firstW := httptest.NewRecorder()
+	r.ServeHTTP(firstW, firstReq)
+	if firstW.Code != http.StatusAccepted {
+		t.Fatalf("expected first enqueue 202, got %d", firstW.Code)
+	}
+
+	secondReq := httptest.NewRequest(http.MethodPost, "/v1/scans", nil)
+	secondW := httptest.NewRecorder()
+	r.ServeHTTP(secondW, secondReq)
+	if secondW.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected queue backpressure 429, got %d", secondW.Code)
+	}
+}
+
+func TestRouterRepoScanQueueBackpressureAndDuplicateGuard(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+	svc.RepoScanAllowedTargets = []string{"owner/*"}
+	svc.RepoQueueMaxPending = 1
+	r := NewRouter(logger, metrics, svc, RouterOptions{})
+
+	firstReq := httptest.NewRequest(http.MethodPost, "/v1/repo-scans", bytes.NewBufferString(`{"repository":"owner/repo"}`))
+	firstReq.Header.Set("Content-Type", "application/json")
+	firstW := httptest.NewRecorder()
+	r.ServeHTTP(firstW, firstReq)
+	if firstW.Code != http.StatusAccepted {
+		t.Fatalf("expected first repo enqueue 202, got %d", firstW.Code)
+	}
+
+	dupReq := httptest.NewRequest(http.MethodPost, "/v1/repo-scans", bytes.NewBufferString(`{"repository":"owner/repo"}`))
+	dupReq.Header.Set("Content-Type", "application/json")
+	dupW := httptest.NewRecorder()
+	r.ServeHTTP(dupW, dupReq)
+	if dupW.Code != http.StatusConflict {
+		t.Fatalf("expected duplicate target conflict 409, got %d", dupW.Code)
+	}
+
+	otherReq := httptest.NewRequest(http.MethodPost, "/v1/repo-scans", bytes.NewBufferString(`{"repository":"owner/another"}`))
+	otherReq.Header.Set("Content-Type", "application/json")
+	otherW := httptest.NewRecorder()
+	r.ServeHTTP(otherW, otherReq)
+	if otherW.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected repo queue backpressure 429, got %d", otherW.Code)
 	}
 }
 

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -22,6 +22,8 @@ const (
 	defaultRepoScanMaxFindings  = 200
 	defaultRepoScanHistoryMax   = 5000
 	defaultRepoScanFindingsMax  = 1000
+	defaultScanQueueMaxPending  = 25
+	defaultRepoQueueMaxPending  = 100
 	maxSourceErrorsInEvent      = 25
 )
 
@@ -63,6 +65,8 @@ type Service struct {
 	RepoScanMaxHistoryLimit     int
 	RepoScanMaxFindingsLimit    int
 	RepoScanAllowedTargets      []string
+	ScanQueueMaxPending         int
+	RepoQueueMaxPending         int
 	RepoScannerFactory          RepoScannerFactory
 }
 
@@ -135,6 +139,9 @@ type OwnershipFilter struct {
 // ErrScanInProgress is returned when a scan for the same provider is already running.
 var ErrScanInProgress = errors.New("scan already in progress")
 
+// ErrScanQueueFull is returned when queued scan requests exceed configured capacity.
+var ErrScanQueueFull = errors.New("scan queue is full")
+
 // ErrInvalidScanDiffBaseline is returned when previous_scan_id is incompatible.
 var ErrInvalidScanDiffBaseline = errors.New("invalid scan diff baseline")
 
@@ -149,6 +156,9 @@ var ErrInvalidRepoScanRequest = errors.New("invalid repo scan request")
 
 // ErrRepoScanInProgress is returned when the same repository scan target is already running.
 var ErrRepoScanInProgress = errors.New("repo scan already in progress")
+
+// ErrRepoScanQueueFull is returned when queued repo scan requests exceed configured capacity.
+var ErrRepoScanQueueFull = errors.New("repo scan queue is full")
 
 // NewService creates an API service with defaults.
 func NewService(store db.Store, scanner ScannerRunner, provider string) *Service {
@@ -165,6 +175,8 @@ func NewService(store db.Store, scanner ScannerRunner, provider string) *Service
 		RepoScanDefaultMaxFindings:  defaultRepoScanMaxFindings,
 		RepoScanMaxHistoryLimit:     defaultRepoScanHistoryMax,
 		RepoScanMaxFindingsLimit:    defaultRepoScanFindingsMax,
+		ScanQueueMaxPending:         defaultScanQueueMaxPending,
+		RepoQueueMaxPending:         defaultRepoQueueMaxPending,
 		RepoScannerFactory: func(historyLimit int, maxFindings int) RepoScanExecutor {
 			return repoexposure.NewScanner(
 				nil,
@@ -173,6 +185,57 @@ func NewService(store db.Store, scanner ScannerRunner, provider string) *Service
 			)
 		},
 	}
+}
+
+// EnqueueScan stores one queued scan request for asynchronous worker execution.
+func (s *Service) EnqueueScan(ctx context.Context) (db.ScanRecord, error) {
+	maxPending := s.ScanQueueMaxPending
+	if maxPending <= 0 {
+		maxPending = defaultScanQueueMaxPending
+	}
+	queuedCount, err := s.Store.CountQueuedScans(ctx, s.Provider)
+	if err != nil {
+		return db.ScanRecord{}, fmt.Errorf("count queued scans: %w", err)
+	}
+	if queuedCount >= maxPending {
+		return db.ScanRecord{}, ErrScanQueueFull
+	}
+	record, err := s.Store.CreateQueuedScan(ctx, s.Provider, s.Now().UTC())
+	if err != nil {
+		return db.ScanRecord{}, fmt.Errorf("enqueue scan: %w", err)
+	}
+	s.appendScanLifecycleEvent(ctx, record.ID, scanLifecycleQueued, map[string]any{"provider": s.Provider})
+	s.appendScanEvent(ctx, record.ID, db.ScanEventLevelInfo, "scan queued for worker execution", map[string]any{
+		"provider":    s.Provider,
+		"queue_depth": queuedCount + 1,
+		"queue_limit": maxPending,
+	})
+	return record, nil
+}
+
+// ProcessNextQueuedScan claims and executes one queued scan. It returns false when no job is available.
+func (s *Service) ProcessNextQueuedScan(ctx context.Context) (bool, error) {
+	if s.Locker != nil {
+		release, ok := s.Locker.TryAcquire(s.lockKey("scan:" + s.Provider))
+		if !ok {
+			return false, nil
+		}
+		defer release()
+	}
+	record, err := s.Store.ClaimNextQueuedScan(ctx, s.Provider)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return false, nil
+		}
+		return false, fmt.Errorf("claim queued scan: %w", err)
+	}
+	s.appendScanLifecycleEvent(ctx, record.ID, scanLifecycleRunning, map[string]any{"provider": record.Provider})
+	s.appendScanEvent(ctx, record.ID, db.ScanEventLevelInfo, "queued scan started", map[string]any{"provider": record.Provider})
+	_, runErr := s.runScanWithRecord(ctx, record)
+	if runErr != nil {
+		return true, runErr
+	}
+	return true, nil
 }
 
 // RunScan executes one scan and persists metadata + findings.
@@ -184,16 +247,17 @@ func (s *Service) RunScan(ctx context.Context) (RunScanResult, error) {
 		}
 		defer release()
 	}
-
-	started := s.Now().UTC()
-	record, err := s.Store.CreateScan(ctx, s.Provider, started)
+	record, err := s.Store.CreateScan(ctx, s.Provider, s.Now().UTC())
 	if err != nil {
 		return RunScanResult{}, err
 	}
 	s.appendScanLifecycleEvent(ctx, record.ID, scanLifecycleQueued, map[string]any{"provider": s.Provider})
 	s.appendScanLifecycleEvent(ctx, record.ID, scanLifecycleRunning, map[string]any{"provider": s.Provider})
 	s.appendScanEvent(ctx, record.ID, db.ScanEventLevelInfo, "scan started", map[string]any{"provider": s.Provider})
+	return s.runScanWithRecord(ctx, record)
+}
 
+func (s *Service) runScanWithRecord(ctx context.Context, record db.ScanRecord) (RunScanResult, error) {
 	result, err := s.Scanner.Run(ctx)
 	if err != nil {
 		s.appendScanLifecycleEvent(ctx, record.ID, scanLifecycleFailed, map[string]any{"error": err.Error()})
@@ -248,8 +312,12 @@ func (s *Service) RunScan(ctx context.Context) (RunScanResult, error) {
 		"partial_source_run": len(result.SourceErrors) > 0,
 	})
 	s.appendScanEvent(ctx, record.ID, db.ScanEventLevelInfo, "scan completed", map[string]any{"assets": result.Assets, "findings": len(result.Findings)})
+	provider := strings.TrimSpace(record.Provider)
+	if provider == "" {
+		provider = s.Provider
+	}
 	if s.Alerter != nil {
-		if alertErr := s.Alerter.NotifyScan(ctx, s.Provider, record, result.Findings); alertErr != nil && s.OnAlertError != nil {
+		if alertErr := s.Alerter.NotifyScan(ctx, provider, record, result.Findings); alertErr != nil && s.OnAlertError != nil {
 			s.OnAlertError(alertErr)
 		}
 	}
@@ -276,20 +344,75 @@ func (s *Service) RunRepoScan(ctx context.Context, request RepoScanRequest) (rep
 	return runResult.Result, nil
 }
 
+// EnqueueRepoScan stores one queued repository scan request for asynchronous worker execution.
+func (s *Service) EnqueueRepoScan(ctx context.Context, request RepoScanRequest) (db.RepoScanRecord, error) {
+	target, historyLimit, maxFindings, err := s.validateRepoScanRequest(request)
+	if err != nil {
+		return db.RepoScanRecord{}, err
+	}
+	pendingForTarget, err := s.Store.CountPendingRepoScansByRepository(ctx, target)
+	if err != nil {
+		return db.RepoScanRecord{}, fmt.Errorf("count pending repo scans for target: %w", err)
+	}
+	if pendingForTarget > 0 {
+		return db.RepoScanRecord{}, ErrRepoScanInProgress
+	}
+	maxPending := s.RepoQueueMaxPending
+	if maxPending <= 0 {
+		maxPending = defaultRepoQueueMaxPending
+	}
+	queuedCount, err := s.Store.CountQueuedRepoScans(ctx)
+	if err != nil {
+		return db.RepoScanRecord{}, fmt.Errorf("count queued repo scans: %w", err)
+	}
+	if queuedCount >= maxPending {
+		return db.RepoScanRecord{}, ErrRepoScanQueueFull
+	}
+	record, err := s.Store.CreateQueuedRepoScan(ctx, target, historyLimit, maxFindings, s.Now().UTC())
+	if err != nil {
+		return db.RepoScanRecord{}, fmt.Errorf("enqueue repo scan: %w", err)
+	}
+	return record, nil
+}
+
+// ProcessNextQueuedRepoScan claims and executes one queued repository scan. It returns false when no job is available.
+func (s *Service) ProcessNextQueuedRepoScan(ctx context.Context) (bool, error) {
+	record, err := s.Store.ClaimNextQueuedRepoScan(ctx)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return false, nil
+		}
+		return false, fmt.Errorf("claim queued repo scan: %w", err)
+	}
+	requeue := false
+	if s.Locker != nil {
+		release, ok := s.Locker.TryAcquire(s.lockKey("repo-scan:" + strings.ToLower(record.Repository)))
+		if !ok {
+			requeue = true
+		} else {
+			defer release()
+		}
+	}
+	if requeue {
+		if requeueErr := s.Store.RequeueRepoScan(ctx, record.ID); requeueErr != nil && !errors.Is(requeueErr, db.ErrNotFound) {
+			return false, fmt.Errorf("requeue repo scan: %w", requeueErr)
+		}
+		// A queued item was handled (requeued) even if this target is currently locked.
+		// Returning true lets the worker keep draining other queued targets in the same tick.
+		return true, nil
+	}
+	_, runErr := s.runRepoScanWithRecord(ctx, record, record.HistoryLimit, record.MaxFindings)
+	if runErr != nil {
+		return true, runErr
+	}
+	return true, nil
+}
+
 // RunRepoScanPersisted runs one repository scan and persists repo scan metadata + findings.
 func (s *Service) RunRepoScanPersisted(ctx context.Context, request RepoScanRequest) (RunRepoScanResult, error) {
-	if !s.RepoScanEnabled {
-		return RunRepoScanResult{}, ErrRepoScanDisabled
-	}
-	target := strings.TrimSpace(request.Repository)
-	if target == "" {
-		return RunRepoScanResult{}, ErrInvalidRepoScanRequest
-	}
-	if repoexposure.IsLocalRepositoryTarget(target) {
-		return RunRepoScanResult{}, ErrRepoTargetNotAllowed
-	}
-	if !repoTargetAllowed(target, s.RepoScanAllowedTargets) {
-		return RunRepoScanResult{}, ErrRepoTargetNotAllowed
+	target, historyLimit, maxFindings, err := s.validateRepoScanRequest(request)
+	if err != nil {
+		return RunRepoScanResult{}, err
 	}
 	if s.Locker != nil {
 		release, ok := s.Locker.TryAcquire(s.lockKey("repo-scan:" + strings.ToLower(target)))
@@ -298,24 +421,57 @@ func (s *Service) RunRepoScanPersisted(ctx context.Context, request RepoScanRequ
 		}
 		defer release()
 	}
+	record, err := s.Store.CreateRepoScan(ctx, target, s.Now().UTC())
+	if err != nil {
+		return RunRepoScanResult{}, fmt.Errorf("create repo scan: %w", err)
+	}
+	return s.runRepoScanWithRecord(ctx, record, historyLimit, maxFindings)
+}
+
+func (s *Service) validateRepoScanRequest(request RepoScanRequest) (string, int, int, error) {
+	if !s.RepoScanEnabled {
+		return "", 0, 0, ErrRepoScanDisabled
+	}
+	target := strings.TrimSpace(request.Repository)
+	if target == "" {
+		return "", 0, 0, ErrInvalidRepoScanRequest
+	}
+	if repoexposure.IsLocalRepositoryTarget(target) {
+		return "", 0, 0, ErrRepoTargetNotAllowed
+	}
+	if !repoTargetAllowed(target, s.RepoScanAllowedTargets) {
+		return "", 0, 0, ErrRepoTargetNotAllowed
+	}
 	historyLimit, err := sanitizeRepoScanLimit(request.HistoryLimit, s.RepoScanDefaultHistoryLimit, s.RepoScanMaxHistoryLimit)
 	if err != nil {
-		return RunRepoScanResult{}, ErrInvalidRepoScanRequest
+		return "", 0, 0, ErrInvalidRepoScanRequest
 	}
 	maxFindings, err := sanitizeRepoScanLimit(request.MaxFindings, s.RepoScanDefaultMaxFindings, s.RepoScanMaxFindingsLimit)
 	if err != nil {
+		return "", 0, 0, ErrInvalidRepoScanRequest
+	}
+	return target, historyLimit, maxFindings, nil
+}
+
+func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanRecord, historyLimit int, maxFindings int) (RunRepoScanResult, error) {
+	target := strings.TrimSpace(record.Repository)
+	if target == "" {
+		return RunRepoScanResult{}, ErrInvalidRepoScanRequest
+	}
+	normalizedHistory, err := sanitizeRepoScanLimit(historyLimit, s.RepoScanDefaultHistoryLimit, s.RepoScanMaxHistoryLimit)
+	if err != nil {
+		_ = s.Store.CompleteRepoScan(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, ErrInvalidRepoScanRequest.Error())
+		return RunRepoScanResult{}, ErrInvalidRepoScanRequest
+	}
+	normalizedMaxFindings, err := sanitizeRepoScanLimit(maxFindings, s.RepoScanDefaultMaxFindings, s.RepoScanMaxFindingsLimit)
+	if err != nil {
+		_ = s.Store.CompleteRepoScan(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, ErrInvalidRepoScanRequest.Error())
 		return RunRepoScanResult{}, ErrInvalidRepoScanRequest
 	}
 	if s.RepoScannerFactory == nil {
 		return RunRepoScanResult{}, fmt.Errorf("repo scanner factory is not configured")
 	}
-
-	started := s.Now().UTC()
-	record, err := s.Store.CreateRepoScan(ctx, target, started)
-	if err != nil {
-		return RunRepoScanResult{}, fmt.Errorf("create repo scan: %w", err)
-	}
-	result, err := s.RepoScannerFactory(historyLimit, maxFindings).ScanRepository(ctx, target)
+	result, err := s.RepoScannerFactory(normalizedHistory, normalizedMaxFindings).ScanRepository(ctx, target)
 	if err != nil {
 		_ = s.Store.CompleteRepoScan(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, err.Error())
 		return RunRepoScanResult{}, err
@@ -345,6 +501,8 @@ func (s *Service) RunRepoScanPersisted(ctx context.Context, request RepoScanRequ
 	record.FilesScanned = result.FilesScanned
 	record.FindingCount = len(result.Findings)
 	record.Truncated = result.Truncated
+	record.HistoryLimit = normalizedHistory
+	record.MaxFindings = normalizedMaxFindings
 	return RunRepoScanResult{RepoScan: record, Result: result}, nil
 }
 

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -1023,6 +1023,9 @@ func TestServiceEnqueueRepoScanGuards(t *testing.T) {
 	if _, err := svc.EnqueueRepoScan(context.Background(), RepoScanRequest{Repository: "owner/repo"}); !errors.Is(err, ErrRepoScanInProgress) {
 		t.Fatalf("expected repo in-progress error for duplicate target, got %v", err)
 	}
+	if _, err := svc.EnqueueRepoScan(context.Background(), RepoScanRequest{Repository: "Owner/Repo"}); !errors.Is(err, ErrRepoScanInProgress) {
+		t.Fatalf("expected repo in-progress error for case-variant duplicate target, got %v", err)
+	}
 	if _, err := svc.EnqueueRepoScan(context.Background(), RepoScanRequest{Repository: "owner/another"}); !errors.Is(err, ErrRepoScanQueueFull) {
 		t.Fatalf("expected repo queue full error, got %v", err)
 	}

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -873,6 +873,268 @@ func TestServiceRunRepoScanPersistedScannerError(t *testing.T) {
 	}
 }
 
+func TestServiceEnqueueScanAndProcessQueue(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 3, 20, 8, 0, 0, 0, time.UTC)
+	svc := NewService(store, fakeScanner{result: app.ScanResult{
+		Assets:   2,
+		Findings: []domain.Finding{{ID: "f-1", Type: domain.FindingOwnerless, Severity: domain.SeverityHigh, CreatedAt: now}},
+	}}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	record, err := svc.EnqueueScan(context.Background())
+	if err != nil {
+		t.Fatalf("enqueue scan: %v", err)
+	}
+	if record.Status != "queued" {
+		t.Fatalf("expected queued status, got %q", record.Status)
+	}
+	processed, err := svc.ProcessNextQueuedScan(context.Background())
+	if err != nil {
+		t.Fatalf("process queued scan: %v", err)
+	}
+	if !processed {
+		t.Fatal("expected one queued scan to be processed")
+	}
+	scan, err := store.GetScan(context.Background(), record.ID)
+	if err != nil {
+		t.Fatalf("get scan: %v", err)
+	}
+	if scan.Status != "completed" || scan.FindingCount != 1 {
+		t.Fatalf("unexpected processed scan record: %+v", scan)
+	}
+	processed, err = svc.ProcessNextQueuedScan(context.Background())
+	if err != nil {
+		t.Fatalf("process queued scan again: %v", err)
+	}
+	if processed {
+		t.Fatal("expected no more queued scans")
+	}
+}
+
+func TestServiceEnqueueScanQueueFull(t *testing.T) {
+	svc := NewService(db.NewMemoryStore(), fakeScanner{}, "aws")
+	svc.ScanQueueMaxPending = 1
+	if _, err := svc.EnqueueScan(context.Background()); err != nil {
+		t.Fatalf("enqueue first scan: %v", err)
+	}
+	if _, err := svc.EnqueueScan(context.Background()); !errors.Is(err, ErrScanQueueFull) {
+		t.Fatalf("expected scan queue full error, got %v", err)
+	}
+}
+
+func TestServiceQueuedScanBurstProcessing(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 3, 20, 8, 15, 0, 0, time.UTC)
+	svc := NewService(store, fakeScanner{result: app.ScanResult{
+		Assets:   1,
+		Findings: []domain.Finding{{ID: "f-burst", Type: domain.FindingOwnerless, Severity: domain.SeverityLow, CreatedAt: now}},
+	}}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.ScanQueueMaxPending = 100
+
+	const queued = 40
+	for i := 0; i < queued; i++ {
+		if _, err := svc.EnqueueScan(context.Background()); err != nil {
+			t.Fatalf("enqueue burst scan %d: %v", i, err)
+		}
+	}
+	processedCount := 0
+	for {
+		processed, err := svc.ProcessNextQueuedScan(context.Background())
+		if err != nil {
+			t.Fatalf("process burst queue: %v", err)
+		}
+		if !processed {
+			break
+		}
+		processedCount++
+	}
+	if processedCount != queued {
+		t.Fatalf("expected %d processed scans, got %d", queued, processedCount)
+	}
+	scans, err := store.ListScans(context.Background(), 1000)
+	if err != nil {
+		t.Fatalf("list scans: %v", err)
+	}
+	if len(scans) != queued {
+		t.Fatalf("expected %d persisted scans, got %d", queued, len(scans))
+	}
+	for _, scan := range scans {
+		if scan.Status != "completed" {
+			t.Fatalf("expected completed scan status, got %q", scan.Status)
+		}
+	}
+}
+
+func TestServiceEnqueueRepoScanAndProcessQueue(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.RepoScanAllowedTargets = []string{"owner/*"}
+	svc.RepoQueueMaxPending = 2
+	svc.RepoScannerFactory = func(historyLimit int, maxFindings int) RepoScanExecutor {
+		return &fakeRepoExecutor{
+			result: repoexposure.ScanResult{
+				Repository:     "owner/repo",
+				CommitsScanned: historyLimit,
+				FilesScanned:   6,
+				Findings: []domain.Finding{
+					{ID: "rf-queued", Type: domain.FindingSecretExposure, Severity: domain.SeverityHigh, CreatedAt: time.Now().UTC()},
+				},
+				Truncated: false,
+			},
+		}
+	}
+	record, err := svc.EnqueueRepoScan(context.Background(), RepoScanRequest{
+		Repository:   "owner/repo",
+		HistoryLimit: 25,
+		MaxFindings:  30,
+	})
+	if err != nil {
+		t.Fatalf("enqueue repo scan: %v", err)
+	}
+	if record.Status != "queued" {
+		t.Fatalf("expected queued repo scan status, got %q", record.Status)
+	}
+	processed, err := svc.ProcessNextQueuedRepoScan(context.Background())
+	if err != nil {
+		t.Fatalf("process queued repo scan: %v", err)
+	}
+	if !processed {
+		t.Fatal("expected queued repo scan to be processed")
+	}
+	stored, err := svc.GetRepoScan(context.Background(), record.ID)
+	if err != nil {
+		t.Fatalf("get repo scan: %v", err)
+	}
+	if stored.Status != "completed" || stored.CommitsScanned != 25 {
+		t.Fatalf("unexpected processed repo scan record: %+v", stored)
+	}
+}
+
+func TestServiceEnqueueRepoScanGuards(t *testing.T) {
+	svc := NewService(db.NewMemoryStore(), fakeScanner{}, "aws")
+	svc.RepoScanAllowedTargets = []string{"owner/*"}
+	svc.RepoQueueMaxPending = 1
+
+	if _, err := svc.EnqueueRepoScan(context.Background(), RepoScanRequest{Repository: "owner/repo"}); err != nil {
+		t.Fatalf("enqueue first repo scan: %v", err)
+	}
+	if _, err := svc.EnqueueRepoScan(context.Background(), RepoScanRequest{Repository: "owner/repo"}); !errors.Is(err, ErrRepoScanInProgress) {
+		t.Fatalf("expected repo in-progress error for duplicate target, got %v", err)
+	}
+	if _, err := svc.EnqueueRepoScan(context.Background(), RepoScanRequest{Repository: "owner/another"}); !errors.Is(err, ErrRepoScanQueueFull) {
+		t.Fatalf("expected repo queue full error, got %v", err)
+	}
+}
+
+func TestServiceProcessQueuedRepoScanRequeuesWhenExecutionLockHeld(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.RepoScanAllowedTargets = []string{"owner/*"}
+	queuedAt := time.Date(2026, 3, 24, 10, 0, 0, 0, time.UTC)
+	svc.Now = func() time.Time { return queuedAt }
+
+	record, err := svc.EnqueueRepoScan(context.Background(), RepoScanRequest{Repository: "owner/repo"})
+	if err != nil {
+		t.Fatalf("enqueue repo scan: %v", err)
+	}
+	locker := scheduler.NewInMemoryLocker()
+	release, ok := locker.TryAcquire("identrail:repo-scan:owner/repo")
+	if !ok {
+		t.Fatal("expected lock acquire")
+	}
+	defer release()
+	svc.Locker = locker
+
+	processed, err := svc.ProcessNextQueuedRepoScan(context.Background())
+	if err != nil {
+		t.Fatalf("process queued repo scan: %v", err)
+	}
+	if !processed {
+		t.Fatal("expected requeue handling to count as queue progress")
+	}
+	stored, err := svc.GetRepoScan(context.Background(), record.ID)
+	if err != nil {
+		t.Fatalf("get repo scan: %v", err)
+	}
+	if stored.Status != "queued" {
+		t.Fatalf("expected repo scan to be requeued, got status %q", stored.Status)
+	}
+	if !stored.StartedAt.After(queuedAt) {
+		t.Fatalf("expected requeued repo scan to move to the back of the queue")
+	}
+}
+
+func TestServiceProcessQueuedRepoScanContinuesToNextTargetAfterRequeue(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.RepoScanAllowedTargets = []string{"owner/*"}
+	now := time.Date(2026, 3, 24, 11, 0, 0, 0, time.UTC)
+	svc.Now = func() time.Time { return now }
+	svc.RepoScannerFactory = func(historyLimit int, maxFindings int) RepoScanExecutor {
+		return &fakeRepoExecutor{
+			result: repoexposure.ScanResult{
+				Repository:     "owner/repo-b",
+				CommitsScanned: historyLimit,
+				FilesScanned:   2,
+				Findings: []domain.Finding{
+					{ID: "rf-next", Type: domain.FindingSecretExposure, Severity: domain.SeverityHigh, CreatedAt: now},
+				},
+			},
+		}
+	}
+
+	repoA, err := svc.EnqueueRepoScan(context.Background(), RepoScanRequest{Repository: "owner/repo-a"})
+	if err != nil {
+		t.Fatalf("enqueue repo-a scan: %v", err)
+	}
+	repoB, err := svc.EnqueueRepoScan(context.Background(), RepoScanRequest{Repository: "owner/repo-b"})
+	if err != nil {
+		t.Fatalf("enqueue repo-b scan: %v", err)
+	}
+
+	locker := scheduler.NewInMemoryLocker()
+	release, ok := locker.TryAcquire("identrail:repo-scan:owner/repo-a")
+	if !ok {
+		t.Fatal("expected lock acquire")
+	}
+	defer release()
+	svc.Locker = locker
+
+	processed, err := svc.ProcessNextQueuedRepoScan(context.Background())
+	if err != nil {
+		t.Fatalf("first queue process failed: %v", err)
+	}
+	if !processed {
+		t.Fatal("expected first queue pass to requeue locked target")
+	}
+
+	processed, err = svc.ProcessNextQueuedRepoScan(context.Background())
+	if err != nil {
+		t.Fatalf("second queue process failed: %v", err)
+	}
+	if !processed {
+		t.Fatal("expected second queue pass to process next target")
+	}
+
+	repoARecord, err := svc.GetRepoScan(context.Background(), repoA.ID)
+	if err != nil {
+		t.Fatalf("get repo-a scan: %v", err)
+	}
+	if repoARecord.Status != "queued" {
+		t.Fatalf("expected repo-a to remain queued while lock is held, got %q", repoARecord.Status)
+	}
+
+	repoBRecord, err := svc.GetRepoScan(context.Background(), repoB.ID)
+	if err != nil {
+		t.Fatalf("get repo-b scan: %v", err)
+	}
+	if repoBRecord.Status != "completed" {
+		t.Fatalf("expected repo-b to complete, got %q", repoBRecord.Status)
+	}
+}
+
 func TestRepoTargetAllowed(t *testing.T) {
 	if repoTargetAllowed("owner/repo", nil) {
 		t.Fatal("expected empty allowlist to deny target")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,9 +24,14 @@ const (
 	defaultRepoScanMaxFindings         = 200
 	defaultRepoScanHistoryLimitMax     = 5000
 	defaultRepoScanMaxFindingsLimitMax = 1000
+	defaultScanQueueMaxPending         = 25
+	defaultRepoQueueMaxPending         = 100
 	defaultWorkerRepoScanEnabled       = false
 	defaultWorkerRepoScanRunNow        = false
 	defaultWorkerRepoScanInterval      = 1 * time.Hour
+	defaultWorkerAPIJobQueueEnabled    = true
+	defaultWorkerAPIJobQueueInterval   = 2 * time.Second
+	defaultWorkerAPIJobQueueBatchSize  = 5
 	defaultLockBackend                 = "auto"
 	defaultLockNamespace               = "identrail"
 	defaultOIDCWriteScopes             = "identrail.write,identrail.admin,write,admin"
@@ -35,119 +40,129 @@ const (
 // Config centralizes process-level configuration. It keeps module wiring simple
 // and deterministic for API, worker, and CLI binaries.
 type Config struct {
-	HTTPAddr                 string
-	LogLevel                 string
-	Provider                 string
-	ServiceName              string
-	TrustedProxies           []string
-	CORSAllowedOrigins       []string
-	DatabaseURL              string
-	AWSSource                string
-	AWSRegion                string
-	AWSProfile               string
-	AWSFixturePath           []string
-	KubernetesFixturePath    []string
-	KubernetesSource         string
-	KubectlPath              string
-	KubeContext              string
-	ScanInterval             time.Duration
-	WorkerRunNow             bool
-	APIKeys                  []string
-	WriteAPIKeys             []string
-	APIKeyScopes             map[string][]string
-	RateLimitRPM             int
-	RateLimitBurst           int
-	RunMigrations            bool
-	MigrationsDir            string
-	AuditLogFile             string
-	AuditForwardURL          string
-	AuditForwardTimeout      time.Duration
-	AuditForwardMaxRetries   int
-	AuditForwardRetryBackoff time.Duration
-	AuditForwardHMACSecret   string
-	AlertWebhookURL          string
-	AlertMinSeverity         string
-	AlertTimeout             time.Duration
-	AlertHMACSecret          string
-	AlertMaxFindings         int
-	AlertMaxRetries          int
-	AlertRetryBackoff        time.Duration
-	RepoScanEnabled          bool
-	RepoScanHistoryLimit     int
-	RepoScanMaxFindings      int
-	RepoScanHistoryLimitMax  int
-	RepoScanMaxFindingsMax   int
-	RepoScanAllowlist        []string
-	WorkerRepoScanEnabled    bool
-	WorkerRepoScanRunNow     bool
-	WorkerRepoScanInterval   time.Duration
-	WorkerRepoScanTargets    []string
-	WorkerRepoScanHistory    int
-	WorkerRepoScanFindings   int
-	LockBackend              string
-	LockNamespace            string
-	OIDCIssuerURL            string
-	OIDCAudience             string
-	OIDCWriteScopes          []string
+	HTTPAddr                   string
+	LogLevel                   string
+	Provider                   string
+	ServiceName                string
+	TrustedProxies             []string
+	CORSAllowedOrigins         []string
+	DatabaseURL                string
+	AWSSource                  string
+	AWSRegion                  string
+	AWSProfile                 string
+	AWSFixturePath             []string
+	KubernetesFixturePath      []string
+	KubernetesSource           string
+	KubectlPath                string
+	KubeContext                string
+	ScanInterval               time.Duration
+	WorkerRunNow               bool
+	APIKeys                    []string
+	WriteAPIKeys               []string
+	APIKeyScopes               map[string][]string
+	RateLimitRPM               int
+	RateLimitBurst             int
+	RunMigrations              bool
+	MigrationsDir              string
+	AuditLogFile               string
+	AuditForwardURL            string
+	AuditForwardTimeout        time.Duration
+	AuditForwardMaxRetries     int
+	AuditForwardRetryBackoff   time.Duration
+	AuditForwardHMACSecret     string
+	AlertWebhookURL            string
+	AlertMinSeverity           string
+	AlertTimeout               time.Duration
+	AlertHMACSecret            string
+	AlertMaxFindings           int
+	AlertMaxRetries            int
+	AlertRetryBackoff          time.Duration
+	RepoScanEnabled            bool
+	RepoScanHistoryLimit       int
+	RepoScanMaxFindings        int
+	RepoScanHistoryLimitMax    int
+	RepoScanMaxFindingsMax     int
+	RepoScanAllowlist          []string
+	ScanQueueMaxPending        int
+	RepoQueueMaxPending        int
+	WorkerRepoScanEnabled      bool
+	WorkerRepoScanRunNow       bool
+	WorkerRepoScanInterval     time.Duration
+	WorkerRepoScanTargets      []string
+	WorkerRepoScanHistory      int
+	WorkerRepoScanFindings     int
+	WorkerAPIJobQueueEnabled   bool
+	WorkerAPIJobQueueInterval  time.Duration
+	WorkerAPIJobQueueBatchSize int
+	LockBackend                string
+	LockNamespace              string
+	OIDCIssuerURL              string
+	OIDCAudience               string
+	OIDCWriteScopes            []string
 }
 
 // Load reads environment variables and applies safe defaults for local and CI use.
 func Load() Config {
 	return Config{
-		HTTPAddr:                 getEnv("IDENTRAIL_HTTP_ADDR", defaultHTTPAddr),
-		LogLevel:                 strings.ToLower(getEnv("IDENTRAIL_LOG_LEVEL", defaultLogLevel)),
-		Provider:                 strings.ToLower(getEnv("IDENTRAIL_PROVIDER", defaultProvider)),
-		ServiceName:              getEnv("IDENTRAIL_SERVICE_NAME", defaultServiceName),
-		TrustedProxies:           parseCommaSeparated(getEnv("IDENTRAIL_TRUSTED_PROXIES", "")),
-		CORSAllowedOrigins:       parseCommaSeparated(getEnv("IDENTRAIL_CORS_ALLOWED_ORIGINS", "")),
-		DatabaseURL:              getEnv("IDENTRAIL_DATABASE_URL", ""),
-		AWSSource:                strings.ToLower(getEnv("IDENTRAIL_AWS_SOURCE", defaultAWSSource)),
-		AWSRegion:                getEnv("IDENTRAIL_AWS_REGION", defaultAWSRegion),
-		AWSProfile:               getEnv("IDENTRAIL_AWS_PROFILE", ""),
-		AWSFixturePath:           parseCommaSeparated(getEnv("IDENTRAIL_AWS_FIXTURES", defaultAWSFixtures)),
-		KubernetesFixturePath:    parseCommaSeparated(getEnv("IDENTRAIL_K8S_FIXTURES", defaultK8sFixtures)),
-		KubernetesSource:         strings.ToLower(getEnv("IDENTRAIL_K8S_SOURCE", defaultK8sSource)),
-		KubectlPath:              getEnv("IDENTRAIL_KUBECTL_PATH", defaultKubectlPath),
-		KubeContext:              getEnv("IDENTRAIL_KUBE_CONTEXT", ""),
-		ScanInterval:             parseDuration(getEnv("IDENTRAIL_SCAN_INTERVAL", defaultScanInterval.String()), defaultScanInterval),
-		WorkerRunNow:             parseBool(getEnv("IDENTRAIL_WORKER_RUN_NOW", "true"), true),
-		APIKeys:                  parseCommaSeparated(getEnv("IDENTRAIL_API_KEYS", "")),
-		WriteAPIKeys:             parseCommaSeparated(getEnv("IDENTRAIL_WRITE_API_KEYS", "")),
-		APIKeyScopes:             parseKeyScopes(getEnv("IDENTRAIL_API_KEY_SCOPES", "")),
-		RateLimitRPM:             parseInt(getEnv("IDENTRAIL_RATE_LIMIT_RPM", "120"), 120),
-		RateLimitBurst:           parseInt(getEnv("IDENTRAIL_RATE_LIMIT_BURST", "20"), 20),
-		RunMigrations:            parseBool(getEnv("IDENTRAIL_RUN_MIGRATIONS", "true"), true),
-		MigrationsDir:            getEnv("IDENTRAIL_MIGRATIONS_DIR", "migrations"),
-		AuditLogFile:             getEnv("IDENTRAIL_AUDIT_LOG_FILE", ""),
-		AuditForwardURL:          getEnv("IDENTRAIL_AUDIT_FORWARD_URL", ""),
-		AuditForwardTimeout:      parseDuration(getEnv("IDENTRAIL_AUDIT_FORWARD_TIMEOUT", "3s"), 3*time.Second),
-		AuditForwardMaxRetries:   parseInt(getEnv("IDENTRAIL_AUDIT_FORWARD_MAX_RETRIES", "1"), 1),
-		AuditForwardRetryBackoff: parseDuration(getEnv("IDENTRAIL_AUDIT_FORWARD_RETRY_BACKOFF", "1s"), 1*time.Second),
-		AuditForwardHMACSecret:   getEnv("IDENTRAIL_AUDIT_FORWARD_HMAC_SECRET", ""),
-		AlertWebhookURL:          getEnv("IDENTRAIL_ALERT_WEBHOOK_URL", ""),
-		AlertMinSeverity:         strings.ToLower(getEnv("IDENTRAIL_ALERT_MIN_SEVERITY", "high")),
-		AlertTimeout:             parseDuration(getEnv("IDENTRAIL_ALERT_TIMEOUT", "5s"), 5*time.Second),
-		AlertHMACSecret:          getEnv("IDENTRAIL_ALERT_HMAC_SECRET", ""),
-		AlertMaxFindings:         parseInt(getEnv("IDENTRAIL_ALERT_MAX_FINDINGS", "25"), 25),
-		AlertMaxRetries:          parseInt(getEnv("IDENTRAIL_ALERT_MAX_RETRIES", "2"), 2),
-		AlertRetryBackoff:        parseDuration(getEnv("IDENTRAIL_ALERT_RETRY_BACKOFF", "1s"), 1*time.Second),
-		RepoScanEnabled:          parseBool(getEnv("IDENTRAIL_REPO_SCAN_ENABLED", "false"), defaultRepoScanEnabled),
-		RepoScanHistoryLimit:     parseInt(getEnv("IDENTRAIL_REPO_SCAN_HISTORY_LIMIT", "500"), defaultRepoScanHistoryLimit),
-		RepoScanMaxFindings:      parseInt(getEnv("IDENTRAIL_REPO_SCAN_MAX_FINDINGS", "200"), defaultRepoScanMaxFindings),
-		RepoScanHistoryLimitMax:  parseInt(getEnv("IDENTRAIL_REPO_SCAN_HISTORY_LIMIT_MAX", "5000"), defaultRepoScanHistoryLimitMax),
-		RepoScanMaxFindingsMax:   parseInt(getEnv("IDENTRAIL_REPO_SCAN_MAX_FINDINGS_MAX", "1000"), defaultRepoScanMaxFindingsLimitMax),
-		RepoScanAllowlist:        parseCommaSeparated(getEnv("IDENTRAIL_REPO_SCAN_ALLOWLIST", "")),
-		WorkerRepoScanEnabled:    parseBool(getEnv("IDENTRAIL_WORKER_REPO_SCAN_ENABLED", "false"), defaultWorkerRepoScanEnabled),
-		WorkerRepoScanRunNow:     parseBool(getEnv("IDENTRAIL_WORKER_REPO_SCAN_RUN_NOW", "false"), defaultWorkerRepoScanRunNow),
-		WorkerRepoScanInterval:   parseDuration(getEnv("IDENTRAIL_WORKER_REPO_SCAN_INTERVAL", defaultWorkerRepoScanInterval.String()), defaultWorkerRepoScanInterval),
-		WorkerRepoScanTargets:    parseCommaSeparated(getEnv("IDENTRAIL_WORKER_REPO_SCAN_TARGETS", "")),
-		WorkerRepoScanHistory:    parseInt(getEnv("IDENTRAIL_WORKER_REPO_SCAN_HISTORY_LIMIT", "0"), 0),
-		WorkerRepoScanFindings:   parseInt(getEnv("IDENTRAIL_WORKER_REPO_SCAN_MAX_FINDINGS", "0"), 0),
-		LockBackend:              strings.ToLower(getEnv("IDENTRAIL_LOCK_BACKEND", defaultLockBackend)),
-		LockNamespace:            getEnv("IDENTRAIL_LOCK_NAMESPACE", defaultLockNamespace),
-		OIDCIssuerURL:            getEnv("IDENTRAIL_OIDC_ISSUER_URL", ""),
-		OIDCAudience:             getEnv("IDENTRAIL_OIDC_AUDIENCE", ""),
-		OIDCWriteScopes:          parseCommaSeparated(getEnv("IDENTRAIL_OIDC_WRITE_SCOPES", defaultOIDCWriteScopes)),
+		HTTPAddr:                   getEnv("IDENTRAIL_HTTP_ADDR", defaultHTTPAddr),
+		LogLevel:                   strings.ToLower(getEnv("IDENTRAIL_LOG_LEVEL", defaultLogLevel)),
+		Provider:                   strings.ToLower(getEnv("IDENTRAIL_PROVIDER", defaultProvider)),
+		ServiceName:                getEnv("IDENTRAIL_SERVICE_NAME", defaultServiceName),
+		TrustedProxies:             parseCommaSeparated(getEnv("IDENTRAIL_TRUSTED_PROXIES", "")),
+		CORSAllowedOrigins:         parseCommaSeparated(getEnv("IDENTRAIL_CORS_ALLOWED_ORIGINS", "")),
+		DatabaseURL:                getEnv("IDENTRAIL_DATABASE_URL", ""),
+		AWSSource:                  strings.ToLower(getEnv("IDENTRAIL_AWS_SOURCE", defaultAWSSource)),
+		AWSRegion:                  getEnv("IDENTRAIL_AWS_REGION", defaultAWSRegion),
+		AWSProfile:                 getEnv("IDENTRAIL_AWS_PROFILE", ""),
+		AWSFixturePath:             parseCommaSeparated(getEnv("IDENTRAIL_AWS_FIXTURES", defaultAWSFixtures)),
+		KubernetesFixturePath:      parseCommaSeparated(getEnv("IDENTRAIL_K8S_FIXTURES", defaultK8sFixtures)),
+		KubernetesSource:           strings.ToLower(getEnv("IDENTRAIL_K8S_SOURCE", defaultK8sSource)),
+		KubectlPath:                getEnv("IDENTRAIL_KUBECTL_PATH", defaultKubectlPath),
+		KubeContext:                getEnv("IDENTRAIL_KUBE_CONTEXT", ""),
+		ScanInterval:               parseDuration(getEnv("IDENTRAIL_SCAN_INTERVAL", defaultScanInterval.String()), defaultScanInterval),
+		WorkerRunNow:               parseBool(getEnv("IDENTRAIL_WORKER_RUN_NOW", "true"), true),
+		APIKeys:                    parseCommaSeparated(getEnv("IDENTRAIL_API_KEYS", "")),
+		WriteAPIKeys:               parseCommaSeparated(getEnv("IDENTRAIL_WRITE_API_KEYS", "")),
+		APIKeyScopes:               parseKeyScopes(getEnv("IDENTRAIL_API_KEY_SCOPES", "")),
+		RateLimitRPM:               parseInt(getEnv("IDENTRAIL_RATE_LIMIT_RPM", "120"), 120),
+		RateLimitBurst:             parseInt(getEnv("IDENTRAIL_RATE_LIMIT_BURST", "20"), 20),
+		RunMigrations:              parseBool(getEnv("IDENTRAIL_RUN_MIGRATIONS", "true"), true),
+		MigrationsDir:              getEnv("IDENTRAIL_MIGRATIONS_DIR", "migrations"),
+		AuditLogFile:               getEnv("IDENTRAIL_AUDIT_LOG_FILE", ""),
+		AuditForwardURL:            getEnv("IDENTRAIL_AUDIT_FORWARD_URL", ""),
+		AuditForwardTimeout:        parseDuration(getEnv("IDENTRAIL_AUDIT_FORWARD_TIMEOUT", "3s"), 3*time.Second),
+		AuditForwardMaxRetries:     parseInt(getEnv("IDENTRAIL_AUDIT_FORWARD_MAX_RETRIES", "1"), 1),
+		AuditForwardRetryBackoff:   parseDuration(getEnv("IDENTRAIL_AUDIT_FORWARD_RETRY_BACKOFF", "1s"), 1*time.Second),
+		AuditForwardHMACSecret:     getEnv("IDENTRAIL_AUDIT_FORWARD_HMAC_SECRET", ""),
+		AlertWebhookURL:            getEnv("IDENTRAIL_ALERT_WEBHOOK_URL", ""),
+		AlertMinSeverity:           strings.ToLower(getEnv("IDENTRAIL_ALERT_MIN_SEVERITY", "high")),
+		AlertTimeout:               parseDuration(getEnv("IDENTRAIL_ALERT_TIMEOUT", "5s"), 5*time.Second),
+		AlertHMACSecret:            getEnv("IDENTRAIL_ALERT_HMAC_SECRET", ""),
+		AlertMaxFindings:           parseInt(getEnv("IDENTRAIL_ALERT_MAX_FINDINGS", "25"), 25),
+		AlertMaxRetries:            parseInt(getEnv("IDENTRAIL_ALERT_MAX_RETRIES", "2"), 2),
+		AlertRetryBackoff:          parseDuration(getEnv("IDENTRAIL_ALERT_RETRY_BACKOFF", "1s"), 1*time.Second),
+		RepoScanEnabled:            parseBool(getEnv("IDENTRAIL_REPO_SCAN_ENABLED", "false"), defaultRepoScanEnabled),
+		RepoScanHistoryLimit:       parseInt(getEnv("IDENTRAIL_REPO_SCAN_HISTORY_LIMIT", "500"), defaultRepoScanHistoryLimit),
+		RepoScanMaxFindings:        parseInt(getEnv("IDENTRAIL_REPO_SCAN_MAX_FINDINGS", "200"), defaultRepoScanMaxFindings),
+		RepoScanHistoryLimitMax:    parseInt(getEnv("IDENTRAIL_REPO_SCAN_HISTORY_LIMIT_MAX", "5000"), defaultRepoScanHistoryLimitMax),
+		RepoScanMaxFindingsMax:     parseInt(getEnv("IDENTRAIL_REPO_SCAN_MAX_FINDINGS_MAX", "1000"), defaultRepoScanMaxFindingsLimitMax),
+		RepoScanAllowlist:          parseCommaSeparated(getEnv("IDENTRAIL_REPO_SCAN_ALLOWLIST", "")),
+		ScanQueueMaxPending:        parseInt(getEnv("IDENTRAIL_SCAN_QUEUE_MAX_PENDING", "25"), defaultScanQueueMaxPending),
+		RepoQueueMaxPending:        parseInt(getEnv("IDENTRAIL_REPO_SCAN_QUEUE_MAX_PENDING", "100"), defaultRepoQueueMaxPending),
+		WorkerRepoScanEnabled:      parseBool(getEnv("IDENTRAIL_WORKER_REPO_SCAN_ENABLED", "false"), defaultWorkerRepoScanEnabled),
+		WorkerRepoScanRunNow:       parseBool(getEnv("IDENTRAIL_WORKER_REPO_SCAN_RUN_NOW", "false"), defaultWorkerRepoScanRunNow),
+		WorkerRepoScanInterval:     parseDuration(getEnv("IDENTRAIL_WORKER_REPO_SCAN_INTERVAL", defaultWorkerRepoScanInterval.String()), defaultWorkerRepoScanInterval),
+		WorkerRepoScanTargets:      parseCommaSeparated(getEnv("IDENTRAIL_WORKER_REPO_SCAN_TARGETS", "")),
+		WorkerRepoScanHistory:      parseInt(getEnv("IDENTRAIL_WORKER_REPO_SCAN_HISTORY_LIMIT", "0"), 0),
+		WorkerRepoScanFindings:     parseInt(getEnv("IDENTRAIL_WORKER_REPO_SCAN_MAX_FINDINGS", "0"), 0),
+		WorkerAPIJobQueueEnabled:   parseBool(getEnv("IDENTRAIL_WORKER_API_JOB_QUEUE_ENABLED", "true"), defaultWorkerAPIJobQueueEnabled),
+		WorkerAPIJobQueueInterval:  parseDuration(getEnv("IDENTRAIL_WORKER_API_JOB_QUEUE_INTERVAL", defaultWorkerAPIJobQueueInterval.String()), defaultWorkerAPIJobQueueInterval),
+		WorkerAPIJobQueueBatchSize: parseInt(getEnv("IDENTRAIL_WORKER_API_JOB_QUEUE_BATCH_SIZE", "5"), defaultWorkerAPIJobQueueBatchSize),
+		LockBackend:                strings.ToLower(getEnv("IDENTRAIL_LOCK_BACKEND", defaultLockBackend)),
+		LockNamespace:              getEnv("IDENTRAIL_LOCK_NAMESPACE", defaultLockNamespace),
+		OIDCIssuerURL:              getEnv("IDENTRAIL_OIDC_ISSUER_URL", ""),
+		OIDCAudience:               getEnv("IDENTRAIL_OIDC_AUDIENCE", ""),
+		OIDCWriteScopes:            parseCommaSeparated(getEnv("IDENTRAIL_OIDC_WRITE_SCOPES", defaultOIDCWriteScopes)),
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -50,12 +50,17 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("IDENTRAIL_REPO_SCAN_HISTORY_LIMIT_MAX", "")
 	t.Setenv("IDENTRAIL_REPO_SCAN_MAX_FINDINGS_MAX", "")
 	t.Setenv("IDENTRAIL_REPO_SCAN_ALLOWLIST", "")
+	t.Setenv("IDENTRAIL_SCAN_QUEUE_MAX_PENDING", "")
+	t.Setenv("IDENTRAIL_REPO_SCAN_QUEUE_MAX_PENDING", "")
 	t.Setenv("IDENTRAIL_WORKER_REPO_SCAN_ENABLED", "")
 	t.Setenv("IDENTRAIL_WORKER_REPO_SCAN_RUN_NOW", "")
 	t.Setenv("IDENTRAIL_WORKER_REPO_SCAN_INTERVAL", "")
 	t.Setenv("IDENTRAIL_WORKER_REPO_SCAN_TARGETS", "")
 	t.Setenv("IDENTRAIL_WORKER_REPO_SCAN_HISTORY_LIMIT", "")
 	t.Setenv("IDENTRAIL_WORKER_REPO_SCAN_MAX_FINDINGS", "")
+	t.Setenv("IDENTRAIL_WORKER_API_JOB_QUEUE_ENABLED", "")
+	t.Setenv("IDENTRAIL_WORKER_API_JOB_QUEUE_INTERVAL", "")
+	t.Setenv("IDENTRAIL_WORKER_API_JOB_QUEUE_BATCH_SIZE", "")
 	t.Setenv("IDENTRAIL_LOCK_BACKEND", "")
 	t.Setenv("IDENTRAIL_LOCK_NAMESPACE", "")
 
@@ -186,6 +191,12 @@ func TestLoadDefaults(t *testing.T) {
 	if len(cfg.RepoScanAllowlist) != 0 {
 		t.Fatalf("expected empty repo scan allowlist by default, got %+v", cfg.RepoScanAllowlist)
 	}
+	if cfg.ScanQueueMaxPending != defaultScanQueueMaxPending {
+		t.Fatalf("expected default scan queue max pending %d, got %d", defaultScanQueueMaxPending, cfg.ScanQueueMaxPending)
+	}
+	if cfg.RepoQueueMaxPending != defaultRepoQueueMaxPending {
+		t.Fatalf("expected default repo queue max pending %d, got %d", defaultRepoQueueMaxPending, cfg.RepoQueueMaxPending)
+	}
 	if cfg.WorkerRepoScanEnabled {
 		t.Fatal("expected worker repo scan disabled by default")
 	}
@@ -203,6 +214,15 @@ func TestLoadDefaults(t *testing.T) {
 	}
 	if cfg.WorkerRepoScanFindings != 0 {
 		t.Fatalf("expected default worker repo scan findings override 0, got %d", cfg.WorkerRepoScanFindings)
+	}
+	if !cfg.WorkerAPIJobQueueEnabled {
+		t.Fatal("expected worker api job queue enabled by default")
+	}
+	if cfg.WorkerAPIJobQueueInterval != defaultWorkerAPIJobQueueInterval {
+		t.Fatalf("expected default worker api job queue interval %v, got %v", defaultWorkerAPIJobQueueInterval, cfg.WorkerAPIJobQueueInterval)
+	}
+	if cfg.WorkerAPIJobQueueBatchSize != defaultWorkerAPIJobQueueBatchSize {
+		t.Fatalf("expected default worker api job queue batch size %d, got %d", defaultWorkerAPIJobQueueBatchSize, cfg.WorkerAPIJobQueueBatchSize)
 	}
 	if cfg.LockBackend != defaultLockBackend {
 		t.Fatalf("expected default lock backend %q, got %q", defaultLockBackend, cfg.LockBackend)
@@ -265,12 +285,17 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("IDENTRAIL_REPO_SCAN_HISTORY_LIMIT_MAX", "9000")
 	t.Setenv("IDENTRAIL_REPO_SCAN_MAX_FINDINGS_MAX", "1400")
 	t.Setenv("IDENTRAIL_REPO_SCAN_ALLOWLIST", "trusted/*,owner/repo")
+	t.Setenv("IDENTRAIL_SCAN_QUEUE_MAX_PENDING", "40")
+	t.Setenv("IDENTRAIL_REPO_SCAN_QUEUE_MAX_PENDING", "160")
 	t.Setenv("IDENTRAIL_WORKER_REPO_SCAN_ENABLED", "true")
 	t.Setenv("IDENTRAIL_WORKER_REPO_SCAN_RUN_NOW", "true")
 	t.Setenv("IDENTRAIL_WORKER_REPO_SCAN_INTERVAL", "45m")
 	t.Setenv("IDENTRAIL_WORKER_REPO_SCAN_TARGETS", "owner/repo,trusted/infra")
 	t.Setenv("IDENTRAIL_WORKER_REPO_SCAN_HISTORY_LIMIT", "700")
 	t.Setenv("IDENTRAIL_WORKER_REPO_SCAN_MAX_FINDINGS", "80")
+	t.Setenv("IDENTRAIL_WORKER_API_JOB_QUEUE_ENABLED", "false")
+	t.Setenv("IDENTRAIL_WORKER_API_JOB_QUEUE_INTERVAL", "5s")
+	t.Setenv("IDENTRAIL_WORKER_API_JOB_QUEUE_BATCH_SIZE", "12")
 	t.Setenv("IDENTRAIL_LOCK_BACKEND", "postgres")
 	t.Setenv("IDENTRAIL_LOCK_NAMESPACE", "prod-identrail")
 	t.Setenv("IDENTRAIL_OIDC_ISSUER_URL", "https://iam.example.com/realms/identrail")
@@ -404,6 +429,12 @@ func TestLoadFromEnv(t *testing.T) {
 	if len(cfg.RepoScanAllowlist) != 2 || cfg.RepoScanAllowlist[0] != "trusted/*" || cfg.RepoScanAllowlist[1] != "owner/repo" {
 		t.Fatalf("unexpected repo scan allowlist: %+v", cfg.RepoScanAllowlist)
 	}
+	if cfg.ScanQueueMaxPending != 40 {
+		t.Fatalf("unexpected scan queue max pending: %d", cfg.ScanQueueMaxPending)
+	}
+	if cfg.RepoQueueMaxPending != 160 {
+		t.Fatalf("unexpected repo queue max pending: %d", cfg.RepoQueueMaxPending)
+	}
 	if !cfg.WorkerRepoScanEnabled {
 		t.Fatal("expected worker repo scan enabled")
 	}
@@ -421,6 +452,15 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.WorkerRepoScanFindings != 80 {
 		t.Fatalf("unexpected worker repo scan findings override: %d", cfg.WorkerRepoScanFindings)
+	}
+	if cfg.WorkerAPIJobQueueEnabled {
+		t.Fatal("expected worker api job queue disabled")
+	}
+	if cfg.WorkerAPIJobQueueInterval != 5*time.Second {
+		t.Fatalf("unexpected worker api job queue interval: %v", cfg.WorkerAPIJobQueueInterval)
+	}
+	if cfg.WorkerAPIJobQueueBatchSize != 12 {
+		t.Fatalf("unexpected worker api job queue batch size: %d", cfg.WorkerAPIJobQueueBatchSize)
 	}
 	if cfg.LockBackend != "postgres" {
 		t.Fatalf("unexpected lock backend: %q", cfg.LockBackend)

--- a/internal/config/security.go
+++ b/internal/config/security.go
@@ -242,7 +242,7 @@ func ValidateSecurity(cfg Config) error {
 		return fmt.Errorf("IDENTRAIL_WORKER_API_JOB_QUEUE_INTERVAL must be > 0")
 	}
 	workerAPIJobQueueBatchSize := cfg.WorkerAPIJobQueueBatchSize
-	if workerAPIJobQueueBatchSize <= 0 {
+	if workerAPIJobQueueBatchSize == 0 {
 		workerAPIJobQueueBatchSize = defaultWorkerAPIJobQueueBatchSize
 	}
 	if workerAPIJobQueueBatchSize <= 0 || workerAPIJobQueueBatchSize > maxWorkerQueueBatchSize {

--- a/internal/config/security.go
+++ b/internal/config/security.go
@@ -235,7 +235,7 @@ func ValidateSecurity(cfg Config) error {
 		return fmt.Errorf("IDENTRAIL_REPO_SCAN_QUEUE_MAX_PENDING must be > 0 and <= %d", maxRepoQueueMaxPending)
 	}
 	workerAPIJobQueueInterval := cfg.WorkerAPIJobQueueInterval
-	if workerAPIJobQueueInterval <= 0 {
+	if workerAPIJobQueueInterval == 0 {
 		workerAPIJobQueueInterval = defaultWorkerAPIJobQueueInterval
 	}
 	if workerAPIJobQueueInterval <= 0 {

--- a/internal/config/security.go
+++ b/internal/config/security.go
@@ -228,7 +228,7 @@ func ValidateSecurity(cfg Config) error {
 		return fmt.Errorf("IDENTRAIL_SCAN_QUEUE_MAX_PENDING must be > 0 and <= %d", maxScanQueueMaxPending)
 	}
 	repoQueueMaxPending := cfg.RepoQueueMaxPending
-	if repoQueueMaxPending <= 0 {
+	if repoQueueMaxPending == 0 {
 		repoQueueMaxPending = defaultRepoQueueMaxPending
 	}
 	if repoQueueMaxPending <= 0 || repoQueueMaxPending > maxRepoQueueMaxPending {

--- a/internal/config/security.go
+++ b/internal/config/security.go
@@ -16,6 +16,9 @@ const (
 	maxAuditForwardBackoffLimit = 30
 	maxRepoScanHistoryLimitMax  = 20000
 	maxRepoScanFindingsLimitMax = 5000
+	maxScanQueueMaxPending      = 20000
+	maxRepoQueueMaxPending      = 50000
+	maxWorkerQueueBatchSize     = 500
 	minAPIKeyLength             = 24
 )
 
@@ -216,6 +219,34 @@ func ValidateSecurity(cfg Config) error {
 	}
 	if maxFindings > maxFindingsMax {
 		return fmt.Errorf("IDENTRAIL_REPO_SCAN_MAX_FINDINGS must be <= IDENTRAIL_REPO_SCAN_MAX_FINDINGS_MAX")
+	}
+	scanQueueMaxPending := cfg.ScanQueueMaxPending
+	if scanQueueMaxPending <= 0 {
+		scanQueueMaxPending = defaultScanQueueMaxPending
+	}
+	if scanQueueMaxPending <= 0 || scanQueueMaxPending > maxScanQueueMaxPending {
+		return fmt.Errorf("IDENTRAIL_SCAN_QUEUE_MAX_PENDING must be > 0 and <= %d", maxScanQueueMaxPending)
+	}
+	repoQueueMaxPending := cfg.RepoQueueMaxPending
+	if repoQueueMaxPending <= 0 {
+		repoQueueMaxPending = defaultRepoQueueMaxPending
+	}
+	if repoQueueMaxPending <= 0 || repoQueueMaxPending > maxRepoQueueMaxPending {
+		return fmt.Errorf("IDENTRAIL_REPO_SCAN_QUEUE_MAX_PENDING must be > 0 and <= %d", maxRepoQueueMaxPending)
+	}
+	workerAPIJobQueueInterval := cfg.WorkerAPIJobQueueInterval
+	if workerAPIJobQueueInterval <= 0 {
+		workerAPIJobQueueInterval = defaultWorkerAPIJobQueueInterval
+	}
+	if workerAPIJobQueueInterval <= 0 {
+		return fmt.Errorf("IDENTRAIL_WORKER_API_JOB_QUEUE_INTERVAL must be > 0")
+	}
+	workerAPIJobQueueBatchSize := cfg.WorkerAPIJobQueueBatchSize
+	if workerAPIJobQueueBatchSize <= 0 {
+		workerAPIJobQueueBatchSize = defaultWorkerAPIJobQueueBatchSize
+	}
+	if workerAPIJobQueueBatchSize <= 0 || workerAPIJobQueueBatchSize > maxWorkerQueueBatchSize {
+		return fmt.Errorf("IDENTRAIL_WORKER_API_JOB_QUEUE_BATCH_SIZE must be > 0 and <= %d", maxWorkerQueueBatchSize)
 	}
 	if cfg.RepoScanEnabled && len(cfg.RepoScanAllowlist) == 0 {
 		return fmt.Errorf("IDENTRAIL_REPO_SCAN_ALLOWLIST must include at least one target pattern when IDENTRAIL_REPO_SCAN_ENABLED=true")

--- a/internal/config/security.go
+++ b/internal/config/security.go
@@ -221,7 +221,7 @@ func ValidateSecurity(cfg Config) error {
 		return fmt.Errorf("IDENTRAIL_REPO_SCAN_MAX_FINDINGS must be <= IDENTRAIL_REPO_SCAN_MAX_FINDINGS_MAX")
 	}
 	scanQueueMaxPending := cfg.ScanQueueMaxPending
-	if scanQueueMaxPending <= 0 {
+	if scanQueueMaxPending == 0 {
 		scanQueueMaxPending = defaultScanQueueMaxPending
 	}
 	if scanQueueMaxPending <= 0 || scanQueueMaxPending > maxScanQueueMaxPending {

--- a/internal/config/security_test.go
+++ b/internal/config/security_test.go
@@ -246,6 +246,36 @@ func TestValidateSecurityRejectsInvalidRepoScanBounds(t *testing.T) {
 	}
 }
 
+func TestValidateSecurityRejectsInvalidScanQueuePendingLimit(t *testing.T) {
+	cfg := Config{
+		APIKeyScopes:        map[string][]string{"reader": {"read"}},
+		ScanQueueMaxPending: maxScanQueueMaxPending + 1,
+	}
+	if err := ValidateSecurity(cfg); err == nil {
+		t.Fatal("expected scan queue max pending validation error")
+	}
+}
+
+func TestValidateSecurityRejectsInvalidRepoQueuePendingLimit(t *testing.T) {
+	cfg := Config{
+		APIKeyScopes:        map[string][]string{"reader": {"read"}},
+		RepoQueueMaxPending: maxRepoQueueMaxPending + 1,
+	}
+	if err := ValidateSecurity(cfg); err == nil {
+		t.Fatal("expected repo queue max pending validation error")
+	}
+}
+
+func TestValidateSecurityRejectsInvalidWorkerAPIQueueBatchSize(t *testing.T) {
+	cfg := Config{
+		APIKeyScopes:               map[string][]string{"reader": {"read"}},
+		WorkerAPIJobQueueBatchSize: maxWorkerQueueBatchSize + 1,
+	}
+	if err := ValidateSecurity(cfg); err == nil {
+		t.Fatal("expected worker api queue batch size validation error")
+	}
+}
+
 func TestValidateSecurityWorkerRepoScanRequiresTargets(t *testing.T) {
 	cfg := Config{
 		APIKeys:                []string{"reader"},

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -464,7 +464,7 @@ func (m *MemoryStore) CountPendingRepoScansByRepository(_ context.Context, repos
 	}
 	count := 0
 	for _, record := range m.repoScans {
-		if strings.TrimSpace(record.Repository) != normalizedRepository {
+		if !strings.EqualFold(strings.TrimSpace(record.Repository), normalizedRepository) {
 			continue
 		}
 		if record.Status == "queued" || record.Status == "running" {

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -55,15 +55,77 @@ func (m *MemoryStore) CreateScan(_ context.Context, provider string, startedAt t
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	return m.createScanLocked(provider, "running", startedAt), nil
+}
+
+// CreateQueuedScan persists one queued scan request.
+func (m *MemoryStore) CreateQueuedScan(_ context.Context, provider string, queuedAt time.Time) (ScanRecord, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.createScanLocked(provider, "queued", queuedAt), nil
+}
+
+// ClaimNextQueuedScan moves one queued scan to running for execution.
+func (m *MemoryStore) ClaimNextQueuedScan(_ context.Context, provider string) (ScanRecord, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	normalizedProvider := strings.TrimSpace(provider)
+	found := false
+	var bestRecord ScanRecord
+	for _, scanID := range m.scanIDs {
+		record := m.scans[scanID]
+		if record.Status != "queued" {
+			continue
+		}
+		if normalizedProvider != "" && !strings.EqualFold(strings.TrimSpace(record.Provider), normalizedProvider) {
+			continue
+		}
+		if !found || record.StartedAt.Before(bestRecord.StartedAt) {
+			bestRecord = record
+			found = true
+		}
+	}
+	if !found {
+		return ScanRecord{}, ErrNotFound
+	}
+	bestRecord.Status = "running"
+	bestRecord.FinishedAt = nil
+	bestRecord.ErrorMessage = ""
+	m.scans[bestRecord.ID] = bestRecord
+	return bestRecord, nil
+}
+
+// CountQueuedScans returns the queued scan count for one provider.
+func (m *MemoryStore) CountQueuedScans(_ context.Context, provider string) (int, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	normalizedProvider := strings.TrimSpace(provider)
+	count := 0
+	for _, record := range m.scans {
+		if record.Status != "queued" {
+			continue
+		}
+		if normalizedProvider != "" && !strings.EqualFold(strings.TrimSpace(record.Provider), normalizedProvider) {
+			continue
+		}
+		count++
+	}
+	return count, nil
+}
+
+func (m *MemoryStore) createScanLocked(provider string, status string, startedAt time.Time) ScanRecord {
 	record := ScanRecord{
 		ID:        uuid.NewString(),
-		Provider:  provider,
-		Status:    "running",
+		Provider:  strings.TrimSpace(provider),
+		Status:    strings.TrimSpace(status),
 		StartedAt: startedAt.UTC(),
 	}
 	m.scans[record.ID] = record
 	m.scanIDs = append(m.scanIDs, record.ID)
-	return record, nil
+	return record
 }
 
 // GetScan returns one persisted scan by id.
@@ -339,15 +401,111 @@ func (m *MemoryStore) CreateRepoScan(_ context.Context, repository string, start
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	return m.createRepoScanLocked(strings.TrimSpace(repository), "running", 0, 0, startedAt), nil
+}
+
+// CreateQueuedRepoScan persists one queued repository exposure scan request.
+func (m *MemoryStore) CreateQueuedRepoScan(_ context.Context, repository string, historyLimit int, maxFindings int, queuedAt time.Time) (RepoScanRecord, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.createRepoScanLocked(strings.TrimSpace(repository), "queued", historyLimit, maxFindings, queuedAt), nil
+}
+
+// ClaimNextQueuedRepoScan moves one queued repository scan to running for execution.
+func (m *MemoryStore) ClaimNextQueuedRepoScan(_ context.Context) (RepoScanRecord, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var claimed RepoScanRecord
+	found := false
+	for _, scanID := range m.repoScanIDs {
+		record := m.repoScans[scanID]
+		if record.Status != "queued" {
+			continue
+		}
+		if !found || record.StartedAt.Before(claimed.StartedAt) {
+			claimed = record
+			found = true
+		}
+	}
+	if !found {
+		return RepoScanRecord{}, ErrNotFound
+	}
+	claimed.Status = "running"
+	claimed.FinishedAt = nil
+	claimed.ErrorMessage = ""
+	m.repoScans[claimed.ID] = claimed
+	return claimed, nil
+}
+
+// CountQueuedRepoScans returns queued repository scan count.
+func (m *MemoryStore) CountQueuedRepoScans(_ context.Context) (int, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	count := 0
+	for _, record := range m.repoScans {
+		if record.Status == "queued" {
+			count++
+		}
+	}
+	return count, nil
+}
+
+// CountPendingRepoScansByRepository returns queued/running scan count for one repository.
+func (m *MemoryStore) CountPendingRepoScansByRepository(_ context.Context, repository string) (int, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	normalizedRepository := strings.TrimSpace(repository)
+	if normalizedRepository == "" {
+		return 0, nil
+	}
+	count := 0
+	for _, record := range m.repoScans {
+		if !strings.EqualFold(strings.TrimSpace(record.Repository), normalizedRepository) {
+			continue
+		}
+		if record.Status == "queued" || record.Status == "running" {
+			count++
+		}
+	}
+	return count, nil
+}
+
+// RequeueRepoScan moves a running repository scan back to queued state.
+func (m *MemoryStore) RequeueRepoScan(_ context.Context, repoScanID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	record, exists := m.repoScans[repoScanID]
+	if !exists {
+		return ErrNotFound
+	}
+	if record.Status != "running" {
+		return ErrNotFound
+	}
+	record.Status = "queued"
+	record.StartedAt = time.Now().UTC()
+	record.FinishedAt = nil
+	record.ErrorMessage = ""
+	m.repoScans[repoScanID] = record
+	return nil
+}
+
+func (m *MemoryStore) createRepoScanLocked(repository string, status string, historyLimit int, maxFindings int, startedAt time.Time) RepoScanRecord {
 	record := RepoScanRecord{
-		ID:         uuid.NewString(),
-		Repository: strings.TrimSpace(repository),
-		Status:     "running",
-		StartedAt:  startedAt.UTC(),
+		ID:           uuid.NewString(),
+		Repository:   strings.TrimSpace(repository),
+		Status:       strings.TrimSpace(status),
+		StartedAt:    startedAt.UTC(),
+		HistoryLimit: historyLimit,
+		MaxFindings:  maxFindings,
 	}
 	m.repoScans[record.ID] = record
 	m.repoScanIDs = append(m.repoScanIDs, record.ID)
-	return record, nil
+	return record
 }
 
 // GetRepoScan returns one persisted repo scan by id.

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -79,7 +79,7 @@ func (m *MemoryStore) ClaimNextQueuedScan(_ context.Context, provider string) (S
 		if record.Status != "queued" {
 			continue
 		}
-		if normalizedProvider != "" && !strings.EqualFold(strings.TrimSpace(record.Provider), normalizedProvider) {
+		if normalizedProvider != "" && strings.TrimSpace(record.Provider) != normalizedProvider {
 			continue
 		}
 		if !found || record.StartedAt.Before(bestRecord.StartedAt) {
@@ -108,7 +108,7 @@ func (m *MemoryStore) CountQueuedScans(_ context.Context, provider string) (int,
 		if record.Status != "queued" {
 			continue
 		}
-		if normalizedProvider != "" && !strings.EqualFold(strings.TrimSpace(record.Provider), normalizedProvider) {
+		if normalizedProvider != "" && strings.TrimSpace(record.Provider) != normalizedProvider {
 			continue
 		}
 		count++
@@ -464,7 +464,7 @@ func (m *MemoryStore) CountPendingRepoScansByRepository(_ context.Context, repos
 	}
 	count := 0
 	for _, record := range m.repoScans {
-		if !strings.EqualFold(strings.TrimSpace(record.Repository), normalizedRepository) {
+		if strings.TrimSpace(record.Repository) != normalizedRepository {
 			continue
 		}
 		if record.Status == "queued" || record.Status == "running" {

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -284,5 +285,86 @@ func TestMemoryStoreRepoScanErrors(t *testing.T) {
 	}
 	if _, err := store.ListRepoFindings(context.Background(), RepoFindingFilter{RepoScanID: "missing"}, 10); err == nil {
 		t.Fatal("expected missing repo scan error for findings list")
+	}
+}
+
+func TestMemoryStoreScanQueueLifecycle(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 3, 21, 9, 0, 0, 0, time.UTC)
+	queued, err := store.CreateQueuedScan(context.Background(), "aws", now)
+	if err != nil {
+		t.Fatalf("create queued scan: %v", err)
+	}
+	if queued.Status != "queued" {
+		t.Fatalf("expected queued status, got %q", queued.Status)
+	}
+	count, err := store.CountQueuedScans(context.Background(), "aws")
+	if err != nil {
+		t.Fatalf("count queued scans: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected queued count 1, got %d", count)
+	}
+	claimed, err := store.ClaimNextQueuedScan(context.Background(), "aws")
+	if err != nil {
+		t.Fatalf("claim queued scan: %v", err)
+	}
+	if claimed.ID != queued.ID || claimed.Status != "running" {
+		t.Fatalf("unexpected claimed scan %+v", claimed)
+	}
+	if _, err := store.ClaimNextQueuedScan(context.Background(), "aws"); err == nil {
+		t.Fatal("expected no queued scan remaining")
+	}
+}
+
+func TestMemoryStoreRepoQueueLifecycle(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 3, 21, 9, 5, 0, 0, time.UTC)
+	queued, err := store.CreateQueuedRepoScan(context.Background(), "owner/repo", 50, 80, now)
+	if err != nil {
+		t.Fatalf("create queued repo scan: %v", err)
+	}
+	if queued.Status != "queued" {
+		t.Fatalf("expected queued status, got %q", queued.Status)
+	}
+	if queued.HistoryLimit != 50 || queued.MaxFindings != 80 {
+		t.Fatalf("expected queued limits retained, got %+v", queued)
+	}
+	queuedCount, err := store.CountQueuedRepoScans(context.Background())
+	if err != nil {
+		t.Fatalf("count queued repo scans: %v", err)
+	}
+	if queuedCount != 1 {
+		t.Fatalf("expected queued repo count 1, got %d", queuedCount)
+	}
+	pendingCount, err := store.CountPendingRepoScansByRepository(context.Background(), "owner/repo")
+	if err != nil {
+		t.Fatalf("count pending repo scans: %v", err)
+	}
+	if pendingCount != 1 {
+		t.Fatalf("expected pending repo count 1, got %d", pendingCount)
+	}
+	if err := store.RequeueRepoScan(context.Background(), queued.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected requeue to reject non-running record, got %v", err)
+	}
+	claimed, err := store.ClaimNextQueuedRepoScan(context.Background())
+	if err != nil {
+		t.Fatalf("claim queued repo scan: %v", err)
+	}
+	if claimed.ID != queued.ID || claimed.Status != "running" {
+		t.Fatalf("unexpected claimed repo scan %+v", claimed)
+	}
+	if err := store.RequeueRepoScan(context.Background(), claimed.ID); err != nil {
+		t.Fatalf("requeue repo scan: %v", err)
+	}
+	requeued, err := store.GetRepoScan(context.Background(), claimed.ID)
+	if err != nil {
+		t.Fatalf("get requeued repo scan: %v", err)
+	}
+	if requeued.Status != "queued" {
+		t.Fatalf("expected requeued status, got %q", requeued.Status)
+	}
+	if !requeued.StartedAt.After(claimed.StartedAt) {
+		t.Fatal("expected requeued repo scan to receive a fresh queue timestamp")
 	}
 }

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -368,3 +368,48 @@ func TestMemoryStoreRepoQueueLifecycle(t *testing.T) {
 		t.Fatal("expected requeued repo scan to receive a fresh queue timestamp")
 	}
 }
+
+func TestMemoryStoreScanQueueProviderMatchingIsCaseSensitive(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 3, 21, 9, 15, 0, 0, time.UTC)
+	if _, err := store.CreateQueuedScan(context.Background(), "AWS", now); err != nil {
+		t.Fatalf("create queued scan: %v", err)
+	}
+
+	count, err := store.CountQueuedScans(context.Background(), "aws")
+	if err != nil {
+		t.Fatalf("count queued scans: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected 0 queued scans for mismatched provider case, got %d", count)
+	}
+	if _, err := store.ClaimNextQueuedScan(context.Background(), "aws"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected no claim for mismatched provider case, got %v", err)
+	}
+	if _, err := store.ClaimNextQueuedScan(context.Background(), "AWS"); err != nil {
+		t.Fatalf("expected claim for exact provider case, got %v", err)
+	}
+}
+
+func TestMemoryStorePendingRepoCountMatchingIsCaseSensitive(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 3, 21, 9, 25, 0, 0, time.UTC)
+	if _, err := store.CreateQueuedRepoScan(context.Background(), "Owner/Repo", 10, 20, now); err != nil {
+		t.Fatalf("create queued repo scan: %v", err)
+	}
+
+	count, err := store.CountPendingRepoScansByRepository(context.Background(), "owner/repo")
+	if err != nil {
+		t.Fatalf("count pending repo scans: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected 0 pending repo scans for mismatched repository case, got %d", count)
+	}
+	count, err = store.CountPendingRepoScansByRepository(context.Background(), "Owner/Repo")
+	if err != nil {
+		t.Fatalf("count pending repo scans exact case: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 pending repo scan for exact repository case, got %d", count)
+	}
+}

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -369,29 +369,7 @@ func TestMemoryStoreRepoQueueLifecycle(t *testing.T) {
 	}
 }
 
-func TestMemoryStoreScanQueueProviderMatchingIsCaseSensitive(t *testing.T) {
-	store := NewMemoryStore()
-	now := time.Date(2026, 3, 21, 9, 15, 0, 0, time.UTC)
-	if _, err := store.CreateQueuedScan(context.Background(), "AWS", now); err != nil {
-		t.Fatalf("create queued scan: %v", err)
-	}
-
-	count, err := store.CountQueuedScans(context.Background(), "aws")
-	if err != nil {
-		t.Fatalf("count queued scans: %v", err)
-	}
-	if count != 0 {
-		t.Fatalf("expected 0 queued scans for mismatched provider case, got %d", count)
-	}
-	if _, err := store.ClaimNextQueuedScan(context.Background(), "aws"); !errors.Is(err, ErrNotFound) {
-		t.Fatalf("expected no claim for mismatched provider case, got %v", err)
-	}
-	if _, err := store.ClaimNextQueuedScan(context.Background(), "AWS"); err != nil {
-		t.Fatalf("expected claim for exact provider case, got %v", err)
-	}
-}
-
-func TestMemoryStorePendingRepoCountMatchingIsCaseSensitive(t *testing.T) {
+func TestMemoryStorePendingRepoCountMatchingIsCaseInsensitive(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 21, 9, 25, 0, 0, time.UTC)
 	if _, err := store.CreateQueuedRepoScan(context.Background(), "Owner/Repo", 10, 20, now); err != nil {
@@ -402,14 +380,7 @@ func TestMemoryStorePendingRepoCountMatchingIsCaseSensitive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("count pending repo scans: %v", err)
 	}
-	if count != 0 {
-		t.Fatalf("expected 0 pending repo scans for mismatched repository case, got %d", count)
-	}
-	count, err = store.CountPendingRepoScansByRepository(context.Background(), "Owner/Repo")
-	if err != nil {
-		t.Fatalf("count pending repo scans exact case: %v", err)
-	}
 	if count != 1 {
-		t.Fatalf("expected 1 pending repo scan for exact repository case, got %d", count)
+		t.Fatalf("expected 1 pending repo scan for case-insensitive repository match, got %d", count)
 	}
 }

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -505,7 +505,7 @@ func (p *PostgresStore) CountPendingRepoScansByRepository(ctx context.Context, r
 		ctx,
 		`SELECT COUNT(*)
 		 FROM repo_scans
-		 WHERE repository = $1
+		 WHERE LOWER(repository) = LOWER($1)
 		   AND status IN ('queued', 'running')`,
 		strings.TrimSpace(repository),
 	).Scan(&count); err != nil {

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -54,25 +54,70 @@ func (p *PostgresStore) DB() *sql.DB {
 
 // CreateScan inserts a new scan row.
 func (p *PostgresStore) CreateScan(ctx context.Context, provider string, startedAt time.Time) (ScanRecord, error) {
-	record := ScanRecord{
-		ID:        uuid.NewString(),
-		Provider:  provider,
-		Status:    "running",
-		StartedAt: startedAt.UTC(),
-	}
+	return p.createScanWithStatus(ctx, provider, "running", startedAt)
+}
 
-	_, err := p.db.ExecContext(
+// CreateQueuedScan inserts a queued scan request row.
+func (p *PostgresStore) CreateQueuedScan(ctx context.Context, provider string, queuedAt time.Time) (ScanRecord, error) {
+	return p.createScanWithStatus(ctx, provider, "queued", queuedAt)
+}
+
+// ClaimNextQueuedScan atomically claims one queued scan for execution.
+func (p *PostgresStore) ClaimNextQueuedScan(ctx context.Context, provider string) (ScanRecord, error) {
+	row := p.db.QueryRowContext(
 		ctx,
-		`INSERT INTO scans (id, provider, status, started_at, asset_count, finding_count) VALUES ($1, $2, $3, $4, 0, 0)`,
-		record.ID,
-		record.Provider,
-		record.Status,
-		record.StartedAt,
+		`WITH next_scan AS (
+			SELECT id
+			FROM scans
+			WHERE provider = $1 AND status = 'queued'
+			ORDER BY started_at ASC
+			FOR UPDATE SKIP LOCKED
+			LIMIT 1
+		)
+		UPDATE scans AS s
+		SET status = 'running',
+		    finished_at = NULL,
+		    error_message = NULL
+		FROM next_scan
+		WHERE s.id = next_scan.id
+		RETURNING s.id, s.provider, s.status, s.started_at, s.finished_at, s.asset_count, s.finding_count, COALESCE(s.error_message, '')`,
+		strings.TrimSpace(provider),
 	)
-	if err != nil {
-		return ScanRecord{}, fmt.Errorf("insert scan: %w", err)
+	var record ScanRecord
+	var finishedAt sql.NullTime
+	if err := row.Scan(
+		&record.ID,
+		&record.Provider,
+		&record.Status,
+		&record.StartedAt,
+		&finishedAt,
+		&record.AssetCount,
+		&record.FindingCount,
+		&record.ErrorMessage,
+	); err != nil {
+		if err == sql.ErrNoRows {
+			return ScanRecord{}, ErrNotFound
+		}
+		return ScanRecord{}, fmt.Errorf("claim queued scan: %w", err)
+	}
+	if finishedAt.Valid {
+		converted := finishedAt.Time.UTC()
+		record.FinishedAt = &converted
 	}
 	return record, nil
+}
+
+// CountQueuedScans returns queued scan requests count for one provider.
+func (p *PostgresStore) CountQueuedScans(ctx context.Context, provider string) (int, error) {
+	var count int
+	if err := p.db.QueryRowContext(
+		ctx,
+		`SELECT COUNT(*) FROM scans WHERE provider = $1 AND status = 'queued'`,
+		strings.TrimSpace(provider),
+	).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count queued scans: %w", err)
+	}
+	return count, nil
 }
 
 // GetScan returns one scan by id.
@@ -394,20 +439,126 @@ func (p *PostgresStore) ListScanEvents(ctx context.Context, scanID string, limit
 
 // CreateRepoScan inserts a new repository exposure scan row.
 func (p *PostgresStore) CreateRepoScan(ctx context.Context, repository string, startedAt time.Time) (RepoScanRecord, error) {
+	return p.createRepoScanWithStatus(ctx, repository, "running", 0, 0, startedAt)
+}
+
+// CreateQueuedRepoScan inserts one queued repository scan request row.
+func (p *PostgresStore) CreateQueuedRepoScan(ctx context.Context, repository string, historyLimit int, maxFindings int, queuedAt time.Time) (RepoScanRecord, error) {
+	return p.createRepoScanWithStatus(ctx, repository, "queued", historyLimit, maxFindings, queuedAt)
+}
+
+// ClaimNextQueuedRepoScan atomically claims one queued repository scan.
+func (p *PostgresStore) ClaimNextQueuedRepoScan(ctx context.Context) (RepoScanRecord, error) {
+	row := p.db.QueryRowContext(
+		ctx,
+		`WITH next_repo_scan AS (
+			SELECT id
+			FROM repo_scans
+			WHERE status = 'queued'
+			ORDER BY started_at ASC
+			FOR UPDATE SKIP LOCKED
+			LIMIT 1
+		)
+		UPDATE repo_scans AS r
+		SET status = 'running',
+		    finished_at = NULL,
+		    error_message = NULL
+		FROM next_repo_scan
+		WHERE r.id = next_repo_scan.id
+		RETURNING
+			r.id,
+			r.repository,
+			r.status,
+			r.started_at,
+			r.finished_at,
+			r.commits_scanned,
+			r.files_scanned,
+			r.finding_count,
+			r.truncated,
+			COALESCE(r.error_message, ''),
+			r.history_limit,
+			r.max_findings_limit`,
+	)
+	record, err := scanRepoScanRecord(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return RepoScanRecord{}, ErrNotFound
+		}
+		return RepoScanRecord{}, fmt.Errorf("claim queued repo scan: %w", err)
+	}
+	return record, nil
+}
+
+// CountQueuedRepoScans returns queued repository scan requests count.
+func (p *PostgresStore) CountQueuedRepoScans(ctx context.Context) (int, error) {
+	var count int
+	if err := p.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM repo_scans WHERE status = 'queued'`).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count queued repo scans: %w", err)
+	}
+	return count, nil
+}
+
+// CountPendingRepoScansByRepository returns queued+running scan count for one repository.
+func (p *PostgresStore) CountPendingRepoScansByRepository(ctx context.Context, repository string) (int, error) {
+	var count int
+	if err := p.db.QueryRowContext(
+		ctx,
+		`SELECT COUNT(*)
+		 FROM repo_scans
+		 WHERE repository = $1
+		   AND status IN ('queued', 'running')`,
+		strings.TrimSpace(repository),
+	).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count pending repo scans: %w", err)
+	}
+	return count, nil
+}
+
+// RequeueRepoScan moves one running repository scan back to queued.
+func (p *PostgresStore) RequeueRepoScan(ctx context.Context, repoScanID string) error {
+	result, err := p.db.ExecContext(
+		ctx,
+		`UPDATE repo_scans
+		 SET status = 'queued',
+		     started_at = NOW(),
+		     finished_at = NULL,
+		     error_message = NULL
+		 WHERE id = $1
+		   AND status = 'running'`,
+		repoScanID,
+	)
+	if err != nil {
+		return fmt.Errorf("requeue repo scan: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("requeue repo scan rows affected: %w", err)
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (p *PostgresStore) createRepoScanWithStatus(ctx context.Context, repository string, status string, historyLimit int, maxFindings int, startedAt time.Time) (RepoScanRecord, error) {
 	record := RepoScanRecord{
-		ID:         uuid.NewString(),
-		Repository: strings.TrimSpace(repository),
-		Status:     "running",
-		StartedAt:  startedAt.UTC(),
+		ID:           uuid.NewString(),
+		Repository:   strings.TrimSpace(repository),
+		Status:       strings.TrimSpace(status),
+		StartedAt:    startedAt.UTC(),
+		HistoryLimit: historyLimit,
+		MaxFindings:  maxFindings,
 	}
 	_, err := p.db.ExecContext(
 		ctx,
-		`INSERT INTO repo_scans (id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated)
-		 VALUES ($1, $2, $3, $4, 0, 0, 0, false)`,
+		`INSERT INTO repo_scans (id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit)
+		 VALUES ($1, $2, $3, $4, 0, 0, 0, false, $5, $6)`,
 		record.ID,
 		record.Repository,
 		record.Status,
 		record.StartedAt,
+		record.HistoryLimit,
+		record.MaxFindings,
 	)
 	if err != nil {
 		return RepoScanRecord{}, fmt.Errorf("insert repo scan: %w", err)
@@ -775,6 +926,58 @@ func repoScanRecordFromRow(row sqlcdb.RepoScanRow) RepoScanRecord {
 		Truncated:      row.Truncated,
 		ErrorMessage:   row.ErrorMessage,
 	}
+}
+
+func (p *PostgresStore) createScanWithStatus(ctx context.Context, provider string, status string, startedAt time.Time) (ScanRecord, error) {
+	record := ScanRecord{
+		ID:        uuid.NewString(),
+		Provider:  strings.TrimSpace(provider),
+		Status:    strings.TrimSpace(status),
+		StartedAt: startedAt.UTC(),
+	}
+	_, err := p.db.ExecContext(
+		ctx,
+		`INSERT INTO scans (id, provider, status, started_at, asset_count, finding_count) VALUES ($1, $2, $3, $4, 0, 0)`,
+		record.ID,
+		record.Provider,
+		record.Status,
+		record.StartedAt,
+	)
+	if err != nil {
+		return ScanRecord{}, fmt.Errorf("insert scan: %w", err)
+	}
+	return record, nil
+}
+
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func scanRepoScanRecord(scanner scanner) (RepoScanRecord, error) {
+	var record RepoScanRecord
+	var finishedAt sql.NullTime
+	if err := scanner.Scan(
+		&record.ID,
+		&record.Repository,
+		&record.Status,
+		&record.StartedAt,
+		&finishedAt,
+		&record.CommitsScanned,
+		&record.FilesScanned,
+		&record.FindingCount,
+		&record.Truncated,
+		&record.ErrorMessage,
+		&record.HistoryLimit,
+		&record.MaxFindings,
+	); err != nil {
+		return RepoScanRecord{}, err
+	}
+	record.StartedAt = record.StartedAt.UTC()
+	if finishedAt.Valid {
+		converted := finishedAt.Time.UTC()
+		record.FinishedAt = &converted
+	}
+	return record, nil
 }
 
 func findingsFromRows(rows []sqlcdb.FindingRow) ([]domain.Finding, error) {

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -304,9 +304,9 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 	store := NewPostgresStoreWithDB(db)
 	now := time.Now().UTC()
 
-	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated)
-		 VALUES ($1, $2, $3, $4, 0, 0, 0, false)`)).
-		WithArgs(sqlmock.AnyArg(), "owner/repo", "running", sqlmock.AnyArg()).
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit)
+		 VALUES ($1, $2, $3, $4, 0, 0, 0, false, $5, $6)`)).
+		WithArgs(sqlmock.AnyArg(), "owner/repo", "running", sqlmock.AnyArg(), 0, 0).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	record, err := store.CreateRepoScan(context.Background(), "owner/repo", now)
@@ -381,6 +381,152 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 	}
 	if gotRepoScan.ID != record.ID {
 		t.Fatalf("unexpected repo scan: %+v", gotRepoScan)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreScanQueueLifecycle(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	now := time.Now().UTC()
+
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO scans (id, provider, status, started_at, asset_count, finding_count) VALUES ($1, $2, $3, $4, 0, 0)`)).
+		WithArgs(sqlmock.AnyArg(), "aws", "queued", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	queued, err := store.CreateQueuedScan(context.Background(), "aws", now)
+	if err != nil {
+		t.Fatalf("create queued scan failed: %v", err)
+	}
+	if queued.Status != "queued" {
+		t.Fatalf("expected queued status, got %q", queued.Status)
+	}
+
+	countRows := sqlmock.NewRows([]string{"count"}).AddRow(1)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*) FROM scans WHERE provider = $1 AND status = 'queued'`)).
+		WithArgs("aws").
+		WillReturnRows(countRows)
+
+	count, err := store.CountQueuedScans(context.Background(), "aws")
+	if err != nil {
+		t.Fatalf("count queued scans failed: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected queued count 1, got %d", count)
+	}
+
+	claimRows := sqlmock.NewRows([]string{"id", "provider", "status", "started_at", "finished_at", "asset_count", "finding_count", "coalesce"}).
+		AddRow(queued.ID, "aws", "running", now, nil, 0, 0, "")
+	mock.ExpectQuery("WITH next_scan AS").WithArgs("aws").WillReturnRows(claimRows)
+
+	claimed, err := store.ClaimNextQueuedScan(context.Background(), "aws")
+	if err != nil {
+		t.Fatalf("claim queued scan failed: %v", err)
+	}
+	if claimed.Status != "running" {
+		t.Fatalf("expected running status after claim, got %q", claimed.Status)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	now := time.Now().UTC()
+
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit)
+		 VALUES ($1, $2, $3, $4, 0, 0, 0, false, $5, $6)`)).
+		WithArgs(sqlmock.AnyArg(), "owner/repo", "queued", sqlmock.AnyArg(), 50, 80).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	queued, err := store.CreateQueuedRepoScan(context.Background(), "owner/repo", 50, 80, now)
+	if err != nil {
+		t.Fatalf("create queued repo scan failed: %v", err)
+	}
+	if queued.Status != "queued" {
+		t.Fatalf("expected queued status, got %q", queued.Status)
+	}
+	if queued.HistoryLimit != 50 || queued.MaxFindings != 80 {
+		t.Fatalf("expected queued limits retained, got %+v", queued)
+	}
+
+	queuedCountRows := sqlmock.NewRows([]string{"count"}).AddRow(1)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*) FROM repo_scans WHERE status = 'queued'`)).
+		WillReturnRows(queuedCountRows)
+
+	queuedCount, err := store.CountQueuedRepoScans(context.Background())
+	if err != nil {
+		t.Fatalf("count queued repo scans failed: %v", err)
+	}
+	if queuedCount != 1 {
+		t.Fatalf("expected queued count 1, got %d", queuedCount)
+	}
+
+	pendingRows := sqlmock.NewRows([]string{"count"}).AddRow(1)
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\)").
+		WithArgs("owner/repo").
+		WillReturnRows(pendingRows)
+
+	pendingCount, err := store.CountPendingRepoScansByRepository(context.Background(), "owner/repo")
+	if err != nil {
+		t.Fatalf("count pending repo scans failed: %v", err)
+	}
+	if pendingCount != 1 {
+		t.Fatalf("expected pending count 1, got %d", pendingCount)
+	}
+
+	claimRows := sqlmock.NewRows([]string{
+		"id",
+		"repository",
+		"status",
+		"started_at",
+		"finished_at",
+		"commits_scanned",
+		"files_scanned",
+		"finding_count",
+		"truncated",
+		"coalesce",
+		"history_limit",
+		"max_findings_limit",
+	}).AddRow(queued.ID, "owner/repo", "running", now, nil, 0, 0, 0, false, "", 50, 80)
+	mock.ExpectQuery("WITH next_repo_scan AS").WillReturnRows(claimRows)
+
+	claimed, err := store.ClaimNextQueuedRepoScan(context.Background())
+	if err != nil {
+		t.Fatalf("claim queued repo scan failed: %v", err)
+	}
+	if claimed.Status != "running" {
+		t.Fatalf("expected running status, got %q", claimed.Status)
+	}
+
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE repo_scans
+		 SET status = 'queued',
+		     started_at = NOW(),
+		     finished_at = NULL,
+		     error_message = NULL
+		 WHERE id = $1
+		   AND status = 'running'`)).
+		WithArgs(claimed.ID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := store.RequeueRepoScan(context.Background(), claimed.ID); err != nil {
+		t.Fatalf("requeue repo scan failed: %v", err)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -480,13 +480,13 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 
 	pendingRows := sqlmock.NewRows([]string{"count"}).AddRow(1)
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*)
-		 FROM repo_scans
-		 WHERE repository = $1
-		   AND status IN ('queued', 'running')`)).
-		WithArgs("owner/repo").
+			 FROM repo_scans
+			 WHERE LOWER(repository) = LOWER($1)
+			   AND status IN ('queued', 'running')`)).
+		WithArgs("OWNER/REPO").
 		WillReturnRows(pendingRows)
 
-	pendingCount, err := store.CountPendingRepoScansByRepository(context.Background(), "owner/repo")
+	pendingCount, err := store.CountPendingRepoScansByRepository(context.Background(), "OWNER/REPO")
 	if err != nil {
 		t.Fatalf("count pending repo scans failed: %v", err)
 	}

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -479,7 +479,10 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 	}
 
 	pendingRows := sqlmock.NewRows([]string{"count"}).AddRow(1)
-	mock.ExpectQuery("SELECT COUNT\\(\\*\\)").
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*)
+		 FROM repo_scans
+		 WHERE repository = $1
+		   AND status IN ('queued', 'running')`)).
 		WithArgs("owner/repo").
 		WillReturnRows(pendingRows)
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -43,6 +43,8 @@ type RepoScanRecord struct {
 	FindingCount   int        `json:"finding_count"`
 	Truncated      bool       `json:"truncated"`
 	ErrorMessage   string     `json:"error_message,omitempty"`
+	HistoryLimit   int        `json:"-"`
+	MaxFindings    int        `json:"-"`
 }
 
 // ScanArtifacts contains raw and normalized scan outputs to persist idempotently.
@@ -99,6 +101,9 @@ type RepoFindingFilter struct {
 // Store defines persistence operations required by API and scheduler orchestration.
 type Store interface {
 	CreateScan(ctx context.Context, provider string, startedAt time.Time) (ScanRecord, error)
+	CreateQueuedScan(ctx context.Context, provider string, queuedAt time.Time) (ScanRecord, error)
+	ClaimNextQueuedScan(ctx context.Context, provider string) (ScanRecord, error)
+	CountQueuedScans(ctx context.Context, provider string) (int, error)
 	GetScan(ctx context.Context, scanID string) (ScanRecord, error)
 	CompleteScan(ctx context.Context, scanID string, status string, finishedAt time.Time, assetCount int, findingCount int, errorMessage string) error
 	UpsertArtifacts(ctx context.Context, scanID string, artifacts ScanArtifacts) error
@@ -111,6 +116,11 @@ type Store interface {
 	AppendScanEvent(ctx context.Context, scanID string, level string, message string, metadata map[string]any) error
 	ListScanEvents(ctx context.Context, scanID string, limit int) ([]ScanEvent, error)
 	CreateRepoScan(ctx context.Context, repository string, startedAt time.Time) (RepoScanRecord, error)
+	CreateQueuedRepoScan(ctx context.Context, repository string, historyLimit int, maxFindings int, queuedAt time.Time) (RepoScanRecord, error)
+	ClaimNextQueuedRepoScan(ctx context.Context) (RepoScanRecord, error)
+	CountQueuedRepoScans(ctx context.Context) (int, error)
+	CountPendingRepoScansByRepository(ctx context.Context, repository string) (int, error)
+	RequeueRepoScan(ctx context.Context, repoScanID string) error
 	GetRepoScan(ctx context.Context, repoScanID string) (RepoScanRecord, error)
 	CompleteRepoScan(ctx context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, errorMessage string) error
 	UpsertRepoFindings(ctx context.Context, repoScanID string, findings []domain.Finding) error

--- a/internal/runtime/service_builder.go
+++ b/internal/runtime/service_builder.go
@@ -128,6 +128,12 @@ func BuildScanService(cfg config.Config) (*api.Service, func() error, error) {
 		svc.RepoScanMaxFindingsLimit = cfg.RepoScanMaxFindingsMax
 	}
 	svc.RepoScanAllowedTargets = append([]string(nil), cfg.RepoScanAllowlist...)
+	if cfg.ScanQueueMaxPending > 0 {
+		svc.ScanQueueMaxPending = cfg.ScanQueueMaxPending
+	}
+	if cfg.RepoQueueMaxPending > 0 {
+		svc.RepoQueueMaxPending = cfg.RepoQueueMaxPending
+	}
 	if cfg.AlertWebhookURL != "" {
 		alerter, alertErr := api.NewWebhookAlerter(
 			cfg.AlertWebhookURL,

--- a/internal/runtime/service_builder_test.go
+++ b/internal/runtime/service_builder_test.go
@@ -43,6 +43,8 @@ func TestBuildScanServiceRepoScanSettings(t *testing.T) {
 		RepoScanHistoryLimitMax: 2500,
 		RepoScanMaxFindingsMax:  900,
 		RepoScanAllowlist:       []string{"trusted/*"},
+		ScanQueueMaxPending:     30,
+		RepoQueueMaxPending:     140,
 	}
 	svc, closeFn, err := BuildScanService(cfg)
 	if err != nil {
@@ -58,6 +60,9 @@ func TestBuildScanServiceRepoScanSettings(t *testing.T) {
 	}
 	if len(svc.RepoScanAllowedTargets) != 1 || svc.RepoScanAllowedTargets[0] != "trusted/*" {
 		t.Fatalf("unexpected repo scan allowlist %+v", svc.RepoScanAllowedTargets)
+	}
+	if svc.ScanQueueMaxPending != 30 || svc.RepoQueueMaxPending != 140 {
+		t.Fatalf("unexpected queue pending limits scan=%d repo=%d", svc.ScanQueueMaxPending, svc.RepoQueueMaxPending)
 	}
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -17,6 +17,7 @@ import (
 const (
 	defaultWorkerTriggerMaxAttempts = 3
 	defaultWorkerRetryBackoff       = 2 * time.Second
+	defaultWorkerQueueMaxAttempts   = 1
 )
 
 // Run starts the scheduled worker loop and exits on signal or context cancellation.
@@ -93,6 +94,33 @@ func Run(ctx context.Context, cfg config.Config, signals <-chan os.Signal) error
 		}
 		return nil
 	}
+	queueBatchSize := cfg.WorkerAPIJobQueueBatchSize
+	if queueBatchSize <= 0 {
+		queueBatchSize = 1
+	}
+	apiQueueTrigger := func(runCtx context.Context) error {
+		for i := 0; i < queueBatchSize; i++ {
+			processed, processErr := svc.ProcessNextQueuedScan(runCtx)
+			if processErr != nil {
+				logger.Error("queued scan processing failed", telemetry.ZapError(processErr))
+				continue
+			}
+			if !processed {
+				break
+			}
+		}
+		for i := 0; i < queueBatchSize; i++ {
+			processed, processErr := svc.ProcessNextQueuedRepoScan(runCtx)
+			if processErr != nil {
+				logger.Error("queued repo scan processing failed", telemetry.ZapError(processErr))
+				continue
+			}
+			if !processed {
+				break
+			}
+		}
+		return nil
+	}
 
 	type scheduledRunner struct {
 		name   string
@@ -126,6 +154,22 @@ func Run(ctx context.Context, cfg config.Config, signals <-chan os.Signal) error
 				RetryBackoff: defaultWorkerRetryBackoff,
 				OnDeadLetter: func(_ context.Context, err error) {
 					logger.Error("repo trigger exhausted retries; dead-letter event emitted", telemetry.ZapError(err))
+				},
+			},
+		})
+	}
+	if cfg.WorkerAPIJobQueueEnabled {
+		runners = append(runners, scheduledRunner{
+			name:   "api-queue",
+			runNow: false,
+			runner: scheduler.Runner{
+				Interval:     cfg.WorkerAPIJobQueueInterval,
+				Key:          "api-job-queue",
+				Trigger:      apiQueueTrigger,
+				MaxAttempts:  defaultWorkerQueueMaxAttempts,
+				RetryBackoff: defaultWorkerRetryBackoff,
+				OnDeadLetter: func(_ context.Context, err error) {
+					logger.Error("api job queue trigger exhausted retries; dead-letter event emitted", telemetry.ZapError(err))
 				},
 			},
 		})

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -20,6 +20,8 @@ const (
 	defaultWorkerQueueMaxAttempts   = 1
 )
 
+type queueProcessFunc func(context.Context) (bool, error)
+
 // Run starts the scheduled worker loop and exits on signal or context cancellation.
 func Run(ctx context.Context, cfg config.Config, signals <-chan os.Signal) error {
 	logger, err := telemetry.NewLogger(cfg.LogLevel)
@@ -99,27 +101,18 @@ func Run(ctx context.Context, cfg config.Config, signals <-chan os.Signal) error
 		queueBatchSize = 1
 	}
 	apiQueueTrigger := func(runCtx context.Context) error {
-		for i := 0; i < queueBatchSize; i++ {
-			processed, processErr := svc.ProcessNextQueuedScan(runCtx)
-			if processErr != nil {
-				logger.Error("queued scan processing failed", telemetry.ZapError(processErr))
-				continue
-			}
-			if !processed {
-				break
-			}
-		}
-		for i := 0; i < queueBatchSize; i++ {
-			processed, processErr := svc.ProcessNextQueuedRepoScan(runCtx)
-			if processErr != nil {
-				logger.Error("queued repo scan processing failed", telemetry.ZapError(processErr))
-				continue
-			}
-			if !processed {
-				break
-			}
-		}
-		return nil
+		return processAPIQueueBatch(
+			runCtx,
+			queueBatchSize,
+			svc.ProcessNextQueuedScan,
+			svc.ProcessNextQueuedRepoScan,
+			func(err error) {
+				logger.Error("queued scan processing failed", telemetry.ZapError(err))
+			},
+			func(err error) {
+				logger.Error("queued repo scan processing failed", telemetry.ZapError(err))
+			},
+		)
 	}
 
 	type scheduledRunner struct {
@@ -210,4 +203,56 @@ func Run(ctx context.Context, cfg config.Config, signals <-chan os.Signal) error
 	case runErr := <-errCh:
 		return runErr
 	}
+}
+
+func processAPIQueueBatch(
+	ctx context.Context,
+	batchSize int,
+	processScan queueProcessFunc,
+	processRepoScan queueProcessFunc,
+	onScanError func(error),
+	onRepoError func(error),
+) error {
+	if batchSize <= 0 {
+		batchSize = 1
+	}
+	failures := 0
+	var firstErr error
+
+	for i := 0; i < batchSize; i++ {
+		processed, err := processScan(ctx)
+		if err != nil {
+			failures++
+			if firstErr == nil {
+				firstErr = err
+			}
+			if onScanError != nil {
+				onScanError(err)
+			}
+			continue
+		}
+		if !processed {
+			break
+		}
+	}
+	for i := 0; i < batchSize; i++ {
+		processed, err := processRepoScan(ctx)
+		if err != nil {
+			failures++
+			if firstErr == nil {
+				firstErr = err
+			}
+			if onRepoError != nil {
+				onRepoError(err)
+			}
+			continue
+		}
+		if !processed {
+			break
+		}
+	}
+	if failures > 0 {
+		return fmt.Errorf("api queue batch failed for %d job(s): %w", failures, firstErr)
+	}
+	return nil
 }

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -2,7 +2,9 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -147,5 +149,41 @@ func TestRunFailsWhenWorkerRepoStartupScanTargetIsInvalid(t *testing.T) {
 	sigCh := make(chan os.Signal, 1)
 	if err := Run(ctx, cfg, sigCh); err == nil {
 		t.Fatal("expected worker repo startup scan error")
+	}
+}
+
+func TestProcessAPIQueueBatchReturnsErrorWhenProcessingFails(t *testing.T) {
+	scanErrors := 0
+	repoErrors := 0
+	err := processAPIQueueBatch(
+		context.Background(),
+		1,
+		func(context.Context) (bool, error) { return false, errors.New("scan failure") },
+		func(context.Context) (bool, error) { return false, errors.New("repo failure") },
+		func(error) { scanErrors++ },
+		func(error) { repoErrors++ },
+	)
+	if err == nil {
+		t.Fatal("expected queue batch error")
+	}
+	if !strings.Contains(err.Error(), "api queue batch failed for 2 job(s)") {
+		t.Fatalf("unexpected queue batch error: %v", err)
+	}
+	if scanErrors != 1 || repoErrors != 1 {
+		t.Fatalf("expected one callback per processing error, got scan=%d repo=%d", scanErrors, repoErrors)
+	}
+}
+
+func TestProcessAPIQueueBatchReturnsNilWhenNoFailures(t *testing.T) {
+	err := processAPIQueueBatch(
+		context.Background(),
+		2,
+		func(context.Context) (bool, error) { return false, nil },
+		func(context.Context) (bool, error) { return false, nil },
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
 	}
 }

--- a/migrations/000005_async_job_queue.down.sql
+++ b/migrations/000005_async_job_queue.down.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS idx_repo_scans_repository_status_started_at;
+DROP INDEX IF EXISTS idx_repo_scans_status_started_at;
+DROP INDEX IF EXISTS idx_scans_status_started_at;
+DROP INDEX IF EXISTS idx_scans_provider_status_started_at;
+
+ALTER TABLE repo_scans
+    DROP COLUMN IF EXISTS max_findings_limit;
+
+ALTER TABLE repo_scans
+    DROP COLUMN IF EXISTS history_limit;

--- a/migrations/000005_async_job_queue.up.sql
+++ b/migrations/000005_async_job_queue.up.sql
@@ -1,0 +1,17 @@
+ALTER TABLE repo_scans
+    ADD COLUMN IF NOT EXISTS history_limit INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE repo_scans
+    ADD COLUMN IF NOT EXISTS max_findings_limit INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_scans_provider_status_started_at
+    ON scans (provider, status, started_at ASC);
+
+CREATE INDEX IF NOT EXISTS idx_scans_status_started_at
+    ON scans (status, started_at ASC);
+
+CREATE INDEX IF NOT EXISTS idx_repo_scans_status_started_at
+    ON repo_scans (status, started_at ASC);
+
+CREATE INDEX IF NOT EXISTS idx_repo_scans_repository_status_started_at
+    ON repo_scans (repository, status, started_at ASC);

--- a/testdata/contracts/api_v1_scan_trigger_response.snapshot.json
+++ b/testdata/contracts/api_v1_scan_trigger_response.snapshot.json
@@ -1,14 +1,10 @@
 {
-  "assets": 1,
-  "finding_count": 1,
-  "partial_source_run": false,
   "scan": {
-    "asset_count": 1,
-    "finding_count": 1,
-    "finished_at": "\u003ctimestamp\u003e",
+    "asset_count": 0,
+    "finding_count": 0,
     "id": "\u003cscan-id\u003e",
     "provider": "aws",
     "started_at": "\u003ctimestamp\u003e",
-    "status": "completed"
+    "status": "queued"
   }
 }


### PR DESCRIPTION
## Summary
- enqueue POST /v1/scans and POST /v1/repo-scans jobs instead of running inline
- add worker queue draining, queue limits/backpressure, and persistence/migration support
- add coverage for queue lifecycle/limits and update API/docs for async 202 behavior

## Validation
- go test ./...
- npm ci --prefix web && npm run --prefix web build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make API-triggered scans asynchronous with a queued job model and worker-driven execution. Improves queue draining with safer retry signaling and consistent behavior across memory and Postgres stores.

- **New Features**
  - `POST /v1/scans` enqueues and returns 202 with a queued `scan`; returns 429 when the provider queue is full; enqueues even if a run is in progress.
  - `POST /v1/repo-scans` enqueues and returns 202 with `repo_scan`; validates targets/limits; returns 400/403 for invalid/unauthorized, 409 for duplicate target (case-insensitive, includes queued and running), 429 when the repo queue is full, and 503 when disabled.
  - Worker drains API queues on a schedule in bounded batches; controlled by `IDENTRAIL_WORKER_API_JOB_QUEUE_ENABLED`, `IDENTRAIL_WORKER_API_JOB_QUEUE_INTERVAL`, and `IDENTRAIL_WORKER_API_JOB_QUEUE_BATCH_SIZE`; requeues locked repo targets and continues draining; robust error reporting.
  - Queue limits with backpressure and config validation: `IDENTRAIL_SCAN_QUEUE_MAX_PENDING` and `IDENTRAIL_REPO_SCAN_QUEUE_MAX_PENDING` (safe bounds enforced), plus validation for worker queue interval and batch size.
  - Persistence for queued jobs in `internal/db` (memory + Postgres): enqueue/claim/count/requeue and per-target pending counts (case-insensitive), plus new indexes; enqueued repo scans persist `history_limit`/`max_findings_limit`; OpenAPI/docs updated to “enqueued” responses and new error codes.

- **Migration**
  - Run DB migration `000005_async_job_queue` (adds `history_limit`/`max_findings_limit` to `repo_scans` and queue indexes).
  - Deploy the worker with queue draining enabled.
  - Configure env vars: `IDENTRAIL_SCAN_QUEUE_MAX_PENDING`, `IDENTRAIL_REPO_SCAN_QUEUE_MAX_PENDING`, `IDENTRAIL_WORKER_API_JOB_QUEUE_*`.
  - Update API clients to handle 202 responses for `POST /v1/scans` and `POST /v1/repo-scans` and poll existing GET endpoints for completion/results.

<sup>Written for commit 495c608c667c1b714008bc9c0a3667f7656abfbc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

