### PR TITLE
docs: add concrete migration catalog to migration strategy

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -39,3 +39,24 @@ Simple migration strategy for production safety.
 - CI integration lane now includes migration roundtrip verification:
   - apply up -> apply down -> apply up
   - run scan and verify persistence still works.
+
+## Current Migration Catalog
+
+Current sequence in `migrations/`:
+
+1. `000001_init` - base schema
+2. `000002_scan_events` - scan lifecycle event stream
+3. `000003_repo_scans` - repo scan persistence tables
+4. `000004_performance_indexes` - baseline performance indexes
+5. `000005_async_job_queue` - queued scan execution tables/paths
+6. `000005_finding_workflow_maturity` - finding triage workflow maturity fields
+7. `000006_tenant_workspace_scope` - tenant/workspace scope columns and guards
+8. `000007_scope_guardrails_for_triage` - triage scope hardening
+9. `000008_postgres_rls_scope_guardrails` - Postgres RLS scope controls
+10. `000009_authz_abac_rebac_data` - central authz ABAC/REBAC data model
+11. `000010_authz_policy_lifecycle_controls` - policy lifecycle primitives
+12. `000011_authz_policy_rollout_staged_controls` - staged rollout controls
+
+Notes:
+- Each migration has matching `.up.sql` and `.down.sql` files.
+- Duplicate numeric prefixes are historical and preserved to avoid reordering risk.


### PR DESCRIPTION
## Summary
Adds a concrete map of current migrations to the migration strategy doc.

## Changes
- lists current migration files in execution order
- adds one-line purpose for each migration set
- documents duplicate numeric prefix caveat

## Why
Operators and reviewers need an explicit migration inventory, not only high-level strategy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a concrete “Current Migration Catalog” to docs/migrations.md that lists all migrations in execution order with a one-line purpose for each. Also documents the matching `.up.sql`/`.down.sql` files and the historical duplicate numeric prefixes to explain ordering stability.

<sup>Written for commit c389fbcd43c570de8925111693111b50e310b3be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

