### PR TITLE
Fixes #735: refresh Go baseline references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@
   - reduced collision risk in large multi-account datasets
   - added deterministic ID regression tests for hash format and stability
 - Refreshed vulnerability-sensitive Go runtime/dependency baseline:
-  - raised project Go version baseline to `1.25.8`
+  - raised project Go version baseline to `1.25.9`
   - upgraded `github.com/quic-go/quic-go` to `v0.57.0` and `qpack` to `v0.6.0`
   - validated compatibility with full test and vet suites
 - Hardened repository exposure scanner clone target validation:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,24 +18,24 @@ Good contributions include:
 ## Ways to Contribute
 
 - **Open an issue** to report a bug, request a feature, or suggest an improvement.
-  
+
 - **Pick up an existing issue** if you want to contribute code, documentation, tests, or cleanup work.
 
 - **Report bugs clearly** by including reproduction steps, expected behavior, actual behavior, environment details, and any relevant logs or screenshots.
-  
+
 - **Link pull requests to issues** by starting your PR description with a closing keyword and issue number, such as `Fixes #500`, `Closes #500`, or `Resolves #500`. This automatically connects the PR to the related issue and helps keep project tracking clean.
-  
+
 - **Propose enhancements** with a clear problem statement, why it matters, and a suggested approach if you have one.
-  
+
 - **Submit focused pull requests** that address one issue or improvement at a time. Include tests and documentation updates when relevant.
-  
+
 - **Improve documentation and runbooks** whenever behavior, setup steps, operations, or troubleshooting guidance changes.
 
-  
+
 ## Before You Start
 
 Prerequisites:
-- Go `1.25.8` (see `go.mod`)
+- Go `1.25.9` (see `go.mod`)
 - Node.js `24` for `web/`
 - Docker for local Compose and image validation
 - PostgreSQL (or Docker) for integration test flows


### PR DESCRIPTION
Fixes #735

## What changed
- Updated `CONTRIBUTING.md` Go prerequisite from `1.25.8` to `1.25.9`.
- Updated the matching Go baseline bullet in `CHANGELOG.md` from `1.25.8` to `1.25.9`.

## Why
- The documented baseline should match `go.mod` and runtime build references.

## Impact
- Contributor and release docs now align with the current Go toolchain baseline.

## Validation
- `go version` alignment reference checked against `go.mod` (`go 1.25.9`)
- `git grep -n "1.25.8" CONTRIBUTING.md CHANGELOG.md` (no matches)

AI-assisted: No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated contributor and changelog docs to raise the Go baseline from `1.25.8` to `1.25.9`, matching `go.mod` and the build toolchain. This keeps local setup and release notes accurate.

<sup>Written for commit 2dd35f64f6c27bc023c0f503137d7a867a9a3aba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

