### PR TITLE
Fixes #733: update contributor repo and base branch guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,20 +18,20 @@ Good contributions include:
 ## Ways to Contribute
 
 - **Open an issue** to report a bug, request a feature, or suggest an improvement.
-  
+
 - **Pick up an existing issue** if you want to contribute code, documentation, tests, or cleanup work.
 
 - **Report bugs clearly** by including reproduction steps, expected behavior, actual behavior, environment details, and any relevant logs or screenshots.
-  
+
 - **Link pull requests to issues** by starting your PR description with a closing keyword and issue number, such as `Fixes #500`, `Closes #500`, or `Resolves #500`. This automatically connects the PR to the related issue and helps keep project tracking clean.
-  
+
 - **Propose enhancements** with a clear problem statement, why it matters, and a suggested approach if you have one.
-  
+
 - **Submit focused pull requests** that address one issue or improvement at a time. Include tests and documentation updates when relevant.
-  
+
 - **Improve documentation and runbooks** whenever behavior, setup steps, operations, or troubleshooting guidance changes.
 
-  
+
 ## Before You Start
 
 Prerequisites:
@@ -43,7 +43,7 @@ Prerequisites:
 
 Recommended first steps:
 ```bash
-git clone https://github.com/Oluwatobi-Mustapha/identrail.git
+git clone https://github.com/identrail/identrail.git
 cd identrail
 go mod download
 npm ci --prefix web
@@ -51,7 +51,7 @@ npm ci --prefix web
 
 ## Development Workflow
 
-1. Create a branch from `main`.
+1. Create a branch from `dev`.
 2. Keep each PR focused on one logical change.
 3. Add or update tests for behavior changes.
 4. Update docs and `CHANGELOG.md` when user-facing or operator-facing behavior changes.


### PR DESCRIPTION
Fixes #733

## What changed
- Updated contributor clone command to use `https://github.com/identrail/identrail.git`.
- Updated branch guidance to create new branches from `dev`.

## Why
- Contributor workflow docs pointed to an old repository path and `main` as base, which does not match the current repository/branch setup.

## Impact
- New contributors now follow the correct repository and base branch workflow.

## Validation
- `git grep -n "github.com/Oluwatobi-Mustapha/identrail" CONTRIBUTING.md` (no matches)
- `git grep -n "Create a branch from `main`" CONTRIBUTING.md` (no matches)

AI-assisted: No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #733. Updates contributing docs to use the correct clone URL (`https://github.com/identrail/identrail.git`) and set `dev` as the base branch so new contributors follow the current workflow.

<sup>Written for commit ed59a4dd4fd08693781a2998137590add4ed81a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

