### PR TITLE
docs: add web route sync checklist for launches

### DIFF
--- a/docs/documentation-quality-checks.md
+++ b/docs/documentation-quality-checks.md
@@ -8,6 +8,7 @@ Use this checklist before merging documentation changes.
 2. New docs are indexed in `docs/README.md`.
 3. API behavior statements match current handlers/contracts.
 4. Env var references match `internal/config/config.go` and `internal/config/security.go`.
+5. Web routes stay synchronized across router, prerender list, and sitemap.
 
 ## Link Integrity Check (local)
 
@@ -43,3 +44,23 @@ if errors:
 print('OK: no broken local markdown links')
 PY
 ```
+
+## Web Route Integrity Check
+
+Before merge, verify manually (or via CI guard when enabled) that:
+
+1. Static routes in `web/src/App.tsx` are included in `web/prerender-routes.ts`.
+2. Prerender routes are included in `web/public/sitemap.xml`.
+
+## Route Change Rules
+
+When adding a real, live page:
+
+1. Add the route in `web/src/App.tsx`.
+2. Add the route to `PRERENDER_ROUTES` in `web/prerender-routes.ts`.
+3. Add the route URL in `web/public/sitemap.xml`.
+
+When a page is planned but not implemented yet:
+
+1. Do not add speculative route URLs to sitemap/prerender lists.
+2. Keep references as explicit TODO notes in docs/config until the page exists.


### PR DESCRIPTION
## Summary
- add a required documentation check for web route synchronization
- document exact route parity checks between router, prerender list, and sitemap
- add explicit rules for handling planned-but-unimplemented pages as TODOs instead of live URLs

## Validation
- python3 docs link integrity check snippet from `docs/documentation-quality-checks.md`

## Scope
- intentionally does not change demo video path work


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a required Web Route Integrity checklist to keep routes in sync across the router, prerender list, and sitemap. Also clarifies how to handle planned pages with TODOs instead of live URLs.

- **New Features**
  - Documented parity checks: routes in `web/src/App.tsx` must appear in `web/prerender-routes.ts`, and all prerender routes must appear in `web/public/sitemap.xml`.
  - Added route change rules: add live pages to all three; keep planned pages as TODOs and do not add speculative URLs to prerender/sitemap.

<sup>Written for commit d26a0041780d608f4e8398a72fa34628d948b311. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/531?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

