### PR TITLE
fix(ci): allow osv scanner reusable workflow permissions

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   security-events: write
 


### PR DESCRIPTION
## Summary
- add `actions: read` to `.github/workflows/osv-scanner.yml` permissions
- keep existing `contents: read` and `security-events: write`

## Why
GitHub validates reusable workflow permission requirements at startup. The OSV reusable workflow requires `actions: read`, but the caller omitted it (effective `actions: none`), causing startup failure.

## Test
- workflow YAML validates
- should unblock `osv-scanner.yml` startup on PR runs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add actions: read permission to .github/workflows/osv-scanner.yml so the OSV reusable workflow can start. Keeps contents: read and security-events: write unchanged to satisfy GitHub’s permission check and unblock PR runs.

<sup>Written for commit 24025dc7a1e98dc9e7ef90f371c4130548929a04. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/256?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

