### PR TITLE
Fix/796 rendered marketing changes

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,8 @@ import { HowItWorksSection } from './components/home/HowItWorksSection';
 import { CommandCenterSection } from './components/home/CommandCenterSection';
 import { ProblemFramingSection } from './components/home/ProblemFramingSection';
 import { TrustProofStrip } from './components/home/TrustProofStrip';
+import { KillSwitchSection } from './components/KillSwitchSection';
+import { TrustGraphAgentSection } from './components/TrustGraphAgentSection';
 import { Footer } from './components/layout/Footer';
 import { Header } from './components/layout/Header';
 import { apiClient } from './api/client';
@@ -1663,6 +1665,10 @@ function HomePage() {
       <CommandCenterSection />
 
       <ProductTourSection />
+
+      <KillSwitchSection />
+
+      <TrustGraphAgentSection />
 
       <HowItWorksSection />
 

--- a/web/src/components/KillSwitchSection.tsx
+++ b/web/src/components/KillSwitchSection.tsx
@@ -15,47 +15,45 @@ export function KillSwitchSection() {
   const logs = useMemo(() => [...baseLog, ...baseLog], []);
 
   return (
-    <section className="section reveal-on-scroll" aria-labelledby="kill-switch-title">
-      <div className={`section-card kill-switch-shell ${revoked ? 'is-revoked' : ''}`}>
-        <div className="kill-switch-copy">
-          <p className="eyebrow eyebrow-dark">Policy Simulation + Response Planning</p>
+    <section className="idt-section idt-shell" aria-labelledby="kill-switch-title">
+      <div className="idt-card-grid two-col">
+        <article className={`idt-card ${revoked ? 'idt-card' : ''}`}>
+          <p className="idt-eyebrow">Policy Simulation + Response Planning</p>
           <h2 id="kill-switch-title">Revocation Impact Simulation</h2>
           <p>
             Simulate revocation impact for risky machine identity paths in open-source, self-hosted environments.
             Use the preview to plan safe operator-driven response steps and audit follow-through.
           </p>
-          <button
-            type="button"
-            className="kill-switch-button"
-            aria-pressed={revoked}
-            onClick={() => setRevoked((value) => !value)}
-          >
-            SIMULATE REVOKE IMPACT
-          </button>
-          <p className="kill-switch-note">
+          <div className="idt-inline-actions">
+            <button
+              type="button"
+              className="idt-btn idt-btn-dark"
+              aria-pressed={revoked}
+              onClick={() => setRevoked((value) => !value)}
+            >
+              SIMULATE REVOKE IMPACT
+            </button>
+          </div>
+          <p>
             Hover or click to simulate revocation impact across AWS and Kubernetes trust paths.
           </p>
-        </div>
+        </article>
 
-        <div className="kill-switch-visuals">
-          <div className="kill-switch-graph" role="img" aria-label="Revocation graph simulation">
+        <article className="idt-card" aria-label="Live revocation log">
+          <p className="idt-eyebrow">Trust simulation log</p>
+          <div className="idt-command-list">
             {trustNodes.map((node) => (
-              <span key={node} className="kill-node">
-                {node}
-              </span>
+              <p key={node}>Node: {node}</p>
             ))}
           </div>
-
-          <div className="kill-switch-log" aria-label="Live revocation log">
-            <p>Live audit stream</p>
-            <div className="kill-switch-log-track">
-              {logs.map((line, index) => (
-                <span key={`${line}-${index}`}>{line}</span>
-              ))}
-            </div>
+          <p className="idt-card-subtle">Live audit stream</p>
+          <div className="idt-command-list">
+            {logs.map((line, index) => (
+              <p key={`${line}-${index}`}>{line}</p>
+            ))}
           </div>
+        </article>
         </div>
-      </div>
     </section>
   );
 }

--- a/web/src/components/KillSwitchSection.tsx
+++ b/web/src/components/KillSwitchSection.tsx
@@ -3,11 +3,11 @@ import { useMemo, useState } from 'react';
 const trustNodes = ['EKS SA', 'OIDC', 'IAM Role', 'KMS', 'S3', 'Build Token'] as const;
 
 const baseLog = [
-  'Revoked access to arn:aws:iam::prod:role/ci-runner at 12:31 UTC',
-  'Revoked access to arn:aws:iam::prod:role/eks-default at 12:31 UTC',
-  'Revoked access to arn:aws:iam::shared:role/oidc-federation at 12:31 UTC',
-  'Revoked access to arn:aws:iam::data:role/s3-replication at 12:31 UTC',
-  'Revoked access to arn:aws:iam::prod:role/secrets-reader at 12:31 UTC'
+  'Simulation: Would revoke access to arn:aws:iam::prod:role/ci-runner at 12:31 UTC',
+  'Simulation: Would revoke access to arn:aws:iam::prod:role/eks-default at 12:31 UTC',
+  'Simulation: Would revoke access to arn:aws:iam::shared:role/oidc-federation at 12:31 UTC',
+  'Simulation: Would revoke access to arn:aws:iam::data:role/s3-replication at 12:31 UTC',
+  'Simulation: Would revoke access to arn:aws:iam::prod:role/secrets-reader at 12:31 UTC'
 ] as const;
 
 export function KillSwitchSection() {

--- a/web/src/components/KillSwitchSection.tsx
+++ b/web/src/components/KillSwitchSection.tsx
@@ -18,11 +18,11 @@ export function KillSwitchSection() {
     <section className="section reveal-on-scroll" aria-labelledby="kill-switch-title">
       <div className={`section-card kill-switch-shell ${revoked ? 'is-revoked' : ''}`}>
         <div className="kill-switch-copy">
-          <p className="eyebrow eyebrow-dark">Policy Simulation + Emergency Control</p>
-          <h2 id="kill-switch-title">Instant Revocation &amp; Kill Switch</h2>
+          <p className="eyebrow eyebrow-dark">Policy Simulation + Response Planning</p>
+          <h2 id="kill-switch-title">Revocation Impact Simulation</h2>
           <p>
-            One-click kill switch for any machine identity — open-source and self-hosted.
-            Immediately sever risky trust edges and generate an audit trail for response teams.
+            Simulate revocation impact for risky machine identity paths in open-source, self-hosted environments.
+            Use the preview to plan safe operator-driven response steps and audit follow-through.
           </p>
           <button
             type="button"
@@ -30,10 +30,10 @@ export function KillSwitchSection() {
             aria-pressed={revoked}
             onClick={() => setRevoked((value) => !value)}
           >
-            REVOKE ALL ACCESS
+            SIMULATE REVOKE IMPACT
           </button>
           <p className="kill-switch-note">
-            Hover or click to simulate immediate revocation across AWS and Kubernetes trust paths.
+            Hover or click to simulate revocation impact across AWS and Kubernetes trust paths.
           </p>
         </div>
 

--- a/web/src/components/TrustGraphAgentSection.tsx
+++ b/web/src/components/TrustGraphAgentSection.tsx
@@ -17,45 +17,39 @@ const afterPolicy = `{
 
 export function TrustGraphAgentSection() {
   return (
-    <section className="section reveal-on-scroll" aria-labelledby="agent-title">
-      <div className="section-card agent-section">
-        <div className="agent-copy">
-          <p className="eyebrow eyebrow-dark">Remediation Planning</p>
+    <section className="idt-section idt-shell" aria-labelledby="agent-title">
+      <div className="idt-card-grid two-col">
+        <article className="idt-card">
+          <p className="idt-eyebrow">Remediation Planning</p>
           <h2 id="agent-title">Meet the Identrail Trust Graph Agent</h2>
           <p>
             Plan machine identity remediation with guided trust-path analysis.
             Review least-privilege change suggestions and simulated pull-request policy diffs before operator approval.
           </p>
-          <div className="agent-steps" aria-hidden="true">
+          <div className="idt-command-steps" aria-hidden="true">
             <span>Analyze graph</span>
             <span>Review fix</span>
             <span>Approve plan</span>
           </div>
-          <SafeLink className="btn btn-primary" href={siteLinks.agentRelease}>
+          <SafeLink className="idt-btn idt-btn-primary" href={siteLinks.agentRelease}>
             Star the repo to follow future agent workflow releases
           </SafeLink>
-        </div>
+        </article>
 
-        <div className="agent-pr-preview" aria-label="Agent remediation pull request preview">
-          <div className="agent-icon" aria-hidden="true">
-            <span className="agent-eye" />
-            <span className="agent-eye" />
+        <article className="idt-card" aria-label="Agent remediation pull request preview">
+          <div className="idt-command-list" aria-hidden="true">
+            <span className="idt-command-label">Before</span>
+            <pre>
+              <code>{beforePolicy}</code>
+            </pre>
           </div>
-          <div className="agent-snippet-grid">
-            <article>
-              <p>Before</p>
-              <pre>
-                <code>{beforePolicy}</code>
-              </pre>
-            </article>
-            <article>
-              <p>After</p>
-              <pre>
-                <code>{afterPolicy}</code>
-              </pre>
-            </article>
+          <div className="idt-command-list" aria-hidden="true">
+            <span className="idt-command-label">After</span>
+            <pre>
+              <code>{afterPolicy}</code>
+            </pre>
           </div>
-        </div>
+        </article>
       </div>
     </section>
   );

--- a/web/src/components/TrustGraphAgentSection.tsx
+++ b/web/src/components/TrustGraphAgentSection.tsx
@@ -20,19 +20,19 @@ export function TrustGraphAgentSection() {
     <section className="section reveal-on-scroll" aria-labelledby="agent-title">
       <div className="section-card agent-section">
         <div className="agent-copy">
-          <p className="eyebrow eyebrow-dark">Auto-Remediate</p>
+          <p className="eyebrow eyebrow-dark">Remediation Planning</p>
           <h2 id="agent-title">Meet the Identrail Trust Graph Agent</h2>
           <p>
-            Auto-remediate machine identity risks with one click. The agent analyzes trust paths,
-            drafts least-privilege changes, and opens a simulated pull request with policy diffs.
+            Plan machine identity remediation with guided trust-path analysis.
+            Review least-privilege change suggestions and simulated pull-request policy diffs before operator approval.
           </p>
           <div className="agent-steps" aria-hidden="true">
             <span>Analyze graph</span>
-            <span>Generate fix</span>
-            <span>Open PR</span>
+            <span>Review fix</span>
+            <span>Approve plan</span>
           </div>
           <SafeLink className="btn btn-primary" href={siteLinks.agentRelease}>
-            Star the repo to get the agent in your next release
+            Star the repo to follow future agent workflow releases
           </SafeLink>
         </div>
 


### PR DESCRIPTION
## Summary

Describe what changed.

## Why

Describe the problem this PR solves.

## Scope

- [ ] Focused change (no unrelated modifications)
- [ ] Backward compatibility considered
- [ ] Risk level assessed

## Validation

List the checks you ran and their outcomes.

```bash
# Example:
# go test ./...
# npm run test:ci --prefix web
```

## Checklist

- [ ] Tests added/updated for behavior changes
- [ ] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [ ] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

If AI tools were used materially for this PR, complete the fields below.

- AI-assisted: yes/no
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Required for this repository size:

- Include at least one issue reference using closing/reference keywords:
  - `Closes #123`, `Fixes #123`, or `Refs #123`
- If no issue exists, include an explicit exemption with rationale:
  - `No issue: <reason>` (for example: docs-only typo fix, CI-only fix, or emergency hotfix)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewords the Kill Switch and Trust Graph Agent sections to emphasize simulation and operator-approved remediation planning, and renders both sections on the homepage. Aligns logs, CTA, and UI copy with the new simulation language per Linear 796.

- **Refactors**
  - KillSwitchSection: updated copy, button text to “SIMULATE REVOKE IMPACT,” and log lines to “Simulation: Would revoke …”; switched to `idt-*` classes and improved ARIA labels.
  - TrustGraphAgentSection: reframed to “Remediation Planning,” adjusted step labels, updated CTA text, and simplified before/after policy preview using `idt-*` classes.
  - App.tsx: imported and added `KillSwitchSection` and `TrustGraphAgentSection` to the Home page.

<sup>Written for commit 689efd44f915e34338232ee34c808f4accae2e69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

