### PR TITLE
Fixes #662: enforce pre-auth rate limit and audit on v1

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -184,12 +184,12 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 	}
 
 	v1 := r.Group("/v1")
-	v1.Use(apiKeyAuthMiddleware(opts.APIKeys, opts.APIKeyScopes, opts.OIDCTokenVerifier, opts.OIDCWriteScopes))
-	v1.Use(requestScopeMiddleware(opts.DefaultTenantID, opts.DefaultWorkspaceID))
+	v1.Use(rateLimitMiddleware(opts.RateLimitRPM, opts.RateLimitBurst))
 	v1.Use(auditLogMiddleware(logger, opts.AuditSink, opts.AuditFingerprinter))
+	v1.Use(apiKeyAuthMiddleware(opts.APIKeys, opts.APIKeyScopes, opts.OIDCTokenVerifier, opts.OIDCWriteScopes, opts.AuditFingerprinter))
+	v1.Use(requestScopeMiddleware(opts.DefaultTenantID, opts.DefaultWorkspaceID))
 	centralPolicyResolver := newCentralPolicyRuntimeResolver(authzStore)
 	v1.Use(requireCentralPolicyMiddleware(centralPolicyResolver, opts.WriteAPIKeys, opts.APIKeyScopes, authzStore, metrics, opts.AuditFingerprinter))
-	v1.Use(rateLimitMiddleware(opts.RateLimitRPM, opts.RateLimitBurst))
 	v1.POST("/authz/policies/simulate", authzPolicySimulationHandler(logger, authzStore, centralPolicyResolver, opts.AuditSink, opts.AuditFingerprinter))
 	v1.POST("/authz/policies/rollback", authzPolicyRollbackHandler(logger, authzStore, metrics, opts.AuditFingerprinter))
 	registerTenancyRoutes(v1, logger, svc)
@@ -1909,7 +1909,7 @@ func securityHeadersMiddleware() gin.HandlerFunc {
 	}
 }
 
-func apiKeyAuthMiddleware(keys []string, scopedKeys map[string][]string, tokenVerifier TokenVerifier, oidcWriteScopes []string) gin.HandlerFunc {
+func apiKeyAuthMiddleware(keys []string, scopedKeys map[string][]string, tokenVerifier TokenVerifier, oidcWriteScopes []string, fingerprinter *audit.Fingerprinter) gin.HandlerFunc {
 	oidcWriteScopeSet := newScopeSet(oidcWriteScopes)
 
 	scopedAllowed := map[string]scopeSet{}
@@ -1942,11 +1942,13 @@ func apiKeyAuthMiddleware(keys []string, scopedKeys map[string][]string, tokenVe
 			if scopes, ok := scopedKeyLookup(scopedAllowed, candidate); ok {
 				c.Set("auth.api_key", candidate)
 				c.Set("auth.scope_set", scopes)
+				setAuditActorOnRequestContext(c, fingerprinter)
 				c.Next()
 				return
 			}
 			if keyInList(legacyAllowed, candidate) {
 				c.Set("auth.api_key", candidate)
+				setAuditActorOnRequestContext(c, fingerprinter)
 				c.Next()
 				return
 			}
@@ -1964,6 +1966,7 @@ func apiKeyAuthMiddleware(keys []string, scopedKeys map[string][]string, tokenVe
 				c.Set("auth.tenant_id", token.TenantID)
 				c.Set("auth.workspace_id", token.WorkspaceID)
 				c.Set("auth.scope_set", scopeSetFromOIDCToken(token, oidcWriteScopeSet))
+				setAuditActorOnRequestContext(c, fingerprinter)
 				c.Next()
 				return
 			}
@@ -2136,9 +2139,7 @@ func auditLogMiddleware(logger *zap.Logger, sink audit.AuditSink, fingerprinter 
 		sink = audit.NopAuditSink{}
 	}
 	return func(c *gin.Context) {
-		actor := triageActorFromContext(c, fingerprinter)
 		ctx := audit.WithSink(c.Request.Context(), sink)
-		ctx = audit.WithActor(ctx, actor)
 
 		// Prefer upstream request IDs when present, otherwise generate a new ID.
 		if headerID := strings.TrimSpace(c.GetHeader("X-Request-Id")); headerID != "" {
@@ -2150,6 +2151,7 @@ func auditLogMiddleware(logger *zap.Logger, sink audit.AuditSink, fingerprinter 
 
 		start := time.Now()
 		c.Next()
+		actor := triageActorFromContext(c, fingerprinter)
 		event := audit.AuditEvent{
 			Timestamp:  time.Now().UTC(),
 			Kind:       "api_request",
@@ -2193,6 +2195,17 @@ func auditLogMiddleware(logger *zap.Logger, sink audit.AuditSink, fingerprinter 
 			logger.Warn("audit sink write failed", telemetry.ZapError(err))
 		}
 	}
+}
+
+func setAuditActorOnRequestContext(c *gin.Context, fingerprinter *audit.Fingerprinter) {
+	if c == nil || c.Request == nil {
+		return
+	}
+	actor := triageActorFromContext(c, fingerprinter)
+	if actor == "unknown" {
+		return
+	}
+	c.Request = c.Request.WithContext(audit.WithActor(c.Request.Context(), actor))
 }
 
 func readAPIKey(c *gin.Context) string {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -184,8 +184,8 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 	}
 
 	v1 := r.Group("/v1")
-	v1.Use(rateLimitMiddleware(opts.RateLimitRPM, opts.RateLimitBurst))
 	v1.Use(auditLogMiddleware(logger, opts.AuditSink, opts.AuditFingerprinter))
+	v1.Use(rateLimitMiddleware(opts.RateLimitRPM, opts.RateLimitBurst))
 	v1.Use(apiKeyAuthMiddleware(opts.APIKeys, opts.APIKeyScopes, opts.OIDCTokenVerifier, opts.OIDCWriteScopes, opts.AuditFingerprinter))
 	v1.Use(requestScopeMiddleware(opts.DefaultTenantID, opts.DefaultWorkspaceID))
 	centralPolicyResolver := newCentralPolicyRuntimeResolver(authzStore)

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1448,6 +1448,43 @@ func TestRouterRateLimitAppliesToUnauthorizedRequests(t *testing.T) {
 	}
 }
 
+func TestRouterRateLimitExceededIsAudited(t *testing.T) {
+	logger := zap.NewNop()
+	metrics := telemetry.NewMetrics()
+	sink := &recordingAuditSink{}
+	r := NewRouter(logger, metrics, nil, RouterOptions{
+		AuditSink:      sink,
+		RateLimitRPM:   1,
+		RateLimitBurst: 1,
+	})
+
+	first := httptest.NewRequest(http.MethodGet, "/v1/scans", nil)
+	first.RemoteAddr = "127.0.0.1:34567"
+	w1 := httptest.NewRecorder()
+	r.ServeHTTP(w1, first)
+	if w1.Code != http.StatusOK {
+		t.Fatalf("expected first request 200, got %d", w1.Code)
+	}
+
+	second := httptest.NewRequest(http.MethodGet, "/v1/scans", nil)
+	second.RemoteAddr = "127.0.0.1:34567"
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, second)
+	if w2.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected second request 429, got %d", w2.Code)
+	}
+
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	if len(sink.events) < 2 {
+		t.Fatalf("expected both requests to be audited, got %d events", len(sink.events))
+	}
+	last := sink.events[len(sink.events)-1]
+	if last.Path != "/v1/scans" || last.Status != http.StatusTooManyRequests {
+		t.Fatalf("expected throttled request audit event, got %+v", last)
+	}
+}
+
 func TestIPRateLimiterEvictsExpiredEntries(t *testing.T) {
 	now := time.Date(2026, 3, 20, 10, 0, 0, 0, time.UTC)
 	limiter := newIPRateLimiterWithClock(

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1422,6 +1422,32 @@ func TestRouterRateLimitExceeded(t *testing.T) {
 	}
 }
 
+func TestRouterRateLimitAppliesToUnauthorizedRequests(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	r := NewRouter(logger, metrics, nil, RouterOptions{
+		APIKeys:        []string{"secret-key"},
+		RateLimitRPM:   1,
+		RateLimitBurst: 1,
+	})
+
+	first := httptest.NewRequest(http.MethodGet, "/v1/scans", nil)
+	first.RemoteAddr = "127.0.0.1:23456"
+	w1 := httptest.NewRecorder()
+	r.ServeHTTP(w1, first)
+	if w1.Code != http.StatusUnauthorized {
+		t.Fatalf("expected first unauthorized request 401, got %d", w1.Code)
+	}
+
+	second := httptest.NewRequest(http.MethodGet, "/v1/scans", nil)
+	second.RemoteAddr = "127.0.0.1:23456"
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, second)
+	if w2.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected second unauthorized request 429, got %d", w2.Code)
+	}
+}
+
 func TestIPRateLimiterEvictsExpiredEntries(t *testing.T) {
 	now := time.Date(2026, 3, 20, 10, 0, 0, 0, time.UTC)
 	limiter := newIPRateLimiterWithClock(
@@ -1580,6 +1606,44 @@ func TestRouterWritesAuditSink(t *testing.T) {
 	}
 	if event.Authz.PolicySetID != defaultCentralPolicySetID {
 		t.Fatalf("expected policy set %q, got %q", defaultCentralPolicySetID, event.Authz.PolicySetID)
+	}
+}
+
+func TestRouterWritesAuditSinkForUnauthorizedRequest(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	sink := &recordingAuditSink{}
+	r := NewRouter(logger, metrics, nil, RouterOptions{
+		AuditSink: sink,
+		APIKeys:   []string{"secret-key"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/scans", nil)
+	req.RemoteAddr = "127.0.0.1:45678"
+	req.Header.Set("User-Agent", "router-test-unauthorized")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected unauthorized request status 401, got %d", w.Code)
+	}
+
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	if len(sink.events) == 0 {
+		t.Fatal("expected sink to capture unauthorized event")
+	}
+	event := sink.events[len(sink.events)-1]
+	if event.Status != http.StatusUnauthorized {
+		t.Fatalf("expected unauthorized status in audit event, got %d", event.Status)
+	}
+	if event.APIKeyID != "" {
+		t.Fatalf("expected empty api key fingerprint for missing key, got %q", event.APIKeyID)
+	}
+	if event.Actor != "unknown" {
+		t.Fatalf("expected unknown actor for missing credentials, got %q", event.Actor)
+	}
+	if event.Authz != nil {
+		t.Fatalf("expected no authz decision for unauthorized request, got %+v", event.Authz)
 	}
 }
 


### PR DESCRIPTION
Fixes #662

## Summary
- move `/v1` rate limiting ahead of authentication so repeated unauthorized requests are throttled
- move `/v1` request auditing ahead of authentication so unauthorized requests are recorded
- preserve actor attribution for downstream action events by setting the audit actor on successful authentication

## Why
- invalid or missing credentials previously bypassed both throttle and audit middleware due to chain order
- this left unauthorized request floods unthrottled and invisible in audit sinks

## Impact and risk
- unauthorized requests now generate audit `api_request` events with `401` status
- repeated unauthorized requests from one IP now receive `429` according to configured limits
- authenticated request behavior is preserved, including actor fingerprinting

## Validation
- `go test ./internal/api -run 'TestRouterRateLimitExceeded|TestRouterRateLimitAppliesToUnauthorizedRequests|TestRouterWritesAuditSink|TestRouterWritesAuditSinkForUnauthorizedRequest|TestRouterRequiresAPIKeyForV1'`
- `go test ./internal/api`

## Checklist
- [x] Scope is focused and free of unrelated changes
- [x] New/changed behavior has test coverage
- [x] CI-relevant checks were run locally for touched areas
- [x] No secrets or credentials are present in code, tests, or logs

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move `/v1` audit logging and rate limiting to run before authentication and ensure throttled requests are audited. Unauthorized floods are now throttled and visible, while authenticated behavior and actor attribution stay the same.

- **Bug Fixes**
  - Run `auditLogMiddleware` before the rate limiter and auth so 401s and throttled 429s are recorded as `api_request` events.
  - Apply `rateLimitMiddleware` pre-auth to throttle repeated unauthorized requests with 429 per configured limits.
  - Preserve actor attribution by setting the audit actor on the request context in `apiKeyAuthMiddleware` after successful auth.

<sup>Written for commit ec93c57744ed31d8a5ea500df55112f59c060c1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

