### PR TITLE
Fix launch gap: align API latency smoke enforcement with documented SLO

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -48,7 +48,7 @@ Authorization policy lifecycle metrics:
 ## V1 SLOs
 
 - Scan success rate: >= 99% over rolling 24h (excluding known provider outages).
-- API p95 latency for list endpoints: <= 300ms under normal load.
+- API p95 latency for list endpoints: <= 300ms under normal load (enforced by `internal/api/slo_smoke_test.go`).
 - Worker scheduled run reliability: >= 99% successful schedule executions per day.
 - Backlog recovery: queue drains to steady state within 30 minutes after outage.
 

--- a/internal/api/slo_smoke_test.go
+++ b/internal/api/slo_smoke_test.go
@@ -12,6 +12,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const findingsListP95SLOThreshold = 300 * time.Millisecond
+
 func TestFindingsListLatencySLOSmoke(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	metrics := telemetry.NewMetrics()
@@ -46,7 +48,7 @@ func TestFindingsListLatencySLOSmoke(t *testing.T) {
 
 	sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
 	p95 := durations[(sampleSize*95/100)-1]
-	if p95 > 500*time.Millisecond {
-		t.Fatalf("p95 findings list latency exceeded SLO smoke threshold: %v", p95)
+	if p95 > findingsListP95SLOThreshold {
+		t.Fatalf("p95 findings list latency exceeded SLO threshold (%v): %v", findingsListP95SLOThreshold, p95)
 	}
 }


### PR DESCRIPTION
## Summary
This PR aligns SLO enforcement with documented API latency targets.

## Changes
- Updated `internal/api/slo_smoke_test.go` p95 threshold from `500ms` to documented `300ms`.
- Introduced explicit threshold constant in the test for readability and drift prevention.
- Updated observability doc wording to reference the enforcing smoke test.

## Validation
- `go test ./internal/api`
- `go test ./...`

## Outcome
The smoke gate now enforces the same p95 list-latency target documented in `docs/observability.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns API latency SLO enforcement with the documented p95 target of 300ms. The smoke test now gates releases against the same threshold.

- **Bug Fixes**
  - Set findings list p95 threshold to 300ms in `internal/api/slo_smoke_test.go` via a named constant.
  - Updated `docs/observability.md` to reference the enforcing smoke test.

<sup>Written for commit b1ba744d41cf434317597138fb17035ce7db7ecf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

