### PR TITLE
Harden Docker build context ignores

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,39 @@
+# Git metadata
 .git
 .github
+
+# Environment / secrets
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+*.crt
+secrets
+secrets/**
+
+# Vercel local project state
+.vercel
+web/.vercel
+site/.vercel
+
+# Terraform local state and providers
+*.tfstate
+*.tfstate.*
+.terraform
+.terraform/**
+.terraform.lock.hcl
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Dependency and build outputs
 web/node_modules
 web/dist
 coverage.out
+coverage
 *.log
 tmp
 .DS_Store


### PR DESCRIPTION
Fixes #689

## Summary
- Mirrors local secret, env, Vercel, and Terraform state exclusions into `.dockerignore`.
- Keeps Docker build contexts from receiving ignored local credentials or state.

## Impact and risk
- Keeps the change scoped to the deployment hardening item tracked in #689.
- Uses conservative defaults or documentation-only guidance where runtime behavior is environment-specific.

## Validation performed
- git diff --check

## Review readiness
- [x] Scope is focused and free of unrelated changes
- [x] Docs updated when operator-facing behavior changed
- [x] No secrets or credentials are present

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand `.dockerignore` to exclude Git metadata, env files (with `!.env.example`), key/cert files, `secrets/`, Vercel/Terraform local state, dependency/build outputs, coverage, logs, and temp files. Prevents credentials and local state from entering Docker build contexts and reduces context size (fixes #689).

<sup>Written for commit 2b3de7a010f9f620c73c427984467893db9c8840. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

