### PR TITLE
chore(frontend): guard API snippets and isolate legacy site snapshot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,9 @@ jobs:
           cache: npm
           cache-dependency-path: web/package-lock.json
 
+      - name: Validate API Example Contract
+        run: ./scripts/check_api_example_contract.sh
+
       - name: Install Web Dependencies
         run: npm ci --prefix web
 

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ build/
 
 # Cache
 .cache/
+
+# Legacy/optional frontend worktree snapshots (not part of active dev branch)
+site/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /usr/bin/env bash
 .DEFAULT_GOAL := help
 
-.PHONY: help bootstrap quickstart quickstart-down fmt fmt-check vet test test-integration web-install web-test web-build vercel-prod-deploy helm-lint tfmt-check ci pre-commit
+.PHONY: help bootstrap quickstart quickstart-down fmt fmt-check vet test test-integration web-install web-test web-build api-example-contract-check vercel-prod-deploy helm-lint tfmt-check ci pre-commit
 
 help: ## Show available targets
 	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z0-9_-]+:.*##/ {printf "%-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -52,6 +52,9 @@ web-test: ## Run web test suite in CI mode
 web-build: ## Build web frontend
 	npm run build --prefix web
 
+api-example-contract-check: ## Validate docs/web API snippets against current v1 contract
+	./scripts/check_api_example_contract.sh
+
 vercel-prod-deploy: ## Trigger Vercel production deploy (always uses origin/dev)
 	./scripts/vercel_prod_deploy.sh
 
@@ -61,7 +64,7 @@ helm-lint: ## Lint Helm chart
 tfmt-check: ## Check Terraform formatting
 	terraform fmt -check -recursive deploy/terraform
 
-ci: fmt-check vet test web-test web-build ## Run core local CI checks
+ci: fmt-check vet test api-example-contract-check web-test web-build ## Run core local CI checks
 
 pre-commit: ## Run pre-commit hooks across the repository
 	pre-commit run --all-files

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -46,6 +46,11 @@ tasks:
     cmds:
       - make web-build
 
+  api-example-contract-check:
+    desc: Validate docs/web API snippets against current v1 contract
+    cmds:
+      - make api-example-contract-check
+
   vercel-prod-deploy:
     desc: Trigger Vercel production deploy (always uses origin/dev)
     cmds:

--- a/docs/frontend-topology.md
+++ b/docs/frontend-topology.md
@@ -1,6 +1,6 @@
 # Frontend Topology
 
-Identrail uses a product dashboard today and may include a separate marketing site surface depending on branch/release packaging.
+Identrail uses `web/` as the active tracked frontend on `dev`.
 
 ## `web/` (product dashboard)
 
@@ -11,15 +11,16 @@ Identrail uses a product dashboard today and may include a separate marketing si
 - Vercel (marketing/demo deploy): set `VITE_IDENTRAIL_API_URL` in Vercel project environment variables (or set GitHub Actions variable `VITE_IDENTRAIL_API_URL` so the deploy workflow upserts it).
 - Production deploys should be triggered from `dev` (example: `make vercel-prod-deploy` / `task vercel-prod-deploy`) to avoid accidentally deploying from a stale local branch.
 
-## `site/` (marketing site, optional in this repo snapshot)
+## `site/` (legacy Next.js marketing surface)
 
 - Stack: Next.js
 - Purpose: public marketing/documentation landing pages
 - Typical runtime: Vercel-hosted static/dynamic site
 - Not part of the core API/worker runtime path
+- Not tracked in this branch snapshot; local leftovers can drift from API contract and should not be treated as source of truth.
 
 ## Operational Guidance
 
 - Treat `web/` as product UI release surface coupled to API compatibility.
-- Treat `site/` as marketing/content release surface with independent cadence.
+- Treat `site/` as legacy/branch-specific surface unless explicitly restored and reviewed.
 - Validate both in CI where relevant, but keep deployment ownership boundaries explicit.

--- a/scripts/check_api_example_contract.sh
+++ b/scripts/check_api_example_contract.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate tracked docs/frontend snippets against the v1 API contract.
+readonly bad_patterns=(
+  '/v1/scans/execute'
+  '/v1/repo-scan/jobs'
+  '/v1/repo-scans/jobs'
+  '/v1/findings?severity=high,critical&status=open'
+)
+
+fail=0
+for pattern in "${bad_patterns[@]}"; do
+  if git grep -n -- "${pattern}" -- docs web >/tmp/api-contract-check.out 2>/dev/null; then
+    echo "Found stale API example pattern: ${pattern}"
+    cat /tmp/api-contract-check.out
+    fail=1
+  fi
+done
+
+rm -f /tmp/api-contract-check.out
+
+if [[ "${fail}" -ne 0 ]]; then
+  cat <<'EOF'
+Expected canonical examples:
+- POST /v1/scans
+- GET /v1/findings?severity=high&lifecycle_status=open
+- POST /v1/repo-scans
+EOF
+  exit 1
+fi
+
+echo "API example contract check passed."


### PR DESCRIPTION
## Summary
- add a contract guard script that blocks stale API snippet patterns (`/v1/scans/execute`, `/v1/repo-scan/jobs`, `/v1/repo-scans/jobs`, and the stale findings query)
- run the guard in CI (`web-build` job) and expose it via `make api-example-contract-check` and `task api-example-contract-check`
- mark `site/` as a legacy local snapshot in docs and ignore it at repo level to avoid untracked stale-app drift

## Why
A local untracked Next.js `site/` snapshot contained outdated API examples that conflict with the canonical v1 contract. This PR prevents that drift from reappearing in tracked docs/frontend content and clarifies that `web/` is the active tracked frontend surface on `dev`.

## Validation
- `make api-example-contract-check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI guard to block outdated API examples in `docs/` and `web/`, and isolates the legacy `site/` snapshot to prevent drift. Ensures examples match the v1 API contract.

- **Refactors**
  - Added `scripts/check_api_example_contract.sh` to fail on stale patterns (`/v1/scans/execute`, `/v1/repo-scan/jobs`, `/v1/repo-scans/jobs`, `/v1/findings?severity=high,critical&status=open`) and point to canonical examples (`POST /v1/scans`, `GET /v1/findings?severity=high&lifecycle_status=open`, `POST /v1/repo-scans`).
  - Wired the check into CI (`web-build` job) and exposed via `make api-example-contract-check` and `task api-example-contract-check`; included in `make ci`.
  - Marked `site/` as legacy in docs and ignored via `.gitignore`; clarified `web/` as the active tracked frontend.

<sup>Written for commit 8949f62ed02b3cbe4515d2b19874052a79768e81. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/253?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

