### PR TITLE
Add OpenSSF Scorecard security scoring workflow

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -1,0 +1,40 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '23 3 * * 1'
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  scorecard:
+    name: Security Scorecard
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -35,6 +35,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarifc8a8a642e79153f5d047b10ec1cba1d1cc65699@v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -23,18 +23,18 @@ jobs:
       actions: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarifc8a8a642e79153f5d047b10ec1cba1d1cc65699@v3
+        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- add a scheduled and PR-triggered OpenSSF Scorecard workflow
- publish scorecard SARIF results to GitHub code scanning
- keep permissions scoped for scorecard execution

## Why
This adds a standard OSS security posture score and surfaces policy gaps continuously.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an OpenSSF Scorecard workflow to assess repo security and publish SARIF to GitHub code scanning. Runs weekly, on `main` pushes, PRs, branch protection changes, and manual dispatch, with least-privilege permissions, disabled credential persistence, and all actions pinned to immutable SHAs.

<sup>Written for commit da34017c5ddbaf23a5ea74ee9213ecd78867d10e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

