### PR TITLE
Fix v1 blocker #3: bump Go runtime/toolchain to 1.25.9

### DIFF
--- a/deploy/docker/Dockerfile.backend
+++ b/deploy/docker/Dockerfile.backend
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.25.9-alpine AS builder
 WORKDIR /src
 
 RUN apk add --no-cache ca-certificates tzdata git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Oluwatobi-Mustapha/identrail
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
## Summary
This PR upgrades the project toolchain/build image to Go `1.25.9` to pick up stdlib security fixes.

## Changes
- `go.mod`: `go 1.25.8` -> `go 1.25.9`
- `deploy/docker/Dockerfile.backend`: `golang:1.25-alpine` -> `golang:1.25.9-alpine`

## Validation
- `GOTOOLCHAIN=go1.25.9 go test ./...`
- `GOTOOLCHAIN=go1.25.9 govulncheck ./...`
- govulncheck result: no reachable vulnerabilities.

## Outcome
- Removes the reachable stdlib vulnerability exposure tied to 1.25.8.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Go runtime/toolchain to 1.25.9 to pick up stdlib security fixes and resolve v1 blocker #3. This removes the reachable stdlib vulnerability in 1.25.8.

- **Dependencies**
  - `go.mod`: set `go 1.25.9`
  - `deploy/docker/Dockerfile.backend`: use `golang:1.25.9-alpine` for the builder stage

<sup>Written for commit 3286752c7df334b74d9f9a7543083d2a82501858. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

