### PR TITLE
feat(web): harden accessibility and keyboard interactions

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { BrowserRouter, Link, NavLink, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { SafeLink } from './components/SafeLink';
 import { apiClient } from './api/client';
@@ -697,6 +697,80 @@ function LeadCaptureForm({
   );
 }
 
+function ModalShell({
+  titleId,
+  onClose,
+  children
+}: {
+  titleId: string;
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  const modalRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const getFocusableElements = () =>
+      modalRef.current?.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      ) ?? [];
+
+    getFocusableElements()[0]?.focus();
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+        return;
+      }
+
+      if (event.key !== 'Tab') {
+        return;
+      }
+
+      const focusableElements = getFocusableElements();
+      if (focusableElements.length === 0) {
+        return;
+      }
+
+      const first = focusableElements[0];
+      const last = focusableElements[focusableElements.length - 1];
+      const active = document.activeElement;
+
+      if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [onClose]);
+
+  return (
+    <div className="idt-modal-backdrop" role="presentation" onClick={onClose}>
+      <div
+        ref={modalRef}
+        className="idt-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        onClick={(event) => event.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
 function ExitIntentPopup() {
   const [open, setOpen] = useState(false);
   const dismissedRef = useRef(false);
@@ -738,22 +812,20 @@ function ExitIntentPopup() {
   if (!open) return null;
 
   return (
-    <div className="idt-modal-backdrop" role="presentation" onClick={close}>
-      <div className="idt-modal" role="dialog" aria-modal="true" aria-labelledby="exit-modal-title" onClick={(event) => event.stopPropagation()}>
-        <button className="idt-modal-close" type="button" onClick={close} aria-label="Close">
-          x
-        </button>
-        <h3 id="exit-modal-title">Before you leave: run a free machine identity risk scan</h3>
-        <p>Identify risky AWS IAM, Kubernetes, and GitHub trust paths before attackers use them.</p>
-        <LeadCaptureForm
-          compact
-          variant="short"
-          title="Start Free Risk Scan"
-          caption="No spam. One actionable plan for cloud identity blast radius reduction."
-          ctaLabel="Start Free Risk Scan"
-        />
-      </div>
-    </div>
+    <ModalShell titleId="exit-modal-title" onClose={close}>
+      <button className="idt-modal-close" type="button" onClick={close} aria-label="Close">
+        x
+      </button>
+      <h3 id="exit-modal-title">Before you leave: run a free machine identity risk scan</h3>
+      <p>Identify risky AWS IAM, Kubernetes, and GitHub trust paths before attackers use them.</p>
+      <LeadCaptureForm
+        compact
+        variant="short"
+        title="Start Free Risk Scan"
+        caption="No spam. One actionable plan for cloud identity blast radius reduction."
+        ctaLabel="Start Free Risk Scan"
+      />
+    </ModalShell>
   );
 }
 
@@ -1051,6 +1123,26 @@ function RoiCalculator() {
 
 function Header() {
   const [menuOpen, setMenuOpen] = useState(false);
+  const location = useLocation();
+
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [location.pathname]);
+
+  useEffect(() => {
+    if (!menuOpen) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [menuOpen]);
 
   return (
     <header className="idt-header">
@@ -1063,11 +1155,18 @@ function Header() {
           </span>
         </Link>
 
-        <button className="idt-menu-toggle" type="button" onClick={() => setMenuOpen((prev) => !prev)}>
+        <button
+          className="idt-menu-toggle"
+          type="button"
+          onClick={() => setMenuOpen((prev) => !prev)}
+          aria-expanded={menuOpen}
+          aria-controls="primary-nav"
+          aria-label="Toggle primary navigation"
+        >
           Menu
         </button>
 
-        <nav className={`idt-nav ${menuOpen ? 'is-open' : ''}`} aria-label="Primary">
+        <nav id="primary-nav" className={`idt-nav ${menuOpen ? 'is-open' : ''}`} aria-label="Primary">
           {NAV_LINKS.map((item) => (
             <NavLink
               key={item.to}
@@ -1964,26 +2063,24 @@ function PricingPage() {
       </section>
 
       {salesModalOpen ? (
-        <div className="idt-modal-backdrop" onClick={() => setSalesModalOpen(false)} role="presentation">
-          <div className="idt-modal" role="dialog" aria-modal="true" aria-labelledby="sales-modal-title" onClick={(event) => event.stopPropagation()}>
-            <button
-              type="button"
-              className="idt-modal-close"
-              aria-label="Close"
-              onClick={() => setSalesModalOpen(false)}
-            >
-              x
-            </button>
-            <h3 id="sales-modal-title">Contact Enterprise Sales</h3>
-            <p>Tell us your environment size and compliance goals. We will tailor a deployment and pricing plan.</p>
-            <LeadCaptureForm
-              compact
-              title="Enterprise Sales"
-              caption="Expected response time: under 1 business day."
-              ctaLabel="Contact Sales"
-            />
-          </div>
-        </div>
+        <ModalShell titleId="sales-modal-title" onClose={() => setSalesModalOpen(false)}>
+          <button
+            type="button"
+            className="idt-modal-close"
+            aria-label="Close"
+            onClick={() => setSalesModalOpen(false)}
+          >
+            x
+          </button>
+          <h3 id="sales-modal-title">Contact Enterprise Sales</h3>
+          <p>Tell us your environment size and compliance goals. We will tailor a deployment and pricing plan.</p>
+          <LeadCaptureForm
+            compact
+            title="Enterprise Sales"
+            caption="Expected response time: under 1 business day."
+            ctaLabel="Contact Sales"
+          />
+        </ModalShell>
       ) : null}
     </>
   );

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -45,6 +45,8 @@ const DISCORD_URL = 'https://discord.gg/7jSUSnQC';
 const LINKEDIN_URL = 'https://www.linkedin.com/company/identrail/';
 const X_URL = 'https://x.com/identrail';
 const CALENDLY_URL = 'https://calendly.com/identrail/15min';
+let activeModalLocks = 0;
+let bodyOverflowBeforeModal = '';
 
 const NAV_LINKS = [
   { to: '/product', label: 'Product' },
@@ -709,8 +711,11 @@ function ModalShell({
   const modalRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
+    if (activeModalLocks === 0) {
+      bodyOverflowBeforeModal = document.body.style.overflow;
+      document.body.style.overflow = 'hidden';
+    }
+    activeModalLocks += 1;
 
     const getFocusableElements = () =>
       modalRef.current?.querySelectorAll<HTMLElement>(
@@ -750,7 +755,10 @@ function ModalShell({
     document.addEventListener('keydown', onKeyDown);
 
     return () => {
-      document.body.style.overflow = previousOverflow;
+      activeModalLocks = Math.max(0, activeModalLocks - 1);
+      if (activeModalLocks === 0) {
+        document.body.style.overflow = bodyOverflowBeforeModal;
+      }
       document.removeEventListener('keydown', onKeyDown);
     };
   }, [onClose]);


### PR DESCRIPTION
## Summary
- add accessible mobile nav semantics (`aria-expanded`, `aria-controls`) and escape-to-close behavior
- auto-close mobile nav on route change to avoid stale open state
- add reusable modal shell with focus trap, escape handling, and body scroll lock
- migrate exit-intent and pricing sales modals to the shared accessible modal

## Testing
- npm run build
- npm test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves accessibility for the mobile nav and marketing modals with proper ARIA semantics and keyboard controls. Adds a reusable `ModalShell` with focus management to standardize modals and keep background scroll locked until all modals close.

- **New Features**
  - Added `ModalShell` with focus trap, initial focus, Escape-to-close, and multi-modal body scroll lock.
  - Migrated exit-intent and pricing sales modals to `ModalShell`.
  - Mobile nav: added `aria-expanded`, `aria-controls`, and label; Escape closes the menu; auto-closes on route change.

<sup>Written for commit e28b7df295daa157060e7e9c9f3a0b9bb9bf3ef4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

