### PR TITLE
fix(web): require lead webhook for lead capture

### DIFF
--- a/web/api/leads.test.ts
+++ b/web/api/leads.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import handler from './leads';
 
 type MockResponse = {
@@ -23,6 +23,11 @@ function createMockResponse(): MockResponse {
 }
 
 describe('web/api/leads handler', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.LEAD_WEBHOOK_URL;
+  });
+
   it('rejects invalid email payloads', async () => {
     const res = createMockResponse();
     await handler(
@@ -40,7 +45,34 @@ describe('web/api/leads handler', () => {
     expect(res.body).toEqual({ error: 'Valid work email is required.' });
   });
 
-  it('accepts read-only scan metadata payloads', async () => {
+  it('returns 503 when lead webhook is not configured', async () => {
+    const res = createMockResponse();
+    await handler(
+      {
+        method: 'POST',
+        body: {
+          email: 'security@company.com',
+          environment: 'AWS IAM + Kubernetes',
+          deployment_model: 'Hosted SaaS',
+          urgency: 'This quarter',
+          team_size: '6-20',
+          scan_goal: 'AWS IAM + Kubernetes trust-path risk reduction',
+          source: 'Read-Only Scan Intake',
+          page_path: '/read-only-scan'
+        }
+      },
+      res
+    );
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toEqual({ error: 'Lead capture is not configured.' });
+  });
+
+  it('accepts payloads when webhook forwarding succeeds', async () => {
+    process.env.LEAD_WEBHOOK_URL = 'https://example.test/webhook';
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
     const res = createMockResponse();
     await handler(
       {
@@ -61,5 +93,6 @@ describe('web/api/leads handler', () => {
 
     expect(res.statusCode).toBe(202);
     expect(res.body).toEqual({ status: 'accepted' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/api/leads.ts
+++ b/web/api/leads.ts
@@ -74,21 +74,24 @@ export default async function handler(
 
   const webhook = process.env.LEAD_WEBHOOK_URL?.trim();
 
-  if (webhook) {
-    try {
-      const forward = await fetch(webhook, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload)
-      });
-      if (!forward.ok) {
-        res.status(502).json({ error: 'Lead forwarding failed.' });
-        return;
-      }
-    } catch {
+  if (!webhook) {
+    res.status(503).json({ error: 'Lead capture is not configured.' });
+    return;
+  }
+
+  try {
+    const forward = await fetch(webhook, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    if (!forward.ok) {
       res.status(502).json({ error: 'Lead forwarding failed.' });
       return;
     }
+  } catch {
+    res.status(502).json({ error: 'Lead forwarding failed.' });
+    return;
   }
 
   res.status(202).json({ status: 'accepted' });


### PR DESCRIPTION
## Summary
- fail lead capture with `503` when `LEAD_WEBHOOK_URL` is unset
- keep `202 accepted` only for successful webhook forwarding
- add tests for unset webhook (503) and successful forwarding (202)

## Verification
- run `npm run test:ci --prefix web`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a configured lead webhook for lead capture. Returns 503 when `LEAD_WEBHOOK_URL` is missing and only returns 202 when forwarding succeeds; returns 502 on forwarding failure.

- **Bug Fixes**
  - Enforce `LEAD_WEBHOOK_URL`; respond with 503 if unset.
  - Forward leads to the webhook; return 502 on failure and 202 only on success.
  - Added tests for unset webhook (503), successful forwarding (202), and that forwarding is called.

- **Migration**
  - Set `LEAD_WEBHOOK_URL` in all environments (including local and CI) to enable lead capture.

<sup>Written for commit 67eaabd0317248af78210409b1587784dd55b61d. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/254?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

