### PR TITLE
fix(web): mobile polish, footer cleanup, and cache consistency

### DIFF
--- a/web/src/components/layout/Footer.tsx
+++ b/web/src/components/layout/Footer.tsx
@@ -52,17 +52,6 @@ type FooterProps = {
   discordUrl: string;
 };
 
-const FOOTER_LINKS = [
-  { to: '/product', label: 'Product' },
-  { to: '/solutions', label: 'Solutions' },
-  { to: '/pricing', label: 'Pricing' },
-  { to: '/demo', label: 'Demo' },
-  { to: '/docs', label: 'Docs' },
-  { to: '/blog', label: 'Blog' },
-  { to: '/security', label: 'Security' },
-  { to: '/about', label: 'About' }
-] as const;
-
 const FOOTER_TRUST_LINKS = [
   { label: 'FAQ', to: '/faq', external: false },
   { label: 'Privacy', to: '/privacy', external: false },
@@ -72,20 +61,26 @@ const FOOTER_TRUST_LINKS = [
 ] as const;
 
 export function Footer({ xUrl, linkedInUrl, githubRepo, discordUrl }: FooterProps) {
-  const buildDate = ((import.meta as ImportMeta & { env?: Record<string, string> }).env?.VITE_BUILD_DATE ?? 'unknown').slice(0, 10);
-
   return (
     <footer className="idt-footer">
       <div className="idt-footer-bar">
         <div className="idt-shell idt-footer-bar-row">
-          <nav className="idt-footer-links" aria-label="Footer">
-            {FOOTER_LINKS.map((item) => (
-              <Link key={item.to} to={item.to}>
-                {item.label}
-              </Link>
-            ))}
-          </nav>
-          <small>© {new Date().getFullYear()} Identrail. All rights reserved.</small>
+          <div className="idt-footer-meta">
+            <small>© {new Date().getFullYear()} Identrail. All rights reserved.</small>
+          </div>
+          <div className="idt-footer-trust-links">
+            {FOOTER_TRUST_LINKS.map((item) =>
+              item.external ? (
+                <SafeLink key={item.label} href={item.to}>
+                  {item.label}
+                </SafeLink>
+              ) : (
+                <Link key={item.label} to={item.to}>
+                  {item.label}
+                </Link>
+              )
+            )}
+          </div>
           <div className="idt-footer-socials">
             <SafeLink href={xUrl} aria-label="X" className="idt-social-link">
               <XIcon />
@@ -100,22 +95,6 @@ export function Footer({ xUrl, linkedInUrl, githubRepo, discordUrl }: FooterProp
               <DiscordIcon />
             </SafeLink>
           </div>
-        </div>
-        <div className="idt-shell idt-footer-maturity-row">
-          <div className="idt-footer-trust-links">
-            {FOOTER_TRUST_LINKS.map((item) =>
-              item.external ? (
-                <SafeLink key={item.label} href={item.to}>
-                  {item.label}
-                </SafeLink>
-              ) : (
-                <Link key={item.label} to={item.to}>
-                  {item.label}
-                </Link>
-              )
-            )}
-          </div>
-          <small>Built in the open · last build {buildDate}</small>
         </div>
       </div>
     </footer>

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -53,9 +53,9 @@ export function Header({
           onClick={() => setMenuOpen((prev) => !prev)}
           aria-expanded={menuOpen}
           aria-controls="primary-nav"
-          aria-label="Toggle primary navigation"
+          aria-label={menuOpen ? 'Close primary navigation' : 'Open primary navigation'}
         >
-          Menu
+          {menuOpen ? 'Close' : 'Menu'}
         </button>
 
         <nav id="primary-nav" className={`idt-nav ${menuOpen ? 'is-open' : ''}`} aria-label="Primary">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -189,7 +189,8 @@ a {
   margin-left: auto;
   border-radius: 999px;
   border: 1px solid var(--idt-line);
-  min-height: 38px;
+  min-height: 44px;
+  min-width: 44px;
   padding: 0 1rem;
   background: rgba(12, 12, 14, 0.95);
   color: #fff;
@@ -682,8 +683,6 @@ h3 {
 
 .idt-section {
   padding: clamp(2.6rem, 6vw, 4.3rem) 0;
-  content-visibility: auto;
-  contain-intrinsic-size: 620px;
 }
 
 .idt-section-title {
@@ -1869,6 +1868,8 @@ h2 {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
+  align-items: center;
+  justify-content: center;
 }
 
 .idt-footer-trust-links a {
@@ -2769,26 +2770,23 @@ body {
 
 .idt-footer-bar-row {
   min-height: 78px;
+  grid-template-columns: auto 1fr auto;
+  gap: 1rem;
+  align-items: center;
 }
 
-.idt-footer-links {
-  gap: 0.78rem;
+.idt-footer-meta {
+  min-width: fit-content;
 }
 
-.idt-footer-links a {
-  text-transform: none;
-  font-size: 0.84rem;
-  letter-spacing: 0.01em;
+.idt-footer-meta small {
+  color: rgba(231, 238, 250, 0.88);
+  font-size: 0.9rem;
   font-weight: 600;
-  color: #d2deef;
-}
-
-.idt-footer-maturity-row {
-  border-top-color: rgba(156, 176, 212, 0.16);
 }
 
 .idt-footer-trust-links a {
-  font-size: 0.76rem;
+  font-size: 0.84rem;
   letter-spacing: 0;
 }
 
@@ -2809,12 +2807,15 @@ body {
     grid-area: menu;
     display: inline-flex;
     justify-self: end;
+    min-height: 44px;
   }
 
   .idt-nav {
     grid-area: nav;
     display: none;
     justify-content: flex-start;
+    flex-wrap: wrap;
+    gap: 0.45rem 0.8rem;
     border-top: 1px solid var(--idt-line);
     padding-top: 0.8rem;
   }
@@ -2868,14 +2869,13 @@ body {
 
   .idt-footer-bar-row {
     grid-template-columns: 1fr;
-    align-items: flex-start;
+    align-items: center;
     padding: 0.9rem 0;
+    gap: 0.9rem;
   }
 
-  .idt-footer-maturity-row {
-    grid-template-columns: 1fr;
-    align-items: flex-start;
-    padding-bottom: 0.8rem;
+  .idt-footer-trust-links {
+    justify-content: flex-start;
   }
 
   .idt-form-grid.is-short {
@@ -2905,15 +2905,39 @@ body {
     width: min(100% - 1.2rem, var(--idt-shell));
   }
 
+  .idt-section {
+    padding: 2.25rem 0;
+  }
+
   .idt-inline-actions .idt-btn,
   .idt-header-actions .idt-btn {
     width: 100%;
+  }
+
+  .idt-brand small {
+    display: none;
+  }
+
+  .idt-nav {
+    width: 100%;
+  }
+
+  .idt-nav a {
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    padding: 0.48rem 0;
+    font-size: 0.95rem;
   }
 
   .idt-header-actions {
     width: 100%;
     display: grid;
     grid-template-columns: 1fr;
+  }
+
+  .idt-header-actions .idt-btn-dark {
+    display: none;
   }
 
   .idt-header-utility {
@@ -2937,8 +2961,22 @@ body {
   }
 
   .idt-demo-node {
-    font-size: 0.72rem;
-    padding: 0.45rem 0.7rem;
+    font-size: 0.78rem;
+    padding: 0.52rem 0.78rem;
+  }
+
+  .idt-demo-node small,
+  .idt-severity-pill,
+  .idt-finding-label,
+  .idt-demo-list-row small {
+    font-size: 0.76rem;
+  }
+
+  .idt-demo-view-toggle button,
+  .idt-demo-scenario-row button,
+  .idt-risk-scenario-item,
+  .idt-proof-link {
+    min-height: 44px;
   }
 
   .idt-hero-points li {

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,6 +1,33 @@
 {
   "headers": [
     {
+      "source": "/index.html",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store, no-cache, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/((?!assets/|favicon-64.png|apple-touch-icon.png|identrail-logo.png|robots.txt|sitemap.xml).*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store, no-cache, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
       "source": "/(.*)",
       "headers": [
         {


### PR DESCRIPTION
## Summary\n- fix mobile nav wrapping/tap targets and tighten mobile section spacing\n- remove noisy footer link block and keep a cleaner legal-links + copyright + social layout\n- add cache headers to reduce stale HTML across browsers while keeping immutable asset caching\n\n## Validation\n- npm run build\n- npm run test -- --run\n- manual mobile check at 320px and 390px on local preview

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished mobile navigation and spacing, simplified the footer layout, and added cache headers to prevent stale HTML while keeping assets cached efficiently.

- **Bug Fixes**
  - Improved mobile tap targets and controls (44px min size, clearer Menu/Close label, better wrap and spacing).
  - Tightened mobile section spacing; removed layout hints that caused jitter on small screens.
  - Set HTML responses to no-store while keeping `/assets/*` immutable with long-term caching via `vercel.json`.

- **Refactors**
  - Reworked footer to a cleaner layout: legal links + copyright + socials.
  - Removed the large footer link block and build-date text.

<sup>Written for commit a7f297234b1c1e34505dd89d7c9ffcdf6cd13981. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

