### PR TITLE
PR-3: Strict OIDC claim mapping and deny-by-default auth

### DIFF
--- a/internal/api/oidc.go
+++ b/internal/api/oidc.go
@@ -8,9 +8,22 @@ import (
 	"github.com/coreos/go-oidc/v3/oidc"
 )
 
+const (
+	defaultOIDCTenantClaim    = "tenant_id"
+	defaultOIDCWorkspaceClaim = "workspace_id"
+	defaultOIDCGroupsClaim    = "groups"
+	defaultOIDCRolesClaim     = "roles"
+)
+
 // OIDCTokenVerifier validates OIDC bearer tokens using issuer discovery and JWKS verification.
 type OIDCTokenVerifier struct {
-	verifier rawTokenVerifier
+	verifier       rawTokenVerifier
+	expectedIssuer string
+	expectedAud    string
+	tenantClaim    string
+	workspaceClaim string
+	groupsClaim    string
+	rolesClaim     string
 }
 
 type tokenClaimsDecoder interface {
@@ -34,7 +47,15 @@ func (v oidcRawTokenVerifier) Verify(ctx context.Context, rawToken string) (toke
 }
 
 // NewOIDCTokenVerifier constructs a verifier from issuer URL and expected audience.
-func NewOIDCTokenVerifier(ctx context.Context, issuerURL string, audience string) (*OIDCTokenVerifier, error) {
+func NewOIDCTokenVerifier(
+	ctx context.Context,
+	issuerURL string,
+	audience string,
+	tenantClaim string,
+	workspaceClaim string,
+	groupsClaim string,
+	rolesClaim string,
+) (*OIDCTokenVerifier, error) {
 	issuer := strings.TrimSpace(issuerURL)
 	if issuer == "" {
 		return nil, fmt.Errorf("oidc issuer url is required")
@@ -43,12 +64,36 @@ func NewOIDCTokenVerifier(ctx context.Context, issuerURL string, audience string
 	if clientID == "" {
 		return nil, fmt.Errorf("oidc audience is required")
 	}
+	tenantClaimName := strings.TrimSpace(tenantClaim)
+	if tenantClaimName == "" {
+		tenantClaimName = defaultOIDCTenantClaim
+	}
+	workspaceClaimName := strings.TrimSpace(workspaceClaim)
+	if workspaceClaimName == "" {
+		workspaceClaimName = defaultOIDCWorkspaceClaim
+	}
+	groupsClaimName := strings.TrimSpace(groupsClaim)
+	if groupsClaimName == "" {
+		groupsClaimName = defaultOIDCGroupsClaim
+	}
+	rolesClaimName := strings.TrimSpace(rolesClaim)
+	if rolesClaimName == "" {
+		rolesClaimName = defaultOIDCRolesClaim
+	}
 	provider, err := oidc.NewProvider(ctx, issuer)
 	if err != nil {
 		return nil, fmt.Errorf("discover oidc provider: %w", err)
 	}
 	verifier := provider.Verifier(&oidc.Config{ClientID: clientID})
-	return &OIDCTokenVerifier{verifier: oidcRawTokenVerifier{verifier: verifier}}, nil
+	return &OIDCTokenVerifier{
+		verifier:       oidcRawTokenVerifier{verifier: verifier},
+		expectedIssuer: issuer,
+		expectedAud:    clientID,
+		tenantClaim:    tenantClaimName,
+		workspaceClaim: workspaceClaimName,
+		groupsClaim:    groupsClaimName,
+		rolesClaim:     rolesClaimName,
+	}, nil
 }
 
 // VerifyToken verifies one raw bearer token and extracts normalized claims.
@@ -62,23 +107,203 @@ func (v *OIDCTokenVerifier) VerifyToken(ctx context.Context, rawToken string) (V
 		return VerifiedToken{}, err
 	}
 
-	var claims struct {
-		Subject string   `json:"sub"`
-		Scope   string   `json:"scope"`
-		SCP     []string `json:"scp"`
-	}
+	var claims map[string]any
 	if err := token.Claims(&claims); err != nil {
 		return VerifiedToken{}, fmt.Errorf("decode oidc claims: %w", err)
 	}
 
-	scopes := []string{}
-	if scopeClaim := strings.TrimSpace(claims.Scope); scopeClaim != "" {
-		scopes = append(scopes, strings.Fields(scopeClaim)...)
+	subject, err := requiredClaimString(claims, "sub")
+	if err != nil {
+		return VerifiedToken{}, err
 	}
-	scopes = append(scopes, claims.SCP...)
+	issuer, err := requiredClaimString(claims, "iss")
+	if err != nil {
+		return VerifiedToken{}, err
+	}
+	if issuer != v.expectedIssuer {
+		return VerifiedToken{}, fmt.Errorf("oidc claim \"iss\" mismatch")
+	}
+	audiences, err := requiredAudienceClaim(claims)
+	if err != nil {
+		return VerifiedToken{}, err
+	}
+	if !stringSliceContains(audiences, v.expectedAud) {
+		return VerifiedToken{}, fmt.Errorf("oidc claim \"aud\" missing expected audience")
+	}
+	tenantID, err := requiredClaimString(claims, v.tenantClaim)
+	if err != nil {
+		return VerifiedToken{}, err
+	}
+	workspaceID, err := requiredClaimString(claims, v.workspaceClaim)
+	if err != nil {
+		return VerifiedToken{}, err
+	}
+	groups, err := optionalStringArrayClaim(claims, v.groupsClaim)
+	if err != nil {
+		return VerifiedToken{}, err
+	}
+	roles, err := optionalStringArrayClaim(claims, v.rolesClaim)
+	if err != nil {
+		return VerifiedToken{}, err
+	}
+	scopes, err := extractTokenScopes(claims)
+	if err != nil {
+		return VerifiedToken{}, err
+	}
 
 	return VerifiedToken{
-		Subject: strings.TrimSpace(claims.Subject),
-		Scopes:  scopes,
+		Subject:     subject,
+		Issuer:      issuer,
+		Audiences:   audiences,
+		TenantID:    tenantID,
+		WorkspaceID: workspaceID,
+		Groups:      groups,
+		Roles:       roles,
+		Scopes:      scopes,
 	}, nil
+}
+
+func requiredClaimString(claims map[string]any, claim string) (string, error) {
+	raw, ok := claims[claim]
+	if !ok {
+		return "", fmt.Errorf("missing required oidc claim %q", claim)
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("oidc claim %q must be a string", claim)
+	}
+	normalized := strings.TrimSpace(value)
+	if normalized == "" {
+		return "", fmt.Errorf("oidc claim %q must be non-empty", claim)
+	}
+	return normalized, nil
+}
+
+func optionalStringArrayClaim(claims map[string]any, claim string) ([]string, error) {
+	raw, ok := claims[claim]
+	if !ok {
+		return []string{}, nil
+	}
+	parsed, err := claimStringArray(raw, claim)
+	if err != nil {
+		return nil, err
+	}
+	return parsed, nil
+}
+
+func claimStringArray(raw any, claim string) ([]string, error) {
+	switch values := raw.(type) {
+	case []string:
+		result := make([]string, 0, len(values))
+		for _, item := range values {
+			normalized := strings.TrimSpace(item)
+			if normalized == "" {
+				return nil, fmt.Errorf("oidc claim %q must contain non-empty string values", claim)
+			}
+			result = append(result, normalized)
+		}
+		return result, nil
+	case []any:
+		result := make([]string, 0, len(values))
+		for _, item := range values {
+			value, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("oidc claim %q must be an array of strings", claim)
+			}
+			normalized := strings.TrimSpace(value)
+			if normalized == "" {
+				return nil, fmt.Errorf("oidc claim %q must contain non-empty string values", claim)
+			}
+			result = append(result, normalized)
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("oidc claim %q must be an array of strings", claim)
+	}
+}
+
+func requiredAudienceClaim(claims map[string]any) ([]string, error) {
+	raw, ok := claims["aud"]
+	if !ok {
+		return nil, fmt.Errorf("missing required oidc claim %q", "aud")
+	}
+	switch aud := raw.(type) {
+	case string:
+		normalized := strings.TrimSpace(aud)
+		if normalized == "" {
+			return nil, fmt.Errorf("oidc claim %q must be non-empty", "aud")
+		}
+		return []string{normalized}, nil
+	case []string:
+		if len(aud) == 0 {
+			return nil, fmt.Errorf("oidc claim %q must be non-empty", "aud")
+		}
+		result := make([]string, 0, len(aud))
+		for _, item := range aud {
+			normalized := strings.TrimSpace(item)
+			if normalized == "" {
+				return nil, fmt.Errorf("oidc claim %q must contain non-empty values", "aud")
+			}
+			result = append(result, normalized)
+		}
+		return result, nil
+	case []any:
+		if len(aud) == 0 {
+			return nil, fmt.Errorf("oidc claim %q must be non-empty", "aud")
+		}
+		result := make([]string, 0, len(aud))
+		for _, item := range aud {
+			value, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("oidc claim %q must be a string or array of strings", "aud")
+			}
+			normalized := strings.TrimSpace(value)
+			if normalized == "" {
+				return nil, fmt.Errorf("oidc claim %q must contain non-empty values", "aud")
+			}
+			result = append(result, normalized)
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("oidc claim %q must be a string or array of strings", "aud")
+	}
+}
+
+func extractTokenScopes(claims map[string]any) ([]string, error) {
+	scopes := []string{}
+	if rawScope, ok := claims["scope"]; ok {
+		scopeString, ok := rawScope.(string)
+		if !ok {
+			return nil, fmt.Errorf("oidc claim %q must be a string", "scope")
+		}
+		normalized := strings.TrimSpace(scopeString)
+		if normalized != "" {
+			scopes = append(scopes, strings.Fields(normalized)...)
+		}
+	}
+	if rawSCP, ok := claims["scp"]; ok {
+		switch typed := rawSCP.(type) {
+		case string:
+			normalized := strings.TrimSpace(typed)
+			if normalized != "" {
+				scopes = append(scopes, strings.Fields(normalized)...)
+			}
+		default:
+			parsed, err := claimStringArray(rawSCP, "scp")
+			if err != nil {
+				return nil, err
+			}
+			scopes = append(scopes, parsed...)
+		}
+	}
+	return scopes, nil
+}
+
+func stringSliceContains(values []string, candidate string) bool {
+	for _, value := range values {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/api/oidc.go
+++ b/internal/api/oidc.go
@@ -193,16 +193,6 @@ func optionalStringArrayClaim(claims map[string]any, claim string) ([]string, er
 
 func claimStringArray(raw any, claim string) ([]string, error) {
 	switch values := raw.(type) {
-	case []string:
-		result := make([]string, 0, len(values))
-		for _, item := range values {
-			normalized := strings.TrimSpace(item)
-			if normalized == "" {
-				return nil, fmt.Errorf("oidc claim %q must contain non-empty string values", claim)
-			}
-			result = append(result, normalized)
-		}
-		return result, nil
 	case []any:
 		result := make([]string, 0, len(values))
 		for _, item := range values {

--- a/internal/api/oidc_test.go
+++ b/internal/api/oidc_test.go
@@ -38,10 +38,10 @@ func (d fakeClaimsDecoder) Claims(v interface{}) error {
 }
 
 func TestNewOIDCTokenVerifierValidation(t *testing.T) {
-	if _, err := NewOIDCTokenVerifier(context.Background(), "", "aud"); err == nil {
+	if _, err := NewOIDCTokenVerifier(context.Background(), "", "aud", "tenant_id", "workspace_id", "groups", "roles"); err == nil {
 		t.Fatal("expected missing issuer validation error")
 	}
-	if _, err := NewOIDCTokenVerifier(context.Background(), "https://issuer.example.com", ""); err == nil {
+	if _, err := NewOIDCTokenVerifier(context.Background(), "https://issuer.example.com", "", "tenant_id", "workspace_id", "groups", "roles"); err == nil {
 		t.Fatal("expected missing audience validation error")
 	}
 }
@@ -50,19 +50,31 @@ func TestNewOIDCTokenVerifierDiscoveryFailure(t *testing.T) {
 	srv := httptest.NewServer(http.NotFoundHandler())
 	defer srv.Close()
 
-	if _, err := NewOIDCTokenVerifier(context.Background(), srv.URL, "identrail"); err == nil {
+	if _, err := NewOIDCTokenVerifier(context.Background(), srv.URL, "identrail", "tenant_id", "workspace_id", "groups", "roles"); err == nil {
 		t.Fatal("expected discovery failure")
 	}
 }
 
 func TestOIDCTokenVerifierVerifyToken(t *testing.T) {
 	verifier := &OIDCTokenVerifier{
+		expectedIssuer: "https://issuer.example.com",
+		expectedAud:    "identrail-api",
+		tenantClaim:    "tenant_id",
+		workspaceClaim: "workspace_id",
+		groupsClaim:    "groups",
+		rolesClaim:     "roles",
 		verifier: fakeRawTokenVerifier{
 			token: fakeClaimsDecoder{
 				claims: map[string]any{
-					"sub":   "subject-1",
-					"scope": "read write",
-					"scp":   []string{"identrail.admin"},
+					"sub":          "subject-1",
+					"iss":          "https://issuer.example.com",
+					"aud":          []string{"identrail-api", "other"},
+					"tenant_id":    "tenant-1",
+					"workspace_id": "workspace-1",
+					"groups":       []string{"engineering"},
+					"roles":        []string{"admin"},
+					"scope":        "read write",
+					"scp":          []string{"identrail.admin"},
 				},
 			},
 		},
@@ -74,6 +86,18 @@ func TestOIDCTokenVerifierVerifyToken(t *testing.T) {
 	}
 	if token.Subject != "subject-1" {
 		t.Fatalf("unexpected subject %q", token.Subject)
+	}
+	if token.TenantID != "tenant-1" {
+		t.Fatalf("unexpected tenant %q", token.TenantID)
+	}
+	if token.WorkspaceID != "workspace-1" {
+		t.Fatalf("unexpected workspace %q", token.WorkspaceID)
+	}
+	if len(token.Groups) != 1 || token.Groups[0] != "engineering" {
+		t.Fatalf("unexpected groups %+v", token.Groups)
+	}
+	if len(token.Roles) != 1 || token.Roles[0] != "admin" {
+		t.Fatalf("unexpected roles %+v", token.Roles)
 	}
 	if len(token.Scopes) != 3 {
 		t.Fatalf("expected 3 scopes, got %+v", token.Scopes)
@@ -99,5 +123,150 @@ func TestOIDCTokenVerifierVerifyTokenErrors(t *testing.T) {
 	}
 	if _, err := claimsErr.VerifyToken(context.Background(), "token"); err == nil {
 		t.Fatal("expected claims decode error")
+	}
+}
+
+func TestOIDCTokenVerifierStrictClaimValidation(t *testing.T) {
+	baseClaims := map[string]any{
+		"sub":          "subject-1",
+		"iss":          "https://issuer.example.com",
+		"aud":          "identrail-api",
+		"tenant_id":    "tenant-1",
+		"workspace_id": "workspace-1",
+		"groups":       []string{"engineering"},
+		"roles":        []string{"viewer"},
+		"scope":        "read",
+	}
+
+	testCases := []struct {
+		name   string
+		claims map[string]any
+	}{
+		{
+			name: "missing sub",
+			claims: map[string]any{
+				"iss":          "https://issuer.example.com",
+				"aud":          "identrail-api",
+				"tenant_id":    "tenant-1",
+				"workspace_id": "workspace-1",
+			},
+		},
+		{
+			name: "issuer mismatch",
+			claims: map[string]any{
+				"sub":          "subject-1",
+				"iss":          "https://other-issuer.example.com",
+				"aud":          "identrail-api",
+				"tenant_id":    "tenant-1",
+				"workspace_id": "workspace-1",
+			},
+		},
+		{
+			name: "audience mismatch",
+			claims: map[string]any{
+				"sub":          "subject-1",
+				"iss":          "https://issuer.example.com",
+				"aud":          "other-aud",
+				"tenant_id":    "tenant-1",
+				"workspace_id": "workspace-1",
+			},
+		},
+		{
+			name: "missing tenant claim",
+			claims: map[string]any{
+				"sub":          "subject-1",
+				"iss":          "https://issuer.example.com",
+				"aud":          "identrail-api",
+				"workspace_id": "workspace-1",
+			},
+		},
+		{
+			name: "missing workspace claim",
+			claims: map[string]any{
+				"sub":       "subject-1",
+				"iss":       "https://issuer.example.com",
+				"aud":       "identrail-api",
+				"tenant_id": "tenant-1",
+			},
+		},
+		{
+			name: "groups invalid format",
+			claims: map[string]any{
+				"sub":          "subject-1",
+				"iss":          "https://issuer.example.com",
+				"aud":          "identrail-api",
+				"tenant_id":    "tenant-1",
+				"workspace_id": "workspace-1",
+				"groups":       "engineering",
+			},
+		},
+		{
+			name: "roles invalid format",
+			claims: map[string]any{
+				"sub":          "subject-1",
+				"iss":          "https://issuer.example.com",
+				"aud":          "identrail-api",
+				"tenant_id":    "tenant-1",
+				"workspace_id": "workspace-1",
+				"roles":        []any{"admin", 1},
+			},
+		},
+		{
+			name: "scope invalid format",
+			claims: map[string]any{
+				"sub":          "subject-1",
+				"iss":          "https://issuer.example.com",
+				"aud":          "identrail-api",
+				"tenant_id":    "tenant-1",
+				"workspace_id": "workspace-1",
+				"scope":        []string{"read"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			claims := tc.claims
+			if len(claims) == 0 {
+				claims = baseClaims
+			}
+			verifier := &OIDCTokenVerifier{
+				expectedIssuer: "https://issuer.example.com",
+				expectedAud:    "identrail-api",
+				tenantClaim:    "tenant_id",
+				workspaceClaim: "workspace_id",
+				groupsClaim:    "groups",
+				rolesClaim:     "roles",
+				verifier: fakeRawTokenVerifier{
+					token: fakeClaimsDecoder{claims: claims},
+				},
+			}
+			if _, err := verifier.VerifyToken(context.Background(), "token"); err == nil {
+				t.Fatal("expected strict claim validation error")
+			}
+		})
+	}
+
+	optionalClaimsOK := &OIDCTokenVerifier{
+		expectedIssuer: "https://issuer.example.com",
+		expectedAud:    "identrail-api",
+		tenantClaim:    "tenant_id",
+		workspaceClaim: "workspace_id",
+		groupsClaim:    "groups",
+		rolesClaim:     "roles",
+		verifier: fakeRawTokenVerifier{
+			token: fakeClaimsDecoder{
+				claims: map[string]any{
+					"sub":          "subject-1",
+					"iss":          "https://issuer.example.com",
+					"aud":          "identrail-api",
+					"tenant_id":    "tenant-1",
+					"workspace_id": "workspace-1",
+				},
+			},
+		},
+	}
+	if _, err := optionalClaimsOK.VerifyToken(context.Background(), "token"); err != nil {
+		t.Fatalf("expected missing optional groups/roles claims to be accepted, got %v", err)
 	}
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -59,8 +59,14 @@ type RouterOptions struct {
 
 // VerifiedToken contains normalized claims extracted from a validated OIDC token.
 type VerifiedToken struct {
-	Subject string
-	Scopes  []string
+	Subject     string
+	Issuer      string
+	Audiences   []string
+	TenantID    string
+	WorkspaceID string
+	Groups      []string
+	Roles       []string
+	Scopes      []string
 }
 
 // TokenVerifier validates bearer tokens and returns normalized claims.
@@ -101,8 +107,8 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 	r.GET("/metrics", gin.WrapH(promhttp.HandlerFor(registry, promhttp.HandlerOpts{})))
 
 	v1 := r.Group("/v1")
-	v1.Use(requestScopeMiddleware(opts.DefaultTenantID, opts.DefaultWorkspaceID))
 	v1.Use(apiKeyAuthMiddleware(opts.APIKeys, opts.APIKeyScopes, opts.OIDCTokenVerifier, opts.OIDCWriteScopes))
+	v1.Use(requestScopeMiddleware(opts.DefaultTenantID, opts.DefaultWorkspaceID))
 	v1.Use(requireReadableScopeMiddleware(opts.APIKeyScopes, opts.OIDCTokenVerifier))
 	v1.Use(rateLimitMiddleware(opts.RateLimitRPM, opts.RateLimitBurst))
 	v1.Use(auditLogMiddleware(logger, opts.AuditSink))
@@ -986,11 +992,17 @@ func requestScopeMiddleware(defaultTenantID string, defaultWorkspaceID string) g
 		WorkspaceID: defaultWorkspaceID,
 	}.Normalize()
 	return func(c *gin.Context) {
-		tenantID := strings.TrimSpace(c.GetHeader(scopeHeaderTenantID))
+		tenantID := authContextString(c, "auth.tenant_id")
+		if tenantID == "" {
+			tenantID = strings.TrimSpace(c.GetHeader(scopeHeaderTenantID))
+		}
 		if tenantID == "" {
 			tenantID = defaultScope.TenantID
 		}
-		workspaceID := strings.TrimSpace(c.GetHeader(scopeHeaderWorkspaceID))
+		workspaceID := authContextString(c, "auth.workspace_id")
+		if workspaceID == "" {
+			workspaceID = strings.TrimSpace(c.GetHeader(scopeHeaderWorkspaceID))
+		}
 		if workspaceID == "" {
 			workspaceID = defaultScope.WorkspaceID
 		}
@@ -1136,25 +1148,18 @@ func apiKeyAuthMiddleware(keys []string, scopedKeys map[string][]string, tokenVe
 			token, err := tokenVerifier.VerifyToken(c.Request.Context(), rawBearer)
 			if err == nil {
 				c.Set("auth.subject", token.Subject)
+				c.Set("auth.issuer", token.Issuer)
+				c.Set("auth.audiences", token.Audiences)
+				c.Set("auth.groups", token.Groups)
+				c.Set("auth.roles", token.Roles)
+				c.Set("auth.tenant_id", token.TenantID)
+				c.Set("auth.workspace_id", token.WorkspaceID)
 				c.Set("auth.scope_set", scopeSetFromOIDCToken(token, oidcWriteScopeSet))
 				c.Next()
 				return
 			}
-		}
-
-		// Backward-compatible fallback for legacy clients sending API key via Bearer token.
-		if rawBearer != "" {
-			if scopes, ok := scopedKeyLookup(scopedAllowed, rawBearer); ok {
-				c.Set("auth.api_key", rawBearer)
-				c.Set("auth.scope_set", scopes)
-				c.Next()
-				return
-			}
-			if keyInList(legacyAllowed, rawBearer) {
-				c.Set("auth.api_key", rawBearer)
-				c.Next()
-				return
-			}
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
 		}
 
 		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
@@ -1439,6 +1444,21 @@ func auditLogMiddleware(logger *zap.Logger, sink AuditSink) gin.HandlerFunc {
 
 func readAPIKey(c *gin.Context) string {
 	return strings.TrimSpace(c.GetHeader("X-API-Key"))
+}
+
+func authContextString(c *gin.Context, key string) string {
+	if c == nil {
+		return ""
+	}
+	value, exists := c.Get(key)
+	if !exists {
+		return ""
+	}
+	text, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(text)
 }
 
 func triageActorFromContext(c *gin.Context) string {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Oluwatobi-Mustapha/identrail/internal/repoexposure"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/scheduler"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/telemetry"
+	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
@@ -1155,11 +1156,19 @@ func TestRouterScopedAuthorizationPrefersScopeMap(t *testing.T) {
 	}
 
 	writeReq := httptest.NewRequest(http.MethodPost, "/v1/scans", nil)
-	writeReq.Header.Set("Authorization", "Bearer writer-key")
+	writeReq.Header.Set("X-API-Key", "writer-key")
 	writeW := httptest.NewRecorder()
 	r.ServeHTTP(writeW, writeReq)
 	if writeW.Code != http.StatusAccepted {
 		t.Fatalf("expected write with writer-key to pass, got %d", writeW.Code)
+	}
+
+	bearerFallbackReq := httptest.NewRequest(http.MethodGet, "/v1/scans", nil)
+	bearerFallbackReq.Header.Set("Authorization", "Bearer writer-key")
+	bearerFallbackW := httptest.NewRecorder()
+	r.ServeHTTP(bearerFallbackW, bearerFallbackReq)
+	if bearerFallbackW.Code != http.StatusUnauthorized {
+		t.Fatalf("expected bearer api-key fallback to be rejected, got %d", bearerFallbackW.Code)
 	}
 
 	badScopeReq := httptest.NewRequest(http.MethodGet, "/v1/scans", nil)
@@ -1177,8 +1186,18 @@ func TestRouterOIDCOnlyAuthentication(t *testing.T) {
 	r := NewRouter(logger, metrics, nil, RouterOptions{
 		OIDCTokenVerifier: fakeTokenVerifier{
 			tokens: map[string]VerifiedToken{
-				"good-token":     {Subject: "user-1", Scopes: []string{"read"}},
-				"no-scope-token": {Subject: "user-2", Scopes: nil},
+				"good-token": {
+					Subject:     "user-1",
+					TenantID:    "tenant-1",
+					WorkspaceID: "workspace-1",
+					Scopes:      []string{"read"},
+				},
+				"no-scope-token": {
+					Subject:     "user-2",
+					TenantID:    "tenant-1",
+					WorkspaceID: "workspace-1",
+					Scopes:      nil,
+				},
 			},
 		},
 	})
@@ -1215,8 +1234,18 @@ func TestRouterOIDCWriteScopeAuthorization(t *testing.T) {
 	r := NewRouter(logger, metrics, svc, RouterOptions{
 		OIDCTokenVerifier: fakeTokenVerifier{
 			tokens: map[string]VerifiedToken{
-				"reader-token": {Subject: "user-read", Scopes: []string{"identrail.read"}},
-				"writer-token": {Subject: "user-write", Scopes: []string{"identrail.write"}},
+				"reader-token": {
+					Subject:     "user-read",
+					TenantID:    "tenant-1",
+					WorkspaceID: "workspace-1",
+					Scopes:      []string{"identrail.read"},
+				},
+				"writer-token": {
+					Subject:     "user-write",
+					TenantID:    "tenant-1",
+					WorkspaceID: "workspace-1",
+					Scopes:      []string{"identrail.write"},
+				},
 			},
 		},
 		OIDCWriteScopes: []string{"identrail.write"},
@@ -1246,7 +1275,12 @@ func TestRouterHybridOIDCAndLegacyAPIKeyReadCompatibility(t *testing.T) {
 		APIKeys: []string{"legacy-key"},
 		OIDCTokenVerifier: fakeTokenVerifier{
 			tokens: map[string]VerifiedToken{
-				"reader-token": {Subject: "user-read", Scopes: []string{"identrail.read"}},
+				"reader-token": {
+					Subject:     "user-read",
+					TenantID:    "tenant-1",
+					WorkspaceID: "workspace-1",
+					Scopes:      []string{"identrail.read"},
+				},
 			},
 		},
 	})
@@ -1257,6 +1291,44 @@ func TestRouterHybridOIDCAndLegacyAPIKeyReadCompatibility(t *testing.T) {
 	r.ServeHTTP(readW, readReq)
 	if readW.Code != http.StatusOK {
 		t.Fatalf("expected legacy api key read to pass in hybrid mode, got %d", readW.Code)
+	}
+}
+
+func TestRequestScopeMiddlewarePrefersOIDCTenantWorkspaceClaims(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("auth.tenant_id", "tenant-from-token")
+		c.Set("auth.workspace_id", "workspace-from-token")
+		c.Next()
+	})
+	r.Use(requestScopeMiddleware("default-tenant", "default-workspace"))
+	r.GET("/scope", func(c *gin.Context) {
+		scope := db.ScopeFromContext(c.Request.Context())
+		c.JSON(http.StatusOK, map[string]string{
+			"tenant_id":    scope.TenantID,
+			"workspace_id": scope.WorkspaceID,
+		})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/scope", nil)
+	req.Header.Set("X-Identrail-Tenant-ID", "header-tenant")
+	req.Header.Set("X-Identrail-Workspace-ID", "header-workspace")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["tenant_id"] != "tenant-from-token" {
+		t.Fatalf("expected tenant from oidc claim, got %q", body["tenant_id"])
+	}
+	if body["workspace_id"] != "workspace-from-token" {
+		t.Fatalf("expected workspace from oidc claim, got %q", body["workspace_id"])
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,10 @@ const (
 	defaultTenantID                    = "default"
 	defaultWorkspaceID                 = "default"
 	defaultOIDCWriteScopes             = "identrail.write,identrail.admin,write,admin"
+	defaultOIDCTenantClaim             = "tenant_id"
+	defaultOIDCWorkspaceClaim          = "workspace_id"
+	defaultOIDCGroupsClaim             = "groups"
+	defaultOIDCRolesClaim              = "roles"
 )
 
 // Config centralizes process-level configuration. It keeps module wiring simple
@@ -103,6 +107,10 @@ type Config struct {
 	OIDCIssuerURL              string
 	OIDCAudience               string
 	OIDCWriteScopes            []string
+	OIDCTenantClaim            string
+	OIDCWorkspaceClaim         string
+	OIDCGroupsClaim            string
+	OIDCRolesClaim             string
 }
 
 // Load reads environment variables and applies safe defaults for local and CI use.
@@ -169,6 +177,10 @@ func Load() Config {
 		OIDCIssuerURL:              getEnv("IDENTRAIL_OIDC_ISSUER_URL", ""),
 		OIDCAudience:               getEnv("IDENTRAIL_OIDC_AUDIENCE", ""),
 		OIDCWriteScopes:            parseCommaSeparated(getEnv("IDENTRAIL_OIDC_WRITE_SCOPES", defaultOIDCWriteScopes)),
+		OIDCTenantClaim:            getEnv("IDENTRAIL_OIDC_TENANT_CLAIM", defaultOIDCTenantClaim),
+		OIDCWorkspaceClaim:         getEnv("IDENTRAIL_OIDC_WORKSPACE_CLAIM", defaultOIDCWorkspaceClaim),
+		OIDCGroupsClaim:            getEnv("IDENTRAIL_OIDC_GROUPS_CLAIM", defaultOIDCGroupsClaim),
+		OIDCRolesClaim:             getEnv("IDENTRAIL_OIDC_ROLES_CLAIM", defaultOIDCRolesClaim),
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -65,6 +65,10 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("IDENTRAIL_LOCK_NAMESPACE", "")
 	t.Setenv("IDENTRAIL_DEFAULT_TENANT_ID", "")
 	t.Setenv("IDENTRAIL_DEFAULT_WORKSPACE_ID", "")
+	t.Setenv("IDENTRAIL_OIDC_TENANT_CLAIM", "")
+	t.Setenv("IDENTRAIL_OIDC_WORKSPACE_CLAIM", "")
+	t.Setenv("IDENTRAIL_OIDC_GROUPS_CLAIM", "")
+	t.Setenv("IDENTRAIL_OIDC_ROLES_CLAIM", "")
 
 	cfg := Load()
 	if cfg.HTTPAddr != defaultHTTPAddr {
@@ -247,6 +251,18 @@ func TestLoadDefaults(t *testing.T) {
 	if len(cfg.OIDCWriteScopes) == 0 {
 		t.Fatal("expected default oidc write scopes")
 	}
+	if cfg.OIDCTenantClaim != defaultOIDCTenantClaim {
+		t.Fatalf("expected default oidc tenant claim %q, got %q", defaultOIDCTenantClaim, cfg.OIDCTenantClaim)
+	}
+	if cfg.OIDCWorkspaceClaim != defaultOIDCWorkspaceClaim {
+		t.Fatalf("expected default oidc workspace claim %q, got %q", defaultOIDCWorkspaceClaim, cfg.OIDCWorkspaceClaim)
+	}
+	if cfg.OIDCGroupsClaim != defaultOIDCGroupsClaim {
+		t.Fatalf("expected default oidc groups claim %q, got %q", defaultOIDCGroupsClaim, cfg.OIDCGroupsClaim)
+	}
+	if cfg.OIDCRolesClaim != defaultOIDCRolesClaim {
+		t.Fatalf("expected default oidc roles claim %q, got %q", defaultOIDCRolesClaim, cfg.OIDCRolesClaim)
+	}
 }
 
 func TestLoadFromEnv(t *testing.T) {
@@ -311,6 +327,10 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("IDENTRAIL_OIDC_ISSUER_URL", "https://iam.example.com/realms/identrail")
 	t.Setenv("IDENTRAIL_OIDC_AUDIENCE", "identrail-api")
 	t.Setenv("IDENTRAIL_OIDC_WRITE_SCOPES", "identrail.write,identrail.admin")
+	t.Setenv("IDENTRAIL_OIDC_TENANT_CLAIM", "tenant")
+	t.Setenv("IDENTRAIL_OIDC_WORKSPACE_CLAIM", "workspace")
+	t.Setenv("IDENTRAIL_OIDC_GROUPS_CLAIM", "groups")
+	t.Setenv("IDENTRAIL_OIDC_ROLES_CLAIM", "roles")
 
 	cfg := Load()
 	if cfg.HTTPAddr != "127.0.0.1:9090" {
@@ -492,6 +512,18 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if len(cfg.OIDCWriteScopes) != 2 || cfg.OIDCWriteScopes[0] != "identrail.write" || cfg.OIDCWriteScopes[1] != "identrail.admin" {
 		t.Fatalf("unexpected oidc write scopes: %+v", cfg.OIDCWriteScopes)
+	}
+	if cfg.OIDCTenantClaim != "tenant" {
+		t.Fatalf("unexpected oidc tenant claim: %q", cfg.OIDCTenantClaim)
+	}
+	if cfg.OIDCWorkspaceClaim != "workspace" {
+		t.Fatalf("unexpected oidc workspace claim: %q", cfg.OIDCWorkspaceClaim)
+	}
+	if cfg.OIDCGroupsClaim != "groups" {
+		t.Fatalf("unexpected oidc groups claim: %q", cfg.OIDCGroupsClaim)
+	}
+	if cfg.OIDCRolesClaim != "roles" {
+		t.Fatalf("unexpected oidc roles claim: %q", cfg.OIDCRolesClaim)
 	}
 }
 

--- a/internal/config/security.go
+++ b/internal/config/security.go
@@ -22,6 +22,7 @@ const (
 	maxWorkerQueueBatchSize     = 500
 	minAPIKeyLength             = 24
 	maxScopeIdentifierLength    = 64
+	maxOIDCClaimNameLength      = 128
 )
 
 var allowedKeyScopes = map[string]struct{}{
@@ -67,6 +68,7 @@ var placeholderAPIKeys = map[string]struct{}{
 }
 
 var scopeIdentifierPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,63}$`)
+var oidcClaimNamePattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9._:-]{0,127}$`)
 
 // ValidateSecurity checks hard-fail security misconfigurations.
 func ValidateSecurity(cfg Config) error {
@@ -99,6 +101,36 @@ func ValidateSecurity(cfg Config) error {
 	}
 	if oidcAudience != "" && oidcIssuer == "" {
 		return fmt.Errorf("IDENTRAIL_OIDC_ISSUER_URL must be set when IDENTRAIL_OIDC_AUDIENCE is configured")
+	}
+	if oidcIssuer != "" {
+		tenantClaim := strings.TrimSpace(cfg.OIDCTenantClaim)
+		if tenantClaim == "" {
+			tenantClaim = defaultOIDCTenantClaim
+		}
+		if err := validateOIDCClaimName("IDENTRAIL_OIDC_TENANT_CLAIM", tenantClaim); err != nil {
+			return err
+		}
+		workspaceClaim := strings.TrimSpace(cfg.OIDCWorkspaceClaim)
+		if workspaceClaim == "" {
+			workspaceClaim = defaultOIDCWorkspaceClaim
+		}
+		if err := validateOIDCClaimName("IDENTRAIL_OIDC_WORKSPACE_CLAIM", workspaceClaim); err != nil {
+			return err
+		}
+		groupsClaim := strings.TrimSpace(cfg.OIDCGroupsClaim)
+		if groupsClaim == "" {
+			groupsClaim = defaultOIDCGroupsClaim
+		}
+		if err := validateOIDCClaimName("IDENTRAIL_OIDC_GROUPS_CLAIM", groupsClaim); err != nil {
+			return err
+		}
+		rolesClaim := strings.TrimSpace(cfg.OIDCRolesClaim)
+		if rolesClaim == "" {
+			rolesClaim = defaultOIDCRolesClaim
+		}
+		if err := validateOIDCClaimName("IDENTRAIL_OIDC_ROLES_CLAIM", rolesClaim); err != nil {
+			return err
+		}
 	}
 
 	if len(cfg.APIKeyScopes) > 0 {
@@ -349,6 +381,20 @@ func validateScopeIdentifier(envName string, value string) error {
 	}
 	if !scopeIdentifierPattern.MatchString(normalized) {
 		return fmt.Errorf("%s must match %s", envName, scopeIdentifierPattern.String())
+	}
+	return nil
+}
+
+func validateOIDCClaimName(envName string, value string) error {
+	normalized := strings.TrimSpace(value)
+	if normalized == "" {
+		return fmt.Errorf("%s must be non-empty", envName)
+	}
+	if len(normalized) > maxOIDCClaimNameLength {
+		return fmt.Errorf("%s must be <= %d characters", envName, maxOIDCClaimNameLength)
+	}
+	if !oidcClaimNamePattern.MatchString(normalized) {
+		return fmt.Errorf("%s must match %s", envName, oidcClaimNamePattern.String())
 	}
 	return nil
 }

--- a/internal/config/security_test.go
+++ b/internal/config/security_test.go
@@ -32,6 +32,34 @@ func TestValidateSecurityRejectsOIDCIssuerWithoutAudience(t *testing.T) {
 	}
 }
 
+func TestValidateSecurityRejectsInvalidOIDCClaimName(t *testing.T) {
+	cfg := Config{
+		OIDCIssuerURL:      "https://iam.example.com/realms/identrail",
+		OIDCAudience:       "identrail-api",
+		OIDCTenantClaim:    "tenant claim",
+		OIDCWorkspaceClaim: "workspace_id",
+		OIDCGroupsClaim:    "groups",
+		OIDCRolesClaim:     "roles",
+	}
+	if err := ValidateSecurity(cfg); err == nil {
+		t.Fatal("expected invalid oidc claim name error")
+	}
+}
+
+func TestValidateSecurityAcceptsValidOIDCClaimNames(t *testing.T) {
+	cfg := Config{
+		OIDCIssuerURL:      "https://iam.example.com/realms/identrail",
+		OIDCAudience:       "identrail-api",
+		OIDCTenantClaim:    "tenant_id",
+		OIDCWorkspaceClaim: "workspace_id",
+		OIDCGroupsClaim:    "groups",
+		OIDCRolesClaim:     "roles",
+	}
+	if err := ValidateSecurity(cfg); err != nil {
+		t.Fatalf("expected valid oidc claim names, got %v", err)
+	}
+}
+
 func TestValidateSecurityWriteKeyMustBeInAPIKeys(t *testing.T) {
 	cfg := Config{
 		APIKeys:      []string{"reader"},

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -91,7 +91,15 @@ func NewBootstrap(ctx context.Context, cfg config.Config) (Bootstrap, error) {
 
 	var tokenVerifier api.TokenVerifier
 	if cfg.OIDCIssuerURL != "" {
-		verifier, verifierErr := api.NewOIDCTokenVerifier(ctx, cfg.OIDCIssuerURL, cfg.OIDCAudience)
+		verifier, verifierErr := api.NewOIDCTokenVerifier(
+			ctx,
+			cfg.OIDCIssuerURL,
+			cfg.OIDCAudience,
+			cfg.OIDCTenantClaim,
+			cfg.OIDCWorkspaceClaim,
+			cfg.OIDCGroupsClaim,
+			cfg.OIDCRolesClaim,
+		)
 		if verifierErr != nil {
 			for _, sink := range auditSinks {
 				_ = sink.Close()


### PR DESCRIPTION
## Summary
- enforce strict OIDC claim validation for `sub`, `iss`, `aud`, tenant, and workspace
- validate optional groups/roles claims as arrays of non-empty strings
- remove Bearer-to-API-key fallback and fail closed on invalid OIDC bearer tokens
- wire tenant/workspace scope from validated OIDC claims into request scope
- add configurable OIDC claim-name settings and validation (`IDENTRAIL_OIDC_*_CLAIM`)

## Behavior changes
- requests with invalid/missing required OIDC claims are denied (`401`)
- Bearer tokens are no longer treated as API keys
- when OIDC auth succeeds, tenant/workspace come from token claims (not override headers)

## Validation
- `go test ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces strict OIDC claim validation and deny-by-default auth. Removes Bearer-to-API-key fallback and sources tenant/workspace from token claims.

- **New Features**
  - Strict validation for `iss`, `aud`, `sub`, and required tenant/workspace claims; tokens must match expected issuer/audience.
  - Configurable claim names via env: IDENTRAIL_OIDC_TENANT_CLAIM, IDENTRAIL_OIDC_WORKSPACE_CLAIM, IDENTRAIL_OIDC_GROUPS_CLAIM, IDENTRAIL_OIDC_ROLES_CLAIM (defaults provided).
  - Optional `groups`/`roles` must be arrays of non-empty strings; missing is allowed.
  - Scopes extracted from `scope` (string) and `scp` (string or array).
  - Router sets auth context (issuer, audiences, tenant, workspace, groups, roles) and prefers token tenant/workspace over headers.

- **Migration**
  - Do not send API keys as Bearer tokens; use X-API-Key. Bearer now only accepts OIDC tokens and returns 401 on invalid tokens.
  - Ensure tokens include the expected `iss`, `aud`, and tenant/workspace claims (or set the envs above to match your IdP).
  - When OIDC auth succeeds, X-Identrail-Tenant-ID and X-Identrail-Workspace-ID are ignored.
  - Startup now validates claim-name envs and OIDC config; issuer and audience must be set together. Invalid values fail fast.

<sup>Written for commit 161028518bd327e774f609fd0a0058e6b393964e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

