### PR TITLE
Fixes #753: add production connector secret key guidance

### DIFF
--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -37,6 +37,8 @@ IDENTRAIL_POSTGRES_PASSWORD=replace-with-strong-postgres-password
 # openssl rand -base64 32
 # IDENTRAIL_CONNECTOR_SECRET_KEYS=v1:replace-with-base64-32-byte-key
 # IDENTRAIL_CONNECTOR_SECRET_KEYS_REQUIRED=true
+# Optional connector secret envelope keys for durable connector credential storage
+# Format: version:base64-encoded-32-byte-key (comma/semicolon separated for rotation sets)
 
 # Locking backend (auto -> postgres in DB mode, in-memory otherwise)
 IDENTRAIL_LOCK_BACKEND=auto

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -11,7 +11,7 @@ This chart is the Kubernetes deployment baseline for Identrail.
 1. Copy default values:
    - `cp deploy/helm/identrail/values.yaml /tmp/identrail-values.yaml`
 2. Create the runtime secret referenced by default (`identrail-secrets`):
-   - `READ_KEY=$(openssl rand -hex 24); WRITE_KEY=$(openssl rand -hex 24); DB_PASSWORD=$(openssl rand -hex 24); kubectl -n identrail create secret generic identrail-secrets --from-literal=IDENTRAIL_API_KEYS="${READ_KEY},${WRITE_KEY}" --from-literal=IDENTRAIL_WRITE_API_KEYS="${WRITE_KEY}" --from-literal=IDENTRAIL_DATABASE_URL="postgres://identrail:${DB_PASSWORD}@postgres:5432/identrail?sslmode=require"`
+   - `READ_KEY=$(openssl rand -hex 24); WRITE_KEY=$(openssl rand -hex 24); DB_PASSWORD=$(openssl rand -hex 24); CONNECTOR_KEY=$(openssl rand -base64 32); kubectl -n identrail create secret generic identrail-secrets --from-literal=IDENTRAIL_API_KEYS="${READ_KEY},${WRITE_KEY}" --from-literal=IDENTRAIL_WRITE_API_KEYS="${WRITE_KEY}" --from-literal=IDENTRAIL_DATABASE_URL="postgres://identrail:${DB_PASSWORD}@postgres:5432/identrail?sslmode=require" --from-literal=IDENTRAIL_CONNECTOR_SECRET_KEYS="v1:${CONNECTOR_KEY}"`
 3. (Optional) If you want Helm to create the secret instead, set `secret.create=true` and provide `secret.data`.
 4. Install or upgrade:
    - `helm upgrade --install identrail deploy/helm/identrail -n identrail --create-namespace -f /tmp/identrail-values.yaml`
@@ -34,3 +34,4 @@ This chart is the Kubernetes deployment baseline for Identrail.
 - Enable web deployment by setting `web.enabled=true`.
 - Enable ingress by setting `ingress.enabled=true`.
 - `IDENTRAIL_AUDIT_LOG_FILE` is empty by default. If you enable it, mount a writable path for the container user.
+- `IDENTRAIL_CONNECTOR_SECRET_KEYS` should be set for durable connector credential storage. If omitted, connector secret envelopes use an ephemeral in-memory key suitable only for local/test runs.

--- a/deploy/kubernetes/secret.example.yaml
+++ b/deploy/kubernetes/secret.example.yaml
@@ -20,7 +20,7 @@ stringData:
   # openssl rand -base64 32
   IDENTRAIL_CONNECTOR_SECRET_KEYS: "v1:replace-with-base64-32-byte-key"
   # Required when IDENTRAIL_CONNECTOR_SECRET_KEYS_REQUIRED=true.
-  # IDENTRAIL_AUDIT_FINGERPRINT_SECRET: "replace-with-strong-secret"
+  IDENTRAIL_AUDIT_FINGERPRINT_SECRET: "replace-with-strong-secret"
   # IDENTRAIL_ALERT_WEBHOOK_URL: "https://alerts.example.com/identrail"
   # IDENTRAIL_ALERT_HMAC_SECRET: "replace-me"
   # IDENTRAIL_AUDIT_FORWARD_URL: "https://audit.example.com/events"

--- a/deploy/kubernetes/secret.example.yaml
+++ b/deploy/kubernetes/secret.example.yaml
@@ -18,7 +18,7 @@ stringData:
   # Format: version:base64-encoded-32-byte-key (comma/semicolon separated for rotation sets)
   # Generate a 32-byte key with:
   # openssl rand -base64 32
-  # IDENTRAIL_CONNECTOR_SECRET_KEYS: "v1:replace-with-base64-32-byte-key"
+  IDENTRAIL_CONNECTOR_SECRET_KEYS: "v1:replace-with-base64-32-byte-key"
   # Required when IDENTRAIL_CONNECTOR_SECRET_KEYS_REQUIRED=true.
   # IDENTRAIL_AUDIT_FINGERPRINT_SECRET: "replace-with-strong-secret"
   # IDENTRAIL_ALERT_WEBHOOK_URL: "https://alerts.example.com/identrail"

--- a/deploy/kubernetes/secret.example.yaml
+++ b/deploy/kubernetes/secret.example.yaml
@@ -14,9 +14,13 @@ stringData:
 
   # Optional alternatives:
   # IDENTRAIL_API_KEY_SCOPES: "reader-key:read;writer-key:read,write"
+  # Optional for durable connector credential storage
+  # Format: version:base64-encoded-32-byte-key (comma/semicolon separated for rotation sets)
+  # Generate a 32-byte key with:
+  # openssl rand -base64 32
+  # IDENTRAIL_CONNECTOR_SECRET_KEYS: "v1:replace-with-base64-32-byte-key"
   # Required when IDENTRAIL_CONNECTOR_SECRET_KEYS_REQUIRED=true.
-  IDENTRAIL_CONNECTOR_SECRET_KEYS: "v1:replace-with-base64-32-byte-key"
-  IDENTRAIL_AUDIT_FINGERPRINT_SECRET: "replace-with-strong-secret"
+  # IDENTRAIL_AUDIT_FINGERPRINT_SECRET: "replace-with-strong-secret"
   # IDENTRAIL_ALERT_WEBHOOK_URL: "https://alerts.example.com/identrail"
   # IDENTRAIL_ALERT_HMAC_SECRET: "replace-me"
   # IDENTRAIL_AUDIT_FORWARD_URL: "https://audit.example.com/events"

--- a/deploy/systemd/identrail.env.example
+++ b/deploy/systemd/identrail.env.example
@@ -19,6 +19,7 @@ IDENTRAIL_REQUIRE_EXPLICIT_SCOPE=true
 # Generate a 32-byte key with:
 # openssl rand -base64 32
 # IDENTRAIL_CONNECTOR_SECRET_KEYS=v1:replace-with-base64-32-byte-key
+IDENTRAIL_CONNECTOR_SECRET_KEYS=v1:replace-with-base64-32-byte-key
 IDENTRAIL_LOCK_BACKEND=auto
 IDENTRAIL_LOCK_NAMESPACE=identrail
 

--- a/deploy/systemd/identrail.env.example
+++ b/deploy/systemd/identrail.env.example
@@ -19,7 +19,7 @@ IDENTRAIL_REQUIRE_EXPLICIT_SCOPE=true
 # Generate a 32-byte key with:
 # openssl rand -base64 32
 # IDENTRAIL_CONNECTOR_SECRET_KEYS=v1:replace-with-base64-32-byte-key
-IDENTRAIL_CONNECTOR_SECRET_KEYS=v1:replace-with-base64-32-byte-key
+# IDENTRAIL_CONNECTOR_SECRET_KEYS=v1:replace-with-base64-32-byte-key
 IDENTRAIL_LOCK_BACKEND=auto
 IDENTRAIL_LOCK_NAMESPACE=identrail
 

--- a/deploy/systemd/identrail.env.example
+++ b/deploy/systemd/identrail.env.example
@@ -14,6 +14,11 @@ IDENTRAIL_REQUIRE_LIVE_SOURCES=true
 IDENTRAIL_API_KEYS=replace-read-key,replace-write-key
 IDENTRAIL_WRITE_API_KEYS=replace-write-key
 IDENTRAIL_REQUIRE_EXPLICIT_SCOPE=true
+# Required for durable connector credential encryption in persisted deployments
+# Format: version:base64-encoded-32-byte-key (comma/semicolon separated for rotation sets)
+# Generate a 32-byte key with:
+# openssl rand -base64 32
+# IDENTRAIL_CONNECTOR_SECRET_KEYS=v1:replace-with-base64-32-byte-key
 IDENTRAIL_LOCK_BACKEND=auto
 IDENTRAIL_LOCK_NAMESPACE=identrail
 

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -5,11 +5,11 @@ create_namespace         = true
 create_kubernetes_secret = true
 
 secret_data = {
-  IDENTRAIL_API_KEYS                 = "replace-read-key,replace-write-key"
-  IDENTRAIL_WRITE_API_KEYS           = "replace-write-key"
-  IDENTRAIL_DATABASE_URL             = "postgres://identrail:replace-password@postgres:5432/identrail?sslmode=require"
-  IDENTRAIL_CONNECTOR_SECRET_KEYS    = "v1:replace-with-base64-32-byte-key"
-  IDENTRAIL_AUDIT_FINGERPRINT_SECRET  = "replace-with-strong-secret"
+  IDENTRAIL_API_KEYS      = "replace-read-key,replace-write-key"
+  IDENTRAIL_WRITE_API_KEYS = "replace-write-key"
+  IDENTRAIL_DATABASE_URL  = "postgres://identrail:replace-password@postgres:5432/identrail?sslmode=require"
+  IDENTRAIL_CONNECTOR_SECRET_KEYS = "v1:replace-with-base64-32-byte-key"
+  IDENTRAIL_AUDIT_FINGERPRINT_SECRET = "replace-with-strong-secret"
 }
 
 chart_values = {

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -9,7 +9,7 @@ secret_data = {
   IDENTRAIL_WRITE_API_KEYS           = "replace-write-key"
   IDENTRAIL_DATABASE_URL             = "postgres://identrail:replace-password@postgres:5432/identrail?sslmode=require"
   IDENTRAIL_CONNECTOR_SECRET_KEYS    = "v1:replace-with-base64-32-byte-key"
-  IDENTRAIL_AUDIT_FINGERPRINT_SECRET = "replace-with-strong-secret"
+  IDENTRAIL_AUDIT_FINGERPRINT_SECRET  = "replace-with-strong-secret"
 }
 
 chart_values = {


### PR DESCRIPTION
Fixes #753

## What changed
- Added `IDENTRAIL_CONNECTOR_SECRET_KEYS` guidance/examples to:
  - `deploy/docker/.env.example`
  - `deploy/kubernetes/secret.example.yaml`
  - `deploy/helm/README.md`
  - `deploy/systemd/identrail.env.example`
  - `deploy/terraform/terraform.tfvars.example`
- Added explicit Helm note that omitting this variable falls back to ephemeral in-memory key behavior suitable only for local/test use.

## Why
- Durable deployments need explicit connector secret keyset configuration for encrypted connector credential storage.

## Impact
- Operators across deployment paths now have concrete setup guidance and key format examples.

## Validation
- `git grep -n "IDENTRAIL_CONNECTOR_SECRET_KEYS" deploy/docker/.env.example deploy/kubernetes/secret.example.yaml deploy/helm/README.md deploy/systemd/identrail.env.example deploy/terraform/terraform.tfvars.example`

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds production deployment guidance for `IDENTRAIL_CONNECTOR_SECRET_KEYS` across Docker, Kubernetes, Helm, systemd, and Terraform to enable durable connector credential encryption (Fixes #753).

- **New Features**
  - Helm: secret creation now includes `IDENTRAIL_CONNECTOR_SECRET_KEYS="v1:${CONNECTOR_KEY}"`; warns about ephemeral fallback if omitted.
  - Kubernetes: example enables `IDENTRAIL_CONNECTOR_SECRET_KEYS` by default with format/rotation notes and `openssl rand -base64 32` guidance.
  - Docker: `.env.example` clarifies optional key usage and rotation format.
  - systemd: shows how to set the key with generation instructions.
  - Terraform: includes the key in `secret_data` and aligns variable names.

<sup>Written for commit c5c754e7019d4ab909ae7d7c5a53d1eb92dc993a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

