### PR TITLE
feat(authz): PR-6.4 policy expressions combining attributes and relationships

### DIFF
--- a/internal/api/authz_evaluators.go
+++ b/internal/api/authz_evaluators.go
@@ -506,6 +506,10 @@ func (e *rebacPolicyEvaluator) Evaluate(ctx context.Context, input PolicyInput) 
 			}
 			continue
 		}
+		// This path is eligible for relationship checks. Reset to the default
+		// relationship-deny reason so stale condition failures from earlier paths
+		// do not mask the actual deny cause.
+		denyReason = "rebac relationship does not grant action"
 		matches, err := e.evaluateReBACPath(ctx, start, objectType, objectID, path)
 		if err != nil {
 			return PolicyOutcomeNoOpinion, "", err

--- a/internal/api/authz_evaluators.go
+++ b/internal/api/authz_evaluators.go
@@ -394,6 +394,7 @@ func lookupPolicyAttribute(attributes map[string]string, key string) (string, bo
 
 type rebacRelationPath struct {
 	Relations []string
+	AllOf     []abacPredicate
 }
 
 type rebacActionPolicy struct {
@@ -445,13 +446,19 @@ func normalizeReBACPolicies(policies map[string]rebacActionPolicy) map[string]re
 }
 
 func normalizeReBACPath(path rebacRelationPath) rebacRelationPath {
-	normalized := rebacRelationPath{Relations: make([]string, 0, len(path.Relations))}
+	normalized := rebacRelationPath{
+		Relations: make([]string, 0, len(path.Relations)),
+		AllOf:     make([]abacPredicate, 0, len(path.AllOf)),
+	}
 	for _, relation := range path.Relations {
 		normalizedRelation := strings.ToLower(strings.TrimSpace(relation))
 		if !isSupportedReBACRelation(normalizedRelation) {
 			return rebacRelationPath{}
 		}
 		normalized.Relations = append(normalized.Relations, normalizedRelation)
+	}
+	for _, predicate := range path.AllOf {
+		normalized.AllOf = append(normalized.AllOf, normalizeABACPredicate(predicate))
 	}
 	return normalized
 }
@@ -490,7 +497,15 @@ func (e *rebacPolicyEvaluator) Evaluate(ctx context.Context, input PolicyInput) 
 	}
 
 	start := rebacNode{SubjectType: subjectType, SubjectID: subjectID}
+	denyReason := "rebac relationship does not grant action"
 	for _, path := range policy.AnyOf {
+		matchesConditions, reason := evaluateReBACPathConditions(input, path.AllOf)
+		if !matchesConditions {
+			if strings.TrimSpace(reason) != "" {
+				denyReason = reason
+			}
+			continue
+		}
 		matches, err := e.evaluateReBACPath(ctx, start, objectType, objectID, path)
 		if err != nil {
 			return PolicyOutcomeNoOpinion, "", err
@@ -499,7 +514,7 @@ func (e *rebacPolicyEvaluator) Evaluate(ctx context.Context, input PolicyInput) 
 			return PolicyOutcomeAllow, "rebac relationship grants action", nil
 		}
 	}
-	return PolicyOutcomeDeny, "rebac relationship does not grant action", nil
+	return PolicyOutcomeDeny, denyReason, nil
 }
 
 func (e *rebacPolicyEvaluator) evaluateReBACPath(ctx context.Context, start rebacNode, objectType string, objectID string, path rebacRelationPath) (bool, error) {
@@ -559,4 +574,21 @@ func (e *rebacPolicyEvaluator) evaluateReBACPath(ctx context.Context, start reba
 	}
 
 	return false, nil
+}
+
+func evaluateReBACPathConditions(input PolicyInput, conditions []abacPredicate) (bool, string) {
+	if len(conditions) == 0 {
+		return true, ""
+	}
+	for _, condition := range conditions {
+		matches, reason := evaluateABACPredicate(input, condition)
+		if matches {
+			continue
+		}
+		if strings.TrimSpace(reason) == "" {
+			return false, "rebac condition failed"
+		}
+		return false, fmt.Sprintf("rebac condition failed: %s", reason)
+	}
+	return true, ""
 }

--- a/internal/api/authz_evaluators_test.go
+++ b/internal/api/authz_evaluators_test.go
@@ -400,3 +400,136 @@ func TestReBACPolicyEvaluatorDenyWhenNoPathMatches(t *testing.T) {
 		t.Fatalf("expected relationship deny reason, got %q", reason)
 	}
 }
+
+func TestReBACPolicyEvaluatorAllowWhenRelationshipAndAttributeConditionsMatch(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	if err := store.UpsertAuthzRelationship(ctx, db.AuthzRelationship{
+		SubjectType: "subject",
+		SubjectID:   "principal-1",
+		Relation:    db.AuthzRelationshipMemberOf,
+		ObjectType:  "team",
+		ObjectID:    "platform-admins",
+	}); err != nil {
+		t.Fatalf("upsert member_of relationship: %v", err)
+	}
+	if err := store.UpsertAuthzRelationship(ctx, db.AuthzRelationship{
+		SubjectType: "team",
+		SubjectID:   "platform-admins",
+		Relation:    db.AuthzRelationshipManages,
+		ObjectType:  "finding",
+		ObjectID:    "finding-1",
+	}); err != nil {
+		t.Fatalf("upsert manages relationship: %v", err)
+	}
+
+	evaluator := newReBACPolicyEvaluator(store, map[string]rebacActionPolicy{
+		"findings.triage": {
+			AnyOf: []rebacRelationPath{
+				{
+					Relations: []string{db.AuthzRelationshipMemberOf, db.AuthzRelationshipManages},
+					AllOf: []abacPredicate{
+						{
+							Source:   abacAttributeSourceResource,
+							Key:      policyAttributeClassification,
+							Operator: abacOperatorOneOf,
+							Values: []string{
+								db.AuthzAttributeClassificationConfidential,
+								db.AuthzAttributeClassificationRestricted,
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	outcome, _, err := evaluator.Evaluate(ctx, PolicyInput{
+		Action: "findings.triage",
+		Subject: PolicySubject{
+			Type: "subject",
+			ID:   "principal-1",
+		},
+		Resource: PolicyResource{
+			Type: "finding",
+			ID:   "finding-1",
+			Attributes: map[string]string{
+				policyAttributeClassification: db.AuthzAttributeClassificationConfidential,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if outcome != PolicyOutcomeAllow {
+		t.Fatalf("expected allow, got %q", outcome)
+	}
+}
+
+func TestReBACPolicyEvaluatorDenyWhenRelationshipMatchesButAttributeConditionFails(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	if err := store.UpsertAuthzRelationship(ctx, db.AuthzRelationship{
+		SubjectType: "subject",
+		SubjectID:   "principal-1",
+		Relation:    db.AuthzRelationshipMemberOf,
+		ObjectType:  "team",
+		ObjectID:    "platform-admins",
+	}); err != nil {
+		t.Fatalf("upsert member_of relationship: %v", err)
+	}
+	if err := store.UpsertAuthzRelationship(ctx, db.AuthzRelationship{
+		SubjectType: "team",
+		SubjectID:   "platform-admins",
+		Relation:    db.AuthzRelationshipManages,
+		ObjectType:  "finding",
+		ObjectID:    "finding-1",
+	}); err != nil {
+		t.Fatalf("upsert manages relationship: %v", err)
+	}
+
+	evaluator := newReBACPolicyEvaluator(store, map[string]rebacActionPolicy{
+		"findings.triage": {
+			AnyOf: []rebacRelationPath{
+				{
+					Relations: []string{db.AuthzRelationshipMemberOf, db.AuthzRelationshipManages},
+					AllOf: []abacPredicate{
+						{
+							Source:   abacAttributeSourceResource,
+							Key:      policyAttributeClassification,
+							Operator: abacOperatorOneOf,
+							Values: []string{
+								db.AuthzAttributeClassificationConfidential,
+								db.AuthzAttributeClassificationRestricted,
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	outcome, reason, err := evaluator.Evaluate(ctx, PolicyInput{
+		Action: "findings.triage",
+		Subject: PolicySubject{
+			Type: "subject",
+			ID:   "principal-1",
+		},
+		Resource: PolicyResource{
+			Type: "finding",
+			ID:   "finding-1",
+			Attributes: map[string]string{
+				policyAttributeClassification: db.AuthzAttributeClassificationPublic,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if outcome != PolicyOutcomeDeny {
+		t.Fatalf("expected deny, got %q", outcome)
+	}
+	if !strings.Contains(reason, "rebac condition failed") {
+		t.Fatalf("expected rebac condition deny reason, got %q", reason)
+	}
+}

--- a/internal/api/authz_evaluators_test.go
+++ b/internal/api/authz_evaluators_test.go
@@ -533,3 +533,55 @@ func TestReBACPolicyEvaluatorDenyWhenRelationshipMatchesButAttributeConditionFai
 		t.Fatalf("expected rebac condition deny reason, got %q", reason)
 	}
 }
+
+func TestReBACPolicyEvaluatorDenyReasonResetsWhenLaterPathRelationshipCheckFails(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+
+	evaluator := newReBACPolicyEvaluator(store, map[string]rebacActionPolicy{
+		"findings.triage": {
+			AnyOf: []rebacRelationPath{
+				{
+					Relations: []string{db.AuthzRelationshipMemberOf, db.AuthzRelationshipManages},
+					AllOf: []abacPredicate{
+						{
+							Source:   abacAttributeSourceResource,
+							Key:      policyAttributeClassification,
+							Operator: abacOperatorOneOf,
+							Values: []string{
+								db.AuthzAttributeClassificationRestricted,
+							},
+						},
+					},
+				},
+				{
+					Relations: []string{db.AuthzRelationshipOwns},
+				},
+			},
+		},
+	})
+
+	outcome, reason, err := evaluator.Evaluate(ctx, PolicyInput{
+		Action: "findings.triage",
+		Subject: PolicySubject{
+			Type: "subject",
+			ID:   "principal-1",
+		},
+		Resource: PolicyResource{
+			Type: "finding",
+			ID:   "finding-1",
+			Attributes: map[string]string{
+				policyAttributeClassification: db.AuthzAttributeClassificationPublic,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if outcome != PolicyOutcomeDeny {
+		t.Fatalf("expected deny, got %q", outcome)
+	}
+	if reason != "rebac relationship does not grant action" {
+		t.Fatalf("expected default relationship deny reason, got %q", reason)
+	}
+}

--- a/internal/api/authz_middleware.go
+++ b/internal/api/authz_middleware.go
@@ -234,15 +234,44 @@ func defaultRouteActionABACPolicies() map[string]abacActionPolicy {
 }
 
 func defaultRouteActionReBACPolicies() map[string]rebacActionPolicy {
+	memberDelegationConditions := []abacPredicate{
+		{
+			Source:   abacAttributeSourceResource,
+			Key:      policyAttributeEnvironment,
+			Operator: abacOperatorOneOf,
+			Values: []string{
+				db.AuthzAttributeEnvProd,
+				db.AuthzAttributeEnvStaging,
+			},
+		},
+		{
+			Source:   abacAttributeSourceResource,
+			Key:      policyAttributeClassification,
+			Operator: abacOperatorOneOf,
+			Values: []string{
+				db.AuthzAttributeClassificationConfidential,
+				db.AuthzAttributeClassificationRestricted,
+			},
+		},
+	}
 	return map[string]rebacActionPolicy{
 		policyActionFindingsTriage: {
 			AnyOf: []rebacRelationPath{
 				{Relations: []string{db.AuthzRelationshipOwns}},
 				{Relations: []string{db.AuthzRelationshipManages}},
 				{Relations: []string{db.AuthzRelationshipDelegatedAdmin}},
-				{Relations: []string{db.AuthzRelationshipMemberOf, db.AuthzRelationshipOwns}},
-				{Relations: []string{db.AuthzRelationshipMemberOf, db.AuthzRelationshipManages}},
-				{Relations: []string{db.AuthzRelationshipMemberOf, db.AuthzRelationshipDelegatedAdmin}},
+				{
+					Relations: []string{db.AuthzRelationshipMemberOf, db.AuthzRelationshipOwns},
+					AllOf:     memberDelegationConditions,
+				},
+				{
+					Relations: []string{db.AuthzRelationshipMemberOf, db.AuthzRelationshipManages},
+					AllOf:     memberDelegationConditions,
+				},
+				{
+					Relations: []string{db.AuthzRelationshipMemberOf, db.AuthzRelationshipDelegatedAdmin},
+					AllOf:     memberDelegationConditions,
+				},
 			},
 		},
 	}

--- a/internal/api/authz_middleware_test.go
+++ b/internal/api/authz_middleware_test.go
@@ -242,6 +242,56 @@ func TestRequireCentralPolicyMiddlewareABACTriageAllowsWhenOwnerTeamMismatchAndR
 	}
 }
 
+func TestRequireCentralPolicyMiddlewareABACTriageDeniesWhenMemberDelegationRelationshipExistsButConditionsFail(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := policyTestScopeContext()
+	if err := store.UpsertAuthzEntityAttributes(ctx, db.AuthzEntityAttributes{
+		EntityKind: db.AuthzEntityKindSubject,
+		EntityType: "subject",
+		EntityID:   "principal-1",
+		OwnerTeam:  "platform",
+	}); err != nil {
+		t.Fatalf("upsert subject attributes: %v", err)
+	}
+	if err := store.UpsertAuthzEntityAttributes(ctx, db.AuthzEntityAttributes{
+		EntityKind:     db.AuthzEntityKindResource,
+		EntityType:     "finding",
+		EntityID:       "finding-1",
+		OwnerTeam:      "security",
+		Environment:    db.AuthzAttributeEnvProd,
+		RiskTier:       db.AuthzAttributeRiskTierHigh,
+		Classification: db.AuthzAttributeClassificationPublic,
+	}); err != nil {
+		t.Fatalf("upsert resource attributes: %v", err)
+	}
+	if err := store.UpsertAuthzRelationship(ctx, db.AuthzRelationship{
+		SubjectType: "subject",
+		SubjectID:   "principal-1",
+		Relation:    db.AuthzRelationshipMemberOf,
+		ObjectType:  "team",
+		ObjectID:    "platform-admins",
+	}); err != nil {
+		t.Fatalf("upsert member_of relationship: %v", err)
+	}
+	if err := store.UpsertAuthzRelationship(ctx, db.AuthzRelationship{
+		SubjectType: "team",
+		SubjectID:   "platform-admins",
+		Relation:    db.AuthzRelationshipManages,
+		ObjectType:  "finding",
+		ObjectID:    "finding-1",
+	}); err != nil {
+		t.Fatalf("upsert manages relationship: %v", err)
+	}
+
+	r := newPolicyTriageRouter(newScopeSet([]string{scopeWrite}), true, store)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/v1/findings/finding-1/triage", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+}
+
 func TestRequireCentralPolicyMiddlewareABACTriageAllowsWhenTrustedAttributesMissing(t *testing.T) {
 	store := db.NewMemoryStore()
 	if err := store.UpsertAuthzEntityAttributes(policyTestScopeContext(), db.AuthzEntityAttributes{


### PR DESCRIPTION
## Summary
- extend ReBAC path policies to include `AllOf` attribute predicates, enabling mixed attribute + relationship expressions
- evaluate ReBAC path conditions before graph relation traversal and return explicit condition-failure reasons on deny
- tighten member-delegation paths for `findings.triage` to require high-trust resource attributes (`env in prod|staging`, `classification in confidential|restricted`)

## Why this PR
- this is the next stacked step after PR-6.3 to satisfy the requirement for policy expressions that reference both attributes and relationships
- it keeps policy logic centralized while preserving route/middleware wiring from 6.3

## Tests
- added evaluator tests for:
  - relationship + attribute condition allow path
  - relationship path match but attribute condition fail
- added middleware integration test for deny when member-delegation relation exists but attribute gates fail
- verified full suite: `go test ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds attribute-aware ReBAC policy expressions that combine relationship paths with AllOf attribute predicates, and tightens `findings.triage` member‑delegation rules. Improves deny reasons with clear condition-failure messages and prevents stale reasons when later path checks fail.

- **New Features**
  - ReBAC paths accept `AllOf` attribute predicates; conditions are evaluated before relation traversal.
  - Default `findings.triage`: member-delegation paths require `env` in `prod|staging` and `classification` in `confidential|restricted`.

- **Bug Fixes**
  - Reset deny reason after condition-gated paths so later relationship failures return the correct relationship-based deny message.

<sup>Written for commit 80db5cbeaf92eb5cb06f66b789575d327e4b1579. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

