### PR TITLE
ci: tighten top-level permissions in scorecard workflow

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -10,8 +10,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions: read-all
-
 jobs:
   scorecard:
     name: Security Scorecard


### PR DESCRIPTION
Replacement PR using renamed branch without codex prefix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the broad top-level `permissions: read-all` from the OSSF Scorecard workflow to reduce token scope and follow least-privilege defaults. The job now uses GitHub’s default, narrower permissions (or job-level overrides if set) with no change to the scorecard run.

<sup>Written for commit 9b3030b4eeae2f55ba8b10f2256c5aca6f653220. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/269?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

