### PR TITLE
feat(web): move ROI modeling into dedicated assessment page

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -73,4 +73,16 @@ describe('App', () => {
       })
     ).toBeInTheDocument();
   });
+
+  it('renders ROI assessment route', () => {
+    window.history.pushState({}, '', '/roi-assessment');
+    render(<App />);
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /Model risk-reduction impact with transparent assumptions/i
+      })
+    ).toBeInTheDocument();
+  });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1812,11 +1812,18 @@ function PricingPage() {
 
       <section className="idt-section idt-shell idt-pricing-roi">
         <SectionTitle
-          eyebrow="Plan Fit"
-          title="Project impact before selecting your deployment path"
-          body="Use transparent assumptions to estimate incident-exposure reduction and triage-efficiency gains."
+          eyebrow="Impact Model"
+          title="Need ROI modeling before procurement?"
+          body="Use the dedicated ROI assessment page with transparent assumptions and editable parameters."
         />
-        <RoiCalculator />
+        <div className="idt-inline-actions">
+          <Link to="/roi-assessment" className="idt-btn idt-btn-primary">
+            Open ROI Assessment
+          </Link>
+          <Link to="/read-only-scan" className="idt-btn idt-btn-dark">
+            Start Read-Only Risk Scan
+          </Link>
+        </div>
       </section>
 
       {salesModalOpen ? (
@@ -1839,6 +1846,47 @@ function PricingPage() {
           />
         </ModalShell>
       ) : null}
+    </>
+  );
+}
+
+function RoiAssessmentPage() {
+  useSeo({
+    title: 'ROI Assessment | Machine Identity Security Impact Model',
+    description:
+      'Run a transparent ROI assessment for machine identity security risk reduction with editable assumptions and impact calculations.',
+    path: '/roi-assessment'
+  });
+
+  return (
+    <>
+      <section className="idt-page-hero idt-shell">
+        <p className="idt-eyebrow">ROI Assessment</p>
+        <h1>Model risk-reduction impact with transparent assumptions</h1>
+        <p>
+          This tool is a planning model, not a guarantee. Adjust each input to match your environment and validate assumptions with
+          your security and finance stakeholders.
+        </p>
+      </section>
+
+      <section className="idt-section idt-shell">
+        <RoiCalculator />
+        <p className="idt-roi-disclaimer">
+          Assumptions: labor savings = weekly triage hours × 52 × $110; incident exposure reduction coefficient = 0.87; high-risk
+          identity reduction coefficient = 0.32.
+        </p>
+      </section>
+
+      <section className="idt-section idt-shell">
+        <div className="idt-inline-actions">
+          <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
+            Start Read-Only Risk Scan
+          </Link>
+          <Link to="/pricing" className="idt-btn idt-btn-dark">
+            Compare Pricing Plans
+          </Link>
+        </div>
+      </section>
     </>
   );
 }
@@ -2476,6 +2524,7 @@ export function RoutedSite() {
             <Route key={page.slug} path={`/solutions/${page.slug}`} element={<SolutionDetailPage page={page} />} />
           ))}
           <Route path="/pricing" element={<PricingPage />} />
+          <Route path="/roi-assessment" element={<RoiAssessmentPage />} />
           <Route path="/read-only-scan" element={<ReadOnlyScanPage />} />
           <Route path="/deployment-models" element={<DeploymentModelsPage />} />
           <Route path="/demo" element={<DemoPage />} />


### PR DESCRIPTION
## Summary
- add dedicated `/roi-assessment` page for full ROI modeling with clear assumptions
- replace pricing-page embedded ROI calculator with focused teaser + route to dedicated model page
- keep pricing page cleaner while preserving ROI access for procurement workflows
- add route test coverage for ROI assessment page

## Validation
- npm --prefix web run test -- --run


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the ROI calculator into a dedicated `/roi-assessment` page to provide clearer assumptions and a focused workflow. Simplified the pricing page with a teaser and CTAs while keeping ROI access easy.

- **New Features**
  - Added `RoiAssessmentPage` with SEO metadata, hero copy, disclaimer, and the existing `RoiCalculator`.
  - Registered `"/roi-assessment"` route and linked to it from pricing; added a CTA to `/read-only-scan`.
  - Added a route test that renders the ROI assessment heading.

<sup>Written for commit 6e7e4b886c584d554a46cbe6d2a04d05cff1361f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

