### PR TITLE
feat(web): clean homepage flow and premium footer layout

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -17,7 +17,7 @@ describe('App', () => {
     expect(screen.getAllByRole('link', { name: /Try Free Hosted SaaS|Start Free Risk Scan/i }).length).toBeGreaterThan(0);
     expect(screen.getByRole('link', { name: 'Star on GitHub' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Book 15-min Demo' })).toBeInTheDocument();
-    expect(screen.getByText(/Choose deployment:/i)).toBeInTheDocument();
+    expect(screen.getByText(/Choose Deployment/i)).toBeInTheDocument();
   });
 
   it('renders pricing page routes and key elements', () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -41,17 +41,15 @@ const SITE_URL = 'https://identrail.com';
 const GITHUB_REPO = 'https://github.com/identrail/identrail';
 const DOCS_REPO = 'https://github.com/identrail/identrail/tree/main/docs';
 const DISCORD_URL = 'https://discord.gg/7jSUSnQC';
+const LINKEDIN_URL = 'https://www.linkedin.com/company/identrail/';
 const CALENDLY_URL = 'https://calendly.com/identrail/15min';
 
 const NAV_LINKS = [
-  { to: '/product', label: 'Product' },
-  { to: '/features', label: 'Features' },
   { to: '/solutions', label: 'Solutions' },
   { to: '/pricing', label: 'Pricing' },
   { to: '/demo', label: 'Demo' },
   { to: '/docs', label: 'Docs' },
-  { to: '/blog', label: 'Blog' },
-  { to: '/security', label: 'Security' }
+  { to: '/blog', label: 'Blog' }
 ] as const;
 
 const TRUSTED_LOGOS = [
@@ -928,14 +926,11 @@ function Header() {
 
 function DeploymentPathBanner() {
   return (
-    <section className="idt-deployment-banner" aria-label="Choose deployment">
-      <div className="idt-shell idt-deployment-inner">
-        <p>
-          Choose deployment:
-          <span> Open Source Self-Hosted</span>
-          <span> Hosted SaaS Pro</span>
-          <span> Enterprise Private Deployment</span>
-        </p>
+    <section className="idt-section idt-shell idt-deployment-bridge" aria-label="Choose deployment">
+      <div className="idt-deployment-panel">
+        <p className="idt-eyebrow">Choose Deployment</p>
+        <h2>Deploy open-source first, then scale to hosted or enterprise when you are ready.</h2>
+        <p className="idt-deployment-copy">Open Source Self-Hosted • Hosted SaaS Pro • Enterprise Private Deployment</p>
         <div className="idt-inline-actions idt-inline-actions-tight">
           <SafeLink href={GITHUB_REPO} className="idt-btn idt-btn-ghost">
             Deploy OSS
@@ -952,82 +947,95 @@ function DeploymentPathBanner() {
   );
 }
 
+function GitHubIcon() {
+  return (
+    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M12 2C6.48 2 2 6.59 2 12.25c0 4.52 2.87 8.35 6.84 9.7.5.1.68-.22.68-.49 0-.24-.01-.89-.01-1.75-2.78.62-3.37-1.37-3.37-1.37-.46-1.2-1.12-1.51-1.12-1.51-.92-.64.07-.63.07-.63 1.02.08 1.55 1.07 1.55 1.07.9 1.59 2.37 1.13 2.95.87.09-.67.35-1.13.64-1.39-2.22-.26-4.56-1.14-4.56-5.08 0-1.12.39-2.03 1.03-2.74-.1-.26-.45-1.31.1-2.73 0 0 .84-.27 2.75 1.05A9.4 9.4 0 0 1 12 6.8c.85 0 1.7.12 2.5.36 1.9-1.32 2.74-1.05 2.74-1.05.56 1.42.21 2.47.11 2.73.64.71 1.02 1.62 1.02 2.74 0 3.95-2.35 4.82-4.58 5.08.36.32.67.95.67 1.91 0 1.38-.01 2.49-.01 2.83 0 .27.18.6.69.49A10.25 10.25 0 0 0 22 12.25C22 6.59 17.52 2 12 2Z"
+      />
+    </svg>
+  );
+}
+
+function LinkedInIcon() {
+  return (
+    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M6.94 8.7A1.88 1.88 0 1 1 6.93 4.95 1.88 1.88 0 0 1 6.94 8.7Zm1.58 2.03v8.31H5.36v-8.3h3.16Zm4.95 0v1.13h.04c.44-.82 1.5-1.7 3.08-1.7 3.3 0 3.91 2.2 3.91 5.05v5.83h-3.16v-5.17c0-1.23-.02-2.8-1.68-2.8-1.68 0-1.94 1.33-1.94 2.71v5.26H10.56v-8.3h2.91Z"
+      />
+    </svg>
+  );
+}
+
+function DiscordIcon() {
+  return (
+    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M19.79 5.59A15.66 15.66 0 0 0 15.9 4.4l-.19.4a14.54 14.54 0 0 1 3.71 1.19 11.77 11.77 0 0 0-3.62-1.13c-2.39-.26-4.79-.26-7.18 0A11.7 11.7 0 0 0 5 6a14.56 14.56 0 0 1 3.71-1.19l-.19-.4a15.7 15.7 0 0 0-3.88 1.18C2.2 9.24 1.52 12.79 1.86 16.29a15.95 15.95 0 0 0 4.77 2.42l.95-1.58c-.52-.2-1.01-.45-1.49-.73.13.1.27.19.41.28 2.06 1.15 4.35 1.52 6.5 1.52 2.15 0 4.44-.37 6.49-1.52.14-.09.28-.18.41-.28-.47.28-.97.53-1.49.73l.95 1.58a15.92 15.92 0 0 0 4.77-2.42c.4-4.06-.68-7.58-2.53-10.7ZM9.54 14.14c-.76 0-1.39-.72-1.39-1.61s.61-1.6 1.39-1.6c.78 0 1.4.72 1.39 1.6 0 .9-.61 1.61-1.39 1.61Zm4.93 0c-.76 0-1.39-.72-1.39-1.61s.61-1.6 1.39-1.6c.78 0 1.4.72 1.39 1.6 0 .9-.61 1.61-1.39 1.61Z"
+      />
+    </svg>
+  );
+}
+
 function Footer() {
+  const footerLinks = [
+    { to: '/solutions', label: 'Solutions' },
+    { to: '/pricing', label: 'Pricing' },
+    { to: '/demo', label: 'Demo' },
+    { to: '/docs', label: 'Docs' },
+    { to: '/blog', label: 'Blog' },
+    { to: '/privacy', label: 'Privacy' },
+    { to: '/terms', label: 'Terms' }
+  ] as const;
+
   return (
     <footer className="idt-footer">
-      <div className="idt-shell idt-footer-grid">
-        <div>
-          <Link to="/" className="idt-brand idt-footer-brand">
-            <img src="/identrail-logo.png" width="30" height="30" alt="Identrail" />
-            <span>
-              Identrail
-              <small>Open-core machine identity platform</small>
-            </span>
-          </Link>
-          <p className="idt-footer-copy">
-            Discover machine identities, map trust paths, detect high-signal risk, and roll out authorization safely.
+      <section className="idt-footer-showcase">
+        <div className="idt-shell">
+          <h2>Benefits</h2>
+          <div className="idt-benefits-row">
+            <span>Fast OSS Start</span>
+            <span>Enterprise-Ready Controls</span>
+            <span>Trust Graph Clarity</span>
+            <span>Safer Rollouts</span>
+          </div>
+          <p>
+            Start with the open-core platform, prove value quickly, and move to hosted or enterprise deployment without re-platforming.
           </p>
+          <div className="idt-footer-cta-row">
+            <Link to="/pricing" className="idt-footer-super-cta">
+              <span>Start Free Risk Scan</span>
+              <small>Try hosted SaaS or choose enterprise rollout</small>
+            </Link>
+          </div>
         </div>
+      </section>
 
-        <div>
-          <h3>Product</h3>
-          <ul>
-            <li>
-              <Link to="/product">Platform Overview</Link>
-            </li>
-            <li>
-              <Link to="/features">Features</Link>
-            </li>
-            <li>
-              <Link to="/demo">Interactive Trust Graph</Link>
-            </li>
-            <li>
-              <Link to="/pricing">Pricing</Link>
-            </li>
-          </ul>
+      <div className="idt-footer-bar">
+        <div className="idt-shell idt-footer-bar-row">
+          <nav className="idt-footer-links" aria-label="Footer">
+            {footerLinks.map((item) => (
+              <Link key={item.to} to={item.to}>
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+          <small>© {new Date().getFullYear()} Identrail. All rights reserved.</small>
+          <div className="idt-footer-socials">
+            <SafeLink href={GITHUB_REPO} aria-label="GitHub" className="idt-social-link">
+              <GitHubIcon />
+            </SafeLink>
+            <SafeLink href={DISCORD_URL} aria-label="Discord" className="idt-social-link">
+              <DiscordIcon />
+            </SafeLink>
+            <SafeLink href={LINKEDIN_URL} aria-label="LinkedIn" className="idt-social-link">
+              <LinkedInIcon />
+            </SafeLink>
+          </div>
         </div>
-
-        <div>
-          <h3>Resources</h3>
-          <ul>
-            <li>
-              <Link to="/docs">Docs</Link>
-            </li>
-            <li>
-              <Link to="/blog">Blog</Link>
-            </li>
-            <li>
-              <SafeLink href={DISCORD_URL}>Discord</SafeLink>
-            </li>
-            <li>
-              <SafeLink href={GITHUB_REPO}>GitHub</SafeLink>
-            </li>
-          </ul>
-        </div>
-
-        <div>
-          <h3>Company</h3>
-          <ul>
-            <li>
-              <Link to="/about">About</Link>
-            </li>
-            <li>
-              <Link to="/security">Security</Link>
-            </li>
-            <li>
-              <Link to="/terms">Terms</Link>
-            </li>
-            <li>
-              <Link to="/privacy">Privacy</Link>
-            </li>
-            <li>
-              <Link to="/privacy-choices">Privacy Choices</Link>
-            </li>
-          </ul>
-        </div>
-      </div>
-      <div className="idt-footer-bottom idt-shell">
-        <small>Copyright {new Date().getFullYear()} Identrail. Built for platform and security teams.</small>
       </div>
     </footer>
   );
@@ -1148,6 +1156,8 @@ function HomePage() {
           </li>
         </ol>
       </section>
+
+      <DeploymentPathBanner />
 
       <section className="idt-section idt-shell">
         <SectionTitle
@@ -2055,7 +2065,6 @@ function RoutedSite() {
       </a>
 
       <Header />
-      <DeploymentPathBanner />
 
       <main id="main-content">
         <Routes>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -191,34 +191,34 @@ a {
   font-weight: 700;
 }
 
-.idt-deployment-banner {
-  border-bottom: 1px solid var(--idt-line);
-  background: linear-gradient(90deg, rgba(0, 229, 201, 0.08), rgba(36, 178, 255, 0.08));
+.idt-deployment-bridge {
+  padding-top: clamp(2rem, 5vw, 3rem);
+  padding-bottom: clamp(2rem, 5vw, 3rem);
 }
 
-.idt-deployment-inner {
-  min-height: 64px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0.65rem 0;
+.idt-deployment-panel {
+  border: 1px solid rgba(0, 229, 201, 0.36);
+  background:
+    radial-gradient(circle at 0% 0%, rgba(0, 229, 201, 0.14), transparent 50%),
+    linear-gradient(160deg, rgba(16, 29, 56, 0.9), rgba(10, 20, 40, 0.92));
+  border-radius: 24px;
+  padding: clamp(1.2rem, 3vw, 2rem);
+  box-shadow: var(--idt-shadow);
 }
 
-.idt-deployment-inner p {
+.idt-deployment-panel h2 {
+  max-width: 28ch;
+  margin-bottom: 0.65rem;
+}
+
+.idt-deployment-copy {
   margin: 0;
-  color: #d8e8ff;
+  color: #d7e6ff;
   font-weight: 600;
-  font-size: 0.93rem;
-}
-
-.idt-deployment-inner p span {
-  color: var(--idt-accent);
-  margin-left: 0.45rem;
 }
 
 .idt-inline-actions-tight {
-  margin-top: 0;
+  margin-top: 1.05rem;
 }
 
 .idt-hero {
@@ -230,6 +230,13 @@ a {
   grid-template-columns: minmax(0, 1fr) minmax(0, 0.95fr);
   align-items: center;
   gap: 2.3rem;
+}
+
+.idt-hero-grid > div:first-child {
+  border: 1px solid rgba(169, 184, 211, 0.22);
+  border-radius: 22px;
+  padding: clamp(1rem, 3vw, 1.6rem);
+  background: linear-gradient(150deg, rgba(16, 29, 56, 0.66), rgba(9, 19, 38, 0.5));
 }
 
 h1,
@@ -893,58 +900,127 @@ h3 {
 }
 
 .idt-footer {
-  border-top: 1px solid var(--idt-line);
-  background: rgba(5, 12, 24, 0.84);
   margin-top: 2rem;
 }
 
-.idt-footer-grid {
+.idt-footer-showcase {
+  border-top: 1px solid var(--idt-line);
+  border-bottom: 1px solid var(--idt-line);
+  background: rgba(248, 250, 252, 0.95);
+  color: #0f172a;
+}
+
+.idt-footer-showcase .idt-shell {
+  padding: clamp(2.4rem, 6vw, 4rem) 0;
+}
+
+.idt-footer-showcase h2 {
+  margin-bottom: 1rem;
+}
+
+.idt-benefits-row {
   display: grid;
-  grid-template-columns: 2fr repeat(3, 1fr);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.7rem;
+}
+
+.idt-benefits-row span {
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.04);
+  font-weight: 700;
+  text-align: center;
+  padding: 0.8rem 0.6rem;
+}
+
+.idt-footer-showcase p {
+  margin: 1.1rem 0 1.2rem;
+  max-width: 70ch;
+  color: #475569;
+}
+
+.idt-footer-cta-row {
+  max-width: 640px;
+}
+
+.idt-footer-super-cta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   gap: 1rem;
-  padding: 2rem 0;
-}
-
-.idt-footer-brand {
-  margin-bottom: 0.8rem;
-}
-
-.idt-footer-copy {
-  margin: 0;
-  max-width: 46ch;
-  color: #b8cae7;
-}
-
-.idt-footer h3 {
-  font-size: 0.95rem;
-  margin-bottom: 0.6rem;
-}
-
-.idt-footer ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 0.35rem;
-}
-
-.idt-footer a {
-  color: #d8e6ff;
+  border-radius: 18px;
+  background: #020617;
+  color: #f8fafc;
   text-decoration: none;
+  padding: 1.1rem 1.25rem;
+  border: 1px solid rgba(2, 6, 23, 0.8);
+  box-shadow: 0 20px 40px rgba(2, 6, 23, 0.35);
 }
 
-.idt-footer a:hover,
-.idt-footer a:focus-visible {
-  color: var(--idt-accent);
+.idt-footer-super-cta span {
+  font-family: var(--idt-display);
+  font-size: 1.12rem;
 }
 
-.idt-footer-bottom {
-  padding: 0.8rem 0 1.2rem;
-  border-top: 1px solid rgba(169, 184, 211, 0.2);
+.idt-footer-super-cta small {
+  color: rgba(248, 250, 252, 0.78);
+  text-align: right;
 }
 
-.idt-footer-bottom small {
-  color: var(--idt-text-muted);
+.idt-footer-bar {
+  background: #4fb56a;
+  color: #051b0d;
+}
+
+.idt-footer-bar-row {
+  min-height: 88px;
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 1rem;
+  align-items: center;
+}
+
+.idt-footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.idt-footer-links a {
+  color: #04220f;
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.idt-footer-links a:hover,
+.idt-footer-links a:focus-visible {
+  text-decoration: underline;
+}
+
+.idt-footer-bar-row small {
+  color: rgba(4, 34, 15, 0.9);
+  font-weight: 600;
+}
+
+.idt-footer-socials {
+  display: flex;
+  gap: 0.45rem;
+}
+
+.idt-social-link {
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  display: inline-grid;
+  place-items: center;
+  color: #02170b;
+  border: 1px solid rgba(4, 34, 15, 0.3);
+  background: rgba(248, 250, 252, 0.4);
+}
+
+.idt-social-link svg {
+  width: 18px;
+  height: 18px;
 }
 
 .idt-modal-backdrop {
@@ -1019,7 +1095,6 @@ h3 {
 
   .idt-hero-grid,
   .idt-demo-surface,
-  .idt-footer-grid,
   .idt-pricing-grid,
   .idt-roi-grid,
   .idt-card-grid.two-col,
@@ -1040,10 +1115,14 @@ h3 {
     min-height: 380px;
   }
 
-  .idt-deployment-inner {
-    flex-direction: column;
+  .idt-benefits-row {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-footer-bar-row {
+    grid-template-columns: 1fr;
     align-items: flex-start;
-    padding: 0.8rem 0;
+    padding: 0.9rem 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- remove `Product`, `Features`, and `Security` from the primary top navigation for a cleaner IA
- move the "Choose Deployment" block from the top into the middle of the homepage flow
- polish hero composition to avoid stacked hero-like sections and improve visual hierarchy
- redesign footer/final area into a cleaner premium layout with benefits row and a single prominent CTA
- add Discord and LinkedIn social icons alongside GitHub in the final footer bar
- update homepage test assertion for the deployment section wording

## Why
The homepage had two hero-like messages too close together and navigation density felt scattered. This refactor creates a cleaner, more premium flow while preserving core conversion actions.

## Scope
- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation
- `npm run test:ci --prefix web` (pass)
- `npm run build --prefix web` (pass)

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure
- AI-assisted: yes
- Tools used: Codex + GitHub CLI
- Areas where used: layout/CSS refactor, navigation cleanup, footer redesign, test update
- Human verification performed: reviewed diffs and validated test/build outputs

## Related Issues
N/A
