### PR TITLE
docs: add frontend topology guide for web and site

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 ## API and developer track
 
 - API contract (OpenAPI): `openapi-v1.yaml`
+- Frontend topology (`web/` vs `site/`): `frontend-topology.md`
 - Development workflow: `development-workflow.md`
 - Testing strategy: `testing.md`
 - Migrations strategy: `migrations.md`

--- a/docs/frontend-topology.md
+++ b/docs/frontend-topology.md
@@ -1,0 +1,23 @@
+# Frontend Topology
+
+Identrail currently has two frontend surfaces with different purposes.
+
+## `web/` (product dashboard)
+
+- Stack: Vite + React
+- Purpose: operator-facing app experience tied to API workflows
+- Typical runtime: containerized deployment (`deploy/docker/Dockerfile.web`, optional Helm `web.enabled`)
+- API URL input: `VITE_IDENTRAIL_API_URL`
+
+## `site/` (marketing site)
+
+- Stack: Next.js
+- Purpose: public marketing/documentation landing pages
+- Typical runtime: Vercel-hosted static/dynamic site
+- Not part of the core API/worker runtime path
+
+## Operational Guidance
+
+- Treat `web/` as product UI release surface coupled to API compatibility.
+- Treat `site/` as marketing/content release surface with independent cadence.
+- Validate both in CI where relevant, but keep deployment ownership boundaries explicit.

--- a/docs/frontend-topology.md
+++ b/docs/frontend-topology.md
@@ -1,6 +1,6 @@
 # Frontend Topology
 
-Identrail currently has two frontend surfaces with different purposes.
+Identrail uses a product dashboard today and may include a separate marketing site surface depending on branch/release packaging.
 
 ## `web/` (product dashboard)
 
@@ -9,7 +9,7 @@ Identrail currently has two frontend surfaces with different purposes.
 - Typical runtime: containerized deployment (`deploy/docker/Dockerfile.web`, optional Helm `web.enabled`)
 - API URL input: `VITE_IDENTRAIL_API_URL`
 
-## `site/` (marketing site)
+## `site/` (marketing site, optional in this repo snapshot)
 
 - Stack: Next.js
 - Purpose: public marketing/documentation landing pages


### PR DESCRIPTION
## Summary
Adds a short topology guide clarifying frontend surfaces in this repo.

## Changes
- introduces docs/frontend-topology.md
- explains purpose/runtime boundary for web and site
- links guide from docs index

## Why
Current docs mention both surfaces but do not define ownership/deployment boundaries clearly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a frontend topology guide that clarifies `web/` (Vite + React dashboard) vs `site/` (Next.js marketing), their runtimes, and deployment/ownership boundaries. Notes that `site/` is optional in this repo snapshot; documents `VITE_IDENTRAIL_API_URL`, Helm `web.enabled`, and links the guide from `docs/README.md`.

<sup>Written for commit e738299f4470b6a4b2db25d011284c280da1bc9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

