### PR TITLE
Expose finding triage workflow in dashboard

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -207,12 +207,12 @@ describe('App', () => {
       const matchedCall = fetchMock.mock.calls.find((call) => {
         const requestCall = call as unknown as [RequestInfo | URL, RequestInit?];
         const options = requestCall[1];
-        const headers = options?.headers as Record<string, string> | undefined;
-        if (!headers) return false;
+        if (!options?.headers) return false;
+        const headers = new Headers(options.headers);
         return (
-          headers['X-API-Key'] === 'reader-key' &&
-          headers['X-Identrail-Tenant-ID'] === 'tenant-a' &&
-          headers['X-Identrail-Workspace-ID'] === 'workspace-a'
+          headers.get('x-api-key') === 'reader-key' &&
+          headers.get('x-identrail-tenant-id') === 'tenant-a' &&
+          headers.get('x-identrail-workspace-id') === 'workspace-a'
         );
       });
       expect(matchedCall).toBeDefined();
@@ -348,5 +348,79 @@ describe('App', () => {
     }) as [RequestInfo | URL, RequestInit] | undefined;
     expect(patchCall).toBeDefined();
     expect(patchCall?.[1].method).toBe('PATCH');
+  });
+
+  it('keeps finding detail visible when history fetch fails', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/v1/findings/summary')) return ok({ total: 1, by_severity: { high: 1 }, by_type: { risky_trust_policy: 1 } });
+      if (url.includes('/v1/findings/trends')) return ok({ items: [] });
+      if (url.includes('/v1/scans?')) {
+        return ok({
+          items: [{ id: 'scan-1', provider: 'aws', status: 'completed', started_at: '2026-03-16T00:00:00Z', asset_count: 1, finding_count: 1 }]
+        });
+      }
+      if (url.includes('/v1/findings?')) {
+        return ok({
+          items: [
+            {
+              id: 'f-1',
+              scan_id: 'scan-1',
+              type: 'risky_trust_policy',
+              severity: 'high',
+              title: 'Risky trust',
+              human_summary: 'summary',
+              remediation: 'fix',
+              created_at: '2026-03-16T00:00:00Z',
+              triage: { status: 'open' }
+            }
+          ]
+        });
+      }
+      if (url.includes('/v1/findings/f-1/history')) {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          json: async () => ({ error: 'history unavailable' })
+        });
+      }
+      if (url.includes('/v1/findings/f-1')) {
+        return ok({
+          id: 'f-1',
+          scan_id: 'scan-1',
+          type: 'risky_trust_policy',
+          severity: 'high',
+          title: 'Risky trust',
+          human_summary: 'summary',
+          remediation: 'fix',
+          created_at: '2026-03-16T00:00:00Z',
+          triage: { status: 'open' }
+        });
+      }
+      if (url.includes('/v1/scans/scan-1/diff')) {
+        return ok({
+          scan_id: 'scan-1',
+          added_count: 0,
+          resolved_count: 0,
+          persisting_count: 1,
+          added: [],
+          resolved: [],
+          persisting: []
+        });
+      }
+      if (url.includes('/v1/identities')) return ok({ items: [] });
+      if (url.includes('/v1/relationships')) return ok({ items: [] });
+      if (url.includes('/v1/scans/scan-1/events')) return ok({ items: [] });
+      return ok({ items: [] });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Risky trust').length).toBeGreaterThan(0);
+      expect(screen.getByText('summary')).toBeInTheDocument();
+      expect(screen.getByText('history unavailable')).toBeInTheDocument();
+    });
   });
 });

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -38,6 +38,22 @@ describe('App', () => {
           ]
         });
       }
+      if (url.includes('/v1/findings/f-1/history')) {
+        return ok({
+          items: [
+            {
+              id: 'evt-1',
+              finding_id: 'f-1',
+              action: 'commented',
+              from_status: 'open',
+              to_status: 'open',
+              comment: 'initial review',
+              actor: 'subject:reviewer',
+              created_at: '2026-03-16T00:00:00Z'
+            }
+          ]
+        });
+      }
       if (url.includes('/v1/findings/f-1')) {
         return ok({
           id: 'f-1',
@@ -201,5 +217,136 @@ describe('App', () => {
       });
       expect(matchedCall).toBeDefined();
     });
+  });
+
+  it('supports finding triage actions and renders audit trail', async () => {
+    let historyItems = [
+      {
+        id: 'evt-1',
+        finding_id: 'f-1',
+        action: 'commented',
+        from_status: 'open',
+        to_status: 'open',
+        comment: 'initial review',
+        actor: 'subject:reviewer',
+        created_at: '2026-03-16T00:00:00Z'
+      }
+    ];
+
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/v1/findings/summary')) return ok({ total: 1, by_severity: { high: 1 }, by_type: { risky_trust_policy: 1 } });
+      if (url.includes('/v1/findings/trends')) return ok({ items: [] });
+      if (url.includes('/v1/scans?')) {
+        return ok({
+          items: [{ id: 'scan-1', provider: 'aws', status: 'completed', started_at: '2026-03-16T00:00:00Z', asset_count: 1, finding_count: 1 }]
+        });
+      }
+      if (url.includes('/v1/findings?')) {
+        return ok({
+          items: [
+            {
+              id: 'f-1',
+              scan_id: 'scan-1',
+              type: 'risky_trust_policy',
+              severity: 'high',
+              title: 'Risky trust',
+              human_summary: 'summary',
+              remediation: 'fix',
+              created_at: '2026-03-16T00:00:00Z',
+              triage: { status: 'open' }
+            }
+          ]
+        });
+      }
+      if (url.includes('/v1/findings/f-1/history')) {
+        return ok({ items: historyItems });
+      }
+      if (url.includes('/v1/findings/f-1/triage')) {
+        historyItems = [
+          {
+            id: 'evt-2',
+            finding_id: 'f-1',
+            action: 'acknowledged',
+            from_status: 'open',
+            to_status: 'ack',
+            comment: 'accepted for follow-up',
+            actor: 'subject:writer',
+            created_at: '2026-03-16T00:01:00Z'
+          },
+          ...historyItems
+        ];
+        return ok({
+          finding: {
+            id: 'f-1',
+            scan_id: 'scan-1',
+            type: 'risky_trust_policy',
+            severity: 'high',
+            title: 'Risky trust',
+            human_summary: 'summary',
+            remediation: 'fix',
+            created_at: '2026-03-16T00:00:00Z',
+            triage: { status: 'ack', assignee: 'platform' }
+          }
+        });
+      }
+      if (url.includes('/v1/findings/f-1')) {
+        return ok({
+          id: 'f-1',
+          scan_id: 'scan-1',
+          type: 'risky_trust_policy',
+          severity: 'high',
+          title: 'Risky trust',
+          human_summary: 'summary',
+          remediation: 'fix',
+          created_at: '2026-03-16T00:00:00Z',
+          triage: { status: 'open' }
+        });
+      }
+      if (url.includes('/v1/scans/scan-1/diff')) {
+        return ok({
+          scan_id: 'scan-1',
+          added_count: 0,
+          resolved_count: 0,
+          persisting_count: 1,
+          added: [],
+          resolved: [],
+          persisting: []
+        });
+      }
+      if (url.includes('/v1/identities')) return ok({ items: [] });
+      if (url.includes('/v1/relationships')) return ok({ items: [] });
+      if (url.includes('/v1/scans/scan-1/events')) return ok({ items: [] });
+      return ok({ items: [] });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Risky trust').length).toBeGreaterThan(0);
+      expect(screen.getByText('commented')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Assignee'), { target: { value: 'platform' } });
+    fireEvent.change(screen.getByLabelText('Comment'), { target: { value: 'accepted for follow-up' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Ack' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText((_, node) => {
+          const text = node?.textContent?.replace(/\s+/g, ' ').trim();
+          return text === 'Status: ack';
+        })
+      ).toBeInTheDocument();
+      expect(screen.getByText('acknowledged')).toBeInTheDocument();
+    });
+
+    const patchCall = fetchMock.mock.calls.find((call) => {
+      const requestCall = call as unknown as [RequestInfo | URL, RequestInit?];
+      return String(requestCall[0]).includes('/v1/findings/f-1/triage?scan_id=scan-1');
+    }) as [RequestInfo | URL, RequestInit] | undefined;
+    expect(patchCall).toBeDefined();
+    expect(patchCall?.[1].method).toBe('PATCH');
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -240,32 +240,43 @@ export function App() {
       setTriageHistory([]);
       setFindingError(null);
       setHistoryError(null);
+      setLoadingHistory(false);
       return;
     }
     let active = true;
     setLoadingFinding(true);
     setLoadingHistory(true);
-    Promise.all([
-      apiClient.getFinding(selectedFindingID, scanID, requestAuth),
-      apiClient.listFindingHistory(selectedFindingID, scanID, 20, requestAuth)
-    ])
-      .then(([item, history]) => {
+    apiClient
+      .getFinding(selectedFindingID, scanID, requestAuth)
+      .then((item) => {
         if (!active) return;
         setSelectedFinding(item);
-        setTriageHistory(history.items);
         setFindingError(null);
-        setHistoryError(null);
       })
       .catch((err: Error) => {
         if (!active) return;
         setSelectedFinding(null);
-        setTriageHistory([]);
         setFindingError(err.message);
-        setHistoryError(err.message);
       })
       .finally(() => {
         if (!active) return;
         setLoadingFinding(false);
+      });
+
+    apiClient
+      .listFindingHistory(selectedFindingID, scanID, 20, requestAuth)
+      .then((history) => {
+        if (!active) return;
+        setTriageHistory(history.items);
+        setHistoryError(null);
+      })
+      .catch((err: Error) => {
+        if (!active) return;
+        setTriageHistory([]);
+        setHistoryError(err.message);
+      })
+      .finally(() => {
+        if (!active) return;
         setLoadingHistory(false);
       });
     return () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -240,6 +240,7 @@ export function App() {
       setTriageHistory([]);
       setFindingError(null);
       setHistoryError(null);
+      setLoadingHistory(false);
       return;
     }
     let active = true;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,8 +2,11 @@ import { useEffect, useMemo, useState } from 'react';
 import {
   apiClient,
   type Finding,
+  type FindingLifecycleStatus,
+  type FindingTriageEvent,
   type FindingsSummary,
   type Identity,
+  type FindingTriageRequest,
   type RequestAuthContext,
   type Relationship,
   type ScanDiff,
@@ -11,6 +14,50 @@ import {
   type ScanRecord,
   type TrendPoint
 } from './api/client';
+
+function formatDateTime(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleString();
+}
+
+function toDateTimeLocal(value?: string): string {
+  if (!value) {
+    return '';
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return '';
+  }
+  const year = parsed.getFullYear();
+  const month = String(parsed.getMonth() + 1).padStart(2, '0');
+  const day = String(parsed.getDate()).padStart(2, '0');
+  const hour = String(parsed.getHours()).padStart(2, '0');
+  const minute = String(parsed.getMinutes()).padStart(2, '0');
+  return `${year}-${month}-${day}T${hour}:${minute}`;
+}
+
+function fromDateTimeLocal(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed.toISOString();
+}
+
+function findingStatus(finding: Finding | null): FindingLifecycleStatus {
+  return finding?.triage?.status ?? 'open';
+}
+
+function formatTriageAction(action: string): string {
+  return action.replace(/_/g, ' ');
+}
 
 export function App() {
   const [apiKey, setApiKey] = useState('');
@@ -33,9 +80,18 @@ export function App() {
   const [overviewError, setOverviewError] = useState<string | null>(null);
   const [detailsError, setDetailsError] = useState<string | null>(null);
   const [findingError, setFindingError] = useState<string | null>(null);
+  const [historyError, setHistoryError] = useState<string | null>(null);
+  const [triageError, setTriageError] = useState<string | null>(null);
+  const [triageSuccess, setTriageSuccess] = useState<string | null>(null);
   const [loadingOverview, setLoadingOverview] = useState(false);
   const [loadingDetails, setLoadingDetails] = useState(false);
   const [loadingFinding, setLoadingFinding] = useState(false);
+  const [loadingHistory, setLoadingHistory] = useState(false);
+  const [submittingTriage, setSubmittingTriage] = useState(false);
+  const [triageHistory, setTriageHistory] = useState<FindingTriageEvent[]>([]);
+  const [triageAssignee, setTriageAssignee] = useState('');
+  const [triageSuppressUntil, setTriageSuppressUntil] = useState('');
+  const [triageComment, setTriageComment] = useState('');
   const [refreshNonce, setRefreshNonce] = useState(0);
 
   const topSeverities = useMemo(() => {
@@ -181,32 +237,96 @@ export function App() {
     const scanID = availableScanID;
     if (!selectedFindingID || !scanID) {
       setSelectedFinding(null);
+      setTriageHistory([]);
       setFindingError(null);
+      setHistoryError(null);
       return;
     }
     let active = true;
     setLoadingFinding(true);
-    apiClient
-      .getFinding(selectedFindingID, scanID, requestAuth)
-      .then((item) => {
+    setLoadingHistory(true);
+    Promise.all([
+      apiClient.getFinding(selectedFindingID, scanID, requestAuth),
+      apiClient.listFindingHistory(selectedFindingID, scanID, 20, requestAuth)
+    ])
+      .then(([item, history]) => {
         if (!active) return;
         setSelectedFinding(item);
+        setTriageHistory(history.items);
         setFindingError(null);
+        setHistoryError(null);
       })
       .catch((err: Error) => {
         if (!active) return;
         setSelectedFinding(null);
+        setTriageHistory([]);
         setFindingError(err.message);
+        setHistoryError(err.message);
       })
       .finally(() => {
-        if (active) setLoadingFinding(false);
+        if (!active) return;
+        setLoadingFinding(false);
+        setLoadingHistory(false);
       });
     return () => {
       active = false;
     };
   }, [selectedFindingID, availableScanID, requestAuth]);
 
+  useEffect(() => {
+    setTriageAssignee(selectedFinding?.triage?.assignee ?? '');
+    setTriageSuppressUntil(toDateTimeLocal(selectedFinding?.triage?.suppression_expires_at));
+    setTriageComment('');
+    setTriageError(null);
+    setTriageSuccess(null);
+  }, [selectedFindingID, selectedFinding?.triage?.assignee, selectedFinding?.triage?.suppression_expires_at]);
+
   const triggerRefresh = () => setRefreshNonce((value) => value + 1);
+  const canSubmitTriage = Boolean(selectedFinding && availableScanID);
+
+  const submitTriageAction = async (status: FindingLifecycleStatus): Promise<void> => {
+    if (!selectedFindingID || !availableScanID) {
+      return;
+    }
+    setTriageError(null);
+    setTriageSuccess(null);
+
+    const payload: FindingTriageRequest = {
+      status,
+      assignee: triageAssignee.trim(),
+      comment: triageComment.trim()
+    };
+
+    if (status === 'suppressed') {
+      const suppressionExpiry = fromDateTimeLocal(triageSuppressUntil);
+      if (!suppressionExpiry) {
+        setTriageError('Suppression requires a valid future "Suppress Until" value.');
+        return;
+      }
+      payload.suppression_expires_at = suppressionExpiry;
+    }
+
+    setSubmittingTriage(true);
+    try {
+      const triageResult = await apiClient.triageFinding(selectedFindingID, payload, availableScanID, requestAuth);
+      setSelectedFinding(triageResult.finding);
+      setFindings((current) =>
+        current.map((finding) => (finding.id === triageResult.finding.id ? triageResult.finding : finding))
+      );
+      const historyResult = await apiClient.listFindingHistory(selectedFindingID, availableScanID, 20, requestAuth);
+      setTriageHistory(historyResult.items);
+      setTriageSuccess(`Finding updated to ${status}.`);
+      setTriageComment('');
+    } catch (err) {
+      if (err instanceof Error) {
+        setTriageError(err.message);
+      } else {
+        setTriageError('failed to update finding triage');
+      }
+    } finally {
+      setSubmittingTriage(false);
+    }
+  };
 
   return (
     <main className="page">
@@ -341,6 +461,7 @@ export function App() {
               <tr>
                 <th>ID</th>
                 <th>Severity</th>
+                <th>Triage</th>
                 <th>Type</th>
                 <th>Title</th>
               </tr>
@@ -354,6 +475,7 @@ export function App() {
                 >
                   <td>{finding.id.slice(0, 12)}</td>
                   <td>{finding.severity}</td>
+                  <td>{finding.triage?.status ?? 'open'}</td>
                   <td>{finding.type}</td>
                   <td>{finding.title}</td>
                 </tr>
@@ -377,6 +499,70 @@ export function App() {
               <p>
                 <strong>Remediation:</strong> {selectedFinding.remediation}
               </p>
+              <p>
+                <strong>Status:</strong> {findingStatus(selectedFinding)}
+              </p>
+              <p>
+                <strong>Assignee:</strong> {selectedFinding.triage?.assignee || 'unassigned'}
+              </p>
+              {selectedFinding.triage?.suppression_expires_at && (
+                <p>
+                  <strong>Suppressed Until:</strong> {formatDateTime(selectedFinding.triage.suppression_expires_at)}
+                </p>
+              )}
+
+              <div className="triage-controls">
+                <h3>Triage Actions</h3>
+                <label htmlFor="triage-assignee">Assignee</label>
+                <input
+                  id="triage-assignee"
+                  value={triageAssignee}
+                  onChange={(event) => setTriageAssignee(event.target.value)}
+                  placeholder="e.g. platform-oncall"
+                />
+
+                <label htmlFor="triage-suppress-until">Suppress Until</label>
+                <input
+                  id="triage-suppress-until"
+                  type="datetime-local"
+                  value={triageSuppressUntil}
+                  onChange={(event) => setTriageSuppressUntil(event.target.value)}
+                />
+
+                <label htmlFor="triage-comment">Comment</label>
+                <textarea
+                  id="triage-comment"
+                  value={triageComment}
+                  onChange={(event) => setTriageComment(event.target.value)}
+                  placeholder="Optional audit comment"
+                />
+
+                <div className="triage-actions">
+                  <button
+                    type="button"
+                    onClick={() => void submitTriageAction('ack')}
+                    disabled={!canSubmitTriage || submittingTriage}
+                  >
+                    Ack
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void submitTriageAction('suppressed')}
+                    disabled={!canSubmitTriage || submittingTriage}
+                  >
+                    Suppress
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void submitTriageAction('resolved')}
+                    disabled={!canSubmitTriage || submittingTriage}
+                  >
+                    Resolve
+                  </button>
+                </div>
+                {triageSuccess && <p className="success">{triageSuccess}</p>}
+                {triageError && <p className="error">{triageError}</p>}
+              </div>
             </>
           )}
         </div>
@@ -388,6 +574,25 @@ export function App() {
               <li>Added: {scanDiff.added_count}</li>
               <li>Resolved: {scanDiff.resolved_count}</li>
               <li>Persisting: {scanDiff.persisting_count}</li>
+            </ul>
+          )}
+
+          <h3>Triage Audit Trail</h3>
+          {loadingHistory && <p>Loading triage history...</p>}
+          {historyError && <p className="error">{historyError}</p>}
+          {!loadingHistory && !historyError && triageHistory.length === 0 && (
+            <p className="hint">No triage actions recorded yet.</p>
+          )}
+          {!loadingHistory && !historyError && triageHistory.length > 0 && (
+            <ul className="stats-list triage-history">
+              {triageHistory.map((event) => (
+                <li key={event.id}>
+                  <strong>{formatTriageAction(event.action)}</strong> · {event.from_status} → {event.to_status} ·{' '}
+                  {formatDateTime(event.created_at)}
+                  {event.actor && <span> · {event.actor}</span>}
+                  {event.comment && <div>{event.comment}</div>}
+                </li>
+              ))}
             </ul>
           )}
         </div>

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { apiClient, buildQuery } from './client';
+import { apiClient, buildQuery, mergeRequestHeaders } from './client';
 
 describe('buildQuery', () => {
   it('encodes defined query params only', () => {
@@ -28,10 +28,9 @@ describe('apiClient', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toContain('/v1/findings?scan_id=scan-1&severity=high&type=risky_trust_policy');
-    expect(options.headers).toMatchObject({
-      'Content-Type': 'application/json',
-      'X-API-Key': 'reader'
-    });
+    const headers = new Headers(options.headers);
+    expect(headers.get('content-type')).toBe('application/json');
+    expect(headers.get('x-api-key')).toBe('reader');
   });
 
   it('uses default scan listing sort contract', async () => {
@@ -84,11 +83,21 @@ describe('apiClient', () => {
     });
 
     const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(options.headers).toMatchObject({
-      'X-API-Key': 'reader',
-      'X-Identrail-Tenant-ID': 'tenant-a',
-      'X-Identrail-Workspace-ID': 'workspace-a'
-    });
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-api-key')).toBe('reader');
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace-a');
+  });
+
+  it('merges override headers from tuple arrays and Headers', () => {
+    const tupleMerged = mergeRequestHeaders({ apiKey: 'reader' }, [['X-Trace-ID', 'trace-1']]);
+    expect(tupleMerged.get('x-api-key')).toBe('reader');
+    expect(tupleMerged.get('x-trace-id')).toBe('trace-1');
+
+    const headerOverrides = new Headers({ Authorization: 'Bearer test-token', 'X-API-Key': 'override' });
+    const headersMerged = mergeRequestHeaders({ apiKey: 'reader' }, headerOverrides);
+    expect(headersMerged.get('authorization')).toBe('Bearer test-token');
+    expect(headersMerged.get('x-api-key')).toBe('override');
   });
 
   it('surfaces backend error envelope message', async () => {

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -101,4 +101,37 @@ describe('apiClient', () => {
 
     await expect(apiClient.getFindingsSummary({ apiKey: 'reader' })).rejects.toThrow('unauthorized');
   });
+
+  it('requests finding triage history with scan scope', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [] })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.listFindingHistory('finding-1', 'scan-1', 15, { apiKey: 'reader' });
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toContain('/v1/findings/finding-1/history?scan_id=scan-1&limit=15');
+  });
+
+  it('sends triage patch payload for finding workflow actions', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ finding: { id: 'finding-1' } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.triageFinding(
+      'finding-1',
+      { status: 'ack', assignee: 'platform', comment: 'acknowledged' },
+      'scan-1',
+      { apiKey: 'writer' }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/v1/findings/finding-1/triage?scan_id=scan-1');
+    expect(options.method).toBe('PATCH');
+    expect(options.body).toBe(JSON.stringify({ status: 'ack', assignee: 'platform', comment: 'acknowledged' }));
+  });
 });

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -153,11 +153,20 @@ function buildRequestHeaders(auth?: RequestAuthContext): Record<string, string> 
   return headers;
 }
 
+export function mergeRequestHeaders(auth?: RequestAuthContext, initHeaders?: HeadersInit): Headers {
+  const headers = new Headers(buildRequestHeaders(auth));
+  if (!initHeaders) {
+    return headers;
+  }
+  const normalizedHeaders = new Headers(initHeaders);
+  normalizedHeaders.forEach((value, key) => {
+    headers.set(key, value);
+  });
+  return headers;
+}
+
 async function request<T>(path: string, auth?: RequestAuthContext, init: RequestInit = {}): Promise<T> {
-  const headers = {
-    ...buildRequestHeaders(auth),
-    ...(init.headers as Record<string, string> | undefined)
-  };
+  const headers = mergeRequestHeaders(auth, init.headers);
   const res = await fetch(`${baseURL}${path}`, { ...init, headers });
   if (!res.ok) {
     let message = `Request failed (${res.status})`;

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -15,6 +15,7 @@ export type Finding = {
   evidence?: Record<string, unknown>;
   remediation: string;
   created_at: string;
+  triage?: FindingTriage;
 };
 
 export type ScanRecord = {
@@ -84,6 +85,36 @@ export type RequestAuthContext = {
   bearerToken?: string;
 };
 
+export type FindingLifecycleStatus = 'open' | 'ack' | 'suppressed' | 'resolved';
+
+export type FindingTriage = {
+  status: FindingLifecycleStatus;
+  assignee?: string;
+  suppression_expires_at?: string;
+  updated_at?: string;
+  updated_by?: string;
+};
+
+export type FindingTriageEvent = {
+  id: string;
+  finding_id: string;
+  action: string;
+  from_status: FindingLifecycleStatus;
+  to_status: FindingLifecycleStatus;
+  assignee?: string;
+  suppression_expires_at?: string;
+  comment?: string;
+  actor?: string;
+  created_at: string;
+};
+
+export type FindingTriageRequest = {
+  status?: FindingLifecycleStatus;
+  assignee?: string;
+  suppression_expires_at?: string;
+  comment?: string;
+};
+
 const configuredURL = import.meta.env.VITE_IDENTRAIL_API_URL as string | undefined;
 if (import.meta.env.PROD) {
   if (!configuredURL) {
@@ -122,9 +153,12 @@ function buildRequestHeaders(auth?: RequestAuthContext): Record<string, string> 
   return headers;
 }
 
-async function request<T>(path: string, auth?: RequestAuthContext): Promise<T> {
-  const headers = buildRequestHeaders(auth);
-  const res = await fetch(`${baseURL}${path}`, { headers });
+async function request<T>(path: string, auth?: RequestAuthContext, init: RequestInit = {}): Promise<T> {
+  const headers = {
+    ...buildRequestHeaders(auth),
+    ...(init.headers as Record<string, string> | undefined)
+  };
+  const res = await fetch(`${baseURL}${path}`, { ...init, headers });
   if (!res.ok) {
     let message = `Request failed (${res.status})`;
     try {
@@ -179,6 +213,19 @@ export const apiClient = {
   getFinding(findingID: string, scanID?: string, auth?: RequestAuthContext) {
     const suffix = buildQuery({ scan_id: scanID });
     return request<Finding>(`/v1/findings/${encodeURIComponent(findingID)}${suffix}`, auth);
+  },
+  listFindingHistory(findingID: string, scanID?: string, limit = 20, auth?: RequestAuthContext) {
+    return request<{ items: FindingTriageEvent[] }>(
+      `/v1/findings/${encodeURIComponent(findingID)}/history${buildQuery({ scan_id: scanID, limit })}`,
+      auth
+    );
+  },
+  triageFinding(findingID: string, payload: FindingTriageRequest, scanID?: string, auth?: RequestAuthContext) {
+    const suffix = buildQuery({ scan_id: scanID });
+    return request<{ finding: Finding }>(`/v1/findings/${encodeURIComponent(findingID)}/triage${suffix}`, auth, {
+      method: 'PATCH',
+      body: JSON.stringify(payload)
+    });
   },
   getScanDiff(scanID: string, limit = 20, auth?: RequestAuthContext, previousScanID?: string) {
     return request<ScanDiff>(

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -77,13 +77,19 @@ label {
 }
 
 input,
-select {
+select,
+textarea {
   width: 100%;
   border: 1px solid #b8ced6;
   border-radius: 10px;
   padding: 0.6rem 0.7rem;
   font-size: 0.95rem;
   background: #fff;
+}
+
+textarea {
+  min-height: 82px;
+  resize: vertical;
 }
 
 .total {
@@ -153,6 +159,50 @@ select {
 
 .error {
   color: var(--warning);
+}
+
+.success {
+  color: #1e7f38;
+}
+
+.triage-controls {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.triage-controls h3 {
+  margin: 0.2rem 0 0;
+}
+
+.triage-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.triage-actions button {
+  border: 1px solid #0a6659;
+  background: #0f8376;
+  color: #fff;
+  border-radius: 8px;
+  padding: 0.45rem 0.8rem;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.triage-actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.triage-history li {
+  padding: 0.45rem 0;
+  border-bottom: 1px solid #e3edf0;
+}
+
+.triage-history li:last-child {
+  border-bottom: none;
 }
 
 .hint {


### PR DESCRIPTION
## Summary
- add triage actions to dashboard finding detail (`Ack`, `Suppress`, `Resolve`) and wire them to `PATCH /v1/findings/{id}/triage`
- load and render finding triage history from `GET /v1/findings/{id}/history` as an audit trail panel
- expose current triage status/assignee/suppression expiry in the finding detail and include triage status in the findings table
- extend web API client/types for triage request/history support and allow request overrides in the shared request helper
- add/update web tests to cover triage API calls, header behavior, and end-to-end triage action rendering

## Why
The API already supports finding triage workflows, but the dashboard was read-mostly. This closes the v1 product gap by enabling triage lifecycle actions and surfacing auditable history in the UI.

## Validation
- `npm run test:ci` (web)
- `npm run build` (web)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the finding triage workflow in the dashboard. Users can Ack, Suppress, or Resolve findings and view an audit trail; triage status is now visible in lists and details.

- New Features
  - Added triage actions (Ack, Suppress with “Suppress Until”, Resolve) wired to `PATCH /v1/findings/{id}/triage`.
  - Added assignee and comment inputs with loading/success/error states; history and details refresh after actions; finding details remain visible if history fetch fails.
  - Added triage audit trail from `GET /v1/findings/{id}/history` showing actor, status changes, comments, and timestamps.
  - Surfaced current triage status, assignee, and suppression expiry in the detail view; added a triage status column to the findings table; added date/time helpers and `datetime-local` input.

- Refactors
  - Extended web API client with `FindingTriage*` types, `listFindingHistory`, `triageFinding`, and a `request` that supports `RequestInit` overrides and header merging via `mergeRequestHeaders` (case-insensitive; supports `Headers` and tuple arrays).
  - Updated tests for triage API calls (scan-scoped history and triage), header merging behavior, end-to-end triage action flow, and resilience when history loading fails.
  - Introduced styles for triage controls, textarea, audit trail, and success messages.

<sup>Written for commit 40c4503d83068f190e92b2becb2b5827b622fbe5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

