### PR TITLE
feat(web): add real blog article content

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2601,42 +2601,47 @@ function BlogArticlePage() {
       <section className="idt-page-hero idt-shell">
         <p className="idt-eyebrow">{post.category}</p>
         <h1>{post.title}</h1>
-        <p>{post.summary}</p>
+        <p>{post.description}</p>
       </section>
 
       <section className="idt-section idt-shell">
         <article className="idt-card idt-blog-article">
+          <p className="idt-chip-row">
+            <span>{post.category}</span>
+            <span>{post.readTime}</span>
+          </p>
+          {post.intro.map((paragraph) => (
+            <p key={paragraph} className="idt-blog-lead">
+              {paragraph}
+            </p>
+          ))}
           {post.sections.map((section) => (
-            <div key={section.heading}>
+            <section key={section.heading} className="idt-blog-section">
               <h2>{section.heading}</h2>
-              {section.paragraphs.map((paragraph, index) => (
-                <p key={`${section.heading}-p-${index}`}>{paragraph}</p>
+              {section.paragraphs.map((paragraph) => (
+                <p key={paragraph}>{paragraph}</p>
               ))}
-              {section.bullets && section.bullets.length > 0 ? (
+              {section.bullets ? (
                 <ul>
                   {section.bullets.map((bullet) => (
                     <li key={bullet}>{bullet}</li>
                   ))}
                 </ul>
               ) : null}
-            </div>
+            </section>
           ))}
-
-          <h2>How Identrail comes in</h2>
-          <ul>
-            {post.identrailFit.map((point) => (
-              <li key={point}>{point}</li>
-            ))}
-          </ul>
-
-          <h2>References</h2>
-          <ul>
-            {post.references.map((reference) => (
-              <li key={reference.href}>
-                <SafeLink href={reference.href}>{reference.label}</SafeLink>
-              </li>
-            ))}
-          </ul>
+          <section className="idt-blog-section">
+            <h2>References and further reading</h2>
+            <ul className="idt-blog-reference-list">
+              {post.references.map((reference) => (
+                <li key={reference.href}>
+                  <SafeLink href={reference.href} className="idt-inline-link">
+                    {reference.label}
+                  </SafeLink>
+                </li>
+              ))}
+            </ul>
+          </section>
           <div className="idt-inline-actions">
             <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
               Start Free Risk Scan

--- a/web/src/content/resources.ts
+++ b/web/src/content/resources.ts
@@ -11,13 +11,12 @@ export type BlogPost = {
   description: string;
   category: string;
   readTime: string;
-  summary: string;
+  intro: string[];
   sections: {
     heading: string;
     paragraphs: string[];
     bullets?: string[];
   }[];
-  identrailFit: string[];
   references: {
     label: string;
     href: string;
@@ -70,54 +69,67 @@ export const BLOG_POSTS: BlogPost[] = [
       'The frameworks platform and security teams use to discover, prioritize, and control machine trust paths in production.',
     category: 'Machine Identity Security',
     readTime: '10 min',
-    summary:
-      'Machine identities now dominate cloud access. This guide lays out an operating model teams can run weekly, not yearly, to reduce real trust-path risk.',
+    intro: [
+      'Machine identity security is no longer a narrow IAM hygiene problem. In most modern environments, non-human identities span AWS roles, Kubernetes service accounts, GitHub Actions runners, OIDC trust relationships, secret stores, and internal service principals. Security teams usually review those systems in separate tools. Attackers do not.',
+      'A practical operating model starts with one simple shift: stop asking whether a single identity is overprivileged in theory, and start asking which trust path can actually reach a sensitive resource in production. That framing is what separates a backlog of noisy findings from a program that reduces real blast radius.'
+    ],
     sections: [
       {
-        heading: 'Why this problem keeps getting worse',
+        heading: 'Why the old model breaks down',
         paragraphs: [
-          'Most teams now run thousands of machine identities across AWS, Kubernetes, CI, and automation. The challenge is not creating identities. The challenge is preventing trust drift across systems that evolve every sprint.',
-          'When security reviews are done as isolated IAM or RBAC checks, organizations miss how permissions chain together. Attack paths are graph problems, not policy-file problems.'
-        ]
-      },
-      {
-        heading: 'A practical operating model security and platform teams can share',
-        paragraphs: [
-          'The model that works in practice has four loops: discovery, trust-path mapping, risk ranking, and rollout-safe control changes. Each loop should run continuously with clear ownership and evidence outputs.',
-          'This aligns with NIST zero trust guidance: no implicit trust, continuous verification, and policy decisions based on live context.'
+          'Traditional reviews focus on static permissions. A role policy is inspected in AWS, an RBAC binding is checked in Kubernetes, and a workflow token is reviewed in GitHub. Each control may look reasonable in isolation. The risk appears when those identities can chain together across systems.',
+          'A GitHub Actions workflow can mint an OIDC token, assume a cloud role, reach a workload identity, and then touch a production resource. If teams do not see that path end to end, they tend to either underreact to real risk or overreact with broad restrictions that break engineering workflows.'
         ],
         bullets: [
-          'Discovery: maintain a current machine-identity inventory across cloud and cluster layers.',
-          'Mapping: model assumable paths and resource reachability, not only direct permissions.',
-          'Prioritization: rank findings by exploitable blast radius and business impact.',
-          'Enforcement: stage policy hardening with simulation and rollback controls.'
+          'Static permission review misses cross-system identity chaining.',
+          'Ownership is fragmented across platform, cloud, and security teams.',
+          'The highest-risk paths usually involve automation, not humans.'
         ]
       },
       {
-        heading: 'How to measure progress without vanity metrics',
+        heading: 'What a workable operating model looks like',
         paragraphs: [
-          'Metrics like tickets closed or policies reviewed are activity metrics. They do not prove reduced risk. Strong programs track: critical trust paths removed, time-to-remediate high-impact paths, and least-privilege coverage for production identities.',
-          'If those three metrics improve quarter over quarter, posture is improving in ways that incident response teams and leadership can both validate.'
+          'The strongest programs do four things well. First, they continuously inventory machine identities and trust edges. Second, they map reachability from source identity to target resource. Third, they prioritize based on production impact, not just policy complexity. Fourth, they introduce controls in a staged way so the fix does not become the next outage.',
+          'That means your core artifacts should be operational, not purely compliance-oriented: a trust graph snapshot, a list of high-risk reachable paths, evidence showing why a path exists, and a remediation plan that can be tested before enforcement.'
+        ],
+        bullets: [
+          'Inventory identities and trust relationships continuously.',
+          'Rank findings by reachable resource sensitivity and privilege depth.',
+          'Simulate policy changes before rolling them out.',
+          'Keep remediation evidence for auditors and engineering leaders.'
+        ]
+      },
+      {
+        heading: 'What good teams measure',
+        paragraphs: [
+          'Security leaders need metrics that connect identity posture to operational outcomes. Useful measures include the number of production-reachable paths, time to validate a risky path, time to remediate a high-severity chain, and the share of machine identities that have clear ownership.',
+          'These metrics are more useful than vanity counts like total policies reviewed. They show whether the organization is getting faster at turning identity data into safer access.'
+        ]
+      },
+      {
+        heading: 'Where Identrail fits',
+        paragraphs: [
+          'Identrail is built for this exact operating model. It discovers machine identities across AWS, Kubernetes, Git-based workflows, and OIDC trust boundaries, then maps the trust paths that matter in production.',
+          'Instead of handing teams another list of detached configuration issues, Identrail helps them see the full path, understand blast radius, and tighten access in stages. That is what makes machine identity security operational rather than aspirational.'
         ]
       }
     ],
-    identrailFit: [
-      'Identrail maintains a graph-based view of machine identities and trust relationships across AWS and Kubernetes.',
-      'It helps teams prioritize reachable high-impact paths instead of broad noisy findings.',
-      'Its rollout-safe workflow supports simulation and staged remediation before production enforcement.'
-    ],
     references: [
       {
-        label: 'NIST SP 800-207 Zero Trust Architecture',
+        label: 'NIST SP 800-207: Zero Trust Architecture',
         href: 'https://csrc.nist.gov/pubs/sp/800/207/final'
       },
       {
-        label: 'CISA Zero Trust Maturity Model',
-        href: 'https://www.cisa.gov/zero-trust-maturity-model'
+        label: 'AWS IAM Access Analyzer',
+        href: 'https://docs.aws.amazon.com/IAM/latest/UserGuide/what-is-access-analyzer.html'
       },
       {
-        label: 'SPIFFE/SPIRE Concepts',
-        href: 'https://spiffe.io/docs/latest/spire-about/spire-concepts/'
+        label: 'Amazon EKS IAM roles for service accounts',
+        href: 'https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html'
+      },
+      {
+        label: 'GitHub Actions OIDC for AWS',
+        href: 'https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services'
       }
     ]
   },
@@ -128,54 +140,62 @@ export const BLOG_POSTS: BlogPost[] = [
       'A field guide to overprivileged IAM role chains, cross-account assumptions, and practical remediation patterns.',
     category: 'AWS Security',
     readTime: '8 min',
-    summary:
-      'Most AWS machine-identity incidents trace back to misconfiguration, not exotic exploitation. This guide prioritizes the 14 patterns that expand blast radius fastest.',
+    intro: [
+      'Most AWS machine identity incidents do not start with a spectacular exploit. They start with ordinary drift: a trust policy that became too broad, a role left reusable across workloads, a permissive cross-account path that nobody revisited after an integration went live.',
+      'That is why AWS non-human identity security needs to be evaluated as path security. The real question is not whether one role is powerful. It is whether one machine principal can inherit, assume, or pivot into a chain that reaches something sensitive.'
+    ],
     sections: [
       {
-        heading: 'Why AWS identity incidents repeat the same root causes',
+        heading: 'The misconfigurations that matter most',
         paragraphs: [
-          'In many breaches, the initial foothold is a compromised workload role or leaked automation credential. Escalation happens because trust and permission boundaries were wider than intended.',
-          'The recurring issue is not missing capability. AWS already ships strong IAM controls. The gap is operational rigor around validation, simulation, and lifecycle hygiene.'
-        ]
-      },
-      {
-        heading: 'The highest-impact misconfiguration patterns',
-        paragraphs: [
-          'The riskiest patterns include wildcard action scopes, wildcard resource scopes, permissive AssumeRole trust policies, stale high-privilege roles, and weak cross-account constraints.',
-          'Teams should also treat process flaws as misconfiguration: policy changes pushed without Access Analyzer checks or simulation gates are effectively unreviewed trust changes.'
+          'The common patterns are familiar. Wildcard principals in trust policies. Cross-account roles without strong conditions. GitHub OIDC trust relationships that only check the provider, not the repo or branch context. Workload roles that carry broad read or write permissions because it was easier than modeling the exact need.',
+          'None of those are novel. The problem is that they accumulate silently. Teams see them as local exceptions, but attackers experience them as one connected privilege system.'
         ],
         bullets: [
-          'Broad role policies (`Action: *`, `Resource: *`) in production contexts.',
-          'Trust policies with unnecessary principals and missing conditions.',
-          'Long-lived access keys where role-based temporary credentials are possible.',
-          'No pre-merge validation or pre-release policy simulation.'
+          'Trust policies that accept more principals than intended.',
+          'Reusable automation roles shared across unrelated systems.',
+          'Cross-account assumptions without strong external or contextual constraints.',
+          'High-value data plane permissions attached to general-purpose workload roles.'
         ]
       },
       {
-        heading: 'A remediation order that avoids outages',
+        heading: 'Why static IAM review is not enough',
         paragraphs: [
-          'First, establish visibility and quality gates. Then tighten high-risk trust paths in staged batches by environment and service criticality.',
-          'This sequence lowers security risk while preserving release reliability, which is usually where IAM hardening projects fail.'
+          'A role can look acceptable when reviewed alone. The issue becomes obvious only when you attach the rest of the chain: who can mint the session, under what conditions, in which account, and what the assumed role can then reach.',
+          'That is why mature AWS identity reviews combine policy analysis with reachability analysis. They do not stop at "can this role do X?" They continue to "which machine identities can get to this role, and which production resources sit behind it?"'
+        ]
+      },
+      {
+        heading: 'What remediation should look like',
+        paragraphs: [
+          'The right fix is usually narrower than teams fear. Tighten trust policy conditions. Break shared automation roles into environment-specific roles. Reduce broad data access permissions first, then shrink the rest over time. Use validation and simulation before rollout so the organization does not trade access risk for deployment risk.',
+          'In practice, the most effective AWS remediation plans are prioritized. You do not need to rewrite all IAM policies in one quarter. You need to remove the highest-impact trust paths first.'
+        ]
+      },
+      {
+        heading: 'Where Identrail fits',
+        paragraphs: [
+          'Identrail helps teams see AWS machine identity risk as a real path, not a disconnected policy file. It maps who can assume what, which role chain reaches which resources, and where blast radius expands across accounts and workloads.',
+          'That lets cloud security teams focus on the misconfigurations that actually matter: reachable, production-relevant paths that can be fixed safely and explained clearly to engineering owners.'
         ]
       }
     ],
-    identrailFit: [
-      'Identrail exposes cross-account trust chains and privilege paths, not just isolated policy findings.',
-      'It prioritizes remediation by reachable impact, helping teams fix what actually reduces blast radius.',
-      'Simulation-first rollout support reduces production disruption during IAM hardening.'
-    ],
     references: [
       {
-        label: 'AWS IAM Security Best Practices',
+        label: 'AWS IAM policy evaluation logic',
+        href: 'https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html'
+      },
+      {
+        label: 'AWS STS AssumeRole API reference',
+        href: 'https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html'
+      },
+      {
+        label: 'AWS IAM best practices',
         href: 'https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html'
       },
       {
-        label: 'IAM Access Analyzer Policy Validation',
-        href: 'https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-policy-validation.html'
-      },
-      {
-        label: 'IAM Policy Simulator',
-        href: 'https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html'
+        label: 'AWS IAM Access Analyzer findings',
+        href: 'https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-findings-view.html'
       }
     ]
   },
@@ -186,54 +206,62 @@ export const BLOG_POSTS: BlogPost[] = [
       'How to map service account privilege escalations and implement rollout-safe policy tightening without downtime.',
     category: 'Kubernetes Security',
     readTime: '9 min',
-    summary:
-      'Kubernetes identity risk is usually a chain of small grants. This article focuses on practical RBAC and service-account fixes that work in live clusters.',
+    intro: [
+      'Kubernetes machine identity problems are often described as RBAC sprawl. That is true, but incomplete. The harder problem is that Kubernetes access rarely stops at Kubernetes. A service account can trigger cloud access through workload identity, read secrets that unlock external systems, or operate inside a namespace that is less isolated than everyone assumed.',
+      'That is why Kubernetes machine identity security has to move beyond single binding reviews. You need to understand which service accounts can actually reach privileged actions, sensitive namespaces, and external cloud resources.'
+    ],
     sections: [
       {
-        heading: 'Why RBAC reviews miss real escalation',
+        heading: 'The RBAC paths that deserve attention first',
         paragraphs: [
-          'Teams often audit roles one by one, but escalation risk typically emerges from combinations: service accounts, bindings, token behavior, admission gaps, and namespace boundaries.',
-          'A permission that looks harmless in isolation can become dangerous when chained with secret access, pod creation, or control-plane adjacent actions.'
-        ]
-      },
-      {
-        heading: 'What to fix first in production',
-        paragraphs: [
-          'Start by reducing default service-account privilege and reviewing cluster-wide bindings. Then enforce admission controls for unsafe RBAC changes and ensure API audit logs support identity-path analysis.',
-          'This order gives immediate reduction in exploitability without attempting an all-at-once RBAC rewrite.'
+          'Teams usually find the same risky patterns. Default or broadly reused service accounts. Namespace-local roles that quietly include secret read or pod exec permissions. ClusterRoleBindings that were added for operational convenience and never narrowed later.',
+          'The most dangerous cases are not always the ones with the longest YAML. They are the ones that combine Kubernetes permissions with another trust boundary, such as IRSA, external secret managers, or CI-issued deploy credentials.'
         ],
         bullets: [
-          'Scope service accounts to workload function and environment.',
-          'Remove unnecessary ClusterRoleBinding entries with broad authority.',
-          'Apply validating admission controls for risky RBAC mutations.',
-          'Enable and tune Kubernetes audit logs for authorization visibility.'
+          'Service accounts shared by multiple workloads.',
+          'Bindings that allow secret read, pod exec, or workload creation.',
+          'Cluster-wide access granted to namespaced automation.',
+          'Cloud reachability attached to Kubernetes identities.'
         ]
       },
       {
-        heading: 'Rollout without breaking workloads',
+        heading: 'Why fixes stall in real environments',
         paragraphs: [
-          'Use monitor-first, then canary policy tightening by namespace tier. Keep rollback paths explicit and tested. Security controls only stick when platform reliability is preserved.',
-          'The goal is progressive reduction of exploitable paths, not perfect policy in one release.'
+          'Most platform teams know some RBAC is too broad. They delay fixes because they do not know what will break. A production cluster is full of hidden coupling: a job depends on one secret read, an operator still needs one cluster-scoped verb, a deployment pipeline assumes a legacy binding still exists.',
+          'That means the bottleneck is not detection. It is confidence. Teams need a way to understand the path, model the impact, and tighten access without creating a service incident.'
+        ]
+      },
+      {
+        heading: 'A practical remediation sequence',
+        paragraphs: [
+          'The cleanest path is staged. Start with visibility into the service account, its RBAC grants, and any attached cloud identity. Group findings by production impact. Then reduce the highest-risk verbs first, especially secret access, workload creation, and cluster-wide permissions. Where possible, shift shared identities into workload-specific identities.',
+          'This turns Kubernetes identity hardening into an engineering workflow. It becomes reviewable, testable, and much easier to prioritize.'
+        ]
+      },
+      {
+        heading: 'Where Identrail fits',
+        paragraphs: [
+          'Identrail helps teams map Kubernetes service accounts as part of a larger trust graph. It connects RBAC exposure to the downstream cloud or data systems that make the finding materially risky.',
+          'That matters because platform teams do not need another generic RBAC report. They need to know which service account paths matter first, what those paths can reach, and how to tighten them without downtime.'
         ]
       }
     ],
-    identrailFit: [
-      'Identrail maps service-account privilege paths with cross-layer trust context.',
-      'It helps teams target exploitable escalation chains for staged remediation.',
-      'Simulation and evidence outputs support safer RBAC tightening in production.'
-    ],
     references: [
       {
-        label: 'Kubernetes RBAC Authorization',
-        href: 'https://kubernetes.io/docs/reference/access-authn-authz/rbac/'
-      },
-      {
-        label: 'Kubernetes Service Accounts',
+        label: 'Kubernetes service accounts',
         href: 'https://kubernetes.io/docs/concepts/security/service-accounts/'
       },
       {
-        label: 'Kubernetes Auditing',
+        label: 'Kubernetes RBAC reference',
+        href: 'https://kubernetes.io/docs/reference/access-authn-authz/rbac/'
+      },
+      {
+        label: 'Kubernetes audit logging',
         href: 'https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/'
+      },
+      {
+        label: 'Amazon EKS IAM roles for service accounts',
+        href: 'https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html'
       }
     ]
   },
@@ -244,54 +272,61 @@ export const BLOG_POSTS: BlogPost[] = [
       'How platform teams operationalize git credential leak findings and connect them to real machine identity risk.',
     category: 'Software Supply Chain',
     readTime: '7 min',
-    summary:
-      'Secret scanners are detection engines, not response programs. This article shows how to convert leak alerts into measurable containment and risk reduction.',
+    intro: [
+      'Repository exposure programs often start with a simple goal: find secrets before attackers do. That is necessary, but it is not the full job. The harder question is which exposed credential or workflow token can actually turn into machine identity reachability in production.',
+      'Without that second layer, secret scanning becomes a noisy triage queue. Teams rotate tokens, close tickets, and still fail to reduce the trust paths that matter.'
+    ],
     sections: [
       {
-        heading: 'Why secret alerts become noise',
+        heading: 'Why secret findings pile up',
         paragraphs: [
-          'Many teams have scanning enabled but still struggle with credential incidents. The gap is triage context: validity, privilege, reachable systems, and owner accountability are often unknown at alert time.',
-          'Without context, teams prioritize by regex confidence or timestamp, not exploitability.'
+          'A leaked key or workflow credential is not equally dangerous in every context. One credential might be scoped to a sandbox. Another might let a CI job assume a production role. If the review process treats both findings the same, teams either burn time on low-value work or miss the urgent issue.',
+          'The answer is to connect the repository finding to the identity path behind it. Which system issued the credential? Which trust relationship accepts it? Which role or service account can it reach? Which data plane permissions sit at the end?'
         ]
       },
       {
-        heading: 'Design a program, not just a scan job',
+        heading: 'What a real repo exposure program should do',
         paragraphs: [
-          'A resilient exposure program links detection to classification, revoke/rotate automation, clear ownership routing, and prevention feedback into delivery pipelines.',
-          'The most useful KPI is high-impact mean time to containment, not total alerts closed.'
+          'A mature program does more than detect strings. It classifies credentials, enriches them with source repository and workflow context, and links them to the infrastructure or identity systems they can influence.',
+          'That is especially important for GitHub Actions and OIDC-based flows. In those environments, the secret itself may not be long-lived, but the workflow can still mint a token that reaches a powerful machine role if the trust relationship is too open.'
         ],
         bullets: [
-          'Classify leaked credentials by active access and environment criticality.',
-          'Automate containment runbooks for common credential classes.',
-          'Route response with explicit service owner SLAs.',
-          'Feed recurrent root causes into SDLC guardrails.'
+          'Separate dormant leaks from production-reachable identity exposure.',
+          'Track the repository, workflow, branch, and environment tied to a finding.',
+          'Prioritize findings that map to cloud roles, service accounts, or high-value pipelines.'
         ]
       },
       {
-        heading: 'Tie credential hygiene to machine identity posture',
+        heading: 'How remediation gets better',
         paragraphs: [
-          'Credential leaks are not only repository hygiene issues. They are machine identity risk issues because leaked credentials often map directly to trust paths in cloud environments.',
-          'Connecting code exposure to live identity blast radius produces better prioritization and faster containment.'
+          'Once findings are tied to trust paths, remediation becomes clearer. Sometimes the right move is still token rotation. Often the better long-term fix is narrowing the trust policy, reducing role scope, locking OIDC claims to specific repos or branches, or tightening environment protection rules.',
+          'That is how platform teams move from a secrets program to a machine identity exposure program. The output is no longer "we found a secret." It becomes "this repository path can reach this production role."'
+        ]
+      },
+      {
+        heading: 'Where Identrail fits',
+        paragraphs: [
+          'Identrail connects repository exposure signals to the machine identity paths they can unlock. That gives security and platform teams the context they need to tell the difference between cleanup work and urgent exposure.',
+          'In practice, that means teams can prioritize the small number of repository findings that truly expand blast radius instead of drowning in a flat stream of leaks.'
         ]
       }
     ],
-    identrailFit: [
-      'Identrail correlates repository exposure findings with machine-identity trust paths.',
-      'It helps teams separate high-impact leaks from low-risk noise quickly.',
-      'Shared evidence improves coordination between security and platform responders.'
-    ],
     references: [
       {
-        label: 'GitHub Secret Scanning',
-        href: 'https://docs.github.com/code-security/secret-scanning/about-secret-scanning'
+        label: 'GitHub secret scanning overview',
+        href: 'https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning'
       },
       {
-        label: 'NIST SSDF SP 800-218',
-        href: 'https://csrc.nist.gov/publications/detail/sp/800-218/final'
+        label: 'GitHub security hardening for Actions',
+        href: 'https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions'
       },
       {
-        label: 'CISA Software Supply Chain Recommended Practices',
-        href: 'https://www.cisa.gov/resources-tools/resources/securing-software-supply-chain-recommended-practices-guide-customers-and'
+        label: 'GitHub OIDC security hardening',
+        href: 'https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect'
+      },
+      {
+        label: 'NIST SP 800-218: Secure Software Development Framework',
+        href: 'https://csrc.nist.gov/pubs/sp/800/218/final'
       }
     ]
   },
@@ -302,54 +337,57 @@ export const BLOG_POSTS: BlogPost[] = [
       'A transparent analysis of architecture, control, and TCO tradeoffs for enterprise buyers evaluating vendors.',
     category: 'Buying Guide',
     readTime: '6 min',
-    summary:
-      'This is less a feature battle and more an operating-model decision. The right choice depends on control requirements, team capacity, and long-term portability.',
+    intro: [
+      'Enterprise buyers evaluating machine identity platforms are usually balancing three pressures at once: time to value, control over deployment, and confidence in how decisions are made. That is why architecture matters as much as feature count.',
+      'The core choice is often not open source versus commercial. It is whether the product gives you enough transparency to understand what it sees, why it flagged a path, and how a control change will affect production.'
+    ],
     sections: [
       {
-        heading: 'What buyers often miss',
+        heading: 'What closed platforms do well',
         paragraphs: [
-          'Platform selection is frequently optimized for fast onboarding instead of long-term operational control. That creates lock-in and architectural friction as requirements evolve.',
-          'Machine identity security touches cloud, platform engineering, compliance, and incident response. Vendor choices should be tested against those real workflows.'
+          'Closed platforms often deliver fast onboarding, polished workflows, and strong commercial support. For some teams, that is exactly the right tradeoff. If the organization wants a hosted service with minimal operational ownership, a managed model can reduce the time required to get to an initial deployment.',
+          'The downside appears later, when the buyer needs to explain how a finding was derived, fit the product into internal architecture constraints, or adapt the system to a more opinionated engineering environment.'
         ]
       },
       {
-        heading: 'Evaluation criteria that survive beyond pilot phase',
+        heading: 'What open-core changes for the buyer',
         paragraphs: [
-          'Strong evaluations check transparency of risk logic, quality of trust-path explainability, rollout safety controls, and audit evidence portability. Teams should also assess migration cost if strategy changes after year one.',
-          'Short demos rarely expose these factors. Structured scorecards and scenario-based testing do.'
+          'Open-core can reduce that black-box problem. It gives technical teams a clearer view of data collection, trust-path construction, and control boundaries, while still leaving room for commercial deployment models and enterprise features where they matter.',
+          'That does not automatically make it cheaper or better. It does make it easier to evaluate on technical truth. You can inspect the architecture, test it in your own environment, and make a more informed decision about where you want managed versus self-managed responsibility.'
         ],
         bullets: [
-          'Can the platform explain exactly why a path is risky?',
-          'Can controls be tuned without brittle custom glue?',
-          'Can evidence be exported for audit and executive reporting?',
-          'Can deployment mode evolve without re-platforming?'
+          'Greater transparency into how findings and relationships are modeled.',
+          'More flexibility for self-hosted evaluation or regulated environments.',
+          'Easier collaboration between security and platform teams during rollout.'
         ]
       },
       {
-        heading: 'Use objective ecosystem signals',
+        heading: 'What buyers should ask',
         paragraphs: [
-          'Complement product evaluation with objective ecosystem indicators such as supply-chain framework alignment and project security health metrics.',
-          'These signals do not replace engineering validation, but they improve procurement decisions and reduce narrative bias.'
+          'The right buying questions are practical. Can the product explain why a path exists? Can it show what would change before enforcement? Can the team self-host if procurement or residency requirements demand it? Can engineering owners validate the output without trusting a black box?',
+          'Those questions usually reveal more than a long comparison spreadsheet. In a category like machine identity security, operational confidence is part of the product.'
+        ]
+      },
+      {
+        heading: 'Where Identrail fits',
+        paragraphs: [
+          'Identrail is designed as an open-core, developer-trustable platform. Teams can evaluate the core transparently, understand the trust graph and evidence model, and then choose whether open-source, hosted, or enterprise deployment fits their environment.',
+          'That positioning matters because machine identity security only works when security teams and platform teams trust what the product is showing them. Transparency is not a nice-to-have. It is part of the control plane.'
         ]
       }
     ],
-    identrailFit: [
-      'Identrail provides open-core transparency with enterprise-ready control pathways.',
-      'Teams can prove value quickly, then scale deployment model without changing the operating workflow.',
-      'The platform is designed for shared security and platform ownership from day one.'
-    ],
     references: [
       {
-        label: 'SLSA Framework',
-        href: 'https://slsa.dev/'
+        label: 'NIST SP 800-218: Secure Software Development Framework',
+        href: 'https://csrc.nist.gov/pubs/sp/800/218/final'
       },
       {
-        label: 'OpenSSF Scorecard',
-        href: 'https://scorecard.dev/'
+        label: 'CISA Secure by Design',
+        href: 'https://www.cisa.gov/securebydesign'
       },
       {
-        label: 'NIST SP 800-207',
-        href: 'https://csrc.nist.gov/pubs/sp/800/207/final'
+        label: 'OpenSSF',
+        href: 'https://openssf.org/'
       }
     ]
   },
@@ -360,54 +398,62 @@ export const BLOG_POSTS: BlogPost[] = [
       'Generate evidence for SOC 2 and ISO 27001 with trust graph snapshots, policy simulations, and remediation trails.',
     category: 'Compliance',
     readTime: '11 min',
-    summary:
-      'Least privilege claims fail audits when evidence is static or incomplete. This article details an evidence model auditors can actually validate.',
+    intro: [
+      'Most audit pain around machine identities comes from one gap: teams can state least privilege as a policy goal, but they cannot produce clear evidence that it is true in practice. Screenshots of policies and access reviews are not enough when non-human identities move across cloud, cluster, CI, and secret-management boundaries.',
+      'Auditors are usually looking for a simple chain of reasoning. What identities exist? What can they reach? How is access reviewed? How are risky permissions reduced safely? The more explainable your answers are, the easier the audit becomes.'
+    ],
     sections: [
       {
-        heading: 'Audit reality: evidence over intent',
+        heading: 'What evidence is actually useful',
         paragraphs: [
-          'Saying least privilege is enforced does not satisfy audit requirements. Auditors expect evidence of current access state, review process, exceptions, and remediation effectiveness.',
-          'For non-human identities, this is especially important because privilege drift can happen rapidly through pipeline and infrastructure changes.'
-        ]
-      },
-      {
-        heading: 'Build an evidence package that holds up',
-        paragraphs: [
-          'An effective package includes point-in-time trust snapshots, trend lines for high-risk path reduction, policy change histories, and exception registers with owner plus expiry.',
-          'Evidence must be reproducible and linked to control operation, not assembled as static narrative near audit deadlines.'
+          'Useful least-privilege evidence combines current state, change control, and proof of review. A trust graph snapshot shows current reachability. A simulation or validation artifact shows how a change was tested before rollout. A remediation trail shows the finding was closed intentionally rather than accidentally disappearing from a dashboard.',
+          'This is why flat entitlement exports are rarely persuasive on their own. They list permissions, but they do not show the path from identity to sensitive target or the operational process used to reduce that path.'
         ],
         bullets: [
-          'Current machine-identity inventory and effective permission view.',
-          'High-impact trust paths with treatment decisions and timestamps.',
-          'Policy change logs with validation and simulation outcomes.',
-          'Exception records with owner, expiration, and closure state.'
+          'Current-state trust-path evidence.',
+          'Owner and review history.',
+          'Before-and-after policy comparison.',
+          'Remediation timeline tied to a ticket or change event.'
         ]
       },
       {
-        heading: 'Align to SOC 2 and ISO 27001 without heavy manual overhead',
+        heading: 'How to make least privilege reviewable',
         paragraphs: [
-          'Teams that continuously collect evidence reduce audit friction significantly. Automated evidence generation lowers manual prep and improves confidence in control effectiveness.',
-          'The practical objective is audit-ready operations, not audit-season document reconstruction.'
+          'The fastest way to improve audit readiness is to standardize what "review" means. Teams should define a short set of artifacts for high-risk machine identities: source principal, trust relationship, reachable sensitive target, current justification, and planned reduction if the path is broader than intended.',
+          'This creates a consistent operating record. It also helps engineering teams because the audit artifact becomes the same artifact they use for prioritization and remediation.'
+        ]
+      },
+      {
+        heading: 'Why simulation matters',
+        paragraphs: [
+          'Auditors increasingly care about control effectiveness, not just the existence of a policy. If a team can show that a trust change was simulated, staged, and reviewed before enforcement, that demonstrates a stronger control process than a one-time manual edit.',
+          'It also makes the evidence more believable. Least privilege is easier to defend when you can show how the organization reduces access without breaking production.'
+        ]
+      },
+      {
+        heading: 'Where Identrail fits',
+        paragraphs: [
+          'Identrail turns least-privilege evidence into an operational artifact. It shows which machine identity path exists today, why it is risky, and what control change is being proposed before the change is enforced.',
+          'That makes the same system useful for both sides of the house: security gets defensible evidence, and platform teams get a safer workflow for tightening access over time.'
         ]
       }
     ],
-    identrailFit: [
-      'Identrail provides trust-graph snapshots and remediation trails suitable for audit evidence.',
-      'It tracks risk-path reduction over time to support least-privilege control claims.',
-      'Security, platform, and compliance teams can review a shared evidence source.'
-    ],
     references: [
       {
-        label: 'AICPA SOC 2 Resources',
-        href: 'https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2'
+        label: 'NIST SP 800-53 AC-6 Least Privilege',
+        href: 'https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final'
       },
       {
-        label: 'ISO/IEC 27001',
-        href: 'https://www.iso.org/standard/27001'
+        label: 'NIST SP 800-207: Zero Trust Architecture',
+        href: 'https://csrc.nist.gov/pubs/sp/800/207/final'
       },
       {
-        label: 'NIST Cybersecurity Framework 2.0 Guide',
-        href: 'https://www.nist.gov/publications/nist-cybersecurity-framework-20-resource-overview-guide'
+        label: 'AWS IAM Access Analyzer',
+        href: 'https://docs.aws.amazon.com/IAM/latest/UserGuide/what-is-access-analyzer.html'
+      },
+      {
+        label: 'Kubernetes audit logging',
+        href: 'https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/'
       }
     ]
   },
@@ -418,54 +464,62 @@ export const BLOG_POSTS: BlogPost[] = [
       'Staged policy rollouts, simulation gates, and kill-switch patterns that reduce authz outage risk in production.',
     category: 'Platform Engineering',
     readTime: '8 min',
-    summary:
-      'Authorization hardening often fails because rollout safety is underdesigned. This article presents a release-engineering model for policy controls.',
+    intro: [
+      'Most teams do not avoid authorization hardening because they disagree with the goal. They avoid it because access changes can break production in ways that are hard to predict. That is especially true when machine identities span multiple systems and ownership is distributed.',
+      'A rollout-safe authorization program is really a software delivery discipline. It treats policy changes like production changes: scoped, previewed, staged, monitored, and reversible.'
+    ],
     sections: [
       {
-        heading: 'Why hardening initiatives trigger outages',
+        heading: 'What makes auth changes risky',
         paragraphs: [
-          'Many teams implement strict policies in one step and discover production breakage after deployment. That erodes trust between security and platform teams.',
-          'The underlying issue is process design: policy changes are treated as simple config updates instead of high-impact production releases.'
+          'Authorization failures are rarely visible until a workload tries to do real work. A role assumption fails during deploy. A service account loses access to one secret. A CI job can still read a repo but can no longer publish an artifact. The control is technically tighter, but the operational effect is an incident.',
+          'That is why good teams do not jump straight from finding to enforcement. They validate the proposed change in the context of the workload and the path it serves.'
         ]
       },
       {
-        heading: 'A rollout-safe authorization pattern',
+        heading: 'The staged rollout pattern',
         paragraphs: [
-          'Use simulation first, monitor mode second, canary deployment third, and gated expansion with tested rollback controls. This pattern mirrors safe software delivery principles.',
-          'Teams should define ownership for each gate, including who can halt rollout and who can trigger rollback.'
+          'The most reliable pattern is simple: identify the risky path, simulate the narrower access, roll out to one bounded environment or identity set, monitor impact, and keep a rollback path. If the first stage is clean, continue to the next stage. If it is not, you have learned something without taking out production.',
+          'This applies across AWS IAM, Kubernetes authorization, and CI/OIDC-based trust. The implementation details differ, but the operating model is the same.'
         ],
         bullets: [
-          'Run pre-enforcement simulation against representative workloads.',
-          'Canary policies by environment or service tier.',
-          'Use reliability gates (error rate, deny rate, SLO impact) before expansion.',
-          'Maintain explicit rollback and kill-switch procedures.'
+          'Preview before enforcement.',
+          'Roll out in small scopes first.',
+          'Monitor for auth failures tied to the change.',
+          'Preserve a fast rollback or temporary bypass.'
         ]
       },
       {
-        heading: 'Make security and reliability shared outcomes',
+        heading: 'Why platform teams should own the workflow',
         paragraphs: [
-          'When teams can see policy impact before full enforcement, security controls become easier to adopt and sustain.',
-          'The target state is predictable, low-drama hardening with measurable risk reduction.'
+          'Security should set the risk bar and priorities. Platform teams usually own the deployment mechanics and the confidence model. When both sides share the same evidence and rollout sequence, authorization hardening stops being a political exercise and becomes an engineering one.',
+          'That is usually the difference between a quarterly permissions cleanup and a continuous control program.'
+        ]
+      },
+      {
+        heading: 'Where Identrail fits',
+        paragraphs: [
+          'Identrail is designed around rollout-safe control changes. It does not stop at surfacing a risky path. It helps teams inspect the path, understand the likely impact of tightening it, and sequence the remediation in a way engineering can actually execute.',
+          'That matters because the hardest part of authorization is not seeing the risk. It is removing the risk without breaking the system that depends on it.'
         ]
       }
     ],
-    identrailFit: [
-      'Identrail supports simulation-first policy hardening and staged rollout controls.',
-      'It surfaces likely impact before production-wide enforcement decisions.',
-      'Teams can improve least privilege while preserving platform reliability.'
-    ],
     references: [
       {
-        label: 'OPA Policy Testing',
-        href: 'https://www.openpolicyagent.org/docs/latest/policy-testing/'
+        label: 'AWS IAM policy simulator',
+        href: 'https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html'
       },
       {
-        label: 'Kubernetes Admission Webhook Good Practices',
-        href: 'https://kubernetes.io/docs/concepts/cluster-administration/admission-webhooks-good-practices/'
+        label: 'Kubernetes dry-run',
+        href: 'https://kubernetes.io/docs/reference/using-api/api-concepts/#dry-run'
       },
       {
-        label: 'Google SRE Canarying Releases',
-        href: 'https://sre.google/workbook/canarying-releases/'
+        label: 'GitHub deployment environments',
+        href: 'https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment'
+      },
+      {
+        label: 'Open Policy Agent',
+        href: 'https://www.openpolicyagent.org/docs/latest/'
       }
     ]
   },
@@ -476,54 +530,58 @@ export const BLOG_POSTS: BlogPost[] = [
       'Metrics that connect machine identity posture improvements to incident reduction and executive risk reporting.',
     category: 'Security Leadership',
     readTime: '7 min',
-    summary:
-      'Leadership reporting improves when metrics reflect reachable risk, not control activity. Trust graphs provide a strong model for decision-grade security metrics.',
+    intro: [
+      'Security leaders do not need more raw machine identity data. They need a way to explain whether identity risk is shrinking, where exposure is concentrated, and whether engineering teams are getting faster at fixing the right problems.',
+      'Trust graphs can help, but only if they are tied to decisions. The point is not to admire the graph. The point is to make blast radius, ownership, and remediation progress visible enough to manage.'
+    ],
     sections: [
       {
-        heading: 'Move beyond activity dashboards',
+        heading: 'The metrics worth putting in front of leadership',
         paragraphs: [
-          'Security dashboards often emphasize counts: alerts, tickets, policies touched. These metrics are operationally useful but weak for executive risk decisions.',
-          'Leaders need to know whether high-impact exposure is decreasing and how quickly the organization can reduce newly discovered risk.'
-        ]
-      },
-      {
-        heading: 'Metrics that create better prioritization',
-        paragraphs: [
-          'A trust-graph model supports metrics like critical path count to crown-jewel systems, mean time to remediate top-tier identity exposure, least-privilege coverage for production identities, and policy rollout failure rate.',
-          'These metrics connect engineering work directly to incident likelihood and business impact.'
+          'The most useful machine identity metrics are path-oriented. How many high-severity trust paths reach production-sensitive resources? How many of those paths are unowned? How long does it take to validate and remediate one? How often do new risky paths appear because a delivery workflow or integration changed?',
+          'Those metrics are better than raw identity counts because they connect posture to exposure. A graph with 20,000 identities is not a problem by itself. A graph with 40 unreviewed production-reachable paths is.'
         ],
         bullets: [
-          'Number of critical trust paths to sensitive systems.',
-          'Time-to-remediate high-impact machine-identity risk.',
-          'Least-privilege coverage across production machine identities.',
-          'Authorization rollout failure and recovery trends.'
+          'High-severity production-reachable trust paths.',
+          'Mean time to validate a reported path.',
+          'Mean time to remediate high-impact findings.',
+          'Share of paths with clear owner and remediation state.'
         ]
       },
       {
-        heading: 'Use external frameworks for reporting context',
+        heading: 'What not to over-index on',
         paragraphs: [
-          'Framework mapping can improve communication quality. ATT&CK cloud coverage can frame detection posture, while DORA delivery metrics can indicate whether controls are improving safely and sustainably.',
-          'The goal is board-level clarity without flattening technical nuance.'
+          'Leaders should be careful with metrics that are easy to count but hard to interpret. Total IAM policies, total service accounts, or total findings can all move in the wrong direction for good reasons. More infrastructure usually means more identities.',
+          'What matters is whether the organization is reducing unnecessary reachability and getting faster at acting on material findings.'
+        ]
+      },
+      {
+        heading: 'How to use the metrics operationally',
+        paragraphs: [
+          'The best reporting rhythm is simple: identify the most exposed trust chains, show trend movement, and tie that to a short list of remediation outcomes. Executives get clarity on risk reduction. Engineering teams see which actions changed the number, not just the narrative.',
+          'When done well, trust-graph reporting becomes a bridge between security and platform leadership. It turns identity risk from an abstract governance topic into a measurable engineering problem.'
+        ]
+      },
+      {
+        heading: 'Where Identrail fits',
+        paragraphs: [
+          'Identrail gives leadership a trust-path view that can be reported without losing technical credibility. It shows which machine identity chains reach sensitive systems, how those paths are changing over time, and which remediation actions are reducing real blast radius.',
+          'That creates a much stronger story than generic entitlement dashboards. Leaders can talk about exposure, ownership, and control effectiveness using evidence the engineering teams actually trust.'
         ]
       }
     ],
-    identrailFit: [
-      'Identrail turns identity relationships into measurable trust-path risk metrics.',
-      'It helps leadership connect remediation activity to reduced blast radius and incident exposure.',
-      'Evidence outputs are structured for both engineering and executive reporting workflows.'
-    ],
     references: [
       {
-        label: 'MITRE ATT&CK Cloud Matrix',
-        href: 'https://attack.mitre.org/matrices/enterprise/cloud/'
+        label: 'NIST SP 800-207: Zero Trust Architecture',
+        href: 'https://csrc.nist.gov/pubs/sp/800/207/final'
       },
       {
-        label: 'DORA Metrics Guide',
-        href: 'https://dora.dev/guides/dora-metrics/'
+        label: 'CISA Secure by Design',
+        href: 'https://www.cisa.gov/securebydesign'
       },
       {
-        label: 'CISA Zero Trust Maturity Model',
-        href: 'https://www.cisa.gov/zero-trust-maturity-model'
+        label: 'AWS IAM Access Analyzer',
+        href: 'https://docs.aws.amazon.com/IAM/latest/UserGuide/what-is-access-analyzer.html'
       }
     ]
   }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1954,8 +1954,34 @@ h2 {
   max-width: 860px;
 }
 
+.idt-blog-lead {
+  font-size: 1.06rem;
+  line-height: 1.78;
+  color: #dfe8f9;
+}
+
+.idt-blog-section + .idt-blog-section {
+  margin-top: 1.6rem;
+}
+
 .idt-blog-article h2 {
   margin-top: 1.6rem;
+}
+
+.idt-blog-article ul {
+  margin: 0.9rem 0 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.idt-blog-reference-list {
+  list-style: none;
+  padding-left: 0;
+}
+
+.idt-blog-reference-list li {
+  display: flex;
 }
 
 .idt-search {
@@ -3758,6 +3784,10 @@ html[data-theme='light'] .idt-form-success {
   background: rgba(38, 71, 127, 0.1);
   border-color: rgba(31, 57, 100, 0.24);
   color: #19315a;
+}
+
+html[data-theme='light'] .idt-blog-lead {
+  color: #294267;
 }
 
 html[data-theme='light'] .idt-footer-bar {


### PR DESCRIPTION
## Summary
- replace the generic blog article template with full article content for all 8 blog posts
- add structured article intros, section bodies, reference links, and product tie-in endings
- update the article page to render real longform content and references cleanly

## Why
- the blog currently has placeholder article pages that do not support launch-quality educational content
- the site needs credible, readable, search-friendly content that explains the category and connects back to Identrail naturally

## Scope
- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation
- `npm install` in `web`
- `npm run test -- --run` ✅
- `npm run build` ✅

## Checklist
- [ ] Tests added/updated for behavior changes
- [ ] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure
- AI-assisted: yes
- Tools used: GPT-5 Codex CLI
- Areas where used: longform article drafting, article data-model updates, page rendering updates
- Human verification performed: reviewed content structure and validated site build/tests locally

## Related Issues
- N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the generic blog template with real longform articles and a cleaner content model. The article page now shows lead intros, structured sections, chips, and a safer references list across 8 posts.

- **New Features**
  - Updated `BlogPost`: added `intro: string[]`, replaced `summary` with `description`, and removed `identrailFit`; populated full content for 8 articles.
  - Renderer now shows a chip row (category, read time), lead intros, section wrappers with paragraphs/bullets, and a “References and further reading” list with safe external links.
  - Added styles for blog leads, section spacing, improved list layout, a `.idt-blog-reference-list`, and light-theme colors.

<sup>Written for commit ea22a02ce8702ce87ab43a2f543db2c69f589a9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

