### PR TITLE
Refresh the product hero into a cleaner trust-path proof

### DIFF
--- a/web/src/components/ui/HeroVisuals.tsx
+++ b/web/src/components/ui/HeroVisuals.tsx
@@ -1,23 +1,13 @@
 import type { ReactNode } from 'react';
 
-const pathSteps = ['GitHub OIDC', 'AWS IAM IdP', 'billing-prod role', 'PostgreSQL ledger'];
-const evidenceRows = [
-  {
-    label: '01',
-    title: 'GitHub OIDC token verified',
-    detail: 'repo: payments-api / deploy-production.yml'
-  },
-  {
-    label: '02',
-    title: 'AssumeRole path detected',
-    detail: 'sts:AssumeRole reaches billing-prod in 4 hops'
-  },
-  {
-    label: '03',
-    title: 'Safe fix simulated',
-    detail: 'Restrict subject claim without workload breakage'
-  }
-];
+const pathSteps = [
+  { label: 'Source', name: 'GitHub OIDC', meta: 'repo: payments-api' },
+  { label: 'Bridge', name: 'AWS role', meta: 'AssumeRole trusted' },
+  { label: 'Workload', name: 'billing-prod', meta: 'owner matched' },
+  { label: 'Target', name: 'PostgreSQL', meta: 'contains customer data' }
+] as const;
+
+const evidenceSignals = ['JWT claims verified', 'Trust policy matched', 'Safe fix simulated'] as const;
 
 function WindowChrome({ children, label }: { children: ReactNode; label: string }) {
   return (
@@ -36,54 +26,46 @@ export function ProductHeroVisual() {
   return (
     <div className="hero-visual hero-visual-product">
       <WindowChrome label="Product trust graph preview">
-        <div className="hero-visual-product-grid">
-          <aside className="hero-visual-nav" aria-hidden="true">
-            <span className="is-active">Trust graph</span>
+        <div className="hero-visual-product-stage">
+          <div className="hero-visual-row hero-visual-product-top">
+            <div>
+              <span className="hero-visual-kicker">Resolved trust path</span>
+              <h3>billing-prod is reachable</h3>
+            </div>
+            <span className="hero-visual-badge is-danger">Critical path</span>
+          </div>
+          <div className="hero-visual-meta hero-visual-meta-product" aria-label="Risk path summary">
+            <span>4 hops</span>
+            <span>Owner matched</span>
+            <span>Fix simulated</span>
+          </div>
+          <div className="hero-path hero-path-product" aria-label="Resolved trust path">
+            {pathSteps.map((step, index) => (
+              <div className="hero-path-node hero-path-node-product" key={step.name}>
+                <span>{step.label}</span>
+                <strong>{step.name}</strong>
+                <small>{step.meta}</small>
+                {index === 1 ? <i className="hero-path-pulse" aria-hidden="true" /> : null}
+              </div>
+            ))}
+          </div>
+          <div className="hero-product-summary">
+            <article className="hero-product-summary-card">
+              <span>Owner</span>
+              <strong>payments-api</strong>
+              <small>Platform team · production</small>
+            </article>
+            <article className="hero-product-summary-card">
+              <span>Safe fix</span>
+              <strong>Restrict subject claim</strong>
+              <small>Contains the path without workload breakage</small>
+            </article>
+          </div>
+          <div className="hero-product-proof" aria-label="Evidence signals">
             <span>Evidence</span>
-            <span>Policies</span>
-          </aside>
-          <div className="hero-visual-main">
-            <div className="hero-visual-row">
-              <div>
-                <span className="hero-visual-kicker">Live trust path</span>
-                <h3>billing-prod is reachable</h3>
-              </div>
-              <span className="hero-visual-badge is-danger">Critical</span>
-            </div>
-            <div className="hero-visual-meta" aria-label="Risk path summary">
-              <span>4 hops</span>
-              <span>Owner matched</span>
-              <span>Fix simulated</span>
-            </div>
-            <div className="hero-path" aria-label="Resolved trust path">
-              {pathSteps.map((step, index) => (
-                <div className="hero-path-node" key={step}>
-                  <span>{String(index + 1).padStart(2, '0')}</span>
-                  <strong>{step}</strong>
-                </div>
-              ))}
-            </div>
-            <div className="hero-visual-grid-2">
-              <div className="hero-visual-metric">
-                <span>Owner</span>
-                <strong>payments-api</strong>
-                <small>Platform / production</small>
-              </div>
-              <div className="hero-visual-metric">
-                <span>Fix</span>
-                <strong>Restrict subject claim</strong>
-                <small>Safe in simulation</small>
-              </div>
-            </div>
-            <div className="hero-evidence-list" aria-label="Evidence trail">
-              {evidenceRows.map((row) => (
-                <article key={row.label}>
-                  <span>{row.label}</span>
-                  <div>
-                    <strong>{row.title}</strong>
-                    <small>{row.detail}</small>
-                  </div>
-                </article>
+            <div>
+              {evidenceSignals.map((signal) => (
+                <b key={signal}>{signal}</b>
               ))}
             </div>
           </div>

--- a/web/src/lib/seoMap.ts
+++ b/web/src/lib/seoMap.ts
@@ -29,9 +29,9 @@ export const ROUTE_META: Record<string, RouteMeta> = {
     keywords: DEFAULT_KEYWORDS
   },
   '/product': {
-    title: 'Product - See every machine identity path and fix the risky ones | Identrail',
+    title: 'Product - Trace machine identity paths and fix the right step | Identrail',
     description:
-      'See every machine identity path, prioritise the risky ones, and simulate the safest fix before you ship it.',
+      'Trace how machine identities reach sensitive systems, identify the risky step, and ship the safest fix with confidence.',
     schemaType: 'Product'
   },
   '/integrations': {

--- a/web/src/pages/ProductPage.tsx
+++ b/web/src/pages/ProductPage.tsx
@@ -1,7 +1,7 @@
 import { PageHero } from '../components/ui/PageHero';
 import { ProductHeroVisual } from '../components/ui/HeroVisuals';
 import { LinkButton, ArrowLink } from '../components/ui/Button';
-import { ArrowRightIcon, GitHubIcon, GraphIcon, ShieldIcon, CheckIcon } from '../components/ui/Icon';
+import { ArrowRightIcon, GraphIcon, ShieldIcon, CheckIcon } from '../components/ui/Icon';
 import { Pill } from '../components/ui/Pill';
 import { Section, SectionHeader } from '../components/ui/Section';
 import { CtaBanner } from '../components/CtaBanner';
@@ -66,20 +66,20 @@ export function ProductPage() {
         eyebrow="Product"
         title={
           <h1>
-            See every machine identity path.
+            Trace the path.
             <br />
-            <span style={{ color: 'var(--text-muted)' }}>Fix the ones that matter.</span>
+            <span style={{ color: 'var(--text-muted)' }}>Fix the right step.</span>
           </h1>
         }
-        lede="Identrail maps reachable access across AWS IAM, Kubernetes, and GitHub OIDC, then shows the safest fix before you ship it."
+        lede="Identrail shows how machine identities reach sensitive systems, who owns the risky step, and the safest fix to ship."
         visual={<ProductHeroVisual />}
         actions={
           <>
             <LinkButton to="/demo" variant="primary" size="lg">
               Start a free risk scan <ArrowRightIcon />
             </LinkButton>
-            <LinkButton to={GITHUB_REPO} variant="secondary" size="lg" external>
-              <GitHubIcon size={16} /> Read the source
+            <LinkButton to="/demo" variant="secondary" size="lg">
+              Book a demo
             </LinkButton>
           </>
         }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -468,32 +468,32 @@ main { display: block; }
 .page-hero-actions { margin-top: var(--space-8); display: flex; flex-wrap: wrap; gap: var(--space-3); }
 .page-hero-visual { min-width: 0; }
 .page-hero-product {
-  padding: var(--space-24) 0 var(--space-12);
+  padding: var(--space-20) 0 var(--space-12);
 }
 .page-hero-product .page-hero-inner {
-  grid-template-columns: minmax(0, 0.84fr) minmax(420px, 1.06fr);
-  gap: var(--space-10);
+  grid-template-columns: minmax(0, 0.78fr) minmax(460px, 1.06fr);
+  gap: var(--space-12);
   align-items: start;
 }
 .page-hero-product .page-hero-copy {
-  max-width: 35rem;
-  padding-top: var(--space-5);
+  max-width: 31rem;
+  padding-top: var(--space-6);
 }
 .page-hero-product h1 {
-  max-width: 9.5ch;
-  font-size: clamp(2.9rem, 1.75rem + 3.9vw, 5rem);
-  line-height: 0.96;
+  max-width: 8ch;
+  font-size: clamp(2.85rem, 1.8rem + 3.65vw, 4.85rem);
+  line-height: 0.94;
   letter-spacing: -0.045em;
   text-wrap: balance;
 }
 .page-hero-product .t-lede {
-  max-width: 30rem;
-  font-size: clamp(1rem, 0.94rem + 0.24vw, 1.1rem);
-  line-height: 1.65;
+  max-width: 28rem;
+  font-size: clamp(1rem, 0.94rem + 0.18vw, 1.05rem);
+  line-height: 1.58;
   color: var(--text-secondary);
 }
 .page-hero-product .page-hero-actions {
-  margin-top: var(--space-6);
+  margin-top: var(--space-5);
 }
 .page-hero-product .page-hero-visual {
   align-self: stretch;
@@ -520,12 +520,12 @@ main { display: block; }
     padding: var(--space-16) 0 var(--space-12);
   }
   .page-hero-product h1 {
-    max-width: min(100%, 11ch);
-    font-size: clamp(2.2rem, 10vw, 3rem);
-    line-height: 1;
+    max-width: min(100%, 9.5ch);
+    font-size: clamp(2.25rem, 10vw, 3rem);
+    line-height: 0.98;
   }
   .page-hero-product .t-lede {
-    max-width: min(100%, 23rem);
+    max-width: min(100%, 22rem);
   }
 }
 
@@ -543,10 +543,10 @@ main { display: block; }
   padding: var(--space-4);
   border-color: color-mix(in srgb, var(--border-default) 70%, transparent);
   background:
-    radial-gradient(circle at 18% 16%, rgba(113, 113, 122, 0.08), transparent 32%),
-    radial-gradient(circle at 84% 6%, rgba(47, 46, 255, 0.08), transparent 26%),
-    linear-gradient(180deg, #fffdf9, #ffffff 36%, #fcfcfd 100%);
-  box-shadow: 0 28px 80px rgba(15, 23, 42, 0.08);
+    radial-gradient(circle at 20% 14%, rgba(113, 113, 122, 0.06), transparent 34%),
+    radial-gradient(circle at 80% 0%, rgba(47, 46, 255, 0.07), transparent 24%),
+    linear-gradient(180deg, #fffefb, #ffffff 40%, #fcfcfd 100%);
+  box-shadow: 0 26px 72px rgba(15, 23, 42, 0.08);
 }
 .hero-visual-window {
   min-height: 330px;
@@ -570,33 +570,14 @@ main { display: block; }
   border-radius: 50%;
   background: var(--c-gray-20);
 }
-.hero-visual-product-grid {
+.hero-visual-product-stage {
   min-height: 288px;
-  display: grid;
-  grid-template-columns: 128px 1fr;
-}
-.hero-visual-nav {
-  padding: var(--space-5) var(--space-4);
-  border-right: 1px solid var(--border-subtle);
-  display: grid;
-  align-content: start;
-  gap: var(--space-3);
-  font-size: var(--text-xs);
-  font-weight: var(--weight-semibold);
-  color: var(--text-muted);
-}
-.hero-visual-nav span {
-  padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius-pill);
-}
-.hero-visual-nav .is-active {
-  background: var(--accent-soft);
-  color: var(--accent);
-}
-.hero-visual-main {
   padding: var(--space-6);
   display: grid;
   gap: var(--space-4);
+}
+.hero-visual-product-top {
+  align-items: center;
 }
 .hero-visual-row {
   display: flex;
@@ -656,19 +637,19 @@ main { display: block; }
   left: 9%;
   right: 9%;
   top: 24px;
-  height: 2px;
-  background: linear-gradient(90deg, var(--accent), var(--c-warning), var(--c-success));
-  opacity: 0.38;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(47, 46, 255, 0.18), rgba(245, 158, 11, 0.24), rgba(34, 197, 94, 0.2));
+  opacity: 1;
 }
 .hero-path-node {
   position: relative;
   z-index: 1;
-  min-height: 96px;
+  min-height: 108px;
   border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-lg);
   background: var(--bg-surface);
   padding: var(--space-4);
-  box-shadow: var(--shadow-sm);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.05);
 }
 .hero-path-node span,
 .hero-visual-metric span,
@@ -681,6 +662,32 @@ main { display: block; }
   color: var(--text-muted);
 }
 .hero-path-node strong { display: block; margin-top: var(--space-3); font-size: var(--text-sm); line-height: 1.3; }
+.hero-path-node small {
+  display: block;
+  margin-top: var(--space-2);
+  font-size: var(--text-xs);
+  line-height: 1.45;
+  color: var(--text-muted);
+}
+.hero-path-node-product:nth-child(2) {
+  border-color: color-mix(in srgb, var(--accent) 22%, var(--border-subtle));
+  box-shadow: 0 12px 34px rgba(47, 46, 255, 0.09);
+}
+.hero-path-pulse {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 0 rgba(47, 46, 255, 0.3);
+  animation: hero-path-pulse 2.4s ease-out infinite;
+}
+.hero-visual-meta-product {
+  padding-bottom: var(--space-1);
+  border-bottom: 1px solid color-mix(in srgb, var(--border-subtle) 78%, transparent);
+}
 .hero-visual-grid-2 { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-3); }
 .hero-visual-grid-3 { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--space-3); }
 .hero-visual-grid-3 div,
@@ -699,44 +706,78 @@ main { display: block; }
   font-size: var(--text-xs);
   color: var(--text-muted);
 }
-.hero-evidence-list {
+.hero-product-summary {
   display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: var(--space-3);
 }
-.hero-evidence-list article {
-  display: grid;
-  grid-template-columns: 44px minmax(0, 1fr);
-  gap: var(--space-3);
-  align-items: start;
+.hero-product-summary-card {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(180deg, rgba(255,255,255,0.96), rgba(251,251,253,0.96));
   padding: var(--space-4);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--bg-surface) 92%, white);
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
 }
-.hero-evidence-list span {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: 12px;
-  background: var(--bg-soft);
-  border: 1px solid var(--border-subtle);
+.hero-product-summary-card span {
+  display: block;
   font-family: var(--font-mono);
   font-size: var(--text-2xs);
-  letter-spacing: 0.06em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
   color: var(--text-muted);
 }
-.hero-evidence-list strong {
+.hero-product-summary-card strong {
   display: block;
+  margin-top: var(--space-2);
+  font-size: var(--text-lg);
+  line-height: 1.28;
   color: var(--text-primary);
-  font-size: var(--text-sm);
+  letter-spacing: -0.02em;
 }
-.hero-evidence-list small {
+.hero-product-summary-card small {
   display: block;
-  margin-top: var(--space-1);
+  margin-top: var(--space-2);
   color: var(--text-muted);
   font-size: var(--text-xs);
+  line-height: 1.45;
+}
+.hero-product-proof {
+  display: grid;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--bg-surface) 94%, white);
+}
+.hero-product-proof > span {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.hero-product-proof > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+.hero-product-proof b {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 0 var(--space-3);
+  border-radius: var(--radius-pill);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+}
+@keyframes hero-path-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(47, 46, 255, 0.28); }
+  70% { box-shadow: 0 0 0 10px rgba(47, 46, 255, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(47, 46, 255, 0); }
 }
 .hero-pricing-bars {
   height: 150px;
@@ -822,14 +863,14 @@ main { display: block; }
 .hero-editorial-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-3); padding: 0 var(--space-6) var(--space-6); }
 @media (max-width: 720px) {
   .hero-visual-window { min-height: auto; }
-  .hero-visual-product-grid { grid-template-columns: 1fr; }
-  .hero-visual-nav { display: none; }
+  .hero-visual-product-stage { padding: var(--space-5); }
   .hero-path { grid-template-columns: 1fr; }
   .hero-path::before { display: none; }
-  .hero-evidence-list article { grid-template-columns: 36px minmax(0, 1fr); }
+  .hero-product-summary,
   .hero-visual-grid-2,
   .hero-visual-grid-3,
   .hero-editorial-grid { grid-template-columns: 1fr; }
+  .hero-product-proof > div { display: grid; grid-template-columns: 1fr; }
 }
 
 /* Home hero */


### PR DESCRIPTION
## Summary
- replace the product page hero copy with a tighter trust-path thesis and cleaner CTA rhythm
- redesign the product hero visual into a single proof canvas instead of a repeated homepage-style dashboard/table stack
- align the `/product` SEO title and description with the new hero narrative

## Why
The existing `/product` hero felt too close to the homepage and repeated the same structure with different wording. This change gives the product page its own identity: one clear promise on the left and one calm, premium trust-path proof scene on the right.

## Validation
- npm run test:ci --prefix web
- npm run build --prefix web
- visual review in local preview on desktop (1440px) and mobile (390px) via Playwright against `http://127.0.0.1:4178/product`

## Notes
- Draft until a linked issue is added for the repo policy check.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the /product hero into a single trust-path proof with tighter copy and clearer CTAs to focus on “trace the path, fix the right step.” Updates the `/product` SEO title and description to match the new narrative.

- **New Features**
  - New hero visual: one proof canvas with a 4-step path, owner/fix summary cards, and evidence signals.
  - Copy/CTAs: headline and lede simplified; replaced GitHub link with “Book a demo”; kept “Start a free risk scan.”
  - Styling: cleaner layout, spacing, and animations (pulse on the risky step); improved mobile responsiveness.
  - SEO: updated `/product` title and description in `seoMap.ts`.
  - Cleanup: removed unused `GitHubIcon` import and streamlined hero markup.

<sup>Written for commit a0be484155635c0792f44db1fcaea2d41aa38fd2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

