### PR TITLE
fix: extract reusable paginated API response helper

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -278,12 +278,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			return
 		}
 		sortFindings(items, sortBy, sortDesc)
-		page, next := pageWithCursor(items, offset, limit)
-		response := gin.H{"items": page}
-		if next != "" {
-			response["next_cursor"] = next
-		}
-		c.JSON(http.StatusOK, response)
+		c.JSON(http.StatusOK, paginatedItemsResponse(items, offset, limit))
 	})
 
 	v1.GET("/findings/summary", func(c *gin.Context) {
@@ -420,12 +415,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			return
 		}
 		sortIdentities(items, sortBy, sortDesc)
-		page, next := pageWithCursor(items, offset, limit)
-		response := gin.H{"items": page}
-		if next != "" {
-			response["next_cursor"] = next
-		}
-		c.JSON(http.StatusOK, response)
+		c.JSON(http.StatusOK, paginatedItemsResponse(items, offset, limit))
 	})
 
 	v1.GET("/relationships", func(c *gin.Context) {
@@ -450,12 +440,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			return
 		}
 		sortRelationships(items, sortBy, sortDesc)
-		page, next := pageWithCursor(items, offset, limit)
-		response := gin.H{"items": page}
-		if next != "" {
-			response["next_cursor"] = next
-		}
-		c.JSON(http.StatusOK, response)
+		c.JSON(http.StatusOK, paginatedItemsResponse(items, offset, limit))
 	})
 
 	v1.GET("/ownership/signals", func(c *gin.Context) {
@@ -477,12 +462,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			return
 		}
 		sortOwnershipSignals(items, sortBy, sortDesc)
-		page, next := pageWithCursor(items, offset, limit)
-		response := gin.H{"items": page}
-		if next != "" {
-			response["next_cursor"] = next
-		}
-		c.JSON(http.StatusOK, response)
+		c.JSON(http.StatusOK, paginatedItemsResponse(items, offset, limit))
 	})
 
 	v1.GET("/scans", func(c *gin.Context) {
@@ -496,12 +476,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			return
 		}
 		sortScans(items, sortBy, sortDesc)
-		page, next := pageWithCursor(items, offset, limit)
-		response := gin.H{"items": page}
-		if next != "" {
-			response["next_cursor"] = next
-		}
-		c.JSON(http.StatusOK, response)
+		c.JSON(http.StatusOK, paginatedItemsResponse(items, offset, limit))
 	})
 
 	v1.GET("/scans/:scan_id/diff", func(c *gin.Context) {
@@ -548,12 +523,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			return
 		}
 		sortScanEvents(items, sortBy, sortDesc)
-		page, next := pageWithCursor(items, offset, limit)
-		response := gin.H{"items": page}
-		if next != "" {
-			response["next_cursor"] = next
-		}
-		c.JSON(http.StatusOK, response)
+		c.JSON(http.StatusOK, paginatedItemsResponse(items, offset, limit))
 	})
 
 	v1.GET("/repo-scans", func(c *gin.Context) {
@@ -567,12 +537,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			return
 		}
 		sortRepoScans(items, sortBy, sortDesc)
-		page, next := pageWithCursor(items, offset, limit)
-		response := gin.H{"items": page}
-		if next != "" {
-			response["next_cursor"] = next
-		}
-		c.JSON(http.StatusOK, response)
+		c.JSON(http.StatusOK, paginatedItemsResponse(items, offset, limit))
 	})
 
 	v1.GET("/repo-scans/:repo_scan_id", func(c *gin.Context) {
@@ -622,12 +587,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			return
 		}
 		sortFindings(items, sortBy, sortDesc)
-		page, next := pageWithCursor(items, offset, limit)
-		response := gin.H{"items": page}
-		if next != "" {
-			response["next_cursor"] = next
-		}
-		c.JSON(http.StatusOK, response)
+		c.JSON(http.StatusOK, paginatedItemsResponse(items, offset, limit))
 	})
 
 	v1.POST("/scans", func(c *gin.Context) {
@@ -769,12 +729,7 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 			return
 		}
 		sortWorkspaces(items, sortBy, sortDesc)
-		page, next := pageWithCursor(items, offset, limit)
-		response := gin.H{"items": page}
-		if next != "" {
-			response["next_cursor"] = next
-		}
-		c.JSON(http.StatusOK, response)
+		c.JSON(http.StatusOK, paginatedItemsResponse(items, offset, limit))
 	})
 
 	v1.POST("/workspaces", func(c *gin.Context) {
@@ -963,12 +918,7 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 			return
 		}
 		sortWorkspaceMembers(items)
-		page, next := pageWithCursor(items, offset, limit)
-		response := gin.H{"items": page}
-		if next != "" {
-			response["next_cursor"] = next
-		}
-		c.JSON(http.StatusOK, response)
+		c.JSON(http.StatusOK, paginatedItemsResponse(items, offset, limit))
 	})
 
 	v1.POST("/workspaces/:workspace_id/members", func(c *gin.Context) {
@@ -1061,12 +1011,7 @@ func registerTenancyRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service
 			return
 		}
 		sortProjects(items, sortBy, sortDesc)
-		page, next := pageWithCursor(items, offset, limit)
-		response := gin.H{"items": page}
-		if next != "" {
-			response["next_cursor"] = next
-		}
-		c.JSON(http.StatusOK, response)
+		c.JSON(http.StatusOK, paginatedItemsResponse(items, offset, limit))
 	})
 
 	v1.POST("/workspaces/:workspace_id/projects", func(c *gin.Context) {
@@ -1793,6 +1738,15 @@ func pageWithCursor[T any](items []T, offset int, limit int) ([]T, string) {
 		next = strconv.Itoa(end)
 	}
 	return items[offset:end], next
+}
+
+func paginatedItemsResponse[T any](items []T, offset int, limit int) gin.H {
+	page, next := pageWithCursor(items, offset, limit)
+	response := gin.H{"items": page}
+	if next != "" {
+		response["next_cursor"] = next
+	}
+	return response
 }
 
 func requestScopeMiddleware(defaultTenantID string, defaultWorkspaceID string) gin.HandlerFunc {


### PR DESCRIPTION
Fixes #731

## Summary
- added `paginatedItemsResponse` helper in `internal/api/router.go`
- replaced repeated list-route response envelope blocks with helper calls
- preserved existing JSON schema (`items` + optional `next_cursor`)

## Why
- reduces repeated pagination envelope code and lowers drift risk across list handlers

## Impact and risk
- low to medium risk
- response shape is unchanged; refactor is internal

## Validation
- `go test ./internal/api -run TestRouterPaginationHelpers -count=1`
- `go test ./internal/api -count=1`
- pre-commit hooks passed on commit
- pre-push checks passed (`go vet`, token/artifact hygiene)

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a reusable helper for paginated API responses and replaced duplicated response code across list endpoints, fixing #731. After merging latest `dev`, behavior is unchanged: JSON stays `items` with optional `next_cursor`.

- **Refactors**
  - Added generic `paginatedItemsResponse[T]` in `internal/api/router.go`.
  - Switched list routes to use the helper instead of inline pagination envelopes.

<sup>Written for commit fef0b770fb3e231b6e1043ec570fc3b70109284c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

