### PR TITLE
docs(readme): New Header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# Identrail
+<p align="center">
+    <a href="https://github.com/Oluwatobi-Mustapha/identrail"><img src="https://capsule-render.vercel.app/api?type=transparent&height=120&text=IDENTRAIL&fontSize=72&fontColor=3b82f6&animation=fadeIn&fontAlignY=65" height="100" /></a>
+</p>
+
+---
+
+[![Coverage](https://img.shields.io/badge/coverage-80.0%25-brightgreen?style=for-the-badge)](https://github.com/Oluwatobi-Mustapha/identrail/actions/workflows/ci.yml)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Oluwatobi-Mustapha/identrail/ci.yml?branch=main&label=tests&style=for-the-badge)](https://github.com/Oluwatobi-Mustapha/identrail/actions/workflows/ci.yml)
+![Latest version](https://img.shields.io/github/v/tag/Oluwatobi-Mustapha/identrail?sort=semver&style=for-the-badge&label=Latest%20version)
 
 Identrail is a machine identity security platform for cloud and Kubernetes environments.
 


### PR DESCRIPTION
## What changed
- Updated the top section of `README.md` to mirror the unique-style presentation.
- Added a centered Identrail wordmark block.
- Added the metrics strip with badges for coverage, tests workflow status, and latest version.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revamps README top section to a Gravity-style header with a centered Identrail wordmark and a metrics strip (coverage, tests status, latest version). Improves the landing page presentation; no runtime or product changes.

<sup>Written for commit 3d76c917c833b596dd0b1913e3d214729bdaaec4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

