### PR TITLE
identrail-reviewer Week 1: foundation, schema, config, and shadow context capture

### DIFF
--- a/.github/identrail-reviewer/finding.schema.json
+++ b/.github/identrail-reviewer/finding.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://identrail.dev/schemas/identrail-reviewer-finding.json",
+  "title": "Identrail Reviewer Finding",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "severity",
+    "confidence",
+    "rule_id",
+    "summary",
+    "rationale",
+    "file",
+    "line",
+    "recommendation"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["P0", "P1", "P2", "P3"]
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "rule_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 8
+    },
+    "rationale": {
+      "type": "string",
+      "minLength": 12
+    },
+    "file": {
+      "type": "string",
+      "minLength": 1
+    },
+    "line": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "recommendation": {
+      "type": "string",
+      "minLength": 8
+    },
+    "references": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/.github/identrail-reviewer/reviewer-config.yml
+++ b/.github/identrail-reviewer/reviewer-config.yml
@@ -1,0 +1,56 @@
+version: 1
+name: identrail-reviewer
+mode: shadow
+
+thresholds:
+  confidence:
+    p0_min: 0.95
+    p1_min: 0.90
+    p2_min: 0.82
+    p3_min: 0.75
+  abstain_below: 0.80
+
+policies:
+  require_evidence: true
+  require_fix_hint: true
+  allow_low_confidence_comment: false
+
+required_finding_fields:
+  - id
+  - severity
+  - confidence
+  - rule_id
+  - summary
+  - rationale
+  - file
+  - line
+  - recommendation
+
+routing:
+  areas:
+    api:
+      - "cmd/server/**"
+      - "internal/api/**"
+      - "internal/service/**"
+    worker:
+      - "cmd/worker/**"
+      - "internal/worker/**"
+    cli:
+      - "cmd/cli/**"
+    ui:
+      - "web/**"
+    infra:
+      - "deploy/**"
+      - ".github/workflows/**"
+    security:
+      - "SECURITY.md"
+      - "docs/security-hardening.md"
+
+dataset:
+  benchmark_path: data/identrail-reviewer/benchmark
+  replay_min_samples: 50
+
+slo:
+  review_latency_p95_seconds: 90
+  high_severity_precision_min: 0.95
+  false_positive_rate_max: 0.08

--- a/.github/workflows/identrail-reviewer-shadow.yml
+++ b/.github/workflows/identrail-reviewer-shadow.yml
@@ -1,0 +1,139 @@
+name: identrail-reviewer-shadow
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, ready_for_review]
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+concurrency:
+  group: identrail-reviewer-shadow-${{ github.event_name }}-${{ github.event.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  pr-context:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Collect PR context
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const pr = context.payload.pull_request;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            let page = 1;
+            const perPage = 100;
+            const files = [];
+
+            while (true) {
+              const response = await github.rest.pulls.listFiles({
+                owner,
+                repo,
+                pull_number: pr.number,
+                per_page: perPage,
+                page
+              });
+
+              const batch = response.data.map((f) => ({
+                filename: f.filename,
+                status: f.status,
+                additions: f.additions,
+                deletions: f.deletions,
+                changes: f.changes,
+                patch_present: Boolean(f.patch)
+              }));
+
+              files.push(...batch);
+
+              if (response.data.length < perPage) {
+                break;
+              }
+              page += 1;
+            }
+
+            const payload = {
+              source: 'identrail-reviewer-shadow',
+              generated_at: new Date().toISOString(),
+              repository: `${owner}/${repo}`,
+              pull_request: {
+                number: pr.number,
+                title: pr.title,
+                state: pr.state,
+                draft: pr.draft,
+                additions: pr.additions,
+                deletions: pr.deletions,
+                changed_files: pr.changed_files,
+                labels: (pr.labels || []).map((l) => l.name),
+                author: pr.user?.login || null,
+                base_ref: pr.base?.ref || null,
+                head_ref: pr.head?.ref || null,
+                body: pr.body || ''
+              },
+              files
+            };
+
+            const outDir = path.join(process.cwd(), 'artifacts');
+            fs.mkdirSync(outDir, { recursive: true });
+            const outFile = path.join(outDir, `pr-${pr.number}-context.json`);
+            fs.writeFileSync(outFile, JSON.stringify(payload, null, 2));
+            core.notice(`Saved ${outFile}`);
+
+      - name: Upload PR context artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: identrail-reviewer-pr-context-${{ github.event.pull_request.number }}
+          path: artifacts/*.json
+          if-no-files-found: error
+
+  issue-context:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Collect issue context
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const issue = context.payload.issue;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const payload = {
+              source: 'identrail-reviewer-shadow',
+              generated_at: new Date().toISOString(),
+              repository: `${owner}/${repo}`,
+              issue: {
+                number: issue.number,
+                title: issue.title,
+                state: issue.state,
+                labels: (issue.labels || []).map((l) => l.name),
+                author: issue.user?.login || null,
+                assignees: (issue.assignees || []).map((a) => a.login),
+                body: issue.body || ''
+              }
+            };
+
+            const outDir = path.join(process.cwd(), 'artifacts');
+            fs.mkdirSync(outDir, { recursive: true });
+            const outFile = path.join(outDir, `issue-${issue.number}-context.json`);
+            fs.writeFileSync(outFile, JSON.stringify(payload, null, 2));
+            core.notice(`Saved ${outFile}`);
+
+      - name: Upload issue context artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: identrail-reviewer-issue-context-${{ github.event.issue.number }}
+          path: artifacts/*.json
+          if-no-files-found: error

--- a/data/identrail-reviewer/benchmark/README.md
+++ b/data/identrail-reviewer/benchmark/README.md
@@ -1,0 +1,29 @@
+# identrail-reviewer benchmark
+
+Place replay cases in this directory using one JSON file per case.
+
+## Suggested naming
+
+- `pr-<number>.json`
+- `issue-<number>.json`
+
+## Minimal PR case shape
+
+```json
+{
+  "type": "pr_review_case",
+  "id": "pr-123",
+  "source_url": "https://github.com/Oluwatobi-Mustapha/identrail/pull/123",
+  "captured_at": "2026-04-04T00:00:00Z",
+  "expected": [
+    {
+      "severity": "P1",
+      "file": ".github/workflows/release.yml",
+      "line": 210,
+      "summary": "Hardcoded production placeholder URL in release image build",
+      "disposition": "true_positive"
+    }
+  ],
+  "notes": "Validated by maintainer after merge"
+}
+```

--- a/docs/identrail-reviewer/README.md
+++ b/docs/identrail-reviewer/README.md
@@ -1,0 +1,23 @@
+# identrail-reviewer
+
+`identrail-reviewer` is the repository-native PR and issue reviewer for Identrail.
+
+It is optimized for high-precision review in this codebase using:
+- deterministic policy checks first
+- evidence-based findings with confidence scoring
+- abstain behavior when confidence is too low
+- a continuously evaluated benchmark and replay dataset
+
+## Delivery Tracks
+
+- Week 1: foundation, contracts, context capture, benchmark scaffolding.
+- Week 2: judgment engine with deterministic review logic and structured findings.
+- Week 3: enterprise hardening (security, reliability, auditability, policy governance).
+- Week 4: controlled rollout, enforcement gates, quality operations, runbooks.
+
+## Core Design Principles
+
+- Precision over volume: avoid noisy comments.
+- Explainability: every finding must include evidence and rationale.
+- Safety: low-confidence paths should abstain.
+- Measurability: quality and latency are continuously tracked.

--- a/docs/identrail-reviewer/ground-truth-dataset.md
+++ b/docs/identrail-reviewer/ground-truth-dataset.md
@@ -1,0 +1,24 @@
+# Ground Truth Dataset Guide
+
+The benchmark dataset under `data/identrail-reviewer/benchmark` is used for replay-based
+precision/recall and false-positive measurement.
+
+## Record types
+
+- `pr_review_case`: a pull request snapshot with expected findings.
+- `issue_triage_case`: an issue snapshot with expected classification and severity.
+
+## Required fields
+
+Each case should include:
+- `id`: stable identifier
+- `source_url`: PR or issue URL
+- `captured_at`: ISO 8601 timestamp
+- `expected`: array of expected outcomes
+- `notes`: maintainer annotation explaining decisions
+
+## Quality rules
+
+- Keep expected outcomes tied to exact file and line where possible.
+- Mark uncertain historical decisions explicitly.
+- Do not include generated secrets or private data.

--- a/docs/identrail-reviewer/week-1-foundation.md
+++ b/docs/identrail-reviewer/week-1-foundation.md
@@ -1,0 +1,22 @@
+# Week 1 Foundation Plan
+
+This phase establishes the operational foundation for `identrail-reviewer`.
+
+## Scope
+
+- Reviewer contract and schema (`.github/identrail-reviewer/finding.schema.json`).
+- Reviewer policy baseline (`.github/identrail-reviewer/reviewer-config.yml`).
+- Shadow mode context collection workflow (`.github/workflows/identrail-reviewer-shadow.yml`).
+- Ground-truth benchmark data scaffolding (`data/identrail-reviewer/benchmark`).
+
+## Why this phase exists
+
+Without a strict contract and historical benchmark, reviewer quality cannot be measured
+reliably. Shadow mode lets us inspect behavior before any blocking policy is enabled.
+
+## Acceptance Criteria
+
+- Shadow workflow captures pull request and issue context as artifacts.
+- Output schema is defined and versioned.
+- Confidence thresholds and abstain policy are defined.
+- Benchmark folder exists with a documented record format.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -149,3 +149,84 @@ func TestRunCancelledContext(t *testing.T) {
 		t.Fatalf("expected clean shutdown, got err: %v", err)
 	}
 }
+
+func TestRunSignalRequested(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := config.Config{
+		HTTPAddr:     ":0",
+		LogLevel:     "info",
+		Provider:     "aws",
+		ServiceName:  "identrail-test",
+		APIKeys:      []string{"test-read"},
+		WriteAPIKeys: []string{"test-read"},
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	sigCh <- os.Interrupt
+	if err := Run(ctx, cfg, sigCh); err != nil {
+		t.Fatalf("expected clean shutdown on signal, got err: %v", err)
+	}
+}
+
+func TestRunServerListenError(t *testing.T) {
+	cfg := config.Config{
+		HTTPAddr:     "invalid-listen-address",
+		LogLevel:     "info",
+		Provider:     "aws",
+		ServiceName:  "identrail-test",
+		APIKeys:      []string{"test-read"},
+		WriteAPIKeys: []string{"test-read"},
+	}
+	sigCh := make(chan os.Signal, 1)
+	if err := Run(context.Background(), cfg, sigCh); err == nil {
+		t.Fatal("expected listen error for invalid address")
+	}
+}
+
+func TestNewBootstrapWithMultipleAuditSinks(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	cfg := config.Config{
+		HTTPAddr:               ":0",
+		LogLevel:               "info",
+		Provider:               "aws",
+		ServiceName:            "identrail-test",
+		AuditLogFile:           filepath.Join(t.TempDir(), "audit.log"),
+		AuditForwardURL:        server.URL,
+		AuditForwardTimeout:    2 * time.Second,
+		AuditForwardHMACSecret: "secret",
+		APIKeys:                []string{"test-read"},
+		WriteAPIKeys:           []string{"test-read"},
+	}
+	bootstrap, err := NewBootstrap(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if bootstrap.AuditClose == nil {
+		t.Fatal("expected audit close function")
+	}
+	if err := bootstrap.AuditClose(); err != nil {
+		t.Fatalf("close audit sink: %v", err)
+	}
+}
+
+func TestNewBootstrapInvalidOIDCVerifierConfig(t *testing.T) {
+	cfg := config.Config{
+		HTTPAddr:       ":0",
+		LogLevel:       "info",
+		Provider:       "aws",
+		ServiceName:    "identrail-test",
+		OIDCIssuerURL:  "://bad-issuer",
+		OIDCAudience:   "identrail-api",
+		APIKeys:        []string{"test-read"},
+		WriteAPIKeys:   []string{"test-read"},
+	}
+	if _, err := NewBootstrap(context.Background(), cfg); err == nil {
+		t.Fatal("expected oidc verifier initialization error")
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -217,14 +217,14 @@ func TestNewBootstrapWithMultipleAuditSinks(t *testing.T) {
 
 func TestNewBootstrapInvalidOIDCVerifierConfig(t *testing.T) {
 	cfg := config.Config{
-		HTTPAddr:       ":0",
-		LogLevel:       "info",
-		Provider:       "aws",
-		ServiceName:    "identrail-test",
-		OIDCIssuerURL:  "://bad-issuer",
-		OIDCAudience:   "identrail-api",
-		APIKeys:        []string{"test-read"},
-		WriteAPIKeys:   []string{"test-read"},
+		HTTPAddr:      ":0",
+		LogLevel:      "info",
+		Provider:      "aws",
+		ServiceName:   "identrail-test",
+		OIDCIssuerURL: "://bad-issuer",
+		OIDCAudience:  "identrail-api",
+		APIKeys:       []string{"test-read"},
+		WriteAPIKeys:  []string{"test-read"},
 	}
 	if _, err := NewBootstrap(context.Background(), cfg); err == nil {
 		t.Fatal("expected oidc verifier initialization error")


### PR DESCRIPTION
## Summary
This PR delivers Week 1 of `identrail-reviewer` by creating the quality and operations foundation in shadow mode.

## What is included
- Reviewer contract schema:
  - `.github/identrail-reviewer/finding.schema.json`
- Baseline reviewer policy:
  - `.github/identrail-reviewer/reviewer-config.yml`
- Shadow mode workflow to capture PR/issue context artifacts:
  - `.github/workflows/identrail-reviewer-shadow.yml`
- Benchmark dataset scaffolding:
  - `data/identrail-reviewer/benchmark/README.md`
- Program documentation:
  - `docs/identrail-reviewer/README.md`
  - `docs/identrail-reviewer/week-1-foundation.md`
  - `docs/identrail-reviewer/ground-truth-dataset.md`

## Why
- Establishes strict finding contracts before enabling any gating.
- Captures replay context to measure precision/false positives over time.
- Defines confidence and abstain thresholds for high-signal reviews.

## Notes
- This is intentionally non-blocking (`mode: shadow`).
- No runtime application behavior changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets up Week 1 foundation for `identrail-reviewer` in shadow mode. Adds strict schema, policy, context capture, docs and dataset scaffolding, plus server tests.

- New Features
  - Finding schema at `.github/identrail-reviewer/finding.schema.json` and reviewer policy at `.github/identrail-reviewer/reviewer-config.yml`.
  - Shadow workflow at `.github/workflows/identrail-reviewer-shadow.yml` captures PR/issue context via `actions/github-script@v8` and `actions/upload-artifact@v4`.
  - Benchmark dataset scaffold at `data/identrail-reviewer/benchmark` with a documented case format.
  - Docs under `docs/identrail-reviewer/` for the foundation plan, dataset guide, and overview.
  - Server tests at `internal/server/server_test.go` covering signal shutdown, listen errors, multiple audit sinks, and invalid OIDC config; formatted with gofmt.

<sup>Written for commit 937c8cf72d89ef208efe799e925b303ee1f7995a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

