### PR TITLE
[codex] fix README badge rendering on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
 </p>
 
 <p align="center">
-[![CI](https://img.shields.io/github/actions/workflow/status/Oluwatobi-Mustapha/identrail/ci.yml?branch=main&style=flat&label=ci&colorA=000000&colorB=000000)](https://github.com/Oluwatobi-Mustapha/identrail/actions/workflows/ci.yml)
-[![Latest version](https://img.shields.io/github/v/tag/Oluwatobi-Mustapha/identrail?sort=semver&style=flat&label=version&colorA=000000&colorB=000000)](https://github.com/Oluwatobi-Mustapha/identrail/tags)
-[![GitHub stars](https://img.shields.io/github/stars/Oluwatobi-Mustapha/identrail?style=flat&colorA=000000&colorB=000000)](https://github.com/Oluwatobi-Mustapha/identrail/stargazers)
+  <a href="https://github.com/Oluwatobi-Mustapha/identrail/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/Oluwatobi-Mustapha/identrail/ci.yml?branch=main&style=flat&label=ci&colorA=000000&colorB=000000" alt="CI" /></a>
+  <a href="https://github.com/Oluwatobi-Mustapha/identrail/tags"><img src="https://img.shields.io/github/v/tag/Oluwatobi-Mustapha/identrail?sort=semver&style=flat&label=version&colorA=000000&colorB=000000" alt="Latest version" /></a>
+  <a href="https://github.com/Oluwatobi-Mustapha/identrail/stargazers"><img src="https://img.shields.io/github/stars/Oluwatobi-Mustapha/identrail?style=flat&colorA=000000&colorB=000000" alt="GitHub stars" /></a>
 </p>
 
 ## About the Project


### PR DESCRIPTION
## Summary
Fix README badge rendering on GitHub by replacing markdown badge syntax inside an HTML-aligned block with equivalent HTML `<a><img/></a>` tags.

## Root cause
GitHub does not reliably render markdown image/link syntax when it is nested inside block HTML containers (`<p align="center">`), so the badges appeared as raw text.

## Changes
- Updated the badge row in `README.md` to use HTML image links.
- No functional/code changes.

## Validation
- Verified diff is README-only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix README badges on GitHub by replacing Markdown badge links inside the centered HTML block with HTML <a><img> tags so they render correctly. README-only change; no functional impact.

<sup>Written for commit a69887131f7a70ad49093b01194544015abd153d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

