### PR TITLE
fix(web): apply security headers + serve security.txt

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,34 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://api.github.com https://img.shields.io; frame-src https://www.youtube.com https://youtube.com https://calendly.com https://assets.calendly.com; media-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        }
+      ]
+    }
+  ]
+}
+

--- a/web/public/.well-known/security.txt
+++ b/web/public/.well-known/security.txt
@@ -1,0 +1,6 @@
+Contact: mailto:security@identrail.com
+Policy: https://www.identrail.com/responsible-disclosure
+Acknowledgments: https://www.identrail.com/security
+Preferred-Languages: en
+Canonical: https://www.identrail.com/.well-known/security.txt
+Expires: 2027-04-26T00:00:00Z

--- a/web/public/security.txt
+++ b/web/public/security.txt
@@ -1,0 +1,6 @@
+Contact: mailto:security@identrail.com
+Policy: https://www.identrail.com/responsible-disclosure
+Acknowledgments: https://www.identrail.com/security
+Preferred-Languages: en
+Canonical: https://www.identrail.com/.well-known/security.txt
+Expires: 2027-04-26T00:00:00Z

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -51,7 +51,7 @@
       ]
     },
     {
-      "source": "/((?!assets/|favicon-64.png|apple-touch-icon.png|identrail-logo.png|robots.txt|sitemap.xml).*)",
+      "source": "/((?!assets/|favicon-64.png|apple-touch-icon.png|identrail-logo.png|robots.txt|sitemap.xml|security.txt|\\.well-known/security.txt).*)",
       "headers": [
         {
           "key": "Cache-Control",
@@ -144,7 +144,7 @@
       "handle": "filesystem"
     },
     {
-      "src": "/((?!assets/|favicon-64.png|apple-touch-icon.png|identrail-logo.png|robots.txt|sitemap.xml).*)",
+      "src": "/((?!assets/|favicon-64.png|apple-touch-icon.png|identrail-logo.png|robots.txt|sitemap.xml|security.txt|\\.well-known/security.txt).*)",
       "dest": "/index.html"
     }
   ]


### PR DESCRIPTION
Fixes two production issues observed on https://www.identrail.com/:

1) Security headers declared in `web/vercel.json` were not appearing in live responses (only HSTS was present). This PR adds a root `vercel.json` that applies the same header set so it is honored regardless of Vercel project root.

2) `/.well-known/security.txt` and `/security.txt` were being rewritten to the SPA HTML. This PR adds static `security.txt` files under `web/public/` and exempts those paths from the SPA rewrite in `web/vercel.json`.

Expected after deploy:
- `/.well-known/security.txt` and `/security.txt` return text content, not `index.html`.
- Responses include CSP, HSTS (with includeSubDomains+preload), X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy headers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix missing security headers in production and ensure `security.txt` serves as plain text. Applies a single global header policy and returns correct responses for `/.well-known/security.txt` and `/security.txt`.

- **Bug Fixes**
  - Added root `vercel.json` to apply headers on all routes: CSP (with upgrade-insecure-requests; connect-src `https://api.github.com` `https://img.shields.io`; frame-src YouTube/Calendly; style-src `https://fonts.googleapis.com`; font-src `https://fonts.gstatic.com`; img-src self/data/https), HSTS (includeSubDomains, preload), X-Frame-Options (DENY), X-Content-Type-Options (nosniff), Referrer-Policy (strict-origin-when-cross-origin), Permissions-Policy (camera/microphone/geolocation off).
  - Added static files at `web/public/security.txt` and `web/public/.well-known/security.txt`, and exempted these paths from SPA rewrites in `web/vercel.json` so they return text instead of `index.html`.

<sup>Written for commit 7ab7df3afe5f0f79f2ed65f0b69a56076b18e0b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

