### PR TITLE
Add GUAC supply-chain graph integration scaffold

### DIFF
--- a/docs/supply-chain-guac.md
+++ b/docs/supply-chain-guac.md
@@ -1,0 +1,33 @@
+# GUAC Integration Scaffold
+
+Identrail already generates signed supply-chain artifacts (SBOM + provenance) in CI. This guide adds a practical path to ingest those artifacts into GUAC for graph-based analysis.
+
+## Prerequisites
+
+- `guacgql` running (in-memory or postgres-backed deployment)
+- `guacone` installed and available on `PATH`
+- `dist/` artifact directory from the `supply-chain-trust` workflow
+
+## Ingest SBOM Artifacts
+
+Use the helper script:
+
+```bash
+scripts/guac/collect_dist_sboms.sh dist
+```
+
+This runs `guacone collect ... files <dir>` to ingest CycloneDX SBOM files into GUAC.
+
+## Enrich Vulnerability Data (Optional)
+
+After ingestion, run:
+
+```bash
+guacone certifier osv
+```
+
+This augments ingested packages with OSV vulnerability relationships.
+
+## Suggested Next Step
+
+Attach this ingestion step to your artifact promotion pipeline so release candidates continuously populate the security graph.

--- a/scripts/guac/collect_dist_sboms.sh
+++ b/scripts/guac/collect_dist_sboms.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR="${1:-dist}"
+
+if ! command -v guacone >/dev/null 2>&1; then
+  echo "ERROR: guacone is required on PATH" >&2
+  exit 1
+fi
+
+if [[ ! -d "${ARTIFACT_DIR}" ]]; then
+  echo "ERROR: artifact directory not found: ${ARTIFACT_DIR}" >&2
+  exit 1
+fi
+
+if ! find "${ARTIFACT_DIR}" -maxdepth 1 -type f -name '*.sbom.cdx.json' | grep -q .; then
+  echo "ERROR: no CycloneDX SBOM artifacts (*.sbom.cdx.json) found in ${ARTIFACT_DIR}" >&2
+  exit 1
+fi
+
+echo "Ingesting SBOM artifacts from ${ARTIFACT_DIR} into GUAC"
+guacone collect --add-vuln-on-ingest --add-license-on-ingest files "${ARTIFACT_DIR}"


### PR DESCRIPTION
## Summary
- add GUAC integration guide tied to existing Identrail SBOM/provenance artifacts
- add helper script to ingest CycloneDX artifacts from dist/ via guacone
- document optional OSV certifier enrichment step

## Why
This enables graph-based dependency and vulnerability relationship analysis from already-produced build artifacts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GUAC integration scaffold with docs and a helper script to ingest CI-generated CycloneDX SBOMs into GUAC, enabling graph-based dependency and vulnerability analysis.

- **New Features**
  - Doc: `docs/supply-chain-guac.md` with steps to run `guacgql`, use `guacone`, and optionally `guacone certifier osv`.
  - Script: `scripts/guac/collect_dist_sboms.sh` to ingest `dist/` `*.sbom.cdx.json` via `guacone collect` with `--add-vuln-on-ingest` and `--add-license-on-ingest`.
  - Safety checks: verifies `guacone` on PATH, artifact directory exists, and SBOM files are present.

<sup>Written for commit 2dc6af20120db07e17f4dc2e4233460a5abd8535. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

