### PR TITLE
docs: add auth scope and OIDC claim mapping guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 ## Authorization and policy operations
 
 - AuthZ operations runbook: `authz-operator-runbook.md`
+- Auth scope and OIDC claims mapping: `auth-scope-and-claims.md`
 - AuthZ rollout lifecycle: `authz-policy-rollout-runbook.md`
 - Security hardening guidance: `security-hardening.md`
 

--- a/docs/auth-scope-and-claims.md
+++ b/docs/auth-scope-and-claims.md
@@ -1,0 +1,38 @@
+# Auth Scope and Claims Mapping
+
+This guide defines how tenant/workspace scope is derived and how OIDC claims map into authorization context.
+
+## Scope Resolution Order
+
+For each request, scope context is resolved in this order:
+
+1. Verified token claims (`tenant`, `workspace` mapped claims)
+2. Scope headers (`X-Identrail-Tenant-ID`, `X-Identrail-Workspace-ID`)
+3. Runtime defaults (`IDENTRAIL_DEFAULT_TENANT_ID`, `IDENTRAIL_DEFAULT_WORKSPACE_ID`)
+
+## OIDC Claim Mapping
+
+Claim names are configurable:
+
+- `IDENTRAIL_OIDC_TENANT_CLAIM` (default `tenant_id`)
+- `IDENTRAIL_OIDC_WORKSPACE_CLAIM` (default `workspace_id`)
+- `IDENTRAIL_OIDC_GROUPS_CLAIM` (default `groups`)
+- `IDENTRAIL_OIDC_ROLES_CLAIM` (default `roles`)
+
+Issuer/audience controls:
+
+- `IDENTRAIL_OIDC_ISSUER_URL`
+- `IDENTRAIL_OIDC_AUDIENCE`
+
+## Write Authorization
+
+Write access is enforced by scope policy for both API keys and OIDC bearer tokens.
+
+- API keys: scoped keys (`write`/`admin`) or legacy write-key config
+- OIDC: write scopes configured via `IDENTRAIL_OIDC_WRITE_SCOPES`
+
+## Operator Checks
+
+- verify claim names match your IdP token shape
+- verify headers are only trusted from approved proxy paths
+- verify defaults are explicit and valid for your tenant/workspace topology


### PR DESCRIPTION
## Summary
Adds a focused operator guide for scope resolution and OIDC claim mapping.

## Changes
- introduces docs/auth-scope-and-claims.md
- documents scope precedence and claim mapping env vars
- links guide from auth/policy docs index section

## Why
These controls are implemented but were scattered across runbooks and code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an operator guide that explains how tenant/workspace scope is resolved and how OIDC claims map into the auth context. Also clarifies write access behavior and links the guide from the Authorization docs.

- **New Features**
  - New `docs/auth-scope-and-claims.md` covering scope order: verified token claims → headers (`X-Identrail-Tenant-ID`, `X-Identrail-Workspace-ID`) → defaults (`IDENTRAIL_DEFAULT_TENANT_ID`, `IDENTRAIL_DEFAULT_WORKSPACE_ID`).
  - Documents OIDC claim mapping env vars (`IDENTRAIL_OIDC_TENANT_CLAIM`, `IDENTRAIL_OIDC_WORKSPACE_CLAIM`, `IDENTRAIL_OIDC_GROUPS_CLAIM`, `IDENTRAIL_OIDC_ROLES_CLAIM`) and issuer/audience (`IDENTRAIL_OIDC_ISSUER_URL`, `IDENTRAIL_OIDC_AUDIENCE`).
  - Clarifies write authorization for API keys and OIDC (`IDENTRAIL_OIDC_WRITE_SCOPES`).
  - Adds operator checks (claim names, header trust paths, default scope config) and links the guide in `docs/README.md`.

<sup>Written for commit eb45e1d526f36b7bc24a89d21a01993a854b2cc9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

