### PR TITLE
feat(authz): PR-5.1 policy input model and ordered PDP chain

### DIFF
--- a/internal/api/authz_policy.go
+++ b/internal/api/authz_policy.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// PolicyStage identifies one authorization layer in the centralized decision pipeline.
+type PolicyStage string
+
+const (
+	PolicyStageTenantIsolation PolicyStage = "tenant_isolation"
+	PolicyStageRBAC            PolicyStage = "rbac"
+	PolicyStageABAC            PolicyStage = "abac"
+	PolicyStageReBAC           PolicyStage = "rebac"
+	PolicyStageDefaultDeny     PolicyStage = "default_deny"
+)
+
+// PolicyOutcome captures one evaluator result.
+type PolicyOutcome string
+
+const (
+	PolicyOutcomeNoOpinion PolicyOutcome = "no_op"
+	PolicyOutcomeAllow     PolicyOutcome = "allow"
+	PolicyOutcomeDeny      PolicyOutcome = "deny"
+)
+
+// PolicySubject is the actor for one authorization decision.
+type PolicySubject struct {
+	Type        string
+	ID          string
+	TenantID    string
+	WorkspaceID string
+	Groups      []string
+	Roles       []string
+}
+
+// PolicyResource identifies the target object.
+type PolicyResource struct {
+	Type        string
+	ID          string
+	TenantID    string
+	WorkspaceID string
+	Attributes  map[string]string
+}
+
+// PolicyContext captures request-time facts used in policy evaluation.
+type PolicyContext struct {
+	RequestPath   string
+	RequestMethod string
+	Now           time.Time
+	Attributes    map[string]string
+}
+
+// PolicyInput is the single input model for centralized authorization.
+type PolicyInput struct {
+	Subject  PolicySubject
+	Action   string
+	Resource PolicyResource
+	Context  PolicyContext
+}
+
+// PolicyDecision is the normalized authorization outcome.
+type PolicyDecision struct {
+	Allowed bool
+	Stage   PolicyStage
+	Reason  string
+}
+
+// PolicyEvaluator evaluates one authorization layer.
+type PolicyEvaluator interface {
+	Evaluate(ctx context.Context, input PolicyInput) (PolicyOutcome, string, error)
+}
+
+// PolicyEngine evaluates authorization in strict order:
+// tenant isolation -> RBAC -> ABAC -> ReBAC -> default deny.
+type PolicyEngine struct {
+	TenantIsolationEvaluator PolicyEvaluator
+	RBACEvaluator            PolicyEvaluator
+	ABACEvaluator            PolicyEvaluator
+	ReBACEvaluator           PolicyEvaluator
+}
+
+// NewPolicyEngine creates one centralized authorization engine.
+func NewPolicyEngine(tenantIsolation PolicyEvaluator, rbac PolicyEvaluator, abac PolicyEvaluator, rebac PolicyEvaluator) *PolicyEngine {
+	return &PolicyEngine{
+		TenantIsolationEvaluator: tenantIsolation,
+		RBACEvaluator:            rbac,
+		ABACEvaluator:            abac,
+		ReBACEvaluator:           rebac,
+	}
+}
+
+// Decide evaluates authorization policies and returns one normalized decision.
+func (p *PolicyEngine) Decide(ctx context.Context, input PolicyInput) (PolicyDecision, error) {
+	if p == nil {
+		return denyDecision(PolicyStageDefaultDeny, "authorization policy engine is not configured"), nil
+	}
+	for _, stage := range []struct {
+		name      PolicyStage
+		evaluator PolicyEvaluator
+	}{
+		{name: PolicyStageTenantIsolation, evaluator: p.TenantIsolationEvaluator},
+		{name: PolicyStageRBAC, evaluator: p.RBACEvaluator},
+		{name: PolicyStageABAC, evaluator: p.ABACEvaluator},
+		{name: PolicyStageReBAC, evaluator: p.ReBACEvaluator},
+	} {
+		if stage.evaluator == nil {
+			continue
+		}
+		outcome, reason, err := stage.evaluator.Evaluate(ctx, input)
+		if err != nil {
+			return PolicyDecision{}, fmt.Errorf("evaluate %s policy: %w", stage.name, err)
+		}
+		reason = strings.TrimSpace(reason)
+		switch outcome {
+		case PolicyOutcomeAllow:
+			return PolicyDecision{Allowed: true, Stage: stage.name, Reason: reason}, nil
+		case PolicyOutcomeDeny:
+			return denyDecision(stage.name, reason), nil
+		case PolicyOutcomeNoOpinion:
+			continue
+		default:
+			return PolicyDecision{}, fmt.Errorf("evaluate %s policy: invalid outcome %q", stage.name, outcome)
+		}
+	}
+	return denyDecision(PolicyStageDefaultDeny, "no policy granted access"), nil
+}
+
+func denyDecision(stage PolicyStage, reason string) PolicyDecision {
+	message := strings.TrimSpace(reason)
+	if message == "" {
+		message = "access denied"
+	}
+	return PolicyDecision{Allowed: false, Stage: stage, Reason: message}
+}

--- a/internal/api/authz_policy_test.go
+++ b/internal/api/authz_policy_test.go
@@ -1,0 +1,150 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type testPolicyEvaluator struct {
+	name    string
+	outcome PolicyOutcome
+	reason  string
+	err     error
+	calls   *[]string
+}
+
+func (e testPolicyEvaluator) Evaluate(_ context.Context, _ PolicyInput) (PolicyOutcome, string, error) {
+	if e.calls != nil {
+		*e.calls = append(*e.calls, e.name)
+	}
+	return e.outcome, e.reason, e.err
+}
+
+func TestPolicyEngineDecideEnforcesOrderAndDefaultDeny(t *testing.T) {
+	calls := []string{}
+	engine := NewPolicyEngine(
+		testPolicyEvaluator{name: "tenant", outcome: PolicyOutcomeNoOpinion, calls: &calls},
+		testPolicyEvaluator{name: "rbac", outcome: PolicyOutcomeNoOpinion, calls: &calls},
+		testPolicyEvaluator{name: "abac", outcome: PolicyOutcomeNoOpinion, calls: &calls},
+		testPolicyEvaluator{name: "rebac", outcome: PolicyOutcomeNoOpinion, calls: &calls},
+	)
+
+	decision, err := engine.Decide(context.Background(), PolicyInput{Action: "findings.read"})
+	if err != nil {
+		t.Fatalf("decide: %v", err)
+	}
+	if decision.Allowed {
+		t.Fatalf("expected default deny decision, got %+v", decision)
+	}
+	if decision.Stage != PolicyStageDefaultDeny {
+		t.Fatalf("expected default deny stage, got %q", decision.Stage)
+	}
+	expectedCalls := []string{"tenant", "rbac", "abac", "rebac"}
+	if !reflect.DeepEqual(calls, expectedCalls) {
+		t.Fatalf("expected call order %v, got %v", expectedCalls, calls)
+	}
+}
+
+func TestPolicyEngineDecideShortCircuitsOnDeny(t *testing.T) {
+	calls := []string{}
+	engine := NewPolicyEngine(
+		testPolicyEvaluator{name: "tenant", outcome: PolicyOutcomeDeny, reason: "tenant mismatch", calls: &calls},
+		testPolicyEvaluator{name: "rbac", outcome: PolicyOutcomeAllow, calls: &calls},
+		testPolicyEvaluator{name: "abac", outcome: PolicyOutcomeAllow, calls: &calls},
+		testPolicyEvaluator{name: "rebac", outcome: PolicyOutcomeAllow, calls: &calls},
+	)
+
+	decision, err := engine.Decide(context.Background(), PolicyInput{Action: "findings.read"})
+	if err != nil {
+		t.Fatalf("decide: %v", err)
+	}
+	if decision.Allowed {
+		t.Fatalf("expected deny decision, got %+v", decision)
+	}
+	if decision.Stage != PolicyStageTenantIsolation {
+		t.Fatalf("expected tenant isolation stage, got %q", decision.Stage)
+	}
+	if decision.Reason != "tenant mismatch" {
+		t.Fatalf("expected tenant deny reason, got %q", decision.Reason)
+	}
+	expectedCalls := []string{"tenant"}
+	if !reflect.DeepEqual(calls, expectedCalls) {
+		t.Fatalf("expected call order %v, got %v", expectedCalls, calls)
+	}
+}
+
+func TestPolicyEngineDecideShortCircuitsOnAllow(t *testing.T) {
+	calls := []string{}
+	engine := NewPolicyEngine(
+		testPolicyEvaluator{name: "tenant", outcome: PolicyOutcomeNoOpinion, calls: &calls},
+		testPolicyEvaluator{name: "rbac", outcome: PolicyOutcomeAllow, reason: "role grants action", calls: &calls},
+		testPolicyEvaluator{name: "abac", outcome: PolicyOutcomeAllow, calls: &calls},
+		testPolicyEvaluator{name: "rebac", outcome: PolicyOutcomeAllow, calls: &calls},
+	)
+
+	decision, err := engine.Decide(context.Background(), PolicyInput{Action: "findings.read"})
+	if err != nil {
+		t.Fatalf("decide: %v", err)
+	}
+	if !decision.Allowed {
+		t.Fatalf("expected allow decision, got %+v", decision)
+	}
+	if decision.Stage != PolicyStageRBAC {
+		t.Fatalf("expected rbac stage, got %q", decision.Stage)
+	}
+	expectedCalls := []string{"tenant", "rbac"}
+	if !reflect.DeepEqual(calls, expectedCalls) {
+		t.Fatalf("expected call order %v, got %v", expectedCalls, calls)
+	}
+}
+
+func TestPolicyEngineDecideEvaluatorErrorIncludesStage(t *testing.T) {
+	engine := NewPolicyEngine(
+		testPolicyEvaluator{name: "tenant", outcome: PolicyOutcomeNoOpinion},
+		testPolicyEvaluator{name: "rbac", err: errors.New("db unavailable")},
+		nil,
+		nil,
+	)
+
+	_, err := engine.Decide(context.Background(), PolicyInput{Action: "findings.read"})
+	if err == nil {
+		t.Fatal("expected evaluator error")
+	}
+	if !strings.Contains(err.Error(), "rbac") {
+		t.Fatalf("expected stage name in error, got %v", err)
+	}
+}
+
+func TestPolicyEngineDecideRejectsInvalidOutcome(t *testing.T) {
+	engine := NewPolicyEngine(
+		testPolicyEvaluator{name: "tenant", outcome: PolicyOutcome("maybe")},
+		nil,
+		nil,
+		nil,
+	)
+
+	_, err := engine.Decide(context.Background(), PolicyInput{Action: "findings.read"})
+	if err == nil {
+		t.Fatal("expected invalid outcome error")
+	}
+	if !strings.Contains(err.Error(), "invalid outcome") {
+		t.Fatalf("expected invalid outcome error, got %v", err)
+	}
+}
+
+func TestPolicyEngineDecideNilEngineDefaultsToDeny(t *testing.T) {
+	var engine *PolicyEngine
+	decision, err := engine.Decide(context.Background(), PolicyInput{Action: "findings.read"})
+	if err != nil {
+		t.Fatalf("decide nil engine: %v", err)
+	}
+	if decision.Allowed {
+		t.Fatalf("expected deny decision, got %+v", decision)
+	}
+	if decision.Stage != PolicyStageDefaultDeny {
+		t.Fatalf("expected default deny stage, got %q", decision.Stage)
+	}
+}


### PR DESCRIPTION
## Summary
This is PR-5.1 in the stacked Centralized AuthZ Decision Layer rollout.

It introduces the centralized policy model and PDP core without changing route behavior.

## Changes
- Add a unified authorization input model: `subject + action + resource + context`
- Add normalized decision model and policy stages
- Add ordered policy engine evaluation pipeline:
  - tenant isolation
  - RBAC
  - ABAC
  - ReBAC
  - default deny
- Add unit tests for order, short-circuit behavior, invalid outcomes, and default deny

## Why this PR is isolated
This lays the foundation so later PRs can add evaluators and router integration with low risk.

## Validation
- `go test ./internal/api`
- `go test ./...`

## Stack
- Base: `main`
- Next PR in stack: `feat/authz-pdp-2-evaluators`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a centralized authorization input model and an ordered policy decision engine (tenant isolation → RBAC → ABAC → ReBAC → default deny). No route behavior changes; prepares the ground for adding evaluators and router integration.

- **New Features**
  - Unified input: subject + action + resource + context.
  - Normalized decision with stage and reason.
  - Ordered evaluation with short-circuit on allow/deny and default deny fallback.
  - Tests for order, short-circuit, invalid outcomes, nil engine, and error propagation.

<sup>Written for commit 8e013a37d23211db0587ede7b8235b01683c721d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

