### PR TITLE
docs: add documentation quality checks guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 
 - API contract (OpenAPI): `openapi-v1.yaml`
 - Development workflow: `development-workflow.md`
+- Documentation quality checks: `documentation-quality-checks.md`
 - Testing strategy: `testing.md`
 - Migrations strategy: `migrations.md`
 - Artifact persistence notes: `persistence-artifacts.md`

--- a/docs/documentation-quality-checks.md
+++ b/docs/documentation-quality-checks.md
@@ -29,7 +29,9 @@ errors=[]
 for f in files:
     txt=f.read_text(errors='ignore')
     for m in re.finditer(r'\[[^\]]+\]\(([^)]+)\)', txt):
-        t=m.group(1).strip().split(None, 1)[0].strip('<>').split('#',1)[0]
+        raw=m.group(1).strip()
+        path=raw[1:].split('>', 1)[0] if raw.startswith('<') else raw.split(None, 1)[0]
+        t=path.split('#',1)[0]
         if not t or t.startswith(('http://','https://','mailto:','#')):
             continue
         if not (f.parent/t).resolve().exists():

--- a/docs/documentation-quality-checks.md
+++ b/docs/documentation-quality-checks.md
@@ -29,7 +29,7 @@ errors=[]
 for f in files:
     txt=f.read_text(errors='ignore')
     for m in re.finditer(r'\[[^\]]+\]\(([^)]+)\)', txt):
-        t=m.group(1).strip().split('#',1)[0]
+        t=m.group(1).strip().split(None, 1)[0].strip('<>').split('#',1)[0]
         if not t or t.startswith(('http://','https://','mailto:','#')):
             continue
         if not (f.parent/t).resolve().exists():

--- a/docs/documentation-quality-checks.md
+++ b/docs/documentation-quality-checks.md
@@ -1,0 +1,43 @@
+# Documentation Quality Checks
+
+Use this checklist before merging documentation changes.
+
+## Required Checks
+
+1. Local links resolve correctly.
+2. New docs are indexed in `docs/README.md`.
+3. API behavior statements match current handlers/contracts.
+4. Env var references match `internal/config/config.go` and `internal/config/security.go`.
+
+## Link Integrity Check (local)
+
+Run from repo root:
+
+```bash
+python3 - <<'PY'
+import re
+from pathlib import Path
+root=Path('.').resolve()
+paths=[root/'docs', root/'deploy', root/'site', root/'README.md']
+files=[]
+for p in paths:
+    if p.is_file():
+        files.append(p)
+    elif p.is_dir():
+        files.extend(x for x in p.rglob('*.md') if 'node_modules' not in x.parts and '.next' not in x.parts)
+errors=[]
+for f in files:
+    txt=f.read_text(errors='ignore')
+    for m in re.finditer(r'\[[^\]]+\]\(([^)]+)\)', txt):
+        t=m.group(1).strip().split('#',1)[0]
+        if not t or t.startswith(('http://','https://','mailto:','#')):
+            continue
+        if not (f.parent/t).resolve().exists():
+            errors.append((f,t))
+if errors:
+    for f,t in errors:
+        print(f"{f}: {t}")
+    raise SystemExit(1)
+print('OK: no broken local markdown links')
+PY
+```


### PR DESCRIPTION
## Summary
Adds a reusable quality-check guide for docs changes.

## Changes
- adds docs/documentation-quality-checks.md
- includes a local markdown link-integrity check command
- links the guide in docs index

## Why
This makes docs consistency and link integrity repeatable for future changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a docs quality-checks guide with a local Markdown link checker (handles link titles and angle-bracket links with spaces) and a pre-merge checklist (indexing, API behavior, env vars).
Links the guide in the docs index to standardize reviews and catch broken links.

<sup>Written for commit 2776ef3c5cebd371cf6cb86ea63b7ebc9f780f25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

