### PR TITLE
test: queued cloud scan failure lifecycle coverage

### DIFF
--- a/deploy/docker/Dockerfile.web
+++ b/deploy/docker/Dockerfile.web
@@ -2,7 +2,11 @@ FROM node:24-bookworm-slim@sha256:03eae3ef7e88a9de535496fb488d67e02b9d96a063a896
 WORKDIR /web
 
 COPY web/package*.json ./
-RUN npm ci
+RUN npm config set fetch-retries 5 \
+    && npm config set fetch-retry-factor 2 \
+    && npm config set fetch-retry-mintimeout 20000 \
+    && npm config set fetch-retry-maxtimeout 120000 \
+    && npm ci --no-audit
 
 COPY web ./
 

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os/exec"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1388,6 +1389,60 @@ func TestServiceEnqueueScanAndProcessQueue(t *testing.T) {
 	}
 	if processed {
 		t.Fatal("expected no more queued scans")
+	}
+}
+
+func TestServiceProcessNextQueuedScanFinalizesFailure(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 3, 20, 9, 0, 0, 0, time.UTC)
+	svc := NewService(store, fakeScanner{err: errors.New("scanner failed during analysis")}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	record, err := svc.EnqueueScan(defaultScopeContext())
+	if err != nil {
+		t.Fatalf("enqueue scan: %v", err)
+	}
+
+	processed, err := svc.ProcessNextQueuedScan(defaultScopeContext())
+	if !processed {
+		t.Fatal("expected queued scan to be processed")
+	}
+	if err == nil {
+		t.Fatal("expected scanner failure to be returned")
+	}
+
+	scan, err := store.GetScan(defaultScopeContext(), record.ID)
+	if err != nil {
+		t.Fatalf("get scan: %v", err)
+	}
+	if scan.Status != "failed" {
+		t.Fatalf("expected failed status, got %q", scan.Status)
+	}
+	if scan.ErrorMessage == "" {
+		t.Fatal("expected persisted scan error message")
+	}
+
+	events, err := svc.ListScanEvents(defaultScopeContext(), record.ID, 20)
+	if err != nil {
+		t.Fatalf("list scan events: %v", err)
+	}
+	foundFailureEvent := false
+	for _, event := range events {
+		if event.Level == db.ScanEventLevelError && strings.Contains(event.Message, "scan failed during collection/analysis") {
+			foundFailureEvent = true
+			break
+		}
+	}
+	if !foundFailureEvent {
+		t.Fatalf("expected failure scan event, got %+v", events)
+	}
+
+	processed, err = svc.ProcessNextQueuedScan(defaultScopeContext())
+	if err != nil {
+		t.Fatalf("second queue process: %v", err)
+	}
+	if processed {
+		t.Fatal("expected failed scan to not be retried from queue")
 	}
 }
 


### PR DESCRIPTION
Fixes #740

## Summary
- add queued cloud scan worker failure lifecycle coverage in `Service.ProcessNextQueuedScan`
- assert failed status finalization, persisted error message, and failure scan event emission
- assert a finalized failed job is not retried on subsequent queue passes

## Validation
- go test ./internal/api -run TestServiceProcessNextQueuedScanFinalizesFailure -count=1

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a unit test for queued cloud scan failures in `Service.ProcessNextQueuedScan` (Fixes #740). It verifies failed status with a persisted error, emits an error event, prevents retries, and hardens the web image by setting `npm` fetch-retry backoff/timeouts and using `npm ci --no-audit`.

<sup>Written for commit 3e50621ffa0929e8a617a0ec9792cef02a5da7a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

