### PR TITLE
feat(ci): publish public container images

### DIFF
--- a/.github/workflows/publish-container-images.yml
+++ b/.github/workflows/publish-container-images.yml
@@ -1,0 +1,122 @@
+name: Publish Container Images
+
+on:
+  push:
+    branches:
+      - dev
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to publish images from. Defaults to the selected branch."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-container-images-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build and Publish GHCR Images
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Resolve image metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          owner="$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
+          source_sha="$(git rev-parse HEAD)"
+          sha_tag="sha-${source_sha::12}"
+          channel_tag="dev"
+          release_web_env="deploy/docker/release-web.env"
+
+          if [ ! -f "${release_web_env}" ]; then
+            echo "Missing ${release_web_env}; cannot build the web image with a versioned API URL." >&2
+            exit 1
+          fi
+
+          web_api_url="$(
+            awk -F= '$1 == "VITE_IDENTRAIL_API_URL" {print substr($0, index($0, "=") + 1)}' "${release_web_env}" \
+              | tail -n1
+          )"
+
+          if [ -z "${web_api_url}" ]; then
+            echo "${release_web_env} must define VITE_IDENTRAIL_API_URL." >&2
+            exit 1
+          fi
+
+          if [[ ! "${web_api_url}" =~ ^https:// ]]; then
+            echo "VITE_IDENTRAIL_API_URL must start with https:// for public images: ${web_api_url}" >&2
+            exit 1
+          fi
+
+          echo "base=ghcr.io/${owner}/identrail" >> "${GITHUB_OUTPUT}"
+          echo "channel_tag=${channel_tag}" >> "${GITHUB_OUTPUT}"
+          echo "sha_tag=${sha_tag}" >> "${GITHUB_OUTPUT}"
+          echo "source_sha=${source_sha}" >> "${GITHUB_OUTPUT}"
+          echo "web_api_url=${web_api_url}" >> "${GITHUB_OUTPUT}"
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+
+      - name: Login to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push images
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          base="${{ steps.meta.outputs.base }}"
+          channel_tag="${{ steps.meta.outputs.channel_tag }}"
+          sha_tag="${{ steps.meta.outputs.sha_tag }}"
+          source_url="${{ github.server_url }}/${{ github.repository }}"
+          revision="${{ steps.meta.outputs.source_sha }}"
+
+          build_and_push() {
+            local name="$1"
+            local title="$2"
+            shift 2
+
+            docker buildx build \
+              --platform linux/amd64,linux/arm64 \
+              --push \
+              --label "org.opencontainers.image.source=${source_url}" \
+              --label "org.opencontainers.image.revision=${revision}" \
+              --label "org.opencontainers.image.title=${title}" \
+              -t "${base}-${name}:${channel_tag}" \
+              -t "${base}-${name}:${sha_tag}" \
+              "$@"
+          }
+
+          build_and_push "api" "Identrail API" \
+            -f deploy/docker/Dockerfile.backend \
+            --build-arg TARGET=server \
+            .
+
+          build_and_push "worker" "Identrail Worker" \
+            -f deploy/docker/Dockerfile.backend \
+            --build-arg TARGET=worker \
+            .
+
+          build_and_push "web" "Identrail Web" \
+            -f deploy/docker/Dockerfile.web \
+            --build-arg "VITE_IDENTRAIL_API_URL=${{ steps.meta.outputs.web_api_url }}" \
+            .

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -9,4 +9,4 @@ Deployment profiles:
 - `terraform/`: infrastructure modules
 - `policies/`: least-privilege read-only templates for AWS and Kubernetes
 
-Published container image examples use `ghcr.io/identrail/identrail-api`, `ghcr.io/identrail/identrail-worker`, and `ghcr.io/identrail/identrail-web`. Pin production deployments to immutable release tags. Helm and Terraform deployment values should use tagged images (`repository` + `tag`), while digest pinning is only for deployment paths that explicitly support digest references.
+Published container image examples use `ghcr.io/identrail/identrail-api`, `ghcr.io/identrail/identrail-worker`, and `ghcr.io/identrail/identrail-web`. The `dev` tag is published from the default branch for evaluation, while production deployments should pin immutable release or SHA tags. Helm and Terraform deployment values should use tagged images (`repository` + `tag`), while digest pinning is only for deployment paths that explicitly support digest references.

--- a/deploy/docker/Dockerfile.backend
+++ b/deploy/docker/Dockerfile.backend
@@ -9,7 +9,9 @@ RUN go mod download
 COPY . .
 
 ARG TARGET=server
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 \
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
     go build -trimpath -ldflags="-s -w" -o /out/identrail ./cmd/${TARGET}
 
 FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -29,6 +29,20 @@ Manual setup:
    - optional context override: `IDENTRAIL_KUBE_CONTEXT`
 3. `docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env up -d --build`
 
+## Public Images
+
+Identrail publishes public development images to GHCR from the `dev` branch:
+
+```bash
+docker pull ghcr.io/identrail/identrail-api:dev
+docker pull ghcr.io/identrail/identrail-worker:dev
+docker pull ghcr.io/identrail/identrail-web:dev
+```
+
+Release images are published as SemVer tags by the release pipeline, for example
+`ghcr.io/identrail/identrail-api:v1.0.0`. Prefer release or SHA tags for
+repeatable production deployments.
+
 Production-style hardening example:
 
 - `docker compose -f deploy/docker/docker-compose.yml -f deploy/docker/docker-compose.prod.example.yml -f deploy/docker/docker-compose.security.example.yml --env-file deploy/docker/.env run --build --rm migrations`

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -30,6 +30,19 @@ Identrail release automation is defined in:
 4. Image digests and web build input metadata.
 5. Auto-generated GitHub Release notes.
 
+## Continuous Public Images
+
+The **Publish Container Images** workflow also publishes public development images
+from every merge to `dev`:
+
+- `ghcr.io/identrail/identrail-api:dev`
+- `ghcr.io/identrail/identrail-worker:dev`
+- `ghcr.io/identrail/identrail-web:dev`
+
+Each run also publishes immutable SHA tags such as `sha-<12-char-sha>`.
+Use the `dev` tags for quick evaluation and SHA or release tags for repeatable
+deployments.
+
 ## Image Tag Rules
 
 - Stable tags (`vX.Y.Z`) publish `<tag>` and `latest`.


### PR DESCRIPTION
Fixes #1070

## Summary
- add a `Publish Container Images` workflow that publishes GHCR `dev` and immutable `sha-<short-sha>` tags for API, worker, and web images after merges to `dev`
- make the backend Dockerfile honor BuildKit `TARGETOS`/`TARGETARCH` so multi-arch API and worker images contain the right binary
- document the public GHCR pull commands and clarify when to use `dev`, SHA, and release tags

## Why
Identrail needs official public images before the website can honestly present Docker/container usage. The release pipeline already supports release-tag images, but the packages do not exist yet and there is no always-available default-branch image channel.

## Validation
- `actionlint .github/workflows/publish-container-images.yml`
- `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./cmd/server`
- `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ./cmd/server`
- `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./cmd/worker`
- `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ./cmd/worker`
- `npm run build --prefix web`

Local Docker build note: `docker build` could not run in this desktop environment because Docker is configured for `docker-credential-desktop`, but that helper is not available on PATH here.

AI-assisted: yes
Tools used: Codex
Where used: workflow, Dockerfile, and documentation updates
Human verification performed: workflow lint, cross-arch Go builds, web production build, and manual diff review


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish public multi-arch images for `api`, `worker`, and `web` to GHCR on `dev` merges, tagged `dev` and immutable `sha-<12>`. Also updates the backend Dockerfile for proper multi-arch builds and documents how to use dev, SHA, and release tags.

- **New Features**
  - Adds `Publish Container Images` workflow to build (amd64/arm64) and push `ghcr.io/identrail/identrail-{api,worker,web}` with `dev` and `sha-<short-sha>` tags; supports manual `workflow_dispatch`.
  - Backend `Dockerfile` honors BuildKit `TARGETOS`/`TARGETARCH` to ensure the correct binary in multi-arch images.
  - Docs: add public pull commands and clarify when to use `dev` vs SHA vs release tags.

<sup>Written for commit 84fe203d9813fd01f03574c8a12a3ea0c655934a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

