### PR TITLE
feat(web): layered live hero finding display

### DIFF
--- a/web/src/components/home/HeroProductReveal.tsx
+++ b/web/src/components/home/HeroProductReveal.tsx
@@ -1,42 +1,274 @@
+import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 
-const PATH_SUMMARY = 'GitHub Actions OIDC → AWS Role → K8s Service Account → RDS Billing Resource';
+type HeroNode = {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+  tone: 'source' | 'broker' | 'workload' | 'privilege' | 'resource';
+};
 
-const PATH_STEPS = [
-  'Source: GitHub Actions workflow identity',
-  'Broker: OIDC trust relationship',
-  'Privilege boundary: AWS IAM role assumption',
-  'Target: production billing datastore'
-] as const;
+type HeroEdge = {
+  from: string;
+  to: string;
+  emphasis?: 'high' | 'medium';
+};
+
+type HeroScene = {
+  id: string;
+  label: string;
+  findingTitle: string;
+  findingSummary: string;
+  severity: 'High severity' | 'Medium severity';
+  hopsLabel: string;
+  modeLabel: string;
+  steps: readonly string[];
+  capabilities: readonly string[];
+  nodes: readonly HeroNode[];
+  edges: readonly HeroEdge[];
+};
+
+const SCENES: readonly HeroScene[] = [
+  {
+    id: 'oidc-chain',
+    label: 'CI/CD OIDC chain',
+    findingTitle: 'High-risk production trust path',
+    findingSummary: 'GitHub Actions OIDC → AWS Role → K8s Service Account → RDS Billing Resource',
+    severity: 'High severity',
+    hopsLabel: '4-hop chain',
+    modeLabel: 'Read-only analysis',
+    steps: [
+      'Source: GitHub Actions workflow identity',
+      'Broker: OIDC trust relationship',
+      'Privilege boundary: AWS IAM role assumption',
+      'Target: production billing datastore'
+    ],
+    capabilities: ['Correlates identity chain', 'Calculates blast radius', 'Prioritizes safe first fix'],
+    nodes: [
+      { id: 'src-gha', label: 'GitHub Actions OIDC', x: 18, y: 20, tone: 'source' },
+      { id: 'broker-oidc', label: 'OIDC Provider', x: 50, y: 31, tone: 'broker' },
+      { id: 'role-aws', label: 'AWS Role: billing-prod', x: 72, y: 47, tone: 'privilege' },
+      { id: 'k8s-sa', label: 'K8s SA: payments-api', x: 42, y: 64, tone: 'workload' },
+      { id: 'rds', label: 'RDS: billing-ledger', x: 73, y: 76, tone: 'resource' }
+    ],
+    edges: [
+      { from: 'src-gha', to: 'broker-oidc', emphasis: 'medium' },
+      { from: 'broker-oidc', to: 'role-aws', emphasis: 'high' },
+      { from: 'role-aws', to: 'k8s-sa', emphasis: 'high' },
+      { from: 'k8s-sa', to: 'rds', emphasis: 'high' }
+    ]
+  },
+  {
+    id: 'k8s-drift',
+    label: 'K8s service account drift',
+    findingTitle: 'Cross-boundary service account drift',
+    findingSummary: 'K8s SA → AssumeRole policy → Shared IAM role → S3 Config bucket',
+    severity: 'High severity',
+    hopsLabel: '4-hop chain',
+    modeLabel: 'Policy simulation',
+    steps: [
+      'Source: payments-api service account token',
+      'Broker: IAM trust condition mismatch',
+      'Privilege boundary: shared platform role reuse',
+      'Target: config artifact bucket with broad read'
+    ],
+    capabilities: ['Detects trust drift', 'Explains policy evidence', 'Simulates non-breaking remediation'],
+    nodes: [
+      { id: 'k8s-sa', label: 'K8s SA: payments-api', x: 22, y: 25, tone: 'workload' },
+      { id: 'iam-trust', label: 'IAM Trust Policy', x: 48, y: 38, tone: 'broker' },
+      { id: 'platform-role', label: 'AWS Role: shared-platform', x: 74, y: 45, tone: 'privilege' },
+      { id: 'config-store', label: 'S3: prod-config-artifacts', x: 64, y: 76, tone: 'resource' },
+      { id: 'runtime', label: 'Prod namespace runtime', x: 29, y: 70, tone: 'source' }
+    ],
+    edges: [
+      { from: 'k8s-sa', to: 'iam-trust', emphasis: 'medium' },
+      { from: 'iam-trust', to: 'platform-role', emphasis: 'high' },
+      { from: 'platform-role', to: 'config-store', emphasis: 'high' },
+      { from: 'k8s-sa', to: 'runtime', emphasis: 'medium' }
+    ]
+  },
+  {
+    id: 'token-leak',
+    label: 'Leaked deploy token path',
+    findingTitle: 'Leaked token expands blast radius',
+    findingSummary: 'Git repo secret → CI runner token → ECR push role → ECS production task',
+    severity: 'Medium severity',
+    hopsLabel: '4-hop chain',
+    modeLabel: 'Containment workflow',
+    steps: [
+      'Source: repository secret exposure event',
+      'Broker: CI runner token replay path',
+      'Privilege boundary: ECR push role assumptions',
+      'Target: production task image deployment path'
+    ],
+    capabilities: ['Links repo event to cloud reachability', 'Scores real production impact', 'Outputs containment sequence'],
+    nodes: [
+      { id: 'repo-secret', label: 'Repo Secret Event', x: 20, y: 23, tone: 'source' },
+      { id: 'runner-token', label: 'CI Runner Token', x: 44, y: 36, tone: 'broker' },
+      { id: 'ecr-role', label: 'AWS Role: ecr-push-prod', x: 70, y: 44, tone: 'privilege' },
+      { id: 'ecr-repo', label: 'ECR: payments-api', x: 53, y: 66, tone: 'resource' },
+      { id: 'ecs-task', label: 'ECS Task: prod-payments', x: 77, y: 76, tone: 'workload' }
+    ],
+    edges: [
+      { from: 'repo-secret', to: 'runner-token', emphasis: 'medium' },
+      { from: 'runner-token', to: 'ecr-role', emphasis: 'high' },
+      { from: 'ecr-role', to: 'ecr-repo', emphasis: 'high' },
+      { from: 'ecr-repo', to: 'ecs-task', emphasis: 'medium' }
+    ]
+  }
+];
+
+const LOOP_INTERVAL_MS = 4400;
+
+function usePrefersReducedMotion() {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const update = () => setPrefersReducedMotion(media.matches);
+    update();
+
+    if (typeof media.addEventListener === 'function') {
+      media.addEventListener('change', update);
+      return () => media.removeEventListener('change', update);
+    }
+
+    media.addListener(update);
+    return () => media.removeListener(update);
+  }, []);
+
+  return prefersReducedMotion;
+}
+
+function findNode(nodes: readonly HeroNode[], id: string) {
+  return nodes.find((node) => node.id === id);
+}
+
+function edgePath(from: HeroNode, to: HeroNode) {
+  const startX = from.x;
+  const startY = from.y;
+  const endX = to.x;
+  const endY = to.y;
+  const controlX = (startX + endX) / 2;
+  const controlY = Math.min(startY, endY) - 8;
+  return `M ${startX} ${startY} Q ${controlX} ${controlY} ${endX} ${endY}`;
+}
 
 export function HeroProductReveal() {
+  const reducedMotion = usePrefersReducedMotion();
+  const [activeSceneIndex, setActiveSceneIndex] = useState(0);
+  const activeScene = SCENES[activeSceneIndex];
+
+  useEffect(() => {
+    if (reducedMotion) {
+      return;
+    }
+
+    const timer = window.setInterval(() => {
+      setActiveSceneIndex((current) => (current + 1) % SCENES.length);
+    }, LOOP_INTERVAL_MS);
+
+    return () => window.clearInterval(timer);
+  }, [reducedMotion]);
+
+  const sceneLayers = useMemo(
+    () =>
+      SCENES.map((scene, index) => {
+        const isActive = index === activeSceneIndex;
+        return (
+          <div key={scene.id} className={`idt-hero-layer ${isActive ? 'is-active' : 'is-dimmed'}`} aria-hidden={!isActive}>
+            <svg className="idt-hero-arrows" viewBox="0 0 100 100" preserveAspectRatio="none">
+              <defs>
+                <linearGradient id={`idt-edge-gradient-${scene.id}`} x1="0%" y1="0%" x2="100%" y2="100%">
+                  <stop offset="0%" stopColor="rgba(170, 197, 255, 0.25)" />
+                  <stop offset="45%" stopColor="rgba(152, 186, 255, 0.82)" />
+                  <stop offset="100%" stopColor="rgba(119, 160, 241, 0.24)" />
+                </linearGradient>
+                <marker id={`idt-arrow-head-${scene.id}`} markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto-start-reverse">
+                  <path d="M0,0 L8,4 L0,8 Z" fill="rgba(162, 191, 252, 0.88)" />
+                </marker>
+              </defs>
+              {scene.edges.map((edge) => {
+                const from = findNode(scene.nodes, edge.from);
+                const to = findNode(scene.nodes, edge.to);
+                if (!from || !to) {
+                  return null;
+                }
+
+                return (
+                  <path
+                    key={`${scene.id}-${edge.from}-${edge.to}`}
+                    className={`idt-hero-arrow ${edge.emphasis === 'high' ? 'is-high' : ''}`}
+                    d={edgePath(from, to)}
+                    stroke={`url(#idt-edge-gradient-${scene.id})`}
+                    markerEnd={`url(#idt-arrow-head-${scene.id})`}
+                  />
+                );
+              })}
+            </svg>
+
+            {scene.nodes.map((node) => (
+              <div
+                key={`${scene.id}-${node.id}`}
+                className={`idt-node idt-node-${node.tone}`}
+                style={{ left: `${node.x}%`, top: `${node.y}%` }}
+              >
+                {node.label}
+              </div>
+            ))}
+          </div>
+        );
+      }),
+    [activeSceneIndex]
+  );
+
   return (
-    <div className="idt-graph-visual" aria-label="Trust path product preview">
+    <div className="idt-graph-visual idt-graph-visual-live" aria-label="Live trust path product preview">
       <div className="idt-graph-grid" />
-      <div className="idt-node idt-node-root">GitHub Actions OIDC</div>
-      <div className="idt-node idt-node-role">AWS Role: billing-prod</div>
-      <div className="idt-node idt-node-k8s">K8s SA: payments-api</div>
-      <div className="idt-node idt-node-repo">RDS: billing-ledger</div>
-      <span className="idt-edge idt-edge-a" />
-      <span className="idt-edge idt-edge-b" />
-      <span className="idt-edge idt-edge-c" />
-      <span className="idt-pulse idt-pulse-a" />
-      <span className="idt-pulse idt-pulse-b" />
+      {sceneLayers}
 
       <aside className="idt-hero-graph-caption idt-hero-proof-card">
-        <p className="idt-hero-graph-title">Sample finding</p>
-        <h3>High-risk production trust path</h3>
-        <p className="idt-hero-path">{PATH_SUMMARY}</p>
-        <div className="idt-hero-proof-meta">
-          <span className="idt-severity-pill">High severity</span>
-          <span>4-hop chain</span>
-          <span>Read-only analysis</span>
+        <div className="idt-hero-layer-head">
+          <p className="idt-hero-graph-title">Live finding layer</p>
+          <div className="idt-hero-layer-dots" aria-label="Live scene steps">
+            {SCENES.map((scene, index) => (
+              <button
+                key={scene.id}
+                type="button"
+                className={index === activeSceneIndex ? 'is-active' : ''}
+                onClick={() => setActiveSceneIndex(index)}
+                aria-label={`Show ${scene.label}`}
+              />
+            ))}
+          </div>
         </div>
+
+        <h3>{activeScene.findingTitle}</h3>
+        <p className="idt-hero-path">{activeScene.findingSummary}</p>
+
+        <div className="idt-hero-proof-meta">
+          <span className="idt-severity-pill">{activeScene.severity}</span>
+          <span>{activeScene.hopsLabel}</span>
+          <span>{activeScene.modeLabel}</span>
+        </div>
+
         <ol className="idt-hero-path-steps">
-          {PATH_STEPS.map((step) => (
+          {activeScene.steps.map((step) => (
             <li key={step}>{step}</li>
           ))}
         </ol>
+
+        <ul className="idt-hero-capability-list">
+          {activeScene.capabilities.map((capability) => (
+            <li key={capability}>{capability}</li>
+          ))}
+        </ul>
+
         <Link to="/demo" className="idt-inline-link">
           Inspect this path in demo
         </Link>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -397,86 +397,102 @@ h3 {
   opacity: 0.28;
 }
 
+.idt-graph-visual-live {
+  isolation: isolate;
+}
+
+.idt-hero-layer {
+  position: absolute;
+  inset: 0;
+  transition: opacity 0.55s ease, filter 0.55s ease, transform 0.55s ease;
+}
+
+.idt-hero-layer.is-active {
+  opacity: 1;
+  filter: blur(0);
+  transform: scale(1);
+  z-index: 2;
+}
+
+.idt-hero-layer.is-dimmed {
+  opacity: 0.14;
+  filter: blur(1px);
+  transform: scale(0.985);
+  z-index: 1;
+}
+
 .idt-node {
   position: absolute;
-  z-index: 2;
+  z-index: 3;
+  transform: translate(-50%, -50%);
   border-radius: 999px;
-  border: 1px solid rgba(215, 227, 255, 0.36);
-  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(210, 225, 255, 0.34);
+  background: linear-gradient(150deg, rgba(21, 28, 44, 0.92), rgba(11, 16, 27, 0.9));
   color: #eaf0ff;
-  padding: 0.42rem 0.74rem;
-  font-size: 0.7rem;
+  padding: 0.38rem 0.7rem;
+  font-size: 0.64rem;
   font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  text-transform: none;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 8px 18px rgba(3, 7, 18, 0.34);
+  white-space: nowrap;
 }
 
-.idt-node-root {
-  top: 16%;
-  left: 17%;
+.idt-node-source {
+  border-color: rgba(179, 203, 255, 0.4);
 }
 
-.idt-node-role {
-  top: 33%;
-  left: 52%;
+.idt-node-broker {
+  border-color: rgba(150, 195, 255, 0.42);
 }
 
-.idt-node-k8s {
-  top: 61%;
-  left: 26%;
+.idt-node-workload {
+  border-color: rgba(143, 232, 214, 0.44);
 }
 
-.idt-node-repo {
-  top: 72%;
-  left: 62%;
+.idt-node-privilege {
+  border-color: rgba(255, 189, 141, 0.46);
 }
 
-.idt-edge {
+.idt-node-resource {
+  border-color: rgba(255, 133, 133, 0.44);
+}
+
+.idt-hero-arrows {
   position: absolute;
-  height: 2px;
-  background: linear-gradient(90deg, transparent, #7f97d8, transparent);
-  opacity: 0.62;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 2;
+  pointer-events: none;
 }
 
-.idt-edge-a {
-  top: 25%;
-  left: 28%;
-  width: 34%;
-  transform: rotate(14deg);
+.idt-hero-arrow {
+  fill: none;
+  stroke-width: 1.45;
+  opacity: 0.78;
+  stroke-linecap: round;
+  stroke-dasharray: 1.8 1.4;
+  animation: idtArrowFlow 4.2s linear infinite;
+  filter: drop-shadow(0 0 6px rgba(117, 162, 246, 0.35));
 }
 
-.idt-edge-b {
-  top: 50%;
-  left: 33%;
-  width: 24%;
-  transform: rotate(-38deg);
+.idt-hero-arrow.is-high {
+  stroke-width: 1.85;
+  opacity: 0.95;
 }
 
-.idt-edge-c {
-  top: 66%;
-  left: 41%;
-  width: 29%;
-  transform: rotate(15deg);
+.idt-hero-layer.is-dimmed .idt-hero-arrow {
+  animation-play-state: paused;
 }
 
-.idt-pulse {
-  position: absolute;
-  border-radius: 999px;
-  border: 1px solid rgba(137, 169, 255, 0.65);
-  width: 16px;
-  height: 16px;
-  animation: idtPulse 2.6s ease-in-out infinite;
-}
-
-.idt-pulse-a {
-  top: 38%;
-  left: 47%;
-}
-
-.idt-pulse-b {
-  top: 62%;
-  left: 56%;
-  animation-delay: 0.95s;
+@keyframes idtArrowFlow {
+  from {
+    stroke-dashoffset: 0;
+  }
+  to {
+    stroke-dashoffset: -14;
+  }
 }
 
 .idt-hero-graph-caption {
@@ -492,11 +508,46 @@ h3 {
   box-shadow: 0 20px 40px rgba(1, 8, 22, 0.55);
 }
 
+.idt-hero-layer-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.idt-hero-layer-dots {
+  display: inline-flex;
+  gap: 0.26rem;
+}
+
+.idt-hero-layer-dots button {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(162, 183, 216, 0.45);
+  background: rgba(111, 133, 173, 0.24);
+  padding: 0;
+  cursor: pointer;
+  transition: transform 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.idt-hero-layer-dots button:hover,
+.idt-hero-layer-dots button:focus-visible {
+  border-color: rgba(210, 223, 247, 0.86);
+  background: rgba(210, 223, 247, 0.42);
+}
+
+.idt-hero-layer-dots button.is-active {
+  background: rgba(226, 235, 250, 0.94);
+  border-color: rgba(226, 235, 250, 0.94);
+  transform: scale(1.08);
+}
+
 .idt-hero-graph-title {
   margin: 0;
   color: #dbe6ff;
   font-size: 0.74rem;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.04em;
   font-weight: 700;
 }
 
@@ -556,30 +607,43 @@ h3 {
   line-height: 1.4;
 }
 
+.idt-hero-capability-list {
+  margin: 0 0 0.8rem;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.32rem;
+}
+
+.idt-hero-capability-list li {
+  color: #c4d6f2;
+  font-size: 0.74rem;
+  line-height: 1.4;
+  position: relative;
+  padding-left: 0.84rem;
+}
+
+.idt-hero-capability-list li::before {
+  content: '';
+  width: 5px;
+  height: 5px;
+  border-radius: 999px;
+  background: rgba(196, 220, 255, 0.84);
+  position: absolute;
+  left: 0;
+  top: 0.42rem;
+}
+
 .idt-severity-high {
   color: var(--severity-high-fg);
   font-weight: 800;
 }
 
-@keyframes idtPulse {
-  0% {
-    transform: scale(0.6);
-    opacity: 0.4;
-  }
-  60% {
-    transform: scale(1.35);
-    opacity: 1;
-  }
-  100% {
-    transform: scale(1.9);
-    opacity: 0;
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
-  .idt-pulse {
+  .idt-hero-arrow {
     animation: none;
-    opacity: 0.7;
+    stroke-dasharray: none;
+    stroke-dashoffset: 0;
   }
 
   * {
@@ -2970,10 +3034,17 @@ body {
     padding: 0.85rem;
   }
 
+  .idt-graph-visual-live {
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+    padding: 0;
+  }
+
   .idt-graph-grid,
-  .idt-node,
-  .idt-edge,
-  .idt-pulse {
+  .idt-hero-layer,
+  .idt-hero-arrows,
+  .idt-node {
     display: none;
   }
 
@@ -3000,6 +3071,10 @@ body {
     margin: 0;
     width: 100%;
     background: linear-gradient(165deg, rgba(9, 13, 20, 0.97), rgba(12, 18, 28, 0.98));
+  }
+
+  .idt-hero-layer-dots {
+    display: none;
   }
 
   .idt-footer-super-cta {


### PR DESCRIPTION
## Summary\n- redesign hero right-side sample finding into a layered live display\n- rotate through multiple trust-path findings with active/dim transitions\n- add premium curved arrow connections between identity nodes\n\n## Validation\n- npm run build\n- npm run test -- --run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the hero finding into a layered, live trust-path display that rotates through multiple scenes with smooth transitions and curved arrow connections. Improves clarity of identity chains and adds manual controls and reduced-motion support.

- **New Features**
  - Layered scenes that auto-rotate every 4.4s with dot controls to switch manually.
  - Curved SVG arrows with gradient strokes, arrowheads, and animated flow with emphasis states.
  - Node theming by role (source, broker, workload, privilege, resource) and dim/blur transitions for inactive layers.
  - Accessibility: honors prefers-reduced-motion (pauses animations) and adds clear ARIA labels for scenes.
  - Dynamic caption content: title, summary, severity, hops, mode, ordered steps, and a capability list.

<sup>Written for commit 56a21532edf6651b29092c04009e51488358dabc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

