### PR TITLE
Make readme better

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 <div align="center">
   <picture>
-    <img src="./docs/static/images/identrail-logo-bw-white.png" alt="Identrail Logo" width="220" />
+   <img src="./docs/static/images/identrail-logo-bw-white.png" alt="Identrail Logo" width="320" style="margin-bottom: 16px;" />
   </picture>
-  <h2>Identrail</h2>
+
+  <br />
+  <br />
+
   <p><strong>Open-source machine identity security for AWS and Kubernetes.</strong></p>
   <p>Discover trust paths, detect high-signal exposure risk, and apply authorization guardrails with explainable decisions.</p>
 </div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improved README header layout: increased logo to 320px with bottom margin, added spacing breaks, and removed the H2 title for a cleaner look.

<sup>Written for commit ccfa76a1a6a6966294da750debf0aeef9cc68081. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/480">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

