### PR TITLE
fix(web): mobile hero overlap and browser cache consistency

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2965,6 +2965,18 @@ body {
     padding: 0.52rem 0.78rem;
   }
 
+  .idt-graph-visual {
+    min-height: auto;
+    padding: 0.85rem;
+  }
+
+  .idt-graph-grid,
+  .idt-node,
+  .idt-edge,
+  .idt-pulse {
+    display: none;
+  }
+
   .idt-demo-node small,
   .idt-severity-pill,
   .idt-finding-label,
@@ -2983,9 +2995,11 @@ body {
     font-size: 0.9rem;
   }
   .idt-hero-graph-caption {
-    position: static;
-    margin: 1rem;
-    width: auto;
+    position: relative;
+    z-index: 1;
+    margin: 0;
+    width: 100%;
+    background: linear-gradient(165deg, rgba(9, 13, 20, 0.97), rgba(12, 18, 28, 0.98));
   }
 
   .idt-footer-super-cta {

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,11 +1,36 @@
 {
   "headers": [
     {
+      "source": "/",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store, no-cache, must-revalidate"
+        },
+        {
+          "key": "Pragma",
+          "value": "no-cache"
+        },
+        {
+          "key": "Expires",
+          "value": "0"
+        }
+      ]
+    },
+    {
       "source": "/index.html",
       "headers": [
         {
           "key": "Cache-Control",
           "value": "no-store, no-cache, must-revalidate"
+        },
+        {
+          "key": "Pragma",
+          "value": "no-cache"
+        },
+        {
+          "key": "Expires",
+          "value": "0"
         }
       ]
     },
@@ -15,6 +40,31 @@
         {
           "key": "Cache-Control",
           "value": "no-store, no-cache, must-revalidate"
+        },
+        {
+          "key": "Pragma",
+          "value": "no-cache"
+        },
+        {
+          "key": "Expires",
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "source": "/(.*)\\.html",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store, no-cache, must-revalidate"
+        },
+        {
+          "key": "Pragma",
+          "value": "no-cache"
+        },
+        {
+          "key": "Expires",
+          "value": "0"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- fix mobile hero trust-path preview overlap by switching to a clean single-card mode on small screens
- hide floating graph layers on mobile to prevent node labels from colliding with finding text
- strengthen no-cache headers for HTML routes to reduce stale versions across non-Brave browsers

## Validation
- npm run build
- npm run test -- --run
- manual mobile screenshot check at 390px

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mobile hero overlap by simplifying the trust-path preview on small screens. Also enforces stronger no‑cache headers for HTML pages to prevent stale content.

- **Bug Fixes**
  - Mobile hero: switch to a single-card view and hide floating graph layers on small screens; adjust caption stacking and padding to stop label collisions and overlap.
  - Caching: add `Cache-Control: no-store, no-cache, must-revalidate`, `Pragma: no-cache`, and `Expires: 0` for `/`, `/index.html`, and all `*.html` routes in `vercel.json`.

<sup>Written for commit 300520b49f53f432969c02f04fecba7c94c037fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

