### PR TITLE
fix: align successful scan status with succeeded lifecycle state

### DIFF
--- a/docs/v1_scope_and_baseline.md
+++ b/docs/v1_scope_and_baseline.md
@@ -22,7 +22,7 @@ This document locks the first twenty non-negotiable V1 priorities.
 - Idempotent persistence for scans, artifacts, findings, and repo findings.
 - Single-flight locking for scan execution (`scan:<provider>`, `repo-scan:<target>`).
 - AWS collector retries transient IAM failures with bounded exponential backoff and jitter.
-- Partial-failure visibility through scan event stream and explicit failed/completed scan status transitions.
+- Partial-failure visibility through scan event stream and explicit failed/succeeded scan status transitions.
 
 ## 4) Data Contract Hardening
 

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -410,13 +410,13 @@ func (s *Service) runScanWithRecord(ctx context.Context, record db.ScanRecord) (
 	}
 	s.appendScanEvent(ctx, record.ID, db.ScanEventLevelInfo, "findings persisted", map[string]any{"findings": len(result.Findings)})
 
-	if err := s.Store.CompleteScan(ctx, record.ID, "completed", s.Now().UTC(), result.Assets, len(result.Findings), ""); err != nil {
+	if err := s.Store.CompleteScan(ctx, record.ID, "succeeded", s.Now().UTC(), result.Assets, len(result.Findings), ""); err != nil {
 		s.appendScanLifecycleEvent(ctx, record.ID, scanLifecycleFailed, map[string]any{"error": err.Error()})
 		s.appendScanEvent(ctx, record.ID, db.ScanEventLevelError, "scan failed while finalizing scan record", map[string]any{"error": err.Error()})
 		return RunScanResult{}, fmt.Errorf("complete scan record: %w", err)
 	}
 
-	record.Status = "completed"
+	record.Status = "succeeded"
 	finished := s.Now().UTC()
 	record.FinishedAt = &finished
 	record.AssetCount = result.Assets
@@ -648,7 +648,7 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 	if err := s.Store.CompleteRepoScan(
 		ctx,
 		record.ID,
-		"completed",
+		"succeeded",
 		s.Now().UTC(),
 		result.CommitsScanned,
 		result.FilesScanned,
@@ -658,7 +658,7 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 	); err != nil {
 		return RunRepoScanResult{}, fmt.Errorf("complete repo scan: %w", err)
 	}
-	record.Status = "completed"
+	record.Status = "succeeded"
 	finished := s.Now().UTC()
 	record.FinishedAt = &finished
 	record.CommitsScanned = result.CommitsScanned

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -89,7 +89,7 @@ func TestServiceRunScanSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run scan failed: %v", err)
 	}
-	if result.Scan.Status != "completed" || result.FindingCount != 1 {
+	if result.Scan.Status != "succeeded" || result.FindingCount != 1 {
 		t.Fatalf("unexpected result: %+v", result)
 	}
 }
@@ -152,7 +152,7 @@ func TestServiceRunScanUsesPersistedAWSConnector(t *testing.T) {
 	if !factoryCalled {
 		t.Fatal("expected scan to use persisted aws connector scanner factory")
 	}
-	if result.Scan.Status != "completed" || result.Assets != 1 {
+	if result.Scan.Status != "succeeded" || result.Assets != 1 {
 		t.Fatalf("unexpected result: %+v", result)
 	}
 }
@@ -266,8 +266,8 @@ func TestServiceRunScanAlertFailureIsNonBlocking(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected scan success despite alert error, got %v", err)
 	}
-	if result.Scan.Status != "completed" {
-		t.Fatalf("expected completed status, got %q", result.Scan.Status)
+	if result.Scan.Status != "succeeded" {
+		t.Fatalf("expected succeeded status, got %q", result.Scan.Status)
 	}
 	if errorCalls != 1 {
 		t.Fatalf("expected alert error callback once, got %d", errorCalls)
@@ -663,8 +663,8 @@ func TestServiceRunScanPartialLifecycleEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run scan: %v", err)
 	}
-	if result.Scan.Status != "completed" {
-		t.Fatalf("expected completed scan status, got %q", result.Scan.Status)
+	if result.Scan.Status != "succeeded" {
+		t.Fatalf("expected succeeded scan status, got %q", result.Scan.Status)
 	}
 
 	events, err := svc.ListScanEvents(defaultScopeContext(), result.Scan.ID, 50)
@@ -1003,7 +1003,7 @@ func TestServiceRunRepoScanPersistedStoresRecords(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run repo scan persisted: %v", err)
 	}
-	if run.RepoScan.ID == "" || run.RepoScan.Status != "completed" || run.RepoScan.FindingCount != 1 {
+	if run.RepoScan.ID == "" || run.RepoScan.Status != "succeeded" || run.RepoScan.FindingCount != 1 {
 		t.Fatalf("unexpected repo scan run result: %+v", run)
 	}
 
@@ -1250,7 +1250,7 @@ func TestServiceEnqueueScanAndProcessQueue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get scan: %v", err)
 	}
-	if scan.Status != "completed" || scan.FindingCount != 1 {
+	if scan.Status != "succeeded" || scan.FindingCount != 1 {
 		t.Fatalf("unexpected processed scan record: %+v", scan)
 	}
 	processed, err = svc.ProcessNextQueuedScan(defaultScopeContext())
@@ -1311,8 +1311,8 @@ func TestServiceQueuedScanBurstProcessing(t *testing.T) {
 		t.Fatalf("expected %d persisted scans, got %d", queued, len(scans))
 	}
 	for _, scan := range scans {
-		if scan.Status != "completed" {
-			t.Fatalf("expected completed scan status, got %q", scan.Status)
+		if scan.Status != "succeeded" {
+			t.Fatalf("expected succeeded scan status, got %q", scan.Status)
 		}
 	}
 }
@@ -1357,7 +1357,7 @@ func TestServiceEnqueueRepoScanAndProcessQueue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get repo scan: %v", err)
 	}
-	if stored.Status != "completed" || stored.CommitsScanned != 25 {
+	if stored.Status != "succeeded" || stored.CommitsScanned != 25 {
 		t.Fatalf("unexpected processed repo scan record: %+v", stored)
 	}
 }
@@ -1483,8 +1483,8 @@ func TestServiceProcessQueuedRepoScanContinuesToNextTargetAfterRequeue(t *testin
 	if err != nil {
 		t.Fatalf("get repo-b scan: %v", err)
 	}
-	if repoBRecord.Status != "completed" {
-		t.Fatalf("expected repo-b to complete, got %q", repoBRecord.Status)
+	if repoBRecord.Status != "succeeded" {
+		t.Fatalf("expected repo-b to succeed, got %q", repoBRecord.Status)
 	}
 }
 


### PR DESCRIPTION
Fixes #651

## Summary
- persist successful cloud and repo scans with `succeeded` status instead of `completed`
- align service-level terminal status behavior with existing lifecycle event naming
- update service test expectations and baseline wording to match the unified status vocabulary

## Impact
- removes status mismatch between persisted scan records and lifecycle states
- keeps queue, failure, and event behavior unchanged while standardizing successful terminal state

## Validation
- `go test ./internal/api -count=1`

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes successful scan status to `succeeded` across cloud and repo scans to match lifecycle events and persisted records. Updates service logic, tests, and docs; queue processing and failure behavior unchanged.

<sup>Written for commit 4b1d12c829eeb50873b84c81bce6220184391b94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

