### PR TITLE
fix: include web route integrity check in local ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /usr/bin/env bash
 .DEFAULT_GOAL := help
 
-.PHONY: help bootstrap quickstart quickstart-down clean-local fmt fmt-check vet test test-integration web-install web-test web-build api-example-contract-check vercel-prod-deploy helm-lint tfmt-check ci pre-commit
+.PHONY: help bootstrap quickstart quickstart-down clean-local fmt fmt-check vet test test-integration web-install web-test web-build web-route-integrity-check api-example-contract-check vercel-prod-deploy helm-lint tfmt-check ci pre-commit
 
 help: ## Show available targets
 	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z0-9_-]+:.*##/ {printf "%-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -55,6 +55,9 @@ web-test: ## Run web test suite in CI mode
 web-build: ## Build web frontend
 	npm run build --prefix web
 
+web-route-integrity-check: ## Validate web app routes for static generation integrity
+	./scripts/check_web_route_integrity.sh
+
 api-example-contract-check: ## Validate docs/web API snippets against current v1 contract
 	./scripts/check_api_example_contract.sh
 
@@ -67,7 +70,7 @@ helm-lint: ## Lint Helm chart
 tfmt-check: ## Check Terraform formatting
 	terraform fmt -check -recursive deploy/terraform
 
-ci: fmt-check vet test api-example-contract-check web-test web-build ## Run core local CI checks
+ci: fmt-check vet test api-example-contract-check web-route-integrity-check web-test web-build ## Run core local CI checks
 
 pre-commit: ## Run pre-commit hooks across the repository
 	pre-commit run --all-files


### PR DESCRIPTION
Fixes #761

## Summary
- added `web-route-integrity-check` target to `Makefile`
- wired `web-route-integrity-check` into `make ci`
- included the new target in `.PHONY`

## Why
- aligns local `make ci` behavior with CI route-integrity enforcement

## Impact and risk
- low risk
- local CI becomes stricter and catches route integrity drift earlier

## Validation
- `make web-route-integrity-check` passed
- pre-commit hooks passed on commit
- pre-push checks passed (`go vet`, token/artifact hygiene)

AI-assisted: No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `web-route-integrity-check` to the Makefile and run it in `make ci` to verify web routes for static generation. Fixes #761 and aligns local checks with CI to catch route drift early.

<sup>Written for commit f40d736788e95083c749fba6b043dc6db4156d96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

