### PR TITLE
Add gitleaks secret scanning to CI

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,25 @@
+name: Gitleaks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - dev
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add gitleaks workflow on pull requests and pushes to dev
- fetch full git history for accurate secret detection
- use GitHub token for scanner integration

## Why
This prevents accidental credential leakage from being merged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CI secret scanning with Gitleaks for PRs and pushes to `dev`, with pinned actions. Scans full git history to catch leaked credentials early.

- **New Features**
  - Runs on PRs, pushes to `dev`, and `workflow_dispatch`; checks out full history with pinned `actions/checkout` and read-only `contents` permission.
  - Executes `gitleaks/gitleaks-action` using `GITHUB_TOKEN`, pinned to an immutable SHA.

<sup>Written for commit 255cf7ea7977e0dcfc684bc05fbe64944bad1160. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

