### PR TITLE
fix(web): correct remaining light-mode block contrast

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3968,8 +3968,10 @@ html[data-theme='light'] .idt-hero-layer-dots button.is-active {
 .idt-footer-trust-links a,
 .idt-header-utility {
   text-decoration-line: underline;
-  text-decoration-thickness: 1.5px;
-  text-underline-offset: 0.22em;
+  text-decoration-style: solid;
+  text-decoration-thickness: 1.4px;
+  text-decoration-skip-ink: none;
+  text-underline-offset: 0.2em;
   text-decoration-color: rgba(171, 191, 225, 0.85);
 }
 
@@ -4076,6 +4078,24 @@ html[data-theme='light'] .idt-calendly-preview {
   background: linear-gradient(160deg, rgba(252, 254, 255, 0.98), rgba(243, 249, 255, 0.96));
   border-color: rgba(20, 40, 72, 0.16);
   box-shadow: 0 12px 26px rgba(32, 54, 93, 0.1);
+}
+
+html[data-theme='light'] .idt-calendly {
+  background: linear-gradient(156deg, rgba(248, 252, 255, 0.98), rgba(237, 245, 255, 0.96));
+  border-color: rgba(22, 40, 71, 0.16);
+  box-shadow: 0 14px 28px rgba(30, 52, 91, 0.12);
+}
+
+html[data-theme='light'] .idt-calendly .idt-section-title .idt-eyebrow {
+  color: #5d79a4;
+}
+
+html[data-theme='light'] .idt-calendly .idt-section-title h2 {
+  color: #183056;
+}
+
+html[data-theme='light'] .idt-calendly .idt-section-title p {
+  color: #2f486f;
 }
 
 html[data-theme='light'] .idt-calendly-note,


### PR DESCRIPTION
## Summary
- fix light-mode contrast for the booking block wrapper and heading copy
- smooth text-link underlines by disabling ink skipping and normalizing stroke
- keep existing layout/structure unchanged

## Verification
- npm run test -- --run
- npm run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes light‑mode contrast in the Calendly booking section and smooths link underlines in header/footer for clearer reading, with no layout changes. Updates Calendly background, border, shadow, and section-title colors; and standardizes underline style (solid, 1.4px, no ink skipping, consistent offset).

<sup>Written for commit 949a1e0dced8ff755f3ed6b7a87064b38b71fff4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

