### PR TITLE
Separate systemd migrations from API and worker

### DIFF
--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -25,3 +25,5 @@ Use this for VM or bare-metal Linux hosts.
 Run `identrail-migrations` once before starting or upgrading the API and worker units. Keep
 `IDENTRAIL_RUN_MIGRATIONS=false` in the shared environment file so long-running services do
 not race each other on schema changes.
+
+The migration unit is intentionally manual-only; avoid enabling it at boot to prevent migrations from running automatically during every startup. Run it explicitly once before enabling long-running services.

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -14,8 +14,14 @@ Use this for VM or bare-metal Linux hosts.
    - `migrations/` to `/opt/identrail/migrations`
    - `testdata/` to `/opt/identrail/testdata`
 4. Install units:
+   - `cp deploy/systemd/identrail-migrations.service /etc/systemd/system/`
    - `cp deploy/systemd/identrail-api.service /etc/systemd/system/`
    - `cp deploy/systemd/identrail-worker.service /etc/systemd/system/`
 5. Start services:
    - `systemctl daemon-reload`
+   - `systemctl start identrail-migrations`
    - `systemctl enable --now identrail-api identrail-worker`
+
+Run `identrail-migrations` once before starting or upgrading the API and worker units. Keep
+`IDENTRAIL_RUN_MIGRATIONS=false` in the shared environment file so long-running services do
+not race each other on schema changes.

--- a/deploy/systemd/identrail-migrations.service
+++ b/deploy/systemd/identrail-migrations.service
@@ -8,16 +8,11 @@ Type=oneshot
 User=identrail
 Group=identrail
 EnvironmentFile=/etc/identrail/identrail.env
-Environment=IDENTRAIL_RUN_MIGRATIONS=true
-Environment=IDENTRAIL_RUN_MIGRATIONS_ONLY=true
 WorkingDirectory=/opt/identrail
-ExecStart=/usr/local/bin/identrail-server
+ExecStart=/usr/bin/env IDENTRAIL_RUN_MIGRATIONS=true IDENTRAIL_RUN_MIGRATIONS_ONLY=true /usr/local/bin/identrail-server
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectHome=true
 ProtectSystem=strict
 ReadWritePaths=/var/log/identrail
 LimitNOFILE=65535
-
-[Install]
-WantedBy=multi-user.target

--- a/deploy/systemd/identrail-migrations.service
+++ b/deploy/systemd/identrail-migrations.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Identrail database migrations
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=identrail
+Group=identrail
+EnvironmentFile=/etc/identrail/identrail.env
+Environment=IDENTRAIL_RUN_MIGRATIONS=true
+Environment=IDENTRAIL_RUN_MIGRATIONS_ONLY=true
+WorkingDirectory=/opt/identrail
+ExecStart=/usr/local/bin/identrail-server
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=/var/log/identrail
+LimitNOFILE=65535
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/identrail.env.example
+++ b/deploy/systemd/identrail.env.example
@@ -26,7 +26,7 @@ IDENTRAIL_LOCK_NAMESPACE=identrail
 # Required persistence
 IDENTRAIL_DATABASE_URL=postgres://identrail:replace-password@127.0.0.1:5432/identrail?sslmode=require
 IDENTRAIL_ALLOW_MEMORY_STORE=false
-IDENTRAIL_RUN_MIGRATIONS=true
+IDENTRAIL_RUN_MIGRATIONS=false
 IDENTRAIL_MIGRATIONS_DIR=/opt/identrail/migrations
 
 # Required for durable connector secret storage


### PR DESCRIPTION
Fixes #706

## Summary
- add a dedicated one-shot systemd migration unit
- keep API and worker services non-migrating by default
- document running migrations before starting long-running units

## Validation
- git diff --check

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated one-shot systemd unit to run database migrations separately from the API and worker. It’s manual-only, reads the shared env, and avoids auto-runs at boot or schema races.

- **Migration**
  - Install and run once (before starting or upgrading): `cp deploy/systemd/identrail-migrations.service /etc/systemd/system/ && systemctl daemon-reload && systemctl start identrail-migrations`.
  - Then enable services: `systemctl enable --now identrail-api identrail-worker`.
  - Keep `IDENTRAIL_RUN_MIGRATIONS=false` in `/etc/identrail/identrail.env`; the migration unit sets `IDENTRAIL_RUN_MIGRATIONS=true` and `IDENTRAIL_RUN_MIGRATIONS_ONLY=true`. Do not enable the migration unit at boot.

<sup>Written for commit a99a04c4de2291dae48bc0523a3541e3246c8cb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

