### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Oluwatobi-Mustapha/identrail/ci.yml?branch=main&label=tests&style=for-the-badge)](https://github.com/Oluwatobi-Mustapha/identrail/actions/workflows/ci.yml)
 ![Latest version](https://img.shields.io/github/v/tag/Oluwatobi-Mustapha/identrail?sort=semver&style=for-the-badge&label=Latest%20version)
 
-- Website: https://identrail.vercel.app
+- Website: identrail.com
 - Discussions: https://github.com/Oluwatobi-Mustapha/identrail/discussions
 - Documentation Index: [docs/README.md](docs/README.md)
 - API Contract: [docs/openapi-v1.yaml](docs/openapi-v1.yaml)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the README website link from https://identrail.vercel.app to identrail.com to reflect the production domain. This ensures users land on the live site.

<sup>Written for commit afd2ee1568b67a47bc74b20287dab6d980e3322d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

