### PR TITLE
ITR-002/003/004: domain models, tenancy migrations, and scoped store layer

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - Repository exposure scanner: `repo-exposure.md`
 - Execution model (API enqueue + worker processing): `execution-model.md`
 - Configuration reference: `configuration-reference.md`
+- Domain entity model: `domain-entities.md`
 
 ## Release and supply chain track
 

--- a/docs/domain-entities.md
+++ b/docs/domain-entities.md
@@ -1,0 +1,63 @@
+# Domain Entity Model (App Mode)
+
+This document defines the normalized multi-tenant app-mode entities introduced for tenancy, project, connector, policy, and remediation workflows.
+
+## Tenancy Core
+
+- `Organization`
+  - Fields: `id`, `name`, `slug`, `created_at`, `updated_at`
+  - Validation: non-empty id/name/slug with identifier-safe formatting.
+- `Workspace`
+  - Fields: `id`, `organization_id`, `name`, `slug`, `created_at`, `updated_at`
+  - Validation: required org reference and identifier-safe ids/slugs.
+- `WorkspaceMember`
+  - Fields: `id`, `workspace_id`, `user_id`, `email`, `role`, `status`, `joined_at`, `updated_at`
+  - Role enum: `owner|admin|analyst|viewer`
+  - Status enum: `invited|active|suspended|removed`
+
+## Project and Connector
+
+- `Project`
+  - Fields: `id`, `workspace_id`, `name`, `slug`, `description`, `archived_at`, `created_at`, `updated_at`
+  - Validation: required workspace and project identity fields.
+- `Connector`
+  - Fields: `id`, `workspace_id`, `project_id`, `type`, `display_name`, `status`, `last_sync_at`, `created_at`, `updated_at`
+  - Type enum: `github|aws|kubernetes`
+  - Status enum: `pending|active|degraded|disconnected`
+  - Transition contract:
+    - `pending -> active|degraded|disconnected`
+    - `active -> degraded|disconnected`
+    - `degraded -> active|disconnected`
+    - `disconnected -> pending|active`
+
+## Policy Entities
+
+- `ScanPolicy`
+  - Fields: `id`, `workspace_id`, `project_id`, `name`, `enabled`, `trigger_mode`, `cron`, `max_concurrent_scans`, `created_at`, `updated_at`
+  - Trigger mode enum: `manual|scheduled|event|hybrid`
+  - Validation: required ids/name, valid mode, `max_concurrent_scans > 0`.
+- `SuppressionPolicy`
+  - Fields: `id`, `workspace_id`, `project_id`, `name`, `scope`, `target`, `reason`, `expires_at`, `created_by`, `created_at`, `last_updated_at`
+  - Scope enum: `finding|rule|resource`
+  - Validation: required ids, scope, target, reason, and creator id.
+
+## Remediation Entity
+
+- `RemediationJob`
+  - Fields: `id`, `workspace_id`, `project_id`, `finding_id`, `type`, `status`, `requested_by`, `requested_at`, `started_at`, `completed_at`, `artifact_ref`, `error_message`, `last_updated_at`
+  - Type enum: `patch_template|create_fix_pr|ticket`
+  - Status enum: `queued|running|succeeded|failed|canceled`
+  - Transition contract:
+    - `queued -> running|canceled`
+    - `running -> succeeded|failed|canceled`
+    - `failed -> queued` (retry)
+    - `succeeded|canceled` are terminal
+
+## Contracts and Validation
+
+- All entities use snake_case JSON tags for API and persistence contract stability.
+- Validation and transition helpers live in:
+  - `internal/domain/appmode.go`
+- Validation and transition tests live in:
+  - `internal/domain/appmode_test.go`
+  - `internal/domain/json_tags_test.go`

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -56,6 +56,7 @@ Current sequence in `migrations/`:
 10. `000009_authz_abac_rebac_data` - central authz ABAC/REBAC data model
 11. `000010_authz_policy_lifecycle_controls` - policy lifecycle primitives
 12. `000011_authz_policy_rollout_staged_controls` - staged rollout controls
+13. `000012_tenancy_core_entities` - organization/workspace/member/project tenancy core
 
 Notes:
 - Each migration has matching `.up.sql` and `.down.sql` files.

--- a/docs/persistence-artifacts.md
+++ b/docs/persistence-artifacts.md
@@ -35,3 +35,14 @@ This allows safe reruns and repeated persistence calls without duplicate row gro
 3. upsert artifacts
 4. upsert findings
 5. complete scan with counts/status
+
+## Tenancy CRUD Persistence
+
+Tenancy and project management CRUD now has dedicated scoped store operations:
+
+- organizations (`tenancy_organizations`)
+- workspaces (`tenancy_workspaces`)
+- workspace members (`tenancy_workspace_members`)
+- projects (`tenancy_projects`)
+
+Scope boundaries are enforced by requiring request scope (`tenant_id`, `workspace_id`) in all store operations, and tests cover cross-scope access denial expectations.

--- a/docs/persistence-artifacts.md
+++ b/docs/persistence-artifacts.md
@@ -45,4 +45,4 @@ Tenancy and project management CRUD now has dedicated scoped store operations:
 - workspace members (`tenancy_workspace_members`)
 - projects (`tenancy_projects`)
 
-Scope boundaries are enforced by requiring request scope (`tenant_id`, `workspace_id`) in all store operations, and tests cover cross-scope access denial expectations.
+Scope boundaries are enforced by requiring request scope (`tenant_id`, `workspace_id`) in all store operations, and workspace-bound CRUD paths deny cross-workspace access even within the same tenant.

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -34,6 +34,10 @@ type MemoryStore struct {
 	authzRollouts map[string]AuthzPolicyRollout
 	authzEvents   map[string][]AuthzPolicyEvent
 	authzEventIDs map[string]struct{}
+	organizations map[string]TenancyOrganization
+	workspaces    map[string]TenancyWorkspace
+	members       map[string]TenancyWorkspaceMember
+	projects      map[string]TenancyProject
 	identities    map[string]domain.Identity
 	policies      map[string]domain.Policy
 	relationships map[string]domain.Relationship
@@ -61,6 +65,10 @@ func NewMemoryStore() *MemoryStore {
 		authzRollouts: map[string]AuthzPolicyRollout{},
 		authzEvents:   map[string][]AuthzPolicyEvent{},
 		authzEventIDs: map[string]struct{}{},
+		organizations: map[string]TenancyOrganization{},
+		workspaces:    map[string]TenancyWorkspace{},
+		members:       map[string]TenancyWorkspaceMember{},
+		projects:      map[string]TenancyProject{},
 		identities:    map[string]domain.Identity{},
 		policies:      map[string]domain.Policy{},
 		relationships: map[string]domain.Relationship{},

--- a/internal/db/memory_tenancy.go
+++ b/internal/db/memory_tenancy.go
@@ -1,0 +1,350 @@
+package db
+
+import (
+	"context"
+	"sort"
+	"strings"
+)
+
+// UpsertOrganization persists or updates one tenant organization record.
+func (m *MemoryStore) UpsertOrganization(ctx context.Context, organization TenancyOrganization) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	organization.TenantID = scope.TenantID
+	normalized, err := NormalizeTenancyOrganizationForWrite(organization)
+	if err != nil {
+		return err
+	}
+	m.organizations[normalized.TenantID] = normalized
+	return nil
+}
+
+// GetOrganization returns the active scoped tenant organization.
+func (m *MemoryStore) GetOrganization(ctx context.Context) (TenancyOrganization, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyOrganization{}, err
+	}
+	organization, exists := m.organizations[scope.TenantID]
+	if !exists {
+		return TenancyOrganization{}, ErrNotFound
+	}
+	return organization, nil
+}
+
+// DeleteOrganization removes the active scoped tenant organization record.
+func (m *MemoryStore) DeleteOrganization(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	if _, exists := m.organizations[scope.TenantID]; !exists {
+		return ErrNotFound
+	}
+	delete(m.organizations, scope.TenantID)
+	for key, workspace := range m.workspaces {
+		if workspace.TenantID == scope.TenantID {
+			delete(m.workspaces, key)
+		}
+	}
+	for key, member := range m.members {
+		if member.TenantID == scope.TenantID {
+			delete(m.members, key)
+		}
+	}
+	for key, project := range m.projects {
+		if project.TenantID == scope.TenantID {
+			delete(m.projects, key)
+		}
+	}
+	return nil
+}
+
+// UpsertWorkspace persists or updates one scoped workspace record.
+func (m *MemoryStore) UpsertWorkspace(ctx context.Context, workspace TenancyWorkspace) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	workspace.TenantID = scope.TenantID
+	if workspace.WorkspaceID == "" {
+		workspace.WorkspaceID = scope.WorkspaceID
+	}
+	normalized, err := NormalizeTenancyWorkspaceForWrite(workspace)
+	if err != nil {
+		return err
+	}
+	if _, exists := m.organizations[normalized.TenantID]; !exists {
+		return ErrNotFound
+	}
+	m.workspaces[tenancyWorkspaceKey(normalized.TenantID, normalized.WorkspaceID)] = normalized
+	return nil
+}
+
+// GetWorkspace returns one workspace by id in active tenant scope.
+func (m *MemoryStore) GetWorkspace(ctx context.Context, workspaceID string) (TenancyWorkspace, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyWorkspace{}, err
+	}
+	key := tenancyWorkspaceKey(scope.TenantID, workspaceID)
+	workspace, exists := m.workspaces[key]
+	if !exists {
+		return TenancyWorkspace{}, ErrNotFound
+	}
+	return workspace, nil
+}
+
+// ListWorkspaces returns scoped workspaces ordered by created_at descending.
+func (m *MemoryStore) ListWorkspaces(ctx context.Context, limit int) ([]TenancyWorkspace, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	workspaces := make([]TenancyWorkspace, 0, limit)
+	for _, workspace := range m.workspaces {
+		if workspace.TenantID != scope.TenantID {
+			continue
+		}
+		workspaces = append(workspaces, workspace)
+	}
+	sort.Slice(workspaces, func(i, j int) bool { return workspaces[i].CreatedAt.After(workspaces[j].CreatedAt) })
+	if len(workspaces) > limit {
+		workspaces = workspaces[:limit]
+	}
+	return workspaces, nil
+}
+
+// DeleteWorkspace removes one scoped workspace and all child records.
+func (m *MemoryStore) DeleteWorkspace(ctx context.Context, workspaceID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	normalizedWorkspaceID := strings.TrimSpace(workspaceID)
+	key := tenancyWorkspaceKey(scope.TenantID, normalizedWorkspaceID)
+	if _, exists := m.workspaces[key]; !exists {
+		return ErrNotFound
+	}
+	delete(m.workspaces, key)
+	for memberKey, member := range m.members {
+		if member.TenantID == scope.TenantID && member.WorkspaceID == normalizedWorkspaceID {
+			delete(m.members, memberKey)
+		}
+	}
+	for projectKey, project := range m.projects {
+		if project.TenantID == scope.TenantID && project.WorkspaceID == normalizedWorkspaceID {
+			delete(m.projects, projectKey)
+		}
+	}
+	return nil
+}
+
+// UpsertWorkspaceMember persists one workspace member assignment.
+func (m *MemoryStore) UpsertWorkspaceMember(ctx context.Context, member TenancyWorkspaceMember) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	member.TenantID = scope.TenantID
+	if member.WorkspaceID == "" {
+		member.WorkspaceID = scope.WorkspaceID
+	}
+	normalized, err := NormalizeTenancyWorkspaceMemberForWrite(member)
+	if err != nil {
+		return err
+	}
+	if _, exists := m.workspaces[tenancyWorkspaceKey(normalized.TenantID, normalized.WorkspaceID)]; !exists {
+		return ErrNotFound
+	}
+	m.members[tenancyMemberKey(normalized.TenantID, normalized.WorkspaceID, normalized.MemberID)] = normalized
+	return nil
+}
+
+// GetWorkspaceMember returns one scoped workspace member by member id.
+func (m *MemoryStore) GetWorkspaceMember(ctx context.Context, workspaceID string, memberID string) (TenancyWorkspaceMember, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyWorkspaceMember{}, err
+	}
+	member, exists := m.members[tenancyMemberKey(scope.TenantID, workspaceID, memberID)]
+	if !exists {
+		return TenancyWorkspaceMember{}, ErrNotFound
+	}
+	return member, nil
+}
+
+// ListWorkspaceMembers returns members for one scoped workspace.
+func (m *MemoryStore) ListWorkspaceMembers(ctx context.Context, workspaceID string, limit int) ([]TenancyWorkspaceMember, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	normalizedWorkspaceID := strings.TrimSpace(workspaceID)
+	members := make([]TenancyWorkspaceMember, 0, limit)
+	for _, member := range m.members {
+		if member.TenantID != scope.TenantID || member.WorkspaceID != normalizedWorkspaceID {
+			continue
+		}
+		members = append(members, member)
+	}
+	sort.Slice(members, func(i, j int) bool { return members[i].JoinedAt.Before(members[j].JoinedAt) })
+	if len(members) > limit {
+		members = members[:limit]
+	}
+	return members, nil
+}
+
+// DeleteWorkspaceMember removes one scoped workspace member.
+func (m *MemoryStore) DeleteWorkspaceMember(ctx context.Context, workspaceID string, memberID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	key := tenancyMemberKey(scope.TenantID, workspaceID, memberID)
+	if _, exists := m.members[key]; !exists {
+		return ErrNotFound
+	}
+	delete(m.members, key)
+	return nil
+}
+
+// UpsertProject persists one scoped project record.
+func (m *MemoryStore) UpsertProject(ctx context.Context, project TenancyProject) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	project.TenantID = scope.TenantID
+	if project.WorkspaceID == "" {
+		project.WorkspaceID = scope.WorkspaceID
+	}
+	normalized, err := NormalizeTenancyProjectForWrite(project)
+	if err != nil {
+		return err
+	}
+	if _, exists := m.workspaces[tenancyWorkspaceKey(normalized.TenantID, normalized.WorkspaceID)]; !exists {
+		return ErrNotFound
+	}
+	m.projects[tenancyProjectKey(normalized.TenantID, normalized.WorkspaceID, normalized.ProjectID)] = normalized
+	return nil
+}
+
+// GetProject returns one scoped project by id.
+func (m *MemoryStore) GetProject(ctx context.Context, workspaceID string, projectID string) (TenancyProject, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyProject{}, err
+	}
+	project, exists := m.projects[tenancyProjectKey(scope.TenantID, workspaceID, projectID)]
+	if !exists {
+		return TenancyProject{}, ErrNotFound
+	}
+	return project, nil
+}
+
+// ListProjects returns projects for one scoped workspace.
+func (m *MemoryStore) ListProjects(ctx context.Context, workspaceID string, includeArchived bool, limit int) ([]TenancyProject, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	normalizedWorkspaceID := strings.TrimSpace(workspaceID)
+	projects := make([]TenancyProject, 0, limit)
+	for _, project := range m.projects {
+		if project.TenantID != scope.TenantID || project.WorkspaceID != normalizedWorkspaceID {
+			continue
+		}
+		if !includeArchived && project.ArchivedAt != nil {
+			continue
+		}
+		projects = append(projects, project)
+	}
+	sort.Slice(projects, func(i, j int) bool { return projects[i].CreatedAt.After(projects[j].CreatedAt) })
+	if len(projects) > limit {
+		projects = projects[:limit]
+	}
+	return projects, nil
+}
+
+// DeleteProject removes one scoped project.
+func (m *MemoryStore) DeleteProject(ctx context.Context, workspaceID string, projectID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	key := tenancyProjectKey(scope.TenantID, workspaceID, projectID)
+	if _, exists := m.projects[key]; !exists {
+		return ErrNotFound
+	}
+	delete(m.projects, key)
+	return nil
+}
+
+func tenancyWorkspaceKey(tenantID string, workspaceID string) string {
+	return strings.TrimSpace(tenantID) + "|" + strings.TrimSpace(workspaceID)
+}
+
+func tenancyMemberKey(tenantID string, workspaceID string, memberID string) string {
+	return tenancyWorkspaceKey(tenantID, workspaceID) + "|" + strings.TrimSpace(memberID)
+}
+
+func tenancyProjectKey(tenantID string, workspaceID string, projectID string) string {
+	return tenancyWorkspaceKey(tenantID, workspaceID) + "|" + strings.TrimSpace(projectID)
+}

--- a/internal/db/memory_tenancy.go
+++ b/internal/db/memory_tenancy.go
@@ -81,9 +81,11 @@ func (m *MemoryStore) UpsertWorkspace(ctx context.Context, workspace TenancyWork
 		return err
 	}
 	workspace.TenantID = scope.TenantID
-	if workspace.WorkspaceID == "" {
-		workspace.WorkspaceID = scope.WorkspaceID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspace.WorkspaceID)
+	if err != nil {
+		return err
 	}
+	workspace.WorkspaceID = resolvedWorkspaceID
 	normalized, err := NormalizeTenancyWorkspaceForWrite(workspace)
 	if err != nil {
 		return err
@@ -104,7 +106,11 @@ func (m *MemoryStore) GetWorkspace(ctx context.Context, workspaceID string) (Ten
 	if err != nil {
 		return TenancyWorkspace{}, err
 	}
-	key := tenancyWorkspaceKey(scope.TenantID, workspaceID)
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return TenancyWorkspace{}, err
+	}
+	key := tenancyWorkspaceKey(scope.TenantID, resolvedWorkspaceID)
 	workspace, exists := m.workspaces[key]
 	if !exists {
 		return TenancyWorkspace{}, ErrNotFound
@@ -112,7 +118,7 @@ func (m *MemoryStore) GetWorkspace(ctx context.Context, workspaceID string) (Ten
 	return workspace, nil
 }
 
-// ListWorkspaces returns scoped workspaces ordered by created_at descending.
+// ListWorkspaces returns tenant-scoped workspaces ordered by created_at descending.
 func (m *MemoryStore) ListWorkspaces(ctx context.Context, limit int) ([]TenancyWorkspace, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -147,7 +153,10 @@ func (m *MemoryStore) DeleteWorkspace(ctx context.Context, workspaceID string) e
 	if err != nil {
 		return err
 	}
-	normalizedWorkspaceID := strings.TrimSpace(workspaceID)
+	normalizedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return err
+	}
 	key := tenancyWorkspaceKey(scope.TenantID, normalizedWorkspaceID)
 	if _, exists := m.workspaces[key]; !exists {
 		return ErrNotFound
@@ -176,9 +185,11 @@ func (m *MemoryStore) UpsertWorkspaceMember(ctx context.Context, member TenancyW
 		return err
 	}
 	member.TenantID = scope.TenantID
-	if member.WorkspaceID == "" {
-		member.WorkspaceID = scope.WorkspaceID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, member.WorkspaceID)
+	if err != nil {
+		return err
 	}
+	member.WorkspaceID = resolvedWorkspaceID
 	normalized, err := NormalizeTenancyWorkspaceMemberForWrite(member)
 	if err != nil {
 		return err
@@ -199,7 +210,11 @@ func (m *MemoryStore) GetWorkspaceMember(ctx context.Context, workspaceID string
 	if err != nil {
 		return TenancyWorkspaceMember{}, err
 	}
-	member, exists := m.members[tenancyMemberKey(scope.TenantID, workspaceID, memberID)]
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return TenancyWorkspaceMember{}, err
+	}
+	member, exists := m.members[tenancyMemberKey(scope.TenantID, resolvedWorkspaceID, memberID)]
 	if !exists {
 		return TenancyWorkspaceMember{}, ErrNotFound
 	}
@@ -218,7 +233,10 @@ func (m *MemoryStore) ListWorkspaceMembers(ctx context.Context, workspaceID stri
 	if limit <= 0 {
 		limit = 100
 	}
-	normalizedWorkspaceID := strings.TrimSpace(workspaceID)
+	normalizedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	members := make([]TenancyWorkspaceMember, 0, limit)
 	for _, member := range m.members {
 		if member.TenantID != scope.TenantID || member.WorkspaceID != normalizedWorkspaceID {
@@ -242,7 +260,11 @@ func (m *MemoryStore) DeleteWorkspaceMember(ctx context.Context, workspaceID str
 	if err != nil {
 		return err
 	}
-	key := tenancyMemberKey(scope.TenantID, workspaceID, memberID)
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return err
+	}
+	key := tenancyMemberKey(scope.TenantID, resolvedWorkspaceID, memberID)
 	if _, exists := m.members[key]; !exists {
 		return ErrNotFound
 	}
@@ -260,9 +282,11 @@ func (m *MemoryStore) UpsertProject(ctx context.Context, project TenancyProject)
 		return err
 	}
 	project.TenantID = scope.TenantID
-	if project.WorkspaceID == "" {
-		project.WorkspaceID = scope.WorkspaceID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, project.WorkspaceID)
+	if err != nil {
+		return err
 	}
+	project.WorkspaceID = resolvedWorkspaceID
 	normalized, err := NormalizeTenancyProjectForWrite(project)
 	if err != nil {
 		return err
@@ -283,7 +307,11 @@ func (m *MemoryStore) GetProject(ctx context.Context, workspaceID string, projec
 	if err != nil {
 		return TenancyProject{}, err
 	}
-	project, exists := m.projects[tenancyProjectKey(scope.TenantID, workspaceID, projectID)]
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return TenancyProject{}, err
+	}
+	project, exists := m.projects[tenancyProjectKey(scope.TenantID, resolvedWorkspaceID, projectID)]
 	if !exists {
 		return TenancyProject{}, ErrNotFound
 	}
@@ -302,7 +330,10 @@ func (m *MemoryStore) ListProjects(ctx context.Context, workspaceID string, incl
 	if limit <= 0 {
 		limit = 100
 	}
-	normalizedWorkspaceID := strings.TrimSpace(workspaceID)
+	normalizedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	projects := make([]TenancyProject, 0, limit)
 	for _, project := range m.projects {
 		if project.TenantID != scope.TenantID || project.WorkspaceID != normalizedWorkspaceID {
@@ -329,7 +360,11 @@ func (m *MemoryStore) DeleteProject(ctx context.Context, workspaceID string, pro
 	if err != nil {
 		return err
 	}
-	key := tenancyProjectKey(scope.TenantID, workspaceID, projectID)
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return err
+	}
+	key := tenancyProjectKey(scope.TenantID, resolvedWorkspaceID, projectID)
 	if _, exists := m.projects[key]; !exists {
 		return ErrNotFound
 	}

--- a/internal/db/memory_tenancy.go
+++ b/internal/db/memory_tenancy.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -315,6 +316,10 @@ func (m *MemoryStore) GetProject(ctx context.Context, workspaceID string, projec
 	if !exists {
 		return TenancyProject{}, ErrNotFound
 	}
+	if project.ArchivedAt != nil {
+		archived := project.ArchivedAt.UTC()
+		project.ArchivedAt = &archived
+	}
 	return project, nil
 }
 
@@ -341,6 +346,10 @@ func (m *MemoryStore) ListProjects(ctx context.Context, workspaceID string, incl
 		}
 		if !includeArchived && project.ArchivedAt != nil {
 			continue
+		}
+		if project.ArchivedAt != nil {
+			archived := project.ArchivedAt.UTC()
+			project.ArchivedAt = &archived
 		}
 		projects = append(projects, project)
 	}
@@ -373,13 +382,24 @@ func (m *MemoryStore) DeleteProject(ctx context.Context, workspaceID string, pro
 }
 
 func tenancyWorkspaceKey(tenantID string, workspaceID string) string {
-	return strings.TrimSpace(tenantID) + "|" + strings.TrimSpace(workspaceID)
+	return tenancyCompositeKey(strings.TrimSpace(tenantID), strings.TrimSpace(workspaceID))
 }
 
 func tenancyMemberKey(tenantID string, workspaceID string, memberID string) string {
-	return tenancyWorkspaceKey(tenantID, workspaceID) + "|" + strings.TrimSpace(memberID)
+	return tenancyCompositeKey(strings.TrimSpace(tenantID), strings.TrimSpace(workspaceID), strings.TrimSpace(memberID))
 }
 
 func tenancyProjectKey(tenantID string, workspaceID string, projectID string) string {
-	return tenancyWorkspaceKey(tenantID, workspaceID) + "|" + strings.TrimSpace(projectID)
+	return tenancyCompositeKey(strings.TrimSpace(tenantID), strings.TrimSpace(workspaceID), strings.TrimSpace(projectID))
+}
+
+func tenancyCompositeKey(parts ...string) string {
+	var builder strings.Builder
+	for _, part := range parts {
+		builder.WriteString(strconv.Itoa(len(part)))
+		builder.WriteByte(':')
+		builder.WriteString(part)
+		builder.WriteByte('|')
+	}
+	return builder.String()
 }

--- a/internal/db/memory_tenancy_test.go
+++ b/internal/db/memory_tenancy_test.go
@@ -1,0 +1,175 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestMemoryStoreTenancyCRUD(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+
+	if err := store.UpsertOrganization(ctx, TenancyOrganization{
+		DisplayName: "Tenant A",
+		Slug:        "tenant-a",
+	}); err != nil {
+		t.Fatalf("upsert organization: %v", err)
+	}
+	if _, err := store.GetOrganization(ctx); err != nil {
+		t.Fatalf("get organization: %v", err)
+	}
+
+	if err := store.UpsertWorkspace(ctx, TenancyWorkspace{
+		WorkspaceID: "workspace-a",
+		DisplayName: "Workspace A",
+		Slug:        "workspace-a",
+	}); err != nil {
+		t.Fatalf("upsert workspace: %v", err)
+	}
+	if _, err := store.GetWorkspace(ctx, "workspace-a"); err != nil {
+		t.Fatalf("get workspace: %v", err)
+	}
+	workspaces, err := store.ListWorkspaces(ctx, 20)
+	if err != nil {
+		t.Fatalf("list workspaces: %v", err)
+	}
+	if len(workspaces) != 1 {
+		t.Fatalf("expected one workspace, got %+v", workspaces)
+	}
+
+	joinedAt := time.Now().UTC()
+	if err := store.UpsertWorkspaceMember(ctx, TenancyWorkspaceMember{
+		WorkspaceID: "workspace-a",
+		MemberID:    "member-1",
+		UserID:      "user-1",
+		Email:       "user@example.com",
+		Role:        "admin",
+		Status:      "active",
+		JoinedAt:    joinedAt,
+	}); err != nil {
+		t.Fatalf("upsert workspace member: %v", err)
+	}
+	members, err := store.ListWorkspaceMembers(ctx, "workspace-a", 20)
+	if err != nil {
+		t.Fatalf("list workspace members: %v", err)
+	}
+	if len(members) != 1 || members[0].MemberID != "member-1" {
+		t.Fatalf("unexpected members: %+v", members)
+	}
+
+	if err := store.UpsertProject(ctx, TenancyProject{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		Name:        "Payments",
+		Slug:        "payments",
+	}); err != nil {
+		t.Fatalf("upsert project: %v", err)
+	}
+	projects, err := store.ListProjects(ctx, "workspace-a", false, 20)
+	if err != nil {
+		t.Fatalf("list projects: %v", err)
+	}
+	if len(projects) != 1 || projects[0].ProjectID != "project-1" {
+		t.Fatalf("unexpected projects: %+v", projects)
+	}
+
+	if err := store.DeleteProject(ctx, "workspace-a", "project-1"); err != nil {
+		t.Fatalf("delete project: %v", err)
+	}
+	if err := store.DeleteWorkspaceMember(ctx, "workspace-a", "member-1"); err != nil {
+		t.Fatalf("delete workspace member: %v", err)
+	}
+	if err := store.DeleteWorkspace(ctx, "workspace-a"); err != nil {
+		t.Fatalf("delete workspace: %v", err)
+	}
+	if err := store.DeleteOrganization(ctx); err != nil {
+		t.Fatalf("delete organization: %v", err)
+	}
+}
+
+func TestMemoryStoreTenancyScopeIsolation(t *testing.T) {
+	store := NewMemoryStore()
+	tenantA := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	tenantB := WithScope(context.Background(), Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
+
+	if err := store.UpsertOrganization(tenantA, TenancyOrganization{
+		DisplayName: "Tenant A",
+		Slug:        "tenant-a",
+	}); err != nil {
+		t.Fatalf("seed organization tenant-a: %v", err)
+	}
+	if err := store.UpsertWorkspace(tenantA, TenancyWorkspace{
+		WorkspaceID: "workspace-a",
+		DisplayName: "Workspace A",
+		Slug:        "workspace-a",
+	}); err != nil {
+		t.Fatalf("seed workspace tenant-a: %v", err)
+	}
+	if err := store.UpsertProject(tenantA, TenancyProject{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-a",
+		Name:        "Project A",
+		Slug:        "project-a",
+	}); err != nil {
+		t.Fatalf("seed project tenant-a: %v", err)
+	}
+
+	if _, err := store.GetOrganization(tenantB); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected tenant-b organization to be isolated, got %v", err)
+	}
+	if _, err := store.GetWorkspace(tenantB, "workspace-a"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected tenant-b workspace to be isolated, got %v", err)
+	}
+	if _, err := store.GetProject(tenantB, "workspace-a", "project-a"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected tenant-b project to be isolated, got %v", err)
+	}
+}
+
+func TestMemoryStoreDeleteWorkspaceCascadesWithPaddedWorkspaceID(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+
+	if err := store.UpsertOrganization(ctx, TenancyOrganization{
+		DisplayName: "Tenant A",
+		Slug:        "tenant-a",
+	}); err != nil {
+		t.Fatalf("upsert organization: %v", err)
+	}
+	if err := store.UpsertWorkspace(ctx, TenancyWorkspace{
+		WorkspaceID: "workspace-a",
+		DisplayName: "Workspace A",
+		Slug:        "workspace-a",
+	}); err != nil {
+		t.Fatalf("upsert workspace: %v", err)
+	}
+	if err := store.UpsertWorkspaceMember(ctx, TenancyWorkspaceMember{
+		WorkspaceID: "workspace-a",
+		MemberID:    "member-1",
+		UserID:      "user-1",
+		Email:       "user@example.com",
+		Role:        "admin",
+		Status:      "active",
+	}); err != nil {
+		t.Fatalf("upsert member: %v", err)
+	}
+	if err := store.UpsertProject(ctx, TenancyProject{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		Name:        "Payments",
+		Slug:        "payments",
+	}); err != nil {
+		t.Fatalf("upsert project: %v", err)
+	}
+
+	if err := store.DeleteWorkspace(ctx, "  workspace-a  "); err != nil {
+		t.Fatalf("delete workspace with padded id: %v", err)
+	}
+	if _, err := store.GetWorkspaceMember(ctx, "workspace-a", "member-1"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected member to be cascade-deleted, got %v", err)
+	}
+	if _, err := store.GetProject(ctx, "workspace-a", "project-1"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected project to be cascade-deleted, got %v", err)
+	}
+}

--- a/internal/db/memory_tenancy_test.go
+++ b/internal/db/memory_tenancy_test.go
@@ -180,3 +180,100 @@ func TestMemoryStoreDeleteWorkspaceCascadesWithPaddedWorkspaceID(t *testing.T) {
 		t.Fatalf("expected project to be cascade-deleted, got %v", err)
 	}
 }
+
+func TestMemoryStoreProjectReadsCloneArchivedPointer(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	now := time.Now().UTC()
+	archived := now
+
+	if err := store.UpsertOrganization(ctx, TenancyOrganization{DisplayName: "Tenant A", Slug: "tenant-a"}); err != nil {
+		t.Fatalf("upsert organization: %v", err)
+	}
+	if err := store.UpsertWorkspace(ctx, TenancyWorkspace{WorkspaceID: "workspace-a", DisplayName: "Workspace A", Slug: "workspace-a"}); err != nil {
+		t.Fatalf("upsert workspace: %v", err)
+	}
+	if err := store.UpsertProject(ctx, TenancyProject{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		Name:        "Payments",
+		Slug:        "payments",
+		ArchivedAt:  &archived,
+	}); err != nil {
+		t.Fatalf("upsert project: %v", err)
+	}
+
+	project, err := store.GetProject(ctx, "workspace-a", "project-1")
+	if err != nil {
+		t.Fatalf("get project: %v", err)
+	}
+	if project.ArchivedAt == nil {
+		t.Fatal("expected archived_at to be set")
+	}
+	mutated := archived.Add(24 * time.Hour)
+	*project.ArchivedAt = mutated
+
+	projectAgain, err := store.GetProject(ctx, "workspace-a", "project-1")
+	if err != nil {
+		t.Fatalf("get project again: %v", err)
+	}
+	if projectAgain.ArchivedAt == nil || !projectAgain.ArchivedAt.Equal(archived) {
+		t.Fatalf("expected stored archived_at to remain unchanged, got %+v want %v", projectAgain.ArchivedAt, archived)
+	}
+
+	listed, err := store.ListProjects(ctx, "workspace-a", true, 10)
+	if err != nil {
+		t.Fatalf("list projects: %v", err)
+	}
+	if len(listed) != 1 || listed[0].ArchivedAt == nil {
+		t.Fatalf("expected one archived project, got %+v", listed)
+	}
+	listMutated := archived.Add(48 * time.Hour)
+	*listed[0].ArchivedAt = listMutated
+
+	projectAfterList, err := store.GetProject(ctx, "workspace-a", "project-1")
+	if err != nil {
+		t.Fatalf("get project after list mutation: %v", err)
+	}
+	if projectAfterList.ArchivedAt == nil || !projectAfterList.ArchivedAt.Equal(archived) {
+		t.Fatalf("expected stored archived_at to remain unchanged after list mutation, got %+v want %v", projectAfterList.ArchivedAt, archived)
+	}
+}
+
+func TestMemoryStoreTenancyKeysAvoidDelimiterCollision(t *testing.T) {
+	store := NewMemoryStore()
+	ctxA := WithScope(context.Background(), Scope{TenantID: "tenant", WorkspaceID: "a|b"})
+	ctxB := WithScope(context.Background(), Scope{TenantID: "tenant|a", WorkspaceID: "b"})
+
+	if err := store.UpsertOrganization(ctxA, TenancyOrganization{DisplayName: "Tenant A", Slug: "tenant-a"}); err != nil {
+		t.Fatalf("upsert org A: %v", err)
+	}
+	if err := store.UpsertOrganization(ctxB, TenancyOrganization{DisplayName: "Tenant B", Slug: "tenant-b"}); err != nil {
+		t.Fatalf("upsert org B: %v", err)
+	}
+	if err := store.UpsertWorkspace(ctxA, TenancyWorkspace{WorkspaceID: "a|b", DisplayName: "Workspace A", Slug: "workspace-a"}); err != nil {
+		t.Fatalf("upsert workspace A: %v", err)
+	}
+	if err := store.UpsertWorkspace(ctxB, TenancyWorkspace{WorkspaceID: "b", DisplayName: "Workspace B", Slug: "workspace-b"}); err != nil {
+		t.Fatalf("upsert workspace B: %v", err)
+	}
+
+	if err := store.UpsertProject(ctxA, TenancyProject{WorkspaceID: "a|b", ProjectID: "project-1", Name: "A", Slug: "a"}); err != nil {
+		t.Fatalf("upsert project A: %v", err)
+	}
+	if err := store.UpsertProject(ctxB, TenancyProject{WorkspaceID: "b", ProjectID: "project-1", Name: "B", Slug: "b"}); err != nil {
+		t.Fatalf("upsert project B: %v", err)
+	}
+
+	projectA, err := store.GetProject(ctxA, "a|b", "project-1")
+	if err != nil {
+		t.Fatalf("get project A: %v", err)
+	}
+	projectB, err := store.GetProject(ctxB, "b", "project-1")
+	if err != nil {
+		t.Fatalf("get project B: %v", err)
+	}
+	if projectA.Name == projectB.Name {
+		t.Fatalf("expected isolated project records, got A=%q B=%q", projectA.Name, projectB.Name)
+	}
+}

--- a/internal/db/memory_tenancy_test.go
+++ b/internal/db/memory_tenancy_test.go
@@ -92,6 +92,7 @@ func TestMemoryStoreTenancyCRUD(t *testing.T) {
 func TestMemoryStoreTenancyScopeIsolation(t *testing.T) {
 	store := NewMemoryStore()
 	tenantA := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	tenantAWorkspaceB := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-b"})
 	tenantB := WithScope(context.Background(), Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
 
 	if err := store.UpsertOrganization(tenantA, TenancyOrganization{
@@ -124,6 +125,12 @@ func TestMemoryStoreTenancyScopeIsolation(t *testing.T) {
 	}
 	if _, err := store.GetProject(tenantB, "workspace-a", "project-a"); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected tenant-b project to be isolated, got %v", err)
+	}
+	if _, err := store.GetWorkspace(tenantAWorkspaceB, "workspace-a"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected cross-workspace lookup to be denied, got %v", err)
+	}
+	if _, err := store.GetProject(tenantAWorkspaceB, "workspace-a", "project-a"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected cross-workspace project lookup to be denied, got %v", err)
 	}
 }
 

--- a/internal/db/memory_tenancy_test.go
+++ b/internal/db/memory_tenancy_test.go
@@ -277,3 +277,64 @@ func TestMemoryStoreTenancyKeysAvoidDelimiterCollision(t *testing.T) {
 		t.Fatalf("expected isolated project records, got A=%q B=%q", projectA.Name, projectB.Name)
 	}
 }
+
+func TestMemoryStoreTenancyNotFoundAndListBranches(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+
+	if err := store.DeleteOrganization(ctx); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected missing organization delete to return ErrNotFound, got %v", err)
+	}
+
+	if err := store.UpsertOrganization(ctx, TenancyOrganization{DisplayName: "Tenant A", Slug: "tenant-a"}); err != nil {
+		t.Fatalf("upsert organization: %v", err)
+	}
+	if err := store.UpsertWorkspace(ctx, TenancyWorkspace{WorkspaceID: "workspace-a", DisplayName: "Workspace A", Slug: "workspace-a"}); err != nil {
+		t.Fatalf("upsert workspace: %v", err)
+	}
+
+	if _, err := store.GetWorkspaceMember(ctx, "workspace-a", "missing-member"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected missing workspace member to return ErrNotFound, got %v", err)
+	}
+	if err := store.DeleteWorkspaceMember(ctx, "workspace-a", "missing-member"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected missing workspace member delete to return ErrNotFound, got %v", err)
+	}
+	if err := store.DeleteProject(ctx, "workspace-a", "missing-project"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected missing project delete to return ErrNotFound, got %v", err)
+	}
+
+	archivedAt := time.Now().UTC()
+	if err := store.UpsertProject(ctx, TenancyProject{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "active-project",
+		Name:        "Active",
+		Slug:        "active",
+	}); err != nil {
+		t.Fatalf("upsert active project: %v", err)
+	}
+	if err := store.UpsertProject(ctx, TenancyProject{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "archived-project",
+		Name:        "Archived",
+		Slug:        "archived",
+		ArchivedAt:  &archivedAt,
+	}); err != nil {
+		t.Fatalf("upsert archived project: %v", err)
+	}
+
+	nonArchived, err := store.ListProjects(ctx, "workspace-a", false, 0)
+	if err != nil {
+		t.Fatalf("list non-archived projects: %v", err)
+	}
+	if len(nonArchived) != 1 || nonArchived[0].ProjectID != "active-project" {
+		t.Fatalf("expected only active project, got %+v", nonArchived)
+	}
+
+	allProjects, err := store.ListProjects(ctx, "workspace-a", true, 0)
+	if err != nil {
+		t.Fatalf("list all projects: %v", err)
+	}
+	if len(allProjects) != 2 {
+		t.Fatalf("expected both projects when includeArchived=true, got %+v", allProjects)
+	}
+}

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -213,3 +213,28 @@ func TestTenthMigrationContainsAuthzPolicyLifecycleTables(t *testing.T) {
 		}
 	}
 }
+
+func TestTwelfthMigrationContainsTenancyCoreTables(t *testing.T) {
+	path := filepath.Join("..", "..", "migrations", "000012_tenancy_core_entities.up.sql")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	text := string(content)
+	required := []string{
+		"CREATE TABLE IF NOT EXISTS tenancy_organizations",
+		"CREATE TABLE IF NOT EXISTS tenancy_workspaces",
+		"CREATE TABLE IF NOT EXISTS tenancy_workspace_members",
+		"CREATE TABLE IF NOT EXISTS tenancy_projects",
+		"FOREIGN KEY (tenant_id) REFERENCES tenancy_organizations(tenant_id)",
+		"FOREIGN KEY (tenant_id, workspace_id) REFERENCES tenancy_workspaces(tenant_id, workspace_id)",
+		"idx_tenancy_workspaces_scope_created",
+		"idx_tenancy_members_scope_role_status",
+		"idx_tenancy_projects_scope_created",
+	}
+	for _, item := range required {
+		if !strings.Contains(text, item) {
+			t.Fatalf("expected tenancy core migration item %q", item)
+		}
+	}
+}

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -230,6 +230,7 @@ func TestTwelfthMigrationContainsTenancyCoreTables(t *testing.T) {
 		"FOREIGN KEY (tenant_id, workspace_id) REFERENCES tenancy_workspaces(tenant_id, workspace_id)",
 		"idx_tenancy_workspaces_scope_created",
 		"idx_tenancy_members_scope_role_status",
+		"idx_tenancy_members_scope_joined",
 		"idx_tenancy_projects_scope_created",
 	}
 	for _, item := range required {

--- a/internal/db/postgres_tenancy.go
+++ b/internal/db/postgres_tenancy.go
@@ -95,9 +95,11 @@ func (p *PostgresStore) UpsertWorkspace(ctx context.Context, workspace TenancyWo
 		return err
 	}
 	workspace.TenantID = scope.TenantID
-	if workspace.WorkspaceID == "" {
-		workspace.WorkspaceID = scope.WorkspaceID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspace.WorkspaceID)
+	if err != nil {
+		return err
 	}
+	workspace.WorkspaceID = resolvedWorkspaceID
 	normalized, err := NormalizeTenancyWorkspaceForWrite(workspace)
 	if err != nil {
 		return err
@@ -126,6 +128,10 @@ func (p *PostgresStore) GetWorkspace(ctx context.Context, workspaceID string) (T
 	if err != nil {
 		return TenancyWorkspace{}, err
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return TenancyWorkspace{}, err
+	}
 	row := p.queryRowContext(
 		ctx,
 		`SELECT tenant_id, workspace_id, display_name, slug, created_at, updated_at
@@ -133,7 +139,7 @@ func (p *PostgresStore) GetWorkspace(ctx context.Context, workspaceID string) (T
 		 WHERE tenant_id = $1
 		   AND workspace_id = $2`,
 		scope.TenantID,
-		workspaceID,
+		resolvedWorkspaceID,
 	)
 	var workspace TenancyWorkspace
 	if err := row.Scan(
@@ -152,7 +158,7 @@ func (p *PostgresStore) GetWorkspace(ctx context.Context, workspaceID string) (T
 	return workspace, nil
 }
 
-// ListWorkspaces returns all scoped workspaces ordered by creation time.
+// ListWorkspaces returns all tenant-scoped workspaces ordered by creation time.
 func (p *PostgresStore) ListWorkspaces(ctx context.Context, limit int) ([]TenancyWorkspace, error) {
 	scope, err := RequireScope(ctx)
 	if err != nil {
@@ -200,13 +206,17 @@ func (p *PostgresStore) DeleteWorkspace(ctx context.Context, workspaceID string)
 	if err != nil {
 		return err
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return err
+	}
 	result, err := p.execContext(
 		ctx,
 		`DELETE FROM tenancy_workspaces
 		 WHERE tenant_id = $1
 		   AND workspace_id = $2`,
 		scope.TenantID,
-		workspaceID,
+		resolvedWorkspaceID,
 	)
 	if err != nil {
 		return err
@@ -228,9 +238,11 @@ func (p *PostgresStore) UpsertWorkspaceMember(ctx context.Context, member Tenanc
 		return err
 	}
 	member.TenantID = scope.TenantID
-	if member.WorkspaceID == "" {
-		member.WorkspaceID = scope.WorkspaceID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, member.WorkspaceID)
+	if err != nil {
+		return err
 	}
+	member.WorkspaceID = resolvedWorkspaceID
 	normalized, err := NormalizeTenancyWorkspaceMemberForWrite(member)
 	if err != nil {
 		return err
@@ -266,6 +278,10 @@ func (p *PostgresStore) GetWorkspaceMember(ctx context.Context, workspaceID stri
 	if err != nil {
 		return TenancyWorkspaceMember{}, err
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return TenancyWorkspaceMember{}, err
+	}
 	row := p.queryRowContext(
 		ctx,
 		`SELECT tenant_id, workspace_id, member_id, user_id, email, role, status, joined_at, updated_at
@@ -274,7 +290,7 @@ func (p *PostgresStore) GetWorkspaceMember(ctx context.Context, workspaceID stri
 		   AND workspace_id = $2
 		   AND member_id = $3`,
 		scope.TenantID,
-		workspaceID,
+		resolvedWorkspaceID,
 		memberID,
 	)
 	var member TenancyWorkspaceMember
@@ -306,6 +322,10 @@ func (p *PostgresStore) ListWorkspaceMembers(ctx context.Context, workspaceID st
 	if limit <= 0 {
 		limit = 100
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	rows, err := p.queryContext(
 		ctx,
 		`SELECT tenant_id, workspace_id, member_id, user_id, email, role, status, joined_at, updated_at
@@ -315,7 +335,7 @@ func (p *PostgresStore) ListWorkspaceMembers(ctx context.Context, workspaceID st
 		 ORDER BY joined_at ASC
 		 LIMIT $3`,
 		scope.TenantID,
-		workspaceID,
+		resolvedWorkspaceID,
 		limit,
 	)
 	if err != nil {
@@ -350,6 +370,10 @@ func (p *PostgresStore) DeleteWorkspaceMember(ctx context.Context, workspaceID s
 	if err != nil {
 		return err
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return err
+	}
 	result, err := p.execContext(
 		ctx,
 		`DELETE FROM tenancy_workspace_members
@@ -357,7 +381,7 @@ func (p *PostgresStore) DeleteWorkspaceMember(ctx context.Context, workspaceID s
 		   AND workspace_id = $2
 		   AND member_id = $3`,
 		scope.TenantID,
-		workspaceID,
+		resolvedWorkspaceID,
 		memberID,
 	)
 	if err != nil {
@@ -380,9 +404,11 @@ func (p *PostgresStore) UpsertProject(ctx context.Context, project TenancyProjec
 		return err
 	}
 	project.TenantID = scope.TenantID
-	if project.WorkspaceID == "" {
-		project.WorkspaceID = scope.WorkspaceID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, project.WorkspaceID)
+	if err != nil {
+		return err
 	}
+	project.WorkspaceID = resolvedWorkspaceID
 	normalized, err := NormalizeTenancyProjectForWrite(project)
 	if err != nil {
 		return err
@@ -418,6 +444,10 @@ func (p *PostgresStore) GetProject(ctx context.Context, workspaceID string, proj
 	if err != nil {
 		return TenancyProject{}, err
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return TenancyProject{}, err
+	}
 	row := p.queryRowContext(
 		ctx,
 		`SELECT tenant_id, workspace_id, project_id, name, slug, COALESCE(description, ''), archived_at, created_at, updated_at
@@ -426,7 +456,7 @@ func (p *PostgresStore) GetProject(ctx context.Context, workspaceID string, proj
 		   AND workspace_id = $2
 		   AND project_id = $3`,
 		scope.TenantID,
-		workspaceID,
+		resolvedWorkspaceID,
 		projectID,
 	)
 	var project TenancyProject
@@ -463,11 +493,15 @@ func (p *PostgresStore) ListProjects(ctx context.Context, workspaceID string, in
 	if limit <= 0 {
 		limit = 100
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	query := `SELECT tenant_id, workspace_id, project_id, name, slug, COALESCE(description, ''), archived_at, created_at, updated_at
 		 FROM tenancy_projects
 		 WHERE tenant_id = $1
 		   AND workspace_id = $2`
-	args := []any{scope.TenantID, workspaceID}
+	args := []any{scope.TenantID, resolvedWorkspaceID}
 	if !includeArchived {
 		query += " AND archived_at IS NULL"
 	}
@@ -511,6 +545,10 @@ func (p *PostgresStore) DeleteProject(ctx context.Context, workspaceID string, p
 	if err != nil {
 		return err
 	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return err
+	}
 	result, err := p.execContext(
 		ctx,
 		`DELETE FROM tenancy_projects
@@ -518,7 +556,7 @@ func (p *PostgresStore) DeleteProject(ctx context.Context, workspaceID string, p
 		   AND workspace_id = $2
 		   AND project_id = $3`,
 		scope.TenantID,
-		workspaceID,
+		resolvedWorkspaceID,
 		projectID,
 	)
 	if err != nil {

--- a/internal/db/postgres_tenancy.go
+++ b/internal/db/postgres_tenancy.go
@@ -1,0 +1,535 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+)
+
+// UpsertOrganization persists one scoped organization metadata row.
+func (p *PostgresStore) UpsertOrganization(ctx context.Context, organization TenancyOrganization) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	organization.TenantID = scope.TenantID
+	normalized, err := NormalizeTenancyOrganizationForWrite(organization)
+	if err != nil {
+		return err
+	}
+	_, err = p.execContext(
+		ctx,
+		`INSERT INTO tenancy_organizations (tenant_id, display_name, slug, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5)
+		 ON CONFLICT (tenant_id) DO UPDATE
+		 SET display_name = EXCLUDED.display_name,
+		     slug = EXCLUDED.slug,
+		     updated_at = EXCLUDED.updated_at`,
+		normalized.TenantID,
+		normalized.DisplayName,
+		normalized.Slug,
+		normalized.CreatedAt,
+		normalized.UpdatedAt,
+	)
+	return err
+}
+
+// GetOrganization returns one scoped organization record.
+func (p *PostgresStore) GetOrganization(ctx context.Context) (TenancyOrganization, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyOrganization{}, err
+	}
+	row := p.queryRowContext(
+		ctx,
+		`SELECT tenant_id, display_name, slug, created_at, updated_at
+		 FROM tenancy_organizations
+		 WHERE tenant_id = $1`,
+		scope.TenantID,
+	)
+	var organization TenancyOrganization
+	if err := row.Scan(
+		&organization.TenantID,
+		&organization.DisplayName,
+		&organization.Slug,
+		&organization.CreatedAt,
+		&organization.UpdatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return TenancyOrganization{}, ErrNotFound
+		}
+		return TenancyOrganization{}, err
+	}
+	return organization, nil
+}
+
+// DeleteOrganization removes one scoped organization record.
+func (p *PostgresStore) DeleteOrganization(ctx context.Context) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	result, err := p.execContext(
+		ctx,
+		`DELETE FROM tenancy_organizations
+		 WHERE tenant_id = $1`,
+		scope.TenantID,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// UpsertWorkspace persists one scoped workspace record.
+func (p *PostgresStore) UpsertWorkspace(ctx context.Context, workspace TenancyWorkspace) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	workspace.TenantID = scope.TenantID
+	if workspace.WorkspaceID == "" {
+		workspace.WorkspaceID = scope.WorkspaceID
+	}
+	normalized, err := NormalizeTenancyWorkspaceForWrite(workspace)
+	if err != nil {
+		return err
+	}
+	_, err = p.execContext(
+		ctx,
+		`INSERT INTO tenancy_workspaces (tenant_id, workspace_id, display_name, slug, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6)
+		 ON CONFLICT (tenant_id, workspace_id) DO UPDATE
+		 SET display_name = EXCLUDED.display_name,
+		     slug = EXCLUDED.slug,
+		     updated_at = EXCLUDED.updated_at`,
+		normalized.TenantID,
+		normalized.WorkspaceID,
+		normalized.DisplayName,
+		normalized.Slug,
+		normalized.CreatedAt,
+		normalized.UpdatedAt,
+	)
+	return err
+}
+
+// GetWorkspace returns one scoped workspace by id.
+func (p *PostgresStore) GetWorkspace(ctx context.Context, workspaceID string) (TenancyWorkspace, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyWorkspace{}, err
+	}
+	row := p.queryRowContext(
+		ctx,
+		`SELECT tenant_id, workspace_id, display_name, slug, created_at, updated_at
+		 FROM tenancy_workspaces
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2`,
+		scope.TenantID,
+		workspaceID,
+	)
+	var workspace TenancyWorkspace
+	if err := row.Scan(
+		&workspace.TenantID,
+		&workspace.WorkspaceID,
+		&workspace.DisplayName,
+		&workspace.Slug,
+		&workspace.CreatedAt,
+		&workspace.UpdatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return TenancyWorkspace{}, ErrNotFound
+		}
+		return TenancyWorkspace{}, err
+	}
+	return workspace, nil
+}
+
+// ListWorkspaces returns all scoped workspaces ordered by creation time.
+func (p *PostgresStore) ListWorkspaces(ctx context.Context, limit int) ([]TenancyWorkspace, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	rows, err := p.queryContext(
+		ctx,
+		`SELECT tenant_id, workspace_id, display_name, slug, created_at, updated_at
+		 FROM tenancy_workspaces
+		 WHERE tenant_id = $1
+		 ORDER BY created_at DESC
+		 LIMIT $2`,
+		scope.TenantID,
+		limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	workspaces := make([]TenancyWorkspace, 0, limit)
+	for rows.Next() {
+		var workspace TenancyWorkspace
+		if err := rows.Scan(
+			&workspace.TenantID,
+			&workspace.WorkspaceID,
+			&workspace.DisplayName,
+			&workspace.Slug,
+			&workspace.CreatedAt,
+			&workspace.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		workspaces = append(workspaces, workspace)
+	}
+	return workspaces, rows.Err()
+}
+
+// DeleteWorkspace deletes one scoped workspace by id.
+func (p *PostgresStore) DeleteWorkspace(ctx context.Context, workspaceID string) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	result, err := p.execContext(
+		ctx,
+		`DELETE FROM tenancy_workspaces
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2`,
+		scope.TenantID,
+		workspaceID,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// UpsertWorkspaceMember persists one scoped workspace member record.
+func (p *PostgresStore) UpsertWorkspaceMember(ctx context.Context, member TenancyWorkspaceMember) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	member.TenantID = scope.TenantID
+	if member.WorkspaceID == "" {
+		member.WorkspaceID = scope.WorkspaceID
+	}
+	normalized, err := NormalizeTenancyWorkspaceMemberForWrite(member)
+	if err != nil {
+		return err
+	}
+	_, err = p.execContext(
+		ctx,
+		`INSERT INTO tenancy_workspace_members (
+		     tenant_id, workspace_id, member_id, user_id, email, role, status, joined_at, updated_at
+		 )
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		 ON CONFLICT (tenant_id, workspace_id, member_id) DO UPDATE
+		 SET user_id = EXCLUDED.user_id,
+		     email = EXCLUDED.email,
+		     role = EXCLUDED.role,
+		     status = EXCLUDED.status,
+		     updated_at = EXCLUDED.updated_at`,
+		normalized.TenantID,
+		normalized.WorkspaceID,
+		normalized.MemberID,
+		normalized.UserID,
+		normalized.Email,
+		normalized.Role,
+		normalized.Status,
+		normalized.JoinedAt,
+		normalized.UpdatedAt,
+	)
+	return err
+}
+
+// GetWorkspaceMember returns one scoped workspace member.
+func (p *PostgresStore) GetWorkspaceMember(ctx context.Context, workspaceID string, memberID string) (TenancyWorkspaceMember, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyWorkspaceMember{}, err
+	}
+	row := p.queryRowContext(
+		ctx,
+		`SELECT tenant_id, workspace_id, member_id, user_id, email, role, status, joined_at, updated_at
+		 FROM tenancy_workspace_members
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND member_id = $3`,
+		scope.TenantID,
+		workspaceID,
+		memberID,
+	)
+	var member TenancyWorkspaceMember
+	if err := row.Scan(
+		&member.TenantID,
+		&member.WorkspaceID,
+		&member.MemberID,
+		&member.UserID,
+		&member.Email,
+		&member.Role,
+		&member.Status,
+		&member.JoinedAt,
+		&member.UpdatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return TenancyWorkspaceMember{}, ErrNotFound
+		}
+		return TenancyWorkspaceMember{}, err
+	}
+	return member, nil
+}
+
+// ListWorkspaceMembers lists members for one scoped workspace.
+func (p *PostgresStore) ListWorkspaceMembers(ctx context.Context, workspaceID string, limit int) ([]TenancyWorkspaceMember, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := p.queryContext(
+		ctx,
+		`SELECT tenant_id, workspace_id, member_id, user_id, email, role, status, joined_at, updated_at
+		 FROM tenancy_workspace_members
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		 ORDER BY joined_at ASC
+		 LIMIT $3`,
+		scope.TenantID,
+		workspaceID,
+		limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	members := make([]TenancyWorkspaceMember, 0, limit)
+	for rows.Next() {
+		var member TenancyWorkspaceMember
+		if err := rows.Scan(
+			&member.TenantID,
+			&member.WorkspaceID,
+			&member.MemberID,
+			&member.UserID,
+			&member.Email,
+			&member.Role,
+			&member.Status,
+			&member.JoinedAt,
+			&member.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		members = append(members, member)
+	}
+	return members, rows.Err()
+}
+
+// DeleteWorkspaceMember removes one scoped member.
+func (p *PostgresStore) DeleteWorkspaceMember(ctx context.Context, workspaceID string, memberID string) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	result, err := p.execContext(
+		ctx,
+		`DELETE FROM tenancy_workspace_members
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND member_id = $3`,
+		scope.TenantID,
+		workspaceID,
+		memberID,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// UpsertProject persists one scoped project record.
+func (p *PostgresStore) UpsertProject(ctx context.Context, project TenancyProject) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	project.TenantID = scope.TenantID
+	if project.WorkspaceID == "" {
+		project.WorkspaceID = scope.WorkspaceID
+	}
+	normalized, err := NormalizeTenancyProjectForWrite(project)
+	if err != nil {
+		return err
+	}
+	_, err = p.execContext(
+		ctx,
+		`INSERT INTO tenancy_projects (
+		     tenant_id, workspace_id, project_id, name, slug, description, archived_at, created_at, updated_at
+		 )
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		 ON CONFLICT (tenant_id, workspace_id, project_id) DO UPDATE
+		 SET name = EXCLUDED.name,
+		     slug = EXCLUDED.slug,
+		     description = EXCLUDED.description,
+		     archived_at = EXCLUDED.archived_at,
+		     updated_at = EXCLUDED.updated_at`,
+		normalized.TenantID,
+		normalized.WorkspaceID,
+		normalized.ProjectID,
+		normalized.Name,
+		normalized.Slug,
+		normalized.Description,
+		normalized.ArchivedAt,
+		normalized.CreatedAt,
+		normalized.UpdatedAt,
+	)
+	return err
+}
+
+// GetProject returns one scoped project.
+func (p *PostgresStore) GetProject(ctx context.Context, workspaceID string, projectID string) (TenancyProject, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return TenancyProject{}, err
+	}
+	row := p.queryRowContext(
+		ctx,
+		`SELECT tenant_id, workspace_id, project_id, name, slug, COALESCE(description, ''), archived_at, created_at, updated_at
+		 FROM tenancy_projects
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND project_id = $3`,
+		scope.TenantID,
+		workspaceID,
+		projectID,
+	)
+	var project TenancyProject
+	var archivedAt sql.NullTime
+	if err := row.Scan(
+		&project.TenantID,
+		&project.WorkspaceID,
+		&project.ProjectID,
+		&project.Name,
+		&project.Slug,
+		&project.Description,
+		&archivedAt,
+		&project.CreatedAt,
+		&project.UpdatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return TenancyProject{}, ErrNotFound
+		}
+		return TenancyProject{}, err
+	}
+	if archivedAt.Valid {
+		value := archivedAt.Time.UTC()
+		project.ArchivedAt = &value
+	}
+	return project, nil
+}
+
+// ListProjects returns scoped projects for a workspace.
+func (p *PostgresStore) ListProjects(ctx context.Context, workspaceID string, includeArchived bool, limit int) ([]TenancyProject, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	query := `SELECT tenant_id, workspace_id, project_id, name, slug, COALESCE(description, ''), archived_at, created_at, updated_at
+		 FROM tenancy_projects
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2`
+	args := []any{scope.TenantID, workspaceID}
+	if !includeArchived {
+		query += " AND archived_at IS NULL"
+	}
+	query += " ORDER BY created_at DESC LIMIT $3"
+	args = append(args, limit)
+	rows, err := p.queryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	projects := make([]TenancyProject, 0, limit)
+	for rows.Next() {
+		var project TenancyProject
+		var archivedAt sql.NullTime
+		if err := rows.Scan(
+			&project.TenantID,
+			&project.WorkspaceID,
+			&project.ProjectID,
+			&project.Name,
+			&project.Slug,
+			&project.Description,
+			&archivedAt,
+			&project.CreatedAt,
+			&project.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		if archivedAt.Valid {
+			value := archivedAt.Time.UTC()
+			project.ArchivedAt = &value
+		}
+		projects = append(projects, project)
+	}
+	return projects, rows.Err()
+}
+
+// DeleteProject removes one scoped project.
+func (p *PostgresStore) DeleteProject(ctx context.Context, workspaceID string, projectID string) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	result, err := p.execContext(
+		ctx,
+		`DELETE FROM tenancy_projects
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND project_id = $3`,
+		scope.TenantID,
+		workspaceID,
+		projectID,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/internal/db/postgres_tenancy.go
+++ b/internal/db/postgres_tenancy.go
@@ -455,6 +455,10 @@ func isTenancyFKViolation(err error) bool {
 	if err == nil {
 		return false
 	}
+	var sqlStateErr interface{ SQLState() string }
+	if errors.As(err, &sqlStateErr) {
+		return sqlStateErr.SQLState() == "23503"
+	}
 	return strings.Contains(err.Error(), "violates foreign key constraint")
 }
 

--- a/internal/db/postgres_tenancy.go
+++ b/internal/db/postgres_tenancy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"strings"
 )
 
 // UpsertOrganization persists one scoped organization metadata row.
@@ -31,6 +32,9 @@ func (p *PostgresStore) UpsertOrganization(ctx context.Context, organization Ten
 		normalized.CreatedAt,
 		normalized.UpdatedAt,
 	)
+	if isTenancyFKViolation(err) {
+		return ErrNotFound
+	}
 	return err
 }
 
@@ -119,6 +123,9 @@ func (p *PostgresStore) UpsertWorkspace(ctx context.Context, workspace TenancyWo
 		normalized.CreatedAt,
 		normalized.UpdatedAt,
 	)
+	if isTenancyFKViolation(err) {
+		return ErrNotFound
+	}
 	return err
 }
 
@@ -269,6 +276,9 @@ func (p *PostgresStore) UpsertWorkspaceMember(ctx context.Context, member Tenanc
 		normalized.JoinedAt,
 		normalized.UpdatedAt,
 	)
+	if isTenancyFKViolation(err) {
+		return ErrNotFound
+	}
 	return err
 }
 
@@ -435,7 +445,17 @@ func (p *PostgresStore) UpsertProject(ctx context.Context, project TenancyProjec
 		normalized.CreatedAt,
 		normalized.UpdatedAt,
 	)
+	if isTenancyFKViolation(err) {
+		return ErrNotFound
+	}
 	return err
+}
+
+func isTenancyFKViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "violates foreign key constraint")
 }
 
 // GetProject returns one scoped project.

--- a/internal/db/postgres_tenancy_test.go
+++ b/internal/db/postgres_tenancy_test.go
@@ -138,3 +138,79 @@ func TestPostgresStoreDeleteProjectScoped(t *testing.T) {
 		t.Fatalf("unmet expectations: %v", err)
 	}
 }
+
+func TestPostgresStoreUpsertsMapForeignKeyViolationToNotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	fkErr := errors.New(`pq: insert or update on table "tenancy_projects" violates foreign key constraint "tenancy_projects_tenant_id_workspace_id_fkey"`)
+
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO tenancy_workspaces (tenant_id, workspace_id, display_name, slug, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6)
+		 ON CONFLICT (tenant_id, workspace_id) DO UPDATE
+		 SET display_name = EXCLUDED.display_name,
+		     slug = EXCLUDED.slug,
+		     updated_at = EXCLUDED.updated_at`)).
+		WithArgs("tenant-a", "workspace-a", "Workspace A", "workspace-a", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnError(fkErr)
+	if err := store.UpsertWorkspace(ctx, TenancyWorkspace{
+		WorkspaceID: "workspace-a",
+		DisplayName: "Workspace A",
+		Slug:        "workspace-a",
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected workspace FK violation to map to ErrNotFound, got %v", err)
+	}
+
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO tenancy_workspace_members (
+		     tenant_id, workspace_id, member_id, user_id, email, role, status, joined_at, updated_at
+		 )
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		 ON CONFLICT (tenant_id, workspace_id, member_id) DO UPDATE
+		 SET user_id = EXCLUDED.user_id,
+		     email = EXCLUDED.email,
+		     role = EXCLUDED.role,
+		     status = EXCLUDED.status,
+		     updated_at = EXCLUDED.updated_at`)).
+		WithArgs("tenant-a", "workspace-a", "member-1", "user-1", "user@example.com", "admin", "active", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnError(fkErr)
+	if err := store.UpsertWorkspaceMember(ctx, TenancyWorkspaceMember{
+		WorkspaceID: "workspace-a",
+		MemberID:    "member-1",
+		UserID:      "user-1",
+		Email:       "user@example.com",
+		Role:        "admin",
+		Status:      "active",
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected member FK violation to map to ErrNotFound, got %v", err)
+	}
+
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO tenancy_projects (
+		     tenant_id, workspace_id, project_id, name, slug, description, archived_at, created_at, updated_at
+		 )
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		 ON CONFLICT (tenant_id, workspace_id, project_id) DO UPDATE
+		 SET name = EXCLUDED.name,
+		     slug = EXCLUDED.slug,
+		     description = EXCLUDED.description,
+		     archived_at = EXCLUDED.archived_at,
+		     updated_at = EXCLUDED.updated_at`)).
+		WithArgs("tenant-a", "workspace-a", "project-1", "Project 1", "project-1", "", nil, sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnError(fkErr)
+	if err := store.UpsertProject(ctx, TenancyProject{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		Name:        "Project 1",
+		Slug:        "project-1",
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected project FK violation to map to ErrNotFound, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/internal/db/postgres_tenancy_test.go
+++ b/internal/db/postgres_tenancy_test.go
@@ -1,0 +1,123 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestPostgresStoreUpsertAndGetOrganizationScoped(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	now := time.Now().UTC()
+
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO tenancy_organizations (tenant_id, display_name, slug, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5)
+		 ON CONFLICT (tenant_id) DO UPDATE
+		 SET display_name = EXCLUDED.display_name,
+		     slug = EXCLUDED.slug,
+		     updated_at = EXCLUDED.updated_at`)).
+		WithArgs("tenant-a", "Tenant A", "tenant-a", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := store.UpsertOrganization(ctx, TenancyOrganization{
+		DisplayName: "Tenant A",
+		Slug:        "tenant-a",
+	}); err != nil {
+		t.Fatalf("upsert organization: %v", err)
+	}
+
+	rows := sqlmock.NewRows([]string{"tenant_id", "display_name", "slug", "created_at", "updated_at"}).
+		AddRow("tenant-a", "Tenant A", "tenant-a", now, now)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, display_name, slug, created_at, updated_at
+		 FROM tenancy_organizations
+		 WHERE tenant_id = $1`)).
+		WithArgs("tenant-a").
+		WillReturnRows(rows)
+
+	organization, err := store.GetOrganization(ctx)
+	if err != nil {
+		t.Fatalf("get organization: %v", err)
+	}
+	if organization.TenantID != "tenant-a" {
+		t.Fatalf("unexpected organization: %+v", organization)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreWorkspaceScopeIsolation(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, workspace_id, display_name, slug, created_at, updated_at
+		 FROM tenancy_workspaces
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2`)).
+		WithArgs("tenant-a", "workspace-b").
+		WillReturnRows(sqlmock.NewRows([]string{"tenant_id", "workspace_id", "display_name", "slug", "created_at", "updated_at"}))
+
+	_, err = store.GetWorkspace(ctx, "workspace-b")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected scoped workspace lookup to fail with ErrNotFound, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreDeleteProjectScoped(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM tenancy_projects
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND project_id = $3`)).
+		WithArgs("tenant-a", "workspace-a", "project-1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := store.DeleteProject(ctx, "workspace-a", "project-1"); err != nil {
+		t.Fatalf("delete project: %v", err)
+	}
+
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM tenancy_projects
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND project_id = $3`)).
+		WithArgs("tenant-a", "workspace-a", "project-missing").
+		WillReturnResult(sqlmock.NewResult(1, 0))
+
+	if err := store.DeleteProject(ctx, "workspace-a", "project-missing"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for missing project delete, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/internal/db/postgres_tenancy_test.go
+++ b/internal/db/postgres_tenancy_test.go
@@ -68,18 +68,35 @@ func TestPostgresStoreWorkspaceScopeIsolation(t *testing.T) {
 	store := NewPostgresStoreWithDB(db)
 	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, workspace_id, display_name, slug, created_at, updated_at
-		 FROM tenancy_workspaces
-		 WHERE tenant_id = $1
-		   AND workspace_id = $2`)).
-		WithArgs("tenant-a", "workspace-b").
-		WillReturnRows(sqlmock.NewRows([]string{"tenant_id", "workspace_id", "display_name", "slug", "created_at", "updated_at"}))
-
 	_, err = store.GetWorkspace(ctx, "workspace-b")
 	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected scoped workspace lookup to fail with ErrNotFound, got %v", err)
 	}
 
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreUpsertProjectRejectsCrossWorkspaceScope(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+
+	err = store.UpsertProject(ctx, TenancyProject{
+		WorkspaceID: "workspace-b",
+		ProjectID:   "project-1",
+		Name:        "Project 1",
+		Slug:        "project-1",
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for cross-workspace upsert, got %v", err)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
 	}

--- a/internal/db/postgres_tenancy_test.go
+++ b/internal/db/postgres_tenancy_test.go
@@ -241,6 +241,10 @@ func TestPostgresStoreDeleteOrganizationScoped(t *testing.T) {
 	if err := store.DeleteOrganization(ctx); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected ErrNotFound for missing organization delete, got %v", err)
 	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
 }
 
 func TestPostgresStoreListAndDeleteWorkspaceScoped(t *testing.T) {
@@ -279,6 +283,10 @@ func TestPostgresStoreListAndDeleteWorkspaceScoped(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	if err := store.DeleteWorkspace(ctx, "workspace-a"); err != nil {
 		t.Fatalf("delete workspace: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
 	}
 }
 
@@ -339,6 +347,10 @@ func TestPostgresStoreWorkspaceMemberCRUD(t *testing.T) {
 	if err := store.DeleteWorkspaceMember(ctx, "workspace-a", "member-1"); err != nil {
 		t.Fatalf("delete workspace member: %v", err)
 	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
 }
 
 func TestPostgresStoreProjectReadPaths(t *testing.T) {
@@ -387,6 +399,10 @@ func TestPostgresStoreProjectReadPaths(t *testing.T) {
 	if len(projects) != 1 || projects[0].ProjectID != "project-1" {
 		t.Fatalf("unexpected projects: %+v", projects)
 	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
 }
 
 func TestPostgresStoreWorkspaceAndMemberNotFoundPaths(t *testing.T) {
@@ -427,6 +443,10 @@ func TestPostgresStoreWorkspaceAndMemberNotFoundPaths(t *testing.T) {
 	if err := store.DeleteWorkspace(ctx, "workspace-a"); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected missing workspace delete to return ErrNotFound, got %v", err)
 	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
 }
 
 func TestPostgresStoreListProjectsIncludesArchivedBranch(t *testing.T) {
@@ -455,5 +475,9 @@ func TestPostgresStoreListProjectsIncludesArchivedBranch(t *testing.T) {
 	}
 	if len(projects) != 1 || projects[0].ArchivedAt == nil {
 		t.Fatalf("expected archived project in result, got %+v", projects)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
 	}
 }

--- a/internal/db/postgres_tenancy_test.go
+++ b/internal/db/postgres_tenancy_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"regexp"
 	"testing"
@@ -212,5 +213,247 @@ func TestPostgresStoreUpsertsMapForeignKeyViolationToNotFound(t *testing.T) {
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreDeleteOrganizationScoped(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM tenancy_organizations
+		 WHERE tenant_id = $1`)).
+		WithArgs("tenant-a").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	if err := store.DeleteOrganization(ctx); err != nil {
+		t.Fatalf("delete organization: %v", err)
+	}
+
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM tenancy_organizations
+		 WHERE tenant_id = $1`)).
+		WithArgs("tenant-a").
+		WillReturnResult(sqlmock.NewResult(1, 0))
+	if err := store.DeleteOrganization(ctx); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for missing organization delete, got %v", err)
+	}
+}
+
+func TestPostgresStoreListAndDeleteWorkspaceScoped(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	now := time.Now().UTC()
+
+	rows := sqlmock.NewRows([]string{"tenant_id", "workspace_id", "display_name", "slug", "created_at", "updated_at"}).
+		AddRow("tenant-a", "workspace-a", "Workspace A", "workspace-a", now, now)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, workspace_id, display_name, slug, created_at, updated_at
+		 FROM tenancy_workspaces
+		 WHERE tenant_id = $1
+		 ORDER BY created_at DESC
+		 LIMIT $2`)).
+		WithArgs("tenant-a", 20).
+		WillReturnRows(rows)
+
+	workspaces, err := store.ListWorkspaces(ctx, 20)
+	if err != nil {
+		t.Fatalf("list workspaces: %v", err)
+	}
+	if len(workspaces) != 1 || workspaces[0].WorkspaceID != "workspace-a" {
+		t.Fatalf("unexpected workspaces: %+v", workspaces)
+	}
+
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM tenancy_workspaces
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2`)).
+		WithArgs("tenant-a", "workspace-a").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	if err := store.DeleteWorkspace(ctx, "workspace-a"); err != nil {
+		t.Fatalf("delete workspace: %v", err)
+	}
+}
+
+func TestPostgresStoreWorkspaceMemberCRUD(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	now := time.Now().UTC()
+
+	row := sqlmock.NewRows([]string{"tenant_id", "workspace_id", "member_id", "user_id", "email", "role", "status", "joined_at", "updated_at"}).
+		AddRow("tenant-a", "workspace-a", "member-1", "user-1", "user@example.com", "admin", "active", now, now)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, workspace_id, member_id, user_id, email, role, status, joined_at, updated_at
+		 FROM tenancy_workspace_members
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND member_id = $3`)).
+		WithArgs("tenant-a", "workspace-a", "member-1").
+		WillReturnRows(row)
+
+	member, err := store.GetWorkspaceMember(ctx, "workspace-a", "member-1")
+	if err != nil {
+		t.Fatalf("get workspace member: %v", err)
+	}
+	if member.MemberID != "member-1" {
+		t.Fatalf("unexpected member: %+v", member)
+	}
+
+	rows := sqlmock.NewRows([]string{"tenant_id", "workspace_id", "member_id", "user_id", "email", "role", "status", "joined_at", "updated_at"}).
+		AddRow("tenant-a", "workspace-a", "member-1", "user-1", "user@example.com", "admin", "active", now, now)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, workspace_id, member_id, user_id, email, role, status, joined_at, updated_at
+		 FROM tenancy_workspace_members
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		 ORDER BY joined_at ASC
+		 LIMIT $3`)).
+		WithArgs("tenant-a", "workspace-a", 100).
+		WillReturnRows(rows)
+
+	members, err := store.ListWorkspaceMembers(ctx, "workspace-a", 100)
+	if err != nil {
+		t.Fatalf("list workspace members: %v", err)
+	}
+	if len(members) != 1 || members[0].MemberID != "member-1" {
+		t.Fatalf("unexpected members: %+v", members)
+	}
+
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM tenancy_workspace_members
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND member_id = $3`)).
+		WithArgs("tenant-a", "workspace-a", "member-1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	if err := store.DeleteWorkspaceMember(ctx, "workspace-a", "member-1"); err != nil {
+		t.Fatalf("delete workspace member: %v", err)
+	}
+}
+
+func TestPostgresStoreProjectReadPaths(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	now := time.Now().UTC()
+	archivedAt := now
+
+	row := sqlmock.NewRows([]string{"tenant_id", "workspace_id", "project_id", "name", "slug", "coalesce", "archived_at", "created_at", "updated_at"}).
+		AddRow("tenant-a", "workspace-a", "project-1", "Project 1", "project-1", "desc", archivedAt, now, now)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, workspace_id, project_id, name, slug, COALESCE(description, ''), archived_at, created_at, updated_at
+		 FROM tenancy_projects
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND project_id = $3`)).
+		WithArgs("tenant-a", "workspace-a", "project-1").
+		WillReturnRows(row)
+
+	project, err := store.GetProject(ctx, "workspace-a", "project-1")
+	if err != nil {
+		t.Fatalf("get project: %v", err)
+	}
+	if project.ProjectID != "project-1" || project.ArchivedAt == nil {
+		t.Fatalf("unexpected project: %+v", project)
+	}
+
+	rows := sqlmock.NewRows([]string{"tenant_id", "workspace_id", "project_id", "name", "slug", "coalesce", "archived_at", "created_at", "updated_at"}).
+		AddRow("tenant-a", "workspace-a", "project-1", "Project 1", "project-1", "desc", nil, now, now)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, workspace_id, project_id, name, slug, COALESCE(description, ''), archived_at, created_at, updated_at
+		 FROM tenancy_projects
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2 AND archived_at IS NULL ORDER BY created_at DESC LIMIT $3`)).
+		WithArgs("tenant-a", "workspace-a", 100).
+		WillReturnRows(rows)
+
+	projects, err := store.ListProjects(ctx, "workspace-a", false, 100)
+	if err != nil {
+		t.Fatalf("list projects: %v", err)
+	}
+	if len(projects) != 1 || projects[0].ProjectID != "project-1" {
+		t.Fatalf("unexpected projects: %+v", projects)
+	}
+}
+
+func TestPostgresStoreWorkspaceAndMemberNotFoundPaths(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, workspace_id, display_name, slug, created_at, updated_at
+		 FROM tenancy_workspaces
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2`)).
+		WithArgs("tenant-a", "workspace-a").
+		WillReturnError(sql.ErrNoRows)
+	if _, err := store.GetWorkspace(ctx, "workspace-a"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected missing workspace to return ErrNotFound, got %v", err)
+	}
+
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM tenancy_workspace_members
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND member_id = $3`)).
+		WithArgs("tenant-a", "workspace-a", "missing-member").
+		WillReturnResult(sqlmock.NewResult(1, 0))
+	if err := store.DeleteWorkspaceMember(ctx, "workspace-a", "missing-member"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected missing member delete to return ErrNotFound, got %v", err)
+	}
+
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM tenancy_workspaces
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2`)).
+		WithArgs("tenant-a", "workspace-a").
+		WillReturnResult(sqlmock.NewResult(1, 0))
+	if err := store.DeleteWorkspace(ctx, "workspace-a"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected missing workspace delete to return ErrNotFound, got %v", err)
+	}
+}
+
+func TestPostgresStoreListProjectsIncludesArchivedBranch(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	now := time.Now().UTC()
+
+	rows := sqlmock.NewRows([]string{"tenant_id", "workspace_id", "project_id", "name", "slug", "coalesce", "archived_at", "created_at", "updated_at"}).
+		AddRow("tenant-a", "workspace-a", "project-1", "Project 1", "project-1", "desc", now, now, now)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, workspace_id, project_id, name, slug, COALESCE(description, ''), archived_at, created_at, updated_at
+		 FROM tenancy_projects
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2 ORDER BY created_at DESC LIMIT $3`)).
+		WithArgs("tenant-a", "workspace-a", 10).
+		WillReturnRows(rows)
+
+	projects, err := store.ListProjects(ctx, "workspace-a", true, 10)
+	if err != nil {
+		t.Fatalf("list projects include archived: %v", err)
+	}
+	if len(projects) != 1 || projects[0].ArchivedAt == nil {
+		t.Fatalf("expected archived project in result, got %+v", projects)
 	}
 }

--- a/internal/db/scope.go
+++ b/internal/db/scope.go
@@ -88,3 +88,17 @@ func MatchScope(scope Scope, tenantID string, workspaceID string) bool {
 	return strings.TrimSpace(tenantID) == normalized.TenantID &&
 		strings.TrimSpace(workspaceID) == normalized.WorkspaceID
 }
+
+// ResolveScopedWorkspaceID normalizes one workspace identifier and enforces
+// that it remains within the active request scope.
+func ResolveScopedWorkspaceID(scope Scope, workspaceID string) (string, error) {
+	normalizedScope := scope.Normalize()
+	resolved := strings.TrimSpace(workspaceID)
+	if resolved == "" {
+		resolved = normalizedScope.WorkspaceID
+	}
+	if resolved != normalizedScope.WorkspaceID {
+		return "", ErrNotFound
+	}
+	return resolved, nil
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -23,6 +23,7 @@ var ErrNotFound = errors.New("record not found")
 var ErrScopeRequired = errors.New("scope is required")
 
 var authzOwnerTeamPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
+var tenancySlugPattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 
 const (
 	ScanEventLevelDebug = "debug"
@@ -105,6 +106,20 @@ var validAuthzPolicyRolloutModes = map[string]struct{}{
 	AuthzPolicyRolloutModeDisabled: {},
 	AuthzPolicyRolloutModeShadow:   {},
 	AuthzPolicyRolloutModeEnforce:  {},
+}
+
+var validTenancyMemberRoles = map[string]struct{}{
+	"owner":   {},
+	"admin":   {},
+	"analyst": {},
+	"viewer":  {},
+}
+
+var validTenancyMemberStatuses = map[string]struct{}{
+	"invited":   {},
+	"active":    {},
+	"suspended": {},
+	"removed":   {},
 }
 
 // ScanRecord tracks persisted scan execution metadata.
@@ -273,6 +288,51 @@ type AuthzPolicyEvent struct {
 	Message     string         `json:"message,omitempty"`
 	Metadata    map[string]any `json:"metadata,omitempty"`
 	CreatedAt   time.Time      `json:"created_at"`
+}
+
+// TenancyOrganization stores one tenant root metadata record.
+type TenancyOrganization struct {
+	TenantID    string    `json:"tenant_id"`
+	DisplayName string    `json:"display_name"`
+	Slug        string    `json:"slug"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// TenancyWorkspace stores one workspace metadata record.
+type TenancyWorkspace struct {
+	TenantID    string    `json:"tenant_id"`
+	WorkspaceID string    `json:"workspace_id"`
+	DisplayName string    `json:"display_name"`
+	Slug        string    `json:"slug"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// TenancyWorkspaceMember stores one workspace member assignment.
+type TenancyWorkspaceMember struct {
+	TenantID    string    `json:"tenant_id"`
+	WorkspaceID string    `json:"workspace_id"`
+	MemberID    string    `json:"member_id"`
+	UserID      string    `json:"user_id"`
+	Email       string    `json:"email,omitempty"`
+	Role        string    `json:"role"`
+	Status      string    `json:"status"`
+	JoinedAt    time.Time `json:"joined_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// TenancyProject stores one project metadata record.
+type TenancyProject struct {
+	TenantID    string     `json:"tenant_id"`
+	WorkspaceID string     `json:"workspace_id"`
+	ProjectID   string     `json:"project_id"`
+	Name        string     `json:"name"`
+	Slug        string     `json:"slug"`
+	Description string     `json:"description,omitempty"`
+	ArchivedAt  *time.Time `json:"archived_at,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
 }
 
 // NormalizeScanEventLevel validates and normalizes event levels.
@@ -537,6 +597,170 @@ func containsInt(values []int, value int) bool {
 	return false
 }
 
+func validateTenancySlug(value, field string) error {
+	if len(value) > 63 {
+		return fmt.Errorf("%s must be 63 characters or fewer", field)
+	}
+	if !tenancySlugPattern.MatchString(value) {
+		return fmt.Errorf("%s must match %s", field, tenancySlugPattern.String())
+	}
+	return nil
+}
+
+// NormalizeTenancyOrganizationForWrite validates and canonicalizes organization metadata.
+func NormalizeTenancyOrganizationForWrite(organization TenancyOrganization) (TenancyOrganization, error) {
+	normalized := organization
+	normalized.TenantID = strings.TrimSpace(organization.TenantID)
+	if normalized.TenantID == "" {
+		return TenancyOrganization{}, fmt.Errorf("tenant id is required")
+	}
+	normalized.DisplayName = strings.TrimSpace(organization.DisplayName)
+	if normalized.DisplayName == "" {
+		return TenancyOrganization{}, fmt.Errorf("display name is required")
+	}
+	normalized.Slug = strings.ToLower(strings.TrimSpace(organization.Slug))
+	if normalized.Slug == "" {
+		return TenancyOrganization{}, fmt.Errorf("slug is required")
+	}
+	if err := validateTenancySlug(normalized.Slug, "slug"); err != nil {
+		return TenancyOrganization{}, err
+	}
+	if normalized.CreatedAt.IsZero() {
+		normalized.CreatedAt = time.Now().UTC()
+	} else {
+		normalized.CreatedAt = normalized.CreatedAt.UTC()
+	}
+	if normalized.UpdatedAt.IsZero() {
+		normalized.UpdatedAt = normalized.CreatedAt
+	} else {
+		normalized.UpdatedAt = normalized.UpdatedAt.UTC()
+	}
+	return normalized, nil
+}
+
+// NormalizeTenancyWorkspaceForWrite validates and canonicalizes workspace metadata.
+func NormalizeTenancyWorkspaceForWrite(workspace TenancyWorkspace) (TenancyWorkspace, error) {
+	normalized := workspace
+	normalized.TenantID = strings.TrimSpace(workspace.TenantID)
+	if normalized.TenantID == "" {
+		return TenancyWorkspace{}, fmt.Errorf("tenant id is required")
+	}
+	normalized.WorkspaceID = strings.TrimSpace(workspace.WorkspaceID)
+	if normalized.WorkspaceID == "" {
+		return TenancyWorkspace{}, fmt.Errorf("workspace id is required")
+	}
+	normalized.DisplayName = strings.TrimSpace(workspace.DisplayName)
+	if normalized.DisplayName == "" {
+		return TenancyWorkspace{}, fmt.Errorf("display name is required")
+	}
+	normalized.Slug = strings.ToLower(strings.TrimSpace(workspace.Slug))
+	if normalized.Slug == "" {
+		return TenancyWorkspace{}, fmt.Errorf("slug is required")
+	}
+	if err := validateTenancySlug(normalized.Slug, "slug"); err != nil {
+		return TenancyWorkspace{}, err
+	}
+	if normalized.CreatedAt.IsZero() {
+		normalized.CreatedAt = time.Now().UTC()
+	} else {
+		normalized.CreatedAt = normalized.CreatedAt.UTC()
+	}
+	if normalized.UpdatedAt.IsZero() {
+		normalized.UpdatedAt = normalized.CreatedAt
+	} else {
+		normalized.UpdatedAt = normalized.UpdatedAt.UTC()
+	}
+	return normalized, nil
+}
+
+// NormalizeTenancyWorkspaceMemberForWrite validates and canonicalizes workspace members.
+func NormalizeTenancyWorkspaceMemberForWrite(member TenancyWorkspaceMember) (TenancyWorkspaceMember, error) {
+	normalized := member
+	normalized.TenantID = strings.TrimSpace(member.TenantID)
+	if normalized.TenantID == "" {
+		return TenancyWorkspaceMember{}, fmt.Errorf("tenant id is required")
+	}
+	normalized.WorkspaceID = strings.TrimSpace(member.WorkspaceID)
+	if normalized.WorkspaceID == "" {
+		return TenancyWorkspaceMember{}, fmt.Errorf("workspace id is required")
+	}
+	normalized.MemberID = strings.TrimSpace(member.MemberID)
+	if normalized.MemberID == "" {
+		return TenancyWorkspaceMember{}, fmt.Errorf("member id is required")
+	}
+	normalized.UserID = strings.TrimSpace(member.UserID)
+	if normalized.UserID == "" {
+		return TenancyWorkspaceMember{}, fmt.Errorf("user id is required")
+	}
+	normalized.Email = strings.TrimSpace(member.Email)
+	normalized.Role = strings.ToLower(strings.TrimSpace(member.Role))
+	if _, ok := validTenancyMemberRoles[normalized.Role]; !ok {
+		return TenancyWorkspaceMember{}, fmt.Errorf("invalid member role")
+	}
+	normalized.Status = strings.ToLower(strings.TrimSpace(member.Status))
+	if normalized.Status == "" {
+		normalized.Status = "invited"
+	}
+	if _, ok := validTenancyMemberStatuses[normalized.Status]; !ok {
+		return TenancyWorkspaceMember{}, fmt.Errorf("invalid member status")
+	}
+	if normalized.JoinedAt.IsZero() {
+		normalized.JoinedAt = time.Now().UTC()
+	} else {
+		normalized.JoinedAt = normalized.JoinedAt.UTC()
+	}
+	if normalized.UpdatedAt.IsZero() {
+		normalized.UpdatedAt = normalized.JoinedAt
+	} else {
+		normalized.UpdatedAt = normalized.UpdatedAt.UTC()
+	}
+	return normalized, nil
+}
+
+// NormalizeTenancyProjectForWrite validates and canonicalizes project metadata.
+func NormalizeTenancyProjectForWrite(project TenancyProject) (TenancyProject, error) {
+	normalized := project
+	normalized.TenantID = strings.TrimSpace(project.TenantID)
+	if normalized.TenantID == "" {
+		return TenancyProject{}, fmt.Errorf("tenant id is required")
+	}
+	normalized.WorkspaceID = strings.TrimSpace(project.WorkspaceID)
+	if normalized.WorkspaceID == "" {
+		return TenancyProject{}, fmt.Errorf("workspace id is required")
+	}
+	normalized.ProjectID = strings.TrimSpace(project.ProjectID)
+	if normalized.ProjectID == "" {
+		return TenancyProject{}, fmt.Errorf("project id is required")
+	}
+	normalized.Name = strings.TrimSpace(project.Name)
+	if normalized.Name == "" {
+		return TenancyProject{}, fmt.Errorf("project name is required")
+	}
+	normalized.Slug = strings.ToLower(strings.TrimSpace(project.Slug))
+	if normalized.Slug == "" {
+		return TenancyProject{}, fmt.Errorf("project slug is required")
+	}
+	if err := validateTenancySlug(normalized.Slug, "project slug"); err != nil {
+		return TenancyProject{}, err
+	}
+	normalized.Description = strings.TrimSpace(project.Description)
+	if normalized.ArchivedAt != nil {
+		archived := normalized.ArchivedAt.UTC()
+		normalized.ArchivedAt = &archived
+	}
+	if normalized.CreatedAt.IsZero() {
+		normalized.CreatedAt = time.Now().UTC()
+	} else {
+		normalized.CreatedAt = normalized.CreatedAt.UTC()
+	}
+	if normalized.UpdatedAt.IsZero() {
+		normalized.UpdatedAt = normalized.CreatedAt
+	} else {
+		normalized.UpdatedAt = normalized.UpdatedAt.UTC()
+	}
+	return normalized, nil
+}
+
 // NormalizeAuthzPolicyEventForWrite validates and canonicalizes one immutable policy event.
 func NormalizeAuthzPolicyEventForWrite(event AuthzPolicyEvent) (AuthzPolicyEvent, error) {
 	normalized := event
@@ -633,6 +857,21 @@ type Store interface {
 	GetAuthzPolicyRollout(ctx context.Context, policySetID string) (AuthzPolicyRollout, error)
 	AppendAuthzPolicyEvent(ctx context.Context, event AuthzPolicyEvent) error
 	ListAuthzPolicyEvents(ctx context.Context, policySetID string, limit int) ([]AuthzPolicyEvent, error)
+	UpsertOrganization(ctx context.Context, organization TenancyOrganization) error
+	GetOrganization(ctx context.Context) (TenancyOrganization, error)
+	DeleteOrganization(ctx context.Context) error
+	UpsertWorkspace(ctx context.Context, workspace TenancyWorkspace) error
+	GetWorkspace(ctx context.Context, workspaceID string) (TenancyWorkspace, error)
+	ListWorkspaces(ctx context.Context, limit int) ([]TenancyWorkspace, error)
+	DeleteWorkspace(ctx context.Context, workspaceID string) error
+	UpsertWorkspaceMember(ctx context.Context, member TenancyWorkspaceMember) error
+	GetWorkspaceMember(ctx context.Context, workspaceID string, memberID string) (TenancyWorkspaceMember, error)
+	ListWorkspaceMembers(ctx context.Context, workspaceID string, limit int) ([]TenancyWorkspaceMember, error)
+	DeleteWorkspaceMember(ctx context.Context, workspaceID string, memberID string) error
+	UpsertProject(ctx context.Context, project TenancyProject) error
+	GetProject(ctx context.Context, workspaceID string, projectID string) (TenancyProject, error)
+	ListProjects(ctx context.Context, workspaceID string, includeArchived bool, limit int) ([]TenancyProject, error)
+	DeleteProject(ctx context.Context, workspaceID string, projectID string) error
 	ListIdentities(ctx context.Context, filter IdentityFilter, limit int) ([]domain.Identity, error)
 	ListRelationships(ctx context.Context, filter RelationshipFilter, limit int) ([]domain.Relationship, error)
 	AppendScanEvent(ctx context.Context, scanID string, level string, message string, metadata map[string]any) error

--- a/internal/db/tenancy_store_test.go
+++ b/internal/db/tenancy_store_test.go
@@ -1,0 +1,164 @@
+package db
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNormalizeTenancyOrganizationForWrite(t *testing.T) {
+	normalized, err := NormalizeTenancyOrganizationForWrite(TenancyOrganization{
+		TenantID:    " tenant-a ",
+		DisplayName: " Core Org ",
+		Slug:        " CORE ",
+	})
+	if err != nil {
+		t.Fatalf("normalize organization: %v", err)
+	}
+	if normalized.TenantID != "tenant-a" {
+		t.Fatalf("expected tenant id tenant-a, got %q", normalized.TenantID)
+	}
+	if normalized.Slug != "core" {
+		t.Fatalf("expected lower slug, got %q", normalized.Slug)
+	}
+	if normalized.CreatedAt.IsZero() || normalized.UpdatedAt.IsZero() {
+		t.Fatal("expected generated timestamps")
+	}
+
+	if _, err := NormalizeTenancyOrganizationForWrite(TenancyOrganization{}); err == nil {
+		t.Fatal("expected required field validation error")
+	}
+	if _, err := NormalizeTenancyOrganizationForWrite(TenancyOrganization{
+		TenantID:    "tenant-a",
+		DisplayName: "Tenant A",
+		Slug:        "tenant a",
+	}); err == nil {
+		t.Fatal("expected invalid organization slug format error")
+	}
+}
+
+func TestNormalizeTenancyWorkspaceMemberForWrite(t *testing.T) {
+	joinedAt := time.Date(2026, 4, 1, 10, 0, 0, 0, time.FixedZone("WAT", 1*60*60))
+	normalized, err := NormalizeTenancyWorkspaceMemberForWrite(TenancyWorkspaceMember{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		MemberID:    "member-1",
+		UserID:      "user-1",
+		Email:       " user@example.com ",
+		Role:        "ADMIN",
+		Status:      "ACTIVE",
+		JoinedAt:    joinedAt,
+	})
+	if err != nil {
+		t.Fatalf("normalize member: %v", err)
+	}
+	if normalized.Role != "admin" || normalized.Status != "active" {
+		t.Fatalf("expected normalized role/status, got role=%q status=%q", normalized.Role, normalized.Status)
+	}
+	if normalized.Email != "user@example.com" {
+		t.Fatalf("expected trimmed email, got %q", normalized.Email)
+	}
+	if normalized.JoinedAt.Location() != time.UTC {
+		t.Fatalf("expected UTC joined_at, got %v", normalized.JoinedAt.Location())
+	}
+
+	if _, err := NormalizeTenancyWorkspaceMemberForWrite(TenancyWorkspaceMember{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		MemberID:    "member-1",
+		UserID:      "user-1",
+		Role:        "invalid",
+		Status:      "active",
+	}); err == nil {
+		t.Fatal("expected invalid role error")
+	}
+}
+
+func TestNormalizeTenancyProjectForWrite(t *testing.T) {
+	archivedAt := time.Date(2026, 4, 2, 10, 0, 0, 0, time.FixedZone("WAT", 1*60*60))
+	normalized, err := NormalizeTenancyProjectForWrite(TenancyProject{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-a",
+		Name:        " Payments ",
+		Slug:        " PAYMENTS ",
+		ArchivedAt:  &archivedAt,
+	})
+	if err != nil {
+		t.Fatalf("normalize project: %v", err)
+	}
+	if normalized.Name != "Payments" || normalized.Slug != "payments" {
+		t.Fatalf("expected normalized name/slug, got name=%q slug=%q", normalized.Name, normalized.Slug)
+	}
+	if normalized.ArchivedAt == nil || normalized.ArchivedAt.Location() != time.UTC {
+		t.Fatalf("expected UTC archived_at, got %+v", normalized.ArchivedAt)
+	}
+
+	if _, err := NormalizeTenancyProjectForWrite(TenancyProject{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-a",
+		Name:        "",
+		Slug:        "payments",
+	}); err == nil {
+		t.Fatal("expected project name required error")
+	}
+	if _, err := NormalizeTenancyProjectForWrite(TenancyProject{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-a",
+		Name:        "Payments",
+		Slug:        "project/a",
+	}); err == nil {
+		t.Fatal("expected project slug format validation error")
+	}
+	if _, err := NormalizeTenancyProjectForWrite(TenancyProject{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-a",
+		Name:        "Payments",
+		Slug:        "project-",
+	}); err == nil {
+		t.Fatal("expected trailing hyphen slug to fail")
+	}
+	if _, err := NormalizeTenancyProjectForWrite(TenancyProject{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-a",
+		Name:        "Payments",
+		Slug:        "project--a",
+	}); err == nil {
+		t.Fatal("expected consecutive hyphen slug to fail")
+	}
+}
+
+func TestNormalizeTenancyWorkspaceForWrite(t *testing.T) {
+	now := time.Date(2026, 4, 4, 10, 0, 0, 0, time.FixedZone("WAT", 1*60*60))
+	normalized, err := NormalizeTenancyWorkspaceForWrite(TenancyWorkspace{
+		TenantID:    " tenant-a ",
+		WorkspaceID: " workspace-a ",
+		DisplayName: " Workspace A ",
+		Slug:        " WORKSPACE-A ",
+		CreatedAt:   now,
+	})
+	if err != nil {
+		t.Fatalf("normalize workspace: %v", err)
+	}
+	if normalized.TenantID != "tenant-a" || normalized.WorkspaceID != "workspace-a" {
+		t.Fatalf("expected trimmed tenant/workspace ids, got tenant=%q workspace=%q", normalized.TenantID, normalized.WorkspaceID)
+	}
+	if normalized.DisplayName != "Workspace A" || normalized.Slug != "workspace-a" {
+		t.Fatalf("expected normalized display name/slug, got display_name=%q slug=%q", normalized.DisplayName, normalized.Slug)
+	}
+	if normalized.CreatedAt.Location() != time.UTC || normalized.UpdatedAt.Location() != time.UTC {
+		t.Fatalf("expected UTC timestamps, got created_at=%v updated_at=%v", normalized.CreatedAt.Location(), normalized.UpdatedAt.Location())
+	}
+
+	if _, err := NormalizeTenancyWorkspaceForWrite(TenancyWorkspace{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		DisplayName: "Workspace A",
+		Slug:        "workspace/a",
+	}); err == nil {
+		t.Fatal("expected workspace slug format validation error")
+	}
+}

--- a/internal/domain/appmode.go
+++ b/internal/domain/appmode.go
@@ -357,6 +357,9 @@ func (j RemediationJob) Validate() error {
 }
 
 func CanTransitionConnectorStatus(from ConnectorStatus, to ConnectorStatus) bool {
+	if !validConnectorStatus(from) || !validConnectorStatus(to) {
+		return false
+	}
 	if from == to {
 		return true
 	}

--- a/internal/domain/appmode.go
+++ b/internal/domain/appmode.go
@@ -1,0 +1,479 @@
+package domain
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var appModeIdentifierPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,63}$`)
+
+// MemberRole enumerates tenancy-level permissions within a workspace.
+type MemberRole string
+
+const (
+	MemberRoleOwner   MemberRole = "owner"
+	MemberRoleAdmin   MemberRole = "admin"
+	MemberRoleAnalyst MemberRole = "analyst"
+	MemberRoleViewer  MemberRole = "viewer"
+)
+
+// MemberStatus tracks workspace membership lifecycle state.
+type MemberStatus string
+
+const (
+	MemberStatusInvited   MemberStatus = "invited"
+	MemberStatusActive    MemberStatus = "active"
+	MemberStatusSuspended MemberStatus = "suspended"
+	MemberStatusRemoved   MemberStatus = "removed"
+)
+
+// ConnectorType identifies one onboarded source connector.
+type ConnectorType string
+
+const (
+	ConnectorTypeGitHub     ConnectorType = "github"
+	ConnectorTypeAWS        ConnectorType = "aws"
+	ConnectorTypeKubernetes ConnectorType = "kubernetes"
+)
+
+// ConnectorStatus represents connector health and lifecycle state.
+type ConnectorStatus string
+
+const (
+	ConnectorStatusPending      ConnectorStatus = "pending"
+	ConnectorStatusActive       ConnectorStatus = "active"
+	ConnectorStatusDegraded     ConnectorStatus = "degraded"
+	ConnectorStatusDisconnected ConnectorStatus = "disconnected"
+)
+
+// ScanTriggerMode controls scan initiation mode.
+type ScanTriggerMode string
+
+const (
+	ScanTriggerModeManual    ScanTriggerMode = "manual"
+	ScanTriggerModeScheduled ScanTriggerMode = "scheduled"
+	ScanTriggerModeEvent     ScanTriggerMode = "event"
+	ScanTriggerModeHybrid    ScanTriggerMode = "hybrid"
+)
+
+// SuppressionScope controls suppression blast radius.
+type SuppressionScope string
+
+const (
+	SuppressionScopeFinding  SuppressionScope = "finding"
+	SuppressionScopeRule     SuppressionScope = "rule"
+	SuppressionScopeResource SuppressionScope = "resource"
+)
+
+// RemediationJobType identifies one remediation class.
+type RemediationJobType string
+
+const (
+	RemediationJobTypePatchTemplate RemediationJobType = "patch_template"
+	RemediationJobTypeCreateFixPR   RemediationJobType = "create_fix_pr"
+	RemediationJobTypeTicket        RemediationJobType = "ticket"
+)
+
+// RemediationJobStatus tracks remediation execution lifecycle.
+type RemediationJobStatus string
+
+const (
+	RemediationJobStatusQueued    RemediationJobStatus = "queued"
+	RemediationJobStatusRunning   RemediationJobStatus = "running"
+	RemediationJobStatusSucceeded RemediationJobStatus = "succeeded"
+	RemediationJobStatusFailed    RemediationJobStatus = "failed"
+	RemediationJobStatusCanceled  RemediationJobStatus = "canceled"
+)
+
+// Organization models one tenant boundary.
+type Organization struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Slug      string    `json:"slug"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// Workspace models one collaboration boundary within an organization.
+type Workspace struct {
+	ID             string    `json:"id"`
+	OrganizationID string    `json:"organization_id"`
+	Name           string    `json:"name"`
+	Slug           string    `json:"slug"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+// WorkspaceMember models one user assignment in a workspace.
+type WorkspaceMember struct {
+	ID          string       `json:"id"`
+	WorkspaceID string       `json:"workspace_id"`
+	UserID      string       `json:"user_id"`
+	Email       string       `json:"email"`
+	Role        MemberRole   `json:"role"`
+	Status      MemberStatus `json:"status"`
+	JoinedAt    time.Time    `json:"joined_at"`
+	UpdatedAt   time.Time    `json:"updated_at"`
+}
+
+// Project models one scoped application or service boundary in a workspace.
+type Project struct {
+	ID          string     `json:"id"`
+	WorkspaceID string     `json:"workspace_id"`
+	Name        string     `json:"name"`
+	Slug        string     `json:"slug"`
+	Description string     `json:"description,omitempty"`
+	ArchivedAt  *time.Time `json:"archived_at,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+}
+
+// Connector models one project integration source.
+type Connector struct {
+	ID          string          `json:"id"`
+	WorkspaceID string          `json:"workspace_id"`
+	ProjectID   string          `json:"project_id"`
+	Type        ConnectorType   `json:"type"`
+	DisplayName string          `json:"display_name"`
+	Status      ConnectorStatus `json:"status"`
+	LastSyncAt  *time.Time      `json:"last_sync_at,omitempty"`
+	CreatedAt   time.Time       `json:"created_at"`
+	UpdatedAt   time.Time       `json:"updated_at"`
+}
+
+// ScanPolicy models scan scheduling and trigger limits for one project.
+type ScanPolicy struct {
+	ID                 string          `json:"id"`
+	WorkspaceID        string          `json:"workspace_id"`
+	ProjectID          string          `json:"project_id"`
+	Name               string          `json:"name"`
+	Enabled            bool            `json:"enabled"`
+	TriggerMode        ScanTriggerMode `json:"trigger_mode"`
+	Cron               string          `json:"cron,omitempty"`
+	MaxConcurrentScans int             `json:"max_concurrent_scans"`
+	CreatedAt          time.Time       `json:"created_at"`
+	UpdatedAt          time.Time       `json:"updated_at"`
+}
+
+// SuppressionPolicy models policy-based finding suppressions.
+type SuppressionPolicy struct {
+	ID            string           `json:"id"`
+	WorkspaceID   string           `json:"workspace_id"`
+	ProjectID     string           `json:"project_id"`
+	Name          string           `json:"name"`
+	Scope         SuppressionScope `json:"scope"`
+	Target        string           `json:"target"`
+	Reason        string           `json:"reason"`
+	ExpiresAt     *time.Time       `json:"expires_at,omitempty"`
+	CreatedBy     string           `json:"created_by"`
+	CreatedAt     time.Time        `json:"created_at"`
+	LastUpdatedAt time.Time        `json:"last_updated_at"`
+}
+
+// RemediationJob models one remediation execution request.
+type RemediationJob struct {
+	ID            string               `json:"id"`
+	WorkspaceID   string               `json:"workspace_id"`
+	ProjectID     string               `json:"project_id"`
+	FindingID     string               `json:"finding_id"`
+	Type          RemediationJobType   `json:"type"`
+	Status        RemediationJobStatus `json:"status"`
+	RequestedBy   string               `json:"requested_by"`
+	RequestedAt   time.Time            `json:"requested_at"`
+	StartedAt     *time.Time           `json:"started_at,omitempty"`
+	CompletedAt   *time.Time           `json:"completed_at,omitempty"`
+	ArtifactRef   string               `json:"artifact_ref,omitempty"`
+	ErrorMessage  string               `json:"error_message,omitempty"`
+	LastUpdatedAt time.Time            `json:"last_updated_at"`
+}
+
+func (o Organization) Validate() error {
+	if err := validateAppModeIdentifier("organization.id", o.ID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(o.Name) == "" {
+		return fmt.Errorf("organization.name is required")
+	}
+	if err := validateAppModeIdentifier("organization.slug", o.Slug); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (w Workspace) Validate() error {
+	if err := validateAppModeIdentifier("workspace.id", w.ID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("workspace.organization_id", w.OrganizationID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(w.Name) == "" {
+		return fmt.Errorf("workspace.name is required")
+	}
+	if err := validateAppModeIdentifier("workspace.slug", w.Slug); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m WorkspaceMember) Validate() error {
+	if err := validateAppModeIdentifier("workspace_member.id", m.ID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("workspace_member.workspace_id", m.WorkspaceID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("workspace_member.user_id", m.UserID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(m.Email) == "" {
+		return fmt.Errorf("workspace_member.email is required")
+	}
+	if !validMemberRole(m.Role) {
+		return fmt.Errorf("workspace_member.role is invalid")
+	}
+	if !validMemberStatus(m.Status) {
+		return fmt.Errorf("workspace_member.status is invalid")
+	}
+	return nil
+}
+
+func (p Project) Validate() error {
+	if err := validateAppModeIdentifier("project.id", p.ID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("project.workspace_id", p.WorkspaceID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(p.Name) == "" {
+		return fmt.Errorf("project.name is required")
+	}
+	if err := validateAppModeIdentifier("project.slug", p.Slug); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c Connector) Validate() error {
+	if err := validateAppModeIdentifier("connector.id", c.ID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("connector.workspace_id", c.WorkspaceID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("connector.project_id", c.ProjectID); err != nil {
+		return err
+	}
+	if !validConnectorType(c.Type) {
+		return fmt.Errorf("connector.type is invalid")
+	}
+	if strings.TrimSpace(c.DisplayName) == "" {
+		return fmt.Errorf("connector.display_name is required")
+	}
+	if !validConnectorStatus(c.Status) {
+		return fmt.Errorf("connector.status is invalid")
+	}
+	return nil
+}
+
+func (p ScanPolicy) Validate() error {
+	if err := validateAppModeIdentifier("scan_policy.id", p.ID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("scan_policy.workspace_id", p.WorkspaceID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("scan_policy.project_id", p.ProjectID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(p.Name) == "" {
+		return fmt.Errorf("scan_policy.name is required")
+	}
+	if !validScanTriggerMode(p.TriggerMode) {
+		return fmt.Errorf("scan_policy.trigger_mode is invalid")
+	}
+	if p.TriggerMode == ScanTriggerModeScheduled && strings.TrimSpace(p.Cron) == "" {
+		return fmt.Errorf("scan_policy.cron is required for scheduled trigger_mode")
+	}
+	if p.MaxConcurrentScans <= 0 {
+		return fmt.Errorf("scan_policy.max_concurrent_scans must be > 0")
+	}
+	return nil
+}
+
+func (p SuppressionPolicy) Validate() error {
+	if err := validateAppModeIdentifier("suppression_policy.id", p.ID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("suppression_policy.workspace_id", p.WorkspaceID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("suppression_policy.project_id", p.ProjectID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(p.Name) == "" {
+		return fmt.Errorf("suppression_policy.name is required")
+	}
+	if !validSuppressionScope(p.Scope) {
+		return fmt.Errorf("suppression_policy.scope is invalid")
+	}
+	if strings.TrimSpace(p.Target) == "" {
+		return fmt.Errorf("suppression_policy.target is required")
+	}
+	if strings.TrimSpace(p.Reason) == "" {
+		return fmt.Errorf("suppression_policy.reason is required")
+	}
+	if err := validateAppModeIdentifier("suppression_policy.created_by", p.CreatedBy); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (j RemediationJob) Validate() error {
+	if err := validateAppModeIdentifier("remediation_job.id", j.ID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("remediation_job.workspace_id", j.WorkspaceID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("remediation_job.project_id", j.ProjectID); err != nil {
+		return err
+	}
+	if err := validateAppModeIdentifier("remediation_job.finding_id", j.FindingID); err != nil {
+		return err
+	}
+	if !validRemediationType(j.Type) {
+		return fmt.Errorf("remediation_job.type is invalid")
+	}
+	if !validRemediationStatus(j.Status) {
+		return fmt.Errorf("remediation_job.status is invalid")
+	}
+	if err := validateAppModeIdentifier("remediation_job.requested_by", j.RequestedBy); err != nil {
+		return err
+	}
+	return nil
+}
+
+func CanTransitionConnectorStatus(from ConnectorStatus, to ConnectorStatus) bool {
+	if from == to {
+		return true
+	}
+	switch from {
+	case ConnectorStatusPending:
+		return to == ConnectorStatusActive || to == ConnectorStatusDisconnected || to == ConnectorStatusDegraded
+	case ConnectorStatusActive:
+		return to == ConnectorStatusDegraded || to == ConnectorStatusDisconnected
+	case ConnectorStatusDegraded:
+		return to == ConnectorStatusActive || to == ConnectorStatusDisconnected
+	case ConnectorStatusDisconnected:
+		return to == ConnectorStatusPending || to == ConnectorStatusActive
+	default:
+		return false
+	}
+}
+
+func CanTransitionRemediationJobStatus(from RemediationJobStatus, to RemediationJobStatus) bool {
+	if from == to {
+		return true
+	}
+	switch from {
+	case RemediationJobStatusQueued:
+		return to == RemediationJobStatusRunning || to == RemediationJobStatusCanceled
+	case RemediationJobStatusRunning:
+		return to == RemediationJobStatusSucceeded || to == RemediationJobStatusFailed || to == RemediationJobStatusCanceled
+	case RemediationJobStatusFailed:
+		return to == RemediationJobStatusQueued
+	case RemediationJobStatusSucceeded, RemediationJobStatusCanceled:
+		return false
+	default:
+		return false
+	}
+}
+
+func validateAppModeIdentifier(field string, value string) error {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return fmt.Errorf("%s is required", field)
+	}
+	if value != trimmed {
+		return fmt.Errorf("%s must not contain surrounding whitespace", field)
+	}
+	if !appModeIdentifierPattern.MatchString(trimmed) {
+		return fmt.Errorf("%s must match %s", field, appModeIdentifierPattern.String())
+	}
+	return nil
+}
+
+func validMemberRole(role MemberRole) bool {
+	switch role {
+	case MemberRoleOwner, MemberRoleAdmin, MemberRoleAnalyst, MemberRoleViewer:
+		return true
+	default:
+		return false
+	}
+}
+
+func validMemberStatus(status MemberStatus) bool {
+	switch status {
+	case MemberStatusInvited, MemberStatusActive, MemberStatusSuspended, MemberStatusRemoved:
+		return true
+	default:
+		return false
+	}
+}
+
+func validConnectorType(connectorType ConnectorType) bool {
+	switch connectorType {
+	case ConnectorTypeGitHub, ConnectorTypeAWS, ConnectorTypeKubernetes:
+		return true
+	default:
+		return false
+	}
+}
+
+func validConnectorStatus(status ConnectorStatus) bool {
+	switch status {
+	case ConnectorStatusPending, ConnectorStatusActive, ConnectorStatusDegraded, ConnectorStatusDisconnected:
+		return true
+	default:
+		return false
+	}
+}
+
+func validScanTriggerMode(mode ScanTriggerMode) bool {
+	switch mode {
+	case ScanTriggerModeManual, ScanTriggerModeScheduled, ScanTriggerModeEvent, ScanTriggerModeHybrid:
+		return true
+	default:
+		return false
+	}
+}
+
+func validSuppressionScope(scope SuppressionScope) bool {
+	switch scope {
+	case SuppressionScopeFinding, SuppressionScopeRule, SuppressionScopeResource:
+		return true
+	default:
+		return false
+	}
+}
+
+func validRemediationType(remediationType RemediationJobType) bool {
+	switch remediationType {
+	case RemediationJobTypePatchTemplate, RemediationJobTypeCreateFixPR, RemediationJobTypeTicket:
+		return true
+	default:
+		return false
+	}
+}
+
+func validRemediationStatus(status RemediationJobStatus) bool {
+	switch status {
+	case RemediationJobStatusQueued, RemediationJobStatusRunning, RemediationJobStatusSucceeded, RemediationJobStatusFailed, RemediationJobStatusCanceled:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/domain/appmode_test.go
+++ b/internal/domain/appmode_test.go
@@ -219,6 +219,9 @@ func TestConnectorStatusTransitions(t *testing.T) {
 	if !CanTransitionConnectorStatus(ConnectorStatusDegraded, ConnectorStatusActive) {
 		t.Fatal("expected degraded -> active transition to be valid")
 	}
+	if CanTransitionConnectorStatus(ConnectorStatus("unknown"), ConnectorStatus("unknown")) {
+		t.Fatal("expected unknown -> unknown transition to be invalid")
+	}
 }
 
 func TestRemediationStatusTransitions(t *testing.T) {
@@ -233,5 +236,83 @@ func TestRemediationStatusTransitions(t *testing.T) {
 	}
 	if !CanTransitionRemediationJobStatus(RemediationJobStatusFailed, RemediationJobStatusQueued) {
 		t.Fatal("expected failed -> queued transition to be valid for retry")
+	}
+}
+
+func TestAppModeValidationRejectsInvalidEnums(t *testing.T) {
+	now := time.Now().UTC()
+
+	invalidMember := WorkspaceMember{
+		ID:          "member-1",
+		WorkspaceID: "workspace-core",
+		UserID:      "user-1",
+		Email:       "user@example.com",
+		Role:        MemberRole("bad-role"),
+		Status:      MemberStatus("bad-status"),
+		JoinedAt:    now,
+		UpdatedAt:   now,
+	}
+	if err := invalidMember.Validate(); err == nil {
+		t.Fatal("expected invalid member role/status to fail")
+	}
+
+	invalidConnector := Connector{
+		ID:          "connector-1",
+		WorkspaceID: "workspace-core",
+		ProjectID:   "project-core",
+		Type:        ConnectorType("bad-type"),
+		DisplayName: "connector",
+		Status:      ConnectorStatus("bad-status"),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := invalidConnector.Validate(); err == nil {
+		t.Fatal("expected invalid connector type/status to fail")
+	}
+
+	invalidScanPolicy := ScanPolicy{
+		ID:                 "policy-1",
+		WorkspaceID:        "workspace-core",
+		ProjectID:          "project-core",
+		Name:               "policy",
+		Enabled:            true,
+		TriggerMode:        ScanTriggerMode("bad-mode"),
+		MaxConcurrentScans: 1,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	if err := invalidScanPolicy.Validate(); err == nil {
+		t.Fatal("expected invalid scan trigger mode to fail")
+	}
+
+	invalidSuppression := SuppressionPolicy{
+		ID:            "suppression-1",
+		WorkspaceID:   "workspace-core",
+		ProjectID:     "project-core",
+		Name:          "suppression",
+		Scope:         SuppressionScope("bad-scope"),
+		Target:        "target",
+		Reason:        "reason",
+		CreatedBy:     "user-1",
+		CreatedAt:     now,
+		LastUpdatedAt: now,
+	}
+	if err := invalidSuppression.Validate(); err == nil {
+		t.Fatal("expected invalid suppression scope to fail")
+	}
+
+	invalidRemediation := RemediationJob{
+		ID:            "remediation-1",
+		WorkspaceID:   "workspace-core",
+		ProjectID:     "project-core",
+		FindingID:     "finding-1",
+		Type:          RemediationJobType("bad-type"),
+		Status:        RemediationJobStatus("bad-status"),
+		RequestedBy:   "user-1",
+		RequestedAt:   now,
+		LastUpdatedAt: now,
+	}
+	if err := invalidRemediation.Validate(); err == nil {
+		t.Fatal("expected invalid remediation type/status to fail")
 	}
 }

--- a/internal/domain/appmode_test.go
+++ b/internal/domain/appmode_test.go
@@ -1,0 +1,237 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAppModeEntitiesValidate(t *testing.T) {
+	now := time.Now().UTC()
+	org := Organization{
+		ID:        "org-core",
+		Name:      "Core Org",
+		Slug:      "core-org",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := org.Validate(); err != nil {
+		t.Fatalf("expected valid organization, got %v", err)
+	}
+
+	workspace := Workspace{
+		ID:             "workspace-core",
+		OrganizationID: org.ID,
+		Name:           "Core Workspace",
+		Slug:           "core-workspace",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := workspace.Validate(); err != nil {
+		t.Fatalf("expected valid workspace, got %v", err)
+	}
+
+	member := WorkspaceMember{
+		ID:          "member-1",
+		WorkspaceID: workspace.ID,
+		UserID:      "user-1",
+		Email:       "user@example.com",
+		Role:        MemberRoleAdmin,
+		Status:      MemberStatusActive,
+		JoinedAt:    now,
+		UpdatedAt:   now,
+	}
+	if err := member.Validate(); err != nil {
+		t.Fatalf("expected valid member, got %v", err)
+	}
+
+	project := Project{
+		ID:          "project-payments",
+		WorkspaceID: workspace.ID,
+		Name:        "Payments",
+		Slug:        "payments",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := project.Validate(); err != nil {
+		t.Fatalf("expected valid project, got %v", err)
+	}
+
+	connector := Connector{
+		ID:          "connector-gh",
+		WorkspaceID: workspace.ID,
+		ProjectID:   project.ID,
+		Type:        ConnectorTypeGitHub,
+		DisplayName: "GitHub Source",
+		Status:      ConnectorStatusActive,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := connector.Validate(); err != nil {
+		t.Fatalf("expected valid connector, got %v", err)
+	}
+
+	policy := ScanPolicy{
+		ID:                 "policy-1",
+		WorkspaceID:        workspace.ID,
+		ProjectID:          project.ID,
+		Name:               "default policy",
+		Enabled:            true,
+		TriggerMode:        ScanTriggerModeHybrid,
+		Cron:               "0 */6 * * *",
+		MaxConcurrentScans: 2,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	if err := policy.Validate(); err != nil {
+		t.Fatalf("expected valid scan policy, got %v", err)
+	}
+
+	suppression := SuppressionPolicy{
+		ID:            "suppression-1",
+		WorkspaceID:   workspace.ID,
+		ProjectID:     project.ID,
+		Name:          "temporary exception",
+		Scope:         SuppressionScopeRule,
+		Target:        "secret_exposure",
+		Reason:        "approved exception",
+		CreatedBy:     "admin-user",
+		CreatedAt:     now,
+		LastUpdatedAt: now,
+	}
+	if err := suppression.Validate(); err != nil {
+		t.Fatalf("expected valid suppression policy, got %v", err)
+	}
+
+	remediation := RemediationJob{
+		ID:            "remediation-1",
+		WorkspaceID:   workspace.ID,
+		ProjectID:     project.ID,
+		FindingID:     "finding-123",
+		Type:          RemediationJobTypeCreateFixPR,
+		Status:        RemediationJobStatusQueued,
+		RequestedBy:   "admin-user",
+		RequestedAt:   now,
+		LastUpdatedAt: now,
+	}
+	if err := remediation.Validate(); err != nil {
+		t.Fatalf("expected valid remediation job, got %v", err)
+	}
+}
+
+func TestAppModeEntityValidationFailsOnMissingRequiredFields(t *testing.T) {
+	if err := (Organization{}).Validate(); err == nil {
+		t.Fatal("expected organization validation to fail")
+	}
+	if err := (Workspace{}).Validate(); err == nil {
+		t.Fatal("expected workspace validation to fail")
+	}
+	if err := (WorkspaceMember{}).Validate(); err == nil {
+		t.Fatal("expected workspace member validation to fail")
+	}
+	if err := (Project{}).Validate(); err == nil {
+		t.Fatal("expected project validation to fail")
+	}
+	if err := (Connector{}).Validate(); err == nil {
+		t.Fatal("expected connector validation to fail")
+	}
+	if err := (ScanPolicy{}).Validate(); err == nil {
+		t.Fatal("expected scan policy validation to fail")
+	}
+	if err := (SuppressionPolicy{}).Validate(); err == nil {
+		t.Fatal("expected suppression policy validation to fail")
+	}
+	if err := (RemediationJob{}).Validate(); err == nil {
+		t.Fatal("expected remediation job validation to fail")
+	}
+}
+
+func TestAppModeIdentifierRejectsSurroundingWhitespace(t *testing.T) {
+	org := Organization{
+		ID:   "  org-1  ",
+		Name: "Org One",
+		Slug: "org-one",
+	}
+	if err := org.Validate(); err == nil {
+		t.Fatal("expected identifier with surrounding whitespace to fail")
+	}
+}
+
+func TestWorkspaceMemberValidationRequiresEmail(t *testing.T) {
+	now := time.Now().UTC()
+	member := WorkspaceMember{
+		ID:          "member-1",
+		WorkspaceID: "workspace-core",
+		UserID:      "user-1",
+		Email:       "   ",
+		Role:        MemberRoleViewer,
+		Status:      MemberStatusInvited,
+		JoinedAt:    now,
+		UpdatedAt:   now,
+	}
+	if err := member.Validate(); err == nil {
+		t.Fatal("expected workspace member email validation to fail")
+	}
+}
+
+func TestScanPolicyScheduledValidationRequiresCron(t *testing.T) {
+	now := time.Now().UTC()
+	policy := ScanPolicy{
+		ID:                 "policy-1",
+		WorkspaceID:        "workspace-core",
+		ProjectID:          "project-core",
+		Name:               "scheduled policy",
+		Enabled:            true,
+		TriggerMode:        ScanTriggerModeScheduled,
+		MaxConcurrentScans: 1,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	if err := policy.Validate(); err == nil {
+		t.Fatal("expected scan policy scheduled validation to fail when cron is missing")
+	}
+}
+
+func TestRemediationJobValidationRequiresValidFindingID(t *testing.T) {
+	now := time.Now().UTC()
+	job := RemediationJob{
+		ID:            "remediation-1",
+		WorkspaceID:   "workspace-core",
+		ProjectID:     "project-core",
+		FindingID:     "finding bad",
+		Type:          RemediationJobTypeCreateFixPR,
+		Status:        RemediationJobStatusQueued,
+		RequestedBy:   "admin-user",
+		RequestedAt:   now,
+		LastUpdatedAt: now,
+	}
+	if err := job.Validate(); err == nil {
+		t.Fatal("expected remediation job finding_id validation to fail")
+	}
+}
+
+func TestConnectorStatusTransitions(t *testing.T) {
+	if !CanTransitionConnectorStatus(ConnectorStatusPending, ConnectorStatusActive) {
+		t.Fatal("expected pending -> active transition to be valid")
+	}
+	if CanTransitionConnectorStatus(ConnectorStatusActive, ConnectorStatusPending) {
+		t.Fatal("expected active -> pending transition to be invalid")
+	}
+	if !CanTransitionConnectorStatus(ConnectorStatusDegraded, ConnectorStatusActive) {
+		t.Fatal("expected degraded -> active transition to be valid")
+	}
+}
+
+func TestRemediationStatusTransitions(t *testing.T) {
+	if !CanTransitionRemediationJobStatus(RemediationJobStatusQueued, RemediationJobStatusRunning) {
+		t.Fatal("expected queued -> running transition to be valid")
+	}
+	if !CanTransitionRemediationJobStatus(RemediationJobStatusRunning, RemediationJobStatusSucceeded) {
+		t.Fatal("expected running -> succeeded transition to be valid")
+	}
+	if CanTransitionRemediationJobStatus(RemediationJobStatusSucceeded, RemediationJobStatusQueued) {
+		t.Fatal("expected succeeded -> queued transition to be invalid")
+	}
+	if !CanTransitionRemediationJobStatus(RemediationJobStatusFailed, RemediationJobStatusQueued) {
+		t.Fatal("expected failed -> queued transition to be valid for retry")
+	}
+}

--- a/internal/domain/json_tags_test.go
+++ b/internal/domain/json_tags_test.go
@@ -61,3 +61,33 @@ func TestIdentityJSONUsesSnakeCaseFields(t *testing.T) {
 		t.Fatalf("unexpected struct field casing leaked in payload: %s", text)
 	}
 }
+
+func TestAppModeEntityJSONUsesSnakeCaseFields(t *testing.T) {
+	now := time.Date(2026, 3, 16, 0, 0, 0, 0, time.UTC)
+	connector := Connector{
+		ID:          "connector-1",
+		WorkspaceID: "workspace-1",
+		ProjectID:   "project-1",
+		Type:        ConnectorTypeGitHub,
+		DisplayName: "GitHub",
+		Status:      ConnectorStatusActive,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	payload, err := json.Marshal(connector)
+	if err != nil {
+		t.Fatalf("marshal connector: %v", err)
+	}
+	text := string(payload)
+	for _, expected := range []string{`"workspace_id"`, `"project_id"`, `"display_name"`, `"created_at"`} {
+		if !strings.Contains(text, expected) {
+			t.Fatalf("expected field %s in %s", expected, text)
+		}
+	}
+	for _, unexpected := range []string{`"WorkspaceID"`, `"ProjectID"`, `"DisplayName"`} {
+		if strings.Contains(text, unexpected) {
+			t.Fatalf("unexpected struct field casing leaked in payload: %s", text)
+		}
+	}
+}

--- a/migrations/000012_tenancy_core_entities.down.sql
+++ b/migrations/000012_tenancy_core_entities.down.sql
@@ -1,5 +1,6 @@
 DROP INDEX IF EXISTS idx_tenancy_projects_scope_archived;
 DROP INDEX IF EXISTS idx_tenancy_projects_scope_created;
+DROP INDEX IF EXISTS idx_tenancy_members_scope_joined;
 DROP INDEX IF EXISTS idx_tenancy_members_scope_role_status;
 DROP INDEX IF EXISTS idx_tenancy_workspaces_scope_created;
 

--- a/migrations/000012_tenancy_core_entities.down.sql
+++ b/migrations/000012_tenancy_core_entities.down.sql
@@ -1,0 +1,9 @@
+DROP INDEX IF EXISTS idx_tenancy_projects_scope_archived;
+DROP INDEX IF EXISTS idx_tenancy_projects_scope_created;
+DROP INDEX IF EXISTS idx_tenancy_members_scope_role_status;
+DROP INDEX IF EXISTS idx_tenancy_workspaces_scope_created;
+
+DROP TABLE IF EXISTS tenancy_projects;
+DROP TABLE IF EXISTS tenancy_workspace_members;
+DROP TABLE IF EXISTS tenancy_workspaces;
+DROP TABLE IF EXISTS tenancy_organizations;

--- a/migrations/000012_tenancy_core_entities.up.sql
+++ b/migrations/000012_tenancy_core_entities.up.sql
@@ -67,6 +67,9 @@ CREATE INDEX IF NOT EXISTS idx_tenancy_workspaces_scope_created
 CREATE INDEX IF NOT EXISTS idx_tenancy_members_scope_role_status
     ON tenancy_workspace_members (tenant_id, workspace_id, role, status);
 
+CREATE INDEX IF NOT EXISTS idx_tenancy_members_scope_joined
+    ON tenancy_workspace_members (tenant_id, workspace_id, joined_at);
+
 CREATE INDEX IF NOT EXISTS idx_tenancy_projects_scope_created
     ON tenancy_projects (tenant_id, workspace_id, created_at DESC);
 

--- a/migrations/000012_tenancy_core_entities.up.sql
+++ b/migrations/000012_tenancy_core_entities.up.sql
@@ -1,0 +1,74 @@
+CREATE TABLE IF NOT EXISTS tenancy_organizations (
+    tenant_id TEXT PRIMARY KEY,
+    display_name TEXT NOT NULL,
+    slug TEXT NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CHECK (LENGTH(TRIM(tenant_id)) > 0),
+    CHECK (LENGTH(TRIM(display_name)) > 0),
+    CHECK (LENGTH(TRIM(slug)) > 0)
+);
+
+CREATE TABLE IF NOT EXISTS tenancy_workspaces (
+    tenant_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    slug TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, workspace_id),
+    UNIQUE (tenant_id, slug),
+    FOREIGN KEY (tenant_id) REFERENCES tenancy_organizations(tenant_id) ON DELETE CASCADE,
+    CHECK (LENGTH(TRIM(workspace_id)) > 0),
+    CHECK (LENGTH(TRIM(display_name)) > 0),
+    CHECK (LENGTH(TRIM(slug)) > 0)
+);
+
+CREATE TABLE IF NOT EXISTS tenancy_workspace_members (
+    tenant_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    member_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    email TEXT,
+    role TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'invited',
+    joined_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, workspace_id, member_id),
+    UNIQUE (tenant_id, workspace_id, user_id),
+    FOREIGN KEY (tenant_id, workspace_id) REFERENCES tenancy_workspaces(tenant_id, workspace_id) ON DELETE CASCADE,
+    CHECK (LENGTH(TRIM(member_id)) > 0),
+    CHECK (LENGTH(TRIM(user_id)) > 0),
+    CHECK (role IN ('owner', 'admin', 'analyst', 'viewer')),
+    CHECK (status IN ('invited', 'active', 'suspended', 'removed'))
+);
+
+CREATE TABLE IF NOT EXISTS tenancy_projects (
+    tenant_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    slug TEXT NOT NULL,
+    description TEXT,
+    archived_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, workspace_id, project_id),
+    UNIQUE (tenant_id, workspace_id, slug),
+    FOREIGN KEY (tenant_id, workspace_id) REFERENCES tenancy_workspaces(tenant_id, workspace_id) ON DELETE CASCADE,
+    CHECK (LENGTH(TRIM(project_id)) > 0),
+    CHECK (LENGTH(TRIM(name)) > 0),
+    CHECK (LENGTH(TRIM(slug)) > 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenancy_workspaces_scope_created
+    ON tenancy_workspaces (tenant_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_tenancy_members_scope_role_status
+    ON tenancy_workspace_members (tenant_id, workspace_id, role, status);
+
+CREATE INDEX IF NOT EXISTS idx_tenancy_projects_scope_created
+    ON tenancy_projects (tenant_id, workspace_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_tenancy_projects_scope_archived
+    ON tenancy_projects (tenant_id, workspace_id, archived_at);


### PR DESCRIPTION
Fixes #542
Fixes #543
Fixes #544

## Summary
Brings the missing ITR-002, ITR-003, and ITR-004 work onto `dev` in dependency order.

### Included
1. ITR-002 (`#542`): app-mode multi-tenant domain entities, validation/state transitions, snake_case JSON contract tests, and entity docs.
2. ITR-003 (`#543`): tenancy core migrations (`000012`) for org/workspace/member/project + FK/index/constraint checks and migration docs updates.
3. ITR-004 (`#544`): scoped tenancy CRUD store layer (memory + postgres) and scope-enforcement hardening (`ResolveScopedWorkspaceID`/`RequireScope`) with tests preventing cross-workspace leaks.

## Commits
- `6a75dce` feat(domain): add app-mode tenancy and remediation entities (ITR-002)
- `1e2b9c7` feat(db): add tenancy core migrations for org/workspace/member/project (ITR-003)
- `33416da` feat(db): implement scoped tenancy CRUD store layer (ITR-004)
- `e588e9b` fix(db): enforce workspace scope boundaries in tenancy stores

## Validation
- `go test ./internal/domain`
- `go test ./internal/db`
- `go test ./internal/api -run "TestOpenAPIV1Spec|TestAPIV1ContractSnapshots"`
