### PR TITLE
fixes (#623): align marketing CTAs to auth-first /app entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## Unreleased
+- Standardized product-entry marketing CTAs to the auth-first app flow:
+  - switched canonical marketing app-entry destination to `/app`
+  - added explicit `signIn` route mapping to `/app/login` in `siteLinks`
+  - updated marketing CTA labels to `Open App` for product-access intent
+  - added regression tests for CTA routing and route-guard `next` redirect behavior
 - Improved first-run onboarding flow:
   - added `make quickstart` with `scripts/quickstart.sh` to bootstrap local Docker, trigger a first scan, and guide findings retrieval
   - updated README quickstart to include first scan + findings flow (not only `/healthz`)

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -150,6 +150,8 @@ describe('App', () => {
         name: /Sign in to the Identrail app shell/i
       })
     ).toBeInTheDocument();
+    expect(window.location.pathname).toBe('/app/login');
+    expect(window.location.search).toContain('next=%2Fapp%2Fdefault%2Fdefault');
   });
 
   it('loads authenticated product shell placeholders after login', async () => {

--- a/web/src/components/CtaBannerSection.tsx
+++ b/web/src/components/CtaBannerSection.tsx
@@ -12,7 +12,7 @@ export function CtaBannerSection() {
         </p>
         <div className="cta-banner-actions">
           <SafeLink className="btn btn-ghost" href={siteLinks.getStarted}>
-            Get Started
+            Open App
           </SafeLink>
           <SafeLink className="btn btn-secondary" href={siteLinks.requestDemo}>
             Request a Demo

--- a/web/src/components/HeroSection.tsx
+++ b/web/src/components/HeroSection.tsx
@@ -36,7 +36,7 @@ export function HeroSection() {
 
           <div className="hero-cta">
             <SafeLink className="btn btn-primary" href={siteLinks.getStarted}>
-              Get Started (Open Source)
+              Open App
             </SafeLink>
             <SafeLink className="btn btn-secondary" href={siteLinks.starOnGithub}>
               Star on GitHub

--- a/web/src/components/IntegrationsCtaSection.tsx
+++ b/web/src/components/IntegrationsCtaSection.tsx
@@ -33,7 +33,7 @@ export function IntegrationsCtaSection() {
           <h3>Secure machine identity paths before they become incidents.</h3>
           <div>
             <SafeLink className="mk-btn mk-btn-primary" href={siteLinks.getStarted}>
-              Get Started (Open Source)
+              Open App
             </SafeLink>
             <SafeLink className="mk-btn mk-btn-secondary" href={siteLinks.requestDemo}>
               Request Demo

--- a/web/src/components/MarketingHero.tsx
+++ b/web/src/components/MarketingHero.tsx
@@ -133,7 +133,7 @@ export function MarketingHero() {
 
           <div className="mk-hero-cta mk-hero-cta-single">
             <SafeLink className="mk-btn mk-btn-primary" href={siteLinks.getStarted}>
-              Get Started
+              Open App
             </SafeLink>
           </div>
 

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link, NavLink, useLocation } from 'react-router-dom';
+import { siteLinks } from '../../siteConfig';
 import { SafeLink } from '../SafeLink';
 
 type NavLinkItem = {
@@ -84,6 +85,9 @@ export function Header({
             Book Demo
           </Link>
           <div className="idt-header-utility-group">
+            <Link to={siteLinks.signIn} className="idt-header-utility">
+              Sign in
+            </Link>
             <SafeLink href={githubRepo} className="idt-header-utility">
               GitHub
             </SafeLink>

--- a/web/src/components/marketingCtaRoutes.test.tsx
+++ b/web/src/components/marketingCtaRoutes.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { siteLinks } from '../siteConfig';
+import { CtaBannerSection } from './CtaBannerSection';
+import { HeroSection } from './HeroSection';
+import { IntegrationsCtaSection } from './IntegrationsCtaSection';
+import { MarketingHero } from './MarketingHero';
+import { Header } from './layout/Header';
+
+describe('marketing CTA routing', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network disabled in unit test')));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('routes product-access CTAs to the canonical /app entry point', () => {
+    render(
+      <>
+        <MarketingHero />
+        <HeroSection />
+        <CtaBannerSection />
+        <IntegrationsCtaSection />
+      </>
+    );
+
+    expect(siteLinks.getStarted).toBe('/app');
+
+    const openAppLinks = screen.getAllByRole('link', { name: 'Open App' });
+    expect(openAppLinks).toHaveLength(4);
+    for (const link of openAppLinks) {
+      expect(link).toHaveAttribute('href', siteLinks.getStarted);
+    }
+  });
+
+  it('preserves docs and GitHub intent links while switching app-entry CTAs', () => {
+    render(<HeroSection />);
+
+    expect(screen.getByRole('link', { name: 'Star on GitHub' })).toHaveAttribute('href', siteLinks.starOnGithub);
+    expect(screen.getByRole('link', { name: /Self-host with Docker/i })).toHaveAttribute('href', siteLinks.quickstartDocker);
+    expect(screen.getByRole('link', { name: /Read the Docs/i })).toHaveAttribute('href', siteLinks.docs);
+  });
+
+  it('keeps explicit sign-in actions mapped to /app/login', () => {
+    render(
+      <MemoryRouter>
+        <Header
+          navLinks={[
+            { to: '/product', label: 'Product' },
+            { to: '/docs', label: 'Docs' }
+          ]}
+          githubRepo={siteLinks.github}
+          theme="dark"
+          onToggleTheme={() => undefined}
+        />
+      </MemoryRouter>
+    );
+
+    expect(siteLinks.signIn).toBe('/app/login');
+    expect(screen.getByRole('link', { name: 'Sign in' })).toHaveAttribute('href', siteLinks.signIn);
+  });
+});

--- a/web/src/siteConfig.ts
+++ b/web/src/siteConfig.ts
@@ -1,4 +1,6 @@
 export const siteLinks = {
+  app: '/app',
+  signIn: '/app/login',
   platform: '/product',
   useCases: '/solutions',
   solutions: '/solutions',
@@ -11,7 +13,7 @@ export const siteLinks = {
   discord: 'https://discord.gg/7jSUSnQC',
   starOnGithub: 'https://github.com/identrail/identrail',
   requestDemo: '/demo',
-  getStarted: 'https://github.com/identrail/identrail',
+  getStarted: '/app',
   watchDemo: '/demo',
   contribute: 'https://github.com/identrail/identrail/blob/dev/CONTRIBUTING.md',
   quickstartDocker: 'https://github.com/identrail/identrail/blob/dev/deploy/docker/README.md',


### PR DESCRIPTION
Fixes #623

## Summary

Standardized product-entry marketing CTAs to an auth-first flow by routing product-intent actions to `/app`, adding an explicit sign-in path mapping for `/app/login`, and updating CTA copy to clearly signal app entry.

## Why

Marketing CTAs were split between product entry and external destinations, which created inconsistent first-run behavior and lost auth context.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation

```bash
npm run test:ci --prefix web
npm run build --prefix web
```

Results summary:
- `test:ci`: pass (7 files, 41 tests)
- `build`: pass (includes prerender routes)

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: No
- Tools used: N/A
- Areas where used: N/A
- Human verification performed: local test/build checks and manual diff review

## Related Issues

- Fixes #623


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes marketing CTAs to an auth‑first app entry at `/app` and adds a clear sign-in route at `/app/login` to fix inconsistent first‑run behavior. Also updates CTA copy to “Open App” and adds tests to protect routing and post‑login redirects. Fixes #623.

- **Bug Fixes**
  - Route all product-intent CTAs to `/app` and relabel them as “Open App”.
  - Map `siteLinks.signIn` to `/app/login` and add a Header “Sign in” link.
  - Add tests for CTA routing and `next` redirect behavior.

<sup>Written for commit a9f7c552e3afcb48c62fdd61692fd7676f4aded7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

