### PR TITLE
Add StepSecurity harden-runner audit workflow

### DIFF
--- a/.github/workflows/harden-runner-audit.yml
+++ b/.github/workflows/harden-runner-audit.yml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176
         with:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/harden-runner-audit.yml
+++ b/.github/workflows/harden-runner-audit.yml
@@ -1,0 +1,30 @@
+name: Harden Runner Audit
+
+on:
+  pull_request:
+  schedule:
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  hardened-go-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run smoke tests
+        run: go test ./internal/api ./internal/config


### PR DESCRIPTION
## Summary
- add dedicated workflow with step-security/harden-runner in audit mode
- run baseline Go smoke tests under hardened runner instrumentation
- schedule daily audit for runner behavior visibility

## Why
This increases CI supply-chain visibility for network/process activity on runners.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow to audit runner egress using `step-security/harden-runner` while running Go smoke tests. Pins all workflow actions to immutable SHAs and adds daily scheduled audits and PR coverage to improve CI supply-chain visibility.

- **New Features**
  - Adds `.github/workflows/harden-runner-audit.yml` with `egress-policy: audit`.
  - Runs `go test ./internal/api ./internal/config` under hardened instrumentation.
  - Triggers on pull requests, manual `workflow_dispatch`, and daily at 04:17 UTC.
  - Pins `step-security/harden-runner`, `actions/checkout`, and `actions/setup-go` to immutable SHAs.

<sup>Written for commit 7b80acc71b8f62b8635f6afddddd6022d793ebe5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

