### PR TITLE
Add worker healthcheck probe support

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -19,6 +19,10 @@ func run(ctx context.Context, sigCh <-chan os.Signal) error {
 }
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "--healthcheck" {
+		return
+	}
+
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(sigCh)

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -33,4 +33,5 @@ Notes:
 - For Kubernetes provider runs, set `IDENTRAIL_K8S_SOURCE=kubectl` and use an image that includes `kubectl`.
 - The default manifests disable service account token automounting. If Kubernetes provider mode needs in-cluster API credentials, explicitly enable token mounting for that workload and bind a least-privilege service account.
 - For upgrade-safe deployment at scale, prefer Helm (`deploy/helm/identrail`).
+- Worker probes use `identrail --healthcheck`, which verifies the worker binary can execute inside the container.
 - Update the API, worker, and migration manifests to the same release tag or digest before applying them in production; avoid mutable `latest` tags.

--- a/deploy/kubernetes/worker-deployment.yaml
+++ b/deploy/kubernetes/worker-deployment.yaml
@@ -35,6 +35,22 @@ spec:
           env:
             - name: IDENTRAIL_RUN_MIGRATIONS
               value: "false"
+          readinessProbe:
+            exec:
+              command:
+                - /usr/local/bin/identrail
+                - --healthcheck
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 2
+          livenessProbe:
+            exec:
+              command:
+                - /usr/local/bin/identrail
+                - --healthcheck
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 2
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
Fixes #696

## Summary
- Adds a worker `--healthcheck` mode for Kubernetes exec probes.
- Adds readiness and liveness probes to the static worker deployment.

## Impact and risk
- Keeps the change scoped to the deployment hardening item tracked in #696.
- Uses conservative defaults or documentation-only guidance where runtime behavior is environment-specific.

## Validation performed
- go test ./cmd/worker
- git diff --check

## Review readiness
- [x] Scope is focused and free of unrelated changes
- [x] Docs updated when operator-facing behavior changed
- [x] No secrets or credentials are present

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #696 by adding a worker `--healthcheck` mode and wiring Kubernetes exec readiness/liveness probes to harden deployments. This confirms the `identrail` binary executes inside the container and surfaces health quickly.

- **New Features**
  - `identrail --healthcheck`: fast no-op exit for probe execution.
  - Worker deployment adds exec readiness and liveness probes using `/usr/local/bin/identrail --healthcheck` with conservative timings.
  - Kubernetes README updated with probe guidance and release tag/digest pinning advice.

<sup>Written for commit 211c62f034048cc83d2aeefa377f8599143a414e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

