### PR TITLE
fix(db): enforce workspace scope boundaries in tenancy stores

### DIFF
--- a/docs/persistence-artifacts.md
+++ b/docs/persistence-artifacts.md
@@ -45,4 +45,4 @@ Tenancy and project management CRUD now has dedicated scoped store operations:
 - workspace members (`tenancy_workspace_members`)
 - projects (`tenancy_projects`)
 
-Scope boundaries are enforced by requiring request scope (`tenant_id`, `workspace_id`) in all store operations, and tests cover cross-scope access denial expectations.
+Scope boundaries are enforced by requiring request scope (`tenant_id`, `workspace_id`) in all store operations, and workspace-bound CRUD paths deny cross-workspace access even within the same tenant.

--- a/internal/db/memory_tenancy.go
+++ b/internal/db/memory_tenancy.go
@@ -81,9 +81,11 @@ func (m *MemoryStore) UpsertWorkspace(ctx context.Context, workspace TenancyWork
 		return err
 	}
 	workspace.TenantID = scope.TenantID
-	if workspace.WorkspaceID == "" {
-		workspace.WorkspaceID = scope.WorkspaceID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspace.WorkspaceID)
+	if err != nil {
+		return err
 	}
+	workspace.WorkspaceID = resolvedWorkspaceID
 	normalized, err := NormalizeTenancyWorkspaceForWrite(workspace)
 	if err != nil {
 		return err
@@ -104,7 +106,11 @@ func (m *MemoryStore) GetWorkspace(ctx context.Context, workspaceID string) (Ten
 	if err != nil {
 		return TenancyWorkspace{}, err
 	}
-	key := tenancyWorkspaceKey(scope.TenantID, workspaceID)
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return TenancyWorkspace{}, err
+	}
+	key := tenancyWorkspaceKey(scope.TenantID, resolvedWorkspaceID)
 	workspace, exists := m.workspaces[key]
 	if !exists {
 		return TenancyWorkspace{}, ErrNotFound
@@ -126,7 +132,7 @@ func (m *MemoryStore) ListWorkspaces(ctx context.Context, limit int) ([]TenancyW
 	}
 	workspaces := make([]TenancyWorkspace, 0, limit)
 	for _, workspace := range m.workspaces {
-		if workspace.TenantID != scope.TenantID {
+		if workspace.TenantID != scope.TenantID || workspace.WorkspaceID != scope.WorkspaceID {
 			continue
 		}
 		workspaces = append(workspaces, workspace)
@@ -147,7 +153,10 @@ func (m *MemoryStore) DeleteWorkspace(ctx context.Context, workspaceID string) e
 	if err != nil {
 		return err
 	}
-	normalizedWorkspaceID := strings.TrimSpace(workspaceID)
+	normalizedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return err
+	}
 	key := tenancyWorkspaceKey(scope.TenantID, normalizedWorkspaceID)
 	if _, exists := m.workspaces[key]; !exists {
 		return ErrNotFound
@@ -176,9 +185,11 @@ func (m *MemoryStore) UpsertWorkspaceMember(ctx context.Context, member TenancyW
 		return err
 	}
 	member.TenantID = scope.TenantID
-	if member.WorkspaceID == "" {
-		member.WorkspaceID = scope.WorkspaceID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, member.WorkspaceID)
+	if err != nil {
+		return err
 	}
+	member.WorkspaceID = resolvedWorkspaceID
 	normalized, err := NormalizeTenancyWorkspaceMemberForWrite(member)
 	if err != nil {
 		return err
@@ -199,7 +210,11 @@ func (m *MemoryStore) GetWorkspaceMember(ctx context.Context, workspaceID string
 	if err != nil {
 		return TenancyWorkspaceMember{}, err
 	}
-	member, exists := m.members[tenancyMemberKey(scope.TenantID, workspaceID, memberID)]
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return TenancyWorkspaceMember{}, err
+	}
+	member, exists := m.members[tenancyMemberKey(scope.TenantID, resolvedWorkspaceID, memberID)]
 	if !exists {
 		return TenancyWorkspaceMember{}, ErrNotFound
 	}
@@ -218,7 +233,10 @@ func (m *MemoryStore) ListWorkspaceMembers(ctx context.Context, workspaceID stri
 	if limit <= 0 {
 		limit = 100
 	}
-	normalizedWorkspaceID := strings.TrimSpace(workspaceID)
+	normalizedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	members := make([]TenancyWorkspaceMember, 0, limit)
 	for _, member := range m.members {
 		if member.TenantID != scope.TenantID || member.WorkspaceID != normalizedWorkspaceID {
@@ -242,7 +260,11 @@ func (m *MemoryStore) DeleteWorkspaceMember(ctx context.Context, workspaceID str
 	if err != nil {
 		return err
 	}
-	key := tenancyMemberKey(scope.TenantID, workspaceID, memberID)
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return err
+	}
+	key := tenancyMemberKey(scope.TenantID, resolvedWorkspaceID, memberID)
 	if _, exists := m.members[key]; !exists {
 		return ErrNotFound
 	}
@@ -260,9 +282,11 @@ func (m *MemoryStore) UpsertProject(ctx context.Context, project TenancyProject)
 		return err
 	}
 	project.TenantID = scope.TenantID
-	if project.WorkspaceID == "" {
-		project.WorkspaceID = scope.WorkspaceID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, project.WorkspaceID)
+	if err != nil {
+		return err
 	}
+	project.WorkspaceID = resolvedWorkspaceID
 	normalized, err := NormalizeTenancyProjectForWrite(project)
 	if err != nil {
 		return err
@@ -283,7 +307,11 @@ func (m *MemoryStore) GetProject(ctx context.Context, workspaceID string, projec
 	if err != nil {
 		return TenancyProject{}, err
 	}
-	project, exists := m.projects[tenancyProjectKey(scope.TenantID, workspaceID, projectID)]
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return TenancyProject{}, err
+	}
+	project, exists := m.projects[tenancyProjectKey(scope.TenantID, resolvedWorkspaceID, projectID)]
 	if !exists {
 		return TenancyProject{}, ErrNotFound
 	}
@@ -302,7 +330,10 @@ func (m *MemoryStore) ListProjects(ctx context.Context, workspaceID string, incl
 	if limit <= 0 {
 		limit = 100
 	}
-	normalizedWorkspaceID := strings.TrimSpace(workspaceID)
+	normalizedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	projects := make([]TenancyProject, 0, limit)
 	for _, project := range m.projects {
 		if project.TenantID != scope.TenantID || project.WorkspaceID != normalizedWorkspaceID {
@@ -329,7 +360,11 @@ func (m *MemoryStore) DeleteProject(ctx context.Context, workspaceID string, pro
 	if err != nil {
 		return err
 	}
-	key := tenancyProjectKey(scope.TenantID, workspaceID, projectID)
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return err
+	}
+	key := tenancyProjectKey(scope.TenantID, resolvedWorkspaceID, projectID)
 	if _, exists := m.projects[key]; !exists {
 		return ErrNotFound
 	}

--- a/internal/db/memory_tenancy_test.go
+++ b/internal/db/memory_tenancy_test.go
@@ -92,6 +92,7 @@ func TestMemoryStoreTenancyCRUD(t *testing.T) {
 func TestMemoryStoreTenancyScopeIsolation(t *testing.T) {
 	store := NewMemoryStore()
 	tenantA := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	tenantAWorkspaceB := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-b"})
 	tenantB := WithScope(context.Background(), Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
 
 	if err := store.UpsertOrganization(tenantA, TenancyOrganization{
@@ -124,6 +125,12 @@ func TestMemoryStoreTenancyScopeIsolation(t *testing.T) {
 	}
 	if _, err := store.GetProject(tenantB, "workspace-a", "project-a"); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected tenant-b project to be isolated, got %v", err)
+	}
+	if _, err := store.GetWorkspace(tenantAWorkspaceB, "workspace-a"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected cross-workspace lookup to be denied, got %v", err)
+	}
+	if _, err := store.GetProject(tenantAWorkspaceB, "workspace-a", "project-a"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected cross-workspace project lookup to be denied, got %v", err)
 	}
 }
 

--- a/internal/db/postgres_tenancy.go
+++ b/internal/db/postgres_tenancy.go
@@ -95,9 +95,11 @@ func (p *PostgresStore) UpsertWorkspace(ctx context.Context, workspace TenancyWo
 		return err
 	}
 	workspace.TenantID = scope.TenantID
-	if workspace.WorkspaceID == "" {
-		workspace.WorkspaceID = scope.WorkspaceID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspace.WorkspaceID)
+	if err != nil {
+		return err
 	}
+	workspace.WorkspaceID = resolvedWorkspaceID
 	normalized, err := NormalizeTenancyWorkspaceForWrite(workspace)
 	if err != nil {
 		return err
@@ -126,6 +128,10 @@ func (p *PostgresStore) GetWorkspace(ctx context.Context, workspaceID string) (T
 	if err != nil {
 		return TenancyWorkspace{}, err
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return TenancyWorkspace{}, err
+	}
 	row := p.queryRowContext(
 		ctx,
 		`SELECT tenant_id, workspace_id, display_name, slug, created_at, updated_at
@@ -133,7 +139,7 @@ func (p *PostgresStore) GetWorkspace(ctx context.Context, workspaceID string) (T
 		 WHERE tenant_id = $1
 		   AND workspace_id = $2`,
 		scope.TenantID,
-		workspaceID,
+		resolvedWorkspaceID,
 	)
 	var workspace TenancyWorkspace
 	if err := row.Scan(
@@ -161,14 +167,20 @@ func (p *PostgresStore) ListWorkspaces(ctx context.Context, limit int) ([]Tenanc
 	if limit <= 0 {
 		limit = 20
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, scope.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
 	rows, err := p.queryContext(
 		ctx,
 		`SELECT tenant_id, workspace_id, display_name, slug, created_at, updated_at
 		 FROM tenancy_workspaces
 		 WHERE tenant_id = $1
+		   AND workspace_id = $2
 		 ORDER BY created_at DESC
-		 LIMIT $2`,
+		 LIMIT $3`,
 		scope.TenantID,
+		resolvedWorkspaceID,
 		limit,
 	)
 	if err != nil {
@@ -200,13 +212,17 @@ func (p *PostgresStore) DeleteWorkspace(ctx context.Context, workspaceID string)
 	if err != nil {
 		return err
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return err
+	}
 	result, err := p.execContext(
 		ctx,
 		`DELETE FROM tenancy_workspaces
 		 WHERE tenant_id = $1
 		   AND workspace_id = $2`,
 		scope.TenantID,
-		workspaceID,
+		resolvedWorkspaceID,
 	)
 	if err != nil {
 		return err
@@ -228,9 +244,11 @@ func (p *PostgresStore) UpsertWorkspaceMember(ctx context.Context, member Tenanc
 		return err
 	}
 	member.TenantID = scope.TenantID
-	if member.WorkspaceID == "" {
-		member.WorkspaceID = scope.WorkspaceID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, member.WorkspaceID)
+	if err != nil {
+		return err
 	}
+	member.WorkspaceID = resolvedWorkspaceID
 	normalized, err := NormalizeTenancyWorkspaceMemberForWrite(member)
 	if err != nil {
 		return err
@@ -266,6 +284,10 @@ func (p *PostgresStore) GetWorkspaceMember(ctx context.Context, workspaceID stri
 	if err != nil {
 		return TenancyWorkspaceMember{}, err
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return TenancyWorkspaceMember{}, err
+	}
 	row := p.queryRowContext(
 		ctx,
 		`SELECT tenant_id, workspace_id, member_id, user_id, email, role, status, joined_at, updated_at
@@ -274,7 +296,7 @@ func (p *PostgresStore) GetWorkspaceMember(ctx context.Context, workspaceID stri
 		   AND workspace_id = $2
 		   AND member_id = $3`,
 		scope.TenantID,
-		workspaceID,
+		resolvedWorkspaceID,
 		memberID,
 	)
 	var member TenancyWorkspaceMember
@@ -306,6 +328,10 @@ func (p *PostgresStore) ListWorkspaceMembers(ctx context.Context, workspaceID st
 	if limit <= 0 {
 		limit = 100
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	rows, err := p.queryContext(
 		ctx,
 		`SELECT tenant_id, workspace_id, member_id, user_id, email, role, status, joined_at, updated_at
@@ -315,7 +341,7 @@ func (p *PostgresStore) ListWorkspaceMembers(ctx context.Context, workspaceID st
 		 ORDER BY joined_at ASC
 		 LIMIT $3`,
 		scope.TenantID,
-		workspaceID,
+		resolvedWorkspaceID,
 		limit,
 	)
 	if err != nil {
@@ -350,6 +376,10 @@ func (p *PostgresStore) DeleteWorkspaceMember(ctx context.Context, workspaceID s
 	if err != nil {
 		return err
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return err
+	}
 	result, err := p.execContext(
 		ctx,
 		`DELETE FROM tenancy_workspace_members
@@ -357,7 +387,7 @@ func (p *PostgresStore) DeleteWorkspaceMember(ctx context.Context, workspaceID s
 		   AND workspace_id = $2
 		   AND member_id = $3`,
 		scope.TenantID,
-		workspaceID,
+		resolvedWorkspaceID,
 		memberID,
 	)
 	if err != nil {
@@ -380,9 +410,11 @@ func (p *PostgresStore) UpsertProject(ctx context.Context, project TenancyProjec
 		return err
 	}
 	project.TenantID = scope.TenantID
-	if project.WorkspaceID == "" {
-		project.WorkspaceID = scope.WorkspaceID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, project.WorkspaceID)
+	if err != nil {
+		return err
 	}
+	project.WorkspaceID = resolvedWorkspaceID
 	normalized, err := NormalizeTenancyProjectForWrite(project)
 	if err != nil {
 		return err
@@ -418,6 +450,10 @@ func (p *PostgresStore) GetProject(ctx context.Context, workspaceID string, proj
 	if err != nil {
 		return TenancyProject{}, err
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return TenancyProject{}, err
+	}
 	row := p.queryRowContext(
 		ctx,
 		`SELECT tenant_id, workspace_id, project_id, name, slug, COALESCE(description, ''), archived_at, created_at, updated_at
@@ -426,7 +462,7 @@ func (p *PostgresStore) GetProject(ctx context.Context, workspaceID string, proj
 		   AND workspace_id = $2
 		   AND project_id = $3`,
 		scope.TenantID,
-		workspaceID,
+		resolvedWorkspaceID,
 		projectID,
 	)
 	var project TenancyProject
@@ -463,11 +499,15 @@ func (p *PostgresStore) ListProjects(ctx context.Context, workspaceID string, in
 	if limit <= 0 {
 		limit = 100
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	query := `SELECT tenant_id, workspace_id, project_id, name, slug, COALESCE(description, ''), archived_at, created_at, updated_at
 		 FROM tenancy_projects
 		 WHERE tenant_id = $1
 		   AND workspace_id = $2`
-	args := []any{scope.TenantID, workspaceID}
+	args := []any{scope.TenantID, resolvedWorkspaceID}
 	if !includeArchived {
 		query += " AND archived_at IS NULL"
 	}
@@ -511,6 +551,10 @@ func (p *PostgresStore) DeleteProject(ctx context.Context, workspaceID string, p
 	if err != nil {
 		return err
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return err
+	}
 	result, err := p.execContext(
 		ctx,
 		`DELETE FROM tenancy_projects
@@ -518,7 +562,7 @@ func (p *PostgresStore) DeleteProject(ctx context.Context, workspaceID string, p
 		   AND workspace_id = $2
 		   AND project_id = $3`,
 		scope.TenantID,
-		workspaceID,
+		resolvedWorkspaceID,
 		projectID,
 	)
 	if err != nil {

--- a/internal/db/postgres_tenancy_test.go
+++ b/internal/db/postgres_tenancy_test.go
@@ -68,18 +68,35 @@ func TestPostgresStoreWorkspaceScopeIsolation(t *testing.T) {
 	store := NewPostgresStoreWithDB(db)
 	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, workspace_id, display_name, slug, created_at, updated_at
-		 FROM tenancy_workspaces
-		 WHERE tenant_id = $1
-		   AND workspace_id = $2`)).
-		WithArgs("tenant-a", "workspace-b").
-		WillReturnRows(sqlmock.NewRows([]string{"tenant_id", "workspace_id", "display_name", "slug", "created_at", "updated_at"}))
-
 	_, err = store.GetWorkspace(ctx, "workspace-b")
 	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected scoped workspace lookup to fail with ErrNotFound, got %v", err)
 	}
 
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreUpsertProjectRejectsCrossWorkspaceScope(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+
+	err = store.UpsertProject(ctx, TenancyProject{
+		WorkspaceID: "workspace-b",
+		ProjectID:   "project-1",
+		Name:        "Project 1",
+		Slug:        "project-1",
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for cross-workspace upsert, got %v", err)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
 	}

--- a/internal/db/scope.go
+++ b/internal/db/scope.go
@@ -88,3 +88,17 @@ func MatchScope(scope Scope, tenantID string, workspaceID string) bool {
 	return strings.TrimSpace(tenantID) == normalized.TenantID &&
 		strings.TrimSpace(workspaceID) == normalized.WorkspaceID
 }
+
+// ResolveScopedWorkspaceID normalizes one workspace identifier and enforces
+// that it remains within the active request scope.
+func ResolveScopedWorkspaceID(scope Scope, workspaceID string) (string, error) {
+	normalizedScope := scope.Normalize()
+	resolved := strings.TrimSpace(workspaceID)
+	if resolved == "" {
+		resolved = normalizedScope.WorkspaceID
+	}
+	if resolved != normalizedScope.WorkspaceID {
+		return "", ErrNotFound
+	}
+	return resolved, nil
+}


### PR DESCRIPTION
## Summary
This PR patches scope-enforcement gaps in the tenancy store layer identified during review of ITR-004 (#593).

It enforces strict workspace scoping for tenancy CRUD paths in both memory and Postgres stores, so cross-workspace access within the same tenant is denied unless the active scope matches.

## Why
In #593, several workspace-bound methods accepted arbitrary `workspace_id` values and enforced only tenant scope.
That creates a risk of same-tenant cross-workspace access if upper-layer checks are bypassed or regress later.

## Changes
- Added scope helper:
  - `ResolveScopedWorkspaceID(scope, workspaceID)` in `internal/db/scope.go`
- Applied workspace scope enforcement in:
  - `internal/db/memory_tenancy.go`
  - `internal/db/postgres_tenancy.go`
- Updated tests to prove cross-workspace denial:
  - `internal/db/memory_tenancy_test.go`
  - `internal/db/postgres_tenancy_test.go`
- Updated docs to align with actual enforced behavior:
  - `docs/persistence-artifacts.md`

## Behavior after patch
- Workspace-bound CRUD methods now deny access when requested workspace differs from active scoped workspace.
- Calls with empty workspace IDs resolve to scoped workspace.
- Same-tenant but different-workspace access returns `ErrNotFound` (consistent with existing scope/isolation behavior).

## Validation
- `go test ./internal/db -count=1` ✅
- `go test ./... -count=1` ✅

## Notes
- This PR is intentionally narrow and targets the tenancy store boundary only.
- No API contract changes are introduced here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce strict workspace scoping in tenancy stores (memory and Postgres) so workspace-bound CRUD only runs within the active scoped workspace. Addresses scope gaps identified in ITR-004 and prevents same-tenant cross-workspace access.

- **Bug Fixes**
  - Apply scoped `workspace_id` checks to workspace, member, and project CRUD and listing.
  - Add `ResolveScopedWorkspaceID(scope, workspaceID)` to normalize IDs, resolve empty to scope, and return `ErrNotFound` on cross-workspace usage.
  - Update tests for cross-workspace denial and refresh docs to reflect the enforced behavior.

<sup>Written for commit 5f38eb7439171b70d4783fccc85dc59317323686. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/596?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



No issue: follow-up scope-enforcement hardening from ITR-004 review
