### PR TITLE
ci: add automatic Vercel production deployment workflow

### DIFF
--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -1,0 +1,45 @@
+name: Vercel Production Deploy
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: vercel-production-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy to Vercel Production
+    if: github.repository == 'identrail/identrail'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token="${{ secrets.VERCEL_TOKEN }}"
+
+      - name: Build Project Artifacts
+        run: vercel build --prod --token="${{ secrets.VERCEL_TOKEN }}"
+
+      - name: Deploy to Production
+        run: vercel deploy --prebuilt --prod --token="${{ secrets.VERCEL_TOKEN }}"

--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -20,26 +20,18 @@ jobs:
     if: github.repository == 'identrail/identrail'
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    env:
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@4b810e26f7bb2a331c698af186f890cbf20d5f72 # v42.2.0
         with:
-          node-version: "24"
-
-      - name: Install Vercel CLI
-        run: npm install --global vercel@50.37.3
-
-      - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=production --token="${{ secrets.VERCEL_TOKEN }}"
-
-      - name: Build Project Artifacts
-        run: vercel build --prod --token="${{ secrets.VERCEL_TOKEN }}"
-
-      - name: Deploy to Production
-        run: vercel deploy --prebuilt --prod --token="${{ secrets.VERCEL_TOKEN }}"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-comment: false
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          target: production
+          force: true
+          root-directory: web

--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy to Vercel Production
-    if: github.repository == 'identrail/identrail'
+    if: github.repository == 'identrail/identrail' && (github.event_name != 'workflow_dispatch' || github.ref_name == 'dev' || github.ref_name == 'main')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -25,15 +25,15 @@ jobs:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
 
       - name: Install Vercel CLI
-        run: npm install --global vercel@latest
+        run: npm install --global vercel@50.37.3
 
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=production --token="${{ secrets.VERCEL_TOKEN }}"


### PR DESCRIPTION
## Summary

Add an automated production deployment workflow for Vercel so pushes to `dev`/`main` deploy without relying on Vercel Git integration.

## Why

Vercel API currently rejects `vercel git connect` for `identrail/identrail` with HTTP 400, so the website is not auto-updating from Git pushes after the org/repo move.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation

- Triggered manual production deployment from latest `origin/dev` and confirmed alias to `www.identrail.com`.
- Verified PR checks pass (`actionlint`, `dco`, `dependency-review`, `gitleaks`, `hardened-go-smoke`, `pr-review`, `pr-context`, `Security Scorecard`).
- Resolved stale GitHub Advanced Security review thread after pinning workflow dependencies.

```bash
vercel pull --yes --environment=production
vercel deploy --prod --yes
gh pr checks 161 --repo identrail/identrail
```

## Checklist

- [ ] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: yes
- Tools used: Codex + GitHub CLI + Vercel CLI
- Areas where used: workflow authoring, deployment verification, PR check/debug triage
- Human verification performed: reviewed workflow changes, validated deploy output, validated PR/check state

## Related Issues

N/A
