### PR TITLE
ci(web): guard prerender routes against sitemap drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,9 @@ jobs:
       - name: Validate API Example Contract
         run: ./scripts/check_api_example_contract.sh
 
+      - name: Validate Web Route Integrity
+        run: ./scripts/check_web_route_integrity.sh
+
       - name: Install Web Dependencies
         run: npm ci --prefix web
 

--- a/scripts/check_web_route_integrity.sh
+++ b/scripts/check_web_route_integrity.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+node <<'NODE'
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = process.cwd();
+
+function read(rel) {
+  return fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+}
+
+function parseAppRoutes(src) {
+  const routes = new Set();
+  const routeRegex = /<Route\s+path="([^"]+)"/g;
+  let m;
+  while ((m = routeRegex.exec(src)) !== null) {
+    const route = m[1];
+    if (route.includes('*') || route.includes(':')) {
+      continue;
+    }
+    routes.add(route);
+  }
+  return routes;
+}
+
+function parsePrerenderRoutes(src) {
+  const blockMatch = src.match(/export const PRERENDER_ROUTES\s*=\s*\[([\s\S]*?)\]\s*as const;/);
+  if (!blockMatch) throw new Error('Unable to parse PRERENDER_ROUTES block');
+  const block = blockMatch[1];
+  const routes = new Set();
+  const routeRegex = /'([^']+)'/g;
+  let m;
+  while ((m = routeRegex.exec(block)) !== null) {
+    routes.add(m[1]);
+  }
+  return routes;
+}
+
+function parseRouteMetaKeys(src) {
+  const blockMatch = src.match(/const ROUTE_META:\s*Record<string, RouteMeta>\s*=\s*\{([\s\S]*?)\n\};/);
+  if (!blockMatch) throw new Error('Unable to parse ROUTE_META block');
+  const block = blockMatch[1];
+  const routes = new Set();
+  const routeRegex = /'([^']+)'\s*:\s*\{/g;
+  let m;
+  while ((m = routeRegex.exec(block)) !== null) {
+    routes.add(m[1]);
+  }
+  return routes;
+}
+
+function parseSitemapRoutes(src) {
+  const routes = new Set();
+  const locRegex = /<loc>https:\/\/www\.identrail\.com([^<]*)<\/loc>/g;
+  let m;
+  while ((m = locRegex.exec(src)) !== null) {
+    const suffix = m[1] || '/';
+    routes.add(suffix === '' ? '/' : suffix);
+  }
+  return routes;
+}
+
+function diff(a, b) {
+  return [...a].filter((x) => !b.has(x));
+}
+
+const appRoutes = parseAppRoutes(read('web/src/App.tsx'));
+const prerenderRoutes = parsePrerenderRoutes(read('web/prerender-routes.ts'));
+const sitemapRoutes = parseSitemapRoutes(read('web/public/sitemap.xml'));
+
+const missingInPrerender = diff(appRoutes, prerenderRoutes);
+const missingInSitemap = diff(prerenderRoutes, sitemapRoutes);
+
+let hasError = false;
+
+if (missingInPrerender.length) {
+  hasError = true;
+  console.error('Routes present in App.tsx but missing from PRERENDER_ROUTES:');
+  for (const route of missingInPrerender.sort()) console.error(`  - ${route}`);
+}
+if (missingInSitemap.length) {
+  hasError = true;
+  console.error('Routes present in PRERENDER_ROUTES but missing from sitemap.xml:');
+  for (const route of missingInSitemap.sort()) console.error(`  - ${route}`);
+}
+
+if (hasError) {
+  process.exit(1);
+}
+
+console.log('OK: web route integrity checks passed');
+NODE

--- a/scripts/check_web_route_integrity.sh
+++ b/scripts/check_web_route_integrity.sh
@@ -22,7 +22,42 @@ function parseAppRoutes(src) {
     }
     routes.add(route);
   }
+  // Include static routes generated from mapped slug collections, e.g.
+  // path={`/features/${page.slug}`} inside FEATURE_DEEP_PAGES.map(...)
+  const mappedRouteRegex = /\{([A-Z0-9_]+)\.map\(\(page\)\s*=>\s*\([\s\S]*?<Route[^>]*\s+path=\{`([^`]*)\$\{page\.slug\}([^`]*)`\}/g;
+  while ((m = mappedRouteRegex.exec(src)) !== null) {
+    const collectionName = m[1];
+    const prefix = m[2];
+    const suffix = m[3];
+    for (const slug of parseSlugCollection(src, collectionName)) {
+      const route = `${prefix}${slug}${suffix}`;
+      if (route.includes('*') || route.includes(':')) {
+        continue;
+      }
+      routes.add(route);
+    }
+  }
+
   return routes;
+}
+
+function parseSlugCollection(src, collectionName) {
+  const collectionRegex = /const\s+([A-Z0-9_]+)\s*=\s*\[([\s\S]*?)\]\s*as const;/g;
+  const slugRegex = /slug:\s*'([^']+)'/g;
+  let m;
+  while ((m = collectionRegex.exec(src)) !== null) {
+    if (m[1] !== collectionName) {
+      continue;
+    }
+    const block = m[2];
+    const slugs = [];
+    let slugMatch;
+    while ((slugMatch = slugRegex.exec(block)) !== null) {
+      slugs.push(slugMatch[1]);
+    }
+    return slugs;
+  }
+  return [];
 }
 
 function parsePrerenderRoutes(src) {


### PR DESCRIPTION
## Summary
- add `scripts/check_web_route_integrity.sh` to compare static app routes, prerender routes, and sitemap entries
- fail CI when app routes are missing from prerender list or prerender routes are missing from sitemap
- run this guard in `.github/workflows/ci.yml` before web build

## Validation
- ./scripts/check_web_route_integrity.sh
- npm run build --prefix web

## Scope
- excludes demo video path work in this PR by design

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a CI guard to keep web routes in sync across `App.tsx`, `PRERENDER_ROUTES`, and `sitemap.xml`. It now also detects mapped static routes generated from slug collections.

- **New Features**
  - Added `scripts/check_web_route_integrity.sh` to compare static routes (including slug-mapped routes) in `web/src/App.tsx`, `web/prerender-routes.ts`, and `web/public/sitemap.xml`.
  - CI fails when app routes are missing from `PRERENDER_ROUTES` or prerender routes are missing from the sitemap.
  - Runs during CI before the web build.

<sup>Written for commit acb787b37ec8febb0b22f6dc387bfbed08740b4d. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/530?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

