### PR TITLE
refactor(web): refine interactive graph connectors

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -845,12 +845,14 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
       return '';
     }
 
-    const mx = (from.x + to.x) / 2;
-    const my = (from.y + to.y) / 2;
-    const bend = Math.max(6, Math.min(14, Math.abs(to.x - from.x) * 0.18));
-    const cx = mx + (to.y - from.y) * 0.05;
-    const cy = my - bend;
-    return `M ${from.x} ${from.y} Q ${cx} ${cy} ${to.x} ${to.y}`;
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+    const bend = Math.min(12, Math.max(4.5, Math.abs(dx) * 0.14 + Math.abs(dy) * 0.06));
+    const c1x = from.x + dx * 0.32;
+    const c1y = from.y + dy * 0.16 - bend;
+    const c2x = to.x - dx * 0.26;
+    const c2y = to.y - dy * 0.12 + bend * 0.16;
+    return `M ${from.x} ${from.y} C ${c1x} ${c1y} ${c2x} ${c2y} ${to.x} ${to.y}`;
   };
 
   const connectedEdges = edges.filter((edge) => edge.from === selected.id || edge.to === selected.id);
@@ -897,15 +899,21 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
         <div id={graphPanelId} role="tabpanel" aria-labelledby={graphTabId} className="idt-demo-graph" aria-label="Interactive trust graph simulation">
           <svg className="idt-demo-edges" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
             <defs>
-              <linearGradient id={`idt-demo-edge-gradient-${variant}`} x1="0%" y1="0%" x2="100%" y2="100%">
-                <stop offset="0%" stopColor="rgba(162, 188, 245, 0.22)" />
-                <stop offset="50%" stopColor="rgba(160, 192, 255, 0.88)" />
-                <stop offset="100%" stopColor="rgba(138, 170, 231, 0.2)" />
+              <linearGradient id={`idt-demo-edge-base-gradient-${variant}`} x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stopColor="rgba(124, 153, 212, 0.16)" />
+                <stop offset="55%" stopColor="rgba(141, 172, 228, 0.42)" />
+                <stop offset="100%" stopColor="rgba(119, 151, 210, 0.15)" />
+              </linearGradient>
+              <linearGradient id={`idt-demo-edge-flow-gradient-${variant}`} x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stopColor="rgba(170, 197, 255, 0.52)" />
+                <stop offset="55%" stopColor="rgba(203, 222, 255, 0.95)" />
+                <stop offset="100%" stopColor="rgba(154, 184, 238, 0.42)" />
               </linearGradient>
             </defs>
             {edges.map((edge, index) => {
               const path = edgePath(edge.from, edge.to);
-              if (!path) {
+              const toNode = getNode(edge.to);
+              if (!path || !toNode) {
                 return null;
               }
 
@@ -913,11 +921,14 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
               const edgeClass = isConnected ? 'is-connected' : '';
               return (
                 <g key={edge.id} className={edgeClass}>
-                  <path className="idt-demo-edge-glow" d={path} stroke={`url(#idt-demo-edge-gradient-${variant})`} />
-                  <path className="idt-demo-edge-path" d={path} stroke={`url(#idt-demo-edge-gradient-${variant})`} />
-                  <circle className="idt-demo-edge-tracer" r="1.1">
-                    <animateMotion dur={`${4.8 + index * 0.7}s`} repeatCount="indefinite" path={path} />
-                  </circle>
+                  <path className="idt-demo-edge-base" d={path} stroke={`url(#idt-demo-edge-base-gradient-${variant})`} />
+                  <path
+                    className="idt-demo-edge-flow"
+                    d={path}
+                    stroke={`url(#idt-demo-edge-flow-gradient-${variant})`}
+                    style={{ animationDelay: `${index * 0.35}s` }}
+                  />
+                  <circle className="idt-demo-edge-end" cx={toNode.x} cy={toNode.y} r={isConnected ? 0.72 : 0.56} />
                 </g>
               );
             })}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -774,14 +774,20 @@ h3 {
     stroke-dashoffset: 0;
   }
 
+  .idt-hero-arrow-tracer {
+    display: none;
+  }
+
   .idt-demo-edge-path {
     animation: none;
     stroke-dasharray: none;
     stroke-dashoffset: 0;
   }
 
-  .idt-demo-edge-tracer {
-    display: none;
+  .idt-demo-edge-flow {
+    animation: none;
+    stroke-dasharray: 0;
+    stroke-dashoffset: 0;
   }
 
   * {
@@ -1091,35 +1097,45 @@ h3 {
   pointer-events: none;
 }
 
-.idt-demo-edge-path {
+.idt-demo-edge-base,
+.idt-demo-edge-flow {
   fill: none;
-  stroke-width: 1.3;
   stroke-linecap: round;
-  stroke-dasharray: 7 8;
-  opacity: 0.56;
-  animation: idtDemoEdgeFlow 2.5s linear infinite;
+  vector-effect: non-scaling-stroke;
 }
 
-.idt-demo-edge-glow {
-  fill: none;
-  stroke-width: 2.8;
-  opacity: 0.17;
-  filter: blur(0.8px);
+.idt-demo-edge-base {
+  stroke-width: 0.96;
+  opacity: 0.42;
 }
 
-.idt-demo-edges g.is-connected .idt-demo-edge-path {
-  stroke-width: 1.7;
+.idt-demo-edge-flow {
+  stroke-width: 1.08;
+  stroke-dasharray: 7 88;
+  stroke-dashoffset: 0;
+  opacity: 0.54;
+  animation: idtDemoEdgeFlow 3.6s linear infinite;
+}
+
+.idt-demo-edges g.is-connected .idt-demo-edge-base {
+  stroke-width: 1.1;
+  opacity: 0.62;
+}
+
+.idt-demo-edges g.is-connected .idt-demo-edge-flow {
+  stroke-width: 1.22;
   opacity: 0.9;
+  stroke-dasharray: 8 74;
 }
 
-.idt-demo-edges g.is-connected .idt-demo-edge-glow {
-  opacity: 0.3;
+.idt-demo-edge-end {
+  fill: rgba(206, 223, 255, 0.66);
+  opacity: 0.62;
 }
 
-.idt-demo-edge-tracer {
-  fill: rgba(221, 233, 255, 0.92);
-  opacity: 0.72;
-  filter: drop-shadow(0 0 4px rgba(143, 184, 255, 0.6));
+.idt-demo-edges g.is-connected .idt-demo-edge-end {
+  fill: rgba(223, 234, 255, 0.9);
+  opacity: 0.92;
 }
 
 @keyframes idtDemoEdgeFlow {
@@ -1127,7 +1143,7 @@ h3 {
     stroke-dashoffset: 0;
   }
   to {
-    stroke-dashoffset: -22;
+    stroke-dashoffset: -95;
   }
 }
 
@@ -3687,6 +3703,30 @@ html[data-theme='light'] .idt-node {
   background: rgba(252, 255, 255, 0.94);
   color: #1b3158;
   box-shadow: 0 8px 18px rgba(35, 55, 92, 0.12);
+}
+
+html[data-theme='light'] .idt-demo-edge-base {
+  opacity: 0.48;
+}
+
+html[data-theme='light'] .idt-demo-edge-flow {
+  opacity: 0.6;
+}
+
+html[data-theme='light'] .idt-demo-edges g.is-connected .idt-demo-edge-base {
+  opacity: 0.7;
+}
+
+html[data-theme='light'] .idt-demo-edges g.is-connected .idt-demo-edge-flow {
+  opacity: 0.94;
+}
+
+html[data-theme='light'] .idt-demo-edge-end {
+  fill: rgba(31, 58, 103, 0.66);
+}
+
+html[data-theme='light'] .idt-demo-edges g.is-connected .idt-demo-edge-end {
+  fill: rgba(18, 45, 88, 0.9);
 }
 
 html[data-theme='light'] .idt-demo-connector {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1125,7 +1125,7 @@ h3 {
 .idt-demo-edges g.is-connected .idt-demo-edge-flow {
   stroke-width: 1.22;
   opacity: 0.9;
-  stroke-dasharray: 8 74;
+  stroke-dasharray: 8 87;
 }
 
 .idt-demo-edge-end {


### PR DESCRIPTION
## Summary
- redesign interactive trust graph connectors with slimmer, cleaner curves
- replace heavy connector treatment with subtle base+flow paths and restrained endpoint markers
- tune light-mode connector visibility to keep a premium, readable look

## Validation
- npm run test -- --run
- npm run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refines the interactive trust‑graph connectors with slimmer cubic curves and a two‑layer base/flow stroke for a cleaner, more readable look. Replaces glow/tracer with a subtle endpoint, improves light‑mode contrast, and honors reduced motion by disabling flow animation.

- **Refactors**
  - Switched from quadratic to cubic Bézier with adaptive bend for smoother paths.
  - Split edges into `base` and `flow` layers with separate gradients; slowed and staggered flow animation per edge.
  - Removed glow and moving tracer; added a small endpoint circle sized by connection state.
  - Used non-scaling strokes and tuned widths/opacities for connected vs. default edges; refined light‑mode colors for better contrast.
  - Added prefers-reduced-motion fallback: no flow animation and solid stroke; tracers hidden.

<sup>Written for commit 9e97760cd0ba88d357126871d1f876945433003c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

