### PR TITLE
fixes (#554): add connector state and scan policy migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## Unreleased
+- Added tenancy persistence migrations for connector and automation policy state:
+  - new scoped tables for `tenancy_connectors`, `tenancy_connector_states`, and `tenancy_scan_policies`
+  - enforced foreign-key integrity from connectors/policies to tenancy projects and connector-state to connector rows
+  - added connector secret metadata reference fields (`secret_provider`, `secret_ref_id`, `secret_ref_version`) without storing raw secrets
+  - added scope-aware indexes for connector health/sync state and policy trigger scheduling queries
 - Standardized product-entry marketing CTAs to the auth-first app flow:
   - switched canonical marketing app-entry destination to `/app`
   - added explicit `signIn` route mapping to `/app/login` in `siteLinks`

--- a/docs/domain-entities.md
+++ b/docs/domain-entities.md
@@ -61,3 +61,17 @@ This document defines the normalized multi-tenant app-mode entities introduced f
 - Validation and transition tests live in:
   - `internal/domain/appmode_test.go`
   - `internal/domain/json_tags_test.go`
+
+## Persistence Mapping
+
+- Tenancy core tables:
+  - `tenancy_organizations`
+  - `tenancy_workspaces`
+  - `tenancy_workspace_members`
+  - `tenancy_projects`
+- Connector and policy tables:
+  - `tenancy_connectors`
+  - `tenancy_connector_states`
+  - `tenancy_scan_policies`
+
+Referential integrity is enforced in migrations so connector/policy rows cannot outlive their workspace/project scope.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -57,6 +57,7 @@ Current sequence in `migrations/`:
 11. `000010_authz_policy_lifecycle_controls` - policy lifecycle primitives
 12. `000011_authz_policy_rollout_staged_controls` - staged rollout controls
 13. `000012_tenancy_core_entities` - organization/workspace/member/project tenancy core
+14. `000013_connectors_state_scan_policies` - connector instances, connector runtime state, and scan policy persistence with scoped foreign-key integrity
 
 Notes:
 - Each migration has matching `.up.sql` and `.down.sql` files.

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -239,3 +239,31 @@ func TestTwelfthMigrationContainsTenancyCoreTables(t *testing.T) {
 		}
 	}
 }
+
+func TestThirteenthMigrationContainsConnectorAndPolicyTables(t *testing.T) {
+	path := filepath.Join("..", "..", "migrations", "000013_connectors_state_scan_policies.up.sql")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	text := string(content)
+	required := []string{
+		"CREATE TABLE IF NOT EXISTS tenancy_connectors",
+		"CREATE TABLE IF NOT EXISTS tenancy_connector_states",
+		"CREATE TABLE IF NOT EXISTS tenancy_scan_policies",
+		"FOREIGN KEY (tenant_id, workspace_id, project_id)",
+		"REFERENCES tenancy_projects(tenant_id, workspace_id, project_id)",
+		"REFERENCES tenancy_connectors(tenant_id, workspace_id, project_id, connector_id)",
+		"CHECK (type IN ('github', 'aws', 'kubernetes'))",
+		"CHECK (trigger_mode IN ('manual', 'scheduled', 'event', 'hybrid'))",
+		"CHECK (max_concurrent_scans > 0)",
+		"idx_tenancy_connectors_scope_status",
+		"idx_tenancy_connector_states_scope_health",
+		"idx_tenancy_scan_policies_scope_mode_enabled",
+	}
+	for _, item := range required {
+		if !strings.Contains(text, item) {
+			t.Fatalf("expected connector/policy migration item %q", item)
+		}
+	}
+}

--- a/migrations/000013_connectors_state_scan_policies.down.sql
+++ b/migrations/000013_connectors_state_scan_policies.down.sql
@@ -1,0 +1,9 @@
+DROP INDEX IF EXISTS idx_tenancy_scan_policies_scope_updated;
+DROP INDEX IF EXISTS idx_tenancy_scan_policies_scope_mode_enabled;
+DROP INDEX IF EXISTS idx_tenancy_connector_states_scope_health;
+DROP INDEX IF EXISTS idx_tenancy_connectors_scope_sync;
+DROP INDEX IF EXISTS idx_tenancy_connectors_scope_status;
+
+DROP TABLE IF EXISTS tenancy_scan_policies;
+DROP TABLE IF EXISTS tenancy_connector_states;
+DROP TABLE IF EXISTS tenancy_connectors;

--- a/migrations/000013_connectors_state_scan_policies.up.sql
+++ b/migrations/000013_connectors_state_scan_policies.up.sql
@@ -26,8 +26,7 @@ CREATE TABLE IF NOT EXISTS tenancy_connectors (
     CHECK (secret_provider IS NULL OR LENGTH(TRIM(secret_provider)) > 0),
     CHECK (secret_ref_id IS NULL OR LENGTH(TRIM(secret_ref_id)) > 0),
     CHECK (
-        secret_provider IS NULL
-        OR (secret_ref_id IS NOT NULL AND LENGTH(TRIM(secret_ref_id)) > 0)
+        (secret_provider IS NULL) = (secret_ref_id IS NULL)
     )
 );
 

--- a/migrations/000013_connectors_state_scan_policies.up.sql
+++ b/migrations/000013_connectors_state_scan_policies.up.sql
@@ -1,0 +1,95 @@
+CREATE TABLE IF NOT EXISTS tenancy_connectors (
+    tenant_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    connector_id TEXT NOT NULL,
+    type TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    secret_provider TEXT,
+    secret_ref_id TEXT,
+    secret_ref_version TEXT,
+    secret_last_rotated_at TIMESTAMPTZ,
+    config_checksum TEXT,
+    last_sync_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, workspace_id, project_id, connector_id),
+    UNIQUE (tenant_id, workspace_id, project_id, type, display_name),
+    FOREIGN KEY (tenant_id, workspace_id, project_id)
+        REFERENCES tenancy_projects(tenant_id, workspace_id, project_id)
+        ON DELETE CASCADE,
+    CHECK (LENGTH(TRIM(connector_id)) > 0),
+    CHECK (LENGTH(TRIM(display_name)) > 0),
+    CHECK (type IN ('github', 'aws', 'kubernetes')),
+    CHECK (status IN ('pending', 'active', 'degraded', 'disconnected')),
+    CHECK (secret_provider IS NULL OR LENGTH(TRIM(secret_provider)) > 0),
+    CHECK (secret_ref_id IS NULL OR LENGTH(TRIM(secret_ref_id)) > 0),
+    CHECK (
+        secret_provider IS NULL
+        OR (secret_ref_id IS NOT NULL AND LENGTH(TRIM(secret_ref_id)) > 0)
+    )
+);
+
+CREATE TABLE IF NOT EXISTS tenancy_connector_states (
+    tenant_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    connector_id TEXT NOT NULL,
+    health_status TEXT NOT NULL DEFAULT 'unknown',
+    sync_cursor TEXT,
+    last_successful_sync_at TIMESTAMPTZ,
+    last_error_code TEXT,
+    last_error_message TEXT,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    observed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, workspace_id, project_id, connector_id),
+    FOREIGN KEY (tenant_id, workspace_id, project_id, connector_id)
+        REFERENCES tenancy_connectors(tenant_id, workspace_id, project_id, connector_id)
+        ON DELETE CASCADE,
+    CHECK (health_status IN ('unknown', 'healthy', 'warning', 'error')),
+    CHECK (jsonb_typeof(metadata) = 'object')
+);
+
+CREATE TABLE IF NOT EXISTS tenancy_scan_policies (
+    tenant_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    policy_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    trigger_mode TEXT NOT NULL DEFAULT 'manual',
+    cron TEXT,
+    max_concurrent_scans INTEGER NOT NULL DEFAULT 1,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, workspace_id, project_id, policy_id),
+    UNIQUE (tenant_id, workspace_id, project_id, name),
+    FOREIGN KEY (tenant_id, workspace_id, project_id)
+        REFERENCES tenancy_projects(tenant_id, workspace_id, project_id)
+        ON DELETE CASCADE,
+    CHECK (LENGTH(TRIM(policy_id)) > 0),
+    CHECK (LENGTH(TRIM(name)) > 0),
+    CHECK (trigger_mode IN ('manual', 'scheduled', 'event', 'hybrid')),
+    CHECK (max_concurrent_scans > 0),
+    CHECK (
+        trigger_mode NOT IN ('scheduled', 'hybrid')
+        OR (cron IS NOT NULL AND LENGTH(TRIM(cron)) > 0)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenancy_connectors_scope_status
+    ON tenancy_connectors (tenant_id, workspace_id, status, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_tenancy_connectors_scope_sync
+    ON tenancy_connectors (tenant_id, workspace_id, project_id, last_sync_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_tenancy_connector_states_scope_health
+    ON tenancy_connector_states (tenant_id, workspace_id, project_id, health_status, observed_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_tenancy_scan_policies_scope_mode_enabled
+    ON tenancy_scan_policies (tenant_id, workspace_id, project_id, trigger_mode, enabled);
+
+CREATE INDEX IF NOT EXISTS idx_tenancy_scan_policies_scope_updated
+    ON tenancy_scan_policies (tenant_id, workspace_id, project_id, updated_at DESC);


### PR DESCRIPTION
Fixes #554

## Summary

Implemented a dedicated migration pair for connector persistence, connector runtime state, and scan scheduling policy persistence with strict tenancy/project referential integrity.

What this adds:
- `tenancy_connectors` table for scoped connector instances.
- `tenancy_connector_states` table for connector health/sync runtime state.
- `tenancy_scan_policies` table for scoped automation scheduling policies.
- Secret metadata reference fields in connectors (`secret_provider`, `secret_ref_id`, `secret_ref_version`) without storing secret values.
- Targeted indexes for high-signal tenancy queries (status, sync, policy mode/enabled, updated recency).

## Why

Issue #554 requires durable connector and automation policy state with integrity constraints. This migration closes that gap and ensures connector/state/policy rows cannot become orphaned outside workspace/project boundaries.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation

```bash
go test ./internal/db/...
go test ./internal/api/...
go test ./internal/domain/...
```

Results summary:
- All listed test suites passed.
- Migration contract test now validates presence of new connector/state/policy tables and integrity/index clauses.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: No
- Tools used: N/A
- Areas where used: N/A
- Human verification performed: local package tests and manual migration/schema review

## Related Issues

- Fixes #554

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tenant-scoped migrations for connectors, connector runtime state, and scan scheduling policies with strict workspace/project integrity. Fixes #554 by persisting durable state and adding unique constraints and targeted indexes for fast scoped queries.

- **New Features**
  - New tables: `tenancy_connectors`, `tenancy_connector_states`, `tenancy_scan_policies`.
  - Scoped foreign keys with cascade deletes to `tenancy_projects` and `tenancy_connectors`.
  - Constraints: allowed connector types/status; trigger modes; cron required for scheduled/hybrid; positive concurrency.
  - Secret metadata (`secret_provider`, `secret_ref_id`, `secret_ref_version`) with both-or-neither rule; no raw secrets stored.
  - Unique constraints per project to prevent duplicate connectors/policies, plus scope-aware indexes for status, sync recency, health, mode/enabled, and updated timestamps.

<sup>Written for commit 661c0a39ab616499b340dc14518be9b4e9f00c05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

