### PR TITLE
refactor: consolidate first-non-empty helpers

### DIFF
--- a/internal/api/authz_middleware.go
+++ b/internal/api/authz_middleware.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Oluwatobi-Mustapha/identrail/internal/audit"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/telemetry"
+	"github.com/Oluwatobi-Mustapha/identrail/internal/textutil"
 	"github.com/gin-gonic/gin"
 )
 
@@ -331,13 +332,13 @@ func shouldTargetRolloutRequest(rollout db.AuthzPolicyRollout, input PolicyInput
 	if canary > 100 {
 		canary = 100
 	}
-	tenantID := firstNonEmpty(
+	tenantID := textutil.FirstNonEmptyTrimmed(
 		input.Resource.TenantID,
-		firstNonEmpty(input.Subject.TenantID, strings.TrimSpace(input.Context.Attributes[policyContextTenantIDKey])),
+		textutil.FirstNonEmptyTrimmed(input.Subject.TenantID, strings.TrimSpace(input.Context.Attributes[policyContextTenantIDKey])),
 	)
-	workspaceID := firstNonEmpty(
+	workspaceID := textutil.FirstNonEmptyTrimmed(
 		input.Resource.WorkspaceID,
-		firstNonEmpty(input.Subject.WorkspaceID, strings.TrimSpace(input.Context.Attributes[policyContextWorkspaceIDKey])),
+		textutil.FirstNonEmptyTrimmed(input.Subject.WorkspaceID, strings.TrimSpace(input.Context.Attributes[policyContextWorkspaceIDKey])),
 	)
 
 	if len(rollout.TenantAllowlist) > 0 && !containsStringExact(rollout.TenantAllowlist, tenantID) {
@@ -437,13 +438,13 @@ func setAuthzDecisionContext(c *gin.Context, policySetID string, policyVersion i
 	if normalizedRolloutMode == "" {
 		normalizedRolloutMode = db.AuthzPolicyRolloutModeDisabled
 	}
-	tenantID := firstNonEmpty(
+	tenantID := textutil.FirstNonEmptyTrimmed(
 		input.Resource.TenantID,
-		firstNonEmpty(input.Subject.TenantID, strings.TrimSpace(input.Context.Attributes[policyContextTenantIDKey])),
+		textutil.FirstNonEmptyTrimmed(input.Subject.TenantID, strings.TrimSpace(input.Context.Attributes[policyContextTenantIDKey])),
 	)
-	workspaceID := firstNonEmpty(
+	workspaceID := textutil.FirstNonEmptyTrimmed(
 		input.Resource.WorkspaceID,
-		firstNonEmpty(input.Subject.WorkspaceID, strings.TrimSpace(input.Context.Attributes[policyContextWorkspaceIDKey])),
+		textutil.FirstNonEmptyTrimmed(input.Subject.WorkspaceID, strings.TrimSpace(input.Context.Attributes[policyContextWorkspaceIDKey])),
 	)
 
 	auditDecision := audit.AuditAuthzDecision{
@@ -484,14 +485,14 @@ func buildPolicyInputFromGinContext(c *gin.Context, policy routePolicy, writeKey
 	if strings.TrimSpace(policy.ResourceIDParam) != "" {
 		resourceID = strings.TrimSpace(c.Param(policy.ResourceIDParam))
 	}
-	subjectType := firstNonEmpty(authContextString(c, "auth.principal_type"), inferPrincipalType(c))
-	subjectID := firstNonEmpty(authContextString(c, "auth.principal_id"), inferPrincipalID(c))
+	subjectType := textutil.FirstNonEmptyTrimmed(authContextString(c, "auth.principal_type"), inferPrincipalType(c))
+	subjectID := textutil.FirstNonEmptyTrimmed(authContextString(c, "auth.principal_id"), inferPrincipalID(c))
 	input := PolicyInput{
 		Subject: PolicySubject{
 			Type:        subjectType,
 			ID:          subjectID,
-			TenantID:    firstNonEmpty(authContextString(c, "auth.tenant_id"), strings.TrimSpace(scope.TenantID)),
-			WorkspaceID: firstNonEmpty(authContextString(c, "auth.workspace_id"), strings.TrimSpace(scope.WorkspaceID)),
+			TenantID:    textutil.FirstNonEmptyTrimmed(authContextString(c, "auth.tenant_id"), strings.TrimSpace(scope.TenantID)),
+			WorkspaceID: textutil.FirstNonEmptyTrimmed(authContextString(c, "auth.workspace_id"), strings.TrimSpace(scope.WorkspaceID)),
 			Roles:       policyRolesFromAuth(c, writeKeys, scopedKeys),
 		},
 		Action: strings.ToLower(strings.TrimSpace(policy.Action)),
@@ -518,13 +519,6 @@ func buildPolicyInputFromGinContext(c *gin.Context, policy routePolicy, writeKey
 		return PolicyInput{}, err
 	}
 	return input, nil
-}
-
-func firstNonEmpty(primary string, fallback string) string {
-	if strings.TrimSpace(primary) != "" {
-		return strings.TrimSpace(primary)
-	}
-	return strings.TrimSpace(fallback)
 }
 
 func inferPrincipalType(c *gin.Context) string {

--- a/internal/api/authz_simulation.go
+++ b/internal/api/authz_simulation.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Oluwatobi-Mustapha/identrail/internal/audit"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/telemetry"
+	"github.com/Oluwatobi-Mustapha/identrail/internal/textutil"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 )
@@ -130,14 +131,14 @@ func authzPolicySimulationHandler(logger *zap.Logger, store db.Store, resolver c
 func toSimulationPolicyInput(c *gin.Context, request authzPolicySimulationRequest) PolicyInput {
 	scope := db.ScopeFromContext(c.Request.Context())
 
-	subjectTenant := firstNonEmpty(request.Subject.TenantID, scope.TenantID)
-	subjectWorkspace := firstNonEmpty(request.Subject.WorkspaceID, scope.WorkspaceID)
-	resourceTenant := firstNonEmpty(request.Resource.TenantID, scope.TenantID)
-	resourceWorkspace := firstNonEmpty(request.Resource.WorkspaceID, scope.WorkspaceID)
+	subjectTenant := textutil.FirstNonEmptyTrimmed(request.Subject.TenantID, scope.TenantID)
+	subjectWorkspace := textutil.FirstNonEmptyTrimmed(request.Subject.WorkspaceID, scope.WorkspaceID)
+	resourceTenant := textutil.FirstNonEmptyTrimmed(request.Resource.TenantID, scope.TenantID)
+	resourceWorkspace := textutil.FirstNonEmptyTrimmed(request.Resource.WorkspaceID, scope.WorkspaceID)
 
 	contextAttributes := normalizeSimulationAttributes(request.Context.Attributes)
-	contextAttributes[policyContextTenantIDKey] = firstNonEmpty(contextAttributes[policyContextTenantIDKey], scope.TenantID)
-	contextAttributes[policyContextWorkspaceIDKey] = firstNonEmpty(contextAttributes[policyContextWorkspaceIDKey], scope.WorkspaceID)
+	contextAttributes[policyContextTenantIDKey] = textutil.FirstNonEmptyTrimmed(contextAttributes[policyContextTenantIDKey], scope.TenantID)
+	contextAttributes[policyContextWorkspaceIDKey] = textutil.FirstNonEmptyTrimmed(contextAttributes[policyContextWorkspaceIDKey], scope.WorkspaceID)
 
 	return PolicyInput{
 		Subject: PolicySubject{

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/domain"
+	"github.com/Oluwatobi-Mustapha/identrail/internal/textutil"
 )
 
 var awsRoleARNPattern = regexp.MustCompile(`^arn:(aws|aws-us-gov|aws-cn):iam::[0-9]{12}:role/[A-Za-z0-9+=,.@_/-]{1,512}$`)
@@ -144,7 +145,7 @@ func (s *Service) UpsertAWSConnection(ctx context.Context, workspaceID string, p
 		"account_id":             strings.TrimSpace(validation.AccountID),
 		"principal_arn":          strings.TrimSpace(validation.PrincipalARN),
 		"user_id":                strings.TrimSpace(validation.UserID),
-		"region":                 firstNonEmptyAWSValue(strings.TrimSpace(validation.Region), normalized.Region),
+		"region":                 textutil.FirstNonEmpty(strings.TrimSpace(validation.Region), normalized.Region),
 		"permission_checks":      checks,
 		"diagnostics":            copyAWSDiagnostics(validation.Diagnostics),
 		"last_validated_at":      now.Format(time.RFC3339Nano),
@@ -260,7 +261,7 @@ func awsConnectionStatusFromStored(stored db.TenancyConnectorWithState) AWSConne
 		ConnectorID:          stored.Connector.ConnectorID,
 		DisplayName:          stored.Connector.DisplayName,
 		Status:               stored.Connector.Status,
-		HealthStatus:         firstNonEmptyAWSValue(stored.State.HealthStatus, "unknown"),
+		HealthStatus:         textutil.FirstNonEmpty(stored.State.HealthStatus, "unknown"),
 		RoleARN:              awsMetadataString(metadata, "role_arn"),
 		ExternalID:           awsMetadataString(metadata, "external_id"),
 		ExternalIDConfigured: awsMetadataBool(metadata, "external_id_configured"),
@@ -318,15 +319,6 @@ func copyAWSDiagnostics(diagnostics []AWSConnectionDiagnostic) []AWSConnectionDi
 	copied := make([]AWSConnectionDiagnostic, len(diagnostics))
 	copy(copied, diagnostics)
 	return copied
-}
-
-func firstNonEmptyAWSValue(values ...string) string {
-	for _, value := range values {
-		if value != "" {
-			return value
-		}
-	}
-	return ""
 }
 
 func awsMetadataString(metadata map[string]any, key string) string {

--- a/internal/api/kubernetes_connect.go
+++ b/internal/api/kubernetes_connect.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/domain"
 	k8sprovider "github.com/Oluwatobi-Mustapha/identrail/internal/providers/kubernetes"
+	"github.com/Oluwatobi-Mustapha/identrail/internal/textutil"
 	"github.com/google/uuid"
 )
 
@@ -121,7 +122,7 @@ func (s *Service) UpsertKubernetesConnection(ctx context.Context, workspaceID st
 		DisplayName:      normalized.DisplayName,
 		Status:           status,
 		HealthStatus:     string(result.Health),
-		Context:          firstNonEmptyKubernetesValue(result.Cluster.Context, normalized.Context),
+		Context:          textutil.FirstNonEmptyTrimmed(result.Cluster.Context, normalized.Context),
 		Cluster:          strings.TrimSpace(result.Cluster.Cluster),
 		Server:           strings.TrimSpace(result.Cluster.Server),
 		GitVersion:       strings.TrimSpace(result.Cluster.GitVersion),
@@ -253,15 +254,6 @@ func firstKubernetesRemediation(diagnostics []k8sprovider.KubernetesPreflightDia
 			if remediation := strings.TrimSpace(check.Remediation); remediation != "" {
 				return remediation
 			}
-		}
-	}
-	return ""
-}
-
-func firstNonEmptyKubernetesValue(values ...string) string {
-	for _, value := range values {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			return trimmed
 		}
 	}
 	return ""

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Oluwatobi-Mustapha/identrail/internal/repoexposure"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/scheduler"
 	"github.com/Oluwatobi-Mustapha/identrail/internal/secretstore"
+	"github.com/Oluwatobi-Mustapha/identrail/internal/textutil"
 )
 
 const (
@@ -1788,13 +1789,11 @@ func (s *Service) lookupWorkspaceMemberBySubject(
 }
 
 func firstNonEmptyTag(tags map[string]string, keys ...string) string {
+	values := make([]string, 0, len(keys))
 	for _, key := range keys {
-		value := strings.TrimSpace(tags[key])
-		if value != "" {
-			return value
-		}
+		values = append(values, tags[key])
 	}
-	return ""
+	return textutil.FirstNonEmptyTrimmed(values...)
 }
 
 func (s *Service) lockKey(key string) string {

--- a/internal/providers/aws/connector_validation.go
+++ b/internal/providers/aws/connector_validation.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	api "github.com/Oluwatobi-Mustapha/identrail/internal/api"
+	"github.com/Oluwatobi-Mustapha/identrail/internal/textutil"
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
 	awscfg "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -64,7 +65,7 @@ func NewConnectionValidator(region string, profile string) *ConnectionValidator 
 
 // ValidateAWSConnection assumes the configured connector role and checks scanner-critical read permissions.
 func (v *ConnectionValidator) ValidateAWSConnection(ctx context.Context, request api.AWSConnectionValidationRequest) (api.AWSConnectionValidationResult, error) {
-	region := firstNonEmptyString(strings.TrimSpace(request.Region), v.region, "us-east-1")
+	region := textutil.FirstNonEmpty(strings.TrimSpace(request.Region), v.region, "us-east-1")
 	loadConfig := v.loadConfig
 	if loadConfig == nil {
 		loadConfig = loadAWSConnectorConfig
@@ -87,7 +88,7 @@ func (v *ConnectionValidator) ValidateAWSConnection(ctx context.Context, request
 
 	assumeInput := &sts.AssumeRoleInput{
 		RoleArn:         awsv2.String(result.RoleARN),
-		RoleSessionName: awsv2.String(firstNonEmptyString(strings.TrimSpace(request.SessionName), "identrail-connector-validation")),
+		RoleSessionName: awsv2.String(textutil.FirstNonEmpty(strings.TrimSpace(request.SessionName), "identrail-connector-validation")),
 	}
 	if externalID := strings.TrimSpace(request.ExternalID); externalID != "" {
 		assumeInput.ExternalId = awsv2.String(externalID)
@@ -289,13 +290,4 @@ func classifyAWSError(err error, fallback string) string {
 		}
 	}
 	return fallback
-}
-
-func firstNonEmptyString(values ...string) string {
-	for _, value := range values {
-		if value != "" {
-			return value
-		}
-	}
-	return ""
 }

--- a/internal/providers/aws/sdk_client.go
+++ b/internal/providers/aws/sdk_client.go
@@ -12,6 +12,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+
+	"github.com/Oluwatobi-Mustapha/identrail/internal/textutil"
 )
 
 const maxAWSPolicyPages = 100
@@ -60,7 +62,7 @@ func NewSDKIAMAPIFromAssumeRole(ctx context.Context, region string, profile stri
 	}
 	options := []func(*stscreds.AssumeRoleOptions){
 		func(options *stscreds.AssumeRoleOptions) {
-			options.RoleSessionName = firstNonEmptySDKString(strings.TrimSpace(sessionName), "identrail-recurring-scan")
+			options.RoleSessionName = textutil.FirstNonEmpty(strings.TrimSpace(sessionName), "identrail-recurring-scan")
 		},
 	}
 	if trimmedExternalID := strings.TrimSpace(externalID); trimmedExternalID != "" {
@@ -89,15 +91,6 @@ func loadSDKConfig(ctx context.Context, region string, profile string) (awsv2.Co
 // NewSDKIAMAPIFromClient creates an IAMAPI from a provided IAM SDK client.
 func NewSDKIAMAPIFromClient(client IAMSDKClient) IAMAPI {
 	return &SDKIAMAPI{client: client}
-}
-
-func firstNonEmptySDKString(values ...string) string {
-	for _, value := range values {
-		if value != "" {
-			return value
-		}
-	}
-	return ""
 }
 
 // ListRoles returns one page of roles enriched with inline and managed policy documents.

--- a/internal/textutil/textutil.go
+++ b/internal/textutil/textutil.go
@@ -1,0 +1,24 @@
+package textutil
+
+import "strings"
+
+// FirstNonEmpty returns the first non-empty string exactly as provided.
+func FirstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+// FirstNonEmptyTrimmed returns the first non-empty trimmed string.
+func FirstNonEmptyTrimmed(values ...string) string {
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/textutil/textutil_test.go
+++ b/internal/textutil/textutil_test.go
@@ -1,0 +1,31 @@
+package textutil
+
+import "testing"
+
+func TestFirstNonEmpty(t *testing.T) {
+	t.Run("returns empty when no values match", func(t *testing.T) {
+		if got := FirstNonEmpty("", "", ""); got != "" {
+			t.Fatalf("expected empty result, got %q", got)
+		}
+	})
+
+	t.Run("returns first exact non-empty value", func(t *testing.T) {
+		if got := FirstNonEmpty("", " value ", "fallback"); got != " value " {
+			t.Fatalf("expected exact first non-empty value, got %q", got)
+		}
+	})
+}
+
+func TestFirstNonEmptyTrimmed(t *testing.T) {
+	t.Run("returns empty when all values are blank", func(t *testing.T) {
+		if got := FirstNonEmptyTrimmed("", "   ", "\n\t"); got != "" {
+			t.Fatalf("expected empty result, got %q", got)
+		}
+	})
+
+	t.Run("returns first trimmed non-empty value", func(t *testing.T) {
+		if got := FirstNonEmptyTrimmed("   ", " value ", "fallback"); got != "value" {
+			t.Fatalf("expected trimmed first non-empty value, got %q", got)
+		}
+	})
+}


### PR DESCRIPTION
Fixes #752

## What changed
- added `internal/textutil` with shared helpers for exact and trimmed first-non-empty selection
- replaced duplicate helper bodies in the API, Kubernetes connector, AWS connector validation, and AWS SDK assume-role paths
- routed tag lookup and authz scope fallback logic through the shared trimmed helper
- added focused unit tests that lock the exact-vs-trimmed behavior contract

## Why
This standardizes first-non-empty behavior in one place and removes multiple near-identical implementations that could drift apart over time.

## Impact and risk
- Low-risk internal refactor
- No API contract changes
- Existing exact-return and trimmed-return behaviors are preserved explicitly

## Validation
- `go test ./internal/textutil ./internal/api ./internal/providers/aws`
- `go vet ./...`
- `go test ./... -coverprofile=coverage.out`
- `go tool cover -func=coverage.out | tail -n 1` (`total: 80.1%`)

## AI assistance
- AI-assisted: yes
- Tools used: OpenAI Codex
- Where used: `internal/api`, `internal/providers/aws`, `internal/textutil`
- Human verification performed: reviewed the full diff, ran targeted tests, ran `go vet ./...`, and reran the full Go test suite with coverage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated all “first non-empty” helpers into `internal/textutil` and refactored API, AWS, and Kubernetes code to use it. Preserves exact vs. trimmed behavior and adds unit tests to lock it in.

- **Refactors**
  - Added `internal/textutil` with `FirstNonEmpty` and `FirstNonEmptyTrimmed`.
  - Replaced duplicate helpers across `internal/api`, `internal/providers/aws`, and the Kubernetes connector.
  - Routed authz scope fallback and tag lookup through the trimmed helper.
  - Added unit tests in `internal/textutil`; no API changes.

<sup>Written for commit d58dac83cc7e70579c0239391cf30713975545c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

