### PR TITLE
docs(readme): premium maturity refresh for adoption clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Choose the rollout path that matches your environment maturity:
 
 See [Deployment Anywhere](./docs/deployment-anywhere.md) for exact commands.
 
-## Project Status and Roadmap
+## Project Status
 
 Status: **Active** (v1 line in active support).
 
@@ -149,7 +149,3 @@ Full policy: [docs/versioning-support-policy.md](./docs/versioning-support-polic
 - [Contributing Guide](./CONTRIBUTING.md)
 - [Code of Conduct](./CODE_OF_CONDUCT.md)
 - [Issues](https://github.com/identrail/identrail/issues)
-
-## License
-
-Licensed under [Apache-2.0](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -3,20 +3,9 @@
     <img src="./docs/static/images/identrail-logo-glow.png" alt="Identrail Logo" width="220" />
   </picture>
   <h2>Identrail</h2>
+  <p><strong>Open-source machine identity security for AWS and Kubernetes.</strong></p>
+  <p>Discover trust paths, detect high-signal exposure risk, and apply authorization guardrails with explainable decisions.</p>
 </div>
-
-<p align="center">
-  Open-source machine identity security platform for AWS and Kubernetes workloads.
-  <br />
-  <a href="https://github.com/identrail/identrail/blob/dev/docs/enterprise-quickstart.md"><strong>Get Started »</strong></a>
-  <br />
-  <br />
-  <a href="https://discord.gg/7jSUSnQC">Discord</a>
-  ·
-  <a href="https://www.identrail.com">Website</a>
-  ·
-  <a href="https://github.com/identrail/identrail/issues">Issues</a>
-</p>
 
 <p align="center">
   <a href="https://github.com/identrail/identrail/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/identrail/identrail/ci.yml?branch=dev&style=flat&label=ci&colorA=000000&colorB=000000" alt="CI" /></a>
@@ -24,26 +13,143 @@
   <a href="https://github.com/identrail/identrail/stargazers"><img src="https://img.shields.io/github/stars/identrail/identrail?style=flat&colorA=000000&colorB=000000" alt="GitHub stars" /></a>
 </p>
 
-## About the Project
+<p align="center">
+  <a href="https://github.com/identrail/identrail/blob/dev/docs/enterprise-quickstart.md"><strong>Enterprise Quickstart</strong></a>
+  ·
+  <a href="https://www.identrail.com">Website</a>
+  ·
+  <a href="https://discord.gg/7jSUSnQC">Discord</a>
+  ·
+  <a href="https://github.com/identrail/identrail/issues">Issues</a>
+</p>
 
-Identrail discovers machine identities and trust paths across AWS and Kubernetes, detects high-signal exposure findings, scans repositories for credential risk, and supports rollout-safe authorization controls.
+## Who This Is For
 
-### Why Identrail
+Identrail is for security and platform teams that need to answer three questions quickly:
 
-Machine identity risk is usually split across cloud IAM, Kubernetes, and source code workflows. Identrail unifies those surfaces into one explainable model so teams can reduce blast radius with clear remediation paths.
+- Which machine identities can reach sensitive resources?
+- Where does trust sprawl create blast-radius risk?
+- How can we enforce safer access with auditable decisions?
 
-## Contribution
+Use it when you run AWS and/or Kubernetes workloads and want identity risk visibility plus deployment-safe control surfaces.
 
-Identrail is open source under the [Apache-2.0 License](./LICENSE).
+## 5-Minute Quickstart
 
-You can help by:
+Prerequisites: Docker, Docker Compose, `curl`, `jq`.
 
-- [Contributing to the source code](./CONTRIBUTING.md)
-- [Suggesting features and reporting issues](https://github.com/identrail/identrail/issues)
-- [Joining community discussions](https://discord.gg/7jSUSnQC)
+```bash
+make quickstart
+```
 
-## Security
+What this does:
 
-If you discover a security vulnerability, please email [security@identrail.com](mailto:security@identrail.com).
+- Boots API, worker, web, and Postgres with local-safe defaults.
+- Triggers an initial scan.
+- Prints follow-up commands to inspect findings.
 
-Please do not disclose vulnerabilities publicly until a fix is coordinated.
+Stop the stack:
+
+```bash
+make quickstart-down
+```
+
+For enterprise auth scope, tenant/workspace context, and decision audit verification, use the full [Enterprise Quickstart](./docs/enterprise-quickstart.md).
+
+## What Identrail Does
+
+- Discovers machine identities and trust relationships across AWS and Kubernetes.
+- Persists raw and normalized scan artifacts for explainability and auditability.
+- Produces deterministic findings with risk evidence and remediation context.
+- Provides API and CLI workflows for scans, findings, trends, and diff analysis.
+- Supports optional repository exposure scanning (secrets and CI/IaC risk) in an isolated pipeline.
+
+## What Identrail Does Not Do
+
+- It is not a cloud SIEM replacement.
+- It is not an endpoint runtime agent.
+- It is not a generic CSPM for every cloud/provider in V1.
+
+V1 is intentionally focused on machine identity security workflows for AWS and Kubernetes.
+
+## How It Works
+
+```text
+Collector -> Raw Assets -> Normalizer -> Graph -> Risk Rules -> Findings Store -> API/CLI/Web
+```
+
+Operational model:
+
+- API can enqueue scans (`POST /v1/scans`, `POST /v1/repo-scans`).
+- Worker drains queue and runs scheduled jobs.
+- Results are queryable via API and CLI with scan-aware filtering and history.
+
+## Deployment Options
+
+Choose the rollout path that matches your environment maturity:
+
+- Local / single host: Docker Compose (`deploy/docker`)
+- Cluster-native: Kubernetes manifests (`deploy/kubernetes`)
+- Upgrade-safe Kubernetes: Helm chart (`deploy/helm/identrail`)
+- IaC rollout: Terraform Helm module (`deploy/terraform`)
+- Non-Kubernetes runtime: Linux VM + systemd (`deploy/systemd`)
+
+See [Deployment Anywhere](./docs/deployment-anywhere.md) for exact commands.
+
+## Project Status and Roadmap
+
+Status: **Active** (v1 line in active support).
+
+Current focus:
+
+- Production hardening for scan reliability and auth safety defaults.
+- Stronger backward-compatibility and contract testing.
+- Operator readiness for repeatable multi-environment rollouts.
+
+Reference docs:
+
+- [Versioning and Support Policy](./docs/versioning-support-policy.md)
+- [Architecture](./docs/architecture.md)
+- [OpenAPI v1](./docs/openapi-v1.yaml)
+
+Demo video: _coming soon_.
+
+## Comparison (Where Identrail Fits)
+
+- Versus broad CSPM tools: Identrail is narrower and deeper on machine identity trust and authorization workflows.
+- Versus secret scanners alone: Identrail includes optional repo exposure scanning, but also links findings into identity risk context.
+- Versus policy engines alone: Identrail adds discovery + risk evidence, not only policy evaluation.
+
+## Security and Support SLA
+
+If you discover a vulnerability, use private reporting only:
+
+- GitHub private advisories: <https://github.com/Oluwatobi-Mustapha/identrail/security/advisories/new>
+- Email: [security@identrail.com](mailto:security@identrail.com)
+
+Maintainer targets for supported versions:
+
+- Acknowledge valid reports within 72 hours.
+- Initial triage within 7 days.
+- Weekly status updates until resolution.
+
+Full policy: [SECURITY.md](./SECURITY.md).
+
+## Release Policy
+
+Identrail uses SemVer (`MAJOR.MINOR.PATCH`) with explicit deprecation and support windows.
+
+- Breaking changes ship in major releases (except emergency security actions).
+- Active support: latest minor of current major.
+- Maintenance support: latest minor of previous major.
+
+Full policy: [docs/versioning-support-policy.md](./docs/versioning-support-policy.md).
+
+## Contributing
+
+- [Contributing Guide](./CONTRIBUTING.md)
+- [Code of Conduct](./CODE_OF_CONDUCT.md)
+- [Issues](https://github.com/identrail/identrail/issues)
+
+## License
+
+Licensed under [Apache-2.0](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Demo video: _coming soon_.
 
 If you discover a vulnerability, use private reporting only:
 
-- GitHub private advisories: <https://github.com/Oluwatobi-Mustapha/identrail/security/advisories/new>
+- GitHub private advisories: <https://github.com/identrail/identrail/security/advisories/new>
 - Email: [security@identrail.com](mailto:security@identrail.com)
 
 Maintainer targets for supported versions:


### PR DESCRIPTION
## Summary
- redesign README to communicate project value in seconds
- add explicit adopter-facing sections: who it is for, quickstart, scope boundaries, deployment options, status/roadmap, comparison, security SLA, and release policy
- keep style minimal, clean, and production-grade while linking to canonical docs

## Why
The previous README was clean but too lightweight for adoption signaling. This update makes the project appear more mature and easier to evaluate quickly without adding noise.

## Highlights
- copy-paste `make quickstart` path
- clear `does / does not do` boundaries
- deployment decision map (Compose/Kubernetes/Helm/Terraform/systemd)
- concise positioning vs adjacent tool categories
- explicit support and security expectations

## Notes
- left a placeholder line for demo video: _coming soon_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the README to clearly explain Identrail and speed up evaluation and adoption. Adds a 5‑minute quickstart, operational model, deployment paths, security/support policies, and links to core docs; removes roadmap and license sections to keep focus.

- **New Features**
  - Audience and scope: who it’s for; what it does/doesn’t; positioning vs adjacent tools.
  - 5‑minute quickstart (`make quickstart`, `make quickstart-down`) with prerequisites; Enterprise Quickstart link.
  - How it works: pipeline overview and API/worker scan model with endpoints.
  - Deployment options with paths (Compose, Kubernetes, Helm, Terraform, systemd) + “Deployment Anywhere” link.
  - Project status: Active v1; links to Architecture, OpenAPI, and versioning/support policy.
  - Security reporting with private advisories + support SLA; release policy (SemVer and support windows).
  - Cleaner header with tagline, badges, and a demo placeholder.

- **Refactors**
  - Removed roadmap and license sections to reduce noise.

<sup>Written for commit d55b19a5c9b6eb296b26b7b14cf11c5d7a071ab0. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/259?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

