### PR TITLE
Reject credential-bearing repo scan URLs before persistence

### DIFF
--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"sort"
 	"strings"
 	"sync"
@@ -599,6 +600,9 @@ func (s *Service) validateRepoScanRequest(request RepoScanRequest) (string, int,
 	if target == "" {
 		return "", 0, 0, ErrInvalidRepoScanRequest
 	}
+	if repoTargetContainsURLCredentials(target) {
+		return "", 0, 0, ErrInvalidRepoScanRequest
+	}
 	if repoexposure.IsLocalRepositoryTarget(target) {
 		return "", 0, 0, ErrRepoTargetNotAllowed
 	}
@@ -614,6 +618,22 @@ func (s *Service) validateRepoScanRequest(request RepoScanRequest) (string, int,
 		return "", 0, 0, ErrInvalidRepoScanRequest
 	}
 	return target, historyLimit, maxFindings, nil
+}
+
+func repoTargetContainsURLCredentials(target string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(target))
+	if err != nil || parsed == nil || parsed.User == nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(parsed.Scheme)) {
+	case "http", "https":
+		return true
+	case "ssh":
+		_, hasPassword := parsed.User.Password()
+		return hasPassword
+	default:
+		return false
+	}
 }
 
 func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanRecord, historyLimit int, maxFindings int) (RunRepoScanResult, error) {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -1514,6 +1514,18 @@ func TestServiceRunRepoScanRejectsLocalRepositoryTarget(t *testing.T) {
 	}
 }
 
+func TestServiceRunRepoScanRejectsCredentialBearingRepositoryURL(t *testing.T) {
+	svc := NewService(db.NewMemoryStore(), fakeScanner{}, "aws")
+	svc.RepoScanAllowedTargets = []string{"*"}
+
+	_, err := svc.RunRepoScan(defaultScopeContext(), RepoScanRequest{
+		Repository: "https://token@example.com/org/repo.git",
+	})
+	if !errors.Is(err, ErrInvalidRepoScanRequest) {
+		t.Fatalf("expected invalid repo scan request for credential-bearing url, got %v", err)
+	}
+}
+
 func TestSanitizeRepoScanLimit(t *testing.T) {
 	got, err := sanitizeRepoScanLimit(0, 100, 500)
 	if err != nil || got != 100 {


### PR DESCRIPTION
Fixes #665

## What changed
- Added early repo scan request validation that rejects credential-bearing repository URLs before any persistence.
- Added regression coverage to ensure `https://token@example.com/...` requests fail with `ErrInvalidRepoScanRequest`.

## Why it changed
Credential-bearing repository URLs could be stored in repo scan records and later exposed in responses or logs. This change prevents those URLs from entering persistence at all.

## Impact and risk
- Credential-bearing URLs are now rejected at API request validation time.
- Normal repository targets continue to work.
- Low risk: behavior is isolated to repo scan request validation with explicit tests.

## Validation
- `go test ./internal/api -run 'TestServiceRunRepoScanRejectsCredentialBearingRepositoryURL|TestServiceRunRepoScanRejectsLocalRepositoryTarget' -count=1`
- `go test ./internal/api -count=1`

AI-assisted: No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject credential-bearing repository URLs during repo scan request validation to prevent sensitive data from being persisted or exposed.

- **Bug Fixes**
  - Added early validation in `internal/api` to reject URLs with credentials and return `ErrInvalidRepoScanRequest`.
  - Implemented credential detection for `http`, `https`, and `ssh` schemes and added a regression test for `https://token@example.com/org/repo.git`.

<sup>Written for commit 79b3a1ba5d67930886389e60b38efde095ae7f09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

