### PR TITLE
Add OpenSSF Allstar policy configuration

### DIFF
--- a/.allstar/README.md
+++ b/.allstar/README.md
@@ -1,0 +1,13 @@
+# OpenSSF Allstar
+
+This directory stores repository-level policy configuration for the OpenSSF Allstar GitHub App.
+
+## Policies enabled
+
+- `branch_protection`
+- `binary_artifacts`
+- `codeowners`
+- `outside`
+- `security`
+
+Each policy is set to `action: issue` so violations are surfaced to maintainers.

--- a/.allstar/allstar.yaml
+++ b/.allstar/allstar.yaml
@@ -1,0 +1,4 @@
+optConfig:
+  optOutStrategy: true
+issueLabel: allstar
+issueFooter: Managed by OpenSSF Allstar policy enforcement.

--- a/.allstar/binary_artifacts.yaml
+++ b/.allstar/binary_artifacts.yaml
@@ -1,0 +1,1 @@
+action: issue

--- a/.allstar/branch_protection.yaml
+++ b/.allstar/branch_protection.yaml
@@ -1,0 +1,1 @@
+action: issue

--- a/.allstar/codeowners.yaml
+++ b/.allstar/codeowners.yaml
@@ -1,0 +1,1 @@
+action: issue

--- a/.allstar/outside.yaml
+++ b/.allstar/outside.yaml
@@ -1,0 +1,1 @@
+action: issue

--- a/.allstar/security.yaml
+++ b/.allstar/security.yaml
@@ -1,0 +1,1 @@
+action: issue


### PR DESCRIPTION
## Summary
- add .allstar repository policy configuration for OpenSSF Allstar
- enable branch protection, binary artifacts, codeowners, outside collaborator, and security policies
- set policy actions to create issues for violations

## Why
Allstar gives policy enforcement-as-code and continuous governance visibility.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add OpenSSF Allstar repo policy config to enforce baseline security and governance. Uses an opt-out strategy and creates labeled issues for any violations.

- **New Features**
  - Enable policies: `branch_protection`, `binary_artifacts`, `codeowners`, `outside`, `security`.
  - Set all policies to `action: issue` with `issueLabel: allstar` and a standard footer.
  - Add `.allstar/README.md` documenting enabled policies.

<sup>Written for commit 7c6450b9fe3c615d9be0c7f4b4b1c3fb4a329da2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

