### PR TITLE
feat(authz): PR-7.2 policy compiler and runtime resolver

### DIFF
--- a/internal/api/authz_middleware.go
+++ b/internal/api/authz_middleware.go
@@ -34,87 +34,11 @@ type routePolicy struct {
 type routePolicyRegistry map[string]routePolicy
 
 func newRoutePolicyRegistry() routePolicyRegistry {
-	return routePolicyRegistry{
-		routePolicyKey(http.MethodGet, "/v1/findings"): {
-			Action:       policyActionFindingsRead,
-			ResourceType: "finding",
-		},
-		routePolicyKey(http.MethodGet, "/v1/findings/:finding_id"): {
-			Action:          policyActionFindingsRead,
-			ResourceType:    "finding",
-			ResourceIDParam: "finding_id",
-		},
-		routePolicyKey(http.MethodGet, "/v1/findings/:finding_id/history"): {
-			Action:          policyActionFindingsRead,
-			ResourceType:    "finding_history",
-			ResourceIDParam: "finding_id",
-		},
-		routePolicyKey(http.MethodGet, "/v1/findings/:finding_id/exports"): {
-			Action:          policyActionFindingsRead,
-			ResourceType:    "finding_export",
-			ResourceIDParam: "finding_id",
-		},
-		routePolicyKey(http.MethodGet, "/v1/findings/trends"): {
-			Action:       policyActionFindingsRead,
-			ResourceType: "finding_trend",
-		},
-		routePolicyKey(http.MethodGet, "/v1/findings/summary"): {
-			Action:       policyActionFindingsRead,
-			ResourceType: "finding_summary",
-		},
-		routePolicyKey(http.MethodPatch, "/v1/findings/:finding_id/triage"): {
-			Action:          policyActionFindingsTriage,
-			ResourceType:    "finding",
-			ResourceIDParam: "finding_id",
-		},
-		routePolicyKey(http.MethodGet, "/v1/identities"): {
-			Action:       policyActionGraphRead,
-			ResourceType: "identity",
-		},
-		routePolicyKey(http.MethodGet, "/v1/relationships"): {
-			Action:       policyActionGraphRead,
-			ResourceType: "relationship",
-		},
-		routePolicyKey(http.MethodGet, "/v1/ownership/signals"): {
-			Action:       policyActionGraphRead,
-			ResourceType: "ownership_signal",
-		},
-		routePolicyKey(http.MethodGet, "/v1/scans"): {
-			Action:       policyActionScansRead,
-			ResourceType: "scan",
-		},
-		routePolicyKey(http.MethodGet, "/v1/scans/:scan_id/diff"): {
-			Action:          policyActionScansRead,
-			ResourceType:    "scan_diff",
-			ResourceIDParam: "scan_id",
-		},
-		routePolicyKey(http.MethodGet, "/v1/scans/:scan_id/events"): {
-			Action:          policyActionScansRead,
-			ResourceType:    "scan_event",
-			ResourceIDParam: "scan_id",
-		},
-		routePolicyKey(http.MethodPost, "/v1/scans"): {
-			Action:       policyActionScansRun,
-			ResourceType: "scan",
-		},
-		routePolicyKey(http.MethodGet, "/v1/repo-scans"): {
-			Action:       policyActionRepoScansRead,
-			ResourceType: "repo_scan",
-		},
-		routePolicyKey(http.MethodGet, "/v1/repo-scans/:repo_scan_id"): {
-			Action:          policyActionRepoScansRead,
-			ResourceType:    "repo_scan",
-			ResourceIDParam: "repo_scan_id",
-		},
-		routePolicyKey(http.MethodGet, "/v1/repo-findings"): {
-			Action:       policyActionRepoScansRead,
-			ResourceType: "repo_finding",
-		},
-		routePolicyKey(http.MethodPost, "/v1/repo-scans"): {
-			Action:       policyActionRepoScansRun,
-			ResourceType: "repo_scan",
-		},
+	compiled, err := compileRouteAuthorizationPolicyBundle(defaultBuiltInRouteAuthorizationPolicyBundle())
+	if err != nil {
+		panic("compile built-in route policy registry: " + err.Error())
 	}
+	return compiled.RouteRegistry
 }
 
 func (r routePolicyRegistry) lookup(method string, fullPath string) (routePolicy, bool) {
@@ -141,12 +65,11 @@ func defaultRouteActionRoleGrants() map[string][]string {
 }
 
 func newCentralPolicyEngine(store db.Store) *PolicyEngine {
-	return NewPolicyEngine(
-		newTenantIsolationEvaluator(),
-		newRBACRequirementEvaluator(defaultRouteActionRoleGrants()),
-		newABACPolicyEvaluator(defaultRouteActionABACPolicies()),
-		newReBACPolicyEvaluator(store, defaultRouteActionReBACPolicies()),
-	)
+	compiled, err := compileRouteAuthorizationPolicyBundle(defaultBuiltInRouteAuthorizationPolicyBundle())
+	if err != nil {
+		panic("compile built-in central policy engine: " + err.Error())
+	}
+	return newCentralPolicyEngineFromCompiled(store, compiled)
 }
 
 func defaultRouteActionABACPolicies() map[string]abacActionPolicy {
@@ -286,16 +209,14 @@ func defaultRouteActionReBACPolicies() map[string]rebacActionPolicy {
 	}
 }
 
-func requireCentralPolicyMiddleware(engine *PolicyEngine, registry routePolicyRegistry, writeKeys []string, scopedKeys map[string][]string, store db.Store) gin.HandlerFunc {
+func requireCentralPolicyMiddleware(resolver centralPolicyRuntimeResolver, writeKeys []string, scopedKeys map[string][]string, store db.Store) gin.HandlerFunc {
 	normalizedWriteKeys := normalizeKeyList(writeKeys)
+	if resolver == nil {
+		resolver = newCentralPolicyRuntimeResolver(store)
+	}
 	return func(c *gin.Context) {
 		fullPath := strings.TrimSpace(c.FullPath())
 		if fullPath == "" {
-			c.Next()
-			return
-		}
-		policy, exists := registry.lookup(c.Request.Method, fullPath)
-		if !exists {
 			c.Next()
 			return
 		}
@@ -306,13 +227,24 @@ func requireCentralPolicyMiddleware(engine *PolicyEngine, registry routePolicyRe
 			return
 		}
 
+		runtimePolicy, err := resolver.Resolve(c.Request.Context())
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "authorization failed"})
+			return
+		}
+		policy, exists := runtimePolicy.Registry.lookup(c.Request.Method, fullPath)
+		if !exists {
+			c.Next()
+			return
+		}
+
 		input, err := buildPolicyInputFromGinContext(c, policy, normalizedWriteKeys, scopedKeys, store)
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "authorization failed"})
 			return
 		}
 
-		decision, err := engine.Decide(c.Request.Context(), input)
+		decision, err := runtimePolicy.Engine.Decide(c.Request.Context(), input)
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "authorization failed"})
 			return
@@ -323,6 +255,12 @@ func requireCentralPolicyMiddleware(engine *PolicyEngine, registry routePolicyRe
 		}
 
 		c.Set("authz.stage", string(decision.Stage))
+		c.Set("authz.policy_source", runtimePolicy.Source)
+		c.Set("authz.policy_set_id", runtimePolicy.PolicySetID)
+		c.Set("authz.rollout_mode", runtimePolicy.RolloutMode)
+		if runtimePolicy.Version > 0 {
+			c.Set("authz.policy_version", runtimePolicy.Version)
+		}
 		c.Next()
 	}
 }

--- a/internal/api/authz_middleware_test.go
+++ b/internal/api/authz_middleware_test.go
@@ -498,7 +498,7 @@ func newPolicyTestRouter(scopes scopeSet, setPrincipal bool, store db.Store) *gi
 		}
 		c.Next()
 	})
-	r.Use(requireCentralPolicyMiddleware(newCentralPolicyEngine(store), newRoutePolicyRegistry(), nil, nil, store))
+	r.Use(requireCentralPolicyMiddleware(newCentralPolicyRuntimeResolver(store), nil, nil, store))
 	r.POST("/v1/scans", func(c *gin.Context) {
 		c.Status(http.StatusNoContent)
 	})
@@ -519,7 +519,7 @@ func newPolicyTriageRouter(scopes scopeSet, setPrincipal bool, store db.Store) *
 		}
 		c.Next()
 	})
-	r.Use(requireCentralPolicyMiddleware(newCentralPolicyEngine(store), newRoutePolicyRegistry(), nil, nil, store))
+	r.Use(requireCentralPolicyMiddleware(newCentralPolicyRuntimeResolver(store), nil, nil, store))
 	r.PATCH("/v1/findings/:finding_id/triage", func(c *gin.Context) {
 		c.Status(http.StatusNoContent)
 	})

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -1,0 +1,528 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
+)
+
+const (
+	routeAuthorizationPolicyBundleSchemaV1 = "identrail.authz.route_policy_bundle.v1"
+	defaultCentralPolicySetID              = "central_authorization"
+)
+
+type routePolicyDefinition struct {
+	Method          string `json:"method"`
+	Path            string `json:"path"`
+	Action          string `json:"action"`
+	ResourceType    string `json:"resource_type"`
+	ResourceIDParam string `json:"resource_id_param,omitempty"`
+}
+
+type routeAuthorizationPolicyBundle struct {
+	SchemaVersion  string                       `json:"schema_version"`
+	RoutePolicies  []routePolicyDefinition      `json:"route_policies"`
+	RBACActionRole map[string][]string          `json:"rbac_action_roles"`
+	ABACPolicies   map[string]abacActionPolicy  `json:"abac_policies"`
+	ReBACPolicies  map[string]rebacActionPolicy `json:"rebac_policies"`
+}
+
+type compiledRouteAuthorizationPolicy struct {
+	RouteRegistry  routePolicyRegistry
+	RBACActionRole map[string][]string
+	ABACPolicies   map[string]abacActionPolicy
+	ReBACPolicies  map[string]rebacActionPolicy
+}
+
+type resolvedCentralPolicyRuntime struct {
+	Engine      *PolicyEngine
+	Registry    routePolicyRegistry
+	Source      string
+	PolicySetID string
+	Version     int
+	RolloutMode string
+}
+
+type centralPolicyRuntimeResolver interface {
+	Resolve(ctx context.Context) (resolvedCentralPolicyRuntime, error)
+}
+
+type storeBackedCentralPolicyRuntimeResolver struct {
+	store      db.Store
+	policySet  string
+	fallback   compiledRouteAuthorizationPolicy
+	cacheByKey sync.Map
+}
+
+func newCentralPolicyRuntimeResolver(store db.Store) centralPolicyRuntimeResolver {
+	return newCentralPolicyRuntimeResolverWithPolicySet(store, defaultCentralPolicySetID)
+}
+
+func newCentralPolicyRuntimeResolverWithPolicySet(store db.Store, policySetID string) centralPolicyRuntimeResolver {
+	compiled, err := compileRouteAuthorizationPolicyBundle(defaultBuiltInRouteAuthorizationPolicyBundle())
+	if err != nil {
+		panic(fmt.Sprintf("compile built-in policy bundle: %v", err))
+	}
+	policySet := strings.TrimSpace(policySetID)
+	if policySet == "" {
+		policySet = defaultCentralPolicySetID
+	}
+	return &storeBackedCentralPolicyRuntimeResolver{
+		store:     store,
+		policySet: policySet,
+		fallback:  compiled,
+	}
+}
+
+func (r *storeBackedCentralPolicyRuntimeResolver) Resolve(ctx context.Context) (resolvedCentralPolicyRuntime, error) {
+	if r == nil {
+		compiled, err := compileRouteAuthorizationPolicyBundle(defaultBuiltInRouteAuthorizationPolicyBundle())
+		if err != nil {
+			return resolvedCentralPolicyRuntime{}, fmt.Errorf("compile built-in policy bundle: %w", err)
+		}
+		return resolvedCentralPolicyRuntime{
+			Engine:      newCentralPolicyEngineFromCompiled(nil, compiled),
+			Registry:    compiled.RouteRegistry,
+			Source:      "built_in_default",
+			PolicySetID: defaultCentralPolicySetID,
+			RolloutMode: db.AuthzPolicyRolloutModeDisabled,
+		}, nil
+	}
+	fallback := r.fallbackRuntime()
+	if r.store == nil {
+		return fallback, nil
+	}
+
+	rollout, err := r.store.GetAuthzPolicyRollout(ctx, r.policySet)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return fallback, nil
+		}
+		return resolvedCentralPolicyRuntime{}, fmt.Errorf("resolve policy rollout: %w", err)
+	}
+	if rollout.Mode != db.AuthzPolicyRolloutModeEnforce || rollout.ActiveVersion == nil || *rollout.ActiveVersion <= 0 {
+		fallback.RolloutMode = strings.TrimSpace(rollout.Mode)
+		return fallback, nil
+	}
+
+	version, err := r.store.GetAuthzPolicyVersion(ctx, r.policySet, *rollout.ActiveVersion)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return fallback, nil
+		}
+		return resolvedCentralPolicyRuntime{}, fmt.Errorf("resolve active policy version: %w", err)
+	}
+	compiled, err := r.compiledVersion(version)
+	if err != nil {
+		return resolvedCentralPolicyRuntime{}, err
+	}
+	return resolvedCentralPolicyRuntime{
+		Engine:      newCentralPolicyEngineFromCompiled(r.store, compiled),
+		Registry:    compiled.RouteRegistry,
+		Source:      "persisted_active_version",
+		PolicySetID: r.policySet,
+		Version:     version.Version,
+		RolloutMode: rollout.Mode,
+	}, nil
+}
+
+func (r *storeBackedCentralPolicyRuntimeResolver) fallbackRuntime() resolvedCentralPolicyRuntime {
+	return resolvedCentralPolicyRuntime{
+		Engine:      newCentralPolicyEngineFromCompiled(r.store, r.fallback),
+		Registry:    r.fallback.RouteRegistry,
+		Source:      "built_in_default",
+		PolicySetID: r.policySet,
+		RolloutMode: db.AuthzPolicyRolloutModeDisabled,
+	}
+}
+
+func (r *storeBackedCentralPolicyRuntimeResolver) compiledVersion(version db.AuthzPolicyVersion) (compiledRouteAuthorizationPolicy, error) {
+	cacheKey := strings.ToLower(strings.TrimSpace(version.PolicySetID)) + "|" + strconv.Itoa(version.Version) + "|" + strings.ToLower(strings.TrimSpace(version.Checksum))
+	if cacheKey != "||" {
+		if cached, exists := r.cacheByKey.Load(cacheKey); exists {
+			compiled, ok := cached.(compiledRouteAuthorizationPolicy)
+			if ok {
+				return compiled, nil
+			}
+		}
+	}
+	compiled, err := compileRouteAuthorizationPolicyBundleJSON(version.Bundle)
+	if err != nil {
+		return compiledRouteAuthorizationPolicy{}, fmt.Errorf("compile policy version %d: %w", version.Version, err)
+	}
+	if cacheKey != "||" {
+		r.cacheByKey.Store(cacheKey, compiled)
+	}
+	return compiled, nil
+}
+
+func newCentralPolicyEngineFromCompiled(store db.Store, compiled compiledRouteAuthorizationPolicy) *PolicyEngine {
+	return NewPolicyEngine(
+		newTenantIsolationEvaluator(),
+		newRBACRequirementEvaluator(compiled.RBACActionRole),
+		newABACPolicyEvaluator(compiled.ABACPolicies),
+		newReBACPolicyEvaluator(store, compiled.ReBACPolicies),
+	)
+}
+
+func compileRouteAuthorizationPolicyBundleJSON(raw string) (compiledRouteAuthorizationPolicy, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return compiledRouteAuthorizationPolicy{}, fmt.Errorf("policy bundle is empty")
+	}
+	var bundle routeAuthorizationPolicyBundle
+	if err := json.Unmarshal([]byte(trimmed), &bundle); err != nil {
+		return compiledRouteAuthorizationPolicy{}, fmt.Errorf("decode policy bundle json: %w", err)
+	}
+	return compileRouteAuthorizationPolicyBundle(bundle)
+}
+
+func compileRouteAuthorizationPolicyBundle(bundle routeAuthorizationPolicyBundle) (compiledRouteAuthorizationPolicy, error) {
+	if strings.TrimSpace(bundle.SchemaVersion) != routeAuthorizationPolicyBundleSchemaV1 {
+		return compiledRouteAuthorizationPolicy{}, fmt.Errorf("unsupported policy bundle schema version %q", bundle.SchemaVersion)
+	}
+
+	registry, actions, err := compileRoutePolicies(bundle.RoutePolicies)
+	if err != nil {
+		return compiledRouteAuthorizationPolicy{}, err
+	}
+	rbac, err := compileRBACRoleGrants(bundle.RBACActionRole, actions)
+	if err != nil {
+		return compiledRouteAuthorizationPolicy{}, err
+	}
+	abac, err := compileABACPolicies(bundle.ABACPolicies, actions)
+	if err != nil {
+		return compiledRouteAuthorizationPolicy{}, err
+	}
+	rebac, err := compileReBACPolicies(bundle.ReBACPolicies, actions)
+	if err != nil {
+		return compiledRouteAuthorizationPolicy{}, err
+	}
+
+	return compiledRouteAuthorizationPolicy{
+		RouteRegistry:  registry,
+		RBACActionRole: rbac,
+		ABACPolicies:   abac,
+		ReBACPolicies:  rebac,
+	}, nil
+}
+
+func compileRoutePolicies(definitions []routePolicyDefinition) (routePolicyRegistry, map[string]struct{}, error) {
+	if len(definitions) == 0 {
+		return nil, nil, fmt.Errorf("at least one route policy is required")
+	}
+	registry := routePolicyRegistry{}
+	actions := map[string]struct{}{}
+	for _, definition := range definitions {
+		normalized, err := normalizeRoutePolicyDefinition(definition)
+		if err != nil {
+			return nil, nil, err
+		}
+		key := routePolicyKey(normalized.Method, normalized.Path)
+		if _, exists := registry[key]; exists {
+			return nil, nil, fmt.Errorf("duplicate route policy for %s %s", normalized.Method, normalized.Path)
+		}
+		registry[key] = routePolicy{
+			Action:          normalized.Action,
+			ResourceType:    normalized.ResourceType,
+			ResourceIDParam: normalized.ResourceIDParam,
+		}
+		actions[normalized.Action] = struct{}{}
+	}
+	return registry, actions, nil
+}
+
+func normalizeRoutePolicyDefinition(definition routePolicyDefinition) (routePolicyDefinition, error) {
+	method := strings.ToUpper(strings.TrimSpace(definition.Method))
+	if method == "" {
+		return routePolicyDefinition{}, fmt.Errorf("route policy method is required")
+	}
+	if _, ok := validHTTPMethods()[method]; !ok {
+		return routePolicyDefinition{}, fmt.Errorf("unsupported route policy method %q", method)
+	}
+	path := strings.TrimSpace(definition.Path)
+	if path == "" || !strings.HasPrefix(path, "/") {
+		return routePolicyDefinition{}, fmt.Errorf("route policy path must be absolute")
+	}
+	if !strings.HasPrefix(path, "/v1/") {
+		return routePolicyDefinition{}, fmt.Errorf("route policy path must target /v1 routes")
+	}
+	action := strings.ToLower(strings.TrimSpace(definition.Action))
+	if action == "" {
+		return routePolicyDefinition{}, fmt.Errorf("route policy action is required")
+	}
+	resourceType := strings.ToLower(strings.TrimSpace(definition.ResourceType))
+	if resourceType == "" {
+		return routePolicyDefinition{}, fmt.Errorf("route policy resource_type is required")
+	}
+	resourceIDParam := strings.TrimSpace(definition.ResourceIDParam)
+	if resourceIDParam != "" {
+		if !strings.Contains(path, ":"+resourceIDParam) {
+			return routePolicyDefinition{}, fmt.Errorf("route policy resource_id_param %q is not present in path %q", resourceIDParam, path)
+		}
+	}
+	return routePolicyDefinition{
+		Method:          method,
+		Path:            path,
+		Action:          action,
+		ResourceType:    resourceType,
+		ResourceIDParam: resourceIDParam,
+	}, nil
+}
+
+func compileRBACRoleGrants(grants map[string][]string, routeActions map[string]struct{}) (map[string][]string, error) {
+	if len(grants) == 0 {
+		return nil, fmt.Errorf("rbac_action_roles must not be empty")
+	}
+	normalized := map[string][]string{}
+	for action, roles := range grants {
+		normalizedAction := strings.ToLower(strings.TrimSpace(action))
+		if normalizedAction == "" {
+			return nil, fmt.Errorf("rbac action key is required")
+		}
+		if _, exists := routeActions[normalizedAction]; !exists {
+			return nil, fmt.Errorf("rbac action %q is not referenced by any route policy", normalizedAction)
+		}
+		roleSet := map[string]struct{}{}
+		for _, role := range roles {
+			normalizedRole := strings.ToLower(strings.TrimSpace(role))
+			if normalizedRole == "" {
+				continue
+			}
+			roleSet[normalizedRole] = struct{}{}
+		}
+		if len(roleSet) == 0 {
+			return nil, fmt.Errorf("rbac action %q must include at least one role", normalizedAction)
+		}
+		normalizedRoles := make([]string, 0, len(roleSet))
+		for role := range roleSet {
+			normalizedRoles = append(normalizedRoles, role)
+		}
+		sort.Strings(normalizedRoles)
+		normalized[normalizedAction] = normalizedRoles
+	}
+	for action := range routeActions {
+		if _, exists := normalized[action]; !exists {
+			return nil, fmt.Errorf("rbac action %q is required by route policy but missing", action)
+		}
+	}
+	return normalized, nil
+}
+
+func compileABACPolicies(policies map[string]abacActionPolicy, routeActions map[string]struct{}) (map[string]abacActionPolicy, error) {
+	if len(policies) == 0 {
+		return nil, fmt.Errorf("abac_policies must not be empty")
+	}
+	for action, policy := range policies {
+		normalizedAction := strings.ToLower(strings.TrimSpace(action))
+		if normalizedAction == "" {
+			return nil, fmt.Errorf("abac policy action key is required")
+		}
+		if _, exists := routeActions[normalizedAction]; !exists {
+			return nil, fmt.Errorf("abac policy action %q is not referenced by any route policy", normalizedAction)
+		}
+		if err := validateABACActionPolicy(policy, "abac_policies."+normalizedAction); err != nil {
+			return nil, err
+		}
+	}
+	normalized := normalizeABACPolicies(policies)
+	for action := range routeActions {
+		if _, exists := normalized[action]; !exists {
+			return nil, fmt.Errorf("abac policy for action %q is required", action)
+		}
+	}
+	return normalized, nil
+}
+
+func compileReBACPolicies(policies map[string]rebacActionPolicy, routeActions map[string]struct{}) (map[string]rebacActionPolicy, error) {
+	if len(policies) == 0 {
+		return map[string]rebacActionPolicy{}, nil
+	}
+	for action, policy := range policies {
+		normalizedAction := strings.ToLower(strings.TrimSpace(action))
+		if normalizedAction == "" {
+			return nil, fmt.Errorf("rebac policy action key is required")
+		}
+		if _, exists := routeActions[normalizedAction]; !exists {
+			return nil, fmt.Errorf("rebac policy action %q is not referenced by any route policy", normalizedAction)
+		}
+		if err := validateReBACActionPolicy(policy, "rebac_policies."+normalizedAction); err != nil {
+			return nil, err
+		}
+	}
+	return normalizeReBACPolicies(policies), nil
+}
+
+func validateABACActionPolicy(policy abacActionPolicy, path string) error {
+	for clauseIndex, clause := range policy.AnyOf {
+		for predicateIndex, predicate := range clause.AllOf {
+			if err := validateABACPredicate(predicate); err != nil {
+				return fmt.Errorf("%s.any_of[%d].all_of[%d]: %w", path, clauseIndex, predicateIndex, err)
+			}
+		}
+	}
+	normalizedOnNoMatch := strings.ToLower(strings.TrimSpace(string(policy.OnNoMatch)))
+	if normalizedOnNoMatch != "" {
+		switch PolicyOutcome(normalizedOnNoMatch) {
+		case PolicyOutcomeNoOpinion, PolicyOutcomeAllow, PolicyOutcomeDeny:
+		default:
+			return fmt.Errorf("%s.on_no_match: invalid outcome %q", path, policy.OnNoMatch)
+		}
+	}
+	return nil
+}
+
+func validateABACPredicate(predicate abacPredicate) error {
+	source := strings.ToLower(strings.TrimSpace(string(predicate.Source)))
+	switch abacAttributeSource(source) {
+	case abacAttributeSourceSubject, abacAttributeSourceResource, abacAttributeSourceContext:
+	default:
+		return fmt.Errorf("invalid source %q", predicate.Source)
+	}
+	if strings.TrimSpace(predicate.Key) == "" {
+		return fmt.Errorf("key is required")
+	}
+	operator := strings.ToLower(strings.TrimSpace(string(predicate.Operator)))
+	if operator == "" {
+		operator = string(abacOperatorEquals)
+	}
+	switch abacOperator(operator) {
+	case abacOperatorEquals:
+		if strings.TrimSpace(predicate.Value) == "" {
+			return fmt.Errorf("equals operator requires value")
+		}
+	case abacOperatorOneOf:
+		hasValue := false
+		for _, value := range predicate.Values {
+			if strings.TrimSpace(value) == "" {
+				continue
+			}
+			hasValue = true
+			break
+		}
+		if !hasValue {
+			return fmt.Errorf("one_of operator requires values")
+		}
+	case abacOperatorEqualsAttribute:
+		compareSource := strings.ToLower(strings.TrimSpace(string(predicate.CompareSource)))
+		switch abacAttributeSource(compareSource) {
+		case abacAttributeSourceSubject, abacAttributeSourceResource, abacAttributeSourceContext:
+		default:
+			return fmt.Errorf("equals_attribute requires valid compare_source")
+		}
+		if strings.TrimSpace(predicate.CompareKey) == "" {
+			return fmt.Errorf("equals_attribute requires compare_key")
+		}
+	default:
+		return fmt.Errorf("unsupported operator %q", predicate.Operator)
+	}
+	return nil
+}
+
+func validateReBACActionPolicy(policy rebacActionPolicy, path string) error {
+	for pathIndex, relationPath := range policy.AnyOf {
+		if len(relationPath.Relations) == 0 {
+			return fmt.Errorf("%s.any_of[%d]: relations are required", path, pathIndex)
+		}
+		for relationIndex, relation := range relationPath.Relations {
+			normalizedRelation := strings.ToLower(strings.TrimSpace(relation))
+			if !isSupportedReBACRelation(normalizedRelation) {
+				return fmt.Errorf("%s.any_of[%d].relations[%d]: unsupported relation %q", path, pathIndex, relationIndex, relation)
+			}
+		}
+		for conditionIndex, condition := range relationPath.AllOf {
+			if err := validateABACPredicate(condition); err != nil {
+				return fmt.Errorf("%s.any_of[%d].all_of[%d]: %w", path, pathIndex, conditionIndex, err)
+			}
+		}
+	}
+	return nil
+}
+
+func validateAuthzPolicyRolloutActivation(ctx context.Context, store db.Store, policySetID string, rollout db.AuthzPolicyRollout) error {
+	if store == nil {
+		return fmt.Errorf("policy store is required")
+	}
+	normalizedPolicySetID := strings.ToLower(strings.TrimSpace(policySetID))
+	if normalizedPolicySetID == "" {
+		return fmt.Errorf("policy set id is required")
+	}
+	if rollout.ActiveVersion != nil {
+		if err := validateAuthzPolicyVersionBundle(ctx, store, normalizedPolicySetID, *rollout.ActiveVersion); err != nil {
+			return fmt.Errorf("active version validation failed: %w", err)
+		}
+	}
+	if rollout.CandidateVersion != nil {
+		if err := validateAuthzPolicyVersionBundle(ctx, store, normalizedPolicySetID, *rollout.CandidateVersion); err != nil {
+			return fmt.Errorf("candidate version validation failed: %w", err)
+		}
+	}
+	return nil
+}
+
+func validateAuthzPolicyVersionBundle(ctx context.Context, store db.Store, policySetID string, version int) error {
+	if version <= 0 {
+		return fmt.Errorf("version must be greater than zero")
+	}
+	record, err := store.GetAuthzPolicyVersion(ctx, policySetID, version)
+	if err != nil {
+		return err
+	}
+	if _, err := compileRouteAuthorizationPolicyBundleJSON(record.Bundle); err != nil {
+		return err
+	}
+	return nil
+}
+
+func defaultBuiltInRouteAuthorizationPolicyBundle() routeAuthorizationPolicyBundle {
+	return routeAuthorizationPolicyBundle{
+		SchemaVersion:  routeAuthorizationPolicyBundleSchemaV1,
+		RoutePolicies:  defaultBuiltInRoutePolicyDefinitions(),
+		RBACActionRole: defaultRouteActionRoleGrants(),
+		ABACPolicies:   defaultRouteActionABACPolicies(),
+		ReBACPolicies:  defaultRouteActionReBACPolicies(),
+	}
+}
+
+func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
+	return []routePolicyDefinition{
+		{Method: http.MethodGet, Path: "/v1/findings", Action: policyActionFindingsRead, ResourceType: "finding"},
+		{Method: http.MethodGet, Path: "/v1/findings/:finding_id", Action: policyActionFindingsRead, ResourceType: "finding", ResourceIDParam: "finding_id"},
+		{Method: http.MethodGet, Path: "/v1/findings/:finding_id/history", Action: policyActionFindingsRead, ResourceType: "finding_history", ResourceIDParam: "finding_id"},
+		{Method: http.MethodGet, Path: "/v1/findings/:finding_id/exports", Action: policyActionFindingsRead, ResourceType: "finding_export", ResourceIDParam: "finding_id"},
+		{Method: http.MethodGet, Path: "/v1/findings/trends", Action: policyActionFindingsRead, ResourceType: "finding_trend"},
+		{Method: http.MethodGet, Path: "/v1/findings/summary", Action: policyActionFindingsRead, ResourceType: "finding_summary"},
+		{Method: http.MethodPatch, Path: "/v1/findings/:finding_id/triage", Action: policyActionFindingsTriage, ResourceType: "finding", ResourceIDParam: "finding_id"},
+		{Method: http.MethodGet, Path: "/v1/identities", Action: policyActionGraphRead, ResourceType: "identity"},
+		{Method: http.MethodGet, Path: "/v1/relationships", Action: policyActionGraphRead, ResourceType: "relationship"},
+		{Method: http.MethodGet, Path: "/v1/ownership/signals", Action: policyActionGraphRead, ResourceType: "ownership_signal"},
+		{Method: http.MethodGet, Path: "/v1/scans", Action: policyActionScansRead, ResourceType: "scan"},
+		{Method: http.MethodGet, Path: "/v1/scans/:scan_id/diff", Action: policyActionScansRead, ResourceType: "scan_diff", ResourceIDParam: "scan_id"},
+		{Method: http.MethodGet, Path: "/v1/scans/:scan_id/events", Action: policyActionScansRead, ResourceType: "scan_event", ResourceIDParam: "scan_id"},
+		{Method: http.MethodPost, Path: "/v1/scans", Action: policyActionScansRun, ResourceType: "scan"},
+		{Method: http.MethodGet, Path: "/v1/repo-scans", Action: policyActionRepoScansRead, ResourceType: "repo_scan"},
+		{Method: http.MethodGet, Path: "/v1/repo-scans/:repo_scan_id", Action: policyActionRepoScansRead, ResourceType: "repo_scan", ResourceIDParam: "repo_scan_id"},
+		{Method: http.MethodGet, Path: "/v1/repo-findings", Action: policyActionRepoScansRead, ResourceType: "repo_finding"},
+		{Method: http.MethodPost, Path: "/v1/repo-scans", Action: policyActionRepoScansRun, ResourceType: "repo_scan"},
+	}
+}
+
+func validHTTPMethods() map[string]struct{} {
+	return map[string]struct{}{
+		http.MethodGet:     {},
+		http.MethodHead:    {},
+		http.MethodPost:    {},
+		http.MethodPut:     {},
+		http.MethodPatch:   {},
+		http.MethodDelete:  {},
+		http.MethodOptions: {},
+	}
+}

--- a/internal/api/authz_policy_bundle_runtime_test.go
+++ b/internal/api/authz_policy_bundle_runtime_test.go
@@ -1,0 +1,297 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
+)
+
+func TestCompileRouteAuthorizationPolicyBundleRejectsInvalidABACPredicate(t *testing.T) {
+	bundle := routeAuthorizationPolicyBundle{
+		SchemaVersion: routeAuthorizationPolicyBundleSchemaV1,
+		RoutePolicies: []routePolicyDefinition{{
+			Method:       "PATCH",
+			Path:         "/v1/findings/:finding_id/triage",
+			Action:       policyActionFindingsTriage,
+			ResourceType: "finding",
+		}},
+		RBACActionRole: map[string][]string{
+			policyActionFindingsTriage: {scopeWrite, scopeAdmin},
+		},
+		ABACPolicies: map[string]abacActionPolicy{
+			policyActionFindingsTriage: {
+				AnyOf: []abacClause{{
+					AllOf: []abacPredicate{{
+						Source:        abacAttributeSourceSubject,
+						Key:           policyAttributeOwnerTeam,
+						Operator:      abacOperatorEqualsAttribute,
+						CompareSource: abacAttributeSourceResource,
+					}},
+				}},
+			},
+		},
+	}
+
+	_, err := compileRouteAuthorizationPolicyBundle(bundle)
+	if err == nil {
+		t.Fatal("expected invalid abac expression to fail compilation")
+	}
+	if !strings.Contains(err.Error(), "compare_key") {
+		t.Fatalf("expected compare_key error, got %v", err)
+	}
+}
+
+func TestCompileRouteAuthorizationPolicyBundleRejectsInvalidReBACRelation(t *testing.T) {
+	bundle := routeAuthorizationPolicyBundle{
+		SchemaVersion: routeAuthorizationPolicyBundleSchemaV1,
+		RoutePolicies: []routePolicyDefinition{{
+			Method:       "PATCH",
+			Path:         "/v1/findings/:finding_id/triage",
+			Action:       policyActionFindingsTriage,
+			ResourceType: "finding",
+		}},
+		RBACActionRole: map[string][]string{
+			policyActionFindingsTriage: {scopeWrite, scopeAdmin},
+		},
+		ABACPolicies: map[string]abacActionPolicy{
+			policyActionFindingsTriage: {
+				AnyOf: []abacClause{{}},
+			},
+		},
+		ReBACPolicies: map[string]rebacActionPolicy{
+			policyActionFindingsTriage: {
+				AnyOf: []rebacRelationPath{{Relations: []string{"viewer"}}},
+			},
+		},
+	}
+
+	_, err := compileRouteAuthorizationPolicyBundle(bundle)
+	if err == nil {
+		t.Fatal("expected invalid rebac relation to fail compilation")
+	}
+	if !strings.Contains(err.Error(), "unsupported relation") {
+		t.Fatalf("expected unsupported relation error, got %v", err)
+	}
+}
+
+func TestCentralPolicyRuntimeResolverFallsBackWhenNoActiveRollout(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := testAuthzPolicyScopeContext()
+	resolver := newCentralPolicyRuntimeResolverWithPolicySet(store, defaultCentralPolicySetID)
+
+	runtimePolicy, err := resolver.Resolve(ctx)
+	if err != nil {
+		t.Fatalf("resolve runtime policy fallback: %v", err)
+	}
+	if runtimePolicy.Source != "built_in_default" {
+		t.Fatalf("expected built-in fallback source, got %q", runtimePolicy.Source)
+	}
+	if _, exists := runtimePolicy.Registry.lookup("POST", "/v1/scans"); !exists {
+		t.Fatal("expected built-in route policy for POST /v1/scans")
+	}
+}
+
+func TestCentralPolicyRuntimeResolverUsesPersistedActiveVersion(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := testAuthzPolicyScopeContext()
+	resolver := newCentralPolicyRuntimeResolverWithPolicySet(store, defaultCentralPolicySetID)
+
+	if err := store.UpsertAuthzPolicySet(ctx, db.AuthzPolicySet{
+		PolicySetID: defaultCentralPolicySetID,
+		DisplayName: "Central Authorization",
+		CreatedBy:   "test",
+	}); err != nil {
+		t.Fatalf("upsert policy set: %v", err)
+	}
+
+	bundle := routeAuthorizationPolicyBundle{
+		SchemaVersion: routeAuthorizationPolicyBundleSchemaV1,
+		RoutePolicies: []routePolicyDefinition{{
+			Method:       "GET",
+			Path:         "/v1/findings",
+			Action:       policyActionFindingsRead,
+			ResourceType: "finding",
+		}},
+		RBACActionRole: map[string][]string{
+			policyActionFindingsRead: {scopeRead, scopeWrite, scopeAdmin},
+		},
+		ABACPolicies: map[string]abacActionPolicy{
+			policyActionFindingsRead: {
+				AnyOf: []abacClause{{}},
+			},
+		},
+	}
+	bundleBytes, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("marshal policy bundle: %v", err)
+	}
+
+	createdVersion, err := store.CreateAuthzPolicyVersion(ctx, db.AuthzPolicyVersion{
+		PolicySetID: defaultCentralPolicySetID,
+		Version:     1,
+		Bundle:      string(bundleBytes),
+		CreatedBy:   "test",
+	})
+	if err != nil {
+		t.Fatalf("create policy version: %v", err)
+	}
+
+	if err := store.UpsertAuthzPolicyRollout(ctx, db.AuthzPolicyRollout{
+		PolicySetID:   defaultCentralPolicySetID,
+		ActiveVersion: &createdVersion.Version,
+		Mode:          db.AuthzPolicyRolloutModeEnforce,
+		UpdatedBy:     "test",
+	}); err != nil {
+		t.Fatalf("upsert policy rollout: %v", err)
+	}
+
+	runtimePolicy, err := resolver.Resolve(ctx)
+	if err != nil {
+		t.Fatalf("resolve runtime policy persisted active version: %v", err)
+	}
+	if runtimePolicy.Source != "persisted_active_version" {
+		t.Fatalf("expected persisted source, got %q", runtimePolicy.Source)
+	}
+	if runtimePolicy.Version != 1 {
+		t.Fatalf("expected active version 1, got %d", runtimePolicy.Version)
+	}
+	policy, exists := runtimePolicy.Registry.lookup("GET", "/v1/findings")
+	if !exists {
+		t.Fatal("expected persisted route policy for GET /v1/findings")
+	}
+	if policy.Action != policyActionFindingsRead {
+		t.Fatalf("expected persisted action %q, got %q", policyActionFindingsRead, policy.Action)
+	}
+}
+
+func TestCentralPolicyRuntimeResolverFallsBackWhenRolloutIsShadow(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := testAuthzPolicyScopeContext()
+	resolver := newCentralPolicyRuntimeResolverWithPolicySet(store, defaultCentralPolicySetID)
+
+	if err := store.UpsertAuthzPolicySet(ctx, db.AuthzPolicySet{
+		PolicySetID: defaultCentralPolicySetID,
+		DisplayName: "Central Authorization",
+		CreatedBy:   "test",
+	}); err != nil {
+		t.Fatalf("upsert policy set: %v", err)
+	}
+
+	bundle := routeAuthorizationPolicyBundle{
+		SchemaVersion: routeAuthorizationPolicyBundleSchemaV1,
+		RoutePolicies: []routePolicyDefinition{{
+			Method:       "GET",
+			Path:         "/v1/findings",
+			Action:       policyActionFindingsRead,
+			ResourceType: "finding",
+		}},
+		RBACActionRole: map[string][]string{
+			policyActionFindingsRead: {scopeRead, scopeWrite, scopeAdmin},
+		},
+		ABACPolicies: map[string]abacActionPolicy{
+			policyActionFindingsRead: {
+				AnyOf: []abacClause{{}},
+			},
+		},
+	}
+	bundleBytes, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("marshal policy bundle: %v", err)
+	}
+	createdVersion, err := store.CreateAuthzPolicyVersion(ctx, db.AuthzPolicyVersion{
+		PolicySetID: defaultCentralPolicySetID,
+		Version:     1,
+		Bundle:      string(bundleBytes),
+		CreatedBy:   "test",
+	})
+	if err != nil {
+		t.Fatalf("create policy version: %v", err)
+	}
+	if err := store.UpsertAuthzPolicyRollout(ctx, db.AuthzPolicyRollout{
+		PolicySetID:   defaultCentralPolicySetID,
+		ActiveVersion: &createdVersion.Version,
+		Mode:          db.AuthzPolicyRolloutModeShadow,
+		UpdatedBy:     "test",
+	}); err != nil {
+		t.Fatalf("upsert policy rollout: %v", err)
+	}
+
+	runtimePolicy, err := resolver.Resolve(ctx)
+	if err != nil {
+		t.Fatalf("resolve runtime policy for shadow mode: %v", err)
+	}
+	if runtimePolicy.Source != "built_in_default" {
+		t.Fatalf("expected built-in fallback source for shadow mode, got %q", runtimePolicy.Source)
+	}
+	if runtimePolicy.RolloutMode != db.AuthzPolicyRolloutModeShadow {
+		t.Fatalf("expected shadow rollout mode, got %q", runtimePolicy.RolloutMode)
+	}
+	if runtimePolicy.Version != 0 {
+		t.Fatalf("expected no enforced version in shadow fallback, got %d", runtimePolicy.Version)
+	}
+}
+
+func TestValidateAuthzPolicyRolloutActivationRejectsInvalidBundle(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := testAuthzPolicyScopeContext()
+
+	if err := store.UpsertAuthzPolicySet(ctx, db.AuthzPolicySet{
+		PolicySetID: defaultCentralPolicySetID,
+		DisplayName: "Central Authorization",
+		CreatedBy:   "test",
+	}); err != nil {
+		t.Fatalf("upsert policy set: %v", err)
+	}
+
+	invalidBundle := routeAuthorizationPolicyBundle{
+		SchemaVersion: routeAuthorizationPolicyBundleSchemaV1,
+		RoutePolicies: []routePolicyDefinition{{
+			Method:       "PATCH",
+			Path:         "/v1/findings/:finding_id/triage",
+			Action:       policyActionFindingsTriage,
+			ResourceType: "finding",
+		}},
+		RBACActionRole: map[string][]string{
+			policyActionFindingsTriage: {scopeWrite, scopeAdmin},
+		},
+		ABACPolicies: map[string]abacActionPolicy{
+			policyActionFindingsTriage: {
+				AnyOf: []abacClause{{
+					AllOf: []abacPredicate{{
+						Source:   abacAttributeSourceSubject,
+						Key:      policyAttributeOwnerTeam,
+						Operator: abacOperatorOneOf,
+					}},
+				}},
+			},
+		},
+	}
+	bundleBytes, err := json.Marshal(invalidBundle)
+	if err != nil {
+		t.Fatalf("marshal invalid bundle: %v", err)
+	}
+	version, err := store.CreateAuthzPolicyVersion(ctx, db.AuthzPolicyVersion{
+		PolicySetID: defaultCentralPolicySetID,
+		Version:     1,
+		Bundle:      string(bundleBytes),
+		CreatedBy:   "test",
+	})
+	if err != nil {
+		t.Fatalf("create invalid policy version: %v", err)
+	}
+	rollout := db.AuthzPolicyRollout{
+		PolicySetID:   defaultCentralPolicySetID,
+		ActiveVersion: &version.Version,
+		Mode:          db.AuthzPolicyRolloutModeEnforce,
+	}
+	if err := validateAuthzPolicyRolloutActivation(ctx, store, defaultCentralPolicySetID, rollout); err == nil {
+		t.Fatal("expected invalid bundle to fail activation validation")
+	}
+}
+
+func testAuthzPolicyScopeContext() context.Context {
+	return db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -114,7 +114,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 	v1 := r.Group("/v1")
 	v1.Use(apiKeyAuthMiddleware(opts.APIKeys, opts.APIKeyScopes, opts.OIDCTokenVerifier, opts.OIDCWriteScopes))
 	v1.Use(requestScopeMiddleware(opts.DefaultTenantID, opts.DefaultWorkspaceID))
-	v1.Use(requireCentralPolicyMiddleware(newCentralPolicyEngine(authzStore), newRoutePolicyRegistry(), opts.WriteAPIKeys, opts.APIKeyScopes, authzStore))
+	v1.Use(requireCentralPolicyMiddleware(newCentralPolicyRuntimeResolver(authzStore), opts.WriteAPIKeys, opts.APIKeyScopes, authzStore))
 	v1.Use(rateLimitMiddleware(opts.RateLimitRPM, opts.RateLimitBurst))
 	v1.Use(auditLogMiddleware(logger, opts.AuditSink))
 


### PR DESCRIPTION
## Summary
- introduce a persisted policy-bundle schema (`route_policies`, `rbac_action_roles`, `abac_policies`, `rebac_policies`) and compile it into runtime evaluators
- move route authorization config from hardcoded route-policy maps into bundle-driven compilation
- add strict compile-time validation for ABAC/ReBAC expressions and action wiring consistency
- add a runtime resolver that determines the effective policy version for the current request scope from rollout + active version
- keep safe fallback to built-in defaults when no active enforce-mode policy is present

## Validation
- go test ./internal/api/...
- go test ./...

## Scope
- middleware and router now resolve policy runtime dynamically via resolver
- persisted policy bundles are compiled and cached by `policy_set + version + checksum`
- helper validation (`validateAuthzPolicyRolloutActivation`) is available for rollout write paths to reject invalid policy expressions before activation

## Notes
- this is stacked on top of PR-7.1 (`feat/authz-policy-lifecycle-7-1-storage`)
- shadow/disabled rollout modes do not enforce persisted policy versions; they intentionally fall back to built-in defaults


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a policy bundle compiler and a runtime resolver for authorization, replacing hardcoded route policies with persisted, versioned bundles. Middleware now resolves the active policy per request based on rollout, with safe fallbacks.

- New Features
  - Introduces a persisted route authorization bundle (route_policies, rbac_action_roles, abac_policies, rebac_policies) compiled into runtime evaluators.
  - Adds strict compile-time validation for ABAC/ReBAC expressions, action wiring, and HTTP method/path constraints.
  - Resolves the effective policy at request time from rollout + active version; shadow/disabled modes fall back to built-in defaults.
  - Caches compiled bundles by policy_set + version + checksum.
  - Middleware records policy metadata on the request context (policy_source, policy_set_id, rollout_mode, policy_version).

- Refactors
  - Replaced hardcoded route-policy maps with bundle-driven compilation.
  - Updated `requireCentralPolicyMiddleware` to accept a runtime resolver; router now uses it.
  - Added unit tests for the compiler, resolver, and rollout activation validation.

<sup>Written for commit 1d194d0d7da3a409842c092536c08b8dd870ff3d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

