### PR TITLE
feat(web): add graph/list trust explorer modes

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -17,7 +17,7 @@ describe('App', () => {
     expect(screen.getAllByRole('link', { name: 'Start Read-Only Risk Scan' }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole('link', { name: 'Book Technical Demo' }).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Adoption Paths/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/Kubernetes service account can assume production AWS role/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Reachable Risk Paths/i).length).toBeGreaterThan(0);
   });
 
   it('renders pricing page routes and key elements', () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import { FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from 'reac
 import { BrowserRouter, Link, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { SafeLink } from './components/SafeLink';
 import { HeroProductReveal } from './components/home/HeroProductReveal';
+import { RiskInsightSection } from './components/home/RiskInsightSection';
 import { TrustProofStrip } from './components/home/TrustProofStrip';
 import { Footer } from './components/layout/Footer';
 import { Header } from './components/layout/Header';
@@ -954,57 +955,6 @@ function DeploymentPathBanner() {
   );
 }
 
-function ProductProofFindingSection() {
-  return (
-    <section className="idt-section idt-shell">
-      <SectionTitle
-        eyebrow="Product Proof"
-        title="See a realistic high-risk trust path before you connect anything"
-        body="Identrail surfaces risky machine identity paths with evidence, impact, and remediation guidance teams can act on immediately."
-      />
-      <div className="idt-finding-proof-grid">
-        <article className="idt-card idt-finding-card">
-          <p className="idt-finding-label">Risk</p>
-          <h3>Kubernetes service account can assume production AWS role</h3>
-          <p>
-            <strong>Severity:</strong> <span className="idt-severity-high">High</span>
-          </p>
-          <p>
-            <strong>Path:</strong> GitHub Actions → OIDC Provider → AWS Role → RDS Billing Resource
-          </p>
-          <p>
-            <strong>Why it matters:</strong> Compromise of CI/CD could reach sensitive production data.
-          </p>
-          <p>
-            <strong>Recommended remediation:</strong> Restrict trust policy conditions and scope role permissions.
-          </p>
-        </article>
-        <article className="idt-card idt-finding-impact">
-          <h3>What teams do next in Identrail</h3>
-          <ul>
-            <li>Inspect every edge in the trust path with source policy evidence.</li>
-            <li>Simulate tighter trust conditions before enforcing policy changes.</li>
-            <li>Roll out in stages to reduce blast radius without breaking production.</li>
-          </ul>
-          <div className="idt-inline-actions">
-            <Link to="/pricing" className="idt-btn idt-btn-primary">
-              Start Free Risk Scan
-            </Link>
-            <Link to="/enterprise" className="idt-btn idt-btn-dark">
-              Book Demo
-            </Link>
-          </div>
-        </article>
-      </div>
-      <div className="idt-card idt-proof-demo-card">
-        <h3>Interactive trust-path preview</h3>
-        <p>Inspect a sample trust path from source identity to sensitive resource before connecting your environment.</p>
-        <TrustGraphDemo />
-      </div>
-    </section>
-  );
-}
-
 function HomeFaqSection() {
   return (
     <section className="idt-section idt-shell">
@@ -1072,7 +1022,15 @@ function HomePage() {
         />
       </section>
 
-      <ProductProofFindingSection />
+      <RiskInsightSection />
+
+      <section className="idt-section idt-shell">
+        <div className="idt-card idt-proof-demo-card">
+          <h3>Interactive trust-path preview</h3>
+          <p>Inspect a sample trust path from source identity to sensitive resource before connecting your environment.</p>
+          <TrustGraphDemo />
+        </div>
+      </section>
 
       <section className="idt-section idt-shell">
         <SectionTitle eyebrow="How It Works" title="Discover, prioritize, simulate, and roll out in four steps" />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -697,6 +697,7 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
   ] as const;
 
   const [scenarioId, setScenarioId] = useState<(typeof scenarios)[number]['id']>('cicd');
+  const [viewMode, setViewMode] = useState<'graph' | 'list'>('graph');
   const nodes = [
     {
       id: 'oidc',
@@ -731,39 +732,54 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
 
   return (
     <section className={`idt-demo-surface ${variant === 'full' ? 'is-full' : ''}`}>
-      {variant === 'full' ? (
-        <div className="idt-demo-toolbar" role="group" aria-label="Demo scenarios">
-          <p>Scenario</p>
-          <div className="idt-demo-scenario-row">
-            {scenarios.map((item) => (
-              <button
-                key={item.id}
-                type="button"
-                className={item.id === scenarioId ? 'is-active' : ''}
-                onClick={() => setScenarioId(item.id)}
-              >
-                {item.label}
-              </button>
-            ))}
-          </div>
+      <div className="idt-demo-toolbar" role="group" aria-label="Demo scenarios">
+        <p>Scenario</p>
+        <div className="idt-demo-scenario-row">
+          {scenarios.map((item) => (
+            <button key={item.id} type="button" className={item.id === scenarioId ? 'is-active' : ''} onClick={() => setScenarioId(item.id)}>
+              {item.label}
+            </button>
+          ))}
         </div>
-      ) : null}
-      <div className="idt-demo-graph" role="img" aria-label="Interactive trust graph simulation">
-        {nodes.map((node) => (
-          <button
-            key={node.id}
-            type="button"
-            className={`idt-demo-node ${selected.id === node.id ? 'is-active' : ''}`}
-            onClick={() => setSelectedId(node.id)}
-          >
-            <span>{node.title}</span>
-          </button>
-        ))}
-        <span className="idt-demo-connector c1" />
-        <span className="idt-demo-connector c2" />
-        <span className="idt-demo-connector c3" />
-        <span className="idt-demo-connector c4" />
       </div>
+
+      <div className="idt-demo-view-toggle" role="tablist" aria-label="Trust path explorer view">
+        <button type="button" role="tab" aria-selected={viewMode === 'graph'} className={viewMode === 'graph' ? 'is-active' : ''} onClick={() => setViewMode('graph')}>
+          Graph
+        </button>
+        <button type="button" role="tab" aria-selected={viewMode === 'list'} className={viewMode === 'list' ? 'is-active' : ''} onClick={() => setViewMode('list')}>
+          List
+        </button>
+      </div>
+
+      {viewMode === 'graph' ? (
+        <div className="idt-demo-graph" role="img" aria-label="Interactive trust graph simulation">
+          {nodes.map((node) => (
+            <button
+              key={node.id}
+              type="button"
+              className={`idt-demo-node ${selected.id === node.id ? 'is-active' : ''}`}
+              onClick={() => setSelectedId(node.id)}
+            >
+              <span>{node.title}</span>
+            </button>
+          ))}
+          <span className="idt-demo-connector c1" />
+          <span className="idt-demo-connector c2" />
+          <span className="idt-demo-connector c3" />
+          <span className="idt-demo-connector c4" />
+        </div>
+      ) : (
+        <div className="idt-demo-list-view" role="table" aria-label="Trust path nodes">
+          {nodes.map((node) => (
+            <button key={node.id} type="button" className={`idt-demo-list-row ${selected.id === node.id ? 'is-active' : ''}`} onClick={() => setSelectedId(node.id)}>
+              <span>{node.title}</span>
+              <small>{node.detail}</small>
+            </button>
+          ))}
+        </div>
+      )}
+
       <aside className="idt-demo-sidebar" aria-live="polite">
         <h3>{selected.title}</h3>
         <p>{selected.detail}</p>
@@ -788,10 +804,10 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
         ) : null}
         <div className="idt-inline-actions">
           <Link to="/pricing" className="idt-btn idt-btn-primary">
-            Start Free Risk Scan
+            Start Read-Only Risk Scan
           </Link>
-          <Link to="/enterprise" className="idt-btn idt-btn-dark">
-            Book Demo
+          <Link to="/demo" className="idt-btn idt-btn-dark">
+            Book Technical Demo
           </Link>
         </div>
       </aside>

--- a/web/src/components/home/RiskInsightSection.tsx
+++ b/web/src/components/home/RiskInsightSection.tsx
@@ -1,0 +1,97 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+const SCENARIOS = [
+  {
+    id: 'oidc-prod',
+    name: 'CI OIDC to prod DB',
+    severity: 'High',
+    path: 'GitHub Actions OIDC → AWS Role → K8s SA → RDS billing-ledger',
+    impact: 'Compromised CI workflow token can reach production billing data in one chain.',
+    signal: '11 reachable resources',
+    firstAction: 'Tighten trust policy subject claims and reduce role action scope.'
+  },
+  {
+    id: 'k8s-pivot',
+    name: 'K8s service-account pivot',
+    severity: 'High',
+    path: 'K8s ServiceAccount → ClusterRoleBinding → IAM role assumption → Artifact bucket',
+    impact: 'Overprivileged service account can pivot across namespace boundary into cloud resources.',
+    signal: '7 cross-namespace privilege links',
+    firstAction: 'Split SA identity by workload and enforce namespace-scoped RBAC.'
+  },
+  {
+    id: 'repo-secret',
+    name: 'Leaked deploy token chain',
+    severity: 'Medium',
+    path: 'Repo secret leak → Bot identity replay → AssumeRole → Container registry push',
+    impact: 'Leaked token can ship unauthorized container images into production path.',
+    signal: '4 privileged registry actions exposed',
+    firstAction: 'Rotate credentials and enforce short-lived workload identity tokens.'
+  }
+] as const;
+
+export function RiskInsightSection() {
+  const [activeScenarioId, setActiveScenarioId] = useState<(typeof SCENARIOS)[number]['id']>('oidc-prod');
+
+  const activeScenario = useMemo(
+    () => SCENARIOS.find((scenario) => scenario.id === activeScenarioId) ?? SCENARIOS[0],
+    [activeScenarioId]
+  );
+
+  return (
+    <section className="idt-section idt-shell" aria-labelledby="risk-insight-title">
+      <div className="idt-section-title">
+        <p className="idt-eyebrow">Reachable Risk Paths</p>
+        <h2 id="risk-insight-title">Prioritize machine identity findings by real impact</h2>
+        <p>
+          Each finding includes path evidence, severity, and a safe first remediation action. Start with what can actually reach
+          production.
+        </p>
+      </div>
+
+      <div className="idt-risk-insight-grid">
+        <div className="idt-risk-scenario-list" role="tablist" aria-label="Risk path scenarios">
+          {SCENARIOS.map((scenario) => {
+            const isActive = scenario.id === activeScenario.id;
+            return (
+              <button
+                key={scenario.id}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                className={`idt-risk-scenario-item ${isActive ? 'is-active' : ''}`}
+                onClick={() => setActiveScenarioId(scenario.id)}
+              >
+                <span>{scenario.name}</span>
+                <small>{scenario.severity}</small>
+              </button>
+            );
+          })}
+        </div>
+
+        <article className="idt-card idt-risk-evidence-card" role="tabpanel" aria-live="polite">
+          <p className="idt-finding-label">Selected path</p>
+          <h3>{activeScenario.path}</h3>
+          <p>
+            <strong>Impact:</strong> {activeScenario.impact}
+          </p>
+          <p>
+            <strong>Evidence signal:</strong> {activeScenario.signal}
+          </p>
+          <p>
+            <strong>Safe first action:</strong> {activeScenario.firstAction}
+          </p>
+          <div className="idt-inline-actions">
+            <Link to="/pricing" className="idt-btn idt-btn-primary">
+              Start Read-Only Risk Scan
+            </Link>
+            <Link to="/demo" className="idt-btn idt-btn-dark">
+              Open technical demo
+            </Link>
+          </div>
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -778,6 +778,29 @@ h3 {
   border-color: rgba(137, 169, 255, 0.74);
 }
 
+.idt-demo-view-toggle {
+  grid-column: 1 / -1;
+  display: inline-flex;
+  gap: 0.4rem;
+}
+
+.idt-demo-view-toggle button {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.03);
+  color: #dee8ff;
+  border-radius: 999px;
+  min-height: 32px;
+  padding: 0 0.72rem;
+  font-size: 0.72rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.idt-demo-view-toggle button.is-active {
+  border-color: rgba(158, 185, 255, 0.72);
+  background: rgba(158, 185, 255, 0.2);
+}
+
 .idt-demo-graph {
   min-height: 420px;
   padding: 1rem;
@@ -786,6 +809,38 @@ h3 {
   place-items: center;
   overflow: hidden;
   background: linear-gradient(160deg, rgba(10, 10, 12, 0.92), rgba(6, 6, 8, 0.95));
+}
+
+.idt-demo-list-view {
+  min-height: 420px;
+  display: grid;
+  gap: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 14px;
+  background: linear-gradient(160deg, rgba(10, 10, 12, 0.9), rgba(6, 6, 8, 0.93));
+  padding: 0.8rem;
+}
+
+.idt-demo-list-row {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.02);
+  color: #e8f1ff;
+  padding: 0.58rem 0.68rem;
+  text-align: left;
+  display: grid;
+  gap: 0.15rem;
+  cursor: pointer;
+}
+
+.idt-demo-list-row small {
+  color: #a6b5cd;
+  font-size: 0.74rem;
+}
+
+.idt-demo-list-row.is-active {
+  border-color: rgba(158, 185, 255, 0.72);
+  background: rgba(158, 185, 255, 0.14);
 }
 
 .idt-demo-node {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2031,6 +2031,46 @@ h2 {
   border-top: 1px solid var(--idt-line);
 }
 
+.idt-risk-insight-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.42fr) minmax(0, 1fr);
+  gap: 1rem;
+}
+
+.idt-risk-scenario-list {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.idt-risk-scenario-item {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.02);
+  color: #e6ecfb;
+  text-align: left;
+  padding: 0.68rem 0.75rem;
+  display: grid;
+  gap: 0.2rem;
+  cursor: pointer;
+}
+
+.idt-risk-scenario-item small {
+  font-size: 0.74rem;
+  color: #a2b0c7;
+}
+
+.idt-risk-scenario-item.is-active,
+.idt-risk-scenario-item:hover,
+.idt-risk-scenario-item:focus-visible {
+  border-color: rgba(172, 196, 255, 0.46);
+  background: rgba(172, 196, 255, 0.09);
+}
+
+.idt-risk-evidence-card {
+  display: grid;
+  gap: 0.54rem;
+}
+
 @media (max-width: 1080px) {
   .idt-header-row {
     grid-template-columns: auto auto;
@@ -2072,6 +2112,7 @@ h2 {
   .idt-demo-surface,
   .idt-pricing-grid,
   .idt-roi-grid,
+  .idt-risk-insight-grid,
   .idt-finding-proof-grid,
   .idt-adoption-grid,
   .idt-card-grid.two-col,


### PR DESCRIPTION
## Summary
- upgrade `TrustGraphDemo` with explicit `Graph/List` explorer modes
- keep scenario controls while adding accessible view-state controls
- add list-view fallback that exposes node details without relying on graph positioning
- normalize trust explorer CTAs to read-only risk scan + technical demo

## Validation
- npm --prefix web run test -- --run


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Graph and List modes to the Trust Explorer with an accessible toggle. Introduces a list-view fallback to show node details without relying on graph layout, and updates CTAs to a read-only risk scan and technical demo.

- **New Features**
  - Added tab-style view toggle (`graph` | `list`) with ARIA roles.
  - List view shows each node’s title and detail as selectable rows; no layout dependence.
  - Kept scenario controls visible and accessible in the toolbar across variants.
  - Updated sidebar CTAs: “Start Read-Only Risk Scan” (`/pricing`) and “Book Technical Demo” (`/demo`).

<sup>Written for commit e153c9060d9fd94470b9109a3dc6b6eeefd5ea5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

