### PR TITLE
ITR-004: implement scoped tenancy CRUD store layer

### DIFF
--- a/docs/persistence-artifacts.md
+++ b/docs/persistence-artifacts.md
@@ -35,3 +35,14 @@ This allows safe reruns and repeated persistence calls without duplicate row gro
 3. upsert artifacts
 4. upsert findings
 5. complete scan with counts/status
+
+## Tenancy CRUD Persistence
+
+Tenancy and project management CRUD now has dedicated scoped store operations:
+
+- organizations (`tenancy_organizations`)
+- workspaces (`tenancy_workspaces`)
+- workspace members (`tenancy_workspace_members`)
+- projects (`tenancy_projects`)
+
+Scope boundaries are enforced by requiring request scope (`tenant_id`, `workspace_id`) in all store operations, and tests cover cross-scope access denial expectations.

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -34,6 +34,10 @@ type MemoryStore struct {
 	authzRollouts map[string]AuthzPolicyRollout
 	authzEvents   map[string][]AuthzPolicyEvent
 	authzEventIDs map[string]struct{}
+	organizations map[string]TenancyOrganization
+	workspaces    map[string]TenancyWorkspace
+	members       map[string]TenancyWorkspaceMember
+	projects      map[string]TenancyProject
 	identities    map[string]domain.Identity
 	policies      map[string]domain.Policy
 	relationships map[string]domain.Relationship
@@ -61,6 +65,10 @@ func NewMemoryStore() *MemoryStore {
 		authzRollouts: map[string]AuthzPolicyRollout{},
 		authzEvents:   map[string][]AuthzPolicyEvent{},
 		authzEventIDs: map[string]struct{}{},
+		organizations: map[string]TenancyOrganization{},
+		workspaces:    map[string]TenancyWorkspace{},
+		members:       map[string]TenancyWorkspaceMember{},
+		projects:      map[string]TenancyProject{},
 		identities:    map[string]domain.Identity{},
 		policies:      map[string]domain.Policy{},
 		relationships: map[string]domain.Relationship{},

--- a/internal/db/memory_tenancy.go
+++ b/internal/db/memory_tenancy.go
@@ -1,0 +1,350 @@
+package db
+
+import (
+	"context"
+	"sort"
+	"strings"
+)
+
+// UpsertOrganization persists or updates one tenant organization record.
+func (m *MemoryStore) UpsertOrganization(ctx context.Context, organization TenancyOrganization) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	organization.TenantID = scope.TenantID
+	normalized, err := NormalizeTenancyOrganizationForWrite(organization)
+	if err != nil {
+		return err
+	}
+	m.organizations[normalized.TenantID] = normalized
+	return nil
+}
+
+// GetOrganization returns the active scoped tenant organization.
+func (m *MemoryStore) GetOrganization(ctx context.Context) (TenancyOrganization, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyOrganization{}, err
+	}
+	organization, exists := m.organizations[scope.TenantID]
+	if !exists {
+		return TenancyOrganization{}, ErrNotFound
+	}
+	return organization, nil
+}
+
+// DeleteOrganization removes the active scoped tenant organization record.
+func (m *MemoryStore) DeleteOrganization(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	if _, exists := m.organizations[scope.TenantID]; !exists {
+		return ErrNotFound
+	}
+	delete(m.organizations, scope.TenantID)
+	for key, workspace := range m.workspaces {
+		if workspace.TenantID == scope.TenantID {
+			delete(m.workspaces, key)
+		}
+	}
+	for key, member := range m.members {
+		if member.TenantID == scope.TenantID {
+			delete(m.members, key)
+		}
+	}
+	for key, project := range m.projects {
+		if project.TenantID == scope.TenantID {
+			delete(m.projects, key)
+		}
+	}
+	return nil
+}
+
+// UpsertWorkspace persists or updates one scoped workspace record.
+func (m *MemoryStore) UpsertWorkspace(ctx context.Context, workspace TenancyWorkspace) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	workspace.TenantID = scope.TenantID
+	if workspace.WorkspaceID == "" {
+		workspace.WorkspaceID = scope.WorkspaceID
+	}
+	normalized, err := NormalizeTenancyWorkspaceForWrite(workspace)
+	if err != nil {
+		return err
+	}
+	if _, exists := m.organizations[normalized.TenantID]; !exists {
+		return ErrNotFound
+	}
+	m.workspaces[tenancyWorkspaceKey(normalized.TenantID, normalized.WorkspaceID)] = normalized
+	return nil
+}
+
+// GetWorkspace returns one workspace by id in active tenant scope.
+func (m *MemoryStore) GetWorkspace(ctx context.Context, workspaceID string) (TenancyWorkspace, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyWorkspace{}, err
+	}
+	key := tenancyWorkspaceKey(scope.TenantID, workspaceID)
+	workspace, exists := m.workspaces[key]
+	if !exists {
+		return TenancyWorkspace{}, ErrNotFound
+	}
+	return workspace, nil
+}
+
+// ListWorkspaces returns scoped workspaces ordered by created_at descending.
+func (m *MemoryStore) ListWorkspaces(ctx context.Context, limit int) ([]TenancyWorkspace, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	workspaces := make([]TenancyWorkspace, 0, limit)
+	for _, workspace := range m.workspaces {
+		if workspace.TenantID != scope.TenantID {
+			continue
+		}
+		workspaces = append(workspaces, workspace)
+	}
+	sort.Slice(workspaces, func(i, j int) bool { return workspaces[i].CreatedAt.After(workspaces[j].CreatedAt) })
+	if len(workspaces) > limit {
+		workspaces = workspaces[:limit]
+	}
+	return workspaces, nil
+}
+
+// DeleteWorkspace removes one scoped workspace and all child records.
+func (m *MemoryStore) DeleteWorkspace(ctx context.Context, workspaceID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	normalizedWorkspaceID := strings.TrimSpace(workspaceID)
+	key := tenancyWorkspaceKey(scope.TenantID, normalizedWorkspaceID)
+	if _, exists := m.workspaces[key]; !exists {
+		return ErrNotFound
+	}
+	delete(m.workspaces, key)
+	for memberKey, member := range m.members {
+		if member.TenantID == scope.TenantID && member.WorkspaceID == normalizedWorkspaceID {
+			delete(m.members, memberKey)
+		}
+	}
+	for projectKey, project := range m.projects {
+		if project.TenantID == scope.TenantID && project.WorkspaceID == normalizedWorkspaceID {
+			delete(m.projects, projectKey)
+		}
+	}
+	return nil
+}
+
+// UpsertWorkspaceMember persists one workspace member assignment.
+func (m *MemoryStore) UpsertWorkspaceMember(ctx context.Context, member TenancyWorkspaceMember) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	member.TenantID = scope.TenantID
+	if member.WorkspaceID == "" {
+		member.WorkspaceID = scope.WorkspaceID
+	}
+	normalized, err := NormalizeTenancyWorkspaceMemberForWrite(member)
+	if err != nil {
+		return err
+	}
+	if _, exists := m.workspaces[tenancyWorkspaceKey(normalized.TenantID, normalized.WorkspaceID)]; !exists {
+		return ErrNotFound
+	}
+	m.members[tenancyMemberKey(normalized.TenantID, normalized.WorkspaceID, normalized.MemberID)] = normalized
+	return nil
+}
+
+// GetWorkspaceMember returns one scoped workspace member by member id.
+func (m *MemoryStore) GetWorkspaceMember(ctx context.Context, workspaceID string, memberID string) (TenancyWorkspaceMember, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyWorkspaceMember{}, err
+	}
+	member, exists := m.members[tenancyMemberKey(scope.TenantID, workspaceID, memberID)]
+	if !exists {
+		return TenancyWorkspaceMember{}, ErrNotFound
+	}
+	return member, nil
+}
+
+// ListWorkspaceMembers returns members for one scoped workspace.
+func (m *MemoryStore) ListWorkspaceMembers(ctx context.Context, workspaceID string, limit int) ([]TenancyWorkspaceMember, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	normalizedWorkspaceID := strings.TrimSpace(workspaceID)
+	members := make([]TenancyWorkspaceMember, 0, limit)
+	for _, member := range m.members {
+		if member.TenantID != scope.TenantID || member.WorkspaceID != normalizedWorkspaceID {
+			continue
+		}
+		members = append(members, member)
+	}
+	sort.Slice(members, func(i, j int) bool { return members[i].JoinedAt.Before(members[j].JoinedAt) })
+	if len(members) > limit {
+		members = members[:limit]
+	}
+	return members, nil
+}
+
+// DeleteWorkspaceMember removes one scoped workspace member.
+func (m *MemoryStore) DeleteWorkspaceMember(ctx context.Context, workspaceID string, memberID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	key := tenancyMemberKey(scope.TenantID, workspaceID, memberID)
+	if _, exists := m.members[key]; !exists {
+		return ErrNotFound
+	}
+	delete(m.members, key)
+	return nil
+}
+
+// UpsertProject persists one scoped project record.
+func (m *MemoryStore) UpsertProject(ctx context.Context, project TenancyProject) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	project.TenantID = scope.TenantID
+	if project.WorkspaceID == "" {
+		project.WorkspaceID = scope.WorkspaceID
+	}
+	normalized, err := NormalizeTenancyProjectForWrite(project)
+	if err != nil {
+		return err
+	}
+	if _, exists := m.workspaces[tenancyWorkspaceKey(normalized.TenantID, normalized.WorkspaceID)]; !exists {
+		return ErrNotFound
+	}
+	m.projects[tenancyProjectKey(normalized.TenantID, normalized.WorkspaceID, normalized.ProjectID)] = normalized
+	return nil
+}
+
+// GetProject returns one scoped project by id.
+func (m *MemoryStore) GetProject(ctx context.Context, workspaceID string, projectID string) (TenancyProject, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyProject{}, err
+	}
+	project, exists := m.projects[tenancyProjectKey(scope.TenantID, workspaceID, projectID)]
+	if !exists {
+		return TenancyProject{}, ErrNotFound
+	}
+	return project, nil
+}
+
+// ListProjects returns projects for one scoped workspace.
+func (m *MemoryStore) ListProjects(ctx context.Context, workspaceID string, includeArchived bool, limit int) ([]TenancyProject, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	normalizedWorkspaceID := strings.TrimSpace(workspaceID)
+	projects := make([]TenancyProject, 0, limit)
+	for _, project := range m.projects {
+		if project.TenantID != scope.TenantID || project.WorkspaceID != normalizedWorkspaceID {
+			continue
+		}
+		if !includeArchived && project.ArchivedAt != nil {
+			continue
+		}
+		projects = append(projects, project)
+	}
+	sort.Slice(projects, func(i, j int) bool { return projects[i].CreatedAt.After(projects[j].CreatedAt) })
+	if len(projects) > limit {
+		projects = projects[:limit]
+	}
+	return projects, nil
+}
+
+// DeleteProject removes one scoped project.
+func (m *MemoryStore) DeleteProject(ctx context.Context, workspaceID string, projectID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	key := tenancyProjectKey(scope.TenantID, workspaceID, projectID)
+	if _, exists := m.projects[key]; !exists {
+		return ErrNotFound
+	}
+	delete(m.projects, key)
+	return nil
+}
+
+func tenancyWorkspaceKey(tenantID string, workspaceID string) string {
+	return strings.TrimSpace(tenantID) + "|" + strings.TrimSpace(workspaceID)
+}
+
+func tenancyMemberKey(tenantID string, workspaceID string, memberID string) string {
+	return tenancyWorkspaceKey(tenantID, workspaceID) + "|" + strings.TrimSpace(memberID)
+}
+
+func tenancyProjectKey(tenantID string, workspaceID string, projectID string) string {
+	return tenancyWorkspaceKey(tenantID, workspaceID) + "|" + strings.TrimSpace(projectID)
+}

--- a/internal/db/memory_tenancy_test.go
+++ b/internal/db/memory_tenancy_test.go
@@ -1,0 +1,175 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestMemoryStoreTenancyCRUD(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+
+	if err := store.UpsertOrganization(ctx, TenancyOrganization{
+		DisplayName: "Tenant A",
+		Slug:        "tenant-a",
+	}); err != nil {
+		t.Fatalf("upsert organization: %v", err)
+	}
+	if _, err := store.GetOrganization(ctx); err != nil {
+		t.Fatalf("get organization: %v", err)
+	}
+
+	if err := store.UpsertWorkspace(ctx, TenancyWorkspace{
+		WorkspaceID: "workspace-a",
+		DisplayName: "Workspace A",
+		Slug:        "workspace-a",
+	}); err != nil {
+		t.Fatalf("upsert workspace: %v", err)
+	}
+	if _, err := store.GetWorkspace(ctx, "workspace-a"); err != nil {
+		t.Fatalf("get workspace: %v", err)
+	}
+	workspaces, err := store.ListWorkspaces(ctx, 20)
+	if err != nil {
+		t.Fatalf("list workspaces: %v", err)
+	}
+	if len(workspaces) != 1 {
+		t.Fatalf("expected one workspace, got %+v", workspaces)
+	}
+
+	joinedAt := time.Now().UTC()
+	if err := store.UpsertWorkspaceMember(ctx, TenancyWorkspaceMember{
+		WorkspaceID: "workspace-a",
+		MemberID:    "member-1",
+		UserID:      "user-1",
+		Email:       "user@example.com",
+		Role:        "admin",
+		Status:      "active",
+		JoinedAt:    joinedAt,
+	}); err != nil {
+		t.Fatalf("upsert workspace member: %v", err)
+	}
+	members, err := store.ListWorkspaceMembers(ctx, "workspace-a", 20)
+	if err != nil {
+		t.Fatalf("list workspace members: %v", err)
+	}
+	if len(members) != 1 || members[0].MemberID != "member-1" {
+		t.Fatalf("unexpected members: %+v", members)
+	}
+
+	if err := store.UpsertProject(ctx, TenancyProject{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		Name:        "Payments",
+		Slug:        "payments",
+	}); err != nil {
+		t.Fatalf("upsert project: %v", err)
+	}
+	projects, err := store.ListProjects(ctx, "workspace-a", false, 20)
+	if err != nil {
+		t.Fatalf("list projects: %v", err)
+	}
+	if len(projects) != 1 || projects[0].ProjectID != "project-1" {
+		t.Fatalf("unexpected projects: %+v", projects)
+	}
+
+	if err := store.DeleteProject(ctx, "workspace-a", "project-1"); err != nil {
+		t.Fatalf("delete project: %v", err)
+	}
+	if err := store.DeleteWorkspaceMember(ctx, "workspace-a", "member-1"); err != nil {
+		t.Fatalf("delete workspace member: %v", err)
+	}
+	if err := store.DeleteWorkspace(ctx, "workspace-a"); err != nil {
+		t.Fatalf("delete workspace: %v", err)
+	}
+	if err := store.DeleteOrganization(ctx); err != nil {
+		t.Fatalf("delete organization: %v", err)
+	}
+}
+
+func TestMemoryStoreTenancyScopeIsolation(t *testing.T) {
+	store := NewMemoryStore()
+	tenantA := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	tenantB := WithScope(context.Background(), Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
+
+	if err := store.UpsertOrganization(tenantA, TenancyOrganization{
+		DisplayName: "Tenant A",
+		Slug:        "tenant-a",
+	}); err != nil {
+		t.Fatalf("seed organization tenant-a: %v", err)
+	}
+	if err := store.UpsertWorkspace(tenantA, TenancyWorkspace{
+		WorkspaceID: "workspace-a",
+		DisplayName: "Workspace A",
+		Slug:        "workspace-a",
+	}); err != nil {
+		t.Fatalf("seed workspace tenant-a: %v", err)
+	}
+	if err := store.UpsertProject(tenantA, TenancyProject{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-a",
+		Name:        "Project A",
+		Slug:        "project-a",
+	}); err != nil {
+		t.Fatalf("seed project tenant-a: %v", err)
+	}
+
+	if _, err := store.GetOrganization(tenantB); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected tenant-b organization to be isolated, got %v", err)
+	}
+	if _, err := store.GetWorkspace(tenantB, "workspace-a"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected tenant-b workspace to be isolated, got %v", err)
+	}
+	if _, err := store.GetProject(tenantB, "workspace-a", "project-a"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected tenant-b project to be isolated, got %v", err)
+	}
+}
+
+func TestMemoryStoreDeleteWorkspaceCascadesWithPaddedWorkspaceID(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+
+	if err := store.UpsertOrganization(ctx, TenancyOrganization{
+		DisplayName: "Tenant A",
+		Slug:        "tenant-a",
+	}); err != nil {
+		t.Fatalf("upsert organization: %v", err)
+	}
+	if err := store.UpsertWorkspace(ctx, TenancyWorkspace{
+		WorkspaceID: "workspace-a",
+		DisplayName: "Workspace A",
+		Slug:        "workspace-a",
+	}); err != nil {
+		t.Fatalf("upsert workspace: %v", err)
+	}
+	if err := store.UpsertWorkspaceMember(ctx, TenancyWorkspaceMember{
+		WorkspaceID: "workspace-a",
+		MemberID:    "member-1",
+		UserID:      "user-1",
+		Email:       "user@example.com",
+		Role:        "admin",
+		Status:      "active",
+	}); err != nil {
+		t.Fatalf("upsert member: %v", err)
+	}
+	if err := store.UpsertProject(ctx, TenancyProject{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		Name:        "Payments",
+		Slug:        "payments",
+	}); err != nil {
+		t.Fatalf("upsert project: %v", err)
+	}
+
+	if err := store.DeleteWorkspace(ctx, "  workspace-a  "); err != nil {
+		t.Fatalf("delete workspace with padded id: %v", err)
+	}
+	if _, err := store.GetWorkspaceMember(ctx, "workspace-a", "member-1"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected member to be cascade-deleted, got %v", err)
+	}
+	if _, err := store.GetProject(ctx, "workspace-a", "project-1"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected project to be cascade-deleted, got %v", err)
+	}
+}

--- a/internal/db/postgres_tenancy.go
+++ b/internal/db/postgres_tenancy.go
@@ -1,0 +1,535 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+)
+
+// UpsertOrganization persists one scoped organization metadata row.
+func (p *PostgresStore) UpsertOrganization(ctx context.Context, organization TenancyOrganization) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	organization.TenantID = scope.TenantID
+	normalized, err := NormalizeTenancyOrganizationForWrite(organization)
+	if err != nil {
+		return err
+	}
+	_, err = p.execContext(
+		ctx,
+		`INSERT INTO tenancy_organizations (tenant_id, display_name, slug, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5)
+		 ON CONFLICT (tenant_id) DO UPDATE
+		 SET display_name = EXCLUDED.display_name,
+		     slug = EXCLUDED.slug,
+		     updated_at = EXCLUDED.updated_at`,
+		normalized.TenantID,
+		normalized.DisplayName,
+		normalized.Slug,
+		normalized.CreatedAt,
+		normalized.UpdatedAt,
+	)
+	return err
+}
+
+// GetOrganization returns one scoped organization record.
+func (p *PostgresStore) GetOrganization(ctx context.Context) (TenancyOrganization, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyOrganization{}, err
+	}
+	row := p.queryRowContext(
+		ctx,
+		`SELECT tenant_id, display_name, slug, created_at, updated_at
+		 FROM tenancy_organizations
+		 WHERE tenant_id = $1`,
+		scope.TenantID,
+	)
+	var organization TenancyOrganization
+	if err := row.Scan(
+		&organization.TenantID,
+		&organization.DisplayName,
+		&organization.Slug,
+		&organization.CreatedAt,
+		&organization.UpdatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return TenancyOrganization{}, ErrNotFound
+		}
+		return TenancyOrganization{}, err
+	}
+	return organization, nil
+}
+
+// DeleteOrganization removes one scoped organization record.
+func (p *PostgresStore) DeleteOrganization(ctx context.Context) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	result, err := p.execContext(
+		ctx,
+		`DELETE FROM tenancy_organizations
+		 WHERE tenant_id = $1`,
+		scope.TenantID,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// UpsertWorkspace persists one scoped workspace record.
+func (p *PostgresStore) UpsertWorkspace(ctx context.Context, workspace TenancyWorkspace) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	workspace.TenantID = scope.TenantID
+	if workspace.WorkspaceID == "" {
+		workspace.WorkspaceID = scope.WorkspaceID
+	}
+	normalized, err := NormalizeTenancyWorkspaceForWrite(workspace)
+	if err != nil {
+		return err
+	}
+	_, err = p.execContext(
+		ctx,
+		`INSERT INTO tenancy_workspaces (tenant_id, workspace_id, display_name, slug, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6)
+		 ON CONFLICT (tenant_id, workspace_id) DO UPDATE
+		 SET display_name = EXCLUDED.display_name,
+		     slug = EXCLUDED.slug,
+		     updated_at = EXCLUDED.updated_at`,
+		normalized.TenantID,
+		normalized.WorkspaceID,
+		normalized.DisplayName,
+		normalized.Slug,
+		normalized.CreatedAt,
+		normalized.UpdatedAt,
+	)
+	return err
+}
+
+// GetWorkspace returns one scoped workspace by id.
+func (p *PostgresStore) GetWorkspace(ctx context.Context, workspaceID string) (TenancyWorkspace, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyWorkspace{}, err
+	}
+	row := p.queryRowContext(
+		ctx,
+		`SELECT tenant_id, workspace_id, display_name, slug, created_at, updated_at
+		 FROM tenancy_workspaces
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2`,
+		scope.TenantID,
+		workspaceID,
+	)
+	var workspace TenancyWorkspace
+	if err := row.Scan(
+		&workspace.TenantID,
+		&workspace.WorkspaceID,
+		&workspace.DisplayName,
+		&workspace.Slug,
+		&workspace.CreatedAt,
+		&workspace.UpdatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return TenancyWorkspace{}, ErrNotFound
+		}
+		return TenancyWorkspace{}, err
+	}
+	return workspace, nil
+}
+
+// ListWorkspaces returns all scoped workspaces ordered by creation time.
+func (p *PostgresStore) ListWorkspaces(ctx context.Context, limit int) ([]TenancyWorkspace, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	rows, err := p.queryContext(
+		ctx,
+		`SELECT tenant_id, workspace_id, display_name, slug, created_at, updated_at
+		 FROM tenancy_workspaces
+		 WHERE tenant_id = $1
+		 ORDER BY created_at DESC
+		 LIMIT $2`,
+		scope.TenantID,
+		limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	workspaces := make([]TenancyWorkspace, 0, limit)
+	for rows.Next() {
+		var workspace TenancyWorkspace
+		if err := rows.Scan(
+			&workspace.TenantID,
+			&workspace.WorkspaceID,
+			&workspace.DisplayName,
+			&workspace.Slug,
+			&workspace.CreatedAt,
+			&workspace.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		workspaces = append(workspaces, workspace)
+	}
+	return workspaces, rows.Err()
+}
+
+// DeleteWorkspace deletes one scoped workspace by id.
+func (p *PostgresStore) DeleteWorkspace(ctx context.Context, workspaceID string) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	result, err := p.execContext(
+		ctx,
+		`DELETE FROM tenancy_workspaces
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2`,
+		scope.TenantID,
+		workspaceID,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// UpsertWorkspaceMember persists one scoped workspace member record.
+func (p *PostgresStore) UpsertWorkspaceMember(ctx context.Context, member TenancyWorkspaceMember) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	member.TenantID = scope.TenantID
+	if member.WorkspaceID == "" {
+		member.WorkspaceID = scope.WorkspaceID
+	}
+	normalized, err := NormalizeTenancyWorkspaceMemberForWrite(member)
+	if err != nil {
+		return err
+	}
+	_, err = p.execContext(
+		ctx,
+		`INSERT INTO tenancy_workspace_members (
+		     tenant_id, workspace_id, member_id, user_id, email, role, status, joined_at, updated_at
+		 )
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		 ON CONFLICT (tenant_id, workspace_id, member_id) DO UPDATE
+		 SET user_id = EXCLUDED.user_id,
+		     email = EXCLUDED.email,
+		     role = EXCLUDED.role,
+		     status = EXCLUDED.status,
+		     updated_at = EXCLUDED.updated_at`,
+		normalized.TenantID,
+		normalized.WorkspaceID,
+		normalized.MemberID,
+		normalized.UserID,
+		normalized.Email,
+		normalized.Role,
+		normalized.Status,
+		normalized.JoinedAt,
+		normalized.UpdatedAt,
+	)
+	return err
+}
+
+// GetWorkspaceMember returns one scoped workspace member.
+func (p *PostgresStore) GetWorkspaceMember(ctx context.Context, workspaceID string, memberID string) (TenancyWorkspaceMember, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyWorkspaceMember{}, err
+	}
+	row := p.queryRowContext(
+		ctx,
+		`SELECT tenant_id, workspace_id, member_id, user_id, email, role, status, joined_at, updated_at
+		 FROM tenancy_workspace_members
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND member_id = $3`,
+		scope.TenantID,
+		workspaceID,
+		memberID,
+	)
+	var member TenancyWorkspaceMember
+	if err := row.Scan(
+		&member.TenantID,
+		&member.WorkspaceID,
+		&member.MemberID,
+		&member.UserID,
+		&member.Email,
+		&member.Role,
+		&member.Status,
+		&member.JoinedAt,
+		&member.UpdatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return TenancyWorkspaceMember{}, ErrNotFound
+		}
+		return TenancyWorkspaceMember{}, err
+	}
+	return member, nil
+}
+
+// ListWorkspaceMembers lists members for one scoped workspace.
+func (p *PostgresStore) ListWorkspaceMembers(ctx context.Context, workspaceID string, limit int) ([]TenancyWorkspaceMember, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := p.queryContext(
+		ctx,
+		`SELECT tenant_id, workspace_id, member_id, user_id, email, role, status, joined_at, updated_at
+		 FROM tenancy_workspace_members
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		 ORDER BY joined_at ASC
+		 LIMIT $3`,
+		scope.TenantID,
+		workspaceID,
+		limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	members := make([]TenancyWorkspaceMember, 0, limit)
+	for rows.Next() {
+		var member TenancyWorkspaceMember
+		if err := rows.Scan(
+			&member.TenantID,
+			&member.WorkspaceID,
+			&member.MemberID,
+			&member.UserID,
+			&member.Email,
+			&member.Role,
+			&member.Status,
+			&member.JoinedAt,
+			&member.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		members = append(members, member)
+	}
+	return members, rows.Err()
+}
+
+// DeleteWorkspaceMember removes one scoped member.
+func (p *PostgresStore) DeleteWorkspaceMember(ctx context.Context, workspaceID string, memberID string) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	result, err := p.execContext(
+		ctx,
+		`DELETE FROM tenancy_workspace_members
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND member_id = $3`,
+		scope.TenantID,
+		workspaceID,
+		memberID,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// UpsertProject persists one scoped project record.
+func (p *PostgresStore) UpsertProject(ctx context.Context, project TenancyProject) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	project.TenantID = scope.TenantID
+	if project.WorkspaceID == "" {
+		project.WorkspaceID = scope.WorkspaceID
+	}
+	normalized, err := NormalizeTenancyProjectForWrite(project)
+	if err != nil {
+		return err
+	}
+	_, err = p.execContext(
+		ctx,
+		`INSERT INTO tenancy_projects (
+		     tenant_id, workspace_id, project_id, name, slug, description, archived_at, created_at, updated_at
+		 )
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		 ON CONFLICT (tenant_id, workspace_id, project_id) DO UPDATE
+		 SET name = EXCLUDED.name,
+		     slug = EXCLUDED.slug,
+		     description = EXCLUDED.description,
+		     archived_at = EXCLUDED.archived_at,
+		     updated_at = EXCLUDED.updated_at`,
+		normalized.TenantID,
+		normalized.WorkspaceID,
+		normalized.ProjectID,
+		normalized.Name,
+		normalized.Slug,
+		normalized.Description,
+		normalized.ArchivedAt,
+		normalized.CreatedAt,
+		normalized.UpdatedAt,
+	)
+	return err
+}
+
+// GetProject returns one scoped project.
+func (p *PostgresStore) GetProject(ctx context.Context, workspaceID string, projectID string) (TenancyProject, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyProject{}, err
+	}
+	row := p.queryRowContext(
+		ctx,
+		`SELECT tenant_id, workspace_id, project_id, name, slug, COALESCE(description, ''), archived_at, created_at, updated_at
+		 FROM tenancy_projects
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND project_id = $3`,
+		scope.TenantID,
+		workspaceID,
+		projectID,
+	)
+	var project TenancyProject
+	var archivedAt sql.NullTime
+	if err := row.Scan(
+		&project.TenantID,
+		&project.WorkspaceID,
+		&project.ProjectID,
+		&project.Name,
+		&project.Slug,
+		&project.Description,
+		&archivedAt,
+		&project.CreatedAt,
+		&project.UpdatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return TenancyProject{}, ErrNotFound
+		}
+		return TenancyProject{}, err
+	}
+	if archivedAt.Valid {
+		value := archivedAt.Time.UTC()
+		project.ArchivedAt = &value
+	}
+	return project, nil
+}
+
+// ListProjects returns scoped projects for a workspace.
+func (p *PostgresStore) ListProjects(ctx context.Context, workspaceID string, includeArchived bool, limit int) ([]TenancyProject, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	query := `SELECT tenant_id, workspace_id, project_id, name, slug, COALESCE(description, ''), archived_at, created_at, updated_at
+		 FROM tenancy_projects
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2`
+	args := []any{scope.TenantID, workspaceID}
+	if !includeArchived {
+		query += " AND archived_at IS NULL"
+	}
+	query += " ORDER BY created_at DESC LIMIT $3"
+	args = append(args, limit)
+	rows, err := p.queryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	projects := make([]TenancyProject, 0, limit)
+	for rows.Next() {
+		var project TenancyProject
+		var archivedAt sql.NullTime
+		if err := rows.Scan(
+			&project.TenantID,
+			&project.WorkspaceID,
+			&project.ProjectID,
+			&project.Name,
+			&project.Slug,
+			&project.Description,
+			&archivedAt,
+			&project.CreatedAt,
+			&project.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		if archivedAt.Valid {
+			value := archivedAt.Time.UTC()
+			project.ArchivedAt = &value
+		}
+		projects = append(projects, project)
+	}
+	return projects, rows.Err()
+}
+
+// DeleteProject removes one scoped project.
+func (p *PostgresStore) DeleteProject(ctx context.Context, workspaceID string, projectID string) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	result, err := p.execContext(
+		ctx,
+		`DELETE FROM tenancy_projects
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND project_id = $3`,
+		scope.TenantID,
+		workspaceID,
+		projectID,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/internal/db/postgres_tenancy_test.go
+++ b/internal/db/postgres_tenancy_test.go
@@ -1,0 +1,123 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestPostgresStoreUpsertAndGetOrganizationScoped(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	now := time.Now().UTC()
+
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO tenancy_organizations (tenant_id, display_name, slug, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5)
+		 ON CONFLICT (tenant_id) DO UPDATE
+		 SET display_name = EXCLUDED.display_name,
+		     slug = EXCLUDED.slug,
+		     updated_at = EXCLUDED.updated_at`)).
+		WithArgs("tenant-a", "Tenant A", "tenant-a", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := store.UpsertOrganization(ctx, TenancyOrganization{
+		DisplayName: "Tenant A",
+		Slug:        "tenant-a",
+	}); err != nil {
+		t.Fatalf("upsert organization: %v", err)
+	}
+
+	rows := sqlmock.NewRows([]string{"tenant_id", "display_name", "slug", "created_at", "updated_at"}).
+		AddRow("tenant-a", "Tenant A", "tenant-a", now, now)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, display_name, slug, created_at, updated_at
+		 FROM tenancy_organizations
+		 WHERE tenant_id = $1`)).
+		WithArgs("tenant-a").
+		WillReturnRows(rows)
+
+	organization, err := store.GetOrganization(ctx)
+	if err != nil {
+		t.Fatalf("get organization: %v", err)
+	}
+	if organization.TenantID != "tenant-a" {
+		t.Fatalf("unexpected organization: %+v", organization)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreWorkspaceScopeIsolation(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, workspace_id, display_name, slug, created_at, updated_at
+		 FROM tenancy_workspaces
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2`)).
+		WithArgs("tenant-a", "workspace-b").
+		WillReturnRows(sqlmock.NewRows([]string{"tenant_id", "workspace_id", "display_name", "slug", "created_at", "updated_at"}))
+
+	_, err = store.GetWorkspace(ctx, "workspace-b")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected scoped workspace lookup to fail with ErrNotFound, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreDeleteProjectScoped(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM tenancy_projects
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND project_id = $3`)).
+		WithArgs("tenant-a", "workspace-a", "project-1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := store.DeleteProject(ctx, "workspace-a", "project-1"); err != nil {
+		t.Fatalf("delete project: %v", err)
+	}
+
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM tenancy_projects
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND project_id = $3`)).
+		WithArgs("tenant-a", "workspace-a", "project-missing").
+		WillReturnResult(sqlmock.NewResult(1, 0))
+
+	if err := store.DeleteProject(ctx, "workspace-a", "project-missing"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for missing project delete, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -23,6 +23,7 @@ var ErrNotFound = errors.New("record not found")
 var ErrScopeRequired = errors.New("scope is required")
 
 var authzOwnerTeamPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
+var tenancySlugPattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 
 const (
 	ScanEventLevelDebug = "debug"
@@ -105,6 +106,20 @@ var validAuthzPolicyRolloutModes = map[string]struct{}{
 	AuthzPolicyRolloutModeDisabled: {},
 	AuthzPolicyRolloutModeShadow:   {},
 	AuthzPolicyRolloutModeEnforce:  {},
+}
+
+var validTenancyMemberRoles = map[string]struct{}{
+	"owner":   {},
+	"admin":   {},
+	"analyst": {},
+	"viewer":  {},
+}
+
+var validTenancyMemberStatuses = map[string]struct{}{
+	"invited":   {},
+	"active":    {},
+	"suspended": {},
+	"removed":   {},
 }
 
 // ScanRecord tracks persisted scan execution metadata.
@@ -273,6 +288,51 @@ type AuthzPolicyEvent struct {
 	Message     string         `json:"message,omitempty"`
 	Metadata    map[string]any `json:"metadata,omitempty"`
 	CreatedAt   time.Time      `json:"created_at"`
+}
+
+// TenancyOrganization stores one tenant root metadata record.
+type TenancyOrganization struct {
+	TenantID    string    `json:"tenant_id"`
+	DisplayName string    `json:"display_name"`
+	Slug        string    `json:"slug"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// TenancyWorkspace stores one workspace metadata record.
+type TenancyWorkspace struct {
+	TenantID    string    `json:"tenant_id"`
+	WorkspaceID string    `json:"workspace_id"`
+	DisplayName string    `json:"display_name"`
+	Slug        string    `json:"slug"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// TenancyWorkspaceMember stores one workspace member assignment.
+type TenancyWorkspaceMember struct {
+	TenantID    string    `json:"tenant_id"`
+	WorkspaceID string    `json:"workspace_id"`
+	MemberID    string    `json:"member_id"`
+	UserID      string    `json:"user_id"`
+	Email       string    `json:"email,omitempty"`
+	Role        string    `json:"role"`
+	Status      string    `json:"status"`
+	JoinedAt    time.Time `json:"joined_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// TenancyProject stores one project metadata record.
+type TenancyProject struct {
+	TenantID    string     `json:"tenant_id"`
+	WorkspaceID string     `json:"workspace_id"`
+	ProjectID   string     `json:"project_id"`
+	Name        string     `json:"name"`
+	Slug        string     `json:"slug"`
+	Description string     `json:"description,omitempty"`
+	ArchivedAt  *time.Time `json:"archived_at,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
 }
 
 // NormalizeScanEventLevel validates and normalizes event levels.
@@ -537,6 +597,170 @@ func containsInt(values []int, value int) bool {
 	return false
 }
 
+func validateTenancySlug(value, field string) error {
+	if len(value) > 63 {
+		return fmt.Errorf("%s must be 63 characters or fewer", field)
+	}
+	if !tenancySlugPattern.MatchString(value) {
+		return fmt.Errorf("%s must match %s", field, tenancySlugPattern.String())
+	}
+	return nil
+}
+
+// NormalizeTenancyOrganizationForWrite validates and canonicalizes organization metadata.
+func NormalizeTenancyOrganizationForWrite(organization TenancyOrganization) (TenancyOrganization, error) {
+	normalized := organization
+	normalized.TenantID = strings.TrimSpace(organization.TenantID)
+	if normalized.TenantID == "" {
+		return TenancyOrganization{}, fmt.Errorf("tenant id is required")
+	}
+	normalized.DisplayName = strings.TrimSpace(organization.DisplayName)
+	if normalized.DisplayName == "" {
+		return TenancyOrganization{}, fmt.Errorf("display name is required")
+	}
+	normalized.Slug = strings.ToLower(strings.TrimSpace(organization.Slug))
+	if normalized.Slug == "" {
+		return TenancyOrganization{}, fmt.Errorf("slug is required")
+	}
+	if err := validateTenancySlug(normalized.Slug, "slug"); err != nil {
+		return TenancyOrganization{}, err
+	}
+	if normalized.CreatedAt.IsZero() {
+		normalized.CreatedAt = time.Now().UTC()
+	} else {
+		normalized.CreatedAt = normalized.CreatedAt.UTC()
+	}
+	if normalized.UpdatedAt.IsZero() {
+		normalized.UpdatedAt = normalized.CreatedAt
+	} else {
+		normalized.UpdatedAt = normalized.UpdatedAt.UTC()
+	}
+	return normalized, nil
+}
+
+// NormalizeTenancyWorkspaceForWrite validates and canonicalizes workspace metadata.
+func NormalizeTenancyWorkspaceForWrite(workspace TenancyWorkspace) (TenancyWorkspace, error) {
+	normalized := workspace
+	normalized.TenantID = strings.TrimSpace(workspace.TenantID)
+	if normalized.TenantID == "" {
+		return TenancyWorkspace{}, fmt.Errorf("tenant id is required")
+	}
+	normalized.WorkspaceID = strings.TrimSpace(workspace.WorkspaceID)
+	if normalized.WorkspaceID == "" {
+		return TenancyWorkspace{}, fmt.Errorf("workspace id is required")
+	}
+	normalized.DisplayName = strings.TrimSpace(workspace.DisplayName)
+	if normalized.DisplayName == "" {
+		return TenancyWorkspace{}, fmt.Errorf("display name is required")
+	}
+	normalized.Slug = strings.ToLower(strings.TrimSpace(workspace.Slug))
+	if normalized.Slug == "" {
+		return TenancyWorkspace{}, fmt.Errorf("slug is required")
+	}
+	if err := validateTenancySlug(normalized.Slug, "slug"); err != nil {
+		return TenancyWorkspace{}, err
+	}
+	if normalized.CreatedAt.IsZero() {
+		normalized.CreatedAt = time.Now().UTC()
+	} else {
+		normalized.CreatedAt = normalized.CreatedAt.UTC()
+	}
+	if normalized.UpdatedAt.IsZero() {
+		normalized.UpdatedAt = normalized.CreatedAt
+	} else {
+		normalized.UpdatedAt = normalized.UpdatedAt.UTC()
+	}
+	return normalized, nil
+}
+
+// NormalizeTenancyWorkspaceMemberForWrite validates and canonicalizes workspace members.
+func NormalizeTenancyWorkspaceMemberForWrite(member TenancyWorkspaceMember) (TenancyWorkspaceMember, error) {
+	normalized := member
+	normalized.TenantID = strings.TrimSpace(member.TenantID)
+	if normalized.TenantID == "" {
+		return TenancyWorkspaceMember{}, fmt.Errorf("tenant id is required")
+	}
+	normalized.WorkspaceID = strings.TrimSpace(member.WorkspaceID)
+	if normalized.WorkspaceID == "" {
+		return TenancyWorkspaceMember{}, fmt.Errorf("workspace id is required")
+	}
+	normalized.MemberID = strings.TrimSpace(member.MemberID)
+	if normalized.MemberID == "" {
+		return TenancyWorkspaceMember{}, fmt.Errorf("member id is required")
+	}
+	normalized.UserID = strings.TrimSpace(member.UserID)
+	if normalized.UserID == "" {
+		return TenancyWorkspaceMember{}, fmt.Errorf("user id is required")
+	}
+	normalized.Email = strings.TrimSpace(member.Email)
+	normalized.Role = strings.ToLower(strings.TrimSpace(member.Role))
+	if _, ok := validTenancyMemberRoles[normalized.Role]; !ok {
+		return TenancyWorkspaceMember{}, fmt.Errorf("invalid member role")
+	}
+	normalized.Status = strings.ToLower(strings.TrimSpace(member.Status))
+	if normalized.Status == "" {
+		normalized.Status = "invited"
+	}
+	if _, ok := validTenancyMemberStatuses[normalized.Status]; !ok {
+		return TenancyWorkspaceMember{}, fmt.Errorf("invalid member status")
+	}
+	if normalized.JoinedAt.IsZero() {
+		normalized.JoinedAt = time.Now().UTC()
+	} else {
+		normalized.JoinedAt = normalized.JoinedAt.UTC()
+	}
+	if normalized.UpdatedAt.IsZero() {
+		normalized.UpdatedAt = normalized.JoinedAt
+	} else {
+		normalized.UpdatedAt = normalized.UpdatedAt.UTC()
+	}
+	return normalized, nil
+}
+
+// NormalizeTenancyProjectForWrite validates and canonicalizes project metadata.
+func NormalizeTenancyProjectForWrite(project TenancyProject) (TenancyProject, error) {
+	normalized := project
+	normalized.TenantID = strings.TrimSpace(project.TenantID)
+	if normalized.TenantID == "" {
+		return TenancyProject{}, fmt.Errorf("tenant id is required")
+	}
+	normalized.WorkspaceID = strings.TrimSpace(project.WorkspaceID)
+	if normalized.WorkspaceID == "" {
+		return TenancyProject{}, fmt.Errorf("workspace id is required")
+	}
+	normalized.ProjectID = strings.TrimSpace(project.ProjectID)
+	if normalized.ProjectID == "" {
+		return TenancyProject{}, fmt.Errorf("project id is required")
+	}
+	normalized.Name = strings.TrimSpace(project.Name)
+	if normalized.Name == "" {
+		return TenancyProject{}, fmt.Errorf("project name is required")
+	}
+	normalized.Slug = strings.ToLower(strings.TrimSpace(project.Slug))
+	if normalized.Slug == "" {
+		return TenancyProject{}, fmt.Errorf("project slug is required")
+	}
+	if err := validateTenancySlug(normalized.Slug, "project slug"); err != nil {
+		return TenancyProject{}, err
+	}
+	normalized.Description = strings.TrimSpace(project.Description)
+	if normalized.ArchivedAt != nil {
+		archived := normalized.ArchivedAt.UTC()
+		normalized.ArchivedAt = &archived
+	}
+	if normalized.CreatedAt.IsZero() {
+		normalized.CreatedAt = time.Now().UTC()
+	} else {
+		normalized.CreatedAt = normalized.CreatedAt.UTC()
+	}
+	if normalized.UpdatedAt.IsZero() {
+		normalized.UpdatedAt = normalized.CreatedAt
+	} else {
+		normalized.UpdatedAt = normalized.UpdatedAt.UTC()
+	}
+	return normalized, nil
+}
+
 // NormalizeAuthzPolicyEventForWrite validates and canonicalizes one immutable policy event.
 func NormalizeAuthzPolicyEventForWrite(event AuthzPolicyEvent) (AuthzPolicyEvent, error) {
 	normalized := event
@@ -633,6 +857,21 @@ type Store interface {
 	GetAuthzPolicyRollout(ctx context.Context, policySetID string) (AuthzPolicyRollout, error)
 	AppendAuthzPolicyEvent(ctx context.Context, event AuthzPolicyEvent) error
 	ListAuthzPolicyEvents(ctx context.Context, policySetID string, limit int) ([]AuthzPolicyEvent, error)
+	UpsertOrganization(ctx context.Context, organization TenancyOrganization) error
+	GetOrganization(ctx context.Context) (TenancyOrganization, error)
+	DeleteOrganization(ctx context.Context) error
+	UpsertWorkspace(ctx context.Context, workspace TenancyWorkspace) error
+	GetWorkspace(ctx context.Context, workspaceID string) (TenancyWorkspace, error)
+	ListWorkspaces(ctx context.Context, limit int) ([]TenancyWorkspace, error)
+	DeleteWorkspace(ctx context.Context, workspaceID string) error
+	UpsertWorkspaceMember(ctx context.Context, member TenancyWorkspaceMember) error
+	GetWorkspaceMember(ctx context.Context, workspaceID string, memberID string) (TenancyWorkspaceMember, error)
+	ListWorkspaceMembers(ctx context.Context, workspaceID string, limit int) ([]TenancyWorkspaceMember, error)
+	DeleteWorkspaceMember(ctx context.Context, workspaceID string, memberID string) error
+	UpsertProject(ctx context.Context, project TenancyProject) error
+	GetProject(ctx context.Context, workspaceID string, projectID string) (TenancyProject, error)
+	ListProjects(ctx context.Context, workspaceID string, includeArchived bool, limit int) ([]TenancyProject, error)
+	DeleteProject(ctx context.Context, workspaceID string, projectID string) error
 	ListIdentities(ctx context.Context, filter IdentityFilter, limit int) ([]domain.Identity, error)
 	ListRelationships(ctx context.Context, filter RelationshipFilter, limit int) ([]domain.Relationship, error)
 	AppendScanEvent(ctx context.Context, scanID string, level string, message string, metadata map[string]any) error

--- a/internal/db/tenancy_store_test.go
+++ b/internal/db/tenancy_store_test.go
@@ -1,0 +1,164 @@
+package db
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNormalizeTenancyOrganizationForWrite(t *testing.T) {
+	normalized, err := NormalizeTenancyOrganizationForWrite(TenancyOrganization{
+		TenantID:    " tenant-a ",
+		DisplayName: " Core Org ",
+		Slug:        " CORE ",
+	})
+	if err != nil {
+		t.Fatalf("normalize organization: %v", err)
+	}
+	if normalized.TenantID != "tenant-a" {
+		t.Fatalf("expected tenant id tenant-a, got %q", normalized.TenantID)
+	}
+	if normalized.Slug != "core" {
+		t.Fatalf("expected lower slug, got %q", normalized.Slug)
+	}
+	if normalized.CreatedAt.IsZero() || normalized.UpdatedAt.IsZero() {
+		t.Fatal("expected generated timestamps")
+	}
+
+	if _, err := NormalizeTenancyOrganizationForWrite(TenancyOrganization{}); err == nil {
+		t.Fatal("expected required field validation error")
+	}
+	if _, err := NormalizeTenancyOrganizationForWrite(TenancyOrganization{
+		TenantID:    "tenant-a",
+		DisplayName: "Tenant A",
+		Slug:        "tenant a",
+	}); err == nil {
+		t.Fatal("expected invalid organization slug format error")
+	}
+}
+
+func TestNormalizeTenancyWorkspaceMemberForWrite(t *testing.T) {
+	joinedAt := time.Date(2026, 4, 1, 10, 0, 0, 0, time.FixedZone("WAT", 1*60*60))
+	normalized, err := NormalizeTenancyWorkspaceMemberForWrite(TenancyWorkspaceMember{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		MemberID:    "member-1",
+		UserID:      "user-1",
+		Email:       " user@example.com ",
+		Role:        "ADMIN",
+		Status:      "ACTIVE",
+		JoinedAt:    joinedAt,
+	})
+	if err != nil {
+		t.Fatalf("normalize member: %v", err)
+	}
+	if normalized.Role != "admin" || normalized.Status != "active" {
+		t.Fatalf("expected normalized role/status, got role=%q status=%q", normalized.Role, normalized.Status)
+	}
+	if normalized.Email != "user@example.com" {
+		t.Fatalf("expected trimmed email, got %q", normalized.Email)
+	}
+	if normalized.JoinedAt.Location() != time.UTC {
+		t.Fatalf("expected UTC joined_at, got %v", normalized.JoinedAt.Location())
+	}
+
+	if _, err := NormalizeTenancyWorkspaceMemberForWrite(TenancyWorkspaceMember{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		MemberID:    "member-1",
+		UserID:      "user-1",
+		Role:        "invalid",
+		Status:      "active",
+	}); err == nil {
+		t.Fatal("expected invalid role error")
+	}
+}
+
+func TestNormalizeTenancyProjectForWrite(t *testing.T) {
+	archivedAt := time.Date(2026, 4, 2, 10, 0, 0, 0, time.FixedZone("WAT", 1*60*60))
+	normalized, err := NormalizeTenancyProjectForWrite(TenancyProject{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-a",
+		Name:        " Payments ",
+		Slug:        " PAYMENTS ",
+		ArchivedAt:  &archivedAt,
+	})
+	if err != nil {
+		t.Fatalf("normalize project: %v", err)
+	}
+	if normalized.Name != "Payments" || normalized.Slug != "payments" {
+		t.Fatalf("expected normalized name/slug, got name=%q slug=%q", normalized.Name, normalized.Slug)
+	}
+	if normalized.ArchivedAt == nil || normalized.ArchivedAt.Location() != time.UTC {
+		t.Fatalf("expected UTC archived_at, got %+v", normalized.ArchivedAt)
+	}
+
+	if _, err := NormalizeTenancyProjectForWrite(TenancyProject{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-a",
+		Name:        "",
+		Slug:        "payments",
+	}); err == nil {
+		t.Fatal("expected project name required error")
+	}
+	if _, err := NormalizeTenancyProjectForWrite(TenancyProject{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-a",
+		Name:        "Payments",
+		Slug:        "project/a",
+	}); err == nil {
+		t.Fatal("expected project slug format validation error")
+	}
+	if _, err := NormalizeTenancyProjectForWrite(TenancyProject{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-a",
+		Name:        "Payments",
+		Slug:        "project-",
+	}); err == nil {
+		t.Fatal("expected trailing hyphen slug to fail")
+	}
+	if _, err := NormalizeTenancyProjectForWrite(TenancyProject{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-a",
+		Name:        "Payments",
+		Slug:        "project--a",
+	}); err == nil {
+		t.Fatal("expected consecutive hyphen slug to fail")
+	}
+}
+
+func TestNormalizeTenancyWorkspaceForWrite(t *testing.T) {
+	now := time.Date(2026, 4, 4, 10, 0, 0, 0, time.FixedZone("WAT", 1*60*60))
+	normalized, err := NormalizeTenancyWorkspaceForWrite(TenancyWorkspace{
+		TenantID:    " tenant-a ",
+		WorkspaceID: " workspace-a ",
+		DisplayName: " Workspace A ",
+		Slug:        " WORKSPACE-A ",
+		CreatedAt:   now,
+	})
+	if err != nil {
+		t.Fatalf("normalize workspace: %v", err)
+	}
+	if normalized.TenantID != "tenant-a" || normalized.WorkspaceID != "workspace-a" {
+		t.Fatalf("expected trimmed tenant/workspace ids, got tenant=%q workspace=%q", normalized.TenantID, normalized.WorkspaceID)
+	}
+	if normalized.DisplayName != "Workspace A" || normalized.Slug != "workspace-a" {
+		t.Fatalf("expected normalized display name/slug, got display_name=%q slug=%q", normalized.DisplayName, normalized.Slug)
+	}
+	if normalized.CreatedAt.Location() != time.UTC || normalized.UpdatedAt.Location() != time.UTC {
+		t.Fatalf("expected UTC timestamps, got created_at=%v updated_at=%v", normalized.CreatedAt.Location(), normalized.UpdatedAt.Location())
+	}
+
+	if _, err := NormalizeTenancyWorkspaceForWrite(TenancyWorkspace{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		DisplayName: "Workspace A",
+		Slug:        "workspace/a",
+	}); err == nil {
+		t.Fatal("expected workspace slug format validation error")
+	}
+}


### PR DESCRIPTION
Fixes #544

## Summary
Implements **ITR-004** by adding tenancy CRUD store interfaces and scoped memory/postgres implementations for organizations, workspaces, members, and projects.

## Why This Fix
Tenancy data access needed a dedicated store layer with explicit scope boundaries before endpoint wiring. This PR introduces consistent scoped CRUD primitives and tests that assert tenant/workspace isolation behavior.

## What Changed
- Expanded `Store` contract in `internal/db/store.go` with scoped CRUD methods for:
  - organizations
  - workspaces
  - workspace members
  - projects
- Added normalization + validation helpers for tenancy write models in `internal/db/store.go`.
- Added memory-store implementation in `internal/db/memory_tenancy.go`.
- Added postgres-store implementation in `internal/db/postgres_tenancy.go`.
- Added tests:
  - normalization contract tests: `internal/db/tenancy_store_test.go`
  - in-memory CRUD + scope isolation: `internal/db/memory_tenancy_test.go`
  - postgres/sql behavior + scoped lookups/deletes: `internal/db/postgres_tenancy_test.go`
- Added docs note in `docs/persistence-artifacts.md` for tenancy CRUD persistence boundaries.

## Premium-Oriented Improvement (In Scope)
Project-scoped CRUD in the store layer enables premium, workspace-specific governance and workflow experiences (including differentiated project policy controls) without adding cross-tenant coupling.

## Self Review
- Verified scope is required and applied consistently to tenancy CRUD methods.
- Verified cross-scope fetches/deletes return `ErrNotFound` and do not leak records.
- Verified method signatures align with the newly introduced tenancy migration tables.
- Kept HTTP/API handler wiring out-of-scope per issue requirements.

## Validation
- `go test ./internal/db`
- `go test ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements ITR-004 by adding a scoped tenancy store with CRUD for organizations, workspaces, members, and projects in both in-memory and Postgres. Enforces tenant/workspace scope on all operations ahead of endpoint wiring.

- **New Features**
  - Extended `Store` with scoped CRUD and list APIs for organizations, workspaces, workspace members, and projects (projects support `includeArchived`; default limits and ordering applied).
  - Added write normalization: slug regex validation, role/status allowlists with default member status, and UTC timestamps.
  - Implemented in-memory and Postgres stores with strict scope checks; memory deletes cascade (workspace → members/projects); all missing or cross-scope access return `ErrNotFound`.
  - Added tests for normalization, scoped CRUD + isolation (memory), and SQL behavior incl. scoped selects/deletes (Postgres). Updated docs to cover `tenancy_*` operations and scope rules.

<sup>Written for commit 05c21b0d91b45a66d56226808009e47d78298917. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/593?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

