### PR TITLE
Fixes #670: document OpenAPI route authorization metadata

### DIFF
--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -19,6 +19,254 @@ tags:
 security:
   - ApiKeyAuth: []
   - BearerAuth: []
+x-identrail-route-authorizations:
+  - method: GET
+    path: /v1/findings
+    action: findings.read
+    resource_type: finding
+  - method: GET
+    path: /v1/findings/{finding_id}
+    action: findings.read
+    resource_type: finding
+    resource_id_param: finding_id
+  - method: GET
+    path: /v1/findings/{finding_id}/history
+    action: findings.read
+    resource_type: finding_history
+    resource_id_param: finding_id
+  - method: GET
+    path: /v1/findings/{finding_id}/exports
+    action: findings.read
+    resource_type: finding_export
+    resource_id_param: finding_id
+  - method: GET
+    path: /v1/findings/trends
+    action: findings.read
+    resource_type: finding_trend
+  - method: GET
+    path: /v1/findings/summary
+    action: findings.read
+    resource_type: finding_summary
+  - method: PATCH
+    path: /v1/findings/{finding_id}/triage
+    action: findings.triage
+    resource_type: finding
+    resource_id_param: finding_id
+  - method: GET
+    path: /v1/identities
+    action: graph.read
+    resource_type: identity
+  - method: GET
+    path: /v1/relationships
+    action: graph.read
+    resource_type: relationship
+  - method: GET
+    path: /v1/ownership/signals
+    action: graph.read
+    resource_type: ownership_signal
+  - method: GET
+    path: /v1/scans
+    action: scans.read
+    resource_type: scan
+  - method: GET
+    path: /v1/scans/{scan_id}/diff
+    action: scans.read
+    resource_type: scan_diff
+    resource_id_param: scan_id
+  - method: GET
+    path: /v1/scans/{scan_id}/events
+    action: scans.read
+    resource_type: scan_event
+    resource_id_param: scan_id
+  - method: POST
+    path: /v1/scans
+    action: scans.run
+    resource_type: scan
+  - method: GET
+    path: /v1/repo-scans
+    action: repo_scans.read
+    resource_type: repo_scan
+  - method: GET
+    path: /v1/repo-scans/{repo_scan_id}
+    action: repo_scans.read
+    resource_type: repo_scan
+    resource_id_param: repo_scan_id
+  - method: GET
+    path: /v1/repo-findings
+    action: repo_scans.read
+    resource_type: repo_finding
+  - method: POST
+    path: /v1/repo-scans
+    action: repo_scans.run
+    resource_type: repo_scan
+  - method: POST
+    path: /v1/authz/policies/simulate
+    action: authz.policies.simulate
+    resource_type: authz_policy
+  - method: POST
+    path: /v1/authz/policies/rollback
+    action: authz.policies.rollback
+    resource_type: authz_policy
+  - method: GET
+    path: /v1/whoami
+    action: tenancy.read
+    resource_type: workspace_context
+  - method: GET
+    path: /v1/organizations/current
+    action: tenancy.read
+    resource_type: organization
+  - method: PUT
+    path: /v1/organizations/current
+    action: tenancy.write
+    resource_type: organization
+  - method: GET
+    path: /v1/workspaces
+    action: tenancy.read
+    resource_type: workspace
+  - method: POST
+    path: /v1/workspaces
+    action: tenancy.write
+    resource_type: workspace
+  - method: POST
+    path: /v1/workspaces/active
+    action: tenancy.read
+    resource_type: workspace_context
+  - method: GET
+    path: /v1/workspaces/{workspace_id}
+    action: tenancy.read
+    resource_type: workspace
+    resource_id_param: workspace_id
+  - method: DELETE
+    path: /v1/workspaces/{workspace_id}
+    action: tenancy.write
+    resource_type: workspace
+    resource_id_param: workspace_id
+  - method: GET
+    path: /v1/workspaces/{workspace_id}/members
+    action: tenancy.read
+    resource_type: workspace_member
+    resource_id_param: workspace_id
+  - method: POST
+    path: /v1/workspaces/{workspace_id}/members
+    action: tenancy.write
+    resource_type: workspace_member
+    resource_id_param: workspace_id
+  - method: GET
+    path: /v1/workspaces/{workspace_id}/members/{member_id}
+    action: tenancy.read
+    resource_type: workspace_member
+    resource_id_param: member_id
+  - method: DELETE
+    path: /v1/workspaces/{workspace_id}/members/{member_id}
+    action: tenancy.write
+    resource_type: workspace_member
+    resource_id_param: member_id
+  - method: GET
+    path: /v1/workspaces/{workspace_id}/projects
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: workspace_id
+  - method: POST
+    path: /v1/workspaces/{workspace_id}/projects
+    action: tenancy.write
+    resource_type: project
+    resource_id_param: workspace_id
+  - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: DELETE
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}
+    action: tenancy.write
+    resource_type: project
+    resource_id_param: project_id
+  - method: POST
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/kubernetes/connection
+    action: tenancy.write
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/kubernetes/connection
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: POST
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/connection
+    action: tenancy.write
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/aws/connection
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: POST
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/github/connect/start
+    action: tenancy.write
+    resource_type: project
+    resource_id_param: project_id
+  - method: POST
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/github/connect/complete
+    action: tenancy.write
+    resource_type: project
+    resource_id_param: project_id
+  - method: GET
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/github/connection
+    action: tenancy.read
+    resource_type: project
+    resource_id_param: project_id
+  - method: PUT
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/github/repositories
+    action: tenancy.write
+    resource_type: project
+    resource_id_param: project_id
+  - method: POST
+    path: /v1/workspaces/{workspace_id}/projects/{project_id}/github/secret/rotate
+    action: tenancy.write
+    resource_type: project
+    resource_id_param: project_id
+x-identrail-action-role-grants:
+  authz.policies.rollback:
+    - admin
+  authz.policies.simulate:
+    - admin
+  findings.read:
+    - read
+    - write
+    - admin
+  findings.triage:
+    - write
+    - admin
+  graph.read:
+    - read
+    - write
+    - admin
+  repo_scans.read:
+    - read
+    - write
+    - admin
+  repo_scans.run:
+    - write
+    - admin
+  scans.read:
+    - read
+    - write
+    - admin
+  scans.run:
+    - write
+    - admin
+  tenancy.read:
+    - read
+    - write
+    - admin
+    - owner
+    - analyst
+    - viewer
+  tenancy.write:
+    - write
+    - admin
+    - owner
 paths:
   /healthz:
     get:

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -138,6 +139,45 @@ func TestOpenAPIV1SpecContainsTenancyProjectContracts(t *testing.T) {
 	}
 }
 
+func TestOpenAPIV1SpecDocumentsRouteAuthorizationMetadata(t *testing.T) {
+	spec := readOpenAPISpec(t)
+	for _, route := range defaultBuiltInRoutePolicyDefinitions() {
+		path := pathVarPattern.ReplaceAllString(route.Path, `{$1}`)
+		lines := []string{
+			fmt.Sprintf("  - method: %s", route.Method),
+			fmt.Sprintf("    path: %s", path),
+			fmt.Sprintf("    action: %s", route.Action),
+			fmt.Sprintf("    resource_type: %s", route.ResourceType),
+		}
+		if route.ResourceIDParam != "" {
+			lines = append(lines, fmt.Sprintf("    resource_id_param: %s", route.ResourceIDParam))
+		}
+		if !strings.Contains(spec, strings.Join(lines, "\n")) {
+			t.Fatalf("openapi authz metadata missing route authorization entry for %s %s", route.Method, path)
+		}
+	}
+}
+
+func TestOpenAPIV1SpecDocumentsActionRoleGrants(t *testing.T) {
+	spec := readOpenAPISpec(t)
+	grants := defaultRouteActionRoleGrants()
+	actions := make([]string, 0, len(grants))
+	for action := range grants {
+		actions = append(actions, action)
+	}
+	sort.Strings(actions)
+
+	for _, action := range actions {
+		lines := []string{fmt.Sprintf("  %s:", action)}
+		for _, role := range uniqueStrings(grants[action]) {
+			lines = append(lines, fmt.Sprintf("    - %s", role))
+		}
+		if !strings.Contains(spec, strings.Join(lines, "\n")) {
+			t.Fatalf("openapi authz metadata missing role grants for action %q", action)
+		}
+	}
+}
+
 func readOpenAPISpec(t *testing.T) string {
 	t.Helper()
 	return readRepositoryFile(t, filepath.Join("docs", "openapi-v1.yaml"))
@@ -214,4 +254,17 @@ func pathBlock(t *testing.T, spec string, path string) string {
 	}
 
 	return spec[start:end]
+}
+
+func uniqueStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
 }


### PR DESCRIPTION
Fixes #670

## What changed
- added a root-level OpenAPI authorization catalog for every protected v1 route
- documented action-to-role grants alongside the route metadata
- added contract tests that compare the OpenAPI authorization catalog with the backend route policy bundle

## Why it changed
- the backend already enforces route-specific authorization actions, but the OpenAPI contract did not expose that mapping for reviewers or client tooling

## Impact and risk
- low runtime risk because this change is documentation and contract-test only
- improves API reviewability and reduces authz drift between code and the published contract

## Validation
- `go test ./internal/api -run 'TestOpenAPIV1SpecDocuments(RouteAuthorizationMetadata|ActionRoleGrants|CoversRegisteredV1Routes|DeclaresAuthSecurity|DocumentsRequestScopeHeaders|ContainsPagingFilterSortParameters|ContainsTenancyProjectContracts)'`

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents OpenAPI v1 route authorization metadata and action-to-role grants, and adds contract tests to keep the spec in sync with backend policies. Fixes #670.

- **New Features**
  - Added `x-identrail-route-authorizations` for all protected v1 routes.
  - Added `x-identrail-action-role-grants` mapping of actions to roles.
  - Added contract tests that assert every registered route and action-role grant is documented.

<sup>Written for commit 7158e7cacd4776778f6f52f46f84247a3eb25c45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

