### PR TITLE
Fixes #678: enforce tenancy and connector rls with safe deploy defaults

### DIFF
--- a/deploy/helm/identrail/values.yaml
+++ b/deploy/helm/identrail/values.yaml
@@ -152,7 +152,7 @@ config:
   IDENTRAIL_OIDC_WORKSPACE_CLAIM: workspace_id
   IDENTRAIL_OIDC_GROUPS_CLAIM: groups
   IDENTRAIL_OIDC_ROLES_CLAIM: roles
-  IDENTRAIL_POSTGRES_RLS_ENFORCED: "false"
+  IDENTRAIL_POSTGRES_RLS_ENFORCED: "true"
   IDENTRAIL_AWS_FIXTURES: /app/testdata/aws/role_with_policies.json,/app/testdata/aws/role_with_urlencoded_trust.json
   IDENTRAIL_K8S_FIXTURES: /app/testdata/kubernetes/service_account_payments.json,/app/testdata/kubernetes/cluster_role_cluster_admin.json,/app/testdata/kubernetes/role_binding_cluster_admin.json,/app/testdata/kubernetes/pod_payments.json
 

--- a/internal/config/security.go
+++ b/internal/config/security.go
@@ -588,6 +588,9 @@ func SecurityWarnings(cfg Config) []string {
 	if len(cfg.APIKeyScopes) > 0 && len(cfg.APIKeyScopeBindings) == 0 {
 		warnings = append(warnings, "scoped API keys are not tenant/workspace bound; set IDENTRAIL_API_KEY_SCOPE_BINDINGS to enforce scope isolation")
 	}
+	if !cfg.PostgresRLSEnforced {
+		warnings = append(warnings, "postgres row-level scope enforcement is disabled; set IDENTRAIL_POSTGRES_RLS_ENFORCED=true for deployment environments")
+	}
 	if strings.TrimSpace(cfg.AuditLogFile) == "" {
 		warnings = append(warnings, "audit file sink is disabled; configure IDENTRAIL_AUDIT_LOG_FILE for durable local audit records")
 	}

--- a/internal/config/security_test.go
+++ b/internal/config/security_test.go
@@ -770,6 +770,25 @@ func TestSecurityWarningsShortAPIKey(t *testing.T) {
 	}
 }
 
+func TestSecurityWarningsPostgresRLSEnforcementDisabled(t *testing.T) {
+	cfg := Config{
+		APIKeys:             []string{"reader-key-12345678901234567890"},
+		WriteAPIKeys:        []string{"reader-key-12345678901234567890"},
+		PostgresRLSEnforced: false,
+	}
+	warnings := SecurityWarnings(cfg)
+	found := false
+	for _, warning := range warnings {
+		if strings.Contains(warning, "row-level scope enforcement is disabled") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected postgres rls warning, got %+v", warnings)
+	}
+}
+
 func TestValidateSecurityAppModeRolloutRequiresToggle(t *testing.T) {
 	cfg := Config{
 		APIKeys:              []string{"reader"},

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -368,14 +368,49 @@ func TestFifteenthMigrationContainsTenancyConnectorRLSGuardrails(t *testing.T) {
 	required := []string{
 		"CREATE OR REPLACE FUNCTION identrail_rls_tenant_matches",
 		"ALTER TABLE tenancy_organizations ENABLE ROW LEVEL SECURITY",
-		"CREATE POLICY tenancy_organizations_scope_isolation",
+		"ALTER TABLE tenancy_workspaces ENABLE ROW LEVEL SECURITY",
+		"ALTER TABLE tenancy_workspace_members ENABLE ROW LEVEL SECURITY",
+		"ALTER TABLE tenancy_projects ENABLE ROW LEVEL SECURITY",
 		"ALTER TABLE tenancy_connectors ENABLE ROW LEVEL SECURITY",
+		"ALTER TABLE tenancy_connector_states ENABLE ROW LEVEL SECURITY",
+		"ALTER TABLE tenancy_scan_policies ENABLE ROW LEVEL SECURITY",
+		"CREATE POLICY tenancy_organizations_scope_isolation",
 		"CREATE POLICY tenancy_connector_states_scope_isolation",
+		"CREATE POLICY tenancy_scan_policies_scope_isolation",
 		"CREATE POLICY tenancy_connector_secret_envelopes_scope_isolation",
 	}
 	for _, item := range required {
 		if !strings.Contains(text, item) {
 			t.Fatalf("expected tenancy rls migration item %q", item)
+		}
+	}
+}
+
+func TestFifteenthMigrationEnforcesRLSForTenancyAndConnectorTables(t *testing.T) {
+	path := filepath.Join("..", "..", "migrations", "000015_tenancy_connector_rls_scope_enforcement.up.sql")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	text := string(content)
+	required := []string{
+		"CREATE OR REPLACE FUNCTION identrail_rls_tenant_matches",
+		"ALTER TABLE tenancy_organizations ENABLE ROW LEVEL SECURITY",
+		"ALTER TABLE tenancy_workspaces ENABLE ROW LEVEL SECURITY",
+		"ALTER TABLE tenancy_workspace_members ENABLE ROW LEVEL SECURITY",
+		"ALTER TABLE tenancy_projects ENABLE ROW LEVEL SECURITY",
+		"CREATE POLICY tenancy_organizations_scope_isolation",
+		"ALTER TABLE tenancy_connectors ENABLE ROW LEVEL SECURITY",
+		"ALTER TABLE tenancy_connector_states ENABLE ROW LEVEL SECURITY",
+		"ALTER TABLE tenancy_scan_policies ENABLE ROW LEVEL SECURITY",
+		"ALTER TABLE tenancy_connector_secret_envelopes ENABLE ROW LEVEL SECURITY",
+		"CREATE POLICY tenancy_connector_states_scope_isolation",
+		"CREATE POLICY tenancy_scan_policies_scope_isolation",
+		"CREATE POLICY tenancy_connector_secret_envelopes_scope_isolation",
+	}
+	for _, item := range required {
+		if !strings.Contains(text, item) {
+			t.Fatalf("expected tenancy/connector RLS migration item %q", item)
 		}
 	}
 }

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -375,6 +375,7 @@ func TestFifteenthMigrationContainsTenancyConnectorRLSGuardrails(t *testing.T) {
 		"ALTER TABLE tenancy_connector_states ENABLE ROW LEVEL SECURITY",
 		"ALTER TABLE tenancy_scan_policies ENABLE ROW LEVEL SECURITY",
 		"CREATE POLICY tenancy_organizations_scope_isolation",
+		"USING (identrail_rls_tenant_matches(tenant_id))",
 		"CREATE POLICY tenancy_connector_states_scope_isolation",
 		"CREATE POLICY tenancy_scan_policies_scope_isolation",
 		"CREATE POLICY tenancy_connector_secret_envelopes_scope_isolation",

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -413,4 +413,7 @@ func TestFifteenthMigrationEnforcesRLSForTenancyAndConnectorTables(t *testing.T)
 			t.Fatalf("expected tenancy/connector RLS migration item %q", item)
 		}
 	}
+	if !strings.Contains(text, "CREATE POLICY tenancy_workspaces_scope_isolation ON tenancy_workspaces\nUSING (identrail_rls_tenant_matches(tenant_id))\nWITH CHECK (identrail_rls_tenant_matches(tenant_id));") {
+		t.Fatal("expected tenancy_workspaces policy to remain tenant-scoped for tenant-level workspace discovery")
+	}
 }

--- a/migrations/000015_tenancy_connector_rls_scope_enforcement.down.sql
+++ b/migrations/000015_tenancy_connector_rls_scope_enforcement.down.sql
@@ -1,0 +1,33 @@
+DROP POLICY IF EXISTS tenancy_connector_secret_envelopes_scope_isolation ON tenancy_connector_secret_envelopes;
+ALTER TABLE tenancy_connector_secret_envelopes NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE tenancy_connector_secret_envelopes DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenancy_scan_policies_scope_isolation ON tenancy_scan_policies;
+ALTER TABLE tenancy_scan_policies NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE tenancy_scan_policies DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenancy_connector_states_scope_isolation ON tenancy_connector_states;
+ALTER TABLE tenancy_connector_states NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE tenancy_connector_states DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenancy_connectors_scope_isolation ON tenancy_connectors;
+ALTER TABLE tenancy_connectors NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE tenancy_connectors DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenancy_projects_scope_isolation ON tenancy_projects;
+ALTER TABLE tenancy_projects NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE tenancy_projects DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenancy_workspace_members_scope_isolation ON tenancy_workspace_members;
+ALTER TABLE tenancy_workspace_members NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE tenancy_workspace_members DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenancy_workspaces_scope_isolation ON tenancy_workspaces;
+ALTER TABLE tenancy_workspaces NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE tenancy_workspaces DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenancy_organizations_scope_isolation ON tenancy_organizations;
+ALTER TABLE tenancy_organizations NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE tenancy_organizations DISABLE ROW LEVEL SECURITY;
+
+DROP FUNCTION IF EXISTS identrail_rls_tenant_matches(TEXT);

--- a/migrations/000015_tenancy_connector_rls_scope_enforcement.up.sql
+++ b/migrations/000015_tenancy_connector_rls_scope_enforcement.up.sql
@@ -1,0 +1,68 @@
+CREATE OR REPLACE FUNCTION identrail_rls_tenant_matches(row_tenant TEXT)
+RETURNS BOOLEAN
+LANGUAGE SQL
+STABLE
+AS $$
+    SELECT
+        COALESCE(current_setting('identrail.rls_enforce', true), 'off') <> 'on'
+        OR (
+            NULLIF(current_setting('identrail.tenant_id', true), '') IS NOT NULL
+            AND row_tenant = current_setting('identrail.tenant_id', true)
+        );
+$$;
+
+ALTER TABLE tenancy_organizations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tenancy_organizations FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenancy_organizations_scope_isolation ON tenancy_organizations;
+CREATE POLICY tenancy_organizations_scope_isolation ON tenancy_organizations
+USING (identrail_rls_tenant_matches(tenant_id))
+WITH CHECK (identrail_rls_tenant_matches(tenant_id));
+
+ALTER TABLE tenancy_workspaces ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tenancy_workspaces FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenancy_workspaces_scope_isolation ON tenancy_workspaces;
+CREATE POLICY tenancy_workspaces_scope_isolation ON tenancy_workspaces
+USING (identrail_rls_scope_matches(tenant_id, workspace_id))
+WITH CHECK (identrail_rls_scope_matches(tenant_id, workspace_id));
+
+ALTER TABLE tenancy_workspace_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tenancy_workspace_members FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenancy_workspace_members_scope_isolation ON tenancy_workspace_members;
+CREATE POLICY tenancy_workspace_members_scope_isolation ON tenancy_workspace_members
+USING (identrail_rls_scope_matches(tenant_id, workspace_id))
+WITH CHECK (identrail_rls_scope_matches(tenant_id, workspace_id));
+
+ALTER TABLE tenancy_projects ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tenancy_projects FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenancy_projects_scope_isolation ON tenancy_projects;
+CREATE POLICY tenancy_projects_scope_isolation ON tenancy_projects
+USING (identrail_rls_scope_matches(tenant_id, workspace_id))
+WITH CHECK (identrail_rls_scope_matches(tenant_id, workspace_id));
+
+ALTER TABLE tenancy_connectors ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tenancy_connectors FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenancy_connectors_scope_isolation ON tenancy_connectors;
+CREATE POLICY tenancy_connectors_scope_isolation ON tenancy_connectors
+USING (identrail_rls_scope_matches(tenant_id, workspace_id))
+WITH CHECK (identrail_rls_scope_matches(tenant_id, workspace_id));
+
+ALTER TABLE tenancy_connector_states ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tenancy_connector_states FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenancy_connector_states_scope_isolation ON tenancy_connector_states;
+CREATE POLICY tenancy_connector_states_scope_isolation ON tenancy_connector_states
+USING (identrail_rls_scope_matches(tenant_id, workspace_id))
+WITH CHECK (identrail_rls_scope_matches(tenant_id, workspace_id));
+
+ALTER TABLE tenancy_scan_policies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tenancy_scan_policies FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenancy_scan_policies_scope_isolation ON tenancy_scan_policies;
+CREATE POLICY tenancy_scan_policies_scope_isolation ON tenancy_scan_policies
+USING (identrail_rls_scope_matches(tenant_id, workspace_id))
+WITH CHECK (identrail_rls_scope_matches(tenant_id, workspace_id));
+
+ALTER TABLE tenancy_connector_secret_envelopes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tenancy_connector_secret_envelopes FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenancy_connector_secret_envelopes_scope_isolation ON tenancy_connector_secret_envelopes;
+CREATE POLICY tenancy_connector_secret_envelopes_scope_isolation ON tenancy_connector_secret_envelopes
+USING (identrail_rls_scope_matches(tenant_id, workspace_id))
+WITH CHECK (identrail_rls_scope_matches(tenant_id, workspace_id));

--- a/migrations/000015_tenancy_connector_rls_scope_enforcement.up.sql
+++ b/migrations/000015_tenancy_connector_rls_scope_enforcement.up.sql
@@ -22,8 +22,8 @@ ALTER TABLE tenancy_workspaces ENABLE ROW LEVEL SECURITY;
 ALTER TABLE tenancy_workspaces FORCE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS tenancy_workspaces_scope_isolation ON tenancy_workspaces;
 CREATE POLICY tenancy_workspaces_scope_isolation ON tenancy_workspaces
-USING (identrail_rls_scope_matches(tenant_id, workspace_id))
-WITH CHECK (identrail_rls_scope_matches(tenant_id, workspace_id));
+USING (identrail_rls_tenant_matches(tenant_id))
+WITH CHECK (identrail_rls_tenant_matches(tenant_id));
 
 ALTER TABLE tenancy_workspace_members ENABLE ROW LEVEL SECURITY;
 ALTER TABLE tenancy_workspace_members FORCE ROW LEVEL SECURITY;

--- a/migrations/000015_tenancy_connector_rls_scope_guardrails.up.sql
+++ b/migrations/000015_tenancy_connector_rls_scope_guardrails.up.sql
@@ -22,8 +22,8 @@ ALTER TABLE tenancy_workspaces ENABLE ROW LEVEL SECURITY;
 ALTER TABLE tenancy_workspaces FORCE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS tenancy_workspaces_scope_isolation ON tenancy_workspaces;
 CREATE POLICY tenancy_workspaces_scope_isolation ON tenancy_workspaces
-USING (identrail_rls_scope_matches(tenant_id, workspace_id))
-WITH CHECK (identrail_rls_scope_matches(tenant_id, workspace_id));
+USING (identrail_rls_tenant_matches(tenant_id))
+WITH CHECK (identrail_rls_tenant_matches(tenant_id));
 
 ALTER TABLE tenancy_workspace_members ENABLE ROW LEVEL SECURITY;
 ALTER TABLE tenancy_workspace_members FORCE ROW LEVEL SECURITY;


### PR DESCRIPTION
Fixes #678

## Summary
- add a new migration to enforce row-level security policies on tenancy and connector persistence tables
- add tenant-only RLS helper for organizations and scope-based policies for workspace/project/connector/state/policy/envelope tables
- update deployment defaults to enable `IDENTRAIL_POSTGRES_RLS_ENFORCED` in Kubernetes and Helm manifests
- add migration and security-warning tests for the new enforcement path

## Why
- tenancy and connector tables had no database-level scope policies, leaving defense-in-depth gaps
- deployment defaults had RLS enforcement disabled in production-style manifests

## Impact and risk
- database enforces tenant/workspace scope isolation for app-mode tenancy and connector data
- production manifests now default to enabled RLS enforcement
- local/test environments can still override the setting explicitly when needed

## Validation
- `go test ./internal/db ./internal/config`
- `helm lint deploy/helm/identrail`

## Checklist
- [x] Scope is focused and free of unrelated changes
- [x] New/changed behavior has test coverage
- [x] CI-relevant checks were run locally for touched areas
- [x] No secrets or credentials are present in code, tests, or logs

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces PostgreSQL RLS for tenancy and connector tables and enables it by default in deploy manifests. Fixes #678 by closing RLS gaps, keeping workspace discovery tenant-scoped, and allowing tenant-wide workspace listing under RLS.

- **New Features**
  - Migration 000015: add `identrail_rls_tenant_matches`; enable and force RLS; tenant-scoped policy for `tenancy_workspaces`; scope policies for organizations, workspace_members, projects, connectors, connector_states, scan_policies, and connector_secret_envelopes.
  - Defaults: set `IDENTRAIL_POSTGRES_RLS_ENFORCED=true` in Helm.
  - Safety: warn when RLS enforcement is off; add tests for migration, workspace policy, and the warning.

- **Migration**
  - Apply DB migration 000015.
  - For local/test, set `IDENTRAIL_POSTGRES_RLS_ENFORCED=false` if you need to disable enforcement.

<sup>Written for commit 08f415ff8efcd734a03df269617d60dc900ba7f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

