### PR TITLE
fix: skip invalid Kubernetes bound_to edges for missing identities

### DIFF
--- a/internal/providers/kubernetes/graph.go
+++ b/internal/providers/kubernetes/graph.go
@@ -25,6 +25,10 @@ func (r *RelationshipResolver) ResolveRelationships(ctx context.Context, bundle 
 	timestamp := r.now().UTC()
 	relationships := []domain.Relationship{}
 	seen := map[string]struct{}{}
+	identityIDs := make(map[string]struct{}, len(bundle.Identities))
+	for _, identity := range bundle.Identities {
+		identityIDs[identity.ID] = struct{}{}
+	}
 
 	for _, workload := range bundle.Workloads {
 		if err := ctx.Err(); err != nil {
@@ -32,6 +36,9 @@ func (r *RelationshipResolver) ResolveRelationships(ctx context.Context, bundle 
 		}
 		identityID := workload.RawRef
 		if identityID == "" {
+			continue
+		}
+		if _, exists := identityIDs[identityID]; !exists {
 			continue
 		}
 		rel := domain.Relationship{

--- a/internal/providers/kubernetes/graph_test.go
+++ b/internal/providers/kubernetes/graph_test.go
@@ -52,3 +52,23 @@ func TestRelationshipResolverBuildsExpectedEdges(t *testing.T) {
 		t.Fatalf("unexpected relationship counts bound_to=%d attached_policy=%d can_access=%d", boundTo, attachedPolicy, canAccess)
 	}
 }
+
+func TestRelationshipResolverSkipsBoundToWhenIdentityMissing(t *testing.T) {
+	resolver := NewRelationshipResolver()
+	relationships, err := resolver.ResolveRelationships(context.Background(), providers.NormalizedBundle{
+		Workloads: []domain.Workload{
+			{
+				ID:     workloadID("apps", "payments-api-0"),
+				RawRef: serviceAccountID("apps", "default"),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("resolve relationships failed: %v", err)
+	}
+	for _, relationship := range relationships {
+		if relationship.Type == domain.RelationshipBoundTo {
+			t.Fatalf("expected missing identity bound_to relationship to be skipped")
+		}
+	}
+}


### PR DESCRIPTION
Fixes #661

## Summary
- prevent Kubernetes `bound_to` relationships from being created when the referenced service account identity is missing
- keep relationship construction stable for workloads that reference valid service accounts
- add regression coverage for missing service-account identity bindings

## Impact
- avoids full scan failures caused by graph validation on unknown `bound_to` identity targets
- preserves existing graph behavior for valid identity/workload relationships

## Validation
- `go test ./internal/providers/kubernetes`

AI-assisted: No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip creating Kubernetes `bound_to` edges when the target service account identity is missing. This prevents scan failures from graph validation and leaves valid bindings unchanged.

- **Bug Fixes**
  - Ignore `bound_to` edges if a workload references an unknown service account ID.
  - Preserve relationship creation for workloads with valid service accounts.
  - Add regression test to ensure missing-identity edges are skipped.

<sup>Written for commit 9bd9e065d9a04ba79901a2f96de7339033502aa3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

