### PR TITLE
Add finding workflow maturity triage lifecycle

### DIFF
--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -52,6 +52,13 @@ paths:
           name: type
           schema:
             $ref: "#/components/schemas/FindingType"
+        - in: query
+          name: lifecycle_status
+          schema:
+            $ref: "#/components/schemas/FindingLifecycleStatus"
+        - in: query
+          name: assignee
+          schema: { type: string }
       responses:
         "200":
           description: Findings page
@@ -126,6 +133,71 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Finding"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /v1/findings/{finding_id}/history:
+    get:
+      tags: [Findings]
+      summary: List finding triage history
+      operationId: listFindingHistory
+      parameters:
+        - in: path
+          name: finding_id
+          required: true
+          schema: { type: string }
+        - in: query
+          name: scan_id
+          schema: { type: string }
+        - $ref: "#/components/parameters/limit"
+      responses:
+        "200":
+          description: Triage history
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/FindingTriageEvent"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /v1/findings/{finding_id}/triage:
+    patch:
+      tags: [Findings]
+      summary: Update finding triage workflow metadata
+      operationId: triageFinding
+      parameters:
+        - in: path
+          name: finding_id
+          required: true
+          schema: { type: string }
+        - in: query
+          name: scan_id
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FindingTriageRequest"
+      responses:
+        "200":
+          description: Updated finding
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  finding:
+                    $ref: "#/components/schemas/Finding"
+        "400":
+          description: Invalid triage request
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Forbidden
         "404":
           $ref: "#/components/responses/NotFound"
   /v1/findings/{finding_id}/exports:
@@ -475,6 +547,59 @@ components:
         - risky_trust_policy
         - secret_exposure
         - repo_misconfiguration
+    FindingLifecycleStatus:
+      type: string
+      enum: [open, ack, suppressed, resolved]
+    FindingTriage:
+      type: object
+      properties:
+        status:
+          $ref: "#/components/schemas/FindingLifecycleStatus"
+        assignee:
+          type: string
+        suppression_expires_at:
+          type: string
+          format: date-time
+          nullable: true
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+        updated_by:
+          type: string
+    FindingTriageRequest:
+      type: object
+      properties:
+        status:
+          $ref: "#/components/schemas/FindingLifecycleStatus"
+        assignee:
+          type: string
+        suppression_expires_at:
+          type: string
+          format: date-time
+          nullable: true
+        comment:
+          type: string
+    FindingTriageEvent:
+      type: object
+      properties:
+        id: { type: string }
+        finding_id: { type: string }
+        action: { type: string }
+        from_status:
+          $ref: "#/components/schemas/FindingLifecycleStatus"
+        to_status:
+          $ref: "#/components/schemas/FindingLifecycleStatus"
+        assignee: { type: string }
+        suppression_expires_at:
+          type: string
+          format: date-time
+          nullable: true
+        comment: { type: string }
+        actor: { type: string }
+        created_at:
+          type: string
+          format: date-time
     Finding:
       type: object
       properties:
@@ -494,6 +619,8 @@ components:
         created_at:
           type: string
           format: date-time
+        triage:
+          $ref: "#/components/schemas/FindingTriage"
     FindingsSummary:
       type: object
       properties:

--- a/internal/api/audit_sink.go
+++ b/internal/api/audit_sink.go
@@ -3,10 +3,9 @@ package api
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"net/http"
 	"net/url"
@@ -180,9 +179,10 @@ func fingerprintAPIKey(raw string) string {
 	if trimmed == "" {
 		return ""
 	}
-	sum := sha256.Sum256([]byte(trimmed))
-	// Truncated, deterministic identifier for correlation without exposing key material.
-	return "sha256:" + hex.EncodeToString(sum[:6])
+	hasher := fnv.New64a()
+	_, _ = hasher.Write([]byte(trimmed))
+	// Deterministic correlation identifier; truncated for compact audit payloads.
+	return fmt.Sprintf("fnv64a:%012x", hasher.Sum64()&0xFFFFFFFFFFFF)
 }
 
 func validateAuditForwardURL(raw string) error {

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -14,6 +14,8 @@ func TestOpenAPIV1SpecContainsCoreEndpoints(t *testing.T) {
 		"openapi: 3.0.3",
 		"/v1/findings:",
 		"/v1/findings/{finding_id}:",
+		"/v1/findings/{finding_id}/history:",
+		"/v1/findings/{finding_id}/triage:",
 		"/v1/scans:",
 		"/v1/scans/{scan_id}/diff:",
 		"/v1/scans/{scan_id}/events:",
@@ -39,6 +41,8 @@ func TestOpenAPIV1SpecContainsPagingFilterSortParameters(t *testing.T) {
 		"name: scan_id",
 		"name: severity",
 		"name: type",
+		"name: lifecycle_status",
+		"name: assignee",
 		"name: previous_scan_id",
 		"next_cursor:",
 	}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -114,6 +114,9 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		v1.GET("/findings/:finding_id", func(c *gin.Context) {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "scan service unavailable"})
 		})
+		v1.GET("/findings/:finding_id/history", func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{"items": []any{}})
+		})
 		v1.GET("/findings/:finding_id/exports", func(c *gin.Context) {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "scan service unavailable"})
 		})
@@ -157,6 +160,9 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		v1.POST("/scans", func(c *gin.Context) {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "scan service unavailable"})
 		})
+		v1.PATCH("/findings/:finding_id/triage", func(c *gin.Context) {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "scan service unavailable"})
+		})
 		v1.POST("/repo-scans", func(c *gin.Context) {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "repo scan service unavailable"})
 		})
@@ -168,9 +174,11 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		offset := parseCursor(c.Query("cursor"))
 		sortBy, sortDesc := parseSortParams(c.Query("sort_by"), c.Query("sort_order"), "created_at")
 		items, err := svc.ListFindingsFiltered(c.Request.Context(), pageFetchLimit(offset, limit), FindingsFilter{
-			ScanID:   strings.TrimSpace(c.Query("scan_id")),
-			Severity: strings.TrimSpace(c.Query("severity")),
-			Type:     strings.TrimSpace(c.Query("type")),
+			ScanID:          strings.TrimSpace(c.Query("scan_id")),
+			Severity:        strings.TrimSpace(c.Query("severity")),
+			Type:            strings.TrimSpace(c.Query("type")),
+			LifecycleStatus: strings.TrimSpace(c.Query("lifecycle_status")),
+			Assignee:        strings.TrimSpace(c.Query("assignee")),
 		})
 		if err != nil {
 			if errors.Is(err, db.ErrNotFound) {
@@ -219,6 +227,26 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, item)
 	})
 
+	v1.GET("/findings/:finding_id/history", func(c *gin.Context) {
+		limit := parseLimit(c.Query("limit"), defaultEventsLimit, maxListLimit)
+		items, err := svc.ListFindingTriageHistory(
+			c.Request.Context(),
+			strings.TrimSpace(c.Param("finding_id")),
+			strings.TrimSpace(c.Query("scan_id")),
+			limit,
+		)
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "finding not found"})
+				return
+			}
+			logger.Error("list finding history", telemetry.ZapError(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list finding history"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"items": items})
+	})
+
 	v1.GET("/findings/:finding_id/exports", func(c *gin.Context) {
 		exports, err := svc.GetFindingExports(
 			c.Request.Context(),
@@ -251,6 +279,35 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"items": items})
+	})
+
+	v1.PATCH("/findings/:finding_id/triage", requireWriteKeyMiddleware(opts.WriteAPIKeys, opts.APIKeyScopes), func(c *gin.Context) {
+		var request FindingTriageRequest
+		if err := c.ShouldBindJSON(&request); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			return
+		}
+		item, err := svc.TriageFinding(
+			c.Request.Context(),
+			strings.TrimSpace(c.Param("finding_id")),
+			strings.TrimSpace(c.Query("scan_id")),
+			request,
+			triageActorFromContext(c),
+		)
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "finding not found"})
+				return
+			}
+			if errors.Is(err, ErrInvalidFindingTriageRequest) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid triage request"})
+				return
+			}
+			logger.Error("triage finding", telemetry.ZapError(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to triage finding"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"finding": item})
 	})
 
 	v1.GET("/identities", func(c *gin.Context) {
@@ -1382,6 +1439,29 @@ func auditLogMiddleware(logger *zap.Logger, sink AuditSink) gin.HandlerFunc {
 
 func readAPIKey(c *gin.Context) string {
 	return strings.TrimSpace(c.GetHeader("X-API-Key"))
+}
+
+func triageActorFromContext(c *gin.Context) string {
+	if c == nil {
+		return "unknown"
+	}
+	if subjectValue, exists := c.Get("auth.subject"); exists {
+		if subject, ok := subjectValue.(string); ok {
+			normalizedSubject := strings.TrimSpace(subject)
+			if normalizedSubject != "" {
+				return "subject:" + normalizedSubject
+			}
+		}
+	}
+	if apiKeyValue, exists := c.Get("auth.api_key"); exists {
+		if apiKey, ok := apiKeyValue.(string); ok {
+			normalizedKey := strings.TrimSpace(apiKey)
+			if normalizedKey != "" {
+				return "api_key:" + fingerprintAPIKey(normalizedKey)
+			}
+		}
+	}
+	return "unknown"
 }
 
 func readBearerToken(c *gin.Context) string {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -987,6 +987,106 @@ func TestRouterWriteAuthorization(t *testing.T) {
 	}
 }
 
+func TestRouterFindingTriageWorkflowEndpoints(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+	r := NewRouter(logger, metrics, svc, RouterOptions{
+		APIKeys:      []string{"read-key", "write-key"},
+		WriteAPIKeys: []string{"write-key"},
+	})
+
+	triggerReq := httptest.NewRequest(http.MethodPost, "/v1/scans", nil)
+	triggerReq.Header.Set("X-API-Key", "write-key")
+	triggerW := httptest.NewRecorder()
+	r.ServeHTTP(triggerW, triggerReq)
+	if triggerW.Code != http.StatusAccepted {
+		t.Fatalf("expected scan trigger 202, got %d", triggerW.Code)
+	}
+	var triggerBody struct {
+		Scan db.ScanRecord `json:"scan"`
+	}
+	if err := json.Unmarshal(triggerW.Body.Bytes(), &triggerBody); err != nil {
+		t.Fatalf("decode scan trigger body: %v", err)
+	}
+	if triggerBody.Scan.ID == "" {
+		t.Fatal("expected scan id in trigger response")
+	}
+
+	triagePayload := bytes.NewBufferString(`{"status":"ack","assignee":"platform","comment":"acknowledged for follow-up"}`)
+	triageDeniedReq := httptest.NewRequest(http.MethodPatch, "/v1/findings/f1/triage?scan_id="+triggerBody.Scan.ID, bytes.NewBuffer(triagePayload.Bytes()))
+	triageDeniedReq.Header.Set("Content-Type", "application/json")
+	triageDeniedReq.Header.Set("X-API-Key", "read-key")
+	triageDeniedW := httptest.NewRecorder()
+	r.ServeHTTP(triageDeniedW, triageDeniedReq)
+	if triageDeniedW.Code != http.StatusForbidden {
+		t.Fatalf("expected read-key triage to be forbidden, got %d", triageDeniedW.Code)
+	}
+
+	triageReq := httptest.NewRequest(http.MethodPatch, "/v1/findings/f1/triage?scan_id="+triggerBody.Scan.ID, bytes.NewBuffer(triagePayload.Bytes()))
+	triageReq.Header.Set("Content-Type", "application/json")
+	triageReq.Header.Set("X-API-Key", "write-key")
+	triageW := httptest.NewRecorder()
+	r.ServeHTTP(triageW, triageReq)
+	if triageW.Code != http.StatusOK {
+		t.Fatalf("expected write-key triage to pass, got %d", triageW.Code)
+	}
+
+	var triageBody struct {
+		Finding domain.Finding `json:"finding"`
+	}
+	if err := json.Unmarshal(triageW.Body.Bytes(), &triageBody); err != nil {
+		t.Fatalf("decode triage body: %v", err)
+	}
+	if triageBody.Finding.Triage.Status != domain.FindingLifecycleAck {
+		t.Fatalf("expected ack triage status, got %q", triageBody.Finding.Triage.Status)
+	}
+	if triageBody.Finding.Triage.Assignee != "platform" {
+		t.Fatalf("expected platform assignee, got %q", triageBody.Finding.Triage.Assignee)
+	}
+
+	filteredReq := httptest.NewRequest(http.MethodGet, "/v1/findings?lifecycle_status=ack&assignee=platform", nil)
+	filteredReq.Header.Set("X-API-Key", "read-key")
+	filteredW := httptest.NewRecorder()
+	r.ServeHTTP(filteredW, filteredReq)
+	if filteredW.Code != http.StatusOK {
+		t.Fatalf("expected filtered findings 200, got %d", filteredW.Code)
+	}
+	var filteredBody struct {
+		Items []domain.Finding `json:"items"`
+	}
+	if err := json.Unmarshal(filteredW.Body.Bytes(), &filteredBody); err != nil {
+		t.Fatalf("decode filtered findings body: %v", err)
+	}
+	if len(filteredBody.Items) != 1 || filteredBody.Items[0].ID != "f1" {
+		t.Fatalf("unexpected filtered findings: %+v", filteredBody.Items)
+	}
+
+	historyReq := httptest.NewRequest(http.MethodGet, "/v1/findings/f1/history?scan_id="+triggerBody.Scan.ID, nil)
+	historyReq.Header.Set("X-API-Key", "read-key")
+	historyW := httptest.NewRecorder()
+	r.ServeHTTP(historyW, historyReq)
+	if historyW.Code != http.StatusOK {
+		t.Fatalf("expected triage history 200, got %d", historyW.Code)
+	}
+	var historyBody struct {
+		Items []db.FindingTriageEvent `json:"items"`
+	}
+	if err := json.Unmarshal(historyW.Body.Bytes(), &historyBody); err != nil {
+		t.Fatalf("decode history body: %v", err)
+	}
+	if len(historyBody.Items) != 1 {
+		t.Fatalf("expected one history event, got %d", len(historyBody.Items))
+	}
+	if historyBody.Items[0].Action != db.FindingTriageActionAcknowledged {
+		t.Fatalf("expected acknowledged action, got %q", historyBody.Items[0].Action)
+	}
+	if historyBody.Items[0].Actor == "" {
+		t.Fatalf("expected actor on history event, got %+v", historyBody.Items[0])
+	}
+}
+
 func TestRouterWriteAuthorizationRequiresConfiguredWriteKeys(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	metrics := telemetry.NewMetrics()

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1016,6 +1016,13 @@ func TestRouterFindingTriageWorkflowEndpoints(t *testing.T) {
 	if triggerBody.Scan.ID == "" {
 		t.Fatal("expected scan id in trigger response")
 	}
+	processed, err := svc.ProcessNextQueuedScan(context.Background())
+	if err != nil {
+		t.Fatalf("process queued scan: %v", err)
+	}
+	if !processed {
+		t.Fatal("expected one queued scan to be processed")
+	}
 
 	triagePayload := bytes.NewBufferString(`{"status":"ack","assignee":"platform","comment":"acknowledged for follow-up"}`)
 	triageDeniedReq := httptest.NewRequest(http.MethodPatch, "/v1/findings/f1/triage?scan_id="+triggerBody.Scan.ID, bytes.NewBuffer(triagePayload.Bytes()))

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -157,6 +157,9 @@ func TestRouterCORSPreflightBypassesAuth(t *testing.T) {
 	if got := w.Header().Get("Access-Control-Allow-Methods"); !strings.Contains(got, http.MethodGet) {
 		t.Fatalf("expected allow methods header to include GET, got %q", got)
 	}
+	if got := w.Header().Get("Access-Control-Allow-Methods"); !strings.Contains(got, http.MethodPatch) {
+		t.Fatalf("expected allow methods header to include PATCH, got %q", got)
+	}
 	if got := w.Header().Get("Access-Control-Allow-Headers"); !strings.Contains(strings.ToLower(got), "x-api-key") {
 		t.Fatalf("expected allow headers to include x-api-key, got %q", got)
 	}

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -94,9 +94,19 @@ type RepoScanRequest struct {
 
 // FindingsFilter narrows findings list queries without changing API response schema.
 type FindingsFilter struct {
-	ScanID   string
-	Severity string
-	Type     string
+	ScanID          string
+	Severity        string
+	Type            string
+	LifecycleStatus string
+	Assignee        string
+}
+
+// FindingTriageRequest captures one triage mutation request for a finding.
+type FindingTriageRequest struct {
+	Status               *string `json:"status,omitempty"`
+	Assignee             *string `json:"assignee,omitempty"`
+	SuppressionExpiresAt *string `json:"suppression_expires_at,omitempty"`
+	Comment              string  `json:"comment,omitempty"`
 }
 
 // FindingsSummary returns quick aggregation counters for dashboards/alerts.
@@ -157,6 +167,9 @@ var ErrInvalidRepoScanRequest = errors.New("invalid repo scan request")
 
 // ErrRepoScanInProgress is returned when the same repository scan target is already running.
 var ErrRepoScanInProgress = errors.New("repo scan already in progress")
+
+// ErrInvalidFindingTriageRequest indicates invalid triage payload or state transition.
+var ErrInvalidFindingTriageRequest = errors.New("invalid finding triage request")
 
 // ErrRepoScanQueueFull is returned when queued repo scan requests exceed configured capacity.
 var ErrRepoScanQueueFull = errors.New("repo scan queue is full")
@@ -339,7 +352,12 @@ func (s *Service) runScanWithRecord(ctx context.Context, record db.ScanRecord) (
 // ListFindings returns persisted findings.
 func (s *Service) ListFindings(ctx context.Context, limit int) ([]domain.Finding, error) {
 	ctx = s.scopeContext(ctx)
-	return s.Store.ListFindings(ctx, limit)
+	items, err := s.Store.ListFindings(ctx, limit)
+	if err != nil {
+		return nil, err
+	}
+	enriched := enrichFindings(items)
+	return s.applyFindingTriageStates(ctx, enriched)
 }
 
 // RunRepoScan performs one repository exposure scan with configured guardrails.
@@ -546,14 +564,6 @@ func (s *Service) ListRepoFindings(ctx context.Context, limit int, filter db.Rep
 // ListFindingsFiltered returns findings with optional scan/type/severity filters.
 func (s *Service) ListFindingsFiltered(ctx context.Context, limit int, filter FindingsFilter) ([]domain.Finding, error) {
 	ctx = s.scopeContext(ctx)
-	if strings.TrimSpace(filter.ScanID) == "" && strings.TrimSpace(filter.Severity) == "" && strings.TrimSpace(filter.Type) == "" {
-		items, err := s.Store.ListFindings(ctx, limit)
-		if err != nil {
-			return nil, err
-		}
-		return enrichFindings(items), nil
-	}
-
 	loadLimit := limit
 	if loadLimit <= 0 {
 		loadLimit = 100
@@ -575,6 +585,8 @@ func (s *Service) ListFindingsFiltered(ctx context.Context, limit int, filter Fi
 
 	severity := strings.ToLower(strings.TrimSpace(filter.Severity))
 	findingType := strings.ToLower(strings.TrimSpace(filter.Type))
+	lifecycleStatus := strings.ToLower(strings.TrimSpace(filter.LifecycleStatus))
+	assignee := strings.ToLower(strings.TrimSpace(filter.Assignee))
 	result := make([]domain.Finding, 0, len(source))
 	for _, item := range source {
 		if severity != "" && strings.ToLower(string(item.Severity)) != severity {
@@ -584,11 +596,27 @@ func (s *Service) ListFindingsFiltered(ctx context.Context, limit int, filter Fi
 			continue
 		}
 		result = append(result, item)
-		if limit > 0 && len(result) >= limit {
+	}
+	enriched := enrichFindings(result)
+	withTriage, err := s.applyFindingTriageStates(ctx, enriched)
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := make([]domain.Finding, 0, len(withTriage))
+	for _, item := range withTriage {
+		if lifecycleStatus != "" && strings.ToLower(string(item.Triage.Status)) != lifecycleStatus {
+			continue
+		}
+		if assignee != "" && strings.ToLower(strings.TrimSpace(item.Triage.Assignee)) != assignee {
+			continue
+		}
+		filtered = append(filtered, item)
+		if limit > 0 && len(filtered) >= limit {
 			break
 		}
 	}
-	return enrichFindings(result), nil
+	return filtered, nil
 }
 
 // GetFinding returns one finding by id, optionally scoped to one scan.
@@ -607,6 +635,113 @@ func (s *Service) GetFinding(ctx context.Context, findingID string, scanID strin
 		}
 	}
 	return domain.Finding{}, db.ErrNotFound
+}
+
+// TriageFinding applies one workflow mutation and records audit history.
+func (s *Service) TriageFinding(ctx context.Context, findingID string, scanID string, request FindingTriageRequest, actor string) (domain.Finding, error) {
+	id := strings.TrimSpace(findingID)
+	if id == "" {
+		return domain.Finding{}, db.ErrNotFound
+	}
+	if _, err := s.GetFinding(ctx, id, scanID); err != nil {
+		return domain.Finding{}, err
+	}
+	if request.Status == nil && request.Assignee == nil && request.SuppressionExpiresAt == nil && strings.TrimSpace(request.Comment) == "" {
+		return domain.Finding{}, ErrInvalidFindingTriageRequest
+	}
+
+	now := s.Now().UTC()
+	currentState, err := s.Store.GetFindingTriageState(ctx, id)
+	if err != nil && !errors.Is(err, db.ErrNotFound) {
+		return domain.Finding{}, err
+	}
+	if errors.Is(err, db.ErrNotFound) {
+		currentState = db.FindingTriageState{
+			FindingID: id,
+			Status:    domain.FindingLifecycleOpen,
+		}
+	}
+	currentState = normalizeFindingTriageState(currentState, now)
+	nextState := currentState
+	changed := false
+
+	if request.Status != nil {
+		parsedStatus, parseErr := parseFindingLifecycleStatus(*request.Status)
+		if parseErr != nil {
+			return domain.Finding{}, parseErr
+		}
+		if nextState.Status != parsedStatus {
+			changed = true
+		}
+		nextState.Status = parsedStatus
+	}
+	if request.Assignee != nil {
+		nextAssignee := strings.TrimSpace(*request.Assignee)
+		if nextState.Assignee != nextAssignee {
+			changed = true
+		}
+		nextState.Assignee = nextAssignee
+	}
+	if request.SuppressionExpiresAt != nil {
+		parsedExpiry, parseErr := parseSuppressionExpiry(*request.SuppressionExpiresAt, now)
+		if parseErr != nil {
+			return domain.Finding{}, parseErr
+		}
+		if !timePointersEqual(nextState.SuppressionExpiresAt, parsedExpiry) {
+			changed = true
+		}
+		nextState.SuppressionExpiresAt = parsedExpiry
+	}
+	if nextState.Status != domain.FindingLifecycleSuppressed && nextState.SuppressionExpiresAt != nil {
+		nextState.SuppressionExpiresAt = nil
+		changed = true
+	}
+	if nextState.Status == domain.FindingLifecycleSuppressed && nextState.SuppressionExpiresAt != nil && !nextState.SuppressionExpiresAt.After(now) {
+		return domain.Finding{}, ErrInvalidFindingTriageRequest
+	}
+	comment := strings.TrimSpace(request.Comment)
+	if !changed && comment == "" {
+		return domain.Finding{}, ErrInvalidFindingTriageRequest
+	}
+
+	nextState.FindingID = id
+	nextState.UpdatedAt = now
+	nextState.UpdatedBy = normalizeActor(actor)
+	if nextState.Status == "" {
+		nextState.Status = domain.FindingLifecycleOpen
+	}
+
+	if err := s.Store.UpsertFindingTriageState(ctx, nextState); err != nil {
+		return domain.Finding{}, err
+	}
+	action := deriveFindingTriageAction(currentState, nextState, comment)
+	if err := s.Store.AppendFindingTriageEvent(ctx, db.FindingTriageEvent{
+		FindingID:            id,
+		Action:               action,
+		FromStatus:           currentState.Status,
+		ToStatus:             nextState.Status,
+		Assignee:             nextState.Assignee,
+		SuppressionExpiresAt: nextState.SuppressionExpiresAt,
+		Comment:              comment,
+		Actor:                nextState.UpdatedBy,
+		CreatedAt:            now,
+	}); err != nil {
+		return domain.Finding{}, err
+	}
+
+	return s.GetFinding(ctx, id, scanID)
+}
+
+// ListFindingTriageHistory returns triage actions newest-first for one finding.
+func (s *Service) ListFindingTriageHistory(ctx context.Context, findingID string, scanID string, limit int) ([]db.FindingTriageEvent, error) {
+	id := strings.TrimSpace(findingID)
+	if id == "" {
+		return nil, db.ErrNotFound
+	}
+	if _, err := s.GetFinding(ctx, id, scanID); err != nil {
+		return nil, err
+	}
+	return s.Store.ListFindingTriageEvents(ctx, id, limit)
 }
 
 // GetFindingExports returns OCSF-aligned and ASFF payloads for one finding.
@@ -961,6 +1096,145 @@ func enrichFindings(findings []domain.Finding) []domain.Finding {
 		enriched = append(enriched, standards.EnrichFinding(finding))
 	}
 	return enriched
+}
+
+func (s *Service) applyFindingTriageStates(ctx context.Context, findings []domain.Finding) ([]domain.Finding, error) {
+	if len(findings) == 0 {
+		return findings, nil
+	}
+	ids := make([]string, 0, len(findings))
+	seen := map[string]struct{}{}
+	for _, finding := range findings {
+		id := strings.TrimSpace(finding.ID)
+		if id == "" {
+			continue
+		}
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	states, err := s.Store.ListFindingTriageStates(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	byID := map[string]db.FindingTriageState{}
+	now := s.Now().UTC()
+	for _, state := range states {
+		normalized := normalizeFindingTriageState(state, now)
+		byID[normalized.FindingID] = normalized
+	}
+	result := make([]domain.Finding, 0, len(findings))
+	for _, finding := range findings {
+		triage := domain.DefaultFindingTriage()
+		if state, exists := byID[strings.TrimSpace(finding.ID)]; exists {
+			updatedAt := state.UpdatedAt.UTC()
+			triage = domain.FindingTriage{
+				Status:               state.Status,
+				Assignee:             state.Assignee,
+				SuppressionExpiresAt: state.SuppressionExpiresAt,
+				UpdatedAt:            &updatedAt,
+				UpdatedBy:            state.UpdatedBy,
+			}
+		}
+		finding.Triage = triage
+		result = append(result, finding)
+	}
+	return result, nil
+}
+
+func normalizeFindingTriageState(state db.FindingTriageState, now time.Time) db.FindingTriageState {
+	if state.Status == "" {
+		state.Status = domain.FindingLifecycleOpen
+	}
+	if !isValidFindingLifecycleStatus(state.Status) {
+		state.Status = domain.FindingLifecycleOpen
+	}
+	if state.Status == domain.FindingLifecycleSuppressed && state.SuppressionExpiresAt != nil && !state.SuppressionExpiresAt.After(now) {
+		state.Status = domain.FindingLifecycleOpen
+		state.SuppressionExpiresAt = nil
+	}
+	if state.Status != domain.FindingLifecycleSuppressed {
+		state.SuppressionExpiresAt = nil
+	}
+	return state
+}
+
+func parseFindingLifecycleStatus(raw string) (domain.FindingLifecycleStatus, error) {
+	status := domain.FindingLifecycleStatus(strings.ToLower(strings.TrimSpace(raw)))
+	if !isValidFindingLifecycleStatus(status) {
+		return "", ErrInvalidFindingTriageRequest
+	}
+	return status, nil
+}
+
+func isValidFindingLifecycleStatus(status domain.FindingLifecycleStatus) bool {
+	switch status {
+	case domain.FindingLifecycleOpen, domain.FindingLifecycleAck, domain.FindingLifecycleSuppressed, domain.FindingLifecycleResolved:
+		return true
+	default:
+		return false
+	}
+}
+
+func parseSuppressionExpiry(raw string, now time.Time) (*time.Time, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return nil, nil
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return nil, ErrInvalidFindingTriageRequest
+	}
+	normalized := parsed.UTC()
+	if !normalized.After(now) {
+		return nil, ErrInvalidFindingTriageRequest
+	}
+	return &normalized, nil
+}
+
+func timePointersEqual(a *time.Time, b *time.Time) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return a.UTC().Equal(b.UTC())
+}
+
+func normalizeActor(actor string) string {
+	normalized := strings.TrimSpace(actor)
+	if normalized == "" {
+		return "unknown"
+	}
+	return normalized
+}
+
+func deriveFindingTriageAction(current db.FindingTriageState, next db.FindingTriageState, comment string) string {
+	if current.Status != next.Status {
+		switch next.Status {
+		case domain.FindingLifecycleAck:
+			return db.FindingTriageActionAcknowledged
+		case domain.FindingLifecycleSuppressed:
+			return db.FindingTriageActionSuppressed
+		case domain.FindingLifecycleResolved:
+			return db.FindingTriageActionResolved
+		case domain.FindingLifecycleOpen:
+			return db.FindingTriageActionReopened
+		}
+	}
+	if current.Assignee != next.Assignee {
+		return db.FindingTriageActionAssigned
+	}
+	if !timePointersEqual(current.SuppressionExpiresAt, next.SuppressionExpiresAt) {
+		return db.FindingTriageActionSuppression
+	}
+	if strings.TrimSpace(comment) != "" {
+		return db.FindingTriageActionCommented
+	}
+	return db.FindingTriageActionCommented
 }
 
 func truncateSourceErrors(errors []providers.SourceError, max int) []providers.SourceError {

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -711,11 +711,8 @@ func (s *Service) TriageFinding(ctx context.Context, findingID string, scanID st
 		nextState.Status = domain.FindingLifecycleOpen
 	}
 
-	if err := s.Store.UpsertFindingTriageState(ctx, nextState); err != nil {
-		return domain.Finding{}, err
-	}
 	action := deriveFindingTriageAction(currentState, nextState, comment)
-	if err := s.Store.AppendFindingTriageEvent(ctx, db.FindingTriageEvent{
+	if err := s.Store.ApplyFindingTriageTransition(ctx, nextState, db.FindingTriageEvent{
 		FindingID:            id,
 		Action:               action,
 		FromStatus:           currentState.Status,

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -251,6 +251,136 @@ func TestServiceGetFinding(t *testing.T) {
 	}
 }
 
+func TestServiceFindingTriageLifecycleAndHistory(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 3, 22, 9, 0, 0, 0, time.UTC)
+	scan, err := store.CreateScan(context.Background(), "aws", now)
+	if err != nil {
+		t.Fatalf("create scan: %v", err)
+	}
+	if err := store.UpsertFindings(context.Background(), scan.ID, []domain.Finding{
+		{ID: "finding-1", Type: domain.FindingOwnerless, Severity: domain.SeverityHigh, CreatedAt: now},
+	}); err != nil {
+		t.Fatalf("upsert findings: %v", err)
+	}
+
+	clock := now
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return clock }
+
+	initial, err := svc.GetFinding(context.Background(), "finding-1", scan.ID)
+	if err != nil {
+		t.Fatalf("get initial finding: %v", err)
+	}
+	if initial.Triage.Status != domain.FindingLifecycleOpen {
+		t.Fatalf("expected default open status, got %q", initial.Triage.Status)
+	}
+
+	suppressed := string(domain.FindingLifecycleSuppressed)
+	assignee := "secops"
+	suppressionExpiry := clock.Add(2 * time.Hour).Format(time.RFC3339)
+	updated, err := svc.TriageFinding(
+		context.Background(),
+		"finding-1",
+		scan.ID,
+		FindingTriageRequest{
+			Status:               &suppressed,
+			Assignee:             &assignee,
+			SuppressionExpiresAt: &suppressionExpiry,
+			Comment:              "accepted risk until patch lands",
+		},
+		"subject:user-1",
+	)
+	if err != nil {
+		t.Fatalf("triage finding: %v", err)
+	}
+	if updated.Triage.Status != domain.FindingLifecycleSuppressed {
+		t.Fatalf("expected suppressed status, got %q", updated.Triage.Status)
+	}
+	if updated.Triage.Assignee != "secops" {
+		t.Fatalf("expected assignee secops, got %q", updated.Triage.Assignee)
+	}
+	if updated.Triage.SuppressionExpiresAt == nil {
+		t.Fatal("expected suppression expiry to be set")
+	}
+	if updated.Triage.UpdatedBy != "subject:user-1" {
+		t.Fatalf("expected triage actor to be persisted, got %q", updated.Triage.UpdatedBy)
+	}
+
+	history, err := svc.ListFindingTriageHistory(context.Background(), "finding-1", scan.ID, 10)
+	if err != nil {
+		t.Fatalf("list triage history: %v", err)
+	}
+	if len(history) != 1 {
+		t.Fatalf("expected one triage event, got %d", len(history))
+	}
+	if history[0].Action != db.FindingTriageActionSuppressed {
+		t.Fatalf("expected suppressed action, got %q", history[0].Action)
+	}
+	if history[0].FromStatus != domain.FindingLifecycleOpen || history[0].ToStatus != domain.FindingLifecycleSuppressed {
+		t.Fatalf("unexpected status transition: %+v", history[0])
+	}
+
+	suppressedItems, err := svc.ListFindingsFiltered(context.Background(), 10, FindingsFilter{
+		LifecycleStatus: "suppressed",
+		Assignee:        "SECOPS",
+	})
+	if err != nil {
+		t.Fatalf("list suppressed findings: %v", err)
+	}
+	if len(suppressedItems) != 1 || suppressedItems[0].ID != "finding-1" {
+		t.Fatalf("unexpected suppressed filter result: %+v", suppressedItems)
+	}
+
+	clock = clock.Add(3 * time.Hour)
+	reopened, err := svc.GetFinding(context.Background(), "finding-1", scan.ID)
+	if err != nil {
+		t.Fatalf("get finding after suppression expiry: %v", err)
+	}
+	if reopened.Triage.Status != domain.FindingLifecycleOpen {
+		t.Fatalf("expected suppression expiry to reopen finding, got %q", reopened.Triage.Status)
+	}
+	if reopened.Triage.SuppressionExpiresAt != nil {
+		t.Fatalf("expected suppression expiry cleared after expiration, got %v", reopened.Triage.SuppressionExpiresAt)
+	}
+}
+
+func TestServiceTriageFindingRejectsInvalidRequest(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 3, 22, 9, 0, 0, 0, time.UTC)
+	scan, err := store.CreateScan(context.Background(), "aws", now)
+	if err != nil {
+		t.Fatalf("create scan: %v", err)
+	}
+	if err := store.UpsertFindings(context.Background(), scan.ID, []domain.Finding{
+		{ID: "finding-1", Type: domain.FindingOwnerless, Severity: domain.SeverityHigh, CreatedAt: now},
+	}); err != nil {
+		t.Fatalf("upsert findings: %v", err)
+	}
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	if _, err := svc.TriageFinding(context.Background(), "finding-1", scan.ID, FindingTriageRequest{}, "subject:user-1"); !errors.Is(err, ErrInvalidFindingTriageRequest) {
+		t.Fatalf("expected invalid triage request error for empty payload, got %v", err)
+	}
+
+	suppressed := string(domain.FindingLifecycleSuppressed)
+	pastExpiry := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	if _, err := svc.TriageFinding(
+		context.Background(),
+		"finding-1",
+		scan.ID,
+		FindingTriageRequest{
+			Status:               &suppressed,
+			SuppressionExpiresAt: &pastExpiry,
+		},
+		"subject:user-1",
+	); !errors.Is(err, ErrInvalidFindingTriageRequest) {
+		t.Fatalf("expected invalid triage request error for past suppression expiry, got %v", err)
+	}
+}
+
 func TestServiceGetFindingExports(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -18,6 +18,8 @@ type MemoryStore struct {
 	scans        map[string]ScanRecord
 	scanIDs      []string
 	findings     map[string]domain.Finding
+	triageStates map[string]FindingTriageState
+	triageEvents map[string][]FindingTriageEvent
 	events       map[string][]ScanEvent
 	repoScans    map[string]RepoScanRecord
 	repoScanIDs  []string
@@ -36,6 +38,8 @@ func NewMemoryStore() *MemoryStore {
 		scans:        map[string]ScanRecord{},
 		scanIDs:      []string{},
 		findings:     map[string]domain.Finding{},
+		triageStates: map[string]FindingTriageState{},
+		triageEvents: map[string][]FindingTriageEvent{},
 		events:       map[string][]ScanEvent{},
 		repoScans:    map[string]RepoScanRecord{},
 		repoScanIDs:  []string{},
@@ -188,6 +192,101 @@ func (m *MemoryStore) UpsertFindings(ctx context.Context, scanID string, finding
 		m.findings[key] = finding
 	}
 	return nil
+}
+
+// GetFindingTriageState returns triage workflow state for one finding id.
+func (m *MemoryStore) GetFindingTriageState(_ context.Context, findingID string) (FindingTriageState, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	state, exists := m.triageStates[strings.TrimSpace(findingID)]
+	if !exists {
+		return FindingTriageState{}, ErrNotFound
+	}
+	return state, nil
+}
+
+// ListFindingTriageStates returns triage states for provided finding ids.
+func (m *MemoryStore) ListFindingTriageStates(_ context.Context, findingIDs []string) ([]FindingTriageState, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	seen := map[string]struct{}{}
+	result := make([]FindingTriageState, 0, len(findingIDs))
+	for _, findingID := range findingIDs {
+		normalized := strings.TrimSpace(findingID)
+		if normalized == "" {
+			continue
+		}
+		if _, exists := seen[normalized]; exists {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		state, exists := m.triageStates[normalized]
+		if !exists {
+			continue
+		}
+		result = append(result, state)
+	}
+	return result, nil
+}
+
+// UpsertFindingTriageState creates or updates mutable triage metadata.
+func (m *MemoryStore) UpsertFindingTriageState(_ context.Context, state FindingTriageState) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	normalizedID := strings.TrimSpace(state.FindingID)
+	if normalizedID == "" {
+		return fmt.Errorf("finding id is required")
+	}
+	state.FindingID = normalizedID
+	state.Assignee = strings.TrimSpace(state.Assignee)
+	state.UpdatedBy = strings.TrimSpace(state.UpdatedBy)
+	state.UpdatedAt = state.UpdatedAt.UTC()
+	m.triageStates[normalizedID] = state
+	return nil
+}
+
+// AppendFindingTriageEvent records one immutable triage action.
+func (m *MemoryStore) AppendFindingTriageEvent(_ context.Context, event FindingTriageEvent) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	normalizedID := strings.TrimSpace(event.FindingID)
+	if normalizedID == "" {
+		return fmt.Errorf("finding id is required")
+	}
+	if strings.TrimSpace(event.ID) == "" {
+		event.ID = uuid.NewString()
+	}
+	event.FindingID = normalizedID
+	event.Action = strings.TrimSpace(event.Action)
+	event.Assignee = strings.TrimSpace(event.Assignee)
+	event.Comment = strings.TrimSpace(event.Comment)
+	event.Actor = strings.TrimSpace(event.Actor)
+	event.CreatedAt = event.CreatedAt.UTC()
+	m.triageEvents[normalizedID] = append(m.triageEvents[normalizedID], event)
+	return nil
+}
+
+// ListFindingTriageEvents returns triage actions newest-first for one finding id.
+func (m *MemoryStore) ListFindingTriageEvents(_ context.Context, findingID string, limit int) ([]FindingTriageEvent, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	normalizedID := strings.TrimSpace(findingID)
+	if normalizedID == "" {
+		return nil, ErrNotFound
+	}
+	events := append([]FindingTriageEvent(nil), m.triageEvents[normalizedID]...)
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].CreatedAt.After(events[j].CreatedAt)
+	})
+	if limit > 0 && len(events) > limit {
+		events = events[:limit]
+	}
+	return events, nil
 }
 
 // UpsertArtifacts persists raw and normalized scan artifacts idempotently.

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -233,40 +233,46 @@ func (m *MemoryStore) ListFindingTriageStates(_ context.Context, findingIDs []st
 
 // UpsertFindingTriageState creates or updates mutable triage metadata.
 func (m *MemoryStore) UpsertFindingTriageState(_ context.Context, state FindingTriageState) error {
+	normalized, err := normalizeFindingTriageStateForWrite(state)
+	if err != nil {
+		return err
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-
-	normalizedID := strings.TrimSpace(state.FindingID)
-	if normalizedID == "" {
-		return fmt.Errorf("finding id is required")
-	}
-	state.FindingID = normalizedID
-	state.Assignee = strings.TrimSpace(state.Assignee)
-	state.UpdatedBy = strings.TrimSpace(state.UpdatedBy)
-	state.UpdatedAt = state.UpdatedAt.UTC()
-	m.triageStates[normalizedID] = state
+	m.triageStates[normalized.FindingID] = normalized
 	return nil
 }
 
 // AppendFindingTriageEvent records one immutable triage action.
 func (m *MemoryStore) AppendFindingTriageEvent(_ context.Context, event FindingTriageEvent) error {
+	normalized, err := normalizeFindingTriageEventForWrite(event)
+	if err != nil {
+		return err
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.triageEvents[normalized.FindingID] = append(m.triageEvents[normalized.FindingID], normalized)
+	return nil
+}
 
-	normalizedID := strings.TrimSpace(event.FindingID)
-	if normalizedID == "" {
-		return fmt.Errorf("finding id is required")
+// ApplyFindingTriageTransition persists state and audit history atomically.
+func (m *MemoryStore) ApplyFindingTriageTransition(_ context.Context, state FindingTriageState, event FindingTriageEvent) error {
+	normalizedState, err := normalizeFindingTriageStateForWrite(state)
+	if err != nil {
+		return err
 	}
-	if strings.TrimSpace(event.ID) == "" {
-		event.ID = uuid.NewString()
+	normalizedEvent, err := normalizeFindingTriageEventForWrite(event)
+	if err != nil {
+		return err
 	}
-	event.FindingID = normalizedID
-	event.Action = strings.TrimSpace(event.Action)
-	event.Assignee = strings.TrimSpace(event.Assignee)
-	event.Comment = strings.TrimSpace(event.Comment)
-	event.Actor = strings.TrimSpace(event.Actor)
-	event.CreatedAt = event.CreatedAt.UTC()
-	m.triageEvents[normalizedID] = append(m.triageEvents[normalizedID], event)
+	if normalizedState.FindingID != normalizedEvent.FindingID {
+		return fmt.Errorf("finding id mismatch between state and event")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.triageStates[normalizedState.FindingID] = normalizedState
+	m.triageEvents[normalizedState.FindingID] = append(m.triageEvents[normalizedState.FindingID], normalizedEvent)
 	return nil
 }
 
@@ -537,6 +543,43 @@ func scanKeyPrefix(key string) string {
 		return ""
 	}
 	return parts[0]
+}
+
+func normalizeFindingTriageStateForWrite(state FindingTriageState) (FindingTriageState, error) {
+	normalizedID := strings.TrimSpace(state.FindingID)
+	if normalizedID == "" {
+		return FindingTriageState{}, fmt.Errorf("finding id is required")
+	}
+	state.FindingID = normalizedID
+	state.Assignee = strings.TrimSpace(state.Assignee)
+	state.UpdatedBy = strings.TrimSpace(state.UpdatedBy)
+	if state.UpdatedAt.IsZero() {
+		state.UpdatedAt = time.Now().UTC()
+	} else {
+		state.UpdatedAt = state.UpdatedAt.UTC()
+	}
+	return state, nil
+}
+
+func normalizeFindingTriageEventForWrite(event FindingTriageEvent) (FindingTriageEvent, error) {
+	normalizedID := strings.TrimSpace(event.FindingID)
+	if normalizedID == "" {
+		return FindingTriageEvent{}, fmt.Errorf("finding id is required")
+	}
+	if strings.TrimSpace(event.ID) == "" {
+		event.ID = uuid.NewString()
+	}
+	event.FindingID = normalizedID
+	event.Action = strings.TrimSpace(event.Action)
+	event.Assignee = strings.TrimSpace(event.Assignee)
+	event.Comment = strings.TrimSpace(event.Comment)
+	event.Actor = strings.TrimSpace(event.Actor)
+	if event.CreatedAt.IsZero() {
+		event.CreatedAt = time.Now().UTC()
+	} else {
+		event.CreatedAt = event.CreatedAt.UTC()
+	}
+	return event, nil
 }
 
 // CreateRepoScan persists one repository exposure scan start event.

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 	"sync"

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -288,6 +288,79 @@ func TestMemoryStoreRepoScanErrors(t *testing.T) {
 	}
 }
 
+func TestMemoryStoreFindingTriageStateAndHistory(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 3, 28, 9, 0, 0, 0, time.UTC)
+	expiry := now.Add(24 * time.Hour)
+
+	if _, err := store.GetFindingTriageState(context.Background(), "finding-1"); err == nil {
+		t.Fatal("expected missing triage state error")
+	}
+
+	state := FindingTriageState{
+		FindingID:            "finding-1",
+		Status:               domain.FindingLifecycleSuppressed,
+		Assignee:             "sec-oncall",
+		SuppressionExpiresAt: &expiry,
+		UpdatedAt:            now,
+		UpdatedBy:            "subject:alice",
+	}
+	if err := store.UpsertFindingTriageState(context.Background(), state); err != nil {
+		t.Fatalf("upsert triage state: %v", err)
+	}
+	gotState, err := store.GetFindingTriageState(context.Background(), "finding-1")
+	if err != nil {
+		t.Fatalf("get triage state: %v", err)
+	}
+	if gotState.Status != domain.FindingLifecycleSuppressed || gotState.Assignee != "sec-oncall" {
+		t.Fatalf("unexpected triage state: %+v", gotState)
+	}
+
+	states, err := store.ListFindingTriageStates(context.Background(), []string{"finding-1", "missing"})
+	if err != nil {
+		t.Fatalf("list triage states: %v", err)
+	}
+	if len(states) != 1 || states[0].FindingID != "finding-1" {
+		t.Fatalf("unexpected triage states: %+v", states)
+	}
+
+	firstEvent := FindingTriageEvent{
+		FindingID:  "finding-1",
+		Action:     FindingTriageActionSuppressed,
+		FromStatus: domain.FindingLifecycleOpen,
+		ToStatus:   domain.FindingLifecycleSuppressed,
+		Assignee:   "sec-oncall",
+		Comment:    "temporary exception",
+		Actor:      "subject:alice",
+		CreatedAt:  now,
+	}
+	secondEvent := FindingTriageEvent{
+		FindingID:  "finding-1",
+		Action:     FindingTriageActionCommented,
+		FromStatus: domain.FindingLifecycleSuppressed,
+		ToStatus:   domain.FindingLifecycleSuppressed,
+		Comment:    "reviewed",
+		Actor:      "subject:bob",
+		CreatedAt:  now.Add(1 * time.Minute),
+	}
+	if err := store.AppendFindingTriageEvent(context.Background(), firstEvent); err != nil {
+		t.Fatalf("append first triage event: %v", err)
+	}
+	if err := store.AppendFindingTriageEvent(context.Background(), secondEvent); err != nil {
+		t.Fatalf("append second triage event: %v", err)
+	}
+	events, err := store.ListFindingTriageEvents(context.Background(), "finding-1", 10)
+	if err != nil {
+		t.Fatalf("list triage events: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 triage events, got %d", len(events))
+	}
+	if events[0].Action != FindingTriageActionCommented {
+		t.Fatalf("expected latest event first, got %+v", events)
+	}
+}
+
 func TestMemoryStoreScanQueueLifecycle(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 21, 9, 0, 0, 0, time.UTC)

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -361,6 +361,37 @@ func TestMemoryStoreFindingTriageStateAndHistory(t *testing.T) {
 	}
 }
 
+func TestMemoryStoreApplyFindingTriageTransitionAtomic(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 3, 28, 12, 0, 0, 0, time.UTC)
+
+	err := store.ApplyFindingTriageTransition(context.Background(), FindingTriageState{
+		FindingID: "finding-1",
+		Status:    domain.FindingLifecycleAck,
+		UpdatedAt: now,
+		UpdatedBy: "subject:alice",
+	}, FindingTriageEvent{
+		FindingID:  "finding-2",
+		Action:     FindingTriageActionAcknowledged,
+		FromStatus: domain.FindingLifecycleOpen,
+		ToStatus:   domain.FindingLifecycleAck,
+		CreatedAt:  now,
+	})
+	if err == nil {
+		t.Fatal("expected mismatch error for triage transition")
+	}
+	if _, err := store.GetFindingTriageState(context.Background(), "finding-1"); err == nil {
+		t.Fatal("expected no state to be persisted after failed transition")
+	}
+	events, err := store.ListFindingTriageEvents(context.Background(), "finding-1", 10)
+	if err != nil {
+		t.Fatalf("list triage events after failed transition: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("expected no events to be persisted after failed transition, got %d", len(events))
+	}
+}
+
 func TestMemoryStoreScanQueueLifecycle(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 21, 9, 0, 0, 0, time.UTC)

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -78,6 +78,26 @@ func TestFourthMigrationContainsPerformanceIndexes(t *testing.T) {
 	}
 }
 
+func TestFifthMigrationContainsFindingWorkflowTables(t *testing.T) {
+	path := filepath.Join("..", "..", "migrations", "000005_finding_workflow_maturity.up.sql")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	text := string(content)
+	required := []string{
+		"CREATE TABLE IF NOT EXISTS finding_triage_states",
+		"CREATE TABLE IF NOT EXISTS finding_triage_events",
+		"idx_finding_triage_states_status",
+		"idx_finding_triage_events_finding_created",
+	}
+	for _, item := range required {
+		if !strings.Contains(text, item) {
+			t.Fatalf("expected workflow migration to contain %q", item)
+		}
+	}
+}
+
 func TestSixthMigrationContainsTenantWorkspaceScope(t *testing.T) {
 	path := filepath.Join("..", "..", "migrations", "000006_tenant_workspace_scope.up.sql")
 	content, err := os.ReadFile(path)

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -506,7 +506,7 @@ func (p *PostgresStore) ListFindingTriageEvents(ctx context.Context, findingID s
 	}
 	defer rows.Close()
 
-	result := make([]FindingTriageEvent, 0, limit)
+	result := []FindingTriageEvent{}
 	for rows.Next() {
 		var event FindingTriageEvent
 		var suppressionExpiresAt sql.NullTime

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -485,8 +485,11 @@ func (p *PostgresStore) ApplyFindingTriageTransition(ctx context.Context, state 
 
 // ListFindingTriageEvents returns triage history newest-first for one finding id.
 func (p *PostgresStore) ListFindingTriageEvents(ctx context.Context, findingID string, limit int) ([]FindingTriageEvent, error) {
+	const maxFindingTriageEventsLimit = 500
 	if limit <= 0 {
 		limit = 100
+	} else if limit > maxFindingTriageEventsLimit {
+		limit = maxFindingTriageEventsLimit
 	}
 	rows, err := p.db.QueryContext(
 		ctx,

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -287,6 +287,214 @@ func (p *PostgresStore) UpsertFindings(ctx context.Context, scanID string, findi
 	return nil
 }
 
+// GetFindingTriageState returns triage workflow state for one finding id.
+func (p *PostgresStore) GetFindingTriageState(ctx context.Context, findingID string) (FindingTriageState, error) {
+	row := p.db.QueryRowContext(
+		ctx,
+		`SELECT finding_id, status, assignee, suppression_expires_at, updated_at, updated_by
+		 FROM finding_triage_states
+		 WHERE finding_id = $1`,
+		strings.TrimSpace(findingID),
+	)
+	var state FindingTriageState
+	var suppressionExpiresAt sql.NullTime
+	if err := row.Scan(
+		&state.FindingID,
+		&state.Status,
+		&state.Assignee,
+		&suppressionExpiresAt,
+		&state.UpdatedAt,
+		&state.UpdatedBy,
+	); err != nil {
+		if err == sql.ErrNoRows {
+			return FindingTriageState{}, ErrNotFound
+		}
+		return FindingTriageState{}, fmt.Errorf("query finding triage state: %w", err)
+	}
+	if suppressionExpiresAt.Valid {
+		value := suppressionExpiresAt.Time.UTC()
+		state.SuppressionExpiresAt = &value
+	}
+	state.UpdatedAt = state.UpdatedAt.UTC()
+	return state, nil
+}
+
+// ListFindingTriageStates returns triage states for provided finding ids.
+func (p *PostgresStore) ListFindingTriageStates(ctx context.Context, findingIDs []string) ([]FindingTriageState, error) {
+	unique := make([]string, 0, len(findingIDs))
+	seen := map[string]struct{}{}
+	for _, findingID := range findingIDs {
+		normalized := strings.TrimSpace(findingID)
+		if normalized == "" {
+			continue
+		}
+		if _, exists := seen[normalized]; exists {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		unique = append(unique, normalized)
+	}
+	if len(unique) == 0 {
+		return []FindingTriageState{}, nil
+	}
+
+	placeholders := make([]string, len(unique))
+	args := make([]any, len(unique))
+	for i, findingID := range unique {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+		args[i] = findingID
+	}
+	query := fmt.Sprintf(
+		`SELECT finding_id, status, assignee, suppression_expires_at, updated_at, updated_by
+		 FROM finding_triage_states
+		 WHERE finding_id IN (%s)`,
+		strings.Join(placeholders, ", "),
+	)
+	rows, err := p.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query finding triage states: %w", err)
+	}
+	defer rows.Close()
+
+	result := make([]FindingTriageState, 0, len(unique))
+	for rows.Next() {
+		var state FindingTriageState
+		var suppressionExpiresAt sql.NullTime
+		if err := rows.Scan(
+			&state.FindingID,
+			&state.Status,
+			&state.Assignee,
+			&suppressionExpiresAt,
+			&state.UpdatedAt,
+			&state.UpdatedBy,
+		); err != nil {
+			return nil, fmt.Errorf("scan finding triage state row: %w", err)
+		}
+		if suppressionExpiresAt.Valid {
+			value := suppressionExpiresAt.Time.UTC()
+			state.SuppressionExpiresAt = &value
+		}
+		state.UpdatedAt = state.UpdatedAt.UTC()
+		result = append(result, state)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("finding triage state rows: %w", err)
+	}
+	return result, nil
+}
+
+// UpsertFindingTriageState creates or updates mutable triage metadata.
+func (p *PostgresStore) UpsertFindingTriageState(ctx context.Context, state FindingTriageState) error {
+	updatedAt := state.UpdatedAt
+	if updatedAt.IsZero() {
+		updatedAt = time.Now().UTC()
+	}
+	_, err := p.db.ExecContext(
+		ctx,
+		`INSERT INTO finding_triage_states (finding_id, status, assignee, suppression_expires_at, updated_at, updated_by)
+		 VALUES ($1, $2, $3, $4, $5, $6)
+		 ON CONFLICT (finding_id)
+		 DO UPDATE SET
+		   status = EXCLUDED.status,
+		   assignee = EXCLUDED.assignee,
+		   suppression_expires_at = EXCLUDED.suppression_expires_at,
+		   updated_at = EXCLUDED.updated_at,
+		   updated_by = EXCLUDED.updated_by`,
+		strings.TrimSpace(state.FindingID),
+		strings.TrimSpace(string(state.Status)),
+		strings.TrimSpace(state.Assignee),
+		state.SuppressionExpiresAt,
+		updatedAt.UTC(),
+		strings.TrimSpace(state.UpdatedBy),
+	)
+	if err != nil {
+		return fmt.Errorf("upsert finding triage state: %w", err)
+	}
+	return nil
+}
+
+// AppendFindingTriageEvent records one immutable triage action.
+func (p *PostgresStore) AppendFindingTriageEvent(ctx context.Context, event FindingTriageEvent) error {
+	createdAt := event.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	eventID := strings.TrimSpace(event.ID)
+	if eventID == "" {
+		eventID = uuid.NewString()
+	}
+	_, err := p.db.ExecContext(
+		ctx,
+		`INSERT INTO finding_triage_events (id, finding_id, action, from_status, to_status, assignee, suppression_expires_at, comment, actor, created_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+		eventID,
+		strings.TrimSpace(event.FindingID),
+		strings.TrimSpace(event.Action),
+		strings.TrimSpace(string(event.FromStatus)),
+		strings.TrimSpace(string(event.ToStatus)),
+		strings.TrimSpace(event.Assignee),
+		event.SuppressionExpiresAt,
+		strings.TrimSpace(event.Comment),
+		strings.TrimSpace(event.Actor),
+		createdAt.UTC(),
+	)
+	if err != nil {
+		return fmt.Errorf("insert finding triage event: %w", err)
+	}
+	return nil
+}
+
+// ListFindingTriageEvents returns triage history newest-first for one finding id.
+func (p *PostgresStore) ListFindingTriageEvents(ctx context.Context, findingID string, limit int) ([]FindingTriageEvent, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := p.db.QueryContext(
+		ctx,
+		`SELECT id, finding_id, action, from_status, to_status, assignee, suppression_expires_at, comment, actor, created_at
+		 FROM finding_triage_events
+		 WHERE finding_id = $1
+		 ORDER BY created_at DESC
+		 LIMIT $2`,
+		strings.TrimSpace(findingID),
+		limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query finding triage events: %w", err)
+	}
+	defer rows.Close()
+
+	result := make([]FindingTriageEvent, 0, limit)
+	for rows.Next() {
+		var event FindingTriageEvent
+		var suppressionExpiresAt sql.NullTime
+		if err := rows.Scan(
+			&event.ID,
+			&event.FindingID,
+			&event.Action,
+			&event.FromStatus,
+			&event.ToStatus,
+			&event.Assignee,
+			&suppressionExpiresAt,
+			&event.Comment,
+			&event.Actor,
+			&event.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan finding triage event row: %w", err)
+		}
+		if suppressionExpiresAt.Valid {
+			value := suppressionExpiresAt.Time.UTC()
+			event.SuppressionExpiresAt = &value
+		}
+		event.CreatedAt = event.CreatedAt.UTC()
+		result = append(result, event)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("finding triage event rows: %w", err)
+	}
+	return result, nil
+}
+
 // ListScans returns latest scans first.
 func (p *PostgresStore) ListScans(ctx context.Context, limit int) ([]ScanRecord, error) {
 	if limit <= 0 {

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -21,6 +21,10 @@ type PostgresStore struct {
 	queries *sqlcdb.Queries
 }
 
+type sqlExecutor interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
 // NewPostgresStore opens a PostgreSQL connection and validates connectivity.
 func NewPostgresStore(databaseURL string) (*PostgresStore, error) {
 	db, err := sql.Open("pgx", databaseURL)
@@ -385,11 +389,15 @@ func (p *PostgresStore) ListFindingTriageStates(ctx context.Context, findingIDs 
 
 // UpsertFindingTriageState creates or updates mutable triage metadata.
 func (p *PostgresStore) UpsertFindingTriageState(ctx context.Context, state FindingTriageState) error {
+	return p.upsertFindingTriageStateWithExecutor(ctx, p.db, state)
+}
+
+func (p *PostgresStore) upsertFindingTriageStateWithExecutor(ctx context.Context, executor sqlExecutor, state FindingTriageState) error {
 	updatedAt := state.UpdatedAt
 	if updatedAt.IsZero() {
 		updatedAt = time.Now().UTC()
 	}
-	_, err := p.db.ExecContext(
+	_, err := executor.ExecContext(
 		ctx,
 		`INSERT INTO finding_triage_states (finding_id, status, assignee, suppression_expires_at, updated_at, updated_by)
 		 VALUES ($1, $2, $3, $4, $5, $6)
@@ -415,6 +423,10 @@ func (p *PostgresStore) UpsertFindingTriageState(ctx context.Context, state Find
 
 // AppendFindingTriageEvent records one immutable triage action.
 func (p *PostgresStore) AppendFindingTriageEvent(ctx context.Context, event FindingTriageEvent) error {
+	return p.appendFindingTriageEventWithExecutor(ctx, p.db, event)
+}
+
+func (p *PostgresStore) appendFindingTriageEventWithExecutor(ctx context.Context, executor sqlExecutor, event FindingTriageEvent) error {
 	createdAt := event.CreatedAt
 	if createdAt.IsZero() {
 		createdAt = time.Now().UTC()
@@ -423,7 +435,7 @@ func (p *PostgresStore) AppendFindingTriageEvent(ctx context.Context, event Find
 	if eventID == "" {
 		eventID = uuid.NewString()
 	}
-	_, err := p.db.ExecContext(
+	_, err := executor.ExecContext(
 		ctx,
 		`INSERT INTO finding_triage_events (id, finding_id, action, from_status, to_status, assignee, suppression_expires_at, comment, actor, created_at)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
@@ -440,6 +452,33 @@ func (p *PostgresStore) AppendFindingTriageEvent(ctx context.Context, event Find
 	)
 	if err != nil {
 		return fmt.Errorf("insert finding triage event: %w", err)
+	}
+	return nil
+}
+
+// ApplyFindingTriageTransition persists state and audit history atomically.
+func (p *PostgresStore) ApplyFindingTriageTransition(ctx context.Context, state FindingTriageState, event FindingTriageEvent) error {
+	if strings.TrimSpace(state.FindingID) == "" || strings.TrimSpace(event.FindingID) == "" {
+		return fmt.Errorf("finding id is required")
+	}
+	if strings.TrimSpace(state.FindingID) != strings.TrimSpace(event.FindingID) {
+		return fmt.Errorf("finding id mismatch between state and event")
+	}
+
+	tx, err := p.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin triage transition tx: %w", err)
+	}
+	if err := p.upsertFindingTriageStateWithExecutor(ctx, tx, state); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := p.appendFindingTriageEventWithExecutor(ctx, tx, event); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit triage transition tx: %w", err)
 	}
 	return nil
 }

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -448,6 +448,98 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 	}
 }
 
+func TestPostgresStoreFindingTriageStateAndHistory(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	now := time.Now().UTC()
+	expiry := now.Add(2 * time.Hour)
+
+	mock.ExpectExec("INSERT INTO finding_triage_states").
+		WithArgs("finding-1", "ack", "sec-oncall", sqlmock.AnyArg(), sqlmock.AnyArg(), "subject:alice").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := store.UpsertFindingTriageState(context.Background(), FindingTriageState{
+		FindingID:            "finding-1",
+		Status:               domain.FindingLifecycleAck,
+		Assignee:             "sec-oncall",
+		SuppressionExpiresAt: &expiry,
+		UpdatedAt:            now,
+		UpdatedBy:            "subject:alice",
+	}); err != nil {
+		t.Fatalf("upsert triage state failed: %v", err)
+	}
+
+	stateRows := sqlmock.NewRows([]string{"finding_id", "status", "assignee", "suppression_expires_at", "updated_at", "updated_by"}).
+		AddRow("finding-1", "ack", "sec-oncall", expiry, now, "subject:alice")
+	mock.ExpectQuery("SELECT finding_id, status, assignee, suppression_expires_at, updated_at, updated_by").
+		WithArgs("finding-1").
+		WillReturnRows(stateRows)
+
+	state, err := store.GetFindingTriageState(context.Background(), "finding-1")
+	if err != nil {
+		t.Fatalf("get triage state failed: %v", err)
+	}
+	if state.Status != domain.FindingLifecycleAck || state.Assignee != "sec-oncall" {
+		t.Fatalf("unexpected triage state: %+v", state)
+	}
+
+	listRows := sqlmock.NewRows([]string{"finding_id", "status", "assignee", "suppression_expires_at", "updated_at", "updated_by"}).
+		AddRow("finding-1", "ack", "sec-oncall", expiry, now, "subject:alice")
+	mock.ExpectQuery("SELECT finding_id, status, assignee, suppression_expires_at, updated_at, updated_by").
+		WithArgs("finding-1", "finding-2").
+		WillReturnRows(listRows)
+
+	states, err := store.ListFindingTriageStates(context.Background(), []string{"finding-1", "finding-2"})
+	if err != nil {
+		t.Fatalf("list triage states failed: %v", err)
+	}
+	if len(states) != 1 || states[0].FindingID != "finding-1" {
+		t.Fatalf("unexpected triage states: %+v", states)
+	}
+
+	mock.ExpectExec("INSERT INTO finding_triage_events").
+		WithArgs(sqlmock.AnyArg(), "finding-1", FindingTriageActionAcknowledged, "open", "ack", "sec-oncall", sqlmock.AnyArg(), "accepted risk", "subject:alice", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := store.AppendFindingTriageEvent(context.Background(), FindingTriageEvent{
+		FindingID:            "finding-1",
+		Action:               FindingTriageActionAcknowledged,
+		FromStatus:           domain.FindingLifecycleOpen,
+		ToStatus:             domain.FindingLifecycleAck,
+		Assignee:             "sec-oncall",
+		SuppressionExpiresAt: &expiry,
+		Comment:              "accepted risk",
+		Actor:                "subject:alice",
+		CreatedAt:            now,
+	}); err != nil {
+		t.Fatalf("append triage event failed: %v", err)
+	}
+
+	eventRows := sqlmock.NewRows([]string{"id", "finding_id", "action", "from_status", "to_status", "assignee", "suppression_expires_at", "comment", "actor", "created_at"}).
+		AddRow("evt-2", "finding-1", FindingTriageActionCommented, "ack", "ack", "sec-oncall", nil, "reviewed", "subject:bob", now.Add(2*time.Minute)).
+		AddRow("evt-1", "finding-1", FindingTriageActionAcknowledged, "open", "ack", "sec-oncall", expiry, "accepted risk", "subject:alice", now)
+	mock.ExpectQuery("SELECT id, finding_id, action, from_status, to_status, assignee, suppression_expires_at, comment, actor, created_at").
+		WithArgs("finding-1", 10).
+		WillReturnRows(eventRows)
+
+	events, err := store.ListFindingTriageEvents(context.Background(), "finding-1", 10)
+	if err != nil {
+		t.Fatalf("list triage events failed: %v", err)
+	}
+	if len(events) != 2 || events[0].ID != "evt-2" {
+		t.Fatalf("unexpected triage events: %+v", events)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestPostgresStoreScanQueueLifecycle(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -540,6 +540,94 @@ func TestPostgresStoreFindingTriageStateAndHistory(t *testing.T) {
 	}
 }
 
+func TestPostgresStoreApplyFindingTriageTransition(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	now := time.Now().UTC()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO finding_triage_states").
+		WithArgs("finding-1", "ack", "sec-oncall", nil, sqlmock.AnyArg(), "subject:alice").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO finding_triage_events").
+		WithArgs(sqlmock.AnyArg(), "finding-1", FindingTriageActionAcknowledged, "open", "ack", "sec-oncall", nil, "acknowledged", "subject:alice", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err = store.ApplyFindingTriageTransition(context.Background(), FindingTriageState{
+		FindingID: "finding-1",
+		Status:    domain.FindingLifecycleAck,
+		Assignee:  "sec-oncall",
+		UpdatedAt: now,
+		UpdatedBy: "subject:alice",
+	}, FindingTriageEvent{
+		FindingID:  "finding-1",
+		Action:     FindingTriageActionAcknowledged,
+		FromStatus: domain.FindingLifecycleOpen,
+		ToStatus:   domain.FindingLifecycleAck,
+		Assignee:   "sec-oncall",
+		Comment:    "acknowledged",
+		Actor:      "subject:alice",
+		CreatedAt:  now,
+	})
+	if err != nil {
+		t.Fatalf("apply triage transition failed: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreApplyFindingTriageTransitionRollsBackOnEventFailure(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	now := time.Now().UTC()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO finding_triage_states").
+		WithArgs("finding-1", "ack", "sec-oncall", nil, sqlmock.AnyArg(), "subject:alice").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO finding_triage_events").
+		WithArgs(sqlmock.AnyArg(), "finding-1", FindingTriageActionAcknowledged, "open", "ack", "sec-oncall", nil, "acknowledged", "subject:alice", sqlmock.AnyArg()).
+		WillReturnError(sql.ErrTxDone)
+	mock.ExpectRollback()
+
+	err = store.ApplyFindingTriageTransition(context.Background(), FindingTriageState{
+		FindingID: "finding-1",
+		Status:    domain.FindingLifecycleAck,
+		Assignee:  "sec-oncall",
+		UpdatedAt: now,
+		UpdatedBy: "subject:alice",
+	}, FindingTriageEvent{
+		FindingID:  "finding-1",
+		Action:     FindingTriageActionAcknowledged,
+		FromStatus: domain.FindingLifecycleOpen,
+		ToStatus:   domain.FindingLifecycleAck,
+		Assignee:   "sec-oncall",
+		Comment:    "acknowledged",
+		Actor:      "subject:alice",
+		CreatedAt:  now,
+	})
+	if err == nil {
+		t.Fatal("expected triage transition error")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestPostgresStoreScanQueueLifecycle(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -17,6 +17,14 @@ const (
 	ScanEventLevelInfo  = "info"
 	ScanEventLevelWarn  = "warn"
 	ScanEventLevelError = "error"
+
+	FindingTriageActionAcknowledged = "acknowledged"
+	FindingTriageActionSuppressed   = "suppressed"
+	FindingTriageActionResolved     = "resolved"
+	FindingTriageActionReopened     = "reopened"
+	FindingTriageActionAssigned     = "assignee_updated"
+	FindingTriageActionSuppression  = "suppression_updated"
+	FindingTriageActionCommented    = "commented"
 )
 
 // ScanRecord tracks persisted scan execution metadata.
@@ -69,6 +77,30 @@ type ScanEvent struct {
 	CreatedAt time.Time      `json:"created_at"`
 }
 
+// FindingTriageState stores mutable workflow metadata for one finding id.
+type FindingTriageState struct {
+	FindingID            string                        `json:"finding_id"`
+	Status               domain.FindingLifecycleStatus `json:"status"`
+	Assignee             string                        `json:"assignee,omitempty"`
+	SuppressionExpiresAt *time.Time                    `json:"suppression_expires_at,omitempty"`
+	UpdatedAt            time.Time                     `json:"updated_at"`
+	UpdatedBy            string                        `json:"updated_by,omitempty"`
+}
+
+// FindingTriageEvent records one immutable workflow action.
+type FindingTriageEvent struct {
+	ID                   string                        `json:"id"`
+	FindingID            string                        `json:"finding_id"`
+	Action               string                        `json:"action"`
+	FromStatus           domain.FindingLifecycleStatus `json:"from_status"`
+	ToStatus             domain.FindingLifecycleStatus `json:"to_status"`
+	Assignee             string                        `json:"assignee,omitempty"`
+	SuppressionExpiresAt *time.Time                    `json:"suppression_expires_at,omitempty"`
+	Comment              string                        `json:"comment,omitempty"`
+	Actor                string                        `json:"actor,omitempty"`
+	CreatedAt            time.Time                     `json:"created_at"`
+}
+
 // NormalizeScanEventLevel validates and normalizes event levels.
 func NormalizeScanEventLevel(level string) (string, error) {
 	switch level {
@@ -112,6 +144,11 @@ type Store interface {
 	CompleteScan(ctx context.Context, scanID string, status string, finishedAt time.Time, assetCount int, findingCount int, errorMessage string) error
 	UpsertArtifacts(ctx context.Context, scanID string, artifacts ScanArtifacts) error
 	UpsertFindings(ctx context.Context, scanID string, findings []domain.Finding) error
+	GetFindingTriageState(ctx context.Context, findingID string) (FindingTriageState, error)
+	ListFindingTriageStates(ctx context.Context, findingIDs []string) ([]FindingTriageState, error)
+	UpsertFindingTriageState(ctx context.Context, state FindingTriageState) error
+	AppendFindingTriageEvent(ctx context.Context, event FindingTriageEvent) error
+	ListFindingTriageEvents(ctx context.Context, findingID string, limit int) ([]FindingTriageEvent, error)
 	ListScans(ctx context.Context, limit int) ([]ScanRecord, error)
 	ListFindings(ctx context.Context, limit int) ([]domain.Finding, error)
 	ListFindingsByScan(ctx context.Context, scanID string, limit int) ([]domain.Finding, error)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -148,6 +148,7 @@ type Store interface {
 	ListFindingTriageStates(ctx context.Context, findingIDs []string) ([]FindingTriageState, error)
 	UpsertFindingTriageState(ctx context.Context, state FindingTriageState) error
 	AppendFindingTriageEvent(ctx context.Context, event FindingTriageEvent) error
+	ApplyFindingTriageTransition(ctx context.Context, state FindingTriageState, event FindingTriageEvent) error
 	ListFindingTriageEvents(ctx context.Context, findingID string, limit int) ([]FindingTriageEvent, error)
 	ListScans(ctx context.Context, limit int) ([]ScanRecord, error)
 	ListFindings(ctx context.Context, limit int) ([]domain.Finding, error)

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -57,6 +57,30 @@ const (
 	FindingRepoMisconfig    FindingType = "repo_misconfiguration"
 )
 
+// FindingLifecycleStatus tracks operator triage state over time.
+type FindingLifecycleStatus string
+
+const (
+	FindingLifecycleOpen       FindingLifecycleStatus = "open"
+	FindingLifecycleAck        FindingLifecycleStatus = "ack"
+	FindingLifecycleSuppressed FindingLifecycleStatus = "suppressed"
+	FindingLifecycleResolved   FindingLifecycleStatus = "resolved"
+)
+
+// FindingTriage stores mutable workflow metadata for one finding id.
+type FindingTriage struct {
+	Status               FindingLifecycleStatus `json:"status"`
+	Assignee             string                 `json:"assignee,omitempty"`
+	SuppressionExpiresAt *time.Time             `json:"suppression_expires_at,omitempty"`
+	UpdatedAt            *time.Time             `json:"updated_at,omitempty"`
+	UpdatedBy            string                 `json:"updated_by,omitempty"`
+}
+
+// DefaultFindingTriage returns the baseline lifecycle state for new findings.
+func DefaultFindingTriage() FindingTriage {
+	return FindingTriage{Status: FindingLifecycleOpen}
+}
+
 // Identity is a normalized machine identity across providers.
 type Identity struct {
 	ID         string            `json:"id"`
@@ -114,6 +138,7 @@ type Finding struct {
 	Evidence     map[string]any  `json:"evidence,omitempty"`
 	Remediation  string          `json:"remediation"`
 	CreatedAt    time.Time       `json:"created_at"`
+	Triage       FindingTriage   `json:"triage,omitempty"`
 }
 
 // OwnershipSignal tracks ownership hints and confidence.

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -138,7 +138,7 @@ type Finding struct {
 	Evidence     map[string]any  `json:"evidence,omitempty"`
 	Remediation  string          `json:"remediation"`
 	CreatedAt    time.Time       `json:"created_at"`
-	Triage       FindingTriage   `json:"triage,omitempty"`
+	Triage       FindingTriage   `json:"triage,omitzero"`
 }
 
 // OwnershipSignal tracks ownership hints and confidence.

--- a/internal/findings/standards/standards.go
+++ b/internal/findings/standards/standards.go
@@ -57,6 +57,10 @@ func ControlsForFinding(findingType domain.FindingType) []ControlRef {
 
 // EnrichFinding injects stable compliance metadata into evidence without changing core finding shape.
 func EnrichFinding(finding domain.Finding) domain.Finding {
+	if finding.Triage.Status == "" {
+		finding.Triage = domain.DefaultFindingTriage()
+	}
+
 	controls := ControlsForFinding(finding.Type)
 	if len(controls) == 0 {
 		return finding

--- a/migrations/000005_finding_workflow_maturity.down.sql
+++ b/migrations/000005_finding_workflow_maturity.down.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS idx_finding_triage_events_finding_created;
+DROP TABLE IF EXISTS finding_triage_events;
+
+DROP INDEX IF EXISTS idx_finding_triage_states_assignee;
+DROP INDEX IF EXISTS idx_finding_triage_states_status;
+DROP TABLE IF EXISTS finding_triage_states;

--- a/migrations/000005_finding_workflow_maturity.up.sql
+++ b/migrations/000005_finding_workflow_maturity.up.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS finding_triage_states (
+    finding_id TEXT PRIMARY KEY,
+    status TEXT NOT NULL,
+    assignee TEXT NOT NULL DEFAULT '',
+    suppression_expires_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_by TEXT NOT NULL DEFAULT '',
+    CONSTRAINT chk_finding_triage_status CHECK (status IN ('open', 'ack', 'suppressed', 'resolved'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_finding_triage_states_status
+    ON finding_triage_states (status);
+
+CREATE INDEX IF NOT EXISTS idx_finding_triage_states_assignee
+    ON finding_triage_states (assignee);
+
+CREATE TABLE IF NOT EXISTS finding_triage_events (
+    id UUID PRIMARY KEY,
+    finding_id TEXT NOT NULL,
+    action TEXT NOT NULL,
+    from_status TEXT NOT NULL,
+    to_status TEXT NOT NULL,
+    assignee TEXT NOT NULL DEFAULT '',
+    suppression_expires_at TIMESTAMPTZ,
+    comment TEXT NOT NULL DEFAULT '',
+    actor TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT chk_finding_triage_events_from_status CHECK (from_status IN ('open', 'ack', 'suppressed', 'resolved')),
+    CONSTRAINT chk_finding_triage_events_to_status CHECK (to_status IN ('open', 'ack', 'suppressed', 'resolved'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_finding_triage_events_finding_created
+    ON finding_triage_events (finding_id, created_at DESC);

--- a/testdata/contracts/api_v1_findings_list_response.snapshot.json
+++ b/testdata/contracts/api_v1_findings_list_response.snapshot.json
@@ -27,6 +27,9 @@
       "scan_id": "\u003cscan-id\u003e",
       "severity": "high",
       "title": "Risky trust",
+      "triage": {
+        "status": "open"
+      },
       "type": "risky_trust_policy"
     }
   ]

--- a/testdata/contracts/finding_enriched_compatibility.snapshot.json
+++ b/testdata/contracts/finding_enriched_compatibility.snapshot.json
@@ -30,5 +30,8 @@
     "schema_version": "v1"
   },
   "remediation": "Remove wildcard trust and reduce permissions.",
-  "created_at": "2026-03-20T08:00:00Z"
+  "created_at": "2026-03-20T08:00:00Z",
+  "triage": {
+    "status": "open"
+  }
 }


### PR DESCRIPTION
## Summary
- add finding triage lifecycle state (`open`, `ack`, `suppressed`, `resolved`) with assignee and suppression expiry
- add triage audit history for every finding mutation
- add API endpoints and filters for triage workflows, plus migration/tests

## Validation
- `go test ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a triage lifecycle to findings with status, assignee, suppression expiry, and audit history, plus filters and a write-key-protected triage API. Triage data is returned on list/get, updates are validated and recorded, and limits/CORS are tightened to address a CodeQL finding.

- New Features
  - Findings now include triage: status (`open|ack|suppressed|resolved`), assignee, `suppression_expires_at`, `updated_*`; defaults to open and auto-reopens on expiry.
  - `PATCH /v1/findings/{finding_id}/triage` updates status/assignee/expiry with optional comment; validates future expiry; records an audit event with actor (subject or compact API key fingerprint); atomically persists state + event; requires a write API key.
  - `GET /v1/findings/{finding_id}/history` lists triage events (newest first) with limit; `/v1/findings` supports `lifecycle_status` and `assignee` filters; triage is included on all list/get responses.
  - OpenAPI v1 updated with new schemas/endpoints; CORS now allows PATCH; list/history endpoints enforce reasonable limits to prevent excessive allocations.

- Migration
  - Run migration `000005_finding_workflow_maturity` to create `finding_triage_states` and `finding_triage_events` plus indexes.
  - Update clients to read the `triage` field and use a write API key when calling the triage endpoint.

<sup>Written for commit 3283e7ab5e996c11004a56f1c2afc5808a3ca5a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

