### PR TITLE
Add actionlint workflow for CI workflow hygiene

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Run actionlint
-        uses: rhysd/actionlint@v1
+        uses: docker://rhysd/actionlint:1.7.12

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -23,3 +23,5 @@ jobs:
 
       - name: Run actionlint
         uses: docker://rhysd/actionlint:1.7.12
+        with:
+          args: -shellcheck=

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,25 @@
+name: Actionlint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches:
+      - dev
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1


### PR DESCRIPTION
## Summary
- add actionlint workflow for workflow YAML changes
- run checks on pull requests and dev branch updates
- keep CI workflow linting isolated and fast

## Why
This catches broken or risky GitHub Actions syntax before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Actionlint CI workflow to lint GitHub Actions YAML in `.github/workflows/**` on PRs, pushes to `dev`, and manual runs. Pins `actions/checkout` by SHA, runs `rhysd/actionlint` `1.7.12` via Docker with read-only permissions, and disables ShellCheck (`args: -shellcheck=`) to reduce baseline noise.

<sup>Written for commit f0e6aef98f3742810245a9e166dfc25c098a05eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

