### PR TITLE
Add All Contributors bot configuration

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,13 @@
+{
+  "projectName": "identrail",
+  "projectOwner": "Oluwatobi-Mustapha",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "contributors": [],
+  "contributorConvention": "all-contributors"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,3 +170,12 @@ A dedicated `CODE_OF_CONDUCT.md` may be added separately. Until then, maintain p
 ## License
 
 By contributing, you agree that your contributions are licensed under the repository license.
+
+## Contributor Recognition
+
+This project is configured for the All Contributors specification.
+
+- Config file: `.all-contributorsrc`
+- Bot/App: https://allcontributors.org/docs/en/bot/overview
+
+When the All Contributors app is installed, maintainers can trigger attribution comments in pull requests to recognize all contribution types (code, docs, design, security, mentoring, etc.).


### PR DESCRIPTION
## Summary
- add .all-contributorsrc scaffold for identrail
- document All Contributors app usage in CONTRIBUTING guide
- prepare repository for contribution-type recognition beyond code commits

## Why
This improves community visibility and acknowledges all contributor roles.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add All Contributors bot configuration and document how to use it. Sets up `.all-contributorsrc` to update `README.md` and recognize all contribution types once the app is installed.

<sup>Written for commit 62f1cdaa9f26fcf8b1d7c97f63ea916fd451457e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

