### PR TITLE
fix(domain): resolve PR-591 review threads

### DIFF
--- a/docs/domain-entities.md
+++ b/docs/domain-entities.md
@@ -37,14 +37,14 @@ This document defines the normalized multi-tenant app-mode entities introduced f
   - Trigger mode enum: `manual|scheduled|event|hybrid`
   - Validation: required ids/name, valid mode, `max_concurrent_scans > 0`.
 - `SuppressionPolicy`
-  - Fields: `id`, `workspace_id`, `project_id`, `name`, `scope`, `target`, `reason`, `expires_at`, `created_by`, `created_at`, `last_updated_at`
+  - Fields: `id`, `workspace_id`, `project_id`, `name`, `scope`, `target`, `reason`, `expires_at`, `created_by`, `created_at`, `updated_at`
   - Scope enum: `finding|rule|resource`
   - Validation: required ids, scope, target, reason, and creator id.
 
 ## Remediation Entity
 
 - `RemediationJob`
-  - Fields: `id`, `workspace_id`, `project_id`, `finding_id`, `type`, `status`, `requested_by`, `requested_at`, `started_at`, `completed_at`, `artifact_ref`, `error_message`, `last_updated_at`
+  - Fields: `id`, `workspace_id`, `project_id`, `finding_id`, `type`, `status`, `requested_by`, `requested_at`, `started_at`, `completed_at`, `artifact_ref`, `error_message`, `updated_at`
   - Type enum: `patch_template|create_fix_pr|ticket`
   - Status enum: `queued|running|succeeded|failed|canceled`
   - Transition contract:

--- a/internal/domain/appmode.go
+++ b/internal/domain/appmode.go
@@ -159,34 +159,34 @@ type ScanPolicy struct {
 
 // SuppressionPolicy models policy-based finding suppressions.
 type SuppressionPolicy struct {
-	ID            string           `json:"id"`
-	WorkspaceID   string           `json:"workspace_id"`
-	ProjectID     string           `json:"project_id"`
-	Name          string           `json:"name"`
-	Scope         SuppressionScope `json:"scope"`
-	Target        string           `json:"target"`
-	Reason        string           `json:"reason"`
-	ExpiresAt     *time.Time       `json:"expires_at,omitempty"`
-	CreatedBy     string           `json:"created_by"`
-	CreatedAt     time.Time        `json:"created_at"`
-	LastUpdatedAt time.Time        `json:"last_updated_at"`
+	ID          string           `json:"id"`
+	WorkspaceID string           `json:"workspace_id"`
+	ProjectID   string           `json:"project_id"`
+	Name        string           `json:"name"`
+	Scope       SuppressionScope `json:"scope"`
+	Target      string           `json:"target"`
+	Reason      string           `json:"reason"`
+	ExpiresAt   *time.Time       `json:"expires_at,omitempty"`
+	CreatedBy   string           `json:"created_by"`
+	CreatedAt   time.Time        `json:"created_at"`
+	UpdatedAt   time.Time        `json:"updated_at"`
 }
 
 // RemediationJob models one remediation execution request.
 type RemediationJob struct {
-	ID            string               `json:"id"`
-	WorkspaceID   string               `json:"workspace_id"`
-	ProjectID     string               `json:"project_id"`
-	FindingID     string               `json:"finding_id"`
-	Type          RemediationJobType   `json:"type"`
-	Status        RemediationJobStatus `json:"status"`
-	RequestedBy   string               `json:"requested_by"`
-	RequestedAt   time.Time            `json:"requested_at"`
-	StartedAt     *time.Time           `json:"started_at,omitempty"`
-	CompletedAt   *time.Time           `json:"completed_at,omitempty"`
-	ArtifactRef   string               `json:"artifact_ref,omitempty"`
-	ErrorMessage  string               `json:"error_message,omitempty"`
-	LastUpdatedAt time.Time            `json:"last_updated_at"`
+	ID           string               `json:"id"`
+	WorkspaceID  string               `json:"workspace_id"`
+	ProjectID    string               `json:"project_id"`
+	FindingID    string               `json:"finding_id"`
+	Type         RemediationJobType   `json:"type"`
+	Status       RemediationJobStatus `json:"status"`
+	RequestedBy  string               `json:"requested_by"`
+	RequestedAt  time.Time            `json:"requested_at"`
+	StartedAt    *time.Time           `json:"started_at,omitempty"`
+	CompletedAt  *time.Time           `json:"completed_at,omitempty"`
+	ArtifactRef  string               `json:"artifact_ref,omitempty"`
+	ErrorMessage string               `json:"error_message,omitempty"`
+	UpdatedAt    time.Time            `json:"updated_at"`
 }
 
 func (o Organization) Validate() error {
@@ -376,7 +376,7 @@ func CanTransitionConnectorStatus(from ConnectorStatus, to ConnectorStatus) bool
 
 func CanTransitionRemediationJobStatus(from RemediationJobStatus, to RemediationJobStatus) bool {
 	if from == to {
-		return true
+		return from != RemediationJobStatusSucceeded && from != RemediationJobStatusCanceled
 	}
 	switch from {
 	case RemediationJobStatusQueued:

--- a/internal/domain/appmode_test.go
+++ b/internal/domain/appmode_test.go
@@ -87,31 +87,31 @@ func TestAppModeEntitiesValidate(t *testing.T) {
 	}
 
 	suppression := SuppressionPolicy{
-		ID:            "suppression-1",
-		WorkspaceID:   workspace.ID,
-		ProjectID:     project.ID,
-		Name:          "temporary exception",
-		Scope:         SuppressionScopeRule,
-		Target:        "secret_exposure",
-		Reason:        "approved exception",
-		CreatedBy:     "admin-user",
-		CreatedAt:     now,
-		LastUpdatedAt: now,
+		ID:          "suppression-1",
+		WorkspaceID: workspace.ID,
+		ProjectID:   project.ID,
+		Name:        "temporary exception",
+		Scope:       SuppressionScopeRule,
+		Target:      "secret_exposure",
+		Reason:      "approved exception",
+		CreatedBy:   "admin-user",
+		CreatedAt:   now,
+		UpdatedAt:   now,
 	}
 	if err := suppression.Validate(); err != nil {
 		t.Fatalf("expected valid suppression policy, got %v", err)
 	}
 
 	remediation := RemediationJob{
-		ID:            "remediation-1",
-		WorkspaceID:   workspace.ID,
-		ProjectID:     project.ID,
-		FindingID:     "finding-123",
-		Type:          RemediationJobTypeCreateFixPR,
-		Status:        RemediationJobStatusQueued,
-		RequestedBy:   "admin-user",
-		RequestedAt:   now,
-		LastUpdatedAt: now,
+		ID:          "remediation-1",
+		WorkspaceID: workspace.ID,
+		ProjectID:   project.ID,
+		FindingID:   "finding-123",
+		Type:        RemediationJobTypeCreateFixPR,
+		Status:      RemediationJobStatusQueued,
+		RequestedBy: "admin-user",
+		RequestedAt: now,
+		UpdatedAt:   now,
 	}
 	if err := remediation.Validate(); err != nil {
 		t.Fatalf("expected valid remediation job, got %v", err)
@@ -194,15 +194,15 @@ func TestScanPolicyScheduledValidationRequiresCron(t *testing.T) {
 func TestRemediationJobValidationRequiresValidFindingID(t *testing.T) {
 	now := time.Now().UTC()
 	job := RemediationJob{
-		ID:            "remediation-1",
-		WorkspaceID:   "workspace-core",
-		ProjectID:     "project-core",
-		FindingID:     "finding bad",
-		Type:          RemediationJobTypeCreateFixPR,
-		Status:        RemediationJobStatusQueued,
-		RequestedBy:   "admin-user",
-		RequestedAt:   now,
-		LastUpdatedAt: now,
+		ID:          "remediation-1",
+		WorkspaceID: "workspace-core",
+		ProjectID:   "project-core",
+		FindingID:   "finding bad",
+		Type:        RemediationJobTypeCreateFixPR,
+		Status:      RemediationJobStatusQueued,
+		RequestedBy: "admin-user",
+		RequestedAt: now,
+		UpdatedAt:   now,
 	}
 	if err := job.Validate(); err == nil {
 		t.Fatal("expected remediation job finding_id validation to fail")
@@ -233,5 +233,11 @@ func TestRemediationStatusTransitions(t *testing.T) {
 	}
 	if !CanTransitionRemediationJobStatus(RemediationJobStatusFailed, RemediationJobStatusQueued) {
 		t.Fatal("expected failed -> queued transition to be valid for retry")
+	}
+	if CanTransitionRemediationJobStatus(RemediationJobStatusSucceeded, RemediationJobStatusSucceeded) {
+		t.Fatal("expected succeeded -> succeeded self-transition to be invalid")
+	}
+	if CanTransitionRemediationJobStatus(RemediationJobStatusCanceled, RemediationJobStatusCanceled) {
+		t.Fatal("expected canceled -> canceled self-transition to be invalid")
 	}
 }


### PR DESCRIPTION
Refs #542

## Summary
- rename app-mode `last_updated_at` fields to consistent `updated_at` on `SuppressionPolicy` and `RemediationJob`
- align domain tests and docs with the updated field names
- disallow terminal remediation self-transitions (`succeeded -> succeeded`, `canceled -> canceled`) while preserving other idempotent transitions

## Validation
- go test ./internal/domain

## Why separate PR
Direct pushes to `codex/itr-002-domain-models` are blocked by repository rules requiring PR-based updates.
