### PR TITLE
feat(web): add premium light and dark theme toggle

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -35,8 +35,27 @@ const DISCORD_URL = 'https://discord.gg/7jSUSnQC';
 const LINKEDIN_URL = 'https://www.linkedin.com/company/identrail/';
 const X_URL = 'https://x.com/identrail';
 const CALENDLY_URL = 'https://calendly.com/identrail/15min';
+const THEME_STORAGE_KEY = 'identrail-theme';
 let activeModalLocks = 0;
 let bodyOverflowBeforeModal = '';
+type ThemeMode = 'dark' | 'light';
+
+function resolveInitialTheme(): ThemeMode {
+  if (typeof window === 'undefined') {
+    return 'dark';
+  }
+
+  const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+  if (stored === 'dark' || stored === 'light') {
+    return stored;
+  }
+
+  if (typeof window.matchMedia === 'function') {
+    return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+  }
+
+  return 'dark';
+}
 
 const NAV_LINKS = [
   { to: '/product', label: 'Product' },
@@ -2785,6 +2804,12 @@ function NotFoundPage() {
 
 export function RoutedSite() {
   useAnalytics();
+  const [theme, setTheme] = useState<ThemeMode>(resolveInitialTheme);
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+  }, [theme]);
 
   return (
     <div className="idt-site">
@@ -2792,7 +2817,12 @@ export function RoutedSite() {
         Skip to content
       </a>
 
-      <Header navLinks={NAV_LINKS} githubRepo={GITHUB_REPO} />
+      <Header
+        navLinks={NAV_LINKS}
+        githubRepo={GITHUB_REPO}
+        theme={theme}
+        onToggleTheme={() => setTheme((current) => (current === 'dark' ? 'light' : 'dark'))}
+      />
 
       <main id="main-content">
         <Routes>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -45,7 +45,12 @@ function resolveInitialTheme(): ThemeMode {
     return 'dark';
   }
 
-  const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+  let stored: string | null = null;
+  try {
+    stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+  } catch {
+    return 'dark';
+  }
   if (stored === 'dark' || stored === 'light') {
     return stored;
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -49,7 +49,7 @@ function resolveInitialTheme(): ThemeMode {
   try {
     stored = window.localStorage.getItem(THEME_STORAGE_KEY);
   } catch {
-    return 'dark';
+    stored = null;
   }
   if (stored === 'dark' || stored === 'light') {
     return stored;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2813,7 +2813,11 @@ export function RoutedSite() {
 
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
-    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    } catch {
+      // Ignore storage write failures (blocked/disabled storage).
+    }
   }, [theme]);
 
   return (

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -9,10 +9,14 @@ type NavLinkItem = {
 
 export function Header({
   navLinks,
-  githubRepo
+  githubRepo,
+  theme,
+  onToggleTheme
 }: {
   navLinks: readonly NavLinkItem[];
   githubRepo: string;
+  theme: 'dark' | 'light';
+  onToggleTheme: () => void;
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const location = useLocation();
@@ -73,6 +77,31 @@ export function Header({
         </nav>
 
         <div className="idt-header-actions">
+          <button
+            type="button"
+            className={`idt-theme-toggle ${theme === 'light' ? 'is-light' : ''}`}
+            onClick={onToggleTheme}
+            aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+            title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+          >
+            {theme === 'dark' ? (
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  fill="currentColor"
+                  d="M6.76 4.84 5.35 3.43 3.93 4.84l1.42 1.41 1.41-1.41Zm10.49 0 1.41-1.41 1.41 1.41-1.41 1.41-1.41-1.41ZM12 4h1V1h-2v3h1Zm7 9h3v-2h-3v2Zm-7 7h1v3h-2v-3h1ZM2 13h3v-2H2v2Zm3.34 6.57 1.41 1.41 1.41-1.41-1.41-1.41-1.41 1.41Zm13.31 1.41 1.41-1.41-1.41-1.41-1.41 1.41 1.41 1.41ZM12 6a6 6 0 1 0 0 12 6 6 0 0 0 0-12Z"
+                />
+              </svg>
+            ) : (
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  fill="currentColor"
+                  d="M20.74 15.35A9.6 9.6 0 0 1 8.65 3.26a.75.75 0 0 0-.92-.93A10.98 10.98 0 1 0 21.67 16.27a.75.75 0 0 0-.93-.92Z"
+                />
+              </svg>
+            )}
+            <span>{theme === 'dark' ? 'Light' : 'Dark'}</span>
+          </button>
+
           <Link to="/read-only-scan" className="idt-btn idt-btn-primary" data-ab-slot="header_primary_cta">
             Start Free Risk Scan
           </Link>

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -11,7 +11,13 @@ function applyInitialTheme() {
     return;
   }
 
-  const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+  const stored = (() => {
+    try {
+      return window.localStorage.getItem(THEME_STORAGE_KEY);
+    } catch {
+      return null;
+    }
+  })();
   const preferredBySystem =
     typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: light)').matches
       ? 'light'

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,6 +4,25 @@ import { App } from './App';
 import './styles/tokens.css';
 import './styles.css';
 
+const THEME_STORAGE_KEY = 'identrail-theme';
+
+function applyInitialTheme() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+  const preferredBySystem =
+    typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: light)').matches
+      ? 'light'
+      : 'dark';
+  const preferred = stored === 'dark' || stored === 'light' ? stored : preferredBySystem;
+
+  document.documentElement.dataset.theme = preferred;
+}
+
+applyInitialTheme();
+
 createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <App />

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -137,6 +137,36 @@ a {
   align-items: center;
 }
 
+.idt-theme-toggle {
+  border: 1px solid rgba(160, 178, 209, 0.32);
+  background: rgba(14, 19, 31, 0.72);
+  color: #dfe9fb;
+  border-radius: 999px;
+  min-height: 40px;
+  padding: 0 0.74rem 0 0.64rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+  font-size: 0.73rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: border-color 0.18s ease, background-color 0.18s ease, color 0.18s ease;
+}
+
+.idt-theme-toggle svg {
+  width: 14px;
+  height: 14px;
+  flex: none;
+}
+
+.idt-theme-toggle:hover,
+.idt-theme-toggle:focus-visible {
+  border-color: rgba(205, 218, 239, 0.66);
+  background: rgba(26, 36, 57, 0.82);
+  color: #f2f7ff;
+}
+
 .idt-btn {
   border: 1px solid transparent;
   text-decoration: none;
@@ -2897,6 +2927,115 @@ body {
   letter-spacing: 0;
 }
 
+html[data-theme='light'] body {
+  background:
+    radial-gradient(circle at 78% -18%, rgba(76, 105, 164, 0.16), transparent 40%),
+    radial-gradient(circle at 8% 14%, rgba(90, 122, 183, 0.11), transparent 30%),
+    var(--idt-bg);
+}
+
+html[data-theme='light'] .idt-header {
+  background: rgba(246, 249, 254, 0.92);
+  border-bottom-color: rgba(19, 33, 58, 0.12);
+}
+
+html[data-theme='light'] .idt-nav a {
+  color: #44516a;
+}
+
+html[data-theme='light'] .idt-nav a:hover,
+html[data-theme='light'] .idt-nav a:focus-visible,
+html[data-theme='light'] .idt-nav a.is-active {
+  color: #121e35;
+  background: rgba(35, 55, 94, 0.08);
+  border-color: rgba(26, 44, 78, 0.2);
+}
+
+html[data-theme='light'] .idt-btn-primary {
+  color: #eef3ff;
+  border-color: rgba(9, 20, 38, 0.18);
+  box-shadow: 0 10px 24px rgba(30, 48, 88, 0.2);
+}
+
+html[data-theme='light'] .idt-btn-dark,
+html[data-theme='light'] .idt-btn-ghost {
+  color: #1c2a47;
+  background: rgba(255, 255, 255, 0.86);
+  border-color: rgba(16, 29, 50, 0.18);
+}
+
+html[data-theme='light'] .idt-header-utility {
+  color: #304260;
+}
+
+html[data-theme='light'] .idt-theme-toggle {
+  color: #1a2a46;
+  border-color: rgba(18, 33, 59, 0.22);
+  background: rgba(255, 255, 255, 0.86);
+}
+
+html[data-theme='light'] .idt-theme-toggle:hover,
+html[data-theme='light'] .idt-theme-toggle:focus-visible {
+  background: rgba(232, 238, 249, 0.9);
+}
+
+html[data-theme='light'] .idt-card,
+html[data-theme='light'] .idt-pricing-card,
+html[data-theme='light'] .idt-lead-form,
+html[data-theme='light'] .idt-roi,
+html[data-theme='light'] .idt-demo-sidebar,
+html[data-theme='light'] .idt-demo-graph,
+html[data-theme='light'] .idt-demo-list-view,
+html[data-theme='light'] .idt-graph-visual,
+html[data-theme='light'] .idt-hero-graph-caption {
+  background: rgba(255, 255, 255, 0.86);
+  border-color: rgba(16, 29, 50, 0.14);
+  box-shadow: 0 10px 26px rgba(34, 52, 90, 0.14);
+}
+
+html[data-theme='light'] .idt-trust-strip {
+  background: rgba(245, 248, 253, 0.88);
+  border-top-color: rgba(17, 30, 52, 0.12);
+  border-bottom-color: rgba(17, 30, 52, 0.12);
+}
+
+html[data-theme='light'] .idt-proof-link {
+  color: #21345a;
+}
+
+html[data-theme='light'] .idt-hero-trust-cues li,
+html[data-theme='light'] .idt-risk-path-list li,
+html[data-theme='light'] .idt-hero-proof-meta span:not(.idt-severity-pill),
+html[data-theme='light'] .idt-adoption-card,
+html[data-theme='light'] .idt-workflow-output {
+  background: rgba(243, 247, 255, 0.9);
+  border-color: rgba(19, 33, 58, 0.18);
+  color: #2a3d61;
+}
+
+html[data-theme='light'] .idt-node {
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.95), rgba(244, 248, 255, 0.92));
+  color: #1b2e4d;
+}
+
+html[data-theme='light'] .idt-footer-bar {
+  background: #edf2f9;
+  color: #13213b;
+  border-top-color: rgba(19, 33, 58, 0.14);
+}
+
+html[data-theme='light'] .idt-social-link {
+  color: #13213b;
+  border-color: rgba(20, 34, 59, 0.22);
+  background: rgba(245, 249, 255, 0.86);
+}
+
+html[data-theme='light'] .idt-inline-link,
+html[data-theme='light'] .idt-footer-links a,
+html[data-theme='light'] .idt-footer-trust-links a {
+  color: #1a2b49;
+}
+
 @media (max-width: 1080px) {
   .idt-header-row {
     grid-template-columns: auto auto;
@@ -3017,7 +3156,8 @@ body {
   }
 
   .idt-inline-actions .idt-btn,
-  .idt-header-actions .idt-btn {
+  .idt-header-actions .idt-btn,
+  .idt-theme-toggle {
     width: 100%;
   }
 
@@ -3041,6 +3181,10 @@ body {
     width: 100%;
     display: grid;
     grid-template-columns: 1fr;
+  }
+
+  .idt-theme-toggle {
+    justify-content: center;
   }
 
   .idt-header-actions .idt-btn-dark {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3024,6 +3024,10 @@ html[data-theme='light'] .idt-footer-bar {
   border-top-color: rgba(19, 33, 58, 0.14);
 }
 
+html[data-theme='light'] .idt-footer-meta small {
+  color: #304260;
+}
+
 html[data-theme='light'] .idt-social-link {
   color: #13213b;
   border-color: rgba(20, 34, 59, 0.22);

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -80,3 +80,39 @@
   --idt-shell: var(--shell-max-width);
   --idt-shadow: var(--shadow-elevated);
 }
+
+:root[data-theme='light'] {
+  color-scheme: light;
+
+  --color-neutral-950: #f3f6fb;
+  --color-neutral-925: #ffffff;
+  --color-neutral-900: #eef2f9;
+  --color-neutral-100: #0f1729;
+  --color-neutral-300: #44516a;
+
+  --color-blue-100: #12203c;
+  --color-blue-200: #1f335d;
+  --color-blue-300: #304778;
+  --color-blue-500-a12: rgba(30, 55, 103, 0.09);
+  --color-blue-600-a32: rgba(48, 71, 120, 0.2);
+
+  --color-line: rgba(16, 26, 45, 0.14);
+  --color-white-strong: rgba(255, 255, 255, 0.95);
+  --color-black-shadow: rgba(10, 22, 43, 0.16);
+
+  --color-risk-high-fg: #9f2222;
+  --color-risk-high-pill-fg: #b03232;
+  --color-risk-high-pill-bg: rgba(218, 103, 103, 0.16);
+
+  --surface-canvas: linear-gradient(180deg, #f5f8fc 0%, #edf2f9 100%);
+  --surface-elevated: #ffffff;
+  --surface-soft: #f2f5fb;
+  --text-primary: #111c31;
+  --text-muted: #4a5871;
+  --border-subtle: rgba(17, 29, 51, 0.16);
+  --accent-primary: #112141;
+  --accent-soft: rgba(40, 65, 112, 0.1);
+  --glow-soft: rgba(64, 92, 146, 0.2);
+  --cta-primary: linear-gradient(120deg, #0f1f3a 0%, #1a2d52 100%);
+  --focus-ring: rgba(36, 58, 102, 0.55);
+}


### PR DESCRIPTION
## Summary\n- add a minimal theme switcher in header with persistent selection\n- bootstrap theme on initial load to avoid flicker\n- add light-mode design tokens and focused contrast overrides\n\n## Validation\n- npm run build\n- npm run test -- --run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a light/dark theme toggle in the header with persistent selection and no initial page flicker. Expands light-theme tokens and UI styles with system preference detection and safe storage fallbacks.

- **New Features**
  - Header theme toggle with icons, text label, accessible titles, and mobile-friendly styles.
  - Theme state lives in `App` with SSR-safe `resolveInitialTheme`; syncs `document.documentElement.dataset.theme` and persists `identrail-theme` to `localStorage` with try/catch.
  - `main.tsx` sets the initial theme before React mounts from storage or `prefers-color-scheme`; falls back to dark.
  - Added `:root[data-theme='light']` tokens in `tokens.css` (sets `color-scheme: light`) and broad light-mode overrides across header, buttons, cards, surfaces, footer, lists, graphs, and forms, plus `.idt-theme-toggle` styles with hover/focus and responsive behavior.

<sup>Written for commit 99a5ab48eb4107f4f24e5fd97383710ed6eee1a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

