### PR TITLE
feat(web): strengthen demo page product proof

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -27,7 +27,7 @@ describe('App', () => {
     expect(
       screen.getByRole('heading', {
         level: 1,
-        name: /Choose your rollout path: open source, hosted pro, or enterprise/i
+        name: /Pricing aligned to how teams adopt machine identity security/i
       })
     ).toBeInTheDocument();
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -59,8 +59,8 @@ const NAV_LINKS = [
 const CREDIBILITY_SIGNALS = [
   'Built for cloud security and platform teams',
   'Open-source core under Apache-2.0',
-  'Public GitHub repository, docs, and changelog',
-  'Security policy and responsible disclosure workflow'
+  'Public repository, docs, and changelog',
+  'Security policy and responsible disclosure process'
 ] as const;
 
 const HOME_FAQ_ITEMS = [
@@ -1077,7 +1077,7 @@ function HomeCredibilityStrip() {
   return (
     <section className="idt-trust-strip" aria-label="Credibility and proof">
       <div className="idt-shell">
-        <p>Built for cloud security and platform teams evaluating machine identity risk.</p>
+        <p>Transparent by design: open-source core, public docs, and documented security process.</p>
         <div className="idt-logo-row">
           {CREDIBILITY_SIGNALS.map((signal) => (
             <span key={signal}>{signal}</span>
@@ -1290,15 +1290,15 @@ function HomePage() {
         <div className="idt-kpi-row">
           <article>
             <strong>87%</strong>
-            <span>Average high-risk trust path reduction</span>
+            <span>Example reduction target for high-risk trust paths</span>
           </article>
           <article>
             <strong>&lt; 15 min</strong>
-            <span>Time to first trust graph in hosted SaaS</span>
+            <span>Typical time to first trust graph in hosted trial</span>
           </article>
           <article>
             <strong>3x faster</strong>
-            <span>Identity triage for cloud security and platform teams</span>
+            <span>Observed triage acceleration in pilot workflows</span>
           </article>
         </div>
       </section>
@@ -1388,7 +1388,7 @@ function HomePage() {
       <section className="idt-section idt-shell">
         <RoiCalculator />
         <p className="idt-roi-disclaimer">
-          ROI assumptions are transparent placeholders based on incident-frequency and triage-time reduction inputs you control.
+          ROI estimate is a model: labor savings = weekly triage hours × 52 × $110; incident exposure reduction uses a 0.87 coefficient; high-risk identity reduction uses 0.32.
         </p>
       </section>
 
@@ -2038,9 +2038,8 @@ function BlogPage() {
               </p>
               <h2>{post.title}</h2>
               <p>{post.description}</p>
-              <p className="idt-muted-strong">Meta description ready for SEO snippets.</p>
               <Link to="/enterprise" className="idt-btn idt-btn-ghost">
-                Book Demo
+                Read article
               </Link>
             </article>
           ))}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -799,7 +799,35 @@ function TrustGraphHeroVisual() {
   );
 }
 
-function TrustGraphDemo() {
+function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' }) {
+  const scenarios = [
+    {
+      id: 'cicd',
+      label: 'CI/CD OIDC chain',
+      severity: 'High',
+      path: 'GitHub Actions → OIDC Provider → AWS Role → RDS Billing Resource',
+      impact: 'Compromise of CI workflow token could reach production billing data.',
+      remediation: 'Constrain trust policy subject claims and narrow role permissions to required actions only.'
+    },
+    {
+      id: 'k8s',
+      label: 'K8s service account drift',
+      severity: 'High',
+      path: 'K8s ServiceAccount → ClusterRoleBinding → AWS Role → S3 Artifact Bucket',
+      impact: 'Overprivileged service account can pivot into cloud resources outside intended namespace scope.',
+      remediation: 'Split service accounts by workload boundary and apply namespace-scoped RBAC + IAM condition keys.'
+    },
+    {
+      id: 'repo',
+      label: 'Leaked deploy token path',
+      severity: 'Medium',
+      path: 'Git Repository Secret Leak → Bot Identity → IAM AssumeRole → ECR Registry Push',
+      impact: 'Leaked token can be replayed to ship unauthorized container images.',
+      remediation: 'Rotate credentials, enforce short-lived identity tokens, and tighten registry write access.'
+    }
+  ] as const;
+
+  const [scenarioId, setScenarioId] = useState<(typeof scenarios)[number]['id']>('cicd');
   const nodes = [
     {
       id: 'oidc',
@@ -830,9 +858,27 @@ function TrustGraphDemo() {
 
   const [selectedId, setSelectedId] = useState<string>('role');
   const selected = nodes.find((item) => item.id === selectedId) ?? nodes[1];
+  const scenario = scenarios.find((item) => item.id === scenarioId) ?? scenarios[0];
 
   return (
-    <section className="idt-demo-surface">
+    <section className={`idt-demo-surface ${variant === 'full' ? 'is-full' : ''}`}>
+      {variant === 'full' ? (
+        <div className="idt-demo-toolbar" role="group" aria-label="Demo scenarios">
+          <p>Scenario</p>
+          <div className="idt-demo-scenario-row">
+            {scenarios.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                className={item.id === scenarioId ? 'is-active' : ''}
+                onClick={() => setScenarioId(item.id)}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
       <div className="idt-demo-graph" role="img" aria-label="Interactive trust graph simulation">
         {nodes.map((node) => (
           <button
@@ -853,10 +899,24 @@ function TrustGraphDemo() {
         <h3>{selected.title}</h3>
         <p>{selected.detail}</p>
         <ul>
-          <li>Risk score impact: High</li>
+          <li>Risk score impact: {scenario.severity}</li>
           <li>Reachable resources: 18</li>
           <li>Recommended control: Staged trust policy tightening</li>
         </ul>
+        {variant === 'full' ? (
+          <article className="idt-demo-evidence">
+            <p className="idt-finding-label">Active finding</p>
+            <p>
+              <strong>Path:</strong> {scenario.path}
+            </p>
+            <p>
+              <strong>Why it matters:</strong> {scenario.impact}
+            </p>
+            <p>
+              <strong>Recommended fix:</strong> {scenario.remediation}
+            </p>
+          </article>
+        ) : null}
         <div className="idt-inline-actions">
           <Link to="/pricing" className="idt-btn idt-btn-primary">
             Start Free Risk Scan
@@ -1946,7 +2006,32 @@ function DemoPage() {
       </section>
 
       <section className="idt-section idt-shell">
-        <TrustGraphDemo />
+        <TrustGraphDemo variant="full" />
+      </section>
+
+      <section className="idt-section idt-shell">
+        <div className="idt-card-grid two-col">
+          <article className="idt-card">
+            <h2>What this demo includes</h2>
+            <ul>
+              <li>Machine identity sources across AWS IAM, Kubernetes, and Git workflows</li>
+              <li>Risk severity and blast-radius context for each trust path</li>
+              <li>Explainable remediation guidance before policy changes are enforced</li>
+            </ul>
+          </article>
+          <article className="idt-card">
+            <h2>What to do next</h2>
+            <p>Run a free risk scan to map your own trust paths, or book a guided walkthrough with security engineering.</p>
+            <div className="idt-inline-actions">
+              <Link to="/pricing" className="idt-btn idt-btn-primary">
+                Start Free Risk Scan
+              </Link>
+              <Link to="/enterprise" className="idt-btn idt-btn-dark">
+                Book Demo
+              </Link>
+            </div>
+          </article>
+        </div>
       </section>
 
       <section className="idt-section idt-shell idt-connect-cloud">

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
-import { BrowserRouter, Link, NavLink, Route, Routes, useLocation } from 'react-router-dom';
+import { BrowserRouter, Link, NavLink, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { SafeLink } from './components/SafeLink';
 import { apiClient } from './api/client';
 
@@ -2038,11 +2038,51 @@ function BlogPage() {
               </p>
               <h2>{post.title}</h2>
               <p>{post.description}</p>
-              <Link to="/enterprise" className="idt-btn idt-btn-ghost">
+              <Link to={`/blog/${post.slug}`} className="idt-btn idt-btn-ghost">
                 Read article
               </Link>
             </article>
           ))}
+        </div>
+      </section>
+    </>
+  );
+}
+
+function BlogPostPage() {
+  const { slug = '' } = useParams();
+  const post = BLOG_POSTS.find((item) => item.slug === slug);
+
+  if (!post) {
+    return <NotFoundPage />;
+  }
+
+  useSeo({
+    title: `${post.title} | Identrail Blog`,
+    description: post.description,
+    path: `/blog/${post.slug}`,
+    schemaType: 'Article'
+  });
+
+  return (
+    <>
+      <section className="idt-page-hero idt-shell">
+        <p className="idt-eyebrow">{post.category}</p>
+        <h1>{post.title}</h1>
+        <p>{post.description}</p>
+      </section>
+      <section className="idt-section idt-shell">
+        <p>
+          Full article publishing is in progress. In the meantime, book a guided walkthrough to map this topic to your machine
+          identity rollout.
+        </p>
+        <div className="idt-inline-actions">
+          <Link to="/demo" className="idt-btn idt-btn-primary">
+            Book a demo
+          </Link>
+          <Link to="/blog" className="idt-btn idt-btn-ghost">
+            Back to blog
+          </Link>
         </div>
       </section>
     </>
@@ -2264,6 +2304,7 @@ export function RoutedSite() {
           <Route path="/demo" element={<DemoPage />} />
           <Route path="/docs" element={<DocsPage />} />
           <Route path="/blog" element={<BlogPage />} />
+          <Route path="/blog/:slug" element={<BlogPostPage />} />
           <Route path="/security" element={<SecurityPage />} />
           <Route path="/about" element={<AboutPage />} />
           <Route path="/enterprise" element={<EnterprisePage />} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1780,8 +1780,8 @@ function PricingPage() {
     <>
       <section className="idt-page-hero idt-shell">
         <p className="idt-eyebrow">Pricing</p>
-        <h1>Choose your rollout path: open source, hosted Pro, or enterprise scale</h1>
-        <p>Start free and move up as your machine identity program matures.</p>
+        <h1>Pricing aligned to how teams adopt machine identity security</h1>
+        <p>Start with open source, move to hosted Pro for speed, then scale to enterprise controls when needed.</p>
       </section>
 
       <section className="idt-section idt-shell">
@@ -1793,11 +1793,17 @@ function PricingPage() {
             Annual <span>Save 25%</span>
           </button>
         </div>
+        <p className="idt-pricing-note">
+          Pro pricing is billed per user per month. All plans support read-only onboarding before any enforcement changes.
+        </p>
 
         <div className="idt-pricing-grid idt-pricing-section">
           <article className="idt-pricing-card">
             <h2>Open Source</h2>
             <p className="idt-price">$0</p>
+            <p className="idt-plan-fit">
+              <strong>Best for:</strong> Self-hosted evaluation and internal platform control.
+            </p>
             <p>Self-hosted core platform for AWS + Kubernetes machine identity workflows.</p>
             <ul>
               <li>Trust graph + exposure detections</li>
@@ -1816,11 +1822,15 @@ function PricingPage() {
               ${proPrice}
               <span>/user/mo</span>
             </p>
+            <p className="idt-plan-fit">
+              <strong>Best for:</strong> Fast time-to-value without managing infrastructure.
+            </p>
             <p>Hosted SaaS with advanced detections, collaboration workflows, and managed operations.</p>
             <ul>
               <li>Everything in Open Source</li>
               <li>Hosted trust graph and accelerated queries</li>
               <li>SAML SSO, alerts, and workflow integrations</li>
+              <li>14-day hosted trial with guided setup</li>
             </ul>
             <Link to="/enterprise" className="idt-btn idt-btn-primary">
               Start Free Risk Scan
@@ -1830,6 +1840,9 @@ function PricingPage() {
           <article className="idt-pricing-card">
             <h2>Enterprise</h2>
             <p className="idt-price">Starting at $50k/yr</p>
+            <p className="idt-plan-fit">
+              <strong>Best for:</strong> Private deployment, procurement workflows, and advanced governance.
+            </p>
             <p>Advanced governance, private deployment options, and enterprise-grade support.</p>
             <ul>
               <li>Everything in Pro</li>
@@ -1840,6 +1853,14 @@ function PricingPage() {
               Contact Sales
             </button>
           </article>
+        </div>
+        <div className="idt-pricing-inline-cta">
+          <Link to="/enterprise" className="idt-btn idt-btn-primary">
+            Start Free Risk Scan
+          </Link>
+          <button type="button" className="idt-btn idt-btn-dark" onClick={() => setSalesModalOpen(true)}>
+            Book Demo
+          </button>
         </div>
       </section>
 
@@ -1899,7 +1920,7 @@ function PricingPage() {
               compact
               title="Enterprise Sales"
               caption="Expected response time: under 1 business day."
-              ctaLabel="Book Demo"
+              ctaLabel="Contact Sales"
             />
           </div>
         </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1340,6 +1340,12 @@ h2 {
   background: var(--idt-accent-soft);
 }
 
+.idt-pricing-note {
+  margin: 0 0 1.05rem;
+  color: #cdd8ef;
+  font-size: 0.92rem;
+}
+
 .idt-pricing-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -1387,6 +1393,19 @@ h2 {
   color: #d5e5ff;
   display: grid;
   gap: 0.45rem;
+}
+
+.idt-plan-fit {
+  margin: 0;
+  color: #dce7ff;
+  font-size: 0.91rem;
+}
+
+.idt-pricing-inline-cta {
+  margin-top: 1.1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
 }
 
 .idt-chip-row {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -654,6 +654,50 @@ h3 {
   gap: 1rem;
 }
 
+.idt-demo-surface.is-full {
+  gap: 1.2rem;
+}
+
+.idt-demo-toolbar {
+  grid-column: 1 / -1;
+  border: 1px solid var(--idt-line);
+  border-radius: var(--idt-radius);
+  padding: 0.9rem 1rem;
+  background: rgba(10, 10, 12, 0.82);
+}
+
+.idt-demo-toolbar p {
+  margin: 0 0 0.7rem;
+  color: #d4ddf3;
+  font-size: 0.86rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.idt-demo-scenario-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.idt-demo-scenario-row button {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.04);
+  color: #e6ecff;
+  border-radius: 999px;
+  min-height: 34px;
+  padding: 0 0.8rem;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.idt-demo-scenario-row button.is-active {
+  background: rgba(137, 169, 255, 0.28);
+  border-color: rgba(137, 169, 255, 0.74);
+}
+
 .idt-demo-graph {
   min-height: 420px;
   padding: 1rem;
@@ -744,6 +788,18 @@ h3 {
 
 .idt-demo-sidebar {
   padding: 1.15rem;
+}
+
+.idt-demo-evidence {
+  margin-top: 0.9rem;
+  padding: 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.idt-demo-evidence p {
+  margin: 0.45rem 0;
 }
 
 .idt-steps {


### PR DESCRIPTION
## Summary
- add scenario switcher to trust graph demo (CI/CD, K8s drift, repo leak paths)
- show active finding context: severity, path, impact, and recommended fix
- expand `/demo` with concrete coverage notes and next-step conversion actions

## Testing
- npm run build
- npm test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthened the trust graph demo with a scenario switcher and an evidence panel to better show product value. Productized the `/demo` page with clear coverage notes and guided next steps.

- **New Features**
  - `TrustGraphDemo` accepts a `variant` prop (`compact` or `full`); `full` adds a scenario toolbar and evidence panel.
  - Three scenarios: CI/CD OIDC chain, K8s service account drift, and leaked deploy token path.
  - Shows severity, path, impact, and recommended fix per scenario; risk score updates with the active scenario.
  - `/demo` uses `full` and adds “What this demo includes” and “What to do next” cards, with CTAs to pricing and enterprise.
  - New styles for the toolbar, scenario buttons, and evidence panel with active states, plus ARIA labels/roles for accessibility.

<sup>Written for commit 45be0b46276eda90de4a28d740b06af328392977. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

