### PR TITLE
feat(web): add dedicated deployment models page

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -49,4 +49,16 @@ describe('App', () => {
     expect(screen.getByText(/Step 1 of 3/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument();
   });
+
+  it('renders deployment models route', () => {
+    window.history.pushState({}, '', '/deployment-models');
+    render(<App />);
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /Choose your control boundary without changing operating model/i
+      })
+    ).toBeInTheDocument();
+  });
 });

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -61,4 +61,16 @@ describe('App', () => {
       })
     ).toBeInTheDocument();
   });
+
+  it('renders integrations route', () => {
+    window.history.pushState({}, '', '/integrations');
+    render(<App />);
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /Identity signal coverage across cloud, cluster, and code workflows/i
+      })
+    ).toBeInTheDocument();
+  });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -124,6 +124,39 @@ const FEATURE_ROWS = [
   }
 ] as const;
 
+const INTEGRATION_ROWS = [
+  {
+    source: 'AWS IAM',
+    signals: 'Roles, trust policies, assumptions, account paths',
+    depth: 'Deep',
+    status: 'GA'
+  },
+  {
+    source: 'Kubernetes',
+    signals: 'Service accounts, RBAC bindings, namespace privilege paths',
+    depth: 'Deep',
+    status: 'GA'
+  },
+  {
+    source: 'GitHub',
+    signals: 'Workflow identities, OIDC trust, repository exposure telemetry',
+    depth: 'Deep',
+    status: 'GA'
+  },
+  {
+    source: 'OIDC Federation',
+    signals: 'Provider trust boundaries and subject claim controls',
+    depth: 'Focused',
+    status: 'GA'
+  },
+  {
+    source: 'Multi-cloud adapters',
+    signals: 'Extended identity graph edges and normalized trust metadata',
+    depth: 'Roadmap',
+    status: 'Beta'
+  }
+] as const;
+
 const FEATURE_DEEP_PAGES = [
   {
     slug: 'aws',
@@ -1909,6 +1942,78 @@ function DeploymentModelsPage() {
   );
 }
 
+function IntegrationsPage() {
+  useSeo({
+    title: 'Integrations | Machine Identity Signal Coverage',
+    description:
+      'Review Identrail integration coverage across AWS IAM, Kubernetes, GitHub, and OIDC trust paths with depth and signal details.',
+    path: '/integrations'
+  });
+
+  return (
+    <>
+      <section className="idt-page-hero idt-shell">
+        <p className="idt-eyebrow">Integrations</p>
+        <h1>Identity signal coverage across cloud, cluster, and code workflows</h1>
+        <p>
+          Identrail unifies machine identity telemetry into one trust-path analysis model. Use this page to verify connector depth
+          before rollout.
+        </p>
+      </section>
+
+      <section className="idt-section idt-shell">
+        <div className="idt-table-wrap">
+          <table className="idt-compare-table">
+            <thead>
+              <tr>
+                <th scope="col">Integration</th>
+                <th scope="col">Signals captured</th>
+                <th scope="col">Depth</th>
+                <th scope="col">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {INTEGRATION_ROWS.map((row) => (
+                <tr key={row.source}>
+                  <th scope="row">{row.source}</th>
+                  <td>{row.signals}</td>
+                  <td>{row.depth}</td>
+                  <td>{row.status}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="idt-section idt-shell">
+        <div className="idt-card-grid two-col">
+          <article className="idt-card">
+            <h2>Integration onboarding workflow</h2>
+            <ul>
+              <li>Start with read-only connector setup and source validation</li>
+              <li>Confirm trust-path ingestion and evidence mapping</li>
+              <li>Review first prioritized findings with platform owners</li>
+            </ul>
+          </article>
+          <article className="idt-card">
+            <h2>Technical bridge</h2>
+            <p>Need implementation details first? Review docs, then run your first guided scan intake.</p>
+            <div className="idt-inline-actions">
+              <SafeLink href={DOCS_REPO} className="idt-btn idt-btn-ghost">
+                Open Documentation
+              </SafeLink>
+              <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
+                Start Read-Only Risk Scan
+              </Link>
+            </div>
+          </article>
+        </div>
+      </section>
+    </>
+  );
+}
+
 function DemoPage() {
   useSeo({
     title: 'Demo | Interactive Trust Graph',
@@ -2362,7 +2467,7 @@ export function RoutedSite() {
           <Route path="/" element={<HomePage />} />
           <Route path="/product" element={<ProductPage />} />
           <Route path="/features" element={<FeaturesPage />} />
-          <Route path="/integrations" element={<FeaturesPage />} />
+          <Route path="/integrations" element={<IntegrationsPage />} />
           {FEATURE_DEEP_PAGES.map((page) => (
             <Route key={page.slug} path={`/features/${page.slug}`} element={<FeatureDetailPage page={page} />} />
           ))}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import { FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from 'reac
 import { BrowserRouter, Link, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { SafeLink } from './components/SafeLink';
 import { HeroProductReveal } from './components/home/HeroProductReveal';
+import { HowItWorksSection } from './components/home/HowItWorksSection';
 import { RiskInsightSection } from './components/home/RiskInsightSection';
 import { TrustProofStrip } from './components/home/TrustProofStrip';
 import { Footer } from './components/layout/Footer';
@@ -1048,27 +1049,7 @@ function HomePage() {
         </div>
       </section>
 
-      <section className="idt-section idt-shell">
-        <SectionTitle eyebrow="How It Works" title="Discover, prioritize, simulate, and roll out in four steps" />
-        <ol className="idt-steps">
-          <li>
-            <h3>1. Connect data sources</h3>
-            <p>Ingest AWS IAM, Kubernetes identities, and repository signals continuously.</p>
-          </li>
-          <li>
-            <h3>2. Build trust paths</h3>
-            <p>Correlate principals, permissions, resources, and transitive assumptions in one graph.</p>
-          </li>
-          <li>
-            <h3>3. Detect high-signal exposures</h3>
-            <p>Prioritize findings based on exploitability, sensitivity, and path reachability.</p>
-          </li>
-          <li>
-            <h3>4. Roll out safer controls</h3>
-            <p>Simulate policy updates, stage changes, and ship with kill-switch safety rails.</p>
-          </li>
-        </ol>
-      </section>
+      <HowItWorksSection />
 
       <DeploymentPathBanner />
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1810,6 +1810,105 @@ function PricingPage() {
   );
 }
 
+function DeploymentModelsPage() {
+  useSeo({
+    title: 'Deployment Models | Open-Core, Hosted, and Enterprise',
+    description:
+      'Compare Identrail deployment models for machine identity security: self-hosted open-core, hosted SaaS, and enterprise private deployment.',
+    path: '/deployment-models'
+  });
+
+  return (
+    <>
+      <section className="idt-page-hero idt-shell">
+        <p className="idt-eyebrow">Deployment Models</p>
+        <h1>Choose your control boundary without changing operating model</h1>
+        <p>
+          Identrail keeps the same trust-path workflow across open-core, hosted SaaS, and enterprise deployments. Choose based on
+          control, speed, and governance requirements.
+        </p>
+      </section>
+
+      <section className="idt-section idt-shell">
+        <div className="idt-card-grid three-col">
+          <article className="idt-card">
+            <h2>Open-Core</h2>
+            <p>
+              <strong>Best for:</strong> teams that require self-hosted control and deep platform customization.
+            </p>
+            <ul>
+              <li>Run in your infrastructure</li>
+              <li>Community support and docs</li>
+              <li>Transparent architecture and source</li>
+            </ul>
+            <SafeLink href={GITHUB_REPO} className="idt-btn idt-btn-ghost">
+              View Open Source
+            </SafeLink>
+          </article>
+          <article className="idt-card">
+            <h2>Hosted SaaS</h2>
+            <p>
+              <strong>Best for:</strong> fastest time-to-value with managed operations.
+            </p>
+            <ul>
+              <li>Managed platform operations</li>
+              <li>Read-only onboarding for first scan</li>
+              <li>Accelerated query and collaboration workflows</li>
+            </ul>
+            <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
+              Start Read-Only Risk Scan
+            </Link>
+          </article>
+          <article className="idt-card">
+            <h2>Enterprise Private</h2>
+            <p>
+              <strong>Best for:</strong> private tenancy, procurement controls, and advanced support programs.
+            </p>
+            <ul>
+              <li>Private deployment options</li>
+              <li>SCIM and advanced governance controls</li>
+              <li>24/7 support and named TAM</li>
+            </ul>
+            <Link to="/enterprise" className="idt-btn idt-btn-dark">
+              Book Technical Demo
+            </Link>
+          </article>
+        </div>
+      </section>
+
+      <section className="idt-section idt-shell">
+        <SectionTitle
+          eyebrow="Capability Matrix"
+          title="Deployment differences by capability"
+          body="Use this matrix to align your deployment choice with security controls, data residency, and support needs."
+        />
+        <div className="idt-table-wrap">
+          <table className="idt-compare-table">
+            <thead>
+              <tr>
+                <th scope="col">Capability</th>
+                <th scope="col">Open-Core</th>
+                <th scope="col">Hosted SaaS</th>
+                <th scope="col">Enterprise</th>
+              </tr>
+            </thead>
+            <tbody>
+              {FEATURE_ROWS.map((row) => (
+                <tr key={row.capability}>
+                  <th scope="row">{row.capability}</th>
+                  <td>{row.openSource}</td>
+                  <td>{row.pro}</td>
+                  <td>{row.enterprise}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </>
+  );
+}
+
 function DemoPage() {
   useSeo({
     title: 'Demo | Interactive Trust Graph',
@@ -2273,7 +2372,7 @@ export function RoutedSite() {
           ))}
           <Route path="/pricing" element={<PricingPage />} />
           <Route path="/read-only-scan" element={<ReadOnlyScanPage />} />
-          <Route path="/deployment-models" element={<PricingPage />} />
+          <Route path="/deployment-models" element={<DeploymentModelsPage />} />
           <Route path="/demo" element={<DemoPage />} />
           <Route path="/docs" element={<DocsPage />} />
           <Route path="/blog" element={<BlogPage />} />

--- a/web/src/components/home/HowItWorksSection.tsx
+++ b/web/src/components/home/HowItWorksSection.tsx
@@ -1,0 +1,44 @@
+const WORKFLOW_STEPS = [
+  {
+    title: '1. Discover trust relationships',
+    description: 'Collect AWS IAM, Kubernetes, GitHub, and OIDC identity metadata in read-only mode.',
+    output: 'Output: identity graph snapshot with source evidence links'
+  },
+  {
+    title: '2. Prioritize reachable risk paths',
+    description: 'Score findings by severity, privilege depth, and production blast-radius potential.',
+    output: 'Output: ranked findings queue with owner-ready context'
+  },
+  {
+    title: '3. Simulate policy hardening',
+    description: 'Preview trust-policy changes and estimate affected workloads before enforcement.',
+    output: 'Output: remediation plan with expected impact summary'
+  },
+  {
+    title: '4. Roll out with safety controls',
+    description: 'Deploy in stages with rollback options and track resolution outcomes.',
+    output: 'Output: audit-ready remediation timeline and status history'
+  }
+] as const;
+
+export function HowItWorksSection() {
+  return (
+    <section className="idt-section idt-shell" aria-labelledby="workflow-title">
+      <div className="idt-section-title">
+        <p className="idt-eyebrow">Operational Workflow</p>
+        <h2 id="workflow-title">Discover, prioritize, simulate, and roll out in four steps</h2>
+        <p>Each stage produces a concrete artifact your security and platform teams can review together.</p>
+      </div>
+
+      <ol className="idt-steps idt-workflow-steps">
+        {WORKFLOW_STEPS.map((step) => (
+          <li key={step.title}>
+            <h3>{step.title}</h3>
+            <p>{step.description}</p>
+            <p className="idt-workflow-output">{step.output}</p>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -953,6 +953,25 @@ h3 {
   padding: 1rem;
 }
 
+.idt-workflow-steps li {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.idt-workflow-steps li p {
+  margin: 0;
+  color: #d2dcec;
+}
+
+.idt-workflow-output {
+  border: 1px dashed rgba(165, 190, 255, 0.4);
+  border-radius: 10px;
+  background: rgba(165, 190, 255, 0.08);
+  padding: 0.42rem 0.54rem;
+  font-size: 0.84rem;
+  color: #e1ecff;
+}
+
 .idt-steps p {
   margin: 0;
   color: #d7e5ff;


### PR DESCRIPTION
## Summary
- add dedicated `/deployment-models` page with open-core, hosted SaaS, and enterprise paths
- replace route aliasing so deployment has its own narrative and matrix
- include capability comparison table for deployment-specific decision making
- add route test coverage for deployment models page

## Validation
- npm --prefix web run test -- --run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added dedicated `/deployment-models` and `/integrations` pages with clear paths, comparison tables, SEO, and targeted CTAs. Reworked the workflow section around proof artifacts to make rollout steps and outputs clear.

- New Features
  - New `DeploymentModelsPage` with hero, capability matrix, and CTAs to read-only scan and enterprise demo.
  - New `IntegrationsPage` with signal coverage table and CTAs to docs and read-only scan.
  - SEO metadata and route tests for `/deployment-models` and `/integrations`.

- Refactors
  - Replaced the pricing alias with a real `/deployment-models` route.
  - Routed `/integrations` to the new page (was `/features`).
  - Extracted `HowItWorksSection` with artifact outputs and styles.

<sup>Written for commit fe1c90fc323bbf22767d25757e6336f948e9f0e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

