### PR TITLE
fix(web): premium polish pass for hero, graph, and spacing

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -759,32 +759,50 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
       id: 'oidc',
       type: 'Broker',
       title: 'OIDC Provider',
-      detail: 'Federated identity provider trusted by CI/CD and cluster workloads.'
+      detail: 'Federated identity provider trusted by CI/CD and cluster workloads.',
+      x: 14,
+      y: 12
     },
     {
       id: 'role',
       type: 'Privilege',
       title: 'AWS Role: payments-prod',
-      detail: 'Role assumed by automation workloads with cross-account permissions.'
+      detail: 'Role assumed by automation workloads with cross-account permissions.',
+      x: 58,
+      y: 32
     },
     {
       id: 'sa',
       type: 'Workload',
       title: 'K8s ServiceAccount: api-gateway',
-      detail: 'Service account with namespace-level and cloud trust-path reachability.'
+      detail: 'Service account with namespace-level and cloud trust-path reachability.',
+      x: 28,
+      y: 58
     },
     {
       id: 'repo',
       type: 'Source',
       title: 'Git Repo: infra-live',
-      detail: 'Repository contains deployment workflows and secrets exposure history.'
+      detail: 'Repository contains deployment workflows and secrets exposure history.',
+      x: 54,
+      y: 80
     },
     {
       id: 'db',
       type: 'Resource',
       title: 'RDS Resource: billing-ledger',
-      detail: 'Sensitive resource reachable through chained assumptions in current policy state.'
+      detail: 'Sensitive resource reachable through chained assumptions in current policy state.',
+      x: 30,
+      y: 92
     }
+  ] as const;
+
+  const edges = [
+    { id: 'e-oidc-role', from: 'oidc', to: 'role' },
+    { id: 'e-oidc-sa', from: 'oidc', to: 'sa' },
+    { id: 'e-sa-role', from: 'sa', to: 'role' },
+    { id: 'e-sa-repo', from: 'sa', to: 'repo' },
+    { id: 'e-repo-db', from: 'repo', to: 'db' }
   ] as const;
 
   const [selectedId, setSelectedId] = useState<string>('role');
@@ -794,6 +812,24 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
   const listTabId = `trust-list-tab-${variant}`;
   const graphPanelId = `trust-graph-panel-${variant}`;
   const listPanelId = `trust-list-panel-${variant}`;
+
+  const getNode = (id: (typeof nodes)[number]['id']) => nodes.find((node) => node.id === id);
+  const edgePath = (fromId: (typeof nodes)[number]['id'], toId: (typeof nodes)[number]['id']) => {
+    const from = getNode(fromId);
+    const to = getNode(toId);
+    if (!from || !to) {
+      return '';
+    }
+
+    const mx = (from.x + to.x) / 2;
+    const my = (from.y + to.y) / 2;
+    const bend = Math.max(6, Math.min(14, Math.abs(to.x - from.x) * 0.18));
+    const cx = mx + (to.y - from.y) * 0.05;
+    const cy = my - bend;
+    return `M ${from.x} ${from.y} Q ${cx} ${cy} ${to.x} ${to.y}`;
+  };
+
+  const connectedEdges = edges.filter((edge) => edge.from === selected.id || edge.to === selected.id);
 
   return (
     <section className={`idt-demo-surface ${variant === 'full' ? 'is-full' : ''}`}>
@@ -835,21 +871,45 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
 
       {viewMode === 'graph' ? (
         <div id={graphPanelId} role="tabpanel" aria-labelledby={graphTabId} className="idt-demo-graph" aria-label="Interactive trust graph simulation">
+          <svg className="idt-demo-edges" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
+            <defs>
+              <linearGradient id={`idt-demo-edge-gradient-${variant}`} x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stopColor="rgba(162, 188, 245, 0.22)" />
+                <stop offset="50%" stopColor="rgba(160, 192, 255, 0.88)" />
+                <stop offset="100%" stopColor="rgba(138, 170, 231, 0.2)" />
+              </linearGradient>
+            </defs>
+            {edges.map((edge, index) => {
+              const path = edgePath(edge.from, edge.to);
+              if (!path) {
+                return null;
+              }
+
+              const isConnected = connectedEdges.some((item) => item.id === edge.id);
+              const edgeClass = isConnected ? 'is-connected' : '';
+              return (
+                <g key={edge.id} className={edgeClass}>
+                  <path className="idt-demo-edge-glow" d={path} stroke={`url(#idt-demo-edge-gradient-${variant})`} />
+                  <path className="idt-demo-edge-path" d={path} stroke={`url(#idt-demo-edge-gradient-${variant})`} />
+                  <circle className="idt-demo-edge-tracer" r="1.1">
+                    <animateMotion dur={`${4.8 + index * 0.7}s`} repeatCount="indefinite" path={path} />
+                  </circle>
+                </g>
+              );
+            })}
+          </svg>
           {nodes.map((node) => (
             <button
               key={node.id}
               type="button"
               className={`idt-demo-node idt-demo-node-${node.type.toLowerCase()} ${selected.id === node.id ? 'is-active' : ''}`}
               onClick={() => setSelectedId(node.id)}
+              style={{ left: `${node.x}%`, top: `${node.y}%` }}
             >
               <small>{node.type}</small>
               <span>{node.title}</span>
             </button>
           ))}
-          <span className="idt-demo-connector c1" />
-          <span className="idt-demo-connector c2" />
-          <span className="idt-demo-connector c3" />
-          <span className="idt-demo-connector c4" />
         </div>
       ) : (
         <div id={listPanelId} role="tabpanel" aria-labelledby={listTabId} className="idt-demo-list-view" aria-label="Trust path nodes">
@@ -1261,7 +1321,7 @@ function HomePage() {
 
       <ProblemFramingSection />
 
-      <section className="idt-section idt-shell">
+      <section className="idt-section idt-section-tight idt-shell">
         <LeadCaptureForm
           id="risk-scan-form"
           variant="short"
@@ -1273,7 +1333,7 @@ function HomePage() {
 
       <RiskInsightSection />
 
-      <section className="idt-section idt-shell">
+      <section className="idt-section idt-shell idt-section-demo">
         <div className="idt-card idt-proof-demo-card">
           <h3>Interactive trust graph explorer</h3>
           <p>
@@ -1328,7 +1388,7 @@ function HomePage() {
           <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
             Start Free Risk Scan
           </Link>
-          <Link to="/enterprise" className="idt-inline-link">
+          <Link to="/enterprise" className="idt-final-cta-link">
             Need enterprise procurement? Contact Sales →
           </Link>
         </div>

--- a/web/src/components/home/HeroProductReveal.tsx
+++ b/web/src/components/home/HeroProductReveal.tsx
@@ -154,8 +154,12 @@ function edgePath(from: HeroNode, to: HeroNode) {
   const startY = from.y;
   const endX = to.x;
   const endY = to.y;
-  const controlX = (startX + endX) / 2;
-  const controlY = Math.min(startY, endY) - 8;
+  const midpointX = (startX + endX) / 2;
+  const midpointY = (startY + endY) / 2;
+  const distanceX = Math.abs(endX - startX);
+  const lift = Math.max(7, Math.min(16, distanceX * 0.2));
+  const controlX = midpointX + (endY - startY) * 0.08;
+  const controlY = midpointY - lift;
   return `M ${startX} ${startY} Q ${controlX} ${controlY} ${endX} ${endY}`;
 }
 
@@ -176,72 +180,64 @@ export function HeroProductReveal() {
     return () => window.clearInterval(timer);
   }, [reducedMotion]);
 
-  const sceneLayers = useMemo(
-    () =>
-      SCENES.map((scene, index) => {
-        const isActive = index === activeSceneIndex;
-        const depth = isActive ? 0 : ((index - activeSceneIndex + SCENES.length) % SCENES.length);
-        return (
+  const sceneLayer = useMemo(() => {
+    const scene = activeScene;
+    return (
+      <div key={scene.id} className="idt-hero-layer is-active">
+        <svg className="idt-hero-arrows" viewBox="0 0 100 100" preserveAspectRatio="none">
+          <defs>
+            <linearGradient id={`idt-edge-gradient-${scene.id}`} x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stopColor="rgba(168, 196, 255, 0.12)" />
+              <stop offset="44%" stopColor="rgba(160, 193, 255, 0.82)" />
+              <stop offset="100%" stopColor="rgba(138, 172, 238, 0.2)" />
+            </linearGradient>
+          </defs>
+
+          {scene.edges.map((edge, edgeIndex) => {
+            const from = findNode(scene.nodes, edge.from);
+            const to = findNode(scene.nodes, edge.to);
+            if (!from || !to) {
+              return null;
+            }
+
+            const path = edgePath(from, to);
+            const tracerDuration = 4 + edgeIndex * 0.65;
+
+            return (
+              <g key={`${scene.id}-${edge.from}-${edge.to}`} className={edge.emphasis === 'high' ? 'is-high' : ''}>
+                <path className="idt-hero-arrow-glow" d={path} stroke={`url(#idt-edge-gradient-${scene.id})`} />
+                <path className="idt-hero-arrow" d={path} stroke={`url(#idt-edge-gradient-${scene.id})`} />
+                {!reducedMotion ? (
+                  <circle className="idt-hero-arrow-tracer" r="1.2">
+                    <animateMotion dur={`${tracerDuration}s`} repeatCount="indefinite" path={path} />
+                  </circle>
+                ) : null}
+              </g>
+            );
+          })}
+        </svg>
+
+        {scene.nodes.map((node) => (
           <div
-            key={scene.id}
-            className={`idt-hero-layer ${isActive ? 'is-active' : 'is-dimmed'}`}
-            aria-hidden={!isActive}
-            data-depth={depth}
+            key={`${scene.id}-${node.id}`}
+            className={`idt-node idt-node-${node.tone}`}
+            style={{ left: `${node.x}%`, top: `${node.y}%` }}
           >
-            <svg className="idt-hero-arrows" viewBox="0 0 100 100" preserveAspectRatio="none">
-              <defs>
-                <linearGradient id={`idt-edge-gradient-${scene.id}`} x1="0%" y1="0%" x2="100%" y2="100%">
-                  <stop offset="0%" stopColor="rgba(170, 197, 255, 0.25)" />
-                  <stop offset="45%" stopColor="rgba(152, 186, 255, 0.82)" />
-                  <stop offset="100%" stopColor="rgba(119, 160, 241, 0.24)" />
-                </linearGradient>
-                <marker id={`idt-arrow-head-${scene.id}`} markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto-start-reverse">
-                  <path d="M0,0 L8,4 L0,8 Z" fill="rgba(162, 191, 252, 0.88)" />
-                </marker>
-              </defs>
-              {scene.edges.map((edge) => {
-                const from = findNode(scene.nodes, edge.from);
-                const to = findNode(scene.nodes, edge.to);
-                if (!from || !to) {
-                  return null;
-                }
-
-                return (
-                  <path
-                    key={`${scene.id}-${edge.from}-${edge.to}`}
-                    className={`idt-hero-arrow ${edge.emphasis === 'high' ? 'is-high' : ''}`}
-                    d={edgePath(from, to)}
-                    stroke={`url(#idt-edge-gradient-${scene.id})`}
-                    markerEnd={`url(#idt-arrow-head-${scene.id})`}
-                  />
-                );
-              })}
-            </svg>
-
-            {isActive &&
-              scene.nodes.map((node) => (
-                <div
-                  key={`${scene.id}-${node.id}`}
-                  className={`idt-node idt-node-${node.tone}`}
-                  style={{ left: `${node.x}%`, top: `${node.y}%` }}
-                >
-                  {node.label}
-                </div>
-              ))}
-
-            {!isActive && <span className="idt-layer-ghost-label">{scene.label}</span>}
+            {node.label}
           </div>
-        );
-      }),
-    [activeSceneIndex]
-  );
+        ))}
+      </div>
+    );
+  }, [activeScene, reducedMotion]);
 
   return (
     <div className="idt-graph-visual idt-graph-visual-live" aria-label="Live trust path product preview">
       <div className="idt-hero-live-layout">
         <div className="idt-hero-graph-canvas" aria-hidden="true">
           <div className="idt-graph-grid" />
-          {sceneLayers}
+          <div className="idt-hero-graph-plane idt-hero-graph-plane-back" />
+          <div className="idt-hero-graph-plane idt-hero-graph-plane-mid" />
+          {sceneLayer}
         </div>
 
         <aside className="idt-hero-graph-caption idt-hero-proof-card">

--- a/web/src/components/home/HowItWorksSection.tsx
+++ b/web/src/components/home/HowItWorksSection.tsx
@@ -23,7 +23,7 @@ const WORKFLOW_STEPS = [
 
 export function HowItWorksSection() {
   return (
-    <section className="idt-section idt-shell" aria-labelledby="workflow-title">
+    <section className="idt-section idt-shell idt-workflow-section" aria-labelledby="workflow-title">
       <div className="idt-section-title">
         <p className="idt-eyebrow">Operational Workflow</p>
         <h2 id="workflow-title">From read-only discovery to safe enforcement</h2>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -736,6 +736,10 @@ h3 {
     stroke-dashoffset: 0;
   }
 
+  .idt-hero-arrow-tracer {
+    display: none;
+  }
+
   .idt-demo-edge-path {
     animation: none;
     stroke-dasharray: none;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -459,60 +459,45 @@ h3 {
   min-height: 340px;
   border: 1px solid rgba(163, 181, 214, 0.24);
   border-radius: 14px;
-  background: linear-gradient(160deg, rgba(10, 15, 26, 0.72), rgba(8, 13, 23, 0.64));
+  background: linear-gradient(160deg, rgba(10, 15, 26, 0.86), rgba(8, 13, 23, 0.78));
   overflow: hidden;
 }
 
 .idt-hero-graph-canvas .idt-graph-grid {
+  opacity: 0.23;
+}
+
+.idt-hero-graph-plane {
+  position: absolute;
+  border: 1px solid rgba(157, 183, 221, 0.16);
+  border-radius: 12px;
+  pointer-events: none;
+}
+
+.idt-hero-graph-plane-back {
+  inset: 0.7rem 0.6rem 0.7rem 0.9rem;
+  opacity: 0.34;
+}
+
+.idt-hero-graph-plane-mid {
+  inset: 1.2rem 1rem 1rem 1.35rem;
   opacity: 0.2;
 }
 
 .idt-hero-layer {
   position: absolute;
-  inset: 0;
-  transition: opacity 0.55s ease, filter 0.55s ease, transform 0.55s ease;
+  inset: 1.55rem 1.2rem 1.2rem 1.55rem;
+  transition: opacity 0.45s ease;
 }
 
 .idt-hero-layer.is-active {
   opacity: 1;
-  filter: blur(0);
-  transform: scale(1);
   z-index: 2;
 }
 
 .idt-hero-layer.is-dimmed {
-  opacity: 0.2;
-  filter: blur(0.9px) saturate(0.72);
-  transform: scale(0.92) translate3d(-10%, -6%, 0);
+  opacity: 0;
   z-index: 1;
-}
-
-.idt-hero-layer.is-dimmed[data-depth='2'] {
-  opacity: 0.1;
-  transform: scale(0.84) translate3d(-16%, -12%, 0);
-}
-
-.idt-hero-layer.is-dimmed .idt-hero-arrow {
-  stroke-dasharray: 1.2 2.2;
-}
-
-.idt-layer-ghost-label {
-  position: absolute;
-  left: 0.8rem;
-  top: 0.8rem;
-  border: 1px solid rgba(176, 194, 226, 0.34);
-  border-radius: 999px;
-  background: rgba(11, 18, 29, 0.66);
-  color: rgba(193, 209, 235, 0.86);
-  padding: 0.18rem 0.5rem;
-  font-size: 0.62rem;
-  letter-spacing: 0.04em;
-  pointer-events: none;
-  text-transform: uppercase;
-}
-
-.idt-hero-layer[data-depth='2'] .idt-layer-ghost-label {
-  top: 1.45rem;
 }
 
 .idt-node {
@@ -521,14 +506,14 @@ h3 {
   transform: translate(-50%, -50%);
   border-radius: 999px;
   border: 1px solid rgba(210, 225, 255, 0.34);
-  background: linear-gradient(150deg, rgba(21, 28, 44, 0.92), rgba(11, 16, 27, 0.9));
+  background: linear-gradient(150deg, rgba(21, 30, 47, 0.96), rgba(11, 16, 27, 0.94));
   color: #eaf0ff;
-  padding: 0.38rem 0.7rem;
+  padding: 0.4rem 0.72rem;
   font-size: 0.64rem;
   font-weight: 600;
   letter-spacing: 0.03em;
   text-transform: none;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 8px 18px rgba(3, 7, 18, 0.34);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 10px 24px rgba(3, 7, 18, 0.3);
   white-space: nowrap;
 }
 
@@ -563,21 +548,34 @@ h3 {
 
 .idt-hero-arrow {
   fill: none;
-  stroke-width: 1.45;
-  opacity: 0.78;
+  stroke-width: 1.16;
+  opacity: 0.74;
   stroke-linecap: round;
-  stroke-dasharray: 1.8 1.4;
-  animation: idtArrowFlow 4.2s linear infinite;
-  filter: drop-shadow(0 0 6px rgba(117, 162, 246, 0.35));
+  stroke-dasharray: 5 9;
+  animation: idtArrowFlow 3s linear infinite;
 }
 
-.idt-hero-arrow.is-high {
-  stroke-width: 1.85;
-  opacity: 0.95;
+.idt-hero-arrow-glow {
+  fill: none;
+  stroke-width: 1.9;
+  opacity: 0.18;
+  filter: blur(0.5px);
 }
 
-.idt-hero-layer.is-dimmed .idt-hero-arrow {
-  animation-play-state: paused;
+.idt-hero-arrows g.is-high .idt-hero-arrow {
+  stroke-width: 1.45;
+  opacity: 0.88;
+  stroke-dasharray: 6 8;
+}
+
+.idt-hero-arrows g.is-high .idt-hero-arrow-glow {
+  opacity: 0.22;
+}
+
+.idt-hero-arrow-tracer {
+  fill: rgba(210, 227, 255, 0.95);
+  opacity: 0.66;
+  filter: drop-shadow(0 0 4px rgba(162, 194, 249, 0.52));
 }
 
 @keyframes idtArrowFlow {
@@ -585,7 +583,7 @@ h3 {
     stroke-dashoffset: 0;
   }
   to {
-    stroke-dashoffset: -14;
+    stroke-dashoffset: -24;
   }
 }
 
@@ -596,8 +594,8 @@ h3 {
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 14px;
   background: linear-gradient(165deg, rgba(8, 8, 10, 0.95), rgba(14, 14, 17, 0.96));
-  padding: 0.9rem;
-  box-shadow: 0 20px 40px rgba(1, 8, 22, 0.55);
+  padding: 1rem;
+  box-shadow: 0 18px 36px rgba(1, 8, 22, 0.42);
 }
 
 .idt-hero-layer-head {
@@ -736,6 +734,16 @@ h3 {
     animation: none;
     stroke-dasharray: none;
     stroke-dashoffset: 0;
+  }
+
+  .idt-demo-edge-path {
+    animation: none;
+    stroke-dasharray: none;
+    stroke-dashoffset: 0;
+  }
+
+  .idt-demo-edge-tracer {
+    display: none;
   }
 
   * {
@@ -1015,80 +1023,74 @@ h3 {
 
 .idt-demo-node {
   position: absolute;
-  border-radius: 999px;
-  border: 1px solid rgba(215, 227, 255, 0.36);
-  background: rgba(255, 255, 255, 0.06);
+  transform: translate(-50%, -50%);
+  border-radius: 12px;
+  border: 1px solid rgba(187, 206, 241, 0.32);
+  background: linear-gradient(140deg, rgba(13, 22, 38, 0.84), rgba(10, 17, 30, 0.92));
   color: #dce6ff;
   font-weight: 600;
-  padding: 0.5rem 0.9rem;
+  padding: 0.5rem 0.82rem;
   cursor: pointer;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  text-transform: none;
+  font-size: 0.66rem;
+  text-align: left;
+  min-width: 140px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03), 0 8px 18px rgba(2, 8, 20, 0.28);
 }
 
 .idt-demo-node.is-active {
-  background: rgba(137, 169, 255, 0.28);
-  box-shadow: 0 0 0 2px rgba(137, 169, 255, 0.38);
+  background: linear-gradient(140deg, rgba(75, 96, 142, 0.44), rgba(52, 72, 112, 0.36));
+  border-color: rgba(172, 197, 247, 0.64);
+  box-shadow: 0 0 0 2px rgba(137, 169, 255, 0.24), 0 8px 24px rgba(42, 64, 104, 0.33);
 }
 
-.idt-demo-node:nth-of-type(1) {
-  top: 8%;
-  left: 10%;
-}
-
-.idt-demo-node:nth-of-type(2) {
-  top: 24%;
-  left: 58%;
-}
-
-.idt-demo-node:nth-of-type(3) {
-  top: 48%;
-  left: 22%;
-}
-
-.idt-demo-node:nth-of-type(4) {
-  top: 68%;
-  left: 54%;
-}
-
-.idt-demo-node:nth-of-type(5) {
-  top: 83%;
-  left: 24%;
-}
-
-.idt-demo-connector {
+.idt-demo-edges {
   position: absolute;
-  height: 2px;
-  background: linear-gradient(90deg, transparent, #8aa9ff, transparent);
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
 }
 
-.idt-demo-connector.c1 {
-  top: 20%;
-  left: 23%;
-  width: 40%;
-  transform: rotate(8deg);
+.idt-demo-edge-path {
+  fill: none;
+  stroke-width: 1.3;
+  stroke-linecap: round;
+  stroke-dasharray: 7 8;
+  opacity: 0.56;
+  animation: idtDemoEdgeFlow 2.5s linear infinite;
 }
 
-.idt-demo-connector.c2 {
-  top: 36%;
-  left: 36%;
-  width: 20%;
-  transform: rotate(130deg);
+.idt-demo-edge-glow {
+  fill: none;
+  stroke-width: 2.8;
+  opacity: 0.17;
+  filter: blur(0.8px);
 }
 
-.idt-demo-connector.c3 {
-  top: 60%;
-  left: 36%;
-  width: 31%;
-  transform: rotate(18deg);
+.idt-demo-edges g.is-connected .idt-demo-edge-path {
+  stroke-width: 1.7;
+  opacity: 0.9;
 }
 
-.idt-demo-connector.c4 {
-  top: 77%;
-  left: 35%;
-  width: 22%;
-  transform: rotate(125deg);
+.idt-demo-edges g.is-connected .idt-demo-edge-glow {
+  opacity: 0.3;
+}
+
+.idt-demo-edge-tracer {
+  fill: rgba(221, 233, 255, 0.92);
+  opacity: 0.72;
+  filter: drop-shadow(0 0 4px rgba(143, 184, 255, 0.6));
+}
+
+@keyframes idtDemoEdgeFlow {
+  from {
+    stroke-dashoffset: 0;
+  }
+  to {
+    stroke-dashoffset: -22;
+  }
 }
 
 .idt-demo-sidebar {
@@ -1241,10 +1243,22 @@ h3 {
   width: 100%;
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 12px;
-  min-height: 42px;
+  min-height: 46px;
   padding: 0.62rem 0.75rem;
   background: rgba(7, 7, 9, 0.9);
   color: #fff;
+}
+
+.idt-form-grid select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%23d2dff6' d='M6 8 0 0h12z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.8rem center;
+  background-size: 10px 7px;
+  padding-right: 2rem;
+  line-height: 1.25;
 }
 
 .idt-roi-number-input {
@@ -1334,12 +1348,21 @@ h3 {
 }
 
 .idt-form-grid.is-short {
-  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr) auto;
-  align-items: end;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: start;
+  gap: 0.85rem 0.9rem;
 }
 
 .idt-form-grid.is-short .idt-btn {
-  min-height: 42px;
+  min-height: 46px;
+  grid-column: 1 / 2;
+  justify-self: flex-start;
+  min-width: 220px;
+}
+
+.idt-form-grid.is-short .idt-form-note,
+.idt-form-grid.is-short .idt-form-error {
+  grid-column: 1 / -1;
 }
 
 .idt-form-note {
@@ -1698,7 +1721,17 @@ h2 {
 }
 
 .idt-section {
-  padding: clamp(3rem, 6vw, 4.8rem) 0;
+  padding: clamp(2.6rem, 5.3vw, 4.2rem) 0;
+}
+
+.idt-section-tight {
+  padding-top: clamp(1.6rem, 3.8vw, 2.3rem);
+  padding-bottom: clamp(1.9rem, 4.2vw, 2.7rem);
+}
+
+.idt-section-demo {
+  padding-top: clamp(2.1rem, 4.2vw, 2.9rem);
+  padding-bottom: clamp(1.4rem, 3.2vw, 2.1rem);
 }
 
 .idt-section-title {
@@ -1736,7 +1769,7 @@ h2 {
 }
 
 .idt-proof-demo-card .idt-demo-surface {
-  margin-top: 0.9rem;
+  margin-top: 0.65rem;
 }
 
 .idt-roi label,
@@ -1894,6 +1927,34 @@ h2 {
 
 .idt-final-cta {
   border-top: 1px solid var(--idt-line);
+  padding-top: clamp(2rem, 4.4vw, 3rem);
+}
+
+.idt-final-cta .idt-inline-actions {
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.idt-final-cta-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 46px;
+  padding: 0 0.95rem;
+  border-radius: 999px;
+  border: 1px solid rgba(170, 187, 219, 0.28);
+  background: rgba(13, 18, 27, 0.56);
+  color: #dfe8f9;
+  font-weight: 700;
+  text-decoration: none;
+  line-height: 1;
+  transition: border-color 0.18s ease, background-color 0.18s ease, color 0.18s ease;
+}
+
+.idt-final-cta-link:hover,
+.idt-final-cta-link:focus-visible {
+  border-color: rgba(208, 221, 244, 0.58);
+  background: rgba(27, 36, 55, 0.74);
+  color: #f4f8ff;
 }
 
 .idt-footer {
@@ -2287,12 +2348,16 @@ h2 {
 }
 
 .idt-form-grid.is-short {
-  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr) auto;
-  align-items: end;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: start;
+  gap: 0.85rem 0.9rem;
 }
 
 .idt-form-grid.is-short .idt-btn {
-  min-height: 42px;
+  min-height: 46px;
+  grid-column: 1 / 2;
+  justify-self: flex-start;
+  min-width: 220px;
 }
 
 .idt-form-note {
@@ -2805,12 +2870,13 @@ body {
 
 .idt-form-grid.is-short {
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.8rem;
+  gap: 0.85rem 0.9rem;
 }
 
 .idt-form-grid.is-short .idt-btn {
-  grid-column: 1 / -1;
+  grid-column: 1 / 2;
   justify-self: flex-start;
+  min-width: 220px;
 }
 
 .idt-roi {
@@ -2905,6 +2971,18 @@ body {
 
 .idt-adoption-actions .idt-btn {
   min-height: 38px;
+}
+
+.idt-workflow-section {
+  padding-top: clamp(2rem, 4.2vw, 3rem);
+}
+
+.idt-workflow-section .idt-section-title {
+  margin-bottom: 1.3rem;
+}
+
+.idt-workflow-section .idt-steps {
+  gap: 0.72rem;
 }
 
 .idt-final-cta {
@@ -3102,6 +3180,15 @@ body {
 
   .idt-header-actions .idt-btn-dark {
     display: none;
+  }
+
+  .idt-final-cta .idt-inline-actions {
+    align-items: stretch;
+  }
+
+  .idt-final-cta-link {
+    width: 100%;
+    justify-content: center;
   }
 
   .idt-header-utility {


### PR DESCRIPTION
## Summary\n- redesign hero graph panel/connectors for cleaner premium motion and layout\n- fix short risk-scan form alignment and reduce section spacing gaps\n- upgrade trust-graph demo connectors to live animated svg paths\n- align final CTA actions and tighten global spacing mismatches\n\n## Validation\n- npm run build\n- npm run test -- --run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the hero and trust graph with live SVG edges, clearer node layout, and smoother motion. Tightened section spacing and aligned the short risk-scan form and final CTA.

- **UI Improvements**
  - Trust graph demo: added positioned nodes with x/y, SVG edge paths with gradient glow and animated tracers, and connected-edge highlighting; removed hard-coded span connectors.
  - Hero preview: improved edge curves with glow and tracers, streamlined to a single active layer, and added depth planes for subtle dimensionality.
  - Layout: introduced `idt-section-tight` and `idt-section-demo` for tighter spacing; styled the final CTA with `.idt-final-cta-link`.
  - Accessibility: honors reduced motion by disabling edge animations and hero tracers when `prefers-reduced-motion` is set.

- **Bug Fixes**
  - Fixed short risk-scan form alignment and spacing (updated grid, input heights, and select styling); aligned “How it works” section spacing.

<sup>Written for commit 091de1cb361f167783687063b7e531fd21af44ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

