### PR TITLE
ci(release): support manual v1.0.0 backfill with checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ on:
         description: "Public HTTPS API URL for the web image build (for example https://api.identrail.io)"
         required: false
         type: string
+      publish_images:
+        description: "Publish container images (true/false). Push-tag releases always publish images."
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -27,6 +32,7 @@ jobs:
       tag: ${{ steps.meta.outputs.tag }}
       prerelease: ${{ steps.meta.outputs.prerelease }}
       publish_latest: ${{ steps.meta.outputs.publish_latest }}
+      publish_images: ${{ steps.meta.outputs.publish_images }}
 
     steps:
       - name: Resolve release metadata
@@ -48,15 +54,21 @@ jobs:
 
           prerelease="false"
           publish_latest="true"
+          publish_images="true"
           tag_without_build="${tag%%+*}"
           if [[ "${tag_without_build}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+- ]]; then
             prerelease="true"
             publish_latest="false"
           fi
 
+          if [ "${GITHUB_EVENT_NAME}" != "push" ] && [ "${{ github.event.inputs.publish_images }}" != "true" ]; then
+            publish_images="false"
+          fi
+
           echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
           echo "prerelease=${prerelease}" >> "${GITHUB_OUTPUT}"
           echo "publish_latest=${publish_latest}" >> "${GITHUB_OUTPUT}"
+          echo "publish_images=${publish_images}" >> "${GITHUB_OUTPUT}"
 
   build-binaries:
     name: Build Release Binaries
@@ -136,6 +148,7 @@ jobs:
   publish-images:
     name: Build and Publish Images
     needs: prepare
+    if: needs.prepare.outputs.publish_images == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -218,7 +231,31 @@ jobs:
 
   publish-release:
     name: Publish GitHub Release
+    needs: [prepare, build-binaries]
+    if: needs.prepare.outputs.publish_images != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Download release binaries
+        uses: actions/download-artifact@v8
+        with:
+          name: release-binaries
+          path: dist
+
+      - name: Publish release with generated notes
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.prepare.outputs.tag }}
+          generate_release_notes: true
+          prerelease: ${{ needs.prepare.outputs.prerelease == 'true' }}
+          files: |
+            dist/*
+
+  publish-release-with-images:
+    name: Publish GitHub Release (With Images)
     needs: [prepare, build-binaries, publish-images]
+    if: needs.prepare.outputs.publish_images == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -9,12 +9,14 @@ Identrail release automation is defined in:
 - Manual dispatch with:
   - `tag` (required)
   - `web_api_url` (optional override for web image build)
+  - `publish_images` (optional boolean; default `false` for manual dispatch)
 
 ## Required Configuration
 
 - Set repository variable `IDENTRAIL_WEB_API_URL` to the public HTTPS API base URL
   used by production web builds (for example `https://api.identrail.io`).
-- For manual runs, you can override this with the `web_api_url` dispatch input.
+- For manual runs with `publish_images=true`, you can override this with the `web_api_url` dispatch input.
+- For manual runs with `publish_images=false`, image configuration is not required.
 
 ## What the Pipeline Publishes
 
@@ -38,3 +40,14 @@ Identrail release automation is defined in:
    - `git tag v1.2.3`
    - `git push origin v1.2.3`
 3. Verify release assets and image digests on GitHub Releases.
+
+## Backfill Existing Tag Releases
+
+If a SemVer tag already exists but no GitHub Release was published (for example `v1.0.0`):
+
+1. Open **Actions** -> **Release** -> **Run workflow**.
+2. Set:
+   - `tag=v1.0.0`
+   - `publish_images=false` (binary/checksum-only backfill), or `true` if GHCR image publish is required.
+   - `web_api_url` only when `publish_images=true`.
+3. Run workflow and confirm release assets include archive files plus `checksums.txt`.


### PR DESCRIPTION
## Summary

Describe what changed.

## Why

Describe the problem this PR solves.

## Scope

- [ ] Focused change (no unrelated modifications)
- [ ] Backward compatibility considered
- [ ] Risk level assessed

## Validation

List the checks you ran and their outcomes.

```bash
# Example:
# go test ./...
# npm run test:ci --prefix web
```

## Checklist

- [ ] Tests added/updated for behavior changes
- [ ] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [ ] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

If AI tools were used materially for this PR, complete the fields below.

- AI-assisted: yes/no
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Link related issues (for example: `Closes #123`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable manual backfill of existing tag releases (e.g., v1.0.0) with binaries and checksums, without pushing container images. Also adds an option to include images when needed and documents the steps.

- **New Features**
  - Add `publish_images` workflow input (default `false` for manual runs). Push-tag releases always publish images.
  - Gate image build/publish; run a separate release path for binaries-only backfills. Release assets include archives and `checksums.txt`.
  - Update docs with backfill instructions and clarify `web_api_url` is only required when `publish_images=true`.

<sup>Written for commit afe30df13b687794a6fb90b691d0233204354786. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

