### PR TITLE
feat(authz): PR-5.3 route policy registry and centralized middleware

### DIFF
--- a/internal/api/authz_evaluators.go
+++ b/internal/api/authz_evaluators.go
@@ -31,10 +31,10 @@ func (tenantIsolationEvaluator) Evaluate(_ context.Context, input PolicyInput) (
 		targetWorkspace = strings.TrimSpace(input.Context.Attributes[policyContextWorkspaceIDKey])
 	}
 
-	if subjectTenant != "" && targetTenant != "" && !strings.EqualFold(subjectTenant, targetTenant) {
+	if subjectTenant != "" && targetTenant != "" && subjectTenant != targetTenant {
 		return PolicyOutcomeDeny, fmt.Sprintf("tenant scope mismatch: subject=%q target=%q", subjectTenant, targetTenant), nil
 	}
-	if subjectWorkspace != "" && targetWorkspace != "" && !strings.EqualFold(subjectWorkspace, targetWorkspace) {
+	if subjectWorkspace != "" && targetWorkspace != "" && subjectWorkspace != targetWorkspace {
 		return PolicyOutcomeDeny, fmt.Sprintf("workspace scope mismatch: subject=%q target=%q", subjectWorkspace, targetWorkspace), nil
 	}
 	return PolicyOutcomeNoOpinion, "", nil

--- a/internal/api/authz_evaluators.go
+++ b/internal/api/authz_evaluators.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+const (
+	policyContextTenantIDKey    = "tenant_id"
+	policyContextWorkspaceIDKey = "workspace_id"
+)
+
+// tenantIsolationEvaluator enforces tenant/workspace scope boundaries before policy grants.
+type tenantIsolationEvaluator struct{}
+
+func newTenantIsolationEvaluator() PolicyEvaluator {
+	return tenantIsolationEvaluator{}
+}
+
+func (tenantIsolationEvaluator) Evaluate(_ context.Context, input PolicyInput) (PolicyOutcome, string, error) {
+	subjectTenant := strings.TrimSpace(input.Subject.TenantID)
+	subjectWorkspace := strings.TrimSpace(input.Subject.WorkspaceID)
+
+	targetTenant := strings.TrimSpace(input.Resource.TenantID)
+	if targetTenant == "" {
+		targetTenant = strings.TrimSpace(input.Context.Attributes[policyContextTenantIDKey])
+	}
+	targetWorkspace := strings.TrimSpace(input.Resource.WorkspaceID)
+	if targetWorkspace == "" {
+		targetWorkspace = strings.TrimSpace(input.Context.Attributes[policyContextWorkspaceIDKey])
+	}
+
+	if subjectTenant != "" && targetTenant != "" && !strings.EqualFold(subjectTenant, targetTenant) {
+		return PolicyOutcomeDeny, fmt.Sprintf("tenant scope mismatch: subject=%q target=%q", subjectTenant, targetTenant), nil
+	}
+	if subjectWorkspace != "" && targetWorkspace != "" && !strings.EqualFold(subjectWorkspace, targetWorkspace) {
+		return PolicyOutcomeDeny, fmt.Sprintf("workspace scope mismatch: subject=%q target=%q", subjectWorkspace, targetWorkspace), nil
+	}
+	return PolicyOutcomeNoOpinion, "", nil
+}
+
+// rbacPolicyEvaluator resolves subject roles against action grants.
+type rbacPolicyEvaluator struct {
+	actionRoles map[string]map[string]struct{}
+}
+
+// newRBACPolicyEvaluator builds one RBAC evaluator from action->roles grants.
+func newRBACPolicyEvaluator(grants map[string][]string) PolicyEvaluator {
+	actionRoles := make(map[string]map[string]struct{}, len(grants))
+	for action, roles := range grants {
+		normalizedAction := strings.ToLower(strings.TrimSpace(action))
+		if normalizedAction == "" {
+			continue
+		}
+		roleSet := map[string]struct{}{}
+		for _, role := range roles {
+			normalizedRole := strings.ToLower(strings.TrimSpace(role))
+			if normalizedRole == "" {
+				continue
+			}
+			roleSet[normalizedRole] = struct{}{}
+		}
+		if len(roleSet) > 0 {
+			actionRoles[normalizedAction] = roleSet
+		}
+	}
+	return &rbacPolicyEvaluator{actionRoles: actionRoles}
+}
+
+func (e *rbacPolicyEvaluator) Evaluate(_ context.Context, input PolicyInput) (PolicyOutcome, string, error) {
+	if e == nil || len(e.actionRoles) == 0 {
+		return PolicyOutcomeNoOpinion, "", nil
+	}
+	action := strings.ToLower(strings.TrimSpace(input.Action))
+	if action == "" {
+		return PolicyOutcomeNoOpinion, "", nil
+	}
+	allowedRoles, exists := e.actionRoles[action]
+	if !exists {
+		return PolicyOutcomeNoOpinion, "", nil
+	}
+	for _, role := range input.Subject.Roles {
+		normalizedRole := strings.ToLower(strings.TrimSpace(role))
+		if normalizedRole == "" {
+			continue
+		}
+		if _, ok := allowedRoles[normalizedRole]; ok {
+			return PolicyOutcomeAllow, "rbac role grants action", nil
+		}
+	}
+	return PolicyOutcomeNoOpinion, "", nil
+}

--- a/internal/api/authz_evaluators_test.go
+++ b/internal/api/authz_evaluators_test.go
@@ -27,6 +27,27 @@ func TestTenantIsolationEvaluatorDenyMismatch(t *testing.T) {
 	}
 }
 
+func TestTenantIsolationEvaluatorDenyCaseVariantIDs(t *testing.T) {
+	evaluator := newTenantIsolationEvaluator()
+	outcome, reason, err := evaluator.Evaluate(context.Background(), PolicyInput{
+		Subject: PolicySubject{TenantID: "Tenant-A", WorkspaceID: "Workspace-A"},
+		Action:  "findings.read",
+		Resource: PolicyResource{
+			TenantID:    "tenant-a",
+			WorkspaceID: "workspace-a",
+		},
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if outcome != PolicyOutcomeDeny {
+		t.Fatalf("expected deny for case-variant IDs, got %q", outcome)
+	}
+	if !strings.Contains(reason, "tenant scope mismatch") {
+		t.Fatalf("expected tenant mismatch reason, got %q", reason)
+	}
+}
+
 func TestTenantIsolationEvaluatorNoOpinionWhenSubjectScopeMissing(t *testing.T) {
 	evaluator := newTenantIsolationEvaluator()
 	outcome, reason, err := evaluator.Evaluate(context.Background(), PolicyInput{

--- a/internal/api/authz_evaluators_test.go
+++ b/internal/api/authz_evaluators_test.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestTenantIsolationEvaluatorDenyMismatch(t *testing.T) {
+	evaluator := newTenantIsolationEvaluator()
+	outcome, reason, err := evaluator.Evaluate(context.Background(), PolicyInput{
+		Subject: PolicySubject{TenantID: "tenant-a", WorkspaceID: "workspace-a"},
+		Action:  "findings.read",
+		Resource: PolicyResource{
+			TenantID:    "tenant-b",
+			WorkspaceID: "workspace-a",
+		},
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if outcome != PolicyOutcomeDeny {
+		t.Fatalf("expected deny, got %q", outcome)
+	}
+	if !strings.Contains(reason, "tenant scope mismatch") {
+		t.Fatalf("expected tenant mismatch reason, got %q", reason)
+	}
+}
+
+func TestTenantIsolationEvaluatorNoOpinionWhenSubjectScopeMissing(t *testing.T) {
+	evaluator := newTenantIsolationEvaluator()
+	outcome, reason, err := evaluator.Evaluate(context.Background(), PolicyInput{
+		Subject: PolicySubject{},
+		Action:  "findings.read",
+		Context: PolicyContext{Attributes: map[string]string{
+			policyContextTenantIDKey:    "tenant-a",
+			policyContextWorkspaceIDKey: "workspace-a",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if outcome != PolicyOutcomeNoOpinion {
+		t.Fatalf("expected no-opinion, got %q", outcome)
+	}
+	if reason != "" {
+		t.Fatalf("expected empty reason for no-opinion, got %q", reason)
+	}
+}
+
+func TestRBACPolicyEvaluatorAllowWhenRoleGrantsAction(t *testing.T) {
+	evaluator := newRBACPolicyEvaluator(map[string][]string{
+		"findings.read": {"viewer", "admin"},
+	})
+	outcome, reason, err := evaluator.Evaluate(context.Background(), PolicyInput{
+		Subject: PolicySubject{Roles: []string{"viewer"}},
+		Action:  "findings.read",
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if outcome != PolicyOutcomeAllow {
+		t.Fatalf("expected allow, got %q", outcome)
+	}
+	if reason == "" {
+		t.Fatal("expected allow reason")
+	}
+}
+
+func TestRBACPolicyEvaluatorNoOpinionWhenRoleMissing(t *testing.T) {
+	evaluator := newRBACPolicyEvaluator(map[string][]string{
+		"findings.read": {"viewer", "admin"},
+	})
+	outcome, reason, err := evaluator.Evaluate(context.Background(), PolicyInput{
+		Subject: PolicySubject{Roles: []string{"analyst"}},
+		Action:  "findings.read",
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if outcome != PolicyOutcomeNoOpinion {
+		t.Fatalf("expected no-opinion, got %q", outcome)
+	}
+	if reason != "" {
+		t.Fatalf("expected empty reason for no-opinion, got %q", reason)
+	}
+}
+
+func TestRBACPolicyEvaluatorNoOpinionWhenActionUnmapped(t *testing.T) {
+	evaluator := newRBACPolicyEvaluator(map[string][]string{
+		"findings.read": {"viewer", "admin"},
+	})
+	outcome, reason, err := evaluator.Evaluate(context.Background(), PolicyInput{
+		Subject: PolicySubject{Roles: []string{"viewer"}},
+		Action:  "scans.run",
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if outcome != PolicyOutcomeNoOpinion {
+		t.Fatalf("expected no-opinion, got %q", outcome)
+	}
+	if reason != "" {
+		t.Fatalf("expected empty reason for no-opinion, got %q", reason)
+	}
+}

--- a/internal/api/authz_middleware.go
+++ b/internal/api/authz_middleware.go
@@ -1,0 +1,176 @@
+package api
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	policyActionFindingsTriage = "findings.triage"
+	policyActionScansRun       = "scans.run"
+	policyActionRepoScansRun   = "repo_scans.run"
+)
+
+type routePolicy struct {
+	Action          string
+	ResourceType    string
+	ResourceIDParam string
+}
+
+type routePolicyRegistry map[string]routePolicy
+
+func newRoutePolicyRegistry() routePolicyRegistry {
+	return routePolicyRegistry{
+		routePolicyKey(http.MethodPatch, "/v1/findings/:finding_id/triage"): {
+			Action:          policyActionFindingsTriage,
+			ResourceType:    "finding",
+			ResourceIDParam: "finding_id",
+		},
+		routePolicyKey(http.MethodPost, "/v1/scans"): {
+			Action:       policyActionScansRun,
+			ResourceType: "scan",
+		},
+		routePolicyKey(http.MethodPost, "/v1/repo-scans"): {
+			Action:       policyActionRepoScansRun,
+			ResourceType: "repo_scan",
+		},
+	}
+}
+
+func (r routePolicyRegistry) lookup(method string, fullPath string) (routePolicy, bool) {
+	policy, exists := r[routePolicyKey(method, fullPath)]
+	return policy, exists
+}
+
+func routePolicyKey(method string, fullPath string) string {
+	return strings.ToUpper(strings.TrimSpace(method)) + " " + strings.TrimSpace(fullPath)
+}
+
+func defaultRouteActionRoleGrants() map[string][]string {
+	return map[string][]string{
+		policyActionFindingsTriage: {scopeWrite, scopeAdmin},
+		policyActionScansRun:       {scopeWrite, scopeAdmin},
+		policyActionRepoScansRun:   {scopeWrite, scopeAdmin},
+	}
+}
+
+func newCentralPolicyEngine() *PolicyEngine {
+	return NewPolicyEngine(
+		newTenantIsolationEvaluator(),
+		newRBACPolicyEvaluator(defaultRouteActionRoleGrants()),
+		nil,
+		nil,
+	)
+}
+
+func requireCentralPolicyMiddleware(engine *PolicyEngine, registry routePolicyRegistry) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		fullPath := strings.TrimSpace(c.FullPath())
+		if fullPath == "" {
+			c.Next()
+			return
+		}
+		policy, exists := registry.lookup(c.Request.Method, fullPath)
+		if !exists {
+			c.Next()
+			return
+		}
+
+		if !hasAuthContext(c) {
+			// Keep local/dev behavior unchanged when authentication is disabled.
+			c.Next()
+			return
+		}
+
+		decision, err := engine.Decide(c.Request.Context(), buildPolicyInputFromGinContext(c, policy))
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "authorization failed"})
+			return
+		}
+		if !decision.Allowed {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			return
+		}
+
+		c.Set("authz.stage", string(decision.Stage))
+		c.Next()
+	}
+}
+
+func buildPolicyInputFromGinContext(c *gin.Context, policy routePolicy) PolicyInput {
+	scope := db.ScopeFromContext(c.Request.Context())
+	resourceID := ""
+	if strings.TrimSpace(policy.ResourceIDParam) != "" {
+		resourceID = strings.TrimSpace(c.Param(policy.ResourceIDParam))
+	}
+	return PolicyInput{
+		Subject: PolicySubject{
+			Type:        authContextString(c, "auth.principal_type"),
+			ID:          authContextString(c, "auth.principal_id"),
+			TenantID:    firstNonEmpty(authContextString(c, "auth.tenant_id"), strings.TrimSpace(scope.TenantID)),
+			WorkspaceID: firstNonEmpty(authContextString(c, "auth.workspace_id"), strings.TrimSpace(scope.WorkspaceID)),
+			Roles:       policyRolesFromScope(c),
+		},
+		Action: strings.ToLower(strings.TrimSpace(policy.Action)),
+		Resource: PolicyResource{
+			Type:        strings.TrimSpace(policy.ResourceType),
+			ID:          resourceID,
+			TenantID:    strings.TrimSpace(scope.TenantID),
+			WorkspaceID: strings.TrimSpace(scope.WorkspaceID),
+		},
+		Context: PolicyContext{
+			RequestPath:   strings.TrimSpace(c.FullPath()),
+			RequestMethod: strings.ToUpper(strings.TrimSpace(c.Request.Method)),
+			Attributes: map[string]string{
+				policyContextTenantIDKey:    strings.TrimSpace(scope.TenantID),
+				policyContextWorkspaceIDKey: strings.TrimSpace(scope.WorkspaceID),
+			},
+		},
+	}
+}
+
+func firstNonEmpty(primary string, fallback string) string {
+	if strings.TrimSpace(primary) != "" {
+		return strings.TrimSpace(primary)
+	}
+	return strings.TrimSpace(fallback)
+}
+
+func hasAuthContext(c *gin.Context) bool {
+	if c == nil {
+		return false
+	}
+	_, exists := c.Get("auth.scope_set")
+	return exists
+}
+
+func policyRolesFromScope(c *gin.Context) []string {
+	scopeSetValue, exists := c.Get("auth.scope_set")
+	if !exists {
+		return nil
+	}
+	scopes, ok := scopeSetValue.(scopeSet)
+	if !ok {
+		return nil
+	}
+	roles := map[string]struct{}{}
+	if scopes.has(scopeAdmin) {
+		roles[scopeAdmin] = struct{}{}
+	}
+	if scopes.has(scopeWrite) {
+		roles[scopeWrite] = struct{}{}
+	}
+	if scopes.has(scopeRead) {
+		roles[scopeRead] = struct{}{}
+	}
+	result := make([]string, 0, len(roles))
+	for role := range roles {
+		result = append(result, role)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/internal/api/authz_middleware.go
+++ b/internal/api/authz_middleware.go
@@ -10,8 +10,12 @@ import (
 )
 
 const (
+	policyActionFindingsRead   = "findings.read"
 	policyActionFindingsTriage = "findings.triage"
+	policyActionGraphRead      = "graph.read"
+	policyActionScansRead      = "scans.read"
 	policyActionScansRun       = "scans.run"
+	policyActionRepoScansRead  = "repo_scans.read"
 	policyActionRepoScansRun   = "repo_scans.run"
 )
 
@@ -25,14 +29,80 @@ type routePolicyRegistry map[string]routePolicy
 
 func newRoutePolicyRegistry() routePolicyRegistry {
 	return routePolicyRegistry{
+		routePolicyKey(http.MethodGet, "/v1/findings"): {
+			Action:       policyActionFindingsRead,
+			ResourceType: "finding",
+		},
+		routePolicyKey(http.MethodGet, "/v1/findings/:finding_id"): {
+			Action:          policyActionFindingsRead,
+			ResourceType:    "finding",
+			ResourceIDParam: "finding_id",
+		},
+		routePolicyKey(http.MethodGet, "/v1/findings/:finding_id/history"): {
+			Action:          policyActionFindingsRead,
+			ResourceType:    "finding_history",
+			ResourceIDParam: "finding_id",
+		},
+		routePolicyKey(http.MethodGet, "/v1/findings/:finding_id/exports"): {
+			Action:          policyActionFindingsRead,
+			ResourceType:    "finding_export",
+			ResourceIDParam: "finding_id",
+		},
+		routePolicyKey(http.MethodGet, "/v1/findings/trends"): {
+			Action:       policyActionFindingsRead,
+			ResourceType: "finding_trend",
+		},
+		routePolicyKey(http.MethodGet, "/v1/findings/summary"): {
+			Action:       policyActionFindingsRead,
+			ResourceType: "finding_summary",
+		},
 		routePolicyKey(http.MethodPatch, "/v1/findings/:finding_id/triage"): {
 			Action:          policyActionFindingsTriage,
 			ResourceType:    "finding",
 			ResourceIDParam: "finding_id",
 		},
+		routePolicyKey(http.MethodGet, "/v1/identities"): {
+			Action:       policyActionGraphRead,
+			ResourceType: "identity",
+		},
+		routePolicyKey(http.MethodGet, "/v1/relationships"): {
+			Action:       policyActionGraphRead,
+			ResourceType: "relationship",
+		},
+		routePolicyKey(http.MethodGet, "/v1/ownership/signals"): {
+			Action:       policyActionGraphRead,
+			ResourceType: "ownership_signal",
+		},
+		routePolicyKey(http.MethodGet, "/v1/scans"): {
+			Action:       policyActionScansRead,
+			ResourceType: "scan",
+		},
+		routePolicyKey(http.MethodGet, "/v1/scans/:scan_id/diff"): {
+			Action:          policyActionScansRead,
+			ResourceType:    "scan_diff",
+			ResourceIDParam: "scan_id",
+		},
+		routePolicyKey(http.MethodGet, "/v1/scans/:scan_id/events"): {
+			Action:          policyActionScansRead,
+			ResourceType:    "scan_event",
+			ResourceIDParam: "scan_id",
+		},
 		routePolicyKey(http.MethodPost, "/v1/scans"): {
 			Action:       policyActionScansRun,
 			ResourceType: "scan",
+		},
+		routePolicyKey(http.MethodGet, "/v1/repo-scans"): {
+			Action:       policyActionRepoScansRead,
+			ResourceType: "repo_scan",
+		},
+		routePolicyKey(http.MethodGet, "/v1/repo-scans/:repo_scan_id"): {
+			Action:          policyActionRepoScansRead,
+			ResourceType:    "repo_scan",
+			ResourceIDParam: "repo_scan_id",
+		},
+		routePolicyKey(http.MethodGet, "/v1/repo-findings"): {
+			Action:       policyActionRepoScansRead,
+			ResourceType: "repo_finding",
 		},
 		routePolicyKey(http.MethodPost, "/v1/repo-scans"): {
 			Action:       policyActionRepoScansRun,
@@ -51,10 +121,16 @@ func routePolicyKey(method string, fullPath string) string {
 }
 
 func defaultRouteActionRoleGrants() map[string][]string {
+	readRoles := []string{scopeRead, scopeWrite, scopeAdmin}
+	writeRoles := []string{scopeWrite, scopeAdmin}
 	return map[string][]string{
-		policyActionFindingsTriage: {scopeWrite, scopeAdmin},
-		policyActionScansRun:       {scopeWrite, scopeAdmin},
-		policyActionRepoScansRun:   {scopeWrite, scopeAdmin},
+		policyActionFindingsRead:   readRoles,
+		policyActionFindingsTriage: writeRoles,
+		policyActionGraphRead:      readRoles,
+		policyActionScansRead:      readRoles,
+		policyActionScansRun:       writeRoles,
+		policyActionRepoScansRead:  readRoles,
+		policyActionRepoScansRun:   writeRoles,
 	}
 }
 
@@ -67,7 +143,8 @@ func newCentralPolicyEngine() *PolicyEngine {
 	)
 }
 
-func requireCentralPolicyMiddleware(engine *PolicyEngine, registry routePolicyRegistry) gin.HandlerFunc {
+func requireCentralPolicyMiddleware(engine *PolicyEngine, registry routePolicyRegistry, writeKeys []string, scopedKeys map[string][]string) gin.HandlerFunc {
+	normalizedWriteKeys := normalizeKeyList(writeKeys)
 	return func(c *gin.Context) {
 		fullPath := strings.TrimSpace(c.FullPath())
 		if fullPath == "" {
@@ -86,7 +163,7 @@ func requireCentralPolicyMiddleware(engine *PolicyEngine, registry routePolicyRe
 			return
 		}
 
-		decision, err := engine.Decide(c.Request.Context(), buildPolicyInputFromGinContext(c, policy))
+		decision, err := engine.Decide(c.Request.Context(), buildPolicyInputFromGinContext(c, policy, normalizedWriteKeys, scopedKeys))
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "authorization failed"})
 			return
@@ -101,7 +178,7 @@ func requireCentralPolicyMiddleware(engine *PolicyEngine, registry routePolicyRe
 	}
 }
 
-func buildPolicyInputFromGinContext(c *gin.Context, policy routePolicy) PolicyInput {
+func buildPolicyInputFromGinContext(c *gin.Context, policy routePolicy, writeKeys []string, scopedKeys map[string][]string) PolicyInput {
 	scope := db.ScopeFromContext(c.Request.Context())
 	resourceID := ""
 	if strings.TrimSpace(policy.ResourceIDParam) != "" {
@@ -113,7 +190,7 @@ func buildPolicyInputFromGinContext(c *gin.Context, policy routePolicy) PolicyIn
 			ID:          authContextString(c, "auth.principal_id"),
 			TenantID:    firstNonEmpty(authContextString(c, "auth.tenant_id"), strings.TrimSpace(scope.TenantID)),
 			WorkspaceID: firstNonEmpty(authContextString(c, "auth.workspace_id"), strings.TrimSpace(scope.WorkspaceID)),
-			Roles:       policyRolesFromScope(c),
+			Roles:       policyRolesFromAuth(c, writeKeys, scopedKeys),
 		},
 		Action: strings.ToLower(strings.TrimSpace(policy.Action)),
 		Resource: PolicyResource{
@@ -144,33 +221,68 @@ func hasAuthContext(c *gin.Context) bool {
 	if c == nil {
 		return false
 	}
-	_, exists := c.Get("auth.scope_set")
-	return exists
+	if _, exists := c.Get("auth.scope_set"); exists {
+		return true
+	}
+	if authContextString(c, "auth.api_key") != "" {
+		return true
+	}
+	if authContextString(c, "auth.subject") != "" {
+		return true
+	}
+	return false
 }
 
-func policyRolesFromScope(c *gin.Context) []string {
-	scopeSetValue, exists := c.Get("auth.scope_set")
-	if !exists {
+func normalizeKeyList(keys []string) []string {
+	normalized := make([]string, 0, len(keys))
+	for _, key := range keys {
+		trimmed := strings.TrimSpace(key)
+		if trimmed == "" {
+			continue
+		}
+		normalized = append(normalized, trimmed)
+	}
+	return normalized
+}
+
+func policyRolesFromAuth(c *gin.Context, writeKeys []string, scopedKeys map[string][]string) []string {
+	if c == nil {
 		return nil
 	}
-	scopes, ok := scopeSetValue.(scopeSet)
-	if !ok {
+	if scopeSetValue, exists := c.Get("auth.scope_set"); exists {
+		scopes, ok := scopeSetValue.(scopeSet)
+		if !ok {
+			return nil
+		}
+		roles := map[string]struct{}{}
+		if scopes.has(scopeAdmin) {
+			roles[scopeAdmin] = struct{}{}
+		}
+		if scopes.has(scopeWrite) {
+			roles[scopeWrite] = struct{}{}
+		}
+		if scopes.has(scopeRead) {
+			roles[scopeRead] = struct{}{}
+		}
+		result := make([]string, 0, len(roles))
+		for role := range roles {
+			result = append(result, role)
+		}
+		sort.Strings(result)
+		return result
+	}
+
+	legacyKey := authContextString(c, "auth.api_key")
+	if legacyKey == "" {
 		return nil
 	}
-	roles := map[string]struct{}{}
-	if scopes.has(scopeAdmin) {
-		roles[scopeAdmin] = struct{}{}
+	// In scoped-key mode, the auth middleware should always set scope_set for valid keys.
+	if len(scopedKeys) > 0 {
+		return nil
 	}
-	if scopes.has(scopeWrite) {
-		roles[scopeWrite] = struct{}{}
+	roles := []string{scopeRead}
+	if keyInList(writeKeys, legacyKey) {
+		roles = append(roles, scopeWrite)
 	}
-	if scopes.has(scopeRead) {
-		roles[scopeRead] = struct{}{}
-	}
-	result := make([]string, 0, len(roles))
-	for role := range roles {
-		result = append(result, role)
-	}
-	sort.Strings(result)
-	return result
+	return roles
 }

--- a/internal/api/authz_middleware_test.go
+++ b/internal/api/authz_middleware_test.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
+	"github.com/gin-gonic/gin"
+)
+
+func TestRoutePolicyRegistryLookup(t *testing.T) {
+	registry := newRoutePolicyRegistry()
+	policy, exists := registry.lookup(http.MethodPost, "/v1/scans")
+	if !exists {
+		t.Fatal("expected policy for POST /v1/scans")
+	}
+	if policy.Action != policyActionScansRun {
+		t.Fatalf("expected scans.run action, got %q", policy.Action)
+	}
+}
+
+func TestPolicyRolesFromScope(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Set("auth.scope_set", newScopeSet([]string{scopeWrite}))
+	roles := policyRolesFromScope(c)
+	if len(roles) != 2 {
+		t.Fatalf("expected read+write roles, got %+v", roles)
+	}
+}
+
+func TestRequireCentralPolicyMiddlewareWriteDeniedForReadRole(t *testing.T) {
+	r := newPolicyTestRouter(newScopeSet([]string{scopeRead}), true)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/scans", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestRequireCentralPolicyMiddlewareWriteAllowedForWriteRole(t *testing.T) {
+	r := newPolicyTestRouter(newScopeSet([]string{scopeWrite}), true)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/scans", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+}
+
+func TestRequireCentralPolicyMiddlewareBypassWhenAuthDisabled(t *testing.T) {
+	r := newPolicyTestRouter(nil, false)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/scans", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 when auth is disabled, got %d", w.Code)
+	}
+}
+
+func newPolicyTestRouter(scopes scopeSet, setPrincipal bool) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Request = c.Request.WithContext(db.WithScope(c.Request.Context(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"}))
+		if scopes != nil {
+			c.Set("auth.scope_set", scopes)
+		}
+		if setPrincipal {
+			c.Set("auth.principal_id", "principal-1")
+		}
+		c.Next()
+	})
+	r.Use(requireCentralPolicyMiddleware(newCentralPolicyEngine(), newRoutePolicyRegistry()))
+	r.POST("/v1/scans", func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+	return r
+}

--- a/internal/api/authz_middleware_test.go
+++ b/internal/api/authz_middleware_test.go
@@ -3,10 +3,13 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
+	"github.com/Oluwatobi-Mustapha/identrail/internal/telemetry"
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
 )
 
 func TestRoutePolicyRegistryLookup(t *testing.T) {
@@ -24,9 +27,19 @@ func TestPolicyRolesFromScope(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
 	c.Set("auth.scope_set", newScopeSet([]string{scopeWrite}))
-	roles := policyRolesFromScope(c)
+	roles := policyRolesFromAuth(c, nil, nil)
 	if len(roles) != 2 {
 		t.Fatalf("expected read+write roles, got %+v", roles)
+	}
+}
+
+func TestPolicyRolesFromAuthLegacyKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Set("auth.api_key", "writer-key")
+	roles := policyRolesFromAuth(c, []string{"writer-key"}, nil)
+	if len(roles) != 2 {
+		t.Fatalf("expected legacy writer to map to read+write roles, got %+v", roles)
 	}
 }
 
@@ -60,6 +73,19 @@ func TestRequireCentralPolicyMiddlewareBypassWhenAuthDisabled(t *testing.T) {
 	}
 }
 
+func TestRoutePolicyRegistryCoversAllV1Routes(t *testing.T) {
+	registry := newRoutePolicyRegistry()
+	router := NewRouter(zap.NewNop(), telemetry.NewMetrics(), nil, RouterOptions{})
+	for _, route := range router.Routes() {
+		if !strings.HasPrefix(route.Path, "/v1/") {
+			continue
+		}
+		if _, exists := registry.lookup(route.Method, route.Path); !exists {
+			t.Fatalf("missing route policy for %s %s", route.Method, route.Path)
+		}
+	}
+}
+
 func newPolicyTestRouter(scopes scopeSet, setPrincipal bool) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
@@ -73,7 +99,7 @@ func newPolicyTestRouter(scopes scopeSet, setPrincipal bool) *gin.Engine {
 		}
 		c.Next()
 	})
-	r.Use(requireCentralPolicyMiddleware(newCentralPolicyEngine(), newRoutePolicyRegistry()))
+	r.Use(requireCentralPolicyMiddleware(newCentralPolicyEngine(), newRoutePolicyRegistry(), nil, nil))
 	r.POST("/v1/scans", func(c *gin.Context) {
 		c.Status(http.StatusNoContent)
 	})

--- a/internal/api/authz_policy.go
+++ b/internal/api/authz_policy.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// PolicyStage identifies one authorization layer in the centralized decision pipeline.
+type PolicyStage string
+
+const (
+	PolicyStageTenantIsolation PolicyStage = "tenant_isolation"
+	PolicyStageRBAC            PolicyStage = "rbac"
+	PolicyStageABAC            PolicyStage = "abac"
+	PolicyStageReBAC           PolicyStage = "rebac"
+	PolicyStageDefaultDeny     PolicyStage = "default_deny"
+)
+
+// PolicyOutcome captures one evaluator result.
+type PolicyOutcome string
+
+const (
+	PolicyOutcomeNoOpinion PolicyOutcome = "no_op"
+	PolicyOutcomeAllow     PolicyOutcome = "allow"
+	PolicyOutcomeDeny      PolicyOutcome = "deny"
+)
+
+// PolicySubject is the actor for one authorization decision.
+type PolicySubject struct {
+	Type        string
+	ID          string
+	TenantID    string
+	WorkspaceID string
+	Groups      []string
+	Roles       []string
+}
+
+// PolicyResource identifies the target object.
+type PolicyResource struct {
+	Type        string
+	ID          string
+	TenantID    string
+	WorkspaceID string
+	Attributes  map[string]string
+}
+
+// PolicyContext captures request-time facts used in policy evaluation.
+type PolicyContext struct {
+	RequestPath   string
+	RequestMethod string
+	Now           time.Time
+	Attributes    map[string]string
+}
+
+// PolicyInput is the single input model for centralized authorization.
+type PolicyInput struct {
+	Subject  PolicySubject
+	Action   string
+	Resource PolicyResource
+	Context  PolicyContext
+}
+
+// PolicyDecision is the normalized authorization outcome.
+type PolicyDecision struct {
+	Allowed bool
+	Stage   PolicyStage
+	Reason  string
+}
+
+// PolicyEvaluator evaluates one authorization layer.
+type PolicyEvaluator interface {
+	Evaluate(ctx context.Context, input PolicyInput) (PolicyOutcome, string, error)
+}
+
+// PolicyEngine evaluates authorization in strict order:
+// tenant isolation -> RBAC -> ABAC -> ReBAC -> default deny.
+type PolicyEngine struct {
+	TenantIsolationEvaluator PolicyEvaluator
+	RBACEvaluator            PolicyEvaluator
+	ABACEvaluator            PolicyEvaluator
+	ReBACEvaluator           PolicyEvaluator
+}
+
+// NewPolicyEngine creates one centralized authorization engine.
+func NewPolicyEngine(tenantIsolation PolicyEvaluator, rbac PolicyEvaluator, abac PolicyEvaluator, rebac PolicyEvaluator) *PolicyEngine {
+	return &PolicyEngine{
+		TenantIsolationEvaluator: tenantIsolation,
+		RBACEvaluator:            rbac,
+		ABACEvaluator:            abac,
+		ReBACEvaluator:           rebac,
+	}
+}
+
+// Decide evaluates authorization policies and returns one normalized decision.
+func (p *PolicyEngine) Decide(ctx context.Context, input PolicyInput) (PolicyDecision, error) {
+	if p == nil {
+		return denyDecision(PolicyStageDefaultDeny, "authorization policy engine is not configured"), nil
+	}
+	for _, stage := range []struct {
+		name      PolicyStage
+		evaluator PolicyEvaluator
+	}{
+		{name: PolicyStageTenantIsolation, evaluator: p.TenantIsolationEvaluator},
+		{name: PolicyStageRBAC, evaluator: p.RBACEvaluator},
+		{name: PolicyStageABAC, evaluator: p.ABACEvaluator},
+		{name: PolicyStageReBAC, evaluator: p.ReBACEvaluator},
+	} {
+		if stage.evaluator == nil {
+			continue
+		}
+		outcome, reason, err := stage.evaluator.Evaluate(ctx, input)
+		if err != nil {
+			return PolicyDecision{}, fmt.Errorf("evaluate %s policy: %w", stage.name, err)
+		}
+		reason = strings.TrimSpace(reason)
+		switch outcome {
+		case PolicyOutcomeAllow:
+			return PolicyDecision{Allowed: true, Stage: stage.name, Reason: reason}, nil
+		case PolicyOutcomeDeny:
+			return denyDecision(stage.name, reason), nil
+		case PolicyOutcomeNoOpinion:
+			continue
+		default:
+			return PolicyDecision{}, fmt.Errorf("evaluate %s policy: invalid outcome %q", stage.name, outcome)
+		}
+	}
+	return denyDecision(PolicyStageDefaultDeny, "no policy granted access"), nil
+}
+
+func denyDecision(stage PolicyStage, reason string) PolicyDecision {
+	message := strings.TrimSpace(reason)
+	if message == "" {
+		message = "access denied"
+	}
+	return PolicyDecision{Allowed: false, Stage: stage, Reason: message}
+}

--- a/internal/api/authz_policy_test.go
+++ b/internal/api/authz_policy_test.go
@@ -1,0 +1,150 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type testPolicyEvaluator struct {
+	name    string
+	outcome PolicyOutcome
+	reason  string
+	err     error
+	calls   *[]string
+}
+
+func (e testPolicyEvaluator) Evaluate(_ context.Context, _ PolicyInput) (PolicyOutcome, string, error) {
+	if e.calls != nil {
+		*e.calls = append(*e.calls, e.name)
+	}
+	return e.outcome, e.reason, e.err
+}
+
+func TestPolicyEngineDecideEnforcesOrderAndDefaultDeny(t *testing.T) {
+	calls := []string{}
+	engine := NewPolicyEngine(
+		testPolicyEvaluator{name: "tenant", outcome: PolicyOutcomeNoOpinion, calls: &calls},
+		testPolicyEvaluator{name: "rbac", outcome: PolicyOutcomeNoOpinion, calls: &calls},
+		testPolicyEvaluator{name: "abac", outcome: PolicyOutcomeNoOpinion, calls: &calls},
+		testPolicyEvaluator{name: "rebac", outcome: PolicyOutcomeNoOpinion, calls: &calls},
+	)
+
+	decision, err := engine.Decide(context.Background(), PolicyInput{Action: "findings.read"})
+	if err != nil {
+		t.Fatalf("decide: %v", err)
+	}
+	if decision.Allowed {
+		t.Fatalf("expected default deny decision, got %+v", decision)
+	}
+	if decision.Stage != PolicyStageDefaultDeny {
+		t.Fatalf("expected default deny stage, got %q", decision.Stage)
+	}
+	expectedCalls := []string{"tenant", "rbac", "abac", "rebac"}
+	if !reflect.DeepEqual(calls, expectedCalls) {
+		t.Fatalf("expected call order %v, got %v", expectedCalls, calls)
+	}
+}
+
+func TestPolicyEngineDecideShortCircuitsOnDeny(t *testing.T) {
+	calls := []string{}
+	engine := NewPolicyEngine(
+		testPolicyEvaluator{name: "tenant", outcome: PolicyOutcomeDeny, reason: "tenant mismatch", calls: &calls},
+		testPolicyEvaluator{name: "rbac", outcome: PolicyOutcomeAllow, calls: &calls},
+		testPolicyEvaluator{name: "abac", outcome: PolicyOutcomeAllow, calls: &calls},
+		testPolicyEvaluator{name: "rebac", outcome: PolicyOutcomeAllow, calls: &calls},
+	)
+
+	decision, err := engine.Decide(context.Background(), PolicyInput{Action: "findings.read"})
+	if err != nil {
+		t.Fatalf("decide: %v", err)
+	}
+	if decision.Allowed {
+		t.Fatalf("expected deny decision, got %+v", decision)
+	}
+	if decision.Stage != PolicyStageTenantIsolation {
+		t.Fatalf("expected tenant isolation stage, got %q", decision.Stage)
+	}
+	if decision.Reason != "tenant mismatch" {
+		t.Fatalf("expected tenant deny reason, got %q", decision.Reason)
+	}
+	expectedCalls := []string{"tenant"}
+	if !reflect.DeepEqual(calls, expectedCalls) {
+		t.Fatalf("expected call order %v, got %v", expectedCalls, calls)
+	}
+}
+
+func TestPolicyEngineDecideShortCircuitsOnAllow(t *testing.T) {
+	calls := []string{}
+	engine := NewPolicyEngine(
+		testPolicyEvaluator{name: "tenant", outcome: PolicyOutcomeNoOpinion, calls: &calls},
+		testPolicyEvaluator{name: "rbac", outcome: PolicyOutcomeAllow, reason: "role grants action", calls: &calls},
+		testPolicyEvaluator{name: "abac", outcome: PolicyOutcomeAllow, calls: &calls},
+		testPolicyEvaluator{name: "rebac", outcome: PolicyOutcomeAllow, calls: &calls},
+	)
+
+	decision, err := engine.Decide(context.Background(), PolicyInput{Action: "findings.read"})
+	if err != nil {
+		t.Fatalf("decide: %v", err)
+	}
+	if !decision.Allowed {
+		t.Fatalf("expected allow decision, got %+v", decision)
+	}
+	if decision.Stage != PolicyStageRBAC {
+		t.Fatalf("expected rbac stage, got %q", decision.Stage)
+	}
+	expectedCalls := []string{"tenant", "rbac"}
+	if !reflect.DeepEqual(calls, expectedCalls) {
+		t.Fatalf("expected call order %v, got %v", expectedCalls, calls)
+	}
+}
+
+func TestPolicyEngineDecideEvaluatorErrorIncludesStage(t *testing.T) {
+	engine := NewPolicyEngine(
+		testPolicyEvaluator{name: "tenant", outcome: PolicyOutcomeNoOpinion},
+		testPolicyEvaluator{name: "rbac", err: errors.New("db unavailable")},
+		nil,
+		nil,
+	)
+
+	_, err := engine.Decide(context.Background(), PolicyInput{Action: "findings.read"})
+	if err == nil {
+		t.Fatal("expected evaluator error")
+	}
+	if !strings.Contains(err.Error(), "rbac") {
+		t.Fatalf("expected stage name in error, got %v", err)
+	}
+}
+
+func TestPolicyEngineDecideRejectsInvalidOutcome(t *testing.T) {
+	engine := NewPolicyEngine(
+		testPolicyEvaluator{name: "tenant", outcome: PolicyOutcome("maybe")},
+		nil,
+		nil,
+		nil,
+	)
+
+	_, err := engine.Decide(context.Background(), PolicyInput{Action: "findings.read"})
+	if err == nil {
+		t.Fatal("expected invalid outcome error")
+	}
+	if !strings.Contains(err.Error(), "invalid outcome") {
+		t.Fatalf("expected invalid outcome error, got %v", err)
+	}
+}
+
+func TestPolicyEngineDecideNilEngineDefaultsToDeny(t *testing.T) {
+	var engine *PolicyEngine
+	decision, err := engine.Decide(context.Background(), PolicyInput{Action: "findings.read"})
+	if err != nil {
+		t.Fatalf("decide nil engine: %v", err)
+	}
+	if decision.Allowed {
+		t.Fatalf("expected deny decision, got %+v", decision)
+	}
+	if decision.Stage != PolicyStageDefaultDeny {
+		t.Fatalf("expected default deny stage, got %q", decision.Stage)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -109,8 +109,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 	v1 := r.Group("/v1")
 	v1.Use(apiKeyAuthMiddleware(opts.APIKeys, opts.APIKeyScopes, opts.OIDCTokenVerifier, opts.OIDCWriteScopes))
 	v1.Use(requestScopeMiddleware(opts.DefaultTenantID, opts.DefaultWorkspaceID))
-	v1.Use(requireReadableScopeMiddleware(opts.APIKeyScopes, opts.OIDCTokenVerifier))
-	v1.Use(requireCentralPolicyMiddleware(newCentralPolicyEngine(), newRoutePolicyRegistry()))
+	v1.Use(requireCentralPolicyMiddleware(newCentralPolicyEngine(), newRoutePolicyRegistry(), opts.WriteAPIKeys, opts.APIKeyScopes))
 	v1.Use(rateLimitMiddleware(opts.RateLimitRPM, opts.RateLimitBurst))
 	v1.Use(auditLogMiddleware(logger, opts.AuditSink))
 
@@ -288,7 +287,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, gin.H{"items": items})
 	})
 
-	v1.PATCH("/findings/:finding_id/triage", requireWriteKeyMiddleware(opts.WriteAPIKeys, opts.APIKeyScopes), func(c *gin.Context) {
+	v1.PATCH("/findings/:finding_id/triage", func(c *gin.Context) {
 		var request FindingTriageRequest
 		if err := c.ShouldBindJSON(&request); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
@@ -549,7 +548,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, response)
 	})
 
-	v1.POST("/scans", requireWriteKeyMiddleware(opts.WriteAPIKeys, opts.APIKeyScopes), func(c *gin.Context) {
+	v1.POST("/scans", func(c *gin.Context) {
 		start := time.Now()
 		metrics.ScanRunsTotal.Inc()
 		metrics.ScanInFlight.Inc()
@@ -575,7 +574,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		})
 	})
 
-	v1.POST("/repo-scans", requireWriteKeyMiddleware(opts.WriteAPIKeys, opts.APIKeyScopes), func(c *gin.Context) {
+	v1.POST("/repo-scans", func(c *gin.Context) {
 		start := time.Now()
 		metrics.RepoScanRunsTotal.Inc()
 		defer func() {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -110,6 +110,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 	v1.Use(apiKeyAuthMiddleware(opts.APIKeys, opts.APIKeyScopes, opts.OIDCTokenVerifier, opts.OIDCWriteScopes))
 	v1.Use(requestScopeMiddleware(opts.DefaultTenantID, opts.DefaultWorkspaceID))
 	v1.Use(requireReadableScopeMiddleware(opts.APIKeyScopes, opts.OIDCTokenVerifier))
+	v1.Use(requireCentralPolicyMiddleware(newCentralPolicyEngine(), newRoutePolicyRegistry()))
 	v1.Use(rateLimitMiddleware(opts.RateLimitRPM, opts.RateLimitBurst))
 	v1.Use(auditLogMiddleware(logger, opts.AuditSink))
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1166,60 +1166,6 @@ func apiKeyAuthMiddleware(keys []string, scopedKeys map[string][]string, tokenVe
 	}
 }
 
-func requireWriteKeyMiddleware(writeKeys []string, scopedKeys map[string][]string) gin.HandlerFunc {
-	allowed := []string{}
-	for _, key := range writeKeys {
-		trimmed := strings.TrimSpace(key)
-		if trimmed == "" {
-			continue
-		}
-		allowed = append(allowed, trimmed)
-	}
-
-	// When scoped auth exists (scoped API keys or OIDC token scopes), prefer scope-based write checks.
-	// This keeps API keys backward compatible while allowing OAuth/OIDC write scopes.
-	return func(c *gin.Context) {
-		if scopeSetValue, exists := c.Get("auth.scope_set"); exists {
-			scopes, ok := scopeSetValue.(scopeSet)
-			if !ok || !scopes.has(scopeWrite) {
-				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
-				return
-			}
-			c.Next()
-			return
-		}
-
-		if len(scopedKeys) > 0 {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
-			return
-		}
-
-		if len(allowed) == 0 {
-			// When auth middleware is disabled (test/local stubs), keep route behavior unchanged.
-			// In authenticated API-key mode, empty write-key config must not grant write access.
-			if _, exists := c.Get("auth.api_key"); exists {
-				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
-				return
-			}
-			c.Next()
-			return
-		}
-
-		apiKeyValue, exists := c.Get("auth.api_key")
-		if !exists {
-			// If API key auth is disabled, write authorization cannot be enforced.
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
-			return
-		}
-		apiKey, _ := apiKeyValue.(string)
-		if !keyInList(allowed, apiKey) {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
-			return
-		}
-		c.Next()
-	}
-}
-
 func keyInList(keys []string, candidate string) bool {
 	for _, key := range keys {
 		if secureKeyEquals(key, candidate) {
@@ -1243,36 +1189,6 @@ func secureKeyEquals(expected string, candidate string) bool {
 		return false
 	}
 	return subtle.ConstantTimeCompare([]byte(expected), []byte(candidate)) == 1
-}
-
-func requireReadableScopeMiddleware(scopedKeys map[string][]string, tokenVerifier TokenVerifier) gin.HandlerFunc {
-	if len(scopedKeys) == 0 && tokenVerifier == nil {
-		return func(c *gin.Context) { c.Next() }
-	}
-	return func(c *gin.Context) {
-		// Backward compatibility: in legacy API-key mode (no scoped keys), an API key
-		// authenticated request remains read-authorized even when OIDC is also enabled.
-		if len(scopedKeys) == 0 {
-			if _, hasAPIKey := c.Get("auth.api_key"); hasAPIKey {
-				if _, hasScopes := c.Get("auth.scope_set"); !hasScopes {
-					c.Next()
-					return
-				}
-			}
-		}
-
-		scopeSetValue, exists := c.Get("auth.scope_set")
-		if !exists {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
-			return
-		}
-		scopes, ok := scopeSetValue.(scopeSet)
-		if !ok || !scopes.has(scopeRead) {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
-			return
-		}
-		c.Next()
-	}
 }
 
 type ipRateLimiter struct {


### PR DESCRIPTION
## Summary
This is PR-5.3 in the stacked Centralized AuthZ Decision Layer rollout.

It introduces a centralized route-policy registry and PDP middleware wiring.

## Changes
- Add route-policy registry primitives
- Add centralized authorization middleware that evaluates PDP decisions for mapped routes
- Add policy input builder from request context
- Add middleware and registry tests
- Wire middleware into `/v1` request chain (incremental integration)

## Why this PR is isolated
This introduces the middleware path without the full route migration, so middleware behavior can be reviewed independently.

## Validation
- `go test ./internal/api`
- `go test ./...`

## Stack
- Base PR: #84 (`feat/authz-pdp-2-evaluators`)
- Next PR in stack: `feat/authz-pdp-4-full-migration`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a centralized route-policy registry and PDP middleware to the `/v1` chain. All protected `/v1` routes now enforce case-sensitive tenant/workspace isolation and RBAC; auth-disabled environments still bypass checks.

- **New Features**
  - Registry maps all protected `/v1` routes to actions (findings read/triage, graph reads, scans read/run, repo scans read/run).
  - Middleware builds policy input from auth context and `db.Scope`, evaluates via `PolicyEngine`, and sets `authz.stage`.
  - Default grants: `read` → read; `write`/`admin` → write.
  - Tests cover registry completeness, role extraction, and allow/deny paths.

- **Refactors**
  - Removed unreachable legacy auth middleware (`requireReadableScopeMiddleware`, `requireWriteKeyMiddleware`) and old per-route write guards to improve coverage and consolidate checks in the central PDP.

<sup>Written for commit bf3efb3088bf7693d1dafc32a35639bd825360dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

