### PR TITLE
Polish product hero narrative and layout

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -64,7 +64,7 @@ describe('App marketing surface (post-redesign)', () => {
     expect(
       screen.getByRole('heading', {
         level: 1,
-        name: /Trace every machine identity/i
+        name: /See every machine identity path/i
       })
     ).toBeInTheDocument();
 

--- a/web/src/components/home/Hero.tsx
+++ b/web/src/components/home/Hero.tsx
@@ -20,13 +20,12 @@ export function HomeHero() {
               Open core · Apache 2.0
             </Pill>
             <h1 className="u-mt-4">
-              Trace every machine identity.<br />
-              <em>Close the dangerous paths</em> safely.
+              See every machine identity path.<br />
+              <em>Fix the risky ones</em> safely.
             </h1>
             <p className="t-lede">
-              Identrail follows how AWS roles, Kubernetes service accounts, GitHub OIDC and trust
-              policies can reach your data — and shows the smallest, safest fix for the people who
-              own each step of the path.
+              Identrail shows how AWS IAM, Kubernetes, and GitHub OIDC paths reach sensitive
+              systems, then gives each team the safest fix.
             </p>
             <div className="home-hero-actions">
               <LinkButton to="/demo" variant="primary" size="lg">

--- a/web/src/components/ui/HeroVisuals.tsx
+++ b/web/src/components/ui/HeroVisuals.tsx
@@ -79,8 +79,10 @@ export function ProductHeroVisual() {
               {evidenceRows.map((row) => (
                 <article key={row.label}>
                   <span>{row.label}</span>
-                  <strong>{row.title}</strong>
-                  <small>{row.detail}</small>
+                  <div>
+                    <strong>{row.title}</strong>
+                    <small>{row.detail}</small>
+                  </div>
                 </article>
               ))}
             </div>

--- a/web/src/components/ui/HeroVisuals.tsx
+++ b/web/src/components/ui/HeroVisuals.tsx
@@ -1,6 +1,23 @@
 import type { ReactNode } from 'react';
 
 const pathSteps = ['GitHub OIDC', 'AWS IAM IdP', 'billing-prod role', 'PostgreSQL ledger'];
+const evidenceRows = [
+  {
+    label: '01',
+    title: 'GitHub OIDC token verified',
+    detail: 'repo: payments-api / deploy-production.yml'
+  },
+  {
+    label: '02',
+    title: 'AssumeRole path detected',
+    detail: 'sts:AssumeRole reaches billing-prod in 4 hops'
+  },
+  {
+    label: '03',
+    title: 'Safe fix simulated',
+    detail: 'Restrict subject claim without workload breakage'
+  }
+];
 
 function WindowChrome({ children, label }: { children: ReactNode; label: string }) {
   return (
@@ -28,10 +45,15 @@ export function ProductHeroVisual() {
           <div className="hero-visual-main">
             <div className="hero-visual-row">
               <div>
-                <span className="hero-visual-kicker">Production workspace</span>
-                <h3>Reachable risk path</h3>
+                <span className="hero-visual-kicker">Live trust path</span>
+                <h3>billing-prod is reachable</h3>
               </div>
               <span className="hero-visual-badge is-danger">Critical</span>
+            </div>
+            <div className="hero-visual-meta" aria-label="Risk path summary">
+              <span>4 hops</span>
+              <span>Owner matched</span>
+              <span>Fix simulated</span>
             </div>
             <div className="hero-path" aria-label="Resolved trust path">
               {pathSteps.map((step, index) => (
@@ -45,11 +67,22 @@ export function ProductHeroVisual() {
               <div className="hero-visual-metric">
                 <span>Owner</span>
                 <strong>payments-api</strong>
+                <small>Platform / production</small>
               </div>
               <div className="hero-visual-metric">
                 <span>Fix</span>
                 <strong>Restrict subject claim</strong>
+                <small>Safe in simulation</small>
               </div>
+            </div>
+            <div className="hero-evidence-list" aria-label="Evidence trail">
+              {evidenceRows.map((row) => (
+                <article key={row.label}>
+                  <span>{row.label}</span>
+                  <strong>{row.title}</strong>
+                  <small>{row.detail}</small>
+                </article>
+              ))}
             </div>
           </div>
         </div>

--- a/web/src/components/ui/PageHero.tsx
+++ b/web/src/components/ui/PageHero.tsx
@@ -6,6 +6,7 @@ type PageHeroProps = {
   lede?: ReactNode;
   actions?: ReactNode;
   visual?: ReactNode;
+  className?: string;
 };
 
 /**
@@ -13,9 +14,9 @@ type PageHeroProps = {
  * Distinguished from the Home hero by being more restrained and
  * left-aligned by default, with no decorative gradient.
  */
-export function PageHero({ eyebrow, title, lede, actions, visual }: PageHeroProps) {
+export function PageHero({ eyebrow, title, lede, actions, visual, className }: PageHeroProps) {
   return (
-    <section className={['page-hero', visual ? 'has-visual' : ''].filter(Boolean).join(' ')}>
+    <section className={['page-hero', visual ? 'has-visual' : '', className].filter(Boolean).join(' ')}>
       <div className="container">
         <div className="page-hero-inner">
           <div className="page-hero-copy">

--- a/web/src/lib/seoMap.ts
+++ b/web/src/lib/seoMap.ts
@@ -23,15 +23,15 @@ export const DEFAULT_KEYWORDS =
 
 export const ROUTE_META: Record<string, RouteMeta> = {
   '/': {
-    title: 'Identrail - Trace every machine identity. Close the dangerous paths safely.',
+    title: 'Identrail - See every machine identity path. Fix the risky ones safely.',
     description:
-      'Identrail traces how AWS roles, Kubernetes service accounts, GitHub OIDC and trust policies can reach your data - and shows the smallest, safest fix. Open core under Apache 2.0.',
+      'Identrail shows how AWS IAM, Kubernetes, and GitHub OIDC paths reach sensitive systems, then gives teams the safest fix. Open core under Apache 2.0.',
     keywords: DEFAULT_KEYWORDS
   },
   '/product': {
-    title: 'Product - One platform for machine identity discovery, detection, and rollout-safe control | Identrail',
+    title: 'Product - See every machine identity path and fix the risky ones | Identrail',
     description:
-      'Discover every machine identity, detect the paths that matter, and remediate without breaking production. Trust graph, simulator, operator surface - explained.',
+      'See every machine identity path, prioritise the risky ones, and simulate the safest fix before you ship it.',
     schemaType: 'Product'
   },
   '/integrations': {

--- a/web/src/pages/ProductPage.tsx
+++ b/web/src/pages/ProductPage.tsx
@@ -62,15 +62,16 @@ export function ProductPage() {
   return (
     <>
       <PageHero
+        className="page-hero-product"
         eyebrow="Product"
         title={
           <h1>
-            One platform for machine identity
+            See every machine identity path.
             <br />
-            <span style={{ color: 'var(--text-muted)' }}>discovery, detection and rollout-safe control.</span>
+            <span style={{ color: 'var(--text-muted)' }}>Fix the ones that matter.</span>
           </h1>
         }
-        lede="Identrail does the three things every team is currently stitching together with scripts and CSVs: see every identity, prioritise the ones that can reach something dangerous, and remediate without breaking production."
+        lede="Identrail maps reachable access across AWS IAM, Kubernetes, and GitHub OIDC, then shows the safest fix before you ship it."
         visual={<ProductHeroVisual />}
         actions={
           <>

--- a/web/src/siteConfig.ts
+++ b/web/src/siteConfig.ts
@@ -9,9 +9,9 @@
 export const SITE_URL = 'https://www.identrail.com';
 export const SITE_NAME = 'Identrail';
 
-export const TAGLINE = 'Trace every machine identity. Close the dangerous paths safely.';
+export const TAGLINE = 'See every machine identity path. Fix the risky ones safely.';
 export const SHORT_DESCRIPTION =
-  'Identrail traces every path a machine identity can take to your data - across AWS IAM, Kubernetes, GitHub Actions and OIDC - and shows how to close the dangerous ones safely.';
+  'Identrail shows how AWS IAM, Kubernetes, and GitHub OIDC paths reach sensitive systems, then gives teams the safest fix.';
 
 export const GITHUB_ORG = 'https://github.com/identrail';
 export const GITHUB_REPO = 'https://github.com/identrail/identrail';

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -468,7 +468,7 @@ main { display: block; }
 .page-hero-actions { margin-top: var(--space-8); display: flex; flex-wrap: wrap; gap: var(--space-3); }
 .page-hero-visual { min-width: 0; }
 .page-hero-product {
-  padding: var(--space-24) 0 var(--space-14);
+  padding: var(--space-24) 0 var(--space-12);
 }
 .page-hero-product .page-hero-inner {
   grid-template-columns: minmax(0, 0.84fr) minmax(420px, 1.06fr);
@@ -493,7 +493,7 @@ main { display: block; }
   color: var(--text-secondary);
 }
 .page-hero-product .page-hero-actions {
-  margin-top: var(--space-7);
+  margin-top: var(--space-6);
 }
 .page-hero-product .page-hero-visual {
   align-self: stretch;
@@ -517,7 +517,7 @@ main { display: block; }
   .page-hero-actions { flex-direction: column; align-items: stretch; }
   .page-hero-actions .btn { width: 100%; white-space: normal; min-height: 44px; height: auto; padding-block: var(--space-3); }
   .page-hero-product {
-    padding: var(--space-18) 0 var(--space-12);
+    padding: var(--space-16) 0 var(--space-12);
   }
   .page-hero-product h1 {
     max-width: min(100%, 11ch);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -467,8 +467,43 @@ main { display: block; }
 .page-hero .t-lede { margin-top: var(--space-5); max-width: 58ch; }
 .page-hero-actions { margin-top: var(--space-8); display: flex; flex-wrap: wrap; gap: var(--space-3); }
 .page-hero-visual { min-width: 0; }
+.page-hero-product {
+  padding: var(--space-24) 0 var(--space-14);
+}
+.page-hero-product .page-hero-inner {
+  grid-template-columns: minmax(0, 0.84fr) minmax(420px, 1.06fr);
+  gap: var(--space-10);
+  align-items: start;
+}
+.page-hero-product .page-hero-copy {
+  max-width: 35rem;
+  padding-top: var(--space-5);
+}
+.page-hero-product h1 {
+  max-width: 9.5ch;
+  font-size: clamp(2.9rem, 1.75rem + 3.9vw, 5rem);
+  line-height: 0.96;
+  letter-spacing: -0.045em;
+  text-wrap: balance;
+}
+.page-hero-product .t-lede {
+  max-width: 30rem;
+  font-size: clamp(1rem, 0.94rem + 0.24vw, 1.1rem);
+  line-height: 1.65;
+  color: var(--text-secondary);
+}
+.page-hero-product .page-hero-actions {
+  margin-top: var(--space-7);
+}
+.page-hero-product .page-hero-visual {
+  align-self: stretch;
+}
 @media (max-width: 920px) {
   .page-hero.has-visual .page-hero-inner { grid-template-columns: 1fr; }
+  .page-hero-product .page-hero-copy {
+    padding-top: 0;
+    max-width: none;
+  }
 }
 @media (max-width: 720px) {
   .page-hero { padding: var(--space-20) 0 var(--space-12); }
@@ -481,6 +516,17 @@ main { display: block; }
   .page-hero .t-lede { max-width: min(100%, 20.5rem); font-size: var(--text-md); }
   .page-hero-actions { flex-direction: column; align-items: stretch; }
   .page-hero-actions .btn { width: 100%; white-space: normal; min-height: 44px; height: auto; padding-block: var(--space-3); }
+  .page-hero-product {
+    padding: var(--space-18) 0 var(--space-12);
+  }
+  .page-hero-product h1 {
+    max-width: min(100%, 11ch);
+    font-size: clamp(2.2rem, 10vw, 3rem);
+    line-height: 1;
+  }
+  .page-hero-product .t-lede {
+    max-width: min(100%, 23rem);
+  }
 }
 
 .hero-visual {
@@ -493,11 +539,20 @@ main { display: block; }
   box-shadow: var(--shadow-lg);
   overflow: hidden;
 }
+.hero-visual-product {
+  padding: var(--space-4);
+  border-color: color-mix(in srgb, var(--border-default) 70%, transparent);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(113, 113, 122, 0.08), transparent 32%),
+    radial-gradient(circle at 84% 6%, rgba(47, 46, 255, 0.08), transparent 26%),
+    linear-gradient(180deg, #fffdf9, #ffffff 36%, #fcfcfd 100%);
+  box-shadow: 0 28px 80px rgba(15, 23, 42, 0.08);
+}
 .hero-visual-window {
   min-height: 330px;
   border: 1px solid var(--border-subtle);
   border-radius: calc(var(--radius-xl) - 4px);
-  background: color-mix(in srgb, var(--bg-surface) 94%, transparent);
+  background: color-mix(in srgb, var(--bg-surface) 97%, transparent);
   overflow: hidden;
 }
 .hero-visual-window-bar {
@@ -541,7 +596,7 @@ main { display: block; }
 .hero-visual-main {
   padding: var(--space-6);
   display: grid;
-  gap: var(--space-5);
+  gap: var(--space-4);
 }
 .hero-visual-row {
   display: flex;
@@ -554,6 +609,23 @@ main { display: block; }
   margin-bottom: var(--space-1);
   font-size: var(--text-xs);
   color: var(--text-muted);
+}
+.hero-visual-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+.hero-visual-meta span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 var(--space-3);
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--bg-soft) 84%, white);
+  border: 1px solid var(--border-subtle);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
 }
 .hero-visual h3 {
   font-size: var(--text-xl);
@@ -620,6 +692,52 @@ main { display: block; }
 }
 .hero-visual-grid-3 strong,
 .hero-visual-metric strong { display: block; margin-top: var(--space-1); color: var(--text-primary); }
+.hero-visual-grid-3 small,
+.hero-visual-metric small {
+  display: block;
+  margin-top: var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+.hero-evidence-list {
+  display: grid;
+  gap: var(--space-3);
+}
+.hero-evidence-list article {
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr);
+  gap: var(--space-3);
+  align-items: start;
+  padding: var(--space-4);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--bg-surface) 92%, white);
+}
+.hero-evidence-list span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  background: var(--bg-soft);
+  border: 1px solid var(--border-subtle);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+.hero-evidence-list strong {
+  display: block;
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+}
+.hero-evidence-list small {
+  display: block;
+  margin-top: var(--space-1);
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
 .hero-pricing-bars {
   height: 150px;
   display: flex;
@@ -708,6 +826,7 @@ main { display: block; }
   .hero-visual-nav { display: none; }
   .hero-path { grid-template-columns: 1fr; }
   .hero-path::before { display: none; }
+  .hero-evidence-list article { grid-template-columns: 36px minmax(0, 1fr); }
   .hero-visual-grid-2,
   .hero-visual-grid-3,
   .hero-editorial-grid { grid-template-columns: 1fr; }


### PR DESCRIPTION
## Summary
- tighten the homepage promise and remove the lingering visible em dash copy
- redesign the product page hero to feel calmer, denser, and more Linear-like
- upgrade the product trust-path visual so it reads like a real product surface instead of a generic mockup

## What changed
- rewrote the homepage hero promise to be shorter and more human
- updated shared site tagline/SEO strings to match the tighter positioning
- gave the product page hero its own layout tuning instead of sharing the more generic inner-page hero treatment
- rebuilt the product hero panel with clearer hierarchy, denser evidence states, and more purposeful detail rows
- updated the homepage test to match the new promise

## Validation
- `npm run test:ci --prefix web`
- `npm run build --prefix web`
- local browser verification at `http://127.0.0.1:4178/` and `/product`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the homepage promise and rebuilt the product page hero with a calmer layout and a more realistic trust-path visual. Updated SEO/tagline and tuned spacing tokens and the evidence trail layout for better readability across breakpoints.

- **New Features**
  - Added a dedicated product hero layout with `page-hero-product` styles and a `className` prop on `PageHero`.
  - Rebuilt the product hero visual with live trust-path steps, risk summary chips, owner/fix metrics, and an evidence trail.

- **Bug Fixes**
  - Fixed product hero spacing tokens and evidence list grid across viewports.

<sup>Written for commit 0ec026d59f3b3b667ffe0fada81bb8527462e532. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

