### PR TITLE
Shift hero visual container left

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9282,7 +9282,7 @@ html[data-theme='light'] .idt-hero,
   min-height: 800px;
   margin-top: 0;
   overflow: hidden;
-  transform: translateX(clamp(-1.75rem, -2.1vw, -0.75rem));
+  transform: translateX(clamp(-3.75rem, calc(1.75rem - 4.5vw), -1.8rem));
 }
 
 .idt-hero-backdrop-panel {


### PR DESCRIPTION
## Summary

Shifted the homepage hero product visual container slightly left on desktop with a responsive transform clamp.

## Why

The laptop/mobile preview container had useful empty space between the copy and product visual while the far-right side felt tight. This change lets the visual area occupy more of that middle space and gives the right edge more breathing room without changing the Docker metric behavior or the product mockup content.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation

```bash
npm run build --prefix web
npm run test --prefix web -- --run src/App.test.tsx src/components/marketingCtaRoutes.test.tsx src/components/home/HeroOpenSourceProofPills.test.tsx
git diff --check
```

All checks passed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

No tests/docs/changelog changes were needed because this is a CSS-only visual spacing adjustment.

## AI Assistance Disclosure

- AI-assisted: yes
- Tools used: ChatGPT/Codex
- Areas where used: `web/src/styles.css`
- Human verification performed: reviewed the one-line CSS diff, ran web build, focused web tests, `git diff --check`, and visual previewed the hero locally.

## Related Issues

No issue: targeted visual spacing follow-up from homepage hero review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shifted the homepage hero product visual container further left on desktop by widening the responsive translateX clamp in CSS. This improves spacing between the copy and the visual and adds right-edge breathing room without changing the hero content.

<sup>Written for commit ecf608c204661499cd9109a3615e69a1287c6204. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

