### PR TITLE
making security md more detailed

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,11 +14,12 @@ Identrail takes security reports seriously. If you believe you have found a vuln
 
 Do not open public GitHub issues for suspected vulnerabilities.
 
-Use GitHub private vulnerability reporting:
+Use GitHub private vulnerability reporting or the company's email(we respond in less than 24hrs:
 - https://github.com/Oluwatobi-Mustapha/identrail/security/advisories/new
+- security@identrail.com
 
-If you cannot use that channel, contact the maintainer directly via GitHub profile message:
-- https://github.com/Oluwatobi-Mustapha
+If you cannot use that channel, contact the maintainer directly via linkeldn:
+- www.linkedin.com/in/oluwatobimustapha
 
 Please include:
 - A clear description of the issue and affected component

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ Identrail takes security reports seriously. If you believe you have found a vuln
 
 Do not open public GitHub issues for suspected vulnerabilities.
 
-Use GitHub private vulnerability reporting or the company's email(we respond in less than 24hrs:
+Use GitHub private vulnerability reporting or the company's email (we respond within 72 hours):
 - https://github.com/Oluwatobi-Mustapha/identrail/security/advisories/new
 - security@identrail.com
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ Use GitHub private vulnerability reporting or the company's email(we respond in 
 - https://github.com/Oluwatobi-Mustapha/identrail/security/advisories/new
 - security@identrail.com
 
-If you cannot use that channel, contact the maintainer directly via linkeldn:
+If you cannot use that channel, contact the maintainer directly via LinkedIn:
 - www.linkedin.com/in/oluwatobimustapha
 
 Please include:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update SECURITY.md to add security@identrail.com as a contact alongside GitHub private reporting and note a 72-hour response time. Also switch the fallback contact from GitHub profile messages to the maintainer’s LinkedIn (www.linkedin.com/in/oluwatobimustapha).

<sup>Written for commit e017350f1d3ebf7d5aee7b11bca1ec42a1785dd5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

