### PR TITLE
Add Helm NetworkPolicy PDB and autoscaling controls

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -33,5 +33,6 @@ This chart is the Kubernetes deployment baseline for Identrail.
 - `IDENTRAIL_K8S_SOURCE` defaults to `fixture` to avoid requiring a `kubectl` binary in the default backend image. For Kubernetes provider deployments, set `IDENTRAIL_K8S_SOURCE=kubectl` and use an image that includes `kubectl`.
 - Enable web deployment by setting `web.enabled=true`.
 - Enable ingress by setting `ingress.enabled=true`.
+- Optional production controls are available through `networkPolicy.enabled`, `podDisruptionBudget.api.enabled`, and `autoscaling.*.enabled`; tune them for the target cluster before enabling.
 - `IDENTRAIL_AUDIT_LOG_FILE` is empty by default. If you enable it, mount a writable path for the container user.
 - `IDENTRAIL_CONNECTOR_SECRET_KEYS` should be set for durable connector credential storage. If omitted, connector secret envelopes use an ephemeral in-memory key suitable only for local/test runs.

--- a/deploy/helm/identrail/templates/hpa.yaml
+++ b/deploy/helm/identrail/templates/hpa.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.autoscaling.api.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "identrail.fullname" . }}-api
+  labels:
+    {{- include "identrail.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "identrail.fullname" . }}-api
+  minReplicas: {{ .Values.autoscaling.api.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.api.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.api.targetCPUUtilizationPercentage }}
+{{- end }}
+{{- if and .Values.web.enabled .Values.autoscaling.web.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "identrail.fullname" . }}-web
+  labels:
+    {{- include "identrail.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "identrail.fullname" . }}-web
+  minReplicas: {{ .Values.autoscaling.web.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.web.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.web.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/deploy/helm/identrail/templates/networkpolicy.yaml
+++ b/deploy/helm/identrail/templates/networkpolicy.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "identrail.fullname" . }}-default-deny
+  labels:
+    {{- include "identrail.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+{{- end }}

--- a/deploy/helm/identrail/templates/pdb.yaml
+++ b/deploy/helm/identrail/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.podDisruptionBudget.api.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "identrail.fullname" . }}-api
+  labels:
+    {{- include "identrail.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.api.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "identrail.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api
+{{- end }}

--- a/deploy/helm/identrail/values.yaml
+++ b/deploy/helm/identrail/values.yaml
@@ -116,6 +116,26 @@ serviceAccount:
   annotations: {}
   name: ""
 
+networkPolicy:
+  enabled: false
+
+podDisruptionBudget:
+  api:
+    enabled: false
+    minAvailable: 1
+
+autoscaling:
+  api:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 70
+  web:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 70
+
 config:
   IDENTRAIL_SERVICE_NAME: identrail
   IDENTRAIL_LOG_LEVEL: info


### PR DESCRIPTION
Fixes #701

## Summary
- Adds opt-in Helm values and templates for NetworkPolicy, API PDB, and API/web HPA.
- Documents tuning these production controls before enabling.

## Impact and risk
- Keeps the change scoped to the deployment hardening item tracked in #701.
- Uses conservative defaults or documentation-only guidance where runtime behavior is environment-specific.

## Validation performed
- helm lint deploy/helm/identrail
- git diff --check

## Review readiness
- [x] Scope is focused and free of unrelated changes
- [x] Docs updated when operator-facing behavior changed
- [x] No secrets or credentials are present

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt‑in Helm controls for `NetworkPolicy`, API `PodDisruptionBudget`, and CPU‑based `HorizontalPodAutoscaler` (API and web) to harden deployments and enable autoscaling. Defaults are off; tune per cluster before enabling.

- **New Features**
  - Default‑deny `NetworkPolicy` (Ingress + Egress) template.
  - `HorizontalPodAutoscaler` for API and web (`autoscaling/v2`, CPU utilization).
  - API `PodDisruptionBudget`.
  - New values in `values.yaml` and a README note on enabling.

- **Migration**
  - Default‑deny: set `networkPolicy.enabled=true` and add allow rules as needed.
  - API PDB: set `podDisruptionBudget.api.enabled=true` and `podDisruptionBudget.api.minAvailable`.
  - HPA: set `autoscaling.api.enabled=true` and/or `autoscaling.web.enabled=true`, configure min/max replicas and `targetCPUUtilizationPercentage` (web also requires `web.enabled=true`).

<sup>Written for commit 3cb50172470933f661a06f5f803ff861190d19d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

