### PR TITLE
Fix v1 blocker #5: complete OpenAPI authz/scope contract and parity checks

### DIFF
--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -37,6 +37,9 @@ paths:
                   service:
                     type: string
   /v1/authz/policies/simulate:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
     post:
       tags: [Authorization]
       summary: Simulate authorization policy decision
@@ -82,6 +85,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
   /v1/authz/policies/rollback:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
     post:
       tags: [Authorization]
       summary: Roll back central authorization policy to a target version
@@ -127,6 +133,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
   /v1/findings:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
     get:
       tags: [Findings]
       summary: List findings
@@ -164,6 +173,9 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
   /v1/findings/summary:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
     get:
       tags: [Findings]
       summary: Findings summary
@@ -178,6 +190,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/FindingsSummary"
   /v1/findings/trends:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
     get:
       tags: [Findings]
       summary: Findings trend over recent scans
@@ -209,6 +224,9 @@ paths:
                     items:
                       $ref: "#/components/schemas/TrendPoint"
   /v1/findings/{finding_id}:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
     get:
       tags: [Findings]
       summary: Get finding by id
@@ -231,6 +249,9 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
   /v1/findings/{finding_id}/history:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
     get:
       tags: [Findings]
       summary: List finding triage history
@@ -259,6 +280,9 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
   /v1/findings/{finding_id}/triage:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
     patch:
       tags: [Findings]
       summary: Update finding triage workflow metadata
@@ -296,6 +320,9 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
   /v1/findings/{finding_id}/exports:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
     get:
       tags: [Findings]
       summary: Get standards-aligned exports for a finding
@@ -323,6 +350,9 @@ paths:
                     type: object
                     additionalProperties: true
   /v1/scans:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
     get:
       tags: [Scans]
       summary: List scans
@@ -356,6 +386,9 @@ paths:
         "429":
           description: Scan queue is full
   /v1/scans/{scan_id}/diff:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
     get:
       tags: [Scans]
       summary: Compare a scan with baseline
@@ -379,6 +412,9 @@ paths:
         "400":
           description: Invalid baseline
   /v1/scans/{scan_id}/events:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
     get:
       tags: [Scans]
       summary: List scan lifecycle events
@@ -405,6 +441,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ScanEventPage"
   /v1/identities:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
     get:
       tags: [Explorer]
       summary: List normalized identities
@@ -436,6 +475,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/IdentityPage"
   /v1/relationships:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
     get:
       tags: [Explorer]
       summary: List graph relationships
@@ -465,6 +507,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/RelationshipPage"
   /v1/ownership/signals:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
     get:
       tags: [Explorer]
       summary: List ownership signals
@@ -485,6 +530,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/OwnershipSignalPage"
   /v1/repo-scans:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
     get:
       tags: [RepositoryExposure]
       summary: List repository exposure scans
@@ -532,6 +580,9 @@ paths:
         "503":
           description: Repo scan is disabled
   /v1/repo-scans/{repo_scan_id}:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
     get:
       tags: [RepositoryExposure]
       summary: Get repository scan
@@ -551,6 +602,9 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
   /v1/repo-findings:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
     get:
       tags: [RepositoryExposure]
       summary: List repository scan findings
@@ -589,6 +643,20 @@ components:
       scheme: bearer
       bearerFormat: JWT
   parameters:
+    scopeTenantID:
+      in: header
+      name: X-Identrail-Tenant-ID
+      required: false
+      schema:
+        type: string
+      description: Optional tenant scope override when token claims do not provide tenant context.
+    scopeWorkspaceID:
+      in: header
+      name: X-Identrail-Workspace-ID
+      required: false
+      schema:
+        type: string
+      description: Optional workspace scope override when token claims do not provide workspace context.
     limit:
       in: query
       name: limit

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	v1RoutePattern  = regexp.MustCompile(`v1\.(GET|POST|PATCH)\("([^"]+)"`)
+	v1RoutePattern  = regexp.MustCompile(`v1\.(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\("([^"]+)"`)
 	pathVarPattern  = regexp.MustCompile(`:([A-Za-z0-9_]+)`)
 	scopeHeaderRefs = []string{
 		`#/components/parameters/scopeTenantID`,

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -3,32 +3,28 @@ package api
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 )
 
-func TestOpenAPIV1SpecContainsCoreEndpoints(t *testing.T) {
-	spec := readOpenAPISpec(t)
-	required := []string{
-		"openapi: 3.0.3",
-		"/v1/authz/policies/simulate:",
-		"/v1/authz/policies/rollback:",
-		"/v1/findings:",
-		"/v1/findings/{finding_id}:",
-		"/v1/findings/{finding_id}/history:",
-		"/v1/findings/{finding_id}/triage:",
-		"/v1/scans:",
-		"/v1/scans/{scan_id}/diff:",
-		"/v1/scans/{scan_id}/events:",
-		"/v1/identities:",
-		"/v1/relationships:",
-		"/v1/repo-scans:",
-		"/v1/repo-findings:",
+var (
+	v1RoutePattern  = regexp.MustCompile(`v1\.(GET|POST|PATCH)\("([^"]+)"`)
+	pathVarPattern  = regexp.MustCompile(`:([A-Za-z0-9_]+)`)
+	scopeHeaderRefs = []string{
+		`#/components/parameters/scopeTenantID`,
+		`#/components/parameters/scopeWorkspaceID`,
 	}
-	for _, item := range required {
-		if !strings.Contains(spec, item) {
-			t.Fatalf("openapi spec missing %q", item)
+)
+
+func TestOpenAPIV1SpecCoversRegisteredV1Routes(t *testing.T) {
+	spec := readOpenAPISpec(t)
+	router := readRouterSource(t)
+	for _, path := range registeredV1OpenAPIPaths(t, router) {
+		if !strings.Contains(spec, "  "+path+":") {
+			t.Fatalf("openapi spec missing router path %q", path)
 		}
 	}
 }
@@ -48,6 +44,31 @@ func TestOpenAPIV1SpecDeclaresAuthSecurity(t *testing.T) {
 	for _, item := range required {
 		if !strings.Contains(spec, item) {
 			t.Fatalf("openapi spec missing %q", item)
+		}
+	}
+}
+
+func TestOpenAPIV1SpecDocumentsRequestScopeHeaders(t *testing.T) {
+	spec := readOpenAPISpec(t)
+	required := []string{
+		"scopeTenantID:",
+		"scopeWorkspaceID:",
+		"name: X-Identrail-Tenant-ID",
+		"name: X-Identrail-Workspace-ID",
+	}
+	for _, item := range required {
+		if !strings.Contains(spec, item) {
+			t.Fatalf("openapi spec missing %q", item)
+		}
+	}
+
+	router := readRouterSource(t)
+	for _, path := range registeredV1OpenAPIPaths(t, router) {
+		block := pathBlock(t, spec, path)
+		for _, scopeRef := range scopeHeaderRefs {
+			if !strings.Contains(block, scopeRef) {
+				t.Fatalf("openapi path %q missing scope header ref %q", path, scopeRef)
+			}
 		}
 	}
 }
@@ -76,15 +97,78 @@ func TestOpenAPIV1SpecContainsPagingFilterSortParameters(t *testing.T) {
 
 func readOpenAPISpec(t *testing.T) string {
 	t.Helper()
+	return readRepositoryFile(t, filepath.Join("docs", "openapi-v1.yaml"))
+}
+
+func readRouterSource(t *testing.T) string {
+	t.Helper()
+	return readRepositoryFile(t, filepath.Join("internal", "api", "router.go"))
+}
+
+func readRepositoryFile(t *testing.T, relPath string) string {
+	t.Helper()
 	_, file, _, ok := runtime.Caller(0)
 	if !ok {
 		t.Fatal("failed to resolve caller")
 	}
 	root := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
-	path := filepath.Join(root, "docs", "openapi-v1.yaml")
+	path := filepath.Join(root, relPath)
 	data, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("read openapi spec: %v", err)
+		t.Fatalf("read %s: %v", relPath, err)
 	}
 	return string(data)
+}
+
+func registeredV1OpenAPIPaths(t *testing.T, routerSource string) []string {
+	t.Helper()
+	matches := v1RoutePattern.FindAllStringSubmatch(routerSource, -1)
+	if len(matches) == 0 {
+		t.Fatal("no /v1 routes found in router source")
+	}
+
+	seen := map[string]struct{}{}
+	for _, match := range matches {
+		route := strings.TrimSpace(match[2])
+		if route == "" || !strings.HasPrefix(route, "/") {
+			continue
+		}
+		path := "/v1" + pathVarPattern.ReplaceAllString(route, `{$1}`)
+		seen[path] = struct{}{}
+	}
+
+	paths := make([]string, 0, len(seen))
+	for path := range seen {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func pathBlock(t *testing.T, spec string, path string) string {
+	t.Helper()
+	start := strings.Index(spec, "\n  "+path+":")
+	if start >= 0 {
+		start++
+	} else {
+		prefix := "  " + path + ":"
+		if strings.HasPrefix(spec, prefix) {
+			start = 0
+		} else {
+			t.Fatalf("openapi path block not found for %q", path)
+		}
+	}
+
+	end := len(spec)
+	if nextPath := strings.Index(spec[start+1:], "\n  /"); nextPath >= 0 {
+		end = start + 1 + nextPath
+	}
+	if components := strings.Index(spec[start+1:], "\ncomponents:"); components >= 0 {
+		componentPos := start + 1 + components
+		if componentPos < end {
+			end = componentPos
+		}
+	}
+
+	return spec[start:end]
 }


### PR DESCRIPTION
## Summary
This PR completes OpenAPI v1 coverage for authorization routes and runtime scoping headers, and strengthens parity enforcement tests.

## Changes
- Documented `X-Identrail-Tenant-ID` and `X-Identrail-Workspace-ID` as reusable OpenAPI header parameters.
- Applied both scope headers to every `/v1` path in `docs/openapi-v1.yaml`.
- Kept explicit API key + bearer security declarations in the contract.
- Reworked `internal/api/openapi_contract_test.go` to:
  - derive `/v1` routes directly from `internal/api/router.go`
  - assert every registered `/v1` route is present in OpenAPI
  - assert every `/v1` path block includes both scope header refs

## Validation
- `go test ./internal/api`
- `go test ./...`

## Outcome
- OpenAPI contract now reflects live route surface and scoping behavior more reliably for v1 stability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the OpenAPI v1 authz and scoping contract and enforces parity with live routes for v1 stability. Addresses v1 blocker #5.

- **Refactors**
  - Added reusable OpenAPI parameters `scopeTenantID` and `scopeWorkspaceID` for headers `X-Identrail-Tenant-ID` and `X-Identrail-Workspace-ID`, and applied them to every `/v1` path in `docs/openapi-v1.yaml`.
  - Kept API key + bearer security declarations.
  - Reworked `internal/api/openapi_contract_test.go` to derive `/v1` routes from `internal/api/router.go`, assert every route is in the spec, verify each path includes both scope header refs, and confirm the header parameter components (and names) are defined.

<sup>Written for commit 224ac1af4d497058e3bea7e5507cb965f4785211. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

