### PR TITLE
Add commit sign-off (DCO) enforcement workflow

### DIFF
--- a/.github/workflows/dco-signoff.yml
+++ b/.github/workflows/dco-signoff.yml
@@ -1,0 +1,36 @@
+name: DCO Sign-off
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Validate Signed-off-by on commits
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          missing=0
+          while IFS= read -r commit; do
+            if ! git show -s --format=%B "$commit" | grep -Eiq '^Signed-off-by:\s+.+<.+>$'; then
+              echo "Missing DCO sign-off in commit: $commit"
+              missing=1
+            fi
+          done < <(git rev-list "${base_sha}..HEAD")
+
+          if [[ "$missing" -ne 0 ]]; then
+            echo "One or more commits are missing Signed-off-by trailers."
+            echo "Recreate commits with: git commit --amend -s (or git rebase -i --signoff)."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- add pull-request workflow that checks every commit for Signed-off-by trailers
- fail PRs when sign-off is missing
- provide remediation guidance in CI output

## Why
This enforces DCO-style commit provenance for all contributions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a GitHub Actions workflow that enforces DCO by checking every PR commit for a "Signed-off-by" trailer. PRs with missing sign-offs fail and show how to fix with git commit --amend -s or git rebase -i --signoff.

<sup>Written for commit 1d431c95386edcbd168b3c2d268cfcd29e2aa658. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

