### PR TITLE
web: conversion plumbing for lead capture

### DIFF
--- a/web/api/leads.ts
+++ b/web/api/leads.ts
@@ -1,0 +1,71 @@
+type LeadCapturePayload = {
+  email?: string;
+  environment?: string;
+  company?: string;
+  challenge?: string;
+  source?: string;
+  page_path?: string;
+};
+
+function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+function badRequest(res: { status: (code: number) => { json: (payload: unknown) => void } }, message: string) {
+  res.status(400).json({ error: message });
+}
+
+export default async function handler(
+  req: { method?: string; body?: LeadCapturePayload },
+  res: { status: (code: number) => { json: (payload: unknown) => void } }
+) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const body = req.body ?? {};
+  const email = (body.email ?? '').trim();
+  const environment = (body.environment ?? '').trim();
+
+  if (!email || !isValidEmail(email)) {
+    badRequest(res, 'Valid work email is required.');
+    return;
+  }
+
+  if (!environment) {
+    badRequest(res, 'Environment is required.');
+    return;
+  }
+
+  const payload = {
+    email,
+    environment,
+    company: body.company?.trim() || undefined,
+    challenge: body.challenge?.trim() || undefined,
+    source: body.source?.trim() || 'unknown',
+    page_path: body.page_path?.trim() || '/',
+    captured_at: new Date().toISOString()
+  };
+
+  const webhook = process.env.LEAD_WEBHOOK_URL?.trim();
+
+  if (webhook) {
+    try {
+      const forward = await fetch(webhook, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      if (!forward.ok) {
+        res.status(502).json({ error: 'Lead forwarding failed.' });
+        return;
+      }
+    } catch {
+      res.status(502).json({ error: 'Lead forwarding failed.' });
+      return;
+    }
+  }
+
+  res.status(202).json({ status: 'accepted' });
+}

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -10,7 +10,7 @@ describe('App', () => {
     expect(
       screen.getByRole('heading', {
         level: 1,
-        name: 'Identify risky AWS IAM, Kubernetes, and GitHub trust paths before attackers use them.'
+        name: 'See risky machine trust paths before attackers do.'
       })
     ).toBeInTheDocument();
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1276,12 +1276,8 @@ function HomePage() {
             <p className="idt-eyebrow">Machine identity security</p>
             <h1>See risky machine trust paths before attackers do.</h1>
             <p className="idt-lead">
-              Identrail maps AWS, Kubernetes, and GitHub identity paths so your team can reduce blast radius safely.
+              Map AWS IAM, Kubernetes, and GitHub identity paths. Prioritize blast radius, then roll out safer access without breaking production.
             </p>
-            <ul className="idt-hero-points" aria-label="What Identrail does">
-              <li>Map machine identities and trust relationships across cloud and clusters.</li>
-              <li>Simulate policy changes before rollout to avoid production breakage.</li>
-            </ul>
             <div className="idt-inline-actions" data-ab-slot="hero_primary_cta">
               <a href="#risk-scan-form" className="idt-btn idt-btn-primary">
                 Start Free Risk Scan
@@ -1290,32 +1286,29 @@ function HomePage() {
                 Book Demo
               </Link>
             </div>
-            <p className="idt-inline-link-note">
-              Need self-hosted first?{' '}
-              <SafeLink href={GITHUB_REPO} className="idt-inline-link">
-                View Open Source on GitHub
-              </SafeLink>
-            </p>
-            <div className="idt-kpi-row">
-              <article>
-                <strong>87%</strong>
-                <span>Average high-risk trust path reduction</span>
-              </article>
-              <article>
-                <strong>&lt; 15 min</strong>
-                <span>Time to first trust graph in hosted SaaS</span>
-              </article>
-              <article>
-                <strong>3x faster</strong>
-                <span>Identity triage for cloud security and platform teams</span>
-              </article>
-            </div>
           </div>
           <TrustGraphHeroVisual />
         </div>
       </section>
 
       <HomeCredibilityStrip />
+
+      <section className="idt-section idt-shell idt-impact-strip" aria-label="Impact snapshot">
+        <div className="idt-kpi-row">
+          <article>
+            <strong>87%</strong>
+            <span>Average high-risk trust path reduction</span>
+          </article>
+          <article>
+            <strong>&lt; 15 min</strong>
+            <span>Time to first trust graph in hosted SaaS</span>
+          </article>
+          <article>
+            <strong>3x faster</strong>
+            <span>Identity triage for cloud security and platform teams</span>
+          </article>
+        </div>
+      </section>
 
       <section className="idt-section idt-shell">
         <SectionTitle

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -199,27 +199,6 @@ const DOC_ENTRIES: DocEntry[] = [
   }
 ];
 
-const SOCIAL_QUOTES = [
-  {
-    quote:
-      'Identrail mapped over 12,000 machine trust paths in week one and gave us a clear remediation queue.',
-    name: 'Principal Cloud Security Engineer',
-    company: 'Global Payments Company'
-  },
-  {
-    quote:
-      'We reduced privileged service account risk by 87% without breaking production rollouts.',
-    name: 'Director of Platform Security',
-    company: 'Enterprise SaaS Provider'
-  },
-  {
-    quote:
-      'The open-core model let us self-host quickly while preparing enterprise controls for procurement.',
-    name: 'VP Security Engineering',
-    company: 'Large Healthcare Network'
-  }
-] as const;
-
 const DIFFERENTIATION_ROWS = [
   {
     area: 'Core Platform Access',
@@ -1194,38 +1173,20 @@ function XIcon() {
 
 function Footer() {
   const footerLinks = [
+    { to: '/product', label: 'Product' },
     { to: '/solutions', label: 'Solutions' },
     { to: '/pricing', label: 'Pricing' },
     { to: '/demo', label: 'Demo' },
     { to: '/docs', label: 'Docs' },
     { to: '/blog', label: 'Blog' },
+    { to: '/security', label: 'Security' },
+    { to: '/about', label: 'About' },
     { to: '/privacy', label: 'Privacy' },
     { to: '/terms', label: 'Terms' }
   ] as const;
 
   return (
     <footer className="idt-footer">
-      <section className="idt-footer-showcase">
-        <div className="idt-shell">
-          <h2>Benefits</h2>
-          <div className="idt-benefits-row">
-            <span>Fast OSS Start</span>
-            <span>Enterprise-Ready Controls</span>
-            <span>Trust Graph Clarity</span>
-            <span>Safer Rollouts</span>
-          </div>
-          <p>
-            Start with the open-core platform, prove value quickly, and move to hosted or enterprise deployment without re-platforming.
-          </p>
-          <div className="idt-footer-cta-row">
-            <Link to="/pricing" className="idt-footer-super-cta">
-              <span>Start Free Risk Scan</span>
-              <small>Try hosted SaaS or choose enterprise rollout</small>
-            </Link>
-          </div>
-        </div>
-      </section>
-
       <div className="idt-footer-bar">
         <div className="idt-shell idt-footer-bar-row">
           <nav className="idt-footer-links" aria-label="Footer">
@@ -1316,7 +1277,7 @@ function HomePage() {
           title="Machine identity risk is hard to control when trust data is fragmented"
           body="Security and platform teams need one view across AWS IAM, Kubernetes RBAC, OIDC relationships, and GitHub/GitOps workflows to understand real exposure."
         />
-        <div className="idt-card-grid three-col">
+        <div className="idt-card-grid two-col">
           <article className="idt-card">
             <h3>What Identrail does</h3>
             <p>Discovers machine identity trust paths and shows where risky access actually exists.</p>
@@ -1324,10 +1285,6 @@ function HomePage() {
           <article className="idt-card">
             <h3>Why it matters</h3>
             <p>Hidden trust chains can turn one compromised workload into broad production access.</p>
-          </article>
-          <article className="idt-card">
-            <h3>What teams do next</h3>
-            <p>Prioritize high-impact paths and reduce overprivileged access with policy simulation.</p>
           </article>
         </div>
       </section>
@@ -1393,23 +1350,6 @@ function HomePage() {
               ))}
             </tbody>
           </table>
-        </div>
-      </section>
-
-      <section className="idt-section idt-shell">
-        <SectionTitle
-          eyebrow="Early User Signals"
-          title="Initial feedback from design-partner cloud teams"
-          body="Placeholders shown until public case studies and named customer logos are published."
-        />
-        <div className="idt-quote-row" role="list">
-          {SOCIAL_QUOTES.map((quote) => (
-            <article key={quote.quote} className="idt-quote-card" role="listitem">
-              <p>{quote.quote}</p>
-              <strong>{quote.name}</strong>
-              <span>{quote.company}</span>
-            </article>
-          ))}
         </div>
       </section>
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -46,10 +46,12 @@ const X_URL = 'https://x.com/identrail';
 const CALENDLY_URL = 'https://calendly.com/identrail/15min';
 
 const NAV_LINKS = [
+  { to: '/product', label: 'Product' },
   { to: '/solutions', label: 'Solutions' },
   { to: '/pricing', label: 'Pricing' },
   { to: '/demo', label: 'Demo' },
   { to: '/docs', label: 'Docs' },
+  { to: '/security', label: 'Security' },
   { to: '/blog', label: 'Blog' }
 ] as const;
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { BrowserRouter, Link, NavLink, Route, Routes, useLocation } from 'react-router-dom';
 import { SafeLink } from './components/SafeLink';
+import { apiClient } from './api/client';
 
 type SeoConfig = {
   title: string;
@@ -611,10 +612,38 @@ function LeadCaptureForm({
   variant?: 'full' | 'short';
 }) {
   const [submitted, setSubmitted] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setSubmitted(true);
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+    const email = String(formData.get('email') ?? '').trim();
+    const environment = String(formData.get('environment') ?? '').trim();
+    const company = String(formData.get('company') ?? '').trim();
+    const challenge = String(formData.get('challenge') ?? '').trim();
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      await apiClient.submitLeadCapture({
+        email,
+        environment,
+        company: company || undefined,
+        challenge: challenge || undefined,
+        source: title,
+        page_path: window.location.pathname
+      });
+      setSubmitted(true);
+      form.reset();
+    } catch (submissionError) {
+      const message = submissionError instanceof Error ? submissionError.message : 'Unable to submit request.';
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -655,9 +684,10 @@ function LeadCaptureForm({
               </label>
             </>
           ) : null}
-          <button type="submit" className="idt-btn idt-btn-primary">
-            {ctaLabel}
+          <button type="submit" className="idt-btn idt-btn-primary" disabled={submitting}>
+            {submitting ? 'Submitting...' : ctaLabel}
           </button>
+          {error ? <p className="idt-form-error">{error} If urgent, use Book Demo.</p> : null}
           <p className="idt-form-note">Receive a practical 30-day machine identity risk reduction plan.</p>
         </form>
       ) : (

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -87,6 +87,15 @@ export type RequestAuthContext = {
 
 export type FindingLifecycleStatus = 'open' | 'ack' | 'suppressed' | 'resolved';
 
+export type LeadCapturePayload = {
+  email: string;
+  environment: string;
+  company?: string;
+  challenge?: string;
+  source: string;
+  page_path: string;
+};
+
 export type FindingTriage = {
   status: FindingLifecycleStatus;
   assignee?: string;
@@ -115,8 +124,9 @@ export type FindingTriageRequest = {
   comment?: string;
 };
 
-const configuredURL = import.meta.env.VITE_IDENTRAIL_API_URL as string | undefined;
-if (import.meta.env.PROD) {
+const viteEnv = ((import.meta as ImportMeta & { env?: Record<string, string> }).env ?? {}) as Record<string, string>;
+const configuredURL = viteEnv.VITE_IDENTRAIL_API_URL;
+if (viteEnv.PROD === 'true') {
   if (!configuredURL) {
     throw new Error('VITE_IDENTRAIL_API_URL must be set in production builds');
   }
@@ -267,6 +277,26 @@ export const apiClient = {
       })}`,
       auth
     );
+  },
+  async submitLeadCapture(payload: LeadCapturePayload) {
+    const res = await fetch('/api/leads', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    if (!res.ok) {
+      let message = 'Unable to submit lead request right now.';
+      try {
+        const data = (await res.json()) as { error?: string };
+        if (data?.error) {
+          message = data.error;
+        }
+      } catch {
+        // Keep generic message when API body is unavailable.
+      }
+      throw new Error(message);
+    }
+    return (await res.json()) as { status: string };
   }
 };
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -357,6 +357,14 @@ h3 {
   gap: 0.8rem;
 }
 
+.idt-impact-strip {
+  padding-top: clamp(1.3rem, 3vw, 2.2rem);
+}
+
+.idt-impact-strip .idt-kpi-row {
+  margin-top: 0;
+}
+
 .idt-kpi-row article {
   border: 1px solid var(--idt-line);
   background: rgba(12, 12, 14, 0.9);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -177,6 +177,12 @@ a {
   transform: translateY(-1px);
 }
 
+.idt-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  transform: none;
+}
+
 .idt-btn-primary {
   background: var(--idt-cta);
   color: #030303;
@@ -960,6 +966,12 @@ h3 {
   margin: 0;
   color: #9ca8bf;
   font-size: 0.8rem;
+}
+
+.idt-form-error {
+  margin: 0;
+  color: #ffb4b1;
+  font-size: 0.85rem;
 }
 
 .idt-form-success {


### PR DESCRIPTION
Connects lead forms to /api/leads with submit/error states and webhook forwarding support.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lead forms now submit to `/api/leads` with validation, submit/error states, and optional webhook forwarding. This connects marketing forms to the backend and surfaces clear errors to users.

- **New Features**
  - Added `/api/leads` POST endpoint: validates email and environment, forwards to `LEAD_WEBHOOK_URL` when set, returns 202 on accept and 4xx/5xx on errors.
  - Wired `LeadCaptureForm` to `apiClient.submitLeadCapture`: disables the button with “Submitting…”, shows API error text, and resets the form on success.
  - Added styles for disabled buttons and form error messages.

- **Refactors**
  - `apiClient`: added `submitLeadCapture` and updated Vite env handling (enforce `VITE_IDENTRAIL_API_URL` only when `PROD === 'true'`).

<sup>Written for commit 50a318554e9f68da29a7e0ccde66608347dfd50e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

