### PR TITLE
Improve first-run quickstart onboarding flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,6 @@ jobs:
           read_key="$(openssl rand -hex 24)"
           write_key="$(openssl rand -hex 24)"
           pg_password="$(openssl rand -hex 24)"
-          pg_password_urlencoded="$(python3 -c 'import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=""))' "${pg_password}")"
           cat > deploy/docker/.env <<EOF
           IDENTRAIL_SERVICE_NAME=identrail
           IDENTRAIL_LOG_LEVEL=info
@@ -243,7 +242,6 @@ jobs:
           IDENTRAIL_API_KEYS=${read_key},${write_key}
           IDENTRAIL_WRITE_API_KEYS=${write_key}
           IDENTRAIL_POSTGRES_PASSWORD=${pg_password}
-          IDENTRAIL_POSTGRES_PASSWORD_URLENCODED=${pg_password_urlencoded}
           IDENTRAIL_RATE_LIMIT_RPM=10000
           IDENTRAIL_RATE_LIMIT_BURST=1000
           IDENTRAIL_LOCK_BACKEND=auto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Improved first-run onboarding flow:
+  - added `make quickstart` with `scripts/quickstart.sh` to bootstrap local Docker, trigger a first scan, and guide findings retrieval
+  - updated README quickstart to include first scan + findings flow (not only `/healthz`)
+  - removed `IDENTRAIL_POSTGRES_PASSWORD_URLENCODED` requirement from Docker Compose local path and related docs
 - Improved Docker Compose out-of-box web/API connectivity:
   - added `IDENTRAIL_CORS_ALLOWED_ORIGINS=http://localhost:8081` to `deploy/docker/.env.example`
   - documented local CORS default in Docker and deployment guides

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /usr/bin/env bash
 .DEFAULT_GOAL := help
 
-.PHONY: help bootstrap fmt fmt-check vet test test-integration web-install web-test web-build helm-lint tfmt-check ci pre-commit
+.PHONY: help bootstrap quickstart quickstart-down fmt fmt-check vet test test-integration web-install web-test web-build helm-lint tfmt-check ci pre-commit
 
 help: ## Show available targets
 	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z0-9_-]+:.*##/ {printf "%-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -9,6 +9,12 @@ help: ## Show available targets
 bootstrap: ## Install local dependencies for Go and web
 	go mod download
 	npm ci --prefix web
+
+quickstart: ## Bootstrap local Docker stack and run first scan
+	./scripts/quickstart.sh
+
+quickstart-down: ## Stop and remove quickstart Docker stack
+	docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env down
 
 fmt: ## Auto-format Go and Terraform files
 	@if git ls-files '*.go' | grep -q .; then \

--- a/README.md
+++ b/README.md
@@ -20,10 +20,21 @@ Identrail discovers machine identities and trust paths across AWS and Kubernetes
 
 ## Getting Started
 
+Fastest path (boots Docker stack, generates local keys/password, runs first scan):
+
+```bash
+make quickstart
+```
+
+Manual path:
+
 ```bash
 cp deploy/docker/.env.example deploy/docker/.env
 docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env up -d --build
 curl -sS http://localhost:8080/healthz
+# trigger first scan and list findings (replace <write-key>/<read-key> with values from deploy/docker/.env)
+curl -sS -X POST http://localhost:8080/v1/scans -H "X-API-Key: <write-key>" -H "Content-Type: application/json"
+curl -sS "http://localhost:8080/v1/findings?limit=5" -H "X-API-Key: <read-key>"
 ```
 
 ## Docs and Project Links

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -9,10 +9,9 @@ IDENTRAIL_AWS_REGION=us-east-1
 # Auth (required)
 IDENTRAIL_API_KEYS=replace-with-strong-read-key,replace-with-strong-write-key
 IDENTRAIL_WRITE_API_KEYS=replace-with-strong-write-key
+# For local Compose quickstart, use URL-safe password characters (hex works well).
+# `make quickstart` auto-generates this value.
 IDENTRAIL_POSTGRES_PASSWORD=replace-with-strong-postgres-password
-# URL-encoded copy of IDENTRAIL_POSTGRES_PASSWORD for DSN parsing safety in postgres:// URLs.
-# Example: python3 -c 'import urllib.parse; print(urllib.parse.quote("replace-with-strong-postgres-password", safe=""))'
-IDENTRAIL_POSTGRES_PASSWORD_URLENCODED=replace-with-strong-postgres-password
 
 # Optional scoped auth alternative (takes precedence over API_KEYS)
 # IDENTRAIL_API_KEY_SCOPES=reader-key:read;writer-key:read,write

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -9,10 +9,15 @@
 
 ## Quick Start
 
+Fastest local onboarding:
+
+1. `make quickstart`
+
+Manual setup:
+
 1. `cp deploy/docker/.env.example deploy/docker/.env`
 2. Edit keys and secrets in `deploy/docker/.env`
    - set `IDENTRAIL_POSTGRES_PASSWORD` to a strong value
-   - set `IDENTRAIL_POSTGRES_PASSWORD_URLENCODED` to the URL-encoded value of `IDENTRAIL_POSTGRES_PASSWORD`
    - local dashboard CORS is enabled by default via `IDENTRAIL_CORS_ALLOWED_ORIGINS=http://localhost:8081`
    - for live k8s collection: set `IDENTRAIL_K8S_SOURCE=kubectl`
    - optional context override: `IDENTRAIL_KUBE_CONTEXT`

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - .env
     environment:
       IDENTRAIL_HTTP_ADDR: ":8080"
-      IDENTRAIL_DATABASE_URL: "postgres://identrail:${IDENTRAIL_POSTGRES_PASSWORD_URLENCODED:?set IDENTRAIL_POSTGRES_PASSWORD_URLENCODED in deploy/docker/.env}@postgres:5432/identrail?sslmode=disable"
+      IDENTRAIL_DATABASE_URL: "postgres://identrail:${IDENTRAIL_POSTGRES_PASSWORD:?set IDENTRAIL_POSTGRES_PASSWORD in deploy/docker/.env}@postgres:5432/identrail?sslmode=disable"
       IDENTRAIL_RUN_MIGRATIONS: "true"
       IDENTRAIL_MIGRATIONS_DIR: "/app/migrations"
     ports:
@@ -56,7 +56,7 @@ services:
     env_file:
       - .env
     environment:
-      IDENTRAIL_DATABASE_URL: "postgres://identrail:${IDENTRAIL_POSTGRES_PASSWORD_URLENCODED:?set IDENTRAIL_POSTGRES_PASSWORD_URLENCODED in deploy/docker/.env}@postgres:5432/identrail?sslmode=disable"
+      IDENTRAIL_DATABASE_URL: "postgres://identrail:${IDENTRAIL_POSTGRES_PASSWORD:?set IDENTRAIL_POSTGRES_PASSWORD in deploy/docker/.env}@postgres:5432/identrail?sslmode=disable"
       IDENTRAIL_RUN_MIGRATIONS: "false"
       IDENTRAIL_MIGRATIONS_DIR: "/app/migrations"
 

--- a/docs/deployment-anywhere.md
+++ b/docs/deployment-anywhere.md
@@ -12,6 +12,9 @@ This guide standardizes deployment for five common targets:
 
 Use this for quick production-like environments on one host.
 
+Fastest local bootstrap:
+- `make quickstart`
+
 1. Copy env template:
    - `cp deploy/docker/.env.example deploy/docker/.env`
 2. Edit strong secrets in `deploy/docker/.env`.

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -18,6 +18,7 @@ Identrail now provides standardized local developer workflows through:
 ## Common Commands
 
 - `make help`: list available make targets.
+- `make quickstart`: bootstrap local Docker stack and run first scan.
 - `make ci`: run core local CI checks (format checks, vet, Go tests, web tests, web build).
 - `make fmt`: format Go and Terraform files.
 - `make fmt-check`: verify formatting only.

--- a/docs/enterprise-quickstart.md
+++ b/docs/enterprise-quickstart.md
@@ -18,7 +18,6 @@ Edit `deploy/docker/.env` and set at minimum:
 - `IDENTRAIL_API_KEYS` with strong unique keys
 - `IDENTRAIL_WRITE_API_KEYS` with write-capable keys
 - `IDENTRAIL_POSTGRES_PASSWORD` with a strong database password
-- `IDENTRAIL_POSTGRES_PASSWORD_URLENCODED` as URL-encoded `IDENTRAIL_POSTGRES_PASSWORD`
 - `IDENTRAIL_API_KEY_SCOPES` (required for this quickstart), for example:
   - `IDENTRAIL_API_KEY_SCOPES=<reader-key>:read;<writer-key>:read,write;<admin-key>:read,write,admin`
 - `IDENTRAIL_AUDIT_LOG_FILE=/tmp/identrail-audit.jsonl`

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -57,13 +57,82 @@ upsert_env() {
   mv "${tmp_file}" "${ENV_FILE}"
 }
 
-READ_KEY="$(openssl rand -hex 24)"
-WRITE_KEY="$(openssl rand -hex 24)"
-DB_PASSWORD="$(openssl rand -hex 24)"
+read_env() {
+  local key="$1"
+  awk -v key="${key}" '
+    $0 ~ ("^" key "=") {
+      print substr($0, index($0, "=") + 1)
+      exit
+    }
+  ' "${ENV_FILE}"
+}
 
-upsert_env "IDENTRAIL_API_KEYS" "${READ_KEY},${WRITE_KEY}"
-upsert_env "IDENTRAIL_WRITE_API_KEYS" "${WRITE_KEY}"
-upsert_env "IDENTRAIL_POSTGRES_PASSWORD" "${DB_PASSWORD}"
+first_csv_value() {
+  local value="$1"
+  printf '%s' "${value%%,*}"
+}
+
+second_csv_value() {
+  local value="$1"
+  if [[ "${value}" == *,* ]]; then
+    local remainder="${value#*,}"
+    printf '%s' "${remainder%%,*}"
+  fi
+}
+
+is_missing_or_template_value() {
+  local key="$1"
+  local value="$2"
+  if [[ -z "${value}" ]]; then
+    return 0
+  fi
+  case "${key}:${value}" in
+    "IDENTRAIL_API_KEYS:replace-with-strong-read-key,replace-with-strong-write-key") return 0 ;;
+    "IDENTRAIL_WRITE_API_KEYS:replace-with-strong-write-key") return 0 ;;
+    "IDENTRAIL_POSTGRES_PASSWORD:replace-with-strong-postgres-password") return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+API_KEYS_VALUE="$(read_env IDENTRAIL_API_KEYS)"
+WRITE_KEYS_VALUE="$(read_env IDENTRAIL_WRITE_API_KEYS)"
+DB_PASSWORD_VALUE="$(read_env IDENTRAIL_POSTGRES_PASSWORD)"
+
+READ_KEY="$(first_csv_value "${API_KEYS_VALUE}")"
+WRITE_KEY="$(first_csv_value "${WRITE_KEYS_VALUE}")"
+DB_PASSWORD="${DB_PASSWORD_VALUE}"
+
+if is_missing_or_template_value "IDENTRAIL_API_KEYS" "${API_KEYS_VALUE}"; then
+  READ_KEY="$(openssl rand -hex 24)"
+  if is_missing_or_template_value "IDENTRAIL_WRITE_API_KEYS" "${WRITE_KEYS_VALUE}"; then
+    WRITE_KEY="$(openssl rand -hex 24)"
+  elif [[ -z "${WRITE_KEY}" ]]; then
+    WRITE_KEY="$(openssl rand -hex 24)"
+  fi
+  API_KEYS_VALUE="${READ_KEY},${WRITE_KEY}"
+  upsert_env "IDENTRAIL_API_KEYS" "${API_KEYS_VALUE}"
+fi
+
+if is_missing_or_template_value "IDENTRAIL_WRITE_API_KEYS" "${WRITE_KEYS_VALUE}"; then
+  WRITE_KEY="$(second_csv_value "${API_KEYS_VALUE}")"
+  if [[ -z "${WRITE_KEY}" ]]; then
+    WRITE_KEY="$(first_csv_value "${API_KEYS_VALUE}")"
+  fi
+  if [[ -z "${WRITE_KEY}" ]]; then
+    WRITE_KEY="$(openssl rand -hex 24)"
+    READ_KEY="${READ_KEY:-$(openssl rand -hex 24)}"
+    API_KEYS_VALUE="${READ_KEY},${WRITE_KEY}"
+    upsert_env "IDENTRAIL_API_KEYS" "${API_KEYS_VALUE}"
+  fi
+  WRITE_KEYS_VALUE="${WRITE_KEY}"
+  upsert_env "IDENTRAIL_WRITE_API_KEYS" "${WRITE_KEYS_VALUE}"
+fi
+
+if is_missing_or_template_value "IDENTRAIL_POSTGRES_PASSWORD" "${DB_PASSWORD_VALUE}"; then
+  DB_PASSWORD="$(openssl rand -hex 24)"
+  upsert_env "IDENTRAIL_POSTGRES_PASSWORD" "${DB_PASSWORD}"
+fi
+
 upsert_env "IDENTRAIL_WORKER_RUN_NOW" "false"
 
 docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" up -d --build

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_EXAMPLE="${ROOT_DIR}/deploy/docker/.env.example"
+ENV_FILE="${ROOT_DIR}/deploy/docker/.env"
+COMPOSE_FILE="${ROOT_DIR}/deploy/docker/docker-compose.yml"
+API_URL="${IDENTRAIL_API_URL:-http://localhost:8080}"
+WEB_URL="${IDENTRAIL_WEB_URL:-http://localhost:8081}"
+HEALTH_URL="${API_URL}/healthz"
+SCAN_URL="${API_URL}/v1/scans"
+FINDINGS_URL="${API_URL}/v1/findings?limit=5"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "ERROR: docker is required"
+  exit 1
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "ERROR: python3 is required"
+  exit 1
+fi
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "ERROR: openssl is required"
+  exit 1
+fi
+if ! docker compose version >/dev/null 2>&1; then
+  echo "ERROR: docker compose plugin is required"
+  exit 1
+fi
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  cp "${ENV_EXAMPLE}" "${ENV_FILE}"
+  echo "Created ${ENV_FILE} from template."
+fi
+
+upsert_env() {
+  local key="$1"
+  local value="$2"
+  local tmp_file
+  tmp_file="$(mktemp)"
+  awk -v key="${key}" -v value="${value}" '
+    BEGIN { replaced = 0 }
+    $0 ~ ("^" key "=") {
+      if (!replaced) {
+        print key "=" value
+        replaced = 1
+      }
+      next
+    }
+    { print }
+    END {
+      if (!replaced) {
+        print key "=" value
+      }
+    }
+  ' "${ENV_FILE}" >"${tmp_file}"
+  mv "${tmp_file}" "${ENV_FILE}"
+}
+
+READ_KEY="$(openssl rand -hex 24)"
+WRITE_KEY="$(openssl rand -hex 24)"
+DB_PASSWORD="$(openssl rand -hex 24)"
+
+upsert_env "IDENTRAIL_API_KEYS" "${READ_KEY},${WRITE_KEY}"
+upsert_env "IDENTRAIL_WRITE_API_KEYS" "${WRITE_KEY}"
+upsert_env "IDENTRAIL_POSTGRES_PASSWORD" "${DB_PASSWORD}"
+upsert_env "IDENTRAIL_WORKER_RUN_NOW" "false"
+
+docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" up -d --build
+
+echo "Waiting for API health endpoint..."
+healthy="false"
+for _ in $(seq 1 45); do
+  if curl -fsS "${HEALTH_URL}" >/dev/null; then
+    healthy="true"
+    break
+  fi
+  sleep 2
+done
+
+if [[ "${healthy}" != "true" ]]; then
+  echo "ERROR: API did not become healthy."
+  docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" ps
+  docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" logs api postgres || true
+  exit 1
+fi
+
+SCAN_JSON="$(
+  curl -fsS -X POST "${SCAN_URL}" \
+    -H "X-API-Key: ${WRITE_KEY}" \
+    -H "Content-Type: application/json"
+)"
+SCAN_ID="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["scan"]["id"])' <<<"${SCAN_JSON}")"
+
+echo "Triggered first scan: ${SCAN_ID}"
+
+for _ in $(seq 1 45); do
+  FINDINGS_JSON="$(curl -fsS "${FINDINGS_URL}" -H "X-API-Key: ${READ_KEY}")"
+  FINDING_COUNT="$(python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("items", [])))' <<<"${FINDINGS_JSON}")"
+  if [[ "${FINDING_COUNT}" -gt 0 ]]; then
+    break
+  fi
+  sleep 2
+done
+
+echo
+echo "Quickstart completed."
+echo "API: ${API_URL}"
+echo "Web: ${WEB_URL}"
+echo "Scan ID: ${SCAN_ID}"
+echo
+echo "Read findings:"
+echo "curl -sS \"${FINDINGS_URL}\" -H \"X-API-Key: ${READ_KEY}\" | python3 -m json.tool"
+echo
+echo "When done:"
+echo "docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env down"


### PR DESCRIPTION
## Summary
- add `make quickstart` and `make quickstart-down` targets
- add `scripts/quickstart.sh` to:
  - bootstrap `deploy/docker/.env` from template when missing
  - generate local API keys and Postgres password automatically
  - start Docker Compose stack
  - wait for API health
  - trigger first scan and print a findings command
- update README getting started section to include first-scan/findings flow
- remove local Docker requirement for `IDENTRAIL_POSTGRES_PASSWORD_URLENCODED`
  - Docker Compose now builds DB URL from `IDENTRAIL_POSTGRES_PASSWORD`
  - docs and examples updated accordingly
- align CI compose smoke config with the new Docker env model

## Why
First-run setup stopped at `/healthz` and required users to manually manage both raw and URL-encoded DB password values, which added avoidable onboarding friction. This change provides a one-command path to first findings and removes the dual-password-variable requirement from local Docker onboarding.

## Validation
- `bash -n scripts/quickstart.sh`
- `cp deploy/docker/.env.example deploy/docker/.env`
- `docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env config`
- `make help`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-command local quickstart that boots Docker, generates API keys and a Postgres password on first run (without rotating them), runs a first scan, and shows how to fetch findings. Removes `IDENTRAIL_POSTGRES_PASSWORD_URLENCODED`, updates Compose and docs, and aligns CI with the new env model.

- **New Features**
  - Added `make quickstart` and `make quickstart-down`.
  - Added `scripts/quickstart.sh` to bootstrap `deploy/docker/.env`, generate keys/password only if missing, start Docker Compose, wait for API health, trigger a scan, and print a findings command.
  - Updated README and guides to include the first scan + findings flow.

- **Migration**
  - Local Docker no longer uses `IDENTRAIL_POSTGRES_PASSWORD_URLENCODED`. Set only `IDENTRAIL_POSTGRES_PASSWORD` (use URL-safe characters) and Compose builds the DB URL from it.
  - You can run `make quickstart` to auto-generate values and start the stack.

<sup>Written for commit dd6f156979ea5d1488743d3599f530ef3e19affd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

