### PR TITLE
feat(web): strengthen hero with selected-path product reveal

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -17,7 +17,7 @@ describe('App', () => {
     expect(screen.getAllByRole('link', { name: 'Start Read-Only Risk Scan' }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole('link', { name: 'Book Technical Demo' }).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Adoption Paths/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/Kubernetes service account can assume production AWS role/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Reachable Risk Paths/i).length).toBeGreaterThan(0);
   });
 
   it('renders pricing page routes and key elements', () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,8 @@ import { FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from 'reac
 import { BrowserRouter, Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { SafeLink } from './components/SafeLink';
 import { HeroProductReveal } from './components/home/HeroProductReveal';
+import { RiskInsightSection } from './components/home/RiskInsightSection';
+import { TrustProofStrip } from './components/home/TrustProofStrip';
 import { Footer } from './components/layout/Footer';
 import { Header } from './components/layout/Header';
 import { apiClient } from './api/client';
@@ -43,14 +45,6 @@ const NAV_LINKS = [
   { to: '/pricing', label: 'Pricing' },
   { to: '/security', label: 'Security' },
   { to: '/demo', label: 'Demo' }
-] as const;
-
-const TRUST_PROOF_LINKS = [
-  { label: 'Architecture Docs', href: DOCS_REPO, external: true },
-  { label: 'Read-Only Scan Model', href: '/security', external: false },
-  { label: 'Sample Risk Report', href: '/demo', external: false },
-  { label: 'Changelog', href: `${GITHUB_REPO}/releases`, external: true },
-  { label: 'Responsible Disclosure', href: '/security', external: false }
 ] as const;
 
 const HOME_FAQ_PREVIEW = HOME_FAQ_ITEMS.slice(0, 4);
@@ -703,6 +697,7 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
   ] as const;
 
   const [scenarioId, setScenarioId] = useState<(typeof scenarios)[number]['id']>('cicd');
+  const [viewMode, setViewMode] = useState<'graph' | 'list'>('graph');
   const nodes = [
     {
       id: 'oidc',
@@ -737,39 +732,54 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
 
   return (
     <section className={`idt-demo-surface ${variant === 'full' ? 'is-full' : ''}`}>
-      {variant === 'full' ? (
-        <div className="idt-demo-toolbar" role="group" aria-label="Demo scenarios">
-          <p>Scenario</p>
-          <div className="idt-demo-scenario-row">
-            {scenarios.map((item) => (
-              <button
-                key={item.id}
-                type="button"
-                className={item.id === scenarioId ? 'is-active' : ''}
-                onClick={() => setScenarioId(item.id)}
-              >
-                {item.label}
-              </button>
-            ))}
-          </div>
+      <div className="idt-demo-toolbar" role="group" aria-label="Demo scenarios">
+        <p>Scenario</p>
+        <div className="idt-demo-scenario-row">
+          {scenarios.map((item) => (
+            <button key={item.id} type="button" className={item.id === scenarioId ? 'is-active' : ''} onClick={() => setScenarioId(item.id)}>
+              {item.label}
+            </button>
+          ))}
         </div>
-      ) : null}
-      <div className="idt-demo-graph" role="img" aria-label="Interactive trust graph simulation">
-        {nodes.map((node) => (
-          <button
-            key={node.id}
-            type="button"
-            className={`idt-demo-node ${selected.id === node.id ? 'is-active' : ''}`}
-            onClick={() => setSelectedId(node.id)}
-          >
-            <span>{node.title}</span>
-          </button>
-        ))}
-        <span className="idt-demo-connector c1" />
-        <span className="idt-demo-connector c2" />
-        <span className="idt-demo-connector c3" />
-        <span className="idt-demo-connector c4" />
       </div>
+
+      <div className="idt-demo-view-toggle" role="tablist" aria-label="Trust path explorer view">
+        <button type="button" role="tab" aria-selected={viewMode === 'graph'} className={viewMode === 'graph' ? 'is-active' : ''} onClick={() => setViewMode('graph')}>
+          Graph
+        </button>
+        <button type="button" role="tab" aria-selected={viewMode === 'list'} className={viewMode === 'list' ? 'is-active' : ''} onClick={() => setViewMode('list')}>
+          List
+        </button>
+      </div>
+
+      {viewMode === 'graph' ? (
+        <div className="idt-demo-graph" role="img" aria-label="Interactive trust graph simulation">
+          {nodes.map((node) => (
+            <button
+              key={node.id}
+              type="button"
+              className={`idt-demo-node ${selected.id === node.id ? 'is-active' : ''}`}
+              onClick={() => setSelectedId(node.id)}
+            >
+              <span>{node.title}</span>
+            </button>
+          ))}
+          <span className="idt-demo-connector c1" />
+          <span className="idt-demo-connector c2" />
+          <span className="idt-demo-connector c3" />
+          <span className="idt-demo-connector c4" />
+        </div>
+      ) : (
+        <div className="idt-demo-list-view" role="table" aria-label="Trust path nodes">
+          {nodes.map((node) => (
+            <button key={node.id} type="button" className={`idt-demo-list-row ${selected.id === node.id ? 'is-active' : ''}`} onClick={() => setSelectedId(node.id)}>
+              <span>{node.title}</span>
+              <small>{node.detail}</small>
+            </button>
+          ))}
+        </div>
+      )}
+
       <aside className="idt-demo-sidebar" aria-live="polite">
         <h3>{selected.title}</h3>
         <p>{selected.detail}</p>
@@ -794,10 +804,10 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
         ) : null}
         <div className="idt-inline-actions">
           <Link to="/pricing" className="idt-btn idt-btn-primary">
-            Start Free Risk Scan
+            Start Read-Only Risk Scan
           </Link>
-          <Link to="/enterprise" className="idt-btn idt-btn-dark">
-            Book Demo
+          <Link to="/demo" className="idt-btn idt-btn-dark">
+            Book Technical Demo
           </Link>
         </div>
       </aside>
@@ -961,80 +971,6 @@ function DeploymentPathBanner() {
   );
 }
 
-function HomeCredibilityStrip() {
-  return (
-    <section className="idt-trust-strip" aria-label="Credibility and proof">
-      <div className="idt-shell">
-        <p>Validate the product before you commit: review architecture, security posture, and output artifacts.</p>
-        <div className="idt-logo-row idt-proof-row">
-          {TRUST_PROOF_LINKS.map((entry) => (
-            entry.external ? (
-              <SafeLink key={entry.label} href={entry.href} className="idt-proof-link">
-                {entry.label}
-              </SafeLink>
-            ) : (
-              <Link key={entry.label} to={entry.href} className="idt-proof-link">
-                {entry.label}
-              </Link>
-            )
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function ProductProofFindingSection() {
-  return (
-    <section className="idt-section idt-shell">
-      <SectionTitle
-        eyebrow="Product Proof"
-        title="See a realistic high-risk trust path before you connect anything"
-        body="Identrail surfaces risky machine identity paths with evidence, impact, and remediation guidance teams can act on immediately."
-      />
-      <div className="idt-finding-proof-grid">
-        <article className="idt-card idt-finding-card">
-          <p className="idt-finding-label">Risk</p>
-          <h3>Kubernetes service account can assume production AWS role</h3>
-          <p>
-            <strong>Severity:</strong> <span className="idt-severity-high">High</span>
-          </p>
-          <p>
-            <strong>Path:</strong> GitHub Actions → OIDC Provider → AWS Role → RDS Billing Resource
-          </p>
-          <p>
-            <strong>Why it matters:</strong> Compromise of CI/CD could reach sensitive production data.
-          </p>
-          <p>
-            <strong>Recommended remediation:</strong> Restrict trust policy conditions and scope role permissions.
-          </p>
-        </article>
-        <article className="idt-card idt-finding-impact">
-          <h3>What teams do next in Identrail</h3>
-          <ul>
-            <li>Inspect every edge in the trust path with source policy evidence.</li>
-            <li>Simulate tighter trust conditions before enforcing policy changes.</li>
-            <li>Roll out in stages to reduce blast radius without breaking production.</li>
-          </ul>
-          <div className="idt-inline-actions">
-            <Link to="/pricing" className="idt-btn idt-btn-primary">
-              Start Free Risk Scan
-            </Link>
-            <Link to="/enterprise" className="idt-btn idt-btn-dark">
-              Book Demo
-            </Link>
-          </div>
-        </article>
-      </div>
-      <div className="idt-card idt-proof-demo-card">
-        <h3>Interactive trust-path preview</h3>
-        <p>Inspect a sample trust path from source identity to sensitive resource before connecting your environment.</p>
-        <TrustGraphDemo />
-      </div>
-    </section>
-  );
-}
-
 function HomeFaqSection() {
   return (
     <section className="idt-section idt-shell">
@@ -1090,7 +1026,7 @@ function HomePage() {
         </div>
       </section>
 
-      <HomeCredibilityStrip />
+      <TrustProofStrip />
 
       <section className="idt-section idt-shell">
         <LeadCaptureForm
@@ -1102,7 +1038,15 @@ function HomePage() {
         />
       </section>
 
-      <ProductProofFindingSection />
+      <RiskInsightSection />
+
+      <section className="idt-section idt-shell">
+        <div className="idt-card idt-proof-demo-card">
+          <h3>Interactive trust-path preview</h3>
+          <p>Inspect a sample trust path from source identity to sensitive resource before connecting your environment.</p>
+          <TrustGraphDemo />
+        </div>
+      </section>
 
       <section className="idt-section idt-shell">
         <SectionTitle eyebrow="How It Works" title="Discover, prioritize, simulate, and roll out in four steps" />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { BrowserRouter, Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { SafeLink } from './components/SafeLink';
+import { HeroProductReveal } from './components/home/HeroProductReveal';
 import { Footer } from './components/layout/Footer';
 import { Header } from './components/layout/Header';
 import { apiClient } from './api/client';
@@ -673,30 +674,6 @@ function CalendlyEmbed() {
   );
 }
 
-function TrustGraphHeroVisual() {
-  return (
-    <div className="idt-graph-visual" aria-label="Trust path product preview">
-      <div className="idt-graph-grid" />
-      <div className="idt-node idt-node-root">GitHub Actions OIDC</div>
-      <div className="idt-node idt-node-role">AWS Role: billing-prod</div>
-      <div className="idt-node idt-node-k8s">K8s SA: payments-api</div>
-      <div className="idt-node idt-node-repo">RDS: billing-ledger</div>
-      <span className="idt-edge idt-edge-a" />
-      <span className="idt-edge idt-edge-b" />
-      <span className="idt-edge idt-edge-c" />
-      <span className="idt-pulse idt-pulse-a" />
-      <span className="idt-pulse idt-pulse-b" />
-      <aside className="idt-hero-graph-caption">
-        <p className="idt-hero-graph-title">Trust graph preview</p>
-        <p>GitHub Actions OIDC → AWS Role → K8s Service Account → RDS Billing Resource</p>
-        <Link to="/demo" className="idt-inline-link">
-          Open interactive demo
-        </Link>
-      </aside>
-    </div>
-  );
-}
-
 function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' }) {
   const scenarios = [
     {
@@ -1109,7 +1086,7 @@ function HomePage() {
               </Link>
             </div>
           </div>
-          <TrustGraphHeroVisual />
+          <HeroProductReveal />
         </div>
       </section>
 

--- a/web/src/components/home/HeroProductReveal.tsx
+++ b/web/src/components/home/HeroProductReveal.tsx
@@ -1,0 +1,47 @@
+import { Link } from 'react-router-dom';
+
+const PATH_SUMMARY = 'GitHub Actions OIDC → AWS Role → K8s Service Account → RDS Billing Resource';
+
+const PROOF_ITEMS = [
+  { label: 'Blast radius', value: '11 production resources reachable' },
+  { label: 'Exposure type', value: 'Federated identity chain with broad role trust' },
+  { label: 'Safe first action', value: 'Constrain role trust subject claims, then simulate rollout' }
+] as const;
+
+export function HeroProductReveal() {
+  return (
+    <div className="idt-graph-visual" aria-label="Trust path product preview">
+      <div className="idt-graph-grid" />
+      <div className="idt-node idt-node-root">GitHub Actions OIDC</div>
+      <div className="idt-node idt-node-role">AWS Role: billing-prod</div>
+      <div className="idt-node idt-node-k8s">K8s SA: payments-api</div>
+      <div className="idt-node idt-node-repo">RDS: billing-ledger</div>
+      <span className="idt-edge idt-edge-a" />
+      <span className="idt-edge idt-edge-b" />
+      <span className="idt-edge idt-edge-c" />
+      <span className="idt-pulse idt-pulse-a" />
+      <span className="idt-pulse idt-pulse-b" />
+
+      <aside className="idt-hero-graph-caption idt-hero-proof-card">
+        <p className="idt-hero-graph-title">Selected risk path</p>
+        <p className="idt-hero-path">{PATH_SUMMARY}</p>
+        <div className="idt-hero-proof-meta">
+          <span className="idt-severity-pill">High</span>
+          <span>4-hop chain</span>
+          <span>Read-only analysis</span>
+        </div>
+        <dl className="idt-hero-proof-list">
+          {PROOF_ITEMS.map((item) => (
+            <div key={item.label}>
+              <dt>{item.label}</dt>
+              <dd>{item.value}</dd>
+            </div>
+          ))}
+        </dl>
+        <Link to="/demo" className="idt-inline-link">
+          Open technical demo
+        </Link>
+      </aside>
+    </div>
+  );
+}

--- a/web/src/components/home/RiskInsightSection.tsx
+++ b/web/src/components/home/RiskInsightSection.tsx
@@ -1,0 +1,97 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+const SCENARIOS = [
+  {
+    id: 'oidc-prod',
+    name: 'CI OIDC to prod DB',
+    severity: 'High',
+    path: 'GitHub Actions OIDC → AWS Role → K8s SA → RDS billing-ledger',
+    impact: 'Compromised CI workflow token can reach production billing data in one chain.',
+    signal: '11 reachable resources',
+    firstAction: 'Tighten trust policy subject claims and reduce role action scope.'
+  },
+  {
+    id: 'k8s-pivot',
+    name: 'K8s service-account pivot',
+    severity: 'High',
+    path: 'K8s ServiceAccount → ClusterRoleBinding → IAM role assumption → Artifact bucket',
+    impact: 'Overprivileged service account can pivot across namespace boundary into cloud resources.',
+    signal: '7 cross-namespace privilege links',
+    firstAction: 'Split SA identity by workload and enforce namespace-scoped RBAC.'
+  },
+  {
+    id: 'repo-secret',
+    name: 'Leaked deploy token chain',
+    severity: 'Medium',
+    path: 'Repo secret leak → Bot identity replay → AssumeRole → Container registry push',
+    impact: 'Leaked token can ship unauthorized container images into production path.',
+    signal: '4 privileged registry actions exposed',
+    firstAction: 'Rotate credentials and enforce short-lived workload identity tokens.'
+  }
+] as const;
+
+export function RiskInsightSection() {
+  const [activeScenarioId, setActiveScenarioId] = useState<(typeof SCENARIOS)[number]['id']>('oidc-prod');
+
+  const activeScenario = useMemo(
+    () => SCENARIOS.find((scenario) => scenario.id === activeScenarioId) ?? SCENARIOS[0],
+    [activeScenarioId]
+  );
+
+  return (
+    <section className="idt-section idt-shell" aria-labelledby="risk-insight-title">
+      <div className="idt-section-title">
+        <p className="idt-eyebrow">Reachable Risk Paths</p>
+        <h2 id="risk-insight-title">Prioritize machine identity findings by real impact</h2>
+        <p>
+          Each finding includes path evidence, severity, and a safe first remediation action. Start with what can actually reach
+          production.
+        </p>
+      </div>
+
+      <div className="idt-risk-insight-grid">
+        <div className="idt-risk-scenario-list" role="tablist" aria-label="Risk path scenarios">
+          {SCENARIOS.map((scenario) => {
+            const isActive = scenario.id === activeScenario.id;
+            return (
+              <button
+                key={scenario.id}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                className={`idt-risk-scenario-item ${isActive ? 'is-active' : ''}`}
+                onClick={() => setActiveScenarioId(scenario.id)}
+              >
+                <span>{scenario.name}</span>
+                <small>{scenario.severity}</small>
+              </button>
+            );
+          })}
+        </div>
+
+        <article className="idt-card idt-risk-evidence-card" role="tabpanel" aria-live="polite">
+          <p className="idt-finding-label">Selected path</p>
+          <h3>{activeScenario.path}</h3>
+          <p>
+            <strong>Impact:</strong> {activeScenario.impact}
+          </p>
+          <p>
+            <strong>Evidence signal:</strong> {activeScenario.signal}
+          </p>
+          <p>
+            <strong>Safe first action:</strong> {activeScenario.firstAction}
+          </p>
+          <div className="idt-inline-actions">
+            <Link to="/pricing" className="idt-btn idt-btn-primary">
+              Start Read-Only Risk Scan
+            </Link>
+            <Link to="/demo" className="idt-btn idt-btn-dark">
+              Open technical demo
+            </Link>
+          </div>
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/home/TrustProofStrip.tsx
+++ b/web/src/components/home/TrustProofStrip.tsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router-dom';
+import { SafeLink } from '../SafeLink';
+import { TRUST_PROOF_LINKS } from '../../content/proofArtifacts';
+
+export function TrustProofStrip() {
+  return (
+    <section className="idt-trust-strip" aria-label="Credibility and proof">
+      <div className="idt-shell">
+        <p>Validate the product before you commit: inspect architecture, outputs, and security process.</p>
+        <div className="idt-logo-row idt-proof-row">
+          {TRUST_PROOF_LINKS.map((entry) => (
+            <article key={entry.label} className="idt-proof-item">
+              {entry.external ? (
+                <SafeLink href={entry.href} className="idt-proof-link">
+                  {entry.label}
+                </SafeLink>
+              ) : (
+                <Link to={entry.href} className="idt-proof-link">
+                  {entry.label}
+                </Link>
+              )}
+              <p>{entry.description}</p>
+              <small>{entry.freshness}</small>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/content/proofArtifacts.ts
+++ b/web/src/content/proofArtifacts.ts
@@ -1,0 +1,45 @@
+export type ProofArtifact = {
+  label: string;
+  href: string;
+  external: boolean;
+  description: string;
+  freshness: string;
+};
+
+export const TRUST_PROOF_LINKS: readonly ProofArtifact[] = [
+  {
+    label: 'Architecture Docs',
+    href: 'https://github.com/identrail/identrail/tree/main/docs',
+    external: true,
+    description: 'System architecture, deployment patterns, and control boundaries.',
+    freshness: 'Updated monthly'
+  },
+  {
+    label: 'Read-Only Scan Model',
+    href: '/security',
+    external: false,
+    description: 'Permission scope and data access constraints for collection connectors.',
+    freshness: 'Policy tracked'
+  },
+  {
+    label: 'Sample Risk Report',
+    href: '/demo',
+    external: false,
+    description: 'Example findings with path evidence, severity, and remediation sequence.',
+    freshness: 'Redacted sample'
+  },
+  {
+    label: 'Changelog',
+    href: 'https://github.com/identrail/identrail/releases',
+    external: true,
+    description: 'Release cadence and shipped platform improvements.',
+    freshness: 'Versioned'
+  },
+  {
+    label: 'Responsible Disclosure',
+    href: '/security',
+    external: false,
+    description: 'Security issue reporting process and response expectations.',
+    freshness: 'Maintained'
+  }
+] as const;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -607,6 +607,33 @@ h3 {
   gap: 0.6rem;
 }
 
+.idt-proof-row {
+  gap: 0.7rem;
+}
+
+.idt-proof-item {
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.02);
+  padding: 0.6rem 0.68rem;
+  display: grid;
+  gap: 0.3rem;
+  min-width: 220px;
+  flex: 1 1 220px;
+}
+
+.idt-proof-item p {
+  margin: 0;
+  color: #cbd5e7;
+  font-size: 0.72rem;
+  line-height: 1.4;
+}
+
+.idt-proof-item small {
+  color: #97a7c3;
+  font-size: 0.68rem;
+}
+
 .idt-logo-row span {
   border: 1px solid rgba(255, 255, 255, 0.18);
   border-radius: 999px;
@@ -619,13 +646,17 @@ h3 {
 }
 
 .idt-proof-link {
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border: 1px solid rgba(255, 255, 255, 0.16);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.03);
-  padding: 0.44rem 0.8rem;
-  font-size: 0.74rem;
-  color: #d7dff1;
-  letter-spacing: 0.03em;
+  padding: 0.3rem 0.62rem;
+  font-size: 0.7rem;
+  color: #dfe8fb;
+  letter-spacing: 0.02em;
+  font-weight: 700;
   text-decoration: none;
   transition: border-color 0.2s ease, background-color 0.2s ease;
 }
@@ -747,6 +778,29 @@ h3 {
   border-color: rgba(137, 169, 255, 0.74);
 }
 
+.idt-demo-view-toggle {
+  grid-column: 1 / -1;
+  display: inline-flex;
+  gap: 0.4rem;
+}
+
+.idt-demo-view-toggle button {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.03);
+  color: #dee8ff;
+  border-radius: 999px;
+  min-height: 32px;
+  padding: 0 0.72rem;
+  font-size: 0.72rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.idt-demo-view-toggle button.is-active {
+  border-color: rgba(158, 185, 255, 0.72);
+  background: rgba(158, 185, 255, 0.2);
+}
+
 .idt-demo-graph {
   min-height: 420px;
   padding: 1rem;
@@ -755,6 +809,38 @@ h3 {
   place-items: center;
   overflow: hidden;
   background: linear-gradient(160deg, rgba(10, 10, 12, 0.92), rgba(6, 6, 8, 0.95));
+}
+
+.idt-demo-list-view {
+  min-height: 420px;
+  display: grid;
+  gap: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 14px;
+  background: linear-gradient(160deg, rgba(10, 10, 12, 0.9), rgba(6, 6, 8, 0.93));
+  padding: 0.8rem;
+}
+
+.idt-demo-list-row {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.02);
+  color: #e8f1ff;
+  padding: 0.58rem 0.68rem;
+  text-align: left;
+  display: grid;
+  gap: 0.15rem;
+  cursor: pointer;
+}
+
+.idt-demo-list-row small {
+  color: #a6b5cd;
+  font-size: 0.74rem;
+}
+
+.idt-demo-list-row.is-active {
+  border-color: rgba(158, 185, 255, 0.72);
+  background: rgba(158, 185, 255, 0.14);
 }
 
 .idt-demo-node {
@@ -1995,6 +2081,46 @@ h2 {
   border-top: 1px solid var(--idt-line);
 }
 
+.idt-risk-insight-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.42fr) minmax(0, 1fr);
+  gap: 1rem;
+}
+
+.idt-risk-scenario-list {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.idt-risk-scenario-item {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.02);
+  color: #e6ecfb;
+  text-align: left;
+  padding: 0.68rem 0.75rem;
+  display: grid;
+  gap: 0.2rem;
+  cursor: pointer;
+}
+
+.idt-risk-scenario-item small {
+  font-size: 0.74rem;
+  color: #a2b0c7;
+}
+
+.idt-risk-scenario-item.is-active,
+.idt-risk-scenario-item:hover,
+.idt-risk-scenario-item:focus-visible {
+  border-color: rgba(172, 196, 255, 0.46);
+  background: rgba(172, 196, 255, 0.09);
+}
+
+.idt-risk-evidence-card {
+  display: grid;
+  gap: 0.54rem;
+}
+
 @media (max-width: 1080px) {
   .idt-header-row {
     grid-template-columns: auto auto;
@@ -2036,6 +2162,7 @@ h2 {
   .idt-demo-surface,
   .idt-pricing-grid,
   .idt-roi-grid,
+  .idt-risk-insight-grid,
   .idt-finding-proof-grid,
   .idt-adoption-grid,
   .idt-card-grid.two-col,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -506,6 +506,55 @@ h3 {
   line-height: 1.45;
 }
 
+.idt-hero-path {
+  margin: 0.45rem 0 0.72rem;
+  color: #e6efff;
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.idt-hero-proof-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-bottom: 0.72rem;
+}
+
+.idt-hero-proof-meta span:not(.idt-severity-pill) {
+  border: 1px solid rgba(255, 255, 255, 0.17);
+  border-radius: 999px;
+  padding: 0.16rem 0.5rem;
+  color: #d4deef;
+  font-size: 0.64rem;
+  letter-spacing: 0.04em;
+}
+
+.idt-hero-proof-list {
+  margin: 0 0 0.8rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.idt-hero-proof-list div {
+  display: grid;
+  gap: 0.12rem;
+}
+
+.idt-hero-proof-list dt {
+  color: #a7b3c8;
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.idt-hero-proof-list dd {
+  margin: 0;
+  color: #e8f1ff;
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
 .idt-severity-high {
   color: var(--severity-high-fg);
   font-weight: 800;


### PR DESCRIPTION
## Summary
- extract hero product reveal into `web/src/components/home/HeroProductReveal.tsx`
- upgrade hero right panel from conceptual caption to selected-path evidence card
- add blast-radius metadata, read-only analysis signal, and remediation-first proof copy
- preserve existing trust graph visual while improving product realism in first fold

## Validation
- npm --prefix web run test -- --run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthened the hero with a selected-path product reveal that surfaces real risk context and a direct demo link. Added Reachable Risk Paths with scenario evidence and enriched proof artifacts, and introduced graph/list trust explorer modes to make the first fold feel like the product.

- **New Features**
  - Replaces the hero’s right panel with `HeroProductReveal` showing path summary, severity, read-only analysis, blast radius, exposure type, and a safe first action, plus a demo link.
  - Adds `RiskInsightSection` with scenario tabs and an evidence card, and updates CTAs to “Start Read-Only Risk Scan” and “Book Technical Demo.”
  - Enriches proof with `TrustProofStrip` using `web/src/content/proofArtifacts.ts`, and adds graph/list view modes to the trust-path demo.

- **Refactors**
  - Extracts hero UI to `web/src/components/home/HeroProductReveal.tsx` and proof artifacts to `web/src/content/proofArtifacts.ts`; updates `web/src/styles.css` for new UI.
  - Updates tests to assert “Reachable Risk Paths.”

<sup>Written for commit 76792003c5fee8e3314197b0300c67b62efe69bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

