### PR TITLE
security(build): pin backend Docker bases to immutable digests

### DIFF
--- a/deploy/docker/Dockerfile.backend
+++ b/deploy/docker/Dockerfile.backend
@@ -1,4 +1,4 @@
-FROM golang:1.25.9-alpine AS builder
+FROM golang:1.25.9-alpine@sha256:5caaf1cca9dc351e13deafbc3879fd4754801acba8653fa9540cea125d01a71f AS builder
 WORKDIR /src
 
 RUN apk add --no-cache ca-certificates tzdata git
@@ -12,7 +12,7 @@ ARG TARGET=server
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 \
     go build -trimpath -ldflags="-s -w" -o /out/identrail ./cmd/${TARGET}
 
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1
 WORKDIR /app
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/


### PR DESCRIPTION
Closes #538

## Summary
- pin builder base image digest for `golang:1.25.9-alpine`
- pin runtime base image digest for `gcr.io/distroless/static-debian12:nonroot`

## Why
Digest pinning improves reproducibility and reduces mutable-tag supply-chain drift.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins backend Docker base images to immutable digests to prevent tag drift and ensure reproducible builds. Addresses #538 by locking `golang:1.25.9-alpine` for the builder and `gcr.io/distroless/static-debian12:nonroot` for runtime.

<sup>Written for commit 474019d18aae1449520f0756314f36a13ec0b3e2. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/587?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

