### PR TITLE
Fix v1 blocker #2: implement real readiness checks with /readyz

### DIFF
--- a/deploy/helm/identrail/templates/api-deployment.yaml
+++ b/deploy/helm/identrail/templates/api-deployment.yaml
@@ -50,7 +50,7 @@ spec:
             periodSeconds: 20
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /readyz
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/deploy/kubernetes/api-deployment.yaml
+++ b/deploy/kubernetes/api-deployment.yaml
@@ -32,7 +32,7 @@ spec:
                 name: identrail-secrets
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /readyz
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -110,6 +110,32 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		})
 	})
 
+	r.GET("/readyz", func(c *gin.Context) {
+		if svc == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{
+				"status":  "not_ready",
+				"service": "identrail",
+			})
+			return
+		}
+		readyCtx, cancel := context.WithTimeout(c.Request.Context(), 2*time.Second)
+		defer cancel()
+		if err := svc.CheckReadiness(readyCtx); err != nil {
+			if logger != nil {
+				logger.Warn("readiness check failed", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusServiceUnavailable, gin.H{
+				"status":  "not_ready",
+				"service": "identrail",
+			})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"status":  "ready",
+			"service": "identrail",
+		})
+	})
+
 	r.GET("/metrics", gin.WrapH(promhttp.HandlerFor(registry, promhttp.HandlerOpts{})))
 
 	var authzStore db.Store

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -92,6 +92,53 @@ func TestRouterHealthz(t *testing.T) {
 	}
 }
 
+func TestRouterReadyzWithoutService(t *testing.T) {
+	logger := zap.NewNop()
+	metrics := telemetry.NewMetrics()
+	r := NewRouter(logger, metrics, nil, RouterOptions{})
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected status 503, got %d", w.Code)
+	}
+}
+
+func TestRouterReadyzWithService(t *testing.T) {
+	logger := zap.NewNop()
+	metrics := telemetry.NewMetrics()
+	svc := NewService(db.NewMemoryStore(), routerScanner{}, "aws")
+	r := NewRouter(logger, metrics, svc, RouterOptions{})
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+}
+
+func TestRouterReadyzWithDependencyFailure(t *testing.T) {
+	logger := zap.NewNop()
+	metrics := telemetry.NewMetrics()
+	svc := NewService(db.NewMemoryStore(), routerScanner{}, "aws")
+	svc.ReadinessCheck = func(context.Context) error {
+		return errors.New("dependency unavailable")
+	}
+	r := NewRouter(logger, metrics, svc, RouterOptions{})
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected status 503, got %d", w.Code)
+	}
+}
+
 func TestRouterCORSDisabledByDefault(t *testing.T) {
 	logger := zap.NewNop()
 	metrics := telemetry.NewMetrics()

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -50,15 +50,16 @@ type RepoScannerFactory func(historyLimit int, maxFindings int) RepoScanExecutor
 
 // Service orchestrates scan execution and persistence.
 type Service struct {
-	Store         db.Store
-	Scanner       ScannerRunner
-	Provider      string
-	DefaultScope  db.Scope
-	Now           func() time.Time
-	Locker        scheduler.Locker
-	LockNamespace string
-	Alerter       FindingAlerter
-	OnAlertError  func(error)
+	Store          db.Store
+	Scanner        ScannerRunner
+	Provider       string
+	DefaultScope   db.Scope
+	Now            func() time.Time
+	Locker         scheduler.Locker
+	LockNamespace  string
+	Alerter        FindingAlerter
+	OnAlertError   func(error)
+	ReadinessCheck func(context.Context) error
 	// Repo scan controls are intentionally separate from cloud identity scan flow.
 	RepoScanEnabled             bool
 	RepoScanDefaultHistoryLimit int
@@ -69,6 +70,25 @@ type Service struct {
 	ScanQueueMaxPending         int
 	RepoQueueMaxPending         int
 	RepoScannerFactory          RepoScannerFactory
+}
+
+// CheckReadiness validates critical runtime dependencies for readiness checks.
+func (s *Service) CheckReadiness(ctx context.Context) error {
+	if s == nil {
+		return errors.New("service is not initialized")
+	}
+	if s.Store == nil {
+		return errors.New("store is not initialized")
+	}
+	if s.Scanner == nil {
+		return errors.New("scanner is not initialized")
+	}
+	if s.ReadinessCheck != nil {
+		if err := s.ReadinessCheck(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // RunScanResult is returned after a scan API trigger.

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -51,6 +51,23 @@ func (f *fakeRepoExecutor) ScanRepository(_ context.Context, target string) (rep
 	return f.result, nil
 }
 
+func TestServiceCheckReadiness(t *testing.T) {
+	svc := NewService(db.NewMemoryStore(), fakeScanner{}, "aws")
+	if err := svc.CheckReadiness(context.Background()); err != nil {
+		t.Fatalf("expected readiness check to pass, got %v", err)
+	}
+}
+
+func TestServiceCheckReadinessDependencyFailure(t *testing.T) {
+	svc := NewService(db.NewMemoryStore(), fakeScanner{}, "aws")
+	svc.ReadinessCheck = func(context.Context) error {
+		return errors.New("dependency unavailable")
+	}
+	if err := svc.CheckReadiness(context.Background()); err == nil {
+		t.Fatal("expected readiness check failure")
+	}
+}
+
 func TestServiceRunScanSuccess(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)

--- a/internal/runtime/service_builder.go
+++ b/internal/runtime/service_builder.go
@@ -119,6 +119,20 @@ func BuildScanService(cfg config.Config) (*api.Service, func() error, error) {
 		// Validation should catch this; keep in-memory as safe fallback.
 		svc.Locker = scheduler.NewInMemoryLocker()
 	}
+	if pgStore != nil {
+		svc.ReadinessCheck = func(ctx context.Context) error {
+			pingCtx := ctx
+			cancel := func() {}
+			if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+				pingCtx, cancel = context.WithTimeout(ctx, 2*time.Second)
+			}
+			defer cancel()
+			if err := pgStore.DB().PingContext(pingCtx); err != nil {
+				return fmt.Errorf("ping postgres: %w", err)
+			}
+			return nil
+		}
+	}
 	svc.RepoScanEnabled = cfg.RepoScanEnabled
 	if cfg.RepoScanHistoryLimit > 0 {
 		svc.RepoScanDefaultHistoryLimit = cfg.RepoScanHistoryLimit


### PR DESCRIPTION
## Summary
This PR introduces a dependency-aware readiness endpoint and wires deployment readiness probes to it.

## Changes
- Added `Service.ReadinessCheck` hook and `CheckReadiness(ctx)`.
- Added `/readyz` route in API router.
- `/readyz` returns `503` when service/dependencies are unavailable, `200` when ready.
- Wired runtime readiness check to Postgres `PingContext` when using Postgres store.
- Updated Helm and raw Kubernetes readiness probes to use `/readyz`.
- Added unit tests for healthy/unhealthy readiness behavior.

## Validation
- `go test ./internal/api ./internal/runtime`
- `helm lint deploy/helm/identrail`
- `go test ./...`

## Outcome
- Pods are only marked Ready when critical runtime dependencies are actually reachable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a dependency-aware readiness endpoint (/readyz) and switch Kubernetes probes to use it so pods only become Ready when Postgres is reachable. Addresses v1 blocker #2.

- **New Features**
  - Added Service.ReadinessCheck hook and CheckReadiness(ctx); used by /readyz.
  - /readyz returns 503 until service and dependencies are ready, 200 when ready.
  - Postgres deployments ping DB with a short timeout during readiness.
  - Updated Helm and raw Kubernetes readinessProbe paths from /healthz to /readyz.
  - Added tests for ready and not-ready cases.

<sup>Written for commit 84ff0d2c0434e6873b89c5bcacb648aad41efbc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

