### PR TITLE
feat(web): rebuild workflow section around proof artifacts

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import { FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from 'reac
 import { BrowserRouter, Link, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { SafeLink } from './components/SafeLink';
 import { HeroProductReveal } from './components/home/HeroProductReveal';
+import { HowItWorksSection } from './components/home/HowItWorksSection';
 import { RiskInsightSection } from './components/home/RiskInsightSection';
 import { TrustProofStrip } from './components/home/TrustProofStrip';
 import { Footer } from './components/layout/Footer';
@@ -1048,27 +1049,7 @@ function HomePage() {
         </div>
       </section>
 
-      <section className="idt-section idt-shell">
-        <SectionTitle eyebrow="How It Works" title="Discover, prioritize, simulate, and roll out in four steps" />
-        <ol className="idt-steps">
-          <li>
-            <h3>1. Connect data sources</h3>
-            <p>Ingest AWS IAM, Kubernetes identities, and repository signals continuously.</p>
-          </li>
-          <li>
-            <h3>2. Build trust paths</h3>
-            <p>Correlate principals, permissions, resources, and transitive assumptions in one graph.</p>
-          </li>
-          <li>
-            <h3>3. Detect high-signal exposures</h3>
-            <p>Prioritize findings based on exploitability, sensitivity, and path reachability.</p>
-          </li>
-          <li>
-            <h3>4. Roll out safer controls</h3>
-            <p>Simulate policy updates, stage changes, and ship with kill-switch safety rails.</p>
-          </li>
-        </ol>
-      </section>
+      <HowItWorksSection />
 
       <DeploymentPathBanner />
 

--- a/web/src/components/home/HowItWorksSection.tsx
+++ b/web/src/components/home/HowItWorksSection.tsx
@@ -1,0 +1,44 @@
+const WORKFLOW_STEPS = [
+  {
+    title: '1. Discover trust relationships',
+    description: 'Collect AWS IAM, Kubernetes, GitHub, and OIDC identity metadata in read-only mode.',
+    output: 'Output: identity graph snapshot with source evidence links'
+  },
+  {
+    title: '2. Prioritize reachable risk paths',
+    description: 'Score findings by severity, privilege depth, and production blast-radius potential.',
+    output: 'Output: ranked findings queue with owner-ready context'
+  },
+  {
+    title: '3. Simulate policy hardening',
+    description: 'Preview trust-policy changes and estimate affected workloads before enforcement.',
+    output: 'Output: remediation plan with expected impact summary'
+  },
+  {
+    title: '4. Roll out with safety controls',
+    description: 'Deploy in stages with rollback options and track resolution outcomes.',
+    output: 'Output: audit-ready remediation timeline and status history'
+  }
+] as const;
+
+export function HowItWorksSection() {
+  return (
+    <section className="idt-section idt-shell" aria-labelledby="workflow-title">
+      <div className="idt-section-title">
+        <p className="idt-eyebrow">Operational Workflow</p>
+        <h2 id="workflow-title">Discover, prioritize, simulate, and roll out in four steps</h2>
+        <p>Each stage produces a concrete artifact your security and platform teams can review together.</p>
+      </div>
+
+      <ol className="idt-steps idt-workflow-steps">
+        {WORKFLOW_STEPS.map((step) => (
+          <li key={step.title}>
+            <h3>{step.title}</h3>
+            <p>{step.description}</p>
+            <p className="idt-workflow-output">{step.output}</p>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -953,6 +953,25 @@ h3 {
   padding: 1rem;
 }
 
+.idt-workflow-steps li {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.idt-workflow-steps li p {
+  margin: 0;
+  color: #d2dcec;
+}
+
+.idt-workflow-output {
+  border: 1px dashed rgba(165, 190, 255, 0.4);
+  border-radius: 10px;
+  background: rgba(165, 190, 255, 0.08);
+  padding: 0.42rem 0.54rem;
+  font-size: 0.84rem;
+  color: #e1ecff;
+}
+
 .idt-steps p {
   margin: 0;
   color: #d7e5ff;


### PR DESCRIPTION
## Summary
- extract homepage workflow into `HowItWorksSection` component
- shift copy from generic process text to artifact-first operational outputs
- make each step explicit about what teams receive and review
- keep the section compact while increasing technical credibility

## Validation
- npm --prefix web run test -- --run


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt the homepage workflow section around proof artifacts with a dedicated `HowItWorksSection` component. Clarifies each step’s output and adds lightweight styling for output callouts to improve scannability for security and platform teams.

- **Refactors**
  - Extracted the workflow UI into `web/src/components/home/HowItWorksSection.tsx` and replaced the inline section in `HomePage`.
  - Added `.idt-workflow-steps` spacing and `.idt-workflow-output` callout styles in `web/src/styles.css`.
  - Set `aria-labelledby` on the section for better accessibility.

<sup>Written for commit a118245192a6d8483731e96daa4393fbdbde5c22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

