### PR TITLE
Fixes #746: fix stale detection engine link

### DIFF
--- a/web/src/siteConfig.ts
+++ b/web/src/siteConfig.ts
@@ -23,7 +23,7 @@ export const siteLinks = {
   platformOverview: '/product',
   howWeDoIt: '/product',
   impactQueries: 'https://github.com/identrail/identrail',
-  detectionEngine: 'https://github.com/identrail/identrail/tree/dev/internal/detection',
+  detectionEngine: 'https://github.com/identrail/identrail/tree/dev/internal/providers',
   interactiveDemo: '/demo',
   agentRelease: 'https://github.com/identrail/identrail',
   technicalDocs: '/docs',


### PR DESCRIPTION
Fixes #746

## What changed
- Updated `siteLinks.detectionEngine` in `web/src/siteConfig.ts` to point to `internal/providers`, which exists in the repository.

## Why
- The previous link targeted `internal/detection`, which is not present.

## Impact
- Users clicking the detection-engine source link are now directed to a valid source path.

## Validation
- Verified target path exists: `internal/providers`

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #746 by updating the detection engine source link. `siteLinks.detectionEngine` in `web/src/siteConfig.ts` now points to `internal/providers` so users reach a valid path.

<sup>Written for commit 3b1dc1c3f9099cdb4f93ad1394ee003127958395. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

