### PR TITLE
fix: centralize oidc default claim keys

### DIFF
--- a/internal/api/oidc.go
+++ b/internal/api/oidc.go
@@ -6,13 +6,7 @@ import (
 	"strings"
 
 	"github.com/coreos/go-oidc/v3/oidc"
-)
-
-const (
-	defaultOIDCTenantClaim    = "tenant_id"
-	defaultOIDCWorkspaceClaim = "workspace_id"
-	defaultOIDCGroupsClaim    = "groups"
-	defaultOIDCRolesClaim     = "roles"
+	"github.com/identrail/identrail/internal/config"
 )
 
 // OIDCTokenVerifier validates OIDC bearer tokens using issuer discovery and JWKS verification.
@@ -66,19 +60,19 @@ func NewOIDCTokenVerifier(
 	}
 	tenantClaimName := strings.TrimSpace(tenantClaim)
 	if tenantClaimName == "" {
-		tenantClaimName = defaultOIDCTenantClaim
+		tenantClaimName = config.OIDCDefaultTenantClaim
 	}
 	workspaceClaimName := strings.TrimSpace(workspaceClaim)
 	if workspaceClaimName == "" {
-		workspaceClaimName = defaultOIDCWorkspaceClaim
+		workspaceClaimName = config.OIDCDefaultWorkspaceClaim
 	}
 	groupsClaimName := strings.TrimSpace(groupsClaim)
 	if groupsClaimName == "" {
-		groupsClaimName = defaultOIDCGroupsClaim
+		groupsClaimName = config.OIDCDefaultGroupsClaim
 	}
 	rolesClaimName := strings.TrimSpace(rolesClaim)
 	if rolesClaimName == "" {
-		rolesClaimName = defaultOIDCRolesClaim
+		rolesClaimName = config.OIDCDefaultRolesClaim
 	}
 	provider, err := oidc.NewProvider(ctx, issuer)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,10 +41,10 @@ const (
 	defaultTenantID                    = "default"
 	defaultWorkspaceID                 = "default"
 	defaultOIDCWriteScopes             = "identrail.write,identrail.admin,write,admin"
-	defaultOIDCTenantClaim             = "tenant_id"
-	defaultOIDCWorkspaceClaim          = "workspace_id"
-	defaultOIDCGroupsClaim             = "groups"
-	defaultOIDCRolesClaim              = "roles"
+	defaultOIDCTenantClaim             = OIDCDefaultTenantClaim
+	defaultOIDCWorkspaceClaim          = OIDCDefaultWorkspaceClaim
+	defaultOIDCGroupsClaim             = OIDCDefaultGroupsClaim
+	defaultOIDCRolesClaim              = OIDCDefaultRolesClaim
 	defaultAppModeEnabled              = false
 	defaultAppModeConnectorsEnabled    = false
 	defaultAppModeSchedulerEnabled     = false
@@ -54,6 +54,13 @@ const (
 	defaultAppModePremiumAutofix       = false
 	defaultAppModeRolloutEnabled       = false
 	defaultAppModeRolloutCanaryPercent = 0
+)
+
+const (
+	OIDCDefaultTenantClaim    = "tenant_id"
+	OIDCDefaultWorkspaceClaim = "workspace_id"
+	OIDCDefaultGroupsClaim    = "groups"
+	OIDCDefaultRolesClaim     = "roles"
 )
 
 // Config centralizes process-level configuration. It keeps module wiring simple

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -106,6 +106,11 @@ type ProductSessionTokens = {
 let inMemoryTokens: ProductSessionTokens = {};
 const OIDC_REFRESH_SKEW_MS = 90 * 1000;
 const OIDC_MAX_PENDING_LOGIN_AGE_MS = 10 * 60 * 1000;
+const OIDC_DEFAULT_CLAIMS = {
+  tenant: 'tenant_id',
+  workspace: 'workspace_id',
+  roles: 'roles'
+} as const;
 
 function normalizeValue(value: string): string {
   return value.trim();
@@ -137,9 +142,9 @@ function readOIDCConfig(): OIDCConfig | null {
     scope: normalizeValue(import.meta.env.VITE_OIDC_SCOPE ?? '') || 'openid profile email offline_access',
     redirectURI,
     postLogoutRedirectURI,
-    tenantClaim: normalizeClaimName(import.meta.env.VITE_OIDC_TENANT_CLAIM ?? '', 'tenant_id'),
-    workspaceClaim: normalizeClaimName(import.meta.env.VITE_OIDC_WORKSPACE_CLAIM ?? '', 'workspace_id'),
-    rolesClaim: normalizeClaimName(import.meta.env.VITE_OIDC_ROLES_CLAIM ?? '', 'roles')
+    tenantClaim: normalizeClaimName(import.meta.env.VITE_OIDC_TENANT_CLAIM ?? '', OIDC_DEFAULT_CLAIMS.tenant),
+    workspaceClaim: normalizeClaimName(import.meta.env.VITE_OIDC_WORKSPACE_CLAIM ?? '', OIDC_DEFAULT_CLAIMS.workspace),
+    rolesClaim: normalizeClaimName(import.meta.env.VITE_OIDC_ROLES_CLAIM ?? '', OIDC_DEFAULT_CLAIMS.roles)
   };
 }
 
@@ -301,10 +306,14 @@ function claimStringArray(claims: OIDCClaims, key: string): string[] {
 }
 
 function resolveSessionScopeFromClaims(claims: OIDCClaims, config: OIDCConfig): { tenantID: string; workspaceID: string } {
-  const tenantID = claimString(claims, config.tenantClaim) || claimString(claims, 'tenant_id') || claimString(claims, 'tenant') || 'default';
+  const tenantID =
+    claimString(claims, config.tenantClaim) ||
+    claimString(claims, OIDC_DEFAULT_CLAIMS.tenant) ||
+    claimString(claims, 'tenant') ||
+    'default';
   const workspaceID =
     claimString(claims, config.workspaceClaim) ||
-    claimString(claims, 'workspace_id') ||
+    claimString(claims, OIDC_DEFAULT_CLAIMS.workspace) ||
     claimString(claims, 'workspace') ||
     'default';
 


### PR DESCRIPTION
Fixes #729

## Summary
- introduced exported OIDC default-claim constants in `internal/config/config.go`
- updated API OIDC verifier defaults in `internal/api/oidc.go` to use config constants
- centralized web OIDC default claim fallbacks in `web/src/productShell.tsx` through one `OIDC_DEFAULT_CLAIMS` object

## Why
- aligns default claim keys across config, backend verifier, and web shell fallback logic
- reduces drift risk when default claim names need updates

## Impact and risk
- low risk
- default values are unchanged; this is a contract-centralization refactor

## Validation
- `go test ./internal/config -count=1`
- `go test ./internal/api -run OIDC -count=1`
- pre-commit hooks passed on commit
- pre-push checks passed (`go vet`, token/artifact hygiene)
- web build/typecheck was not run in this worktree because `web` dependencies are not installed (`tsc` unavailable)

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes OIDC default claim key names in one place across config, API verifier, and web UI. No behavior change; reduces drift and closes #729.

- **Refactors**
  - Exported `OIDCDefault*` constants in `internal/config` and wired config defaults to them.
  - Updated `internal/api` OIDC verifier to use config constants for tenant/workspace/groups/roles fallbacks.
  - Added `OIDC_DEFAULT_CLAIMS` in `web/src/productShell.tsx` and used it for env defaults and tenant/workspace/roles fallbacks.

<sup>Written for commit 4f00e43e889a79099ac5837145fe944772594bd0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

