### PR TITLE
Add production API URL readiness checks

### DIFF
--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -67,6 +67,7 @@ jobs:
 
       - name: Check VITE_IDENTRAIL_API_URL variable
         id: check-api-url
+        if: steps.normalize-token.outputs.has_token == 'true'
         env:
           VITE_IDENTRAIL_API_URL: ${{ vars.VITE_IDENTRAIL_API_URL }}
           IDENTRAIL_WEB_ORIGINS: https://identrail.com,https://www.identrail.com,https://app.identrail.com

--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -67,9 +67,9 @@ jobs:
 
       - name: Check VITE_IDENTRAIL_API_URL variable
         id: check-api-url
-        if: steps.normalize-token.outputs.has_token == 'true'
         env:
           VITE_IDENTRAIL_API_URL: ${{ vars.VITE_IDENTRAIL_API_URL }}
+          IDENTRAIL_WEB_ORIGINS: https://identrail.com,https://www.identrail.com,https://app.identrail.com
         run: |
           set -euo pipefail
           if [ -z "${VITE_IDENTRAIL_API_URL}" ]; then
@@ -77,6 +77,7 @@ jobs:
             echo "Set this GitHub Actions variable before production deploys."
             exit 1
           fi
+          ./scripts/check_public_api_url.sh "${VITE_IDENTRAIL_API_URL}"
           echo "has_api_url=true" >> "$GITHUB_OUTPUT"
 
       - name: Upsert Vercel env VITE_IDENTRAIL_API_URL

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /usr/bin/env bash
 .DEFAULT_GOAL := help
 
-.PHONY: help bootstrap quickstart quickstart-down clean-local fmt fmt-check vet test test-integration web-install web-test web-build web-route-integrity-check api-example-contract-check vercel-prod-deploy helm-lint tfmt-check ci pre-commit
+.PHONY: help bootstrap quickstart quickstart-down clean-local fmt fmt-check vet test test-integration web-install web-test web-build web-route-integrity-check api-example-contract-check production-api-url-check production-api-preflight vercel-prod-deploy helm-lint tfmt-check ci pre-commit
 
 help: ## Show available targets
 	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z0-9_-]+:.*##/ {printf "%-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -64,6 +64,12 @@ web-route-integrity-check: ## Validate web app routes for static generation inte
 
 api-example-contract-check: ## Validate docs/web API snippets against current v1 contract
 	./scripts/check_api_example_contract.sh
+
+production-api-url-check: ## Validate VITE_IDENTRAIL_API_URL does not point at the web frontend
+	./scripts/check_public_api_url.sh
+
+production-api-preflight: ## Validate and probe the public API URL before wiring the frontend
+	./scripts/check_public_api_url.sh --probe
 
 vercel-prod-deploy: ## Trigger Vercel production deploy (always uses origin/dev)
 	./scripts/vercel_prod_deploy.sh

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -56,6 +56,16 @@ tasks:
     cmds:
       - make api-example-contract-check
 
+  production-api-url-check:
+    desc: Validate VITE_IDENTRAIL_API_URL does not point at the web frontend
+    cmds:
+      - make production-api-url-check
+
+  production-api-preflight:
+    desc: Validate and probe the public API URL before wiring the frontend
+    cmds:
+      - make production-api-preflight
+
   vercel-prod-deploy:
     desc: Trigger Vercel production deploy (always uses origin/dev)
     cmds:

--- a/docs/auth/README.md
+++ b/docs/auth/README.md
@@ -11,8 +11,9 @@ Start at the top. Each later doc fills in detail for one section of the first.
 3. [`identity-linking-rules.md`](./identity-linking-rules.md) - how we connect provider identities to Identrail accounts. Has the account-takeover exploit narrative.
 4. [`cookie-and-session-spec.md`](./cookie-and-session-spec.md) - exact cookie attributes, session lifetimes, rotation rules.
 5. [`connector-foundation.md`](./connector-foundation.md) - the Provider interface, status state machine, and error taxonomy that every connector implements.
-6. [`env-vars-reference.md`](./env-vars-reference.md) - flat list of every environment variable across the twelve PRs.
-7. [`12-pr-plan.md`](./12-pr-plan.md) - the canonical scope for each of the twelve PRs.
+6. [`production-api-readiness.md`](./production-api-readiness.md) - the production web/API split required before the frontend auth UI can work on Vercel.
+7. [`env-vars-reference.md`](./env-vars-reference.md) - flat list of every environment variable across the twelve PRs.
+8. [`12-pr-plan.md`](./12-pr-plan.md) - the canonical scope for each of the twelve PRs.
 
 ## When to Update These Docs
 

--- a/docs/auth/production-api-readiness.md
+++ b/docs/auth/production-api-readiness.md
@@ -1,0 +1,58 @@
+# Production API Readiness
+
+PR 6 is the operational bridge between the merged frontend auth UI and the later provider/onboarding work.
+
+The frontend auth pages are intentionally unable to call an unknown backend in production. Before Vercel can serve working sign-in and sign-up flows, the public API must exist and the web build must point at it.
+
+## Target Shape
+
+```text
+identrail.com       -> Vercel web
+www.identrail.com   -> Vercel web
+app.identrail.com   -> Vercel web/app
+api.identrail.com   -> Identrail API
+```
+
+`VITE_IDENTRAIL_API_URL` must point at the API origin:
+
+```text
+VITE_IDENTRAIL_API_URL=https://api.identrail.com
+```
+
+It must not point at `https://identrail.com`, `https://www.identrail.com`, or `https://app.identrail.com`.
+
+## API Requirements
+
+Before wiring the frontend to the production API URL, the API deployment must expose:
+
+- `GET /healthz` returning `200`
+- `GET /readyz` returning `200` only after runtime dependencies are ready
+- `GET /v1/auth/config` returning JSON, not the web HTML shell
+- `IDENTRAIL_CORS_ALLOWED_ORIGINS` containing the web origins that need browser access
+- `IDENTRAIL_PUBLIC_BASE_URL` set to the API origin when WorkOS callbacks terminate at the API
+- `IDENTRAIL_SESSION_KEY` set from at least 32 bytes of secret key material
+- persistent storage through `IDENTRAIL_DATABASE_URL`
+
+For Identrail Cloud, the first production API deployment should use:
+
+```text
+IDENTRAIL_CORS_ALLOWED_ORIGINS=https://identrail.com,https://www.identrail.com,https://app.identrail.com
+IDENTRAIL_PUBLIC_BASE_URL=https://api.identrail.com
+VITE_IDENTRAIL_API_URL=https://api.identrail.com
+```
+
+## Checks
+
+Static URL validation catches missing values, non-HTTPS values, and accidental web origins:
+
+```bash
+VITE_IDENTRAIL_API_URL=https://api.identrail.com make production-api-url-check
+```
+
+Full preflight probes the live API endpoints:
+
+```bash
+VITE_IDENTRAIL_API_URL=https://api.identrail.com make production-api-preflight
+```
+
+Run the full preflight after DNS and TLS are live for `api.identrail.com`, and before changing Vercel production variables.

--- a/docs/frontend-topology.md
+++ b/docs/frontend-topology.md
@@ -21,6 +21,7 @@ Identrail uses `web/` as the active tracked frontend on `dev`.
 - If the API is served from the same domain via reverse proxy, use that public API base path.
 - Configure the API deployment with `IDENTRAIL_CORS_ALLOWED_ORIGINS` set to the web app origin when the frontend and API use different origins.
 - The default Vercel CSP allows `https://api.identrail.io`; update `connect-src` when using a custom API host.
+- For Identrail Cloud, use `https://api.identrail.com` once that API domain is live. Do not use `https://identrail.com`, `https://www.identrail.com`, or `https://app.identrail.com`; those are web origins.
 
 ### Where to configure it
 
@@ -32,6 +33,18 @@ Identrail uses `web/` as the active tracked frontend on `dev`.
    - Add `VITE_IDENTRAIL_API_URL` for Production (and Preview if needed)
 
 If the GitHub Actions variable is missing, the production deploy workflow fails before deployment so the web app cannot ship without an explicit API URL.
+
+### Production API preflight
+
+Before wiring or rotating the Vercel value, run:
+
+```bash
+VITE_IDENTRAIL_API_URL=https://api.identrail.com make production-api-preflight
+```
+
+The preflight verifies that `/healthz` and `/v1/auth/config` return API responses instead of the frontend HTML shell. Use `make production-api-url-check` when the API is not live yet and only static URL validation is needed.
+
+See [Production API Readiness](./auth/production-api-readiness.md) for the full API/web domain checklist.
 
 ## `site/` (legacy Next.js marketing surface)
 

--- a/docs/frontend-topology.md
+++ b/docs/frontend-topology.md
@@ -32,7 +32,7 @@ Identrail uses `web/` as the active tracked frontend on `dev`.
    - `Project` -> `Settings` -> `Environment Variables`
    - Add `VITE_IDENTRAIL_API_URL` for Production (and Preview if needed)
 
-If the GitHub Actions variable is missing, the production deploy workflow fails before deployment so the web app cannot ship without an explicit API URL.
+For token-based Vercel deployments, if the GitHub Actions variable is missing, the production deploy workflow fails before deployment so the web app cannot ship without an explicit API URL. Hook-only fallback deployments cannot read Vercel project env values from GitHub Actions; keep `VITE_IDENTRAIL_API_URL` configured directly in Vercel and run the preflight manually before relying on the hook fallback.
 
 ### Production API preflight
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -58,3 +58,21 @@ Checks:
 1. In GitHub: `Settings` -> `Secrets and variables` -> `Actions` -> `Variables`, confirm `VITE_IDENTRAIL_API_URL` exists.
 2. In Vercel: `Project` -> `Settings` -> `Environment Variables`, confirm `VITE_IDENTRAIL_API_URL` exists for Production.
 3. Ensure the value points to the public API URL (not the web frontend URL).
+
+For Identrail Cloud, the intended value is:
+
+```text
+VITE_IDENTRAIL_API_URL=https://api.identrail.com
+```
+
+Do not use `https://identrail.com`, `https://www.identrail.com`, or `https://app.identrail.com` for this value. Those are frontend origins. Validate the value with:
+
+```bash
+VITE_IDENTRAIL_API_URL=https://api.identrail.com make production-api-url-check
+```
+
+After `api.identrail.com` is live, run the full probe:
+
+```bash
+VITE_IDENTRAIL_API_URL=https://api.identrail.com make production-api-preflight
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -53,6 +53,7 @@ Symptoms:
 Why this happens:
 1. GitHub workflow checks repository variable `vars.VITE_IDENTRAIL_API_URL`.
 2. Vercel can still deploy successfully when the variable already exists directly in Vercel project settings.
+3. Hook-only fallback deploys use the env already configured in Vercel and cannot upsert or inspect that value from GitHub Actions.
 
 Checks:
 1. In GitHub: `Settings` -> `Secrets and variables` -> `Actions` -> `Variables`, confirm `VITE_IDENTRAIL_API_URL` exists.

--- a/scripts/check_public_api_url.sh
+++ b/scripts/check_public_api_url.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: check_public_api_url.sh [--probe] [--allow-local] [API_URL]
+
+Validates the public Identrail API base URL used by the web frontend.
+
+Inputs:
+  API_URL                      Optional. Defaults to VITE_IDENTRAIL_API_URL.
+  IDENTRAIL_WEB_ORIGINS        Optional comma-separated web origins to reject.
+
+Options:
+  --probe                      Also call /healthz and /v1/auth/config.
+  --allow-local                Permit http://localhost and http://127.0.0.1.
+  -h, --help                   Show this help text.
+USAGE
+}
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+lower() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+extract_origin() {
+  local value="$1"
+  printf '%s' "$value" | sed -E 's#^(https?://[^/]+).*$#\1#'
+}
+
+fail() {
+  printf 'Identrail API URL check failed: %s\n' "$1" >&2
+  exit 1
+}
+
+probe=false
+allow_local=false
+api_url="${VITE_IDENTRAIL_API_URL:-}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --probe)
+      probe=true
+      ;;
+    --allow-local)
+      allow_local=true
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --*)
+      fail "unknown option $1"
+      ;;
+    *)
+      api_url="$1"
+      ;;
+  esac
+  shift
+done
+
+api_url="$(trim "$api_url")"
+api_url="${api_url%/}"
+
+if [ -z "$api_url" ]; then
+  fail "VITE_IDENTRAIL_API_URL is required"
+fi
+
+if [[ "$api_url" =~ ^http://(localhost|127\.0\.0\.1)(:[0-9]+)?($|/) ]]; then
+  if [ "$allow_local" != "true" ]; then
+    fail "local HTTP URLs are not allowed for production API wiring"
+  fi
+elif [[ ! "$api_url" =~ ^https://[^/[:space:]]+($|/) ]]; then
+  fail "use an absolute HTTPS API URL such as https://api.identrail.com"
+fi
+
+api_origin="$(lower "$(extract_origin "$api_url")")"
+web_origins="${IDENTRAIL_WEB_ORIGINS:-https://identrail.com,https://www.identrail.com,https://app.identrail.com}"
+IFS=',' read -r -a rejected_origins <<< "$web_origins"
+for rejected in "${rejected_origins[@]}"; do
+  rejected="$(lower "$(trim "${rejected%/}")")"
+  if [ -n "$rejected" ] && [ "$api_origin" = "$rejected" ]; then
+    fail "API URL points at web origin $rejected; use a dedicated API origin such as https://api.identrail.com"
+  fi
+done
+
+if [ "$probe" = "true" ]; then
+  for path in /healthz /v1/auth/config; do
+    tmp_body="$(mktemp)"
+    tmp_headers="$(mktemp)"
+    status="$(curl -L -sS -o "$tmp_body" -D "$tmp_headers" -w '%{http_code}' "${api_url}${path}" || true)"
+    content_type="$(tr -d '\r' < "$tmp_headers" | awk 'BEGIN{IGNORECASE=1} /^content-type:/ {print $0}' | tail -n 1)"
+    body_prefix="$(head -c 256 "$tmp_body" | tr '\n' ' ')"
+    rm -f "$tmp_body" "$tmp_headers"
+
+    if [ "$status" != "200" ]; then
+      fail "${api_url}${path} returned HTTP ${status}, expected 200"
+    fi
+    if printf '%s' "$content_type" | grep -Eiq 'text/html'; then
+      fail "${api_url}${path} returned HTML, which usually means the URL points at the frontend"
+    fi
+    if printf '%s' "$body_prefix" | grep -Eiq '<!doctype html|<html'; then
+      fail "${api_url}${path} returned an HTML page, not an API response"
+    fi
+  done
+fi
+
+printf 'Identrail API URL check passed: %s\n' "$api_url"

--- a/scripts/check_public_api_url_test.sh
+++ b/scripts/check_public_api_url_test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+check_script="${script_dir}/check_public_api_url.sh"
+
+expect_pass() {
+  local name="$1"
+  shift
+  if ! "$check_script" "$@" >/tmp/identrail-api-url-test.out 2>/tmp/identrail-api-url-test.err; then
+    printf 'FAIL expected pass: %s\n' "$name" >&2
+    cat /tmp/identrail-api-url-test.err >&2
+    exit 1
+  fi
+}
+
+expect_fail() {
+  local name="$1"
+  shift
+  if "$check_script" "$@" >/tmp/identrail-api-url-test.out 2>/tmp/identrail-api-url-test.err; then
+    printf 'FAIL expected failure: %s\n' "$name" >&2
+    cat /tmp/identrail-api-url-test.out >&2
+    exit 1
+  fi
+}
+
+expect_pass "dedicated https api origin" "https://api.identrail.com"
+expect_pass "api origin with base path" "https://api.identrail.com/service"
+expect_pass "local dev with opt-in" --allow-local "http://localhost:8080"
+
+expect_fail "empty value"
+expect_fail "web apex origin" "https://identrail.com"
+expect_fail "web app origin" "https://app.identrail.com"
+expect_fail "non-local http" "http://api.identrail.com"
+expect_fail "local dev without opt-in" "http://localhost:8080"
+expect_fail "relative URL" "/v1"
+
+rm -f /tmp/identrail-api-url-test.out /tmp/identrail-api-url-test.err
+printf 'check_public_api_url tests passed\n'


### PR DESCRIPTION
Fixes #1086

## Summary

This PR makes the production web -> API wiring harder to misconfigure before we continue the auth rollout.

- Adds `scripts/check_public_api_url.sh` to validate `VITE_IDENTRAIL_API_URL` and optionally probe `/healthz` plus `/v1/auth/config`.
- Rejects the known web origins (`identrail.com`, `www.identrail.com`, `app.identrail.com`) when they are accidentally used as the API URL.
- Wires the static check into the Vercel production deploy workflow before either token-based or hook-based deployment can proceed.
- Documents the intended split: Vercel hosts the web/app origins, while the API should live at `https://api.identrail.com`.

## Why

The frontend auth UI merged in PR 5 correctly refuses to call an unknown backend in production. The production site then showed a clear error because `VITE_IDENTRAIL_API_URL` was missing. This PR prevents the next bad states too: missing URL, non-HTTPS URL, local-only URL, or a URL pointed at the frontend instead of the API.

## Compatibility

- No API routes or auth behavior changed.
- Local development still supports localhost when the check is run with `--allow-local`.
- The Vercel deploy path keeps the existing env upsert flow, but validates the value before deployment.

## Validation

- `bash -n scripts/check_public_api_url.sh scripts/check_public_api_url_test.sh`
- `./scripts/check_public_api_url_test.sh`
- `VITE_IDENTRAIL_API_URL=https://api.identrail.com make production-api-url-check`
- `git diff --check`
- pre-commit during commit: merge conflicts, YAML, EOF, whitespace, gofmt, Vercel artifact hygiene
- pre-push during push: merge conflicts, YAML, EOF, whitespace, gofmt, go vet, local env token hygiene, Vercel artifact hygiene

## AI Disclosure

- AI-assisted: yes
- Tools used: OpenAI Codex
- Where used: implementation, docs, validation workflow
- Human verification performed: reviewed diff and ran the validation listed above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add production API URL readiness checks to block misconfigured web→API wiring in production. Validates `VITE_IDENTRAIL_API_URL`, rejects web origins, and can probe `/healthz` and `/v1/auth/config`.

- **New Features**
  - Added `scripts/check_public_api_url.sh` for static validation with `--probe` and `--allow-local`; rejects `https://identrail.com`, `https://www.identrail.com`, and `https://app.identrail.com`, and enforces HTTPS.
  - Integrated the check into the Vercel production deploy workflow to fail early if `vars.VITE_IDENTRAIL_API_URL` is missing or invalid; supports `IDENTRAIL_WEB_ORIGINS`. Hook-only Vercel deploy fallback is preserved; validate manually before relying on the hook.
  - Added Make/Task runners: `production-api-url-check` and `production-api-preflight`.
  - Docs: new `auth/production-api-readiness.md`; updates to `auth/README.md`, `frontend-topology.md`, and `troubleshooting.md`.

- **Migration**
  - Set `VITE_IDENTRAIL_API_URL` to `https://api.identrail.com` in GitHub Actions Variables and Vercel Production envs.
  - Ensure the API exposes `GET /healthz`, `GET /readyz`, and `GET /v1/auth/config` (JSON), and configure `IDENTRAIL_CORS_ALLOWED_ORIGINS` and `IDENTRAIL_PUBLIC_BASE_URL` for the production domains.
  - Verify before switching prod: run `make production-api-preflight` once DNS/TLS for `api.identrail.com` is live; use `make production-api-url-check` for static validation only.

<sup>Written for commit bf22d4935462bc608ac466401bf6c964f4d52012. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

