### PR TITLE
fix(api): make audit sink retry backoff context-cancelable

### DIFF
--- a/internal/api/audit_sink.go
+++ b/internal/api/audit_sink.go
@@ -157,7 +157,9 @@ func (s *HTTPAuditSink) Write(ctx context.Context, event AuditEvent) error {
 		if !retryable || attempt == attempts-1 {
 			break
 		}
-		time.Sleep(backoffDuration(s.retryBackoff, attempt))
+		if waitErr := waitForRetry(ctx, backoffDuration(s.retryBackoff, attempt)); waitErr != nil {
+			return waitErr
+		}
 	}
 	return lastErr
 }
@@ -264,4 +266,15 @@ func (s *HTTPAuditSink) send(ctx context.Context, payload []byte) (bool, error) 
 		return retryable, fmt.Errorf("audit forward status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	return false, nil
+}
+
+func waitForRetry(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }

--- a/internal/api/audit_sink.go
+++ b/internal/api/audit_sink.go
@@ -61,7 +61,7 @@ type AuditSink interface {
 type NopAuditSink struct{}
 
 func (NopAuditSink) Write(context.Context, AuditEvent) error { return nil }
-func (NopAuditSink) Close() error           { return nil }
+func (NopAuditSink) Close() error                            { return nil }
 
 // FileAuditSink writes audit events in JSON lines format.
 type FileAuditSink struct {

--- a/internal/api/audit_sink.go
+++ b/internal/api/audit_sink.go
@@ -53,14 +53,14 @@ type AuditAuthzDecision struct {
 
 // AuditSink defines the export target for API audit events.
 type AuditSink interface {
-	Write(event AuditEvent) error
+	Write(ctx context.Context, event AuditEvent) error
 	Close() error
 }
 
 // NopAuditSink discards audit events when no export target is configured.
 type NopAuditSink struct{}
 
-func (NopAuditSink) Write(AuditEvent) error { return nil }
+func (NopAuditSink) Write(context.Context, AuditEvent) error { return nil }
 func (NopAuditSink) Close() error           { return nil }
 
 // FileAuditSink writes audit events in JSON lines format.
@@ -78,7 +78,7 @@ func NewFileAuditSink(path string) (*FileAuditSink, error) {
 	return &FileAuditSink{file: file}, nil
 }
 
-func (s *FileAuditSink) Write(event AuditEvent) error {
+func (s *FileAuditSink) Write(_ context.Context, event AuditEvent) error {
 	payload, err := json.Marshal(event)
 	if err != nil {
 		return fmt.Errorf("marshal audit event: %w", err)
@@ -138,15 +138,18 @@ func NewHTTPAuditSink(endpoint string, timeout time.Duration, hmacSecret string,
 	}, nil
 }
 
-func (s *HTTPAuditSink) Write(event AuditEvent) error {
+func (s *HTTPAuditSink) Write(ctx context.Context, event AuditEvent) error {
 	payload, err := json.Marshal(event)
 	if err != nil {
 		return fmt.Errorf("marshal audit event: %w", err)
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	var lastErr error
 	attempts := s.maxRetries + 1
 	for attempt := 0; attempt < attempts; attempt++ {
-		retryable, err := s.send(payload)
+		retryable, err := s.send(ctx, payload)
 		if err == nil {
 			return nil
 		}
@@ -178,10 +181,10 @@ func NewMultiAuditSink(sinks ...AuditSink) *MultiAuditSink {
 	return &MultiAuditSink{sinks: filtered}
 }
 
-func (m *MultiAuditSink) Write(event AuditEvent) error {
+func (m *MultiAuditSink) Write(ctx context.Context, event AuditEvent) error {
 	var firstErr error
 	for _, sink := range m.sinks {
-		if err := sink.Write(event); err != nil && firstErr == nil {
+		if err := sink.Write(ctx, event); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
@@ -232,11 +235,15 @@ func validateAuditForwardURL(raw string) error {
 	}
 }
 
-func (s *HTTPAuditSink) send(payload []byte) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), s.client.Timeout)
+func (s *HTTPAuditSink) send(ctx context.Context, payload []byte) (bool, error) {
+	requestCtx := ctx
+	cancel := func() {}
+	if s.client.Timeout > 0 {
+		requestCtx, cancel = context.WithTimeout(ctx, s.client.Timeout)
+	}
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.url, bytes.NewReader(payload))
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, s.url, bytes.NewReader(payload))
 	if err != nil {
 		return false, fmt.Errorf("build audit forward request: %w", err)
 	}

--- a/internal/api/audit_sink_test.go
+++ b/internal/api/audit_sink_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -18,7 +19,7 @@ type testRecordingAuditSink struct {
 	events []AuditEvent
 }
 
-func (s *testRecordingAuditSink) Write(event AuditEvent) error {
+func (s *testRecordingAuditSink) Write(_ context.Context, event AuditEvent) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.events = append(s.events, event)
@@ -62,7 +63,7 @@ func TestFileAuditSinkWritesJSONL(t *testing.T) {
 			},
 		},
 	}
-	if err := sink.Write(event); err != nil {
+	if err := sink.Write(context.Background(), event); err != nil {
 		t.Fatalf("write audit event: %v", err)
 	}
 	if err := sink.Close(); err != nil {
@@ -113,7 +114,7 @@ func TestHTTPAuditSinkWritesEvent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new http audit sink: %v", err)
 	}
-	err = sink.Write(AuditEvent{Method: "GET", Path: "/v1/scans", Timestamp: time.Now().UTC()})
+	err = sink.Write(context.Background(), AuditEvent{Method: "GET", Path: "/v1/scans", Timestamp: time.Now().UTC()})
 	if err != nil {
 		t.Fatalf("write http audit event: %v", err)
 	}
@@ -145,7 +146,7 @@ func TestHTTPAuditSinkRetriesOnTransientFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new http audit sink: %v", err)
 	}
-	if err := sink.Write(AuditEvent{Method: "GET", Path: "/v1/scans", Timestamp: time.Now().UTC()}); err != nil {
+	if err := sink.Write(context.Background(), AuditEvent{Method: "GET", Path: "/v1/scans", Timestamp: time.Now().UTC()}); err != nil {
 		t.Fatalf("write http audit event with retries: %v", err)
 	}
 	if requests != 3 {
@@ -166,7 +167,7 @@ func TestHTTPAuditSinkDoesNotRetryOnClientError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new http audit sink: %v", err)
 	}
-	if err := sink.Write(AuditEvent{Method: "GET", Path: "/v1/scans", Timestamp: time.Now().UTC()}); err == nil {
+	if err := sink.Write(context.Background(), AuditEvent{Method: "GET", Path: "/v1/scans", Timestamp: time.Now().UTC()}); err == nil {
 		t.Fatal("expected client error")
 	}
 	if requests != 1 {
@@ -177,7 +178,7 @@ func TestHTTPAuditSinkDoesNotRetryOnClientError(t *testing.T) {
 func TestMultiAuditSinkFanout(t *testing.T) {
 	record := &testRecordingAuditSink{}
 	multi := NewMultiAuditSink(record, NopAuditSink{})
-	if err := multi.Write(AuditEvent{Method: "GET", Path: "/v1/scans"}); err != nil {
+	if err := multi.Write(context.Background(), AuditEvent{Method: "GET", Path: "/v1/scans"}); err != nil {
 		t.Fatalf("write fanout event: %v", err)
 	}
 	record.mu.Lock()

--- a/internal/api/authz_middleware_test.go
+++ b/internal/api/authz_middleware_test.go
@@ -823,7 +823,7 @@ type middlewareRecordingAuditSink struct {
 	events []AuditEvent
 }
 
-func (s *middlewareRecordingAuditSink) Write(event AuditEvent) error {
+func (s *middlewareRecordingAuditSink) Write(_ context.Context, event AuditEvent) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.events = append(s.events, event)

--- a/internal/api/authz_simulation.go
+++ b/internal/api/authz_simulation.go
@@ -253,7 +253,7 @@ func writeSimulationAuditEvent(logger *zap.Logger, sink AuditSink, c *gin.Contex
 	if apiKey := authContextString(c, "auth.api_key"); apiKey != "" {
 		event.APIKeyID = fingerprintAPIKey(apiKey)
 	}
-	if err := sink.Write(event); err != nil {
+	if err := sink.Write(c.Request.Context(), event); err != nil {
 		logger.Warn("authz simulation audit write failed", telemetry.ZapError(err))
 	}
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1404,7 +1404,7 @@ func auditLogMiddleware(logger *zap.Logger, sink AuditSink) gin.HandlerFunc {
 			zap.Int64("duration_ms", event.DurationMS),
 			zap.String("user_agent", event.UserAgent),
 		)
-		if err := sink.Write(event); err != nil {
+		if err := sink.Write(c.Request.Context(), event); err != nil {
 			logger.Warn("audit sink write failed", telemetry.ZapError(err))
 		}
 	}

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -58,7 +58,7 @@ func (v fakeTokenVerifier) VerifyToken(_ context.Context, rawToken string) (Veri
 	return token, nil
 }
 
-func (s *recordingAuditSink) Write(event AuditEvent) error {
+func (s *recordingAuditSink) Write(_ context.Context, event AuditEvent) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.events = append(s.events, event)


### PR DESCRIPTION
## Summary
- make HTTP audit sink retry backoff context-cancelable using timer/select on caller context
- stop using uninterruptible `time.Sleep` between retry attempts
- include caller-context propagation for audit sink writes so cancellation can reach retry/backoff logic

## Why
Audit sink retry backoff previously used `time.Sleep`, which could delay shutdown/cancellation during retry windows.

## Scope
- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation
- go test ./internal/api

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] CHANGELOG.md updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure
- AI-assisted: yes
- Tools used: Codex (GPT-5)
- Areas where used: retry cancellation logic and PR prep
- Human verification performed: reviewed diff and package tests

## Related Issues
Closes #279

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make audit sink retries cancelable via context and forward the request context through HTTP audit requests. This prevents shutdowns from hanging during retry backoff and cancels in-flight requests.

- **Bug Fixes**
  - Replaced `time.Sleep` with a context-aware backoff wait, so retries stop on cancellation.
  - Changed `AuditSink.Write` to accept `context.Context`; updated sinks, middleware, and fanout to pass the request context.
  - Updated `HTTPAuditSink` to layer per-request timeouts on the caller context and to cancel both backoff waits and HTTP calls.

<sup>Written for commit 322ccf877ac2a2f9d914d424de80c7764cab8983. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/504?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

