### PR TITLE
Fix v1 blocker #4: align release qualification script with compose env_file

### DIFF
--- a/scripts/v1_release_qualify.sh
+++ b/scripts/v1_release_qualify.sh
@@ -26,7 +26,7 @@ else
 fi
 
 echo "[4/8] Docker compose config validation"
-[[ -f deploy/docker/.env ]] || cp deploy/docker/.env.example deploy/docker/.env
+cp deploy/docker/.env.example deploy/docker/.env
 docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env config >/tmp/identrail-compose.yml
 
 echo "[5/8] Terraform validation"

--- a/scripts/v1_release_qualify.sh
+++ b/scripts/v1_release_qualify.sh
@@ -26,7 +26,8 @@ else
 fi
 
 echo "[4/8] Docker compose config validation"
-docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env.example config >/tmp/identrail-compose.yml
+cp deploy/docker/.env.example deploy/docker/.env
+docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env config >/tmp/identrail-compose.yml
 
 echo "[5/8] Terraform validation"
 if command -v terraform >/dev/null 2>&1; then

--- a/scripts/v1_release_qualify.sh
+++ b/scripts/v1_release_qualify.sh
@@ -26,8 +26,25 @@ else
 fi
 
 echo "[4/8] Docker compose config validation"
-cp deploy/docker/.env.example deploy/docker/.env
-docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env config >/tmp/identrail-compose.yml
+compose_env_path="deploy/docker/.env"
+compose_env_backup=""
+cleanup_compose_env() {
+  if [[ -n "${compose_env_backup}" && -f "${compose_env_backup}" ]]; then
+    mv "${compose_env_backup}" "${compose_env_path}"
+    compose_env_backup=""
+    return
+  fi
+  rm -f "${compose_env_path}"
+}
+if [[ -f "${compose_env_path}" ]]; then
+  compose_env_backup="$(mktemp)"
+  cp "${compose_env_path}" "${compose_env_backup}"
+fi
+trap cleanup_compose_env EXIT
+cp deploy/docker/.env.example "${compose_env_path}"
+docker compose -f deploy/docker/docker-compose.yml --env-file "${compose_env_path}" config >/tmp/identrail-compose.yml
+cleanup_compose_env
+trap - EXIT
 
 echo "[5/8] Terraform validation"
 if command -v terraform >/dev/null 2>&1; then

--- a/scripts/v1_release_qualify.sh
+++ b/scripts/v1_release_qualify.sh
@@ -26,7 +26,7 @@ else
 fi
 
 echo "[4/8] Docker compose config validation"
-cp deploy/docker/.env.example deploy/docker/.env
+[[ -f deploy/docker/.env ]] || cp deploy/docker/.env.example deploy/docker/.env
 docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env config >/tmp/identrail-compose.yml
 
 echo "[5/8] Terraform validation"


### PR DESCRIPTION
## Summary
This PR fixes `scripts/v1_release_qualify.sh` so compose validation works consistently with repository CI behavior.

## Changes
- Before `docker compose config`, copy `deploy/docker/.env.example` to `deploy/docker/.env`.
- Validate compose using the generated `.env` file.

## Validation
- `bash -n scripts/v1_release_qualify.sh`
- `docker compose --env-file deploy/docker/.env -f deploy/docker/docker-compose.yml config`

## Outcome
- Release qualification no longer fails on missing `.env` when run in clean environments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns compose validation in `scripts/v1_release_qualify.sh` with CI and makes it deterministic without clobbering local env by temporarily using `deploy/docker/.env` derived from `.env.example`. Fixes v1 blocker #4 so release qualification works in clean and existing dev environments.

- **Bug Fixes**
  - Temporarily copy `deploy/docker/.env.example` to `deploy/docker/.env` and validate with `--env-file deploy/docker/.env`.
  - Backup existing `deploy/docker/.env` and restore on exit via `trap`; remove the temp file if none existed.

<sup>Written for commit 3ccac87ac77422d0fcc202650de91a5bc935397b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

