### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Oluwatobi-Mustapha/identrail
+module github.com/identrail/identrail
 
 go 1.25.9
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update Go module path from `github.com/Oluwatobi-Mustapha/identrail` to `github.com/identrail/identrail` to reflect the org move. This prevents import mismatches and ensures new installs use the correct path.

- **Migration**
  - Update imports to `github.com/identrail/identrail` and run go mod tidy.

<sup>Written for commit e062f12f7d70bf116fca53a58b664afa216feaa5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

