### PR TITLE
Fix API key tenant/workspace scope binding

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1801,15 +1801,16 @@ func requestScopeMiddleware(defaultTenantID string, defaultWorkspaceID string) g
 		WorkspaceID: defaultWorkspaceID,
 	}.Normalize()
 	return func(c *gin.Context) {
+		apiKeyAuth := authContextString(c, "auth.api_key") != ""
 		tenantID := authContextString(c, "auth.tenant_id")
-		if tenantID == "" {
+		if tenantID == "" && !apiKeyAuth {
 			tenantID = strings.TrimSpace(c.GetHeader(scopeHeaderTenantID))
 		}
 		if tenantID == "" {
 			tenantID = defaultScope.TenantID
 		}
 		workspaceID := authContextString(c, "auth.workspace_id")
-		if workspaceID == "" {
+		if workspaceID == "" && !apiKeyAuth {
 			workspaceID = strings.TrimSpace(c.GetHeader(scopeHeaderWorkspaceID))
 		}
 		if workspaceID == "" {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1400,6 +1400,43 @@ func TestRequestScopeMiddlewarePrefersOIDCTenantWorkspaceClaims(t *testing.T) {
 	}
 }
 
+func TestRequestScopeMiddlewareIgnoresScopeHeadersForAPIKeyAuth(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("auth.api_key", "reader-key")
+		c.Next()
+	})
+	r.Use(requestScopeMiddleware("default-tenant", "default-workspace"))
+	r.GET("/scope", func(c *gin.Context) {
+		scope := db.ScopeFromContext(c.Request.Context())
+		c.JSON(http.StatusOK, map[string]string{
+			"tenant_id":    scope.TenantID,
+			"workspace_id": scope.WorkspaceID,
+		})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/scope", nil)
+	req.Header.Set("X-Identrail-Tenant-ID", "header-tenant")
+	req.Header.Set("X-Identrail-Workspace-ID", "header-workspace")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["tenant_id"] != "default-tenant" {
+		t.Fatalf("expected default tenant for api key auth, got %q", body["tenant_id"])
+	}
+	if body["workspace_id"] != "default-workspace" {
+		t.Fatalf("expected default workspace for api key auth, got %q", body["workspace_id"])
+	}
+}
+
 func TestRouterRateLimitExceeded(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	metrics := telemetry.NewMetrics()


### PR DESCRIPTION
Fixes #663

## What changed
- Updated `requestScopeMiddleware` to ignore `X-Identrail-Tenant-ID` and `X-Identrail-Workspace-ID` when the caller is authenticated with an API key.
- Kept OIDC behavior unchanged: token tenant/workspace claims still take precedence.
- Added a regression test to assert API-key callers cannot override scope via headers.

## Why it changed
API-key callers were able to choose tenant/workspace scope by setting request headers. This allowed scope switching that was not bound to trusted identity claims.

## Impact and risk
- API-key requests now resolve scope from trusted context only.
- Header-based scope switching remains available for non-API-key contexts where token claims are not present.
- Low regression risk because behavior is covered with focused middleware tests.

## Validation
- `go test ./internal/api -run 'TestRequestScopeMiddleware' -count=1`
- `go test ./internal/api -count=1`

AI-assisted: No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents API-key callers from overriding tenant/workspace scope via request headers. Scope is now bound to the trusted auth context for API-key requests.

- **Bug Fixes**
  - Updated `requestScopeMiddleware` to ignore `X-Identrail-Tenant-ID` and `X-Identrail-Workspace-ID` when `auth.api_key` is present.
  - OIDC behavior unchanged: token tenant/workspace claims still take precedence over headers.
  - Added a regression test to confirm API-key callers cannot override scope via headers.

<sup>Written for commit 5d336a7e9edae69162bb40806f247250ba2a4c3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

