### PR TITLE
fixes (#605): ignore root .vercel metadata and block staged .vercel artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ web/build/
 web/coverage/
 web/coverage 2/
 web/coverage 3/
+.vercel/
 web/.vercel/
 site/.next/
 site/.vercel/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,9 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-push]
+
+      - id: vercel-artifact-hygiene
+        name: vercel artifact hygiene
+        entry: ./scripts/check-no-vercel-artifacts.sh
+        language: system
+        pass_filenames: false

--- a/scripts/check-no-vercel-artifacts.sh
+++ b/scripts/check-no-vercel-artifacts.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-staged_files="$(git diff --cached --name-only --diff-filter=ACMR || true)"
+staged_files="$(git diff --cached --name-only --diff-filter=ACMR)"
 if [[ -z "${staged_files}" ]]; then
   exit 0
 fi

--- a/scripts/check-no-vercel-artifacts.sh
+++ b/scripts/check-no-vercel-artifacts.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+staged_files="$(git diff --cached --name-only --diff-filter=ACMR || true)"
+if [[ -z "${staged_files}" ]]; then
+  exit 0
+fi
+
+if printf '%s\n' "${staged_files}" | grep -Eq '(^|/)\.vercel/'; then
+  cat <<'MSG' >&2
+Detected staged .vercel artifacts.
+
+The following paths must not be committed:
+- .vercel/**
+- web/.vercel/**
+- site/.vercel/**
+
+Remove these paths from the commit before pushing.
+MSG
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Fixes #605

## What changed
- added root `.vercel/` to [`.gitignore`](/Users/user1/Documents/Aurelius/identrail/.gitignore) so local Vercel project metadata is ignored by default.
- added a new pre-commit hygiene guard at [`scripts/check-no-vercel-artifacts.sh`](/Users/user1/Documents/Aurelius/identrail/scripts/check-no-vercel-artifacts.sh) that blocks staged paths containing any `.vercel/` directory segment.
- wired the guard into [`.pre-commit-config.yaml`](/Users/user1/Documents/Aurelius/identrail/.pre-commit-config.yaml) as `vercel-artifact-hygiene`.

## Why
Issue #605 identified accidental commit risk for local Vercel metadata in root `.vercel/`. This change prevents accidental inclusion via both ignore rules and staged-file validation.

## Impact and risk
- Low risk: only affects git hygiene and local commit checks.
- Improves repo cleanliness and reduces metadata leakage risk.

## Validation performed
- `bash scripts/check-no-vercel-artifacts.sh` (passes with normal staged files)
- forced staged check verification:
  - `git add -f .vercel/project.json`
  - `bash scripts/check-no-vercel-artifacts.sh` (fails as expected)
  - `git restore --staged .vercel/project.json`
- pre-commit hook execution during commit:
  - `vercel artifact hygiene` passed

## AI disclosure
- AI-assisted: yes
- Tools used: Codex (GPT-5)
- Where used: `.gitignore`, `.pre-commit-config.yaml`, `scripts/check-no-vercel-artifacts.sh`
- Human verification performed: manual diff review + staged-path positive/negative checks + hook pass during commit
