### PR TITLE
docs: add scope, OIDC claim, and RLS checks to deploy runbook

### DIFF
--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -28,6 +28,16 @@ Portable deployment profiles:
 - Confirm API auth is configured:
   - legacy: `IDENTRAIL_API_KEYS` (+ `IDENTRAIL_WRITE_API_KEYS`)
   - scoped: `IDENTRAIL_API_KEY_SCOPES`
+- Confirm default request scope values for non-claim/non-header contexts:
+  - `IDENTRAIL_DEFAULT_TENANT_ID`
+  - `IDENTRAIL_DEFAULT_WORKSPACE_ID`
+- Confirm OIDC claim mapping when OIDC is enabled:
+  - `IDENTRAIL_OIDC_TENANT_CLAIM`
+  - `IDENTRAIL_OIDC_WORKSPACE_CLAIM`
+  - `IDENTRAIL_OIDC_GROUPS_CLAIM`
+  - `IDENTRAIL_OIDC_ROLES_CLAIM`
+- Confirm Postgres RLS enforcement mode for scoped read paths:
+  - `IDENTRAIL_POSTGRES_RLS_ENFORCED`
 - Confirm alert config:
   - `IDENTRAIL_ALERT_WEBHOOK_URL`
   - `IDENTRAIL_ALERT_MIN_SEVERITY`


### PR DESCRIPTION
## Summary
Extends deploy pre-checks with missing runtime configuration items.

## Changes
- adds default tenant/workspace scope env vars
- adds OIDC claim mapping env vars
- adds Postgres RLS enforcement toggle

## Why
These settings are runtime-supported and should be part of operator pre-deploy validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds new pre-deploy checks to the deploy runbook for default scope, OIDC claim mappings, and Postgres RLS enforcement. This helps operators verify required runtime config before rollout.

- **New Features**
  - Default scope env vars: `IDENTRAIL_DEFAULT_TENANT_ID`, `IDENTRAIL_DEFAULT_WORKSPACE_ID`
  - OIDC claim mapping env vars: `IDENTRAIL_OIDC_TENANT_CLAIM`, `IDENTRAIL_OIDC_WORKSPACE_CLAIM`, `IDENTRAIL_OIDC_GROUPS_CLAIM`, `IDENTRAIL_OIDC_ROLES_CLAIM`
  - RLS enforcement toggle: `IDENTRAIL_POSTGRES_RLS_ENFORCED`

<sup>Written for commit 83d9b29564db6404b6f8bf854717a30ad16acb40. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

