### PR TITLE
security(ci): add top-level permissions baseline to scorecard workflow

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: read-all
+
 jobs:
   scorecard:
     name: Security Scorecard


### PR DESCRIPTION
Closes #537

## Summary
- add `permissions: read-all` at workflow top-level
- keep job-level overrides for required `security-events: write` and `id-token: write`

## Why
This preserves least-privilege defaults for any future jobs while retaining current required write scopes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add top-level `permissions: read-all` to the OSSF Scorecard workflow to enforce a read-only default for future jobs. Keep required job-level overrides for `security-events: write` and `id-token: write` to retain current behavior; aligns with #537.

<sup>Written for commit e32fb85f015a62312284fbb99481d6da13480282. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/586?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

