### PR TITLE
Fixes #737: correct README CLI capability claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For enterprise auth scope, tenant/workspace context, and decision audit verifica
 - Discovers machine identities and trust relationships across AWS and Kubernetes.
 - Persists raw and normalized scan artifacts for explainability and auditability.
 - Produces deterministic findings with risk evidence and remediation context.
-- Provides API and CLI workflows for scans, findings, trends, and diff analysis.
+- Provides API and web workflows for trends and diff analysis, plus CLI workflows for scans, findings, repo exposure scans, and authz rollback.
 - Supports optional repository exposure scanning (secrets and CI/IaC risk) in an isolated pipeline.
 
 ## What Identrail Does Not Do


### PR DESCRIPTION
Fixes #737

## What changed
- Updated README capability wording to correctly separate CLI capabilities from API/web capabilities.

## Why
- The README previously implied CLI coverage for trends and diff analysis, which are currently API/web surfaces.

## Impact
- Product capability docs now match current command surface in `internal/cli/root.go`.

## Validation
- `git grep -n "trends, and diff analysis" README.md` (no matches)

AI-assisted: No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Correct the README to separate CLI and API/web capabilities. Trends and diff analysis are documented as API/web, while CLI covers scans, findings, repo exposure scans, and authz rollback.

<sup>Written for commit 019c2c09dc96ac584a6255e2c27f1aefa1e7cafc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

