### PR TITLE
docs: add /readyz and /metrics to OpenAPI contract

### DIFF
--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -36,6 +36,43 @@ paths:
                     type: string
                   service:
                     type: string
+  /readyz:
+    get:
+      tags: [Health]
+      summary: Readiness check
+      operationId: readinessCheck
+      security: []
+      responses:
+        "200":
+          description: Service ready
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  service:
+                    type: string
+        "503":
+          description: Service not ready
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /metrics:
+    get:
+      tags: [Health]
+      summary: Prometheus metrics endpoint
+      operationId: metrics
+      security: []
+      responses:
+        "200":
+          description: Prometheus text exposition format
+          content:
+            text/plain:
+              schema:
+                type: string
   /v1/authz/policies/simulate:
     parameters:
       - $ref: "#/components/parameters/scopeTenantID"


### PR DESCRIPTION
## Summary
Adds operational endpoints to the API contract file.

## Changes
- documents GET /readyz with 200/503 responses
- documents GET /metrics as Prometheus text endpoint

## Why
These endpoints are implemented and operator-facing, and should be visible in the published contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `/readyz` and `/metrics` to the OpenAPI contract so operators can check readiness and scrape Prometheus metrics.

- **New Features**
  - Documented `GET /readyz` with `200` (`status`, `service`) and `503` (`ErrorResponse`), no auth, tagged `Health`.
  - Documented `GET /metrics` as Prometheus `text/plain` with `200`, no auth, tagged `Health`.

<sup>Written for commit 778451663075c3e2ff69490c04c6d0dfc83bce1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

