### PR TITLE
Codex/itr 004 tenancy store

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - Repository exposure scanner: `repo-exposure.md`
 - Execution model (API enqueue + worker processing): `execution-model.md`
 - Configuration reference: `configuration-reference.md`
+- Domain entity model: `domain-entities.md`
 
 ## Release and supply chain track
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -57,6 +57,22 @@ Cross-provider:
 - `IDENTRAIL_LOCK_BACKEND` (`auto|inmemory|postgres`)
 - `IDENTRAIL_LOCK_NAMESPACE`
 
+## App-Mode Feature Flags
+
+All app-mode feature flags are disabled by default and must be explicitly enabled.
+
+- `IDENTRAIL_APP_MODE_ENABLED` (default: `false`)
+- `IDENTRAIL_APP_MODE_CONNECTORS_ENABLED` (default: `false`)
+- `IDENTRAIL_APP_MODE_SCHEDULER_ENABLED` (default: `false`)
+- `IDENTRAIL_APP_MODE_REMEDIATION_ENABLED` (default: `false`)
+- `IDENTRAIL_APP_MODE_PREMIUM_ENABLED` (default: `false`)
+- `IDENTRAIL_APP_MODE_PREMIUM_REPORTS_ENABLED` (default: `false`)
+- `IDENTRAIL_APP_MODE_PREMIUM_AUTOFIX_ENABLED` (default: `false`)
+- `IDENTRAIL_APP_MODE_ROLLOUT_ENABLED` (default: `false`)
+- `IDENTRAIL_APP_MODE_ROLLOUT_CANARY_PERCENT` (`0..100`, default: `0`)
+- `IDENTRAIL_APP_MODE_ROLLOUT_TENANT_ALLOWLIST` (CSV tenant ids)
+- `IDENTRAIL_APP_MODE_ROLLOUT_WORKSPACE_ALLOWLIST` (CSV workspace ids)
+
 ## Repository Exposure
 
 - `IDENTRAIL_REPO_SCAN_ENABLED`

--- a/docs/domain-entities.md
+++ b/docs/domain-entities.md
@@ -1,0 +1,63 @@
+# Domain Entity Model (App Mode)
+
+This document defines the normalized multi-tenant app-mode entities introduced for tenancy, project, connector, policy, and remediation workflows.
+
+## Tenancy Core
+
+- `Organization`
+  - Fields: `id`, `name`, `slug`, `created_at`, `updated_at`
+  - Validation: non-empty id/name/slug with identifier-safe formatting.
+- `Workspace`
+  - Fields: `id`, `organization_id`, `name`, `slug`, `created_at`, `updated_at`
+  - Validation: required org reference and identifier-safe ids/slugs.
+- `WorkspaceMember`
+  - Fields: `id`, `workspace_id`, `user_id`, `email`, `role`, `status`, `joined_at`, `updated_at`
+  - Role enum: `owner|admin|analyst|viewer`
+  - Status enum: `invited|active|suspended|removed`
+
+## Project and Connector
+
+- `Project`
+  - Fields: `id`, `workspace_id`, `name`, `slug`, `description`, `archived_at`, `created_at`, `updated_at`
+  - Validation: required workspace and project identity fields.
+- `Connector`
+  - Fields: `id`, `workspace_id`, `project_id`, `type`, `display_name`, `status`, `last_sync_at`, `created_at`, `updated_at`
+  - Type enum: `github|aws|kubernetes`
+  - Status enum: `pending|active|degraded|disconnected`
+  - Transition contract:
+    - `pending -> active|degraded|disconnected`
+    - `active -> degraded|disconnected`
+    - `degraded -> active|disconnected`
+    - `disconnected -> pending|active`
+
+## Policy Entities
+
+- `ScanPolicy`
+  - Fields: `id`, `workspace_id`, `project_id`, `name`, `enabled`, `trigger_mode`, `cron`, `max_concurrent_scans`, `created_at`, `updated_at`
+  - Trigger mode enum: `manual|scheduled|event|hybrid`
+  - Validation: required ids/name, valid mode, `max_concurrent_scans > 0`.
+- `SuppressionPolicy`
+  - Fields: `id`, `workspace_id`, `project_id`, `name`, `scope`, `target`, `reason`, `expires_at`, `created_by`, `created_at`, `last_updated_at`
+  - Scope enum: `finding|rule|resource`
+  - Validation: required ids, scope, target, reason, and creator id.
+
+## Remediation Entity
+
+- `RemediationJob`
+  - Fields: `id`, `workspace_id`, `project_id`, `finding_id`, `type`, `status`, `requested_by`, `requested_at`, `started_at`, `completed_at`, `artifact_ref`, `error_message`, `last_updated_at`
+  - Type enum: `patch_template|create_fix_pr|ticket`
+  - Status enum: `queued|running|succeeded|failed|canceled`
+  - Transition contract:
+    - `queued -> running|canceled`
+    - `running -> succeeded|failed|canceled`
+    - `failed -> queued` (retry)
+    - `succeeded|canceled` are terminal
+
+## Contracts and Validation
+
+- All entities use snake_case JSON tags for API and persistence contract stability.
+- Validation and transition helpers live in:
+  - `internal/domain/appmode.go`
+- Validation and transition tests live in:
+  - `internal/domain/appmode_test.go`
+  - `internal/domain/json_tags_test.go`

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -56,6 +56,7 @@ Current sequence in `migrations/`:
 10. `000009_authz_abac_rebac_data` - central authz ABAC/REBAC data model
 11. `000010_authz_policy_lifecycle_controls` - policy lifecycle primitives
 12. `000011_authz_policy_rollout_staged_controls` - staged rollout controls
+13. `000012_tenancy_core_entities` - organization/workspace/member/project tenancy core
 
 Notes:
 - Each migration has matching `.up.sql` and `.down.sql` files.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -10,6 +10,8 @@ servers:
 tags:
   - name: Health
   - name: Authorization
+  - name: Tenancy
+  - name: ProjectManagement
   - name: Findings
   - name: Scans
   - name: Explorer
@@ -169,6 +171,389 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /v1/organizations/current:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+    get:
+      tags: [Tenancy]
+      summary: Get current organization
+      operationId: getCurrentOrganization
+      responses:
+        "200":
+          description: Current organization record
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  organization:
+                    $ref: "#/components/schemas/Organization"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    put:
+      tags: [Tenancy]
+      summary: Upsert current organization
+      operationId: upsertCurrentOrganization
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OrganizationUpsertRequest"
+      responses:
+        "200":
+          description: Organization upserted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  organization:
+                    $ref: "#/components/schemas/Organization"
+        "400":
+          description: Invalid organization payload
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /v1/workspaces:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+    get:
+      tags: [Tenancy]
+      summary: List workspaces for current tenant
+      operationId: listWorkspaces
+      parameters:
+        - $ref: "#/components/parameters/limit"
+        - $ref: "#/components/parameters/cursor"
+        - $ref: "#/components/parameters/sortBy"
+        - $ref: "#/components/parameters/sortOrder"
+      responses:
+        "200":
+          description: Workspace page
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkspacePage"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    post:
+      tags: [Tenancy]
+      summary: Create or update workspace
+      operationId: upsertWorkspace
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkspaceUpsertRequest"
+      responses:
+        "200":
+          description: Workspace upserted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  workspace:
+                    $ref: "#/components/schemas/Workspace"
+        "400":
+          description: Invalid workspace payload
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /v1/workspaces/{workspace_id}:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+    get:
+      tags: [Tenancy]
+      summary: Get workspace
+      operationId: getWorkspace
+      parameters:
+        - in: path
+          name: workspace_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Workspace detail
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  workspace:
+                    $ref: "#/components/schemas/Workspace"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      tags: [Tenancy]
+      summary: Delete workspace
+      operationId: deleteWorkspace
+      parameters:
+        - in: path
+          name: workspace_id
+          required: true
+          schema: { type: string }
+      responses:
+        "204":
+          description: Workspace deleted
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /v1/workspaces/{workspace_id}/members:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+    get:
+      tags: [Tenancy]
+      summary: List workspace members
+      operationId: listWorkspaceMembers
+      parameters:
+        - in: path
+          name: workspace_id
+          required: true
+          schema: { type: string }
+        - $ref: "#/components/parameters/limit"
+        - in: query
+          name: role
+          schema:
+            $ref: "#/components/schemas/WorkspaceMemberRole"
+        - in: query
+          name: status
+          schema:
+            $ref: "#/components/schemas/WorkspaceMemberStatus"
+      responses:
+        "200":
+          description: Workspace member page
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkspaceMemberPage"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    post:
+      tags: [Tenancy]
+      summary: Create or update workspace member
+      operationId: upsertWorkspaceMember
+      parameters:
+        - in: path
+          name: workspace_id
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkspaceMemberUpsertRequest"
+      responses:
+        "200":
+          description: Workspace member upserted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  member:
+                    $ref: "#/components/schemas/WorkspaceMember"
+        "400":
+          description: Invalid member payload
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /v1/workspaces/{workspace_id}/members/{member_id}:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+    get:
+      tags: [Tenancy]
+      summary: Get workspace member
+      operationId: getWorkspaceMember
+      parameters:
+        - in: path
+          name: workspace_id
+          required: true
+          schema: { type: string }
+        - in: path
+          name: member_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Workspace member detail
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  member:
+                    $ref: "#/components/schemas/WorkspaceMember"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      tags: [Tenancy]
+      summary: Delete workspace member
+      operationId: deleteWorkspaceMember
+      parameters:
+        - in: path
+          name: workspace_id
+          required: true
+          schema: { type: string }
+        - in: path
+          name: member_id
+          required: true
+          schema: { type: string }
+      responses:
+        "204":
+          description: Member deleted
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /v1/workspaces/{workspace_id}/projects:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+    get:
+      tags: [ProjectManagement]
+      summary: List workspace projects
+      operationId: listProjects
+      parameters:
+        - in: path
+          name: workspace_id
+          required: true
+          schema: { type: string }
+        - $ref: "#/components/parameters/limit"
+        - $ref: "#/components/parameters/cursor"
+        - $ref: "#/components/parameters/sortBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - in: query
+          name: include_archived
+          schema:
+            type: boolean
+            default: false
+      responses:
+        "200":
+          description: Project page
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectPage"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    post:
+      tags: [ProjectManagement]
+      summary: Create or update workspace project
+      operationId: upsertProject
+      parameters:
+        - in: path
+          name: workspace_id
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProjectUpsertRequest"
+      responses:
+        "200":
+          description: Project upserted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  project:
+                    $ref: "#/components/schemas/Project"
+        "400":
+          description: Invalid project payload
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /v1/workspaces/{workspace_id}/projects/{project_id}:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+    get:
+      tags: [ProjectManagement]
+      summary: Get workspace project
+      operationId: getProject
+      parameters:
+        - in: path
+          name: workspace_id
+          required: true
+          schema: { type: string }
+        - in: path
+          name: project_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Project detail
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  project:
+                    $ref: "#/components/schemas/Project"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      tags: [ProjectManagement]
+      summary: Delete workspace project
+      operationId: deleteProject
+      parameters:
+        - in: path
+          name: workspace_id
+          required: true
+          schema: { type: string }
+        - in: path
+          name: project_id
+          required: true
+          schema: { type: string }
+      responses:
+        "204":
+          description: Project deleted
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /v1/findings:
     parameters:
       - $ref: "#/components/parameters/scopeTenantID"
@@ -737,6 +1122,137 @@ components:
       type: object
       properties:
         error:
+          type: string
+    Organization:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        display_name: { type: string }
+        slug: { type: string }
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    OrganizationUpsertRequest:
+      type: object
+      required: [display_name, slug]
+      properties:
+        display_name: { type: string }
+        slug: { type: string }
+    Workspace:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        display_name: { type: string }
+        slug: { type: string }
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    WorkspaceUpsertRequest:
+      type: object
+      required: [workspace_id, display_name, slug]
+      properties:
+        workspace_id: { type: string }
+        display_name: { type: string }
+        slug: { type: string }
+    WorkspaceMemberRole:
+      type: string
+      enum: [owner, admin, analyst, viewer]
+    WorkspaceMemberStatus:
+      type: string
+      enum: [invited, active, suspended, removed]
+    WorkspaceMember:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        member_id: { type: string }
+        user_id: { type: string }
+        email: { type: string }
+        role:
+          $ref: "#/components/schemas/WorkspaceMemberRole"
+        status:
+          $ref: "#/components/schemas/WorkspaceMemberStatus"
+        joined_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    WorkspaceMemberUpsertRequest:
+      type: object
+      required: [member_id, user_id, role, status]
+      properties:
+        member_id: { type: string }
+        user_id: { type: string }
+        email: { type: string }
+        role:
+          $ref: "#/components/schemas/WorkspaceMemberRole"
+        status:
+          $ref: "#/components/schemas/WorkspaceMemberStatus"
+    Project:
+      type: object
+      properties:
+        tenant_id: { type: string }
+        workspace_id: { type: string }
+        project_id: { type: string }
+        name: { type: string }
+        slug: { type: string }
+        description: { type: string }
+        archived_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    ProjectUpsertRequest:
+      type: object
+      required: [project_id, name, slug]
+      properties:
+        project_id: { type: string }
+        name: { type: string }
+        slug: { type: string }
+        description: { type: string }
+        archived_at:
+          type: string
+          format: date-time
+          nullable: true
+    WorkspacePage:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Workspace"
+        next_cursor:
+          type: string
+    WorkspaceMemberPage:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkspaceMember"
+        next_cursor:
+          type: string
+    ProjectPage:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Project"
+        next_cursor:
           type: string
     PolicyStage:
       type: string

--- a/docs/persistence-artifacts.md
+++ b/docs/persistence-artifacts.md
@@ -35,3 +35,14 @@ This allows safe reruns and repeated persistence calls without duplicate row gro
 3. upsert artifacts
 4. upsert findings
 5. complete scan with counts/status
+
+## Tenancy CRUD Persistence
+
+Tenancy and project management CRUD now has dedicated scoped store operations:
+
+- organizations (`tenancy_organizations`)
+- workspaces (`tenancy_workspaces`)
+- workspace members (`tenancy_workspace_members`)
+- projects (`tenancy_projects`)
+
+Scope boundaries are enforced by requiring request scope (`tenant_id`, `workspace_id`) in all store operations, and tests cover cross-scope access denial expectations.

--- a/docs/persistence-artifacts.md
+++ b/docs/persistence-artifacts.md
@@ -45,4 +45,4 @@ Tenancy and project management CRUD now has dedicated scoped store operations:
 - workspace members (`tenancy_workspace_members`)
 - projects (`tenancy_projects`)
 
-Scope boundaries are enforced by requiring request scope (`tenant_id`, `workspace_id`) in all store operations, and tests cover cross-scope access denial expectations.
+Scope boundaries are enforced by requiring request scope (`tenant_id`, `workspace_id`) in all store operations, and workspace-bound CRUD paths deny cross-workspace access even within the same tenant.

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -95,6 +95,31 @@ func TestOpenAPIV1SpecContainsPagingFilterSortParameters(t *testing.T) {
 	}
 }
 
+func TestOpenAPIV1SpecContainsTenancyProjectContracts(t *testing.T) {
+	spec := readOpenAPISpec(t)
+	required := []string{
+		"/v1/organizations/current:",
+		"/v1/workspaces:",
+		"/v1/workspaces/{workspace_id}:",
+		"/v1/workspaces/{workspace_id}/members:",
+		"/v1/workspaces/{workspace_id}/members/{member_id}:",
+		"/v1/workspaces/{workspace_id}/projects:",
+		"/v1/workspaces/{workspace_id}/projects/{project_id}:",
+		"OrganizationUpsertRequest:",
+		"WorkspaceUpsertRequest:",
+		"WorkspaceMemberUpsertRequest:",
+		"ProjectUpsertRequest:",
+		"WorkspacePage:",
+		"WorkspaceMemberPage:",
+		"ProjectPage:",
+	}
+	for _, item := range required {
+		if !strings.Contains(spec, item) {
+			t.Fatalf("openapi spec missing %q", item)
+		}
+	}
+}
+
 func readOpenAPISpec(t *testing.T) string {
 	t.Helper()
 	return readRepositoryFile(t, filepath.Join("docs", "openapi-v1.yaml"))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,15 @@ const (
 	defaultOIDCWorkspaceClaim          = "workspace_id"
 	defaultOIDCGroupsClaim             = "groups"
 	defaultOIDCRolesClaim              = "roles"
+	defaultAppModeEnabled              = false
+	defaultAppModeConnectorsEnabled    = false
+	defaultAppModeSchedulerEnabled     = false
+	defaultAppModeRemediationEnabled   = false
+	defaultAppModePremiumEnabled       = false
+	defaultAppModePremiumReports       = false
+	defaultAppModePremiumAutofix       = false
+	defaultAppModeRolloutEnabled       = false
+	defaultAppModeRolloutCanaryPercent = 0
 )
 
 // Config centralizes process-level configuration. It keeps module wiring simple
@@ -117,6 +126,17 @@ type Config struct {
 	OIDCWorkspaceClaim         string
 	OIDCGroupsClaim            string
 	OIDCRolesClaim             string
+	AppModeEnabled             bool
+	AppModeConnectorsEnabled   bool
+	AppModeSchedulerEnabled    bool
+	AppModeRemediationEnabled  bool
+	AppModePremiumEnabled      bool
+	AppModePremiumReports      bool
+	AppModePremiumAutofix      bool
+	AppModeRolloutEnabled      bool
+	AppModeRolloutCanary       int
+	AppModeTenantAllowlist     []string
+	AppModeWorkspaceAllowlist  []string
 }
 
 // Load reads environment variables and applies safe defaults for local and CI use.
@@ -195,6 +215,17 @@ func Load() Config {
 		OIDCWorkspaceClaim:         getEnv("IDENTRAIL_OIDC_WORKSPACE_CLAIM", defaultOIDCWorkspaceClaim),
 		OIDCGroupsClaim:            getEnv("IDENTRAIL_OIDC_GROUPS_CLAIM", defaultOIDCGroupsClaim),
 		OIDCRolesClaim:             getEnv("IDENTRAIL_OIDC_ROLES_CLAIM", defaultOIDCRolesClaim),
+		AppModeEnabled:             parseBool(getEnv("IDENTRAIL_APP_MODE_ENABLED", "false"), defaultAppModeEnabled),
+		AppModeConnectorsEnabled:   parseBool(getEnv("IDENTRAIL_APP_MODE_CONNECTORS_ENABLED", "false"), defaultAppModeConnectorsEnabled),
+		AppModeSchedulerEnabled:    parseBool(getEnv("IDENTRAIL_APP_MODE_SCHEDULER_ENABLED", "false"), defaultAppModeSchedulerEnabled),
+		AppModeRemediationEnabled:  parseBool(getEnv("IDENTRAIL_APP_MODE_REMEDIATION_ENABLED", "false"), defaultAppModeRemediationEnabled),
+		AppModePremiumEnabled:      parseBool(getEnv("IDENTRAIL_APP_MODE_PREMIUM_ENABLED", "false"), defaultAppModePremiumEnabled),
+		AppModePremiumReports:      parseBool(getEnv("IDENTRAIL_APP_MODE_PREMIUM_REPORTS_ENABLED", "false"), defaultAppModePremiumReports),
+		AppModePremiumAutofix:      parseBool(getEnv("IDENTRAIL_APP_MODE_PREMIUM_AUTOFIX_ENABLED", "false"), defaultAppModePremiumAutofix),
+		AppModeRolloutEnabled:      parseBool(getEnv("IDENTRAIL_APP_MODE_ROLLOUT_ENABLED", "false"), defaultAppModeRolloutEnabled),
+		AppModeRolloutCanary:       parseIntAllowZero(getEnv("IDENTRAIL_APP_MODE_ROLLOUT_CANARY_PERCENT", "0"), defaultAppModeRolloutCanaryPercent),
+		AppModeTenantAllowlist:     parseCommaSeparated(getEnv("IDENTRAIL_APP_MODE_ROLLOUT_TENANT_ALLOWLIST", "")),
+		AppModeWorkspaceAllowlist:  parseCommaSeparated(getEnv("IDENTRAIL_APP_MODE_ROLLOUT_WORKSPACE_ALLOWLIST", "")),
 	}
 }
 
@@ -247,6 +278,14 @@ func parseBoolWithValidity(value string, fallback bool) (bool, bool) {
 func parseInt(value string, fallback int) int {
 	parsed, err := strconv.Atoi(strings.TrimSpace(value))
 	if err != nil || parsed <= 0 {
+		return fallback
+	}
+	return parsed
+}
+
+func parseIntAllowZero(value string, fallback int) int {
+	parsed, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || parsed < 0 {
 		return fallback
 	}
 	return parsed

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -627,6 +627,89 @@ func TestParseInt(t *testing.T) {
 	}
 }
 
+func TestParseIntAllowZero(t *testing.T) {
+	if got := parseIntAllowZero("25", 1); got != 25 {
+		t.Fatalf("expected 25, got %d", got)
+	}
+	if got := parseIntAllowZero("0", 7); got != 0 {
+		t.Fatalf("expected 0, got %d", got)
+	}
+	if got := parseIntAllowZero("-1", 7); got != 7 {
+		t.Fatalf("expected fallback 7, got %d", got)
+	}
+	if got := parseIntAllowZero("bad", 9); got != 9 {
+		t.Fatalf("expected fallback 9, got %d", got)
+	}
+}
+
+func TestLoadAppModeDefaults(t *testing.T) {
+	t.Setenv("IDENTRAIL_APP_MODE_ENABLED", "")
+	t.Setenv("IDENTRAIL_APP_MODE_CONNECTORS_ENABLED", "")
+	t.Setenv("IDENTRAIL_APP_MODE_SCHEDULER_ENABLED", "")
+	t.Setenv("IDENTRAIL_APP_MODE_REMEDIATION_ENABLED", "")
+	t.Setenv("IDENTRAIL_APP_MODE_PREMIUM_ENABLED", "")
+	t.Setenv("IDENTRAIL_APP_MODE_PREMIUM_REPORTS_ENABLED", "")
+	t.Setenv("IDENTRAIL_APP_MODE_PREMIUM_AUTOFIX_ENABLED", "")
+	t.Setenv("IDENTRAIL_APP_MODE_ROLLOUT_ENABLED", "")
+	t.Setenv("IDENTRAIL_APP_MODE_ROLLOUT_CANARY_PERCENT", "")
+	t.Setenv("IDENTRAIL_APP_MODE_ROLLOUT_TENANT_ALLOWLIST", "")
+	t.Setenv("IDENTRAIL_APP_MODE_ROLLOUT_WORKSPACE_ALLOWLIST", "")
+
+	cfg := Load()
+	if cfg.AppModeEnabled {
+		t.Fatal("expected app mode disabled by default")
+	}
+	if cfg.AppModeConnectorsEnabled || cfg.AppModeSchedulerEnabled || cfg.AppModeRemediationEnabled {
+		t.Fatal("expected app mode feature flags disabled by default")
+	}
+	if cfg.AppModePremiumEnabled || cfg.AppModePremiumReports || cfg.AppModePremiumAutofix {
+		t.Fatal("expected premium feature flags disabled by default")
+	}
+	if cfg.AppModeRolloutEnabled {
+		t.Fatal("expected rollout disabled by default")
+	}
+	if cfg.AppModeRolloutCanary != 0 {
+		t.Fatalf("expected rollout canary default 0, got %d", cfg.AppModeRolloutCanary)
+	}
+	if len(cfg.AppModeTenantAllowlist) != 0 || len(cfg.AppModeWorkspaceAllowlist) != 0 {
+		t.Fatal("expected empty rollout allowlists by default")
+	}
+}
+
+func TestLoadAppModeFromEnv(t *testing.T) {
+	t.Setenv("IDENTRAIL_APP_MODE_ENABLED", "true")
+	t.Setenv("IDENTRAIL_APP_MODE_CONNECTORS_ENABLED", "true")
+	t.Setenv("IDENTRAIL_APP_MODE_SCHEDULER_ENABLED", "true")
+	t.Setenv("IDENTRAIL_APP_MODE_REMEDIATION_ENABLED", "true")
+	t.Setenv("IDENTRAIL_APP_MODE_PREMIUM_ENABLED", "true")
+	t.Setenv("IDENTRAIL_APP_MODE_PREMIUM_REPORTS_ENABLED", "true")
+	t.Setenv("IDENTRAIL_APP_MODE_PREMIUM_AUTOFIX_ENABLED", "true")
+	t.Setenv("IDENTRAIL_APP_MODE_ROLLOUT_ENABLED", "true")
+	t.Setenv("IDENTRAIL_APP_MODE_ROLLOUT_CANARY_PERCENT", "15")
+	t.Setenv("IDENTRAIL_APP_MODE_ROLLOUT_TENANT_ALLOWLIST", "tenant-a,tenant-b")
+	t.Setenv("IDENTRAIL_APP_MODE_ROLLOUT_WORKSPACE_ALLOWLIST", "workspace-a,workspace-b")
+
+	cfg := Load()
+	if !cfg.AppModeEnabled || !cfg.AppModeConnectorsEnabled || !cfg.AppModeSchedulerEnabled || !cfg.AppModeRemediationEnabled {
+		t.Fatal("expected app mode feature flags enabled from env")
+	}
+	if !cfg.AppModePremiumEnabled || !cfg.AppModePremiumReports || !cfg.AppModePremiumAutofix {
+		t.Fatal("expected premium feature flags enabled from env")
+	}
+	if !cfg.AppModeRolloutEnabled {
+		t.Fatal("expected rollout enabled from env")
+	}
+	if cfg.AppModeRolloutCanary != 15 {
+		t.Fatalf("expected rollout canary 15, got %d", cfg.AppModeRolloutCanary)
+	}
+	if len(cfg.AppModeTenantAllowlist) != 2 || cfg.AppModeTenantAllowlist[0] != "tenant-a" || cfg.AppModeTenantAllowlist[1] != "tenant-b" {
+		t.Fatalf("unexpected app mode tenant allowlist: %+v", cfg.AppModeTenantAllowlist)
+	}
+	if len(cfg.AppModeWorkspaceAllowlist) != 2 || cfg.AppModeWorkspaceAllowlist[0] != "workspace-a" || cfg.AppModeWorkspaceAllowlist[1] != "workspace-b" {
+		t.Fatalf("unexpected app mode workspace allowlist: %+v", cfg.AppModeWorkspaceAllowlist)
+	}
+}
+
 func TestParseKeyScopes(t *testing.T) {
 	scopes := parseKeyScopes("key1:read;key2:read,write;invalid;:missing")
 	if len(scopes) != 2 {

--- a/internal/config/security.go
+++ b/internal/config/security.go
@@ -23,6 +23,7 @@ const (
 	minAPIKeyLength             = 24
 	maxScopeIdentifierLength    = 64
 	maxOIDCClaimNameLength      = 128
+	maxAppModeCanaryPercent     = 100
 )
 
 var allowedKeyScopes = map[string]struct{}{
@@ -95,6 +96,51 @@ func ValidateSecurity(cfg Config) error {
 	}
 	if err := validateScopeIdentifier("IDENTRAIL_DEFAULT_WORKSPACE_ID", defaultWorkspace); err != nil {
 		return err
+	}
+	if cfg.AppModeConnectorsEnabled && !cfg.AppModeEnabled {
+		return fmt.Errorf("IDENTRAIL_APP_MODE_CONNECTORS_ENABLED requires IDENTRAIL_APP_MODE_ENABLED=true")
+	}
+	if cfg.AppModeSchedulerEnabled && !cfg.AppModeEnabled {
+		return fmt.Errorf("IDENTRAIL_APP_MODE_SCHEDULER_ENABLED requires IDENTRAIL_APP_MODE_ENABLED=true")
+	}
+	if cfg.AppModeRemediationEnabled && !cfg.AppModeEnabled {
+		return fmt.Errorf("IDENTRAIL_APP_MODE_REMEDIATION_ENABLED requires IDENTRAIL_APP_MODE_ENABLED=true")
+	}
+	if cfg.AppModePremiumEnabled && !cfg.AppModeEnabled {
+		return fmt.Errorf("IDENTRAIL_APP_MODE_PREMIUM_ENABLED requires IDENTRAIL_APP_MODE_ENABLED=true")
+	}
+	if cfg.AppModePremiumReports && !cfg.AppModePremiumEnabled {
+		return fmt.Errorf("IDENTRAIL_APP_MODE_PREMIUM_REPORTS_ENABLED requires IDENTRAIL_APP_MODE_PREMIUM_ENABLED=true")
+	}
+	if cfg.AppModePremiumAutofix && !cfg.AppModePremiumEnabled {
+		return fmt.Errorf("IDENTRAIL_APP_MODE_PREMIUM_AUTOFIX_ENABLED requires IDENTRAIL_APP_MODE_PREMIUM_ENABLED=true")
+	}
+	if cfg.AppModeRolloutEnabled && !cfg.AppModeEnabled {
+		return fmt.Errorf("IDENTRAIL_APP_MODE_ROLLOUT_ENABLED requires IDENTRAIL_APP_MODE_ENABLED=true")
+	}
+	if !cfg.AppModeRolloutEnabled {
+		if cfg.AppModeRolloutCanary > 0 {
+			return fmt.Errorf("IDENTRAIL_APP_MODE_ROLLOUT_CANARY_PERCENT requires IDENTRAIL_APP_MODE_ROLLOUT_ENABLED=true")
+		}
+		if len(cfg.AppModeTenantAllowlist) > 0 {
+			return fmt.Errorf("IDENTRAIL_APP_MODE_ROLLOUT_TENANT_ALLOWLIST requires IDENTRAIL_APP_MODE_ROLLOUT_ENABLED=true")
+		}
+		if len(cfg.AppModeWorkspaceAllowlist) > 0 {
+			return fmt.Errorf("IDENTRAIL_APP_MODE_ROLLOUT_WORKSPACE_ALLOWLIST requires IDENTRAIL_APP_MODE_ROLLOUT_ENABLED=true")
+		}
+	}
+	if cfg.AppModeRolloutCanary < 0 || cfg.AppModeRolloutCanary > maxAppModeCanaryPercent {
+		return fmt.Errorf("IDENTRAIL_APP_MODE_ROLLOUT_CANARY_PERCENT must be between 0 and %d", maxAppModeCanaryPercent)
+	}
+	for _, tenantID := range cfg.AppModeTenantAllowlist {
+		if err := validateScopeIdentifier("IDENTRAIL_APP_MODE_ROLLOUT_TENANT_ALLOWLIST", tenantID); err != nil {
+			return err
+		}
+	}
+	for _, workspaceID := range cfg.AppModeWorkspaceAllowlist {
+		if err := validateScopeIdentifier("IDENTRAIL_APP_MODE_ROLLOUT_WORKSPACE_ALLOWLIST", workspaceID); err != nil {
+			return err
+		}
 	}
 
 	oidcIssuer := strings.TrimSpace(cfg.OIDCIssuerURL)
@@ -440,6 +486,24 @@ func SecurityWarnings(cfg Config) []string {
 		warnings = append(warnings, "IDENTRAIL_LOCK_BACKEND is inmemory in database mode; use postgres lock backend for multi-instance deployments")
 	}
 	return warnings
+}
+
+// StartupDiagnostics returns startup-safe key runtime mode summaries.
+func StartupDiagnostics(cfg Config) []string {
+	diagnostics := []string{
+		fmt.Sprintf("app_mode.enabled=%t", cfg.AppModeEnabled),
+		fmt.Sprintf("app_mode.connectors.enabled=%t", cfg.AppModeConnectorsEnabled),
+		fmt.Sprintf("app_mode.scheduler.enabled=%t", cfg.AppModeSchedulerEnabled),
+		fmt.Sprintf("app_mode.remediation.enabled=%t", cfg.AppModeRemediationEnabled),
+		fmt.Sprintf("app_mode.premium.enabled=%t", cfg.AppModePremiumEnabled),
+		fmt.Sprintf("app_mode.premium.reports.enabled=%t", cfg.AppModePremiumReports),
+		fmt.Sprintf("app_mode.premium.autofix.enabled=%t", cfg.AppModePremiumAutofix),
+		fmt.Sprintf("app_mode.rollout.enabled=%t", cfg.AppModeRolloutEnabled),
+		fmt.Sprintf("app_mode.rollout.canary_percent=%d", cfg.AppModeRolloutCanary),
+		fmt.Sprintf("app_mode.rollout.tenant_allowlist_count=%d", len(cfg.AppModeTenantAllowlist)),
+		fmt.Sprintf("app_mode.rollout.workspace_allowlist_count=%d", len(cfg.AppModeWorkspaceAllowlist)),
+	}
+	return diagnostics
 }
 
 func hasShortAPIKey(keys []string, scoped map[string][]string) bool {

--- a/internal/config/security_test.go
+++ b/internal/config/security_test.go
@@ -582,3 +582,88 @@ func TestSecurityWarningsShortAPIKey(t *testing.T) {
 		t.Fatalf("expected short API key warning, got %+v", warnings)
 	}
 }
+
+func TestValidateSecurityAppModeRolloutRequiresToggle(t *testing.T) {
+	cfg := Config{
+		APIKeys:              []string{"reader"},
+		AppModeRolloutCanary: 10,
+	}
+	if err := ValidateSecurity(cfg); err == nil {
+		t.Fatal("expected app mode rollout toggle dependency error")
+	}
+}
+
+func TestValidateSecurityAppModePremiumReportsRequiresPremiumFlag(t *testing.T) {
+	cfg := Config{
+		APIKeys:               []string{"reader"},
+		AppModeEnabled:        true,
+		AppModePremiumReports: true,
+	}
+	if err := ValidateSecurity(cfg); err == nil {
+		t.Fatal("expected premium reports dependency error")
+	}
+}
+
+func TestValidateSecurityRejectsOutOfRangeAppModeCanary(t *testing.T) {
+	cfg := Config{
+		APIKeys:               []string{"reader"},
+		AppModeEnabled:        true,
+		AppModeRolloutEnabled: true,
+		AppModeRolloutCanary:  101,
+	}
+	if err := ValidateSecurity(cfg); err == nil {
+		t.Fatal("expected app mode canary range validation error")
+	}
+}
+
+func TestValidateSecurityAcceptsAppModeConfig(t *testing.T) {
+	cfg := Config{
+		APIKeyScopes:              map[string][]string{"reader-key-12345678901234567890": {"read"}},
+		AppModeEnabled:            true,
+		AppModeConnectorsEnabled:  true,
+		AppModeSchedulerEnabled:   true,
+		AppModeRemediationEnabled: true,
+		AppModePremiumEnabled:     true,
+		AppModePremiumReports:     true,
+		AppModePremiumAutofix:     true,
+		AppModeRolloutEnabled:     true,
+		AppModeRolloutCanary:      20,
+		AppModeTenantAllowlist:    []string{"tenant-a"},
+		AppModeWorkspaceAllowlist: []string{"workspace-a"},
+	}
+	if err := ValidateSecurity(cfg); err != nil {
+		t.Fatalf("expected app mode config to be valid, got %v", err)
+	}
+}
+
+func TestStartupDiagnosticsIncludesAppModeSummary(t *testing.T) {
+	cfg := Config{
+		AppModeEnabled:            true,
+		AppModeConnectorsEnabled:  true,
+		AppModeRolloutEnabled:     true,
+		AppModeRolloutCanary:      5,
+		AppModeTenantAllowlist:    []string{"tenant-a", "tenant-b"},
+		AppModeWorkspaceAllowlist: []string{"workspace-a"},
+	}
+	diagnostics := StartupDiagnostics(cfg)
+	required := []string{
+		"app_mode.enabled=true",
+		"app_mode.connectors.enabled=true",
+		"app_mode.rollout.enabled=true",
+		"app_mode.rollout.canary_percent=5",
+		"app_mode.rollout.tenant_allowlist_count=2",
+		"app_mode.rollout.workspace_allowlist_count=1",
+	}
+	for _, item := range required {
+		found := false
+		for _, diagnostic := range diagnostics {
+			if diagnostic == item {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected diagnostic %q, got %+v", item, diagnostics)
+		}
+	}
+}

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -34,6 +34,10 @@ type MemoryStore struct {
 	authzRollouts map[string]AuthzPolicyRollout
 	authzEvents   map[string][]AuthzPolicyEvent
 	authzEventIDs map[string]struct{}
+	organizations map[string]TenancyOrganization
+	workspaces    map[string]TenancyWorkspace
+	members       map[string]TenancyWorkspaceMember
+	projects      map[string]TenancyProject
 	identities    map[string]domain.Identity
 	policies      map[string]domain.Policy
 	relationships map[string]domain.Relationship
@@ -61,6 +65,10 @@ func NewMemoryStore() *MemoryStore {
 		authzRollouts: map[string]AuthzPolicyRollout{},
 		authzEvents:   map[string][]AuthzPolicyEvent{},
 		authzEventIDs: map[string]struct{}{},
+		organizations: map[string]TenancyOrganization{},
+		workspaces:    map[string]TenancyWorkspace{},
+		members:       map[string]TenancyWorkspaceMember{},
+		projects:      map[string]TenancyProject{},
 		identities:    map[string]domain.Identity{},
 		policies:      map[string]domain.Policy{},
 		relationships: map[string]domain.Relationship{},

--- a/internal/db/memory_tenancy.go
+++ b/internal/db/memory_tenancy.go
@@ -1,0 +1,350 @@
+package db
+
+import (
+	"context"
+	"sort"
+	"strings"
+)
+
+// UpsertOrganization persists or updates one tenant organization record.
+func (m *MemoryStore) UpsertOrganization(ctx context.Context, organization TenancyOrganization) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	organization.TenantID = scope.TenantID
+	normalized, err := NormalizeTenancyOrganizationForWrite(organization)
+	if err != nil {
+		return err
+	}
+	m.organizations[normalized.TenantID] = normalized
+	return nil
+}
+
+// GetOrganization returns the active scoped tenant organization.
+func (m *MemoryStore) GetOrganization(ctx context.Context) (TenancyOrganization, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyOrganization{}, err
+	}
+	organization, exists := m.organizations[scope.TenantID]
+	if !exists {
+		return TenancyOrganization{}, ErrNotFound
+	}
+	return organization, nil
+}
+
+// DeleteOrganization removes the active scoped tenant organization record.
+func (m *MemoryStore) DeleteOrganization(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	if _, exists := m.organizations[scope.TenantID]; !exists {
+		return ErrNotFound
+	}
+	delete(m.organizations, scope.TenantID)
+	for key, workspace := range m.workspaces {
+		if workspace.TenantID == scope.TenantID {
+			delete(m.workspaces, key)
+		}
+	}
+	for key, member := range m.members {
+		if member.TenantID == scope.TenantID {
+			delete(m.members, key)
+		}
+	}
+	for key, project := range m.projects {
+		if project.TenantID == scope.TenantID {
+			delete(m.projects, key)
+		}
+	}
+	return nil
+}
+
+// UpsertWorkspace persists or updates one scoped workspace record.
+func (m *MemoryStore) UpsertWorkspace(ctx context.Context, workspace TenancyWorkspace) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	workspace.TenantID = scope.TenantID
+	if workspace.WorkspaceID == "" {
+		workspace.WorkspaceID = scope.WorkspaceID
+	}
+	normalized, err := NormalizeTenancyWorkspaceForWrite(workspace)
+	if err != nil {
+		return err
+	}
+	if _, exists := m.organizations[normalized.TenantID]; !exists {
+		return ErrNotFound
+	}
+	m.workspaces[tenancyWorkspaceKey(normalized.TenantID, normalized.WorkspaceID)] = normalized
+	return nil
+}
+
+// GetWorkspace returns one workspace by id in active tenant scope.
+func (m *MemoryStore) GetWorkspace(ctx context.Context, workspaceID string) (TenancyWorkspace, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyWorkspace{}, err
+	}
+	key := tenancyWorkspaceKey(scope.TenantID, workspaceID)
+	workspace, exists := m.workspaces[key]
+	if !exists {
+		return TenancyWorkspace{}, ErrNotFound
+	}
+	return workspace, nil
+}
+
+// ListWorkspaces returns scoped workspaces ordered by created_at descending.
+func (m *MemoryStore) ListWorkspaces(ctx context.Context, limit int) ([]TenancyWorkspace, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	workspaces := make([]TenancyWorkspace, 0, limit)
+	for _, workspace := range m.workspaces {
+		if workspace.TenantID != scope.TenantID {
+			continue
+		}
+		workspaces = append(workspaces, workspace)
+	}
+	sort.Slice(workspaces, func(i, j int) bool { return workspaces[i].CreatedAt.After(workspaces[j].CreatedAt) })
+	if len(workspaces) > limit {
+		workspaces = workspaces[:limit]
+	}
+	return workspaces, nil
+}
+
+// DeleteWorkspace removes one scoped workspace and all child records.
+func (m *MemoryStore) DeleteWorkspace(ctx context.Context, workspaceID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	normalizedWorkspaceID := strings.TrimSpace(workspaceID)
+	key := tenancyWorkspaceKey(scope.TenantID, normalizedWorkspaceID)
+	if _, exists := m.workspaces[key]; !exists {
+		return ErrNotFound
+	}
+	delete(m.workspaces, key)
+	for memberKey, member := range m.members {
+		if member.TenantID == scope.TenantID && member.WorkspaceID == normalizedWorkspaceID {
+			delete(m.members, memberKey)
+		}
+	}
+	for projectKey, project := range m.projects {
+		if project.TenantID == scope.TenantID && project.WorkspaceID == normalizedWorkspaceID {
+			delete(m.projects, projectKey)
+		}
+	}
+	return nil
+}
+
+// UpsertWorkspaceMember persists one workspace member assignment.
+func (m *MemoryStore) UpsertWorkspaceMember(ctx context.Context, member TenancyWorkspaceMember) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	member.TenantID = scope.TenantID
+	if member.WorkspaceID == "" {
+		member.WorkspaceID = scope.WorkspaceID
+	}
+	normalized, err := NormalizeTenancyWorkspaceMemberForWrite(member)
+	if err != nil {
+		return err
+	}
+	if _, exists := m.workspaces[tenancyWorkspaceKey(normalized.TenantID, normalized.WorkspaceID)]; !exists {
+		return ErrNotFound
+	}
+	m.members[tenancyMemberKey(normalized.TenantID, normalized.WorkspaceID, normalized.MemberID)] = normalized
+	return nil
+}
+
+// GetWorkspaceMember returns one scoped workspace member by member id.
+func (m *MemoryStore) GetWorkspaceMember(ctx context.Context, workspaceID string, memberID string) (TenancyWorkspaceMember, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyWorkspaceMember{}, err
+	}
+	member, exists := m.members[tenancyMemberKey(scope.TenantID, workspaceID, memberID)]
+	if !exists {
+		return TenancyWorkspaceMember{}, ErrNotFound
+	}
+	return member, nil
+}
+
+// ListWorkspaceMembers returns members for one scoped workspace.
+func (m *MemoryStore) ListWorkspaceMembers(ctx context.Context, workspaceID string, limit int) ([]TenancyWorkspaceMember, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	normalizedWorkspaceID := strings.TrimSpace(workspaceID)
+	members := make([]TenancyWorkspaceMember, 0, limit)
+	for _, member := range m.members {
+		if member.TenantID != scope.TenantID || member.WorkspaceID != normalizedWorkspaceID {
+			continue
+		}
+		members = append(members, member)
+	}
+	sort.Slice(members, func(i, j int) bool { return members[i].JoinedAt.Before(members[j].JoinedAt) })
+	if len(members) > limit {
+		members = members[:limit]
+	}
+	return members, nil
+}
+
+// DeleteWorkspaceMember removes one scoped workspace member.
+func (m *MemoryStore) DeleteWorkspaceMember(ctx context.Context, workspaceID string, memberID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	key := tenancyMemberKey(scope.TenantID, workspaceID, memberID)
+	if _, exists := m.members[key]; !exists {
+		return ErrNotFound
+	}
+	delete(m.members, key)
+	return nil
+}
+
+// UpsertProject persists one scoped project record.
+func (m *MemoryStore) UpsertProject(ctx context.Context, project TenancyProject) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	project.TenantID = scope.TenantID
+	if project.WorkspaceID == "" {
+		project.WorkspaceID = scope.WorkspaceID
+	}
+	normalized, err := NormalizeTenancyProjectForWrite(project)
+	if err != nil {
+		return err
+	}
+	if _, exists := m.workspaces[tenancyWorkspaceKey(normalized.TenantID, normalized.WorkspaceID)]; !exists {
+		return ErrNotFound
+	}
+	m.projects[tenancyProjectKey(normalized.TenantID, normalized.WorkspaceID, normalized.ProjectID)] = normalized
+	return nil
+}
+
+// GetProject returns one scoped project by id.
+func (m *MemoryStore) GetProject(ctx context.Context, workspaceID string, projectID string) (TenancyProject, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyProject{}, err
+	}
+	project, exists := m.projects[tenancyProjectKey(scope.TenantID, workspaceID, projectID)]
+	if !exists {
+		return TenancyProject{}, ErrNotFound
+	}
+	return project, nil
+}
+
+// ListProjects returns projects for one scoped workspace.
+func (m *MemoryStore) ListProjects(ctx context.Context, workspaceID string, includeArchived bool, limit int) ([]TenancyProject, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	normalizedWorkspaceID := strings.TrimSpace(workspaceID)
+	projects := make([]TenancyProject, 0, limit)
+	for _, project := range m.projects {
+		if project.TenantID != scope.TenantID || project.WorkspaceID != normalizedWorkspaceID {
+			continue
+		}
+		if !includeArchived && project.ArchivedAt != nil {
+			continue
+		}
+		projects = append(projects, project)
+	}
+	sort.Slice(projects, func(i, j int) bool { return projects[i].CreatedAt.After(projects[j].CreatedAt) })
+	if len(projects) > limit {
+		projects = projects[:limit]
+	}
+	return projects, nil
+}
+
+// DeleteProject removes one scoped project.
+func (m *MemoryStore) DeleteProject(ctx context.Context, workspaceID string, projectID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	key := tenancyProjectKey(scope.TenantID, workspaceID, projectID)
+	if _, exists := m.projects[key]; !exists {
+		return ErrNotFound
+	}
+	delete(m.projects, key)
+	return nil
+}
+
+func tenancyWorkspaceKey(tenantID string, workspaceID string) string {
+	return strings.TrimSpace(tenantID) + "|" + strings.TrimSpace(workspaceID)
+}
+
+func tenancyMemberKey(tenantID string, workspaceID string, memberID string) string {
+	return tenancyWorkspaceKey(tenantID, workspaceID) + "|" + strings.TrimSpace(memberID)
+}
+
+func tenancyProjectKey(tenantID string, workspaceID string, projectID string) string {
+	return tenancyWorkspaceKey(tenantID, workspaceID) + "|" + strings.TrimSpace(projectID)
+}

--- a/internal/db/memory_tenancy.go
+++ b/internal/db/memory_tenancy.go
@@ -81,9 +81,11 @@ func (m *MemoryStore) UpsertWorkspace(ctx context.Context, workspace TenancyWork
 		return err
 	}
 	workspace.TenantID = scope.TenantID
-	if workspace.WorkspaceID == "" {
-		workspace.WorkspaceID = scope.WorkspaceID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspace.WorkspaceID)
+	if err != nil {
+		return err
 	}
+	workspace.WorkspaceID = resolvedWorkspaceID
 	normalized, err := NormalizeTenancyWorkspaceForWrite(workspace)
 	if err != nil {
 		return err
@@ -104,7 +106,11 @@ func (m *MemoryStore) GetWorkspace(ctx context.Context, workspaceID string) (Ten
 	if err != nil {
 		return TenancyWorkspace{}, err
 	}
-	key := tenancyWorkspaceKey(scope.TenantID, workspaceID)
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return TenancyWorkspace{}, err
+	}
+	key := tenancyWorkspaceKey(scope.TenantID, resolvedWorkspaceID)
 	workspace, exists := m.workspaces[key]
 	if !exists {
 		return TenancyWorkspace{}, ErrNotFound
@@ -112,7 +118,7 @@ func (m *MemoryStore) GetWorkspace(ctx context.Context, workspaceID string) (Ten
 	return workspace, nil
 }
 
-// ListWorkspaces returns scoped workspaces ordered by created_at descending.
+// ListWorkspaces returns tenant-scoped workspaces ordered by created_at descending.
 func (m *MemoryStore) ListWorkspaces(ctx context.Context, limit int) ([]TenancyWorkspace, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -147,7 +153,10 @@ func (m *MemoryStore) DeleteWorkspace(ctx context.Context, workspaceID string) e
 	if err != nil {
 		return err
 	}
-	normalizedWorkspaceID := strings.TrimSpace(workspaceID)
+	normalizedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return err
+	}
 	key := tenancyWorkspaceKey(scope.TenantID, normalizedWorkspaceID)
 	if _, exists := m.workspaces[key]; !exists {
 		return ErrNotFound
@@ -176,9 +185,11 @@ func (m *MemoryStore) UpsertWorkspaceMember(ctx context.Context, member TenancyW
 		return err
 	}
 	member.TenantID = scope.TenantID
-	if member.WorkspaceID == "" {
-		member.WorkspaceID = scope.WorkspaceID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, member.WorkspaceID)
+	if err != nil {
+		return err
 	}
+	member.WorkspaceID = resolvedWorkspaceID
 	normalized, err := NormalizeTenancyWorkspaceMemberForWrite(member)
 	if err != nil {
 		return err
@@ -199,7 +210,11 @@ func (m *MemoryStore) GetWorkspaceMember(ctx context.Context, workspaceID string
 	if err != nil {
 		return TenancyWorkspaceMember{}, err
 	}
-	member, exists := m.members[tenancyMemberKey(scope.TenantID, workspaceID, memberID)]
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return TenancyWorkspaceMember{}, err
+	}
+	member, exists := m.members[tenancyMemberKey(scope.TenantID, resolvedWorkspaceID, memberID)]
 	if !exists {
 		return TenancyWorkspaceMember{}, ErrNotFound
 	}
@@ -218,7 +233,10 @@ func (m *MemoryStore) ListWorkspaceMembers(ctx context.Context, workspaceID stri
 	if limit <= 0 {
 		limit = 100
 	}
-	normalizedWorkspaceID := strings.TrimSpace(workspaceID)
+	normalizedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	members := make([]TenancyWorkspaceMember, 0, limit)
 	for _, member := range m.members {
 		if member.TenantID != scope.TenantID || member.WorkspaceID != normalizedWorkspaceID {
@@ -242,7 +260,11 @@ func (m *MemoryStore) DeleteWorkspaceMember(ctx context.Context, workspaceID str
 	if err != nil {
 		return err
 	}
-	key := tenancyMemberKey(scope.TenantID, workspaceID, memberID)
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return err
+	}
+	key := tenancyMemberKey(scope.TenantID, resolvedWorkspaceID, memberID)
 	if _, exists := m.members[key]; !exists {
 		return ErrNotFound
 	}
@@ -260,9 +282,11 @@ func (m *MemoryStore) UpsertProject(ctx context.Context, project TenancyProject)
 		return err
 	}
 	project.TenantID = scope.TenantID
-	if project.WorkspaceID == "" {
-		project.WorkspaceID = scope.WorkspaceID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, project.WorkspaceID)
+	if err != nil {
+		return err
 	}
+	project.WorkspaceID = resolvedWorkspaceID
 	normalized, err := NormalizeTenancyProjectForWrite(project)
 	if err != nil {
 		return err
@@ -283,7 +307,11 @@ func (m *MemoryStore) GetProject(ctx context.Context, workspaceID string, projec
 	if err != nil {
 		return TenancyProject{}, err
 	}
-	project, exists := m.projects[tenancyProjectKey(scope.TenantID, workspaceID, projectID)]
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return TenancyProject{}, err
+	}
+	project, exists := m.projects[tenancyProjectKey(scope.TenantID, resolvedWorkspaceID, projectID)]
 	if !exists {
 		return TenancyProject{}, ErrNotFound
 	}
@@ -302,7 +330,10 @@ func (m *MemoryStore) ListProjects(ctx context.Context, workspaceID string, incl
 	if limit <= 0 {
 		limit = 100
 	}
-	normalizedWorkspaceID := strings.TrimSpace(workspaceID)
+	normalizedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	projects := make([]TenancyProject, 0, limit)
 	for _, project := range m.projects {
 		if project.TenantID != scope.TenantID || project.WorkspaceID != normalizedWorkspaceID {
@@ -329,7 +360,11 @@ func (m *MemoryStore) DeleteProject(ctx context.Context, workspaceID string, pro
 	if err != nil {
 		return err
 	}
-	key := tenancyProjectKey(scope.TenantID, workspaceID, projectID)
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return err
+	}
+	key := tenancyProjectKey(scope.TenantID, resolvedWorkspaceID, projectID)
 	if _, exists := m.projects[key]; !exists {
 		return ErrNotFound
 	}

--- a/internal/db/memory_tenancy_test.go
+++ b/internal/db/memory_tenancy_test.go
@@ -1,0 +1,175 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestMemoryStoreTenancyCRUD(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+
+	if err := store.UpsertOrganization(ctx, TenancyOrganization{
+		DisplayName: "Tenant A",
+		Slug:        "tenant-a",
+	}); err != nil {
+		t.Fatalf("upsert organization: %v", err)
+	}
+	if _, err := store.GetOrganization(ctx); err != nil {
+		t.Fatalf("get organization: %v", err)
+	}
+
+	if err := store.UpsertWorkspace(ctx, TenancyWorkspace{
+		WorkspaceID: "workspace-a",
+		DisplayName: "Workspace A",
+		Slug:        "workspace-a",
+	}); err != nil {
+		t.Fatalf("upsert workspace: %v", err)
+	}
+	if _, err := store.GetWorkspace(ctx, "workspace-a"); err != nil {
+		t.Fatalf("get workspace: %v", err)
+	}
+	workspaces, err := store.ListWorkspaces(ctx, 20)
+	if err != nil {
+		t.Fatalf("list workspaces: %v", err)
+	}
+	if len(workspaces) != 1 {
+		t.Fatalf("expected one workspace, got %+v", workspaces)
+	}
+
+	joinedAt := time.Now().UTC()
+	if err := store.UpsertWorkspaceMember(ctx, TenancyWorkspaceMember{
+		WorkspaceID: "workspace-a",
+		MemberID:    "member-1",
+		UserID:      "user-1",
+		Email:       "user@example.com",
+		Role:        "admin",
+		Status:      "active",
+		JoinedAt:    joinedAt,
+	}); err != nil {
+		t.Fatalf("upsert workspace member: %v", err)
+	}
+	members, err := store.ListWorkspaceMembers(ctx, "workspace-a", 20)
+	if err != nil {
+		t.Fatalf("list workspace members: %v", err)
+	}
+	if len(members) != 1 || members[0].MemberID != "member-1" {
+		t.Fatalf("unexpected members: %+v", members)
+	}
+
+	if err := store.UpsertProject(ctx, TenancyProject{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		Name:        "Payments",
+		Slug:        "payments",
+	}); err != nil {
+		t.Fatalf("upsert project: %v", err)
+	}
+	projects, err := store.ListProjects(ctx, "workspace-a", false, 20)
+	if err != nil {
+		t.Fatalf("list projects: %v", err)
+	}
+	if len(projects) != 1 || projects[0].ProjectID != "project-1" {
+		t.Fatalf("unexpected projects: %+v", projects)
+	}
+
+	if err := store.DeleteProject(ctx, "workspace-a", "project-1"); err != nil {
+		t.Fatalf("delete project: %v", err)
+	}
+	if err := store.DeleteWorkspaceMember(ctx, "workspace-a", "member-1"); err != nil {
+		t.Fatalf("delete workspace member: %v", err)
+	}
+	if err := store.DeleteWorkspace(ctx, "workspace-a"); err != nil {
+		t.Fatalf("delete workspace: %v", err)
+	}
+	if err := store.DeleteOrganization(ctx); err != nil {
+		t.Fatalf("delete organization: %v", err)
+	}
+}
+
+func TestMemoryStoreTenancyScopeIsolation(t *testing.T) {
+	store := NewMemoryStore()
+	tenantA := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	tenantB := WithScope(context.Background(), Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
+
+	if err := store.UpsertOrganization(tenantA, TenancyOrganization{
+		DisplayName: "Tenant A",
+		Slug:        "tenant-a",
+	}); err != nil {
+		t.Fatalf("seed organization tenant-a: %v", err)
+	}
+	if err := store.UpsertWorkspace(tenantA, TenancyWorkspace{
+		WorkspaceID: "workspace-a",
+		DisplayName: "Workspace A",
+		Slug:        "workspace-a",
+	}); err != nil {
+		t.Fatalf("seed workspace tenant-a: %v", err)
+	}
+	if err := store.UpsertProject(tenantA, TenancyProject{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-a",
+		Name:        "Project A",
+		Slug:        "project-a",
+	}); err != nil {
+		t.Fatalf("seed project tenant-a: %v", err)
+	}
+
+	if _, err := store.GetOrganization(tenantB); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected tenant-b organization to be isolated, got %v", err)
+	}
+	if _, err := store.GetWorkspace(tenantB, "workspace-a"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected tenant-b workspace to be isolated, got %v", err)
+	}
+	if _, err := store.GetProject(tenantB, "workspace-a", "project-a"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected tenant-b project to be isolated, got %v", err)
+	}
+}
+
+func TestMemoryStoreDeleteWorkspaceCascadesWithPaddedWorkspaceID(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+
+	if err := store.UpsertOrganization(ctx, TenancyOrganization{
+		DisplayName: "Tenant A",
+		Slug:        "tenant-a",
+	}); err != nil {
+		t.Fatalf("upsert organization: %v", err)
+	}
+	if err := store.UpsertWorkspace(ctx, TenancyWorkspace{
+		WorkspaceID: "workspace-a",
+		DisplayName: "Workspace A",
+		Slug:        "workspace-a",
+	}); err != nil {
+		t.Fatalf("upsert workspace: %v", err)
+	}
+	if err := store.UpsertWorkspaceMember(ctx, TenancyWorkspaceMember{
+		WorkspaceID: "workspace-a",
+		MemberID:    "member-1",
+		UserID:      "user-1",
+		Email:       "user@example.com",
+		Role:        "admin",
+		Status:      "active",
+	}); err != nil {
+		t.Fatalf("upsert member: %v", err)
+	}
+	if err := store.UpsertProject(ctx, TenancyProject{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		Name:        "Payments",
+		Slug:        "payments",
+	}); err != nil {
+		t.Fatalf("upsert project: %v", err)
+	}
+
+	if err := store.DeleteWorkspace(ctx, "  workspace-a  "); err != nil {
+		t.Fatalf("delete workspace with padded id: %v", err)
+	}
+	if _, err := store.GetWorkspaceMember(ctx, "workspace-a", "member-1"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected member to be cascade-deleted, got %v", err)
+	}
+	if _, err := store.GetProject(ctx, "workspace-a", "project-1"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected project to be cascade-deleted, got %v", err)
+	}
+}

--- a/internal/db/memory_tenancy_test.go
+++ b/internal/db/memory_tenancy_test.go
@@ -92,6 +92,7 @@ func TestMemoryStoreTenancyCRUD(t *testing.T) {
 func TestMemoryStoreTenancyScopeIsolation(t *testing.T) {
 	store := NewMemoryStore()
 	tenantA := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	tenantAWorkspaceB := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-b"})
 	tenantB := WithScope(context.Background(), Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
 
 	if err := store.UpsertOrganization(tenantA, TenancyOrganization{
@@ -124,6 +125,12 @@ func TestMemoryStoreTenancyScopeIsolation(t *testing.T) {
 	}
 	if _, err := store.GetProject(tenantB, "workspace-a", "project-a"); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected tenant-b project to be isolated, got %v", err)
+	}
+	if _, err := store.GetWorkspace(tenantAWorkspaceB, "workspace-a"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected cross-workspace lookup to be denied, got %v", err)
+	}
+	if _, err := store.GetProject(tenantAWorkspaceB, "workspace-a", "project-a"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected cross-workspace project lookup to be denied, got %v", err)
 	}
 }
 

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -213,3 +213,28 @@ func TestTenthMigrationContainsAuthzPolicyLifecycleTables(t *testing.T) {
 		}
 	}
 }
+
+func TestTwelfthMigrationContainsTenancyCoreTables(t *testing.T) {
+	path := filepath.Join("..", "..", "migrations", "000012_tenancy_core_entities.up.sql")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	text := string(content)
+	required := []string{
+		"CREATE TABLE IF NOT EXISTS tenancy_organizations",
+		"CREATE TABLE IF NOT EXISTS tenancy_workspaces",
+		"CREATE TABLE IF NOT EXISTS tenancy_workspace_members",
+		"CREATE TABLE IF NOT EXISTS tenancy_projects",
+		"FOREIGN KEY (tenant_id) REFERENCES tenancy_organizations(tenant_id)",
+		"FOREIGN KEY (tenant_id, workspace_id) REFERENCES tenancy_workspaces(tenant_id, workspace_id)",
+		"idx_tenancy_workspaces_scope_created",
+		"idx_tenancy_members_scope_role_status",
+		"idx_tenancy_projects_scope_created",
+	}
+	for _, item := range required {
+		if !strings.Contains(text, item) {
+			t.Fatalf("expected tenancy core migration item %q", item)
+		}
+	}
+}

--- a/internal/db/postgres_tenancy.go
+++ b/internal/db/postgres_tenancy.go
@@ -95,9 +95,11 @@ func (p *PostgresStore) UpsertWorkspace(ctx context.Context, workspace TenancyWo
 		return err
 	}
 	workspace.TenantID = scope.TenantID
-	if workspace.WorkspaceID == "" {
-		workspace.WorkspaceID = scope.WorkspaceID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspace.WorkspaceID)
+	if err != nil {
+		return err
 	}
+	workspace.WorkspaceID = resolvedWorkspaceID
 	normalized, err := NormalizeTenancyWorkspaceForWrite(workspace)
 	if err != nil {
 		return err
@@ -126,6 +128,10 @@ func (p *PostgresStore) GetWorkspace(ctx context.Context, workspaceID string) (T
 	if err != nil {
 		return TenancyWorkspace{}, err
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return TenancyWorkspace{}, err
+	}
 	row := p.queryRowContext(
 		ctx,
 		`SELECT tenant_id, workspace_id, display_name, slug, created_at, updated_at
@@ -133,7 +139,7 @@ func (p *PostgresStore) GetWorkspace(ctx context.Context, workspaceID string) (T
 		 WHERE tenant_id = $1
 		   AND workspace_id = $2`,
 		scope.TenantID,
-		workspaceID,
+		resolvedWorkspaceID,
 	)
 	var workspace TenancyWorkspace
 	if err := row.Scan(
@@ -152,7 +158,7 @@ func (p *PostgresStore) GetWorkspace(ctx context.Context, workspaceID string) (T
 	return workspace, nil
 }
 
-// ListWorkspaces returns all scoped workspaces ordered by creation time.
+// ListWorkspaces returns all tenant-scoped workspaces ordered by creation time.
 func (p *PostgresStore) ListWorkspaces(ctx context.Context, limit int) ([]TenancyWorkspace, error) {
 	scope, err := RequireScope(ctx)
 	if err != nil {
@@ -200,13 +206,17 @@ func (p *PostgresStore) DeleteWorkspace(ctx context.Context, workspaceID string)
 	if err != nil {
 		return err
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return err
+	}
 	result, err := p.execContext(
 		ctx,
 		`DELETE FROM tenancy_workspaces
 		 WHERE tenant_id = $1
 		   AND workspace_id = $2`,
 		scope.TenantID,
-		workspaceID,
+		resolvedWorkspaceID,
 	)
 	if err != nil {
 		return err
@@ -228,9 +238,11 @@ func (p *PostgresStore) UpsertWorkspaceMember(ctx context.Context, member Tenanc
 		return err
 	}
 	member.TenantID = scope.TenantID
-	if member.WorkspaceID == "" {
-		member.WorkspaceID = scope.WorkspaceID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, member.WorkspaceID)
+	if err != nil {
+		return err
 	}
+	member.WorkspaceID = resolvedWorkspaceID
 	normalized, err := NormalizeTenancyWorkspaceMemberForWrite(member)
 	if err != nil {
 		return err
@@ -266,6 +278,10 @@ func (p *PostgresStore) GetWorkspaceMember(ctx context.Context, workspaceID stri
 	if err != nil {
 		return TenancyWorkspaceMember{}, err
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return TenancyWorkspaceMember{}, err
+	}
 	row := p.queryRowContext(
 		ctx,
 		`SELECT tenant_id, workspace_id, member_id, user_id, email, role, status, joined_at, updated_at
@@ -274,7 +290,7 @@ func (p *PostgresStore) GetWorkspaceMember(ctx context.Context, workspaceID stri
 		   AND workspace_id = $2
 		   AND member_id = $3`,
 		scope.TenantID,
-		workspaceID,
+		resolvedWorkspaceID,
 		memberID,
 	)
 	var member TenancyWorkspaceMember
@@ -306,6 +322,10 @@ func (p *PostgresStore) ListWorkspaceMembers(ctx context.Context, workspaceID st
 	if limit <= 0 {
 		limit = 100
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	rows, err := p.queryContext(
 		ctx,
 		`SELECT tenant_id, workspace_id, member_id, user_id, email, role, status, joined_at, updated_at
@@ -315,7 +335,7 @@ func (p *PostgresStore) ListWorkspaceMembers(ctx context.Context, workspaceID st
 		 ORDER BY joined_at ASC
 		 LIMIT $3`,
 		scope.TenantID,
-		workspaceID,
+		resolvedWorkspaceID,
 		limit,
 	)
 	if err != nil {
@@ -350,6 +370,10 @@ func (p *PostgresStore) DeleteWorkspaceMember(ctx context.Context, workspaceID s
 	if err != nil {
 		return err
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return err
+	}
 	result, err := p.execContext(
 		ctx,
 		`DELETE FROM tenancy_workspace_members
@@ -357,7 +381,7 @@ func (p *PostgresStore) DeleteWorkspaceMember(ctx context.Context, workspaceID s
 		   AND workspace_id = $2
 		   AND member_id = $3`,
 		scope.TenantID,
-		workspaceID,
+		resolvedWorkspaceID,
 		memberID,
 	)
 	if err != nil {
@@ -380,9 +404,11 @@ func (p *PostgresStore) UpsertProject(ctx context.Context, project TenancyProjec
 		return err
 	}
 	project.TenantID = scope.TenantID
-	if project.WorkspaceID == "" {
-		project.WorkspaceID = scope.WorkspaceID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, project.WorkspaceID)
+	if err != nil {
+		return err
 	}
+	project.WorkspaceID = resolvedWorkspaceID
 	normalized, err := NormalizeTenancyProjectForWrite(project)
 	if err != nil {
 		return err
@@ -418,6 +444,10 @@ func (p *PostgresStore) GetProject(ctx context.Context, workspaceID string, proj
 	if err != nil {
 		return TenancyProject{}, err
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return TenancyProject{}, err
+	}
 	row := p.queryRowContext(
 		ctx,
 		`SELECT tenant_id, workspace_id, project_id, name, slug, COALESCE(description, ''), archived_at, created_at, updated_at
@@ -426,7 +456,7 @@ func (p *PostgresStore) GetProject(ctx context.Context, workspaceID string, proj
 		   AND workspace_id = $2
 		   AND project_id = $3`,
 		scope.TenantID,
-		workspaceID,
+		resolvedWorkspaceID,
 		projectID,
 	)
 	var project TenancyProject
@@ -463,11 +493,15 @@ func (p *PostgresStore) ListProjects(ctx context.Context, workspaceID string, in
 	if limit <= 0 {
 		limit = 100
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	query := `SELECT tenant_id, workspace_id, project_id, name, slug, COALESCE(description, ''), archived_at, created_at, updated_at
 		 FROM tenancy_projects
 		 WHERE tenant_id = $1
 		   AND workspace_id = $2`
-	args := []any{scope.TenantID, workspaceID}
+	args := []any{scope.TenantID, resolvedWorkspaceID}
 	if !includeArchived {
 		query += " AND archived_at IS NULL"
 	}
@@ -511,6 +545,10 @@ func (p *PostgresStore) DeleteProject(ctx context.Context, workspaceID string, p
 	if err != nil {
 		return err
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return err
+	}
 	result, err := p.execContext(
 		ctx,
 		`DELETE FROM tenancy_projects
@@ -518,7 +556,7 @@ func (p *PostgresStore) DeleteProject(ctx context.Context, workspaceID string, p
 		   AND workspace_id = $2
 		   AND project_id = $3`,
 		scope.TenantID,
-		workspaceID,
+		resolvedWorkspaceID,
 		projectID,
 	)
 	if err != nil {

--- a/internal/db/postgres_tenancy.go
+++ b/internal/db/postgres_tenancy.go
@@ -1,0 +1,535 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+)
+
+// UpsertOrganization persists one scoped organization metadata row.
+func (p *PostgresStore) UpsertOrganization(ctx context.Context, organization TenancyOrganization) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	organization.TenantID = scope.TenantID
+	normalized, err := NormalizeTenancyOrganizationForWrite(organization)
+	if err != nil {
+		return err
+	}
+	_, err = p.execContext(
+		ctx,
+		`INSERT INTO tenancy_organizations (tenant_id, display_name, slug, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5)
+		 ON CONFLICT (tenant_id) DO UPDATE
+		 SET display_name = EXCLUDED.display_name,
+		     slug = EXCLUDED.slug,
+		     updated_at = EXCLUDED.updated_at`,
+		normalized.TenantID,
+		normalized.DisplayName,
+		normalized.Slug,
+		normalized.CreatedAt,
+		normalized.UpdatedAt,
+	)
+	return err
+}
+
+// GetOrganization returns one scoped organization record.
+func (p *PostgresStore) GetOrganization(ctx context.Context) (TenancyOrganization, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyOrganization{}, err
+	}
+	row := p.queryRowContext(
+		ctx,
+		`SELECT tenant_id, display_name, slug, created_at, updated_at
+		 FROM tenancy_organizations
+		 WHERE tenant_id = $1`,
+		scope.TenantID,
+	)
+	var organization TenancyOrganization
+	if err := row.Scan(
+		&organization.TenantID,
+		&organization.DisplayName,
+		&organization.Slug,
+		&organization.CreatedAt,
+		&organization.UpdatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return TenancyOrganization{}, ErrNotFound
+		}
+		return TenancyOrganization{}, err
+	}
+	return organization, nil
+}
+
+// DeleteOrganization removes one scoped organization record.
+func (p *PostgresStore) DeleteOrganization(ctx context.Context) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	result, err := p.execContext(
+		ctx,
+		`DELETE FROM tenancy_organizations
+		 WHERE tenant_id = $1`,
+		scope.TenantID,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// UpsertWorkspace persists one scoped workspace record.
+func (p *PostgresStore) UpsertWorkspace(ctx context.Context, workspace TenancyWorkspace) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	workspace.TenantID = scope.TenantID
+	if workspace.WorkspaceID == "" {
+		workspace.WorkspaceID = scope.WorkspaceID
+	}
+	normalized, err := NormalizeTenancyWorkspaceForWrite(workspace)
+	if err != nil {
+		return err
+	}
+	_, err = p.execContext(
+		ctx,
+		`INSERT INTO tenancy_workspaces (tenant_id, workspace_id, display_name, slug, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6)
+		 ON CONFLICT (tenant_id, workspace_id) DO UPDATE
+		 SET display_name = EXCLUDED.display_name,
+		     slug = EXCLUDED.slug,
+		     updated_at = EXCLUDED.updated_at`,
+		normalized.TenantID,
+		normalized.WorkspaceID,
+		normalized.DisplayName,
+		normalized.Slug,
+		normalized.CreatedAt,
+		normalized.UpdatedAt,
+	)
+	return err
+}
+
+// GetWorkspace returns one scoped workspace by id.
+func (p *PostgresStore) GetWorkspace(ctx context.Context, workspaceID string) (TenancyWorkspace, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyWorkspace{}, err
+	}
+	row := p.queryRowContext(
+		ctx,
+		`SELECT tenant_id, workspace_id, display_name, slug, created_at, updated_at
+		 FROM tenancy_workspaces
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2`,
+		scope.TenantID,
+		workspaceID,
+	)
+	var workspace TenancyWorkspace
+	if err := row.Scan(
+		&workspace.TenantID,
+		&workspace.WorkspaceID,
+		&workspace.DisplayName,
+		&workspace.Slug,
+		&workspace.CreatedAt,
+		&workspace.UpdatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return TenancyWorkspace{}, ErrNotFound
+		}
+		return TenancyWorkspace{}, err
+	}
+	return workspace, nil
+}
+
+// ListWorkspaces returns all scoped workspaces ordered by creation time.
+func (p *PostgresStore) ListWorkspaces(ctx context.Context, limit int) ([]TenancyWorkspace, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	rows, err := p.queryContext(
+		ctx,
+		`SELECT tenant_id, workspace_id, display_name, slug, created_at, updated_at
+		 FROM tenancy_workspaces
+		 WHERE tenant_id = $1
+		 ORDER BY created_at DESC
+		 LIMIT $2`,
+		scope.TenantID,
+		limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	workspaces := make([]TenancyWorkspace, 0, limit)
+	for rows.Next() {
+		var workspace TenancyWorkspace
+		if err := rows.Scan(
+			&workspace.TenantID,
+			&workspace.WorkspaceID,
+			&workspace.DisplayName,
+			&workspace.Slug,
+			&workspace.CreatedAt,
+			&workspace.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		workspaces = append(workspaces, workspace)
+	}
+	return workspaces, rows.Err()
+}
+
+// DeleteWorkspace deletes one scoped workspace by id.
+func (p *PostgresStore) DeleteWorkspace(ctx context.Context, workspaceID string) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	result, err := p.execContext(
+		ctx,
+		`DELETE FROM tenancy_workspaces
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2`,
+		scope.TenantID,
+		workspaceID,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// UpsertWorkspaceMember persists one scoped workspace member record.
+func (p *PostgresStore) UpsertWorkspaceMember(ctx context.Context, member TenancyWorkspaceMember) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	member.TenantID = scope.TenantID
+	if member.WorkspaceID == "" {
+		member.WorkspaceID = scope.WorkspaceID
+	}
+	normalized, err := NormalizeTenancyWorkspaceMemberForWrite(member)
+	if err != nil {
+		return err
+	}
+	_, err = p.execContext(
+		ctx,
+		`INSERT INTO tenancy_workspace_members (
+		     tenant_id, workspace_id, member_id, user_id, email, role, status, joined_at, updated_at
+		 )
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		 ON CONFLICT (tenant_id, workspace_id, member_id) DO UPDATE
+		 SET user_id = EXCLUDED.user_id,
+		     email = EXCLUDED.email,
+		     role = EXCLUDED.role,
+		     status = EXCLUDED.status,
+		     updated_at = EXCLUDED.updated_at`,
+		normalized.TenantID,
+		normalized.WorkspaceID,
+		normalized.MemberID,
+		normalized.UserID,
+		normalized.Email,
+		normalized.Role,
+		normalized.Status,
+		normalized.JoinedAt,
+		normalized.UpdatedAt,
+	)
+	return err
+}
+
+// GetWorkspaceMember returns one scoped workspace member.
+func (p *PostgresStore) GetWorkspaceMember(ctx context.Context, workspaceID string, memberID string) (TenancyWorkspaceMember, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyWorkspaceMember{}, err
+	}
+	row := p.queryRowContext(
+		ctx,
+		`SELECT tenant_id, workspace_id, member_id, user_id, email, role, status, joined_at, updated_at
+		 FROM tenancy_workspace_members
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND member_id = $3`,
+		scope.TenantID,
+		workspaceID,
+		memberID,
+	)
+	var member TenancyWorkspaceMember
+	if err := row.Scan(
+		&member.TenantID,
+		&member.WorkspaceID,
+		&member.MemberID,
+		&member.UserID,
+		&member.Email,
+		&member.Role,
+		&member.Status,
+		&member.JoinedAt,
+		&member.UpdatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return TenancyWorkspaceMember{}, ErrNotFound
+		}
+		return TenancyWorkspaceMember{}, err
+	}
+	return member, nil
+}
+
+// ListWorkspaceMembers lists members for one scoped workspace.
+func (p *PostgresStore) ListWorkspaceMembers(ctx context.Context, workspaceID string, limit int) ([]TenancyWorkspaceMember, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := p.queryContext(
+		ctx,
+		`SELECT tenant_id, workspace_id, member_id, user_id, email, role, status, joined_at, updated_at
+		 FROM tenancy_workspace_members
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		 ORDER BY joined_at ASC
+		 LIMIT $3`,
+		scope.TenantID,
+		workspaceID,
+		limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	members := make([]TenancyWorkspaceMember, 0, limit)
+	for rows.Next() {
+		var member TenancyWorkspaceMember
+		if err := rows.Scan(
+			&member.TenantID,
+			&member.WorkspaceID,
+			&member.MemberID,
+			&member.UserID,
+			&member.Email,
+			&member.Role,
+			&member.Status,
+			&member.JoinedAt,
+			&member.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		members = append(members, member)
+	}
+	return members, rows.Err()
+}
+
+// DeleteWorkspaceMember removes one scoped member.
+func (p *PostgresStore) DeleteWorkspaceMember(ctx context.Context, workspaceID string, memberID string) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	result, err := p.execContext(
+		ctx,
+		`DELETE FROM tenancy_workspace_members
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND member_id = $3`,
+		scope.TenantID,
+		workspaceID,
+		memberID,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// UpsertProject persists one scoped project record.
+func (p *PostgresStore) UpsertProject(ctx context.Context, project TenancyProject) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	project.TenantID = scope.TenantID
+	if project.WorkspaceID == "" {
+		project.WorkspaceID = scope.WorkspaceID
+	}
+	normalized, err := NormalizeTenancyProjectForWrite(project)
+	if err != nil {
+		return err
+	}
+	_, err = p.execContext(
+		ctx,
+		`INSERT INTO tenancy_projects (
+		     tenant_id, workspace_id, project_id, name, slug, description, archived_at, created_at, updated_at
+		 )
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		 ON CONFLICT (tenant_id, workspace_id, project_id) DO UPDATE
+		 SET name = EXCLUDED.name,
+		     slug = EXCLUDED.slug,
+		     description = EXCLUDED.description,
+		     archived_at = EXCLUDED.archived_at,
+		     updated_at = EXCLUDED.updated_at`,
+		normalized.TenantID,
+		normalized.WorkspaceID,
+		normalized.ProjectID,
+		normalized.Name,
+		normalized.Slug,
+		normalized.Description,
+		normalized.ArchivedAt,
+		normalized.CreatedAt,
+		normalized.UpdatedAt,
+	)
+	return err
+}
+
+// GetProject returns one scoped project.
+func (p *PostgresStore) GetProject(ctx context.Context, workspaceID string, projectID string) (TenancyProject, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyProject{}, err
+	}
+	row := p.queryRowContext(
+		ctx,
+		`SELECT tenant_id, workspace_id, project_id, name, slug, COALESCE(description, ''), archived_at, created_at, updated_at
+		 FROM tenancy_projects
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND project_id = $3`,
+		scope.TenantID,
+		workspaceID,
+		projectID,
+	)
+	var project TenancyProject
+	var archivedAt sql.NullTime
+	if err := row.Scan(
+		&project.TenantID,
+		&project.WorkspaceID,
+		&project.ProjectID,
+		&project.Name,
+		&project.Slug,
+		&project.Description,
+		&archivedAt,
+		&project.CreatedAt,
+		&project.UpdatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return TenancyProject{}, ErrNotFound
+		}
+		return TenancyProject{}, err
+	}
+	if archivedAt.Valid {
+		value := archivedAt.Time.UTC()
+		project.ArchivedAt = &value
+	}
+	return project, nil
+}
+
+// ListProjects returns scoped projects for a workspace.
+func (p *PostgresStore) ListProjects(ctx context.Context, workspaceID string, includeArchived bool, limit int) ([]TenancyProject, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	query := `SELECT tenant_id, workspace_id, project_id, name, slug, COALESCE(description, ''), archived_at, created_at, updated_at
+		 FROM tenancy_projects
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2`
+	args := []any{scope.TenantID, workspaceID}
+	if !includeArchived {
+		query += " AND archived_at IS NULL"
+	}
+	query += " ORDER BY created_at DESC LIMIT $3"
+	args = append(args, limit)
+	rows, err := p.queryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	projects := make([]TenancyProject, 0, limit)
+	for rows.Next() {
+		var project TenancyProject
+		var archivedAt sql.NullTime
+		if err := rows.Scan(
+			&project.TenantID,
+			&project.WorkspaceID,
+			&project.ProjectID,
+			&project.Name,
+			&project.Slug,
+			&project.Description,
+			&archivedAt,
+			&project.CreatedAt,
+			&project.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		if archivedAt.Valid {
+			value := archivedAt.Time.UTC()
+			project.ArchivedAt = &value
+		}
+		projects = append(projects, project)
+	}
+	return projects, rows.Err()
+}
+
+// DeleteProject removes one scoped project.
+func (p *PostgresStore) DeleteProject(ctx context.Context, workspaceID string, projectID string) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	result, err := p.execContext(
+		ctx,
+		`DELETE FROM tenancy_projects
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND project_id = $3`,
+		scope.TenantID,
+		workspaceID,
+		projectID,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/internal/db/postgres_tenancy_test.go
+++ b/internal/db/postgres_tenancy_test.go
@@ -1,0 +1,123 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestPostgresStoreUpsertAndGetOrganizationScoped(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	now := time.Now().UTC()
+
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO tenancy_organizations (tenant_id, display_name, slug, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5)
+		 ON CONFLICT (tenant_id) DO UPDATE
+		 SET display_name = EXCLUDED.display_name,
+		     slug = EXCLUDED.slug,
+		     updated_at = EXCLUDED.updated_at`)).
+		WithArgs("tenant-a", "Tenant A", "tenant-a", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := store.UpsertOrganization(ctx, TenancyOrganization{
+		DisplayName: "Tenant A",
+		Slug:        "tenant-a",
+	}); err != nil {
+		t.Fatalf("upsert organization: %v", err)
+	}
+
+	rows := sqlmock.NewRows([]string{"tenant_id", "display_name", "slug", "created_at", "updated_at"}).
+		AddRow("tenant-a", "Tenant A", "tenant-a", now, now)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, display_name, slug, created_at, updated_at
+		 FROM tenancy_organizations
+		 WHERE tenant_id = $1`)).
+		WithArgs("tenant-a").
+		WillReturnRows(rows)
+
+	organization, err := store.GetOrganization(ctx)
+	if err != nil {
+		t.Fatalf("get organization: %v", err)
+	}
+	if organization.TenantID != "tenant-a" {
+		t.Fatalf("unexpected organization: %+v", organization)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreWorkspaceScopeIsolation(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, workspace_id, display_name, slug, created_at, updated_at
+		 FROM tenancy_workspaces
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2`)).
+		WithArgs("tenant-a", "workspace-b").
+		WillReturnRows(sqlmock.NewRows([]string{"tenant_id", "workspace_id", "display_name", "slug", "created_at", "updated_at"}))
+
+	_, err = store.GetWorkspace(ctx, "workspace-b")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected scoped workspace lookup to fail with ErrNotFound, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreDeleteProjectScoped(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM tenancy_projects
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND project_id = $3`)).
+		WithArgs("tenant-a", "workspace-a", "project-1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := store.DeleteProject(ctx, "workspace-a", "project-1"); err != nil {
+		t.Fatalf("delete project: %v", err)
+	}
+
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM tenancy_projects
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND project_id = $3`)).
+		WithArgs("tenant-a", "workspace-a", "project-missing").
+		WillReturnResult(sqlmock.NewResult(1, 0))
+
+	if err := store.DeleteProject(ctx, "workspace-a", "project-missing"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for missing project delete, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/internal/db/postgres_tenancy_test.go
+++ b/internal/db/postgres_tenancy_test.go
@@ -68,18 +68,35 @@ func TestPostgresStoreWorkspaceScopeIsolation(t *testing.T) {
 	store := NewPostgresStoreWithDB(db)
 	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, workspace_id, display_name, slug, created_at, updated_at
-		 FROM tenancy_workspaces
-		 WHERE tenant_id = $1
-		   AND workspace_id = $2`)).
-		WithArgs("tenant-a", "workspace-b").
-		WillReturnRows(sqlmock.NewRows([]string{"tenant_id", "workspace_id", "display_name", "slug", "created_at", "updated_at"}))
-
 	_, err = store.GetWorkspace(ctx, "workspace-b")
 	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected scoped workspace lookup to fail with ErrNotFound, got %v", err)
 	}
 
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreUpsertProjectRejectsCrossWorkspaceScope(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+
+	err = store.UpsertProject(ctx, TenancyProject{
+		WorkspaceID: "workspace-b",
+		ProjectID:   "project-1",
+		Name:        "Project 1",
+		Slug:        "project-1",
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for cross-workspace upsert, got %v", err)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
 	}

--- a/internal/db/scope.go
+++ b/internal/db/scope.go
@@ -88,3 +88,17 @@ func MatchScope(scope Scope, tenantID string, workspaceID string) bool {
 	return strings.TrimSpace(tenantID) == normalized.TenantID &&
 		strings.TrimSpace(workspaceID) == normalized.WorkspaceID
 }
+
+// ResolveScopedWorkspaceID normalizes one workspace identifier and enforces
+// that it remains within the active request scope.
+func ResolveScopedWorkspaceID(scope Scope, workspaceID string) (string, error) {
+	normalizedScope := scope.Normalize()
+	resolved := strings.TrimSpace(workspaceID)
+	if resolved == "" {
+		resolved = normalizedScope.WorkspaceID
+	}
+	if resolved != normalizedScope.WorkspaceID {
+		return "", ErrNotFound
+	}
+	return resolved, nil
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -23,6 +23,7 @@ var ErrNotFound = errors.New("record not found")
 var ErrScopeRequired = errors.New("scope is required")
 
 var authzOwnerTeamPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
+var tenancySlugPattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 
 const (
 	ScanEventLevelDebug = "debug"
@@ -105,6 +106,20 @@ var validAuthzPolicyRolloutModes = map[string]struct{}{
 	AuthzPolicyRolloutModeDisabled: {},
 	AuthzPolicyRolloutModeShadow:   {},
 	AuthzPolicyRolloutModeEnforce:  {},
+}
+
+var validTenancyMemberRoles = map[string]struct{}{
+	"owner":   {},
+	"admin":   {},
+	"analyst": {},
+	"viewer":  {},
+}
+
+var validTenancyMemberStatuses = map[string]struct{}{
+	"invited":   {},
+	"active":    {},
+	"suspended": {},
+	"removed":   {},
 }
 
 // ScanRecord tracks persisted scan execution metadata.
@@ -273,6 +288,51 @@ type AuthzPolicyEvent struct {
 	Message     string         `json:"message,omitempty"`
 	Metadata    map[string]any `json:"metadata,omitempty"`
 	CreatedAt   time.Time      `json:"created_at"`
+}
+
+// TenancyOrganization stores one tenant root metadata record.
+type TenancyOrganization struct {
+	TenantID    string    `json:"tenant_id"`
+	DisplayName string    `json:"display_name"`
+	Slug        string    `json:"slug"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// TenancyWorkspace stores one workspace metadata record.
+type TenancyWorkspace struct {
+	TenantID    string    `json:"tenant_id"`
+	WorkspaceID string    `json:"workspace_id"`
+	DisplayName string    `json:"display_name"`
+	Slug        string    `json:"slug"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// TenancyWorkspaceMember stores one workspace member assignment.
+type TenancyWorkspaceMember struct {
+	TenantID    string    `json:"tenant_id"`
+	WorkspaceID string    `json:"workspace_id"`
+	MemberID    string    `json:"member_id"`
+	UserID      string    `json:"user_id"`
+	Email       string    `json:"email,omitempty"`
+	Role        string    `json:"role"`
+	Status      string    `json:"status"`
+	JoinedAt    time.Time `json:"joined_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// TenancyProject stores one project metadata record.
+type TenancyProject struct {
+	TenantID    string     `json:"tenant_id"`
+	WorkspaceID string     `json:"workspace_id"`
+	ProjectID   string     `json:"project_id"`
+	Name        string     `json:"name"`
+	Slug        string     `json:"slug"`
+	Description string     `json:"description,omitempty"`
+	ArchivedAt  *time.Time `json:"archived_at,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
 }
 
 // NormalizeScanEventLevel validates and normalizes event levels.
@@ -537,6 +597,170 @@ func containsInt(values []int, value int) bool {
 	return false
 }
 
+func validateTenancySlug(value, field string) error {
+	if len(value) > 63 {
+		return fmt.Errorf("%s must be 63 characters or fewer", field)
+	}
+	if !tenancySlugPattern.MatchString(value) {
+		return fmt.Errorf("%s must match %s", field, tenancySlugPattern.String())
+	}
+	return nil
+}
+
+// NormalizeTenancyOrganizationForWrite validates and canonicalizes organization metadata.
+func NormalizeTenancyOrganizationForWrite(organization TenancyOrganization) (TenancyOrganization, error) {
+	normalized := organization
+	normalized.TenantID = strings.TrimSpace(organization.TenantID)
+	if normalized.TenantID == "" {
+		return TenancyOrganization{}, fmt.Errorf("tenant id is required")
+	}
+	normalized.DisplayName = strings.TrimSpace(organization.DisplayName)
+	if normalized.DisplayName == "" {
+		return TenancyOrganization{}, fmt.Errorf("display name is required")
+	}
+	normalized.Slug = strings.ToLower(strings.TrimSpace(organization.Slug))
+	if normalized.Slug == "" {
+		return TenancyOrganization{}, fmt.Errorf("slug is required")
+	}
+	if err := validateTenancySlug(normalized.Slug, "slug"); err != nil {
+		return TenancyOrganization{}, err
+	}
+	if normalized.CreatedAt.IsZero() {
+		normalized.CreatedAt = time.Now().UTC()
+	} else {
+		normalized.CreatedAt = normalized.CreatedAt.UTC()
+	}
+	if normalized.UpdatedAt.IsZero() {
+		normalized.UpdatedAt = normalized.CreatedAt
+	} else {
+		normalized.UpdatedAt = normalized.UpdatedAt.UTC()
+	}
+	return normalized, nil
+}
+
+// NormalizeTenancyWorkspaceForWrite validates and canonicalizes workspace metadata.
+func NormalizeTenancyWorkspaceForWrite(workspace TenancyWorkspace) (TenancyWorkspace, error) {
+	normalized := workspace
+	normalized.TenantID = strings.TrimSpace(workspace.TenantID)
+	if normalized.TenantID == "" {
+		return TenancyWorkspace{}, fmt.Errorf("tenant id is required")
+	}
+	normalized.WorkspaceID = strings.TrimSpace(workspace.WorkspaceID)
+	if normalized.WorkspaceID == "" {
+		return TenancyWorkspace{}, fmt.Errorf("workspace id is required")
+	}
+	normalized.DisplayName = strings.TrimSpace(workspace.DisplayName)
+	if normalized.DisplayName == "" {
+		return TenancyWorkspace{}, fmt.Errorf("display name is required")
+	}
+	normalized.Slug = strings.ToLower(strings.TrimSpace(workspace.Slug))
+	if normalized.Slug == "" {
+		return TenancyWorkspace{}, fmt.Errorf("slug is required")
+	}
+	if err := validateTenancySlug(normalized.Slug, "slug"); err != nil {
+		return TenancyWorkspace{}, err
+	}
+	if normalized.CreatedAt.IsZero() {
+		normalized.CreatedAt = time.Now().UTC()
+	} else {
+		normalized.CreatedAt = normalized.CreatedAt.UTC()
+	}
+	if normalized.UpdatedAt.IsZero() {
+		normalized.UpdatedAt = normalized.CreatedAt
+	} else {
+		normalized.UpdatedAt = normalized.UpdatedAt.UTC()
+	}
+	return normalized, nil
+}
+
+// NormalizeTenancyWorkspaceMemberForWrite validates and canonicalizes workspace members.
+func NormalizeTenancyWorkspaceMemberForWrite(member TenancyWorkspaceMember) (TenancyWorkspaceMember, error) {
+	normalized := member
+	normalized.TenantID = strings.TrimSpace(member.TenantID)
+	if normalized.TenantID == "" {
+		return TenancyWorkspaceMember{}, fmt.Errorf("tenant id is required")
+	}
+	normalized.WorkspaceID = strings.TrimSpace(member.WorkspaceID)
+	if normalized.WorkspaceID == "" {
+		return TenancyWorkspaceMember{}, fmt.Errorf("workspace id is required")
+	}
+	normalized.MemberID = strings.TrimSpace(member.MemberID)
+	if normalized.MemberID == "" {
+		return TenancyWorkspaceMember{}, fmt.Errorf("member id is required")
+	}
+	normalized.UserID = strings.TrimSpace(member.UserID)
+	if normalized.UserID == "" {
+		return TenancyWorkspaceMember{}, fmt.Errorf("user id is required")
+	}
+	normalized.Email = strings.TrimSpace(member.Email)
+	normalized.Role = strings.ToLower(strings.TrimSpace(member.Role))
+	if _, ok := validTenancyMemberRoles[normalized.Role]; !ok {
+		return TenancyWorkspaceMember{}, fmt.Errorf("invalid member role")
+	}
+	normalized.Status = strings.ToLower(strings.TrimSpace(member.Status))
+	if normalized.Status == "" {
+		normalized.Status = "invited"
+	}
+	if _, ok := validTenancyMemberStatuses[normalized.Status]; !ok {
+		return TenancyWorkspaceMember{}, fmt.Errorf("invalid member status")
+	}
+	if normalized.JoinedAt.IsZero() {
+		normalized.JoinedAt = time.Now().UTC()
+	} else {
+		normalized.JoinedAt = normalized.JoinedAt.UTC()
+	}
+	if normalized.UpdatedAt.IsZero() {
+		normalized.UpdatedAt = normalized.JoinedAt
+	} else {
+		normalized.UpdatedAt = normalized.UpdatedAt.UTC()
+	}
+	return normalized, nil
+}
+
+// NormalizeTenancyProjectForWrite validates and canonicalizes project metadata.
+func NormalizeTenancyProjectForWrite(project TenancyProject) (TenancyProject, error) {
+	normalized := project
+	normalized.TenantID = strings.TrimSpace(project.TenantID)
+	if normalized.TenantID == "" {
+		return TenancyProject{}, fmt.Errorf("tenant id is required")
+	}
+	normalized.WorkspaceID = strings.TrimSpace(project.WorkspaceID)
+	if normalized.WorkspaceID == "" {
+		return TenancyProject{}, fmt.Errorf("workspace id is required")
+	}
+	normalized.ProjectID = strings.TrimSpace(project.ProjectID)
+	if normalized.ProjectID == "" {
+		return TenancyProject{}, fmt.Errorf("project id is required")
+	}
+	normalized.Name = strings.TrimSpace(project.Name)
+	if normalized.Name == "" {
+		return TenancyProject{}, fmt.Errorf("project name is required")
+	}
+	normalized.Slug = strings.ToLower(strings.TrimSpace(project.Slug))
+	if normalized.Slug == "" {
+		return TenancyProject{}, fmt.Errorf("project slug is required")
+	}
+	if err := validateTenancySlug(normalized.Slug, "project slug"); err != nil {
+		return TenancyProject{}, err
+	}
+	normalized.Description = strings.TrimSpace(project.Description)
+	if normalized.ArchivedAt != nil {
+		archived := normalized.ArchivedAt.UTC()
+		normalized.ArchivedAt = &archived
+	}
+	if normalized.CreatedAt.IsZero() {
+		normalized.CreatedAt = time.Now().UTC()
+	} else {
+		normalized.CreatedAt = normalized.CreatedAt.UTC()
+	}
+	if normalized.UpdatedAt.IsZero() {
+		normalized.UpdatedAt = normalized.CreatedAt
+	} else {
+		normalized.UpdatedAt = normalized.UpdatedAt.UTC()
+	}
+	return normalized, nil
+}
+
 // NormalizeAuthzPolicyEventForWrite validates and canonicalizes one immutable policy event.
 func NormalizeAuthzPolicyEventForWrite(event AuthzPolicyEvent) (AuthzPolicyEvent, error) {
 	normalized := event
@@ -633,6 +857,21 @@ type Store interface {
 	GetAuthzPolicyRollout(ctx context.Context, policySetID string) (AuthzPolicyRollout, error)
 	AppendAuthzPolicyEvent(ctx context.Context, event AuthzPolicyEvent) error
 	ListAuthzPolicyEvents(ctx context.Context, policySetID string, limit int) ([]AuthzPolicyEvent, error)
+	UpsertOrganization(ctx context.Context, organization TenancyOrganization) error
+	GetOrganization(ctx context.Context) (TenancyOrganization, error)
+	DeleteOrganization(ctx context.Context) error
+	UpsertWorkspace(ctx context.Context, workspace TenancyWorkspace) error
+	GetWorkspace(ctx context.Context, workspaceID string) (TenancyWorkspace, error)
+	ListWorkspaces(ctx context.Context, limit int) ([]TenancyWorkspace, error)
+	DeleteWorkspace(ctx context.Context, workspaceID string) error
+	UpsertWorkspaceMember(ctx context.Context, member TenancyWorkspaceMember) error
+	GetWorkspaceMember(ctx context.Context, workspaceID string, memberID string) (TenancyWorkspaceMember, error)
+	ListWorkspaceMembers(ctx context.Context, workspaceID string, limit int) ([]TenancyWorkspaceMember, error)
+	DeleteWorkspaceMember(ctx context.Context, workspaceID string, memberID string) error
+	UpsertProject(ctx context.Context, project TenancyProject) error
+	GetProject(ctx context.Context, workspaceID string, projectID string) (TenancyProject, error)
+	ListProjects(ctx context.Context, workspaceID string, includeArchived bool, limit int) ([]TenancyProject, error)
+	DeleteProject(ctx context.Context, workspaceID string, projectID string) error
 	ListIdentities(ctx context.Context, filter IdentityFilter, limit int) ([]domain.Identity, error)
 	ListRelationships(ctx context.Context, filter RelationshipFilter, limit int) ([]domain.Relationship, error)
 	AppendScanEvent(ctx context.Context, scanID string, level string, message string, metadata map[string]any) error

--- a/internal/db/tenancy_store_test.go
+++ b/internal/db/tenancy_store_test.go
@@ -1,0 +1,164 @@
+package db
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNormalizeTenancyOrganizationForWrite(t *testing.T) {
+	normalized, err := NormalizeTenancyOrganizationForWrite(TenancyOrganization{
+		TenantID:    " tenant-a ",
+		DisplayName: " Core Org ",
+		Slug:        " CORE ",
+	})
+	if err != nil {
+		t.Fatalf("normalize organization: %v", err)
+	}
+	if normalized.TenantID != "tenant-a" {
+		t.Fatalf("expected tenant id tenant-a, got %q", normalized.TenantID)
+	}
+	if normalized.Slug != "core" {
+		t.Fatalf("expected lower slug, got %q", normalized.Slug)
+	}
+	if normalized.CreatedAt.IsZero() || normalized.UpdatedAt.IsZero() {
+		t.Fatal("expected generated timestamps")
+	}
+
+	if _, err := NormalizeTenancyOrganizationForWrite(TenancyOrganization{}); err == nil {
+		t.Fatal("expected required field validation error")
+	}
+	if _, err := NormalizeTenancyOrganizationForWrite(TenancyOrganization{
+		TenantID:    "tenant-a",
+		DisplayName: "Tenant A",
+		Slug:        "tenant a",
+	}); err == nil {
+		t.Fatal("expected invalid organization slug format error")
+	}
+}
+
+func TestNormalizeTenancyWorkspaceMemberForWrite(t *testing.T) {
+	joinedAt := time.Date(2026, 4, 1, 10, 0, 0, 0, time.FixedZone("WAT", 1*60*60))
+	normalized, err := NormalizeTenancyWorkspaceMemberForWrite(TenancyWorkspaceMember{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		MemberID:    "member-1",
+		UserID:      "user-1",
+		Email:       " user@example.com ",
+		Role:        "ADMIN",
+		Status:      "ACTIVE",
+		JoinedAt:    joinedAt,
+	})
+	if err != nil {
+		t.Fatalf("normalize member: %v", err)
+	}
+	if normalized.Role != "admin" || normalized.Status != "active" {
+		t.Fatalf("expected normalized role/status, got role=%q status=%q", normalized.Role, normalized.Status)
+	}
+	if normalized.Email != "user@example.com" {
+		t.Fatalf("expected trimmed email, got %q", normalized.Email)
+	}
+	if normalized.JoinedAt.Location() != time.UTC {
+		t.Fatalf("expected UTC joined_at, got %v", normalized.JoinedAt.Location())
+	}
+
+	if _, err := NormalizeTenancyWorkspaceMemberForWrite(TenancyWorkspaceMember{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		MemberID:    "member-1",
+		UserID:      "user-1",
+		Role:        "invalid",
+		Status:      "active",
+	}); err == nil {
+		t.Fatal("expected invalid role error")
+	}
+}
+
+func TestNormalizeTenancyProjectForWrite(t *testing.T) {
+	archivedAt := time.Date(2026, 4, 2, 10, 0, 0, 0, time.FixedZone("WAT", 1*60*60))
+	normalized, err := NormalizeTenancyProjectForWrite(TenancyProject{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-a",
+		Name:        " Payments ",
+		Slug:        " PAYMENTS ",
+		ArchivedAt:  &archivedAt,
+	})
+	if err != nil {
+		t.Fatalf("normalize project: %v", err)
+	}
+	if normalized.Name != "Payments" || normalized.Slug != "payments" {
+		t.Fatalf("expected normalized name/slug, got name=%q slug=%q", normalized.Name, normalized.Slug)
+	}
+	if normalized.ArchivedAt == nil || normalized.ArchivedAt.Location() != time.UTC {
+		t.Fatalf("expected UTC archived_at, got %+v", normalized.ArchivedAt)
+	}
+
+	if _, err := NormalizeTenancyProjectForWrite(TenancyProject{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-a",
+		Name:        "",
+		Slug:        "payments",
+	}); err == nil {
+		t.Fatal("expected project name required error")
+	}
+	if _, err := NormalizeTenancyProjectForWrite(TenancyProject{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-a",
+		Name:        "Payments",
+		Slug:        "project/a",
+	}); err == nil {
+		t.Fatal("expected project slug format validation error")
+	}
+	if _, err := NormalizeTenancyProjectForWrite(TenancyProject{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-a",
+		Name:        "Payments",
+		Slug:        "project-",
+	}); err == nil {
+		t.Fatal("expected trailing hyphen slug to fail")
+	}
+	if _, err := NormalizeTenancyProjectForWrite(TenancyProject{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-a",
+		Name:        "Payments",
+		Slug:        "project--a",
+	}); err == nil {
+		t.Fatal("expected consecutive hyphen slug to fail")
+	}
+}
+
+func TestNormalizeTenancyWorkspaceForWrite(t *testing.T) {
+	now := time.Date(2026, 4, 4, 10, 0, 0, 0, time.FixedZone("WAT", 1*60*60))
+	normalized, err := NormalizeTenancyWorkspaceForWrite(TenancyWorkspace{
+		TenantID:    " tenant-a ",
+		WorkspaceID: " workspace-a ",
+		DisplayName: " Workspace A ",
+		Slug:        " WORKSPACE-A ",
+		CreatedAt:   now,
+	})
+	if err != nil {
+		t.Fatalf("normalize workspace: %v", err)
+	}
+	if normalized.TenantID != "tenant-a" || normalized.WorkspaceID != "workspace-a" {
+		t.Fatalf("expected trimmed tenant/workspace ids, got tenant=%q workspace=%q", normalized.TenantID, normalized.WorkspaceID)
+	}
+	if normalized.DisplayName != "Workspace A" || normalized.Slug != "workspace-a" {
+		t.Fatalf("expected normalized display name/slug, got display_name=%q slug=%q", normalized.DisplayName, normalized.Slug)
+	}
+	if normalized.CreatedAt.Location() != time.UTC || normalized.UpdatedAt.Location() != time.UTC {
+		t.Fatalf("expected UTC timestamps, got created_at=%v updated_at=%v", normalized.CreatedAt.Location(), normalized.UpdatedAt.Location())
+	}
+
+	if _, err := NormalizeTenancyWorkspaceForWrite(TenancyWorkspace{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		DisplayName: "Workspace A",
+		Slug:        "workspace/a",
+	}); err == nil {
+		t.Fatal("expected workspace slug format validation error")
+	}
+}

--- a/internal/domain/appmode.go
+++ b/internal/domain/appmode.go
@@ -1,0 +1,479 @@
+package domain
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var appModeIdentifierPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,63}$`)
+
+// MemberRole enumerates tenancy-level permissions within a workspace.
+type MemberRole string
+
+const (
+	MemberRoleOwner   MemberRole = "owner"
+	MemberRoleAdmin   MemberRole = "admin"
+	MemberRoleAnalyst MemberRole = "analyst"
+	MemberRoleViewer  MemberRole = "viewer"
+)
+
+// MemberStatus tracks workspace membership lifecycle state.
+type MemberStatus string
+
+const (
+	MemberStatusInvited   MemberStatus = "invited"
+	MemberStatusActive    MemberStatus = "active"
+	MemberStatusSuspended MemberStatus = "suspended"
+	MemberStatusRemoved   MemberStatus = "removed"
+)
+
+// ConnectorType identifies one onboarded source connector.
+type ConnectorType string
+
+const (
+	ConnectorTypeGitHub     ConnectorType = "github"
+	ConnectorTypeAWS        ConnectorType = "aws"
+	ConnectorTypeKubernetes ConnectorType = "kubernetes"
+)
+
+// ConnectorStatus represents connector health and lifecycle state.
+type ConnectorStatus string
+
+const (
+	ConnectorStatusPending      ConnectorStatus = "pending"
+	ConnectorStatusActive       ConnectorStatus = "active"
+	ConnectorStatusDegraded     ConnectorStatus = "degraded"
+	ConnectorStatusDisconnected ConnectorStatus = "disconnected"
+)
+
+// ScanTriggerMode controls scan initiation mode.
+type ScanTriggerMode string
+
+const (
+	ScanTriggerModeManual    ScanTriggerMode = "manual"
+	ScanTriggerModeScheduled ScanTriggerMode = "scheduled"
+	ScanTriggerModeEvent     ScanTriggerMode = "event"
+	ScanTriggerModeHybrid    ScanTriggerMode = "hybrid"
+)
+
+// SuppressionScope controls suppression blast radius.
+type SuppressionScope string
+
+const (
+	SuppressionScopeFinding  SuppressionScope = "finding"
+	SuppressionScopeRule     SuppressionScope = "rule"
+	SuppressionScopeResource SuppressionScope = "resource"
+)
+
+// RemediationJobType identifies one remediation class.
+type RemediationJobType string
+
+const (
+	RemediationJobTypePatchTemplate RemediationJobType = "patch_template"
+	RemediationJobTypeCreateFixPR   RemediationJobType = "create_fix_pr"
+	RemediationJobTypeTicket        RemediationJobType = "ticket"
+)
+
+// RemediationJobStatus tracks remediation execution lifecycle.
+type RemediationJobStatus string
+
+const (
+	RemediationJobStatusQueued    RemediationJobStatus = "queued"
+	RemediationJobStatusRunning   RemediationJobStatus = "running"
+	RemediationJobStatusSucceeded RemediationJobStatus = "succeeded"
+	RemediationJobStatusFailed    RemediationJobStatus = "failed"
+	RemediationJobStatusCanceled  RemediationJobStatus = "canceled"
+)
+
+// Organization models one tenant boundary.
+type Organization struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Slug      string    `json:"slug"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// Workspace models one collaboration boundary within an organization.
+type Workspace struct {
+	ID             string    `json:"id"`
+	OrganizationID string    `json:"organization_id"`
+	Name           string    `json:"name"`
+	Slug           string    `json:"slug"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+// WorkspaceMember models one user assignment in a workspace.
+type WorkspaceMember struct {
+	ID          string       `json:"id"`
+	WorkspaceID string       `json:"workspace_id"`
+	UserID      string       `json:"user_id"`
+	Email       string       `json:"email"`
+	Role        MemberRole   `json:"role"`
+	Status      MemberStatus `json:"status"`
+	JoinedAt    time.Time    `json:"joined_at"`
+	UpdatedAt   time.Time    `json:"updated_at"`
+}
+
+// Project models one scoped application or service boundary in a workspace.
+type Project struct {
+	ID          string     `json:"id"`
+	WorkspaceID string     `json:"workspace_id"`
+	Name        string     `json:"name"`
+	Slug        string     `json:"slug"`
+	Description string     `json:"description,omitempty"`
+	ArchivedAt  *time.Time `json:"archived_at,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+}
+
+// Connector models one project integration source.
+type Connector struct {
+	ID          string          `json:"id"`
+	WorkspaceID string          `json:"workspace_id"`
+	ProjectID   string          `json:"project_id"`
+	Type        ConnectorType   `json:"type"`
+	DisplayName string          `json:"display_name"`
+	Status      ConnectorStatus `json:"status"`
+	LastSyncAt  *time.Time      `json:"last_sync_at,omitempty"`
+	CreatedAt   time.Time       `json:"created_at"`
+	UpdatedAt   time.Time       `json:"updated_at"`
+}
+
+// ScanPolicy models scan scheduling and trigger limits for one project.
+type ScanPolicy struct {
+	ID                 string          `json:"id"`
+	WorkspaceID        string          `json:"workspace_id"`
+	ProjectID          string          `json:"project_id"`
+	Name               string          `json:"name"`
+	Enabled            bool            `json:"enabled"`
+	TriggerMode        ScanTriggerMode `json:"trigger_mode"`
+	Cron               string          `json:"cron,omitempty"`
+	MaxConcurrentScans int             `json:"max_concurrent_scans"`
+	CreatedAt          time.Time       `json:"created_at"`
+	UpdatedAt          time.Time       `json:"updated_at"`
+}
+
+// SuppressionPolicy models policy-based finding suppressions.
+type SuppressionPolicy struct {
+	ID            string           `json:"id"`
+	WorkspaceID   string           `json:"workspace_id"`
+	ProjectID     string           `json:"project_id"`
+	Name          string           `json:"name"`
+	Scope         SuppressionScope `json:"scope"`
+	Target        string           `json:"target"`
+	Reason        string           `json:"reason"`
+	ExpiresAt     *time.Time       `json:"expires_at,omitempty"`
+	CreatedBy     string           `json:"created_by"`
+	CreatedAt     time.Time        `json:"created_at"`
+	LastUpdatedAt time.Time        `json:"last_updated_at"`
+}
+
+// RemediationJob models one remediation execution request.
+type RemediationJob struct {
+	ID            string               `json:"id"`
+	WorkspaceID   string               `json:"workspace_id"`
+	ProjectID     string               `json:"project_id"`
+	FindingID     string               `json:"finding_id"`
+	Type          RemediationJobType   `json:"type"`
+	Status        RemediationJobStatus `json:"status"`
+	RequestedBy   string               `json:"requested_by"`
+	RequestedAt   time.Time            `json:"requested_at"`
+	StartedAt     *time.Time           `json:"started_at,omitempty"`
+	CompletedAt   *time.Time           `json:"completed_at,omitempty"`
+	ArtifactRef   string               `json:"artifact_ref,omitempty"`
+	ErrorMessage  string               `json:"error_message,omitempty"`
+	LastUpdatedAt time.Time            `json:"last_updated_at"`
+}
+
+func (o Organization) Validate() error {
+	if err := validateAppModeIdentifier("organization.id", o.ID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(o.Name) == "" {
+		return fmt.Errorf("organization.name is required")
+	}
+	if err := validateAppModeIdentifier("organization.slug", o.Slug); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (w Workspace) Validate() error {
+	if err := validateAppModeIdentifier("workspace.id", w.ID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("workspace.organization_id", w.OrganizationID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(w.Name) == "" {
+		return fmt.Errorf("workspace.name is required")
+	}
+	if err := validateAppModeIdentifier("workspace.slug", w.Slug); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m WorkspaceMember) Validate() error {
+	if err := validateAppModeIdentifier("workspace_member.id", m.ID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("workspace_member.workspace_id", m.WorkspaceID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("workspace_member.user_id", m.UserID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(m.Email) == "" {
+		return fmt.Errorf("workspace_member.email is required")
+	}
+	if !validMemberRole(m.Role) {
+		return fmt.Errorf("workspace_member.role is invalid")
+	}
+	if !validMemberStatus(m.Status) {
+		return fmt.Errorf("workspace_member.status is invalid")
+	}
+	return nil
+}
+
+func (p Project) Validate() error {
+	if err := validateAppModeIdentifier("project.id", p.ID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("project.workspace_id", p.WorkspaceID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(p.Name) == "" {
+		return fmt.Errorf("project.name is required")
+	}
+	if err := validateAppModeIdentifier("project.slug", p.Slug); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c Connector) Validate() error {
+	if err := validateAppModeIdentifier("connector.id", c.ID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("connector.workspace_id", c.WorkspaceID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("connector.project_id", c.ProjectID); err != nil {
+		return err
+	}
+	if !validConnectorType(c.Type) {
+		return fmt.Errorf("connector.type is invalid")
+	}
+	if strings.TrimSpace(c.DisplayName) == "" {
+		return fmt.Errorf("connector.display_name is required")
+	}
+	if !validConnectorStatus(c.Status) {
+		return fmt.Errorf("connector.status is invalid")
+	}
+	return nil
+}
+
+func (p ScanPolicy) Validate() error {
+	if err := validateAppModeIdentifier("scan_policy.id", p.ID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("scan_policy.workspace_id", p.WorkspaceID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("scan_policy.project_id", p.ProjectID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(p.Name) == "" {
+		return fmt.Errorf("scan_policy.name is required")
+	}
+	if !validScanTriggerMode(p.TriggerMode) {
+		return fmt.Errorf("scan_policy.trigger_mode is invalid")
+	}
+	if p.TriggerMode == ScanTriggerModeScheduled && strings.TrimSpace(p.Cron) == "" {
+		return fmt.Errorf("scan_policy.cron is required for scheduled trigger_mode")
+	}
+	if p.MaxConcurrentScans <= 0 {
+		return fmt.Errorf("scan_policy.max_concurrent_scans must be > 0")
+	}
+	return nil
+}
+
+func (p SuppressionPolicy) Validate() error {
+	if err := validateAppModeIdentifier("suppression_policy.id", p.ID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("suppression_policy.workspace_id", p.WorkspaceID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("suppression_policy.project_id", p.ProjectID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(p.Name) == "" {
+		return fmt.Errorf("suppression_policy.name is required")
+	}
+	if !validSuppressionScope(p.Scope) {
+		return fmt.Errorf("suppression_policy.scope is invalid")
+	}
+	if strings.TrimSpace(p.Target) == "" {
+		return fmt.Errorf("suppression_policy.target is required")
+	}
+	if strings.TrimSpace(p.Reason) == "" {
+		return fmt.Errorf("suppression_policy.reason is required")
+	}
+	if err := validateAppModeIdentifier("suppression_policy.created_by", p.CreatedBy); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (j RemediationJob) Validate() error {
+	if err := validateAppModeIdentifier("remediation_job.id", j.ID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("remediation_job.workspace_id", j.WorkspaceID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("remediation_job.project_id", j.ProjectID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("remediation_job.finding_id", j.FindingID); err != nil {
+		return err
+	}
+	if !validRemediationType(j.Type) {
+		return fmt.Errorf("remediation_job.type is invalid")
+	}
+	if !validRemediationStatus(j.Status) {
+		return fmt.Errorf("remediation_job.status is invalid")
+	}
+	if err := validateAppModeIdentifier("remediation_job.requested_by", j.RequestedBy); err != nil {
+		return err
+	}
+	return nil
+}
+
+func CanTransitionConnectorStatus(from ConnectorStatus, to ConnectorStatus) bool {
+	if from == to {
+		return true
+	}
+	switch from {
+	case ConnectorStatusPending:
+		return to == ConnectorStatusActive || to == ConnectorStatusDisconnected || to == ConnectorStatusDegraded
+	case ConnectorStatusActive:
+		return to == ConnectorStatusDegraded || to == ConnectorStatusDisconnected
+	case ConnectorStatusDegraded:
+		return to == ConnectorStatusActive || to == ConnectorStatusDisconnected
+	case ConnectorStatusDisconnected:
+		return to == ConnectorStatusPending || to == ConnectorStatusActive
+	default:
+		return false
+	}
+}
+
+func CanTransitionRemediationJobStatus(from RemediationJobStatus, to RemediationJobStatus) bool {
+	if from == to {
+		return true
+	}
+	switch from {
+	case RemediationJobStatusQueued:
+		return to == RemediationJobStatusRunning || to == RemediationJobStatusCanceled
+	case RemediationJobStatusRunning:
+		return to == RemediationJobStatusSucceeded || to == RemediationJobStatusFailed || to == RemediationJobStatusCanceled
+	case RemediationJobStatusFailed:
+		return to == RemediationJobStatusQueued
+	case RemediationJobStatusSucceeded, RemediationJobStatusCanceled:
+		return false
+	default:
+		return false
+	}
+}
+
+func validateAppModeIdentifier(field string, value string) error {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return fmt.Errorf("%s is required", field)
+	}
+	if value != trimmed {
+		return fmt.Errorf("%s must not contain surrounding whitespace", field)
+	}
+	if !appModeIdentifierPattern.MatchString(trimmed) {
+		return fmt.Errorf("%s must match %s", field, appModeIdentifierPattern.String())
+	}
+	return nil
+}
+
+func validMemberRole(role MemberRole) bool {
+	switch role {
+	case MemberRoleOwner, MemberRoleAdmin, MemberRoleAnalyst, MemberRoleViewer:
+		return true
+	default:
+		return false
+	}
+}
+
+func validMemberStatus(status MemberStatus) bool {
+	switch status {
+	case MemberStatusInvited, MemberStatusActive, MemberStatusSuspended, MemberStatusRemoved:
+		return true
+	default:
+		return false
+	}
+}
+
+func validConnectorType(connectorType ConnectorType) bool {
+	switch connectorType {
+	case ConnectorTypeGitHub, ConnectorTypeAWS, ConnectorTypeKubernetes:
+		return true
+	default:
+		return false
+	}
+}
+
+func validConnectorStatus(status ConnectorStatus) bool {
+	switch status {
+	case ConnectorStatusPending, ConnectorStatusActive, ConnectorStatusDegraded, ConnectorStatusDisconnected:
+		return true
+	default:
+		return false
+	}
+}
+
+func validScanTriggerMode(mode ScanTriggerMode) bool {
+	switch mode {
+	case ScanTriggerModeManual, ScanTriggerModeScheduled, ScanTriggerModeEvent, ScanTriggerModeHybrid:
+		return true
+	default:
+		return false
+	}
+}
+
+func validSuppressionScope(scope SuppressionScope) bool {
+	switch scope {
+	case SuppressionScopeFinding, SuppressionScopeRule, SuppressionScopeResource:
+		return true
+	default:
+		return false
+	}
+}
+
+func validRemediationType(remediationType RemediationJobType) bool {
+	switch remediationType {
+	case RemediationJobTypePatchTemplate, RemediationJobTypeCreateFixPR, RemediationJobTypeTicket:
+		return true
+	default:
+		return false
+	}
+}
+
+func validRemediationStatus(status RemediationJobStatus) bool {
+	switch status {
+	case RemediationJobStatusQueued, RemediationJobStatusRunning, RemediationJobStatusSucceeded, RemediationJobStatusFailed, RemediationJobStatusCanceled:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/domain/appmode_test.go
+++ b/internal/domain/appmode_test.go
@@ -1,0 +1,237 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAppModeEntitiesValidate(t *testing.T) {
+	now := time.Now().UTC()
+	org := Organization{
+		ID:        "org-core",
+		Name:      "Core Org",
+		Slug:      "core-org",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := org.Validate(); err != nil {
+		t.Fatalf("expected valid organization, got %v", err)
+	}
+
+	workspace := Workspace{
+		ID:             "workspace-core",
+		OrganizationID: org.ID,
+		Name:           "Core Workspace",
+		Slug:           "core-workspace",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := workspace.Validate(); err != nil {
+		t.Fatalf("expected valid workspace, got %v", err)
+	}
+
+	member := WorkspaceMember{
+		ID:          "member-1",
+		WorkspaceID: workspace.ID,
+		UserID:      "user-1",
+		Email:       "user@example.com",
+		Role:        MemberRoleAdmin,
+		Status:      MemberStatusActive,
+		JoinedAt:    now,
+		UpdatedAt:   now,
+	}
+	if err := member.Validate(); err != nil {
+		t.Fatalf("expected valid member, got %v", err)
+	}
+
+	project := Project{
+		ID:          "project-payments",
+		WorkspaceID: workspace.ID,
+		Name:        "Payments",
+		Slug:        "payments",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := project.Validate(); err != nil {
+		t.Fatalf("expected valid project, got %v", err)
+	}
+
+	connector := Connector{
+		ID:          "connector-gh",
+		WorkspaceID: workspace.ID,
+		ProjectID:   project.ID,
+		Type:        ConnectorTypeGitHub,
+		DisplayName: "GitHub Source",
+		Status:      ConnectorStatusActive,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := connector.Validate(); err != nil {
+		t.Fatalf("expected valid connector, got %v", err)
+	}
+
+	policy := ScanPolicy{
+		ID:                 "policy-1",
+		WorkspaceID:        workspace.ID,
+		ProjectID:          project.ID,
+		Name:               "default policy",
+		Enabled:            true,
+		TriggerMode:        ScanTriggerModeHybrid,
+		Cron:               "0 */6 * * *",
+		MaxConcurrentScans: 2,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	if err := policy.Validate(); err != nil {
+		t.Fatalf("expected valid scan policy, got %v", err)
+	}
+
+	suppression := SuppressionPolicy{
+		ID:            "suppression-1",
+		WorkspaceID:   workspace.ID,
+		ProjectID:     project.ID,
+		Name:          "temporary exception",
+		Scope:         SuppressionScopeRule,
+		Target:        "secret_exposure",
+		Reason:        "approved exception",
+		CreatedBy:     "admin-user",
+		CreatedAt:     now,
+		LastUpdatedAt: now,
+	}
+	if err := suppression.Validate(); err != nil {
+		t.Fatalf("expected valid suppression policy, got %v", err)
+	}
+
+	remediation := RemediationJob{
+		ID:            "remediation-1",
+		WorkspaceID:   workspace.ID,
+		ProjectID:     project.ID,
+		FindingID:     "finding-123",
+		Type:          RemediationJobTypeCreateFixPR,
+		Status:        RemediationJobStatusQueued,
+		RequestedBy:   "admin-user",
+		RequestedAt:   now,
+		LastUpdatedAt: now,
+	}
+	if err := remediation.Validate(); err != nil {
+		t.Fatalf("expected valid remediation job, got %v", err)
+	}
+}
+
+func TestAppModeEntityValidationFailsOnMissingRequiredFields(t *testing.T) {
+	if err := (Organization{}).Validate(); err == nil {
+		t.Fatal("expected organization validation to fail")
+	}
+	if err := (Workspace{}).Validate(); err == nil {
+		t.Fatal("expected workspace validation to fail")
+	}
+	if err := (WorkspaceMember{}).Validate(); err == nil {
+		t.Fatal("expected workspace member validation to fail")
+	}
+	if err := (Project{}).Validate(); err == nil {
+		t.Fatal("expected project validation to fail")
+	}
+	if err := (Connector{}).Validate(); err == nil {
+		t.Fatal("expected connector validation to fail")
+	}
+	if err := (ScanPolicy{}).Validate(); err == nil {
+		t.Fatal("expected scan policy validation to fail")
+	}
+	if err := (SuppressionPolicy{}).Validate(); err == nil {
+		t.Fatal("expected suppression policy validation to fail")
+	}
+	if err := (RemediationJob{}).Validate(); err == nil {
+		t.Fatal("expected remediation job validation to fail")
+	}
+}
+
+func TestAppModeIdentifierRejectsSurroundingWhitespace(t *testing.T) {
+	org := Organization{
+		ID:   "  org-1  ",
+		Name: "Org One",
+		Slug: "org-one",
+	}
+	if err := org.Validate(); err == nil {
+		t.Fatal("expected identifier with surrounding whitespace to fail")
+	}
+}
+
+func TestWorkspaceMemberValidationRequiresEmail(t *testing.T) {
+	now := time.Now().UTC()
+	member := WorkspaceMember{
+		ID:          "member-1",
+		WorkspaceID: "workspace-core",
+		UserID:      "user-1",
+		Email:       "   ",
+		Role:        MemberRoleViewer,
+		Status:      MemberStatusInvited,
+		JoinedAt:    now,
+		UpdatedAt:   now,
+	}
+	if err := member.Validate(); err == nil {
+		t.Fatal("expected workspace member email validation to fail")
+	}
+}
+
+func TestScanPolicyScheduledValidationRequiresCron(t *testing.T) {
+	now := time.Now().UTC()
+	policy := ScanPolicy{
+		ID:                 "policy-1",
+		WorkspaceID:        "workspace-core",
+		ProjectID:          "project-core",
+		Name:               "scheduled policy",
+		Enabled:            true,
+		TriggerMode:        ScanTriggerModeScheduled,
+		MaxConcurrentScans: 1,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	if err := policy.Validate(); err == nil {
+		t.Fatal("expected scan policy scheduled validation to fail when cron is missing")
+	}
+}
+
+func TestRemediationJobValidationRequiresValidFindingID(t *testing.T) {
+	now := time.Now().UTC()
+	job := RemediationJob{
+		ID:            "remediation-1",
+		WorkspaceID:   "workspace-core",
+		ProjectID:     "project-core",
+		FindingID:     "finding bad",
+		Type:          RemediationJobTypeCreateFixPR,
+		Status:        RemediationJobStatusQueued,
+		RequestedBy:   "admin-user",
+		RequestedAt:   now,
+		LastUpdatedAt: now,
+	}
+	if err := job.Validate(); err == nil {
+		t.Fatal("expected remediation job finding_id validation to fail")
+	}
+}
+
+func TestConnectorStatusTransitions(t *testing.T) {
+	if !CanTransitionConnectorStatus(ConnectorStatusPending, ConnectorStatusActive) {
+		t.Fatal("expected pending -> active transition to be valid")
+	}
+	if CanTransitionConnectorStatus(ConnectorStatusActive, ConnectorStatusPending) {
+		t.Fatal("expected active -> pending transition to be invalid")
+	}
+	if !CanTransitionConnectorStatus(ConnectorStatusDegraded, ConnectorStatusActive) {
+		t.Fatal("expected degraded -> active transition to be valid")
+	}
+}
+
+func TestRemediationStatusTransitions(t *testing.T) {
+	if !CanTransitionRemediationJobStatus(RemediationJobStatusQueued, RemediationJobStatusRunning) {
+		t.Fatal("expected queued -> running transition to be valid")
+	}
+	if !CanTransitionRemediationJobStatus(RemediationJobStatusRunning, RemediationJobStatusSucceeded) {
+		t.Fatal("expected running -> succeeded transition to be valid")
+	}
+	if CanTransitionRemediationJobStatus(RemediationJobStatusSucceeded, RemediationJobStatusQueued) {
+		t.Fatal("expected succeeded -> queued transition to be invalid")
+	}
+	if !CanTransitionRemediationJobStatus(RemediationJobStatusFailed, RemediationJobStatusQueued) {
+		t.Fatal("expected failed -> queued transition to be valid for retry")
+	}
+}

--- a/internal/domain/json_tags_test.go
+++ b/internal/domain/json_tags_test.go
@@ -61,3 +61,33 @@ func TestIdentityJSONUsesSnakeCaseFields(t *testing.T) {
 		t.Fatalf("unexpected struct field casing leaked in payload: %s", text)
 	}
 }
+
+func TestAppModeEntityJSONUsesSnakeCaseFields(t *testing.T) {
+	now := time.Date(2026, 3, 16, 0, 0, 0, 0, time.UTC)
+	connector := Connector{
+		ID:          "connector-1",
+		WorkspaceID: "workspace-1",
+		ProjectID:   "project-1",
+		Type:        ConnectorTypeGitHub,
+		DisplayName: "GitHub",
+		Status:      ConnectorStatusActive,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	payload, err := json.Marshal(connector)
+	if err != nil {
+		t.Fatalf("marshal connector: %v", err)
+	}
+	text := string(payload)
+	for _, expected := range []string{`"workspace_id"`, `"project_id"`, `"display_name"`, `"created_at"`} {
+		if !strings.Contains(text, expected) {
+			t.Fatalf("expected field %s in %s", expected, text)
+		}
+	}
+	for _, unexpected := range []string{`"WorkspaceID"`, `"ProjectID"`, `"DisplayName"`} {
+		if strings.Contains(text, unexpected) {
+			t.Fatalf("unexpected struct field casing leaked in payload: %s", text)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -38,6 +38,9 @@ func NewBootstrap(ctx context.Context, cfg config.Config) (Bootstrap, error) {
 	for _, warning := range config.SecurityWarnings(cfg) {
 		logger.Warn("security configuration warning", telemetry.String("detail", warning))
 	}
+	for _, diagnostic := range config.StartupDiagnostics(cfg) {
+		logger.Info("startup configuration diagnostic", telemetry.String("detail", diagnostic))
+	}
 
 	metrics := telemetry.NewMetrics()
 	traceShutdown, err := telemetry.SetupTracing(ctx, cfg.ServiceName)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -35,6 +35,9 @@ func Run(ctx context.Context, cfg config.Config, signals <-chan os.Signal) error
 	for _, warning := range config.SecurityWarnings(cfg) {
 		logger.Warn("security configuration warning", telemetry.String("detail", warning))
 	}
+	for _, diagnostic := range config.StartupDiagnostics(cfg) {
+		logger.Info("startup configuration diagnostic", telemetry.String("detail", diagnostic))
+	}
 
 	traceShutdown, err := telemetry.SetupTracing(ctx, cfg.ServiceName+"-worker")
 	if err != nil {

--- a/migrations/000012_tenancy_core_entities.down.sql
+++ b/migrations/000012_tenancy_core_entities.down.sql
@@ -1,0 +1,9 @@
+DROP INDEX IF EXISTS idx_tenancy_projects_scope_archived;
+DROP INDEX IF EXISTS idx_tenancy_projects_scope_created;
+DROP INDEX IF EXISTS idx_tenancy_members_scope_role_status;
+DROP INDEX IF EXISTS idx_tenancy_workspaces_scope_created;
+
+DROP TABLE IF EXISTS tenancy_projects;
+DROP TABLE IF EXISTS tenancy_workspace_members;
+DROP TABLE IF EXISTS tenancy_workspaces;
+DROP TABLE IF EXISTS tenancy_organizations;

--- a/migrations/000012_tenancy_core_entities.up.sql
+++ b/migrations/000012_tenancy_core_entities.up.sql
@@ -1,0 +1,74 @@
+CREATE TABLE IF NOT EXISTS tenancy_organizations (
+    tenant_id TEXT PRIMARY KEY,
+    display_name TEXT NOT NULL,
+    slug TEXT NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CHECK (LENGTH(TRIM(tenant_id)) > 0),
+    CHECK (LENGTH(TRIM(display_name)) > 0),
+    CHECK (LENGTH(TRIM(slug)) > 0)
+);
+
+CREATE TABLE IF NOT EXISTS tenancy_workspaces (
+    tenant_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    slug TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, workspace_id),
+    UNIQUE (tenant_id, slug),
+    FOREIGN KEY (tenant_id) REFERENCES tenancy_organizations(tenant_id) ON DELETE CASCADE,
+    CHECK (LENGTH(TRIM(workspace_id)) > 0),
+    CHECK (LENGTH(TRIM(display_name)) > 0),
+    CHECK (LENGTH(TRIM(slug)) > 0)
+);
+
+CREATE TABLE IF NOT EXISTS tenancy_workspace_members (
+    tenant_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    member_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    email TEXT,
+    role TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'invited',
+    joined_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, workspace_id, member_id),
+    UNIQUE (tenant_id, workspace_id, user_id),
+    FOREIGN KEY (tenant_id, workspace_id) REFERENCES tenancy_workspaces(tenant_id, workspace_id) ON DELETE CASCADE,
+    CHECK (LENGTH(TRIM(member_id)) > 0),
+    CHECK (LENGTH(TRIM(user_id)) > 0),
+    CHECK (role IN ('owner', 'admin', 'analyst', 'viewer')),
+    CHECK (status IN ('invited', 'active', 'suspended', 'removed'))
+);
+
+CREATE TABLE IF NOT EXISTS tenancy_projects (
+    tenant_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    slug TEXT NOT NULL,
+    description TEXT,
+    archived_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, workspace_id, project_id),
+    UNIQUE (tenant_id, workspace_id, slug),
+    FOREIGN KEY (tenant_id, workspace_id) REFERENCES tenancy_workspaces(tenant_id, workspace_id) ON DELETE CASCADE,
+    CHECK (LENGTH(TRIM(project_id)) > 0),
+    CHECK (LENGTH(TRIM(name)) > 0),
+    CHECK (LENGTH(TRIM(slug)) > 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenancy_workspaces_scope_created
+    ON tenancy_workspaces (tenant_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_tenancy_members_scope_role_status
+    ON tenancy_workspace_members (tenant_id, workspace_id, role, status);
+
+CREATE INDEX IF NOT EXISTS idx_tenancy_projects_scope_created
+    ON tenancy_projects (tenant_id, workspace_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_tenancy_projects_scope_archived
+    ON tenancy_projects (tenant_id, workspace_id, archived_at);


### PR DESCRIPTION
## Summary

Describe what changed.

## Why

Describe the problem this PR solves.

## Scope

- [ ] Focused change (no unrelated modifications)
- [ ] Backward compatibility considered
- [ ] Risk level assessed

## Validation

List the checks you ran and their outcomes.

```bash
# Example:
# go test ./...
# npm run test:ci --prefix web
```

## Checklist

- [ ] Tests added/updated for behavior changes
- [ ] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [ ] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

If AI tools were used materially for this PR, complete the fields below.

- AI-assisted: yes/no
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Required for this repository size:

- Include at least one issue reference using closing/reference keywords:
  - `Closes #123`, `Fixes #123`, or `Refs #123`
- If no issue exists, include an explicit exemption with rationale:
  - `No issue: <reason>` (for example: docs-only typo fix, CI-only fix, or emergency hotfix)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add multi-tenant app‑mode core with a scoped tenancy store (organization, workspace, member, project), new OpenAPI endpoints, and DB migrations. Implements ITR-004 tenancy store and adds app‑mode runtime flags with security validation and startup diagnostics.

- **New Features**
  - Scoped tenancy CRUD in `internal/db` for Postgres and in‑memory stores with strict `tenant_id`/`workspace_id` enforcement.
  - App‑mode domain entities and validation in `internal/domain/appmode.go` with snake_case JSON tests.
  - Tenancy and ProjectManagement OpenAPI paths in `docs/openapi-v1.yaml` with contract tests.
  - App‑mode feature flags and rollout controls in `internal/config` (security checks + startup diagnostics); docs updated.

- **Migration**
  - Apply `migrations/000012_tenancy_core_entities.up.sql`.
  - Enable app‑mode via `IDENTRAIL_APP_MODE_ENABLED=true` and opt‑in sub‑flags as needed (see docs).
  - Regenerate API clients if you consume `docs/openapi-v1.yaml` generated SDKs.

<sup>Written for commit 70d2e6fc1c535d7eb0bf663df73f50245b778a89. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/598?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

