### PR TITLE
feat(web): compress homepage IA and tighten nav conversion paths

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -10,12 +10,12 @@ describe('App', () => {
     expect(
       screen.getByRole('heading', {
         level: 1,
-        name: 'See risky machine trust paths before attackers do.'
+        name: 'See which machine identities can actually reach production.'
       })
     ).toBeInTheDocument();
 
-    expect(screen.getAllByRole('link', { name: 'Start Free Risk Scan' }).length).toBeGreaterThan(0);
-    expect(screen.getAllByRole('link', { name: 'Book Demo' }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('link', { name: 'Start Read-Only Risk Scan' }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('link', { name: 'Book Technical Demo' }).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Adoption Paths/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Kubernetes service account can assume production AWS role/i).length).toBeGreaterThan(0);
   });

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -17,7 +17,7 @@ describe('App', () => {
     expect(screen.getAllByRole('link', { name: 'Start Read-Only Risk Scan' }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole('link', { name: 'Book Technical Demo' }).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Adoption Paths/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/Kubernetes service account can assume production AWS role/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Reachable Risk Paths/i).length).toBeGreaterThan(0);
   });
 
   it('renders pricing page routes and key elements', () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,9 @@
 import { FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { BrowserRouter, Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { SafeLink } from './components/SafeLink';
+import { HeroProductReveal } from './components/home/HeroProductReveal';
+import { RiskInsightSection } from './components/home/RiskInsightSection';
+import { TrustProofStrip } from './components/home/TrustProofStrip';
 import { Footer } from './components/layout/Footer';
 import { Header } from './components/layout/Header';
 import { apiClient } from './api/client';
@@ -42,14 +45,6 @@ const NAV_LINKS = [
   { to: '/pricing', label: 'Pricing' },
   { to: '/security', label: 'Security' },
   { to: '/demo', label: 'Demo' }
-] as const;
-
-const TRUST_PROOF_LINKS = [
-  { label: 'Architecture Docs', href: DOCS_REPO, external: true },
-  { label: 'Read-Only Scan Model', href: '/security', external: false },
-  { label: 'Sample Risk Report', href: '/demo', external: false },
-  { label: 'Changelog', href: `${GITHUB_REPO}/releases`, external: true },
-  { label: 'Responsible Disclosure', href: '/security', external: false }
 ] as const;
 
 const HOME_FAQ_PREVIEW = HOME_FAQ_ITEMS.slice(0, 4);
@@ -673,30 +668,6 @@ function CalendlyEmbed() {
   );
 }
 
-function TrustGraphHeroVisual() {
-  return (
-    <div className="idt-graph-visual" aria-label="Trust path product preview">
-      <div className="idt-graph-grid" />
-      <div className="idt-node idt-node-root">GitHub Actions OIDC</div>
-      <div className="idt-node idt-node-role">AWS Role: billing-prod</div>
-      <div className="idt-node idt-node-k8s">K8s SA: payments-api</div>
-      <div className="idt-node idt-node-repo">RDS: billing-ledger</div>
-      <span className="idt-edge idt-edge-a" />
-      <span className="idt-edge idt-edge-b" />
-      <span className="idt-edge idt-edge-c" />
-      <span className="idt-pulse idt-pulse-a" />
-      <span className="idt-pulse idt-pulse-b" />
-      <aside className="idt-hero-graph-caption">
-        <p className="idt-hero-graph-title">Trust graph preview</p>
-        <p>GitHub Actions OIDC → AWS Role → K8s Service Account → RDS Billing Resource</p>
-        <Link to="/demo" className="idt-inline-link">
-          Open interactive demo
-        </Link>
-      </aside>
-    </div>
-  );
-}
-
 function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' }) {
   const scenarios = [
     {
@@ -726,6 +697,7 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
   ] as const;
 
   const [scenarioId, setScenarioId] = useState<(typeof scenarios)[number]['id']>('cicd');
+  const [viewMode, setViewMode] = useState<'graph' | 'list'>('graph');
   const nodes = [
     {
       id: 'oidc',
@@ -760,39 +732,54 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
 
   return (
     <section className={`idt-demo-surface ${variant === 'full' ? 'is-full' : ''}`}>
-      {variant === 'full' ? (
-        <div className="idt-demo-toolbar" role="group" aria-label="Demo scenarios">
-          <p>Scenario</p>
-          <div className="idt-demo-scenario-row">
-            {scenarios.map((item) => (
-              <button
-                key={item.id}
-                type="button"
-                className={item.id === scenarioId ? 'is-active' : ''}
-                onClick={() => setScenarioId(item.id)}
-              >
-                {item.label}
-              </button>
-            ))}
-          </div>
+      <div className="idt-demo-toolbar" role="group" aria-label="Demo scenarios">
+        <p>Scenario</p>
+        <div className="idt-demo-scenario-row">
+          {scenarios.map((item) => (
+            <button key={item.id} type="button" className={item.id === scenarioId ? 'is-active' : ''} onClick={() => setScenarioId(item.id)}>
+              {item.label}
+            </button>
+          ))}
         </div>
-      ) : null}
-      <div className="idt-demo-graph" role="img" aria-label="Interactive trust graph simulation">
-        {nodes.map((node) => (
-          <button
-            key={node.id}
-            type="button"
-            className={`idt-demo-node ${selected.id === node.id ? 'is-active' : ''}`}
-            onClick={() => setSelectedId(node.id)}
-          >
-            <span>{node.title}</span>
-          </button>
-        ))}
-        <span className="idt-demo-connector c1" />
-        <span className="idt-demo-connector c2" />
-        <span className="idt-demo-connector c3" />
-        <span className="idt-demo-connector c4" />
       </div>
+
+      <div className="idt-demo-view-toggle" role="tablist" aria-label="Trust path explorer view">
+        <button type="button" role="tab" aria-selected={viewMode === 'graph'} className={viewMode === 'graph' ? 'is-active' : ''} onClick={() => setViewMode('graph')}>
+          Graph
+        </button>
+        <button type="button" role="tab" aria-selected={viewMode === 'list'} className={viewMode === 'list' ? 'is-active' : ''} onClick={() => setViewMode('list')}>
+          List
+        </button>
+      </div>
+
+      {viewMode === 'graph' ? (
+        <div className="idt-demo-graph" role="img" aria-label="Interactive trust graph simulation">
+          {nodes.map((node) => (
+            <button
+              key={node.id}
+              type="button"
+              className={`idt-demo-node ${selected.id === node.id ? 'is-active' : ''}`}
+              onClick={() => setSelectedId(node.id)}
+            >
+              <span>{node.title}</span>
+            </button>
+          ))}
+          <span className="idt-demo-connector c1" />
+          <span className="idt-demo-connector c2" />
+          <span className="idt-demo-connector c3" />
+          <span className="idt-demo-connector c4" />
+        </div>
+      ) : (
+        <div className="idt-demo-list-view" role="table" aria-label="Trust path nodes">
+          {nodes.map((node) => (
+            <button key={node.id} type="button" className={`idt-demo-list-row ${selected.id === node.id ? 'is-active' : ''}`} onClick={() => setSelectedId(node.id)}>
+              <span>{node.title}</span>
+              <small>{node.detail}</small>
+            </button>
+          ))}
+        </div>
+      )}
+
       <aside className="idt-demo-sidebar" aria-live="polite">
         <h3>{selected.title}</h3>
         <p>{selected.detail}</p>
@@ -817,10 +804,10 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
         ) : null}
         <div className="idt-inline-actions">
           <Link to="/pricing" className="idt-btn idt-btn-primary">
-            Start Free Risk Scan
+            Start Read-Only Risk Scan
           </Link>
-          <Link to="/enterprise" className="idt-btn idt-btn-dark">
-            Book Demo
+          <Link to="/demo" className="idt-btn idt-btn-dark">
+            Book Technical Demo
           </Link>
         </div>
       </aside>
@@ -984,80 +971,6 @@ function DeploymentPathBanner() {
   );
 }
 
-function HomeCredibilityStrip() {
-  return (
-    <section className="idt-trust-strip" aria-label="Credibility and proof">
-      <div className="idt-shell">
-        <p>Validate the product before you commit: review architecture, security posture, and output artifacts.</p>
-        <div className="idt-logo-row idt-proof-row">
-          {TRUST_PROOF_LINKS.map((entry) => (
-            entry.external ? (
-              <SafeLink key={entry.label} href={entry.href} className="idt-proof-link">
-                {entry.label}
-              </SafeLink>
-            ) : (
-              <Link key={entry.label} to={entry.href} className="idt-proof-link">
-                {entry.label}
-              </Link>
-            )
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function ProductProofFindingSection() {
-  return (
-    <section className="idt-section idt-shell">
-      <SectionTitle
-        eyebrow="Product Proof"
-        title="See a realistic high-risk trust path before you connect anything"
-        body="Identrail surfaces risky machine identity paths with evidence, impact, and remediation guidance teams can act on immediately."
-      />
-      <div className="idt-finding-proof-grid">
-        <article className="idt-card idt-finding-card">
-          <p className="idt-finding-label">Risk</p>
-          <h3>Kubernetes service account can assume production AWS role</h3>
-          <p>
-            <strong>Severity:</strong> <span className="idt-severity-high">High</span>
-          </p>
-          <p>
-            <strong>Path:</strong> GitHub Actions → OIDC Provider → AWS Role → RDS Billing Resource
-          </p>
-          <p>
-            <strong>Why it matters:</strong> Compromise of CI/CD could reach sensitive production data.
-          </p>
-          <p>
-            <strong>Recommended remediation:</strong> Restrict trust policy conditions and scope role permissions.
-          </p>
-        </article>
-        <article className="idt-card idt-finding-impact">
-          <h3>What teams do next in Identrail</h3>
-          <ul>
-            <li>Inspect every edge in the trust path with source policy evidence.</li>
-            <li>Simulate tighter trust conditions before enforcing policy changes.</li>
-            <li>Roll out in stages to reduce blast radius without breaking production.</li>
-          </ul>
-          <div className="idt-inline-actions">
-            <Link to="/pricing" className="idt-btn idt-btn-primary">
-              Start Free Risk Scan
-            </Link>
-            <Link to="/enterprise" className="idt-btn idt-btn-dark">
-              Book Demo
-            </Link>
-          </div>
-        </article>
-      </div>
-      <div className="idt-card idt-proof-demo-card">
-        <h3>Interactive trust-path preview</h3>
-        <p>Inspect a sample trust path from source identity to sensitive resource before connecting your environment.</p>
-        <TrustGraphDemo />
-      </div>
-    </section>
-  );
-}
-
 function HomeFaqSection() {
   return (
     <section className="idt-section idt-shell">
@@ -1109,11 +1022,11 @@ function HomePage() {
               </Link>
             </div>
           </div>
-          <TrustGraphHeroVisual />
+          <HeroProductReveal />
         </div>
       </section>
 
-      <HomeCredibilityStrip />
+      <TrustProofStrip />
 
       <section className="idt-section idt-shell">
         <LeadCaptureForm
@@ -1125,7 +1038,15 @@ function HomePage() {
         />
       </section>
 
-      <ProductProofFindingSection />
+      <RiskInsightSection />
+
+      <section className="idt-section idt-shell">
+        <div className="idt-card idt-proof-demo-card">
+          <h3>Interactive trust-path preview</h3>
+          <p>Inspect a sample trust path from source identity to sensitive resource before connecting your environment.</p>
+          <TrustGraphDemo />
+        </div>
+      </section>
 
       <section className="idt-section idt-shell">
         <SectionTitle eyebrow="How It Works" title="Discover, prioritize, simulate, and roll out in four steps" />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -34,19 +34,23 @@ let bodyOverflowBeforeModal = '';
 const NAV_LINKS = [
   { to: '/product', label: 'Product' },
   { to: '/solutions', label: 'Solutions' },
-  { to: '/pricing', label: 'Pricing' },
-  { to: '/demo', label: 'Demo' },
+  { to: '/integrations', label: 'Integrations' },
+  { to: '/deployment-models', label: 'Deployment' },
   { to: '/docs', label: 'Docs' },
+  { to: '/pricing', label: 'Pricing' },
   { to: '/security', label: 'Security' },
-  { to: '/blog', label: 'Blog' }
+  { to: '/demo', label: 'Demo' }
 ] as const;
 
-const CREDIBILITY_SIGNALS = [
-  'Built for cloud security and platform teams',
-  'Open-source core under Apache-2.0',
-  'Public repository, docs, and changelog',
-  'Security policy and responsible disclosure process'
+const TRUST_PROOF_LINKS = [
+  { label: 'Architecture Docs', href: DOCS_REPO, external: true },
+  { label: 'Read-Only Scan Model', href: '/security', external: false },
+  { label: 'Sample Risk Report', href: '/demo', external: false },
+  { label: 'Changelog', href: `${GITHUB_REPO}/releases`, external: true },
+  { label: 'Responsible Disclosure', href: '/security', external: false }
 ] as const;
+
+const HOME_FAQ_PREVIEW = HOME_FAQ_ITEMS.slice(0, 4);
 
 const DIFFERENTIATION_ROWS = [
   {
@@ -1001,14 +1005,11 @@ function Header() {
 
         <div className="idt-header-actions">
           <Link to="/pricing" className="idt-btn idt-btn-primary" data-ab-slot="header_primary_cta">
-            Start Free Risk Scan
+            Start Read-Only Risk Scan
           </Link>
-          <Link to="/enterprise" className="idt-btn idt-btn-dark">
-            Book Demo
+          <Link to="/demo" className="idt-btn idt-btn-dark">
+            Book Technical Demo
           </Link>
-          <SafeLink href={GITHUB_REPO} className="idt-btn idt-btn-ghost">
-            GitHub
-          </SafeLink>
         </div>
       </div>
     </header>
@@ -1056,10 +1057,18 @@ function HomeCredibilityStrip() {
   return (
     <section className="idt-trust-strip" aria-label="Credibility and proof">
       <div className="idt-shell">
-        <p>Transparent by design: open-source core, public docs, and documented security process.</p>
-        <div className="idt-logo-row">
-          {CREDIBILITY_SIGNALS.map((signal) => (
-            <span key={signal}>{signal}</span>
+        <p>Validate the product before you commit: review architecture, security posture, and output artifacts.</p>
+        <div className="idt-logo-row idt-proof-row">
+          {TRUST_PROOF_LINKS.map((entry) => (
+            entry.external ? (
+              <SafeLink key={entry.label} href={entry.href} className="idt-proof-link">
+                {entry.label}
+              </SafeLink>
+            ) : (
+              <Link key={entry.label} to={entry.href} className="idt-proof-link">
+                {entry.label}
+              </Link>
+            )
           ))}
         </div>
       </div>
@@ -1123,11 +1132,11 @@ function HomeFaqSection() {
     <section className="idt-section idt-shell">
       <SectionTitle
         eyebrow="FAQ"
-        title="Answers for security and platform teams evaluating adoption"
-        body="Each answer focuses on safe data access, deployment options, and rollout reliability."
+        title="Top evaluation questions"
+        body="Full FAQs live in docs. These are the four questions teams ask first."
       />
       <div className="idt-faq-list">
-        {HOME_FAQ_ITEMS.map((item) => (
+        {HOME_FAQ_PREVIEW.map((item) => (
           <details key={item.question} className="idt-faq-item">
             <summary>{item.question}</summary>
             <p>{item.answer}</p>
@@ -1246,16 +1255,16 @@ function HomePage() {
         <div className="idt-shell idt-hero-grid">
           <div className="idt-hero-copy">
             <p className="idt-eyebrow">Machine identity security</p>
-            <h1>See risky machine trust paths before attackers do.</h1>
+            <h1>See which machine identities can actually reach production.</h1>
             <p className="idt-lead">
-              Map AWS IAM, Kubernetes, and GitHub identity paths. Prioritize blast radius, then roll out safer access without breaking production.
+              Identrail maps AWS IAM, Kubernetes, GitHub, and OIDC trust paths in read-only mode so teams can prioritize reachable blast radius and roll out safer access.
             </p>
             <div className="idt-inline-actions" data-ab-slot="hero_primary_cta">
               <a href="#risk-scan-form" className="idt-btn idt-btn-primary">
-                Start Free Risk Scan
+                Start Read-Only Risk Scan
               </a>
-              <Link to="/enterprise" className="idt-btn idt-btn-dark">
-                Book Demo
+              <Link to="/demo" className="idt-btn idt-btn-dark">
+                Book Technical Demo
               </Link>
             </div>
           </div>
@@ -1265,55 +1274,20 @@ function HomePage() {
 
       <HomeCredibilityStrip />
 
-      <section className="idt-section idt-shell idt-impact-strip" aria-label="Impact snapshot">
-        <div className="idt-kpi-row">
-          <article>
-            <strong>87%</strong>
-            <span>Example reduction target for high-risk trust paths</span>
-          </article>
-          <article>
-            <strong>&lt; 15 min</strong>
-            <span>Typical time to first trust graph in hosted trial</span>
-          </article>
-          <article>
-            <strong>3x faster</strong>
-            <span>Observed triage acceleration in pilot workflows</span>
-          </article>
-        </div>
-      </section>
-
-      <section className="idt-section idt-shell">
-        <SectionTitle
-          eyebrow="Why This Matters"
-          title="Machine identity risk is hard to control when trust data is fragmented"
-          body="Security and platform teams need one view across AWS IAM, Kubernetes RBAC, OIDC relationships, and GitHub/GitOps workflows to understand real exposure."
-        />
-        <div className="idt-card-grid two-col">
-          <article className="idt-card">
-            <h3>What Identrail does</h3>
-            <p>Discovers machine identity trust paths and shows where risky access actually exists.</p>
-          </article>
-          <article className="idt-card">
-            <h3>Why it matters</h3>
-            <p>Hidden trust chains can turn one compromised workload into broad production access.</p>
-          </article>
-        </div>
-      </section>
-
       <section className="idt-section idt-shell">
         <LeadCaptureForm
           id="risk-scan-form"
           variant="short"
-          title="Start your free risk scan in under one minute"
-          caption="Share your work email and primary environment. Receive a practical 30-day risk reduction plan."
-          ctaLabel="Start Free Risk Scan"
+          title="Start a read-only risk scan in under one minute"
+          caption="Share your work email and primary environment. Receive a prioritized machine identity risk report and remediation sequence."
+          ctaLabel="Start Read-Only Risk Scan"
         />
       </section>
 
       <ProductProofFindingSection />
 
       <section className="idt-section idt-shell">
-        <SectionTitle eyebrow="How It Works" title="From data collection to safe control in four steps" />
+        <SectionTitle eyebrow="How It Works" title="Discover, prioritize, simulate, and roll out in four steps" />
         <ol className="idt-steps">
           <li>
             <h3>1. Connect data sources</h3>
@@ -1338,9 +1312,9 @@ function HomePage() {
 
       <section className="idt-section idt-shell">
         <SectionTitle
-          eyebrow="Open-Core Advantage"
-          title="Purpose-built alternative to closed machine identity platforms"
-          body="Open-core transparency, fast time-to-value, and enterprise controls without vendor lock-in."
+          eyebrow="Evaluation Criteria"
+          title="Evaluate machine identity platforms on operational evidence"
+          body="Use criteria that map to real risk reduction, rollout safety, and platform-team execution."
         />
         <div className="idt-table-wrap">
           <table className="idt-compare-table">
@@ -1364,27 +1338,20 @@ function HomePage() {
         </div>
       </section>
 
-      <section className="idt-section idt-shell">
-        <RoiCalculator />
-        <p className="idt-roi-disclaimer">
-          ROI estimate is a model: labor savings = weekly triage hours × 52 × $110; incident exposure reduction uses a 0.87 coefficient; high-risk identity reduction uses 0.32.
-        </p>
-      </section>
-
       <HomeFaqSection />
 
       <section className="idt-section idt-shell idt-final-cta" id="start">
         <SectionTitle
-          eyebrow="Get Started"
-          title="Move from trust-path uncertainty to controlled machine identity risk"
-          body="Start with a free risk scan, then book a technical demo for your environment."
+          eyebrow="Start With Evidence"
+          title="Run a read-only machine identity risk scan"
+          body="Get prioritized trust paths, blast-radius context, and rollout-safe remediation guidance."
         />
         <div className="idt-inline-actions">
           <Link to="/pricing" className="idt-btn idt-btn-primary">
-            Start Free Risk Scan
+            Start Read-Only Risk Scan
           </Link>
-          <Link to="/enterprise" className="idt-btn idt-btn-dark">
-            Book Demo
+          <Link to="/demo" className="idt-btn idt-btn-dark">
+            Book Technical Demo
           </Link>
         </div>
       </section>
@@ -2359,6 +2326,7 @@ export function RoutedSite() {
           <Route path="/" element={<HomePage />} />
           <Route path="/product" element={<ProductPage />} />
           <Route path="/features" element={<FeaturesPage />} />
+          <Route path="/integrations" element={<FeaturesPage />} />
           {FEATURE_DEEP_PAGES.map((page) => (
             <Route key={page.slug} path={`/features/${page.slug}`} element={<FeatureDetailPage page={page} />} />
           ))}
@@ -2367,6 +2335,7 @@ export function RoutedSite() {
             <Route key={page.slug} path={`/solutions/${page.slug}`} element={<SolutionDetailPage page={page} />} />
           ))}
           <Route path="/pricing" element={<PricingPage />} />
+          <Route path="/deployment-models" element={<PricingPage />} />
           <Route path="/demo" element={<DemoPage />} />
           <Route path="/docs" element={<DocsPage />} />
           <Route path="/blog" element={<BlogPage />} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,8 @@
 import { FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
-import { BrowserRouter, Link, NavLink, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { BrowserRouter, Link, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { SafeLink } from './components/SafeLink';
+import { Footer } from './components/layout/Footer';
+import { Header } from './components/layout/Header';
 import { apiClient } from './api/client';
 import { BLOG_POSTS, DOC_ENTRIES, HOME_FAQ_ITEMS } from './content/resources';
 
@@ -945,77 +947,6 @@ function RoiCalculator() {
   );
 }
 
-function Header() {
-  const [menuOpen, setMenuOpen] = useState(false);
-  const location = useLocation();
-
-  useEffect(() => {
-    setMenuOpen(false);
-  }, [location.pathname]);
-
-  useEffect(() => {
-    if (!menuOpen) {
-      return;
-    }
-
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setMenuOpen(false);
-      }
-    };
-
-    document.addEventListener('keydown', onKeyDown);
-    return () => document.removeEventListener('keydown', onKeyDown);
-  }, [menuOpen]);
-
-  return (
-    <header className="idt-header">
-      <div className="idt-shell idt-header-row">
-        <Link to="/" className="idt-brand" aria-label="Identrail homepage">
-          <img src="/identrail-logo.png" width="32" height="32" alt="Identrail" />
-          <span>
-            Identrail
-            <small>Machine Identity Security</small>
-          </span>
-        </Link>
-
-        <button
-          className="idt-menu-toggle"
-          type="button"
-          onClick={() => setMenuOpen((prev) => !prev)}
-          aria-expanded={menuOpen}
-          aria-controls="primary-nav"
-          aria-label="Toggle primary navigation"
-        >
-          Menu
-        </button>
-
-        <nav id="primary-nav" className={`idt-nav ${menuOpen ? 'is-open' : ''}`} aria-label="Primary">
-          {NAV_LINKS.map((item) => (
-            <NavLink
-              key={item.to}
-              to={item.to}
-              className={({ isActive }) => (isActive ? 'is-active' : '')}
-              onClick={() => setMenuOpen(false)}
-            >
-              {item.label}
-            </NavLink>
-          ))}
-        </nav>
-
-        <div className="idt-header-actions">
-          <Link to="/pricing" className="idt-btn idt-btn-primary" data-ab-slot="header_primary_cta">
-            Start Read-Only Risk Scan
-          </Link>
-          <Link to="/demo" className="idt-btn idt-btn-dark">
-            Book Technical Demo
-          </Link>
-        </div>
-      </div>
-    </header>
-  );
-}
-
 function DeploymentPathBanner() {
   return (
     <section className="idt-section idt-shell idt-deployment-bridge" aria-label="Adoption paths">
@@ -1144,96 +1075,6 @@ function HomeFaqSection() {
         ))}
       </div>
     </section>
-  );
-}
-
-function GitHubIcon() {
-  return (
-    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
-      <path
-        fill="currentColor"
-        d="M12 2C6.48 2 2 6.59 2 12.25c0 4.52 2.87 8.35 6.84 9.7.5.1.68-.22.68-.49 0-.24-.01-.89-.01-1.75-2.78.62-3.37-1.37-3.37-1.37-.46-1.2-1.12-1.51-1.12-1.51-.92-.64.07-.63.07-.63 1.02.08 1.55 1.07 1.55 1.07.9 1.59 2.37 1.13 2.95.87.09-.67.35-1.13.64-1.39-2.22-.26-4.56-1.14-4.56-5.08 0-1.12.39-2.03 1.03-2.74-.1-.26-.45-1.31.1-2.73 0 0 .84-.27 2.75 1.05A9.4 9.4 0 0 1 12 6.8c.85 0 1.7.12 2.5.36 1.9-1.32 2.74-1.05 2.74-1.05.56 1.42.21 2.47.11 2.73.64.71 1.02 1.62 1.02 2.74 0 3.95-2.35 4.82-4.58 5.08.36.32.67.95.67 1.91 0 1.38-.01 2.49-.01 2.83 0 .27.18.6.69.49A10.25 10.25 0 0 0 22 12.25C22 6.59 17.52 2 12 2Z"
-      />
-    </svg>
-  );
-}
-
-function LinkedInIcon() {
-  return (
-    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
-      <path
-        fill="currentColor"
-        d="M22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003ZM7.119 20.452H3.555V9h3.564v11.452ZM5.337 7.433a2.063 2.063 0 1 1 0-4.126 2.063 2.063 0 0 1 0 4.126ZM20.452 20.452H16.89V14.89c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.94v5.659H9.344V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286Z"
-      />
-    </svg>
-  );
-}
-
-function DiscordIcon() {
-  return (
-    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
-      <path
-        fill="currentColor"
-        d="M19.79 5.59A15.66 15.66 0 0 0 15.9 4.4l-.19.4a14.54 14.54 0 0 1 3.71 1.19 11.77 11.77 0 0 0-3.62-1.13c-2.39-.26-4.79-.26-7.18 0A11.7 11.7 0 0 0 5 6a14.56 14.56 0 0 1 3.71-1.19l-.19-.4a15.7 15.7 0 0 0-3.88 1.18C2.2 9.24 1.52 12.79 1.86 16.29a15.95 15.95 0 0 0 4.77 2.42l.95-1.58c-.52-.2-1.01-.45-1.49-.73.13.1.27.19.41.28 2.06 1.15 4.35 1.52 6.5 1.52 2.15 0 4.44-.37 6.49-1.52.14-.09.28-.18.41-.28-.47.28-.97.53-1.49.73l.95 1.58a15.92 15.92 0 0 0 4.77-2.42c.4-4.06-.68-7.58-2.53-10.7ZM9.54 14.14c-.76 0-1.39-.72-1.39-1.61s.61-1.6 1.39-1.6c.78 0 1.4.72 1.39 1.6 0 .9-.61 1.61-1.39 1.61Zm4.93 0c-.76 0-1.39-.72-1.39-1.61s.61-1.6 1.39-1.6c.78 0 1.4.72 1.39 1.6 0 .9-.61 1.61-1.39 1.61Z"
-      />
-    </svg>
-  );
-}
-
-function XIcon() {
-  return (
-    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
-      <path
-        fill="currentColor"
-        d="M18.901 1.153h3.68l-8.04 9.19 9.46 12.504H16.62l-5.778-7.553-6.607 7.553H.552l8.603-9.834L0 1.154h7.57l5.215 6.882 6.116-6.883Zm-1.291 19.496h2.039L6.463 3.237H4.276L17.61 20.649Z"
-      />
-    </svg>
-  );
-}
-
-function Footer() {
-  const footerLinks = [
-    { to: '/product', label: 'Product' },
-    { to: '/solutions', label: 'Solutions' },
-    { to: '/pricing', label: 'Pricing' },
-    { to: '/demo', label: 'Demo' },
-    { to: '/docs', label: 'Docs' },
-    { to: '/blog', label: 'Blog' },
-    { to: '/security', label: 'Security' },
-    { to: '/about', label: 'About' },
-    { to: '/privacy', label: 'Privacy' },
-    { to: '/terms', label: 'Terms' }
-  ] as const;
-
-  return (
-    <footer className="idt-footer">
-      <div className="idt-footer-bar">
-        <div className="idt-shell idt-footer-bar-row">
-          <nav className="idt-footer-links" aria-label="Footer">
-            {footerLinks.map((item) => (
-              <Link key={item.to} to={item.to}>
-                {item.label}
-              </Link>
-            ))}
-          </nav>
-          <small>© {new Date().getFullYear()} Identrail. All rights reserved.</small>
-          <div className="idt-footer-socials">
-            <SafeLink href={X_URL} aria-label="X" className="idt-social-link">
-              <XIcon />
-            </SafeLink>
-            <SafeLink href={LINKEDIN_URL} aria-label="LinkedIn" className="idt-social-link">
-              <LinkedInIcon />
-            </SafeLink>
-            <SafeLink href={GITHUB_REPO} aria-label="GitHub" className="idt-social-link">
-              <GitHubIcon />
-            </SafeLink>
-            <SafeLink href={DISCORD_URL} aria-label="Discord" className="idt-social-link">
-              <DiscordIcon />
-            </SafeLink>
-          </div>
-        </div>
-      </div>
-    </footer>
   );
 }
 
@@ -2319,7 +2160,7 @@ export function RoutedSite() {
         Skip to content
       </a>
 
-      <Header />
+      <Header navLinks={NAV_LINKS} />
 
       <main id="main-content">
         <Routes>
@@ -2350,7 +2191,7 @@ export function RoutedSite() {
         </Routes>
       </main>
 
-      <Footer />
+      <Footer xUrl={X_URL} linkedInUrl={LINKEDIN_URL} githubRepo={GITHUB_REPO} discordUrl={DISCORD_URL} />
       <ExitIntentPopup />
     </div>
   );

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
-import { BrowserRouter, Link, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { BrowserRouter, Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { SafeLink } from './components/SafeLink';
 import { Footer } from './components/layout/Footer';
 import { Header } from './components/layout/Header';
@@ -2167,7 +2167,7 @@ export function RoutedSite() {
           <Route path="/" element={<HomePage />} />
           <Route path="/product" element={<ProductPage />} />
           <Route path="/features" element={<FeaturesPage />} />
-          <Route path="/integrations" element={<FeaturesPage />} />
+          <Route path="/integrations" element={<Navigate to="/features" replace />} />
           {FEATURE_DEEP_PAGES.map((page) => (
             <Route key={page.slug} path={`/features/${page.slug}`} element={<FeatureDetailPage page={page} />} />
           ))}
@@ -2176,7 +2176,7 @@ export function RoutedSite() {
             <Route key={page.slug} path={`/solutions/${page.slug}`} element={<SolutionDetailPage page={page} />} />
           ))}
           <Route path="/pricing" element={<PricingPage />} />
-          <Route path="/deployment-models" element={<PricingPage />} />
+          <Route path="/deployment-models" element={<Navigate to="/pricing" replace />} />
           <Route path="/demo" element={<DemoPage />} />
           <Route path="/docs" element={<DocsPage />} />
           <Route path="/blog" element={<BlogPage />} />

--- a/web/src/components/home/HeroProductReveal.tsx
+++ b/web/src/components/home/HeroProductReveal.tsx
@@ -1,0 +1,47 @@
+import { Link } from 'react-router-dom';
+
+const PATH_SUMMARY = 'GitHub Actions OIDC → AWS Role → K8s Service Account → RDS Billing Resource';
+
+const PROOF_ITEMS = [
+  { label: 'Blast radius', value: '11 production resources reachable' },
+  { label: 'Exposure type', value: 'Federated identity chain with broad role trust' },
+  { label: 'Safe first action', value: 'Constrain role trust subject claims, then simulate rollout' }
+] as const;
+
+export function HeroProductReveal() {
+  return (
+    <div className="idt-graph-visual" aria-label="Trust path product preview">
+      <div className="idt-graph-grid" />
+      <div className="idt-node idt-node-root">GitHub Actions OIDC</div>
+      <div className="idt-node idt-node-role">AWS Role: billing-prod</div>
+      <div className="idt-node idt-node-k8s">K8s SA: payments-api</div>
+      <div className="idt-node idt-node-repo">RDS: billing-ledger</div>
+      <span className="idt-edge idt-edge-a" />
+      <span className="idt-edge idt-edge-b" />
+      <span className="idt-edge idt-edge-c" />
+      <span className="idt-pulse idt-pulse-a" />
+      <span className="idt-pulse idt-pulse-b" />
+
+      <aside className="idt-hero-graph-caption idt-hero-proof-card">
+        <p className="idt-hero-graph-title">Selected risk path</p>
+        <p className="idt-hero-path">{PATH_SUMMARY}</p>
+        <div className="idt-hero-proof-meta">
+          <span className="idt-severity-pill">High</span>
+          <span>4-hop chain</span>
+          <span>Read-only analysis</span>
+        </div>
+        <dl className="idt-hero-proof-list">
+          {PROOF_ITEMS.map((item) => (
+            <div key={item.label}>
+              <dt>{item.label}</dt>
+              <dd>{item.value}</dd>
+            </div>
+          ))}
+        </dl>
+        <Link to="/demo" className="idt-inline-link">
+          Open technical demo
+        </Link>
+      </aside>
+    </div>
+  );
+}

--- a/web/src/components/home/RiskInsightSection.tsx
+++ b/web/src/components/home/RiskInsightSection.tsx
@@ -1,0 +1,97 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+const SCENARIOS = [
+  {
+    id: 'oidc-prod',
+    name: 'CI OIDC to prod DB',
+    severity: 'High',
+    path: 'GitHub Actions OIDC → AWS Role → K8s SA → RDS billing-ledger',
+    impact: 'Compromised CI workflow token can reach production billing data in one chain.',
+    signal: '11 reachable resources',
+    firstAction: 'Tighten trust policy subject claims and reduce role action scope.'
+  },
+  {
+    id: 'k8s-pivot',
+    name: 'K8s service-account pivot',
+    severity: 'High',
+    path: 'K8s ServiceAccount → ClusterRoleBinding → IAM role assumption → Artifact bucket',
+    impact: 'Overprivileged service account can pivot across namespace boundary into cloud resources.',
+    signal: '7 cross-namespace privilege links',
+    firstAction: 'Split SA identity by workload and enforce namespace-scoped RBAC.'
+  },
+  {
+    id: 'repo-secret',
+    name: 'Leaked deploy token chain',
+    severity: 'Medium',
+    path: 'Repo secret leak → Bot identity replay → AssumeRole → Container registry push',
+    impact: 'Leaked token can ship unauthorized container images into production path.',
+    signal: '4 privileged registry actions exposed',
+    firstAction: 'Rotate credentials and enforce short-lived workload identity tokens.'
+  }
+] as const;
+
+export function RiskInsightSection() {
+  const [activeScenarioId, setActiveScenarioId] = useState<(typeof SCENARIOS)[number]['id']>('oidc-prod');
+
+  const activeScenario = useMemo(
+    () => SCENARIOS.find((scenario) => scenario.id === activeScenarioId) ?? SCENARIOS[0],
+    [activeScenarioId]
+  );
+
+  return (
+    <section className="idt-section idt-shell" aria-labelledby="risk-insight-title">
+      <div className="idt-section-title">
+        <p className="idt-eyebrow">Reachable Risk Paths</p>
+        <h2 id="risk-insight-title">Prioritize machine identity findings by real impact</h2>
+        <p>
+          Each finding includes path evidence, severity, and a safe first remediation action. Start with what can actually reach
+          production.
+        </p>
+      </div>
+
+      <div className="idt-risk-insight-grid">
+        <div className="idt-risk-scenario-list" role="tablist" aria-label="Risk path scenarios">
+          {SCENARIOS.map((scenario) => {
+            const isActive = scenario.id === activeScenario.id;
+            return (
+              <button
+                key={scenario.id}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                className={`idt-risk-scenario-item ${isActive ? 'is-active' : ''}`}
+                onClick={() => setActiveScenarioId(scenario.id)}
+              >
+                <span>{scenario.name}</span>
+                <small>{scenario.severity}</small>
+              </button>
+            );
+          })}
+        </div>
+
+        <article className="idt-card idt-risk-evidence-card" role="tabpanel" aria-live="polite">
+          <p className="idt-finding-label">Selected path</p>
+          <h3>{activeScenario.path}</h3>
+          <p>
+            <strong>Impact:</strong> {activeScenario.impact}
+          </p>
+          <p>
+            <strong>Evidence signal:</strong> {activeScenario.signal}
+          </p>
+          <p>
+            <strong>Safe first action:</strong> {activeScenario.firstAction}
+          </p>
+          <div className="idt-inline-actions">
+            <Link to="/pricing" className="idt-btn idt-btn-primary">
+              Start Read-Only Risk Scan
+            </Link>
+            <Link to="/demo" className="idt-btn idt-btn-dark">
+              Open technical demo
+            </Link>
+          </div>
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/home/TrustProofStrip.tsx
+++ b/web/src/components/home/TrustProofStrip.tsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router-dom';
+import { SafeLink } from '../SafeLink';
+import { TRUST_PROOF_LINKS } from '../../content/proofArtifacts';
+
+export function TrustProofStrip() {
+  return (
+    <section className="idt-trust-strip" aria-label="Credibility and proof">
+      <div className="idt-shell">
+        <p>Validate the product before you commit: inspect architecture, outputs, and security process.</p>
+        <div className="idt-logo-row idt-proof-row">
+          {TRUST_PROOF_LINKS.map((entry) => (
+            <article key={entry.label} className="idt-proof-item">
+              {entry.external ? (
+                <SafeLink href={entry.href} className="idt-proof-link">
+                  {entry.label}
+                </SafeLink>
+              ) : (
+                <Link to={entry.href} className="idt-proof-link">
+                  {entry.label}
+                </Link>
+              )}
+              <p>{entry.description}</p>
+              <small>{entry.freshness}</small>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/layout/Footer.tsx
+++ b/web/src/components/layout/Footer.tsx
@@ -1,0 +1,99 @@
+import { Link } from 'react-router-dom';
+import { SafeLink } from '../SafeLink';
+
+function GitHubIcon() {
+  return (
+    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M12 2C6.48 2 2 6.59 2 12.25c0 4.52 2.87 8.35 6.84 9.7.5.1.68-.22.68-.49 0-.24-.01-.89-.01-1.75-2.78.62-3.37-1.37-3.37-1.37-.46-1.2-1.12-1.51-1.12-1.51-.92-.64.07-.63.07-.63 1.02.08 1.55 1.07 1.55 1.07.9 1.59 2.37 1.13 2.95.87.09-.67.35-1.13.64-1.39-2.22-.26-4.56-1.14-4.56-5.08 0-1.12.39-2.03 1.03-2.74-.1-.26-.45-1.31.1-2.73 0 0 .84-.27 2.75 1.05A9.4 9.4 0 0 1 12 6.8c.85 0 1.7.12 2.5.36 1.9-1.32 2.74-1.05 2.74-1.05.56 1.42.21 2.47.11 2.73.64.71 1.02 1.62 1.02 2.74 0 3.95-2.35 4.82-4.58 5.08.36.32.67.95.67 1.91 0 1.38-.01 2.49-.01 2.83 0 .27.18.6.69.49A10.25 10.25 0 0 0 22 12.25C22 6.59 17.52 2 12 2Z"
+      />
+    </svg>
+  );
+}
+
+function LinkedInIcon() {
+  return (
+    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003ZM7.119 20.452H3.555V9h3.564v11.452ZM5.337 7.433a2.063 2.063 0 1 1 0-4.126 2.063 2.063 0 0 1 0 4.126ZM20.452 20.452H16.89V14.89c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.94v5.659H9.344V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286Z"
+      />
+    </svg>
+  );
+}
+
+function DiscordIcon() {
+  return (
+    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M19.79 5.59A15.66 15.66 0 0 0 15.9 4.4l-.19.4a14.54 14.54 0 0 1 3.71 1.19 11.77 11.77 0 0 0-3.62-1.13c-2.39-.26-4.79-.26-7.18 0A11.7 11.7 0 0 0 5 6a14.56 14.56 0 0 1 3.71-1.19l-.19-.4a15.7 15.7 0 0 0-3.88 1.18C2.2 9.24 1.52 12.79 1.86 16.29a15.95 15.95 0 0 0 4.77 2.42l.95-1.58c-.52-.2-1.01-.45-1.49-.73.13.1.27.19.41.28 2.06 1.15 4.35 1.52 6.5 1.52 2.15 0 4.44-.37 6.49-1.52.14-.09.28-.18.41-.28-.47.28-.97.53-1.49.73l.95 1.58a15.92 15.92 0 0 0 4.77-2.42c.4-4.06-.68-7.58-2.53-10.7ZM9.54 14.14c-.76 0-1.39-.72-1.39-1.61s.61-1.6 1.39-1.6c.78 0 1.4.72 1.39 1.6 0 .9-.61 1.61-1.39 1.61Zm4.93 0c-.76 0-1.39-.72-1.39-1.61s.61-1.6 1.39-1.6c.78 0 1.4.72 1.39 1.6 0 .9-.61 1.61-1.39 1.61Z"
+      />
+    </svg>
+  );
+}
+
+function XIcon() {
+  return (
+    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M18.901 1.153h3.68l-8.04 9.19 9.46 12.504H16.62l-5.778-7.553-6.607 7.553H.552l8.603-9.834L0 1.154h7.57l5.215 6.882 6.116-6.883Zm-1.291 19.496h2.039L6.463 3.237H4.276L17.61 20.649Z"
+      />
+    </svg>
+  );
+}
+
+type FooterProps = {
+  xUrl: string;
+  linkedInUrl: string;
+  githubRepo: string;
+  discordUrl: string;
+};
+
+const FOOTER_LINKS = [
+  { to: '/product', label: 'Product' },
+  { to: '/solutions', label: 'Solutions' },
+  { to: '/pricing', label: 'Pricing' },
+  { to: '/demo', label: 'Demo' },
+  { to: '/docs', label: 'Docs' },
+  { to: '/blog', label: 'Blog' },
+  { to: '/security', label: 'Security' },
+  { to: '/about', label: 'About' },
+  { to: '/privacy', label: 'Privacy' },
+  { to: '/terms', label: 'Terms' }
+] as const;
+
+export function Footer({ xUrl, linkedInUrl, githubRepo, discordUrl }: FooterProps) {
+  return (
+    <footer className="idt-footer">
+      <div className="idt-footer-bar">
+        <div className="idt-shell idt-footer-bar-row">
+          <nav className="idt-footer-links" aria-label="Footer">
+            {FOOTER_LINKS.map((item) => (
+              <Link key={item.to} to={item.to}>
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+          <small>© {new Date().getFullYear()} Identrail. All rights reserved.</small>
+          <div className="idt-footer-socials">
+            <SafeLink href={xUrl} aria-label="X" className="idt-social-link">
+              <XIcon />
+            </SafeLink>
+            <SafeLink href={linkedInUrl} aria-label="LinkedIn" className="idt-social-link">
+              <LinkedInIcon />
+            </SafeLink>
+            <SafeLink href={githubRepo} aria-label="GitHub" className="idt-social-link">
+              <GitHubIcon />
+            </SafeLink>
+            <SafeLink href={discordUrl} aria-label="Discord" className="idt-social-link">
+              <DiscordIcon />
+            </SafeLink>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react';
+import { Link, NavLink, useLocation } from 'react-router-dom';
+
+type NavLinkItem = {
+  to: string;
+  label: string;
+};
+
+export function Header({ navLinks }: { navLinks: readonly NavLinkItem[] }) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const location = useLocation();
+
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [location.pathname]);
+
+  useEffect(() => {
+    if (!menuOpen) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [menuOpen]);
+
+  return (
+    <header className="idt-header">
+      <div className="idt-shell idt-header-row">
+        <Link to="/" className="idt-brand" aria-label="Identrail homepage">
+          <img src="/identrail-logo.png" width="32" height="32" alt="Identrail" />
+          <span>
+            Identrail
+            <small>Machine Identity Security</small>
+          </span>
+        </Link>
+
+        <button
+          className="idt-menu-toggle"
+          type="button"
+          onClick={() => setMenuOpen((prev) => !prev)}
+          aria-expanded={menuOpen}
+          aria-controls="primary-nav"
+          aria-label="Toggle primary navigation"
+        >
+          Menu
+        </button>
+
+        <nav id="primary-nav" className={`idt-nav ${menuOpen ? 'is-open' : ''}`} aria-label="Primary">
+          {navLinks.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              className={({ isActive }) => (isActive ? 'is-active' : '')}
+              onClick={() => setMenuOpen(false)}
+            >
+              {item.label}
+            </NavLink>
+          ))}
+        </nav>
+
+        <div className="idt-header-actions">
+          <Link to="/pricing" className="idt-btn idt-btn-primary" data-ab-slot="header_primary_cta">
+            Start Read-Only Risk Scan
+          </Link>
+          <Link to="/demo" className="idt-btn idt-btn-dark">
+            Book Technical Demo
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/web/src/content/proofArtifacts.ts
+++ b/web/src/content/proofArtifacts.ts
@@ -1,0 +1,45 @@
+export type ProofArtifact = {
+  label: string;
+  href: string;
+  external: boolean;
+  description: string;
+  freshness: string;
+};
+
+export const TRUST_PROOF_LINKS: readonly ProofArtifact[] = [
+  {
+    label: 'Architecture Docs',
+    href: 'https://github.com/identrail/identrail/tree/main/docs',
+    external: true,
+    description: 'System architecture, deployment patterns, and control boundaries.',
+    freshness: 'Updated monthly'
+  },
+  {
+    label: 'Read-Only Scan Model',
+    href: '/security',
+    external: false,
+    description: 'Permission scope and data access constraints for collection connectors.',
+    freshness: 'Policy tracked'
+  },
+  {
+    label: 'Sample Risk Report',
+    href: '/demo',
+    external: false,
+    description: 'Example findings with path evidence, severity, and remediation sequence.',
+    freshness: 'Redacted sample'
+  },
+  {
+    label: 'Changelog',
+    href: 'https://github.com/identrail/identrail/releases',
+    external: true,
+    description: 'Release cadence and shipped platform improvements.',
+    freshness: 'Versioned'
+  },
+  {
+    label: 'Responsible Disclosure',
+    href: '/security',
+    external: false,
+    description: 'Security issue reporting process and response expectations.',
+    freshness: 'Maintained'
+  }
+] as const;

--- a/web/src/content/proofArtifacts.ts
+++ b/web/src/content/proofArtifacts.ts
@@ -16,7 +16,7 @@ export const TRUST_PROOF_LINKS: readonly ProofArtifact[] = [
   },
   {
     label: 'Read-Only Scan Model',
-    href: '/security',
+    href: '/docs',
     external: false,
     description: 'Permission scope and data access constraints for collection connectors.',
     freshness: 'Policy tracked'

--- a/web/src/design/tokens/index.ts
+++ b/web/src/design/tokens/index.ts
@@ -1,0 +1,58 @@
+export const designTokens = {
+  color: {
+    surface: {
+      canvas: 'var(--surface-canvas)',
+      elevated: 'var(--surface-elevated)',
+      soft: 'var(--surface-soft)'
+    },
+    text: {
+      primary: 'var(--text-primary)',
+      muted: 'var(--text-muted)'
+    },
+    border: {
+      subtle: 'var(--border-subtle)'
+    },
+    accent: {
+      primary: 'var(--accent-primary)',
+      soft: 'var(--accent-soft)'
+    },
+    severity: {
+      high: {
+        fg: 'var(--severity-high-fg)',
+        pillFg: 'var(--severity-high-pill-fg)',
+        pillBg: 'var(--severity-high-pill-bg)'
+      }
+    }
+  },
+  typography: {
+    display: 'var(--font-display)',
+    body: 'var(--font-body)',
+    mono: 'var(--font-mono)'
+  },
+  radius: {
+    sm: 'var(--radius-sm)',
+    md: 'var(--radius-md)',
+    lg: 'var(--radius-lg)'
+  },
+  spacing: {
+    1: 'var(--space-1)',
+    2: 'var(--space-2)',
+    3: 'var(--space-3)',
+    4: 'var(--space-4)',
+    6: 'var(--space-6)',
+    8: 'var(--space-8)',
+    12: 'var(--space-12)',
+    16: 'var(--space-16)'
+  },
+  motion: {
+    fast: 'var(--motion-fast)',
+    base: 'var(--motion-base)',
+    slow: 'var(--motion-slow)'
+  },
+  layout: {
+    shellMaxWidth: 'var(--shell-max-width)'
+  },
+  shadow: {
+    elevated: 'var(--shadow-elevated)'
+  }
+} as const;

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
+import './styles/tokens.css';
 import './styles.css';
 
 createRoot(document.getElementById('root') as HTMLElement).render(

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -506,6 +506,55 @@ h3 {
   line-height: 1.45;
 }
 
+.idt-hero-path {
+  margin: 0.45rem 0 0.72rem;
+  color: #e6efff;
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.idt-hero-proof-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-bottom: 0.72rem;
+}
+
+.idt-hero-proof-meta span:not(.idt-severity-pill) {
+  border: 1px solid rgba(255, 255, 255, 0.17);
+  border-radius: 999px;
+  padding: 0.16rem 0.5rem;
+  color: #d4deef;
+  font-size: 0.64rem;
+  letter-spacing: 0.04em;
+}
+
+.idt-hero-proof-list {
+  margin: 0 0 0.8rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.idt-hero-proof-list div {
+  display: grid;
+  gap: 0.12rem;
+}
+
+.idt-hero-proof-list dt {
+  color: #a7b3c8;
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.idt-hero-proof-list dd {
+  margin: 0;
+  color: #e8f1ff;
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
 .idt-severity-high {
   color: var(--severity-high-fg);
   font-weight: 800;
@@ -558,6 +607,33 @@ h3 {
   gap: 0.6rem;
 }
 
+.idt-proof-row {
+  gap: 0.7rem;
+}
+
+.idt-proof-item {
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.02);
+  padding: 0.6rem 0.68rem;
+  display: grid;
+  gap: 0.3rem;
+  min-width: 220px;
+  flex: 1 1 220px;
+}
+
+.idt-proof-item p {
+  margin: 0;
+  color: #cbd5e7;
+  font-size: 0.72rem;
+  line-height: 1.4;
+}
+
+.idt-proof-item small {
+  color: #97a7c3;
+  font-size: 0.68rem;
+}
+
 .idt-logo-row span {
   border: 1px solid rgba(255, 255, 255, 0.18);
   border-radius: 999px;
@@ -570,13 +646,17 @@ h3 {
 }
 
 .idt-proof-link {
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border: 1px solid rgba(255, 255, 255, 0.16);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.03);
-  padding: 0.44rem 0.8rem;
-  font-size: 0.74rem;
-  color: #d7dff1;
-  letter-spacing: 0.03em;
+  padding: 0.3rem 0.62rem;
+  font-size: 0.7rem;
+  color: #dfe8fb;
+  letter-spacing: 0.02em;
+  font-weight: 700;
   text-decoration: none;
   transition: border-color 0.2s ease, background-color 0.2s ease;
 }
@@ -698,6 +778,29 @@ h3 {
   border-color: rgba(137, 169, 255, 0.74);
 }
 
+.idt-demo-view-toggle {
+  grid-column: 1 / -1;
+  display: inline-flex;
+  gap: 0.4rem;
+}
+
+.idt-demo-view-toggle button {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.03);
+  color: #dee8ff;
+  border-radius: 999px;
+  min-height: 32px;
+  padding: 0 0.72rem;
+  font-size: 0.72rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.idt-demo-view-toggle button.is-active {
+  border-color: rgba(158, 185, 255, 0.72);
+  background: rgba(158, 185, 255, 0.2);
+}
+
 .idt-demo-graph {
   min-height: 420px;
   padding: 1rem;
@@ -706,6 +809,38 @@ h3 {
   place-items: center;
   overflow: hidden;
   background: linear-gradient(160deg, rgba(10, 10, 12, 0.92), rgba(6, 6, 8, 0.95));
+}
+
+.idt-demo-list-view {
+  min-height: 420px;
+  display: grid;
+  gap: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 14px;
+  background: linear-gradient(160deg, rgba(10, 10, 12, 0.9), rgba(6, 6, 8, 0.93));
+  padding: 0.8rem;
+}
+
+.idt-demo-list-row {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.02);
+  color: #e8f1ff;
+  padding: 0.58rem 0.68rem;
+  text-align: left;
+  display: grid;
+  gap: 0.15rem;
+  cursor: pointer;
+}
+
+.idt-demo-list-row small {
+  color: #a6b5cd;
+  font-size: 0.74rem;
+}
+
+.idt-demo-list-row.is-active {
+  border-color: rgba(158, 185, 255, 0.72);
+  background: rgba(158, 185, 255, 0.14);
 }
 
 .idt-demo-node {
@@ -1946,6 +2081,46 @@ h2 {
   border-top: 1px solid var(--idt-line);
 }
 
+.idt-risk-insight-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.42fr) minmax(0, 1fr);
+  gap: 1rem;
+}
+
+.idt-risk-scenario-list {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.idt-risk-scenario-item {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.02);
+  color: #e6ecfb;
+  text-align: left;
+  padding: 0.68rem 0.75rem;
+  display: grid;
+  gap: 0.2rem;
+  cursor: pointer;
+}
+
+.idt-risk-scenario-item small {
+  font-size: 0.74rem;
+  color: #a2b0c7;
+}
+
+.idt-risk-scenario-item.is-active,
+.idt-risk-scenario-item:hover,
+.idt-risk-scenario-item:focus-visible {
+  border-color: rgba(172, 196, 255, 0.46);
+  background: rgba(172, 196, 255, 0.09);
+}
+
+.idt-risk-evidence-card {
+  display: grid;
+  gap: 0.54rem;
+}
+
 @media (max-width: 1080px) {
   .idt-header-row {
     grid-template-columns: auto auto;
@@ -1987,6 +2162,7 @@ h2 {
   .idt-demo-surface,
   .idt-pricing-grid,
   .idt-roi-grid,
+  .idt-risk-insight-grid,
   .idt-finding-proof-grid,
   .idt-adoption-grid,
   .idt-card-grid.two-col,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -587,6 +587,24 @@ h3 {
   text-transform: uppercase;
 }
 
+.idt-proof-link {
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.03);
+  padding: 0.44rem 0.8rem;
+  font-size: 0.74rem;
+  color: #d7dff1;
+  letter-spacing: 0.03em;
+  text-decoration: none;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.idt-proof-link:hover,
+.idt-proof-link:focus-visible {
+  border-color: rgba(215, 227, 255, 0.45);
+  background: rgba(215, 227, 255, 0.1);
+}
+
 .idt-section {
   padding: clamp(2.6rem, 6vw, 4.3rem) 0;
 }
@@ -1286,6 +1304,7 @@ h2 {
 .idt-kpi-row span,
 .idt-trust-strip p,
 .idt-logo-row span,
+.idt-proof-link,
 .idt-compare-table th,
 .idt-finding-label {
   text-transform: none;
@@ -1297,6 +1316,10 @@ h2 {
 }
 
 .idt-logo-row span {
+  font-size: 0.8rem;
+}
+
+.idt-proof-link {
   font-size: 0.8rem;
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,21 +1,3 @@
-:root {
-  --idt-bg: #030303;
-  --idt-bg-elevated: #0b0b0d;
-  --idt-bg-soft: #141416;
-  --idt-text: #f5f7fb;
-  --idt-text-muted: #9ca3b2;
-  --idt-line: rgba(245, 247, 251, 0.12);
-  --idt-accent: #d7e3ff;
-  --idt-accent-soft: rgba(215, 227, 255, 0.12);
-  --idt-glow: rgba(137, 169, 255, 0.32);
-  --idt-cta: linear-gradient(120deg, #ffffff 0%, #e8edf7 100%);
-  --idt-display: 'Barlow Semi Condensed', 'Space Grotesk', 'Inter', 'Segoe UI', sans-serif;
-  --idt-body: 'Inter', 'Segoe UI', sans-serif;
-  --idt-radius: 14px;
-  --idt-shell: 1200px;
-  --idt-shadow: 0 10px 28px rgba(0, 0, 0, 0.34);
-}
-
 * {
   box-sizing: border-box;
 }
@@ -43,7 +25,7 @@ a {
 }
 
 :focus-visible {
-  outline: 2px solid rgba(215, 227, 255, 0.72);
+  outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
 }
 
@@ -525,7 +507,7 @@ h3 {
 }
 
 .idt-severity-high {
-  color: #ffaca7;
+  color: var(--severity-high-fg);
   font-weight: 800;
 }
 
@@ -1803,8 +1785,8 @@ h2 {
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  background: rgba(255, 125, 125, 0.15);
-  color: #ffb4b1;
+  background: var(--severity-high-pill-bg);
+  color: var(--severity-high-pill-fg);
 }
 
 .idt-hero-preview-card dl {
@@ -1833,7 +1815,7 @@ h2 {
 }
 
 .idt-severity-high {
-  color: #ffaca7;
+  color: var(--severity-high-fg);
   font-weight: 800;
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1814,11 +1814,6 @@ h2 {
   font-size: 0.78rem;
 }
 
-.idt-severity-high {
-  color: var(--severity-high-fg);
-  font-weight: 800;
-}
-
 .idt-roi-field > span {
   font-size: 0.92rem;
   font-weight: 600;

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -1,0 +1,82 @@
+:root {
+  color-scheme: dark;
+
+  /* Primitive colors */
+  --color-neutral-950: #030303;
+  --color-neutral-925: #0b0b0d;
+  --color-neutral-900: #141416;
+  --color-neutral-100: #f5f7fb;
+  --color-neutral-300: #9ca3b2;
+
+  --color-blue-100: #d7e3ff;
+  --color-blue-200: #c4d5fb;
+  --color-blue-300: #a7c0ff;
+  --color-blue-500-a12: rgba(215, 227, 255, 0.12);
+  --color-blue-600-a32: rgba(137, 169, 255, 0.32);
+
+  --color-line: rgba(245, 247, 251, 0.12);
+  --color-white-strong: rgba(255, 255, 255, 0.85);
+  --color-black-shadow: rgba(0, 0, 0, 0.34);
+
+  --color-risk-high-fg: #ffaca7;
+  --color-risk-high-pill-fg: #ffb4b1;
+  --color-risk-high-pill-bg: rgba(255, 125, 125, 0.15);
+
+  /* Typography */
+  --font-display: 'Barlow Semi Condensed', 'Space Grotesk', 'Inter', 'Segoe UI', sans-serif;
+  --font-body: 'Inter', 'Segoe UI', sans-serif;
+  --font-mono: 'IBM Plex Mono', 'SFMono-Regular', 'Menlo', monospace;
+
+  /* Sizing + spacing */
+  --shell-max-width: 1200px;
+  --radius-sm: 10px;
+  --radius-md: 14px;
+  --radius-lg: 18px;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  /* Motion + elevation */
+  --motion-fast: 120ms;
+  --motion-base: 180ms;
+  --motion-slow: 260ms;
+  --shadow-elevated: 0 10px 28px var(--color-black-shadow);
+
+  /* Semantic tokens */
+  --surface-canvas: var(--color-neutral-950);
+  --surface-elevated: var(--color-neutral-925);
+  --surface-soft: var(--color-neutral-900);
+  --text-primary: var(--color-neutral-100);
+  --text-muted: var(--color-neutral-300);
+  --border-subtle: var(--color-line);
+  --accent-primary: var(--color-blue-100);
+  --accent-soft: var(--color-blue-500-a12);
+  --glow-soft: var(--color-blue-600-a32);
+  --cta-primary: linear-gradient(120deg, #ffffff 0%, #e8edf7 100%);
+  --focus-ring: rgba(215, 227, 255, 0.72);
+  --severity-high-fg: var(--color-risk-high-fg);
+  --severity-high-pill-fg: var(--color-risk-high-pill-fg);
+  --severity-high-pill-bg: var(--color-risk-high-pill-bg);
+
+  /* Legacy aliases for gradual migration */
+  --idt-bg: var(--surface-canvas);
+  --idt-bg-elevated: var(--surface-elevated);
+  --idt-bg-soft: var(--surface-soft);
+  --idt-text: var(--text-primary);
+  --idt-text-muted: var(--text-muted);
+  --idt-line: var(--border-subtle);
+  --idt-accent: var(--accent-primary);
+  --idt-accent-soft: var(--accent-soft);
+  --idt-glow: var(--glow-soft);
+  --idt-cta: var(--cta-primary);
+  --idt-display: var(--font-display);
+  --idt-body: var(--font-body);
+  --idt-radius: var(--radius-md);
+  --idt-shell: var(--shell-max-width);
+  --idt-shadow: var(--shadow-elevated);
+}


### PR DESCRIPTION
## Summary\n- compress homepage flow by removing weak/duplicative sections (impact stats + homepage ROI)\n- tighten top nav around product proof journeys (product, solutions, integrations, deployment, docs, pricing, security, demo)\n- upgrade trust strip to proof links and tighten FAQ preview to 4 core questions\n- align CTA language to read-only risk scan and technical demo\n\n## Validation\n- npm --prefix web run test -- --run\n

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compressed the homepage IA and tightened nav to drive users to a read-only scan and a technical demo. Added a selected-path hero reveal, interactive risk insights, and a graph/list trust explorer with standardized CTAs.

- **New Features**
  - Hero selected-path card with path summary, severity pill, blast radius, and “Open technical demo”.
  - Trust proof strip with artifact links/descriptions and freshness via `web/src/content/proofArtifacts.ts` (read-only scan model points to `/docs`).
  - “Reachable Risk Paths” section with scenario tabs showing impact, evidence signal, and a safe first action.
  - Trust explorer adds Graph/List modes; CTAs unified to “Start Read-Only Risk Scan” and “Book Technical Demo”.
  - In-page read-only scan intake (short form at `#risk-scan-form`) with updated copy and CTA.

- **Refactors**
  - Nav updated with `Integrations` and `Deployment`; added redirects: `/integrations` → `/features`, `/deployment-models` → `/pricing`.
  - Introduced semantic design tokens (`styles/tokens.css`, `design/tokens/index.ts`), imported in `web/src/main.tsx`; removed duplicate severity style.
  - Extracted `Header` and `Footer` to `web/src/components/layout/`; header uses prop-driven nav and two CTAs; removed GitHub button and blog from top nav.
  - Trimmed homepage content (removed KPI and ROI), retitled How It Works, and limited FAQ to the top 4.

<sup>Written for commit 3ffa4d0c16a3c6fb34bca0fcb51d426fb329bf59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

