### PR TITLE
feat(authz): PR-5.2 tenant isolation and RBAC evaluators

### DIFF
--- a/internal/api/authz_evaluators.go
+++ b/internal/api/authz_evaluators.go
@@ -31,10 +31,10 @@ func (tenantIsolationEvaluator) Evaluate(_ context.Context, input PolicyInput) (
 		targetWorkspace = strings.TrimSpace(input.Context.Attributes[policyContextWorkspaceIDKey])
 	}
 
-	if subjectTenant != "" && targetTenant != "" && !strings.EqualFold(subjectTenant, targetTenant) {
+	if subjectTenant != "" && targetTenant != "" && subjectTenant != targetTenant {
 		return PolicyOutcomeDeny, fmt.Sprintf("tenant scope mismatch: subject=%q target=%q", subjectTenant, targetTenant), nil
 	}
-	if subjectWorkspace != "" && targetWorkspace != "" && !strings.EqualFold(subjectWorkspace, targetWorkspace) {
+	if subjectWorkspace != "" && targetWorkspace != "" && subjectWorkspace != targetWorkspace {
 		return PolicyOutcomeDeny, fmt.Sprintf("workspace scope mismatch: subject=%q target=%q", subjectWorkspace, targetWorkspace), nil
 	}
 	return PolicyOutcomeNoOpinion, "", nil

--- a/internal/api/authz_evaluators.go
+++ b/internal/api/authz_evaluators.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+const (
+	policyContextTenantIDKey    = "tenant_id"
+	policyContextWorkspaceIDKey = "workspace_id"
+)
+
+// tenantIsolationEvaluator enforces tenant/workspace scope boundaries before policy grants.
+type tenantIsolationEvaluator struct{}
+
+func newTenantIsolationEvaluator() PolicyEvaluator {
+	return tenantIsolationEvaluator{}
+}
+
+func (tenantIsolationEvaluator) Evaluate(_ context.Context, input PolicyInput) (PolicyOutcome, string, error) {
+	subjectTenant := strings.TrimSpace(input.Subject.TenantID)
+	subjectWorkspace := strings.TrimSpace(input.Subject.WorkspaceID)
+
+	targetTenant := strings.TrimSpace(input.Resource.TenantID)
+	if targetTenant == "" {
+		targetTenant = strings.TrimSpace(input.Context.Attributes[policyContextTenantIDKey])
+	}
+	targetWorkspace := strings.TrimSpace(input.Resource.WorkspaceID)
+	if targetWorkspace == "" {
+		targetWorkspace = strings.TrimSpace(input.Context.Attributes[policyContextWorkspaceIDKey])
+	}
+
+	if subjectTenant != "" && targetTenant != "" && !strings.EqualFold(subjectTenant, targetTenant) {
+		return PolicyOutcomeDeny, fmt.Sprintf("tenant scope mismatch: subject=%q target=%q", subjectTenant, targetTenant), nil
+	}
+	if subjectWorkspace != "" && targetWorkspace != "" && !strings.EqualFold(subjectWorkspace, targetWorkspace) {
+		return PolicyOutcomeDeny, fmt.Sprintf("workspace scope mismatch: subject=%q target=%q", subjectWorkspace, targetWorkspace), nil
+	}
+	return PolicyOutcomeNoOpinion, "", nil
+}
+
+// rbacPolicyEvaluator resolves subject roles against action grants.
+type rbacPolicyEvaluator struct {
+	actionRoles map[string]map[string]struct{}
+}
+
+// newRBACPolicyEvaluator builds one RBAC evaluator from action->roles grants.
+func newRBACPolicyEvaluator(grants map[string][]string) PolicyEvaluator {
+	actionRoles := make(map[string]map[string]struct{}, len(grants))
+	for action, roles := range grants {
+		normalizedAction := strings.ToLower(strings.TrimSpace(action))
+		if normalizedAction == "" {
+			continue
+		}
+		roleSet := map[string]struct{}{}
+		for _, role := range roles {
+			normalizedRole := strings.ToLower(strings.TrimSpace(role))
+			if normalizedRole == "" {
+				continue
+			}
+			roleSet[normalizedRole] = struct{}{}
+		}
+		if len(roleSet) > 0 {
+			actionRoles[normalizedAction] = roleSet
+		}
+	}
+	return &rbacPolicyEvaluator{actionRoles: actionRoles}
+}
+
+func (e *rbacPolicyEvaluator) Evaluate(_ context.Context, input PolicyInput) (PolicyOutcome, string, error) {
+	if e == nil || len(e.actionRoles) == 0 {
+		return PolicyOutcomeNoOpinion, "", nil
+	}
+	action := strings.ToLower(strings.TrimSpace(input.Action))
+	if action == "" {
+		return PolicyOutcomeNoOpinion, "", nil
+	}
+	allowedRoles, exists := e.actionRoles[action]
+	if !exists {
+		return PolicyOutcomeNoOpinion, "", nil
+	}
+	for _, role := range input.Subject.Roles {
+		normalizedRole := strings.ToLower(strings.TrimSpace(role))
+		if normalizedRole == "" {
+			continue
+		}
+		if _, ok := allowedRoles[normalizedRole]; ok {
+			return PolicyOutcomeAllow, "rbac role grants action", nil
+		}
+	}
+	return PolicyOutcomeNoOpinion, "", nil
+}

--- a/internal/api/authz_evaluators_test.go
+++ b/internal/api/authz_evaluators_test.go
@@ -27,6 +27,27 @@ func TestTenantIsolationEvaluatorDenyMismatch(t *testing.T) {
 	}
 }
 
+func TestTenantIsolationEvaluatorDenyCaseVariantIDs(t *testing.T) {
+	evaluator := newTenantIsolationEvaluator()
+	outcome, reason, err := evaluator.Evaluate(context.Background(), PolicyInput{
+		Subject: PolicySubject{TenantID: "Tenant-A", WorkspaceID: "Workspace-A"},
+		Action:  "findings.read",
+		Resource: PolicyResource{
+			TenantID:    "tenant-a",
+			WorkspaceID: "workspace-a",
+		},
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if outcome != PolicyOutcomeDeny {
+		t.Fatalf("expected deny for case-variant IDs, got %q", outcome)
+	}
+	if !strings.Contains(reason, "tenant scope mismatch") {
+		t.Fatalf("expected tenant mismatch reason, got %q", reason)
+	}
+}
+
 func TestTenantIsolationEvaluatorNoOpinionWhenSubjectScopeMissing(t *testing.T) {
 	evaluator := newTenantIsolationEvaluator()
 	outcome, reason, err := evaluator.Evaluate(context.Background(), PolicyInput{

--- a/internal/api/authz_evaluators_test.go
+++ b/internal/api/authz_evaluators_test.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestTenantIsolationEvaluatorDenyMismatch(t *testing.T) {
+	evaluator := newTenantIsolationEvaluator()
+	outcome, reason, err := evaluator.Evaluate(context.Background(), PolicyInput{
+		Subject: PolicySubject{TenantID: "tenant-a", WorkspaceID: "workspace-a"},
+		Action:  "findings.read",
+		Resource: PolicyResource{
+			TenantID:    "tenant-b",
+			WorkspaceID: "workspace-a",
+		},
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if outcome != PolicyOutcomeDeny {
+		t.Fatalf("expected deny, got %q", outcome)
+	}
+	if !strings.Contains(reason, "tenant scope mismatch") {
+		t.Fatalf("expected tenant mismatch reason, got %q", reason)
+	}
+}
+
+func TestTenantIsolationEvaluatorNoOpinionWhenSubjectScopeMissing(t *testing.T) {
+	evaluator := newTenantIsolationEvaluator()
+	outcome, reason, err := evaluator.Evaluate(context.Background(), PolicyInput{
+		Subject: PolicySubject{},
+		Action:  "findings.read",
+		Context: PolicyContext{Attributes: map[string]string{
+			policyContextTenantIDKey:    "tenant-a",
+			policyContextWorkspaceIDKey: "workspace-a",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if outcome != PolicyOutcomeNoOpinion {
+		t.Fatalf("expected no-opinion, got %q", outcome)
+	}
+	if reason != "" {
+		t.Fatalf("expected empty reason for no-opinion, got %q", reason)
+	}
+}
+
+func TestRBACPolicyEvaluatorAllowWhenRoleGrantsAction(t *testing.T) {
+	evaluator := newRBACPolicyEvaluator(map[string][]string{
+		"findings.read": {"viewer", "admin"},
+	})
+	outcome, reason, err := evaluator.Evaluate(context.Background(), PolicyInput{
+		Subject: PolicySubject{Roles: []string{"viewer"}},
+		Action:  "findings.read",
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if outcome != PolicyOutcomeAllow {
+		t.Fatalf("expected allow, got %q", outcome)
+	}
+	if reason == "" {
+		t.Fatal("expected allow reason")
+	}
+}
+
+func TestRBACPolicyEvaluatorNoOpinionWhenRoleMissing(t *testing.T) {
+	evaluator := newRBACPolicyEvaluator(map[string][]string{
+		"findings.read": {"viewer", "admin"},
+	})
+	outcome, reason, err := evaluator.Evaluate(context.Background(), PolicyInput{
+		Subject: PolicySubject{Roles: []string{"analyst"}},
+		Action:  "findings.read",
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if outcome != PolicyOutcomeNoOpinion {
+		t.Fatalf("expected no-opinion, got %q", outcome)
+	}
+	if reason != "" {
+		t.Fatalf("expected empty reason for no-opinion, got %q", reason)
+	}
+}
+
+func TestRBACPolicyEvaluatorNoOpinionWhenActionUnmapped(t *testing.T) {
+	evaluator := newRBACPolicyEvaluator(map[string][]string{
+		"findings.read": {"viewer", "admin"},
+	})
+	outcome, reason, err := evaluator.Evaluate(context.Background(), PolicyInput{
+		Subject: PolicySubject{Roles: []string{"viewer"}},
+		Action:  "scans.run",
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if outcome != PolicyOutcomeNoOpinion {
+		t.Fatalf("expected no-opinion, got %q", outcome)
+	}
+	if reason != "" {
+		t.Fatalf("expected empty reason for no-opinion, got %q", reason)
+	}
+}

--- a/internal/api/authz_policy.go
+++ b/internal/api/authz_policy.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// PolicyStage identifies one authorization layer in the centralized decision pipeline.
+type PolicyStage string
+
+const (
+	PolicyStageTenantIsolation PolicyStage = "tenant_isolation"
+	PolicyStageRBAC            PolicyStage = "rbac"
+	PolicyStageABAC            PolicyStage = "abac"
+	PolicyStageReBAC           PolicyStage = "rebac"
+	PolicyStageDefaultDeny     PolicyStage = "default_deny"
+)
+
+// PolicyOutcome captures one evaluator result.
+type PolicyOutcome string
+
+const (
+	PolicyOutcomeNoOpinion PolicyOutcome = "no_op"
+	PolicyOutcomeAllow     PolicyOutcome = "allow"
+	PolicyOutcomeDeny      PolicyOutcome = "deny"
+)
+
+// PolicySubject is the actor for one authorization decision.
+type PolicySubject struct {
+	Type        string
+	ID          string
+	TenantID    string
+	WorkspaceID string
+	Groups      []string
+	Roles       []string
+}
+
+// PolicyResource identifies the target object.
+type PolicyResource struct {
+	Type        string
+	ID          string
+	TenantID    string
+	WorkspaceID string
+	Attributes  map[string]string
+}
+
+// PolicyContext captures request-time facts used in policy evaluation.
+type PolicyContext struct {
+	RequestPath   string
+	RequestMethod string
+	Now           time.Time
+	Attributes    map[string]string
+}
+
+// PolicyInput is the single input model for centralized authorization.
+type PolicyInput struct {
+	Subject  PolicySubject
+	Action   string
+	Resource PolicyResource
+	Context  PolicyContext
+}
+
+// PolicyDecision is the normalized authorization outcome.
+type PolicyDecision struct {
+	Allowed bool
+	Stage   PolicyStage
+	Reason  string
+}
+
+// PolicyEvaluator evaluates one authorization layer.
+type PolicyEvaluator interface {
+	Evaluate(ctx context.Context, input PolicyInput) (PolicyOutcome, string, error)
+}
+
+// PolicyEngine evaluates authorization in strict order:
+// tenant isolation -> RBAC -> ABAC -> ReBAC -> default deny.
+type PolicyEngine struct {
+	TenantIsolationEvaluator PolicyEvaluator
+	RBACEvaluator            PolicyEvaluator
+	ABACEvaluator            PolicyEvaluator
+	ReBACEvaluator           PolicyEvaluator
+}
+
+// NewPolicyEngine creates one centralized authorization engine.
+func NewPolicyEngine(tenantIsolation PolicyEvaluator, rbac PolicyEvaluator, abac PolicyEvaluator, rebac PolicyEvaluator) *PolicyEngine {
+	return &PolicyEngine{
+		TenantIsolationEvaluator: tenantIsolation,
+		RBACEvaluator:            rbac,
+		ABACEvaluator:            abac,
+		ReBACEvaluator:           rebac,
+	}
+}
+
+// Decide evaluates authorization policies and returns one normalized decision.
+func (p *PolicyEngine) Decide(ctx context.Context, input PolicyInput) (PolicyDecision, error) {
+	if p == nil {
+		return denyDecision(PolicyStageDefaultDeny, "authorization policy engine is not configured"), nil
+	}
+	for _, stage := range []struct {
+		name      PolicyStage
+		evaluator PolicyEvaluator
+	}{
+		{name: PolicyStageTenantIsolation, evaluator: p.TenantIsolationEvaluator},
+		{name: PolicyStageRBAC, evaluator: p.RBACEvaluator},
+		{name: PolicyStageABAC, evaluator: p.ABACEvaluator},
+		{name: PolicyStageReBAC, evaluator: p.ReBACEvaluator},
+	} {
+		if stage.evaluator == nil {
+			continue
+		}
+		outcome, reason, err := stage.evaluator.Evaluate(ctx, input)
+		if err != nil {
+			return PolicyDecision{}, fmt.Errorf("evaluate %s policy: %w", stage.name, err)
+		}
+		reason = strings.TrimSpace(reason)
+		switch outcome {
+		case PolicyOutcomeAllow:
+			return PolicyDecision{Allowed: true, Stage: stage.name, Reason: reason}, nil
+		case PolicyOutcomeDeny:
+			return denyDecision(stage.name, reason), nil
+		case PolicyOutcomeNoOpinion:
+			continue
+		default:
+			return PolicyDecision{}, fmt.Errorf("evaluate %s policy: invalid outcome %q", stage.name, outcome)
+		}
+	}
+	return denyDecision(PolicyStageDefaultDeny, "no policy granted access"), nil
+}
+
+func denyDecision(stage PolicyStage, reason string) PolicyDecision {
+	message := strings.TrimSpace(reason)
+	if message == "" {
+		message = "access denied"
+	}
+	return PolicyDecision{Allowed: false, Stage: stage, Reason: message}
+}

--- a/internal/api/authz_policy_test.go
+++ b/internal/api/authz_policy_test.go
@@ -1,0 +1,150 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type testPolicyEvaluator struct {
+	name    string
+	outcome PolicyOutcome
+	reason  string
+	err     error
+	calls   *[]string
+}
+
+func (e testPolicyEvaluator) Evaluate(_ context.Context, _ PolicyInput) (PolicyOutcome, string, error) {
+	if e.calls != nil {
+		*e.calls = append(*e.calls, e.name)
+	}
+	return e.outcome, e.reason, e.err
+}
+
+func TestPolicyEngineDecideEnforcesOrderAndDefaultDeny(t *testing.T) {
+	calls := []string{}
+	engine := NewPolicyEngine(
+		testPolicyEvaluator{name: "tenant", outcome: PolicyOutcomeNoOpinion, calls: &calls},
+		testPolicyEvaluator{name: "rbac", outcome: PolicyOutcomeNoOpinion, calls: &calls},
+		testPolicyEvaluator{name: "abac", outcome: PolicyOutcomeNoOpinion, calls: &calls},
+		testPolicyEvaluator{name: "rebac", outcome: PolicyOutcomeNoOpinion, calls: &calls},
+	)
+
+	decision, err := engine.Decide(context.Background(), PolicyInput{Action: "findings.read"})
+	if err != nil {
+		t.Fatalf("decide: %v", err)
+	}
+	if decision.Allowed {
+		t.Fatalf("expected default deny decision, got %+v", decision)
+	}
+	if decision.Stage != PolicyStageDefaultDeny {
+		t.Fatalf("expected default deny stage, got %q", decision.Stage)
+	}
+	expectedCalls := []string{"tenant", "rbac", "abac", "rebac"}
+	if !reflect.DeepEqual(calls, expectedCalls) {
+		t.Fatalf("expected call order %v, got %v", expectedCalls, calls)
+	}
+}
+
+func TestPolicyEngineDecideShortCircuitsOnDeny(t *testing.T) {
+	calls := []string{}
+	engine := NewPolicyEngine(
+		testPolicyEvaluator{name: "tenant", outcome: PolicyOutcomeDeny, reason: "tenant mismatch", calls: &calls},
+		testPolicyEvaluator{name: "rbac", outcome: PolicyOutcomeAllow, calls: &calls},
+		testPolicyEvaluator{name: "abac", outcome: PolicyOutcomeAllow, calls: &calls},
+		testPolicyEvaluator{name: "rebac", outcome: PolicyOutcomeAllow, calls: &calls},
+	)
+
+	decision, err := engine.Decide(context.Background(), PolicyInput{Action: "findings.read"})
+	if err != nil {
+		t.Fatalf("decide: %v", err)
+	}
+	if decision.Allowed {
+		t.Fatalf("expected deny decision, got %+v", decision)
+	}
+	if decision.Stage != PolicyStageTenantIsolation {
+		t.Fatalf("expected tenant isolation stage, got %q", decision.Stage)
+	}
+	if decision.Reason != "tenant mismatch" {
+		t.Fatalf("expected tenant deny reason, got %q", decision.Reason)
+	}
+	expectedCalls := []string{"tenant"}
+	if !reflect.DeepEqual(calls, expectedCalls) {
+		t.Fatalf("expected call order %v, got %v", expectedCalls, calls)
+	}
+}
+
+func TestPolicyEngineDecideShortCircuitsOnAllow(t *testing.T) {
+	calls := []string{}
+	engine := NewPolicyEngine(
+		testPolicyEvaluator{name: "tenant", outcome: PolicyOutcomeNoOpinion, calls: &calls},
+		testPolicyEvaluator{name: "rbac", outcome: PolicyOutcomeAllow, reason: "role grants action", calls: &calls},
+		testPolicyEvaluator{name: "abac", outcome: PolicyOutcomeAllow, calls: &calls},
+		testPolicyEvaluator{name: "rebac", outcome: PolicyOutcomeAllow, calls: &calls},
+	)
+
+	decision, err := engine.Decide(context.Background(), PolicyInput{Action: "findings.read"})
+	if err != nil {
+		t.Fatalf("decide: %v", err)
+	}
+	if !decision.Allowed {
+		t.Fatalf("expected allow decision, got %+v", decision)
+	}
+	if decision.Stage != PolicyStageRBAC {
+		t.Fatalf("expected rbac stage, got %q", decision.Stage)
+	}
+	expectedCalls := []string{"tenant", "rbac"}
+	if !reflect.DeepEqual(calls, expectedCalls) {
+		t.Fatalf("expected call order %v, got %v", expectedCalls, calls)
+	}
+}
+
+func TestPolicyEngineDecideEvaluatorErrorIncludesStage(t *testing.T) {
+	engine := NewPolicyEngine(
+		testPolicyEvaluator{name: "tenant", outcome: PolicyOutcomeNoOpinion},
+		testPolicyEvaluator{name: "rbac", err: errors.New("db unavailable")},
+		nil,
+		nil,
+	)
+
+	_, err := engine.Decide(context.Background(), PolicyInput{Action: "findings.read"})
+	if err == nil {
+		t.Fatal("expected evaluator error")
+	}
+	if !strings.Contains(err.Error(), "rbac") {
+		t.Fatalf("expected stage name in error, got %v", err)
+	}
+}
+
+func TestPolicyEngineDecideRejectsInvalidOutcome(t *testing.T) {
+	engine := NewPolicyEngine(
+		testPolicyEvaluator{name: "tenant", outcome: PolicyOutcome("maybe")},
+		nil,
+		nil,
+		nil,
+	)
+
+	_, err := engine.Decide(context.Background(), PolicyInput{Action: "findings.read"})
+	if err == nil {
+		t.Fatal("expected invalid outcome error")
+	}
+	if !strings.Contains(err.Error(), "invalid outcome") {
+		t.Fatalf("expected invalid outcome error, got %v", err)
+	}
+}
+
+func TestPolicyEngineDecideNilEngineDefaultsToDeny(t *testing.T) {
+	var engine *PolicyEngine
+	decision, err := engine.Decide(context.Background(), PolicyInput{Action: "findings.read"})
+	if err != nil {
+		t.Fatalf("decide nil engine: %v", err)
+	}
+	if decision.Allowed {
+		t.Fatalf("expected deny decision, got %+v", decision)
+	}
+	if decision.Stage != PolicyStageDefaultDeny {
+		t.Fatalf("expected default deny stage, got %q", decision.Stage)
+	}
+}


### PR DESCRIPTION
## Summary
This is PR-5.2 in the stacked Centralized AuthZ Decision Layer rollout.

It adds evaluator implementations on top of PR-5.1.

## Changes
- Add `tenantIsolationEvaluator`
  - denies on tenant/workspace mismatch
- Add `rbacPolicyEvaluator`
  - resolves action grants against subject roles
- Add evaluator-focused unit tests for allow/deny/no-op behavior

## Why this PR is isolated
This keeps evaluator logic independent from router changes so policy correctness is reviewed before request-path integration.

## Validation
- `go test ./internal/api`
- `go test ./...`

## Stack
- Base PR: #83 (`feat/authz-pdp-1-model`)
- Next PR in stack: `feat/authz-pdp-3-policy-middleware`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a centralized `PolicyEngine` with an ordered PDP chain and two evaluators. Enforces case-sensitive tenant/workspace isolation and role-based grants, with tests for allow/deny/no-op and engine ordering.

- **New Features**
  - `PolicyEngine`: unified input model (`PolicySubject`, `PolicyResource`, `PolicyContext`), ordered stages (tenant isolation → RBAC → ABAC → ReBAC), short-circuit on allow/deny, default deny fallback.
  - `tenantIsolationEvaluator` and `rbacPolicyEvaluator`: case-sensitive tenant/workspace checks deny on mismatch (resource or context `tenant_id`/`workspace_id`); RBAC builds action→roles map and allows on matching subject role; no-op for unmapped actions.

<sup>Written for commit a4c94bea293cdf7b697205b4f0aff0286651340f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

