### PR TITLE
Fix store parity for scan limits and blank provider filters

### DIFF
--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -413,6 +413,9 @@ func (m *MemoryStore) ListScans(ctx context.Context, limit int) ([]ScanRecord, e
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	if limit <= 0 {
+		limit = 100
+	}
 	scope, err := RequireScope(ctx)
 	if err != nil {
 		return nil, err
@@ -428,7 +431,7 @@ func (m *MemoryStore) ListScans(ctx context.Context, limit int) ([]ScanRecord, e
 	sort.Slice(records, func(i, j int) bool {
 		return records[i].StartedAt.After(records[j].StartedAt)
 	})
-	if limit > 0 && len(records) > limit {
+	if len(records) > limit {
 		records = records[:limit]
 	}
 	return records, nil
@@ -439,6 +442,9 @@ func (m *MemoryStore) ListFindings(ctx context.Context, limit int) ([]domain.Fin
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	if limit <= 0 {
+		limit = 100
+	}
 	scope, err := RequireScope(ctx)
 	if err != nil {
 		return nil, err
@@ -454,7 +460,7 @@ func (m *MemoryStore) ListFindings(ctx context.Context, limit int) ([]domain.Fin
 	sort.Slice(result, func(i, j int) bool {
 		return result[i].CreatedAt.After(result[j].CreatedAt)
 	})
-	if limit > 0 && len(result) > limit {
+	if len(result) > limit {
 		result = result[:limit]
 	}
 	return result, nil
@@ -465,6 +471,9 @@ func (m *MemoryStore) ListFindingsByScan(ctx context.Context, scanID string, lim
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	if limit <= 0 {
+		limit = 100
+	}
 	scope, err := RequireScope(ctx)
 	if err != nil {
 		return nil, err
@@ -484,7 +493,7 @@ func (m *MemoryStore) ListFindingsByScan(ctx context.Context, scanID string, lim
 	sort.Slice(result, func(i, j int) bool {
 		return result[i].CreatedAt.After(result[j].CreatedAt)
 	})
-	if limit > 0 && len(result) > limit {
+	if len(result) > limit {
 		result = result[:limit]
 	}
 	return result, nil

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -418,6 +419,60 @@ func TestMemoryStoreScanQueueLifecycle(t *testing.T) {
 	}
 	if _, err := store.ClaimNextQueuedScan(defaultScopeContext(), "aws"); err == nil {
 		t.Fatal("expected no queued scan remaining")
+	}
+}
+
+func TestMemoryStoreCountQueuedScansBlankProviderIsWildcard(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 3, 21, 9, 0, 0, 0, time.UTC)
+	if _, err := store.CreateQueuedScan(defaultScopeContext(), "aws", now); err != nil {
+		t.Fatalf("create aws queued scan: %v", err)
+	}
+	if _, err := store.CreateQueuedScan(defaultScopeContext(), "gcp", now.Add(time.Minute)); err != nil {
+		t.Fatalf("create gcp queued scan: %v", err)
+	}
+
+	count, err := store.CountQueuedScans(defaultScopeContext(), "")
+	if err != nil {
+		t.Fatalf("count queued scans wildcard: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected wildcard queued count 2, got %d", count)
+	}
+}
+
+func TestMemoryStoreNonPositiveLimitsUseDefaultPageSize(t *testing.T) {
+	store := NewMemoryStore()
+	base := time.Date(2026, 3, 21, 9, 0, 0, 0, time.UTC)
+	for i := 0; i < 105; i++ {
+		scan, err := store.CreateScan(defaultScopeContext(), "aws", base.Add(time.Duration(i)*time.Minute))
+		if err != nil {
+			t.Fatalf("create scan %d: %v", i, err)
+		}
+		if err := store.UpsertFindings(defaultScopeContext(), scan.ID, []domain.Finding{{
+			ID:        fmt.Sprintf("finding-%03d", i),
+			Type:      domain.FindingOwnerless,
+			Severity:  domain.SeverityHigh,
+			CreatedAt: base.Add(time.Duration(i) * time.Minute),
+		}}); err != nil {
+			t.Fatalf("upsert finding %d: %v", i, err)
+		}
+	}
+
+	scans, err := store.ListScans(defaultScopeContext(), 0)
+	if err != nil {
+		t.Fatalf("list scans default page: %v", err)
+	}
+	if len(scans) != 100 {
+		t.Fatalf("expected default scan page size 100, got %d", len(scans))
+	}
+
+	findings, err := store.ListFindings(defaultScopeContext(), 0)
+	if err != nil {
+		t.Fatalf("list findings default page: %v", err)
+	}
+	if len(findings) != 100 {
+		t.Fatalf("expected default finding page size 100, got %d", len(findings))
 	}
 }
 

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -287,7 +287,7 @@ func (p *PostgresStore) CountQueuedScans(ctx context.Context, provider string) (
 		 FROM scans
 		 WHERE tenant_id = $1
 		   AND workspace_id = $2
-		   AND provider = $3
+		   AND ($3 = '' OR provider = $3)
 		   AND status = 'queued'`,
 		scope.TenantID,
 		scope.WorkspaceID,
@@ -739,7 +739,7 @@ func (p *PostgresStore) ListFindingTriageEvents(ctx context.Context, findingID s
 // ListScans returns latest scans first.
 func (p *PostgresStore) ListScans(ctx context.Context, limit int) ([]ScanRecord, error) {
 	if limit <= 0 {
-		limit = 20
+		limit = 100
 	}
 	scope, err := RequireScope(ctx)
 	if err != nil {

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -182,6 +182,32 @@ func TestPostgresStoreListScansAndFindings(t *testing.T) {
 	}
 }
 
+func TestPostgresStoreListScansDefaultsNonPositiveLimitToOneHundred(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	now := time.Now().UTC()
+	rows := sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "provider", "status", "started_at", "finished_at", "asset_count", "finding_count", "error_message"}).
+		AddRow("scan-1", "default", "default", "aws", "completed", now, now, 1, 1, "")
+	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, provider, status").WithArgs("default", "default", 100).WillReturnRows(rows)
+
+	scans, err := store.ListScans(defaultScopeContext(), 0)
+	if err != nil {
+		t.Fatalf("list scans default limit: %v", err)
+	}
+	if len(scans) != 1 {
+		t.Fatalf("expected one scan, got %d", len(scans))
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestPostgresStoreGetScanAndFindingsByScan(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -657,7 +683,7 @@ func TestPostgresStoreScanQueueLifecycle(t *testing.T) {
 		 FROM scans
 		 WHERE tenant_id = $1
 		   AND workspace_id = $2
-		   AND provider = $3
+		   AND ($3 = '' OR provider = $3)
 		   AND status = 'queued'`)).
 		WithArgs("default", "default", "aws").
 		WillReturnRows(countRows)
@@ -697,6 +723,37 @@ func TestPostgresStoreRequiresScopeContext(t *testing.T) {
 	store := NewPostgresStoreWithDB(db)
 	if _, err := store.ListScans(context.Background(), 10); !errors.Is(err, ErrScopeRequired) {
 		t.Fatalf("expected ErrScopeRequired, got %v", err)
+	}
+}
+
+func TestPostgresStoreCountQueuedScansBlankProviderIsWildcard(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	countRows := sqlmock.NewRows([]string{"count"}).AddRow(2)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*)
+		 FROM scans
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND ($3 = '' OR provider = $3)
+		   AND status = 'queued'`)).
+		WithArgs("default", "default", "").
+		WillReturnRows(countRows)
+
+	count, err := store.CountQueuedScans(defaultScopeContext(), "")
+	if err != nil {
+		t.Fatalf("count queued scans wildcard: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected wildcard queued count 2, got %d", count)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
 	}
 }
 


### PR DESCRIPTION
Fixes #780

## Summary
- align in-memory and Postgres queued-scan counting when the provider filter is blank
- make non-positive scan and finding limits use the same default page size in both adapters
- add adapter tests that lock the shared semantics in place

## Testing
- go test ./internal/db ./internal/api

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the memory and Postgres stores so queued-scan counting and pagination behave the same. Blank provider filters now count all queued scans, and non‑positive limits default to 100 across listing APIs.

- **Bug Fixes**
  - Treat blank provider as a wildcard in queued-scan counts (Postgres now matches memory).
  - Default limit of 100 when limit <= 0 for scans, findings, and findings-by-scan in both adapters.
  - Added tests for wildcard counting and default pagination.

<sup>Written for commit 8c728bf92cb7f76f7cbc660aadc998e948024cd6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

