### PR TITLE
Normalize AWS OIDC region configuration

### DIFF
--- a/.github/workflows/aws-oidc-verification.yml
+++ b/.github/workflows/aws-oidc-verification.yml
@@ -24,8 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      AWS_REGION: ${{ vars.AWS_REGION }}
-      AWS_DEFAULT_REGION: ${{ vars.AWS_REGION }}
+      IDENTRAIL_AWS_REGION: ${{ vars.AWS_REGION }}
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
     steps:
       - name: Validate GitHub AWS configuration
@@ -33,8 +32,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ -z "${AWS_REGION}" ]; then
+          aws_region="$(printf '%s' "${IDENTRAIL_AWS_REGION}" | tr -d '[:space:]')"
+          if [ -z "${aws_region}" ]; then
             echo "Missing repository variable AWS_REGION."
+            exit 1
+          fi
+          if [[ ! "${aws_region}" =~ ^[a-z]{2}(-gov)?-[a-z]+-[0-9]+$ ]]; then
+            echo "AWS_REGION must be an AWS region such as us-east-1."
             exit 1
           fi
           if [ -z "${AWS_ROLE_ARN}" ]; then
@@ -52,6 +56,10 @@ jobs:
             echo "account_id=${account_id}"
             echo "role_name=${role_name}"
           } >> "$GITHUB_OUTPUT"
+          {
+            echo "AWS_REGION=${aws_region}"
+            echo "AWS_DEFAULT_REGION=${aws_region}"
+          } >> "$GITHUB_ENV"
 
       - name: Assume AWS deployment role
         id: assume


### PR DESCRIPTION
Fixes #1094

## What changed
- Read the raw GitHub repository variable as `IDENTRAIL_AWS_REGION` instead of exporting it directly to the AWS CLI environment.
- Trim whitespace from the configured region before setting `AWS_REGION` and `AWS_DEFAULT_REGION`.
- Validate the normalized region before the workflow requests AWS credentials.

## Why
The first post-merge AWS OIDC verification run from PR #1091 failed because `AWS_REGION` reached the AWS CLI with trailing whitespace, so `us-east-1` was interpreted as an unsupported region value.

## Impact and risk
This only changes workflow configuration handling. It does not create, modify, or delete AWS resources. Blank or malformed region values still fail clearly before AWS calls run.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/aws-oidc-verification.yml"); puts "yaml ok"'`\n- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -shellcheck= .github/workflows/aws-oidc-verification.yml`\n- Local bash reproduction trimming ` us-east-1\\n` to `us-east-1`\n- `git diff --check`\n- Commit and push hooks\n\nAI-assisted: yes\nTools used: Codex\nWhere used: workflow patch and validation\nHuman verification performed: reviewed diff, reproduced the failing region format locally, and ran the checks listed above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize AWS OIDC region handling in the verification workflow to prevent invalid region errors from trailing or stray whitespace. The workflow now trims and validates the region before exporting `AWS_REGION` and `AWS_DEFAULT_REGION`.

- **Bug Fixes**
  - Read raw repo var as `IDENTRAIL_AWS_REGION`; set `AWS_REGION`/`AWS_DEFAULT_REGION` via `$GITHUB_ENV` after trimming.
  - Remove all whitespace and validate against a region pattern (e.g., `us-east-1`) before assuming the role.
  - Fail fast with clear errors if the region or `AWS_ROLE_ARN` is missing or malformed.

<sup>Written for commit 674932f717ff028051de5859df461fba34b3cd68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

