### PR TITLE
feat(auth): workspace-scoped RBAC core with route enforcement

### DIFF
--- a/internal/api/rbac_authz.go
+++ b/internal/api/rbac_authz.go
@@ -1,0 +1,268 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	rbacPermissionFindingsRead   = "findings.read"
+	rbacPermissionFindingsTriage = "findings.triage"
+	rbacPermissionGraphRead      = "graph.read"
+	rbacPermissionScansRead      = "scans.read"
+	rbacPermissionScansRun       = "scans.run"
+	rbacPermissionRepoScansRead  = "repo_scans.read"
+	rbacPermissionRepoScansRun   = "repo_scans.run"
+	rbacPermissionRBACManage     = "rbac.manage"
+)
+
+var builtinRBACRoles = []db.RBACRole{
+	{
+		Name:        "viewer",
+		Description: "Read-only access to findings, graph, and scan results",
+		IsBuiltIn:   true,
+		Permissions: []string{
+			rbacPermissionFindingsRead,
+			rbacPermissionGraphRead,
+			rbacPermissionScansRead,
+			rbacPermissionRepoScansRead,
+		},
+	},
+	{
+		Name:        "analyst",
+		Description: "Viewer access plus finding triage",
+		IsBuiltIn:   true,
+		Permissions: []string{
+			rbacPermissionFindingsRead,
+			rbacPermissionFindingsTriage,
+			rbacPermissionGraphRead,
+			rbacPermissionScansRead,
+			rbacPermissionRepoScansRead,
+		},
+	},
+	{
+		Name:        "operator",
+		Description: "Analyst access plus scan execution",
+		IsBuiltIn:   true,
+		Permissions: []string{
+			rbacPermissionFindingsRead,
+			rbacPermissionFindingsTriage,
+			rbacPermissionGraphRead,
+			rbacPermissionScansRead,
+			rbacPermissionScansRun,
+			rbacPermissionRepoScansRead,
+			rbacPermissionRepoScansRun,
+		},
+	},
+	{
+		Name:        "admin",
+		Description: "Full workspace administrative access",
+		IsBuiltIn:   true,
+		Permissions: []string{
+			rbacPermissionFindingsRead,
+			rbacPermissionFindingsTriage,
+			rbacPermissionGraphRead,
+			rbacPermissionScansRead,
+			rbacPermissionScansRun,
+			rbacPermissionRepoScansRead,
+			rbacPermissionRepoScansRun,
+			rbacPermissionRBACManage,
+		},
+	},
+}
+
+type rbacAuthorizer struct {
+	store   db.Store
+	now     func() time.Time
+	seeded  sync.Map
+	seedMux sync.Mutex
+}
+
+func newRBACAuthorizer(svc *Service) *rbacAuthorizer {
+	if svc == nil || svc.Store == nil {
+		return &rbacAuthorizer{now: time.Now}
+	}
+	return &rbacAuthorizer{
+		store: svc.Store,
+		now:   time.Now,
+	}
+}
+
+func requireRBACPermissionMiddleware(authorizer *rbacAuthorizer, permission string) gin.HandlerFunc {
+	required := strings.ToLower(strings.TrimSpace(permission))
+	return func(c *gin.Context) {
+		if strings.TrimSpace(required) == "" {
+			c.Next()
+			return
+		}
+		allowed, err := authorizer.allow(c, required)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "authorization failed"})
+			return
+		}
+		if !allowed {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			return
+		}
+		c.Next()
+	}
+}
+
+func (a *rbacAuthorizer) allow(c *gin.Context, permission string) (bool, error) {
+	if c == nil {
+		return false, nil
+	}
+
+	principalType := authContextString(c, "auth.principal_type")
+	principalID := authContextString(c, "auth.principal_id")
+
+	if principalType == "" || principalID == "" {
+		// Authentication middleware is disabled, keep local/test behavior unchanged.
+		if authContextString(c, "auth.subject") == "" && authContextString(c, "auth.api_key") == "" {
+			return true, nil
+		}
+		return legacyScopeAllowsPermission(c, permission), nil
+	}
+
+	if a == nil || a.store == nil {
+		return legacyScopeAllowsPermission(c, permission), nil
+	}
+
+	if err := a.ensureBuiltinRoles(c.Request.Context()); err != nil {
+		return false, err
+	}
+
+	if principalType == db.RBACSubjectTypeAPIKey {
+		if err := a.bootstrapAPIKeyBinding(c); err != nil {
+			return false, err
+		}
+	}
+
+	permissions, err := a.store.ListRBACPermissionsForSubject(c.Request.Context(), principalType, principalID, a.nowUTC())
+	if err != nil {
+		return false, err
+	}
+	for _, granted := range permissions {
+		normalized := strings.ToLower(strings.TrimSpace(granted))
+		if normalized == permission || normalized == "*" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (a *rbacAuthorizer) ensureBuiltinRoles(ctx context.Context) error {
+	if a == nil || a.store == nil {
+		return nil
+	}
+	scope, err := db.RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	scopeKey := scope.TenantID + "|" + scope.WorkspaceID
+	if _, loaded := a.seeded.Load(scopeKey); loaded {
+		return nil
+	}
+
+	a.seedMux.Lock()
+	defer a.seedMux.Unlock()
+	if _, loaded := a.seeded.Load(scopeKey); loaded {
+		return nil
+	}
+	for _, role := range builtinRBACRoles {
+		if _, err := a.store.UpsertRBACRole(ctx, role); err != nil {
+			return err
+		}
+	}
+	a.seeded.Store(scopeKey, struct{}{})
+	return nil
+}
+
+func (a *rbacAuthorizer) bootstrapAPIKeyBinding(c *gin.Context) error {
+	if a == nil || a.store == nil || c == nil {
+		return nil
+	}
+	principalID := authContextString(c, "auth.principal_id")
+	if principalID == "" {
+		return nil
+	}
+	scopeSetValue, exists := c.Get("auth.scope_set")
+	if !exists {
+		return nil
+	}
+	scopes, ok := scopeSetValue.(scopeSet)
+	if !ok {
+		return nil
+	}
+
+	roleName := "viewer"
+	switch {
+	case scopes.has(scopeAdmin):
+		roleName = "admin"
+	case scopes.has(scopeWrite):
+		roleName = "operator"
+	case scopes.has(scopeRead):
+		roleName = "viewer"
+	default:
+		return nil
+	}
+
+	var selected db.RBACRole
+	for _, role := range builtinRBACRoles {
+		if role.Name == roleName {
+			selected = role
+			break
+		}
+	}
+	if selected.Name == "" {
+		return fmt.Errorf("missing built-in role %q", roleName)
+	}
+	upserted, err := a.store.UpsertRBACRole(c.Request.Context(), selected)
+	if err != nil {
+		return err
+	}
+	_, err = a.store.UpsertRBACBinding(c.Request.Context(), db.RBACBinding{
+		SubjectType: db.RBACSubjectTypeAPIKey,
+		SubjectID:   principalID,
+		RoleID:      upserted.ID,
+	})
+	return err
+}
+
+func (a *rbacAuthorizer) nowUTC() time.Time {
+	if a == nil || a.now == nil {
+		return time.Now().UTC()
+	}
+	return a.now().UTC()
+}
+
+func legacyScopeAllowsPermission(c *gin.Context, permission string) bool {
+	if c == nil {
+		return false
+	}
+	scopeSetValue, exists := c.Get("auth.scope_set")
+	if !exists {
+		return false
+	}
+	scopes, ok := scopeSetValue.(scopeSet)
+	if !ok {
+		return false
+	}
+	switch permission {
+	case rbacPermissionFindingsRead, rbacPermissionGraphRead, rbacPermissionScansRead, rbacPermissionRepoScansRead:
+		return scopes.has(scopeRead)
+	case rbacPermissionFindingsTriage, rbacPermissionScansRun, rbacPermissionRepoScansRun:
+		return scopes.has(scopeWrite)
+	case rbacPermissionRBACManage:
+		return scopes.has(scopeAdmin)
+	default:
+		return false
+	}
+}

--- a/internal/api/rbac_authz_test.go
+++ b/internal/api/rbac_authz_test.go
@@ -1,0 +1,358 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
+	"github.com/gin-gonic/gin"
+)
+
+func TestLegacyScopeAllowsPermission(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	if legacyScopeAllowsPermission(c, rbacPermissionFindingsRead) {
+		t.Fatal("expected deny when scope_set is absent")
+	}
+
+	c.Set("auth.scope_set", newScopeSet([]string{scopeRead}))
+	if !legacyScopeAllowsPermission(c, rbacPermissionFindingsRead) {
+		t.Fatal("expected read permission for read scope")
+	}
+	if legacyScopeAllowsPermission(c, rbacPermissionScansRun) {
+		t.Fatal("expected write permission deny for read scope")
+	}
+
+	c.Set("auth.scope_set", newScopeSet([]string{scopeWrite}))
+	if !legacyScopeAllowsPermission(c, rbacPermissionScansRun) {
+		t.Fatal("expected write permission for write scope")
+	}
+
+	c.Set("auth.scope_set", newScopeSet([]string{scopeAdmin}))
+	if !legacyScopeAllowsPermission(c, rbacPermissionRBACManage) {
+		t.Fatal("expected admin permission for admin scope")
+	}
+	if legacyScopeAllowsPermission(c, "unknown.permission") {
+		t.Fatal("expected deny for unknown permission")
+	}
+}
+
+func TestRBACAuthorizerAllowFallbacks(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	a := &rbacAuthorizer{}
+	allowed, err := a.allow(c, rbacPermissionFindingsRead)
+	if err != nil {
+		t.Fatalf("allow without auth context: %v", err)
+	}
+	if !allowed {
+		t.Fatal("expected allow when auth middleware is disabled")
+	}
+
+	c.Set("auth.subject", "subject-1")
+	c.Set("auth.scope_set", newScopeSet([]string{scopeRead}))
+	allowed, err = a.allow(c, rbacPermissionFindingsRead)
+	if err != nil {
+		t.Fatalf("allow legacy fallback: %v", err)
+	}
+	if !allowed {
+		t.Fatal("expected allow via legacy scope fallback")
+	}
+
+	delete(c.Keys, "auth.scope_set")
+	allowed, err = a.allow(c, rbacPermissionFindingsRead)
+	if err != nil {
+		t.Fatalf("allow legacy deny path: %v", err)
+	}
+	if allowed {
+		t.Fatal("expected deny without legacy scope set")
+	}
+}
+
+func TestRBACAuthorizerEnsureBuiltinRolesAndAllow(t *testing.T) {
+	store := db.NewMemoryStore()
+	a := &rbacAuthorizer{store: store, now: func() time.Time { return time.Date(2026, 4, 4, 20, 0, 0, 0, time.UTC) }}
+	ctx := defaultScopeContext()
+
+	if err := a.ensureBuiltinRoles(ctx); err != nil {
+		t.Fatalf("seed builtin roles: %v", err)
+	}
+	if err := a.ensureBuiltinRoles(ctx); err != nil {
+		t.Fatalf("seed builtin roles idempotent: %v", err)
+	}
+
+	roles, err := store.ListRBACRoles(ctx)
+	if err != nil {
+		t.Fatalf("list seeded roles: %v", err)
+	}
+	if len(roles) < 4 {
+		t.Fatalf("expected builtin roles to be seeded, got %d", len(roles))
+	}
+
+	var viewerRole db.RBACRole
+	for _, role := range roles {
+		if role.Name == "viewer" {
+			viewerRole = role
+			break
+		}
+	}
+	if viewerRole.ID == "" {
+		t.Fatal("expected viewer role in seeded set")
+	}
+	if _, err := store.UpsertRBACBinding(ctx, db.RBACBinding{
+		SubjectType: db.RBACSubjectTypeOIDCSubject,
+		SubjectID:   "alice",
+		RoleID:      viewerRole.ID,
+	}); err != nil {
+		t.Fatalf("upsert viewer binding: %v", err)
+	}
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	c.Request = req.WithContext(ctx)
+	c.Set("auth.principal_type", db.RBACSubjectTypeOIDCSubject)
+	c.Set("auth.principal_id", "alice")
+
+	allowed, err := a.allow(c, rbacPermissionFindingsRead)
+	if err != nil {
+		t.Fatalf("allow read with viewer binding: %v", err)
+	}
+	if !allowed {
+		t.Fatal("expected viewer binding to grant findings.read")
+	}
+
+	allowed, err = a.allow(c, rbacPermissionScansRun)
+	if err != nil {
+		t.Fatalf("allow run with viewer binding: %v", err)
+	}
+	if allowed {
+		t.Fatal("expected viewer binding to deny scans.run")
+	}
+}
+
+func TestRBACAuthorizerBootstrapAPIKeyBinding(t *testing.T) {
+	store := db.NewMemoryStore()
+	a := &rbacAuthorizer{store: store, now: time.Now}
+	ctx := defaultScopeContext()
+	if err := a.ensureBuiltinRoles(ctx); err != nil {
+		t.Fatalf("seed builtin roles: %v", err)
+	}
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	c.Request = req.WithContext(ctx)
+	c.Set("auth.principal_id", "key-fingerprint")
+	c.Set("auth.scope_set", newScopeSet([]string{scopeWrite}))
+
+	if err := a.bootstrapAPIKeyBinding(c); err != nil {
+		t.Fatalf("bootstrap api key binding: %v", err)
+	}
+
+	permissions, err := store.ListRBACPermissionsForSubject(ctx, db.RBACSubjectTypeAPIKey, "key-fingerprint", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("list api key permissions: %v", err)
+	}
+	if len(permissions) == 0 {
+		t.Fatal("expected permissions from bootstrap binding")
+	}
+}
+
+func TestRBACAuthorizerBootstrapAPIKeyBindingNoopCases(t *testing.T) {
+	store := db.NewMemoryStore()
+	a := &rbacAuthorizer{store: store, now: time.Now}
+	ctx := defaultScopeContext()
+	if err := a.ensureBuiltinRoles(ctx); err != nil {
+		t.Fatalf("seed builtin roles: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		set  func(*gin.Context)
+	}{
+		{
+			name: "missing principal id",
+			set: func(c *gin.Context) {
+				c.Set("auth.scope_set", newScopeSet([]string{scopeRead}))
+			},
+		},
+		{
+			name: "missing scope set",
+			set: func(c *gin.Context) {
+				c.Set("auth.principal_id", "api-key-fp")
+			},
+		},
+		{
+			name: "invalid scope set type",
+			set: func(c *gin.Context) {
+				c.Set("auth.principal_id", "api-key-fp")
+				c.Set("auth.scope_set", "invalid")
+			},
+		},
+		{
+			name: "unmapped scope set",
+			set: func(c *gin.Context) {
+				c.Set("auth.principal_id", "api-key-fp")
+				c.Set("auth.scope_set", newScopeSet([]string{"custom.scope"}))
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			c.Request = req.WithContext(ctx)
+			tc.set(c)
+			if err := a.bootstrapAPIKeyBinding(c); err != nil {
+				t.Fatalf("bootstrap noop case should not error: %v", err)
+			}
+		})
+	}
+}
+
+func TestRequireRBACPermissionMiddlewareResponses(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("empty permission bypass", func(t *testing.T) {
+		r := gin.New()
+		r.Use(requireRBACPermissionMiddleware(&rbacAuthorizer{}, "  "))
+		r.GET("/", func(c *gin.Context) { c.Status(http.StatusNoContent) })
+
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("expected 204, got %d", w.Code)
+		}
+	})
+
+	t.Run("authorization error", func(t *testing.T) {
+		a := &rbacAuthorizer{store: db.NewMemoryStore(), now: time.Now}
+		r := gin.New()
+		r.Use(func(c *gin.Context) {
+			c.Set("auth.principal_type", db.RBACSubjectTypeOIDCSubject)
+			c.Set("auth.principal_id", "subject-1")
+			c.Next()
+		})
+		r.Use(requireRBACPermissionMiddleware(a, rbacPermissionFindingsRead))
+		r.GET("/", func(c *gin.Context) { c.Status(http.StatusNoContent) })
+
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected 500, got %d", w.Code)
+		}
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		a := &rbacAuthorizer{store: db.NewMemoryStore(), now: time.Now}
+		r := gin.New()
+		r.Use(func(c *gin.Context) {
+			c.Request = c.Request.WithContext(defaultScopeContext())
+			c.Set("auth.principal_type", db.RBACSubjectTypeOIDCSubject)
+			c.Set("auth.principal_id", "subject-1")
+			c.Next()
+		})
+		r.Use(requireRBACPermissionMiddleware(a, rbacPermissionFindingsRead))
+		r.GET("/", func(c *gin.Context) { c.Status(http.StatusNoContent) })
+
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("expected 403, got %d", w.Code)
+		}
+	})
+
+	t.Run("allow", func(t *testing.T) {
+		a := &rbacAuthorizer{store: db.NewMemoryStore(), now: time.Now}
+		r := gin.New()
+		r.Use(func(c *gin.Context) {
+			c.Request = c.Request.WithContext(defaultScopeContext())
+			c.Set("auth.principal_type", db.RBACSubjectTypeAPIKey)
+			c.Set("auth.principal_id", "api-key-fp")
+			c.Set("auth.scope_set", newScopeSet([]string{scopeRead}))
+			c.Next()
+		})
+		r.Use(requireRBACPermissionMiddleware(a, rbacPermissionFindingsRead))
+		r.GET("/", func(c *gin.Context) { c.Status(http.StatusNoContent) })
+
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("expected 204, got %d", w.Code)
+		}
+	})
+}
+
+func TestRBACAuthorizerNowUTC(t *testing.T) {
+	var nilAuthorizer *rbacAuthorizer
+	if nilAuthorizer.nowUTC().IsZero() {
+		t.Fatal("expected non-zero time for nil authorizer")
+	}
+
+	a := &rbacAuthorizer{now: func() time.Time { return time.Date(2026, 4, 4, 23, 30, 0, 0, time.FixedZone("WAT", 3600)) }}
+	if got := a.nowUTC(); got.Location() != time.UTC {
+		t.Fatalf("expected UTC time, got %v", got.Location())
+	}
+}
+
+func TestRBACAuthorizerEnsureBuiltinRolesRequiresScope(t *testing.T) {
+	a := &rbacAuthorizer{store: db.NewMemoryStore(), now: time.Now}
+	if err := a.ensureBuiltinRoles(context.Background()); err == nil {
+		t.Fatal("expected scope-required error")
+	}
+}
+
+func TestRouterAuthContextHelpers(t *testing.T) {
+	if got := authContextString(nil, "auth.subject"); got != "" {
+		t.Fatalf("expected empty string for nil context, got %q", got)
+	}
+	if got := triageActorFromContext(nil); got != "unknown" {
+		t.Fatalf("expected unknown actor for nil context, got %q", got)
+	}
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	if got := authContextString(c, "missing"); got != "" {
+		t.Fatalf("expected empty string for missing key, got %q", got)
+	}
+	c.Set("auth.subject", 123)
+	if got := authContextString(c, "auth.subject"); got != "" {
+		t.Fatalf("expected empty string for non-string context value, got %q", got)
+	}
+	c.Set("auth.subject", "  alice  ")
+	if got := authContextString(c, "auth.subject"); got != "alice" {
+		t.Fatalf("expected trimmed auth subject, got %q", got)
+	}
+	if got := triageActorFromContext(c); got != "subject:alice" {
+		t.Fatalf("expected subject actor, got %q", got)
+	}
+
+	c.Set("auth.subject", "   ")
+	c.Set("auth.api_key", "key-1")
+	expected := "api_key:" + fingerprintAPIKey("key-1")
+	if got := triageActorFromContext(c); got != expected {
+		t.Fatalf("expected api key actor %q, got %q", expected, got)
+	}
+}
+
+func TestScopeSetFromOIDCToken(t *testing.T) {
+	token := VerifiedToken{Scopes: []string{"identrail.read", "custom:writer"}}
+	overrides := newScopeSet([]string{"custom:writer"})
+
+	set := scopeSetFromOIDCToken(token, overrides)
+	if !set.has(scopeRead) || !set.has(scopeWrite) {
+		t.Fatalf("expected read and write from read scope + override, got %+v", set)
+	}
+
+	admin := scopeSetFromOIDCToken(VerifiedToken{Scopes: []string{"identrail.admin"}}, nil)
+	if !admin.has(scopeAdmin) || !admin.has(scopeRead) || !admin.has(scopeWrite) {
+		t.Fatalf("expected admin scope expansion, got %+v", admin)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -106,76 +106,76 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 
 	r.GET("/metrics", gin.WrapH(promhttp.HandlerFor(registry, promhttp.HandlerOpts{})))
 
+	authorizer := newRBACAuthorizer(svc)
 	v1 := r.Group("/v1")
-	v1.Use(apiKeyAuthMiddleware(opts.APIKeys, opts.APIKeyScopes, opts.OIDCTokenVerifier, opts.OIDCWriteScopes))
+	v1.Use(apiKeyAuthMiddleware(opts.APIKeys, opts.WriteAPIKeys, opts.APIKeyScopes, opts.OIDCTokenVerifier, opts.OIDCWriteScopes))
 	v1.Use(requestScopeMiddleware(opts.DefaultTenantID, opts.DefaultWorkspaceID))
-	v1.Use(requireReadableScopeMiddleware(opts.APIKeyScopes, opts.OIDCTokenVerifier))
 	v1.Use(rateLimitMiddleware(opts.RateLimitRPM, opts.RateLimitBurst))
 	v1.Use(auditLogMiddleware(logger, opts.AuditSink))
 
 	if svc == nil {
-		v1.GET("/findings", func(c *gin.Context) {
+		v1.GET("/findings", requireRBACPermissionMiddleware(authorizer, rbacPermissionFindingsRead), func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"items": []any{}})
 		})
-		v1.GET("/findings/:finding_id", func(c *gin.Context) {
+		v1.GET("/findings/:finding_id", requireRBACPermissionMiddleware(authorizer, rbacPermissionFindingsRead), func(c *gin.Context) {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "scan service unavailable"})
 		})
-		v1.GET("/findings/:finding_id/history", func(c *gin.Context) {
+		v1.GET("/findings/:finding_id/history", requireRBACPermissionMiddleware(authorizer, rbacPermissionFindingsRead), func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"items": []any{}})
 		})
-		v1.GET("/findings/:finding_id/exports", func(c *gin.Context) {
+		v1.GET("/findings/:finding_id/exports", requireRBACPermissionMiddleware(authorizer, rbacPermissionFindingsRead), func(c *gin.Context) {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "scan service unavailable"})
 		})
-		v1.GET("/findings/trends", func(c *gin.Context) {
+		v1.GET("/findings/trends", requireRBACPermissionMiddleware(authorizer, rbacPermissionFindingsRead), func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"items": []any{}})
 		})
-		v1.GET("/findings/summary", func(c *gin.Context) {
+		v1.GET("/findings/summary", requireRBACPermissionMiddleware(authorizer, rbacPermissionFindingsRead), func(c *gin.Context) {
 			c.JSON(http.StatusOK, FindingsSummary{
 				Total:      0,
 				BySeverity: map[string]int{},
 				ByType:     map[string]int{},
 			})
 		})
-		v1.GET("/identities", func(c *gin.Context) {
+		v1.GET("/identities", requireRBACPermissionMiddleware(authorizer, rbacPermissionGraphRead), func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"items": []any{}})
 		})
-		v1.GET("/relationships", func(c *gin.Context) {
+		v1.GET("/relationships", requireRBACPermissionMiddleware(authorizer, rbacPermissionGraphRead), func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"items": []any{}})
 		})
-		v1.GET("/ownership/signals", func(c *gin.Context) {
+		v1.GET("/ownership/signals", requireRBACPermissionMiddleware(authorizer, rbacPermissionGraphRead), func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"items": []any{}})
 		})
-		v1.GET("/scans", func(c *gin.Context) {
+		v1.GET("/scans", requireRBACPermissionMiddleware(authorizer, rbacPermissionScansRead), func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"items": []any{}})
 		})
-		v1.GET("/scans/:scan_id/diff", func(c *gin.Context) {
+		v1.GET("/scans/:scan_id/diff", requireRBACPermissionMiddleware(authorizer, rbacPermissionScansRead), func(c *gin.Context) {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "scan service unavailable"})
 		})
-		v1.GET("/scans/:scan_id/events", func(c *gin.Context) {
+		v1.GET("/scans/:scan_id/events", requireRBACPermissionMiddleware(authorizer, rbacPermissionScansRead), func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"items": []any{}})
 		})
-		v1.GET("/repo-scans", func(c *gin.Context) {
+		v1.GET("/repo-scans", requireRBACPermissionMiddleware(authorizer, rbacPermissionRepoScansRead), func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"items": []any{}})
 		})
-		v1.GET("/repo-scans/:repo_scan_id", func(c *gin.Context) {
+		v1.GET("/repo-scans/:repo_scan_id", requireRBACPermissionMiddleware(authorizer, rbacPermissionRepoScansRead), func(c *gin.Context) {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "repo scan service unavailable"})
 		})
-		v1.GET("/repo-findings", func(c *gin.Context) {
+		v1.GET("/repo-findings", requireRBACPermissionMiddleware(authorizer, rbacPermissionRepoScansRead), func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"items": []any{}})
 		})
-		v1.POST("/scans", func(c *gin.Context) {
+		v1.POST("/scans", requireRBACPermissionMiddleware(authorizer, rbacPermissionScansRun), func(c *gin.Context) {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "scan service unavailable"})
 		})
-		v1.PATCH("/findings/:finding_id/triage", func(c *gin.Context) {
+		v1.PATCH("/findings/:finding_id/triage", requireRBACPermissionMiddleware(authorizer, rbacPermissionFindingsTriage), func(c *gin.Context) {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "scan service unavailable"})
 		})
-		v1.POST("/repo-scans", func(c *gin.Context) {
+		v1.POST("/repo-scans", requireRBACPermissionMiddleware(authorizer, rbacPermissionRepoScansRun), func(c *gin.Context) {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "repo scan service unavailable"})
 		})
 		return r
 	}
 
-	v1.GET("/findings", func(c *gin.Context) {
+	v1.GET("/findings", requireRBACPermissionMiddleware(authorizer, rbacPermissionFindingsRead), func(c *gin.Context) {
 		limit := parseLimit(c.Query("limit"), defaultFindingsLimit, maxListLimit)
 		offset := parseCursor(c.Query("cursor"))
 		sortBy, sortDesc := parseSortParams(c.Query("sort_by"), c.Query("sort_order"), "created_at")
@@ -204,7 +204,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, response)
 	})
 
-	v1.GET("/findings/summary", func(c *gin.Context) {
+	v1.GET("/findings/summary", requireRBACPermissionMiddleware(authorizer, rbacPermissionFindingsRead), func(c *gin.Context) {
 		limit := parseLimit(c.Query("limit"), defaultFindingsLimit, maxListLimit)
 		summary, err := svc.GetFindingsSummary(c.Request.Context(), limit)
 		if err != nil {
@@ -215,7 +215,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, summary)
 	})
 
-	v1.GET("/findings/:finding_id", func(c *gin.Context) {
+	v1.GET("/findings/:finding_id", requireRBACPermissionMiddleware(authorizer, rbacPermissionFindingsRead), func(c *gin.Context) {
 		item, err := svc.GetFinding(
 			c.Request.Context(),
 			strings.TrimSpace(c.Param("finding_id")),
@@ -233,7 +233,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, item)
 	})
 
-	v1.GET("/findings/:finding_id/history", func(c *gin.Context) {
+	v1.GET("/findings/:finding_id/history", requireRBACPermissionMiddleware(authorizer, rbacPermissionFindingsRead), func(c *gin.Context) {
 		limit := parseLimit(c.Query("limit"), defaultEventsLimit, maxListLimit)
 		items, err := svc.ListFindingTriageHistory(
 			c.Request.Context(),
@@ -253,7 +253,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, gin.H{"items": items})
 	})
 
-	v1.GET("/findings/:finding_id/exports", func(c *gin.Context) {
+	v1.GET("/findings/:finding_id/exports", requireRBACPermissionMiddleware(authorizer, rbacPermissionFindingsRead), func(c *gin.Context) {
 		exports, err := svc.GetFindingExports(
 			c.Request.Context(),
 			strings.TrimSpace(c.Param("finding_id")),
@@ -271,7 +271,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, exports)
 	})
 
-	v1.GET("/findings/trends", func(c *gin.Context) {
+	v1.GET("/findings/trends", requireRBACPermissionMiddleware(authorizer, rbacPermissionFindingsRead), func(c *gin.Context) {
 		points := parseLimit(c.Query("points"), 10, 100)
 		items, err := svc.GetFindingsTrendFiltered(
 			c.Request.Context(),
@@ -287,7 +287,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, gin.H{"items": items})
 	})
 
-	v1.PATCH("/findings/:finding_id/triage", requireWriteKeyMiddleware(opts.WriteAPIKeys, opts.APIKeyScopes), func(c *gin.Context) {
+	v1.PATCH("/findings/:finding_id/triage", requireRBACPermissionMiddleware(authorizer, rbacPermissionFindingsTriage), func(c *gin.Context) {
 		var request FindingTriageRequest
 		if err := c.ShouldBindJSON(&request); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
@@ -316,7 +316,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, gin.H{"finding": item})
 	})
 
-	v1.GET("/identities", func(c *gin.Context) {
+	v1.GET("/identities", requireRBACPermissionMiddleware(authorizer, rbacPermissionGraphRead), func(c *gin.Context) {
 		limit := parseLimit(c.Query("limit"), defaultFindingsLimit, maxListLimit)
 		offset := parseCursor(c.Query("cursor"))
 		sortBy, sortDesc := parseSortParams(c.Query("sort_by"), c.Query("sort_order"), "name")
@@ -346,7 +346,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, response)
 	})
 
-	v1.GET("/relationships", func(c *gin.Context) {
+	v1.GET("/relationships", requireRBACPermissionMiddleware(authorizer, rbacPermissionGraphRead), func(c *gin.Context) {
 		limit := parseLimit(c.Query("limit"), defaultFindingsLimit, maxListLimit)
 		offset := parseCursor(c.Query("cursor"))
 		sortBy, sortDesc := parseSortParams(c.Query("sort_by"), c.Query("sort_order"), "discovered_at")
@@ -376,7 +376,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, response)
 	})
 
-	v1.GET("/ownership/signals", func(c *gin.Context) {
+	v1.GET("/ownership/signals", requireRBACPermissionMiddleware(authorizer, rbacPermissionGraphRead), func(c *gin.Context) {
 		limit := parseLimit(c.Query("limit"), defaultFindingsLimit, maxListLimit)
 		offset := parseCursor(c.Query("cursor"))
 		sortBy, sortDesc := parseSortParams(c.Query("sort_by"), c.Query("sort_order"), "confidence")
@@ -403,7 +403,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, response)
 	})
 
-	v1.GET("/scans", func(c *gin.Context) {
+	v1.GET("/scans", requireRBACPermissionMiddleware(authorizer, rbacPermissionScansRead), func(c *gin.Context) {
 		limit := parseLimit(c.Query("limit"), defaultScansLimit, maxListLimit)
 		offset := parseCursor(c.Query("cursor"))
 		sortBy, sortDesc := parseSortParams(c.Query("sort_by"), c.Query("sort_order"), "started_at")
@@ -422,7 +422,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, response)
 	})
 
-	v1.GET("/scans/:scan_id/diff", func(c *gin.Context) {
+	v1.GET("/scans/:scan_id/diff", requireRBACPermissionMiddleware(authorizer, rbacPermissionScansRead), func(c *gin.Context) {
 		limit := parseLimit(c.Query("limit"), defaultFindingsLimit, maxListLimit)
 		diff, err := svc.GetScanDiffAgainst(
 			c.Request.Context(),
@@ -446,7 +446,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, diff)
 	})
 
-	v1.GET("/scans/:scan_id/events", func(c *gin.Context) {
+	v1.GET("/scans/:scan_id/events", requireRBACPermissionMiddleware(authorizer, rbacPermissionScansRead), func(c *gin.Context) {
 		limit := parseLimit(c.Query("limit"), defaultEventsLimit, maxListLimit)
 		offset := parseCursor(c.Query("cursor"))
 		sortBy, sortDesc := parseSortParams(c.Query("sort_by"), c.Query("sort_order"), "created_at")
@@ -474,7 +474,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, response)
 	})
 
-	v1.GET("/repo-scans", func(c *gin.Context) {
+	v1.GET("/repo-scans", requireRBACPermissionMiddleware(authorizer, rbacPermissionRepoScansRead), func(c *gin.Context) {
 		limit := parseLimit(c.Query("limit"), defaultScansLimit, maxListLimit)
 		offset := parseCursor(c.Query("cursor"))
 		sortBy, sortDesc := parseSortParams(c.Query("sort_by"), c.Query("sort_order"), "started_at")
@@ -493,7 +493,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, response)
 	})
 
-	v1.GET("/repo-scans/:repo_scan_id", func(c *gin.Context) {
+	v1.GET("/repo-scans/:repo_scan_id", requireRBACPermissionMiddleware(authorizer, rbacPermissionRepoScansRead), func(c *gin.Context) {
 		repoScanID := strings.TrimSpace(c.Param("repo_scan_id"))
 		if !isValidUUID(repoScanID) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid repo_scan_id"})
@@ -512,7 +512,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, item)
 	})
 
-	v1.GET("/repo-findings", func(c *gin.Context) {
+	v1.GET("/repo-findings", requireRBACPermissionMiddleware(authorizer, rbacPermissionRepoScansRead), func(c *gin.Context) {
 		limit := parseLimit(c.Query("limit"), defaultFindingsLimit, maxListLimit)
 		offset := parseCursor(c.Query("cursor"))
 		sortBy, sortDesc := parseSortParams(c.Query("sort_by"), c.Query("sort_order"), "created_at")
@@ -548,7 +548,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, response)
 	})
 
-	v1.POST("/scans", requireWriteKeyMiddleware(opts.WriteAPIKeys, opts.APIKeyScopes), func(c *gin.Context) {
+	v1.POST("/scans", requireRBACPermissionMiddleware(authorizer, rbacPermissionScansRun), func(c *gin.Context) {
 		start := time.Now()
 		metrics.ScanRunsTotal.Inc()
 		metrics.ScanInFlight.Inc()
@@ -574,7 +574,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		})
 	})
 
-	v1.POST("/repo-scans", requireWriteKeyMiddleware(opts.WriteAPIKeys, opts.APIKeyScopes), func(c *gin.Context) {
+	v1.POST("/repo-scans", requireRBACPermissionMiddleware(authorizer, rbacPermissionRepoScansRun), func(c *gin.Context) {
 		start := time.Now()
 		metrics.RepoScanRunsTotal.Inc()
 		defer func() {
@@ -619,6 +619,101 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusAccepted, gin.H{
 			"repo_scan": record,
 		})
+	})
+
+	rbacGroup := v1.Group("/rbac")
+	rbacGroup.Use(requireRBACPermissionMiddleware(authorizer, rbacPermissionRBACManage))
+	rbacGroup.GET("/roles", func(c *gin.Context) {
+		roles, err := svc.ListRBACRoles(c.Request.Context())
+		if err != nil {
+			logger.Error("list rbac roles", telemetry.ZapError(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list rbac roles"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"items": roles})
+	})
+	rbacGroup.PUT("/roles/:name", func(c *gin.Context) {
+		var req struct {
+			Description string   `json:"description"`
+			Permissions []string `json:"permissions"`
+		}
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			return
+		}
+		role, err := svc.UpsertRBACRole(c.Request.Context(), db.RBACRole{
+			Name:        strings.TrimSpace(c.Param("name")),
+			Description: req.Description,
+			Permissions: req.Permissions,
+		})
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid rbac role"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"role": role})
+	})
+	rbacGroup.DELETE("/roles/:role_id", func(c *gin.Context) {
+		if err := svc.DeleteRBACRole(c.Request.Context(), c.Param("role_id")); err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "rbac role not found"})
+				return
+			}
+			c.JSON(http.StatusBadRequest, gin.H{"error": "unable to delete rbac role"})
+			return
+		}
+		c.Status(http.StatusNoContent)
+	})
+	rbacGroup.GET("/bindings", func(c *gin.Context) {
+		bindings, err := svc.ListRBACBindings(c.Request.Context())
+		if err != nil {
+			logger.Error("list rbac bindings", telemetry.ZapError(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list rbac bindings"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"items": bindings})
+	})
+	rbacGroup.POST("/bindings", func(c *gin.Context) {
+		var req struct {
+			SubjectType string `json:"subject_type"`
+			SubjectID   string `json:"subject_id"`
+			RoleID      string `json:"role_id"`
+			ExpiresAt   string `json:"expires_at"`
+		}
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			return
+		}
+		expiresAt, err := parseOptionalRFC3339(req.ExpiresAt)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid expires_at"})
+			return
+		}
+		binding, err := svc.UpsertRBACBinding(c.Request.Context(), db.RBACBinding{
+			SubjectType: req.SubjectType,
+			SubjectID:   req.SubjectID,
+			RoleID:      req.RoleID,
+			ExpiresAt:   expiresAt,
+		})
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "rbac role not found"})
+				return
+			}
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid rbac binding"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"binding": binding})
+	})
+	rbacGroup.DELETE("/bindings/:binding_id", func(c *gin.Context) {
+		if err := svc.DeleteRBACBinding(c.Request.Context(), c.Param("binding_id")); err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "rbac binding not found"})
+				return
+			}
+			c.JSON(http.StatusBadRequest, gin.H{"error": "unable to delete rbac binding"})
+			return
+		}
+		c.Status(http.StatusNoContent)
 	})
 
 	return r
@@ -1100,7 +1195,13 @@ func securityHeadersMiddleware() gin.HandlerFunc {
 	}
 }
 
-func apiKeyAuthMiddleware(keys []string, scopedKeys map[string][]string, tokenVerifier TokenVerifier, oidcWriteScopes []string) gin.HandlerFunc {
+func apiKeyAuthMiddleware(
+	keys []string,
+	writeKeys []string,
+	scopedKeys map[string][]string,
+	tokenVerifier TokenVerifier,
+	oidcWriteScopes []string,
+) gin.HandlerFunc {
 	oidcWriteScopeSet := newScopeSet(oidcWriteScopes)
 
 	scopedAllowed := map[string]scopeSet{}
@@ -1123,6 +1224,14 @@ func apiKeyAuthMiddleware(keys []string, scopedKeys map[string][]string, tokenVe
 			legacyAllowed = append(legacyAllowed, trimmed)
 		}
 	}
+	legacyWriteAllowed := []string{}
+	for _, key := range writeKeys {
+		trimmed := strings.TrimSpace(key)
+		if trimmed == "" {
+			continue
+		}
+		legacyWriteAllowed = append(legacyWriteAllowed, trimmed)
+	}
 
 	if len(scopedAllowed) == 0 && len(legacyAllowed) == 0 && tokenVerifier == nil {
 		return func(c *gin.Context) { c.Next() }
@@ -1133,11 +1242,16 @@ func apiKeyAuthMiddleware(keys []string, scopedKeys map[string][]string, tokenVe
 			if scopes, ok := scopedKeyLookup(scopedAllowed, candidate); ok {
 				c.Set("auth.api_key", candidate)
 				c.Set("auth.scope_set", scopes)
+				c.Set("auth.principal_type", db.RBACSubjectTypeAPIKey)
+				c.Set("auth.principal_id", fingerprintAPIKey(candidate))
 				c.Next()
 				return
 			}
 			if keyInList(legacyAllowed, candidate) {
 				c.Set("auth.api_key", candidate)
+				c.Set("auth.scope_set", legacyScopeSetForKey(candidate, legacyWriteAllowed))
+				c.Set("auth.principal_type", db.RBACSubjectTypeAPIKey)
+				c.Set("auth.principal_id", fingerprintAPIKey(candidate))
 				c.Next()
 				return
 			}
@@ -1155,6 +1269,8 @@ func apiKeyAuthMiddleware(keys []string, scopedKeys map[string][]string, tokenVe
 				c.Set("auth.tenant_id", token.TenantID)
 				c.Set("auth.workspace_id", token.WorkspaceID)
 				c.Set("auth.scope_set", scopeSetFromOIDCToken(token, oidcWriteScopeSet))
+				c.Set("auth.principal_type", db.RBACSubjectTypeOIDCSubject)
+				c.Set("auth.principal_id", token.Subject)
 				c.Next()
 				return
 			}
@@ -1163,60 +1279,6 @@ func apiKeyAuthMiddleware(keys []string, scopedKeys map[string][]string, tokenVe
 		}
 
 		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
-	}
-}
-
-func requireWriteKeyMiddleware(writeKeys []string, scopedKeys map[string][]string) gin.HandlerFunc {
-	allowed := []string{}
-	for _, key := range writeKeys {
-		trimmed := strings.TrimSpace(key)
-		if trimmed == "" {
-			continue
-		}
-		allowed = append(allowed, trimmed)
-	}
-
-	// When scoped auth exists (scoped API keys or OIDC token scopes), prefer scope-based write checks.
-	// This keeps API keys backward compatible while allowing OAuth/OIDC write scopes.
-	return func(c *gin.Context) {
-		if scopeSetValue, exists := c.Get("auth.scope_set"); exists {
-			scopes, ok := scopeSetValue.(scopeSet)
-			if !ok || !scopes.has(scopeWrite) {
-				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
-				return
-			}
-			c.Next()
-			return
-		}
-
-		if len(scopedKeys) > 0 {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
-			return
-		}
-
-		if len(allowed) == 0 {
-			// When auth middleware is disabled (test/local stubs), keep route behavior unchanged.
-			// In authenticated API-key mode, empty write-key config must not grant write access.
-			if _, exists := c.Get("auth.api_key"); exists {
-				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
-				return
-			}
-			c.Next()
-			return
-		}
-
-		apiKeyValue, exists := c.Get("auth.api_key")
-		if !exists {
-			// If API key auth is disabled, write authorization cannot be enforced.
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
-			return
-		}
-		apiKey, _ := apiKeyValue.(string)
-		if !keyInList(allowed, apiKey) {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
-			return
-		}
-		c.Next()
 	}
 }
 
@@ -1238,41 +1300,21 @@ func scopedKeyLookup(scoped map[string]scopeSet, candidate string) (scopeSet, bo
 	return scopeSet{}, false
 }
 
+func legacyScopeSetForKey(candidate string, writeKeys []string) scopeSet {
+	set := scopeSet{
+		scopeRead: {},
+	}
+	if keyInList(writeKeys, candidate) {
+		set[scopeWrite] = struct{}{}
+	}
+	return set
+}
+
 func secureKeyEquals(expected string, candidate string) bool {
 	if len(expected) != len(candidate) {
 		return false
 	}
 	return subtle.ConstantTimeCompare([]byte(expected), []byte(candidate)) == 1
-}
-
-func requireReadableScopeMiddleware(scopedKeys map[string][]string, tokenVerifier TokenVerifier) gin.HandlerFunc {
-	if len(scopedKeys) == 0 && tokenVerifier == nil {
-		return func(c *gin.Context) { c.Next() }
-	}
-	return func(c *gin.Context) {
-		// Backward compatibility: in legacy API-key mode (no scoped keys), an API key
-		// authenticated request remains read-authorized even when OIDC is also enabled.
-		if len(scopedKeys) == 0 {
-			if _, hasAPIKey := c.Get("auth.api_key"); hasAPIKey {
-				if _, hasScopes := c.Get("auth.scope_set"); !hasScopes {
-					c.Next()
-					return
-				}
-			}
-		}
-
-		scopeSetValue, exists := c.Get("auth.scope_set")
-		if !exists {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
-			return
-		}
-		scopes, ok := scopeSetValue.(scopeSet)
-		if !ok || !scopes.has(scopeRead) {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
-			return
-		}
-		c.Next()
-	}
 }
 
 type ipRateLimiter struct {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1231,6 +1231,22 @@ func TestRouterOIDCWriteScopeAuthorization(t *testing.T) {
 	metrics := telemetry.NewMetrics()
 	store := db.NewMemoryStore()
 	svc := NewService(store, routerScanner{}, "aws")
+	writerScopeCtx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-1", WorkspaceID: "workspace-1"})
+	writerRole, err := svc.UpsertRBACRole(writerScopeCtx, db.RBACRole{
+		Name:        "writer",
+		Description: "writer role",
+		Permissions: []string{rbacPermissionScansRun, rbacPermissionScansRead},
+	})
+	if err != nil {
+		t.Fatalf("create writer role: %v", err)
+	}
+	if _, err := svc.UpsertRBACBinding(writerScopeCtx, db.RBACBinding{
+		SubjectType: db.RBACSubjectTypeOIDCSubject,
+		SubjectID:   "user-write",
+		RoleID:      writerRole.ID,
+	}); err != nil {
+		t.Fatalf("bind writer role: %v", err)
+	}
 	r := NewRouter(logger, metrics, svc, RouterOptions{
 		OIDCTokenVerifier: fakeTokenVerifier{
 			tokens: map[string]VerifiedToken{
@@ -1291,6 +1307,98 @@ func TestRouterHybridOIDCAndLegacyAPIKeyReadCompatibility(t *testing.T) {
 	r.ServeHTTP(readW, readReq)
 	if readW.Code != http.StatusOK {
 		t.Fatalf("expected legacy api key read to pass in hybrid mode, got %d", readW.Code)
+	}
+}
+
+func TestRouterRBACLeastPrivilegeByWorkspace(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+
+	scopeA := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	roleA, err := svc.UpsertRBACRole(scopeA, db.RBACRole{
+		Name:        "workspace-a-viewer",
+		Description: "workspace A viewer",
+		Permissions: []string{rbacPermissionFindingsRead},
+	})
+	if err != nil {
+		t.Fatalf("create workspace role: %v", err)
+	}
+	if _, err := svc.UpsertRBACBinding(scopeA, db.RBACBinding{
+		SubjectType: db.RBACSubjectTypeOIDCSubject,
+		SubjectID:   "user-1",
+		RoleID:      roleA.ID,
+	}); err != nil {
+		t.Fatalf("bind workspace role: %v", err)
+	}
+
+	r := NewRouter(logger, metrics, svc, RouterOptions{
+		OIDCTokenVerifier: fakeTokenVerifier{
+			tokens: map[string]VerifiedToken{
+				"token-workspace-a": {
+					Subject:     "user-1",
+					TenantID:    "tenant-a",
+					WorkspaceID: "workspace-a",
+					Scopes:      []string{"identrail.read"},
+				},
+				"token-workspace-b": {
+					Subject:     "user-1",
+					TenantID:    "tenant-a",
+					WorkspaceID: "workspace-b",
+					Scopes:      []string{"identrail.read"},
+				},
+			},
+		},
+	})
+
+	allowedReq := httptest.NewRequest(http.MethodGet, "/v1/findings", nil)
+	allowedReq.Header.Set("Authorization", "Bearer token-workspace-a")
+	allowedW := httptest.NewRecorder()
+	r.ServeHTTP(allowedW, allowedReq)
+	if allowedW.Code != http.StatusOK {
+		t.Fatalf("expected workspace-a request to pass, got %d", allowedW.Code)
+	}
+
+	deniedReq := httptest.NewRequest(http.MethodGet, "/v1/findings", nil)
+	deniedReq.Header.Set("Authorization", "Bearer token-workspace-b")
+	deniedW := httptest.NewRecorder()
+	r.ServeHTTP(deniedW, deniedReq)
+	if deniedW.Code != http.StatusForbidden {
+		t.Fatalf("expected workspace-b request to be forbidden, got %d", deniedW.Code)
+	}
+}
+
+func TestRouterRBACManageEndpointsWithAdminScopedAPIKey(t *testing.T) {
+	logger := zap.NewNop()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+	r := NewRouter(logger, metrics, svc, RouterOptions{
+		APIKeyScopes: map[string][]string{
+			"admin-key": {"admin"},
+		},
+	})
+
+	listReq := httptest.NewRequest(http.MethodGet, "/v1/rbac/roles", nil)
+	listReq.Header.Set("X-API-Key", "admin-key")
+	listW := httptest.NewRecorder()
+	r.ServeHTTP(listW, listReq)
+	if listW.Code != http.StatusOK {
+		t.Fatalf("expected list roles to pass for admin key, got %d", listW.Code)
+	}
+
+	putReq := httptest.NewRequest(
+		http.MethodPut,
+		"/v1/rbac/roles/custom-viewer",
+		bytes.NewBufferString(`{"description":"custom","permissions":["findings.read"]}`),
+	)
+	putReq.Header.Set("Content-Type", "application/json")
+	putReq.Header.Set("X-API-Key", "admin-key")
+	putW := httptest.NewRecorder()
+	r.ServeHTTP(putW, putReq)
+	if putW.Code != http.StatusOK {
+		t.Fatalf("expected role upsert to pass for admin key, got %d", putW.Code)
 	}
 }
 

--- a/internal/api/service_rbac.go
+++ b/internal/api/service_rbac.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
+)
+
+// UpsertRBACRole creates or updates a workspace-scoped RBAC role.
+func (s *Service) UpsertRBACRole(ctx context.Context, role db.RBACRole) (db.RBACRole, error) {
+	ctx = s.scopeContext(ctx)
+	name := strings.ToLower(strings.TrimSpace(role.Name))
+	if name == "" {
+		return db.RBACRole{}, fmt.Errorf("role name is required")
+	}
+	role.Name = name
+	role.Description = strings.TrimSpace(role.Description)
+	role.Permissions = normalizePermissionList(role.Permissions)
+	if len(role.Permissions) == 0 {
+		return db.RBACRole{}, fmt.Errorf("role permissions are required")
+	}
+	return s.Store.UpsertRBACRole(ctx, role)
+}
+
+// ListRBACRoles returns role definitions for current workspace scope.
+func (s *Service) ListRBACRoles(ctx context.Context) ([]db.RBACRole, error) {
+	ctx = s.scopeContext(ctx)
+	roles, err := s.Store.ListRBACRoles(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i := range roles {
+		roles[i].Permissions = normalizePermissionList(roles[i].Permissions)
+	}
+	return roles, nil
+}
+
+// DeleteRBACRole removes a custom role in the current workspace.
+func (s *Service) DeleteRBACRole(ctx context.Context, roleID string) error {
+	ctx = s.scopeContext(ctx)
+	return s.Store.DeleteRBACRole(ctx, strings.TrimSpace(roleID))
+}
+
+// UpsertRBACBinding creates or updates a subject-role binding.
+func (s *Service) UpsertRBACBinding(ctx context.Context, binding db.RBACBinding) (db.RBACBinding, error) {
+	ctx = s.scopeContext(ctx)
+	binding.SubjectType = strings.ToLower(strings.TrimSpace(binding.SubjectType))
+	binding.SubjectID = strings.TrimSpace(binding.SubjectID)
+	binding.RoleID = strings.TrimSpace(binding.RoleID)
+	if binding.SubjectID == "" || binding.RoleID == "" {
+		return db.RBACBinding{}, fmt.Errorf("subject_id and role_id are required")
+	}
+	if binding.ExpiresAt != nil {
+		expires := binding.ExpiresAt.UTC()
+		binding.ExpiresAt = &expires
+	}
+	return s.Store.UpsertRBACBinding(ctx, binding)
+}
+
+// ListRBACBindings returns current workspace bindings.
+func (s *Service) ListRBACBindings(ctx context.Context) ([]db.RBACBinding, error) {
+	ctx = s.scopeContext(ctx)
+	return s.Store.ListRBACBindings(ctx)
+}
+
+// DeleteRBACBinding removes one binding in current scope.
+func (s *Service) DeleteRBACBinding(ctx context.Context, bindingID string) error {
+	ctx = s.scopeContext(ctx)
+	return s.Store.DeleteRBACBinding(ctx, strings.TrimSpace(bindingID))
+}
+
+func normalizePermissionList(values []string) []string {
+	seen := map[string]struct{}{}
+	permissions := make([]string, 0, len(values))
+	for _, item := range values {
+		normalized := strings.ToLower(strings.TrimSpace(item))
+		if normalized == "" {
+			continue
+		}
+		if _, exists := seen[normalized]; exists {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		permissions = append(permissions, normalized)
+	}
+	return permissions
+}
+
+func parseOptionalRFC3339(raw string) (*time.Time, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, nil
+	}
+	parsed, err := time.Parse(time.RFC3339, trimmed)
+	if err != nil {
+		return nil, fmt.Errorf("invalid timestamp format")
+	}
+	value := parsed.UTC()
+	return &value, nil
+}

--- a/internal/api/service_rbac_test.go
+++ b/internal/api/service_rbac_test.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
+)
+
+func TestServiceRBACRoleAndBindingLifecycle(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, nil, "aws")
+	ctx := defaultScopeContext()
+
+	role, err := svc.UpsertRBACRole(ctx, db.RBACRole{
+		Name:        " Viewer ",
+		Description: " read only ",
+		Permissions: []string{"Scans.Read", "findings.read", "scans.read", "   "},
+	})
+	if err != nil {
+		t.Fatalf("upsert role: %v", err)
+	}
+	if role.Name != "viewer" {
+		t.Fatalf("expected normalized role name, got %q", role.Name)
+	}
+
+	roles, err := svc.ListRBACRoles(ctx)
+	if err != nil {
+		t.Fatalf("list roles: %v", err)
+	}
+	if len(roles) != 1 {
+		t.Fatalf("expected one role, got %d", len(roles))
+	}
+	if len(roles[0].Permissions) != 2 {
+		t.Fatalf("expected deduped permissions, got %+v", roles[0].Permissions)
+	}
+
+	expiresLocal := time.Date(2026, 4, 4, 15, 0, 0, 0, time.FixedZone("WAT", 3600))
+	binding, err := svc.UpsertRBACBinding(ctx, db.RBACBinding{
+		SubjectType: db.RBACSubjectTypeOIDCSubject,
+		SubjectID:   " user-1 ",
+		RoleID:      " " + role.ID + " ",
+		ExpiresAt:   &expiresLocal,
+	})
+	if err != nil {
+		t.Fatalf("upsert binding: %v", err)
+	}
+	if binding.ExpiresAt == nil || binding.ExpiresAt.Location() != time.UTC {
+		t.Fatalf("expected UTC expires_at, got %+v", binding.ExpiresAt)
+	}
+
+	bindings, err := svc.ListRBACBindings(ctx)
+	if err != nil {
+		t.Fatalf("list bindings: %v", err)
+	}
+	if len(bindings) != 1 {
+		t.Fatalf("expected one binding, got %d", len(bindings))
+	}
+
+	if err := svc.DeleteRBACBinding(ctx, " "+binding.ID+" "); err != nil {
+		t.Fatalf("delete binding: %v", err)
+	}
+	if err := svc.DeleteRBACRole(ctx, " "+role.ID+" "); err != nil {
+		t.Fatalf("delete role: %v", err)
+	}
+}
+
+func TestServiceRBACInputValidation(t *testing.T) {
+	svc := NewService(db.NewMemoryStore(), nil, "aws")
+	ctx := defaultScopeContext()
+
+	if _, err := svc.UpsertRBACRole(ctx, db.RBACRole{Name: "", Permissions: []string{"findings.read"}}); err == nil {
+		t.Fatal("expected role name validation error")
+	}
+	if _, err := svc.UpsertRBACRole(ctx, db.RBACRole{Name: "custom", Permissions: []string{" ", ""}}); err == nil {
+		t.Fatal("expected role permissions validation error")
+	}
+	if _, err := svc.UpsertRBACBinding(ctx, db.RBACBinding{SubjectType: db.RBACSubjectTypeOIDCSubject, RoleID: "role-1"}); err == nil {
+		t.Fatal("expected missing subject id error")
+	}
+	if _, err := svc.UpsertRBACBinding(ctx, db.RBACBinding{SubjectType: db.RBACSubjectTypeOIDCSubject, SubjectID: "user-1"}); err == nil {
+		t.Fatal("expected missing role id error")
+	}
+
+	if err := svc.DeleteRBACBinding(ctx, " "); !errors.Is(err, db.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound deleting blank binding id, got %v", err)
+	}
+	if err := svc.DeleteRBACRole(ctx, " "); !errors.Is(err, db.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound deleting blank role id, got %v", err)
+	}
+}
+
+func TestParseOptionalRFC3339(t *testing.T) {
+	if got, err := parseOptionalRFC3339("   "); err != nil || got != nil {
+		t.Fatalf("expected nil timestamp, got %v err=%v", got, err)
+	}
+
+	parsed, err := parseOptionalRFC3339("2026-04-04T21:30:00+01:00")
+	if err != nil {
+		t.Fatalf("parse rfc3339: %v", err)
+	}
+	if parsed == nil || parsed.Location() != time.UTC {
+		t.Fatalf("expected UTC timestamp, got %+v", parsed)
+	}
+
+	if _, err := parseOptionalRFC3339("not-a-timestamp"); err == nil {
+		t.Fatal("expected parse error for invalid timestamp")
+	}
+}
+
+func TestNormalizePermissionList(t *testing.T) {
+	got := normalizePermissionList([]string{" findings.read ", "FINDINGS.READ", "scans.run", ""})
+	if len(got) != 2 {
+		t.Fatalf("expected 2 permissions, got %+v", got)
+	}
+	if got[0] != "findings.read" || got[1] != "scans.run" {
+		t.Fatalf("unexpected normalized permissions: %+v", got)
+	}
+}

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -31,6 +31,12 @@ type MemoryStore struct {
 	policies      map[string]domain.Policy
 	relationships map[string]domain.Relationship
 	permissions   map[string]providers.PermissionTuple
+
+	rbacRoles       map[string]RBACRole
+	rbacRoleByName  map[string]string
+	rbacRolePerms   map[string][]string
+	rbacBindings    map[string]RBACBinding
+	rbacBindingByID []string
 }
 
 // NewMemoryStore initializes an empty in-memory store.
@@ -51,6 +57,12 @@ func NewMemoryStore() *MemoryStore {
 		policies:      map[string]domain.Policy{},
 		relationships: map[string]domain.Relationship{},
 		permissions:   map[string]providers.PermissionTuple{},
+
+		rbacRoles:       map[string]RBACRole{},
+		rbacRoleByName:  map[string]string{},
+		rbacRolePerms:   map[string][]string{},
+		rbacBindings:    map[string]RBACBinding{},
+		rbacBindingByID: []string{},
 	}
 }
 
@@ -940,6 +952,275 @@ func (m *MemoryStore) ListRepoFindings(ctx context.Context, filter RepoFindingFi
 		result = result[:limit]
 	}
 	return result, nil
+}
+
+// UpsertRBACRole creates or updates one workspace-scoped role.
+func (m *MemoryStore) UpsertRBACRole(ctx context.Context, role RBACRole) (RBACRole, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return RBACRole{}, err
+	}
+
+	name := strings.ToLower(strings.TrimSpace(role.Name))
+	if name == "" {
+		return RBACRole{}, fmt.Errorf("role name is required")
+	}
+	roleKey := rbacRoleNameScopeKey(scope, name)
+	existingID, exists := m.rbacRoleByName[roleKey]
+
+	now := time.Now().UTC()
+	normalized := RBACRole{
+		ID:          strings.TrimSpace(role.ID),
+		TenantID:    scope.Normalize().TenantID,
+		WorkspaceID: scope.Normalize().WorkspaceID,
+		Name:        name,
+		Description: strings.TrimSpace(role.Description),
+		IsBuiltIn:   role.IsBuiltIn,
+		Permissions: normalizeRBACPermissionList(role.Permissions),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	if exists {
+		existingRole := m.rbacRoles[existingID]
+		normalized.ID = existingRole.ID
+		normalized.CreatedAt = existingRole.CreatedAt
+		normalized.UpdatedAt = now
+		if existingRole.IsBuiltIn {
+			normalized.IsBuiltIn = true
+		}
+	} else if normalized.ID == "" {
+		normalized.ID = uuid.NewString()
+	}
+
+	m.rbacRoles[normalized.ID] = normalized
+	m.rbacRoleByName[roleKey] = normalized.ID
+	m.rbacRolePerms[normalized.ID] = append([]string(nil), normalized.Permissions...)
+	return normalized, nil
+}
+
+// ListRBACRoles returns roles for current tenant/workspace scope.
+func (m *MemoryStore) ListRBACRoles(ctx context.Context) ([]RBACRole, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	normalizedScope := scope.Normalize()
+	roles := []RBACRole{}
+	for _, role := range m.rbacRoles {
+		if !MatchScope(normalizedScope, role.TenantID, role.WorkspaceID) {
+			continue
+		}
+		roleCopy := role
+		roleCopy.Permissions = append([]string(nil), m.rbacRolePerms[role.ID]...)
+		roles = append(roles, roleCopy)
+	}
+	sort.SliceStable(roles, func(i, j int) bool {
+		if roles[i].Name == roles[j].Name {
+			return roles[i].ID < roles[j].ID
+		}
+		return roles[i].Name < roles[j].Name
+	})
+	return roles, nil
+}
+
+// DeleteRBACRole removes one role and any associated bindings.
+func (m *MemoryStore) DeleteRBACRole(ctx context.Context, roleID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	normalizedRoleID := strings.TrimSpace(roleID)
+	if normalizedRoleID == "" {
+		return ErrNotFound
+	}
+	role, exists := m.rbacRoles[normalizedRoleID]
+	if !exists || !MatchScope(scope, role.TenantID, role.WorkspaceID) {
+		return ErrNotFound
+	}
+	if role.IsBuiltIn {
+		return fmt.Errorf("built-in roles cannot be deleted")
+	}
+	delete(m.rbacRoles, normalizedRoleID)
+	delete(m.rbacRolePerms, normalizedRoleID)
+	delete(m.rbacRoleByName, rbacRoleNameScopeKey(scope, role.Name))
+	for bindingID, binding := range m.rbacBindings {
+		if binding.RoleID == normalizedRoleID && MatchScope(scope, binding.TenantID, binding.WorkspaceID) {
+			delete(m.rbacBindings, bindingID)
+		}
+	}
+	return nil
+}
+
+// UpsertRBACBinding binds one subject to one role inside current scope.
+func (m *MemoryStore) UpsertRBACBinding(ctx context.Context, binding RBACBinding) (RBACBinding, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return RBACBinding{}, err
+	}
+	normalizedScope := scope.Normalize()
+
+	subjectType, err := normalizeRBACSubjectType(binding.SubjectType)
+	if err != nil {
+		return RBACBinding{}, err
+	}
+	subjectID := strings.TrimSpace(binding.SubjectID)
+	if subjectID == "" {
+		return RBACBinding{}, fmt.Errorf("subject id is required")
+	}
+	roleID := strings.TrimSpace(binding.RoleID)
+	if roleID == "" {
+		return RBACBinding{}, fmt.Errorf("role id is required")
+	}
+	role, exists := m.rbacRoles[roleID]
+	if !exists || !MatchScope(normalizedScope, role.TenantID, role.WorkspaceID) {
+		return RBACBinding{}, ErrNotFound
+	}
+
+	for _, existing := range m.rbacBindings {
+		if !MatchScope(normalizedScope, existing.TenantID, existing.WorkspaceID) {
+			continue
+		}
+		if existing.SubjectType == subjectType &&
+			existing.SubjectID == subjectID &&
+			existing.RoleID == roleID {
+			updated := existing
+			if binding.ExpiresAt != nil {
+				expires := binding.ExpiresAt.UTC()
+				updated.ExpiresAt = &expires
+			} else {
+				updated.ExpiresAt = nil
+			}
+			m.rbacBindings[updated.ID] = updated
+			return updated, nil
+		}
+	}
+
+	now := time.Now().UTC()
+	created := RBACBinding{
+		ID:          uuid.NewString(),
+		TenantID:    normalizedScope.TenantID,
+		WorkspaceID: normalizedScope.WorkspaceID,
+		SubjectType: subjectType,
+		SubjectID:   subjectID,
+		RoleID:      roleID,
+		CreatedAt:   now,
+	}
+	if binding.ExpiresAt != nil {
+		expires := binding.ExpiresAt.UTC()
+		created.ExpiresAt = &expires
+	}
+	m.rbacBindings[created.ID] = created
+	m.rbacBindingByID = append(m.rbacBindingByID, created.ID)
+	return created, nil
+}
+
+// ListRBACBindings returns bindings for current tenant/workspace scope.
+func (m *MemoryStore) ListRBACBindings(ctx context.Context) ([]RBACBinding, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := []RBACBinding{}
+	for _, bindingID := range m.rbacBindingByID {
+		binding, exists := m.rbacBindings[bindingID]
+		if !exists {
+			continue
+		}
+		if !MatchScope(scope, binding.TenantID, binding.WorkspaceID) {
+			continue
+		}
+		result = append(result, binding)
+	}
+	return result, nil
+}
+
+// DeleteRBACBinding removes one binding by id in current scope.
+func (m *MemoryStore) DeleteRBACBinding(ctx context.Context, bindingID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	normalizedID := strings.TrimSpace(bindingID)
+	if normalizedID == "" {
+		return ErrNotFound
+	}
+	binding, exists := m.rbacBindings[normalizedID]
+	if !exists || !MatchScope(scope, binding.TenantID, binding.WorkspaceID) {
+		return ErrNotFound
+	}
+	delete(m.rbacBindings, normalizedID)
+	return nil
+}
+
+// ListRBACPermissionsForSubject resolves role permissions for one subject in current scope.
+func (m *MemoryStore) ListRBACPermissionsForSubject(ctx context.Context, subjectType string, subjectID string, asOf time.Time) ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	normalizedType, err := normalizeRBACSubjectType(subjectType)
+	if err != nil {
+		return nil, err
+	}
+	normalizedSubjectID := strings.TrimSpace(subjectID)
+	if normalizedSubjectID == "" {
+		return nil, nil
+	}
+
+	now := asOf.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	permissions := map[string]struct{}{}
+	for _, binding := range m.rbacBindings {
+		if !MatchScope(scope, binding.TenantID, binding.WorkspaceID) {
+			continue
+		}
+		if binding.SubjectType != normalizedType || binding.SubjectID != normalizedSubjectID {
+			continue
+		}
+		if binding.ExpiresAt != nil && binding.ExpiresAt.UTC().Before(now) {
+			continue
+		}
+		for _, permission := range m.rbacRolePerms[binding.RoleID] {
+			permissions[permission] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(permissions))
+	for permission := range permissions {
+		result = append(result, permission)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func rbacRoleNameScopeKey(scope Scope, name string) string {
+	normalized := scope.Normalize()
+	return normalized.TenantID + "|" + normalized.WorkspaceID + "|" + strings.ToLower(strings.TrimSpace(name))
 }
 
 // Close closes store resources.

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -551,3 +551,83 @@ func TestMemoryStoreRequiresScopeContext(t *testing.T) {
 		t.Fatalf("expected ErrScopeRequired, got %v", err)
 	}
 }
+
+func TestMemoryStoreRBACRoleBindingAndPermissionResolution(t *testing.T) {
+	store := NewMemoryStore()
+	defaultCtx := defaultScopeContext()
+	otherCtx := WithScope(defaultScopeContext(), Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
+
+	viewerRole, err := store.UpsertRBACRole(defaultCtx, RBACRole{
+		Name:        "viewer",
+		Description: "read-only",
+		Permissions: []string{"findings.read", "scans.read"},
+	})
+	if err != nil {
+		t.Fatalf("upsert rbac role: %v", err)
+	}
+	if viewerRole.ID == "" {
+		t.Fatal("expected role id")
+	}
+
+	if _, err := store.UpsertRBACBinding(defaultCtx, RBACBinding{
+		SubjectType: RBACSubjectTypeOIDCSubject,
+		SubjectID:   "user-1",
+		RoleID:      viewerRole.ID,
+	}); err != nil {
+		t.Fatalf("upsert rbac binding: %v", err)
+	}
+
+	permissions, err := store.ListRBACPermissionsForSubject(defaultCtx, RBACSubjectTypeOIDCSubject, "user-1", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("list rbac permissions: %v", err)
+	}
+	if len(permissions) != 2 {
+		t.Fatalf("expected two permissions, got %+v", permissions)
+	}
+
+	otherPermissions, err := store.ListRBACPermissionsForSubject(otherCtx, RBACSubjectTypeOIDCSubject, "user-1", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("list cross-scope permissions: %v", err)
+	}
+	if len(otherPermissions) != 0 {
+		t.Fatalf("expected no cross-scope permissions, got %+v", otherPermissions)
+	}
+
+	roles, err := store.ListRBACRoles(defaultCtx)
+	if err != nil {
+		t.Fatalf("list rbac roles: %v", err)
+	}
+	if len(roles) != 1 || roles[0].Name != "viewer" {
+		t.Fatalf("unexpected rbac roles: %+v", roles)
+	}
+
+	bindings, err := store.ListRBACBindings(defaultCtx)
+	if err != nil {
+		t.Fatalf("list rbac bindings: %v", err)
+	}
+	if len(bindings) != 1 {
+		t.Fatalf("expected one binding, got %+v", bindings)
+	}
+
+	if err := store.DeleteRBACBinding(defaultCtx, bindings[0].ID); err != nil {
+		t.Fatalf("delete binding: %v", err)
+	}
+	if err := store.DeleteRBACRole(defaultCtx, viewerRole.ID); err != nil {
+		t.Fatalf("delete role: %v", err)
+	}
+}
+
+func TestMemoryStoreRBACRejectsBuiltInRoleDelete(t *testing.T) {
+	store := NewMemoryStore()
+	role, err := store.UpsertRBACRole(defaultScopeContext(), RBACRole{
+		Name:        "admin",
+		IsBuiltIn:   true,
+		Permissions: []string{"rbac.manage"},
+	})
+	if err != nil {
+		t.Fatalf("upsert role: %v", err)
+	}
+	if err := store.DeleteRBACRole(defaultScopeContext(), role.ID); err == nil {
+		t.Fatal("expected built-in role delete to fail")
+	}
+}

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -159,3 +159,26 @@ func TestEighthMigrationContainsPostgresRLSGuardrails(t *testing.T) {
 		}
 	}
 }
+
+func TestNinthMigrationContainsRBACCoreTables(t *testing.T) {
+	path := filepath.Join("..", "..", "migrations", "000009_rbac_core_workspace_scope.up.sql")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	text := string(content)
+	required := []string{
+		"CREATE TABLE IF NOT EXISTS rbac_roles",
+		"CREATE TABLE IF NOT EXISTS rbac_role_permissions",
+		"CREATE TABLE IF NOT EXISTS rbac_bindings",
+		"idx_rbac_roles_scope_name",
+		"idx_rbac_bindings_scope_subject_role",
+		"rbac_roles_scope_isolation",
+		"rbac_bindings_scope_isolation",
+	}
+	for _, item := range required {
+		if !strings.Contains(text, item) {
+			t.Fatalf("expected rbac migration item %q", item)
+		}
+	}
+}

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -1500,6 +1500,356 @@ func (p *PostgresStore) ListRepoFindings(ctx context.Context, filter RepoFinding
 	return result, nil
 }
 
+// UpsertRBACRole creates or updates one scoped RBAC role.
+func (p *PostgresStore) UpsertRBACRole(ctx context.Context, role RBACRole) (RBACRole, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return RBACRole{}, err
+	}
+	name := strings.ToLower(strings.TrimSpace(role.Name))
+	if name == "" {
+		return RBACRole{}, fmt.Errorf("role name is required")
+	}
+	description := strings.TrimSpace(role.Description)
+	permissions := normalizeRBACPermissionList(role.Permissions)
+	now := time.Now().UTC()
+
+	tx, err := p.beginTx(ctx)
+	if err != nil {
+		return RBACRole{}, fmt.Errorf("begin rbac role transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	row := tx.QueryRowContext(
+		ctx,
+		`INSERT INTO rbac_roles (id, tenant_id, workspace_id, name, description, is_builtin, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		 ON CONFLICT (tenant_id, workspace_id, name)
+		 DO UPDATE SET
+		   description = EXCLUDED.description,
+		   is_builtin = rbac_roles.is_builtin OR EXCLUDED.is_builtin,
+		   updated_at = EXCLUDED.updated_at
+		 RETURNING id, tenant_id, workspace_id, name, description, is_builtin, created_at, updated_at`,
+		uuid.NewString(),
+		scope.TenantID,
+		scope.WorkspaceID,
+		name,
+		description,
+		role.IsBuiltIn,
+		now,
+		now,
+	)
+
+	updatedRole, scanErr := scanRBACRole(row)
+	if scanErr != nil {
+		return RBACRole{}, fmt.Errorf("upsert rbac role: %w", scanErr)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM rbac_role_permissions WHERE role_id = $1`, updatedRole.ID); err != nil {
+		return RBACRole{}, fmt.Errorf("reset rbac role permissions: %w", err)
+	}
+	for _, permission := range permissions {
+		if _, err := tx.ExecContext(
+			ctx,
+			`INSERT INTO rbac_role_permissions (role_id, permission, created_at) VALUES ($1, $2, $3)
+			 ON CONFLICT (role_id, permission) DO NOTHING`,
+			updatedRole.ID,
+			permission,
+			now,
+		); err != nil {
+			return RBACRole{}, fmt.Errorf("insert rbac role permission: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return RBACRole{}, fmt.Errorf("commit rbac role transaction: %w", err)
+	}
+	updatedRole.Permissions = permissions
+	return updatedRole, nil
+}
+
+// ListRBACRoles returns scoped RBAC roles and permissions.
+func (p *PostgresStore) ListRBACRoles(ctx context.Context) ([]RBACRole, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := p.queryContext(
+		ctx,
+		`SELECT r.id, r.tenant_id, r.workspace_id, r.name, COALESCE(r.description, ''), r.is_builtin, r.created_at, r.updated_at, rp.permission
+		 FROM rbac_roles r
+		 LEFT JOIN rbac_role_permissions rp ON rp.role_id = r.id
+		 WHERE r.tenant_id = $1
+		   AND r.workspace_id = $2
+		 ORDER BY r.name ASC, rp.permission ASC`,
+		scope.TenantID,
+		scope.WorkspaceID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list rbac roles: %w", err)
+	}
+	defer rows.Close()
+
+	byID := map[string]RBACRole{}
+	order := []string{}
+	for rows.Next() {
+		var rowRole RBACRole
+		var permission sql.NullString
+		if err := rows.Scan(
+			&rowRole.ID,
+			&rowRole.TenantID,
+			&rowRole.WorkspaceID,
+			&rowRole.Name,
+			&rowRole.Description,
+			&rowRole.IsBuiltIn,
+			&rowRole.CreatedAt,
+			&rowRole.UpdatedAt,
+			&permission,
+		); err != nil {
+			return nil, fmt.Errorf("scan rbac role row: %w", err)
+		}
+		existing, exists := byID[rowRole.ID]
+		if !exists {
+			rowRole.Permissions = []string{}
+			byID[rowRole.ID] = rowRole
+			order = append(order, rowRole.ID)
+			existing = rowRole
+		}
+		if permission.Valid {
+			existing.Permissions = append(existing.Permissions, permission.String)
+			byID[rowRole.ID] = existing
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rbac role rows: %w", err)
+	}
+	result := make([]RBACRole, 0, len(order))
+	for _, roleID := range order {
+		role := byID[roleID]
+		role.Permissions = normalizeRBACPermissionList(role.Permissions)
+		result = append(result, role)
+	}
+	return result, nil
+}
+
+// DeleteRBACRole deletes one scoped RBAC role (custom roles only).
+func (p *PostgresStore) DeleteRBACRole(ctx context.Context, roleID string) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	normalizedRoleID := strings.TrimSpace(roleID)
+	if normalizedRoleID == "" {
+		return ErrNotFound
+	}
+	var builtIn bool
+	if err := p.queryRowContext(
+		ctx,
+		`SELECT is_builtin
+		 FROM rbac_roles
+		 WHERE id = $1
+		   AND tenant_id = $2
+		   AND workspace_id = $3`,
+		normalizedRoleID,
+		scope.TenantID,
+		scope.WorkspaceID,
+	).Scan(&builtIn); err != nil {
+		if errorsIsNoRows(err) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("lookup rbac role: %w", err)
+	}
+	if builtIn {
+		return fmt.Errorf("built-in roles cannot be deleted")
+	}
+	result, err := p.execContext(
+		ctx,
+		`DELETE FROM rbac_roles
+		 WHERE id = $1
+		   AND tenant_id = $2
+		   AND workspace_id = $3`,
+		normalizedRoleID,
+		scope.TenantID,
+		scope.WorkspaceID,
+	)
+	if err != nil {
+		return fmt.Errorf("delete rbac role: %w", err)
+	}
+	return ensureRowsAffected(result)
+}
+
+// UpsertRBACBinding creates or updates one scoped subject-role binding.
+func (p *PostgresStore) UpsertRBACBinding(ctx context.Context, binding RBACBinding) (RBACBinding, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return RBACBinding{}, err
+	}
+	subjectType, err := normalizeRBACSubjectType(binding.SubjectType)
+	if err != nil {
+		return RBACBinding{}, err
+	}
+	subjectID := strings.TrimSpace(binding.SubjectID)
+	if subjectID == "" {
+		return RBACBinding{}, fmt.Errorf("subject id is required")
+	}
+	roleID := strings.TrimSpace(binding.RoleID)
+	if roleID == "" {
+		return RBACBinding{}, fmt.Errorf("role id is required")
+	}
+	if err := p.queryRowContext(
+		ctx,
+		`SELECT 1
+		 FROM rbac_roles
+		 WHERE id = $1
+		   AND tenant_id = $2
+		   AND workspace_id = $3`,
+		roleID,
+		scope.TenantID,
+		scope.WorkspaceID,
+	).Scan(new(int)); err != nil {
+		if errorsIsNoRows(err) {
+			return RBACBinding{}, ErrNotFound
+		}
+		return RBACBinding{}, fmt.Errorf("lookup rbac role for binding: %w", err)
+	}
+
+	now := time.Now().UTC()
+	row := p.queryRowContext(
+		ctx,
+		`INSERT INTO rbac_bindings (id, tenant_id, workspace_id, subject_type, subject_id, role_id, created_at, expires_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		 ON CONFLICT (tenant_id, workspace_id, subject_type, subject_id, role_id)
+		 DO UPDATE SET
+		   expires_at = EXCLUDED.expires_at
+		 RETURNING id, tenant_id, workspace_id, subject_type, subject_id, role_id, created_at, expires_at`,
+		uuid.NewString(),
+		scope.TenantID,
+		scope.WorkspaceID,
+		subjectType,
+		subjectID,
+		roleID,
+		now,
+		nullableTimePtr(binding.ExpiresAt),
+	)
+	created, scanErr := scanRBACBinding(row)
+	if scanErr != nil {
+		return RBACBinding{}, fmt.Errorf("upsert rbac binding: %w", scanErr)
+	}
+	return created, nil
+}
+
+// ListRBACBindings returns scoped subject-role bindings.
+func (p *PostgresStore) ListRBACBindings(ctx context.Context) ([]RBACBinding, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := p.queryContext(
+		ctx,
+		`SELECT id, tenant_id, workspace_id, subject_type, subject_id, role_id, created_at, expires_at
+		 FROM rbac_bindings
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		 ORDER BY created_at DESC, id ASC`,
+		scope.TenantID,
+		scope.WorkspaceID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list rbac bindings: %w", err)
+	}
+	defer rows.Close()
+
+	result := []RBACBinding{}
+	for rows.Next() {
+		binding, scanErr := scanRBACBinding(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("scan rbac binding row: %w", scanErr)
+		}
+		result = append(result, binding)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rbac binding rows: %w", err)
+	}
+	return result, nil
+}
+
+// DeleteRBACBinding removes one scoped binding.
+func (p *PostgresStore) DeleteRBACBinding(ctx context.Context, bindingID string) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	normalizedID := strings.TrimSpace(bindingID)
+	if normalizedID == "" {
+		return ErrNotFound
+	}
+	result, err := p.execContext(
+		ctx,
+		`DELETE FROM rbac_bindings
+		 WHERE id = $1
+		   AND tenant_id = $2
+		   AND workspace_id = $3`,
+		normalizedID,
+		scope.TenantID,
+		scope.WorkspaceID,
+	)
+	if err != nil {
+		return fmt.Errorf("delete rbac binding: %w", err)
+	}
+	return ensureRowsAffected(result)
+}
+
+// ListRBACPermissionsForSubject resolves role-derived permissions for one scoped subject.
+func (p *PostgresStore) ListRBACPermissionsForSubject(ctx context.Context, subjectType string, subjectID string, asOf time.Time) ([]string, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	normalizedType, err := normalizeRBACSubjectType(subjectType)
+	if err != nil {
+		return nil, err
+	}
+	normalizedSubjectID := strings.TrimSpace(subjectID)
+	if normalizedSubjectID == "" {
+		return []string{}, nil
+	}
+	at := asOf.UTC()
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	rows, err := p.queryContext(
+		ctx,
+		`SELECT DISTINCT rp.permission
+		 FROM rbac_bindings b
+		 JOIN rbac_role_permissions rp ON rp.role_id = b.role_id
+		 WHERE b.tenant_id = $1
+		   AND b.workspace_id = $2
+		   AND b.subject_type = $3
+		   AND b.subject_id = $4
+		   AND (b.expires_at IS NULL OR b.expires_at >= $5)
+		 ORDER BY rp.permission ASC`,
+		scope.TenantID,
+		scope.WorkspaceID,
+		normalizedType,
+		normalizedSubjectID,
+		at,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list rbac permissions: %w", err)
+	}
+	defer rows.Close()
+	result := []string{}
+	for rows.Next() {
+		var permission string
+		if err := rows.Scan(&permission); err != nil {
+			return nil, fmt.Errorf("scan rbac permission row: %w", err)
+		}
+		result = append(result, permission)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rbac permission rows: %w", err)
+	}
+	return result, nil
+}
+
 // Close closes database resources.
 func (p *PostgresStore) Close() error {
 	if p.db == nil {
@@ -1520,6 +1870,56 @@ func nullableTime(value time.Time) any {
 		return nil
 	}
 	return value.UTC()
+}
+
+func nullableTimePtr(value *time.Time) any {
+	if value == nil {
+		return nil
+	}
+	return nullableTime(value.UTC())
+}
+
+func scanRBACRole(scanner scanner) (RBACRole, error) {
+	var role RBACRole
+	if err := scanner.Scan(
+		&role.ID,
+		&role.TenantID,
+		&role.WorkspaceID,
+		&role.Name,
+		&role.Description,
+		&role.IsBuiltIn,
+		&role.CreatedAt,
+		&role.UpdatedAt,
+	); err != nil {
+		return RBACRole{}, err
+	}
+	role.CreatedAt = role.CreatedAt.UTC()
+	role.UpdatedAt = role.UpdatedAt.UTC()
+	role.Permissions = normalizeRBACPermissionList(role.Permissions)
+	return role, nil
+}
+
+func scanRBACBinding(scanner scanner) (RBACBinding, error) {
+	var binding RBACBinding
+	var expiresAt sql.NullTime
+	if err := scanner.Scan(
+		&binding.ID,
+		&binding.TenantID,
+		&binding.WorkspaceID,
+		&binding.SubjectType,
+		&binding.SubjectID,
+		&binding.RoleID,
+		&binding.CreatedAt,
+		&expiresAt,
+	); err != nil {
+		return RBACBinding{}, err
+	}
+	binding.CreatedAt = binding.CreatedAt.UTC()
+	if expiresAt.Valid {
+		value := expiresAt.Time.UTC()
+		binding.ExpiresAt = &value
+	}
+	return binding, nil
 }
 
 func upsertRawAssets(ctx context.Context, tx *sql.Tx, scanID string, assets []providers.RawAsset) error {

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -998,3 +998,284 @@ func TestErrorsIsNoRows(t *testing.T) {
 		t.Fatal("expected false for non-no-rows error")
 	}
 }
+
+func TestPostgresStoreRBACRoleBindingAndPermissionResolution(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO rbac_roles (id, tenant_id, workspace_id, name, description, is_builtin, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		 ON CONFLICT (tenant_id, workspace_id, name)
+		 DO UPDATE SET
+		   description = EXCLUDED.description,
+		   is_builtin = rbac_roles.is_builtin OR EXCLUDED.is_builtin,
+		   updated_at = EXCLUDED.updated_at
+		 RETURNING id, tenant_id, workspace_id, name, description, is_builtin, created_at, updated_at`)).
+		WithArgs(sqlmock.AnyArg(), "default", "default", "viewer", "read-only", false, sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "name", "description", "is_builtin", "created_at", "updated_at"}).
+			AddRow("role-1", "default", "default", "viewer", "read-only", false, time.Now().UTC(), time.Now().UTC()))
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM rbac_role_permissions WHERE role_id = $1`)).
+		WithArgs("role-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO rbac_role_permissions").
+		WithArgs("role-1", "findings.read", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	role, err := store.UpsertRBACRole(defaultScopeContext(), RBACRole{
+		Name:        "viewer",
+		Description: "read-only",
+		Permissions: []string{"findings.read"},
+	})
+	if err != nil {
+		t.Fatalf("upsert rbac role: %v", err)
+	}
+	if role.ID != "role-1" {
+		t.Fatalf("unexpected role id: %q", role.ID)
+	}
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT 1
+		 FROM rbac_roles
+		 WHERE id = $1
+		   AND tenant_id = $2
+		   AND workspace_id = $3`)).
+		WithArgs("role-1", "default", "default").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(1))
+	mock.ExpectQuery("INSERT INTO rbac_bindings").
+		WithArgs(sqlmock.AnyArg(), "default", "default", "oidc_subject", "user-1", "role-1", sqlmock.AnyArg(), nil).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "subject_type", "subject_id", "role_id", "created_at", "expires_at"}).
+			AddRow("binding-1", "default", "default", "oidc_subject", "user-1", "role-1", time.Now().UTC(), nil))
+
+	binding, err := store.UpsertRBACBinding(defaultScopeContext(), RBACBinding{
+		SubjectType: RBACSubjectTypeOIDCSubject,
+		SubjectID:   "user-1",
+		RoleID:      "role-1",
+	})
+	if err != nil {
+		t.Fatalf("upsert rbac binding: %v", err)
+	}
+	if binding.ID != "binding-1" {
+		t.Fatalf("unexpected binding id: %q", binding.ID)
+	}
+
+	mock.ExpectQuery("SELECT DISTINCT rp.permission").
+		WithArgs("default", "default", "oidc_subject", "user-1", sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"permission"}).AddRow("findings.read"))
+	permissions, err := store.ListRBACPermissionsForSubject(defaultScopeContext(), RBACSubjectTypeOIDCSubject, "user-1", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("list rbac permissions: %v", err)
+	}
+	if len(permissions) != 1 || permissions[0] != "findings.read" {
+		t.Fatalf("unexpected permissions: %+v", permissions)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreListAndDeleteRBACRoles(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	ctx := defaultScopeContext()
+	now := time.Now().UTC()
+
+	rows := sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "name", "description", "is_builtin", "created_at", "updated_at", "permission"}).
+		AddRow("role-1", "default", "default", "viewer", "read", true, now, now, "scans.read").
+		AddRow("role-1", "default", "default", "viewer", "read", true, now, now, "findings.read").
+		AddRow("role-2", "default", "default", "custom", "custom role", false, now, now, "scans.run")
+	mock.ExpectQuery("SELECT r.id, r.tenant_id, r.workspace_id, r.name").
+		WithArgs("default", "default").
+		WillReturnRows(rows)
+
+	roles, err := store.ListRBACRoles(ctx)
+	if err != nil {
+		t.Fatalf("list rbac roles: %v", err)
+	}
+	if len(roles) != 2 {
+		t.Fatalf("expected 2 roles, got %+v", roles)
+	}
+	if len(roles[0].Permissions) != 2 || roles[0].Permissions[0] != "findings.read" || roles[0].Permissions[1] != "scans.read" {
+		t.Fatalf("expected sorted deduped role permissions, got %+v", roles[0].Permissions)
+	}
+
+	mock.ExpectQuery("SELECT is_builtin").
+		WithArgs("role-2", "default", "default").
+		WillReturnRows(sqlmock.NewRows([]string{"is_builtin"}).AddRow(false))
+	mock.ExpectExec("DELETE FROM rbac_roles").
+		WithArgs("role-2", "default", "default").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	if err := store.DeleteRBACRole(ctx, "role-2"); err != nil {
+		t.Fatalf("delete custom role: %v", err)
+	}
+
+	mock.ExpectQuery("SELECT is_builtin").
+		WithArgs("role-1", "default", "default").
+		WillReturnRows(sqlmock.NewRows([]string{"is_builtin"}).AddRow(true))
+	if err := store.DeleteRBACRole(ctx, "role-1"); err == nil {
+		t.Fatal("expected built-in role deletion to fail")
+	}
+
+	mock.ExpectQuery("SELECT is_builtin").
+		WithArgs("missing", "default", "default").
+		WillReturnError(sql.ErrNoRows)
+	if err := store.DeleteRBACRole(ctx, "missing"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for missing role, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreListAndDeleteRBACBindings(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	ctx := defaultScopeContext()
+	now := time.Now().UTC()
+	expires := now.Add(24 * time.Hour)
+
+	rows := sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "subject_type", "subject_id", "role_id", "created_at", "expires_at"}).
+		AddRow("binding-1", "default", "default", "oidc_subject", "user-1", "role-1", now, nil).
+		AddRow("binding-2", "default", "default", "api_key", "fp-1", "role-2", now, expires)
+	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, subject_type, subject_id, role_id, created_at, expires_at").
+		WithArgs("default", "default").
+		WillReturnRows(rows)
+
+	bindings, err := store.ListRBACBindings(ctx)
+	if err != nil {
+		t.Fatalf("list rbac bindings: %v", err)
+	}
+	if len(bindings) != 2 {
+		t.Fatalf("expected 2 bindings, got %+v", bindings)
+	}
+	if bindings[1].ExpiresAt == nil || !bindings[1].ExpiresAt.Equal(expires) {
+		t.Fatalf("expected second binding expiry to be set, got %+v", bindings[1].ExpiresAt)
+	}
+
+	mock.ExpectExec("DELETE FROM rbac_bindings").
+		WithArgs("binding-1", "default", "default").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	if err := store.DeleteRBACBinding(ctx, "binding-1"); err != nil {
+		t.Fatalf("delete binding: %v", err)
+	}
+
+	if err := store.DeleteRBACBinding(ctx, " "); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for blank binding id, got %v", err)
+	}
+
+	mock.ExpectExec("DELETE FROM rbac_bindings").
+		WithArgs("missing", "default", "default").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	if err := store.DeleteRBACBinding(ctx, "missing"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for missing binding, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreListRBACBindingsErrors(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	ctx := defaultScopeContext()
+	now := time.Now().UTC()
+
+	rowsErr := sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "subject_type", "subject_id", "role_id", "created_at", "expires_at"}).
+		AddRow("binding-2", "default", "default", "oidc_subject", "user-2", "role-2", now, nil).
+		RowError(0, errors.New("scan row failed"))
+	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, subject_type, subject_id, role_id, created_at, expires_at").
+		WithArgs("default", "default").
+		WillReturnRows(rowsErr)
+
+	if _, err := store.ListRBACBindings(ctx); err == nil {
+		t.Fatal("expected list bindings rows error")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreDeleteRBACRoleBlankID(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	if err := store.DeleteRBACRole(defaultScopeContext(), "  "); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for blank role id, got %v", err)
+	}
+}
+
+func TestPostgresHelpersNullableAndClose(t *testing.T) {
+	if got := nullableString("value"); got == nil {
+		t.Fatalf("expected non-nil nullable string for non-empty value")
+	} else if value, ok := got.(string); !ok || value != "value" {
+		t.Fatalf("unexpected nullable string value: %#v", got)
+	}
+	if got := nullableString(""); got != nil {
+		t.Fatalf("expected invalid nullable string for empty value: %+v", got)
+	}
+
+	now := time.Date(2026, 4, 4, 12, 0, 0, 0, time.UTC)
+	if got := nullableTime(now); got == nil {
+		t.Fatalf("expected non-nil nullable time for non-zero value")
+	} else if value, ok := got.(time.Time); !ok || !value.Equal(now) {
+		t.Fatalf("unexpected nullable time value: %#v", got)
+	}
+	if got := nullableTime(time.Time{}); got != nil {
+		t.Fatalf("expected invalid nullable time for zero value: %+v", got)
+	}
+
+	if got := nullableTimePtr(nil); got != nil {
+		t.Fatalf("expected invalid nullable time pointer for nil: %+v", got)
+	}
+	if got := nullableTimePtr(&now); got == nil {
+		t.Fatalf("expected non-nil nullable time pointer for non-nil input")
+	} else if value, ok := got.(time.Time); !ok || !value.Equal(now) {
+		t.Fatalf("unexpected nullable time pointer value: %#v", got)
+	}
+
+	store := &PostgresStore{}
+	if err := store.Close(); err != nil {
+		t.Fatalf("expected nil close error for store without DB, got %v", err)
+	}
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	store = NewPostgresStoreWithDB(db)
+	mock.ExpectClose()
+	if err := store.Close(); err != nil {
+		t.Fatalf("close store with db: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/internal/db/rbac.go
+++ b/internal/db/rbac.go
@@ -1,0 +1,68 @@
+package db
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	// RBACSubjectTypeOIDCSubject binds permissions to a verified OIDC subject (sub claim).
+	RBACSubjectTypeOIDCSubject = "oidc_subject"
+	// RBACSubjectTypeAPIKey binds permissions to an API key fingerprint.
+	RBACSubjectTypeAPIKey = "api_key"
+)
+
+// RBACRole defines one workspace-scoped role and its permissions.
+type RBACRole struct {
+	ID          string    `json:"id"`
+	TenantID    string    `json:"-"`
+	WorkspaceID string    `json:"-"`
+	Name        string    `json:"name"`
+	Description string    `json:"description,omitempty"`
+	IsBuiltIn   bool      `json:"is_builtin"`
+	Permissions []string  `json:"permissions"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// RBACBinding links one subject to one role inside one tenant/workspace scope.
+type RBACBinding struct {
+	ID          string     `json:"id"`
+	TenantID    string     `json:"-"`
+	WorkspaceID string     `json:"-"`
+	SubjectType string     `json:"subject_type"`
+	SubjectID   string     `json:"subject_id"`
+	RoleID      string     `json:"role_id"`
+	CreatedAt   time.Time  `json:"created_at"`
+	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
+}
+
+func normalizeRBACSubjectType(value string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	switch normalized {
+	case RBACSubjectTypeOIDCSubject, RBACSubjectTypeAPIKey:
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("invalid rbac subject type")
+	}
+}
+
+func normalizeRBACPermissionList(values []string) []string {
+	seen := map[string]struct{}{}
+	permissions := make([]string, 0, len(values))
+	for _, item := range values {
+		normalized := strings.ToLower(strings.TrimSpace(item))
+		if normalized == "" {
+			continue
+		}
+		if _, exists := seen[normalized]; exists {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		permissions = append(permissions, normalized)
+	}
+	sort.Strings(permissions)
+	return permissions
+}

--- a/internal/db/rbac_test.go
+++ b/internal/db/rbac_test.go
@@ -1,0 +1,27 @@
+package db
+
+import "testing"
+
+func TestNormalizeRBACSubjectType(t *testing.T) {
+	got, err := normalizeRBACSubjectType(" OIDC_SUBJECT ")
+	if err != nil {
+		t.Fatalf("normalize subject type: %v", err)
+	}
+	if got != RBACSubjectTypeOIDCSubject {
+		t.Fatalf("expected %q, got %q", RBACSubjectTypeOIDCSubject, got)
+	}
+
+	if _, err := normalizeRBACSubjectType("invalid"); err == nil {
+		t.Fatal("expected invalid subject type error")
+	}
+}
+
+func TestNormalizeRBACPermissionList(t *testing.T) {
+	got := normalizeRBACPermissionList([]string{" scans.run ", "findings.read", "FINDINGS.READ", ""})
+	if len(got) != 2 {
+		t.Fatalf("expected deduped permissions, got %+v", got)
+	}
+	if got[0] != "findings.read" || got[1] != "scans.run" {
+		t.Fatalf("unexpected sorted permissions: %+v", got)
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -171,5 +171,12 @@ type Store interface {
 	UpsertRepoFindings(ctx context.Context, repoScanID string, findings []domain.Finding) error
 	ListRepoScans(ctx context.Context, limit int) ([]RepoScanRecord, error)
 	ListRepoFindings(ctx context.Context, filter RepoFindingFilter, limit int) ([]domain.Finding, error)
+	UpsertRBACRole(ctx context.Context, role RBACRole) (RBACRole, error)
+	ListRBACRoles(ctx context.Context) ([]RBACRole, error)
+	DeleteRBACRole(ctx context.Context, roleID string) error
+	UpsertRBACBinding(ctx context.Context, binding RBACBinding) (RBACBinding, error)
+	ListRBACBindings(ctx context.Context) ([]RBACBinding, error)
+	DeleteRBACBinding(ctx context.Context, bindingID string) error
+	ListRBACPermissionsForSubject(ctx context.Context, subjectType string, subjectID string, asOf time.Time) ([]string, error)
 	Close() error
 }

--- a/internal/identrailreviewer/enforcement/enforcement_test.go
+++ b/internal/identrailreviewer/enforcement/enforcement_test.go
@@ -1,6 +1,9 @@
 package enforcement
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/model"
@@ -89,5 +92,174 @@ func TestDecideBlocksOnProtectedPathWithWindowsStyleChangedFile(t *testing.T) {
 	}
 	if len(decision.BlockingFindingIDs) != 1 || decision.BlockingFindingIDs[0] != "F-1" {
 		t.Fatalf("unexpected blocking finding ids: %#v", decision.BlockingFindingIDs)
+	}
+}
+
+func TestLoad(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty path uses builtin defaults", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := Load("")
+		if err != nil {
+			t.Fatalf("Load(\"\") error: %v", err)
+		}
+		if cfg.Phase != "advisory" {
+			t.Fatalf("expected default advisory phase, got %q", cfg.Phase)
+		}
+		if len(cfg.ProtectedPaths) == 0 || len(cfg.BlockSeverities) == 0 {
+			t.Fatalf("expected non-empty default protected paths and block severities: %+v", cfg)
+		}
+	})
+
+	t.Run("valid file overrides config", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		p := filepath.Join(dir, "rollout.json")
+		payload := `{"version":"v1","phase":"strict","protected_paths":["internal/**"],"block_severities":["P0"],"require_no_abstain_on_protected":true}`
+		if err := os.WriteFile(p, []byte(payload), 0o644); err != nil {
+			t.Fatalf("write rollout config: %v", err)
+		}
+		cfg, err := Load(p)
+		if err != nil {
+			t.Fatalf("Load(valid file) error: %v", err)
+		}
+		if cfg.Phase != "strict" || !cfg.RequireNoAbstainOnProtected {
+			t.Fatalf("expected parsed strict config, got %+v", cfg)
+		}
+	})
+
+	t.Run("invalid file and json return errors", func(t *testing.T) {
+		t.Parallel()
+		if _, err := Load("definitely-missing-rollout.json"); err == nil {
+			t.Fatal("expected read error for missing rollout file")
+		}
+
+		dir := t.TempDir()
+		p := filepath.Join(dir, "bad.json")
+		if err := os.WriteFile(p, []byte("{"), 0o644); err != nil {
+			t.Fatalf("write invalid json: %v", err)
+		}
+		if _, err := Load(p); err == nil || !strings.Contains(err.Error(), "parse rollout JSON") {
+			t.Fatalf("expected parse rollout JSON error, got %v", err)
+		}
+	})
+}
+
+func TestDecidePhasesAndFallback(t *testing.T) {
+	t.Parallel()
+
+	nonBlockingFinding := model.Finding{ID: "F-low", Severity: "P3"}
+	blockingFinding := model.Finding{ID: "F-high", Severity: "P1"}
+
+	tests := []struct {
+		name        string
+		cfg         Config
+		result      model.ReviewResult
+		changed     []model.ChangedFile
+		wantStatus  string
+		wantReason  string
+		wantBlockID string
+	}{
+		{
+			name:       "advisory with findings warns",
+			cfg:        Config{Phase: "advisory", BlockSeverities: []string{"P1"}},
+			result:     model.ReviewResult{Findings: []model.Finding{nonBlockingFinding}},
+			wantStatus: "warn",
+			wantReason: "advisory phase: findings reported but merge is not blocked",
+		},
+		{
+			name:       "advisory without findings passes",
+			cfg:        Config{Phase: "advisory"},
+			result:     model.ReviewResult{},
+			wantStatus: "pass",
+			wantReason: "advisory phase: no findings",
+		},
+		{
+			name: "enforced abstain on protected blocks",
+			cfg: Config{
+				Phase:                       "enforced",
+				ProtectedPaths:              []string{"deploy/**"},
+				BlockSeverities:             []string{"P1"},
+				RequireNoAbstainOnProtected: true,
+			},
+			result: model.ReviewResult{
+				Findings: []model.Finding{nonBlockingFinding},
+				Abstain:  []string{"insufficient-context"},
+			},
+			changed:    []model.ChangedFile{{Filename: "deploy/app.yaml"}},
+			wantStatus: "block",
+			wantReason: "abstentions are disallowed for protected-path changes",
+		},
+		{
+			name: "enforced findings outside block conditions warn",
+			cfg: Config{
+				Phase:          "enforced",
+				ProtectedPaths: []string{"deploy/**"},
+				BlockSeverities: []string{
+					"P1",
+				},
+			},
+			result:     model.ReviewResult{Findings: []model.Finding{nonBlockingFinding}},
+			changed:    []model.ChangedFile{{Filename: "internal/api/router.go"}},
+			wantStatus: "warn",
+			wantReason: "findings detected outside enforce block conditions",
+		},
+		{
+			name:       "enforced without findings passes",
+			cfg:        Config{Phase: "enforced"},
+			result:     model.ReviewResult{},
+			wantStatus: "pass",
+			wantReason: "enforced phase: no blocking conditions met",
+		},
+		{
+			name:        "strict with blocking severity blocks",
+			cfg:         Config{Phase: "strict", BlockSeverities: []string{"P1"}},
+			result:      model.ReviewResult{Findings: []model.Finding{blockingFinding}},
+			wantStatus:  "block",
+			wantReason:  "strict phase: blocking severities are not allowed",
+			wantBlockID: "F-high",
+		},
+		{
+			name:       "strict with non-blocking finding warns",
+			cfg:        Config{Phase: "strict", BlockSeverities: []string{"P0"}},
+			result:     model.ReviewResult{Findings: []model.Finding{nonBlockingFinding}},
+			wantStatus: "warn",
+			wantReason: "strict phase: non-blocking findings present",
+		},
+		{
+			name:       "strict with no findings passes",
+			cfg:        Config{Phase: "strict"},
+			result:     model.ReviewResult{},
+			wantStatus: "pass",
+			wantReason: "strict phase: no findings",
+		},
+		{
+			name:        "unknown phase warns with fallback reason",
+			cfg:         Config{Phase: "custom", BlockSeverities: []string{"P1"}},
+			result:      model.ReviewResult{Findings: []model.Finding{blockingFinding}},
+			wantStatus:  "warn",
+			wantReason:  "unknown phase; defaulting to advisory semantics",
+			wantBlockID: "F-high",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			decision := Decide(tc.cfg, tc.result, tc.changed)
+			if decision.Status != tc.wantStatus {
+				t.Fatalf("Decide status = %q, want %q", decision.Status, tc.wantStatus)
+			}
+			if decision.Reason != tc.wantReason {
+				t.Fatalf("Decide reason = %q, want %q", decision.Reason, tc.wantReason)
+			}
+			if tc.wantBlockID != "" {
+				if len(decision.BlockingFindingIDs) == 0 || decision.BlockingFindingIDs[0] != tc.wantBlockID {
+					t.Fatalf("unexpected blocking ids: %#v", decision.BlockingFindingIDs)
+				}
+			}
+		})
 	}
 }

--- a/migrations/000009_rbac_core_workspace_scope.down.sql
+++ b/migrations/000009_rbac_core_workspace_scope.down.sql
@@ -1,0 +1,19 @@
+DROP POLICY IF EXISTS rbac_bindings_scope_isolation ON rbac_bindings;
+ALTER TABLE rbac_bindings NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE rbac_bindings DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS rbac_role_permissions_scope_isolation ON rbac_role_permissions;
+ALTER TABLE rbac_role_permissions NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE rbac_role_permissions DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS rbac_roles_scope_isolation ON rbac_roles;
+ALTER TABLE rbac_roles NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE rbac_roles DISABLE ROW LEVEL SECURITY;
+
+DROP INDEX IF EXISTS idx_rbac_bindings_scope_subject;
+DROP INDEX IF EXISTS idx_rbac_bindings_scope_subject_role;
+DROP INDEX IF EXISTS idx_rbac_roles_scope_name;
+
+DROP TABLE IF EXISTS rbac_bindings;
+DROP TABLE IF EXISTS rbac_role_permissions;
+DROP TABLE IF EXISTS rbac_roles;

--- a/migrations/000009_rbac_core_workspace_scope.up.sql
+++ b/migrations/000009_rbac_core_workspace_scope.up.sql
@@ -1,0 +1,72 @@
+CREATE TABLE IF NOT EXISTS rbac_roles (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    is_builtin BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_rbac_roles_scope_name
+    ON rbac_roles (tenant_id, workspace_id, name);
+
+CREATE TABLE IF NOT EXISTS rbac_role_permissions (
+    role_id TEXT NOT NULL REFERENCES rbac_roles(id) ON DELETE CASCADE,
+    permission TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (role_id, permission)
+);
+
+CREATE TABLE IF NOT EXISTS rbac_bindings (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    subject_type TEXT NOT NULL,
+    subject_id TEXT NOT NULL,
+    role_id TEXT NOT NULL REFERENCES rbac_roles(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_rbac_bindings_scope_subject_role
+    ON rbac_bindings (tenant_id, workspace_id, subject_type, subject_id, role_id);
+
+CREATE INDEX IF NOT EXISTS idx_rbac_bindings_scope_subject
+    ON rbac_bindings (tenant_id, workspace_id, subject_type, subject_id, created_at DESC);
+
+ALTER TABLE rbac_roles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE rbac_roles FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS rbac_roles_scope_isolation ON rbac_roles;
+CREATE POLICY rbac_roles_scope_isolation ON rbac_roles
+USING (identrail_rls_scope_matches(tenant_id, workspace_id))
+WITH CHECK (identrail_rls_scope_matches(tenant_id, workspace_id));
+
+ALTER TABLE rbac_role_permissions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE rbac_role_permissions FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS rbac_role_permissions_scope_isolation ON rbac_role_permissions;
+CREATE POLICY rbac_role_permissions_scope_isolation ON rbac_role_permissions
+USING (
+    EXISTS (
+        SELECT 1
+        FROM rbac_roles r
+        WHERE r.id = rbac_role_permissions.role_id
+          AND identrail_rls_scope_matches(r.tenant_id, r.workspace_id)
+    )
+)
+WITH CHECK (
+    EXISTS (
+        SELECT 1
+        FROM rbac_roles r
+        WHERE r.id = rbac_role_permissions.role_id
+          AND identrail_rls_scope_matches(r.tenant_id, r.workspace_id)
+    )
+);
+
+ALTER TABLE rbac_bindings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE rbac_bindings FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS rbac_bindings_scope_isolation ON rbac_bindings;
+CREATE POLICY rbac_bindings_scope_isolation ON rbac_bindings
+USING (identrail_rls_scope_matches(tenant_id, workspace_id))
+WITH CHECK (identrail_rls_scope_matches(tenant_id, workspace_id));


### PR DESCRIPTION
## Summary
- add workspace-scoped RBAC data model (`rbac_roles`, `rbac_role_permissions`, `rbac_bindings`) with migration and RLS policies
- extend store interface and implement RBAC CRUD/permission resolution in both memory and Postgres stores
- add RBAC authorizer + built-in role seeding (`viewer`, `analyst`, `operator`, `admin`) and enforce route-level permissions
- add `/v1/rbac` management endpoints for roles and bindings
- wire authenticated principals (`oidc_subject` / API key fingerprint) into request context for RBAC resolution
- add service-layer RBAC operations and comprehensive tests across API and DB packages

## Why
This completes the RBAC core milestone by replacing coarse read/write gating with workspace-scoped least-privilege role evaluation (`subject -> role -> permissions`). Missing or insufficient grants now deny access consistently.

## Validation
- `go test ./...`
- `go test ./... -coverprofile=coverage.out`
- CI coverage gate check (`total >= 80%`) now passes at `80.0%`

## Notes
- includes migration `000009_rbac_core_workspace_scope`
- built-in roles are protected from deletion

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds workspace-scoped RBAC with route-level permission enforcement and management APIs to enable least-privilege access across workspaces. Replaces legacy read/write gating with explicit permissions and seeds built-in roles.

- **New Features**
  - RBAC data model with workspace scope and RLS (Postgres + in-memory): roles, role permissions, and bindings.
  - Route middleware `requireRBACPermissionMiddleware` and authorizer with built-in roles (`viewer`, `analyst`, `operator`, `admin`).
  - `/v1/rbac` endpoints to list/upsert/delete roles and list/upsert/delete bindings.
  - Auth context includes principal type/id for OIDC subjects and API key fingerprints; API keys auto-bind to roles based on scopes.
  - All v1 routes now enforce explicit permissions (e.g., `findings.read`, `scans.run`, `rbac.manage`).

- **Migration**
  - Run migration `000009_rbac_core_workspace_scope` to create RBAC tables, indexes, and RLS policies.
  - Built-in roles are upserted per workspace and cannot be deleted.
  - Existing API keys remain compatible; they map to roles on first use based on configured scopes, and legacy read/write scopes still authorize equivalent permissions during transition.

<sup>Written for commit c3eb6f9b3f348a1d66c8adeca6b7e220a1c01198. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

