### PR TITLE
feat(authz): PR-6.1 ABAC/ReBAC data model, validation, and scoped storage

### DIFF
--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -27,6 +27,8 @@ type MemoryStore struct {
 	repoFindings map[string]domain.Finding
 
 	rawAssets     map[string]providers.RawAsset
+	authzAttrs    map[string]AuthzEntityAttributes
+	authzRels     map[string]AuthzRelationship
 	identities    map[string]domain.Identity
 	policies      map[string]domain.Policy
 	relationships map[string]domain.Relationship
@@ -47,6 +49,8 @@ func NewMemoryStore() *MemoryStore {
 		repoFindings: map[string]domain.Finding{},
 
 		rawAssets:     map[string]providers.RawAsset{},
+		authzAttrs:    map[string]AuthzEntityAttributes{},
+		authzRels:     map[string]AuthzRelationship{},
 		identities:    map[string]domain.Identity{},
 		policies:      map[string]domain.Policy{},
 		relationships: map[string]domain.Relationship{},
@@ -464,6 +468,176 @@ func (m *MemoryStore) ListFindingsByScan(ctx context.Context, scanID string, lim
 	return result, nil
 }
 
+// UpsertAuthzEntityAttributes creates or updates trusted authorization attributes.
+func (m *MemoryStore) UpsertAuthzEntityAttributes(ctx context.Context, attributes AuthzEntityAttributes) error {
+	normalized, err := NormalizeAuthzEntityAttributesForWrite(attributes)
+	if err != nil {
+		return err
+	}
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scoped := scope.Normalize()
+	normalized.TenantID = scoped.TenantID
+	normalized.WorkspaceID = scoped.WorkspaceID
+	m.authzAttrs[authzEntityScopeKey(scoped, normalized.EntityKind, normalized.EntityType, normalized.EntityID)] = normalized
+	return nil
+}
+
+// GetAuthzEntityAttributes returns trusted authorization attributes for one entity.
+func (m *MemoryStore) GetAuthzEntityAttributes(ctx context.Context, entityKind string, entityType string, entityID string) (AuthzEntityAttributes, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return AuthzEntityAttributes{}, err
+	}
+	lookup, err := NormalizeAuthzEntityAttributesForWrite(AuthzEntityAttributes{
+		EntityKind: entityKind,
+		EntityType: entityType,
+		EntityID:   entityID,
+	})
+	if err != nil {
+		return AuthzEntityAttributes{}, err
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scoped := scope.Normalize()
+	record, exists := m.authzAttrs[authzEntityScopeKey(scoped, lookup.EntityKind, lookup.EntityType, lookup.EntityID)]
+	if !exists {
+		return AuthzEntityAttributes{}, ErrNotFound
+	}
+	return record, nil
+}
+
+// UpsertAuthzRelationship creates or updates one scoped ReBAC tuple.
+func (m *MemoryStore) UpsertAuthzRelationship(ctx context.Context, relationship AuthzRelationship) error {
+	normalized, err := NormalizeAuthzRelationshipForWrite(relationship)
+	if err != nil {
+		return err
+	}
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scoped := scope.Normalize()
+	normalized.TenantID = scoped.TenantID
+	normalized.WorkspaceID = scoped.WorkspaceID
+	key := authzRelationshipScopeKey(scoped, normalized.SubjectType, normalized.SubjectID, normalized.Relation, normalized.ObjectType, normalized.ObjectID)
+	if existing, exists := m.authzRels[key]; exists {
+		normalized.CreatedAt = existing.CreatedAt
+	}
+	m.authzRels[key] = normalized
+	return nil
+}
+
+// DeleteAuthzRelationship removes one scoped ReBAC tuple.
+func (m *MemoryStore) DeleteAuthzRelationship(ctx context.Context, relationship AuthzRelationship) error {
+	normalized, err := NormalizeAuthzRelationshipForWrite(relationship)
+	if err != nil {
+		return err
+	}
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scoped := scope.Normalize()
+	key := authzRelationshipScopeKey(scoped, normalized.SubjectType, normalized.SubjectID, normalized.Relation, normalized.ObjectType, normalized.ObjectID)
+	if _, exists := m.authzRels[key]; !exists {
+		return ErrNotFound
+	}
+	delete(m.authzRels, key)
+	return nil
+}
+
+// ListAuthzRelationships returns filtered scoped ReBAC tuples.
+func (m *MemoryStore) ListAuthzRelationships(ctx context.Context, filter AuthzRelationshipFilter, limit int) ([]AuthzRelationship, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	normalizedScope := scope.Normalize()
+	subjectType := strings.ToLower(strings.TrimSpace(filter.SubjectType))
+	subjectID := strings.TrimSpace(filter.SubjectID)
+	relation := strings.ToLower(strings.TrimSpace(filter.Relation))
+	if relation != "" {
+		if _, ok := validAuthzRelationships[relation]; !ok {
+			return nil, fmt.Errorf("invalid relation value")
+		}
+	}
+	objectType := strings.ToLower(strings.TrimSpace(filter.ObjectType))
+	objectID := strings.TrimSpace(filter.ObjectID)
+	now := time.Now().UTC()
+
+	records := make([]AuthzRelationship, 0, len(m.authzRels))
+	for _, relationship := range m.authzRels {
+		if !MatchScope(normalizedScope, relationship.TenantID, relationship.WorkspaceID) {
+			continue
+		}
+		if subjectType != "" && relationship.SubjectType != subjectType {
+			continue
+		}
+		if subjectID != "" && relationship.SubjectID != subjectID {
+			continue
+		}
+		if relation != "" && relationship.Relation != relation {
+			continue
+		}
+		if objectType != "" && relationship.ObjectType != objectType {
+			continue
+		}
+		if objectID != "" && relationship.ObjectID != objectID {
+			continue
+		}
+		if !filter.IncludeExpired && relationship.ExpiresAt != nil && !relationship.ExpiresAt.After(now) {
+			continue
+		}
+		records = append(records, relationship)
+	}
+
+	sort.Slice(records, func(i, j int) bool {
+		left := records[i]
+		right := records[j]
+		if left.SubjectType != right.SubjectType {
+			return left.SubjectType < right.SubjectType
+		}
+		if left.SubjectID != right.SubjectID {
+			return left.SubjectID < right.SubjectID
+		}
+		if left.Relation != right.Relation {
+			return left.Relation < right.Relation
+		}
+		if left.ObjectType != right.ObjectType {
+			return left.ObjectType < right.ObjectType
+		}
+		if left.ObjectID != right.ObjectID {
+			return left.ObjectID < right.ObjectID
+		}
+		return left.UpdatedAt.After(right.UpdatedAt)
+	})
+	if limit > 0 && len(records) > limit {
+		records = records[:limit]
+	}
+	return records, nil
+}
+
 // ListIdentities returns identities filtered by scan/provider/type/name.
 func (m *MemoryStore) ListIdentities(ctx context.Context, filter IdentityFilter, limit int) ([]domain.Identity, error) {
 	m.mu.RLock()
@@ -622,6 +796,16 @@ func scanKeyPrefix(key string) string {
 func findingScopeKey(scope Scope, findingID string) string {
 	normalized := scope.Normalize()
 	return normalized.TenantID + "|" + normalized.WorkspaceID + "|" + strings.TrimSpace(findingID)
+}
+
+func authzEntityScopeKey(scope Scope, entityKind string, entityType string, entityID string) string {
+	normalized := scope.Normalize()
+	return normalized.TenantID + "|" + normalized.WorkspaceID + "|" + strings.ToLower(strings.TrimSpace(entityKind)) + "|" + strings.ToLower(strings.TrimSpace(entityType)) + "|" + strings.TrimSpace(entityID)
+}
+
+func authzRelationshipScopeKey(scope Scope, subjectType string, subjectID string, relation string, objectType string, objectID string) string {
+	normalized := scope.Normalize()
+	return normalized.TenantID + "|" + normalized.WorkspaceID + "|" + strings.ToLower(strings.TrimSpace(subjectType)) + "|" + strings.TrimSpace(subjectID) + "|" + strings.ToLower(strings.TrimSpace(relation)) + "|" + strings.ToLower(strings.TrimSpace(objectType)) + "|" + strings.TrimSpace(objectID)
 }
 
 func normalizeFindingTriageStateForWrite(state FindingTriageState) (FindingTriageState, error) {

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -551,3 +551,115 @@ func TestMemoryStoreRequiresScopeContext(t *testing.T) {
 		t.Fatalf("expected ErrScopeRequired, got %v", err)
 	}
 }
+
+func TestMemoryStoreAuthzEntityAttributesLifecycle(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := defaultScopeContext()
+
+	err := store.UpsertAuthzEntityAttributes(ctx, AuthzEntityAttributes{
+		EntityKind:     AuthzEntityKindResource,
+		EntityType:     "finding",
+		EntityID:       "finding-1",
+		OwnerTeam:      "platform_sec",
+		Environment:    AuthzAttributeEnvProd,
+		RiskTier:       AuthzAttributeRiskTierHigh,
+		Classification: AuthzAttributeClassificationConfidential,
+	})
+	if err != nil {
+		t.Fatalf("upsert authz attributes: %v", err)
+	}
+
+	attrs, err := store.GetAuthzEntityAttributes(ctx, AuthzEntityKindResource, "finding", "finding-1")
+	if err != nil {
+		t.Fatalf("get authz attributes: %v", err)
+	}
+	if attrs.OwnerTeam != "platform_sec" || attrs.Environment != AuthzAttributeEnvProd {
+		t.Fatalf("unexpected authz attributes: %+v", attrs)
+	}
+
+	otherScope := WithScope(ctx, Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
+	if _, err := store.GetAuthzEntityAttributes(otherScope, AuthzEntityKindResource, "finding", "finding-1"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected scoped authz attributes isolation, got %v", err)
+	}
+
+	if err := store.UpsertAuthzEntityAttributes(ctx, AuthzEntityAttributes{
+		EntityKind:  AuthzEntityKindResource,
+		EntityType:  "finding",
+		EntityID:    "finding-2",
+		Environment: "qa",
+	}); err == nil {
+		t.Fatal("expected invalid authz env error")
+	}
+}
+
+func TestMemoryStoreAuthzRelationshipLifecycle(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := defaultScopeContext()
+	expiredAt := time.Now().UTC().Add(-1 * time.Minute)
+
+	if err := store.UpsertAuthzRelationship(ctx, AuthzRelationship{
+		SubjectType: "user",
+		SubjectID:   "alice",
+		Relation:    AuthzRelationshipManages,
+		ObjectType:  "workspace",
+		ObjectID:    "workspace-1",
+		Source:      "sync",
+	}); err != nil {
+		t.Fatalf("upsert active authz relationship: %v", err)
+	}
+	if err := store.UpsertAuthzRelationship(ctx, AuthzRelationship{
+		SubjectType: "user",
+		SubjectID:   "alice",
+		Relation:    AuthzRelationshipDelegatedAdmin,
+		ObjectType:  "workspace",
+		ObjectID:    "workspace-1",
+		ExpiresAt:   &expiredAt,
+	}); err != nil {
+		t.Fatalf("upsert expired authz relationship: %v", err)
+	}
+
+	relationships, err := store.ListAuthzRelationships(ctx, AuthzRelationshipFilter{
+		SubjectType: "user",
+		SubjectID:   "alice",
+	}, 10)
+	if err != nil {
+		t.Fatalf("list active authz relationships: %v", err)
+	}
+	if len(relationships) != 1 || relationships[0].Relation != AuthzRelationshipManages {
+		t.Fatalf("unexpected active relationships: %+v", relationships)
+	}
+
+	withExpired, err := store.ListAuthzRelationships(ctx, AuthzRelationshipFilter{
+		SubjectType:    "user",
+		SubjectID:      "alice",
+		IncludeExpired: true,
+	}, 10)
+	if err != nil {
+		t.Fatalf("list relationships with expired: %v", err)
+	}
+	if len(withExpired) != 2 {
+		t.Fatalf("expected 2 relationships including expired, got %d", len(withExpired))
+	}
+
+	if err := store.DeleteAuthzRelationship(ctx, AuthzRelationship{
+		SubjectType: "user",
+		SubjectID:   "alice",
+		Relation:    AuthzRelationshipManages,
+		ObjectType:  "workspace",
+		ObjectID:    "workspace-1",
+	}); err != nil {
+		t.Fatalf("delete authz relationship: %v", err)
+	}
+
+	remaining, err := store.ListAuthzRelationships(ctx, AuthzRelationshipFilter{
+		SubjectType:    "user",
+		SubjectID:      "alice",
+		IncludeExpired: true,
+	}, 10)
+	if err != nil {
+		t.Fatalf("list remaining authz relationships: %v", err)
+	}
+	if len(remaining) != 1 || remaining[0].Relation != AuthzRelationshipDelegatedAdmin {
+		t.Fatalf("unexpected remaining relationships: %+v", remaining)
+	}
+}

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -159,3 +159,25 @@ func TestEighthMigrationContainsPostgresRLSGuardrails(t *testing.T) {
 		}
 	}
 }
+
+func TestNinthMigrationContainsAuthzABACAndReBACDataTables(t *testing.T) {
+	path := filepath.Join("..", "..", "migrations", "000009_authz_abac_rebac_data.up.sql")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	text := string(content)
+	required := []string{
+		"CREATE TABLE IF NOT EXISTS authz_entity_attributes",
+		"CREATE TABLE IF NOT EXISTS authz_relationships",
+		"idx_authz_entity_attributes_scope_kind_type",
+		"idx_authz_relationships_scope_subject_relation",
+		"CREATE POLICY authz_entity_attributes_scope_isolation",
+		"CREATE POLICY authz_relationships_scope_isolation",
+	}
+	for _, item := range required {
+		if !strings.Contains(text, item) {
+			t.Fatalf("expected authz data migration item %q", item)
+		}
+	}
+}

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -838,6 +838,247 @@ func (p *PostgresStore) ListFindingsByScan(ctx context.Context, scanID string, l
 	return findingsFromSQLRows(rows)
 }
 
+// UpsertAuthzEntityAttributes creates or updates trusted authorization attributes.
+func (p *PostgresStore) UpsertAuthzEntityAttributes(ctx context.Context, attributes AuthzEntityAttributes) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	normalized, err := NormalizeAuthzEntityAttributesForWrite(attributes)
+	if err != nil {
+		return err
+	}
+	normalized.TenantID = scope.TenantID
+	normalized.WorkspaceID = scope.WorkspaceID
+
+	_, err = p.execContext(
+		ctx,
+		`INSERT INTO authz_entity_attributes (
+			tenant_id, workspace_id, entity_kind, entity_type, entity_id, owner_team, env, risk_tier, classification, updated_at
+		) VALUES ($1, $2, $3, $4, $5, NULLIF($6, ''), NULLIF($7, ''), NULLIF($8, ''), NULLIF($9, ''), $10)
+		ON CONFLICT (tenant_id, workspace_id, entity_kind, entity_type, entity_id)
+		DO UPDATE SET
+			owner_team = EXCLUDED.owner_team,
+			env = EXCLUDED.env,
+			risk_tier = EXCLUDED.risk_tier,
+			classification = EXCLUDED.classification,
+			updated_at = EXCLUDED.updated_at`,
+		normalized.TenantID,
+		normalized.WorkspaceID,
+		normalized.EntityKind,
+		normalized.EntityType,
+		normalized.EntityID,
+		normalized.OwnerTeam,
+		normalized.Environment,
+		normalized.RiskTier,
+		normalized.Classification,
+		normalized.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert authz entity attributes: %w", err)
+	}
+	return nil
+}
+
+// GetAuthzEntityAttributes returns trusted authorization attributes for one entity.
+func (p *PostgresStore) GetAuthzEntityAttributes(ctx context.Context, entityKind string, entityType string, entityID string) (AuthzEntityAttributes, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return AuthzEntityAttributes{}, err
+	}
+	normalized, err := NormalizeAuthzEntityAttributesForWrite(AuthzEntityAttributes{
+		EntityKind: entityKind,
+		EntityType: entityType,
+		EntityID:   entityID,
+	})
+	if err != nil {
+		return AuthzEntityAttributes{}, err
+	}
+
+	row := p.queryRowContext(
+		ctx,
+		`SELECT tenant_id, workspace_id, entity_kind, entity_type, entity_id, COALESCE(owner_team, ''), COALESCE(env, ''), COALESCE(risk_tier, ''), COALESCE(classification, ''), updated_at
+		 FROM authz_entity_attributes
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND entity_kind = $3
+		   AND entity_type = $4
+		   AND entity_id = $5`,
+		scope.TenantID,
+		scope.WorkspaceID,
+		normalized.EntityKind,
+		normalized.EntityType,
+		normalized.EntityID,
+	)
+	record, err := scanAuthzEntityAttributes(row)
+	if err != nil {
+		if errorsIsNoRows(err) {
+			return AuthzEntityAttributes{}, ErrNotFound
+		}
+		return AuthzEntityAttributes{}, fmt.Errorf("query authz entity attributes: %w", err)
+	}
+	return record, nil
+}
+
+// UpsertAuthzRelationship creates or updates one scoped ReBAC tuple.
+func (p *PostgresStore) UpsertAuthzRelationship(ctx context.Context, relationship AuthzRelationship) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	normalized, err := NormalizeAuthzRelationshipForWrite(relationship)
+	if err != nil {
+		return err
+	}
+	normalized.TenantID = scope.TenantID
+	normalized.WorkspaceID = scope.WorkspaceID
+
+	_, err = p.execContext(
+		ctx,
+		`INSERT INTO authz_relationships (
+			tenant_id, workspace_id, subject_type, subject_id, relation, object_type, object_id, source, expires_at, created_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		ON CONFLICT (tenant_id, workspace_id, subject_type, subject_id, relation, object_type, object_id)
+		DO UPDATE SET
+			source = EXCLUDED.source,
+			expires_at = EXCLUDED.expires_at,
+			updated_at = EXCLUDED.updated_at`,
+		normalized.TenantID,
+		normalized.WorkspaceID,
+		normalized.SubjectType,
+		normalized.SubjectID,
+		normalized.Relation,
+		normalized.ObjectType,
+		normalized.ObjectID,
+		normalized.Source,
+		normalized.ExpiresAt,
+		normalized.CreatedAt,
+		normalized.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert authz relationship: %w", err)
+	}
+	return nil
+}
+
+// DeleteAuthzRelationship removes one scoped ReBAC tuple.
+func (p *PostgresStore) DeleteAuthzRelationship(ctx context.Context, relationship AuthzRelationship) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	normalized, err := NormalizeAuthzRelationshipForWrite(relationship)
+	if err != nil {
+		return err
+	}
+	result, err := p.execContext(
+		ctx,
+		`DELETE FROM authz_relationships
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND subject_type = $3
+		   AND subject_id = $4
+		   AND relation = $5
+		   AND object_type = $6
+		   AND object_id = $7`,
+		scope.TenantID,
+		scope.WorkspaceID,
+		normalized.SubjectType,
+		normalized.SubjectID,
+		normalized.Relation,
+		normalized.ObjectType,
+		normalized.ObjectID,
+	)
+	if err != nil {
+		return fmt.Errorf("delete authz relationship: %w", err)
+	}
+	if err := ensureRowsAffected(result); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ListAuthzRelationships returns scoped ReBAC tuples using optional filters.
+func (p *PostgresStore) ListAuthzRelationships(ctx context.Context, filter AuthzRelationshipFilter, limit int) ([]AuthzRelationship, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	subjectType := strings.ToLower(strings.TrimSpace(filter.SubjectType))
+	subjectID := strings.TrimSpace(filter.SubjectID)
+	relation := strings.ToLower(strings.TrimSpace(filter.Relation))
+	if relation != "" {
+		if _, ok := validAuthzRelationships[relation]; !ok {
+			return nil, fmt.Errorf("invalid relation value")
+		}
+	}
+	objectType := strings.ToLower(strings.TrimSpace(filter.ObjectType))
+	objectID := strings.TrimSpace(filter.ObjectID)
+
+	args := []any{scope.TenantID, scope.WorkspaceID}
+	query := strings.Builder{}
+	query.WriteString(`SELECT tenant_id, workspace_id, subject_type, subject_id, relation, object_type, object_id, source, expires_at, created_at, updated_at
+		FROM authz_relationships
+		WHERE tenant_id = $1
+		  AND workspace_id = $2`)
+
+	next := 3
+	if subjectType != "" {
+		query.WriteString(fmt.Sprintf(" AND subject_type = $%d", next))
+		args = append(args, subjectType)
+		next++
+	}
+	if subjectID != "" {
+		query.WriteString(fmt.Sprintf(" AND subject_id = $%d", next))
+		args = append(args, subjectID)
+		next++
+	}
+	if relation != "" {
+		query.WriteString(fmt.Sprintf(" AND relation = $%d", next))
+		args = append(args, relation)
+		next++
+	}
+	if objectType != "" {
+		query.WriteString(fmt.Sprintf(" AND object_type = $%d", next))
+		args = append(args, objectType)
+		next++
+	}
+	if objectID != "" {
+		query.WriteString(fmt.Sprintf(" AND object_id = $%d", next))
+		args = append(args, objectID)
+		next++
+	}
+	if !filter.IncludeExpired {
+		query.WriteString(fmt.Sprintf(" AND (expires_at IS NULL OR expires_at > $%d)", next))
+		args = append(args, time.Now().UTC())
+		next++
+	}
+	query.WriteString(" ORDER BY subject_type ASC, subject_id ASC, relation ASC, object_type ASC, object_id ASC")
+	if limit > 0 {
+		query.WriteString(fmt.Sprintf(" LIMIT $%d", next))
+		args = append(args, limit)
+	}
+
+	rows, err := p.queryContext(ctx, query.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("query authz relationships: %w", err)
+	}
+	defer rows.Close()
+
+	result := []AuthzRelationship{}
+	for rows.Next() {
+		record, scanErr := scanAuthzRelationship(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("authz relationship row: %w", scanErr)
+		}
+		result = append(result, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("authz relationship rows: %w", err)
+	}
+	return result, nil
+}
+
 // ListIdentities returns identities filtered by scan/provider/type/name prefix.
 func (p *PostgresStore) ListIdentities(ctx context.Context, filter IdentityFilter, limit int) ([]domain.Identity, error) {
 	if limit <= 0 {
@@ -1761,6 +2002,53 @@ func scanScanRecord(scanner scanner) (ScanRecord, error) {
 		finished := finishedAt.Time.UTC()
 		record.FinishedAt = &finished
 	}
+	return record, nil
+}
+
+func scanAuthzEntityAttributes(scanner scanner) (AuthzEntityAttributes, error) {
+	var record AuthzEntityAttributes
+	if err := scanner.Scan(
+		&record.TenantID,
+		&record.WorkspaceID,
+		&record.EntityKind,
+		&record.EntityType,
+		&record.EntityID,
+		&record.OwnerTeam,
+		&record.Environment,
+		&record.RiskTier,
+		&record.Classification,
+		&record.UpdatedAt,
+	); err != nil {
+		return AuthzEntityAttributes{}, err
+	}
+	record.UpdatedAt = record.UpdatedAt.UTC()
+	return record, nil
+}
+
+func scanAuthzRelationship(scanner scanner) (AuthzRelationship, error) {
+	var record AuthzRelationship
+	var expiresAt sql.NullTime
+	if err := scanner.Scan(
+		&record.TenantID,
+		&record.WorkspaceID,
+		&record.SubjectType,
+		&record.SubjectID,
+		&record.Relation,
+		&record.ObjectType,
+		&record.ObjectID,
+		&record.Source,
+		&expiresAt,
+		&record.CreatedAt,
+		&record.UpdatedAt,
+	); err != nil {
+		return AuthzRelationship{}, err
+	}
+	if expiresAt.Valid {
+		converted := expiresAt.Time.UTC()
+		record.ExpiresAt = &converted
+	}
+	record.CreatedAt = record.CreatedAt.UTC()
+	record.UpdatedAt = record.UpdatedAt.UTC()
 	return record, nil
 }
 

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -808,6 +808,218 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 	}
 }
 
+func TestPostgresStoreAuthzEntityAttributesLifecycle(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	mock.ExpectExec("INSERT INTO authz_entity_attributes").
+		WithArgs(
+			"default",
+			"default",
+			AuthzEntityKindResource,
+			"finding",
+			"finding-1",
+			"platform_sec",
+			AuthzAttributeEnvProd,
+			AuthzAttributeRiskTierHigh,
+			AuthzAttributeClassificationConfidential,
+			sqlmock.AnyArg(),
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := store.UpsertAuthzEntityAttributes(defaultScopeContext(), AuthzEntityAttributes{
+		EntityKind:     AuthzEntityKindResource,
+		EntityType:     "finding",
+		EntityID:       "finding-1",
+		OwnerTeam:      "platform_sec",
+		Environment:    AuthzAttributeEnvProd,
+		RiskTier:       AuthzAttributeRiskTierHigh,
+		Classification: AuthzAttributeClassificationConfidential,
+	}); err != nil {
+		t.Fatalf("upsert authz attributes: %v", err)
+	}
+
+	now := time.Now().UTC()
+	rows := sqlmock.NewRows([]string{
+		"tenant_id",
+		"workspace_id",
+		"entity_kind",
+		"entity_type",
+		"entity_id",
+		"owner_team",
+		"env",
+		"risk_tier",
+		"classification",
+		"updated_at",
+	}).AddRow("default", "default", AuthzEntityKindResource, "finding", "finding-1", "platform_sec", AuthzAttributeEnvProd, AuthzAttributeRiskTierHigh, AuthzAttributeClassificationConfidential, now)
+	mock.ExpectQuery("SELECT tenant_id, workspace_id, entity_kind, entity_type, entity_id").
+		WithArgs("default", "default", AuthzEntityKindResource, "finding", "finding-1").
+		WillReturnRows(rows)
+
+	record, err := store.GetAuthzEntityAttributes(defaultScopeContext(), AuthzEntityKindResource, "finding", "finding-1")
+	if err != nil {
+		t.Fatalf("get authz attributes: %v", err)
+	}
+	if record.OwnerTeam != "platform_sec" || record.Environment != AuthzAttributeEnvProd {
+		t.Fatalf("unexpected authz attributes %+v", record)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreAuthzRelationshipLifecycle(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	mock.ExpectExec("INSERT INTO authz_relationships").
+		WithArgs(
+			"default",
+			"default",
+			"user",
+			"alice",
+			AuthzRelationshipManages,
+			"workspace",
+			"workspace-1",
+			"sync",
+			nil,
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := store.UpsertAuthzRelationship(defaultScopeContext(), AuthzRelationship{
+		SubjectType: "user",
+		SubjectID:   "alice",
+		Relation:    AuthzRelationshipManages,
+		ObjectType:  "workspace",
+		ObjectID:    "workspace-1",
+		Source:      "sync",
+	}); err != nil {
+		t.Fatalf("upsert authz relationship: %v", err)
+	}
+
+	now := time.Now().UTC()
+	rows := sqlmock.NewRows([]string{
+		"tenant_id",
+		"workspace_id",
+		"subject_type",
+		"subject_id",
+		"relation",
+		"object_type",
+		"object_id",
+		"source",
+		"expires_at",
+		"created_at",
+		"updated_at",
+	}).AddRow("default", "default", "user", "alice", AuthzRelationshipManages, "workspace", "workspace-1", "sync", nil, now, now)
+	mock.ExpectQuery("SELECT tenant_id, workspace_id, subject_type, subject_id, relation, object_type, object_id, source, expires_at, created_at, updated_at").
+		WithArgs("default", "default", "user", "alice", sqlmock.AnyArg(), 10).
+		WillReturnRows(rows)
+
+	relationships, err := store.ListAuthzRelationships(defaultScopeContext(), AuthzRelationshipFilter{
+		SubjectType: "user",
+		SubjectID:   "alice",
+	}, 10)
+	if err != nil {
+		t.Fatalf("list authz relationships: %v", err)
+	}
+	if len(relationships) != 1 || relationships[0].Relation != AuthzRelationshipManages {
+		t.Fatalf("unexpected authz relationships: %+v", relationships)
+	}
+
+	mock.ExpectExec("DELETE FROM authz_relationships").
+		WithArgs("default", "default", "user", "alice", AuthzRelationshipManages, "workspace", "workspace-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := store.DeleteAuthzRelationship(defaultScopeContext(), AuthzRelationship{
+		SubjectType: "user",
+		SubjectID:   "alice",
+		Relation:    AuthzRelationshipManages,
+		ObjectType:  "workspace",
+		ObjectID:    "workspace-1",
+	}); err != nil {
+		t.Fatalf("delete authz relationship: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreListAuthzRelationshipsWithFullFilters(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	now := time.Now().UTC()
+	rows := sqlmock.NewRows([]string{
+		"tenant_id",
+		"workspace_id",
+		"subject_type",
+		"subject_id",
+		"relation",
+		"object_type",
+		"object_id",
+		"source",
+		"expires_at",
+		"created_at",
+		"updated_at",
+	}).AddRow("default", "default", "user", "alice", AuthzRelationshipManages, "workspace", "workspace-1", "manual", now, now, now)
+	mock.ExpectQuery("SELECT tenant_id, workspace_id, subject_type, subject_id, relation, object_type, object_id, source, expires_at, created_at, updated_at").
+		WithArgs("default", "default", "user", "alice", AuthzRelationshipManages, "workspace", "workspace-1").
+		WillReturnRows(rows)
+
+	relationships, err := store.ListAuthzRelationships(defaultScopeContext(), AuthzRelationshipFilter{
+		SubjectType:    "user",
+		SubjectID:      "alice",
+		Relation:       AuthzRelationshipManages,
+		ObjectType:     "workspace",
+		ObjectID:       "workspace-1",
+		IncludeExpired: true,
+	}, 0)
+	if err != nil {
+		t.Fatalf("list authz relationships with full filters: %v", err)
+	}
+	if len(relationships) != 1 {
+		t.Fatalf("expected one relationship, got %d", len(relationships))
+	}
+	if relationships[0].ExpiresAt == nil {
+		t.Fatalf("expected expires_at to be populated")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreListAuthzRelationshipsRejectsInvalidRelationFilter(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	if _, err := store.ListAuthzRelationships(defaultScopeContext(), AuthzRelationshipFilter{
+		Relation: "viewer",
+	}, 10); err == nil {
+		t.Fatal("expected invalid relation filter error")
+	}
+}
+
 func TestPostgresStoreInjectScopeCTEBypassWhenDisabled(t *testing.T) {
 	store := &PostgresStore{}
 	query := "SELECT id FROM scans WHERE tenant_id = $1"

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -3,6 +3,9 @@ package db
 import (
 	"context"
 	"errors"
+	"fmt"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/Oluwatobi-Mustapha/identrail/internal/domain"
@@ -14,6 +17,8 @@ var ErrNotFound = errors.New("record not found")
 
 // ErrScopeRequired indicates tenant/workspace scope must be provided in context.
 var ErrScopeRequired = errors.New("scope is required")
+
+var authzOwnerTeamPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
 
 const (
 	ScanEventLevelDebug = "debug"
@@ -28,7 +33,65 @@ const (
 	FindingTriageActionAssigned     = "assignee_updated"
 	FindingTriageActionSuppression  = "suppression_updated"
 	FindingTriageActionCommented    = "commented"
+
+	AuthzEntityKindSubject  = "subject"
+	AuthzEntityKindResource = "resource"
+
+	AuthzAttributeEnvProd    = "prod"
+	AuthzAttributeEnvStaging = "staging"
+	AuthzAttributeEnvDev     = "dev"
+	AuthzAttributeEnvTest    = "test"
+	AuthzAttributeEnvSandbox = "sandbox"
+
+	AuthzAttributeRiskTierLow      = "low"
+	AuthzAttributeRiskTierMedium   = "medium"
+	AuthzAttributeRiskTierHigh     = "high"
+	AuthzAttributeRiskTierCritical = "critical"
+
+	AuthzAttributeClassificationPublic       = "public"
+	AuthzAttributeClassificationInternal     = "internal"
+	AuthzAttributeClassificationConfidential = "confidential"
+	AuthzAttributeClassificationRestricted   = "restricted"
+
+	AuthzRelationshipOwns           = "owns"
+	AuthzRelationshipManages        = "manages"
+	AuthzRelationshipDelegatedAdmin = "delegated_admin"
+	AuthzRelationshipMemberOf       = "member_of"
 )
+
+var validAuthzEntityKinds = map[string]struct{}{
+	AuthzEntityKindSubject:  {},
+	AuthzEntityKindResource: {},
+}
+
+var validAuthzEnvironments = map[string]struct{}{
+	AuthzAttributeEnvProd:    {},
+	AuthzAttributeEnvStaging: {},
+	AuthzAttributeEnvDev:     {},
+	AuthzAttributeEnvTest:    {},
+	AuthzAttributeEnvSandbox: {},
+}
+
+var validAuthzRiskTiers = map[string]struct{}{
+	AuthzAttributeRiskTierLow:      {},
+	AuthzAttributeRiskTierMedium:   {},
+	AuthzAttributeRiskTierHigh:     {},
+	AuthzAttributeRiskTierCritical: {},
+}
+
+var validAuthzClassifications = map[string]struct{}{
+	AuthzAttributeClassificationPublic:       {},
+	AuthzAttributeClassificationInternal:     {},
+	AuthzAttributeClassificationConfidential: {},
+	AuthzAttributeClassificationRestricted:   {},
+}
+
+var validAuthzRelationships = map[string]struct{}{
+	AuthzRelationshipOwns:           {},
+	AuthzRelationshipManages:        {},
+	AuthzRelationshipDelegatedAdmin: {},
+	AuthzRelationshipMemberOf:       {},
+}
 
 // ScanRecord tracks persisted scan execution metadata.
 type ScanRecord struct {
@@ -104,6 +167,45 @@ type FindingTriageEvent struct {
 	CreatedAt            time.Time                     `json:"created_at"`
 }
 
+// AuthzEntityAttributes stores trusted policy attributes for one subject or resource.
+type AuthzEntityAttributes struct {
+	TenantID       string    `json:"-"`
+	WorkspaceID    string    `json:"-"`
+	EntityKind     string    `json:"entity_kind"`
+	EntityType     string    `json:"entity_type"`
+	EntityID       string    `json:"entity_id"`
+	OwnerTeam      string    `json:"owner_team,omitempty"`
+	Environment    string    `json:"env,omitempty"`
+	RiskTier       string    `json:"risk_tier,omitempty"`
+	Classification string    `json:"classification,omitempty"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+// AuthzRelationship stores one directional relation tuple used by ReBAC checks.
+type AuthzRelationship struct {
+	TenantID    string     `json:"-"`
+	WorkspaceID string     `json:"-"`
+	SubjectType string     `json:"subject_type"`
+	SubjectID   string     `json:"subject_id"`
+	Relation    string     `json:"relation"`
+	ObjectType  string     `json:"object_type"`
+	ObjectID    string     `json:"object_id"`
+	Source      string     `json:"source,omitempty"`
+	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+}
+
+// AuthzRelationshipFilter controls scoped ReBAC tuple listing.
+type AuthzRelationshipFilter struct {
+	SubjectType    string
+	SubjectID      string
+	Relation       string
+	ObjectType     string
+	ObjectID       string
+	IncludeExpired bool
+}
+
 // NormalizeScanEventLevel validates and normalizes event levels.
 func NormalizeScanEventLevel(level string) (string, error) {
 	switch level {
@@ -112,6 +214,95 @@ func NormalizeScanEventLevel(level string) (string, error) {
 	default:
 		return "", errors.New("invalid scan event level")
 	}
+}
+
+// NormalizeAuthzEntityAttributesForWrite validates and canonicalizes trusted authz attributes.
+func NormalizeAuthzEntityAttributesForWrite(attrs AuthzEntityAttributes) (AuthzEntityAttributes, error) {
+	normalized := attrs
+	normalized.EntityKind = strings.ToLower(strings.TrimSpace(attrs.EntityKind))
+	if _, ok := validAuthzEntityKinds[normalized.EntityKind]; !ok {
+		return AuthzEntityAttributes{}, fmt.Errorf("invalid authz entity kind")
+	}
+	normalized.EntityType = strings.ToLower(strings.TrimSpace(attrs.EntityType))
+	if normalized.EntityType == "" {
+		return AuthzEntityAttributes{}, fmt.Errorf("entity type is required")
+	}
+	normalized.EntityID = strings.TrimSpace(attrs.EntityID)
+	if normalized.EntityID == "" {
+		return AuthzEntityAttributes{}, fmt.Errorf("entity id is required")
+	}
+	normalized.OwnerTeam = strings.ToLower(strings.TrimSpace(attrs.OwnerTeam))
+	if normalized.OwnerTeam != "" && !authzOwnerTeamPattern.MatchString(normalized.OwnerTeam) {
+		return AuthzEntityAttributes{}, fmt.Errorf("invalid owner_team format")
+	}
+	normalized.Environment = strings.ToLower(strings.TrimSpace(attrs.Environment))
+	if normalized.Environment != "" {
+		if _, ok := validAuthzEnvironments[normalized.Environment]; !ok {
+			return AuthzEntityAttributes{}, fmt.Errorf("invalid env value")
+		}
+	}
+	normalized.RiskTier = strings.ToLower(strings.TrimSpace(attrs.RiskTier))
+	if normalized.RiskTier != "" {
+		if _, ok := validAuthzRiskTiers[normalized.RiskTier]; !ok {
+			return AuthzEntityAttributes{}, fmt.Errorf("invalid risk_tier value")
+		}
+	}
+	normalized.Classification = strings.ToLower(strings.TrimSpace(attrs.Classification))
+	if normalized.Classification != "" {
+		if _, ok := validAuthzClassifications[normalized.Classification]; !ok {
+			return AuthzEntityAttributes{}, fmt.Errorf("invalid classification value")
+		}
+	}
+	if normalized.UpdatedAt.IsZero() {
+		normalized.UpdatedAt = time.Now().UTC()
+	} else {
+		normalized.UpdatedAt = normalized.UpdatedAt.UTC()
+	}
+	return normalized, nil
+}
+
+// NormalizeAuthzRelationshipForWrite validates and canonicalizes relationship tuples.
+func NormalizeAuthzRelationshipForWrite(relationship AuthzRelationship) (AuthzRelationship, error) {
+	normalized := relationship
+	normalized.SubjectType = strings.ToLower(strings.TrimSpace(relationship.SubjectType))
+	if normalized.SubjectType == "" {
+		return AuthzRelationship{}, fmt.Errorf("subject type is required")
+	}
+	normalized.SubjectID = strings.TrimSpace(relationship.SubjectID)
+	if normalized.SubjectID == "" {
+		return AuthzRelationship{}, fmt.Errorf("subject id is required")
+	}
+	normalized.Relation = strings.ToLower(strings.TrimSpace(relationship.Relation))
+	if _, ok := validAuthzRelationships[normalized.Relation]; !ok {
+		return AuthzRelationship{}, fmt.Errorf("invalid relation value")
+	}
+	normalized.ObjectType = strings.ToLower(strings.TrimSpace(relationship.ObjectType))
+	if normalized.ObjectType == "" {
+		return AuthzRelationship{}, fmt.Errorf("object type is required")
+	}
+	normalized.ObjectID = strings.TrimSpace(relationship.ObjectID)
+	if normalized.ObjectID == "" {
+		return AuthzRelationship{}, fmt.Errorf("object id is required")
+	}
+	normalized.Source = strings.ToLower(strings.TrimSpace(relationship.Source))
+	if normalized.Source == "" {
+		normalized.Source = "manual"
+	}
+	if normalized.ExpiresAt != nil {
+		utc := normalized.ExpiresAt.UTC()
+		normalized.ExpiresAt = &utc
+	}
+	if normalized.CreatedAt.IsZero() {
+		normalized.CreatedAt = time.Now().UTC()
+	} else {
+		normalized.CreatedAt = normalized.CreatedAt.UTC()
+	}
+	if normalized.UpdatedAt.IsZero() {
+		normalized.UpdatedAt = normalized.CreatedAt
+	} else {
+		normalized.UpdatedAt = normalized.UpdatedAt.UTC()
+	}
+	return normalized, nil
 }
 
 // IdentityFilter controls identity list query shape.
@@ -156,6 +347,11 @@ type Store interface {
 	ListScans(ctx context.Context, limit int) ([]ScanRecord, error)
 	ListFindings(ctx context.Context, limit int) ([]domain.Finding, error)
 	ListFindingsByScan(ctx context.Context, scanID string, limit int) ([]domain.Finding, error)
+	UpsertAuthzEntityAttributes(ctx context.Context, attributes AuthzEntityAttributes) error
+	GetAuthzEntityAttributes(ctx context.Context, entityKind string, entityType string, entityID string) (AuthzEntityAttributes, error)
+	UpsertAuthzRelationship(ctx context.Context, relationship AuthzRelationship) error
+	DeleteAuthzRelationship(ctx context.Context, relationship AuthzRelationship) error
+	ListAuthzRelationships(ctx context.Context, filter AuthzRelationshipFilter, limit int) ([]AuthzRelationship, error)
 	ListIdentities(ctx context.Context, filter IdentityFilter, limit int) ([]domain.Identity, error)
 	ListRelationships(ctx context.Context, filter RelationshipFilter, limit int) ([]domain.Relationship, error)
 	AppendScanEvent(ctx context.Context, scanID string, level string, message string, metadata map[string]any) error

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -1,6 +1,9 @@
 package db
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestNormalizeScanEventLevel(t *testing.T) {
 	cases := []string{ScanEventLevelDebug, ScanEventLevelInfo, ScanEventLevelWarn, ScanEventLevelError}
@@ -27,5 +30,112 @@ func TestStoreCloseHelpers(t *testing.T) {
 	postgres := &PostgresStore{}
 	if err := postgres.Close(); err != nil {
 		t.Fatalf("nil postgres close failed: %v", err)
+	}
+}
+
+func TestNormalizeAuthzEntityAttributesForWrite(t *testing.T) {
+	normalized, err := NormalizeAuthzEntityAttributesForWrite(AuthzEntityAttributes{
+		EntityKind:     "RESOURCE",
+		EntityType:     "Finding",
+		EntityID:       "finding-1",
+		OwnerTeam:      "Platform_Sec",
+		Environment:    "Prod",
+		RiskTier:       "High",
+		Classification: "Confidential",
+		UpdatedAt:      time.Date(2026, 4, 8, 12, 0, 0, 0, time.FixedZone("WAT", 1*60*60)),
+	})
+	if err != nil {
+		t.Fatalf("normalize entity attributes failed: %v", err)
+	}
+	if normalized.EntityKind != AuthzEntityKindResource {
+		t.Fatalf("expected entity kind %q, got %q", AuthzEntityKindResource, normalized.EntityKind)
+	}
+	if normalized.OwnerTeam != "platform_sec" {
+		t.Fatalf("expected owner team normalized to lower case, got %q", normalized.OwnerTeam)
+	}
+	if normalized.Environment != AuthzAttributeEnvProd {
+		t.Fatalf("expected env %q, got %q", AuthzAttributeEnvProd, normalized.Environment)
+	}
+	if normalized.UpdatedAt.Location() != time.UTC {
+		t.Fatalf("expected UTC updated_at, got %v", normalized.UpdatedAt.Location())
+	}
+
+	if _, err := NormalizeAuthzEntityAttributesForWrite(AuthzEntityAttributes{
+		EntityKind:  AuthzEntityKindResource,
+		EntityType:  "finding",
+		EntityID:    "finding-1",
+		Environment: "qa",
+	}); err == nil {
+		t.Fatal("expected invalid env error")
+	}
+
+	if _, err := NormalizeAuthzEntityAttributesForWrite(AuthzEntityAttributes{
+		EntityKind: AuthzEntityKindSubject,
+		EntityType: "user",
+		EntityID:   "alice",
+		OwnerTeam:  "platform sec",
+	}); err == nil {
+		t.Fatal("expected invalid owner_team format error")
+	}
+
+	implicitTime, err := NormalizeAuthzEntityAttributesForWrite(AuthzEntityAttributes{
+		EntityKind: AuthzEntityKindSubject,
+		EntityType: "user",
+		EntityID:   "alice",
+	})
+	if err != nil {
+		t.Fatalf("expected valid subject attrs with generated updated_at, got %v", err)
+	}
+	if implicitTime.UpdatedAt.IsZero() {
+		t.Fatal("expected non-zero generated updated_at")
+	}
+}
+
+func TestNormalizeAuthzRelationshipForWrite(t *testing.T) {
+	expiresAt := time.Date(2026, 4, 9, 12, 0, 0, 0, time.FixedZone("WAT", 1*60*60))
+	normalized, err := NormalizeAuthzRelationshipForWrite(AuthzRelationship{
+		SubjectType: "user",
+		SubjectID:   "user-1",
+		Relation:    "MANAGES",
+		ObjectType:  "workspace",
+		ObjectID:    "workspace-1",
+		Source:      "SYNC",
+		ExpiresAt:   &expiresAt,
+	})
+	if err != nil {
+		t.Fatalf("normalize relationship failed: %v", err)
+	}
+	if normalized.Relation != AuthzRelationshipManages {
+		t.Fatalf("expected relation %q, got %q", AuthzRelationshipManages, normalized.Relation)
+	}
+	if normalized.Source != "sync" {
+		t.Fatalf("expected source lower-cased, got %q", normalized.Source)
+	}
+	if normalized.ExpiresAt == nil || normalized.ExpiresAt.Location() != time.UTC {
+		t.Fatalf("expected UTC expires_at, got %+v", normalized.ExpiresAt)
+	}
+
+	if _, err := NormalizeAuthzRelationshipForWrite(AuthzRelationship{
+		SubjectType: "user",
+		SubjectID:   "user-1",
+		Relation:    "viewer",
+		ObjectType:  "workspace",
+		ObjectID:    "workspace-1",
+	}); err == nil {
+		t.Fatal("expected invalid relation error")
+	}
+
+	defaultSource, err := NormalizeAuthzRelationshipForWrite(AuthzRelationship{
+		SubjectType: "user",
+		SubjectID:   "user-2",
+		Relation:    AuthzRelationshipOwns,
+		ObjectType:  "finding",
+		ObjectID:    "finding-2",
+	})
+	if err != nil {
+		t.Fatalf("normalize relationship with default source failed: %v", err)
+	}
+	if defaultSource.Source != "manual" {
+		t.Fatalf("expected default source manual, got %q", defaultSource.Source)
 	}
 }

--- a/migrations/000009_authz_abac_rebac_data.down.sql
+++ b/migrations/000009_authz_abac_rebac_data.down.sql
@@ -1,0 +1,10 @@
+DROP POLICY IF EXISTS authz_relationships_scope_isolation ON authz_relationships;
+ALTER TABLE authz_relationships NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE authz_relationships DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS authz_entity_attributes_scope_isolation ON authz_entity_attributes;
+ALTER TABLE authz_entity_attributes NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE authz_entity_attributes DISABLE ROW LEVEL SECURITY;
+
+DROP TABLE IF EXISTS authz_relationships;
+DROP TABLE IF EXISTS authz_entity_attributes;

--- a/migrations/000009_authz_abac_rebac_data.up.sql
+++ b/migrations/000009_authz_abac_rebac_data.up.sql
@@ -1,0 +1,59 @@
+CREATE TABLE IF NOT EXISTS authz_entity_attributes (
+    tenant_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    entity_kind TEXT NOT NULL,
+    entity_type TEXT NOT NULL,
+    entity_id TEXT NOT NULL,
+    owner_team TEXT,
+    env TEXT,
+    risk_tier TEXT,
+    classification TEXT,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, workspace_id, entity_kind, entity_type, entity_id),
+    CHECK (entity_kind IN ('subject', 'resource')),
+    CHECK (env IS NULL OR env IN ('prod', 'staging', 'dev', 'test', 'sandbox')),
+    CHECK (risk_tier IS NULL OR risk_tier IN ('low', 'medium', 'high', 'critical')),
+    CHECK (classification IS NULL OR classification IN ('public', 'internal', 'confidential', 'restricted'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_authz_entity_attributes_scope_kind_type
+    ON authz_entity_attributes (tenant_id, workspace_id, entity_kind, entity_type);
+
+CREATE TABLE IF NOT EXISTS authz_relationships (
+    tenant_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    subject_type TEXT NOT NULL,
+    subject_id TEXT NOT NULL,
+    relation TEXT NOT NULL,
+    object_type TEXT NOT NULL,
+    object_id TEXT NOT NULL,
+    source TEXT NOT NULL DEFAULT 'manual',
+    expires_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, workspace_id, subject_type, subject_id, relation, object_type, object_id),
+    CHECK (relation IN ('owns', 'manages', 'delegated_admin', 'member_of'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_authz_relationships_scope_subject_relation
+    ON authz_relationships (tenant_id, workspace_id, subject_type, subject_id, relation);
+
+CREATE INDEX IF NOT EXISTS idx_authz_relationships_scope_object_relation
+    ON authz_relationships (tenant_id, workspace_id, object_type, object_id, relation);
+
+CREATE INDEX IF NOT EXISTS idx_authz_relationships_scope_expires_at
+    ON authz_relationships (tenant_id, workspace_id, expires_at);
+
+ALTER TABLE authz_entity_attributes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE authz_entity_attributes FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS authz_entity_attributes_scope_isolation ON authz_entity_attributes;
+CREATE POLICY authz_entity_attributes_scope_isolation ON authz_entity_attributes
+USING (identrail_rls_scope_matches(tenant_id, workspace_id))
+WITH CHECK (identrail_rls_scope_matches(tenant_id, workspace_id));
+
+ALTER TABLE authz_relationships ENABLE ROW LEVEL SECURITY;
+ALTER TABLE authz_relationships FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS authz_relationships_scope_isolation ON authz_relationships;
+CREATE POLICY authz_relationships_scope_isolation ON authz_relationships
+USING (identrail_rls_scope_matches(tenant_id, workspace_id))
+WITH CHECK (identrail_rls_scope_matches(tenant_id, workspace_id));


### PR DESCRIPTION
## Summary
- add ABAC/ReBAC persistence schema in `000009_authz_abac_rebac_data` (entity attributes + relationship tuples)
- enforce scoped integrity with tenant/workspace primary keys, enum/check constraints, indexes, and RLS policies
- extend `db.Store` with scoped authz attribute/relationship CRUD/list APIs
- implement memory and postgres store support with strict normalization/validation
- add migration, store, memory, and postgres tests for new data paths

## Non-Goals (for this PR)
- no ABAC/ReBAC authorization enforcement yet
- no policy expression evaluation yet

## Verification
- `go test ./internal/db/...`
- `go test ./...`
- `go test ./... -coverprofile=coverage.out` (total: `80.1%`)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an ABAC/ReBAC data model with scoped storage and validation, plus new authz attribute and relationship APIs across memory and Postgres stores. Enforces tenant/workspace isolation via Postgres RLS; authorization checks are not implemented yet.

- **New Features**
  - Added `authz_entity_attributes` and `authz_relationships` tables with check constraints, indexes, and RLS.
  - Added scoped CRUD/list methods to `db.Store` for attributes and relationships.
  - Implemented memory and Postgres support with strict normalization and validation.

- **Migration**
  - Apply `000009_authz_abac_rebac_data` migration.
  - Requires `identrail_rls_scope_matches` for RLS policies.

<sup>Written for commit 6ceb6b109a11d591b61c05a5310f3a901c7b9024. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

