### PR TITLE
refactor(web): clean app shell and content ownership

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -27,7 +27,7 @@ describe('App', () => {
     expect(
       screen.getByRole('heading', {
         level: 1,
-        name: /Choose your rollout path: open source, hosted pro, or enterprise/i
+        name: /Pricing aligned to how teams adopt machine identity security/i
       })
     ).toBeInTheDocument();
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { BrowserRouter, Link, NavLink, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { SafeLink } from './components/SafeLink';
 import { apiClient } from './api/client';
@@ -697,6 +697,80 @@ function LeadCaptureForm({
   );
 }
 
+function ModalShell({
+  titleId,
+  onClose,
+  children
+}: {
+  titleId: string;
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  const modalRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const getFocusableElements = () =>
+      modalRef.current?.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      ) ?? [];
+
+    getFocusableElements()[0]?.focus();
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+        return;
+      }
+
+      if (event.key !== 'Tab') {
+        return;
+      }
+
+      const focusableElements = getFocusableElements();
+      if (focusableElements.length === 0) {
+        return;
+      }
+
+      const first = focusableElements[0];
+      const last = focusableElements[focusableElements.length - 1];
+      const active = document.activeElement;
+
+      if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [onClose]);
+
+  return (
+    <div className="idt-modal-backdrop" role="presentation" onClick={onClose}>
+      <div
+        ref={modalRef}
+        className="idt-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        onClick={(event) => event.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
 function ExitIntentPopup() {
   const [open, setOpen] = useState(false);
   const dismissedRef = useRef(false);
@@ -738,22 +812,20 @@ function ExitIntentPopup() {
   if (!open) return null;
 
   return (
-    <div className="idt-modal-backdrop" role="presentation" onClick={close}>
-      <div className="idt-modal" role="dialog" aria-modal="true" aria-labelledby="exit-modal-title" onClick={(event) => event.stopPropagation()}>
-        <button className="idt-modal-close" type="button" onClick={close} aria-label="Close">
-          x
-        </button>
-        <h3 id="exit-modal-title">Before you leave: run a free machine identity risk scan</h3>
-        <p>Identify risky AWS IAM, Kubernetes, and GitHub trust paths before attackers use them.</p>
-        <LeadCaptureForm
-          compact
-          variant="short"
-          title="Start Free Risk Scan"
-          caption="No spam. One actionable plan for cloud identity blast radius reduction."
-          ctaLabel="Start Free Risk Scan"
-        />
-      </div>
-    </div>
+    <ModalShell titleId="exit-modal-title" onClose={close}>
+      <button className="idt-modal-close" type="button" onClick={close} aria-label="Close">
+        x
+      </button>
+      <h3 id="exit-modal-title">Before you leave: run a free machine identity risk scan</h3>
+      <p>Identify risky AWS IAM, Kubernetes, and GitHub trust paths before attackers use them.</p>
+      <LeadCaptureForm
+        compact
+        variant="short"
+        title="Start Free Risk Scan"
+        caption="No spam. One actionable plan for cloud identity blast radius reduction."
+        ctaLabel="Start Free Risk Scan"
+      />
+    </ModalShell>
   );
 }
 
@@ -1051,6 +1123,26 @@ function RoiCalculator() {
 
 function Header() {
   const [menuOpen, setMenuOpen] = useState(false);
+  const location = useLocation();
+
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [location.pathname]);
+
+  useEffect(() => {
+    if (!menuOpen) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [menuOpen]);
 
   return (
     <header className="idt-header">
@@ -1063,11 +1155,18 @@ function Header() {
           </span>
         </Link>
 
-        <button className="idt-menu-toggle" type="button" onClick={() => setMenuOpen((prev) => !prev)}>
+        <button
+          className="idt-menu-toggle"
+          type="button"
+          onClick={() => setMenuOpen((prev) => !prev)}
+          aria-expanded={menuOpen}
+          aria-controls="primary-nav"
+          aria-label="Toggle primary navigation"
+        >
           Menu
         </button>
 
-        <nav className={`idt-nav ${menuOpen ? 'is-open' : ''}`} aria-label="Primary">
+        <nav id="primary-nav" className={`idt-nav ${menuOpen ? 'is-open' : ''}`} aria-label="Primary">
           {NAV_LINKS.map((item) => (
             <NavLink
               key={item.to}
@@ -1964,26 +2063,24 @@ function PricingPage() {
       </section>
 
       {salesModalOpen ? (
-        <div className="idt-modal-backdrop" onClick={() => setSalesModalOpen(false)} role="presentation">
-          <div className="idt-modal" role="dialog" aria-modal="true" aria-labelledby="sales-modal-title" onClick={(event) => event.stopPropagation()}>
-            <button
-              type="button"
-              className="idt-modal-close"
-              aria-label="Close"
-              onClick={() => setSalesModalOpen(false)}
-            >
-              x
-            </button>
-            <h3 id="sales-modal-title">Contact Enterprise Sales</h3>
-            <p>Tell us your environment size and compliance goals. We will tailor a deployment and pricing plan.</p>
-            <LeadCaptureForm
-              compact
-              title="Enterprise Sales"
-              caption="Expected response time: under 1 business day."
-              ctaLabel="Contact Sales"
-            />
-          </div>
-        </div>
+        <ModalShell titleId="sales-modal-title" onClose={() => setSalesModalOpen(false)}>
+          <button
+            type="button"
+            className="idt-modal-close"
+            aria-label="Close"
+            onClick={() => setSalesModalOpen(false)}
+          >
+            x
+          </button>
+          <h3 id="sales-modal-title">Contact Enterprise Sales</h3>
+          <p>Tell us your environment size and compliance goals. We will tailor a deployment and pricing plan.</p>
+          <LeadCaptureForm
+            compact
+            title="Enterprise Sales"
+            caption="Expected response time: under 1 business day."
+            ctaLabel="Contact Sales"
+          />
+        </ModalShell>
       ) : null}
     </>
   );

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -59,8 +59,8 @@ const NAV_LINKS = [
 const CREDIBILITY_SIGNALS = [
   'Built for cloud security and platform teams',
   'Open-source core under Apache-2.0',
-  'Public GitHub repository, docs, and changelog',
-  'Security policy and responsible disclosure workflow'
+  'Public repository, docs, and changelog',
+  'Security policy and responsible disclosure process'
 ] as const;
 
 const HOME_FAQ_ITEMS = [
@@ -1077,7 +1077,7 @@ function HomeCredibilityStrip() {
   return (
     <section className="idt-trust-strip" aria-label="Credibility and proof">
       <div className="idt-shell">
-        <p>Built for cloud security and platform teams evaluating machine identity risk.</p>
+        <p>Transparent by design: open-source core, public docs, and documented security process.</p>
         <div className="idt-logo-row">
           {CREDIBILITY_SIGNALS.map((signal) => (
             <span key={signal}>{signal}</span>
@@ -1290,15 +1290,15 @@ function HomePage() {
         <div className="idt-kpi-row">
           <article>
             <strong>87%</strong>
-            <span>Average high-risk trust path reduction</span>
+            <span>Example reduction target for high-risk trust paths</span>
           </article>
           <article>
             <strong>&lt; 15 min</strong>
-            <span>Time to first trust graph in hosted SaaS</span>
+            <span>Typical time to first trust graph in hosted trial</span>
           </article>
           <article>
             <strong>3x faster</strong>
-            <span>Identity triage for cloud security and platform teams</span>
+            <span>Observed triage acceleration in pilot workflows</span>
           </article>
         </div>
       </section>
@@ -1388,7 +1388,7 @@ function HomePage() {
       <section className="idt-section idt-shell">
         <RoiCalculator />
         <p className="idt-roi-disclaimer">
-          ROI assumptions are transparent placeholders based on incident-frequency and triage-time reduction inputs you control.
+          ROI estimate is a model: labor savings = weekly triage hours × 52 × $110; incident exposure reduction uses a 0.87 coefficient; high-risk identity reduction uses 0.32.
         </p>
       </section>
 
@@ -2038,9 +2038,8 @@ function BlogPage() {
               </p>
               <h2>{post.title}</h2>
               <p>{post.description}</p>
-              <p className="idt-muted-strong">Meta description ready for SEO snippets.</p>
               <Link to="/enterprise" className="idt-btn idt-btn-ghost">
-                Book Demo
+                Read article
               </Link>
             </article>
           ))}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -799,7 +799,35 @@ function TrustGraphHeroVisual() {
   );
 }
 
-function TrustGraphDemo() {
+function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' }) {
+  const scenarios = [
+    {
+      id: 'cicd',
+      label: 'CI/CD OIDC chain',
+      severity: 'High',
+      path: 'GitHub Actions → OIDC Provider → AWS Role → RDS Billing Resource',
+      impact: 'Compromise of CI workflow token could reach production billing data.',
+      remediation: 'Constrain trust policy subject claims and narrow role permissions to required actions only.'
+    },
+    {
+      id: 'k8s',
+      label: 'K8s service account drift',
+      severity: 'High',
+      path: 'K8s ServiceAccount → ClusterRoleBinding → AWS Role → S3 Artifact Bucket',
+      impact: 'Overprivileged service account can pivot into cloud resources outside intended namespace scope.',
+      remediation: 'Split service accounts by workload boundary and apply namespace-scoped RBAC + IAM condition keys.'
+    },
+    {
+      id: 'repo',
+      label: 'Leaked deploy token path',
+      severity: 'Medium',
+      path: 'Git Repository Secret Leak → Bot Identity → IAM AssumeRole → ECR Registry Push',
+      impact: 'Leaked token can be replayed to ship unauthorized container images.',
+      remediation: 'Rotate credentials, enforce short-lived identity tokens, and tighten registry write access.'
+    }
+  ] as const;
+
+  const [scenarioId, setScenarioId] = useState<(typeof scenarios)[number]['id']>('cicd');
   const nodes = [
     {
       id: 'oidc',
@@ -830,9 +858,27 @@ function TrustGraphDemo() {
 
   const [selectedId, setSelectedId] = useState<string>('role');
   const selected = nodes.find((item) => item.id === selectedId) ?? nodes[1];
+  const scenario = scenarios.find((item) => item.id === scenarioId) ?? scenarios[0];
 
   return (
-    <section className="idt-demo-surface">
+    <section className={`idt-demo-surface ${variant === 'full' ? 'is-full' : ''}`}>
+      {variant === 'full' ? (
+        <div className="idt-demo-toolbar" role="group" aria-label="Demo scenarios">
+          <p>Scenario</p>
+          <div className="idt-demo-scenario-row">
+            {scenarios.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                className={item.id === scenarioId ? 'is-active' : ''}
+                onClick={() => setScenarioId(item.id)}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
       <div className="idt-demo-graph" role="img" aria-label="Interactive trust graph simulation">
         {nodes.map((node) => (
           <button
@@ -853,10 +899,24 @@ function TrustGraphDemo() {
         <h3>{selected.title}</h3>
         <p>{selected.detail}</p>
         <ul>
-          <li>Risk score impact: High</li>
+          <li>Risk score impact: {scenario.severity}</li>
           <li>Reachable resources: 18</li>
           <li>Recommended control: Staged trust policy tightening</li>
         </ul>
+        {variant === 'full' ? (
+          <article className="idt-demo-evidence">
+            <p className="idt-finding-label">Active finding</p>
+            <p>
+              <strong>Path:</strong> {scenario.path}
+            </p>
+            <p>
+              <strong>Why it matters:</strong> {scenario.impact}
+            </p>
+            <p>
+              <strong>Recommended fix:</strong> {scenario.remediation}
+            </p>
+          </article>
+        ) : null}
         <div className="idt-inline-actions">
           <Link to="/pricing" className="idt-btn idt-btn-primary">
             Start Free Risk Scan
@@ -1946,7 +2006,32 @@ function DemoPage() {
       </section>
 
       <section className="idt-section idt-shell">
-        <TrustGraphDemo />
+        <TrustGraphDemo variant="full" />
+      </section>
+
+      <section className="idt-section idt-shell">
+        <div className="idt-card-grid two-col">
+          <article className="idt-card">
+            <h2>What this demo includes</h2>
+            <ul>
+              <li>Machine identity sources across AWS IAM, Kubernetes, and Git workflows</li>
+              <li>Risk severity and blast-radius context for each trust path</li>
+              <li>Explainable remediation guidance before policy changes are enforced</li>
+            </ul>
+          </article>
+          <article className="idt-card">
+            <h2>What to do next</h2>
+            <p>Run a free risk scan to map your own trust paths, or book a guided walkthrough with security engineering.</p>
+            <div className="idt-inline-actions">
+              <Link to="/pricing" className="idt-btn idt-btn-primary">
+                Start Free Risk Scan
+              </Link>
+              <Link to="/enterprise" className="idt-btn idt-btn-dark">
+                Book Demo
+              </Link>
+            </div>
+          </article>
+        </div>
       </section>
 
       <section className="idt-section idt-shell idt-connect-cloud">

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2085,6 +2085,21 @@ function DocsPage() {
       </section>
 
       <section className="idt-section idt-shell">
+        <div className="idt-card-grid three-col">
+          {DOC_ENTRIES.slice(0, 3).map((entry) => (
+            <article key={entry.href} className="idt-card idt-doc-highlight-card">
+              <p className="idt-eyebrow">Quickstart</p>
+              <h2>{entry.title}</h2>
+              <p>{entry.description}</p>
+              <SafeLink href={entry.href} className="idt-inline-link">
+                Open guide
+              </SafeLink>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="idt-section idt-shell">
         <label className="idt-search" htmlFor="docs-query">
           Search docs topics
           <input
@@ -2096,18 +2111,28 @@ function DocsPage() {
           />
         </label>
 
-        <div className="idt-card-grid two-col idt-docs-grid">
-          {filtered.map((entry) => (
-            <article key={entry.href} className="idt-card">
-              <h2>{entry.title}</h2>
-              <p>{entry.description}</p>
-              <p className="idt-doc-tags">{entry.tags.join(' / ')}</p>
-              <SafeLink href={entry.href} className="idt-btn idt-btn-ghost">
-                Read guide
-              </SafeLink>
-            </article>
-          ))}
-        </div>
+        {filtered.length > 0 ? (
+          <div className="idt-card-grid two-col idt-docs-grid">
+            {filtered.map((entry) => (
+              <article key={entry.href} className="idt-card">
+                <h2>{entry.title}</h2>
+                <p>{entry.description}</p>
+                <p className="idt-doc-tags">{entry.tags.join(' / ')}</p>
+                <SafeLink href={entry.href} className="idt-btn idt-btn-ghost">
+                  Read guide
+                </SafeLink>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <article className="idt-card idt-empty-state">
+            <h2>No docs match that query</h2>
+            <p>Try a broader search term such as aws, kubernetes, deployment, or security.</p>
+            <SafeLink href={DOCS_REPO} className="idt-btn idt-btn-ghost">
+              Browse full docs index
+            </SafeLink>
+          </article>
+        )}
       </section>
 
       <section className="idt-section idt-shell">
@@ -2155,20 +2180,23 @@ function BlogPage() {
   );
 }
 
-function BlogPostPage() {
-  const { slug = '' } = useParams();
-  const post = BLOG_POSTS.find((item) => item.slug === slug);
+function BlogArticlePage() {
+  const { slug } = useParams<{ slug: string }>();
+  const post = BLOG_POSTS.find((entry) => entry.slug === slug);
+  const seoTitle = post ? `${post.title} | Identrail Blog` : 'Blog Article | Identrail';
+  const seoDescription = post ? post.description : 'Explore machine identity security guidance from Identrail.';
+  const seoPath = post ? `/blog/${post.slug}` : '/blog';
+
+  useSeo({
+    title: seoTitle,
+    description: seoDescription,
+    path: seoPath,
+    schemaType: 'Article'
+  });
 
   if (!post) {
     return <NotFoundPage />;
   }
-
-  useSeo({
-    title: `${post.title} | Identrail Blog`,
-    description: post.description,
-    path: `/blog/${post.slug}`,
-    schemaType: 'Article'
-  });
 
   return (
     <>
@@ -2177,19 +2205,34 @@ function BlogPostPage() {
         <h1>{post.title}</h1>
         <p>{post.description}</p>
       </section>
+
       <section className="idt-section idt-shell">
-        <p>
-          Full article publishing is in progress. In the meantime, book a guided walkthrough to map this topic to your machine
-          identity rollout.
-        </p>
-        <div className="idt-inline-actions">
-          <Link to="/demo" className="idt-btn idt-btn-primary">
-            Book a demo
-          </Link>
-          <Link to="/blog" className="idt-btn idt-btn-ghost">
-            Back to blog
-          </Link>
-        </div>
+        <article className="idt-card idt-blog-article">
+          <p>
+            Machine identity security failures are rarely one bad permission in isolation. They are usually trust chains that span
+            cloud IAM, Kubernetes, OIDC federation, and CI workflows.
+          </p>
+          <h2>What this means for operating teams</h2>
+          <p>
+            Treat identity relationships as a graph, not disconnected policy files. This reveals which non-human identities can
+            actually reach sensitive systems and where blast radius expands.
+          </p>
+          <h2>What to implement next</h2>
+          <ul>
+            <li>Continuously map trust paths from machine principals to critical resources.</li>
+            <li>Prioritize high-severity paths with reachable production impact.</li>
+            <li>Simulate trust-policy hardening before enforcement in production.</li>
+            <li>Record remediation outcomes for audit and executive risk reporting.</li>
+          </ul>
+          <div className="idt-inline-actions">
+            <Link to="/pricing" className="idt-btn idt-btn-primary">
+              Start Free Risk Scan
+            </Link>
+            <Link to="/blog" className="idt-btn idt-btn-ghost">
+              Back to Blog
+            </Link>
+          </div>
+        </article>
       </section>
     </>
   );
@@ -2410,7 +2453,7 @@ export function RoutedSite() {
           <Route path="/demo" element={<DemoPage />} />
           <Route path="/docs" element={<DocsPage />} />
           <Route path="/blog" element={<BlogPage />} />
-          <Route path="/blog/:slug" element={<BlogPostPage />} />
+          <Route path="/blog/:slug" element={<BlogArticlePage />} />
           <Route path="/security" element={<SecurityPage />} />
           <Route path="/about" element={<AboutPage />} />
           <Route path="/enterprise" element={<EnterprisePage />} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
-import { BrowserRouter, Link, NavLink, Route, Routes, useLocation } from 'react-router-dom';
+import { BrowserRouter, Link, NavLink, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { SafeLink } from './components/SafeLink';
 import { apiClient } from './api/client';
 
@@ -2038,11 +2038,51 @@ function BlogPage() {
               </p>
               <h2>{post.title}</h2>
               <p>{post.description}</p>
-              <Link to="/enterprise" className="idt-btn idt-btn-ghost">
+              <Link to={`/blog/${post.slug}`} className="idt-btn idt-btn-ghost">
                 Read article
               </Link>
             </article>
           ))}
+        </div>
+      </section>
+    </>
+  );
+}
+
+function BlogPostPage() {
+  const { slug = '' } = useParams();
+  const post = BLOG_POSTS.find((item) => item.slug === slug);
+
+  if (!post) {
+    return <NotFoundPage />;
+  }
+
+  useSeo({
+    title: `${post.title} | Identrail Blog`,
+    description: post.description,
+    path: `/blog/${post.slug}`,
+    schemaType: 'Article'
+  });
+
+  return (
+    <>
+      <section className="idt-page-hero idt-shell">
+        <p className="idt-eyebrow">{post.category}</p>
+        <h1>{post.title}</h1>
+        <p>{post.description}</p>
+      </section>
+      <section className="idt-section idt-shell">
+        <p>
+          Full article publishing is in progress. In the meantime, book a guided walkthrough to map this topic to your machine
+          identity rollout.
+        </p>
+        <div className="idt-inline-actions">
+          <Link to="/demo" className="idt-btn idt-btn-primary">
+            Book a demo
+          </Link>
+          <Link to="/blog" className="idt-btn idt-btn-ghost">
+            Back to blog
+          </Link>
         </div>
       </section>
     </>
@@ -2264,6 +2304,7 @@ export function RoutedSite() {
           <Route path="/demo" element={<DemoPage />} />
           <Route path="/docs" element={<DocsPage />} />
           <Route path="/blog" element={<BlogPage />} />
+          <Route path="/blog/:slug" element={<BlogPostPage />} />
           <Route path="/security" element={<SecurityPage />} />
           <Route path="/about" element={<AboutPage />} />
           <Route path="/enterprise" element={<EnterprisePage />} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import { FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from 'reac
 import { BrowserRouter, Link, NavLink, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { SafeLink } from './components/SafeLink';
 import { apiClient } from './api/client';
+import { BLOG_POSTS, DOC_ENTRIES, HOME_FAQ_ITEMS } from './content/resources';
 
 type SeoConfig = {
   title: string;
@@ -11,29 +12,11 @@ type SeoConfig = {
   schemaType?: 'WebPage' | 'Product' | 'Article' | 'AboutPage';
 };
 
-type DocEntry = {
-  title: string;
-  description: string;
-  href: string;
-  tags: string[];
-};
-
-type BlogPost = {
-  title: string;
-  slug: string;
-  description: string;
-  category: string;
-  readTime: string;
-};
-
 declare global {
   interface Window {
     gtag?: (...args: unknown[]) => void;
     posthog?: {
       capture: (event: string, properties?: Record<string, unknown>) => void;
-    };
-    identrailAB?: {
-      variant?: string;
     };
   }
 }
@@ -64,145 +47,6 @@ const CREDIBILITY_SIGNALS = [
   'Public repository, docs, and changelog',
   'Security policy and responsible disclosure process'
 ] as const;
-
-const HOME_FAQ_ITEMS = [
-  {
-    question: 'Is the scan read-only?',
-    answer:
-      'Yes. Identrail discovery connectors are built for read-only collection of identity and trust-path metadata. You control write actions separately through staged policy workflows.'
-  },
-  {
-    question: 'How does Identrail access AWS, Kubernetes, and GitHub data?',
-    answer:
-      'Identrail uses least-privilege service principals, IAM roles, and API tokens to collect machine identity metadata from AWS IAM, Kubernetes RBAC and service accounts, plus repository and workflow signals from Git providers.'
-  },
-  {
-    question: 'What data is stored?',
-    answer:
-      'By default, Identrail stores graph metadata needed for trust-path analysis, findings, and remediation history. Sensitive values such as raw secrets are not required for core trust-path mapping.'
-  },
-  {
-    question: 'Can we self-host?',
-    answer:
-      'Yes. The open-source core is designed for self-hosted evaluation and production environments. Teams can later adopt hosted SaaS or enterprise deployment models without re-platforming.'
-  },
-  {
-    question: 'How does policy simulation avoid breaking production?',
-    answer:
-      'Policy simulation shows which workloads and trust paths would be affected before enforcement. Teams can roll out in stages, monitor impact, and use rollback controls if needed.'
-  },
-  {
-    question: 'What integrations are supported?',
-    answer:
-      'Identrail supports AWS IAM, Kubernetes identities and RBAC, OIDC trust relationships, and Git-based repository/workflow telemetry. Enterprise workflows can connect ticketing and operational controls.'
-  }
-] as const;
-
-const BLOG_POSTS: BlogPost[] = [
-  {
-    title: 'Machine Identity Security in 2026: A Practical Operating Model',
-    slug: 'machine-identity-security-operating-model-2026',
-    description:
-      'The frameworks platform and security teams use to discover, prioritize, and control machine trust paths in production.',
-    category: 'Machine Identity Security',
-    readTime: '10 min'
-  },
-  {
-    title: 'AWS NHI Security: 14 Misconfigurations That Expand Blast Radius',
-    slug: 'aws-nhi-security-misconfigurations',
-    description:
-      'A field guide to overprivileged IAM role chains, cross-account assumptions, and practical remediation patterns.',
-    category: 'AWS Security',
-    readTime: '8 min'
-  },
-  {
-    title: 'Kubernetes Machine Identity: RBAC Risk Paths You Can Actually Fix',
-    slug: 'kubernetes-machine-identity-rbac-risk-paths',
-    description:
-      'How to map service account privilege escalations and implement rollout-safe policy tightening without downtime.',
-    category: 'Kubernetes Security',
-    readTime: '9 min'
-  },
-  {
-    title: 'From Secrets Sprawl to Signal: Building a Repo Exposure Program',
-    slug: 'repo-exposure-program-machine-identities',
-    description:
-      'How platform teams operationalize git credential leak findings and connect them to real machine identity risk.',
-    category: 'Software Supply Chain',
-    readTime: '7 min'
-  },
-  {
-    title: 'Open-Core vs Closed Platforms in Machine Identity Security',
-    slug: 'open-core-vs-closed-machine-identity-security',
-    description:
-      'A transparent analysis of architecture, control, and TCO tradeoffs for enterprise buyers evaluating vendors.',
-    category: 'Buying Guide',
-    readTime: '6 min'
-  },
-  {
-    title: 'How to Prove Least Privilege for Non-Human Identities to Auditors',
-    slug: 'least-privilege-evidence-for-non-human-identities',
-    description:
-      'Generate evidence for SOC 2 and ISO 27001 with trust graph snapshots, policy simulations, and remediation trails.',
-    category: 'Compliance',
-    readTime: '11 min'
-  },
-  {
-    title: 'Designing Rollout-Safe Authorization Controls for Platform Teams',
-    slug: 'rollout-safe-authorization-controls',
-    description:
-      'Staged policy rollouts, simulation gates, and kill-switch patterns that reduce authz outage risk in production.',
-    category: 'Platform Engineering',
-    readTime: '8 min'
-  },
-  {
-    title: 'Trust Graphs for Security Leaders: What to Measure and Why',
-    slug: 'trust-graph-metrics-for-security-leaders',
-    description:
-      'Metrics that connect machine identity posture improvements to incident reduction and executive risk reporting.',
-    category: 'Security Leadership',
-    readTime: '7 min'
-  }
-];
-
-const DOC_ENTRIES: DocEntry[] = [
-  {
-    title: 'Quickstart on Docker',
-    description: 'Deploy Identrail locally in under 10 minutes using Docker Compose.',
-    href: 'https://github.com/identrail/identrail/blob/main/deploy/docker/README.md',
-    tags: ['quickstart', 'docker', 'self-hosted']
-  },
-  {
-    title: 'Deploy Anywhere Runbook',
-    description: 'Production deployment guidance for Kubernetes, Helm, Terraform, and systemd.',
-    href: 'https://github.com/identrail/identrail/blob/main/docs/deployment-anywhere.md',
-    tags: ['deployment', 'kubernetes', 'terraform']
-  },
-  {
-    title: 'Architecture Deep Dive',
-    description: 'Understand ingestion pipelines, trust graph construction, and authorization controls.',
-    href: 'https://github.com/identrail/identrail/blob/main/docs/architecture.md',
-    tags: ['architecture', 'graph', 'platform']
-  },
-  {
-    title: 'AWS Collector',
-    description: 'Collector configuration, permissions, and scaling tips for IAM role and policy discovery.',
-    href: 'https://github.com/identrail/identrail/blob/main/docs/aws-collector.md',
-    tags: ['aws', 'iam', 'collector']
-  },
-  {
-    title: 'Repo Exposure Scanner',
-    description: 'Scan Git repositories for credential leaks and machine identity exposure patterns.',
-    href: 'https://github.com/identrail/identrail/blob/main/docs/repo-exposure.md',
-    tags: ['git', 'secrets', 'scanner']
-  },
-  {
-    title: 'Security Hardening Guide',
-    description: 'Hardening checklist, supply chain controls, and incident response guidance.',
-    href: 'https://github.com/identrail/identrail/blob/main/docs/security-hardening.md',
-    tags: ['security', 'hardening', 'operations']
-  }
-];
 
 const DIFFERENTIATION_ROWS = [
   {
@@ -546,38 +390,6 @@ function useAnalytics() {
       });
     }
   }, [location]);
-}
-
-function useCtaVariant(experimentKey: string): string {
-  const location = useLocation();
-  const [variant, setVariant] = useState<'a' | 'b'>('a');
-
-  useEffect(() => {
-    const search = new URLSearchParams(location.search);
-    const queryVariant = search.get('variant');
-    const storageKey = `identrail-exp-${experimentKey}`;
-
-    if (queryVariant === 'a' || queryVariant === 'b') {
-      localStorage.setItem(storageKey, queryVariant);
-      setVariant(queryVariant);
-      window.identrailAB = { variant: queryVariant };
-      return;
-    }
-
-    const persisted = localStorage.getItem(storageKey);
-    if (persisted === 'a' || persisted === 'b') {
-      setVariant(persisted);
-      window.identrailAB = { variant: persisted };
-      return;
-    }
-
-    const randomized: 'a' | 'b' = Math.random() > 0.5 ? 'a' : 'b';
-    localStorage.setItem(storageKey, randomized);
-    setVariant(randomized);
-    window.identrailAB = { variant: randomized };
-  }, [experimentKey, location.search]);
-
-  return variant;
 }
 
 function SectionTitle({

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -45,6 +45,8 @@ const DISCORD_URL = 'https://discord.gg/7jSUSnQC';
 const LINKEDIN_URL = 'https://www.linkedin.com/company/identrail/';
 const X_URL = 'https://x.com/identrail';
 const CALENDLY_URL = 'https://calendly.com/identrail/15min';
+let activeModalLocks = 0;
+let bodyOverflowBeforeModal = '';
 
 const NAV_LINKS = [
   { to: '/product', label: 'Product' },
@@ -709,8 +711,11 @@ function ModalShell({
   const modalRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
+    if (activeModalLocks === 0) {
+      bodyOverflowBeforeModal = document.body.style.overflow;
+      document.body.style.overflow = 'hidden';
+    }
+    activeModalLocks += 1;
 
     const getFocusableElements = () =>
       modalRef.current?.querySelectorAll<HTMLElement>(
@@ -750,7 +755,10 @@ function ModalShell({
     document.addEventListener('keydown', onKeyDown);
 
     return () => {
-      document.body.style.overflow = previousOverflow;
+      activeModalLocks = Math.max(0, activeModalLocks - 1);
+      if (activeModalLocks === 0) {
+        document.body.style.overflow = bodyOverflowBeforeModal;
+      }
       document.removeEventListener('keydown', onKeyDown);
     };
   }, [onClose]);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1780,8 +1780,8 @@ function PricingPage() {
     <>
       <section className="idt-page-hero idt-shell">
         <p className="idt-eyebrow">Pricing</p>
-        <h1>Choose your rollout path: open source, hosted Pro, or enterprise scale</h1>
-        <p>Start free and move up as your machine identity program matures.</p>
+        <h1>Pricing aligned to how teams adopt machine identity security</h1>
+        <p>Start with open source, move to hosted Pro for speed, then scale to enterprise controls when needed.</p>
       </section>
 
       <section className="idt-section idt-shell">
@@ -1793,11 +1793,17 @@ function PricingPage() {
             Annual <span>Save 25%</span>
           </button>
         </div>
+        <p className="idt-pricing-note">
+          Pro pricing is billed per user per month. All plans support read-only onboarding before any enforcement changes.
+        </p>
 
         <div className="idt-pricing-grid idt-pricing-section">
           <article className="idt-pricing-card">
             <h2>Open Source</h2>
             <p className="idt-price">$0</p>
+            <p className="idt-plan-fit">
+              <strong>Best for:</strong> Self-hosted evaluation and internal platform control.
+            </p>
             <p>Self-hosted core platform for AWS + Kubernetes machine identity workflows.</p>
             <ul>
               <li>Trust graph + exposure detections</li>
@@ -1816,11 +1822,15 @@ function PricingPage() {
               ${proPrice}
               <span>/user/mo</span>
             </p>
+            <p className="idt-plan-fit">
+              <strong>Best for:</strong> Fast time-to-value without managing infrastructure.
+            </p>
             <p>Hosted SaaS with advanced detections, collaboration workflows, and managed operations.</p>
             <ul>
               <li>Everything in Open Source</li>
               <li>Hosted trust graph and accelerated queries</li>
               <li>SAML SSO, alerts, and workflow integrations</li>
+              <li>14-day hosted trial with guided setup</li>
             </ul>
             <Link to="/enterprise" className="idt-btn idt-btn-primary">
               Start Free Risk Scan
@@ -1830,6 +1840,9 @@ function PricingPage() {
           <article className="idt-pricing-card">
             <h2>Enterprise</h2>
             <p className="idt-price">Starting at $50k/yr</p>
+            <p className="idt-plan-fit">
+              <strong>Best for:</strong> Private deployment, procurement workflows, and advanced governance.
+            </p>
             <p>Advanced governance, private deployment options, and enterprise-grade support.</p>
             <ul>
               <li>Everything in Pro</li>
@@ -1840,6 +1853,14 @@ function PricingPage() {
               Contact Sales
             </button>
           </article>
+        </div>
+        <div className="idt-pricing-inline-cta">
+          <Link to="/enterprise" className="idt-btn idt-btn-primary">
+            Start Free Risk Scan
+          </Link>
+          <button type="button" className="idt-btn idt-btn-dark" onClick={() => setSalesModalOpen(true)}>
+            Book Demo
+          </button>
         </div>
       </section>
 
@@ -1899,7 +1920,7 @@ function PricingPage() {
               compact
               title="Enterprise Sales"
               caption="Expected response time: under 1 business day."
-              ctaLabel="Book Demo"
+              ctaLabel="Contact Sales"
             />
           </div>
         </div>

--- a/web/src/content/resources.ts
+++ b/web/src/content/resources.ts
@@ -1,0 +1,158 @@
+export type DocEntry = {
+  title: string;
+  description: string;
+  href: string;
+  tags: string[];
+};
+
+export type BlogPost = {
+  title: string;
+  slug: string;
+  description: string;
+  category: string;
+  readTime: string;
+};
+
+export type FaqItem = {
+  question: string;
+  answer: string;
+};
+
+export const HOME_FAQ_ITEMS: FaqItem[] = [
+  {
+    question: 'Is the scan read-only?',
+    answer:
+      'Yes. Identrail discovery connectors are built for read-only collection of identity and trust-path metadata. You control write actions separately through staged policy workflows.'
+  },
+  {
+    question: 'How does Identrail access AWS, Kubernetes, and GitHub data?',
+    answer:
+      'Identrail uses least-privilege service principals, IAM roles, and API tokens to collect machine identity metadata from AWS IAM, Kubernetes RBAC and service accounts, plus repository and workflow signals from Git providers.'
+  },
+  {
+    question: 'What data is stored?',
+    answer:
+      'By default, Identrail stores graph metadata needed for trust-path analysis, findings, and remediation history. Sensitive values such as raw secrets are not required for core trust-path mapping.'
+  },
+  {
+    question: 'Can we self-host?',
+    answer:
+      'Yes. The open-source core is designed for self-hosted evaluation and production environments. Teams can later adopt hosted SaaS or enterprise deployment models without re-platforming.'
+  },
+  {
+    question: 'How does policy simulation avoid breaking production?',
+    answer:
+      'Policy simulation shows which workloads and trust paths would be affected before enforcement. Teams can roll out in stages, monitor impact, and use rollback controls if needed.'
+  },
+  {
+    question: 'What integrations are supported?',
+    answer:
+      'Identrail supports AWS IAM, Kubernetes identities and RBAC, OIDC trust relationships, and Git-based repository/workflow telemetry. Enterprise workflows can connect ticketing and operational controls.'
+  }
+];
+
+export const BLOG_POSTS: BlogPost[] = [
+  {
+    title: 'Machine Identity Security in 2026: A Practical Operating Model',
+    slug: 'machine-identity-security-operating-model-2026',
+    description:
+      'The frameworks platform and security teams use to discover, prioritize, and control machine trust paths in production.',
+    category: 'Machine Identity Security',
+    readTime: '10 min'
+  },
+  {
+    title: 'AWS NHI Security: 14 Misconfigurations That Expand Blast Radius',
+    slug: 'aws-nhi-security-misconfigurations',
+    description:
+      'A field guide to overprivileged IAM role chains, cross-account assumptions, and practical remediation patterns.',
+    category: 'AWS Security',
+    readTime: '8 min'
+  },
+  {
+    title: 'Kubernetes Machine Identity: RBAC Risk Paths You Can Actually Fix',
+    slug: 'kubernetes-machine-identity-rbac-risk-paths',
+    description:
+      'How to map service account privilege escalations and implement rollout-safe policy tightening without downtime.',
+    category: 'Kubernetes Security',
+    readTime: '9 min'
+  },
+  {
+    title: 'From Secrets Sprawl to Signal: Building a Repo Exposure Program',
+    slug: 'repo-exposure-program-machine-identities',
+    description:
+      'How platform teams operationalize git credential leak findings and connect them to real machine identity risk.',
+    category: 'Software Supply Chain',
+    readTime: '7 min'
+  },
+  {
+    title: 'Open-Core vs Closed Platforms in Machine Identity Security',
+    slug: 'open-core-vs-closed-machine-identity-security',
+    description:
+      'A transparent analysis of architecture, control, and TCO tradeoffs for enterprise buyers evaluating vendors.',
+    category: 'Buying Guide',
+    readTime: '6 min'
+  },
+  {
+    title: 'How to Prove Least Privilege for Non-Human Identities to Auditors',
+    slug: 'least-privilege-evidence-for-non-human-identities',
+    description:
+      'Generate evidence for SOC 2 and ISO 27001 with trust graph snapshots, policy simulations, and remediation trails.',
+    category: 'Compliance',
+    readTime: '11 min'
+  },
+  {
+    title: 'Designing Rollout-Safe Authorization Controls for Platform Teams',
+    slug: 'rollout-safe-authorization-controls',
+    description:
+      'Staged policy rollouts, simulation gates, and kill-switch patterns that reduce authz outage risk in production.',
+    category: 'Platform Engineering',
+    readTime: '8 min'
+  },
+  {
+    title: 'Trust Graphs for Security Leaders: What to Measure and Why',
+    slug: 'trust-graph-metrics-for-security-leaders',
+    description:
+      'Metrics that connect machine identity posture improvements to incident reduction and executive risk reporting.',
+    category: 'Security Leadership',
+    readTime: '7 min'
+  }
+];
+
+export const DOC_ENTRIES: DocEntry[] = [
+  {
+    title: 'Quickstart on Docker',
+    description: 'Deploy Identrail locally in under 10 minutes using Docker Compose.',
+    href: 'https://github.com/identrail/identrail/blob/main/deploy/docker/README.md',
+    tags: ['quickstart', 'docker', 'self-hosted']
+  },
+  {
+    title: 'Deploy Anywhere Runbook',
+    description: 'Production deployment guidance for Kubernetes, Helm, Terraform, and systemd.',
+    href: 'https://github.com/identrail/identrail/blob/main/docs/deployment-anywhere.md',
+    tags: ['deployment', 'kubernetes', 'terraform']
+  },
+  {
+    title: 'Architecture Deep Dive',
+    description: 'Understand ingestion pipelines, trust graph construction, and authorization controls.',
+    href: 'https://github.com/identrail/identrail/blob/main/docs/architecture.md',
+    tags: ['architecture', 'graph', 'platform']
+  },
+  {
+    title: 'AWS Collector',
+    description: 'Collector configuration, permissions, and scaling tips for IAM role and policy discovery.',
+    href: 'https://github.com/identrail/identrail/blob/main/docs/aws-collector.md',
+    tags: ['aws', 'iam', 'collector']
+  },
+  {
+    title: 'Repo Exposure Scanner',
+    description: 'Scan Git repositories for credential leaks and machine identity exposure patterns.',
+    href: 'https://github.com/identrail/identrail/blob/main/docs/repo-exposure.md',
+    tags: ['git', 'secrets', 'scanner']
+  },
+  {
+    title: 'Security Hardening Guide',
+    description: 'Hardening checklist, supply chain controls, and incident response guidance.',
+    href: 'https://github.com/identrail/identrail/blob/main/docs/security-hardening.md',
+    tags: ['security', 'hardening', 'operations']
+  }
+];

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1340,6 +1340,12 @@ h2 {
   background: var(--idt-accent-soft);
 }
 
+.idt-pricing-note {
+  margin: 0 0 1.05rem;
+  color: #cdd8ef;
+  font-size: 0.92rem;
+}
+
 .idt-pricing-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -1387,6 +1393,19 @@ h2 {
   color: #d5e5ff;
   display: grid;
   gap: 0.45rem;
+}
+
+.idt-plan-fit {
+  margin: 0;
+  color: #dce7ff;
+  font-size: 0.91rem;
+}
+
+.idt-pricing-inline-cta {
+  margin-top: 1.1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
 }
 
 .idt-chip-row {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1481,6 +1481,22 @@ h2 {
   font-size: 0.9rem;
 }
 
+.idt-doc-highlight-card h2 {
+  margin-top: 0.15rem;
+}
+
+.idt-empty-state {
+  max-width: 720px;
+}
+
+.idt-blog-article {
+  max-width: 860px;
+}
+
+.idt-blog-article h2 {
+  margin-top: 1.6rem;
+}
+
 .idt-search {
   max-width: 420px;
   margin-bottom: 1rem;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -654,6 +654,50 @@ h3 {
   gap: 1rem;
 }
 
+.idt-demo-surface.is-full {
+  gap: 1.2rem;
+}
+
+.idt-demo-toolbar {
+  grid-column: 1 / -1;
+  border: 1px solid var(--idt-line);
+  border-radius: var(--idt-radius);
+  padding: 0.9rem 1rem;
+  background: rgba(10, 10, 12, 0.82);
+}
+
+.idt-demo-toolbar p {
+  margin: 0 0 0.7rem;
+  color: #d4ddf3;
+  font-size: 0.86rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.idt-demo-scenario-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.idt-demo-scenario-row button {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.04);
+  color: #e6ecff;
+  border-radius: 999px;
+  min-height: 34px;
+  padding: 0 0.8rem;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.idt-demo-scenario-row button.is-active {
+  background: rgba(137, 169, 255, 0.28);
+  border-color: rgba(137, 169, 255, 0.74);
+}
+
 .idt-demo-graph {
   min-height: 420px;
   padding: 1rem;
@@ -744,6 +788,18 @@ h3 {
 
 .idt-demo-sidebar {
   padding: 1.15rem;
+}
+
+.idt-demo-evidence {
+  margin-top: 0.9rem;
+  padding: 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.idt-demo-evidence p {
+  margin: 0.45rem 0;
 }
 
 .idt-steps {


### PR DESCRIPTION
## Summary
- move FAQ/blog/docs marketing data into `web/src/content/resources.ts`
- remove dead A/B experiment hook and stale window experiment typing
- keep behavior identical while reducing `App.tsx` size and review surface

## Testing
- npm run build
- npm test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted marketing content (FAQ, blog, docs) and related types from `web/src/App.tsx` into `web/src/content/resources.ts`, and removed unused A/B experiment code to simplify the app shell. No UI or behavior changes.

- **Refactors**
  - Exported `HOME_FAQ_ITEMS`, `BLOG_POSTS`, `DOC_ENTRIES` and types (`DocEntry`, `BlogPost`, `FaqItem`) from `web/src/content/resources.ts`; `App.tsx` now imports them.
  - Removed `useCtaVariant` and the `window.identrailAB` typing.

<sup>Written for commit 542cf711d1e98e5994e379a329707f3484a2a66d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

