### PR TITLE
Redesign auth entry pages

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -188,7 +188,7 @@ describe('App', () => {
     expect(
       await screen.findByRole('heading', {
         level: 1,
-        name: /Sign in to Identrail/i
+        name: /Log in to Identrail/i
       })
     ).toBeInTheDocument();
     expect(window.location.pathname).toBe('/signin');
@@ -224,9 +224,9 @@ describe('App', () => {
     setCurrentPath('/signin?return_to=/app/team/workspace');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { level: 1, name: /Sign in to Identrail/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 1, name: /Log in to Identrail/i })).toBeInTheDocument();
     expect(screen.queryByLabelText(/Tenant ID/i)).not.toBeInTheDocument();
-    const hostedSignIn = screen.getByRole('link', { name: /Continue with hosted sign-in/i });
+    const hostedSignIn = screen.getByRole('link', { name: /Continue with Google/i });
     expect(hostedSignIn).toBeInTheDocument();
     expect(hostedSignIn).toHaveAttribute(
       'href',
@@ -949,7 +949,7 @@ describe('App', () => {
     setCurrentPath('/auth/callback');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { level: 1, name: /Sign in to Identrail/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 1, name: /Log in to Identrail/i })).toBeInTheDocument();
     expect(window.location.pathname).toBe('/signin');
     expect(window.location.search).toContain('reason=callback_error');
   });
@@ -1029,7 +1029,7 @@ describe('App', () => {
     setCurrentPath('/app/logout');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { level: 1, name: /Sign in to Identrail/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 1, name: /Log in to Identrail/i })).toBeInTheDocument();
     expect(await screen.findByText(/Signed out successfully/i)).toBeInTheDocument();
     expect(window.location.pathname).toBe('/signin');
   });
@@ -1043,7 +1043,7 @@ describe('App', () => {
     setCurrentPath('/app/logout');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { level: 1, name: /Sign in to Identrail/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 1, name: /Log in to Identrail/i })).toBeInTheDocument();
     expect(await screen.findByText(/Signed out successfully/i)).toBeInTheDocument();
     expect(window.location.pathname).toBe('/signin');
   });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3341,6 +3341,8 @@ export function RoutedSite() {
   useAnalytics();
   const location = useLocation();
   const isProductShellRoute = location.pathname.startsWith('/app');
+  const normalizedPath = location.pathname.replace(/\/+$/, '') || '/';
+  const isAuthChoiceRoute = normalizedPath === '/signin' || normalizedPath === '/signup';
 
   useEffect(() => {
     document.documentElement.dataset.theme = 'light';
@@ -3352,12 +3354,12 @@ export function RoutedSite() {
   }, []);
 
   return (
-    <div className="idt-site">
+    <div className={`idt-site ${isAuthChoiceRoute ? 'idt-site-auth' : ''}`}>
       <a className="idt-skip" href="#main-content">
         Skip to content
       </a>
 
-      {!isProductShellRoute ? (
+      {!isProductShellRoute && !isAuthChoiceRoute ? (
         <Header
           navLinks={NAV_LINKS}
           githubRepo={GITHUB_REPO}
@@ -3435,7 +3437,7 @@ export function RoutedSite() {
         </Routes>
       </main>
 
-      {!isProductShellRoute ? (
+      {!isProductShellRoute && !isAuthChoiceRoute ? (
         <>
           <Footer xUrl={X_URL} linkedInUrl={LINKEDIN_URL} githubRepo={GITHUB_REPO} discordUrl={DISCORD_URL} />
         </>

--- a/web/src/pages/SignInPage.tsx
+++ b/web/src/pages/SignInPage.tsx
@@ -8,6 +8,19 @@ type AuthChoicePageProps = {
   intent: AuthIntent;
 };
 
+type HostedProvider = {
+  id: string;
+  label: string;
+  icon: 'google' | 'github' | 'sso';
+  signUpTone?: 'dark';
+};
+
+const HOSTED_PROVIDERS: HostedProvider[] = [
+  { id: 'google_oauth', label: 'Continue with Google', icon: 'google' },
+  { id: 'github_oauth', label: 'Continue with GitHub', icon: 'github', signUpTone: 'dark' },
+  { id: 'authkit', label: 'Continue with SAML SSO', icon: 'sso' }
+];
+
 function normalizeReturnTo(value: string | null): string {
   const candidate = value?.trim() ?? '';
   if (!candidate || !candidate.startsWith('/') || candidate.startsWith('//')) {
@@ -37,6 +50,30 @@ function workOSURL(intent: AuthIntent, returnTo: string): string {
   const webReturnTo = typeof window === 'undefined' ? returnTo : new URL(returnTo, window.location.origin).toString();
   query.set('return_to', webReturnTo);
   return buildAPIURL(`/auth/${intent === 'signup' ? 'signup' : 'login'}?${query.toString()}`);
+}
+
+function providerIcon(provider: HostedProvider) {
+  switch (provider.icon) {
+    case 'google':
+      return (
+        <span className="idt-auth-provider-icon idt-auth-provider-icon-google" aria-hidden="true">
+          G
+        </span>
+      );
+    case 'github':
+      return <img className="idt-auth-provider-icon" src="/brand-logos/github.svg" alt="" />;
+    case 'sso':
+      return (
+        <span className="idt-auth-provider-icon idt-auth-provider-icon-sso" aria-hidden="true">
+          <svg viewBox="0 0 16 16" focusable="false">
+            <path
+              fill="currentColor"
+              d="M4.25 7.1V5.4a3.75 3.75 0 1 1 7.5 0v1.7h.45c.72 0 1.3.58 1.3 1.3v4.25c0 .72-.58 1.3-1.3 1.3H3.8c-.72 0-1.3-.58-1.3-1.3V8.4c0-.72.58-1.3 1.3-1.3h.45Zm1.35 0h4.8V5.4a2.4 2.4 0 0 0-4.8 0v1.7Zm3.1 2.75a.7.7 0 1 0-1.4 0v1.45a.7.7 0 1 0 1.4 0V9.85Z"
+            />
+          </svg>
+        </span>
+      );
+  }
 }
 
 export function AuthChoicePage({ intent }: AuthChoicePageProps) {
@@ -107,34 +144,29 @@ export function AuthChoicePage({ intent }: AuthChoicePageProps) {
     }
   };
 
-  const title = intent === 'signup' ? 'Create your Identrail account' : 'Sign in to Identrail';
-  const subtitle =
-    intent === 'signup'
-      ? 'Start with hosted, passwordless access and keep self-host development behind a separate manual mode.'
-      : 'Use your approved identity provider to enter the Identrail workspace boundary.';
+  const providerIDs = config?.auth.providers ?? [];
+  const hostedProviders =
+    config?.auth.workos_login_enabled === true
+      ? HOSTED_PROVIDERS.filter((provider) => providerIDs.includes(provider.id))
+      : [];
+  const title = intent === 'signup' ? 'Your first trust graph is just a sign-up away.' : 'Log in to Identrail';
   const switchLink = intent === 'signup' ? '/signin' : '/signup';
-  const switchCopy = intent === 'signup' ? 'Already have an account?' : 'New to Identrail?';
-  const switchAction = intent === 'signup' ? 'Sign in' : 'Create account';
+  const switchAction = intent === 'signup' ? 'Log In' : 'Sign Up';
 
   return (
-    <section className="idt-auth-page">
-      <div className="idt-auth-visual" aria-hidden="true">
-        <div className="idt-auth-signal-card">
+    <section className={`idt-auth-page idt-auth-page-${intent}`}>
+      <div className="idt-auth-topbar">
+        <Link to="/" className={`idt-auth-logo ${intent === 'login' ? 'is-mark-only' : ''}`} aria-label="Identrail homepage">
           <img src="/identrail-logo.png" alt="" />
-          <span>Verified access</span>
-        </div>
-        <div className="idt-auth-path">
-          <span>GitHub</span>
-          <span>Google</span>
-          <span>WorkOS</span>
           <span>Identrail</span>
-        </div>
+        </Link>
+        <Link className="idt-auth-switch" to={switchLink}>
+          {switchAction}
+        </Link>
       </div>
 
-      <article className="idt-auth-panel">
-        <p className="idt-app-kicker">Account access</p>
+      <article className={`idt-auth-panel idt-auth-panel-${intent}`}>
         <h1>{title}</h1>
-        <p>{subtitle}</p>
 
         {signedOut ? <p className="idt-app-alert idt-app-alert-success">Signed out successfully.</p> : null}
         {reason ? <p className="idt-app-alert">{reason}</p> : null}
@@ -144,20 +176,18 @@ export function AuthChoicePage({ intent }: AuthChoicePageProps) {
 
         {config?.auth.workos_login_enabled ? (
           <div className="idt-auth-provider-stack">
-            <a className="idt-auth-provider idt-auth-provider-primary" href={workOSURL(intent, returnTo)}>
-              <img src="/brand-logos/openid.svg" alt="" />
-              <span>{intent === 'signup' ? 'Continue with hosted sign-up' : 'Continue with hosted sign-in'}</span>
-            </a>
-            <div className="idt-auth-provider-grid" aria-label="Supported identity providers">
-              <a className="idt-auth-provider" href={workOSURL(intent, returnTo)}>
-                <img src="/brand-logos/github.svg" alt="" />
-                <span>GitHub</span>
+            {hostedProviders.map((provider) => (
+              <a
+                key={provider.id}
+                className={`idt-auth-provider ${
+                  intent === 'signup' && provider.signUpTone === 'dark' ? 'idt-auth-provider-dark' : ''
+                }`}
+                href={workOSURL(intent, returnTo)}
+              >
+                {providerIcon(provider)}
+                <span>{provider.label}</span>
               </a>
-              <a className="idt-auth-provider" href={workOSURL(intent, returnTo)}>
-                <span className="idt-auth-provider-letter">G</span>
-                <span>Google</span>
-              </a>
-            </div>
+            ))}
           </div>
         ) : null}
 
@@ -203,7 +233,7 @@ export function AuthChoicePage({ intent }: AuthChoicePageProps) {
               />
             </label>
             {manualError ? <p className="idt-app-alert idt-app-alert-error">{manualError}</p> : null}
-            <button className="idt-btn idt-btn-ghost" type="submit" disabled={manualSubmitting}>
+            <button className="idt-auth-provider idt-auth-provider-dark" type="submit" disabled={manualSubmitting}>
               {manualSubmitting ? 'Creating session...' : 'Continue in dev mode'}
             </button>
           </form>
@@ -213,12 +243,25 @@ export function AuthChoicePage({ intent }: AuthChoicePageProps) {
           <p className="idt-app-alert idt-app-alert-error">This deployment has not enabled an account provider yet.</p>
         ) : null}
 
-        <div className="idt-auth-footer-line">
-          <span>{switchCopy}</span>
-          <Link to={switchLink}>{switchAction}</Link>
-          <Link to="/why-no-passwords">Why no passwords?</Link>
-        </div>
+        {intent === 'login' ? (
+          <div className="idt-auth-footer-line">
+            <span>Don't have an account?</span>
+            <Link to={switchLink}>Sign Up</Link>
+          </div>
+        ) : (
+          <p className="idt-auth-terms">
+            By joining, you agree to our <Link to="/terms">Terms of Service</Link> and{' '}
+            <Link to="/privacy">Privacy Policy</Link>
+          </p>
+        )}
       </article>
+
+      {intent === 'login' ? (
+        <div className="idt-auth-legal-footer">
+          <Link to="/terms">Terms</Link>
+          <Link to="/privacy">Privacy Policy</Link>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4305,78 +4305,151 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
 }
 
 .idt-auth-page {
-  width: min(100% - 2rem, 1120px);
-  margin: 2.5rem auto 4rem;
+  width: 100%;
+  min-height: 100svh;
+  margin: 0;
+  padding: 7rem 1.5rem 5.25rem;
   display: grid;
-  grid-template-columns: minmax(0, 0.95fr) minmax(360px, 1.05fr);
-  gap: 1.5rem;
-  align-items: stretch;
+  align-items: start;
+  justify-items: center;
+  position: relative;
+  background: #fafafa;
+  color: #171717;
 }
 
-.idt-auth-visual,
+.idt-site-auth {
+  min-height: 100svh;
+  background: #fafafa;
+}
+
+.idt-site-auth > main {
+  min-height: 100svh;
+}
+
+.idt-auth-topbar {
+  position: absolute;
+  top: 1.35rem;
+  left: 1.75rem;
+  right: 1.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  pointer-events: none;
+}
+
+.idt-auth-logo,
+.idt-auth-switch {
+  pointer-events: auto;
+}
+
+.idt-auth-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: #000000;
+  text-decoration: none;
+}
+
+.idt-auth-logo img {
+  width: 1.55rem;
+  height: 1.55rem;
+  border-radius: 5px;
+}
+
+.idt-auth-logo span {
+  color: #000000;
+  font-family: var(--idt-body);
+  font-size: 1.85rem;
+  font-weight: 750;
+  letter-spacing: -0.01em;
+  line-height: 1;
+}
+
+.idt-auth-logo.is-mark-only span {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.idt-auth-switch {
+  min-width: 5.35rem;
+  min-height: 2.45rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #171717;
+  font-size: 0.95rem;
+  font-weight: 500;
+  text-decoration: none;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.02);
+  transition:
+    border-color 0.16s ease,
+    background-color 0.16s ease;
+}
+
+.idt-auth-switch:hover,
+.idt-auth-switch:focus-visible {
+  background: #f7f7f7;
+  border-color: #d8d8d8;
+}
+
 .idt-auth-panel,
 .idt-empty-panel,
 .idt-error-panel {
-  border: 1px solid rgba(120, 151, 207, 0.26);
+  border: 1px solid #e5e5e5;
   border-radius: 8px;
-  background: rgba(10, 17, 30, 0.84);
-}
-
-.idt-auth-visual {
-  min-height: 560px;
-  padding: 1.25rem;
-  display: grid;
-  align-content: end;
-  gap: 1rem;
-  background:
-    linear-gradient(140deg, rgba(13, 25, 42, 0.86), rgba(15, 35, 51, 0.72)),
-    url('/identrail-logo.png') center 18% / 172px auto no-repeat;
-}
-
-.idt-auth-signal-card {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  width: fit-content;
-  max-width: 100%;
-  border: 1px solid rgba(139, 206, 179, 0.36);
-  border-radius: 8px;
-  padding: 0.75rem 0.9rem;
-  color: #dffbed;
-  background: rgba(9, 24, 25, 0.74);
-}
-
-.idt-auth-signal-card img {
-  width: 28px;
-  height: 28px;
-  object-fit: contain;
-}
-
-.idt-auth-path {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.5rem;
-}
-
-.idt-auth-path span {
-  border: 1px solid rgba(164, 183, 211, 0.28);
-  border-radius: 8px;
-  padding: 0.7rem;
-  text-align: center;
-  color: #d8e6f8;
-  background: rgba(11, 18, 31, 0.82);
-  font-size: 0.88rem;
-  font-weight: 700;
+  background: #ffffff;
 }
 
 .idt-auth-panel {
-  padding: clamp(1.25rem, 3vw, 2rem);
+  width: min(100%, 23rem);
+  margin-top: 6.5rem;
   display: grid;
-  align-content: center;
   gap: 1rem;
+  border-color: transparent;
+  background: transparent;
 }
 
-.idt-auth-panel h1,
+.idt-auth-panel-signup {
+  width: min(100%, 39.5rem);
+  min-height: 45.5rem;
+  align-content: center;
+  justify-items: center;
+  gap: 1.25rem;
+  padding: clamp(2.25rem, 5vw, 4.9rem) clamp(1.5rem, 4vw, 5.65rem) 2rem;
+  border-color: #dedede;
+  background: #ffffff;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 18px 54px rgba(0, 0, 0, 0.03);
+}
+
+.idt-auth-panel h1 {
+  margin: 0 0 1rem;
+  color: #171717;
+  font-family: var(--idt-body);
+  font-size: clamp(2rem, 4vw, 2.42rem);
+  font-weight: 750;
+  letter-spacing: -0.04em;
+  line-height: 1.15;
+  text-align: center;
+}
+
+.idt-auth-panel-signup h1 {
+  max-width: 16ch;
+  margin-bottom: 1.55rem;
+  font-size: clamp(2.05rem, 4.2vw, 2.45rem);
+}
+
 .idt-passwordless-hero h1 {
   max-width: 780px;
   font-size: clamp(2.15rem, 4vw, 4.4rem);
@@ -4386,81 +4459,204 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
 .idt-auth-provider-stack,
 .idt-auth-provider-grid {
   display: grid;
-  gap: 0.65rem;
+  width: 100%;
+  gap: 1rem;
 }
 
 .idt-auth-provider-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: 1fr;
 }
 
 .idt-auth-provider {
-  min-height: 48px;
+  width: 100%;
+  min-height: 3.55rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.65rem;
-  border: 1px solid rgba(126, 157, 211, 0.34);
+  gap: 0.7rem;
+  border: 1px solid #e5e5e5;
   border-radius: 8px;
-  color: #e7f1ff;
+  color: #171717;
   text-decoration: none;
-  font-weight: 800;
-  background: rgba(13, 21, 35, 0.88);
+  font-size: 1.08rem;
+  font-weight: 500;
+  line-height: 1.2;
+  background: #ffffff;
+  cursor: pointer;
+  transition:
+    border-color 0.16s ease,
+    background-color 0.16s ease,
+    box-shadow 0.16s ease;
 }
 
-.idt-auth-provider:hover {
-  border-color: rgba(139, 206, 179, 0.58);
-  color: #f4fff8;
+.idt-auth-provider:hover,
+.idt-auth-provider:focus-visible {
+  border-color: #cfcfcf;
+  background: #fbfbfb;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
 }
 
-.idt-auth-provider-primary {
-  justify-content: flex-start;
-  padding-inline: 1rem;
-  background: #dceaff;
-  color: #14294e;
+.idt-auth-provider:disabled {
+  cursor: not-allowed;
+  opacity: 0.64;
 }
 
-.idt-auth-provider img {
-  width: 22px;
-  height: 22px;
+.idt-auth-provider-dark {
+  border-color: #24292f;
+  background: #24292f;
+  color: #ffffff;
+}
+
+.idt-auth-provider-dark:hover,
+.idt-auth-provider-dark:focus-visible {
+  border-color: #24292f;
+  background: #1f2328;
+  color: #ffffff;
+}
+
+.idt-auth-provider-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  flex: none;
   object-fit: contain;
 }
 
-.idt-auth-provider-letter {
-  width: 22px;
-  height: 22px;
+.idt-auth-provider-dark .idt-auth-provider-icon {
+  filter: brightness(0) invert(1);
+}
+
+.idt-auth-provider-icon-google,
+.idt-auth-provider-icon-sso {
   display: inline-grid;
   place-items: center;
-  border-radius: 999px;
-  color: #0f233f;
-  background: #f8fbff;
-  font-weight: 900;
+}
+
+.idt-auth-provider-icon-google {
+  color: #ffffff;
+  border-radius: 50%;
+  background: conic-gradient(from -45deg, #4285f4 0 25%, #34a853 0 50%, #fbbc05 0 75%, #ea4335 0 100%);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.idt-auth-provider-icon-sso svg {
+  width: 1rem;
+  height: 1rem;
+  color: #171717;
+}
+
+.idt-auth-panel .idt-app-alert {
+  margin: 0;
+  border-color: #e5e5e5;
+  background: #ffffff;
+  color: #525252;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.idt-auth-panel .idt-app-alert-error {
+  border-color: #fecaca;
+  background: #fff7f7;
+  color: #991b1b;
+}
+
+.idt-auth-panel .idt-app-alert-success {
+  border-color: #bbf7d0;
+  background: #f0fdf4;
+  color: #166534;
 }
 
 .idt-auth-manual-form {
-  border-top: 1px solid rgba(126, 157, 211, 0.22);
+  width: 100%;
+  margin-top: 0.25rem;
   padding-top: 1rem;
+  border-top: 1px solid #e5e5e5;
+}
+
+.idt-auth-manual-form label {
+  color: #525252;
+  font-size: 0.86rem;
+  font-weight: 500;
+}
+
+.idt-auth-manual-form input {
+  min-height: 2.8rem;
+  border-color: #e5e5e5;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #171717;
+  padding: 0.65rem 0.8rem;
 }
 
 .idt-dev-mode-banner {
   width: fit-content;
-  border: 1px solid rgba(221, 184, 85, 0.44);
-  border-radius: 8px;
-  padding: 0.32rem 0.55rem;
-  color: #ffe8a8;
-  background: rgba(49, 35, 10, 0.72);
-  font-weight: 800;
+  margin: 0;
+  border: 1px solid #e5e5e5;
+  border-radius: 999px;
+  padding: 0.25rem 0.58rem;
+  color: #525252;
+  background: #fafafa;
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1.2;
 }
 
 .idt-auth-footer-line {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.65rem;
-  color: #c6d7ed;
+  justify-content: center;
+  gap: 0.28rem;
+  margin-top: 1rem;
+  color: #171717;
+  font-size: 0.98rem;
+  line-height: 1.45;
 }
 
-.idt-auth-footer-line a {
-  color: #dffbed;
-  font-weight: 800;
+.idt-auth-footer-line a,
+.idt-auth-terms a,
+.idt-auth-legal-footer a {
+  color: #0070f3;
+  font-weight: 400;
+  text-decoration: none;
+}
+
+.idt-auth-footer-line a:hover,
+.idt-auth-footer-line a:focus-visible,
+.idt-auth-terms a:hover,
+.idt-auth-terms a:focus-visible,
+.idt-auth-legal-footer a:hover,
+.idt-auth-legal-footer a:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+}
+
+.idt-auth-terms {
+  max-width: 100%;
+  margin: clamp(2.4rem, 7vw, 4.5rem) 0 0;
+  color: #666666;
+  font-size: 0.91rem;
+  line-height: 1.5;
+  text-align: center;
+}
+
+.idt-auth-terms a {
+  color: #171717;
+}
+
+.idt-auth-legal-footer {
+  position: absolute;
+  bottom: 1.75rem;
+  left: 1rem;
+  right: 1rem;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  color: #888888;
+  font-size: 0.86rem;
+}
+
+.idt-auth-legal-footer a {
+  color: #888888;
 }
 
 .idt-passwordless-page {
@@ -5130,6 +5326,35 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
     grid-template-columns: 1fr;
   }
 
+  .idt-auth-page {
+    padding: 6rem 1rem 4.75rem;
+  }
+
+  .idt-auth-panel {
+    margin-top: 0;
+  }
+
+  .idt-auth-topbar {
+    top: 1rem;
+    left: 1rem;
+    right: 1rem;
+  }
+
+  .idt-auth-logo span {
+    font-size: 1.45rem;
+  }
+
+  .idt-auth-switch {
+    min-width: 4.65rem;
+    min-height: 2.25rem;
+    font-size: 0.88rem;
+  }
+
+  .idt-auth-panel-signup {
+    min-height: auto;
+    padding: 2.8rem 1.25rem 1.7rem;
+  }
+
   .idt-session-row,
   .idt-security-section-header {
     display: grid;
@@ -5253,6 +5478,76 @@ html[data-theme='light'] .idt-auth-footer-line {
 
 html[data-theme='light'] .idt-auth-footer-line a {
   color: #183c6b;
+}
+
+html[data-theme='light'] .idt-site-auth,
+html[data-theme='light'] .idt-auth-page {
+  background: #fafafa;
+}
+
+html[data-theme='light'] .idt-auth-panel-login {
+  background: transparent;
+  border-color: transparent;
+}
+
+html[data-theme='light'] .idt-auth-panel-signup {
+  background: #ffffff;
+  border-color: #dedede;
+}
+
+html[data-theme='light'] .idt-auth-provider {
+  color: #171717;
+  background: #ffffff;
+  border-color: #e5e5e5;
+}
+
+html[data-theme='light'] .idt-auth-provider:hover,
+html[data-theme='light'] .idt-auth-provider:focus-visible {
+  background: #fbfbfb;
+  border-color: #cfcfcf;
+}
+
+html[data-theme='light'] .idt-auth-provider-dark,
+html[data-theme='light'] .idt-auth-provider-dark:hover,
+html[data-theme='light'] .idt-auth-provider-dark:focus-visible {
+  color: #ffffff;
+  background: #24292f;
+  border-color: #24292f;
+}
+
+html[data-theme='light'] .idt-auth-provider-dark .idt-auth-provider-icon {
+  filter: brightness(0) invert(1);
+}
+
+html[data-theme='light'] .idt-auth-footer-line,
+html[data-theme='light'] .idt-auth-panel h1 {
+  color: #171717;
+}
+
+html[data-theme='light'] .idt-auth-footer-line a,
+html[data-theme='light'] .idt-auth-legal-footer a {
+  color: #0070f3;
+}
+
+html[data-theme='light'] .idt-auth-terms a {
+  color: #171717;
+}
+
+html[data-theme='light'] .idt-auth-manual-form label,
+html[data-theme='light'] .idt-auth-terms {
+  color: #666666;
+}
+
+html[data-theme='light'] .idt-auth-manual-form input {
+  color: #171717;
+  background: #ffffff;
+  border-color: #e5e5e5;
+}
+
+html[data-theme='light'] .idt-dev-mode-banner {
+  color: #525252;
+  background: #fafafa;
+  border-color: #e5e5e5;
 }
 
 html[data-theme='light'] .idt-passwordless-hero {


### PR DESCRIPTION
## Summary

- Redesigns `/signin` and `/signup` into minimal Vercel-style auth entry pages.
- Shows only Identrail's configured hosted providers from `/v1/auth/config`: Google, GitHub, and SAML SSO/AuthKit.
- Removes the public site header/footer from auth entry routes, including prerendered trailing-slash paths.
- Leaves `/why-no-passwords` in place, but removes it from the auth entry screen for now.

## Why

The existing auth entry experience used a split marketing/auth layout that did not match the requested clean Vercel-style flow. This keeps the auth surface focused while preserving the current backend contract and hosted login behavior.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

Risk: low. This is frontend-only visual/layout work for public auth entry pages. Backend routes and auth behavior are unchanged.

## Validation

```bash
git diff --check
npm run test:ci --prefix web
npm run build --prefix web
```

Results:
- `git diff --check` passed.
- `npm run test:ci --prefix web` passed: 6 files, 60 tests.
- `npm run build --prefix web` passed and prerendered 40 routes.
- Browser preview checked `/signin/` and `/signup/` at desktop and mobile widths with a local mock auth config.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

Docs/changelog note: not updated because this is visual-only frontend auth entry work with no user-facing product behavior, API contract, operator setup, or release-note requirement.

## AI Assistance Disclosure

- AI-assisted: yes
- Tools used: Codex
- Areas where used: frontend auth page layout, CSS styling, provider rendering, and test expectation updates
- Human verification performed: local diff review, web test suite, production build/prerender, and browser layout checks

## Related Issues

No issue: visual-only auth entry redesign requested directly; no backend or API behavior change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned `/signin` and `/signup` into focused, Vercel-style pages that show only enabled hosted providers and remove site chrome on auth routes. This delivers a cleaner auth flow with no backend changes.

- **New Features**
  - Provider list now driven by `/v1/auth/config`; renders only enabled hosted providers (Google, GitHub, SAML SSO/AuthKit).
  - Minimal layout with logo topbar and auth switch; adds Terms/Privacy links and keeps dev mode entry.
  - Normalizes trailing-slash routes and hides header/footer on auth pages.

- **Refactors**
  - Updated headings and tests (e.g., “Log in to Identrail”, provider-specific CTAs).
  - Consolidated provider rendering and icons; overhauled styles for the new light, minimal look.

<sup>Written for commit 264f272c045d1cc3590c276426fd1f70b8bbe540. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

