### PR TITLE
Harden singleton migration flow for Kubernetes/Helm

### DIFF
--- a/deploy/helm/identrail/templates/migration-job.yaml
+++ b/deploy/helm/identrail/templates/migration-job.yaml
@@ -38,6 +38,8 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           envFrom:
+            - configMapRef:
+                name: {{ include "identrail.fullname" . }}-config
             - secretRef:
                 name: {{ include "identrail.secretName" . }}
           env:

--- a/deploy/helm/identrail/values.yaml
+++ b/deploy/helm/identrail/values.yaml
@@ -85,6 +85,7 @@ config:
   IDENTRAIL_HTTP_ADDR: ":8080"
   IDENTRAIL_LOCK_BACKEND: auto
   IDENTRAIL_LOCK_NAMESPACE: identrail
+  # Keep shared pods non-migrating; use the dedicated migrations job instead.
   IDENTRAIL_RUN_MIGRATIONS: "false"
   IDENTRAIL_RUN_MIGRATIONS_ONLY: "false"
   IDENTRAIL_MIGRATIONS_DIR: /app/migrations

--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -17,6 +17,7 @@ data:
   IDENTRAIL_HTTP_ADDR: ":8080"
   IDENTRAIL_LOCK_BACKEND: "auto"
   IDENTRAIL_LOCK_NAMESPACE: "identrail"
+  # Keep shared pods non-migrating; use deploy/kubernetes/migration-job.yaml.
   IDENTRAIL_RUN_MIGRATIONS: "false"
   IDENTRAIL_RUN_MIGRATIONS_ONLY: "false"
   IDENTRAIL_MIGRATIONS_DIR: "/app/migrations"

--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -20,6 +20,7 @@ Portable deployment profiles:
 
 - Confirm `IDENTRAIL_DATABASE_URL` points to target environment.
 - Confirm migrations path is correct (`IDENTRAIL_MIGRATIONS_DIR`).
+- Confirm shared API/worker config keeps `IDENTRAIL_RUN_MIGRATIONS=false`.
 - Confirm lock backend for deployment shape:
   - single instance: `IDENTRAIL_LOCK_BACKEND=inmemory` or `auto`
   - multi-instance: `IDENTRAIL_LOCK_BACKEND=postgres`
@@ -53,10 +54,12 @@ Portable deployment profiles:
 ## 2) Deploy Sequence
 
 1. Ensure CI is green on `main` (`Go Quality`, `Go Tests`, `Go Integration (Postgres)`, `Web Build`).
-2. Deploy API service with `IDENTRAIL_RUN_MIGRATIONS=true`.
-3. Verify health endpoint: `GET /healthz`.
-4. Verify migrations were applied.
-5. Deploy worker with same DB + provider config.
+2. Run migrations once using the dedicated migration job:
+   - Kubernetes manifests: apply `deploy/kubernetes/migration-job.yaml` and wait for job completion.
+   - Helm: pre-install/pre-upgrade hook job runs automatically when `migrations.enabled=true`.
+3. Deploy API service with `IDENTRAIL_RUN_MIGRATIONS=false`.
+4. Verify health endpoint: `GET /healthz`.
+5. Deploy worker with same DB + provider config (`IDENTRAIL_RUN_MIGRATIONS=false`).
 6. Trigger one scan (`POST /v1/scans`) with write-authorized key.
 7. Verify:
   - scan is accepted as queued (`202`) then completed by worker

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -11,16 +11,20 @@ Simple migration strategy for production safety.
 
 ## Runtime Behavior
 
-- API startup can auto-apply up migrations when:
+- Shared API/worker deployments must run with `IDENTRAIL_RUN_MIGRATIONS=false`.
+- Run schema migrations in a single one-shot migrator process:
+  - Kubernetes manifests: `deploy/kubernetes/migration-job.yaml`
+  - Helm chart: pre-install/pre-upgrade migration Job hook
+- The migrator job sets:
   - `IDENTRAIL_RUN_MIGRATIONS=true`
-  - `IDENTRAIL_MIGRATIONS_DIR` points to the migration folder.
+  - `IDENTRAIL_RUN_MIGRATIONS_ONLY=true`
 - Down migrations are intentionally manual.
 
 ## Roll Forward (Preferred)
 
-1. Deploy new app version with `IDENTRAIL_RUN_MIGRATIONS=true`.
-2. Verify `/healthz` and one scan smoke run.
-3. Keep worker disabled until API checks pass, then enable worker.
+1. Deploy and wait for the dedicated migrator job to complete successfully.
+2. Deploy API and worker pods with `IDENTRAIL_RUN_MIGRATIONS=false`.
+3. Verify `/healthz` and one scan smoke run.
 
 ## Rollback Procedure
 


### PR DESCRIPTION
## Summary
- ensure the Helm migration Job inherits chart config via ConfigMap + Secret while explicitly forcing migration-only flags
- keep deployment defaults explicit that shared API/worker pods must stay non-migrating
- align migration docs/runbook with the dedicated one-shot migration job flow (instead of startup migrations on API pods)

## Why
Running startup migrations from multiple pods is unsafe with policy DDL (e.g. DROP/CREATE policy) and can cause boot failures under parallel rollout. This keeps migrations isolated to a single job path and avoids accidental reintroduction via deployment guidance.

## Validation
- helm lint deploy/helm/identrail
- helm template identrail deploy/helm/identrail | rg "IDENTRAIL_RUN_MIGRATIONS|component: migrations"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolate schema migrations to a single Kubernetes/Helm job to prevent multi-pod startup migrations and DDL conflicts. The migration job now inherits chart config, while API/worker pods stay non-migrating by default; docs updated to reflect the one-shot job flow.

- **Bug Fixes**
  - Helm migration Job now pulls env from chart ConfigMap + Secret via `envFrom`.
  - Keep API/worker defaults non-migrating; migrations run only via the dedicated job.
  - Updated runbook and migrations docs to use the one-shot migrator (Helm hook or Kubernetes Job).

- **Migration**
  - Helm: enable the pre-install/pre-upgrade migration hook (e.g., `migrations.enabled=true`).
  - Kubernetes manifests: apply `deploy/kubernetes/migration-job.yaml` and wait for completion.
  - Ensure shared API/worker pods keep `IDENTRAIL_RUN_MIGRATIONS=false`.

<sup>Written for commit 316cb4c62b3b52313dd0554192f4d41c11d15d57. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

