### PR TITLE
docs: explain VITE_IDENTRAIL_API_URL source and deploy behavior

### DIFF
--- a/docs/frontend-topology.md
+++ b/docs/frontend-topology.md
@@ -11,6 +11,23 @@ Identrail uses `web/` as the active tracked frontend on `dev`.
 - Vercel (marketing/demo deploy): set `VITE_IDENTRAIL_API_URL` in Vercel project environment variables (or set GitHub Actions variable `VITE_IDENTRAIL_API_URL` so the deploy workflow upserts it).
 - Production deploys should be triggered from `dev` (example: `make vercel-prod-deploy` / `task vercel-prod-deploy`) to avoid accidentally deploying from a stale local branch.
 
+### `VITE_IDENTRAIL_API_URL` value source
+
+- This value should be the public HTTPS base URL of the Identrail API service (not the website URL).
+- Typical value shape: `https://api.<your-domain>`
+- If the API is served from the same domain via reverse proxy, use that public API base path.
+
+### Where to configure it
+
+1. GitHub repository variable:
+   - `Settings` -> `Secrets and variables` -> `Actions` -> `Variables`
+   - Add `VITE_IDENTRAIL_API_URL`
+2. Vercel project environment variable:
+   - `Project` -> `Settings` -> `Environment Variables`
+   - Add `VITE_IDENTRAIL_API_URL` for Production (and Preview if needed)
+
+If GitHub Actions variable is missing, workflow upsert is skipped. Deploy may still succeed when Vercel already has the env var set manually.
+
 ## `site/` (legacy Next.js marketing surface)
 
 - Stack: Next.js

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -43,3 +43,18 @@ Checks:
 2. `IDENTRAIL_REPO_SCAN_ALLOWLIST` is set and includes the target.
 3. API target is remote (`owner/repo`, `https://...`, or `ssh://...`) and not a local filesystem path.
 4. Request uses write-authorized API key/scope.
+
+## GitHub Action says missing `VITE_IDENTRAIL_API_URL`
+
+Symptoms:
+1. `Vercel Production Deploy` workflow logs show missing `vars.VITE_IDENTRAIL_API_URL`.
+2. Vercel dashboard still shows successful deployments.
+
+Why this happens:
+1. GitHub workflow checks repository variable `vars.VITE_IDENTRAIL_API_URL`.
+2. Vercel can still deploy successfully when the variable already exists directly in Vercel project settings.
+
+Checks:
+1. In GitHub: `Settings` -> `Secrets and variables` -> `Actions` -> `Variables`, confirm `VITE_IDENTRAIL_API_URL` exists.
+2. In Vercel: `Project` -> `Settings` -> `Environment Variables`, confirm `VITE_IDENTRAIL_API_URL` exists for Production.
+3. Ensure the value points to the public API URL (not the web frontend URL).


### PR DESCRIPTION
## Summary
- document the correct source for `VITE_IDENTRAIL_API_URL` (public API base URL)
- add exact GitHub and Vercel UI paths to configure this variable
- clarify why GitHub workflow can report missing variable while Vercel deployments still succeed
- add troubleshooting steps for this mismatch

## Validation
- python3 docs link integrity check snippet from `docs/documentation-quality-checks.md`

## Scope
- intentionally excludes demo video path updates


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies how to set `VITE_IDENTRAIL_API_URL` (the public API base URL) and where it comes from. Adds exact GitHub and Vercel UI paths, explains why GitHub Actions may show it missing while Vercel still deploys, and includes quick troubleshooting.

<sup>Written for commit c2c4dac40ebde4e06a6f2c1641c0f42e56ed9098. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/532?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

