### PR TITLE
Add Postgres RLS scope guardrails (PR-2B)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ const (
 	defaultWorkerAPIJobQueueBatchSize  = 5
 	defaultLockBackend                 = "auto"
 	defaultLockNamespace               = "identrail"
+	defaultPostgresRLSEnforced         = false
 	defaultTenantID                    = "default"
 	defaultWorkspaceID                 = "default"
 	defaultOIDCWriteScopes             = "identrail.write,identrail.admin,write,admin"
@@ -66,6 +67,7 @@ type Config struct {
 	RateLimitBurst             int
 	RunMigrations              bool
 	MigrationsDir              string
+	PostgresRLSEnforced        bool
 	AuditLogFile               string
 	AuditForwardURL            string
 	AuditForwardTimeout        time.Duration
@@ -132,6 +134,7 @@ func Load() Config {
 		RateLimitBurst:             parseInt(getEnv("IDENTRAIL_RATE_LIMIT_BURST", "20"), 20),
 		RunMigrations:              parseBool(getEnv("IDENTRAIL_RUN_MIGRATIONS", "true"), true),
 		MigrationsDir:              getEnv("IDENTRAIL_MIGRATIONS_DIR", "migrations"),
+		PostgresRLSEnforced:        parseBool(getEnv("IDENTRAIL_POSTGRES_RLS_ENFORCED", "false"), defaultPostgresRLSEnforced),
 		AuditLogFile:               getEnv("IDENTRAIL_AUDIT_LOG_FILE", ""),
 		AuditForwardURL:            getEnv("IDENTRAIL_AUDIT_FORWARD_URL", ""),
 		AuditForwardTimeout:        parseDuration(getEnv("IDENTRAIL_AUDIT_FORWARD_TIMEOUT", "3s"), 3*time.Second),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -31,6 +31,7 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("IDENTRAIL_RATE_LIMIT_BURST", "")
 	t.Setenv("IDENTRAIL_RUN_MIGRATIONS", "")
 	t.Setenv("IDENTRAIL_MIGRATIONS_DIR", "")
+	t.Setenv("IDENTRAIL_POSTGRES_RLS_ENFORCED", "")
 	t.Setenv("IDENTRAIL_AUDIT_LOG_FILE", "")
 	t.Setenv("IDENTRAIL_AUDIT_FORWARD_URL", "")
 	t.Setenv("IDENTRAIL_AUDIT_FORWARD_TIMEOUT", "")
@@ -135,6 +136,9 @@ func TestLoadDefaults(t *testing.T) {
 	}
 	if cfg.MigrationsDir != "migrations" {
 		t.Fatalf("unexpected migrations dir: %q", cfg.MigrationsDir)
+	}
+	if cfg.PostgresRLSEnforced {
+		t.Fatal("expected postgres rls enforcement disabled by default")
 	}
 	if cfg.AuditLogFile != "" {
 		t.Fatalf("expected empty audit log file, got %q", cfg.AuditLogFile)
@@ -274,6 +278,7 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("IDENTRAIL_RATE_LIMIT_BURST", "50")
 	t.Setenv("IDENTRAIL_RUN_MIGRATIONS", "false")
 	t.Setenv("IDENTRAIL_MIGRATIONS_DIR", "db/migrations")
+	t.Setenv("IDENTRAIL_POSTGRES_RLS_ENFORCED", "true")
 	t.Setenv("IDENTRAIL_AUDIT_LOG_FILE", "/tmp/audit.log")
 	t.Setenv("IDENTRAIL_AUDIT_FORWARD_URL", "https://audit.example.com/events")
 	t.Setenv("IDENTRAIL_AUDIT_FORWARD_TIMEOUT", "8s")
@@ -381,6 +386,9 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.MigrationsDir != "db/migrations" {
 		t.Fatalf("unexpected migrations dir: %q", cfg.MigrationsDir)
+	}
+	if !cfg.PostgresRLSEnforced {
+		t.Fatal("expected postgres rls enforcement enabled from env")
 	}
 	if cfg.AuditLogFile != "/tmp/audit.log" {
 		t.Fatalf("unexpected audit log file: %q", cfg.AuditLogFile)

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -138,3 +138,24 @@ func TestSeventhMigrationContainsScopedTriageGuardrails(t *testing.T) {
 		}
 	}
 }
+
+func TestEighthMigrationContainsPostgresRLSGuardrails(t *testing.T) {
+	path := filepath.Join("..", "..", "migrations", "000008_postgres_rls_scope_guardrails.up.sql")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	text := string(content)
+	required := []string{
+		"CREATE OR REPLACE FUNCTION identrail_rls_scope_matches",
+		"ALTER TABLE scans ENABLE ROW LEVEL SECURITY",
+		"CREATE POLICY scans_scope_isolation",
+		"CREATE POLICY repo_scans_scope_isolation",
+		"CREATE POLICY finding_triage_states_scope_isolation",
+	}
+	for _, item := range required {
+		if !strings.Contains(text, item) {
+			t.Fatalf("expected postgres rls migration item %q", item)
+		}
+	}
+}

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -41,6 +42,19 @@ func (e errScanner) Scan(_ ...any) error {
 }
 
 var placeholderPattern = regexp.MustCompile(`\$(\d+)`)
+
+var errQueryArgCapacityOverflow = errors.New("query argument capacity overflow")
+
+func checkedSliceCapacity(base int, extra int) (int, error) {
+	if base < 0 || extra < 0 {
+		return 0, fmt.Errorf("invalid slice capacity inputs")
+	}
+	maxInt := int(^uint(0) >> 1)
+	if base > maxInt-extra {
+		return 0, errQueryArgCapacityOverflow
+	}
+	return base + extra, nil
+}
 
 // NewPostgresStore opens a PostgreSQL connection and validates connectivity.
 func NewPostgresStore(databaseURL string) (*PostgresStore, error) {
@@ -133,7 +147,12 @@ func (p *PostgresStore) injectScopeCTE(ctx context.Context, query string, args [
 		query = "WITH " + scopeCTE + " " + query
 	}
 
-	scopedArgs := make([]any, 0, len(args)+3)
+	capacity, err := checkedSliceCapacity(len(args), 3)
+	if err != nil {
+		return "", nil, err
+	}
+
+	scopedArgs := make([]any, 0, capacity)
 	scopedArgs = append(scopedArgs, args...)
 	scopedArgs = append(scopedArgs, scope.TenantID, scope.WorkspaceID, "on")
 	return query, scopedArgs, nil

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -17,13 +19,28 @@ import (
 
 // PostgresStore persists scans/findings in PostgreSQL.
 type PostgresStore struct {
-	db      *sql.DB
-	queries *sqlcdb.Queries
+	db              *sql.DB
+	queries         *sqlcdb.Queries
+	enforceScopeRLS bool
 }
 
 type sqlExecutor interface {
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 }
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+type errScanner struct {
+	err error
+}
+
+func (e errScanner) Scan(_ ...any) error {
+	return e.err
+}
+
+var placeholderPattern = regexp.MustCompile(`\$(\d+)`)
 
 // NewPostgresStore opens a PostgreSQL connection and validates connectivity.
 func NewPostgresStore(databaseURL string) (*PostgresStore, error) {
@@ -56,6 +73,122 @@ func (p *PostgresStore) DB() *sql.DB {
 	return p.db
 }
 
+// SetScopeRLSEnforcement toggles statement-level RLS enforcement with scoped GUCs.
+func (p *PostgresStore) SetScopeRLSEnforcement(enabled bool) {
+	if p == nil {
+		return
+	}
+	p.enforceScopeRLS = enabled
+}
+
+// ScopeRLSEnforcementEnabled returns true when scoped RLS enforcement is enabled.
+func (p *PostgresStore) ScopeRLSEnforcementEnabled() bool {
+	if p == nil {
+		return false
+	}
+	return p.enforceScopeRLS
+}
+
+func (p *PostgresStore) injectScopeCTE(ctx context.Context, query string, args []any) (string, []any, error) {
+	if !p.enforceScopeRLS {
+		return query, args, nil
+	}
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return "", nil, err
+	}
+
+	maxPlaceholder := 0
+	for _, match := range placeholderPattern.FindAllStringSubmatch(query, -1) {
+		if len(match) != 2 {
+			continue
+		}
+		value, convErr := strconv.Atoi(match[1])
+		if convErr != nil {
+			continue
+		}
+		if value > maxPlaceholder {
+			maxPlaceholder = value
+		}
+	}
+
+	tenantPos := maxPlaceholder + 1
+	workspacePos := maxPlaceholder + 2
+	enforcePos := maxPlaceholder + 3
+	scopeCTE := fmt.Sprintf(
+		"_identrail_scope AS (SELECT set_config('identrail.tenant_id', $%d, true), set_config('identrail.workspace_id', $%d, true), set_config('identrail.rls_enforce', $%d, true))",
+		tenantPos,
+		workspacePos,
+		enforcePos,
+	)
+	trimmed := strings.TrimSpace(query)
+	upper := strings.ToUpper(trimmed)
+	if strings.HasPrefix(upper, "WITH RECURSIVE ") {
+		trimmed = strings.TrimSpace(trimmed[len("WITH RECURSIVE "):])
+		query = "WITH RECURSIVE " + scopeCTE + ", " + trimmed
+	} else if strings.HasPrefix(upper, "WITH ") {
+		trimmed = strings.TrimSpace(trimmed[5:])
+		query = "WITH " + scopeCTE + ", " + trimmed
+	} else {
+		query = "WITH " + scopeCTE + " " + query
+	}
+
+	scopedArgs := make([]any, 0, len(args)+3)
+	scopedArgs = append(scopedArgs, args...)
+	scopedArgs = append(scopedArgs, scope.TenantID, scope.WorkspaceID, "on")
+	return query, scopedArgs, nil
+}
+
+func (p *PostgresStore) execContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	scopedQuery, scopedArgs, err := p.injectScopeCTE(ctx, query, args)
+	if err != nil {
+		return nil, err
+	}
+	return p.db.ExecContext(ctx, scopedQuery, scopedArgs...)
+}
+
+func (p *PostgresStore) queryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	scopedQuery, scopedArgs, err := p.injectScopeCTE(ctx, query, args)
+	if err != nil {
+		return nil, err
+	}
+	return p.db.QueryContext(ctx, scopedQuery, scopedArgs...)
+}
+
+func (p *PostgresStore) queryRowContext(ctx context.Context, query string, args ...any) rowScanner {
+	scopedQuery, scopedArgs, err := p.injectScopeCTE(ctx, query, args)
+	if err != nil {
+		return errScanner{err: err}
+	}
+	return p.db.QueryRowContext(ctx, scopedQuery, scopedArgs...)
+}
+
+func (p *PostgresStore) beginTx(ctx context.Context) (*sql.Tx, error) {
+	tx, err := p.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	if !p.enforceScopeRLS {
+		return tx, nil
+	}
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, err
+	}
+	if _, err := tx.ExecContext(
+		ctx,
+		`SELECT set_config('identrail.tenant_id', $1, true), set_config('identrail.workspace_id', $2, true), set_config('identrail.rls_enforce', $3, true)`,
+		scope.TenantID,
+		scope.WorkspaceID,
+		"on",
+	); err != nil {
+		_ = tx.Rollback()
+		return nil, fmt.Errorf("set rls scope context: %w", err)
+	}
+	return tx, nil
+}
+
 // CreateScan inserts a new scan row.
 func (p *PostgresStore) CreateScan(ctx context.Context, provider string, startedAt time.Time) (ScanRecord, error) {
 	return p.createScanWithStatus(ctx, provider, "running", startedAt)
@@ -72,7 +205,7 @@ func (p *PostgresStore) ClaimNextQueuedScan(ctx context.Context, provider string
 	if err != nil {
 		return ScanRecord{}, err
 	}
-	row := p.db.QueryRowContext(
+	row := p.queryRowContext(
 		ctx,
 		`WITH next_scan AS (
 			SELECT id
@@ -129,7 +262,7 @@ func (p *PostgresStore) CountQueuedScans(ctx context.Context, provider string) (
 		return 0, err
 	}
 	var count int
-	if err := p.db.QueryRowContext(
+	if err := p.queryRowContext(
 		ctx,
 		`SELECT COUNT(*)
 		 FROM scans
@@ -152,7 +285,7 @@ func (p *PostgresStore) GetScan(ctx context.Context, scanID string) (ScanRecord,
 	if err != nil {
 		return ScanRecord{}, err
 	}
-	row := p.db.QueryRowContext(
+	row := p.queryRowContext(
 		ctx,
 		`SELECT id, tenant_id, workspace_id, provider, status, started_at, finished_at, asset_count, finding_count, COALESCE(error_message, '')
 		 FROM scans
@@ -179,7 +312,7 @@ func (p *PostgresStore) CompleteScan(ctx context.Context, scanID string, status 
 	if err != nil {
 		return err
 	}
-	result, err := p.db.ExecContext(
+	result, err := p.execContext(
 		ctx,
 		`UPDATE scans
 		 SET status=$2, finished_at=$3, asset_count=$4, finding_count=$5, error_message=$6
@@ -209,7 +342,7 @@ func (p *PostgresStore) UpsertArtifacts(ctx context.Context, scanID string, arti
 	if err := p.ensureScanInScope(ctx, scanID); err != nil {
 		return err
 	}
-	tx, err := p.db.BeginTx(ctx, nil)
+	tx, err := p.beginTx(ctx)
 	if err != nil {
 		return fmt.Errorf("begin artifacts transaction: %w", err)
 	}
@@ -242,7 +375,7 @@ func (p *PostgresStore) UpsertFindings(ctx context.Context, scanID string, findi
 	if err := p.ensureScanInScope(ctx, scanID); err != nil {
 		return err
 	}
-	tx, err := p.db.BeginTx(ctx, nil)
+	tx, err := p.beginTx(ctx)
 	if err != nil {
 		return fmt.Errorf("begin transaction: %w", err)
 	}
@@ -309,7 +442,7 @@ func (p *PostgresStore) GetFindingTriageState(ctx context.Context, findingID str
 	if err != nil {
 		return FindingTriageState{}, err
 	}
-	row := p.db.QueryRowContext(
+	row := p.queryRowContext(
 		ctx,
 		`SELECT finding_id, status, assignee, suppression_expires_at, updated_at, updated_by
 		 FROM finding_triage_states
@@ -381,7 +514,7 @@ func (p *PostgresStore) ListFindingTriageStates(ctx context.Context, findingIDs 
 		   AND finding_id IN (%s)`,
 		strings.Join(placeholders, ", "),
 	)
-	rows, err := p.db.QueryContext(ctx, query, args...)
+	rows, err := p.queryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("query finding triage states: %w", err)
 	}
@@ -504,7 +637,7 @@ func (p *PostgresStore) ApplyFindingTriageTransition(ctx context.Context, state 
 		return fmt.Errorf("finding id mismatch between state and event")
 	}
 
-	tx, err := p.db.BeginTx(ctx, nil)
+	tx, err := p.beginTx(ctx)
 	if err != nil {
 		return fmt.Errorf("begin triage transition tx: %w", err)
 	}
@@ -534,7 +667,7 @@ func (p *PostgresStore) ListFindingTriageEvents(ctx context.Context, findingID s
 	} else if limit > maxFindingTriageEventsLimit {
 		limit = maxFindingTriageEventsLimit
 	}
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT id, finding_id, action, from_status, to_status, assignee, suppression_expires_at, comment, actor, created_at
 		 FROM finding_triage_events
@@ -593,7 +726,7 @@ func (p *PostgresStore) ListScans(ctx context.Context, limit int) ([]ScanRecord,
 	if err != nil {
 		return nil, err
 	}
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT id, tenant_id, workspace_id, provider, status, started_at, finished_at, asset_count, finding_count, COALESCE(error_message, '')
 		 FROM scans
@@ -632,7 +765,7 @@ func (p *PostgresStore) ListFindings(ctx context.Context, limit int) ([]domain.F
 	if err != nil {
 		return nil, err
 	}
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT f.scan_id, f.finding_id, f.type, f.severity, f.title, f.human_summary, f.path, f.evidence, COALESCE(f.remediation, ''), f.created_at
 		 FROM findings f
@@ -664,7 +797,7 @@ func (p *PostgresStore) ListFindingsByScan(ctx context.Context, scanID string, l
 	if err != nil {
 		return nil, err
 	}
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT f.scan_id, f.finding_id, f.type, f.severity, f.title, f.human_summary, f.path, f.evidence, COALESCE(f.remediation, ''), f.created_at
 		 FROM findings f
@@ -700,7 +833,7 @@ func (p *PostgresStore) ListIdentities(ctx context.Context, filter IdentityFilte
 			return nil, err
 		}
 	}
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT i.id, i.provider, i.type, i.name, COALESCE(i.arn, ''), COALESCE(i.owner_hint, ''), i.created_at, i.last_used_at, i.tags, i.raw_ref
 		 FROM identities i
@@ -772,7 +905,7 @@ func (p *PostgresStore) ListRelationships(ctx context.Context, filter Relationsh
 			return nil, err
 		}
 	}
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT r.id, r.type, r.from_node_id, r.to_node_id, COALESCE(r.evidence_ref, ''), r.discovered_at
 		 FROM relationships r
@@ -828,7 +961,7 @@ func (p *PostgresStore) AppendScanEvent(ctx context.Context, scanID string, leve
 	if err != nil {
 		return fmt.Errorf("marshal scan event metadata: %w", err)
 	}
-	result, err := p.db.ExecContext(
+	result, err := p.execContext(
 		ctx,
 		`INSERT INTO scan_events (id, scan_id, level, message, metadata, created_at)
 		 SELECT $1, $2, $3, $4, $5, NOW()
@@ -865,7 +998,7 @@ func (p *PostgresStore) ListScanEvents(ctx context.Context, scanID string, limit
 	if err != nil {
 		return nil, err
 	}
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT e.id, e.scan_id, e.level, e.message, e.metadata, e.created_at
 		 FROM scan_events e
@@ -927,7 +1060,7 @@ func (p *PostgresStore) ClaimNextQueuedRepoScan(ctx context.Context) (RepoScanRe
 	if err != nil {
 		return RepoScanRecord{}, err
 	}
-	row := p.db.QueryRowContext(
+	row := p.queryRowContext(
 		ctx,
 		`WITH next_repo_scan AS (
 			SELECT id
@@ -980,7 +1113,7 @@ func (p *PostgresStore) CountQueuedRepoScans(ctx context.Context) (int, error) {
 		return 0, err
 	}
 	var count int
-	if err := p.db.QueryRowContext(
+	if err := p.queryRowContext(
 		ctx,
 		`SELECT COUNT(*)
 		 FROM repo_scans
@@ -1002,7 +1135,7 @@ func (p *PostgresStore) CountPendingRepoScansByRepository(ctx context.Context, r
 		return 0, err
 	}
 	var count int
-	if err := p.db.QueryRowContext(
+	if err := p.queryRowContext(
 		ctx,
 		`SELECT COUNT(*)
 		 FROM repo_scans
@@ -1025,7 +1158,7 @@ func (p *PostgresStore) RequeueRepoScan(ctx context.Context, repoScanID string) 
 	if err != nil {
 		return err
 	}
-	result, err := p.db.ExecContext(
+	result, err := p.execContext(
 		ctx,
 		`UPDATE repo_scans
 		 SET status = 'queued',
@@ -1068,7 +1201,7 @@ func (p *PostgresStore) createRepoScanWithStatus(ctx context.Context, repository
 		HistoryLimit: historyLimit,
 		MaxFindings:  maxFindings,
 	}
-	_, err = p.db.ExecContext(
+	_, err = p.execContext(
 		ctx,
 		`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit)
 		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8)`,
@@ -1093,7 +1226,7 @@ func (p *PostgresStore) GetRepoScan(ctx context.Context, repoScanID string) (Rep
 	if err != nil {
 		return RepoScanRecord{}, err
 	}
-	row := p.db.QueryRowContext(
+	row := p.queryRowContext(
 		ctx,
 		`SELECT id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(error_message, ''), history_limit, max_findings_limit
 		 FROM repo_scans
@@ -1120,7 +1253,7 @@ func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string,
 	if err != nil {
 		return err
 	}
-	result, err := p.db.ExecContext(
+	result, err := p.execContext(
 		ctx,
 		`UPDATE repo_scans
 		 SET status = $2,
@@ -1158,7 +1291,7 @@ func (p *PostgresStore) UpsertRepoFindings(ctx context.Context, repoScanID strin
 	if err := p.ensureRepoScanInScope(ctx, repoScanID); err != nil {
 		return err
 	}
-	tx, err := p.db.BeginTx(ctx, nil)
+	tx, err := p.beginTx(ctx)
 	if err != nil {
 		return fmt.Errorf("begin repo findings transaction: %w", err)
 	}
@@ -1224,7 +1357,7 @@ func (p *PostgresStore) ListRepoScans(ctx context.Context, limit int) ([]RepoSca
 	if err != nil {
 		return nil, err
 	}
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(error_message, ''), history_limit, max_findings_limit
 		 FROM repo_scans
@@ -1269,7 +1402,7 @@ func (p *PostgresStore) ListRepoFindings(ctx context.Context, filter RepoFinding
 	if err != nil {
 		return nil, err
 	}
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT rf.repo_scan_id, rf.finding_id, rf.type, rf.severity, rf.title, rf.human_summary, rf.path, rf.evidence, COALESCE(rf.remediation, ''), rf.created_at
 		 FROM repo_findings rf
@@ -1538,7 +1671,7 @@ func (p *PostgresStore) createScanWithStatus(ctx context.Context, provider strin
 		Status:      strings.TrimSpace(status),
 		StartedAt:   startedAt.UTC(),
 	}
-	_, err = p.db.ExecContext(
+	_, err = p.execContext(
 		ctx,
 		`INSERT INTO scans (id, tenant_id, workspace_id, provider, status, started_at, asset_count, finding_count) VALUES ($1, $2, $3, $4, $5, $6, 0, 0)`,
 		record.ID,
@@ -1689,7 +1822,7 @@ func (p *PostgresStore) ensureScanInScope(ctx context.Context, scanID string) er
 		return err
 	}
 	var exists bool
-	err = p.db.QueryRowContext(
+	err = p.queryRowContext(
 		ctx,
 		`SELECT EXISTS (
 			SELECT 1
@@ -1717,7 +1850,7 @@ func (p *PostgresStore) ensureRepoScanInScope(ctx context.Context, repoScanID st
 		return err
 	}
 	var exists bool
-	err = p.db.QueryRowContext(
+	err = p.queryRowContext(
 		ctx,
 		`SELECT EXISTS (
 			SELECT 1

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -945,4 +945,56 @@ func TestCheckedSliceCapacity(t *testing.T) {
 	if _, err := checkedSliceCapacity(maxInt, 1); !errors.Is(err, errQueryArgCapacityOverflow) {
 		t.Fatalf("expected overflow error, got %v", err)
 	}
+
+	if _, err := checkedSliceCapacity(-1, 1); err == nil {
+		t.Fatal("expected invalid input error")
+	}
+}
+
+func TestPostgresStoreDBAndScopeFlagHelpers(t *testing.T) {
+	var nilStore *PostgresStore
+	if got := nilStore.DB(); got != nil {
+		t.Fatalf("expected nil DB from nil store, got %v", got)
+	}
+	if nilStore.ScopeRLSEnforcementEnabled() {
+		t.Fatal("expected nil store scope rls enforcement to be false")
+	}
+
+	sqlDB := &sql.DB{}
+	store := NewPostgresStoreWithDB(sqlDB)
+	if got := store.DB(); got != sqlDB {
+		t.Fatalf("expected DB pointer to match")
+	}
+	if store.ScopeRLSEnforcementEnabled() {
+		t.Fatal("expected scope rls enforcement disabled by default")
+	}
+
+	store.SetScopeRLSEnforcement(true)
+	if !store.ScopeRLSEnforcementEnabled() {
+		t.Fatal("expected scope rls enforcement enabled")
+	}
+}
+
+func TestPostgresStoreWrapperScopeErrors(t *testing.T) {
+	store := &PostgresStore{}
+	store.SetScopeRLSEnforcement(true)
+
+	if _, err := store.execContext(context.Background(), "SELECT 1"); !errors.Is(err, ErrScopeRequired) {
+		t.Fatalf("expected ErrScopeRequired from execContext, got %v", err)
+	}
+	if _, err := store.queryContext(context.Background(), "SELECT 1"); !errors.Is(err, ErrScopeRequired) {
+		t.Fatalf("expected ErrScopeRequired from queryContext, got %v", err)
+	}
+	if err := store.queryRowContext(context.Background(), "SELECT 1").Scan(new(int)); !errors.Is(err, ErrScopeRequired) {
+		t.Fatalf("expected ErrScopeRequired from queryRowContext scan, got %v", err)
+	}
+}
+
+func TestErrorsIsNoRows(t *testing.T) {
+	if !errorsIsNoRows(sql.ErrNoRows) {
+		t.Fatal("expected true for sql.ErrNoRows")
+	}
+	if errorsIsNoRows(errors.New("different error")) {
+		t.Fatal("expected false for non-no-rows error")
+	}
 }

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"reflect"
 	"regexp"
 	"testing"
 	"time"
@@ -800,6 +801,130 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 
 	if err := store.RequeueRepoScan(defaultScopeContext(), claimed.ID); err != nil {
 		t.Fatalf("requeue repo scan failed: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreInjectScopeCTEBypassWhenDisabled(t *testing.T) {
+	store := &PostgresStore{}
+	query := "SELECT id FROM scans WHERE tenant_id = $1"
+	args := []any{"tenant-a"}
+
+	gotQuery, gotArgs, err := store.injectScopeCTE(defaultScopeContext(), query, args)
+	if err != nil {
+		t.Fatalf("inject scope cte: %v", err)
+	}
+	if gotQuery != query {
+		t.Fatalf("expected query unchanged, got %q", gotQuery)
+	}
+	if !reflect.DeepEqual(gotArgs, args) {
+		t.Fatalf("expected args unchanged, got %+v", gotArgs)
+	}
+}
+
+func TestPostgresStoreInjectScopeCTERewritesQueryWhenEnabled(t *testing.T) {
+	store := &PostgresStore{}
+	store.SetScopeRLSEnforcement(true)
+
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	query := "SELECT id FROM scans WHERE tenant_id = $1 AND workspace_id = $2 LIMIT $3"
+	args := []any{"tenant-a", "workspace-a", 10}
+
+	gotQuery, gotArgs, err := store.injectScopeCTE(ctx, query, args)
+	if err != nil {
+		t.Fatalf("inject scope cte: %v", err)
+	}
+
+	expectedQuery := "WITH _identrail_scope AS (SELECT set_config('identrail.tenant_id', $4, true), set_config('identrail.workspace_id', $5, true), set_config('identrail.rls_enforce', $6, true)) " + query
+	if gotQuery != expectedQuery {
+		t.Fatalf("unexpected rewritten query:\nexpected: %s\ngot:      %s", expectedQuery, gotQuery)
+	}
+
+	expectedArgs := []any{"tenant-a", "workspace-a", 10, "tenant-a", "workspace-a", "on"}
+	if !reflect.DeepEqual(gotArgs, expectedArgs) {
+		t.Fatalf("unexpected rewritten args: %+v", gotArgs)
+	}
+}
+
+func TestPostgresStoreInjectScopeCTEHandlesWithRecursive(t *testing.T) {
+	store := &PostgresStore{}
+	store.SetScopeRLSEnforcement(true)
+
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	query := "WITH RECURSIVE chain AS (SELECT 1 AS n) SELECT n FROM chain"
+
+	gotQuery, gotArgs, err := store.injectScopeCTE(ctx, query, nil)
+	if err != nil {
+		t.Fatalf("inject scope cte: %v", err)
+	}
+
+	expectedQuery := "WITH RECURSIVE _identrail_scope AS (SELECT set_config('identrail.tenant_id', $1, true), set_config('identrail.workspace_id', $2, true), set_config('identrail.rls_enforce', $3, true)), chain AS (SELECT 1 AS n) SELECT n FROM chain"
+	if gotQuery != expectedQuery {
+		t.Fatalf("unexpected recursive rewritten query:\nexpected: %s\ngot:      %s", expectedQuery, gotQuery)
+	}
+
+	expectedArgs := []any{"tenant-a", "workspace-a", "on"}
+	if !reflect.DeepEqual(gotArgs, expectedArgs) {
+		t.Fatalf("unexpected rewritten args: %+v", gotArgs)
+	}
+}
+
+func TestPostgresStoreInjectScopeCTERequiresScopeWhenEnabled(t *testing.T) {
+	store := &PostgresStore{}
+	store.SetScopeRLSEnforcement(true)
+
+	if _, _, err := store.injectScopeCTE(context.Background(), "SELECT 1", nil); !errors.Is(err, ErrScopeRequired) {
+		t.Fatalf("expected ErrScopeRequired, got %v", err)
+	}
+}
+
+func TestPostgresStoreBeginTxSetsRLSScopeContext(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	store.SetScopeRLSEnforcement(true)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(`SELECT set_config('identrail.tenant_id', $1, true), set_config('identrail.workspace_id', $2, true), set_config('identrail.rls_enforce', $3, true)`)).
+		WithArgs("default", "default", "on").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectRollback()
+
+	tx, err := store.beginTx(defaultScopeContext())
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback tx: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreBeginTxRequiresScopeWhenRLSEnabled(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	store.SetScopeRLSEnforcement(true)
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	if _, err := store.beginTx(context.Background()); !errors.Is(err, ErrScopeRequired) {
+		t.Fatalf("expected ErrScopeRequired, got %v", err)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -931,3 +931,18 @@ func TestPostgresStoreBeginTxRequiresScopeWhenRLSEnabled(t *testing.T) {
 		t.Fatalf("unmet expectations: %v", err)
 	}
 }
+
+func TestCheckedSliceCapacity(t *testing.T) {
+	got, err := checkedSliceCapacity(4, 3)
+	if err != nil {
+		t.Fatalf("checked slice capacity: %v", err)
+	}
+	if got != 7 {
+		t.Fatalf("expected capacity 7, got %d", got)
+	}
+
+	maxInt := int(^uint(0) >> 1)
+	if _, err := checkedSliceCapacity(maxInt, 1); !errors.Is(err, errQueryArgCapacityOverflow) {
+		t.Fatalf("expected overflow error, got %v", err)
+	}
+}

--- a/internal/runtime/service_builder.go
+++ b/internal/runtime/service_builder.go
@@ -35,6 +35,7 @@ func BuildScanService(cfg config.Config) (*api.Service, func() error, error) {
 				return nil, nil, fmt.Errorf("apply migrations: %w", migrateErr)
 			}
 		}
+		pgStore.SetScopeRLSEnforcement(cfg.PostgresRLSEnforced)
 		store = pgStore
 	}
 

--- a/migrations/000008_postgres_rls_scope_guardrails.down.sql
+++ b/migrations/000008_postgres_rls_scope_guardrails.down.sql
@@ -1,0 +1,55 @@
+DROP POLICY IF EXISTS finding_triage_events_scope_isolation ON finding_triage_events;
+ALTER TABLE finding_triage_events NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE finding_triage_events DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS finding_triage_states_scope_isolation ON finding_triage_states;
+ALTER TABLE finding_triage_states NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE finding_triage_states DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS repo_findings_scope_isolation ON repo_findings;
+ALTER TABLE repo_findings NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE repo_findings DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS repo_scans_scope_isolation ON repo_scans;
+ALTER TABLE repo_scans NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE repo_scans DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS ownership_signals_scope_isolation ON ownership_signals;
+ALTER TABLE ownership_signals NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE ownership_signals DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS scan_events_scope_isolation ON scan_events;
+ALTER TABLE scan_events NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE scan_events DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS findings_scope_isolation ON findings;
+ALTER TABLE findings NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE findings DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS permissions_scope_isolation ON permissions;
+ALTER TABLE permissions NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE permissions DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS relationships_scope_isolation ON relationships;
+ALTER TABLE relationships NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE relationships DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS policies_scope_isolation ON policies;
+ALTER TABLE policies NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE policies DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS identities_scope_isolation ON identities;
+ALTER TABLE identities NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE identities DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS raw_assets_scope_isolation ON raw_assets;
+ALTER TABLE raw_assets NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE raw_assets DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS scans_scope_isolation ON scans;
+ALTER TABLE scans NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE scans DISABLE ROW LEVEL SECURITY;
+
+DROP FUNCTION IF EXISTS identrail_rls_repo_scan_scope_matches(UUID);
+DROP FUNCTION IF EXISTS identrail_rls_scan_scope_matches(UUID);
+DROP FUNCTION IF EXISTS identrail_rls_scope_matches(TEXT, TEXT);

--- a/migrations/000008_postgres_rls_scope_guardrails.up.sql
+++ b/migrations/000008_postgres_rls_scope_guardrails.up.sql
@@ -1,0 +1,131 @@
+CREATE OR REPLACE FUNCTION identrail_rls_scope_matches(row_tenant TEXT, row_workspace TEXT)
+RETURNS BOOLEAN
+LANGUAGE SQL
+STABLE
+AS $$
+    SELECT
+        COALESCE(current_setting('identrail.rls_enforce', true), 'off') <> 'on'
+        OR (
+            NULLIF(current_setting('identrail.tenant_id', true), '') IS NOT NULL
+            AND NULLIF(current_setting('identrail.workspace_id', true), '') IS NOT NULL
+            AND row_tenant = current_setting('identrail.tenant_id', true)
+            AND row_workspace = current_setting('identrail.workspace_id', true)
+        );
+$$;
+
+CREATE OR REPLACE FUNCTION identrail_rls_scan_scope_matches(scan_uuid UUID)
+RETURNS BOOLEAN
+LANGUAGE SQL
+STABLE
+AS $$
+    SELECT EXISTS (
+        SELECT 1
+        FROM scans s
+        WHERE s.id = scan_uuid
+          AND identrail_rls_scope_matches(s.tenant_id, s.workspace_id)
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION identrail_rls_repo_scan_scope_matches(repo_scan_uuid UUID)
+RETURNS BOOLEAN
+LANGUAGE SQL
+STABLE
+AS $$
+    SELECT EXISTS (
+        SELECT 1
+        FROM repo_scans rs
+        WHERE rs.id = repo_scan_uuid
+          AND identrail_rls_scope_matches(rs.tenant_id, rs.workspace_id)
+    );
+$$;
+
+ALTER TABLE scans ENABLE ROW LEVEL SECURITY;
+ALTER TABLE scans FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS scans_scope_isolation ON scans;
+CREATE POLICY scans_scope_isolation ON scans
+USING (identrail_rls_scope_matches(tenant_id, workspace_id))
+WITH CHECK (identrail_rls_scope_matches(tenant_id, workspace_id));
+
+ALTER TABLE raw_assets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE raw_assets FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS raw_assets_scope_isolation ON raw_assets;
+CREATE POLICY raw_assets_scope_isolation ON raw_assets
+USING (identrail_rls_scan_scope_matches(scan_id))
+WITH CHECK (identrail_rls_scan_scope_matches(scan_id));
+
+ALTER TABLE identities ENABLE ROW LEVEL SECURITY;
+ALTER TABLE identities FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS identities_scope_isolation ON identities;
+CREATE POLICY identities_scope_isolation ON identities
+USING (identrail_rls_scan_scope_matches(scan_id))
+WITH CHECK (identrail_rls_scan_scope_matches(scan_id));
+
+ALTER TABLE policies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE policies FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS policies_scope_isolation ON policies;
+CREATE POLICY policies_scope_isolation ON policies
+USING (identrail_rls_scan_scope_matches(scan_id))
+WITH CHECK (identrail_rls_scan_scope_matches(scan_id));
+
+ALTER TABLE relationships ENABLE ROW LEVEL SECURITY;
+ALTER TABLE relationships FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS relationships_scope_isolation ON relationships;
+CREATE POLICY relationships_scope_isolation ON relationships
+USING (identrail_rls_scan_scope_matches(scan_id))
+WITH CHECK (identrail_rls_scan_scope_matches(scan_id));
+
+ALTER TABLE permissions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE permissions FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS permissions_scope_isolation ON permissions;
+CREATE POLICY permissions_scope_isolation ON permissions
+USING (identrail_rls_scan_scope_matches(scan_id))
+WITH CHECK (identrail_rls_scan_scope_matches(scan_id));
+
+ALTER TABLE findings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE findings FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS findings_scope_isolation ON findings;
+CREATE POLICY findings_scope_isolation ON findings
+USING (identrail_rls_scan_scope_matches(scan_id))
+WITH CHECK (identrail_rls_scan_scope_matches(scan_id));
+
+ALTER TABLE scan_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE scan_events FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS scan_events_scope_isolation ON scan_events;
+CREATE POLICY scan_events_scope_isolation ON scan_events
+USING (identrail_rls_scan_scope_matches(scan_id))
+WITH CHECK (identrail_rls_scan_scope_matches(scan_id));
+
+ALTER TABLE ownership_signals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ownership_signals FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS ownership_signals_scope_isolation ON ownership_signals;
+CREATE POLICY ownership_signals_scope_isolation ON ownership_signals
+USING (identrail_rls_scan_scope_matches(scan_id))
+WITH CHECK (identrail_rls_scan_scope_matches(scan_id));
+
+ALTER TABLE repo_scans ENABLE ROW LEVEL SECURITY;
+ALTER TABLE repo_scans FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS repo_scans_scope_isolation ON repo_scans;
+CREATE POLICY repo_scans_scope_isolation ON repo_scans
+USING (identrail_rls_scope_matches(tenant_id, workspace_id))
+WITH CHECK (identrail_rls_scope_matches(tenant_id, workspace_id));
+
+ALTER TABLE repo_findings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE repo_findings FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS repo_findings_scope_isolation ON repo_findings;
+CREATE POLICY repo_findings_scope_isolation ON repo_findings
+USING (identrail_rls_repo_scan_scope_matches(repo_scan_id))
+WITH CHECK (identrail_rls_repo_scan_scope_matches(repo_scan_id));
+
+ALTER TABLE finding_triage_states ENABLE ROW LEVEL SECURITY;
+ALTER TABLE finding_triage_states FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS finding_triage_states_scope_isolation ON finding_triage_states;
+CREATE POLICY finding_triage_states_scope_isolation ON finding_triage_states
+USING (identrail_rls_scope_matches(tenant_id, workspace_id))
+WITH CHECK (identrail_rls_scope_matches(tenant_id, workspace_id));
+
+ALTER TABLE finding_triage_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE finding_triage_events FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS finding_triage_events_scope_isolation ON finding_triage_events;
+CREATE POLICY finding_triage_events_scope_isolation ON finding_triage_events
+USING (identrail_rls_scope_matches(tenant_id, workspace_id))
+WITH CHECK (identrail_rls_scope_matches(tenant_id, workspace_id));


### PR DESCRIPTION
## Summary
- add migration `000008_postgres_rls_scope_guardrails` with Postgres RLS policies for tenant/workspace isolation
- add opt-in runtime flag `IDENTRAIL_POSTGRES_RLS_ENFORCED` to activate statement-level scoped RLS enforcement
- add Postgres store/query rewrite tests and migration coverage for the new guardrails

## Validation
- `go test ./internal/db -count=1`
- `go test ./internal/config -count=1`
- `go test ./internal/runtime -count=1`
- `go test ./... -count=1`
- `go test -tags=integration ./internal/integration -count=1`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in Postgres RLS guardrails to enforce tenant/workspace isolation at the DB level. Also hardens the query rewrite with a capacity overflow guard and expands DB test coverage for RLS helper paths.

- **New Features**
  - Migration `000008_postgres_rls_scope_guardrails` adds RLS policies and helper functions across scans, findings, repo scans, triage, and related tables.
  - New flag `IDENTRAIL_POSTGRES_RLS_ENFORCED` (default false). Wired in `service_builder` to toggle enforcement.
  - `PostgresStore` injects a scope CTE that sets `identrail.tenant_id`, `identrail.workspace_id`, and `identrail.rls_enforce` per statement; transactions set the same GUCs on begin. Rewriter supports existing `WITH`/`WITH RECURSIVE` and guards query arg slice capacity to prevent overflow.
  - Query/exec helpers (`queryRowContext`, `queryContext`, `execContext`, `beginTx`) ensure scope is applied consistently; tests now cover disabled/enabled paths, recursive CTEs, tx GUCs, helper wrappers, overflow/invalid input checks, env config defaults, and migration contents.

- **Migration**
  - Run migrations to create RLS policies.
  - To enable enforcement at runtime: set `IDENTRAIL_POSTGRES_RLS_ENFORCED=true`. Disabled by default and safe to roll back via the down migration.

<sup>Written for commit fb78f47508e8930ce2d06b72051be88928d28bc5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

