### PR TITLE
web: refine first impression and trust architecture

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -10,12 +10,12 @@ describe('App', () => {
     expect(
       screen.getByRole('heading', {
         level: 1,
-        name: 'See which machine identities can actually reach production.'
+        name: 'Identify risky machine trust paths before they become incidents.'
       })
     ).toBeInTheDocument();
 
-    expect(screen.getAllByRole('link', { name: 'Start Read-Only Risk Scan' }).length).toBeGreaterThan(0);
-    expect(screen.getAllByRole('link', { name: 'Book Technical Demo' }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('link', { name: 'Start Free Risk Scan' }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('link', { name: 'Book Demo' }).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Adoption Paths/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Reachable Risk Paths/i).length).toBeGreaterThan(0);
     expect(screen.getAllByRole('tab', { name: 'Graph' }).length).toBeGreaterThan(0);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Link, Navigate, Route, Routes, useLocation, useParams } 
 import { SafeLink } from './components/SafeLink';
 import { HeroProductReveal } from './components/home/HeroProductReveal';
 import { HowItWorksSection } from './components/home/HowItWorksSection';
+import { ProblemFramingSection } from './components/home/ProblemFramingSection';
 import { RiskInsightSection } from './components/home/RiskInsightSection';
 import { TrustProofStrip } from './components/home/TrustProofStrip';
 import { Footer } from './components/layout/Footer';
@@ -40,12 +41,10 @@ let bodyOverflowBeforeModal = '';
 const NAV_LINKS = [
   { to: '/product', label: 'Product' },
   { to: '/solutions', label: 'Solutions' },
-  { to: '/integrations', label: 'Integrations' },
-  { to: '/deployment-models', label: 'Deployment' },
+  { to: '/demo', label: 'Demo' },
   { to: '/docs', label: 'Docs' },
   { to: '/pricing', label: 'Pricing' },
-  { to: '/security', label: 'Security' },
-  { to: '/demo', label: 'Demo' }
+  { to: '/blog', label: 'Blog' }
 ] as const;
 
 const HOME_FAQ_PREVIEW = HOME_FAQ_ITEMS.slice(0, 4);
@@ -1119,18 +1118,24 @@ function HomePage() {
         <div className="idt-shell idt-hero-grid">
           <div className="idt-hero-copy">
             <p className="idt-eyebrow">Machine identity security</p>
-            <h1>See which machine identities can actually reach production.</h1>
+            <h1>Identify risky machine trust paths before they become incidents.</h1>
             <p className="idt-lead">
-              Identrail maps AWS IAM, Kubernetes, GitHub, and OIDC trust paths in read-only mode so teams can prioritize reachable blast radius and roll out safer access.
+              Trace how AWS IAM roles, Kubernetes service accounts, and GitHub/OIDC identities reach sensitive resources. Start read-only, inspect evidence, then roll out safer access with confidence.
             </p>
             <div className="idt-inline-actions" data-ab-slot="hero_primary_cta">
               <a href="#risk-scan-form" className="idt-btn idt-btn-primary">
-                Start Read-Only Risk Scan
+                Start Free Risk Scan
               </a>
               <Link to="/demo" className="idt-btn idt-btn-dark">
-                Book Technical Demo
+                Book Demo
               </Link>
             </div>
+            <ul className="idt-hero-trust-cues" aria-label="Evaluation trust cues">
+              <li>Open-core under Apache-2.0</li>
+              <li>Read-only onboarding model</li>
+              <li>Self-hosted and hosted paths</li>
+              <li>Public docs and release history</li>
+            </ul>
           </div>
           <HeroProductReveal />
         </div>
@@ -1138,13 +1143,15 @@ function HomePage() {
 
       <TrustProofStrip />
 
+      <ProblemFramingSection />
+
       <section className="idt-section idt-shell">
         <LeadCaptureForm
           id="risk-scan-form"
           variant="short"
           title="Start a read-only risk scan in under one minute"
-          caption="Share your work email and primary environment. Receive a prioritized machine identity risk report and remediation sequence."
-          ctaLabel="Start Read-Only Risk Scan"
+          caption="No production writes. You receive a prioritized trust-path report and a practical first-remediation sequence."
+          ctaLabel="Start Free Risk Scan"
         />
       </section>
 
@@ -1200,10 +1207,10 @@ function HomePage() {
         />
         <div className="idt-inline-actions">
           <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-            Start Read-Only Risk Scan
+            Start Free Risk Scan
           </Link>
           <Link to="/demo" className="idt-btn idt-btn-dark">
-            Book Technical Demo
+            Book Demo
           </Link>
         </div>
       </section>
@@ -2674,7 +2681,7 @@ export function RoutedSite() {
         Skip to content
       </a>
 
-      <Header navLinks={NAV_LINKS} />
+      <Header navLinks={NAV_LINKS} githubRepo={GITHUB_REPO} />
 
       <main id="main-content">
         <Routes>

--- a/web/src/components/home/HeroProductReveal.tsx
+++ b/web/src/components/home/HeroProductReveal.tsx
@@ -2,10 +2,11 @@ import { Link } from 'react-router-dom';
 
 const PATH_SUMMARY = 'GitHub Actions OIDC → AWS Role → K8s Service Account → RDS Billing Resource';
 
-const PROOF_ITEMS = [
-  { label: 'Blast radius', value: '11 production resources reachable' },
-  { label: 'Exposure type', value: 'Federated identity chain with broad role trust' },
-  { label: 'Safe first action', value: 'Constrain role trust subject claims, then simulate rollout' }
+const PATH_STEPS = [
+  'Source: GitHub Actions workflow identity',
+  'Broker: OIDC trust relationship',
+  'Privilege boundary: AWS IAM role assumption',
+  'Target: production billing datastore'
 ] as const;
 
 export function HeroProductReveal() {
@@ -23,23 +24,21 @@ export function HeroProductReveal() {
       <span className="idt-pulse idt-pulse-b" />
 
       <aside className="idt-hero-graph-caption idt-hero-proof-card">
-        <p className="idt-hero-graph-title">Selected risk path</p>
+        <p className="idt-hero-graph-title">Sample finding</p>
+        <h3>High-risk production trust path</h3>
         <p className="idt-hero-path">{PATH_SUMMARY}</p>
         <div className="idt-hero-proof-meta">
-          <span className="idt-severity-pill">High</span>
+          <span className="idt-severity-pill">High severity</span>
           <span>4-hop chain</span>
           <span>Read-only analysis</span>
         </div>
-        <dl className="idt-hero-proof-list">
-          {PROOF_ITEMS.map((item) => (
-            <div key={item.label}>
-              <dt>{item.label}</dt>
-              <dd>{item.value}</dd>
-            </div>
+        <ol className="idt-hero-path-steps">
+          {PATH_STEPS.map((step) => (
+            <li key={step}>{step}</li>
           ))}
-        </dl>
+        </ol>
         <Link to="/demo" className="idt-inline-link">
-          Open technical demo
+          Inspect this path in demo
         </Link>
       </aside>
     </div>

--- a/web/src/components/home/ProblemFramingSection.tsx
+++ b/web/src/components/home/ProblemFramingSection.tsx
@@ -1,0 +1,31 @@
+export function ProblemFramingSection() {
+  return (
+    <section className="idt-section idt-shell idt-problem-frame" aria-labelledby="problem-frame-title">
+      <div className="idt-problem-frame-grid">
+        <div>
+          <p className="idt-eyebrow">Why teams miss machine identity risk</p>
+          <h2 id="problem-frame-title">Trust data is fragmented across cloud, cluster, and CI systems.</h2>
+          <p>
+            IAM policies, Kubernetes RBAC, and OIDC workflow identities are usually reviewed in separate tools. Attack paths are not.
+            That gap is where overprivileged machine access survives into production.
+          </p>
+        </div>
+
+        <div className="idt-problem-signals" role="list" aria-label="Fragmentation signals">
+          <article role="listitem">
+            <h3>AWS IAM in one console</h3>
+            <p>Role assumptions and cross-account trust are reviewed without Kubernetes or CI context.</p>
+          </article>
+          <article role="listitem">
+            <h3>Kubernetes RBAC in another</h3>
+            <p>Service account privilege drift is visible, but downstream cloud reachability remains opaque.</p>
+          </article>
+          <article role="listitem">
+            <h3>CI/OIDC evidence in logs</h3>
+            <p>Workflow identity misuse is discovered late because chain-level visibility is missing during review.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/home/TrustProofStrip.tsx
+++ b/web/src/components/home/TrustProofStrip.tsx
@@ -2,25 +2,27 @@ import { Link } from 'react-router-dom';
 import { SafeLink } from '../SafeLink';
 import { TRUST_PROOF_LINKS } from '../../content/proofArtifacts';
 
+const TRUST_SUMMARY_ITEMS = TRUST_PROOF_LINKS.slice(0, 4);
+
 export function TrustProofStrip() {
   return (
     <section className="idt-trust-strip" aria-label="Credibility and proof">
-      <div className="idt-shell">
-        <p>Validate the product before you commit: inspect architecture, outputs, and security process.</p>
-        <div className="idt-logo-row idt-proof-row">
-          {TRUST_PROOF_LINKS.map((entry) => (
-            <article key={entry.label} className="idt-proof-item">
+      <div className="idt-shell idt-proof-architecture">
+        <p className="idt-proof-heading">Built in the open with verifiable trust controls.</p>
+        <div className="idt-proof-architecture-list">
+          {TRUST_SUMMARY_ITEMS.map((entry) => (
+            <article key={entry.label} className="idt-proof-architecture-item">
+              <p className="idt-proof-item-title">{entry.label}</p>
+              <p>{entry.description}</p>
               {entry.external ? (
                 <SafeLink href={entry.href} className="idt-proof-link">
-                  {entry.label}
+                  Review
                 </SafeLink>
               ) : (
                 <Link to={entry.href} className="idt-proof-link">
-                  {entry.label}
+                  Review
                 </Link>
               )}
-              <p>{entry.description}</p>
-              <small>{entry.freshness}</small>
             </article>
           ))}
         </div>

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,12 +1,19 @@
 import { useEffect, useState } from 'react';
 import { Link, NavLink, useLocation } from 'react-router-dom';
+import { SafeLink } from '../SafeLink';
 
 type NavLinkItem = {
   to: string;
   label: string;
 };
 
-export function Header({ navLinks }: { navLinks: readonly NavLinkItem[] }) {
+export function Header({
+  navLinks,
+  githubRepo
+}: {
+  navLinks: readonly NavLinkItem[];
+  githubRepo: string;
+}) {
   const [menuOpen, setMenuOpen] = useState(false);
   const location = useLocation();
 
@@ -66,11 +73,14 @@ export function Header({ navLinks }: { navLinks: readonly NavLinkItem[] }) {
 
         <div className="idt-header-actions">
           <Link to="/read-only-scan" className="idt-btn idt-btn-primary" data-ab-slot="header_primary_cta">
-            Start Read-Only Risk Scan
+            Start Free Risk Scan
           </Link>
           <Link to="/demo" className="idt-btn idt-btn-dark">
-            Book Technical Demo
+            Book Demo
           </Link>
+          <SafeLink href={githubRepo} className="idt-header-utility">
+            GitHub
+          </SafeLink>
         </div>
       </div>
     </header>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2251,6 +2251,251 @@ h2 {
   gap: 0.54rem;
 }
 
+/* PR-A: restrained premium foundation */
+body {
+  background:
+    radial-gradient(circle at 18% -8%, rgba(116, 140, 188, 0.13), transparent 34%),
+    radial-gradient(circle at 82% 0%, rgba(86, 111, 161, 0.11), transparent 31%),
+    var(--idt-bg);
+}
+
+.idt-header {
+  border-bottom: 1px solid rgba(158, 176, 210, 0.2);
+  background: rgba(8, 12, 18, 0.9);
+}
+
+.idt-header-row {
+  min-height: 76px;
+  grid-template-columns: auto 1fr auto;
+  gap: 1.6rem;
+}
+
+.idt-nav {
+  justify-content: center;
+  gap: 1rem;
+}
+
+.idt-nav a {
+  font-size: 0.9rem;
+  padding: 0.3rem 0;
+  color: #a8b7cf;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.idt-nav a:hover,
+.idt-nav a:focus-visible,
+.idt-nav a.is-active {
+  color: #e9eef9;
+  border-color: transparent;
+  background: transparent;
+  text-decoration: underline;
+  text-decoration-color: rgba(189, 205, 233, 0.72);
+  text-underline-offset: 0.28rem;
+}
+
+.idt-header-actions {
+  gap: 0.7rem;
+}
+
+.idt-header-actions .idt-btn {
+  min-height: 40px;
+  padding: 0.5rem 0.95rem;
+  font-size: 0.86rem;
+}
+
+.idt-header-actions .idt-btn-primary {
+  background: #d7e0f0;
+  border-color: rgba(255, 255, 255, 0.92);
+  color: #08101a;
+  box-shadow: none;
+}
+
+.idt-header-actions .idt-btn-dark {
+  background: rgba(17, 24, 38, 0.86);
+  border-color: rgba(168, 183, 207, 0.28);
+}
+
+.idt-header-utility {
+  color: #9fb0cd;
+  text-decoration: none;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.idt-header-utility:hover,
+.idt-header-utility:focus-visible {
+  color: #e7edf8;
+  text-decoration: underline;
+  text-underline-offset: 0.24rem;
+}
+
+.idt-hero {
+  padding: clamp(4.8rem, 11vw, 7.4rem) 0 clamp(3.5rem, 8vw, 5.2rem);
+}
+
+.idt-hero-grid {
+  align-items: start;
+  gap: clamp(2rem, 5vw, 3.4rem);
+}
+
+.idt-hero-grid > div:first-child,
+.idt-hero-copy {
+  border: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.idt-hero-copy h1 {
+  max-width: 14ch;
+}
+
+.idt-lead {
+  max-width: 58ch;
+  color: #c8d5eb;
+}
+
+.idt-hero-trust-cues {
+  margin: 1.05rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.idt-hero-trust-cues li {
+  border: 1px solid rgba(161, 179, 212, 0.26);
+  border-radius: 999px;
+  background: rgba(10, 16, 26, 0.58);
+  color: #b9c8de;
+  font-size: 0.78rem;
+  padding: 0.26rem 0.64rem;
+}
+
+.idt-graph-visual {
+  border: 1px solid rgba(154, 176, 214, 0.26);
+  background: linear-gradient(160deg, rgba(10, 14, 22, 0.96) 0%, rgba(8, 12, 18, 0.98) 100%);
+}
+
+.idt-hero-graph-caption {
+  border: 1px solid rgba(148, 170, 206, 0.3);
+  background: linear-gradient(165deg, rgba(9, 13, 20, 0.94), rgba(12, 18, 28, 0.95));
+  box-shadow: 0 14px 34px rgba(2, 8, 18, 0.58);
+}
+
+.idt-hero-graph-caption h3 {
+  margin: 0 0 0.52rem;
+  font-size: 1rem;
+}
+
+.idt-hero-path-steps {
+  margin: 0 0 0.8rem;
+  padding-left: 1.05rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.idt-hero-path-steps li {
+  color: #d6e2f4;
+  font-size: 0.76rem;
+}
+
+.idt-trust-strip {
+  background: rgba(9, 13, 20, 0.66);
+  border-top: 1px solid rgba(154, 174, 208, 0.18);
+  border-bottom: 1px solid rgba(154, 174, 208, 0.18);
+}
+
+.idt-proof-architecture {
+  padding: 1.35rem 0;
+}
+
+.idt-proof-heading {
+  margin: 0 0 0.85rem;
+  color: #e9eef8;
+  font-size: 0.94rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.idt-proof-architecture-list {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.idt-proof-architecture-item {
+  border-left: 1px solid rgba(150, 170, 205, 0.28);
+  padding-left: 0.75rem;
+  display: grid;
+  gap: 0.42rem;
+}
+
+.idt-proof-item-title {
+  margin: 0;
+  color: #f0f4fb;
+  font-size: 0.84rem;
+  font-weight: 600;
+}
+
+.idt-proof-architecture-item p {
+  margin: 0;
+  color: #aebed6;
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+.idt-proof-link {
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: #dce7f9;
+  font-size: 0.78rem;
+  text-decoration: underline;
+  text-underline-offset: 0.22rem;
+}
+
+.idt-problem-frame {
+  padding-top: clamp(2.2rem, 5vw, 3rem);
+}
+
+.idt-problem-frame-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+  gap: 1.4rem;
+  align-items: start;
+}
+
+.idt-problem-frame p {
+  color: #c5d3e9;
+  margin: 0;
+}
+
+.idt-problem-signals {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.idt-problem-signals article {
+  border: 1px solid rgba(153, 172, 205, 0.2);
+  border-radius: 12px;
+  background: rgba(10, 15, 24, 0.56);
+  padding: 0.86rem 0.9rem;
+}
+
+.idt-problem-signals h3 {
+  margin: 0 0 0.32rem;
+  font-size: 0.96rem;
+}
+
+.idt-problem-signals p {
+  color: #adbdd4;
+  font-size: 0.86rem;
+}
+
 @media (max-width: 1080px) {
   .idt-header-row {
     grid-template-columns: auto auto;
@@ -2293,6 +2538,8 @@ h2 {
   .idt-pricing-grid,
   .idt-roi-grid,
   .idt-risk-insight-grid,
+  .idt-proof-architecture-list,
+  .idt-problem-frame-grid,
   .idt-finding-proof-grid,
   .idt-adoption-grid,
   .idt-intake-grid,
@@ -2341,6 +2588,10 @@ h2 {
   .idt-hero-copy {
     padding: 1.2rem;
   }
+
+  .idt-header-utility {
+    padding-block: 0.4rem;
+  }
 }
 
 @media (max-width: 720px) {
@@ -2359,11 +2610,22 @@ h2 {
     grid-template-columns: 1fr;
   }
 
+  .idt-header-utility {
+    width: 100%;
+    text-align: center;
+    padding-bottom: 0.5rem;
+  }
+
   .idt-header {
     position: static;
   }
 
   .idt-logo-row {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .idt-hero-trust-cues {
     display: grid;
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
## Summary
- simplify header hierarchy with one dominant CTA and GitHub as tertiary utility
- redesign hero copy/layout for clearer first-scan understanding
- improve trust strip from badge clutter to editorial proof architecture
- add a new problem-framing section before lead capture
- tighten first-screen messaging to improve clarity and credibility

## Testing
- npm run build
- npm test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refines the homepage to improve first-scan clarity and credibility: a simpler header with a GitHub utility link, a clearer hero with trust cues and a sample finding, an editorial trust strip, and a new problem-framing section. Adopts the restrained PR‑A visual foundation and standardizes CTAs to “Start Free Risk Scan” and “Book Demo”; navigation now adds Demo and Blog and removes Integrations, Deployment, and Security.

- **New Features**
  - Added `ProblemFramingSection` before lead capture.
  - Hero: new headline, trust cues, sample finding with path steps, and updated demo link text.
  - Trust strip: switched to an editorial “proof architecture” summarizing top artifacts.
  - Header: added GitHub repository utility link.

- **Refactors**
  - Renamed CTAs to “Start Free Risk Scan” and “Book Demo”; updated copy and tests.
  - Lead capture caption clarified to emphasize read-only, no-writes onboarding.
  - Introduced PR‑A styles across header, hero, trust strip, and problem frame.
  - Navigation streamlined: added Demo and Blog; removed Integrations, Deployment, Security.

<sup>Written for commit 2908ba5c58b44a12e46be5f4710482db9fdb48ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

