### PR TITLE
fixes (#548): build guarded app shell routes with tenancy-scoped layout boundaries

### DIFF
--- a/docs/frontend-topology.md
+++ b/docs/frontend-topology.md
@@ -6,6 +6,9 @@ Identrail uses `web/` as the active tracked frontend on `dev`.
 
 - Stack: Vite + React
 - Purpose: operator-facing app experience tied to API workflows
+- Product shell route group: `/app/*` for authenticated workflows
+  - Login gateway: `/app/login`
+  - Scoped shell paths: `/app/:tenantID/:workspaceID/*`
 - Typical runtime: containerized deployment (`deploy/docker/Dockerfile.web`, optional Helm `web.enabled`)
 - API URL input: `VITE_IDENTRAIL_API_URL`
 - Vercel (marketing/demo deploy): set `VITE_IDENTRAIL_API_URL` in Vercel project environment variables (or set GitHub Actions variable `VITE_IDENTRAIL_API_URL` so the deploy workflow upserts it).

--- a/docs/phase-3.md
+++ b/docs/phase-3.md
@@ -10,6 +10,10 @@ Create a thin React + TypeScript dashboard shell that can consume Identrail APIs
   - Vite + React + TypeScript setup
   - API client (`web/src/api/client.ts`)
   - app shell (`web/src/App.tsx`)
+- Authenticated product shell route boundary (`/app/*`):
+  - guarded login route (`/app/login`)
+  - tenancy-scoped route group (`/app/:tenantID/:workspaceID/*`)
+  - non-marketing layout shell with global error boundary and placeholder loading/empty states
 - Initial views consume:
   - `GET /v1/findings/summary`
   - `GET /v1/findings/trends`

--- a/scripts/check_web_route_integrity.sh
+++ b/scripts/check_web_route_integrity.sh
@@ -20,6 +20,12 @@ function parseAppRoutes(src) {
     if (route.includes('*') || route.includes(':')) {
       continue;
     }
+    if (!route.startsWith('/')) {
+      continue;
+    }
+    if (route === '/app' || route.startsWith('/app/')) {
+      continue;
+    }
     routes.add(route);
   }
   // Include static routes generated from mapped slug collections, e.g.

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,8 +1,12 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { App } from './App';
 
 describe('App', () => {
+  beforeEach(() => {
+    window.localStorage.removeItem('identrail-product-session');
+  });
+
   it('renders homepage hero and conversion CTAs', () => {
     window.history.pushState({}, '', '/');
     render(<App />);
@@ -109,5 +113,44 @@ describe('App', () => {
         name: /Report security issues through a coordinated disclosure process/i
       })
     ).toBeInTheDocument();
+  });
+
+  it('guards product shell routes and redirects unauthenticated users to app login', () => {
+    window.history.pushState({}, '', '/app/default/default');
+    render(<App />);
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /Sign in to the Identrail app shell/i
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('loads authenticated product shell placeholders after login', async () => {
+    window.history.pushState({}, '', '/app/login');
+    render(<App />);
+
+    fireEvent.change(screen.getByLabelText(/Tenant ID/i), { target: { value: 'tenant-a' } });
+    fireEvent.change(screen.getByLabelText(/Workspace ID/i), { target: { value: 'workspace-a' } });
+    fireEvent.click(screen.getByRole('button', { name: /Continue to app/i }));
+
+    expect(await screen.findByRole('heading', { level: 1, name: /Identrail Workspace/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
+  });
+
+  it('renders tenancy-scoped project detail placeholder route inside app shell', async () => {
+    window.localStorage.setItem(
+      'identrail-product-session',
+      JSON.stringify({
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace-a'
+      })
+    );
+    window.history.pushState({}, '', '/app/tenant-a/workspace-a/projects/project-1');
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { level: 2, name: /Project detail/i })).toBeInTheDocument();
+    expect(await screen.findByText(/Project project-1 placeholder/i)).toBeInTheDocument();
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,18 @@ import { Footer } from './components/layout/Footer';
 import { Header } from './components/layout/Header';
 import { apiClient } from './api/client';
 import { BLOG_POSTS, DOC_ENTRIES, HOME_FAQ_ITEMS } from './content/resources';
+import {
+  ProductAppIndexRedirect,
+  ProductFindingsPage,
+  ProductLoginPage,
+  ProductOverviewPage,
+  ProductProjectDetailPage,
+  ProductProjectsPage,
+  RequireProductAuth,
+  ProductSettingsPage,
+  ProductShellLayout,
+  ProductWorkspacesPage
+} from './productShell';
 
 type SeoConfig = {
   title: string;
@@ -2926,7 +2938,9 @@ function NotFoundPage() {
 
 export function RoutedSite() {
   useAnalytics();
+  const location = useLocation();
   const [theme, setTheme] = useState<ThemeMode>(resolveInitialTheme);
+  const isProductShellRoute = location.pathname.startsWith('/app');
 
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
@@ -2943,15 +2957,41 @@ export function RoutedSite() {
         Skip to content
       </a>
 
-      <Header
-        navLinks={NAV_LINKS}
-        githubRepo={GITHUB_REPO}
-        theme={theme}
-        onToggleTheme={() => setTheme((current) => (current === 'dark' ? 'light' : 'dark'))}
-      />
+      {!isProductShellRoute ? (
+        <Header
+          navLinks={NAV_LINKS}
+          githubRepo={GITHUB_REPO}
+          theme={theme}
+          onToggleTheme={() => setTheme((current) => (current === 'dark' ? 'light' : 'dark'))}
+        />
+      ) : null}
 
       <main id="main-content">
         <Routes>
+          <Route path="/app/login" element={<ProductLoginPage />} />
+          <Route
+            path="/app"
+            element={
+              <RequireProductAuth>
+                <ProductAppIndexRedirect />
+              </RequireProductAuth>
+            }
+          />
+          <Route
+            path="/app/:tenantID/:workspaceID"
+            element={
+              <RequireProductAuth>
+                <ProductShellLayout />
+              </RequireProductAuth>
+            }
+          >
+            <Route index element={<ProductOverviewPage />} />
+            <Route path="workspaces" element={<ProductWorkspacesPage />} />
+            <Route path="projects" element={<ProductProjectsPage />} />
+            <Route path="projects/:projectID" element={<ProductProjectDetailPage />} />
+            <Route path="findings" element={<ProductFindingsPage />} />
+            <Route path="settings" element={<ProductSettingsPage />} />
+          </Route>
           <Route path="/" element={<HomePage />} />
           <Route path="/product" element={<ProductPage />} />
           <Route path="/features" element={<FeaturesPage />} />
@@ -2983,8 +3023,12 @@ export function RoutedSite() {
         </Routes>
       </main>
 
-      <Footer xUrl={X_URL} linkedInUrl={LINKEDIN_URL} githubRepo={GITHUB_REPO} discordUrl={DISCORD_URL} />
-      <ExitIntentPopup />
+      {!isProductShellRoute ? (
+        <>
+          <Footer xUrl={X_URL} linkedInUrl={LINKEDIN_URL} githubRepo={GITHUB_REPO} discordUrl={DISCORD_URL} />
+          <ExitIntentPopup />
+        </>
+      ) : null}
     </div>
   );
 }

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -370,7 +370,7 @@ export function ProductOverviewPage() {
       title="Overview"
       description={`Entry view for tenant ${scope?.tenantID ?? 'unknown'} and workspace ${scope?.workspaceID ?? 'unknown'}.`}
       actionLabel="Open findings"
-      actionTo={`/${['app', scope?.tenantID ?? 'default', scope?.workspaceID ?? 'default', 'findings'].join('/')}`}
+      actionTo={`/app/${encodeURIComponent(scope?.tenantID ?? 'default')}/${encodeURIComponent(scope?.workspaceID ?? 'default')}/findings`}
     />
   );
 }
@@ -387,7 +387,7 @@ export function ProductProjectsPage() {
       title="Projects"
       description="Project-level onboarding and scan boundaries live here."
       actionLabel="View placeholder project"
-      actionTo={`/${['app', scope?.tenantID ?? 'default', scope?.workspaceID ?? 'default', 'projects', scope?.projectID ?? 'sample-project'].join('/')}`}
+      actionTo={`/app/${encodeURIComponent(scope?.tenantID ?? 'default')}/${encodeURIComponent(scope?.workspaceID ?? 'default')}/projects/${encodeURIComponent(scope?.projectID ?? 'sample-project')}`}
     />
   );
 }

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -5,8 +5,6 @@ type ProductSession = {
   tenantID: string;
   workspaceID: string;
   projectID?: string;
-  apiKey?: string;
-  bearerToken?: string;
 };
 
 type ScopeRouteParams = {
@@ -46,9 +44,7 @@ function readProductSession(): ProductSession | null {
     return {
       tenantID,
       workspaceID,
-      projectID: normalizeValue(parsed.projectID ?? '') || undefined,
-      apiKey: normalizeValue(parsed.apiKey ?? '') || undefined,
-      bearerToken: normalizeValue(parsed.bearerToken ?? '') || undefined
+      projectID: normalizeValue(parsed.projectID ?? '') || undefined
     };
   } catch {
     return null;
@@ -59,12 +55,7 @@ function saveProductSession(session: ProductSession) {
   if (typeof window === 'undefined') {
     return;
   }
-  const persistedSession: Pick<ProductSession, 'tenantID' | 'workspaceID' | 'projectID'> = {
-    tenantID: session.tenantID,
-    workspaceID: session.workspaceID,
-    projectID: session.projectID
-  };
-  window.localStorage.setItem(PRODUCT_SESSION_STORAGE_KEY, JSON.stringify(persistedSession));
+  window.localStorage.setItem(PRODUCT_SESSION_STORAGE_KEY, JSON.stringify(session));
 }
 
 function clearProductSession() {
@@ -187,8 +178,6 @@ export function ProductLoginPage() {
   const [tenantID, setTenantID] = useState(existing?.tenantID ?? 'default');
   const [workspaceID, setWorkspaceID] = useState(existing?.workspaceID ?? 'default');
   const [projectID, setProjectID] = useState(existing?.projectID ?? '');
-  const [apiKey, setApiKey] = useState(existing?.apiKey ?? '');
-  const [bearerToken, setBearerToken] = useState(existing?.bearerToken ?? '');
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -201,9 +190,7 @@ export function ProductLoginPage() {
     const session: ProductSession = {
       tenantID: normalizedTenantID,
       workspaceID: normalizedWorkspaceID,
-      projectID: normalizeValue(projectID) || undefined,
-      apiKey: normalizeValue(apiKey) || undefined,
-      bearerToken: normalizeValue(bearerToken) || undefined
+      projectID: normalizeValue(projectID) || undefined
     };
     saveProductSession(session);
 
@@ -234,14 +221,6 @@ export function ProductLoginPage() {
           <label>
             Project ID (optional)
             <input value={projectID} onChange={(event) => setProjectID(event.target.value)} />
-          </label>
-          <label>
-            API key (optional)
-            <input value={apiKey} onChange={(event) => setApiKey(event.target.value)} />
-          </label>
-          <label>
-            Bearer token (optional)
-            <input value={bearerToken} onChange={(event) => setBearerToken(event.target.value)} />
           </label>
           <button className="idt-btn idt-btn-primary" type="submit">
             Continue to app

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -59,7 +59,12 @@ function saveProductSession(session: ProductSession) {
   if (typeof window === 'undefined') {
     return;
   }
-  window.localStorage.setItem(PRODUCT_SESSION_STORAGE_KEY, JSON.stringify(session));
+  const persistedSession: Pick<ProductSession, 'tenantID' | 'workspaceID' | 'projectID'> = {
+    tenantID: session.tenantID,
+    workspaceID: session.workspaceID,
+    projectID: session.projectID
+  };
+  window.localStorage.setItem(PRODUCT_SESSION_STORAGE_KEY, JSON.stringify(persistedSession));
 }
 
 function clearProductSession() {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1,0 +1,427 @@
+import { Component, FormEvent, ReactNode, useEffect, useMemo, useState } from 'react';
+import { Link, Navigate, NavLink, Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
+
+type ProductSession = {
+  tenantID: string;
+  workspaceID: string;
+  projectID?: string;
+  apiKey?: string;
+  bearerToken?: string;
+};
+
+type ScopeRouteParams = {
+  tenantID?: string;
+  workspaceID?: string;
+  projectID?: string;
+};
+
+type ScopedShellPageProps = {
+  title: string;
+  description: string;
+  actionLabel?: string;
+  actionTo?: string;
+};
+
+const PRODUCT_SESSION_STORAGE_KEY = 'identrail-product-session';
+
+function normalizeValue(value: string): string {
+  return value.trim();
+}
+
+function readProductSession(): ProductSession | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    const raw = window.localStorage.getItem(PRODUCT_SESSION_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as Partial<ProductSession>;
+    const tenantID = normalizeValue(parsed.tenantID ?? '');
+    const workspaceID = normalizeValue(parsed.workspaceID ?? '');
+    if (!tenantID || !workspaceID) {
+      return null;
+    }
+    return {
+      tenantID,
+      workspaceID,
+      projectID: normalizeValue(parsed.projectID ?? '') || undefined,
+      apiKey: normalizeValue(parsed.apiKey ?? '') || undefined,
+      bearerToken: normalizeValue(parsed.bearerToken ?? '') || undefined
+    };
+  } catch {
+    return null;
+  }
+}
+
+function saveProductSession(session: ProductSession) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.setItem(PRODUCT_SESSION_STORAGE_KEY, JSON.stringify(session));
+}
+
+function clearProductSession() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.removeItem(PRODUCT_SESSION_STORAGE_KEY);
+}
+
+function buildTenantWorkspacePath(tenantID: string, workspaceID: string): string {
+  return `/app/${encodeURIComponent(tenantID)}/${encodeURIComponent(workspaceID)}`;
+}
+
+function buildScopedPath(scope: ProductSession, suffix = ''): string {
+  const base = buildTenantWorkspacePath(scope.tenantID, scope.workspaceID);
+  return suffix ? `${base}/${suffix}` : base;
+}
+
+function useScaffoldDataState(delayMS = 320) {
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setLoading(false), delayMS);
+    return () => window.clearTimeout(timer);
+  }, [delayMS]);
+
+  return loading;
+}
+
+function ProductErrorBoundary({ children }: { children: ReactNode }) {
+  return <ProductErrorBoundaryInner>{children}</ProductErrorBoundaryInner>;
+}
+
+type ProductErrorBoundaryState = {
+  hasError: boolean;
+  message: string;
+};
+
+class ProductErrorBoundaryInner extends Component<
+  { children: ReactNode },
+  ProductErrorBoundaryState
+> {
+  constructor(props: { children: ReactNode }) {
+    super(props);
+    this.state = { hasError: false, message: '' };
+  }
+
+  static getDerivedStateFromError(error: unknown): ProductErrorBoundaryState {
+    return {
+      hasError: true,
+      message: error instanceof Error ? error.message : 'Unexpected app shell failure'
+    };
+  }
+
+  componentDidCatch() {
+    // Intentionally no-op: fallback UI already captures global shell failures.
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <section className="idt-app-shell-screen" role="alert">
+          <article className="idt-app-panel idt-app-panel-error">
+            <p className="idt-app-kicker">App shell error</p>
+            <h1>We hit a shell boundary error</h1>
+            <p>{this.state.message}</p>
+            <p>Refresh the page or return to the marketing site while we restore this workspace view.</p>
+            <Link className="idt-btn idt-btn-primary" to="/">
+              Back to homepage
+            </Link>
+          </article>
+        </section>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+function AppShellLoading({ message }: { message: string }) {
+  return (
+    <section className="idt-app-shell-screen" aria-live="polite">
+      <article className="idt-app-panel">
+        <p className="idt-app-kicker">Loading</p>
+        <h1>{message}</h1>
+        <p>Preparing route context and tenancy scope.</p>
+      </article>
+    </section>
+  );
+}
+
+function AppShellEmptyState({ title, body }: { title: string; body: string }) {
+  return (
+    <article className="idt-app-empty-state">
+      <h2>{title}</h2>
+      <p>{body}</p>
+    </article>
+  );
+}
+
+export function RequireProductAuth({ children }: { children: ReactNode }) {
+  const location = useLocation();
+  const session = readProductSession();
+
+  if (!session) {
+    const next = `${location.pathname}${location.search}`;
+    return <Navigate to={`/app/login?next=${encodeURIComponent(next)}`} replace />;
+  }
+
+  return <>{children}</>;
+}
+
+export function ProductLoginPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const query = new URLSearchParams(location.search);
+  const nextPath = normalizeValue(query.get('next') ?? '');
+  const existing = useMemo(() => readProductSession(), []);
+
+  const [tenantID, setTenantID] = useState(existing?.tenantID ?? 'default');
+  const [workspaceID, setWorkspaceID] = useState(existing?.workspaceID ?? 'default');
+  const [projectID, setProjectID] = useState(existing?.projectID ?? '');
+  const [apiKey, setApiKey] = useState(existing?.apiKey ?? '');
+  const [bearerToken, setBearerToken] = useState(existing?.bearerToken ?? '');
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const normalizedTenantID = normalizeValue(tenantID);
+    const normalizedWorkspaceID = normalizeValue(workspaceID);
+    if (!normalizedTenantID || !normalizedWorkspaceID) {
+      return;
+    }
+
+    const session: ProductSession = {
+      tenantID: normalizedTenantID,
+      workspaceID: normalizedWorkspaceID,
+      projectID: normalizeValue(projectID) || undefined,
+      apiKey: normalizeValue(apiKey) || undefined,
+      bearerToken: normalizeValue(bearerToken) || undefined
+    };
+    saveProductSession(session);
+
+    if (nextPath.startsWith('/app/')) {
+      navigate(nextPath, { replace: true });
+      return;
+    }
+
+    navigate(buildScopedPath(session), { replace: true });
+  };
+
+  return (
+    <section className="idt-app-shell-screen">
+      <article className="idt-app-panel">
+        <p className="idt-app-kicker">Product access</p>
+        <h1>Sign in to the Identrail app shell</h1>
+        <p>Set your tenant and workspace scope to enter the authenticated app route boundary.</p>
+
+        <form className="idt-app-form" onSubmit={handleSubmit}>
+          <label>
+            Tenant ID
+            <input value={tenantID} onChange={(event) => setTenantID(event.target.value)} required />
+          </label>
+          <label>
+            Workspace ID
+            <input value={workspaceID} onChange={(event) => setWorkspaceID(event.target.value)} required />
+          </label>
+          <label>
+            Project ID (optional)
+            <input value={projectID} onChange={(event) => setProjectID(event.target.value)} />
+          </label>
+          <label>
+            API key (optional)
+            <input value={apiKey} onChange={(event) => setApiKey(event.target.value)} />
+          </label>
+          <label>
+            Bearer token (optional)
+            <input value={bearerToken} onChange={(event) => setBearerToken(event.target.value)} />
+          </label>
+          <button className="idt-btn idt-btn-primary" type="submit">
+            Continue to app
+          </button>
+        </form>
+      </article>
+    </section>
+  );
+}
+
+export function ProductAppIndexRedirect() {
+  const session = readProductSession();
+  if (!session) {
+    return <Navigate to="/app/login" replace />;
+  }
+  return <Navigate to={buildScopedPath(session)} replace />;
+}
+
+function resolveScopeFromParams(params: ScopeRouteParams): ProductSession | null {
+  const tenantID = normalizeValue(params.tenantID ?? '');
+  const workspaceID = normalizeValue(params.workspaceID ?? '');
+  const projectID = normalizeValue(params.projectID ?? '') || undefined;
+  if (!tenantID || !workspaceID) {
+    return null;
+  }
+  return { tenantID, workspaceID, projectID };
+}
+
+export function ProductShellLayout() {
+  const params = useParams<ScopeRouteParams>();
+  const navigate = useNavigate();
+  const scope = resolveScopeFromParams(params);
+
+  useEffect(() => {
+    if (!scope) {
+      return;
+    }
+    const current = readProductSession();
+    if (!current) {
+      return;
+    }
+    saveProductSession({
+      ...current,
+      tenantID: scope.tenantID,
+      workspaceID: scope.workspaceID,
+      projectID: scope.projectID ?? current.projectID
+    });
+  }, [scope]);
+
+  if (!scope) {
+    return <AppShellLoading message="Resolving workspace scope" />;
+  }
+
+  const basePath = buildScopedPath(scope);
+
+  return (
+    <ProductErrorBoundary>
+      <div className="idt-app-shell" data-tenant={scope.tenantID} data-workspace={scope.workspaceID}>
+        <header className="idt-app-shell-header">
+          <div>
+            <p className="idt-app-kicker">Authenticated app shell</p>
+            <h1>Identrail Workspace</h1>
+            <p>
+              Tenant <strong>{scope.tenantID}</strong> · Workspace <strong>{scope.workspaceID}</strong>
+              {scope.projectID ? (
+                <>
+                  {' '}
+                  · Project <strong>{scope.projectID}</strong>
+                </>
+              ) : null}
+            </p>
+          </div>
+          <div className="idt-app-shell-actions">
+            <button
+              type="button"
+              className="idt-btn idt-btn-ghost"
+              onClick={() => {
+                clearProductSession();
+                navigate('/app/login', { replace: true });
+              }}
+            >
+              Sign out
+            </button>
+            <Link to="/" className="idt-btn idt-btn-dark">
+              Marketing site
+            </Link>
+          </div>
+        </header>
+
+        <nav className="idt-app-shell-nav" aria-label="App sections">
+          <NavLink to={basePath} end>
+            Overview
+          </NavLink>
+          <NavLink to={`${basePath}/workspaces`}>Workspaces</NavLink>
+          <NavLink to={`${basePath}/projects`}>Projects</NavLink>
+          <NavLink to={`${basePath}/findings`}>Findings</NavLink>
+          <NavLink to={`${basePath}/settings`}>Settings</NavLink>
+        </nav>
+
+        <main className="idt-app-shell-main">
+          <Outlet />
+        </main>
+      </div>
+    </ProductErrorBoundary>
+  );
+}
+
+function ScopedShellPage({ title, description, actionLabel, actionTo }: ScopedShellPageProps) {
+  const loading = useScaffoldDataState();
+
+  if (loading) {
+    return (
+      <section className="idt-app-panel" aria-busy="true" aria-live="polite">
+        <p className="idt-app-kicker">Loading</p>
+        <h2>{title}</h2>
+        <p>Fetching scoped data for this workspace route.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="idt-app-panel">
+      <p className="idt-app-kicker">Scaffold</p>
+      <h2>{title}</h2>
+      <p>{description}</p>
+      <AppShellEmptyState
+        title="No data yet"
+        body="This placeholder is intentionally empty until backend wiring and feature-specific views are connected."
+      />
+      {actionLabel && actionTo ? (
+        <div className="idt-inline-actions">
+          <Link className="idt-btn idt-btn-primary" to={actionTo}>
+            {actionLabel}
+          </Link>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+export function ProductOverviewPage() {
+  const params = useParams<ScopeRouteParams>();
+  const scope = resolveScopeFromParams(params);
+
+  return (
+    <ScopedShellPage
+      title="Overview"
+      description={`Entry view for tenant ${scope?.tenantID ?? 'unknown'} and workspace ${scope?.workspaceID ?? 'unknown'}.`}
+      actionLabel="Open findings"
+      actionTo={`/${['app', scope?.tenantID ?? 'default', scope?.workspaceID ?? 'default', 'findings'].join('/')}`}
+    />
+  );
+}
+
+export function ProductWorkspacesPage() {
+  return <ScopedShellPage title="Workspaces" description="Workspace lifecycle, membership, and scope boundaries will be managed from this route group." />;
+}
+
+export function ProductProjectsPage() {
+  const params = useParams<ScopeRouteParams>();
+  const scope = resolveScopeFromParams(params);
+  return (
+    <ScopedShellPage
+      title="Projects"
+      description="Project-level onboarding and scan boundaries live here."
+      actionLabel="View placeholder project"
+      actionTo={`/${['app', scope?.tenantID ?? 'default', scope?.workspaceID ?? 'default', 'projects', scope?.projectID ?? 'sample-project'].join('/')}`}
+    />
+  );
+}
+
+export function ProductProjectDetailPage() {
+  const params = useParams<ScopeRouteParams>();
+  return (
+    <ScopedShellPage
+      title="Project detail"
+      description={`Project ${params.projectID ?? 'unknown'} placeholder with room for run status, controls, and ownership context.`}
+    />
+  );
+}
+
+export function ProductFindingsPage() {
+  return <ScopedShellPage title="Findings" description="Finding triage queue placeholder for scoped findings, filters, and ownership assignment." />;
+}
+
+export function ProductSettingsPage() {
+  return <ScopedShellPage title="Settings" description="Tenant/workspace app settings, auth provider mapping, and shell preferences will render here." />;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4132,3 +4132,142 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   border-color: rgba(39, 68, 118, 0.42);
   box-shadow: 0 0 0 2px rgba(74, 108, 165, 0.2);
 }
+
+.idt-app-shell-screen {
+  width: min(100% - 2rem, 760px);
+  margin: 4rem auto;
+}
+
+.idt-app-shell {
+  width: min(100% - 2rem, 1180px);
+  margin: 2rem auto 3rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.idt-app-shell-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.25rem;
+  border: 1px solid rgba(137, 168, 224, 0.28);
+  border-radius: 0.85rem;
+  background: linear-gradient(160deg, rgba(14, 23, 39, 0.9), rgba(12, 20, 33, 0.8));
+}
+
+.idt-app-shell-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.idt-app-shell-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.idt-app-shell-nav a {
+  color: #bfd2ee;
+  text-decoration: none;
+  font-weight: 600;
+  border: 1px solid rgba(130, 160, 214, 0.3);
+  border-radius: 999px;
+  padding: 0.4rem 0.8rem;
+  background: rgba(14, 23, 36, 0.72);
+}
+
+.idt-app-shell-nav a.active {
+  color: #0f223f;
+  background: #d7e5ff;
+  border-color: #d7e5ff;
+}
+
+.idt-app-shell-main {
+  min-height: 360px;
+}
+
+.idt-app-panel {
+  border: 1px solid rgba(120, 151, 207, 0.28);
+  border-radius: 0.85rem;
+  padding: 1.25rem;
+  background: linear-gradient(165deg, rgba(12, 21, 35, 0.9), rgba(10, 17, 30, 0.78));
+}
+
+.idt-app-panel-error {
+  border-color: rgba(213, 125, 125, 0.42);
+}
+
+.idt-app-kicker {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.74rem;
+  font-weight: 700;
+  color: #91add6;
+}
+
+.idt-app-form {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.idt-app-form label {
+  display: grid;
+  gap: 0.35rem;
+  color: #d3e1f7;
+  font-size: 0.95rem;
+}
+
+.idt-app-form input {
+  border: 1px solid rgba(126, 157, 211, 0.35);
+  border-radius: 0.55rem;
+  background: rgba(9, 15, 26, 0.84);
+  color: #e4efff;
+  padding: 0.5rem 0.6rem;
+}
+
+.idt-app-empty-state {
+  border: 1px dashed rgba(130, 160, 214, 0.4);
+  border-radius: 0.7rem;
+  padding: 0.9rem;
+  margin-top: 0.9rem;
+  background: rgba(11, 18, 31, 0.72);
+}
+
+html[data-theme='light'] .idt-app-shell-header,
+html[data-theme='light'] .idt-app-panel {
+  background: linear-gradient(165deg, rgba(252, 254, 255, 0.98), rgba(243, 249, 255, 0.94));
+  border-color: rgba(35, 64, 111, 0.2);
+}
+
+html[data-theme='light'] .idt-app-shell-nav a {
+  color: #24406e;
+  background: rgba(239, 246, 255, 0.95);
+  border-color: rgba(35, 64, 111, 0.23);
+}
+
+html[data-theme='light'] .idt-app-shell-nav a.active {
+  color: #12284c;
+  background: #dbe8ff;
+  border-color: #dbe8ff;
+}
+
+html[data-theme='light'] .idt-app-kicker {
+  color: #5473a4;
+}
+
+html[data-theme='light'] .idt-app-form label {
+  color: #2b456c;
+}
+
+html[data-theme='light'] .idt-app-form input {
+  color: #1c355d;
+  background: #ffffff;
+  border-color: rgba(42, 71, 119, 0.32);
+}
+
+html[data-theme='light'] .idt-app-empty-state {
+  background: rgba(239, 246, 255, 0.93);
+  border-color: rgba(42, 71, 119, 0.32);
+}


### PR DESCRIPTION
Fixes #548

## What changed
- Added an authenticated product shell route group under `/app/*` with route boundaries for tenancy scope:
  - `/app/login`
  - `/app/:tenantID/:workspaceID`
  - `/app/:tenantID/:workspaceID/workspaces`
  - `/app/:tenantID/:workspaceID/projects`
  - `/app/:tenantID/:workspaceID/projects/:projectID`
  - `/app/:tenantID/:workspaceID/findings`
  - `/app/:tenantID/:workspaceID/settings`
- Added guarded route access for product shell flows with redirect to `/app/login` when no app session exists.
- Added a non-marketing app layout shell for authenticated workflows (separate from site header/footer/exit popup).
- Added global app-shell error boundary fallback and route-level loading/empty-state scaffolds for placeholder pages.
- Added tenancy-aware shell navigation and scoped context display in the app shell header.
- Added tests covering:
  - unauthenticated guard redirect behavior
  - login-to-shell flow
  - tenancy-scoped project detail route rendering
- Updated frontend docs for the `/app/*` product shell topology.

## Why
Issue #548 requires a stable authenticated product shell with guarded routes, layout boundaries, global error handling, and loading/empty state scaffolding without introducing feature-specific pages.

## Impact and risk
- Low-to-moderate risk, scoped to frontend routing/layout behavior.
- Existing marketing routes remain intact.
- Product shell routes are additive and isolated from public marketing shell chrome.

## Validation performed
- `npm run test --prefix web -- --run`
- `npm run build --prefix web`

## AI disclosure
- AI-assisted: no
- Human verification performed: manual code review, route behavior validation via tests, and production build verification
