### PR TITLE
updated to the latest development.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Prerequisites:
 
 Recommended first steps:
 ```bash
-git clone https://github.com/Oluwatobi-Mustapha/identrail.git
+git clone https://github.com/identrail/identrail.git
 cd identrail
 go mod download
 npm ci --prefix web
@@ -51,7 +51,7 @@ npm ci --prefix web
 
 ## Development Workflow
 
-1. Create a branch from `main`.
+1. Create a branch from `dev`.
 2. Keep each PR focused on one logical change.
 3. Add or update tests for behavior changes.
 4. Update docs and `CHANGELOG.md` when user-facing or operator-facing behavior changes.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated CONTRIBUTING to reflect the current repository location and branching workflow. Contributors now clone from `identrail/identrail` and branch from `dev`.

- **Bug Fixes**
  - Updated clone URL to `https://github.com/identrail/identrail.git`.
  - Switched branching guideline from `main` to `dev`.

<sup>Written for commit e404b3c9217bf0a9e0c76c01e6d948f4114d097f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

