### PR TITLE
Follow-up: avoid scoped fallback in queue-depth metrics

### DIFF
--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -562,9 +562,11 @@ func (s *Service) recordQueueDepth(queue string, depth int) {
 
 func (s *Service) countQueuedScansForDepth(ctx context.Context, provider string) int {
 	if counter, ok := s.Store.(queuedScanDepthCounter); ok {
-		if count, err := counter.CountQueuedScansAnyScope(ctx, provider); err == nil {
-			return count
+		count, err := counter.CountQueuedScansAnyScope(ctx, provider)
+		if err != nil {
+			return 0
 		}
+		return count
 	}
 	count, err := s.Store.CountQueuedScans(ctx, provider)
 	if err != nil {
@@ -575,9 +577,11 @@ func (s *Service) countQueuedScansForDepth(ctx context.Context, provider string)
 
 func (s *Service) countQueuedRepoScansForDepth(ctx context.Context) int {
 	if counter, ok := s.Store.(queuedRepoScanDepthCounter); ok {
-		if count, err := counter.CountQueuedRepoScansAnyScope(ctx); err == nil {
-			return count
+		count, err := counter.CountQueuedRepoScansAnyScope(ctx)
+		if err != nil {
+			return 0
 		}
+		return count
 	}
 	count, err := s.Store.CountQueuedRepoScans(ctx)
 	if err != nil {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -61,6 +61,18 @@ type completionContextStore struct {
 	lastRepoScanCompletionCtxErr error
 }
 
+type failingAnyScopeDepthStore struct {
+	*db.MemoryStore
+}
+
+func (s *failingAnyScopeDepthStore) CountQueuedScansAnyScope(context.Context, string) (int, error) {
+	return 0, errors.New("count queued scans any scope failed")
+}
+
+func (s *failingAnyScopeDepthStore) CountQueuedRepoScansAnyScope(context.Context) (int, error) {
+	return 0, errors.New("count queued repo scans any scope failed")
+}
+
 func (s *completionContextStore) CompleteScan(
 	ctx context.Context,
 	scanID string,
@@ -1513,6 +1525,29 @@ func TestServiceEnqueueScanAndProcessQueue(t *testing.T) {
 	}
 }
 
+func TestServiceCountQueuedScansForDepthReturnsZeroWhenAnyScopeCountFails(t *testing.T) {
+	store := &failingAnyScopeDepthStore{MemoryStore: db.NewMemoryStore()}
+	svc := NewService(store, fakeScanner{}, "aws")
+	scopedCtx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	now := time.Date(2026, 5, 10, 11, 30, 0, 0, time.UTC)
+
+	if _, err := store.CreateQueuedScanWithinLimit(scopedCtx, "aws", now, 5); err != nil {
+		t.Fatalf("create queued scan: %v", err)
+	}
+	scopedCount, err := store.CountQueuedScans(scopedCtx, "aws")
+	if err != nil {
+		t.Fatalf("count queued scans in scope: %v", err)
+	}
+	if scopedCount != 1 {
+		t.Fatalf("expected one scoped queued scan, got %d", scopedCount)
+	}
+
+	queuedCount := svc.countQueuedScansForDepth(scopedCtx, "aws")
+	if queuedCount != 0 {
+		t.Fatalf("expected depth 0 when any-scope count fails, got %d", queuedCount)
+	}
+}
+
 func TestServiceProcessNextQueuedScanFinalizesFailure(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 20, 9, 0, 0, 0, time.UTC)
@@ -1785,6 +1820,29 @@ func TestServiceEnqueueRepoScanAndProcessQueue(t *testing.T) {
 	}
 	if stored.Status != "succeeded" || stored.CommitsScanned != 25 {
 		t.Fatalf("unexpected processed repo scan record: %+v", stored)
+	}
+}
+
+func TestServiceCountQueuedRepoScansForDepthReturnsZeroWhenAnyScopeCountFails(t *testing.T) {
+	store := &failingAnyScopeDepthStore{MemoryStore: db.NewMemoryStore()}
+	svc := NewService(store, fakeScanner{}, "aws")
+	scopedCtx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	now := time.Date(2026, 5, 10, 11, 45, 0, 0, time.UTC)
+
+	if _, err := store.CreateQueuedRepoScanWithinLimit(scopedCtx, "owner/repo", 50, 200, now, 5); err != nil {
+		t.Fatalf("create queued repo scan: %v", err)
+	}
+	scopedCount, err := store.CountQueuedRepoScans(scopedCtx)
+	if err != nil {
+		t.Fatalf("count queued repo scans in scope: %v", err)
+	}
+	if scopedCount != 1 {
+		t.Fatalf("expected one scoped queued repo scan, got %d", scopedCount)
+	}
+
+	queuedCount := svc.countQueuedRepoScansForDepth(scopedCtx)
+	if queuedCount != 0 {
+		t.Fatalf("expected depth 0 when any-scope repo count fails, got %d", queuedCount)
 	}
 }
 


### PR DESCRIPTION
Fixes #971
Follow-up to #997.

## What changed
- Updated `countQueuedScansForDepth` so any-scope counter errors now return `0` immediately.
- Updated `countQueuedRepoScansForDepth` with the same behavior.
- Added regression tests that prove we do not fall back to scoped counts when any-scope counting fails.

## Why
The scoped fallback can overwrite global queue-depth gauges with tenant/workspace-local values, which makes the exported metric inaccurate.

## Validation
- `go test ./internal/api -run 'TestServiceCountQueuedScansForDepthReturnsZeroWhenAnyScopeCountFails|TestServiceCountQueuedRepoScansForDepthReturnsZeroWhenAnyScopeCountFails'`
- `go test ./...`

AI-assisted: No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop falling back to scoped counts when any-scope queue-depth queries fail. We now return 0 in that case so global queue-depth metrics stay accurate.

- **Bug Fixes**
  - Updated `countQueuedScansForDepth` and `countQueuedRepoScansForDepth` to return 0 on any-scope errors.
  - Added regression tests to ensure we never fall back to scoped counts.
  - Prevents tenant/workspace values from overwriting global gauges.

<sup>Written for commit ac2c47619761b92b72c5b6483f88493f4e038fd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

