### PR TITLE
Add AWS deployment foundation

### DIFF
--- a/.github/workflows/aws-deployment-foundation.yml
+++ b/.github/workflows/aws-deployment-foundation.yml
@@ -112,7 +112,12 @@ jobs:
       - name: Terraform Plan
         if: github.repository == 'identrail/identrail' && github.ref == 'refs/heads/dev'
         working-directory: deploy/aws/terraform
-        run: terraform plan -refresh=false -input=false -var-file=environments/dev/terraform.tfvars.example
+        run: |
+          terraform plan \
+            -refresh=false \
+            -input=false \
+            -var-file=environments/dev/terraform.tfvars.example \
+            -var="aws_region=${AWS_REGION}"
 
       - name: Skip AWS Plan Outside Dev
         if: github.repository != 'identrail/identrail' || github.ref != 'refs/heads/dev'

--- a/.github/workflows/aws-deployment-foundation.yml
+++ b/.github/workflows/aws-deployment-foundation.yml
@@ -1,0 +1,119 @@
+name: AWS Deployment Foundation
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/aws-deployment-foundation.yml'
+      - 'deploy/aws/**'
+      - 'docs/aws-deployment-foundation.md'
+  push:
+    branches:
+      - dev
+    paths:
+      - '.github/workflows/aws-deployment-foundation.yml'
+      - 'deploy/aws/**'
+      - 'docs/aws-deployment-foundation.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: aws-deployment-foundation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  terraform:
+    name: Terraform Plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      IDENTRAIL_AWS_REGION: ${{ vars.AWS_REGION }}
+      IDENTRAIL_AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      TF_IN_AUTOMATION: "true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85
+
+      - name: Terraform Format Check
+        run: terraform fmt -check -recursive deploy/aws/terraform
+
+      - name: Terraform Init
+        working-directory: deploy/aws/terraform
+        run: terraform init -backend=false
+
+      - name: Terraform Validate
+        working-directory: deploy/aws/terraform
+        run: terraform validate
+
+      - name: Configure AWS credentials
+        if: github.repository == 'identrail/identrail' && github.ref == 'refs/heads/dev'
+        shell: bash
+        run: |
+          set -euo pipefail
+          aws_region="$(printf '%s' "${IDENTRAIL_AWS_REGION}" | tr -d '[:space:]')"
+          if [ -z "${aws_region}" ]; then
+            echo "Missing repository variable AWS_REGION."
+            exit 1
+          fi
+          if [[ ! "${aws_region}" =~ ^[a-z]{2}(-gov)?-[a-z]+-[0-9]+$ ]]; then
+            echo "AWS_REGION must be an AWS region such as us-east-1."
+            exit 1
+          fi
+          aws_role_arn="$(printf '%s' "${IDENTRAIL_AWS_ROLE_ARN}" | tr -d '[:space:]')"
+          if [ -z "${aws_role_arn}" ]; then
+            echo "Missing repository secret AWS_ROLE_ARN."
+            exit 1
+          fi
+          if [[ ! "${aws_role_arn}" =~ ^arn:aws:iam::[0-9]{12}:role/.+$ ]]; then
+            echo "AWS_ROLE_ARN must look like arn:aws:iam::<account-id>:role/<role-name>."
+            exit 1
+          fi
+          echo "::add-mask::${aws_role_arn}"
+
+          token_response="$(
+            curl -fsSL \
+              -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sts.amazonaws.com"
+          )"
+          oidc_token="$(jq -r '.value // empty' <<< "${token_response}")"
+          if [ -z "${oidc_token}" ]; then
+            echo "GitHub did not return an OIDC token."
+            exit 1
+          fi
+
+          credentials="$(
+            aws sts assume-role-with-web-identity \
+              --role-arn "${aws_role_arn}" \
+              --role-session-name "identrail-aws-foundation-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+              --web-identity-token "${oidc_token}" \
+              --duration-seconds 900 \
+              --query 'Credentials' \
+              --output json
+          )"
+          access_key_id="$(jq -r '.AccessKeyId' <<< "${credentials}")"
+          secret_access_key="$(jq -r '.SecretAccessKey' <<< "${credentials}")"
+          session_token="$(jq -r '.SessionToken' <<< "${credentials}")"
+          echo "::add-mask::${access_key_id}"
+          echo "::add-mask::${secret_access_key}"
+          echo "::add-mask::${session_token}"
+          {
+            echo "AWS_ACCESS_KEY_ID=${access_key_id}"
+            echo "AWS_SECRET_ACCESS_KEY=${secret_access_key}"
+            echo "AWS_SESSION_TOKEN=${session_token}"
+            echo "AWS_REGION=${aws_region}"
+            echo "AWS_DEFAULT_REGION=${aws_region}"
+          } >> "$GITHUB_ENV"
+
+      - name: Terraform Plan
+        if: github.repository == 'identrail/identrail' && github.ref == 'refs/heads/dev'
+        working-directory: deploy/aws/terraform
+        run: terraform plan -refresh=false -input=false -var-file=environments/dev/terraform.tfvars.example
+
+      - name: Skip AWS Plan Outside Dev
+        if: github.repository != 'identrail/identrail' || github.ref != 'refs/heads/dev'
+        run: echo "Skipping AWS plan because OIDC trust is scoped to identrail/identrail dev."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,13 +194,16 @@ jobs:
         uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85
 
       - name: Terraform Format Check
-        run: terraform fmt -check -recursive deploy/terraform
+        run: terraform fmt -check -recursive deploy/terraform deploy/aws/terraform
 
       - name: Terraform Validate
         shell: bash
         run: |
           set -euo pipefail
           cd deploy/terraform
+          terraform init -backend=false
+          terraform validate
+          cd ../aws/terraform
           terraform init -backend=false
           terraform validate
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,6 +2,7 @@
 
 Deployment profiles:
 
+- `aws/`: AWS deployment foundation and future AWS hosting stack
 - `docker/`: single-host container deployment
 - `kubernetes/`: cluster deployment manifests
 - `helm/`: Kubernetes Helm chart
@@ -10,3 +11,6 @@ Deployment profiles:
 - `policies/`: least-privilege read-only templates for AWS and Kubernetes
 
 Published container image examples use `ghcr.io/identrail/identrail` for the main server image, with `ghcr.io/identrail/identrail-worker`, `ghcr.io/identrail/identrail-web`, and the compatibility alias `ghcr.io/identrail/identrail-api` for multi-service deployments. Pin production deployments to immutable release tags. Helm and Terraform deployment values should use tagged images (`repository` + `tag`), while digest pinning is only for deployment paths that explicitly support digest references.
+
+AWS deployment starts with a validation-only foundation. See `aws/README.md`
+before enabling resource creation.

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -1,0 +1,26 @@
+# AWS Deployment
+
+This directory contains the AWS-specific deployment foundation for Identrail.
+
+The first foundation module is intentionally safe by default:
+
+- It validates AWS provider wiring and naming conventions.
+- It defines production-adjacent primitives needed by later API hosting work.
+- It does not create resources unless `create_foundation_resources=true`.
+- It does not deploy the Identrail API, worker, database, or public domains yet.
+
+## Current Scope
+
+- Terraform foundation: `terraform/`
+- GitHub OIDC role verification: `.github/workflows/aws-oidc-verification.yml`
+- Dev-only foundation plan workflow: `.github/workflows/aws-deployment-foundation.yml`
+
+## Expected Order
+
+1. Verify GitHub can assume the AWS deployment role through OIDC.
+2. Validate and plan this AWS foundation.
+3. Add the API hosting stack.
+4. Add database, secrets, migrations, and domain cutover.
+
+Keep production applies manual until the API hosting stack and rollback runbook
+are both in place.

--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -1,0 +1,46 @@
+# AWS Terraform Foundation
+
+This Terraform root prepares AWS deployment primitives for Identrail without
+deploying the application yet.
+
+## What It Can Create
+
+When `create_foundation_resources=true`, the root can create:
+
+- CloudWatch log groups for API and worker workloads.
+- A Secrets Manager secret metadata record for future runtime configuration.
+
+It does not write secret values. Runtime secrets should be injected by the
+operator or a dedicated secrets workflow after the hosting stack exists.
+
+## Safe Defaults
+
+The default configuration sets `create_foundation_resources=false`, so CI and
+pull requests can run `terraform init`, `terraform validate`, and `terraform
+plan` without creating billable AWS resources.
+
+## Local Validation
+
+```bash
+cd deploy/aws/terraform
+terraform init -backend=false
+terraform fmt -check -recursive
+terraform validate
+terraform plan -refresh=false -input=false -var-file=environments/dev/terraform.tfvars.example
+```
+
+## Manual Dev Plan With Resources Enabled
+
+Only run this when you intentionally want to see the resources Terraform would
+create in the target AWS account:
+
+```bash
+cd deploy/aws/terraform
+terraform plan \
+  -input=false \
+  -var-file=environments/dev/terraform.tfvars.example \
+  -var='create_foundation_resources=true'
+```
+
+Do not run `terraform apply` from this foundation until the API hosting stack,
+database plan, secrets handling, and rollback runbook are ready.

--- a/deploy/aws/terraform/environments/dev/terraform.tfvars.example
+++ b/deploy/aws/terraform/environments/dev/terraform.tfvars.example
@@ -1,0 +1,14 @@
+aws_region  = "us-east-1"
+environment = "dev"
+name_prefix = "identrail"
+
+# Keep false until the API hosting stack and rollback runbook are ready.
+create_foundation_resources = false
+
+create_runtime_secret = true
+log_retention_days    = 30
+
+tags = {
+  Project = "identrail"
+  Stage   = "auth-rollout"
+}

--- a/deploy/aws/terraform/main.tf
+++ b/deploy/aws/terraform/main.tf
@@ -1,0 +1,38 @@
+locals {
+  service_names = toset(["api", "worker"])
+  runtime_secret_name = length(trimspace(var.runtime_secret_name)) > 0 ? trimspace(var.runtime_secret_name) : (
+    "${var.name_prefix}/${var.environment}/runtime"
+  )
+  common_tags = merge(
+    {
+      Application = "identrail"
+      Environment = var.environment
+      ManagedBy   = "terraform"
+    },
+    var.tags
+  )
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.common_tags
+  }
+}
+
+resource "aws_cloudwatch_log_group" "service" {
+  for_each = var.create_foundation_resources ? local.service_names : toset([])
+
+  name              = "/${var.name_prefix}/${var.environment}/${each.key}"
+  retention_in_days = var.log_retention_days
+  kms_key_id        = var.log_kms_key_id
+}
+
+resource "aws_secretsmanager_secret" "runtime" {
+  count = var.create_foundation_resources && var.create_runtime_secret ? 1 : 0
+
+  name                    = local.runtime_secret_name
+  description             = "Identrail ${var.environment} runtime configuration placeholder"
+  recovery_window_in_days = 7
+}

--- a/deploy/aws/terraform/outputs.tf
+++ b/deploy/aws/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "foundation_resources_enabled" {
+  description = "Whether this plan creates AWS foundation resources."
+  value       = var.create_foundation_resources
+}
+
+output "log_group_names" {
+  description = "CloudWatch log groups for future Identrail services."
+  value       = { for name, log_group in aws_cloudwatch_log_group.service : name => log_group.name }
+}
+
+output "runtime_secret_name" {
+  description = "Secrets Manager secret metadata name for future runtime configuration."
+  value       = try(aws_secretsmanager_secret.runtime[0].name, local.runtime_secret_name)
+}

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -1,0 +1,71 @@
+variable "aws_region" {
+  description = "AWS region where Identrail foundation resources will live."
+  type        = string
+  default     = "us-east-1"
+  validation {
+    condition     = can(regex("^[a-z]{2}(-gov)?-[a-z]+-[0-9]+$", var.aws_region))
+    error_message = "aws_region must be an AWS region such as us-east-1."
+  }
+}
+
+variable "environment" {
+  description = "Short environment name used in resource names and tags."
+  type        = string
+  default     = "dev"
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{1,30}[a-z0-9]$", var.environment))
+    error_message = "environment must be 3-32 lowercase letters, numbers, or dashes, starting with a letter and ending with a letter or number."
+  }
+}
+
+variable "name_prefix" {
+  description = "Resource name prefix for Identrail AWS resources."
+  type        = string
+  default     = "identrail"
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{1,30}[a-z0-9]$", var.name_prefix))
+    error_message = "name_prefix must be 3-32 lowercase letters, numbers, or dashes, starting with a letter and ending with a letter or number."
+  }
+}
+
+variable "create_foundation_resources" {
+  description = "Create foundation AWS resources. Keep false for validation-only PR and CI plans."
+  type        = bool
+  default     = false
+}
+
+variable "create_runtime_secret" {
+  description = "Create the Secrets Manager metadata record for future Identrail runtime configuration."
+  type        = bool
+  default     = true
+}
+
+variable "runtime_secret_name" {
+  description = "Secrets Manager secret name for future runtime configuration. Defaults to <name_prefix>/<environment>/runtime."
+  type        = string
+  default     = ""
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch log retention for future Identrail service logs."
+  type        = number
+  default     = 30
+  validation {
+    condition = contains([
+      1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653
+    ], var.log_retention_days)
+    error_message = "log_retention_days must be a CloudWatch Logs supported retention value."
+  }
+}
+
+variable "log_kms_key_id" {
+  description = "Optional KMS key ARN or ID for CloudWatch log group encryption."
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "Additional tags to apply to AWS resources."
+  type        = map(string)
+  default     = {}
+}

--- a/deploy/aws/terraform/versions.tf
+++ b/deploy/aws/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - Operator readiness handoff: `operator-readiness.md`
 - Deployment runbook: `deploy-runbook.md`
 - AWS OIDC deployment role: `aws-oidc-deployment.md`
+- AWS deployment foundation: `aws-deployment-foundation.md`
 
 ## Operator track
 
@@ -18,6 +19,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
   - `../deploy/kubernetes/README.md`
   - `../deploy/helm/README.md`
   - `../deploy/terraform/README.md`
+  - `../deploy/aws/README.md`
 - Day-2 operations:
   - `observability.md`
   - `troubleshooting.md`

--- a/docs/aws-deployment-foundation.md
+++ b/docs/aws-deployment-foundation.md
@@ -1,0 +1,34 @@
+# AWS Deployment Foundation
+
+The AWS deployment foundation is the step after GitHub OIDC verification.
+
+PR 7A proved that GitHub Actions can request short-lived AWS credentials without
+long-lived access keys. This foundation gives the repository a safe place to
+validate AWS deployment plans before the production API hosting stack is added.
+
+## What This Does Now
+
+- Adds an AWS Terraform root at `deploy/aws/terraform`.
+- Adds safe, opt-in foundation resources for future API and worker hosting.
+- Adds a dev workflow that assumes the AWS OIDC role and runs Terraform plan.
+- Keeps `terraform apply` manual and out of CI.
+
+## What It Does Not Do Yet
+
+- It does not deploy the Identrail API to AWS.
+- It does not create a production database.
+- It does not change `app.identrail.com` or `api.identrail.com`.
+- It does not move traffic away from the current Vercel deployment.
+
+## Why Resource Creation Defaults Off
+
+The first AWS deployment PR should prove the path without spending money or
+creating surprise infrastructure. The Terraform root defaults
+`create_foundation_resources=false`, so CI can validate the stack and later PRs
+can intentionally enable resources when the API hosting design is ready.
+
+## Next Deployment Step
+
+The next PR should add the actual API hosting layer on top of this foundation,
+including service shape, database connectivity, runtime secrets, health checks,
+and rollback instructions.

--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -8,6 +8,7 @@ Portable deployment profiles:
 - Linux VM/systemd: `deploy/systemd/`
 - Guide: `docs/deployment-anywhere.md`
 - AWS OIDC deployment role: `docs/aws-oidc-deployment.md`
+- AWS deployment foundation: `docs/aws-deployment-foundation.md`
 - Operator readiness: `docs/operator-readiness.md`
 - Troubleshooting playbook: `docs/troubleshooting.md`
 - Incident workflow: `docs/incident-response.md`


### PR DESCRIPTION
Fixes #1098

## What changed
- Added `deploy/aws/terraform`, a safe AWS Terraform foundation root for future API and worker hosting primitives.
- Added `.github/workflows/aws-deployment-foundation.yml` to validate the AWS root on PRs and run a dev-only OIDC-backed Terraform plan after merge.
- Extended CI infra validation so the existing pipeline validates both the Kubernetes Helm Terraform root and the new AWS root.
- Added operator docs explaining what the AWS foundation does now and what remains for future API hosting.

## Why
PR 7A proved GitHub Actions can assume the AWS deployment role with OIDC. This PR is the next minimal step: it creates a validated AWS deployment lane without applying resources or moving traffic.

## Impact and risk
- No AWS resources are created by default.
- `terraform apply` is not run by CI.
- `app.identrail.com`, `api.identrail.com`, and the current Vercel deployment remain unchanged.
- Future PRs can intentionally enable foundation resources and add the API hosting stack on top.

## Validation
- `terraform fmt -recursive deploy/aws/terraform deploy/terraform`
- `terraform fmt -check -recursive deploy/terraform deploy/aws/terraform`
- `terraform init -backend=false && terraform validate && terraform plan -refresh=false -input=false -var-file=environments/dev/terraform.tfvars.example` in `deploy/aws/terraform`
- `terraform init -backend=false && terraform validate` in `deploy/terraform`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f) }; puts "yaml ok"'`\n- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -shellcheck= .github/workflows/*.yml`\n- `git diff --check`\n- Commit and push hooks\n\nAI-assisted: yes\nTools used: Codex\nWhere used: workflow, Terraform foundation, docs, and validation\nHuman verification performed: reviewed diff, ran Terraform validation/plan, actionlint, YAML parse, diff check, and repository hooks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a validation‑only AWS deployment foundation with a new Terraform root and a dev‑only plan workflow using GitHub OIDC. Passes the AWS region from repo vars into the Terraform plan; no apply and no resources by default. Fixes #1098.

- **New Features**
  - Added `deploy/aws/terraform` with opt‑in `create_foundation_resources`, CloudWatch log groups, and a runtime secret metadata record; strict name/region validation.
  - Added `.github/workflows/aws-deployment-foundation.yml` to fmt/validate and, on `identrail/identrail@dev`, assume the AWS role and run `terraform plan`, passing the region via `-var="aws_region=${AWS_REGION}"`.
  - Extended `.github/workflows/ci.yml` to fmt/validate both the existing Terraform root and the new AWS root.
  - Added operator docs: `docs/aws-deployment-foundation.md`, `deploy/aws/README.md`, and `deploy/aws/terraform/README.md`; current domains/Vercel remain unchanged.

<sup>Written for commit d4fdc76102018c9cf24d3921b8205f6921d69c5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

