### PR TITLE
fix(scheduler): surface run errors from Runner.Start loop

### DIFF
--- a/internal/scheduler/runner.go
+++ b/internal/scheduler/runner.go
@@ -102,9 +102,9 @@ func (r Runner) Start(ctx context.Context) error {
 			if err == nil || errors.Is(err, ErrAlreadyRunning) {
 				continue
 			}
-				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-					return err
-				}
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return err
+			}
 			if r.OnError != nil {
 				r.OnError(ctx, err)
 				continue

--- a/internal/scheduler/runner.go
+++ b/internal/scheduler/runner.go
@@ -102,9 +102,9 @@ func (r Runner) Start(ctx context.Context) error {
 			if err == nil || errors.Is(err, ErrAlreadyRunning) {
 				continue
 			}
-			if errors.Is(err, context.Canceled) {
-				return err
-			}
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					return err
+				}
 			if r.OnError != nil {
 				r.OnError(ctx, err)
 				continue

--- a/internal/scheduler/runner.go
+++ b/internal/scheduler/runner.go
@@ -15,6 +15,9 @@ type TriggerFunc func(context.Context) error
 // DeadLetterFunc is called when retries are exhausted and trigger still fails.
 type DeadLetterFunc func(context.Context, error)
 
+// ErrorFunc is called when scheduled RunOnce returns a non-cancellation error.
+type ErrorFunc func(context.Context, error)
+
 // Runner periodically executes a trigger while enforcing single-flight per key.
 type Runner struct {
 	Interval     time.Duration
@@ -24,6 +27,7 @@ type Runner struct {
 	MaxAttempts  int
 	RetryBackoff time.Duration
 	OnDeadLetter DeadLetterFunc
+	OnError      ErrorFunc
 }
 
 // RunOnce triggers a scan exactly once.
@@ -94,7 +98,18 @@ func (r Runner) Start(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			_ = r.RunOnce(ctx)
+			err := r.RunOnce(ctx)
+			if err == nil || errors.Is(err, ErrAlreadyRunning) {
+				continue
+			}
+			if errors.Is(err, context.Canceled) {
+				return err
+			}
+			if r.OnError != nil {
+				r.OnError(ctx, err)
+				continue
+			}
+			return err
 		}
 	}
 }

--- a/internal/scheduler/runner_test.go
+++ b/internal/scheduler/runner_test.go
@@ -126,3 +126,43 @@ func TestRunnerRunOnceDeadLetterOnFailure(t *testing.T) {
 		t.Fatalf("expected one dead-letter callback, got %d", deadLetterCalls)
 	}
 }
+
+func TestRunnerStartReturnsTriggerErrorWhenNoErrorHandler(t *testing.T) {
+	runner := Runner{
+		Interval: 1 * time.Millisecond,
+		Trigger:  func(context.Context) error { return errors.New("boom") },
+	}
+
+	err := runner.Start(context.Background())
+	if err == nil || err.Error() != "boom" {
+		t.Fatalf("expected trigger error to be returned, got %v", err)
+	}
+}
+
+func TestRunnerStartInvokesOnErrorAndContinues(t *testing.T) {
+	var calls int32
+	var onErrorCalls int32
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runner := Runner{
+		Interval: 1 * time.Millisecond,
+		Trigger: func(context.Context) error {
+			if atomic.AddInt32(&calls, 1) >= 2 {
+				cancel()
+			}
+			return errors.New("boom")
+		},
+		OnError: func(context.Context, error) {
+			atomic.AddInt32(&onErrorCalls, 1)
+		},
+	}
+
+	err := runner.Start(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+	if onErrorCalls == 0 {
+		t.Fatal("expected OnError to be invoked")
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -133,6 +133,9 @@ func Run(ctx context.Context, cfg config.Config, signals <-chan os.Signal) error
 			OnDeadLetter: func(_ context.Context, err error) {
 				logger.Error("cloud trigger exhausted retries; dead-letter event emitted", telemetry.ZapError(err))
 			},
+			OnError: func(_ context.Context, err error) {
+				logger.Error("cloud runner iteration failed", telemetry.ZapError(err))
+			},
 		},
 	}}
 	if cfg.WorkerRepoScanEnabled {
@@ -147,6 +150,9 @@ func Run(ctx context.Context, cfg config.Config, signals <-chan os.Signal) error
 				RetryBackoff: defaultWorkerRetryBackoff,
 				OnDeadLetter: func(_ context.Context, err error) {
 					logger.Error("repo trigger exhausted retries; dead-letter event emitted", telemetry.ZapError(err))
+				},
+				OnError: func(_ context.Context, err error) {
+					logger.Error("repo runner iteration failed", telemetry.ZapError(err))
 				},
 			},
 		})
@@ -163,6 +169,9 @@ func Run(ctx context.Context, cfg config.Config, signals <-chan os.Signal) error
 				RetryBackoff: defaultWorkerRetryBackoff,
 				OnDeadLetter: func(_ context.Context, err error) {
 					logger.Error("api job queue trigger exhausted retries; dead-letter event emitted", telemetry.ZapError(err))
+				},
+				OnError: func(_ context.Context, err error) {
+					logger.Error("api queue runner iteration failed", telemetry.ZapError(err))
 				},
 			},
 		})


### PR DESCRIPTION
## Summary
- add `Runner.OnError` callback for scheduled iteration failures
- update `Runner.Start` to stop suppressing `RunOnce` errors
- return iteration errors when no handler is configured
- wire worker runners to log surfaced iteration errors via `OnError`

## Why
`Runner.Start` previously discarded all `RunOnce` errors, hiding recurring trigger failures.

## Scope
- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation
- go test ./internal/scheduler ./internal/worker

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] CHANGELOG.md updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure
- AI-assisted: yes
- Tools used: Codex (GPT-5)
- Areas where used: scheduler error propagation and worker wiring
- Human verification performed: reviewed diff and package tests

## Related Issues
Closes #271

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface scheduled run errors from `Runner.Start` and add `Runner.OnError` to handle iteration failures without exiting. Worker runners now log iteration errors for cloud, repo, and API queue triggers.

- **Bug Fixes**
  - `Runner.Start` returns `RunOnce` errors when no handler is set.
  - Continues on `ErrAlreadyRunning`; stops on context cancellation or deadline exceeded.

- **New Features**
  - Added `Runner.OnError` callback for iteration failures.
  - Workers log surfaced errors for cloud, repo, and API queue triggers.

<sup>Written for commit cf54dd6bb17edbd1ba8477712b6915f7787bcb0b. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/505?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

