### PR TITLE
fix(web): harden accessibility semantics and modal focus behavior

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -18,6 +18,7 @@ describe('App', () => {
     expect(screen.getAllByRole('link', { name: 'Book Technical Demo' }).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Adoption Paths/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Reachable Risk Paths/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('tab', { name: 'Graph' }).length).toBeGreaterThan(0);
   });
 
   it('renders pricing page routes and key elements', () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -574,8 +574,11 @@ function ModalShell({
   children: ReactNode;
 }) {
   const modalRef = useRef<HTMLDivElement | null>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
+    previouslyFocusedRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
     if (activeModalLocks === 0) {
       bodyOverflowBeforeModal = document.body.style.overflow;
       document.body.style.overflow = 'hidden';
@@ -625,6 +628,7 @@ function ModalShell({
         document.body.style.overflow = bodyOverflowBeforeModal;
       }
       document.removeEventListener('keydown', onKeyDown);
+      previouslyFocusedRef.current?.focus();
     };
   }, [onClose]);
 
@@ -781,6 +785,10 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
   const [selectedId, setSelectedId] = useState<string>('role');
   const selected = nodes.find((item) => item.id === selectedId) ?? nodes[1];
   const scenario = scenarios.find((item) => item.id === scenarioId) ?? scenarios[0];
+  const graphTabId = `trust-graph-tab-${variant}`;
+  const listTabId = `trust-list-tab-${variant}`;
+  const graphPanelId = `trust-graph-panel-${variant}`;
+  const listPanelId = `trust-list-panel-${variant}`;
 
   return (
     <section className={`idt-demo-surface ${variant === 'full' ? 'is-full' : ''}`}>
@@ -796,16 +804,32 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
       </div>
 
       <div className="idt-demo-view-toggle" role="tablist" aria-label="Trust path explorer view">
-        <button type="button" role="tab" aria-selected={viewMode === 'graph'} className={viewMode === 'graph' ? 'is-active' : ''} onClick={() => setViewMode('graph')}>
+        <button
+          id={graphTabId}
+          type="button"
+          role="tab"
+          aria-controls={graphPanelId}
+          aria-selected={viewMode === 'graph'}
+          className={viewMode === 'graph' ? 'is-active' : ''}
+          onClick={() => setViewMode('graph')}
+        >
           Graph
         </button>
-        <button type="button" role="tab" aria-selected={viewMode === 'list'} className={viewMode === 'list' ? 'is-active' : ''} onClick={() => setViewMode('list')}>
+        <button
+          id={listTabId}
+          type="button"
+          role="tab"
+          aria-controls={listPanelId}
+          aria-selected={viewMode === 'list'}
+          className={viewMode === 'list' ? 'is-active' : ''}
+          onClick={() => setViewMode('list')}
+        >
           List
         </button>
       </div>
 
       {viewMode === 'graph' ? (
-        <div className="idt-demo-graph" role="img" aria-label="Interactive trust graph simulation">
+        <div id={graphPanelId} role="tabpanel" aria-labelledby={graphTabId} className="idt-demo-graph" aria-label="Interactive trust graph simulation">
           {nodes.map((node) => (
             <button
               key={node.id}
@@ -822,7 +846,7 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
           <span className="idt-demo-connector c4" />
         </div>
       ) : (
-        <div className="idt-demo-list-view" role="table" aria-label="Trust path nodes">
+        <div id={listPanelId} role="tabpanel" aria-labelledby={listTabId} className="idt-demo-list-view" aria-label="Trust path nodes">
           {nodes.map((node) => (
             <button key={node.id} type="button" className={`idt-demo-list-row ${selected.id === node.id ? 'is-active' : ''}`} onClick={() => setSelectedId(node.id)}>
               <span>{node.title}</span>

--- a/web/src/components/home/RiskInsightSection.tsx
+++ b/web/src/components/home/RiskInsightSection.tsx
@@ -55,14 +55,13 @@ export function RiskInsightSection() {
           {SCENARIOS.map((scenario) => {
             const isActive = scenario.id === activeScenario.id;
             const tabId = `risk-scenario-tab-${scenario.id}`;
-            const panelId = `risk-scenario-panel-${scenario.id}`;
             return (
               <button
                 key={scenario.id}
                 id={tabId}
                 type="button"
                 role="tab"
-                aria-controls={panelId}
+                aria-controls="risk-scenario-panel"
                 aria-selected={isActive}
                 className={`idt-risk-scenario-item ${isActive ? 'is-active' : ''}`}
                 onClick={() => setActiveScenarioId(scenario.id)}
@@ -75,7 +74,7 @@ export function RiskInsightSection() {
         </div>
 
         <article
-          id={`risk-scenario-panel-${activeScenario.id}`}
+          id="risk-scenario-panel"
           className="idt-card idt-risk-evidence-card"
           role="tabpanel"
           aria-labelledby={`risk-scenario-tab-${activeScenario.id}`}

--- a/web/src/components/home/RiskInsightSection.tsx
+++ b/web/src/components/home/RiskInsightSection.tsx
@@ -54,11 +54,15 @@ export function RiskInsightSection() {
         <div className="idt-risk-scenario-list" role="tablist" aria-label="Risk path scenarios">
           {SCENARIOS.map((scenario) => {
             const isActive = scenario.id === activeScenario.id;
+            const tabId = `risk-scenario-tab-${scenario.id}`;
+            const panelId = `risk-scenario-panel-${scenario.id}`;
             return (
               <button
                 key={scenario.id}
+                id={tabId}
                 type="button"
                 role="tab"
+                aria-controls={panelId}
                 aria-selected={isActive}
                 className={`idt-risk-scenario-item ${isActive ? 'is-active' : ''}`}
                 onClick={() => setActiveScenarioId(scenario.id)}
@@ -70,7 +74,13 @@ export function RiskInsightSection() {
           })}
         </div>
 
-        <article className="idt-card idt-risk-evidence-card" role="tabpanel" aria-live="polite">
+        <article
+          id={`risk-scenario-panel-${activeScenario.id}`}
+          className="idt-card idt-risk-evidence-card"
+          role="tabpanel"
+          aria-labelledby={`risk-scenario-tab-${activeScenario.id}`}
+          aria-live="polite"
+        >
           <p className="idt-finding-label">Selected path</p>
           <h3>{activeScenario.path}</h3>
           <p>

--- a/web/src/components/layout/Footer.tsx
+++ b/web/src/components/layout/Footer.tsx
@@ -55,9 +55,12 @@ type FooterProps = {
 const FOOTER_LINKS = [
   { to: '/product', label: 'Product' },
   { to: '/solutions', label: 'Solutions' },
+  { to: '/integrations', label: 'Integrations' },
+  { to: '/deployment-models', label: 'Deployment' },
   { to: '/pricing', label: 'Pricing' },
   { to: '/demo', label: 'Demo' },
   { to: '/docs', label: 'Docs' },
+  { to: '/faq', label: 'FAQ' },
   { to: '/blog', label: 'Blog' },
   { to: '/security', label: 'Security' },
   { to: '/about', label: 'About' },
@@ -65,7 +68,16 @@ const FOOTER_LINKS = [
   { to: '/terms', label: 'Terms' }
 ] as const;
 
+const FOOTER_TRUST_LINKS = [
+  { label: 'Responsible Disclosure', to: '/responsible-disclosure', external: false },
+  { label: 'Changelog', to: 'https://github.com/identrail/identrail/releases', external: true },
+  { label: 'Docs', to: 'https://github.com/identrail/identrail/tree/main/docs', external: true },
+  { label: 'GitHub', to: 'https://github.com/identrail/identrail', external: true }
+] as const;
+
 export function Footer({ xUrl, linkedInUrl, githubRepo, discordUrl }: FooterProps) {
+  const buildDate = new Date().toISOString().slice(0, 10);
+
   return (
     <footer className="idt-footer">
       <div className="idt-footer-bar">
@@ -92,6 +104,22 @@ export function Footer({ xUrl, linkedInUrl, githubRepo, discordUrl }: FooterProp
               <DiscordIcon />
             </SafeLink>
           </div>
+        </div>
+        <div className="idt-shell idt-footer-maturity-row">
+          <div className="idt-footer-trust-links">
+            {FOOTER_TRUST_LINKS.map((item) =>
+              item.external ? (
+                <SafeLink key={item.label} href={item.to}>
+                  {item.label}
+                </SafeLink>
+              ) : (
+                <Link key={item.label} to={item.to}>
+                  {item.label}
+                </Link>
+              )
+            )}
+          </div>
+          <small>Build metadata updated: {buildDate}</small>
         </div>
       </div>
     </footer>

--- a/web/src/components/layout/Footer.tsx
+++ b/web/src/components/layout/Footer.tsx
@@ -76,7 +76,7 @@ const FOOTER_TRUST_LINKS = [
 ] as const;
 
 export function Footer({ xUrl, linkedInUrl, githubRepo, discordUrl }: FooterProps) {
-  const buildDate = new Date().toISOString().slice(0, 10);
+  const buildDate = ((import.meta as ImportMeta & { env?: Record<string, string> }).env?.VITE_BUILD_DATE ?? 'unknown').slice(0, 10);
 
   return (
     <footer className="idt-footer">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1847,6 +1847,34 @@ h2 {
   gap: 0.45rem;
 }
 
+.idt-footer-maturity-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  min-height: 54px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 0.5rem 0;
+}
+
+.idt-footer-trust-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.idt-footer-trust-links a {
+  color: rgba(235, 241, 255, 0.9);
+  text-decoration: none;
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+}
+
+.idt-footer-trust-links a:hover,
+.idt-footer-trust-links a:focus-visible {
+  text-decoration: underline;
+}
+
 .idt-social-link {
   width: 38px;
   height: 38px;
@@ -2279,6 +2307,12 @@ h2 {
     grid-template-columns: 1fr;
     align-items: flex-start;
     padding: 0.9rem 0;
+  }
+
+  .idt-footer-maturity-row {
+    grid-template-columns: 1fr;
+    align-items: flex-start;
+    padding-bottom: 0.8rem;
   }
 
   .idt-form-grid.is-short {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -580,6 +580,19 @@ h3 {
     animation: none;
     opacity: 0.7;
   }
+
+  * {
+    scroll-behavior: auto !important;
+  }
+
+  .idt-btn,
+  .idt-social-link,
+  .idt-proof-link,
+  .idt-risk-scenario-item,
+  .idt-demo-view-toggle button {
+    transition: none !important;
+    transform: none !important;
+  }
 }
 
 .idt-trust-strip {


### PR DESCRIPTION
## Summary
- restore focus to previously active element when modal closes
- add stronger tab/tabpanel semantics for trust explorer and risk scenario controls
- add reduced-motion safety overrides for interactive control transitions
- extend homepage test coverage for tab semantics presence

## Validation
- npm --prefix web run test -- --run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves accessibility with stronger tab/tabpanel semantics, reduced-motion safeguards, and focus restoration on modal close. Adds a footer trust row with links and build date, and a test that confirms the "Graph" tab renders.

- **New Features**
  - Bind Trust Graph/List and Risk Scenario tabs to stable panels via `aria-controls`/`aria-labelledby`; add a homepage test for the "Graph" tab.
  - Expand `prefers-reduced-motion` handling: disable transitions/transforms on buttons and controls; set `scroll-behavior: auto`.
  - Add footer trust links (Responsible Disclosure, Changelog, Docs, GitHub), show build date, and extend footer nav.

- **Bug Fixes**
  - Restore focus to the previously focused element when a modal closes.

<sup>Written for commit 2e96aa70f5452f8734b1b588277239be018851e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

