### PR TITLE
Pin privileged GitHub Actions to immutable SHAs

### DIFF
--- a/.github/workflows/code-scanning-autofix.yml
+++ b/.github/workflows/code-scanning-autofix.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Process open code scanning alerts
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/dependabot-auto-triage.yml
+++ b/.github/workflows/dependabot-auto-triage.yml
@@ -19,12 +19,12 @@ jobs:
     steps:
       - name: Fetch Dependabot Metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Apply triage labels
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           PACKAGE_ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
           UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}

--- a/.github/workflows/dependabot-patch-automerge.yml
+++ b/.github/workflows/dependabot-patch-automerge.yml
@@ -19,14 +19,14 @@ jobs:
       - name: Fetch Dependabot Metadata
         id: metadata
         continue-on-error: true
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           skip-commit-verification: true
 
       - name: Enable auto-merge for patch updates
         if: steps.metadata.outcome == 'success' && steps.metadata.outputs.update-type == 'version-update:semver-patch' && !github.event.pull_request.draft
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/enforce-branch-protection.yml
+++ b/.github/workflows/enforce-branch-protection.yml
@@ -33,13 +33,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Validate config JSON
         run: jq empty .github/branch-protection/dev.json
 
       - name: Audit drift and optionally apply protection
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           REPO_ADMIN_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
           MODE: ${{ env.MODE }}

--- a/.github/workflows/good-egg-trust.yml
+++ b/.github/workflows/good-egg-trust.yml
@@ -30,7 +30,7 @@ jobs:
           fail-on-low: 'false'
 
       - name: Sync trust labels
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           TRUST_LEVEL: ${{ steps.egg.outputs.trust-level }}
         with:

--- a/.github/workflows/issue-area-labeler.yml
+++ b/.github/workflows/issue-area-labeler.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Apply area label from issue form
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/pr-area-labeler.yml
+++ b/.github/workflows/pr-area-labeler.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Label PR
-        uses: actions/labeler@v6
+        uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Sync labels from manifest
-        uses: crazy-max/ghaction-github-labeler@v6
+        uses: crazy-max/ghaction-github-labeler@548a7c3603594ec17c819e1239f281a3b801ab4d # v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/labels.yml


### PR DESCRIPTION
Fixes #942

## Summary

Pins the remaining mutable GitHub Action references in privileged and write-capable workflows to immutable commit SHAs while keeping version comments for maintainability.

## Why

Privileged workflows should run reviewed action code. Pinning by SHA prevents a future mutable major tag change from silently altering what runs with repository permissions.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation

```bash
rg -n "uses: .+@v[0-9]" .github/workflows || true
git diff --check
git commit -s -m "pin privileged workflow actions"
```

This PR is stacked on #944 so CI evaluates against the canonical module-path fix while keeping this workflow-only diff focused. Its touched-surface checks passed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: No
- Tools used: None
- Areas where used: None
- Human verification performed: Workflow reference scan, whitespace check, pre-commit hooks during signed commit.
