### PR TITLE
fix: remove unused Navigate import in web app router

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
-import { BrowserRouter, Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { BrowserRouter, Link, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { SafeLink } from './components/SafeLink';
 import { HeroProductReveal } from './components/home/HeroProductReveal';
 import { HowItWorksSection } from './components/home/HowItWorksSection';


### PR DESCRIPTION
Fixes #724

## Summary
- removed the unused `Navigate` import from `web/src/App.tsx`
- kept routing behavior unchanged

## Why
- clears dead import noise and keeps strict TypeScript hygiene clean for this file

## Impact and risk
- low risk
- no runtime behavior change expected

## Validation
- pre-commit hooks passed on commit
- pre-push checks passed (`go vet`, local token hygiene, artifact hygiene)
- web build/typecheck was not run in this worktree because `web` dependencies are not installed (`tsc` missing)

AI-assisted: No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused `Navigate` import from `react-router-dom` in `web/src/App.tsx` to clean up TypeScript warnings. No runtime or routing changes.

<sup>Written for commit 77c38f6716c1711225f18b44c29ecd77b27b9f0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

