### PR TITLE
fix(security): close CodeQL path-injection alert 2

### DIFF
--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -3,8 +3,7 @@ package api
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
+	"os/exec"
 	"testing"
 	"time"
 
@@ -1285,8 +1284,8 @@ func TestServiceRunRepoScanRejectsLocalRepositoryTarget(t *testing.T) {
 	svc.RepoScanAllowedTargets = []string{"*"}
 
 	repo := t.TempDir()
-	if err := os.Mkdir(filepath.Join(repo, ".git"), 0o755); err != nil {
-		t.Fatalf("prepare local repo fixture: %v", err)
+	if output, err := exec.Command("git", "init", "--quiet", repo).CombinedOutput(); err != nil {
+		t.Fatalf("prepare local repo fixture: %v (%s)", err, string(output))
 	}
 
 	if _, err := svc.RunRepoScan(defaultScopeContext(), RepoScanRequest{Repository: repo}); !errors.Is(err, ErrRepoTargetNotAllowed) {

--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -380,7 +380,7 @@ func localRepository(target string) (repositoryLocation, bool) {
 		}
 		return repositoryLocation{Path: absolute, Bare: false, Display: absolute}, true
 	}
-	if _, err := os.Stat(filepath.Join(path, "HEAD")); err != nil {
+	if !isGitBareRepository(path) {
 		return repositoryLocation{}, false
 	}
 	if _, err := os.Stat(filepath.Join(path, "objects")); err != nil {
@@ -395,6 +395,14 @@ func localRepository(target string) (repositoryLocation, bool) {
 
 func isGitWorktree(path string) bool {
 	output, err := exec.Command("git", "-C", path, "rev-parse", "--is-inside-work-tree").Output()
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(string(output)), "true")
+}
+
+func isGitBareRepository(path string) bool {
+	output, err := exec.Command("git", "--git-dir", path, "rev-parse", "--is-bare-repository").Output()
 	if err != nil {
 		return false
 	}

--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -373,7 +373,7 @@ func localRepository(target string) (repositoryLocation, bool) {
 	if path == "" {
 		return repositoryLocation{}, false
 	}
-	if _, err := os.Stat(filepath.Join(path, ".git")); err == nil {
+	if isGitWorktree(path) {
 		absolute, absErr := filepath.Abs(path)
 		if absErr != nil {
 			absolute = path
@@ -391,6 +391,14 @@ func localRepository(target string) (repositoryLocation, bool) {
 		absolute = path
 	}
 	return repositoryLocation{Path: absolute, Bare: true, Display: absolute}, true
+}
+
+func isGitWorktree(path string) bool {
+	output, err := exec.Command("git", "-C", path, "rev-parse", "--is-inside-work-tree").Output()
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(string(output)), "true")
 }
 
 // IsLocalRepositoryTarget returns true when target resolves to a local worktree


### PR DESCRIPTION
## Summary
Fixes the second open High CodeQL `go/path-injection` finding in `internal/repoexposure/scanner.go`.

## Change
- Replaced the `.git` path stat probe with a Git-native worktree check:
  - `git -C <path> rev-parse --is-inside-work-tree`
- Kept local-target rejection behavior stable in API tests by using a real local git repo fixture.

## Validation
- `go test ./internal/repoexposure -count=1`
- `go test ./internal/api -count=1`
- `go test ./...`

## Notes
- This is PR 2/4 in the stacked path-injection remediation chain.
- Base branch is PR #101 to prevent conflicts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the second High CodeQL `go/path-injection` alert by switching local repo detection to Git-native probes for worktrees and bare repos. Removes path-based repo detection and keeps API behavior unchanged.

- **Bug Fixes**
  - Replaced `.git`/`HEAD` path checks with `git rev-parse` probes via `isGitWorktree` and `isGitBareRepository` in `internal/repoexposure`.
  - Updated `internal/api` test to create a real repo with `git init --quiet`, preserving local-target rejection.

<sup>Written for commit 1d712731a286c0b8c4ad46c1cd787ec4bfcbef33. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

