### PR TITLE
ITR-002: define app-mode domain models and validation contracts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - Repository exposure scanner: `repo-exposure.md`
 - Execution model (API enqueue + worker processing): `execution-model.md`
 - Configuration reference: `configuration-reference.md`
+- Domain entity model: `domain-entities.md`
 
 ## Release and supply chain track
 

--- a/docs/domain-entities.md
+++ b/docs/domain-entities.md
@@ -1,0 +1,63 @@
+# Domain Entity Model (App Mode)
+
+This document defines the normalized multi-tenant app-mode entities introduced for tenancy, project, connector, policy, and remediation workflows.
+
+## Tenancy Core
+
+- `Organization`
+  - Fields: `id`, `name`, `slug`, `created_at`, `updated_at`
+  - Validation: non-empty id/name/slug with identifier-safe formatting.
+- `Workspace`
+  - Fields: `id`, `organization_id`, `name`, `slug`, `created_at`, `updated_at`
+  - Validation: required org reference and identifier-safe ids/slugs.
+- `WorkspaceMember`
+  - Fields: `id`, `workspace_id`, `user_id`, `email`, `role`, `status`, `joined_at`, `updated_at`
+  - Role enum: `owner|admin|analyst|viewer`
+  - Status enum: `invited|active|suspended|removed`
+
+## Project and Connector
+
+- `Project`
+  - Fields: `id`, `workspace_id`, `name`, `slug`, `description`, `archived_at`, `created_at`, `updated_at`
+  - Validation: required workspace and project identity fields.
+- `Connector`
+  - Fields: `id`, `workspace_id`, `project_id`, `type`, `display_name`, `status`, `last_sync_at`, `created_at`, `updated_at`
+  - Type enum: `github|aws|kubernetes`
+  - Status enum: `pending|active|degraded|disconnected`
+  - Transition contract:
+    - `pending -> active|degraded|disconnected`
+    - `active -> degraded|disconnected`
+    - `degraded -> active|disconnected`
+    - `disconnected -> pending|active`
+
+## Policy Entities
+
+- `ScanPolicy`
+  - Fields: `id`, `workspace_id`, `project_id`, `name`, `enabled`, `trigger_mode`, `cron`, `max_concurrent_scans`, `created_at`, `updated_at`
+  - Trigger mode enum: `manual|scheduled|event|hybrid`
+  - Validation: required ids/name, valid mode, `max_concurrent_scans > 0`.
+- `SuppressionPolicy`
+  - Fields: `id`, `workspace_id`, `project_id`, `name`, `scope`, `target`, `reason`, `expires_at`, `created_by`, `created_at`, `last_updated_at`
+  - Scope enum: `finding|rule|resource`
+  - Validation: required ids, scope, target, reason, and creator id.
+
+## Remediation Entity
+
+- `RemediationJob`
+  - Fields: `id`, `workspace_id`, `project_id`, `finding_id`, `type`, `status`, `requested_by`, `requested_at`, `started_at`, `completed_at`, `artifact_ref`, `error_message`, `last_updated_at`
+  - Type enum: `patch_template|create_fix_pr|ticket`
+  - Status enum: `queued|running|succeeded|failed|canceled`
+  - Transition contract:
+    - `queued -> running|canceled`
+    - `running -> succeeded|failed|canceled`
+    - `failed -> queued` (retry)
+    - `succeeded|canceled` are terminal
+
+## Contracts and Validation
+
+- All entities use snake_case JSON tags for API and persistence contract stability.
+- Validation and transition helpers live in:
+  - `internal/domain/appmode.go`
+- Validation and transition tests live in:
+  - `internal/domain/appmode_test.go`
+  - `internal/domain/json_tags_test.go`

--- a/internal/domain/appmode.go
+++ b/internal/domain/appmode.go
@@ -1,0 +1,479 @@
+package domain
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var appModeIdentifierPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,63}$`)
+
+// MemberRole enumerates tenancy-level permissions within a workspace.
+type MemberRole string
+
+const (
+	MemberRoleOwner   MemberRole = "owner"
+	MemberRoleAdmin   MemberRole = "admin"
+	MemberRoleAnalyst MemberRole = "analyst"
+	MemberRoleViewer  MemberRole = "viewer"
+)
+
+// MemberStatus tracks workspace membership lifecycle state.
+type MemberStatus string
+
+const (
+	MemberStatusInvited   MemberStatus = "invited"
+	MemberStatusActive    MemberStatus = "active"
+	MemberStatusSuspended MemberStatus = "suspended"
+	MemberStatusRemoved   MemberStatus = "removed"
+)
+
+// ConnectorType identifies one onboarded source connector.
+type ConnectorType string
+
+const (
+	ConnectorTypeGitHub     ConnectorType = "github"
+	ConnectorTypeAWS        ConnectorType = "aws"
+	ConnectorTypeKubernetes ConnectorType = "kubernetes"
+)
+
+// ConnectorStatus represents connector health and lifecycle state.
+type ConnectorStatus string
+
+const (
+	ConnectorStatusPending      ConnectorStatus = "pending"
+	ConnectorStatusActive       ConnectorStatus = "active"
+	ConnectorStatusDegraded     ConnectorStatus = "degraded"
+	ConnectorStatusDisconnected ConnectorStatus = "disconnected"
+)
+
+// ScanTriggerMode controls scan initiation mode.
+type ScanTriggerMode string
+
+const (
+	ScanTriggerModeManual    ScanTriggerMode = "manual"
+	ScanTriggerModeScheduled ScanTriggerMode = "scheduled"
+	ScanTriggerModeEvent     ScanTriggerMode = "event"
+	ScanTriggerModeHybrid    ScanTriggerMode = "hybrid"
+)
+
+// SuppressionScope controls suppression blast radius.
+type SuppressionScope string
+
+const (
+	SuppressionScopeFinding  SuppressionScope = "finding"
+	SuppressionScopeRule     SuppressionScope = "rule"
+	SuppressionScopeResource SuppressionScope = "resource"
+)
+
+// RemediationJobType identifies one remediation class.
+type RemediationJobType string
+
+const (
+	RemediationJobTypePatchTemplate RemediationJobType = "patch_template"
+	RemediationJobTypeCreateFixPR   RemediationJobType = "create_fix_pr"
+	RemediationJobTypeTicket        RemediationJobType = "ticket"
+)
+
+// RemediationJobStatus tracks remediation execution lifecycle.
+type RemediationJobStatus string
+
+const (
+	RemediationJobStatusQueued    RemediationJobStatus = "queued"
+	RemediationJobStatusRunning   RemediationJobStatus = "running"
+	RemediationJobStatusSucceeded RemediationJobStatus = "succeeded"
+	RemediationJobStatusFailed    RemediationJobStatus = "failed"
+	RemediationJobStatusCanceled  RemediationJobStatus = "canceled"
+)
+
+// Organization models one tenant boundary.
+type Organization struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Slug      string    `json:"slug"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// Workspace models one collaboration boundary within an organization.
+type Workspace struct {
+	ID             string    `json:"id"`
+	OrganizationID string    `json:"organization_id"`
+	Name           string    `json:"name"`
+	Slug           string    `json:"slug"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+// WorkspaceMember models one user assignment in a workspace.
+type WorkspaceMember struct {
+	ID          string       `json:"id"`
+	WorkspaceID string       `json:"workspace_id"`
+	UserID      string       `json:"user_id"`
+	Email       string       `json:"email"`
+	Role        MemberRole   `json:"role"`
+	Status      MemberStatus `json:"status"`
+	JoinedAt    time.Time    `json:"joined_at"`
+	UpdatedAt   time.Time    `json:"updated_at"`
+}
+
+// Project models one scoped application or service boundary in a workspace.
+type Project struct {
+	ID          string     `json:"id"`
+	WorkspaceID string     `json:"workspace_id"`
+	Name        string     `json:"name"`
+	Slug        string     `json:"slug"`
+	Description string     `json:"description,omitempty"`
+	ArchivedAt  *time.Time `json:"archived_at,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+}
+
+// Connector models one project integration source.
+type Connector struct {
+	ID          string          `json:"id"`
+	WorkspaceID string          `json:"workspace_id"`
+	ProjectID   string          `json:"project_id"`
+	Type        ConnectorType   `json:"type"`
+	DisplayName string          `json:"display_name"`
+	Status      ConnectorStatus `json:"status"`
+	LastSyncAt  *time.Time      `json:"last_sync_at,omitempty"`
+	CreatedAt   time.Time       `json:"created_at"`
+	UpdatedAt   time.Time       `json:"updated_at"`
+}
+
+// ScanPolicy models scan scheduling and trigger limits for one project.
+type ScanPolicy struct {
+	ID                 string          `json:"id"`
+	WorkspaceID        string          `json:"workspace_id"`
+	ProjectID          string          `json:"project_id"`
+	Name               string          `json:"name"`
+	Enabled            bool            `json:"enabled"`
+	TriggerMode        ScanTriggerMode `json:"trigger_mode"`
+	Cron               string          `json:"cron,omitempty"`
+	MaxConcurrentScans int             `json:"max_concurrent_scans"`
+	CreatedAt          time.Time       `json:"created_at"`
+	UpdatedAt          time.Time       `json:"updated_at"`
+}
+
+// SuppressionPolicy models policy-based finding suppressions.
+type SuppressionPolicy struct {
+	ID            string           `json:"id"`
+	WorkspaceID   string           `json:"workspace_id"`
+	ProjectID     string           `json:"project_id"`
+	Name          string           `json:"name"`
+	Scope         SuppressionScope `json:"scope"`
+	Target        string           `json:"target"`
+	Reason        string           `json:"reason"`
+	ExpiresAt     *time.Time       `json:"expires_at,omitempty"`
+	CreatedBy     string           `json:"created_by"`
+	CreatedAt     time.Time        `json:"created_at"`
+	LastUpdatedAt time.Time        `json:"last_updated_at"`
+}
+
+// RemediationJob models one remediation execution request.
+type RemediationJob struct {
+	ID            string               `json:"id"`
+	WorkspaceID   string               `json:"workspace_id"`
+	ProjectID     string               `json:"project_id"`
+	FindingID     string               `json:"finding_id"`
+	Type          RemediationJobType   `json:"type"`
+	Status        RemediationJobStatus `json:"status"`
+	RequestedBy   string               `json:"requested_by"`
+	RequestedAt   time.Time            `json:"requested_at"`
+	StartedAt     *time.Time           `json:"started_at,omitempty"`
+	CompletedAt   *time.Time           `json:"completed_at,omitempty"`
+	ArtifactRef   string               `json:"artifact_ref,omitempty"`
+	ErrorMessage  string               `json:"error_message,omitempty"`
+	LastUpdatedAt time.Time            `json:"last_updated_at"`
+}
+
+func (o Organization) Validate() error {
+	if err := validateAppModeIdentifier("organization.id", o.ID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(o.Name) == "" {
+		return fmt.Errorf("organization.name is required")
+	}
+	if err := validateAppModeIdentifier("organization.slug", o.Slug); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (w Workspace) Validate() error {
+	if err := validateAppModeIdentifier("workspace.id", w.ID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("workspace.organization_id", w.OrganizationID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(w.Name) == "" {
+		return fmt.Errorf("workspace.name is required")
+	}
+	if err := validateAppModeIdentifier("workspace.slug", w.Slug); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m WorkspaceMember) Validate() error {
+	if err := validateAppModeIdentifier("workspace_member.id", m.ID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("workspace_member.workspace_id", m.WorkspaceID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("workspace_member.user_id", m.UserID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(m.Email) == "" {
+		return fmt.Errorf("workspace_member.email is required")
+	}
+	if !validMemberRole(m.Role) {
+		return fmt.Errorf("workspace_member.role is invalid")
+	}
+	if !validMemberStatus(m.Status) {
+		return fmt.Errorf("workspace_member.status is invalid")
+	}
+	return nil
+}
+
+func (p Project) Validate() error {
+	if err := validateAppModeIdentifier("project.id", p.ID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("project.workspace_id", p.WorkspaceID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(p.Name) == "" {
+		return fmt.Errorf("project.name is required")
+	}
+	if err := validateAppModeIdentifier("project.slug", p.Slug); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c Connector) Validate() error {
+	if err := validateAppModeIdentifier("connector.id", c.ID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("connector.workspace_id", c.WorkspaceID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("connector.project_id", c.ProjectID); err != nil {
+		return err
+	}
+	if !validConnectorType(c.Type) {
+		return fmt.Errorf("connector.type is invalid")
+	}
+	if strings.TrimSpace(c.DisplayName) == "" {
+		return fmt.Errorf("connector.display_name is required")
+	}
+	if !validConnectorStatus(c.Status) {
+		return fmt.Errorf("connector.status is invalid")
+	}
+	return nil
+}
+
+func (p ScanPolicy) Validate() error {
+	if err := validateAppModeIdentifier("scan_policy.id", p.ID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("scan_policy.workspace_id", p.WorkspaceID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("scan_policy.project_id", p.ProjectID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(p.Name) == "" {
+		return fmt.Errorf("scan_policy.name is required")
+	}
+	if !validScanTriggerMode(p.TriggerMode) {
+		return fmt.Errorf("scan_policy.trigger_mode is invalid")
+	}
+	if p.TriggerMode == ScanTriggerModeScheduled && strings.TrimSpace(p.Cron) == "" {
+		return fmt.Errorf("scan_policy.cron is required for scheduled trigger_mode")
+	}
+	if p.MaxConcurrentScans <= 0 {
+		return fmt.Errorf("scan_policy.max_concurrent_scans must be > 0")
+	}
+	return nil
+}
+
+func (p SuppressionPolicy) Validate() error {
+	if err := validateAppModeIdentifier("suppression_policy.id", p.ID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("suppression_policy.workspace_id", p.WorkspaceID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("suppression_policy.project_id", p.ProjectID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(p.Name) == "" {
+		return fmt.Errorf("suppression_policy.name is required")
+	}
+	if !validSuppressionScope(p.Scope) {
+		return fmt.Errorf("suppression_policy.scope is invalid")
+	}
+	if strings.TrimSpace(p.Target) == "" {
+		return fmt.Errorf("suppression_policy.target is required")
+	}
+	if strings.TrimSpace(p.Reason) == "" {
+		return fmt.Errorf("suppression_policy.reason is required")
+	}
+	if err := validateAppModeIdentifier("suppression_policy.created_by", p.CreatedBy); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (j RemediationJob) Validate() error {
+	if err := validateAppModeIdentifier("remediation_job.id", j.ID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("remediation_job.workspace_id", j.WorkspaceID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("remediation_job.project_id", j.ProjectID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("remediation_job.finding_id", j.FindingID); err != nil {
+		return err
+	}
+	if !validRemediationType(j.Type) {
+		return fmt.Errorf("remediation_job.type is invalid")
+	}
+	if !validRemediationStatus(j.Status) {
+		return fmt.Errorf("remediation_job.status is invalid")
+	}
+	if err := validateAppModeIdentifier("remediation_job.requested_by", j.RequestedBy); err != nil {
+		return err
+	}
+	return nil
+}
+
+func CanTransitionConnectorStatus(from ConnectorStatus, to ConnectorStatus) bool {
+	if from == to {
+		return true
+	}
+	switch from {
+	case ConnectorStatusPending:
+		return to == ConnectorStatusActive || to == ConnectorStatusDisconnected || to == ConnectorStatusDegraded
+	case ConnectorStatusActive:
+		return to == ConnectorStatusDegraded || to == ConnectorStatusDisconnected
+	case ConnectorStatusDegraded:
+		return to == ConnectorStatusActive || to == ConnectorStatusDisconnected
+	case ConnectorStatusDisconnected:
+		return to == ConnectorStatusPending || to == ConnectorStatusActive
+	default:
+		return false
+	}
+}
+
+func CanTransitionRemediationJobStatus(from RemediationJobStatus, to RemediationJobStatus) bool {
+	if from == to {
+		return true
+	}
+	switch from {
+	case RemediationJobStatusQueued:
+		return to == RemediationJobStatusRunning || to == RemediationJobStatusCanceled
+	case RemediationJobStatusRunning:
+		return to == RemediationJobStatusSucceeded || to == RemediationJobStatusFailed || to == RemediationJobStatusCanceled
+	case RemediationJobStatusFailed:
+		return to == RemediationJobStatusQueued
+	case RemediationJobStatusSucceeded, RemediationJobStatusCanceled:
+		return false
+	default:
+		return false
+	}
+}
+
+func validateAppModeIdentifier(field string, value string) error {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return fmt.Errorf("%s is required", field)
+	}
+	if value != trimmed {
+		return fmt.Errorf("%s must not contain surrounding whitespace", field)
+	}
+	if !appModeIdentifierPattern.MatchString(trimmed) {
+		return fmt.Errorf("%s must match %s", field, appModeIdentifierPattern.String())
+	}
+	return nil
+}
+
+func validMemberRole(role MemberRole) bool {
+	switch role {
+	case MemberRoleOwner, MemberRoleAdmin, MemberRoleAnalyst, MemberRoleViewer:
+		return true
+	default:
+		return false
+	}
+}
+
+func validMemberStatus(status MemberStatus) bool {
+	switch status {
+	case MemberStatusInvited, MemberStatusActive, MemberStatusSuspended, MemberStatusRemoved:
+		return true
+	default:
+		return false
+	}
+}
+
+func validConnectorType(connectorType ConnectorType) bool {
+	switch connectorType {
+	case ConnectorTypeGitHub, ConnectorTypeAWS, ConnectorTypeKubernetes:
+		return true
+	default:
+		return false
+	}
+}
+
+func validConnectorStatus(status ConnectorStatus) bool {
+	switch status {
+	case ConnectorStatusPending, ConnectorStatusActive, ConnectorStatusDegraded, ConnectorStatusDisconnected:
+		return true
+	default:
+		return false
+	}
+}
+
+func validScanTriggerMode(mode ScanTriggerMode) bool {
+	switch mode {
+	case ScanTriggerModeManual, ScanTriggerModeScheduled, ScanTriggerModeEvent, ScanTriggerModeHybrid:
+		return true
+	default:
+		return false
+	}
+}
+
+func validSuppressionScope(scope SuppressionScope) bool {
+	switch scope {
+	case SuppressionScopeFinding, SuppressionScopeRule, SuppressionScopeResource:
+		return true
+	default:
+		return false
+	}
+}
+
+func validRemediationType(remediationType RemediationJobType) bool {
+	switch remediationType {
+	case RemediationJobTypePatchTemplate, RemediationJobTypeCreateFixPR, RemediationJobTypeTicket:
+		return true
+	default:
+		return false
+	}
+}
+
+func validRemediationStatus(status RemediationJobStatus) bool {
+	switch status {
+	case RemediationJobStatusQueued, RemediationJobStatusRunning, RemediationJobStatusSucceeded, RemediationJobStatusFailed, RemediationJobStatusCanceled:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/domain/appmode_test.go
+++ b/internal/domain/appmode_test.go
@@ -1,0 +1,237 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAppModeEntitiesValidate(t *testing.T) {
+	now := time.Now().UTC()
+	org := Organization{
+		ID:        "org-core",
+		Name:      "Core Org",
+		Slug:      "core-org",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := org.Validate(); err != nil {
+		t.Fatalf("expected valid organization, got %v", err)
+	}
+
+	workspace := Workspace{
+		ID:             "workspace-core",
+		OrganizationID: org.ID,
+		Name:           "Core Workspace",
+		Slug:           "core-workspace",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := workspace.Validate(); err != nil {
+		t.Fatalf("expected valid workspace, got %v", err)
+	}
+
+	member := WorkspaceMember{
+		ID:          "member-1",
+		WorkspaceID: workspace.ID,
+		UserID:      "user-1",
+		Email:       "user@example.com",
+		Role:        MemberRoleAdmin,
+		Status:      MemberStatusActive,
+		JoinedAt:    now,
+		UpdatedAt:   now,
+	}
+	if err := member.Validate(); err != nil {
+		t.Fatalf("expected valid member, got %v", err)
+	}
+
+	project := Project{
+		ID:          "project-payments",
+		WorkspaceID: workspace.ID,
+		Name:        "Payments",
+		Slug:        "payments",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := project.Validate(); err != nil {
+		t.Fatalf("expected valid project, got %v", err)
+	}
+
+	connector := Connector{
+		ID:          "connector-gh",
+		WorkspaceID: workspace.ID,
+		ProjectID:   project.ID,
+		Type:        ConnectorTypeGitHub,
+		DisplayName: "GitHub Source",
+		Status:      ConnectorStatusActive,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := connector.Validate(); err != nil {
+		t.Fatalf("expected valid connector, got %v", err)
+	}
+
+	policy := ScanPolicy{
+		ID:                 "policy-1",
+		WorkspaceID:        workspace.ID,
+		ProjectID:          project.ID,
+		Name:               "default policy",
+		Enabled:            true,
+		TriggerMode:        ScanTriggerModeHybrid,
+		Cron:               "0 */6 * * *",
+		MaxConcurrentScans: 2,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	if err := policy.Validate(); err != nil {
+		t.Fatalf("expected valid scan policy, got %v", err)
+	}
+
+	suppression := SuppressionPolicy{
+		ID:            "suppression-1",
+		WorkspaceID:   workspace.ID,
+		ProjectID:     project.ID,
+		Name:          "temporary exception",
+		Scope:         SuppressionScopeRule,
+		Target:        "secret_exposure",
+		Reason:        "approved exception",
+		CreatedBy:     "admin-user",
+		CreatedAt:     now,
+		LastUpdatedAt: now,
+	}
+	if err := suppression.Validate(); err != nil {
+		t.Fatalf("expected valid suppression policy, got %v", err)
+	}
+
+	remediation := RemediationJob{
+		ID:            "remediation-1",
+		WorkspaceID:   workspace.ID,
+		ProjectID:     project.ID,
+		FindingID:     "finding-123",
+		Type:          RemediationJobTypeCreateFixPR,
+		Status:        RemediationJobStatusQueued,
+		RequestedBy:   "admin-user",
+		RequestedAt:   now,
+		LastUpdatedAt: now,
+	}
+	if err := remediation.Validate(); err != nil {
+		t.Fatalf("expected valid remediation job, got %v", err)
+	}
+}
+
+func TestAppModeEntityValidationFailsOnMissingRequiredFields(t *testing.T) {
+	if err := (Organization{}).Validate(); err == nil {
+		t.Fatal("expected organization validation to fail")
+	}
+	if err := (Workspace{}).Validate(); err == nil {
+		t.Fatal("expected workspace validation to fail")
+	}
+	if err := (WorkspaceMember{}).Validate(); err == nil {
+		t.Fatal("expected workspace member validation to fail")
+	}
+	if err := (Project{}).Validate(); err == nil {
+		t.Fatal("expected project validation to fail")
+	}
+	if err := (Connector{}).Validate(); err == nil {
+		t.Fatal("expected connector validation to fail")
+	}
+	if err := (ScanPolicy{}).Validate(); err == nil {
+		t.Fatal("expected scan policy validation to fail")
+	}
+	if err := (SuppressionPolicy{}).Validate(); err == nil {
+		t.Fatal("expected suppression policy validation to fail")
+	}
+	if err := (RemediationJob{}).Validate(); err == nil {
+		t.Fatal("expected remediation job validation to fail")
+	}
+}
+
+func TestAppModeIdentifierRejectsSurroundingWhitespace(t *testing.T) {
+	org := Organization{
+		ID:   "  org-1  ",
+		Name: "Org One",
+		Slug: "org-one",
+	}
+	if err := org.Validate(); err == nil {
+		t.Fatal("expected identifier with surrounding whitespace to fail")
+	}
+}
+
+func TestWorkspaceMemberValidationRequiresEmail(t *testing.T) {
+	now := time.Now().UTC()
+	member := WorkspaceMember{
+		ID:          "member-1",
+		WorkspaceID: "workspace-core",
+		UserID:      "user-1",
+		Email:       "   ",
+		Role:        MemberRoleViewer,
+		Status:      MemberStatusInvited,
+		JoinedAt:    now,
+		UpdatedAt:   now,
+	}
+	if err := member.Validate(); err == nil {
+		t.Fatal("expected workspace member email validation to fail")
+	}
+}
+
+func TestScanPolicyScheduledValidationRequiresCron(t *testing.T) {
+	now := time.Now().UTC()
+	policy := ScanPolicy{
+		ID:                 "policy-1",
+		WorkspaceID:        "workspace-core",
+		ProjectID:          "project-core",
+		Name:               "scheduled policy",
+		Enabled:            true,
+		TriggerMode:        ScanTriggerModeScheduled,
+		MaxConcurrentScans: 1,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	if err := policy.Validate(); err == nil {
+		t.Fatal("expected scan policy scheduled validation to fail when cron is missing")
+	}
+}
+
+func TestRemediationJobValidationRequiresValidFindingID(t *testing.T) {
+	now := time.Now().UTC()
+	job := RemediationJob{
+		ID:            "remediation-1",
+		WorkspaceID:   "workspace-core",
+		ProjectID:     "project-core",
+		FindingID:     "finding bad",
+		Type:          RemediationJobTypeCreateFixPR,
+		Status:        RemediationJobStatusQueued,
+		RequestedBy:   "admin-user",
+		RequestedAt:   now,
+		LastUpdatedAt: now,
+	}
+	if err := job.Validate(); err == nil {
+		t.Fatal("expected remediation job finding_id validation to fail")
+	}
+}
+
+func TestConnectorStatusTransitions(t *testing.T) {
+	if !CanTransitionConnectorStatus(ConnectorStatusPending, ConnectorStatusActive) {
+		t.Fatal("expected pending -> active transition to be valid")
+	}
+	if CanTransitionConnectorStatus(ConnectorStatusActive, ConnectorStatusPending) {
+		t.Fatal("expected active -> pending transition to be invalid")
+	}
+	if !CanTransitionConnectorStatus(ConnectorStatusDegraded, ConnectorStatusActive) {
+		t.Fatal("expected degraded -> active transition to be valid")
+	}
+}
+
+func TestRemediationStatusTransitions(t *testing.T) {
+	if !CanTransitionRemediationJobStatus(RemediationJobStatusQueued, RemediationJobStatusRunning) {
+		t.Fatal("expected queued -> running transition to be valid")
+	}
+	if !CanTransitionRemediationJobStatus(RemediationJobStatusRunning, RemediationJobStatusSucceeded) {
+		t.Fatal("expected running -> succeeded transition to be valid")
+	}
+	if CanTransitionRemediationJobStatus(RemediationJobStatusSucceeded, RemediationJobStatusQueued) {
+		t.Fatal("expected succeeded -> queued transition to be invalid")
+	}
+	if !CanTransitionRemediationJobStatus(RemediationJobStatusFailed, RemediationJobStatusQueued) {
+		t.Fatal("expected failed -> queued transition to be valid for retry")
+	}
+}

--- a/internal/domain/json_tags_test.go
+++ b/internal/domain/json_tags_test.go
@@ -61,3 +61,33 @@ func TestIdentityJSONUsesSnakeCaseFields(t *testing.T) {
 		t.Fatalf("unexpected struct field casing leaked in payload: %s", text)
 	}
 }
+
+func TestAppModeEntityJSONUsesSnakeCaseFields(t *testing.T) {
+	now := time.Date(2026, 3, 16, 0, 0, 0, 0, time.UTC)
+	connector := Connector{
+		ID:          "connector-1",
+		WorkspaceID: "workspace-1",
+		ProjectID:   "project-1",
+		Type:        ConnectorTypeGitHub,
+		DisplayName: "GitHub",
+		Status:      ConnectorStatusActive,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	payload, err := json.Marshal(connector)
+	if err != nil {
+		t.Fatalf("marshal connector: %v", err)
+	}
+	text := string(payload)
+	for _, expected := range []string{`"workspace_id"`, `"project_id"`, `"display_name"`, `"created_at"`} {
+		if !strings.Contains(text, expected) {
+			t.Fatalf("expected field %s in %s", expected, text)
+		}
+	}
+	for _, unexpected := range []string{`"WorkspaceID"`, `"ProjectID"`, `"DisplayName"`} {
+		if strings.Contains(text, unexpected) {
+			t.Fatalf("unexpected struct field casing leaked in payload: %s", text)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #542 

## Summary
Implements **ITR-002** by defining normalized app-mode domain entities for org/workspace/project/member/connector/policies/remediation jobs, with validation and transition contracts.

## Why This Fix
Without canonical domain models, tenancy and workflow semantics drift across API/store layers. This PR establishes a stable domain contract before persistence and endpoint wiring, reducing inconsistency risk in dependent implementation work.

## What Changed
- Added new domain entity definitions in `internal/domain/appmode.go`:
  - `Organization`
  - `Workspace`
  - `WorkspaceMember`
  - `Project`
  - `Connector`
  - `ScanPolicy`
  - `SuppressionPolicy`
  - `RemediationJob`
- Added enum contracts and validation for:
  - member roles/status
  - connector type/status
  - scan trigger modes
  - suppression scope
  - remediation job type/status
- Added state transition helpers:
  - `CanTransitionConnectorStatus`
  - `CanTransitionRemediationJobStatus`
- Added test coverage:
  - entity required-field validation (`internal/domain/appmode_test.go`)
  - transition constraints (`internal/domain/appmode_test.go`)
  - JSON serialization contract (snake_case) (`internal/domain/json_tags_test.go`)
- Added documentation for entity contracts in `docs/domain-entities.md` and linked it from `docs/README.md`.

## Premium-Oriented Improvement (In Scope)
`RemediationJob` includes an explicit `create_fix_pr` job type in the domain contract, enabling premium remediation automation flows to be built on a first-class, validated model.

## Self Review
- Verified required fields are validated for all new entities.
- Verified connector and remediation transitions encode expected lifecycle constraints.
- Verified JSON tags stay snake_case for compatibility and future API schema generation.
- Kept DB schema and API handlers out-of-scope per issue requirements.

## Validation
- `go test ./internal/domain`
- `go test ./...`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines canonical app‑mode domain models with validation and lifecycle guards for orgs, workspaces, projects, connectors, policies, and remediation to satisfy ITR‑002. Locks down a stable snake_case JSON contract to unblock persistence and API work.

- **New Features**
  - Added entities in `internal/domain/appmode.go`: Organization, Workspace, WorkspaceMember, Project, Connector, ScanPolicy, SuppressionPolicy, RemediationJob.
  - Implemented enums, validation, and transitions: identifier‑safe IDs/slugs; member role/status; connector type/status with `CanTransitionConnectorStatus`; scan trigger modes (`cron` required for scheduled, `max_concurrent_scans > 0`); suppression scope; remediation type/status with `CanTransitionRemediationJobStatus` (includes `create_fix_pr`, retry from failed).
  - Added tests for required fields, identifiers, transitions, and snake_case JSON; added `docs/domain-entities.md` and linked it from `docs/README.md`.

<sup>Written for commit 37b3785ed4c8c1e465484fb03fd6534bd27b49d0. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/591?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

