### PR TITLE
web: patch tmp advisory via npm override

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -6348,13 +6348,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/web/package.json
+++ b/web/package.json
@@ -34,5 +34,8 @@
     "typescript": "^6.0.3",
     "vite": "^8.0.10",
     "vitest": "^4.1.2"
+  },
+  "overrides": {
+    "tmp": "^0.2.4"
   }
 }


### PR DESCRIPTION
Adds npm override for tmp and refreshes lockfile to remediate GHSA-52f5-9888-hmc6 reported in Dependabot.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force `tmp` to `^0.2.4` via npm `overrides` to remediate GHSA-52f5-9888-hmc6, and refreshed `package-lock.json` (includes `uuid` -> `13.0.0`).

<sup>Written for commit 72544252586bb64f0eadf175ebd7eff6d8b82fa5. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/261?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

