### PR TITLE
fix: make remediation transition helper internal

### DIFF
--- a/internal/domain/appmode.go
+++ b/internal/domain/appmode.go
@@ -377,7 +377,7 @@ func CanTransitionConnectorStatus(from ConnectorStatus, to ConnectorStatus) bool
 	}
 }
 
-func CanTransitionRemediationJobStatus(from RemediationJobStatus, to RemediationJobStatus) bool {
+func canTransitionRemediationJobStatus(from RemediationJobStatus, to RemediationJobStatus) bool {
 	if from == to {
 		return true
 	}

--- a/internal/domain/appmode_test.go
+++ b/internal/domain/appmode_test.go
@@ -225,16 +225,16 @@ func TestConnectorStatusTransitions(t *testing.T) {
 }
 
 func TestRemediationStatusTransitions(t *testing.T) {
-	if !CanTransitionRemediationJobStatus(RemediationJobStatusQueued, RemediationJobStatusRunning) {
+	if !canTransitionRemediationJobStatus(RemediationJobStatusQueued, RemediationJobStatusRunning) {
 		t.Fatal("expected queued -> running transition to be valid")
 	}
-	if !CanTransitionRemediationJobStatus(RemediationJobStatusRunning, RemediationJobStatusSucceeded) {
+	if !canTransitionRemediationJobStatus(RemediationJobStatusRunning, RemediationJobStatusSucceeded) {
 		t.Fatal("expected running -> succeeded transition to be valid")
 	}
-	if CanTransitionRemediationJobStatus(RemediationJobStatusSucceeded, RemediationJobStatusQueued) {
+	if canTransitionRemediationJobStatus(RemediationJobStatusSucceeded, RemediationJobStatusQueued) {
 		t.Fatal("expected succeeded -> queued transition to be invalid")
 	}
-	if !CanTransitionRemediationJobStatus(RemediationJobStatusFailed, RemediationJobStatusQueued) {
+	if !canTransitionRemediationJobStatus(RemediationJobStatusFailed, RemediationJobStatusQueued) {
 		t.Fatal("expected failed -> queued transition to be valid for retry")
 	}
 }


### PR DESCRIPTION
Fixes #732

## Summary
- changed remediation transition helper visibility from exported to package-internal
- updated domain tests to use the internal helper name

## Why
- keeps the symbol surface aligned with actual in-package usage
- avoids exposing an exported API that has no external consumer

## Impact and risk
- low risk
- no behavior change in transition rules

## Validation
- `go test ./internal/domain -count=1`
- pre-commit hooks passed on commit
- pre-push checks passed (`go vet`, token/artifact hygiene)

AI-assisted: No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the remediation job status transition helper package-internal by renaming `CanTransitionRemediationJobStatus` to `canTransitionRemediationJobStatus` (fixes #732). Updated tests; no behavior change.

<sup>Written for commit 7acd4e8e55265fa6c9876222c55118aabed982ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

