### PR TITLE
feat(authz): PR-6.3 ReBAC data-path evaluator and graph lookup policy

### DIFF
--- a/internal/api/authz_evaluators.go
+++ b/internal/api/authz_evaluators.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
 )
 
 const (
@@ -165,7 +167,8 @@ type abacClause struct {
 }
 
 type abacActionPolicy struct {
-	AnyOf []abacClause
+	AnyOf     []abacClause
+	OnNoMatch PolicyOutcome
 }
 
 type abacPolicyEvaluator struct {
@@ -196,6 +199,14 @@ func normalizeABACPolicy(policy abacActionPolicy) abacActionPolicy {
 			normalizedClause.AllOf = append(normalizedClause.AllOf, normalizeABACPredicate(predicate))
 		}
 		result.AnyOf = append(result.AnyOf, normalizedClause)
+	}
+	switch PolicyOutcome(strings.ToLower(strings.TrimSpace(string(policy.OnNoMatch)))) {
+	case PolicyOutcomeNoOpinion:
+		result.OnNoMatch = PolicyOutcomeNoOpinion
+	case PolicyOutcomeAllow:
+		result.OnNoMatch = PolicyOutcomeAllow
+	default:
+		result.OnNoMatch = PolicyOutcomeDeny
 	}
 	return result
 }
@@ -263,7 +274,14 @@ func (e *abacPolicyEvaluator) Evaluate(_ context.Context, input PolicyInput) (Po
 			return PolicyOutcomeAllow, "abac policy grants action", nil
 		}
 	}
-	return PolicyOutcomeDeny, denyReason, nil
+	switch policy.OnNoMatch {
+	case PolicyOutcomeNoOpinion:
+		return PolicyOutcomeNoOpinion, "", nil
+	case PolicyOutcomeAllow:
+		return PolicyOutcomeAllow, "abac policy grants action", nil
+	default:
+		return PolicyOutcomeDeny, denyReason, nil
+	}
 }
 
 func evaluateABACPredicate(input PolicyInput, predicate abacPredicate) (bool, string) {
@@ -372,4 +390,173 @@ func lookupPolicyAttribute(attributes map[string]string, key string) (string, bo
 		return trimmed, trimmed != ""
 	}
 	return "", false
+}
+
+type rebacRelationPath struct {
+	Relations []string
+}
+
+type rebacActionPolicy struct {
+	AnyOf []rebacRelationPath
+}
+
+type rebacPolicyEvaluator struct {
+	store          db.Store
+	actionPolicies map[string]rebacActionPolicy
+	lookupLimit    int
+}
+
+type rebacNode struct {
+	SubjectType string
+	SubjectID   string
+}
+
+const rebacDefaultLookupLimit = 200
+
+func newReBACPolicyEvaluator(store db.Store, policies map[string]rebacActionPolicy) PolicyEvaluator {
+	return &rebacPolicyEvaluator{
+		store:          store,
+		actionPolicies: normalizeReBACPolicies(policies),
+		lookupLimit:    rebacDefaultLookupLimit,
+	}
+}
+
+func normalizeReBACPolicies(policies map[string]rebacActionPolicy) map[string]rebacActionPolicy {
+	normalized := make(map[string]rebacActionPolicy, len(policies))
+	for action, policy := range policies {
+		normalizedAction := strings.ToLower(strings.TrimSpace(action))
+		if normalizedAction == "" {
+			continue
+		}
+		normalizedPolicy := rebacActionPolicy{AnyOf: make([]rebacRelationPath, 0, len(policy.AnyOf))}
+		for _, path := range policy.AnyOf {
+			normalizedPath := normalizeReBACPath(path)
+			if len(normalizedPath.Relations) == 0 {
+				continue
+			}
+			normalizedPolicy.AnyOf = append(normalizedPolicy.AnyOf, normalizedPath)
+		}
+		if len(normalizedPolicy.AnyOf) == 0 {
+			continue
+		}
+		normalized[normalizedAction] = normalizedPolicy
+	}
+	return normalized
+}
+
+func normalizeReBACPath(path rebacRelationPath) rebacRelationPath {
+	normalized := rebacRelationPath{Relations: make([]string, 0, len(path.Relations))}
+	for _, relation := range path.Relations {
+		normalizedRelation := strings.ToLower(strings.TrimSpace(relation))
+		if !isSupportedReBACRelation(normalizedRelation) {
+			continue
+		}
+		normalized.Relations = append(normalized.Relations, normalizedRelation)
+	}
+	return normalized
+}
+
+func isSupportedReBACRelation(relation string) bool {
+	switch strings.ToLower(strings.TrimSpace(relation)) {
+	case db.AuthzRelationshipOwns, db.AuthzRelationshipManages, db.AuthzRelationshipDelegatedAdmin, db.AuthzRelationshipMemberOf:
+		return true
+	default:
+		return false
+	}
+}
+
+func (e *rebacPolicyEvaluator) Evaluate(ctx context.Context, input PolicyInput) (PolicyOutcome, string, error) {
+	if e == nil || e.store == nil || len(e.actionPolicies) == 0 {
+		return PolicyOutcomeNoOpinion, "", nil
+	}
+	action := strings.ToLower(strings.TrimSpace(input.Action))
+	if action == "" {
+		return PolicyOutcomeNoOpinion, "", nil
+	}
+	policy, exists := e.actionPolicies[action]
+	if !exists {
+		return PolicyOutcomeNoOpinion, "", nil
+	}
+	if len(policy.AnyOf) == 0 {
+		return PolicyOutcomeNoOpinion, "", nil
+	}
+
+	subjectType := strings.ToLower(strings.TrimSpace(input.Subject.Type))
+	subjectID := strings.TrimSpace(input.Subject.ID)
+	objectType := strings.ToLower(strings.TrimSpace(input.Resource.Type))
+	objectID := strings.TrimSpace(input.Resource.ID)
+	if subjectType == "" || subjectID == "" || objectType == "" || objectID == "" {
+		return PolicyOutcomeDeny, "rebac subject or resource identity is missing", nil
+	}
+
+	start := rebacNode{SubjectType: subjectType, SubjectID: subjectID}
+	for _, path := range policy.AnyOf {
+		matches, err := e.evaluateReBACPath(ctx, start, objectType, objectID, path)
+		if err != nil {
+			return PolicyOutcomeNoOpinion, "", err
+		}
+		if matches {
+			return PolicyOutcomeAllow, "rebac relationship grants action", nil
+		}
+	}
+	return PolicyOutcomeDeny, "rebac relationship does not grant action", nil
+}
+
+func (e *rebacPolicyEvaluator) evaluateReBACPath(ctx context.Context, start rebacNode, objectType string, objectID string, path rebacRelationPath) (bool, error) {
+	if len(path.Relations) == 0 {
+		return false, nil
+	}
+
+	nodes := []rebacNode{start}
+	for index, relation := range path.Relations {
+		isLastHop := index == len(path.Relations)-1
+		if isLastHop {
+			for _, node := range nodes {
+				tuples, err := e.store.ListAuthzRelationships(ctx, db.AuthzRelationshipFilter{
+					SubjectType: node.SubjectType,
+					SubjectID:   node.SubjectID,
+					Relation:    relation,
+					ObjectType:  objectType,
+					ObjectID:    objectID,
+				}, e.lookupLimit)
+				if err != nil {
+					return false, fmt.Errorf("list rebac relationships: %w", err)
+				}
+				if len(tuples) > 0 {
+					return true, nil
+				}
+			}
+			return false, nil
+		}
+
+		nextNodes := map[string]rebacNode{}
+		for _, node := range nodes {
+			tuples, err := e.store.ListAuthzRelationships(ctx, db.AuthzRelationshipFilter{
+				SubjectType: node.SubjectType,
+				SubjectID:   node.SubjectID,
+				Relation:    relation,
+			}, e.lookupLimit)
+			if err != nil {
+				return false, fmt.Errorf("list rebac relationships: %w", err)
+			}
+			for _, tuple := range tuples {
+				nextType := strings.ToLower(strings.TrimSpace(tuple.ObjectType))
+				nextID := strings.TrimSpace(tuple.ObjectID)
+				if nextType == "" || nextID == "" {
+					continue
+				}
+				nextKey := nextType + "|" + nextID
+				nextNodes[nextKey] = rebacNode{SubjectType: nextType, SubjectID: nextID}
+			}
+		}
+		if len(nextNodes) == 0 {
+			return false, nil
+		}
+		nodes = make([]rebacNode, 0, len(nextNodes))
+		for _, node := range nextNodes {
+			nodes = append(nodes, node)
+		}
+	}
+
+	return false, nil
 }

--- a/internal/api/authz_evaluators.go
+++ b/internal/api/authz_evaluators.go
@@ -449,7 +449,7 @@ func normalizeReBACPath(path rebacRelationPath) rebacRelationPath {
 	for _, relation := range path.Relations {
 		normalizedRelation := strings.ToLower(strings.TrimSpace(relation))
 		if !isSupportedReBACRelation(normalizedRelation) {
-			continue
+			return rebacRelationPath{}
 		}
 		normalized.Relations = append(normalized.Relations, normalizedRelation)
 	}

--- a/internal/api/authz_evaluators_test.go
+++ b/internal/api/authz_evaluators_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
 )
 
 func TestTenantIsolationEvaluatorDenyMismatch(t *testing.T) {
@@ -261,5 +263,140 @@ func TestABACPolicyEvaluatorNoOpinionWhenActionUnmapped(t *testing.T) {
 	}
 	if reason != "" {
 		t.Fatalf("expected empty reason, got %q", reason)
+	}
+}
+
+func TestReBACPolicyEvaluatorAllowWhenDirectRelationshipMatches(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	if err := store.UpsertAuthzRelationship(ctx, db.AuthzRelationship{
+		SubjectType: "subject",
+		SubjectID:   "principal-1",
+		Relation:    db.AuthzRelationshipDelegatedAdmin,
+		ObjectType:  "finding",
+		ObjectID:    "finding-1",
+	}); err != nil {
+		t.Fatalf("upsert relationship: %v", err)
+	}
+
+	evaluator := newReBACPolicyEvaluator(store, map[string]rebacActionPolicy{
+		"findings.triage": {
+			AnyOf: []rebacRelationPath{
+				{Relations: []string{db.AuthzRelationshipDelegatedAdmin}},
+			},
+		},
+	})
+
+	outcome, reason, err := evaluator.Evaluate(ctx, PolicyInput{
+		Action: "findings.triage",
+		Subject: PolicySubject{
+			Type: "subject",
+			ID:   "principal-1",
+		},
+		Resource: PolicyResource{
+			Type: "finding",
+			ID:   "finding-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if outcome != PolicyOutcomeAllow {
+		t.Fatalf("expected allow, got %q", outcome)
+	}
+	if strings.TrimSpace(reason) == "" {
+		t.Fatal("expected allow reason")
+	}
+}
+
+func TestReBACPolicyEvaluatorAllowWhenMemberOfPathMatches(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	if err := store.UpsertAuthzRelationship(ctx, db.AuthzRelationship{
+		SubjectType: "subject",
+		SubjectID:   "principal-1",
+		Relation:    db.AuthzRelationshipMemberOf,
+		ObjectType:  "team",
+		ObjectID:    "platform",
+	}); err != nil {
+		t.Fatalf("upsert membership relationship: %v", err)
+	}
+	if err := store.UpsertAuthzRelationship(ctx, db.AuthzRelationship{
+		SubjectType: "team",
+		SubjectID:   "platform",
+		Relation:    db.AuthzRelationshipManages,
+		ObjectType:  "finding",
+		ObjectID:    "finding-1",
+	}); err != nil {
+		t.Fatalf("upsert managed relationship: %v", err)
+	}
+
+	evaluator := newReBACPolicyEvaluator(store, map[string]rebacActionPolicy{
+		"findings.triage": {
+			AnyOf: []rebacRelationPath{
+				{Relations: []string{db.AuthzRelationshipMemberOf, db.AuthzRelationshipManages}},
+			},
+		},
+	})
+
+	outcome, _, err := evaluator.Evaluate(ctx, PolicyInput{
+		Action: "findings.triage",
+		Subject: PolicySubject{
+			Type: "subject",
+			ID:   "principal-1",
+		},
+		Resource: PolicyResource{
+			Type: "finding",
+			ID:   "finding-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if outcome != PolicyOutcomeAllow {
+		t.Fatalf("expected allow, got %q", outcome)
+	}
+}
+
+func TestReBACPolicyEvaluatorDenyWhenNoPathMatches(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	if err := store.UpsertAuthzRelationship(ctx, db.AuthzRelationship{
+		SubjectType: "subject",
+		SubjectID:   "principal-1",
+		Relation:    db.AuthzRelationshipOwns,
+		ObjectType:  "finding",
+		ObjectID:    "finding-2",
+	}); err != nil {
+		t.Fatalf("upsert relationship: %v", err)
+	}
+
+	evaluator := newReBACPolicyEvaluator(store, map[string]rebacActionPolicy{
+		"findings.triage": {
+			AnyOf: []rebacRelationPath{
+				{Relations: []string{db.AuthzRelationshipOwns}},
+			},
+		},
+	})
+
+	outcome, reason, err := evaluator.Evaluate(ctx, PolicyInput{
+		Action: "findings.triage",
+		Subject: PolicySubject{
+			Type: "subject",
+			ID:   "principal-1",
+		},
+		Resource: PolicyResource{
+			Type: "finding",
+			ID:   "finding-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if outcome != PolicyOutcomeDeny {
+		t.Fatalf("expected deny, got %q", outcome)
+	}
+	if !strings.Contains(reason, "does not grant") {
+		t.Fatalf("expected relationship deny reason, got %q", reason)
 	}
 }

--- a/internal/api/authz_middleware.go
+++ b/internal/api/authz_middleware.go
@@ -140,12 +140,12 @@ func defaultRouteActionRoleGrants() map[string][]string {
 	}
 }
 
-func newCentralPolicyEngine() *PolicyEngine {
+func newCentralPolicyEngine(store db.Store) *PolicyEngine {
 	return NewPolicyEngine(
 		newTenantIsolationEvaluator(),
 		newRBACRequirementEvaluator(defaultRouteActionRoleGrants()),
 		newABACPolicyEvaluator(defaultRouteActionABACPolicies()),
-		nil,
+		newReBACPolicyEvaluator(store, defaultRouteActionReBACPolicies()),
 	)
 }
 
@@ -161,6 +161,7 @@ func defaultRouteActionABACPolicies() map[string]abacActionPolicy {
 		policyActionRepoScansRead: passThroughPolicy,
 		policyActionRepoScansRun:  passThroughPolicy,
 		policyActionFindingsTriage: {
+			OnNoMatch: PolicyOutcomeNoOpinion,
 			AnyOf: []abacClause{
 				{
 					AllOf: []abacPredicate{
@@ -227,6 +228,21 @@ func defaultRouteActionABACPolicies() map[string]abacActionPolicy {
 						},
 					},
 				},
+			},
+		},
+	}
+}
+
+func defaultRouteActionReBACPolicies() map[string]rebacActionPolicy {
+	return map[string]rebacActionPolicy{
+		policyActionFindingsTriage: {
+			AnyOf: []rebacRelationPath{
+				{Relations: []string{db.AuthzRelationshipOwns}},
+				{Relations: []string{db.AuthzRelationshipManages}},
+				{Relations: []string{db.AuthzRelationshipDelegatedAdmin}},
+				{Relations: []string{db.AuthzRelationshipMemberOf, db.AuthzRelationshipOwns}},
+				{Relations: []string{db.AuthzRelationshipMemberOf, db.AuthzRelationshipManages}},
+				{Relations: []string{db.AuthzRelationshipMemberOf, db.AuthzRelationshipDelegatedAdmin}},
 			},
 		},
 	}

--- a/internal/api/authz_middleware_test.go
+++ b/internal/api/authz_middleware_test.go
@@ -151,6 +151,97 @@ func TestRequireCentralPolicyMiddlewareABACTriageDeniesWhenOwnerTeamMismatch(t *
 	}
 }
 
+func TestRequireCentralPolicyMiddlewareABACTriageAllowsWhenOwnerTeamMismatchAndReBACDirectGrant(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := policyTestScopeContext()
+	if err := store.UpsertAuthzEntityAttributes(ctx, db.AuthzEntityAttributes{
+		EntityKind: db.AuthzEntityKindSubject,
+		EntityType: "subject",
+		EntityID:   "principal-1",
+		OwnerTeam:  "platform",
+	}); err != nil {
+		t.Fatalf("upsert subject attributes: %v", err)
+	}
+	if err := store.UpsertAuthzEntityAttributes(ctx, db.AuthzEntityAttributes{
+		EntityKind:     db.AuthzEntityKindResource,
+		EntityType:     "finding",
+		EntityID:       "finding-1",
+		OwnerTeam:      "security",
+		Environment:    db.AuthzAttributeEnvProd,
+		RiskTier:       db.AuthzAttributeRiskTierHigh,
+		Classification: db.AuthzAttributeClassificationConfidential,
+	}); err != nil {
+		t.Fatalf("upsert resource attributes: %v", err)
+	}
+	if err := store.UpsertAuthzRelationship(ctx, db.AuthzRelationship{
+		SubjectType: "subject",
+		SubjectID:   "principal-1",
+		Relation:    db.AuthzRelationshipDelegatedAdmin,
+		ObjectType:  "finding",
+		ObjectID:    "finding-1",
+	}); err != nil {
+		t.Fatalf("upsert delegated_admin relationship: %v", err)
+	}
+
+	r := newPolicyTriageRouter(newScopeSet([]string{scopeWrite}), true, store)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/v1/findings/finding-1/triage", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+}
+
+func TestRequireCentralPolicyMiddlewareABACTriageAllowsWhenOwnerTeamMismatchAndReBACMemberOfGrant(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := policyTestScopeContext()
+	if err := store.UpsertAuthzEntityAttributes(ctx, db.AuthzEntityAttributes{
+		EntityKind: db.AuthzEntityKindSubject,
+		EntityType: "subject",
+		EntityID:   "principal-1",
+		OwnerTeam:  "platform",
+	}); err != nil {
+		t.Fatalf("upsert subject attributes: %v", err)
+	}
+	if err := store.UpsertAuthzEntityAttributes(ctx, db.AuthzEntityAttributes{
+		EntityKind:     db.AuthzEntityKindResource,
+		EntityType:     "finding",
+		EntityID:       "finding-1",
+		OwnerTeam:      "security",
+		Environment:    db.AuthzAttributeEnvProd,
+		RiskTier:       db.AuthzAttributeRiskTierHigh,
+		Classification: db.AuthzAttributeClassificationConfidential,
+	}); err != nil {
+		t.Fatalf("upsert resource attributes: %v", err)
+	}
+	if err := store.UpsertAuthzRelationship(ctx, db.AuthzRelationship{
+		SubjectType: "subject",
+		SubjectID:   "principal-1",
+		Relation:    db.AuthzRelationshipMemberOf,
+		ObjectType:  "team",
+		ObjectID:    "platform-admins",
+	}); err != nil {
+		t.Fatalf("upsert member_of relationship: %v", err)
+	}
+	if err := store.UpsertAuthzRelationship(ctx, db.AuthzRelationship{
+		SubjectType: "team",
+		SubjectID:   "platform-admins",
+		Relation:    db.AuthzRelationshipManages,
+		ObjectType:  "finding",
+		ObjectID:    "finding-1",
+	}); err != nil {
+		t.Fatalf("upsert manages relationship: %v", err)
+	}
+
+	r := newPolicyTriageRouter(newScopeSet([]string{scopeWrite}), true, store)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/v1/findings/finding-1/triage", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+}
+
 func TestRequireCentralPolicyMiddlewareABACTriageAllowsWhenTrustedAttributesMissing(t *testing.T) {
 	store := db.NewMemoryStore()
 	if err := store.UpsertAuthzEntityAttributes(policyTestScopeContext(), db.AuthzEntityAttributes{
@@ -219,7 +310,7 @@ func newPolicyTestRouter(scopes scopeSet, setPrincipal bool, store db.Store) *gi
 		}
 		c.Next()
 	})
-	r.Use(requireCentralPolicyMiddleware(newCentralPolicyEngine(), newRoutePolicyRegistry(), nil, nil, store))
+	r.Use(requireCentralPolicyMiddleware(newCentralPolicyEngine(store), newRoutePolicyRegistry(), nil, nil, store))
 	r.POST("/v1/scans", func(c *gin.Context) {
 		c.Status(http.StatusNoContent)
 	})
@@ -240,7 +331,7 @@ func newPolicyTriageRouter(scopes scopeSet, setPrincipal bool, store db.Store) *
 		}
 		c.Next()
 	})
-	r.Use(requireCentralPolicyMiddleware(newCentralPolicyEngine(), newRoutePolicyRegistry(), nil, nil, store))
+	r.Use(requireCentralPolicyMiddleware(newCentralPolicyEngine(store), newRoutePolicyRegistry(), nil, nil, store))
 	r.PATCH("/v1/findings/:finding_id/triage", func(c *gin.Context) {
 		c.Status(http.StatusNoContent)
 	})

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -114,7 +114,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 	v1 := r.Group("/v1")
 	v1.Use(apiKeyAuthMiddleware(opts.APIKeys, opts.APIKeyScopes, opts.OIDCTokenVerifier, opts.OIDCWriteScopes))
 	v1.Use(requestScopeMiddleware(opts.DefaultTenantID, opts.DefaultWorkspaceID))
-	v1.Use(requireCentralPolicyMiddleware(newCentralPolicyEngine(), newRoutePolicyRegistry(), opts.WriteAPIKeys, opts.APIKeyScopes, authzStore))
+	v1.Use(requireCentralPolicyMiddleware(newCentralPolicyEngine(authzStore), newRoutePolicyRegistry(), opts.WriteAPIKeys, opts.APIKeyScopes, authzStore))
 	v1.Use(rateLimitMiddleware(opts.RateLimitRPM, opts.RateLimitBurst))
 	v1.Use(auditLogMiddleware(logger, opts.AuditSink))
 


### PR DESCRIPTION
## Summary
- add a ReBAC evaluator with relationship-path policy expressions for centralized AuthZ
- support direct and graph path checks (`owns`, `manages`, `delegated_admin`, `member_of -> ...`)
- wire ReBAC into the central policy engine for `findings.triage`
- allow ABAC to defer (`no_op`) on triage non-match so ReBAC can evaluate fallback grants
- keep lookup queries scoped and targeted via filtered `ListAuthzRelationships` calls

## Tests
- add ReBAC evaluator tests for direct grant, member-of chain grant, and deny path
- add middleware integration tests for ABAC-mismatch + ReBAC direct/member-of grants
- run full suite: `go test ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a ReBAC relationship-path evaluator and wires it into the central policy engine to enable graph-based grants. ABAC can now return no-opinion on non-matches so ReBAC can grant access as a fallback.

- **New Features**
  - ReBAC evaluator with direct and multi-hop paths over owns, manages, delegated_admin, and member_of; scoped graph lookups with a default limit of 200.
  - Central engine now includes ReBAC via `newCentralPolicyEngine(store)` and a default `findings.triage` ReBAC policy (direct and member_of→{owns|manages|delegated_admin}).
  - ABAC adds `OnNoMatch` and returns no-opinion when set; `findings.triage` ABAC now defers to ReBAC.
  - Added unit and middleware tests for direct grants, member_of chains, deny paths, and ABAC-mismatch fallbacks.

<sup>Written for commit 8dff496cd1c79cd747011e7e40f21ad6f2640417. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

