### PR TITLE
Fixes #719: add scoped API key normalization and non-leaking error tests

### DIFF
--- a/internal/api/router_api_key_scope_normalization_test.go
+++ b/internal/api/router_api_key_scope_normalization_test.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
+	"github.com/Oluwatobi-Mustapha/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func TestRouterScopedAuthorizationNormalizesScopeValues(t *testing.T) {
+	logger := zap.NewNop()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+	r := NewRouter(logger, metrics, svc, RouterOptions{
+		APIKeyScopes: map[string][]string{
+			"reader-key": {" READ "},
+			"writer-key": {" write "},
+		},
+	})
+
+	readerReq := httptest.NewRequest(http.MethodGet, "/v1/scans", nil)
+	readerReq.Header.Set("X-API-Key", "reader-key")
+	readerResp := httptest.NewRecorder()
+	r.ServeHTTP(readerResp, readerReq)
+	if readerResp.Code != http.StatusOK {
+		t.Fatalf("expected reader GET 200, got %d", readerResp.Code)
+	}
+
+	readerWriteReq := httptest.NewRequest(http.MethodPost, "/v1/scans", nil)
+	readerWriteReq.Header.Set("X-API-Key", "reader-key")
+	readerWriteResp := httptest.NewRecorder()
+	r.ServeHTTP(readerWriteResp, readerWriteReq)
+	if readerWriteResp.Code != http.StatusForbidden {
+		t.Fatalf("expected reader POST 403, got %d", readerWriteResp.Code)
+	}
+
+	writerWriteReq := httptest.NewRequest(http.MethodPost, "/v1/scans", nil)
+	writerWriteReq.Header.Set("X-API-Key", "writer-key")
+	writerWriteResp := httptest.NewRecorder()
+	r.ServeHTTP(writerWriteResp, writerWriteReq)
+	if writerWriteResp.Code != http.StatusAccepted {
+		t.Fatalf("expected writer POST 202, got %d", writerWriteResp.Code)
+	}
+}

--- a/internal/config/security_api_key_scope_test.go
+++ b/internal/config/security_api_key_scope_test.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateSecurityAcceptsNormalizedScopedAPIKeyScopes(t *testing.T) {
+	cfg := Config{
+		APIKeyScopes: map[string][]string{
+			"reader-key": {" READ "},
+			"writer-key": {" write ", "ADMIN"},
+		},
+	}
+	if err := ValidateSecurity(cfg); err != nil {
+		t.Fatalf("expected mixed-case and padded scopes to validate, got %v", err)
+	}
+}
+
+func TestValidateSecurityInvalidScopedAPIKeyErrorDoesNotLeakKeyOrScopeValue(t *testing.T) {
+	const apiKey = "sensitive-api-key-value"
+	const invalidScope = "dangerous-scope-value"
+
+	cfg := Config{
+		APIKeyScopes: map[string][]string{
+			apiKey: {invalidScope},
+		},
+	}
+	err := ValidateSecurity(cfg)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	errText := err.Error()
+	if strings.Contains(errText, apiKey) {
+		t.Fatalf("validation error leaked api key: %q", errText)
+	}
+	if strings.Contains(errText, invalidScope) {
+		t.Fatalf("validation error leaked invalid scope value: %q", errText)
+	}
+}
+
+func TestValidateSecurityScopedAPIKeyWithoutValidScopeErrorDoesNotLeakKey(t *testing.T) {
+	const apiKey = "sensitive-empty-scope-key"
+
+	cfg := Config{
+		APIKeyScopes: map[string][]string{
+			apiKey: {"   "},
+		},
+	}
+	err := ValidateSecurity(cfg)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	errText := err.Error()
+	if strings.Contains(errText, apiKey) {
+		t.Fatalf("validation error leaked api key: %q", errText)
+	}
+}


### PR DESCRIPTION
Fixes #719

## Summary
- add config validation tests for mixed-case and padded scoped API key values
- add regression checks that scoped key validation errors do not leak raw API keys or invalid scope values
- add router-level authorization coverage proving normalized scoped values enforce expected read/write behavior

## Validation
- `go test ./internal/config -run "TestValidateSecurity(AcceptsNormalizedScopedAPIKeyScopes|InvalidScopedAPIKeyErrorDoesNotLeakKeyOrScopeValue|ScopedAPIKeyWithoutValidScopeErrorDoesNotLeakKey)" -count=1`
- `go test ./internal/api -run TestRouterScopedAuthorizationNormalizesScopeValues -count=1`

AI-assisted: No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests to verify scoped API key scope normalization and correct read/write behavior in the router. Adds regression checks ensuring validation errors never leak raw API keys or invalid scope values.

<sup>Written for commit 369c3efcfd754c9f6a0fac36e8011eaf503193ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

