### PR TITLE
feat(authz): PR-7.3 dry-run simulation endpoint with explainability

### DIFF
--- a/internal/api/authz_middleware.go
+++ b/internal/api/authz_middleware.go
@@ -20,6 +20,7 @@ const (
 	policyActionScansRun       = "scans.run"
 	policyActionRepoScansRead  = "repo_scans.read"
 	policyActionRepoScansRun   = "repo_scans.run"
+	policyActionAuthzSimulate  = "authz.policies.simulate"
 
 	policyContextABACSubjectAttrsLoadedKey  = "abac.subject_attributes_loaded"
 	policyContextABACResourceAttrsLoadedKey = "abac.resource_attributes_loaded"
@@ -61,6 +62,7 @@ func defaultRouteActionRoleGrants() map[string][]string {
 		policyActionScansRun:       writeRoles,
 		policyActionRepoScansRead:  readRoles,
 		policyActionRepoScansRun:   writeRoles,
+		policyActionAuthzSimulate:  {scopeAdmin},
 	}
 }
 
@@ -83,6 +85,7 @@ func defaultRouteActionABACPolicies() map[string]abacActionPolicy {
 		policyActionScansRun:      passThroughPolicy,
 		policyActionRepoScansRead: passThroughPolicy,
 		policyActionRepoScansRun:  passThroughPolicy,
+		policyActionAuthzSimulate: passThroughPolicy,
 		policyActionFindingsTriage: {
 			OnNoMatch: PolicyOutcomeNoOpinion,
 			AnyOf: []abacClause{

--- a/internal/api/authz_policy.go
+++ b/internal/api/authz_policy.go
@@ -25,6 +25,7 @@ const (
 	PolicyOutcomeNoOpinion PolicyOutcome = "no_op"
 	PolicyOutcomeAllow     PolicyOutcome = "allow"
 	PolicyOutcomeDeny      PolicyOutcome = "deny"
+	PolicyOutcomeSkipped   PolicyOutcome = "skipped"
 )
 
 // PolicySubject is the actor for one authorization decision.
@@ -70,6 +71,13 @@ type PolicyDecision struct {
 	Reason  string
 }
 
+// PolicyTraceStep captures one stage-level evaluator outcome for explainability.
+type PolicyTraceStep struct {
+	Stage   PolicyStage   `json:"stage"`
+	Outcome PolicyOutcome `json:"outcome"`
+	Reason  string        `json:"reason"`
+}
+
 // PolicyEvaluator evaluates one authorization layer.
 type PolicyEvaluator interface {
 	Evaluate(ctx context.Context, input PolicyInput) (PolicyOutcome, string, error)
@@ -96,38 +104,120 @@ func NewPolicyEngine(tenantIsolation PolicyEvaluator, rbac PolicyEvaluator, abac
 
 // Decide evaluates authorization policies and returns one normalized decision.
 func (p *PolicyEngine) Decide(ctx context.Context, input PolicyInput) (PolicyDecision, error) {
-	if p == nil {
-		return denyDecision(PolicyStageDefaultDeny, "authorization policy engine is not configured"), nil
-	}
-	for _, stage := range []struct {
+	decision, _, err := p.DecideWithTrace(ctx, input)
+	return decision, err
+}
+
+// DecideWithTrace evaluates authorization and returns a full stage-by-stage trace.
+func (p *PolicyEngine) DecideWithTrace(ctx context.Context, input PolicyInput) (PolicyDecision, []PolicyTraceStep, error) {
+	stages := []struct {
 		name      PolicyStage
 		evaluator PolicyEvaluator
 	}{
-		{name: PolicyStageTenantIsolation, evaluator: p.TenantIsolationEvaluator},
-		{name: PolicyStageRBAC, evaluator: p.RBACEvaluator},
-		{name: PolicyStageABAC, evaluator: p.ABACEvaluator},
-		{name: PolicyStageReBAC, evaluator: p.ReBACEvaluator},
-	} {
+		{name: PolicyStageTenantIsolation, evaluator: nil},
+		{name: PolicyStageRBAC, evaluator: nil},
+		{name: PolicyStageABAC, evaluator: nil},
+		{name: PolicyStageReBAC, evaluator: nil},
+	}
+
+	if p == nil {
+		trace := make([]PolicyTraceStep, 0, len(stages)+1)
+		for _, stage := range stages {
+			trace = append(trace, PolicyTraceStep{
+				Stage:   stage.name,
+				Outcome: PolicyOutcomeSkipped,
+				Reason:  "policy engine is not configured",
+			})
+		}
+		decision := denyDecision(PolicyStageDefaultDeny, "authorization policy engine is not configured")
+		trace = append(trace, PolicyTraceStep{
+			Stage:   PolicyStageDefaultDeny,
+			Outcome: PolicyOutcomeDeny,
+			Reason:  decision.Reason,
+		})
+		return decision, trace, nil
+	}
+
+	stages[0].evaluator = p.TenantIsolationEvaluator
+	stages[1].evaluator = p.RBACEvaluator
+	stages[2].evaluator = p.ABACEvaluator
+	stages[3].evaluator = p.ReBACEvaluator
+
+	trace := make([]PolicyTraceStep, 0, len(stages)+1)
+	for index, stage := range stages {
 		if stage.evaluator == nil {
+			trace = append(trace, PolicyTraceStep{
+				Stage:   stage.name,
+				Outcome: PolicyOutcomeNoOpinion,
+				Reason:  "stage evaluator is not configured",
+			})
 			continue
 		}
 		outcome, reason, err := stage.evaluator.Evaluate(ctx, input)
 		if err != nil {
-			return PolicyDecision{}, fmt.Errorf("evaluate %s policy: %w", stage.name, err)
+			return PolicyDecision{}, trace, fmt.Errorf("evaluate %s policy: %w", stage.name, err)
 		}
 		reason = strings.TrimSpace(reason)
+		if reason == "" {
+			switch outcome {
+			case PolicyOutcomeNoOpinion:
+				reason = "no policy opinion"
+			case PolicyOutcomeAllow:
+				reason = "policy grants action"
+			case PolicyOutcomeDeny:
+				reason = "policy denies action"
+			}
+		}
+		trace = append(trace, PolicyTraceStep{
+			Stage:   stage.name,
+			Outcome: outcome,
+			Reason:  reason,
+		})
 		switch outcome {
 		case PolicyOutcomeAllow:
-			return PolicyDecision{Allowed: true, Stage: stage.name, Reason: reason}, nil
+			decision := PolicyDecision{Allowed: true, Stage: stage.name, Reason: reason}
+			for _, remaining := range stages[index+1:] {
+				trace = append(trace, PolicyTraceStep{
+					Stage:   remaining.name,
+					Outcome: PolicyOutcomeSkipped,
+					Reason:  "skipped after terminal decision at " + string(stage.name),
+				})
+			}
+			trace = append(trace, PolicyTraceStep{
+				Stage:   PolicyStageDefaultDeny,
+				Outcome: PolicyOutcomeSkipped,
+				Reason:  "skipped after terminal decision at " + string(stage.name),
+			})
+			return decision, trace, nil
 		case PolicyOutcomeDeny:
-			return denyDecision(stage.name, reason), nil
+			decision := denyDecision(stage.name, reason)
+			for _, remaining := range stages[index+1:] {
+				trace = append(trace, PolicyTraceStep{
+					Stage:   remaining.name,
+					Outcome: PolicyOutcomeSkipped,
+					Reason:  "skipped after terminal decision at " + string(stage.name),
+				})
+			}
+			trace = append(trace, PolicyTraceStep{
+				Stage:   PolicyStageDefaultDeny,
+				Outcome: PolicyOutcomeSkipped,
+				Reason:  "skipped after terminal decision at " + string(stage.name),
+			})
+			return decision, trace, nil
 		case PolicyOutcomeNoOpinion:
 			continue
 		default:
-			return PolicyDecision{}, fmt.Errorf("evaluate %s policy: invalid outcome %q", stage.name, outcome)
+			return PolicyDecision{}, trace, fmt.Errorf("evaluate %s policy: invalid outcome %q", stage.name, outcome)
 		}
 	}
-	return denyDecision(PolicyStageDefaultDeny, "no policy granted access"), nil
+
+	decision := denyDecision(PolicyStageDefaultDeny, "no policy granted access")
+	trace = append(trace, PolicyTraceStep{
+		Stage:   PolicyStageDefaultDeny,
+		Outcome: PolicyOutcomeDeny,
+		Reason:  decision.Reason,
+	})
+	return decision, trace, nil
 }
 
 func denyDecision(stage PolicyStage, reason string) PolicyDecision {

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -512,6 +512,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/repo-scans/:repo_scan_id", Action: policyActionRepoScansRead, ResourceType: "repo_scan", ResourceIDParam: "repo_scan_id"},
 		{Method: http.MethodGet, Path: "/v1/repo-findings", Action: policyActionRepoScansRead, ResourceType: "repo_finding"},
 		{Method: http.MethodPost, Path: "/v1/repo-scans", Action: policyActionRepoScansRun, ResourceType: "repo_scan"},
+		{Method: http.MethodPost, Path: "/v1/authz/policies/simulate", Action: policyActionAuthzSimulate, ResourceType: "authz_policy"},
 	}
 }
 

--- a/internal/api/authz_policy_test.go
+++ b/internal/api/authz_policy_test.go
@@ -148,3 +148,62 @@ func TestPolicyEngineDecideNilEngineDefaultsToDeny(t *testing.T) {
 		t.Fatalf("expected default deny stage, got %q", decision.Stage)
 	}
 }
+
+func TestPolicyEngineDecideWithTraceIncludesAllStages(t *testing.T) {
+	calls := []string{}
+	engine := NewPolicyEngine(
+		testPolicyEvaluator{name: "tenant", outcome: PolicyOutcomeNoOpinion, calls: &calls},
+		testPolicyEvaluator{name: "rbac", outcome: PolicyOutcomeNoOpinion, calls: &calls},
+		testPolicyEvaluator{name: "abac", outcome: PolicyOutcomeNoOpinion, calls: &calls},
+		testPolicyEvaluator{name: "rebac", outcome: PolicyOutcomeNoOpinion, calls: &calls},
+	)
+
+	decision, trace, err := engine.DecideWithTrace(context.Background(), PolicyInput{Action: "findings.read"})
+	if err != nil {
+		t.Fatalf("decide with trace: %v", err)
+	}
+	if decision.Allowed {
+		t.Fatalf("expected deny decision, got %+v", decision)
+	}
+	expectedStages := []PolicyStage{
+		PolicyStageTenantIsolation,
+		PolicyStageRBAC,
+		PolicyStageABAC,
+		PolicyStageReBAC,
+		PolicyStageDefaultDeny,
+	}
+	if len(trace) != len(expectedStages) {
+		t.Fatalf("expected %d trace steps, got %d", len(expectedStages), len(trace))
+	}
+	for i, stage := range expectedStages {
+		if trace[i].Stage != stage {
+			t.Fatalf("expected stage %q at index %d, got %q", stage, i, trace[i].Stage)
+		}
+	}
+	if trace[len(trace)-1].Outcome != PolicyOutcomeDeny {
+		t.Fatalf("expected default deny outcome in trace, got %q", trace[len(trace)-1].Outcome)
+	}
+}
+
+func TestPolicyEngineDecideWithTraceMarksSkippedStagesAfterAllow(t *testing.T) {
+	engine := NewPolicyEngine(
+		testPolicyEvaluator{name: "tenant", outcome: PolicyOutcomeNoOpinion},
+		testPolicyEvaluator{name: "rbac", outcome: PolicyOutcomeAllow, reason: "rbac permit"},
+		testPolicyEvaluator{name: "abac", outcome: PolicyOutcomeAllow},
+		testPolicyEvaluator{name: "rebac", outcome: PolicyOutcomeAllow},
+	)
+
+	decision, trace, err := engine.DecideWithTrace(context.Background(), PolicyInput{Action: "findings.read"})
+	if err != nil {
+		t.Fatalf("decide with trace: %v", err)
+	}
+	if !decision.Allowed || decision.Stage != PolicyStageRBAC {
+		t.Fatalf("expected allow decision at RBAC stage, got %+v", decision)
+	}
+	if len(trace) != 5 {
+		t.Fatalf("expected full five-stage trace, got %d", len(trace))
+	}
+	if trace[2].Outcome != PolicyOutcomeSkipped || trace[3].Outcome != PolicyOutcomeSkipped || trace[4].Outcome != PolicyOutcomeSkipped {
+		t.Fatalf("expected downstream stages to be marked skipped, got %+v", trace)
+	}
+}

--- a/internal/api/authz_simulation.go
+++ b/internal/api/authz_simulation.go
@@ -1,0 +1,259 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
+	"github.com/Oluwatobi-Mustapha/identrail/internal/telemetry"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+type policySimulationSubjectInput struct {
+	Type        string            `json:"type"`
+	ID          string            `json:"id"`
+	TenantID    string            `json:"tenant_id"`
+	WorkspaceID string            `json:"workspace_id"`
+	Groups      []string          `json:"groups"`
+	Roles       []string          `json:"roles"`
+	Attributes  map[string]string `json:"attributes"`
+}
+
+type policySimulationResourceInput struct {
+	Type        string            `json:"type"`
+	ID          string            `json:"id"`
+	TenantID    string            `json:"tenant_id"`
+	WorkspaceID string            `json:"workspace_id"`
+	Attributes  map[string]string `json:"attributes"`
+}
+
+type policySimulationContextInput struct {
+	RequestPath   string            `json:"request_path"`
+	RequestMethod string            `json:"request_method"`
+	Attributes    map[string]string `json:"attributes"`
+}
+
+type authzPolicySimulationRequest struct {
+	Subject       policySimulationSubjectInput  `json:"subject"`
+	Action        string                        `json:"action"`
+	Resource      policySimulationResourceInput `json:"resource"`
+	Context       policySimulationContextInput  `json:"context"`
+	PolicySetID   string                        `json:"policy_set_id"`
+	TargetVersion *int                          `json:"target_version"`
+	AuditEvent    bool                          `json:"audit_event"`
+}
+
+type authzPolicySimulationPolicyResponse struct {
+	Source        string `json:"source"`
+	PolicySetID   string `json:"policy_set_id"`
+	Version       int    `json:"version,omitempty"`
+	RolloutMode   string `json:"rollout_mode,omitempty"`
+	TargetVersion *int   `json:"target_version,omitempty"`
+}
+
+type authzPolicySimulationResponse struct {
+	Decision PolicyDecision                      `json:"decision"`
+	Trace    []PolicyTraceStep                   `json:"trace"`
+	Policy   authzPolicySimulationPolicyResponse `json:"policy"`
+}
+
+func authzPolicySimulationHandler(logger *zap.Logger, store db.Store, resolver centralPolicyRuntimeResolver, sink AuditSink) gin.HandlerFunc {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return func(c *gin.Context) {
+		start := time.Now()
+		var request authzPolicySimulationRequest
+		if err := c.ShouldBindJSON(&request); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			return
+		}
+
+		policySetID := strings.TrimSpace(request.PolicySetID)
+		if policySetID == "" {
+			policySetID = defaultCentralPolicySetID
+		}
+		if request.TargetVersion != nil && *request.TargetVersion <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "target_version must be greater than zero"})
+			return
+		}
+
+		input := toSimulationPolicyInput(c, request)
+		if strings.TrimSpace(input.Action) == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "action is required"})
+			return
+		}
+
+		runtimePolicy, err := resolveSimulationRuntime(c, store, resolver, policySetID, request.TargetVersion)
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "policy version not found"})
+				return
+			}
+			logger.Error("resolve authz simulation runtime", telemetry.ZapError(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to resolve policy runtime"})
+			return
+		}
+
+		decision, trace, err := runtimePolicy.Engine.DecideWithTrace(c.Request.Context(), input)
+		if err != nil {
+			logger.Error("simulate authz decision", telemetry.ZapError(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to simulate policy decision"})
+			return
+		}
+
+		response := authzPolicySimulationResponse{
+			Decision: decision,
+			Trace:    trace,
+			Policy: authzPolicySimulationPolicyResponse{
+				Source:        runtimePolicy.Source,
+				PolicySetID:   runtimePolicy.PolicySetID,
+				Version:       runtimePolicy.Version,
+				RolloutMode:   runtimePolicy.RolloutMode,
+				TargetVersion: request.TargetVersion,
+			},
+		}
+		c.JSON(http.StatusOK, response)
+
+		if request.AuditEvent {
+			writeSimulationAuditEvent(logger, sink, c, start)
+		}
+	}
+}
+
+func toSimulationPolicyInput(c *gin.Context, request authzPolicySimulationRequest) PolicyInput {
+	scope := db.ScopeFromContext(c.Request.Context())
+
+	subjectTenant := firstNonEmpty(request.Subject.TenantID, scope.TenantID)
+	subjectWorkspace := firstNonEmpty(request.Subject.WorkspaceID, scope.WorkspaceID)
+	resourceTenant := firstNonEmpty(request.Resource.TenantID, scope.TenantID)
+	resourceWorkspace := firstNonEmpty(request.Resource.WorkspaceID, scope.WorkspaceID)
+
+	contextAttributes := normalizeSimulationAttributes(request.Context.Attributes)
+	contextAttributes[policyContextTenantIDKey] = firstNonEmpty(contextAttributes[policyContextTenantIDKey], scope.TenantID)
+	contextAttributes[policyContextWorkspaceIDKey] = firstNonEmpty(contextAttributes[policyContextWorkspaceIDKey], scope.WorkspaceID)
+
+	return PolicyInput{
+		Subject: PolicySubject{
+			Type:        strings.ToLower(strings.TrimSpace(request.Subject.Type)),
+			ID:          strings.TrimSpace(request.Subject.ID),
+			TenantID:    subjectTenant,
+			WorkspaceID: subjectWorkspace,
+			Groups:      normalizeSimulationList(request.Subject.Groups, false),
+			Roles:       normalizeSimulationList(request.Subject.Roles, true),
+			Attributes:  normalizeSimulationAttributes(request.Subject.Attributes),
+		},
+		Action: strings.ToLower(strings.TrimSpace(request.Action)),
+		Resource: PolicyResource{
+			Type:        strings.ToLower(strings.TrimSpace(request.Resource.Type)),
+			ID:          strings.TrimSpace(request.Resource.ID),
+			TenantID:    resourceTenant,
+			WorkspaceID: resourceWorkspace,
+			Attributes:  normalizeSimulationAttributes(request.Resource.Attributes),
+		},
+		Context: PolicyContext{
+			RequestPath:   strings.TrimSpace(request.Context.RequestPath),
+			RequestMethod: strings.ToUpper(strings.TrimSpace(request.Context.RequestMethod)),
+			Now:           time.Now().UTC(),
+			Attributes:    contextAttributes,
+		},
+	}
+}
+
+func normalizeSimulationList(values []string, lower bool) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		item := strings.TrimSpace(value)
+		if lower {
+			item = strings.ToLower(item)
+		}
+		if item == "" {
+			continue
+		}
+		if _, exists := seen[item]; exists {
+			continue
+		}
+		seen[item] = struct{}{}
+		normalized = append(normalized, item)
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func normalizeSimulationAttributes(attributes map[string]string) map[string]string {
+	if len(attributes) == 0 {
+		return map[string]string{}
+	}
+	normalized := make(map[string]string, len(attributes))
+	for key, value := range attributes {
+		normalizedKey := strings.ToLower(strings.TrimSpace(key))
+		normalizedValue := strings.TrimSpace(value)
+		if normalizedKey == "" || normalizedValue == "" {
+			continue
+		}
+		normalized[normalizedKey] = normalizedValue
+	}
+	return normalized
+}
+
+func resolveSimulationRuntime(c *gin.Context, store db.Store, resolver centralPolicyRuntimeResolver, policySetID string, targetVersion *int) (resolvedCentralPolicyRuntime, error) {
+	if targetVersion == nil {
+		if resolver == nil {
+			resolver = newCentralPolicyRuntimeResolverWithPolicySet(store, policySetID)
+		}
+		return resolver.Resolve(c.Request.Context())
+	}
+	if store == nil {
+		return resolvedCentralPolicyRuntime{}, fmt.Errorf("policy store is not configured")
+	}
+	version, err := store.GetAuthzPolicyVersion(c.Request.Context(), policySetID, *targetVersion)
+	if err != nil {
+		return resolvedCentralPolicyRuntime{}, err
+	}
+	compiled, err := compileRouteAuthorizationPolicyBundleJSON(version.Bundle)
+	if err != nil {
+		return resolvedCentralPolicyRuntime{}, fmt.Errorf("compile target policy version: %w", err)
+	}
+	rolloutMode := db.AuthzPolicyRolloutModeDisabled
+	if rollout, err := store.GetAuthzPolicyRollout(c.Request.Context(), policySetID); err == nil {
+		rolloutMode = strings.TrimSpace(rollout.Mode)
+	}
+	return resolvedCentralPolicyRuntime{
+		Engine:      newCentralPolicyEngineFromCompiled(store, compiled),
+		Registry:    compiled.RouteRegistry,
+		Source:      "persisted_target_version",
+		PolicySetID: policySetID,
+		Version:     version.Version,
+		RolloutMode: rolloutMode,
+	}, nil
+}
+
+func writeSimulationAuditEvent(logger *zap.Logger, sink AuditSink, c *gin.Context, start time.Time) {
+	if sink == nil {
+		return
+	}
+	event := AuditEvent{
+		Timestamp:  time.Now().UTC(),
+		Method:     "SIMULATE",
+		Path:       "/v1/authz/policies/simulate",
+		Status:     http.StatusOK,
+		ClientIP:   c.ClientIP(),
+		DurationMS: time.Since(start).Milliseconds(),
+		UserAgent:  c.Request.UserAgent(),
+	}
+	if apiKey := authContextString(c, "auth.api_key"); apiKey != "" {
+		event.APIKeyID = fingerprintAPIKey(apiKey)
+	}
+	if err := sink.Write(event); err != nil {
+		logger.Warn("authz simulation audit write failed", telemetry.ZapError(err))
+	}
+}

--- a/internal/api/authz_simulation_test.go
+++ b/internal/api/authz_simulation_test.go
@@ -1,0 +1,240 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
+	"github.com/Oluwatobi-Mustapha/identrail/internal/telemetry"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+func TestRouterAuthzPolicySimulationTargetVersionReturnsDecisionAndTrace(t *testing.T) {
+	logger := zap.NewNop()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+	sink := &recordingAuditSink{}
+
+	ctx := defaultScopeContext()
+	if err := store.UpsertAuthzPolicySet(ctx, db.AuthzPolicySet{
+		PolicySetID: defaultCentralPolicySetID,
+		DisplayName: "Central Authorization",
+		CreatedBy:   "test",
+	}); err != nil {
+		t.Fatalf("upsert policy set: %v", err)
+	}
+
+	bundle := routeAuthorizationPolicyBundle{
+		SchemaVersion: routeAuthorizationPolicyBundleSchemaV1,
+		RoutePolicies: []routePolicyDefinition{
+			{Method: "GET", Path: "/v1/findings", Action: policyActionFindingsRead, ResourceType: "finding"},
+		},
+		RBACActionRole: map[string][]string{
+			policyActionFindingsRead: {scopeRead, scopeAdmin},
+		},
+		ABACPolicies: map[string]abacActionPolicy{
+			policyActionFindingsRead: {AnyOf: []abacClause{{}}},
+		},
+	}
+	bundleBytes, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("marshal policy bundle: %v", err)
+	}
+	createdVersion, err := store.CreateAuthzPolicyVersion(ctx, db.AuthzPolicyVersion{
+		PolicySetID: defaultCentralPolicySetID,
+		Version:     1,
+		Bundle:      string(bundleBytes),
+		CreatedBy:   "test",
+	})
+	if err != nil {
+		t.Fatalf("create policy version: %v", err)
+	}
+
+	router := NewRouter(logger, metrics, svc, RouterOptions{
+		AuditSink: sink,
+		APIKeyScopes: map[string][]string{
+			"admin-key": {scopeAdmin},
+		},
+	})
+
+	requestBody := `{
+		"subject":{"type":"subject","id":"user-1","tenant_id":"default","workspace_id":"default","roles":["admin"]},
+		"action":"findings.read",
+		"resource":{"type":"finding","id":"finding-1","tenant_id":"default","workspace_id":"default"},
+		"context":{"request_path":"/v1/findings","request_method":"GET"},
+		"policy_set_id":"central_authorization",
+		"target_version":1,
+		"audit_event":true
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/authz/policies/simulate", bytes.NewBufferString(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", "admin-key")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	var response authzPolicySimulationResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode simulation response: %v", err)
+	}
+	if !response.Decision.Allowed {
+		t.Fatalf("expected allowed simulation decision, got %+v", response.Decision)
+	}
+	if response.Policy.Source != "persisted_target_version" {
+		t.Fatalf("expected persisted target version source, got %q", response.Policy.Source)
+	}
+	if response.Policy.Version != createdVersion.Version {
+		t.Fatalf("expected policy version %d, got %d", createdVersion.Version, response.Policy.Version)
+	}
+	if len(response.Trace) != 5 {
+		t.Fatalf("expected full 5-step trace, got %d", len(response.Trace))
+	}
+	if response.Trace[0].Stage != PolicyStageTenantIsolation ||
+		response.Trace[1].Stage != PolicyStageRBAC ||
+		response.Trace[2].Stage != PolicyStageABAC ||
+		response.Trace[3].Stage != PolicyStageReBAC ||
+		response.Trace[4].Stage != PolicyStageDefaultDeny {
+		t.Fatalf("unexpected trace ordering: %+v", response.Trace)
+	}
+
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	foundSimulationAudit := false
+	for _, event := range sink.events {
+		if event.Method == "SIMULATE" && event.Path == "/v1/authz/policies/simulate" {
+			foundSimulationAudit = true
+			break
+		}
+	}
+	if !foundSimulationAudit {
+		t.Fatalf("expected optional simulation audit event, got %+v", sink.events)
+	}
+}
+
+func TestRouterAuthzPolicySimulationRequiresAdminRole(t *testing.T) {
+	logger := zap.NewNop()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+
+	router := NewRouter(logger, metrics, svc, RouterOptions{
+		APIKeyScopes: map[string][]string{
+			"reader-key": {scopeRead},
+		},
+	})
+
+	requestBody := `{
+		"subject":{"type":"subject","id":"user-1","roles":["read"]},
+		"action":"findings.read",
+		"resource":{"type":"finding","id":"finding-1"},
+		"context":{"request_path":"/v1/findings","request_method":"GET"}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/authz/policies/simulate", bytes.NewBufferString(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", "reader-key")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected status 403 for non-admin simulation caller, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRouterAuthzPolicySimulationValidatesInput(t *testing.T) {
+	logger := zap.NewNop()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+
+	router := NewRouter(logger, metrics, svc, RouterOptions{
+		APIKeyScopes: map[string][]string{
+			"admin-key": {scopeAdmin},
+		},
+	})
+
+	requestBody := `{
+		"subject":{"type":"subject","id":"user-1","roles":["admin"]},
+		"action":"findings.read",
+		"resource":{"type":"finding","id":"finding-1"},
+		"context":{"request_path":"/v1/findings","request_method":"GET"},
+		"target_version":0
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/authz/policies/simulate", bytes.NewBufferString(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", "admin-key")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400 for invalid target_version, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestNormalizeSimulationHelpers(t *testing.T) {
+	if got := normalizeSimulationList(nil, true); got != nil {
+		t.Fatalf("expected nil normalized list for empty input, got %+v", got)
+	}
+	roles := normalizeSimulationList([]string{" Admin ", "admin", "WRITE", " "}, true)
+	if len(roles) != 2 || roles[0] != "admin" || roles[1] != "write" {
+		t.Fatalf("unexpected normalized role list: %+v", roles)
+	}
+
+	emptyAttrs := normalizeSimulationAttributes(nil)
+	if len(emptyAttrs) != 0 {
+		t.Fatalf("expected empty normalized attribute map, got %+v", emptyAttrs)
+	}
+	attrs := normalizeSimulationAttributes(map[string]string{
+		" Owner_Team ": " platform ",
+		"":             "ignored",
+		"env":          " ",
+	})
+	if len(attrs) != 1 || attrs["owner_team"] != "platform" {
+		t.Fatalf("unexpected normalized attributes: %+v", attrs)
+	}
+}
+
+func TestResolveSimulationRuntimeTargetVersionBranches(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "default", WorkspaceID: "default"})
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/authz/policies/simulate", nil).WithContext(ctx)
+
+	targetVersion := 1
+	if _, err := resolveSimulationRuntime(c, nil, nil, defaultCentralPolicySetID, &targetVersion); err == nil {
+		t.Fatal("expected error when resolving target version without policy store")
+	}
+
+	store := db.NewMemoryStore()
+	if _, err := resolveSimulationRuntime(c, store, nil, defaultCentralPolicySetID, &targetVersion); !errors.Is(err, db.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for missing target version, got %v", err)
+	}
+
+	if err := store.UpsertAuthzPolicySet(ctx, db.AuthzPolicySet{
+		PolicySetID: defaultCentralPolicySetID,
+		DisplayName: "Central Authorization",
+		CreatedBy:   "test",
+	}); err != nil {
+		t.Fatalf("upsert policy set: %v", err)
+	}
+	if _, err := store.CreateAuthzPolicyVersion(ctx, db.AuthzPolicyVersion{
+		PolicySetID: defaultCentralPolicySetID,
+		Version:     1,
+		Bundle:      `{"schema_version":"invalid"}`,
+		CreatedBy:   "test",
+	}); err != nil {
+		t.Fatalf("create invalid policy version: %v", err)
+	}
+	if _, err := resolveSimulationRuntime(c, store, nil, defaultCentralPolicySetID, &targetVersion); err == nil {
+		t.Fatal("expected compile error for invalid target policy bundle")
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -118,7 +118,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 	v1.Use(requireCentralPolicyMiddleware(centralPolicyResolver, opts.WriteAPIKeys, opts.APIKeyScopes, authzStore))
 	v1.Use(rateLimitMiddleware(opts.RateLimitRPM, opts.RateLimitBurst))
 	v1.Use(auditLogMiddleware(logger, opts.AuditSink))
-	v1.POST("/authz/policies/simulate", authzPolicySimulationHandler(logger, authzStore, centralPolicyResolver, opts.AuditSink))
+	v1.POST("/authz/policies/simulate", authzPolicySimulationHandler(logger, authzStore, nil, opts.AuditSink))
 
 	if svc == nil {
 		v1.GET("/findings", func(c *gin.Context) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -114,9 +114,11 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 	v1 := r.Group("/v1")
 	v1.Use(apiKeyAuthMiddleware(opts.APIKeys, opts.APIKeyScopes, opts.OIDCTokenVerifier, opts.OIDCWriteScopes))
 	v1.Use(requestScopeMiddleware(opts.DefaultTenantID, opts.DefaultWorkspaceID))
-	v1.Use(requireCentralPolicyMiddleware(newCentralPolicyRuntimeResolver(authzStore), opts.WriteAPIKeys, opts.APIKeyScopes, authzStore))
+	centralPolicyResolver := newCentralPolicyRuntimeResolver(authzStore)
+	v1.Use(requireCentralPolicyMiddleware(centralPolicyResolver, opts.WriteAPIKeys, opts.APIKeyScopes, authzStore))
 	v1.Use(rateLimitMiddleware(opts.RateLimitRPM, opts.RateLimitBurst))
 	v1.Use(auditLogMiddleware(logger, opts.AuditSink))
+	v1.POST("/authz/policies/simulate", authzPolicySimulationHandler(logger, authzStore, centralPolicyResolver, opts.AuditSink))
 
 	if svc == nil {
 		v1.GET("/findings", func(c *gin.Context) {


### PR DESCRIPTION
## Summary
- add `POST /v1/authz/policies/simulate` for read-only authorization simulation
- support simulation input model: subject + action + resource + context plus optional `target_version`
- return full ordered stage trace (`tenant_isolation -> rbac -> abac -> rebac -> default_deny`) with outcome and reasons
- add optional simulation-specific audit event emission (`audit_event=true`) while keeping policy state read-only

## Implementation Details
- added `PolicyEngine.DecideWithTrace(...)` and `PolicyTraceStep` to capture full explainability traces
- wired a dedicated simulation handler that can evaluate:
  - the active runtime policy (resolver path)
  - or an explicit persisted policy version (`target_version`)
- enforced route-level authorization for simulation with a new action `authz.policies.simulate` mapped to admin role
- added route-policy bundle entry for `/v1/authz/policies/simulate`

## API Contract
`POST /v1/authz/policies/simulate`
- request: subject/action/resource/context + optional `policy_set_id`, `target_version`, `audit_event`
- response: `decision`, full `trace`, and policy runtime metadata (`source`, `policy_set_id`, `version`, `rollout_mode`)

## Safety
- no authz policy write side effects
- only read operations against policy storage
- optional audit sink write when explicitly requested

## Tests
- added policy engine trace tests
- added router simulation endpoint tests for:
  - successful target-version simulation with full trace
  - admin-only access enforcement
  - request validation
  - runtime/helper error-path coverage
- local validation:
  - `go test ./internal/api -run 'TestPolicyEngineDecideWithTrace|TestRouterAuthzPolicySimulation|TestRoutePolicyRegistryCoversAllV1Routes' -count=1`
  - `go test ./... -coverprofile=coverage.out` (80.1221%)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only authorization simulation endpoint with full decision traces so admins can safely test policies. Supports targeting a specific policy version and optional audit logging.

- **New Features**
  - POST `/v1/authz/policies/simulate`: accepts `subject`/`action`/`resource`/`context` plus optional `policy_set_id`, `target_version`, `audit_event`. Returns `decision`, ordered `trace` (`tenant_isolation -> rbac -> abac -> rebac -> default_deny`), and policy metadata (`source`, `policy_set_id`, `version`, `rollout_mode`, `target_version`).
  - Access control: new action `authz.policies.simulate`, admin-only. Route policy added and router registers the POST endpoint.
  - Explainability: added `PolicyEngine.DecideWithTrace` and `PolicyTraceStep`. Records `no_op`, `skipped`, and default deny; nil engine yields a full skipped trace ending in deny.
  - Runtime selection: simulate against the active runtime or a persisted `target_version`. Compiles bundles on demand and reports the evaluation source.
  - Optional auditing: emits a simulation audit event when `audit_event=true`. No policy writes or runtime side effects.

<sup>Written for commit 2cd0d44eeb728d52f60894610860f8880abd0cba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

