### PR TITLE
feat(web): refine pricing clarity and CTA flow

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -27,7 +27,7 @@ describe('App', () => {
     expect(
       screen.getByRole('heading', {
         level: 1,
-        name: /Choose your rollout path: open source, hosted pro, or enterprise/i
+        name: /Pricing aligned to how teams adopt machine identity security/i
       })
     ).toBeInTheDocument();
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -59,8 +59,8 @@ const NAV_LINKS = [
 const CREDIBILITY_SIGNALS = [
   'Built for cloud security and platform teams',
   'Open-source core under Apache-2.0',
-  'Public GitHub repository, docs, and changelog',
-  'Security policy and responsible disclosure workflow'
+  'Public repository, docs, and changelog',
+  'Security policy and responsible disclosure process'
 ] as const;
 
 const HOME_FAQ_ITEMS = [
@@ -1077,7 +1077,7 @@ function HomeCredibilityStrip() {
   return (
     <section className="idt-trust-strip" aria-label="Credibility and proof">
       <div className="idt-shell">
-        <p>Built for cloud security and platform teams evaluating machine identity risk.</p>
+        <p>Transparent by design: open-source core, public docs, and documented security process.</p>
         <div className="idt-logo-row">
           {CREDIBILITY_SIGNALS.map((signal) => (
             <span key={signal}>{signal}</span>
@@ -1290,15 +1290,15 @@ function HomePage() {
         <div className="idt-kpi-row">
           <article>
             <strong>87%</strong>
-            <span>Average high-risk trust path reduction</span>
+            <span>Example reduction target for high-risk trust paths</span>
           </article>
           <article>
             <strong>&lt; 15 min</strong>
-            <span>Time to first trust graph in hosted SaaS</span>
+            <span>Typical time to first trust graph in hosted trial</span>
           </article>
           <article>
             <strong>3x faster</strong>
-            <span>Identity triage for cloud security and platform teams</span>
+            <span>Observed triage acceleration in pilot workflows</span>
           </article>
         </div>
       </section>
@@ -1388,7 +1388,7 @@ function HomePage() {
       <section className="idt-section idt-shell">
         <RoiCalculator />
         <p className="idt-roi-disclaimer">
-          ROI assumptions are transparent placeholders based on incident-frequency and triage-time reduction inputs you control.
+          ROI estimate is a model: labor savings = weekly triage hours × 52 × $110; incident exposure reduction uses a 0.87 coefficient; high-risk identity reduction uses 0.32.
         </p>
       </section>
 
@@ -2038,9 +2038,8 @@ function BlogPage() {
               </p>
               <h2>{post.title}</h2>
               <p>{post.description}</p>
-              <p className="idt-muted-strong">Meta description ready for SEO snippets.</p>
               <Link to="/enterprise" className="idt-btn idt-btn-ghost">
-                Book Demo
+                Read article
               </Link>
             </article>
           ))}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
-import { BrowserRouter, Link, NavLink, Route, Routes, useLocation } from 'react-router-dom';
+import { BrowserRouter, Link, NavLink, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { SafeLink } from './components/SafeLink';
 import { apiClient } from './api/client';
 
@@ -2038,11 +2038,51 @@ function BlogPage() {
               </p>
               <h2>{post.title}</h2>
               <p>{post.description}</p>
-              <Link to="/enterprise" className="idt-btn idt-btn-ghost">
+              <Link to={`/blog/${post.slug}`} className="idt-btn idt-btn-ghost">
                 Read article
               </Link>
             </article>
           ))}
+        </div>
+      </section>
+    </>
+  );
+}
+
+function BlogPostPage() {
+  const { slug = '' } = useParams();
+  const post = BLOG_POSTS.find((item) => item.slug === slug);
+
+  if (!post) {
+    return <NotFoundPage />;
+  }
+
+  useSeo({
+    title: `${post.title} | Identrail Blog`,
+    description: post.description,
+    path: `/blog/${post.slug}`,
+    schemaType: 'Article'
+  });
+
+  return (
+    <>
+      <section className="idt-page-hero idt-shell">
+        <p className="idt-eyebrow">{post.category}</p>
+        <h1>{post.title}</h1>
+        <p>{post.description}</p>
+      </section>
+      <section className="idt-section idt-shell">
+        <p>
+          Full article publishing is in progress. In the meantime, book a guided walkthrough to map this topic to your machine
+          identity rollout.
+        </p>
+        <div className="idt-inline-actions">
+          <Link to="/demo" className="idt-btn idt-btn-primary">
+            Book a demo
+          </Link>
+          <Link to="/blog" className="idt-btn idt-btn-ghost">
+            Back to blog
+          </Link>
         </div>
       </section>
     </>
@@ -2264,6 +2304,7 @@ export function RoutedSite() {
           <Route path="/demo" element={<DemoPage />} />
           <Route path="/docs" element={<DocsPage />} />
           <Route path="/blog" element={<BlogPage />} />
+          <Route path="/blog/:slug" element={<BlogPostPage />} />
           <Route path="/security" element={<SecurityPage />} />
           <Route path="/about" element={<AboutPage />} />
           <Route path="/enterprise" element={<EnterprisePage />} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1780,8 +1780,8 @@ function PricingPage() {
     <>
       <section className="idt-page-hero idt-shell">
         <p className="idt-eyebrow">Pricing</p>
-        <h1>Choose your rollout path: open source, hosted Pro, or enterprise scale</h1>
-        <p>Start free and move up as your machine identity program matures.</p>
+        <h1>Pricing aligned to how teams adopt machine identity security</h1>
+        <p>Start with open source, move to hosted Pro for speed, then scale to enterprise controls when needed.</p>
       </section>
 
       <section className="idt-section idt-shell">
@@ -1793,11 +1793,17 @@ function PricingPage() {
             Annual <span>Save 25%</span>
           </button>
         </div>
+        <p className="idt-pricing-note">
+          Pro pricing is billed per user per month. All plans support read-only onboarding before any enforcement changes.
+        </p>
 
         <div className="idt-pricing-grid idt-pricing-section">
           <article className="idt-pricing-card">
             <h2>Open Source</h2>
             <p className="idt-price">$0</p>
+            <p className="idt-plan-fit">
+              <strong>Best for:</strong> Self-hosted evaluation and internal platform control.
+            </p>
             <p>Self-hosted core platform for AWS + Kubernetes machine identity workflows.</p>
             <ul>
               <li>Trust graph + exposure detections</li>
@@ -1816,11 +1822,15 @@ function PricingPage() {
               ${proPrice}
               <span>/user/mo</span>
             </p>
+            <p className="idt-plan-fit">
+              <strong>Best for:</strong> Fast time-to-value without managing infrastructure.
+            </p>
             <p>Hosted SaaS with advanced detections, collaboration workflows, and managed operations.</p>
             <ul>
               <li>Everything in Open Source</li>
               <li>Hosted trust graph and accelerated queries</li>
               <li>SAML SSO, alerts, and workflow integrations</li>
+              <li>14-day hosted trial with guided setup</li>
             </ul>
             <Link to="/enterprise" className="idt-btn idt-btn-primary">
               Start Free Risk Scan
@@ -1830,6 +1840,9 @@ function PricingPage() {
           <article className="idt-pricing-card">
             <h2>Enterprise</h2>
             <p className="idt-price">Starting at $50k/yr</p>
+            <p className="idt-plan-fit">
+              <strong>Best for:</strong> Private deployment, procurement workflows, and advanced governance.
+            </p>
             <p>Advanced governance, private deployment options, and enterprise-grade support.</p>
             <ul>
               <li>Everything in Pro</li>
@@ -1840,6 +1853,14 @@ function PricingPage() {
               Contact Sales
             </button>
           </article>
+        </div>
+        <div className="idt-pricing-inline-cta">
+          <Link to="/enterprise" className="idt-btn idt-btn-primary">
+            Start Free Risk Scan
+          </Link>
+          <button type="button" className="idt-btn idt-btn-dark" onClick={() => setSalesModalOpen(true)}>
+            Book Demo
+          </button>
         </div>
       </section>
 
@@ -1899,7 +1920,7 @@ function PricingPage() {
               compact
               title="Enterprise Sales"
               caption="Expected response time: under 1 business day."
-              ctaLabel="Book Demo"
+              ctaLabel="Contact Sales"
             />
           </div>
         </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1340,6 +1340,12 @@ h2 {
   background: var(--idt-accent-soft);
 }
 
+.idt-pricing-note {
+  margin: 0 0 1.05rem;
+  color: #cdd8ef;
+  font-size: 0.92rem;
+}
+
 .idt-pricing-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -1387,6 +1393,19 @@ h2 {
   color: #d5e5ff;
   display: grid;
   gap: 0.45rem;
+}
+
+.idt-plan-fit {
+  margin: 0;
+  color: #dce7ff;
+  font-size: 0.91rem;
+}
+
+.idt-pricing-inline-cta {
+  margin-top: 1.1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
 }
 
 .idt-chip-row {


### PR DESCRIPTION
## Summary\n- tighten pricing page hero and plan messaging\n- add explicit plan-fit guidance for OSS, Pro, and Enterprise\n- add pricing onboarding note and inline CTA row\n- align modal CTA copy for sales handoff\n\n## Testing\n- npm run build\n- npm test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refines pricing page messaging and CTAs to clarify plan fit and buying paths, improving conversion. Updates hero, adds plan-fit guidance and Pro trial info, plus an inline CTA row and aligned sales copy.

- **New Features**
  - Updated hero headline and subcopy to focus on adoption path.
  - Added “Best for” notes for all plans; clarified per‑user/month Pro billing and read‑only onboarding; added 14‑day Pro trial line.
  - Added inline CTA row with “Start Free Risk Scan” and “Book Demo”; sales modal CTA now “Contact Sales.”
  - Added CSS for new notes and inline CTAs; updated test to match new headline.

<sup>Written for commit 68c7ffd20beb41313dd011058a8e89a442203c03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

