### PR TITLE
CI: gate default branch (dev)

### DIFF
--- a/.github/branch-protection/dev.json
+++ b/.github/branch-protection/dev.json
@@ -1,0 +1,30 @@
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "Go Quality",
+      "Go Tests",
+      "Go Integration (Postgres)",
+      "CLI Smoke",
+      "Web Build",
+      "Infra Validate",
+      "Deploy Portability",
+      "Analyze (go)",
+      "Analyze (javascript-typescript)"
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 1,
+    "require_last_push_approval": false
+  },
+  "restrictions": null,
+  "required_conversation_resolution": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_linear_history": true,
+  "block_creations": false
+}
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: ["main"]
+    branches: ["dev"]
   push:
-    branches: ["main"]
+    branches: ["dev"]
 
 permissions:
   contents: read

--- a/.github/workflows/code-scanning-autofix.yml
+++ b/.github/workflows/code-scanning-autofix.yml
@@ -201,7 +201,7 @@ jobs:
                 repo,
                 title,
                 head: branchName,
-                base: "main",
+                base: "dev",
                 body,
                 draft: true,
               });

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: ["main"]
+    branches: ["dev"]
   pull_request:
-    branches: ["main"]
+    branches: ["dev"]
   schedule:
     - cron: "17 4 * * 1"
 

--- a/.github/workflows/enforce-branch-protection.yml
+++ b/.github/workflows/enforce-branch-protection.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   enforce:
-    name: Enforce main branch protection
+    name: Enforce dev branch protection
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -26,13 +26,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Validate config JSON
-        run: jq empty .github/branch-protection/main.json
+        run: jq empty .github/branch-protection/dev.json
 
       - name: Print protection plan (dry-run)
         if: inputs.mode == 'dry-run'
         run: |
-          echo "Branch protection payload for main:"
-          cat .github/branch-protection/main.json
+          echo "Branch protection payload for dev:"
+          cat .github/branch-protection/dev.json
 
       - name: Apply protection via GitHub API
         if: inputs.mode == 'apply'
@@ -49,15 +49,15 @@ jobs:
             }
 
             const payload = JSON.parse(
-              fs.readFileSync('.github/branch-protection/main.json', 'utf8')
+              fs.readFileSync('.github/branch-protection/dev.json', 'utf8')
             );
 
             const octokit = github.getOctokit(token);
             await octokit.rest.repos.updateBranchProtection({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              branch: 'main',
+              branch: 'dev',
               ...payload,
             });
 
-            core.info('Branch protection updated for main.');
+            core.info('Branch protection updated for dev.');

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -6,7 +6,7 @@ on:
     - cron: '23 3 * * 1'
   push:
     branches:
-      - main
+      - dev
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -3,7 +3,7 @@ name: Sync Labels
 on:
   workflow_dispatch:
   push:
-    branches: ["main"]
+    branches: ["dev"]
     paths:
       - .github/labels.yml
 

--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - dev
-      - main
   workflow_dispatch:
 
 permissions:
@@ -17,7 +16,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy to Vercel Production
-    if: github.repository == 'identrail/identrail' && (github.event_name != 'workflow_dispatch' || github.ref_name == 'dev' || github.ref_name == 'main')
+    if: github.repository == 'identrail/identrail' && (github.event_name != 'workflow_dispatch' || github.ref_name == 'dev')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p align="center">
   Open-source machine identity security platform for AWS and Kubernetes workloads.
   <br />
-  <a href="https://github.com/identrail/identrail/blob/main/docs/enterprise-quickstart.md"><strong>Get Started »</strong></a>
+  <a href="https://github.com/identrail/identrail/blob/dev/docs/enterprise-quickstart.md"><strong>Get Started »</strong></a>
   <br />
   <br />
   <a href="https://discord.gg/7jSUSnQC">Discord</a>
@@ -19,7 +19,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/identrail/identrail/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/identrail/identrail/ci.yml?branch=main&style=flat&label=ci&colorA=000000&colorB=000000" alt="CI" /></a>
+  <a href="https://github.com/identrail/identrail/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/identrail/identrail/ci.yml?branch=dev&style=flat&label=ci&colorA=000000&colorB=000000" alt="CI" /></a>
   <a href="https://github.com/identrail/identrail/tags"><img src="https://img.shields.io/github/v/tag/identrail/identrail?sort=semver&style=flat&label=version&colorA=000000&colorB=000000" alt="Latest version" /></a>
   <a href="https://github.com/identrail/identrail/stargazers"><img src="https://img.shields.io/github/stars/identrail/identrail?style=flat&colorA=000000&colorB=000000" alt="GitHub stars" /></a>
 </p>

--- a/docs/copilot-autofix.md
+++ b/docs/copilot-autofix.md
@@ -11,7 +11,7 @@ Workflow file:
 2. Requests an autofix for each alert.
 3. Waits for autofix generation to complete.
 4. Creates a commit on `autofix/code-scanning-alert-<alert_number>`.
-5. Opens a draft PR to `main`.
+5. Opens a draft PR to `dev`.
 
 ## Triggers
 

--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -63,7 +63,7 @@ Portable deployment profiles:
 
 ## 2) Deploy Sequence
 
-1. Ensure CI is green on `main` (`Go Quality`, `Go Tests`, `Go Integration (Postgres)`, `Web Build`).
+1. Ensure CI is green on `dev` (`Go Quality`, `Go Tests`, `Go Integration (Postgres)`, `Web Build`).
 2. Run migrations once using the dedicated migration job:
    - Kubernetes manifests: apply `deploy/kubernetes/migration-job.yaml` and wait for job completion.
    - Helm: pre-install/pre-upgrade hook job runs automatically when `migrations.enabled=true`.

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -35,7 +35,7 @@ Identrail release automation is defined in:
 
 ## Recommended Usage
 
-1. Merge all release-ready PRs into `main`.
+1. Merge all release-ready PRs into `dev`.
 2. Create and push a SemVer tag:
    - `git tag v1.2.3`
    - `git push origin v1.2.3`

--- a/docs/v1_release_qualification.md
+++ b/docs/v1_release_qualification.md
@@ -28,7 +28,7 @@ This is the release gate for priorities 21-22.
 
 ## Tagging Flow
 
-1. Ensure CI for `main` is green.
+1. Ensure CI for `dev` is green.
 2. Create release candidate tag:
    - `git tag -a v1.0.0-rc.1 -m "Identrail v1.0.0 release candidate 1"`
    - `git push origin v1.0.0-rc.1`


### PR DESCRIPTION
### What
- Switch CI-related workflows that were pinned to `main` to target `dev` (the repository default branch).
- Update Code Scanning Autofix to open PRs against `dev`.
- Add `.github/branch-protection/dev.json` and retarget the branch-protection enforcement workflow to `dev`.
- Update README CI badge and docs that referenced `main` to `dev`.

### Why
GitHub default branch is `dev`, but CI and other automations were still pinned to `main`, so `gh run list --branch dev --workflow CI` returned no runs and the README badge was stale.

### Notes
- This does not change the GitHub repo default branch setting itself; it makes repo automation follow it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align CI, security scans, and deploy automation with the default branch `dev` to restore expected runs and accurate badges. Adds a `dev` branch-protection config and updates enforcement; does not change the repo default branch setting.

- **Refactors**
  - Retarget `ci.yml`, `codeql.yml`, `ossf-scorecard.yml`, and `sync-labels.yml` to `dev`.
  - Set Code Scanning Autofix PR base to `dev`.
  - Add `.github/branch-protection/dev.json` and update enforcement workflow to use it.
  - Restrict Vercel production deploy to `dev` only.
  - Update README CI badge and docs from `main` to `dev`.

<sup>Written for commit d7a4f0d220b01c32ba2a8ec7868c48a515e0c546. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

