### PR TITLE
fix(scheduler): propagate caller context through advisory lock operations

### DIFF
--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -639,11 +639,11 @@ func TestRouterScanEnqueueSucceedsWhenExecutionLockIsHeld(t *testing.T) {
 	svc := NewService(store, routerScanner{}, "aws")
 
 	locker := scheduler.NewInMemoryLocker()
-	release, ok := locker.TryAcquire("identrail:scan:aws")
+	release, ok := locker.TryAcquire(context.Background(), "identrail:scan:aws")
 	if !ok {
 		t.Fatal("expected lock acquire")
 	}
-	defer release()
+	defer release(context.Background())
 	svc.Locker = locker
 
 	r := NewRouter(logger, metrics, svc, RouterOptions{})
@@ -663,11 +663,11 @@ func TestRouterRepoScanEnqueueSucceedsWhenExecutionLockIsHeld(t *testing.T) {
 	svc := NewService(store, routerScanner{}, "aws")
 	svc.RepoScanAllowedTargets = []string{"owner/repo"}
 	locker := scheduler.NewInMemoryLocker()
-	release, ok := locker.TryAcquire("identrail:repo-scan:owner/repo")
+	release, ok := locker.TryAcquire(context.Background(), "identrail:repo-scan:owner/repo")
 	if !ok {
 		t.Fatal("expected lock acquire")
 	}
-	defer release()
+	defer release(context.Background())
 	svc.Locker = locker
 
 	r := NewRouter(logger, metrics, svc, RouterOptions{})

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -253,11 +253,11 @@ func (s *Service) EnqueueScan(ctx context.Context) (db.ScanRecord, error) {
 func (s *Service) ProcessNextQueuedScan(ctx context.Context) (bool, error) {
 	ctx = s.scopeContext(ctx)
 	if s.Locker != nil {
-		release, ok := s.Locker.TryAcquire(s.lockKey("scan:" + s.Provider))
+		release, ok := s.Locker.TryAcquire(ctx, s.lockKey("scan:"+s.Provider))
 		if !ok {
 			return false, nil
 		}
-		defer release()
+		defer release(ctx)
 	}
 	record, err := s.Store.ClaimNextQueuedScan(ctx, s.Provider)
 	if err != nil {
@@ -279,11 +279,11 @@ func (s *Service) ProcessNextQueuedScan(ctx context.Context) (bool, error) {
 func (s *Service) RunScan(ctx context.Context) (RunScanResult, error) {
 	ctx = s.scopeContext(ctx)
 	if s.Locker != nil {
-		release, ok := s.Locker.TryAcquire(s.lockKey("scan:" + s.Provider))
+		release, ok := s.Locker.TryAcquire(ctx, s.lockKey("scan:"+s.Provider))
 		if !ok {
 			return RunScanResult{}, ErrScanInProgress
 		}
-		defer release()
+		defer release(ctx)
 	}
 	record, err := s.Store.CreateScan(ctx, s.Provider, s.Now().UTC())
 	if err != nil {
@@ -433,11 +433,11 @@ func (s *Service) ProcessNextQueuedRepoScan(ctx context.Context) (bool, error) {
 	}
 	requeue := false
 	if s.Locker != nil {
-		release, ok := s.Locker.TryAcquire(s.lockKey("repo-scan:" + strings.ToLower(record.Repository)))
+		release, ok := s.Locker.TryAcquire(ctx, s.lockKey("repo-scan:"+strings.ToLower(record.Repository)))
 		if !ok {
 			requeue = true
 		} else {
-			defer release()
+			defer release(ctx)
 		}
 	}
 	if requeue {
@@ -463,11 +463,11 @@ func (s *Service) RunRepoScanPersisted(ctx context.Context, request RepoScanRequ
 		return RunRepoScanResult{}, err
 	}
 	if s.Locker != nil {
-		release, ok := s.Locker.TryAcquire(s.lockKey("repo-scan:" + strings.ToLower(target)))
+		release, ok := s.Locker.TryAcquire(ctx, s.lockKey("repo-scan:"+strings.ToLower(target)))
 		if !ok {
 			return RunRepoScanResult{}, ErrRepoScanInProgress
 		}
-		defer release()
+		defer release(ctx)
 	}
 	record, err := s.Store.CreateRepoScan(ctx, target, s.Now().UTC())
 	if err != nil {

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -257,7 +257,7 @@ func (s *Service) ProcessNextQueuedScan(ctx context.Context) (bool, error) {
 		if !ok {
 			return false, nil
 		}
-		defer release(ctx)
+		defer release(context.Background())
 	}
 	record, err := s.Store.ClaimNextQueuedScan(ctx, s.Provider)
 	if err != nil {
@@ -283,7 +283,7 @@ func (s *Service) RunScan(ctx context.Context) (RunScanResult, error) {
 		if !ok {
 			return RunScanResult{}, ErrScanInProgress
 		}
-		defer release(ctx)
+		defer release(context.Background())
 	}
 	record, err := s.Store.CreateScan(ctx, s.Provider, s.Now().UTC())
 	if err != nil {
@@ -437,7 +437,7 @@ func (s *Service) ProcessNextQueuedRepoScan(ctx context.Context) (bool, error) {
 		if !ok {
 			requeue = true
 		} else {
-			defer release(ctx)
+			defer release(context.Background())
 		}
 	}
 	if requeue {
@@ -467,7 +467,7 @@ func (s *Service) RunRepoScanPersisted(ctx context.Context, request RepoScanRequ
 		if !ok {
 			return RunRepoScanResult{}, ErrRepoScanInProgress
 		}
-		defer release(ctx)
+		defer release(context.Background())
 	}
 	record, err := s.Store.CreateRepoScan(ctx, target, s.Now().UTC())
 	if err != nil {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -118,11 +118,11 @@ func TestServiceRunScanFailure(t *testing.T) {
 func TestServiceRunScanLocked(t *testing.T) {
 	store := db.NewMemoryStore()
 	locker := scheduler.NewInMemoryLocker()
-	release, ok := locker.TryAcquire("identrail:scan:aws")
+	release, ok := locker.TryAcquire(context.Background(), "identrail:scan:aws")
 	if !ok {
 		t.Fatal("expected lock acquire")
 	}
-	defer release()
+	defer release(context.Background())
 
 	svc := NewService(store, fakeScanner{}, "aws")
 	svc.Locker = locker
@@ -961,11 +961,11 @@ func TestServiceRunRepoScanLocked(t *testing.T) {
 	svc := NewService(store, fakeScanner{}, "aws")
 	svc.RepoScanAllowedTargets = []string{"owner/repo"}
 	locker := scheduler.NewInMemoryLocker()
-	release, ok := locker.TryAcquire("identrail:repo-scan:owner/repo")
+	release, ok := locker.TryAcquire(context.Background(), "identrail:repo-scan:owner/repo")
 	if !ok {
 		t.Fatal("expected repo lock acquire")
 	}
-	defer release()
+	defer release(context.Background())
 	svc.Locker = locker
 
 	if _, err := svc.RunRepoScanPersisted(defaultScopeContext(), RepoScanRequest{Repository: "owner/repo"}); !errors.Is(err, ErrRepoScanInProgress) {
@@ -1189,11 +1189,11 @@ func TestServiceProcessQueuedRepoScanRequeuesWhenExecutionLockHeld(t *testing.T)
 		t.Fatalf("enqueue repo scan: %v", err)
 	}
 	locker := scheduler.NewInMemoryLocker()
-	release, ok := locker.TryAcquire("identrail:repo-scan:owner/repo")
+	release, ok := locker.TryAcquire(context.Background(), "identrail:repo-scan:owner/repo")
 	if !ok {
 		t.Fatal("expected lock acquire")
 	}
-	defer release()
+	defer release(context.Background())
 	svc.Locker = locker
 
 	processed, err := svc.ProcessNextQueuedRepoScan(defaultScopeContext())
@@ -1244,11 +1244,11 @@ func TestServiceProcessQueuedRepoScanContinuesToNextTargetAfterRequeue(t *testin
 	}
 
 	locker := scheduler.NewInMemoryLocker()
-	release, ok := locker.TryAcquire("identrail:repo-scan:owner/repo-a")
+	release, ok := locker.TryAcquire(context.Background(), "identrail:repo-scan:owner/repo-a")
 	if !ok {
 		t.Fatal("expected lock acquire")
 	}
-	defer release()
+	defer release(context.Background())
 	svc.Locker = locker
 
 	processed, err := svc.ProcessNextQueuedRepoScan(defaultScopeContext())

--- a/internal/scheduler/lock.go
+++ b/internal/scheduler/lock.go
@@ -1,13 +1,16 @@
 package scheduler
 
-import "sync"
+import (
+	"context"
+	"sync"
+)
 
 // ReleaseFn releases an acquired lock.
-type ReleaseFn func()
+type ReleaseFn func(context.Context)
 
 // Locker coordinates idempotent, non-overlapping scan execution.
 type Locker interface {
-	TryAcquire(key string) (ReleaseFn, bool)
+	TryAcquire(ctx context.Context, key string) (ReleaseFn, bool)
 }
 
 // InMemoryLocker is a keyed in-memory lock implementation.
@@ -22,7 +25,7 @@ func NewInMemoryLocker() *InMemoryLocker {
 }
 
 // TryAcquire acquires a key lock if available.
-func (l *InMemoryLocker) TryAcquire(key string) (ReleaseFn, bool) {
+func (l *InMemoryLocker) TryAcquire(_ context.Context, key string) (ReleaseFn, bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -35,7 +38,7 @@ func (l *InMemoryLocker) TryAcquire(key string) (ReleaseFn, bool) {
 	l.locks[key] = true
 
 	released := false
-	return func() {
+	return func(_ context.Context) {
 		l.mu.Lock()
 		defer l.mu.Unlock()
 		if released {

--- a/internal/scheduler/lock_test.go
+++ b/internal/scheduler/lock_test.go
@@ -1,35 +1,38 @@
 package scheduler
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestInMemoryLockerTryAcquire(t *testing.T) {
 	locker := NewInMemoryLocker()
 
-	release, ok := locker.TryAcquire("scan:aws")
+	release, ok := locker.TryAcquire(context.Background(), "scan:aws")
 	if !ok || release == nil {
 		t.Fatal("expected first acquire success")
 	}
 
-	if _, ok := locker.TryAcquire("scan:aws"); ok {
+	if _, ok := locker.TryAcquire(context.Background(), "scan:aws"); ok {
 		t.Fatal("expected lock contention")
 	}
 
-	release()
-	if _, ok := locker.TryAcquire("scan:aws"); !ok {
+	release(context.Background())
+	if _, ok := locker.TryAcquire(context.Background(), "scan:aws"); !ok {
 		t.Fatal("expected acquire after release")
 	}
 }
 
 func TestInMemoryLockerReleaseIdempotent(t *testing.T) {
 	locker := NewInMemoryLocker()
-	release, ok := locker.TryAcquire("scan:aws")
+	release, ok := locker.TryAcquire(context.Background(), "scan:aws")
 	if !ok {
 		t.Fatal("expected acquire success")
 	}
-	release()
-	release()
+	release(context.Background())
+	release(context.Background())
 
-	if _, ok := locker.TryAcquire("scan:aws"); !ok {
+	if _, ok := locker.TryAcquire(context.Background(), "scan:aws"); !ok {
 		t.Fatal("expected acquire after double release")
 	}
 }

--- a/internal/scheduler/postgres_lock.go
+++ b/internal/scheduler/postgres_lock.go
@@ -6,6 +6,7 @@ import (
 	"hash/fnv"
 	"strings"
 	"sync"
+	"time"
 )
 
 // PostgresAdvisoryLocker implements Locker using PostgreSQL advisory locks.
@@ -46,10 +47,12 @@ func (l *PostgresAdvisoryLocker) TryAcquire(ctx context.Context, key string) (Re
 	var once sync.Once
 	return func(releaseCtx context.Context) {
 		once.Do(func() {
-			if releaseCtx == nil {
+			if releaseCtx == nil || releaseCtx.Err() != nil {
 				releaseCtx = context.Background()
 			}
-			_, _ = conn.ExecContext(releaseCtx, "SELECT pg_advisory_unlock($1)", lockKey)
+			unlockCtx, cancel := context.WithTimeout(releaseCtx, 5*time.Second)
+			defer cancel()
+			_, _ = conn.ExecContext(unlockCtx, "SELECT pg_advisory_unlock($1)", lockKey)
 			_ = conn.Close()
 		})
 	}, true

--- a/internal/scheduler/postgres_lock.go
+++ b/internal/scheduler/postgres_lock.go
@@ -20,18 +20,21 @@ func NewPostgresAdvisoryLocker(db *sql.DB) *PostgresAdvisoryLocker {
 }
 
 // TryAcquire attempts to take a non-blocking advisory lock for key.
-func (l *PostgresAdvisoryLocker) TryAcquire(key string) (ReleaseFn, bool) {
+func (l *PostgresAdvisoryLocker) TryAcquire(ctx context.Context, key string) (ReleaseFn, bool) {
 	if l == nil || l.db == nil {
 		return nil, false
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	lockKey := advisoryLockID(key)
-	conn, err := l.db.Conn(context.Background())
+	conn, err := l.db.Conn(ctx)
 	if err != nil {
 		return nil, false
 	}
 
 	var acquired bool
-	if err := conn.QueryRowContext(context.Background(), "SELECT pg_try_advisory_lock($1)", lockKey).Scan(&acquired); err != nil {
+	if err := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1)", lockKey).Scan(&acquired); err != nil {
 		_ = conn.Close()
 		return nil, false
 	}
@@ -41,9 +44,12 @@ func (l *PostgresAdvisoryLocker) TryAcquire(key string) (ReleaseFn, bool) {
 	}
 
 	var once sync.Once
-	return func() {
+	return func(releaseCtx context.Context) {
 		once.Do(func() {
-			_, _ = conn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1)", lockKey)
+			if releaseCtx == nil {
+				releaseCtx = context.Background()
+			}
+			_, _ = conn.ExecContext(releaseCtx, "SELECT pg_advisory_unlock($1)", lockKey)
 			_ = conn.Close()
 		})
 	}, true

--- a/internal/scheduler/postgres_lock_test.go
+++ b/internal/scheduler/postgres_lock_test.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"context"
 	"regexp"
 	"testing"
 
@@ -24,13 +25,13 @@ func TestPostgresAdvisoryLockerTryAcquireAndRelease(t *testing.T) {
 		WithArgs(lockID).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	release, ok := locker.TryAcquire("identrail:scan:aws")
+	release, ok := locker.TryAcquire(context.Background(), "identrail:scan:aws")
 	if !ok || release == nil {
 		t.Fatal("expected advisory lock to be acquired")
 	}
-	release()
+	release(context.Background())
 	// Ensure release is idempotent.
-	release()
+	release(context.Background())
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
@@ -50,7 +51,7 @@ func TestPostgresAdvisoryLockerTryAcquireFailure(t *testing.T) {
 		WithArgs(lockID).
 		WillReturnRows(sqlmock.NewRows([]string{"pg_try_advisory_lock"}).AddRow(false))
 
-	release, ok := locker.TryAcquire("identrail:scan:aws")
+	release, ok := locker.TryAcquire(context.Background(), "identrail:scan:aws")
 	if ok || release != nil {
 		t.Fatal("expected lock acquisition failure")
 	}
@@ -69,7 +70,7 @@ func TestAdvisoryLockIDStability(t *testing.T) {
 
 func TestPostgresAdvisoryLockerTryAcquireWithNilDB(t *testing.T) {
 	locker := NewPostgresAdvisoryLocker(nil)
-	release, ok := locker.TryAcquire("scan:aws")
+	release, ok := locker.TryAcquire(context.Background(), "scan:aws")
 	if ok || release != nil {
 		t.Fatal("expected nil db locker to fail acquisition")
 	}

--- a/internal/scheduler/runner.go
+++ b/internal/scheduler/runner.go
@@ -33,11 +33,11 @@ func (r Runner) RunOnce(ctx context.Context) error {
 	}
 
 	if r.Locker != nil {
-		release, ok := r.Locker.TryAcquire(r.key())
+		release, ok := r.Locker.TryAcquire(ctx, r.key())
 		if !ok {
 			return ErrAlreadyRunning
 		}
-		defer release()
+		defer release(ctx)
 	}
 
 	attempts := r.MaxAttempts

--- a/internal/scheduler/runner.go
+++ b/internal/scheduler/runner.go
@@ -37,7 +37,7 @@ func (r Runner) RunOnce(ctx context.Context) error {
 		if !ok {
 			return ErrAlreadyRunning
 		}
-		defer release(ctx)
+		defer release(context.Background())
 	}
 
 	attempts := r.MaxAttempts

--- a/internal/scheduler/runner_test.go
+++ b/internal/scheduler/runner_test.go
@@ -29,11 +29,11 @@ func TestRunnerRunOnce(t *testing.T) {
 
 func TestRunnerRunOnceAlreadyRunning(t *testing.T) {
 	locker := NewInMemoryLocker()
-	release, ok := locker.TryAcquire("scan:aws")
+	release, ok := locker.TryAcquire(context.Background(), "scan:aws")
 	if !ok {
 		t.Fatal("expected lock acquire")
 	}
-	defer release()
+	defer release(context.Background())
 
 	runner := Runner{
 		Locker:  locker,


### PR DESCRIPTION
## Summary
- make scheduler locker APIs context-aware (`TryAcquire(ctx, key)` and `ReleaseFn(context.Context)`)
- use caller context for postgres advisory lock connection, acquire query, and unlock query
- update runner and tests to pass context through acquire/release paths

## Why
Postgres advisory lock operations used `context.Background()`, which ignored caller cancellation/deadlines during lock handling.

## Scope
- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation
- go test ./internal/scheduler

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] CHANGELOG.md updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure
- AI-assisted: yes
- Tools used: Codex (GPT-5)
- Areas where used: context propagation refactor and test updates
- Human verification performed: reviewed diff and package tests

## Related Issues
Closes #366

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates caller context through scheduler locks so Postgres advisory lock acquire respects cancellation/deadlines. Releases now use a 5s bounded context to reliably unlock even if the caller was canceled; runner and API call release with `context.Background()`.

- **Bug Fixes**
  - Use caller context for DB connection and `pg_try_advisory_lock` in the Postgres locker (falls back to `context.Background()` if nil).
  - Release uses provided context when valid, otherwise `context.Background()` with a 5s timeout for `pg_advisory_unlock`. Updated in-memory locker, runner, API service/router, and tests to use `TryAcquire(ctx, key)` and `release(context.Background())`.

- **Migration**
  - Replace `TryAcquire(key)` with `TryAcquire(ctx, key)`.
  - Replace `release()` with `release(ctx)`.

<sup>Written for commit 250ffd8b497de654fa6335689801291eb75719ef. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/502?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

