### PR TITLE
fix(web): clean mobile menu and single-card sample finding

### DIFF
--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -55,7 +55,8 @@ export function Header({
           aria-controls="primary-nav"
           aria-label={menuOpen ? 'Close primary navigation' : 'Open primary navigation'}
         >
-          {menuOpen ? 'Close' : 'Menu'}
+          <span className="idt-menu-toggle-icon" aria-hidden="true" />
+          <span className="idt-menu-toggle-label">{menuOpen ? 'Close' : 'Menu'}</span>
         </button>
 
         <nav id="primary-nav" className={`idt-nav ${menuOpen ? 'is-open' : ''}`} aria-label="Primary">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -187,16 +187,59 @@ a {
 .idt-menu-toggle {
   display: none;
   margin-left: auto;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
   border-radius: 999px;
   border: 1px solid var(--idt-line);
   min-height: 44px;
   min-width: 44px;
-  padding: 0 1rem;
+  padding: 0 0.84rem;
   background: rgba(12, 12, 14, 0.95);
   color: #fff;
   font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  text-transform: none;
+  letter-spacing: 0.01em;
+  line-height: 1;
+  font-size: 0.92rem;
+}
+
+.idt-menu-toggle-icon {
+  width: 12px;
+  height: 10px;
+  position: relative;
+  display: inline-block;
+  color: currentColor;
+}
+
+.idt-menu-toggle-icon::before,
+.idt-menu-toggle-icon::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  width: 12px;
+  height: 1.5px;
+  border-radius: 999px;
+  background: currentColor;
+  transition: transform 0.2s ease, top 0.2s ease, opacity 0.2s ease;
+}
+
+.idt-menu-toggle-icon::before {
+  top: 2px;
+}
+
+.idt-menu-toggle-icon::after {
+  top: 7px;
+}
+
+.idt-menu-toggle[aria-expanded='true'] .idt-menu-toggle-icon::before {
+  top: 4.5px;
+  transform: rotate(45deg);
+}
+
+.idt-menu-toggle[aria-expanded='true'] .idt-menu-toggle-icon::after {
+  top: 4.5px;
+  transform: rotate(-45deg);
 }
 
 .idt-deployment-bridge {
@@ -2967,7 +3010,10 @@ body {
 
   .idt-graph-visual {
     min-height: auto;
-    padding: 0.85rem;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
   }
 
   .idt-graph-grid,

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -8,6 +8,14 @@
           "value": "no-store, no-cache, must-revalidate"
         },
         {
+          "key": "CDN-Cache-Control",
+          "value": "no-store"
+        },
+        {
+          "key": "Vercel-CDN-Cache-Control",
+          "value": "no-store"
+        },
+        {
           "key": "Pragma",
           "value": "no-cache"
         },
@@ -23,6 +31,14 @@
         {
           "key": "Cache-Control",
           "value": "no-store, no-cache, must-revalidate"
+        },
+        {
+          "key": "CDN-Cache-Control",
+          "value": "no-store"
+        },
+        {
+          "key": "Vercel-CDN-Cache-Control",
+          "value": "no-store"
         },
         {
           "key": "Pragma",
@@ -42,6 +58,14 @@
           "value": "no-store, no-cache, must-revalidate"
         },
         {
+          "key": "CDN-Cache-Control",
+          "value": "no-store"
+        },
+        {
+          "key": "Vercel-CDN-Cache-Control",
+          "value": "no-store"
+        },
+        {
           "key": "Pragma",
           "value": "no-cache"
         },
@@ -57,6 +81,14 @@
         {
           "key": "Cache-Control",
           "value": "no-store, no-cache, must-revalidate"
+        },
+        {
+          "key": "CDN-Cache-Control",
+          "value": "no-store"
+        },
+        {
+          "key": "Vercel-CDN-Cache-Control",
+          "value": "no-store"
         },
         {
           "key": "Pragma",


### PR DESCRIPTION
## Summary
- redesign the mobile Menu/Close control to a cleaner balanced pill with icon + centered label
- remove the double-box effect on mobile hero sample finding by collapsing the outer hero graph container into a transparent wrapper
- strengthen HTML cache bypass across browsers by adding CDN-level no-store headers for route HTML

## Validation
- npm run build
- npm run test -- --run
- mobile visual checks at 390px for header/menu and sample finding

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the mobile navigation and fixed the hero sample card’s double-box on small screens. Also disabled CDN caching for HTML routes to prevent stale pages.

- **Bug Fixes**
  - Redesigned the mobile menu toggle to a pill with icon + centered label; better alignment and tap target.
  - Removed the double-box effect on the mobile hero sample card by making the outer container transparent and borderless.
  - Added `CDN-Cache-Control: no-store` and `Vercel-CDN-Cache-Control: no-store` for HTML routes to bypass CDN caches.

<sup>Written for commit bc0e36420155d46cc6c990aaaa5865ee9c24c810. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

