### PR TITLE
Add DB scope guardrails for tenant/workspace isolation

### DIFF
--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -299,7 +299,7 @@ func TestRouterRunsScanAndListsData(t *testing.T) {
 		t.Fatal("expected second scan id in post response")
 	}
 	for i := 0; i < 2; i++ {
-		processed, err := svc.ProcessNextQueuedScan(context.Background())
+		processed, err := svc.ProcessNextQueuedScan(defaultScopeContext())
 		if err != nil {
 			t.Fatalf("process queued scan: %v", err)
 		}
@@ -438,7 +438,7 @@ func TestRouterRunsScanAndListsData(t *testing.T) {
 	if repoW.Code != http.StatusAccepted {
 		t.Fatalf("expected repo scan 202, got %d", repoW.Code)
 	}
-	processedRepo, processRepoErr := svc.ProcessNextQueuedRepoScan(context.Background())
+	processedRepo, processRepoErr := svc.ProcessNextQueuedRepoScan(defaultScopeContext())
 	if processRepoErr != nil {
 		t.Fatalf("process queued repo scan: %v", processRepoErr)
 	}
@@ -696,11 +696,11 @@ func TestRouterSupportsFindingsSortParameters(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 20, 9, 0, 0, 0, time.UTC)
 
-	scan, err := store.CreateScan(context.Background(), "aws", now)
+	scan, err := store.CreateScan(defaultScopeContext(), "aws", now)
 	if err != nil {
 		t.Fatalf("create scan: %v", err)
 	}
-	if err := store.UpsertFindings(context.Background(), scan.ID, []domain.Finding{
+	if err := store.UpsertFindings(defaultScopeContext(), scan.ID, []domain.Finding{
 		{ID: "f-critical", Severity: domain.SeverityCritical, Type: domain.FindingEscalationPath, Title: "critical", CreatedAt: now},
 		{ID: "f-info", Severity: domain.SeverityInfo, Type: domain.FindingOwnerless, Title: "info", CreatedAt: now},
 		{ID: "f-high", Severity: domain.SeverityHigh, Type: domain.FindingRiskyTrustPolicy, Title: "high", CreatedAt: now},
@@ -737,18 +737,18 @@ func TestRouterSupportsScansSortParameters(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 20, 9, 0, 0, 0, time.UTC)
 
-	scanA, err := store.CreateScan(context.Background(), "aws", now)
+	scanA, err := store.CreateScan(defaultScopeContext(), "aws", now)
 	if err != nil {
 		t.Fatalf("create scan A: %v", err)
 	}
-	scanB, err := store.CreateScan(context.Background(), "aws", now.Add(1*time.Minute))
+	scanB, err := store.CreateScan(defaultScopeContext(), "aws", now.Add(1*time.Minute))
 	if err != nil {
 		t.Fatalf("create scan B: %v", err)
 	}
-	if err := store.CompleteScan(context.Background(), scanA.ID, "completed", now.Add(2*time.Minute), 2, 7, ""); err != nil {
+	if err := store.CompleteScan(defaultScopeContext(), scanA.ID, "completed", now.Add(2*time.Minute), 2, 7, ""); err != nil {
 		t.Fatalf("complete scan A: %v", err)
 	}
-	if err := store.CompleteScan(context.Background(), scanB.ID, "completed", now.Add(3*time.Minute), 2, 1, ""); err != nil {
+	if err := store.CompleteScan(defaultScopeContext(), scanB.ID, "completed", now.Add(3*time.Minute), 2, 1, ""); err != nil {
 		t.Fatalf("complete scan B: %v", err)
 	}
 
@@ -1016,7 +1016,7 @@ func TestRouterFindingTriageWorkflowEndpoints(t *testing.T) {
 	if triggerBody.Scan.ID == "" {
 		t.Fatal("expected scan id in trigger response")
 	}
-	processed, err := svc.ProcessNextQueuedScan(context.Background())
+	processed, err := svc.ProcessNextQueuedScan(defaultScopeContext())
 	if err != nil {
 		t.Fatalf("process queued scan: %v", err)
 	}
@@ -1472,7 +1472,7 @@ func TestRouterScanDiffAndEventsNotFound(t *testing.T) {
 		t.Fatalf("expected finding-by-id 404 for missing finding, got %d", findingW.Code)
 	}
 
-	scan, err := store.CreateScan(context.Background(), "aws", time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC))
+	scan, err := store.CreateScan(defaultScopeContext(), "aws", time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("create scan: %v", err)
 	}

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -69,7 +69,7 @@ func TestServiceRunScanSuccess(t *testing.T) {
 	}}, "aws")
 	svc.Now = func() time.Time { return now }
 
-	result, err := svc.RunScan(context.Background())
+	result, err := svc.RunScan(defaultScopeContext())
 	if err != nil {
 		t.Fatalf("run scan failed: %v", err)
 	}
@@ -85,12 +85,12 @@ func TestServiceRunScanFailure(t *testing.T) {
 	svc := NewService(store, fakeScanner{err: errors.New("scanner failed")}, "aws")
 	svc.Now = func() time.Time { return now }
 
-	_, err := svc.RunScan(context.Background())
+	_, err := svc.RunScan(defaultScopeContext())
 	if err == nil {
 		t.Fatal("expected error")
 	}
 
-	scans, listErr := store.ListScans(context.Background(), 1)
+	scans, listErr := store.ListScans(defaultScopeContext(), 1)
 	if listErr != nil {
 		t.Fatalf("list scans failed: %v", listErr)
 	}
@@ -111,7 +111,7 @@ func TestServiceRunScanLocked(t *testing.T) {
 	svc := NewService(store, fakeScanner{}, "aws")
 	svc.Locker = locker
 
-	_, err := svc.RunScan(context.Background())
+	_, err := svc.RunScan(defaultScopeContext())
 	if !errors.Is(err, ErrScanInProgress) {
 		t.Fatalf("expected ErrScanInProgress, got %v", err)
 	}
@@ -128,7 +128,7 @@ func TestServiceRunScanAlertHookCalled(t *testing.T) {
 	svc.Now = func() time.Time { return now }
 	svc.Alerter = alerter
 
-	if _, err := svc.RunScan(context.Background()); err != nil {
+	if _, err := svc.RunScan(defaultScopeContext()); err != nil {
 		t.Fatalf("run scan: %v", err)
 	}
 	if alerter.calls != 1 {
@@ -154,7 +154,7 @@ func TestServiceRunScanAlertFailureIsNonBlocking(t *testing.T) {
 		}
 	}
 
-	result, err := svc.RunScan(context.Background())
+	result, err := svc.RunScan(defaultScopeContext())
 	if err != nil {
 		t.Fatalf("expected scan success despite alert error, got %v", err)
 	}
@@ -169,11 +169,11 @@ func TestServiceRunScanAlertFailureIsNonBlocking(t *testing.T) {
 func TestServiceGetFindingsSummary(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
-	scan, err := store.CreateScan(context.Background(), "aws", now)
+	scan, err := store.CreateScan(defaultScopeContext(), "aws", now)
 	if err != nil {
 		t.Fatalf("create scan: %v", err)
 	}
-	if err := store.UpsertFindings(context.Background(), scan.ID, []domain.Finding{
+	if err := store.UpsertFindings(defaultScopeContext(), scan.ID, []domain.Finding{
 		{ID: "f1", Type: domain.FindingOwnerless, Severity: domain.SeverityHigh, CreatedAt: now},
 		{ID: "f2", Type: domain.FindingOwnerless, Severity: domain.SeverityMedium, CreatedAt: now},
 		{ID: "f3", Type: domain.FindingStaleIdentity, Severity: domain.SeverityHigh, CreatedAt: now},
@@ -182,7 +182,7 @@ func TestServiceGetFindingsSummary(t *testing.T) {
 	}
 
 	svc := NewService(store, fakeScanner{}, "aws")
-	summary, err := svc.GetFindingsSummary(context.Background(), 100)
+	summary, err := svc.GetFindingsSummary(defaultScopeContext(), 100)
 	if err != nil {
 		t.Fatalf("get summary: %v", err)
 	}
@@ -200,19 +200,19 @@ func TestServiceGetFindingsSummary(t *testing.T) {
 func TestServiceListFindingsFiltered(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
-	scanA, _ := store.CreateScan(context.Background(), "aws", now)
-	scanB, _ := store.CreateScan(context.Background(), "aws", now.Add(1*time.Minute))
-	_ = store.UpsertFindings(context.Background(), scanA.ID, []domain.Finding{
+	scanA, _ := store.CreateScan(defaultScopeContext(), "aws", now)
+	scanB, _ := store.CreateScan(defaultScopeContext(), "aws", now.Add(1*time.Minute))
+	_ = store.UpsertFindings(defaultScopeContext(), scanA.ID, []domain.Finding{
 		{ID: "f1", Type: domain.FindingOwnerless, Severity: domain.SeverityHigh, CreatedAt: now},
 	})
-	_ = store.UpsertFindings(context.Background(), scanB.ID, []domain.Finding{
+	_ = store.UpsertFindings(defaultScopeContext(), scanB.ID, []domain.Finding{
 		{ID: "f2", Type: domain.FindingEscalationPath, Severity: domain.SeverityCritical, CreatedAt: now.Add(1 * time.Minute)},
 		{ID: "f3", Type: domain.FindingOwnerless, Severity: domain.SeverityLow, CreatedAt: now.Add(1 * time.Minute)},
 	})
 
 	svc := NewService(store, fakeScanner{}, "aws")
 
-	highOnly, err := svc.ListFindingsFiltered(context.Background(), 10, FindingsFilter{Severity: "critical"})
+	highOnly, err := svc.ListFindingsFiltered(defaultScopeContext(), 10, FindingsFilter{Severity: "critical"})
 	if err != nil {
 		t.Fatalf("list findings filtered by severity: %v", err)
 	}
@@ -220,7 +220,7 @@ func TestServiceListFindingsFiltered(t *testing.T) {
 		t.Fatalf("unexpected critical findings: %+v", highOnly)
 	}
 
-	scanOnly, err := svc.ListFindingsFiltered(context.Background(), 10, FindingsFilter{ScanID: scanA.ID, Type: "ownerless_identity"})
+	scanOnly, err := svc.ListFindingsFiltered(defaultScopeContext(), 10, FindingsFilter{ScanID: scanA.ID, Type: "ownerless_identity"})
 	if err != nil {
 		t.Fatalf("list findings filtered by scan/type: %v", err)
 	}
@@ -232,13 +232,13 @@ func TestServiceListFindingsFiltered(t *testing.T) {
 func TestServiceGetFinding(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
-	scan, _ := store.CreateScan(context.Background(), "aws", now)
-	_ = store.UpsertFindings(context.Background(), scan.ID, []domain.Finding{
+	scan, _ := store.CreateScan(defaultScopeContext(), "aws", now)
+	_ = store.UpsertFindings(defaultScopeContext(), scan.ID, []domain.Finding{
 		{ID: "finding-1", Type: domain.FindingOwnerless, Severity: domain.SeverityHigh, CreatedAt: now},
 	})
 
 	svc := NewService(store, fakeScanner{}, "aws")
-	found, err := svc.GetFinding(context.Background(), "finding-1", scan.ID)
+	found, err := svc.GetFinding(defaultScopeContext(), "finding-1", scan.ID)
 	if err != nil {
 		t.Fatalf("get finding: %v", err)
 	}
@@ -246,7 +246,7 @@ func TestServiceGetFinding(t *testing.T) {
 		t.Fatalf("unexpected finding id: %q", found.ID)
 	}
 
-	if _, err := svc.GetFinding(context.Background(), "missing", scan.ID); !errors.Is(err, db.ErrNotFound) {
+	if _, err := svc.GetFinding(defaultScopeContext(), "missing", scan.ID); !errors.Is(err, db.ErrNotFound) {
 		t.Fatalf("expected not found for missing finding, got %v", err)
 	}
 }
@@ -254,11 +254,11 @@ func TestServiceGetFinding(t *testing.T) {
 func TestServiceFindingTriageLifecycleAndHistory(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 22, 9, 0, 0, 0, time.UTC)
-	scan, err := store.CreateScan(context.Background(), "aws", now)
+	scan, err := store.CreateScan(defaultScopeContext(), "aws", now)
 	if err != nil {
 		t.Fatalf("create scan: %v", err)
 	}
-	if err := store.UpsertFindings(context.Background(), scan.ID, []domain.Finding{
+	if err := store.UpsertFindings(defaultScopeContext(), scan.ID, []domain.Finding{
 		{ID: "finding-1", Type: domain.FindingOwnerless, Severity: domain.SeverityHigh, CreatedAt: now},
 	}); err != nil {
 		t.Fatalf("upsert findings: %v", err)
@@ -268,7 +268,7 @@ func TestServiceFindingTriageLifecycleAndHistory(t *testing.T) {
 	svc := NewService(store, fakeScanner{}, "aws")
 	svc.Now = func() time.Time { return clock }
 
-	initial, err := svc.GetFinding(context.Background(), "finding-1", scan.ID)
+	initial, err := svc.GetFinding(defaultScopeContext(), "finding-1", scan.ID)
 	if err != nil {
 		t.Fatalf("get initial finding: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestServiceFindingTriageLifecycleAndHistory(t *testing.T) {
 	assignee := "secops"
 	suppressionExpiry := clock.Add(2 * time.Hour).Format(time.RFC3339)
 	updated, err := svc.TriageFinding(
-		context.Background(),
+		defaultScopeContext(),
 		"finding-1",
 		scan.ID,
 		FindingTriageRequest{
@@ -307,7 +307,7 @@ func TestServiceFindingTriageLifecycleAndHistory(t *testing.T) {
 		t.Fatalf("expected triage actor to be persisted, got %q", updated.Triage.UpdatedBy)
 	}
 
-	history, err := svc.ListFindingTriageHistory(context.Background(), "finding-1", scan.ID, 10)
+	history, err := svc.ListFindingTriageHistory(defaultScopeContext(), "finding-1", scan.ID, 10)
 	if err != nil {
 		t.Fatalf("list triage history: %v", err)
 	}
@@ -321,7 +321,7 @@ func TestServiceFindingTriageLifecycleAndHistory(t *testing.T) {
 		t.Fatalf("unexpected status transition: %+v", history[0])
 	}
 
-	suppressedItems, err := svc.ListFindingsFiltered(context.Background(), 10, FindingsFilter{
+	suppressedItems, err := svc.ListFindingsFiltered(defaultScopeContext(), 10, FindingsFilter{
 		LifecycleStatus: "suppressed",
 		Assignee:        "SECOPS",
 	})
@@ -333,7 +333,7 @@ func TestServiceFindingTriageLifecycleAndHistory(t *testing.T) {
 	}
 
 	clock = clock.Add(3 * time.Hour)
-	reopened, err := svc.GetFinding(context.Background(), "finding-1", scan.ID)
+	reopened, err := svc.GetFinding(defaultScopeContext(), "finding-1", scan.ID)
 	if err != nil {
 		t.Fatalf("get finding after suppression expiry: %v", err)
 	}
@@ -348,11 +348,11 @@ func TestServiceFindingTriageLifecycleAndHistory(t *testing.T) {
 func TestServiceTriageFindingRejectsInvalidRequest(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 22, 9, 0, 0, 0, time.UTC)
-	scan, err := store.CreateScan(context.Background(), "aws", now)
+	scan, err := store.CreateScan(defaultScopeContext(), "aws", now)
 	if err != nil {
 		t.Fatalf("create scan: %v", err)
 	}
-	if err := store.UpsertFindings(context.Background(), scan.ID, []domain.Finding{
+	if err := store.UpsertFindings(defaultScopeContext(), scan.ID, []domain.Finding{
 		{ID: "finding-1", Type: domain.FindingOwnerless, Severity: domain.SeverityHigh, CreatedAt: now},
 	}); err != nil {
 		t.Fatalf("upsert findings: %v", err)
@@ -361,14 +361,14 @@ func TestServiceTriageFindingRejectsInvalidRequest(t *testing.T) {
 	svc := NewService(store, fakeScanner{}, "aws")
 	svc.Now = func() time.Time { return now }
 
-	if _, err := svc.TriageFinding(context.Background(), "finding-1", scan.ID, FindingTriageRequest{}, "subject:user-1"); !errors.Is(err, ErrInvalidFindingTriageRequest) {
+	if _, err := svc.TriageFinding(defaultScopeContext(), "finding-1", scan.ID, FindingTriageRequest{}, "subject:user-1"); !errors.Is(err, ErrInvalidFindingTriageRequest) {
 		t.Fatalf("expected invalid triage request error for empty payload, got %v", err)
 	}
 
 	suppressed := string(domain.FindingLifecycleSuppressed)
 	pastExpiry := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	if _, err := svc.TriageFinding(
-		context.Background(),
+		defaultScopeContext(),
 		"finding-1",
 		scan.ID,
 		FindingTriageRequest{
@@ -384,8 +384,8 @@ func TestServiceTriageFindingRejectsInvalidRequest(t *testing.T) {
 func TestServiceGetFindingExports(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
-	scan, _ := store.CreateScan(context.Background(), "aws", now)
-	_ = store.UpsertFindings(context.Background(), scan.ID, []domain.Finding{
+	scan, _ := store.CreateScan(defaultScopeContext(), "aws", now)
+	_ = store.UpsertFindings(defaultScopeContext(), scan.ID, []domain.Finding{
 		{
 			ID:        "finding-1",
 			Type:      domain.FindingOverPrivileged,
@@ -396,7 +396,7 @@ func TestServiceGetFindingExports(t *testing.T) {
 	})
 
 	svc := NewService(store, fakeScanner{}, "aws")
-	exports, err := svc.GetFindingExports(context.Background(), "finding-1", scan.ID)
+	exports, err := svc.GetFindingExports(defaultScopeContext(), "finding-1", scan.ID)
 	if err != nil {
 		t.Fatalf("get finding exports: %v", err)
 	}
@@ -416,22 +416,22 @@ func TestServiceGetScanDiff(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
 
-	first, err := store.CreateScan(context.Background(), "aws", now)
+	first, err := store.CreateScan(defaultScopeContext(), "aws", now)
 	if err != nil {
 		t.Fatalf("create first scan: %v", err)
 	}
-	if err := store.UpsertFindings(context.Background(), first.ID, []domain.Finding{
+	if err := store.UpsertFindings(defaultScopeContext(), first.ID, []domain.Finding{
 		{ID: "persist", Type: domain.FindingOwnerless, Severity: domain.SeverityHigh, CreatedAt: now.Add(1 * time.Second)},
 		{ID: "resolved", Type: domain.FindingStaleIdentity, Severity: domain.SeverityMedium, CreatedAt: now.Add(2 * time.Second)},
 	}); err != nil {
 		t.Fatalf("seed first findings: %v", err)
 	}
 
-	second, err := store.CreateScan(context.Background(), "aws", now.Add(10*time.Minute))
+	second, err := store.CreateScan(defaultScopeContext(), "aws", now.Add(10*time.Minute))
 	if err != nil {
 		t.Fatalf("create second scan: %v", err)
 	}
-	if err := store.UpsertFindings(context.Background(), second.ID, []domain.Finding{
+	if err := store.UpsertFindings(defaultScopeContext(), second.ID, []domain.Finding{
 		{ID: "persist", Type: domain.FindingOwnerless, Severity: domain.SeverityHigh, CreatedAt: now.Add(11 * time.Minute)},
 		{ID: "added", Type: domain.FindingEscalationPath, Severity: domain.SeverityCritical, CreatedAt: now.Add(12 * time.Minute)},
 	}); err != nil {
@@ -439,7 +439,7 @@ func TestServiceGetScanDiff(t *testing.T) {
 	}
 
 	svc := NewService(store, fakeScanner{}, "aws")
-	diff, err := svc.GetScanDiff(context.Background(), second.ID, 10)
+	diff, err := svc.GetScanDiff(defaultScopeContext(), second.ID, 10)
 	if err != nil {
 		t.Fatalf("get scan diff: %v", err)
 	}
@@ -455,19 +455,19 @@ func TestServiceGetScanDiffAgainst(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
 
-	first, _ := store.CreateScan(context.Background(), "aws", now)
-	_ = store.UpsertFindings(context.Background(), first.ID, []domain.Finding{
+	first, _ := store.CreateScan(defaultScopeContext(), "aws", now)
+	_ = store.UpsertFindings(defaultScopeContext(), first.ID, []domain.Finding{
 		{ID: "persist", Severity: domain.SeverityHigh, CreatedAt: now.Add(1 * time.Second)},
 		{ID: "resolved", Severity: domain.SeverityMedium, CreatedAt: now.Add(2 * time.Second)},
 	})
-	second, _ := store.CreateScan(context.Background(), "aws", now.Add(5*time.Minute))
-	_ = store.UpsertFindings(context.Background(), second.ID, []domain.Finding{
+	second, _ := store.CreateScan(defaultScopeContext(), "aws", now.Add(5*time.Minute))
+	_ = store.UpsertFindings(defaultScopeContext(), second.ID, []domain.Finding{
 		{ID: "persist", Severity: domain.SeverityHigh, CreatedAt: now.Add(5 * time.Minute)},
 		{ID: "added", Severity: domain.SeverityCritical, CreatedAt: now.Add(6 * time.Minute)},
 	})
 
 	svc := NewService(store, fakeScanner{}, "aws")
-	diff, err := svc.GetScanDiffAgainst(context.Background(), second.ID, first.ID, 10)
+	diff, err := svc.GetScanDiffAgainst(defaultScopeContext(), second.ID, first.ID, 10)
 	if err != nil {
 		t.Fatalf("get scan diff against baseline: %v", err)
 	}
@@ -480,23 +480,23 @@ func TestServiceGetScanDiffAgainstRejectsInvalidBaseline(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
 
-	current, _ := store.CreateScan(context.Background(), "aws", now)
-	previous, _ := store.CreateScan(context.Background(), "aws", now.Add(-5*time.Minute))
-	wrongProvider, _ := store.CreateScan(context.Background(), "azure", now.Add(-10*time.Minute))
-	newerBaseline, _ := store.CreateScan(context.Background(), "aws", now.Add(10*time.Minute))
+	current, _ := store.CreateScan(defaultScopeContext(), "aws", now)
+	previous, _ := store.CreateScan(defaultScopeContext(), "aws", now.Add(-5*time.Minute))
+	wrongProvider, _ := store.CreateScan(defaultScopeContext(), "azure", now.Add(-10*time.Minute))
+	newerBaseline, _ := store.CreateScan(defaultScopeContext(), "aws", now.Add(10*time.Minute))
 
 	svc := NewService(store, fakeScanner{}, "aws")
 
-	if _, err := svc.GetScanDiffAgainst(context.Background(), current.ID, current.ID, 10); !errors.Is(err, ErrInvalidScanDiffBaseline) {
+	if _, err := svc.GetScanDiffAgainst(defaultScopeContext(), current.ID, current.ID, 10); !errors.Is(err, ErrInvalidScanDiffBaseline) {
 		t.Fatalf("expected invalid baseline when baseline==current, got %v", err)
 	}
-	if _, err := svc.GetScanDiffAgainst(context.Background(), current.ID, wrongProvider.ID, 10); !errors.Is(err, ErrInvalidScanDiffBaseline) {
+	if _, err := svc.GetScanDiffAgainst(defaultScopeContext(), current.ID, wrongProvider.ID, 10); !errors.Is(err, ErrInvalidScanDiffBaseline) {
 		t.Fatalf("expected invalid baseline provider error, got %v", err)
 	}
-	if _, err := svc.GetScanDiffAgainst(context.Background(), current.ID, newerBaseline.ID, 10); !errors.Is(err, ErrInvalidScanDiffBaseline) {
+	if _, err := svc.GetScanDiffAgainst(defaultScopeContext(), current.ID, newerBaseline.ID, 10); !errors.Is(err, ErrInvalidScanDiffBaseline) {
 		t.Fatalf("expected invalid baseline time ordering error, got %v", err)
 	}
-	if _, err := svc.GetScanDiffAgainst(context.Background(), current.ID, previous.ID, 10); err != nil {
+	if _, err := svc.GetScanDiffAgainst(defaultScopeContext(), current.ID, previous.ID, 10); err != nil {
 		t.Fatalf("expected valid older baseline, got %v", err)
 	}
 }
@@ -506,11 +506,11 @@ func TestServiceListScanEvents(t *testing.T) {
 	svc := NewService(store, fakeScanner{result: app.ScanResult{}}, "aws")
 	svc.Now = func() time.Time { return time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC) }
 
-	result, err := svc.RunScan(context.Background())
+	result, err := svc.RunScan(defaultScopeContext())
 	if err != nil {
 		t.Fatalf("run scan: %v", err)
 	}
-	events, err := svc.ListScanEvents(context.Background(), result.Scan.ID, 10)
+	events, err := svc.ListScanEvents(defaultScopeContext(), result.Scan.ID, 10)
 	if err != nil {
 		t.Fatalf("list scan events: %v", err)
 	}
@@ -518,10 +518,10 @@ func TestServiceListScanEvents(t *testing.T) {
 		t.Fatal("expected scan events")
 	}
 
-	if err := store.AppendScanEvent(context.Background(), result.Scan.ID, db.ScanEventLevelError, "forced error", nil); err != nil {
+	if err := store.AppendScanEvent(defaultScopeContext(), result.Scan.ID, db.ScanEventLevelError, "forced error", nil); err != nil {
 		t.Fatalf("append error event: %v", err)
 	}
-	errorEvents, err := svc.ListScanEventsFiltered(context.Background(), result.Scan.ID, db.ScanEventLevelError, 20)
+	errorEvents, err := svc.ListScanEventsFiltered(defaultScopeContext(), result.Scan.ID, db.ScanEventLevelError, 20)
 	if err != nil {
 		t.Fatalf("list filtered scan events: %v", err)
 	}
@@ -551,7 +551,7 @@ func TestServiceRunScanPartialLifecycleEvents(t *testing.T) {
 	}}, "aws")
 	svc.Now = func() time.Time { return now }
 
-	result, err := svc.RunScan(context.Background())
+	result, err := svc.RunScan(defaultScopeContext())
 	if err != nil {
 		t.Fatalf("run scan: %v", err)
 	}
@@ -559,7 +559,7 @@ func TestServiceRunScanPartialLifecycleEvents(t *testing.T) {
 		t.Fatalf("expected completed scan status, got %q", result.Scan.Status)
 	}
 
-	events, err := svc.ListScanEvents(context.Background(), result.Scan.ID, 50)
+	events, err := svc.ListScanEvents(defaultScopeContext(), result.Scan.ID, 50)
 	if err != nil {
 		t.Fatalf("list scan events: %v", err)
 	}
@@ -652,7 +652,7 @@ func TestServiceRunScanPersistsRawAndNormalizedArtifactsConsistently(t *testing.
 	}}, "aws")
 	svc.Now = func() time.Time { return now }
 
-	result, err := svc.RunScan(context.Background())
+	result, err := svc.RunScan(defaultScopeContext())
 	if err != nil {
 		t.Fatalf("run scan: %v", err)
 	}
@@ -660,7 +660,7 @@ func TestServiceRunScanPersistsRawAndNormalizedArtifactsConsistently(t *testing.
 		t.Fatalf("unexpected run result: %+v", result)
 	}
 
-	identities, err := svc.ListIdentities(context.Background(), result.Scan.ID, "aws", "role", "", 10)
+	identities, err := svc.ListIdentities(defaultScopeContext(), result.Scan.ID, "aws", "role", "", 10)
 	if err != nil {
 		t.Fatalf("list identities: %v", err)
 	}
@@ -668,7 +668,7 @@ func TestServiceRunScanPersistsRawAndNormalizedArtifactsConsistently(t *testing.
 		t.Fatalf("unexpected identities: %+v", identities)
 	}
 
-	relationships, err := svc.ListRelationships(context.Background(), result.Scan.ID, string(domain.RelationshipAttachedPolicy), "", "", 10)
+	relationships, err := svc.ListRelationships(defaultScopeContext(), result.Scan.ID, string(domain.RelationshipAttachedPolicy), "", "", 10)
 	if err != nil {
 		t.Fatalf("list relationships: %v", err)
 	}
@@ -676,7 +676,7 @@ func TestServiceRunScanPersistsRawAndNormalizedArtifactsConsistently(t *testing.
 		t.Fatalf("unexpected relationships: %+v", relationships)
 	}
 
-	findings, err := svc.ListFindingsFiltered(context.Background(), 10, FindingsFilter{ScanID: result.Scan.ID})
+	findings, err := svc.ListFindingsFiltered(defaultScopeContext(), 10, FindingsFilter{ScanID: result.Scan.ID})
 	if err != nil {
 		t.Fatalf("list findings filtered: %v", err)
 	}
@@ -689,11 +689,11 @@ func TestServiceListIdentitiesAndRelationshipsDefaultsToLatestScan(t *testing.T)
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
 
-	scanA, err := store.CreateScan(context.Background(), "aws", now)
+	scanA, err := store.CreateScan(defaultScopeContext(), "aws", now)
 	if err != nil {
 		t.Fatalf("create scan A: %v", err)
 	}
-	if err := store.UpsertArtifacts(context.Background(), scanA.ID, db.ScanArtifacts{
+	if err := store.UpsertArtifacts(defaultScopeContext(), scanA.ID, db.ScanArtifacts{
 		Bundle: providers.NormalizedBundle{
 			Identities: []domain.Identity{{ID: "id-1", Provider: domain.ProviderAWS, Type: domain.IdentityTypeRole, Name: "app-a", RawRef: "raw-a"}},
 		},
@@ -702,11 +702,11 @@ func TestServiceListIdentitiesAndRelationshipsDefaultsToLatestScan(t *testing.T)
 		t.Fatalf("seed artifacts A: %v", err)
 	}
 
-	scanB, err := store.CreateScan(context.Background(), "aws", now.Add(2*time.Minute))
+	scanB, err := store.CreateScan(defaultScopeContext(), "aws", now.Add(2*time.Minute))
 	if err != nil {
 		t.Fatalf("create scan B: %v", err)
 	}
-	if err := store.UpsertArtifacts(context.Background(), scanB.ID, db.ScanArtifacts{
+	if err := store.UpsertArtifacts(defaultScopeContext(), scanB.ID, db.ScanArtifacts{
 		Bundle: providers.NormalizedBundle{
 			Identities: []domain.Identity{{ID: "id-2", Provider: domain.ProviderAWS, Type: domain.IdentityTypeRole, Name: "app-b", RawRef: "raw-b"}},
 		},
@@ -716,7 +716,7 @@ func TestServiceListIdentitiesAndRelationshipsDefaultsToLatestScan(t *testing.T)
 	}
 
 	svc := NewService(store, fakeScanner{}, "aws")
-	identities, err := svc.ListIdentities(context.Background(), "", "aws", "role", "app", 10)
+	identities, err := svc.ListIdentities(defaultScopeContext(), "", "aws", "role", "app", 10)
 	if err != nil {
 		t.Fatalf("list identities: %v", err)
 	}
@@ -724,7 +724,7 @@ func TestServiceListIdentitiesAndRelationshipsDefaultsToLatestScan(t *testing.T)
 		t.Fatalf("unexpected identities from latest scan: %+v", identities)
 	}
 
-	relationships, err := svc.ListRelationships(context.Background(), "", "can_access", "", "", 10)
+	relationships, err := svc.ListRelationships(defaultScopeContext(), "", "can_access", "", "", 10)
 	if err != nil {
 		t.Fatalf("list relationships: %v", err)
 	}
@@ -736,11 +736,11 @@ func TestServiceListIdentitiesAndRelationshipsDefaultsToLatestScan(t *testing.T)
 func TestServiceListOwnershipSignals(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 17, 18, 0, 0, 0, time.UTC)
-	scan, err := store.CreateScan(context.Background(), "aws", now)
+	scan, err := store.CreateScan(defaultScopeContext(), "aws", now)
 	if err != nil {
 		t.Fatalf("create scan: %v", err)
 	}
-	if err := store.UpsertArtifacts(context.Background(), scan.ID, db.ScanArtifacts{
+	if err := store.UpsertArtifacts(defaultScopeContext(), scan.ID, db.ScanArtifacts{
 		Bundle: providers.NormalizedBundle{
 			Identities: []domain.Identity{
 				{
@@ -769,7 +769,7 @@ func TestServiceListOwnershipSignals(t *testing.T) {
 	}
 
 	svc := NewService(store, fakeScanner{}, "aws")
-	signals, err := svc.ListOwnershipSignals(context.Background(), 10, OwnershipFilter{ScanID: scan.ID})
+	signals, err := svc.ListOwnershipSignals(defaultScopeContext(), 10, OwnershipFilter{ScanID: scan.ID})
 	if err != nil {
 		t.Fatalf("list ownership signals: %v", err)
 	}
@@ -785,18 +785,18 @@ func TestServiceGetFindingsTrend(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
 
-	scanA, _ := store.CreateScan(context.Background(), "aws", now)
-	_ = store.UpsertFindings(context.Background(), scanA.ID, []domain.Finding{
+	scanA, _ := store.CreateScan(defaultScopeContext(), "aws", now)
+	_ = store.UpsertFindings(defaultScopeContext(), scanA.ID, []domain.Finding{
 		{ID: "f1", Severity: domain.SeverityHigh, CreatedAt: now},
 	})
-	scanB, _ := store.CreateScan(context.Background(), "aws", now.Add(3*time.Minute))
-	_ = store.UpsertFindings(context.Background(), scanB.ID, []domain.Finding{
+	scanB, _ := store.CreateScan(defaultScopeContext(), "aws", now.Add(3*time.Minute))
+	_ = store.UpsertFindings(defaultScopeContext(), scanB.ID, []domain.Finding{
 		{ID: "f2", Severity: domain.SeverityCritical, CreatedAt: now.Add(3 * time.Minute)},
 		{ID: "f3", Severity: domain.SeverityMedium, CreatedAt: now.Add(3 * time.Minute)},
 	})
 
 	svc := NewService(store, fakeScanner{}, "aws")
-	points, err := svc.GetFindingsTrend(context.Background(), 10)
+	points, err := svc.GetFindingsTrend(defaultScopeContext(), 10)
 	if err != nil {
 		t.Fatalf("get findings trend: %v", err)
 	}
@@ -814,14 +814,14 @@ func TestServiceGetFindingsTrend(t *testing.T) {
 func TestServiceGetFindingsTrendFiltered(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
-	scan, _ := store.CreateScan(context.Background(), "aws", now)
-	_ = store.UpsertFindings(context.Background(), scan.ID, []domain.Finding{
+	scan, _ := store.CreateScan(defaultScopeContext(), "aws", now)
+	_ = store.UpsertFindings(defaultScopeContext(), scan.ID, []domain.Finding{
 		{ID: "f1", Severity: domain.SeverityCritical, Type: domain.FindingEscalationPath, CreatedAt: now},
 		{ID: "f2", Severity: domain.SeverityHigh, Type: domain.FindingOwnerless, CreatedAt: now},
 	})
 
 	svc := NewService(store, fakeScanner{}, "aws")
-	points, err := svc.GetFindingsTrendFiltered(context.Background(), 10, "critical", "escalation_path")
+	points, err := svc.GetFindingsTrendFiltered(defaultScopeContext(), 10, "critical", "escalation_path")
 	if err != nil {
 		t.Fatalf("trend filtered: %v", err)
 	}
@@ -850,7 +850,7 @@ func TestServiceRunRepoScanSuccess(t *testing.T) {
 		return executor
 	}
 
-	result, err := svc.RunRepoScan(context.Background(), RepoScanRequest{
+	result, err := svc.RunRepoScan(defaultScopeContext(), RepoScanRequest{
 		Repository:   "owner/repo",
 		HistoryLimit: 800,
 		MaxFindings:  300,
@@ -887,7 +887,7 @@ func TestServiceRunRepoScanPersistedStoresRecords(t *testing.T) {
 			},
 		}
 	}
-	run, err := svc.RunRepoScanPersisted(context.Background(), RepoScanRequest{
+	run, err := svc.RunRepoScanPersisted(defaultScopeContext(), RepoScanRequest{
 		Repository:   "owner/repo",
 		HistoryLimit: 10,
 		MaxFindings:  20,
@@ -899,7 +899,7 @@ func TestServiceRunRepoScanPersistedStoresRecords(t *testing.T) {
 		t.Fatalf("unexpected repo scan run result: %+v", run)
 	}
 
-	stored, err := svc.GetRepoScan(context.Background(), run.RepoScan.ID)
+	stored, err := svc.GetRepoScan(defaultScopeContext(), run.RepoScan.ID)
 	if err != nil {
 		t.Fatalf("get repo scan: %v", err)
 	}
@@ -907,7 +907,7 @@ func TestServiceRunRepoScanPersistedStoresRecords(t *testing.T) {
 		t.Fatalf("unexpected persisted repo scan: %+v", stored)
 	}
 
-	findings, err := svc.ListRepoFindings(context.Background(), 10, db.RepoFindingFilter{RepoScanID: run.RepoScan.ID})
+	findings, err := svc.ListRepoFindings(defaultScopeContext(), 10, db.RepoFindingFilter{RepoScanID: run.RepoScan.ID})
 	if err != nil {
 		t.Fatalf("list repo findings: %v", err)
 	}
@@ -919,23 +919,23 @@ func TestServiceRunRepoScanPersistedStoresRecords(t *testing.T) {
 func TestServiceRunRepoScanGuards(t *testing.T) {
 	svc := NewService(db.NewMemoryStore(), fakeScanner{}, "aws")
 	svc.RepoScanEnabled = false
-	if _, err := svc.RunRepoScan(context.Background(), RepoScanRequest{Repository: "owner/repo"}); !errors.Is(err, ErrRepoScanDisabled) {
+	if _, err := svc.RunRepoScan(defaultScopeContext(), RepoScanRequest{Repository: "owner/repo"}); !errors.Is(err, ErrRepoScanDisabled) {
 		t.Fatalf("expected disabled error, got %v", err)
 	}
 
 	svc.RepoScanEnabled = true
 	svc.RepoScanAllowedTargets = []string{"trusted/*"}
-	if _, err := svc.RunRepoScan(context.Background(), RepoScanRequest{Repository: "owner/repo"}); !errors.Is(err, ErrRepoTargetNotAllowed) {
+	if _, err := svc.RunRepoScan(defaultScopeContext(), RepoScanRequest{Repository: "owner/repo"}); !errors.Is(err, ErrRepoTargetNotAllowed) {
 		t.Fatalf("expected target not allowed error, got %v", err)
 	}
 
 	svc.RepoScanAllowedTargets = nil
-	if _, err := svc.RunRepoScan(context.Background(), RepoScanRequest{Repository: "", HistoryLimit: 10, MaxFindings: 10}); !errors.Is(err, ErrInvalidRepoScanRequest) {
+	if _, err := svc.RunRepoScan(defaultScopeContext(), RepoScanRequest{Repository: "", HistoryLimit: 10, MaxFindings: 10}); !errors.Is(err, ErrInvalidRepoScanRequest) {
 		t.Fatalf("expected invalid request error for missing repo, got %v", err)
 	}
 
 	svc.RepoScanAllowedTargets = []string{"owner/repo"}
-	if _, err := svc.RunRepoScan(context.Background(), RepoScanRequest{Repository: "owner/repo", HistoryLimit: -1, MaxFindings: 10}); !errors.Is(err, ErrInvalidRepoScanRequest) {
+	if _, err := svc.RunRepoScan(defaultScopeContext(), RepoScanRequest{Repository: "owner/repo", HistoryLimit: -1, MaxFindings: 10}); !errors.Is(err, ErrInvalidRepoScanRequest) {
 		t.Fatalf("expected invalid request error for negative history, got %v", err)
 	}
 }
@@ -952,7 +952,7 @@ func TestServiceRunRepoScanLocked(t *testing.T) {
 	defer release()
 	svc.Locker = locker
 
-	if _, err := svc.RunRepoScanPersisted(context.Background(), RepoScanRequest{Repository: "owner/repo"}); !errors.Is(err, ErrRepoScanInProgress) {
+	if _, err := svc.RunRepoScanPersisted(defaultScopeContext(), RepoScanRequest{Repository: "owner/repo"}); !errors.Is(err, ErrRepoScanInProgress) {
 		t.Fatalf("expected repo scan in progress error, got %v", err)
 	}
 }
@@ -960,24 +960,24 @@ func TestServiceRunRepoScanLocked(t *testing.T) {
 func TestServiceListFindingsWrapperAndRepoScanDetailGuard(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 17, 15, 10, 0, 0, time.UTC)
-	scan, err := store.CreateScan(context.Background(), "aws", now)
+	scan, err := store.CreateScan(defaultScopeContext(), "aws", now)
 	if err != nil {
 		t.Fatalf("create scan: %v", err)
 	}
-	if err := store.UpsertFindings(context.Background(), scan.ID, []domain.Finding{
+	if err := store.UpsertFindings(defaultScopeContext(), scan.ID, []domain.Finding{
 		{ID: "f1", Type: domain.FindingOwnerless, Severity: domain.SeverityHigh, CreatedAt: now},
 	}); err != nil {
 		t.Fatalf("upsert findings: %v", err)
 	}
 	svc := NewService(store, fakeScanner{}, "aws")
-	items, err := svc.ListFindings(context.Background(), 10)
+	items, err := svc.ListFindings(defaultScopeContext(), 10)
 	if err != nil {
 		t.Fatalf("list findings wrapper: %v", err)
 	}
 	if len(items) != 1 || items[0].ID != "f1" {
 		t.Fatalf("unexpected list findings result %+v", items)
 	}
-	if _, err := svc.GetRepoScan(context.Background(), " "); !errors.Is(err, db.ErrNotFound) {
+	if _, err := svc.GetRepoScan(defaultScopeContext(), " "); !errors.Is(err, db.ErrNotFound) {
 		t.Fatalf("expected not found for empty repo scan id, got %v", err)
 	}
 }
@@ -989,12 +989,12 @@ func TestServiceRunRepoScanPersistedScannerError(t *testing.T) {
 	svc.RepoScannerFactory = func(int, int) RepoScanExecutor {
 		return &fakeRepoExecutor{err: errors.New("scanner failed")}
 	}
-	if _, err := svc.RunRepoScanPersisted(context.Background(), RepoScanRequest{
+	if _, err := svc.RunRepoScanPersisted(defaultScopeContext(), RepoScanRequest{
 		Repository: "owner/repo",
 	}); err == nil {
 		t.Fatal("expected scanner error")
 	}
-	repoScans, err := svc.ListRepoScans(context.Background(), 10)
+	repoScans, err := svc.ListRepoScans(defaultScopeContext(), 10)
 	if err != nil {
 		t.Fatalf("list repo scans: %v", err)
 	}
@@ -1012,28 +1012,28 @@ func TestServiceEnqueueScanAndProcessQueue(t *testing.T) {
 	}}, "aws")
 	svc.Now = func() time.Time { return now }
 
-	record, err := svc.EnqueueScan(context.Background())
+	record, err := svc.EnqueueScan(defaultScopeContext())
 	if err != nil {
 		t.Fatalf("enqueue scan: %v", err)
 	}
 	if record.Status != "queued" {
 		t.Fatalf("expected queued status, got %q", record.Status)
 	}
-	processed, err := svc.ProcessNextQueuedScan(context.Background())
+	processed, err := svc.ProcessNextQueuedScan(defaultScopeContext())
 	if err != nil {
 		t.Fatalf("process queued scan: %v", err)
 	}
 	if !processed {
 		t.Fatal("expected one queued scan to be processed")
 	}
-	scan, err := store.GetScan(context.Background(), record.ID)
+	scan, err := store.GetScan(defaultScopeContext(), record.ID)
 	if err != nil {
 		t.Fatalf("get scan: %v", err)
 	}
 	if scan.Status != "completed" || scan.FindingCount != 1 {
 		t.Fatalf("unexpected processed scan record: %+v", scan)
 	}
-	processed, err = svc.ProcessNextQueuedScan(context.Background())
+	processed, err = svc.ProcessNextQueuedScan(defaultScopeContext())
 	if err != nil {
 		t.Fatalf("process queued scan again: %v", err)
 	}
@@ -1045,10 +1045,10 @@ func TestServiceEnqueueScanAndProcessQueue(t *testing.T) {
 func TestServiceEnqueueScanQueueFull(t *testing.T) {
 	svc := NewService(db.NewMemoryStore(), fakeScanner{}, "aws")
 	svc.ScanQueueMaxPending = 1
-	if _, err := svc.EnqueueScan(context.Background()); err != nil {
+	if _, err := svc.EnqueueScan(defaultScopeContext()); err != nil {
 		t.Fatalf("enqueue first scan: %v", err)
 	}
-	if _, err := svc.EnqueueScan(context.Background()); !errors.Is(err, ErrScanQueueFull) {
+	if _, err := svc.EnqueueScan(defaultScopeContext()); !errors.Is(err, ErrScanQueueFull) {
 		t.Fatalf("expected scan queue full error, got %v", err)
 	}
 }
@@ -1065,13 +1065,13 @@ func TestServiceQueuedScanBurstProcessing(t *testing.T) {
 
 	const queued = 40
 	for i := 0; i < queued; i++ {
-		if _, err := svc.EnqueueScan(context.Background()); err != nil {
+		if _, err := svc.EnqueueScan(defaultScopeContext()); err != nil {
 			t.Fatalf("enqueue burst scan %d: %v", i, err)
 		}
 	}
 	processedCount := 0
 	for {
-		processed, err := svc.ProcessNextQueuedScan(context.Background())
+		processed, err := svc.ProcessNextQueuedScan(defaultScopeContext())
 		if err != nil {
 			t.Fatalf("process burst queue: %v", err)
 		}
@@ -1083,7 +1083,7 @@ func TestServiceQueuedScanBurstProcessing(t *testing.T) {
 	if processedCount != queued {
 		t.Fatalf("expected %d processed scans, got %d", queued, processedCount)
 	}
-	scans, err := store.ListScans(context.Background(), 1000)
+	scans, err := store.ListScans(defaultScopeContext(), 1000)
 	if err != nil {
 		t.Fatalf("list scans: %v", err)
 	}
@@ -1115,7 +1115,7 @@ func TestServiceEnqueueRepoScanAndProcessQueue(t *testing.T) {
 			},
 		}
 	}
-	record, err := svc.EnqueueRepoScan(context.Background(), RepoScanRequest{
+	record, err := svc.EnqueueRepoScan(defaultScopeContext(), RepoScanRequest{
 		Repository:   "owner/repo",
 		HistoryLimit: 25,
 		MaxFindings:  30,
@@ -1126,14 +1126,14 @@ func TestServiceEnqueueRepoScanAndProcessQueue(t *testing.T) {
 	if record.Status != "queued" {
 		t.Fatalf("expected queued repo scan status, got %q", record.Status)
 	}
-	processed, err := svc.ProcessNextQueuedRepoScan(context.Background())
+	processed, err := svc.ProcessNextQueuedRepoScan(defaultScopeContext())
 	if err != nil {
 		t.Fatalf("process queued repo scan: %v", err)
 	}
 	if !processed {
 		t.Fatal("expected queued repo scan to be processed")
 	}
-	stored, err := svc.GetRepoScan(context.Background(), record.ID)
+	stored, err := svc.GetRepoScan(defaultScopeContext(), record.ID)
 	if err != nil {
 		t.Fatalf("get repo scan: %v", err)
 	}
@@ -1147,16 +1147,16 @@ func TestServiceEnqueueRepoScanGuards(t *testing.T) {
 	svc.RepoScanAllowedTargets = []string{"owner/*"}
 	svc.RepoQueueMaxPending = 1
 
-	if _, err := svc.EnqueueRepoScan(context.Background(), RepoScanRequest{Repository: "owner/repo"}); err != nil {
+	if _, err := svc.EnqueueRepoScan(defaultScopeContext(), RepoScanRequest{Repository: "owner/repo"}); err != nil {
 		t.Fatalf("enqueue first repo scan: %v", err)
 	}
-	if _, err := svc.EnqueueRepoScan(context.Background(), RepoScanRequest{Repository: "owner/repo"}); !errors.Is(err, ErrRepoScanInProgress) {
+	if _, err := svc.EnqueueRepoScan(defaultScopeContext(), RepoScanRequest{Repository: "owner/repo"}); !errors.Is(err, ErrRepoScanInProgress) {
 		t.Fatalf("expected repo in-progress error for duplicate target, got %v", err)
 	}
-	if _, err := svc.EnqueueRepoScan(context.Background(), RepoScanRequest{Repository: "Owner/Repo"}); !errors.Is(err, ErrRepoScanInProgress) {
+	if _, err := svc.EnqueueRepoScan(defaultScopeContext(), RepoScanRequest{Repository: "Owner/Repo"}); !errors.Is(err, ErrRepoScanInProgress) {
 		t.Fatalf("expected repo in-progress error for case-variant duplicate target, got %v", err)
 	}
-	if _, err := svc.EnqueueRepoScan(context.Background(), RepoScanRequest{Repository: "owner/another"}); !errors.Is(err, ErrRepoScanQueueFull) {
+	if _, err := svc.EnqueueRepoScan(defaultScopeContext(), RepoScanRequest{Repository: "owner/another"}); !errors.Is(err, ErrRepoScanQueueFull) {
 		t.Fatalf("expected repo queue full error, got %v", err)
 	}
 }
@@ -1168,7 +1168,7 @@ func TestServiceProcessQueuedRepoScanRequeuesWhenExecutionLockHeld(t *testing.T)
 	queuedAt := time.Date(2026, 3, 24, 10, 0, 0, 0, time.UTC)
 	svc.Now = func() time.Time { return queuedAt }
 
-	record, err := svc.EnqueueRepoScan(context.Background(), RepoScanRequest{Repository: "owner/repo"})
+	record, err := svc.EnqueueRepoScan(defaultScopeContext(), RepoScanRequest{Repository: "owner/repo"})
 	if err != nil {
 		t.Fatalf("enqueue repo scan: %v", err)
 	}
@@ -1180,14 +1180,14 @@ func TestServiceProcessQueuedRepoScanRequeuesWhenExecutionLockHeld(t *testing.T)
 	defer release()
 	svc.Locker = locker
 
-	processed, err := svc.ProcessNextQueuedRepoScan(context.Background())
+	processed, err := svc.ProcessNextQueuedRepoScan(defaultScopeContext())
 	if err != nil {
 		t.Fatalf("process queued repo scan: %v", err)
 	}
 	if !processed {
 		t.Fatal("expected requeue handling to count as queue progress")
 	}
-	stored, err := svc.GetRepoScan(context.Background(), record.ID)
+	stored, err := svc.GetRepoScan(defaultScopeContext(), record.ID)
 	if err != nil {
 		t.Fatalf("get repo scan: %v", err)
 	}
@@ -1218,11 +1218,11 @@ func TestServiceProcessQueuedRepoScanContinuesToNextTargetAfterRequeue(t *testin
 		}
 	}
 
-	repoA, err := svc.EnqueueRepoScan(context.Background(), RepoScanRequest{Repository: "owner/repo-a"})
+	repoA, err := svc.EnqueueRepoScan(defaultScopeContext(), RepoScanRequest{Repository: "owner/repo-a"})
 	if err != nil {
 		t.Fatalf("enqueue repo-a scan: %v", err)
 	}
-	repoB, err := svc.EnqueueRepoScan(context.Background(), RepoScanRequest{Repository: "owner/repo-b"})
+	repoB, err := svc.EnqueueRepoScan(defaultScopeContext(), RepoScanRequest{Repository: "owner/repo-b"})
 	if err != nil {
 		t.Fatalf("enqueue repo-b scan: %v", err)
 	}
@@ -1235,7 +1235,7 @@ func TestServiceProcessQueuedRepoScanContinuesToNextTargetAfterRequeue(t *testin
 	defer release()
 	svc.Locker = locker
 
-	processed, err := svc.ProcessNextQueuedRepoScan(context.Background())
+	processed, err := svc.ProcessNextQueuedRepoScan(defaultScopeContext())
 	if err != nil {
 		t.Fatalf("first queue process failed: %v", err)
 	}
@@ -1243,7 +1243,7 @@ func TestServiceProcessQueuedRepoScanContinuesToNextTargetAfterRequeue(t *testin
 		t.Fatal("expected first queue pass to requeue locked target")
 	}
 
-	processed, err = svc.ProcessNextQueuedRepoScan(context.Background())
+	processed, err = svc.ProcessNextQueuedRepoScan(defaultScopeContext())
 	if err != nil {
 		t.Fatalf("second queue process failed: %v", err)
 	}
@@ -1251,7 +1251,7 @@ func TestServiceProcessQueuedRepoScanContinuesToNextTargetAfterRequeue(t *testin
 		t.Fatal("expected second queue pass to process next target")
 	}
 
-	repoARecord, err := svc.GetRepoScan(context.Background(), repoA.ID)
+	repoARecord, err := svc.GetRepoScan(defaultScopeContext(), repoA.ID)
 	if err != nil {
 		t.Fatalf("get repo-a scan: %v", err)
 	}
@@ -1259,7 +1259,7 @@ func TestServiceProcessQueuedRepoScanContinuesToNextTargetAfterRequeue(t *testin
 		t.Fatalf("expected repo-a to remain queued while lock is held, got %q", repoARecord.Status)
 	}
 
-	repoBRecord, err := svc.GetRepoScan(context.Background(), repoB.ID)
+	repoBRecord, err := svc.GetRepoScan(defaultScopeContext(), repoB.ID)
 	if err != nil {
 		t.Fatalf("get repo-b scan: %v", err)
 	}
@@ -1289,7 +1289,7 @@ func TestServiceRunRepoScanRejectsLocalRepositoryTarget(t *testing.T) {
 		t.Fatalf("prepare local repo fixture: %v", err)
 	}
 
-	if _, err := svc.RunRepoScan(context.Background(), RepoScanRequest{Repository: repo}); !errors.Is(err, ErrRepoTargetNotAllowed) {
+	if _, err := svc.RunRepoScan(defaultScopeContext(), RepoScanRequest{Repository: repo}); !errors.Is(err, ErrRepoTargetNotAllowed) {
 		t.Fatalf("expected local repo target rejection, got %v", err)
 	}
 }

--- a/internal/api/test_scope_context_test.go
+++ b/internal/api/test_scope_context_test.go
@@ -1,0 +1,11 @@
+package api
+
+import (
+	"context"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
+)
+
+func defaultScopeContext() context.Context {
+	return db.WithScope(context.Background(), db.Scope{})
+}

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -59,7 +59,11 @@ func (m *MemoryStore) CreateScan(ctx context.Context, provider string, startedAt
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	return m.createScanLocked(ScopeFromContext(ctx), provider, "running", startedAt), nil
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return ScanRecord{}, err
+	}
+	return m.createScanLocked(scope, provider, "running", startedAt), nil
 }
 
 // CreateQueuedScan persists one queued scan request.
@@ -67,7 +71,11 @@ func (m *MemoryStore) CreateQueuedScan(ctx context.Context, provider string, que
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	return m.createScanLocked(ScopeFromContext(ctx), provider, "queued", queuedAt), nil
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return ScanRecord{}, err
+	}
+	return m.createScanLocked(scope, provider, "queued", queuedAt), nil
 }
 
 // ClaimNextQueuedScan moves one queued scan to running for execution.
@@ -75,7 +83,10 @@ func (m *MemoryStore) ClaimNextQueuedScan(ctx context.Context, provider string) 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return ScanRecord{}, err
+	}
 	normalizedProvider := strings.TrimSpace(provider)
 	found := false
 	var bestRecord ScanRecord
@@ -110,7 +121,10 @@ func (m *MemoryStore) CountQueuedScans(ctx context.Context, provider string) (in
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return 0, err
+	}
 	normalizedProvider := strings.TrimSpace(provider)
 	count := 0
 	for _, record := range m.scans {
@@ -148,7 +162,10 @@ func (m *MemoryStore) GetScan(ctx context.Context, scanID string) (ScanRecord, e
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return ScanRecord{}, err
+	}
 	record, exists := m.scans[scanID]
 	if !exists || !MatchScope(scope, record.TenantID, record.WorkspaceID) {
 		return ScanRecord{}, ErrNotFound
@@ -161,7 +178,10 @@ func (m *MemoryStore) CompleteScan(ctx context.Context, scanID string, status st
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
 	record, exists := m.scans[scanID]
 	if !exists || !MatchScope(scope, record.TenantID, record.WorkspaceID) {
 		return ErrNotFound
@@ -181,7 +201,10 @@ func (m *MemoryStore) UpsertFindings(ctx context.Context, scanID string, finding
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
 	scan, exists := m.scans[scanID]
 	if !exists || !MatchScope(scope, scan.TenantID, scan.WorkspaceID) {
 		return ErrNotFound
@@ -196,11 +219,15 @@ func (m *MemoryStore) UpsertFindings(ctx context.Context, scanID string, finding
 }
 
 // GetFindingTriageState returns triage workflow state for one finding id.
-func (m *MemoryStore) GetFindingTriageState(_ context.Context, findingID string) (FindingTriageState, error) {
+func (m *MemoryStore) GetFindingTriageState(ctx context.Context, findingID string) (FindingTriageState, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	state, exists := m.triageStates[strings.TrimSpace(findingID)]
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return FindingTriageState{}, err
+	}
+	state, exists := m.triageStates[findingScopeKey(scope, findingID)]
 	if !exists {
 		return FindingTriageState{}, ErrNotFound
 	}
@@ -208,10 +235,14 @@ func (m *MemoryStore) GetFindingTriageState(_ context.Context, findingID string)
 }
 
 // ListFindingTriageStates returns triage states for provided finding ids.
-func (m *MemoryStore) ListFindingTriageStates(_ context.Context, findingIDs []string) ([]FindingTriageState, error) {
+func (m *MemoryStore) ListFindingTriageStates(ctx context.Context, findingIDs []string) ([]FindingTriageState, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
 	seen := map[string]struct{}{}
 	result := make([]FindingTriageState, 0, len(findingIDs))
 	for _, findingID := range findingIDs {
@@ -223,7 +254,7 @@ func (m *MemoryStore) ListFindingTriageStates(_ context.Context, findingIDs []st
 			continue
 		}
 		seen[normalized] = struct{}{}
-		state, exists := m.triageStates[normalized]
+		state, exists := m.triageStates[findingScopeKey(scope, normalized)]
 		if !exists {
 			continue
 		}
@@ -233,31 +264,40 @@ func (m *MemoryStore) ListFindingTriageStates(_ context.Context, findingIDs []st
 }
 
 // UpsertFindingTriageState creates or updates mutable triage metadata.
-func (m *MemoryStore) UpsertFindingTriageState(_ context.Context, state FindingTriageState) error {
+func (m *MemoryStore) UpsertFindingTriageState(ctx context.Context, state FindingTriageState) error {
 	normalized, err := normalizeFindingTriageStateForWrite(state)
 	if err != nil {
 		return err
 	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.triageStates[normalized.FindingID] = normalized
-	return nil
-}
-
-// AppendFindingTriageEvent records one immutable triage action.
-func (m *MemoryStore) AppendFindingTriageEvent(_ context.Context, event FindingTriageEvent) error {
-	normalized, err := normalizeFindingTriageEventForWrite(event)
+	scope, err := RequireScope(ctx)
 	if err != nil {
 		return err
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.triageEvents[normalized.FindingID] = append(m.triageEvents[normalized.FindingID], normalized)
+	m.triageStates[findingScopeKey(scope, normalized.FindingID)] = normalized
+	return nil
+}
+
+// AppendFindingTriageEvent records one immutable triage action.
+func (m *MemoryStore) AppendFindingTriageEvent(ctx context.Context, event FindingTriageEvent) error {
+	normalized, err := normalizeFindingTriageEventForWrite(event)
+	if err != nil {
+		return err
+	}
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := findingScopeKey(scope, normalized.FindingID)
+	m.triageEvents[key] = append(m.triageEvents[key], normalized)
 	return nil
 }
 
 // ApplyFindingTriageTransition persists state and audit history atomically.
-func (m *MemoryStore) ApplyFindingTriageTransition(_ context.Context, state FindingTriageState, event FindingTriageEvent) error {
+func (m *MemoryStore) ApplyFindingTriageTransition(ctx context.Context, state FindingTriageState, event FindingTriageEvent) error {
 	normalizedState, err := normalizeFindingTriageStateForWrite(state)
 	if err != nil {
 		return err
@@ -269,24 +309,33 @@ func (m *MemoryStore) ApplyFindingTriageTransition(_ context.Context, state Find
 	if normalizedState.FindingID != normalizedEvent.FindingID {
 		return fmt.Errorf("finding id mismatch between state and event")
 	}
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.triageStates[normalizedState.FindingID] = normalizedState
-	m.triageEvents[normalizedState.FindingID] = append(m.triageEvents[normalizedState.FindingID], normalizedEvent)
+	key := findingScopeKey(scope, normalizedState.FindingID)
+	m.triageStates[key] = normalizedState
+	m.triageEvents[key] = append(m.triageEvents[key], normalizedEvent)
 	return nil
 }
 
 // ListFindingTriageEvents returns triage actions newest-first for one finding id.
-func (m *MemoryStore) ListFindingTriageEvents(_ context.Context, findingID string, limit int) ([]FindingTriageEvent, error) {
+func (m *MemoryStore) ListFindingTriageEvents(ctx context.Context, findingID string, limit int) ([]FindingTriageEvent, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
 	normalizedID := strings.TrimSpace(findingID)
 	if normalizedID == "" {
 		return nil, ErrNotFound
 	}
-	events := append([]FindingTriageEvent(nil), m.triageEvents[normalizedID]...)
+	events := append([]FindingTriageEvent(nil), m.triageEvents[findingScopeKey(scope, normalizedID)]...)
 	sort.Slice(events, func(i, j int) bool {
 		return events[i].CreatedAt.After(events[j].CreatedAt)
 	})
@@ -301,7 +350,10 @@ func (m *MemoryStore) UpsertArtifacts(ctx context.Context, scanID string, artifa
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
 	scan, exists := m.scans[scanID]
 	if !exists || !MatchScope(scope, scan.TenantID, scan.WorkspaceID) {
 		return ErrNotFound
@@ -335,7 +387,10 @@ func (m *MemoryStore) ListScans(ctx context.Context, limit int) ([]ScanRecord, e
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
 	records := make([]ScanRecord, 0, len(m.scanIDs))
 	for _, scanID := range m.scanIDs {
 		record := m.scans[scanID]
@@ -358,7 +413,10 @@ func (m *MemoryStore) ListFindings(ctx context.Context, limit int) ([]domain.Fin
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
 	result := make([]domain.Finding, 0, len(m.findings))
 	for _, finding := range m.findings {
 		scan, exists := m.scans[finding.ScanID]
@@ -381,7 +439,10 @@ func (m *MemoryStore) ListFindingsByScan(ctx context.Context, scanID string, lim
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
 	scan, exists := m.scans[scanID]
 	if !exists || !MatchScope(scope, scan.TenantID, scan.WorkspaceID) {
 		return nil, ErrNotFound
@@ -408,7 +469,10 @@ func (m *MemoryStore) ListIdentities(ctx context.Context, filter IdentityFilter,
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
 	filteredScanID := strings.TrimSpace(filter.ScanID)
 	if filteredScanID != "" {
 		scan, exists := m.scans[filteredScanID]
@@ -453,7 +517,10 @@ func (m *MemoryStore) ListRelationships(ctx context.Context, filter Relationship
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
 	filteredScanID := strings.TrimSpace(filter.ScanID)
 	if filteredScanID != "" {
 		scan, exists := m.scans[filteredScanID]
@@ -498,7 +565,10 @@ func (m *MemoryStore) AppendScanEvent(ctx context.Context, scanID string, level 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
 	scan, exists := m.scans[scanID]
 	if !exists || !MatchScope(scope, scan.TenantID, scan.WorkspaceID) {
 		return ErrNotFound
@@ -523,7 +593,10 @@ func (m *MemoryStore) ListScanEvents(ctx context.Context, scanID string, limit i
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
 	scan, exists := m.scans[scanID]
 	if !exists || !MatchScope(scope, scan.TenantID, scan.WorkspaceID) {
 		return nil, ErrNotFound
@@ -544,6 +617,11 @@ func scanKeyPrefix(key string) string {
 		return ""
 	}
 	return parts[0]
+}
+
+func findingScopeKey(scope Scope, findingID string) string {
+	normalized := scope.Normalize()
+	return normalized.TenantID + "|" + normalized.WorkspaceID + "|" + strings.TrimSpace(findingID)
 }
 
 func normalizeFindingTriageStateForWrite(state FindingTriageState) (FindingTriageState, error) {
@@ -588,7 +666,11 @@ func (m *MemoryStore) CreateRepoScan(ctx context.Context, repository string, sta
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	return m.createRepoScanLocked(ScopeFromContext(ctx), strings.TrimSpace(repository), "running", 0, 0, startedAt), nil
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return RepoScanRecord{}, err
+	}
+	return m.createRepoScanLocked(scope, strings.TrimSpace(repository), "running", 0, 0, startedAt), nil
 }
 
 // CreateQueuedRepoScan persists one queued repository exposure scan request.
@@ -596,7 +678,11 @@ func (m *MemoryStore) CreateQueuedRepoScan(ctx context.Context, repository strin
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	return m.createRepoScanLocked(ScopeFromContext(ctx), strings.TrimSpace(repository), "queued", historyLimit, maxFindings, queuedAt), nil
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return RepoScanRecord{}, err
+	}
+	return m.createRepoScanLocked(scope, strings.TrimSpace(repository), "queued", historyLimit, maxFindings, queuedAt), nil
 }
 
 // ClaimNextQueuedRepoScan moves one queued repository scan to running for execution.
@@ -604,7 +690,10 @@ func (m *MemoryStore) ClaimNextQueuedRepoScan(ctx context.Context) (RepoScanReco
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return RepoScanRecord{}, err
+	}
 	var claimed RepoScanRecord
 	found := false
 	for _, scanID := range m.repoScanIDs {
@@ -635,7 +724,10 @@ func (m *MemoryStore) CountQueuedRepoScans(ctx context.Context) (int, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return 0, err
+	}
 	count := 0
 	for _, record := range m.repoScans {
 		if !MatchScope(scope, record.TenantID, record.WorkspaceID) {
@@ -653,7 +745,10 @@ func (m *MemoryStore) CountPendingRepoScansByRepository(ctx context.Context, rep
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return 0, err
+	}
 	normalizedRepository := strings.TrimSpace(repository)
 	if normalizedRepository == "" {
 		return 0, nil
@@ -678,7 +773,10 @@ func (m *MemoryStore) RequeueRepoScan(ctx context.Context, repoScanID string) er
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
 	record, exists := m.repoScans[repoScanID]
 	if !exists || !MatchScope(scope, record.TenantID, record.WorkspaceID) {
 		return ErrNotFound
@@ -716,7 +814,10 @@ func (m *MemoryStore) GetRepoScan(ctx context.Context, repoScanID string) (RepoS
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return RepoScanRecord{}, err
+	}
 	record, exists := m.repoScans[repoScanID]
 	if !exists || !MatchScope(scope, record.TenantID, record.WorkspaceID) {
 		return RepoScanRecord{}, ErrNotFound
@@ -729,7 +830,10 @@ func (m *MemoryStore) CompleteRepoScan(ctx context.Context, repoScanID string, s
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
 	record, exists := m.repoScans[repoScanID]
 	if !exists || !MatchScope(scope, record.TenantID, record.WorkspaceID) {
 		return ErrNotFound
@@ -751,7 +855,10 @@ func (m *MemoryStore) UpsertRepoFindings(ctx context.Context, repoScanID string,
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
 	repoScan, exists := m.repoScans[repoScanID]
 	if !exists || !MatchScope(scope, repoScan.TenantID, repoScan.WorkspaceID) {
 		return ErrNotFound
@@ -769,7 +876,10 @@ func (m *MemoryStore) ListRepoScans(ctx context.Context, limit int) ([]RepoScanR
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
 	result := make([]RepoScanRecord, 0, len(m.repoScanIDs))
 	for _, scanID := range m.repoScanIDs {
 		record := m.repoScans[scanID]
@@ -792,7 +902,10 @@ func (m *MemoryStore) ListRepoFindings(ctx context.Context, filter RepoFindingFi
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
 	repoScanID := strings.TrimSpace(filter.RepoScanID)
 	if repoScanID != "" {
 		record, exists := m.repoScans[repoScanID]

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -14,7 +14,7 @@ func TestMemoryStoreScanLifecycleAndFindings(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
 
-	scan, err := store.CreateScan(context.Background(), "aws", now)
+	scan, err := store.CreateScan(defaultScopeContext(), "aws", now)
 	if err != nil {
 		t.Fatalf("create scan failed: %v", err)
 	}
@@ -27,10 +27,10 @@ func TestMemoryStoreScanLifecycleAndFindings(t *testing.T) {
 		HumanSummary: "Cross-account trust",
 		CreatedAt:    now,
 	}}
-	if err := store.UpsertFindings(context.Background(), scan.ID, findings); err != nil {
+	if err := store.UpsertFindings(defaultScopeContext(), scan.ID, findings); err != nil {
 		t.Fatalf("upsert findings failed: %v", err)
 	}
-	if err := store.UpsertArtifacts(context.Background(), scan.ID, ScanArtifacts{
+	if err := store.UpsertArtifacts(defaultScopeContext(), scan.ID, ScanArtifacts{
 		RawAssets: []providers.RawAsset{{Kind: "iam_role", SourceID: "arn:aws:iam::1:role/test", Payload: []byte(`{"arn":"arn:aws:iam::1:role/test"}`), Collected: now.Format(time.RFC3339Nano)}},
 		Bundle: providers.NormalizedBundle{
 			Identities: []domain.Identity{{ID: "aws:identity:arn:aws:iam::1:role/test", Provider: domain.ProviderAWS, Type: domain.IdentityTypeRole, Name: "test", RawRef: "arn:aws:iam::1:role/test"}},
@@ -41,15 +41,15 @@ func TestMemoryStoreScanLifecycleAndFindings(t *testing.T) {
 		t.Fatalf("upsert artifacts failed: %v", err)
 	}
 	// idempotent re-run must not fail
-	if err := store.UpsertArtifacts(context.Background(), scan.ID, ScanArtifacts{}); err != nil {
+	if err := store.UpsertArtifacts(defaultScopeContext(), scan.ID, ScanArtifacts{}); err != nil {
 		t.Fatalf("second upsert artifacts failed: %v", err)
 	}
 
-	if err := store.CompleteScan(context.Background(), scan.ID, "completed", now.Add(2*time.Second), 3, 1, ""); err != nil {
+	if err := store.CompleteScan(defaultScopeContext(), scan.ID, "completed", now.Add(2*time.Second), 3, 1, ""); err != nil {
 		t.Fatalf("complete scan failed: %v", err)
 	}
 
-	scans, err := store.ListScans(context.Background(), 10)
+	scans, err := store.ListScans(defaultScopeContext(), 10)
 	if err != nil {
 		t.Fatalf("list scans failed: %v", err)
 	}
@@ -57,7 +57,7 @@ func TestMemoryStoreScanLifecycleAndFindings(t *testing.T) {
 		t.Fatalf("unexpected scans: %+v", scans)
 	}
 
-	storedFindings, err := store.ListFindings(context.Background(), 10)
+	storedFindings, err := store.ListFindings(defaultScopeContext(), 10)
 	if err != nil {
 		t.Fatalf("list findings failed: %v", err)
 	}
@@ -68,32 +68,32 @@ func TestMemoryStoreScanLifecycleAndFindings(t *testing.T) {
 
 func TestMemoryStoreErrorsForUnknownScan(t *testing.T) {
 	store := NewMemoryStore()
-	err := store.CompleteScan(context.Background(), "missing", "failed", time.Now(), 0, 0, "boom")
+	err := store.CompleteScan(defaultScopeContext(), "missing", "failed", time.Now(), 0, 0, "boom")
 	if err == nil {
 		t.Fatal("expected error")
 	}
 
-	err = store.UpsertFindings(context.Background(), "missing", []domain.Finding{{ID: "f1"}})
+	err = store.UpsertFindings(defaultScopeContext(), "missing", []domain.Finding{{ID: "f1"}})
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	err = store.UpsertArtifacts(context.Background(), "missing", ScanArtifacts{})
+	err = store.UpsertArtifacts(defaultScopeContext(), "missing", ScanArtifacts{})
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	_, err = store.GetScan(context.Background(), "missing")
+	_, err = store.GetScan(defaultScopeContext(), "missing")
 	if err == nil {
 		t.Fatal("expected get scan error")
 	}
-	_, err = store.ListFindingsByScan(context.Background(), "missing", 10)
+	_, err = store.ListFindingsByScan(defaultScopeContext(), "missing", 10)
 	if err == nil {
 		t.Fatal("expected findings-by-scan error")
 	}
-	err = store.AppendScanEvent(context.Background(), "missing", "info", "msg", nil)
+	err = store.AppendScanEvent(defaultScopeContext(), "missing", "info", "msg", nil)
 	if err == nil {
 		t.Fatal("expected append scan event error")
 	}
-	_, err = store.ListScanEvents(context.Background(), "missing", 10)
+	_, err = store.ListScanEvents(defaultScopeContext(), "missing", 10)
 	if err == nil {
 		t.Fatal("expected list scan events error")
 	}
@@ -103,23 +103,23 @@ func TestMemoryStoreScanDetails(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
 
-	scanA, err := store.CreateScan(context.Background(), "aws", now)
+	scanA, err := store.CreateScan(defaultScopeContext(), "aws", now)
 	if err != nil {
 		t.Fatalf("create scan A: %v", err)
 	}
-	scanB, err := store.CreateScan(context.Background(), "aws", now.Add(1*time.Minute))
+	scanB, err := store.CreateScan(defaultScopeContext(), "aws", now.Add(1*time.Minute))
 	if err != nil {
 		t.Fatalf("create scan B: %v", err)
 	}
 
-	if err := store.UpsertFindings(context.Background(), scanA.ID, []domain.Finding{
+	if err := store.UpsertFindings(defaultScopeContext(), scanA.ID, []domain.Finding{
 		{ID: "f1", ScanID: scanA.ID, CreatedAt: now.Add(1 * time.Second)},
 		{ID: "f2", ScanID: scanA.ID, CreatedAt: now.Add(2 * time.Second)},
 	}); err != nil {
 		t.Fatalf("upsert findings: %v", err)
 	}
 
-	gotScan, err := store.GetScan(context.Background(), scanA.ID)
+	gotScan, err := store.GetScan(defaultScopeContext(), scanA.ID)
 	if err != nil {
 		t.Fatalf("get scan: %v", err)
 	}
@@ -127,7 +127,7 @@ func TestMemoryStoreScanDetails(t *testing.T) {
 		t.Fatalf("unexpected scan id: %q", gotScan.ID)
 	}
 
-	findings, err := store.ListFindingsByScan(context.Background(), scanA.ID, 10)
+	findings, err := store.ListFindingsByScan(defaultScopeContext(), scanA.ID, 10)
 	if err != nil {
 		t.Fatalf("list findings by scan: %v", err)
 	}
@@ -135,13 +135,13 @@ func TestMemoryStoreScanDetails(t *testing.T) {
 		t.Fatalf("unexpected findings: %+v", findings)
 	}
 
-	if err := store.AppendScanEvent(context.Background(), scanB.ID, "info", "scan started", map[string]any{"provider": "aws"}); err != nil {
+	if err := store.AppendScanEvent(defaultScopeContext(), scanB.ID, "info", "scan started", map[string]any{"provider": "aws"}); err != nil {
 		t.Fatalf("append scan event 1: %v", err)
 	}
-	if err := store.AppendScanEvent(context.Background(), scanB.ID, "info", "scan completed", nil); err != nil {
+	if err := store.AppendScanEvent(defaultScopeContext(), scanB.ID, "info", "scan completed", nil); err != nil {
 		t.Fatalf("append scan event 2: %v", err)
 	}
-	events, err := store.ListScanEvents(context.Background(), scanB.ID, 10)
+	events, err := store.ListScanEvents(defaultScopeContext(), scanB.ID, 10)
 	if err != nil {
 		t.Fatalf("list scan events: %v", err)
 	}
@@ -153,15 +153,15 @@ func TestMemoryStoreScanDetails(t *testing.T) {
 func TestMemoryStoreIdentityAndRelationshipFilters(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
-	scanA, err := store.CreateScan(context.Background(), "aws", now)
+	scanA, err := store.CreateScan(defaultScopeContext(), "aws", now)
 	if err != nil {
 		t.Fatalf("create scan A: %v", err)
 	}
-	scanB, err := store.CreateScan(context.Background(), "aws", now.Add(5*time.Minute))
+	scanB, err := store.CreateScan(defaultScopeContext(), "aws", now.Add(5*time.Minute))
 	if err != nil {
 		t.Fatalf("create scan B: %v", err)
 	}
-	if err := store.UpsertArtifacts(context.Background(), scanA.ID, ScanArtifacts{
+	if err := store.UpsertArtifacts(defaultScopeContext(), scanA.ID, ScanArtifacts{
 		Bundle: providers.NormalizedBundle{
 			Identities: []domain.Identity{
 				{ID: "id-1", Provider: domain.ProviderAWS, Type: domain.IdentityTypeRole, Name: "app-role", RawRef: "raw-1"},
@@ -174,7 +174,7 @@ func TestMemoryStoreIdentityAndRelationshipFilters(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("upsert artifacts scan A: %v", err)
 	}
-	if err := store.UpsertArtifacts(context.Background(), scanB.ID, ScanArtifacts{
+	if err := store.UpsertArtifacts(defaultScopeContext(), scanB.ID, ScanArtifacts{
 		Bundle: providers.NormalizedBundle{
 			Identities: []domain.Identity{
 				{ID: "id-3", Provider: domain.ProviderAWS, Type: domain.IdentityTypeRole, Name: "app-worker", RawRef: "raw-3"},
@@ -187,7 +187,7 @@ func TestMemoryStoreIdentityAndRelationshipFilters(t *testing.T) {
 		t.Fatalf("upsert artifacts scan B: %v", err)
 	}
 
-	identities, err := store.ListIdentities(context.Background(), IdentityFilter{ScanID: scanA.ID, NamePrefix: "app"}, 10)
+	identities, err := store.ListIdentities(defaultScopeContext(), IdentityFilter{ScanID: scanA.ID, NamePrefix: "app"}, 10)
 	if err != nil {
 		t.Fatalf("list identities: %v", err)
 	}
@@ -195,7 +195,7 @@ func TestMemoryStoreIdentityAndRelationshipFilters(t *testing.T) {
 		t.Fatalf("unexpected identities: %+v", identities)
 	}
 
-	relationships, err := store.ListRelationships(context.Background(), RelationshipFilter{Type: "can_access"}, 10)
+	relationships, err := store.ListRelationships(defaultScopeContext(), RelationshipFilter{Type: "can_access"}, 10)
 	if err != nil {
 		t.Fatalf("list relationships: %v", err)
 	}
@@ -206,11 +206,11 @@ func TestMemoryStoreIdentityAndRelationshipFilters(t *testing.T) {
 
 func TestMemoryStoreRejectsInvalidScanEventLevel(t *testing.T) {
 	store := NewMemoryStore()
-	scan, err := store.CreateScan(context.Background(), "aws", time.Now().UTC())
+	scan, err := store.CreateScan(defaultScopeContext(), "aws", time.Now().UTC())
 	if err != nil {
 		t.Fatalf("create scan: %v", err)
 	}
-	err = store.AppendScanEvent(context.Background(), scan.ID, "invalid", "bad level", nil)
+	err = store.AppendScanEvent(defaultScopeContext(), scan.ID, "invalid", "bad level", nil)
 	if err == nil {
 		t.Fatal("expected invalid event level error")
 	}
@@ -220,7 +220,7 @@ func TestMemoryStoreRepoScanLifecycle(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 17, 14, 0, 0, 0, time.UTC)
 
-	repoScan, err := store.CreateRepoScan(context.Background(), "owner/repo", now)
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", now)
 	if err != nil {
 		t.Fatalf("create repo scan: %v", err)
 	}
@@ -232,14 +232,14 @@ func TestMemoryStoreRepoScanLifecycle(t *testing.T) {
 		{ID: "rf-1", Type: domain.FindingSecretExposure, Severity: domain.SeverityHigh, Title: "secret", HumanSummary: "summary", CreatedAt: now},
 		{ID: "rf-2", Type: domain.FindingRepoMisconfig, Severity: domain.SeverityMedium, Title: "misconfig", HumanSummary: "summary", CreatedAt: now.Add(1 * time.Minute)},
 	}
-	if err := store.UpsertRepoFindings(context.Background(), repoScan.ID, findings); err != nil {
+	if err := store.UpsertRepoFindings(defaultScopeContext(), repoScan.ID, findings); err != nil {
 		t.Fatalf("upsert repo findings: %v", err)
 	}
-	if err := store.CompleteRepoScan(context.Background(), repoScan.ID, "completed", now.Add(2*time.Minute), 10, 6, 2, false, ""); err != nil {
+	if err := store.CompleteRepoScan(defaultScopeContext(), repoScan.ID, "completed", now.Add(2*time.Minute), 10, 6, 2, false, ""); err != nil {
 		t.Fatalf("complete repo scan: %v", err)
 	}
 
-	gotScan, err := store.GetRepoScan(context.Background(), repoScan.ID)
+	gotScan, err := store.GetRepoScan(defaultScopeContext(), repoScan.ID)
 	if err != nil {
 		t.Fatalf("get repo scan: %v", err)
 	}
@@ -247,7 +247,7 @@ func TestMemoryStoreRepoScanLifecycle(t *testing.T) {
 		t.Fatalf("unexpected repo scan record: %+v", gotScan)
 	}
 
-	storedFindings, err := store.ListRepoFindings(context.Background(), RepoFindingFilter{RepoScanID: repoScan.ID}, 10)
+	storedFindings, err := store.ListRepoFindings(defaultScopeContext(), RepoFindingFilter{RepoScanID: repoScan.ID}, 10)
 	if err != nil {
 		t.Fatalf("list repo findings: %v", err)
 	}
@@ -255,7 +255,7 @@ func TestMemoryStoreRepoScanLifecycle(t *testing.T) {
 		t.Fatalf("unexpected repo findings: %+v", storedFindings)
 	}
 
-	highOnly, err := store.ListRepoFindings(context.Background(), RepoFindingFilter{Severity: "high"}, 10)
+	highOnly, err := store.ListRepoFindings(defaultScopeContext(), RepoFindingFilter{Severity: "high"}, 10)
 	if err != nil {
 		t.Fatalf("list repo findings high-only: %v", err)
 	}
@@ -263,7 +263,7 @@ func TestMemoryStoreRepoScanLifecycle(t *testing.T) {
 		t.Fatalf("unexpected high severity findings: %+v", highOnly)
 	}
 
-	repoScans, err := store.ListRepoScans(context.Background(), 10)
+	repoScans, err := store.ListRepoScans(defaultScopeContext(), 10)
 	if err != nil {
 		t.Fatalf("list repo scans: %v", err)
 	}
@@ -274,16 +274,16 @@ func TestMemoryStoreRepoScanLifecycle(t *testing.T) {
 
 func TestMemoryStoreRepoScanErrors(t *testing.T) {
 	store := NewMemoryStore()
-	if _, err := store.GetRepoScan(context.Background(), "missing"); err == nil {
+	if _, err := store.GetRepoScan(defaultScopeContext(), "missing"); err == nil {
 		t.Fatal("expected missing repo scan error")
 	}
-	if err := store.UpsertRepoFindings(context.Background(), "missing", []domain.Finding{{ID: "x"}}); err == nil {
+	if err := store.UpsertRepoFindings(defaultScopeContext(), "missing", []domain.Finding{{ID: "x"}}); err == nil {
 		t.Fatal("expected missing repo scan error for findings upsert")
 	}
-	if err := store.CompleteRepoScan(context.Background(), "missing", "failed", time.Now(), 0, 0, 0, false, "boom"); err == nil {
+	if err := store.CompleteRepoScan(defaultScopeContext(), "missing", "failed", time.Now(), 0, 0, 0, false, "boom"); err == nil {
 		t.Fatal("expected missing repo scan error for completion")
 	}
-	if _, err := store.ListRepoFindings(context.Background(), RepoFindingFilter{RepoScanID: "missing"}, 10); err == nil {
+	if _, err := store.ListRepoFindings(defaultScopeContext(), RepoFindingFilter{RepoScanID: "missing"}, 10); err == nil {
 		t.Fatal("expected missing repo scan error for findings list")
 	}
 }
@@ -293,7 +293,7 @@ func TestMemoryStoreFindingTriageStateAndHistory(t *testing.T) {
 	now := time.Date(2026, 3, 28, 9, 0, 0, 0, time.UTC)
 	expiry := now.Add(24 * time.Hour)
 
-	if _, err := store.GetFindingTriageState(context.Background(), "finding-1"); err == nil {
+	if _, err := store.GetFindingTriageState(defaultScopeContext(), "finding-1"); err == nil {
 		t.Fatal("expected missing triage state error")
 	}
 
@@ -305,10 +305,10 @@ func TestMemoryStoreFindingTriageStateAndHistory(t *testing.T) {
 		UpdatedAt:            now,
 		UpdatedBy:            "subject:alice",
 	}
-	if err := store.UpsertFindingTriageState(context.Background(), state); err != nil {
+	if err := store.UpsertFindingTriageState(defaultScopeContext(), state); err != nil {
 		t.Fatalf("upsert triage state: %v", err)
 	}
-	gotState, err := store.GetFindingTriageState(context.Background(), "finding-1")
+	gotState, err := store.GetFindingTriageState(defaultScopeContext(), "finding-1")
 	if err != nil {
 		t.Fatalf("get triage state: %v", err)
 	}
@@ -316,7 +316,7 @@ func TestMemoryStoreFindingTriageStateAndHistory(t *testing.T) {
 		t.Fatalf("unexpected triage state: %+v", gotState)
 	}
 
-	states, err := store.ListFindingTriageStates(context.Background(), []string{"finding-1", "missing"})
+	states, err := store.ListFindingTriageStates(defaultScopeContext(), []string{"finding-1", "missing"})
 	if err != nil {
 		t.Fatalf("list triage states: %v", err)
 	}
@@ -343,13 +343,13 @@ func TestMemoryStoreFindingTriageStateAndHistory(t *testing.T) {
 		Actor:      "subject:bob",
 		CreatedAt:  now.Add(1 * time.Minute),
 	}
-	if err := store.AppendFindingTriageEvent(context.Background(), firstEvent); err != nil {
+	if err := store.AppendFindingTriageEvent(defaultScopeContext(), firstEvent); err != nil {
 		t.Fatalf("append first triage event: %v", err)
 	}
-	if err := store.AppendFindingTriageEvent(context.Background(), secondEvent); err != nil {
+	if err := store.AppendFindingTriageEvent(defaultScopeContext(), secondEvent); err != nil {
 		t.Fatalf("append second triage event: %v", err)
 	}
-	events, err := store.ListFindingTriageEvents(context.Background(), "finding-1", 10)
+	events, err := store.ListFindingTriageEvents(defaultScopeContext(), "finding-1", 10)
 	if err != nil {
 		t.Fatalf("list triage events: %v", err)
 	}
@@ -365,7 +365,7 @@ func TestMemoryStoreApplyFindingTriageTransitionAtomic(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 28, 12, 0, 0, 0, time.UTC)
 
-	err := store.ApplyFindingTriageTransition(context.Background(), FindingTriageState{
+	err := store.ApplyFindingTriageTransition(defaultScopeContext(), FindingTriageState{
 		FindingID: "finding-1",
 		Status:    domain.FindingLifecycleAck,
 		UpdatedAt: now,
@@ -380,10 +380,10 @@ func TestMemoryStoreApplyFindingTriageTransitionAtomic(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected mismatch error for triage transition")
 	}
-	if _, err := store.GetFindingTriageState(context.Background(), "finding-1"); err == nil {
+	if _, err := store.GetFindingTriageState(defaultScopeContext(), "finding-1"); err == nil {
 		t.Fatal("expected no state to be persisted after failed transition")
 	}
-	events, err := store.ListFindingTriageEvents(context.Background(), "finding-1", 10)
+	events, err := store.ListFindingTriageEvents(defaultScopeContext(), "finding-1", 10)
 	if err != nil {
 		t.Fatalf("list triage events after failed transition: %v", err)
 	}
@@ -395,28 +395,28 @@ func TestMemoryStoreApplyFindingTriageTransitionAtomic(t *testing.T) {
 func TestMemoryStoreScanQueueLifecycle(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 21, 9, 0, 0, 0, time.UTC)
-	queued, err := store.CreateQueuedScan(context.Background(), "aws", now)
+	queued, err := store.CreateQueuedScan(defaultScopeContext(), "aws", now)
 	if err != nil {
 		t.Fatalf("create queued scan: %v", err)
 	}
 	if queued.Status != "queued" {
 		t.Fatalf("expected queued status, got %q", queued.Status)
 	}
-	count, err := store.CountQueuedScans(context.Background(), "aws")
+	count, err := store.CountQueuedScans(defaultScopeContext(), "aws")
 	if err != nil {
 		t.Fatalf("count queued scans: %v", err)
 	}
 	if count != 1 {
 		t.Fatalf("expected queued count 1, got %d", count)
 	}
-	claimed, err := store.ClaimNextQueuedScan(context.Background(), "aws")
+	claimed, err := store.ClaimNextQueuedScan(defaultScopeContext(), "aws")
 	if err != nil {
 		t.Fatalf("claim queued scan: %v", err)
 	}
 	if claimed.ID != queued.ID || claimed.Status != "running" {
 		t.Fatalf("unexpected claimed scan %+v", claimed)
 	}
-	if _, err := store.ClaimNextQueuedScan(context.Background(), "aws"); err == nil {
+	if _, err := store.ClaimNextQueuedScan(defaultScopeContext(), "aws"); err == nil {
 		t.Fatal("expected no queued scan remaining")
 	}
 }
@@ -424,7 +424,7 @@ func TestMemoryStoreScanQueueLifecycle(t *testing.T) {
 func TestMemoryStoreRepoQueueLifecycle(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 21, 9, 5, 0, 0, time.UTC)
-	queued, err := store.CreateQueuedRepoScan(context.Background(), "owner/repo", 50, 80, now)
+	queued, err := store.CreateQueuedRepoScan(defaultScopeContext(), "owner/repo", 50, 80, now)
 	if err != nil {
 		t.Fatalf("create queued repo scan: %v", err)
 	}
@@ -434,34 +434,34 @@ func TestMemoryStoreRepoQueueLifecycle(t *testing.T) {
 	if queued.HistoryLimit != 50 || queued.MaxFindings != 80 {
 		t.Fatalf("expected queued limits retained, got %+v", queued)
 	}
-	queuedCount, err := store.CountQueuedRepoScans(context.Background())
+	queuedCount, err := store.CountQueuedRepoScans(defaultScopeContext())
 	if err != nil {
 		t.Fatalf("count queued repo scans: %v", err)
 	}
 	if queuedCount != 1 {
 		t.Fatalf("expected queued repo count 1, got %d", queuedCount)
 	}
-	pendingCount, err := store.CountPendingRepoScansByRepository(context.Background(), "owner/repo")
+	pendingCount, err := store.CountPendingRepoScansByRepository(defaultScopeContext(), "owner/repo")
 	if err != nil {
 		t.Fatalf("count pending repo scans: %v", err)
 	}
 	if pendingCount != 1 {
 		t.Fatalf("expected pending repo count 1, got %d", pendingCount)
 	}
-	if err := store.RequeueRepoScan(context.Background(), queued.ID); !errors.Is(err, ErrNotFound) {
+	if err := store.RequeueRepoScan(defaultScopeContext(), queued.ID); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected requeue to reject non-running record, got %v", err)
 	}
-	claimed, err := store.ClaimNextQueuedRepoScan(context.Background())
+	claimed, err := store.ClaimNextQueuedRepoScan(defaultScopeContext())
 	if err != nil {
 		t.Fatalf("claim queued repo scan: %v", err)
 	}
 	if claimed.ID != queued.ID || claimed.Status != "running" {
 		t.Fatalf("unexpected claimed repo scan %+v", claimed)
 	}
-	if err := store.RequeueRepoScan(context.Background(), claimed.ID); err != nil {
+	if err := store.RequeueRepoScan(defaultScopeContext(), claimed.ID); err != nil {
 		t.Fatalf("requeue repo scan: %v", err)
 	}
-	requeued, err := store.GetRepoScan(context.Background(), claimed.ID)
+	requeued, err := store.GetRepoScan(defaultScopeContext(), claimed.ID)
 	if err != nil {
 		t.Fatalf("get requeued repo scan: %v", err)
 	}
@@ -476,11 +476,11 @@ func TestMemoryStoreRepoQueueLifecycle(t *testing.T) {
 func TestMemoryStorePendingRepoCountMatchingIsCaseInsensitive(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 21, 9, 25, 0, 0, time.UTC)
-	if _, err := store.CreateQueuedRepoScan(context.Background(), "Owner/Repo", 10, 20, now); err != nil {
+	if _, err := store.CreateQueuedRepoScan(defaultScopeContext(), "Owner/Repo", 10, 20, now); err != nil {
 		t.Fatalf("create queued repo scan: %v", err)
 	}
 
-	count, err := store.CountPendingRepoScansByRepository(context.Background(), "owner/repo")
+	count, err := store.CountPendingRepoScansByRepository(defaultScopeContext(), "owner/repo")
 	if err != nil {
 		t.Fatalf("count pending repo scans: %v", err)
 	}
@@ -493,8 +493,8 @@ func TestMemoryStoreScopeIsolation(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 22, 10, 0, 0, 0, time.UTC)
 
-	defaultCtx := context.Background()
-	otherCtx := WithScope(context.Background(), Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
+	defaultCtx := defaultScopeContext()
+	otherCtx := WithScope(defaultScopeContext(), Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
 
 	defaultScan, err := store.CreateScan(defaultCtx, "aws", now)
 	if err != nil {
@@ -542,5 +542,12 @@ func TestMemoryStoreScopeIsolation(t *testing.T) {
 	}
 	if _, err := store.GetRepoScan(otherCtx, defaultRepo.ID); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected cross-scope get repo scan to fail with not found, got %v", err)
+	}
+}
+
+func TestMemoryStoreRequiresScopeContext(t *testing.T) {
+	store := NewMemoryStore()
+	if _, err := store.ListScans(context.Background(), 10); !errors.Is(err, ErrScopeRequired) {
+		t.Fatalf("expected ErrScopeRequired, got %v", err)
 	}
 }

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -117,3 +117,24 @@ func TestSixthMigrationContainsTenantWorkspaceScope(t *testing.T) {
 		}
 	}
 }
+
+func TestSeventhMigrationContainsScopedTriageGuardrails(t *testing.T) {
+	path := filepath.Join("..", "..", "migrations", "000007_scope_guardrails_for_triage.up.sql")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	text := string(content)
+	required := []string{
+		"ADD COLUMN IF NOT EXISTS tenant_id",
+		"ADD COLUMN IF NOT EXISTS workspace_id",
+		"PRIMARY KEY (tenant_id, workspace_id, finding_id)",
+		"idx_finding_triage_states_scope_status",
+		"idx_finding_triage_events_scope_finding_created",
+	}
+	for _, item := range required {
+		if !strings.Contains(text, item) {
+			t.Fatalf("expected scoped triage migration item %q", item)
+		}
+	}
+}

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -68,7 +68,10 @@ func (p *PostgresStore) CreateQueuedScan(ctx context.Context, provider string, q
 
 // ClaimNextQueuedScan atomically claims one queued scan for execution.
 func (p *PostgresStore) ClaimNextQueuedScan(ctx context.Context, provider string) (ScanRecord, error) {
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return ScanRecord{}, err
+	}
 	row := p.db.QueryRowContext(
 		ctx,
 		`WITH next_scan AS (
@@ -121,7 +124,10 @@ func (p *PostgresStore) ClaimNextQueuedScan(ctx context.Context, provider string
 
 // CountQueuedScans returns queued scan requests count for one provider.
 func (p *PostgresStore) CountQueuedScans(ctx context.Context, provider string) (int, error) {
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return 0, err
+	}
 	var count int
 	if err := p.db.QueryRowContext(
 		ctx,
@@ -142,7 +148,10 @@ func (p *PostgresStore) CountQueuedScans(ctx context.Context, provider string) (
 
 // GetScan returns one scan by id.
 func (p *PostgresStore) GetScan(ctx context.Context, scanID string) (ScanRecord, error) {
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return ScanRecord{}, err
+	}
 	row := p.db.QueryRowContext(
 		ctx,
 		`SELECT id, tenant_id, workspace_id, provider, status, started_at, finished_at, asset_count, finding_count, COALESCE(error_message, '')
@@ -166,7 +175,10 @@ func (p *PostgresStore) GetScan(ctx context.Context, scanID string) (ScanRecord,
 
 // CompleteScan updates scan completion metadata.
 func (p *PostgresStore) CompleteScan(ctx context.Context, scanID string, status string, finishedAt time.Time, assetCount int, findingCount int, errorMessage string) error {
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
 	result, err := p.db.ExecContext(
 		ctx,
 		`UPDATE scans
@@ -293,12 +305,20 @@ func (p *PostgresStore) UpsertFindings(ctx context.Context, scanID string, findi
 
 // GetFindingTriageState returns triage workflow state for one finding id.
 func (p *PostgresStore) GetFindingTriageState(ctx context.Context, findingID string) (FindingTriageState, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return FindingTriageState{}, err
+	}
 	row := p.db.QueryRowContext(
 		ctx,
 		`SELECT finding_id, status, assignee, suppression_expires_at, updated_at, updated_by
 		 FROM finding_triage_states
-		 WHERE finding_id = $1`,
+		 WHERE finding_id = $1
+		   AND tenant_id = $2
+		   AND workspace_id = $3`,
 		strings.TrimSpace(findingID),
+		scope.TenantID,
+		scope.WorkspaceID,
 	)
 	var state FindingTriageState
 	var suppressionExpiresAt sql.NullTime
@@ -325,6 +345,10 @@ func (p *PostgresStore) GetFindingTriageState(ctx context.Context, findingID str
 
 // ListFindingTriageStates returns triage states for provided finding ids.
 func (p *PostgresStore) ListFindingTriageStates(ctx context.Context, findingIDs []string) ([]FindingTriageState, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
 	unique := make([]string, 0, len(findingIDs))
 	seen := map[string]struct{}{}
 	for _, findingID := range findingIDs {
@@ -343,15 +367,18 @@ func (p *PostgresStore) ListFindingTriageStates(ctx context.Context, findingIDs 
 	}
 
 	placeholders := make([]string, len(unique))
-	args := make([]any, len(unique))
+	args := make([]any, 0, len(unique)+2)
+	args = append(args, scope.TenantID, scope.WorkspaceID)
 	for i, findingID := range unique {
-		placeholders[i] = fmt.Sprintf("$%d", i+1)
-		args[i] = findingID
+		placeholders[i] = fmt.Sprintf("$%d", i+3)
+		args = append(args, findingID)
 	}
 	query := fmt.Sprintf(
 		`SELECT finding_id, status, assignee, suppression_expires_at, updated_at, updated_by
 		 FROM finding_triage_states
-		 WHERE finding_id IN (%s)`,
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND finding_id IN (%s)`,
 		strings.Join(placeholders, ", "),
 	)
 	rows, err := p.db.QueryContext(ctx, query, args...)
@@ -393,21 +420,27 @@ func (p *PostgresStore) UpsertFindingTriageState(ctx context.Context, state Find
 }
 
 func (p *PostgresStore) upsertFindingTriageStateWithExecutor(ctx context.Context, executor sqlExecutor, state FindingTriageState) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
 	updatedAt := state.UpdatedAt
 	if updatedAt.IsZero() {
 		updatedAt = time.Now().UTC()
 	}
-	_, err := executor.ExecContext(
+	_, err = executor.ExecContext(
 		ctx,
-		`INSERT INTO finding_triage_states (finding_id, status, assignee, suppression_expires_at, updated_at, updated_by)
-		 VALUES ($1, $2, $3, $4, $5, $6)
-		 ON CONFLICT (finding_id)
+		`INSERT INTO finding_triage_states (tenant_id, workspace_id, finding_id, status, assignee, suppression_expires_at, updated_at, updated_by)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		 ON CONFLICT (tenant_id, workspace_id, finding_id)
 		 DO UPDATE SET
 		   status = EXCLUDED.status,
 		   assignee = EXCLUDED.assignee,
 		   suppression_expires_at = EXCLUDED.suppression_expires_at,
 		   updated_at = EXCLUDED.updated_at,
 		   updated_by = EXCLUDED.updated_by`,
+		scope.TenantID,
+		scope.WorkspaceID,
 		strings.TrimSpace(state.FindingID),
 		strings.TrimSpace(string(state.Status)),
 		strings.TrimSpace(state.Assignee),
@@ -427,6 +460,10 @@ func (p *PostgresStore) AppendFindingTriageEvent(ctx context.Context, event Find
 }
 
 func (p *PostgresStore) appendFindingTriageEventWithExecutor(ctx context.Context, executor sqlExecutor, event FindingTriageEvent) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
 	createdAt := event.CreatedAt
 	if createdAt.IsZero() {
 		createdAt = time.Now().UTC()
@@ -435,11 +472,13 @@ func (p *PostgresStore) appendFindingTriageEventWithExecutor(ctx context.Context
 	if eventID == "" {
 		eventID = uuid.NewString()
 	}
-	_, err := executor.ExecContext(
+	_, err = executor.ExecContext(
 		ctx,
-		`INSERT INTO finding_triage_events (id, finding_id, action, from_status, to_status, assignee, suppression_expires_at, comment, actor, created_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+		`INSERT INTO finding_triage_events (id, tenant_id, workspace_id, finding_id, action, from_status, to_status, assignee, suppression_expires_at, comment, actor, created_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
 		eventID,
+		scope.TenantID,
+		scope.WorkspaceID,
 		strings.TrimSpace(event.FindingID),
 		strings.TrimSpace(event.Action),
 		strings.TrimSpace(string(event.FromStatus)),
@@ -485,6 +524,10 @@ func (p *PostgresStore) ApplyFindingTriageTransition(ctx context.Context, state 
 
 // ListFindingTriageEvents returns triage history newest-first for one finding id.
 func (p *PostgresStore) ListFindingTriageEvents(ctx context.Context, findingID string, limit int) ([]FindingTriageEvent, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
 	const maxFindingTriageEventsLimit = 500
 	if limit <= 0 {
 		limit = 100
@@ -496,9 +539,13 @@ func (p *PostgresStore) ListFindingTriageEvents(ctx context.Context, findingID s
 		`SELECT id, finding_id, action, from_status, to_status, assignee, suppression_expires_at, comment, actor, created_at
 		 FROM finding_triage_events
 		 WHERE finding_id = $1
+		   AND tenant_id = $2
+		   AND workspace_id = $3
 		 ORDER BY created_at DESC
-		 LIMIT $2`,
+		 LIMIT $4`,
 		strings.TrimSpace(findingID),
+		scope.TenantID,
+		scope.WorkspaceID,
 		limit,
 	)
 	if err != nil {
@@ -542,7 +589,10 @@ func (p *PostgresStore) ListScans(ctx context.Context, limit int) ([]ScanRecord,
 	if limit <= 0 {
 		limit = 20
 	}
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
 	rows, err := p.db.QueryContext(
 		ctx,
 		`SELECT id, tenant_id, workspace_id, provider, status, started_at, finished_at, asset_count, finding_count, COALESCE(error_message, '')
@@ -578,7 +628,10 @@ func (p *PostgresStore) ListFindings(ctx context.Context, limit int) ([]domain.F
 	if limit <= 0 {
 		limit = 100
 	}
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
 	rows, err := p.db.QueryContext(
 		ctx,
 		`SELECT f.scan_id, f.finding_id, f.type, f.severity, f.title, f.human_summary, f.path, f.evidence, COALESCE(f.remediation, ''), f.created_at
@@ -607,7 +660,10 @@ func (p *PostgresStore) ListFindingsByScan(ctx context.Context, scanID string, l
 	if err := p.ensureScanInScope(ctx, scanID); err != nil {
 		return nil, err
 	}
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
 	rows, err := p.db.QueryContext(
 		ctx,
 		`SELECT f.scan_id, f.finding_id, f.type, f.severity, f.title, f.human_summary, f.path, f.evidence, COALESCE(f.remediation, ''), f.created_at
@@ -635,7 +691,10 @@ func (p *PostgresStore) ListIdentities(ctx context.Context, filter IdentityFilte
 	if limit <= 0 {
 		limit = 100
 	}
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if strings.TrimSpace(filter.ScanID) != "" {
 		if err := p.ensureScanInScope(ctx, filter.ScanID); err != nil {
 			return nil, err
@@ -704,7 +763,10 @@ func (p *PostgresStore) ListRelationships(ctx context.Context, filter Relationsh
 	if limit <= 0 {
 		limit = 100
 	}
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if strings.TrimSpace(filter.ScanID) != "" {
 		if err := p.ensureScanInScope(ctx, filter.ScanID); err != nil {
 			return nil, err
@@ -754,7 +816,10 @@ func (p *PostgresStore) ListRelationships(ctx context.Context, filter Relationsh
 
 // AppendScanEvent writes one scan event row.
 func (p *PostgresStore) AppendScanEvent(ctx context.Context, scanID string, level string, message string, metadata map[string]any) error {
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
 	normalizedLevel, levelErr := NormalizeScanEventLevel(strings.ToLower(strings.TrimSpace(level)))
 	if levelErr != nil {
 		return levelErr
@@ -796,7 +861,10 @@ func (p *PostgresStore) ListScanEvents(ctx context.Context, scanID string, limit
 	if err := p.ensureScanInScope(ctx, scanID); err != nil {
 		return nil, err
 	}
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
 	rows, err := p.db.QueryContext(
 		ctx,
 		`SELECT e.id, e.scan_id, e.level, e.message, e.metadata, e.created_at
@@ -855,7 +923,10 @@ func (p *PostgresStore) CreateQueuedRepoScan(ctx context.Context, repository str
 
 // ClaimNextQueuedRepoScan atomically claims one queued repository scan.
 func (p *PostgresStore) ClaimNextQueuedRepoScan(ctx context.Context) (RepoScanRecord, error) {
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return RepoScanRecord{}, err
+	}
 	row := p.db.QueryRowContext(
 		ctx,
 		`WITH next_repo_scan AS (
@@ -904,7 +975,10 @@ func (p *PostgresStore) ClaimNextQueuedRepoScan(ctx context.Context) (RepoScanRe
 
 // CountQueuedRepoScans returns queued repository scan requests count.
 func (p *PostgresStore) CountQueuedRepoScans(ctx context.Context) (int, error) {
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return 0, err
+	}
 	var count int
 	if err := p.db.QueryRowContext(
 		ctx,
@@ -923,7 +997,10 @@ func (p *PostgresStore) CountQueuedRepoScans(ctx context.Context) (int, error) {
 
 // CountPendingRepoScansByRepository returns queued+running scan count for one repository.
 func (p *PostgresStore) CountPendingRepoScansByRepository(ctx context.Context, repository string) (int, error) {
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return 0, err
+	}
 	var count int
 	if err := p.db.QueryRowContext(
 		ctx,
@@ -944,7 +1021,10 @@ func (p *PostgresStore) CountPendingRepoScansByRepository(ctx context.Context, r
 
 // RequeueRepoScan moves one running repository scan back to queued.
 func (p *PostgresStore) RequeueRepoScan(ctx context.Context, repoScanID string) error {
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
 	result, err := p.db.ExecContext(
 		ctx,
 		`UPDATE repo_scans
@@ -974,7 +1054,10 @@ func (p *PostgresStore) RequeueRepoScan(ctx context.Context, repoScanID string) 
 }
 
 func (p *PostgresStore) createRepoScanWithStatus(ctx context.Context, repository string, status string, historyLimit int, maxFindings int, startedAt time.Time) (RepoScanRecord, error) {
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return RepoScanRecord{}, err
+	}
 	record := RepoScanRecord{
 		ID:           uuid.NewString(),
 		TenantID:     scope.TenantID,
@@ -985,7 +1068,7 @@ func (p *PostgresStore) createRepoScanWithStatus(ctx context.Context, repository
 		HistoryLimit: historyLimit,
 		MaxFindings:  maxFindings,
 	}
-	_, err := p.db.ExecContext(
+	_, err = p.db.ExecContext(
 		ctx,
 		`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit)
 		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8)`,
@@ -1006,7 +1089,10 @@ func (p *PostgresStore) createRepoScanWithStatus(ctx context.Context, repository
 
 // GetRepoScan returns one repository scan by id.
 func (p *PostgresStore) GetRepoScan(ctx context.Context, repoScanID string) (RepoScanRecord, error) {
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return RepoScanRecord{}, err
+	}
 	row := p.db.QueryRowContext(
 		ctx,
 		`SELECT id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(error_message, ''), history_limit, max_findings_limit
@@ -1030,7 +1116,10 @@ func (p *PostgresStore) GetRepoScan(ctx context.Context, repoScanID string) (Rep
 
 // CompleteRepoScan updates repository scan completion metadata.
 func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, errorMessage string) error {
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
 	result, err := p.db.ExecContext(
 		ctx,
 		`UPDATE repo_scans
@@ -1131,7 +1220,10 @@ func (p *PostgresStore) ListRepoScans(ctx context.Context, limit int) ([]RepoSca
 	if limit <= 0 {
 		limit = 20
 	}
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
 	rows, err := p.db.QueryContext(
 		ctx,
 		`SELECT id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(error_message, ''), history_limit, max_findings_limit
@@ -1173,7 +1265,10 @@ func (p *PostgresStore) ListRepoFindings(ctx context.Context, filter RepoFinding
 			return nil, err
 		}
 	}
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
 	rows, err := p.db.QueryContext(
 		ctx,
 		`SELECT rf.repo_scan_id, rf.finding_id, rf.type, rf.severity, rf.title, rf.human_summary, rf.path, rf.evidence, COALESCE(rf.remediation, ''), rf.created_at
@@ -1431,7 +1526,10 @@ func upsertPermissions(ctx context.Context, tx *sql.Tx, scanID string, permissio
 }
 
 func (p *PostgresStore) createScanWithStatus(ctx context.Context, provider string, status string, startedAt time.Time) (ScanRecord, error) {
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return ScanRecord{}, err
+	}
 	record := ScanRecord{
 		ID:          uuid.NewString(),
 		TenantID:    scope.TenantID,
@@ -1440,7 +1538,7 @@ func (p *PostgresStore) createScanWithStatus(ctx context.Context, provider strin
 		Status:      strings.TrimSpace(status),
 		StartedAt:   startedAt.UTC(),
 	}
-	_, err := p.db.ExecContext(
+	_, err = p.db.ExecContext(
 		ctx,
 		`INSERT INTO scans (id, tenant_id, workspace_id, provider, status, started_at, asset_count, finding_count) VALUES ($1, $2, $3, $4, $5, $6, 0, 0)`,
 		record.ID,
@@ -1586,9 +1684,12 @@ func ensureRowsAffected(result sql.Result) error {
 }
 
 func (p *PostgresStore) ensureScanInScope(ctx context.Context, scanID string) error {
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
 	var exists bool
-	err := p.db.QueryRowContext(
+	err = p.db.QueryRowContext(
 		ctx,
 		`SELECT EXISTS (
 			SELECT 1
@@ -1611,9 +1712,12 @@ func (p *PostgresStore) ensureScanInScope(ctx context.Context, scanID string) er
 }
 
 func (p *PostgresStore) ensureRepoScanInScope(ctx context.Context, repoScanID string) error {
-	scope := ScopeFromContext(ctx)
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
 	var exists bool
-	err := p.db.QueryRowContext(
+	err = p.db.QueryRowContext(
 		ctx,
 		`SELECT EXISTS (
 			SELECT 1

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"regexp"
 	"testing"
 	"time"
@@ -25,7 +26,7 @@ func TestPostgresStoreCreateAndCompleteScan(t *testing.T) {
 		WithArgs(sqlmock.AnyArg(), "default", "default", "aws", "running", sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	scan, err := store.CreateScan(context.Background(), "aws", time.Now())
+	scan, err := store.CreateScan(defaultScopeContext(), "aws", time.Now())
 	if err != nil {
 		t.Fatalf("create scan failed: %v", err)
 	}
@@ -38,7 +39,7 @@ func TestPostgresStoreCreateAndCompleteScan(t *testing.T) {
 		WithArgs(scan.ID, "completed", sqlmock.AnyArg(), 2, 1, nil, "default", "default").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	if err := store.CompleteScan(context.Background(), scan.ID, "completed", time.Now(), 2, 1, ""); err != nil {
+	if err := store.CompleteScan(defaultScopeContext(), scan.ID, "completed", time.Now(), 2, 1, ""); err != nil {
 		t.Fatalf("complete scan failed: %v", err)
 	}
 
@@ -82,7 +83,7 @@ func TestPostgresStoreUpsertFindings(t *testing.T) {
 		CreatedAt:    time.Now(),
 	}}
 
-	if err := store.UpsertFindings(context.Background(), "scan-1", findings); err != nil {
+	if err := store.UpsertFindings(defaultScopeContext(), "scan-1", findings); err != nil {
 		t.Fatalf("upsert findings failed: %v", err)
 	}
 
@@ -118,7 +119,7 @@ func TestPostgresStoreUpsertArtifacts(t *testing.T) {
 	mock.ExpectExec("INSERT INTO permissions").WithArgs("scan-1", "a", "s3:GetObject", "*", "Allow").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
-	err = store.UpsertArtifacts(context.Background(), "scan-1", ScanArtifacts{
+	err = store.UpsertArtifacts(defaultScopeContext(), "scan-1", ScanArtifacts{
 		RawAssets: []providers.RawAsset{{
 			Kind:      "iam_role",
 			SourceID:  "arn:aws:iam::1:role/test",
@@ -155,7 +156,7 @@ func TestPostgresStoreListScansAndFindings(t *testing.T) {
 		AddRow("scan-1", "default", "default", "aws", "completed", now, now, 2, 1, "")
 	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, provider, status").WithArgs("default", "default", 20).WillReturnRows(scanRows)
 
-	scans, err := store.ListScans(context.Background(), 20)
+	scans, err := store.ListScans(defaultScopeContext(), 20)
 	if err != nil {
 		t.Fatalf("list scans failed: %v", err)
 	}
@@ -167,7 +168,7 @@ func TestPostgresStoreListScansAndFindings(t *testing.T) {
 		AddRow("scan-1", "f1", "ownerless_identity", "medium", "Ownerless", "summary", []byte("[\"x\"]"), []byte("{\"a\":1}"), "fix", now)
 	mock.ExpectQuery("SELECT f.scan_id, f.finding_id, f.type").WithArgs("default", "default", 100).WillReturnRows(findingsRows)
 
-	findings, err := store.ListFindings(context.Background(), 100)
+	findings, err := store.ListFindings(defaultScopeContext(), 100)
 	if err != nil {
 		t.Fatalf("list findings failed: %v", err)
 	}
@@ -194,7 +195,7 @@ func TestPostgresStoreGetScanAndFindingsByScan(t *testing.T) {
 		AddRow("scan-1", "default", "default", "aws", "completed", now, now, 2, 1, "")
 	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, provider, status").WithArgs("scan-1", "default", "default").WillReturnRows(scanRow)
 
-	scan, err := store.GetScan(context.Background(), "scan-1")
+	scan, err := store.GetScan(defaultScopeContext(), "scan-1")
 	if err != nil {
 		t.Fatalf("get scan failed: %v", err)
 	}
@@ -215,7 +216,7 @@ func TestPostgresStoreGetScanAndFindingsByScan(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
 	mock.ExpectQuery("SELECT f.scan_id, f.finding_id, f.type").WithArgs("scan-1", "default", "default", 100).WillReturnRows(findingsRows)
 
-	findings, err := store.ListFindingsByScan(context.Background(), "scan-1", 100)
+	findings, err := store.ListFindingsByScan(defaultScopeContext(), "scan-1", 100)
 	if err != nil {
 		t.Fatalf("list findings by scan failed: %v", err)
 	}
@@ -240,7 +241,7 @@ func TestPostgresStoreScanEvents(t *testing.T) {
 		WithArgs(sqlmock.AnyArg(), "scan-1", "info", "scan started", sqlmock.AnyArg(), "default", "default").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	if err := store.AppendScanEvent(context.Background(), "scan-1", "info", "scan started", map[string]any{"provider": "aws"}); err != nil {
+	if err := store.AppendScanEvent(defaultScopeContext(), "scan-1", "info", "scan started", map[string]any{"provider": "aws"}); err != nil {
 		t.Fatalf("append scan event failed: %v", err)
 	}
 
@@ -258,7 +259,7 @@ func TestPostgresStoreScanEvents(t *testing.T) {
 		AddRow("event-1", "scan-1", "info", "scan started", []byte(`{"provider":"aws"}`), now)
 	mock.ExpectQuery("SELECT e.id, e.scan_id, e.level, e.message, e.metadata, e.created_at").WithArgs("scan-1", "default", "default", 10).WillReturnRows(rows)
 
-	events, err := store.ListScanEvents(context.Background(), "scan-1", 10)
+	events, err := store.ListScanEvents(defaultScopeContext(), "scan-1", 10)
 	if err != nil {
 		t.Fatalf("list scan events failed: %v", err)
 	}
@@ -279,7 +280,7 @@ func TestPostgresStoreRejectsInvalidScanEventLevel(t *testing.T) {
 	defer db.Close()
 
 	store := NewPostgresStoreWithDB(db)
-	if err := store.AppendScanEvent(context.Background(), "scan-1", "invalid", "bad", nil); err == nil {
+	if err := store.AppendScanEvent(defaultScopeContext(), "scan-1", "invalid", "bad", nil); err == nil {
 		t.Fatal("expected invalid level error")
 	}
 }
@@ -298,7 +299,7 @@ func TestPostgresStoreListIdentitiesAndRelationships(t *testing.T) {
 		AddRow("id-1", "aws", "role", "app-role", "arn:aws:iam::1:role/app-role", "", now, nil, []byte(`{"team":"platform"}`), "raw-1")
 	mock.ExpectQuery("SELECT i.id, i.provider, i.type, i.name").WithArgs("", "aws", "role", "app", 20, "default", "default").WillReturnRows(identityRows)
 
-	identities, err := store.ListIdentities(context.Background(), IdentityFilter{
+	identities, err := store.ListIdentities(defaultScopeContext(), IdentityFilter{
 		Provider:   "aws",
 		Type:       "role",
 		NamePrefix: "app",
@@ -314,7 +315,7 @@ func TestPostgresStoreListIdentitiesAndRelationships(t *testing.T) {
 		AddRow("rel-1", "can_assume", "id-1", "id-2", "", now)
 	mock.ExpectQuery("SELECT r.id, r.type, r.from_node_id").WithArgs("", "can_assume", "", "", 30, "default", "default").WillReturnRows(relationshipRows)
 
-	relationships, err := store.ListRelationships(context.Background(), RelationshipFilter{Type: "can_assume"}, 30)
+	relationships, err := store.ListRelationships(defaultScopeContext(), RelationshipFilter{Type: "can_assume"}, 30)
 	if err != nil {
 		t.Fatalf("list relationships failed: %v", err)
 	}
@@ -349,7 +350,7 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "running", sqlmock.AnyArg(), 0, 0).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	record, err := store.CreateRepoScan(context.Background(), "owner/repo", now)
+	record, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", now)
 	if err != nil {
 		t.Fatalf("create repo scan failed: %v", err)
 	}
@@ -369,7 +370,7 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
-	if err := store.UpsertRepoFindings(context.Background(), record.ID, []domain.Finding{{
+	if err := store.UpsertRepoFindings(defaultScopeContext(), record.ID, []domain.Finding{{
 		ID:           "rf-1",
 		Type:         domain.FindingSecretExposure,
 		Severity:     domain.SeverityHigh,
@@ -397,14 +398,14 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		WithArgs(record.ID, "completed", sqlmock.AnyArg(), 12, 8, 1, false, nil, "default", "default").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	if err := store.CompleteRepoScan(context.Background(), record.ID, "completed", now, 12, 8, 1, false, ""); err != nil {
+	if err := store.CompleteRepoScan(defaultScopeContext(), record.ID, "completed", now, 12, 8, 1, false, ""); err != nil {
 		t.Fatalf("complete repo scan failed: %v", err)
 	}
 
 	repoScanRows := sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "error_message", "history_limit", "max_findings_limit"}).
 		AddRow(record.ID, "default", "default", "owner/repo", "completed", now, now, 12, 8, 1, false, "", 0, 0)
 	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, repository, status").WithArgs("default", "default", 20).WillReturnRows(repoScanRows)
-	repoScans, err := store.ListRepoScans(context.Background(), 20)
+	repoScans, err := store.ListRepoScans(defaultScopeContext(), 20)
 	if err != nil {
 		t.Fatalf("list repo scans failed: %v", err)
 	}
@@ -424,7 +425,7 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		WithArgs(record.ID, "default", "default").
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
 	mock.ExpectQuery("SELECT rf.repo_scan_id, rf.finding_id, rf.type").WithArgs(record.ID, "", "", 100, "default", "default").WillReturnRows(repoFindingsRows)
-	repoFindings, err := store.ListRepoFindings(context.Background(), RepoFindingFilter{RepoScanID: record.ID}, 100)
+	repoFindings, err := store.ListRepoFindings(defaultScopeContext(), RepoFindingFilter{RepoScanID: record.ID}, 100)
 	if err != nil {
 		t.Fatalf("list repo findings failed: %v", err)
 	}
@@ -435,7 +436,7 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 	repoScanRow := sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "error_message", "history_limit", "max_findings_limit"}).
 		AddRow(record.ID, "default", "default", "owner/repo", "completed", now, now, 12, 8, 1, false, "", 0, 0)
 	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, repository, status").WithArgs(record.ID, "default", "default").WillReturnRows(repoScanRow)
-	gotRepoScan, err := store.GetRepoScan(context.Background(), record.ID)
+	gotRepoScan, err := store.GetRepoScan(defaultScopeContext(), record.ID)
 	if err != nil {
 		t.Fatalf("get repo scan failed: %v", err)
 	}
@@ -460,10 +461,10 @@ func TestPostgresStoreFindingTriageStateAndHistory(t *testing.T) {
 	expiry := now.Add(2 * time.Hour)
 
 	mock.ExpectExec("INSERT INTO finding_triage_states").
-		WithArgs("finding-1", "ack", "sec-oncall", sqlmock.AnyArg(), sqlmock.AnyArg(), "subject:alice").
+		WithArgs("default", "default", "finding-1", "ack", "sec-oncall", sqlmock.AnyArg(), sqlmock.AnyArg(), "subject:alice").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	if err := store.UpsertFindingTriageState(context.Background(), FindingTriageState{
+	if err := store.UpsertFindingTriageState(defaultScopeContext(), FindingTriageState{
 		FindingID:            "finding-1",
 		Status:               domain.FindingLifecycleAck,
 		Assignee:             "sec-oncall",
@@ -477,10 +478,10 @@ func TestPostgresStoreFindingTriageStateAndHistory(t *testing.T) {
 	stateRows := sqlmock.NewRows([]string{"finding_id", "status", "assignee", "suppression_expires_at", "updated_at", "updated_by"}).
 		AddRow("finding-1", "ack", "sec-oncall", expiry, now, "subject:alice")
 	mock.ExpectQuery("SELECT finding_id, status, assignee, suppression_expires_at, updated_at, updated_by").
-		WithArgs("finding-1").
+		WithArgs("finding-1", "default", "default").
 		WillReturnRows(stateRows)
 
-	state, err := store.GetFindingTriageState(context.Background(), "finding-1")
+	state, err := store.GetFindingTriageState(defaultScopeContext(), "finding-1")
 	if err != nil {
 		t.Fatalf("get triage state failed: %v", err)
 	}
@@ -491,10 +492,10 @@ func TestPostgresStoreFindingTriageStateAndHistory(t *testing.T) {
 	listRows := sqlmock.NewRows([]string{"finding_id", "status", "assignee", "suppression_expires_at", "updated_at", "updated_by"}).
 		AddRow("finding-1", "ack", "sec-oncall", expiry, now, "subject:alice")
 	mock.ExpectQuery("SELECT finding_id, status, assignee, suppression_expires_at, updated_at, updated_by").
-		WithArgs("finding-1", "finding-2").
+		WithArgs("default", "default", "finding-1", "finding-2").
 		WillReturnRows(listRows)
 
-	states, err := store.ListFindingTriageStates(context.Background(), []string{"finding-1", "finding-2"})
+	states, err := store.ListFindingTriageStates(defaultScopeContext(), []string{"finding-1", "finding-2"})
 	if err != nil {
 		t.Fatalf("list triage states failed: %v", err)
 	}
@@ -503,10 +504,10 @@ func TestPostgresStoreFindingTriageStateAndHistory(t *testing.T) {
 	}
 
 	mock.ExpectExec("INSERT INTO finding_triage_events").
-		WithArgs(sqlmock.AnyArg(), "finding-1", FindingTriageActionAcknowledged, "open", "ack", "sec-oncall", sqlmock.AnyArg(), "accepted risk", "subject:alice", sqlmock.AnyArg()).
+		WithArgs(sqlmock.AnyArg(), "default", "default", "finding-1", FindingTriageActionAcknowledged, "open", "ack", "sec-oncall", sqlmock.AnyArg(), "accepted risk", "subject:alice", sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	if err := store.AppendFindingTriageEvent(context.Background(), FindingTriageEvent{
+	if err := store.AppendFindingTriageEvent(defaultScopeContext(), FindingTriageEvent{
 		FindingID:            "finding-1",
 		Action:               FindingTriageActionAcknowledged,
 		FromStatus:           domain.FindingLifecycleOpen,
@@ -524,10 +525,10 @@ func TestPostgresStoreFindingTriageStateAndHistory(t *testing.T) {
 		AddRow("evt-2", "finding-1", FindingTriageActionCommented, "ack", "ack", "sec-oncall", nil, "reviewed", "subject:bob", now.Add(2*time.Minute)).
 		AddRow("evt-1", "finding-1", FindingTriageActionAcknowledged, "open", "ack", "sec-oncall", expiry, "accepted risk", "subject:alice", now)
 	mock.ExpectQuery("SELECT id, finding_id, action, from_status, to_status, assignee, suppression_expires_at, comment, actor, created_at").
-		WithArgs("finding-1", 10).
+		WithArgs("finding-1", "default", "default", 10).
 		WillReturnRows(eventRows)
 
-	events, err := store.ListFindingTriageEvents(context.Background(), "finding-1", 10)
+	events, err := store.ListFindingTriageEvents(defaultScopeContext(), "finding-1", 10)
 	if err != nil {
 		t.Fatalf("list triage events failed: %v", err)
 	}
@@ -552,14 +553,14 @@ func TestPostgresStoreApplyFindingTriageTransition(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectExec("INSERT INTO finding_triage_states").
-		WithArgs("finding-1", "ack", "sec-oncall", nil, sqlmock.AnyArg(), "subject:alice").
+		WithArgs("default", "default", "finding-1", "ack", "sec-oncall", nil, sqlmock.AnyArg(), "subject:alice").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO finding_triage_events").
-		WithArgs(sqlmock.AnyArg(), "finding-1", FindingTriageActionAcknowledged, "open", "ack", "sec-oncall", nil, "acknowledged", "subject:alice", sqlmock.AnyArg()).
+		WithArgs(sqlmock.AnyArg(), "default", "default", "finding-1", FindingTriageActionAcknowledged, "open", "ack", "sec-oncall", nil, "acknowledged", "subject:alice", sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
-	err = store.ApplyFindingTriageTransition(context.Background(), FindingTriageState{
+	err = store.ApplyFindingTriageTransition(defaultScopeContext(), FindingTriageState{
 		FindingID: "finding-1",
 		Status:    domain.FindingLifecycleAck,
 		Assignee:  "sec-oncall",
@@ -596,14 +597,14 @@ func TestPostgresStoreApplyFindingTriageTransitionRollsBackOnEventFailure(t *tes
 
 	mock.ExpectBegin()
 	mock.ExpectExec("INSERT INTO finding_triage_states").
-		WithArgs("finding-1", "ack", "sec-oncall", nil, sqlmock.AnyArg(), "subject:alice").
+		WithArgs("default", "default", "finding-1", "ack", "sec-oncall", nil, sqlmock.AnyArg(), "subject:alice").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO finding_triage_events").
-		WithArgs(sqlmock.AnyArg(), "finding-1", FindingTriageActionAcknowledged, "open", "ack", "sec-oncall", nil, "acknowledged", "subject:alice", sqlmock.AnyArg()).
+		WithArgs(sqlmock.AnyArg(), "default", "default", "finding-1", FindingTriageActionAcknowledged, "open", "ack", "sec-oncall", nil, "acknowledged", "subject:alice", sqlmock.AnyArg()).
 		WillReturnError(sql.ErrTxDone)
 	mock.ExpectRollback()
 
-	err = store.ApplyFindingTriageTransition(context.Background(), FindingTriageState{
+	err = store.ApplyFindingTriageTransition(defaultScopeContext(), FindingTriageState{
 		FindingID: "finding-1",
 		Status:    domain.FindingLifecycleAck,
 		Assignee:  "sec-oncall",
@@ -642,7 +643,7 @@ func TestPostgresStoreScanQueueLifecycle(t *testing.T) {
 		WithArgs(sqlmock.AnyArg(), "default", "default", "aws", "queued", sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	queued, err := store.CreateQueuedScan(context.Background(), "aws", now)
+	queued, err := store.CreateQueuedScan(defaultScopeContext(), "aws", now)
 	if err != nil {
 		t.Fatalf("create queued scan failed: %v", err)
 	}
@@ -660,7 +661,7 @@ func TestPostgresStoreScanQueueLifecycle(t *testing.T) {
 		WithArgs("default", "default", "aws").
 		WillReturnRows(countRows)
 
-	count, err := store.CountQueuedScans(context.Background(), "aws")
+	count, err := store.CountQueuedScans(defaultScopeContext(), "aws")
 	if err != nil {
 		t.Fatalf("count queued scans failed: %v", err)
 	}
@@ -672,7 +673,7 @@ func TestPostgresStoreScanQueueLifecycle(t *testing.T) {
 		AddRow(queued.ID, "default", "default", "aws", "running", now, nil, 0, 0, "")
 	mock.ExpectQuery("WITH next_scan AS").WithArgs("default", "default", "aws").WillReturnRows(claimRows)
 
-	claimed, err := store.ClaimNextQueuedScan(context.Background(), "aws")
+	claimed, err := store.ClaimNextQueuedScan(defaultScopeContext(), "aws")
 	if err != nil {
 		t.Fatalf("claim queued scan failed: %v", err)
 	}
@@ -682,6 +683,19 @@ func TestPostgresStoreScanQueueLifecycle(t *testing.T) {
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreRequiresScopeContext(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	if _, err := store.ListScans(context.Background(), 10); !errors.Is(err, ErrScopeRequired) {
+		t.Fatalf("expected ErrScopeRequired, got %v", err)
 	}
 }
 
@@ -700,7 +714,7 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "queued", sqlmock.AnyArg(), 50, 80).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	queued, err := store.CreateQueuedRepoScan(context.Background(), "owner/repo", 50, 80, now)
+	queued, err := store.CreateQueuedRepoScan(defaultScopeContext(), "owner/repo", 50, 80, now)
 	if err != nil {
 		t.Fatalf("create queued repo scan failed: %v", err)
 	}
@@ -720,7 +734,7 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 		WithArgs("default", "default").
 		WillReturnRows(queuedCountRows)
 
-	queuedCount, err := store.CountQueuedRepoScans(context.Background())
+	queuedCount, err := store.CountQueuedRepoScans(defaultScopeContext())
 	if err != nil {
 		t.Fatalf("count queued repo scans failed: %v", err)
 	}
@@ -738,7 +752,7 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 		WithArgs("default", "default", "OWNER/REPO").
 		WillReturnRows(pendingRows)
 
-	pendingCount, err := store.CountPendingRepoScansByRepository(context.Background(), "OWNER/REPO")
+	pendingCount, err := store.CountPendingRepoScansByRepository(defaultScopeContext(), "OWNER/REPO")
 	if err != nil {
 		t.Fatalf("count pending repo scans failed: %v", err)
 	}
@@ -764,7 +778,7 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 	}).AddRow(queued.ID, "default", "default", "owner/repo", "running", now, nil, 0, 0, 0, false, "", 50, 80)
 	mock.ExpectQuery("WITH next_repo_scan AS").WithArgs("default", "default").WillReturnRows(claimRows)
 
-	claimed, err := store.ClaimNextQueuedRepoScan(context.Background())
+	claimed, err := store.ClaimNextQueuedRepoScan(defaultScopeContext())
 	if err != nil {
 		t.Fatalf("claim queued repo scan failed: %v", err)
 	}
@@ -784,7 +798,7 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 		WithArgs(claimed.ID, "default", "default").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	if err := store.RequeueRepoScan(context.Background(), claimed.ID); err != nil {
+	if err := store.RequeueRepoScan(defaultScopeContext(), claimed.ID); err != nil {
 		t.Fatalf("requeue repo scan failed: %v", err)
 	}
 

--- a/internal/db/scope.go
+++ b/internal/db/scope.go
@@ -65,6 +65,15 @@ func ScopeFromContext(ctx context.Context) Scope {
 	return Scope{}.Normalize()
 }
 
+// RequireScope returns the active scope and fails when context is unscoped.
+func RequireScope(ctx context.Context) (Scope, error) {
+	scope, ok := LookupScope(ctx)
+	if !ok {
+		return Scope{}, ErrScopeRequired
+	}
+	return scope.Normalize(), nil
+}
+
 // WithDefaultScope applies fallback scope only when context has no scope.
 func WithDefaultScope(ctx context.Context, fallback Scope) context.Context {
 	if _, ok := LookupScope(ctx); ok {

--- a/internal/db/scope_test.go
+++ b/internal/db/scope_test.go
@@ -33,3 +33,20 @@ func TestMatchScope(t *testing.T) {
 		t.Fatal("expected scope mismatch for workspace")
 	}
 }
+
+func TestRequireScopeMissing(t *testing.T) {
+	if _, err := RequireScope(context.Background()); err == nil {
+		t.Fatal("expected missing scope error")
+	}
+}
+
+func TestRequireScopeSuccess(t *testing.T) {
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		t.Fatalf("require scope: %v", err)
+	}
+	if scope.TenantID != "tenant-a" || scope.WorkspaceID != "workspace-a" {
+		t.Fatalf("unexpected scope: %+v", scope)
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -12,6 +12,9 @@ import (
 // ErrNotFound indicates the requested record does not exist.
 var ErrNotFound = errors.New("record not found")
 
+// ErrScopeRequired indicates tenant/workspace scope must be provided in context.
+var ErrScopeRequired = errors.New("scope is required")
+
 const (
 	ScanEventLevelDebug = "debug"
 	ScanEventLevelInfo  = "info"

--- a/internal/db/test_scope_context_test.go
+++ b/internal/db/test_scope_context_test.go
@@ -1,0 +1,7 @@
+package db
+
+import "context"
+
+func defaultScopeContext() context.Context {
+	return WithScope(context.Background(), Scope{})
+}

--- a/migrations/000007_scope_guardrails_for_triage.down.sql
+++ b/migrations/000007_scope_guardrails_for_triage.down.sql
@@ -11,11 +11,19 @@ CREATE INDEX IF NOT EXISTS idx_finding_triage_states_assignee
 CREATE INDEX IF NOT EXISTS idx_finding_triage_events_finding_created
     ON finding_triage_events (finding_id, created_at DESC);
 
-DELETE FROM finding_triage_states a
-USING finding_triage_states b
-WHERE a.finding_id = b.finding_id
-  AND (a.tenant_id, a.workspace_id) <> (b.tenant_id, b.workspace_id)
-  AND a.ctid < b.ctid;
+WITH ranked_states AS (
+    SELECT
+        ctid,
+        ROW_NUMBER() OVER (
+            PARTITION BY finding_id
+            ORDER BY updated_at DESC, tenant_id ASC, workspace_id ASC
+        ) AS row_rank
+    FROM finding_triage_states
+)
+DELETE FROM finding_triage_states s
+USING ranked_states r
+WHERE s.ctid = r.ctid
+  AND r.row_rank > 1;
 
 ALTER TABLE finding_triage_states
     DROP CONSTRAINT IF EXISTS finding_triage_states_pkey;

--- a/migrations/000007_scope_guardrails_for_triage.down.sql
+++ b/migrations/000007_scope_guardrails_for_triage.down.sql
@@ -1,0 +1,36 @@
+DROP INDEX IF EXISTS idx_finding_triage_events_scope_finding_created;
+DROP INDEX IF EXISTS idx_finding_triage_states_scope_assignee;
+DROP INDEX IF EXISTS idx_finding_triage_states_scope_status;
+
+CREATE INDEX IF NOT EXISTS idx_finding_triage_states_status
+    ON finding_triage_states (status);
+
+CREATE INDEX IF NOT EXISTS idx_finding_triage_states_assignee
+    ON finding_triage_states (assignee);
+
+CREATE INDEX IF NOT EXISTS idx_finding_triage_events_finding_created
+    ON finding_triage_events (finding_id, created_at DESC);
+
+DELETE FROM finding_triage_states a
+USING finding_triage_states b
+WHERE a.finding_id = b.finding_id
+  AND (a.tenant_id, a.workspace_id) <> (b.tenant_id, b.workspace_id)
+  AND a.ctid < b.ctid;
+
+ALTER TABLE finding_triage_states
+    DROP CONSTRAINT IF EXISTS finding_triage_states_pkey;
+
+ALTER TABLE finding_triage_states
+    ADD CONSTRAINT finding_triage_states_pkey PRIMARY KEY (finding_id);
+
+ALTER TABLE finding_triage_events
+    DROP COLUMN IF EXISTS workspace_id;
+
+ALTER TABLE finding_triage_events
+    DROP COLUMN IF EXISTS tenant_id;
+
+ALTER TABLE finding_triage_states
+    DROP COLUMN IF EXISTS workspace_id;
+
+ALTER TABLE finding_triage_states
+    DROP COLUMN IF EXISTS tenant_id;

--- a/migrations/000007_scope_guardrails_for_triage.up.sql
+++ b/migrations/000007_scope_guardrails_for_triage.up.sql
@@ -1,0 +1,46 @@
+ALTER TABLE finding_triage_states
+    ADD COLUMN IF NOT EXISTS tenant_id TEXT NOT NULL DEFAULT 'default';
+
+ALTER TABLE finding_triage_states
+    ADD COLUMN IF NOT EXISTS workspace_id TEXT NOT NULL DEFAULT 'default';
+
+ALTER TABLE finding_triage_events
+    ADD COLUMN IF NOT EXISTS tenant_id TEXT NOT NULL DEFAULT 'default';
+
+ALTER TABLE finding_triage_events
+    ADD COLUMN IF NOT EXISTS workspace_id TEXT NOT NULL DEFAULT 'default';
+
+UPDATE finding_triage_states
+SET tenant_id = 'default'
+WHERE COALESCE(TRIM(tenant_id), '') = '';
+
+UPDATE finding_triage_states
+SET workspace_id = 'default'
+WHERE COALESCE(TRIM(workspace_id), '') = '';
+
+UPDATE finding_triage_events
+SET tenant_id = 'default'
+WHERE COALESCE(TRIM(tenant_id), '') = '';
+
+UPDATE finding_triage_events
+SET workspace_id = 'default'
+WHERE COALESCE(TRIM(workspace_id), '') = '';
+
+ALTER TABLE finding_triage_states
+    DROP CONSTRAINT IF EXISTS finding_triage_states_pkey;
+
+ALTER TABLE finding_triage_states
+    ADD CONSTRAINT finding_triage_states_pkey PRIMARY KEY (tenant_id, workspace_id, finding_id);
+
+DROP INDEX IF EXISTS idx_finding_triage_states_status;
+DROP INDEX IF EXISTS idx_finding_triage_states_assignee;
+DROP INDEX IF EXISTS idx_finding_triage_events_finding_created;
+
+CREATE INDEX IF NOT EXISTS idx_finding_triage_states_scope_status
+    ON finding_triage_states (tenant_id, workspace_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_finding_triage_states_scope_assignee
+    ON finding_triage_states (tenant_id, workspace_id, assignee);
+
+CREATE INDEX IF NOT EXISTS idx_finding_triage_events_scope_finding_created
+    ON finding_triage_events (tenant_id, workspace_id, finding_id, created_at DESC);


### PR DESCRIPTION
## Summary
- scope triage state/event data by tenant/workspace (migration 000007)
- enforce fail-closed scope requirements in DB store methods
- add scoped triage query/write logic in Postgres and Memory stores
- update tests for explicit scoped context

## Test
- go test ./... -count=1
- go test -tags=integration ./internal/integration -count=1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces tenant/workspace isolation across triage data and scan workflows. All store operations now require an explicit scope and fail closed if missing; the migration adds scoped columns, keys, and indexes, and rollback dedupe is deterministic.

- **New Features**
  - Add `RequireScope` guard; unscoped calls return `ErrScopeRequired`.
  - Scope triage states/events and scan queue/claim/count by tenant/workspace in Postgres and Memory stores.
  - Add composite primary key and scoped indexes to prevent cross-tenant collisions.
  - Update tests to pass a scoped context.

- **Migration**
  - Run `000007_scope_guardrails_for_triage` to add `tenant_id`/`workspace_id`, composite PK, and scoped indexes; existing rows are backfilled to `default`.
  - Down migration performs deterministic dedupe to ensure stable rollback behavior.
  - Ensure callers pass a scoped context, e.g. `db.WithScope(ctx, db.Scope{TenantID: "...", WorkspaceID: "..."})`; unscoped calls now fail with `ErrScopeRequired`.

<sup>Written for commit c5aefe6c349517a6fbe1661ad63c8ae624b830d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

