### PR TITLE
docs: align troubleshooting with async scan queue behavior

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -15,13 +15,19 @@ Checks:
 2. Check provider rate limits and transient API failures.
 3. Confirm collector retry/backoff settings are active.
 
-## API `409 scan already in progress`
+## API scan trigger rejected (`429 scan queue is full`)
 
 Checks:
-1. Confirm long-running scan status in `/v1/scans`.
-2. Validate lock backend:
-   - multi-instance should use `IDENTRAIL_LOCK_BACKEND=postgres`.
-3. Verify same namespace for lock keys (`IDENTRAIL_LOCK_NAMESPACE`).
+1. Confirm worker is running and draining queued jobs.
+2. Check queue settings:
+   - `IDENTRAIL_SCAN_QUEUE_MAX_PENDING`
+   - `IDENTRAIL_WORKER_API_JOB_QUEUE_ENABLED`
+   - `IDENTRAIL_WORKER_API_JOB_QUEUE_INTERVAL`
+   - `IDENTRAIL_WORKER_API_JOB_QUEUE_BATCH_SIZE`
+3. Confirm no prolonged downstream scanner failures are stalling queue drain.
+
+Note:
+- `POST /v1/scans` is asynchronous and returns `202` when accepted into queue.
 
 ## No Findings Returned
 


### PR DESCRIPTION
## Summary
Updates troubleshooting guidance to reflect current async scan trigger behavior.

## Changes
- replaces old 409 in-progress section with queue-full diagnostics
- documents 202 accepted semantics for POST /v1/scans
- adds worker queue tuning checks

## Why
Current API enqueues scans; docs should guide operators to queue and worker diagnostics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns troubleshooting docs with the asynchronous scan queue behavior. Replaces the 409 “scan already in progress” guidance with 429 “queue is full”, documents `202 Accepted` for `POST /v1/scans`, and adds queue/worker tuning checks (e.g., `IDENTRAIL_SCAN_QUEUE_MAX_PENDING`, `IDENTRAIL_WORKER_API_JOB_QUEUE_*`) to diagnose stalled drains.

<sup>Written for commit 1090290f6310bb4d5349e6ea2502e61d51ebc709. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

