### PR TITLE
Allow configured web API and OIDC origins in CSP

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; frame-src https://www.youtube.com https://youtube.com https://calendly.com https://assets.calendly.com; media-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
+      content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src __IDENTRAIL_CONNECT_SRC__; frame-src https://www.youtube.com https://youtube.com https://calendly.com https://assets.calendly.com; media-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
     />
     <meta
       name="description"

--- a/web/index.html
+++ b/web/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://api.github.com https://img.shields.io; frame-src https://www.youtube.com https://youtube.com https://calendly.com https://assets.calendly.com; media-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
+      content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; frame-src https://www.youtube.com https://youtube.com https://calendly.com https://assets.calendly.com; media-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
     />
     <meta
       name="description"

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -125,6 +125,10 @@
           "value": "DENY"
         },
         {
+          "key": "Content-Security-Policy",
+          "value": "frame-ancestors 'none'"
+        },
+        {
           "key": "Referrer-Policy",
           "value": "strict-origin-when-cross-origin"
         },

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -114,7 +114,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://api.github.com https://img.shields.io; frame-src https://www.youtube.com https://youtube.com https://calendly.com https://assets.calendly.com; media-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; frame-src https://www.youtube.com https://youtube.com https://calendly.com https://assets.calendly.com; media-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
         },
         {
           "key": "Strict-Transport-Security",

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -113,10 +113,6 @@
       "source": "/(.*)",
       "headers": [
         {
-          "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; frame-src https://www.youtube.com https://youtube.com https://calendly.com https://assets.calendly.com; media-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
-        },
-        {
           "key": "Strict-Transport-Security",
           "value": "max-age=63072000; includeSubDomains; preload"
         },

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,8 +1,51 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
+function originFromURL(value?: string): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    return new URL(trimmed).origin;
+  } catch {
+    return null;
+  }
+}
+
+function buildConnectSrc(): string {
+  const allowlist = new Set<string>(["'self'", 'https://api.github.com', 'https://img.shields.io']);
+  const apiOrigin = originFromURL(process.env.VITE_IDENTRAIL_API_URL);
+  const oidcOrigin = originFromURL(process.env.VITE_OIDC_ISSUER_URL);
+
+  if (apiOrigin) {
+    allowlist.add(apiOrigin);
+  }
+  if (oidcOrigin) {
+    allowlist.add(oidcOrigin);
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    allowlist.add('http://localhost:8080');
+    allowlist.add('http://127.0.0.1:8080');
+    allowlist.add('ws://localhost:5173');
+    allowlist.add('ws://127.0.0.1:5173');
+  }
+
+  return Array.from(allowlist).join(' ');
+}
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    {
+      name: 'identrail-csp-connect-src',
+      transformIndexHtml(html) {
+        return html.replace(/__IDENTRAIL_CONNECT_SRC__/g, buildConnectSrc());
+      }
+    }
+  ],
   build: {
     cssCodeSplit: true,
     chunkSizeWarningLimit: 800,

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import { loadEnv } from 'vite';
 
 function originFromURL(value?: string): string | null {
   const trimmed = value?.trim();
@@ -14,10 +15,10 @@ function originFromURL(value?: string): string | null {
   }
 }
 
-function buildConnectSrc(): string {
+function buildConnectSrc(env: Record<string, string>, isProduction: boolean): string {
   const allowlist = new Set<string>(["'self'", 'https://api.github.com', 'https://img.shields.io']);
-  const apiOrigin = originFromURL(process.env.VITE_IDENTRAIL_API_URL);
-  const oidcOrigin = originFromURL(process.env.VITE_OIDC_ISSUER_URL);
+  const apiOrigin = originFromURL(env.VITE_IDENTRAIL_API_URL);
+  const oidcOrigin = originFromURL(env.VITE_OIDC_ISSUER_URL);
 
   if (apiOrigin) {
     allowlist.add(apiOrigin);
@@ -26,7 +27,7 @@ function buildConnectSrc(): string {
     allowlist.add(oidcOrigin);
   }
 
-  if (process.env.NODE_ENV !== 'production') {
+  if (!isProduction) {
     allowlist.add('http://localhost:8080');
     allowlist.add('http://127.0.0.1:8080');
     allowlist.add('ws://localhost:5173');
@@ -36,47 +37,52 @@ function buildConnectSrc(): string {
   return Array.from(allowlist).join(' ');
 }
 
-export default defineConfig({
-  plugins: [
-    react(),
-    {
-      name: 'identrail-csp-connect-src',
-      transformIndexHtml(html) {
-        return html.replace(/__IDENTRAIL_CONNECT_SRC__/g, buildConnectSrc());
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const connectSrc = buildConnectSrc(env, mode === 'production');
+
+  return {
+    plugins: [
+      react(),
+      {
+        name: 'identrail-csp-connect-src',
+        transformIndexHtml(html) {
+          return html.replace(/__IDENTRAIL_CONNECT_SRC__/g, connectSrc);
+        }
       }
-    }
-  ],
-  build: {
-    cssCodeSplit: true,
-    chunkSizeWarningLimit: 800,
-    rollupOptions: {
-      output: {
-        manualChunks(id) {
-          if (id.includes('react') || id.includes('react-dom') || id.includes('react-router-dom')) {
-            return 'react_vendor';
+    ],
+    build: {
+      cssCodeSplit: true,
+      chunkSizeWarningLimit: 800,
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (id.includes('react') || id.includes('react-dom') || id.includes('react-router-dom')) {
+              return 'react_vendor';
+            }
+            return undefined;
           }
-          return undefined;
+        }
+      }
+    },
+    server: {
+      port: 5173,
+      host: true
+    },
+    test: {
+      environment: 'jsdom',
+      globals: true,
+      setupFiles: ['./src/test/setup.ts'],
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'lcov'],
+        thresholds: {
+          lines: 60,
+          functions: 53,
+          statements: 60,
+          branches: 50
         }
       }
     }
-  },
-  server: {
-    port: 5173,
-    host: true
-  },
-  test: {
-    environment: 'jsdom',
-    globals: true,
-    setupFiles: ['./src/test/setup.ts'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'lcov'],
-      thresholds: {
-        lines: 60,
-        functions: 53,
-        statements: 60,
-        branches: 50
-      }
-    }
-  }
+  };
 });


### PR DESCRIPTION
Fixes #717

## Summary

Allow the web frontend CSP to connect to configured HTTPS API and OIDC origins in production while preserving the existing policy shape.

## Why

The deployed frontend can be configured to call a separate API origin and an external OIDC issuer, but the previous `connect-src` directive only allowed a couple of hard-coded hosts. Browsers blocked those production requests before the app could authenticate or load data.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation

```bash
npm run test:ci --prefix web
npm run build --prefix web
```

- `npm run test:ci --prefix web` ✅
- `npm run build --prefix web` ✅

## Checklist

- [ ] Tests added/updated for behavior changes
- [ ] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: No

## Related Issues

- Fixes #717

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand the web CSP to allow configured HTTPS API and OIDC origins, plus localhost and WS for dev, and restore `frame-ancestors` enforcement so the app can authenticate and load data in production (fixes #717).

- **Bug Fixes**
  - Build `connect-src` at build time from `VITE_IDENTRAIL_API_URL` and `VITE_OIDC_ISSUER_URL` using Vite `loadEnv`, including `'self'`, `https://api.github.com`, `https://img.shields.io`, and dev `localhost`/`127.0.0.1` HTTP/WS.
  - Inject `connect-src` into `web/index.html` via a small `vite` plugin; `web/vercel.json` now only sets `Content-Security-Policy: frame-ancestors 'none'`.

<sup>Written for commit 71ccb4a01ea8552f2f7d99cad67b6908509f1eac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

