### PR TITLE
fix(web): improve light-mode contrast and graph connectors

### DIFF
--- a/web/src/components/home/HeroProductReveal.tsx
+++ b/web/src/components/home/HeroProductReveal.tsx
@@ -154,13 +154,14 @@ function edgePath(from: HeroNode, to: HeroNode) {
   const startY = from.y;
   const endX = to.x;
   const endY = to.y;
-  const midpointX = (startX + endX) / 2;
-  const midpointY = (startY + endY) / 2;
-  const distanceX = Math.abs(endX - startX);
-  const lift = Math.max(7, Math.min(16, distanceX * 0.2));
-  const controlX = midpointX + (endY - startY) * 0.08;
-  const controlY = midpointY - lift;
-  return `M ${startX} ${startY} Q ${controlX} ${controlY} ${endX} ${endY}`;
+  const dx = endX - startX;
+  const dy = endY - startY;
+  const bend = Math.min(14, Math.max(6, Math.abs(dx) * 0.18 + Math.abs(dy) * 0.1));
+  const c1x = startX + dx * 0.32;
+  const c1y = startY + dy * 0.14 - bend;
+  const c2x = endX - dx * 0.26;
+  const c2y = endY - dy * 0.12 + bend * 0.25;
+  return `M ${startX} ${startY} C ${c1x} ${c1y} ${c2x} ${c2y} ${endX} ${endY}`;
 }
 
 export function HeroProductReveal() {
@@ -186,11 +187,13 @@ export function HeroProductReveal() {
       <div key={scene.id} className="idt-hero-layer is-active">
         <svg className="idt-hero-arrows" viewBox="0 0 100 100" preserveAspectRatio="none">
           <defs>
-            <linearGradient id={`idt-edge-gradient-${scene.id}`} x1="0%" y1="0%" x2="100%" y2="100%">
-              <stop offset="0%" stopColor="rgba(168, 196, 255, 0.12)" />
-              <stop offset="44%" stopColor="rgba(160, 193, 255, 0.82)" />
-              <stop offset="100%" stopColor="rgba(138, 172, 238, 0.2)" />
-            </linearGradient>
+            <filter id={`idt-edge-glow-${scene.id}`} x="-60%" y="-60%" width="220%" height="220%">
+              <feGaussianBlur stdDeviation="0.26" result="blurred" />
+              <feMerge>
+                <feMergeNode in="blurred" />
+                <feMergeNode in="SourceGraphic" />
+              </feMerge>
+            </filter>
           </defs>
 
           {scene.edges.map((edge, edgeIndex) => {
@@ -201,17 +204,28 @@ export function HeroProductReveal() {
             }
 
             const path = edgePath(from, to);
-            const tracerDuration = 4 + edgeIndex * 0.65;
 
             return (
-              <g key={`${scene.id}-${edge.from}-${edge.to}`} className={edge.emphasis === 'high' ? 'is-high' : ''}>
-                <path className="idt-hero-arrow-glow" d={path} stroke={`url(#idt-edge-gradient-${scene.id})`} />
-                <path className="idt-hero-arrow" d={path} stroke={`url(#idt-edge-gradient-${scene.id})`} />
-                {!reducedMotion ? (
-                  <circle className="idt-hero-arrow-tracer" r="1.2">
-                    <animateMotion dur={`${tracerDuration}s`} repeatCount="indefinite" path={path} />
-                  </circle>
-                ) : null}
+              <g key={`${scene.id}-${edge.from}-${edge.to}`}>
+                <path className={`idt-hero-arrow-base ${edge.emphasis === 'high' ? 'is-high' : ''}`} d={path} />
+                <path
+                  className={`idt-hero-arrow-flow ${edge.emphasis === 'high' ? 'is-high' : ''}`}
+                  d={path}
+                  style={
+                    reducedMotion
+                      ? undefined
+                      : ({
+                          animationDelay: `${edgeIndex * 0.42}s`
+                        } as const)
+                  }
+                  filter={`url(#idt-edge-glow-${scene.id})`}
+                />
+                <circle
+                  className={`idt-hero-arrow-end ${edge.emphasis === 'high' ? 'is-high' : ''}`}
+                  cx={to.x}
+                  cy={to.y}
+                  r={edge.emphasis === 'high' ? 0.9 : 0.7}
+                />
               </g>
             );
           })}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -576,36 +576,44 @@ h3 {
   pointer-events: none;
 }
 
-.idt-hero-arrow {
+.idt-hero-arrow-base,
+.idt-hero-arrow-flow {
   fill: none;
-  stroke-width: 1.16;
-  opacity: 0.74;
   stroke-linecap: round;
-  stroke-dasharray: 5 9;
-  animation: idtArrowFlow 3s linear infinite;
+  vector-effect: non-scaling-stroke;
 }
 
-.idt-hero-arrow-glow {
-  fill: none;
-  stroke-width: 1.9;
-  opacity: 0.18;
-  filter: blur(0.5px);
+.idt-hero-arrow-base {
+  stroke: rgba(124, 155, 216, 0.38);
+  stroke-width: 1.14;
+  opacity: 0.8;
 }
 
-.idt-hero-arrows g.is-high .idt-hero-arrow {
-  stroke-width: 1.45;
-  opacity: 0.88;
-  stroke-dasharray: 6 8;
+.idt-hero-arrow-base.is-high {
+  stroke: rgba(148, 181, 243, 0.52);
+  stroke-width: 1.34;
 }
 
-.idt-hero-arrows g.is-high .idt-hero-arrow-glow {
-  opacity: 0.22;
+.idt-hero-arrow-flow {
+  stroke: rgba(199, 220, 255, 0.92);
+  stroke-width: 1.24;
+  stroke-dasharray: 7 96;
+  stroke-dashoffset: 0;
+  opacity: 0.94;
+  animation: idtArrowFlow 3.8s linear infinite;
 }
 
-.idt-hero-arrow-tracer {
-  fill: rgba(210, 227, 255, 0.95);
-  opacity: 0.66;
-  filter: drop-shadow(0 0 4px rgba(162, 194, 249, 0.52));
+.idt-hero-arrow-flow.is-high {
+  stroke: rgba(221, 233, 255, 0.97);
+  stroke-width: 1.42;
+}
+
+.idt-hero-arrow-end {
+  fill: rgba(186, 212, 255, 0.82);
+}
+
+.idt-hero-arrow-end.is-high {
+  fill: rgba(217, 230, 255, 0.92);
 }
 
 @keyframes idtArrowFlow {
@@ -613,7 +621,7 @@ h3 {
     stroke-dashoffset: 0;
   }
   to {
-    stroke-dashoffset: -24;
+    stroke-dashoffset: -103;
   }
 }
 
@@ -760,14 +768,10 @@ h3 {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .idt-hero-arrow {
+  .idt-hero-arrow-flow {
     animation: none;
-    stroke-dasharray: none;
+    stroke-dasharray: 0;
     stroke-dashoffset: 0;
-  }
-
-  .idt-hero-arrow-tracer {
-    display: none;
   }
 
   .idt-demo-edge-path {
@@ -3685,11 +3689,33 @@ html[data-theme='light'] .idt-node {
   box-shadow: 0 8px 18px rgba(35, 55, 92, 0.12);
 }
 
-html[data-theme='light'] .idt-demo-connector,
-html[data-theme='light'] .idt-hero-arrow {
+html[data-theme='light'] .idt-demo-connector {
   background: linear-gradient(90deg, transparent, rgba(36, 68, 124, 0.6), transparent);
-  stroke: rgba(36, 68, 124, 0.62);
+}
+
+html[data-theme='light'] .idt-hero-arrow-base {
+  stroke: rgba(39, 68, 120, 0.4);
+}
+
+html[data-theme='light'] .idt-hero-arrow-base.is-high {
+  stroke: rgba(32, 63, 116, 0.52);
+}
+
+html[data-theme='light'] .idt-hero-arrow-flow {
+  stroke: rgba(35, 67, 121, 0.82);
   filter: none;
+}
+
+html[data-theme='light'] .idt-hero-arrow-flow.is-high {
+  stroke: rgba(22, 51, 102, 0.92);
+}
+
+html[data-theme='light'] .idt-hero-arrow-end {
+  fill: rgba(35, 67, 121, 0.78);
+}
+
+html[data-theme='light'] .idt-hero-arrow-end.is-high {
+  fill: rgba(22, 51, 102, 0.9);
 }
 
 html[data-theme='light'] .idt-compare-table th,
@@ -3748,4 +3774,89 @@ html[data-theme='light'] .idt-social-link {
   background: rgba(248, 252, 255, 0.9);
   border-color: rgba(20, 39, 70, 0.22);
   color: #1a325c;
+}
+
+html[data-theme='light'] .idt-eyebrow {
+  color: #60789f;
+}
+
+html[data-theme='light'] .idt-muted-strong,
+html[data-theme='light'] .idt-adoption-card p,
+html[data-theme='light'] .idt-adoption-card dd,
+html[data-theme='light'] .idt-faq-group dd,
+html[data-theme='light'] .idt-steps p,
+html[data-theme='light'] .idt-workflow-steps li p,
+html[data-theme='light'] .idt-roi-note,
+html[data-theme='light'] .idt-inline-link-note {
+  color: #405577;
+}
+
+html[data-theme='light'] .idt-adoption-card h3,
+html[data-theme='light'] .idt-faq-group h3,
+html[data-theme='light'] .idt-faq-group dt,
+html[data-theme='light'] .idt-steps h3,
+html[data-theme='light'] .idt-workflow-steps li strong,
+html[data-theme='light'] .idt-section-title h2 {
+  color: #152b4f;
+}
+
+html[data-theme='light'] .idt-adoption-card dt {
+  color: #5f779f;
+}
+
+html[data-theme='light'] .idt-faq-group {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(247, 251, 255, 0.95));
+  border-color: rgba(19, 38, 68, 0.17);
+  box-shadow: 0 10px 22px rgba(34, 55, 94, 0.1);
+}
+
+html[data-theme='light'] .idt-final-cta .idt-inline-link {
+  color: #173461;
+  text-decoration: underline;
+  text-underline-offset: 0.2rem;
+}
+
+html[data-theme='light'] .idt-deployment-panel {
+  background: linear-gradient(170deg, rgba(248, 252, 255, 0.98), rgba(239, 246, 255, 0.97));
+  border-color: rgba(19, 38, 68, 0.18);
+}
+
+html[data-theme='light'] .idt-hero-graph-canvas {
+  background: linear-gradient(165deg, rgba(232, 240, 252, 0.92), rgba(225, 235, 250, 0.9));
+  border-color: rgba(28, 48, 83, 0.24);
+}
+
+html[data-theme='light'] .idt-hero-graph-canvas .idt-graph-grid {
+  opacity: 0.28;
+  background-image:
+    linear-gradient(rgba(44, 68, 108, 0.09) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(44, 68, 108, 0.09) 1px, transparent 1px);
+}
+
+html[data-theme='light'] .idt-hero-graph-title {
+  color: #49638d;
+}
+
+html[data-theme='light'] .idt-hero-path,
+html[data-theme='light'] .idt-hero-path-steps li,
+html[data-theme='light'] .idt-hero-capability-list li,
+html[data-theme='light'] .idt-hero-graph-caption > p,
+html[data-theme='light'] .idt-hero-proof-meta span:not(.idt-severity-pill) {
+  color: #2e476f;
+}
+
+html[data-theme='light'] .idt-hero-proof-meta span:not(.idt-severity-pill),
+html[data-theme='light'] .idt-hero-capability-list li::before {
+  border-color: rgba(34, 58, 98, 0.22);
+  background: rgba(54, 86, 143, 0.16);
+}
+
+html[data-theme='light'] .idt-hero-layer-dots button {
+  border-color: rgba(35, 58, 99, 0.28);
+  background: rgba(56, 88, 145, 0.2);
+}
+
+html[data-theme='light'] .idt-hero-layer-dots button.is-active {
+  border-color: rgba(22, 45, 82, 0.9);
+  background: rgba(22, 45, 82, 0.9);
 }


### PR DESCRIPTION
## Summary
- improve light-mode readability in adoption, faq, workflow, and helper text blocks
- polish hero graph connectors with cleaner curved paths and restrained live flow animation
- refine light-mode hero graph canvas and metadata contrast for clearer hierarchy

## Validation
- npm run test -- --run
- npm run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves light-mode readability across home sections and polishes the hero graph connectors for cleaner paths and calmer motion. Results in better contrast, clearer hierarchy, and reduced visual noise.

- **Refactors**
  - Hero connectors: switched to cubic Bézier paths with base/flow/end layers, added subtle glow, staggered flow timing, tuned dash lengths, and respected reduced motion.
  - Light mode: updated text and UI colors for adoption cards, FAQ, workflow, helper notes, and hero graph (canvas, grid, captions, metadata, dots); adjusted connector strokes for sharper contrast.

<sup>Written for commit d400730bb6dbdbb26903705a9e93d228c274ab54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

