### PR TITLE
Document production-safe Docker Compose profile

### DIFF
--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -29,6 +29,11 @@ Manual setup:
 
 The default Compose file is a local quickstart profile. Do not reuse its `sslmode=disable` database URLs or localhost web API URL for production. For single-host production-like deployments, adapt `docker-compose.prod.example.yml` with a TLS-enabled Postgres URL, a public HTTPS API URL, and a reverse proxy that owns external ports and TLS.
 
+Apply database migrations before starting API and worker services:
+
+- `docker compose -f deploy/docker/docker-compose.yml -f deploy/docker/docker-compose.prod.example.yml run --rm migrations`
+- `docker compose -f deploy/docker/docker-compose.yml -f deploy/docker/docker-compose.prod.example.yml up -d api worker web`
+
 
 - API health: `curl http://localhost:8080/healthz`
 - Web UI: `http://localhost:8081`

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -25,7 +25,7 @@ Manual setup:
 3. `docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env up -d --build`
 
 ## Verify
-## Production notes
+### Production notes
 
 The default Compose file is a local quickstart profile. Do not reuse its `sslmode=disable` database URLs or localhost web API URL for production. For single-host production-like deployments, adapt `docker-compose.prod.example.yml` with a TLS-enabled Postgres URL, a public HTTPS API URL, and a reverse proxy that owns external ports and TLS.
 

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -25,6 +25,10 @@ Manual setup:
 3. `docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env up -d --build`
 
 ## Verify
+## Production notes
+
+The default Compose file is a local quickstart profile. Do not reuse its `sslmode=disable` database URLs or localhost web API URL for production. For single-host production-like deployments, adapt `docker-compose.prod.example.yml` with a TLS-enabled Postgres URL, a public HTTPS API URL, and a reverse proxy that owns external ports and TLS.
+
 
 - API health: `curl http://localhost:8080/healthz`
 - Web UI: `http://localhost:8081`

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -31,8 +31,8 @@ The default Compose file is a local quickstart profile. Do not reuse its `sslmod
 
 Apply database migrations before starting API and worker services:
 
-- `docker compose -f deploy/docker/docker-compose.yml -f deploy/docker/docker-compose.prod.example.yml run --rm migrations`
-- `docker compose -f deploy/docker/docker-compose.yml -f deploy/docker/docker-compose.prod.example.yml up -d api worker web`
+- `docker compose --env-file deploy/docker/.env -f deploy/docker/docker-compose.yml -f deploy/docker/docker-compose.prod.example.yml run --rm migrations`
+- `docker compose --env-file deploy/docker/.env -f deploy/docker/docker-compose.yml -f deploy/docker/docker-compose.prod.example.yml up -d api worker web`
 
 
 - API health: `curl http://localhost:8080/healthz`

--- a/deploy/docker/docker-compose.prod.example.yml
+++ b/deploy/docker/docker-compose.prod.example.yml
@@ -1,0 +1,23 @@
+# Production-oriented override for deploy/docker/docker-compose.yml.
+# Copy or adapt this file instead of using the local quickstart defaults directly.
+services:
+  postgres:
+    ports: []
+
+  api:
+    environment:
+      IDENTRAIL_DATABASE_URL: "${IDENTRAIL_DATABASE_URL:?set a TLS-enabled production Postgres URL}"
+      IDENTRAIL_RUN_MIGRATIONS: "false"
+      IDENTRAIL_CORS_ALLOWED_ORIGINS: "${IDENTRAIL_CORS_ALLOWED_ORIGINS:?set the public web origin}"
+    ports: []
+
+  worker:
+    environment:
+      IDENTRAIL_DATABASE_URL: "${IDENTRAIL_DATABASE_URL:?set a TLS-enabled production Postgres URL}"
+      IDENTRAIL_RUN_MIGRATIONS: "false"
+
+  web:
+    build:
+      args:
+        VITE_IDENTRAIL_API_URL: "${VITE_IDENTRAIL_API_URL:?set the public HTTPS API URL}"
+    ports: []

--- a/deploy/docker/docker-compose.prod.example.yml
+++ b/deploy/docker/docker-compose.prod.example.yml
@@ -3,18 +3,22 @@
 services:
   postgres:
     ports: !reset []
+    profiles:
+      - local
 
   api:
     environment:
       IDENTRAIL_DATABASE_URL: "${IDENTRAIL_DATABASE_URL:?set a TLS-enabled production Postgres URL}"
       IDENTRAIL_RUN_MIGRATIONS: "false"
       IDENTRAIL_CORS_ALLOWED_ORIGINS: "${IDENTRAIL_CORS_ALLOWED_ORIGINS:?set the public web origin}"
+    depends_on: !reset []
     ports: !reset []
 
   worker:
     environment:
       IDENTRAIL_DATABASE_URL: "${IDENTRAIL_DATABASE_URL:?set a TLS-enabled production Postgres URL}"
       IDENTRAIL_RUN_MIGRATIONS: "false"
+    depends_on: !reset []
 
   web:
     build:

--- a/deploy/docker/docker-compose.prod.example.yml
+++ b/deploy/docker/docker-compose.prod.example.yml
@@ -37,8 +37,7 @@ services:
       - .env
     environment:
       IDENTRAIL_DATABASE_URL: "${IDENTRAIL_DATABASE_URL:?set a TLS-enabled production Postgres URL}"
-      IDENTRAIL_REQUIRE_LIVE_SOURCES: "true"
-      IDENTRAIL_AWS_SOURCE: "sdk"
+      IDENTRAIL_REQUIRE_LIVE_SOURCES: "false"
       IDENTRAIL_RUN_MIGRATIONS: "true"
       IDENTRAIL_RUN_MIGRATIONS_ONLY: "true"
       IDENTRAIL_MIGRATIONS_DIR: "/app/migrations"

--- a/deploy/docker/docker-compose.prod.example.yml
+++ b/deploy/docker/docker-compose.prod.example.yml
@@ -20,4 +20,5 @@ services:
     build:
       args:
         VITE_IDENTRAIL_API_URL: "${VITE_IDENTRAIL_API_URL:?set the public HTTPS API URL}"
+        NGINX_CONF: "default.conf"
     ports: !reset []

--- a/deploy/docker/docker-compose.prod.example.yml
+++ b/deploy/docker/docker-compose.prod.example.yml
@@ -9,7 +9,10 @@ services:
   api:
     environment:
       IDENTRAIL_DATABASE_URL: "${IDENTRAIL_DATABASE_URL:?set a TLS-enabled production Postgres URL}"
-      IDENTRAIL_RUN_MIGRATIONS: "false"
+      IDENTRAIL_REQUIRE_LIVE_SOURCES: "true"
+      IDENTRAIL_AWS_SOURCE: "sdk"
+      IDENTRAIL_K8S_SOURCE: "kubectl"
+      IDENTRAIL_RUN_MIGRATIONS: "true"
       IDENTRAIL_CORS_ALLOWED_ORIGINS: "${IDENTRAIL_CORS_ALLOWED_ORIGINS:?set the public web origin}"
     depends_on: !reset []
     ports: !reset []
@@ -17,6 +20,9 @@ services:
   worker:
     environment:
       IDENTRAIL_DATABASE_URL: "${IDENTRAIL_DATABASE_URL:?set a TLS-enabled production Postgres URL}"
+      IDENTRAIL_REQUIRE_LIVE_SOURCES: "true"
+      IDENTRAIL_AWS_SOURCE: "sdk"
+      IDENTRAIL_K8S_SOURCE: "kubectl"
       IDENTRAIL_RUN_MIGRATIONS: "false"
     depends_on: !reset []
 

--- a/deploy/docker/docker-compose.prod.example.yml
+++ b/deploy/docker/docker-compose.prod.example.yml
@@ -11,8 +11,7 @@ services:
       IDENTRAIL_DATABASE_URL: "${IDENTRAIL_DATABASE_URL:?set a TLS-enabled production Postgres URL}"
       IDENTRAIL_REQUIRE_LIVE_SOURCES: "true"
       IDENTRAIL_AWS_SOURCE: "sdk"
-      IDENTRAIL_K8S_SOURCE: "kubectl"
-      IDENTRAIL_RUN_MIGRATIONS: "true"
+      IDENTRAIL_RUN_MIGRATIONS: "false"
       IDENTRAIL_CORS_ALLOWED_ORIGINS: "${IDENTRAIL_CORS_ALLOWED_ORIGINS:?set the public web origin}"
     depends_on: !reset []
     ports: !reset []
@@ -22,9 +21,27 @@ services:
       IDENTRAIL_DATABASE_URL: "${IDENTRAIL_DATABASE_URL:?set a TLS-enabled production Postgres URL}"
       IDENTRAIL_REQUIRE_LIVE_SOURCES: "true"
       IDENTRAIL_AWS_SOURCE: "sdk"
-      IDENTRAIL_K8S_SOURCE: "kubectl"
       IDENTRAIL_RUN_MIGRATIONS: "false"
     depends_on: !reset []
+
+  migrations:
+    build:
+      context: ../..
+      dockerfile: deploy/docker/Dockerfile.backend
+      args:
+        TARGET: server
+    image: identrail/api:local
+    container_name: identrail-migrations
+    restart: "no"
+    env_file:
+      - .env
+    environment:
+      IDENTRAIL_DATABASE_URL: "${IDENTRAIL_DATABASE_URL:?set a TLS-enabled production Postgres URL}"
+      IDENTRAIL_REQUIRE_LIVE_SOURCES: "true"
+      IDENTRAIL_AWS_SOURCE: "sdk"
+      IDENTRAIL_RUN_MIGRATIONS: "true"
+      IDENTRAIL_RUN_MIGRATIONS_ONLY: "true"
+      IDENTRAIL_MIGRATIONS_DIR: "/app/migrations"
 
   web:
     build:

--- a/deploy/docker/docker-compose.prod.example.yml
+++ b/deploy/docker/docker-compose.prod.example.yml
@@ -2,14 +2,14 @@
 # Copy or adapt this file instead of using the local quickstart defaults directly.
 services:
   postgres:
-    ports: []
+    ports: !reset []
 
   api:
     environment:
       IDENTRAIL_DATABASE_URL: "${IDENTRAIL_DATABASE_URL:?set a TLS-enabled production Postgres URL}"
       IDENTRAIL_RUN_MIGRATIONS: "false"
       IDENTRAIL_CORS_ALLOWED_ORIGINS: "${IDENTRAIL_CORS_ALLOWED_ORIGINS:?set the public web origin}"
-    ports: []
+    ports: !reset []
 
   worker:
     environment:
@@ -20,4 +20,4 @@ services:
     build:
       args:
         VITE_IDENTRAIL_API_URL: "${VITE_IDENTRAIL_API_URL:?set the public HTTPS API URL}"
-    ports: []
+    ports: !reset []

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       POSTGRES_DB: identrail
       POSTGRES_USER: identrail
-      POSTGRES_PASSWORD: "${IDENTRAIL_POSTGRES_PASSWORD:?set IDENTRAIL_POSTGRES_PASSWORD in deploy/docker/.env}"
+      POSTGRES_PASSWORD: "${IDENTRAIL_POSTGRES_PASSWORD}"
     ports:
       - "127.0.0.1:5432:5432"
     volumes:
@@ -33,7 +33,7 @@ services:
       - .env
     environment:
       IDENTRAIL_HTTP_ADDR: ":8080"
-      IDENTRAIL_DATABASE_URL: "postgres://identrail:${IDENTRAIL_POSTGRES_PASSWORD:?set IDENTRAIL_POSTGRES_PASSWORD in deploy/docker/.env}@postgres:5432/identrail?sslmode=disable"
+      IDENTRAIL_DATABASE_URL: "postgres://identrail:${IDENTRAIL_POSTGRES_PASSWORD}@postgres:5432/identrail?sslmode=disable"
       IDENTRAIL_RUN_MIGRATIONS: "true"
       IDENTRAIL_MIGRATIONS_DIR: "/app/migrations"
     ports:
@@ -56,7 +56,7 @@ services:
     env_file:
       - .env
     environment:
-      IDENTRAIL_DATABASE_URL: "postgres://identrail:${IDENTRAIL_POSTGRES_PASSWORD:?set IDENTRAIL_POSTGRES_PASSWORD in deploy/docker/.env}@postgres:5432/identrail?sslmode=disable"
+      IDENTRAIL_DATABASE_URL: "postgres://identrail:${IDENTRAIL_POSTGRES_PASSWORD}@postgres:5432/identrail?sslmode=disable"
       IDENTRAIL_RUN_MIGRATIONS: "false"
       IDENTRAIL_MIGRATIONS_DIR: "/app/migrations"
 

--- a/docs/deployment-anywhere.md
+++ b/docs/deployment-anywhere.md
@@ -12,6 +12,8 @@ This guide standardizes deployment for five common targets:
 
 Use this for quick production-like environments on one host.
 
+The checked-in Compose file is optimized for local bootstrap. For production-like single-host use, adapt `deploy/docker/docker-compose.prod.example.yml` and set a TLS-enabled `IDENTRAIL_DATABASE_URL`, `VITE_IDENTRAIL_API_URL`, and `IDENTRAIL_CORS_ALLOWED_ORIGINS`.
+
 Fastest local bootstrap:
 - `make quickstart`
 


### PR DESCRIPTION
Fixes #691

## Summary
- Adds a production-oriented Compose override example.
- Documents that quickstart localhost and `sslmode=disable` defaults are local-only.

## Impact and risk
- Keeps the change scoped to the deployment hardening item tracked in #691.
- Uses conservative defaults or documentation-only guidance where runtime behavior is environment-specific.

## Validation performed
- git diff --check

## Review readiness
- [x] Scope is focused and free of unrelated changes
- [x] Docs updated when operator-facing behavior changed
- [x] No secrets or credentials are present

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a production-safe Docker Compose override and clarifies the default is for local-only use, per #691. Enables single-host deployments with external TLS Postgres, strict Nginx for `web`, and a reverse proxy that owns public ports/TLS.

- **New Features**
  - Added `deploy/docker/docker-compose.prod.example.yml` for single-host production-like use: disables local `postgres` and port binds, clears `depends_on`, requires TLS `IDENTRAIL_DATABASE_URL`, `IDENTRAIL_CORS_ALLOWED_ORIGINS`, and `VITE_IDENTRAIL_API_URL`, uses strict Nginx, and adds a one-shot `migrations` service; updated deployment docs and README with production notes and `--env-file` commands.

- **Bug Fixes**
  - Fixed external DB URL interpolation; corrected migrations guidance and removed a stale `IDENTRAIL_K8S_SOURCE` ref; made `IDENTRAIL_POSTGRES_PASSWORD` optional in local Compose; disabled live-source validation for the `migrations` job.

<sup>Written for commit e63ed08e3789a4fa40b42416844b646be11bb331. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

