### PR TITLE
docs: expand documentation index coverage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,3 +62,29 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - Reviewer overview: `identrail-reviewer/README.md`
 - Ground-truth dataset guide: `identrail-reviewer/ground-truth-dataset.md`
 - Reviewer operations runbook: `identrail-reviewer/operations-runbook.md`
+
+## Architecture and provider internals
+
+- Architecture overview: `architecture.md`
+- AWS collector details: `aws-collector.md`
+- AWS normalizer and graph: `aws-normalizer-graph.md`
+- AWS risk engine: `aws-risk-engine.md`
+
+## Historical phase records
+
+- Phase 1: `phase-1.md`
+- Phase 2: `phase-2.md`
+- Phase 3: `phase-3.md`
+- Phase 4: `phase-4.md`
+
+## Supply chain implementation notes
+
+- GUAC scaffold notes: `supply-chain-guac.md`
+- Copilot autofix policy: `copilot-autofix.md`
+
+## identrail-reviewer weekly implementation logs
+
+- Week 1 foundation: `identrail-reviewer/week-1-foundation.md`
+- Week 2 judgment engine: `identrail-reviewer/week-2-judgment-engine.md`
+- Week 3 hardening: `identrail-reviewer/week-3-hardening.md`
+- Week 4 rollout: `identrail-reviewer/week-4-rollout.md`


### PR DESCRIPTION
## Summary
Expands docs index coverage to include currently unindexed guides.

## Changes
- adds architecture and AWS internals docs
- adds phase-history docs
- adds supply-chain implementation notes
- adds identrail-reviewer week-by-week docs

## Why
Key docs existed but were hard to discover from the primary index.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand the docs index so all key guides are linked from `docs/README.md`. Adds sections for architecture and provider internals, historical phase records, supply-chain notes, and weekly `identrail-reviewer` logs.

<sup>Written for commit 43de0a72bc08ce8a06c9170629fda2ffff47501e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

