### PR TITLE
feat(web): add interactive risk insight evidence section

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -17,7 +17,7 @@ describe('App', () => {
     expect(screen.getAllByRole('link', { name: 'Start Read-Only Risk Scan' }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole('link', { name: 'Book Technical Demo' }).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Adoption Paths/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/Kubernetes service account can assume production AWS role/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Reachable Risk Paths/i).length).toBeGreaterThan(0);
   });
 
   it('renders pricing page routes and key elements', () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import { FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from 'reac
 import { BrowserRouter, Link, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { SafeLink } from './components/SafeLink';
 import { HeroProductReveal } from './components/home/HeroProductReveal';
+import { RiskInsightSection } from './components/home/RiskInsightSection';
 import { TrustProofStrip } from './components/home/TrustProofStrip';
 import { Footer } from './components/layout/Footer';
 import { Header } from './components/layout/Header';
@@ -954,57 +955,6 @@ function DeploymentPathBanner() {
   );
 }
 
-function ProductProofFindingSection() {
-  return (
-    <section className="idt-section idt-shell">
-      <SectionTitle
-        eyebrow="Product Proof"
-        title="See a realistic high-risk trust path before you connect anything"
-        body="Identrail surfaces risky machine identity paths with evidence, impact, and remediation guidance teams can act on immediately."
-      />
-      <div className="idt-finding-proof-grid">
-        <article className="idt-card idt-finding-card">
-          <p className="idt-finding-label">Risk</p>
-          <h3>Kubernetes service account can assume production AWS role</h3>
-          <p>
-            <strong>Severity:</strong> <span className="idt-severity-high">High</span>
-          </p>
-          <p>
-            <strong>Path:</strong> GitHub Actions → OIDC Provider → AWS Role → RDS Billing Resource
-          </p>
-          <p>
-            <strong>Why it matters:</strong> Compromise of CI/CD could reach sensitive production data.
-          </p>
-          <p>
-            <strong>Recommended remediation:</strong> Restrict trust policy conditions and scope role permissions.
-          </p>
-        </article>
-        <article className="idt-card idt-finding-impact">
-          <h3>What teams do next in Identrail</h3>
-          <ul>
-            <li>Inspect every edge in the trust path with source policy evidence.</li>
-            <li>Simulate tighter trust conditions before enforcing policy changes.</li>
-            <li>Roll out in stages to reduce blast radius without breaking production.</li>
-          </ul>
-          <div className="idt-inline-actions">
-            <Link to="/pricing" className="idt-btn idt-btn-primary">
-              Start Free Risk Scan
-            </Link>
-            <Link to="/enterprise" className="idt-btn idt-btn-dark">
-              Book Demo
-            </Link>
-          </div>
-        </article>
-      </div>
-      <div className="idt-card idt-proof-demo-card">
-        <h3>Interactive trust-path preview</h3>
-        <p>Inspect a sample trust path from source identity to sensitive resource before connecting your environment.</p>
-        <TrustGraphDemo />
-      </div>
-    </section>
-  );
-}
-
 function HomeFaqSection() {
   return (
     <section className="idt-section idt-shell">
@@ -1072,7 +1022,15 @@ function HomePage() {
         />
       </section>
 
-      <ProductProofFindingSection />
+      <RiskInsightSection />
+
+      <section className="idt-section idt-shell">
+        <div className="idt-card idt-proof-demo-card">
+          <h3>Interactive trust-path preview</h3>
+          <p>Inspect a sample trust path from source identity to sensitive resource before connecting your environment.</p>
+          <TrustGraphDemo />
+        </div>
+      </section>
 
       <section className="idt-section idt-shell">
         <SectionTitle eyebrow="How It Works" title="Discover, prioritize, simulate, and roll out in four steps" />

--- a/web/src/components/home/RiskInsightSection.tsx
+++ b/web/src/components/home/RiskInsightSection.tsx
@@ -1,0 +1,97 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+const SCENARIOS = [
+  {
+    id: 'oidc-prod',
+    name: 'CI OIDC to prod DB',
+    severity: 'High',
+    path: 'GitHub Actions OIDC → AWS Role → K8s SA → RDS billing-ledger',
+    impact: 'Compromised CI workflow token can reach production billing data in one chain.',
+    signal: '11 reachable resources',
+    firstAction: 'Tighten trust policy subject claims and reduce role action scope.'
+  },
+  {
+    id: 'k8s-pivot',
+    name: 'K8s service-account pivot',
+    severity: 'High',
+    path: 'K8s ServiceAccount → ClusterRoleBinding → IAM role assumption → Artifact bucket',
+    impact: 'Overprivileged service account can pivot across namespace boundary into cloud resources.',
+    signal: '7 cross-namespace privilege links',
+    firstAction: 'Split SA identity by workload and enforce namespace-scoped RBAC.'
+  },
+  {
+    id: 'repo-secret',
+    name: 'Leaked deploy token chain',
+    severity: 'Medium',
+    path: 'Repo secret leak → Bot identity replay → AssumeRole → Container registry push',
+    impact: 'Leaked token can ship unauthorized container images into production path.',
+    signal: '4 privileged registry actions exposed',
+    firstAction: 'Rotate credentials and enforce short-lived workload identity tokens.'
+  }
+] as const;
+
+export function RiskInsightSection() {
+  const [activeScenarioId, setActiveScenarioId] = useState<(typeof SCENARIOS)[number]['id']>('oidc-prod');
+
+  const activeScenario = useMemo(
+    () => SCENARIOS.find((scenario) => scenario.id === activeScenarioId) ?? SCENARIOS[0],
+    [activeScenarioId]
+  );
+
+  return (
+    <section className="idt-section idt-shell" aria-labelledby="risk-insight-title">
+      <div className="idt-section-title">
+        <p className="idt-eyebrow">Reachable Risk Paths</p>
+        <h2 id="risk-insight-title">Prioritize machine identity findings by real impact</h2>
+        <p>
+          Each finding includes path evidence, severity, and a safe first remediation action. Start with what can actually reach
+          production.
+        </p>
+      </div>
+
+      <div className="idt-risk-insight-grid">
+        <div className="idt-risk-scenario-list" role="tablist" aria-label="Risk path scenarios">
+          {SCENARIOS.map((scenario) => {
+            const isActive = scenario.id === activeScenario.id;
+            return (
+              <button
+                key={scenario.id}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                className={`idt-risk-scenario-item ${isActive ? 'is-active' : ''}`}
+                onClick={() => setActiveScenarioId(scenario.id)}
+              >
+                <span>{scenario.name}</span>
+                <small>{scenario.severity}</small>
+              </button>
+            );
+          })}
+        </div>
+
+        <article className="idt-card idt-risk-evidence-card" role="tabpanel" aria-live="polite">
+          <p className="idt-finding-label">Selected path</p>
+          <h3>{activeScenario.path}</h3>
+          <p>
+            <strong>Impact:</strong> {activeScenario.impact}
+          </p>
+          <p>
+            <strong>Evidence signal:</strong> {activeScenario.signal}
+          </p>
+          <p>
+            <strong>Safe first action:</strong> {activeScenario.firstAction}
+          </p>
+          <div className="idt-inline-actions">
+            <Link to="/pricing" className="idt-btn idt-btn-primary">
+              Start Read-Only Risk Scan
+            </Link>
+            <Link to="/demo" className="idt-btn idt-btn-dark">
+              Open technical demo
+            </Link>
+          </div>
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2031,6 +2031,46 @@ h2 {
   border-top: 1px solid var(--idt-line);
 }
 
+.idt-risk-insight-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.42fr) minmax(0, 1fr);
+  gap: 1rem;
+}
+
+.idt-risk-scenario-list {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.idt-risk-scenario-item {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.02);
+  color: #e6ecfb;
+  text-align: left;
+  padding: 0.68rem 0.75rem;
+  display: grid;
+  gap: 0.2rem;
+  cursor: pointer;
+}
+
+.idt-risk-scenario-item small {
+  font-size: 0.74rem;
+  color: #a2b0c7;
+}
+
+.idt-risk-scenario-item.is-active,
+.idt-risk-scenario-item:hover,
+.idt-risk-scenario-item:focus-visible {
+  border-color: rgba(172, 196, 255, 0.46);
+  background: rgba(172, 196, 255, 0.09);
+}
+
+.idt-risk-evidence-card {
+  display: grid;
+  gap: 0.54rem;
+}
+
 @media (max-width: 1080px) {
   .idt-header-row {
     grid-template-columns: auto auto;
@@ -2072,6 +2112,7 @@ h2 {
   .idt-demo-surface,
   .idt-pricing-grid,
   .idt-roi-grid,
+  .idt-risk-insight-grid,
   .idt-finding-proof-grid,
   .idt-adoption-grid,
   .idt-card-grid.two-col,


### PR DESCRIPTION
## Summary
- replace static product-proof block with interactive risk insight section
- add scenario selector with evidence-backed details (impact, signal, first action)
- keep clear conversion actions tied to read-only scan and technical demo
- preserve trust-path demo as separate focused block below insights

## Validation
- npm --prefix web run test -- --run


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the static product-proof block with an interactive Risk Insight section that surfaces reachable risk paths with evidence and a safe first action. The trust-path demo remains a separate block; copy, styles, and tests updated.

- **New Features**
  - Added `RiskInsightSection` with selectable scenarios showing path, impact, evidence signal, and a safe first action.
  - Updated the home page to use the new section and kept the trust-path demo in its own section.
  - Updated copy and styles; test now asserts "Reachable Risk Paths" and reflects new CTAs ("Start Read-Only Risk Scan", "Open technical demo").

<sup>Written for commit 0ce8dbfc622f71bb145d831b6c8c1158325688ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

