### PR TITLE
web: polish conversion flow and bottom-section trust

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -516,6 +516,7 @@ function LeadCaptureForm({
     <section id={id} className={`idt-lead-form ${compact ? 'is-compact' : ''}`} aria-label={title}>
       <h3>{title}</h3>
       <p>{caption}</p>
+      <p className="idt-form-trust-note">Read-only onboarding. No production writes during evaluation.</p>
 
       {!submitted ? (
         <form onSubmit={handleSubmit} className={`idt-form-grid ${variant === 'short' ? 'is-short' : ''}`}>
@@ -947,6 +948,31 @@ function RoiNumberField({ id, label, value, min, step, onChange }: RoiNumberFiel
 }
 
 function RoiCalculator() {
+  const profiles = [
+    {
+      id: 'startup',
+      label: 'Startup cloud-native',
+      identities: 900,
+      incidentCost: 95000,
+      hoursPerWeek: 16
+    },
+    {
+      id: 'midmarket',
+      label: 'Mid-market platform team',
+      identities: 3200,
+      incidentCost: 195000,
+      hoursPerWeek: 44
+    },
+    {
+      id: 'enterprise',
+      label: 'Enterprise multi-account AWS',
+      identities: 9800,
+      incidentCost: 420000,
+      hoursPerWeek: 88
+    }
+  ] as const;
+
+  const [activeProfileId, setActiveProfileId] = useState<(typeof profiles)[number]['id']>('midmarket');
   const [identities, setIdentities] = useState(3200);
   const [incidentCost, setIncidentCost] = useState(195000);
   const [hoursPerWeek, setHoursPerWeek] = useState(44);
@@ -969,9 +995,28 @@ function RoiCalculator() {
     <section className="idt-roi" aria-label="ROI calculator">
       <SectionTitle
         eyebrow="ROI Calculator"
-        title="See your potential risk and cost reduction"
-        body="Estimate impact from reduced machine identity incidents and faster remediation workflows."
+        title="Model impact with conservative assumptions"
+        body="Use a planning model to estimate labor savings and reduced incident exposure from better trust-path visibility."
       />
+      <div className="idt-roi-profiles" role="tablist" aria-label="ROI profiles">
+        {profiles.map((profile) => (
+          <button
+            key={profile.id}
+            type="button"
+            role="tab"
+            aria-selected={activeProfileId === profile.id}
+            className={activeProfileId === profile.id ? 'is-active' : ''}
+            onClick={() => {
+              setActiveProfileId(profile.id);
+              setIdentities(profile.identities);
+              setIncidentCost(profile.incidentCost);
+              setHoursPerWeek(profile.hoursPerWeek);
+            }}
+          >
+            {profile.label}
+          </button>
+        ))}
+      </div>
       <div className="idt-roi-grid">
         <RoiNumberField
           id="roi-identities"
@@ -1010,6 +1055,10 @@ function RoiCalculator() {
           </p>
           <p className="idt-roi-total">
             Estimated annual impact: <strong>${output.estimatedTotal.toLocaleString()}</strong>
+          </p>
+          <p className="idt-roi-note">
+            Model assumptions: labor hour rate $110/hr, incident reduction coefficient 0.87, high-risk identity reduction
+            coefficient 0.32.
           </p>
         </div>
       </div>
@@ -1094,19 +1143,37 @@ function DeploymentPathBanner() {
 }
 
 function HomeFaqSection() {
+  const groups = [
+    {
+      title: 'Security and access',
+      items: HOME_FAQ_PREVIEW.slice(0, 2)
+    },
+    {
+      title: 'Rollout and operations',
+      items: HOME_FAQ_PREVIEW.slice(2, 4)
+    }
+  ] as const;
+
   return (
     <section className="idt-section idt-shell">
       <SectionTitle
         eyebrow="FAQ"
-        title="Top evaluation questions"
-        body="Full FAQs live in docs. These are the four questions teams ask first."
+        title="Answers to the first questions security teams ask"
+        body="Clear answers on read-only access, deployment options, and rollout safety."
       />
-      <div className="idt-faq-list">
-        {HOME_FAQ_PREVIEW.map((item) => (
-          <details key={item.question} className="idt-faq-item">
-            <summary>{item.question}</summary>
-            <p>{item.answer}</p>
-          </details>
+      <div className="idt-faq-groups">
+        {groups.map((group) => (
+          <article key={group.title} className="idt-faq-group">
+            <h3>{group.title}</h3>
+            <dl>
+              {group.items.map((item) => (
+                <div key={item.question}>
+                  <dt>{item.question}</dt>
+                  <dd>{item.answer}</dd>
+                </div>
+              ))}
+            </dl>
+          </article>
         ))}
       </div>
       <div className="idt-inline-actions">
@@ -1251,9 +1318,9 @@ function HomePage() {
 
       <section className="idt-section idt-shell idt-final-cta" id="start">
         <SectionTitle
-          eyebrow="Start With Evidence"
-          title="Run a read-only machine identity risk scan"
-          body="Get prioritized trust paths, blast-radius context, and rollout-safe remediation guidance."
+          eyebrow="Ready to evaluate"
+          title="Map your first production trust path in minutes"
+          body="Start with a read-only scan, review evidence, then decide whether to self-host, use hosted SaaS, or move to enterprise deployment."
         />
         <div className="idt-inline-actions">
           <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
@@ -1282,7 +1349,7 @@ function ReadOnlyScanPage() {
   const [error, setError] = useState<string | null>(null);
 
   useSeo({
-    title: 'Start Read-Only Risk Scan | Identrail',
+    title: 'Start Free Risk Scan | Identrail',
     description:
       'Start a read-only machine identity risk scan with Identrail. Share environment context and receive a prioritized trust-path report and rollout-safe remediation plan.',
     path: '/read-only-scan'
@@ -1447,7 +1514,7 @@ function ReadOnlyScanPage() {
                   </button>
                 ) : (
                   <button type="submit" className="idt-btn idt-btn-primary" disabled={submitting || !email.trim()}>
-                    {submitting ? 'Submitting...' : 'Start Read-Only Risk Scan'}
+                    {submitting ? 'Submitting...' : 'Start Free Risk Scan'}
                   </button>
                 )}
               </div>
@@ -1458,7 +1525,7 @@ function ReadOnlyScanPage() {
               <p>Thanks. We will send your first read-only scan onboarding response within one business day.</p>
               <div className="idt-inline-actions">
                 <Link to="/demo" className="idt-btn idt-btn-dark">
-                  Book Technical Demo
+                  Book Demo
                 </Link>
                 <Link to="/docs" className="idt-btn idt-btn-ghost">
                   Review Documentation
@@ -1964,7 +2031,7 @@ function PricingPage() {
             Open ROI Assessment
           </Link>
           <Link to="/read-only-scan" className="idt-btn idt-btn-dark">
-            Start Read-Only Risk Scan
+            Start Free Risk Scan
           </Link>
         </div>
       </section>
@@ -2023,7 +2090,7 @@ function RoiAssessmentPage() {
       <section className="idt-section idt-shell">
         <div className="idt-inline-actions">
           <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-            Start Read-Only Risk Scan
+            Start Free Risk Scan
           </Link>
           <Link to="/pricing" className="idt-btn idt-btn-dark">
             Compare Pricing Plans
@@ -2080,7 +2147,7 @@ function DeploymentModelsPage() {
               <li>Accelerated query and collaboration workflows</li>
             </ul>
             <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-              Start Read-Only Risk Scan
+              Start Free Risk Scan
             </Link>
           </article>
           <article className="idt-card">
@@ -2094,7 +2161,7 @@ function DeploymentModelsPage() {
               <li>24/7 support and named TAM</li>
             </ul>
             <Link to="/enterprise" className="idt-btn idt-btn-dark">
-              Book Technical Demo
+              Book Demo
             </Link>
           </article>
         </div>
@@ -2195,7 +2262,7 @@ function IntegrationsPage() {
                 Open Documentation
               </SafeLink>
               <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-                Start Read-Only Risk Scan
+                Start Free Risk Scan
               </Link>
             </div>
           </article>
@@ -2540,7 +2607,7 @@ function SecurityPage() {
             Responsible Disclosure
           </Link>
           <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-            Start Read-Only Risk Scan
+            Start Free Risk Scan
           </Link>
           <SafeLink href={DOCS_REPO} className="idt-btn idt-btn-ghost">
             Review Security Docs

--- a/web/src/components/layout/Footer.tsx
+++ b/web/src/components/layout/Footer.tsx
@@ -55,24 +55,20 @@ type FooterProps = {
 const FOOTER_LINKS = [
   { to: '/product', label: 'Product' },
   { to: '/solutions', label: 'Solutions' },
-  { to: '/integrations', label: 'Integrations' },
-  { to: '/deployment-models', label: 'Deployment' },
   { to: '/pricing', label: 'Pricing' },
   { to: '/demo', label: 'Demo' },
   { to: '/docs', label: 'Docs' },
-  { to: '/faq', label: 'FAQ' },
   { to: '/blog', label: 'Blog' },
   { to: '/security', label: 'Security' },
-  { to: '/about', label: 'About' },
-  { to: '/privacy', label: 'Privacy' },
-  { to: '/terms', label: 'Terms' }
+  { to: '/about', label: 'About' }
 ] as const;
 
 const FOOTER_TRUST_LINKS = [
+  { label: 'FAQ', to: '/faq', external: false },
+  { label: 'Privacy', to: '/privacy', external: false },
+  { label: 'Terms', to: '/terms', external: false },
   { label: 'Responsible Disclosure', to: '/responsible-disclosure', external: false },
-  { label: 'Changelog', to: 'https://github.com/identrail/identrail/releases', external: true },
-  { label: 'Docs', to: 'https://github.com/identrail/identrail/tree/main/docs', external: true },
-  { label: 'GitHub', to: 'https://github.com/identrail/identrail', external: true }
+  { label: 'Changelog', to: 'https://github.com/identrail/identrail/releases', external: true }
 ] as const;
 
 export function Footer({ xUrl, linkedInUrl, githubRepo, discordUrl }: FooterProps) {
@@ -119,7 +115,7 @@ export function Footer({ xUrl, linkedInUrl, githubRepo, discordUrl }: FooterProp
               )
             )}
           </div>
-          <small>Build metadata updated: {buildDate}</small>
+          <small>Built in the open · last build {buildDate}</small>
         </div>
       </div>
     </footer>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2641,6 +2641,143 @@ body {
   z-index: 1;
 }
 
+/* PR-C: conversion polish and bottom-half clarity */
+.idt-lead-form {
+  border-color: rgba(158, 176, 210, 0.26);
+  background: linear-gradient(150deg, rgba(10, 14, 22, 0.9), rgba(8, 12, 18, 0.88));
+}
+
+.idt-form-trust-note {
+  margin: -0.2rem 0 0.65rem;
+  color: #9eb0ca;
+  font-size: 0.8rem;
+}
+
+.idt-form-grid.is-short {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
+.idt-form-grid.is-short .idt-btn {
+  grid-column: 1 / -1;
+  justify-self: flex-start;
+}
+
+.idt-roi {
+  border-color: rgba(158, 176, 210, 0.26);
+  background: linear-gradient(165deg, rgba(10, 14, 22, 0.9), rgba(8, 12, 18, 0.88));
+}
+
+.idt-roi-profiles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.48rem;
+  margin: -0.2rem 0 0.9rem;
+}
+
+.idt-roi-profiles button {
+  border: 1px solid rgba(159, 180, 215, 0.26);
+  background: rgba(13, 18, 29, 0.56);
+  color: #d5e0f3;
+  border-radius: 999px;
+  min-height: 34px;
+  padding: 0 0.72rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.idt-roi-profiles button.is-active {
+  border-color: rgba(201, 214, 237, 0.8);
+  background: rgba(201, 214, 237, 0.16);
+  color: #f1f6ff;
+}
+
+.idt-roi-note {
+  margin-top: 0.65rem;
+  color: #a4b2c9;
+  font-size: 0.76rem;
+  line-height: 1.5;
+}
+
+.idt-faq-groups {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.idt-faq-group {
+  border: 1px solid rgba(158, 176, 210, 0.22);
+  border-radius: 12px;
+  background: rgba(10, 15, 24, 0.56);
+  padding: 0.95rem;
+}
+
+.idt-faq-group h3 {
+  margin: 0 0 0.68rem;
+  font-size: 1rem;
+}
+
+.idt-faq-group dl {
+  margin: 0;
+  display: grid;
+  gap: 0.62rem;
+}
+
+.idt-faq-group dt {
+  color: #e8eef9;
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.idt-faq-group dd {
+  margin: 0.24rem 0 0;
+  color: #b2c1d7;
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+.idt-final-cta {
+  border-top-color: rgba(161, 181, 216, 0.24);
+}
+
+.idt-final-cta .idt-section-title {
+  max-width: 62ch;
+}
+
+.idt-footer {
+  margin-top: 3rem;
+}
+
+.idt-footer-bar {
+  background: #080f19;
+  border-top: 1px solid rgba(156, 176, 212, 0.2);
+}
+
+.idt-footer-bar-row {
+  min-height: 78px;
+}
+
+.idt-footer-links {
+  gap: 0.78rem;
+}
+
+.idt-footer-links a {
+  text-transform: none;
+  font-size: 0.84rem;
+  letter-spacing: 0.01em;
+  font-weight: 600;
+  color: #d2deef;
+}
+
+.idt-footer-maturity-row {
+  border-top-color: rgba(156, 176, 212, 0.16);
+}
+
+.idt-footer-trust-links a {
+  font-size: 0.76rem;
+  letter-spacing: 0;
+}
+
 @media (max-width: 1080px) {
   .idt-header-row {
     grid-template-columns: auto auto;
@@ -2682,6 +2819,7 @@ body {
   .idt-demo-surface,
   .idt-pricing-grid,
   .idt-roi-grid,
+  .idt-faq-groups,
   .idt-risk-insight-grid,
   .idt-proof-architecture-list,
   .idt-problem-frame-grid,
@@ -2728,6 +2866,11 @@ body {
 
   .idt-form-grid.is-short {
     grid-template-columns: 1fr;
+  }
+
+  .idt-form-grid.is-short .idt-btn {
+    grid-column: auto;
+    width: 100%;
   }
 
   .idt-page-hero {


### PR DESCRIPTION
## Summary
- improve lead-capture trust framing and cleaner short-form layout
- add ROI profile presets and clearer conservative assumptions
- redesign homepage FAQ preview into grouped, readable answers
- tighten final CTA copy and hierarchy
- simplify footer IA and improve visual polish for links/social/trust metadata
- align CTA wording consistently to "Start Free Risk Scan" and "Book Demo"

## Testing
- npm run build
- npm test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the conversion flow and trust signals to clarify read-only evaluation and reduce friction. Added ROI presets, clearer assumptions, grouped FAQs, unified CTAs, and a leaner footer.

- New Features
  - Lead form: added a read-only trust note; cleaned up the compact short-form grid.
  - ROI calculator: profile presets (startup, mid-market, enterprise) with tabs; updated copy; explicit assumptions ($110/hr, 0.87, 0.32).
  - FAQ: grouped into “Security and access” and “Rollout and operations” with clearer Q&A.
  - Final CTA and copy: reframed to “Ready to evaluate” and “Map your first production trust path”; unified CTAs to “Start Free Risk Scan” and “Book Demo”; updated SEO title.
  - Footer and styles: simplified nav and trust links; updated build note (“Built in the open · last build …”); UI polish and responsive tweaks across form, ROI, FAQ, final CTA, and footer.

<sup>Written for commit 061fed86f645ef537166e799fc9e0b0c57e393eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

