### PR TITLE
[codex] redesign premium marketing homepage

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -39,7 +39,7 @@ describe('App', () => {
     expect(
       screen.getByRole('heading', {
         level: 1,
-        name: 'Identify risky machine trust paths before they become incidents.'
+        name: 'The control room for every machine identity path.'
       })
     ).toBeInTheDocument();
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Link, Navigate, Route, Routes, useLocation, useParams } 
 import { SafeLink } from './components/SafeLink';
 import { HeroProductReveal } from './components/home/HeroProductReveal';
 import { HowItWorksSection } from './components/home/HowItWorksSection';
+import { CommandCenterSection } from './components/home/CommandCenterSection';
 import { ProblemFramingSection } from './components/home/ProblemFramingSection';
 import { RiskInsightSection } from './components/home/RiskInsightSection';
 import { TrustProofStrip } from './components/home/TrustProofStrip';
@@ -970,10 +971,9 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
                 <g key={edge.id} className={edgeClass}>
                   <path className="idt-demo-edge-base" d={path} stroke={`url(#idt-demo-edge-base-gradient-${variant})`} />
                   <path
-                    className="idt-demo-edge-flow"
+                    className={`idt-demo-edge-flow idt-demo-edge-delay-${index}`}
                     d={path}
                     stroke={`url(#idt-demo-edge-flow-gradient-${variant})`}
-                    style={{ animationDelay: `${index * 0.35}s` }}
                   />
                   <circle className="idt-demo-edge-end" cx={toNode.x} cy={toNode.y} r={isConnected ? 0.72 : 0.56} />
                 </g>
@@ -984,9 +984,8 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
             <button
               key={node.id}
               type="button"
-              className={`idt-demo-node idt-demo-node-${node.type.toLowerCase()} ${selected.id === node.id ? 'is-active' : ''}`}
+              className={`idt-demo-node idt-demo-node-${node.type.toLowerCase()} idt-demo-node-${node.id} ${selected.id === node.id ? 'is-active' : ''}`}
               onClick={() => setSelectedId(node.id)}
-              style={{ left: `${node.x}%`, top: `${node.y}%` }}
             >
               <small>{node.type}</small>
               <span>{node.title}</span>
@@ -1353,9 +1352,9 @@ function FaqPage() {
 
 function HomePage() {
   const seo: SeoConfig = {
-    title: 'Machine Identity Security | AWS IAM Trust Path Analysis | Identrail',
+    title: 'Machine Identity Trust Graph | AWS IAM, Kubernetes, OIDC | Identrail',
     description:
-      'Identrail delivers machine identity security with AWS IAM trust path analysis, Kubernetes service account risk detection, OIDC security visibility, and cloud identity blast radius reduction.',
+      'Identrail is the trust graph for machine identity security across AWS IAM, Kubernetes, GitHub/OIDC, and repository exposure signals with read-only evidence and safe remediation.',
     path: '/',
     keywords:
       'machine identity security, AWS IAM trust path analysis, Kubernetes service account risk, OIDC security, cloud identity blast radius reduction, GitHub trust path risk',
@@ -1368,10 +1367,11 @@ function HomePage() {
       <section className="idt-hero">
         <div className="idt-shell idt-hero-grid">
           <div className="idt-hero-copy">
-            <p className="idt-eyebrow">Machine identity security</p>
-            <h1>Identify risky machine trust paths before they become incidents.</h1>
+            <p className="idt-eyebrow">Machine identity trust graph</p>
+            <h1>The control room for every machine identity path.</h1>
             <p className="idt-lead">
-              Trace how AWS IAM roles, Kubernetes service accounts, and GitHub/OIDC identities reach sensitive resources. Start read-only, inspect evidence, then roll out safer access with confidence.
+              Identrail maps how AWS IAM roles, Kubernetes service accounts, GitHub workflows, and OIDC claims reach
+              sensitive resources, then turns the evidence into safe, owner-ready remediation.
             </p>
             <div className="idt-inline-actions" data-ab-slot="hero_primary_cta">
               <a href="#risk-scan-form" className="idt-btn idt-btn-primary">
@@ -1381,6 +1381,20 @@ function HomePage() {
                 Book Demo
               </Link>
             </div>
+            <dl className="idt-hero-metrics" aria-label="Product assurances">
+              <div>
+                <dt>Collection</dt>
+                <dd>Read-only by default</dd>
+              </div>
+              <div>
+                <dt>Coverage</dt>
+                <dd>AWS, K8s, GitHub, OIDC</dd>
+              </div>
+              <div>
+                <dt>Output</dt>
+                <dd>Evidence and first fix</dd>
+              </div>
+            </dl>
             <ul className="idt-hero-trust-cues" aria-label="Evaluation trust cues">
               <li>Open-core under Apache-2.0</li>
               <li>Read-only onboarding model</li>
@@ -1395,6 +1409,8 @@ function HomePage() {
       <TrustProofStrip />
 
       <ProblemFramingSection />
+
+      <CommandCenterSection />
 
       <section className="idt-section idt-section-tight idt-shell">
         <LeadCaptureForm

--- a/web/src/components/TrustGraphIllustration.tsx
+++ b/web/src/components/TrustGraphIllustration.tsx
@@ -61,8 +61,7 @@ export function TrustGraphIllustration({ className, label }: TrustGraphIllustrat
       {nodes.map((node) => (
         <span
           key={node.id}
-          className={`trust-node ${node.tone}`}
-          style={{ left: `${node.x}%`, top: `${node.y}%` }}
+          className={`trust-node ${node.tone} trust-node-${node.id}`}
         >
           <span>{node.label}</span>
         </span>

--- a/web/src/components/home/CommandCenterSection.tsx
+++ b/web/src/components/home/CommandCenterSection.tsx
@@ -1,0 +1,146 @@
+import { useMemo, useState } from 'react';
+
+const COMMAND_VIEWS = [
+  {
+    id: 'triage',
+    label: 'Triage',
+    eyebrow: 'Exposure triage',
+    title: 'Turn scattered identity signals into one owner-ready queue.',
+    metricLabel: 'Primary risk path',
+    metricValue: 'Production database reachable',
+    secondaryLabel: 'Signal match',
+    secondaryValue: 'AWS role + K8s service account + OIDC claim drift',
+    confidence: 'High confidence',
+    evidence: [
+      'Trust policy allows broad workflow subject claims',
+      'ClusterRoleBinding grants namespace-spanning workload access',
+      'Reachable resource is tagged production and regulated'
+    ],
+    playbook: ['Confirm owner', 'Review evidence bundle', 'Prioritize first fix']
+  },
+  {
+    id: 'simulate',
+    label: 'Simulate',
+    eyebrow: 'Policy simulation',
+    title: 'Preview access hardening before anything changes in production.',
+    metricLabel: 'Projected breakage',
+    metricValue: 'No critical workload impact',
+    secondaryLabel: 'Recommended change',
+    secondaryValue: 'Scope OIDC subject claims and split shared platform role',
+    confidence: 'Simulation ready',
+    evidence: [
+      'No active workloads require the broad subject wildcard',
+      'Two service accounts can move to namespace-scoped bindings',
+      'Rollback path preserves current role until validation passes'
+    ],
+    playbook: ['Model policy change', 'Review affected workloads', 'Stage rollout']
+  },
+  {
+    id: 'report',
+    label: 'Report',
+    eyebrow: 'Executive report',
+    title: 'Package remediation progress for security, platform, and leadership.',
+    metricLabel: 'Risk narrative',
+    metricValue: 'Clear path from source to sensitive target',
+    secondaryLabel: 'Artifacts',
+    secondaryValue: 'Evidence export, timeline, owner notes, and residual risk',
+    confidence: 'Audit ready',
+    evidence: [
+      'Every finding keeps source system evidence attached',
+      'Owner handoff includes first action and expected outcome',
+      'Remediation timeline captures decisions and exceptions'
+    ],
+    playbook: ['Export packet', 'Share owner plan', 'Track closure']
+  }
+] as const;
+
+export function CommandCenterSection() {
+  const [activeViewId, setActiveViewId] = useState<(typeof COMMAND_VIEWS)[number]['id']>('triage');
+
+  const activeView = useMemo(
+    () => COMMAND_VIEWS.find((view) => view.id === activeViewId) ?? COMMAND_VIEWS[0],
+    [activeViewId]
+  );
+
+  return (
+    <section className="idt-section idt-command-center" aria-labelledby="command-center-title">
+      <div className="idt-shell idt-command-center-grid">
+        <div className="idt-command-copy">
+          <p className="idt-eyebrow">Trust operations layer</p>
+          <h2 id="command-center-title">A premium control room for machine identity risk.</h2>
+          <p>
+            Identrail gives security and platform teams the same operating picture: live trust paths, policy evidence,
+            blast-radius context, and a practical next step for each owner.
+          </p>
+
+          <div className="idt-command-tabs" role="tablist" aria-label="Command center views">
+            {COMMAND_VIEWS.map((view) => {
+              const isActive = view.id === activeView.id;
+              return (
+                <button
+                  key={view.id}
+                  id={`command-tab-${view.id}`}
+                  type="button"
+                  role="tab"
+                  aria-controls="command-panel"
+                  aria-selected={isActive}
+                  className={isActive ? 'is-active' : ''}
+                  onClick={() => setActiveViewId(view.id)}
+                >
+                  <span aria-hidden="true" />
+                  {view.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <article
+          id="command-panel"
+          className="idt-command-surface"
+          role="tabpanel"
+          aria-labelledby={`command-tab-${activeView.id}`}
+          aria-live="polite"
+        >
+          <div className="idt-command-surface-head">
+            <div>
+              <p>{activeView.eyebrow}</p>
+              <h3>{activeView.title}</h3>
+            </div>
+            <span>{activeView.confidence}</span>
+          </div>
+
+          <div className="idt-command-metrics" aria-label="Selected command center metrics">
+            <div>
+              <small>{activeView.metricLabel}</small>
+              <strong>{activeView.metricValue}</strong>
+            </div>
+            <div>
+              <small>{activeView.secondaryLabel}</small>
+              <strong>{activeView.secondaryValue}</strong>
+            </div>
+          </div>
+
+          <div className="idt-command-detail-grid">
+            <div>
+              <p className="idt-command-label">Evidence</p>
+              <ul className="idt-command-list">
+                {activeView.evidence.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <p className="idt-command-label">Operator playbook</p>
+              <ol className="idt-command-playbook">
+                {activeView.playbook.map((step) => (
+                  <li key={step}>{step}</li>
+                ))}
+              </ol>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/home/HeroProductReveal.tsx
+++ b/web/src/components/home/HeroProductReveal.tsx
@@ -209,15 +209,8 @@ export function HeroProductReveal() {
               <g key={`${scene.id}-${edge.from}-${edge.to}`}>
                 <path className={`idt-hero-arrow-base ${edge.emphasis === 'high' ? 'is-high' : ''}`} d={path} />
                 <path
-                  className={`idt-hero-arrow-flow ${edge.emphasis === 'high' ? 'is-high' : ''}`}
+                  className={`idt-hero-arrow-flow idt-hero-edge-delay-${edgeIndex} ${edge.emphasis === 'high' ? 'is-high' : ''}`}
                   d={path}
-                  style={
-                    reducedMotion
-                      ? undefined
-                      : ({
-                          animationDelay: `${edgeIndex * 0.42}s`
-                        } as const)
-                  }
                   filter={`url(#idt-edge-glow-${scene.id})`}
                 />
                 <circle
@@ -234,8 +227,7 @@ export function HeroProductReveal() {
         {scene.nodes.map((node) => (
           <div
             key={`${scene.id}-${node.id}`}
-            className={`idt-node idt-node-${node.tone}`}
-            style={{ left: `${node.x}%`, top: `${node.y}%` }}
+            className={`idt-node idt-node-${node.tone} idt-node-${scene.id}-${node.id}`}
           >
             {node.label}
           </div>

--- a/web/src/components/home/HowItWorksSection.tsx
+++ b/web/src/components/home/HowItWorksSection.tsx
@@ -1,21 +1,25 @@
 const WORKFLOW_STEPS = [
   {
-    title: '1. Discover trust relationships',
+    stage: 'Discover',
+    title: 'Build the trust graph',
     description: 'Collect AWS IAM, Kubernetes, GitHub, and OIDC identity metadata in read-only mode.',
     output: 'Output: identity graph snapshot with source evidence links'
   },
   {
-    title: '2. Prioritize reachable risk paths',
+    stage: 'Prioritize',
+    title: 'Rank reachable risk paths',
     description: 'Score findings by severity, privilege depth, and production blast-radius potential.',
     output: 'Output: ranked findings queue with owner-ready context'
   },
   {
-    title: '3. Simulate policy hardening',
+    stage: 'Simulate',
+    title: 'Preview hardening safely',
     description: 'Preview trust-policy changes and estimate affected workloads before enforcement.',
     output: 'Output: remediation plan with expected impact summary'
   },
   {
-    title: '4. Roll out with safety controls',
+    stage: 'Operate',
+    title: 'Roll out with controls',
     description: 'Deploy in stages with rollback options and track resolution outcomes.',
     output: 'Output: audit-ready remediation timeline and status history'
   }
@@ -31,8 +35,11 @@ export function HowItWorksSection() {
       </div>
 
       <ol className="idt-steps idt-workflow-track">
-        {WORKFLOW_STEPS.map((step) => (
+        {WORKFLOW_STEPS.map((step, index) => (
           <li key={step.title}>
+            <span className="idt-workflow-stage">
+              {String(index + 1).padStart(2, '0')} / {step.stage}
+            </span>
             <h3>{step.title}</h3>
             <p>{step.description}</p>
             <p className="idt-workflow-output">{step.output}</p>

--- a/web/src/components/home/ProblemFramingSection.tsx
+++ b/web/src/components/home/ProblemFramingSection.tsx
@@ -4,27 +4,47 @@ export function ProblemFramingSection() {
       <div className="idt-problem-frame-grid">
         <div>
           <p className="idt-eyebrow">Why teams miss machine identity risk</p>
-          <h2 id="problem-frame-title">Trust data is fragmented across cloud, cluster, and CI systems.</h2>
+          <h2 id="problem-frame-title">Cloud, cluster, and CI evidence rarely arrives as one story.</h2>
           <p>
-            IAM policies, Kubernetes RBAC, and OIDC workflow identities are usually reviewed in separate tools. Attack paths are not.
-            That gap is where overprivileged machine access survives into production.
+            IAM policies, Kubernetes RBAC, repository exposure, and OIDC workflow identities are reviewed in separate
+            tools. Attack paths are not. Identrail closes that gap by turning each signal into a connected trust path
+            with source evidence.
           </p>
         </div>
 
-        <div className="idt-problem-signals" role="list" aria-label="Fragmentation signals">
-          <article role="listitem">
-            <h3>AWS IAM in one console</h3>
-            <p>Role assumptions and cross-account trust are reviewed without Kubernetes or CI context.</p>
-          </article>
-          <article role="listitem">
-            <h3>Kubernetes RBAC in another</h3>
-            <p>Service account privilege drift is visible, but downstream cloud reachability remains opaque.</p>
-          </article>
-          <article role="listitem">
-            <h3>CI/OIDC evidence in logs</h3>
-            <p>Workflow identity misuse is discovered late because chain-level visibility is missing during review.</p>
-          </article>
+        <div className="idt-problem-map" aria-label="Identity signals converge into the Identrail trust graph">
+          <div className="idt-problem-map-source">
+            <span>AWS IAM</span>
+            <small>roles, policies, assumptions</small>
+          </div>
+          <div className="idt-problem-map-source">
+            <span>Kubernetes</span>
+            <small>service accounts, RBAC, namespaces</small>
+          </div>
+          <div className="idt-problem-map-source">
+            <span>GitHub/OIDC</span>
+            <small>workflow identity, claims, exposure</small>
+          </div>
+          <div className="idt-problem-map-core">
+            <span>Identrail trust graph</span>
+            <small>path evidence, blast radius, first safe fix</small>
+          </div>
         </div>
+      </div>
+
+      <div className="idt-problem-signals" role="list" aria-label="Fragmentation signals">
+        <article role="listitem">
+          <h3>Before: isolated alerts</h3>
+          <p>Each system can look acceptable on its own while the combined path is risky.</p>
+        </article>
+        <article role="listitem">
+          <h3>During: evidence stitching</h3>
+          <p>Read-only collection normalizes source evidence into a single chain from identity to resource.</p>
+        </article>
+        <article role="listitem">
+          <h3>After: safe remediation</h3>
+          <p>Owners receive the policy context, affected workload view, and first action to reduce blast radius.</p>
+        </article>
       </div>
     </section>
   );

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -77,7 +77,7 @@ export function Header({
           ))}
         </nav>
 
-        <div className="idt-header-actions">
+        <div className={`idt-header-actions ${menuOpen ? 'is-open' : ''}`}>
           <Link to="/read-only-scan" className="idt-btn idt-btn-primary" data-ab-slot="header_primary_cta">
             Start Free Risk Scan
           </Link>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4466,3 +4466,923 @@ html[data-theme='light'] .idt-workspace-table th {
 html[data-theme='light'] .idt-workspace-table td span {
   color: #5a78a6;
 }
+
+/* Premium homepage refresh */
+:root {
+  --idt-premium-ink: #050607;
+  --idt-premium-panel: #0c1012;
+  --idt-premium-panel-strong: #111717;
+  --idt-premium-line: rgba(229, 236, 222, 0.16);
+  --idt-premium-line-strong: rgba(229, 236, 222, 0.28);
+  --idt-premium-text: #f4f5ef;
+  --idt-premium-muted: #b6c1b6;
+  --idt-premium-mint: #b8f3d6;
+  --idt-premium-copper: #f1b36d;
+  --idt-premium-rose: #ff928c;
+  --idt-premium-sky: #a8c7ff;
+}
+
+body {
+  background:
+    linear-gradient(rgba(255, 255, 255, 0.026) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.022) 1px, transparent 1px),
+    linear-gradient(180deg, #050607 0%, #080b0c 44%, #0c1110 100%);
+  background-size: 56px 56px, 56px 56px, auto;
+}
+
+.idt-header {
+  background: rgba(5, 7, 8, 0.9);
+  border-bottom-color: rgba(229, 236, 222, 0.14);
+}
+
+.idt-nav a {
+  letter-spacing: 0.04em;
+}
+
+.idt-hero {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  padding: 4.6rem 0 3.4rem;
+  border-bottom: 1px solid rgba(229, 236, 222, 0.12);
+  background:
+    linear-gradient(115deg, rgba(184, 243, 214, 0.09), transparent 28%),
+    linear-gradient(160deg, rgba(241, 179, 109, 0.07), transparent 34%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.025), transparent 58%);
+}
+
+.idt-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background:
+    linear-gradient(90deg, rgba(229, 236, 222, 0.08) 1px, transparent 1px),
+    linear-gradient(rgba(229, 236, 222, 0.06) 1px, transparent 1px);
+  background-size: 84px 84px;
+  opacity: 0.16;
+}
+
+.idt-hero-grid {
+  grid-template-columns: minmax(0, 0.88fr) minmax(440px, 1.12fr);
+  align-items: center;
+}
+
+.idt-hero-copy h1 {
+  max-width: 13.5ch;
+  color: var(--idt-premium-text);
+  font-size: 4.95rem;
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.idt-lead {
+  max-width: 62ch;
+  color: rgba(230, 235, 225, 0.78);
+  font-size: 1.08rem;
+  line-height: 1.7;
+}
+
+.idt-hero-metrics {
+  margin: 1.35rem 0 0;
+  padding: 1rem 0 0;
+  border-top: 1px solid rgba(229, 236, 222, 0.15);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
+.idt-hero-metrics div {
+  min-width: 0;
+}
+
+.idt-hero-metrics dt {
+  color: rgba(184, 243, 214, 0.82);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.idt-hero-metrics dd {
+  margin: 0.2rem 0 0;
+  color: #f0f2eb;
+  font-size: 0.88rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.idt-hero-trust-cues li {
+  border-color: rgba(229, 236, 222, 0.18);
+  border-radius: 8px;
+  background: rgba(13, 18, 18, 0.72);
+  color: rgba(226, 232, 222, 0.76);
+}
+
+.idt-hero .idt-btn-primary {
+  background: #edf3e6;
+  color: #09100d;
+  border-color: #edf3e6;
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.28);
+}
+
+.idt-hero .idt-btn-dark {
+  background: rgba(12, 18, 18, 0.76);
+  border-color: rgba(229, 236, 222, 0.2);
+  color: #edf3e6;
+}
+
+.idt-graph-visual {
+  border-radius: 8px;
+  border-color: rgba(229, 236, 222, 0.18);
+  background:
+    linear-gradient(145deg, rgba(184, 243, 214, 0.08), transparent 34%),
+    linear-gradient(165deg, rgba(12, 17, 18, 0.98), rgba(6, 8, 9, 0.98));
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.36);
+}
+
+.idt-hero-graph-canvas {
+  border-radius: 8px;
+  border-color: rgba(229, 236, 222, 0.13);
+  background:
+    linear-gradient(160deg, rgba(184, 243, 214, 0.07), transparent 38%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0.015));
+}
+
+.idt-hero-graph-caption {
+  border-radius: 8px;
+  border-color: rgba(229, 236, 222, 0.18);
+  background: rgba(9, 13, 14, 0.94);
+}
+
+.idt-hero-graph-title,
+.idt-finding-label,
+.idt-command-label {
+  letter-spacing: 0.11em;
+}
+
+.idt-proof-architecture-list,
+.idt-problem-signals {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.idt-proof-architecture-item {
+  border-left-color: rgba(184, 243, 214, 0.3);
+}
+
+.idt-proof-link,
+.idt-inline-link {
+  color: var(--idt-premium-mint);
+}
+
+.idt-problem-frame {
+  padding-top: 4rem;
+}
+
+.idt-problem-frame-grid {
+  grid-template-columns: minmax(0, 0.84fr) minmax(420px, 1.16fr);
+  gap: 2rem;
+  align-items: center;
+}
+
+.idt-problem-frame h2,
+.idt-command-copy h2 {
+  max-width: 12ch;
+  color: #f3f5ee;
+  font-size: 3.2rem;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.idt-problem-frame p,
+.idt-command-copy p {
+  color: rgba(226, 233, 224, 0.76);
+}
+
+.idt-problem-map {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.65rem;
+  align-items: stretch;
+}
+
+.idt-problem-map::after {
+  content: '';
+  position: absolute;
+  left: 8%;
+  right: 8%;
+  top: calc(50% - 1px);
+  border-top: 1px solid rgba(184, 243, 214, 0.22);
+  pointer-events: none;
+}
+
+.idt-problem-map-source,
+.idt-problem-map-core {
+  position: relative;
+  z-index: 1;
+  min-height: 118px;
+  border: 1px solid rgba(229, 236, 222, 0.16);
+  border-radius: 8px;
+  background: rgba(10, 14, 15, 0.82);
+  padding: 0.9rem;
+  display: grid;
+  align-content: center;
+  gap: 0.3rem;
+}
+
+.idt-problem-map-core {
+  grid-column: 1 / -1;
+  min-height: 132px;
+  border-color: rgba(184, 243, 214, 0.38);
+  background:
+    linear-gradient(135deg, rgba(184, 243, 214, 0.13), transparent 45%),
+    rgba(11, 17, 16, 0.94);
+}
+
+.idt-problem-map-source span,
+.idt-problem-map-core span {
+  color: #f1f4ed;
+  font-size: 1rem;
+  font-weight: 800;
+}
+
+.idt-problem-map-source small,
+.idt-problem-map-core small {
+  color: rgba(213, 223, 211, 0.68);
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.idt-problem-signals {
+  margin-top: 1rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.idt-problem-signals article {
+  border-radius: 8px;
+  border-color: rgba(229, 236, 222, 0.14);
+  background: rgba(8, 12, 13, 0.7);
+  padding: 1rem;
+}
+
+.idt-problem-signals h3 {
+  color: #eff3e9;
+}
+
+.idt-command-center {
+  width: 100%;
+  padding: 4.6rem 0;
+  border-block: 1px solid rgba(229, 236, 222, 0.12);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0.008)),
+    #080b0b;
+}
+
+.idt-command-center-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.82fr) minmax(460px, 1.18fr);
+  gap: 2rem;
+  align-items: start;
+}
+
+.idt-command-copy {
+  display: grid;
+  gap: 1rem;
+}
+
+.idt-command-copy h2,
+.idt-command-copy p {
+  margin: 0;
+}
+
+.idt-command-tabs {
+  margin-top: 0.4rem;
+  display: inline-grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.35rem;
+  width: min(100%, 480px);
+  border: 1px solid rgba(229, 236, 222, 0.14);
+  border-radius: 8px;
+  padding: 0.32rem;
+  background: rgba(6, 9, 9, 0.72);
+}
+
+.idt-command-tabs button {
+  border: 1px solid transparent;
+  border-radius: 6px;
+  min-height: 42px;
+  background: transparent;
+  color: rgba(230, 236, 226, 0.72);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.42rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.idt-command-tabs button span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgba(184, 243, 214, 0.38);
+}
+
+.idt-command-tabs button.is-active {
+  background: rgba(237, 243, 230, 0.95);
+  border-color: rgba(237, 243, 230, 0.95);
+  color: #07100d;
+}
+
+.idt-command-tabs button.is-active span {
+  background: #0f2419;
+}
+
+.idt-command-surface {
+  border: 1px solid rgba(229, 236, 222, 0.16);
+  border-radius: 8px;
+  background:
+    linear-gradient(140deg, rgba(184, 243, 214, 0.1), transparent 34%),
+    linear-gradient(180deg, rgba(17, 23, 23, 0.96), rgba(8, 11, 12, 0.98));
+  box-shadow: 0 30px 76px rgba(0, 0, 0, 0.34);
+  padding: 1.15rem;
+}
+
+.idt-command-surface-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.idt-command-surface-head p,
+.idt-command-label {
+  margin: 0;
+  color: var(--idt-premium-copper);
+  font-size: 0.7rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.idt-command-surface-head h3 {
+  margin: 0.45rem 0 0;
+  max-width: 28ch;
+  color: #f5f6f0;
+  font-size: 1.55rem;
+  line-height: 1.18;
+}
+
+.idt-command-surface-head > span {
+  flex: none;
+  border: 1px solid rgba(184, 243, 214, 0.28);
+  border-radius: 999px;
+  padding: 0.3rem 0.62rem;
+  background: rgba(184, 243, 214, 0.1);
+  color: var(--idt-premium-mint);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.idt-command-metrics {
+  margin-top: 1.15rem;
+  display: grid;
+  grid-template-columns: minmax(0, 0.78fr) minmax(0, 1.22fr);
+  gap: 0.7rem;
+}
+
+.idt-command-metrics div {
+  border: 1px solid rgba(229, 236, 222, 0.14);
+  border-radius: 8px;
+  background: rgba(5, 8, 8, 0.58);
+  padding: 0.85rem;
+  display: grid;
+  gap: 0.28rem;
+}
+
+.idt-command-metrics small {
+  color: rgba(218, 226, 216, 0.58);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.idt-command-metrics strong {
+  color: #f4f6ef;
+  font-size: 1.02rem;
+  line-height: 1.35;
+}
+
+.idt-command-detail-grid {
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1.12fr) minmax(0, 0.88fr);
+  gap: 0.9rem;
+}
+
+.idt-command-list,
+.idt-command-playbook {
+  margin: 0.65rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.idt-command-list li,
+.idt-command-playbook li {
+  border: 1px solid rgba(229, 236, 222, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.035);
+  color: rgba(234, 239, 230, 0.8);
+  padding: 0.7rem;
+  line-height: 1.45;
+}
+
+.idt-command-playbook {
+  counter-reset: command-playbook;
+}
+
+.idt-command-playbook li {
+  counter-increment: command-playbook;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.55rem;
+  align-items: start;
+}
+
+.idt-command-playbook li::before {
+  content: counter(command-playbook);
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 50%;
+  background: rgba(241, 179, 109, 0.16);
+  color: var(--idt-premium-copper);
+  display: inline-grid;
+  place-items: center;
+  font-size: 0.72rem;
+  font-weight: 900;
+}
+
+.idt-risk-insight-grid {
+  gap: 1.15rem;
+}
+
+.idt-risk-scenario-item,
+.idt-risk-evidence-card,
+.idt-proof-demo-card,
+.idt-table-wrap,
+.idt-lead-form,
+.idt-steps li {
+  border-radius: 8px;
+  border-color: rgba(229, 236, 222, 0.16);
+}
+
+.idt-risk-scenario-item {
+  background: rgba(8, 12, 13, 0.72);
+}
+
+.idt-risk-scenario-item.is-active,
+.idt-risk-scenario-item:hover,
+.idt-risk-scenario-item:focus-visible {
+  border-color: rgba(184, 243, 214, 0.44);
+  background: rgba(184, 243, 214, 0.09);
+}
+
+.idt-risk-path-list li {
+  border-radius: 8px;
+  border-color: rgba(184, 243, 214, 0.22);
+}
+
+.idt-workflow-track {
+  counter-reset: workflow;
+  align-items: stretch;
+}
+
+.idt-workflow-stage {
+  color: var(--idt-premium-copper);
+  font-size: 0.68rem;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.idt-workflow-track li {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.018)),
+    rgba(9, 13, 13, 0.76);
+}
+
+.idt-workflow-track h3 {
+  margin-top: 0.58rem;
+}
+
+.idt-workflow-output {
+  border-radius: 8px;
+}
+
+html[data-theme='light'] body {
+  background:
+    linear-gradient(rgba(16, 30, 28, 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(16, 30, 28, 0.035) 1px, transparent 1px),
+    linear-gradient(180deg, #f6f8f1 0%, #edf4f0 48%, #f7f5ee 100%);
+  background-size: 56px 56px, 56px 56px, auto;
+}
+
+html[data-theme='light'] .idt-header {
+  background: rgba(250, 252, 246, 0.9);
+  border-bottom-color: rgba(22, 44, 39, 0.14);
+}
+
+html[data-theme='light'] .idt-hero {
+  background:
+    linear-gradient(115deg, rgba(25, 112, 76, 0.08), transparent 31%),
+    linear-gradient(160deg, rgba(181, 99, 40, 0.08), transparent 35%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.55), transparent 58%);
+  border-bottom-color: rgba(22, 44, 39, 0.12);
+}
+
+html[data-theme='light'] .idt-hero-copy h1,
+html[data-theme='light'] .idt-problem-frame h2,
+html[data-theme='light'] .idt-command-copy h2,
+html[data-theme='light'] .idt-command-surface-head h3 {
+  color: #14221d;
+}
+
+html[data-theme='light'] .idt-lead,
+html[data-theme='light'] .idt-problem-frame p,
+html[data-theme='light'] .idt-command-copy p {
+  color: #3f554f;
+}
+
+html[data-theme='light'] .idt-hero-metrics {
+  border-top-color: rgba(25, 52, 45, 0.16);
+}
+
+html[data-theme='light'] .idt-hero-metrics dt {
+  color: #27704f;
+}
+
+html[data-theme='light'] .idt-hero-metrics dd {
+  color: #17271f;
+}
+
+html[data-theme='light'] .idt-hero-trust-cues li,
+html[data-theme='light'] .idt-problem-map-source,
+html[data-theme='light'] .idt-problem-map-core,
+html[data-theme='light'] .idt-problem-signals article,
+html[data-theme='light'] .idt-command-surface,
+html[data-theme='light'] .idt-command-metrics div,
+html[data-theme='light'] .idt-command-list li,
+html[data-theme='light'] .idt-command-playbook li {
+  background: rgba(255, 255, 250, 0.82);
+  border-color: rgba(24, 50, 43, 0.16);
+  color: #172820;
+  box-shadow: 0 16px 34px rgba(42, 69, 58, 0.08);
+}
+
+html[data-theme='light'] .idt-problem-map-source span,
+html[data-theme='light'] .idt-problem-map-core span,
+html[data-theme='light'] .idt-problem-signals h3,
+html[data-theme='light'] .idt-command-metrics strong,
+html[data-theme='light'] .idt-command-list li,
+html[data-theme='light'] .idt-command-playbook li {
+  color: #15251f;
+}
+
+html[data-theme='light'] .idt-problem-map-source small,
+html[data-theme='light'] .idt-problem-map-core small,
+html[data-theme='light'] .idt-problem-signals p,
+html[data-theme='light'] .idt-command-metrics small {
+  color: #51675f;
+}
+
+html[data-theme='light'] .idt-command-center {
+  background: rgba(243, 247, 239, 0.72);
+  border-block-color: rgba(22, 44, 39, 0.12);
+}
+
+html[data-theme='light'] .idt-command-tabs {
+  background: rgba(255, 255, 250, 0.7);
+  border-color: rgba(24, 50, 43, 0.16);
+}
+
+html[data-theme='light'] .idt-command-tabs button {
+  color: #435a53;
+}
+
+html[data-theme='light'] .idt-command-tabs button.is-active {
+  background: #15241d;
+  border-color: #15241d;
+  color: #f6f8f1;
+}
+
+html[data-theme='light'] .idt-command-tabs button.is-active span {
+  background: #b8f3d6;
+}
+
+html[data-theme='light'] .idt-command-surface-head p,
+html[data-theme='light'] .idt-command-label,
+html[data-theme='light'] .idt-workflow-stage {
+  color: #a55e1d;
+}
+
+html[data-theme='light'] .idt-command-surface-head > span {
+  background: rgba(31, 112, 76, 0.1);
+  border-color: rgba(31, 112, 76, 0.22);
+  color: #1f704c;
+}
+
+html[data-theme='light'] .idt-proof-heading,
+html[data-theme='light'] .idt-proof-item-title {
+  color: #1b3028;
+}
+
+@media (max-width: 1100px) {
+  .idt-hero-copy h1 {
+    font-size: 4.15rem;
+  }
+
+  .idt-problem-frame h2,
+  .idt-command-copy h2 {
+    font-size: 2.75rem;
+  }
+
+  .idt-command-center-grid,
+  .idt-problem-frame-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 980px) {
+  .idt-hero-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-proof-architecture-list,
+  .idt-problem-signals,
+  .idt-command-detail-grid,
+  .idt-command-metrics {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .idt-hero {
+    padding: 3.4rem 0 2.7rem;
+  }
+
+  .idt-hero-copy h1 {
+    font-size: 3.1rem;
+    max-width: 13ch;
+  }
+
+  .idt-lead {
+    font-size: 1rem;
+  }
+
+  .idt-hero-metrics,
+  .idt-problem-map,
+  .idt-command-tabs {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-problem-frame h2,
+  .idt-command-copy h2 {
+    font-size: 2.35rem;
+    max-width: 14ch;
+  }
+
+  .idt-problem-map::after {
+    display: none;
+  }
+
+  .idt-command-center {
+    padding: 3rem 0;
+  }
+
+  .idt-command-surface {
+    padding: 0.95rem;
+  }
+
+  .idt-command-surface-head {
+    display: grid;
+  }
+
+  .idt-command-surface-head > span {
+    width: fit-content;
+  }
+}
+
+.idt-hero-edge-delay-0,
+.idt-demo-edge-delay-0 {
+  animation-delay: 0s;
+}
+
+.idt-hero-edge-delay-1 {
+  animation-delay: 0.42s;
+}
+
+.idt-hero-edge-delay-2 {
+  animation-delay: 0.84s;
+}
+
+.idt-hero-edge-delay-3 {
+  animation-delay: 1.26s;
+}
+
+.idt-demo-edge-delay-1 {
+  animation-delay: 0.35s;
+}
+
+.idt-demo-edge-delay-2 {
+  animation-delay: 0.7s;
+}
+
+.idt-demo-edge-delay-3 {
+  animation-delay: 1.05s;
+}
+
+.idt-demo-edge-delay-4 {
+  animation-delay: 1.4s;
+}
+
+.idt-node-oidc-chain-src-gha {
+  left: 18%;
+  top: 20%;
+}
+
+.idt-node-oidc-chain-broker-oidc {
+  left: 50%;
+  top: 31%;
+}
+
+.idt-node-oidc-chain-role-aws {
+  left: 72%;
+  top: 47%;
+}
+
+.idt-node-oidc-chain-k8s-sa {
+  left: 42%;
+  top: 64%;
+}
+
+.idt-node-oidc-chain-rds {
+  left: 73%;
+  top: 76%;
+}
+
+.idt-node-k8s-drift-k8s-sa {
+  left: 22%;
+  top: 25%;
+}
+
+.idt-node-k8s-drift-iam-trust {
+  left: 48%;
+  top: 38%;
+}
+
+.idt-node-k8s-drift-platform-role {
+  left: 74%;
+  top: 45%;
+}
+
+.idt-node-k8s-drift-config-store {
+  left: 64%;
+  top: 76%;
+}
+
+.idt-node-k8s-drift-runtime {
+  left: 29%;
+  top: 70%;
+}
+
+.idt-node-token-leak-repo-secret {
+  left: 20%;
+  top: 23%;
+}
+
+.idt-node-token-leak-runner-token {
+  left: 44%;
+  top: 36%;
+}
+
+.idt-node-token-leak-ecr-role {
+  left: 70%;
+  top: 44%;
+}
+
+.idt-node-token-leak-ecr-repo {
+  left: 53%;
+  top: 66%;
+}
+
+.idt-node-token-leak-ecs-task {
+  left: 77%;
+  top: 76%;
+}
+
+.idt-demo-node-oidc {
+  left: 14%;
+  top: 12%;
+}
+
+.idt-demo-node-role {
+  left: 58%;
+  top: 32%;
+}
+
+.idt-demo-node-sa {
+  left: 28%;
+  top: 58%;
+}
+
+.idt-demo-node-repo {
+  left: 54%;
+  top: 80%;
+}
+
+.idt-demo-node-db {
+  left: 30%;
+  top: 92%;
+}
+
+.trust-node-n1 {
+  left: 14%;
+  top: 50%;
+}
+
+.trust-node-n2 {
+  left: 34%;
+  top: 26%;
+}
+
+.trust-node-n3 {
+  left: 55%;
+  top: 48%;
+}
+
+.trust-node-n4 {
+  left: 70%;
+  top: 24%;
+}
+
+.trust-node-n5 {
+  left: 84%;
+  top: 54%;
+}
+
+.trust-node-n6 {
+  left: 33%;
+  top: 72%;
+}
+
+.trust-node-n7 {
+  left: 57%;
+  top: 74%;
+}
+
+@media (max-width: 980px) {
+  .idt-header-actions {
+    display: none;
+  }
+
+  .idt-header-actions.is-open {
+    display: flex;
+  }
+}
+
+@media (max-width: 720px) {
+  .idt-header-actions {
+    display: none;
+  }
+
+  .idt-header-actions.is-open {
+    display: grid;
+  }
+
+  .idt-hero-copy h1 {
+    font-size: 2.85rem;
+    line-height: 1;
+  }
+
+  .idt-hero-metrics {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.45rem;
+  }
+
+  .idt-hero-metrics dt {
+    font-size: 0.58rem;
+  }
+
+  .idt-hero-metrics dd {
+    font-size: 0.74rem;
+    overflow-wrap: anywhere;
+  }
+
+  .idt-hero-trust-cues,
+  .idt-hero .idt-graph-visual {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary

Redesigns the Identrail marketing homepage with a more premium trust-graph positioning, sharper hero proof, and a new interactive command-center section for triage, simulation, and reporting.

## What changed

- Repositioned the homepage hero around the machine identity trust graph and added product-assurance metrics.
- Added a new interactive command-center section that shows triage, simulation, and reporting workflows.
- Reworked the problem framing and workflow sections with clearer evidence/storytelling artifacts.
- Tightened responsive behavior, including mobile header actions that now respect the menu state.
- Removed React inline positioning styles from graph visuals so the existing strict CSP no longer blocks product graphics.

## Impact

The homepage now reads more like a premium security product surface, gives evaluators clearer proof of the product experience, and keeps the main conversion routes intact.

## Validation

- `npm test -- --run` from `web/` passed: 43 tests across 6 files.
- `npm run build` from `web/` passed and prerendered 37 routes.
- Production preview checked in browser at desktop and mobile widths with zero console errors after the CSP-safe graph refactor.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the marketing homepage around the machine identity trust graph with a new interactive command center and CSP-safe visuals. Improves clarity of product proof and fixes mobile header behavior.

- **New Features**
  - Added an interactive Command Center with Triage, Simulate, and Report views, including metrics, evidence, and playbooks.
  - Updated hero with new headline, lead, and product-assurance metrics; refreshed SEO title and description.
  - Reworked problem framing and “How it works” to show the connected trust graph and staged workflow.

- **Bug Fixes**
  - Removed inline positioning/animation from graph visuals; moved to CSS classes to satisfy strict CSP.
  - Mobile header actions now respect the menu state to avoid layout issues.

<sup>Written for commit fe836b531b9551c08787aa7df5c37afdd798a40f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

