### PR TITLE
fix(web): block prod localhost API fallback

### DIFF
--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -66,12 +66,9 @@ jobs:
           echo "Token verified for Vercel user:"
           jq -r '.user.username // .username // "unknown"' /tmp/vercel-user.json
 
-      - name: Ensure Vercel env has VITE_IDENTRAIL_API_URL
+      - name: Require VITE_IDENTRAIL_API_URL variable
         if: steps.normalize-token.outputs.has_token == 'true'
         env:
-          VERCEL_TOKEN: ${{ steps.normalize-token.outputs.token }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VITE_IDENTRAIL_API_URL: ${{ vars.VITE_IDENTRAIL_API_URL }}
         run: |
           set -euo pipefail
@@ -81,6 +78,16 @@ jobs:
             exit 1
           fi
 
+      - name: Upsert Vercel env VITE_IDENTRAIL_API_URL
+        if: steps.normalize-token.outputs.has_token == 'true'
+        continue-on-error: true
+        env:
+          VERCEL_TOKEN: ${{ steps.normalize-token.outputs.token }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VITE_IDENTRAIL_API_URL: ${{ vars.VITE_IDENTRAIL_API_URL }}
+        run: |
+          set -euo pipefail
           payload="$(jq -n --arg value "${VITE_IDENTRAIL_API_URL}" '{
             key: "VITE_IDENTRAIL_API_URL",
             value: $value,

--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -66,6 +66,37 @@ jobs:
           echo "Token verified for Vercel user:"
           jq -r '.user.username // .username // "unknown"' /tmp/vercel-user.json
 
+      - name: Ensure Vercel env has VITE_IDENTRAIL_API_URL
+        if: steps.normalize-token.outputs.has_token == 'true'
+        env:
+          VERCEL_TOKEN: ${{ steps.normalize-token.outputs.token }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VITE_IDENTRAIL_API_URL: ${{ vars.VITE_IDENTRAIL_API_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${VITE_IDENTRAIL_API_URL}" ]; then
+            echo "Missing vars.VITE_IDENTRAIL_API_URL."
+            echo "Set this GitHub Actions variable and it will be upserted into the Vercel project env vars."
+            exit 1
+          fi
+
+          payload="$(jq -n --arg value "${VITE_IDENTRAIL_API_URL}" '{
+            key: "VITE_IDENTRAIL_API_URL",
+            value: $value,
+            type: "plain",
+            target: ["production", "preview"],
+            comment: "Identrail web -> API base URL (required for production builds)"
+          }')"
+
+          curl -fsS -X POST \
+            "https://api.vercel.com/v10/projects/${VERCEL_PROJECT_ID}/env?upsert=true&teamId=${VERCEL_ORG_ID}" \
+            -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "${payload}" \
+            > /tmp/vercel-env-upsert.json
+          jq -r '.created.key // "Vercel env upserted."' /tmp/vercel-env-upsert.json
+
       - name: Deploy to Vercel
         id: deploy-action
         if: steps.normalize-token.outputs.has_token == 'true'

--- a/docs/frontend-topology.md
+++ b/docs/frontend-topology.md
@@ -8,6 +8,7 @@ Identrail uses a product dashboard today and may include a separate marketing si
 - Purpose: operator-facing app experience tied to API workflows
 - Typical runtime: containerized deployment (`deploy/docker/Dockerfile.web`, optional Helm `web.enabled`)
 - API URL input: `VITE_IDENTRAIL_API_URL`
+- Vercel (marketing/demo deploy): set `VITE_IDENTRAIL_API_URL` in Vercel project environment variables (or set GitHub Actions variable `VITE_IDENTRAIL_API_URL` so the deploy workflow upserts it).
 
 ## `site/` (marketing site, optional in this repo snapshot)
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -128,18 +128,20 @@ export type FindingTriageRequest = {
   comment?: string;
 };
 
-const viteEnv = ((import.meta as ImportMeta & { env?: Record<string, string> }).env ?? {}) as Record<string, string>;
-const configuredURL = viteEnv.VITE_IDENTRAIL_API_URL;
-if (viteEnv.PROD === 'true') {
-  if (!configuredURL) {
-    throw new Error('VITE_IDENTRAIL_API_URL must be set in production builds');
-  }
+const viteEnv = ((import.meta as unknown as { env?: Record<string, unknown> }).env ?? {}) as Record<string, unknown>;
+const isProd = viteEnv.PROD === true || viteEnv.PROD === 'true';
+const configuredURL = typeof viteEnv.VITE_IDENTRAIL_API_URL === 'string' ? viteEnv.VITE_IDENTRAIL_API_URL : undefined;
+
+// Never silently fall back to localhost in production builds (for example on Vercel).
+// If the API URL is not configured, requests should fail loudly when invoked.
+if (isProd && configuredURL) {
   const parsed = new URL(configuredURL);
   if (parsed.protocol === 'http:' && parsed.hostname !== 'localhost') {
     throw new Error('VITE_IDENTRAIL_API_URL must use HTTPS in production (HTTP only allowed for localhost)');
   }
 }
-const baseURL = configuredURL ?? 'http://localhost:8080';
+
+const baseURL = configuredURL ?? (isProd ? '' : 'http://localhost:8080');
 
 function trimOrUndefined(value?: string): string | undefined {
   const trimmed = value?.trim();
@@ -180,6 +182,11 @@ export function mergeRequestHeaders(auth?: RequestAuthContext, initHeaders?: Hea
 }
 
 async function request<T>(path: string, auth?: RequestAuthContext, init: RequestInit = {}): Promise<T> {
+  if (isProd && !configuredURL) {
+    throw new Error(
+      'Identrail API URL is not configured. Set VITE_IDENTRAIL_API_URL in Vercel project environment variables.'
+    );
+  }
   const headers = mergeRequestHeaders(auth, init.headers);
   const res = await fetch(`${baseURL}${path}`, { ...init, headers });
   if (!res.ok) {


### PR DESCRIPTION
Fixes a production-only footgun where the web client could fall back to http://localhost:8080 when Vite exposes PROD as a boolean and VITE_IDENTRAIL_API_URL is unset.

Changes:
- Harden env detection so PROD boolean/string both work.
- In production, never default API base to localhost; requests now fail with a clear message if VITE_IDENTRAIL_API_URL is missing.
- Vercel deploy workflow upserts VITE_IDENTRAIL_API_URL into the Vercel project env (requires GitHub Actions variable vars.VITE_IDENTRAIL_API_URL).

Ops:
- Set GitHub Actions variable VITE_IDENTRAIL_API_URL to your API base (https).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the web app from falling back to http://localhost:8080 in production by requiring an explicit API base URL. Hardens env detection and adds clear errors so prod builds don’t accidentally hit localhost.

- **Bug Fixes**
  - Treats `PROD` as boolean or string for reliable env detection.
  - In production, never default to localhost; requests fail with a clear error if `VITE_IDENTRAIL_API_URL` is missing.
  - Enforces HTTPS in production (HTTP only allowed for `localhost`).

- **Migration**
  - Set GitHub Actions variable `VITE_IDENTRAIL_API_URL` to your HTTPS API base.
  - The Vercel deploy workflow now upserts `VITE_IDENTRAIL_API_URL` into the Vercel project environment (best-effort; deploy continues if upsert fails).

<sup>Written for commit eff853a9445e5edab5e41130f072ed9eb618678b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

