### PR TITLE
Add Kubernetes NetworkPolicy baseline example

### DIFF
--- a/deploy/kubernetes/network-policy.example.yaml
+++ b/deploy/kubernetes/network-policy.example.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: identrail-default-deny
+      namespace: identrail
+    spec:
+      podSelector:
+        matchExpressions:
+          - key: app
+            operator: In
+            values:
+              - identrail-api
+              - identrail-worker
+              - identrail-migrations
+      policyTypes:
+        - Ingress
+        - Egress
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: identrail-postgres-ingress
+      namespace: identrail
+    spec:
+      podSelector:
+        matchLabels:
+          app: postgres
+      policyTypes:
+        - Ingress
+      ingress:
+        - from:
+            - podSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - identrail-api
+                      - identrail-worker
+                      - identrail-migrations
+          ports:
+            - protocol: TCP
+              port: 5432
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: identrail-api-ingress
+      namespace: identrail
+    spec:
+      podSelector:
+        matchLabels:
+          app: identrail-api
+      policyTypes:
+        - Ingress
+      ingress:
+        - ports:
+            - protocol: TCP
+              port: 8080
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: identrail-runtime-egress
+      namespace: identrail
+    spec:
+      podSelector:
+        matchExpressions:
+          - key: app
+            operator: In
+            values:
+              - identrail-api
+              - identrail-worker
+              - identrail-migrations
+      policyTypes:
+        - Egress
+      egress:
+        - to:
+            - namespaceSelector: {}
+          ports:
+            - protocol: UDP
+              port: 53
+            - protocol: TCP
+              port: 53
+        - ports:
+            - protocol: TCP
+              port: 443
+            - protocol: TCP
+              port: 5432


### PR DESCRIPTION
Fixes #695

## Summary
- Adds an optional static NetworkPolicy baseline example.
- Documents reviewing and applying it for cluster-specific ingress, DNS, database, and provider egress.

## Impact and risk
- Keeps the change scoped to the deployment hardening item tracked in #695.
- Uses an opt-in example so operators can adapt it to their CNI and cluster topology before applying.

## Validation performed
- git diff --check

## Review readiness
- [x] Scope is focused and free of unrelated changes
- [x] Docs updated when operator-facing behavior changed
- [x] No secrets or credentials are present

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in Kubernetes NetworkPolicy example for the `identrail` namespace to harden network access (fixes #695). Applies a default deny to `identrail-api`, `identrail-worker`, and `identrail-migrations`; allows `identrail-api` ingress on TCP 8080, permits `app: postgres` ingress from those apps on TCP 5432, and restricts egress to DNS (53 TCP/UDP), HTTPS (443), and Postgres (5432).

<sup>Written for commit 806c8c1b6a0b35af982a27f8ec5097c2026f8c31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

