### PR TITLE
[codex] fix CodeQL go/path-injection in repo scanner

### DIFF
--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -395,22 +395,17 @@ func localRepository(target string) (repositoryLocation, bool) {
 	if !looksLikeLocalPath(path) {
 		return repositoryLocation{}, false
 	}
-	if isGitWorktree(path) {
-		absolute, absErr := filepath.Abs(path)
-		if absErr != nil {
-			absolute = path
-		}
+
+	absolute, absErr := filepath.Abs(filepath.Clean(path))
+	if absErr != nil {
+		return repositoryLocation{}, false
+	}
+
+	if isGitWorktree(absolute) {
 		return repositoryLocation{Path: absolute, Bare: false, Display: absolute}, true
 	}
-	if !isGitBareRepository(path) {
+	if !isGitBareRepository(absolute) {
 		return repositoryLocation{}, false
-	}
-	if _, err := os.Stat(filepath.Join(path, "objects")); err != nil {
-		return repositoryLocation{}, false
-	}
-	absolute, absErr := filepath.Abs(path)
-	if absErr != nil {
-		absolute = path
 	}
 	return repositoryLocation{Path: absolute, Bare: true, Display: absolute}, true
 }


### PR DESCRIPTION
## Summary
Fix GitHub Advanced Security CodeQL `go/path-injection` finding in repository scanner local-path handling.

## Why
CodeQL flagged a path expression built from user-controlled input in `internal/repoexposure/scanner.go`.

## Scope
- Normalize local repository paths to cleaned absolute paths before validation.
- Use normalized absolute path for worktree/bare checks.
- Remove redundant `os.Stat(filepath.Join(path, "objects"))` check on raw input.

## Validation
- `go test ./internal/repoexposure`
- `go test ./...`

## Checklist
- [x] Minimal, targeted change
- [x] Tests pass locally
- [x] DCO sign-off included

## AI Assistance Disclosure
Implemented with AI coding assistance and reviewed before commit.

## Related Issues
- Resolves GitHub Advanced Security alert: `go/path-injection` (`internal/repoexposure/scanner.go`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CodeQL `go/path-injection` in the repo scanner by sanitizing local repository paths. Paths are cleaned and made absolute before validation, worktree/bare checks use the sanitized path, and the raw `objects` stat was removed.

<sup>Written for commit dd39e8e1075131410ab5f6cac43cd1062565e2b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

