### PR TITLE
fix(ci): make Vercel deploy resilient to stale tokens

### DIFF
--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -24,14 +24,82 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Deploy to Vercel
-        uses: amondnet/vercel-action@4b810e26f7bb2a331c698af186f890cbf20d5f72 # v42.2.0
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          github-comment: false
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          target: production
-          force: true
-          root-directory: web
+          node-version: '20'
+
+      - name: Validate required Vercel identifiers
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "$VERCEL_ORG_ID" ] || [ -z "$VERCEL_PROJECT_ID" ]; then
+            echo "Missing Vercel identifiers. Set VERCEL_ORG_ID and VERCEL_PROJECT_ID repository secrets."
+            exit 1
+          fi
+
+      - name: Normalize Vercel token secret
+        id: normalize-token
+        env:
+          RAW_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+          token="$(printf '%s' "$RAW_TOKEN" | tr -d '\r\n' | sed -e 's/^"//' -e 's/"$//')"
+          if [ -z "$token" ]; then
+            echo "has_token=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::add-mask::$token"
+          {
+            echo "has_token=true"
+            echo "token=$token"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Verify Vercel token
+        id: verify-token
+        if: steps.normalize-token.outputs.has_token == 'true'
+        continue-on-error: true
+        env:
+          VERCEL_TOKEN: ${{ steps.normalize-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          curl -fsS -H "Authorization: Bearer $VERCEL_TOKEN" https://api.vercel.com/v2/user > /tmp/vercel-user.json
+          echo "Token verified for Vercel user:"
+          jq -r '.user.username // .username // "unknown"' /tmp/vercel-user.json
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@50.37.3
+
+      - name: Deploy to Vercel via CLI
+        id: deploy-cli
+        if: steps.normalize-token.outputs.has_token == 'true'
+        continue-on-error: true
+        env:
+          VERCEL_TOKEN: ${{ steps.normalize-token.outputs.token }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          cd web
+          vercel pull --yes --environment=production --token "$VERCEL_TOKEN"
+          vercel deploy --prod --yes --token "$VERCEL_TOKEN"
+
+      - name: Fallback deploy via hook
+        id: deploy-hook
+        if: (steps.normalize-token.outputs.has_token != 'true' || steps.deploy-cli.outcome != 'success') && secrets.VERCEL_DEPLOY_HOOK_URL != ''
+        env:
+          VERCEL_DEPLOY_HOOK_URL: ${{ secrets.VERCEL_DEPLOY_HOOK_URL }}
+        run: |
+          set -euo pipefail
+          curl -fsS -X POST "$VERCEL_DEPLOY_HOOK_URL" > /tmp/vercel-hook-response.json
+          echo "Triggered Vercel deploy hook successfully."
+
+      - name: Fail if no deployment path succeeded
+        if: steps.deploy-cli.outcome != 'success' && steps.deploy-hook.outcome != 'success'
+        run: |
+          echo "Vercel deployment failed."
+          echo "Root cause is usually an invalid/stale VERCEL_TOKEN."
+          echo "Fix by rotating VERCEL_TOKEN, or set VERCEL_DEPLOY_HOOK_URL for hook-based fallback."
+          exit 1

--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -20,14 +20,11 @@ jobs:
     if: github.repository == 'identrail/identrail' && (github.event_name != 'workflow_dispatch' || github.ref_name == 'dev' || github.ref_name == 'main')
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      VERCEL_DEPLOY_HOOK_URL: ${{ secrets.VERCEL_DEPLOY_HOOK_URL }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
 
       - name: Validate required Vercel identifiers
         env:
@@ -69,35 +66,31 @@ jobs:
           echo "Token verified for Vercel user:"
           jq -r '.user.username // .username // "unknown"' /tmp/vercel-user.json
 
-      - name: Install Vercel CLI
-        run: npm install --global vercel@50.37.3
-
-      - name: Deploy to Vercel via CLI
-        id: deploy-cli
+      - name: Deploy to Vercel
+        id: deploy-action
         if: steps.normalize-token.outputs.has_token == 'true'
         continue-on-error: true
-        env:
-          VERCEL_TOKEN: ${{ steps.normalize-token.outputs.token }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-        run: |
-          set -euo pipefail
-          cd web
-          vercel pull --yes --environment=production --token "$VERCEL_TOKEN"
-          vercel deploy --prod --yes --token "$VERCEL_TOKEN"
+        uses: amondnet/vercel-action@4b810e26f7bb2a331c698af186f890cbf20d5f72 # v42.2.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-comment: false
+          vercel-token: ${{ steps.normalize-token.outputs.token }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          target: production
+          force: true
+          root-directory: web
 
       - name: Fallback deploy via hook
         id: deploy-hook
-        if: (steps.normalize-token.outputs.has_token != 'true' || steps.deploy-cli.outcome != 'success') && secrets.VERCEL_DEPLOY_HOOK_URL != ''
-        env:
-          VERCEL_DEPLOY_HOOK_URL: ${{ secrets.VERCEL_DEPLOY_HOOK_URL }}
+        if: (steps.normalize-token.outputs.has_token != 'true' || steps.verify-token.outcome != 'success' || steps.deploy-action.outcome != 'success') && env.VERCEL_DEPLOY_HOOK_URL != ''
         run: |
           set -euo pipefail
           curl -fsS -X POST "$VERCEL_DEPLOY_HOOK_URL" > /tmp/vercel-hook-response.json
           echo "Triggered Vercel deploy hook successfully."
 
       - name: Fail if no deployment path succeeded
-        if: steps.deploy-cli.outcome != 'success' && steps.deploy-hook.outcome != 'success'
+        if: steps.deploy-action.outcome != 'success' && steps.deploy-hook.outcome != 'success'
         run: |
           echo "Vercel deployment failed."
           echo "Root cause is usually an invalid/stale VERCEL_TOKEN."

--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Fallback deploy via hook
         id: deploy-hook
-        if: (steps.normalize-token.outputs.has_token != 'true' || steps.verify-token.outcome != 'success' || steps.deploy-action.outcome != 'success') && env.VERCEL_DEPLOY_HOOK_URL != ''
+        if: (steps.normalize-token.outputs.has_token != 'true' || steps.deploy-action.outcome != 'success') && env.VERCEL_DEPLOY_HOOK_URL != ''
         run: |
           set -euo pipefail
           curl -fsS -X POST "$VERCEL_DEPLOY_HOOK_URL" > /tmp/vercel-hook-response.json


### PR DESCRIPTION
## Root Cause
Merges to `dev` were triggering the deployment workflow, but deployment failed with:

- `Deployment failed: {"code":"forbidden","message":"Not authorized","invalidToken":true,"status":403}`

This means the current `VERCEL_TOKEN` secret is invalid/stale for the Vercel project scope.

## What this PR changes
- Replaces the direct third-party action deployment path with explicit Vercel CLI flow.
- Adds preflight validation for required identifiers (`VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`).
- Normalizes token input (trims newline/quotes) before use.
- Verifies token against Vercel API for faster diagnostics.
- Adds optional fallback deployment path via `VERCEL_DEPLOY_HOOK_URL` if token deploy fails.
- Fails with clear remediation guidance if no deploy path succeeds.

## Why this helps
- Prevents silent/opaque failures when a token is malformed or stale.
- Keeps automatic deploys possible via hook fallback during token rotation windows.
- Improves operational clarity for future incidents.

## Required one-time secret action
To fully restore deployments, rotate `VERCEL_TOKEN` in repo secrets (or add `VERCEL_DEPLOY_HOOK_URL`):
- `VERCEL_TOKEN`
- (optional fallback) `VERCEL_DEPLOY_HOOK_URL`

## Verification
- Workflow YAML parses successfully.
- Existing run logs confirm root cause (`invalidToken: true`) and this patch addresses that path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Vercel production deploys resilient to stale or invalid tokens by verifying and normalizing `VERCEL_TOKEN`, with a deploy-hook fallback. Also fixes actionlint/scorecard warnings and hardens the workflow.

- **Bug Fixes**
  - Preflight checks for `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID`; normalized and masked `VERCEL_TOKEN`.
  - Verified the token via Vercel API; deployed using pinned `amondnet/vercel-action` (SHA for v42.2.0) with the normalized token.
  - Fallback via `VERCEL_DEPLOY_HOOK_URL` when the token is missing/invalid or deploy fails; clear failure guidance if all paths fail.

- **Migration**
  - Rotate `VERCEL_TOKEN` in repo secrets.
  - Optionally set `VERCEL_DEPLOY_HOOK_URL` for fallback during token rotations.

<sup>Written for commit f79d863b1daf5881dc6e2c152d3e18f3b12a3510. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

