### PR TITLE
Polish homepage product tour section

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -68,7 +68,9 @@ describe('App', () => {
     expect(screen.getByRole('link', { name: /Book Demo/i })).toBeInTheDocument();
     expect(screen.getAllByText(/Adoption Paths/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Reachable Risk Paths/i).length).toBeGreaterThan(0);
-    expect(screen.getByRole('heading', { level: 2, name: /From connector setup to board-ready risk evidence/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: /From connector setup to evidence-ready remediation/i })
+    ).toBeInTheDocument();
   });
 
   it('renders pricing page routes and key elements', () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -90,29 +90,72 @@ const DIFFERENTIATION_ROWS = [
 const PRODUCT_TOUR_STEPS = [
   {
     step: '01',
-    title: 'Connect read-only signals',
-    detail: 'Add AWS IAM, Kubernetes, GitHub, and OIDC sources without granting write access.',
-    proof: 'Least-privilege connector scope'
+    title: 'Connect read-only sources',
+    detail: 'Validate AWS IAM, Kubernetes, GitHub Actions, and OIDC claims without write permissions.',
+    proof: 'Connector scope',
+    active: true
   },
   {
     step: '02',
-    title: 'Rank reachable risk paths',
-    detail: 'See which identities can reach production resources and why the path matters.',
-    proof: 'Blast-radius queue'
+    title: 'Trace reachable risk paths',
+    detail: 'Show the identity, workload, role, and resource in one chain with severity context.',
+    proof: 'Reachable path',
+    active: false
   },
   {
     step: '03',
     title: 'Simulate the first safe fix',
-    detail: 'Preview trust-policy and RBAC changes before enforcement to avoid workload breakage.',
-    proof: 'Policy simulation'
+    detail: 'Preview trust-policy and RBAC edits before anything touches production.',
+    proof: 'Policy simulation',
+    active: false
   },
   {
     step: '04',
     title: 'Export the evidence packet',
-    detail: 'Package source evidence, owner notes, timeline, and residual risk for review.',
-    proof: 'Audit-ready report'
+    detail: 'Package the source proof, owner note, policy diff, and residual risk for review.',
+    proof: 'Evidence packet',
+    active: false
   }
 ] as const;
+
+const PRODUCT_TOUR_CONNECTORS = [
+  {
+    name: 'AWS IAM',
+    status: 'Read-only',
+    icon: '/brand-logos/aws.svg'
+  },
+  {
+    name: 'Kubernetes',
+    status: 'Namespace scope',
+    icon: '/brand-logos/kubernetes.svg'
+  },
+  {
+    name: 'GitHub/OIDC',
+    status: 'Claims only',
+    icon: '/brand-logos/github.svg'
+  }
+] as const;
+
+const PRODUCT_TOUR_PATH = [
+  {
+    label: 'Identity',
+    value: 'GitHub Actions OIDC'
+  },
+  {
+    label: 'Privilege',
+    value: 'AWS IAM role: billing-prod'
+  },
+  {
+    label: 'Workload',
+    value: 'payments-api namespace'
+  },
+  {
+    label: 'Resource',
+    value: 'PostgreSQL billing ledger'
+  }
+] as const;
+
+const PRODUCT_TOUR_PACKET = ['Source proof', 'Policy diff', 'Affected workload', 'Owner timeline'] as const;
 
 const FEATURE_ROWS = [
   {
@@ -1478,19 +1521,24 @@ function ProductTourSection() {
     <section className="idt-section idt-shell idt-product-tour" aria-labelledby="product-tour-title">
       <div className="idt-product-tour-copy">
         <p className="idt-eyebrow">Product tour</p>
-        <h2 id="product-tour-title">From connector setup to board-ready risk evidence.</h2>
+        <h2 id="product-tour-title">From connector setup to evidence-ready remediation.</h2>
         <p>
-          A tighter product story: connect safely, find reachable risk, simulate remediation, and export proof without
-          repeating the same trust-graph promise section after section.
+          Connect read-only sources, trace the path to sensitive resources, test the safest fix, and hand owners one
+          evidence packet they can act on.
         </p>
       </div>
 
       <div className="idt-product-tour-shell" aria-label="Identrail product workflow preview">
         <div className="idt-tour-rail">
           {PRODUCT_TOUR_STEPS.map((item) => (
-            <article key={item.step} className="idt-tour-step">
-              <span>{item.step}</span>
+            <article
+              key={item.step}
+              aria-current={item.active ? 'step' : undefined}
+              className={`idt-tour-step${item.active ? ' is-active' : ''}`}
+            >
+              <span className="idt-tour-step-index">{item.step}</span>
               <div>
+                <small>{item.proof}</small>
                 <h3>{item.title}</h3>
                 <p>{item.detail}</p>
               </div>
@@ -1500,23 +1548,74 @@ function ProductTourSection() {
 
         <div className="idt-tour-screen">
           <div className="idt-tour-screen-head">
-            <div>
-              <p>Live trust path investigation</p>
-              <h3>Reachable Risk Paths</h3>
+            <div className="idt-tour-window-dots" aria-hidden="true">
+              <span />
+              <span />
+              <span />
             </div>
-            <span>4 evidence artifacts</span>
+            <div>
+              <p>Production workspace</p>
+              <h3>Owner-ready risk path</h3>
+            </div>
+            <span>Evidence ready</span>
           </div>
-          <div className="idt-tour-finding-grid">
-            {PRODUCT_TOUR_STEPS.map((item) => (
-              <article key={item.proof}>
-                <small>{item.proof}</small>
-                <strong>{item.title}</strong>
-              </article>
-            ))}
-          </div>
-          <div className="idt-tour-report">
-            <p>Export packet</p>
-            <strong>Source evidence, policy diff, affected workloads, owner timeline, residual risk</strong>
+
+          <div className="idt-tour-product-preview">
+            <aside className="idt-tour-connector-scope" aria-label="Read-only connector scope">
+              <p>Connector scope</p>
+              {PRODUCT_TOUR_CONNECTORS.map((connector) => (
+                <article key={connector.name}>
+                  <img src={connector.icon} alt="" aria-hidden="true" loading="lazy" />
+                  <div>
+                    <strong>{connector.name}</strong>
+                    <span>{connector.status}</span>
+                  </div>
+                </article>
+              ))}
+            </aside>
+
+            <div className="idt-tour-path-panel">
+              <div className="idt-tour-path-head">
+                <div>
+                  <p>Reachable path</p>
+                  <h4>GitHub workflow can reach billing data through AWS role trust.</h4>
+                </div>
+                <span>High</span>
+              </div>
+
+              <div className="idt-tour-path-chain" aria-label="Machine identity path">
+                {PRODUCT_TOUR_PATH.map((node) => (
+                  <article key={node.label}>
+                    <small>{node.label}</small>
+                    <strong>{node.value}</strong>
+                  </article>
+                ))}
+              </div>
+            </div>
+
+            <div className="idt-tour-simulation">
+              <div>
+                <p>Safe fix simulation</p>
+                <strong>Restrict subject claim and namespace tags</strong>
+              </div>
+              <code>
+                <span className="is-remove">- sub = "*"</span>
+                <span className="is-add">+ sub = "repo:payments-api:prod"</span>
+                <span className="is-add">+ namespace = "payments-api"</span>
+              </code>
+            </div>
+
+            <div className="idt-tour-evidence-packet">
+              <div>
+                <p>Evidence packet</p>
+                <strong>Ready for owner review</strong>
+              </div>
+              <ul aria-label="Evidence packet contents">
+                {PRODUCT_TOUR_PACKET.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
           </div>
         </div>
       </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -10577,3 +10577,559 @@ html[data-theme='light'] .idt-problem-map-core div span {
     transition: none;
   }
 }
+
+/* Product tour: Vercel-like guided workflow surface. */
+.idt-product-tour {
+  display: grid;
+  gap: 2rem;
+  padding-block: clamp(4.5rem, 7vw, 6.5rem);
+}
+
+.idt-product-tour-copy {
+  max-width: 780px;
+}
+
+.idt-product-tour-copy h2,
+html[data-theme='light'] .idt-product-tour-copy h2 {
+  max-width: 14ch;
+  margin: 0.18rem 0 0;
+  color: #111827;
+  font-size: clamp(3.05rem, 5vw, 4.35rem);
+  font-weight: 610;
+  line-height: 1.02;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.idt-product-tour-copy p:not(.idt-eyebrow),
+html[data-theme='light'] .idt-product-tour-copy p:not(.idt-eyebrow) {
+  max-width: 58ch;
+  margin: 1.1rem 0 0;
+  color: #4f5a6b;
+  font-size: 1.08rem;
+  line-height: 1.72;
+}
+
+.idt-product-tour-shell,
+html[data-theme='light'] .idt-product-tour-shell {
+  display: grid;
+  grid-template-columns: minmax(320px, 0.76fr) minmax(620px, 1.24fr);
+  gap: 1rem;
+  align-items: stretch;
+  max-width: 100%;
+  min-width: 0;
+  padding: 1rem;
+  border: 1px solid rgba(17, 24, 39, 0.1);
+  border-radius: 28px;
+  background:
+    radial-gradient(circle at 4% 4%, rgba(109, 55, 221, 0.06), transparent 28%),
+    linear-gradient(180deg, #ffffff 0%, #fbfbfb 100%);
+  box-shadow: 0 34px 90px rgba(17, 24, 39, 0.1);
+}
+
+.idt-tour-rail {
+  display: grid;
+  gap: 0.55rem;
+  align-content: start;
+  min-width: 0;
+}
+
+.idt-tour-step,
+html[data-theme='light'] .idt-tour-step {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.85rem;
+  min-height: 112px;
+  padding: 1rem;
+  border: 1px solid transparent;
+  border-radius: 20px;
+  background: transparent;
+  box-shadow: none;
+  min-width: 0;
+}
+
+.idt-tour-step > div,
+.idt-tour-screen,
+.idt-tour-product-preview,
+.idt-tour-connector-scope,
+.idt-tour-path-panel,
+.idt-tour-simulation,
+.idt-tour-evidence-packet {
+  min-width: 0;
+}
+
+.idt-tour-step.is-active,
+html[data-theme='light'] .idt-tour-step.is-active {
+  border-color: rgba(17, 24, 39, 0.12);
+  background:
+    radial-gradient(circle at 12% 20%, rgba(109, 55, 221, 0.1), transparent 36%),
+    #0b0d12;
+  box-shadow: 0 22px 54px rgba(17, 24, 39, 0.18);
+}
+
+.idt-tour-step-index,
+.idt-tour-step > span,
+html[data-theme='light'] .idt-tour-step > span {
+  width: 2rem;
+  height: 2rem;
+  display: inline-grid;
+  place-items: center;
+  border-radius: 999px;
+  background: #f2efff;
+  color: #6d37dd;
+  font-size: 0.72rem;
+  font-weight: 760;
+}
+
+.idt-tour-step.is-active .idt-tour-step-index,
+html[data-theme='light'] .idt-tour-step.is-active .idt-tour-step-index {
+  background: #ffffff;
+  color: #111827;
+}
+
+.idt-tour-step small {
+  display: block;
+  margin: 0 0 0.28rem;
+  color: #7a8495;
+  font-size: 0.66rem;
+  font-weight: 780;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.idt-tour-step h3,
+html[data-theme='light'] .idt-tour-step h3 {
+  margin: 0;
+  color: #151922;
+  font-size: 1rem;
+  font-weight: 720;
+  line-height: 1.2;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.idt-tour-step p,
+html[data-theme='light'] .idt-tour-step p {
+  margin: 0.38rem 0 0;
+  color: #5b6678;
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+
+.idt-tour-step.is-active small {
+  color: rgba(255, 255, 255, 0.58);
+}
+
+.idt-tour-step.is-active h3,
+html[data-theme='light'] .idt-tour-step.is-active h3 {
+  color: #ffffff;
+}
+
+.idt-tour-step.is-active p,
+html[data-theme='light'] .idt-tour-step.is-active p {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.idt-tour-screen,
+html[data-theme='light'] .idt-tour-screen {
+  overflow: hidden;
+  border: 1px solid rgba(17, 24, 39, 0.1);
+  border-radius: 24px;
+  background: #f8f9fb;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.95),
+    0 18px 50px rgba(17, 24, 39, 0.08);
+}
+
+.idt-tour-screen-head {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.95rem 1rem;
+  border-bottom: 1px solid rgba(17, 24, 39, 0.08);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(247, 248, 251, 0.92)),
+    #ffffff;
+}
+
+.idt-tour-window-dots {
+  display: inline-flex;
+  gap: 0.34rem;
+}
+
+.idt-tour-window-dots span {
+  width: 0.58rem;
+  height: 0.58rem;
+  border-radius: 999px;
+  background: #d9dde4;
+}
+
+.idt-tour-screen-head p,
+.idt-tour-path-head p,
+.idt-tour-connector-scope > p,
+.idt-tour-simulation p,
+.idt-tour-evidence-packet p,
+html[data-theme='light'] .idt-tour-screen-head p {
+  margin: 0;
+  color: #6d37dd;
+  font-size: 0.68rem;
+  font-weight: 780;
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.idt-tour-screen-head h3,
+html[data-theme='light'] .idt-tour-screen-head h3 {
+  margin: 0.18rem 0 0;
+  color: #151922;
+  font-size: 1.06rem;
+  font-weight: 720;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.idt-tour-screen-head > span,
+html[data-theme='light'] .idt-tour-screen-head > span {
+  border: 1px solid rgba(24, 155, 97, 0.18);
+  border-radius: 999px;
+  padding: 0.42rem 0.62rem;
+  background: #e9fbf2;
+  color: #147348;
+  font-size: 0.74rem;
+  font-weight: 720;
+  white-space: nowrap;
+}
+
+.idt-tour-product-preview {
+  display: grid;
+  grid-template-columns: minmax(190px, 0.46fr) minmax(0, 1fr);
+  gap: 0.9rem;
+  padding: 1rem;
+}
+
+.idt-tour-connector-scope,
+.idt-tour-path-panel,
+.idt-tour-simulation,
+.idt-tour-evidence-packet {
+  border: 1px solid rgba(17, 24, 39, 0.09);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 12px 30px rgba(17, 24, 39, 0.05);
+}
+
+.idt-tour-connector-scope {
+  display: grid;
+  gap: 0.65rem;
+  align-content: start;
+  padding: 0.9rem;
+}
+
+.idt-tour-connector-scope article {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.58rem;
+  align-items: center;
+  padding: 0.72rem;
+  border-radius: 14px;
+  background: #f7f8fa;
+}
+
+.idt-tour-connector-scope img {
+  width: 1.45rem;
+  height: 1.45rem;
+  object-fit: contain;
+}
+
+.idt-tour-connector-scope strong,
+.idt-tour-connector-scope span {
+  display: block;
+}
+
+.idt-tour-connector-scope strong {
+  color: #151922;
+  font-size: 0.82rem;
+  line-height: 1.2;
+}
+
+.idt-tour-connector-scope span {
+  margin-top: 0.1rem;
+  color: #667085;
+  font-size: 0.72rem;
+  line-height: 1.2;
+}
+
+.idt-tour-path-panel {
+  padding: 1rem;
+}
+
+.idt-tour-path-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.idt-tour-path-head h4 {
+  max-width: 36ch;
+  margin: 0.28rem 0 0;
+  color: #111827;
+  font-size: 1.32rem;
+  font-weight: 710;
+  line-height: 1.18;
+  letter-spacing: 0;
+}
+
+.idt-tour-path-head > span {
+  border-radius: 999px;
+  padding: 0.38rem 0.56rem;
+  background: #fff3df;
+  color: #9a4f00;
+  font-size: 0.72rem;
+  font-weight: 780;
+}
+
+.idt-tour-path-chain {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.6rem;
+  margin-top: 1rem;
+}
+
+.idt-tour-path-chain::before {
+  content: '';
+  position: absolute;
+  left: 8%;
+  right: 8%;
+  top: 1.25rem;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(109, 55, 221, 0.28), rgba(20, 115, 72, 0.32));
+}
+
+.idt-tour-path-chain article {
+  position: relative;
+  min-height: 102px;
+  padding: 2.2rem 0.7rem 0.72rem;
+  border: 1px solid rgba(17, 24, 39, 0.08);
+  border-radius: 15px;
+  background: #ffffff;
+}
+
+.idt-tour-path-chain article::before {
+  content: '';
+  position: absolute;
+  left: 0.72rem;
+  top: 0.92rem;
+  width: 0.66rem;
+  height: 0.66rem;
+  border: 3px solid #ffffff;
+  border-radius: 999px;
+  background: #6d37dd;
+  box-shadow: 0 0 0 1px rgba(109, 55, 221, 0.28);
+}
+
+.idt-tour-path-chain article:last-child::before {
+  background: #147348;
+  box-shadow: 0 0 0 1px rgba(20, 115, 72, 0.28);
+}
+
+.idt-tour-path-chain small {
+  display: block;
+  color: #8a94a6;
+  font-size: 0.64rem;
+  font-weight: 760;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.idt-tour-path-chain strong {
+  display: block;
+  margin-top: 0.24rem;
+  color: #151922;
+  font-size: 0.76rem;
+  line-height: 1.36;
+}
+
+.idt-tour-simulation,
+.idt-tour-evidence-packet {
+  padding: 0.9rem;
+}
+
+.idt-tour-simulation {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.idt-tour-simulation strong,
+.idt-tour-evidence-packet strong {
+  display: block;
+  margin-top: 0.26rem;
+  color: #151922;
+  font-size: 0.92rem;
+  line-height: 1.3;
+}
+
+.idt-tour-simulation code {
+  display: grid;
+  gap: 0.28rem;
+  padding: 0.75rem;
+  border: 1px solid rgba(17, 24, 39, 0.08);
+  border-radius: 14px;
+  background: #0b0d12;
+  color: #d9e2f2;
+  font-family: var(--font-mono, 'IBM Plex Mono', 'SFMono-Regular', monospace);
+  font-size: 0.72rem;
+  line-height: 1.45;
+  white-space: normal;
+}
+
+.idt-tour-simulation code span {
+  display: block;
+}
+
+.idt-tour-simulation code .is-remove {
+  color: #ffaaa5;
+}
+
+.idt-tour-simulation code .is-add {
+  color: #8ee8bf;
+}
+
+.idt-tour-evidence-packet {
+  display: grid;
+  grid-template-columns: minmax(0, 0.72fr) minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.idt-tour-evidence-packet ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.42rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.idt-tour-evidence-packet li {
+  border: 1px solid rgba(17, 24, 39, 0.08);
+  border-radius: 999px;
+  padding: 0.38rem 0.52rem;
+  background: #f7f8fa;
+  color: #3f4858;
+  font-size: 0.7rem;
+  font-weight: 680;
+}
+
+@media (max-width: 1120px) {
+  .idt-product-tour-shell,
+  html[data-theme='light'] .idt-product-tour-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-tour-rail {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 860px) {
+  .idt-product-tour-copy h2,
+  html[data-theme='light'] .idt-product-tour-copy h2 {
+    font-size: 2.75rem;
+  }
+
+  .idt-tour-rail,
+  .idt-tour-product-preview {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-tour-path-chain {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-tour-path-chain::before {
+    left: 1rem;
+    right: auto;
+    top: 1rem;
+    bottom: 1rem;
+    width: 1px;
+    height: auto;
+    background: linear-gradient(180deg, rgba(109, 55, 221, 0.28), rgba(20, 115, 72, 0.32));
+  }
+
+  .idt-tour-evidence-packet {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 560px) {
+  .idt-product-tour {
+    padding-block: 3.5rem;
+    overflow: hidden;
+  }
+
+  .idt-product-tour-copy h2,
+  html[data-theme='light'] .idt-product-tour-copy h2 {
+    font-size: 2.3rem;
+  }
+
+  .idt-product-tour-shell,
+  html[data-theme='light'] .idt-product-tour-shell {
+    display: block;
+    max-width: 100%;
+    overflow: hidden;
+    padding: 0.7rem;
+    border-radius: 22px;
+  }
+
+  .idt-tour-rail,
+  .idt-tour-screen {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .idt-tour-rail {
+    margin-bottom: 0.75rem;
+  }
+
+  .idt-tour-screen-head {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-tour-window-dots {
+    display: none;
+  }
+
+  .idt-tour-step,
+  html[data-theme='light'] .idt-tour-step {
+    grid-template-columns: 1fr;
+    min-height: auto;
+  }
+
+  .idt-tour-step p,
+  .idt-product-tour-copy p:not(.idt-eyebrow),
+  .idt-tour-path-head h4,
+  .idt-tour-path-chain strong,
+  .idt-tour-simulation strong {
+    overflow-wrap: anywhere;
+  }
+
+  .idt-tour-path-head {
+    display: grid;
+  }
+
+  .idt-tour-path-head > span {
+    width: fit-content;
+  }
+
+  .idt-tour-path-chain article {
+    min-height: auto;
+  }
+
+  .idt-tour-simulation code {
+    font-size: 0.66rem;
+  }
+}


### PR DESCRIPTION
Fixes #1049

## What changed
- Rewrote the homepage product-tour headline and intro copy around evidence-ready remediation.
- Removed the duplicated four-step cards from the right side of the section.
- Rebuilt the left side as a guided four-step product-tour stepper with an active first step.
- Replaced the right side with one Vercel-like Identrail product surface showing connector scope, reachable path context, safe-fix simulation, and evidence packet contents.
- Added responsive polish so the section keeps the same product-led hierarchy across desktop, tablet, and phone widths.

## Why
The previous section repeated the same product story twice and felt more like marketing cards than a premium product workflow. The new version keeps the four-step narrative but makes the right side do real visual work: it shows what Identrail produces from read-only connectors through remediation proof.

## Impact and risk
- UI-only homepage change in the public web app.
- Uses existing same-origin brand logo assets under `/brand-logos`.
- No API, backend, or deployment config changes.

## Validation
- `npm run build --prefix web`
- `npm run test --prefix web -- --run src/App.test.tsx src/components/marketingCtaRoutes.test.tsx src/components/home/HeroOpenSourceProofPills.test.tsx`
- `git diff --check`
- Local preview screenshot review at `http://127.0.0.1:4187/`

## AI disclosure
- AI-assisted: yes
- Tools used: ChatGPT/Codex
- Where used: `web/src/App.tsx`, `web/src/App.test.tsx`, `web/src/styles.css`
- Human verification performed: local build, focused web tests, diff check, and visual screenshot review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt the homepage product tour into a guided four-step workflow centered on evidence-ready remediation. The section now shows real product surfaces, adds clear step/status cues, and keeps a consistent hierarchy across breakpoints.

- **New Features**
  - Updated headline and intro copy to “From connector setup to evidence-ready remediation.”
  - Left rail is now a four-step guided tour with an active first step; removed duplicated right-side cards.
  - Right pane shows one product surface: read-only connector scope with logos, reachable path chain with severity, safe-fix simulation diff, and an evidence packet list.
  - Added responsive styles and ARIA labels; updated test for the new heading. UI-only change, no API/backend updates.

<sup>Written for commit 562fa9fb9bbc460057bd9efe8a7272c6202fd3a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

