### PR TITLE
[codex] polish homepage audit fixes

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -47,7 +47,7 @@ describe('App', () => {
     expect(screen.getAllByRole('link', { name: 'Book Demo' }).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Adoption Paths/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Reachable Risk Paths/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByRole('tab', { name: 'Graph' }).length).toBeGreaterThan(0);
+    expect(screen.getByRole('heading', { level: 2, name: /From connector setup to board-ready risk evidence/i })).toBeInTheDocument();
   });
 
   it('renders pricing page routes and key elements', () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1443,7 +1443,7 @@ function HomePage() {
           title="Why teams choose Identrail over closed black-box workflows"
           body="Compare on explainability, rollout safety, and day-two operability."
         />
-        <div className="idt-table-wrap">
+        <div className="idt-table-wrap idt-home-compare">
           <table className="idt-compare-table">
             <thead>
               <tr>
@@ -1465,7 +1465,7 @@ function HomePage() {
         </div>
       </section>
 
-      <section className="idt-section idt-shell idt-final-cta" id="start">
+      <section className="idt-section idt-shell idt-final-cta" id="risk-scan-form">
         <SectionTitle
           eyebrow="Ready to evaluate"
           title="Map your first production trust path in minutes"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,7 +5,6 @@ import { HeroProductReveal } from './components/home/HeroProductReveal';
 import { HowItWorksSection } from './components/home/HowItWorksSection';
 import { CommandCenterSection } from './components/home/CommandCenterSection';
 import { ProblemFramingSection } from './components/home/ProblemFramingSection';
-import { RiskInsightSection } from './components/home/RiskInsightSection';
 import { TrustProofStrip } from './components/home/TrustProofStrip';
 import { Footer } from './components/layout/Footer';
 import { Header } from './components/layout/Header';
@@ -108,6 +107,33 @@ const DIFFERENTIATION_ROWS = [
     area: 'Developer and platform fit',
     identrail: 'Built for security + platform collaboration with inspectable outputs',
     closed: 'Security-only workflows can be harder for platform teams to operationalize'
+  }
+] as const;
+
+const PRODUCT_TOUR_STEPS = [
+  {
+    step: '01',
+    title: 'Connect read-only signals',
+    detail: 'Add AWS IAM, Kubernetes, GitHub, and OIDC sources without granting write access.',
+    proof: 'Least-privilege connector scope'
+  },
+  {
+    step: '02',
+    title: 'Rank reachable risk paths',
+    detail: 'See which identities can reach production resources and why the path matters.',
+    proof: 'Blast-radius queue'
+  },
+  {
+    step: '03',
+    title: 'Simulate the first safe fix',
+    detail: 'Preview trust-policy and RBAC changes before enforcement to avoid workload breakage.',
+    proof: 'Policy simulation'
+  },
+  {
+    step: '04',
+    title: 'Export the evidence packet',
+    detail: 'Package source evidence, owner notes, timeline, and residual risk for review.',
+    proof: 'Audit-ready report'
   }
 ] as const;
 
@@ -687,64 +713,6 @@ function ModalShell({
   );
 }
 
-function ExitIntentPopup() {
-  const [open, setOpen] = useState(false);
-  const dismissedRef = useRef(false);
-
-  useEffect(() => {
-    const storageKey = 'identrail-exit-modal-dismissed';
-    dismissedRef.current = localStorage.getItem(storageKey) === 'yes';
-
-    if (dismissedRef.current) {
-      return;
-    }
-
-    const onMouseOut = (event: MouseEvent) => {
-      if (event.clientY <= 8 && !dismissedRef.current) {
-        setOpen(true);
-      }
-    };
-
-    const timer = window.setTimeout(() => {
-      if (!dismissedRef.current) {
-        setOpen(true);
-      }
-    }, 45000);
-
-    document.addEventListener('mouseout', onMouseOut);
-
-    return () => {
-      window.clearTimeout(timer);
-      document.removeEventListener('mouseout', onMouseOut);
-    };
-  }, []);
-
-  const close = () => {
-    dismissedRef.current = true;
-    localStorage.setItem('identrail-exit-modal-dismissed', 'yes');
-    setOpen(false);
-  };
-
-  if (!open) return null;
-
-  return (
-    <ModalShell titleId="exit-modal-title" onClose={close}>
-      <button className="idt-modal-close" type="button" onClick={close} aria-label="Close">
-        x
-      </button>
-      <h3 id="exit-modal-title">Before you leave: run a free machine identity risk scan</h3>
-      <p>Identify risky AWS IAM, Kubernetes, and GitHub trust paths before attackers use them.</p>
-      <LeadCaptureForm
-        compact
-        variant="short"
-        title="Start Free Risk Scan"
-        caption="No spam. One actionable plan for cloud identity blast radius reduction."
-        ctaLabel="Start Free Risk Scan"
-      />
-    </ModalShell>
-  );
-}
-
 function CalendlyEmbed() {
   return (
     <section className="idt-calendly">
@@ -1278,6 +1246,57 @@ function DeploymentPathBanner() {
   );
 }
 
+function ProductTourSection() {
+  return (
+    <section className="idt-section idt-shell idt-product-tour" aria-labelledby="product-tour-title">
+      <div className="idt-product-tour-copy">
+        <p className="idt-eyebrow">Product tour</p>
+        <h2 id="product-tour-title">From connector setup to board-ready risk evidence.</h2>
+        <p>
+          A tighter product story: connect safely, find reachable risk, simulate remediation, and export proof without
+          repeating the same trust-graph promise section after section.
+        </p>
+      </div>
+
+      <div className="idt-product-tour-shell" aria-label="Identrail product workflow preview">
+        <div className="idt-tour-rail">
+          {PRODUCT_TOUR_STEPS.map((item) => (
+            <article key={item.step} className="idt-tour-step">
+              <span>{item.step}</span>
+              <div>
+                <h3>{item.title}</h3>
+                <p>{item.detail}</p>
+              </div>
+            </article>
+          ))}
+        </div>
+
+        <div className="idt-tour-screen">
+          <div className="idt-tour-screen-head">
+            <div>
+              <p>Live trust path investigation</p>
+              <h3>Reachable Risk Paths</h3>
+            </div>
+            <span>4 evidence artifacts</span>
+          </div>
+          <div className="idt-tour-finding-grid">
+            {PRODUCT_TOUR_STEPS.map((item) => (
+              <article key={item.proof}>
+                <small>{item.proof}</small>
+                <strong>{item.title}</strong>
+              </article>
+            ))}
+          </div>
+          <div className="idt-tour-report">
+            <p>Export packet</p>
+            <strong>Source evidence, policy diff, affected workloads, owner timeline, residual risk</strong>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function HomeFaqSection() {
   const groups = [
     {
@@ -1412,28 +1431,7 @@ function HomePage() {
 
       <CommandCenterSection />
 
-      <section className="idt-section idt-section-tight idt-shell">
-        <LeadCaptureForm
-          id="risk-scan-form"
-          variant="short"
-          title="Start a read-only risk scan in under one minute"
-          caption="No production writes. You receive a prioritized trust-path report and a practical first-remediation sequence."
-          ctaLabel="Start Free Risk Scan"
-        />
-      </section>
-
-      <RiskInsightSection />
-
-      <section className="idt-section idt-shell idt-section-demo">
-        <div className="idt-card idt-proof-demo-card">
-          <h3>Interactive trust graph explorer</h3>
-          <p>
-            Explore source identity, broker, workload, privilege, and target resource states. Select a node to inspect risk evidence
-            and first remediation actions.
-          </p>
-          <TrustGraphDemo />
-        </div>
-      </section>
+      <ProductTourSection />
 
       <HowItWorksSection />
 
@@ -1466,8 +1464,6 @@ function HomePage() {
           </table>
         </div>
       </section>
-
-      <HomeFaqSection />
 
       <section className="idt-section idt-shell idt-final-cta" id="start">
         <SectionTitle
@@ -2505,8 +2501,8 @@ function DocsPage() {
     <>
       <section className="idt-page-hero idt-shell">
         <p className="idt-eyebrow">Docs</p>
-        <h1>Beautiful docs experience with deep operator workflows</h1>
-        <p>Mintlify-style navigation, fast search, and practical runbooks linked to the source repository.</p>
+        <h1>Deploy, connect, and operate Identrail in production</h1>
+        <p>Fast search, practical runbooks, and source-linked operator docs for production rollouts.</p>
         <SafeLink href={DOCS_REPO} className="idt-btn idt-btn-primary">
           Open Full GitHub Docs
         </SafeLink>
@@ -3046,7 +3042,6 @@ export function RoutedSite() {
       {!isProductShellRoute ? (
         <>
           <Footer xUrl={X_URL} linkedInUrl={LINKEDIN_URL} githubRepo={GITHUB_REPO} discordUrl={DISCORD_URL} />
-          <ExitIntentPopup />
         </>
       ) : null}
     </div>

--- a/web/src/components/home/TrustProofStrip.tsx
+++ b/web/src/components/home/TrustProofStrip.tsx
@@ -3,12 +3,27 @@ import { SafeLink } from '../SafeLink';
 import { TRUST_PROOF_LINKS } from '../../content/proofArtifacts';
 
 const TRUST_SUMMARY_ITEMS = TRUST_PROOF_LINKS.slice(0, 4);
+const TRUST_METRICS = [
+  { value: 'Apache-2.0', label: 'open-core license' },
+  { value: '37', label: 'public routes and docs paths' },
+  { value: '4', label: 'production signal families' }
+] as const;
 
 export function TrustProofStrip() {
   return (
     <section className="idt-trust-strip" aria-label="Credibility and proof">
       <div className="idt-shell idt-proof-architecture">
-        <p className="idt-proof-heading">Built in the open with verifiable trust controls.</p>
+        <div className="idt-proof-strip-head">
+          <p className="idt-proof-heading">Built in the open with verifiable trust controls.</p>
+          <dl className="idt-proof-metrics" aria-label="Identrail trust signals">
+            {TRUST_METRICS.map((metric) => (
+              <div key={metric.label}>
+                <dt>{metric.value}</dt>
+                <dd>{metric.label}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
         <div className="idt-proof-architecture-list">
           {TRUST_SUMMARY_ITEMS.map((entry) => (
             <article key={entry.label} className="idt-proof-architecture-item">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5618,30 +5618,30 @@ html[data-theme='light'] .idt-tour-report {
     width: fit-content;
   }
 
-  .idt-table-wrap {
+  .idt-home-compare {
     overflow: visible;
     border: 0;
     background: transparent;
   }
 
-  .idt-compare-table {
+  .idt-home-compare .idt-compare-table {
     min-width: 0;
     display: block;
   }
 
-  .idt-compare-table thead {
+  .idt-home-compare .idt-compare-table thead {
     display: none;
   }
 
-  .idt-compare-table tbody,
-  .idt-compare-table tr,
-  .idt-compare-table th,
-  .idt-compare-table td {
+  .idt-home-compare .idt-compare-table tbody,
+  .idt-home-compare .idt-compare-table tr,
+  .idt-home-compare .idt-compare-table th,
+  .idt-home-compare .idt-compare-table td {
     display: block;
     width: 100%;
   }
 
-  .idt-compare-table tr {
+  .idt-home-compare .idt-compare-table tr {
     border: 1px solid rgba(229, 236, 222, 0.16);
     border-radius: 8px;
     background: rgba(8, 12, 13, 0.72);
@@ -5649,21 +5649,21 @@ html[data-theme='light'] .idt-tour-report {
     overflow: hidden;
   }
 
-  .idt-compare-table th,
-  .idt-compare-table td {
+  .idt-home-compare .idt-compare-table th,
+  .idt-home-compare .idt-compare-table td {
     border-bottom: 1px solid rgba(169, 184, 211, 0.16);
     padding: 0.8rem;
   }
 
-  .idt-compare-table td:nth-of-type(1)::before {
+  .idt-home-compare .idt-compare-table td:nth-of-type(1)::before {
     content: 'Identrail';
   }
 
-  .idt-compare-table td:nth-of-type(2)::before {
+  .idt-home-compare .idt-compare-table td:nth-of-type(2)::before {
     content: 'Typical alternative';
   }
 
-  .idt-compare-table td::before {
+  .idt-home-compare .idt-compare-table td::before {
     display: block;
     margin-bottom: 0.35rem;
     color: var(--idt-premium-copper);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2665,12 +2665,45 @@ body {
   padding: 1.35rem 0;
 }
 
+.idt-proof-strip-head {
+  display: grid;
+  grid-template-columns: minmax(0, 0.82fr) minmax(420px, 1.18fr);
+  gap: 1rem;
+  align-items: start;
+  margin-bottom: 0.9rem;
+}
+
 .idt-proof-heading {
-  margin: 0 0 0.85rem;
+  margin: 0;
   color: #e9eef8;
   font-size: 0.94rem;
   font-weight: 600;
   letter-spacing: 0.01em;
+}
+
+.idt-proof-metrics {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.idt-proof-metrics div {
+  border-left: 1px solid rgba(184, 243, 214, 0.3);
+  padding-left: 0.7rem;
+}
+
+.idt-proof-metrics dt {
+  color: #f4f7ef;
+  font-size: 1rem;
+  font-weight: 900;
+}
+
+.idt-proof-metrics dd {
+  margin: 0.15rem 0 0;
+  color: #aebed6;
+  font-size: 0.76rem;
+  line-height: 1.35;
 }
 
 .idt-proof-architecture-list {
@@ -4929,6 +4962,162 @@ body {
   gap: 1.15rem;
 }
 
+.idt-product-tour {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.idt-product-tour-copy {
+  max-width: 760px;
+}
+
+.idt-product-tour-copy h2 {
+  margin: 0.25rem 0 0;
+  max-width: 13ch;
+  color: #f3f5ee;
+  font-size: 3.2rem;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.idt-product-tour-copy p:not(.idt-eyebrow) {
+  margin: 0.9rem 0 0;
+  color: rgba(226, 233, 224, 0.76);
+  font-size: 1rem;
+  max-width: 62ch;
+}
+
+.idt-product-tour-shell {
+  border: 1px solid rgba(229, 236, 222, 0.16);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(168, 199, 255, 0.08), transparent 38%),
+    rgba(8, 12, 13, 0.78);
+  display: grid;
+  grid-template-columns: minmax(0, 0.86fr) minmax(420px, 1.14fr);
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.idt-tour-rail {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.idt-tour-step {
+  border: 1px solid rgba(229, 236, 222, 0.13);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.035);
+  padding: 0.85rem;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+}
+
+.idt-tour-step > span {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: rgba(184, 243, 214, 0.12);
+  color: var(--idt-premium-mint);
+  display: inline-grid;
+  place-items: center;
+  font-size: 0.72rem;
+  font-weight: 900;
+}
+
+.idt-tour-step h3,
+.idt-tour-step p {
+  margin: 0;
+}
+
+.idt-tour-step h3 {
+  color: #f4f6ef;
+  font-size: 1rem;
+}
+
+.idt-tour-step p {
+  margin-top: 0.32rem;
+  color: rgba(226, 233, 224, 0.72);
+  font-size: 0.86rem;
+  line-height: 1.55;
+}
+
+.idt-tour-screen {
+  border: 1px solid rgba(229, 236, 222, 0.14);
+  border-radius: 8px;
+  background:
+    linear-gradient(140deg, rgba(184, 243, 214, 0.1), transparent 38%),
+    #070a0b;
+  padding: 1rem;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.idt-tour-screen-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.idt-tour-screen-head p,
+.idt-tour-report p {
+  margin: 0;
+  color: var(--idt-premium-copper);
+  font-size: 0.68rem;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.idt-tour-screen-head h3 {
+  margin: 0.3rem 0 0;
+  color: #f4f6ef;
+  font-size: 1.5rem;
+}
+
+.idt-tour-screen-head > span {
+  border: 1px solid rgba(184, 243, 214, 0.24);
+  border-radius: 999px;
+  padding: 0.32rem 0.6rem;
+  color: var(--idt-premium-mint);
+  background: rgba(184, 243, 214, 0.1);
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.idt-tour-finding-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.idt-tour-finding-grid article,
+.idt-tour-report {
+  border: 1px solid rgba(229, 236, 222, 0.13);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.035);
+  padding: 0.85rem;
+}
+
+.idt-tour-finding-grid small {
+  color: rgba(218, 226, 216, 0.58);
+  display: block;
+  font-size: 0.66rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.idt-tour-finding-grid strong,
+.idt-tour-report strong {
+  display: block;
+  margin-top: 0.32rem;
+  color: #f4f6ef;
+  line-height: 1.35;
+}
+
 .idt-risk-scenario-item,
 .idt-risk-evidence-card,
 .idt-proof-demo-card,
@@ -5095,8 +5284,30 @@ html[data-theme='light'] .idt-command-surface-head > span {
 }
 
 html[data-theme='light'] .idt-proof-heading,
-html[data-theme='light'] .idt-proof-item-title {
+html[data-theme='light'] .idt-proof-item-title,
+html[data-theme='light'] .idt-product-tour-copy h2,
+html[data-theme='light'] .idt-tour-screen-head h3,
+html[data-theme='light'] .idt-tour-step h3,
+html[data-theme='light'] .idt-tour-finding-grid strong,
+html[data-theme='light'] .idt-tour-report strong,
+html[data-theme='light'] .idt-proof-metrics dt {
   color: #1b3028;
+}
+
+html[data-theme='light'] .idt-product-tour-copy p:not(.idt-eyebrow),
+html[data-theme='light'] .idt-tour-step p,
+html[data-theme='light'] .idt-proof-metrics dd {
+  color: #51675f;
+}
+
+html[data-theme='light'] .idt-product-tour-shell,
+html[data-theme='light'] .idt-tour-screen,
+html[data-theme='light'] .idt-tour-step,
+html[data-theme='light'] .idt-tour-finding-grid article,
+html[data-theme='light'] .idt-tour-report {
+  background: rgba(255, 255, 250, 0.82);
+  border-color: rgba(24, 50, 43, 0.16);
+  box-shadow: 0 16px 34px rgba(42, 69, 58, 0.08);
 }
 
 @media (max-width: 1100px) {
@@ -5110,7 +5321,8 @@ html[data-theme='light'] .idt-proof-item-title {
   }
 
   .idt-command-center-grid,
-  .idt-problem-frame-grid {
+  .idt-problem-frame-grid,
+  .idt-product-tour-shell {
     grid-template-columns: 1fr;
   }
 }
@@ -5123,7 +5335,8 @@ html[data-theme='light'] .idt-proof-item-title {
   .idt-proof-architecture-list,
   .idt-problem-signals,
   .idt-command-detail-grid,
-  .idt-command-metrics {
+  .idt-command-metrics,
+  .idt-proof-strip-head {
     grid-template-columns: 1fr;
   }
 }
@@ -5144,7 +5357,9 @@ html[data-theme='light'] .idt-proof-item-title {
 
   .idt-hero-metrics,
   .idt-problem-map,
-  .idt-command-tabs {
+  .idt-command-tabs,
+  .idt-tour-finding-grid,
+  .idt-proof-metrics {
     grid-template-columns: 1fr;
   }
 
@@ -5384,5 +5599,77 @@ html[data-theme='light'] .idt-proof-item-title {
   .idt-hero-trust-cues,
   .idt-hero .idt-graph-visual {
     display: none;
+  }
+
+  .idt-product-tour-copy h2 {
+    font-size: 2.35rem;
+    max-width: 14ch;
+  }
+
+  .idt-product-tour-shell {
+    padding: 0.75rem;
+  }
+
+  .idt-tour-screen-head {
+    display: grid;
+  }
+
+  .idt-tour-screen-head > span {
+    width: fit-content;
+  }
+
+  .idt-table-wrap {
+    overflow: visible;
+    border: 0;
+    background: transparent;
+  }
+
+  .idt-compare-table {
+    min-width: 0;
+    display: block;
+  }
+
+  .idt-compare-table thead {
+    display: none;
+  }
+
+  .idt-compare-table tbody,
+  .idt-compare-table tr,
+  .idt-compare-table th,
+  .idt-compare-table td {
+    display: block;
+    width: 100%;
+  }
+
+  .idt-compare-table tr {
+    border: 1px solid rgba(229, 236, 222, 0.16);
+    border-radius: 8px;
+    background: rgba(8, 12, 13, 0.72);
+    margin-bottom: 0.75rem;
+    overflow: hidden;
+  }
+
+  .idt-compare-table th,
+  .idt-compare-table td {
+    border-bottom: 1px solid rgba(169, 184, 211, 0.16);
+    padding: 0.8rem;
+  }
+
+  .idt-compare-table td:nth-of-type(1)::before {
+    content: 'Identrail';
+  }
+
+  .idt-compare-table td:nth-of-type(2)::before {
+    content: 'Typical alternative';
+  }
+
+  .idt-compare-table td::before {
+    display: block;
+    margin-bottom: 0.35rem;
+    color: var(--idt-premium-copper);
+    font-size: 0.68rem;
+    font-weight: 900;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to the premium homepage redesign after a full visual/product audit. This tightens the homepage, removes interruptive behavior, adds stronger premium proof, and fixes mobile comparison overflow.

## What changed

- Removed the exit-intent scan modal from marketing pages so visitors are not interrupted mid-evaluation.
- Compressed the homepage by replacing repeated scan/demo proof blocks with a focused product-tour section.
- Added stronger open-core/product proof metrics to the trust strip.
- Added a product workflow preview covering connector setup, risk ranking, simulation, and evidence export.
- Fixed the mobile comparison table by converting rows into stacked comparison cards instead of overflowing horizontally.
- Updated the docs hero copy from self-referential wording to production/operator-focused messaging.

## Impact

The homepage is shorter, more premium, less repetitive, and better aligned with the audit findings. Mobile no longer horizontally overflows on the comparison section, and the site avoids modal interruption while preserving the main scan and demo conversion paths.

## Validation

- `npm test -- --run` from `web/` passed: 43 tests across 6 files.
- `npm run build` from `web/` passed and prerendered 37 routes.
- Browser preview checked before branch cleanup: no console errors, no exit modal, no mobile horizontal overflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the premium homepage after a visual/product audit. Removed the exit-intent modal and repetitive demo/insight/FAQ sections, added a focused Product Tour and stronger trust proof, fixed mobile comparison overflow, and updated docs copy.

- **New Features**
  - Added a Product Tour: connect read-only signals → rank reachable risk → simulate safe fixes → export evidence.
  - Trust strip now shows open-core/product metrics (license, public routes/docs, signal families).

- **Bug Fixes**
  - Mobile comparison section now stacks into cards on small screens to eliminate horizontal overflow.

<sup>Written for commit e3b7f84d4a33564c27ef6678a5c081ba497378f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

