### PR TITLE
fix: prevent concurrent duplicate repo enqueue for same target

### DIFF
--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -81,7 +81,6 @@ type Service struct {
 	KubernetesPreflightFactory  KubernetesConnectorPreflightFactory
 	AWSConnectorValidator       AWSConnectorValidator
 	AWSScannerFactory           AWSScannerFactory
-	repoQueueMu                 sync.Mutex
 	githubConnectMu             sync.RWMutex
 	githubConnections           map[string]githubProjectConnection
 	githubConnectStates         map[string]githubConnectState
@@ -518,29 +517,20 @@ func (s *Service) EnqueueRepoScan(ctx context.Context, request RepoScanRequest) 
 	if err != nil {
 		return db.RepoScanRecord{}, err
 	}
-	s.repoQueueMu.Lock()
-	defer s.repoQueueMu.Unlock()
-	pendingForTarget, err := s.Store.CountPendingRepoScansByRepository(ctx, target)
-	if err != nil {
-		return db.RepoScanRecord{}, fmt.Errorf("count pending repo scans for target: %w", err)
-	}
-	if pendingForTarget > 0 {
-		return db.RepoScanRecord{}, ErrRepoScanInProgress
-	}
 	maxPending := s.RepoQueueMaxPending
 	if maxPending <= 0 {
 		maxPending = defaultRepoQueueMaxPending
 	}
-	queuedCount, err := s.Store.CountQueuedRepoScans(ctx)
+	record, err := s.Store.CreateQueuedRepoScanWithinLimit(ctx, target, historyLimit, maxFindings, s.Now().UTC(), maxPending)
 	if err != nil {
-		return db.RepoScanRecord{}, fmt.Errorf("count queued repo scans: %w", err)
-	}
-	if queuedCount >= maxPending {
-		return db.RepoScanRecord{}, ErrRepoScanQueueFull
-	}
-	record, err := s.Store.CreateQueuedRepoScan(ctx, target, historyLimit, maxFindings, s.Now().UTC())
-	if err != nil {
-		return db.RepoScanRecord{}, fmt.Errorf("enqueue repo scan: %w", err)
+		switch {
+		case errors.Is(err, db.ErrPendingRepoScanExists):
+			return db.RepoScanRecord{}, ErrRepoScanInProgress
+		case errors.Is(err, db.ErrQueueLimitReached):
+			return db.RepoScanRecord{}, ErrRepoScanQueueFull
+		default:
+			return db.RepoScanRecord{}, fmt.Errorf("enqueue repo scan: %w", err)
+		}
 	}
 	return record, nil
 }

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -81,6 +81,7 @@ type Service struct {
 	KubernetesPreflightFactory  KubernetesConnectorPreflightFactory
 	AWSConnectorValidator       AWSConnectorValidator
 	AWSScannerFactory           AWSScannerFactory
+	repoQueueMu                 sync.Mutex
 	githubConnectMu             sync.RWMutex
 	githubConnections           map[string]githubProjectConnection
 	githubConnectStates         map[string]githubConnectState
@@ -517,6 +518,8 @@ func (s *Service) EnqueueRepoScan(ctx context.Context, request RepoScanRequest) 
 	if err != nil {
 		return db.RepoScanRecord{}, err
 	}
+	s.repoQueueMu.Lock()
+	defer s.repoQueueMu.Unlock()
 	pendingForTarget, err := s.Store.CountPendingRepoScansByRepository(ctx, target)
 	if err != nil {
 		return db.RepoScanRecord{}, fmt.Errorf("count pending repo scans for target: %w", err)

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -1645,7 +1645,6 @@ func TestServiceEnqueueRepoScanGuards(t *testing.T) {
 	}
 }
 
-<<<<<<< HEAD
 func TestServiceProcessQueuedRepoScanAcrossScopes(t *testing.T) {
 	store := db.NewMemoryStore()
 	svc := NewService(store, fakeScanner{}, "aws")
@@ -1686,7 +1685,9 @@ func TestServiceProcessQueuedRepoScanAcrossScopes(t *testing.T) {
 	}
 	if stored.Status != "succeeded" {
 		t.Fatalf("expected succeeded repo scan status, got %q", stored.Status)
-=======
+	}
+}
+
 func TestServiceEnqueueRepoScanConcurrentDeduplicatesTarget(t *testing.T) {
 	svc := NewService(db.NewMemoryStore(), fakeScanner{}, "aws")
 	svc.RepoScanAllowedTargets = []string{"owner/*"}
@@ -1733,7 +1734,6 @@ func TestServiceEnqueueRepoScanConcurrentDeduplicatesTarget(t *testing.T) {
 	}
 	if inProgressCount != workers-1 {
 		t.Fatalf("expected %d in-progress responses, got %d", workers-1, inProgressCount)
->>>>>>> 1e70c6b (serialize repo queue checks during enqueue)
 	}
 }
 

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -1645,6 +1645,7 @@ func TestServiceEnqueueRepoScanGuards(t *testing.T) {
 	}
 }
 
+<<<<<<< HEAD
 func TestServiceProcessQueuedRepoScanAcrossScopes(t *testing.T) {
 	store := db.NewMemoryStore()
 	svc := NewService(store, fakeScanner{}, "aws")
@@ -1685,6 +1686,54 @@ func TestServiceProcessQueuedRepoScanAcrossScopes(t *testing.T) {
 	}
 	if stored.Status != "succeeded" {
 		t.Fatalf("expected succeeded repo scan status, got %q", stored.Status)
+=======
+func TestServiceEnqueueRepoScanConcurrentDeduplicatesTarget(t *testing.T) {
+	svc := NewService(db.NewMemoryStore(), fakeScanner{}, "aws")
+	svc.RepoScanAllowedTargets = []string{"owner/*"}
+	svc.RepoQueueMaxPending = 100
+
+	const workers = 12
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	var successCount int32
+	var inProgressCount int32
+	var queueFullCount int32
+	var unexpectedErrCount int32
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := svc.EnqueueRepoScan(defaultScopeContext(), RepoScanRequest{Repository: "owner/repo"})
+			switch {
+			case err == nil:
+				atomic.AddInt32(&successCount, 1)
+			case errors.Is(err, ErrRepoScanInProgress):
+				atomic.AddInt32(&inProgressCount, 1)
+			case errors.Is(err, ErrRepoScanQueueFull):
+				atomic.AddInt32(&queueFullCount, 1)
+			default:
+				atomic.AddInt32(&unexpectedErrCount, 1)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	if unexpectedErrCount != 0 {
+		t.Fatalf("expected no unexpected enqueue errors, got %d", unexpectedErrCount)
+	}
+	if queueFullCount != 0 {
+		t.Fatalf("expected no queue-full errors, got %d", queueFullCount)
+	}
+	if successCount != 1 {
+		t.Fatalf("expected exactly one successful enqueue, got %d", successCount)
+	}
+	if inProgressCount != workers-1 {
+		t.Fatalf("expected %d in-progress responses, got %d", workers-1, inProgressCount)
+>>>>>>> 1e70c6b (serialize repo queue checks during enqueue)
 	}
 }
 

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -1237,6 +1237,37 @@ func (m *MemoryStore) CreateQueuedRepoScan(ctx context.Context, repository strin
 	return m.createRepoScanLocked(scope, strings.TrimSpace(repository), "queued", historyLimit, maxFindings, queuedAt), nil
 }
 
+// CreateQueuedRepoScanWithinLimit persists one queued repository scan only when the target is idle and queue capacity remains.
+func (m *MemoryStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (RepoScanRecord, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return RepoScanRecord{}, err
+	}
+	if maxPending <= 0 {
+		maxPending = 1
+	}
+	normalizedRepository := strings.TrimSpace(repository)
+	queued := 0
+	for _, record := range m.repoScans {
+		if !MatchScope(scope, record.TenantID, record.WorkspaceID) {
+			continue
+		}
+		if strings.EqualFold(record.Repository, normalizedRepository) && (record.Status == "queued" || record.Status == "running") {
+			return RepoScanRecord{}, ErrPendingRepoScanExists
+		}
+		if record.Status == "queued" {
+			queued++
+		}
+	}
+	if queued >= maxPending {
+		return RepoScanRecord{}, ErrQueueLimitReached
+	}
+	return m.createRepoScanLocked(scope, normalizedRepository, "queued", historyLimit, maxFindings, queuedAt), nil
+}
+
 // ClaimNextQueuedRepoScan moves one queued repository scan to running for execution.
 func (m *MemoryStore) ClaimNextQueuedRepoScan(ctx context.Context) (RepoScanRecord, error) {
 	m.mu.Lock()

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -1955,6 +1955,98 @@ func (p *PostgresStore) CreateQueuedRepoScan(ctx context.Context, repository str
 	return p.createRepoScanWithStatus(ctx, repository, "queued", historyLimit, maxFindings, queuedAt)
 }
 
+// CreateQueuedRepoScanWithinLimit inserts one queued repository scan only when the target is idle and queue capacity remains.
+func (p *PostgresStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (RepoScanRecord, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return RepoScanRecord{}, err
+	}
+	if maxPending <= 0 {
+		maxPending = 1
+	}
+	tx, err := p.beginTx(ctx)
+	if err != nil {
+		return RepoScanRecord{}, fmt.Errorf("begin queued repo scan transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	normalizedRepository := strings.TrimSpace(repository)
+	queueLockKey := fmt.Sprintf("repo-queue:%s:%s", scope.TenantID, scope.WorkspaceID)
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtext($1)::bigint)`, queueLockKey); err != nil {
+		return RepoScanRecord{}, fmt.Errorf("lock repo scan queue capacity: %w", err)
+	}
+	repositoryLockKey := fmt.Sprintf("repo-target:%s:%s:%s", scope.TenantID, scope.WorkspaceID, strings.ToLower(normalizedRepository))
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtext($1)::bigint)`, repositoryLockKey); err != nil {
+		return RepoScanRecord{}, fmt.Errorf("lock repo scan target: %w", err)
+	}
+
+	var pendingForTarget int
+	if err := tx.QueryRowContext(
+		ctx,
+		`SELECT COUNT(*)
+		 FROM repo_scans
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND LOWER(repository) = LOWER($3)
+		   AND status IN ('queued', 'running')`,
+		scope.TenantID,
+		scope.WorkspaceID,
+		normalizedRepository,
+	).Scan(&pendingForTarget); err != nil {
+		return RepoScanRecord{}, fmt.Errorf("count pending repo scans: %w", err)
+	}
+	if pendingForTarget > 0 {
+		return RepoScanRecord{}, ErrPendingRepoScanExists
+	}
+
+	var queued int
+	if err := tx.QueryRowContext(
+		ctx,
+		`SELECT COUNT(*)
+		 FROM repo_scans
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND status = 'queued'`,
+		scope.TenantID,
+		scope.WorkspaceID,
+	).Scan(&queued); err != nil {
+		return RepoScanRecord{}, fmt.Errorf("count queued repo scans: %w", err)
+	}
+	if queued >= maxPending {
+		return RepoScanRecord{}, ErrQueueLimitReached
+	}
+
+	record := RepoScanRecord{
+		ID:           uuid.NewString(),
+		TenantID:     scope.TenantID,
+		WorkspaceID:  scope.WorkspaceID,
+		Repository:   normalizedRepository,
+		Status:       "queued",
+		StartedAt:    queuedAt.UTC(),
+		HistoryLimit: historyLimit,
+		MaxFindings:  maxFindings,
+	}
+	if _, err := tx.ExecContext(
+		ctx,
+		`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit)
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8)`,
+		record.ID,
+		record.TenantID,
+		record.WorkspaceID,
+		record.Repository,
+		record.Status,
+		record.StartedAt,
+		record.HistoryLimit,
+		record.MaxFindings,
+	); err != nil {
+		return RepoScanRecord{}, fmt.Errorf("insert queued repo scan: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return RepoScanRecord{}, fmt.Errorf("commit queued repo scan transaction: %w", err)
+	}
+	return record, nil
+}
+
 // ClaimNextQueuedRepoScan atomically claims one queued repository scan.
 func (p *PostgresStore) ClaimNextQueuedRepoScan(ctx context.Context) (RepoScanRecord, error) {
 	scope, err := RequireScope(ctx)

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -920,6 +920,106 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 	}
 }
 
+func TestPostgresStoreCreateQueuedRepoScanWithinLimit(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	now := time.Now().UTC()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("SELECT pg_advisory_xact_lock").
+		WithArgs("repo-queue:default:default").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("SELECT pg_advisory_xact_lock").
+		WithArgs("repo-target:default:default:owner/repo").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*)
+		 FROM repo_scans
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND LOWER(repository) = LOWER($3)
+		   AND status IN ('queued', 'running')`)).
+		WithArgs("default", "default", "owner/repo").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*)
+		 FROM repo_scans
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND status = 'queued'`)).
+		WithArgs("default", "default").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit)
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8)`)).
+		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "queued", now, 50, 80).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	record, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo", 50, 80, now, 2)
+	if err != nil {
+		t.Fatalf("create queued repo scan within limit: %v", err)
+	}
+	if record.Repository != "owner/repo" || record.Status != "queued" {
+		t.Fatalf("unexpected queued repo scan %+v", record)
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec("SELECT pg_advisory_xact_lock").
+		WithArgs("repo-queue:default:default").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("SELECT pg_advisory_xact_lock").
+		WithArgs("repo-target:default:default:owner/repo").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*)
+		 FROM repo_scans
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND LOWER(repository) = LOWER($3)
+		   AND status IN ('queued', 'running')`)).
+		WithArgs("default", "default", "owner/repo").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectRollback()
+
+	if _, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo", 50, 80, now.Add(time.Minute), 2); !errors.Is(err, ErrPendingRepoScanExists) {
+		t.Fatalf("expected ErrPendingRepoScanExists, got %v", err)
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec("SELECT pg_advisory_xact_lock").
+		WithArgs("repo-queue:default:default").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("SELECT pg_advisory_xact_lock").
+		WithArgs("repo-target:default:default:owner/other").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*)
+		 FROM repo_scans
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND LOWER(repository) = LOWER($3)
+		   AND status IN ('queued', 'running')`)).
+		WithArgs("default", "default", "owner/other").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*)
+		 FROM repo_scans
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND status = 'queued'`)).
+		WithArgs("default", "default").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+	mock.ExpectRollback()
+
+	if _, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/other", 50, 80, now.Add(2*time.Minute), 2); !errors.Is(err, ErrQueueLimitReached) {
+		t.Fatalf("expected ErrQueueLimitReached, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestPostgresStoreAuthzEntityAttributesLifecycle(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -22,9 +22,11 @@ var ErrNotFound = errors.New("record not found")
 // ErrScopeRequired indicates tenant/workspace scope must be provided in context.
 var ErrScopeRequired = errors.New("scope is required")
 
-// ErrQueueLimitReached indicates enqueue was rejected because pending capacity is full.
+// ErrQueueLimitReached indicates a bounded queue has no remaining capacity.
 var ErrQueueLimitReached = errors.New("queue limit reached")
 
+// ErrPendingRepoScanExists indicates the target repository already has a queued or running scan.
+var ErrPendingRepoScanExists = errors.New("pending repo scan exists")
 var authzOwnerTeamPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
 var tenancySlugPattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 
@@ -1057,6 +1059,7 @@ type Store interface {
 	ListScanEvents(ctx context.Context, scanID string, limit int) ([]ScanEvent, error)
 	CreateRepoScan(ctx context.Context, repository string, startedAt time.Time) (RepoScanRecord, error)
 	CreateQueuedRepoScan(ctx context.Context, repository string, historyLimit int, maxFindings int, queuedAt time.Time) (RepoScanRecord, error)
+	CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (RepoScanRecord, error)
 	ClaimNextQueuedRepoScan(ctx context.Context) (RepoScanRecord, error)
 	ClaimNextQueuedRepoScanAnyScope(ctx context.Context) (RepoScanRecord, error)
 	CountQueuedRepoScans(ctx context.Context) (int, error)


### PR DESCRIPTION
Fixes #650

## Summary
- serialize repository enqueue checks so pending-target and queue-depth validation execute atomically per service instance
- prevent concurrent same-target requests from both passing pre-enqueue guards
- add concurrent regression coverage for repo-target dedupe behavior

## Impact
- avoids duplicate queued repo scans for the same repository under concurrent API requests on the same service instance
- preserves existing queue-full and target-validation behavior

## Validation
- `go test ./internal/api -count=1`

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Atomically enforce repo scan enqueue dedupe and queue capacity to prevent duplicate entries under concurrent requests. Checks now run in the store (Postgres uses advisory locks scoped to tenant/workspace) so only one enqueue succeeds; others return “in progress” or “queue full”.

- **Bug Fixes**
  - Replaced service-level mutex with `Store.CreateQueuedRepoScanWithinLimit` to atomically check target-idle and queue capacity and insert in one step (Postgres uses `pg_advisory_xact_lock` for queue and per-target locks; memory store uses a mutex).
  - Mapped `ErrPendingRepoScanExists` and `ErrQueueLimitReached` to `ErrRepoScanInProgress` and `ErrRepoScanQueueFull` in `EnqueueRepoScan`.
  - Case-insensitive target dedupe for queued/running scans.
  - Added concurrent service test, Postgres sqlmock tests, and memory store tests for the new enqueue path.

<sup>Written for commit 1d32dd0783c67569cca949e97e94794fca2e2204. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

