### PR TITLE
ci: tighten top-level permissions in scorecard workflow

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -10,8 +10,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions: read-all
-
 jobs:
   scorecard:
     name: Security Scorecard


### PR DESCRIPTION
Removes global read-all permission from the OpenSSF Scorecard workflow and relies on the existing job-scoped minimum permissions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the top-level `permissions: read-all` from the OpenSSF Scorecard workflow (`.github/workflows/ossf-scorecard.yml`) to rely on job-scoped minimum permissions. This narrows the token scope and follows least-privilege best practices.

<sup>Written for commit 9b3030b4eeae2f55ba8b10f2256c5aca6f653220. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/264?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

