### PR TITLE
web: patch uuid advisory via npm override

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -34,5 +34,8 @@
     "typescript": "^6.0.3",
     "vite": "^8.0.10",
     "vitest": "^4.1.2"
+  },
+  "overrides": {
+    "uuid": "^13.0.0"
   }
 }


### PR DESCRIPTION
Adds npm override for uuid and refreshes lockfile to remediate GHSA-w5hq-g745-h8pq reported in Dependabot.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force `uuid` to ^13.0.0 in the web app via npm overrides to remediate GHSA-w5hq-g745-h8pq. This blocks vulnerable `uuid` versions from being installed (direct or transitive).

<sup>Written for commit 28539b97f3b88dbff234c0dbbb636d34a62dee65. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/260?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

