### PR TITLE
Verify AWS OIDC deployment role

### DIFF
--- a/.github/workflows/aws-oidc-verification.yml
+++ b/.github/workflows/aws-oidc-verification.yml
@@ -1,0 +1,112 @@
+name: AWS OIDC Verification
+
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - '.github/workflows/aws-oidc-verification.yml'
+      - 'docs/aws-oidc-deployment.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: aws-oidc-verification-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify AWS OIDC role
+    if: github.repository == 'identrail/identrail' && github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      AWS_DEFAULT_REGION: ${{ vars.AWS_REGION }}
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+    steps:
+      - name: Validate GitHub AWS configuration
+        id: config
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${AWS_REGION}" ]; then
+            echo "Missing repository variable AWS_REGION."
+            exit 1
+          fi
+          if [ -z "${AWS_ROLE_ARN}" ]; then
+            echo "Missing repository secret AWS_ROLE_ARN."
+            exit 1
+          fi
+          if [[ ! "${AWS_ROLE_ARN}" =~ ^arn:aws:iam::([0-9]{12}):role/(.+)$ ]]; then
+            echo "AWS_ROLE_ARN must look like arn:aws:iam::<account-id>:role/<role-name>."
+            exit 1
+          fi
+          account_id="${BASH_REMATCH[1]}"
+          role_name="${BASH_REMATCH[2]}"
+          {
+            echo "account_id=${account_id}"
+            echo "role_name=${role_name}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Assume AWS deployment role
+        id: assume
+        shell: bash
+        run: |
+          set -euo pipefail
+          token_response="$(
+            curl -fsSL \
+              -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sts.amazonaws.com"
+          )"
+          oidc_token="$(jq -r '.value // empty' <<< "${token_response}")"
+          if [ -z "${oidc_token}" ]; then
+            echo "GitHub did not return an OIDC token."
+            exit 1
+          fi
+          credentials="$(
+            aws sts assume-role-with-web-identity \
+              --role-arn "${AWS_ROLE_ARN}" \
+              --role-session-name "identrail-github-oidc-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+              --web-identity-token "${oidc_token}" \
+              --duration-seconds 900 \
+              --query 'Credentials' \
+              --output json
+          )"
+          access_key_id="$(jq -r '.AccessKeyId' <<< "${credentials}")"
+          secret_access_key="$(jq -r '.SecretAccessKey' <<< "${credentials}")"
+          session_token="$(jq -r '.SessionToken' <<< "${credentials}")"
+          echo "::add-mask::${access_key_id}"
+          echo "::add-mask::${secret_access_key}"
+          echo "::add-mask::${session_token}"
+          {
+            echo "AWS_ACCESS_KEY_ID=${access_key_id}"
+            echo "AWS_SECRET_ACCESS_KEY=${secret_access_key}"
+            echo "AWS_SESSION_TOKEN=${session_token}"
+          } >> "$GITHUB_ENV"
+
+      - name: Verify caller identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          identity="$(aws sts get-caller-identity --output json)"
+          account="$(jq -r '.Account' <<< "${identity}")"
+          arn="$(jq -r '.Arn' <<< "${identity}")"
+          expected_account="${{ steps.config.outputs.account_id }}"
+          expected_role="${{ steps.config.outputs.role_name }}"
+
+          if [ "${account}" != "${expected_account}" ]; then
+            echo "Unexpected AWS account ${account}; expected ${expected_account}."
+            exit 1
+          fi
+          if [[ "${arn}" != *":assumed-role/${expected_role}/"* ]]; then
+            echo "Unexpected caller ARN ${arn}; expected assumed role ${expected_role}."
+            exit 1
+          fi
+
+          echo "AWS OIDC verification passed."
+          echo "Account: ${account}"
+          echo "Role: ${expected_role}"

--- a/.github/workflows/aws-oidc-verification.yml
+++ b/.github/workflows/aws-oidc-verification.yml
@@ -46,7 +46,8 @@ jobs:
             exit 1
           fi
           account_id="${BASH_REMATCH[1]}"
-          role_name="${BASH_REMATCH[2]}"
+          role_resource="${BASH_REMATCH[2]}"
+          role_name="${role_resource##*/}"
           {
             echo "account_id=${account_id}"
             echo "role_name=${role_name}"

--- a/.github/workflows/aws-oidc-verification.yml
+++ b/.github/workflows/aws-oidc-verification.yml
@@ -108,5 +108,5 @@ jobs:
           fi
 
           echo "AWS OIDC verification passed."
-          echo "Account: ${account}"
+          echo "AWS account matched the configured role ARN."
           echo "Role: ${expected_role}"

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - Enterprise quickstart: `enterprise-quickstart.md`
 - Operator readiness handoff: `operator-readiness.md`
 - Deployment runbook: `deploy-runbook.md`
+- AWS OIDC deployment role: `aws-oidc-deployment.md`
 
 ## Operator track
 

--- a/docs/aws-oidc-deployment.md
+++ b/docs/aws-oidc-deployment.md
@@ -1,0 +1,64 @@
+# AWS OIDC Deployment Role
+
+Identrail deploys AWS infrastructure from GitHub Actions through OpenID Connect (OIDC), not long-lived AWS access keys.
+
+## Why This Exists
+
+GitHub Actions receives short-lived AWS credentials only when AWS can verify the workflow identity. The current production trust target is:
+
+```text
+repo:identrail/identrail:ref:refs/heads/dev
+```
+
+That means PR branches and forks cannot assume the deployment role. The first AWS workflow is intentionally a verification-only workflow before any infrastructure is created.
+
+## GitHub Repository Configuration
+
+Required repository secret:
+
+```text
+AWS_ROLE_ARN=arn:aws:iam::263434643405:role/IdentrailGithubDeployRole
+```
+
+Required repository variable:
+
+```text
+AWS_REGION=us-east-1
+```
+
+## AWS Trust Policy
+
+The role trust policy should allow only the `dev` branch in this repository:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::263434643405:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub": "repo:identrail/identrail:ref:refs/heads/dev"
+        }
+      }
+    }
+  ]
+}
+```
+
+## Verification Workflow
+
+The workflow `.github/workflows/aws-oidc-verification.yml` does three things:
+
+1. Requests a GitHub OIDC token for `sts.amazonaws.com`.
+2. Assumes `AWS_ROLE_ARN` with `aws sts assume-role-with-web-identity`.
+3. Runs `aws sts get-caller-identity` and verifies the returned AWS account and role.
+
+It does not create, modify, or delete AWS resources.
+
+Because the trust policy is scoped to `refs/heads/dev`, the workflow is expected to run only after this workflow file is on `dev` or when manually dispatched from `dev`.

--- a/docs/aws-oidc-deployment.md
+++ b/docs/aws-oidc-deployment.md
@@ -17,7 +17,7 @@ That means PR branches and forks cannot assume the deployment role. The first AW
 Required repository secret:
 
 ```text
-AWS_ROLE_ARN=arn:aws:iam::263434643405:role/IdentrailGithubDeployRole
+AWS_ROLE_ARN=arn:aws:iam::<aws-account-id>:role/IdentrailGithubDeployRole
 ```
 
 Required repository variable:
@@ -37,7 +37,7 @@ The role trust policy should allow only the `dev` branch in this repository:
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::263434643405:oidc-provider/token.actions.githubusercontent.com"
+        "Federated": "arn:aws:iam::<aws-account-id>:oidc-provider/token.actions.githubusercontent.com"
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
@@ -50,6 +50,8 @@ The role trust policy should allow only the `dev` branch in this repository:
   ]
 }
 ```
+
+Replace `<aws-account-id>` with the target AWS account ID when configuring the role. Do not commit personal account-specific ARNs unless the repository intentionally documents a public production account.
 
 ## Verification Workflow
 

--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -7,6 +7,7 @@ Portable deployment profiles:
 - Kubernetes: `deploy/kubernetes/`
 - Linux VM/systemd: `deploy/systemd/`
 - Guide: `docs/deployment-anywhere.md`
+- AWS OIDC deployment role: `docs/aws-oidc-deployment.md`
 - Operator readiness: `docs/operator-readiness.md`
 - Troubleshooting playbook: `docs/troubleshooting.md`
 - Incident workflow: `docs/incident-response.md`


### PR DESCRIPTION
Fixes #1090

## Summary

This PR adds a zero-resource AWS OIDC verification step before the real AWS deployment work.

- Adds `.github/workflows/aws-oidc-verification.yml`.
- Uses GitHub's built-in OIDC token endpoint and `aws sts assume-role-with-web-identity` directly, without adding a third-party AWS credentials action.
- Verifies `aws sts get-caller-identity` returns the account and role encoded by `AWS_ROLE_ARN`.
- Documents the required GitHub repo config and AWS trust policy in `docs/aws-oidc-deployment.md`.

## Why

Before PR 7 creates AWS infrastructure, we need to prove the secure deployment identity works: GitHub Actions should be able to assume the deployment role from `dev` without AWS passwords or long-lived access keys.

## Security / Compatibility

- No AWS resources are created, modified, or deleted.
- Workflow permissions are limited to `contents: read` and `id-token: write`.
- The job is guarded to run only for `identrail/identrail` on `refs/heads/dev`, matching the AWS trust policy.
- PR branches are not expected to assume the AWS role; the verification should run after this lands on `dev` or via manual dispatch from `dev`.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/aws-oidc-verification.yml"); puts "yaml ok"'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -shellcheck= .github/workflows/aws-oidc-verification.yml`
- `git diff --check`
- pre-commit hooks during commit: merge conflicts, YAML, EOF, whitespace, gofmt, Vercel artifact hygiene
- pre-push hooks during push: merge conflicts, YAML, EOF, whitespace, gofmt, go vet, local env token hygiene, Vercel artifact hygiene

## AI Disclosure

- AI-assisted: yes
- Tools used: OpenAI Codex
- Where used: workflow/docs implementation and validation
- Human verification performed: reviewed diff and ran validation listed above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a workflow to verify that GitHub Actions on `dev` can assume the AWS deployment role via OIDC (including path-scoped roles), with no AWS changes or third‑party actions. Adds docs for repo config and a generic trust policy; avoids account‑specific ARNs in docs and logs.

- **New Features**
  - New workflow `/.github/workflows/aws-oidc-verification.yml` requests a GitHub OIDC token, runs `aws sts assume-role-with-web-identity`, and checks `get-caller-identity` matches the account and role from `AWS_ROLE_ARN`; supports path-scoped role ARNs, masks credentials, and prints only the role name.
  - Guardrails: `contents: read`, `id-token: write`, concurrency cancel-in-progress; runs only for `identrail/identrail` on `refs/heads/dev` (push or manual); validates `AWS_REGION` and `AWS_ROLE_ARN` presence and ARN format.
  - New `docs/aws-oidc-deployment.md` explains `AWS_ROLE_ARN` (secret) and `AWS_REGION` (variable), provides a trust policy using `<aws-account-id>`, and links from `docs/README.md` and `docs/deploy-runbook.md`.

<sup>Written for commit 4e5f6806dd40a6c22b665aa1caeece3322f2d38b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

