### PR TITLE
test(web): workspace admin api failure states

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -5,6 +5,21 @@ import { saveProductSession } from './productShell';
 
 const OIDC_PENDING_LOGIN_STORAGE_KEY = 'identrail-oidc-pending-login';
 
+function okJSON(payload: unknown) {
+  return {
+    ok: true,
+    json: async () => payload
+  };
+}
+
+function errorJSON(status: number, error: string) {
+  return {
+    ok: false,
+    status,
+    json: async () => ({ error })
+  };
+}
+
 function makeJWT(payload: Record<string, unknown>): string {
   const header = btoa(JSON.stringify({ alg: 'RS256', typ: 'JWT' }))
     .replace(/\+/g, '-')
@@ -459,6 +474,121 @@ describe('App', () => {
     await waitFor(() => {
       expect(window.location.pathname).toBe('/app/default/payments/workspaces');
     });
+  });
+
+  it('shows workspace admin load errors without redirecting to login', async () => {
+    saveProductSession({
+      tenantID: 'default',
+      workspaceID: 'default'
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(errorJSON(403, 'workspace access denied')));
+
+    window.history.pushState({}, '', '/app/default/default/workspaces');
+    render(<App />);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/workspace access denied/i);
+    expect(window.location.pathname).toBe('/app/default/default/workspaces');
+    expect(window.location.pathname).not.toBe('/app/login');
+  });
+
+  it('keeps existing member state when invite action fails', async () => {
+    saveProductSession({
+      tenantID: 'default',
+      workspaceID: 'default'
+    });
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        okJSON({
+          principal: { type: 'subject', id: 'owner-user' },
+          roles: ['owner'],
+          scopes: ['read', 'write', 'admin'],
+          scope: { tenant_id: 'default', workspace_id: 'default' },
+          active_workspace: {
+            workspace: {
+              tenant_id: 'default',
+              workspace_id: 'default',
+              display_name: 'Default',
+              slug: 'default',
+              created_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-01T00:00:00Z'
+            },
+            member: {
+              tenant_id: 'default',
+              workspace_id: 'default',
+              member_id: 'member-owner-user',
+              user_id: 'owner-user',
+              email: 'owner@example.com',
+              role: 'owner',
+              status: 'active',
+              joined_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-01T00:00:00Z'
+            },
+            is_active: true
+          },
+          workspaces: [
+            {
+              workspace: {
+                tenant_id: 'default',
+                workspace_id: 'default',
+                display_name: 'Default',
+                slug: 'default',
+                created_at: '2026-01-01T00:00:00Z',
+                updated_at: '2026-01-01T00:00:00Z'
+              },
+              member: {
+                tenant_id: 'default',
+                workspace_id: 'default',
+                member_id: 'member-owner-user',
+                user_id: 'owner-user',
+                email: 'owner@example.com',
+                role: 'owner',
+                status: 'active',
+                joined_at: '2026-01-01T00:00:00Z',
+                updated_at: '2026-01-01T00:00:00Z'
+              },
+              is_active: true
+            }
+          ]
+        })
+      )
+      .mockResolvedValueOnce(
+        okJSON({
+          items: [
+            {
+              tenant_id: 'default',
+              workspace_id: 'default',
+              member_id: 'member-owner-user',
+              user_id: 'owner-user',
+              email: 'owner@example.com',
+              role: 'owner',
+              status: 'active',
+              joined_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-01T00:00:00Z'
+            }
+          ]
+        })
+      )
+      .mockResolvedValueOnce(errorJSON(500, 'invite rejected'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    window.history.pushState({}, '', '/app/default/default/workspaces');
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { level: 2, name: /Members and roles/i })).toBeInTheDocument();
+    expect(screen.getByText('owner-user')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('User ID'), { target: { value: 'analyst@example.com' } });
+    fireEvent.change(screen.getByLabelText('Email (optional)'), { target: { value: 'analyst@example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: /Invite member/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/invite rejected/i);
+    expect(screen.getByText('owner-user')).toBeInTheDocument();
+    expect(screen.queryByText('member-analyst-example-com')).not.toBeInTheDocument();
+    expect(window.location.pathname).toBe('/app/default/default/workspaces');
   });
 
   it('redirects expired oidc sessions to login with re-auth prompt', async () => {


### PR DESCRIPTION
Fixes #759

## Summary
- add frontend route test coverage for workspace admin initial-load API failure handling (`role=alert` + no login redirect)
- add action-failure coverage ensuring failed member invite does not mutate existing workspace member state
- keep assertions focused on safe, actionable failure messaging and route/session stability

## Validation
- npm --prefix web exec vitest -- --run web/src/App.test.tsx -t "workspace admin load errors|invite action fails" *(fails in this environment because web test dependencies are not installed: `@testing-library/react` missing)*

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds frontend tests for workspace admin API failure states to ensure clear alerts and stable routing. Covers invite failures so member state isn’t mutated.

- **New Tests**
  - Initial workspace admin load error: shows `role=alert` message and does not redirect to login.
  - Invite action failure: shows error and keeps the existing member list unchanged.

<sup>Written for commit 1b70c6ef457e55d4f51f3ef2ae78d2e3eabe4375. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

