### PR TITLE
refactor(web): extract app shell header and footer components

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,8 @@
 import { FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
-import { BrowserRouter, Link, NavLink, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { BrowserRouter, Link, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { SafeLink } from './components/SafeLink';
+import { Footer } from './components/layout/Footer';
+import { Header } from './components/layout/Header';
 import { apiClient } from './api/client';
 import { BLOG_POSTS, DOC_ENTRIES, HOME_FAQ_ITEMS } from './content/resources';
 
@@ -945,77 +947,6 @@ function RoiCalculator() {
   );
 }
 
-function Header() {
-  const [menuOpen, setMenuOpen] = useState(false);
-  const location = useLocation();
-
-  useEffect(() => {
-    setMenuOpen(false);
-  }, [location.pathname]);
-
-  useEffect(() => {
-    if (!menuOpen) {
-      return;
-    }
-
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setMenuOpen(false);
-      }
-    };
-
-    document.addEventListener('keydown', onKeyDown);
-    return () => document.removeEventListener('keydown', onKeyDown);
-  }, [menuOpen]);
-
-  return (
-    <header className="idt-header">
-      <div className="idt-shell idt-header-row">
-        <Link to="/" className="idt-brand" aria-label="Identrail homepage">
-          <img src="/identrail-logo.png" width="32" height="32" alt="Identrail" />
-          <span>
-            Identrail
-            <small>Machine Identity Security</small>
-          </span>
-        </Link>
-
-        <button
-          className="idt-menu-toggle"
-          type="button"
-          onClick={() => setMenuOpen((prev) => !prev)}
-          aria-expanded={menuOpen}
-          aria-controls="primary-nav"
-          aria-label="Toggle primary navigation"
-        >
-          Menu
-        </button>
-
-        <nav id="primary-nav" className={`idt-nav ${menuOpen ? 'is-open' : ''}`} aria-label="Primary">
-          {NAV_LINKS.map((item) => (
-            <NavLink
-              key={item.to}
-              to={item.to}
-              className={({ isActive }) => (isActive ? 'is-active' : '')}
-              onClick={() => setMenuOpen(false)}
-            >
-              {item.label}
-            </NavLink>
-          ))}
-        </nav>
-
-        <div className="idt-header-actions">
-          <Link to="/pricing" className="idt-btn idt-btn-primary" data-ab-slot="header_primary_cta">
-            Start Read-Only Risk Scan
-          </Link>
-          <Link to="/demo" className="idt-btn idt-btn-dark">
-            Book Technical Demo
-          </Link>
-        </div>
-      </div>
-    </header>
-  );
-}
-
 function DeploymentPathBanner() {
   return (
     <section className="idt-section idt-shell idt-deployment-bridge" aria-label="Adoption paths">
@@ -1144,96 +1075,6 @@ function HomeFaqSection() {
         ))}
       </div>
     </section>
-  );
-}
-
-function GitHubIcon() {
-  return (
-    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
-      <path
-        fill="currentColor"
-        d="M12 2C6.48 2 2 6.59 2 12.25c0 4.52 2.87 8.35 6.84 9.7.5.1.68-.22.68-.49 0-.24-.01-.89-.01-1.75-2.78.62-3.37-1.37-3.37-1.37-.46-1.2-1.12-1.51-1.12-1.51-.92-.64.07-.63.07-.63 1.02.08 1.55 1.07 1.55 1.07.9 1.59 2.37 1.13 2.95.87.09-.67.35-1.13.64-1.39-2.22-.26-4.56-1.14-4.56-5.08 0-1.12.39-2.03 1.03-2.74-.1-.26-.45-1.31.1-2.73 0 0 .84-.27 2.75 1.05A9.4 9.4 0 0 1 12 6.8c.85 0 1.7.12 2.5.36 1.9-1.32 2.74-1.05 2.74-1.05.56 1.42.21 2.47.11 2.73.64.71 1.02 1.62 1.02 2.74 0 3.95-2.35 4.82-4.58 5.08.36.32.67.95.67 1.91 0 1.38-.01 2.49-.01 2.83 0 .27.18.6.69.49A10.25 10.25 0 0 0 22 12.25C22 6.59 17.52 2 12 2Z"
-      />
-    </svg>
-  );
-}
-
-function LinkedInIcon() {
-  return (
-    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
-      <path
-        fill="currentColor"
-        d="M22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003ZM7.119 20.452H3.555V9h3.564v11.452ZM5.337 7.433a2.063 2.063 0 1 1 0-4.126 2.063 2.063 0 0 1 0 4.126ZM20.452 20.452H16.89V14.89c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.94v5.659H9.344V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286Z"
-      />
-    </svg>
-  );
-}
-
-function DiscordIcon() {
-  return (
-    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
-      <path
-        fill="currentColor"
-        d="M19.79 5.59A15.66 15.66 0 0 0 15.9 4.4l-.19.4a14.54 14.54 0 0 1 3.71 1.19 11.77 11.77 0 0 0-3.62-1.13c-2.39-.26-4.79-.26-7.18 0A11.7 11.7 0 0 0 5 6a14.56 14.56 0 0 1 3.71-1.19l-.19-.4a15.7 15.7 0 0 0-3.88 1.18C2.2 9.24 1.52 12.79 1.86 16.29a15.95 15.95 0 0 0 4.77 2.42l.95-1.58c-.52-.2-1.01-.45-1.49-.73.13.1.27.19.41.28 2.06 1.15 4.35 1.52 6.5 1.52 2.15 0 4.44-.37 6.49-1.52.14-.09.28-.18.41-.28-.47.28-.97.53-1.49.73l.95 1.58a15.92 15.92 0 0 0 4.77-2.42c.4-4.06-.68-7.58-2.53-10.7ZM9.54 14.14c-.76 0-1.39-.72-1.39-1.61s.61-1.6 1.39-1.6c.78 0 1.4.72 1.39 1.6 0 .9-.61 1.61-1.39 1.61Zm4.93 0c-.76 0-1.39-.72-1.39-1.61s.61-1.6 1.39-1.6c.78 0 1.4.72 1.39 1.6 0 .9-.61 1.61-1.39 1.61Z"
-      />
-    </svg>
-  );
-}
-
-function XIcon() {
-  return (
-    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
-      <path
-        fill="currentColor"
-        d="M18.901 1.153h3.68l-8.04 9.19 9.46 12.504H16.62l-5.778-7.553-6.607 7.553H.552l8.603-9.834L0 1.154h7.57l5.215 6.882 6.116-6.883Zm-1.291 19.496h2.039L6.463 3.237H4.276L17.61 20.649Z"
-      />
-    </svg>
-  );
-}
-
-function Footer() {
-  const footerLinks = [
-    { to: '/product', label: 'Product' },
-    { to: '/solutions', label: 'Solutions' },
-    { to: '/pricing', label: 'Pricing' },
-    { to: '/demo', label: 'Demo' },
-    { to: '/docs', label: 'Docs' },
-    { to: '/blog', label: 'Blog' },
-    { to: '/security', label: 'Security' },
-    { to: '/about', label: 'About' },
-    { to: '/privacy', label: 'Privacy' },
-    { to: '/terms', label: 'Terms' }
-  ] as const;
-
-  return (
-    <footer className="idt-footer">
-      <div className="idt-footer-bar">
-        <div className="idt-shell idt-footer-bar-row">
-          <nav className="idt-footer-links" aria-label="Footer">
-            {footerLinks.map((item) => (
-              <Link key={item.to} to={item.to}>
-                {item.label}
-              </Link>
-            ))}
-          </nav>
-          <small>© {new Date().getFullYear()} Identrail. All rights reserved.</small>
-          <div className="idt-footer-socials">
-            <SafeLink href={X_URL} aria-label="X" className="idt-social-link">
-              <XIcon />
-            </SafeLink>
-            <SafeLink href={LINKEDIN_URL} aria-label="LinkedIn" className="idt-social-link">
-              <LinkedInIcon />
-            </SafeLink>
-            <SafeLink href={GITHUB_REPO} aria-label="GitHub" className="idt-social-link">
-              <GitHubIcon />
-            </SafeLink>
-            <SafeLink href={DISCORD_URL} aria-label="Discord" className="idt-social-link">
-              <DiscordIcon />
-            </SafeLink>
-          </div>
-        </div>
-      </div>
-    </footer>
   );
 }
 
@@ -2319,7 +2160,7 @@ export function RoutedSite() {
         Skip to content
       </a>
 
-      <Header />
+      <Header navLinks={NAV_LINKS} />
 
       <main id="main-content">
         <Routes>
@@ -2350,7 +2191,7 @@ export function RoutedSite() {
         </Routes>
       </main>
 
-      <Footer />
+      <Footer xUrl={X_URL} linkedInUrl={LINKEDIN_URL} githubRepo={GITHUB_REPO} discordUrl={DISCORD_URL} />
       <ExitIntentPopup />
     </div>
   );

--- a/web/src/components/layout/Footer.tsx
+++ b/web/src/components/layout/Footer.tsx
@@ -1,0 +1,99 @@
+import { Link } from 'react-router-dom';
+import { SafeLink } from '../SafeLink';
+
+function GitHubIcon() {
+  return (
+    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M12 2C6.48 2 2 6.59 2 12.25c0 4.52 2.87 8.35 6.84 9.7.5.1.68-.22.68-.49 0-.24-.01-.89-.01-1.75-2.78.62-3.37-1.37-3.37-1.37-.46-1.2-1.12-1.51-1.12-1.51-.92-.64.07-.63.07-.63 1.02.08 1.55 1.07 1.55 1.07.9 1.59 2.37 1.13 2.95.87.09-.67.35-1.13.64-1.39-2.22-.26-4.56-1.14-4.56-5.08 0-1.12.39-2.03 1.03-2.74-.1-.26-.45-1.31.1-2.73 0 0 .84-.27 2.75 1.05A9.4 9.4 0 0 1 12 6.8c.85 0 1.7.12 2.5.36 1.9-1.32 2.74-1.05 2.74-1.05.56 1.42.21 2.47.11 2.73.64.71 1.02 1.62 1.02 2.74 0 3.95-2.35 4.82-4.58 5.08.36.32.67.95.67 1.91 0 1.38-.01 2.49-.01 2.83 0 .27.18.6.69.49A10.25 10.25 0 0 0 22 12.25C22 6.59 17.52 2 12 2Z"
+      />
+    </svg>
+  );
+}
+
+function LinkedInIcon() {
+  return (
+    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003ZM7.119 20.452H3.555V9h3.564v11.452ZM5.337 7.433a2.063 2.063 0 1 1 0-4.126 2.063 2.063 0 0 1 0 4.126ZM20.452 20.452H16.89V14.89c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.94v5.659H9.344V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286Z"
+      />
+    </svg>
+  );
+}
+
+function DiscordIcon() {
+  return (
+    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M19.79 5.59A15.66 15.66 0 0 0 15.9 4.4l-.19.4a14.54 14.54 0 0 1 3.71 1.19 11.77 11.77 0 0 0-3.62-1.13c-2.39-.26-4.79-.26-7.18 0A11.7 11.7 0 0 0 5 6a14.56 14.56 0 0 1 3.71-1.19l-.19-.4a15.7 15.7 0 0 0-3.88 1.18C2.2 9.24 1.52 12.79 1.86 16.29a15.95 15.95 0 0 0 4.77 2.42l.95-1.58c-.52-.2-1.01-.45-1.49-.73.13.1.27.19.41.28 2.06 1.15 4.35 1.52 6.5 1.52 2.15 0 4.44-.37 6.49-1.52.14-.09.28-.18.41-.28-.47.28-.97.53-1.49.73l.95 1.58a15.92 15.92 0 0 0 4.77-2.42c.4-4.06-.68-7.58-2.53-10.7ZM9.54 14.14c-.76 0-1.39-.72-1.39-1.61s.61-1.6 1.39-1.6c.78 0 1.4.72 1.39 1.6 0 .9-.61 1.61-1.39 1.61Zm4.93 0c-.76 0-1.39-.72-1.39-1.61s.61-1.6 1.39-1.6c.78 0 1.4.72 1.39 1.6 0 .9-.61 1.61-1.39 1.61Z"
+      />
+    </svg>
+  );
+}
+
+function XIcon() {
+  return (
+    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M18.901 1.153h3.68l-8.04 9.19 9.46 12.504H16.62l-5.778-7.553-6.607 7.553H.552l8.603-9.834L0 1.154h7.57l5.215 6.882 6.116-6.883Zm-1.291 19.496h2.039L6.463 3.237H4.276L17.61 20.649Z"
+      />
+    </svg>
+  );
+}
+
+type FooterProps = {
+  xUrl: string;
+  linkedInUrl: string;
+  githubRepo: string;
+  discordUrl: string;
+};
+
+const FOOTER_LINKS = [
+  { to: '/product', label: 'Product' },
+  { to: '/solutions', label: 'Solutions' },
+  { to: '/pricing', label: 'Pricing' },
+  { to: '/demo', label: 'Demo' },
+  { to: '/docs', label: 'Docs' },
+  { to: '/blog', label: 'Blog' },
+  { to: '/security', label: 'Security' },
+  { to: '/about', label: 'About' },
+  { to: '/privacy', label: 'Privacy' },
+  { to: '/terms', label: 'Terms' }
+] as const;
+
+export function Footer({ xUrl, linkedInUrl, githubRepo, discordUrl }: FooterProps) {
+  return (
+    <footer className="idt-footer">
+      <div className="idt-footer-bar">
+        <div className="idt-shell idt-footer-bar-row">
+          <nav className="idt-footer-links" aria-label="Footer">
+            {FOOTER_LINKS.map((item) => (
+              <Link key={item.to} to={item.to}>
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+          <small>© {new Date().getFullYear()} Identrail. All rights reserved.</small>
+          <div className="idt-footer-socials">
+            <SafeLink href={xUrl} aria-label="X" className="idt-social-link">
+              <XIcon />
+            </SafeLink>
+            <SafeLink href={linkedInUrl} aria-label="LinkedIn" className="idt-social-link">
+              <LinkedInIcon />
+            </SafeLink>
+            <SafeLink href={githubRepo} aria-label="GitHub" className="idt-social-link">
+              <GitHubIcon />
+            </SafeLink>
+            <SafeLink href={discordUrl} aria-label="Discord" className="idt-social-link">
+              <DiscordIcon />
+            </SafeLink>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react';
+import { Link, NavLink, useLocation } from 'react-router-dom';
+
+type NavLinkItem = {
+  to: string;
+  label: string;
+};
+
+export function Header({ navLinks }: { navLinks: readonly NavLinkItem[] }) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const location = useLocation();
+
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [location.pathname]);
+
+  useEffect(() => {
+    if (!menuOpen) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [menuOpen]);
+
+  return (
+    <header className="idt-header">
+      <div className="idt-shell idt-header-row">
+        <Link to="/" className="idt-brand" aria-label="Identrail homepage">
+          <img src="/identrail-logo.png" width="32" height="32" alt="Identrail" />
+          <span>
+            Identrail
+            <small>Machine Identity Security</small>
+          </span>
+        </Link>
+
+        <button
+          className="idt-menu-toggle"
+          type="button"
+          onClick={() => setMenuOpen((prev) => !prev)}
+          aria-expanded={menuOpen}
+          aria-controls="primary-nav"
+          aria-label="Toggle primary navigation"
+        >
+          Menu
+        </button>
+
+        <nav id="primary-nav" className={`idt-nav ${menuOpen ? 'is-open' : ''}`} aria-label="Primary">
+          {navLinks.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              className={({ isActive }) => (isActive ? 'is-active' : '')}
+              onClick={() => setMenuOpen(false)}
+            >
+              {item.label}
+            </NavLink>
+          ))}
+        </nav>
+
+        <div className="idt-header-actions">
+          <Link to="/pricing" className="idt-btn idt-btn-primary" data-ab-slot="header_primary_cta">
+            Start Read-Only Risk Scan
+          </Link>
+          <Link to="/demo" className="idt-btn idt-btn-dark">
+            Book Technical Demo
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/web/src/design/tokens/index.ts
+++ b/web/src/design/tokens/index.ts
@@ -1,0 +1,58 @@
+export const designTokens = {
+  color: {
+    surface: {
+      canvas: 'var(--surface-canvas)',
+      elevated: 'var(--surface-elevated)',
+      soft: 'var(--surface-soft)'
+    },
+    text: {
+      primary: 'var(--text-primary)',
+      muted: 'var(--text-muted)'
+    },
+    border: {
+      subtle: 'var(--border-subtle)'
+    },
+    accent: {
+      primary: 'var(--accent-primary)',
+      soft: 'var(--accent-soft)'
+    },
+    severity: {
+      high: {
+        fg: 'var(--severity-high-fg)',
+        pillFg: 'var(--severity-high-pill-fg)',
+        pillBg: 'var(--severity-high-pill-bg)'
+      }
+    }
+  },
+  typography: {
+    display: 'var(--font-display)',
+    body: 'var(--font-body)',
+    mono: 'var(--font-mono)'
+  },
+  radius: {
+    sm: 'var(--radius-sm)',
+    md: 'var(--radius-md)',
+    lg: 'var(--radius-lg)'
+  },
+  spacing: {
+    1: 'var(--space-1)',
+    2: 'var(--space-2)',
+    3: 'var(--space-3)',
+    4: 'var(--space-4)',
+    6: 'var(--space-6)',
+    8: 'var(--space-8)',
+    12: 'var(--space-12)',
+    16: 'var(--space-16)'
+  },
+  motion: {
+    fast: 'var(--motion-fast)',
+    base: 'var(--motion-base)',
+    slow: 'var(--motion-slow)'
+  },
+  layout: {
+    shellMaxWidth: 'var(--shell-max-width)'
+  },
+  shadow: {
+    elevated: 'var(--shadow-elevated)'
+  }
+} as const;

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
+import './styles/tokens.css';
 import './styles.css';
 
 createRoot(document.getElementById('root') as HTMLElement).render(

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,21 +1,3 @@
-:root {
-  --idt-bg: #030303;
-  --idt-bg-elevated: #0b0b0d;
-  --idt-bg-soft: #141416;
-  --idt-text: #f5f7fb;
-  --idt-text-muted: #9ca3b2;
-  --idt-line: rgba(245, 247, 251, 0.12);
-  --idt-accent: #d7e3ff;
-  --idt-accent-soft: rgba(215, 227, 255, 0.12);
-  --idt-glow: rgba(137, 169, 255, 0.32);
-  --idt-cta: linear-gradient(120deg, #ffffff 0%, #e8edf7 100%);
-  --idt-display: 'Barlow Semi Condensed', 'Space Grotesk', 'Inter', 'Segoe UI', sans-serif;
-  --idt-body: 'Inter', 'Segoe UI', sans-serif;
-  --idt-radius: 14px;
-  --idt-shell: 1200px;
-  --idt-shadow: 0 10px 28px rgba(0, 0, 0, 0.34);
-}
-
 * {
   box-sizing: border-box;
 }
@@ -43,7 +25,7 @@ a {
 }
 
 :focus-visible {
-  outline: 2px solid rgba(215, 227, 255, 0.72);
+  outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
 }
 
@@ -525,7 +507,7 @@ h3 {
 }
 
 .idt-severity-high {
-  color: #ffaca7;
+  color: var(--severity-high-fg);
   font-weight: 800;
 }
 
@@ -1803,8 +1785,8 @@ h2 {
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  background: rgba(255, 125, 125, 0.15);
-  color: #ffb4b1;
+  background: var(--severity-high-pill-bg);
+  color: var(--severity-high-pill-fg);
 }
 
 .idt-hero-preview-card dl {
@@ -1833,7 +1815,7 @@ h2 {
 }
 
 .idt-severity-high {
-  color: #ffaca7;
+  color: var(--severity-high-fg);
   font-weight: 800;
 }
 

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -1,0 +1,82 @@
+:root {
+  color-scheme: dark;
+
+  /* Primitive colors */
+  --color-neutral-950: #030303;
+  --color-neutral-925: #0b0b0d;
+  --color-neutral-900: #141416;
+  --color-neutral-100: #f5f7fb;
+  --color-neutral-300: #9ca3b2;
+
+  --color-blue-100: #d7e3ff;
+  --color-blue-200: #c4d5fb;
+  --color-blue-300: #a7c0ff;
+  --color-blue-500-a12: rgba(215, 227, 255, 0.12);
+  --color-blue-600-a32: rgba(137, 169, 255, 0.32);
+
+  --color-line: rgba(245, 247, 251, 0.12);
+  --color-white-strong: rgba(255, 255, 255, 0.85);
+  --color-black-shadow: rgba(0, 0, 0, 0.34);
+
+  --color-risk-high-fg: #ffaca7;
+  --color-risk-high-pill-fg: #ffb4b1;
+  --color-risk-high-pill-bg: rgba(255, 125, 125, 0.15);
+
+  /* Typography */
+  --font-display: 'Barlow Semi Condensed', 'Space Grotesk', 'Inter', 'Segoe UI', sans-serif;
+  --font-body: 'Inter', 'Segoe UI', sans-serif;
+  --font-mono: 'IBM Plex Mono', 'SFMono-Regular', 'Menlo', monospace;
+
+  /* Sizing + spacing */
+  --shell-max-width: 1200px;
+  --radius-sm: 10px;
+  --radius-md: 14px;
+  --radius-lg: 18px;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  /* Motion + elevation */
+  --motion-fast: 120ms;
+  --motion-base: 180ms;
+  --motion-slow: 260ms;
+  --shadow-elevated: 0 10px 28px var(--color-black-shadow);
+
+  /* Semantic tokens */
+  --surface-canvas: var(--color-neutral-950);
+  --surface-elevated: var(--color-neutral-925);
+  --surface-soft: var(--color-neutral-900);
+  --text-primary: var(--color-neutral-100);
+  --text-muted: var(--color-neutral-300);
+  --border-subtle: var(--color-line);
+  --accent-primary: var(--color-blue-100);
+  --accent-soft: var(--color-blue-500-a12);
+  --glow-soft: var(--color-blue-600-a32);
+  --cta-primary: linear-gradient(120deg, #ffffff 0%, #e8edf7 100%);
+  --focus-ring: rgba(215, 227, 255, 0.72);
+  --severity-high-fg: var(--color-risk-high-fg);
+  --severity-high-pill-fg: var(--color-risk-high-pill-fg);
+  --severity-high-pill-bg: var(--color-risk-high-pill-bg);
+
+  /* Legacy aliases for gradual migration */
+  --idt-bg: var(--surface-canvas);
+  --idt-bg-elevated: var(--surface-elevated);
+  --idt-bg-soft: var(--surface-soft);
+  --idt-text: var(--text-primary);
+  --idt-text-muted: var(--text-muted);
+  --idt-line: var(--border-subtle);
+  --idt-accent: var(--accent-primary);
+  --idt-accent-soft: var(--accent-soft);
+  --idt-glow: var(--glow-soft);
+  --idt-cta: var(--cta-primary);
+  --idt-display: var(--font-display);
+  --idt-body: var(--font-body);
+  --idt-radius: var(--radius-md);
+  --idt-shell: var(--shell-max-width);
+  --idt-shadow: var(--shadow-elevated);
+}


### PR DESCRIPTION
## Summary
- extract `Header` into `web/src/components/layout/Header.tsx`
- extract `Footer` into `web/src/components/layout/Footer.tsx`
- keep behavior unchanged while reducing `App.tsx` app-shell coupling
- wire app shell through explicit props for nav and social links

## Validation
- npm --prefix web run test -- --run


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the app shell by extracting `Header` and `Footer` components and added semantic design tokens. Behavior is unchanged; `App.tsx` is smaller and styling now uses centralized tokens.

- **Refactors**
  - Moved `Header` to `web/src/components/layout/Header.tsx` and `Footer` to `web/src/components/layout/Footer.tsx`.
  - `Header` now takes `navLinks`; `Footer` takes `xUrl`, `linkedInUrl`, `githubRepo`, `discordUrl`.
  - Updated `web/src/App.tsx` to use the new components.
  - Added `web/src/styles/tokens.css` and `web/src/design/tokens/index.ts`; imported tokens in `web/src/main.tsx`.
  - Replaced hard-coded values in `web/src/styles.css` with token variables.

- **Migration**
  - Pass `navLinks` to `<Header />` and social URLs to `<Footer />` when using the app shell.

<sup>Written for commit 49f3aeaa731ab37f79f5fcad525847de5142bf52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

