### PR TITLE
improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <p align="center">
   <a href="https://github.com/identrail/identrail/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/identrail/identrail/ci.yml?branch=dev&style=flat&label=ci&colorA=000000&colorB=2ea043" alt="CI" /></a>
-  <a href="https://github.com/identrail/identrail/tags"><img src="https://img.shields.io/github/v/tag/identrail/identrail?sort=semver&style=flat&label=version&colorA=000000&colorB=000000" alt="Latest version" /></a>
+  <a href="https://github.com/identrail/identrail/tags"><img src="https://img.shields.io/github/v/tag/identrail/identrail?sort=semver&style=flat&label=version&colorA=000000&colorB=0969da" alt="Latest version" /></a>
   <a href="https://github.com/identrail/identrail/stargazers"><img src="https://img.shields.io/github/stars/identrail/identrail?style=flat&colorA=000000&colorB=d4af37" alt="GitHub stars" /></a>
 </p>
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated README to improve the version badge visibility by switching to GitHub blue. Changed the version shield’s colorB from 000000 to 0969da.

<sup>Written for commit da5db5c60843073d0cec53aa249920b36c560493. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/506?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

