### PR TITLE
refactor(web): separate hero graph layers from finding panel

### DIFF
--- a/web/src/components/home/HeroProductReveal.tsx
+++ b/web/src/components/home/HeroProductReveal.tsx
@@ -180,8 +180,14 @@ export function HeroProductReveal() {
     () =>
       SCENES.map((scene, index) => {
         const isActive = index === activeSceneIndex;
+        const depth = isActive ? 0 : ((index - activeSceneIndex + SCENES.length) % SCENES.length);
         return (
-          <div key={scene.id} className={`idt-hero-layer ${isActive ? 'is-active' : 'is-dimmed'}`} aria-hidden={!isActive}>
+          <div
+            key={scene.id}
+            className={`idt-hero-layer ${isActive ? 'is-active' : 'is-dimmed'}`}
+            aria-hidden={!isActive}
+            data-depth={depth}
+          >
             <svg className="idt-hero-arrows" viewBox="0 0 100 100" preserveAspectRatio="none">
               <defs>
                 <linearGradient id={`idt-edge-gradient-${scene.id}`} x1="0%" y1="0%" x2="100%" y2="100%">
@@ -212,15 +218,18 @@ export function HeroProductReveal() {
               })}
             </svg>
 
-            {scene.nodes.map((node) => (
-              <div
-                key={`${scene.id}-${node.id}`}
-                className={`idt-node idt-node-${node.tone}`}
-                style={{ left: `${node.x}%`, top: `${node.y}%` }}
-              >
-                {node.label}
-              </div>
-            ))}
+            {isActive &&
+              scene.nodes.map((node) => (
+                <div
+                  key={`${scene.id}-${node.id}`}
+                  className={`idt-node idt-node-${node.tone}`}
+                  style={{ left: `${node.x}%`, top: `${node.y}%` }}
+                >
+                  {node.label}
+                </div>
+              ))}
+
+            {!isActive && <span className="idt-layer-ghost-label">{scene.label}</span>}
           </div>
         );
       }),
@@ -229,50 +238,54 @@ export function HeroProductReveal() {
 
   return (
     <div className="idt-graph-visual idt-graph-visual-live" aria-label="Live trust path product preview">
-      <div className="idt-graph-grid" />
-      {sceneLayers}
+      <div className="idt-hero-live-layout">
+        <div className="idt-hero-graph-canvas" aria-hidden="true">
+          <div className="idt-graph-grid" />
+          {sceneLayers}
+        </div>
 
-      <aside className="idt-hero-graph-caption idt-hero-proof-card">
-        <div className="idt-hero-layer-head">
-          <p className="idt-hero-graph-title">Live finding layer</p>
-          <div className="idt-hero-layer-dots" aria-label="Live scene steps">
-            {SCENES.map((scene, index) => (
-              <button
-                key={scene.id}
-                type="button"
-                className={index === activeSceneIndex ? 'is-active' : ''}
-                onClick={() => setActiveSceneIndex(index)}
-                aria-label={`Show ${scene.label}`}
-              />
-            ))}
+        <aside className="idt-hero-graph-caption idt-hero-proof-card">
+          <div className="idt-hero-layer-head">
+            <p className="idt-hero-graph-title">Live finding layer</p>
+            <div className="idt-hero-layer-dots" aria-label="Live scene steps">
+              {SCENES.map((scene, index) => (
+                <button
+                  key={scene.id}
+                  type="button"
+                  className={index === activeSceneIndex ? 'is-active' : ''}
+                  onClick={() => setActiveSceneIndex(index)}
+                  aria-label={`Show ${scene.label}`}
+                />
+              ))}
+            </div>
           </div>
-        </div>
 
-        <h3>{activeScene.findingTitle}</h3>
-        <p className="idt-hero-path">{activeScene.findingSummary}</p>
+          <h3>{activeScene.findingTitle}</h3>
+          <p className="idt-hero-path">{activeScene.findingSummary}</p>
 
-        <div className="idt-hero-proof-meta">
-          <span className="idt-severity-pill">{activeScene.severity}</span>
-          <span>{activeScene.hopsLabel}</span>
-          <span>{activeScene.modeLabel}</span>
-        </div>
+          <div className="idt-hero-proof-meta">
+            <span className="idt-severity-pill">{activeScene.severity}</span>
+            <span>{activeScene.hopsLabel}</span>
+            <span>{activeScene.modeLabel}</span>
+          </div>
 
-        <ol className="idt-hero-path-steps">
-          {activeScene.steps.map((step) => (
-            <li key={step}>{step}</li>
-          ))}
-        </ol>
+          <ol className="idt-hero-path-steps">
+            {activeScene.steps.map((step) => (
+              <li key={step}>{step}</li>
+            ))}
+          </ol>
 
-        <ul className="idt-hero-capability-list">
-          {activeScene.capabilities.map((capability) => (
-            <li key={capability}>{capability}</li>
-          ))}
-        </ul>
+          <ul className="idt-hero-capability-list">
+            {activeScene.capabilities.map((capability) => (
+              <li key={capability}>{capability}</li>
+            ))}
+          </ul>
 
-        <Link to="/demo" className="idt-inline-link">
-          Inspect this path in demo
-        </Link>
-      </aside>
+          <Link to="/demo" className="idt-inline-link">
+            Inspect this path in demo
+          </Link>
+        </aside>
+      </div>
     </div>
   );
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -441,7 +441,30 @@ h3 {
 }
 
 .idt-graph-visual-live {
+  display: grid;
+  min-height: 380px;
+  padding: 0.85rem;
   isolation: isolate;
+}
+
+.idt-hero-live-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.02fr) minmax(0, 0.98fr);
+  gap: 0.85rem;
+  min-height: 100%;
+}
+
+.idt-hero-graph-canvas {
+  position: relative;
+  min-height: 340px;
+  border: 1px solid rgba(163, 181, 214, 0.24);
+  border-radius: 14px;
+  background: linear-gradient(160deg, rgba(10, 15, 26, 0.72), rgba(8, 13, 23, 0.64));
+  overflow: hidden;
+}
+
+.idt-hero-graph-canvas .idt-graph-grid {
+  opacity: 0.2;
 }
 
 .idt-hero-layer {
@@ -458,10 +481,38 @@ h3 {
 }
 
 .idt-hero-layer.is-dimmed {
-  opacity: 0.14;
-  filter: blur(1px);
-  transform: scale(0.985);
+  opacity: 0.2;
+  filter: blur(0.9px) saturate(0.72);
+  transform: scale(0.92) translate3d(-10%, -6%, 0);
   z-index: 1;
+}
+
+.idt-hero-layer.is-dimmed[data-depth='2'] {
+  opacity: 0.1;
+  transform: scale(0.84) translate3d(-16%, -12%, 0);
+}
+
+.idt-hero-layer.is-dimmed .idt-hero-arrow {
+  stroke-dasharray: 1.2 2.2;
+}
+
+.idt-layer-ghost-label {
+  position: absolute;
+  left: 0.8rem;
+  top: 0.8rem;
+  border: 1px solid rgba(176, 194, 226, 0.34);
+  border-radius: 999px;
+  background: rgba(11, 18, 29, 0.66);
+  color: rgba(193, 209, 235, 0.86);
+  padding: 0.18rem 0.5rem;
+  font-size: 0.62rem;
+  letter-spacing: 0.04em;
+  pointer-events: none;
+  text-transform: uppercase;
+}
+
+.idt-hero-layer[data-depth='2'] .idt-layer-ghost-label {
+  top: 1.45rem;
 }
 
 .idt-node {
@@ -539,11 +590,9 @@ h3 {
 }
 
 .idt-hero-graph-caption {
-  position: absolute;
-  right: 0.85rem;
-  bottom: 0.85rem;
-  z-index: 3;
-  width: min(100% - 1.7rem, 420px);
+  position: relative;
+  z-index: 2;
+  width: 100%;
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 14px;
   background: linear-gradient(165deg, rgba(8, 8, 10, 0.95), rgba(14, 14, 17, 0.96));
@@ -2970,6 +3019,14 @@ body {
     min-height: 380px;
   }
 
+  .idt-hero-live-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-hero-graph-canvas {
+    min-height: 300px;
+  }
+
   .idt-benefits-row {
     grid-template-columns: 1fr;
   }
@@ -3087,7 +3144,13 @@ body {
     padding: 0;
   }
 
+  .idt-hero-live-layout {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+
   .idt-graph-grid,
+  .idt-hero-graph-canvas,
   .idt-hero-layer,
   .idt-hero-arrows,
   .idt-node {


### PR DESCRIPTION
## Summary\n- separate hero graph canvas and finding panel to prevent overlap\n- restack inactive layers with depth offsets and ghost labels\n- keep mobile fallback clean and non-obstructive\n\n## Validation\n- npm run build\n- npm run test -- --run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separated the hero graph canvas from the finding panel to prevent overlap and reduce visual clutter. Inactive scenes now stack with depth offsets and ghost labels, while the layout stays mobile-friendly.

- **Refactors**
  - Added a grid layout to split the graph (`.idt-hero-graph-canvas`) and the caption card; removed overlapping absolute positioning.
  - Introduced `data-depth` on layers with transforms/opacity and dashed arrows for inactive scenes.
  - Rendered node elements only for the active scene; added a small ghost label for inactive layers.
  - Switched the caption to a relative, full-width card and refined canvas borders/background.
  - Added responsive rules to stack on small screens; set `aria-hidden="true"` on the canvas to reduce screen reader noise.

<sup>Written for commit 53badaa36ceb8e95c1ffe23de0f0949ae3518dd3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

