### PR TITLE
identrail-reviewer Week 2: deterministic PR/issue judgment engine and review workflow

### DIFF
--- a/.github/identrail-reviewer/finding.schema.json
+++ b/.github/identrail-reviewer/finding.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://identrail.dev/schemas/identrail-reviewer-finding.json",
+  "title": "Identrail Reviewer Finding",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "severity",
+    "confidence",
+    "rule_id",
+    "summary",
+    "rationale",
+    "file",
+    "line",
+    "recommendation"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["P0", "P1", "P2", "P3"]
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "rule_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 8
+    },
+    "rationale": {
+      "type": "string",
+      "minLength": 12
+    },
+    "file": {
+      "type": "string",
+      "minLength": 1
+    },
+    "line": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "recommendation": {
+      "type": "string",
+      "minLength": 8
+    },
+    "references": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/.github/identrail-reviewer/reviewer-config.yml
+++ b/.github/identrail-reviewer/reviewer-config.yml
@@ -1,0 +1,56 @@
+version: 1
+name: identrail-reviewer
+mode: shadow
+
+thresholds:
+  confidence:
+    p0_min: 0.95
+    p1_min: 0.90
+    p2_min: 0.82
+    p3_min: 0.75
+  abstain_below: 0.80
+
+policies:
+  require_evidence: true
+  require_fix_hint: true
+  allow_low_confidence_comment: false
+
+required_finding_fields:
+  - id
+  - severity
+  - confidence
+  - rule_id
+  - summary
+  - rationale
+  - file
+  - line
+  - recommendation
+
+routing:
+  areas:
+    api:
+      - "cmd/server/**"
+      - "internal/api/**"
+      - "internal/service/**"
+    worker:
+      - "cmd/worker/**"
+      - "internal/worker/**"
+    cli:
+      - "cmd/cli/**"
+    ui:
+      - "web/**"
+    infra:
+      - "deploy/**"
+      - ".github/workflows/**"
+    security:
+      - "SECURITY.md"
+      - "docs/security-hardening.md"
+
+dataset:
+  benchmark_path: data/identrail-reviewer/benchmark
+  replay_min_samples: 50
+
+slo:
+  review_latency_p95_seconds: 90
+  high_severity_precision_min: 0.95
+  false_positive_rate_max: 0.08

--- a/.github/scripts/identrail-reviewer/upsert-review-comment.js
+++ b/.github/scripts/identrail-reviewer/upsert-review-comment.js
@@ -1,0 +1,102 @@
+"use strict";
+
+const fs = require("fs");
+
+function formatFindings(findings, maxFindings) {
+  const limit = Number.isInteger(maxFindings) && maxFindings > 0 ? maxFindings : findings.length;
+  const clipped = findings.slice(0, limit);
+
+  let body = "";
+  if (clipped.length > 0) {
+    body += "### Findings\n";
+    for (const finding of clipped) {
+      body += `- [${finding.severity}] ${finding.summary} (${finding.file}:${finding.line})\n`;
+      body += `  - Rule: \`${finding.rule_id}\` | Confidence: ${finding.confidence}\n`;
+      body += `  - Recommendation: ${finding.recommendation}\n`;
+    }
+  } else {
+    body += "### Findings\n- No deterministic findings.\n";
+  }
+
+  if (findings.length > limit) {
+    body += `\nAdditional findings omitted: ${findings.length - limit}.\n`;
+  }
+
+  return body;
+}
+
+function formatAbstentions(abstentions) {
+  if (!Array.isArray(abstentions) || abstentions.length === 0) {
+    return "";
+  }
+  let body = "\n### Abstentions\n";
+  for (const note of abstentions) {
+    body += `- ${note}\n`;
+  }
+  return body;
+}
+
+function renderBody({ marker, heading, result, maxFindings }) {
+  const findings = Array.isArray(result.findings) ? result.findings : [];
+  const abstentions = Array.isArray(result.abstentions) ? result.abstentions : [];
+
+  let body = `${marker}\n${heading}\n`;
+  body += `Status: **${result.status}**\n\n`;
+  body += `${result.summary}\n\n`;
+  body += formatFindings(findings, maxFindings);
+  body += formatAbstentions(abstentions);
+  body += `\n_Reviewer version: ${result.version}_\n`;
+  return body;
+}
+
+async function upsertReviewComment({
+  github,
+  context,
+  reviewPath,
+  marker,
+  heading,
+  issueNumber,
+  maxFindings,
+}) {
+  if (!issueNumber || issueNumber <= 0) {
+    throw new Error("issue number is required for comment upsert");
+  }
+
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+  const result = JSON.parse(fs.readFileSync(reviewPath, "utf8"));
+  const body = renderBody({
+    marker,
+    heading,
+    result,
+    maxFindings,
+  });
+
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: issueNumber,
+    per_page: 100,
+  });
+  const existing = comments.find((comment) => comment.body && comment.body.includes(marker));
+  if (existing) {
+    await github.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: existing.id,
+      body,
+    });
+    return;
+  }
+
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    body,
+  });
+}
+
+module.exports = {
+  upsertReviewComment,
+};

--- a/.github/workflows/identrail-reviewer-review.yml
+++ b/.github/workflows/identrail-reviewer-review.yml
@@ -82,69 +82,16 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const fs = require('fs');
-            const result = JSON.parse(fs.readFileSync('.tmp/review.json', 'utf8'));
-            const marker = '<!-- identrail-reviewer:pr -->';
-            const issue_number = context.payload.pull_request.number;
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-
-            const findings = result.findings || [];
-            const abstentions = result.abstentions || [];
-            const maxFindings = 20;
-            const clipped = findings.slice(0, maxFindings);
-
-            let body = `${marker}\n## identrail-reviewer\n`;
-            body += `Status: **${result.status}**\n\n`;
-            body += `${result.summary}\n\n`;
-
-            if (clipped.length > 0) {
-              body += `### Findings\n`;
-              for (const finding of clipped) {
-                body += `- [${finding.severity}] ${finding.summary} (${finding.file}:${finding.line})\n`;
-                body += `  - Rule: \`${finding.rule_id}\` | Confidence: ${finding.confidence}\n`;
-                body += `  - Recommendation: ${finding.recommendation}\n`;
-              }
-            } else {
-              body += `### Findings\n- No deterministic findings.\n`;
-            }
-
-            if (findings.length > maxFindings) {
-              body += `\nAdditional findings omitted: ${findings.length - maxFindings}.\n`;
-            }
-
-            if (abstentions.length > 0) {
-              body += `\n### Abstentions\n`;
-              for (const note of abstentions) {
-                body += `- ${note}\n`;
-              }
-            }
-
-            body += `\n_Reviewer version: ${result.version}_\n`;
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number,
-              per_page: 100
+            const { upsertReviewComment } = require('./.github/scripts/identrail-reviewer/upsert-review-comment');
+            await upsertReviewComment({
+              github,
+              context,
+              reviewPath: '.tmp/review.json',
+              marker: '<!-- identrail-reviewer:pr -->',
+              heading: '## identrail-reviewer',
+              issueNumber: context.payload.pull_request.number,
+              maxFindings: 20
             });
-
-            const existing = comments.find((c) => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existing.id,
-                body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number,
-                body
-              });
-            }
 
   issue-review:
     if: github.event_name == 'issues'
@@ -179,59 +126,12 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const fs = require('fs');
-            const result = JSON.parse(fs.readFileSync('.tmp/review.json', 'utf8'));
-            const marker = '<!-- identrail-reviewer:issue -->';
-            const issue_number = context.payload.issue.number;
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-
-            const findings = result.findings || [];
-            const abstentions = result.abstentions || [];
-
-            let body = `${marker}\n## identrail-reviewer issue triage\n`;
-            body += `Status: **${result.status}**\n\n`;
-            body += `${result.summary}\n\n`;
-
-            if (findings.length > 0) {
-              body += `### Findings\n`;
-              for (const finding of findings) {
-                body += `- [${finding.severity}] ${finding.summary} (${finding.file}:${finding.line})\n`;
-                body += `  - Rule: \`${finding.rule_id}\` | Confidence: ${finding.confidence}\n`;
-                body += `  - Recommendation: ${finding.recommendation}\n`;
-              }
-            } else {
-              body += `### Findings\n- No deterministic findings.\n`;
-            }
-
-            if (abstentions.length > 0) {
-              body += `\n### Abstentions\n`;
-              for (const note of abstentions) {
-                body += `- ${note}\n`;
-              }
-            }
-
-            body += `\n_Reviewer version: ${result.version}_\n`;
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number,
-              per_page: 100
+            const { upsertReviewComment } = require('./.github/scripts/identrail-reviewer/upsert-review-comment');
+            await upsertReviewComment({
+              github,
+              context,
+              reviewPath: '.tmp/review.json',
+              marker: '<!-- identrail-reviewer:issue -->',
+              heading: '## identrail-reviewer issue triage',
+              issueNumber: context.payload.issue.number
             });
-            const existing = comments.find((c) => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existing.id,
-                body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number,
-                body
-              });
-            }

--- a/.github/workflows/identrail-reviewer-review.yml
+++ b/.github/workflows/identrail-reviewer-review.yml
@@ -1,0 +1,237 @@
+name: identrail-reviewer-review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: identrail-reviewer-review-${{ github.event_name }}-${{ github.event.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  pr-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Collect changed files
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const number = context.payload.pull_request.number;
+            const outDir = path.join(process.cwd(), '.tmp');
+            fs.mkdirSync(outDir, { recursive: true });
+
+            const files = [];
+            let page = 1;
+            const perPage = 100;
+            while (true) {
+              const resp = await github.rest.pulls.listFiles({
+                owner,
+                repo,
+                pull_number: number,
+                per_page: perPage,
+                page
+              });
+              files.push(...resp.data.map((f) => ({ filename: f.filename, status: f.status })));
+              if (resp.data.length < perPage) break;
+              page += 1;
+            }
+
+            fs.writeFileSync(path.join(outDir, 'changed-files.json'), JSON.stringify(files, null, 2));
+
+      - name: Run identrail-reviewer (PR)
+        run: |
+          set -euo pipefail
+          go run ./cmd/identrail-reviewer review-pr \
+            --repo-root . \
+            --event-path "$GITHUB_EVENT_PATH" \
+            --changed-files .tmp/changed-files.json \
+            --output .tmp/review.json
+
+      - name: Upload review artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: identrail-reviewer-pr-${{ github.event.pull_request.number }}
+          path: .tmp/review.json
+          if-no-files-found: error
+
+      - name: Upsert PR review comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const result = JSON.parse(fs.readFileSync('.tmp/review.json', 'utf8'));
+            const marker = '<!-- identrail-reviewer:pr -->';
+            const issue_number = context.payload.pull_request.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const findings = result.findings || [];
+            const abstentions = result.abstentions || [];
+            const maxFindings = 20;
+            const clipped = findings.slice(0, maxFindings);
+
+            let body = `${marker}\n## identrail-reviewer\n`;
+            body += `Status: **${result.status}**\n\n`;
+            body += `${result.summary}\n\n`;
+
+            if (clipped.length > 0) {
+              body += `### Findings\n`;
+              for (const finding of clipped) {
+                body += `- [${finding.severity}] ${finding.summary} (${finding.file}:${finding.line})\n`;
+                body += `  - Rule: \`${finding.rule_id}\` | Confidence: ${finding.confidence}\n`;
+                body += `  - Recommendation: ${finding.recommendation}\n`;
+              }
+            } else {
+              body += `### Findings\n- No deterministic findings.\n`;
+            }
+
+            if (findings.length > maxFindings) {
+              body += `\nAdditional findings omitted: ${findings.length - maxFindings}.\n`;
+            }
+
+            if (abstentions.length > 0) {
+              body += `\n### Abstentions\n`;
+              for (const note of abstentions) {
+                body += `- ${note}\n`;
+              }
+            }
+
+            body += `\n_Reviewer version: ${result.version}_\n`;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100
+            });
+
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body
+              });
+            }
+
+  issue-review:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run identrail-reviewer (Issue)
+        run: |
+          set -euo pipefail
+          mkdir -p .tmp
+          go run ./cmd/identrail-reviewer review-issue \
+            --event-path "$GITHUB_EVENT_PATH" \
+            --output .tmp/review.json
+
+      - name: Upload issue review artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: identrail-reviewer-issue-${{ github.event.issue.number }}
+          path: .tmp/review.json
+          if-no-files-found: error
+
+      - name: Upsert issue review comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const result = JSON.parse(fs.readFileSync('.tmp/review.json', 'utf8'));
+            const marker = '<!-- identrail-reviewer:issue -->';
+            const issue_number = context.payload.issue.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const findings = result.findings || [];
+            const abstentions = result.abstentions || [];
+
+            let body = `${marker}\n## identrail-reviewer issue triage\n`;
+            body += `Status: **${result.status}**\n\n`;
+            body += `${result.summary}\n\n`;
+
+            if (findings.length > 0) {
+              body += `### Findings\n`;
+              for (const finding of findings) {
+                body += `- [${finding.severity}] ${finding.summary} (${finding.file}:${finding.line})\n`;
+                body += `  - Rule: \`${finding.rule_id}\` | Confidence: ${finding.confidence}\n`;
+                body += `  - Recommendation: ${finding.recommendation}\n`;
+              }
+            } else {
+              body += `### Findings\n- No deterministic findings.\n`;
+            }
+
+            if (abstentions.length > 0) {
+              body += `\n### Abstentions\n`;
+              for (const note of abstentions) {
+                body += `- ${note}\n`;
+              }
+            }
+
+            body += `\n_Reviewer version: ${result.version}_\n`;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body
+              });
+            }

--- a/.github/workflows/identrail-reviewer-shadow.yml
+++ b/.github/workflows/identrail-reviewer-shadow.yml
@@ -1,0 +1,139 @@
+name: identrail-reviewer-shadow
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, ready_for_review]
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+concurrency:
+  group: identrail-reviewer-shadow-${{ github.event_name }}-${{ github.event.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  pr-context:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Collect PR context
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const pr = context.payload.pull_request;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            let page = 1;
+            const perPage = 100;
+            const files = [];
+
+            while (true) {
+              const response = await github.rest.pulls.listFiles({
+                owner,
+                repo,
+                pull_number: pr.number,
+                per_page: perPage,
+                page
+              });
+
+              const batch = response.data.map((f) => ({
+                filename: f.filename,
+                status: f.status,
+                additions: f.additions,
+                deletions: f.deletions,
+                changes: f.changes,
+                patch_present: Boolean(f.patch)
+              }));
+
+              files.push(...batch);
+
+              if (response.data.length < perPage) {
+                break;
+              }
+              page += 1;
+            }
+
+            const payload = {
+              source: 'identrail-reviewer-shadow',
+              generated_at: new Date().toISOString(),
+              repository: `${owner}/${repo}`,
+              pull_request: {
+                number: pr.number,
+                title: pr.title,
+                state: pr.state,
+                draft: pr.draft,
+                additions: pr.additions,
+                deletions: pr.deletions,
+                changed_files: pr.changed_files,
+                labels: (pr.labels || []).map((l) => l.name),
+                author: pr.user?.login || null,
+                base_ref: pr.base?.ref || null,
+                head_ref: pr.head?.ref || null,
+                body: pr.body || ''
+              },
+              files
+            };
+
+            const outDir = path.join(process.cwd(), 'artifacts');
+            fs.mkdirSync(outDir, { recursive: true });
+            const outFile = path.join(outDir, `pr-${pr.number}-context.json`);
+            fs.writeFileSync(outFile, JSON.stringify(payload, null, 2));
+            core.notice(`Saved ${outFile}`);
+
+      - name: Upload PR context artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: identrail-reviewer-pr-context-${{ github.event.pull_request.number }}
+          path: artifacts/*.json
+          if-no-files-found: error
+
+  issue-context:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Collect issue context
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const issue = context.payload.issue;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const payload = {
+              source: 'identrail-reviewer-shadow',
+              generated_at: new Date().toISOString(),
+              repository: `${owner}/${repo}`,
+              issue: {
+                number: issue.number,
+                title: issue.title,
+                state: issue.state,
+                labels: (issue.labels || []).map((l) => l.name),
+                author: issue.user?.login || null,
+                assignees: (issue.assignees || []).map((a) => a.login),
+                body: issue.body || ''
+              }
+            };
+
+            const outDir = path.join(process.cwd(), 'artifacts');
+            fs.mkdirSync(outDir, { recursive: true });
+            const outFile = path.join(outDir, `issue-${issue.number}-context.json`);
+            fs.writeFileSync(outFile, JSON.stringify(payload, null, 2));
+            core.notice(`Saved ${outFile}`);
+
+      - name: Upload issue context artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: identrail-reviewer-issue-context-${{ github.event.issue.number }}
+          path: artifacts/*.json
+          if-no-files-found: error

--- a/cmd/identrail-reviewer/main.go
+++ b/cmd/identrail-reviewer/main.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/model"
+	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/review"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fatal("usage: identrail-reviewer <review-pr|review-issue> [flags]")
+	}
+
+	switch os.Args[1] {
+	case "review-pr":
+		reviewPR(os.Args[2:])
+	case "review-issue":
+		reviewIssue(os.Args[2:])
+	default:
+		fatal("unknown subcommand: " + os.Args[1])
+	}
+}
+
+func reviewPR(args []string) {
+	fs := flag.NewFlagSet("review-pr", flag.ExitOnError)
+	repoRoot := fs.String("repo-root", ".", "repository root")
+	eventPath := fs.String("event-path", "", "GitHub event payload path")
+	changedFilesPath := fs.String("changed-files", "", "changed files JSON path")
+	outputPath := fs.String("output", "", "output path for review result")
+	_ = fs.Parse(args)
+
+	if *eventPath == "" || *changedFilesPath == "" || *outputPath == "" {
+		fatal("review-pr requires --event-path, --changed-files, and --output")
+	}
+
+	eventBytes, err := os.ReadFile(*eventPath)
+	if err != nil {
+		fatal(err.Error())
+	}
+
+	var event model.PullRequestEvent
+	if err := json.Unmarshal(eventBytes, &event); err != nil {
+		fatal("failed to parse PR event payload: " + err.Error())
+	}
+
+	changedBytes, err := os.ReadFile(*changedFilesPath)
+	if err != nil {
+		fatal(err.Error())
+	}
+
+	var changedFiles []model.ChangedFile
+	if err := json.Unmarshal(changedBytes, &changedFiles); err != nil {
+		fatal("failed to parse changed files JSON: " + err.Error())
+	}
+
+	labels := make([]string, 0, len(event.PullRequest.Labels))
+	for _, l := range event.PullRequest.Labels {
+		labels = append(labels, l.Name)
+	}
+
+	result := review.ReviewPR(
+		*repoRoot,
+		event.PullRequest.Number,
+		event.PullRequest.Title,
+		event.PullRequest.Body,
+		labels,
+		changedFiles,
+	)
+	writeJSON(*outputPath, result)
+}
+
+func reviewIssue(args []string) {
+	fs := flag.NewFlagSet("review-issue", flag.ExitOnError)
+	eventPath := fs.String("event-path", "", "GitHub event payload path")
+	outputPath := fs.String("output", "", "output path for review result")
+	_ = fs.Parse(args)
+
+	if *eventPath == "" || *outputPath == "" {
+		fatal("review-issue requires --event-path and --output")
+	}
+
+	eventBytes, err := os.ReadFile(*eventPath)
+	if err != nil {
+		fatal(err.Error())
+	}
+
+	var event model.IssueEvent
+	if err := json.Unmarshal(eventBytes, &event); err != nil {
+		fatal("failed to parse issue event payload: " + err.Error())
+	}
+
+	if event.Issue.Number == 0 {
+		fatal(errors.New("event payload does not contain issue context").Error())
+	}
+
+	labels := make([]string, 0, len(event.Issue.Labels))
+	for _, l := range event.Issue.Labels {
+		labels = append(labels, l.Name)
+	}
+
+	result := review.ReviewIssue(
+		event.Issue.Number,
+		event.Issue.Title,
+		event.Issue.Body,
+		labels,
+	)
+	writeJSON(*outputPath, result)
+}
+
+func writeJSON(path string, v any) {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		fatal(err.Error())
+	}
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		fatal(err.Error())
+	}
+}
+
+func fatal(msg string) {
+	fmt.Fprintln(os.Stderr, msg)
+	os.Exit(1)
+}

--- a/cmd/identrail-reviewer/main.go
+++ b/cmd/identrail-reviewer/main.go
@@ -47,6 +47,9 @@ func reviewPR(args []string) {
 	if err := json.Unmarshal(eventBytes, &event); err != nil {
 		fatal("failed to parse PR event payload: " + err.Error())
 	}
+	if event.PullRequest.Number == 0 {
+		fatal(errors.New("event payload does not contain pull request context").Error())
+	}
 
 	changedBytes, err := os.ReadFile(*changedFilesPath)
 	if err != nil {

--- a/cmd/identrail-reviewer/main_test.go
+++ b/cmd/identrail-reviewer/main_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/model"
+)
+
+func TestReviewPRWritesOutput(t *testing.T) {
+	root := t.TempDir()
+	eventPath := filepath.Join(root, "event.json")
+	changedPath := filepath.Join(root, "changed.json")
+	outputPath := filepath.Join(root, "review.json")
+
+	event := model.PullRequestEvent{
+		PullRequest: model.PullRequest{
+			Number: 77,
+			Title:  "test pr",
+			Body:   "### Summary\nok\n### Why\nok\n### Scope\nok\n### Validation\nok\n### Checklist\nok\n### AI Assistance Disclosure\nok\n### Related Issues\nok\n",
+			Labels: []model.Label{{Name: "area/security"}},
+		},
+	}
+	if err := writeJSONFile(eventPath, event); err != nil {
+		t.Fatalf("write event json: %v", err)
+	}
+	if err := writeJSONFile(changedPath, []model.ChangedFile{}); err != nil {
+		t.Fatalf("write changed files json: %v", err)
+	}
+
+	reviewPR([]string{
+		"--repo-root", root,
+		"--event-path", eventPath,
+		"--changed-files", changedPath,
+		"--output", outputPath,
+	})
+
+	var got model.ReviewResult
+	if err := readJSONFile(outputPath, &got); err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if got.Target != "pull_request" {
+		t.Fatalf("expected pull_request target, got %q", got.Target)
+	}
+	if got.Number != 77 {
+		t.Fatalf("expected PR number 77, got %d", got.Number)
+	}
+}
+
+func TestReviewIssueWritesOutput(t *testing.T) {
+	root := t.TempDir()
+	eventPath := filepath.Join(root, "event.json")
+	outputPath := filepath.Join(root, "review.json")
+
+	event := model.IssueEvent{
+		Issue: model.Issue{
+			Number: 88,
+			Title:  "[feature]: add report",
+			Body:   "### Problem statement\nx\n### Proposed solution\ny\n### Area\nz\n### User and operator impact\nlow\n### Acceptance criteria\ndone\n",
+			Labels: []model.Label{{Name: "kind/enhancement"}},
+		},
+	}
+	if err := writeJSONFile(eventPath, event); err != nil {
+		t.Fatalf("write event json: %v", err)
+	}
+
+	reviewIssue([]string{
+		"--event-path", eventPath,
+		"--output", outputPath,
+	})
+
+	var got model.ReviewResult
+	if err := readJSONFile(outputPath, &got); err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if got.Target != "issue" {
+		t.Fatalf("expected issue target, got %q", got.Target)
+	}
+	if got.Number != 88 {
+		t.Fatalf("expected issue number 88, got %d", got.Number)
+	}
+}
+
+func TestWriteJSONWritesFile(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "out.json")
+	writeJSON(path, map[string]string{"k": "v"})
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read output file: %v", err)
+	}
+	if len(b) == 0 {
+		t.Fatal("expected non-empty output file")
+	}
+}
+
+func writeJSONFile(path string, v any) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0o644)
+}
+
+func readJSONFile(path string, out any) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, out)
+}

--- a/data/identrail-reviewer/benchmark/README.md
+++ b/data/identrail-reviewer/benchmark/README.md
@@ -1,0 +1,29 @@
+# identrail-reviewer benchmark
+
+Place replay cases in this directory using one JSON file per case.
+
+## Suggested naming
+
+- `pr-<number>.json`
+- `issue-<number>.json`
+
+## Minimal PR case shape
+
+```json
+{
+  "type": "pr_review_case",
+  "id": "pr-123",
+  "source_url": "https://github.com/Oluwatobi-Mustapha/identrail/pull/123",
+  "captured_at": "2026-04-04T00:00:00Z",
+  "expected": [
+    {
+      "severity": "P1",
+      "file": ".github/workflows/release.yml",
+      "line": 210,
+      "summary": "Hardcoded production placeholder URL in release image build",
+      "disposition": "true_positive"
+    }
+  ],
+  "notes": "Validated by maintainer after merge"
+}
+```

--- a/docs/identrail-reviewer/README.md
+++ b/docs/identrail-reviewer/README.md
@@ -1,0 +1,23 @@
+# identrail-reviewer
+
+`identrail-reviewer` is the repository-native PR and issue reviewer for Identrail.
+
+It is optimized for high-precision review in this codebase using:
+- deterministic policy checks first
+- evidence-based findings with confidence scoring
+- abstain behavior when confidence is too low
+- a continuously evaluated benchmark and replay dataset
+
+## Delivery Tracks
+
+- Week 1: foundation, contracts, context capture, benchmark scaffolding.
+- Week 2: judgment engine with deterministic review logic and structured findings.
+- Week 3: enterprise hardening (security, reliability, auditability, policy governance).
+- Week 4: controlled rollout, enforcement gates, quality operations, runbooks.
+
+## Core Design Principles
+
+- Precision over volume: avoid noisy comments.
+- Explainability: every finding must include evidence and rationale.
+- Safety: low-confidence paths should abstain.
+- Measurability: quality and latency are continuously tracked.

--- a/docs/identrail-reviewer/ground-truth-dataset.md
+++ b/docs/identrail-reviewer/ground-truth-dataset.md
@@ -1,0 +1,24 @@
+# Ground Truth Dataset Guide
+
+The benchmark dataset under `data/identrail-reviewer/benchmark` is used for replay-based
+precision/recall and false-positive measurement.
+
+## Record types
+
+- `pr_review_case`: a pull request snapshot with expected findings.
+- `issue_triage_case`: an issue snapshot with expected classification and severity.
+
+## Required fields
+
+Each case should include:
+- `id`: stable identifier
+- `source_url`: PR or issue URL
+- `captured_at`: ISO 8601 timestamp
+- `expected`: array of expected outcomes
+- `notes`: maintainer annotation explaining decisions
+
+## Quality rules
+
+- Keep expected outcomes tied to exact file and line where possible.
+- Mark uncertain historical decisions explicitly.
+- Do not include generated secrets or private data.

--- a/docs/identrail-reviewer/week-1-foundation.md
+++ b/docs/identrail-reviewer/week-1-foundation.md
@@ -1,0 +1,22 @@
+# Week 1 Foundation Plan
+
+This phase establishes the operational foundation for `identrail-reviewer`.
+
+## Scope
+
+- Reviewer contract and schema (`.github/identrail-reviewer/finding.schema.json`).
+- Reviewer policy baseline (`.github/identrail-reviewer/reviewer-config.yml`).
+- Shadow mode context collection workflow (`.github/workflows/identrail-reviewer-shadow.yml`).
+- Ground-truth benchmark data scaffolding (`data/identrail-reviewer/benchmark`).
+
+## Why this phase exists
+
+Without a strict contract and historical benchmark, reviewer quality cannot be measured
+reliably. Shadow mode lets us inspect behavior before any blocking policy is enabled.
+
+## Acceptance Criteria
+
+- Shadow workflow captures pull request and issue context as artifacts.
+- Output schema is defined and versioned.
+- Confidence thresholds and abstain policy are defined.
+- Benchmark folder exists with a documented record format.

--- a/docs/identrail-reviewer/week-2-judgment-engine.md
+++ b/docs/identrail-reviewer/week-2-judgment-engine.md
@@ -1,0 +1,32 @@
+# Week 2 Judgment Engine
+
+Week 2 delivers deterministic PR and issue review logic for `identrail-reviewer`.
+
+## Delivered components
+
+- CLI reviewer entrypoint:
+  - `cmd/identrail-reviewer/main.go`
+- Structured model and output contract usage:
+  - `internal/identrailreviewer/model/model.go`
+- Pull request review rules:
+  - `internal/identrailreviewer/review/pr.go`
+- Issue triage review rules:
+  - `internal/identrailreviewer/review/issue.go`
+- Utility parsing helpers:
+  - `internal/identrailreviewer/review/util.go`
+- Active review workflow with PR/issue comment upsert:
+  - `.github/workflows/identrail-reviewer-review.yml`
+
+## Review behavior
+
+- Deterministic workflow checks for release and permissions regressions.
+- PR template completeness validation.
+- Issue template completeness validation.
+- Public sensitive-data exposure detection in issue bodies.
+- Structured findings with severity, confidence, rationale, and recommendation.
+
+## Guardrails
+
+- Findings are deterministic and evidence-based.
+- If issue type cannot be inferred safely, reviewer abstains on that classification.
+- Comments are updated in-place to avoid review spam.

--- a/internal/identrailreviewer/model/model.go
+++ b/internal/identrailreviewer/model/model.go
@@ -1,0 +1,58 @@
+package model
+
+type Finding struct {
+	ID             string   `json:"id"`
+	Severity       string   `json:"severity"`
+	Confidence     float64  `json:"confidence"`
+	RuleID         string   `json:"rule_id"`
+	Summary        string   `json:"summary"`
+	Rationale      string   `json:"rationale"`
+	File           string   `json:"file"`
+	Line           int      `json:"line"`
+	Recommendation string   `json:"recommendation"`
+	References     []string `json:"references,omitempty"`
+}
+
+type ReviewResult struct {
+	Reviewer string            `json:"reviewer"`
+	Version  string            `json:"version"`
+	Mode     string            `json:"mode"`
+	Target   string            `json:"target"`
+	Number   int               `json:"number"`
+	Status   string            `json:"status"`
+	Summary  string            `json:"summary"`
+	Findings []Finding         `json:"findings"`
+	Abstain  []string          `json:"abstentions,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+type ChangedFile struct {
+	Filename string `json:"filename"`
+	Status   string `json:"status"`
+}
+
+type PullRequestEvent struct {
+	PullRequest PullRequest `json:"pull_request"`
+}
+
+type PullRequest struct {
+	Number int     `json:"number"`
+	Title  string  `json:"title"`
+	Body   string  `json:"body"`
+	Labels []Label `json:"labels"`
+}
+
+type IssueEvent struct {
+	Issue Issue `json:"issue"`
+}
+
+type Issue struct {
+	Number int     `json:"number"`
+	Title  string  `json:"title"`
+	Body   string  `json:"body"`
+	Labels []Label `json:"labels"`
+}
+
+type Label struct {
+	Name string `json:"name"`
+}

--- a/internal/identrailreviewer/review/issue.go
+++ b/internal/identrailreviewer/review/issue.go
@@ -1,0 +1,101 @@
+package review
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/model"
+)
+
+func ReviewIssue(number int, title, body string, labels []string) model.ReviewResult {
+	findings := make([]model.Finding, 0)
+	abstentions := make([]string, 0)
+
+	isBug := strings.HasPrefix(strings.ToLower(strings.TrimSpace(title)), "[bug]:") || hasLabel(labels, "kind/bug")
+	isFeature := strings.HasPrefix(strings.ToLower(strings.TrimSpace(title)), "[feature]:") || hasLabel(labels, "kind/enhancement")
+
+	if isBug {
+		required := []string{"Area", "Version", "Environment", "Steps to reproduce", "Expected behavior", "Actual behavior", "Impact"}
+		for _, heading := range required {
+			if !hasHeading(body, heading) {
+				findings = append(findings, model.Finding{
+					ID:             fmt.Sprintf("IR-IS-001-%s", slugToken(heading)),
+					Severity:       "P3",
+					Confidence:     0.88,
+					RuleID:         "issue/bug-template-completeness",
+					Summary:        fmt.Sprintf("Bug issue is missing required field: %s", heading),
+					Rationale:      "Missing bug context slows triage and increases misclassification risk.",
+					File:           ".github/ISSUE_TEMPLATE/bug_report.yml",
+					Line:           1,
+					Recommendation: fmt.Sprintf("Edit the issue to include a populated '%s' section.", heading),
+				})
+			}
+		}
+	}
+
+	if isFeature {
+		required := []string{"Problem statement", "Proposed solution", "Area", "User and operator impact", "Acceptance criteria"}
+		for _, heading := range required {
+			if !hasHeading(body, heading) {
+				findings = append(findings, model.Finding{
+					ID:             fmt.Sprintf("IR-IS-002-%s", slugToken(heading)),
+					Severity:       "P3",
+					Confidence:     0.88,
+					RuleID:         "issue/feature-template-completeness",
+					Summary:        fmt.Sprintf("Feature issue is missing required field: %s", heading),
+					Rationale:      "Feature requests need clear framing to support prioritization and design review.",
+					File:           ".github/ISSUE_TEMPLATE/feature_request.yml",
+					Line:           1,
+					Recommendation: fmt.Sprintf("Edit the issue to include a populated '%s' section.", heading),
+				})
+			}
+		}
+	}
+
+	if !isBug && !isFeature {
+		abstentions = append(abstentions, "issue type could not be confidently inferred from title or labels")
+	}
+
+	sensitivePattern := regexp.MustCompile(`(?i)(aws_access_key_id|aws_secret_access_key|-----BEGIN [A-Z ]+PRIVATE KEY-----|token\s*[:=]|password\s*[:=])`)
+	if sensitivePattern.MatchString(body) {
+		findings = append(findings, model.Finding{
+			ID:             "IR-IS-003",
+			Severity:       "P1",
+			Confidence:     0.90,
+			RuleID:         "issue/public-sensitive-material",
+			Summary:        "Issue body may include sensitive material",
+			Rationale:      "Public issues should not contain credentials, tokens, or private keys.",
+			File:           "ISSUE_BODY",
+			Line:           lineOfRegex(body, sensitivePattern),
+			Recommendation: "Redact sensitive values immediately and report vulnerabilities privately via SECURITY.md.",
+		})
+	}
+
+	status := "clean"
+	summary := "No deterministic triage findings were detected."
+	if len(findings) > 0 {
+		status = "findings"
+		summary = fmt.Sprintf("Detected %d issue triage finding(s).", len(findings))
+	}
+	if len(findings) == 0 && len(abstentions) > 0 {
+		status = "abstain"
+		summary = "No deterministic findings; reviewer abstained on issue-type classification."
+	}
+
+	return model.ReviewResult{
+		Reviewer: "identrail-reviewer",
+		Version:  "0.2.0-week2",
+		Mode:     "active",
+		Target:   "issue",
+		Number:   number,
+		Status:   status,
+		Summary:  summary,
+		Findings: findings,
+		Abstain:  abstentions,
+		Metadata: map[string]string{
+			"title":  title,
+			"labels": strings.Join(labels, ","),
+		},
+	}
+}

--- a/internal/identrailreviewer/review/issue_test.go
+++ b/internal/identrailreviewer/review/issue_test.go
@@ -1,0 +1,49 @@
+package review
+
+import "testing"
+
+func TestReviewIssueBugTemplateAndSensitiveMaterial(t *testing.T) {
+	result := ReviewIssue(
+		33,
+		"[bug]: api panic on startup",
+		"### Area\napi\n\n### Version\nv1.2.3\n\naWS_SECRET_ACCESS_KEY = abc123",
+		nil,
+	)
+	if result.Status != "findings" {
+		t.Fatalf("expected findings status, got %q", result.Status)
+	}
+	if len(result.Findings) == 0 {
+		t.Fatal("expected findings for incomplete bug template and sensitive material")
+	}
+}
+
+func TestReviewIssueFeatureCleanByLabel(t *testing.T) {
+	body := "" +
+		"### Problem statement\nx\n" +
+		"### Proposed solution\ny\n" +
+		"### Area\nz\n" +
+		"### User and operator impact\nlow\n" +
+		"### Acceptance criteria\ndone\n"
+	result := ReviewIssue(
+		34,
+		"Improve reporting",
+		body,
+		[]string{"kind/enhancement"},
+	)
+	if result.Status != "clean" {
+		t.Fatalf("expected clean status, got %q", result.Status)
+	}
+	if len(result.Findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(result.Findings))
+	}
+}
+
+func TestReviewIssueAbstainWhenTypeUnknown(t *testing.T) {
+	result := ReviewIssue(35, "Question about docs", "body", []string{"question"})
+	if result.Status != "abstain" {
+		t.Fatalf("expected abstain status, got %q", result.Status)
+	}
+	if len(result.Abstain) == 0 {
+		t.Fatal("expected abstention note")
+	}
+}

--- a/internal/identrailreviewer/review/pr.go
+++ b/internal/identrailreviewer/review/pr.go
@@ -1,0 +1,130 @@
+package review
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/model"
+)
+
+func ReviewPR(repoRoot string, number int, title, body string, labels []string, changedFiles []model.ChangedFile) model.ReviewResult {
+	findings := make([]model.Finding, 0)
+	abstentions := make([]string, 0)
+
+	for _, f := range changedFiles {
+		if !isWorkflowFile(f.Filename) {
+			continue
+		}
+
+		content, err := readFile(repoRoot, f.Filename)
+		if err != nil {
+			abstentions = append(abstentions, fmt.Sprintf("unable to inspect %s: %v", f.Filename, err))
+			continue
+		}
+
+		if strings.Contains(content, "https://api.identrail.example") {
+			findings = append(findings, model.Finding{
+				ID:             "IR-PR-001",
+				Severity:       "P1",
+				Confidence:     0.98,
+				RuleID:         "workflow/release-web-api-placeholder",
+				Summary:        "Release web image uses placeholder production API URL",
+				Rationale:      "Hardcoded example endpoints in release images can ship misconfigured production builds.",
+				File:           f.Filename,
+				Line:           lineOfSubstring(content, "https://api.identrail.example"),
+				Recommendation: "Use a repository variable or workflow input to inject the real API URL and fail if unset.",
+			})
+		}
+
+		if strings.Contains(content, `if [[ "${tag}" == *-* ]]`) && strings.Contains(content, `(\+[0-9A-Za-z.-]+)?$`) {
+			findings = append(findings, model.Finding{
+				ID:             "IR-PR-002",
+				Severity:       "P2",
+				Confidence:     0.91,
+				RuleID:         "workflow/prerelease-detection-build-metadata",
+				Summary:        "Prerelease detection may misclassify build-metadata tags",
+				Rationale:      "Checking for '-' across the whole tag can classify stable tags with +build metadata incorrectly.",
+				File:           f.Filename,
+				Line:           lineOfSubstring(content, `if [[ "${tag}" == *-* ]]`),
+				Recommendation: "Strip +build metadata before prerelease detection or match only semantic prerelease segment.",
+			})
+		}
+
+		if !strings.Contains(content, "\npermissions:") && !strings.HasPrefix(content, "permissions:") {
+			findings = append(findings, model.Finding{
+				ID:             "IR-PR-003",
+				Severity:       "P2",
+				Confidence:     0.87,
+				RuleID:         "workflow/missing-permissions-block",
+				Summary:        "Workflow file does not declare explicit permissions",
+				Rationale:      "Explicit permissions reduce token scope and limit blast radius during workflow execution.",
+				File:           f.Filename,
+				Line:           1,
+				Recommendation: "Add a top-level permissions block with least-privilege scopes.",
+			})
+		}
+	}
+
+	sections := []string{
+		"Summary",
+		"Why",
+		"Scope",
+		"Validation",
+		"Checklist",
+		"AI Assistance Disclosure",
+		"Related Issues",
+	}
+	for _, section := range sections {
+		if !hasHeading(body, section) {
+			findings = append(findings, model.Finding{
+				ID:             fmt.Sprintf("IR-PR-004-%s", slugToken(section)),
+				Severity:       "P3",
+				Confidence:     0.84,
+				RuleID:         "process/pr-template-missing-sections",
+				Summary:        fmt.Sprintf("PR description missing required section: %s", section),
+				Rationale:      "Consistent PR structure improves review quality, traceability, and change risk assessment.",
+				File:           ".github/PULL_REQUEST_TEMPLATE.md",
+				Line:           1,
+				Recommendation: fmt.Sprintf("Update the PR body to include the '%s' section.", section),
+			})
+		}
+	}
+
+	status := "clean"
+	summary := "No deterministic findings were detected."
+	if len(findings) > 0 {
+		status = "findings"
+		summary = fmt.Sprintf("Detected %d deterministic finding(s) for review.", len(findings))
+	}
+
+	if len(findings) == 0 && len(abstentions) > 0 {
+		status = "abstain"
+		summary = "No deterministic findings; reviewer abstained on at least one check."
+	}
+
+	return model.ReviewResult{
+		Reviewer: "identrail-reviewer",
+		Version:  "0.2.0-week2",
+		Mode:     "active",
+		Target:   "pull_request",
+		Number:   number,
+		Status:   status,
+		Summary:  summary,
+		Findings: findings,
+		Abstain:  abstentions,
+		Metadata: map[string]string{
+			"title":     title,
+			"labels":    strings.Join(labels, ","),
+			"fileCount": fmt.Sprintf("%d", len(changedFiles)),
+		},
+	}
+}
+
+func isWorkflowFile(path string) bool {
+	if !strings.HasPrefix(path, ".github/workflows/") {
+		return false
+	}
+	ext := strings.ToLower(filepath.Ext(path))
+	return ext == ".yml" || ext == ".yaml"
+}

--- a/internal/identrailreviewer/review/pr_test.go
+++ b/internal/identrailreviewer/review/pr_test.go
@@ -1,0 +1,130 @@
+package review
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/model"
+)
+
+func TestReviewPRDetectsWorkflowAndTemplateFindings(t *testing.T) {
+	t.Helper()
+	repoRoot := t.TempDir()
+	workflowPath := filepath.Join(repoRoot, ".github", "workflows", "release.yml")
+	if err := writeFile(workflowPath, strings.Join([]string{
+		"name: release",
+		"on:",
+		"  push:",
+		"    tags:",
+		"      - v*",
+		"jobs:",
+		"  release:",
+		"    runs-on: ubuntu-latest",
+		"    steps:",
+		`      - run: echo "https://api.identrail.example"`,
+		`      - run: |`,
+		`          if [[ "${tag}" == *-* ]]; then`,
+		`            echo "${tag}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'`,
+		"          fi",
+	}, "\n")); err != nil {
+		t.Fatalf("write workflow fixture: %v", err)
+	}
+
+	result := ReviewPR(
+		repoRoot,
+		101,
+		"Week2 reviewer PR",
+		"### Summary\n",
+		[]string{"area/security"},
+		[]model.ChangedFile{
+			{Filename: ".github/workflows/release.yml", Status: "modified"},
+			{Filename: "README.md", Status: "modified"},
+		},
+	)
+
+	if result.Status != "findings" {
+		t.Fatalf("expected findings status, got %q", result.Status)
+	}
+	if len(result.Findings) < 4 {
+		t.Fatalf("expected multiple findings, got %d", len(result.Findings))
+	}
+	if result.Metadata["fileCount"] != "2" {
+		t.Fatalf("expected fileCount=2, got %q", result.Metadata["fileCount"])
+	}
+
+	wantRules := map[string]bool{
+		"workflow/release-web-api-placeholder":         false,
+		"workflow/prerelease-detection-build-metadata": false,
+		"workflow/missing-permissions-block":           false,
+		"process/pr-template-missing-sections":         false,
+	}
+	for _, finding := range result.Findings {
+		if _, ok := wantRules[finding.RuleID]; ok {
+			wantRules[finding.RuleID] = true
+		}
+	}
+	for ruleID, seen := range wantRules {
+		if !seen {
+			t.Fatalf("expected finding for rule %q", ruleID)
+		}
+	}
+}
+
+func TestReviewPRAbstainsOnUnreadableWorkflow(t *testing.T) {
+	result := ReviewPR(
+		t.TempDir(),
+		102,
+		"Week2 reviewer PR",
+		fullPRTemplateBody(),
+		nil,
+		[]model.ChangedFile{
+			{Filename: ".github/workflows/missing.yml", Status: "modified"},
+		},
+	)
+	if result.Status != "abstain" {
+		t.Fatalf("expected abstain status, got %q", result.Status)
+	}
+	if len(result.Findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(result.Findings))
+	}
+	if len(result.Abstain) == 0 {
+		t.Fatal("expected abstention note")
+	}
+}
+
+func TestIsWorkflowFile(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{path: ".github/workflows/build.yml", want: true},
+		{path: ".github/workflows/build.yaml", want: true},
+		{path: ".github/workflows/build.txt", want: false},
+		{path: "deploy/workflows/build.yml", want: false},
+	}
+	for _, tc := range cases {
+		if got := isWorkflowFile(tc.path); got != tc.want {
+			t.Fatalf("isWorkflowFile(%q)=%t want %t", tc.path, got, tc.want)
+		}
+	}
+}
+
+func fullPRTemplateBody() string {
+	return strings.Join([]string{
+		"### Summary",
+		"ok",
+		"### Why",
+		"ok",
+		"### Scope",
+		"ok",
+		"### Validation",
+		"ok",
+		"### Checklist",
+		"ok",
+		"### AI Assistance Disclosure",
+		"ok",
+		"### Related Issues",
+		"ok",
+	}, "\n")
+}

--- a/internal/identrailreviewer/review/test_helpers_test.go
+++ b/internal/identrailreviewer/review/test_helpers_test.go
@@ -1,0 +1,13 @@
+package review
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func writeFile(path string, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o644)
+}

--- a/internal/identrailreviewer/review/util.go
+++ b/internal/identrailreviewer/review/util.go
@@ -1,0 +1,72 @@
+package review
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+func readFile(repoRoot, relPath string) (string, error) {
+	b, err := os.ReadFile(filepath.Join(repoRoot, relPath))
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func lineOfSubstring(content, needle string) int {
+	if needle == "" {
+		return 1
+	}
+	s := bufio.NewScanner(strings.NewReader(content))
+	line := 1
+	for s.Scan() {
+		if strings.Contains(s.Text(), needle) {
+			return line
+		}
+		line++
+	}
+	return 1
+}
+
+func lineOfRegex(content string, re *regexp.Regexp) int {
+	s := bufio.NewScanner(strings.NewReader(content))
+	line := 1
+	for s.Scan() {
+		if re.MatchString(s.Text()) {
+			return line
+		}
+		line++
+	}
+	return 1
+}
+
+func hasHeading(body, heading string) bool {
+	needle := "### " + strings.ToLower(strings.TrimSpace(heading))
+	s := bufio.NewScanner(strings.NewReader(body))
+	for s.Scan() {
+		if strings.TrimSpace(strings.ToLower(s.Text())) == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func hasLabel(labels []string, want string) bool {
+	for _, label := range labels {
+		if strings.EqualFold(label, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func slugToken(s string) string {
+	token := strings.ToLower(strings.TrimSpace(s))
+	token = strings.ReplaceAll(token, " ", "-")
+	token = strings.ReplaceAll(token, "/", "-")
+	token = strings.ReplaceAll(token, "_", "-")
+	return token
+}

--- a/internal/identrailreviewer/review/util_test.go
+++ b/internal/identrailreviewer/review/util_test.go
@@ -1,0 +1,60 @@
+package review
+
+import (
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+func TestReadFileAndHelpers(t *testing.T) {
+	root := t.TempDir()
+	rel := filepath.Join("nested", "file.txt")
+	full := filepath.Join(root, rel)
+	if err := writeFile(full, "line1\nsecret=abc\nline3\n"); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	content, err := readFile(root, rel)
+	if err != nil {
+		t.Fatalf("readFile: %v", err)
+	}
+	if content == "" {
+		t.Fatal("expected non-empty content")
+	}
+
+	if got := lineOfSubstring(content, "secret=abc"); got != 2 {
+		t.Fatalf("unexpected substring line: %d", got)
+	}
+	if got := lineOfSubstring(content, "missing"); got != 1 {
+		t.Fatalf("unexpected fallback line: %d", got)
+	}
+	if got := lineOfSubstring(content, ""); got != 1 {
+		t.Fatalf("unexpected empty needle line: %d", got)
+	}
+
+	re := regexp.MustCompile(`secret=`)
+	if got := lineOfRegex(content, re); got != 2 {
+		t.Fatalf("unexpected regex line: %d", got)
+	}
+}
+
+func TestHeadingLabelAndSlugHelpers(t *testing.T) {
+	if !hasHeading("### Summary\nok", "summary") {
+		t.Fatal("expected heading match")
+	}
+	if hasHeading("### Scope\nok", "summary") {
+		t.Fatal("did not expect heading match")
+	}
+	if !hasLabel([]string{"Kind/Bug"}, "kind/bug") {
+		t.Fatal("expected case-insensitive label match")
+	}
+	if hasLabel([]string{"kind/enhancement"}, "kind/bug") {
+		t.Fatal("did not expect label match")
+	}
+	if got := slugToken("User and operator impact"); got != "user-and-operator-impact" {
+		t.Fatalf("unexpected slug token: %q", got)
+	}
+	if got := slugToken("A/B_C"); got != "a-b-c" {
+		t.Fatalf("unexpected slash/underscore normalization: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
Week 2 adds the first active judgment engine for `identrail-reviewer` on top of Week 1.

## What is included
- Deterministic reviewer CLI:
  - `cmd/identrail-reviewer/main.go`
- Structured review models:
  - `internal/identrailreviewer/model/model.go`
- PR review rules:
  - `internal/identrailreviewer/review/pr.go`
- Issue triage rules:
  - `internal/identrailreviewer/review/issue.go`
- Parsing and helper utilities:
  - `internal/identrailreviewer/review/util.go`
- Active workflow for PR/issue review and comment upsert:
  - `.github/workflows/identrail-reviewer-review.yml`
- Week 2 documentation:
  - `docs/identrail-reviewer/week-2-judgment-engine.md`

## Behavior
- Detects deterministic workflow and process regressions.
- Checks PR description completeness against required sections.
- Checks issue template completeness and basic sensitive-data exposure patterns.
- Publishes structured findings with severity, confidence, rationale, and recommendation.
- Upserts a single reviewer comment to avoid noise.

## Notes
- This PR is stacked on Week 1 (`identrail-reviewer/week-1-foundation`).
- Verified with local `go test` on reviewer packages and YAML parse validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic PR and issue judgment engine with active and shadow GitHub workflows for `identrail-reviewer`, plus unit tests to lock behavior and satisfy coverage. It validates PR context, paginates changed files, and upserts a single deduped review comment with structured findings.

- New Features
  - CLI `identrail-reviewer` with `review-pr` and `review-issue`, emitting JSON `ReviewResult` (`cmd/identrail-reviewer/main.go`).
  - Deterministic rule sets for PRs and issues: PR template checks; issue template checks and basic sensitive-data detection (`internal/identrailreviewer/review/pr.go`, `internal/identrailreviewer/review/issue.go`).
  - Active workflow `identrail-reviewer-review` runs on PRs/issues, paginates changed files, uploads a review artifact, and dedupes/upserts a single comment via `.github/scripts/identrail-reviewer/upsert-review-comment.js` (`.github/workflows/identrail-reviewer-review.yml`).
  - Shadow workflow `identrail-reviewer-shadow` captures PR/issue context artifacts with read-only permissions for replay/benchmarking (`.github/workflows/identrail-reviewer-shadow.yml`).
  - Contracts, policy, and docs: finding schema, reviewer config with thresholds/routing, and dataset scaffolding (`.github/identrail-reviewer/*`, `data/identrail-reviewer/benchmark`, `docs/identrail-reviewer/*`).
  - Unit tests for CLI, PR/issue rules, and helpers to meet coverage gate (`cmd/identrail-reviewer/main_test.go`, `internal/identrailreviewer/review/*_test.go`).

<sup>Written for commit 5a6c8304cfde3d2dbfbb84b6f3f51c799bd624e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

