### PR TITLE
fix(rbac): follow-up to resolve cubic review findings from #77

### DIFF
--- a/internal/api/rbac_authz.go
+++ b/internal/api/rbac_authz.go
@@ -202,6 +202,23 @@ func (a *rbacAuthorizer) bootstrapAPIKeyBinding(c *gin.Context) error {
 		return nil
 	}
 
+	// Do not override administrator-managed bindings on every request.
+	// If any active binding already exists for this API key in scope, keep it.
+	existingBindings, err := a.store.ListRBACBindings(c.Request.Context())
+	if err != nil {
+		return err
+	}
+	now := a.nowUTC()
+	for _, binding := range existingBindings {
+		if binding.SubjectType != db.RBACSubjectTypeAPIKey || binding.SubjectID != principalID {
+			continue
+		}
+		if binding.ExpiresAt != nil && !binding.ExpiresAt.After(now) {
+			continue
+		}
+		return nil
+	}
+
 	roleName := "viewer"
 	switch {
 	case scopes.has(scopeAdmin):

--- a/internal/api/rbac_authz.go
+++ b/internal/api/rbac_authz.go
@@ -204,7 +204,7 @@ func (a *rbacAuthorizer) bootstrapAPIKeyBinding(c *gin.Context) error {
 
 	// Do not override administrator-managed bindings on every request.
 	// If any active binding already exists for this API key in scope, keep it.
-	existingBindings, err := a.store.ListRBACBindings(c.Request.Context())
+	existingBindings, err := a.store.ListRBACBindingsForSubject(c.Request.Context(), db.RBACSubjectTypeAPIKey, principalID)
 	if err != nil {
 		return err
 	}

--- a/internal/api/rbac_authz_test.go
+++ b/internal/api/rbac_authz_test.go
@@ -164,6 +164,53 @@ func TestRBACAuthorizerBootstrapAPIKeyBinding(t *testing.T) {
 	}
 }
 
+func TestRBACAuthorizerBootstrapAPIKeyBindingDoesNotOverrideExistingBinding(t *testing.T) {
+	store := db.NewMemoryStore()
+	a := &rbacAuthorizer{store: store, now: time.Now}
+	ctx := defaultScopeContext()
+	if err := a.ensureBuiltinRoles(ctx); err != nil {
+		t.Fatalf("seed builtin roles: %v", err)
+	}
+
+	customRole, err := store.UpsertRBACRole(ctx, db.RBACRole{
+		Name:        "custom-api-key-role",
+		Description: "admin managed binding",
+		Permissions: []string{rbacPermissionScansRun},
+	})
+	if err != nil {
+		t.Fatalf("upsert custom role: %v", err)
+	}
+	existing, err := store.UpsertRBACBinding(ctx, db.RBACBinding{
+		SubjectType: db.RBACSubjectTypeAPIKey,
+		SubjectID:   "key-fingerprint",
+		RoleID:      customRole.ID,
+	})
+	if err != nil {
+		t.Fatalf("upsert existing binding: %v", err)
+	}
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	c.Request = req.WithContext(ctx)
+	c.Set("auth.principal_id", "key-fingerprint")
+	c.Set("auth.scope_set", newScopeSet([]string{scopeRead}))
+
+	if err := a.bootstrapAPIKeyBinding(c); err != nil {
+		t.Fatalf("bootstrap should preserve existing binding: %v", err)
+	}
+
+	bindings, err := store.ListRBACBindings(ctx)
+	if err != nil {
+		t.Fatalf("list bindings: %v", err)
+	}
+	if len(bindings) != 1 {
+		t.Fatalf("expected existing binding to remain unchanged, got %+v", bindings)
+	}
+	if bindings[0].ID != existing.ID || bindings[0].RoleID != customRole.ID {
+		t.Fatalf("expected existing admin-managed binding to remain, got %+v", bindings[0])
+	}
+}
+
 func TestRBACAuthorizerBootstrapAPIKeyBindingNoopCases(t *testing.T) {
 	store := db.NewMemoryStore()
 	a := &rbacAuthorizer{store: store, now: time.Now}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -647,7 +647,12 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			Permissions: req.Permissions,
 		})
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid rbac role"})
+			if isRBACRoleValidationError(err) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid rbac role"})
+				return
+			}
+			logger.Error("upsert rbac role", telemetry.ZapError(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to upsert rbac role"})
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"role": role})
@@ -658,7 +663,12 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 				c.JSON(http.StatusNotFound, gin.H{"error": "rbac role not found"})
 				return
 			}
-			c.JSON(http.StatusBadRequest, gin.H{"error": "unable to delete rbac role"})
+			if strings.Contains(strings.ToLower(err.Error()), "built-in roles cannot be deleted") {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "unable to delete rbac role"})
+				return
+			}
+			logger.Error("delete rbac role", telemetry.ZapError(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete rbac role"})
 			return
 		}
 		c.Status(http.StatusNoContent)
@@ -699,7 +709,12 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 				c.JSON(http.StatusNotFound, gin.H{"error": "rbac role not found"})
 				return
 			}
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid rbac binding"})
+			if isRBACBindingValidationError(err) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid rbac binding"})
+				return
+			}
+			logger.Error("upsert rbac binding", telemetry.ZapError(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to upsert rbac binding"})
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"binding": binding})
@@ -710,7 +725,8 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 				c.JSON(http.StatusNotFound, gin.H{"error": "rbac binding not found"})
 				return
 			}
-			c.JSON(http.StatusBadRequest, gin.H{"error": "unable to delete rbac binding"})
+			logger.Error("delete rbac binding", telemetry.ZapError(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete rbac binding"})
 			return
 		}
 		c.Status(http.StatusNoContent)
@@ -1586,4 +1602,24 @@ func scopeSetFromOIDCToken(token VerifiedToken, writeScopeOverrides scopeSet) sc
 		}
 	}
 	return set
+}
+
+func isRBACRoleValidationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "role name is required") ||
+		strings.Contains(msg, "role permissions are required")
+}
+
+func isRBACBindingValidationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "subject_id and role_id are required") ||
+		strings.Contains(msg, "subject id is required") ||
+		strings.Contains(msg, "role id is required") ||
+		strings.Contains(msg, "invalid rbac subject type")
 }

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -1170,6 +1170,13 @@ func (m *MemoryStore) DeleteRBACBinding(ctx context.Context, bindingID string) e
 		return ErrNotFound
 	}
 	delete(m.rbacBindings, normalizedID)
+	filtered := m.rbacBindingByID[:0]
+	for _, id := range m.rbacBindingByID {
+		if id != normalizedID {
+			filtered = append(filtered, id)
+		}
+	}
+	m.rbacBindingByID = filtered
 	return nil
 }
 

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -1152,6 +1152,41 @@ func (m *MemoryStore) ListRBACBindings(ctx context.Context) ([]RBACBinding, erro
 	return result, nil
 }
 
+// ListRBACBindingsForSubject returns scoped bindings for one subject.
+func (m *MemoryStore) ListRBACBindingsForSubject(ctx context.Context, subjectType string, subjectID string) ([]RBACBinding, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	normalizedType, err := normalizeRBACSubjectType(subjectType)
+	if err != nil {
+		return nil, err
+	}
+	normalizedSubjectID := strings.TrimSpace(subjectID)
+	if normalizedSubjectID == "" {
+		return []RBACBinding{}, nil
+	}
+
+	result := []RBACBinding{}
+	for _, bindingID := range m.rbacBindingByID {
+		binding, exists := m.rbacBindings[bindingID]
+		if !exists {
+			continue
+		}
+		if !MatchScope(scope, binding.TenantID, binding.WorkspaceID) {
+			continue
+		}
+		if binding.SubjectType != normalizedType || binding.SubjectID != normalizedSubjectID {
+			continue
+		}
+		result = append(result, binding)
+	}
+	return result, nil
+}
+
 // DeleteRBACBinding removes one binding by id in current scope.
 func (m *MemoryStore) DeleteRBACBinding(ctx context.Context, bindingID string) error {
 	m.mu.Lock()

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -608,6 +608,20 @@ func TestMemoryStoreRBACRoleBindingAndPermissionResolution(t *testing.T) {
 	if len(bindings) != 1 {
 		t.Fatalf("expected one binding, got %+v", bindings)
 	}
+	subjectBindings, err := store.ListRBACBindingsForSubject(defaultCtx, RBACSubjectTypeOIDCSubject, "user-1")
+	if err != nil {
+		t.Fatalf("list rbac bindings for subject: %v", err)
+	}
+	if len(subjectBindings) != 1 || subjectBindings[0].ID != bindings[0].ID {
+		t.Fatalf("expected one matching subject binding, got %+v", subjectBindings)
+	}
+	crossScopeBindings, err := store.ListRBACBindingsForSubject(otherCtx, RBACSubjectTypeOIDCSubject, "user-1")
+	if err != nil {
+		t.Fatalf("list cross-scope subject bindings: %v", err)
+	}
+	if len(crossScopeBindings) != 0 {
+		t.Fatalf("expected no cross-scope subject bindings, got %+v", crossScopeBindings)
+	}
 
 	if err := store.DeleteRBACBinding(defaultCtx, bindings[0].ID); err != nil {
 		t.Fatalf("delete binding: %v", err)

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -612,6 +612,9 @@ func TestMemoryStoreRBACRoleBindingAndPermissionResolution(t *testing.T) {
 	if err := store.DeleteRBACBinding(defaultCtx, bindings[0].ID); err != nil {
 		t.Fatalf("delete binding: %v", err)
 	}
+	if len(store.rbacBindingByID) != 0 {
+		t.Fatalf("expected binding index to be pruned after delete, got %+v", store.rbacBindingByID)
+	}
 	if err := store.DeleteRBACRole(defaultCtx, viewerRole.ID); err != nil {
 		t.Fatalf("delete role: %v", err)
 	}

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -173,6 +173,7 @@ func TestNinthMigrationContainsRBACCoreTables(t *testing.T) {
 		"CREATE TABLE IF NOT EXISTS rbac_bindings",
 		"idx_rbac_roles_scope_name",
 		"idx_rbac_bindings_scope_subject_role",
+		"idx_rbac_bindings_role_id",
 		"rbac_roles_scope_isolation",
 		"rbac_bindings_scope_isolation",
 	}

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -1771,6 +1771,53 @@ func (p *PostgresStore) ListRBACBindings(ctx context.Context) ([]RBACBinding, er
 	return result, nil
 }
 
+// ListRBACBindingsForSubject returns scoped subject-role bindings for one subject.
+func (p *PostgresStore) ListRBACBindingsForSubject(ctx context.Context, subjectType string, subjectID string) ([]RBACBinding, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	normalizedType, err := normalizeRBACSubjectType(subjectType)
+	if err != nil {
+		return nil, err
+	}
+	normalizedSubjectID := strings.TrimSpace(subjectID)
+	if normalizedSubjectID == "" {
+		return []RBACBinding{}, nil
+	}
+	rows, err := p.queryContext(
+		ctx,
+		`SELECT id, tenant_id, workspace_id, subject_type, subject_id, role_id, created_at, expires_at
+		 FROM rbac_bindings
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND subject_type = $3
+		   AND subject_id = $4
+		 ORDER BY created_at DESC, id ASC`,
+		scope.TenantID,
+		scope.WorkspaceID,
+		normalizedType,
+		normalizedSubjectID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list rbac bindings for subject: %w", err)
+	}
+	defer rows.Close()
+
+	result := []RBACBinding{}
+	for rows.Next() {
+		binding, scanErr := scanRBACBinding(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("scan rbac binding row: %w", scanErr)
+		}
+		result = append(result, binding)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rbac binding rows: %w", err)
+	}
+	return result, nil
+}
+
 // DeleteRBACBinding removes one scoped binding.
 func (p *PostgresStore) DeleteRBACBinding(ctx context.Context, bindingID string) error {
 	scope, err := RequireScope(ctx)

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -1106,8 +1106,18 @@ func TestPostgresStoreListAndDeleteRBACRoles(t *testing.T) {
 	if len(roles) != 2 {
 		t.Fatalf("expected 2 roles, got %+v", roles)
 	}
-	if len(roles[0].Permissions) != 2 || roles[0].Permissions[0] != "findings.read" || roles[0].Permissions[1] != "scans.read" {
-		t.Fatalf("expected sorted deduped role permissions, got %+v", roles[0].Permissions)
+	viewer := RBACRole{}
+	for _, role := range roles {
+		if role.Name == "viewer" {
+			viewer = role
+			break
+		}
+	}
+	if viewer.Name != "viewer" {
+		t.Fatalf("expected viewer role, got %+v", roles)
+	}
+	if len(viewer.Permissions) != 2 || viewer.Permissions[0] != "findings.read" || viewer.Permissions[1] != "scans.read" {
+		t.Fatalf("expected sorted deduped role permissions, got %+v", viewer.Permissions)
 	}
 
 	mock.ExpectQuery("SELECT is_builtin").

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -1178,6 +1178,19 @@ func TestPostgresStoreListAndDeleteRBACBindings(t *testing.T) {
 	if bindings[1].ExpiresAt == nil || !bindings[1].ExpiresAt.Equal(expires) {
 		t.Fatalf("expected second binding expiry to be set, got %+v", bindings[1].ExpiresAt)
 	}
+	subjectRows := sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "subject_type", "subject_id", "role_id", "created_at", "expires_at"}).
+		AddRow("binding-2", "default", "default", "api_key", "fp-1", "role-2", now, expires)
+	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, subject_type, subject_id, role_id, created_at, expires_at").
+		WithArgs("default", "default", "api_key", "fp-1").
+		WillReturnRows(subjectRows)
+
+	subjectBindings, err := store.ListRBACBindingsForSubject(ctx, RBACSubjectTypeAPIKey, "fp-1")
+	if err != nil {
+		t.Fatalf("list rbac bindings for subject: %v", err)
+	}
+	if len(subjectBindings) != 1 || subjectBindings[0].ID != "binding-2" {
+		t.Fatalf("expected one api key binding, got %+v", subjectBindings)
+	}
 
 	mock.ExpectExec("DELETE FROM rbac_bindings").
 		WithArgs("binding-1", "default", "default").

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -176,6 +176,7 @@ type Store interface {
 	DeleteRBACRole(ctx context.Context, roleID string) error
 	UpsertRBACBinding(ctx context.Context, binding RBACBinding) (RBACBinding, error)
 	ListRBACBindings(ctx context.Context) ([]RBACBinding, error)
+	ListRBACBindingsForSubject(ctx context.Context, subjectType string, subjectID string) ([]RBACBinding, error)
 	DeleteRBACBinding(ctx context.Context, bindingID string) error
 	ListRBACPermissionsForSubject(ctx context.Context, subjectType string, subjectID string, asOf time.Time) ([]string, error)
 	Close() error

--- a/migrations/000009_rbac_core_workspace_scope.down.sql
+++ b/migrations/000009_rbac_core_workspace_scope.down.sql
@@ -12,6 +12,7 @@ ALTER TABLE rbac_roles DISABLE ROW LEVEL SECURITY;
 
 DROP INDEX IF EXISTS idx_rbac_bindings_scope_subject;
 DROP INDEX IF EXISTS idx_rbac_bindings_scope_subject_role;
+DROP INDEX IF EXISTS idx_rbac_bindings_role_id;
 DROP INDEX IF EXISTS idx_rbac_roles_scope_name;
 
 DROP TABLE IF EXISTS rbac_bindings;

--- a/migrations/000009_rbac_core_workspace_scope.up.sql
+++ b/migrations/000009_rbac_core_workspace_scope.up.sql
@@ -36,6 +36,9 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_rbac_bindings_scope_subject_role
 CREATE INDEX IF NOT EXISTS idx_rbac_bindings_scope_subject
     ON rbac_bindings (tenant_id, workspace_id, subject_type, subject_id, created_at DESC);
 
+CREATE INDEX IF NOT EXISTS idx_rbac_bindings_role_id
+    ON rbac_bindings (role_id);
+
 ALTER TABLE rbac_roles ENABLE ROW LEVEL SECURITY;
 ALTER TABLE rbac_roles FORCE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS rbac_roles_scope_isolation ON rbac_roles;


### PR DESCRIPTION
## Summary
Follow-up to address all actionable cubic-dev-ai review findings raised on PR #77.

### Fixes included
- Prevented API-key auto-bootstrap from overriding admin-managed RBAC bindings:
  - `bootstrapAPIKeyBinding` now checks for existing active API-key bindings in scope and skips write bootstrap if one exists.
- Fixed RBAC binding deletion memory leak in in-memory store:
  - prune `rbacBindingByID` on `DeleteRBACBinding`.
- Improved RBAC route error handling and logging:
  - `PUT /v1/rbac/roles/:name`: validation errors remain `400`; infrastructure/server errors are logged and return `500`.
  - `DELETE /v1/rbac/bindings/:binding_id`: non-`ErrNotFound` errors now log and return `500`.
  - also aligned `DELETE /v1/rbac/roles/:role_id` and `POST /v1/rbac/bindings` to distinguish validation vs server failures consistently.
- Added missing FK-supporting index for cascade deletes:
  - `idx_rbac_bindings_role_id` in `000009_rbac_core_workspace_scope.up.sql` and corresponding drop in down migration.
- Stabilized Postgres RBAC role test ordering:
  - find the `viewer` role by name before asserting permissions.
- Added/updated tests for all above behavior.

## Validation
- `gofmt` on touched Go files
- `go test ./internal/api ./internal/db ./internal/identrailreviewer/enforcement ./cmd/identrail-reviewer`
- `go test ./... -coverprofile=coverage.out`
- coverage gate check passes (`80.0%`)

## Related
- Resolves cubic-dev-ai review findings from: https://github.com/Oluwatobi-Mustapha/identrail/pull/77

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens RBAC behavior and error handling to preserve admin-managed bindings and return correct 4xx/5xx responses. Also speeds up API-key bootstrap by querying subject-scoped bindings, and adds an index for faster role deletes.

- **Bug Fixes**
  - Skip API-key bootstrap when an active binding exists in scope; use subject-scoped lookup to avoid full binding scans.
  - Prune `rbacBindingByID` on delete to fix in-memory binding leak.
  - Distinguish validation (400) vs server errors (500) with logging for:
    - `PUT /v1/rbac/roles/:name`, `DELETE /v1/rbac/roles/:role_id`, `POST /v1/rbac/bindings`, `DELETE /v1/rbac/bindings/:binding_id`.
  - Add helpers `isRBACRoleValidationError` and `isRBACBindingValidationError`.
  - Stabilize Postgres role tests by selecting `viewer` by name.

- **Migration**
  - Add `idx_rbac_bindings_role_id` in `000009_rbac_core_workspace_scope.up.sql` (drop in down) to support cascade deletes.

<sup>Written for commit 43ba1943740d372b6c6bf70c37c337b7c421079d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

