### PR TITLE
ci(release): enable v1.0.0 release backfill with artifacts/checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ on:
         description: "Public HTTPS API URL for the web image build (for example https://api.identrail.io)"
         required: false
         type: string
+      publish_images:
+        description: "Publish container images (true/false). Push-tag releases always publish images."
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -27,6 +32,7 @@ jobs:
       tag: ${{ steps.meta.outputs.tag }}
       prerelease: ${{ steps.meta.outputs.prerelease }}
       publish_latest: ${{ steps.meta.outputs.publish_latest }}
+      publish_images: ${{ steps.meta.outputs.publish_images }}
 
     steps:
       - name: Resolve release metadata
@@ -48,15 +54,21 @@ jobs:
 
           prerelease="false"
           publish_latest="true"
+          publish_images="true"
           tag_without_build="${tag%%+*}"
           if [[ "${tag_without_build}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+- ]]; then
             prerelease="true"
             publish_latest="false"
           fi
 
+          if [ "${GITHUB_EVENT_NAME}" != "push" ] && [ "${{ github.event.inputs.publish_images }}" != "true" ]; then
+            publish_images="false"
+          fi
+
           echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
           echo "prerelease=${prerelease}" >> "${GITHUB_OUTPUT}"
           echo "publish_latest=${publish_latest}" >> "${GITHUB_OUTPUT}"
+          echo "publish_images=${publish_images}" >> "${GITHUB_OUTPUT}"
 
   build-binaries:
     name: Build Release Binaries
@@ -136,6 +148,7 @@ jobs:
   publish-images:
     name: Build and Publish Images
     needs: prepare
+    if: needs.prepare.outputs.publish_images == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -218,7 +231,31 @@ jobs:
 
   publish-release:
     name: Publish GitHub Release
+    needs: [prepare, build-binaries]
+    if: needs.prepare.outputs.publish_images != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Download release binaries
+        uses: actions/download-artifact@v8
+        with:
+          name: release-binaries
+          path: dist
+
+      - name: Publish release with generated notes
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.prepare.outputs.tag }}
+          generate_release_notes: true
+          prerelease: ${{ needs.prepare.outputs.prerelease == 'true' }}
+          files: |
+            dist/*
+
+  publish-release-with-images:
+    name: Publish GitHub Release (With Images)
     needs: [prepare, build-binaries, publish-images]
+    if: needs.prepare.outputs.publish_images == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -9,12 +9,14 @@ Identrail release automation is defined in:
 - Manual dispatch with:
   - `tag` (required)
   - `web_api_url` (optional override for web image build)
+  - `publish_images` (optional boolean; default `false` for manual dispatch)
 
 ## Required Configuration
 
 - Set repository variable `IDENTRAIL_WEB_API_URL` to the public HTTPS API base URL
   used by production web builds (for example `https://api.identrail.io`).
-- For manual runs, you can override this with the `web_api_url` dispatch input.
+- For manual runs with `publish_images=true`, you can override this with the `web_api_url` dispatch input.
+- For manual runs with `publish_images=false`, image configuration is not required.
 
 ## What the Pipeline Publishes
 
@@ -38,3 +40,14 @@ Identrail release automation is defined in:
    - `git tag v1.2.3`
    - `git push origin v1.2.3`
 3. Verify release assets and image digests on GitHub Releases.
+
+## Backfill Existing Tag Releases
+
+If a SemVer tag already exists but no GitHub Release was published (for example `v1.0.0`):
+
+1. Open **Actions** -> **Release** -> **Run workflow**.
+2. Set:
+   - `tag=v1.0.0`
+   - `publish_images=false` (binary/checksum-only backfill), or `true` if GHCR image publish is required.
+   - `web_api_url` only when `publish_images=true`.
+3. Run workflow and confirm release assets include archive files plus `checksums.txt`.


### PR DESCRIPTION
## Summary
Adds a launch-safe path to publish an actual GitHub Release for existing tags like `v1.0.0` with binary artifacts and `checksums.txt`.

## Why
`v1.0.0` tag already exists, but the repository currently has no published GitHub Release. This PR enables manual backfill without requiring image publishing prerequisites.

## Changes
- Updated `.github/workflows/release.yml`:
  - Added `workflow_dispatch` input: `publish_images` (boolean, default `false` for manual runs).
  - Push-tag releases remain unchanged (`publish_images=true` by default).
  - Added conditional release publish jobs:
    - `publish-release` (binaries/checksums only)
    - `publish-release-with-images` (binaries/checksums + image metadata)
- Updated `docs/release-pipeline.md`:
  - Documented `publish_images` input.
  - Added explicit backfill instructions for `v1.0.0`.

## Validation
- Workflow YAML parses successfully (`yaml.safe_load`).
- No runtime code changes.

## How to use after merge
- Actions -> Release -> Run workflow
  - `tag=v1.0.0`
  - `publish_images=false`
- This publishes a GitHub Release with archives and `checksums.txt`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manual, launch-safe path to publish a GitHub Release for existing tags (e.g., `v1.0.0`) with binaries and `checksums.txt`, without pushing container images by default. Push-tag releases keep publishing images as before.

- New Features
  - Added `publish_images` (boolean, default `false`) to `.github/workflows/release.yml` for manual runs; push-tag behavior unchanged.
  - Gated image publishing and split release jobs: `publish-release` (binaries/checksums only) and `publish-release-with-images` (includes image metadata).
  - Updated docs with backfill steps for `v1.0.0` and notes on when to set `web_api_url`.

<sup>Written for commit afe30df13b687794a6fb90b691d0233204354786. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

