### PR TITLE
fix(web): add dedicated prerender metadata for live routes

### DIFF
--- a/web/scripts/prerender-routes.ts
+++ b/web/scripts/prerender-routes.ts
@@ -93,15 +93,40 @@ const ROUTE_META: Record<string, RouteMeta> = {
     description:
       'Compare Open Source, Hosted SaaS, and Enterprise machine identity security plans based on team size, deployment needs, and controls.'
   },
+  '/roi-assessment': {
+    title: 'ROI Assessment | Quantify Machine Identity Risk Reduction',
+    description:
+      'Estimate expected risk reduction and operational impact from machine identity hardening with an ROI-first assessment workflow.'
+  },
+  '/read-only-scan': {
+    title: 'Read-Only Risk Scan | Safe Machine Identity Discovery',
+    description:
+      'Run a read-only machine identity risk scan across AWS and Kubernetes trust paths without making policy changes in your environment.'
+  },
+  '/deployment-models': {
+    title: 'Deployment Models | Self-Hosted, SaaS, and Enterprise Options',
+    description:
+      'Compare Identrail deployment models across self-hosted, hosted SaaS, and enterprise rollout patterns with security and control tradeoffs.'
+  },
   '/demo': {
     title: 'Demo | Interactive Trust Graph and Risk Workflows',
     description:
       'Explore an interactive trust graph demo showing machine identity attack-path evidence, risk scoring, and recommended controls.'
   },
+  '/integrations': {
+    title: 'Integrations | AWS, Kubernetes, GitHub, OIDC, and Observability',
+    description:
+      'Review current integrations and telemetry sources used to build machine identity trust paths and prioritized risk evidence.'
+  },
   '/docs': {
     title: 'Docs | Identrail Documentation Hub',
     description:
       'Read deployment, integration, and operational documentation for Identrail machine identity security workflows.'
+  },
+  '/faq': {
+    title: 'FAQ | Machine Identity Security and Product Operations',
+    description:
+      'Answers to common questions on read-only scanning, trust-path analysis, deployment models, and rollout-safe remediation.'
   },
   '/blog': {
     title: 'Blog | Machine Identity Security Guides and Insights',
@@ -152,6 +177,11 @@ const ROUTE_META: Record<string, RouteMeta> = {
     title: 'Security and Compliance | Identrail',
     description:
       'Review Identrail security controls, compliance roadmap, disclosure process, and deployment safeguards.'
+  },
+  '/responsible-disclosure': {
+    title: 'Responsible Disclosure | Report Security Issues to Identrail',
+    description:
+      'Report security vulnerabilities privately and review disclosure expectations, triage timelines, and coordination policy.'
   },
   '/about': {
     title: 'About | Identrail',


### PR DESCRIPTION
## Summary
Add explicit prerender metadata entries for live routes that were previously falling back to homepage/default metadata.

## Scope
- Update  route metadata map.
- No route additions/removals.

## Validation
- Ran 
> identrail-web@0.1.0 build
> tsc -b && vite build && npm run prerender:routes

vite v8.0.10 building client environment for production...
[2Ktransforming...✓ 36 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                             2.06 kB │ gzip:  0.89 kB
dist/assets/index-Dox-mwxR.css             63.67 kB │ gzip: 13.65 kB
dist/assets/rolldown-runtime-jpDsebLB.js    0.56 kB │ gzip:  0.36 kB
dist/assets/index-Cuuq5DW_.js             143.49 kB │ gzip: 38.81 kB
dist/assets/react_vendor-D8GA58KU.js      230.40 kB │ gzip: 73.58 kB

✓ built in 335ms

> identrail-web@0.1.0 prerender:routes
> tsx ./scripts/prerender-routes.ts

Prerendered 37 routes. successfully (includes prerender step).

## Notes
- Intentionally excludes demo-video path work for now per current rollout decision.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit prerender metadata for several live routes so they no longer fall back to homepage defaults, improving SEO and share previews.

- **Bug Fixes**
  - Added metadata entries for `/roi-assessment`, `/read-only-scan`, `/deployment-models`, `/integrations`, `/faq`, `/responsible-disclosure`.
  - Updated `ROUTE_META` in `web/scripts/prerender-routes.ts`; build and prerender succeed (37 routes).

<sup>Written for commit aab7a85a5040dc04d9ac680333d27ccb08310a8a. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/528?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

