### PR TITLE
Align Helm API baseline with static manifests

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -24,6 +24,7 @@ This chart is the Kubernetes deployment baseline for Identrail.
 - Default mode uses `secret.existingSecret=identrail-secrets` with `secret.create=false`.
 - Migrations run as a pre-install/pre-upgrade Helm hook job (`templates/migration-job.yaml`).
 - API and worker deployments force `IDENTRAIL_RUN_MIGRATIONS=false` to avoid DDL races.
+- Helm API defaults match the static production manifest baseline for replica count and API resources; tune values explicitly for smaller development clusters.
 - Disable hook jobs only if migrations are handled externally: set `migrations.enabled=false`.
 - Values default to `IDENTRAIL_AWS_SOURCE=sdk` and enforce `IDENTRAIL_REQUIRE_LIVE_SOURCES=true`.
 - `IDENTRAIL_K8S_SOURCE` defaults to `fixture` to avoid requiring a `kubectl` binary in the default backend image. For Kubernetes provider deployments, set `IDENTRAIL_K8S_SOURCE=kubectl` and use an image that includes `kubectl`.

--- a/deploy/helm/identrail/values.yaml
+++ b/deploy/helm/identrail/values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: ""
 imagePullSecrets: []
 
 api:
-  replicaCount: 1
+  replicaCount: 2
   image:
     repository: identrail/api
     tag: latest
@@ -20,7 +20,13 @@ api:
   service:
     type: ClusterIP
     port: 8080
-  resources: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
 
 worker:
   replicaCount: 1


### PR DESCRIPTION
Fixes #699

## Summary
- Aligns Helm API replica count and resource defaults with the static Kubernetes baseline.
- Documents tuning lower values only for smaller development clusters.

## Impact and risk
- Keeps the change scoped to the deployment hardening item tracked in #699.
- Uses conservative defaults or documentation-only guidance where runtime behavior is environment-specific.

## Validation performed
- helm lint deploy/helm/identrail
- git diff --check

## Review readiness
- [x] Scope is focused and free of unrelated changes
- [x] Docs updated when operator-facing behavior changed
- [x] No secrets or credentials are present

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Helm chart API defaults with the static Kubernetes manifests by setting `api.replicaCount` to 2 and adding CPU/memory requests (100m/128Mi) and limits (500m/512Mi). Adds a README note to tune these for smaller dev clusters.

- **Migration**
  - No action for production. For small dev clusters, override `api.replicaCount: 1` and adjust `api.resources` as needed.

<sup>Written for commit e71d94d2ca4063cb0b410a3b9b935620d896d4db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

