### PR TITLE
ITR-003: add tenancy core migrations for org/workspace/member/project

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -56,6 +56,7 @@ Current sequence in `migrations/`:
 10. `000009_authz_abac_rebac_data` - central authz ABAC/REBAC data model
 11. `000010_authz_policy_lifecycle_controls` - policy lifecycle primitives
 12. `000011_authz_policy_rollout_staged_controls` - staged rollout controls
+13. `000012_tenancy_core_entities` - organization/workspace/member/project tenancy core
 
 Notes:
 - Each migration has matching `.up.sql` and `.down.sql` files.

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -213,3 +213,28 @@ func TestTenthMigrationContainsAuthzPolicyLifecycleTables(t *testing.T) {
 		}
 	}
 }
+
+func TestTwelfthMigrationContainsTenancyCoreTables(t *testing.T) {
+	path := filepath.Join("..", "..", "migrations", "000012_tenancy_core_entities.up.sql")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	text := string(content)
+	required := []string{
+		"CREATE TABLE IF NOT EXISTS tenancy_organizations",
+		"CREATE TABLE IF NOT EXISTS tenancy_workspaces",
+		"CREATE TABLE IF NOT EXISTS tenancy_workspace_members",
+		"CREATE TABLE IF NOT EXISTS tenancy_projects",
+		"FOREIGN KEY (tenant_id) REFERENCES tenancy_organizations(tenant_id)",
+		"FOREIGN KEY (tenant_id, workspace_id) REFERENCES tenancy_workspaces(tenant_id, workspace_id)",
+		"idx_tenancy_workspaces_scope_created",
+		"idx_tenancy_members_scope_role_status",
+		"idx_tenancy_projects_scope_created",
+	}
+	for _, item := range required {
+		if !strings.Contains(text, item) {
+			t.Fatalf("expected tenancy core migration item %q", item)
+		}
+	}
+}

--- a/migrations/000012_tenancy_core_entities.down.sql
+++ b/migrations/000012_tenancy_core_entities.down.sql
@@ -1,0 +1,9 @@
+DROP INDEX IF EXISTS idx_tenancy_projects_scope_archived;
+DROP INDEX IF EXISTS idx_tenancy_projects_scope_created;
+DROP INDEX IF EXISTS idx_tenancy_members_scope_role_status;
+DROP INDEX IF EXISTS idx_tenancy_workspaces_scope_created;
+
+DROP TABLE IF EXISTS tenancy_projects;
+DROP TABLE IF EXISTS tenancy_workspace_members;
+DROP TABLE IF EXISTS tenancy_workspaces;
+DROP TABLE IF EXISTS tenancy_organizations;

--- a/migrations/000012_tenancy_core_entities.up.sql
+++ b/migrations/000012_tenancy_core_entities.up.sql
@@ -1,0 +1,74 @@
+CREATE TABLE IF NOT EXISTS tenancy_organizations (
+    tenant_id TEXT PRIMARY KEY,
+    display_name TEXT NOT NULL,
+    slug TEXT NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CHECK (LENGTH(TRIM(tenant_id)) > 0),
+    CHECK (LENGTH(TRIM(display_name)) > 0),
+    CHECK (LENGTH(TRIM(slug)) > 0)
+);
+
+CREATE TABLE IF NOT EXISTS tenancy_workspaces (
+    tenant_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    slug TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, workspace_id),
+    UNIQUE (tenant_id, slug),
+    FOREIGN KEY (tenant_id) REFERENCES tenancy_organizations(tenant_id) ON DELETE CASCADE,
+    CHECK (LENGTH(TRIM(workspace_id)) > 0),
+    CHECK (LENGTH(TRIM(display_name)) > 0),
+    CHECK (LENGTH(TRIM(slug)) > 0)
+);
+
+CREATE TABLE IF NOT EXISTS tenancy_workspace_members (
+    tenant_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    member_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    email TEXT,
+    role TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'invited',
+    joined_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, workspace_id, member_id),
+    UNIQUE (tenant_id, workspace_id, user_id),
+    FOREIGN KEY (tenant_id, workspace_id) REFERENCES tenancy_workspaces(tenant_id, workspace_id) ON DELETE CASCADE,
+    CHECK (LENGTH(TRIM(member_id)) > 0),
+    CHECK (LENGTH(TRIM(user_id)) > 0),
+    CHECK (role IN ('owner', 'admin', 'analyst', 'viewer')),
+    CHECK (status IN ('invited', 'active', 'suspended', 'removed'))
+);
+
+CREATE TABLE IF NOT EXISTS tenancy_projects (
+    tenant_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    slug TEXT NOT NULL,
+    description TEXT,
+    archived_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, workspace_id, project_id),
+    UNIQUE (tenant_id, workspace_id, slug),
+    FOREIGN KEY (tenant_id, workspace_id) REFERENCES tenancy_workspaces(tenant_id, workspace_id) ON DELETE CASCADE,
+    CHECK (LENGTH(TRIM(project_id)) > 0),
+    CHECK (LENGTH(TRIM(name)) > 0),
+    CHECK (LENGTH(TRIM(slug)) > 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenancy_workspaces_scope_created
+    ON tenancy_workspaces (tenant_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_tenancy_members_scope_role_status
+    ON tenancy_workspace_members (tenant_id, workspace_id, role, status);
+
+CREATE INDEX IF NOT EXISTS idx_tenancy_projects_scope_created
+    ON tenancy_projects (tenant_id, workspace_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_tenancy_projects_scope_archived
+    ON tenancy_projects (tenant_id, workspace_id, archived_at);


### PR DESCRIPTION
Fixes #543

## Summary
Implements **ITR-003** by adding up/down SQL migrations for tenancy core persistence: organizations, workspaces, workspace members, and projects.

## Why This Fix
The tenancy model needed durable persistence with referential integrity before store/API implementation. This PR establishes schema-level guarantees and indexes for expected lookup paths.

## What Changed
- Added migration pair:
  - `migrations/000012_tenancy_core_entities.up.sql`
  - `migrations/000012_tenancy_core_entities.down.sql`
- Added tenancy core tables:
  - `tenancy_organizations`
  - `tenancy_workspaces`
  - `tenancy_workspace_members`
  - `tenancy_projects`
- Added relational integrity constraints:
  - workspace -> organization FK
  - workspace_members -> workspaces FK
  - projects -> workspaces FK
- Added uniqueness and field integrity checks for ids/slugs/status/role columns.
- Added indexes for common lookup patterns:
  - workspace by tenant/time
  - members by scope/user and scope/role/status
  - projects by scope/time and scope/archived state
- Updated migration coverage test (`internal/db/migrations_test.go`) and migration catalog docs (`docs/migrations.md`).

## Premium-Oriented Improvement (In Scope)
Project-level tenancy schema now supports clean premium segmentation patterns (for example, premium-only project experiences and workspace-level enterprise policy overlays) without requiring later schema churn.

## Self Review
- Confirmed up/down scripts are idempotent and reversible.
- Confirmed FK graph enforces tenancy hierarchy in the DB layer.
- Confirmed indexes align with expected scoped query paths.
- Kept store/API changes out-of-scope per issue definition.

## Validation
- `go test ./internal/db`
- `go test ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds up/down SQL migrations for tenancy core (organizations, workspaces, workspace members, projects) with composite keys, cascade FKs, validations, and scoped indexes to implement ITR-003.

- **Migration**
  - Adds `migrations/000012_tenancy_core_entities.up.sql` and `.down.sql`, `docs/migrations.md` entry, and a covering test.
  - Creates `tenancy_organizations`, `tenancy_workspaces`, `tenancy_workspace_members`, `tenancy_projects`.
  - Relationships and keys: composite PKs; workspace → organization; members/projects → workspace with ON DELETE CASCADE.
  - Constraints and indexes: non-empty ids/names/slugs; role (`owner`, `admin`, `analyst`, `viewer`); status (`invited`, `active`, `suspended`, `removed`); indexes `idx_tenancy_workspaces_scope_created`, `idx_tenancy_members_scope_role_status`, `idx_tenancy_projects_scope_created`, `idx_tenancy_projects_scope_archived`.

<sup>Written for commit eeb2a7a1ddb5c102740650ecb7f907c3dc1219a2. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/592?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

