### PR TITLE
test(authz): PR-6.5 customer ABAC/ReBAC scenario hardening

### DIFF
--- a/internal/api/authz_middleware.go
+++ b/internal/api/authz_middleware.go
@@ -246,6 +246,15 @@ func defaultRouteActionReBACPolicies() map[string]rebacActionPolicy {
 		},
 		{
 			Source:   abacAttributeSourceResource,
+			Key:      policyAttributeRiskTier,
+			Operator: abacOperatorOneOf,
+			Values: []string{
+				db.AuthzAttributeRiskTierHigh,
+				db.AuthzAttributeRiskTierCritical,
+			},
+		},
+		{
+			Source:   abacAttributeSourceResource,
 			Key:      policyAttributeClassification,
 			Operator: abacOperatorOneOf,
 			Values: []string{

--- a/internal/api/authz_middleware_test.go
+++ b/internal/api/authz_middleware_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/telemetry"
@@ -281,6 +282,143 @@ func TestRequireCentralPolicyMiddlewareABACTriageDeniesWhenMemberDelegationRelat
 		ObjectID:    "finding-1",
 	}); err != nil {
 		t.Fatalf("upsert manages relationship: %v", err)
+	}
+
+	r := newPolicyTriageRouter(newScopeSet([]string{scopeWrite}), true, store)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/v1/findings/finding-1/triage", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestRequireCentralPolicyMiddlewareABACTriageDeniesWhenMemberDelegationRiskTierTooLow(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := policyTestScopeContext()
+	if err := store.UpsertAuthzEntityAttributes(ctx, db.AuthzEntityAttributes{
+		EntityKind: db.AuthzEntityKindSubject,
+		EntityType: "subject",
+		EntityID:   "principal-1",
+		OwnerTeam:  "platform",
+	}); err != nil {
+		t.Fatalf("upsert subject attributes: %v", err)
+	}
+	if err := store.UpsertAuthzEntityAttributes(ctx, db.AuthzEntityAttributes{
+		EntityKind:     db.AuthzEntityKindResource,
+		EntityType:     "finding",
+		EntityID:       "finding-1",
+		OwnerTeam:      "security",
+		Environment:    db.AuthzAttributeEnvProd,
+		RiskTier:       db.AuthzAttributeRiskTierMedium,
+		Classification: db.AuthzAttributeClassificationConfidential,
+	}); err != nil {
+		t.Fatalf("upsert resource attributes: %v", err)
+	}
+	if err := store.UpsertAuthzRelationship(ctx, db.AuthzRelationship{
+		SubjectType: "subject",
+		SubjectID:   "principal-1",
+		Relation:    db.AuthzRelationshipMemberOf,
+		ObjectType:  "team",
+		ObjectID:    "platform-admins",
+	}); err != nil {
+		t.Fatalf("upsert member_of relationship: %v", err)
+	}
+	if err := store.UpsertAuthzRelationship(ctx, db.AuthzRelationship{
+		SubjectType: "team",
+		SubjectID:   "platform-admins",
+		Relation:    db.AuthzRelationshipManages,
+		ObjectType:  "finding",
+		ObjectID:    "finding-1",
+	}); err != nil {
+		t.Fatalf("upsert manages relationship: %v", err)
+	}
+
+	r := newPolicyTriageRouter(newScopeSet([]string{scopeWrite}), true, store)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/v1/findings/finding-1/triage", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestRequireCentralPolicyMiddlewareABACTriageDeniesWhenDirectDelegationExpired(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := policyTestScopeContext()
+	if err := store.UpsertAuthzEntityAttributes(ctx, db.AuthzEntityAttributes{
+		EntityKind: db.AuthzEntityKindSubject,
+		EntityType: "subject",
+		EntityID:   "principal-1",
+		OwnerTeam:  "platform",
+	}); err != nil {
+		t.Fatalf("upsert subject attributes: %v", err)
+	}
+	if err := store.UpsertAuthzEntityAttributes(ctx, db.AuthzEntityAttributes{
+		EntityKind:     db.AuthzEntityKindResource,
+		EntityType:     "finding",
+		EntityID:       "finding-1",
+		OwnerTeam:      "security",
+		Environment:    db.AuthzAttributeEnvProd,
+		RiskTier:       db.AuthzAttributeRiskTierHigh,
+		Classification: db.AuthzAttributeClassificationConfidential,
+	}); err != nil {
+		t.Fatalf("upsert resource attributes: %v", err)
+	}
+	expiredAt := time.Now().UTC().Add(-30 * time.Minute)
+	if err := store.UpsertAuthzRelationship(ctx, db.AuthzRelationship{
+		SubjectType: "subject",
+		SubjectID:   "principal-1",
+		Relation:    db.AuthzRelationshipDelegatedAdmin,
+		ObjectType:  "finding",
+		ObjectID:    "finding-1",
+		ExpiresAt:   &expiredAt,
+	}); err != nil {
+		t.Fatalf("upsert expired delegated_admin relationship: %v", err)
+	}
+
+	r := newPolicyTriageRouter(newScopeSet([]string{scopeWrite}), true, store)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/v1/findings/finding-1/triage", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestRequireCentralPolicyMiddlewareABACTriageDeniesWhenDelegationExistsInDifferentWorkspace(t *testing.T) {
+	store := db.NewMemoryStore()
+	scopeA := db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"}
+	scopeB := db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-b"}
+	ctxA := db.WithScope(context.Background(), scopeA)
+	ctxB := db.WithScope(context.Background(), scopeB)
+	if err := store.UpsertAuthzEntityAttributes(ctxA, db.AuthzEntityAttributes{
+		EntityKind: db.AuthzEntityKindSubject,
+		EntityType: "subject",
+		EntityID:   "principal-1",
+		OwnerTeam:  "platform",
+	}); err != nil {
+		t.Fatalf("upsert subject attributes: %v", err)
+	}
+	if err := store.UpsertAuthzEntityAttributes(ctxA, db.AuthzEntityAttributes{
+		EntityKind:     db.AuthzEntityKindResource,
+		EntityType:     "finding",
+		EntityID:       "finding-1",
+		OwnerTeam:      "security",
+		Environment:    db.AuthzAttributeEnvProd,
+		RiskTier:       db.AuthzAttributeRiskTierHigh,
+		Classification: db.AuthzAttributeClassificationConfidential,
+	}); err != nil {
+		t.Fatalf("upsert resource attributes: %v", err)
+	}
+	if err := store.UpsertAuthzRelationship(ctxB, db.AuthzRelationship{
+		SubjectType: "subject",
+		SubjectID:   "principal-1",
+		Relation:    db.AuthzRelationshipDelegatedAdmin,
+		ObjectType:  "finding",
+		ObjectID:    "finding-1",
+	}); err != nil {
+		t.Fatalf("upsert delegated_admin relationship in workspace-b: %v", err)
 	}
 
 	r := newPolicyTriageRouter(newScopeSet([]string{scopeWrite}), true, store)


### PR DESCRIPTION
## Summary
- strengthen member-delegation ReBAC policy expressions with `risk_tier` constraints (`high|critical`)
- add customer-style integration scenarios for `findings.triage` authorization behavior
  - deny when member-delegation relation exists but `risk_tier` is too low
  - deny when direct delegation relationship is expired
  - deny when delegation exists only in a different workspace

## Why this PR
- this completes the PR-6 milestone criterion: customer-required ABAC/ReBAC scenarios are executable and enforced in tests
- policy behavior is now explicit around scope boundaries and time-bounded delegation

## Validation
- `go test ./internal/api/...`
- `go test ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened findings triage authorization by adding an ABAC check that requires resource `risk_tier` to be `high` or `critical`. Added tests that enforce customer scenarios: deny when risk is lower, when a direct delegation is expired, and when delegation exists only in another workspace.

<sup>Written for commit 2c6f5b3b97080c0b3a3b4f51d06c97e72258cb39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

