### PR TITLE
chore(web): remove stale TODO placeholders from site source

### DIFF
--- a/web/src/components/AdvantagesSplitSection.tsx
+++ b/web/src/components/AdvantagesSplitSection.tsx
@@ -19,7 +19,6 @@ export function AdvantagesSplitSection() {
       <div className="section-card advantages-shell">
         <blockquote className="advantages-quote">
           <span aria-hidden="true">“</span>
-          {/* TODO: Oluwatobi will update real customer photo later. */}
           <div className="advantages-quote-avatar" aria-hidden="true" />
           <p>
             Identrail gave us board-level confidence in machine identity risk because every finding

--- a/web/src/components/EntroIntegrationSection.tsx
+++ b/web/src/components/EntroIntegrationSection.tsx
@@ -1,7 +1,6 @@
 import { siteLinks } from '../siteConfig';
 import { SafeLink } from './SafeLink';
 
-// TODO: Oluwatobi will update real integration logos later.
 const integrations = [
   'AWS',
   'Kubernetes',
@@ -15,7 +14,6 @@ const integrations = [
   'Datadog'
 ] as const;
 
-// TODO: Oluwatobi will update real award badges later.
 const awards = [
   'Cloud Security Innovation 2026',
   'Top Open Source Identity Project',

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -1,7 +1,6 @@
 import { siteLinks } from '../siteConfig';
 import { SafeLink } from './SafeLink';
 
-// TODO: Oluwatobi will update real URL paths later.
 const footerColumns = [
   {
     title: 'Platform',

--- a/web/src/components/ImpactProductionSection.tsx
+++ b/web/src/components/ImpactProductionSection.tsx
@@ -28,7 +28,6 @@ const impactResults = [
   }
 ] as const;
 
-// TODO: Oluwatobi will update real customer logos later.
 const trustedBy = [
   'Northbank Group',
   'Apex Retail',

--- a/web/src/components/ProofSection.tsx
+++ b/web/src/components/ProofSection.tsx
@@ -1,7 +1,6 @@
 import { siteLinks } from '../siteConfig';
 import { SafeLink } from './SafeLink';
 
-// TODO: Oluwatobi will update real customer names and media later.
 const logos = ['Global Bank', 'InfraCo', 'Cloud Retail', 'FinServe', 'HealthOps', 'ScaleWare'] as const;
 
 export function ProofSection() {

--- a/web/src/components/TestimonialCarouselSection.tsx
+++ b/web/src/components/TestimonialCarouselSection.tsx
@@ -37,7 +37,6 @@ export function TestimonialCarouselSection() {
 
         <div className="testimonial-carousel" aria-label="Customer testimonial carousel">
           <div className="testimonial-track">
-            {/* TODO: Oluwatobi will update real customer photos later. */}
             {rail.map((item, index) => (
               <article key={`${item.author}-${index}`} className="testimonial-card">
                 <div className="testimonial-avatar" aria-hidden="true" />

--- a/web/src/siteConfig.ts
+++ b/web/src/siteConfig.ts
@@ -1,4 +1,3 @@
-// TODO: Oluwatobi will update real URL later.
 export const siteLinks = {
   platform: '/product',
   useCases: '/solutions',
@@ -49,7 +48,6 @@ export const githubRepo = {
   name: 'identrail'
 } as const;
 
-// TODO: Oluwatobi will update real Docker Hub repos later if namespace changes.
 export const projectMetricsSource = {
   github: githubRepo,
   dockerHubRepos: ['identrail/api', 'identrail/worker', 'identrail/web']

--- a/web/src/siteContent.ts
+++ b/web/src/siteContent.ts
@@ -91,7 +91,6 @@ export const impactCards: TextCard[] = [
   }
 ];
 
-// TODO: Oluwatobi will update real URL paths later.
 export const useCases: UseCaseCard[] = [
   { id: '01', title: 'Machine Identity Posture Management', body: 'Reveal overprivileged service identities, stale credentials, and risky trust relationships before they are exploited.', href: '/solutions/security-teams' },
   { id: '02', title: 'Cloud Trust Path Analysis', body: 'See exactly who can assume what across AWS accounts and Kubernetes clusters with end-to-end trust path mapping.', href: '/features/trust-graph' },


### PR DESCRIPTION
Closes #540

## Summary
- remove stale `TODO` placeholder comments from production-facing `web/src` files
- no behavioral changes

## Validation
- `npm test -- --run` in `web`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove stale TODO placeholder comments from production-facing `web/src` components and config to keep the site source clean and production-ready. No behavior changes; addresses #540.

<sup>Written for commit 1516d316dd2f491b132a77ced0d709558d92bcbe. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/589?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

