### PR TITLE
chore(web): add quality gate and conversion analytics events

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,8 @@
     "test": "vitest",
     "test:ci": "vitest run --coverage",
     "perf:lighthouse": "lhci autorun --config=./lighthouserc.json",
-    "perf:bundle": "vite build --mode production"
+    "perf:bundle": "vite build --mode production",
+    "quality:gate": "npm run test:ci && npm run perf:bundle"
   },
   "dependencies": {
     "react": "^19.2.5",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { BrowserRouter, Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { SafeLink } from './components/SafeLink';
+import { captureAnalyticsEvent } from './analytics/events';
 import { HeroProductReveal } from './components/home/HeroProductReveal';
 import { HowItWorksSection } from './components/home/HowItWorksSection';
 import { RiskInsightSection } from './components/home/RiskInsightSection';
@@ -49,6 +50,14 @@ const NAV_LINKS = [
 ] as const;
 
 const HOME_FAQ_PREVIEW = HOME_FAQ_ITEMS.slice(0, 4);
+
+function captureAnalyticsEventSafe(eventName: string, properties: Record<string, unknown>) {
+  try {
+    captureAnalyticsEvent(eventName, properties);
+  } catch {
+    // Analytics failures must never interrupt user flows.
+  }
+}
 
 const DIFFERENTIATION_ROWS = [
   {
@@ -502,6 +511,11 @@ function LeadCaptureForm({
         challenge: challenge || undefined,
         source: title,
         page_path: window.location.pathname
+      });
+      captureAnalyticsEventSafe('lead_capture_submitted', {
+        source: title,
+        page_path: window.location.pathname,
+        environment
       });
       setSubmitted(true);
       form.reset();
@@ -1252,6 +1266,12 @@ function ReadOnlyScanPage() {
         scan_goal: `${environment} trust-path risk reduction`,
         source: 'Read-Only Scan Intake',
         page_path: '/read-only-scan'
+      });
+      captureAnalyticsEventSafe('read_only_scan_intake_submitted', {
+        environment,
+        deployment,
+        urgency,
+        team_size: teamSize
       });
       setSubmitted(true);
     } catch (submissionError) {

--- a/web/src/analytics/events.test.ts
+++ b/web/src/analytics/events.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import { captureAnalyticsEvent } from './events';
+
+describe('captureAnalyticsEvent', () => {
+  it('forwards events to gtag and posthog when available', () => {
+    const gtag = vi.fn();
+    const capture = vi.fn();
+
+    (window as Window & { gtag?: typeof gtag }).gtag = gtag;
+    (window as Window & { posthog?: { capture: typeof capture } }).posthog = { capture };
+
+    captureAnalyticsEvent('cta_click', { placement: 'header' });
+
+    expect(gtag).toHaveBeenCalledWith('event', 'cta_click', { placement: 'header' });
+    expect(capture).toHaveBeenCalledWith('cta_click', { placement: 'header' });
+  });
+
+  it('still forwards to posthog when gtag throws', () => {
+    const gtag = vi.fn(() => {
+      throw new Error('blocked');
+    });
+    const capture = vi.fn();
+
+    (window as Window & { gtag?: typeof gtag }).gtag = gtag;
+    (window as Window & { posthog?: { capture: typeof capture } }).posthog = { capture };
+
+    expect(() => captureAnalyticsEvent('cta_click', { placement: 'header' })).not.toThrow();
+    expect(gtag).toHaveBeenCalledTimes(1);
+    expect(capture).toHaveBeenCalledWith('cta_click', { placement: 'header' });
+  });
+});

--- a/web/src/analytics/events.ts
+++ b/web/src/analytics/events.ts
@@ -1,0 +1,30 @@
+type EventProperties = Record<string, unknown>;
+
+export function captureAnalyticsEvent(eventName: string, properties: EventProperties = {}): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const globalWindow = window as Window & {
+    gtag?: (...args: unknown[]) => void;
+    posthog?: {
+      capture: (event: string, properties?: EventProperties) => void;
+    };
+  };
+
+  if (globalWindow.gtag) {
+    try {
+      globalWindow.gtag('event', eventName, properties);
+    } catch {
+      // Never block the caller due to analytics transport failures.
+    }
+  }
+
+  if (globalWindow.posthog) {
+    try {
+      globalWindow.posthog.capture(eventName, properties);
+    } catch {
+      // Never block the caller due to analytics transport failures.
+    }
+  }
+}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link, NavLink, useLocation } from 'react-router-dom';
+import { captureAnalyticsEvent } from '../../analytics/events';
 
 type NavLinkItem = {
   to: string;
@@ -65,10 +66,19 @@ export function Header({ navLinks }: { navLinks: readonly NavLinkItem[] }) {
         </nav>
 
         <div className="idt-header-actions">
-          <Link to="/read-only-scan" className="idt-btn idt-btn-primary" data-ab-slot="header_primary_cta">
+          <Link
+            to="/read-only-scan"
+            className="idt-btn idt-btn-primary"
+            data-ab-slot="header_primary_cta"
+            onClick={() => captureAnalyticsEvent('cta_header_read_only_scan_click', { placement: 'header' })}
+          >
             Start Read-Only Risk Scan
           </Link>
-          <Link to="/demo" className="idt-btn idt-btn-dark">
+          <Link
+            to="/demo"
+            className="idt-btn idt-btn-dark"
+            onClick={() => captureAnalyticsEvent('cta_header_technical_demo_click', { placement: 'header' })}
+          >
             Book Technical Demo
           </Link>
         </div>


### PR DESCRIPTION
## Summary
- add analytics event utility for consistent conversion instrumentation
- instrument header and lead/scan submission flows with explicit event names
- add analytics unit tests for dual-provider forwarding (gtag + posthog)
- add `quality:gate` script to enforce regression and bundle checks (`test:ci` + `perf:bundle`)

## Validation
- npm --prefix web run test -- --run
- npm --prefix web run perf:bundle

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a unified analytics event helper and instruments header CTAs and lead/read-only scan submissions to capture conversions. Introduces a `quality:gate` script to enforce tests and bundle checks before releases.

- **New Features**
  - Added `captureAnalyticsEvent` that forwards events to `gtag` and `posthog`.
  - Instrumented header CTAs and lead/read-only scan submission flows with explicit event names, capturing environment and form details.
  - Added unit tests for dual-provider forwarding, including fallback when `gtag` throws.
  - Added `quality:gate` script that runs `test:ci` and `perf:bundle`.

<sup>Written for commit 0b0ea97afa9987d2019ecc39098eb1bc399c99d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

