### PR TITLE
feat(web): add dedicated integrations hub page

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -61,4 +61,16 @@ describe('App', () => {
       })
     ).toBeInTheDocument();
   });
+
+  it('renders integrations route', () => {
+    window.history.pushState({}, '', '/integrations');
+    render(<App />);
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /Identity signal coverage across cloud, cluster, and code workflows/i
+      })
+    ).toBeInTheDocument();
+  });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -124,6 +124,39 @@ const FEATURE_ROWS = [
   }
 ] as const;
 
+const INTEGRATION_ROWS = [
+  {
+    source: 'AWS IAM',
+    signals: 'Roles, trust policies, assumptions, account paths',
+    depth: 'Deep',
+    status: 'GA'
+  },
+  {
+    source: 'Kubernetes',
+    signals: 'Service accounts, RBAC bindings, namespace privilege paths',
+    depth: 'Deep',
+    status: 'GA'
+  },
+  {
+    source: 'GitHub',
+    signals: 'Workflow identities, OIDC trust, repository exposure telemetry',
+    depth: 'Deep',
+    status: 'GA'
+  },
+  {
+    source: 'OIDC Federation',
+    signals: 'Provider trust boundaries and subject claim controls',
+    depth: 'Focused',
+    status: 'GA'
+  },
+  {
+    source: 'Multi-cloud adapters',
+    signals: 'Extended identity graph edges and normalized trust metadata',
+    depth: 'Roadmap',
+    status: 'Beta'
+  }
+] as const;
+
 const FEATURE_DEEP_PAGES = [
   {
     slug: 'aws',
@@ -1909,6 +1942,78 @@ function DeploymentModelsPage() {
   );
 }
 
+function IntegrationsPage() {
+  useSeo({
+    title: 'Integrations | Machine Identity Signal Coverage',
+    description:
+      'Review Identrail integration coverage across AWS IAM, Kubernetes, GitHub, and OIDC trust paths with depth and signal details.',
+    path: '/integrations'
+  });
+
+  return (
+    <>
+      <section className="idt-page-hero idt-shell">
+        <p className="idt-eyebrow">Integrations</p>
+        <h1>Identity signal coverage across cloud, cluster, and code workflows</h1>
+        <p>
+          Identrail unifies machine identity telemetry into one trust-path analysis model. Use this page to verify connector depth
+          before rollout.
+        </p>
+      </section>
+
+      <section className="idt-section idt-shell">
+        <div className="idt-table-wrap">
+          <table className="idt-compare-table">
+            <thead>
+              <tr>
+                <th scope="col">Integration</th>
+                <th scope="col">Signals captured</th>
+                <th scope="col">Depth</th>
+                <th scope="col">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {INTEGRATION_ROWS.map((row) => (
+                <tr key={row.source}>
+                  <th scope="row">{row.source}</th>
+                  <td>{row.signals}</td>
+                  <td>{row.depth}</td>
+                  <td>{row.status}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="idt-section idt-shell">
+        <div className="idt-card-grid two-col">
+          <article className="idt-card">
+            <h2>Integration onboarding workflow</h2>
+            <ul>
+              <li>Start with read-only connector setup and source validation</li>
+              <li>Confirm trust-path ingestion and evidence mapping</li>
+              <li>Review first prioritized findings with platform owners</li>
+            </ul>
+          </article>
+          <article className="idt-card">
+            <h2>Technical bridge</h2>
+            <p>Need implementation details first? Review docs, then run your first guided scan intake.</p>
+            <div className="idt-inline-actions">
+              <SafeLink href={DOCS_REPO} className="idt-btn idt-btn-ghost">
+                Open Documentation
+              </SafeLink>
+              <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
+                Start Read-Only Risk Scan
+              </Link>
+            </div>
+          </article>
+        </div>
+      </section>
+    </>
+  );
+}
+
 function DemoPage() {
   useSeo({
     title: 'Demo | Interactive Trust Graph',
@@ -2362,7 +2467,7 @@ export function RoutedSite() {
           <Route path="/" element={<HomePage />} />
           <Route path="/product" element={<ProductPage />} />
           <Route path="/features" element={<FeaturesPage />} />
-          <Route path="/integrations" element={<FeaturesPage />} />
+          <Route path="/integrations" element={<IntegrationsPage />} />
           {FEATURE_DEEP_PAGES.map((page) => (
             <Route key={page.slug} path={`/features/${page.slug}`} element={<FeatureDetailPage page={page} />} />
           ))}


### PR DESCRIPTION
## Summary
- add dedicated `/integrations` page with integration depth matrix
- replace route aliasing so integrations has its own technical proof narrative
- include onboarding workflow guidance and docs-to-scan bridge CTAs
- add route test coverage for integrations page

## Validation
- npm --prefix web run test -- --run


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated integrations hub at /integrations with a coverage matrix and onboarding guidance. Updates routing to use the new page and adds a test for the route.

**New Features**
- Integration coverage table (signals, depth, status) for AWS IAM, Kubernetes, GitHub, OIDC Federation, and Multi‑cloud adapters.
- Onboarding workflow steps and CTAs to documentation and a read‑only risk scan.
- SEO title and description for the page.
- Router now renders the integrations hub (no longer an alias to Features); test verifies the H1 on /integrations.

<sup>Written for commit 8586b3f26792b848b627387d9716a50fcc4eb446. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

