### PR TITLE
Pin the Postgres image digest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       CI_POSTGRES_PASSWORD: ci-pg-${{ github.run_id }}-${{ github.run_attempt }}
     services:
       postgres:
-        image: postgres:16-alpine
+        image: postgres:16-alpine@sha256:4e6e670bb069649261c9c18031f0aded7bb249a5b6664ddec29c013a89310d50
         env:
           POSTGRES_USER: identrail
           POSTGRES_PASSWORD: ${{ env.CI_POSTGRES_PASSWORD }}

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -27,3 +27,13 @@ Manual setup:
 
 - API health: `curl http://localhost:8080/healthz`
 - Web UI: `http://localhost:8081`
+
+## Image Digest Updates
+
+Supporting service images are pinned by digest so local Compose and CI use the
+same reviewed image. When rotating Postgres:
+
+1. Resolve the new `postgres:16-alpine` manifest digest from the registry.
+2. Update both `deploy/docker/docker-compose.yml` and `.github/workflows/ci.yml`.
+3. Run `docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env config`.
+4. Run the Postgres-backed integration test flow before merging.

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:16-alpine@sha256:4e6e670bb069649261c9c18031f0aded7bb249a5b6664ddec29c013a89310d50
     container_name: identrail-postgres
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Fixes #949

## Summary

Pins the Postgres image used by local Docker Compose and CI integration tests to the same immutable digest, and documents the rotation process.

## Why

The app images are already digest-pinned. Pinning the supporting Postgres image closes the remaining tag-drift gap in local and CI database environments.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation

```bash
cp deploy/docker/.env.example deploy/docker/.env
docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env config >/tmp/identrail-compose-949.yml
rm -f deploy/docker/.env
rg -n "postgres:16-alpine" .github/workflows deploy/docker
git diff --check
git commit -s -m "pin postgres image digest"
```

This PR is stacked on #944 so CI evaluates against the canonical module-path fix while keeping this deployment-image diff focused. Its touched-surface checks passed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: No
- Tools used: None
- Areas where used: None
- Human verification performed: Compose config render, digest reference scan, whitespace check, pre-commit hooks during signed commit.
