### PR TITLE
fixes (#553): build workspace administration UI for members and roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## Unreleased
+- Added workspace administration UI in app shell:
+  - workspace switcher wired to `/v1/workspaces/active`
+  - member invite flow (`owner|admin|analyst|viewer` with invited/active lifecycle)
+  - inline role/status updates and member removal actions
+  - role-aware admin guardrails and workspace membership filters/search
+  - frontend/API tests covering member write/delete and workspace switching
 - Standardized product-entry marketing CTAs to the auth-first app flow:
   - switched canonical marketing app-entry destination to `/app`
   - added explicit `signIn` route mapping to `/app/login` in `siteLinks`

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -178,6 +178,289 @@ describe('App', () => {
     expect(await screen.findByText(/Project project-1 placeholder/i)).toBeInTheDocument();
   });
 
+  it('supports workspace member invite workflow from app shell administration route', async () => {
+    saveProductSession({
+      tenantID: 'default',
+      workspaceID: 'default'
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          principal: { type: 'subject', id: 'owner-user' },
+          roles: ['owner'],
+          scopes: ['read', 'write', 'admin'],
+          scope: { tenant_id: 'default', workspace_id: 'default' },
+          active_workspace: {
+            workspace: {
+              tenant_id: 'default',
+              workspace_id: 'default',
+              display_name: 'Default',
+              slug: 'default',
+              created_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-01T00:00:00Z'
+            },
+            member: {
+              tenant_id: 'default',
+              workspace_id: 'default',
+              member_id: 'member-owner-user',
+              user_id: 'owner-user',
+              email: 'owner@example.com',
+              role: 'owner',
+              status: 'active',
+              joined_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-01T00:00:00Z'
+            },
+            is_active: true
+          },
+          workspaces: [
+            {
+              workspace: {
+                tenant_id: 'default',
+                workspace_id: 'default',
+                display_name: 'Default',
+                slug: 'default',
+                created_at: '2026-01-01T00:00:00Z',
+                updated_at: '2026-01-01T00:00:00Z'
+              },
+              member: {
+                tenant_id: 'default',
+                workspace_id: 'default',
+                member_id: 'member-owner-user',
+                user_id: 'owner-user',
+                email: 'owner@example.com',
+                role: 'owner',
+                status: 'active',
+                joined_at: '2026-01-01T00:00:00Z',
+                updated_at: '2026-01-01T00:00:00Z'
+              },
+              is_active: true
+            }
+          ]
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [
+            {
+              tenant_id: 'default',
+              workspace_id: 'default',
+              member_id: 'member-owner-user',
+              user_id: 'owner-user',
+              email: 'owner@example.com',
+              role: 'owner',
+              status: 'active',
+              joined_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-01T00:00:00Z'
+            }
+          ]
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          member: {
+            tenant_id: 'default',
+            workspace_id: 'default',
+            member_id: 'member-analyst-example-com',
+            user_id: 'analyst@example.com',
+            email: 'analyst@example.com',
+            role: 'viewer',
+            status: 'invited',
+            joined_at: '2026-01-02T00:00:00Z',
+            updated_at: '2026-01-02T00:00:00Z'
+          }
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [
+            {
+              tenant_id: 'default',
+              workspace_id: 'default',
+              member_id: 'member-owner-user',
+              user_id: 'owner-user',
+              email: 'owner@example.com',
+              role: 'owner',
+              status: 'active',
+              joined_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-01T00:00:00Z'
+            },
+            {
+              tenant_id: 'default',
+              workspace_id: 'default',
+              member_id: 'member-analyst-example-com',
+              user_id: 'analyst@example.com',
+              email: 'analyst@example.com',
+              role: 'viewer',
+              status: 'invited',
+              joined_at: '2026-01-02T00:00:00Z',
+              updated_at: '2026-01-02T00:00:00Z'
+            }
+          ]
+        })
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    window.history.pushState({}, '', '/app/default/default/workspaces');
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { level: 2, name: /Members and roles/i })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('User ID'), { target: { value: 'analyst@example.com' } });
+    fireEvent.change(screen.getByLabelText('Email (optional)'), { target: { value: 'analyst@example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: /Invite member/i }));
+
+    await screen.findByText(/Member invitation saved/i);
+    expect(screen.getAllByText('analyst@example.com').length).toBeGreaterThan(0);
+
+    const inviteCall = fetchMock.mock.calls.find(([url, options]) => {
+      return typeof url === 'string' && url.includes('/v1/workspaces/default/members') && options?.method === 'POST';
+    });
+    expect(inviteCall).toBeDefined();
+  });
+
+  it('switches workspace context from workspaces admin route', async () => {
+    saveProductSession({
+      tenantID: 'default',
+      workspaceID: 'default'
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          principal: { type: 'subject', id: 'owner-user' },
+          roles: ['owner'],
+          scopes: ['read', 'write', 'admin'],
+          scope: { tenant_id: 'default', workspace_id: 'default' },
+          active_workspace: {
+            workspace: {
+              tenant_id: 'default',
+              workspace_id: 'default',
+              display_name: 'Default',
+              slug: 'default',
+              created_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-01T00:00:00Z'
+            },
+            member: {
+              tenant_id: 'default',
+              workspace_id: 'default',
+              member_id: 'member-owner-user',
+              user_id: 'owner-user',
+              email: 'owner@example.com',
+              role: 'owner',
+              status: 'active',
+              joined_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-01T00:00:00Z'
+            },
+            is_active: true
+          },
+          workspaces: [
+            {
+              workspace: {
+                tenant_id: 'default',
+                workspace_id: 'default',
+                display_name: 'Default',
+                slug: 'default',
+                created_at: '2026-01-01T00:00:00Z',
+                updated_at: '2026-01-01T00:00:00Z'
+              },
+              member: {
+                tenant_id: 'default',
+                workspace_id: 'default',
+                member_id: 'member-owner-user',
+                user_id: 'owner-user',
+                email: 'owner@example.com',
+                role: 'owner',
+                status: 'active',
+                joined_at: '2026-01-01T00:00:00Z',
+                updated_at: '2026-01-01T00:00:00Z'
+              },
+              is_active: true
+            },
+            {
+              workspace: {
+                tenant_id: 'default',
+                workspace_id: 'payments',
+                display_name: 'Payments',
+                slug: 'payments',
+                created_at: '2026-01-01T00:00:00Z',
+                updated_at: '2026-01-01T00:00:00Z'
+              },
+              member: {
+                tenant_id: 'default',
+                workspace_id: 'payments',
+                member_id: 'member-owner-user',
+                user_id: 'owner-user',
+                email: 'owner@example.com',
+                role: 'owner',
+                status: 'active',
+                joined_at: '2026-01-01T00:00:00Z',
+                updated_at: '2026-01-01T00:00:00Z'
+              },
+              is_active: false
+            }
+          ]
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ items: [] })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          active_workspace: {
+            workspace: {
+              tenant_id: 'default',
+              workspace_id: 'payments',
+              display_name: 'Payments',
+              slug: 'payments',
+              created_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-01T00:00:00Z'
+            },
+            member: {
+              tenant_id: 'default',
+              workspace_id: 'payments',
+              member_id: 'member-owner-user',
+              user_id: 'owner-user',
+              email: 'owner@example.com',
+              role: 'owner',
+              status: 'active',
+              joined_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-01T00:00:00Z'
+            },
+            is_active: true
+          },
+          scope: { tenant_id: 'default', workspace_id: 'payments' },
+          scope_headers: {
+            'X-Identrail-Tenant-ID': 'default',
+            'X-Identrail-Workspace-ID': 'payments'
+          }
+        })
+      })
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ items: [] })
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    window.history.pushState({}, '', '/app/default/default/workspaces');
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { level: 2, name: /Members and roles/i })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Workspace'), { target: { value: 'payments' } });
+    fireEvent.click(screen.getByRole('button', { name: /Switch workspace/i }));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/app/default/payments/workspaces');
+    });
+  });
+
   it('redirects expired oidc sessions to login with re-auth prompt', async () => {
     saveProductSession({
       tenantID: 'tenant-a',

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -143,4 +143,56 @@ describe('apiClient', () => {
     expect(options.method).toBe('PATCH');
     expect(options.body).toBe(JSON.stringify({ status: 'ack', assignee: 'platform', comment: 'acknowledged' }));
   });
+
+  it('posts workspace member invite/update payload and includes scoped headers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ member: { member_id: 'member-user-a' } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.upsertWorkspaceMember(
+      'workspace-a',
+      {
+        member_id: 'member-user-a',
+        user_id: 'user-a',
+        email: 'user-a@example.com',
+        role: 'admin',
+        status: 'active'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace-a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/v1/workspaces/workspace-a/members');
+    expect(options.method).toBe('POST');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace-a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
+  it('supports 204 no-content workspace member removal responses', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      json: async () => ({})
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      apiClient.deleteWorkspaceMember('workspace-a', 'member-a', {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace-a'
+      })
+    ).resolves.toBeUndefined();
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/v1/workspaces/workspace-a/members/member-a');
+    expect(options.method).toBe('DELETE');
+  });
 });

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -85,6 +85,51 @@ export type RequestAuthContext = {
   bearerToken?: string;
 };
 
+export type WorkspaceMemberRole = 'owner' | 'admin' | 'analyst' | 'viewer';
+export type WorkspaceMemberStatus = 'invited' | 'active' | 'suspended' | 'removed';
+
+export type WorkspaceRecord = {
+  tenant_id: string;
+  workspace_id: string;
+  display_name: string;
+  slug: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type WorkspaceMemberRecord = {
+  tenant_id: string;
+  workspace_id: string;
+  member_id: string;
+  user_id: string;
+  email?: string;
+  role: WorkspaceMemberRole;
+  status: WorkspaceMemberStatus;
+  joined_at: string;
+  updated_at: string;
+};
+
+export type WorkspaceContextSnapshot = {
+  workspace: WorkspaceRecord;
+  member?: WorkspaceMemberRecord;
+  is_active: boolean;
+};
+
+export type WhoAmIResponse = {
+  principal: {
+    type: 'subject' | 'api_key' | 'anonymous';
+    id: string;
+  };
+  roles: string[];
+  scopes: string[];
+  scope: {
+    tenant_id: string;
+    workspace_id: string;
+  };
+  active_workspace?: WorkspaceContextSnapshot;
+  workspaces: WorkspaceContextSnapshot[];
+};
+
 export type FindingLifecycleStatus = 'open' | 'ack' | 'suppressed' | 'resolved';
 
 export type LeadCapturePayload = {
@@ -201,6 +246,9 @@ async function request<T>(path: string, auth?: RequestAuthContext, init: Request
     }
     throw new Error(message);
   }
+  if (res.status === 204) {
+    return undefined as T;
+  }
   return (await res.json()) as T;
 }
 
@@ -215,6 +263,63 @@ function buildQuery(params: Record<string, string | number | undefined>): string
 }
 
 export const apiClient = {
+  getWhoAmI(auth?: RequestAuthContext) {
+    return request<WhoAmIResponse>('/v1/whoami', auth);
+  },
+  resolveActiveWorkspace(workspaceID: string, auth?: RequestAuthContext) {
+    return request<{
+      active_workspace: WorkspaceContextSnapshot;
+      scope: { tenant_id: string; workspace_id: string };
+      scope_headers: { 'X-Identrail-Tenant-ID': string; 'X-Identrail-Workspace-ID': string };
+    }>('/v1/workspaces/active', auth, {
+      method: 'POST',
+      body: JSON.stringify({ workspace_id: workspaceID })
+    });
+  },
+  listWorkspaceMembers(
+    workspaceID: string,
+    filters: {
+      role?: WorkspaceMemberRole;
+      status?: WorkspaceMemberStatus;
+      limit?: number;
+    } = {},
+    auth?: RequestAuthContext
+  ) {
+    const encodedWorkspaceID = encodeURIComponent(workspaceID);
+    return request<{ items: WorkspaceMemberRecord[] }>(
+      `/v1/workspaces/${encodedWorkspaceID}/members${buildQuery(filters)}`,
+      auth
+    );
+  },
+  upsertWorkspaceMember(
+    workspaceID: string,
+    payload: {
+      member_id: string;
+      user_id: string;
+      email?: string;
+      role: WorkspaceMemberRole;
+      status: WorkspaceMemberStatus;
+    },
+    auth?: RequestAuthContext
+  ) {
+    return request<{ member: WorkspaceMemberRecord }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/members`,
+      auth,
+      {
+        method: 'POST',
+        body: JSON.stringify(payload)
+      }
+    );
+  },
+  deleteWorkspaceMember(workspaceID: string, memberID: string, auth?: RequestAuthContext) {
+    return request<void>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/members/${encodeURIComponent(memberID)}`,
+      auth,
+      {
+        method: 'DELETE'
+      }
+    );
+  },
   getFindingsSummary(auth?: RequestAuthContext) {
     return request<FindingsSummary>('/v1/findings/summary', auth);
   },

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -670,13 +670,13 @@ function hasWorkspaceAdminAccess(scope: ProductSession, whoAmI: WhoAmIResponse |
     return false;
   }
   if (!whoAmI) {
-    return true;
+    return false;
   }
   const activeRole =
     whoAmI.active_workspace?.member?.role ??
     whoAmI.workspaces.find((item) => item.workspace.workspace_id === scope.workspaceID)?.member?.role;
   if (!activeRole) {
-    return true;
+    return false;
   }
   return activeRole === 'owner' || activeRole === 'admin';
 }

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1,5 +1,13 @@
 import { Component, FormEvent, ReactNode, useEffect, useMemo, useState } from 'react';
 import { Link, Navigate, NavLink, Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
+import {
+  apiClient,
+  type RequestAuthContext,
+  type WhoAmIResponse,
+  type WorkspaceMemberRecord,
+  type WorkspaceMemberRole,
+  type WorkspaceMemberStatus
+} from './api/client';
 
 type ProductSessionAuthMode = 'manual' | 'oidc';
 
@@ -625,6 +633,54 @@ function buildScopedPath(scope: ProductSession, suffix = ''): string {
   return suffix ? `${base}/${suffix}` : base;
 }
 
+const MEMBER_ROLE_OPTIONS: WorkspaceMemberRole[] = ['owner', 'admin', 'analyst', 'viewer'];
+const MEMBER_STATUS_OPTIONS: WorkspaceMemberStatus[] = ['invited', 'active', 'suspended', 'removed'];
+
+function buildProductAuthContext(scope: ProductSession): RequestAuthContext {
+  const session = readProductSession();
+  return {
+    tenantID: scope.tenantID,
+    workspaceID: scope.workspaceID,
+    bearerToken: session?.accessToken
+  };
+}
+
+function normalizeMemberID(value: string): string {
+  const normalized = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+  return normalized || 'member';
+}
+
+function deriveMemberID(userID: string, email: string): string {
+  const userToken = normalizeMemberID(userID);
+  const emailToken = normalizeMemberID(email.split('@')[0] ?? '');
+  const token = userToken || emailToken;
+  return token ? `member-${token}`.slice(0, 72) : `member-${Date.now()}`;
+}
+
+function hasWorkspaceAdminAccess(scope: ProductSession, whoAmI: WhoAmIResponse | null): boolean {
+  const fromSession = (readProductSession()?.roles ?? []).map((role) => role.toLowerCase());
+  if (fromSession.includes('owner') || fromSession.includes('admin')) {
+    return true;
+  }
+  if (fromSession.includes('viewer') || fromSession.includes('analyst')) {
+    return false;
+  }
+  if (!whoAmI) {
+    return true;
+  }
+  const activeRole =
+    whoAmI.active_workspace?.member?.role ??
+    whoAmI.workspaces.find((item) => item.workspace.workspace_id === scope.workspaceID)?.member?.role;
+  if (!activeRole) {
+    return true;
+  }
+  return activeRole === 'owner' || activeRole === 'admin';
+}
+
 function useScaffoldDataState(delayMS = 320) {
   const [loading, setLoading] = useState(true);
 
@@ -1132,8 +1188,542 @@ export function ProductOverviewPage() {
   );
 }
 
+type MemberDraftState = Record<
+  string,
+  {
+    role: WorkspaceMemberRole;
+    status: WorkspaceMemberStatus;
+  }
+>;
+
 export function ProductWorkspacesPage() {
-  return <ScopedShellPage title="Workspaces" description="Workspace lifecycle, membership, and scope boundaries will be managed from this route group." />;
+  const params = useParams<ScopeRouteParams>();
+  const navigate = useNavigate();
+  const scope = resolveScopeFromParams(params);
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+
+  const [whoAmI, setWhoAmI] = useState<WhoAmIResponse | null>(null);
+  const [members, setMembers] = useState<WorkspaceMemberRecord[]>([]);
+  const [memberDrafts, setMemberDrafts] = useState<MemberDraftState>({});
+
+  const [workspaceTarget, setWorkspaceTarget] = useState('');
+  const [switching, setSwitching] = useState(false);
+
+  const [memberSearch, setMemberSearch] = useState('');
+  const [memberRoleFilter, setMemberRoleFilter] = useState<'all' | WorkspaceMemberRole>('all');
+  const [memberStatusFilter, setMemberStatusFilter] = useState<'all' | WorkspaceMemberStatus>('all');
+
+  const [inviting, setInviting] = useState(false);
+  const [inviteInput, setInviteInput] = useState({
+    userID: '',
+    email: '',
+    role: 'viewer' as WorkspaceMemberRole,
+    status: 'invited' as WorkspaceMemberStatus
+  });
+
+  const [savingMemberID, setSavingMemberID] = useState('');
+  const [removingMemberID, setRemovingMemberID] = useState('');
+
+  const refreshMembers = async (targetScope: ProductSession) => {
+    const auth = buildProductAuthContext(targetScope);
+    const response = await apiClient.listWorkspaceMembers(targetScope.workspaceID, {}, auth);
+    setMembers(response.items);
+    setMemberDrafts(
+      response.items.reduce<MemberDraftState>((acc, member) => {
+        acc[member.member_id] = { role: member.role, status: member.status };
+        return acc;
+      }, {})
+    );
+  };
+
+  useEffect(() => {
+    if (!scope) {
+      setLoading(false);
+      setError('Workspace route context is missing.');
+      return;
+    }
+
+    let mounted = true;
+    const run = async () => {
+      setLoading(true);
+      setError('');
+      setSuccessMessage('');
+      try {
+        const auth = buildProductAuthContext(scope);
+        const snapshot = await apiClient.getWhoAmI(auth);
+        if (!mounted) {
+          return;
+        }
+        setWhoAmI(snapshot);
+        setWorkspaceTarget(snapshot.scope.workspace_id || scope.workspaceID);
+        await refreshMembers(scope);
+      } catch (requestError) {
+        if (!mounted) {
+          return;
+        }
+        const message = requestError instanceof Error ? requestError.message : 'Failed to load workspace administration data.';
+        setError(message);
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    };
+    void run();
+    return () => {
+      mounted = false;
+    };
+  }, [scope?.tenantID, scope?.workspaceID]);
+
+  if (!scope) {
+    return <AppShellLoading message="Resolving workspace scope" />;
+  }
+
+  const canAdmin = hasWorkspaceAdminAccess(scope, whoAmI);
+  const roleCounts = members.reduce<Record<WorkspaceMemberRole, number>>(
+    (acc, member) => {
+      acc[member.role] += 1;
+      return acc;
+    },
+    { owner: 0, admin: 0, analyst: 0, viewer: 0 }
+  );
+
+  const activeCount = members.filter((member) => member.status === 'active').length;
+  const invitedCount = members.filter((member) => member.status === 'invited').length;
+  const filteredMembers = members.filter((member) => {
+    const search = normalizeValue(memberSearch).toLowerCase();
+    const matchesSearch =
+      search.length === 0 ||
+      member.user_id.toLowerCase().includes(search) ||
+      (member.email ?? '').toLowerCase().includes(search) ||
+      member.member_id.toLowerCase().includes(search);
+    const matchesRole = memberRoleFilter === 'all' || member.role === memberRoleFilter;
+    const matchesStatus = memberStatusFilter === 'all' || member.status === memberStatusFilter;
+    return matchesSearch && matchesRole && matchesStatus;
+  });
+
+  const handleSwitchWorkspace = async () => {
+    if (!workspaceTarget || workspaceTarget === scope.workspaceID) {
+      return;
+    }
+    setSwitching(true);
+    setError('');
+    setSuccessMessage('');
+    try {
+      const auth = buildProductAuthContext(scope);
+      const response = await apiClient.resolveActiveWorkspace(workspaceTarget, auth);
+      const switchedScope: ProductSession = {
+        ...scope,
+        tenantID: response.scope.tenant_id,
+        workspaceID: response.scope.workspace_id
+      };
+      const current = readProductSession();
+      if (current) {
+        saveProductSession({
+          ...current,
+          tenantID: switchedScope.tenantID,
+          workspaceID: switchedScope.workspaceID
+        });
+      }
+      navigate(buildScopedPath(switchedScope, 'workspaces'), { replace: true });
+    } catch (switchError) {
+      const message = switchError instanceof Error ? switchError.message : 'Failed to switch workspace.';
+      setError(message);
+    } finally {
+      setSwitching(false);
+    }
+  };
+
+  const handleInviteMember = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canAdmin) {
+      return;
+    }
+    setInviting(true);
+    setError('');
+    setSuccessMessage('');
+    try {
+      const userID = normalizeValue(inviteInput.userID);
+      const email = normalizeValue(inviteInput.email);
+      if (!userID) {
+        throw new Error('User ID is required.');
+      }
+      const auth = buildProductAuthContext(scope);
+      await apiClient.upsertWorkspaceMember(
+        scope.workspaceID,
+        {
+          member_id: deriveMemberID(userID, email),
+          user_id: userID,
+          email: email || undefined,
+          role: inviteInput.role,
+          status: inviteInput.status
+        },
+        auth
+      );
+      await refreshMembers(scope);
+      setInviteInput({
+        userID: '',
+        email: '',
+        role: 'viewer',
+        status: 'invited'
+      });
+      setSuccessMessage('Member invitation saved.');
+    } catch (inviteError) {
+      const message = inviteError instanceof Error ? inviteError.message : 'Failed to invite member.';
+      setError(message);
+    } finally {
+      setInviting(false);
+    }
+  };
+
+  const handleSaveMember = async (member: WorkspaceMemberRecord) => {
+    if (!canAdmin) {
+      return;
+    }
+    const draft = memberDrafts[member.member_id];
+    if (!draft) {
+      return;
+    }
+    setSavingMemberID(member.member_id);
+    setError('');
+    setSuccessMessage('');
+    try {
+      const auth = buildProductAuthContext(scope);
+      await apiClient.upsertWorkspaceMember(
+        scope.workspaceID,
+        {
+          member_id: member.member_id,
+          user_id: member.user_id,
+          email: member.email,
+          role: draft.role,
+          status: draft.status
+        },
+        auth
+      );
+      await refreshMembers(scope);
+      setSuccessMessage(`Updated ${member.user_id}.`);
+    } catch (saveError) {
+      const message = saveError instanceof Error ? saveError.message : 'Failed to update member.';
+      setError(message);
+    } finally {
+      setSavingMemberID('');
+    }
+  };
+
+  const handleRemoveMember = async (member: WorkspaceMemberRecord) => {
+    if (!canAdmin) {
+      return;
+    }
+    const shouldRemove = window.confirm(`Remove ${member.user_id} from workspace ${scope.workspaceID}?`);
+    if (!shouldRemove) {
+      return;
+    }
+    setRemovingMemberID(member.member_id);
+    setError('');
+    setSuccessMessage('');
+    try {
+      const auth = buildProductAuthContext(scope);
+      await apiClient.deleteWorkspaceMember(scope.workspaceID, member.member_id, auth);
+      await refreshMembers(scope);
+      setSuccessMessage(`Removed ${member.user_id} from workspace.`);
+    } catch (removeError) {
+      const message = removeError instanceof Error ? removeError.message : 'Failed to remove member.';
+      setError(message);
+    } finally {
+      setRemovingMemberID('');
+    }
+  };
+
+  if (loading) {
+    return <AppShellLoading message="Loading workspace administration" />;
+  }
+
+  const availableWorkspaces = whoAmI?.workspaces ?? [];
+
+  return (
+    <section className="idt-app-panel idt-workspace-admin">
+      <p className="idt-app-kicker">Workspace administration</p>
+      <h2>Members and roles</h2>
+      <p>Invite members, update roles instantly, and switch active workspace scope without leaving the app shell.</p>
+
+      {error ? (
+        <p role="alert" className="idt-app-alert idt-app-alert-error">
+          {error}
+        </p>
+      ) : null}
+      {successMessage ? (
+        <p role="status" className="idt-app-alert idt-app-alert-success">
+          {successMessage}
+        </p>
+      ) : null}
+      {!canAdmin ? (
+        <p className="idt-app-alert">
+          You currently have read-only tenancy access. Ask a workspace owner/admin to grant elevated role access.
+        </p>
+      ) : null}
+
+      <div className="idt-workspace-stats" aria-label="workspace membership summary">
+        <article>
+          <h3>{members.length}</h3>
+          <p>Total members</p>
+        </article>
+        <article>
+          <h3>{activeCount}</h3>
+          <p>Active</p>
+        </article>
+        <article>
+          <h3>{invitedCount}</h3>
+          <p>Invited</p>
+        </article>
+        <article>
+          <h3>{roleCounts.owner + roleCounts.admin}</h3>
+          <p>Privileged roles</p>
+        </article>
+      </div>
+
+      <div className="idt-workspace-admin-grid">
+        <article className="idt-app-empty-state">
+          <h3>Switch active workspace</h3>
+          <p>Change context to another workspace you can access.</p>
+          <div className="idt-workspace-switcher">
+            <label htmlFor="workspace-switch-select">Workspace</label>
+            <select
+              id="workspace-switch-select"
+              value={workspaceTarget}
+              onChange={(event) => setWorkspaceTarget(event.target.value)}
+            >
+              {[...availableWorkspaces]
+                .sort((a, b) => a.workspace.display_name.localeCompare(b.workspace.display_name))
+                .map((item) => (
+                  <option key={item.workspace.workspace_id} value={item.workspace.workspace_id}>
+                    {item.workspace.display_name} ({item.workspace.workspace_id})
+                  </option>
+                ))}
+            </select>
+            <button
+              type="button"
+              className="idt-btn idt-btn-ghost"
+              onClick={() => {
+                void handleSwitchWorkspace();
+              }}
+              disabled={switching || workspaceTarget === scope.workspaceID}
+            >
+              {switching ? 'Switching...' : 'Switch workspace'}
+            </button>
+          </div>
+        </article>
+
+        <article className="idt-app-empty-state">
+          <h3>Invite member</h3>
+          <form className="idt-app-form" onSubmit={handleInviteMember}>
+            <label>
+              User ID
+              <input
+                value={inviteInput.userID}
+                onChange={(event) => setInviteInput((current) => ({ ...current, userID: event.target.value }))}
+                placeholder="engineer@example.com"
+                disabled={!canAdmin || inviting}
+                required
+              />
+            </label>
+            <label>
+              Email (optional)
+              <input
+                type="email"
+                value={inviteInput.email}
+                onChange={(event) => setInviteInput((current) => ({ ...current, email: event.target.value }))}
+                placeholder="engineer@example.com"
+                disabled={!canAdmin || inviting}
+              />
+            </label>
+            <div className="idt-workspace-inline-fields">
+              <label>
+                Role
+                <select
+                  value={inviteInput.role}
+                  onChange={(event) =>
+                    setInviteInput((current) => ({ ...current, role: event.target.value as WorkspaceMemberRole }))
+                  }
+                  disabled={!canAdmin || inviting}
+                >
+                  {MEMBER_ROLE_OPTIONS.map((role) => (
+                    <option key={role} value={role}>
+                      {role}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Status
+                <select
+                  value={inviteInput.status}
+                  onChange={(event) =>
+                    setInviteInput((current) => ({ ...current, status: event.target.value as WorkspaceMemberStatus }))
+                  }
+                  disabled={!canAdmin || inviting}
+                >
+                  {MEMBER_STATUS_OPTIONS.map((status) => (
+                    <option key={status} value={status}>
+                      {status}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            <button className="idt-btn idt-btn-primary" type="submit" disabled={!canAdmin || inviting}>
+              {inviting ? 'Saving...' : 'Invite member'}
+            </button>
+          </form>
+        </article>
+      </div>
+
+      <div className="idt-workspace-member-toolbar">
+        <label>
+          Search
+          <input
+            value={memberSearch}
+            onChange={(event) => setMemberSearch(event.target.value)}
+            placeholder="user id, email, or member id"
+          />
+        </label>
+        <label>
+          Role
+          <select
+            value={memberRoleFilter}
+            onChange={(event) => setMemberRoleFilter(event.target.value as 'all' | WorkspaceMemberRole)}
+          >
+            <option value="all">all</option>
+            {MEMBER_ROLE_OPTIONS.map((role) => (
+              <option key={role} value={role}>
+                {role}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Status
+          <select
+            value={memberStatusFilter}
+            onChange={(event) => setMemberStatusFilter(event.target.value as 'all' | WorkspaceMemberStatus)}
+          >
+            <option value="all">all</option>
+            {MEMBER_STATUS_OPTIONS.map((status) => (
+              <option key={status} value={status}>
+                {status}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div className="idt-workspace-table-wrap">
+        <table className="idt-workspace-table">
+          <thead>
+            <tr>
+              <th>User</th>
+              <th>Member ID</th>
+              <th>Role</th>
+              <th>Status</th>
+              <th>Last updated</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredMembers.map((member) => {
+              const draft = memberDrafts[member.member_id] ?? { role: member.role, status: member.status };
+              const dirty = draft.role !== member.role || draft.status !== member.status;
+              return (
+                <tr key={member.member_id}>
+                  <td>
+                    <strong>{member.user_id}</strong>
+                    {member.email ? <span>{member.email}</span> : null}
+                  </td>
+                  <td>{member.member_id}</td>
+                  <td>
+                    <select
+                      value={draft.role}
+                      onChange={(event) =>
+                        setMemberDrafts((current) => ({
+                          ...current,
+                          [member.member_id]: {
+                            role: event.target.value as WorkspaceMemberRole,
+                            status: current[member.member_id]?.status ?? member.status
+                          }
+                        }))
+                      }
+                      disabled={!canAdmin}
+                    >
+                      {MEMBER_ROLE_OPTIONS.map((role) => (
+                        <option key={role} value={role}>
+                          {role}
+                        </option>
+                      ))}
+                    </select>
+                  </td>
+                  <td>
+                    <select
+                      value={draft.status}
+                      onChange={(event) =>
+                        setMemberDrafts((current) => ({
+                          ...current,
+                          [member.member_id]: {
+                            role: current[member.member_id]?.role ?? member.role,
+                            status: event.target.value as WorkspaceMemberStatus
+                          }
+                        }))
+                      }
+                      disabled={!canAdmin}
+                    >
+                      {MEMBER_STATUS_OPTIONS.map((status) => (
+                        <option key={status} value={status}>
+                          {status}
+                        </option>
+                      ))}
+                    </select>
+                  </td>
+                  <td>{new Date(member.updated_at).toLocaleString()}</td>
+                  <td>
+                    <div className="idt-workspace-actions">
+                      <button
+                        type="button"
+                        className="idt-btn idt-btn-ghost"
+                        onClick={() => {
+                          void handleSaveMember(member);
+                        }}
+                        disabled={!canAdmin || !dirty || savingMemberID === member.member_id}
+                      >
+                        {savingMemberID === member.member_id ? 'Saving...' : 'Save'}
+                      </button>
+                      <button
+                        type="button"
+                        className="idt-btn idt-btn-dark"
+                        onClick={() => {
+                          void handleRemoveMember(member);
+                        }}
+                        disabled={!canAdmin || removingMemberID === member.member_id}
+                      >
+                        {removingMemberID === member.member_id ? 'Removing...' : 'Remove'}
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {filteredMembers.length === 0 ? (
+        <AppShellEmptyState
+          title="No members match this filter"
+          body="Try adjusting role/status filters or invite a new workspace member."
+        />
+      ) : null}
+    </section>
+  );
 }
 
 export function ProductProjectsPage() {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4235,6 +4235,154 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   background: rgba(11, 18, 31, 0.72);
 }
 
+.idt-app-alert {
+  border-radius: 0.55rem;
+  border: 1px solid rgba(130, 160, 214, 0.34);
+  background: rgba(12, 20, 33, 0.72);
+  color: #d7e6ff;
+  padding: 0.55rem 0.7rem;
+}
+
+.idt-app-alert-error {
+  border-color: rgba(220, 129, 129, 0.44);
+  color: #ffd0d0;
+}
+
+.idt-app-alert-success {
+  border-color: rgba(137, 204, 156, 0.46);
+  color: #d7ffdf;
+}
+
+.idt-workspace-admin {
+  display: grid;
+  gap: 1rem;
+}
+
+.idt-workspace-stats {
+  display: grid;
+  gap: 0.7rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.idt-workspace-stats article {
+  border: 1px solid rgba(130, 160, 214, 0.28);
+  border-radius: 0.7rem;
+  padding: 0.75rem;
+  background: rgba(8, 14, 25, 0.5);
+}
+
+.idt-workspace-stats h3 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.idt-workspace-stats p {
+  margin: 0.2rem 0 0;
+  color: #c2d4f0;
+}
+
+.idt-workspace-admin-grid {
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.idt-workspace-switcher {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.idt-workspace-switcher label,
+.idt-workspace-member-toolbar label,
+.idt-workspace-inline-fields label {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.idt-workspace-switcher select,
+.idt-workspace-inline-fields select,
+.idt-workspace-member-toolbar select,
+.idt-workspace-member-toolbar input,
+.idt-workspace-table select {
+  border: 1px solid rgba(126, 157, 211, 0.35);
+  border-radius: 0.55rem;
+  background: rgba(9, 15, 26, 0.84);
+  color: #e4efff;
+  padding: 0.5rem 0.6rem;
+}
+
+.idt-workspace-inline-fields {
+  display: grid;
+  gap: 0.7rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.idt-workspace-member-toolbar {
+  display: grid;
+  gap: 0.7rem;
+  grid-template-columns: 2fr 1fr 1fr;
+}
+
+.idt-workspace-table-wrap {
+  overflow-x: auto;
+  border: 1px solid rgba(130, 160, 214, 0.28);
+  border-radius: 0.7rem;
+}
+
+.idt-workspace-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 760px;
+}
+
+.idt-workspace-table th,
+.idt-workspace-table td {
+  text-align: left;
+  padding: 0.62rem 0.68rem;
+  border-bottom: 1px solid rgba(130, 160, 214, 0.2);
+}
+
+.idt-workspace-table th {
+  color: #9fb8de;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.idt-workspace-table td {
+  vertical-align: middle;
+}
+
+.idt-workspace-table td span {
+  display: block;
+  color: #adbfdd;
+  font-size: 0.84rem;
+}
+
+.idt-workspace-actions {
+  display: inline-flex;
+  gap: 0.4rem;
+}
+
+@media (max-width: 980px) {
+  .idt-workspace-stats,
+  .idt-workspace-admin-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .idt-workspace-member-toolbar {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .idt-workspace-stats,
+  .idt-workspace-admin-grid,
+  .idt-workspace-inline-fields {
+    grid-template-columns: 1fr;
+  }
+}
+
 html[data-theme='light'] .idt-app-shell-header,
 html[data-theme='light'] .idt-app-panel {
   background: linear-gradient(165deg, rgba(252, 254, 255, 0.98), rgba(243, 249, 255, 0.94));
@@ -4270,4 +4418,51 @@ html[data-theme='light'] .idt-app-form input {
 html[data-theme='light'] .idt-app-empty-state {
   background: rgba(239, 246, 255, 0.93);
   border-color: rgba(42, 71, 119, 0.32);
+}
+
+html[data-theme='light'] .idt-app-alert {
+  background: rgba(236, 245, 255, 0.96);
+  border-color: rgba(42, 71, 119, 0.27);
+  color: #15345e;
+}
+
+html[data-theme='light'] .idt-app-alert-error {
+  border-color: rgba(186, 71, 71, 0.35);
+  color: #7e1f1f;
+}
+
+html[data-theme='light'] .idt-app-alert-success {
+  border-color: rgba(44, 122, 70, 0.35);
+  color: #1e5a31;
+}
+
+html[data-theme='light'] .idt-workspace-stats article {
+  background: rgba(245, 250, 255, 0.95);
+  border-color: rgba(42, 71, 119, 0.24);
+}
+
+html[data-theme='light'] .idt-workspace-stats p {
+  color: #35598d;
+}
+
+html[data-theme='light'] .idt-workspace-switcher select,
+html[data-theme='light'] .idt-workspace-inline-fields select,
+html[data-theme='light'] .idt-workspace-member-toolbar select,
+html[data-theme='light'] .idt-workspace-member-toolbar input,
+html[data-theme='light'] .idt-workspace-table select {
+  color: #1c355d;
+  background: #ffffff;
+  border-color: rgba(42, 71, 119, 0.32);
+}
+
+html[data-theme='light'] .idt-workspace-table-wrap {
+  border-color: rgba(42, 71, 119, 0.27);
+}
+
+html[data-theme='light'] .idt-workspace-table th {
+  color: #385f95;
+}
+
+html[data-theme='light'] .idt-workspace-table td span {
+  color: #5a78a6;
 }


### PR DESCRIPTION
Fixes #553

## Summary

Implemented a full workspace administration UI inside the app shell so owners/admins can manage membership and workspace context without CLI/API-only workflows.

What was added:
- Workspace switcher wired to `POST /v1/workspaces/active`.
- Workspace member management wired to tenancy APIs:
  - Invite member
  - Update role/status inline
  - Remove member
- Role-aware UI guardrails:
  - Owners/admins get write controls
  - Viewer/analyst users get read-only messaging
- Stronger UX and operability:
  - Member search/filter (role/status)
  - Membership summary cards (total, active, invited, privileged)
  - Confirmation prompt before member removal
- Client API support for tenancy routes and `204` delete responses.

## Why

Issue #553 identifies a launch-critical gap: membership and role administration was not available in product UI. This change closes that gap and aligns app-shell workflows with backend tenancy capabilities already present.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation

```bash
npm run test:ci --prefix web
npm run build --prefix web
```

Validation results:
- `web` tests: pass (`45 passed`)
- `web` build + prerender: pass

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: No
- Tools used: N/A
- Areas where used: N/A
- Human verification performed: local test/build execution, manual code and diff review

## Related Issues

- Fixes #553

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Built a workspace administration UI in the app shell so owners/admins can manage members and switch active workspaces without CLI/API. Fixes #553.

- **New Features**
  - Workspace switcher posts to `/v1/workspaces/active`, persists scope, and updates the app path.
  - Member management: invite, inline role/status updates (`invited|active|suspended|removed`), and removal (supports `204`).
  - Role-aware guardrails for owners/admins; viewers/analysts see read-only messaging.
  - Member tools: search, role/status filters, summary cards, success/error alerts, and removal confirmation.
  - API client and tests: `getWhoAmI`, `resolveActiveWorkspace`, `listWorkspaceMembers`, `upsertWorkspaceMember`, `deleteWorkspaceMember` with scoped headers; app and client tests cover switching and member flows.

<sup>Written for commit 626a4a299e2232164ec269602afab85042782993. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

