### PR TITLE
Expand scan automation observability

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -26,8 +26,19 @@ Risk output metric:
 
 Repository scan metrics:
 - `identrail_repo_scan_runs_total`
+- `identrail_repo_scan_success_total`
 - `identrail_repo_scan_failure_total`
+- `identrail_repo_scan_truncated_total`
 - `identrail_repo_scan_duration_milliseconds`
+
+Automation reliability metrics:
+- `identrail_queue_depth{queue="scan|repo_scan"}`: current API/worker queue backlog.
+- `identrail_worker_jobs_total{queue="scan|repo_scan",outcome="success|failure|requeued"}`: queue worker processing results.
+- `identrail_worker_requeues_total{queue="scan|repo_scan"}`: jobs put back on a queue because work could not safely run yet.
+- `identrail_worker_dead_letters_total{runner="cloud|repo|api_queue|scan_policy|scan|repo_scan"}`: scheduled or queued work that exhausted retries.
+- `identrail_worker_retries_total{runner="cloud|repo|api_queue|scan_policy"}`: retryable scheduled runner failures.
+- `identrail_automation_runs_total{source="scheduled|event|api_queue",connector="aws|github|kubernetes|repo_scan",outcome="queued|succeeded|failed|partial|skipped|requeued"}`: bounded automation reliability counter for scheduled scans, GitHub webhook-triggered scans, and API queue processing.
+- `identrail_automation_lag_milliseconds{source="scheduled|api_queue",queue="scan|repo_scan"}`: scheduler catch-up or queue wait lag before work is enqueued or claimed.
 
 Authorization policy lifecycle metrics:
 - `identrail_authz_policy_decisions_by_version_total`
@@ -45,6 +56,7 @@ Allowed label examples:
 - Decision labels with small, controlled value sets: `allowed`, `outcome`, `reason`, `kind`.
 - Rollout labels controlled by configuration or code: `policy_source`, `policy_version`, `rollout_mode`.
 - Worker labels controlled by code constants: `queue`, `runner`, `source`.
+- Automation labels controlled by code constants: `connector`, `outcome`.
 
 Forbidden label examples:
 - Request-scoped identifiers: `request_id`, trace IDs, correlation IDs.
@@ -63,6 +75,9 @@ If a value is useful for incident triage but has unbounded cardinality, put it i
   - `scanner.permissions`
   - `scanner.relationships`
   - `scanner.risk`
+- Automation orchestration emits OpenTelemetry spans:
+  - `automation.scan_policy_scheduler`
+  - `automation.github_webhook`
 
 ## V1 SLOs
 
@@ -76,4 +91,24 @@ If a value is useful for incident triage but has unbounded cardinality, put it i
 - `identrail_scan_failure_total` increase > 3 in 10 minutes.
 - `identrail_scan_partial_total` increase > 5 in 30 minutes.
 - `identrail_scan_in_flight` stuck > 1 for 10 minutes.
+- `identrail_automation_runs_total{outcome="failed"}` increase > 0 in 10 minutes for source `scheduled` or `event`.
+- `identrail_automation_runs_total{outcome="skipped"}` increase > 5 in 10 minutes for source `scheduled` or `event`.
+- `histogram_quantile(0.95, sum by (le, source, queue) (rate(identrail_automation_lag_milliseconds_bucket[10m]))) > 300000` for queued scan recovery lag.
+- `identrail_queue_depth{queue="repo_scan"}` remains above 0 for 30 minutes.
+- `identrail_worker_dead_letters_total` increase > 0 in 10 minutes.
 - API p95 latency above SLO for 15 minutes.
+
+Route alert descriptions to this runbook section first, then to `docs/deploy-runbook.md` for process-level recovery and `docs/authz-operator-runbook.md` when authorization policy metrics are involved.
+
+## Dashboard Panels
+
+Recommended operator dashboard panels:
+
+- Automation success rate by source: `sum by (source, connector, outcome) (rate(identrail_automation_runs_total[5m]))`.
+- Scheduled scan SLA: `sum by (connector, outcome) (increase(identrail_automation_runs_total{source="scheduled"}[24h]))`.
+- Event-driven scan SLA: `sum by (connector, outcome) (increase(identrail_automation_runs_total{source="event"}[24h]))`.
+- Queue depth by queue: `identrail_queue_depth`.
+- Queue lag p95: `histogram_quantile(0.95, sum by (le, source, queue) (rate(identrail_automation_lag_milliseconds_bucket[10m])))`.
+- Worker dead letters by runner: `sum by (runner) (increase(identrail_worker_dead_letters_total[24h]))`.
+
+Use structured logs and scan events for high-cardinality drill-down such as repository name, scan id, tenant, workspace, request id, or trace id.

--- a/internal/api/automation_metrics_test.go
+++ b/internal/api/automation_metrics_test.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/telemetry"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestAutomationMetricLabelsAreBounded(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "source scheduled", got: automationSourceLabel(" scheduled "), want: "scheduled"},
+		{name: "source unknown", got: automationSourceLabel("tenant-a"), want: "other"},
+		{name: "connector github", got: automationConnectorLabel(" GitHub "), want: "github"},
+		{name: "connector unknown", got: automationConnectorLabel("owner/repo"), want: "other"},
+		{name: "outcome partial", got: automationOutcomeLabel(" partial "), want: "partial"},
+		{name: "outcome unknown", got: automationOutcomeLabel("custom"), want: "other"},
+		{name: "queue repo", got: automationQueueLabel(" repo_scan "), want: "repo_scan"},
+		{name: "queue unknown", got: automationQueueLabel("tenant-queue"), want: "other"},
+	}
+	for _, tc := range tests {
+		if tc.got != tc.want {
+			t.Fatalf("%s = %q, want %q", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+func TestRecordAutomationMetrics(t *testing.T) {
+	svc := NewService(db.NewMemoryStore(), fakeScanner{}, "aws")
+	svc.Metrics = telemetry.NewMetrics()
+
+	svc.recordAutomationRun("event", "github", "queued")
+	svc.recordAutomationRuns("scheduled", "github", "skipped", 2)
+	svc.recordAutomationRuns("scheduled", "github", "failed", 0)
+	svc.recordAutomationLag("api_queue", "scan", -5*time.Second)
+	svc.recordAutomationLag("api_queue", "repo_scan", 1500*time.Millisecond)
+
+	if got := testutil.ToFloat64(svc.Metrics.AutomationRunsTotal.WithLabelValues("event", "github", "queued")); got != 1 {
+		t.Fatalf("event github queued metric = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(svc.Metrics.AutomationRunsTotal.WithLabelValues("scheduled", "github", "skipped")); got != 2 {
+		t.Fatalf("scheduled github skipped metric = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(svc.Metrics.AutomationRunsTotal.WithLabelValues("scheduled", "github", "failed")); got != 0 {
+		t.Fatalf("scheduled github failed metric = %v, want 0", got)
+	}
+	if got := testutil.CollectAndCount(svc.Metrics.AutomationLagMS); got == 0 {
+		t.Fatal("expected automation lag metric to be collected")
+	}
+}

--- a/internal/api/github_connect.go
+++ b/internal/api/github_connect.go
@@ -21,6 +21,9 @@ import (
 	"github.com/identrail/identrail/internal/db"
 	"github.com/identrail/identrail/internal/domain"
 	"github.com/identrail/identrail/internal/secretstore"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 )
 
 const (
@@ -401,19 +404,27 @@ func (s *Service) RotateGitHubConnectionSecret(ctx context.Context, workspaceID 
 }
 
 func (s *Service) HandleGitHubWebhook(ctx context.Context, eventType string, deliveryID string, signature string, payload []byte) (GitHubWebhookResult, error) {
+	ctx, span := otel.Tracer("identrail/automation").Start(ctx, "automation.github_webhook")
+	defer span.End()
+
 	normalizedEventType := strings.ToLower(strings.TrimSpace(eventType))
 	if normalizedEventType == "" || len(payload) == 0 {
+		span.SetStatus(codes.Error, "invalid github webhook payload")
 		return GitHubWebhookResult{}, ErrInvalidGitHubWebhookPayload
 	}
+	span.SetAttributes(attribute.String("github.event_type", normalizedEventType))
 
 	var envelope githubWebhookEnvelope
 	if err := json.Unmarshal(payload, &envelope); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "invalid github webhook payload")
 		return GitHubWebhookResult{}, ErrInvalidGitHubWebhookPayload
 	}
 	installationID := envelope.Installation.ID
 	normalizedSignature := strings.TrimSpace(signature)
 
 	if !s.verifyGitHubWebhookSignatureForInstallation(installationID, payload, normalizedSignature) {
+		span.SetStatus(codes.Error, "github webhook signature invalid")
 		return GitHubWebhookResult{}, ErrGitHubWebhookSignatureInvalid
 	}
 
@@ -434,6 +445,7 @@ func (s *Service) HandleGitHubWebhook(ctx context.Context, eventType string, del
 		}
 	}
 	if len(validConnections) == 0 {
+		span.SetStatus(codes.Error, "github webhook signature invalid")
 		return GitHubWebhookResult{}, ErrGitHubWebhookSignatureInvalid
 	}
 
@@ -451,6 +463,7 @@ func (s *Service) HandleGitHubWebhook(ctx context.Context, eventType string, del
 		replayed := s.isGitHubWebhookReplay(connection, normalizedDeliveryID, now)
 		if replayed && scanTriggerEvent {
 			result.SkippedScans++
+			s.recordAutomationRun("event", "github", "skipped")
 			continue
 		}
 		if !scanTriggerEvent {
@@ -459,6 +472,7 @@ func (s *Service) HandleGitHubWebhook(ctx context.Context, eventType string, del
 		}
 		if s.shouldThrottleGitHubWebhookScan(connection, repository, now) {
 			result.SkippedScans++
+			s.recordAutomationRun("event", "github", "skipped")
 			s.recordGitHubWebhookDelivery(ctx, connection, normalizedEventType, normalizedDeliveryID, now)
 			continue
 		}
@@ -468,6 +482,7 @@ func (s *Service) HandleGitHubWebhook(ctx context.Context, eventType string, del
 		if err != nil {
 			if errors.Is(err, ErrRepoScanQueueFull) {
 				result.SkippedScans++
+				s.recordAutomationRun("event", "github", "skipped")
 				continue
 			}
 			if errors.Is(err, ErrRepoScanInProgress) ||
@@ -475,16 +490,26 @@ func (s *Service) HandleGitHubWebhook(ctx context.Context, eventType string, del
 				errors.Is(err, ErrRepoTargetNotAllowed) ||
 				errors.Is(err, ErrInvalidRepoScanRequest) {
 				result.SkippedScans++
+				s.recordAutomationRun("event", "github", "skipped")
 				s.recordGitHubWebhookDelivery(ctx, connection, normalizedEventType, normalizedDeliveryID, now)
 				continue
 			}
+			s.recordAutomationRun("event", "github", "failed")
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "enqueue webhook repo scan failed")
 			return GitHubWebhookResult{}, err
 		}
 		result.QueuedScans++
+		s.recordAutomationRun("event", "github", "queued")
 		s.recordGitHubWebhookDelivery(ctx, connection, normalizedEventType, normalizedDeliveryID, now)
 		s.recordGitHubWebhookQueuedScan(ctx, connection, repository, now)
 	}
 
+	span.SetAttributes(
+		attribute.Int("automation.matched_projects", result.MatchedProjects),
+		attribute.Int("automation.queued_scans", result.QueuedScans),
+		attribute.Int("automation.skipped_scans", result.SkippedScans),
+	)
 	return result, nil
 }
 

--- a/internal/api/github_connect_test.go
+++ b/internal/api/github_connect_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/identrail/identrail/internal/domain"
 	"github.com/identrail/identrail/internal/secretstore"
 	"github.com/identrail/identrail/internal/telemetry"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"go.uber.org/zap"
 )
 
@@ -350,6 +351,7 @@ func TestGitHubConnectionPersistsAcrossServiceInstances(t *testing.T) {
 func TestHandleGitHubWebhookReplayDeliverySkipsDuplicateScan(t *testing.T) {
 	store := db.NewMemoryStore()
 	svc := NewService(store, routerScanner{}, "aws")
+	svc.Metrics = telemetry.NewMetrics()
 	svc.RepoScanEnabled = true
 	svc.RepoScanAllowedTargets = []string{"owner/*"}
 	now := time.Date(2026, 5, 12, 14, 0, 0, 0, time.UTC)
@@ -429,6 +431,12 @@ func TestHandleGitHubWebhookReplayDeliverySkipsDuplicateScan(t *testing.T) {
 	}
 	if len(scans) != 1 {
 		t.Fatalf("expected replay dedupe to keep one repo scan record, got %d", len(scans))
+	}
+	if got := testutil.ToFloat64(svc.Metrics.AutomationRunsTotal.WithLabelValues("event", "github", "queued")); got != 1 {
+		t.Fatalf("event github queued metric = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(svc.Metrics.AutomationRunsTotal.WithLabelValues("event", "github", "skipped")); got != 1 {
+		t.Fatalf("event github skipped metric = %v, want 1", got)
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -141,6 +141,8 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		metrics.WorkerRequeuesTotal,
 		metrics.WorkerDeadLettersTotal,
 		metrics.WorkerRetriesTotal,
+		metrics.AutomationRunsTotal,
+		metrics.AutomationLagMS,
 		metrics.RepoFindingsGenerated,
 		metrics.APIDeniedRequestsTotal,
 		metrics.AuthzPolicyShadowEvaluationsTotal,

--- a/internal/api/scan_policy_scheduler.go
+++ b/internal/api/scan_policy_scheduler.go
@@ -9,6 +9,9 @@ import (
 
 	"github.com/identrail/identrail/internal/db"
 	"github.com/identrail/identrail/internal/scheduler"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 )
 
 const defaultScanPolicyScheduleLimit = 500
@@ -34,8 +37,12 @@ func (s *Service) EnqueueDueScanPolicies(ctx context.Context) (ScanPolicySchedul
 
 // EnqueueDueScanPoliciesAt is the deterministic variant used by tests.
 func (s *Service) EnqueueDueScanPoliciesAt(ctx context.Context, now time.Time) (ScanPolicyScheduleResult, error) {
+	ctx, span := otel.Tracer("identrail/automation").Start(ctx, "automation.scan_policy_scheduler")
+	defer span.End()
+
 	store, ok := s.Store.(scanPolicyScheduleStore)
 	if !ok {
+		span.SetStatus(codes.Error, "scan policy store unavailable")
 		return ScanPolicyScheduleResult{}, ErrScanPolicyStoreUnavailable
 	}
 	now = now.UTC()
@@ -43,6 +50,8 @@ func (s *Service) EnqueueDueScanPoliciesAt(ctx context.Context, now time.Time) (
 	for offset := 0; ; offset += defaultScanPolicyScheduleLimit {
 		policies, err := store.ListScheduledTenancyScanPolicies(ctx, defaultScanPolicyScheduleLimit, offset)
 		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "list scheduled policies failed")
 			return result, err
 		}
 		result.PoliciesChecked += len(policies)
@@ -50,24 +59,38 @@ func (s *Service) EnqueueDueScanPoliciesAt(ctx context.Context, now time.Time) (
 			scheduledAt, due, err := dueScanPolicyTick(policy, now)
 			if err != nil {
 				result.SkippedScans++
+				s.recordAutomationRun("scheduled", "github", "skipped")
 				continue
 			}
 			if !due {
 				continue
 			}
 			result.PoliciesDue++
+			s.recordAutomationLag("scheduled", "repo_scan", now.Sub(scheduledAt.UTC()))
 			policyResult, err := s.enqueueDueScanPolicy(ctx, store, policy, scheduledAt, now)
 			if err != nil {
+				s.recordAutomationRun("scheduled", "github", "failed")
+				span.RecordError(err)
+				span.SetStatus(codes.Error, "enqueue scheduled policy failed")
 				return result, err
 			}
 			result.PoliciesClaimed += policyResult.PoliciesClaimed
 			result.QueuedScans += policyResult.QueuedScans
 			result.SkippedScans += policyResult.SkippedScans
+			s.recordAutomationRuns("scheduled", "github", "queued", policyResult.QueuedScans)
+			s.recordAutomationRuns("scheduled", "github", "skipped", policyResult.SkippedScans)
 		}
 		if len(policies) < defaultScanPolicyScheduleLimit {
 			break
 		}
 	}
+	span.SetAttributes(
+		attribute.Int("automation.policies_checked", result.PoliciesChecked),
+		attribute.Int("automation.policies_due", result.PoliciesDue),
+		attribute.Int("automation.policies_claimed", result.PoliciesClaimed),
+		attribute.Int("automation.queued_scans", result.QueuedScans),
+		attribute.Int("automation.skipped_scans", result.SkippedScans),
+	)
 	return result, nil
 }
 

--- a/internal/api/scan_policy_scheduler_test.go
+++ b/internal/api/scan_policy_scheduler_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/identrail/identrail/internal/db"
 	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/telemetry"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func TestEnqueueDueScanPoliciesRecoversLatestMissedTick(t *testing.T) {
@@ -48,6 +50,28 @@ func TestEnqueueDueScanPoliciesRecoversLatestMissedTick(t *testing.T) {
 	}
 	if second.PoliciesClaimed != 0 || second.QueuedScans != 0 {
 		t.Fatalf("duplicate scheduler pass enqueued work: %+v", second)
+	}
+}
+
+func TestEnqueueDueScanPoliciesRecordsAutomationMetrics(t *testing.T) {
+	now := time.Date(2026, 5, 12, 12, 17, 30, 0, time.UTC)
+	svc, store, ctx := newScanPolicySchedulerTestService(t, now, []string{"owner/repo-a", "owner/repo-b"})
+	svc.Metrics = telemetry.NewMetrics()
+	createdAt := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	upsertTestScanPolicy(t, store, ctx, createdAt, 2)
+
+	result, err := svc.EnqueueDueScanPolicies(ctx)
+	if err != nil {
+		t.Fatalf("EnqueueDueScanPolicies returned error: %v", err)
+	}
+	if result.QueuedScans != 2 {
+		t.Fatalf("queued scans = %d, want 2", result.QueuedScans)
+	}
+	if got := testutil.ToFloat64(svc.Metrics.AutomationRunsTotal.WithLabelValues("scheduled", "github", "queued")); got != 2 {
+		t.Fatalf("scheduled github queued metric = %v, want 2", got)
+	}
+	if got := testutil.CollectAndCount(svc.Metrics.AutomationLagMS); got == 0 {
+		t.Fatal("expected scheduled automation lag metric to be collected")
 	}
 }
 

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -355,21 +355,9 @@ func NewService(store db.Store, scanner ScannerRunner, provider string) *Service
 func (s *Service) EnqueueScan(ctx context.Context) (db.ScanRecord, error) {
 	ctx = s.scopeContext(ctx)
 	ctx = withQueueTraceContext(ctx)
-	enqueueStarted := time.Now()
-	if s.Metrics != nil {
-		s.Metrics.ScanEnqueueTotal.Inc()
-		defer func() {
-			s.Metrics.ScanEnqueueDurationMS.Observe(float64(time.Since(enqueueStarted).Milliseconds()))
-		}()
-	}
 	maxPending := s.ScanQueueMaxPending
 	if maxPending <= 0 {
 		maxPending = 1
-	}
-	recordEnqueueFailure := func() {
-		if s.Metrics != nil {
-			s.Metrics.ScanEnqueueFailureTotal.Inc()
-		}
 	}
 
 	var (
@@ -379,18 +367,15 @@ func (s *Service) EnqueueScan(ctx context.Context) (db.ScanRecord, error) {
 	if maxPending == 1 {
 		record, err = s.Store.CreateQueuedScanIfNoPending(ctx, s.Provider, s.Now().UTC())
 		if errors.Is(err, db.ErrPendingScanExists) {
-			recordEnqueueFailure()
 			return db.ScanRecord{}, ErrScanInProgress
 		}
 	} else {
 		record, err = s.Store.CreateQueuedScanWithinLimit(ctx, s.Provider, s.Now().UTC(), maxPending)
 		if errors.Is(err, db.ErrQueueLimitReached) {
-			recordEnqueueFailure()
 			return db.ScanRecord{}, ErrScanQueueFull
 		}
 	}
 	if err != nil {
-		recordEnqueueFailure()
 		return db.ScanRecord{}, fmt.Errorf("enqueue scan: %w", err)
 	}
 	queuedCount := s.countQueuedScansForDepth(ctx, s.Provider)
@@ -1003,21 +988,8 @@ func (s *Service) RunRepoScan(ctx context.Context, request RepoScanRequest) (rep
 func (s *Service) EnqueueRepoScan(ctx context.Context, request RepoScanRequest) (db.RepoScanRecord, error) {
 	ctx = s.scopeContext(ctx)
 	ctx = withQueueTraceContext(ctx)
-	enqueueStarted := time.Now()
-	if s.Metrics != nil {
-		s.Metrics.RepoScanEnqueueTotal.Inc()
-		defer func() {
-			s.Metrics.RepoScanEnqueueDurationMS.Observe(float64(time.Since(enqueueStarted).Milliseconds()))
-		}()
-	}
-	recordEnqueueFailure := func() {
-		if s.Metrics != nil {
-			s.Metrics.RepoScanEnqueueFailureTotal.Inc()
-		}
-	}
 	target, historyLimit, maxFindings, err := s.validateRepoScanRequest(ctx, request)
 	if err != nil {
-		recordEnqueueFailure()
 		return db.RepoScanRecord{}, err
 	}
 	maxPending := s.RepoQueueMaxPending
@@ -1028,13 +1000,10 @@ func (s *Service) EnqueueRepoScan(ctx context.Context, request RepoScanRequest) 
 	if err != nil {
 		switch {
 		case errors.Is(err, db.ErrPendingRepoScanExists):
-			recordEnqueueFailure()
 			return db.RepoScanRecord{}, ErrRepoScanInProgress
 		case errors.Is(err, db.ErrQueueLimitReached):
-			recordEnqueueFailure()
 			return db.RepoScanRecord{}, ErrRepoScanQueueFull
 		default:
-			recordEnqueueFailure()
 			return db.RepoScanRecord{}, fmt.Errorf("enqueue repo scan: %w", err)
 		}
 	}

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -355,9 +355,21 @@ func NewService(store db.Store, scanner ScannerRunner, provider string) *Service
 func (s *Service) EnqueueScan(ctx context.Context) (db.ScanRecord, error) {
 	ctx = s.scopeContext(ctx)
 	ctx = withQueueTraceContext(ctx)
+	enqueueStarted := time.Now()
+	if s.Metrics != nil {
+		s.Metrics.ScanEnqueueTotal.Inc()
+		defer func() {
+			s.Metrics.ScanEnqueueDurationMS.Observe(float64(time.Since(enqueueStarted).Milliseconds()))
+		}()
+	}
 	maxPending := s.ScanQueueMaxPending
 	if maxPending <= 0 {
 		maxPending = 1
+	}
+	recordEnqueueFailure := func() {
+		if s.Metrics != nil {
+			s.Metrics.ScanEnqueueFailureTotal.Inc()
+		}
 	}
 
 	var (
@@ -367,15 +379,18 @@ func (s *Service) EnqueueScan(ctx context.Context) (db.ScanRecord, error) {
 	if maxPending == 1 {
 		record, err = s.Store.CreateQueuedScanIfNoPending(ctx, s.Provider, s.Now().UTC())
 		if errors.Is(err, db.ErrPendingScanExists) {
+			recordEnqueueFailure()
 			return db.ScanRecord{}, ErrScanInProgress
 		}
 	} else {
 		record, err = s.Store.CreateQueuedScanWithinLimit(ctx, s.Provider, s.Now().UTC(), maxPending)
 		if errors.Is(err, db.ErrQueueLimitReached) {
+			recordEnqueueFailure()
 			return db.ScanRecord{}, ErrScanQueueFull
 		}
 	}
 	if err != nil {
+		recordEnqueueFailure()
 		return db.ScanRecord{}, fmt.Errorf("enqueue scan: %w", err)
 	}
 	queuedCount := s.countQueuedScansForDepth(ctx, s.Provider)
@@ -467,14 +482,21 @@ func (s *Service) ProcessNextQueuedScan(ctx context.Context) (bool, error) {
 		TenantID:    record.TenantID,
 		WorkspaceID: record.WorkspaceID,
 	})
+	s.recordAutomationLag("api_queue", "scan", s.Now().UTC().Sub(record.StartedAt.UTC()))
 	recordScopeCtx = continueQueueTraceContext(recordScopeCtx, record.TraceParent, record.TraceState)
 	s.appendScanLifecycleEvent(recordScopeCtx, record.ID, scanLifecycleRunning, map[string]any{"provider": record.Provider})
 	s.appendScanEvent(recordScopeCtx, record.ID, db.ScanEventLevelInfo, "queued scan started", map[string]any{"provider": record.Provider})
-	_, runErr := s.runScanWithRecord(recordScopeCtx, record, true)
+	runResult, runErr := s.runScanWithRecord(recordScopeCtx, record, true)
 	if runErr != nil {
+		s.recordAutomationRun("api_queue", record.Provider, "failed")
 		s.recordWorkerJob("scan", "failure")
 		return true, runErr
 	}
+	outcome := "succeeded"
+	if runResult.PartialSourceRun {
+		outcome = "partial"
+	}
+	s.recordAutomationRun("api_queue", record.Provider, outcome)
 	s.recordWorkerJob("scan", "success")
 	return true, nil
 }
@@ -869,6 +891,94 @@ func (s *Service) recordWorkerDeadLetter(runner string) {
 	}
 }
 
+func (s *Service) recordAutomationRun(source string, connector string, outcome string) {
+	s.recordAutomationRuns(source, connector, outcome, 1)
+}
+
+func (s *Service) recordAutomationRuns(source string, connector string, outcome string, count int) {
+	if s.Metrics == nil || count <= 0 {
+		return
+	}
+	s.Metrics.AutomationRunsTotal.WithLabelValues(
+		automationSourceLabel(source),
+		automationConnectorLabel(connector),
+		automationOutcomeLabel(outcome),
+	).Add(float64(count))
+}
+
+func (s *Service) recordAutomationLag(source string, queue string, lag time.Duration) {
+	if s.Metrics == nil {
+		return
+	}
+	if lag < 0 {
+		lag = 0
+	}
+	s.Metrics.AutomationLagMS.WithLabelValues(
+		automationSourceLabel(source),
+		automationQueueLabel(queue),
+	).Observe(float64(lag.Milliseconds()))
+}
+
+func automationSourceLabel(source string) string {
+	switch strings.ToLower(strings.TrimSpace(source)) {
+	case "scheduled":
+		return "scheduled"
+	case "event":
+		return "event"
+	case "api_queue":
+		return "api_queue"
+	default:
+		return "other"
+	}
+}
+
+func automationConnectorLabel(connector string) string {
+	switch strings.ToLower(strings.TrimSpace(connector)) {
+	case "aws":
+		return "aws"
+	case "github":
+		return "github"
+	case "kubernetes":
+		return "kubernetes"
+	case "repo_scan":
+		return "repo_scan"
+	case "scan_policy":
+		return "scan_policy"
+	default:
+		return "other"
+	}
+}
+
+func automationOutcomeLabel(outcome string) string {
+	switch strings.ToLower(strings.TrimSpace(outcome)) {
+	case "queued":
+		return "queued"
+	case "succeeded":
+		return "succeeded"
+	case "failed":
+		return "failed"
+	case "partial":
+		return "partial"
+	case "skipped":
+		return "skipped"
+	case "requeued":
+		return "requeued"
+	default:
+		return "other"
+	}
+}
+
+func automationQueueLabel(queue string) string {
+	switch strings.ToLower(strings.TrimSpace(queue)) {
+	case "scan":
+		return "scan"
+	case "repo_scan":
+		return "repo_scan"
+	default:
+		return "other"
+	}
+}
+
 // ListFindings returns persisted findings.
 func (s *Service) ListFindings(ctx context.Context, limit int) ([]domain.Finding, error) {
 	ctx = s.scopeContext(ctx)
@@ -893,8 +1003,21 @@ func (s *Service) RunRepoScan(ctx context.Context, request RepoScanRequest) (rep
 func (s *Service) EnqueueRepoScan(ctx context.Context, request RepoScanRequest) (db.RepoScanRecord, error) {
 	ctx = s.scopeContext(ctx)
 	ctx = withQueueTraceContext(ctx)
+	enqueueStarted := time.Now()
+	if s.Metrics != nil {
+		s.Metrics.RepoScanEnqueueTotal.Inc()
+		defer func() {
+			s.Metrics.RepoScanEnqueueDurationMS.Observe(float64(time.Since(enqueueStarted).Milliseconds()))
+		}()
+	}
+	recordEnqueueFailure := func() {
+		if s.Metrics != nil {
+			s.Metrics.RepoScanEnqueueFailureTotal.Inc()
+		}
+	}
 	target, historyLimit, maxFindings, err := s.validateRepoScanRequest(ctx, request)
 	if err != nil {
+		recordEnqueueFailure()
 		return db.RepoScanRecord{}, err
 	}
 	maxPending := s.RepoQueueMaxPending
@@ -905,10 +1028,13 @@ func (s *Service) EnqueueRepoScan(ctx context.Context, request RepoScanRequest) 
 	if err != nil {
 		switch {
 		case errors.Is(err, db.ErrPendingRepoScanExists):
+			recordEnqueueFailure()
 			return db.RepoScanRecord{}, ErrRepoScanInProgress
 		case errors.Is(err, db.ErrQueueLimitReached):
+			recordEnqueueFailure()
 			return db.RepoScanRecord{}, ErrRepoScanQueueFull
 		default:
+			recordEnqueueFailure()
 			return db.RepoScanRecord{}, fmt.Errorf("enqueue repo scan: %w", err)
 		}
 	}
@@ -933,6 +1059,7 @@ func (s *Service) ProcessNextQueuedRepoScan(ctx context.Context) (bool, error) {
 		TenantID:    record.TenantID,
 		WorkspaceID: record.WorkspaceID,
 	})
+	s.recordAutomationLag("api_queue", "repo_scan", s.Now().UTC().Sub(record.StartedAt.UTC()))
 	recordScopeCtx = continueQueueTraceContext(recordScopeCtx, record.TraceParent, record.TraceState)
 	requeue := false
 	if s.Locker != nil {
@@ -948,6 +1075,7 @@ func (s *Service) ProcessNextQueuedRepoScan(ctx context.Context) (bool, error) {
 			s.recordWorkerJob("repo_scan", "failure")
 			return false, fmt.Errorf("requeue repo scan: %w", requeueErr)
 		}
+		s.recordAutomationRun("api_queue", "repo_scan", "requeued")
 		s.recordWorkerJob("repo_scan", "requeued")
 		s.recordWorkerRequeue("repo_scan")
 		// A queued item was handled (requeued) even if this target is currently locked.
@@ -956,10 +1084,12 @@ func (s *Service) ProcessNextQueuedRepoScan(ctx context.Context) (bool, error) {
 	}
 	_, runErr := s.runRepoScanWithRecord(recordScopeCtx, record, record.HistoryLimit, record.MaxFindings)
 	if runErr != nil {
+		s.recordAutomationRun("api_queue", "repo_scan", "failed")
 		s.recordWorkerJob("repo_scan", "failure")
 		s.recordWorkerDeadLetter("repo_scan")
 		return true, runErr
 	}
+	s.recordAutomationRun("api_queue", "repo_scan", "succeeded")
 	s.recordWorkerJob("repo_scan", "success")
 	return true, nil
 }

--- a/internal/telemetry/cardinality_test.go
+++ b/internal/telemetry/cardinality_test.go
@@ -5,6 +5,7 @@ import "testing"
 func TestValidateMetricLabelsAllowsBoundedLabels(t *testing.T) {
 	labels := []string{
 		"allowed",
+		"connector",
 		"kind",
 		"outcome",
 		"policy_source",
@@ -53,6 +54,8 @@ func TestValidateMetricLabelsRejectsHighCardinalityLabels(t *testing.T) {
 func TestKnownMetricLabelsStayLowCardinality(t *testing.T) {
 	known := map[string][]string{
 		"identrail_authz_policy_decisions_by_version_total": {"policy_version", "policy_source", "rollout_mode", "allowed"},
+		"identrail_automation_runs_total":                   {"source", "connector", "outcome"},
+		"identrail_automation_lag_milliseconds":             {"source", "queue"},
 	}
 	for metric, labels := range known {
 		if err := ValidateMetricLabels(metric, labels...); err != nil {

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -29,6 +29,8 @@ type Metrics struct {
 	WorkerRequeuesTotal                    *prometheus.CounterVec
 	WorkerDeadLettersTotal                 *prometheus.CounterVec
 	WorkerRetriesTotal                     *prometheus.CounterVec
+	AutomationRunsTotal                    *prometheus.CounterVec
+	AutomationLagMS                        *prometheus.HistogramVec
 	APIDeniedRequestsTotal                 *prometheus.CounterVec
 	AuthzPolicyShadowEvaluationsTotal      prometheus.Counter
 	AuthzPolicyShadowDivergencesTotal      prometheus.Counter
@@ -207,6 +209,19 @@ func NewMetrics() *Metrics {
 			Name:      "retries_total",
 			Help:      "Total worker retryable failures by bounded runner name.",
 		}, []string{"runner"}),
+		AutomationRunsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "identrail",
+			Subsystem: "automation",
+			Name:      "runs_total",
+			Help:      "Total scheduled, event-driven, and queue automation actions by bounded source, connector, and outcome.",
+		}, []string{"source", "connector", "outcome"}),
+		AutomationLagMS: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "identrail",
+			Subsystem: "automation",
+			Name:      "lag_milliseconds",
+			Help:      "Observed scheduling or queue lag for automation work by bounded source and queue.",
+			Buckets:   []float64{100, 500, 1000, 5000, 15000, 30000, 60000, 300000, 900000, 1800000},
+		}, []string{"source", "queue"}),
 		APIDeniedRequestsTotal: apiDeniedRequestsTotal,
 		AuthzPolicyShadowEvaluationsTotal: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: "identrail",

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -36,6 +36,8 @@ func TestNewMetricsCountersAndHistogram(t *testing.T) {
 	m.WorkerRequeuesTotal.WithLabelValues("repo_scan").Add(1)
 	m.WorkerDeadLettersTotal.WithLabelValues("api_queue").Add(1)
 	m.WorkerRetriesTotal.WithLabelValues("api_queue").Add(1)
+	m.AutomationRunsTotal.WithLabelValues("scheduled", "github", "queued").Add(2)
+	m.AutomationLagMS.WithLabelValues("scheduled", "repo_scan").Observe(1500)
 	m.RepoFindingsGenerated.Add(4)
 	m.APIDeniedRequestsTotal.WithLabelValues("unauthorized", "auth").Add(1)
 	m.APIDeniedRequestsTotal.WithLabelValues("forbidden", "authz").Add(1)
@@ -101,6 +103,9 @@ func TestNewMetricsCountersAndHistogram(t *testing.T) {
 	}
 	if got := testutil.ToFloat64(m.WorkerRetriesTotal.WithLabelValues("api_queue")); got != 1 {
 		t.Fatalf("expected api queue retries 1, got %v", got)
+	}
+	if got := testutil.ToFloat64(m.AutomationRunsTotal.WithLabelValues("scheduled", "github", "queued")); got != 2 {
+		t.Fatalf("expected scheduled github automation runs 2, got %v", got)
 	}
 	if got := testutil.ToFloat64(m.RepoScanTruncatedTotal); got != 1 {
 		t.Fatalf("expected repo scan truncations 1, got %v", got)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -76,12 +76,19 @@ func Run(ctx context.Context, cfg config.Config, signals <-chan os.Signal) error
 		result, runErr := svc.RunScan(scanCtx)
 		if runErr != nil {
 			if errors.Is(runErr, api.ErrScanInProgress) {
+				recordWorkerAutomationRun(metrics, "scheduled", cfg.Provider, "skipped")
 				logger.Info("scan skipped because another run is in progress", telemetry.StandardLogFields("worker", "scheduled_scan", telemetry.String("provider", cfg.Provider), telemetry.String("outcome", "skipped_in_progress"))...)
 				return nil
 			}
+			recordWorkerAutomationRun(metrics, "scheduled", cfg.Provider, "failed")
 			logger.Error("scheduled scan failed", telemetry.StandardLogFields("worker", "scheduled_scan", telemetry.String("provider", cfg.Provider), telemetry.String("outcome", "failed"), telemetry.ZapError(runErr))...)
 			return runErr
 		}
+		outcome := "succeeded"
+		if result.PartialSourceRun {
+			outcome = "partial"
+		}
+		recordWorkerAutomationRun(metrics, "scheduled", cfg.Provider, outcome)
 		logger.Info("scheduled scan completed", telemetry.StandardLogFields("worker", "scheduled_scan", telemetry.String("provider", cfg.Provider), telemetry.String("scan_id", result.Scan.ID), telemetry.String("outcome", "completed"))...)
 		return nil
 	}
@@ -98,13 +105,16 @@ func Run(ctx context.Context, cfg config.Config, signals <-chan os.Signal) error
 			cancel()
 			if runErr != nil {
 				if errors.Is(runErr, api.ErrRepoScanInProgress) {
+					recordWorkerAutomationRun(metrics, "scheduled", "repo_scan", "skipped")
 					logger.Info("repo scan skipped because another run is in progress", telemetry.StandardLogFields("worker", "scheduled_repo_scan", telemetry.String("repository", target), telemetry.String("outcome", "skipped_in_progress"))...)
 					continue
 				}
 				failures++
+				recordWorkerAutomationRun(metrics, "scheduled", "repo_scan", "failed")
 				logger.Error("scheduled repo scan failed", telemetry.StandardLogFields("worker", "scheduled_repo_scan", telemetry.String("repository", target), telemetry.String("outcome", "failed"), telemetry.ZapError(runErr))...)
 				continue
 			}
+			recordWorkerAutomationRun(metrics, "scheduled", "repo_scan", "succeeded")
 			logger.Info(
 				"scheduled repo scan completed",
 				telemetry.StandardLogFields("worker", "scheduled_repo_scan",
@@ -297,6 +307,66 @@ func writeWorkerHeartbeat(path string) error {
 	}
 	payload := []byte(time.Now().UTC().Format(time.RFC3339Nano) + "\n")
 	return os.WriteFile(path, payload, 0o600)
+}
+
+func recordWorkerAutomationRun(metrics *telemetry.Metrics, source string, connector string, outcome string) {
+	if metrics == nil {
+		return
+	}
+	metrics.AutomationRunsTotal.WithLabelValues(
+		workerAutomationSourceLabel(source),
+		workerAutomationConnectorLabel(connector),
+		workerAutomationOutcomeLabel(outcome),
+	).Inc()
+}
+
+func workerAutomationSourceLabel(source string) string {
+	switch strings.ToLower(strings.TrimSpace(source)) {
+	case "scheduled":
+		return "scheduled"
+	case "event":
+		return "event"
+	case "api_queue":
+		return "api_queue"
+	default:
+		return "other"
+	}
+}
+
+func workerAutomationConnectorLabel(connector string) string {
+	switch strings.ToLower(strings.TrimSpace(connector)) {
+	case "aws":
+		return "aws"
+	case "github":
+		return "github"
+	case "kubernetes":
+		return "kubernetes"
+	case "repo_scan":
+		return "repo_scan"
+	case "scan_policy":
+		return "scan_policy"
+	default:
+		return "other"
+	}
+}
+
+func workerAutomationOutcomeLabel(outcome string) string {
+	switch strings.ToLower(strings.TrimSpace(outcome)) {
+	case "queued":
+		return "queued"
+	case "succeeded":
+		return "succeeded"
+	case "failed":
+		return "failed"
+	case "partial":
+		return "partial"
+	case "skipped":
+		return "skipped"
+	case "requeued":
+		return "requeued"
+	default:
+		return "other"
+	}
 }
 
 func withTimeoutIfNone(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/identrail/identrail/internal/config"
+	"github.com/identrail/identrail/internal/telemetry"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func TestRunWithCancelledContext(t *testing.T) {
@@ -269,5 +271,40 @@ func TestProcessAPIQueueBatchRepoFailuresContinueWithinBatch(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "api queue batch failed for 1 job(s)") {
 		t.Fatalf("unexpected queue batch error: %v", err)
+	}
+}
+
+func TestWorkerAutomationMetricLabelsAreBounded(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "source scheduled", got: workerAutomationSourceLabel(" scheduled "), want: "scheduled"},
+		{name: "source unknown", got: workerAutomationSourceLabel("workspace-a"), want: "other"},
+		{name: "connector aws", got: workerAutomationConnectorLabel(" AWS "), want: "aws"},
+		{name: "connector unknown", got: workerAutomationConnectorLabel("owner/repo"), want: "other"},
+		{name: "outcome requeued", got: workerAutomationOutcomeLabel(" requeued "), want: "requeued"},
+		{name: "outcome unknown", got: workerAutomationOutcomeLabel("custom"), want: "other"},
+	}
+	for _, tc := range tests {
+		if tc.got != tc.want {
+			t.Fatalf("%s = %q, want %q", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+func TestRecordWorkerAutomationRun(t *testing.T) {
+	metrics := telemetry.NewMetrics()
+
+	recordWorkerAutomationRun(metrics, "scheduled", "aws", "succeeded")
+	recordWorkerAutomationRun(metrics, "scheduled", "kubernetes", "partial")
+	recordWorkerAutomationRun(nil, "scheduled", "aws", "failed")
+
+	if got := testutil.ToFloat64(metrics.AutomationRunsTotal.WithLabelValues("scheduled", "aws", "succeeded")); got != 1 {
+		t.Fatalf("scheduled aws succeeded metric = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.AutomationRunsTotal.WithLabelValues("scheduled", "kubernetes", "partial")); got != 1 {
+		t.Fatalf("scheduled kubernetes partial metric = %v, want 1", got)
 	}
 }


### PR DESCRIPTION
Fixes #565

## What Changed
- Added bounded automation reliability metrics for scheduled, event-driven, and API-queue scan work.
- Wired queue lag, automation outcome, enqueue attempt, and enqueue failure metrics into scan, repo scan, GitHub webhook, scan-policy scheduler, and worker paths.
- Added OpenTelemetry orchestration spans for GitHub webhook handling and scan-policy scheduling.
- Added focused metric tests and cardinality coverage for the new labels.
- Expanded the observability runbook with dashboard panel recipes, alert expressions, and runbook routing guidance.

## Why
The issue is a true positive: Identrail already exposed baseline scan metrics and scanner-stage tracing, but automation reliability was not measurable enough for scheduled and event-driven scans. Operators lacked explicit source/outcome/lag metrics, per-connector SLA panel recipes, and alert guidance tied back to runbooks.

## Impact and Risk
- Backward compatible: existing metric names, API responses, and scan behavior are preserved.
- New metric labels are bounded to avoid tenant, workspace, repository, scan id, request id, or trace id cardinality leaks.
- Risk is limited to additional Prometheus series and tracing spans for automation paths.

## Validation Performed
- `gofmt -w` on touched Go files.
- Commit/push hooks passed: merge-conflict check, EOF check, whitespace check, gofmt check, go vet, local env token hygiene, and Vercel artifact hygiene.
- Full `go test ./...` was not run locally.

## AI Usage Disclosure
- AI-assisted: No
- Tools used: None
- Where used: N/A
- Human verification performed: issue checked against current metrics/tracing/docs; focused code and docs changes reviewed before commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automation observability for scheduled, event-driven, and API-queue scans with new bounded Prometheus metrics and orchestration spans. Addresses #565 by exposing source/outcome/lag and queue health for SLA dashboards and alerts.

- **New Features**
  - Prometheus: `identrail_automation_runs_total{source,connector,outcome}` and `identrail_automation_lag_milliseconds{source,queue}` wired into API `scan`/`repo_scan` processors, GitHub webhook, scan-policy scheduler, and scheduled workers; metrics registered in the API router. Outcomes include `queued|succeeded|failed|partial|skipped|requeued`.
  - Orchestration spans: `automation.github_webhook` and `automation.scan_policy_scheduler` with attributes and error status for triage.
  - Queue/worker telemetry: records API/worker lag; reports requeues, dead letters, retries, and bounded outcomes across `scan` and `repo_scan`.
  - Docs and tests: bounded-label helpers and metric tests; observability runbook expanded with panels, p95 lag SLOs, and alert examples. Labels are bounded; no breaking changes.

<sup>Written for commit 31b44c98352541fe5ba0f3438a0b8fdc6605208d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

