### PR TITLE
fix: consolidate first-non-empty helper logic

### DIFF
--- a/internal/api/authz_middleware.go
+++ b/internal/api/authz_middleware.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/identrail/identrail/internal/audit"
 	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/stringutil"
 	"github.com/identrail/identrail/internal/telemetry"
 )
 

--- a/internal/api/authz_middleware.go
+++ b/internal/api/authz_middleware.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Oluwatobi-Mustapha/identrail/internal/audit"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
+	"github.com/Oluwatobi-Mustapha/identrail/internal/stringutil"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/telemetry"
 	"github.com/gin-gonic/gin"
 )
@@ -521,10 +522,7 @@ func buildPolicyInputFromGinContext(c *gin.Context, policy routePolicy, writeKey
 }
 
 func firstNonEmpty(primary string, fallback string) string {
-	if strings.TrimSpace(primary) != "" {
-		return strings.TrimSpace(primary)
-	}
-	return strings.TrimSpace(fallback)
+	return stringutil.FirstNonBlankTrimmed(primary, fallback)
 }
 
 func inferPrincipalType(c *gin.Context) string {

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/identrail/identrail/internal/db"
 	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/stringutil"
 )
 
 var awsRoleARNPattern = regexp.MustCompile(`^arn:(aws|aws-us-gov|aws-cn):iam::[0-9]{12}:role/[A-Za-z0-9+=,.@_/-]{1,512}$`)

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/domain"
+	"github.com/Oluwatobi-Mustapha/identrail/internal/stringutil"
 )
 
 var awsRoleARNPattern = regexp.MustCompile(`^arn:(aws|aws-us-gov|aws-cn):iam::[0-9]{12}:role/[A-Za-z0-9+=,.@_/-]{1,512}$`)
@@ -321,12 +322,7 @@ func copyAWSDiagnostics(diagnostics []AWSConnectionDiagnostic) []AWSConnectionDi
 }
 
 func firstNonEmptyAWSValue(values ...string) string {
-	for _, value := range values {
-		if value != "" {
-			return value
-		}
-	}
-	return ""
+	return stringutil.FirstNonEmpty(values...)
 }
 
 func awsMetadataString(metadata map[string]any, key string) string {

--- a/internal/api/router_api_key_scope_normalization_test.go
+++ b/internal/api/router_api_key_scope_normalization_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
-	"github.com/Oluwatobi-Mustapha/identrail/internal/telemetry"
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/telemetry"
 	"go.uber.org/zap"
 )
 

--- a/internal/providers/aws/connector_validation.go
+++ b/internal/providers/aws/connector_validation.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/smithy-go"
 	api "github.com/identrail/identrail/internal/api"
+	"github.com/identrail/identrail/internal/stringutil"
 )
 
 // ConnectionValidator validates AWS connector setup with read-only AWS calls.

--- a/internal/providers/aws/connector_validation.go
+++ b/internal/providers/aws/connector_validation.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	api "github.com/Oluwatobi-Mustapha/identrail/internal/api"
+	"github.com/Oluwatobi-Mustapha/identrail/internal/stringutil"
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
 	awscfg "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -292,10 +293,5 @@ func classifyAWSError(err error, fallback string) string {
 }
 
 func firstNonEmptyString(values ...string) string {
-	for _, value := range values {
-		if value != "" {
-			return value
-		}
-	}
-	return ""
+	return stringutil.FirstNonEmpty(values...)
 }

--- a/internal/stringutil/first_non_empty.go
+++ b/internal/stringutil/first_non_empty.go
@@ -1,0 +1,24 @@
+package stringutil
+
+import "strings"
+
+// FirstNonEmpty returns the first non-empty value in order.
+func FirstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+// FirstNonBlankTrimmed returns the first non-blank value after trimming whitespace.
+func FirstNonBlankTrimmed(values ...string) string {
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Fixes #763

## Summary
- added shared helper functions in `internal/stringutil`
- replaced duplicate first-non-empty helper bodies in:
  - `internal/api/authz_middleware.go`
  - `internal/api/aws_connect.go`
  - `internal/providers/aws/connector_validation.go`

## Why
- reduces duplicated utility logic and makes empty/non-blank selection behavior easier to keep consistent

## Impact and risk
- low risk
- helper behavior is preserved for current call sites

## Validation
- `go test ./internal/api -count=1`
- `go test ./internal/providers/aws -count=1`
- pre-commit hooks passed on commit
- pre-push checks passed (`go vet`, token/artifact hygiene)

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates first-non-empty helpers into a shared `internal/stringutil` utility and restores correct imports after the refactor; no behavior change. Fixes #763.

- **Refactors**
  - Added `internal/stringutil/first_non_empty.go` with `FirstNonEmpty` and `FirstNonBlankTrimmed`.
  - Replaced duplicate helpers in `internal/api/authz_middleware.go`, `internal/api/aws_connect.go`, and `internal/providers/aws/connector_validation.go`.

- **Bug Fixes**
  - Restored imports to use `internal/stringutil` and corrected module import path in `internal/api/router_api_key_scope_normalization_test.go`.

<sup>Written for commit 31e892cbcc313e8fd48a4a58aca84489fa38dc00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

