### PR TITLE
Update SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ Identrail takes security reports seriously. If you believe you have found a vuln
 Do not open public GitHub issues for suspected vulnerabilities.
 
 Use GitHub private vulnerability reporting or the company's email (we respond within 72 hours):
-- https://github.com/Oluwatobi-Mustapha/identrail/security/advisories/new
+- https://github.com/identrail/identrail/security/advisories/new
 - security@identrail.com
 
 If you cannot use that channel, contact the maintainer directly via LinkedIn:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the private vulnerability reporting link in SECURITY.md to point to the canonical `identrail/identrail` repo instead of a fork. Ensures security reports go to the correct channel without delays.

<sup>Written for commit 3dbd1ea68cbf86670a94bed05947685d3f04d4cd. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/507?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

