### PR TITLE
Fixes #734: standardize security advisory and support links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
         Thanks for reporting a bug.
 
         Do not use this template for security vulnerabilities.
-        Use private reporting instead: https://github.com/Oluwatobi-Mustapha/identrail/security/advisories/new
+        Use private reporting instead: https://github.com/identrail/identrail/security/advisories/new
 
   - type: checkboxes
     id: preflight
@@ -48,7 +48,7 @@ body:
     id: version
     attributes:
       label: Version
-      description: Example: v1.0.0, main commit SHA, container tag
+      description: "Example: v1.0.0, main commit SHA, container tag"
       placeholder: v1.0.0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability reporting (private)
-    url: https://github.com/Oluwatobi-Mustapha/identrail/security/advisories/new
+    url: https://github.com/identrail/identrail/security/advisories/new
     about: Report security issues privately. Do not open public issues for vulnerabilities.
   - name: Questions and support
-    url: https://github.com/Oluwatobi-Mustapha/identrail/discussions
+    url: https://github.com/identrail/identrail/discussions
     about: Ask usage questions and share ideas in Discussions.


### PR DESCRIPTION
Fixes #734

## What changed
- Updated `.github/ISSUE_TEMPLATE/config.yml` security advisory and support discussion links to `github.com/identrail/identrail`.
- Updated security reporting URL in `.github/ISSUE_TEMPLATE/bug_report.yml` to the same repository.
- Quoted one issue-template description field so the YAML template validates.

## Why
- Active issue template links were still pointing to the old repository path.

## Impact
- Security and support guidance in issue templates now routes to the correct repository.

## Validation
- `pre-commit run check-yaml --files .github/ISSUE_TEMPLATE/config.yml .github/ISSUE_TEMPLATE/bug_report.yml`

AI-assisted: No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized security advisory and support links in GitHub issue templates to the `identrail/identrail` repository. This routes users to the right place and resolves a small YAML validation issue.

- **Bug Fixes**
  - Updated security advisories and discussions URLs to https://github.com/identrail/identrail.
  - Quoted the Version field description in `.github/ISSUE_TEMPLATE/bug_report.yml` to validate YAML.

<sup>Written for commit 2a5681c443043729c833b0b0f9912783a28356ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

