### PR TITLE
CI: don't hard-fail Vercel deploy when API URL variable is unset

### DIFF
--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -65,7 +65,8 @@ jobs:
           echo "Token verified for Vercel user:"
           jq -r '.user.username // .username // "unknown"' /tmp/vercel-user.json
 
-      - name: Require VITE_IDENTRAIL_API_URL variable
+      - name: Check VITE_IDENTRAIL_API_URL variable
+        id: check-api-url
         if: steps.normalize-token.outputs.has_token == 'true'
         env:
           VITE_IDENTRAIL_API_URL: ${{ vars.VITE_IDENTRAIL_API_URL }}
@@ -73,12 +74,15 @@ jobs:
           set -euo pipefail
           if [ -z "${VITE_IDENTRAIL_API_URL}" ]; then
             echo "Missing vars.VITE_IDENTRAIL_API_URL."
-            echo "Set this GitHub Actions variable and it will be upserted into the Vercel project env vars."
-            exit 1
+            echo "Skipping Vercel env upsert for VITE_IDENTRAIL_API_URL."
+            echo "Set this GitHub Actions variable to keep Vercel env synchronized from Actions."
+            echo "has_api_url=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          echo "has_api_url=true" >> "$GITHUB_OUTPUT"
 
       - name: Upsert Vercel env VITE_IDENTRAIL_API_URL
-        if: steps.normalize-token.outputs.has_token == 'true'
+        if: steps.normalize-token.outputs.has_token == 'true' && steps.check-api-url.outputs.has_api_url == 'true'
         continue-on-error: true
         env:
           VERCEL_TOKEN: ${{ steps.normalize-token.outputs.token }}


### PR DESCRIPTION
Summary:
- change Vercel production workflow to check VITE_IDENTRAIL_API_URL without failing the job
- skip Vercel env upsert step when variable is missing
- keep deploy and fallback deploy paths available instead of failing early

Why:
Production deploys were failing at the preflight step that required VITE_IDENTRAIL_API_URL when the repo variable is unset. This blocks merges even when deploy could proceed via existing Vercel project env or hook fallback.

Behavior after change:
- if VITE_IDENTRAIL_API_URL is set: upsert runs as before
- if missing: workflow logs a warning and continues deployment

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop hard-failing the Vercel production deploy when the `VITE_IDENTRAIL_API_URL` GitHub Actions variable is missing. The workflow now warns, skips the env upsert, and continues the deploy using existing Vercel config or fallback.

- **Bug Fixes**
  - Added a non-blocking check (`check-api-url`) that sets `has_api_url=false` instead of exiting when the var is unset.
  - Gated the env upsert to run only when a token exists and `has_api_url` is true; deploy proceeds either way.

<sup>Written for commit ca1ddd5c01d5390e8829317c6b7b75765a3d7873. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/258?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

