### PR TITLE
Set local Docker CORS default for web connectivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Improved Docker Compose out-of-box web/API connectivity:
+  - added `IDENTRAIL_CORS_ALLOWED_ORIGINS=http://localhost:8081` to `deploy/docker/.env.example`
+  - documented local CORS default in Docker and deployment guides
 - Hardened repository scan API defaults and target restrictions:
   - local filesystem repository paths are now rejected in API/worker repo-scan flow
   - empty repo scan allowlist now denies all targets (explicit allowlist required)

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -59,6 +59,8 @@ IDENTRAIL_REPO_SCAN_MAX_FINDINGS_MAX=1000
 # API controls
 IDENTRAIL_RATE_LIMIT_RPM=120
 IDENTRAIL_RATE_LIMIT_BURST=20
+# Local dashboard origin for out-of-box web -> API calls in Docker Compose quickstart.
+IDENTRAIL_CORS_ALLOWED_ORIGINS=http://localhost:8081
 # Comma-separated trusted proxy IPs/CIDRs (empty = trust none, safest default)
 # IDENTRAIL_TRUSTED_PROXIES=10.0.0.0/8,127.0.0.1
 

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -13,6 +13,7 @@
 2. Edit keys and secrets in `deploy/docker/.env`
    - set `IDENTRAIL_POSTGRES_PASSWORD` to a strong value
    - set `IDENTRAIL_POSTGRES_PASSWORD_URLENCODED` to the URL-encoded value of `IDENTRAIL_POSTGRES_PASSWORD`
+   - local dashboard CORS is enabled by default via `IDENTRAIL_CORS_ALLOWED_ORIGINS=http://localhost:8081`
    - for live k8s collection: set `IDENTRAIL_K8S_SOURCE=kubectl`
    - optional context override: `IDENTRAIL_KUBE_CONTEXT`
 3. `docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env up -d --build`

--- a/docs/deployment-anywhere.md
+++ b/docs/deployment-anywhere.md
@@ -15,6 +15,7 @@ Use this for quick production-like environments on one host.
 1. Copy env template:
    - `cp deploy/docker/.env.example deploy/docker/.env`
 2. Edit strong secrets in `deploy/docker/.env`.
+   - local dashboard CORS is preconfigured in the template: `IDENTRAIL_CORS_ALLOWED_ORIGINS=http://localhost:8081`
 3. Start stack:
    - `docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env up -d --build`
 4. Verify:


### PR DESCRIPTION
## Summary
- add `IDENTRAIL_CORS_ALLOWED_ORIGINS=http://localhost:8081` to `deploy/docker/.env.example`
- document the local default in:
  - `deploy/docker/README.md`
  - `docs/deployment-anywhere.md`
- add changelog entry under `Unreleased`

## Why
CORS is intentionally disabled when no origins are configured, but Docker quickstart expects the web UI (`http://localhost:8081`) to call the API (`http://localhost:8080`) out of the box. This default removes first-run connectivity friction for local Compose users.

## Validation
- `cp deploy/docker/.env.example deploy/docker/.env`
- `docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env config`
- remove temporary `deploy/docker/.env` after validation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set a default CORS origin for local Docker so the web UI (http://localhost:8081) can call the API (http://localhost:8080) without manual config. Adds `IDENTRAIL_CORS_ALLOWED_ORIGINS=http://localhost:8081` to `deploy/docker/.env.example` and documents the default in Docker and deployment guides.

<sup>Written for commit 8a9333de13f5aedb3040899a0ae8443c6055b335. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

