### PR TITLE
refactor(web): reduce repeated homepage CTAs

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -886,14 +886,13 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
             </p>
           </article>
         ) : null}
-        <div className="idt-inline-actions">
-          <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-            Start Free Risk Scan
+        <p className="idt-demo-follow-up">
+          Explore the full investigation workflow on the{' '}
+          <Link to="/demo" className="idt-inline-link">
+            interactive demo page
           </Link>
-          <Link to="/demo" className="idt-btn idt-btn-dark">
-            Book Demo
-          </Link>
-        </div>
+          .
+        </p>
       </aside>
     </section>
   );
@@ -1090,8 +1089,8 @@ function DeploymentPathBanner() {
                 <dd>Community and docs-led</dd>
               </div>
             </dl>
-            <SafeLink href={GITHUB_REPO} className="idt-btn idt-btn-ghost">
-              View Open Source
+            <SafeLink href={GITHUB_REPO} className="idt-inline-link">
+              View open-source setup →
             </SafeLink>
           </article>
           <article className="idt-adoption-card is-featured">
@@ -1111,9 +1110,7 @@ function DeploymentPathBanner() {
                 <dd>Product support and assisted onboarding</dd>
               </div>
             </dl>
-            <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-              Start Free Risk Scan
-            </Link>
+            <p className="idt-adoption-note">Recommended for teams that need the fastest first scan.</p>
           </article>
           <article className="idt-adoption-card">
             <h3>Enterprise</h3>
@@ -1132,10 +1129,15 @@ function DeploymentPathBanner() {
                 <dd>Enterprise SLA and named partner team</dd>
               </div>
             </dl>
-            <Link to="/enterprise" className="idt-btn idt-btn-dark">
-              Book Demo
+            <Link to="/enterprise" className="idt-inline-link">
+              Contact enterprise team →
             </Link>
           </article>
+        </div>
+        <div className="idt-inline-actions idt-adoption-actions">
+          <Link to="/pricing" className="idt-btn idt-btn-ghost">
+            Compare plan details
+          </Link>
         </div>
       </div>
     </section>
@@ -1326,8 +1328,8 @@ function HomePage() {
           <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
             Start Free Risk Scan
           </Link>
-          <Link to="/demo" className="idt-btn idt-btn-dark">
-            Book Demo
+          <Link to="/enterprise" className="idt-inline-link">
+            Need enterprise procurement? Contact Sales →
           </Link>
         </div>
       </section>
@@ -1979,14 +1981,6 @@ function PricingPage() {
               Contact Sales
             </button>
           </article>
-        </div>
-        <div className="idt-pricing-inline-cta">
-          <Link to="/enterprise" className="idt-btn idt-btn-primary">
-            Start Free Risk Scan
-          </Link>
-          <button type="button" className="idt-btn idt-btn-dark" onClick={() => setSalesModalOpen(true)}>
-            Book Demo
-          </button>
         </div>
       </section>
 

--- a/web/src/components/home/RiskInsightSection.tsx
+++ b/web/src/components/home/RiskInsightSection.tsx
@@ -103,14 +103,13 @@ export function RiskInsightSection() {
           <p>
             <strong>Recommended first fix:</strong> {activeScenario.firstAction}
           </p>
-          <div className="idt-inline-actions">
-            <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-              Start Free Risk Scan
+          <p className="idt-risk-follow-up">
+            Need deeper context?{' '}
+            <Link to="/demo" className="idt-inline-link">
+              Inspect this path in the interactive demo
             </Link>
-            <Link to="/demo" className="idt-btn idt-btn-dark">
-              Book Demo
-            </Link>
-          </div>
+            .
+          </p>
         </article>
       </div>
     </section>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1699,13 +1699,6 @@ h2 {
   font-size: 0.91rem;
 }
 
-.idt-pricing-inline-cta {
-  margin-top: 1.1rem;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.7rem;
-}
-
 .idt-chip-row {
   display: flex;
   justify-content: space-between;
@@ -2734,6 +2727,27 @@ body {
   color: #b2c1d7;
   font-size: 0.82rem;
   line-height: 1.55;
+}
+
+.idt-risk-follow-up,
+.idt-demo-follow-up {
+  margin: 0.55rem 0 0;
+  color: #adbed7;
+  font-size: 0.84rem;
+}
+
+.idt-adoption-note {
+  margin: 0;
+  color: #b2c3dc;
+  font-size: 0.83rem;
+}
+
+.idt-adoption-actions {
+  margin-top: 0.95rem;
+}
+
+.idt-adoption-actions .idt-btn {
+  min-height: 38px;
 }
 
 .idt-final-cta {


### PR DESCRIPTION
## Summary
- remove repeated Start Free Risk Scan / Book Demo button pairs from mid-page sections
- keep one clear primary CTA flow and convert secondary duplicates to subtle inline links
- clean up affected spacing so sections stay aligned after CTA reduction

## Validation
- npm run build
- npm run test -- --run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduced repeated CTAs on the homepage by removing mid-page “Start Free Risk Scan / Book Demo” button pairs and converting secondary actions to inline links. This clarifies the primary flow and keeps sections aligned with light style updates.

- **Refactors**
  - Removed duplicate CTA button pairs from mid-page sections.
  - Converted secondary actions to inline links across sections (demo, open-source, enterprise contact).
  - Added a ghost “Compare plan details” button under adoption cards and a short recommendation note.
  - Updated spacing and styles: added `.idt-risk-follow-up`, `.idt-demo-follow-up`, `.idt-adoption-note`, `.idt-adoption-actions`; removed `.idt-pricing-inline-cta`.

<sup>Written for commit 4023874c1ea48eddedb0d25fc0fab75ed8587889. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

