### PR TITLE
ops: safe Vercel production deploy entrypoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /usr/bin/env bash
 .DEFAULT_GOAL := help
 
-.PHONY: help bootstrap quickstart quickstart-down fmt fmt-check vet test test-integration web-install web-test web-build helm-lint tfmt-check ci pre-commit
+.PHONY: help bootstrap quickstart quickstart-down fmt fmt-check vet test test-integration web-install web-test web-build vercel-prod-deploy helm-lint tfmt-check ci pre-commit
 
 help: ## Show available targets
 	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z0-9_-]+:.*##/ {printf "%-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -51,6 +51,9 @@ web-test: ## Run web test suite in CI mode
 
 web-build: ## Build web frontend
 	npm run build --prefix web
+
+vercel-prod-deploy: ## Trigger Vercel production deploy (always uses origin/dev)
+	./scripts/vercel_prod_deploy.sh
 
 helm-lint: ## Lint Helm chart
 	helm lint deploy/helm/identrail

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -46,6 +46,11 @@ tasks:
     cmds:
       - make web-build
 
+  vercel-prod-deploy:
+    desc: Trigger Vercel production deploy (always uses origin/dev)
+    cmds:
+      - make vercel-prod-deploy
+
   ci:
     desc: Run core local CI checks
     cmds:

--- a/docs/frontend-topology.md
+++ b/docs/frontend-topology.md
@@ -9,6 +9,7 @@ Identrail uses a product dashboard today and may include a separate marketing si
 - Typical runtime: containerized deployment (`deploy/docker/Dockerfile.web`, optional Helm `web.enabled`)
 - API URL input: `VITE_IDENTRAIL_API_URL`
 - Vercel (marketing/demo deploy): set `VITE_IDENTRAIL_API_URL` in Vercel project environment variables (or set GitHub Actions variable `VITE_IDENTRAIL_API_URL` so the deploy workflow upserts it).
+- Production deploys should be triggered from `dev` (example: `make vercel-prod-deploy` / `task vercel-prod-deploy`) to avoid accidentally deploying from a stale local branch.
 
 ## `site/` (marketing site, optional in this repo snapshot)
 

--- a/scripts/vercel_prod_deploy.sh
+++ b/scripts/vercel_prod_deploy.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "${ROOT_DIR}" ]]; then
+  echo "ERROR: must run from inside the identrail git repository"
+  exit 1
+fi
+
+cd "${ROOT_DIR}"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: GitHub CLI (gh) is required"
+  exit 1
+fi
+
+# Production deploys must always come from the dev branch on GitHub, not from the
+# operator's local working tree (which may be stale).
+gh workflow run .github/workflows/vercel-production-deploy.yml --ref dev
+
+echo "Triggered Vercel production deploy for ref=dev."
+echo "Follow progress: gh run list --workflow .github/workflows/vercel-production-deploy.yml -L 5"


### PR DESCRIPTION
Problem: It's easy to accidentally deploy the marketing web from a stale local branch (missing routes already live on dev).

Solution:
- Add scripts/vercel_prod_deploy.sh to trigger the existing Vercel Production Deploy workflow using ref=dev.
- Wire into Makefile and Taskfile as vercel-prod-deploy.
- Document the intended deploy path in docs/frontend-topology.md.

This ensures production deploys are always sourced from the GitHub dev branch, not the operator's local working tree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a safe entrypoint to trigger Vercel production deploys from the GitHub `dev` branch. This prevents accidental deploys from a stale local branch and standardizes the deploy path.

- **New Features**
  - Added `scripts/vercel_prod_deploy.sh` to run `.github/workflows/vercel-production-deploy.yml` with `--ref dev` via `gh`.
  - Added `vercel-prod-deploy` target in `Makefile` and `Taskfile.yml`.
  - Documented the deploy path in `docs/frontend-topology.md` with `make vercel-prod-deploy` / `task vercel-prod-deploy`.

<sup>Written for commit bef68994dad5ee7bb67cc30760f1cc0829fe1a35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

