### PR TITLE
Add advisory Good Egg trust scoring workflow for PRs

### DIFF
--- a/.github/workflows/good-egg-trust.yml
+++ b/.github/workflows/good-egg-trust.yml
@@ -28,8 +28,6 @@ jobs:
           comment: 'true'
           check-run: 'true'
           fail-on-low: 'false'
-          scoring-model: 'v3'
-          skip-known-contributors: 'true'
 
       - name: Sync trust labels
         uses: actions/github-script@v8
@@ -48,7 +46,6 @@ jobs:
               'trust/low': { color: 'd93f0b', description: 'Good Egg trust level: LOW' },
               'trust/unknown': { color: '6e7781', description: 'Good Egg trust level: UNKNOWN' },
               'trust/bot': { color: '5319e7', description: 'Good Egg trust level: BOT' },
-              'trust/existing-contributor': { color: '1d76db', description: 'Good Egg trust level: EXISTING_CONTRIBUTOR' },
             };
 
             const trustToLabel = {
@@ -57,7 +54,6 @@ jobs:
               LOW: 'trust/low',
               UNKNOWN: 'trust/unknown',
               BOT: 'trust/bot',
-              EXISTING_CONTRIBUTOR: 'trust/existing-contributor',
             };
 
             const targetLabel = trustToLabel[trustLevel] || 'trust/unknown';

--- a/.github/workflows/good-egg-trust.yml
+++ b/.github/workflows/good-egg-trust.yml
@@ -1,0 +1,103 @@
+name: Good Egg Trust
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  issues: write
+
+concurrency:
+  group: good-egg-trust-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  score-author-trust:
+    name: Score PR author trust
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Score PR author (advisory)
+        id: egg
+        uses: 2ndSetAI/good-egg@026775d031d94339d1fc0f6428abe04677d3e2d9 # v0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment: 'true'
+          check-run: 'true'
+          fail-on-low: 'false'
+          scoring-model: 'v3'
+          skip-known-contributors: 'true'
+
+      - name: Sync trust labels
+        uses: actions/github-script@v8
+        env:
+          TRUST_LEVEL: ${{ steps.egg.outputs.trust-level }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = context.payload.pull_request.number;
+            const trustLevel = (process.env.TRUST_LEVEL || 'UNKNOWN').toUpperCase();
+
+            const labelMeta = {
+              'trust/high': { color: '0e8a16', description: 'Good Egg trust level: HIGH' },
+              'trust/medium': { color: 'fbca04', description: 'Good Egg trust level: MEDIUM' },
+              'trust/low': { color: 'd93f0b', description: 'Good Egg trust level: LOW' },
+              'trust/unknown': { color: '6e7781', description: 'Good Egg trust level: UNKNOWN' },
+              'trust/bot': { color: '5319e7', description: 'Good Egg trust level: BOT' },
+              'trust/existing-contributor': { color: '1d76db', description: 'Good Egg trust level: EXISTING_CONTRIBUTOR' },
+            };
+
+            const trustToLabel = {
+              HIGH: 'trust/high',
+              MEDIUM: 'trust/medium',
+              LOW: 'trust/low',
+              UNKNOWN: 'trust/unknown',
+              BOT: 'trust/bot',
+              EXISTING_CONTRIBUTOR: 'trust/existing-contributor',
+            };
+
+            const targetLabel = trustToLabel[trustLevel] || 'trust/unknown';
+            const managedLabels = Object.keys(labelMeta);
+
+            for (const [name, meta] of Object.entries(labelMeta)) {
+              try {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name,
+                  color: meta.color,
+                  description: meta.description,
+                });
+              } catch (error) {
+                if (error.status !== 422) {
+                  throw error;
+                }
+              }
+            }
+
+            const currentLabels = (context.payload.pull_request.labels || []).map((label) => label.name);
+            const staleLabels = currentLabels.filter((label) => managedLabels.includes(label) && label !== targetLabel);
+
+            for (const label of staleLabels) {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: prNumber,
+                name: label,
+              });
+            }
+
+            if (!currentLabels.includes(targetLabel)) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: prNumber,
+                labels: [targetLabel],
+              });
+            }
+
+            core.info(`Applied Good Egg trust label: ${targetLabel}`);

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 ## Security and governance track
 
 - Threat model: `threat_model.md`
+- Contributor trust scoring (Good Egg): `contributor-trust-scoring.md`
 - Architecture decisions: `ADR.md`
 - V1 scope baseline: `v1_scope_and_baseline.md`
 - Security policy: `../SECURITY.md`

--- a/docs/contributor-trust-scoring.md
+++ b/docs/contributor-trust-scoring.md
@@ -7,7 +7,7 @@ Workflow:
 
 ## What it does
 
-- Scores PR authors with the Good Egg `v3` model.
+- Scores every PR author on each workflow run.
 - Posts a PR comment and check run with the trust result.
 - Applies a single trust label on the PR:
   - `trust/high`
@@ -15,7 +15,6 @@ Workflow:
   - `trust/low`
   - `trust/unknown`
   - `trust/bot`
-  - `trust/existing-contributor`
 
 This signal is advisory by default (`fail-on-low=false`). It is meant to support triage, not replace code review.
 

--- a/docs/contributor-trust-scoring.md
+++ b/docs/contributor-trust-scoring.md
@@ -1,0 +1,30 @@
+# Contributor Trust Scoring (Good Egg)
+
+Identrail runs Good Egg on pull requests to provide an advisory trust signal for the PR author.
+
+Workflow:
+- `.github/workflows/good-egg-trust.yml`
+
+## What it does
+
+- Scores PR authors with the Good Egg `v3` model.
+- Posts a PR comment and check run with the trust result.
+- Applies a single trust label on the PR:
+  - `trust/high`
+  - `trust/medium`
+  - `trust/low`
+  - `trust/unknown`
+  - `trust/bot`
+  - `trust/existing-contributor`
+
+This signal is advisory by default (`fail-on-low=false`). It is meant to support triage, not replace code review.
+
+## Trigger
+
+- `pull_request_target` on: `opened`, `reopened`, `synchronize`, `ready_for_review`.
+
+## Operational guidance
+
+- Treat `trust/low` and `trust/unknown` as "review deeper" indicators.
+- Do not auto-merge based on trust labels alone.
+- Keep branch protection tied to core CI and security checks.


### PR DESCRIPTION
## Summary
- add a new advisory workflow for contributor trust scoring using Good Egg
- score pull-request authors on `pull_request_target` events and post Good Egg comment/check outputs
- map Good Egg trust levels to managed PR labels (`trust/high`, `trust/medium`, `trust/low`, `trust/unknown`, `trust/bot`, `trust/existing-contributor`)
- document the behavior in `docs/contributor-trust-scoring.md` and link it from `docs/README.md`

## Why
This adds a lightweight trust signal for PR triage without replacing normal code review and CI gates.

## Scope
- `.github/workflows/good-egg-trust.yml`
- `docs/contributor-trust-scoring.md`
- `docs/README.md`

## Validation
- parsed workflow YAML successfully (`yaml-ok`)
- reviewed generated trust labels and workflow permissions

## Checklist
- [x] advisory mode enabled (`fail-on-low=false`)
- [x] action reference pinned to a specific commit SHA
- [x] docs added for operations/maintainer guidance

## AI Assistance Disclosure
- drafted and implemented via AI coding assistant under direct maintainer instructions.

## Related Issues
- none

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an advisory Good Egg trust scoring workflow for PR authors to aid PR triage. It posts a comment and check run, and applies a single `trust/*` label without blocking CI or merge.

- **New Features**
  - New workflow at `.github/workflows/good-egg-trust.yml` runs on `pull_request_target` (opened, reopened, synchronize, ready_for_review).
  - Always scores authors via `2ndSetAI/good-egg` in advisory mode (`fail-on-low=false`), posting a comment and check run.
  - Syncs exactly one trust label per PR: `trust/high`, `trust/medium`, `trust/low`, `trust/unknown`, or `trust/bot` (creates if missing, removes stale) using `actions/github-script`, with per-PR concurrency.
  - Adds `docs/contributor-trust-scoring.md` and links it from `docs/README.md`.

<sup>Written for commit 41c882eac6b3c3aa429d807d20fe8a910ffdfb6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

