### PR TITLE
fixes (#546): implement vNext org/workspace/project tenancy endpoints

### DIFF
--- a/internal/api/authz_middleware.go
+++ b/internal/api/authz_middleware.go
@@ -27,6 +27,8 @@ const (
 	policyActionRepoScansRun   = "repo_scans.run"
 	policyActionAuthzSimulate  = "authz.policies.simulate"
 	policyActionAuthzRollback  = "authz.policies.rollback"
+	policyActionTenancyRead    = "tenancy.read"
+	policyActionTenancyWrite   = "tenancy.write"
 
 	policyContextABACSubjectAttrsLoadedKey  = "abac.subject_attributes_loaded"
 	policyContextABACResourceAttrsLoadedKey = "abac.resource_attributes_loaded"
@@ -70,6 +72,8 @@ func defaultRouteActionRoleGrants() map[string][]string {
 		policyActionRepoScansRun:   writeRoles,
 		policyActionAuthzSimulate:  {scopeAdmin},
 		policyActionAuthzRollback:  {scopeAdmin},
+		policyActionTenancyRead:    readRoles,
+		policyActionTenancyWrite:   writeRoles,
 	}
 }
 
@@ -94,6 +98,8 @@ func defaultRouteActionABACPolicies() map[string]abacActionPolicy {
 		policyActionRepoScansRun:  passThroughPolicy,
 		policyActionAuthzSimulate: passThroughPolicy,
 		policyActionAuthzRollback: passThroughPolicy,
+		policyActionTenancyRead:   passThroughPolicy,
+		policyActionTenancyWrite:  passThroughPolicy,
 		policyActionFindingsTriage: {
 			OnNoMatch: PolicyOutcomeNoOpinion,
 			AnyOf: []abacClause{

--- a/internal/api/authz_middleware_test.go
+++ b/internal/api/authz_middleware_test.go
@@ -26,6 +26,14 @@ func TestRoutePolicyRegistryLookup(t *testing.T) {
 	if policy.Action != policyActionScansRun {
 		t.Fatalf("expected scans.run action, got %q", policy.Action)
 	}
+
+	tenancyPolicy, exists := registry.lookup(http.MethodGet, "/v1/organizations/current")
+	if !exists {
+		t.Fatal("expected policy for GET /v1/organizations/current")
+	}
+	if tenancyPolicy.Action != policyActionTenancyRead {
+		t.Fatalf("expected tenancy.read action, got %q", tenancyPolicy.Action)
+	}
 }
 
 func TestPolicyRolesFromScope(t *testing.T) {

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -658,6 +658,20 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodPost, Path: "/v1/repo-scans", Action: policyActionRepoScansRun, ResourceType: "repo_scan"},
 		{Method: http.MethodPost, Path: "/v1/authz/policies/simulate", Action: policyActionAuthzSimulate, ResourceType: "authz_policy"},
 		{Method: http.MethodPost, Path: "/v1/authz/policies/rollback", Action: policyActionAuthzRollback, ResourceType: "authz_policy"},
+		{Method: http.MethodGet, Path: "/v1/organizations/current", Action: policyActionTenancyRead, ResourceType: "organization"},
+		{Method: http.MethodPut, Path: "/v1/organizations/current", Action: policyActionTenancyWrite, ResourceType: "organization"},
+		{Method: http.MethodGet, Path: "/v1/workspaces", Action: policyActionTenancyRead, ResourceType: "workspace"},
+		{Method: http.MethodPost, Path: "/v1/workspaces", Action: policyActionTenancyWrite, ResourceType: "workspace"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id", Action: policyActionTenancyRead, ResourceType: "workspace", ResourceIDParam: "workspace_id"},
+		{Method: http.MethodDelete, Path: "/v1/workspaces/:workspace_id", Action: policyActionTenancyWrite, ResourceType: "workspace", ResourceIDParam: "workspace_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/members", Action: policyActionTenancyRead, ResourceType: "workspace_member", ResourceIDParam: "workspace_id"},
+		{Method: http.MethodPost, Path: "/v1/workspaces/:workspace_id/members", Action: policyActionTenancyWrite, ResourceType: "workspace_member", ResourceIDParam: "workspace_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/members/:member_id", Action: policyActionTenancyRead, ResourceType: "workspace_member", ResourceIDParam: "member_id"},
+		{Method: http.MethodDelete, Path: "/v1/workspaces/:workspace_id/members/:member_id", Action: policyActionTenancyWrite, ResourceType: "workspace_member", ResourceIDParam: "member_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "workspace_id"},
+		{Method: http.MethodPost, Path: "/v1/workspaces/:workspace_id/projects", Action: policyActionTenancyWrite, ResourceType: "project", ResourceIDParam: "workspace_id"},
+		{Method: http.MethodGet, Path: "/v1/workspaces/:workspace_id/projects/:project_id", Action: policyActionTenancyRead, ResourceType: "project", ResourceIDParam: "project_id"},
+		{Method: http.MethodDelete, Path: "/v1/workspaces/:workspace_id/projects/:project_id", Action: policyActionTenancyWrite, ResourceType: "project", ResourceIDParam: "project_id"},
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -32,7 +32,7 @@ const (
 	rateLimiterEntryTTL    = 15 * time.Minute
 	rateLimiterMaxEntries  = 10000
 	rateLimiterCleanupTick = 256
-	corsAllowMethods       = "GET,POST,PATCH,OPTIONS"
+	corsAllowMethods       = "GET,POST,PUT,PATCH,DELETE,OPTIONS"
 	corsAllowHeaders       = "Authorization,Content-Type,X-API-Key,X-Identrail-Tenant-ID,X-Identrail-Workspace-ID"
 	corsMaxAgeSeconds      = "600"
 	scopeRead              = "read"
@@ -154,6 +154,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 	v1.Use(rateLimitMiddleware(opts.RateLimitRPM, opts.RateLimitBurst))
 	v1.POST("/authz/policies/simulate", authzPolicySimulationHandler(logger, authzStore, centralPolicyResolver, opts.AuditSink, opts.AuditFingerprinter))
 	v1.POST("/authz/policies/rollback", authzPolicyRollbackHandler(logger, authzStore, metrics, opts.AuditFingerprinter))
+	registerTenancyRoutes(v1, logger, svc)
 
 	if svc == nil {
 		v1.GET("/findings", func(c *gin.Context) {
@@ -666,6 +667,356 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 	return r
 }
 
+func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service) {
+	v1.GET("/organizations/current", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetOrganization(c.Request.Context())
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "organization not found"})
+				return
+			}
+			if logger != nil {
+				logger.Error("get organization", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get organization"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"organization": record})
+	})
+
+	v1.PUT("/organizations/current", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		var request OrganizationUpsertRequest
+		if err := c.ShouldBindJSON(&request); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			return
+		}
+		record, err := svc.UpsertOrganization(c.Request.Context(), request)
+		if err != nil {
+			if errors.Is(err, ErrInvalidTenancyRequest) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid organization request"})
+				return
+			}
+			if logger != nil {
+				logger.Error("upsert organization", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to upsert organization"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"organization": record})
+	})
+
+	v1.GET("/workspaces", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		limit := parseLimit(c.Query("limit"), defaultScansLimit, maxListLimit)
+		offset := parseCursor(c.Query("cursor"))
+		sortBy, sortDesc := parseSortParams(c.Query("sort_by"), c.Query("sort_order"), "created_at")
+		items, err := svc.ListWorkspaces(c.Request.Context(), pageFetchLimit(offset, limit))
+		if err != nil {
+			if logger != nil {
+				logger.Error("list workspaces", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list workspaces"})
+			return
+		}
+		sortWorkspaces(items, sortBy, sortDesc)
+		page, next := pageWithCursor(items, offset, limit)
+		response := gin.H{"items": page}
+		if next != "" {
+			response["next_cursor"] = next
+		}
+		c.JSON(http.StatusOK, response)
+	})
+
+	v1.POST("/workspaces", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		var request WorkspaceUpsertRequest
+		if err := c.ShouldBindJSON(&request); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			return
+		}
+		record, err := svc.UpsertWorkspace(c.Request.Context(), request)
+		if err != nil {
+			if errors.Is(err, ErrInvalidTenancyRequest) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid workspace request"})
+				return
+			}
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "organization not found"})
+				return
+			}
+			if logger != nil {
+				logger.Error("upsert workspace", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to upsert workspace"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"workspace": record})
+	})
+
+	v1.GET("/workspaces/:workspace_id", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetWorkspace(c.Request.Context(), c.Param("workspace_id"))
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "workspace not found"})
+				return
+			}
+			if logger != nil {
+				logger.Error("get workspace", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get workspace"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"workspace": record})
+	})
+
+	v1.DELETE("/workspaces/:workspace_id", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		if err := svc.DeleteWorkspace(c.Request.Context(), c.Param("workspace_id")); err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "workspace not found"})
+				return
+			}
+			if logger != nil {
+				logger.Error("delete workspace", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete workspace"})
+			return
+		}
+		c.Status(http.StatusNoContent)
+	})
+
+	v1.GET("/workspaces/:workspace_id/members", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		limit := parseLimit(c.Query("limit"), defaultFindingsLimit, maxListLimit)
+		offset := parseCursor(c.Query("cursor"))
+		role := strings.ToLower(strings.TrimSpace(c.Query("role")))
+		status := strings.ToLower(strings.TrimSpace(c.Query("status")))
+		if role != "" && !isValidWorkspaceMemberRole(role) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid workspace member role"})
+			return
+		}
+		if status != "" && !isValidWorkspaceMemberStatus(status) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid workspace member status"})
+			return
+		}
+		items, err := svc.ListWorkspaceMembers(
+			c.Request.Context(),
+			c.Param("workspace_id"),
+			role,
+			status,
+			pageFetchLimit(offset, limit),
+		)
+		if err != nil {
+			if logger != nil {
+				logger.Error("list workspace members", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list workspace members"})
+			return
+		}
+		sortWorkspaceMembers(items)
+		page, next := pageWithCursor(items, offset, limit)
+		response := gin.H{"items": page}
+		if next != "" {
+			response["next_cursor"] = next
+		}
+		c.JSON(http.StatusOK, response)
+	})
+
+	v1.POST("/workspaces/:workspace_id/members", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		var request WorkspaceMemberUpsertRequest
+		if err := c.ShouldBindJSON(&request); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			return
+		}
+		record, err := svc.UpsertWorkspaceMember(c.Request.Context(), c.Param("workspace_id"), request)
+		if err != nil {
+			if errors.Is(err, ErrInvalidTenancyRequest) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid workspace member request"})
+				return
+			}
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "workspace not found"})
+				return
+			}
+			if logger != nil {
+				logger.Error("upsert workspace member", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to upsert workspace member"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"member": record})
+	})
+
+	v1.GET("/workspaces/:workspace_id/members/:member_id", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetWorkspaceMember(c.Request.Context(), c.Param("workspace_id"), c.Param("member_id"))
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "workspace member not found"})
+				return
+			}
+			if logger != nil {
+				logger.Error("get workspace member", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get workspace member"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"member": record})
+	})
+
+	v1.DELETE("/workspaces/:workspace_id/members/:member_id", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		if err := svc.DeleteWorkspaceMember(c.Request.Context(), c.Param("workspace_id"), c.Param("member_id")); err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "workspace member not found"})
+				return
+			}
+			if logger != nil {
+				logger.Error("delete workspace member", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete workspace member"})
+			return
+		}
+		c.Status(http.StatusNoContent)
+	})
+
+	v1.GET("/workspaces/:workspace_id/projects", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		limit := parseLimit(c.Query("limit"), defaultScansLimit, maxListLimit)
+		offset := parseCursor(c.Query("cursor"))
+		sortBy, sortDesc := parseSortParams(c.Query("sort_by"), c.Query("sort_order"), "created_at")
+		includeArchived, err := parseIncludeArchived(c.Query("include_archived"))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid include_archived query parameter"})
+			return
+		}
+		items, err := svc.ListProjects(c.Request.Context(), c.Param("workspace_id"), includeArchived, pageFetchLimit(offset, limit))
+		if err != nil {
+			if logger != nil {
+				logger.Error("list projects", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list projects"})
+			return
+		}
+		sortProjects(items, sortBy, sortDesc)
+		page, next := pageWithCursor(items, offset, limit)
+		response := gin.H{"items": page}
+		if next != "" {
+			response["next_cursor"] = next
+		}
+		c.JSON(http.StatusOK, response)
+	})
+
+	v1.POST("/workspaces/:workspace_id/projects", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		var request ProjectUpsertRequest
+		if err := c.ShouldBindJSON(&request); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			return
+		}
+		record, err := svc.UpsertProject(c.Request.Context(), c.Param("workspace_id"), request)
+		if err != nil {
+			if errors.Is(err, ErrInvalidTenancyRequest) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid project request"})
+				return
+			}
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "workspace not found"})
+				return
+			}
+			if logger != nil {
+				logger.Error("upsert project", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to upsert project"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"project": record})
+	})
+
+	v1.GET("/workspaces/:workspace_id/projects/:project_id", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		record, err := svc.GetProject(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id"))
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "project not found"})
+				return
+			}
+			if logger != nil {
+				logger.Error("get project", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get project"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"project": record})
+	})
+
+	v1.DELETE("/workspaces/:workspace_id/projects/:project_id", func(c *gin.Context) {
+		if svc == nil {
+			tenancyServiceUnavailable(c)
+			return
+		}
+		if err := svc.DeleteProject(c.Request.Context(), c.Param("workspace_id"), c.Param("project_id")); err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "project not found"})
+				return
+			}
+			if logger != nil {
+				logger.Error("delete project", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete project"})
+			return
+		}
+		c.Status(http.StatusNoContent)
+	})
+}
+
+func tenancyServiceUnavailable(c *gin.Context) {
+	c.JSON(http.StatusServiceUnavailable, gin.H{"error": "service unavailable"})
+}
+
 func configureTrustedProxies(r *gin.Engine, logger *zap.Logger, proxies []string) {
 	normalized := normalizeTrustedProxies(proxies)
 	var err error
@@ -737,6 +1088,18 @@ func parseSortParams(rawBy string, rawOrder string, fallbackBy string) (string, 
 		return by, false
 	}
 	return by, true
+}
+
+func parseIncludeArchived(raw string) (bool, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return false, nil
+	}
+	value, err := strconv.ParseBool(trimmed)
+	if err != nil {
+		return false, err
+	}
+	return value, nil
 }
 
 func isValidUUID(raw string) bool {
@@ -918,6 +1281,88 @@ func sortOwnershipSignals(items []domain.OwnershipSignal, sortBy string, desc bo
 		}
 		return cmp < 0
 	})
+}
+
+func sortWorkspaces(items []db.TenancyWorkspace, sortBy string, desc bool) {
+	sort.SliceStable(items, func(i, j int) bool {
+		left := items[i]
+		right := items[j]
+		var cmp int
+		switch sortBy {
+		case "workspace_id":
+			cmp = compareString(left.WorkspaceID, right.WorkspaceID)
+		case "display_name":
+			cmp = compareString(left.DisplayName, right.DisplayName)
+		case "slug":
+			cmp = compareString(left.Slug, right.Slug)
+		default:
+			cmp = compareTime(left.CreatedAt, right.CreatedAt)
+		}
+		if cmp == 0 {
+			cmp = compareString(left.WorkspaceID, right.WorkspaceID)
+		}
+		if desc {
+			return cmp > 0
+		}
+		return cmp < 0
+	})
+}
+
+func sortWorkspaceMembers(items []db.TenancyWorkspaceMember) {
+	sort.SliceStable(items, func(i, j int) bool {
+		left := items[i]
+		right := items[j]
+		cmp := compareTime(left.JoinedAt, right.JoinedAt)
+		if cmp == 0 {
+			cmp = compareString(left.MemberID, right.MemberID)
+		}
+		return cmp < 0
+	})
+}
+
+func sortProjects(items []db.TenancyProject, sortBy string, desc bool) {
+	sort.SliceStable(items, func(i, j int) bool {
+		left := items[i]
+		right := items[j]
+		var cmp int
+		switch sortBy {
+		case "project_id":
+			cmp = compareString(left.ProjectID, right.ProjectID)
+		case "name":
+			cmp = compareString(left.Name, right.Name)
+		case "slug":
+			cmp = compareString(left.Slug, right.Slug)
+		case "updated_at":
+			cmp = compareTime(left.UpdatedAt, right.UpdatedAt)
+		default:
+			cmp = compareTime(left.CreatedAt, right.CreatedAt)
+		}
+		if cmp == 0 {
+			cmp = compareString(left.ProjectID, right.ProjectID)
+		}
+		if desc {
+			return cmp > 0
+		}
+		return cmp < 0
+	})
+}
+
+func isValidWorkspaceMemberRole(role string) bool {
+	switch role {
+	case "owner", "admin", "analyst", "viewer":
+		return true
+	default:
+		return false
+	}
+}
+
+func isValidWorkspaceMemberStatus(status string) bool {
+	switch status {
+	case "invited", "active", "suspended", "removed":
+		return true
+	default:
+		return false
+	}
 }
 
 func compareTime(left time.Time, right time.Time) int {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1719,11 +1719,33 @@ func TestRouterTenancyRoutesUnavailableWithoutService(t *testing.T) {
 	metrics := telemetry.NewMetrics()
 	r := NewRouter(logger, metrics, nil, RouterOptions{})
 
-	req := httptest.NewRequest(http.MethodGet, "/v1/organizations/current", nil)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
-	if w.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected tenancy route to return 503 without service, got %d", w.Code)
+	routes := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/v1/organizations/current"},
+		{http.MethodPut, "/v1/organizations/current"},
+		{http.MethodGet, "/v1/workspaces"},
+		{http.MethodPost, "/v1/workspaces"},
+		{http.MethodGet, "/v1/workspaces/ws-1"},
+		{http.MethodDelete, "/v1/workspaces/ws-1"},
+		{http.MethodGet, "/v1/workspaces/ws-1/members"},
+		{http.MethodPost, "/v1/workspaces/ws-1/members"},
+		{http.MethodGet, "/v1/workspaces/ws-1/members/m-1"},
+		{http.MethodDelete, "/v1/workspaces/ws-1/members/m-1"},
+		{http.MethodGet, "/v1/workspaces/ws-1/projects"},
+		{http.MethodPost, "/v1/workspaces/ws-1/projects"},
+		{http.MethodGet, "/v1/workspaces/ws-1/projects/p-1"},
+		{http.MethodDelete, "/v1/workspaces/ws-1/projects/p-1"},
+	}
+
+	for _, rt := range routes {
+		req := httptest.NewRequest(rt.method, rt.path, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusServiceUnavailable {
+			t.Fatalf("%s %s: expected 503 without service, got %d", rt.method, rt.path, w.Code)
+		}
 	}
 }
 
@@ -1807,5 +1829,312 @@ func TestRouterTenancyEndpointsCRUDFlow(t *testing.T) {
 	}
 	if len(projectsBody.Items) != 1 || projectsBody.Items[0].ProjectID != "project-1" {
 		t.Fatalf("unexpected projects payload: %+v", projectsBody.Items)
+	}
+
+	orgGetResp := doRequest(http.MethodGet, "/v1/organizations/current", "")
+	if orgGetResp.Code != http.StatusOK {
+		t.Fatalf("expected organization get 200, got %d body=%s", orgGetResp.Code, orgGetResp.Body.String())
+	}
+
+	workspaceGetResp := doRequest(http.MethodGet, "/v1/workspaces/workspace-a", "")
+	if workspaceGetResp.Code != http.StatusOK {
+		t.Fatalf("expected workspace get 200, got %d body=%s", workspaceGetResp.Code, workspaceGetResp.Body.String())
+	}
+
+	listWorkspacesResp := doRequest(http.MethodGet, "/v1/workspaces?sort_by=display_name&sort_order=desc", "")
+	if listWorkspacesResp.Code != http.StatusOK {
+		t.Fatalf("expected workspace list 200, got %d body=%s", listWorkspacesResp.Code, listWorkspacesResp.Body.String())
+	}
+
+	memberGetResp := doRequest(http.MethodGet, "/v1/workspaces/workspace-a/members/member-1", "")
+	if memberGetResp.Code != http.StatusOK {
+		t.Fatalf("expected member get 200, got %d body=%s", memberGetResp.Code, memberGetResp.Body.String())
+	}
+
+	deleteProjectResp := doRequest(http.MethodDelete, "/v1/workspaces/workspace-a/projects/project-1", "")
+	if deleteProjectResp.Code != http.StatusNoContent {
+		t.Fatalf("expected project delete 204, got %d body=%s", deleteProjectResp.Code, deleteProjectResp.Body.String())
+	}
+
+	deleteMemberResp := doRequest(http.MethodDelete, "/v1/workspaces/workspace-a/members/member-1", "")
+	if deleteMemberResp.Code != http.StatusNoContent {
+		t.Fatalf("expected member delete 204, got %d body=%s", deleteMemberResp.Code, deleteMemberResp.Body.String())
+	}
+
+	deleteWorkspaceResp := doRequest(http.MethodDelete, "/v1/workspaces/workspace-a", "")
+	if deleteWorkspaceResp.Code != http.StatusNoContent {
+		t.Fatalf("expected workspace delete 204, got %d body=%s", deleteWorkspaceResp.Code, deleteWorkspaceResp.Body.String())
+	}
+
+	notFoundResp := doRequest(http.MethodGet, "/v1/workspaces/workspace-a", "")
+	if notFoundResp.Code != http.StatusNotFound {
+		t.Fatalf("expected workspace get 404 after delete, got %d", notFoundResp.Code)
+	}
+}
+
+func TestSortWorkspaces(t *testing.T) {
+	now := time.Now()
+	items := []db.TenancyWorkspace{
+		{WorkspaceID: "ws-b", DisplayName: "Beta", Slug: "beta", CreatedAt: now},
+		{WorkspaceID: "ws-a", DisplayName: "Alpha", Slug: "alpha", CreatedAt: now.Add(-time.Hour)},
+		{WorkspaceID: "ws-c", DisplayName: "Charlie", Slug: "charlie", CreatedAt: now.Add(time.Hour)},
+	}
+
+	sortWorkspaces(items, "slug", false)
+	if items[0].Slug != "alpha" || items[1].Slug != "beta" || items[2].Slug != "charlie" {
+		t.Fatalf("expected ascending slug sort, got %v %v %v", items[0].Slug, items[1].Slug, items[2].Slug)
+	}
+
+	sortWorkspaces(items, "display_name", true)
+	if items[0].DisplayName != "Charlie" || items[2].DisplayName != "Alpha" {
+		t.Fatalf("expected descending display_name sort, got %v %v %v", items[0].DisplayName, items[1].DisplayName, items[2].DisplayName)
+	}
+
+	sortWorkspaces(items, "workspace_id", false)
+	if items[0].WorkspaceID != "ws-a" || items[2].WorkspaceID != "ws-c" {
+		t.Fatalf("expected ascending workspace_id sort, got %v %v %v", items[0].WorkspaceID, items[1].WorkspaceID, items[2].WorkspaceID)
+	}
+
+	sortWorkspaces(items, "created_at", false)
+	if !items[0].CreatedAt.Before(items[1].CreatedAt) {
+		t.Fatalf("expected ascending created_at sort")
+	}
+}
+
+func TestSortProjects(t *testing.T) {
+	now := time.Now()
+	items := []db.TenancyProject{
+		{ProjectID: "p-b", Name: "Bravo", Slug: "bravo", CreatedAt: now, UpdatedAt: now},
+		{ProjectID: "p-a", Name: "Alpha", Slug: "alpha", CreatedAt: now.Add(-time.Hour), UpdatedAt: now.Add(time.Hour)},
+		{ProjectID: "p-c", Name: "Charlie", Slug: "charlie", CreatedAt: now.Add(time.Hour), UpdatedAt: now.Add(-time.Hour)},
+	}
+
+	sortProjects(items, "name", false)
+	if items[0].Name != "Alpha" || items[1].Name != "Bravo" || items[2].Name != "Charlie" {
+		t.Fatalf("expected ascending name sort, got %v %v %v", items[0].Name, items[1].Name, items[2].Name)
+	}
+
+	sortProjects(items, "name", true)
+	if items[0].Name != "Charlie" || items[2].Name != "Alpha" {
+		t.Fatalf("expected descending name sort, got %v %v %v", items[0].Name, items[1].Name, items[2].Name)
+	}
+
+	sortProjects(items, "slug", false)
+	if items[0].Slug != "alpha" || items[2].Slug != "charlie" {
+		t.Fatalf("expected ascending slug sort, got %v %v %v", items[0].Slug, items[1].Slug, items[2].Slug)
+	}
+
+	sortProjects(items, "project_id", false)
+	if items[0].ProjectID != "p-a" || items[2].ProjectID != "p-c" {
+		t.Fatalf("expected ascending project_id sort, got %v %v %v", items[0].ProjectID, items[1].ProjectID, items[2].ProjectID)
+	}
+
+	sortProjects(items, "updated_at", false)
+	if !items[0].UpdatedAt.Before(items[1].UpdatedAt) {
+		t.Fatalf("expected ascending updated_at sort")
+	}
+
+	sortProjects(items, "created_at", false)
+	if !items[0].CreatedAt.Before(items[1].CreatedAt) {
+		t.Fatalf("expected ascending created_at sort (default)")
+	}
+}
+
+func TestSortWorkspaceMembers(t *testing.T) {
+	now := time.Now()
+	items := []db.TenancyWorkspaceMember{
+		{MemberID: "m-c", JoinedAt: now.Add(time.Hour)},
+		{MemberID: "m-a", JoinedAt: now.Add(-time.Hour)},
+		{MemberID: "m-b", JoinedAt: now},
+	}
+
+	sortWorkspaceMembers(items)
+	if items[0].MemberID != "m-a" || items[1].MemberID != "m-b" || items[2].MemberID != "m-c" {
+		t.Fatalf("expected members sorted by joined_at asc, got %v %v %v", items[0].MemberID, items[1].MemberID, items[2].MemberID)
+	}
+}
+
+func TestRouterTenancyInvalidRoleStatus(t *testing.T) {
+	logger := zap.NewNop()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+	r := NewRouter(logger, metrics, svc, RouterOptions{
+		APIKeys:            []string{"key"},
+		WriteAPIKeys:       []string{"key"},
+		DefaultTenantID:    "tenant-a",
+		DefaultWorkspaceID: "workspace-a",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/workspaces/ws/members?role=invalid_role", nil)
+	req.Header.Set("X-API-Key", "key")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid role, got %d", w.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/v1/workspaces/ws/members?status=bogus", nil)
+	req.Header.Set("X-API-Key", "key")
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid status, got %d", w.Code)
+	}
+}
+
+func TestRouterTenancyErrorPaths(t *testing.T) {
+	logger := zap.NewNop()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+	r := NewRouter(logger, metrics, svc, RouterOptions{
+		APIKeys:            []string{"key"},
+		WriteAPIKeys:       []string{"key"},
+		DefaultTenantID:    "tenant-a",
+		DefaultWorkspaceID: "workspace-a",
+		RateLimitRPM:       10000,
+		RateLimitBurst:     10000,
+	})
+
+	doRequest := func(method string, path string, body string) *httptest.ResponseRecorder {
+		var requestBody *bytes.Buffer
+		if body == "" {
+			requestBody = bytes.NewBuffer(nil)
+		} else {
+			requestBody = bytes.NewBufferString(body)
+		}
+		req := httptest.NewRequest(method, path, requestBody)
+		req.Header.Set("X-API-Key", "key")
+		if body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w
+	}
+
+	orgBadBody := doRequest(http.MethodPut, "/v1/organizations/current", `{invalid json`)
+	if orgBadBody.Code != http.StatusBadRequest {
+		t.Fatalf("expected org bad body 400, got %d", orgBadBody.Code)
+	}
+
+	wsBadBody := doRequest(http.MethodPost, "/v1/workspaces", `{invalid`)
+	if wsBadBody.Code != http.StatusBadRequest {
+		t.Fatalf("expected workspace bad body 400, got %d", wsBadBody.Code)
+	}
+
+	memberBadBody := doRequest(http.MethodPost, "/v1/workspaces/workspace-a/members", `{invalid`)
+	if memberBadBody.Code != http.StatusBadRequest {
+		t.Fatalf("expected member bad body 400, got %d", memberBadBody.Code)
+	}
+
+	projectBadBody := doRequest(http.MethodPost, "/v1/workspaces/workspace-a/projects", `{invalid`)
+	if projectBadBody.Code != http.StatusBadRequest {
+		t.Fatalf("expected project bad body 400, got %d", projectBadBody.Code)
+	}
+
+	orgNotFound := doRequest(http.MethodGet, "/v1/organizations/current", "")
+	if orgNotFound.Code != http.StatusNotFound {
+		t.Fatalf("expected org not found 404, got %d", orgNotFound.Code)
+	}
+
+	wsNotFound := doRequest(http.MethodGet, "/v1/workspaces/nonexistent", "")
+	if wsNotFound.Code != http.StatusNotFound {
+		t.Fatalf("expected workspace not found 404, got %d", wsNotFound.Code)
+	}
+
+	wsDeleteNotFound := doRequest(http.MethodDelete, "/v1/workspaces/nonexistent", "")
+	if wsDeleteNotFound.Code != http.StatusNotFound {
+		t.Fatalf("expected workspace delete not found 404, got %d", wsDeleteNotFound.Code)
+	}
+
+	memberNotFound := doRequest(http.MethodGet, "/v1/workspaces/workspace-a/members/nonexistent", "")
+	if memberNotFound.Code != http.StatusNotFound {
+		t.Fatalf("expected member not found 404, got %d", memberNotFound.Code)
+	}
+
+	memberDeleteNotFound := doRequest(http.MethodDelete, "/v1/workspaces/workspace-a/members/nonexistent", "")
+	if memberDeleteNotFound.Code != http.StatusNotFound {
+		t.Fatalf("expected member delete not found 404, got %d", memberDeleteNotFound.Code)
+	}
+
+	projectNotFound := doRequest(http.MethodGet, "/v1/workspaces/workspace-a/projects/nonexistent", "")
+	if projectNotFound.Code != http.StatusNotFound {
+		t.Fatalf("expected project not found 404, got %d", projectNotFound.Code)
+	}
+
+	projectDeleteNotFound := doRequest(http.MethodDelete, "/v1/workspaces/workspace-a/projects/nonexistent", "")
+	if projectDeleteNotFound.Code != http.StatusNotFound {
+		t.Fatalf("expected project delete not found 404, got %d", projectDeleteNotFound.Code)
+	}
+
+	listWorkspacesResp := doRequest(http.MethodGet, "/v1/workspaces", "")
+	if listWorkspacesResp.Code != http.StatusOK {
+		t.Fatalf("expected workspace list 200, got %d", listWorkspacesResp.Code)
+	}
+
+	listMembersResp := doRequest(http.MethodGet, "/v1/workspaces/workspace-a/members", "")
+	if listMembersResp.Code != http.StatusOK {
+		t.Fatalf("expected members list 200, got %d", listMembersResp.Code)
+	}
+
+	listProjectsResp := doRequest(http.MethodGet, "/v1/workspaces/workspace-a/projects", "")
+	if listProjectsResp.Code != http.StatusOK {
+		t.Fatalf("expected projects list 200, got %d", listProjectsResp.Code)
+	}
+
+	badArchivedResp := doRequest(http.MethodGet, "/v1/workspaces/workspace-a/projects?include_archived=notbool", "")
+	if badArchivedResp.Code != http.StatusBadRequest {
+		t.Fatalf("expected bad include_archived 400, got %d", badArchivedResp.Code)
+	}
+
+	orgInvalidSlug := doRequest(http.MethodPut, "/v1/organizations/current", `{"display_name":"","slug":""}`)
+	if orgInvalidSlug.Code != http.StatusBadRequest {
+		t.Fatalf("expected org invalid data 400, got %d body=%s", orgInvalidSlug.Code, orgInvalidSlug.Body.String())
+	}
+
+	doRequest(http.MethodPut, "/v1/organizations/current", `{"display_name":"Org","slug":"org"}`)
+
+	wsInvalidSlug := doRequest(http.MethodPost, "/v1/workspaces", `{"workspace_id":"workspace-a","display_name":"","slug":""}`)
+	if wsInvalidSlug.Code != http.StatusBadRequest {
+		t.Fatalf("expected workspace invalid data 400, got %d body=%s", wsInvalidSlug.Code, wsInvalidSlug.Body.String())
+	}
+
+	doRequest(http.MethodPost, "/v1/workspaces", `{"workspace_id":"workspace-a","display_name":"WS","slug":"ws-a"}`)
+
+	memberInvalid := doRequest(http.MethodPost, "/v1/workspaces/workspace-a/members", `{"member_id":"","user_id":"","email":"","role":"","status":""}`)
+	if memberInvalid.Code != http.StatusBadRequest {
+		t.Fatalf("expected member invalid data 400, got %d body=%s", memberInvalid.Code, memberInvalid.Body.String())
+	}
+
+	projectInvalid := doRequest(http.MethodPost, "/v1/workspaces/workspace-a/projects", `{"project_id":"","name":"","slug":""}`)
+	if projectInvalid.Code != http.StatusBadRequest {
+		t.Fatalf("expected project invalid data 400, got %d body=%s", projectInvalid.Code, projectInvalid.Body.String())
+	}
+
+	wsMismatch := doRequest(http.MethodPost, "/v1/workspaces", `{"workspace_id":"other-ws","display_name":"Other","slug":"other"}`)
+	if wsMismatch.Code != http.StatusNotFound {
+		t.Fatalf("expected workspace scope mismatch 404, got %d body=%s", wsMismatch.Code, wsMismatch.Body.String())
+	}
+
+	memberWsMismatch := doRequest(http.MethodPost, "/v1/workspaces/other-ws/members", `{"member_id":"m-1","user_id":"u-1","email":"a@b.com","role":"admin","status":"active"}`)
+	if memberWsMismatch.Code != http.StatusNotFound {
+		t.Fatalf("expected member workspace mismatch 404, got %d body=%s", memberWsMismatch.Code, memberWsMismatch.Body.String())
+	}
+
+	projectWsMismatch := doRequest(http.MethodPost, "/v1/workspaces/other-ws/projects", `{"project_id":"p-1","name":"P","slug":"p"}`)
+	if projectWsMismatch.Code != http.StatusNotFound {
+		t.Fatalf("expected project workspace mismatch 404, got %d body=%s", projectWsMismatch.Code, projectWsMismatch.Body.String())
+	}
+
+	projectWithArchived := doRequest(http.MethodPost, "/v1/workspaces/workspace-a/projects", `{"project_id":"p-arch","name":"Archived","slug":"arch","archived_at":"2025-01-01T00:00:00Z"}`)
+	if projectWithArchived.Code != http.StatusOK {
+		t.Fatalf("expected project with archived_at 200, got %d body=%s", projectWithArchived.Code, projectWithArchived.Body.String())
+	}
+
+	projectBadArchived := doRequest(http.MethodPost, "/v1/workspaces/workspace-a/projects", `{"project_id":"p-bad","name":"Bad","slug":"bad","archived_at":"not-a-date"}`)
+	if projectBadArchived.Code != http.StatusBadRequest {
+		t.Fatalf("expected project with bad archived_at 400, got %d body=%s", projectBadArchived.Code, projectBadArchived.Body.String())
 	}
 }

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1713,3 +1713,99 @@ func TestRouterPaginationHelpers(t *testing.T) {
 		t.Fatalf("unexpected final page result page=%+v next=%q", page, next)
 	}
 }
+
+func TestRouterTenancyRoutesUnavailableWithoutService(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	r := NewRouter(logger, metrics, nil, RouterOptions{})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/organizations/current", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected tenancy route to return 503 without service, got %d", w.Code)
+	}
+}
+
+func TestRouterTenancyEndpointsCRUDFlow(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+	r := NewRouter(logger, metrics, svc, RouterOptions{
+		APIKeys:            []string{"writer-key"},
+		WriteAPIKeys:       []string{"writer-key"},
+		DefaultTenantID:    "tenant-a",
+		DefaultWorkspaceID: "workspace-a",
+	})
+
+	doRequest := func(method string, path string, body string) *httptest.ResponseRecorder {
+		var requestBody *bytes.Buffer
+		if body == "" {
+			requestBody = bytes.NewBuffer(nil)
+		} else {
+			requestBody = bytes.NewBufferString(body)
+		}
+		req := httptest.NewRequest(method, path, requestBody)
+		req.Header.Set("X-API-Key", "writer-key")
+		if body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w
+	}
+
+	orgResp := doRequest(http.MethodPut, "/v1/organizations/current", `{"display_name":"Tenant A","slug":"tenant-a"}`)
+	if orgResp.Code != http.StatusOK {
+		t.Fatalf("expected organization upsert 200, got %d body=%s", orgResp.Code, orgResp.Body.String())
+	}
+
+	workspaceResp := doRequest(http.MethodPost, "/v1/workspaces", `{"workspace_id":"workspace-a","display_name":"Workspace A","slug":"workspace-a"}`)
+	if workspaceResp.Code != http.StatusOK {
+		t.Fatalf("expected workspace upsert 200, got %d body=%s", workspaceResp.Code, workspaceResp.Body.String())
+	}
+
+	memberResp := doRequest(http.MethodPost, "/v1/workspaces/workspace-a/members", `{"member_id":"member-1","user_id":"user-1","email":"user1@example.com","role":"admin","status":"active"}`)
+	if memberResp.Code != http.StatusOK {
+		t.Fatalf("expected member upsert 200, got %d body=%s", memberResp.Code, memberResp.Body.String())
+	}
+
+	listMembersResp := doRequest(http.MethodGet, "/v1/workspaces/workspace-a/members?role=admin&status=active", "")
+	if listMembersResp.Code != http.StatusOK {
+		t.Fatalf("expected member list 200, got %d body=%s", listMembersResp.Code, listMembersResp.Body.String())
+	}
+	var membersBody struct {
+		Items []db.TenancyWorkspaceMember `json:"items"`
+	}
+	if err := json.Unmarshal(listMembersResp.Body.Bytes(), &membersBody); err != nil {
+		t.Fatalf("decode members response: %v", err)
+	}
+	if len(membersBody.Items) != 1 || membersBody.Items[0].MemberID != "member-1" {
+		t.Fatalf("unexpected members payload: %+v", membersBody.Items)
+	}
+
+	projectResp := doRequest(http.MethodPost, "/v1/workspaces/workspace-a/projects", `{"project_id":"project-1","name":"Project 1","slug":"project-1","description":"First project"}`)
+	if projectResp.Code != http.StatusOK {
+		t.Fatalf("expected project upsert 200, got %d body=%s", projectResp.Code, projectResp.Body.String())
+	}
+
+	projectDetailResp := doRequest(http.MethodGet, "/v1/workspaces/workspace-a/projects/project-1", "")
+	if projectDetailResp.Code != http.StatusOK {
+		t.Fatalf("expected project get 200, got %d body=%s", projectDetailResp.Code, projectDetailResp.Body.String())
+	}
+
+	listProjectsResp := doRequest(http.MethodGet, "/v1/workspaces/workspace-a/projects?include_archived=true", "")
+	if listProjectsResp.Code != http.StatusOK {
+		t.Fatalf("expected project list 200, got %d body=%s", listProjectsResp.Code, listProjectsResp.Body.String())
+	}
+	var projectsBody struct {
+		Items []db.TenancyProject `json:"items"`
+	}
+	if err := json.Unmarshal(listProjectsResp.Body.Bytes(), &projectsBody); err != nil {
+		t.Fatalf("decode projects response: %v", err)
+	}
+	if len(projectsBody.Items) != 1 || projectsBody.Items[0].ProjectID != "project-1" {
+		t.Fatalf("unexpected projects payload: %+v", projectsBody.Items)
+	}
+}

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -695,7 +695,15 @@ func (s *Service) ListWorkspaceMembers(
 	limit int,
 ) ([]db.TenancyWorkspaceMember, error) {
 	ctx = s.scopeContext(ctx)
-	items, err := s.Store.ListWorkspaceMembers(ctx, strings.TrimSpace(workspaceID), limit)
+	loadLimit := limit
+	if loadLimit <= 0 {
+		loadLimit = 100
+	}
+	hasFilter := strings.TrimSpace(role) != "" || strings.TrimSpace(status) != ""
+	if hasFilter && loadLimit < 5000 {
+		loadLimit = 5000
+	}
+	items, err := s.Store.ListWorkspaceMembers(ctx, strings.TrimSpace(workspaceID), loadLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -710,6 +718,9 @@ func (s *Service) ListWorkspaceMembers(
 			continue
 		}
 		filtered = append(filtered, item)
+		if limit > 0 && len(filtered) >= limit {
+			break
+		}
 	}
 	return filtered, nil
 }

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -112,6 +112,37 @@ type RepoScanRequest struct {
 	MaxFindings  int    `json:"max_findings"`
 }
 
+// OrganizationUpsertRequest captures one tenancy organization write payload.
+type OrganizationUpsertRequest struct {
+	DisplayName string `json:"display_name"`
+	Slug        string `json:"slug"`
+}
+
+// WorkspaceUpsertRequest captures one workspace write payload.
+type WorkspaceUpsertRequest struct {
+	WorkspaceID string `json:"workspace_id"`
+	DisplayName string `json:"display_name"`
+	Slug        string `json:"slug"`
+}
+
+// WorkspaceMemberUpsertRequest captures one workspace member write payload.
+type WorkspaceMemberUpsertRequest struct {
+	MemberID string `json:"member_id"`
+	UserID   string `json:"user_id"`
+	Email    string `json:"email,omitempty"`
+	Role     string `json:"role"`
+	Status   string `json:"status"`
+}
+
+// ProjectUpsertRequest captures one workspace project write payload.
+type ProjectUpsertRequest struct {
+	ProjectID   string  `json:"project_id"`
+	Name        string  `json:"name"`
+	Slug        string  `json:"slug"`
+	Description string  `json:"description,omitempty"`
+	ArchivedAt  *string `json:"archived_at,omitempty"`
+}
+
 // FindingsFilter narrows findings list queries without changing API response schema.
 type FindingsFilter struct {
 	ScanID          string
@@ -193,6 +224,9 @@ var ErrInvalidFindingTriageRequest = errors.New("invalid finding triage request"
 
 // ErrRepoScanQueueFull is returned when queued repo scan requests exceed configured capacity.
 var ErrRepoScanQueueFull = errors.New("repo scan queue is full")
+
+// ErrInvalidTenancyRequest indicates invalid tenancy write payload.
+var ErrInvalidTenancyRequest = errors.New("invalid tenancy request")
 
 // NewService creates an API service with defaults.
 func NewService(store db.Store, scanner ScannerRunner, provider string) *Service {
@@ -579,6 +613,201 @@ func (s *Service) ListRepoFindings(ctx context.Context, limit int, filter db.Rep
 		return nil, err
 	}
 	return enrichFindings(findings), nil
+}
+
+// GetOrganization returns the current scoped organization record.
+func (s *Service) GetOrganization(ctx context.Context) (db.TenancyOrganization, error) {
+	ctx = s.scopeContext(ctx)
+	return s.Store.GetOrganization(ctx)
+}
+
+// UpsertOrganization creates or updates the current scoped organization.
+func (s *Service) UpsertOrganization(ctx context.Context, request OrganizationUpsertRequest) (db.TenancyOrganization, error) {
+	ctx = s.scopeContext(ctx)
+	scope, err := db.RequireScope(ctx)
+	if err != nil {
+		return db.TenancyOrganization{}, err
+	}
+	normalized, err := db.NormalizeTenancyOrganizationForWrite(db.TenancyOrganization{
+		TenantID:    scope.TenantID,
+		DisplayName: request.DisplayName,
+		Slug:        request.Slug,
+	})
+	if err != nil {
+		return db.TenancyOrganization{}, ErrInvalidTenancyRequest
+	}
+	if err := s.Store.UpsertOrganization(ctx, normalized); err != nil {
+		return db.TenancyOrganization{}, err
+	}
+	return s.Store.GetOrganization(ctx)
+}
+
+// ListWorkspaces returns tenant-scoped workspaces.
+func (s *Service) ListWorkspaces(ctx context.Context, limit int) ([]db.TenancyWorkspace, error) {
+	ctx = s.scopeContext(ctx)
+	return s.Store.ListWorkspaces(ctx, limit)
+}
+
+// UpsertWorkspace creates or updates one scoped workspace.
+func (s *Service) UpsertWorkspace(ctx context.Context, request WorkspaceUpsertRequest) (db.TenancyWorkspace, error) {
+	ctx = s.scopeContext(ctx)
+	scope, err := db.RequireScope(ctx)
+	if err != nil {
+		return db.TenancyWorkspace{}, err
+	}
+	normalizedWorkspaceID, err := db.ResolveScopedWorkspaceID(scope, request.WorkspaceID)
+	if err != nil {
+		return db.TenancyWorkspace{}, err
+	}
+	normalized, err := db.NormalizeTenancyWorkspaceForWrite(db.TenancyWorkspace{
+		TenantID:    scope.TenantID,
+		WorkspaceID: normalizedWorkspaceID,
+		DisplayName: request.DisplayName,
+		Slug:        request.Slug,
+	})
+	if err != nil {
+		return db.TenancyWorkspace{}, ErrInvalidTenancyRequest
+	}
+	if err := s.Store.UpsertWorkspace(ctx, normalized); err != nil {
+		return db.TenancyWorkspace{}, err
+	}
+	return s.Store.GetWorkspace(ctx, normalized.WorkspaceID)
+}
+
+// GetWorkspace returns one workspace by id.
+func (s *Service) GetWorkspace(ctx context.Context, workspaceID string) (db.TenancyWorkspace, error) {
+	ctx = s.scopeContext(ctx)
+	return s.Store.GetWorkspace(ctx, strings.TrimSpace(workspaceID))
+}
+
+// DeleteWorkspace removes one workspace.
+func (s *Service) DeleteWorkspace(ctx context.Context, workspaceID string) error {
+	ctx = s.scopeContext(ctx)
+	return s.Store.DeleteWorkspace(ctx, strings.TrimSpace(workspaceID))
+}
+
+// ListWorkspaceMembers returns members for one scoped workspace with optional role/status filters.
+func (s *Service) ListWorkspaceMembers(
+	ctx context.Context,
+	workspaceID string,
+	role string,
+	status string,
+	limit int,
+) ([]db.TenancyWorkspaceMember, error) {
+	ctx = s.scopeContext(ctx)
+	items, err := s.Store.ListWorkspaceMembers(ctx, strings.TrimSpace(workspaceID), limit)
+	if err != nil {
+		return nil, err
+	}
+	normalizedRole := strings.ToLower(strings.TrimSpace(role))
+	normalizedStatus := strings.ToLower(strings.TrimSpace(status))
+	filtered := make([]db.TenancyWorkspaceMember, 0, len(items))
+	for _, item := range items {
+		if normalizedRole != "" && strings.ToLower(strings.TrimSpace(item.Role)) != normalizedRole {
+			continue
+		}
+		if normalizedStatus != "" && strings.ToLower(strings.TrimSpace(item.Status)) != normalizedStatus {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered, nil
+}
+
+// UpsertWorkspaceMember creates or updates one scoped workspace member.
+func (s *Service) UpsertWorkspaceMember(
+	ctx context.Context,
+	workspaceID string,
+	request WorkspaceMemberUpsertRequest,
+) (db.TenancyWorkspaceMember, error) {
+	ctx = s.scopeContext(ctx)
+	scope, err := db.RequireScope(ctx)
+	if err != nil {
+		return db.TenancyWorkspaceMember{}, err
+	}
+	normalizedWorkspaceID, err := db.ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return db.TenancyWorkspaceMember{}, err
+	}
+	normalized, err := db.NormalizeTenancyWorkspaceMemberForWrite(db.TenancyWorkspaceMember{
+		TenantID:    scope.TenantID,
+		WorkspaceID: normalizedWorkspaceID,
+		MemberID:    request.MemberID,
+		UserID:      request.UserID,
+		Email:       request.Email,
+		Role:        request.Role,
+		Status:      request.Status,
+	})
+	if err != nil {
+		return db.TenancyWorkspaceMember{}, ErrInvalidTenancyRequest
+	}
+	if err := s.Store.UpsertWorkspaceMember(ctx, normalized); err != nil {
+		return db.TenancyWorkspaceMember{}, err
+	}
+	return s.Store.GetWorkspaceMember(ctx, normalized.WorkspaceID, normalized.MemberID)
+}
+
+// GetWorkspaceMember returns one scoped workspace member.
+func (s *Service) GetWorkspaceMember(ctx context.Context, workspaceID string, memberID string) (db.TenancyWorkspaceMember, error) {
+	ctx = s.scopeContext(ctx)
+	return s.Store.GetWorkspaceMember(ctx, strings.TrimSpace(workspaceID), strings.TrimSpace(memberID))
+}
+
+// DeleteWorkspaceMember removes one scoped workspace member.
+func (s *Service) DeleteWorkspaceMember(ctx context.Context, workspaceID string, memberID string) error {
+	ctx = s.scopeContext(ctx)
+	return s.Store.DeleteWorkspaceMember(ctx, strings.TrimSpace(workspaceID), strings.TrimSpace(memberID))
+}
+
+// ListProjects returns projects for one scoped workspace.
+func (s *Service) ListProjects(ctx context.Context, workspaceID string, includeArchived bool, limit int) ([]db.TenancyProject, error) {
+	ctx = s.scopeContext(ctx)
+	return s.Store.ListProjects(ctx, strings.TrimSpace(workspaceID), includeArchived, limit)
+}
+
+// UpsertProject creates or updates one scoped project.
+func (s *Service) UpsertProject(ctx context.Context, workspaceID string, request ProjectUpsertRequest) (db.TenancyProject, error) {
+	ctx = s.scopeContext(ctx)
+	scope, err := db.RequireScope(ctx)
+	if err != nil {
+		return db.TenancyProject{}, err
+	}
+	normalizedWorkspaceID, err := db.ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return db.TenancyProject{}, err
+	}
+	archivedAt, err := parseTenancyArchivedAt(request.ArchivedAt)
+	if err != nil {
+		return db.TenancyProject{}, err
+	}
+	normalized, err := db.NormalizeTenancyProjectForWrite(db.TenancyProject{
+		TenantID:    scope.TenantID,
+		WorkspaceID: normalizedWorkspaceID,
+		ProjectID:   request.ProjectID,
+		Name:        request.Name,
+		Slug:        request.Slug,
+		Description: request.Description,
+		ArchivedAt:  archivedAt,
+	})
+	if err != nil {
+		return db.TenancyProject{}, ErrInvalidTenancyRequest
+	}
+	if err := s.Store.UpsertProject(ctx, normalized); err != nil {
+		return db.TenancyProject{}, err
+	}
+	return s.Store.GetProject(ctx, normalized.WorkspaceID, normalized.ProjectID)
+}
+
+// GetProject returns one scoped project by id.
+func (s *Service) GetProject(ctx context.Context, workspaceID string, projectID string) (db.TenancyProject, error) {
+	ctx = s.scopeContext(ctx)
+	return s.Store.GetProject(ctx, strings.TrimSpace(workspaceID), strings.TrimSpace(projectID))
+}
+
+// DeleteProject removes one scoped project.
+func (s *Service) DeleteProject(ctx context.Context, workspaceID string, projectID string) error {
+	ctx = s.scopeContext(ctx)
+	return s.Store.DeleteProject(ctx, strings.TrimSpace(workspaceID), strings.TrimSpace(projectID))
 }
 
 // ListFindingsFiltered returns findings with optional scan/type/severity filters.
@@ -1208,6 +1437,22 @@ func parseSuppressionExpiry(raw string, now time.Time) (*time.Time, error) {
 	if !normalized.After(now) {
 		return nil, ErrInvalidFindingTriageRequest
 	}
+	return &normalized, nil
+}
+
+func parseTenancyArchivedAt(raw *string) (*time.Time, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	value := strings.TrimSpace(*raw)
+	if value == "" {
+		return nil, nil
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return nil, ErrInvalidTenancyRequest
+	}
+	normalized := parsed.UTC()
 	return &normalized, nil
 }
 


### PR DESCRIPTION
Fixes #546

## What changed
- implemented tenancy API handlers in `internal/api/router.go` for:
  - `GET/PUT /v1/organizations/current`
  - `GET/POST /v1/workspaces`
  - `GET/DELETE /v1/workspaces/:workspace_id`
  - `GET/POST /v1/workspaces/:workspace_id/members`
  - `GET/DELETE /v1/workspaces/:workspace_id/members/:member_id`
  - `GET/POST /v1/workspaces/:workspace_id/projects`
  - `GET/DELETE /v1/workspaces/:workspace_id/projects/:project_id`
- added tenancy service request DTOs and service methods in `internal/api/service.go`:
  - org/workspace/member/project get/list/upsert/delete wrappers
  - validation/error mapping via `ErrInvalidTenancyRequest`
  - RFC3339 parsing for `project.archived_at`
- extended CORS allow methods to include `PUT` and `DELETE` for the new routes.
- registered tenancy routes in built-in central authz route registry (`internal/api/authz_policy_bundle_runtime.go`).
- added `tenancy.read` and `tenancy.write` policy actions to RBAC/ABAC defaults (`internal/api/authz_middleware.go`).
- added/updated tests:
  - route-policy lookup for tenancy action
  - end-to-end tenancy route CRUD flow
  - service-unavailable behavior when tenancy service is absent

## Why
Issue #546 requires parity with the vNext contract for organization/workspace/project endpoints and proper central policy mapping.

## Impact and risk
- Adds new v1 endpoints already present in OpenAPI spec.
- Keeps existing auth middleware behavior and scope enforcement.
- Risk is low-to-moderate and covered by targeted + full test runs.

## Validation performed
- `gofmt -w internal/api/service.go internal/api/router.go internal/api/authz_middleware.go internal/api/authz_policy_bundle_runtime.go internal/api/authz_middleware_test.go internal/api/router_test.go`
- `go test ./internal/api -count=1`
- `go test ./internal/db -count=1`
- `go test ./... -count=1`
- `go vet ./internal/api ./internal/db`

## AI disclosure
- AI-assisted: yes
- Tools used: Codex (GPT-5)
- Where used: `internal/api/service.go`, `internal/api/router.go`, `internal/api/authz_middleware.go`, `internal/api/authz_policy_bundle_runtime.go`, `internal/api/router_test.go`, `internal/api/authz_middleware_test.go`
- Human verification performed: full diff review, gofmt, go vet, targeted tests, full test suite
