### PR TITLE
Expire tokenless OIDC sessions after reload

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -476,6 +476,24 @@ describe('App', () => {
     expect(await screen.findByText(/Your session expired/i)).toBeInTheDocument();
   });
 
+  it('redirects persisted oidc sessions without tokens back to login after reload', async () => {
+    window.sessionStorage.setItem(
+      'identrail-product-session',
+      JSON.stringify({
+        tenantID: 'tenant-a',
+        workspaceID: 'workspace-a',
+        authMode: 'oidc',
+        expiresAt: Date.now() + 60_000
+      })
+    );
+
+    window.history.pushState({}, '', '/app/tenant-a/workspace-a');
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { level: 1, name: /Sign in to the Identrail app shell/i })).toBeInTheDocument();
+    expect(await screen.findByText(/Your session expired/i)).toBeInTheDocument();
+  });
+
   it('completes oidc callback and restores authenticated workspace shell', async () => {
     vi.stubEnv('VITE_OIDC_ISSUER_URL', 'https://sso.example.com/realms/identrail');
     vi.stubEnv('VITE_OIDC_CLIENT_ID', 'identrail-web');

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -579,6 +579,10 @@ async function ensureActiveSession(session: ProductSession): Promise<ProductSess
     return session;
   }
 
+  if (!session.accessToken) {
+    return session.refreshToken ? refreshOIDCSession(session) : null;
+  }
+
   if (!isSessionExpired(session) && !needsSessionRefresh(session)) {
     return session;
   }


### PR DESCRIPTION
Fixes #722

## Summary

Treat persisted OIDC sessions without an in-memory bearer token as expired and send the browser back through sign-in.

## Why

The app intentionally avoids persisting OIDC tokens in browser storage, but the route guard previously trusted the remaining session metadata after a hard reload. That left users inside the app shell even though API requests no longer had an `Authorization` header.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation

```bash
npm run test:ci --prefix web
npm run build --prefix web
```

- `npm run test:ci --prefix web` ✅
- `npm run build --prefix web` ✅

## Checklist

- [x] Tests added/updated for behavior changes
- [ ] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: No

## Related Issues

- Fixes #722

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expire tokenless OIDC sessions after a hard reload so users are sent to sign-in instead of staying in the app shell (fixes #722). If a `refreshToken` exists we try to refresh; otherwise we show “Your session expired.”

- **Bug Fixes**
  - In `ensureActiveSession`, treat missing `accessToken` as expired; call `refreshOIDCSession` when a `refreshToken` is present, else return `null` to trigger redirect.
  - Added test for redirect to login and expired message for persisted OIDC sessions without tokens after reload.

<sup>Written for commit 981dada3115c4a8881dd5613eeed8f79f9677954. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

