### PR TITLE
Add PR dependency review security gate

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,10 @@
+vulnerability-check: true
+comment-summary-in-pr: always
+fail-on-severity: high
+allow-licenses:
+  - MIT
+  - Apache-2.0
+  - BSD-2-Clause
+  - BSD-3-Clause
+  - ISC
+  - MPL-2.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Dependency Review
-        uses: actions/dependency-review-actioncfc080254a8a887f58cffee85186f0e49e48@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
         with:
           config-file: .github/dependency-review-config.yml

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,6 +14,6 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-actioncfc080254a8a887f58cffee85186f0e49e48@v4
         with:
           config-file: .github/dependency-review-config.yml

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,19 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          config-file: .github/dependency-review-config.yml


### PR DESCRIPTION
## Summary
- add dependency review workflow for pull requests
- enforce vulnerability checks with high-severity fail threshold
- add explicit license allow-list config

## Why
This blocks risky dependency changes before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dependency review gate on pull requests that fails when new dependencies add high‑severity vulnerabilities, enforces a strict license allow‑list, and posts a summary comment. Pins `actions/dependency-review-action` and `actions/checkout` to SHAs for reproducible, secure CI.

- **New Features**
  - Runs dependency review on PRs using `.github/dependency-review-config.yml` with pinned `actions/dependency-review-action` and `actions/checkout`.
  - Fails the check for high‑severity vulnerabilities; always posts a review summary.
  - Enforces allowed licenses only: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0.

<sup>Written for commit 4a6c2fa6273e5877e4c4024500da2b733956954e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

