### PR TITLE
feat(web): move full FAQ to dedicated route

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -97,4 +97,16 @@ describe('App', () => {
       })
     ).toBeInTheDocument();
   });
+
+  it('renders responsible disclosure route', () => {
+    window.history.pushState({}, '', '/responsible-disclosure');
+    render(<App />);
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /Report security issues through a coordinated disclosure process/i
+      })
+    ).toBeInTheDocument();
+  });
 });

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -85,4 +85,16 @@ describe('App', () => {
       })
     ).toBeInTheDocument();
   });
+
+  it('renders full FAQ route', () => {
+    window.history.pushState({}, '', '/faq');
+    render(<App />);
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /Technical and operational questions teams ask before rollout/i
+      })
+    ).toBeInTheDocument();
+  });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1021,7 +1021,41 @@ function HomeFaqSection() {
           </details>
         ))}
       </div>
+      <div className="idt-inline-actions">
+        <Link to="/faq" className="idt-btn idt-btn-ghost">
+          View Full FAQ
+        </Link>
+      </div>
     </section>
+  );
+}
+
+function FaqPage() {
+  useSeo({
+    title: 'FAQ | Identrail Machine Identity Security',
+    description:
+      'Detailed answers for machine identity security adoption including read-only model, data handling, deployment options, and rollout safety.',
+    path: '/faq'
+  });
+
+  return (
+    <>
+      <section className="idt-page-hero idt-shell">
+        <p className="idt-eyebrow">FAQ</p>
+        <h1>Technical and operational questions teams ask before rollout</h1>
+        <p>Answers focus on read-only collection boundaries, deployment models, and safe remediation workflows.</p>
+      </section>
+      <section className="idt-section idt-shell">
+        <div className="idt-faq-list">
+          {HOME_FAQ_ITEMS.map((item) => (
+            <details key={item.question} className="idt-faq-item">
+              <summary>{item.question}</summary>
+              <p>{item.answer}</p>
+            </details>
+          ))}
+        </div>
+      </section>
+    </>
   );
 }
 
@@ -2539,6 +2573,7 @@ export function RoutedSite() {
           <Route path="/deployment-models" element={<DeploymentModelsPage />} />
           <Route path="/demo" element={<DemoPage />} />
           <Route path="/docs" element={<DocsPage />} />
+          <Route path="/faq" element={<FaqPage />} />
           <Route path="/blog" element={<BlogPage />} />
           <Route path="/blog/:slug" element={<BlogArticlePage />} />
           <Route path="/security" element={<SecurityPage />} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -157,6 +157,24 @@ const INTEGRATION_ROWS = [
   }
 ] as const;
 
+const READ_ONLY_CONTROL_ROWS = [
+  {
+    area: 'Identity metadata collection',
+    access: 'Read-only API calls for identity, policy, and relationship metadata',
+    excluded: 'No secret material ingestion, no credential writeback'
+  },
+  {
+    area: 'Policy simulation',
+    access: 'Simulation engine evaluates proposed changes against collected graph state',
+    excluded: 'No direct policy mutation during simulation'
+  },
+  {
+    area: 'Remediation workflow',
+    access: 'Action plans and exportable recommendations',
+    excluded: 'No automatic enforcement without explicit operator action'
+  }
+] as const;
+
 const FEATURE_DEEP_PAGES = [
   {
     slug: 'aws',
@@ -2372,6 +2390,34 @@ function SecurityPage() {
       </section>
 
       <section className="idt-section idt-shell">
+        <SectionTitle
+          eyebrow="Read-Only Model"
+          title="Collection boundaries and control guarantees"
+          body="Use this matrix to validate how Identrail collects trust data and where write actions are intentionally excluded."
+        />
+        <div className="idt-table-wrap">
+          <table className="idt-compare-table">
+            <thead>
+              <tr>
+                <th scope="col">Control area</th>
+                <th scope="col">What Identrail does</th>
+                <th scope="col">What Identrail does not do</th>
+              </tr>
+            </thead>
+            <tbody>
+              {READ_ONLY_CONTROL_ROWS.map((row) => (
+                <tr key={row.area}>
+                  <th scope="row">{row.area}</th>
+                  <td>{row.access}</td>
+                  <td>{row.excluded}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="idt-section idt-shell">
         <div className="idt-card-grid two-col idt-security-grid">
           <article className="idt-card">
             <h2>Compliance roadmap</h2>
@@ -2408,11 +2454,56 @@ function SecurityPage() {
         </div>
       </section>
       <section className="idt-section idt-shell">
-        <LeadCaptureForm
-          title="Need vendor security documentation?"
-          caption="Request security package access for procurement and compliance review."
-          ctaLabel="Book Demo"
-        />
+        <div className="idt-inline-actions">
+          <Link to="/responsible-disclosure" className="idt-btn idt-btn-dark">
+            Responsible Disclosure
+          </Link>
+          <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
+            Start Read-Only Risk Scan
+          </Link>
+          <SafeLink href={DOCS_REPO} className="idt-btn idt-btn-ghost">
+            Review Security Docs
+          </SafeLink>
+        </div>
+      </section>
+    </>
+  );
+}
+
+function ResponsibleDisclosurePage() {
+  useSeo({
+    title: 'Responsible Disclosure | Identrail Security',
+    description:
+      'Report potential vulnerabilities to Identrail using our responsible disclosure process and coordinated response workflow.',
+    path: '/responsible-disclosure'
+  });
+
+  return (
+    <>
+      <section className="idt-page-hero idt-shell">
+        <p className="idt-eyebrow">Responsible Disclosure</p>
+        <h1>Report security issues through a coordinated disclosure process</h1>
+        <p>We investigate security reports promptly and coordinate remediation and communication with reporters.</p>
+      </section>
+      <section className="idt-section idt-shell">
+        <div className="idt-card-grid two-col">
+          <article className="idt-card">
+            <h2>How to report</h2>
+            <ul>
+              <li>Submit detailed findings through our documented security contact channel</li>
+              <li>Include reproduction steps, affected components, and potential impact</li>
+              <li>Avoid public disclosure until coordinated remediation is completed</li>
+            </ul>
+          </article>
+          <article className="idt-card">
+            <h2>Response expectations</h2>
+            <ul>
+              <li>Initial acknowledgement within one business day</li>
+              <li>Triage and severity classification with engineering review</li>
+              <li>Coordinated disclosure timeline after remediation is validated</li>
+            </ul>
+          </article>
+        </div>
       </section>
     </>
   );
@@ -2577,6 +2668,7 @@ export function RoutedSite() {
           <Route path="/blog" element={<BlogPage />} />
           <Route path="/blog/:slug" element={<BlogArticlePage />} />
           <Route path="/security" element={<SecurityPage />} />
+          <Route path="/responsible-disclosure" element={<ResponsibleDisclosurePage />} />
           <Route path="/about" element={<AboutPage />} />
           <Route path="/enterprise" element={<EnterprisePage />} />
           <Route path="/terms" element={<LegalPage title="Terms" body="Use of this website and platform is subject to our terms and acceptable use obligations." />} />


### PR DESCRIPTION
## Summary
- add dedicated `/faq` page with full machine-identity adoption questions
- keep homepage FAQ as concise preview and add explicit route to full FAQ
- preserve FAQ content while improving homepage compression and hierarchy
- add route test coverage for FAQ page

## Validation
- npm --prefix web run test -- --run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the full FAQ to a dedicated `/faq` route and kept a short preview on the homepage. Expanded the Trust Center with a read‑only control matrix and a new `/responsible-disclosure` page.

- **New Features**
  - Added `/faq` and `/responsible-disclosure` pages with `useSeo`, and a “View Full FAQ” link on the homepage.
  - Added a read‑only control matrix to Security and CTAs to disclosure, `/read-only-scan`, and security docs.
  - Added route tests that verify H1s for full FAQ and responsible disclosure.

<sup>Written for commit 1d6863164f6651e4f5e6ffe2207a7ecfe77267df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

