### PR TITLE
Support enterprise tenant/workspace headers in dashboard

### DIFF
--- a/docs/enterprise-quickstart.md
+++ b/docs/enterprise-quickstart.md
@@ -46,6 +46,11 @@ export IDENTRAIL_WRITER_KEY="<writer-key-from-.env>"
 export IDENTRAIL_ADMIN_KEY="<admin-key-from-.env>"
 ```
 
+If you are using the web dashboard, enter these same values in the top control bar:
+- `API Key`
+- `Tenant ID`
+- `Workspace ID`
+
 ## 4. Health and Auth Smoke Checks
 
 ```bash

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { App } from './App';
 
@@ -149,6 +149,57 @@ describe('App', () => {
 
     await waitFor(() => {
       expect(screen.getByText('unauthorized')).toBeInTheDocument();
+    });
+  });
+
+  it('applies tenant and workspace headers from dashboard controls', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/v1/findings/summary')) return ok({ total: 0, by_severity: {}, by_type: {} });
+      if (url.includes('/v1/findings/trends')) return ok({ items: [] });
+      if (url.includes('/v1/scans?')) {
+        return ok({
+          items: [{ id: 'scan-1', provider: 'aws', status: 'completed', started_at: '2026-03-16T00:00:00Z', asset_count: 0, finding_count: 0 }]
+        });
+      }
+      if (url.includes('/v1/findings?')) return ok({ items: [] });
+      if (url.includes('/v1/scans/scan-1/diff')) {
+        return ok({
+          scan_id: 'scan-1',
+          added_count: 0,
+          resolved_count: 0,
+          persisting_count: 0,
+          added: [],
+          resolved: [],
+          persisting: []
+        });
+      }
+      if (url.includes('/v1/identities')) return ok({ items: [] });
+      if (url.includes('/v1/relationships')) return ok({ items: [] });
+      if (url.includes('/v1/scans/scan-1/events')) return ok({ items: [] });
+      return ok({ items: [] });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<App />);
+
+    fireEvent.change(screen.getByLabelText('API Key'), { target: { value: 'reader-key' } });
+    fireEvent.change(screen.getByLabelText('Tenant ID'), { target: { value: 'tenant-a' } });
+    fireEvent.change(screen.getByLabelText('Workspace ID'), { target: { value: 'workspace-a' } });
+
+    await waitFor(() => {
+      const matchedCall = fetchMock.mock.calls.find((call) => {
+        const requestCall = call as unknown as [RequestInfo | URL, RequestInit?];
+        const options = requestCall[1];
+        const headers = options?.headers as Record<string, string> | undefined;
+        if (!headers) return false;
+        return (
+          headers['X-API-Key'] === 'reader-key' &&
+          headers['X-Identrail-Tenant-ID'] === 'tenant-a' &&
+          headers['X-Identrail-Workspace-ID'] === 'workspace-a'
+        );
+      });
+      expect(matchedCall).toBeDefined();
     });
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import {
   type Finding,
   type FindingsSummary,
   type Identity,
+  type RequestAuthContext,
   type Relationship,
   type ScanDiff,
   type ScanEvent,
@@ -13,6 +14,8 @@ import {
 
 export function App() {
   const [apiKey, setApiKey] = useState('');
+  const [tenantID, setTenantID] = useState('');
+  const [workspaceID, setWorkspaceID] = useState('');
   const [summary, setSummary] = useState<FindingsSummary | null>(null);
   const [trends, setTrends] = useState<TrendPoint[]>([]);
   const [scans, setScans] = useState<ScanRecord[]>([]);
@@ -56,13 +59,22 @@ export function App() {
     [scans, availableScanID]
   );
 
+  const requestAuth = useMemo<RequestAuthContext>(
+    () => ({
+      apiKey,
+      tenantID,
+      workspaceID
+    }),
+    [apiKey, tenantID, workspaceID]
+  );
+
   useEffect(() => {
     let active = true;
     setLoadingOverview(true);
     Promise.all([
-      apiClient.getFindingsSummary(apiKey || undefined),
-      apiClient.getFindingsTrends({ points: 10 }, apiKey || undefined),
-      apiClient.listScans(apiKey || undefined)
+      apiClient.getFindingsSummary(requestAuth),
+      apiClient.getFindingsTrends({ points: 10 }, requestAuth),
+      apiClient.listScans(requestAuth)
     ])
       .then(([summaryData, trendData, scanData]) => {
         if (!active) return;
@@ -87,7 +99,7 @@ export function App() {
     return () => {
       active = false;
     };
-  }, [apiKey, refreshNonce, selectedScanID]);
+  }, [requestAuth, refreshNonce, selectedScanID]);
 
   useEffect(() => {
     if (!baselineScanID) return;
@@ -124,12 +136,12 @@ export function App() {
           sort_by: 'severity',
           sort_order: 'desc'
         },
-        apiKey || undefined
+        requestAuth
       ),
-      apiClient.getScanDiff(scanID, 20, apiKey || undefined, baselineScanID || undefined),
-      apiClient.listIdentities(scanID, 100, apiKey || undefined),
-      apiClient.listRelationships(scanID, 100, apiKey || undefined),
-      apiClient.listScanEvents(scanID, 'info', 30, apiKey || undefined)
+      apiClient.getScanDiff(scanID, 20, requestAuth, baselineScanID || undefined),
+      apiClient.listIdentities(scanID, 100, requestAuth),
+      apiClient.listRelationships(scanID, 100, requestAuth),
+      apiClient.listScanEvents(scanID, 'info', 30, requestAuth)
     ])
       .then(([findingsData, diffData, identitiesData, relationshipsData, eventsData]) => {
         if (!active) return;
@@ -163,7 +175,7 @@ export function App() {
     return () => {
       active = false;
     };
-  }, [availableScanID, baselineScanID, severityFilter, typeFilter, apiKey, refreshNonce]);
+  }, [availableScanID, baselineScanID, severityFilter, typeFilter, requestAuth, refreshNonce]);
 
   useEffect(() => {
     const scanID = availableScanID;
@@ -175,7 +187,7 @@ export function App() {
     let active = true;
     setLoadingFinding(true);
     apiClient
-      .getFinding(selectedFindingID, scanID, apiKey || undefined)
+      .getFinding(selectedFindingID, scanID, requestAuth)
       .then((item) => {
         if (!active) return;
         setSelectedFinding(item);
@@ -192,7 +204,7 @@ export function App() {
     return () => {
       active = false;
     };
-  }, [selectedFindingID, availableScanID, apiKey]);
+  }, [selectedFindingID, availableScanID, requestAuth]);
 
   const triggerRefresh = () => setRefreshNonce((value) => value + 1);
 
@@ -212,6 +224,24 @@ export function App() {
             value={apiKey}
             onChange={(event) => setApiKey(event.target.value)}
             placeholder="Optional for local dev"
+          />
+        </div>
+        <div>
+          <label htmlFor="tenant-id">Tenant ID</label>
+          <input
+            id="tenant-id"
+            value={tenantID}
+            onChange={(event) => setTenantID(event.target.value)}
+            placeholder="Optional tenant scope"
+          />
+        </div>
+        <div>
+          <label htmlFor="workspace-id">Workspace ID</label>
+          <input
+            id="workspace-id"
+            value={workspaceID}
+            onChange={(event) => setWorkspaceID(event.target.value)}
+            placeholder="Optional workspace scope"
           />
         </div>
         <div>

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -20,7 +20,10 @@ describe('apiClient', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    await apiClient.listFindings({ scan_id: 'scan-1', severity: 'high', type: 'risky_trust_policy' }, 'reader');
+    await apiClient.listFindings(
+      { scan_id: 'scan-1', severity: 'high', type: 'risky_trust_policy' },
+      { apiKey: 'reader' }
+    );
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
@@ -38,7 +41,7 @@ describe('apiClient', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    await apiClient.listScans('reader');
+    await apiClient.listScans({ apiKey: 'reader' });
     const [url] = fetchMock.mock.calls[0] as [string];
     expect(url).toContain('/v1/scans?sort_by=started_at&sort_order=desc');
   });
@@ -50,7 +53,7 @@ describe('apiClient', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    await apiClient.getScanDiff('scan/id with space', 20, 'reader');
+    await apiClient.getScanDiff('scan/id with space', 20, { apiKey: 'reader' });
     const [url] = fetchMock.mock.calls[0] as [string];
     expect(url).toContain('/v1/scans/scan%2Fid%20with%20space/diff?limit=20');
   });
@@ -62,9 +65,30 @@ describe('apiClient', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    await apiClient.getScanDiff('scan-2', 20, 'reader', 'scan-1');
+    await apiClient.getScanDiff('scan-2', 20, { apiKey: 'reader' }, 'scan-1');
     const [url] = fetchMock.mock.calls[0] as [string];
     expect(url).toContain('/v1/scans/scan-2/diff?limit=20&previous_scan_id=scan-1');
+  });
+
+  it('sends enterprise tenant/workspace scope headers when configured', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [] })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.listScans({
+      apiKey: ' reader ',
+      tenantID: ' tenant-a ',
+      workspaceID: ' workspace-a '
+    });
+
+    const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(options.headers).toMatchObject({
+      'X-API-Key': 'reader',
+      'X-Identrail-Tenant-ID': 'tenant-a',
+      'X-Identrail-Workspace-ID': 'workspace-a'
+    });
   });
 
   it('surfaces backend error envelope message', async () => {
@@ -75,6 +99,6 @@ describe('apiClient', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(apiClient.getFindingsSummary('reader')).rejects.toThrow('unauthorized');
+    await expect(apiClient.getFindingsSummary({ apiKey: 'reader' })).rejects.toThrow('unauthorized');
   });
 });

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -77,6 +77,13 @@ export type ScanEvent = {
   created_at: string;
 };
 
+export type RequestAuthContext = {
+  apiKey?: string;
+  tenantID?: string;
+  workspaceID?: string;
+  bearerToken?: string;
+};
+
 const configuredURL = import.meta.env.VITE_IDENTRAIL_API_URL as string | undefined;
 if (import.meta.env.PROD) {
   if (!configuredURL) {
@@ -89,11 +96,34 @@ if (import.meta.env.PROD) {
 }
 const baseURL = configuredURL ?? 'http://localhost:8080';
 
-async function request<T>(path: string, apiKey?: string): Promise<T> {
+function trimOrUndefined(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function buildRequestHeaders(auth?: RequestAuthContext): Record<string, string> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const apiKey = trimOrUndefined(auth?.apiKey);
   if (apiKey) {
     headers['X-API-Key'] = apiKey;
   }
+  const tenantID = trimOrUndefined(auth?.tenantID);
+  if (tenantID) {
+    headers['X-Identrail-Tenant-ID'] = tenantID;
+  }
+  const workspaceID = trimOrUndefined(auth?.workspaceID);
+  if (workspaceID) {
+    headers['X-Identrail-Workspace-ID'] = workspaceID;
+  }
+  const bearerToken = trimOrUndefined(auth?.bearerToken);
+  if (bearerToken) {
+    headers.Authorization = `Bearer ${bearerToken}`;
+  }
+  return headers;
+}
+
+async function request<T>(path: string, auth?: RequestAuthContext): Promise<T> {
+  const headers = buildRequestHeaders(auth);
   const res = await fetch(`${baseURL}${path}`, { headers });
   if (!res.ok) {
     let message = `Request failed (${res.status})`;
@@ -121,17 +151,17 @@ function buildQuery(params: Record<string, string | number | undefined>): string
 }
 
 export const apiClient = {
-  getFindingsSummary(apiKey?: string) {
-    return request<FindingsSummary>('/v1/findings/summary', apiKey);
+  getFindingsSummary(auth?: RequestAuthContext) {
+    return request<FindingsSummary>('/v1/findings/summary', auth);
   },
   getFindingsTrends(
     filters: { points?: number; severity?: string; type?: string } = {},
-    apiKey?: string
+    auth?: RequestAuthContext
   ) {
-    return request<{ items: TrendPoint[] }>(`/v1/findings/trends${buildQuery(filters)}`, apiKey);
+    return request<{ items: TrendPoint[] }>(`/v1/findings/trends${buildQuery(filters)}`, auth);
   },
-  listScans(apiKey?: string) {
-    return request<{ items: ScanRecord[] }>('/v1/scans?sort_by=started_at&sort_order=desc', apiKey);
+  listScans(auth?: RequestAuthContext) {
+    return request<{ items: ScanRecord[] }>('/v1/scans?sort_by=started_at&sort_order=desc', auth);
   },
   listFindings(
     filters: {
@@ -142,36 +172,36 @@ export const apiClient = {
       sort_by?: string;
       sort_order?: 'asc' | 'desc';
     } = {},
-    apiKey?: string
+    auth?: RequestAuthContext
   ) {
-    return request<{ items: Finding[] }>(`/v1/findings${buildQuery(filters)}`, apiKey);
+    return request<{ items: Finding[] }>(`/v1/findings${buildQuery(filters)}`, auth);
   },
-  getFinding(findingID: string, scanID?: string, apiKey?: string) {
+  getFinding(findingID: string, scanID?: string, auth?: RequestAuthContext) {
     const suffix = buildQuery({ scan_id: scanID });
-    return request<Finding>(`/v1/findings/${encodeURIComponent(findingID)}${suffix}`, apiKey);
+    return request<Finding>(`/v1/findings/${encodeURIComponent(findingID)}${suffix}`, auth);
   },
-  getScanDiff(scanID: string, limit = 20, apiKey?: string, previousScanID?: string) {
+  getScanDiff(scanID: string, limit = 20, auth?: RequestAuthContext, previousScanID?: string) {
     return request<ScanDiff>(
       `/v1/scans/${encodeURIComponent(scanID)}/diff${buildQuery({
         limit,
         previous_scan_id: previousScanID
       })}`,
-      apiKey
+      auth
     );
   },
-  listIdentities(scanID: string, limit = 100, apiKey?: string) {
+  listIdentities(scanID: string, limit = 100, auth?: RequestAuthContext) {
     return request<{ items: Identity[] }>(
       `/v1/identities${buildQuery({ scan_id: scanID, limit, sort_by: 'name', sort_order: 'asc' })}`,
-      apiKey
+      auth
     );
   },
-  listRelationships(scanID: string, limit = 100, apiKey?: string) {
+  listRelationships(scanID: string, limit = 100, auth?: RequestAuthContext) {
     return request<{ items: Relationship[] }>(
       `/v1/relationships${buildQuery({ scan_id: scanID, limit, sort_by: 'discovered_at', sort_order: 'desc' })}`,
-      apiKey
+      auth
     );
   },
-  listScanEvents(scanID: string, level?: string, limit = 50, apiKey?: string) {
+  listScanEvents(scanID: string, level?: string, limit = 50, auth?: RequestAuthContext) {
     return request<{ items: ScanEvent[] }>(
       `/v1/scans/${encodeURIComponent(scanID)}/events${buildQuery({
         level,
@@ -179,7 +209,7 @@ export const apiClient = {
         sort_by: 'created_at',
         sort_order: 'desc'
       })}`,
-      apiKey
+      auth
     );
   }
 };

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -51,7 +51,7 @@ body {
 
 .controls {
   display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
+  grid-template-columns: repeat(8, minmax(0, 1fr));
   gap: 0.8rem;
   align-items: end;
 }


### PR DESCRIPTION
## Summary
- add request auth context support in the web API client for:
  - `X-API-Key`
  - `X-Identrail-Tenant-ID`
  - `X-Identrail-Workspace-ID`
  - optional bearer token support for future OIDC flows
- wire dashboard controls to collect tenant/workspace values and send them on all API calls
- update dashboard layout to include the new scope controls
- add tests for API client scope header behavior
- add dashboard test coverage to verify tenant/workspace headers are emitted after user input
- update enterprise quickstart to point dashboard users to the API key + tenant/workspace controls

## Why
Enterprise usage relies on tenant/workspace request scope. Before this change, the dashboard only sent `X-API-Key`, which could lead to inconsistent behavior in multi-tenant environments compared with documented API usage.

## Validation
- `npm run test:ci --prefix web`
- `npm run build --prefix web`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add enterprise scoping to the dashboard by sending tenant and workspace headers with every API call. Adds simple controls for API Key, Tenant ID, and Workspace ID to avoid multi-tenant inconsistencies and prepare for future OIDC.

- New Features
  - API client now accepts a request auth context and sends X-API-Key, X-Identrail-Tenant-ID, X-Identrail-Workspace-ID, plus optional Bearer token.
  - Dashboard includes Tenant ID and Workspace ID inputs wired into all requests.
  - Tests cover header emission and dashboard control behavior.
  - Enterprise quickstart updated to point users to the new controls.

- Refactors
  - API client method signatures now take a `RequestAuthContext` instead of a bare API key.
  - Layout grid expanded to fit the new controls.

<sup>Written for commit 31b0a40bb55cefa129b5968465a1b97ac5f316bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

