### PR TITLE
Add OSV-Scanner vulnerability workflow

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   osv-pr:
     if: github.event_name == 'pull_request'
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.1
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@375a0e8ebdc98e99b02ac4338a724f5750f21213
     with:
       scan-args: |-
         --recursive
@@ -21,7 +21,7 @@ jobs:
 
   osv-default:
     if: github.event_name != 'pull_request'
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.1
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@375a0e8ebdc98e99b02ac4338a724f5750f21213
     with:
       scan-args: |-
         --recursive

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,28 @@
+name: OSV Scanner
+
+on:
+  pull_request:
+  schedule:
+    - cron: '31 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  osv-pr:
+    if: github.event_name == 'pull_request'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.1
+    with:
+      scan-args: |-
+        --recursive
+        .
+
+  osv-default:
+    if: github.event_name != 'pull_request'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.1
+    with:
+      scan-args: |-
+        --recursive
+        .


### PR DESCRIPTION
## Summary
- add OSV-Scanner workflow for pull requests and scheduled scans
- scan repository dependencies recursively
- keep security-events permission available for scanner outputs

## Why
This adds fast vulnerability detection for ecosystem dependencies.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add OSV-Scanner CI workflow to catch vulnerable dependencies early. It scans the repo recursively on PRs, a daily schedule, and manual runs, uploads results to the Security tab (security-events: write), and pins `google/osv-scanner-action` reusable workflows to an immutable SHA for supply-chain safety.

<sup>Written for commit 4411eb28d7726e1ed2334a5e8a23fe700610a04a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

