### PR TITLE
identrail-reviewer Week 3: enterprise policy enforcement, audit trail, and workflow hardening

### DIFF
--- a/.github/identrail-reviewer/policy.v1.json
+++ b/.github/identrail-reviewer/policy.v1.json
@@ -1,0 +1,22 @@
+{
+  "version": "2026-04-04",
+  "confidence": {
+    "p0_min": 0.95,
+    "p1_min": 0.90,
+    "p2_min": 0.82,
+    "p3_min": 0.75
+  },
+  "abstain_below": 0.80,
+  "require_evidence": true,
+  "required_fields": [
+    "id",
+    "severity",
+    "confidence",
+    "rule_id",
+    "summary",
+    "rationale",
+    "file",
+    "line",
+    "recommendation"
+  ]
+}

--- a/.github/workflows/identrail-reviewer-review.yml
+++ b/.github/workflows/identrail-reviewer-review.yml
@@ -65,17 +65,39 @@ jobs:
       - name: Run identrail-reviewer (PR)
         run: |
           set -euo pipefail
-          go run ./cmd/identrail-reviewer review-pr \
-            --repo-root . \
-            --event-path "$GITHUB_EVENT_PATH" \
-            --changed-files .tmp/changed-files.json \
-            --output .tmp/review.json
+          mkdir -p .tmp
+          for attempt in 1 2 3; do
+            if go run ./cmd/identrail-reviewer review-pr \
+              --repo-root . \
+              --event-path "$GITHUB_EVENT_PATH" \
+              --changed-files .tmp/changed-files.json \
+              --policy .github/identrail-reviewer/policy.v1.json \
+              --audit-log .tmp/audit.jsonl \
+              --output .tmp/review.json; then
+              break
+            fi
+
+            if [ "${attempt}" -eq 3 ]; then
+              echo "identrail-reviewer failed after 3 attempts" >&2
+              exit 1
+            fi
+            sleep $((attempt * 2))
+          done
+
+      - name: Generate review checksums
+        run: |
+          set -euo pipefail
+          sha256sum .tmp/review.json .tmp/audit.jsonl > .tmp/review.sha256
 
       - name: Upload review artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: identrail-reviewer-pr-${{ github.event.pull_request.number }}
-          path: .tmp/review.json
+          path: |
+            .tmp/review.json
+            .tmp/audit.jsonl
+            .tmp/review.sha256
           if-no-files-found: error
 
       - name: Upsert PR review comment
@@ -111,15 +133,36 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p .tmp
-          go run ./cmd/identrail-reviewer review-issue \
-            --event-path "$GITHUB_EVENT_PATH" \
-            --output .tmp/review.json
+          for attempt in 1 2 3; do
+            if go run ./cmd/identrail-reviewer review-issue \
+              --event-path "$GITHUB_EVENT_PATH" \
+              --policy .github/identrail-reviewer/policy.v1.json \
+              --audit-log .tmp/audit.jsonl \
+              --output .tmp/review.json; then
+              break
+            fi
+
+            if [ "${attempt}" -eq 3 ]; then
+              echo "identrail-reviewer failed after 3 attempts" >&2
+              exit 1
+            fi
+            sleep $((attempt * 2))
+          done
+
+      - name: Generate issue review checksums
+        run: |
+          set -euo pipefail
+          sha256sum .tmp/review.json .tmp/audit.jsonl > .tmp/review.sha256
 
       - name: Upload issue review artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: identrail-reviewer-issue-${{ github.event.issue.number }}
-          path: .tmp/review.json
+          path: |
+            .tmp/review.json
+            .tmp/audit.jsonl
+            .tmp/review.sha256
           if-no-files-found: error
 
       - name: Upsert issue review comment

--- a/cmd/identrail-reviewer/main.go
+++ b/cmd/identrail-reviewer/main.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/audit"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/model"
+	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/policy"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/review"
 )
 
@@ -31,6 +33,8 @@ func reviewPR(args []string) {
 	repoRoot := fs.String("repo-root", ".", "repository root")
 	eventPath := fs.String("event-path", "", "GitHub event payload path")
 	changedFilesPath := fs.String("changed-files", "", "changed files JSON path")
+	policyPath := fs.String("policy", "", "review policy JSON path")
+	auditPath := fs.String("audit-log", "", "audit JSONL output path")
 	outputPath := fs.String("output", "", "output path for review result")
 	_ = fs.Parse(args)
 
@@ -74,12 +78,24 @@ func reviewPR(args []string) {
 		labels,
 		changedFiles,
 	)
+
+	cfg, err := policy.Load(*policyPath)
+	if err != nil {
+		fatal("failed to load policy: " + err.Error())
+	}
+	result = policy.Apply(cfg, result)
+
+	if err := audit.Append(*auditPath, result); err != nil {
+		fatal("failed to write audit log: " + err.Error())
+	}
 	writeJSON(*outputPath, result)
 }
 
 func reviewIssue(args []string) {
 	fs := flag.NewFlagSet("review-issue", flag.ExitOnError)
 	eventPath := fs.String("event-path", "", "GitHub event payload path")
+	policyPath := fs.String("policy", "", "review policy JSON path")
+	auditPath := fs.String("audit-log", "", "audit JSONL output path")
 	outputPath := fs.String("output", "", "output path for review result")
 	_ = fs.Parse(args)
 
@@ -112,6 +128,16 @@ func reviewIssue(args []string) {
 		event.Issue.Body,
 		labels,
 	)
+
+	cfg, err := policy.Load(*policyPath)
+	if err != nil {
+		fatal("failed to load policy: " + err.Error())
+	}
+	result = policy.Apply(cfg, result)
+
+	if err := audit.Append(*auditPath, result); err != nil {
+		fatal("failed to write audit log: " + err.Error())
+	}
 	writeJSON(*outputPath, result)
 }
 

--- a/docs/identrail-reviewer/week-3-hardening.md
+++ b/docs/identrail-reviewer/week-3-hardening.md
@@ -1,0 +1,24 @@
+# Week 3 Enterprise Hardening
+
+Week 3 adds enterprise controls to improve precision, traceability, and operational resilience.
+
+## Delivered controls
+
+- Policy versioning and enforcement:
+  - `.github/identrail-reviewer/policy.v1.json`
+  - `internal/identrailreviewer/policy/policy.go`
+- Audit trail writer:
+  - `internal/identrailreviewer/audit/audit.go`
+- Runtime hardening in reviewer CLI:
+  - policy filtering (confidence and evidence checks)
+  - audit entry append support
+- Workflow hardening:
+  - retry wrapper for reviewer execution
+  - output checksum artifacts for integrity review
+
+## Control outcomes
+
+- Low-confidence findings are suppressed and converted into explicit abstentions.
+- Findings missing required evidence fields are suppressed automatically.
+- Every run can emit audit records with deterministic finding fingerprints.
+- Artifacts include checksums for integrity verification in CI logs.

--- a/internal/identrailreviewer/audit/audit.go
+++ b/internal/identrailreviewer/audit/audit.go
@@ -1,0 +1,82 @@
+package audit
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/model"
+)
+
+type Entry struct {
+	Timestamp       string `json:"timestamp"`
+	Reviewer        string `json:"reviewer"`
+	Version         string `json:"version"`
+	Target          string `json:"target"`
+	Number          int    `json:"number"`
+	Status          string `json:"status"`
+	FindingCount    int    `json:"finding_count"`
+	AbstentionCount int    `json:"abstention_count"`
+	PolicyVersion   string `json:"policy_version,omitempty"`
+	Fingerprint     string `json:"fingerprint"`
+}
+
+func Append(path string, result model.ReviewResult) error {
+	if path == "" {
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create audit directory: %w", err)
+	}
+
+	fingerprint, err := findingFingerprint(result.Findings)
+	if err != nil {
+		return fmt.Errorf("calculate fingerprint: %w", err)
+	}
+
+	entry := Entry{
+		Timestamp:       time.Now().UTC().Format(time.RFC3339),
+		Reviewer:        result.Reviewer,
+		Version:         result.Version,
+		Target:          result.Target,
+		Number:          result.Number,
+		Status:          result.Status,
+		FindingCount:    len(result.Findings),
+		AbstentionCount: len(result.Abstain),
+		Fingerprint:     fingerprint,
+	}
+	if result.Metadata != nil {
+		entry.PolicyVersion = result.Metadata["policy_version"]
+	}
+
+	b, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("marshal audit entry: %w", err)
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open audit file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		return fmt.Errorf("write audit entry: %w", err)
+	}
+
+	return nil
+}
+
+func findingFingerprint(findings []model.Finding) (string, error) {
+	b, err := json.Marshal(findings)
+	if err != nil {
+		return "", err
+	}
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:]), nil
+}

--- a/internal/identrailreviewer/audit/audit_test.go
+++ b/internal/identrailreviewer/audit/audit_test.go
@@ -1,0 +1,99 @@
+package audit
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/model"
+)
+
+func TestAppendNoopWhenPathEmpty(t *testing.T) {
+	if err := Append("", model.ReviewResult{}); err != nil {
+		t.Fatalf("append with empty path should be a no-op: %v", err)
+	}
+}
+
+func TestAppendWritesAuditEntry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit", "events.jsonl")
+	result := model.ReviewResult{
+		Reviewer: "identrail-reviewer",
+		Version:  "0.3.0",
+		Target:   "pr",
+		Number:   74,
+		Status:   "findings",
+		Findings: []model.Finding{
+			{ID: "F-1", RuleID: "rule-a", Severity: "P1", Confidence: 0.91, File: "a.go", Line: 10},
+		},
+		Abstain: []string{"suppressed low confidence"},
+		Metadata: map[string]string{
+			"policy_version": "policy.v1",
+		},
+	}
+
+	if err := Append(path, result); err != nil {
+		t.Fatalf("append audit entry: %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read audit file: %v", err)
+	}
+
+	var entry Entry
+	if err := json.Unmarshal(content, &entry); err != nil {
+		t.Fatalf("unmarshal audit entry: %v", err)
+	}
+
+	if entry.Reviewer != result.Reviewer {
+		t.Fatalf("reviewer mismatch: got %q want %q", entry.Reviewer, result.Reviewer)
+	}
+	if entry.Version != result.Version {
+		t.Fatalf("version mismatch: got %q want %q", entry.Version, result.Version)
+	}
+	if entry.Target != result.Target {
+		t.Fatalf("target mismatch: got %q want %q", entry.Target, result.Target)
+	}
+	if entry.Number != result.Number {
+		t.Fatalf("number mismatch: got %d want %d", entry.Number, result.Number)
+	}
+	if entry.Status != result.Status {
+		t.Fatalf("status mismatch: got %q want %q", entry.Status, result.Status)
+	}
+	if entry.FindingCount != len(result.Findings) {
+		t.Fatalf("finding count mismatch: got %d want %d", entry.FindingCount, len(result.Findings))
+	}
+	if entry.AbstentionCount != len(result.Abstain) {
+		t.Fatalf("abstention count mismatch: got %d want %d", entry.AbstentionCount, len(result.Abstain))
+	}
+	if entry.PolicyVersion != "policy.v1" {
+		t.Fatalf("policy version mismatch: got %q", entry.PolicyVersion)
+	}
+	if len(entry.Fingerprint) != 64 {
+		t.Fatalf("fingerprint should be 64 hex chars, got %d", len(entry.Fingerprint))
+	}
+	if _, err := time.Parse(time.RFC3339, entry.Timestamp); err != nil {
+		t.Fatalf("timestamp should be RFC3339: %v", err)
+	}
+}
+
+func TestFindingFingerprintDeterministic(t *testing.T) {
+	findings := []model.Finding{
+		{ID: "F-1", RuleID: "rule-a", Severity: "P1", Confidence: 0.91, File: "a.go", Line: 10},
+		{ID: "F-2", RuleID: "rule-b", Severity: "P2", Confidence: 0.88, File: "b.go", Line: 22},
+	}
+
+	first, err := findingFingerprint(findings)
+	if err != nil {
+		t.Fatalf("first fingerprint: %v", err)
+	}
+	second, err := findingFingerprint(findings)
+	if err != nil {
+		t.Fatalf("second fingerprint: %v", err)
+	}
+	if first != second {
+		t.Fatalf("fingerprints must be deterministic: %q != %q", first, second)
+	}
+}

--- a/internal/identrailreviewer/policy/policy.go
+++ b/internal/identrailreviewer/policy/policy.go
@@ -1,0 +1,180 @@
+package policy
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/model"
+)
+
+type Config struct {
+	Version         string              `json:"version"`
+	Confidence      confidenceThreshold `json:"confidence"`
+	AbstainBelow    float64             `json:"abstain_below"`
+	RequireEvidence bool                `json:"require_evidence"`
+	RequiredFields  []string            `json:"required_fields"`
+}
+
+type confidenceThreshold struct {
+	P0Min float64 `json:"p0_min"`
+	P1Min float64 `json:"p1_min"`
+	P2Min float64 `json:"p2_min"`
+	P3Min float64 `json:"p3_min"`
+}
+
+func Load(path string) (Config, error) {
+	if path == "" {
+		return defaultConfig(), nil
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, fmt.Errorf("read policy: %w", err)
+	}
+
+	cfg := defaultConfig()
+	if err := json.Unmarshal(b, &cfg); err != nil {
+		return Config{}, fmt.Errorf("parse policy JSON: %w", err)
+	}
+	return cfg, nil
+}
+
+func Apply(cfg Config, result model.ReviewResult) model.ReviewResult {
+	filtered := make([]model.Finding, 0, len(result.Findings))
+	abstentions := append([]string{}, result.Abstain...)
+	suppressed := 0
+
+	for _, finding := range result.Findings {
+		if cfg.RequireEvidence && !hasRequiredFields(finding, cfg.RequiredFields) {
+			suppressed++
+			abstentions = append(abstentions, fmt.Sprintf("suppressed %s: incomplete evidence fields", finding.ID))
+			continue
+		}
+
+		requiredConfidence := minConfidence(cfg, finding.Severity)
+		if finding.Confidence < requiredConfidence {
+			suppressed++
+			abstentions = append(abstentions, fmt.Sprintf("suppressed %s: confidence %.2f below %.2f", finding.ID, finding.Confidence, requiredConfidence))
+			continue
+		}
+
+		filtered = append(filtered, finding)
+	}
+
+	result.Findings = filtered
+	result.Abstain = abstentions
+	if result.Metadata == nil {
+		result.Metadata = map[string]string{}
+	}
+	result.Metadata["policy_version"] = cfg.Version
+	result.Metadata["suppressed_findings"] = fmt.Sprintf("%d", suppressed)
+
+	if len(filtered) == 0 && len(abstentions) > 0 {
+		result.Status = "abstain"
+		if suppressed > 0 {
+			result.Summary = "Findings were suppressed by policy thresholds or evidence requirements."
+		}
+	} else if len(filtered) > 0 {
+		result.Status = "findings"
+		result.Summary = fmt.Sprintf("Detected %d deterministic finding(s) after policy filtering.", len(filtered))
+	} else {
+		result.Status = "clean"
+		result.Summary = "No deterministic findings after policy filtering."
+	}
+
+	return result
+}
+
+func minConfidence(cfg Config, severity string) float64 {
+	threshold := cfg.AbstainBelow
+	switch strings.ToUpper(strings.TrimSpace(severity)) {
+	case "P0":
+		if cfg.Confidence.P0Min > threshold {
+			threshold = cfg.Confidence.P0Min
+		}
+	case "P1":
+		if cfg.Confidence.P1Min > threshold {
+			threshold = cfg.Confidence.P1Min
+		}
+	case "P2":
+		if cfg.Confidence.P2Min > threshold {
+			threshold = cfg.Confidence.P2Min
+		}
+	case "P3":
+		if cfg.Confidence.P3Min > threshold {
+			threshold = cfg.Confidence.P3Min
+		}
+	}
+	return threshold
+}
+
+func hasRequiredFields(f model.Finding, fields []string) bool {
+	for _, field := range fields {
+		switch field {
+		case "id":
+			if strings.TrimSpace(f.ID) == "" {
+				return false
+			}
+		case "severity":
+			if strings.TrimSpace(f.Severity) == "" {
+				return false
+			}
+		case "confidence":
+			if f.Confidence <= 0 || f.Confidence > 1 {
+				return false
+			}
+		case "rule_id":
+			if strings.TrimSpace(f.RuleID) == "" {
+				return false
+			}
+		case "summary":
+			if strings.TrimSpace(f.Summary) == "" {
+				return false
+			}
+		case "rationale":
+			if strings.TrimSpace(f.Rationale) == "" {
+				return false
+			}
+		case "file":
+			if strings.TrimSpace(f.File) == "" {
+				return false
+			}
+		case "line":
+			if f.Line <= 0 {
+				return false
+			}
+		case "recommendation":
+			if strings.TrimSpace(f.Recommendation) == "" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func defaultConfig() Config {
+	return Config{
+		Version: "builtin-v1",
+		Confidence: confidenceThreshold{
+			P0Min: 0.95,
+			P1Min: 0.90,
+			P2Min: 0.82,
+			P3Min: 0.75,
+		},
+		AbstainBelow:    0.80,
+		RequireEvidence: true,
+		RequiredFields: []string{
+			"id",
+			"severity",
+			"confidence",
+			"rule_id",
+			"summary",
+			"rationale",
+			"file",
+			"line",
+			"recommendation",
+		},
+	}
+}

--- a/internal/identrailreviewer/policy/policy.go
+++ b/internal/identrailreviewer/policy/policy.go
@@ -24,6 +24,18 @@ type confidenceThreshold struct {
 	P3Min float64 `json:"p3_min"`
 }
 
+var allowedRequiredFields = map[string]struct{}{
+	"id":             {},
+	"severity":       {},
+	"confidence":     {},
+	"rule_id":        {},
+	"summary":        {},
+	"rationale":      {},
+	"file":           {},
+	"line":           {},
+	"recommendation": {},
+}
+
 func Load(path string) (Config, error) {
 	if path == "" {
 		return defaultConfig(), nil
@@ -38,6 +50,11 @@ func Load(path string) (Config, error) {
 	if err := json.Unmarshal(b, &cfg); err != nil {
 		return Config{}, fmt.Errorf("parse policy JSON: %w", err)
 	}
+	requiredFields, err := normalizeRequiredFields(cfg.RequiredFields)
+	if err != nil {
+		return Config{}, fmt.Errorf("validate policy: %w", err)
+	}
+	cfg.RequiredFields = requiredFields
 	return cfg, nil
 }
 
@@ -112,7 +129,7 @@ func minConfidence(cfg Config, severity string) float64 {
 
 func hasRequiredFields(f model.Finding, fields []string) bool {
 	for _, field := range fields {
-		switch field {
+		switch strings.ToLower(strings.TrimSpace(field)) {
 		case "id":
 			if strings.TrimSpace(f.ID) == "" {
 				return false
@@ -149,9 +166,26 @@ func hasRequiredFields(f model.Finding, fields []string) bool {
 			if strings.TrimSpace(f.Recommendation) == "" {
 				return false
 			}
+		default:
+			return false
 		}
 	}
 	return true
+}
+
+func normalizeRequiredFields(fields []string) ([]string, error) {
+	normalized := make([]string, 0, len(fields))
+	for _, field := range fields {
+		value := strings.ToLower(strings.TrimSpace(field))
+		if value == "" {
+			return nil, fmt.Errorf("required_fields contains empty field name")
+		}
+		if _, ok := allowedRequiredFields[value]; !ok {
+			return nil, fmt.Errorf("required_fields contains unknown field %q", field)
+		}
+		normalized = append(normalized, value)
+	}
+	return normalized, nil
 }
 
 func defaultConfig() Config {

--- a/internal/identrailreviewer/policy/policy_test.go
+++ b/internal/identrailreviewer/policy/policy_test.go
@@ -1,0 +1,85 @@
+package policy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/model"
+)
+
+func TestApplyUnknownRequiredFieldFailsClosed(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.RequiredFields = append(cfg.RequiredFields, "recomendation")
+
+	result := Apply(cfg, model.ReviewResult{
+		Findings: []model.Finding{validFinding()},
+	})
+
+	if len(result.Findings) != 0 {
+		t.Fatalf("expected finding to be suppressed for unknown required field, got %d findings", len(result.Findings))
+	}
+	if result.Status != "abstain" {
+		t.Fatalf("expected status abstain, got %q", result.Status)
+	}
+}
+
+func TestApplyNormalizesRequiredFieldNames(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.RequiredFields = []string{
+		" ID ",
+		"Severity",
+		"CONFIDENCE",
+		"Rule_ID",
+		"Summary",
+		"Rationale",
+		"File",
+		"Line",
+		"Recommendation",
+	}
+
+	result := Apply(cfg, model.ReviewResult{
+		Findings: []model.Finding{validFinding()},
+	})
+
+	if len(result.Findings) != 1 {
+		t.Fatalf("expected finding to remain after normalized required fields, got %d", len(result.Findings))
+	}
+	if result.Status != "findings" {
+		t.Fatalf("expected status findings, got %q", result.Status)
+	}
+}
+
+func TestLoadRejectsUnknownRequiredField(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "policy.json")
+	content := `{
+		"required_fields": ["id", "recomendation"]
+	}`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write policy fixture: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected load to fail for unknown required field")
+	}
+	if !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("expected unknown field validation error, got %v", err)
+	}
+}
+
+func validFinding() model.Finding {
+	return model.Finding{
+		ID:             "F-1",
+		Severity:       "P1",
+		Confidence:     0.99,
+		RuleID:         "rule",
+		Summary:        "summary",
+		Rationale:      "rationale",
+		File:           "file.go",
+		Line:           12,
+		Recommendation: "fix",
+	}
+}


### PR DESCRIPTION
## Summary
Harden `identrail-reviewer` Week 3 with policy enforcement, audit logging, and workflow reliability improvements.

## Why
This makes reviewer output safer and more production-ready by enforcing evidence/confidence policy, producing traceable audit logs, and improving workflow robustness.

## Scope
- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation
```bash
go test ./...
go test ./cmd/identrail-reviewer ./internal/identrailreviewer/...
```

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure
- AI-assisted: yes
- Tools used: Codex, cubic summary
- Areas where used: implementation, tests, PR hygiene
- Human verification performed: local tests (`go test ./...`) and manual diff review

## Related Issues
N/A (stacked work for enterprise reviewer hardening roadmap).
