### PR TITLE
identrail-reviewer Week 4: phased rollout enforcement, weekly reporting, and ops runbook

### DIFF
--- a/.github/identrail-reviewer/rollout.v1.json
+++ b/.github/identrail-reviewer/rollout.v1.json
@@ -1,0 +1,13 @@
+{
+  "version": "2026-04-04",
+  "phase": "advisory",
+  "protected_paths": [
+    ".github/workflows/**",
+    "deploy/**",
+    "cmd/server/**",
+    "internal/service/**",
+    "internal/security/**"
+  ],
+  "block_severities": ["P0", "P1"],
+  "require_no_abstain_on_protected": false
+}

--- a/.github/scripts/identrail-reviewer/upsert-review-comment.js
+++ b/.github/scripts/identrail-reviewer/upsert-review-comment.js
@@ -36,13 +36,43 @@ function formatAbstentions(abstentions) {
   return body;
 }
 
-function renderBody({ marker, heading, result, maxFindings }) {
+function formatGate(gate) {
+  if (!gate || typeof gate !== "object") {
+    return "";
+  }
+
+  let body = "";
+  if (typeof gate.status === "string") {
+    const phase = typeof gate.phase === "string" ? gate.phase : "";
+    body += `Gate: **${gate.status}**`;
+    if (phase.length > 0) {
+      body += ` (phase: \`${phase}\`)`;
+    }
+    body += "\n";
+  }
+
+  if (typeof gate.reason === "string" && gate.reason.length > 0) {
+    body += `Gate reason: ${gate.reason}\n`;
+  }
+
+  if (Array.isArray(gate.blocking_finding_ids) && gate.blocking_finding_ids.length > 0) {
+    body += `Blocking findings: ${gate.blocking_finding_ids.join(", ")}\n`;
+  }
+
+  if (body.length > 0) {
+    return `${body}\n`;
+  }
+  return "";
+}
+
+function renderBody({ marker, heading, result, gate, maxFindings }) {
   const findings = Array.isArray(result.findings) ? result.findings : [];
   const abstentions = Array.isArray(result.abstentions) ? result.abstentions : [];
 
   let body = `${marker}\n${heading}\n`;
   body += `Status: **${result.status}**\n\n`;
   body += `${result.summary}\n\n`;
+  body += formatGate(gate);
   body += formatFindings(findings, maxFindings);
   body += formatAbstentions(abstentions);
   body += `\n_Reviewer version: ${result.version}_\n`;
@@ -57,6 +87,7 @@ async function upsertReviewComment({
   heading,
   issueNumber,
   maxFindings,
+  gatePath,
 }) {
   if (!issueNumber || issueNumber <= 0) {
     throw new Error("issue number is required for comment upsert");
@@ -65,10 +96,12 @@ async function upsertReviewComment({
   const owner = context.repo.owner;
   const repo = context.repo.repo;
   const result = JSON.parse(fs.readFileSync(reviewPath, "utf8"));
+  const gate = gatePath ? JSON.parse(fs.readFileSync(gatePath, "utf8")) : undefined;
   const body = renderBody({
     marker,
     heading,
     result,
+    gate,
     maxFindings,
   });
 

--- a/.github/workflows/identrail-reviewer-review.yml
+++ b/.github/workflows/identrail-reviewer-review.yml
@@ -87,7 +87,14 @@ jobs:
       - name: Generate review checksums
         run: |
           set -euo pipefail
-          sha256sum .tmp/review.json .tmp/audit.jsonl > .tmp/review.sha256
+          go run ./cmd/identrail-reviewer enforce \
+            --review .tmp/review.json \
+            --changed-files .tmp/changed-files.json \
+            --rollout .github/identrail-reviewer/rollout.v1.json \
+            --output .tmp/enforcement.json \
+            --fail-on-block=false
+
+          sha256sum .tmp/review.json .tmp/audit.jsonl .tmp/enforcement.json > .tmp/review.sha256
 
       - name: Upload review artifact
         if: always()
@@ -97,6 +104,7 @@ jobs:
           path: |
             .tmp/review.json
             .tmp/audit.jsonl
+            .tmp/enforcement.json
             .tmp/review.sha256
           if-no-files-found: error
 
@@ -112,9 +120,26 @@ jobs:
               marker: '<!-- identrail-reviewer:pr -->',
               heading: '## identrail-reviewer',
               issueNumber: context.payload.pull_request.number,
-              maxFindings: 20
+              maxFindings: 20,
+              gatePath: '.tmp/enforcement.json'
             });
 
+      - name: Enforce rollout gate
+        run: |
+          set -euo pipefail
+          gate_status="$(jq -r '.status' .tmp/enforcement.json)"
+          case "${gate_status}" in
+            pass|warn)
+              ;;
+            block)
+              echo "identrail-reviewer gate blocked this PR." >&2
+              exit 1
+              ;;
+            *)
+              echo "identrail-reviewer gate returned unexpected status: ${gate_status}" >&2
+              exit 1
+              ;;
+          esac
   issue-review:
     if: github.event_name == 'issues'
     runs-on: ubuntu-latest

--- a/.github/workflows/identrail-reviewer-weekly-report.yml
+++ b/.github/workflows/identrail-reviewer-weekly-report.yml
@@ -1,0 +1,76 @@
+name: identrail-reviewer-weekly-report
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 9 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  weekly-report:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Generate weekly reviewer report
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+            const workflowFile = 'identrail-reviewer-review.yml';
+            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner,
+              repo,
+              workflow_id: workflowFile,
+              per_page: 100
+            });
+
+            const recent = runs.filter((r) => new Date(r.created_at) >= since);
+            const totals = { success: 0, failure: 0, cancelled: 0, other: 0 };
+            for (const run of recent) {
+              const c = run.conclusion || 'other';
+              if (Object.prototype.hasOwnProperty.call(totals, c)) {
+                totals[c] += 1;
+              } else {
+                totals.other += 1;
+              }
+            }
+
+            const report = [
+              '# identrail-reviewer weekly report',
+              '',
+              `Repository: ${owner}/${repo}`,
+              `Generated at: ${new Date().toISOString()}`,
+              `Window start: ${since.toISOString()}`,
+              '',
+              '## Workflow run outcomes',
+              '',
+              `- Total runs: ${recent.length}`,
+              `- Success: ${totals.success}`,
+              `- Failure: ${totals.failure}`,
+              `- Cancelled: ${totals.cancelled}`,
+              `- Other: ${totals.other}`,
+              '',
+              '## Operational notes',
+              '',
+              '- Review precision and false-positive analysis should be validated against benchmark replay samples.',
+              '- If failures increase week-over-week, inspect workflow logs and recent policy/config changes first.'
+            ].join('\n');
+
+            const outDir = path.join(process.cwd(), 'artifacts');
+            fs.mkdirSync(outDir, { recursive: true });
+            fs.writeFileSync(path.join(outDir, 'identrail-reviewer-weekly-report.md'), report);
+
+      - name: Upload weekly report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: identrail-reviewer-weekly-report
+          path: artifacts/identrail-reviewer-weekly-report.md
+          if-no-files-found: error

--- a/cmd/identrail-reviewer/main.go
+++ b/cmd/identrail-reviewer/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/audit"
+	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/enforcement"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/model"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/policy"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/review"
@@ -23,8 +24,10 @@ func main() {
 		reviewPR(os.Args[2:])
 	case "review-issue":
 		reviewIssue(os.Args[2:])
+	case "enforce":
+		enforceGate(os.Args[2:])
 	default:
-		fatal("unknown subcommand: " + os.Args[1])
+		fatal("unknown subcommand: " + os.Args[1] + " (expected: review-pr, review-issue, enforce)")
 	}
 }
 
@@ -139,6 +142,49 @@ func reviewIssue(args []string) {
 		fatal("failed to write audit log: " + err.Error())
 	}
 	writeJSON(*outputPath, result)
+}
+
+func enforceGate(args []string) {
+	fs := flag.NewFlagSet("enforce", flag.ExitOnError)
+	reviewPath := fs.String("review", "", "review JSON path")
+	changedFilesPath := fs.String("changed-files", "", "changed files JSON path")
+	rolloutPath := fs.String("rollout", "", "rollout policy JSON path")
+	outputPath := fs.String("output", "", "output path for enforcement decision")
+	failOnBlock := fs.Bool("fail-on-block", true, "exit non-zero when decision status is block")
+	_ = fs.Parse(args)
+
+	if *reviewPath == "" || *changedFilesPath == "" || *outputPath == "" {
+		fatal("enforce requires --review, --changed-files, and --output")
+	}
+
+	reviewBytes, err := os.ReadFile(*reviewPath)
+	if err != nil {
+		fatal("failed to read review JSON: " + err.Error())
+	}
+	var result model.ReviewResult
+	if err := json.Unmarshal(reviewBytes, &result); err != nil {
+		fatal("failed to parse review JSON: " + err.Error())
+	}
+
+	changedBytes, err := os.ReadFile(*changedFilesPath)
+	if err != nil {
+		fatal("failed to read changed files JSON: " + err.Error())
+	}
+	var changedFiles []model.ChangedFile
+	if err := json.Unmarshal(changedBytes, &changedFiles); err != nil {
+		fatal("failed to parse changed files JSON: " + err.Error())
+	}
+
+	cfg, err := enforcement.Load(*rolloutPath)
+	if err != nil {
+		fatal("failed to load rollout policy: " + err.Error())
+	}
+	decision := enforcement.Decide(cfg, result, changedFiles)
+	writeJSON(*outputPath, decision)
+
+	if *failOnBlock && decision.Status == "block" {
+		fatal("enforcement gate blocked: " + decision.Reason)
+	}
 }
 
 func writeJSON(path string, v any) {

--- a/cmd/identrail-reviewer/main.go
+++ b/cmd/identrail-reviewer/main.go
@@ -16,7 +16,7 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		fatal("usage: identrail-reviewer <review-pr|review-issue> [flags]")
+		fatal("usage: identrail-reviewer <review-pr|review-issue|enforce> [flags]")
 	}
 
 	switch os.Args[1] {

--- a/cmd/identrail-reviewer/main_test.go
+++ b/cmd/identrail-reviewer/main_test.go
@@ -97,6 +97,105 @@ func TestWriteJSONWritesFile(t *testing.T) {
 	}
 }
 
+func TestEnforceGateWritesWarnDecision(t *testing.T) {
+	root := t.TempDir()
+	reviewPath := filepath.Join(root, "review.json")
+	changedPath := filepath.Join(root, "changed.json")
+	rolloutPath := filepath.Join(root, "rollout.json")
+	outputPath := filepath.Join(root, "enforcement.json")
+
+	review := model.ReviewResult{
+		Findings: []model.Finding{
+			{ID: "F-1", Severity: "P2"},
+		},
+	}
+	changed := []model.ChangedFile{{Filename: "internal/api/router.go"}}
+	rollout := map[string]any{
+		"version":         "test",
+		"phase":           "advisory",
+		"protected_paths": []string{"deploy/**"},
+		"block_severities": []string{
+			"P0",
+			"P1",
+		},
+	}
+	if err := writeJSONFile(reviewPath, review); err != nil {
+		t.Fatalf("write review json: %v", err)
+	}
+	if err := writeJSONFile(changedPath, changed); err != nil {
+		t.Fatalf("write changed files json: %v", err)
+	}
+	if err := writeJSONFile(rolloutPath, rollout); err != nil {
+		t.Fatalf("write rollout json: %v", err)
+	}
+
+	enforceGate([]string{
+		"--review", reviewPath,
+		"--changed-files", changedPath,
+		"--rollout", rolloutPath,
+		"--output", outputPath,
+		"--fail-on-block=false",
+	})
+
+	var got map[string]any
+	if err := readJSONFile(outputPath, &got); err != nil {
+		t.Fatalf("read enforcement output: %v", err)
+	}
+	if got["status"] != "warn" {
+		t.Fatalf("expected status warn, got %v", got["status"])
+	}
+}
+
+func TestEnforceGateWritesBlockDecisionWithoutExitWhenConfigured(t *testing.T) {
+	root := t.TempDir()
+	reviewPath := filepath.Join(root, "review.json")
+	changedPath := filepath.Join(root, "changed.json")
+	rolloutPath := filepath.Join(root, "rollout.json")
+	outputPath := filepath.Join(root, "enforcement.json")
+
+	review := model.ReviewResult{
+		Findings: []model.Finding{
+			{ID: "F-1", Severity: "P1"},
+		},
+	}
+	changed := []model.ChangedFile{{Filename: "deploy/prod/service.yaml"}}
+	rollout := map[string]any{
+		"version":         "test",
+		"phase":           "enforced",
+		"protected_paths": []string{"deploy/**"},
+		"block_severities": []string{
+			"P0",
+			"P1",
+		},
+		"require_no_abstain_on_protected": true,
+	}
+	if err := writeJSONFile(reviewPath, review); err != nil {
+		t.Fatalf("write review json: %v", err)
+	}
+	if err := writeJSONFile(changedPath, changed); err != nil {
+		t.Fatalf("write changed files json: %v", err)
+	}
+	if err := writeJSONFile(rolloutPath, rollout); err != nil {
+		t.Fatalf("write rollout json: %v", err)
+	}
+
+	enforceGate([]string{
+		"--review", reviewPath,
+		"--changed-files", changedPath,
+		"--rollout", rolloutPath,
+		"--output", outputPath,
+		"--fail-on-block=false",
+	})
+
+	var got map[string]any
+	if err := readJSONFile(outputPath, &got); err != nil {
+		t.Fatalf("read enforcement output: %v", err)
+	}
+	if got["status"] != "block" {
+		t.Fatalf("expected status block, got %v", got["status"])
+	}
+}
+
 func writeJSONFile(path string, v any) error {
 	b, err := json.Marshal(v)
 	if err != nil {

--- a/docs/identrail-reviewer/operations-runbook.md
+++ b/docs/identrail-reviewer/operations-runbook.md
@@ -1,0 +1,20 @@
+# identrail-reviewer Operations Runbook
+
+## SLO targets
+
+- PR review latency p95: <= 90 seconds for typical PR size.
+- High-severity precision (P0/P1): >= 95% on replay benchmark.
+- False-positive rate overall: <= 8%.
+
+## Incident response
+
+1. Detection: identify spike in workflow failures, bad comments, or merge blocks.
+2. Containment: set rollout phase to `advisory` in `.github/identrail-reviewer/rollout.v1.json`.
+3. Verification: replay benchmark cases and compare recent audit artifacts.
+4. Recovery: patch rules/policy and restore previous phase only after validation.
+
+## Change management
+
+- Policy and rollout changes must be reviewed via pull request.
+- Every rollout phase change should include a rationale in PR description.
+- Weekly report artifacts should be inspected for trend breaks.

--- a/docs/identrail-reviewer/week-4-rollout.md
+++ b/docs/identrail-reviewer/week-4-rollout.md
@@ -1,0 +1,26 @@
+# Week 4 Rollout and Enforcement
+
+Week 4 introduces phased enforcement and operating procedures for production rollout.
+
+## Delivered components
+
+- Rollout config with phase controls:
+  - `.github/identrail-reviewer/rollout.v1.json`
+- Enforcement decision engine:
+  - `internal/identrailreviewer/enforcement/enforcement.go`
+- Weekly operations report workflow:
+  - `.github/workflows/identrail-reviewer-weekly-report.yml`
+- PR review workflow gate integration:
+  - `.github/workflows/identrail-reviewer-review.yml`
+
+## Rollout model
+
+- `advisory`: findings are reported but no merge blocking.
+- `enforced`: protected-path changes can be blocked for configured severities.
+- `strict`: blocking severities block regardless of file scope.
+
+## Operational expectations
+
+- Start in `advisory` and gather accuracy metrics.
+- Move to `enforced` only after precision and false-positive targets are stable.
+- Use `strict` only after sustained quality over multiple release cycles.

--- a/internal/identrailreviewer/enforcement/enforcement.go
+++ b/internal/identrailreviewer/enforcement/enforcement.go
@@ -1,0 +1,167 @@
+package enforcement
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/model"
+)
+
+type Config struct {
+	Version                     string   `json:"version"`
+	Phase                       string   `json:"phase"`
+	ProtectedPaths              []string `json:"protected_paths"`
+	BlockSeverities             []string `json:"block_severities"`
+	RequireNoAbstainOnProtected bool     `json:"require_no_abstain_on_protected"`
+}
+
+type Decision struct {
+	Phase               string   `json:"phase"`
+	Status              string   `json:"status"`
+	Reason              string   `json:"reason"`
+	ProtectedPathChange bool     `json:"protected_path_change"`
+	BlockingFindingIDs  []string `json:"blocking_finding_ids,omitempty"`
+}
+
+func Load(path string) (Config, error) {
+	if path == "" {
+		return defaultConfig(), nil
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, fmt.Errorf("read rollout config: %w", err)
+	}
+	cfg := defaultConfig()
+	if err := json.Unmarshal(b, &cfg); err != nil {
+		return Config{}, fmt.Errorf("parse rollout JSON: %w", err)
+	}
+	return cfg, nil
+}
+
+func Decide(cfg Config, result model.ReviewResult, changedFiles []model.ChangedFile) Decision {
+	protected := hasProtectedPathChange(cfg.ProtectedPaths, changedFiles)
+	blockingIDs := collectBlockingFindings(cfg.BlockSeverities, result.Findings)
+	phase := strings.ToLower(strings.TrimSpace(cfg.Phase))
+
+	switch phase {
+	case "advisory":
+		if len(result.Findings) > 0 {
+			return Decision{
+				Phase:               phase,
+				Status:              "warn",
+				Reason:              "advisory phase: findings reported but merge is not blocked",
+				ProtectedPathChange: protected,
+				BlockingFindingIDs:  blockingIDs,
+			}
+		}
+		return Decision{Phase: phase, Status: "pass", Reason: "advisory phase: no findings", ProtectedPathChange: protected}
+
+	case "enforced":
+		if protected && len(blockingIDs) > 0 {
+			return Decision{
+				Phase:               phase,
+				Status:              "block",
+				Reason:              "blocking severities detected on protected-path changes",
+				ProtectedPathChange: true,
+				BlockingFindingIDs:  blockingIDs,
+			}
+		}
+		if protected && cfg.RequireNoAbstainOnProtected && len(result.Abstain) > 0 {
+			return Decision{
+				Phase:               phase,
+				Status:              "block",
+				Reason:              "abstentions are disallowed for protected-path changes",
+				ProtectedPathChange: true,
+			}
+		}
+		if len(result.Findings) > 0 {
+			return Decision{
+				Phase:               phase,
+				Status:              "warn",
+				Reason:              "findings detected outside enforce block conditions",
+				ProtectedPathChange: protected,
+				BlockingFindingIDs:  blockingIDs,
+			}
+		}
+		return Decision{Phase: phase, Status: "pass", Reason: "enforced phase: no blocking conditions met", ProtectedPathChange: protected}
+
+	case "strict":
+		if len(blockingIDs) > 0 {
+			return Decision{
+				Phase:               phase,
+				Status:              "block",
+				Reason:              "strict phase: blocking severities are not allowed",
+				ProtectedPathChange: protected,
+				BlockingFindingIDs:  blockingIDs,
+			}
+		}
+		if len(result.Findings) > 0 {
+			return Decision{
+				Phase:               phase,
+				Status:              "warn",
+				Reason:              "strict phase: non-blocking findings present",
+				ProtectedPathChange: protected,
+			}
+		}
+		return Decision{Phase: phase, Status: "pass", Reason: "strict phase: no findings", ProtectedPathChange: protected}
+	default:
+		return Decision{Phase: phase, Status: "warn", Reason: "unknown phase; defaulting to advisory semantics", ProtectedPathChange: protected, BlockingFindingIDs: blockingIDs}
+	}
+}
+
+func collectBlockingFindings(blockSeverities []string, findings []model.Finding) []string {
+	allowed := map[string]struct{}{}
+	for _, s := range blockSeverities {
+		allowed[strings.ToUpper(strings.TrimSpace(s))] = struct{}{}
+	}
+
+	ids := make([]string, 0)
+	for _, f := range findings {
+		if _, ok := allowed[strings.ToUpper(strings.TrimSpace(f.Severity))]; ok {
+			ids = append(ids, f.ID)
+		}
+	}
+	return ids
+}
+
+func hasProtectedPathChange(patterns []string, changedFiles []model.ChangedFile) bool {
+	for _, changed := range changedFiles {
+		for _, pattern := range patterns {
+			if matchesPathPattern(pattern, changed.Filename) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func matchesPathPattern(pattern, file string) bool {
+	if strings.HasSuffix(pattern, "/**") {
+		prefix := strings.TrimSuffix(pattern, "/**")
+		return strings.HasPrefix(file, prefix+"/") || file == prefix
+	}
+	ok, err := filepath.Match(pattern, file)
+	if err != nil {
+		return false
+	}
+	return ok
+}
+
+func defaultConfig() Config {
+	return Config{
+		Version: "builtin-rollout-v1",
+		Phase:   "advisory",
+		ProtectedPaths: []string{
+			".github/workflows/**",
+			"deploy/**",
+			"cmd/server/**",
+			"internal/service/**",
+			"internal/security/**",
+		},
+		BlockSeverities:             []string{"P0", "P1"},
+		RequireNoAbstainOnProtected: false,
+	}
+}

--- a/internal/identrailreviewer/enforcement/enforcement.go
+++ b/internal/identrailreviewer/enforcement/enforcement.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -139,15 +140,33 @@ func hasProtectedPathChange(patterns []string, changedFiles []model.ChangedFile)
 }
 
 func matchesPathPattern(pattern, file string) bool {
-	if strings.HasSuffix(pattern, "/**") {
-		prefix := strings.TrimSuffix(pattern, "/**")
-		return strings.HasPrefix(file, prefix+"/") || file == prefix
+	normalizedPattern := normalizeRepoPath(pattern)
+	normalizedFile := normalizeRepoPath(file)
+
+	if strings.HasSuffix(normalizedPattern, "/**") {
+		prefix := strings.TrimSuffix(normalizedPattern, "/**")
+		prefix = strings.TrimSuffix(prefix, "/")
+		return strings.HasPrefix(normalizedFile, prefix+"/") || normalizedFile == prefix
 	}
-	ok, err := filepath.Match(filepath.FromSlash(pattern), filepath.FromSlash(file))
+
+	ok, err := path.Match(normalizedPattern, normalizedFile)
 	if err != nil {
 		return false
 	}
 	return ok
+}
+
+func normalizeRepoPath(value string) string {
+	normalized := strings.TrimSpace(value)
+	normalized = strings.ReplaceAll(normalized, "\\", "/")
+	normalized = filepath.ToSlash(normalized)
+	for strings.HasPrefix(normalized, "./") {
+		normalized = strings.TrimPrefix(normalized, "./")
+	}
+	for strings.Contains(normalized, "//") {
+		normalized = strings.ReplaceAll(normalized, "//", "/")
+	}
+	return normalized
 }
 
 func defaultConfig() Config {

--- a/internal/identrailreviewer/enforcement/enforcement.go
+++ b/internal/identrailreviewer/enforcement/enforcement.go
@@ -143,7 +143,7 @@ func matchesPathPattern(pattern, file string) bool {
 		prefix := strings.TrimSuffix(pattern, "/**")
 		return strings.HasPrefix(file, prefix+"/") || file == prefix
 	}
-	ok, err := filepath.Match(pattern, file)
+	ok, err := filepath.Match(filepath.FromSlash(pattern), filepath.FromSlash(file))
 	if err != nil {
 		return false
 	}

--- a/internal/identrailreviewer/enforcement/enforcement_test.go
+++ b/internal/identrailreviewer/enforcement/enforcement_test.go
@@ -1,0 +1,93 @@
+package enforcement
+
+import (
+	"testing"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/model"
+)
+
+func TestMatchesPathPatternNormalizesSlashDelimitedPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		pattern string
+		file    string
+		want    bool
+	}{
+		{
+			name:    "recursive pattern matches windows style file path",
+			pattern: "deploy/**",
+			file:    `deploy\prod\values.yaml`,
+			want:    true,
+		},
+		{
+			name:    "single segment wildcard matches windows style file path",
+			pattern: ".github/workflows/*",
+			file:    `.github\workflows\ci.yml`,
+			want:    true,
+		},
+		{
+			name:    "normalized relative file path matches",
+			pattern: "cmd/server/**",
+			file:    `./cmd\server\main.go`,
+			want:    true,
+		},
+		{
+			name:    "non matching path returns false",
+			pattern: "internal/security/**",
+			file:    "internal/api/router.go",
+			want:    false,
+		},
+		{
+			name:    "invalid glob pattern fails closed",
+			pattern: "internal/[",
+			file:    "internal/a.go",
+			want:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := matchesPathPattern(tc.pattern, tc.file)
+			if got != tc.want {
+				t.Fatalf("matchesPathPattern(%q, %q) = %v, want %v", tc.pattern, tc.file, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDecideBlocksOnProtectedPathWithWindowsStyleChangedFile(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Phase:          "enforced",
+		ProtectedPaths: []string{"deploy/**"},
+		BlockSeverities: []string{
+			"P0",
+			"P1",
+		},
+	}
+
+	result := model.ReviewResult{
+		Findings: []model.Finding{
+			{ID: "F-1", Severity: "P1"},
+		},
+	}
+
+	decision := Decide(cfg, result, []model.ChangedFile{
+		{Filename: `deploy\prod\service.yaml`},
+	})
+
+	if decision.Status != "block" {
+		t.Fatalf("expected block decision, got %q", decision.Status)
+	}
+	if !decision.ProtectedPathChange {
+		t.Fatal("expected protected path change to be true")
+	}
+	if len(decision.BlockingFindingIDs) != 1 || decision.BlockingFindingIDs[0] != "F-1" {
+		t.Fatalf("unexpected blocking finding ids: %#v", decision.BlockingFindingIDs)
+	}
+}


### PR DESCRIPTION
## Summary
Week 4 adds phased rollout controls and operational workflows for productionizing `identrail-reviewer`.

## What is included
- Rollout phase config:
  - `.github/identrail-reviewer/rollout.v1.json`
- Enforcement engine:
  - `internal/identrailreviewer/enforcement/enforcement.go`
- CLI enforcement subcommand integration:
  - `cmd/identrail-reviewer/main.go`
- PR workflow rollout gate integration:
  - `.github/workflows/identrail-reviewer-review.yml`
- Weekly operations reporting workflow:
  - `.github/workflows/identrail-reviewer-weekly-report.yml`
- Runbook/docs:
  - `docs/identrail-reviewer/week-4-rollout.md`
  - `docs/identrail-reviewer/operations-runbook.md`

## Rollout behavior
- Supports phases: `advisory`, `enforced`, `strict`.
- Produces explicit gate decisions (`pass`, `warn`, `block`) from review output + changed paths.
- Adds protected-path aware blocking logic for configured severities.
- Includes weekly run-outcome report artifacts for operational trend checks.

## Notes
- This PR is stacked on Week 3 (`identrail-reviewer/week-3-hardening`).
- Local validation executed:
  - `go test ./cmd/identrail-reviewer ./internal/identrailreviewer/...`
  - workflow YAML and rollout JSON parse checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds phased rollout enforcement to `identrail-reviewer` with clear pass/warn/block decisions and weekly ops reporting. PR comments now include gate phase, reason, and blocking finding IDs; the workflow computes the gate and blocks on `block`.

- **New Features**
  - Rollout policy: `rollout.v1.json` with `phase`, `protected_paths`, `block_severities`, and `require_no_abstain_on_protected`; enforcement collects blocking IDs and detects protected-path changes across OS path styles.
  - Enforcement: `enforce` subcommand + default config; decisions include phase, reason, protected-path flag, and blocking finding IDs; hardened glob matching (supports `/**`) with unit tests; added tests for `enforce` warn/block paths.
  - Review workflow: generates `.tmp/enforcement.json`, includes it in checksums/artifacts, upserts PR comment with gate details, and fails on `block`; issue triage runs in parallel.
  - Weekly reporting: scheduled workflow creates a markdown report of reviewer run outcomes; added rollout guide and an ops runbook.

- **Migration**
  - Start with `phase: advisory` and monitor weekly report artifacts.
  - When stable, move to `enforced` (and later `strict`) and adjust `protected_paths` and `block_severities` as needed.

<sup>Written for commit 2ffcd910460eac5b10df16337c313f1c3218dfd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

