### PR TITLE
Fixes #660: Verify webhook signatures before repository routing

### DIFF
--- a/internal/api/github_connect.go
+++ b/internal/api/github_connect.go
@@ -352,16 +352,16 @@ func (s *Service) HandleGitHubWebhook(ctx context.Context, eventType string, del
 	if err := json.Unmarshal(payload, &envelope); err != nil {
 		return GitHubWebhookResult{}, ErrInvalidGitHubWebhookPayload
 	}
-	repository := normalizeGitHubRepository(envelope.Repository.FullName)
-	if repository == "" {
-		return GitHubWebhookResult{EventType: normalizedEventType}, nil
-	}
-
 	installationID := envelope.Installation.ID
 	normalizedSignature := strings.TrimSpace(signature)
 
 	if !s.verifyGitHubWebhookSignatureForInstallation(installationID, payload, normalizedSignature) {
 		return GitHubWebhookResult{}, ErrGitHubWebhookSignatureInvalid
+	}
+
+	repository := normalizeGitHubRepository(envelope.Repository.FullName)
+	if repository == "" {
+		return GitHubWebhookResult{EventType: normalizedEventType}, nil
 	}
 
 	candidates := s.lookupGitHubConnectionsByRepository(repository, installationID)

--- a/internal/api/github_connect_test.go
+++ b/internal/api/github_connect_test.go
@@ -529,6 +529,16 @@ func TestRouterGitHubWebhookEdgeCases(t *testing.T) {
 	if badJSONResp.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for invalid JSON, got %d", badJSONResp.Code)
 	}
+
+	noRepoPayload := []byte(`{"installation":{"id":1}}`)
+	noRepoReq := httptest.NewRequest(http.MethodPost, "/webhooks/github", bytes.NewReader(noRepoPayload))
+	noRepoReq.Header.Set("X-GitHub-Event", "push")
+	noRepoReq.Header.Set("X-Hub-Signature-256", "sha256=abc")
+	noRepoResp := httptest.NewRecorder()
+	r.ServeHTTP(noRepoResp, noRepoReq)
+	if noRepoResp.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for unsigned webhook payload without repository, got %d body=%s", noRepoResp.Code, noRepoResp.Body.String())
+	}
 }
 
 func TestRouterGitHubConnectCompleteErrorPaths(t *testing.T) {


### PR DESCRIPTION
Fixes #660

## What changed
- Reordered webhook handling so installation signature verification runs before repository-dependent early returns.
- Added regression coverage for repository-less webhook payloads with invalid signatures.

## Why
- Removes a success path for malformed unsigned payloads.
- Ensures webhook authentication is consistently enforced before accepting the request.

## Impact and risk
- Unsigned or invalidly signed webhook payloads without `repository.full_name` now return `401` instead of being accepted.
- Valid signed webhook behavior remains unchanged.

## Validation
- `go test ./internal/api`
- `go test ./...`

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #660 by verifying GitHub webhook signatures before any repository routing. Invalid or unsigned payloads without a repository now return 401; valid signed behavior is unchanged.

- **Bug Fixes**
  - Verify installation signature before repository-based early returns.
  - Add regression test ensuring 401 for repository-less payloads with invalid signatures.

<sup>Written for commit 65eb21470de3b05122f48cd9949afd88db88c6a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

