### PR TITLE
Move v1 rate limiting ahead of auth middleware

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -196,10 +196,10 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 	}
 
 	v1 := r.Group("/v1")
+	v1.Use(auditLogMiddleware(logger, opts.AuditSink, opts.AuditFingerprinter))
+	v1.Use(apiDenialMetricsMiddleware(metrics))
 	v1.Use(rateLimitMiddleware(opts.RateLimitRPM, opts.RateLimitBurst))
 	v1.Use(apiKeyAuthMiddleware(opts.APIKeys, opts.APIKeyScopes, opts.OIDCTokenVerifier, opts.OIDCWriteScopes, opts.AuditFingerprinter))
-	v1.Use(apiDenialMetricsMiddleware(metrics))
-	v1.Use(auditLogMiddleware(logger, opts.AuditSink, opts.AuditFingerprinter))
 	v1.Use(requestScopeMiddleware(opts.DefaultTenantID, opts.DefaultWorkspaceID, opts.RequireExplicitScope))
 	centralPolicyResolver := newCentralPolicyRuntimeResolver(authzStore)
 	v1.Use(requireCentralPolicyMiddleware(centralPolicyResolver, opts.WriteAPIKeys, opts.APIKeyScopes, authzStore, metrics, opts.AuditFingerprinter))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -196,10 +196,10 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 	}
 
 	v1 := r.Group("/v1")
+	v1.Use(rateLimitMiddleware(opts.RateLimitRPM, opts.RateLimitBurst))
 	v1.Use(apiKeyAuthMiddleware(opts.APIKeys, opts.APIKeyScopes, opts.OIDCTokenVerifier, opts.OIDCWriteScopes, opts.AuditFingerprinter))
 	v1.Use(apiDenialMetricsMiddleware(metrics))
 	v1.Use(auditLogMiddleware(logger, opts.AuditSink, opts.AuditFingerprinter))
-	v1.Use(rateLimitMiddleware(opts.RateLimitRPM, opts.RateLimitBurst))
 	v1.Use(requestScopeMiddleware(opts.DefaultTenantID, opts.DefaultWorkspaceID, opts.RequireExplicitScope))
 	centralPolicyResolver := newCentralPolicyRuntimeResolver(authzStore)
 	v1.Use(requireCentralPolicyMiddleware(centralPolicyResolver, opts.WriteAPIKeys, opts.APIKeyScopes, authzStore, metrics, opts.AuditFingerprinter))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2250,10 +2250,10 @@ func rateLimitKey(c *gin.Context) string {
 		return ip + "|anon"
 	}
 	if apiKey := readAPIKey(c); apiKey != "" {
-		return ip + "|api:" + audit.FingerprintAPIKey(apiKey)
+		return ip + "|api"
 	}
 	if bearer := readBearerToken(c); bearer != "" {
-		return ip + "|bearer:" + audit.FingerprintIdentifier(bearer)
+		return ip + "|bearer"
 	}
 	return ip + "|anon"
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2253,7 +2253,7 @@ func rateLimitKey(c *gin.Context) string {
 		return ip + "|api"
 	}
 	if bearer := readBearerToken(c); bearer != "" {
-		return ip + "|bearer"
+		return ip + "|bearer:" + fingerprintIdentifierWith(nil, bearer)
 	}
 	return ip + "|anon"
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2231,16 +2231,31 @@ func (l *ipRateLimiter) evictOldestLocked() {
 func rateLimitMiddleware(rpm int, burst int) gin.HandlerFunc {
 	limiter := newIPRateLimiter(rpm, burst)
 	return func(c *gin.Context) {
-		ip := c.ClientIP()
-		if ip == "" {
-			ip = "unknown"
-		}
-		if !limiter.allow(ip) {
+		if !limiter.allow(rateLimitKey(c)) {
 			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "rate limit exceeded"})
 			return
 		}
 		c.Next()
 	}
+}
+
+func rateLimitKey(c *gin.Context) string {
+	ip := "unknown"
+	if c != nil {
+		if clientIP := strings.TrimSpace(c.ClientIP()); clientIP != "" {
+			ip = clientIP
+		}
+	}
+	if c == nil {
+		return ip + "|anon"
+	}
+	if apiKey := readAPIKey(c); apiKey != "" {
+		return ip + "|api:" + audit.FingerprintAPIKey(apiKey)
+	}
+	if bearer := readBearerToken(c); bearer != "" {
+		return ip + "|bearer:" + audit.FingerprintIdentifier(bearer)
+	}
+	return ip + "|anon"
 }
 
 func auditLogMiddleware(logger *zap.Logger, sink audit.AuditSink, fingerprinter *audit.Fingerprinter) gin.HandlerFunc {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1608,6 +1608,15 @@ func TestRouterRateLimitAppliesBeforeUnauthorizedAuthChecks(t *testing.T) {
 	if w2.Code != http.StatusTooManyRequests {
 		t.Fatalf("expected second unauthorized request to return 429, got %d", w2.Code)
 	}
+
+	authorized := httptest.NewRequest(http.MethodGet, "/v1/scans", nil)
+	authorized.RemoteAddr = "127.0.0.1:23456"
+	authorized.Header.Set("X-API-Key", "expected-key")
+	w3 := httptest.NewRecorder()
+	r.ServeHTTP(w3, authorized)
+	if w3.Code != http.StatusOK {
+		t.Fatalf("expected authorized request to use a separate rate limit bucket, got %d", w3.Code)
+	}
 }
 
 func TestIPRateLimiterEvictsExpiredEntries(t *testing.T) {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1547,6 +1547,77 @@ func TestRouterRateLimitExceeded(t *testing.T) {
 	}
 }
 
+func TestRouterRateLimitAppliesToUnauthorizedRequests(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	r := NewRouter(logger, metrics, nil, RouterOptions{
+		APIKeys:        []string{"secret-key"},
+		RateLimitRPM:   1,
+		RateLimitBurst: 1,
+	})
+
+	first := httptest.NewRequest(http.MethodGet, "/v1/scans", nil)
+	first.RemoteAddr = "127.0.0.1:23456"
+	w1 := httptest.NewRecorder()
+	r.ServeHTTP(w1, first)
+	if w1.Code != http.StatusUnauthorized {
+		t.Fatalf("expected first unauthorized request 401, got %d", w1.Code)
+	}
+
+	second := httptest.NewRequest(http.MethodGet, "/v1/scans", nil)
+	second.RemoteAddr = "127.0.0.1:23456"
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, second)
+	if w2.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected second unauthorized request 429, got %d", w2.Code)
+	}
+}
+
+func TestRouterRateLimitInvalidBearerDoesNotThrottleValidOIDCToken(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	r := NewRouter(logger, metrics, nil, RouterOptions{
+		OIDCTokenVerifier: fakeTokenVerifier{
+			tokens: map[string]VerifiedToken{
+				"good-token": {
+					Subject:     "user-1",
+					TenantID:    "tenant-1",
+					WorkspaceID: "workspace-1",
+					Scopes:      []string{"read"},
+				},
+			},
+		},
+		RateLimitRPM:   1,
+		RateLimitBurst: 1,
+	})
+
+	invalid := httptest.NewRequest(http.MethodGet, "/v1/scans", nil)
+	invalid.RemoteAddr = "127.0.0.1:27501"
+	invalid.Header.Set("Authorization", "Bearer invalid-token")
+	invalidW := httptest.NewRecorder()
+	r.ServeHTTP(invalidW, invalid)
+	if invalidW.Code != http.StatusUnauthorized {
+		t.Fatalf("expected invalid bearer request to be unauthorized, got %d", invalidW.Code)
+	}
+
+	valid := httptest.NewRequest(http.MethodGet, "/v1/scans", nil)
+	valid.RemoteAddr = "127.0.0.1:27501"
+	valid.Header.Set("Authorization", "Bearer good-token")
+	validW := httptest.NewRecorder()
+	r.ServeHTTP(validW, valid)
+	if validW.Code != http.StatusOK {
+		t.Fatalf("expected valid oidc request to avoid invalid bearer bucket and pass, got %d", validW.Code)
+	}
+
+	validSecond := httptest.NewRequest(http.MethodGet, "/v1/scans", nil)
+	validSecond.RemoteAddr = "127.0.0.1:27501"
+	validSecond.Header.Set("Authorization", "Bearer good-token")
+	validSecondW := httptest.NewRecorder()
+	r.ServeHTTP(validSecondW, validSecond)
+	if validSecondW.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected second request for same valid bearer token to hit 429, got %d", validSecondW.Code)
+	}
+}
 func TestRouterRateLimitExceededIsAudited(t *testing.T) {
 	logger := zap.NewNop()
 	metrics := telemetry.NewMetrics()

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1584,6 +1584,32 @@ func TestRouterRateLimitExceededIsAudited(t *testing.T) {
 	}
 }
 
+func TestRouterRateLimitAppliesBeforeUnauthorizedAuthChecks(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	r := NewRouter(logger, metrics, nil, RouterOptions{
+		APIKeys:        []string{"expected-key"},
+		RateLimitRPM:   1,
+		RateLimitBurst: 1,
+	})
+
+	first := httptest.NewRequest(http.MethodGet, "/v1/scans", nil)
+	first.RemoteAddr = "127.0.0.1:23456"
+	w1 := httptest.NewRecorder()
+	r.ServeHTTP(w1, first)
+	if w1.Code != http.StatusUnauthorized {
+		t.Fatalf("expected first unauthorized request to return 401, got %d", w1.Code)
+	}
+
+	second := httptest.NewRequest(http.MethodGet, "/v1/scans", nil)
+	second.RemoteAddr = "127.0.0.1:23456"
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, second)
+	if w2.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected second unauthorized request to return 429, got %d", w2.Code)
+	}
+}
+
 func TestIPRateLimiterEvictsExpiredEntries(t *testing.T) {
 	now := time.Date(2026, 3, 20, 10, 0, 0, 0, time.UTC)
 	limiter := newIPRateLimiterWithClock(

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1619,6 +1619,34 @@ func TestRouterRateLimitAppliesBeforeUnauthorizedAuthChecks(t *testing.T) {
 	}
 }
 
+func TestRouterRateLimitDoesNotTrustPresentedCredentialValue(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	r := NewRouter(logger, metrics, nil, RouterOptions{
+		APIKeys:        []string{"expected-key"},
+		RateLimitRPM:   1,
+		RateLimitBurst: 1,
+	})
+
+	first := httptest.NewRequest(http.MethodGet, "/v1/scans", nil)
+	first.RemoteAddr = "127.0.0.1:34567"
+	first.Header.Set("X-API-Key", "bogus-one")
+	w1 := httptest.NewRecorder()
+	r.ServeHTTP(w1, first)
+	if w1.Code != http.StatusUnauthorized {
+		t.Fatalf("expected first invalid API key request to return 401, got %d", w1.Code)
+	}
+
+	second := httptest.NewRequest(http.MethodGet, "/v1/scans", nil)
+	second.RemoteAddr = "127.0.0.1:34567"
+	second.Header.Set("X-API-Key", "bogus-two")
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, second)
+	if w2.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected second invalid API key request to return 429 despite a rotated key, got %d", w2.Code)
+	}
+}
+
 func TestIPRateLimiterEvictsExpiredEntries(t *testing.T) {
 	now := time.Date(2026, 3, 20, 10, 0, 0, 0, time.UTC)
 	limiter := newIPRateLimiterWithClock(


### PR DESCRIPTION
Fixes #666

## What changed
- Reordered `/v1` middleware so `rateLimitMiddleware` runs before auth, request scope, audit, and central policy middleware.
- Added regression coverage showing repeated unauthenticated requests are rate limited (`401` then `429`) from the same client IP.

## Why it changed
Rate limiting previously ran after authentication and authorization middleware, which let abusive unauthenticated traffic consume auth/policy work before any limit was enforced.

## Impact and risk
- Auth and policy paths are now protected earlier from request floods.
- Existing authorized behavior remains unchanged.
- Low risk with targeted middleware-order regression tests.

## Validation
- `go test ./internal/api -run 'TestRouterRateLimitExceeded|TestRouterRateLimitAppliesBeforeUnauthorizedAuthChecks' -count=1`
- `go test ./internal/api -count=1`

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply rate limiting to `/v1` before auth and central policy to block abusive unauthenticated traffic earlier. 429s from the limiter are now audited and counted, and buckets are keyed by IP and credential type with bearer tokens isolated by fingerprint.

- **Bug Fixes**
  - Run limiter on `/v1` before auth, request scope, and central policy; audit and denial-metrics run first so rejections are observable.
  - Add `rateLimitKey`: trimmed IP (defaults to "unknown") and buckets `|anon`, `|api`, `|bearer:<fp>`; do not trust presented credential values for invalid keys.
  - Tests cover 401→429 for repeated unauthenticated/invalid creds, separate buckets for valid API key or OIDC vs anonymous/invalid bearer, and that 429s are audited.

<sup>Written for commit 411d4df9ef10fee50db92751c1b73e6260fe6e8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

