### PR TITLE
Normalize AWS OIDC role ARN secret

### DIFF
--- a/.github/workflows/aws-oidc-verification.yml
+++ b/.github/workflows/aws-oidc-verification.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 10
     env:
       IDENTRAIL_AWS_REGION: ${{ vars.AWS_REGION }}
-      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      IDENTRAIL_AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
     steps:
       - name: Validate GitHub AWS configuration
         id: config
@@ -41,14 +41,16 @@ jobs:
             echo "AWS_REGION must be an AWS region such as us-east-1."
             exit 1
           fi
-          if [ -z "${AWS_ROLE_ARN}" ]; then
+          aws_role_arn="$(printf '%s' "${IDENTRAIL_AWS_ROLE_ARN}" | tr -d '[:space:]')"
+          if [ -z "${aws_role_arn}" ]; then
             echo "Missing repository secret AWS_ROLE_ARN."
             exit 1
           fi
-          if [[ ! "${AWS_ROLE_ARN}" =~ ^arn:aws:iam::([0-9]{12}):role/(.+)$ ]]; then
+          if [[ ! "${aws_role_arn}" =~ ^arn:aws:iam::([0-9]{12}):role/(.+)$ ]]; then
             echo "AWS_ROLE_ARN must look like arn:aws:iam::<account-id>:role/<role-name>."
             exit 1
           fi
+          echo "::add-mask::${aws_role_arn}"
           account_id="${BASH_REMATCH[1]}"
           role_resource="${BASH_REMATCH[2]}"
           role_name="${role_resource##*/}"
@@ -59,6 +61,7 @@ jobs:
           {
             echo "AWS_REGION=${aws_region}"
             echo "AWS_DEFAULT_REGION=${aws_region}"
+            echo "AWS_ROLE_ARN=${aws_role_arn}"
           } >> "$GITHUB_ENV"
 
       - name: Assume AWS deployment role


### PR DESCRIPTION
Fixes #1096

## What changed
- Read the raw GitHub secret as `IDENTRAIL_AWS_ROLE_ARN` instead of passing it directly to AWS CLI.
- Trim whitespace from the role ARN before validation and AWS CLI use.
- Mask the normalized ARN before exporting it as `AWS_ROLE_ARN`.

## Why
After PR #1095 merged, the AWS OIDC verification run got past region normalization and failed with `Request ARN is invalid` during `AssumeRoleWithWebIdentity`. That means the workflow reached the role-assumption step but the ARN value sent to AWS was not in a clean ARN format, most likely because the GitHub secret was pasted with hidden whitespace.

## Impact and risk
This only hardens workflow input handling. It does not change AWS trust policy rules and does not create, modify, or delete AWS resources. Blank or malformed ARN values still fail before any AWS role assumption attempt.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/aws-oidc-verification.yml"); puts "yaml ok"'`\n- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -shellcheck= .github/workflows/aws-oidc-verification.yml`\n- Local bash reproduction trimming ` arn:aws:iam::123456789012:role/github/IdentrailGithubDeployRole\\n` and extracting `IdentrailGithubDeployRole`\n- `git diff --check`\n- Commit and push hooks\n\nAI-assisted: yes\nTools used: Codex\nWhere used: workflow patch and validation\nHuman verification performed: reviewed diff, reproduced the malformed secret format locally, and ran the checks listed above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes the AWS OIDC role ARN in `.github/workflows/aws-oidc-verification.yml` to prevent invalid ARN errors when secrets include whitespace. Reads the secret into `IDENTRAIL_AWS_ROLE_ARN`, trims and validates it, masks the value, then exports it as `AWS_ROLE_ARN` for downstream steps.

- **Bug Fixes**
  - Trim and validate the ARN; fail fast with a clear message if missing or malformed.
  - Mask the normalized ARN and export as `AWS_ROLE_ARN`; no changes to AWS resources or trust policies.

<sup>Written for commit f14c9b6ea8add61222950d5abba65bbdee405a28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

