### PR TITLE
feat(web): add footer trust links and maturity metadata

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -97,4 +97,16 @@ describe('App', () => {
       })
     ).toBeInTheDocument();
   });
+
+  it('renders responsible disclosure route', () => {
+    window.history.pushState({}, '', '/responsible-disclosure');
+    render(<App />);
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /Report security issues through a coordinated disclosure process/i
+      })
+    ).toBeInTheDocument();
+  });
 });

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -85,4 +85,16 @@ describe('App', () => {
       })
     ).toBeInTheDocument();
   });
+
+  it('renders full FAQ route', () => {
+    window.history.pushState({}, '', '/faq');
+    render(<App />);
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /Technical and operational questions teams ask before rollout/i
+      })
+    ).toBeInTheDocument();
+  });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1021,7 +1021,41 @@ function HomeFaqSection() {
           </details>
         ))}
       </div>
+      <div className="idt-inline-actions">
+        <Link to="/faq" className="idt-btn idt-btn-ghost">
+          View Full FAQ
+        </Link>
+      </div>
     </section>
+  );
+}
+
+function FaqPage() {
+  useSeo({
+    title: 'FAQ | Identrail Machine Identity Security',
+    description:
+      'Detailed answers for machine identity security adoption including read-only model, data handling, deployment options, and rollout safety.',
+    path: '/faq'
+  });
+
+  return (
+    <>
+      <section className="idt-page-hero idt-shell">
+        <p className="idt-eyebrow">FAQ</p>
+        <h1>Technical and operational questions teams ask before rollout</h1>
+        <p>Answers focus on read-only collection boundaries, deployment models, and safe remediation workflows.</p>
+      </section>
+      <section className="idt-section idt-shell">
+        <div className="idt-faq-list">
+          {HOME_FAQ_ITEMS.map((item) => (
+            <details key={item.question} className="idt-faq-item">
+              <summary>{item.question}</summary>
+              <p>{item.answer}</p>
+            </details>
+          ))}
+        </div>
+      </section>
+    </>
   );
 }
 
@@ -2539,6 +2573,7 @@ export function RoutedSite() {
           <Route path="/deployment-models" element={<DeploymentModelsPage />} />
           <Route path="/demo" element={<DemoPage />} />
           <Route path="/docs" element={<DocsPage />} />
+          <Route path="/faq" element={<FaqPage />} />
           <Route path="/blog" element={<BlogPage />} />
           <Route path="/blog/:slug" element={<BlogArticlePage />} />
           <Route path="/security" element={<SecurityPage />} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -157,6 +157,24 @@ const INTEGRATION_ROWS = [
   }
 ] as const;
 
+const READ_ONLY_CONTROL_ROWS = [
+  {
+    area: 'Identity metadata collection',
+    access: 'Read-only API calls for identity, policy, and relationship metadata',
+    excluded: 'No secret material ingestion, no credential writeback'
+  },
+  {
+    area: 'Policy simulation',
+    access: 'Simulation engine evaluates proposed changes against collected graph state',
+    excluded: 'No direct policy mutation during simulation'
+  },
+  {
+    area: 'Remediation workflow',
+    access: 'Action plans and exportable recommendations',
+    excluded: 'No automatic enforcement without explicit operator action'
+  }
+] as const;
+
 const FEATURE_DEEP_PAGES = [
   {
     slug: 'aws',
@@ -2372,6 +2390,34 @@ function SecurityPage() {
       </section>
 
       <section className="idt-section idt-shell">
+        <SectionTitle
+          eyebrow="Read-Only Model"
+          title="Collection boundaries and control guarantees"
+          body="Use this matrix to validate how Identrail collects trust data and where write actions are intentionally excluded."
+        />
+        <div className="idt-table-wrap">
+          <table className="idt-compare-table">
+            <thead>
+              <tr>
+                <th scope="col">Control area</th>
+                <th scope="col">What Identrail does</th>
+                <th scope="col">What Identrail does not do</th>
+              </tr>
+            </thead>
+            <tbody>
+              {READ_ONLY_CONTROL_ROWS.map((row) => (
+                <tr key={row.area}>
+                  <th scope="row">{row.area}</th>
+                  <td>{row.access}</td>
+                  <td>{row.excluded}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="idt-section idt-shell">
         <div className="idt-card-grid two-col idt-security-grid">
           <article className="idt-card">
             <h2>Compliance roadmap</h2>
@@ -2408,11 +2454,56 @@ function SecurityPage() {
         </div>
       </section>
       <section className="idt-section idt-shell">
-        <LeadCaptureForm
-          title="Need vendor security documentation?"
-          caption="Request security package access for procurement and compliance review."
-          ctaLabel="Book Demo"
-        />
+        <div className="idt-inline-actions">
+          <Link to="/responsible-disclosure" className="idt-btn idt-btn-dark">
+            Responsible Disclosure
+          </Link>
+          <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
+            Start Read-Only Risk Scan
+          </Link>
+          <SafeLink href={DOCS_REPO} className="idt-btn idt-btn-ghost">
+            Review Security Docs
+          </SafeLink>
+        </div>
+      </section>
+    </>
+  );
+}
+
+function ResponsibleDisclosurePage() {
+  useSeo({
+    title: 'Responsible Disclosure | Identrail Security',
+    description:
+      'Report potential vulnerabilities to Identrail using our responsible disclosure process and coordinated response workflow.',
+    path: '/responsible-disclosure'
+  });
+
+  return (
+    <>
+      <section className="idt-page-hero idt-shell">
+        <p className="idt-eyebrow">Responsible Disclosure</p>
+        <h1>Report security issues through a coordinated disclosure process</h1>
+        <p>We investigate security reports promptly and coordinate remediation and communication with reporters.</p>
+      </section>
+      <section className="idt-section idt-shell">
+        <div className="idt-card-grid two-col">
+          <article className="idt-card">
+            <h2>How to report</h2>
+            <ul>
+              <li>Submit detailed findings through our documented security contact channel</li>
+              <li>Include reproduction steps, affected components, and potential impact</li>
+              <li>Avoid public disclosure until coordinated remediation is completed</li>
+            </ul>
+          </article>
+          <article className="idt-card">
+            <h2>Response expectations</h2>
+            <ul>
+              <li>Initial acknowledgement within one business day</li>
+              <li>Triage and severity classification with engineering review</li>
+              <li>Coordinated disclosure timeline after remediation is validated</li>
+            </ul>
+          </article>
+        </div>
       </section>
     </>
   );
@@ -2577,6 +2668,7 @@ export function RoutedSite() {
           <Route path="/blog" element={<BlogPage />} />
           <Route path="/blog/:slug" element={<BlogArticlePage />} />
           <Route path="/security" element={<SecurityPage />} />
+          <Route path="/responsible-disclosure" element={<ResponsibleDisclosurePage />} />
           <Route path="/about" element={<AboutPage />} />
           <Route path="/enterprise" element={<EnterprisePage />} />
           <Route path="/terms" element={<LegalPage title="Terms" body="Use of this website and platform is subject to our terms and acceptable use obligations." />} />

--- a/web/src/components/layout/Footer.tsx
+++ b/web/src/components/layout/Footer.tsx
@@ -55,9 +55,12 @@ type FooterProps = {
 const FOOTER_LINKS = [
   { to: '/product', label: 'Product' },
   { to: '/solutions', label: 'Solutions' },
+  { to: '/integrations', label: 'Integrations' },
+  { to: '/deployment-models', label: 'Deployment' },
   { to: '/pricing', label: 'Pricing' },
   { to: '/demo', label: 'Demo' },
   { to: '/docs', label: 'Docs' },
+  { to: '/faq', label: 'FAQ' },
   { to: '/blog', label: 'Blog' },
   { to: '/security', label: 'Security' },
   { to: '/about', label: 'About' },
@@ -65,7 +68,16 @@ const FOOTER_LINKS = [
   { to: '/terms', label: 'Terms' }
 ] as const;
 
+const FOOTER_TRUST_LINKS = [
+  { label: 'Responsible Disclosure', to: '/responsible-disclosure', external: false },
+  { label: 'Changelog', to: 'https://github.com/identrail/identrail/releases', external: true },
+  { label: 'Docs', to: 'https://github.com/identrail/identrail/tree/main/docs', external: true },
+  { label: 'GitHub', to: 'https://github.com/identrail/identrail', external: true }
+] as const;
+
 export function Footer({ xUrl, linkedInUrl, githubRepo, discordUrl }: FooterProps) {
+  const buildDate = new Date().toISOString().slice(0, 10);
+
   return (
     <footer className="idt-footer">
       <div className="idt-footer-bar">
@@ -92,6 +104,22 @@ export function Footer({ xUrl, linkedInUrl, githubRepo, discordUrl }: FooterProp
               <DiscordIcon />
             </SafeLink>
           </div>
+        </div>
+        <div className="idt-shell idt-footer-maturity-row">
+          <div className="idt-footer-trust-links">
+            {FOOTER_TRUST_LINKS.map((item) =>
+              item.external ? (
+                <SafeLink key={item.label} href={item.to}>
+                  {item.label}
+                </SafeLink>
+              ) : (
+                <Link key={item.label} to={item.to}>
+                  {item.label}
+                </Link>
+              )
+            )}
+          </div>
+          <small>Build metadata updated: {buildDate}</small>
         </div>
       </div>
     </footer>

--- a/web/src/components/layout/Footer.tsx
+++ b/web/src/components/layout/Footer.tsx
@@ -76,7 +76,7 @@ const FOOTER_TRUST_LINKS = [
 ] as const;
 
 export function Footer({ xUrl, linkedInUrl, githubRepo, discordUrl }: FooterProps) {
-  const buildDate = new Date().toISOString().slice(0, 10);
+  const buildDate = ((import.meta as ImportMeta & { env?: Record<string, string> }).env?.VITE_BUILD_DATE ?? 'unknown').slice(0, 10);
 
   return (
     <footer className="idt-footer">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1847,6 +1847,34 @@ h2 {
   gap: 0.45rem;
 }
 
+.idt-footer-maturity-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  min-height: 54px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 0.5rem 0;
+}
+
+.idt-footer-trust-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.idt-footer-trust-links a {
+  color: rgba(235, 241, 255, 0.9);
+  text-decoration: none;
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+}
+
+.idt-footer-trust-links a:hover,
+.idt-footer-trust-links a:focus-visible {
+  text-decoration: underline;
+}
+
 .idt-social-link {
   width: 38px;
   height: 38px;
@@ -2279,6 +2307,12 @@ h2 {
     grid-template-columns: 1fr;
     align-items: flex-start;
     padding: 0.9rem 0;
+  }
+
+  .idt-footer-maturity-row {
+    grid-template-columns: 1fr;
+    align-items: flex-start;
+    padding-bottom: 0.8rem;
   }
 
   .idt-form-grid.is-short {


### PR DESCRIPTION
## Summary
- expand footer navigation with integrations, deployment, and FAQ links
- add dedicated trust links row (responsible disclosure, changelog, docs, GitHub)
- add build metadata line to strengthen operational maturity signal
- ensure footer remains responsive across breakpoints

## Validation
- npm --prefix web run test -- --run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded the footer with a trust links row and build metadata, deepened the trust center with a Responsible Disclosure page and a read‑only controls matrix, and added a full FAQ page. Also added new nav links, inline security actions, tests, and responsive CSS.

- **New Features**
  - Footer links: Integrations, Deployment, FAQ.
  - Trust row with Responsible Disclosure, Changelog, Docs, and GitHub; shows build date (YYYY‑MM‑DD).
  - Full FAQ page (/faq) and Responsible Disclosure page (/responsible-disclosure) with test coverage.
  - Read‑only controls matrix and quick actions (disclosure, read‑only scan, docs) on the Security page.

<sup>Written for commit f3f1ff372305b1dc45612064e8c9d9d7194f49f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

