### PR TITLE
web: simplify homepage narrative flow

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1276,12 +1276,8 @@ function HomePage() {
             <p className="idt-eyebrow">Machine identity security</p>
             <h1>See risky machine trust paths before attackers do.</h1>
             <p className="idt-lead">
-              Identrail maps AWS, Kubernetes, and GitHub identity paths so your team can reduce blast radius safely.
+              Map AWS IAM, Kubernetes, and GitHub identity paths. Prioritize blast radius, then roll out safer access without breaking production.
             </p>
-            <ul className="idt-hero-points" aria-label="What Identrail does">
-              <li>Map machine identities and trust relationships across cloud and clusters.</li>
-              <li>Simulate policy changes before rollout to avoid production breakage.</li>
-            </ul>
             <div className="idt-inline-actions" data-ab-slot="hero_primary_cta">
               <a href="#risk-scan-form" className="idt-btn idt-btn-primary">
                 Start Free Risk Scan
@@ -1290,32 +1286,29 @@ function HomePage() {
                 Book Demo
               </Link>
             </div>
-            <p className="idt-inline-link-note">
-              Need self-hosted first?{' '}
-              <SafeLink href={GITHUB_REPO} className="idt-inline-link">
-                View Open Source on GitHub
-              </SafeLink>
-            </p>
-            <div className="idt-kpi-row">
-              <article>
-                <strong>87%</strong>
-                <span>Average high-risk trust path reduction</span>
-              </article>
-              <article>
-                <strong>&lt; 15 min</strong>
-                <span>Time to first trust graph in hosted SaaS</span>
-              </article>
-              <article>
-                <strong>3x faster</strong>
-                <span>Identity triage for cloud security and platform teams</span>
-              </article>
-            </div>
           </div>
           <TrustGraphHeroVisual />
         </div>
       </section>
 
       <HomeCredibilityStrip />
+
+      <section className="idt-section idt-shell idt-impact-strip" aria-label="Impact snapshot">
+        <div className="idt-kpi-row">
+          <article>
+            <strong>87%</strong>
+            <span>Average high-risk trust path reduction</span>
+          </article>
+          <article>
+            <strong>&lt; 15 min</strong>
+            <span>Time to first trust graph in hosted SaaS</span>
+          </article>
+          <article>
+            <strong>3x faster</strong>
+            <span>Identity triage for cloud security and platform teams</span>
+          </article>
+        </div>
+      </section>
 
       <section className="idt-section idt-shell">
         <SectionTitle

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -199,27 +199,6 @@ const DOC_ENTRIES: DocEntry[] = [
   }
 ];
 
-const SOCIAL_QUOTES = [
-  {
-    quote:
-      'Identrail mapped over 12,000 machine trust paths in week one and gave us a clear remediation queue.',
-    name: 'Principal Cloud Security Engineer',
-    company: 'Global Payments Company'
-  },
-  {
-    quote:
-      'We reduced privileged service account risk by 87% without breaking production rollouts.',
-    name: 'Director of Platform Security',
-    company: 'Enterprise SaaS Provider'
-  },
-  {
-    quote:
-      'The open-core model let us self-host quickly while preparing enterprise controls for procurement.',
-    name: 'VP Security Engineering',
-    company: 'Large Healthcare Network'
-  }
-] as const;
-
 const DIFFERENTIATION_ROWS = [
   {
     area: 'Core Platform Access',
@@ -1194,38 +1173,20 @@ function XIcon() {
 
 function Footer() {
   const footerLinks = [
+    { to: '/product', label: 'Product' },
     { to: '/solutions', label: 'Solutions' },
     { to: '/pricing', label: 'Pricing' },
     { to: '/demo', label: 'Demo' },
     { to: '/docs', label: 'Docs' },
     { to: '/blog', label: 'Blog' },
+    { to: '/security', label: 'Security' },
+    { to: '/about', label: 'About' },
     { to: '/privacy', label: 'Privacy' },
     { to: '/terms', label: 'Terms' }
   ] as const;
 
   return (
     <footer className="idt-footer">
-      <section className="idt-footer-showcase">
-        <div className="idt-shell">
-          <h2>Benefits</h2>
-          <div className="idt-benefits-row">
-            <span>Fast OSS Start</span>
-            <span>Enterprise-Ready Controls</span>
-            <span>Trust Graph Clarity</span>
-            <span>Safer Rollouts</span>
-          </div>
-          <p>
-            Start with the open-core platform, prove value quickly, and move to hosted or enterprise deployment without re-platforming.
-          </p>
-          <div className="idt-footer-cta-row">
-            <Link to="/pricing" className="idt-footer-super-cta">
-              <span>Start Free Risk Scan</span>
-              <small>Try hosted SaaS or choose enterprise rollout</small>
-            </Link>
-          </div>
-        </div>
-      </section>
-
       <div className="idt-footer-bar">
         <div className="idt-shell idt-footer-bar-row">
           <nav className="idt-footer-links" aria-label="Footer">
@@ -1316,7 +1277,7 @@ function HomePage() {
           title="Machine identity risk is hard to control when trust data is fragmented"
           body="Security and platform teams need one view across AWS IAM, Kubernetes RBAC, OIDC relationships, and GitHub/GitOps workflows to understand real exposure."
         />
-        <div className="idt-card-grid three-col">
+        <div className="idt-card-grid two-col">
           <article className="idt-card">
             <h3>What Identrail does</h3>
             <p>Discovers machine identity trust paths and shows where risky access actually exists.</p>
@@ -1324,10 +1285,6 @@ function HomePage() {
           <article className="idt-card">
             <h3>Why it matters</h3>
             <p>Hidden trust chains can turn one compromised workload into broad production access.</p>
-          </article>
-          <article className="idt-card">
-            <h3>What teams do next</h3>
-            <p>Prioritize high-impact paths and reduce overprivileged access with policy simulation.</p>
           </article>
         </div>
       </section>
@@ -1393,23 +1350,6 @@ function HomePage() {
               ))}
             </tbody>
           </table>
-        </div>
-      </section>
-
-      <section className="idt-section idt-shell">
-        <SectionTitle
-          eyebrow="Early User Signals"
-          title="Initial feedback from design-partner cloud teams"
-          body="Placeholders shown until public case studies and named customer logos are published."
-        />
-        <div className="idt-quote-row" role="list">
-          {SOCIAL_QUOTES.map((quote) => (
-            <article key={quote.quote} className="idt-quote-card" role="listitem">
-              <p>{quote.quote}</p>
-              <strong>{quote.name}</strong>
-              <span>{quote.company}</span>
-            </article>
-          ))}
         </div>
       </section>
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -357,6 +357,14 @@ h3 {
   gap: 0.8rem;
 }
 
+.idt-impact-strip {
+  padding-top: clamp(1.3rem, 3vw, 2.2rem);
+}
+
+.idt-impact-strip .idt-kpi-row {
+  margin-top: 0;
+}
+
 .idt-kpi-row article {
   border: 1px solid var(--idt-line);
   background: rgba(12, 12, 14, 0.9);


### PR DESCRIPTION
Removes placeholder testimonial noise and simplifies homepage/ footer structure for a cleaner story.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the homepage narrative by removing placeholder testimonials and the footer promo, and streamlines content for a cleaner, two-column story. Also updates footer navigation links.

- **Refactors**
  - Removed Early User Signals section and `SOCIAL_QUOTES`.
  - Deleted footer “Benefits” showcase and CTA; added footer links for Product, Security, and About.
  - Reduced homepage card grid from three to two columns by removing “What teams do next”.

<sup>Written for commit e84fb8a344c826c28ab69794906c058c3e48c58f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

