### PR TITLE
feat(authz): PR-5.4 migrate all protected v1 routes to centralized policy enforcement

### DIFF
--- a/internal/api/authz_middleware.go
+++ b/internal/api/authz_middleware.go
@@ -10,8 +10,12 @@ import (
 )
 
 const (
+	policyActionFindingsRead   = "findings.read"
 	policyActionFindingsTriage = "findings.triage"
+	policyActionGraphRead      = "graph.read"
+	policyActionScansRead      = "scans.read"
 	policyActionScansRun       = "scans.run"
+	policyActionRepoScansRead  = "repo_scans.read"
 	policyActionRepoScansRun   = "repo_scans.run"
 )
 
@@ -25,14 +29,80 @@ type routePolicyRegistry map[string]routePolicy
 
 func newRoutePolicyRegistry() routePolicyRegistry {
 	return routePolicyRegistry{
+		routePolicyKey(http.MethodGet, "/v1/findings"): {
+			Action:       policyActionFindingsRead,
+			ResourceType: "finding",
+		},
+		routePolicyKey(http.MethodGet, "/v1/findings/:finding_id"): {
+			Action:          policyActionFindingsRead,
+			ResourceType:    "finding",
+			ResourceIDParam: "finding_id",
+		},
+		routePolicyKey(http.MethodGet, "/v1/findings/:finding_id/history"): {
+			Action:          policyActionFindingsRead,
+			ResourceType:    "finding_history",
+			ResourceIDParam: "finding_id",
+		},
+		routePolicyKey(http.MethodGet, "/v1/findings/:finding_id/exports"): {
+			Action:          policyActionFindingsRead,
+			ResourceType:    "finding_export",
+			ResourceIDParam: "finding_id",
+		},
+		routePolicyKey(http.MethodGet, "/v1/findings/trends"): {
+			Action:       policyActionFindingsRead,
+			ResourceType: "finding_trend",
+		},
+		routePolicyKey(http.MethodGet, "/v1/findings/summary"): {
+			Action:       policyActionFindingsRead,
+			ResourceType: "finding_summary",
+		},
 		routePolicyKey(http.MethodPatch, "/v1/findings/:finding_id/triage"): {
 			Action:          policyActionFindingsTriage,
 			ResourceType:    "finding",
 			ResourceIDParam: "finding_id",
 		},
+		routePolicyKey(http.MethodGet, "/v1/identities"): {
+			Action:       policyActionGraphRead,
+			ResourceType: "identity",
+		},
+		routePolicyKey(http.MethodGet, "/v1/relationships"): {
+			Action:       policyActionGraphRead,
+			ResourceType: "relationship",
+		},
+		routePolicyKey(http.MethodGet, "/v1/ownership/signals"): {
+			Action:       policyActionGraphRead,
+			ResourceType: "ownership_signal",
+		},
+		routePolicyKey(http.MethodGet, "/v1/scans"): {
+			Action:       policyActionScansRead,
+			ResourceType: "scan",
+		},
+		routePolicyKey(http.MethodGet, "/v1/scans/:scan_id/diff"): {
+			Action:          policyActionScansRead,
+			ResourceType:    "scan_diff",
+			ResourceIDParam: "scan_id",
+		},
+		routePolicyKey(http.MethodGet, "/v1/scans/:scan_id/events"): {
+			Action:          policyActionScansRead,
+			ResourceType:    "scan_event",
+			ResourceIDParam: "scan_id",
+		},
 		routePolicyKey(http.MethodPost, "/v1/scans"): {
 			Action:       policyActionScansRun,
 			ResourceType: "scan",
+		},
+		routePolicyKey(http.MethodGet, "/v1/repo-scans"): {
+			Action:       policyActionRepoScansRead,
+			ResourceType: "repo_scan",
+		},
+		routePolicyKey(http.MethodGet, "/v1/repo-scans/:repo_scan_id"): {
+			Action:          policyActionRepoScansRead,
+			ResourceType:    "repo_scan",
+			ResourceIDParam: "repo_scan_id",
+		},
+		routePolicyKey(http.MethodGet, "/v1/repo-findings"): {
+			Action:       policyActionRepoScansRead,
+			ResourceType: "repo_finding",
 		},
 		routePolicyKey(http.MethodPost, "/v1/repo-scans"): {
 			Action:       policyActionRepoScansRun,
@@ -51,10 +121,16 @@ func routePolicyKey(method string, fullPath string) string {
 }
 
 func defaultRouteActionRoleGrants() map[string][]string {
+	readRoles := []string{scopeRead, scopeWrite, scopeAdmin}
+	writeRoles := []string{scopeWrite, scopeAdmin}
 	return map[string][]string{
-		policyActionFindingsTriage: {scopeWrite, scopeAdmin},
-		policyActionScansRun:       {scopeWrite, scopeAdmin},
-		policyActionRepoScansRun:   {scopeWrite, scopeAdmin},
+		policyActionFindingsRead:   readRoles,
+		policyActionFindingsTriage: writeRoles,
+		policyActionGraphRead:      readRoles,
+		policyActionScansRead:      readRoles,
+		policyActionScansRun:       writeRoles,
+		policyActionRepoScansRead:  readRoles,
+		policyActionRepoScansRun:   writeRoles,
 	}
 }
 
@@ -67,7 +143,8 @@ func newCentralPolicyEngine() *PolicyEngine {
 	)
 }
 
-func requireCentralPolicyMiddleware(engine *PolicyEngine, registry routePolicyRegistry) gin.HandlerFunc {
+func requireCentralPolicyMiddleware(engine *PolicyEngine, registry routePolicyRegistry, writeKeys []string, scopedKeys map[string][]string) gin.HandlerFunc {
+	normalizedWriteKeys := normalizeKeyList(writeKeys)
 	return func(c *gin.Context) {
 		fullPath := strings.TrimSpace(c.FullPath())
 		if fullPath == "" {
@@ -86,7 +163,7 @@ func requireCentralPolicyMiddleware(engine *PolicyEngine, registry routePolicyRe
 			return
 		}
 
-		decision, err := engine.Decide(c.Request.Context(), buildPolicyInputFromGinContext(c, policy))
+		decision, err := engine.Decide(c.Request.Context(), buildPolicyInputFromGinContext(c, policy, normalizedWriteKeys, scopedKeys))
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "authorization failed"})
 			return
@@ -101,7 +178,7 @@ func requireCentralPolicyMiddleware(engine *PolicyEngine, registry routePolicyRe
 	}
 }
 
-func buildPolicyInputFromGinContext(c *gin.Context, policy routePolicy) PolicyInput {
+func buildPolicyInputFromGinContext(c *gin.Context, policy routePolicy, writeKeys []string, scopedKeys map[string][]string) PolicyInput {
 	scope := db.ScopeFromContext(c.Request.Context())
 	resourceID := ""
 	if strings.TrimSpace(policy.ResourceIDParam) != "" {
@@ -113,7 +190,7 @@ func buildPolicyInputFromGinContext(c *gin.Context, policy routePolicy) PolicyIn
 			ID:          authContextString(c, "auth.principal_id"),
 			TenantID:    firstNonEmpty(authContextString(c, "auth.tenant_id"), strings.TrimSpace(scope.TenantID)),
 			WorkspaceID: firstNonEmpty(authContextString(c, "auth.workspace_id"), strings.TrimSpace(scope.WorkspaceID)),
-			Roles:       policyRolesFromScope(c),
+			Roles:       policyRolesFromAuth(c, writeKeys, scopedKeys),
 		},
 		Action: strings.ToLower(strings.TrimSpace(policy.Action)),
 		Resource: PolicyResource{
@@ -144,33 +221,68 @@ func hasAuthContext(c *gin.Context) bool {
 	if c == nil {
 		return false
 	}
-	_, exists := c.Get("auth.scope_set")
-	return exists
+	if _, exists := c.Get("auth.scope_set"); exists {
+		return true
+	}
+	if authContextString(c, "auth.api_key") != "" {
+		return true
+	}
+	if authContextString(c, "auth.subject") != "" {
+		return true
+	}
+	return false
 }
 
-func policyRolesFromScope(c *gin.Context) []string {
-	scopeSetValue, exists := c.Get("auth.scope_set")
-	if !exists {
+func normalizeKeyList(keys []string) []string {
+	normalized := make([]string, 0, len(keys))
+	for _, key := range keys {
+		trimmed := strings.TrimSpace(key)
+		if trimmed == "" {
+			continue
+		}
+		normalized = append(normalized, trimmed)
+	}
+	return normalized
+}
+
+func policyRolesFromAuth(c *gin.Context, writeKeys []string, scopedKeys map[string][]string) []string {
+	if c == nil {
 		return nil
 	}
-	scopes, ok := scopeSetValue.(scopeSet)
-	if !ok {
+	if scopeSetValue, exists := c.Get("auth.scope_set"); exists {
+		scopes, ok := scopeSetValue.(scopeSet)
+		if !ok {
+			return nil
+		}
+		roles := map[string]struct{}{}
+		if scopes.has(scopeAdmin) {
+			roles[scopeAdmin] = struct{}{}
+		}
+		if scopes.has(scopeWrite) {
+			roles[scopeWrite] = struct{}{}
+		}
+		if scopes.has(scopeRead) {
+			roles[scopeRead] = struct{}{}
+		}
+		result := make([]string, 0, len(roles))
+		for role := range roles {
+			result = append(result, role)
+		}
+		sort.Strings(result)
+		return result
+	}
+
+	legacyKey := authContextString(c, "auth.api_key")
+	if legacyKey == "" {
 		return nil
 	}
-	roles := map[string]struct{}{}
-	if scopes.has(scopeAdmin) {
-		roles[scopeAdmin] = struct{}{}
+	// In scoped-key mode, the auth middleware should always set scope_set for valid keys.
+	if len(scopedKeys) > 0 {
+		return nil
 	}
-	if scopes.has(scopeWrite) {
-		roles[scopeWrite] = struct{}{}
+	roles := []string{scopeRead}
+	if keyInList(writeKeys, legacyKey) {
+		roles = append(roles, scopeWrite)
 	}
-	if scopes.has(scopeRead) {
-		roles[scopeRead] = struct{}{}
-	}
-	result := make([]string, 0, len(roles))
-	for role := range roles {
-		result = append(result, role)
-	}
-	sort.Strings(result)
-	return result
+	return roles
 }

--- a/internal/api/authz_middleware_test.go
+++ b/internal/api/authz_middleware_test.go
@@ -3,10 +3,13 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
+	"github.com/Oluwatobi-Mustapha/identrail/internal/telemetry"
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
 )
 
 func TestRoutePolicyRegistryLookup(t *testing.T) {
@@ -24,9 +27,19 @@ func TestPolicyRolesFromScope(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
 	c.Set("auth.scope_set", newScopeSet([]string{scopeWrite}))
-	roles := policyRolesFromScope(c)
+	roles := policyRolesFromAuth(c, nil, nil)
 	if len(roles) != 2 {
 		t.Fatalf("expected read+write roles, got %+v", roles)
+	}
+}
+
+func TestPolicyRolesFromAuthLegacyKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Set("auth.api_key", "writer-key")
+	roles := policyRolesFromAuth(c, []string{"writer-key"}, nil)
+	if len(roles) != 2 {
+		t.Fatalf("expected legacy writer to map to read+write roles, got %+v", roles)
 	}
 }
 
@@ -60,6 +73,19 @@ func TestRequireCentralPolicyMiddlewareBypassWhenAuthDisabled(t *testing.T) {
 	}
 }
 
+func TestRoutePolicyRegistryCoversAllV1Routes(t *testing.T) {
+	registry := newRoutePolicyRegistry()
+	router := NewRouter(zap.NewNop(), telemetry.NewMetrics(), nil, RouterOptions{})
+	for _, route := range router.Routes() {
+		if !strings.HasPrefix(route.Path, "/v1/") {
+			continue
+		}
+		if _, exists := registry.lookup(route.Method, route.Path); !exists {
+			t.Fatalf("missing route policy for %s %s", route.Method, route.Path)
+		}
+	}
+}
+
 func newPolicyTestRouter(scopes scopeSet, setPrincipal bool) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
@@ -73,7 +99,7 @@ func newPolicyTestRouter(scopes scopeSet, setPrincipal bool) *gin.Engine {
 		}
 		c.Next()
 	})
-	r.Use(requireCentralPolicyMiddleware(newCentralPolicyEngine(), newRoutePolicyRegistry()))
+	r.Use(requireCentralPolicyMiddleware(newCentralPolicyEngine(), newRoutePolicyRegistry(), nil, nil))
 	r.POST("/v1/scans", func(c *gin.Context) {
 		c.Status(http.StatusNoContent)
 	})

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -109,8 +109,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 	v1 := r.Group("/v1")
 	v1.Use(apiKeyAuthMiddleware(opts.APIKeys, opts.APIKeyScopes, opts.OIDCTokenVerifier, opts.OIDCWriteScopes))
 	v1.Use(requestScopeMiddleware(opts.DefaultTenantID, opts.DefaultWorkspaceID))
-	v1.Use(requireReadableScopeMiddleware(opts.APIKeyScopes, opts.OIDCTokenVerifier))
-	v1.Use(requireCentralPolicyMiddleware(newCentralPolicyEngine(), newRoutePolicyRegistry()))
+	v1.Use(requireCentralPolicyMiddleware(newCentralPolicyEngine(), newRoutePolicyRegistry(), opts.WriteAPIKeys, opts.APIKeyScopes))
 	v1.Use(rateLimitMiddleware(opts.RateLimitRPM, opts.RateLimitBurst))
 	v1.Use(auditLogMiddleware(logger, opts.AuditSink))
 
@@ -288,7 +287,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, gin.H{"items": items})
 	})
 
-	v1.PATCH("/findings/:finding_id/triage", requireWriteKeyMiddleware(opts.WriteAPIKeys, opts.APIKeyScopes), func(c *gin.Context) {
+	v1.PATCH("/findings/:finding_id/triage", func(c *gin.Context) {
 		var request FindingTriageRequest
 		if err := c.ShouldBindJSON(&request); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
@@ -549,7 +548,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		c.JSON(http.StatusOK, response)
 	})
 
-	v1.POST("/scans", requireWriteKeyMiddleware(opts.WriteAPIKeys, opts.APIKeyScopes), func(c *gin.Context) {
+	v1.POST("/scans", func(c *gin.Context) {
 		start := time.Now()
 		metrics.ScanRunsTotal.Inc()
 		metrics.ScanInFlight.Inc()
@@ -575,7 +574,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		})
 	})
 
-	v1.POST("/repo-scans", requireWriteKeyMiddleware(opts.WriteAPIKeys, opts.APIKeyScopes), func(c *gin.Context) {
+	v1.POST("/repo-scans", func(c *gin.Context) {
 		start := time.Now()
 		metrics.RepoScanRunsTotal.Inc()
 		defer func() {


### PR DESCRIPTION
## Summary
This is PR-5.4 in the stacked Centralized AuthZ Decision Layer rollout.

It completes migration so all protected `/v1` routes are authorized through the centralized PDP path.

## Changes
- Expand route-policy registry to cover all protected `/v1` routes
- Add read + write action grants in central RBAC evaluator mapping
- Remove scattered route-level write checks in handlers
- Remove global readable-scope middleware from `/v1` chain
- Add legacy API-key compatibility in centralized role derivation
  - legacy key => read role
  - write-key list membership => write role
- Add test that registry covers every `/v1` route

## Done Criteria Alignment
- One unified authorization input model is used by middleware PDP calls
- Evaluation order remains enforced by policy engine
- Route-level scattered auth checks are replaced by centralized middleware/PDP checks
- All protected `/v1` routes are now policy-registry backed

## Validation
- `go test ./internal/api`
- `go test ./...`

## Stack
- Base PR: #85 (`feat/authz-pdp-3-policy-middleware`)
- Final PR in this stack

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes authorization for all protected `/v1` routes behind the PDP middleware, replacing route-level checks and unifying RBAC. Adds full read/write policy coverage while preserving legacy API-key behavior.

- **New Features**
  - Added read policies for GET endpoints: findings (list/details/history/exports/trends/summary), graph (identities/relationships/ownership signals), scans (list/diff/events), repo scans, and repo findings.
  - Unified action-to-role grants: read → `read|write|admin`; run/triage → `write|admin`.
  - Legacy API keys map in middleware (default `read`; writer keys → `read`+`write`; fallback only when not using `APIKeyScopes`). Tests verify every `/v1` route has a policy and legacy writer keys get write access.

- **Refactors**
  - Removed `requireReadableScopeMiddleware` and all route-level `requireWriteKeyMiddleware` on triage and scan run paths.
  - Router passes `opts.WriteAPIKeys` and `opts.APIKeyScopes` to the PDP middleware; all authz decisions flow through it.

<sup>Written for commit 23cb884939fc6ddad153dee23eed23158c2ef2e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

