### PR TITLE
fix(security): add local OIDC token hygiene guardrails

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,10 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-push]
+
+      - id: local-token-hygiene
+        name: local env token hygiene
+        entry: ./scripts/check-local-token-hygiene.sh
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - API contract (OpenAPI): `openapi-v1.yaml`
 - Frontend topology (`web/` vs `site/`): `frontend-topology.md`
 - Development workflow: `development-workflow.md`
+- Local token hygiene (Vercel OIDC): `local-token-hygiene.md`
 - CLI reference: `cli-reference.md`
 - Documentation quality checks: `documentation-quality-checks.md`
 - Testing strategy: `testing.md`

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -44,3 +44,11 @@ Configured hooks include:
 - trailing whitespace and EOF normalization
 - Go formatting check
 - Go vet on pre-push
+- Local `.env.local` token hygiene check on pre-push (`VERCEL_OIDC_TOKEN`)
+
+## Local Token Hygiene
+
+If your local workflow uses Vercel OIDC and writes `VERCEL_OIDC_TOKEN` into `.env.local`:
+- Treat the token as short-lived and regenerate with `vercel env pull .env.local` when needed.
+- Never share raw token values in logs, screenshots, or pasted debug snippets.
+- Use the local runbook: `local-token-hygiene.md`.

--- a/docs/local-token-hygiene.md
+++ b/docs/local-token-hygiene.md
@@ -1,0 +1,38 @@
+# Local Token Hygiene (Vercel OIDC)
+
+This runbook prevents accidental leaks of short-lived local tokens pulled into `.env.local`.
+
+## Why this matters
+
+`VERCEL_OIDC_TOKEN` is a bearer credential. Even though `.env.local` is gitignored, leakage can still happen through:
+- copied terminal output
+- screenshots
+- pasted debug files
+- local artifact sharing
+
+## Safe local workflow
+
+1. Link the project when needed:
+   - `vercel link`
+2. Pull fresh local env values only when needed:
+   - `vercel env pull .env.local`
+3. Treat the token as ephemeral:
+   - regenerate with `vercel env pull .env.local` when expired
+   - do not reuse old copied values
+
+## Rotation and containment
+
+If token exposure is suspected:
+
+1. Regenerate immediately:
+   - `vercel env pull .env.local`
+2. Remove local copies from scratch files, screenshots, and logs.
+3. Re-run any failing local auth flow with the fresh token.
+
+## Built-in guardrail
+
+This repository ships an optional pre-push hook:
+- script: `scripts/check-local-token-hygiene.sh`
+- hook id: `local-token-hygiene` in `.pre-commit-config.yaml`
+
+When enabled via pre-commit, pushes are blocked if `.env.local` contains a JWT-shaped `VERCEL_OIDC_TOKEN`.

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -9,7 +9,9 @@ This page is the v1 security baseline for operators.
   - Docker `.env` (dev only)
   - Kubernetes Secret
   - Terraform sensitive variables
+- Treat local `.env.local` OIDC tokens as ephemeral credentials and regenerate on demand.
 - Prefer OIDC (`IDENTRAIL_OIDC_ISSUER_URL` + `IDENTRAIL_OIDC_AUDIENCE`) over static API keys for human access.
+- See local handling runbook: `local-token-hygiene.md`.
 
 ## 2) API Key Hardening
 

--- a/scripts/check-local-token-hygiene.sh
+++ b/scripts/check-local-token-hygiene.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+env_file=".env.local"
+
+if [[ ! -f "${env_file}" ]]; then
+  exit 0
+fi
+
+token_line="$(grep -E '^[[:space:]]*VERCEL_OIDC_TOKEN=' "${env_file}" | tail -n1 || true)"
+if [[ -z "${token_line}" ]]; then
+  exit 0
+fi
+
+token_value="${token_line#*=}"
+token_value="${token_value%\"}"
+token_value="${token_value#\"}"
+token_value="$(printf '%s' "${token_value}" | tr -d '\r' | xargs)"
+
+if [[ -z "${token_value}" ]]; then
+  exit 0
+fi
+
+# Vercel OIDC tokens are JWT-shaped. Block pushes when one is present locally.
+if [[ "${token_value}" =~ ^eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$ ]]; then
+  cat <<'MSG' >&2
+Detected a JWT-shaped VERCEL_OIDC_TOKEN in .env.local.
+
+For local token hygiene:
+1) Rotate/regenerate the token (vercel env pull).
+2) Avoid sharing terminal output that includes token values.
+3) Redact the token in local files before publishing logs/screenshots.
+
+This pre-push check is intentionally blocking to reduce local credential leak risk.
+MSG
+  exit 1
+fi
+
+exit 0

--- a/scripts/check-local-token-hygiene.sh
+++ b/scripts/check-local-token-hygiene.sh
@@ -13,9 +13,19 @@ if [[ -z "${token_line}" ]]; then
 fi
 
 token_value="${token_line#*=}"
+token_value="$(printf '%s' "${token_value}" | tr -d '\r')"
+
+# Strip inline comments (un-quoted # and everything after)
+token_value="$(printf '%s' "${token_value}" | sed -E 's/[[:space:]]+#.*$//')"
+
+# Strip surrounding quotes (double or single)
 token_value="${token_value%\"}"
 token_value="${token_value#\"}"
-token_value="$(printf '%s' "${token_value}" | tr -d '\r' | xargs)"
+token_value="${token_value%\'}"
+token_value="${token_value#\'}"
+
+# Trim leading/trailing whitespace
+token_value="$(printf '%s' "${token_value}" | xargs)"
 
 if [[ -z "${token_value}" ]]; then
   exit 0


### PR DESCRIPTION
Fixes #606

## Summary
This PR hardens local Vercel OIDC token hygiene so accidental local credential leakage is less likely.

## What Changed
- Added a local guard script: `scripts/check-local-token-hygiene.sh`
  - Checks `.env.local` for a JWT-shaped `VERCEL_OIDC_TOKEN`
  - Blocks push (when pre-commit hooks are enabled) with explicit remediation steps
- Added optional pre-push hook in `.pre-commit-config.yaml`:
  - Hook id: `local-token-hygiene`
- Added runbook: `docs/local-token-hygiene.md`
  - Safe local workflow for pulling/regenerating OIDC token values
  - Containment/rotation steps when exposure is suspected
- Updated docs discoverability:
  - `docs/development-workflow.md`
  - `docs/security-hardening.md`
  - `docs/README.md`

## Why
Issue #606 identifies a real operational risk: `.env.local` is gitignored, but token leaks still happen through logs/screenshots/debug sharing. This adds a practical guardrail and explicit runbook guidance.

## Impact and Risk
- Runtime behavior: no production/runtime code path changes.
- Developer workflow: only affects contributors who enable pre-commit hooks; then pushes are blocked if a JWT-shaped local OIDC token is present in `.env.local`.

## Validation
- `bash -n scripts/check-local-token-hygiene.sh`
- Positive case: script exits 0 when `.env.local` has no `VERCEL_OIDC_TOKEN`
- Negative case: script exits non-zero when `.env.local` has JWT-shaped `VERCEL_OIDC_TOKEN`

## AI Assistance Disclosure
- AI-assisted: yes
- Tools used: Codex (GPT-5)
- Where used: `.pre-commit-config.yaml`, `scripts/check-local-token-hygiene.sh`, docs updates under `docs/`
- Human verification performed: manual review + script syntax check + positive/negative script execution checks
