### PR TITLE
Build connect-source wizard for project onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Added a project connect-source wizard in the authenticated web app:
+  - guided GitHub, AWS, and Kubernetes source onboarding from the project detail route
+  - wired live connection status, validation, retry, and remediation feedback to existing project-scoped connector APIs
+  - added UI and API-client regression coverage for first-source onboarding
 - Hardened connector secret storage and rotation:
   - encrypted GitHub webhook secrets with versioned AES-256-GCM envelopes instead of retaining plaintext service state
   - added a webhook-secret rotation endpoint with audit events and status metadata for key version, algorithm, and rotation due date

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,8 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
   - `observability.md`
   - `troubleshooting.md`
   - `incident-response.md`
+- Source setup:
+  - `source-onboarding.md`
 - Worker/scheduler behavior:
   - `worker.md`
   - `scheduler.md`

--- a/docs/source-onboarding.md
+++ b/docs/source-onboarding.md
@@ -1,0 +1,41 @@
+# Source Onboarding
+
+Identrail source onboarding is available from the authenticated product shell at:
+
+`/app/{tenant_id}/{workspace_id}/projects/{project_id}`
+
+The project detail view presents a guided connect-source wizard for GitHub, AWS, and Kubernetes. It reads current source status first, then runs the existing project-scoped connector APIs when an operator validates or saves a source.
+
+## GitHub
+
+The wizard starts the GitHub App installation flow through:
+
+`POST /v1/workspaces/{workspace_id}/projects/{project_id}/github/connect/start`
+
+After installation metadata is available, the wizard saves the project connection through:
+
+`POST /v1/workspaces/{workspace_id}/projects/{project_id}/github/connect/complete`
+
+The UI keeps repository selection explicit and stores only credential references plus encrypted webhook-secret metadata returned by the API.
+
+## AWS
+
+The wizard validates and saves one read-only IAM role through:
+
+`POST /v1/workspaces/{workspace_id}/projects/{project_id}/aws/connection`
+
+Validation returns account identity, permission checks, diagnostics, and remediation text. A successful validation marks the connector active; failed checks leave the connector diagnosable instead of hiding the issue.
+
+## Kubernetes
+
+The wizard runs a non-mutating preflight through:
+
+`POST /v1/workspaces/{workspace_id}/projects/{project_id}/kubernetes/connection`
+
+The API runtime uses its configured `kubectl` path and optional context override. The response includes cluster metadata, read-access checks, diagnostics, and remediation text for missing scanner-critical RBAC permissions.
+
+## Operational Notes
+
+- The wizard is scoped by tenant, workspace, and project route params.
+- Retry is safe: AWS and Kubernetes validation paths are read-only, and GitHub start state expires server-side.
+- Status refresh uses the three provider status endpoints and keeps partial failures visible per source.

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -166,16 +166,327 @@ describe('App', () => {
     expect(await screen.findByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
   });
 
-  it('renders tenancy-scoped project detail placeholder route inside app shell', async () => {
+  it('renders tenancy-scoped connect-source wizard inside app shell', async () => {
     saveProductSession({
       tenantID: 'tenant-a',
       workspaceID: 'workspace-a'
     });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connection: {
+            provider: 'github_app',
+            connected: false,
+            webhook_secret_rotation_required: false,
+            selected_repositories: []
+          }
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connection: {
+            provider: 'aws',
+            connected: false,
+            status: 'pending',
+            health_status: 'unknown',
+            external_id_configured: false,
+            permission_checks: [],
+            diagnostics: []
+          }
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connection: {
+            provider: 'kubernetes',
+            connected: false,
+            status: 'pending',
+            health_status: 'unknown',
+            permission_checks: [],
+            diagnostics: []
+          }
+        })
+      });
+    vi.stubGlobal('fetch', fetchMock);
     window.history.pushState({}, '', '/app/tenant-a/workspace-a/projects/project-1');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { level: 2, name: /Project detail/i })).toBeInTheDocument();
-    expect(await screen.findByText(/Project project-1 placeholder/i)).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: /Connect sources for project-1/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Generate install link/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /AWS/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Kubernetes/i })).toBeInTheDocument();
+  });
+
+  it('validates and saves an AWS source from the connect-source wizard', async () => {
+    saveProductSession({
+      tenantID: 'tenant-a',
+      workspaceID: 'workspace-a'
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connection: {
+            provider: 'github_app',
+            connected: false,
+            webhook_secret_rotation_required: false,
+            selected_repositories: []
+          }
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connection: {
+            provider: 'aws',
+            connected: false,
+            status: 'pending',
+            health_status: 'unknown',
+            external_id_configured: false,
+            permission_checks: [],
+            diagnostics: []
+          }
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connection: {
+            provider: 'kubernetes',
+            connected: false,
+            status: 'pending',
+            health_status: 'unknown',
+            permission_checks: [],
+            diagnostics: []
+          }
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connection: {
+            provider: 'aws',
+            connected: true,
+            status: 'active',
+            health_status: 'healthy',
+            role_arn: 'arn:aws:iam::123456789012:role/IdentrailReadOnly',
+            external_id_configured: true,
+            account_id: '123456789012',
+            region: 'us-east-1',
+            permission_checks: [{ name: 'sts:AssumeRole', passed: true, message: 'Role assumption succeeded.' }],
+            diagnostics: [],
+            last_validated_at: '2026-05-05T10:00:00Z'
+          }
+        })
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    window.history.pushState({}, '', '/app/tenant-a/workspace-a/projects/project-1');
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { level: 2, name: /Connect sources for project-1/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /AWS/i }));
+    fireEvent.change(screen.getByLabelText('Role ARN'), {
+      target: { value: 'arn:aws:iam::123456789012:role/IdentrailReadOnly' }
+    });
+    fireEvent.change(screen.getByLabelText('External ID'), { target: { value: 'external-prod' } });
+    fireEvent.click(screen.getByRole('button', { name: /Validate and save AWS/i }));
+
+    expect(await screen.findByText(/AWS connector is active/i)).toBeInTheDocument();
+    const postCall = fetchMock.mock.calls.find(([url, options]) => {
+      return typeof url === 'string' && url.includes('/projects/project-1/aws/connection') && options?.method === 'POST';
+    });
+    expect(postCall).toBeDefined();
+    expect(postCall?.[1]?.body).toContain('external-prod');
+  });
+
+  it('starts and completes a GitHub source from the connect-source wizard', async () => {
+    saveProductSession({
+      tenantID: 'tenant-a',
+      workspaceID: 'workspace-a'
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connection: {
+            provider: 'github_app',
+            connected: false,
+            webhook_secret_rotation_required: false,
+            selected_repositories: []
+          }
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connection: {
+            provider: 'aws',
+            connected: false,
+            status: 'pending',
+            health_status: 'unknown',
+            external_id_configured: false,
+            permission_checks: [],
+            diagnostics: []
+          }
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connection: {
+            provider: 'kubernetes',
+            connected: false,
+            status: 'pending',
+            health_status: 'unknown',
+            permission_checks: [],
+            diagnostics: []
+          }
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connection: {
+            state: 'state-123',
+            connect_url: 'https://github.com/apps/identrail/installations/new?state=state-123',
+            expires_at: '2026-05-05T10:10:00Z'
+          }
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connection: {
+            provider: 'github_app',
+            connected: true,
+            account_login: 'identrail',
+            installation_id: 77,
+            token_reference: 'github-app-installation:77',
+            webhook_secret_reference: 'github-webhook:project-1:77',
+            webhook_secret_rotation_required: false,
+            selected_repositories: ['identrail/identrail'],
+            updated_at: '2026-05-05T10:05:00Z'
+          }
+        })
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    window.history.pushState({}, '', '/app/tenant-a/workspace-a/projects/project-1');
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { level: 2, name: /Connect sources for project-1/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Generate install link/i }));
+    expect(await screen.findByText(/GitHub installation link generated/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Open GitHub/i })).toHaveAttribute('href', expect.stringContaining('state-123'));
+
+    fireEvent.change(screen.getByLabelText('Installation ID'), { target: { value: '77' } });
+    fireEvent.change(screen.getByLabelText('Account login'), { target: { value: 'identrail' } });
+    fireEvent.change(screen.getByLabelText('Selected repositories'), { target: { value: 'Identrail/Identrail' } });
+    fireEvent.click(screen.getByRole('button', { name: /Save GitHub connection/i }));
+
+    expect(await screen.findByText(/GitHub connection saved/i)).toBeInTheDocument();
+    const completeCall = fetchMock.mock.calls.find(([url, options]) => {
+      return typeof url === 'string' && url.includes('/projects/project-1/github/connect/complete') && options?.method === 'POST';
+    });
+    expect(completeCall).toBeDefined();
+    expect(completeCall?.[1]?.body).toContain('"selected_repositories":["identrail/identrail"]');
+  });
+
+  it('runs Kubernetes preflight from the connect-source wizard', async () => {
+    saveProductSession({
+      tenantID: 'tenant-a',
+      workspaceID: 'workspace-a'
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connection: {
+            provider: 'github_app',
+            connected: false,
+            webhook_secret_rotation_required: false,
+            selected_repositories: []
+          }
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connection: {
+            provider: 'aws',
+            connected: false,
+            status: 'pending',
+            health_status: 'unknown',
+            external_id_configured: false,
+            permission_checks: [],
+            diagnostics: []
+          }
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connection: {
+            provider: 'kubernetes',
+            connected: false,
+            status: 'pending',
+            health_status: 'unknown',
+            permission_checks: [],
+            diagnostics: []
+          }
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connection: {
+            provider: 'kubernetes',
+            connected: true,
+            status: 'active',
+            health_status: 'healthy',
+            display_name: 'Production cluster',
+            context: 'prod',
+            cluster: 'prod-cluster',
+            server: 'https://kubernetes.example.test',
+            permission_checks: [
+              {
+                verb: 'list',
+                resource: 'pods',
+                scope: 'cluster',
+                allowed: true
+              }
+            ],
+            diagnostics: [],
+            last_validated_at: '2026-05-05T10:00:00Z'
+          }
+        })
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    window.history.pushState({}, '', '/app/tenant-a/workspace-a/projects/project-1');
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { level: 2, name: /Connect sources for project-1/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Kubernetes/i }));
+    fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Production cluster' } });
+    fireEvent.change(screen.getByLabelText('kubectl context'), { target: { value: 'prod' } });
+    fireEvent.click(screen.getByRole('button', { name: /Run preflight and save/i }));
+
+    expect(await screen.findByText(/Kubernetes connector is active/i)).toBeInTheDocument();
+    expect(screen.getByText(/prod-cluster/i)).toBeInTheDocument();
+    const postCall = fetchMock.mock.calls.find(([url, options]) => {
+      return typeof url === 'string' && url.includes('/projects/project-1/kubernetes/connection') && options?.method === 'POST';
+    });
+    expect(postCall).toBeDefined();
+    expect(postCall?.[1]?.body).toContain('"context":"prod"');
   });
 
   it('supports workspace member invite workflow from app shell administration route', async () => {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { App } from './App';
 import { saveProductSession } from './productShell';
@@ -403,6 +403,146 @@ describe('App', () => {
       expect(screen.queryByText(/Account project-1-org/i)).not.toBeInTheDocument();
     });
     expect(screen.getByText(/Account project-2-org/i)).toBeInTheDocument();
+  });
+
+  it('ignores stale connector submit responses after project navigation', async () => {
+    saveProductSession({
+      tenantID: 'tenant-a',
+      workspaceID: 'workspace-a'
+    });
+
+    let staleAWSResponseParsed = false;
+    const staleAWSSubmit = deferred<Response>();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connection: {
+            provider: 'github_app',
+            connected: false,
+            webhook_secret_rotation_required: false,
+            selected_repositories: []
+          }
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connection: {
+            provider: 'aws',
+            connected: false,
+            status: 'pending',
+            health_status: 'unknown',
+            external_id_configured: false,
+            permission_checks: [],
+            diagnostics: []
+          }
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connection: {
+            provider: 'kubernetes',
+            connected: false,
+            status: 'pending',
+            health_status: 'unknown',
+            permission_checks: [],
+            diagnostics: []
+          }
+        })
+      })
+      .mockImplementationOnce(() => staleAWSSubmit.promise)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connection: {
+            provider: 'github_app',
+            connected: false,
+            webhook_secret_rotation_required: false,
+            selected_repositories: []
+          }
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connection: {
+            provider: 'aws',
+            connected: false,
+            status: 'pending',
+            health_status: 'unknown',
+            external_id_configured: false,
+            permission_checks: [],
+            diagnostics: []
+          }
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connection: {
+            provider: 'kubernetes',
+            connected: false,
+            status: 'pending',
+            health_status: 'unknown',
+            permission_checks: [],
+            diagnostics: []
+          }
+        })
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    window.history.pushState({}, '', '/app/tenant-a/workspace-a/projects/project-1');
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { level: 2, name: /Connect sources for project-1/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /AWS/i }));
+    fireEvent.change(screen.getByLabelText('Role ARN'), {
+      target: { value: 'arn:aws:iam::123456789012:role/IdentrailReadOnly' }
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Validate and save AWS/i }));
+
+    await act(async () => {
+      window.history.pushState({}, '', '/app/tenant-a/workspace-a/projects/project-2');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+
+    expect(await screen.findByRole('heading', { level: 2, name: /Connect sources for project-2/i })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Refresh status/i })).not.toBeDisabled();
+    });
+    expect(screen.getByRole('button', { name: /Validate and save AWS/i })).not.toBeDisabled();
+
+    await act(async () => {
+      staleAWSSubmit.resolve({
+        ok: true,
+        json: async () => {
+          staleAWSResponseParsed = true;
+          return {
+            connection: {
+              provider: 'aws',
+              connected: true,
+              status: 'active',
+              health_status: 'healthy',
+              role_arn: 'arn:aws:iam::123456789012:role/IdentrailReadOnly',
+              external_id_configured: false,
+              permission_checks: [],
+              diagnostics: []
+            }
+          };
+        }
+      } as Response);
+      await staleAWSSubmit.promise;
+    });
+
+    await waitFor(() => {
+      expect(staleAWSResponseParsed).toBe(true);
+    });
+
+    expect(screen.queryByText(/AWS connector is active\./i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Validate and save AWS/i })).not.toBeDisabled();
   });
 
   it('validates and saves an AWS source from the connect-source wizard', async () => {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -17,6 +17,16 @@ function makeJWT(payload: Record<string, unknown>): string {
   return `${header}.${body}.signature`;
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe('App', () => {
   beforeEach(() => {
     window.sessionStorage.removeItem('identrail-product-session');
@@ -166,6 +176,54 @@ describe('App', () => {
     expect(await screen.findByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
   });
 
+  it('routes overview onboarding into the real project selection flow', async () => {
+    saveProductSession({
+      tenantID: 'tenant-a',
+      workspaceID: 'workspace-a'
+    });
+
+    window.history.pushState({}, '', '/app/tenant-a/workspace-a');
+    render(<App />);
+
+    const selectProjectLink = await screen.findByRole('link', { name: /Select project/i });
+    expect(selectProjectLink).toHaveAttribute('href', '/app/tenant-a/workspace-a/projects');
+  });
+
+  it('lists workspace projects and links them to concrete source onboarding routes', async () => {
+    saveProductSession({
+      tenantID: 'tenant-a',
+      workspaceID: 'workspace-a'
+    });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            tenant_id: 'tenant-a',
+            workspace_id: 'workspace-a',
+            project_id: 'project-1',
+            name: 'Production platform',
+            slug: 'production-platform',
+            description: 'Primary production boundary',
+            created_at: '2026-05-04T10:00:00Z',
+            updated_at: '2026-05-05T10:00:00Z'
+          }
+        ]
+      })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    window.history.pushState({}, '', '/app/tenant-a/workspace-a/projects');
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { level: 2, name: /Choose a project before connecting source data/i })).toBeInTheDocument();
+    expect(screen.getByText('Production platform')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Manage sources/i })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/projects/project-1'
+    );
+  });
+
   it('renders tenancy-scoped connect-source wizard inside app shell', async () => {
     saveProductSession({
       tenantID: 'tenant-a',
@@ -219,6 +277,132 @@ describe('App', () => {
     expect(screen.getByRole('button', { name: /Generate install link/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /AWS/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Kubernetes/i })).toBeInTheDocument();
+  });
+
+  it('ignores stale project refresh responses after route changes', async () => {
+    saveProductSession({
+      tenantID: 'tenant-a',
+      workspaceID: 'workspace-a'
+    });
+
+    const project1GitHub = deferred<Response>();
+    const project1AWS = deferred<Response>();
+    const project1Kubernetes = deferred<Response>();
+    const project2GitHub = deferred<Response>();
+    const project2AWS = deferred<Response>();
+    const project2Kubernetes = deferred<Response>();
+
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => project1GitHub.promise)
+      .mockImplementationOnce(() => project1AWS.promise)
+      .mockImplementationOnce(() => project1Kubernetes.promise)
+      .mockImplementationOnce(() => project2GitHub.promise)
+      .mockImplementationOnce(() => project2AWS.promise)
+      .mockImplementationOnce(() => project2Kubernetes.promise);
+    vi.stubGlobal('fetch', fetchMock);
+
+    window.history.pushState({}, '', '/app/tenant-a/workspace-a/projects/project-1');
+    render(<App />);
+
+    window.history.pushState({}, '', '/app/tenant-a/workspace-a/projects/project-2');
+    window.dispatchEvent(new PopStateEvent('popstate'));
+
+    project2GitHub.resolve({
+      ok: true,
+      json: async () => ({
+        connection: {
+          provider: 'github_app',
+          connected: true,
+          account_login: 'project-2-org',
+          installation_id: 22,
+          token_reference: 'github-app-installation:22',
+          webhook_secret_reference: 'github-webhook:project-2:22',
+          webhook_secret_rotation_required: false,
+          selected_repositories: ['identrail/project-2'],
+          updated_at: '2026-05-05T10:05:00Z'
+        }
+      })
+    } as Response);
+    project2AWS.resolve({
+      ok: true,
+      json: async () => ({
+        connection: {
+          provider: 'aws',
+          connected: false,
+          status: 'pending',
+          health_status: 'unknown',
+          external_id_configured: false,
+          permission_checks: [],
+          diagnostics: []
+        }
+      })
+    } as Response);
+    project2Kubernetes.resolve({
+      ok: true,
+      json: async () => ({
+        connection: {
+          provider: 'kubernetes',
+          connected: false,
+          status: 'pending',
+          health_status: 'unknown',
+          permission_checks: [],
+          diagnostics: []
+        }
+      })
+    } as Response);
+
+    expect(await screen.findByRole('heading', { level: 2, name: /Connect sources for project-2/i })).toBeInTheDocument();
+    expect(await screen.findByText(/Account project-2-org/i)).toBeInTheDocument();
+
+    project1GitHub.resolve({
+      ok: true,
+      json: async () => ({
+        connection: {
+          provider: 'github_app',
+          connected: true,
+          account_login: 'project-1-org',
+          installation_id: 11,
+          token_reference: 'github-app-installation:11',
+          webhook_secret_reference: 'github-webhook:project-1:11',
+          webhook_secret_rotation_required: false,
+          selected_repositories: ['identrail/project-1'],
+          updated_at: '2026-05-05T09:55:00Z'
+        }
+      })
+    } as Response);
+    project1AWS.resolve({
+      ok: true,
+      json: async () => ({
+        connection: {
+          provider: 'aws',
+          connected: false,
+          status: 'pending',
+          health_status: 'unknown',
+          external_id_configured: false,
+          permission_checks: [],
+          diagnostics: []
+        }
+      })
+    } as Response);
+    project1Kubernetes.resolve({
+      ok: true,
+      json: async () => ({
+        connection: {
+          provider: 'kubernetes',
+          connected: false,
+          status: 'pending',
+          health_status: 'unknown',
+          permission_checks: [],
+          diagnostics: []
+        }
+      })
+    } as Response);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Account project-1-org/i)).not.toBeInTheDocument();
+    });
+    expect(screen.getByText(/Account project-2-org/i)).toBeInTheDocument();
   });
 
   it('validates and saves an AWS source from the connect-source wizard', async () => {

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -195,4 +195,42 @@ describe('apiClient', () => {
     expect(url).toContain('/v1/workspaces/workspace-a/members/member-a');
     expect(options.method).toBe('DELETE');
   });
+
+  it('posts project source connector payloads with scoped headers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ connection: { provider: 'aws', connected: true } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.upsertAWSProjectConnection(
+      'workspace/a',
+      'project 1',
+      {
+        role_arn: 'arn:aws:iam::123456789012:role/IdentrailReadOnly',
+        external_id: 'external-prod',
+        region: 'us-east-1'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/v1/workspaces/workspace%2Fa/projects/project%201/aws/connection');
+    expect(options.method).toBe('POST');
+    expect(options.body).toBe(
+      JSON.stringify({
+        role_arn: 'arn:aws:iam::123456789012:role/IdentrailReadOnly',
+        external_id: 'external-prod',
+        region: 'us-east-1'
+      })
+    );
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
 });

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -3,8 +3,14 @@ import { apiClient, buildQuery, mergeRequestHeaders } from './client';
 
 describe('buildQuery', () => {
   it('encodes defined query params only', () => {
-    const query = buildQuery({ scan_id: 'scan-1', severity: 'high', empty: '', missing: undefined });
-    expect(query).toBe('?scan_id=scan-1&severity=high');
+    const query = buildQuery({
+      scan_id: 'scan-1',
+      severity: 'high',
+      include_archived: true,
+      empty: '',
+      missing: undefined
+    });
+    expect(query).toBe('?scan_id=scan-1&severity=high&include_archived=true');
   });
 });
 
@@ -174,6 +180,73 @@ describe('apiClient', () => {
     expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
     expect(headers.get('x-identrail-workspace-id')).toBe('workspace-a');
     expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
+  it('lists workspace projects with archive filters and scoped headers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [] })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.listProjects(
+      'workspace/a',
+      {
+        limit: 25,
+        sort_by: 'updated_at',
+        sort_order: 'desc',
+        include_archived: true
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      '/v1/workspaces/workspace%2Fa/projects?limit=25&sort_by=updated_at&sort_order=desc&include_archived=true'
+    );
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-identrail-tenant-id')).toBe('tenant-a');
+    expect(headers.get('x-identrail-workspace-id')).toBe('workspace/a');
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+  });
+
+  it('posts workspace project payload and encodes the target workspace id', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ project: { project_id: 'project-1' } })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.upsertProject(
+      'workspace/a',
+      {
+        project_id: 'project-1',
+        name: 'Project 1',
+        slug: 'project-1',
+        description: 'Production boundary'
+      },
+      {
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace/a',
+        bearerToken: 'token-a'
+      }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/v1/workspaces/workspace%2Fa/projects');
+    expect(options.method).toBe('POST');
+    expect(options.body).toBe(
+      JSON.stringify({
+        project_id: 'project-1',
+        name: 'Project 1',
+        slug: 'project-1',
+        description: 'Production boundary'
+      })
+    );
   });
 
   it('supports 204 no-content workspace member removal responses', async () => {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -115,6 +115,26 @@ export type WorkspaceContextSnapshot = {
   is_active: boolean;
 };
 
+export type ProjectRecord = {
+  tenant_id: string;
+  workspace_id: string;
+  project_id: string;
+  name: string;
+  slug: string;
+  description?: string;
+  archived_at?: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ProjectUpsertRequest = {
+  project_id: string;
+  name: string;
+  slug: string;
+  description?: string;
+  archived_at?: string | null;
+};
+
 export type WhoAmIResponse = {
   principal: {
     type: 'subject' | 'api_key' | 'anonymous';
@@ -381,7 +401,7 @@ async function request<T>(path: string, auth?: RequestAuthContext, init: Request
   return (await res.json()) as T;
 }
 
-function buildQuery(params: Record<string, string | number | undefined>): string {
+function buildQuery(params: Record<string, string | number | boolean | undefined>): string {
   const query = new URLSearchParams();
   Object.entries(params).forEach(([key, value]) => {
     if (value === undefined || value === '') return;
@@ -418,6 +438,38 @@ export const apiClient = {
     return request<{ items: WorkspaceMemberRecord[] }>(
       `/v1/workspaces/${encodedWorkspaceID}/members${buildQuery(filters)}`,
       auth
+    );
+  },
+  listProjects(
+    workspaceID: string,
+    filters: {
+      limit?: number;
+      cursor?: string;
+      sort_by?: string;
+      sort_order?: 'asc' | 'desc';
+      include_archived?: boolean;
+    } = {},
+    auth?: RequestAuthContext
+  ) {
+    return request<{ items: ProjectRecord[]; next_cursor?: string }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects${buildQuery(filters)}`,
+      auth
+    );
+  },
+  getProject(workspaceID: string, projectID: string, auth?: RequestAuthContext) {
+    return request<{ project: ProjectRecord }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}`,
+      auth
+    );
+  },
+  upsertProject(workspaceID: string, payload: ProjectUpsertRequest, auth?: RequestAuthContext) {
+    return request<{ project: ProjectRecord }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects`,
+      auth,
+      {
+        method: 'POST',
+        body: JSON.stringify(payload)
+      }
     );
   },
   upsertWorkspaceMember(

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -173,6 +173,135 @@ export type FindingTriageRequest = {
   comment?: string;
 };
 
+export type ConnectorLifecycleStatus = 'pending' | 'active' | 'degraded' | 'disconnected';
+export type ConnectorHealthStatus = 'unknown' | 'healthy' | 'warning' | 'error';
+
+export type AWSConnectionPermissionCheck = {
+  name: string;
+  passed: boolean;
+  message: string;
+  remediation?: string;
+};
+
+export type AWSConnectionDiagnostic = {
+  code: string;
+  message: string;
+  remediation?: string;
+};
+
+export type AWSConnectionStatus = {
+  provider: 'aws';
+  connected: boolean;
+  connector_id?: string;
+  display_name?: string;
+  status: ConnectorLifecycleStatus;
+  health_status: ConnectorHealthStatus;
+  role_arn?: string;
+  external_id_configured: boolean;
+  account_id?: string;
+  principal_arn?: string;
+  user_id?: string;
+  region?: string;
+  permission_checks: AWSConnectionPermissionCheck[];
+  diagnostics: AWSConnectionDiagnostic[];
+  remediation_message?: string;
+  created_at?: string;
+  updated_at?: string;
+  last_validated_at?: string;
+};
+
+export type AWSConnectionUpsertRequest = {
+  connector_id?: string;
+  display_name?: string;
+  role_arn: string;
+  external_id?: string;
+  region?: string;
+  session_name?: string;
+};
+
+export type KubernetesPermissionCheck = {
+  verb: string;
+  resource: string;
+  scope: string;
+  allowed: boolean;
+  diagnostic?: string;
+  remediation?: string;
+};
+
+export type KubernetesPreflightDiagnostic = {
+  code: string;
+  severity: 'warning' | 'error';
+  message: string;
+  remediation?: string;
+};
+
+export type KubernetesConnectionStatus = {
+  provider: 'kubernetes';
+  connected: boolean;
+  connector_id?: string;
+  display_name?: string;
+  status: ConnectorLifecycleStatus;
+  health_status: ConnectorHealthStatus;
+  context?: string;
+  cluster?: string;
+  server?: string;
+  git_version?: string;
+  platform?: string;
+  permission_checks: KubernetesPermissionCheck[];
+  diagnostics: KubernetesPreflightDiagnostic[];
+  remediation_message?: string;
+  created_at?: string;
+  updated_at?: string;
+  last_validated_at?: string;
+};
+
+export type KubernetesConnectionUpsertRequest = {
+  connector_id?: string;
+  display_name?: string;
+  context?: string;
+};
+
+export type GitHubConnectionStartRequest = {
+  app_slug?: string;
+  redirect_uri?: string;
+};
+
+export type GitHubConnectionStartResponse = {
+  state: string;
+  connect_url: string;
+  expires_at: string;
+};
+
+export type GitHubConnectionCompleteRequest = {
+  state: string;
+  installation_id: number;
+  account_login?: string;
+  token_reference: string;
+  webhook_secret: string;
+  webhook_secret_reference: string;
+  selected_repositories?: string[];
+};
+
+export type GitHubConnectionStatus = {
+  provider: string;
+  connected: boolean;
+  account_login?: string;
+  installation_id?: number;
+  token_reference?: string;
+  webhook_secret_reference?: string;
+  webhook_secret_key_version?: string;
+  webhook_secret_algorithm?: string;
+  webhook_secret_rotated_at?: string;
+  webhook_secret_rotation_due_at?: string;
+  webhook_secret_rotation_required: boolean;
+  selected_repositories: string[];
+  created_at?: string;
+  updated_at?: string;
+  last_webhook_event_type?: string;
+  last_webhook_delivery_id?: string;
+  last_webhook_event_at?: string;
+};
+
 const viteEnv = ((import.meta as unknown as { env?: Record<string, unknown> }).env ?? {}) as Record<string, unknown>;
 const isProd = viteEnv.PROD === true || viteEnv.PROD === 'true';
 const configuredURL = typeof viteEnv.VITE_IDENTRAIL_API_URL === 'string' ? viteEnv.VITE_IDENTRAIL_API_URL : undefined;
@@ -392,6 +521,84 @@ export const apiClient = {
         sort_order: 'desc'
       })}`,
       auth
+    );
+  },
+  getAWSProjectConnection(workspaceID: string, projectID: string, auth?: RequestAuthContext) {
+    return request<{ connection: AWSConnectionStatus }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/connection`,
+      auth
+    );
+  },
+  upsertAWSProjectConnection(
+    workspaceID: string,
+    projectID: string,
+    payload: AWSConnectionUpsertRequest,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ connection: AWSConnectionStatus }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/aws/connection`,
+      auth,
+      {
+        method: 'POST',
+        body: JSON.stringify(payload)
+      }
+    );
+  },
+  getKubernetesProjectConnection(workspaceID: string, projectID: string, auth?: RequestAuthContext) {
+    return request<{ connection: KubernetesConnectionStatus }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/kubernetes/connection`,
+      auth
+    );
+  },
+  upsertKubernetesProjectConnection(
+    workspaceID: string,
+    projectID: string,
+    payload: KubernetesConnectionUpsertRequest,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ connection: KubernetesConnectionStatus }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/kubernetes/connection`,
+      auth,
+      {
+        method: 'POST',
+        body: JSON.stringify(payload)
+      }
+    );
+  },
+  getGitHubProjectConnection(workspaceID: string, projectID: string, auth?: RequestAuthContext) {
+    return request<{ connection: GitHubConnectionStatus }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/github/connection`,
+      auth
+    );
+  },
+  startGitHubProjectConnection(
+    workspaceID: string,
+    projectID: string,
+    payload: GitHubConnectionStartRequest = {},
+    auth?: RequestAuthContext
+  ) {
+    return request<{ connection: GitHubConnectionStartResponse }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/github/connect/start`,
+      auth,
+      {
+        method: 'POST',
+        body: JSON.stringify(payload)
+      }
+    );
+  },
+  completeGitHubProjectConnection(
+    workspaceID: string,
+    projectID: string,
+    payload: GitHubConnectionCompleteRequest,
+    auth?: RequestAuthContext
+  ) {
+    return request<{ connection: GitHubConnectionStatus }>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/projects/${encodeURIComponent(projectID)}/github/connect/complete`,
+      auth,
+      {
+        method: 'POST',
+        body: JSON.stringify(payload)
+      }
     );
   },
   async submitLeadCapture(payload: LeadCapturePayload) {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1,4 +1,4 @@
-import { Component, FormEvent, ReactNode, useEffect, useMemo, useState } from 'react';
+import { Component, FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, Navigate, NavLink, Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
 import {
   apiClient,
@@ -6,6 +6,7 @@ import {
   type GitHubConnectionStartResponse,
   type GitHubConnectionStatus,
   type KubernetesConnectionStatus,
+  type ProjectRecord,
   type RequestAuthContext,
   type WhoAmIResponse,
   type WorkspaceMemberRecord,
@@ -654,6 +655,14 @@ function buildScopedPath(scope: ProductSession, suffix = ''): string {
   return suffix ? `${base}/${suffix}` : base;
 }
 
+function buildProjectsPath(scope: ProductSession): string {
+  return buildScopedPath(scope, 'projects');
+}
+
+function buildProjectPath(scope: ProductSession, projectID: string): string {
+  return `${buildProjectsPath(scope)}/${encodeURIComponent(projectID)}`;
+}
+
 const MEMBER_ROLE_OPTIONS: WorkspaceMemberRole[] = ['owner', 'admin', 'analyst', 'viewer'];
 const MEMBER_STATUS_OPTIONS: WorkspaceMemberStatus[] = ['invited', 'active', 'suspended', 'removed'];
 const SOURCE_PROFILES: Record<SourceProvider, SourceProfile> = {
@@ -710,6 +719,18 @@ function deriveMemberID(userID: string, email: string): string {
   const emailToken = normalizeMemberID(email.split('@')[0] ?? '');
   const token = userToken || emailToken;
   return token ? `member-${token}`.slice(0, 72) : `member-${Date.now()}`;
+}
+
+function normalizeProjectToken(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+}
+
+function deriveProjectToken(value: string, fallback = 'project'): string {
+  return normalizeProjectToken(value) || fallback;
 }
 
 function hasWorkspaceAdminAccess(scope: ProductSession, whoAmI: WhoAmIResponse | null): boolean {
@@ -1312,9 +1333,9 @@ export function ProductOverviewPage() {
   return (
     <ScopedShellPage
       title="Overview"
-      description={`Entry view for tenant ${scope?.tenantID ?? 'unknown'} and workspace ${scope?.workspaceID ?? 'unknown'}.`}
-      actionLabel="Connect source"
-      actionTo={`/app/${encodeURIComponent(scope?.tenantID ?? 'default')}/${encodeURIComponent(scope?.workspaceID ?? 'default')}/projects/${encodeURIComponent(scope?.projectID ?? 'sample-project')}`}
+      description={`Choose a project for tenant ${scope?.tenantID ?? 'unknown'} and workspace ${scope?.workspaceID ?? 'unknown'} before connecting source telemetry.`}
+      actionLabel="Select project"
+      actionTo={scope ? buildProjectsPath(scope) : undefined}
     />
   );
 }
@@ -1859,14 +1880,302 @@ export function ProductWorkspacesPage() {
 
 export function ProductProjectsPage() {
   const params = useParams<ScopeRouteParams>();
+  const navigate = useNavigate();
   const scope = resolveScopeFromParams(params);
+
+  const [projects, setProjects] = useState<ProjectRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [draftName, setDraftName] = useState('');
+  const [draftProjectID, setDraftProjectID] = useState('');
+  const [draftSlug, setDraftSlug] = useState('');
+  const [draftDescription, setDraftDescription] = useState('');
+  const [projectIDEdited, setProjectIDEdited] = useState(false);
+  const [slugEdited, setSlugEdited] = useState(false);
+
+  useEffect(() => {
+    if (!scope) {
+      setProjects([]);
+      setLoading(false);
+      return;
+    }
+
+    let active = true;
+
+    const loadProjects = async () => {
+      setLoading(true);
+      setError('');
+      setProjects([]);
+      try {
+        const auth = buildProductAuthContext(scope);
+        const response = await apiClient.listProjects(
+          scope.workspaceID,
+          {
+            limit: 50,
+            sort_by: 'updated_at',
+            sort_order: 'desc',
+            include_archived: true
+          },
+          auth
+        );
+        if (!active) {
+          return;
+        }
+        setProjects(response.items);
+      } catch (loadError) {
+        if (!active) {
+          return;
+        }
+        setError(loadError instanceof Error ? loadError.message : 'Unable to load workspace projects.');
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void loadProjects();
+
+    return () => {
+      active = false;
+    };
+  }, [scope?.tenantID, scope?.workspaceID]);
+
+  const activeProjectCount = useMemo(
+    () => projects.filter((project) => !normalizeValue(project.archived_at ?? '')).length,
+    [projects]
+  );
+  const archivedProjectCount = projects.length - activeProjectCount;
+  const latestProject = projects[0];
+
+  if (!scope) {
+    return <AppShellLoading message="Resolving workspace scope" />;
+  }
+
+  if (loading) {
+    return <AppShellLoading message="Loading projects" />;
+  }
+
+  const handleNameChange = (value: string) => {
+    setDraftName(value);
+    const token = deriveProjectToken(value);
+    if (!projectIDEdited) {
+      setDraftProjectID(token);
+    }
+    if (!slugEdited) {
+      setDraftSlug(token);
+    }
+  };
+
+  const handleCreateProject = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const name = normalizeValue(draftName);
+    const projectID = normalizeValue(draftProjectID) || deriveProjectToken(name);
+    const slug = normalizeValue(draftSlug) || deriveProjectToken(name);
+    const description = normalizeValue(draftDescription);
+
+    if (!name) {
+      setError('Project name is required.');
+      return;
+    }
+    if (!projectID) {
+      setError('Project ID is required.');
+      return;
+    }
+    if (!slug) {
+      setError('Project slug is required.');
+      return;
+    }
+
+    setSaving(true);
+    setError('');
+
+    try {
+      const auth = buildProductAuthContext(scope);
+      const response = await apiClient.upsertProject(
+        scope.workspaceID,
+        {
+          project_id: projectID,
+          name,
+          slug,
+          description: description || undefined
+        },
+        auth
+      );
+      setProjects((current) => {
+        const remaining = current.filter((project) => project.project_id !== response.project.project_id);
+        return [response.project, ...remaining];
+      });
+      setDraftName('');
+      setDraftProjectID('');
+      setDraftSlug('');
+      setDraftDescription('');
+      setProjectIDEdited(false);
+      setSlugEdited(false);
+      navigate(buildProjectPath(scope, response.project.project_id));
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : 'Unable to save project.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
-    <ScopedShellPage
-      title="Projects"
-      description="Project-level onboarding and scan boundaries live here."
-      actionLabel="Connect source"
-      actionTo={`/app/${encodeURIComponent(scope?.tenantID ?? 'default')}/${encodeURIComponent(scope?.workspaceID ?? 'default')}/projects/${encodeURIComponent(scope?.projectID ?? 'sample-project')}`}
-    />
+    <section className="idt-app-panel idt-projects-page">
+      <div className="idt-projects-header">
+        <div>
+          <p className="idt-app-kicker">Project registry</p>
+          <h2>Choose a project before connecting source data</h2>
+          <p>Projects set the workspace boundary for GitHub, AWS, and Kubernetes onboarding.</p>
+        </div>
+        <div className="idt-inline-actions">
+          <Link className="idt-btn idt-btn-ghost" to={buildScopedPath(scope)}>
+            Back to overview
+          </Link>
+        </div>
+      </div>
+
+      <div className="idt-projects-summary">
+        <article>
+          <span>{projects.length}</span>
+          <p>Total projects</p>
+        </article>
+        <article>
+          <span>{activeProjectCount}</span>
+          <p>Active boundaries</p>
+        </article>
+        <article>
+          <span>{latestProject ? formatConnectionTime(latestProject.updated_at) : 'No activity yet'}</span>
+          <p>Latest update</p>
+        </article>
+      </div>
+
+      {error ? <div className="idt-app-alert idt-app-alert-error">{error}</div> : null}
+
+      <div className="idt-projects-grid">
+        <article className="idt-projects-list">
+          <div className="idt-projects-section-header">
+            <div>
+              <h3>Workspace projects</h3>
+              <p>
+                {archivedProjectCount > 0
+                  ? `${activeProjectCount} active, ${archivedProjectCount} archived.`
+                  : 'Select an existing project to continue source onboarding.'}
+              </p>
+            </div>
+          </div>
+
+          {projects.length === 0 ? (
+            <AppShellEmptyState
+              title="No projects yet"
+              body="Create the first project for this workspace, then continue into source onboarding."
+            />
+          ) : (
+            <div className="idt-project-card-list">
+              {projects.map((project) => {
+                const archived = Boolean(normalizeValue(project.archived_at ?? ''));
+                return (
+                  <article key={project.project_id} className="idt-project-card">
+                    <div className="idt-project-card-header">
+                      <div>
+                        <h4>{project.name}</h4>
+                        <p>{project.description || 'No description yet. Use this project to scope connector onboarding and scan ownership.'}</p>
+                      </div>
+                      <span
+                        className={`idt-source-status-pill ${archived ? 'is-warning' : 'is-success'}`}
+                      >
+                        {archived ? 'Archived' : 'Active'}
+                      </span>
+                    </div>
+
+                    <dl className="idt-project-card-meta">
+                      <div>
+                        <dt>Project ID</dt>
+                        <dd>{project.project_id}</dd>
+                      </div>
+                      <div>
+                        <dt>Slug</dt>
+                        <dd>{project.slug}</dd>
+                      </div>
+                      <div>
+                        <dt>Updated</dt>
+                        <dd>{formatConnectionTime(project.updated_at)}</dd>
+                      </div>
+                    </dl>
+
+                    <div className="idt-inline-actions">
+                      <Link className="idt-btn idt-btn-primary" to={buildProjectPath(scope, project.project_id)}>
+                        Manage sources
+                      </Link>
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </article>
+
+        <article className="idt-project-composer">
+          <div className="idt-projects-section-header">
+            <div>
+              <h3>Create project</h3>
+              <p>Set the canonical project ID and route-safe slug once, then continue into connector setup.</p>
+            </div>
+          </div>
+
+          <form className="idt-app-form" onSubmit={handleCreateProject}>
+            <label>
+              Project name
+              <input
+                value={draftName}
+                onChange={(event) => handleNameChange(event.target.value)}
+                placeholder="Production platform"
+                required
+              />
+            </label>
+            <div className="idt-project-inline-fields">
+              <label>
+                Project ID
+                <input
+                  value={draftProjectID}
+                  onChange={(event) => {
+                    setProjectIDEdited(true);
+                    setDraftProjectID(normalizeProjectToken(event.target.value));
+                  }}
+                  placeholder="production-platform"
+                  required
+                />
+              </label>
+              <label>
+                Slug
+                <input
+                  value={draftSlug}
+                  onChange={(event) => {
+                    setSlugEdited(true);
+                    setDraftSlug(normalizeProjectToken(event.target.value));
+                  }}
+                  placeholder="production-platform"
+                  required
+                />
+              </label>
+            </div>
+            <label>
+              Description
+              <textarea
+                value={draftDescription}
+                onChange={(event) => setDraftDescription(event.target.value)}
+                placeholder="Identity boundary for the production control plane and its delivery repositories."
+              />
+            </label>
+            <button className="idt-btn idt-btn-primary" type="submit" disabled={saving}>
+              {saving ? 'Creating project...' : 'Create project and continue'}
+            </button>
+          </form>
+        </article>
+      </div>
+    </section>
   );
 }
 
@@ -1874,6 +2183,7 @@ export function ProductProjectDetailPage() {
   const params = useParams<ScopeRouteParams>();
   const scope = resolveScopeFromParams(params);
   const projectID = normalizeValue(params.projectID ?? '');
+  const refreshSequenceRef = useRef(0);
 
   const [connections, setConnections] = useState<SourceConnectionMap>({});
   const [sourceErrors, setSourceErrors] = useState<Partial<Record<SourceProvider, string>>>({});
@@ -1909,8 +2219,14 @@ export function ProductProjectDetailPage() {
   });
 
   const refreshConnections = async (quiet = false) => {
+    const refreshSequence = refreshSequenceRef.current + 1;
+    refreshSequenceRef.current = refreshSequence;
+
     if (!scope || !projectID) {
+      setConnections({});
+      setSourceErrors({});
       setLoading(false);
+      setRefreshing(false);
       return;
     }
 
@@ -1927,6 +2243,10 @@ export function ProductProjectDetailPage() {
       apiClient.getAWSProjectConnection(scope.workspaceID, projectID, auth),
       apiClient.getKubernetesProjectConnection(scope.workspaceID, projectID, auth)
     ]);
+
+    if (refreshSequenceRef.current !== refreshSequence) {
+      return;
+    }
 
     const nextConnections: SourceConnectionMap = {};
     const nextErrors: Partial<Record<SourceProvider, string>> = {};
@@ -1950,14 +2270,22 @@ export function ProductProjectDetailPage() {
       nextErrors[provider] = result.reason instanceof Error ? result.reason.message : `Unable to load ${SOURCE_PROFILES[provider].name} status.`;
     });
 
-    setConnections((current) => ({ ...current, ...nextConnections }));
+    setConnections(nextConnections);
     setSourceErrors(nextErrors);
     setLoading(false);
     setRefreshing(false);
   };
 
   useEffect(() => {
+    setConnections({});
+    setSourceErrors({});
+    setSuccessMessage('');
+    setGitHubStart(null);
     void refreshConnections(false);
+
+    return () => {
+      refreshSequenceRef.current += 1;
+    };
   }, [scope?.tenantID, scope?.workspaceID, projectID]);
 
   if (!scope || !projectID) {
@@ -1982,9 +2310,7 @@ export function ProductProjectDetailPage() {
       const auth = buildProductAuthContext(scope);
       const redirectURI =
         normalizeValue(githubStartForm.redirectURI) ||
-        (typeof window !== 'undefined'
-          ? `${window.location.origin}${buildScopedPath(scope, `projects/${projectID}`)}`
-          : undefined);
+        (typeof window !== 'undefined' ? `${window.location.origin}${buildProjectPath(scope, projectID)}` : undefined);
       const response = await apiClient.startGitHubProjectConnection(
         scope.workspaceID,
         projectID,

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -2218,9 +2218,16 @@ export function ProductProjectDetailPage() {
     context: ''
   });
 
+  const nextRequestSequence = () => {
+    const nextSequence = refreshSequenceRef.current + 1;
+    refreshSequenceRef.current = nextSequence;
+    return nextSequence;
+  };
+
+  const isStaleRequestSequence = (sequence: number) => refreshSequenceRef.current !== sequence;
+
   const refreshConnections = async (quiet = false) => {
-    const refreshSequence = refreshSequenceRef.current + 1;
-    refreshSequenceRef.current = refreshSequence;
+    const refreshSequence = nextRequestSequence();
 
     if (!scope || !projectID) {
       setConnections({});
@@ -2244,7 +2251,7 @@ export function ProductProjectDetailPage() {
       apiClient.getKubernetesProjectConnection(scope.workspaceID, projectID, auth)
     ]);
 
-    if (refreshSequenceRef.current !== refreshSequence) {
+    if (isStaleRequestSequence(refreshSequence)) {
       return;
     }
 
@@ -2279,6 +2286,7 @@ export function ProductProjectDetailPage() {
   useEffect(() => {
     setConnections({});
     setSourceErrors({});
+    setSubmitting('');
     setSuccessMessage('');
     setGitHubStart(null);
     void refreshConnections(false);
@@ -2306,6 +2314,7 @@ export function ProductProjectDetailPage() {
     setSubmitting('github');
     setSuccessMessage('');
     setSourceErrors((current) => ({ ...current, github: undefined }));
+    const requestSequence = refreshSequenceRef.current;
     try {
       const auth = buildProductAuthContext(scope);
       const redirectURI =
@@ -2320,6 +2329,9 @@ export function ProductProjectDetailPage() {
         },
         auth
       );
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
       setGitHubStart(response.connection);
       setGitHubComplete((current) => ({
         ...current,
@@ -2330,10 +2342,15 @@ export function ProductProjectDetailPage() {
       }));
       setSuccessMessage('GitHub installation link generated.');
     } catch (error) {
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
       const message = error instanceof Error ? error.message : 'Unable to start GitHub connection.';
       setSourceErrors((current) => ({ ...current, github: message }));
     } finally {
-      setSubmitting('');
+      if (!isStaleRequestSequence(requestSequence)) {
+        setSubmitting('');
+      }
     }
   };
 
@@ -2342,6 +2359,7 @@ export function ProductProjectDetailPage() {
     setSubmitting('github');
     setSuccessMessage('');
     setSourceErrors((current) => ({ ...current, github: undefined }));
+    const requestSequence = refreshSequenceRef.current;
     try {
       const state = normalizeValue(githubComplete.state || githubStart?.state || '');
       const installationID = Number.parseInt(githubComplete.installationID, 10);
@@ -2383,14 +2401,22 @@ export function ProductProjectDetailPage() {
         },
         auth
       );
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
       setConnections((current) => ({ ...current, github: response.connection }));
       setGitHubStart(null);
       setSuccessMessage('GitHub connection saved and ready for repository events.');
     } catch (error) {
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
       const message = error instanceof Error ? error.message : 'Unable to complete GitHub connection.';
       setSourceErrors((current) => ({ ...current, github: message }));
     } finally {
-      setSubmitting('');
+      if (!isStaleRequestSequence(requestSequence)) {
+        setSubmitting('');
+      }
     }
   };
 
@@ -2399,6 +2425,7 @@ export function ProductProjectDetailPage() {
     setSubmitting('aws');
     setSuccessMessage('');
     setSourceErrors((current) => ({ ...current, aws: undefined }));
+    const requestSequence = refreshSequenceRef.current;
     try {
       const roleARN = normalizeValue(awsForm.roleARN);
       if (!AWS_ROLE_ARN_PATTERN.test(roleARN)) {
@@ -2417,15 +2444,23 @@ export function ProductProjectDetailPage() {
         },
         auth
       );
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
       setConnections((current) => ({ ...current, aws: response.connection }));
       setSuccessMessage(
         response.connection.connected ? 'AWS connector is active.' : 'AWS connector saved with diagnostics to resolve.'
       );
     } catch (error) {
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
       const message = error instanceof Error ? error.message : 'Unable to validate AWS connection.';
       setSourceErrors((current) => ({ ...current, aws: message }));
     } finally {
-      setSubmitting('');
+      if (!isStaleRequestSequence(requestSequence)) {
+        setSubmitting('');
+      }
     }
   };
 
@@ -2434,6 +2469,7 @@ export function ProductProjectDetailPage() {
     setSubmitting('kubernetes');
     setSuccessMessage('');
     setSourceErrors((current) => ({ ...current, kubernetes: undefined }));
+    const requestSequence = refreshSequenceRef.current;
     try {
       const auth = buildProductAuthContext(scope);
       const response = await apiClient.upsertKubernetesProjectConnection(
@@ -2445,6 +2481,9 @@ export function ProductProjectDetailPage() {
         },
         auth
       );
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
       setConnections((current) => ({ ...current, kubernetes: response.connection }));
       setSuccessMessage(
         response.connection.connected
@@ -2452,10 +2491,15 @@ export function ProductProjectDetailPage() {
           : 'Kubernetes preflight completed with diagnostics to resolve.'
       );
     } catch (error) {
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
       const message = error instanceof Error ? error.message : 'Unable to validate Kubernetes connection.';
       setSourceErrors((current) => ({ ...current, kubernetes: message }));
     } finally {
-      setSubmitting('');
+      if (!isStaleRequestSequence(requestSequence)) {
+        setSubmitting('');
+      }
     }
   };
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -2,6 +2,10 @@ import { Component, FormEvent, ReactNode, useEffect, useMemo, useState } from 'r
 import { Link, Navigate, NavLink, Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
 import {
   apiClient,
+  type AWSConnectionStatus,
+  type GitHubConnectionStartResponse,
+  type GitHubConnectionStatus,
+  type KubernetesConnectionStatus,
   type RequestAuthContext,
   type WhoAmIResponse,
   type WorkspaceMemberRecord,
@@ -35,6 +39,23 @@ type ScopedShellPageProps = {
   description: string;
   actionLabel?: string;
   actionTo?: string;
+};
+
+type SourceProvider = 'github' | 'aws' | 'kubernetes';
+
+type SourceConnectionMap = {
+  github?: GitHubConnectionStatus;
+  aws?: AWSConnectionStatus;
+  kubernetes?: KubernetesConnectionStatus;
+};
+
+type SourceProfile = {
+  provider: SourceProvider;
+  name: string;
+  eyebrow: string;
+  summary: string;
+  primarySignal: string;
+  requiredAccess: string;
 };
 
 type OIDCConfig = {
@@ -635,6 +656,36 @@ function buildScopedPath(scope: ProductSession, suffix = ''): string {
 
 const MEMBER_ROLE_OPTIONS: WorkspaceMemberRole[] = ['owner', 'admin', 'analyst', 'viewer'];
 const MEMBER_STATUS_OPTIONS: WorkspaceMemberStatus[] = ['invited', 'active', 'suspended', 'removed'];
+const SOURCE_PROFILES: Record<SourceProvider, SourceProfile> = {
+  github: {
+    provider: 'github',
+    name: 'GitHub',
+    eyebrow: 'Code and workflow identity',
+    summary: 'Connect a GitHub App installation and select repositories that should feed exposure telemetry.',
+    primarySignal: 'Repositories, workflow identity, webhook scan triggers',
+    requiredAccess: 'GitHub App installation with selected repository access'
+  },
+  aws: {
+    provider: 'aws',
+    name: 'AWS',
+    eyebrow: 'Cloud IAM identity',
+    summary: 'Validate a read-only IAM role before Identrail records the account connector.',
+    primarySignal: 'Roles, trust policies, account identity, IAM read checks',
+    requiredAccess: 'Assumable read-only IAM role ARN'
+  },
+  kubernetes: {
+    provider: 'kubernetes',
+    name: 'Kubernetes',
+    eyebrow: 'Cluster service identity',
+    summary: 'Run a non-mutating preflight against the configured cluster context before activation.',
+    primarySignal: 'Service accounts, RBAC bindings, pods, cluster metadata',
+    requiredAccess: 'Read-only kubectl context available to the API runtime'
+  }
+};
+const SOURCE_ORDER: SourceProvider[] = ['github', 'aws', 'kubernetes'];
+const CONNECT_SOURCE_STEPS = ['Choose', 'Configure', 'Validate', 'Active'] as const;
+const GITHUB_REPOSITORY_SPLIT_PATTERN = /[\n,]+/;
+const AWS_ROLE_ARN_PATTERN = /^arn:(aws|aws-us-gov|aws-cn):iam::[0-9]{12}:role\/[A-Za-z0-9+=,.@_/-]{1,512}$/;
 
 function buildProductAuthContext(scope: ProductSession): RequestAuthContext {
   const session = readProductSession();
@@ -679,6 +730,86 @@ function hasWorkspaceAdminAccess(scope: ProductSession, whoAmI: WhoAmIResponse |
     return false;
   }
   return activeRole === 'owner' || activeRole === 'admin';
+}
+
+function sourceConnection(connections: SourceConnectionMap, provider: SourceProvider) {
+  return provider === 'github'
+    ? connections.github
+    : provider === 'aws'
+      ? connections.aws
+      : connections.kubernetes;
+}
+
+function connectionHealth(status?: GitHubConnectionStatus | AWSConnectionStatus | KubernetesConnectionStatus): string {
+  if (!status) {
+    return 'unknown';
+  }
+  if ('health_status' in status) {
+    return status.health_status;
+  }
+  return status.connected ? 'healthy' : 'unknown';
+}
+
+function connectionLifecycle(status?: GitHubConnectionStatus | AWSConnectionStatus | KubernetesConnectionStatus): string {
+  if (!status) {
+    return 'Not checked';
+  }
+  if (status.connected) {
+    return 'Active';
+  }
+  if ('status' in status) {
+    return status.status.charAt(0).toUpperCase() + status.status.slice(1);
+  }
+  return 'Not connected';
+}
+
+function connectionTone(status?: GitHubConnectionStatus | AWSConnectionStatus | KubernetesConnectionStatus): 'success' | 'warning' | 'error' | 'neutral' {
+  if (!status) {
+    return 'neutral';
+  }
+  const health = connectionHealth(status);
+  if (status.connected && (health === 'healthy' || health === 'unknown')) {
+    return 'success';
+  }
+  if (health === 'error' || ('status' in status && status.status === 'degraded')) {
+    return 'error';
+  }
+  if (health === 'warning') {
+    return 'warning';
+  }
+  return 'neutral';
+}
+
+function formatConnectionTime(value?: string): string {
+  if (!value) {
+    return 'Never';
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleString();
+}
+
+function parseGitHubRepositories(value: string): string[] {
+  const seen = new Set<string>();
+  return value
+    .split(GITHUB_REPOSITORY_SPLIT_PATTERN)
+    .map((entry) => normalizeValue(entry).toLowerCase())
+    .filter((entry) => {
+      if (!entry || !entry.includes('/') || seen.has(entry)) {
+        return false;
+      }
+      seen.add(entry);
+      return true;
+    });
+}
+
+function newWebhookSecret(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    return `whsec_${randomString(32)}`;
+  }
+  return `whsec_${Date.now().toString(36)}`;
 }
 
 function useScaffoldDataState(delayMS = 320) {
@@ -1182,8 +1313,8 @@ export function ProductOverviewPage() {
     <ScopedShellPage
       title="Overview"
       description={`Entry view for tenant ${scope?.tenantID ?? 'unknown'} and workspace ${scope?.workspaceID ?? 'unknown'}.`}
-      actionLabel="Open findings"
-      actionTo={`/app/${encodeURIComponent(scope?.tenantID ?? 'default')}/${encodeURIComponent(scope?.workspaceID ?? 'default')}/findings`}
+      actionLabel="Connect source"
+      actionTo={`/app/${encodeURIComponent(scope?.tenantID ?? 'default')}/${encodeURIComponent(scope?.workspaceID ?? 'default')}/projects/${encodeURIComponent(scope?.projectID ?? 'sample-project')}`}
     />
   );
 }
@@ -1733,7 +1864,7 @@ export function ProductProjectsPage() {
     <ScopedShellPage
       title="Projects"
       description="Project-level onboarding and scan boundaries live here."
-      actionLabel="View placeholder project"
+      actionLabel="Connect source"
       actionTo={`/app/${encodeURIComponent(scope?.tenantID ?? 'default')}/${encodeURIComponent(scope?.workspaceID ?? 'default')}/projects/${encodeURIComponent(scope?.projectID ?? 'sample-project')}`}
     />
   );
@@ -1741,11 +1872,659 @@ export function ProductProjectsPage() {
 
 export function ProductProjectDetailPage() {
   const params = useParams<ScopeRouteParams>();
+  const scope = resolveScopeFromParams(params);
+  const projectID = normalizeValue(params.projectID ?? '');
+
+  const [connections, setConnections] = useState<SourceConnectionMap>({});
+  const [sourceErrors, setSourceErrors] = useState<Partial<Record<SourceProvider, string>>>({});
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [submitting, setSubmitting] = useState<SourceProvider | ''>('');
+  const [selectedSource, setSelectedSource] = useState<SourceProvider>('github');
+  const [successMessage, setSuccessMessage] = useState('');
+  const [githubStart, setGitHubStart] = useState<GitHubConnectionStartResponse | null>(null);
+  const [githubStartForm, setGitHubStartForm] = useState({
+    appSlug: 'identrail',
+    redirectURI: ''
+  });
+  const [githubComplete, setGitHubComplete] = useState({
+    state: '',
+    installationID: '',
+    accountLogin: '',
+    repositories: '',
+    tokenReference: '',
+    webhookSecret: '',
+    webhookSecretReference: ''
+  });
+  const [awsForm, setAWSForm] = useState({
+    roleARN: '',
+    externalID: '',
+    region: 'us-east-1',
+    displayName: '',
+    sessionName: 'identrail-connector-validation'
+  });
+  const [kubernetesForm, setKubernetesForm] = useState({
+    displayName: '',
+    context: ''
+  });
+
+  const refreshConnections = async (quiet = false) => {
+    if (!scope || !projectID) {
+      setLoading(false);
+      return;
+    }
+
+    if (quiet) {
+      setRefreshing(true);
+    } else {
+      setLoading(true);
+    }
+    setSourceErrors({});
+    const auth = buildProductAuthContext(scope);
+
+    const results = await Promise.allSettled([
+      apiClient.getGitHubProjectConnection(scope.workspaceID, projectID, auth),
+      apiClient.getAWSProjectConnection(scope.workspaceID, projectID, auth),
+      apiClient.getKubernetesProjectConnection(scope.workspaceID, projectID, auth)
+    ]);
+
+    const nextConnections: SourceConnectionMap = {};
+    const nextErrors: Partial<Record<SourceProvider, string>> = {};
+    const providers: SourceProvider[] = ['github', 'aws', 'kubernetes'];
+
+    results.forEach((result, index) => {
+      const provider = providers[index];
+      if (!provider) {
+        return;
+      }
+      if (result.status === 'fulfilled') {
+        if (provider === 'github') {
+          nextConnections.github = result.value.connection as GitHubConnectionStatus;
+        } else if (provider === 'aws') {
+          nextConnections.aws = result.value.connection as AWSConnectionStatus;
+        } else {
+          nextConnections.kubernetes = result.value.connection as KubernetesConnectionStatus;
+        }
+        return;
+      }
+      nextErrors[provider] = result.reason instanceof Error ? result.reason.message : `Unable to load ${SOURCE_PROFILES[provider].name} status.`;
+    });
+
+    setConnections((current) => ({ ...current, ...nextConnections }));
+    setSourceErrors(nextErrors);
+    setLoading(false);
+    setRefreshing(false);
+  };
+
+  useEffect(() => {
+    void refreshConnections(false);
+  }, [scope?.tenantID, scope?.workspaceID, projectID]);
+
+  if (!scope || !projectID) {
+    return <AppShellLoading message="Resolving project scope" />;
+  }
+
+  if (loading) {
+    return <AppShellLoading message="Loading source connections" />;
+  }
+
+  const selectedStatus = sourceConnection(connections, selectedSource);
+  const selectedProfile = SOURCE_PROFILES[selectedSource];
+  const connectedCount = SOURCE_ORDER.filter((provider) => sourceConnection(connections, provider)?.connected).length;
+  const activeStepIndex = selectedStatus?.connected ? 3 : submitting === selectedSource ? 2 : 1;
+
+  const handleGitHubStart = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitting('github');
+    setSuccessMessage('');
+    setSourceErrors((current) => ({ ...current, github: undefined }));
+    try {
+      const auth = buildProductAuthContext(scope);
+      const redirectURI =
+        normalizeValue(githubStartForm.redirectURI) ||
+        (typeof window !== 'undefined'
+          ? `${window.location.origin}${buildScopedPath(scope, `projects/${projectID}`)}`
+          : undefined);
+      const response = await apiClient.startGitHubProjectConnection(
+        scope.workspaceID,
+        projectID,
+        {
+          app_slug: normalizeValue(githubStartForm.appSlug) || undefined,
+          redirect_uri: redirectURI
+        },
+        auth
+      );
+      setGitHubStart(response.connection);
+      setGitHubComplete((current) => ({
+        ...current,
+        state: response.connection.state,
+        webhookSecret: current.webhookSecret || newWebhookSecret(),
+        webhookSecretReference:
+          current.webhookSecretReference || `github-webhook:${projectID}:${response.connection.state.slice(0, 8)}`
+      }));
+      setSuccessMessage('GitHub installation link generated.');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to start GitHub connection.';
+      setSourceErrors((current) => ({ ...current, github: message }));
+    } finally {
+      setSubmitting('');
+    }
+  };
+
+  const handleGitHubComplete = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitting('github');
+    setSuccessMessage('');
+    setSourceErrors((current) => ({ ...current, github: undefined }));
+    try {
+      const state = normalizeValue(githubComplete.state || githubStart?.state || '');
+      const installationID = Number.parseInt(githubComplete.installationID, 10);
+      const repositories = parseGitHubRepositories(githubComplete.repositories);
+      if (!state) {
+        throw new Error('Generate a GitHub install state before saving the connection.');
+      }
+      if (!Number.isFinite(installationID) || installationID <= 0) {
+        throw new Error('Enter a valid GitHub App installation ID.');
+      }
+      if (repositories.length === 0) {
+        throw new Error('Add at least one repository in owner/name format.');
+      }
+
+      const tokenReference =
+        normalizeValue(githubComplete.tokenReference) || `github-app-installation:${installationID}`;
+      const webhookSecret = normalizeValue(githubComplete.webhookSecret) || newWebhookSecret();
+      const webhookSecretReference =
+        normalizeValue(githubComplete.webhookSecretReference) || `github-webhook:${projectID}:${installationID}`;
+      setGitHubComplete((current) => ({
+        ...current,
+        tokenReference,
+        webhookSecret,
+        webhookSecretReference
+      }));
+
+      const auth = buildProductAuthContext(scope);
+      const response = await apiClient.completeGitHubProjectConnection(
+        scope.workspaceID,
+        projectID,
+        {
+          state,
+          installation_id: installationID,
+          account_login: normalizeValue(githubComplete.accountLogin) || undefined,
+          token_reference: tokenReference,
+          webhook_secret: webhookSecret,
+          webhook_secret_reference: webhookSecretReference,
+          selected_repositories: repositories
+        },
+        auth
+      );
+      setConnections((current) => ({ ...current, github: response.connection }));
+      setGitHubStart(null);
+      setSuccessMessage('GitHub connection saved and ready for repository events.');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to complete GitHub connection.';
+      setSourceErrors((current) => ({ ...current, github: message }));
+    } finally {
+      setSubmitting('');
+    }
+  };
+
+  const handleAWSSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitting('aws');
+    setSuccessMessage('');
+    setSourceErrors((current) => ({ ...current, aws: undefined }));
+    try {
+      const roleARN = normalizeValue(awsForm.roleARN);
+      if (!AWS_ROLE_ARN_PATTERN.test(roleARN)) {
+        throw new Error('Enter a valid IAM role ARN, for example arn:aws:iam::123456789012:role/IdentrailReadOnly.');
+      }
+      const auth = buildProductAuthContext(scope);
+      const response = await apiClient.upsertAWSProjectConnection(
+        scope.workspaceID,
+        projectID,
+        {
+          role_arn: roleARN,
+          external_id: normalizeValue(awsForm.externalID) || undefined,
+          region: normalizeValue(awsForm.region) || 'us-east-1',
+          display_name: normalizeValue(awsForm.displayName) || undefined,
+          session_name: normalizeValue(awsForm.sessionName) || undefined
+        },
+        auth
+      );
+      setConnections((current) => ({ ...current, aws: response.connection }));
+      setSuccessMessage(
+        response.connection.connected ? 'AWS connector is active.' : 'AWS connector saved with diagnostics to resolve.'
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to validate AWS connection.';
+      setSourceErrors((current) => ({ ...current, aws: message }));
+    } finally {
+      setSubmitting('');
+    }
+  };
+
+  const handleKubernetesSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitting('kubernetes');
+    setSuccessMessage('');
+    setSourceErrors((current) => ({ ...current, kubernetes: undefined }));
+    try {
+      const auth = buildProductAuthContext(scope);
+      const response = await apiClient.upsertKubernetesProjectConnection(
+        scope.workspaceID,
+        projectID,
+        {
+          display_name: normalizeValue(kubernetesForm.displayName) || undefined,
+          context: normalizeValue(kubernetesForm.context) || undefined
+        },
+        auth
+      );
+      setConnections((current) => ({ ...current, kubernetes: response.connection }));
+      setSuccessMessage(
+        response.connection.connected
+          ? 'Kubernetes connector is active.'
+          : 'Kubernetes preflight completed with diagnostics to resolve.'
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to validate Kubernetes connection.';
+      setSourceErrors((current) => ({ ...current, kubernetes: message }));
+    } finally {
+      setSubmitting('');
+    }
+  };
+
   return (
-    <ScopedShellPage
-      title="Project detail"
-      description={`Project ${params.projectID ?? 'unknown'} placeholder with room for run status, controls, and ownership context.`}
-    />
+    <section className="idt-app-panel idt-source-onboarding">
+      <div className="idt-source-onboarding-header">
+        <div>
+          <p className="idt-app-kicker">Project source onboarding</p>
+          <h2>Connect sources for {projectID}</h2>
+          <p>
+            Add GitHub, AWS, or Kubernetes signals for workspace <strong>{scope.workspaceID}</strong> with live
+            validation and remediation feedback.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="idt-btn idt-btn-ghost"
+          onClick={() => {
+            void refreshConnections(true);
+          }}
+          disabled={refreshing || submitting !== ''}
+        >
+          {refreshing ? 'Refreshing...' : 'Refresh status'}
+        </button>
+      </div>
+
+      <div className="idt-source-summary" aria-label="source connection summary">
+        <article>
+          <span>{connectedCount}</span>
+          <p>Active sources</p>
+        </article>
+        <article>
+          <span>{SOURCE_ORDER.length - connectedCount}</span>
+          <p>Remaining</p>
+        </article>
+        <article>
+          <span>{connectionLifecycle(selectedStatus)}</span>
+          <p>Selected status</p>
+        </article>
+      </div>
+
+      {successMessage ? (
+        <p role="status" className="idt-app-alert idt-app-alert-success">
+          {successMessage}
+        </p>
+      ) : null}
+
+      <ol className="idt-source-stepper" aria-label="Connect source steps">
+        {CONNECT_SOURCE_STEPS.map((step, index) => (
+          <li key={step} className={index <= activeStepIndex ? 'is-active' : ''}>
+            <span>{index + 1}</span>
+            {step}
+          </li>
+        ))}
+      </ol>
+
+      <div className="idt-source-wizard-grid">
+        <aside className="idt-source-picker" aria-label="Source types">
+          {SOURCE_ORDER.map((provider) => {
+            const profile = SOURCE_PROFILES[provider];
+            const status = sourceConnection(connections, provider);
+            const error = sourceErrors[provider];
+            return (
+              <button
+                key={provider}
+                type="button"
+                className={`idt-source-card ${selectedSource === provider ? 'is-selected' : ''}`}
+                aria-pressed={selectedSource === provider}
+                onClick={() => setSelectedSource(provider)}
+              >
+                <span className="idt-source-card-topline">
+                  <span>{profile.eyebrow}</span>
+                  <span className={`idt-source-status-pill is-${connectionTone(status)}`}>
+                    {error ? 'Needs retry' : connectionLifecycle(status)}
+                  </span>
+                </span>
+                <strong>{profile.name}</strong>
+                <small>{profile.primarySignal}</small>
+              </button>
+            );
+          })}
+        </aside>
+
+        <div className="idt-source-config">
+          <div className="idt-source-config-header">
+            <div>
+              <p className="idt-app-kicker">{selectedProfile.eyebrow}</p>
+              <h3>{selectedProfile.name}</h3>
+              <p>{selectedProfile.summary}</p>
+            </div>
+            <span className={`idt-source-status-pill is-${connectionTone(selectedStatus)}`}>
+              {connectionLifecycle(selectedStatus)}
+            </span>
+          </div>
+
+          <dl className="idt-source-meta">
+            <div>
+              <dt>Required access</dt>
+              <dd>{selectedProfile.requiredAccess}</dd>
+            </div>
+            <div>
+              <dt>Health</dt>
+              <dd>{connectionHealth(selectedStatus)}</dd>
+            </div>
+            <div>
+              <dt>Last validation</dt>
+              <dd>
+                {selectedStatus && 'last_validated_at' in selectedStatus
+                  ? formatConnectionTime(selectedStatus.last_validated_at)
+                  : formatConnectionTime(selectedStatus?.updated_at)}
+              </dd>
+            </div>
+          </dl>
+
+          {sourceErrors[selectedSource] ? (
+            <p role="alert" className="idt-app-alert idt-app-alert-error">
+              {sourceErrors[selectedSource]}
+            </p>
+          ) : null}
+
+          {selectedSource === 'github' ? (
+            <div className="idt-source-form-stack">
+              <form className="idt-app-form" onSubmit={handleGitHubStart}>
+                <div className="idt-source-inline-fields">
+                  <label>
+                    GitHub App slug
+                    <input
+                      value={githubStartForm.appSlug}
+                      onChange={(event) => setGitHubStartForm((current) => ({ ...current, appSlug: event.target.value }))}
+                      placeholder="identrail"
+                    />
+                  </label>
+                  <label>
+                    Redirect URI
+                    <input
+                      value={githubStartForm.redirectURI}
+                      onChange={(event) =>
+                        setGitHubStartForm((current) => ({ ...current, redirectURI: event.target.value }))
+                      }
+                      placeholder="Current project page"
+                    />
+                  </label>
+                </div>
+                <button className="idt-btn idt-btn-primary" type="submit" disabled={submitting !== ''}>
+                  {submitting === 'github' ? 'Preparing...' : 'Generate install link'}
+                </button>
+              </form>
+
+              {githubStart ? (
+                <article className="idt-source-install-card">
+                  <div>
+                    <h4>GitHub installation ready</h4>
+                    <p>State expires {formatConnectionTime(githubStart.expires_at)}.</p>
+                  </div>
+                  <a className="idt-btn idt-btn-dark" href={githubStart.connect_url} target="_blank" rel="noreferrer">
+                    Open GitHub
+                  </a>
+                </article>
+              ) : null}
+
+              <form className="idt-app-form" onSubmit={handleGitHubComplete}>
+                <div className="idt-source-inline-fields">
+                  <label>
+                    Install state
+                    <input
+                      value={githubComplete.state}
+                      onChange={(event) => setGitHubComplete((current) => ({ ...current, state: event.target.value }))}
+                      placeholder="Generated install state"
+                      required
+                    />
+                  </label>
+                  <label>
+                    Installation ID
+                    <input
+                      inputMode="numeric"
+                      value={githubComplete.installationID}
+                      onChange={(event) =>
+                        setGitHubComplete((current) => ({ ...current, installationID: event.target.value }))
+                      }
+                      placeholder="12345678"
+                      required
+                    />
+                  </label>
+                </div>
+                <label>
+                  Account login
+                  <input
+                    value={githubComplete.accountLogin}
+                    onChange={(event) =>
+                      setGitHubComplete((current) => ({ ...current, accountLogin: event.target.value }))
+                    }
+                    placeholder="organization or user"
+                  />
+                </label>
+                <label>
+                  Selected repositories
+                  <textarea
+                    value={githubComplete.repositories}
+                    onChange={(event) =>
+                      setGitHubComplete((current) => ({ ...current, repositories: event.target.value }))
+                    }
+                    placeholder="owner/repo, owner/security-platform"
+                    required
+                  />
+                </label>
+                <details className="idt-source-advanced">
+                  <summary>Credential references</summary>
+                  <div className="idt-source-inline-fields">
+                    <label>
+                      Token reference
+                      <input
+                        value={githubComplete.tokenReference}
+                        onChange={(event) =>
+                          setGitHubComplete((current) => ({ ...current, tokenReference: event.target.value }))
+                        }
+                        placeholder="Auto generated from installation ID"
+                      />
+                    </label>
+                    <label>
+                      Webhook secret reference
+                      <input
+                        value={githubComplete.webhookSecretReference}
+                        onChange={(event) =>
+                          setGitHubComplete((current) => ({ ...current, webhookSecretReference: event.target.value }))
+                        }
+                        placeholder="Auto generated for this project"
+                      />
+                    </label>
+                  </div>
+                  <label>
+                    Webhook secret
+                    <input
+                      type="password"
+                      value={githubComplete.webhookSecret}
+                      onChange={(event) =>
+                        setGitHubComplete((current) => ({ ...current, webhookSecret: event.target.value }))
+                      }
+                      placeholder="Generated when install link is created"
+                    />
+                  </label>
+                </details>
+                <button className="idt-btn idt-btn-primary" type="submit" disabled={submitting !== ''}>
+                  {submitting === 'github' ? 'Saving...' : 'Save GitHub connection'}
+                </button>
+              </form>
+            </div>
+          ) : null}
+
+          {selectedSource === 'aws' ? (
+            <form className="idt-app-form" onSubmit={handleAWSSubmit}>
+              <label>
+                Role ARN
+                <input
+                  value={awsForm.roleARN}
+                  onChange={(event) => setAWSForm((current) => ({ ...current, roleARN: event.target.value }))}
+                  placeholder="arn:aws:iam::123456789012:role/IdentrailReadOnly"
+                  required
+                />
+              </label>
+              <div className="idt-source-inline-fields">
+                <label>
+                  External ID
+                  <input
+                    value={awsForm.externalID}
+                    onChange={(event) => setAWSForm((current) => ({ ...current, externalID: event.target.value }))}
+                    placeholder="optional trust-policy guard"
+                  />
+                </label>
+                <label>
+                  Region
+                  <input
+                    value={awsForm.region}
+                    onChange={(event) => setAWSForm((current) => ({ ...current, region: event.target.value }))}
+                    placeholder="us-east-1"
+                  />
+                </label>
+              </div>
+              <div className="idt-source-inline-fields">
+                <label>
+                  Display name
+                  <input
+                    value={awsForm.displayName}
+                    onChange={(event) => setAWSForm((current) => ({ ...current, displayName: event.target.value }))}
+                    placeholder="Production AWS"
+                  />
+                </label>
+                <label>
+                  Session name
+                  <input
+                    value={awsForm.sessionName}
+                    onChange={(event) => setAWSForm((current) => ({ ...current, sessionName: event.target.value }))}
+                    placeholder="identrail-connector-validation"
+                  />
+                </label>
+              </div>
+              <button className="idt-btn idt-btn-primary" type="submit" disabled={submitting !== ''}>
+                {submitting === 'aws' ? 'Validating...' : 'Validate and save AWS'}
+              </button>
+            </form>
+          ) : null}
+
+          {selectedSource === 'kubernetes' ? (
+            <form className="idt-app-form" onSubmit={handleKubernetesSubmit}>
+              <div className="idt-source-inline-fields">
+                <label>
+                  Display name
+                  <input
+                    value={kubernetesForm.displayName}
+                    onChange={(event) =>
+                      setKubernetesForm((current) => ({ ...current, displayName: event.target.value }))
+                    }
+                    placeholder="Production cluster"
+                  />
+                </label>
+                <label>
+                  kubectl context
+                  <input
+                    value={kubernetesForm.context}
+                    onChange={(event) => setKubernetesForm((current) => ({ ...current, context: event.target.value }))}
+                    placeholder="API runtime default"
+                  />
+                </label>
+              </div>
+              <button className="idt-btn idt-btn-primary" type="submit" disabled={submitting !== ''}>
+                {submitting === 'kubernetes' ? 'Running preflight...' : 'Run preflight and save'}
+              </button>
+            </form>
+          ) : null}
+
+          {selectedSource === 'aws' && connections.aws ? (
+            <div className="idt-source-diagnostics">
+              {connections.aws.account_id ? <p>Account {connections.aws.account_id}</p> : null}
+              {connections.aws.principal_arn ? <p>Principal {connections.aws.principal_arn}</p> : null}
+              {connections.aws.permission_checks.map((check) => (
+                <article key={check.name}>
+                  <strong>{check.name}</strong>
+                  <span>{check.passed ? 'Passed' : 'Needs attention'}</span>
+                  <p>{check.message}</p>
+                  {check.remediation ? <small>{check.remediation}</small> : null}
+                </article>
+              ))}
+              {connections.aws.diagnostics.map((diagnostic) => (
+                <article key={diagnostic.code}>
+                  <strong>{diagnostic.code}</strong>
+                  <span>Diagnostic</span>
+                  <p>{diagnostic.message}</p>
+                  {diagnostic.remediation ? <small>{diagnostic.remediation}</small> : null}
+                </article>
+              ))}
+            </div>
+          ) : null}
+
+          {selectedSource === 'kubernetes' && connections.kubernetes ? (
+            <div className="idt-source-diagnostics">
+              {connections.kubernetes.cluster ? <p>Cluster {connections.kubernetes.cluster}</p> : null}
+              {connections.kubernetes.server ? <p>Server {connections.kubernetes.server}</p> : null}
+              {connections.kubernetes.permission_checks.map((check) => (
+                <article key={`${check.verb}-${check.resource}-${check.scope}`}>
+                  <strong>
+                    {check.verb} {check.resource}
+                  </strong>
+                  <span>{check.allowed ? 'Allowed' : 'Blocked'}</span>
+                  {check.diagnostic ? <p>{check.diagnostic}</p> : null}
+                  {check.remediation ? <small>{check.remediation}</small> : null}
+                </article>
+              ))}
+              {connections.kubernetes.diagnostics.map((diagnostic) => (
+                <article key={diagnostic.code}>
+                  <strong>{diagnostic.code}</strong>
+                  <span>{diagnostic.severity}</span>
+                  <p>{diagnostic.message}</p>
+                  {diagnostic.remediation ? <small>{diagnostic.remediation}</small> : null}
+                </article>
+              ))}
+            </div>
+          ) : null}
+
+          {selectedSource === 'github' && connections.github ? (
+            <div className="idt-source-diagnostics">
+              {connections.github.account_login ? <p>Account {connections.github.account_login}</p> : null}
+              {connections.github.installation_id ? <p>Installation {connections.github.installation_id}</p> : null}
+              {connections.github.webhook_secret_rotation_due_at ? (
+                <p>Webhook rotation due {formatConnectionTime(connections.github.webhook_secret_rotation_due_at)}</p>
+              ) : null}
+              {connections.github.selected_repositories.map((repository) => (
+                <article key={repository}>
+                  <strong>{repository}</strong>
+                  <span>Selected</span>
+                </article>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4397,13 +4397,328 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   gap: 0.4rem;
 }
 
+.idt-source-onboarding {
+  display: grid;
+  gap: 1rem;
+}
+
+.idt-source-onboarding-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.idt-source-onboarding-header h2,
+.idt-source-config-header h3 {
+  margin-bottom: 0.4rem;
+}
+
+.idt-source-onboarding-header p,
+.idt-source-config-header p {
+  margin: 0;
+  color: #c9d8ee;
+}
+
+.idt-source-summary {
+  display: grid;
+  gap: 0.7rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.idt-source-summary article {
+  border: 1px solid rgba(130, 160, 214, 0.28);
+  border-radius: 0.7rem;
+  padding: 0.75rem;
+  background: rgba(8, 14, 25, 0.52);
+}
+
+.idt-source-summary span {
+  display: block;
+  font-family: var(--idt-display);
+  font-size: 1.2rem;
+  line-height: 1.2;
+  color: #f2f7ff;
+}
+
+.idt-source-summary p {
+  margin: 0.2rem 0 0;
+  color: #c2d4f0;
+}
+
+.idt-source-stepper {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.45rem;
+  padding: 0;
+  margin: 0;
+}
+
+.idt-source-stepper li {
+  border: 1px solid rgba(130, 160, 214, 0.24);
+  border-radius: 0.65rem;
+  padding: 0.55rem;
+  color: #91a9cf;
+  background: rgba(7, 12, 22, 0.56);
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.idt-source-stepper li.is-active {
+  color: #eaf3ff;
+  border-color: rgba(184, 243, 214, 0.46);
+  background: rgba(32, 78, 65, 0.28);
+}
+
+.idt-source-stepper span {
+  display: inline-grid;
+  place-items: center;
+  width: 1.35rem;
+  height: 1.35rem;
+  margin-right: 0.35rem;
+  border-radius: 999px;
+  background: rgba(130, 160, 214, 0.18);
+}
+
+.idt-source-wizard-grid {
+  display: grid;
+  grid-template-columns: minmax(250px, 0.75fr) minmax(0, 1.6fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.idt-source-picker {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.idt-source-card {
+  appearance: none;
+  width: 100%;
+  border: 1px solid rgba(130, 160, 214, 0.28);
+  border-radius: 0.7rem;
+  padding: 0.8rem;
+  text-align: left;
+  background: rgba(8, 14, 25, 0.62);
+  color: #e7f0ff;
+  cursor: pointer;
+  display: grid;
+  gap: 0.45rem;
+  transition: border-color 0.18s ease, background-color 0.18s ease, transform 0.18s ease;
+}
+
+.idt-source-card:hover,
+.idt-source-card:focus-visible,
+.idt-source-card.is-selected {
+  border-color: rgba(184, 243, 214, 0.58);
+  background: rgba(15, 31, 39, 0.78);
+  transform: translateY(-1px);
+}
+
+.idt-source-card strong {
+  font-family: var(--idt-display);
+  font-size: 1.05rem;
+  text-transform: uppercase;
+}
+
+.idt-source-card small {
+  color: #afc2df;
+  line-height: 1.45;
+}
+
+.idt-source-card-topline,
+.idt-source-config-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.7rem;
+}
+
+.idt-source-card-topline > span:first-child {
+  color: #95afd8;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.idt-source-status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+  border-radius: 999px;
+  border: 1px solid rgba(130, 160, 214, 0.3);
+  padding: 0.22rem 0.5rem;
+  font-size: 0.72rem;
+  font-weight: 800;
+  line-height: 1.2;
+  color: #cbd9ef;
+  background: rgba(10, 18, 32, 0.78);
+}
+
+.idt-source-status-pill.is-success {
+  color: #dffce9;
+  border-color: rgba(91, 199, 123, 0.44);
+  background: rgba(28, 89, 50, 0.34);
+}
+
+.idt-source-status-pill.is-warning {
+  color: #fff0c4;
+  border-color: rgba(221, 167, 62, 0.46);
+  background: rgba(104, 75, 22, 0.34);
+}
+
+.idt-source-status-pill.is-error {
+  color: #ffd2d2;
+  border-color: rgba(220, 115, 115, 0.48);
+  background: rgba(93, 31, 35, 0.36);
+}
+
+.idt-source-config {
+  border: 1px solid rgba(130, 160, 214, 0.26);
+  border-radius: 0.7rem;
+  padding: 1rem;
+  background: rgba(7, 12, 22, 0.54);
+  display: grid;
+  gap: 0.9rem;
+}
+
+.idt-source-meta {
+  display: grid;
+  grid-template-columns: 1.4fr 0.7fr 0.9fr;
+  gap: 0.65rem;
+  margin: 0;
+}
+
+.idt-source-meta div {
+  border: 1px solid rgba(130, 160, 214, 0.24);
+  border-radius: 0.65rem;
+  padding: 0.65rem;
+  background: rgba(9, 15, 26, 0.64);
+}
+
+.idt-source-meta dt {
+  color: #9fb8de;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.idt-source-meta dd {
+  margin: 0.15rem 0 0;
+  color: #e1ebfb;
+}
+
+.idt-source-form-stack {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.idt-source-inline-fields {
+  display: grid;
+  gap: 0.7rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.idt-app-form textarea,
+.idt-app-form select {
+  border: 1px solid rgba(126, 157, 211, 0.35);
+  border-radius: 0.55rem;
+  background: rgba(9, 15, 26, 0.84);
+  color: #e4efff;
+  padding: 0.5rem 0.6rem;
+}
+
+.idt-app-form textarea {
+  min-height: 5.5rem;
+  resize: vertical;
+}
+
+.idt-source-install-card,
+.idt-source-advanced {
+  border: 1px solid rgba(130, 160, 214, 0.28);
+  border-radius: 0.7rem;
+  padding: 0.8rem;
+  background: rgba(12, 22, 35, 0.7);
+}
+
+.idt-source-install-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+}
+
+.idt-source-install-card h4,
+.idt-source-install-card p {
+  margin: 0;
+}
+
+.idt-source-install-card p {
+  color: #c2d4f0;
+}
+
+.idt-source-advanced summary {
+  cursor: pointer;
+  color: #dce9fb;
+  font-weight: 800;
+}
+
+.idt-source-advanced .idt-source-inline-fields,
+.idt-source-advanced label {
+  margin-top: 0.75rem;
+}
+
+.idt-source-diagnostics {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.idt-source-diagnostics > p {
+  margin: 0;
+  color: #c8d8ef;
+}
+
+.idt-source-diagnostics article {
+  border: 1px solid rgba(130, 160, 214, 0.24);
+  border-radius: 0.65rem;
+  padding: 0.65rem;
+  background: rgba(9, 15, 26, 0.62);
+}
+
+.idt-source-diagnostics strong,
+.idt-source-diagnostics span,
+.idt-source-diagnostics small {
+  display: block;
+}
+
+.idt-source-diagnostics span {
+  margin-top: 0.15rem;
+  color: #b8f3d6;
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.idt-source-diagnostics p,
+.idt-source-diagnostics small {
+  margin: 0.3rem 0 0;
+  color: #c6d5ec;
+}
+
 @media (max-width: 980px) {
   .idt-workspace-stats,
-  .idt-workspace-admin-grid {
+  .idt-workspace-admin-grid,
+  .idt-source-summary,
+  .idt-source-meta {
     grid-template-columns: 1fr 1fr;
   }
 
-  .idt-workspace-member-toolbar {
+  .idt-workspace-member-toolbar,
+  .idt-source-wizard-grid {
     grid-template-columns: 1fr;
   }
 }
@@ -4411,8 +4726,18 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
 @media (max-width: 720px) {
   .idt-workspace-stats,
   .idt-workspace-admin-grid,
-  .idt-workspace-inline-fields {
+  .idt-workspace-inline-fields,
+  .idt-source-summary,
+  .idt-source-stepper,
+  .idt-source-inline-fields,
+  .idt-source-meta {
     grid-template-columns: 1fr;
+  }
+
+  .idt-source-onboarding-header,
+  .idt-source-config-header,
+  .idt-source-install-card {
+    display: grid;
   }
 }
 
@@ -4498,6 +4823,66 @@ html[data-theme='light'] .idt-workspace-table th {
 
 html[data-theme='light'] .idt-workspace-table td span {
   color: #5a78a6;
+}
+
+html[data-theme='light'] .idt-source-summary article,
+html[data-theme='light'] .idt-source-card,
+html[data-theme='light'] .idt-source-config,
+html[data-theme='light'] .idt-source-meta div,
+html[data-theme='light'] .idt-source-install-card,
+html[data-theme='light'] .idt-source-advanced,
+html[data-theme='light'] .idt-source-diagnostics article {
+  background: rgba(245, 250, 255, 0.95);
+  border-color: rgba(42, 71, 119, 0.24);
+}
+
+html[data-theme='light'] .idt-source-onboarding-header p,
+html[data-theme='light'] .idt-source-config-header p,
+html[data-theme='light'] .idt-source-summary p,
+html[data-theme='light'] .idt-source-card small,
+html[data-theme='light'] .idt-source-install-card p,
+html[data-theme='light'] .idt-source-diagnostics > p,
+html[data-theme='light'] .idt-source-diagnostics p,
+html[data-theme='light'] .idt-source-diagnostics small {
+  color: #35598d;
+}
+
+html[data-theme='light'] .idt-source-summary span,
+html[data-theme='light'] .idt-source-card,
+html[data-theme='light'] .idt-source-meta dd,
+html[data-theme='light'] .idt-source-advanced summary {
+  color: #1c355d;
+}
+
+html[data-theme='light'] .idt-source-card:hover,
+html[data-theme='light'] .idt-source-card:focus-visible,
+html[data-theme='light'] .idt-source-card.is-selected,
+html[data-theme='light'] .idt-source-stepper li.is-active {
+  background: rgba(224, 244, 235, 0.95);
+  border-color: rgba(33, 124, 83, 0.32);
+  color: #173b2b;
+}
+
+html[data-theme='light'] .idt-source-stepper li {
+  background: rgba(239, 246, 255, 0.95);
+  border-color: rgba(42, 71, 119, 0.22);
+  color: #42679a;
+}
+
+html[data-theme='light'] .idt-source-card-topline > span:first-child,
+html[data-theme='light'] .idt-source-meta dt {
+  color: #4c6f9f;
+}
+
+html[data-theme='light'] .idt-app-form textarea,
+html[data-theme='light'] .idt-app-form select {
+  color: #1c355d;
+  background: #ffffff;
+  border-color: rgba(42, 71, 119, 0.32);
+}
+
+html[data-theme='light'] .idt-source-diagnostics span {
+  color: #246b46;
 }
 
 /* Premium homepage refresh */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4397,6 +4397,122 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   gap: 0.4rem;
 }
 
+.idt-projects-page,
+.idt-projects-list,
+.idt-project-composer,
+.idt-project-card-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.idt-projects-header,
+.idt-projects-section-header,
+.idt-project-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.idt-projects-header h2,
+.idt-projects-section-header h3,
+.idt-project-card h4 {
+  margin-bottom: 0.4rem;
+}
+
+.idt-projects-header p,
+.idt-projects-section-header p,
+.idt-project-card p {
+  margin: 0;
+  color: #c9d8ee;
+}
+
+.idt-projects-summary {
+  display: grid;
+  gap: 0.7rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.idt-projects-summary article,
+.idt-projects-list,
+.idt-project-composer,
+.idt-project-card,
+.idt-project-card-meta div {
+  border: 1px solid rgba(130, 160, 214, 0.28);
+  border-radius: 0.7rem;
+  background: rgba(8, 14, 25, 0.52);
+}
+
+.idt-projects-summary article,
+.idt-project-card,
+.idt-project-card-meta div {
+  padding: 0.75rem;
+}
+
+.idt-projects-list,
+.idt-project-composer {
+  padding: 1rem;
+  align-content: start;
+}
+
+.idt-projects-summary span {
+  display: block;
+  font-family: var(--idt-display);
+  font-size: 1.2rem;
+  line-height: 1.2;
+  color: #f2f7ff;
+}
+
+.idt-projects-summary p {
+  margin: 0.2rem 0 0;
+  color: #c2d4f0;
+}
+
+.idt-projects-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(300px, 0.95fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.idt-project-card {
+  gap: 0.85rem;
+}
+
+.idt-project-card h4 {
+  margin-top: 0;
+}
+
+.idt-project-card p {
+  line-height: 1.5;
+}
+
+.idt-project-card-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.65rem;
+  margin: 0;
+}
+
+.idt-project-card-meta dt {
+  color: #9fb8de;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.idt-project-card-meta dd {
+  margin: 0.15rem 0 0;
+  color: #e1ebfb;
+}
+
+.idt-project-inline-fields {
+  display: grid;
+  gap: 0.7rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 .idt-source-onboarding {
   display: grid;
   gap: 1rem;
@@ -4712,12 +4828,14 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
 @media (max-width: 980px) {
   .idt-workspace-stats,
   .idt-workspace-admin-grid,
+  .idt-projects-summary,
   .idt-source-summary,
   .idt-source-meta {
     grid-template-columns: 1fr 1fr;
   }
 
   .idt-workspace-member-toolbar,
+  .idt-projects-grid,
   .idt-source-wizard-grid {
     grid-template-columns: 1fr;
   }
@@ -4727,6 +4845,9 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   .idt-workspace-stats,
   .idt-workspace-admin-grid,
   .idt-workspace-inline-fields,
+  .idt-projects-summary,
+  .idt-project-inline-fields,
+  .idt-project-card-meta,
   .idt-source-summary,
   .idt-source-stepper,
   .idt-source-inline-fields,
@@ -4734,6 +4855,9 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
     grid-template-columns: 1fr;
   }
 
+  .idt-projects-header,
+  .idt-projects-section-header,
+  .idt-project-card-header,
   .idt-source-onboarding-header,
   .idt-source-config-header,
   .idt-source-install-card {
@@ -4803,11 +4927,37 @@ html[data-theme='light'] .idt-workspace-stats p {
   color: #35598d;
 }
 
+html[data-theme='light'] .idt-projects-header p,
+html[data-theme='light'] .idt-projects-section-header p,
+html[data-theme='light'] .idt-project-card p,
+html[data-theme='light'] .idt-projects-summary p {
+  color: #35598d;
+}
+
+html[data-theme='light'] .idt-projects-summary article,
+html[data-theme='light'] .idt-projects-list,
+html[data-theme='light'] .idt-project-composer,
+html[data-theme='light'] .idt-project-card,
+html[data-theme='light'] .idt-project-card-meta div {
+  background: rgba(245, 250, 255, 0.95);
+  border-color: rgba(42, 71, 119, 0.24);
+}
+
+html[data-theme='light'] .idt-projects-summary span,
+html[data-theme='light'] .idt-project-card-meta dd {
+  color: #1c355d;
+}
+
+html[data-theme='light'] .idt-project-card-meta dt {
+  color: #385f95;
+}
+
 html[data-theme='light'] .idt-workspace-switcher select,
 html[data-theme='light'] .idt-workspace-inline-fields select,
 html[data-theme='light'] .idt-workspace-member-toolbar select,
 html[data-theme='light'] .idt-workspace-member-toolbar input,
-html[data-theme='light'] .idt-workspace-table select {
+html[data-theme='light'] .idt-workspace-table select,
+html[data-theme='light'] .idt-project-inline-fields input {
   color: #1c355d;
   background: #ffffff;
   border-color: rgba(42, 71, 119, 0.32);


### PR DESCRIPTION
Fixes #559

## What changed
- Added a project-level connect-source wizard in the authenticated web app for GitHub, AWS, and Kubernetes.
- Wired the wizard to the existing project-scoped connector APIs for status refresh, validation, save, retry, and remediation feedback.
- Added typed API client contracts, source-onboarding documentation, changelog coverage, and regression tests for first-source onboarding flows.

## Why it changed
Source setup was previously too dependent on manual operator knowledge. This gives first-time users a guided in-app path to connect at least one source from the project route while keeping provider validation explicit and diagnosable.

## Impact and risk
- Impact: first-time project onboarding now has a visible source chooser, provider-specific forms, progress status, retry controls, and remediation output.
- Risk: scoped to the web app, API client, docs, and tests; no backend contract changes or connector permission expansion.

## Validation
- `npm run build --prefix web`
- `npm run test --prefix web -- --run src/App.test.tsx src/api/client.test.ts`
- `npm run test:ci --prefix web` (47 tests passed, 63.23% statement coverage)
- `go test ./... -coverprofile=coverage.out` (80.0% total coverage)
- `go vet ./...`
- Production preview browser check at `/app/tenant-a/workspace-a/projects/project-1` verified the wizard renders with GitHub, AWS, and Kubernetes cards, no app console errors, and no error overlay.

## Disclosure
- AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds a project-level connect-source wizard and adds a projects list/create flow so users can choose a project and connect GitHub, AWS, and Kubernetes with live validation. Fixes #559 by making onboarding explicit, resilient to route changes, and diagnosable from the project page.

- New Features
  - Added Projects index with cards and a create form; routes to `/app/{tenant}/{workspace}/projects/{project_id}` for onboarding.
  - Implemented connect-source wizard with provider forms (GitHub start/complete, AWS validate/save, Kubernetes preflight/save), stepper, status summary, and manual refresh.
  - Expanded typed `apiClient` with project list/get/upsert plus project-scoped connector methods (GitHub start/complete/get, AWS get/upsert, Kubernetes get/upsert); `buildQuery` now supports boolean params.
  - Added `docs/source-onboarding.md`, changelog entry, and regression tests for project list/create and GitHub/AWS/Kubernetes flows.
  - No backend contract changes.

- Bug Fixes
  - Ignored stale refresh and submit responses after route changes.
  - Hardened inputs: normalized project IDs/slugs, parsed repo lists, validated AWS role ARNs, and stored only credential references client-side.

<sup>Written for commit c854dfda40b57b2b0419c0a3324afdeecd2c43cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

