### PR TITLE
identrail-reviewer: baseline new-findings mode + inline PR comments

### DIFF
--- a/.github/identrail-reviewer/baseline.v1.json
+++ b/.github/identrail-reviewer/baseline.v1.json
@@ -1,0 +1,5 @@
+{
+  "version": "2026-04-05",
+  "mode": "new-findings-only",
+  "known_finding_ids": []
+}

--- a/.github/scripts/identrail-reviewer/upsert-review-comment.js
+++ b/.github/scripts/identrail-reviewer/upsert-review-comment.js
@@ -105,7 +105,6 @@ function parseTouchedLines(patch) {
       continue;
     }
     if (line.startsWith("+") && !line.startsWith("+++")) {
-      touched.add(nextRightLine);
       nextRightLine += 1;
       continue;
     }

--- a/.github/scripts/identrail-reviewer/upsert-review-comment.js
+++ b/.github/scripts/identrail-reviewer/upsert-review-comment.js
@@ -1,6 +1,14 @@
 "use strict";
 
+const crypto = require("crypto");
 const fs = require("fs");
+
+const INLINE_MARKER_PREFIX = "<!-- identrail-reviewer:inline:";
+const INLINE_MARKER_SUFFIX = " -->";
+
+function normalizePath(value) {
+  return String(value || "").trim().replace(/\\/g, "/").replace(/^\.\/+/, "");
+}
 
 function formatFindings(findings, maxFindings) {
   const limit = Number.isInteger(maxFindings) && maxFindings > 0 ? maxFindings : findings.length;
@@ -79,6 +87,69 @@ function renderBody({ marker, heading, result, gate, maxFindings }) {
   return body;
 }
 
+function parseTouchedLines(patch) {
+  const touched = new Set();
+  if (typeof patch !== "string" || patch.length === 0) {
+    return touched;
+  }
+
+  const lines = patch.split("\n");
+  let nextRightLine = null;
+  for (const line of lines) {
+    if (line.startsWith("@@")) {
+      const match = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+      nextRightLine = match ? Number.parseInt(match[1], 10) : null;
+      continue;
+    }
+    if (nextRightLine === null) {
+      continue;
+    }
+    if (line.startsWith("+") && !line.startsWith("+++")) {
+      touched.add(nextRightLine);
+      nextRightLine += 1;
+      continue;
+    }
+    if (line.startsWith("-") && !line.startsWith("---")) {
+      continue;
+    }
+    if (line.startsWith(" ")) {
+      touched.add(nextRightLine);
+      nextRightLine += 1;
+    }
+  }
+  return touched;
+}
+
+function findingInlineFingerprint(finding) {
+  const payload = [
+    String(finding.rule_id || "").trim(),
+    normalizePath(finding.file),
+    String(Number(finding.line) || 0),
+    String(finding.summary || "").trim(),
+  ].join("|");
+  return crypto.createHash("sha256").update(payload).digest("hex").slice(0, 24);
+}
+
+function extractInlineMarker(body) {
+  if (typeof body !== "string" || body.length === 0) {
+    return "";
+  }
+  const regex = /<!--\s*identrail-reviewer:inline:([a-f0-9]{24})\s*-->/i;
+  const match = regex.exec(body);
+  return match ? match[1].toLowerCase() : "";
+}
+
+function inlineCommentBody(finding, markerKey) {
+  const severity = String(finding.severity || "P3").toUpperCase();
+  return [
+    `[${severity}] ${finding.summary}`,
+    `Rule: \`${finding.rule_id}\` | Confidence: ${finding.confidence}`,
+    `Recommendation: ${finding.recommendation}`,
+    "",
+    `${INLINE_MARKER_PREFIX}${markerKey}${INLINE_MARKER_SUFFIX}`,
+  ].join("\n");
+}
+
 async function upsertReviewComment({
   github,
   context,
@@ -130,6 +201,112 @@ async function upsertReviewComment({
   });
 }
 
+async function upsertInlineReviewComments({
+  github,
+  context,
+  reviewPath,
+  changedFilesPath,
+  maxComments,
+}) {
+  const pullRequest = context.payload.pull_request;
+  if (!pullRequest || !pullRequest.number) {
+    return { posted: 0, skipped: 0 };
+  }
+
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+  const pullNumber = pullRequest.number;
+  const commitID = pullRequest.head && pullRequest.head.sha ? pullRequest.head.sha : "";
+  if (!commitID) {
+    return { posted: 0, skipped: 0 };
+  }
+
+  const review = JSON.parse(fs.readFileSync(reviewPath, "utf8"));
+  const findings = Array.isArray(review.findings) ? review.findings : [];
+  if (findings.length === 0) {
+    return { posted: 0, skipped: 0 };
+  }
+
+  const changedFiles = JSON.parse(fs.readFileSync(changedFilesPath, "utf8"));
+  const touchedByPath = new Map();
+  for (const file of changedFiles) {
+    const normalized = normalizePath(file.filename);
+    if (!normalized) {
+      continue;
+    }
+    touchedByPath.set(normalized, parseTouchedLines(file.patch));
+  }
+
+  const existingComments = await github.paginate(github.rest.pulls.listReviewComments, {
+    owner,
+    repo,
+    pull_number: pullNumber,
+    per_page: 100,
+  });
+  const existingMarkers = new Set();
+  for (const comment of existingComments) {
+    const marker = extractInlineMarker(comment.body);
+    if (marker) {
+      existingMarkers.add(marker);
+    }
+  }
+
+  const limit = Number.isInteger(maxComments) && maxComments > 0 ? maxComments : 10;
+  let posted = 0;
+  let skipped = 0;
+  const seenCandidates = new Set();
+
+  for (const finding of findings) {
+    if (posted >= limit) {
+      break;
+    }
+    const filePath = normalizePath(finding.file);
+    const line = Number(finding.line);
+    if (!filePath || !Number.isInteger(line) || line <= 0) {
+      skipped += 1;
+      continue;
+    }
+
+    const touched = touchedByPath.get(filePath);
+    if (!touched || !touched.has(line)) {
+      skipped += 1;
+      continue;
+    }
+
+    const markerKey = findingInlineFingerprint(finding);
+    if (seenCandidates.has(markerKey) || existingMarkers.has(markerKey)) {
+      skipped += 1;
+      continue;
+    }
+    seenCandidates.add(markerKey);
+
+    try {
+      await github.rest.pulls.createReviewComment({
+        owner,
+        repo,
+        pull_number: pullNumber,
+        commit_id: commitID,
+        path: filePath,
+        line,
+        side: "RIGHT",
+        body: inlineCommentBody(finding, markerKey),
+      });
+      posted += 1;
+    } catch (error) {
+      const status = error && typeof error.status === "number" ? error.status : 0;
+      if (status === 422) {
+        skipped += 1;
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  return { posted, skipped };
+}
+
 module.exports = {
+  upsertInlineReviewComments,
   upsertReviewComment,
 };
+

--- a/.github/workflows/identrail-reviewer-review.yml
+++ b/.github/workflows/identrail-reviewer-review.yml
@@ -55,7 +55,12 @@ jobs:
                 per_page: perPage,
                 page
               });
-              files.push(...resp.data.map((f) => ({ filename: f.filename, status: f.status })));
+              files.push(...resp.data.map((f) => ({
+                filename: f.filename,
+                status: f.status,
+                patch: f.patch || '',
+                previous_filename: f.previous_filename || ''
+              })));
               if (resp.data.length < perPage) break;
               page += 1;
             }
@@ -72,6 +77,7 @@ jobs:
               --event-path "$GITHUB_EVENT_PATH" \
               --changed-files .tmp/changed-files.json \
               --policy .github/identrail-reviewer/policy.v1.json \
+              --baseline .github/identrail-reviewer/baseline.v1.json \
               --audit-log .tmp/audit.jsonl \
               --output .tmp/review.json; then
               break
@@ -122,6 +128,19 @@ jobs:
               issueNumber: context.payload.pull_request.number,
               maxFindings: 20,
               gatePath: '.tmp/enforcement.json'
+            });
+
+      - name: Upsert inline PR review comments
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { upsertInlineReviewComments } = require('./.github/scripts/identrail-reviewer/upsert-review-comment');
+            await upsertInlineReviewComments({
+              github,
+              context,
+              reviewPath: '.tmp/review.json',
+              changedFilesPath: '.tmp/changed-files.json',
+              maxComments: 10
             });
 
       - name: Enforce rollout gate

--- a/cmd/identrail-reviewer/main.go
+++ b/cmd/identrail-reviewer/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/audit"
+	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/baseline"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/enforcement"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/model"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/policy"
@@ -37,6 +38,7 @@ func reviewPR(args []string) {
 	eventPath := fs.String("event-path", "", "GitHub event payload path")
 	changedFilesPath := fs.String("changed-files", "", "changed files JSON path")
 	policyPath := fs.String("policy", "", "review policy JSON path")
+	baselinePath := fs.String("baseline", "", "baseline JSON path for new-findings-only filtering")
 	auditPath := fs.String("audit-log", "", "audit JSONL output path")
 	outputPath := fs.String("output", "", "output path for review result")
 	_ = fs.Parse(args)
@@ -87,6 +89,12 @@ func reviewPR(args []string) {
 		fatal("failed to load policy: " + err.Error())
 	}
 	result = policy.Apply(cfg, result)
+
+	baselineCfg, err := baseline.Load(*baselinePath)
+	if err != nil {
+		fatal("failed to load baseline: " + err.Error())
+	}
+	result = baseline.Apply(baselineCfg, result)
 
 	if err := audit.Append(*auditPath, result); err != nil {
 		fatal("failed to write audit log: " + err.Error())

--- a/cmd/identrail-reviewer/main_test.go
+++ b/cmd/identrail-reviewer/main_test.go
@@ -49,6 +49,58 @@ func TestReviewPRWritesOutput(t *testing.T) {
 	}
 }
 
+func TestReviewPRAppliesBaselineFiltering(t *testing.T) {
+	root := t.TempDir()
+	eventPath := filepath.Join(root, "event.json")
+	changedPath := filepath.Join(root, "changed.json")
+	baselinePath := filepath.Join(root, "baseline.json")
+	outputPath := filepath.Join(root, "review.json")
+
+	event := model.PullRequestEvent{
+		PullRequest: model.PullRequest{
+			Number: 101,
+			Title:  "missing sections",
+			Body:   "## Summary\nonly one section provided\n",
+		},
+	}
+	if err := writeJSONFile(eventPath, event); err != nil {
+		t.Fatalf("write event json: %v", err)
+	}
+	if err := writeJSONFile(changedPath, []model.ChangedFile{}); err != nil {
+		t.Fatalf("write changed files json: %v", err)
+	}
+	baseline := map[string]any{
+		"version":           "test-v1",
+		"mode":              "new-findings-only",
+		"known_finding_ids": []string{"IR-PR-004-why"},
+	}
+	if err := writeJSONFile(baselinePath, baseline); err != nil {
+		t.Fatalf("write baseline json: %v", err)
+	}
+
+	reviewPR([]string{
+		"--repo-root", root,
+		"--event-path", eventPath,
+		"--changed-files", changedPath,
+		"--baseline", baselinePath,
+		"--output", outputPath,
+	})
+
+	var got model.ReviewResult
+	if err := readJSONFile(outputPath, &got); err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if got.Metadata["baseline_mode"] != "new-findings-only" {
+		t.Fatalf("expected baseline mode metadata, got %q", got.Metadata["baseline_mode"])
+	}
+	if got.Metadata["baseline_suppressed_findings"] != "1" {
+		t.Fatalf("expected one baseline-suppressed finding, got %q", got.Metadata["baseline_suppressed_findings"])
+	}
+	if len(got.Findings) != 6 {
+		t.Fatalf("expected 6 findings after one suppression, got %d", len(got.Findings))
+	}
+}
+
 func TestReviewIssueWritesOutput(t *testing.T) {
 	root := t.TempDir()
 	eventPath := filepath.Join(root, "event.json")

--- a/docs/identrail-reviewer/operations-runbook.md
+++ b/docs/identrail-reviewer/operations-runbook.md
@@ -18,3 +18,11 @@
 - Policy and rollout changes must be reviewed via pull request.
 - Every rollout phase change should include a rationale in PR description.
 - Weekly report artifacts should be inspected for trend breaks.
+- Baseline updates (`.github/identrail-reviewer/baseline.v1.json`) should include explicit rationale for each newly ignored finding ID.
+
+## Baseline workflow
+
+1. Capture reviewer artifacts from recent successful runs.
+2. Add only explicitly accepted legacy findings to `known_finding_ids`.
+3. Re-run reviewer checks and confirm no unexpected new suppressions.
+4. Keep baseline review-owned and update it as debt is paid down.

--- a/docs/identrail-reviewer/week-4-rollout.md
+++ b/docs/identrail-reviewer/week-4-rollout.md
@@ -6,6 +6,8 @@ Week 4 introduces phased enforcement and operating procedures for production rol
 
 - Rollout config with phase controls:
   - `.github/identrail-reviewer/rollout.v1.json`
+- Baseline config for new-findings-only mode:
+  - `.github/identrail-reviewer/baseline.v1.json`
 - Enforcement decision engine:
   - `internal/identrailreviewer/enforcement/enforcement.go`
 - Weekly operations report workflow:
@@ -24,3 +26,5 @@ Week 4 introduces phased enforcement and operating procedures for production rol
 - Start in `advisory` and gather accuracy metrics.
 - Move to `enforced` only after precision and false-positive targets are stable.
 - Use `strict` only after sustained quality over multiple release cycles.
+- Maintain the baseline file so review comments focus on new regressions, not accepted legacy debt.
+- Use inline comments for diff-touched findings to shorten remediation cycle time.

--- a/internal/identrailreviewer/baseline/baseline.go
+++ b/internal/identrailreviewer/baseline/baseline.go
@@ -1,0 +1,129 @@
+package baseline
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/model"
+)
+
+const (
+	modeOff             = "off"
+	modeNewFindingsOnly = "new-findings-only"
+)
+
+type Config struct {
+	Version         string   `json:"version"`
+	Mode            string   `json:"mode"`
+	KnownFindingIDs []string `json:"known_finding_ids"`
+}
+
+func Load(path string) (Config, error) {
+	if strings.TrimSpace(path) == "" {
+		return Config{Mode: modeOff}, nil
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, fmt.Errorf("read baseline: %w", err)
+	}
+
+	cfg := Config{Mode: modeNewFindingsOnly}
+	if err := json.Unmarshal(b, &cfg); err != nil {
+		return Config{}, fmt.Errorf("parse baseline JSON: %w", err)
+	}
+	if err := validateConfig(&cfg); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+func Apply(cfg Config, result model.ReviewResult) model.ReviewResult {
+	normalizedMode := strings.ToLower(strings.TrimSpace(cfg.Mode))
+	if normalizedMode == "" {
+		normalizedMode = modeNewFindingsOnly
+	}
+
+	if result.Metadata == nil {
+		result.Metadata = map[string]string{}
+	}
+	result.Metadata["baseline_mode"] = normalizedMode
+	if strings.TrimSpace(cfg.Version) != "" {
+		result.Metadata["baseline_version"] = strings.TrimSpace(cfg.Version)
+	}
+
+	if normalizedMode != modeNewFindingsOnly {
+		return result
+	}
+
+	known := make(map[string]struct{}, len(cfg.KnownFindingIDs))
+	for _, id := range cfg.KnownFindingIDs {
+		value := strings.TrimSpace(id)
+		if value == "" {
+			continue
+		}
+		known[value] = struct{}{}
+	}
+
+	if len(known) == 0 {
+		result.Metadata["baseline_suppressed_findings"] = "0"
+		return result
+	}
+
+	filtered := make([]model.Finding, 0, len(result.Findings))
+	suppressed := 0
+	for _, finding := range result.Findings {
+		if _, ok := known[strings.TrimSpace(finding.ID)]; ok {
+			suppressed++
+			continue
+		}
+		filtered = append(filtered, finding)
+	}
+
+	result.Findings = filtered
+	result.Metadata["baseline_suppressed_findings"] = fmt.Sprintf("%d", suppressed)
+
+	if suppressed == 0 {
+		return result
+	}
+
+	switch {
+	case len(filtered) > 0:
+		result.Status = "findings"
+		result.Summary = fmt.Sprintf("Detected %d new deterministic finding(s) after baseline filtering.", len(filtered))
+	case len(result.Abstain) > 0:
+		result.Status = "abstain"
+		result.Summary = "No new deterministic findings after baseline filtering; reviewer abstained on at least one check."
+	default:
+		result.Status = "clean"
+		result.Summary = "No new deterministic findings after baseline filtering."
+	}
+
+	return result
+}
+
+func validateConfig(cfg *Config) error {
+	cfg.Mode = strings.ToLower(strings.TrimSpace(cfg.Mode))
+	if cfg.Mode == "" {
+		cfg.Mode = modeNewFindingsOnly
+	}
+	switch cfg.Mode {
+	case modeOff, modeNewFindingsOnly:
+	default:
+		return fmt.Errorf("validate baseline: unsupported mode %q", cfg.Mode)
+	}
+
+	normalized := make([]string, 0, len(cfg.KnownFindingIDs))
+	for _, id := range cfg.KnownFindingIDs {
+		value := strings.TrimSpace(id)
+		if value == "" {
+			return fmt.Errorf("validate baseline: known_finding_ids contains empty value")
+		}
+		normalized = append(normalized, value)
+	}
+	cfg.KnownFindingIDs = normalized
+	cfg.Version = strings.TrimSpace(cfg.Version)
+	return nil
+}

--- a/internal/identrailreviewer/baseline/baseline_test.go
+++ b/internal/identrailreviewer/baseline/baseline_test.go
@@ -1,0 +1,174 @@
+package baseline
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/model"
+)
+
+func TestLoadEmptyPathReturnsOffMode(t *testing.T) {
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("load baseline with empty path: %v", err)
+	}
+	if cfg.Mode != modeOff {
+		t.Fatalf("expected mode %q, got %q", modeOff, cfg.Mode)
+	}
+}
+
+func TestLoadRejectsUnsupportedMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "baseline.json")
+	if err := os.WriteFile(path, []byte(`{"mode":"unsupported"}`), 0o600); err != nil {
+		t.Fatalf("write baseline fixture: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected load to fail for unsupported mode")
+	}
+	if !strings.Contains(err.Error(), "unsupported mode") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadRejectsEmptyKnownFindingID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "baseline.json")
+	if err := os.WriteFile(path, []byte(`{"mode":"new-findings-only","known_finding_ids":[""]}`), 0o600); err != nil {
+		t.Fatalf("write baseline fixture: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected load to fail for empty known finding ID")
+	}
+	if !strings.Contains(err.Error(), "known_finding_ids contains empty value") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadDefaultsModeWhenOmitted(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "baseline.json")
+	if err := os.WriteFile(path, []byte(`{"version":"v1","known_finding_ids":["IR-1"]}`), 0o600); err != nil {
+		t.Fatalf("write baseline fixture: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load baseline: %v", err)
+	}
+	if cfg.Mode != modeNewFindingsOnly {
+		t.Fatalf("expected default mode %q, got %q", modeNewFindingsOnly, cfg.Mode)
+	}
+}
+
+func TestApplySuppressesKnownFindingIDs(t *testing.T) {
+	result := model.ReviewResult{
+		Status:  "findings",
+		Summary: "Detected findings",
+		Findings: []model.Finding{
+			{ID: "IR-1", Summary: "known"},
+			{ID: "IR-2", Summary: "new"},
+		},
+	}
+
+	got := Apply(Config{
+		Version:         "2026-04-05",
+		Mode:            modeNewFindingsOnly,
+		KnownFindingIDs: []string{"IR-1"},
+	}, result)
+
+	if len(got.Findings) != 1 {
+		t.Fatalf("expected 1 remaining finding, got %d", len(got.Findings))
+	}
+	if got.Findings[0].ID != "IR-2" {
+		t.Fatalf("expected remaining finding IR-2, got %q", got.Findings[0].ID)
+	}
+	if got.Metadata["baseline_suppressed_findings"] != "1" {
+		t.Fatalf("expected baseline_suppressed_findings=1, got %q", got.Metadata["baseline_suppressed_findings"])
+	}
+	if got.Status != "findings" {
+		t.Fatalf("expected findings status, got %q", got.Status)
+	}
+}
+
+func TestApplyAllSuppressedMarksClean(t *testing.T) {
+	result := model.ReviewResult{
+		Status: "findings",
+		Findings: []model.Finding{
+			{ID: "IR-1"},
+		},
+	}
+
+	got := Apply(Config{
+		Mode:            modeNewFindingsOnly,
+		KnownFindingIDs: []string{"IR-1"},
+	}, result)
+
+	if got.Status != "clean" {
+		t.Fatalf("expected clean status after suppression, got %q", got.Status)
+	}
+	if len(got.Findings) != 0 {
+		t.Fatalf("expected 0 findings, got %d", len(got.Findings))
+	}
+}
+
+func TestApplyAllSuppressedWithAbstentionsMarksAbstain(t *testing.T) {
+	result := model.ReviewResult{
+		Status:  "findings",
+		Abstain: []string{"unable to inspect file"},
+		Findings: []model.Finding{
+			{ID: "IR-1"},
+		},
+	}
+
+	got := Apply(Config{
+		Mode:            modeNewFindingsOnly,
+		KnownFindingIDs: []string{"IR-1"},
+	}, result)
+
+	if got.Status != "abstain" {
+		t.Fatalf("expected abstain status after suppression with abstentions, got %q", got.Status)
+	}
+}
+
+func TestApplyWithNoKnownEntriesSetsSuppressedZero(t *testing.T) {
+	result := model.ReviewResult{
+		Status: "findings",
+		Findings: []model.Finding{
+			{ID: "IR-1"},
+		},
+	}
+
+	got := Apply(Config{
+		Mode:            modeNewFindingsOnly,
+		KnownFindingIDs: nil,
+	}, result)
+
+	if got.Metadata["baseline_suppressed_findings"] != "0" {
+		t.Fatalf("expected baseline_suppressed_findings=0, got %q", got.Metadata["baseline_suppressed_findings"])
+	}
+}
+
+func TestApplyOffModeLeavesResultUnchanged(t *testing.T) {
+	result := model.ReviewResult{
+		Status: "findings",
+		Findings: []model.Finding{
+			{ID: "IR-1"},
+		},
+	}
+
+	got := Apply(Config{
+		Mode:            modeOff,
+		KnownFindingIDs: []string{"IR-1"},
+	}, result)
+
+	if got.Status != "findings" {
+		t.Fatalf("expected findings status, got %q", got.Status)
+	}
+	if len(got.Findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(got.Findings))
+	}
+}

--- a/internal/identrailreviewer/model/model.go
+++ b/internal/identrailreviewer/model/model.go
@@ -27,8 +27,10 @@ type ReviewResult struct {
 }
 
 type ChangedFile struct {
-	Filename string `json:"filename"`
-	Status   string `json:"status"`
+	Filename         string `json:"filename"`
+	Status           string `json:"status"`
+	Patch            string `json:"patch,omitempty"`
+	PreviousFilename string `json:"previous_filename,omitempty"`
 }
 
 type PullRequestEvent struct {


### PR DESCRIPTION
## Summary
Add two reviewer upgrades: baseline-driven new-findings-only filtering and inline PR comments for findings on touched diff lines.

## Why
This reduces repeat noise from known findings and makes feedback actionable directly on changed code.

## Scope
- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation
```bash
go test ./cmd/identrail-reviewer ./internal/identrailreviewer/...
go test ./...
go test ./... -coverprofile=coverage.out
```

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure
- AI-assisted: yes
- Tools used: Codex
- Areas where used: implementation, tests, workflow wiring
- Human verification performed: local go tests and coverage verification

## Related Issues
Implements the agreed "baseline mode + inline comments" reviewer improvements.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds baseline-driven new-findings-only filtering and inline PR comments on diff-touched lines to cut noise and make feedback actionable. This keeps reviews focused on regressions and speeds up fixes.

- **New Features**
  - Baseline filtering: load `baseline.v1.json`, suppress `known_finding_ids` in `new-findings-only` mode, update result metadata and status; new CLI flag `--baseline`; package `internal/identrailreviewer/baseline` with tests.
  - Inline PR comments: `upsertInlineReviewComments` posts comments only on touched diff lines using SHA-256 fingerprint markers for stable de-dup across runs, path normalization, and `patch` hunk parsing; respects a per-run limit.
  - Workflow: saves file patches from GitHub, passes `--baseline` to the reviewer step, and adds an inline-comment step (`actions/github-script@v8`).
  - Model: `ChangedFile` now includes `patch` and `previous_filename` to support inline mapping.
  - Docs: added baseline workflow guidance and rollout notes.

- **Migration**
  - Add and maintain `.github/identrail-reviewer/baseline.v1.json` (start with `known_finding_ids: []`, then add accepted legacy IDs over time).

<sup>Written for commit a3cbd834f516d378acefd0da74eb672774b092aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

