### PR TITLE
ITR-001: app-mode runtime config + feature flag skeleton

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -57,6 +57,22 @@ Cross-provider:
 - `IDENTRAIL_LOCK_BACKEND` (`auto|inmemory|postgres`)
 - `IDENTRAIL_LOCK_NAMESPACE`
 
+## App-Mode Feature Flags
+
+All app-mode feature flags are disabled by default and must be explicitly enabled.
+
+- `IDENTRAIL_APP_MODE_ENABLED` (default: `false`)
+- `IDENTRAIL_APP_MODE_CONNECTORS_ENABLED` (default: `false`)
+- `IDENTRAIL_APP_MODE_SCHEDULER_ENABLED` (default: `false`)
+- `IDENTRAIL_APP_MODE_REMEDIATION_ENABLED` (default: `false`)
+- `IDENTRAIL_APP_MODE_PREMIUM_ENABLED` (default: `false`)
+- `IDENTRAIL_APP_MODE_PREMIUM_REPORTS_ENABLED` (default: `false`)
+- `IDENTRAIL_APP_MODE_PREMIUM_AUTOFIX_ENABLED` (default: `false`)
+- `IDENTRAIL_APP_MODE_ROLLOUT_ENABLED` (default: `false`)
+- `IDENTRAIL_APP_MODE_ROLLOUT_CANARY_PERCENT` (`0..100`, default: `0`)
+- `IDENTRAIL_APP_MODE_ROLLOUT_TENANT_ALLOWLIST` (CSV tenant ids)
+- `IDENTRAIL_APP_MODE_ROLLOUT_WORKSPACE_ALLOWLIST` (CSV workspace ids)
+
 ## Repository Exposure
 
 - `IDENTRAIL_REPO_SCAN_ENABLED`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,15 @@ const (
 	defaultOIDCWorkspaceClaim          = "workspace_id"
 	defaultOIDCGroupsClaim             = "groups"
 	defaultOIDCRolesClaim              = "roles"
+	defaultAppModeEnabled              = false
+	defaultAppModeConnectorsEnabled    = false
+	defaultAppModeSchedulerEnabled     = false
+	defaultAppModeRemediationEnabled   = false
+	defaultAppModePremiumEnabled       = false
+	defaultAppModePremiumReports       = false
+	defaultAppModePremiumAutofix       = false
+	defaultAppModeRolloutEnabled       = false
+	defaultAppModeRolloutCanaryPercent = 0
 )
 
 // Config centralizes process-level configuration. It keeps module wiring simple
@@ -117,6 +126,17 @@ type Config struct {
 	OIDCWorkspaceClaim         string
 	OIDCGroupsClaim            string
 	OIDCRolesClaim             string
+	AppModeEnabled             bool
+	AppModeConnectorsEnabled   bool
+	AppModeSchedulerEnabled    bool
+	AppModeRemediationEnabled  bool
+	AppModePremiumEnabled      bool
+	AppModePremiumReports      bool
+	AppModePremiumAutofix      bool
+	AppModeRolloutEnabled      bool
+	AppModeRolloutCanary       int
+	AppModeTenantAllowlist     []string
+	AppModeWorkspaceAllowlist  []string
 }
 
 // Load reads environment variables and applies safe defaults for local and CI use.
@@ -195,6 +215,17 @@ func Load() Config {
 		OIDCWorkspaceClaim:         getEnv("IDENTRAIL_OIDC_WORKSPACE_CLAIM", defaultOIDCWorkspaceClaim),
 		OIDCGroupsClaim:            getEnv("IDENTRAIL_OIDC_GROUPS_CLAIM", defaultOIDCGroupsClaim),
 		OIDCRolesClaim:             getEnv("IDENTRAIL_OIDC_ROLES_CLAIM", defaultOIDCRolesClaim),
+		AppModeEnabled:             parseBool(getEnv("IDENTRAIL_APP_MODE_ENABLED", "false"), defaultAppModeEnabled),
+		AppModeConnectorsEnabled:   parseBool(getEnv("IDENTRAIL_APP_MODE_CONNECTORS_ENABLED", "false"), defaultAppModeConnectorsEnabled),
+		AppModeSchedulerEnabled:    parseBool(getEnv("IDENTRAIL_APP_MODE_SCHEDULER_ENABLED", "false"), defaultAppModeSchedulerEnabled),
+		AppModeRemediationEnabled:  parseBool(getEnv("IDENTRAIL_APP_MODE_REMEDIATION_ENABLED", "false"), defaultAppModeRemediationEnabled),
+		AppModePremiumEnabled:      parseBool(getEnv("IDENTRAIL_APP_MODE_PREMIUM_ENABLED", "false"), defaultAppModePremiumEnabled),
+		AppModePremiumReports:      parseBool(getEnv("IDENTRAIL_APP_MODE_PREMIUM_REPORTS_ENABLED", "false"), defaultAppModePremiumReports),
+		AppModePremiumAutofix:      parseBool(getEnv("IDENTRAIL_APP_MODE_PREMIUM_AUTOFIX_ENABLED", "false"), defaultAppModePremiumAutofix),
+		AppModeRolloutEnabled:      parseBool(getEnv("IDENTRAIL_APP_MODE_ROLLOUT_ENABLED", "false"), defaultAppModeRolloutEnabled),
+		AppModeRolloutCanary:       parseIntAllowZero(getEnv("IDENTRAIL_APP_MODE_ROLLOUT_CANARY_PERCENT", "0"), defaultAppModeRolloutCanaryPercent),
+		AppModeTenantAllowlist:     parseCommaSeparated(getEnv("IDENTRAIL_APP_MODE_ROLLOUT_TENANT_ALLOWLIST", "")),
+		AppModeWorkspaceAllowlist:  parseCommaSeparated(getEnv("IDENTRAIL_APP_MODE_ROLLOUT_WORKSPACE_ALLOWLIST", "")),
 	}
 }
 
@@ -247,6 +278,14 @@ func parseBoolWithValidity(value string, fallback bool) (bool, bool) {
 func parseInt(value string, fallback int) int {
 	parsed, err := strconv.Atoi(strings.TrimSpace(value))
 	if err != nil || parsed <= 0 {
+		return fallback
+	}
+	return parsed
+}
+
+func parseIntAllowZero(value string, fallback int) int {
+	parsed, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || parsed < 0 {
 		return fallback
 	}
 	return parsed

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -627,6 +627,89 @@ func TestParseInt(t *testing.T) {
 	}
 }
 
+func TestParseIntAllowZero(t *testing.T) {
+	if got := parseIntAllowZero("25", 1); got != 25 {
+		t.Fatalf("expected 25, got %d", got)
+	}
+	if got := parseIntAllowZero("0", 7); got != 0 {
+		t.Fatalf("expected 0, got %d", got)
+	}
+	if got := parseIntAllowZero("-1", 7); got != 7 {
+		t.Fatalf("expected fallback 7, got %d", got)
+	}
+	if got := parseIntAllowZero("bad", 9); got != 9 {
+		t.Fatalf("expected fallback 9, got %d", got)
+	}
+}
+
+func TestLoadAppModeDefaults(t *testing.T) {
+	t.Setenv("IDENTRAIL_APP_MODE_ENABLED", "")
+	t.Setenv("IDENTRAIL_APP_MODE_CONNECTORS_ENABLED", "")
+	t.Setenv("IDENTRAIL_APP_MODE_SCHEDULER_ENABLED", "")
+	t.Setenv("IDENTRAIL_APP_MODE_REMEDIATION_ENABLED", "")
+	t.Setenv("IDENTRAIL_APP_MODE_PREMIUM_ENABLED", "")
+	t.Setenv("IDENTRAIL_APP_MODE_PREMIUM_REPORTS_ENABLED", "")
+	t.Setenv("IDENTRAIL_APP_MODE_PREMIUM_AUTOFIX_ENABLED", "")
+	t.Setenv("IDENTRAIL_APP_MODE_ROLLOUT_ENABLED", "")
+	t.Setenv("IDENTRAIL_APP_MODE_ROLLOUT_CANARY_PERCENT", "")
+	t.Setenv("IDENTRAIL_APP_MODE_ROLLOUT_TENANT_ALLOWLIST", "")
+	t.Setenv("IDENTRAIL_APP_MODE_ROLLOUT_WORKSPACE_ALLOWLIST", "")
+
+	cfg := Load()
+	if cfg.AppModeEnabled {
+		t.Fatal("expected app mode disabled by default")
+	}
+	if cfg.AppModeConnectorsEnabled || cfg.AppModeSchedulerEnabled || cfg.AppModeRemediationEnabled {
+		t.Fatal("expected app mode feature flags disabled by default")
+	}
+	if cfg.AppModePremiumEnabled || cfg.AppModePremiumReports || cfg.AppModePremiumAutofix {
+		t.Fatal("expected premium feature flags disabled by default")
+	}
+	if cfg.AppModeRolloutEnabled {
+		t.Fatal("expected rollout disabled by default")
+	}
+	if cfg.AppModeRolloutCanary != 0 {
+		t.Fatalf("expected rollout canary default 0, got %d", cfg.AppModeRolloutCanary)
+	}
+	if len(cfg.AppModeTenantAllowlist) != 0 || len(cfg.AppModeWorkspaceAllowlist) != 0 {
+		t.Fatal("expected empty rollout allowlists by default")
+	}
+}
+
+func TestLoadAppModeFromEnv(t *testing.T) {
+	t.Setenv("IDENTRAIL_APP_MODE_ENABLED", "true")
+	t.Setenv("IDENTRAIL_APP_MODE_CONNECTORS_ENABLED", "true")
+	t.Setenv("IDENTRAIL_APP_MODE_SCHEDULER_ENABLED", "true")
+	t.Setenv("IDENTRAIL_APP_MODE_REMEDIATION_ENABLED", "true")
+	t.Setenv("IDENTRAIL_APP_MODE_PREMIUM_ENABLED", "true")
+	t.Setenv("IDENTRAIL_APP_MODE_PREMIUM_REPORTS_ENABLED", "true")
+	t.Setenv("IDENTRAIL_APP_MODE_PREMIUM_AUTOFIX_ENABLED", "true")
+	t.Setenv("IDENTRAIL_APP_MODE_ROLLOUT_ENABLED", "true")
+	t.Setenv("IDENTRAIL_APP_MODE_ROLLOUT_CANARY_PERCENT", "15")
+	t.Setenv("IDENTRAIL_APP_MODE_ROLLOUT_TENANT_ALLOWLIST", "tenant-a,tenant-b")
+	t.Setenv("IDENTRAIL_APP_MODE_ROLLOUT_WORKSPACE_ALLOWLIST", "workspace-a,workspace-b")
+
+	cfg := Load()
+	if !cfg.AppModeEnabled || !cfg.AppModeConnectorsEnabled || !cfg.AppModeSchedulerEnabled || !cfg.AppModeRemediationEnabled {
+		t.Fatal("expected app mode feature flags enabled from env")
+	}
+	if !cfg.AppModePremiumEnabled || !cfg.AppModePremiumReports || !cfg.AppModePremiumAutofix {
+		t.Fatal("expected premium feature flags enabled from env")
+	}
+	if !cfg.AppModeRolloutEnabled {
+		t.Fatal("expected rollout enabled from env")
+	}
+	if cfg.AppModeRolloutCanary != 15 {
+		t.Fatalf("expected rollout canary 15, got %d", cfg.AppModeRolloutCanary)
+	}
+	if len(cfg.AppModeTenantAllowlist) != 2 || cfg.AppModeTenantAllowlist[0] != "tenant-a" || cfg.AppModeTenantAllowlist[1] != "tenant-b" {
+		t.Fatalf("unexpected app mode tenant allowlist: %+v", cfg.AppModeTenantAllowlist)
+	}
+	if len(cfg.AppModeWorkspaceAllowlist) != 2 || cfg.AppModeWorkspaceAllowlist[0] != "workspace-a" || cfg.AppModeWorkspaceAllowlist[1] != "workspace-b" {
+		t.Fatalf("unexpected app mode workspace allowlist: %+v", cfg.AppModeWorkspaceAllowlist)
+	}
+}
+
 func TestParseKeyScopes(t *testing.T) {
 	scopes := parseKeyScopes("key1:read;key2:read,write;invalid;:missing")
 	if len(scopes) != 2 {

--- a/internal/config/security.go
+++ b/internal/config/security.go
@@ -23,6 +23,7 @@ const (
 	minAPIKeyLength             = 24
 	maxScopeIdentifierLength    = 64
 	maxOIDCClaimNameLength      = 128
+	maxAppModeCanaryPercent     = 100
 )
 
 var allowedKeyScopes = map[string]struct{}{
@@ -95,6 +96,51 @@ func ValidateSecurity(cfg Config) error {
 	}
 	if err := validateScopeIdentifier("IDENTRAIL_DEFAULT_WORKSPACE_ID", defaultWorkspace); err != nil {
 		return err
+	}
+	if cfg.AppModeConnectorsEnabled && !cfg.AppModeEnabled {
+		return fmt.Errorf("IDENTRAIL_APP_MODE_CONNECTORS_ENABLED requires IDENTRAIL_APP_MODE_ENABLED=true")
+	}
+	if cfg.AppModeSchedulerEnabled && !cfg.AppModeEnabled {
+		return fmt.Errorf("IDENTRAIL_APP_MODE_SCHEDULER_ENABLED requires IDENTRAIL_APP_MODE_ENABLED=true")
+	}
+	if cfg.AppModeRemediationEnabled && !cfg.AppModeEnabled {
+		return fmt.Errorf("IDENTRAIL_APP_MODE_REMEDIATION_ENABLED requires IDENTRAIL_APP_MODE_ENABLED=true")
+	}
+	if cfg.AppModePremiumEnabled && !cfg.AppModeEnabled {
+		return fmt.Errorf("IDENTRAIL_APP_MODE_PREMIUM_ENABLED requires IDENTRAIL_APP_MODE_ENABLED=true")
+	}
+	if cfg.AppModePremiumReports && !cfg.AppModePremiumEnabled {
+		return fmt.Errorf("IDENTRAIL_APP_MODE_PREMIUM_REPORTS_ENABLED requires IDENTRAIL_APP_MODE_PREMIUM_ENABLED=true")
+	}
+	if cfg.AppModePremiumAutofix && !cfg.AppModePremiumEnabled {
+		return fmt.Errorf("IDENTRAIL_APP_MODE_PREMIUM_AUTOFIX_ENABLED requires IDENTRAIL_APP_MODE_PREMIUM_ENABLED=true")
+	}
+	if cfg.AppModeRolloutEnabled && !cfg.AppModeEnabled {
+		return fmt.Errorf("IDENTRAIL_APP_MODE_ROLLOUT_ENABLED requires IDENTRAIL_APP_MODE_ENABLED=true")
+	}
+	if !cfg.AppModeRolloutEnabled {
+		if cfg.AppModeRolloutCanary > 0 {
+			return fmt.Errorf("IDENTRAIL_APP_MODE_ROLLOUT_CANARY_PERCENT requires IDENTRAIL_APP_MODE_ROLLOUT_ENABLED=true")
+		}
+		if len(cfg.AppModeTenantAllowlist) > 0 {
+			return fmt.Errorf("IDENTRAIL_APP_MODE_ROLLOUT_TENANT_ALLOWLIST requires IDENTRAIL_APP_MODE_ROLLOUT_ENABLED=true")
+		}
+		if len(cfg.AppModeWorkspaceAllowlist) > 0 {
+			return fmt.Errorf("IDENTRAIL_APP_MODE_ROLLOUT_WORKSPACE_ALLOWLIST requires IDENTRAIL_APP_MODE_ROLLOUT_ENABLED=true")
+		}
+	}
+	if cfg.AppModeRolloutCanary < 0 || cfg.AppModeRolloutCanary > maxAppModeCanaryPercent {
+		return fmt.Errorf("IDENTRAIL_APP_MODE_ROLLOUT_CANARY_PERCENT must be between 0 and %d", maxAppModeCanaryPercent)
+	}
+	for _, tenantID := range cfg.AppModeTenantAllowlist {
+		if err := validateScopeIdentifier("IDENTRAIL_APP_MODE_ROLLOUT_TENANT_ALLOWLIST", tenantID); err != nil {
+			return err
+		}
+	}
+	for _, workspaceID := range cfg.AppModeWorkspaceAllowlist {
+		if err := validateScopeIdentifier("IDENTRAIL_APP_MODE_ROLLOUT_WORKSPACE_ALLOWLIST", workspaceID); err != nil {
+			return err
+		}
 	}
 
 	oidcIssuer := strings.TrimSpace(cfg.OIDCIssuerURL)
@@ -440,6 +486,24 @@ func SecurityWarnings(cfg Config) []string {
 		warnings = append(warnings, "IDENTRAIL_LOCK_BACKEND is inmemory in database mode; use postgres lock backend for multi-instance deployments")
 	}
 	return warnings
+}
+
+// StartupDiagnostics returns startup-safe key runtime mode summaries.
+func StartupDiagnostics(cfg Config) []string {
+	diagnostics := []string{
+		fmt.Sprintf("app_mode.enabled=%t", cfg.AppModeEnabled),
+		fmt.Sprintf("app_mode.connectors.enabled=%t", cfg.AppModeConnectorsEnabled),
+		fmt.Sprintf("app_mode.scheduler.enabled=%t", cfg.AppModeSchedulerEnabled),
+		fmt.Sprintf("app_mode.remediation.enabled=%t", cfg.AppModeRemediationEnabled),
+		fmt.Sprintf("app_mode.premium.enabled=%t", cfg.AppModePremiumEnabled),
+		fmt.Sprintf("app_mode.premium.reports.enabled=%t", cfg.AppModePremiumReports),
+		fmt.Sprintf("app_mode.premium.autofix.enabled=%t", cfg.AppModePremiumAutofix),
+		fmt.Sprintf("app_mode.rollout.enabled=%t", cfg.AppModeRolloutEnabled),
+		fmt.Sprintf("app_mode.rollout.canary_percent=%d", cfg.AppModeRolloutCanary),
+		fmt.Sprintf("app_mode.rollout.tenant_allowlist_count=%d", len(cfg.AppModeTenantAllowlist)),
+		fmt.Sprintf("app_mode.rollout.workspace_allowlist_count=%d", len(cfg.AppModeWorkspaceAllowlist)),
+	}
+	return diagnostics
 }
 
 func hasShortAPIKey(keys []string, scoped map[string][]string) bool {

--- a/internal/config/security_test.go
+++ b/internal/config/security_test.go
@@ -582,3 +582,88 @@ func TestSecurityWarningsShortAPIKey(t *testing.T) {
 		t.Fatalf("expected short API key warning, got %+v", warnings)
 	}
 }
+
+func TestValidateSecurityAppModeRolloutRequiresToggle(t *testing.T) {
+	cfg := Config{
+		APIKeys:              []string{"reader"},
+		AppModeRolloutCanary: 10,
+	}
+	if err := ValidateSecurity(cfg); err == nil {
+		t.Fatal("expected app mode rollout toggle dependency error")
+	}
+}
+
+func TestValidateSecurityAppModePremiumReportsRequiresPremiumFlag(t *testing.T) {
+	cfg := Config{
+		APIKeys:               []string{"reader"},
+		AppModeEnabled:        true,
+		AppModePremiumReports: true,
+	}
+	if err := ValidateSecurity(cfg); err == nil {
+		t.Fatal("expected premium reports dependency error")
+	}
+}
+
+func TestValidateSecurityRejectsOutOfRangeAppModeCanary(t *testing.T) {
+	cfg := Config{
+		APIKeys:               []string{"reader"},
+		AppModeEnabled:        true,
+		AppModeRolloutEnabled: true,
+		AppModeRolloutCanary:  101,
+	}
+	if err := ValidateSecurity(cfg); err == nil {
+		t.Fatal("expected app mode canary range validation error")
+	}
+}
+
+func TestValidateSecurityAcceptsAppModeConfig(t *testing.T) {
+	cfg := Config{
+		APIKeyScopes:              map[string][]string{"reader-key-12345678901234567890": {"read"}},
+		AppModeEnabled:            true,
+		AppModeConnectorsEnabled:  true,
+		AppModeSchedulerEnabled:   true,
+		AppModeRemediationEnabled: true,
+		AppModePremiumEnabled:     true,
+		AppModePremiumReports:     true,
+		AppModePremiumAutofix:     true,
+		AppModeRolloutEnabled:     true,
+		AppModeRolloutCanary:      20,
+		AppModeTenantAllowlist:    []string{"tenant-a"},
+		AppModeWorkspaceAllowlist: []string{"workspace-a"},
+	}
+	if err := ValidateSecurity(cfg); err != nil {
+		t.Fatalf("expected app mode config to be valid, got %v", err)
+	}
+}
+
+func TestStartupDiagnosticsIncludesAppModeSummary(t *testing.T) {
+	cfg := Config{
+		AppModeEnabled:            true,
+		AppModeConnectorsEnabled:  true,
+		AppModeRolloutEnabled:     true,
+		AppModeRolloutCanary:      5,
+		AppModeTenantAllowlist:    []string{"tenant-a", "tenant-b"},
+		AppModeWorkspaceAllowlist: []string{"workspace-a"},
+	}
+	diagnostics := StartupDiagnostics(cfg)
+	required := []string{
+		"app_mode.enabled=true",
+		"app_mode.connectors.enabled=true",
+		"app_mode.rollout.enabled=true",
+		"app_mode.rollout.canary_percent=5",
+		"app_mode.rollout.tenant_allowlist_count=2",
+		"app_mode.rollout.workspace_allowlist_count=1",
+	}
+	for _, item := range required {
+		found := false
+		for _, diagnostic := range diagnostics {
+			if diagnostic == item {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected diagnostic %q, got %+v", item, diagnostics)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -38,6 +38,9 @@ func NewBootstrap(ctx context.Context, cfg config.Config) (Bootstrap, error) {
 	for _, warning := range config.SecurityWarnings(cfg) {
 		logger.Warn("security configuration warning", telemetry.String("detail", warning))
 	}
+	for _, diagnostic := range config.StartupDiagnostics(cfg) {
+		logger.Info("startup configuration diagnostic", telemetry.String("detail", diagnostic))
+	}
 
 	metrics := telemetry.NewMetrics()
 	traceShutdown, err := telemetry.SetupTracing(ctx, cfg.ServiceName)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -35,6 +35,9 @@ func Run(ctx context.Context, cfg config.Config, signals <-chan os.Signal) error
 	for _, warning := range config.SecurityWarnings(cfg) {
 		logger.Warn("security configuration warning", telemetry.String("detail", warning))
 	}
+	for _, diagnostic := range config.StartupDiagnostics(cfg) {
+		logger.Info("startup configuration diagnostic", telemetry.String("detail", diagnostic))
+	}
 
 	traceShutdown, err := telemetry.SetupTracing(ctx, cfg.ServiceName+"-worker")
 	if err != nil {


### PR DESCRIPTION
Fixes #541


## Summary
Implements **ITR-001** by introducing a validated app-mode runtime configuration surface with feature flags, rollout controls, startup diagnostics, and docs/tests.

## Why This Fix
Before this change, app-mode behavior controls were not formalized in one validated config contract. That increases rollout and misconfiguration risk. This PR creates a fail-fast baseline for future app-mode work without introducing behavior changes to scan logic or UI flow.

## What Changed
- Added new config/env surface in `internal/config/config.go`:
  - `IDENTRAIL_APP_MODE_ENABLED`
  - `IDENTRAIL_APP_MODE_CONNECTORS_ENABLED`
  - `IDENTRAIL_APP_MODE_SCHEDULER_ENABLED`
  - `IDENTRAIL_APP_MODE_REMEDIATION_ENABLED`
  - `IDENTRAIL_APP_MODE_PREMIUM_ENABLED`
  - `IDENTRAIL_APP_MODE_PREMIUM_REPORTS_ENABLED`
  - `IDENTRAIL_APP_MODE_PREMIUM_AUTOFIX_ENABLED`
  - `IDENTRAIL_APP_MODE_ROLLOUT_ENABLED`
  - `IDENTRAIL_APP_MODE_ROLLOUT_CANARY_PERCENT`
  - `IDENTRAIL_APP_MODE_ROLLOUT_TENANT_ALLOWLIST`
  - `IDENTRAIL_APP_MODE_ROLLOUT_WORKSPACE_ALLOWLIST`
- Added strict validation in `internal/config/security.go`:
  - dependency validation between parent/child flags
  - rollout guardrails (toggle requirements + canary range)
  - allowlist identifier validation
- Added startup diagnostics output (`config.StartupDiagnostics`) and emitted diagnostics in:
  - `internal/server/server.go`
  - `internal/worker/worker.go`
- Updated configuration docs in `docs/configuration-reference.md`.
- Added test coverage for defaults, env parsing, validation failures/success, and diagnostics output.

## Premium-Oriented Improvement (In Scope)
Added explicit premium gating sub-flags (`PREMIUM_REPORTS`, `PREMIUM_AUTOFIX`) behind `APP_MODE_PREMIUM_ENABLED` to enable controlled enterprise feature rollouts without exposing premium behavior by default.

## Self Review
- Verified all new flags default to disabled (`false` / `0`) to keep rollout safe.
- Verified invalid dependency combinations fail fast at startup.
- Verified diagnostics contain state only (no secrets).
- Confirmed no scan engine or UI behavior was changed (out-of-scope respected).

## Validation
- `go test ./...`



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a validated app‑mode runtime config with feature flags, rollout controls, and startup diagnostics to provide a safe baseline for future app‑mode work. Implements ITR‑001 with no scan or UI behavior changes; all flags default to off.

- **New Features**
  - App‑mode env flags under `IDENTRAIL_APP_MODE_*` for core features, premium gates (`PREMIUM_*`), and rollouts (`ROLLOUT_*`).
  - Strict validation for parent/child flags, canary percent (`0–100` via `IDENTRAIL_APP_MODE_ROLLOUT_CANARY_PERCENT`), and tenant/workspace allowlists; fail‑fast on invalid combos.
  - Startup diagnostics log non‑sensitive app‑mode state in server and worker.
  - Docs updated and tests added for defaults, parsing, validation, and diagnostics.

- **Migration**
  - No action required; defaults keep app‑mode disabled.
  - To opt in: set `IDENTRAIL_APP_MODE_ENABLED=true` and enable specific features.
  - For staged rollout: set `IDENTRAIL_APP_MODE_ROLLOUT_ENABLED=true` and configure `IDENTRAIL_APP_MODE_ROLLOUT_CANARY_PERCENT` or allowlists.

<sup>Written for commit b16be272443dc2a29f54b2a6444e4b1c51b4ccd0. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/590?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


