### PR TITLE
docs: production-grade README and documentation index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Identrail
+# I D E N T R A I L
 
 - Website: https://github.com/Oluwatobi-Mustapha/identrail
 - Discussions: https://github.com/Oluwatobi-Mustapha/identrail/discussions
@@ -10,6 +10,7 @@
 [![CI](https://img.shields.io/github/actions/workflow/status/Oluwatobi-Mustapha/identrail/ci.yml?branch=main&label=ci)](https://github.com/Oluwatobi-Mustapha/identrail/actions/workflows/ci.yml)
 [![CodeQL](https://img.shields.io/github/actions/workflow/status/Oluwatobi-Mustapha/identrail/codeql.yml?branch=main&label=codeql)](https://github.com/Oluwatobi-Mustapha/identrail/actions/workflows/codeql.yml)
 [![Release](https://img.shields.io/github/v/tag/Oluwatobi-Mustapha/identrail?sort=semver&label=release)](https://github.com/Oluwatobi-Mustapha/identrail/releases)
+[![Coverage Gate](https://img.shields.io/badge/coverage%20gate-%E2%89%A580%25-brightgreen)](https://github.com/Oluwatobi-Mustapha/identrail/actions/workflows/ci.yml)
 
 Identrail is a machine identity security platform for cloud and Kubernetes workloads. It discovers identities and trust paths, detects risky access patterns, and supports operator-safe remediation workflows.
 
@@ -68,6 +69,9 @@ Core local checks:
 make bootstrap
 make ci
 ```
+
+Coverage policy:
+- Go test coverage gate is enforced in CI at `>= 80%`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,147 +1,74 @@
-# I D E N T R A I L
+# Identrail
+
+- Website: https://github.com/Oluwatobi-Mustapha/identrail
+- Discussions: https://github.com/Oluwatobi-Mustapha/identrail/discussions
+- Documentation Index: [docs/README.md](docs/README.md)
+- API Contract: [docs/openapi-v1.yaml](docs/openapi-v1.yaml)
+- Enterprise Quickstart: [docs/enterprise-quickstart.md](docs/enterprise-quickstart.md)
+- Security Policy: [SECURITY.md](SECURITY.md)
 
 [![CI](https://img.shields.io/github/actions/workflow/status/Oluwatobi-Mustapha/identrail/ci.yml?branch=main&label=ci)](https://github.com/Oluwatobi-Mustapha/identrail/actions/workflows/ci.yml)
 [![CodeQL](https://img.shields.io/github/actions/workflow/status/Oluwatobi-Mustapha/identrail/codeql.yml?branch=main&label=codeql)](https://github.com/Oluwatobi-Mustapha/identrail/actions/workflows/codeql.yml)
 [![Release](https://img.shields.io/github/v/tag/Oluwatobi-Mustapha/identrail?sort=semver&label=release)](https://github.com/Oluwatobi-Mustapha/identrail/releases)
 
-Identrail is a machine-identity security platform for cloud and Kubernetes workloads.  
-It discovers identities and trust paths, detects risky access patterns, and supports operator-safe remediation workflows.
+Identrail is a machine identity security platform for cloud and Kubernetes workloads. It discovers identities and trust paths, detects risky access patterns, and supports operator-safe remediation workflows.
 
-## Why teams use Identrail
+The key features of Identrail are:
 
-- Discover machine identities, relationships, and ownership signals from AWS and Kubernetes.
-- Detect high-signal identity risk findings with remediation guidance.
-- Scan repository history and configuration for secret exposure and misconfiguration risks.
-- Enforce scoped, centralized authorization with tenant/workspace isolation and default-deny behavior.
-- Operate safely with rollout controls, simulation, rollback, and decision audit logging.
+- **Identity Discovery and Risk Detection**: Collects identity data from AWS and Kubernetes, builds relationships, and produces typed findings with remediation guidance.
 
-## What is in this repository
+- **Repository Exposure Scanning**: Scans repository history and configuration for secret exposure and misconfiguration risks, with bounded scan controls and allowlists.
 
-- `cmd/server`: HTTP API service (`/healthz`, `/metrics`, `/v1/*`)
-- `cmd/worker`: scheduled scan worker and queue processor
-- `cmd/cli`: operator/developer CLI (`scan`, `findings`, `repo-scan`, `authz rollback`)
-- `cmd/identrail-reviewer`: repo-native PR/issue reviewer engine
-- `internal/`: core scanner, API/authz, storage, providers, telemetry, scheduler
-- `web/`: React dashboard
-- `deploy/`: Docker, Helm, Kubernetes, systemd, Terraform deployment assets
-- `docs/`: runbooks, policy/security docs, release and support docs
+- **Centralized Authorization**: Enforces tenant/workspace isolation and a strict policy decision order (`tenant_isolation -> rbac -> abac -> rebac -> default_deny`) with simulation, staged rollout, and rollback controls.
 
-## 60-second local start
+- **Operational Safety and Auditability**: Provides decision audit logging, rollout metrics, and runbooks for secure operations and compliance evidence workflows.
+
+- **Portable Deployment and Release Pipeline**: Includes Docker, Kubernetes, Helm, and Terraform deployment assets with CI, CodeQL, release automation, and supply-chain trust artifacts.
+
+For more information, refer to the [documentation index](docs/README.md).
+
+## Getting Started & Documentation
+
+Documentation is available in this repository:
+
+- [Documentation Index](docs/README.md)
+- [Enterprise 5-Minute Quickstart](docs/enterprise-quickstart.md)
+- [Operator Readiness](docs/operator-readiness.md)
+- [Deploy Runbook](docs/deploy-runbook.md)
+- [AuthZ Operator Runbook](docs/authz-operator-runbook.md)
+- [AuthZ Policy Rollout Runbook](docs/authz-policy-rollout-runbook.md)
+
+If you want a fast local start:
 
 ```bash
 cp deploy/docker/.env.example deploy/docker/.env
-```
-
-Set strong keys in `deploy/docker/.env`:
-- `IDENTRAIL_API_KEYS`
-- `IDENTRAIL_WRITE_API_KEYS`
-- optional scoped model: `IDENTRAIL_API_KEY_SCOPES`
-
-Start the stack:
-
-```bash
 docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env up -d --build
-```
-
-Smoke check:
-
-```bash
 curl -sS http://localhost:8080/healthz
-curl -sS http://localhost:8080/v1/findings?limit=5 -H "X-API-Key: <read-or-admin-key>"
 ```
 
-Stop:
+## Developing Identrail
 
-```bash
-docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env down
-```
+This repository contains Identrail core runtime and developer tooling, including:
 
-## API surface (v1)
+- API server (`cmd/server`)
+- background worker (`cmd/worker`)
+- operator/developer CLI (`cmd/cli`)
+- repository-native reviewer engine (`cmd/identrail-reviewer`)
+- web dashboard (`web/`)
 
-Core endpoints:
-- Findings: list, detail, summary, trends, triage, exports
-- Scans: enqueue, list, diff, events
-- Explorer: identities, relationships, ownership signals
-- Repository scans: enqueue/list/detail findings
-- AuthZ ops: policy simulation and rollback
+To learn more about compiling Identrail and contributing suggested changes, refer to:
 
-Contract:
-- `docs/openapi-v1.yaml`
+- [Contributing Guide](CONTRIBUTING.md)
+- [Development Workflow](docs/development-workflow.md)
+- [Testing Strategy](docs/testing.md)
 
-## Security and authorization model
-
-- API key and OIDC auth paths with explicit scope handling (`read`, `write`, `admin`).
-- Tenant/workspace request scoping with strict boundary checks.
-- Central decision order:
-  - `tenant_isolation -> rbac -> abac -> rebac -> default_deny`
-- Policy lifecycle controls:
-  - persisted policy bundles
-  - staged rollout modes (`disabled`, `shadow`, `enforce`)
-  - simulation endpoint with full stage trace
-  - one-call rollback endpoint/CLI
-- Audit events include authz decision metadata with hashed subject/resource IDs.
-
-Runbooks:
-- `docs/authz-operator-runbook.md`
-- `docs/authz-policy-rollout-runbook.md`
-- `docs/security-hardening.md`
-
-## Build and test
+Core local checks:
 
 ```bash
 make bootstrap
 make ci
 ```
 
-Or task runner:
+## License
 
-```bash
-task bootstrap
-task ci
-```
-
-CI gates include:
-- gofmt + `go vet`
-- Go tests with coverage threshold
-- Postgres integration tests
-- Web tests/build
-- Infra validation (Helm/Terraform)
-- Deploy portability smoke checks
-
-## Deployment paths
-
-- Docker Compose: `deploy/docker/`
-- Kubernetes manifests: `deploy/kubernetes/`
-- Helm chart: `deploy/helm/identrail/`
-- Terraform (Helm-based): `deploy/terraform/`
-- systemd services: `deploy/systemd/`
-
-Operator start points:
-- `docs/enterprise-quickstart.md`
-- `docs/operator-readiness.md`
-- `docs/deploy-runbook.md`
-- `docs/troubleshooting.md`
-
-## Releases and supply chain trust
-
-- Release automation:
-  - `.github/workflows/release.yml`
-  - `docs/release-pipeline.md`
-- SBOM, attestations, and signing:
-  - `.github/workflows/supply-chain-trust.yml`
-  - `docs/supply-chain-trust.md`
-- Version/support policy:
-  - `docs/versioning-support-policy.md`
-
-## Documentation map
-
-Documentation index:
-- `docs/README.md`
-
-## Community and governance
-
-- Discussions: https://github.com/Oluwatobi-Mustapha/identrail/discussions
-- Contributing: `CONTRIBUTING.md`
-- Security policy: `SECURITY.md`
-- Code of conduct: `CODE_OF_CONDUCT.md`
-- Funding/sponsorship: `.github/FUNDING.yml`
+[Apache License 2.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,27 +1,147 @@
-<p align="center">
-    <a href="https://github.com/Oluwatobi-Mustapha/identrail"><img src="https://capsule-render.vercel.app/api?type=transparent&height=120&text=IDENTRAIL&fontSize=72&fontColor=3b82f6&animation=fadeIn&fontAlignY=65" height="100" /></a>
-</p>
+# I D E N T R A I L
 
----
+[![CI](https://img.shields.io/github/actions/workflow/status/Oluwatobi-Mustapha/identrail/ci.yml?branch=main&label=ci)](https://github.com/Oluwatobi-Mustapha/identrail/actions/workflows/ci.yml)
+[![CodeQL](https://img.shields.io/github/actions/workflow/status/Oluwatobi-Mustapha/identrail/codeql.yml?branch=main&label=codeql)](https://github.com/Oluwatobi-Mustapha/identrail/actions/workflows/codeql.yml)
+[![Release](https://img.shields.io/github/v/tag/Oluwatobi-Mustapha/identrail?sort=semver&label=release)](https://github.com/Oluwatobi-Mustapha/identrail/releases)
 
-[![Coverage](https://img.shields.io/badge/coverage-80.0%25-brightgreen?style=for-the-badge)](https://github.com/Oluwatobi-Mustapha/identrail/actions/workflows/ci.yml)
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Oluwatobi-Mustapha/identrail/ci.yml?branch=main&label=tests&style=for-the-badge)](https://github.com/Oluwatobi-Mustapha/identrail/actions/workflows/ci.yml)
-![Latest version](https://img.shields.io/github/v/tag/Oluwatobi-Mustapha/identrail?sort=semver&style=for-the-badge&label=Latest%20version)
+Identrail is a machine-identity security platform for cloud and Kubernetes workloads.  
+It discovers identities and trust paths, detects risky access patterns, and supports operator-safe remediation workflows.
 
-Identrail is a machine identity security platform for cloud and Kubernetes environments.
+## Why teams use Identrail
 
-It helps teams:
-- discover unmanaged machine and workload identities
-- find overprivileged or risky access paths before attackers do
-- reduce blast radius with clear, actionable remediation guidance
-- improve audit readiness with consistent identity risk visibility over time
+- Discover machine identities, relationships, and ownership signals from AWS and Kubernetes.
+- Detect high-signal identity risk findings with remediation guidance.
+- Scan repository history and configuration for secret exposure and misconfiguration risks.
+- Enforce scoped, centralized authorization with tenant/workspace isolation and default-deny behavior.
+- Operate safely with rollout controls, simulation, rollback, and decision audit logging.
 
-Business outcome: fewer identity-driven incidents, faster remediation cycles, and stronger security posture at lower operational cost.
+## What is in this repository
 
-Operational docs:
-- `docs/enterprise-quickstart.md`
-- `docs/operator-readiness.md`
+- `cmd/server`: HTTP API service (`/healthz`, `/metrics`, `/v1/*`)
+- `cmd/worker`: scheduled scan worker and queue processor
+- `cmd/cli`: operator/developer CLI (`scan`, `findings`, `repo-scan`, `authz rollback`)
+- `cmd/identrail-reviewer`: repo-native PR/issue reviewer engine
+- `internal/`: core scanner, API/authz, storage, providers, telemetry, scheduler
+- `web/`: React dashboard
+- `deploy/`: Docker, Helm, Kubernetes, systemd, Terraform deployment assets
+- `docs/`: runbooks, policy/security docs, release and support docs
+
+## 60-second local start
+
+```bash
+cp deploy/docker/.env.example deploy/docker/.env
+```
+
+Set strong keys in `deploy/docker/.env`:
+- `IDENTRAIL_API_KEYS`
+- `IDENTRAIL_WRITE_API_KEYS`
+- optional scoped model: `IDENTRAIL_API_KEY_SCOPES`
+
+Start the stack:
+
+```bash
+docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env up -d --build
+```
+
+Smoke check:
+
+```bash
+curl -sS http://localhost:8080/healthz
+curl -sS http://localhost:8080/v1/findings?limit=5 -H "X-API-Key: <read-or-admin-key>"
+```
+
+Stop:
+
+```bash
+docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env down
+```
+
+## API surface (v1)
+
+Core endpoints:
+- Findings: list, detail, summary, trends, triage, exports
+- Scans: enqueue, list, diff, events
+- Explorer: identities, relationships, ownership signals
+- Repository scans: enqueue/list/detail findings
+- AuthZ ops: policy simulation and rollback
+
+Contract:
+- `docs/openapi-v1.yaml`
+
+## Security and authorization model
+
+- API key and OIDC auth paths with explicit scope handling (`read`, `write`, `admin`).
+- Tenant/workspace request scoping with strict boundary checks.
+- Central decision order:
+  - `tenant_isolation -> rbac -> abac -> rebac -> default_deny`
+- Policy lifecycle controls:
+  - persisted policy bundles
+  - staged rollout modes (`disabled`, `shadow`, `enforce`)
+  - simulation endpoint with full stage trace
+  - one-call rollback endpoint/CLI
+- Audit events include authz decision metadata with hashed subject/resource IDs.
+
+Runbooks:
 - `docs/authz-operator-runbook.md`
 - `docs/authz-policy-rollout-runbook.md`
+- `docs/security-hardening.md`
 
-**...will update the README once I'm done building the first version and stress test it. Thanks!**
+## Build and test
+
+```bash
+make bootstrap
+make ci
+```
+
+Or task runner:
+
+```bash
+task bootstrap
+task ci
+```
+
+CI gates include:
+- gofmt + `go vet`
+- Go tests with coverage threshold
+- Postgres integration tests
+- Web tests/build
+- Infra validation (Helm/Terraform)
+- Deploy portability smoke checks
+
+## Deployment paths
+
+- Docker Compose: `deploy/docker/`
+- Kubernetes manifests: `deploy/kubernetes/`
+- Helm chart: `deploy/helm/identrail/`
+- Terraform (Helm-based): `deploy/terraform/`
+- systemd services: `deploy/systemd/`
+
+Operator start points:
+- `docs/enterprise-quickstart.md`
+- `docs/operator-readiness.md`
+- `docs/deploy-runbook.md`
+- `docs/troubleshooting.md`
+
+## Releases and supply chain trust
+
+- Release automation:
+  - `.github/workflows/release.yml`
+  - `docs/release-pipeline.md`
+- SBOM, attestations, and signing:
+  - `.github/workflows/supply-chain-trust.yml`
+  - `docs/supply-chain-trust.md`
+- Version/support policy:
+  - `docs/versioning-support-policy.md`
+
+## Documentation map
+
+Documentation index:
+- `docs/README.md`
+
+## Community and governance
+
+- Discussions: https://github.com/Oluwatobi-Mustapha/identrail/discussions
+- Contributing: `CONTRIBUTING.md`
+- Security policy: `SECURITY.md`
+- Code of conduct: `CODE_OF_CONDUCT.md`
+- Funding/sponsorship: `.github/FUNDING.yml`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,75 @@
+# Documentation Index
+
+This index maps Identrail docs by operator, developer, security/compliance, and release workflows.
+
+## Start here
+
+- Enterprise quickstart: `enterprise-quickstart.md`
+- Operator readiness handoff: `operator-readiness.md`
+- Deployment runbook: `deploy-runbook.md`
+
+## Operator track
+
+- Deployment options:
+  - `../deploy/README.md`
+  - `deployment-anywhere.md`
+  - `../deploy/docker/README.md`
+  - `../deploy/kubernetes/README.md`
+  - `../deploy/helm/README.md`
+  - `../deploy/terraform/README.md`
+- Day-2 operations:
+  - `observability.md`
+  - `troubleshooting.md`
+  - `incident-response.md`
+- Worker/scheduler behavior:
+  - `worker.md`
+  - `scheduler.md`
+
+## Authorization and policy operations
+
+- AuthZ operations runbook: `authz-operator-runbook.md`
+- AuthZ rollout lifecycle: `authz-policy-rollout-runbook.md`
+- Security hardening guidance: `security-hardening.md`
+
+## API and developer track
+
+- API contract (OpenAPI): `openapi-v1.yaml`
+- Development workflow: `development-workflow.md`
+- Testing strategy: `testing.md`
+- Migrations strategy: `migrations.md`
+- Artifact persistence notes: `persistence-artifacts.md`
+- Repository exposure scanner: `repo-exposure.md`
+
+## Release and supply chain track
+
+- Release pipeline: `release-pipeline.md`
+- Supply chain trust artifacts: `supply-chain-trust.md`
+- Versioning and support policy: `versioning-support-policy.md`
+- Release qualification checklist: `v1_release_qualification.md`
+
+## Security and governance track
+
+- Threat model: `threat_model.md`
+- Architecture decisions: `ADR.md`
+- V1 scope baseline: `v1_scope_and_baseline.md`
+- Security policy: `../SECURITY.md`
+- Contributing guide: `../CONTRIBUTING.md`
+- Code of conduct: `../CODE_OF_CONDUCT.md`
+
+## identrail-reviewer track
+
+- Reviewer overview: `identrail-reviewer/README.md`
+- Ground-truth dataset guide: `identrail-reviewer/ground-truth-dataset.md`
+- Reviewer operations runbook: `identrail-reviewer/operations-runbook.md`
+- Week-by-week delivery docs:
+  - `identrail-reviewer/week-1-foundation.md`
+  - `identrail-reviewer/week-2-judgment-engine.md`
+  - `identrail-reviewer/week-3-hardening.md`
+  - `identrail-reviewer/week-4-rollout.md`
+
+## Historical phase docs
+
+- `phase-1.md`
+- `phase-2.md`
+- `phase-3.md`
+- `phase-4.md`


### PR DESCRIPTION
## Summary
- replace the placeholder README with a production-grade, minimal-but-detailed project README
- add docs/README.md as a structured docs index by operator/developer/security/release tracks
- link README sections to existing runbooks, deployment paths, API contract, and governance docs

## Why
The current README did not reflect the actual v1 implementation surface and lacked a clear navigation model for operators and contributors.

## Scope
- README documentation architecture and copy refresh
- docs navigation entrypoint addition
- no runtime or API code changes

## Validation
- verified all referenced paths/commands against current repository structure and workflows
- docs-only change; no code/test behavior modified

## Checklist
- [x] Tests added/updated for behavior changes (not applicable: docs-only)
- [x] Docs updated for user/operator-facing changes
- [x] CHANGELOG.md updated when relevant (not required for docs-only navigation/content refresh)
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure
- AI-assisted: No

## Related Issues
- n/a



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades the README to a production-grade, Terraform-style doc that restores Identrail branding and adds quality signals (CI, CodeQL, release, coverage gate), website/discussions links, a 5‑minute local Docker quickstart, core features, component map, and developer workflow/testing links.
Adds a structured docs index with operator/developer/security/release and `identrail-reviewer` tracks, linking to runbooks, deployment options, the v1 OpenAPI contract, authz operations, and release/supply-chain docs; no runtime or API changes.

<sup>Written for commit c60c0a9ec9d8fda08b7791ac0781da749cac906d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



