### PR TITLE
security(build): pin web Docker bases to immutable digests

### DIFF
--- a/deploy/docker/Dockerfile.web
+++ b/deploy/docker/Dockerfile.web
@@ -1,4 +1,4 @@
-FROM node:24-bookworm-slim AS builder
+FROM node:24-bookworm-slim@sha256:03eae3ef7e88a9de535496fb488d67e02b9d96a063a8967bae657744ecd513f2 AS builder
 WORKDIR /web
 
 COPY web/package*.json ./
@@ -11,7 +11,7 @@ ENV VITE_IDENTRAIL_API_URL=${VITE_IDENTRAIL_API_URL}
 
 RUN npm run build
 
-FROM nginxinc/nginx-unprivileged:1.27-alpine
+FROM nginxinc/nginx-unprivileged:1.27-alpine@sha256:65e3e85dbaed8ba248841d9d58a899b6197106c23cb0ff1a132b7bfe0547e4c0
 COPY deploy/docker/nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /web/dist /usr/share/nginx/html
 


### PR DESCRIPTION
Closes #539

## Summary
- pin builder base image digest for `node:24-bookworm-slim`
- pin runtime base image digest for `nginxinc/nginx-unprivileged:1.27-alpine`

## Why
Digest pinning improves build determinism and reduces mutable-tag supply-chain risk.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin web Docker base images to immutable digests. This locks build inputs for reproducible builds and reduces supply‑chain risk, addressing #539.

- **Dependencies**
  - Builder: `node:24-bookworm-slim@sha256:03eae3ef7e88a9de535496fb488d67e02b9d96a063a8967bae657744ecd513f2`
  - Runtime: `nginxinc/nginx-unprivileged:1.27-alpine@sha256:65e3e85dbaed8ba248841d9d58a899b6197106c23cb0ff1a132b7bfe0547e4c0`

<sup>Written for commit 3eff659f594ea9f95036188637c2107cfe8f8e82. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/588?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

