### PR TITLE
Fix local worktree contamination from site/node_modules during Go tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ yarn-error.log*
 pnpm-debug.log*
 web/dist/
 web/build/
+web/coverage/
+web/.vercel/
+site/.next/
+site/.vercel/
 *.tsbuildinfo
 
 # Testing

--- a/site/go.mod
+++ b/site/go.mod
@@ -1,0 +1,3 @@
+module github.com/Oluwatobi-Mustapha/identrail/site
+
+go 1.25.0


### PR DESCRIPTION
## Summary
- add  to create a module boundary under 
- update  to explicitly ignore local frontend build/dev artifacts:
  - 
  - 
  - 
  - 

## Why
github.com/Oluwatobi-Mustapha/identrail/cmd/cli
github.com/Oluwatobi-Mustapha/identrail/cmd/identrail-reviewer
github.com/Oluwatobi-Mustapha/identrail/cmd/server
github.com/Oluwatobi-Mustapha/identrail/cmd/worker
github.com/Oluwatobi-Mustapha/identrail/internal/api
github.com/Oluwatobi-Mustapha/identrail/internal/app
github.com/Oluwatobi-Mustapha/identrail/internal/cli
github.com/Oluwatobi-Mustapha/identrail/internal/config
github.com/Oluwatobi-Mustapha/identrail/internal/db
github.com/Oluwatobi-Mustapha/identrail/internal/db/sqlcdb
github.com/Oluwatobi-Mustapha/identrail/internal/domain
github.com/Oluwatobi-Mustapha/identrail/internal/findings/standards
github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/audit
github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/baseline
github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/enforcement
github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/model
github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/policy
github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/review
github.com/Oluwatobi-Mustapha/identrail/internal/providers
github.com/Oluwatobi-Mustapha/identrail/internal/providers/aws
github.com/Oluwatobi-Mustapha/identrail/internal/providers/kubernetes
github.com/Oluwatobi-Mustapha/identrail/internal/repoexposure
github.com/Oluwatobi-Mustapha/identrail/internal/runtime
github.com/Oluwatobi-Mustapha/identrail/internal/scheduler
github.com/Oluwatobi-Mustapha/identrail/internal/server
github.com/Oluwatobi-Mustapha/identrail/internal/telemetry
github.com/Oluwatobi-Mustapha/identrail/internal/worker and ok  	github.com/Oluwatobi-Mustapha/identrail/cmd/cli	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/cmd/identrail-reviewer	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/cmd/server	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/cmd/worker	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/api	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/app	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/cli	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/config	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/db	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/db/sqlcdb	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/domain	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/findings/standards	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/audit	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/baseline	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/enforcement	(cached)
?   	github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/model	[no test files]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/policy	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/review	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/providers	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/providers/aws	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/providers/kubernetes	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/repoexposure	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/runtime	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/scheduler	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/server	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/telemetry	(cached)
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/worker	(cached) from the repo root can discover Go packages under  in a dirty local tree. Adding a module boundary prevents root module traversal into , keeping local verification deterministic.

## Verification
- before: root Go package discovery included 
- after: github.com/Oluwatobi-Mustapha/identrail/cmd/cli
github.com/Oluwatobi-Mustapha/identrail/cmd/identrail-reviewer
github.com/Oluwatobi-Mustapha/identrail/cmd/server
github.com/Oluwatobi-Mustapha/identrail/cmd/worker
github.com/Oluwatobi-Mustapha/identrail/internal/api
github.com/Oluwatobi-Mustapha/identrail/internal/app
github.com/Oluwatobi-Mustapha/identrail/internal/cli
github.com/Oluwatobi-Mustapha/identrail/internal/config
github.com/Oluwatobi-Mustapha/identrail/internal/db
github.com/Oluwatobi-Mustapha/identrail/internal/db/sqlcdb
github.com/Oluwatobi-Mustapha/identrail/internal/domain
github.com/Oluwatobi-Mustapha/identrail/internal/findings/standards
github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/audit
github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/baseline
github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/enforcement
github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/model
github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/policy
github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/review
github.com/Oluwatobi-Mustapha/identrail/internal/providers
github.com/Oluwatobi-Mustapha/identrail/internal/providers/aws
github.com/Oluwatobi-Mustapha/identrail/internal/providers/kubernetes
github.com/Oluwatobi-Mustapha/identrail/internal/repoexposure
github.com/Oluwatobi-Mustapha/identrail/internal/runtime
github.com/Oluwatobi-Mustapha/identrail/internal/scheduler
github.com/Oluwatobi-Mustapha/identrail/internal/server
github.com/Oluwatobi-Mustapha/identrail/internal/telemetry
github.com/Oluwatobi-Mustapha/identrail/internal/worker shows no  packages from root module
- after: ok  	github.com/Oluwatobi-Mustapha/identrail/cmd/cli	0.679s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/cmd/identrail-reviewer	1.172s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/cmd/server	0.973s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/cmd/worker	7.162s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/api	4.347s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/app	5.782s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/cli	1.494s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/config	5.250s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/db	6.376s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/db/sqlcdb	7.991s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/domain	3.384s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/findings/standards	8.427s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/audit	2.870s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/baseline	8.856s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/enforcement	9.279s [no tests to run]
?   	github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/model	[no test files]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/policy	4.795s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/identrailreviewer/review	7.554s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/providers	9.395s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/providers/aws	8.882s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/providers/kubernetes	8.960s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/repoexposure	8.034s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/runtime	7.003s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/scheduler	7.439s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/server	7.353s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/telemetry	6.157s [no tests to run]
ok  	github.com/Oluwatobi-Mustapha/identrail/internal/worker	7.539s [no tests to run] no longer reports  traversal

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated the `site` workspace with its own Go module and ignored local frontend artifacts to stop Go package discovery/tests from traversing into `site`. This prevents local worktree contamination and keeps root-level `go test ./...` deterministic.

- **Bug Fixes**
  - Added `site/go.mod` to create a module boundary under `site`.
  - Updated `.gitignore` to ignore `web/coverage/`, `web/.vercel/`, `site/.next/`, `site/.vercel/`.

<sup>Written for commit 6e833a5da668d9cfcbf58c9730e849e8e429fd0d. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/255?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

