### PR TITLE
Fixes #658: Protect metrics endpoint with authenticated scope checks

### DIFF
--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -305,7 +305,9 @@ paths:
       tags: [Health]
       summary: Prometheus metrics endpoint
       operationId: metrics
-      security: []
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
       responses:
         "200":
           description: Prometheus text exposition format

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -154,7 +154,12 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		})
 	})
 
-	r.GET("/metrics", gin.WrapH(promhttp.HandlerFor(registry, promhttp.HandlerOpts{})))
+	r.GET(
+		"/metrics",
+		apiKeyAuthMiddleware(opts.APIKeys, opts.APIKeyScopes, opts.OIDCTokenVerifier, opts.OIDCWriteScopes),
+		requireMetricsScopeMiddleware(opts.WriteAPIKeys, opts.APIKeyScopes),
+		gin.WrapH(promhttp.HandlerFor(registry, promhttp.HandlerOpts{})),
+	)
 
 	r.POST("/webhooks/github", func(c *gin.Context) {
 		if svc == nil {
@@ -2425,6 +2430,25 @@ func rateLimitKey(c *gin.Context) string {
 		return ip + "|bearer"
 	}
 	return ip + "|anon"
+}
+
+func requireMetricsScopeMiddleware(writeKeys []string, scopedKeys map[string][]string) gin.HandlerFunc {
+	normalizedWriteKeys := normalizeKeyList(writeKeys)
+	return func(c *gin.Context) {
+		roles := policyRolesFromAuth(c, normalizedWriteKeys, scopedKeys)
+		allowed := false
+		for _, role := range roles {
+			if role == scopeWrite || role == scopeAdmin {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			return
+		}
+		c.Next()
+	}
 }
 
 func auditLogMiddleware(logger *zap.Logger, sink audit.AuditSink, fingerprinter *audit.Fingerprinter) gin.HandlerFunc {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -156,6 +156,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 
 	r.GET(
 		"/metrics",
+		rateLimitMiddleware(opts.RateLimitRPM, opts.RateLimitBurst),
 		apiKeyAuthMiddleware(
 			opts.APIKeys,
 			opts.APIKeyScopes,

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -156,7 +156,16 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 
 	r.GET(
 		"/metrics",
-		apiKeyAuthMiddleware(opts.APIKeys, opts.APIKeyScopes, opts.OIDCTokenVerifier, opts.OIDCWriteScopes),
+		apiKeyAuthMiddleware(
+			opts.APIKeys,
+			opts.APIKeyScopes,
+			opts.APIKeyScopeBindings,
+			opts.OIDCTokenVerifier,
+			opts.OIDCWriteScopes,
+			opts.AuditSink,
+			opts.AuditFingerprinter,
+			logger,
+		),
 		requireMetricsScopeMiddleware(opts.WriteAPIKeys, opts.APIKeyScopes),
 		gin.WrapH(promhttp.HandlerFor(registry, promhttp.HandlerOpts{})),
 	)

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -160,6 +160,51 @@ func TestRouterReadyzWithDependencyFailure(t *testing.T) {
 	assertServiceStatusBody(t, w.Body.Bytes(), "not_ready")
 }
 
+func TestRouterMetricsRequiresAuthentication(t *testing.T) {
+	logger := zap.NewNop()
+	metrics := telemetry.NewMetrics()
+	r := NewRouter(logger, metrics, nil, RouterOptions{
+		APIKeys: []string{"metrics-key"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected metrics endpoint to require auth, got %d", w.Code)
+	}
+}
+
+func TestRouterMetricsRequiresWriteOrAdminScope(t *testing.T) {
+	logger := zap.NewNop()
+	metrics := telemetry.NewMetrics()
+	r := NewRouter(logger, metrics, nil, RouterOptions{
+		APIKeyScopes: map[string][]string{
+			"reader-key": {scopeRead},
+			"writer-key": {scopeWrite},
+		},
+	})
+
+	readReq := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	readReq.Header.Set("X-API-Key", "reader-key")
+	readW := httptest.NewRecorder()
+	r.ServeHTTP(readW, readReq)
+	if readW.Code != http.StatusForbidden {
+		t.Fatalf("expected read-only scoped key denied on metrics endpoint, got %d", readW.Code)
+	}
+
+	writeReq := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	writeReq.Header.Set("X-API-Key", "writer-key")
+	writeW := httptest.NewRecorder()
+	r.ServeHTTP(writeW, writeReq)
+	if writeW.Code != http.StatusOK {
+		t.Fatalf("expected write scoped key allowed on metrics endpoint, got %d", writeW.Code)
+	}
+	if strings.TrimSpace(writeW.Body.String()) == "" {
+		t.Fatal("expected metrics response body")
+	}
+}
+
 func TestRouterCORSDisabledByDefault(t *testing.T) {
 	logger := zap.NewNop()
 	metrics := telemetry.NewMetrics()

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -175,6 +175,32 @@ func TestRouterMetricsRequiresAuthentication(t *testing.T) {
 	}
 }
 
+func TestRouterMetricsRateLimitAppliesBeforeAuth(t *testing.T) {
+	logger := zap.NewNop()
+	metrics := telemetry.NewMetrics()
+	r := NewRouter(logger, metrics, nil, RouterOptions{
+		APIKeys:        []string{"metrics-key"},
+		RateLimitRPM:   1,
+		RateLimitBurst: 1,
+	})
+
+	first := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	first.RemoteAddr = "127.0.0.1:30001"
+	w1 := httptest.NewRecorder()
+	r.ServeHTTP(w1, first)
+	if w1.Code != http.StatusUnauthorized {
+		t.Fatalf("expected first unauthorized metrics request to return 401, got %d", w1.Code)
+	}
+
+	second := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	second.RemoteAddr = "127.0.0.1:30001"
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, second)
+	if w2.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected second unauthorized metrics request to return 429, got %d", w2.Code)
+	}
+}
+
 func TestRouterMetricsRequiresWriteOrAdminScope(t *testing.T) {
 	logger := zap.NewNop()
 	metrics := telemetry.NewMetrics()


### PR DESCRIPTION
Fixes #658

## What changed
- Protected `GET /metrics` with API key or bearer authentication.
- Added scope gating so only write/admin-capable principals can access metrics.
- Added router tests for unauthenticated denial, read-scope denial, and write-scope success.
- Updated OpenAPI to document `/metrics` as an authenticated endpoint.

## Why
- Removes public unauthenticated access to operational telemetry.
- Reduces reconnaissance surface by requiring authenticated access before metrics exposition.

## Impact and risk
- Unauthenticated `/metrics` requests now fail.
- Read-only API keys can no longer scrape metrics; write/admin-capable principals can.

## Validation
- `go test ./internal/api`
- `go test ./...`

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secures the `/metrics` endpoint with authentication, scope checks, and pre-auth rate limiting. Only write or admin principals can read metrics; public access removed (Fixes #658).

- **Bug Fixes**
  - Require API key or Bearer token on `GET /metrics` (401 if missing); enforce write/admin scope (403 for read-only).
  - Apply rate limiting before auth checks (429 on bursts, including unauthenticated requests).
  - Update OpenAPI to require `ApiKeyAuth` or `BearerAuth`; add router tests for 401/403/429/200 and non-empty metrics body.

<sup>Written for commit 27db209a6da3fe64aee1f01c2d4429bc4d837280. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

