### PR TITLE
ci: stop identrail-reviewer from running on PRs

### DIFF
--- a/.github/workflows/identrail-reviewer-review.yml
+++ b/.github/workflows/identrail-reviewer-review.yml
@@ -1,8 +1,6 @@
 name: identrail-reviewer-review
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, edited]
   issues:
     types: [opened, edited, reopened]
 

--- a/.github/workflows/identrail-reviewer-shadow.yml
+++ b/.github/workflows/identrail-reviewer-shadow.yml
@@ -1,8 +1,6 @@
 name: identrail-reviewer-shadow
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, edited, ready_for_review]
   issues:
     types: [opened, edited, reopened]
 


### PR DESCRIPTION
## Summary
- remove pull_request triggers from identrail-reviewer-review workflow
- remove pull_request triggers from identrail-reviewer-shadow workflow
- keep issue-triggered behavior unchanged

## Why
- removes identrail-reviewer bot comments/checks from pull requests

## Validation
- verified only PR triggers were removed in both workflow files


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable `identrail-reviewer-review` and `identrail-reviewer-shadow` workflows on `pull_request` events to stop bot comments/checks on PRs. Issue triggers remain unchanged.

<sup>Written for commit 2a34325e1214cef375bff04b09095e3321a8086f. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/483">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

