### PR TITLE
Pr 854

### DIFF
--- a/deploy/helm/identrail/templates/web-deployment.yaml
+++ b/deploy/helm/identrail/templates/web-deployment.yaml
@@ -25,10 +25,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.web.podSecurityContext }}
-      securityContext:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       containers:
         - name: web
           image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"

--- a/deploy/helm/identrail/templates/web-deployment.yaml
+++ b/deploy/helm/identrail/templates/web-deployment.yaml
@@ -25,6 +25,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.web.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: web
           image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"

--- a/deploy/helm/identrail/values.yaml
+++ b/deploy/helm/identrail/values.yaml
@@ -13,7 +13,6 @@ api:
     runAsNonRoot: true
   securityContext:
     allowPrivilegeEscalation: false
-    readOnlyRootFilesystem: true
     capabilities:
       drop:
         - ALL

--- a/deploy/helm/identrail/values.yaml
+++ b/deploy/helm/identrail/values.yaml
@@ -4,10 +4,10 @@ fullnameOverride: ""
 imagePullSecrets: []
 
 api:
-  replicaCount: 2
+  replicaCount: 1
   image:
-    repository: ghcr.io/identrail/identrail-api
-    tag: v1.0.0
+    repository: identrail/api
+    tag: v0.1.0
     pullPolicy: IfNotPresent
   podSecurityContext:
     runAsNonRoot: true
@@ -31,8 +31,8 @@ api:
 worker:
   replicaCount: 1
   image:
-    repository: ghcr.io/identrail/identrail-worker
-    tag: v1.0.0
+    repository: identrail/worker
+    tag: v0.1.0
     pullPolicy: IfNotPresent
   podSecurityContext:
     runAsNonRoot: true
@@ -59,8 +59,8 @@ web:
   enabled: false
   replicaCount: 1
   image:
-    repository: ghcr.io/identrail/identrail-web
-    tag: v1.0.0
+    repository: identrail/web
+    tag: v0.1.0
     pullPolicy: IfNotPresent
   podSecurityContext:
     runAsNonRoot: true
@@ -123,7 +123,7 @@ config:
   IDENTRAIL_AWS_SOURCE: sdk
   IDENTRAIL_AWS_REGION: us-east-1
   IDENTRAIL_AWS_PROFILE: ""
-  IDENTRAIL_K8S_SOURCE: kubectl
+  IDENTRAIL_K8S_SOURCE: fixture
   IDENTRAIL_KUBECTL_PATH: /usr/bin/kubectl
   IDENTRAIL_KUBE_CONTEXT: ""
   IDENTRAIL_REQUIRE_LIVE_SOURCES: "true"
@@ -136,9 +136,6 @@ config:
   IDENTRAIL_MIGRATIONS_DIR: /app/migrations
   IDENTRAIL_SCAN_INTERVAL: 15m
   IDENTRAIL_WORKER_RUN_NOW: "true"
-  IDENTRAIL_WORKER_API_JOB_QUEUE_ENABLED: "true"
-  IDENTRAIL_WORKER_API_JOB_QUEUE_INTERVAL: 2s
-  IDENTRAIL_WORKER_API_JOB_QUEUE_BATCH_SIZE: "5"
   IDENTRAIL_WORKER_REPO_SCAN_ENABLED: "false"
   IDENTRAIL_WORKER_REPO_SCAN_RUN_NOW: "false"
   IDENTRAIL_WORKER_REPO_SCAN_INTERVAL: 1h
@@ -151,17 +148,6 @@ config:
   IDENTRAIL_REPO_SCAN_HISTORY_LIMIT_MAX: "5000"
   IDENTRAIL_REPO_SCAN_MAX_FINDINGS_MAX: "1000"
   IDENTRAIL_REPO_SCAN_ALLOWLIST: ""
-  IDENTRAIL_APP_MODE_ENABLED: "false"
-  IDENTRAIL_APP_MODE_CONNECTORS_ENABLED: "false"
-  IDENTRAIL_APP_MODE_SCHEDULER_ENABLED: "false"
-  IDENTRAIL_APP_MODE_REMEDIATION_ENABLED: "false"
-  IDENTRAIL_APP_MODE_PREMIUM_ENABLED: "false"
-  IDENTRAIL_APP_MODE_PREMIUM_REPORTS_ENABLED: "false"
-  IDENTRAIL_APP_MODE_PREMIUM_AUTOFIX_ENABLED: "false"
-  IDENTRAIL_APP_MODE_ROLLOUT_ENABLED: "false"
-  IDENTRAIL_APP_MODE_ROLLOUT_CANARY_PERCENT: "0"
-  IDENTRAIL_APP_MODE_ROLLOUT_TENANT_ALLOWLIST: ""
-  IDENTRAIL_APP_MODE_ROLLOUT_WORKSPACE_ALLOWLIST: ""
   IDENTRAIL_RATE_LIMIT_RPM: "120"
   IDENTRAIL_RATE_LIMIT_BURST: "20"
   IDENTRAIL_SCAN_QUEUE_MAX_PENDING: "25"
@@ -172,9 +158,6 @@ config:
   IDENTRAIL_OIDC_WRITE_SCOPES: identrail.write,identrail.admin,write,admin
   IDENTRAIL_DEFAULT_TENANT_ID: default
   IDENTRAIL_DEFAULT_WORKSPACE_ID: default
-  IDENTRAIL_REQUIRE_EXPLICIT_SCOPE: "true"
-  IDENTRAIL_ALLOW_MEMORY_STORE: "false"
-  IDENTRAIL_CONNECTOR_SECRET_KEYS_REQUIRED: "false"
   IDENTRAIL_OIDC_TENANT_CLAIM: tenant_id
   IDENTRAIL_OIDC_WORKSPACE_CLAIM: workspace_id
   IDENTRAIL_OIDC_GROUPS_CLAIM: groups
@@ -190,7 +173,6 @@ secret:
     IDENTRAIL_API_KEYS: ""
     IDENTRAIL_WRITE_API_KEYS: ""
     IDENTRAIL_DATABASE_URL: "postgres://identrail:replace-password@postgres:5432/identrail?sslmode=require"
-    IDENTRAIL_CONNECTOR_SECRET_KEYS: ""
     IDENTRAIL_API_KEY_SCOPES: ""
     IDENTRAIL_ALERT_WEBHOOK_URL: ""
     IDENTRAIL_ALERT_HMAC_SECRET: ""
@@ -204,4 +186,3 @@ secret:
     IDENTRAIL_AUDIT_FORWARD_MAX_RETRIES: "1"
     IDENTRAIL_AUDIT_FORWARD_RETRY_BACKOFF: 1s
     IDENTRAIL_AUDIT_FORWARD_HMAC_SECRET: ""
-    IDENTRAIL_AUDIT_FINGERPRINT_SECRET: ""

--- a/deploy/helm/identrail/values.yaml
+++ b/deploy/helm/identrail/values.yaml
@@ -13,6 +13,7 @@ api:
     runAsNonRoot: true
   securityContext:
     allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
     capabilities:
       drop:
         - ALL
@@ -37,7 +38,6 @@ worker:
     runAsNonRoot: true
   securityContext:
     allowPrivilegeEscalation: false
-    readOnlyRootFilesystem: true
     capabilities:
       drop:
         - ALL
@@ -126,6 +126,7 @@ config:
   IDENTRAIL_KUBECTL_PATH: /usr/bin/kubectl
   IDENTRAIL_KUBE_CONTEXT: ""
   IDENTRAIL_REQUIRE_LIVE_SOURCES: "true"
+  IDENTRAIL_REQUIRE_EXPLICIT_SCOPE: "true"
   IDENTRAIL_HTTP_ADDR: ":8080"
   IDENTRAIL_LOCK_BACKEND: auto
   IDENTRAIL_LOCK_NAMESPACE: identrail

--- a/deploy/kubernetes/api-deployment.yaml
+++ b/deploy/kubernetes/api-deployment.yaml
@@ -16,16 +16,11 @@ spec:
       labels:
         app: identrail-api
     spec:
-      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        seccompProfile:
-          type: RuntimeDefault
       containers:
         - name: api
-          image: ghcr.io/identrail/identrail-api:v1.0.0
+          image: ghcr.io/oluwatobi-mustapha/identrail-api:v0.1.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -62,9 +57,6 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
             capabilities:
               drop:
                 - ALL

--- a/deploy/kubernetes/api-deployment.yaml
+++ b/deploy/kubernetes/api-deployment.yaml
@@ -16,11 +16,12 @@ spec:
       labels:
         app: identrail-api
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
       containers:
         - name: api
-          image: ghcr.io/oluwatobi-mustapha/identrail-api:v0.1.0
+          image: ghcr.io/identrail/identrail-api:v0.1.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/deploy/kubernetes/migration-job.yaml
+++ b/deploy/kubernetes/migration-job.yaml
@@ -14,11 +14,12 @@ spec:
         app: identrail-migrations
     spec:
       restartPolicy: OnFailure
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
       containers:
         - name: migrations
-          image: ghcr.io/oluwatobi-mustapha/identrail-api:v0.1.0
+          image: ghcr.io/identrail/identrail-api:v0.1.0
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:

--- a/deploy/kubernetes/migration-job.yaml
+++ b/deploy/kubernetes/migration-job.yaml
@@ -14,16 +14,11 @@ spec:
         app: identrail-migrations
     spec:
       restartPolicy: OnFailure
-      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        seccompProfile:
-          type: RuntimeDefault
       containers:
         - name: migrations
-          image: ghcr.io/identrail/identrail-api:v1.0.0
+          image: ghcr.io/oluwatobi-mustapha/identrail-api:v0.1.0
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -45,9 +40,6 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
             capabilities:
               drop:
                 - ALL

--- a/deploy/kubernetes/worker-deployment.yaml
+++ b/deploy/kubernetes/worker-deployment.yaml
@@ -16,11 +16,12 @@ spec:
       labels:
         app: identrail-worker
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
       containers:
         - name: worker
-          image: ghcr.io/oluwatobi-mustapha/identrail-worker:v0.1.0
+          image: ghcr.io/identrail/identrail-worker:v0.1.0
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:

--- a/deploy/kubernetes/worker-deployment.yaml
+++ b/deploy/kubernetes/worker-deployment.yaml
@@ -16,16 +16,11 @@ spec:
       labels:
         app: identrail-worker
     spec:
-      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        seccompProfile:
-          type: RuntimeDefault
       containers:
         - name: worker
-          image: ghcr.io/identrail/identrail-worker:v1.0.0
+          image: ghcr.io/oluwatobi-mustapha/identrail-worker:v0.1.0
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -35,22 +30,6 @@ spec:
           env:
             - name: IDENTRAIL_RUN_MIGRATIONS
               value: "false"
-          readinessProbe:
-            exec:
-              command:
-                - /usr/local/bin/identrail
-                - --healthcheck
-            initialDelaySeconds: 5
-            periodSeconds: 30
-            timeoutSeconds: 2
-          livenessProbe:
-            exec:
-              command:
-                - /usr/local/bin/identrail
-                - --healthcheck
-            initialDelaySeconds: 30
-            periodSeconds: 30
-            timeoutSeconds: 2
           resources:
             requests:
               cpu: 100m
@@ -61,9 +40,6 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
             capabilities:
               drop:
                 - ALL


### PR DESCRIPTION
## Summary

Describe what changed.

## Why

Describe the problem this PR solves.

## Scope

- [ ] Focused change (no unrelated modifications)
- [ ] Backward compatibility considered
- [ ] Risk level assessed

## Validation

List the checks you ran and their outcomes.

```bash
# Example:
# go test ./...
# npm run test:ci --prefix web
```

## Checklist

- [ ] Tests added/updated for behavior changes
- [ ] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [ ] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

If AI tools were used materially for this PR, complete the fields below.

- AI-assisted: yes/no
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Required for this repository size:

- Include at least one issue reference using closing/reference keywords:
  - `Closes #123`, `Fixes #123`, or `Refs #123`
- If no issue exists, include an explicit exemption with rationale:
  - `No issue: <reason>` (for example: docs-only typo fix, CI-only fix, or emergency hotfix)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Helm and Kubernetes defaults to use v0.1.0 images and align packaging for review/test deployments. Reduces API replicas to 1 and simplifies pod security and config.

- **Refactors**
  - Helm: switch images to `identrail/api`, `identrail/worker`, `identrail/web` with tag `v0.1.0`; set `api` replicas to 1.
  - Kubernetes: bump `api`, `worker`, and `migration` images to `v0.1.0`; remove `runAsUser`, `runAsGroup`, and `seccompProfile` while keeping non-root and no-privilege escalation; drop worker probes.
  - Config: set `IDENTRAIL_K8S_SOURCE=fixture`; enable `IDENTRAIL_REQUIRE_EXPLICIT_SCOPE`; remove worker job-queue and `APP_MODE*` flags; prune unused secrets.

<sup>Written for commit d3a5291956976b97c3e5fd8221d2dd22aea9631b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

