### PR TITLE
Reject negative scan policy concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   - introduced scan-policy CRUD endpoints under project tenancy routes with trigger-mode and enabled filters
   - persisted policy bounds for `history_limit` and `max_findings` with migration and scoped store adapters
   - embedded a scan policy editor in the project detail page and documented new contracts in `docs/openapi-v1.yaml`
+  - rejects negative `max_concurrent_scans` API values instead of silently defaulting them to one
 - Hardened connector secret storage and rotation:
   - encrypted GitHub webhook secrets with versioned AES-256-GCM envelopes instead of retaining plaintext service state
   - added a webhook-secret rotation endpoint with audit events and status metadata for key version, algorithm, and rotation due date

--- a/internal/api/scan_policy.go
+++ b/internal/api/scan_policy.go
@@ -111,7 +111,10 @@ func (s *Service) UpsertScanPolicy(ctx context.Context, workspaceID string, proj
 		enabled = *request.Enabled
 	}
 	maxConcurrent := request.MaxConcurrentScans
-	if maxConcurrent <= 0 {
+	if maxConcurrent < 0 {
+		return db.TenancyScanPolicy{}, ErrInvalidScanPolicyRequest
+	}
+	if maxConcurrent == 0 {
 		maxConcurrent = 1
 	}
 	policy, err := db.NormalizeTenancyScanPolicyForWrite(db.TenancyScanPolicy{

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -495,6 +495,15 @@ func TestServiceScanPolicyValidation(t *testing.T) {
 				MaxFindings: 51,
 			},
 		},
+		{
+			name: "negative max concurrent scans",
+			request: ScanPolicyUpsertRequest{
+				PolicyID:           "negative-concurrency",
+				Name:               "Negative concurrency",
+				TriggerMode:        "manual",
+				MaxConcurrentScans: -1,
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Fixes #1071

## What changed
- Reject negative `max_concurrent_scans` values during project scan-policy upsert validation.
- Preserve the existing default behavior where an omitted/zero `max_concurrent_scans` becomes `1`.
- Add service-level regression coverage for the negative concurrency case.
- Update the changelog entry for scan-policy API behavior.

## Why it changed
The OpenAPI schema documents `max_concurrent_scans` with `minimum: 1`. PR #1067 accidentally treated negative values like omitted values, silently persisting concurrency `1` instead of returning a validation error.

## Impact and risk
- API clients now receive a validation error for invalid negative concurrency input.
- Existing clients that omit the field keep the same default behavior.
- Risk is low; the change is limited to scan-policy upsert validation.

## Validation performed
- `go test ./internal/api -run 'TestServiceScanPolicyValidation|TestRouterTenancyEndpointsCRUDFlow' -count=1`

## AI disclosure
- AI-assisted: yes
- Tools used: AI coding assistant
- Where used: scan-policy validation, regression test, changelog update
- Human verification performed: reviewed the merged code path, confirmed the finding against the OpenAPI contract, and ran the targeted Go tests above


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject negative `max_concurrent_scans` in project scan-policy upsert and return a validation error instead of defaulting to 1. Zero or omitted values still default to 1.

- **Bug Fixes**
  - Aligns service validation with the OpenAPI contract (`minimum: 1`).
  - Adds regression test for the negative concurrency case and updates the changelog.

<sup>Written for commit 33227cd0ed8616079ee1aaca81380bb1c754a951. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

