### PR TITLE
web: simplify hero copy and right-side preview

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -777,24 +777,13 @@ function TrustGraphHeroVisual() {
       <span className="idt-edge idt-edge-c" />
       <span className="idt-pulse idt-pulse-a" />
       <span className="idt-pulse idt-pulse-b" />
-      <article className="idt-hero-preview-card">
-        <p className="idt-hero-preview-title">Sample Finding</p>
-        <h3>Kubernetes service account can assume production AWS role</h3>
-        <p className="idt-hero-preview-meta">
-          <span className="idt-severity-pill">High severity</span>
-          <span>Reachable resources: 18</span>
-        </p>
-        <dl>
-          <div>
-            <dt>Path</dt>
-            <dd>GitHub Actions → OIDC Provider → AWS Role → RDS Billing Resource</dd>
-          </div>
-          <div>
-            <dt>Fix</dt>
-            <dd>Restrict trust policy conditions and scope role permissions.</dd>
-          </div>
-        </dl>
-      </article>
+      <aside className="idt-hero-graph-caption">
+        <p className="idt-hero-graph-title">Trust graph preview</p>
+        <p>GitHub Actions OIDC → AWS Role → K8s Service Account → RDS Billing Resource</p>
+        <Link to="/demo" className="idt-inline-link">
+          Open interactive demo
+        </Link>
+      </aside>
     </div>
   );
 }
@@ -1284,15 +1273,14 @@ function HomePage() {
       <section className="idt-hero">
         <div className="idt-shell idt-hero-grid">
           <div className="idt-hero-copy">
-            <p className="idt-eyebrow">Machine identity security for AWS, Kubernetes, OIDC, and GitHub</p>
-            <h1>Identify risky AWS IAM, Kubernetes, and GitHub trust paths before attackers use them.</h1>
+            <p className="idt-eyebrow">Machine identity security</p>
+            <h1>See risky machine trust paths before attackers do.</h1>
             <p className="idt-lead">
-              Find risky machine identity trust paths, understand blast radius, and roll out safer access without breaking production.
+              Identrail maps AWS, Kubernetes, and GitHub identity paths so your team can reduce blast radius safely.
             </p>
             <ul className="idt-hero-points" aria-label="What Identrail does">
               <li>Map machine identities and trust relationships across cloud and clusters.</li>
-              <li>Prioritize high-risk paths with clear blast-radius evidence.</li>
-              <li>Simulate remediations before rollout to avoid production breakage.</li>
+              <li>Simulate policy changes before rollout to avoid production breakage.</li>
             </ul>
             <div className="idt-inline-actions" data-ab-slot="hero_primary_cta">
               <a href="#risk-scan-form" className="idt-btn idt-btn-primary">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -482,56 +482,32 @@ h3 {
   animation-delay: 0.95s;
 }
 
-.idt-hero-preview-card {
+.idt-hero-graph-caption {
   position: absolute;
   right: 0.85rem;
   bottom: 0.85rem;
   z-index: 3;
-  width: min(100% - 1.7rem, 360px);
+  width: min(100% - 1.7rem, 420px);
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 14px;
   background: linear-gradient(165deg, rgba(8, 8, 10, 0.95), rgba(14, 14, 17, 0.96));
-  padding: 0.85rem;
+  padding: 0.9rem;
   box-shadow: 0 20px 40px rgba(1, 8, 22, 0.55);
 }
 
-.idt-hero-preview-title {
+.idt-hero-graph-title {
   margin: 0;
   color: #dbe6ff;
-  font-size: 0.68rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
   font-weight: 700;
 }
 
-.idt-hero-preview-card h3 {
-  margin: 0.5rem 0 0.7rem;
+.idt-hero-graph-caption > p {
+  margin: 0.45rem 0 0.6rem;
+  color: #d6dff0;
   font-size: 0.88rem;
-}
-
-.idt-hero-preview-card dl {
-  margin: 0;
-  display: grid;
-  gap: 0.55rem;
-}
-
-.idt-hero-preview-card dl div {
-  display: grid;
-  gap: 0.14rem;
-}
-
-.idt-hero-preview-card dt {
-  color: #a7b3c8;
-  font-size: 0.66rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.idt-hero-preview-card dd {
-  margin: 0;
-  color: #ecf4ff;
-  font-size: 0.78rem;
+  line-height: 1.45;
 }
 
 .idt-severity-high {
@@ -1976,7 +1952,7 @@ h2 {
   .idt-hero-points li {
     font-size: 0.9rem;
   }
-  .idt-hero-preview-card {
+  .idt-hero-graph-caption {
     position: static;
     margin: 1rem;
     width: auto;


### PR DESCRIPTION
Shortens hero wording and makes the right-side hero visual a single coherent trust-graph preview.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the homepage hero with tighter copy and a unified right‑side trust-graph caption, replacing the sample finding card and adding a clear “Open interactive demo” link.

- **Refactors**
  - Shortened hero copy: concise eyebrow, headline, and lead; streamlined bullet points.
  - Replaced preview card with a single caption and link; graph path shown as one line.
  - Renamed styles from `.idt-hero-preview-card` to `.idt-hero-graph-caption` and adjusted typography, width, and padding; removed unused preview card rules and improved mobile layout.

<sup>Written for commit 88e1136868e62dad49029b9f664b5785ba3dd585. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

