### PR TITLE
web: strengthen product proof and trust-path workflow

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -51,24 +51,24 @@ const HOME_FAQ_PREVIEW = HOME_FAQ_ITEMS.slice(0, 4);
 
 const DIFFERENTIATION_ROWS = [
   {
-    area: 'Read-only collection boundaries',
-    verify: 'Connector permission scope, data collected, and storage boundaries',
-    impact: 'Prevents overreach and clarifies deployment risk assumptions before onboarding'
-  },
-  {
     area: 'Trust-path explainability',
-    verify: 'Can each finding show source identity, chain edges, and affected resources?',
-    impact: 'Allows platform teams to act on evidence instead of opaque risk scores'
+    identrail: 'Shows full identity chain with policy evidence and affected resources',
+    closed: 'Often returns abstract risk findings without chain-level context'
   },
   {
-    area: 'Rollout safety workflow',
-    verify: 'Policy simulation, staged rollout controls, and rollback support',
-    impact: 'Reduces authorization outage risk during least-privilege enforcement'
+    area: 'Rollout safety',
+    identrail: 'Read-only collection, simulation-first remediation, staged enforcement',
+    closed: 'Policy hardening usually relies on external tooling and manual checks'
   },
   {
-    area: 'Integration depth',
-    verify: 'Coverage for AWS IAM, Kubernetes, GitHub, and OIDC trust relationships',
-    impact: 'Avoids fragmented visibility and missed transitive trust exposure'
+    area: 'Open-core transparency',
+    identrail: 'Public repository, documentation, and release history',
+    closed: 'Limited implementation visibility and slower verification by engineers'
+  },
+  {
+    area: 'Developer and platform fit',
+    identrail: 'Built for security + platform collaboration with inspectable outputs',
+    closed: 'Security-only workflows can be harder for platform teams to operationalize'
   }
 ] as const;
 
@@ -756,26 +756,31 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
   const nodes = [
     {
       id: 'oidc',
+      type: 'Broker',
       title: 'OIDC Provider',
       detail: 'Federated identity provider trusted by CI/CD and cluster workloads.'
     },
     {
       id: 'role',
+      type: 'Privilege',
       title: 'AWS Role: payments-prod',
       detail: 'Role assumed by automation workloads with cross-account permissions.'
     },
     {
       id: 'sa',
+      type: 'Workload',
       title: 'K8s ServiceAccount: api-gateway',
       detail: 'Service account with namespace-level and cloud trust-path reachability.'
     },
     {
       id: 'repo',
+      type: 'Source',
       title: 'Git Repo: infra-live',
       detail: 'Repository contains deployment workflows and secrets exposure history.'
     },
     {
       id: 'db',
+      type: 'Resource',
       title: 'RDS Resource: billing-ledger',
       detail: 'Sensitive resource reachable through chained assumptions in current policy state.'
     }
@@ -833,9 +838,10 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
             <button
               key={node.id}
               type="button"
-              className={`idt-demo-node ${selected.id === node.id ? 'is-active' : ''}`}
+              className={`idt-demo-node idt-demo-node-${node.type.toLowerCase()} ${selected.id === node.id ? 'is-active' : ''}`}
               onClick={() => setSelectedId(node.id)}
             >
+              <small>{node.type}</small>
               <span>{node.title}</span>
             </button>
           ))}
@@ -849,6 +855,7 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
           {nodes.map((node) => (
             <button key={node.id} type="button" className={`idt-demo-list-row ${selected.id === node.id ? 'is-active' : ''}`} onClick={() => setSelectedId(node.id)}>
               <span>{node.title}</span>
+              <strong>{node.type}</strong>
               <small>{node.detail}</small>
             </button>
           ))}
@@ -856,12 +863,13 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
       )}
 
       <aside className="idt-demo-sidebar" aria-live="polite">
+        <p className="idt-finding-label">{selected.type}</p>
         <h3>{selected.title}</h3>
         <p>{selected.detail}</p>
         <ul>
           <li>Risk score impact: {scenario.severity}</li>
-          <li>Reachable resources: 18</li>
-          <li>Recommended control: Staged trust policy tightening</li>
+          <li>Reachable resources: 18 sensitive nodes</li>
+          <li>Policy confidence: 96% edge evidence coverage</li>
         </ul>
         {variant === 'full' ? (
           <article className="idt-demo-evidence">
@@ -879,10 +887,10 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
         ) : null}
         <div className="idt-inline-actions">
           <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-            Start Read-Only Risk Scan
+            Start Free Risk Scan
           </Link>
           <Link to="/demo" className="idt-btn idt-btn-dark">
-            Book Technical Demo
+            Book Demo
           </Link>
         </div>
       </aside>
@@ -1014,28 +1022,67 @@ function DeploymentPathBanner() {
     <section className="idt-section idt-shell idt-deployment-bridge" aria-label="Adoption paths">
       <div className="idt-deployment-panel">
         <p className="idt-eyebrow">Adoption Paths</p>
-        <h2>Choose the rollout model that matches your security and platform maturity.</h2>
+        <h2>Choose the deployment model that fits your operating constraints.</h2>
         <div className="idt-adoption-grid">
           <article className="idt-adoption-card">
             <h3>Open Source</h3>
-            <p className="idt-muted-strong">Best for self-hosted evaluation and internal platform control.</p>
-            <p>Run the open-core platform in your environment and validate trust-path findings before wider rollout.</p>
+            <p className="idt-muted-strong">Best for: self-hosted evaluation and internal control.</p>
+            <dl>
+              <div>
+                <dt>Time to value</dt>
+                <dd>Same day with Docker/Kubernetes setup</dd>
+              </div>
+              <div>
+                <dt>Control level</dt>
+                <dd>Full infrastructure and data ownership</dd>
+              </div>
+              <div>
+                <dt>Support model</dt>
+                <dd>Community and docs-led</dd>
+              </div>
+            </dl>
             <SafeLink href={GITHUB_REPO} className="idt-btn idt-btn-ghost">
               View Open Source
             </SafeLink>
           </article>
           <article className="idt-adoption-card is-featured">
             <h3>Hosted SaaS</h3>
-            <p className="idt-muted-strong">Best for fast scanning and time-to-value.</p>
-            <p>Start quickly with managed infrastructure while your team focuses on machine identity risk reduction.</p>
+            <p className="idt-muted-strong">Best for: fastest onboarding and operational simplicity.</p>
+            <dl>
+              <div>
+                <dt>Time to value</dt>
+                <dd>Minutes to first trust-path scan</dd>
+              </div>
+              <div>
+                <dt>Control level</dt>
+                <dd>Managed platform with guided rollout</dd>
+              </div>
+              <div>
+                <dt>Support model</dt>
+                <dd>Product support and assisted onboarding</dd>
+              </div>
+            </dl>
             <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
               Start Free Risk Scan
             </Link>
           </article>
           <article className="idt-adoption-card">
             <h3>Enterprise</h3>
-            <p className="idt-muted-strong">Best for private deployment, procurement, and advanced controls.</p>
-            <p>Deploy with enterprise governance requirements, support expectations, and security program alignment.</p>
+            <p className="idt-muted-strong">Best for: private tenancy, procurement, and compliance control.</p>
+            <dl>
+              <div>
+                <dt>Time to value</dt>
+                <dd>Planned onboarding with architecture review</dd>
+              </div>
+              <div>
+                <dt>Control level</dt>
+                <dd>Private deployment and regional controls</dd>
+              </div>
+              <div>
+                <dt>Support model</dt>
+                <dd>Enterprise SLA and named partner team</dd>
+              </div>
+            </dl>
             <Link to="/enterprise" className="idt-btn idt-btn-dark">
               Book Demo
             </Link>
@@ -1159,8 +1206,11 @@ function HomePage() {
 
       <section className="idt-section idt-shell">
         <div className="idt-card idt-proof-demo-card">
-          <h3>Interactive trust-path preview</h3>
-          <p>Inspect a sample trust path from source identity to sensitive resource before connecting your environment.</p>
+          <h3>Interactive trust graph explorer</h3>
+          <p>
+            Explore source identity, broker, workload, privilege, and target resource states. Select a node to inspect risk evidence
+            and first remediation actions.
+          </p>
           <TrustGraphDemo />
         </div>
       </section>
@@ -1171,25 +1221,25 @@ function HomePage() {
 
       <section className="idt-section idt-shell">
         <SectionTitle
-          eyebrow="Evaluation Criteria"
-          title="Evaluate machine identity platforms on operational evidence"
-          body="Use this checklist to compare implementation reality, not marketing claims."
+          eyebrow="Comparison"
+          title="Why teams choose Identrail over closed black-box workflows"
+          body="Compare on explainability, rollout safety, and day-two operability."
         />
         <div className="idt-table-wrap">
           <table className="idt-compare-table">
             <thead>
               <tr>
-                <th scope="col">Criterion</th>
-                <th scope="col">What to verify</th>
-                <th scope="col">Why it matters</th>
+                <th scope="col">Category</th>
+                <th scope="col">Identrail</th>
+                <th scope="col">Typical closed alternatives</th>
               </tr>
             </thead>
             <tbody>
               {DIFFERENTIATION_ROWS.map((row) => (
                 <tr key={row.area}>
                   <th scope="row">{row.area}</th>
-                  <td>{row.verify}</td>
-                  <td>{row.impact}</td>
+                  <td>{row.identrail}</td>
+                  <td>{row.closed}</td>
                 </tr>
               ))}
             </tbody>

--- a/web/src/components/home/HowItWorksSection.tsx
+++ b/web/src/components/home/HowItWorksSection.tsx
@@ -26,11 +26,11 @@ export function HowItWorksSection() {
     <section className="idt-section idt-shell" aria-labelledby="workflow-title">
       <div className="idt-section-title">
         <p className="idt-eyebrow">Operational Workflow</p>
-        <h2 id="workflow-title">Discover, prioritize, simulate, and roll out in four steps</h2>
-        <p>Each stage produces a concrete artifact your security and platform teams can review together.</p>
+        <h2 id="workflow-title">From read-only discovery to safe enforcement</h2>
+        <p>Each stage produces a concrete artifact security and platform teams can review before taking action.</p>
       </div>
 
-      <ol className="idt-steps idt-workflow-steps">
+      <ol className="idt-steps idt-workflow-track">
         {WORKFLOW_STEPS.map((step) => (
           <li key={step.title}>
             <h3>{step.title}</h3>

--- a/web/src/components/home/RiskInsightSection.tsx
+++ b/web/src/components/home/RiskInsightSection.tsx
@@ -9,6 +9,7 @@ const SCENARIOS = [
     path: 'GitHub Actions OIDC → AWS Role → K8s SA → RDS billing-ledger',
     impact: 'Compromised CI workflow token can reach production billing data in one chain.',
     signal: '11 reachable resources',
+    blastRadius: 'Cross-account read and write permissions on billing systems',
     firstAction: 'Tighten trust policy subject claims and reduce role action scope.'
   },
   {
@@ -18,6 +19,7 @@ const SCENARIOS = [
     path: 'K8s ServiceAccount → ClusterRoleBinding → IAM role assumption → Artifact bucket',
     impact: 'Overprivileged service account can pivot across namespace boundary into cloud resources.',
     signal: '7 cross-namespace privilege links',
+    blastRadius: 'Build artifact tampering and namespace privilege escalation',
     firstAction: 'Split SA identity by workload and enforce namespace-scoped RBAC.'
   },
   {
@@ -27,6 +29,7 @@ const SCENARIOS = [
     path: 'Repo secret leak → Bot identity replay → AssumeRole → Container registry push',
     impact: 'Leaked token can ship unauthorized container images into production path.',
     signal: '4 privileged registry actions exposed',
+    blastRadius: 'Unauthorized image promotion through production CI path',
     firstAction: 'Rotate credentials and enforce short-lived workload identity tokens.'
   }
 ] as const;
@@ -42,11 +45,11 @@ export function RiskInsightSection() {
   return (
     <section className="idt-section idt-shell" aria-labelledby="risk-insight-title">
       <div className="idt-section-title">
-        <p className="idt-eyebrow">Reachable Risk Paths</p>
-        <h2 id="risk-insight-title">Prioritize machine identity findings by real impact</h2>
+        <p className="idt-eyebrow">Product proof</p>
+        <h2 id="risk-insight-title">See evidence for a high-risk trust path, not just a score</h2>
         <p>
-          Each finding includes path evidence, severity, and a safe first remediation action. Start with what can actually reach
-          production.
+          Identrail explains how a machine identity reaches production resources, why it matters, and what to change first without
+          breaking workloads.
         </p>
       </div>
 
@@ -67,7 +70,8 @@ export function RiskInsightSection() {
                 onClick={() => setActiveScenarioId(scenario.id)}
               >
                 <span>{scenario.name}</span>
-                <small>{scenario.severity}</small>
+                <small>{scenario.severity} severity</small>
+                <p>{scenario.signal}</p>
               </button>
             );
           })}
@@ -81,22 +85,30 @@ export function RiskInsightSection() {
           aria-live="polite"
         >
           <p className="idt-finding-label">Selected path</p>
-          <h3>{activeScenario.path}</h3>
+          <h3>Risk: {activeScenario.name}</h3>
+          <ol className="idt-risk-path-list" aria-label="Trust path sequence">
+            {activeScenario.path.split(' → ').map((step) => (
+              <li key={step}>{step}</li>
+            ))}
+          </ol>
           <p>
             <strong>Impact:</strong> {activeScenario.impact}
+          </p>
+          <p>
+            <strong>Blast radius:</strong> {activeScenario.blastRadius}
           </p>
           <p>
             <strong>Evidence signal:</strong> {activeScenario.signal}
           </p>
           <p>
-            <strong>Safe first action:</strong> {activeScenario.firstAction}
+            <strong>Recommended first fix:</strong> {activeScenario.firstAction}
           </p>
           <div className="idt-inline-actions">
             <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-              Start Read-Only Risk Scan
+              Start Free Risk Scan
             </Link>
             <Link to="/demo" className="idt-btn idt-btn-dark">
-              Open technical demo
+              Book Demo
             </Link>
           </div>
         </article>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2496,6 +2496,151 @@ body {
   font-size: 0.86rem;
 }
 
+/* PR-B: product proof and workflow clarity */
+.idt-risk-scenario-item {
+  align-content: start;
+  gap: 0.25rem;
+}
+
+.idt-risk-scenario-item span {
+  font-weight: 700;
+}
+
+.idt-risk-scenario-item p {
+  margin: 0;
+  color: #9eb0ca;
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.idt-risk-path-list {
+  margin: 0.45rem 0 0.7rem;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.42rem;
+}
+
+.idt-risk-path-list li {
+  border: 1px solid rgba(161, 182, 219, 0.28);
+  border-radius: 999px;
+  background: rgba(12, 18, 29, 0.6);
+  padding: 0.22rem 0.54rem;
+  font-size: 0.76rem;
+  color: #d8e3f6;
+}
+
+.idt-demo-list-row {
+  gap: 0.2rem;
+}
+
+.idt-demo-list-row strong {
+  color: #d8e6ff;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.idt-demo-node {
+  border-radius: 11px;
+  padding: 0.4rem 0.62rem;
+  display: grid;
+  text-align: left;
+  gap: 0.1rem;
+}
+
+.idt-demo-node small {
+  color: #9eb2d3;
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+}
+
+.idt-demo-node-source {
+  border-color: rgba(143, 191, 255, 0.4);
+}
+
+.idt-demo-node-broker {
+  border-color: rgba(155, 174, 255, 0.42);
+}
+
+.idt-demo-node-workload {
+  border-color: rgba(154, 214, 201, 0.42);
+}
+
+.idt-demo-node-privilege {
+  border-color: rgba(255, 175, 143, 0.42);
+}
+
+.idt-demo-node-resource {
+  border-color: rgba(243, 143, 143, 0.45);
+}
+
+.idt-workflow-track {
+  position: relative;
+  gap: 1rem;
+}
+
+.idt-workflow-track::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: calc(50% - 1px);
+  border-top: 1px solid rgba(161, 181, 216, 0.22);
+  pointer-events: none;
+}
+
+.idt-workflow-track li {
+  position: relative;
+  z-index: 1;
+}
+
+.idt-workflow-output {
+  border-style: solid;
+  border-color: rgba(161, 181, 216, 0.28);
+  background: rgba(12, 17, 26, 0.58);
+}
+
+.idt-adoption-card {
+  gap: 0.72rem;
+}
+
+.idt-adoption-card dl {
+  margin: 0;
+  display: grid;
+  gap: 0.42rem;
+}
+
+.idt-adoption-card dl div {
+  display: grid;
+  gap: 0.08rem;
+}
+
+.idt-adoption-card dt {
+  color: #aebed7;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.idt-adoption-card dd {
+  margin: 0;
+  color: #d9e3f3;
+  font-size: 0.84rem;
+}
+
+.idt-table-wrap {
+  background: rgba(10, 14, 22, 0.64);
+}
+
+.idt-compare-table tbody th {
+  position: sticky;
+  left: 0;
+  background: rgba(12, 18, 28, 0.95);
+  z-index: 1;
+}
+
 @media (max-width: 1080px) {
   .idt-header-row {
     grid-template-columns: auto auto;
@@ -2551,6 +2696,10 @@ body {
 
   .idt-kpi-row {
     grid-template-columns: 1fr;
+  }
+
+  .idt-workflow-track::before {
+    display: none;
   }
 
   .idt-steps {


### PR DESCRIPTION
## Summary
- upgrade risk proof into clearer evidence-first path storytelling
- improve trust graph semantics with node-type distinctions and stronger selected states
- redesign workflow section to better communicate step outputs
- refine adoption-path cards with operational comparison dimensions
- tighten comparison table language around open-core vs closed workflows

## Testing
- npm run build
- npm test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens product proof and the trust‑path workflow so teams can see concrete evidence and safe next steps. Elevates the home experience with typed nodes, clearer risk paths, and a sharper adoption/comparison story.

- **New Features**
  - Trust graph: Displays node types (Source, Broker, Workload, Privilege, Resource) in buttons and list; sidebar shows selected type and policy confidence; CTAs updated to “Start Free Risk Scan” / “Book Demo”; card retitled “Interactive trust graph explorer”.
  - Risk insights: Evidence‑first copy; path rendered as step chips; shows severity, signal, and blast radius; scenario list surfaces severity + signal; tightened action label; CTAs updated.
  - Workflow: Retitled to “From read‑only discovery to safe enforcement” and uses `.idt-workflow-track` for a simple timeline with clearer stage outputs.
  - Adoption paths: Cards add “Best for” plus Time to value, Control level, and Support model for Open Source, Hosted SaaS, and Enterprise.
  - Comparison table: Reframed to “Why teams choose Identrail over closed black‑box workflows” with columns “Category / Identrail / Typical closed alternatives”.
  - Styles: New classes for node‑type styling (`.idt-demo-node-*`), risk path chips (`.idt-risk-path-list`), workflow track, sticky compare row headers, and adoption card lists.

<sup>Written for commit bcf9fd303fe7a28210eedba26cad4ecd5a551310. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

