### PR TITLE
Polish website header navigation and brand wordmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Polished the public website header navigation and brand treatment:
+  - renamed the primary navigation to Product, Docs, Company, Pricing, and Blog
+  - removed dropdown chevrons from plain navigation links
+  - tightened the IDENTRAIL wordmark and applied Geist typography to the header controls
 - Added a project connect-source wizard in the authenticated web app:
   - guided GitHub, AWS, and Kubernetes source onboarding from the project detail route
   - wired live connection status, validation, retry, and remediation feedback to existing project-scoped connector APIs

--- a/internal/api/router_oidc_scope_precedence_test.go
+++ b/internal/api/router_oidc_scope_precedence_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/Oluwatobi-Mustapha/identrail/internal/db"
-	"github.com/Oluwatobi-Mustapha/identrail/internal/telemetry"
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/telemetry"
 	"go.uber.org/zap"
 )
 

--- a/web/index.html
+++ b/web/index.html
@@ -19,7 +19,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Barlow+Semi+Condensed:wght@500;600;700&family=Inter:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Barlow+Semi+Condensed:wght@500;600;700&family=Geist:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap"
     />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -54,9 +54,9 @@ let activeModalLocks = 0;
 let bodyOverflowBeforeModal = '';
 
 const NAV_LINKS = [
-  { to: '/product', label: 'Platform', hasMenu: true },
-  { to: '/docs', label: 'Develop', hasMenu: true },
-  { to: '/about', label: 'Company', hasMenu: true },
+  { to: '/product', label: 'Product' },
+  { to: '/docs', label: 'Docs' },
+  { to: '/about', label: 'Company' },
   { to: '/pricing', label: 'Pricing' },
   { to: '/blog', label: 'Blog' }
 ] as const;

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -106,12 +106,11 @@ export function Header({
               </svg>
               Star
             </span>
-            <span
-              className={`idt-github-star-count ${starCount === null ? 'is-loading' : ''}`}
-              aria-label={starCount === null ? 'Loading GitHub star count' : `${formatGitHubStars(starCount)} GitHub stars`}
-            >
-              {starCount === null ? '...' : formatGitHubStars(starCount)}
-            </span>
+            {starCount !== null ? (
+              <span className="idt-github-star-count" aria-label={`${formatGitHubStars(starCount)} GitHub stars`}>
+                {formatGitHubStars(starCount)}
+              </span>
+            ) : null}
           </SafeLink>
           <Link to={siteLinks.signIn} className="idt-header-utility">
             Login

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -6,7 +6,6 @@ import { SafeLink } from '../SafeLink';
 type NavLinkItem = {
   to: string;
   label: string;
-  hasMenu?: boolean;
 };
 
 function formatGitHubStars(count: number): string {
@@ -68,10 +67,7 @@ export function Header({
       <div className="idt-shell idt-header-row">
         <Link to="/" className="idt-brand" aria-label="Identrail homepage">
           <img src="/identrail-logo.png" width="32" height="32" alt="Identrail" decoding="async" />
-          <span>
-            Identrail
-            <small>Machine Identity Security</small>
-          </span>
+          <span>IDENTRAIL</span>
         </Link>
 
         <button
@@ -95,7 +91,6 @@ export function Header({
               onClick={() => setMenuOpen(false)}
             >
               <span>{item.label}</span>
-              {item.hasMenu ? <span className="idt-nav-chevron" aria-hidden="true" /> : null}
             </NavLink>
           ))}
         </nav>
@@ -111,7 +106,12 @@ export function Header({
               </svg>
               Star
             </span>
-            {starCount !== null ? <span className="idt-github-star-count">{formatGitHubStars(starCount)}</span> : null}
+            <span
+              className={`idt-github-star-count ${starCount === null ? 'is-loading' : ''}`}
+              aria-label={starCount === null ? 'Loading GitHub star count' : `${formatGitHubStars(starCount)} GitHub stars`}
+            >
+              {starCount === null ? '...' : formatGitHubStars(starCount)}
+            </span>
           </SafeLink>
           <Link to={siteLinks.signIn} className="idt-header-utility">
             Login

--- a/web/src/components/marketingCtaRoutes.test.tsx
+++ b/web/src/components/marketingCtaRoutes.test.tsx
@@ -50,8 +50,8 @@ describe('marketing CTA routing', () => {
       <MemoryRouter>
         <Header
           navLinks={[
-            { to: '/product', label: 'Platform', hasMenu: true },
-            { to: '/docs', label: 'Develop', hasMenu: true }
+            { to: '/product', label: 'Product' },
+            { to: '/docs', label: 'Docs' }
           ]}
           githubRepo={siteLinks.github}
         />

--- a/web/src/components/marketingCtaRoutes.test.tsx
+++ b/web/src/components/marketingCtaRoutes.test.tsx
@@ -62,5 +62,6 @@ describe('marketing CTA routing', () => {
     expect(screen.getByRole('link', { name: 'Login' })).toHaveAttribute('href', siteLinks.signIn);
     expect(screen.getByRole('link', { name: 'Sign up' })).toHaveAttribute('href', siteLinks.app);
     expect(screen.getByRole('link', { name: 'Star Identrail on GitHub' })).toHaveAttribute('href', siteLinks.github);
+    expect(screen.queryByLabelText(/Loading GitHub star count/i)).not.toBeInTheDocument();
   });
 });

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7226,6 +7226,7 @@ html[data-theme='light'] .idt-header,
   background: rgba(255, 255, 255, 0.92);
   border-bottom: 1px solid rgba(21, 25, 34, 0.08);
   backdrop-filter: blur(16px);
+  box-shadow: 0 10px 30px rgba(21, 25, 34, 0.045);
 }
 
 .idt-header-row {
@@ -7252,12 +7253,17 @@ html[data-theme='light'] .idt-header,
 }
 
 .idt-brand span {
+  font-family: var(--idt-nav-font);
   color: #151922;
-  font-size: 1.02rem;
-  font-weight: 500;
-  letter-spacing: 0.44em;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
   line-height: 1;
   text-transform: uppercase;
+}
+
+.idt-brand small {
+  display: none;
 }
 
 .idt-nav {
@@ -7266,6 +7272,7 @@ html[data-theme='light'] .idt-header,
 }
 
 .idt-nav a {
+  position: relative;
   min-height: 42px;
   padding: 0;
   display: inline-flex;
@@ -7274,11 +7281,28 @@ html[data-theme='light'] .idt-header,
   border: 0;
   border-radius: 0;
   color: #5d6370;
-  font-size: 0.95rem;
-  font-weight: 400;
+  font-family: var(--idt-nav-font);
+  font-size: 0.94rem;
+  font-weight: 500;
   letter-spacing: 0;
   line-height: 1;
   text-transform: none;
+  transition: color 160ms ease;
+}
+
+.idt-nav a::after {
+  content: '';
+  position: absolute;
+  right: 0;
+  bottom: 0.48rem;
+  left: 0;
+  height: 2px;
+  border-radius: 999px;
+  background: #742bdc;
+  opacity: 0;
+  transform: scaleX(0.4);
+  transform-origin: center;
+  transition: opacity 160ms ease, transform 160ms ease;
 }
 
 html[data-theme='light'] .idt-nav a:hover,
@@ -7291,13 +7315,11 @@ html[data-theme='light'] .idt-nav a.is-active,
   color: #151922;
 }
 
-.idt-nav-chevron {
-  width: 0.42rem;
-  height: 0.42rem;
-  border-right: 1.5px solid currentColor;
-  border-bottom: 1.5px solid currentColor;
-  transform: translateY(-0.12rem) rotate(45deg);
-  opacity: 0.72;
+.idt-nav a:hover::after,
+.idt-nav a:focus-visible::after,
+.idt-nav a.is-active::after {
+  opacity: 1;
+  transform: scaleX(1);
 }
 
 .idt-header-actions {
@@ -7306,6 +7328,7 @@ html[data-theme='light'] .idt-nav a.is-active,
 }
 
 .idt-github-star {
+  font-family: var(--idt-nav-font);
   min-height: 40px;
   display: inline-flex;
   align-items: center;
@@ -7316,6 +7339,14 @@ html[data-theme='light'] .idt-nav a.is-active,
   color: #090b10;
   text-decoration: none;
   box-shadow: 0 8px 18px rgba(21, 25, 34, 0.04);
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+}
+
+.idt-github-star:hover,
+.idt-github-star:focus-visible {
+  border-color: rgba(116, 43, 220, 0.28);
+  box-shadow: 0 10px 24px rgba(21, 25, 34, 0.08);
+  transform: translateY(-1px);
 }
 
 .idt-github-star-action,
@@ -7342,18 +7373,32 @@ html[data-theme='light'] .idt-nav a.is-active,
 .idt-github-star-count {
   border-left: 1px solid rgba(21, 25, 34, 0.1);
   background: #ffffff;
+  min-width: 2.45rem;
+}
+
+.idt-github-star-count.is-loading {
+  color: rgba(21, 25, 34, 0.42);
 }
 
 .idt-header-utility {
+  font-family: var(--idt-nav-font);
   min-height: 40px;
   display: inline-flex;
   align-items: center;
   color: #5d6370;
   font-size: 0.94rem;
-  font-weight: 400;
+  font-weight: 500;
+  text-decoration: none;
+  transition: color 160ms ease;
+}
+
+.idt-header-utility:hover,
+.idt-header-utility:focus-visible {
+  color: #151922;
 }
 
 .idt-header-actions .idt-btn {
+  font-family: var(--idt-nav-font);
   min-height: 40px;
   border-radius: 7px;
   padding: 0.52rem 1.1rem;
@@ -7667,6 +7712,14 @@ html[data-theme='light'] .idt-trust-strip,
     border-bottom: 1px solid rgba(21, 25, 34, 0.08);
   }
 
+  .idt-nav a::after {
+    right: auto;
+    bottom: 0.8rem;
+    left: 0;
+    width: 22px;
+    transform-origin: left;
+  }
+
   .idt-header-actions {
     display: none;
   }
@@ -7693,7 +7746,7 @@ html[data-theme='light'] .idt-trust-strip,
 @media (max-width: 720px) {
   .idt-brand span {
     font-size: 0.9rem;
-    letter-spacing: 0.3em;
+    letter-spacing: 0.08em;
   }
 
   .idt-brand img {
@@ -7742,6 +7795,39 @@ html[data-theme='light'] .idt-trust-strip,
 
   .idt-logo-cloud-track span {
     font-size: 1.5rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .idt-header-row {
+    position: relative;
+    width: min(100% - 1rem, 1080px);
+    gap: 0.6rem;
+  }
+
+  .idt-brand {
+    gap: 0.5rem;
+  }
+
+  .idt-menu-toggle {
+    position: fixed;
+    top: 12px;
+    right: 0.75rem;
+    width: 40px;
+    min-width: 40px;
+    min-height: 40px;
+    border-radius: 50%;
+    padding: 0;
+    z-index: 180;
+  }
+
+  .idt-menu-toggle-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
   }
 }
 

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -24,6 +24,7 @@
 
   /* Typography */
   --font-display: 'Barlow Semi Condensed', 'Space Grotesk', 'Inter', 'Segoe UI', sans-serif;
+  --font-nav: 'Geist', 'Inter', 'Segoe UI', sans-serif;
   --font-body: 'Inter', 'Segoe UI', sans-serif;
   --font-mono: 'IBM Plex Mono', 'SFMono-Regular', 'Menlo', monospace;
 
@@ -75,6 +76,7 @@
   --idt-glow: var(--glow-soft);
   --idt-cta: var(--cta-primary);
   --idt-display: var(--font-display);
+  --idt-nav-font: var(--font-nav);
   --idt-body: var(--font-body);
   --idt-radius: var(--radius-md);
   --idt-shell: var(--shell-max-width);


### PR DESCRIPTION
Fixes #1027

## What changed
- Renamed the public website header navigation to Product, Docs, Company, Pricing, and Blog.
- Removed the false dropdown chevrons from the plain top-level links.
- Tightened the header wordmark to `IDENTRAIL` and removed the small tagline from the header treatment.
- Added Geist as the header typography layer and polished hover/active states for the nav, GitHub star pill, Login, and Sign up actions.
- Kept the GitHub star action, dynamic count slot, Login, and Sign up cluster visible and balanced.

## Why
The header previously implied dropdown behavior for links that navigated directly, and the widely spaced wordmark felt scattered. This makes the navigation simpler, more intentional, and closer to a premium product header without adding premature mega menus.

## Impact and risk
- Public website header only.
- No API, backend, or auth behavior changes.
- The branch is intentionally based on the live production website merge commit `632c0b4` so this PR preserves the deployed website refresh instead of reverting to the current remote `dev` snapshot.

## Validation
- `npm ci --prefix web`
- `npm run build --prefix web`
- `npm run test --prefix web -- --run src/components/marketingCtaRoutes.test.tsx`
- `git diff --check`
- Local preview screenshot check at `http://127.0.0.1:4182/` for desktop and narrow mobile header layout
- Pre-push hooks: merge-conflict check, EOF/whitespace checks, gofmt check, `go vet`, local env token hygiene, Vercel artifact hygiene

## AI disclosure
- AI-assisted: yes
- Tools used: OpenAI Codex
- Where used: website header implementation, CSS polish, validation workflow
- Human verification performed: build, targeted test, diff check, local visual review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the public website header by simplifying navigation, tightening the IDENTRAIL wordmark, and applying `Geist` typography for a cleaner look. Also hides the stale GitHub star loading state; addresses #1027 with no backend/auth changes.

- **Refactors**
  - Renamed nav to Product, Docs, Company, Pricing, Blog; removed chevrons/`hasMenu` and updated tests.
  - Tightened wordmark to IDENTRAIL; removed the tagline.
  - Applied `Geist` to header controls via new nav font tokens; updated Google Fonts link.
  - Added subtle header shadow, nav underline animation, and smoother hover/focus transitions.
  - GitHub star pill polish: accessible count label and refined hover/focus effects.
  - Mobile tweaks: fixed menu toggle positioning/label and small spacing.

- **Bug Fixes**
  - Hide stale GitHub star loading state after the count loads.

<sup>Written for commit 49d1a2fe64169451cae3e1c161b92c66ff6897eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

