### PR TITLE
fix: reject malformed scan_id inputs in API routes

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -261,8 +261,12 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		limit := parseLimit(c.Query("limit"), defaultFindingsLimit, maxListLimit)
 		offset := parseCursor(c.Query("cursor"))
 		sortBy, sortDesc := parseSortParams(c.Query("sort_by"), c.Query("sort_order"), "created_at")
+		scanID, ok := optionalUUIDParam(c, c.Query("scan_id"), "scan_id")
+		if !ok {
+			return
+		}
 		items, err := svc.ListFindingsFiltered(c.Request.Context(), pageFetchLimit(offset, limit), FindingsFilter{
-			ScanID:          strings.TrimSpace(c.Query("scan_id")),
+			ScanID:          scanID,
 			Severity:        strings.TrimSpace(c.Query("severity")),
 			Type:            strings.TrimSpace(c.Query("type")),
 			LifecycleStatus: strings.TrimSpace(c.Query("lifecycle_status")),
@@ -298,10 +302,14 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 	})
 
 	v1.GET("/findings/:finding_id", func(c *gin.Context) {
+		scanID, ok := optionalUUIDParam(c, c.Query("scan_id"), "scan_id")
+		if !ok {
+			return
+		}
 		item, err := svc.GetFinding(
 			c.Request.Context(),
 			strings.TrimSpace(c.Param("finding_id")),
-			strings.TrimSpace(c.Query("scan_id")),
+			scanID,
 		)
 		if err != nil {
 			if errors.Is(err, db.ErrNotFound) {
@@ -317,10 +325,14 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 
 	v1.GET("/findings/:finding_id/history", func(c *gin.Context) {
 		limit := parseLimit(c.Query("limit"), defaultEventsLimit, maxListLimit)
+		scanID, ok := optionalUUIDParam(c, c.Query("scan_id"), "scan_id")
+		if !ok {
+			return
+		}
 		items, err := svc.ListFindingTriageHistory(
 			c.Request.Context(),
 			strings.TrimSpace(c.Param("finding_id")),
-			strings.TrimSpace(c.Query("scan_id")),
+			scanID,
 			limit,
 		)
 		if err != nil {
@@ -336,10 +348,14 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 	})
 
 	v1.GET("/findings/:finding_id/exports", func(c *gin.Context) {
+		scanID, ok := optionalUUIDParam(c, c.Query("scan_id"), "scan_id")
+		if !ok {
+			return
+		}
 		exports, err := svc.GetFindingExports(
 			c.Request.Context(),
 			strings.TrimSpace(c.Param("finding_id")),
-			strings.TrimSpace(c.Query("scan_id")),
+			scanID,
 		)
 		if err != nil {
 			if errors.Is(err, db.ErrNotFound) {
@@ -375,10 +391,14 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
 			return
 		}
+		scanID, ok := optionalUUIDParam(c, c.Query("scan_id"), "scan_id")
+		if !ok {
+			return
+		}
 		item, err := svc.TriageFinding(
 			c.Request.Context(),
 			strings.TrimSpace(c.Param("finding_id")),
-			strings.TrimSpace(c.Query("scan_id")),
+			scanID,
 			request,
 			triageActorFromContext(c, opts.AuditFingerprinter),
 		)
@@ -402,9 +422,13 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		limit := parseLimit(c.Query("limit"), defaultFindingsLimit, maxListLimit)
 		offset := parseCursor(c.Query("cursor"))
 		sortBy, sortDesc := parseSortParams(c.Query("sort_by"), c.Query("sort_order"), "name")
+		scanID, ok := optionalUUIDParam(c, c.Query("scan_id"), "scan_id")
+		if !ok {
+			return
+		}
 		items, err := svc.ListIdentities(
 			c.Request.Context(),
-			strings.TrimSpace(c.Query("scan_id")),
+			scanID,
 			strings.TrimSpace(c.Query("provider")),
 			strings.TrimSpace(c.Query("type")),
 			strings.TrimSpace(c.Query("name_prefix")),
@@ -432,9 +456,13 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		limit := parseLimit(c.Query("limit"), defaultFindingsLimit, maxListLimit)
 		offset := parseCursor(c.Query("cursor"))
 		sortBy, sortDesc := parseSortParams(c.Query("sort_by"), c.Query("sort_order"), "discovered_at")
+		scanID, ok := optionalUUIDParam(c, c.Query("scan_id"), "scan_id")
+		if !ok {
+			return
+		}
 		items, err := svc.ListRelationships(
 			c.Request.Context(),
-			strings.TrimSpace(c.Query("scan_id")),
+			scanID,
 			strings.TrimSpace(c.Query("type")),
 			strings.TrimSpace(c.Query("from_node_id")),
 			strings.TrimSpace(c.Query("to_node_id")),
@@ -462,10 +490,14 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		limit := parseLimit(c.Query("limit"), defaultFindingsLimit, maxListLimit)
 		offset := parseCursor(c.Query("cursor"))
 		sortBy, sortDesc := parseSortParams(c.Query("sort_by"), c.Query("sort_order"), "confidence")
+		scanID, ok := optionalUUIDParam(c, c.Query("scan_id"), "scan_id")
+		if !ok {
+			return
+		}
 		items, err := svc.ListOwnershipSignals(
 			c.Request.Context(),
 			pageFetchLimit(offset, limit),
-			OwnershipFilter{ScanID: strings.TrimSpace(c.Query("scan_id"))},
+			OwnershipFilter{ScanID: scanID},
 		)
 		if err != nil {
 			if errors.Is(err, db.ErrNotFound) {
@@ -506,9 +538,13 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 
 	v1.GET("/scans/:scan_id/diff", func(c *gin.Context) {
 		limit := parseLimit(c.Query("limit"), defaultFindingsLimit, maxListLimit)
+		scanID, ok := requiredUUIDParam(c, c.Param("scan_id"), "scan_id")
+		if !ok {
+			return
+		}
 		diff, err := svc.GetScanDiffAgainst(
 			c.Request.Context(),
-			strings.TrimSpace(c.Param("scan_id")),
+			scanID,
 			strings.TrimSpace(c.Query("previous_scan_id")),
 			limit,
 		)
@@ -532,9 +568,13 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		limit := parseLimit(c.Query("limit"), defaultEventsLimit, maxListLimit)
 		offset := parseCursor(c.Query("cursor"))
 		sortBy, sortDesc := parseSortParams(c.Query("sort_by"), c.Query("sort_order"), "created_at")
+		scanID, ok := requiredUUIDParam(c, c.Param("scan_id"), "scan_id")
+		if !ok {
+			return
+		}
 		items, err := svc.ListScanEventsFiltered(
 			c.Request.Context(),
-			strings.TrimSpace(c.Param("scan_id")),
+			scanID,
 			strings.TrimSpace(c.Query("level")),
 			pageFetchLimit(offset, limit),
 		)
@@ -1430,6 +1470,27 @@ func isValidUUID(raw string) bool {
 	}
 	_, err := uuid.Parse(strings.TrimSpace(raw))
 	return err == nil
+}
+
+func optionalUUIDParam(c *gin.Context, raw string, field string) (string, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", true
+	}
+	if !isValidUUID(trimmed) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid " + field})
+		return "", false
+	}
+	return trimmed, true
+}
+
+func requiredUUIDParam(c *gin.Context, raw string, field string) (string, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if !isValidUUID(trimmed) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid " + field})
+		return "", false
+	}
+	return trimmed, true
 }
 
 func sortFindings(items []domain.Finding, sortBy string, desc bool) {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1632,36 +1632,37 @@ func TestRouterScanDiffAndEventsNotFound(t *testing.T) {
 	store := db.NewMemoryStore()
 	svc := NewService(store, routerScanner{}, "aws")
 	r := NewRouter(logger, metrics, svc, RouterOptions{})
+	missingScanID := "11111111-1111-1111-1111-111111111111"
 
-	diffReq := httptest.NewRequest(http.MethodGet, "/v1/scans/missing/diff", nil)
+	diffReq := httptest.NewRequest(http.MethodGet, "/v1/scans/"+missingScanID+"/diff", nil)
 	diffW := httptest.NewRecorder()
 	r.ServeHTTP(diffW, diffReq)
 	if diffW.Code != http.StatusNotFound {
 		t.Fatalf("expected diff 404 for missing scan, got %d", diffW.Code)
 	}
 
-	eventsReq := httptest.NewRequest(http.MethodGet, "/v1/scans/missing/events", nil)
+	eventsReq := httptest.NewRequest(http.MethodGet, "/v1/scans/"+missingScanID+"/events", nil)
 	eventsW := httptest.NewRecorder()
 	r.ServeHTTP(eventsW, eventsReq)
 	if eventsW.Code != http.StatusNotFound {
 		t.Fatalf("expected events 404 for missing scan, got %d", eventsW.Code)
 	}
 
-	identitiesReq := httptest.NewRequest(http.MethodGet, "/v1/identities?scan_id=missing", nil)
+	identitiesReq := httptest.NewRequest(http.MethodGet, "/v1/identities?scan_id="+missingScanID, nil)
 	identitiesW := httptest.NewRecorder()
 	r.ServeHTTP(identitiesW, identitiesReq)
 	if identitiesW.Code != http.StatusNotFound {
 		t.Fatalf("expected identities 404 for missing scan, got %d", identitiesW.Code)
 	}
 
-	relationshipsReq := httptest.NewRequest(http.MethodGet, "/v1/relationships?scan_id=missing", nil)
+	relationshipsReq := httptest.NewRequest(http.MethodGet, "/v1/relationships?scan_id="+missingScanID, nil)
 	relationshipsW := httptest.NewRecorder()
 	r.ServeHTTP(relationshipsW, relationshipsReq)
 	if relationshipsW.Code != http.StatusNotFound {
 		t.Fatalf("expected relationships 404 for missing scan, got %d", relationshipsW.Code)
 	}
 
-	findingsReq := httptest.NewRequest(http.MethodGet, "/v1/findings?scan_id=missing", nil)
+	findingsReq := httptest.NewRequest(http.MethodGet, "/v1/findings?scan_id="+missingScanID, nil)
 	findingsW := httptest.NewRecorder()
 	r.ServeHTTP(findingsW, findingsReq)
 	if findingsW.Code != http.StatusNotFound {
@@ -1688,6 +1689,41 @@ func TestRouterScanDiffAndEventsNotFound(t *testing.T) {
 	r.ServeHTTP(invalidBaselineW, invalidBaselineReq)
 	if invalidBaselineW.Code != http.StatusBadRequest {
 		t.Fatalf("expected diff 400 for invalid baseline scan, got %d", invalidBaselineW.Code)
+	}
+}
+
+func TestRouterRejectsInvalidScanUUIDInputs(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+	r := NewRouter(logger, metrics, svc, RouterOptions{})
+
+	cases := []string{
+		"/v1/scans/not-a-uuid/diff",
+		"/v1/scans/not-a-uuid/events",
+		"/v1/findings?scan_id=not-a-uuid",
+		"/v1/findings/f1?scan_id=not-a-uuid",
+		"/v1/findings/f1/history?scan_id=not-a-uuid",
+		"/v1/findings/f1/exports?scan_id=not-a-uuid",
+		"/v1/identities?scan_id=not-a-uuid",
+		"/v1/relationships?scan_id=not-a-uuid",
+		"/v1/ownership/signals?scan_id=not-a-uuid",
+	}
+	for _, path := range cases {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for invalid scan_id on %s, got %d", path, w.Code)
+		}
+	}
+
+	triageReq := httptest.NewRequest(http.MethodPatch, "/v1/findings/f1/triage?scan_id=not-a-uuid", bytes.NewBufferString(`{"status":"ack"}`))
+	triageW := httptest.NewRecorder()
+	r.ServeHTTP(triageW, triageReq)
+	if triageW.Code != http.StatusBadRequest {
+		t.Fatalf("expected triage 400 for invalid scan_id, got %d", triageW.Code)
 	}
 }
 


### PR DESCRIPTION
Fixes #657

## Summary
- validate non-repo `scan_id` values at router boundaries for both path and query inputs
- return `400 invalid scan_id` for malformed UUIDs before store/database calls
- keep `404` behavior for well-formed but missing scan IDs and add regression tests

## Impact
- prevents malformed UUIDs from surfacing as downstream database errors
- standardizes scan-id validation behavior across findings, identities, relationships, ownership, diff, and events endpoints

## Validation
- `go test ./internal/api`

AI-assisted: No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `scan_id` UUIDs at API boundaries and return 400 for malformed inputs. This prevents downstream DB errors and standardizes behavior across related routes.

- **Bug Fixes**
  - Validate `scan_id` in query and path using `optionalUUIDParam` and `requiredUUIDParam`.
  - Keep 404 for well-formed but missing IDs; malformed inputs now return 400 with "invalid scan_id".
  - Applied to: findings (list, get, history, exports, triage), identities, relationships, ownership signals, scans diff, and scan events.
  - Added regression tests for invalid UUID cases.

<sup>Written for commit 30b038101ea989b32755574541d67cae3fd5b74c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

