### PR TITLE
refactor(web): establish semantic design token foundation

### DIFF
--- a/web/src/design/tokens/index.ts
+++ b/web/src/design/tokens/index.ts
@@ -1,0 +1,58 @@
+export const designTokens = {
+  color: {
+    surface: {
+      canvas: 'var(--surface-canvas)',
+      elevated: 'var(--surface-elevated)',
+      soft: 'var(--surface-soft)'
+    },
+    text: {
+      primary: 'var(--text-primary)',
+      muted: 'var(--text-muted)'
+    },
+    border: {
+      subtle: 'var(--border-subtle)'
+    },
+    accent: {
+      primary: 'var(--accent-primary)',
+      soft: 'var(--accent-soft)'
+    },
+    severity: {
+      high: {
+        fg: 'var(--severity-high-fg)',
+        pillFg: 'var(--severity-high-pill-fg)',
+        pillBg: 'var(--severity-high-pill-bg)'
+      }
+    }
+  },
+  typography: {
+    display: 'var(--font-display)',
+    body: 'var(--font-body)',
+    mono: 'var(--font-mono)'
+  },
+  radius: {
+    sm: 'var(--radius-sm)',
+    md: 'var(--radius-md)',
+    lg: 'var(--radius-lg)'
+  },
+  spacing: {
+    1: 'var(--space-1)',
+    2: 'var(--space-2)',
+    3: 'var(--space-3)',
+    4: 'var(--space-4)',
+    6: 'var(--space-6)',
+    8: 'var(--space-8)',
+    12: 'var(--space-12)',
+    16: 'var(--space-16)'
+  },
+  motion: {
+    fast: 'var(--motion-fast)',
+    base: 'var(--motion-base)',
+    slow: 'var(--motion-slow)'
+  },
+  layout: {
+    shellMaxWidth: 'var(--shell-max-width)'
+  },
+  shadow: {
+    elevated: 'var(--shadow-elevated)'
+  }
+} as const;

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
+import './styles/tokens.css';
 import './styles.css';
 
 createRoot(document.getElementById('root') as HTMLElement).render(

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,21 +1,3 @@
-:root {
-  --idt-bg: #030303;
-  --idt-bg-elevated: #0b0b0d;
-  --idt-bg-soft: #141416;
-  --idt-text: #f5f7fb;
-  --idt-text-muted: #9ca3b2;
-  --idt-line: rgba(245, 247, 251, 0.12);
-  --idt-accent: #d7e3ff;
-  --idt-accent-soft: rgba(215, 227, 255, 0.12);
-  --idt-glow: rgba(137, 169, 255, 0.32);
-  --idt-cta: linear-gradient(120deg, #ffffff 0%, #e8edf7 100%);
-  --idt-display: 'Barlow Semi Condensed', 'Space Grotesk', 'Inter', 'Segoe UI', sans-serif;
-  --idt-body: 'Inter', 'Segoe UI', sans-serif;
-  --idt-radius: 14px;
-  --idt-shell: 1200px;
-  --idt-shadow: 0 10px 28px rgba(0, 0, 0, 0.34);
-}
-
 * {
   box-sizing: border-box;
 }
@@ -43,7 +25,7 @@ a {
 }
 
 :focus-visible {
-  outline: 2px solid rgba(215, 227, 255, 0.72);
+  outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
 }
 
@@ -525,7 +507,7 @@ h3 {
 }
 
 .idt-severity-high {
-  color: #ffaca7;
+  color: var(--severity-high-fg);
   font-weight: 800;
 }
 
@@ -1803,8 +1785,8 @@ h2 {
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  background: rgba(255, 125, 125, 0.15);
-  color: #ffb4b1;
+  background: var(--severity-high-pill-bg);
+  color: var(--severity-high-pill-fg);
 }
 
 .idt-hero-preview-card dl {
@@ -1833,7 +1815,7 @@ h2 {
 }
 
 .idt-severity-high {
-  color: #ffaca7;
+  color: var(--severity-high-fg);
   font-weight: 800;
 }
 

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -1,0 +1,82 @@
+:root {
+  color-scheme: dark;
+
+  /* Primitive colors */
+  --color-neutral-950: #030303;
+  --color-neutral-925: #0b0b0d;
+  --color-neutral-900: #141416;
+  --color-neutral-100: #f5f7fb;
+  --color-neutral-300: #9ca3b2;
+
+  --color-blue-100: #d7e3ff;
+  --color-blue-200: #c4d5fb;
+  --color-blue-300: #a7c0ff;
+  --color-blue-500-a12: rgba(215, 227, 255, 0.12);
+  --color-blue-600-a32: rgba(137, 169, 255, 0.32);
+
+  --color-line: rgba(245, 247, 251, 0.12);
+  --color-white-strong: rgba(255, 255, 255, 0.85);
+  --color-black-shadow: rgba(0, 0, 0, 0.34);
+
+  --color-risk-high-fg: #ffaca7;
+  --color-risk-high-pill-fg: #ffb4b1;
+  --color-risk-high-pill-bg: rgba(255, 125, 125, 0.15);
+
+  /* Typography */
+  --font-display: 'Barlow Semi Condensed', 'Space Grotesk', 'Inter', 'Segoe UI', sans-serif;
+  --font-body: 'Inter', 'Segoe UI', sans-serif;
+  --font-mono: 'IBM Plex Mono', 'SFMono-Regular', 'Menlo', monospace;
+
+  /* Sizing + spacing */
+  --shell-max-width: 1200px;
+  --radius-sm: 10px;
+  --radius-md: 14px;
+  --radius-lg: 18px;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  /* Motion + elevation */
+  --motion-fast: 120ms;
+  --motion-base: 180ms;
+  --motion-slow: 260ms;
+  --shadow-elevated: 0 10px 28px var(--color-black-shadow);
+
+  /* Semantic tokens */
+  --surface-canvas: var(--color-neutral-950);
+  --surface-elevated: var(--color-neutral-925);
+  --surface-soft: var(--color-neutral-900);
+  --text-primary: var(--color-neutral-100);
+  --text-muted: var(--color-neutral-300);
+  --border-subtle: var(--color-line);
+  --accent-primary: var(--color-blue-100);
+  --accent-soft: var(--color-blue-500-a12);
+  --glow-soft: var(--color-blue-600-a32);
+  --cta-primary: linear-gradient(120deg, #ffffff 0%, #e8edf7 100%);
+  --focus-ring: rgba(215, 227, 255, 0.72);
+  --severity-high-fg: var(--color-risk-high-fg);
+  --severity-high-pill-fg: var(--color-risk-high-pill-fg);
+  --severity-high-pill-bg: var(--color-risk-high-pill-bg);
+
+  /* Legacy aliases for gradual migration */
+  --idt-bg: var(--surface-canvas);
+  --idt-bg-elevated: var(--surface-elevated);
+  --idt-bg-soft: var(--surface-soft);
+  --idt-text: var(--text-primary);
+  --idt-text-muted: var(--text-muted);
+  --idt-line: var(--border-subtle);
+  --idt-accent: var(--accent-primary);
+  --idt-accent-soft: var(--accent-soft);
+  --idt-glow: var(--glow-soft);
+  --idt-cta: var(--cta-primary);
+  --idt-display: var(--font-display);
+  --idt-body: var(--font-body);
+  --idt-radius: var(--radius-md);
+  --idt-shell: var(--shell-max-width);
+  --idt-shadow: var(--shadow-elevated);
+}


### PR DESCRIPTION
## Summary
- add semantic CSS token layer (`web/src/styles/tokens.css`) with color, type, spacing, motion, radius, and severity primitives
- add typed token map for component-level reuse (`web/src/design/tokens/index.ts`)
- wire token stylesheet at app entry (`web/src/main.tsx`)
- migrate key style references to semantic token usage (focus ring + severity styles) while keeping legacy aliases for safe incremental migration

## Validation
- npm --prefix web run test -- --run


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a semantic design token layer and a typed token map to standardize color, type, spacing, motion, and radius across the app. Tokens are loaded at app start, and focus ring + severity styles are migrated with legacy aliases for a safe rollout.

- **Refactors**
  - Add `web/src/styles/tokens.css` with primitives, semantic tokens, and legacy aliases.
  - Add `designTokens` map in `web/src/design/tokens/index.ts` for typed component usage.
  - Import tokens in `web/src/main.tsx`.
  - Update `web/src/styles.css` to use tokens for focus ring and severity styles; remove old root variables.

<sup>Written for commit fd11f3b43234975cb6b094741329407d218bca73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

