### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -368,9 +368,31 @@ func parseDiffPath(line string) string {
 	return strings.TrimPrefix(path, "b/")
 }
 
+func looksLikeLocalPath(target string) bool {
+	trimmed := strings.TrimSpace(target)
+	if trimmed == "" {
+		return false
+	}
+	lower := strings.ToLower(trimmed)
+	if strings.Contains(lower, "://") || strings.HasPrefix(lower, "git@") {
+		return false
+	}
+	if strings.Count(trimmed, "/") == 1 &&
+		!strings.HasPrefix(trimmed, "/") &&
+		!strings.HasPrefix(trimmed, ".") &&
+		!strings.HasPrefix(trimmed, "~") &&
+		!strings.Contains(trimmed, "\\") {
+		return false
+	}
+	return true
+}
+
 func localRepository(target string) (repositoryLocation, bool) {
 	path := strings.TrimSpace(target)
 	if path == "" {
+		return repositoryLocation{}, false
+	}
+	if !looksLikeLocalPath(path) {
 		return repositoryLocation{}, false
 	}
 	if isGitWorktree(path) {


### PR DESCRIPTION
Potential fix for [https://github.com/Oluwatobi-Mustapha/identrail/security/code-scanning/5](https://github.com/Oluwatobi-Mustapha/identrail/security/code-scanning/5)

To fix this safely without changing intended behavior, tighten `localRepository` input handling so it only performs local filesystem checks for strings that clearly represent local filesystem paths. For non-local-looking repository identifiers (URLs, SCP-style git refs like `git@...`, or owner/repo shorthand), return `false` early and avoid any `os.Stat`, `filepath.Join`, or git invocation with that user input.

Best concrete fix in `internal/repoexposure/scanner.go`:
1. Add a helper `looksLikeLocalPath(string) bool` that:
   - rejects URL/scheme-like targets (`://`, `http://`, `https://`, `ssh://`, `git@`)
   - rejects owner/repo shorthand (`one slash, no leading slash/dot/tilde, no backslash`)  
   - allows obvious local forms (`/abs`, `./rel`, `../rel`, `~/...`, Windows-style with `\`, drive-letter-like `C:\`).
2. In `localRepository`, after trimming and empty check, return false if `!looksLikeLocalPath(path)`.

This preserves functional intent: local repositories are still detected/blocked, while remote repo identifiers no longer get interpreted as local filesystem paths during validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents uncontrolled path usage in `localRepository` by only treating obvious local paths as local and rejecting remote-like inputs. Addresses the code scanning alert for uncontrolled data in path expressions.

- **Bug Fixes**
  - Added `looksLikeLocalPath` to reject URLs, `git@` refs, and owner/repo shorthand.
  - Early return in `localRepository` when input isn’t a local path, avoiding filesystem and git checks.

<sup>Written for commit d22d4df3a96cac1010745700bcdabd0298721996. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

