### PR TITLE
fix(web): remove fragile process typing in leads API

### DIFF
--- a/web/api/leads.ts
+++ b/web/api/leads.ts
@@ -72,7 +72,7 @@ export default async function handler(
     captured_at: new Date().toISOString()
   };
 
-  const webhook = process.env.LEAD_WEBHOOK_URL?.trim();
+  const webhook = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env?.LEAD_WEBHOOK_URL?.trim();
 
   if (webhook) {
     try {


### PR DESCRIPTION
## Summary
- replace direct `process.env` access in `web/api/leads.ts` with a `globalThis`-safe read
- avoid requiring Node global typings for this Vercel function path
- preserve existing runtime behavior for `LEAD_WEBHOOK_URL`

## Validation
- npm run build (web)
- npm run test:ci (web)
- vercel build --yes --scope oluwatobimustapha539-gmailcoms-projects


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the leads API to read `LEAD_WEBHOOK_URL` via a `globalThis`-safe access instead of direct `process.env`. This removes a fragile Node typing dependency in the Vercel/web function while keeping behavior unchanged.

- **Bug Fixes**
  - Avoids TypeScript errors in environments without Node globals.
  - No change to webhook behavior; the URL is used when set.

<sup>Written for commit 17114612e0ac9ec2e85ce0a0b0b961f3841f9958. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/257?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

