### PR TITLE
Fixes #607: add repository hygiene cleanup tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,8 @@ secrets/
 logs/
 tmp/
 *.tmp
-canceled
-succeeded
+/canceled
+/succeeded
 
 # Go
 bin/

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ secrets/
 logs/
 tmp/
 *.tmp
+canceled
+succeeded
 
 # Go
 bin/
@@ -37,6 +39,8 @@ pnpm-debug.log*
 web/dist/
 web/build/
 web/coverage/
+web/coverage 2/
+web/coverage 3/
 web/.vercel/
 site/.next/
 site/.vercel/
@@ -72,6 +76,12 @@ build/
 
 # Cache
 .cache/
+
+# Local duplicate artifacts accidentally produced by manual copy operations
+/* 2
+/* 3
+/* 2.*
+/* 3.*
 
 # Legacy/optional frontend worktree snapshots (not part of active dev branch)
 site/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /usr/bin/env bash
 .DEFAULT_GOAL := help
 
-.PHONY: help bootstrap quickstart quickstart-down fmt fmt-check vet test test-integration web-install web-test web-build api-example-contract-check vercel-prod-deploy helm-lint tfmt-check ci pre-commit
+.PHONY: help bootstrap quickstart quickstart-down clean-local fmt fmt-check vet test test-integration web-install web-test web-build api-example-contract-check vercel-prod-deploy helm-lint tfmt-check ci pre-commit
 
 help: ## Show available targets
 	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z0-9_-]+:.*##/ {printf "%-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -15,6 +15,9 @@ quickstart: ## Bootstrap local Docker stack and run first scan
 
 quickstart-down: ## Stop and remove quickstart Docker stack
 	docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env down
+
+clean-local: ## Remove local duplicate/temp artifacts not tracked in git
+	./scripts/clean_local.sh
 
 fmt: ## Auto-format Go and Terraform files
 	@if git ls-files '*.go' | grep -q .; then \

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,6 +16,11 @@ tasks:
     cmds:
       - make fmt
 
+  clean:
+    desc: Remove local duplicate/temp artifacts not tracked in git
+    cmds:
+      - make clean-local
+
   fmt-check:
     desc: Check formatting without modifying files
     cmds:

--- a/scripts/clean_local.sh
+++ b/scripts/clean_local.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+echo "Cleaning local artifacts in ${repo_root}"
+
+removed=0
+
+remove_path() {
+  local path="$1"
+  if [ -e "${path}" ] || [ -L "${path}" ]; then
+    rm -rf "${path}"
+    echo "removed: ${path}"
+    removed=1
+  fi
+}
+
+# Known marker files seen in local workflows.
+remove_path "canceled"
+remove_path "succeeded"
+
+# Coverage outputs outside source of truth.
+remove_path "coverage"
+remove_path "coverage 2"
+remove_path "coverage 3"
+remove_path "web/coverage"
+remove_path "web/coverage 2"
+remove_path "web/coverage 3"
+
+# Delete root-level duplicate artifacts like "README 2.md", "Makefile 3", etc.
+while IFS= read -r -d '' candidate; do
+  # Never remove tracked files.
+  if git ls-files --error-unmatch "${candidate}" >/dev/null 2>&1; then
+    continue
+  fi
+  rm -rf "${candidate}"
+  echo "removed duplicate: ${candidate}"
+  removed=1
+done < <(
+  find . -maxdepth 1 \( -name '* 2' -o -name '* 3' -o -name '* 2.*' -o -name '* 3.*' \) -print0
+)
+
+if [ "${removed}" -eq 0 ]; then
+  echo "No local artifacts found."
+fi


### PR DESCRIPTION
Fixes #607

## What changed
- Added local cleanup script at `scripts/clean_local.sh` to remove common stale local artifacts (duplicate ` 2`/` 3` copies, marker files, extra coverage outputs) while skipping tracked files.
- Added `make clean-local` target for one-command cleanup.
- Added `task clean` wrapper in `Taskfile.yml`.
- Added ignore patterns in `.gitignore` for recurring local artifact noise.

## Why
- Reduces dirty-worktree noise and accidental commit risk.
- Gives contributors a safe, repeatable local cleanup path.

## Impact / risk
- Low risk: changes are limited to local dev hygiene and ignore rules.
- Script only removes known local artifacts and explicitly avoids deleting tracked files.

## Validation performed
- `bash -n scripts/clean_local.sh`
- `make clean-local`

## AI-assisted disclosure
- AI-assisted: yes
- Tools used: Codex
- Where used: `.gitignore`, `Makefile`, `Taskfile.yml`, `scripts/clean_local.sh`
- Human verification performed: script lint + local cleanup run
