### PR TITLE
fix: validate AWS policy effects during normalization

### DIFF
--- a/internal/providers/aws/model.go
+++ b/internal/providers/aws/model.go
@@ -69,19 +69,27 @@ func parsePolicyDocument(raw string) (iamPolicyDocument, error) {
 	return doc, nil
 }
 
-func normalizedStatement(effect string, actions, resources []string) map[string]any {
+func normalizedStatement(effect string, actions, resources []string) (map[string]any, bool) {
+	canonical, ok := canonicalEffect(effect)
+	if !ok {
+		return nil, false
+	}
 	return map[string]any{
-		"effect":    canonicalEffect(effect),
+		"effect":    canonical,
 		"actions":   dedupeStrings(actions),
 		"resources": dedupeStrings(resources),
-	}
+	}, true
 }
 
-func canonicalEffect(effect string) string {
-	if strings.EqualFold(effect, "deny") {
-		return "Deny"
+func canonicalEffect(effect string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(effect)) {
+	case "allow":
+		return "Allow", true
+	case "deny":
+		return "Deny", true
+	default:
+		return "", false
 	}
-	return "Allow"
 }
 
 func dedupeStrings(items []string) []string {

--- a/internal/providers/aws/normalizer.go
+++ b/internal/providers/aws/normalizer.go
@@ -115,7 +115,11 @@ func normalizePermissionPolicies(identityID string, policies []IAMPermissionPoli
 			if len(actions) == 0 || len(resources) == 0 {
 				continue
 			}
-			statements = append(statements, normalizedStatement(statement.Effect, actions, resources))
+			normalized, ok := normalizedStatement(statement.Effect, actions, resources)
+			if !ok {
+				continue
+			}
+			statements = append(statements, normalized)
 		}
 		if len(statements) == 0 {
 			continue

--- a/internal/providers/aws/normalizer_test.go
+++ b/internal/providers/aws/normalizer_test.go
@@ -109,3 +109,67 @@ func TestRoleNormalizerInvalidPermissionPolicyDocument(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestRoleNormalizerSkipsPermissionStatementsWithInvalidEffect(t *testing.T) {
+	role := IAMRole{
+		ARN:  "arn:aws:iam::1:role/demo",
+		Name: "demo",
+		PermissionPolicies: []IAMPermissionPolicy{{
+			Name: "mixed",
+			Document: `{
+				"Version":"2012-10-17",
+				"Statement":[
+					{"Effect":"Alow","Action":"s3:GetObject","Resource":"*"},
+					{"Effect":"Allow","Action":"s3:ListBucket","Resource":"*"}
+				]
+			}`,
+		}},
+	}
+	payload, _ := json.Marshal(role)
+
+	normalizer := NewRoleNormalizer()
+	bundle, err := normalizer.Normalize(context.Background(), []providers.RawAsset{{Kind: "iam_role", Payload: payload, SourceID: role.ARN}})
+	if err != nil {
+		t.Fatalf("normalize failed: %v", err)
+	}
+	if len(bundle.Policies) != 1 {
+		t.Fatalf("expected one normalized permission policy, got %d", len(bundle.Policies))
+	}
+	statements, ok := bundle.Policies[0].Normalized[statementsKey].([]map[string]any)
+	if !ok {
+		t.Fatalf("expected normalized statements slice, got %T", bundle.Policies[0].Normalized[statementsKey])
+	}
+	if len(statements) != 1 {
+		t.Fatalf("expected invalid-effect statements to be skipped, got %d statements", len(statements))
+	}
+	if got := statements[0]["effect"]; got != "Allow" {
+		t.Fatalf("expected surviving statement effect Allow, got %#v", got)
+	}
+}
+
+func TestRoleNormalizerSkipsPermissionPolicyWhenNoValidEffectsRemain(t *testing.T) {
+	role := IAMRole{
+		ARN:  "arn:aws:iam::1:role/demo",
+		Name: "demo",
+		PermissionPolicies: []IAMPermissionPolicy{{
+			Name: "invalid-only",
+			Document: `{
+				"Version":"2012-10-17",
+				"Statement":[
+					{"Effect":"","Action":"s3:GetObject","Resource":"*"},
+					{"Effect":"Alow","Action":"s3:ListBucket","Resource":"*"}
+				]
+			}`,
+		}},
+	}
+	payload, _ := json.Marshal(role)
+
+	normalizer := NewRoleNormalizer()
+	bundle, err := normalizer.Normalize(context.Background(), []providers.RawAsset{{Kind: "iam_role", Payload: payload, SourceID: role.ARN}})
+	if err != nil {
+		t.Fatalf("normalize failed: %v", err)
+	}
+	if len(bundle.Policies) != 0 {
+		t.Fatalf("expected no normalized policies when no valid effects exist, got %d", len(bundle.Policies))
+	}
+}


### PR DESCRIPTION
Fixes #659

## Summary
- require explicit IAM statement effects (`Allow` or `Deny`) during permission-policy normalization
- skip malformed/unknown-effect statements instead of treating them as `Allow`
- add regression tests for mixed valid/invalid effects and invalid-only policies

## Impact
- prevents malformed IAM policy statements from creating false-positive access edges and findings
- keeps valid IAM statements fully functional

## Validation
- `go test ./internal/providers/aws`

AI-assisted: No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates IAM policy statement effects during normalization to stop malformed effects from defaulting to Allow and creating false-positive access edges. Only Allow and Deny are accepted; invalid-effect statements are skipped, and policies with no valid statements are dropped.

- **Bug Fixes**
  - Require explicit `Allow` or `Deny` in permission-policy normalization.
  - Skip statements with unknown/empty effects instead of defaulting to `Allow`.
  - Add regression tests for mixed valid/invalid effects and invalid-only policies.

<sup>Written for commit 46a1d9ff442be27432779480a57114a97f531b3d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

