### PR TITLE
Fixes #646: Bind scoped API keys to tenant/workspace context

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -31,6 +31,8 @@ This page is the canonical runtime configuration surface for API and worker proc
 Notes:
 - `IDENTRAIL_OIDC_ISSUER_URL` and `IDENTRAIL_OIDC_AUDIENCE` must be configured together.
 - OIDC bearer auth enforces issuer/audience plus token validity (`exp`) via provider verification.
+- `IDENTRAIL_API_KEY_SCOPES` supports optional tenant/workspace binding metadata per key: `tenant:<tenant-id>` and `workspace:<workspace-id>`.
+- API key callers can send `X-Identrail-Tenant-ID` and `X-Identrail-Workspace-ID` only when those headers match the key binding metadata.
 
 ## Provider Collection
 

--- a/docs/enterprise-quickstart.md
+++ b/docs/enterprise-quickstart.md
@@ -19,8 +19,10 @@ Edit `deploy/docker/.env` and set at minimum:
 - `IDENTRAIL_WRITE_API_KEYS` with write-capable keys
 - `IDENTRAIL_POSTGRES_PASSWORD` with a strong database password
 - `IDENTRAIL_API_KEY_SCOPES` (required for this quickstart), for example:
-  - `IDENTRAIL_API_KEY_SCOPES=<reader-key>:read;<writer-key>:read,write;<admin-key>:read,write,admin`
+  - `IDENTRAIL_API_KEY_SCOPES=<reader-key>:read,tenant:tenant-a,workspace:workspace-a;<writer-key>:read,write,tenant:tenant-a,workspace:workspace-a;<admin-key>:read,write,admin,tenant:tenant-a,workspace:workspace-a`
 - `IDENTRAIL_AUDIT_LOG_FILE=/tmp/identrail-audit.jsonl`
+
+Scoped API key bindings are enforced before tenant/workspace headers are accepted. For API key callers, `X-Identrail-Tenant-ID` and `X-Identrail-Workspace-ID` must match the key binding metadata.
 
 Optional hardening:
 - `IDENTRAIL_AUDIT_FORWARD_URL=https://audit.example.com/events`

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -1531,14 +1531,14 @@ components:
       required: false
       schema:
         type: string
-      description: Optional tenant scope override when token claims do not provide tenant context.
+      description: Optional tenant scope override when token claims do not provide tenant context. API key callers must use a key bound to the same tenant scope.
     scopeWorkspaceID:
       in: header
       name: X-Identrail-Workspace-ID
       required: false
       schema:
         type: string
-      description: Optional workspace scope override when token claims do not provide workspace context.
+      description: Optional workspace scope override when token claims do not provide workspace context. API key callers must use a key bound to the same workspace scope.
     limit:
       in: query
       name: limit

--- a/internal/api/authz_policy_rollback_test.go
+++ b/internal/api/authz_policy_rollback_test.go
@@ -49,7 +49,7 @@ func TestAuthzPolicyRollbackEndpointSwitchesActiveVersionAndCountsRollback(t *te
 		DefaultTenantID:    "tenant-a",
 		DefaultWorkspaceID: "workspace-a",
 		APIKeyScopes: map[string][]string{
-			"admin-key": {scopeRead, scopeWrite, scopeAdmin},
+			"admin-key": {scopeRead, scopeWrite, scopeAdmin, "tenant:tenant-a", "workspace:workspace-a"},
 		},
 	})
 
@@ -116,8 +116,8 @@ func TestAuthzPolicyLifecycleActivateShadowEnforceRollbackIntegration(t *testing
 		DefaultTenantID:    "tenant-a",
 		DefaultWorkspaceID: "workspace-a",
 		APIKeyScopes: map[string][]string{
-			"write-key": {scopeRead, scopeWrite},
-			"admin-key": {scopeRead, scopeWrite, scopeAdmin},
+			"write-key": {scopeRead, scopeWrite, "tenant:tenant-a", "workspace:workspace-a"},
+			"admin-key": {scopeRead, scopeWrite, scopeAdmin, "tenant:tenant-a", "workspace:workspace-a"},
 		},
 	})
 
@@ -207,7 +207,7 @@ func TestAuthzPolicyRollbackEndpointReturnsInternalErrorOnTargetVersionStoreFail
 		DefaultTenantID:    "tenant-a",
 		DefaultWorkspaceID: "workspace-a",
 		APIKeyScopes: map[string][]string{
-			"admin-key": {scopeRead, scopeWrite, scopeAdmin},
+			"admin-key": {scopeRead, scopeWrite, scopeAdmin, "tenant:tenant-a", "workspace:workspace-a"},
 		},
 	})
 
@@ -250,7 +250,7 @@ func TestAuthzPolicyRollbackEndpointReturnsBadRequestWhenTargetBundleInvalid(t *
 		DefaultTenantID:    "tenant-a",
 		DefaultWorkspaceID: "workspace-a",
 		APIKeyScopes: map[string][]string{
-			"admin-key": {scopeRead, scopeWrite, scopeAdmin},
+			"admin-key": {scopeRead, scopeWrite, scopeAdmin, "tenant:tenant-a", "workspace:workspace-a"},
 		},
 	})
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -39,8 +39,12 @@ const (
 	scopeRead              = "read"
 	scopeWrite             = "write"
 	scopeAdmin             = "admin"
+	apiKeyScopeTenant      = "tenant:"
+	apiKeyScopeWorkspace   = "workspace:"
 	scopeHeaderTenantID    = "X-Identrail-Tenant-ID"
 	scopeHeaderWorkspaceID = "X-Identrail-Workspace-ID"
+	authAPIKeyTenantID     = "auth.api_key_tenant_id"
+	authAPIKeyWorkspaceID  = "auth.api_key_workspace_id"
 )
 
 // RouterOptions controls API middleware behavior.
@@ -58,6 +62,12 @@ type RouterOptions struct {
 	CORSAllowedOrigins []string
 	DefaultTenantID    string
 	DefaultWorkspaceID string
+}
+
+type scopedAPIKeyAuthConfig struct {
+	Scopes      scopeSet
+	TenantID    string
+	WorkspaceID string
 }
 
 // VerifiedToken contains normalized claims extracted from a validated OIDC token.
@@ -1802,18 +1812,44 @@ func requestScopeMiddleware(defaultTenantID string, defaultWorkspaceID string) g
 	}.Normalize()
 	return func(c *gin.Context) {
 		tenantID := authContextString(c, "auth.tenant_id")
-		if tenantID == "" {
-			tenantID = strings.TrimSpace(c.GetHeader(scopeHeaderTenantID))
-		}
-		if tenantID == "" {
-			tenantID = defaultScope.TenantID
-		}
 		workspaceID := authContextString(c, "auth.workspace_id")
-		if workspaceID == "" {
-			workspaceID = strings.TrimSpace(c.GetHeader(scopeHeaderWorkspaceID))
-		}
-		if workspaceID == "" {
-			workspaceID = defaultScope.WorkspaceID
+		tenantHeader := strings.TrimSpace(c.GetHeader(scopeHeaderTenantID))
+		workspaceHeader := strings.TrimSpace(c.GetHeader(scopeHeaderWorkspaceID))
+
+		if tenantID == "" && workspaceID == "" && authContextString(c, "auth.api_key") != "" {
+			boundTenantID := authContextString(c, authAPIKeyTenantID)
+			boundWorkspaceID := authContextString(c, authAPIKeyWorkspaceID)
+			if tenantHeader != "" && (boundTenantID == "" || tenantHeader != boundTenantID) {
+				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+				return
+			}
+			if workspaceHeader != "" && (boundWorkspaceID == "" || workspaceHeader != boundWorkspaceID) {
+				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+				return
+			}
+			if boundTenantID != "" {
+				tenantID = boundTenantID
+			} else {
+				tenantID = defaultScope.TenantID
+			}
+			if boundWorkspaceID != "" {
+				workspaceID = boundWorkspaceID
+			} else {
+				workspaceID = defaultScope.WorkspaceID
+			}
+		} else {
+			if tenantID == "" {
+				tenantID = tenantHeader
+			}
+			if tenantID == "" {
+				tenantID = defaultScope.TenantID
+			}
+			if workspaceID == "" {
+				workspaceID = workspaceHeader
+			}
+			if workspaceID == "" {
+				workspaceID = defaultScope.WorkspaceID
+			}
 		}
 		scopedCtx := db.WithScope(c.Request.Context(), db.Scope{
 			TenantID:    tenantID,
@@ -1912,13 +1948,13 @@ func securityHeadersMiddleware() gin.HandlerFunc {
 func apiKeyAuthMiddleware(keys []string, scopedKeys map[string][]string, tokenVerifier TokenVerifier, oidcWriteScopes []string) gin.HandlerFunc {
 	oidcWriteScopeSet := newScopeSet(oidcWriteScopes)
 
-	scopedAllowed := map[string]scopeSet{}
+	scopedAllowed := map[string]scopedAPIKeyAuthConfig{}
 	for key, scopes := range scopedKeys {
 		trimmed := strings.TrimSpace(key)
 		if trimmed == "" {
 			continue
 		}
-		scopedAllowed[trimmed] = newScopeSet(scopes)
+		scopedAllowed[trimmed] = parseScopedAPIKeyAuthConfig(scopes)
 	}
 
 	// Scoped keys are the source of truth when configured.
@@ -1939,9 +1975,15 @@ func apiKeyAuthMiddleware(keys []string, scopedKeys map[string][]string, tokenVe
 
 	return func(c *gin.Context) {
 		if candidate := readAPIKey(c); candidate != "" {
-			if scopes, ok := scopedKeyLookup(scopedAllowed, candidate); ok {
+			if config, ok := scopedKeyLookup(scopedAllowed, candidate); ok {
 				c.Set("auth.api_key", candidate)
-				c.Set("auth.scope_set", scopes)
+				c.Set("auth.scope_set", config.Scopes)
+				if config.TenantID != "" {
+					c.Set(authAPIKeyTenantID, config.TenantID)
+				}
+				if config.WorkspaceID != "" {
+					c.Set(authAPIKeyWorkspaceID, config.WorkspaceID)
+				}
 				c.Next()
 				return
 			}
@@ -1984,13 +2026,33 @@ func keyInList(keys []string, candidate string) bool {
 	return false
 }
 
-func scopedKeyLookup(scoped map[string]scopeSet, candidate string) (scopeSet, bool) {
-	for key, scopes := range scoped {
-		if secureKeyEquals(key, candidate) {
-			return scopes, true
+func parseScopedAPIKeyAuthConfig(scopes []string) scopedAPIKeyAuthConfig {
+	config := scopedAPIKeyAuthConfig{Scopes: scopeSet{}}
+	for _, rawScope := range scopes {
+		trimmed := strings.TrimSpace(rawScope)
+		if trimmed == "" {
+			continue
+		}
+		normalized := strings.ToLower(trimmed)
+		switch {
+		case strings.HasPrefix(normalized, apiKeyScopeTenant):
+			config.TenantID = strings.TrimSpace(trimmed[len(apiKeyScopeTenant):])
+		case strings.HasPrefix(normalized, apiKeyScopeWorkspace):
+			config.WorkspaceID = strings.TrimSpace(trimmed[len(apiKeyScopeWorkspace):])
+		default:
+			config.Scopes[normalized] = struct{}{}
 		}
 	}
-	return scopeSet{}, false
+	return config
+}
+
+func scopedKeyLookup(scoped map[string]scopedAPIKeyAuthConfig, candidate string) (scopedAPIKeyAuthConfig, bool) {
+	for key, config := range scoped {
+		if secureKeyEquals(key, candidate) {
+			return config, true
+		}
+	}
+	return scopedAPIKeyAuthConfig{}, false
 }
 
 func secureKeyEquals(expected string, candidate string) bool {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -969,15 +969,15 @@ func TestSecureKeyHelpers(t *testing.T) {
 	if !keyInList([]string{"reader", "writer"}, "writer") {
 		t.Fatal("expected exact key to be found")
 	}
-	scoped := map[string]scopeSet{
-		"reader": newScopeSet([]string{"read"}),
-		"writer": newScopeSet([]string{"read", "write"}),
+	scoped := map[string]scopedAPIKeyAuthConfig{
+		"reader": {Scopes: newScopeSet([]string{"read"})},
+		"writer": {Scopes: newScopeSet([]string{"read", "write"})},
 	}
 	if _, ok := scopedKeyLookup(scoped, "missing"); ok {
 		t.Fatal("expected missing scoped key to not resolve")
 	}
-	if scopes, ok := scopedKeyLookup(scoped, "writer"); !ok || !scopes.has("write") {
-		t.Fatalf("expected writer scopes to resolve, got ok=%t scopes=%+v", ok, scopes)
+	if config, ok := scopedKeyLookup(scoped, "writer"); !ok || !config.Scopes.has("write") {
+		t.Fatalf("expected writer scopes to resolve, got ok=%t config=%+v", ok, config)
 	}
 }
 
@@ -1400,6 +1400,90 @@ func TestRequestScopeMiddlewarePrefersOIDCTenantWorkspaceClaims(t *testing.T) {
 	}
 }
 
+func TestRequestScopeMiddlewareRejectsUnboundAPIKeyHeaderOverrides(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("auth.api_key", "reader-key")
+		c.Next()
+	})
+	r.Use(requestScopeMiddleware("default-tenant", "default-workspace"))
+	r.GET("/scope", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/scope", nil)
+	req.Header.Set(scopeHeaderTenantID, "tenant-a")
+	req.Header.Set(scopeHeaderWorkspaceID, "workspace-a")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected unbound api key scope override rejected with 403, got %d", w.Code)
+	}
+}
+
+func TestRequestScopeMiddlewareUsesAPIKeyScopeBindings(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("auth.api_key", "reader-key")
+		c.Set(authAPIKeyTenantID, "tenant-a")
+		c.Set(authAPIKeyWorkspaceID, "workspace-a")
+		c.Next()
+	})
+	r.Use(requestScopeMiddleware("default-tenant", "default-workspace"))
+	r.GET("/scope", func(c *gin.Context) {
+		scope := db.ScopeFromContext(c.Request.Context())
+		c.JSON(http.StatusOK, map[string]string{
+			"tenant_id":    scope.TenantID,
+			"workspace_id": scope.WorkspaceID,
+		})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/scope", nil)
+	req.Header.Set(scopeHeaderTenantID, "tenant-a")
+	req.Header.Set(scopeHeaderWorkspaceID, "workspace-a")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected bound api key scope to pass, got %d", w.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["tenant_id"] != "tenant-a" || body["workspace_id"] != "workspace-a" {
+		t.Fatalf("expected bound scope values, got %+v", body)
+	}
+}
+
+func TestRequestScopeMiddlewareRejectsAPIKeyHeaderScopeMismatch(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("auth.api_key", "reader-key")
+		c.Set(authAPIKeyTenantID, "tenant-a")
+		c.Set(authAPIKeyWorkspaceID, "workspace-a")
+		c.Next()
+	})
+	r.Use(requestScopeMiddleware("default-tenant", "default-workspace"))
+	r.GET("/scope", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/scope", nil)
+	req.Header.Set(scopeHeaderTenantID, "tenant-b")
+	req.Header.Set(scopeHeaderWorkspaceID, "workspace-a")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected mismatched api key scope override rejected with 403, got %d", w.Code)
+	}
+}
+
 func TestRouterRateLimitExceeded(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	metrics := telemetry.NewMetrics()
@@ -1533,7 +1617,7 @@ func TestRouterWritesAuditSink(t *testing.T) {
 	sink := &recordingAuditSink{}
 	r := NewRouter(logger, metrics, nil, RouterOptions{
 		AuditSink:    sink,
-		APIKeyScopes: map[string][]string{"reader-key": {"read"}},
+		APIKeyScopes: map[string][]string{"reader-key": {"read", "tenant:tenant-a", "workspace:workspace-a"}},
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/scans/scan-1/events", nil)
@@ -1590,7 +1674,7 @@ func TestRouterWritesAuditSinkForDeniedAuthzDecision(t *testing.T) {
 	r := NewRouter(logger, metrics, nil, RouterOptions{
 		AuditSink: sink,
 		APIKeyScopes: map[string][]string{
-			"read-key": {scopeRead},
+			"read-key": {scopeRead, "tenant:tenant-a", "workspace:workspace-a"},
 		},
 	})
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -719,11 +719,11 @@ func TestLoadAppModeFromEnv(t *testing.T) {
 }
 
 func TestParseKeyScopes(t *testing.T) {
-	scopes := parseKeyScopes("key1:read;key2:read,write;invalid;:missing")
+	scopes := parseKeyScopes("key1:read;key2:read,write,tenant:tenant-a,workspace:workspace-a;invalid;:missing")
 	if len(scopes) != 2 {
 		t.Fatalf("expected 2 scoped keys, got %d", len(scopes))
 	}
-	if len(scopes["key2"]) != 2 {
-		t.Fatalf("expected key2 to have 2 scopes, got %+v", scopes["key2"])
+	if len(scopes["key2"]) != 4 {
+		t.Fatalf("expected key2 to have 4 scope entries, got %+v", scopes["key2"])
 	}
 }

--- a/internal/config/security.go
+++ b/internal/config/security.go
@@ -34,6 +34,11 @@ var allowedKeyScopes = map[string]struct{}{
 	"admin": {},
 }
 
+const (
+	apiKeyScopeTenantPrefix    = "tenant:"
+	apiKeyScopeWorkspacePrefix = "workspace:"
+)
+
 var allowedAlertSeverities = map[string]struct{}{
 	"info":     {},
 	"low":      {},
@@ -191,9 +196,39 @@ func ValidateSecurity(cfg Config) error {
 				return fmt.Errorf("scoped api key cannot be empty")
 			}
 			validScopeCount := 0
+			tenantBinding := ""
+			workspaceBinding := ""
 			for _, scope := range scopes {
 				normalizedScope := strings.ToLower(strings.TrimSpace(scope))
 				if normalizedScope == "" {
+					continue
+				}
+				if strings.HasPrefix(normalizedScope, apiKeyScopeTenantPrefix) {
+					tenantID := strings.TrimSpace(scope[len(apiKeyScopeTenantPrefix):])
+					if tenantID == "" {
+						return fmt.Errorf("invalid API key scope configured")
+					}
+					if err := validateScopeIdentifier("IDENTRAIL_API_KEY_SCOPES tenant binding", tenantID); err != nil {
+						return err
+					}
+					if tenantBinding != "" && tenantBinding != tenantID {
+						return fmt.Errorf("invalid API key scope configured")
+					}
+					tenantBinding = tenantID
+					continue
+				}
+				if strings.HasPrefix(normalizedScope, apiKeyScopeWorkspacePrefix) {
+					workspaceID := strings.TrimSpace(scope[len(apiKeyScopeWorkspacePrefix):])
+					if workspaceID == "" {
+						return fmt.Errorf("invalid API key scope configured")
+					}
+					if err := validateScopeIdentifier("IDENTRAIL_API_KEY_SCOPES workspace binding", workspaceID); err != nil {
+						return err
+					}
+					if workspaceBinding != "" && workspaceBinding != workspaceID {
+						return fmt.Errorf("invalid API key scope configured")
+					}
+					workspaceBinding = workspaceID
 					continue
 				}
 				if _, ok := allowedKeyScopes[normalizedScope]; !ok {

--- a/internal/config/security_test.go
+++ b/internal/config/security_test.go
@@ -227,6 +227,39 @@ func TestValidateSecurityRejectsInvalidScopedKeyScope(t *testing.T) {
 	}
 }
 
+func TestValidateSecurityAcceptsScopedKeyTenantWorkspaceBindings(t *testing.T) {
+	cfg := Config{
+		APIKeyScopes: map[string][]string{
+			"reader-key-12345678901234567890": {"read", "tenant:tenant-a", "workspace:workspace-a"},
+		},
+	}
+	if err := ValidateSecurity(cfg); err != nil {
+		t.Fatalf("expected scoped key bindings to validate, got %v", err)
+	}
+}
+
+func TestValidateSecurityRejectsInvalidScopedKeyTenantBinding(t *testing.T) {
+	cfg := Config{
+		APIKeyScopes: map[string][]string{
+			"reader-key-12345678901234567890": {"read", "tenant:bad tenant"},
+		},
+	}
+	if err := ValidateSecurity(cfg); err == nil {
+		t.Fatal("expected invalid tenant binding to fail validation")
+	}
+}
+
+func TestValidateSecurityRejectsConflictingScopedKeyTenantBindings(t *testing.T) {
+	cfg := Config{
+		APIKeyScopes: map[string][]string{
+			"reader-key-12345678901234567890": {"read", "tenant:tenant-a", "tenant:tenant-b"},
+		},
+	}
+	if err := ValidateSecurity(cfg); err == nil {
+		t.Fatal("expected conflicting tenant bindings to fail validation")
+	}
+}
+
 func TestValidateSecurityRejectsInvalidDefaultTenantID(t *testing.T) {
 	cfg := Config{
 		APIKeys:         []string{"reader", "writer"},


### PR DESCRIPTION
Fixes #646

## What changed
- Added scoped API key tenant/workspace binding support using `tenant:<id>` and `workspace:<id>` entries in `IDENTRAIL_API_KEY_SCOPES`.
- Enforced API key scope binding checks in request scope middleware so tenant/workspace headers are accepted only when they match the key binding.
- Updated security validation to allow and validate bound tenant/workspace metadata in scoped key configuration.
- Added regression tests for unbound header rejection, mismatch rejection, and bound scope acceptance.
- Updated security docs and OpenAPI parameter descriptions to document the bound-header requirement.

## Why
- Prevents API key callers from selecting arbitrary tenant/workspace scope via headers.
- Ensures tenant/workspace context is derived from trusted key metadata before header overrides are honored.

## Impact and risk
- API key requests that send tenant/workspace headers now require matching scoped key bindings.
- Existing scoped keys without bindings continue to work with default scope, but header overrides are blocked.

## Validation
- `go test ./internal/api ./internal/config`
- `go test ./...`

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind scoped API keys to tenant/workspace context and block arbitrary header overrides. Enforces bound scope from key metadata and returns 403 when headers do not match.

- **New Features**
  - Support `tenant:<id>` and `workspace:<id>` bindings in `IDENTRAIL_API_KEY_SCOPES`.
  - Enforce header scope for API key callers; mismatched `X-Identrail-Tenant-ID`/`X-Identrail-Workspace-ID` returns 403.
  - Use bound tenant/workspace as defaults when none are set; validate binding format and conflicts in config.
  - Updated docs and OpenAPI; added tests for accept/reject paths.

- **Migration**
  - If API key clients send `X-Identrail-Tenant-ID` or `X-Identrail-Workspace-ID`, add matching bindings to `IDENTRAIL_API_KEY_SCOPES` (e.g., `reader:read,tenant:tenant-a,workspace:workspace-a`).
  - Keys without bindings keep default scope; header overrides are ignored.

<sup>Written for commit 43efa920c5d7f7314136ec19dba91c9707eee3f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

