### PR TITLE
fix(web): final sweep for roi and selector bugs

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1060,15 +1060,8 @@ function RoiNumberField({ id, label, value, min, step, onChange }: RoiNumberFiel
             }
             updateValue(parsed);
           }}
+          onBlur={() => updateValue(value)}
         />
-        <div className="idt-roi-stepper" role="group" aria-label={`${label} controls`}>
-          <button type="button" onClick={() => updateValue(value - step)} aria-label={`Decrease ${label}`}>
-            −
-          </button>
-          <button type="button" onClick={() => updateValue(value + step)} aria-label={`Increase ${label}`}>
-            +
-          </button>
-        </div>
       </div>
     </label>
   );

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1304,24 +1304,19 @@ h3 {
 }
 
 .idt-form-grid select {
-  appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%23d2dff6' d='M6 8 0 0h12z'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 0.8rem center;
-  background-size: 10px 7px;
-  padding-right: 2rem;
   line-height: 1.25;
 }
 
 .idt-roi-number-input {
   min-height: 52px;
-  padding-right: 4.8rem;
+  padding-right: 0.95rem;
   padding-left: 0.95rem;
   font-size: clamp(0.95rem, 1.05vw, 1.05rem);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
+  appearance: textfield;
+  -webkit-appearance: textfield;
+  -moz-appearance: textfield;
 }
 
 .idt-roi-number-input::-webkit-outer-spin-button,
@@ -2355,11 +2350,14 @@ h2 {
 
 .idt-roi-number-input {
   min-height: 52px;
-  padding-right: 4.8rem;
+  padding-right: 0.95rem;
   padding-left: 0.95rem;
   font-size: clamp(0.95rem, 1.05vw, 1.05rem);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
+  appearance: textfield;
+  -webkit-appearance: textfield;
+  -moz-appearance: textfield;
 }
 
 .idt-roi-number-input::-webkit-outer-spin-button,
@@ -3783,7 +3781,7 @@ html[data-theme='light'] .idt-form-grid input,
 html[data-theme='light'] .idt-form-grid select,
 html[data-theme='light'] .idt-intake-grid input,
 html[data-theme='light'] .idt-intake-grid select {
-  background: rgba(253, 255, 255, 0.96);
+  background-color: rgba(253, 255, 255, 0.96);
   border-color: rgba(20, 39, 70, 0.24);
   color: #162a4d;
 }
@@ -4123,19 +4121,6 @@ html[data-theme='light'] .idt-header-utility {
   }
 }
 
-/* Final sweep: make selects theme-aware and smooth focus states */
-.idt-form-grid select,
-.idt-intake-grid select {
-  appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  background-repeat: no-repeat;
-  background-position: right 0.82rem center;
-  background-size: 10px 7px;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%23d2dff6' d='M6 8 0 0h12z'/%3E%3C/svg%3E");
-  padding-right: 2rem;
-}
-
 .idt-roi input:focus-visible,
 .idt-search input:focus-visible,
 .idt-form-grid input:focus-visible,
@@ -4145,11 +4130,6 @@ html[data-theme='light'] .idt-header-utility {
   outline: none;
   border-color: rgba(166, 189, 233, 0.6);
   box-shadow: 0 0 0 2px rgba(142, 167, 214, 0.22);
-}
-
-html[data-theme='light'] .idt-form-grid select,
-html[data-theme='light'] .idt-intake-grid select {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%23243f69' d='M6 8 0 0h12z'/%3E%3C/svg%3E");
 }
 
 html[data-theme='light'] .idt-roi input:focus-visible,


### PR DESCRIPTION
## Summary
- remove ROI inline +/- button controls and keep clean numeric inputs
- enforce spinner-free number inputs across themes
- normalize select background handling in light mode to prevent tiled/duplicated selector artifacts
- keep focus states consistent for form controls

## Validation
- npm run test -- --run
- npm run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies ROI number inputs and fixes select styling bugs. Removes stepper controls, enforces spinner-free numeric inputs, and resolves light‑mode select background tiling.

- **Bug Fixes**
  - ROI: removed +/- buttons, adjusted input padding, and re-sync value on blur to avoid stale display.
  - Number inputs: forced textfield appearance to hide spinners across browsers/themes.
  - Selects: dropped custom SVG backgrounds and used background-color to prevent tiled/duplicated artifacts in light mode; kept focus states consistent.

<sup>Written for commit e217a542e1b6bf3e046d89e0625629777525b6f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

