### PR TITLE
security(ci): pin CodeQL workflow actions to immutable SHAs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,23 +25,23 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.35.2
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           languages: ${{ matrix.language }}
 
       - name: Setup Go
         if: matrix.language == 'go'
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Setup Node
         if: matrix.language == 'javascript-typescript'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
           cache: npm
@@ -60,6 +60,6 @@ jobs:
           npm run build --prefix web
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.35.2
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Closes #536

## Summary
- pin all external actions in `.github/workflows/codeql.yml` to immutable commit SHAs
- retain version comments for maintainability

## Validation
- workflow syntax preserved (no key or structural changes)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins all external actions in `.github/workflows/codeql.yml` to immutable commit SHAs to harden the CodeQL workflow and close #536. No logic or key changes; version comments retained for maintainability.

<sup>Written for commit df5b4bc55ff74ccbebed4b6ee046b0ac766f361c. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/584?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

