### PR TITLE
Fixes #720: add custom OIDC claim mapping coverage

### DIFF
--- a/internal/api/oidc_custom_claim_mapping_test.go
+++ b/internal/api/oidc_custom_claim_mapping_test.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestOIDCTokenVerifierUsesConfiguredCustomClaimNames(t *testing.T) {
+	verifier := &OIDCTokenVerifier{
+		expectedIssuer: "https://issuer.example.com",
+		expectedAud:    "identrail-api",
+		tenantClaim:    "https://identrail.example/tenant",
+		workspaceClaim: "https://identrail.example/workspace",
+		groupsClaim:    "realm_groups",
+		rolesClaim:     "realm_roles",
+		verifier: fakeRawTokenVerifier{
+			token: fakeClaimsDecoder{
+				claims: map[string]any{
+					"sub":                                 "subject-1",
+					"iss":                                 "https://issuer.example.com",
+					"aud":                                 []any{"identrail-api"},
+					"https://identrail.example/tenant":    "tenant-custom",
+					"https://identrail.example/workspace": "workspace-custom",
+					"tenant_id":                           "tenant-default",
+					"workspace_id":                        "workspace-default",
+					"realm_groups":                        []any{"platform"},
+					"realm_roles":                         []any{"owner"},
+					"groups":                              []any{"ignored-group"},
+					"roles":                               []any{"ignored-role"},
+					"scope":                               "read write",
+				},
+			},
+		},
+	}
+
+	token, err := verifier.VerifyToken(context.Background(), "token")
+	if err != nil {
+		t.Fatalf("verify token: %v", err)
+	}
+	if token.TenantID != "tenant-custom" || token.WorkspaceID != "workspace-custom" {
+		t.Fatalf("expected custom scope claims, got tenant=%q workspace=%q", token.TenantID, token.WorkspaceID)
+	}
+	if len(token.Groups) != 1 || token.Groups[0] != "platform" {
+		t.Fatalf("expected custom groups claim, got %+v", token.Groups)
+	}
+	if len(token.Roles) != 1 || token.Roles[0] != "owner" {
+		t.Fatalf("expected custom roles claim, got %+v", token.Roles)
+	}
+}
+
+func TestOIDCTokenVerifierFailsWhenConfiguredCustomScopeClaimsAreMissing(t *testing.T) {
+	verifier := &OIDCTokenVerifier{
+		expectedIssuer: "https://issuer.example.com",
+		expectedAud:    "identrail-api",
+		tenantClaim:    "https://identrail.example/tenant",
+		workspaceClaim: "https://identrail.example/workspace",
+		groupsClaim:    "groups",
+		rolesClaim:     "roles",
+		verifier: fakeRawTokenVerifier{
+			token: fakeClaimsDecoder{
+				claims: map[string]any{
+					"sub":          "subject-1",
+					"iss":          "https://issuer.example.com",
+					"aud":          "identrail-api",
+					"tenant_id":    "tenant-default",
+					"workspace_id": "workspace-default",
+				},
+			},
+		},
+	}
+
+	_, err := verifier.VerifyToken(context.Background(), "token")
+	if err == nil {
+		t.Fatal("expected validation error for missing configured custom claims")
+	}
+	if !strings.Contains(err.Error(), "https://identrail.example/tenant") {
+		t.Fatalf("expected missing custom tenant claim in error, got %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #720

## Summary
- add regression coverage for custom tenant/workspace/groups/roles claim mapping in `OIDCTokenVerifier`
- verify configured custom claim names take precedence over default claim keys when both are present
- verify missing configured custom scope claim fails validation

## Validation
- `go test ./internal/api -run "TestOIDCTokenVerifier(UsesConfiguredCustomClaimNames|FailsWhenConfiguredCustomScopeClaimsAreMissing)" -count=1`

AI-assisted: No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds regression tests for custom OIDC claim mapping in `OIDCTokenVerifier` (fixes #720). Ensures configured custom tenant/workspace/groups/roles claims override defaults, and missing configured custom scope claims fail validation.

<sup>Written for commit 2add9aa07dbf3e4cc1915fb6580fec06c0bf6e61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

