### PR TITLE
fixes (#550): enforce tenancy RBAC role mapping and policy gates

### DIFF
--- a/docs/auth-scope-and-claims.md
+++ b/docs/auth-scope-and-claims.md
@@ -47,6 +47,22 @@ Write access is enforced by scope policy for both API keys and OIDC bearer token
 - API keys: scoped keys (`write`/`admin`) or legacy write-key config
 - OIDC: write scopes configured via `IDENTRAIL_OIDC_WRITE_SCOPES`
 
+## Tenancy RBAC Role Mapping
+
+For org/workspace/project actions, Identrail supports direct role mapping from OIDC `roles` claim values.
+
+Supported mapped roles:
+
+- `owner`
+- `admin`
+- `analyst`
+- `viewer`
+
+Tenancy action matrix:
+
+- `tenancy.read`: `owner`, `admin`, `analyst`, `viewer` (also compatible with `read`/`write`/`admin` scoped auth)
+- `tenancy.write`: `owner`, `admin` (also compatible with `write`/`admin` scoped auth)
+
 ## Operator Checks
 
 - verify claim names match your IdP token shape

--- a/internal/api/authz_middleware.go
+++ b/internal/api/authz_middleware.go
@@ -62,6 +62,8 @@ func routePolicyKey(method string, fullPath string) string {
 func defaultRouteActionRoleGrants() map[string][]string {
 	readRoles := []string{scopeRead, scopeWrite, scopeAdmin}
 	writeRoles := []string{scopeWrite, scopeAdmin}
+	tenancyReadRoles := []string{scopeRead, scopeWrite, scopeAdmin, "owner", "admin", "analyst", "viewer"}
+	tenancyWriteRoles := []string{scopeWrite, scopeAdmin, "owner", "admin"}
 	return map[string][]string{
 		policyActionFindingsRead:   readRoles,
 		policyActionFindingsTriage: writeRoles,
@@ -72,8 +74,8 @@ func defaultRouteActionRoleGrants() map[string][]string {
 		policyActionRepoScansRun:   writeRoles,
 		policyActionAuthzSimulate:  {scopeAdmin},
 		policyActionAuthzRollback:  {scopeAdmin},
-		policyActionTenancyRead:    readRoles,
-		policyActionTenancyWrite:   writeRoles,
+		policyActionTenancyRead:    tenancyReadRoles,
+		policyActionTenancyWrite:   tenancyWriteRoles,
 	}
 }
 
@@ -654,21 +656,29 @@ func policyRolesFromAuth(c *gin.Context, writeKeys []string, scopedKeys map[stri
 	if c == nil {
 		return nil
 	}
+	roles := map[string]struct{}{}
 	if scopeSetValue, exists := c.Get("auth.scope_set"); exists {
 		scopes, ok := scopeSetValue.(scopeSet)
-		if !ok {
-			return nil
+		if ok {
+			if scopes.has(scopeAdmin) {
+				roles[scopeAdmin] = struct{}{}
+			}
+			if scopes.has(scopeWrite) {
+				roles[scopeWrite] = struct{}{}
+			}
+			if scopes.has(scopeRead) {
+				roles[scopeRead] = struct{}{}
+			}
 		}
-		roles := map[string]struct{}{}
-		if scopes.has(scopeAdmin) {
-			roles[scopeAdmin] = struct{}{}
+	}
+	for _, rawRole := range authClaimRoles(c) {
+		normalized := strings.ToLower(strings.TrimSpace(rawRole))
+		switch normalized {
+		case "owner", "admin", "analyst", "viewer", scopeRead, scopeWrite:
+			roles[normalized] = struct{}{}
 		}
-		if scopes.has(scopeWrite) {
-			roles[scopeWrite] = struct{}{}
-		}
-		if scopes.has(scopeRead) {
-			roles[scopeRead] = struct{}{}
-		}
+	}
+	if len(roles) > 0 {
 		result := make([]string, 0, len(roles))
 		for role := range roles {
 			result = append(result, role)
@@ -685,9 +695,35 @@ func policyRolesFromAuth(c *gin.Context, writeKeys []string, scopedKeys map[stri
 	if len(scopedKeys) > 0 {
 		return nil
 	}
-	roles := []string{scopeRead}
+	legacyRoles := []string{scopeRead}
 	if keyInList(writeKeys, legacyKey) {
-		roles = append(roles, scopeWrite)
+		legacyRoles = append(legacyRoles, scopeWrite)
 	}
-	return roles
+	return legacyRoles
+}
+
+func authClaimRoles(c *gin.Context) []string {
+	if c == nil {
+		return nil
+	}
+	raw, exists := c.Get("auth.roles")
+	if !exists {
+		return nil
+	}
+	switch typed := raw.(type) {
+	case []string:
+		return typed
+	case []any:
+		result := make([]string, 0, len(typed))
+		for _, item := range typed {
+			role, ok := item.(string)
+			if !ok {
+				continue
+			}
+			result = append(result, role)
+		}
+		return result
+	default:
+		return nil
+	}
 }

--- a/internal/api/authz_middleware_test.go
+++ b/internal/api/authz_middleware_test.go
@@ -56,6 +56,19 @@ func TestPolicyRolesFromAuthLegacyKey(t *testing.T) {
 	}
 }
 
+func TestPolicyRolesFromAuthClaims(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Set("auth.roles", []string{"owner", "viewer", "ignored_role"})
+	roles := policyRolesFromAuth(c, nil, nil)
+	if len(roles) != 2 {
+		t.Fatalf("expected owner+viewer claim roles, got %+v", roles)
+	}
+	if roles[0] != "owner" || roles[1] != "viewer" {
+		t.Fatalf("unexpected claim role mapping %+v", roles)
+	}
+}
+
 func TestRequireCentralPolicyMiddlewareWriteDeniedForReadRole(t *testing.T) {
 	r := newPolicyTestRouter(newScopeSet([]string{scopeRead}), true, nil)
 	w := httptest.NewRecorder()
@@ -83,6 +96,60 @@ func TestRequireCentralPolicyMiddlewareBypassWhenAuthDisabled(t *testing.T) {
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusNoContent {
 		t.Fatalf("expected 204 when auth is disabled, got %d", w.Code)
+	}
+}
+
+func TestRequireCentralPolicyMiddlewareTenancyRoleMatrix(t *testing.T) {
+	testCases := []struct {
+		name        string
+		role        string
+		readStatus  int
+		writeStatus int
+	}{
+		{
+			name:        "owner can read and write tenancy",
+			role:        "owner",
+			readStatus:  http.StatusNoContent,
+			writeStatus: http.StatusNoContent,
+		},
+		{
+			name:        "admin can read and write tenancy",
+			role:        "admin",
+			readStatus:  http.StatusNoContent,
+			writeStatus: http.StatusNoContent,
+		},
+		{
+			name:        "analyst can read but cannot write tenancy",
+			role:        "analyst",
+			readStatus:  http.StatusNoContent,
+			writeStatus: http.StatusForbidden,
+		},
+		{
+			name:        "viewer can read but cannot write tenancy",
+			role:        "viewer",
+			readStatus:  http.StatusNoContent,
+			writeStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newPolicyTenancyRoleRouter(tc.role)
+
+			readReq := httptest.NewRequest(http.MethodGet, "/v1/workspaces", nil)
+			readW := httptest.NewRecorder()
+			r.ServeHTTP(readW, readReq)
+			if readW.Code != tc.readStatus {
+				t.Fatalf("expected read status %d for role %q, got %d", tc.readStatus, tc.role, readW.Code)
+			}
+
+			writeReq := httptest.NewRequest(http.MethodPost, "/v1/workspaces", nil)
+			writeW := httptest.NewRecorder()
+			r.ServeHTTP(writeW, writeReq)
+			if writeW.Code != tc.writeStatus {
+				t.Fatalf("expected write status %d for role %q, got %d", tc.writeStatus, tc.role, writeW.Code)
+			}
+		})
 	}
 }
 
@@ -783,6 +850,27 @@ func newPolicyTriageRouter(scopes scopeSet, setPrincipal bool, store db.Store) *
 	})
 	r.Use(requireCentralPolicyMiddleware(newCentralPolicyRuntimeResolver(store), nil, nil, store, telemetry.NewMetrics(), nil))
 	r.PATCH("/v1/findings/:finding_id/triage", func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+	return r
+}
+
+func newPolicyTenancyRoleRouter(role string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Request = c.Request.WithContext(db.WithScope(c.Request.Context(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"}))
+		c.Set("auth.subject", "subject-1")
+		c.Set("auth.roles", []string{role})
+		c.Set("auth.principal_type", "subject")
+		c.Set("auth.principal_id", "subject-1")
+		c.Next()
+	})
+	r.Use(requireCentralPolicyMiddleware(newCentralPolicyRuntimeResolver(nil), nil, nil, nil, telemetry.NewMetrics(), nil))
+	r.GET("/v1/workspaces", func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+	r.POST("/v1/workspaces", func(c *gin.Context) {
 		c.Status(http.StatusNoContent)
 	})
 	return r


### PR DESCRIPTION
Fixes #550

## Summary

- enforce tenancy RBAC role grants for `owner|admin|analyst|viewer` in the built-in authorization matrix
- map OIDC `roles` claim values into policy subject roles for central policy evaluation
- keep backward compatibility with existing scoped-key auth (`read|write|admin`) for tenancy routes
- add role-matrix tests to verify allowed/forbidden outcomes across tenancy read/write actions
- document tenancy RBAC role mapping in auth claims docs

## Why

Issue #550 requires enforceable role-based authorization for org/workspace/project actions, including role mapping from token claims and explicit forbidden results for disallowed roles.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation

```bash
go test ./internal/api -count=1
go test ./internal/server -count=1
```

All commands passed locally.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: no
- Tools used: N/A
- Areas where used: N/A
- Human verification performed: local tests and manual diff review

## Related Issues

- Fixes #550
