### PR TITLE
Add tenant/workspace scope foundation

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -31,12 +31,14 @@ const (
 	rateLimiterEntryTTL    = 15 * time.Minute
 	rateLimiterMaxEntries  = 10000
 	rateLimiterCleanupTick = 256
-	corsAllowMethods       = "GET,POST,OPTIONS"
-	corsAllowHeaders       = "Authorization,Content-Type,X-API-Key"
+	corsAllowMethods       = "GET,POST,PATCH,OPTIONS"
+	corsAllowHeaders       = "Authorization,Content-Type,X-API-Key,X-Identrail-Tenant-ID,X-Identrail-Workspace-ID"
 	corsMaxAgeSeconds      = "600"
 	scopeRead              = "read"
 	scopeWrite             = "write"
 	scopeAdmin             = "admin"
+	scopeHeaderTenantID    = "X-Identrail-Tenant-ID"
+	scopeHeaderWorkspaceID = "X-Identrail-Workspace-ID"
 )
 
 // RouterOptions controls API middleware behavior.
@@ -51,6 +53,8 @@ type RouterOptions struct {
 	AuditSink          AuditSink
 	TrustedProxies     []string
 	CORSAllowedOrigins []string
+	DefaultTenantID    string
+	DefaultWorkspaceID string
 }
 
 // VerifiedToken contains normalized claims extracted from a validated OIDC token.
@@ -97,6 +101,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 	r.GET("/metrics", gin.WrapH(promhttp.HandlerFor(registry, promhttp.HandlerOpts{})))
 
 	v1 := r.Group("/v1")
+	v1.Use(requestScopeMiddleware(opts.DefaultTenantID, opts.DefaultWorkspaceID))
 	v1.Use(apiKeyAuthMiddleware(opts.APIKeys, opts.APIKeyScopes, opts.OIDCTokenVerifier, opts.OIDCWriteScopes))
 	v1.Use(requireReadableScopeMiddleware(opts.APIKeyScopes, opts.OIDCTokenVerifier))
 	v1.Use(rateLimitMiddleware(opts.RateLimitRPM, opts.RateLimitBurst))
@@ -916,6 +921,29 @@ func pageWithCursor[T any](items []T, offset int, limit int) ([]T, string) {
 		next = strconv.Itoa(end)
 	}
 	return items[offset:end], next
+}
+
+func requestScopeMiddleware(defaultTenantID string, defaultWorkspaceID string) gin.HandlerFunc {
+	defaultScope := db.Scope{
+		TenantID:    defaultTenantID,
+		WorkspaceID: defaultWorkspaceID,
+	}.Normalize()
+	return func(c *gin.Context) {
+		tenantID := strings.TrimSpace(c.GetHeader(scopeHeaderTenantID))
+		if tenantID == "" {
+			tenantID = defaultScope.TenantID
+		}
+		workspaceID := strings.TrimSpace(c.GetHeader(scopeHeaderWorkspaceID))
+		if workspaceID == "" {
+			workspaceID = defaultScope.WorkspaceID
+		}
+		scopedCtx := db.WithScope(c.Request.Context(), db.Scope{
+			TenantID:    tenantID,
+			WorkspaceID: workspaceID,
+		})
+		c.Request = c.Request.WithContext(scopedCtx)
+		c.Next()
+	}
 }
 
 func corsMiddleware(allowedOrigins []string) gin.HandlerFunc {

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -53,6 +53,7 @@ type Service struct {
 	Store         db.Store
 	Scanner       ScannerRunner
 	Provider      string
+	DefaultScope  db.Scope
 	Now           func() time.Time
 	Locker        scheduler.Locker
 	LockNamespace string
@@ -166,6 +167,7 @@ func NewService(store db.Store, scanner ScannerRunner, provider string) *Service
 		Store:                       store,
 		Scanner:                     scanner,
 		Provider:                    provider,
+		DefaultScope:                db.Scope{}.Normalize(),
 		Now:                         time.Now,
 		Locker:                      scheduler.NewInMemoryLocker(),
 		LockNamespace:               "identrail",
@@ -189,6 +191,7 @@ func NewService(store db.Store, scanner ScannerRunner, provider string) *Service
 
 // EnqueueScan stores one queued scan request for asynchronous worker execution.
 func (s *Service) EnqueueScan(ctx context.Context) (db.ScanRecord, error) {
+	ctx = s.scopeContext(ctx)
 	maxPending := s.ScanQueueMaxPending
 	if maxPending <= 0 {
 		maxPending = defaultScanQueueMaxPending
@@ -215,6 +218,7 @@ func (s *Service) EnqueueScan(ctx context.Context) (db.ScanRecord, error) {
 
 // ProcessNextQueuedScan claims and executes one queued scan. It returns false when no job is available.
 func (s *Service) ProcessNextQueuedScan(ctx context.Context) (bool, error) {
+	ctx = s.scopeContext(ctx)
 	if s.Locker != nil {
 		release, ok := s.Locker.TryAcquire(s.lockKey("scan:" + s.Provider))
 		if !ok {
@@ -240,6 +244,7 @@ func (s *Service) ProcessNextQueuedScan(ctx context.Context) (bool, error) {
 
 // RunScan executes one scan and persists metadata + findings.
 func (s *Service) RunScan(ctx context.Context) (RunScanResult, error) {
+	ctx = s.scopeContext(ctx)
 	if s.Locker != nil {
 		release, ok := s.Locker.TryAcquire(s.lockKey("scan:" + s.Provider))
 		if !ok {
@@ -258,6 +263,7 @@ func (s *Service) RunScan(ctx context.Context) (RunScanResult, error) {
 }
 
 func (s *Service) runScanWithRecord(ctx context.Context, record db.ScanRecord) (RunScanResult, error) {
+	ctx = s.scopeContext(ctx)
 	result, err := s.Scanner.Run(ctx)
 	if err != nil {
 		s.appendScanLifecycleEvent(ctx, record.ID, scanLifecycleFailed, map[string]any{"error": err.Error()})
@@ -332,6 +338,7 @@ func (s *Service) runScanWithRecord(ctx context.Context, record db.ScanRecord) (
 
 // ListFindings returns persisted findings.
 func (s *Service) ListFindings(ctx context.Context, limit int) ([]domain.Finding, error) {
+	ctx = s.scopeContext(ctx)
 	return s.Store.ListFindings(ctx, limit)
 }
 
@@ -346,6 +353,7 @@ func (s *Service) RunRepoScan(ctx context.Context, request RepoScanRequest) (rep
 
 // EnqueueRepoScan stores one queued repository scan request for asynchronous worker execution.
 func (s *Service) EnqueueRepoScan(ctx context.Context, request RepoScanRequest) (db.RepoScanRecord, error) {
+	ctx = s.scopeContext(ctx)
 	target, historyLimit, maxFindings, err := s.validateRepoScanRequest(request)
 	if err != nil {
 		return db.RepoScanRecord{}, err
@@ -377,6 +385,7 @@ func (s *Service) EnqueueRepoScan(ctx context.Context, request RepoScanRequest) 
 
 // ProcessNextQueuedRepoScan claims and executes one queued repository scan. It returns false when no job is available.
 func (s *Service) ProcessNextQueuedRepoScan(ctx context.Context) (bool, error) {
+	ctx = s.scopeContext(ctx)
 	record, err := s.Store.ClaimNextQueuedRepoScan(ctx)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
@@ -410,6 +419,7 @@ func (s *Service) ProcessNextQueuedRepoScan(ctx context.Context) (bool, error) {
 
 // RunRepoScanPersisted runs one repository scan and persists repo scan metadata + findings.
 func (s *Service) RunRepoScanPersisted(ctx context.Context, request RepoScanRequest) (RunRepoScanResult, error) {
+	ctx = s.scopeContext(ctx)
 	target, historyLimit, maxFindings, err := s.validateRepoScanRequest(request)
 	if err != nil {
 		return RunRepoScanResult{}, err
@@ -454,6 +464,7 @@ func (s *Service) validateRepoScanRequest(request RepoScanRequest) (string, int,
 }
 
 func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanRecord, historyLimit int, maxFindings int) (RunRepoScanResult, error) {
+	ctx = s.scopeContext(ctx)
 	target := strings.TrimSpace(record.Repository)
 	if target == "" {
 		return RunRepoScanResult{}, ErrInvalidRepoScanRequest
@@ -508,11 +519,13 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 
 // ListRepoScans returns persisted repository scans.
 func (s *Service) ListRepoScans(ctx context.Context, limit int) ([]db.RepoScanRecord, error) {
+	ctx = s.scopeContext(ctx)
 	return s.Store.ListRepoScans(ctx, limit)
 }
 
 // GetRepoScan returns one repository scan by id.
 func (s *Service) GetRepoScan(ctx context.Context, repoScanID string) (db.RepoScanRecord, error) {
+	ctx = s.scopeContext(ctx)
 	id := strings.TrimSpace(repoScanID)
 	if id == "" {
 		return db.RepoScanRecord{}, db.ErrNotFound
@@ -522,6 +535,7 @@ func (s *Service) GetRepoScan(ctx context.Context, repoScanID string) (db.RepoSc
 
 // ListRepoFindings returns repository findings using optional filters.
 func (s *Service) ListRepoFindings(ctx context.Context, limit int, filter db.RepoFindingFilter) ([]domain.Finding, error) {
+	ctx = s.scopeContext(ctx)
 	findings, err := s.Store.ListRepoFindings(ctx, filter, limit)
 	if err != nil {
 		return nil, err
@@ -531,6 +545,7 @@ func (s *Service) ListRepoFindings(ctx context.Context, limit int, filter db.Rep
 
 // ListFindingsFiltered returns findings with optional scan/type/severity filters.
 func (s *Service) ListFindingsFiltered(ctx context.Context, limit int, filter FindingsFilter) ([]domain.Finding, error) {
+	ctx = s.scopeContext(ctx)
 	if strings.TrimSpace(filter.ScanID) == "" && strings.TrimSpace(filter.Severity) == "" && strings.TrimSpace(filter.Type) == "" {
 		items, err := s.Store.ListFindings(ctx, limit)
 		if err != nil {
@@ -608,11 +623,13 @@ func (s *Service) GetFindingExports(ctx context.Context, findingID string, scanI
 
 // ListScans returns persisted scans.
 func (s *Service) ListScans(ctx context.Context, limit int) ([]db.ScanRecord, error) {
+	ctx = s.scopeContext(ctx)
 	return s.Store.ListScans(ctx, limit)
 }
 
 // GetFindingsSummary returns grouped counts by severity and type.
 func (s *Service) GetFindingsSummary(ctx context.Context, limit int) (FindingsSummary, error) {
+	ctx = s.scopeContext(ctx)
 	items, err := s.Store.ListFindings(ctx, limit)
 	if err != nil {
 		return FindingsSummary{}, err
@@ -636,6 +653,7 @@ func (s *Service) ListScanEvents(ctx context.Context, scanID string, limit int) 
 
 // ListScanEventsFiltered returns recent scan events with optional level filtering.
 func (s *Service) ListScanEventsFiltered(ctx context.Context, scanID string, level string, limit int) ([]db.ScanEvent, error) {
+	ctx = s.scopeContext(ctx)
 	events, err := s.Store.ListScanEvents(ctx, scanID, limit)
 	if err != nil {
 		return nil, err
@@ -656,6 +674,7 @@ func (s *Service) ListScanEventsFiltered(ctx context.Context, scanID string, lev
 
 // ListIdentities returns identities for given filters, defaulting scan_id to latest scan.
 func (s *Service) ListIdentities(ctx context.Context, scanID string, provider string, identityType string, namePrefix string, limit int) ([]domain.Identity, error) {
+	ctx = s.scopeContext(ctx)
 	normalizedScanID := scanID
 	if normalizedScanID == "" {
 		latest, err := s.latestScanID(ctx)
@@ -674,6 +693,7 @@ func (s *Service) ListIdentities(ctx context.Context, scanID string, provider st
 
 // ListRelationships returns relationships for given filters, defaulting scan_id to latest scan.
 func (s *Service) ListRelationships(ctx context.Context, scanID string, relationshipType string, fromNodeID string, toNodeID string, limit int) ([]domain.Relationship, error) {
+	ctx = s.scopeContext(ctx)
 	normalizedScanID := scanID
 	if normalizedScanID == "" {
 		latest, err := s.latestScanID(ctx)
@@ -697,6 +717,7 @@ func (s *Service) GetFindingsTrend(ctx context.Context, points int) ([]TrendPoin
 
 // GetFindingsTrendFiltered returns findings trend with optional severity/type filters.
 func (s *Service) GetFindingsTrendFiltered(ctx context.Context, points int, severity string, findingType string) ([]TrendPoint, error) {
+	ctx = s.scopeContext(ctx)
 	if points <= 0 {
 		points = 10
 	}
@@ -739,6 +760,7 @@ func (s *Service) GetFindingsTrendFiltered(ctx context.Context, points int, seve
 
 // ListOwnershipSignals returns inferred ownership hints for identities in one scan.
 func (s *Service) ListOwnershipSignals(ctx context.Context, limit int, filter OwnershipFilter) ([]domain.OwnershipSignal, error) {
+	ctx = s.scopeContext(ctx)
 	normalizedScanID := strings.TrimSpace(filter.ScanID)
 	if normalizedScanID == "" {
 		latest, err := s.latestScanID(ctx)
@@ -785,6 +807,7 @@ func (s *Service) GetScanDiff(ctx context.Context, scanID string, limit int) (Sc
 
 // GetScanDiffAgainst compares findings between one scan and an optional baseline scan.
 func (s *Service) GetScanDiffAgainst(ctx context.Context, scanID string, previousScanID string, limit int) (ScanDiff, error) {
+	ctx = s.scopeContext(ctx)
 	currentScan, err := s.Store.GetScan(ctx, scanID)
 	if err != nil {
 		return ScanDiff{}, err
@@ -871,6 +894,7 @@ func (s *Service) GetScanDiffAgainst(ctx context.Context, scanID string, previou
 }
 
 func (s *Service) appendScanEvent(ctx context.Context, scanID string, level string, message string, metadata map[string]any) {
+	ctx = s.scopeContext(ctx)
 	_ = s.Store.AppendScanEvent(ctx, scanID, level, message, metadata)
 }
 
@@ -898,6 +922,7 @@ func (d *ScanDiff) applyLimit(limit int) {
 }
 
 func (s *Service) latestScanID(ctx context.Context) (string, error) {
+	ctx = s.scopeContext(ctx)
 	scans, err := s.Store.ListScans(ctx, 1)
 	if err != nil {
 		return "", err
@@ -1037,4 +1062,8 @@ func (s *Service) lockKey(key string) string {
 		return namespace
 	}
 	return namespace + ":" + normalizedKey
+}
+
+func (s *Service) scopeContext(ctx context.Context) context.Context {
+	return db.WithDefaultScope(ctx, s.DefaultScope)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,8 @@ const (
 	defaultWorkerAPIJobQueueBatchSize  = 5
 	defaultLockBackend                 = "auto"
 	defaultLockNamespace               = "identrail"
+	defaultTenantID                    = "default"
+	defaultWorkspaceID                 = "default"
 	defaultOIDCWriteScopes             = "identrail.write,identrail.admin,write,admin"
 )
 
@@ -96,6 +98,8 @@ type Config struct {
 	WorkerAPIJobQueueBatchSize int
 	LockBackend                string
 	LockNamespace              string
+	DefaultTenantID            string
+	DefaultWorkspaceID         string
 	OIDCIssuerURL              string
 	OIDCAudience               string
 	OIDCWriteScopes            []string
@@ -160,6 +164,8 @@ func Load() Config {
 		WorkerAPIJobQueueBatchSize: parseInt(getEnv("IDENTRAIL_WORKER_API_JOB_QUEUE_BATCH_SIZE", "5"), defaultWorkerAPIJobQueueBatchSize),
 		LockBackend:                strings.ToLower(getEnv("IDENTRAIL_LOCK_BACKEND", defaultLockBackend)),
 		LockNamespace:              getEnv("IDENTRAIL_LOCK_NAMESPACE", defaultLockNamespace),
+		DefaultTenantID:            getEnv("IDENTRAIL_DEFAULT_TENANT_ID", defaultTenantID),
+		DefaultWorkspaceID:         getEnv("IDENTRAIL_DEFAULT_WORKSPACE_ID", defaultWorkspaceID),
 		OIDCIssuerURL:              getEnv("IDENTRAIL_OIDC_ISSUER_URL", ""),
 		OIDCAudience:               getEnv("IDENTRAIL_OIDC_AUDIENCE", ""),
 		OIDCWriteScopes:            parseCommaSeparated(getEnv("IDENTRAIL_OIDC_WRITE_SCOPES", defaultOIDCWriteScopes)),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -63,6 +63,8 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("IDENTRAIL_WORKER_API_JOB_QUEUE_BATCH_SIZE", "")
 	t.Setenv("IDENTRAIL_LOCK_BACKEND", "")
 	t.Setenv("IDENTRAIL_LOCK_NAMESPACE", "")
+	t.Setenv("IDENTRAIL_DEFAULT_TENANT_ID", "")
+	t.Setenv("IDENTRAIL_DEFAULT_WORKSPACE_ID", "")
 
 	cfg := Load()
 	if cfg.HTTPAddr != defaultHTTPAddr {
@@ -230,6 +232,12 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.LockNamespace != defaultLockNamespace {
 		t.Fatalf("expected default lock namespace %q, got %q", defaultLockNamespace, cfg.LockNamespace)
 	}
+	if cfg.DefaultTenantID != defaultTenantID {
+		t.Fatalf("expected default tenant id %q, got %q", defaultTenantID, cfg.DefaultTenantID)
+	}
+	if cfg.DefaultWorkspaceID != defaultWorkspaceID {
+		t.Fatalf("expected default workspace id %q, got %q", defaultWorkspaceID, cfg.DefaultWorkspaceID)
+	}
 	if cfg.OIDCIssuerURL != "" {
 		t.Fatalf("expected empty oidc issuer by default, got %q", cfg.OIDCIssuerURL)
 	}
@@ -298,6 +306,8 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("IDENTRAIL_WORKER_API_JOB_QUEUE_BATCH_SIZE", "12")
 	t.Setenv("IDENTRAIL_LOCK_BACKEND", "postgres")
 	t.Setenv("IDENTRAIL_LOCK_NAMESPACE", "prod-identrail")
+	t.Setenv("IDENTRAIL_DEFAULT_TENANT_ID", "tenant-prod")
+	t.Setenv("IDENTRAIL_DEFAULT_WORKSPACE_ID", "workspace-blue")
 	t.Setenv("IDENTRAIL_OIDC_ISSUER_URL", "https://iam.example.com/realms/identrail")
 	t.Setenv("IDENTRAIL_OIDC_AUDIENCE", "identrail-api")
 	t.Setenv("IDENTRAIL_OIDC_WRITE_SCOPES", "identrail.write,identrail.admin")
@@ -467,6 +477,12 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.LockNamespace != "prod-identrail" {
 		t.Fatalf("unexpected lock namespace: %q", cfg.LockNamespace)
+	}
+	if cfg.DefaultTenantID != "tenant-prod" {
+		t.Fatalf("unexpected default tenant id: %q", cfg.DefaultTenantID)
+	}
+	if cfg.DefaultWorkspaceID != "workspace-blue" {
+		t.Fatalf("unexpected default workspace id: %q", cfg.DefaultWorkspaceID)
 	}
 	if cfg.OIDCIssuerURL != "https://iam.example.com/realms/identrail" {
 		t.Fatalf("unexpected oidc issuer url: %q", cfg.OIDCIssuerURL)

--- a/internal/config/security.go
+++ b/internal/config/security.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/netip"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -20,6 +21,7 @@ const (
 	maxRepoQueueMaxPending      = 50000
 	maxWorkerQueueBatchSize     = 500
 	minAPIKeyLength             = 24
+	maxScopeIdentifierLength    = 64
 )
 
 var allowedKeyScopes = map[string]struct{}{
@@ -64,6 +66,8 @@ var placeholderAPIKeys = map[string]struct{}{
 	"replace-with-strong-write-key": {},
 }
 
+var scopeIdentifierPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,63}$`)
+
 // ValidateSecurity checks hard-fail security misconfigurations.
 func ValidateSecurity(cfg Config) error {
 	provider := strings.ToLower(strings.TrimSpace(cfg.Provider))
@@ -72,6 +76,20 @@ func ValidateSecurity(cfg Config) error {
 	}
 	if _, ok := allowedProviders[provider]; !ok {
 		return fmt.Errorf("invalid IDENTRAIL_PROVIDER %q: v1 supports aws or kubernetes", cfg.Provider)
+	}
+	defaultTenant := strings.TrimSpace(cfg.DefaultTenantID)
+	if defaultTenant == "" {
+		defaultTenant = defaultTenantID
+	}
+	if err := validateScopeIdentifier("IDENTRAIL_DEFAULT_TENANT_ID", defaultTenant); err != nil {
+		return err
+	}
+	defaultWorkspace := strings.TrimSpace(cfg.DefaultWorkspaceID)
+	if defaultWorkspace == "" {
+		defaultWorkspace = defaultWorkspaceID
+	}
+	if err := validateScopeIdentifier("IDENTRAIL_DEFAULT_WORKSPACE_ID", defaultWorkspace); err != nil {
+		return err
 	}
 
 	oidcIssuer := strings.TrimSpace(cfg.OIDCIssuerURL)
@@ -317,6 +335,20 @@ func ValidateSecurity(cfg Config) error {
 		if _, err := netip.ParseAddr(normalized); err != nil {
 			return fmt.Errorf("invalid IDENTRAIL_TRUSTED_PROXIES entry %q: %w", normalized, err)
 		}
+	}
+	return nil
+}
+
+func validateScopeIdentifier(envName string, value string) error {
+	normalized := strings.TrimSpace(value)
+	if normalized == "" {
+		return fmt.Errorf("%s must be non-empty", envName)
+	}
+	if len(normalized) > maxScopeIdentifierLength {
+		return fmt.Errorf("%s must be <= %d characters", envName, maxScopeIdentifierLength)
+	}
+	if !scopeIdentifierPattern.MatchString(normalized) {
+		return fmt.Errorf("%s must match %s", envName, scopeIdentifierPattern.String())
 	}
 	return nil
 }

--- a/internal/config/security_test.go
+++ b/internal/config/security_test.go
@@ -152,6 +152,28 @@ func TestValidateSecurityRejectsInvalidScopedKeyScope(t *testing.T) {
 	}
 }
 
+func TestValidateSecurityRejectsInvalidDefaultTenantID(t *testing.T) {
+	cfg := Config{
+		APIKeys:         []string{"reader", "writer"},
+		WriteAPIKeys:    []string{"writer"},
+		DefaultTenantID: "bad tenant id",
+	}
+	if err := ValidateSecurity(cfg); err == nil {
+		t.Fatal("expected invalid tenant id error")
+	}
+}
+
+func TestValidateSecurityRejectsInvalidDefaultWorkspaceID(t *testing.T) {
+	cfg := Config{
+		APIKeys:            []string{"reader", "writer"},
+		WriteAPIKeys:       []string{"writer"},
+		DefaultWorkspaceID: "bad workspace id",
+	}
+	if err := ValidateSecurity(cfg); err == nil {
+		t.Fatal("expected invalid workspace id error")
+	}
+}
+
 func TestValidateSecurityRejectsScopedKeyWithoutValidScope(t *testing.T) {
 	cfg := Config{
 		APIKeyScopes: map[string][]string{"key1": {""}},

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"strings"
 	"sync"
@@ -51,31 +50,35 @@ func NewMemoryStore() *MemoryStore {
 }
 
 // CreateScan persists a scan start event.
-func (m *MemoryStore) CreateScan(_ context.Context, provider string, startedAt time.Time) (ScanRecord, error) {
+func (m *MemoryStore) CreateScan(ctx context.Context, provider string, startedAt time.Time) (ScanRecord, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	return m.createScanLocked(provider, "running", startedAt), nil
+	return m.createScanLocked(ScopeFromContext(ctx), provider, "running", startedAt), nil
 }
 
 // CreateQueuedScan persists one queued scan request.
-func (m *MemoryStore) CreateQueuedScan(_ context.Context, provider string, queuedAt time.Time) (ScanRecord, error) {
+func (m *MemoryStore) CreateQueuedScan(ctx context.Context, provider string, queuedAt time.Time) (ScanRecord, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	return m.createScanLocked(provider, "queued", queuedAt), nil
+	return m.createScanLocked(ScopeFromContext(ctx), provider, "queued", queuedAt), nil
 }
 
 // ClaimNextQueuedScan moves one queued scan to running for execution.
-func (m *MemoryStore) ClaimNextQueuedScan(_ context.Context, provider string) (ScanRecord, error) {
+func (m *MemoryStore) ClaimNextQueuedScan(ctx context.Context, provider string) (ScanRecord, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	scope := ScopeFromContext(ctx)
 	normalizedProvider := strings.TrimSpace(provider)
 	found := false
 	var bestRecord ScanRecord
 	for _, scanID := range m.scanIDs {
 		record := m.scans[scanID]
+		if !MatchScope(scope, record.TenantID, record.WorkspaceID) {
+			continue
+		}
 		if record.Status != "queued" {
 			continue
 		}
@@ -98,13 +101,17 @@ func (m *MemoryStore) ClaimNextQueuedScan(_ context.Context, provider string) (S
 }
 
 // CountQueuedScans returns the queued scan count for one provider.
-func (m *MemoryStore) CountQueuedScans(_ context.Context, provider string) (int, error) {
+func (m *MemoryStore) CountQueuedScans(ctx context.Context, provider string) (int, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	scope := ScopeFromContext(ctx)
 	normalizedProvider := strings.TrimSpace(provider)
 	count := 0
 	for _, record := range m.scans {
+		if !MatchScope(scope, record.TenantID, record.WorkspaceID) {
+			continue
+		}
 		if record.Status != "queued" {
 			continue
 		}
@@ -116,12 +123,15 @@ func (m *MemoryStore) CountQueuedScans(_ context.Context, provider string) (int,
 	return count, nil
 }
 
-func (m *MemoryStore) createScanLocked(provider string, status string, startedAt time.Time) ScanRecord {
+func (m *MemoryStore) createScanLocked(scope Scope, provider string, status string, startedAt time.Time) ScanRecord {
+	normalizedScope := scope.Normalize()
 	record := ScanRecord{
-		ID:        uuid.NewString(),
-		Provider:  strings.TrimSpace(provider),
-		Status:    strings.TrimSpace(status),
-		StartedAt: startedAt.UTC(),
+		ID:          uuid.NewString(),
+		TenantID:    normalizedScope.TenantID,
+		WorkspaceID: normalizedScope.WorkspaceID,
+		Provider:    strings.TrimSpace(provider),
+		Status:      strings.TrimSpace(status),
+		StartedAt:   startedAt.UTC(),
 	}
 	m.scans[record.ID] = record
 	m.scanIDs = append(m.scanIDs, record.ID)
@@ -129,25 +139,27 @@ func (m *MemoryStore) createScanLocked(provider string, status string, startedAt
 }
 
 // GetScan returns one persisted scan by id.
-func (m *MemoryStore) GetScan(_ context.Context, scanID string) (ScanRecord, error) {
+func (m *MemoryStore) GetScan(ctx context.Context, scanID string) (ScanRecord, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	scope := ScopeFromContext(ctx)
 	record, exists := m.scans[scanID]
-	if !exists {
+	if !exists || !MatchScope(scope, record.TenantID, record.WorkspaceID) {
 		return ScanRecord{}, ErrNotFound
 	}
 	return record, nil
 }
 
 // CompleteScan finalizes persisted scan metadata.
-func (m *MemoryStore) CompleteScan(_ context.Context, scanID string, status string, finishedAt time.Time, assetCount int, findingCount int, errorMessage string) error {
+func (m *MemoryStore) CompleteScan(ctx context.Context, scanID string, status string, finishedAt time.Time, assetCount int, findingCount int, errorMessage string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	scope := ScopeFromContext(ctx)
 	record, exists := m.scans[scanID]
-	if !exists {
-		return fmt.Errorf("scan %s not found", scanID)
+	if !exists || !MatchScope(scope, record.TenantID, record.WorkspaceID) {
+		return ErrNotFound
 	}
 	finished := finishedAt.UTC()
 	record.Status = status
@@ -160,12 +172,14 @@ func (m *MemoryStore) CompleteScan(_ context.Context, scanID string, status stri
 }
 
 // UpsertFindings persists findings idempotently by scan_id + finding_id.
-func (m *MemoryStore) UpsertFindings(_ context.Context, scanID string, findings []domain.Finding) error {
+func (m *MemoryStore) UpsertFindings(ctx context.Context, scanID string, findings []domain.Finding) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.scans[scanID]; !exists {
-		return fmt.Errorf("scan %s not found", scanID)
+	scope := ScopeFromContext(ctx)
+	scan, exists := m.scans[scanID]
+	if !exists || !MatchScope(scope, scan.TenantID, scan.WorkspaceID) {
+		return ErrNotFound
 	}
 
 	for _, finding := range findings {
@@ -177,12 +191,14 @@ func (m *MemoryStore) UpsertFindings(_ context.Context, scanID string, findings 
 }
 
 // UpsertArtifacts persists raw and normalized scan artifacts idempotently.
-func (m *MemoryStore) UpsertArtifacts(_ context.Context, scanID string, artifacts ScanArtifacts) error {
+func (m *MemoryStore) UpsertArtifacts(ctx context.Context, scanID string, artifacts ScanArtifacts) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.scans[scanID]; !exists {
-		return fmt.Errorf("scan %s not found", scanID)
+	scope := ScopeFromContext(ctx)
+	scan, exists := m.scans[scanID]
+	if !exists || !MatchScope(scope, scan.TenantID, scan.WorkspaceID) {
+		return ErrNotFound
 	}
 
 	for _, asset := range artifacts.RawAssets {
@@ -209,13 +225,18 @@ func (m *MemoryStore) UpsertArtifacts(_ context.Context, scanID string, artifact
 }
 
 // ListScans returns latest scans first.
-func (m *MemoryStore) ListScans(_ context.Context, limit int) ([]ScanRecord, error) {
+func (m *MemoryStore) ListScans(ctx context.Context, limit int) ([]ScanRecord, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	scope := ScopeFromContext(ctx)
 	records := make([]ScanRecord, 0, len(m.scanIDs))
 	for _, scanID := range m.scanIDs {
-		records = append(records, m.scans[scanID])
+		record := m.scans[scanID]
+		if !MatchScope(scope, record.TenantID, record.WorkspaceID) {
+			continue
+		}
+		records = append(records, record)
 	}
 	sort.Slice(records, func(i, j int) bool {
 		return records[i].StartedAt.After(records[j].StartedAt)
@@ -227,12 +248,17 @@ func (m *MemoryStore) ListScans(_ context.Context, limit int) ([]ScanRecord, err
 }
 
 // ListFindings returns latest findings first.
-func (m *MemoryStore) ListFindings(_ context.Context, limit int) ([]domain.Finding, error) {
+func (m *MemoryStore) ListFindings(ctx context.Context, limit int) ([]domain.Finding, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	scope := ScopeFromContext(ctx)
 	result := make([]domain.Finding, 0, len(m.findings))
 	for _, finding := range m.findings {
+		scan, exists := m.scans[finding.ScanID]
+		if !exists || !MatchScope(scope, scan.TenantID, scan.WorkspaceID) {
+			continue
+		}
 		result = append(result, finding)
 	}
 	sort.Slice(result, func(i, j int) bool {
@@ -245,11 +271,13 @@ func (m *MemoryStore) ListFindings(_ context.Context, limit int) ([]domain.Findi
 }
 
 // ListFindingsByScan returns latest findings first for one scan.
-func (m *MemoryStore) ListFindingsByScan(_ context.Context, scanID string, limit int) ([]domain.Finding, error) {
+func (m *MemoryStore) ListFindingsByScan(ctx context.Context, scanID string, limit int) ([]domain.Finding, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if _, exists := m.scans[scanID]; !exists {
+	scope := ScopeFromContext(ctx)
+	scan, exists := m.scans[scanID]
+	if !exists || !MatchScope(scope, scan.TenantID, scan.WorkspaceID) {
 		return nil, ErrNotFound
 	}
 
@@ -270,13 +298,15 @@ func (m *MemoryStore) ListFindingsByScan(_ context.Context, scanID string, limit
 }
 
 // ListIdentities returns identities filtered by scan/provider/type/name.
-func (m *MemoryStore) ListIdentities(_ context.Context, filter IdentityFilter, limit int) ([]domain.Identity, error) {
+func (m *MemoryStore) ListIdentities(ctx context.Context, filter IdentityFilter, limit int) ([]domain.Identity, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	scope := ScopeFromContext(ctx)
 	filteredScanID := strings.TrimSpace(filter.ScanID)
 	if filteredScanID != "" {
-		if _, exists := m.scans[filteredScanID]; !exists {
+		scan, exists := m.scans[filteredScanID]
+		if !exists || !MatchScope(scope, scan.TenantID, scan.WorkspaceID) {
 			return nil, ErrNotFound
 		}
 	}
@@ -287,6 +317,10 @@ func (m *MemoryStore) ListIdentities(_ context.Context, filter IdentityFilter, l
 	result := []domain.Identity{}
 	for key, identity := range m.identities {
 		scanID := scanKeyPrefix(key)
+		scan, exists := m.scans[scanID]
+		if !exists || !MatchScope(scope, scan.TenantID, scan.WorkspaceID) {
+			continue
+		}
 		if filteredScanID != "" && scanID != filteredScanID {
 			continue
 		}
@@ -309,13 +343,15 @@ func (m *MemoryStore) ListIdentities(_ context.Context, filter IdentityFilter, l
 }
 
 // ListRelationships returns relationships filtered by scan/type/from/to.
-func (m *MemoryStore) ListRelationships(_ context.Context, filter RelationshipFilter, limit int) ([]domain.Relationship, error) {
+func (m *MemoryStore) ListRelationships(ctx context.Context, filter RelationshipFilter, limit int) ([]domain.Relationship, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	scope := ScopeFromContext(ctx)
 	filteredScanID := strings.TrimSpace(filter.ScanID)
 	if filteredScanID != "" {
-		if _, exists := m.scans[filteredScanID]; !exists {
+		scan, exists := m.scans[filteredScanID]
+		if !exists || !MatchScope(scope, scan.TenantID, scan.WorkspaceID) {
 			return nil, ErrNotFound
 		}
 	}
@@ -326,6 +362,10 @@ func (m *MemoryStore) ListRelationships(_ context.Context, filter RelationshipFi
 	result := []domain.Relationship{}
 	for key, relationship := range m.relationships {
 		scanID := scanKeyPrefix(key)
+		scan, exists := m.scans[scanID]
+		if !exists || !MatchScope(scope, scan.TenantID, scan.WorkspaceID) {
+			continue
+		}
 		if filteredScanID != "" && scanID != filteredScanID {
 			continue
 		}
@@ -348,11 +388,13 @@ func (m *MemoryStore) ListRelationships(_ context.Context, filter RelationshipFi
 }
 
 // AppendScanEvent appends one scan event entry.
-func (m *MemoryStore) AppendScanEvent(_ context.Context, scanID string, level string, message string, metadata map[string]any) error {
+func (m *MemoryStore) AppendScanEvent(ctx context.Context, scanID string, level string, message string, metadata map[string]any) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.scans[scanID]; !exists {
+	scope := ScopeFromContext(ctx)
+	scan, exists := m.scans[scanID]
+	if !exists || !MatchScope(scope, scan.TenantID, scan.WorkspaceID) {
 		return ErrNotFound
 	}
 	normalizedLevel, err := NormalizeScanEventLevel(strings.ToLower(strings.TrimSpace(level)))
@@ -371,11 +413,13 @@ func (m *MemoryStore) AppendScanEvent(_ context.Context, scanID string, level st
 }
 
 // ListScanEvents returns most recent scan events first.
-func (m *MemoryStore) ListScanEvents(_ context.Context, scanID string, limit int) ([]ScanEvent, error) {
+func (m *MemoryStore) ListScanEvents(ctx context.Context, scanID string, limit int) ([]ScanEvent, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if _, exists := m.scans[scanID]; !exists {
+	scope := ScopeFromContext(ctx)
+	scan, exists := m.scans[scanID]
+	if !exists || !MatchScope(scope, scan.TenantID, scan.WorkspaceID) {
 		return nil, ErrNotFound
 	}
 	events := append([]ScanEvent(nil), m.events[scanID]...)
@@ -397,30 +441,34 @@ func scanKeyPrefix(key string) string {
 }
 
 // CreateRepoScan persists one repository exposure scan start event.
-func (m *MemoryStore) CreateRepoScan(_ context.Context, repository string, startedAt time.Time) (RepoScanRecord, error) {
+func (m *MemoryStore) CreateRepoScan(ctx context.Context, repository string, startedAt time.Time) (RepoScanRecord, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	return m.createRepoScanLocked(strings.TrimSpace(repository), "running", 0, 0, startedAt), nil
+	return m.createRepoScanLocked(ScopeFromContext(ctx), strings.TrimSpace(repository), "running", 0, 0, startedAt), nil
 }
 
 // CreateQueuedRepoScan persists one queued repository exposure scan request.
-func (m *MemoryStore) CreateQueuedRepoScan(_ context.Context, repository string, historyLimit int, maxFindings int, queuedAt time.Time) (RepoScanRecord, error) {
+func (m *MemoryStore) CreateQueuedRepoScan(ctx context.Context, repository string, historyLimit int, maxFindings int, queuedAt time.Time) (RepoScanRecord, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	return m.createRepoScanLocked(strings.TrimSpace(repository), "queued", historyLimit, maxFindings, queuedAt), nil
+	return m.createRepoScanLocked(ScopeFromContext(ctx), strings.TrimSpace(repository), "queued", historyLimit, maxFindings, queuedAt), nil
 }
 
 // ClaimNextQueuedRepoScan moves one queued repository scan to running for execution.
-func (m *MemoryStore) ClaimNextQueuedRepoScan(_ context.Context) (RepoScanRecord, error) {
+func (m *MemoryStore) ClaimNextQueuedRepoScan(ctx context.Context) (RepoScanRecord, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	scope := ScopeFromContext(ctx)
 	var claimed RepoScanRecord
 	found := false
 	for _, scanID := range m.repoScanIDs {
 		record := m.repoScans[scanID]
+		if !MatchScope(scope, record.TenantID, record.WorkspaceID) {
+			continue
+		}
 		if record.Status != "queued" {
 			continue
 		}
@@ -440,12 +488,16 @@ func (m *MemoryStore) ClaimNextQueuedRepoScan(_ context.Context) (RepoScanRecord
 }
 
 // CountQueuedRepoScans returns queued repository scan count.
-func (m *MemoryStore) CountQueuedRepoScans(_ context.Context) (int, error) {
+func (m *MemoryStore) CountQueuedRepoScans(ctx context.Context) (int, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	scope := ScopeFromContext(ctx)
 	count := 0
 	for _, record := range m.repoScans {
+		if !MatchScope(scope, record.TenantID, record.WorkspaceID) {
+			continue
+		}
 		if record.Status == "queued" {
 			count++
 		}
@@ -454,16 +506,20 @@ func (m *MemoryStore) CountQueuedRepoScans(_ context.Context) (int, error) {
 }
 
 // CountPendingRepoScansByRepository returns queued/running scan count for one repository.
-func (m *MemoryStore) CountPendingRepoScansByRepository(_ context.Context, repository string) (int, error) {
+func (m *MemoryStore) CountPendingRepoScansByRepository(ctx context.Context, repository string) (int, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	scope := ScopeFromContext(ctx)
 	normalizedRepository := strings.TrimSpace(repository)
 	if normalizedRepository == "" {
 		return 0, nil
 	}
 	count := 0
 	for _, record := range m.repoScans {
+		if !MatchScope(scope, record.TenantID, record.WorkspaceID) {
+			continue
+		}
 		if !strings.EqualFold(strings.TrimSpace(record.Repository), normalizedRepository) {
 			continue
 		}
@@ -475,12 +531,13 @@ func (m *MemoryStore) CountPendingRepoScansByRepository(_ context.Context, repos
 }
 
 // RequeueRepoScan moves a running repository scan back to queued state.
-func (m *MemoryStore) RequeueRepoScan(_ context.Context, repoScanID string) error {
+func (m *MemoryStore) RequeueRepoScan(ctx context.Context, repoScanID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	scope := ScopeFromContext(ctx)
 	record, exists := m.repoScans[repoScanID]
-	if !exists {
+	if !exists || !MatchScope(scope, record.TenantID, record.WorkspaceID) {
 		return ErrNotFound
 	}
 	if record.Status != "running" {
@@ -494,9 +551,12 @@ func (m *MemoryStore) RequeueRepoScan(_ context.Context, repoScanID string) erro
 	return nil
 }
 
-func (m *MemoryStore) createRepoScanLocked(repository string, status string, historyLimit int, maxFindings int, startedAt time.Time) RepoScanRecord {
+func (m *MemoryStore) createRepoScanLocked(scope Scope, repository string, status string, historyLimit int, maxFindings int, startedAt time.Time) RepoScanRecord {
+	normalizedScope := scope.Normalize()
 	record := RepoScanRecord{
 		ID:           uuid.NewString(),
+		TenantID:     normalizedScope.TenantID,
+		WorkspaceID:  normalizedScope.WorkspaceID,
 		Repository:   strings.TrimSpace(repository),
 		Status:       strings.TrimSpace(status),
 		StartedAt:    startedAt.UTC(),
@@ -509,24 +569,26 @@ func (m *MemoryStore) createRepoScanLocked(repository string, status string, his
 }
 
 // GetRepoScan returns one persisted repo scan by id.
-func (m *MemoryStore) GetRepoScan(_ context.Context, repoScanID string) (RepoScanRecord, error) {
+func (m *MemoryStore) GetRepoScan(ctx context.Context, repoScanID string) (RepoScanRecord, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	scope := ScopeFromContext(ctx)
 	record, exists := m.repoScans[repoScanID]
-	if !exists {
+	if !exists || !MatchScope(scope, record.TenantID, record.WorkspaceID) {
 		return RepoScanRecord{}, ErrNotFound
 	}
 	return record, nil
 }
 
 // CompleteRepoScan finalizes repo scan metadata.
-func (m *MemoryStore) CompleteRepoScan(_ context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, errorMessage string) error {
+func (m *MemoryStore) CompleteRepoScan(ctx context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, errorMessage string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	scope := ScopeFromContext(ctx)
 	record, exists := m.repoScans[repoScanID]
-	if !exists {
+	if !exists || !MatchScope(scope, record.TenantID, record.WorkspaceID) {
 		return ErrNotFound
 	}
 	finished := finishedAt.UTC()
@@ -542,11 +604,13 @@ func (m *MemoryStore) CompleteRepoScan(_ context.Context, repoScanID string, sta
 }
 
 // UpsertRepoFindings persists repository findings idempotently by repo_scan_id + finding_id.
-func (m *MemoryStore) UpsertRepoFindings(_ context.Context, repoScanID string, findings []domain.Finding) error {
+func (m *MemoryStore) UpsertRepoFindings(ctx context.Context, repoScanID string, findings []domain.Finding) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.repoScans[repoScanID]; !exists {
+	scope := ScopeFromContext(ctx)
+	repoScan, exists := m.repoScans[repoScanID]
+	if !exists || !MatchScope(scope, repoScan.TenantID, repoScan.WorkspaceID) {
 		return ErrNotFound
 	}
 	for _, finding := range findings {
@@ -558,13 +622,18 @@ func (m *MemoryStore) UpsertRepoFindings(_ context.Context, repoScanID string, f
 }
 
 // ListRepoScans returns latest repo scans first.
-func (m *MemoryStore) ListRepoScans(_ context.Context, limit int) ([]RepoScanRecord, error) {
+func (m *MemoryStore) ListRepoScans(ctx context.Context, limit int) ([]RepoScanRecord, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	scope := ScopeFromContext(ctx)
 	result := make([]RepoScanRecord, 0, len(m.repoScanIDs))
 	for _, scanID := range m.repoScanIDs {
-		result = append(result, m.repoScans[scanID])
+		record := m.repoScans[scanID]
+		if !MatchScope(scope, record.TenantID, record.WorkspaceID) {
+			continue
+		}
+		result = append(result, record)
 	}
 	sort.Slice(result, func(i, j int) bool {
 		return result[i].StartedAt.After(result[j].StartedAt)
@@ -576,13 +645,15 @@ func (m *MemoryStore) ListRepoScans(_ context.Context, limit int) ([]RepoScanRec
 }
 
 // ListRepoFindings returns repository findings using optional filters.
-func (m *MemoryStore) ListRepoFindings(_ context.Context, filter RepoFindingFilter, limit int) ([]domain.Finding, error) {
+func (m *MemoryStore) ListRepoFindings(ctx context.Context, filter RepoFindingFilter, limit int) ([]domain.Finding, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	scope := ScopeFromContext(ctx)
 	repoScanID := strings.TrimSpace(filter.RepoScanID)
 	if repoScanID != "" {
-		if _, exists := m.repoScans[repoScanID]; !exists {
+		record, exists := m.repoScans[repoScanID]
+		if !exists || !MatchScope(scope, record.TenantID, record.WorkspaceID) {
 			return nil, ErrNotFound
 		}
 	}
@@ -591,6 +662,10 @@ func (m *MemoryStore) ListRepoFindings(_ context.Context, filter RepoFindingFilt
 
 	result := make([]domain.Finding, 0, len(m.repoFindings))
 	for _, finding := range m.repoFindings {
+		record, exists := m.repoScans[finding.ScanID]
+		if !exists || !MatchScope(scope, record.TenantID, record.WorkspaceID) {
+			continue
+		}
 		if repoScanID != "" && finding.ScanID != repoScanID {
 			continue
 		}

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -384,3 +384,59 @@ func TestMemoryStorePendingRepoCountMatchingIsCaseInsensitive(t *testing.T) {
 		t.Fatalf("expected 1 pending repo scan for case-insensitive repository match, got %d", count)
 	}
 }
+
+func TestMemoryStoreScopeIsolation(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 3, 22, 10, 0, 0, 0, time.UTC)
+
+	defaultCtx := context.Background()
+	otherCtx := WithScope(context.Background(), Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
+
+	defaultScan, err := store.CreateScan(defaultCtx, "aws", now)
+	if err != nil {
+		t.Fatalf("create default scan: %v", err)
+	}
+	otherScan, err := store.CreateScan(otherCtx, "aws", now.Add(1*time.Minute))
+	if err != nil {
+		t.Fatalf("create other scan: %v", err)
+	}
+
+	if _, err := store.GetScan(defaultCtx, otherScan.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected cross-scope get scan to fail with not found, got %v", err)
+	}
+	if _, err := store.GetScan(otherCtx, defaultScan.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected cross-scope get scan to fail with not found, got %v", err)
+	}
+
+	defaultScans, err := store.ListScans(defaultCtx, 10)
+	if err != nil {
+		t.Fatalf("list default scans: %v", err)
+	}
+	if len(defaultScans) != 1 || defaultScans[0].ID != defaultScan.ID {
+		t.Fatalf("unexpected default scope scans: %+v", defaultScans)
+	}
+
+	otherScans, err := store.ListScans(otherCtx, 10)
+	if err != nil {
+		t.Fatalf("list other scans: %v", err)
+	}
+	if len(otherScans) != 1 || otherScans[0].ID != otherScan.ID {
+		t.Fatalf("unexpected other scope scans: %+v", otherScans)
+	}
+
+	defaultRepo, err := store.CreateQueuedRepoScan(defaultCtx, "owner/repo", 10, 10, now)
+	if err != nil {
+		t.Fatalf("create default repo scan: %v", err)
+	}
+	otherRepo, err := store.CreateQueuedRepoScan(otherCtx, "owner/repo", 10, 10, now.Add(2*time.Minute))
+	if err != nil {
+		t.Fatalf("create other repo scan: %v", err)
+	}
+
+	if _, err := store.GetRepoScan(defaultCtx, otherRepo.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected cross-scope get repo scan to fail with not found, got %v", err)
+	}
+	if _, err := store.GetRepoScan(otherCtx, defaultRepo.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected cross-scope get repo scan to fail with not found, got %v", err)
+	}
+}

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -77,3 +77,23 @@ func TestFourthMigrationContainsPerformanceIndexes(t *testing.T) {
 		}
 	}
 }
+
+func TestSixthMigrationContainsTenantWorkspaceScope(t *testing.T) {
+	path := filepath.Join("..", "..", "migrations", "000006_tenant_workspace_scope.up.sql")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	text := string(content)
+	required := []string{
+		"ADD COLUMN IF NOT EXISTS tenant_id",
+		"ADD COLUMN IF NOT EXISTS workspace_id",
+		"idx_scans_scope_started_at",
+		"idx_repo_scans_scope_started_at",
+	}
+	for _, item := range required {
+		if !strings.Contains(text, item) {
+			t.Fatalf("expected tenant/workspace scope migration item %q", item)
+		}
+	}
+}

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -64,12 +64,16 @@ func (p *PostgresStore) CreateQueuedScan(ctx context.Context, provider string, q
 
 // ClaimNextQueuedScan atomically claims one queued scan for execution.
 func (p *PostgresStore) ClaimNextQueuedScan(ctx context.Context, provider string) (ScanRecord, error) {
+	scope := ScopeFromContext(ctx)
 	row := p.db.QueryRowContext(
 		ctx,
 		`WITH next_scan AS (
 			SELECT id
 			FROM scans
-			WHERE provider = $1 AND status = 'queued'
+			WHERE tenant_id = $1
+			  AND workspace_id = $2
+			  AND provider = $3
+			  AND status = 'queued'
 			ORDER BY started_at ASC
 			FOR UPDATE SKIP LOCKED
 			LIMIT 1
@@ -80,13 +84,17 @@ func (p *PostgresStore) ClaimNextQueuedScan(ctx context.Context, provider string
 		    error_message = NULL
 		FROM next_scan
 		WHERE s.id = next_scan.id
-		RETURNING s.id, s.provider, s.status, s.started_at, s.finished_at, s.asset_count, s.finding_count, COALESCE(s.error_message, '')`,
+		RETURNING s.id, s.tenant_id, s.workspace_id, s.provider, s.status, s.started_at, s.finished_at, s.asset_count, s.finding_count, COALESCE(s.error_message, '')`,
+		scope.TenantID,
+		scope.WorkspaceID,
 		strings.TrimSpace(provider),
 	)
 	var record ScanRecord
 	var finishedAt sql.NullTime
 	if err := row.Scan(
 		&record.ID,
+		&record.TenantID,
+		&record.WorkspaceID,
 		&record.Provider,
 		&record.Status,
 		&record.StartedAt,
@@ -109,10 +117,18 @@ func (p *PostgresStore) ClaimNextQueuedScan(ctx context.Context, provider string
 
 // CountQueuedScans returns queued scan requests count for one provider.
 func (p *PostgresStore) CountQueuedScans(ctx context.Context, provider string) (int, error) {
+	scope := ScopeFromContext(ctx)
 	var count int
 	if err := p.db.QueryRowContext(
 		ctx,
-		`SELECT COUNT(*) FROM scans WHERE provider = $1 AND status = 'queued'`,
+		`SELECT COUNT(*)
+		 FROM scans
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND provider = $3
+		   AND status = 'queued'`,
+		scope.TenantID,
+		scope.WorkspaceID,
 		strings.TrimSpace(provider),
 	).Scan(&count); err != nil {
 		return 0, fmt.Errorf("count queued scans: %w", err)
@@ -122,36 +138,61 @@ func (p *PostgresStore) CountQueuedScans(ctx context.Context, provider string) (
 
 // GetScan returns one scan by id.
 func (p *PostgresStore) GetScan(ctx context.Context, scanID string) (ScanRecord, error) {
-	row, err := p.queries.GetScan(ctx, scanID)
+	scope := ScopeFromContext(ctx)
+	row := p.db.QueryRowContext(
+		ctx,
+		`SELECT id, tenant_id, workspace_id, provider, status, started_at, finished_at, asset_count, finding_count, COALESCE(error_message, '')
+		 FROM scans
+		 WHERE id = $1
+		   AND tenant_id = $2
+		   AND workspace_id = $3`,
+		scanID,
+		scope.TenantID,
+		scope.WorkspaceID,
+	)
+	record, err := scanScanRecord(row)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errorsIsNoRows(err) {
 			return ScanRecord{}, ErrNotFound
 		}
 		return ScanRecord{}, fmt.Errorf("query scan: %w", err)
 	}
-	return scanRecordFromRow(row), nil
+	return record, nil
 }
 
 // CompleteScan updates scan completion metadata.
 func (p *PostgresStore) CompleteScan(ctx context.Context, scanID string, status string, finishedAt time.Time, assetCount int, findingCount int, errorMessage string) error {
-	_, err := p.db.ExecContext(
+	scope := ScopeFromContext(ctx)
+	result, err := p.db.ExecContext(
 		ctx,
-		`UPDATE scans SET status=$2, finished_at=$3, asset_count=$4, finding_count=$5, error_message=$6 WHERE id=$1`,
+		`UPDATE scans
+		 SET status=$2, finished_at=$3, asset_count=$4, finding_count=$5, error_message=$6
+		 WHERE id=$1
+		   AND tenant_id=$7
+		   AND workspace_id=$8`,
 		scanID,
 		status,
 		finishedAt.UTC(),
 		assetCount,
 		findingCount,
 		nullableString(errorMessage),
+		scope.TenantID,
+		scope.WorkspaceID,
 	)
 	if err != nil {
 		return fmt.Errorf("complete scan: %w", err)
+	}
+	if err := ensureRowsAffected(result); err != nil {
+		return err
 	}
 	return nil
 }
 
 // UpsertArtifacts inserts raw and normalized artifacts idempotently for one scan.
 func (p *PostgresStore) UpsertArtifacts(ctx context.Context, scanID string, artifacts ScanArtifacts) error {
+	if err := p.ensureScanInScope(ctx, scanID); err != nil {
+		return err
+	}
 	tx, err := p.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin artifacts transaction: %w", err)
@@ -182,6 +223,9 @@ func (p *PostgresStore) UpsertArtifacts(ctx context.Context, scanID string, arti
 
 // UpsertFindings inserts findings idempotently for the scan.
 func (p *PostgresStore) UpsertFindings(ctx context.Context, scanID string, findings []domain.Finding) error {
+	if err := p.ensureScanInScope(ctx, scanID); err != nil {
+		return err
+	}
 	tx, err := p.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin transaction: %w", err)
@@ -248,13 +292,33 @@ func (p *PostgresStore) ListScans(ctx context.Context, limit int) ([]ScanRecord,
 	if limit <= 0 {
 		limit = 20
 	}
-	rows, err := p.queries.ListScans(ctx, limit)
+	scope := ScopeFromContext(ctx)
+	rows, err := p.db.QueryContext(
+		ctx,
+		`SELECT id, tenant_id, workspace_id, provider, status, started_at, finished_at, asset_count, finding_count, COALESCE(error_message, '')
+		 FROM scans
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		 ORDER BY started_at DESC
+		 LIMIT $3`,
+		scope.TenantID,
+		scope.WorkspaceID,
+		limit,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("query scans: %w", err)
 	}
-	result := make([]ScanRecord, 0, len(rows))
-	for _, row := range rows {
-		result = append(result, scanRecordFromRow(row))
+	defer rows.Close()
+	result := []ScanRecord{}
+	for rows.Next() {
+		record, scanErr := scanScanRecord(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("scan row: %w", scanErr)
+		}
+		result = append(result, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("scan rows: %w", err)
 	}
 	return result, nil
 }
@@ -264,11 +328,25 @@ func (p *PostgresStore) ListFindings(ctx context.Context, limit int) ([]domain.F
 	if limit <= 0 {
 		limit = 100
 	}
-	rows, err := p.queries.ListFindings(ctx, limit)
+	scope := ScopeFromContext(ctx)
+	rows, err := p.db.QueryContext(
+		ctx,
+		`SELECT f.scan_id, f.finding_id, f.type, f.severity, f.title, f.human_summary, f.path, f.evidence, f.remediation, f.created_at
+		 FROM findings f
+		 JOIN scans s ON s.id = f.scan_id
+		 WHERE s.tenant_id = $1
+		   AND s.workspace_id = $2
+		 ORDER BY f.created_at DESC
+		 LIMIT $3`,
+		scope.TenantID,
+		scope.WorkspaceID,
+		limit,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("query findings: %w", err)
 	}
-	return findingsFromRows(rows)
+	defer rows.Close()
+	return findingsFromSQLRows(rows)
 }
 
 // ListFindingsByScan returns latest findings first for one scan id.
@@ -276,11 +354,30 @@ func (p *PostgresStore) ListFindingsByScan(ctx context.Context, scanID string, l
 	if limit <= 0 {
 		limit = 100
 	}
-	rows, err := p.queries.ListFindingsByScan(ctx, scanID, limit)
+	if err := p.ensureScanInScope(ctx, scanID); err != nil {
+		return nil, err
+	}
+	scope := ScopeFromContext(ctx)
+	rows, err := p.db.QueryContext(
+		ctx,
+		`SELECT f.scan_id, f.finding_id, f.type, f.severity, f.title, f.human_summary, f.path, f.evidence, f.remediation, f.created_at
+		 FROM findings f
+		 JOIN scans s ON s.id = f.scan_id
+		 WHERE f.scan_id = $1
+		   AND s.tenant_id = $2
+		   AND s.workspace_id = $3
+		 ORDER BY f.created_at DESC
+		 LIMIT $4`,
+		scanID,
+		scope.TenantID,
+		scope.WorkspaceID,
+		limit,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("query findings by scan: %w", err)
 	}
-	return findingsFromRows(rows)
+	defer rows.Close()
+	return findingsFromSQLRows(rows)
 }
 
 // ListIdentities returns identities filtered by scan/provider/type/name prefix.
@@ -288,14 +385,23 @@ func (p *PostgresStore) ListIdentities(ctx context.Context, filter IdentityFilte
 	if limit <= 0 {
 		limit = 100
 	}
+	scope := ScopeFromContext(ctx)
+	if strings.TrimSpace(filter.ScanID) != "" {
+		if err := p.ensureScanInScope(ctx, filter.ScanID); err != nil {
+			return nil, err
+		}
+	}
 	rows, err := p.db.QueryContext(
 		ctx,
 		`SELECT i.id, i.provider, i.type, i.name, COALESCE(i.arn, ''), COALESCE(i.owner_hint, ''), i.created_at, i.last_used_at, i.tags, i.raw_ref
 		 FROM identities i
+		 JOIN scans s ON s.id = i.scan_id
 		 WHERE ($1 = '' OR i.scan_id = $1::uuid)
 		   AND ($2 = '' OR i.provider = $2)
 		   AND ($3 = '' OR i.type = $3)
 		   AND ($4 = '' OR LOWER(i.name) LIKE LOWER($4 || '%'))
+		   AND s.tenant_id = $6
+		   AND s.workspace_id = $7
 		 ORDER BY i.name ASC
 		 LIMIT $5`,
 		filter.ScanID,
@@ -303,6 +409,8 @@ func (p *PostgresStore) ListIdentities(ctx context.Context, filter IdentityFilte
 		filter.Type,
 		filter.NamePrefix,
 		limit,
+		scope.TenantID,
+		scope.WorkspaceID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("query identities: %w", err)
@@ -346,21 +454,32 @@ func (p *PostgresStore) ListRelationships(ctx context.Context, filter Relationsh
 	if limit <= 0 {
 		limit = 100
 	}
+	scope := ScopeFromContext(ctx)
+	if strings.TrimSpace(filter.ScanID) != "" {
+		if err := p.ensureScanInScope(ctx, filter.ScanID); err != nil {
+			return nil, err
+		}
+	}
 	rows, err := p.db.QueryContext(
 		ctx,
-		`SELECT id, type, from_node_id, to_node_id, COALESCE(evidence_ref, ''), discovered_at
-		 FROM relationships
-		 WHERE ($1 = '' OR scan_id = $1::uuid)
-		   AND ($2 = '' OR type = $2)
-		   AND ($3 = '' OR from_node_id = $3)
-		   AND ($4 = '' OR to_node_id = $4)
-		 ORDER BY discovered_at DESC
+		`SELECT r.id, r.type, r.from_node_id, r.to_node_id, COALESCE(r.evidence_ref, ''), r.discovered_at
+		 FROM relationships r
+		 JOIN scans s ON s.id = r.scan_id
+		 WHERE ($1 = '' OR r.scan_id = $1::uuid)
+		   AND ($2 = '' OR r.type = $2)
+		   AND ($3 = '' OR r.from_node_id = $3)
+		   AND ($4 = '' OR r.to_node_id = $4)
+		   AND s.tenant_id = $6
+		   AND s.workspace_id = $7
+		 ORDER BY r.discovered_at DESC
 		 LIMIT $5`,
 		filter.ScanID,
 		filter.Type,
 		filter.FromNodeID,
 		filter.ToNodeID,
 		limit,
+		scope.TenantID,
+		scope.WorkspaceID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("query relationships: %w", err)
@@ -385,6 +504,7 @@ func (p *PostgresStore) ListRelationships(ctx context.Context, filter Relationsh
 
 // AppendScanEvent writes one scan event row.
 func (p *PostgresStore) AppendScanEvent(ctx context.Context, scanID string, level string, message string, metadata map[string]any) error {
+	scope := ScopeFromContext(ctx)
 	normalizedLevel, levelErr := NormalizeScanEventLevel(strings.ToLower(strings.TrimSpace(level)))
 	if levelErr != nil {
 		return levelErr
@@ -393,18 +513,27 @@ func (p *PostgresStore) AppendScanEvent(ctx context.Context, scanID string, leve
 	if err != nil {
 		return fmt.Errorf("marshal scan event metadata: %w", err)
 	}
-	_, err = p.db.ExecContext(
+	result, err := p.db.ExecContext(
 		ctx,
 		`INSERT INTO scan_events (id, scan_id, level, message, metadata, created_at)
-		 VALUES ($1, $2, $3, $4, $5, NOW())`,
+		 SELECT $1, $2, $3, $4, $5, NOW()
+		 FROM scans s
+		 WHERE s.id = $2
+		   AND s.tenant_id = $6
+		   AND s.workspace_id = $7`,
 		uuid.NewString(),
 		scanID,
 		normalizedLevel,
 		message,
 		payload,
+		scope.TenantID,
+		scope.WorkspaceID,
 	)
 	if err != nil {
 		return fmt.Errorf("insert scan event: %w", err)
+	}
+	if err := ensureRowsAffected(result); err != nil {
+		return err
 	}
 	return nil
 }
@@ -414,12 +543,36 @@ func (p *PostgresStore) ListScanEvents(ctx context.Context, scanID string, limit
 	if limit <= 0 {
 		limit = 100
 	}
-	rows, err := p.queries.ListScanEvents(ctx, scanID, limit)
+	if err := p.ensureScanInScope(ctx, scanID); err != nil {
+		return nil, err
+	}
+	scope := ScopeFromContext(ctx)
+	rows, err := p.db.QueryContext(
+		ctx,
+		`SELECT e.id, e.scan_id, e.level, e.message, e.metadata, e.created_at
+		 FROM scan_events e
+		 JOIN scans s ON s.id = e.scan_id
+		 WHERE e.scan_id = $1
+		   AND s.tenant_id = $2
+		   AND s.workspace_id = $3
+		 ORDER BY e.created_at DESC
+		 LIMIT $4`,
+		scanID,
+		scope.TenantID,
+		scope.WorkspaceID,
+		limit,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("query scan events: %w", err)
 	}
+	defer rows.Close()
 	result := []ScanEvent{}
-	for _, row := range rows {
+	for rows.Next() {
+		var row ScanEvent
+		var metadata []byte
+		if err := rows.Scan(&row.ID, &row.ScanID, &row.Level, &row.Message, &metadata, &row.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan event row: %w", err)
+		}
 		event := ScanEvent{
 			ID:        row.ID,
 			ScanID:    row.ScanID,
@@ -427,12 +580,15 @@ func (p *PostgresStore) ListScanEvents(ctx context.Context, scanID string, limit
 			Message:   row.Message,
 			CreatedAt: row.CreatedAt,
 		}
-		if len(row.Metadata) > 0 {
-			if err := json.Unmarshal(row.Metadata, &event.Metadata); err != nil {
+		if len(metadata) > 0 {
+			if err := json.Unmarshal(metadata, &event.Metadata); err != nil {
 				return nil, fmt.Errorf("decode scan event metadata: %w", err)
 			}
 		}
 		result = append(result, event)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("scan event rows: %w", err)
 	}
 	return result, nil
 }
@@ -449,12 +605,15 @@ func (p *PostgresStore) CreateQueuedRepoScan(ctx context.Context, repository str
 
 // ClaimNextQueuedRepoScan atomically claims one queued repository scan.
 func (p *PostgresStore) ClaimNextQueuedRepoScan(ctx context.Context) (RepoScanRecord, error) {
+	scope := ScopeFromContext(ctx)
 	row := p.db.QueryRowContext(
 		ctx,
 		`WITH next_repo_scan AS (
 			SELECT id
 			FROM repo_scans
-			WHERE status = 'queued'
+			WHERE tenant_id = $1
+			  AND workspace_id = $2
+			  AND status = 'queued'
 			ORDER BY started_at ASC
 			FOR UPDATE SKIP LOCKED
 			LIMIT 1
@@ -467,6 +626,8 @@ func (p *PostgresStore) ClaimNextQueuedRepoScan(ctx context.Context) (RepoScanRe
 		WHERE r.id = next_repo_scan.id
 		RETURNING
 			r.id,
+			r.tenant_id,
+			r.workspace_id,
 			r.repository,
 			r.status,
 			r.started_at,
@@ -478,6 +639,8 @@ func (p *PostgresStore) ClaimNextQueuedRepoScan(ctx context.Context) (RepoScanRe
 			COALESCE(r.error_message, ''),
 			r.history_limit,
 			r.max_findings_limit`,
+		scope.TenantID,
+		scope.WorkspaceID,
 	)
 	record, err := scanRepoScanRecord(row)
 	if err != nil {
@@ -491,8 +654,18 @@ func (p *PostgresStore) ClaimNextQueuedRepoScan(ctx context.Context) (RepoScanRe
 
 // CountQueuedRepoScans returns queued repository scan requests count.
 func (p *PostgresStore) CountQueuedRepoScans(ctx context.Context) (int, error) {
+	scope := ScopeFromContext(ctx)
 	var count int
-	if err := p.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM repo_scans WHERE status = 'queued'`).Scan(&count); err != nil {
+	if err := p.db.QueryRowContext(
+		ctx,
+		`SELECT COUNT(*)
+		 FROM repo_scans
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND status = 'queued'`,
+		scope.TenantID,
+		scope.WorkspaceID,
+	).Scan(&count); err != nil {
 		return 0, fmt.Errorf("count queued repo scans: %w", err)
 	}
 	return count, nil
@@ -500,13 +673,18 @@ func (p *PostgresStore) CountQueuedRepoScans(ctx context.Context) (int, error) {
 
 // CountPendingRepoScansByRepository returns queued+running scan count for one repository.
 func (p *PostgresStore) CountPendingRepoScansByRepository(ctx context.Context, repository string) (int, error) {
+	scope := ScopeFromContext(ctx)
 	var count int
 	if err := p.db.QueryRowContext(
 		ctx,
 		`SELECT COUNT(*)
 		 FROM repo_scans
-		 WHERE LOWER(repository) = LOWER($1)
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND LOWER(repository) = LOWER($3)
 		   AND status IN ('queued', 'running')`,
+		scope.TenantID,
+		scope.WorkspaceID,
 		strings.TrimSpace(repository),
 	).Scan(&count); err != nil {
 		return 0, fmt.Errorf("count pending repo scans: %w", err)
@@ -516,6 +694,7 @@ func (p *PostgresStore) CountPendingRepoScansByRepository(ctx context.Context, r
 
 // RequeueRepoScan moves one running repository scan back to queued.
 func (p *PostgresStore) RequeueRepoScan(ctx context.Context, repoScanID string) error {
+	scope := ScopeFromContext(ctx)
 	result, err := p.db.ExecContext(
 		ctx,
 		`UPDATE repo_scans
@@ -524,8 +703,12 @@ func (p *PostgresStore) RequeueRepoScan(ctx context.Context, repoScanID string) 
 		     finished_at = NULL,
 		     error_message = NULL
 		 WHERE id = $1
+		   AND tenant_id = $2
+		   AND workspace_id = $3
 		   AND status = 'running'`,
 		repoScanID,
+		scope.TenantID,
+		scope.WorkspaceID,
 	)
 	if err != nil {
 		return fmt.Errorf("requeue repo scan: %w", err)
@@ -541,8 +724,11 @@ func (p *PostgresStore) RequeueRepoScan(ctx context.Context, repoScanID string) 
 }
 
 func (p *PostgresStore) createRepoScanWithStatus(ctx context.Context, repository string, status string, historyLimit int, maxFindings int, startedAt time.Time) (RepoScanRecord, error) {
+	scope := ScopeFromContext(ctx)
 	record := RepoScanRecord{
 		ID:           uuid.NewString(),
+		TenantID:     scope.TenantID,
+		WorkspaceID:  scope.WorkspaceID,
 		Repository:   strings.TrimSpace(repository),
 		Status:       strings.TrimSpace(status),
 		StartedAt:    startedAt.UTC(),
@@ -551,9 +737,11 @@ func (p *PostgresStore) createRepoScanWithStatus(ctx context.Context, repository
 	}
 	_, err := p.db.ExecContext(
 		ctx,
-		`INSERT INTO repo_scans (id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit)
-		 VALUES ($1, $2, $3, $4, 0, 0, 0, false, $5, $6)`,
+		`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit)
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8)`,
 		record.ID,
+		record.TenantID,
+		record.WorkspaceID,
 		record.Repository,
 		record.Status,
 		record.StartedAt,
@@ -568,19 +756,32 @@ func (p *PostgresStore) createRepoScanWithStatus(ctx context.Context, repository
 
 // GetRepoScan returns one repository scan by id.
 func (p *PostgresStore) GetRepoScan(ctx context.Context, repoScanID string) (RepoScanRecord, error) {
-	row, err := p.queries.GetRepoScan(ctx, repoScanID)
+	scope := ScopeFromContext(ctx)
+	row := p.db.QueryRowContext(
+		ctx,
+		`SELECT id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(error_message, ''), history_limit, max_findings_limit
+		 FROM repo_scans
+		 WHERE id = $1
+		   AND tenant_id = $2
+		   AND workspace_id = $3`,
+		repoScanID,
+		scope.TenantID,
+		scope.WorkspaceID,
+	)
+	record, err := scanRepoScanRecord(row)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errorsIsNoRows(err) {
 			return RepoScanRecord{}, ErrNotFound
 		}
 		return RepoScanRecord{}, fmt.Errorf("query repo scan: %w", err)
 	}
-	return repoScanRecordFromRow(row), nil
+	return record, nil
 }
 
 // CompleteRepoScan updates repository scan completion metadata.
 func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, errorMessage string) error {
-	_, err := p.db.ExecContext(
+	scope := ScopeFromContext(ctx)
+	result, err := p.db.ExecContext(
 		ctx,
 		`UPDATE repo_scans
 		 SET status = $2,
@@ -590,7 +791,9 @@ func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string,
 		     finding_count = $6,
 		     truncated = $7,
 		     error_message = $8
-		 WHERE id = $1`,
+		 WHERE id = $1
+		   AND tenant_id = $9
+		   AND workspace_id = $10`,
 		repoScanID,
 		strings.TrimSpace(status),
 		finishedAt.UTC(),
@@ -599,15 +802,23 @@ func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string,
 		findingCount,
 		truncated,
 		nullableString(errorMessage),
+		scope.TenantID,
+		scope.WorkspaceID,
 	)
 	if err != nil {
 		return fmt.Errorf("complete repo scan: %w", err)
+	}
+	if err := ensureRowsAffected(result); err != nil {
+		return err
 	}
 	return nil
 }
 
 // UpsertRepoFindings inserts repository findings idempotently.
 func (p *PostgresStore) UpsertRepoFindings(ctx context.Context, repoScanID string, findings []domain.Finding) error {
+	if err := p.ensureRepoScanInScope(ctx, repoScanID); err != nil {
+		return err
+	}
 	tx, err := p.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin repo findings transaction: %w", err)
@@ -670,13 +881,33 @@ func (p *PostgresStore) ListRepoScans(ctx context.Context, limit int) ([]RepoSca
 	if limit <= 0 {
 		limit = 20
 	}
-	rows, err := p.queries.ListRepoScans(ctx, limit)
+	scope := ScopeFromContext(ctx)
+	rows, err := p.db.QueryContext(
+		ctx,
+		`SELECT id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(error_message, ''), history_limit, max_findings_limit
+		 FROM repo_scans
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		 ORDER BY started_at DESC
+		 LIMIT $3`,
+		scope.TenantID,
+		scope.WorkspaceID,
+		limit,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("query repo scans: %w", err)
 	}
-	result := make([]RepoScanRecord, 0, len(rows))
-	for _, row := range rows {
-		result = append(result, repoScanRecordFromRow(row))
+	defer rows.Close()
+	result := []RepoScanRecord{}
+	for rows.Next() {
+		record, scanErr := scanRepoScanRecord(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("repo scan row: %w", scanErr)
+		}
+		result = append(result, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("repo scan rows: %w", err)
 	}
 	return result, nil
 }
@@ -686,18 +917,64 @@ func (p *PostgresStore) ListRepoFindings(ctx context.Context, filter RepoFinding
 	if limit <= 0 {
 		limit = 100
 	}
-	rows, err := p.queries.ListRepoFindings(
+	repoScanID := strings.TrimSpace(filter.RepoScanID)
+	if repoScanID != "" {
+		if err := p.ensureRepoScanInScope(ctx, repoScanID); err != nil {
+			return nil, err
+		}
+	}
+	scope := ScopeFromContext(ctx)
+	rows, err := p.db.QueryContext(
 		ctx,
-		strings.TrimSpace(filter.RepoScanID),
+		`SELECT rf.repo_scan_id, rf.finding_id, rf.type, rf.severity, rf.title, rf.human_summary, rf.path, rf.evidence, rf.remediation, rf.created_at
+		 FROM repo_findings rf
+		 JOIN repo_scans rs ON rs.id = rf.repo_scan_id
+		 WHERE ($1 = '' OR rf.repo_scan_id = $1::uuid)
+		   AND ($2 = '' OR rf.severity = $2)
+		   AND ($3 = '' OR rf.type = $3)
+		   AND rs.tenant_id = $5
+		   AND rs.workspace_id = $6
+		 ORDER BY rf.created_at DESC
+		 LIMIT $4`,
+		repoScanID,
 		strings.TrimSpace(filter.Severity),
 		strings.TrimSpace(filter.Type),
 		limit,
+		scope.TenantID,
+		scope.WorkspaceID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("query repo findings: %w", err)
 	}
-	result := make([]domain.Finding, 0, len(rows))
-	for _, row := range rows {
+	defer rows.Close()
+	result := []domain.Finding{}
+	for rows.Next() {
+		var row struct {
+			RepoScanID   string
+			FindingID    string
+			Type         string
+			Severity     string
+			Title        string
+			HumanSummary string
+			Path         []byte
+			Evidence     []byte
+			Remediation  string
+			CreatedAt    time.Time
+		}
+		if err := rows.Scan(
+			&row.RepoScanID,
+			&row.FindingID,
+			&row.Type,
+			&row.Severity,
+			&row.Title,
+			&row.HumanSummary,
+			&row.Path,
+			&row.Evidence,
+			&row.Remediation,
+			&row.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("repo finding row: %w", err)
+		}
 		finding := domain.Finding{
 			ScanID:       row.RepoScanID,
 			ID:           row.FindingID,
@@ -719,6 +996,9 @@ func (p *PostgresStore) ListRepoFindings(ctx context.Context, filter RepoFinding
 			}
 		}
 		result = append(result, finding)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("repo finding rows: %w", err)
 	}
 	return result, nil
 }
@@ -900,45 +1180,22 @@ func upsertPermissions(ctx context.Context, tx *sql.Tx, scanID string, permissio
 	return nil
 }
 
-func scanRecordFromRow(row sqlcdb.ScanRow) ScanRecord {
-	return ScanRecord{
-		ID:           row.ID,
-		Provider:     row.Provider,
-		Status:       row.Status,
-		StartedAt:    row.StartedAt,
-		FinishedAt:   row.FinishedAt,
-		AssetCount:   row.AssetCount,
-		FindingCount: row.FindingCount,
-		ErrorMessage: row.ErrorMessage,
-	}
-}
-
-func repoScanRecordFromRow(row sqlcdb.RepoScanRow) RepoScanRecord {
-	return RepoScanRecord{
-		ID:             row.ID,
-		Repository:     row.Repository,
-		Status:         row.Status,
-		StartedAt:      row.StartedAt.UTC(),
-		FinishedAt:     row.FinishedAt,
-		CommitsScanned: row.CommitsScanned,
-		FilesScanned:   row.FilesScanned,
-		FindingCount:   row.FindingCount,
-		Truncated:      row.Truncated,
-		ErrorMessage:   row.ErrorMessage,
-	}
-}
-
 func (p *PostgresStore) createScanWithStatus(ctx context.Context, provider string, status string, startedAt time.Time) (ScanRecord, error) {
+	scope := ScopeFromContext(ctx)
 	record := ScanRecord{
-		ID:        uuid.NewString(),
-		Provider:  strings.TrimSpace(provider),
-		Status:    strings.TrimSpace(status),
-		StartedAt: startedAt.UTC(),
+		ID:          uuid.NewString(),
+		TenantID:    scope.TenantID,
+		WorkspaceID: scope.WorkspaceID,
+		Provider:    strings.TrimSpace(provider),
+		Status:      strings.TrimSpace(status),
+		StartedAt:   startedAt.UTC(),
 	}
 	_, err := p.db.ExecContext(
 		ctx,
-		`INSERT INTO scans (id, provider, status, started_at, asset_count, finding_count) VALUES ($1, $2, $3, $4, 0, 0)`,
+		`INSERT INTO scans (id, tenant_id, workspace_id, provider, status, started_at, asset_count, finding_count) VALUES ($1, $2, $3, $4, $5, $6, 0, 0)`,
 		record.ID,
+		record.TenantID,
+		record.WorkspaceID,
 		record.Provider,
 		record.Status,
 		record.StartedAt,
@@ -958,6 +1215,8 @@ func scanRepoScanRecord(scanner scanner) (RepoScanRecord, error) {
 	var finishedAt sql.NullTime
 	if err := scanner.Scan(
 		&record.ID,
+		&record.TenantID,
+		&record.WorkspaceID,
 		&record.Repository,
 		&record.Status,
 		&record.StartedAt,
@@ -980,9 +1239,60 @@ func scanRepoScanRecord(scanner scanner) (RepoScanRecord, error) {
 	return record, nil
 }
 
-func findingsFromRows(rows []sqlcdb.FindingRow) ([]domain.Finding, error) {
-	result := make([]domain.Finding, 0, len(rows))
-	for _, row := range rows {
+func scanScanRecord(scanner scanner) (ScanRecord, error) {
+	var record ScanRecord
+	var finishedAt sql.NullTime
+	if err := scanner.Scan(
+		&record.ID,
+		&record.TenantID,
+		&record.WorkspaceID,
+		&record.Provider,
+		&record.Status,
+		&record.StartedAt,
+		&finishedAt,
+		&record.AssetCount,
+		&record.FindingCount,
+		&record.ErrorMessage,
+	); err != nil {
+		return ScanRecord{}, err
+	}
+	record.StartedAt = record.StartedAt.UTC()
+	if finishedAt.Valid {
+		finished := finishedAt.Time.UTC()
+		record.FinishedAt = &finished
+	}
+	return record, nil
+}
+
+func findingsFromSQLRows(rows *sql.Rows) ([]domain.Finding, error) {
+	result := []domain.Finding{}
+	for rows.Next() {
+		var row struct {
+			ScanID       string
+			FindingID    string
+			Type         string
+			Severity     string
+			Title        string
+			HumanSummary string
+			Path         []byte
+			Evidence     []byte
+			Remediation  string
+			CreatedAt    time.Time
+		}
+		if err := rows.Scan(
+			&row.ScanID,
+			&row.FindingID,
+			&row.Type,
+			&row.Severity,
+			&row.Title,
+			&row.HumanSummary,
+			&row.Path,
+			&row.Evidence,
+			&row.Remediation,
+			&row.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("finding row: %w", err)
+		}
 		finding := domain.Finding{
 			ScanID:       row.ScanID,
 			ID:           row.FindingID,
@@ -1005,5 +1315,76 @@ func findingsFromRows(rows []sqlcdb.FindingRow) ([]domain.Finding, error) {
 		}
 		result = append(result, finding)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("finding rows: %w", err)
+	}
 	return result, nil
+}
+
+func ensureRowsAffected(result sql.Result) error {
+	if result == nil {
+		return ErrNotFound
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (p *PostgresStore) ensureScanInScope(ctx context.Context, scanID string) error {
+	scope := ScopeFromContext(ctx)
+	var exists bool
+	err := p.db.QueryRowContext(
+		ctx,
+		`SELECT EXISTS (
+			SELECT 1
+			FROM scans
+			WHERE id = $1
+			  AND tenant_id = $2
+			  AND workspace_id = $3
+		)`,
+		scanID,
+		scope.TenantID,
+		scope.WorkspaceID,
+	).Scan(&exists)
+	if err != nil {
+		return fmt.Errorf("verify scan scope: %w", err)
+	}
+	if !exists {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (p *PostgresStore) ensureRepoScanInScope(ctx context.Context, repoScanID string) error {
+	scope := ScopeFromContext(ctx)
+	var exists bool
+	err := p.db.QueryRowContext(
+		ctx,
+		`SELECT EXISTS (
+			SELECT 1
+			FROM repo_scans
+			WHERE id = $1
+			  AND tenant_id = $2
+			  AND workspace_id = $3
+		)`,
+		repoScanID,
+		scope.TenantID,
+		scope.WorkspaceID,
+	).Scan(&exists)
+	if err != nil {
+		return fmt.Errorf("verify repo scan scope: %w", err)
+	}
+	if !exists {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func errorsIsNoRows(err error) bool {
+	return err == sql.ErrNoRows
 }

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -331,7 +331,7 @@ func (p *PostgresStore) ListFindings(ctx context.Context, limit int) ([]domain.F
 	scope := ScopeFromContext(ctx)
 	rows, err := p.db.QueryContext(
 		ctx,
-		`SELECT f.scan_id, f.finding_id, f.type, f.severity, f.title, f.human_summary, f.path, f.evidence, f.remediation, f.created_at
+		`SELECT f.scan_id, f.finding_id, f.type, f.severity, f.title, f.human_summary, f.path, f.evidence, COALESCE(f.remediation, ''), f.created_at
 		 FROM findings f
 		 JOIN scans s ON s.id = f.scan_id
 		 WHERE s.tenant_id = $1
@@ -360,7 +360,7 @@ func (p *PostgresStore) ListFindingsByScan(ctx context.Context, scanID string, l
 	scope := ScopeFromContext(ctx)
 	rows, err := p.db.QueryContext(
 		ctx,
-		`SELECT f.scan_id, f.finding_id, f.type, f.severity, f.title, f.human_summary, f.path, f.evidence, f.remediation, f.created_at
+		`SELECT f.scan_id, f.finding_id, f.type, f.severity, f.title, f.human_summary, f.path, f.evidence, COALESCE(f.remediation, ''), f.created_at
 		 FROM findings f
 		 JOIN scans s ON s.id = f.scan_id
 		 WHERE f.scan_id = $1
@@ -926,7 +926,7 @@ func (p *PostgresStore) ListRepoFindings(ctx context.Context, filter RepoFinding
 	scope := ScopeFromContext(ctx)
 	rows, err := p.db.QueryContext(
 		ctx,
-		`SELECT rf.repo_scan_id, rf.finding_id, rf.type, rf.severity, rf.title, rf.human_summary, rf.path, rf.evidence, rf.remediation, rf.created_at
+		`SELECT rf.repo_scan_id, rf.finding_id, rf.type, rf.severity, rf.title, rf.human_summary, rf.path, rf.evidence, COALESCE(rf.remediation, ''), rf.created_at
 		 FROM repo_findings rf
 		 JOIN repo_scans rs ON rs.id = rf.repo_scan_id
 		 WHERE ($1 = '' OR rf.repo_scan_id = $1::uuid)

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -21,8 +21,8 @@ func TestPostgresStoreCreateAndCompleteScan(t *testing.T) {
 
 	store := NewPostgresStoreWithDB(db)
 
-	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO scans (id, provider, status, started_at, asset_count, finding_count) VALUES ($1, $2, $3, $4, 0, 0)`)).
-		WithArgs(sqlmock.AnyArg(), "aws", "running", sqlmock.AnyArg()).
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO scans (id, tenant_id, workspace_id, provider, status, started_at, asset_count, finding_count) VALUES ($1, $2, $3, $4, $5, $6, 0, 0)`)).
+		WithArgs(sqlmock.AnyArg(), "default", "default", "aws", "running", sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	scan, err := store.CreateScan(context.Background(), "aws", time.Now())
@@ -30,8 +30,12 @@ func TestPostgresStoreCreateAndCompleteScan(t *testing.T) {
 		t.Fatalf("create scan failed: %v", err)
 	}
 
-	mock.ExpectExec(regexp.QuoteMeta(`UPDATE scans SET status=$2, finished_at=$3, asset_count=$4, finding_count=$5, error_message=$6 WHERE id=$1`)).
-		WithArgs(scan.ID, "completed", sqlmock.AnyArg(), 2, 1, nil).
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE scans
+		 SET status=$2, finished_at=$3, asset_count=$4, finding_count=$5, error_message=$6
+		 WHERE id=$1
+		   AND tenant_id=$7
+		   AND workspace_id=$8`)).
+		WithArgs(scan.ID, "completed", sqlmock.AnyArg(), 2, 1, nil, "default", "default").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	if err := store.CompleteScan(context.Background(), scan.ID, "completed", time.Now(), 2, 1, ""); err != nil {
@@ -51,6 +55,15 @@ func TestPostgresStoreUpsertFindings(t *testing.T) {
 	defer db.Close()
 
 	store := NewPostgresStoreWithDB(db)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT EXISTS (
+			SELECT 1
+			FROM scans
+			WHERE id = $1
+			  AND tenant_id = $2
+			  AND workspace_id = $3
+		)`)).
+		WithArgs("scan-1", "default", "default").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
 	mock.ExpectBegin()
 	mock.ExpectExec("INSERT INTO findings").
 		WithArgs("scan-1", "f1", "risky_trust_policy", "high", "Risky trust", "summary", sqlmock.AnyArg(), sqlmock.AnyArg(), "fix", sqlmock.AnyArg()).
@@ -88,6 +101,15 @@ func TestPostgresStoreUpsertArtifacts(t *testing.T) {
 	store := NewPostgresStoreWithDB(db)
 	now := time.Now().UTC()
 
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT EXISTS (
+			SELECT 1
+			FROM scans
+			WHERE id = $1
+			  AND tenant_id = $2
+			  AND workspace_id = $3
+		)`)).
+		WithArgs("scan-1", "default", "default").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
 	mock.ExpectBegin()
 	mock.ExpectExec("INSERT INTO raw_assets").WithArgs("scan-1", "arn:aws:iam::1:role/test", "iam_role", sqlmock.AnyArg(), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO identities").WithArgs("scan-1", "aws:identity:arn:aws:iam::1:role/test", "aws", "role", "test", nil, nil, nil, nil, sqlmock.AnyArg(), "raw").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -129,9 +151,9 @@ func TestPostgresStoreListScansAndFindings(t *testing.T) {
 	store := NewPostgresStoreWithDB(db)
 	now := time.Now().UTC()
 
-	scanRows := sqlmock.NewRows([]string{"id", "provider", "status", "started_at", "finished_at", "asset_count", "finding_count", "error_message"}).
-		AddRow("scan-1", "aws", "completed", now, now, 2, 1, "")
-	mock.ExpectQuery("SELECT id, provider, status").WithArgs(20).WillReturnRows(scanRows)
+	scanRows := sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "provider", "status", "started_at", "finished_at", "asset_count", "finding_count", "error_message"}).
+		AddRow("scan-1", "default", "default", "aws", "completed", now, now, 2, 1, "")
+	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, provider, status").WithArgs("default", "default", 20).WillReturnRows(scanRows)
 
 	scans, err := store.ListScans(context.Background(), 20)
 	if err != nil {
@@ -143,7 +165,7 @@ func TestPostgresStoreListScansAndFindings(t *testing.T) {
 
 	findingsRows := sqlmock.NewRows([]string{"scan_id", "finding_id", "type", "severity", "title", "human_summary", "path", "evidence", "remediation", "created_at"}).
 		AddRow("scan-1", "f1", "ownerless_identity", "medium", "Ownerless", "summary", []byte("[\"x\"]"), []byte("{\"a\":1}"), "fix", now)
-	mock.ExpectQuery("SELECT scan_id, finding_id, type").WithArgs(100).WillReturnRows(findingsRows)
+	mock.ExpectQuery("SELECT f.scan_id, f.finding_id, f.type").WithArgs("default", "default", 100).WillReturnRows(findingsRows)
 
 	findings, err := store.ListFindings(context.Background(), 100)
 	if err != nil {
@@ -168,9 +190,9 @@ func TestPostgresStoreGetScanAndFindingsByScan(t *testing.T) {
 	store := NewPostgresStoreWithDB(db)
 	now := time.Now().UTC()
 
-	scanRow := sqlmock.NewRows([]string{"id", "provider", "status", "started_at", "finished_at", "asset_count", "finding_count", "error_message"}).
-		AddRow("scan-1", "aws", "completed", now, now, 2, 1, "")
-	mock.ExpectQuery("SELECT id, provider, status").WithArgs("scan-1").WillReturnRows(scanRow)
+	scanRow := sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "provider", "status", "started_at", "finished_at", "asset_count", "finding_count", "error_message"}).
+		AddRow("scan-1", "default", "default", "aws", "completed", now, now, 2, 1, "")
+	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, provider, status").WithArgs("scan-1", "default", "default").WillReturnRows(scanRow)
 
 	scan, err := store.GetScan(context.Background(), "scan-1")
 	if err != nil {
@@ -182,7 +204,16 @@ func TestPostgresStoreGetScanAndFindingsByScan(t *testing.T) {
 
 	findingsRows := sqlmock.NewRows([]string{"scan_id", "finding_id", "type", "severity", "title", "human_summary", "path", "evidence", "remediation", "created_at"}).
 		AddRow("scan-1", "f1", "ownerless_identity", "medium", "Ownerless", "summary", []byte("[\"x\"]"), []byte("{\"a\":1}"), "fix", now)
-	mock.ExpectQuery("SELECT scan_id, finding_id, type").WithArgs("scan-1", 100).WillReturnRows(findingsRows)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT EXISTS (
+			SELECT 1
+			FROM scans
+			WHERE id = $1
+			  AND tenant_id = $2
+			  AND workspace_id = $3
+		)`)).
+		WithArgs("scan-1", "default", "default").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectQuery("SELECT f.scan_id, f.finding_id, f.type").WithArgs("scan-1", "default", "default", 100).WillReturnRows(findingsRows)
 
 	findings, err := store.ListFindingsByScan(context.Background(), "scan-1", 100)
 	if err != nil {
@@ -206,7 +237,7 @@ func TestPostgresStoreScanEvents(t *testing.T) {
 
 	store := NewPostgresStoreWithDB(db)
 	mock.ExpectExec("INSERT INTO scan_events").
-		WithArgs(sqlmock.AnyArg(), "scan-1", "info", "scan started", sqlmock.AnyArg()).
+		WithArgs(sqlmock.AnyArg(), "scan-1", "info", "scan started", sqlmock.AnyArg(), "default", "default").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	if err := store.AppendScanEvent(context.Background(), "scan-1", "info", "scan started", map[string]any{"provider": "aws"}); err != nil {
@@ -214,9 +245,18 @@ func TestPostgresStoreScanEvents(t *testing.T) {
 	}
 
 	now := time.Now().UTC()
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT EXISTS (
+			SELECT 1
+			FROM scans
+			WHERE id = $1
+			  AND tenant_id = $2
+			  AND workspace_id = $3
+		)`)).
+		WithArgs("scan-1", "default", "default").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
 	rows := sqlmock.NewRows([]string{"id", "scan_id", "level", "message", "metadata", "created_at"}).
 		AddRow("event-1", "scan-1", "info", "scan started", []byte(`{"provider":"aws"}`), now)
-	mock.ExpectQuery("SELECT id, scan_id, level, message, metadata, created_at").WithArgs("scan-1", 10).WillReturnRows(rows)
+	mock.ExpectQuery("SELECT e.id, e.scan_id, e.level, e.message, e.metadata, e.created_at").WithArgs("scan-1", "default", "default", 10).WillReturnRows(rows)
 
 	events, err := store.ListScanEvents(context.Background(), "scan-1", 10)
 	if err != nil {
@@ -256,7 +296,7 @@ func TestPostgresStoreListIdentitiesAndRelationships(t *testing.T) {
 
 	identityRows := sqlmock.NewRows([]string{"id", "provider", "type", "name", "arn", "owner_hint", "created_at", "last_used_at", "tags", "raw_ref"}).
 		AddRow("id-1", "aws", "role", "app-role", "arn:aws:iam::1:role/app-role", "", now, nil, []byte(`{"team":"platform"}`), "raw-1")
-	mock.ExpectQuery("SELECT i.id, i.provider, i.type, i.name").WithArgs("", "aws", "role", "app", 20).WillReturnRows(identityRows)
+	mock.ExpectQuery("SELECT i.id, i.provider, i.type, i.name").WithArgs("", "aws", "role", "app", 20, "default", "default").WillReturnRows(identityRows)
 
 	identities, err := store.ListIdentities(context.Background(), IdentityFilter{
 		Provider:   "aws",
@@ -272,7 +312,7 @@ func TestPostgresStoreListIdentitiesAndRelationships(t *testing.T) {
 
 	relationshipRows := sqlmock.NewRows([]string{"id", "type", "from_node_id", "to_node_id", "evidence_ref", "discovered_at"}).
 		AddRow("rel-1", "can_assume", "id-1", "id-2", "", now)
-	mock.ExpectQuery("SELECT id, type, from_node_id").WithArgs("", "can_assume", "", "", 30).WillReturnRows(relationshipRows)
+	mock.ExpectQuery("SELECT r.id, r.type, r.from_node_id").WithArgs("", "can_assume", "", "", 30, "default", "default").WillReturnRows(relationshipRows)
 
 	relationships, err := store.ListRelationships(context.Background(), RelationshipFilter{Type: "can_assume"}, 30)
 	if err != nil {
@@ -304,9 +344,9 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 	store := NewPostgresStoreWithDB(db)
 	now := time.Now().UTC()
 
-	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit)
-		 VALUES ($1, $2, $3, $4, 0, 0, 0, false, $5, $6)`)).
-		WithArgs(sqlmock.AnyArg(), "owner/repo", "running", sqlmock.AnyArg(), 0, 0).
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit)
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8)`)).
+		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "running", sqlmock.AnyArg(), 0, 0).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	record, err := store.CreateRepoScan(context.Background(), "owner/repo", now)
@@ -314,6 +354,15 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		t.Fatalf("create repo scan failed: %v", err)
 	}
 
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT EXISTS (
+			SELECT 1
+			FROM repo_scans
+			WHERE id = $1
+			  AND tenant_id = $2
+			  AND workspace_id = $3
+		)`)).
+		WithArgs(record.ID, "default", "default").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
 	mock.ExpectBegin()
 	mock.ExpectExec("INSERT INTO repo_findings").
 		WithArgs(record.ID, "rf-1", "secret_exposure", "high", "secret", "summary", sqlmock.AnyArg(), sqlmock.AnyArg(), "fix", sqlmock.AnyArg()).
@@ -342,17 +391,19 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		     finding_count = $6,
 		     truncated = $7,
 		     error_message = $8
-		 WHERE id = $1`)).
-		WithArgs(record.ID, "completed", sqlmock.AnyArg(), 12, 8, 1, false, nil).
+		 WHERE id = $1
+		   AND tenant_id = $9
+		   AND workspace_id = $10`)).
+		WithArgs(record.ID, "completed", sqlmock.AnyArg(), 12, 8, 1, false, nil, "default", "default").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	if err := store.CompleteRepoScan(context.Background(), record.ID, "completed", now, 12, 8, 1, false, ""); err != nil {
 		t.Fatalf("complete repo scan failed: %v", err)
 	}
 
-	repoScanRows := sqlmock.NewRows([]string{"id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "error_message"}).
-		AddRow(record.ID, "owner/repo", "completed", now, now, 12, 8, 1, false, "")
-	mock.ExpectQuery("SELECT id, repository, status").WithArgs(20).WillReturnRows(repoScanRows)
+	repoScanRows := sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "error_message", "history_limit", "max_findings_limit"}).
+		AddRow(record.ID, "default", "default", "owner/repo", "completed", now, now, 12, 8, 1, false, "", 0, 0)
+	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, repository, status").WithArgs("default", "default", 20).WillReturnRows(repoScanRows)
 	repoScans, err := store.ListRepoScans(context.Background(), 20)
 	if err != nil {
 		t.Fatalf("list repo scans failed: %v", err)
@@ -363,7 +414,16 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 
 	repoFindingsRows := sqlmock.NewRows([]string{"repo_scan_id", "finding_id", "type", "severity", "title", "human_summary", "path", "evidence", "remediation", "created_at"}).
 		AddRow(record.ID, "rf-1", "secret_exposure", "high", "secret", "summary", []byte(`["app.env"]`), []byte(`{"k":"v"}`), "fix", now)
-	mock.ExpectQuery("SELECT repo_scan_id, finding_id, type").WithArgs(record.ID, "", "", 100).WillReturnRows(repoFindingsRows)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT EXISTS (
+			SELECT 1
+			FROM repo_scans
+			WHERE id = $1
+			  AND tenant_id = $2
+			  AND workspace_id = $3
+		)`)).
+		WithArgs(record.ID, "default", "default").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectQuery("SELECT rf.repo_scan_id, rf.finding_id, rf.type").WithArgs(record.ID, "", "", 100, "default", "default").WillReturnRows(repoFindingsRows)
 	repoFindings, err := store.ListRepoFindings(context.Background(), RepoFindingFilter{RepoScanID: record.ID}, 100)
 	if err != nil {
 		t.Fatalf("list repo findings failed: %v", err)
@@ -372,9 +432,9 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		t.Fatalf("unexpected repo findings: %+v", repoFindings)
 	}
 
-	repoScanRow := sqlmock.NewRows([]string{"id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "error_message"}).
-		AddRow(record.ID, "owner/repo", "completed", now, now, 12, 8, 1, false, "")
-	mock.ExpectQuery("SELECT id, repository, status").WithArgs(record.ID).WillReturnRows(repoScanRow)
+	repoScanRow := sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "error_message", "history_limit", "max_findings_limit"}).
+		AddRow(record.ID, "default", "default", "owner/repo", "completed", now, now, 12, 8, 1, false, "", 0, 0)
+	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, repository, status").WithArgs(record.ID, "default", "default").WillReturnRows(repoScanRow)
 	gotRepoScan, err := store.GetRepoScan(context.Background(), record.ID)
 	if err != nil {
 		t.Fatalf("get repo scan failed: %v", err)
@@ -398,8 +458,8 @@ func TestPostgresStoreScanQueueLifecycle(t *testing.T) {
 	store := NewPostgresStoreWithDB(db)
 	now := time.Now().UTC()
 
-	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO scans (id, provider, status, started_at, asset_count, finding_count) VALUES ($1, $2, $3, $4, 0, 0)`)).
-		WithArgs(sqlmock.AnyArg(), "aws", "queued", sqlmock.AnyArg()).
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO scans (id, tenant_id, workspace_id, provider, status, started_at, asset_count, finding_count) VALUES ($1, $2, $3, $4, $5, $6, 0, 0)`)).
+		WithArgs(sqlmock.AnyArg(), "default", "default", "aws", "queued", sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	queued, err := store.CreateQueuedScan(context.Background(), "aws", now)
@@ -411,8 +471,13 @@ func TestPostgresStoreScanQueueLifecycle(t *testing.T) {
 	}
 
 	countRows := sqlmock.NewRows([]string{"count"}).AddRow(1)
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*) FROM scans WHERE provider = $1 AND status = 'queued'`)).
-		WithArgs("aws").
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*)
+		 FROM scans
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND provider = $3
+		   AND status = 'queued'`)).
+		WithArgs("default", "default", "aws").
 		WillReturnRows(countRows)
 
 	count, err := store.CountQueuedScans(context.Background(), "aws")
@@ -423,9 +488,9 @@ func TestPostgresStoreScanQueueLifecycle(t *testing.T) {
 		t.Fatalf("expected queued count 1, got %d", count)
 	}
 
-	claimRows := sqlmock.NewRows([]string{"id", "provider", "status", "started_at", "finished_at", "asset_count", "finding_count", "coalesce"}).
-		AddRow(queued.ID, "aws", "running", now, nil, 0, 0, "")
-	mock.ExpectQuery("WITH next_scan AS").WithArgs("aws").WillReturnRows(claimRows)
+	claimRows := sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "provider", "status", "started_at", "finished_at", "asset_count", "finding_count", "coalesce"}).
+		AddRow(queued.ID, "default", "default", "aws", "running", now, nil, 0, 0, "")
+	mock.ExpectQuery("WITH next_scan AS").WithArgs("default", "default", "aws").WillReturnRows(claimRows)
 
 	claimed, err := store.ClaimNextQueuedScan(context.Background(), "aws")
 	if err != nil {
@@ -450,9 +515,9 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 	store := NewPostgresStoreWithDB(db)
 	now := time.Now().UTC()
 
-	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit)
-		 VALUES ($1, $2, $3, $4, 0, 0, 0, false, $5, $6)`)).
-		WithArgs(sqlmock.AnyArg(), "owner/repo", "queued", sqlmock.AnyArg(), 50, 80).
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit)
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8)`)).
+		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "queued", sqlmock.AnyArg(), 50, 80).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	queued, err := store.CreateQueuedRepoScan(context.Background(), "owner/repo", 50, 80, now)
@@ -467,7 +532,12 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 	}
 
 	queuedCountRows := sqlmock.NewRows([]string{"count"}).AddRow(1)
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*) FROM repo_scans WHERE status = 'queued'`)).
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*)
+		 FROM repo_scans
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND status = 'queued'`)).
+		WithArgs("default", "default").
 		WillReturnRows(queuedCountRows)
 
 	queuedCount, err := store.CountQueuedRepoScans(context.Background())
@@ -481,9 +551,11 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 	pendingRows := sqlmock.NewRows([]string{"count"}).AddRow(1)
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*)
 			 FROM repo_scans
-			 WHERE LOWER(repository) = LOWER($1)
+			 WHERE tenant_id = $1
+			   AND workspace_id = $2
+			   AND LOWER(repository) = LOWER($3)
 			   AND status IN ('queued', 'running')`)).
-		WithArgs("OWNER/REPO").
+		WithArgs("default", "default", "OWNER/REPO").
 		WillReturnRows(pendingRows)
 
 	pendingCount, err := store.CountPendingRepoScansByRepository(context.Background(), "OWNER/REPO")
@@ -496,6 +568,8 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 
 	claimRows := sqlmock.NewRows([]string{
 		"id",
+		"tenant_id",
+		"workspace_id",
 		"repository",
 		"status",
 		"started_at",
@@ -507,8 +581,8 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 		"coalesce",
 		"history_limit",
 		"max_findings_limit",
-	}).AddRow(queued.ID, "owner/repo", "running", now, nil, 0, 0, 0, false, "", 50, 80)
-	mock.ExpectQuery("WITH next_repo_scan AS").WillReturnRows(claimRows)
+	}).AddRow(queued.ID, "default", "default", "owner/repo", "running", now, nil, 0, 0, 0, false, "", 50, 80)
+	mock.ExpectQuery("WITH next_repo_scan AS").WithArgs("default", "default").WillReturnRows(claimRows)
 
 	claimed, err := store.ClaimNextQueuedRepoScan(context.Background())
 	if err != nil {
@@ -524,8 +598,10 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 		     finished_at = NULL,
 		     error_message = NULL
 		 WHERE id = $1
+		   AND tenant_id = $2
+		   AND workspace_id = $3
 		   AND status = 'running'`)).
-		WithArgs(claimed.ID).
+		WithArgs(claimed.ID, "default", "default").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	if err := store.RequeueRepoScan(context.Background(), claimed.ID); err != nil {

--- a/internal/db/scope.go
+++ b/internal/db/scope.go
@@ -1,0 +1,81 @@
+package db
+
+import (
+	"context"
+	"strings"
+)
+
+const (
+	// DefaultTenantID applies when no tenant is explicitly provided in context.
+	DefaultTenantID = "default"
+	// DefaultWorkspaceID applies when no workspace is explicitly provided in context.
+	DefaultWorkspaceID = "default"
+)
+
+// Scope represents the active tenant/workspace boundary for a request.
+type Scope struct {
+	TenantID    string
+	WorkspaceID string
+}
+
+type scopeContextKey struct{}
+
+// Normalize returns a canonical, non-empty scope using secure defaults.
+func (s Scope) Normalize() Scope {
+	tenantID := strings.TrimSpace(s.TenantID)
+	if tenantID == "" {
+		tenantID = DefaultTenantID
+	}
+	workspaceID := strings.TrimSpace(s.WorkspaceID)
+	if workspaceID == "" {
+		workspaceID = DefaultWorkspaceID
+	}
+	return Scope{
+		TenantID:    tenantID,
+		WorkspaceID: workspaceID,
+	}
+}
+
+// WithScope stores scope in context.
+func WithScope(ctx context.Context, scope Scope) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, scopeContextKey{}, scope.Normalize())
+}
+
+// LookupScope returns scope from context when present.
+func LookupScope(ctx context.Context) (Scope, bool) {
+	if ctx == nil {
+		return Scope{}, false
+	}
+	raw := ctx.Value(scopeContextKey{})
+	scope, ok := raw.(Scope)
+	if !ok {
+		return Scope{}, false
+	}
+	return scope.Normalize(), true
+}
+
+// ScopeFromContext always returns a non-empty scope.
+func ScopeFromContext(ctx context.Context) Scope {
+	if scope, ok := LookupScope(ctx); ok {
+		return scope
+	}
+	return Scope{}.Normalize()
+}
+
+// WithDefaultScope applies fallback scope only when context has no scope.
+func WithDefaultScope(ctx context.Context, fallback Scope) context.Context {
+	if _, ok := LookupScope(ctx); ok {
+		return ctx
+	}
+	return WithScope(ctx, fallback)
+}
+
+// MatchScope returns true when record scope matches the active scope.
+func MatchScope(scope Scope, tenantID string, workspaceID string) bool {
+	normalized := scope.Normalize()
+	return strings.TrimSpace(tenantID) == normalized.TenantID &&
+		strings.TrimSpace(workspaceID) == normalized.WorkspaceID
+}

--- a/internal/db/scope_test.go
+++ b/internal/db/scope_test.go
@@ -1,0 +1,35 @@
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+func TestScopeFromContextDefaults(t *testing.T) {
+	scope := ScopeFromContext(context.Background())
+	if scope.TenantID != DefaultTenantID || scope.WorkspaceID != DefaultWorkspaceID {
+		t.Fatalf("unexpected default scope: %+v", scope)
+	}
+}
+
+func TestWithDefaultScopeDoesNotOverrideExistingScope(t *testing.T) {
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	ctx = WithDefaultScope(ctx, Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
+	scope := ScopeFromContext(ctx)
+	if scope.TenantID != "tenant-a" || scope.WorkspaceID != "workspace-a" {
+		t.Fatalf("expected existing scope preserved, got %+v", scope)
+	}
+}
+
+func TestMatchScope(t *testing.T) {
+	scope := Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"}
+	if !MatchScope(scope, "tenant-a", "workspace-a") {
+		t.Fatal("expected scope match")
+	}
+	if MatchScope(scope, "tenant-b", "workspace-a") {
+		t.Fatal("expected scope mismatch for tenant")
+	}
+	if MatchScope(scope, "tenant-a", "workspace-b") {
+		t.Fatal("expected scope mismatch for workspace")
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -22,6 +22,8 @@ const (
 // ScanRecord tracks persisted scan execution metadata.
 type ScanRecord struct {
 	ID           string     `json:"id"`
+	TenantID     string     `json:"-"`
+	WorkspaceID  string     `json:"-"`
 	Provider     string     `json:"provider"`
 	Status       string     `json:"status"`
 	StartedAt    time.Time  `json:"started_at"`
@@ -34,6 +36,8 @@ type ScanRecord struct {
 // RepoScanRecord tracks persisted repository exposure scan metadata.
 type RepoScanRecord struct {
 	ID             string     `json:"id"`
+	TenantID       string     `json:"-"`
+	WorkspaceID    string     `json:"-"`
 	Repository     string     `json:"repository"`
 	Status         string     `json:"status"`
 	StartedAt      time.Time  `json:"started_at"`

--- a/internal/runtime/service_builder.go
+++ b/internal/runtime/service_builder.go
@@ -97,6 +97,10 @@ func BuildScanService(cfg config.Config) (*api.Service, func() error, error) {
 	}
 
 	svc := api.NewService(store, scanner, cfg.Provider)
+	svc.DefaultScope = db.Scope{
+		TenantID:    cfg.DefaultTenantID,
+		WorkspaceID: cfg.DefaultWorkspaceID,
+	}.Normalize()
 	svc.LockNamespace = strings.TrimSpace(cfg.LockNamespace)
 	lockBackend := strings.ToLower(strings.TrimSpace(cfg.LockBackend))
 	switch lockBackend {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -114,6 +114,8 @@ func NewBootstrap(ctx context.Context, cfg config.Config) (Bootstrap, error) {
 		AuditSink:          auditSink,
 		TrustedProxies:     cfg.TrustedProxies,
 		CORSAllowedOrigins: cfg.CORSAllowedOrigins,
+		DefaultTenantID:    cfg.DefaultTenantID,
+		DefaultWorkspaceID: cfg.DefaultWorkspaceID,
 	})
 	return Bootstrap{
 		Logger:        logger,

--- a/migrations/000006_tenant_workspace_scope.down.sql
+++ b/migrations/000006_tenant_workspace_scope.down.sql
@@ -1,0 +1,17 @@
+DROP INDEX IF EXISTS idx_repo_scans_scope_repository_status_started_at;
+DROP INDEX IF EXISTS idx_repo_scans_scope_status_started_at;
+DROP INDEX IF EXISTS idx_repo_scans_scope_started_at;
+DROP INDEX IF EXISTS idx_scans_scope_provider_status_started_at;
+DROP INDEX IF EXISTS idx_scans_scope_started_at;
+
+ALTER TABLE repo_scans
+    DROP COLUMN IF EXISTS workspace_id;
+
+ALTER TABLE repo_scans
+    DROP COLUMN IF EXISTS tenant_id;
+
+ALTER TABLE scans
+    DROP COLUMN IF EXISTS workspace_id;
+
+ALTER TABLE scans
+    DROP COLUMN IF EXISTS tenant_id;

--- a/migrations/000006_tenant_workspace_scope.up.sql
+++ b/migrations/000006_tenant_workspace_scope.up.sql
@@ -1,0 +1,42 @@
+ALTER TABLE scans
+    ADD COLUMN IF NOT EXISTS tenant_id TEXT NOT NULL DEFAULT 'default';
+
+ALTER TABLE scans
+    ADD COLUMN IF NOT EXISTS workspace_id TEXT NOT NULL DEFAULT 'default';
+
+ALTER TABLE repo_scans
+    ADD COLUMN IF NOT EXISTS tenant_id TEXT NOT NULL DEFAULT 'default';
+
+ALTER TABLE repo_scans
+    ADD COLUMN IF NOT EXISTS workspace_id TEXT NOT NULL DEFAULT 'default';
+
+UPDATE scans
+SET tenant_id = 'default'
+WHERE COALESCE(TRIM(tenant_id), '') = '';
+
+UPDATE scans
+SET workspace_id = 'default'
+WHERE COALESCE(TRIM(workspace_id), '') = '';
+
+UPDATE repo_scans
+SET tenant_id = 'default'
+WHERE COALESCE(TRIM(tenant_id), '') = '';
+
+UPDATE repo_scans
+SET workspace_id = 'default'
+WHERE COALESCE(TRIM(workspace_id), '') = '';
+
+CREATE INDEX IF NOT EXISTS idx_scans_scope_started_at
+    ON scans (tenant_id, workspace_id, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_scans_scope_provider_status_started_at
+    ON scans (tenant_id, workspace_id, provider, status, started_at ASC);
+
+CREATE INDEX IF NOT EXISTS idx_repo_scans_scope_started_at
+    ON repo_scans (tenant_id, workspace_id, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_repo_scans_scope_status_started_at
+    ON repo_scans (tenant_id, workspace_id, status, started_at ASC);
+
+CREATE INDEX IF NOT EXISTS idx_repo_scans_scope_repository_status_started_at
+    ON repo_scans (tenant_id, workspace_id, repository, status, started_at ASC);


### PR DESCRIPTION
## Summary
- add tenant/workspace scope context + default config wiring
- enforce scope in API request context and Memory/Postgres store queries/writes
- add migration `000006_tenant_workspace_scope` and tests

## Validation
- `go test ./... -count=1`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tenant/workspace scoping across the API and storage to enable safe multi-tenant isolation by default. All reads/writes are now enforced within a tenant/workspace scope, with sensible defaults.

- **New Features**
  - Request scope middleware reads `X-Identrail-Tenant-ID` and `X-Identrail-Workspace-ID`; falls back to configured defaults.
  - Added `IDENTRAIL_DEFAULT_TENANT_ID` and `IDENTRAIL_DEFAULT_WORKSPACE_ID` (default: `default`) with validation of allowed characters/length.
  - CORS now allows `PATCH` and headers `X-Identrail-Tenant-ID`, `X-Identrail-Workspace-ID`.
  - `Service` ensures store calls run with a default scope; router injects scope into request context.
  - Memory and Postgres stores enforce scope on all queries and writes; new helpers for scope context and matching.
  - Queries coalesce NULL remediation fields to empty strings to avoid decode errors.
  - New tests for scope isolation and migration contents.

- **Migration**
  - Apply migration `000006_tenant_workspace_scope` to add `tenant_id` and `workspace_id` to `scans` and `repo_scans` with supporting indexes.
  - Set `IDENTRAIL_DEFAULT_TENANT_ID` and `IDENTRAIL_DEFAULT_WORKSPACE_ID` if you need non-default values.
  - Update clients to send `X-Identrail-Tenant-ID` and `X-Identrail-Workspace-ID` to target non-default scopes.

<sup>Written for commit 2da4b665e86ccf5f56eb901e5d97d286d24dd95b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

