### PR TITLE
fixes (#603): enforce branch-protection drift checks and optional auto-apply

### DIFF
--- a/.github/workflows/enforce-branch-protection.yml
+++ b/.github/workflows/enforce-branch-protection.yml
@@ -137,17 +137,32 @@ jobs:
             }
 
             const octokit = github.getOctokit(token);
-            const liveResponse = await octokit.rest.repos.getBranchProtection({
-              owner,
-              repo,
-              branch
-            });
-            const liveNormalized = normalizeLive(liveResponse.data);
-            core.info(
-              `live policy: ${JSON.stringify(liveNormalized, null, 2)}`
-            );
 
-            const driftDetected =
+            let liveNormalized = null;
+            let branchUnprotected = false;
+            try {
+              const liveResponse = await octokit.rest.repos.getBranchProtection({
+                owner,
+                repo,
+                branch
+              });
+              liveNormalized = normalizeLive(liveResponse.data);
+            } catch (err) {
+              if (err.status === 404) {
+                branchUnprotected = true;
+                core.warning(`Branch '${branch}' has no protection rules configured.`);
+              } else {
+                throw err;
+              }
+            }
+
+            if (!branchUnprotected) {
+              core.info(
+                `live policy: ${JSON.stringify(liveNormalized, null, 2)}`
+              );
+            }
+
+            const driftDetected = branchUnprotected ||
               JSON.stringify(desiredNormalized) !== JSON.stringify(liveNormalized);
 
             if (!driftDetected) {
@@ -155,11 +170,17 @@ jobs:
               return;
             }
 
-            core.warning('Branch protection drift detected for dev.');
+            core.warning(
+              branchUnprotected
+                ? `Branch '${branch}' is unprotected. Protection rules must be applied.`
+                : 'Branch protection drift detected for dev.'
+            );
 
             if (mode !== 'apply') {
               core.setFailed(
-                'Branch protection drift detected. Re-run this workflow with mode=apply to reconcile.'
+                branchUnprotected
+                  ? 'Branch is unprotected. Re-run this workflow with mode=apply to apply protection.'
+                  : 'Branch protection drift detected. Re-run this workflow with mode=apply to reconcile.'
               );
               return;
             }

--- a/.github/workflows/enforce-branch-protection.yml
+++ b/.github/workflows/enforce-branch-protection.yml
@@ -11,6 +11,14 @@ on:
         options:
           - dry-run
           - apply
+  schedule:
+    - cron: "23 3 * * *"
+  push:
+    branches:
+      - dev
+    paths:
+      - ".github/branch-protection/dev.json"
+      - ".github/workflows/enforce-branch-protection.yml"
 
 permissions:
   contents: read
@@ -20,6 +28,8 @@ jobs:
     name: Enforce dev branch protection
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      MODE: ${{ github.event.inputs.mode || 'dry-run' }}
 
     steps:
       - name: Checkout
@@ -28,36 +38,154 @@ jobs:
       - name: Validate config JSON
         run: jq empty .github/branch-protection/dev.json
 
-      - name: Print protection plan (dry-run)
-        if: inputs.mode == 'dry-run'
-        run: |
-          echo "Branch protection payload for dev:"
-          cat .github/branch-protection/dev.json
-
-      - name: Apply protection via GitHub API
-        if: inputs.mode == 'apply'
+      - name: Audit drift and optionally apply protection
         uses: actions/github-script@v9
         env:
           REPO_ADMIN_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
+          MODE: ${{ env.MODE }}
         with:
           script: |
             const fs = require('fs');
-            const token = process.env.REPO_ADMIN_TOKEN;
-            if (!token) {
-              core.setFailed('Missing REPO_ADMIN_TOKEN secret (repo admin scope required).');
-              return;
-            }
 
-            const payload = JSON.parse(
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const branch = 'dev';
+            const mode = (process.env.MODE || 'dry-run').trim();
+            const token = (process.env.REPO_ADMIN_TOKEN || '').trim();
+
+            const desiredRaw = JSON.parse(
               fs.readFileSync('.github/branch-protection/dev.json', 'utf8')
             );
 
-            const octokit = github.getOctokit(token);
-            await octokit.rest.repos.updateBranchProtection({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              branch: 'dev',
-              ...payload,
+            const normalizeStatusChecks = (statusChecks) => {
+              if (!statusChecks) {
+                return null;
+              }
+              const contextsFromChecks = Array.isArray(statusChecks.checks)
+                ? statusChecks.checks
+                    .map((item) => item && item.context)
+                    .filter((value) => typeof value === 'string')
+                : [];
+              const contextsFromLegacy = Array.isArray(statusChecks.contexts)
+                ? statusChecks.contexts.filter((value) => typeof value === 'string')
+                : [];
+              const merged = [...new Set([...contextsFromChecks, ...contextsFromLegacy])].sort();
+              return {
+                strict: Boolean(statusChecks.strict),
+                contexts: merged
+              };
+            };
+
+            const normalizeDesired = (payload) => ({
+              required_status_checks: normalizeStatusChecks(payload.required_status_checks),
+              enforce_admins: Boolean(payload.enforce_admins),
+              required_pull_request_reviews: payload.required_pull_request_reviews
+                ? {
+                    dismiss_stale_reviews: Boolean(payload.required_pull_request_reviews.dismiss_stale_reviews),
+                    require_code_owner_reviews: Boolean(payload.required_pull_request_reviews.require_code_owner_reviews),
+                    required_approving_review_count: Number(
+                      payload.required_pull_request_reviews.required_approving_review_count || 0
+                    ),
+                    require_last_push_approval: Boolean(payload.required_pull_request_reviews.require_last_push_approval)
+                  }
+                : null,
+              restrictions: payload.restrictions ?? null,
+              required_conversation_resolution: Boolean(payload.required_conversation_resolution),
+              allow_force_pushes: Boolean(payload.allow_force_pushes),
+              allow_deletions: Boolean(payload.allow_deletions),
+              required_linear_history: Boolean(payload.required_linear_history),
+              block_creations: Boolean(payload.block_creations)
             });
 
-            core.info('Branch protection updated for dev.');
+            const normalizeLive = (payload) => ({
+              required_status_checks: normalizeStatusChecks(payload.required_status_checks),
+              enforce_admins: Boolean(payload.enforce_admins && payload.enforce_admins.enabled),
+              required_pull_request_reviews: payload.required_pull_request_reviews
+                ? {
+                    dismiss_stale_reviews: Boolean(payload.required_pull_request_reviews.dismiss_stale_reviews),
+                    require_code_owner_reviews: Boolean(payload.required_pull_request_reviews.require_code_owner_reviews),
+                    required_approving_review_count: Number(
+                      payload.required_pull_request_reviews.required_approving_review_count || 0
+                    ),
+                    require_last_push_approval: Boolean(payload.required_pull_request_reviews.require_last_push_approval)
+                  }
+                : null,
+              restrictions: payload.restrictions ?? null,
+              required_conversation_resolution: Boolean(
+                payload.required_conversation_resolution &&
+                  payload.required_conversation_resolution.enabled
+              ),
+              allow_force_pushes: Boolean(payload.allow_force_pushes && payload.allow_force_pushes.enabled),
+              allow_deletions: Boolean(payload.allow_deletions && payload.allow_deletions.enabled),
+              required_linear_history: Boolean(
+                payload.required_linear_history && payload.required_linear_history.enabled
+              ),
+              block_creations: Boolean(payload.block_creations && payload.block_creations.enabled)
+            });
+
+            const desiredNormalized = normalizeDesired(desiredRaw);
+            core.info(`branch-protection mode: ${mode}`);
+            core.info(
+              `desired policy: ${JSON.stringify(desiredNormalized, null, 2)}`
+            );
+
+            if (!token) {
+              core.setFailed(
+                'Missing REPO_ADMIN_TOKEN secret (repo admin scope required for drift audit/apply).'
+              );
+              return;
+            }
+
+            const octokit = github.getOctokit(token);
+            const liveResponse = await octokit.rest.repos.getBranchProtection({
+              owner,
+              repo,
+              branch
+            });
+            const liveNormalized = normalizeLive(liveResponse.data);
+            core.info(
+              `live policy: ${JSON.stringify(liveNormalized, null, 2)}`
+            );
+
+            const driftDetected =
+              JSON.stringify(desiredNormalized) !== JSON.stringify(liveNormalized);
+
+            if (!driftDetected) {
+              core.info('Branch protection is already aligned with repo policy.');
+              return;
+            }
+
+            core.warning('Branch protection drift detected for dev.');
+
+            if (mode !== 'apply') {
+              core.setFailed(
+                'Branch protection drift detected. Re-run this workflow with mode=apply to reconcile.'
+              );
+              return;
+            }
+
+            await octokit.rest.repos.updateBranchProtection({
+              owner,
+              repo,
+              branch,
+              ...desiredRaw
+            });
+
+            const postApply = await octokit.rest.repos.getBranchProtection({
+              owner,
+              repo,
+              branch
+            });
+            const postApplyNormalized = normalizeLive(postApply.data);
+
+            if (
+              JSON.stringify(desiredNormalized) !==
+              JSON.stringify(postApplyNormalized)
+            ) {
+              core.setFailed(
+                'Apply attempt completed but protection still does not match desired policy.'
+              );
+              return;
+            }
+
+            core.info('Branch protection updated and verified for dev.');


### PR DESCRIPTION
Fixes #603

## What changed
- upgraded `.github/workflows/enforce-branch-protection.yml` from manual-only execution to continuous enforcement coverage:
  - keeps `workflow_dispatch` with `mode` (`dry-run` or `apply`)
  - adds nightly scheduled drift audit
  - adds automatic audit trigger when branch-protection policy/workflow config changes on `dev`
- replaced one-way apply logic with full drift detection + reconciliation flow:
  - validates policy JSON from `.github/branch-protection/dev.json`
  - fetches live `dev` branch protection from GitHub API
  - normalizes and compares desired vs live protection (including required status checks contexts)
  - fails in `dry-run` mode when drift exists
  - applies and verifies reconciliation in `apply` mode
- enforced explicit admin-token requirement for drift audit/apply (`REPO_ADMIN_TOKEN`) so checks cannot silently pass without authority to read branch protection.

## Why
Issue #603 reports branch-protection drift where required status checks in repo policy are not enforced live. This change makes drift detectable on a schedule and on policy updates, and provides controlled auto-reconciliation when run in apply mode.

## Impact and risk
- Low runtime risk (workflow-only change).
- High governance impact: prevents silent drift of required checks on `dev`.
- `dry-run` intentionally fails on drift to create actionable signal.

## Validation performed
- pre-commit checks on commit:
  - `check yaml`
  - `fix end of files`
  - `trim trailing whitespace`
- push-time checks:
  - `go vet`
  - workflow file syntax accepted by repository checks
- manual review of normalization/compare/apply logic against current GitHub branch-protection API response shapes.

## AI disclosure
- AI-assisted: no
- Human verification performed: workflow logic review, policy-to-live comparison review, and local hook validation
