### PR TITLE
refactor(web): improve light mode and move theme toggle

### DIFF
--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -77,40 +77,40 @@ export function Header({
         </nav>
 
         <div className="idt-header-actions">
-          <button
-            type="button"
-            className={`idt-theme-toggle ${theme === 'light' ? 'is-light' : ''}`}
-            onClick={onToggleTheme}
-            aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
-            title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
-          >
-            {theme === 'dark' ? (
-              <svg viewBox="0 0 24 24" aria-hidden="true">
-                <path
-                  fill="currentColor"
-                  d="M6.76 4.84 5.35 3.43 3.93 4.84l1.42 1.41 1.41-1.41Zm10.49 0 1.41-1.41 1.41 1.41-1.41 1.41-1.41-1.41ZM12 4h1V1h-2v3h1Zm7 9h3v-2h-3v2Zm-7 7h1v3h-2v-3h1ZM2 13h3v-2H2v2Zm3.34 6.57 1.41 1.41 1.41-1.41-1.41-1.41-1.41 1.41Zm13.31 1.41 1.41-1.41-1.41-1.41-1.41 1.41 1.41 1.41ZM12 6a6 6 0 1 0 0 12 6 6 0 0 0 0-12Z"
-                />
-              </svg>
-            ) : (
-              <svg viewBox="0 0 24 24" aria-hidden="true">
-                <path
-                  fill="currentColor"
-                  d="M20.74 15.35A9.6 9.6 0 0 1 8.65 3.26a.75.75 0 0 0-.92-.93A10.98 10.98 0 1 0 21.67 16.27a.75.75 0 0 0-.93-.92Z"
-                />
-              </svg>
-            )}
-            <span>{theme === 'dark' ? 'Light' : 'Dark'}</span>
-          </button>
-
           <Link to="/read-only-scan" className="idt-btn idt-btn-primary" data-ab-slot="header_primary_cta">
             Start Free Risk Scan
           </Link>
           <Link to="/demo" className="idt-btn idt-btn-dark">
             Book Demo
           </Link>
-          <SafeLink href={githubRepo} className="idt-header-utility">
-            GitHub
-          </SafeLink>
+          <div className="idt-header-utility-group">
+            <SafeLink href={githubRepo} className="idt-header-utility">
+              GitHub
+            </SafeLink>
+            <button
+              type="button"
+              className={`idt-theme-toggle ${theme === 'light' ? 'is-light' : ''}`}
+              onClick={onToggleTheme}
+              aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+              title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+            >
+              {theme === 'dark' ? (
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path
+                    fill="currentColor"
+                    d="M12 4.5a1 1 0 0 1 1 1V7a1 1 0 1 1-2 0V5.5a1 1 0 0 1 1-1Zm0 12a1 1 0 0 1 1 1v1.5a1 1 0 1 1-2 0V17.5a1 1 0 0 1 1-1ZM6.34 6.34a1 1 0 0 1 1.41 0L8.8 7.39A1 1 0 0 1 7.39 8.8L6.34 7.75a1 1 0 0 1 0-1.41Zm8.86 8.86a1 1 0 0 1 1.41 0l1.05 1.05a1 1 0 0 1-1.41 1.41L15.2 16.6a1 1 0 0 1 0-1.4ZM4.5 12a1 1 0 0 1 1-1H7a1 1 0 0 1 0 2H5.5a1 1 0 0 1-1-1Zm12.5 0a1 1 0 0 1 1-1h1.5a1 1 0 1 1 0 2H18a1 1 0 0 1-1-1ZM7.39 15.2A1 1 0 1 1 8.8 16.6l-1.05 1.06a1 1 0 0 1-1.41-1.42l1.05-1.05Zm8.86-8.86a1 1 0 1 1 1.42 1.41L16.6 8.8a1 1 0 1 1-1.4-1.41l1.05-1.05ZM12 8.5a3.5 3.5 0 1 1 0 7 3.5 3.5 0 0 1 0-7Z"
+                  />
+                </svg>
+              ) : (
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path
+                    fill="currentColor"
+                    d="M21.2 14.97A8.94 8.94 0 0 1 9.03 2.8a.75.75 0 0 0-.92-.95A10.5 10.5 0 1 0 22.15 15.9a.75.75 0 0 0-.95-.92Z"
+                  />
+                </svg>
+              )}
+            </button>
+          </div>
         </div>
       </div>
     </header>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3347,3 +3347,314 @@ html[data-theme='light'] .idt-footer-trust-links a {
     min-height: 520px;
   }
 }
+
+/* Header controls: keep utility + theme control grouped after GitHub */
+.idt-header-utility-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.58rem;
+  margin-left: 0.24rem;
+}
+
+.idt-header-utility {
+  display: inline-flex;
+  align-items: center;
+  min-height: 38px;
+  padding: 0 0.12rem;
+  color: #a9b9d2;
+  font-weight: 650;
+  line-height: 1;
+}
+
+.idt-theme-toggle {
+  width: 38px;
+  height: 38px;
+  min-height: 38px;
+  min-width: 38px;
+  padding: 0;
+  border-radius: 999px;
+  border: 1px solid rgba(168, 186, 218, 0.34);
+  background: rgba(12, 18, 29, 0.72);
+  color: #e1ebfb;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.idt-theme-toggle svg {
+  width: 17px;
+  height: 17px;
+}
+
+.idt-theme-toggle span {
+  display: none;
+}
+
+.idt-theme-toggle:hover,
+.idt-theme-toggle:focus-visible {
+  border-color: rgba(215, 227, 255, 0.68);
+  background: rgba(20, 30, 47, 0.86);
+  color: #f4f8ff;
+}
+
+@media (max-width: 1080px) {
+  .idt-header-utility-group {
+    margin-left: 0;
+  }
+}
+
+@media (max-width: 720px) {
+  .idt-header-actions {
+    align-items: stretch;
+  }
+
+  .idt-header-utility-group {
+    width: 100%;
+    justify-content: center;
+    padding-bottom: 0.4rem;
+  }
+
+  .idt-header-utility {
+    width: auto;
+    text-align: center;
+    padding: 0;
+  }
+
+  .idt-theme-toggle {
+    width: 40px;
+    min-width: 40px;
+    height: 40px;
+    min-height: 40px;
+  }
+}
+
+/* Light-mode redesign pass: stronger contrast, cleaner surfaces, better readability */
+html[data-theme='light'] body {
+  background:
+    radial-gradient(circle at 82% -12%, rgba(73, 106, 169, 0.2), transparent 42%),
+    radial-gradient(circle at 8% 20%, rgba(111, 141, 193, 0.14), transparent 34%),
+    linear-gradient(180deg, #f6f9ff 0%, #edf3fc 56%, #e8eff9 100%);
+  color: #101f39;
+}
+
+html[data-theme='light'] h1,
+html[data-theme='light'] h2,
+html[data-theme='light'] h3,
+html[data-theme='light'] h4 {
+  color: #11223f;
+}
+
+html[data-theme='light'] .idt-header {
+  background: rgba(248, 251, 255, 0.92);
+  border-bottom-color: rgba(18, 35, 64, 0.14);
+}
+
+html[data-theme='light'] .idt-brand small,
+html[data-theme='light'] .idt-section-title p,
+html[data-theme='light'] .idt-lead,
+html[data-theme='light'] .idt-card p,
+html[data-theme='light'] .idt-card li,
+html[data-theme='light'] .idt-proof-item p,
+html[data-theme='light'] .idt-proof-architecture-item p,
+html[data-theme='light'] .idt-workflow-steps li p,
+html[data-theme='light'] .idt-form-note,
+html[data-theme='light'] .idt-form-trust-note,
+html[data-theme='light'] .idt-faq-item p,
+html[data-theme='light'] .idt-problem-frame p,
+html[data-theme='light'] .idt-problem-signals p,
+html[data-theme='light'] .idt-demo-follow-up,
+html[data-theme='light'] .idt-adoption-note {
+  color: #3f5273;
+}
+
+html[data-theme='light'] .idt-nav a {
+  color: #3c4f70;
+}
+
+html[data-theme='light'] .idt-nav a:hover,
+html[data-theme='light'] .idt-nav a:focus-visible,
+html[data-theme='light'] .idt-nav a.is-active {
+  color: #122445;
+  background: rgba(27, 48, 86, 0.1);
+  border-color: rgba(20, 38, 68, 0.2);
+  text-decoration: none;
+}
+
+html[data-theme='light'] .idt-btn-primary {
+  background: linear-gradient(120deg, #152a4f 0%, #213b66 100%);
+  border-color: rgba(15, 32, 59, 0.25);
+  color: #f5f9ff;
+  box-shadow: 0 12px 30px rgba(32, 52, 92, 0.22);
+}
+
+html[data-theme='light'] .idt-btn-dark,
+html[data-theme='light'] .idt-btn-ghost {
+  color: #1c3053;
+  border-color: rgba(20, 37, 66, 0.24);
+  background: rgba(255, 255, 255, 0.9);
+}
+
+html[data-theme='light'] .idt-header-utility {
+  color: #1f3257;
+}
+
+html[data-theme='light'] .idt-header-utility:hover,
+html[data-theme='light'] .idt-header-utility:focus-visible {
+  color: #0f203d;
+}
+
+html[data-theme='light'] .idt-theme-toggle {
+  border-color: rgba(22, 41, 73, 0.26);
+  background: rgba(255, 255, 255, 0.88);
+  color: #1f3358;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.92);
+}
+
+html[data-theme='light'] .idt-theme-toggle:hover,
+html[data-theme='light'] .idt-theme-toggle:focus-visible {
+  background: rgba(238, 245, 255, 0.96);
+  border-color: rgba(22, 41, 73, 0.42);
+  color: #132747;
+}
+
+html[data-theme='light'] .idt-card,
+html[data-theme='light'] .idt-pricing-card,
+html[data-theme='light'] .idt-lead-form,
+html[data-theme='light'] .idt-roi,
+html[data-theme='light'] .idt-demo-sidebar,
+html[data-theme='light'] .idt-demo-graph,
+html[data-theme='light'] .idt-demo-list-view,
+html[data-theme='light'] .idt-graph-visual,
+html[data-theme='light'] .idt-hero-graph-caption,
+html[data-theme='light'] .idt-faq-item,
+html[data-theme='light'] .idt-steps li,
+html[data-theme='light'] .idt-problem-signals article,
+html[data-theme='light'] .idt-quote-card,
+html[data-theme='light'] .idt-demo-toolbar,
+html[data-theme='light'] .idt-deployment-panel,
+html[data-theme='light'] .idt-adoption-card,
+html[data-theme='light'] .idt-table-wrap {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(248, 252, 255, 0.93));
+  border-color: rgba(19, 38, 68, 0.16);
+  box-shadow: 0 14px 30px rgba(35, 55, 92, 0.12);
+}
+
+html[data-theme='light'] .idt-trust-strip {
+  background: rgba(243, 248, 255, 0.82);
+  border-top-color: rgba(18, 36, 64, 0.12);
+  border-bottom-color: rgba(18, 36, 64, 0.12);
+}
+
+html[data-theme='light'] .idt-proof-item,
+html[data-theme='light'] .idt-logo-row span,
+html[data-theme='light'] .idt-hero-trust-cues li,
+html[data-theme='light'] .idt-risk-path-list li,
+html[data-theme='light'] .idt-hero-proof-meta span:not(.idt-severity-pill),
+html[data-theme='light'] .idt-workflow-output,
+html[data-theme='light'] .idt-demo-evidence,
+html[data-theme='light'] .idt-intake-summary {
+  background: rgba(241, 247, 255, 0.9);
+  border-color: rgba(24, 43, 75, 0.18);
+  color: #243a60;
+}
+
+html[data-theme='light'] .idt-proof-link,
+html[data-theme='light'] .idt-inline-link,
+html[data-theme='light'] .idt-footer-links a,
+html[data-theme='light'] .idt-footer-trust-links a {
+  color: #17305b;
+}
+
+html[data-theme='light'] .idt-demo-toolbar p,
+html[data-theme='light'] .idt-finding-label,
+html[data-theme='light'] .idt-intake-step {
+  color: #2e456d;
+}
+
+html[data-theme='light'] .idt-demo-scenario-row button,
+html[data-theme='light'] .idt-demo-view-toggle button,
+html[data-theme='light'] .idt-risk-scenario-item {
+  background: rgba(244, 249, 255, 0.94);
+  color: #223a64;
+  border-color: rgba(25, 45, 78, 0.22);
+}
+
+html[data-theme='light'] .idt-demo-scenario-row button.is-active,
+html[data-theme='light'] .idt-demo-view-toggle button[aria-selected='true'] {
+  background: rgba(31, 60, 112, 0.14);
+  border-color: rgba(29, 53, 93, 0.48);
+  color: #132a4f;
+}
+
+html[data-theme='light'] .idt-demo-node,
+html[data-theme='light'] .idt-node {
+  background: rgba(252, 255, 255, 0.94);
+  color: #1b3158;
+  box-shadow: 0 8px 18px rgba(35, 55, 92, 0.12);
+}
+
+html[data-theme='light'] .idt-demo-connector,
+html[data-theme='light'] .idt-hero-arrow {
+  background: linear-gradient(90deg, transparent, rgba(36, 68, 124, 0.6), transparent);
+  stroke: rgba(36, 68, 124, 0.62);
+  filter: none;
+}
+
+html[data-theme='light'] .idt-compare-table th,
+html[data-theme='light'] .idt-compare-table tbody th {
+  background: rgba(234, 242, 255, 0.92);
+  color: #1c3258;
+}
+
+html[data-theme='light'] .idt-compare-table td {
+  color: #223656;
+  border-bottom-color: rgba(27, 47, 80, 0.16);
+}
+
+html[data-theme='light'] .idt-roi label,
+html[data-theme='light'] .idt-search,
+html[data-theme='light'] .idt-form-grid label,
+html[data-theme='light'] .idt-intake-grid label,
+html[data-theme='light'] .idt-roi-field > span {
+  color: #2c446b;
+}
+
+html[data-theme='light'] .idt-roi input,
+html[data-theme='light'] .idt-search input,
+html[data-theme='light'] .idt-form-grid input,
+html[data-theme='light'] .idt-form-grid select,
+html[data-theme='light'] .idt-intake-grid input,
+html[data-theme='light'] .idt-intake-grid select {
+  background: rgba(253, 255, 255, 0.96);
+  border-color: rgba(20, 39, 70, 0.24);
+  color: #162a4d;
+}
+
+html[data-theme='light'] .idt-roi-stepper button {
+  background: rgba(233, 241, 254, 0.94);
+  color: #1b345d;
+  border-color: rgba(25, 45, 80, 0.3);
+}
+
+html[data-theme='light'] .idt-roi-output,
+html[data-theme='light'] .idt-form-success {
+  background: rgba(38, 71, 127, 0.1);
+  border-color: rgba(31, 57, 100, 0.24);
+  color: #19315a;
+}
+
+html[data-theme='light'] .idt-footer-bar {
+  background: #e8eef8;
+  border-top-color: rgba(18, 36, 64, 0.16);
+}
+
+html[data-theme='light'] .idt-footer-meta small {
+  color: #2a3f65;
+}
+
+html[data-theme='light'] .idt-social-link {
+  background: rgba(248, 252, 255, 0.9);
+  border-color: rgba(20, 39, 70, 0.22);
+  color: #1a325c;
+}


### PR DESCRIPTION
## Summary
- redesign light theme for stronger contrast and cleaner surfaces
- move theme toggle to the right of GitHub in header actions
- switch to icon-only theme control with improved spacing and hover/focus states

## Validation
- npm run test -- --run
- npm run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned light mode for higher contrast and cleaner surfaces, and moved the theme toggle next to GitHub as an icon-only control. This improves readability site-wide and streamlines header actions on desktop and mobile.

- **Refactors**
  - `Header.tsx`: Grouped GitHub + theme toggle with `.idt-header-utility-group`; relocated toggle to the right of GitHub; switched to icon-only SVG with preserved aria-label/title and existing handler.
  - `styles.css`: Added styles for the new utility group and toggle (spacing, hover/focus, sizes), responsive tweaks for ≤1080px/≤720px, and a comprehensive light-mode palette update for nav, buttons, cards, forms, tables, and graphs to boost contrast and clarity.

<sup>Written for commit 83565ab4d140852fcb24d356621c4252a41bcbf9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

