### PR TITLE
Make infrastructure validation reproducible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,12 +186,16 @@ jobs:
 
       - name: Setup Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
+        with:
+          version: v4.1.3
 
       - name: Helm Lint
         run: helm lint deploy/helm/identrail
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85
+        with:
+          terraform_version: 1.14.3
 
       - name: Terraform Format Check
         run: terraform fmt -check -recursive deploy/terraform

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ coverage/
 *.tfstate.*
 .terraform/
 .terraform.lock.hcl
+!deploy/terraform/.terraform.lock.hcl
 crash.log
 override.tf
 override.tf.json

--- a/deploy/terraform/.terraform.lock.hcl
+++ b/deploy/terraform/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "3.1.1"
+  constraints = "~> 3.1.0"
+  hashes = [
+    "h1:/tVXN35+rcMB8KjqtYTIoFl7lxcQyDCCj+vKLXDmXck=",
+    "zh:1a6d5ce931708aec29d1f3d9e360c2a0c35ba5a54d03eeaff0ce3ca597cd0275",
+    "zh:3411919ba2a5941801e677f0fea08bdd0ae22ba3c9ce3309f55554699e06524a",
+    "zh:81b36138b8f2320dc7f877b50f9e38f4bc614affe68de885d322629dd0d16a29",
+    "zh:95a2a0a497a6082ee06f95b38bd0f0d6924a65722892a856cfd914c0d117f104",
+    "zh:9d3e78c2d1bb46508b972210ad706dd8c8b106f8b206ecf096cd211c54f46990",
+    "zh:a79139abf687387a6efdbbb04289a0a8e7eaca2bd91cdc0ce68ea4f3286c2c34",
+    "zh:aaa8784be125fbd50c48d84d6e171d3fb6ef84a221dbc5165c067ce05faab4c8",
+    "zh:afecd301f469975c9d8f350cc482fe656e082b6ab0f677d1a816c3c615837cc1",
+    "zh:c54c22b18d48ff9053d899d178d9ffef7d9d19785d9bf310a07d648b7aac075b",
+    "zh:db2eefd55aea48e73384a555c72bac3f7d428e24147bedb64e1a039398e5b903",
+    "zh:ee61666a233533fd2be971091cecc01650561f1585783c381b6f6e8a390198a4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "3.0.1"
+  constraints = "~> 3.0.0"
+  hashes = [
+    "h1:fu3VBNxwJU/G1Ocw+rEoUtPEM233B0bQMquk12+pxWY=",
+    "zh:02d55b0b2238fd17ffa12d5464593864e80f402b90b31f6e1bd02249b9727281",
+    "zh:20b93a51bfeed82682b3c12f09bac3031f5bdb4977c47c97a042e4df4fb2f9ba",
+    "zh:6e14486ecfaee38c09ccf33d4fdaf791409f90795c1b66e026c226fad8bc03c7",
+    "zh:8d0656ff422df94575668e32c310980193fccb1c28117e5c78dd2d4050a760a6",
+    "zh:9795119b30ec0c1baa99a79abace56ac850b6e6fbce60e7f6067792f6eb4b5f4",
+    "zh:b388c87acc40f6bd9620f4e23f01f3c7b41d9b88a68d5255dec0a72f0bdec249",
+    "zh:b59abd0a980649c2f97f172392f080eaeb18e486b603f83bf95f5d93aeccc090",
+    "zh:ba6e3060fddf4a022087d8f09e38aa0001c705f21170c2ded3d1c26c12f70d97",
+    "zh:c12626d044b1d5501cf95ca78cbe507c13ad1dd9f12d4736df66eb8e5f336eb8",
+    "zh:c55203240d50f4cdeb3df1e1760630d677679f5b1a6ffd9eba23662a4ad05119",
+    "zh:ea206a5a32d6e0d6e32f1849ad703da9a28355d9c516282a8458b5cf1502b2a1",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -24,6 +24,18 @@ This Terraform baseline deploys Identrail on Kubernetes through the Helm chart.
 - Kubernetes provider auth from kubeconfig or in-cluster identity.
 - Helm provider uses the same Kubernetes context.
 
+## Dependency Updates
+
+Terraform providers are selected through bounded constraints in `versions.tf`
+and locked in `.terraform.lock.hcl` for reproducible fresh clones and CI runs.
+
+When rotating Terraform, Helm, or Kubernetes provider versions:
+
+1. Update the version constraints in `versions.tf` and matching module constraints.
+2. Run `terraform init -upgrade -backend=false` from `deploy/terraform`.
+3. Review and commit the resulting `.terraform.lock.hcl` change.
+4. Run `terraform fmt -check -recursive deploy/terraform` and `terraform validate`.
+
 ## Notes
 
 - This module assumes a Kubernetes cluster already exists.

--- a/deploy/terraform/modules/identrail-helm/versions.tf
+++ b/deploy/terraform/modules/identrail-helm/versions.tf
@@ -1,14 +1,14 @@
 terraform {
-  required_version = ">= 1.5.0"
+  required_version = "~> 1.14.0"
 
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.13.0"
+      version = "~> 3.1.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.30.0"
+      version = "~> 3.0.0"
     }
   }
 }

--- a/deploy/terraform/versions.tf
+++ b/deploy/terraform/versions.tf
@@ -1,14 +1,14 @@
 terraform {
-  required_version = ">= 1.5.0"
+  required_version = "~> 1.14.0"
 
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.13.0"
+      version = "~> 3.1.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.30.0"
+      version = "~> 3.0.0"
     }
   }
 }


### PR DESCRIPTION
Fixes #943

## Summary

Makes Terraform and Helm validation reproducible by bounding provider and Terraform versions, tracking the Terraform lockfile, and pinning the Helm and Terraform versions used by CI.

## Why

Fresh clones and CI should resolve the same reviewed infrastructure tooling and providers until a maintainer intentionally rotates them.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation

```bash
terraform fmt -check -recursive deploy/terraform
cd deploy/terraform && terraform init -backend=false && terraform validate
git diff --check
git commit -s -m "make infra validation reproducible"
```

This PR is stacked on #944 so CI evaluates against the canonical module-path fix while keeping this infrastructure-only diff focused. Its touched-surface checks passed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: No
- Tools used: None
- Areas where used: None
- Human verification performed: Terraform format check, init, validate, whitespace check, pre-commit hooks during signed commit.
