### PR TITLE
web: hero precision pass

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1276,12 +1276,8 @@ function HomePage() {
             <p className="idt-eyebrow">Machine identity security</p>
             <h1>See risky machine trust paths before attackers do.</h1>
             <p className="idt-lead">
-              Identrail maps AWS, Kubernetes, and GitHub identity paths so your team can reduce blast radius safely.
+              Map AWS IAM, Kubernetes, and GitHub identity paths. Prioritize blast radius, then roll out safer access without breaking production.
             </p>
-            <ul className="idt-hero-points" aria-label="What Identrail does">
-              <li>Map machine identities and trust relationships across cloud and clusters.</li>
-              <li>Simulate policy changes before rollout to avoid production breakage.</li>
-            </ul>
             <div className="idt-inline-actions" data-ab-slot="hero_primary_cta">
               <a href="#risk-scan-form" className="idt-btn idt-btn-primary">
                 Start Free Risk Scan
@@ -1290,32 +1286,29 @@ function HomePage() {
                 Book Demo
               </Link>
             </div>
-            <p className="idt-inline-link-note">
-              Need self-hosted first?{' '}
-              <SafeLink href={GITHUB_REPO} className="idt-inline-link">
-                View Open Source on GitHub
-              </SafeLink>
-            </p>
-            <div className="idt-kpi-row">
-              <article>
-                <strong>87%</strong>
-                <span>Average high-risk trust path reduction</span>
-              </article>
-              <article>
-                <strong>&lt; 15 min</strong>
-                <span>Time to first trust graph in hosted SaaS</span>
-              </article>
-              <article>
-                <strong>3x faster</strong>
-                <span>Identity triage for cloud security and platform teams</span>
-              </article>
-            </div>
           </div>
           <TrustGraphHeroVisual />
         </div>
       </section>
 
       <HomeCredibilityStrip />
+
+      <section className="idt-section idt-shell idt-impact-strip" aria-label="Impact snapshot">
+        <div className="idt-kpi-row">
+          <article>
+            <strong>87%</strong>
+            <span>Average high-risk trust path reduction</span>
+          </article>
+          <article>
+            <strong>&lt; 15 min</strong>
+            <span>Time to first trust graph in hosted SaaS</span>
+          </article>
+          <article>
+            <strong>3x faster</strong>
+            <span>Identity triage for cloud security and platform teams</span>
+          </article>
+        </div>
+      </section>
 
       <section className="idt-section idt-shell">
         <SectionTitle

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -357,6 +357,14 @@ h3 {
   gap: 0.8rem;
 }
 
+.idt-impact-strip {
+  padding-top: clamp(1.3rem, 3vw, 2.2rem);
+}
+
+.idt-impact-strip .idt-kpi-row {
+  margin-top: 0;
+}
+
 .idt-kpi-row article {
   border: 1px solid var(--idt-line);
   background: rgba(12, 12, 14, 0.9);


### PR DESCRIPTION
Tightens homepage hero messaging and removes first-fold clutter for clearer intent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the homepage hero and trims first-fold content so users see the core value faster.

- **Refactors**
  - Updated hero lead to: “Map AWS IAM, Kubernetes, and GitHub identity paths. Prioritize blast radius, then roll out safer access without breaking production.”
  - Removed the hero bullets and the self-hosted inline note to reduce clutter.
  - Moved KPIs into a new “Impact snapshot” section and added `.idt-impact-strip` styles for spacing.

<sup>Written for commit eacefc8fb95dc017941bef427758069e6c569a3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

