### PR TITLE
Strengthen hero visual desktop shift

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9285,6 +9285,12 @@ html[data-theme='light'] .idt-hero,
   transform: translateX(clamp(-3.75rem, calc(1.75rem - 4.5vw), -1.8rem));
 }
 
+@media (min-width: 1440px) {
+  .idt-hero-product-stage {
+    transform: translateX(clamp(-7.5rem, calc(4rem - 9vw), -4.75rem));
+  }
+}
+
 .idt-hero-backdrop-panel {
   display: block;
   inset: 0;


### PR DESCRIPTION
## Summary

Added a wide-desktop override that shifts the homepage hero product visual container further left than the previous merged adjustment.

## Why

The first spacing PR was too subtle on wide screens, so the product container still looked almost unchanged in production. This follow-up makes the desktop movement visible while preserving the safer existing layout for smaller desktop, tablet, and mobile breakpoints.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation

```bash
npm run build --prefix web
npm run test --prefix web -- --run src/App.test.tsx src/components/marketingCtaRoutes.test.tsx src/components/home/HeroOpenSourceProofPills.test.tsx
git diff --check
```

All checks passed.

Visual check:
- Rendered the built site locally at a 2048x1280 viewport and confirmed the product visual moves left without clipping the hero copy or colliding with the CTA row.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

No tests/docs/changelog changes were needed because this is a CSS-only responsive layout adjustment.

## AI Assistance Disclosure

- AI-assisted: yes
- Tools used: ChatGPT/Codex
- Areas where used: `web/src/styles.css`
- Human verification performed: reviewed the focused CSS diff, ran web build, focused web tests, `git diff --check`, and locally rendered the built homepage at wide desktop size.

## Related Issues

No issue: targeted visual spacing follow-up from homepage hero review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the left shift of the homepage hero product visual on ≥1440px screens so the movement is clearly visible. Adds a `@media (min-width: 1440px)` override that applies `transform: translateX(clamp(-7.5rem, calc(4rem - 9vw), -4.75rem))` to `.idt-hero-product-stage`; smaller breakpoints unchanged.

<sup>Written for commit 422f7fc16bfaf5719bc55da7d1735882e7b9d32f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

