### PR TITLE
fixes (#549): harden Keycloak OIDC verification coverage

### DIFF
--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -19,6 +19,9 @@ IDENTRAIL_POSTGRES_PASSWORD=replace-with-strong-postgres-password
 # IDENTRAIL_DEFAULT_TENANT_ID=default
 # IDENTRAIL_DEFAULT_WORKSPACE_ID=default
 # Optional OIDC claim mapping overrides
+# IDENTRAIL_OIDC_ISSUER_URL=https://keycloak.example.com/realms/identrail
+# IDENTRAIL_OIDC_AUDIENCE=identrail-api
+# IDENTRAIL_OIDC_WRITE_SCOPES=identrail.write,identrail.admin,write,admin
 # IDENTRAIL_OIDC_TENANT_CLAIM=tenant_id
 # IDENTRAIL_OIDC_WORKSPACE_CLAIM=workspace_id
 # IDENTRAIL_OIDC_GROUPS_CLAIM=groups

--- a/docs/auth-scope-and-claims.md
+++ b/docs/auth-scope-and-claims.md
@@ -24,6 +24,22 @@ Issuer/audience controls:
 - `IDENTRAIL_OIDC_ISSUER_URL`
 - `IDENTRAIL_OIDC_AUDIENCE`
 
+### Keycloak Baseline
+
+For Keycloak-backed OIDC verification, set:
+
+- `IDENTRAIL_OIDC_ISSUER_URL=https://<keycloak-host>/realms/<realm>`
+- `IDENTRAIL_OIDC_AUDIENCE=<keycloak-client-id>`
+
+Token requirements for Identrail auth middleware:
+
+- `iss` must exactly match `IDENTRAIL_OIDC_ISSUER_URL`
+- `aud` must include `IDENTRAIL_OIDC_AUDIENCE`
+- `exp` must be valid (expired tokens are rejected)
+- tenant/workspace claims must exist using configured claim names
+
+If your Keycloak token does not already expose `tenant_id` and `workspace_id` as top-level string claims, add protocol mappers for them in the client.
+
 ## Write Authorization
 
 Write access is enforced by scope policy for both API keys and OIDC bearer tokens.

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -28,6 +28,10 @@ This page is the canonical runtime configuration surface for API and worker proc
 - `IDENTRAIL_DEFAULT_TENANT_ID`
 - `IDENTRAIL_DEFAULT_WORKSPACE_ID`
 
+Notes:
+- `IDENTRAIL_OIDC_ISSUER_URL` and `IDENTRAIL_OIDC_AUDIENCE` must be configured together.
+- OIDC bearer auth enforces issuer/audience plus token validity (`exp`) via provider verification.
+
 ## Provider Collection
 
 AWS:

--- a/internal/api/oidc_test.go
+++ b/internal/api/oidc_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -123,6 +124,22 @@ func TestOIDCTokenVerifierVerifyTokenErrors(t *testing.T) {
 	}
 	if _, err := claimsErr.VerifyToken(context.Background(), "token"); err == nil {
 		t.Fatal("expected claims decode error")
+	}
+}
+
+func TestOIDCTokenVerifierRejectsExpiredToken(t *testing.T) {
+	verifier := &OIDCTokenVerifier{
+		verifier: fakeRawTokenVerifier{
+			err: errors.New("oidc: token is expired"),
+		},
+	}
+
+	_, err := verifier.VerifyToken(context.Background(), "expired-token")
+	if err == nil {
+		t.Fatal("expected expired token verification error")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "expired") {
+		t.Fatalf("expected expired-token error, got %v", err)
 	}
 }
 

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -49,9 +49,13 @@ type recordingAuditSink struct {
 
 type fakeTokenVerifier struct {
 	tokens map[string]VerifiedToken
+	errs   map[string]error
 }
 
 func (v fakeTokenVerifier) VerifyToken(_ context.Context, rawToken string) (VerifiedToken, error) {
+	if err, ok := v.errs[rawToken]; ok {
+		return VerifiedToken{}, err
+	}
 	token, ok := v.tokens[rawToken]
 	if !ok {
 		return VerifiedToken{}, errors.New("invalid token")
@@ -1247,6 +1251,9 @@ func TestRouterOIDCOnlyAuthentication(t *testing.T) {
 					Scopes:      nil,
 				},
 			},
+			errs: map[string]error{
+				"expired-token": errors.New("oidc: token is expired"),
+			},
 		},
 	})
 
@@ -1271,6 +1278,14 @@ func TestRouterOIDCOnlyAuthentication(t *testing.T) {
 	r.ServeHTTP(noScopeW, noScopeReq)
 	if noScopeW.Code != http.StatusForbidden {
 		t.Fatalf("expected 403 for oidc token without read scope, got %d", noScopeW.Code)
+	}
+
+	expiredReq := httptest.NewRequest(http.MethodGet, "/v1/scans", nil)
+	expiredReq.Header.Set("Authorization", "Bearer expired-token")
+	expiredW := httptest.NewRecorder()
+	r.ServeHTTP(expiredW, expiredReq)
+	if expiredW.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for expired oidc token, got %d", expiredW.Code)
 	}
 }
 


### PR DESCRIPTION
Fixes #549

## Summary

- add explicit expired-token denial coverage for OIDC auth flow in API router tests
- add explicit expired-token verification coverage in OIDC verifier tests
- document a concrete Keycloak OIDC baseline (issuer, audience, required claims) for operators
- add commented OIDC issuer/audience/write-scope examples to Docker env template

## Why

Issue #549 requires backend OIDC verification hardening for Keycloak-compatible deployments, including clear claim/issuer expectations and auth tests that cover token expiry and issuer mismatch behavior.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation

```bash
go test ./internal/api -count=1
go test ./internal/server -count=1
go test ./internal/config -count=1
```

All commands passed locally.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no
- Tools used: N/A
- Areas where used: N/A
- Human verification performed: local test execution and manual diff review

## Related Issues

- Fixes #549
