### PR TITLE
ci: pin actions in release and supply-chain workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,12 +78,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: refs/tags/${{ needs.prepare.outputs.tag }}
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: go.mod
           cache: true
@@ -139,7 +139,7 @@ jobs:
           )
 
       - name: Upload release binaries
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: release-binaries
           path: dist/*
@@ -154,15 +154,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: refs/tags/${{ needs.prepare.outputs.tag }}
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -223,7 +223,7 @@ jobs:
           build_and_push "web" -f deploy/docker/Dockerfile.web --build-arg "VITE_IDENTRAIL_API_URL=${web_api_url}" .
 
       - name: Upload image metadata
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: release-image-metadata
           path: dist/image-digests.txt
@@ -238,13 +238,13 @@ jobs:
 
     steps:
       - name: Download release binaries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: release-binaries
           path: dist
 
       - name: Publish release with generated notes
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
           tag_name: ${{ needs.prepare.outputs.tag }}
           generate_release_notes: true
@@ -261,19 +261,19 @@ jobs:
 
     steps:
       - name: Download release binaries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: release-binaries
           path: dist
 
       - name: Download image metadata
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: release-image-metadata
           path: dist
 
       - name: Publish release with generated notes
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
           tag_name: ${{ needs.prepare.outputs.tag }}
           generate_release_notes: true

--- a/.github/workflows/supply-chain-trust.yml
+++ b/.github/workflows/supply-chain-trust.yml
@@ -51,12 +51,12 @@ jobs:
 
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: refs/tags/${{ needs.prepare.outputs.tag }}
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: go.mod
           cache: true
@@ -78,7 +78,7 @@ jobs:
           )
 
       - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610
 
       - name: Generate binary SBOM
         shell: bash
@@ -87,7 +87,7 @@ jobs:
           syft dir:dist -o cyclonedx-json=dist/identrail-binaries.sbom.cdx.json
 
       - name: Login to GHCR (for image SBOM/signing)
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -111,7 +111,7 @@ jobs:
           done
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac
 
       - name: Sign checksum manifest (keyless)
         shell: bash
@@ -140,7 +140,7 @@ jobs:
           done
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
         with:
           subject-path: |
             dist/identrail-cli-*
@@ -149,7 +149,7 @@ jobs:
             dist/checksums.txt
 
       - name: Upload trust artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: supply-chain-trust-artifacts
           path: |


### PR DESCRIPTION
Pins mutable action tags in release.yml and supply-chain-trust.yml to immutable commit SHAs to reduce supply-chain risk and improve Scorecard checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins all third‑party GitHub Actions in `release.yml` and `supply-chain-trust.yml` to immutable commit SHAs to harden CI and satisfy OSSF Scorecard checks. No behavior changes; only action references were updated.

<sup>Written for commit 0c846dd9518350ab41f72df0c88a3e49d7ca8ba4. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/263?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

