### PR TITLE
Add AWS API hosting layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   - defines ECS/Fargate API service, HTTPS load balancer, task roles, security groups, health checks, and CPU autoscaling primitives
   - keeps API hosting resource creation disabled by default for cost-safe CI validation
   - configures hosted API CORS origins and trusted ALB proxy CIDRs so the split web/API domains preserve browser access and real client IPs
-  - validates distinct public/private subnet inputs and public subnet Availability Zone spread before planning the load balancer and Fargate service
+  - validates distinct public/private subnet inputs, public subnet Availability Zone spread, and subnet VPC membership before planning the load balancer and Fargate service
   - documents operator inputs, Secrets Manager references, DNS cutover, and rollback expectations for `api.identrail.com`
 - Added clickable GitHub line links for repository findings:
   - repo findings now expose stable `repository` and `source_url` fields in API payloads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   - keeps API hosting resource creation disabled by default for cost-safe CI validation
   - configures hosted API CORS origins and trusted ALB proxy CIDRs so the split web/API domains preserve browser access and real client IPs
   - validates distinct public/private subnet inputs, public subnet Availability Zone spread, subnet VPC membership, and public-subnet Internet Gateway routes before planning the load balancer and Fargate service
+  - requires operator confirmation that private API task subnets have NAT or VPC endpoint egress before planning Fargate tasks with `assign_public_ip=false`
+  - validates the ACM certificate ARN partition against the active AWS provider partition
   - grants ECS secret injection IAM permissions on base Secrets Manager ARNs when `api_secrets` use JSON-key or version selectors
   - documents operator inputs, Secrets Manager references, DNS cutover, and rollback expectations for `api.identrail.com`
 - Added clickable GitHub line links for repository findings:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   - defines ECS/Fargate API service, HTTPS load balancer, task roles, security groups, health checks, and CPU autoscaling primitives
   - keeps API hosting resource creation disabled by default for cost-safe CI validation
   - configures hosted API CORS origins and trusted ALB proxy CIDRs so the split web/API domains preserve browser access and real client IPs
-  - validates distinct public/private subnet inputs, public subnet Availability Zone spread, subnet VPC membership, and public-subnet Internet Gateway routes before planning the load balancer and Fargate service
+  - validates distinct public/private subnet inputs, public subnet Availability Zone spread, subnet VPC membership, and public-subnet Internet Gateway routes, including inherited main route tables, before planning the load balancer and Fargate service
   - requires operator confirmation that private API task subnets have NAT or VPC endpoint egress before planning Fargate tasks with `assign_public_ip=false`
   - validates the ACM certificate ARN partition against the active AWS provider partition
   - grants ECS secret injection IAM permissions on base Secrets Manager ARNs when `api_secrets` use JSON-key or version selectors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - validates the ACM certificate ARN partition against the active AWS provider partition
   - grants ECS secret injection IAM permissions on base Secrets Manager ARNs when `api_secrets` use JSON-key or version selectors
   - keeps long-running ECS API tasks non-migrating so schema changes stay in a dedicated migration step
+  - rejects pathful CORS URLs so hosted API browser access uses exact bare origins
   - documents operator inputs, Secrets Manager references, DNS cutover, and rollback expectations for `api.identrail.com`
 - Added clickable GitHub line links for repository findings:
   - repo findings now expose stable `repository` and `source_url` fields in API payloads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added a plan-first AWS API hosting layer:
   - defines ECS/Fargate API service, HTTPS load balancer, task roles, security groups, health checks, and CPU autoscaling primitives
   - keeps API hosting resource creation disabled by default for cost-safe CI validation
+  - configures hosted API CORS origins and trusted ALB proxy CIDRs so the split web/API domains preserve browser access and real client IPs
   - documents operator inputs, Secrets Manager references, DNS cutover, and rollback expectations for `api.identrail.com`
 - Added clickable GitHub line links for repository findings:
   - repo findings now expose stable `repository` and `source_url` fields in API payloads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - keeps API hosting resource creation disabled by default for cost-safe CI validation
   - configures hosted API CORS origins and trusted ALB proxy CIDRs so the split web/API domains preserve browser access and real client IPs
   - validates distinct public/private subnet inputs, public subnet Availability Zone spread, and subnet VPC membership before planning the load balancer and Fargate service
+  - grants ECS secret injection IAM permissions on base Secrets Manager ARNs when `api_secrets` use JSON-key or version selectors
   - documents operator inputs, Secrets Manager references, DNS cutover, and rollback expectations for `api.identrail.com`
 - Added clickable GitHub line links for repository findings:
   - repo findings now expose stable `repository` and `source_url` fields in API payloads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   - defines ECS/Fargate API service, HTTPS load balancer, task roles, security groups, health checks, and CPU autoscaling primitives
   - keeps API hosting resource creation disabled by default for cost-safe CI validation
   - configures hosted API CORS origins and trusted ALB proxy CIDRs so the split web/API domains preserve browser access and real client IPs
+  - validates distinct public/private subnet inputs before planning the load balancer and Fargate service
   - documents operator inputs, Secrets Manager references, DNS cutover, and rollback expectations for `api.identrail.com`
 - Added clickable GitHub line links for repository findings:
   - repo findings now expose stable `repository` and `source_url` fields in API payloads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   - defines ECS/Fargate API service, HTTPS load balancer, task roles, security groups, health checks, and CPU autoscaling primitives
   - keeps API hosting resource creation disabled by default for cost-safe CI validation
   - configures hosted API CORS origins and trusted ALB proxy CIDRs so the split web/API domains preserve browser access and real client IPs
-  - validates distinct public/private subnet inputs before planning the load balancer and Fargate service
+  - validates distinct public/private subnet inputs and public subnet Availability Zone spread before planning the load balancer and Fargate service
   - documents operator inputs, Secrets Manager references, DNS cutover, and rollback expectations for `api.identrail.com`
 - Added clickable GitHub line links for repository findings:
   - repo findings now expose stable `repository` and `source_url` fields in API payloads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   - defines ECS/Fargate API service, HTTPS load balancer, task roles, security groups, health checks, and CPU autoscaling primitives
   - keeps API hosting resource creation disabled by default for cost-safe CI validation
   - configures hosted API CORS origins and trusted ALB proxy CIDRs so the split web/API domains preserve browser access and real client IPs
-  - validates distinct public/private subnet inputs, public subnet Availability Zone spread, and subnet VPC membership before planning the load balancer and Fargate service
+  - validates distinct public/private subnet inputs, public subnet Availability Zone spread, subnet VPC membership, and public-subnet Internet Gateway routes before planning the load balancer and Fargate service
   - grants ECS secret injection IAM permissions on base Secrets Manager ARNs when `api_secrets` use JSON-key or version selectors
   - documents operator inputs, Secrets Manager references, DNS cutover, and rollback expectations for `api.identrail.com`
 - Added clickable GitHub line links for repository findings:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Added a plan-first AWS API hosting layer:
+  - defines ECS/Fargate API service, HTTPS load balancer, task roles, security groups, health checks, and CPU autoscaling primitives
+  - keeps API hosting resource creation disabled by default for cost-safe CI validation
+  - documents operator inputs, Secrets Manager references, DNS cutover, and rollback expectations for `api.identrail.com`
 - Enriched repo findings with stable remediation metadata:
   - exposed `commit`, `file_path`, `line_number`, `detector`, `line_snippet`, and `line_snippet_redacted` in scanner and API finding payloads
   - normalized persisted repo finding evidence so existing rows read back without a storage migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - requires operator confirmation that private API task subnets have NAT or VPC endpoint egress before planning Fargate tasks with `assign_public_ip=false`
   - validates the ACM certificate ARN partition against the active AWS provider partition
   - grants ECS secret injection IAM permissions on base Secrets Manager ARNs when `api_secrets` use JSON-key or version selectors
+  - keeps long-running ECS API tasks non-migrating so schema changes stay in a dedicated migration step
   - documents operator inputs, Secrets Manager references, DNS cutover, and rollback expectations for `api.identrail.com`
 - Added clickable GitHub line links for repository findings:
   - repo findings now expose stable `repository` and `source_url` fields in API payloads

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -12,5 +12,6 @@ Deployment profiles:
 
 Published container image examples use `ghcr.io/identrail/identrail` for the main server image, with `ghcr.io/identrail/identrail-worker`, `ghcr.io/identrail/identrail-web`, and the compatibility alias `ghcr.io/identrail/identrail-api` for multi-service deployments. Pin production deployments to immutable release tags. Helm and Terraform deployment values should use tagged images (`repository` + `tag`), while digest pinning is only for deployment paths that explicitly support digest references.
 
-AWS deployment starts with a validation-only foundation. See `aws/README.md`
-before enabling resource creation.
+AWS deployment starts with a validation-only foundation and a plan-first API
+hosting layer. See `aws/README.md` and `../docs/aws-api-hosting.md` before
+enabling resource creation.

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -2,16 +2,18 @@
 
 This directory contains the AWS-specific deployment foundation for Identrail.
 
-The first foundation module is intentionally safe by default:
+The AWS module is intentionally safe by default:
 
 - It validates AWS provider wiring and naming conventions.
 - It defines production-adjacent primitives needed by later API hosting work.
-- It does not create resources unless `create_foundation_resources=true`.
-- It does not deploy the Identrail API, worker, database, or public domains yet.
+- It does not create foundation resources unless `create_foundation_resources=true`.
+- It does not create the API hosting layer unless `create_api_hosting_resources=true`.
+- It does not deploy the worker, database, or public domains yet.
 
 ## Current Scope
 
 - Terraform foundation: `terraform/`
+- API hosting plan: `terraform/api_hosting.tf`
 - GitHub OIDC role verification: `.github/workflows/aws-oidc-verification.yml`
 - Dev-only foundation plan workflow: `.github/workflows/aws-deployment-foundation.yml`
 
@@ -19,7 +21,7 @@ The first foundation module is intentionally safe by default:
 
 1. Verify GitHub can assume the AWS deployment role through OIDC.
 2. Validate and plan this AWS foundation.
-3. Add the API hosting stack.
+3. Plan the API hosting stack with resource creation still manually controlled.
 4. Add database, secrets, migrations, and domain cutover.
 
 Keep production applies manual until the API hosting stack and rollback runbook

--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -40,6 +40,9 @@ The hosted API task also defaults to live AWS collection with
 origins through `IDENTRAIL_CORS_ALLOWED_ORIGINS`, and configures
 `IDENTRAIL_TRUSTED_PROXIES` from `api_trusted_proxy_cidr_blocks` so ALB
 `X-Forwarded-For` client IPs are honored by audit and rate-limit paths.
+Long-running API tasks set `IDENTRAIL_RUN_MIGRATIONS=false`; run migrations
+through a dedicated one-off migration step before deploying or upgrading the
+service.
 The task role includes the read-only IAM discovery calls required by that live
 collector. Optional `sts:AssumeRole` access is limited to ARNs listed in
 `api_connector_role_arns`.

--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -82,7 +82,8 @@ immutable API image, database, auth configuration, and Secrets Manager
 references are ready. The API-hosting plan reads public and private subnet
 metadata from AWS and fails before apply if the load balancer subnets are not
 spread across at least two Availability Zones or if any provided subnet is
-outside `api_vpc_id`:
+outside `api_vpc_id`. It also reads the public subnet route tables and requires
+an Internet Gateway default route so the public API load balancer is reachable:
 
 ```bash
 cd deploy/aws/terraform

--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -83,7 +83,9 @@ references are ready. The API-hosting plan reads public and private subnet
 metadata from AWS and fails before apply if the load balancer subnets are not
 spread across at least two Availability Zones or if any provided subnet is
 outside `api_vpc_id`. It also reads the public subnet route tables and requires
-an Internet Gateway default route so the public API load balancer is reachable:
+an Internet Gateway default route so the public API load balancer is reachable.
+public subnets may use either an explicit subnet route-table association or the
+VPC main route table.
 
 ```bash
 cd deploy/aws/terraform

--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -24,6 +24,9 @@ It does not write secret values. Runtime secrets should be created by the
 operator or a dedicated secrets workflow and referenced through `api_secrets`.
 If those secrets use customer-managed KMS keys, list the key ARNs in
 `api_secret_kms_key_arns` so ECS secret injection can decrypt them.
+`api_secrets` may use ECS `valueFrom` selectors for JSON keys or versions, but
+the generated IAM policy grants `GetSecretValue` on the underlying base secret
+ARN so task startup has the correct access.
 Do not place database URLs, API keys, session keys, or OAuth/webhook/HMAC
 secrets in `api_environment_variables`; API hosting rejects known secret-bearing
 Identrail variables there so Terraform state does not receive secret material.

--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -95,6 +95,7 @@ terraform plan \
   -var='api_vpc_id=<vpc-id>' \
   -var='api_public_subnet_ids=["<public-subnet-a>","<public-subnet-b>"]' \
   -var='api_private_subnet_ids=["<private-subnet-a>","<private-subnet-b>"]' \
+  -var='api_private_subnet_egress_ready=true' \
   -var='api_certificate_arn=<api-certificate-arn>' \
   -var='api_container_image=ghcr.io/identrail/identrail-api:<immutable-release-tag>' \
   -var='api_cors_allowed_origins=["https://app.identrail.com","https://identrail.com","https://www.identrail.com"]' \
@@ -111,6 +112,11 @@ reviewed.
 Keep `api_connector_role_arns=[]` until reviewed AWS connector roles exist. Add
 only those connector role ARNs when the hosted API should validate connector
 setup or run recurring scans through assumed roles.
+
+Set `api_private_subnet_egress_ready=true` only after the private task subnets
+have NAT egress or private VPC endpoints for the services Fargate needs at
+startup, including ECR API, ECR Docker, CloudWatch Logs, Secrets Manager, and
+S3 access for image layers. Identrail API tasks run with `assign_public_ip=false`.
 
 Set `api_enable_execute_command=true` only when operator IAM and audit
 expectations are ready. The task role receives the required SSM Messages

--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -73,9 +73,10 @@ terraform plan \
 
 ## Manual Dev Plan With API Hosting Enabled
 
-Only run this after the VPC, public/private subnets, ACM certificate, immutable
-API image, database, auth configuration, and Secrets Manager references are
-ready:
+Only run this after the VPC, at least two distinct public subnets in different
+Availability Zones, at least two distinct private subnets, ACM certificate,
+immutable API image, database, auth configuration, and Secrets Manager
+references are ready:
 
 ```bash
 cd deploy/aws/terraform

--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -40,6 +40,8 @@ The hosted API task also defaults to live AWS collection with
 origins through `IDENTRAIL_CORS_ALLOWED_ORIGINS`, and configures
 `IDENTRAIL_TRUSTED_PROXIES` from `api_trusted_proxy_cidr_blocks` so ALB
 `X-Forwarded-For` client IPs are honored by audit and rate-limit paths.
+Allowed CORS entries must be bare HTTPS origins such as
+`https://app.identrail.com`, with no path, query, fragment, or trailing slash.
 Long-running API tasks set `IDENTRAIL_RUN_MIGRATIONS=false`; run migrations
 through a dedicated one-off migration step before deploying or upgrading the
 service.

--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -76,9 +76,10 @@ terraform plan \
 Only run this after the VPC, at least two distinct public subnets in different
 Availability Zones, at least two distinct private subnets, ACM certificate,
 immutable API image, database, auth configuration, and Secrets Manager
-references are ready. The API-hosting plan reads public subnet metadata from AWS
-and fails before apply if the load balancer subnets are not spread across at
-least two Availability Zones:
+references are ready. The API-hosting plan reads public and private subnet
+metadata from AWS and fails before apply if the load balancer subnets are not
+spread across at least two Availability Zones or if any provided subnet is
+outside `api_vpc_id`:
 
 ```bash
 cd deploy/aws/terraform

--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -33,7 +33,10 @@ before it will plan ECS resources.
 The hosted API task also defaults to live AWS collection with
 `IDENTRAIL_AWS_SOURCE=sdk`, `IDENTRAIL_REQUIRE_LIVE_SOURCES=true`, and
 `IDENTRAIL_AWS_REGION` from `aws_region`. It binds the API process with
-`IDENTRAIL_HTTP_ADDR` from `api_container_port`.
+`IDENTRAIL_HTTP_ADDR` from `api_container_port`, allows the Identrail Cloud web
+origins through `IDENTRAIL_CORS_ALLOWED_ORIGINS`, and configures
+`IDENTRAIL_TRUSTED_PROXIES` from `api_trusted_proxy_cidr_blocks` so ALB
+`X-Forwarded-For` client IPs are honored by audit and rate-limit paths.
 The task role includes the read-only IAM discovery calls required by that live
 collector. Optional `sts:AssumeRole` access is limited to ARNs listed in
 `api_connector_role_arns`.
@@ -86,6 +89,8 @@ terraform plan \
   -var='api_private_subnet_ids=["<private-subnet-a>","<private-subnet-b>"]' \
   -var='api_certificate_arn=<api-certificate-arn>' \
   -var='api_container_image=ghcr.io/identrail/identrail-api:<immutable-release-tag>' \
+  -var='api_cors_allowed_origins=["https://app.identrail.com","https://identrail.com","https://www.identrail.com"]' \
+  -var='api_trusted_proxy_cidr_blocks=["10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"]' \
   -var='api_secrets={"IDENTRAIL_DATABASE_URL":"<database-url-secret-arn>","IDENTRAIL_API_KEY_SCOPES":"<api-key-scopes-secret-arn>"}' \
   -var='api_secret_kms_key_arns=[]' \
   -var='api_connector_role_arns=[]'

--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -76,7 +76,9 @@ terraform plan \
 Only run this after the VPC, at least two distinct public subnets in different
 Availability Zones, at least two distinct private subnets, ACM certificate,
 immutable API image, database, auth configuration, and Secrets Manager
-references are ready:
+references are ready. The API-hosting plan reads public subnet metadata from AWS
+and fails before apply if the load balancer subnets are not spread across at
+least two Availability Zones:
 
 ```bash
 cd deploy/aws/terraform

--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -1,7 +1,8 @@
 # AWS Terraform Foundation
 
-This Terraform root prepares AWS deployment primitives for Identrail without
-deploying the application yet.
+This Terraform root prepares AWS deployment primitives for Identrail. It can
+validate the foundation in CI and, when explicitly enabled by an operator,
+define the API hosting layer that will eventually sit behind `api.identrail.com`.
 
 ## What It Can Create
 
@@ -10,14 +11,39 @@ When `create_foundation_resources=true`, the root can create:
 - CloudWatch log groups for API and worker workloads.
 - A Secrets Manager secret metadata record for future runtime configuration.
 
-It does not write secret values. Runtime secrets should be injected by the
-operator or a dedicated secrets workflow after the hosting stack exists.
+When `create_api_hosting_resources=true`, the root can also create:
+
+- an ECS/Fargate cluster, task definition, service, and autoscaling policy for
+  the Identrail API
+- an internet-facing application load balancer with HTTPS listener and optional
+  HTTP-to-HTTPS redirect
+- API load balancer and ECS service security groups
+- task execution and task IAM roles
+
+It does not write secret values. Runtime secrets should be created by the
+operator or a dedicated secrets workflow and referenced through `api_secrets`.
+If those secrets use customer-managed KMS keys, list the key ARNs in
+`api_secret_kms_key_arns` so ECS secret injection can decrypt them.
+Do not place database URLs, API keys, session keys, or OAuth/webhook/HMAC
+secrets in `api_environment_variables`; API hosting rejects known secret-bearing
+Identrail variables there so Terraform state does not receive secret material.
+When API hosting is enabled, Terraform also validates that the task has a
+database reference and at least one supported Identrail authentication mode
+before it will plan ECS resources.
+The hosted API task also defaults to live AWS collection with
+`IDENTRAIL_AWS_SOURCE=sdk`, `IDENTRAIL_REQUIRE_LIVE_SOURCES=true`, and
+`IDENTRAIL_AWS_REGION` from `aws_region`. It binds the API process with
+`IDENTRAIL_HTTP_ADDR` from `api_container_port`.
+The task role includes the read-only IAM discovery calls required by that live
+collector. Optional `sts:AssumeRole` access is limited to ARNs listed in
+`api_connector_role_arns`.
 
 ## Safe Defaults
 
-The default configuration sets `create_foundation_resources=false`, so CI and
-pull requests can run `terraform init`, `terraform validate`, and `terraform
-plan` without creating billable AWS resources.
+The default configuration sets both `create_foundation_resources=false` and
+`create_api_hosting_resources=false`, so CI and pull requests can run
+`terraform init`, `terraform validate`, and `terraform plan` without creating
+billable AWS resources.
 
 ## Local Validation
 
@@ -29,7 +55,7 @@ terraform validate
 terraform plan -refresh=false -input=false -var-file=environments/dev/terraform.tfvars.example
 ```
 
-## Manual Dev Plan With Resources Enabled
+## Manual Dev Plan With Foundation Resources Enabled
 
 Only run this when you intentionally want to see the resources Terraform would
 create in the target AWS account:
@@ -42,5 +68,37 @@ terraform plan \
   -var='create_foundation_resources=true'
 ```
 
-Do not run `terraform apply` from this foundation until the API hosting stack,
-database plan, secrets handling, and rollback runbook are ready.
+## Manual Dev Plan With API Hosting Enabled
+
+Only run this after the VPC, public/private subnets, ACM certificate, immutable
+API image, database, auth configuration, and Secrets Manager references are
+ready:
+
+```bash
+cd deploy/aws/terraform
+terraform plan \
+  -input=false \
+  -var-file=environments/dev/terraform.tfvars.example \
+  -var='create_foundation_resources=true' \
+  -var='create_api_hosting_resources=true' \
+  -var='api_vpc_id=<vpc-id>' \
+  -var='api_public_subnet_ids=["<public-subnet-a>","<public-subnet-b>"]' \
+  -var='api_private_subnet_ids=["<private-subnet-a>","<private-subnet-b>"]' \
+  -var='api_certificate_arn=<api-certificate-arn>' \
+  -var='api_container_image=ghcr.io/identrail/identrail-api:<immutable-release-tag>' \
+  -var='api_secrets={"IDENTRAIL_DATABASE_URL":"<database-url-secret-arn>","IDENTRAIL_API_KEY_SCOPES":"<api-key-scopes-secret-arn>"}' \
+  -var='api_secret_kms_key_arns=[]' \
+  -var='api_connector_role_arns=[]'
+```
+
+Do not run `terraform apply` until the database, runtime secrets, container
+image tag, health checks, rollback plan, and DNS cutover plan have all been
+reviewed.
+
+Keep `api_connector_role_arns=[]` until reviewed AWS connector roles exist. Add
+only those connector role ARNs when the hosted API should validate connector
+setup or run recurring scans through assumed roles.
+
+Set `api_enable_execute_command=true` only when operator IAM and audit
+expectations are ready. The task role receives the required SSM Messages
+permissions only when ECS Exec is enabled.

--- a/deploy/aws/terraform/api_hosting.tf
+++ b/deploy/aws/terraform/api_hosting.tf
@@ -36,6 +36,23 @@ locals {
   api_runtime_trusted_proxies = compact([
     for cidr_block in split(",", lookup(local.api_runtime_environment_variables, "IDENTRAIL_TRUSTED_PROXIES", "")) : trimspace(cidr_block)
   ])
+  api_main_route_table_ids = [
+    for route_table_id, route_table in data.aws_route_table.api_vpc : route_table_id
+    if anytrue([for association in route_table.associations : association.main])
+  ]
+  api_public_subnet_explicit_route_table_ids = {
+    for subnet_id in var.api_public_subnet_ids : subnet_id => [
+      for route_table_id, route_table in data.aws_route_table.api_vpc : route_table_id
+      if anytrue([for association in route_table.associations : association.subnet_id == subnet_id])
+    ]
+  }
+  api_public_subnet_effective_route_table_ids = {
+    for subnet_id in var.api_public_subnet_ids : subnet_id => (
+      length(local.api_public_subnet_explicit_route_table_ids[subnet_id]) > 0 ?
+      local.api_public_subnet_explicit_route_table_ids[subnet_id] :
+      local.api_main_route_table_ids
+    )
+  }
   api_new_auth_enabled = lower(lookup(local.api_runtime_environment_variables, "IDENTRAIL_FEATURE_NEW_AUTH", "")) == "true"
   api_has_supported_auth = (
     contains(local.api_secret_config_names, "IDENTRAIL_API_KEY_SCOPES") ||
@@ -71,10 +88,16 @@ data "aws_subnet" "api_private" {
   id = var.api_private_subnet_ids[count.index]
 }
 
-data "aws_route_table" "api_public" {
-  count = var.create_api_hosting_resources ? length(var.api_public_subnet_ids) : 0
+data "aws_route_tables" "api_vpc" {
+  count = var.create_api_hosting_resources ? 1 : 0
 
-  subnet_id = var.api_public_subnet_ids[count.index]
+  vpc_id = var.api_vpc_id
+}
+
+data "aws_route_table" "api_vpc" {
+  for_each = var.create_api_hosting_resources ? toset(data.aws_route_tables.api_vpc[0].ids) : toset([])
+
+  route_table_id = each.value
 }
 
 resource "terraform_data" "api_inputs" {
@@ -109,11 +132,13 @@ resource "terraform_data" "api_inputs" {
 
     precondition {
       condition = alltrue([
-        for route_table in data.aws_route_table.api_public : anytrue([
-          for route in route_table.routes : route.cidr_block == "0.0.0.0/0" && can(regex("^igw-", route.gateway_id))
+        for route_table_ids in values(local.api_public_subnet_effective_route_table_ids) : anytrue([
+          for route_table_id in route_table_ids : anytrue([
+            for route in data.aws_route_table.api_vpc[route_table_id].routes : route.cidr_block == "0.0.0.0/0" && can(regex("^igw-", route.gateway_id))
+          ])
         ])
       ])
-      error_message = "api_public_subnet_ids must be associated with route tables that have a 0.0.0.0/0 Internet Gateway route when create_api_hosting_resources=true."
+      error_message = "api_public_subnet_ids must resolve to explicit or inherited main route tables with a 0.0.0.0/0 Internet Gateway route when create_api_hosting_resources=true."
     }
 
     precondition {

--- a/deploy/aws/terraform/api_hosting.tf
+++ b/deploy/aws/terraform/api_hosting.tf
@@ -56,6 +56,12 @@ locals {
 
 data "aws_partition" "current" {}
 
+data "aws_subnet" "api_public" {
+  count = var.create_api_hosting_resources ? length(var.api_public_subnet_ids) : 0
+
+  id = var.api_public_subnet_ids[count.index]
+}
+
 resource "terraform_data" "api_inputs" {
   count = var.create_api_hosting_resources ? 1 : 0
 
@@ -71,7 +77,12 @@ resource "terraform_data" "api_inputs" {
       condition = length(distinct(var.api_public_subnet_ids)) >= 2 && alltrue([
         for subnet_id in var.api_public_subnet_ids : can(regex("^subnet-[0-9a-f]+$", subnet_id))
       ])
-      error_message = "api_public_subnet_ids must include at least two distinct valid subnet IDs, preferably in different Availability Zones, when create_api_hosting_resources=true."
+      error_message = "api_public_subnet_ids must include at least two distinct valid subnet IDs when create_api_hosting_resources=true."
+    }
+
+    precondition {
+      condition     = length(distinct(data.aws_subnet.api_public[*].availability_zone_id)) >= 2
+      error_message = "api_public_subnet_ids must include public subnets in at least two distinct Availability Zones when create_api_hosting_resources=true."
     }
 
     precondition {

--- a/deploy/aws/terraform/api_hosting.tf
+++ b/deploy/aws/terraform/api_hosting.tf
@@ -27,6 +27,9 @@ locals {
   api_runtime_environment_variables = merge(local.api_default_environment_variables, var.api_environment_variables)
   api_config_names                  = toset(concat(keys(local.api_runtime_environment_variables), keys(var.api_secrets)))
   api_secret_config_names           = toset(keys(var.api_secrets))
+  api_secret_resource_arns = toset([
+    for value_from in values(var.api_secrets) : join(":", slice(split(":", value_from), 0, 7))
+  ])
   api_runtime_cors_allowed_origins = compact([
     for origin in split(",", lookup(local.api_runtime_environment_variables, "IDENTRAIL_CORS_ALLOWED_ORIGINS", "")) : trimspace(origin)
   ])
@@ -189,7 +192,7 @@ data "aws_iam_policy_document" "api_task_execution_secrets" {
 
   statement {
     actions   = ["secretsmanager:GetSecretValue"]
-    resources = values(var.api_secrets)
+    resources = local.api_secret_resource_arns
   }
 
   dynamic "statement" {

--- a/deploy/aws/terraform/api_hosting.tf
+++ b/deploy/aws/terraform/api_hosting.tf
@@ -62,6 +62,12 @@ data "aws_subnet" "api_public" {
   id = var.api_public_subnet_ids[count.index]
 }
 
+data "aws_subnet" "api_private" {
+  count = var.create_api_hosting_resources ? length(var.api_private_subnet_ids) : 0
+
+  id = var.api_private_subnet_ids[count.index]
+}
+
 resource "terraform_data" "api_inputs" {
   count = var.create_api_hosting_resources ? 1 : 0
 
@@ -86,10 +92,24 @@ resource "terraform_data" "api_inputs" {
     }
 
     precondition {
+      condition = alltrue([
+        for subnet in data.aws_subnet.api_public : subnet.vpc_id == var.api_vpc_id
+      ])
+      error_message = "api_public_subnet_ids must all belong to api_vpc_id when create_api_hosting_resources=true."
+    }
+
+    precondition {
       condition = length(distinct(var.api_private_subnet_ids)) >= 2 && alltrue([
         for subnet_id in var.api_private_subnet_ids : can(regex("^subnet-[0-9a-f]+$", subnet_id))
       ])
       error_message = "api_private_subnet_ids must include at least two distinct valid subnet IDs when create_api_hosting_resources=true."
+    }
+
+    precondition {
+      condition = alltrue([
+        for subnet in data.aws_subnet.api_private : subnet.vpc_id == var.api_vpc_id
+      ])
+      error_message = "api_private_subnet_ids must all belong to api_vpc_id when create_api_hosting_resources=true."
     }
 
     precondition {

--- a/deploy/aws/terraform/api_hosting.tf
+++ b/deploy/aws/terraform/api_hosting.tf
@@ -132,10 +132,15 @@ resource "terraform_data" "api_inputs" {
 
     precondition {
       condition = can(regex(
-        "^arn:(aws|aws-us-gov|aws-cn):acm:${var.aws_region}:[0-9]{12}:certificate/.+$",
+        "^arn:${data.aws_partition.current.partition}:acm:${var.aws_region}:[0-9]{12}:certificate/.+$",
         var.api_certificate_arn
       ))
-      error_message = "api_certificate_arn must be an ACM certificate ARN in aws_region when create_api_hosting_resources=true."
+      error_message = "api_certificate_arn must be an ACM certificate ARN in the active AWS partition and aws_region when create_api_hosting_resources=true."
+    }
+
+    precondition {
+      condition     = var.api_private_subnet_egress_ready
+      error_message = "api_private_subnet_egress_ready must be true when create_api_hosting_resources=true after confirming private API subnets have NAT egress or VPC endpoints for ECR, Secrets Manager, and CloudWatch Logs."
     }
 
     precondition {
@@ -514,7 +519,8 @@ resource "aws_ecs_service" "api" {
   network_configuration {
     assign_public_ip = false
     security_groups  = [aws_security_group.api_service[0].id]
-    subnets          = var.api_private_subnet_ids
+    # terraform_data.api_inputs requires operator-confirmed NAT or VPC endpoints before these private subnets are used.
+    subnets = var.api_private_subnet_ids
   }
 
   depends_on = [

--- a/deploy/aws/terraform/api_hosting.tf
+++ b/deploy/aws/terraform/api_hosting.tf
@@ -71,6 +71,12 @@ data "aws_subnet" "api_private" {
   id = var.api_private_subnet_ids[count.index]
 }
 
+data "aws_route_table" "api_public" {
+  count = var.create_api_hosting_resources ? length(var.api_public_subnet_ids) : 0
+
+  subnet_id = var.api_public_subnet_ids[count.index]
+}
+
 resource "terraform_data" "api_inputs" {
   count = var.create_api_hosting_resources ? 1 : 0
 
@@ -99,6 +105,15 @@ resource "terraform_data" "api_inputs" {
         for subnet in data.aws_subnet.api_public : subnet.vpc_id == var.api_vpc_id
       ])
       error_message = "api_public_subnet_ids must all belong to api_vpc_id when create_api_hosting_resources=true."
+    }
+
+    precondition {
+      condition = alltrue([
+        for route_table in data.aws_route_table.api_public : anytrue([
+          for route in route_table.routes : route.cidr_block == "0.0.0.0/0" && can(regex("^igw-", route.gateway_id))
+        ])
+      ])
+      error_message = "api_public_subnet_ids must be associated with route tables that have a 0.0.0.0/0 Internet Gateway route when create_api_hosting_resources=true."
     }
 
     precondition {

--- a/deploy/aws/terraform/api_hosting.tf
+++ b/deploy/aws/terraform/api_hosting.tf
@@ -14,16 +14,26 @@ locals {
     "16384" = range(32768, 122881, 8192)
   }
   api_fargate_memory_options = lookup(local.api_fargate_memory_by_cpu, tostring(var.api_task_cpu), [])
+  api_cors_allowed_origins   = join(",", var.api_cors_allowed_origins)
+  api_trusted_proxies        = join(",", var.api_trusted_proxy_cidr_blocks)
   api_default_environment_variables = {
     IDENTRAIL_AWS_REGION           = var.aws_region
     IDENTRAIL_AWS_SOURCE           = "sdk"
+    IDENTRAIL_CORS_ALLOWED_ORIGINS = local.api_cors_allowed_origins
     IDENTRAIL_HTTP_ADDR            = ":${var.api_container_port}"
     IDENTRAIL_REQUIRE_LIVE_SOURCES = "true"
+    IDENTRAIL_TRUSTED_PROXIES      = local.api_trusted_proxies
   }
   api_runtime_environment_variables = merge(local.api_default_environment_variables, var.api_environment_variables)
   api_config_names                  = toset(concat(keys(local.api_runtime_environment_variables), keys(var.api_secrets)))
   api_secret_config_names           = toset(keys(var.api_secrets))
-  api_new_auth_enabled              = lower(lookup(local.api_runtime_environment_variables, "IDENTRAIL_FEATURE_NEW_AUTH", "")) == "true"
+  api_runtime_cors_allowed_origins = compact([
+    for origin in split(",", lookup(local.api_runtime_environment_variables, "IDENTRAIL_CORS_ALLOWED_ORIGINS", "")) : trimspace(origin)
+  ])
+  api_runtime_trusted_proxies = compact([
+    for cidr_block in split(",", lookup(local.api_runtime_environment_variables, "IDENTRAIL_TRUSTED_PROXIES", "")) : trimspace(cidr_block)
+  ])
+  api_new_auth_enabled = lower(lookup(local.api_runtime_environment_variables, "IDENTRAIL_FEATURE_NEW_AUTH", "")) == "true"
   api_has_supported_auth = (
     contains(local.api_secret_config_names, "IDENTRAIL_API_KEY_SCOPES") ||
     (contains(local.api_secret_config_names, "IDENTRAIL_API_KEYS") && contains(local.api_secret_config_names, "IDENTRAIL_WRITE_API_KEYS")) ||
@@ -92,6 +102,20 @@ resource "terraform_data" "api_inputs" {
     precondition {
       condition     = local.api_has_supported_auth
       error_message = "API hosting requires at least one supported auth mode: IDENTRAIL_API_KEY_SCOPES in api_secrets, legacy IDENTRAIL_API_KEYS plus IDENTRAIL_WRITE_API_KEYS in api_secrets, OIDC issuer plus audience, or new auth with IDENTRAIL_FEATURE_NEW_AUTH=true, IDENTRAIL_PUBLIC_BASE_URL, and IDENTRAIL_SESSION_KEY in api_secrets."
+    }
+
+    precondition {
+      condition = length(local.api_runtime_cors_allowed_origins) > 0 && alltrue([
+        for origin in local.api_runtime_cors_allowed_origins : can(regex("^https://[^, ]+$", origin))
+      ])
+      error_message = "API hosting requires IDENTRAIL_CORS_ALLOWED_ORIGINS to contain at least one HTTPS web origin."
+    }
+
+    precondition {
+      condition = length(local.api_runtime_trusted_proxies) > 0 && alltrue([
+        for cidr_block in local.api_runtime_trusted_proxies : can(cidrhost(cidr_block, 0)) && can(cidrnetmask(cidr_block))
+      ])
+      error_message = "API hosting requires IDENTRAIL_TRUSTED_PROXIES to contain at least one trusted ALB/VPC proxy CIDR."
     }
 
     precondition {

--- a/deploy/aws/terraform/api_hosting.tf
+++ b/deploy/aws/terraform/api_hosting.tf
@@ -1,0 +1,482 @@
+locals {
+  api_service_name     = "${var.name_prefix}-${var.environment}-api"
+  api_name_hash        = substr(sha1(local.api_service_name), 0, 8)
+  api_name_prefix      = "${trimsuffix(substr(local.api_service_name, 0, 23), "-")}-${local.api_name_hash}"
+  api_iam_name_prefix  = "${trimsuffix(substr(local.api_service_name, 0, 43), "-")}-${local.api_name_hash}"
+  api_policy_name_base = "${trimsuffix(substr(local.api_service_name, 0, 47), "-")}-${local.api_name_hash}"
+  api_fargate_memory_by_cpu = {
+    "256"   = [512, 1024, 2048]
+    "512"   = [1024, 2048, 3072, 4096]
+    "1024"  = [2048, 3072, 4096, 5120, 6144, 7168, 8192]
+    "2048"  = range(4096, 16385, 1024)
+    "4096"  = range(8192, 30721, 1024)
+    "8192"  = range(16384, 61441, 4096)
+    "16384" = range(32768, 122881, 8192)
+  }
+  api_fargate_memory_options = lookup(local.api_fargate_memory_by_cpu, tostring(var.api_task_cpu), [])
+  api_default_environment_variables = {
+    IDENTRAIL_AWS_REGION           = var.aws_region
+    IDENTRAIL_AWS_SOURCE           = "sdk"
+    IDENTRAIL_HTTP_ADDR            = ":${var.api_container_port}"
+    IDENTRAIL_REQUIRE_LIVE_SOURCES = "true"
+  }
+  api_runtime_environment_variables = merge(local.api_default_environment_variables, var.api_environment_variables)
+  api_config_names                  = toset(concat(keys(local.api_runtime_environment_variables), keys(var.api_secrets)))
+  api_secret_config_names           = toset(keys(var.api_secrets))
+  api_new_auth_enabled              = lower(lookup(local.api_runtime_environment_variables, "IDENTRAIL_FEATURE_NEW_AUTH", "")) == "true"
+  api_has_supported_auth = (
+    contains(local.api_secret_config_names, "IDENTRAIL_API_KEY_SCOPES") ||
+    (contains(local.api_secret_config_names, "IDENTRAIL_API_KEYS") && contains(local.api_secret_config_names, "IDENTRAIL_WRITE_API_KEYS")) ||
+    (contains(local.api_config_names, "IDENTRAIL_OIDC_ISSUER_URL") && contains(local.api_config_names, "IDENTRAIL_OIDC_AUDIENCE")) ||
+    (local.api_new_auth_enabled && contains(local.api_config_names, "IDENTRAIL_PUBLIC_BASE_URL") && contains(local.api_secret_config_names, "IDENTRAIL_SESSION_KEY"))
+  )
+  api_environment = [
+    for name, value in local.api_runtime_environment_variables : {
+      name  = name
+      value = value
+    }
+  ]
+  api_secrets = [
+    for name, value_from in var.api_secrets : {
+      name      = name
+      valueFrom = value_from
+    }
+  ]
+}
+
+data "aws_partition" "current" {}
+
+resource "terraform_data" "api_inputs" {
+  count = var.create_api_hosting_resources ? 1 : 0
+
+  input = local.api_service_name
+
+  lifecycle {
+    precondition {
+      condition     = can(regex("^vpc-[0-9a-f]+$", var.api_vpc_id))
+      error_message = "api_vpc_id must be a valid VPC ID when create_api_hosting_resources=true."
+    }
+
+    precondition {
+      condition = length(var.api_public_subnet_ids) >= 2 && alltrue([
+        for subnet_id in var.api_public_subnet_ids : can(regex("^subnet-[0-9a-f]+$", subnet_id))
+      ])
+      error_message = "api_public_subnet_ids must include at least two valid subnet IDs when create_api_hosting_resources=true."
+    }
+
+    precondition {
+      condition = length(var.api_private_subnet_ids) >= 2 && alltrue([
+        for subnet_id in var.api_private_subnet_ids : can(regex("^subnet-[0-9a-f]+$", subnet_id))
+      ])
+      error_message = "api_private_subnet_ids must include at least two valid subnet IDs when create_api_hosting_resources=true."
+    }
+
+    precondition {
+      condition = can(regex(
+        "^arn:(aws|aws-us-gov|aws-cn):acm:${var.aws_region}:[0-9]{12}:certificate/.+$",
+        var.api_certificate_arn
+      ))
+      error_message = "api_certificate_arn must be an ACM certificate ARN in aws_region when create_api_hosting_resources=true."
+    }
+
+    precondition {
+      condition     = length(trimspace(var.api_container_image)) > 0
+      error_message = "api_container_image is required when create_api_hosting_resources=true."
+    }
+
+    precondition {
+      condition     = contains(local.api_secret_config_names, "IDENTRAIL_DATABASE_URL")
+      error_message = "api_secrets must include IDENTRAIL_DATABASE_URL when create_api_hosting_resources=true."
+    }
+
+    precondition {
+      condition     = local.api_has_supported_auth
+      error_message = "API hosting requires at least one supported auth mode: IDENTRAIL_API_KEY_SCOPES in api_secrets, legacy IDENTRAIL_API_KEYS plus IDENTRAIL_WRITE_API_KEYS in api_secrets, OIDC issuer plus audience, or new auth with IDENTRAIL_FEATURE_NEW_AUTH=true, IDENTRAIL_PUBLIC_BASE_URL, and IDENTRAIL_SESSION_KEY in api_secrets."
+    }
+
+    precondition {
+      condition     = contains(local.api_fargate_memory_options, var.api_task_memory)
+      error_message = "api_task_cpu and api_task_memory must be a valid AWS Fargate CPU/memory pair."
+    }
+
+    precondition {
+      condition     = lower(local.api_runtime_environment_variables["IDENTRAIL_AWS_SOURCE"]) == "sdk"
+      error_message = "API hosting requires IDENTRAIL_AWS_SOURCE=sdk so hosted ECS tasks use live AWS collection instead of fixtures."
+    }
+
+    precondition {
+      condition     = lower(local.api_runtime_environment_variables["IDENTRAIL_REQUIRE_LIVE_SOURCES"]) == "true"
+      error_message = "API hosting requires IDENTRAIL_REQUIRE_LIVE_SOURCES=true so hosted ECS tasks cannot serve fixture-backed scans."
+    }
+
+    precondition {
+      condition     = !var.api_autoscaling_enabled || var.api_autoscaling_max_capacity >= var.api_autoscaling_min_capacity
+      error_message = "api_autoscaling_max_capacity must be greater than or equal to api_autoscaling_min_capacity when autoscaling is enabled."
+    }
+  }
+}
+
+data "aws_iam_policy_document" "ecs_tasks_assume_role" {
+  count = var.create_api_hosting_resources ? 1 : 0
+
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "api_task_execution_secrets" {
+  count = var.create_api_hosting_resources && length(var.api_secrets) > 0 ? 1 : 0
+
+  statement {
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = values(var.api_secrets)
+  }
+
+  dynamic "statement" {
+    for_each = length(var.api_secret_kms_key_arns) > 0 ? [1] : []
+
+    content {
+      actions   = ["kms:Decrypt"]
+      resources = var.api_secret_kms_key_arns
+    }
+  }
+}
+
+data "aws_iam_policy_document" "api_task_exec_command" {
+  count = var.create_api_hosting_resources && var.api_enable_execute_command ? 1 : 0
+
+  statement {
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel",
+    ]
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "api_task_aws_collector" {
+  count = var.create_api_hosting_resources ? 1 : 0
+
+  statement {
+    actions = [
+      "iam:ListRoles",
+      "iam:ListRolePolicies",
+      "iam:GetRolePolicy",
+      "iam:ListAttachedRolePolicies",
+      "iam:GetPolicy",
+      "iam:GetPolicyVersion",
+    ]
+    resources = ["*"]
+  }
+
+  dynamic "statement" {
+    for_each = length(var.api_connector_role_arns) > 0 ? [1] : []
+
+    content {
+      actions   = ["sts:AssumeRole"]
+      resources = var.api_connector_role_arns
+    }
+  }
+}
+
+resource "aws_ecs_cluster" "api" {
+  count = var.create_api_hosting_resources ? 1 : 0
+
+  name = local.api_service_name
+
+  setting {
+    name  = "containerInsights"
+    value = var.api_container_insights_enabled ? "enabled" : "disabled"
+  }
+}
+
+resource "aws_iam_role" "api_task_execution" {
+  count = var.create_api_hosting_resources ? 1 : 0
+
+  name               = "${local.api_iam_name_prefix}-execution"
+  assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume_role[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "api_task_execution" {
+  count = var.create_api_hosting_resources ? 1 : 0
+
+  role       = aws_iam_role.api_task_execution[0].name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy" "api_task_execution_secrets" {
+  count = var.create_api_hosting_resources && length(var.api_secrets) > 0 ? 1 : 0
+
+  name   = "${local.api_policy_name_base}-secrets"
+  role   = aws_iam_role.api_task_execution[0].id
+  policy = data.aws_iam_policy_document.api_task_execution_secrets[0].json
+}
+
+resource "aws_iam_role" "api_task" {
+  count = var.create_api_hosting_resources ? 1 : 0
+
+  name               = "${local.api_iam_name_prefix}-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume_role[0].json
+}
+
+resource "aws_iam_role_policy" "api_task_exec_command" {
+  count = var.create_api_hosting_resources && var.api_enable_execute_command ? 1 : 0
+
+  name   = "${local.api_policy_name_base}-exec"
+  role   = aws_iam_role.api_task[0].id
+  policy = data.aws_iam_policy_document.api_task_exec_command[0].json
+}
+
+resource "aws_iam_role_policy" "api_task_aws_collector" {
+  count = var.create_api_hosting_resources ? 1 : 0
+
+  name   = "${local.api_policy_name_base}-aws-collector"
+  role   = aws_iam_role.api_task[0].id
+  policy = data.aws_iam_policy_document.api_task_aws_collector[0].json
+}
+
+resource "aws_security_group" "api_load_balancer" {
+  count = var.create_api_hosting_resources ? 1 : 0
+
+  name        = "${local.api_service_name}-alb"
+  description = "Public HTTPS ingress for the Identrail API load balancer"
+  vpc_id      = var.api_vpc_id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "api_load_balancer_https" {
+  count = var.create_api_hosting_resources ? length(var.api_allowed_cidr_blocks) : 0
+
+  security_group_id = aws_security_group.api_load_balancer[0].id
+  cidr_ipv4         = var.api_allowed_cidr_blocks[count.index]
+  from_port         = 443
+  ip_protocol       = "tcp"
+  to_port           = 443
+}
+
+resource "aws_vpc_security_group_ingress_rule" "api_load_balancer_http" {
+  count = var.create_api_hosting_resources && var.api_enable_http_redirect ? length(var.api_allowed_cidr_blocks) : 0
+
+  security_group_id = aws_security_group.api_load_balancer[0].id
+  cidr_ipv4         = var.api_allowed_cidr_blocks[count.index]
+  from_port         = 80
+  ip_protocol       = "tcp"
+  to_port           = 80
+}
+
+resource "aws_vpc_security_group_egress_rule" "api_load_balancer_to_service" {
+  count = var.create_api_hosting_resources ? 1 : 0
+
+  security_group_id            = aws_security_group.api_load_balancer[0].id
+  referenced_security_group_id = aws_security_group.api_service[0].id
+  from_port                    = var.api_container_port
+  ip_protocol                  = "tcp"
+  to_port                      = var.api_container_port
+}
+
+resource "aws_security_group" "api_service" {
+  count = var.create_api_hosting_resources ? 1 : 0
+
+  name        = "${local.api_service_name}-service"
+  description = "Private ECS service access for the Identrail API"
+  vpc_id      = var.api_vpc_id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "api_service_from_load_balancer" {
+  count = var.create_api_hosting_resources ? 1 : 0
+
+  security_group_id            = aws_security_group.api_service[0].id
+  referenced_security_group_id = aws_security_group.api_load_balancer[0].id
+  from_port                    = var.api_container_port
+  ip_protocol                  = "tcp"
+  to_port                      = var.api_container_port
+}
+
+resource "aws_vpc_security_group_egress_rule" "api_service_egress" {
+  count = var.create_api_hosting_resources ? 1 : 0
+
+  security_group_id = aws_security_group.api_service[0].id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+}
+
+resource "aws_lb" "api" {
+  count = var.create_api_hosting_resources ? 1 : 0
+
+  name                       = local.api_name_prefix
+  internal                   = false
+  load_balancer_type         = "application"
+  security_groups            = [aws_security_group.api_load_balancer[0].id]
+  subnets                    = var.api_public_subnet_ids
+  drop_invalid_header_fields = true
+  enable_deletion_protection = var.api_load_balancer_deletion_protection
+}
+
+resource "aws_lb_target_group" "api" {
+  count = var.create_api_hosting_resources ? 1 : 0
+
+  name        = local.api_name_prefix
+  port        = var.api_container_port
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = var.api_vpc_id
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 2
+    interval            = 30
+    matcher             = "200"
+    path                = var.api_health_check_path
+    port                = "traffic-port"
+    protocol            = "HTTP"
+    timeout             = 5
+    unhealthy_threshold = 3
+  }
+}
+
+resource "aws_lb_listener" "api_https" {
+  count = var.create_api_hosting_resources ? 1 : 0
+
+  load_balancer_arn = aws_lb.api[0].arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = var.api_tls_policy
+  certificate_arn   = var.api_certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.api[0].arn
+  }
+}
+
+resource "aws_lb_listener" "api_http_redirect" {
+  count = var.create_api_hosting_resources && var.api_enable_http_redirect ? 1 : 0
+
+  load_balancer_arn = aws_lb.api[0].arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_ecs_task_definition" "api" {
+  count = var.create_api_hosting_resources ? 1 : 0
+
+  family                   = local.api_service_name
+  cpu                      = var.api_task_cpu
+  execution_role_arn       = aws_iam_role.api_task_execution[0].arn
+  memory                   = var.api_task_memory
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  task_role_arn            = aws_iam_role.api_task[0].arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "api"
+      image     = var.api_container_image
+      essential = true
+      portMappings = [
+        {
+          containerPort = var.api_container_port
+          hostPort      = var.api_container_port
+          protocol      = "tcp"
+        }
+      ]
+      environment = local.api_environment
+      secrets     = local.api_secrets
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.service["api"].name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "api"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_service" "api" {
+  count = var.create_api_hosting_resources ? 1 : 0
+
+  name            = local.api_service_name
+  cluster         = aws_ecs_cluster.api[0].id
+  task_definition = aws_ecs_task_definition.api[0].arn
+  desired_count   = var.api_desired_count
+  launch_type     = "FARGATE"
+
+  deployment_maximum_percent         = 200
+  deployment_minimum_healthy_percent = 100
+  enable_ecs_managed_tags            = true
+  enable_execute_command             = var.api_enable_execute_command
+  health_check_grace_period_seconds  = var.api_health_check_grace_period_seconds
+  propagate_tags                     = "SERVICE"
+  wait_for_steady_state              = false
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.api[0].arn
+    container_name   = "api"
+    container_port   = var.api_container_port
+  }
+
+  network_configuration {
+    assign_public_ip = false
+    security_groups  = [aws_security_group.api_service[0].id]
+    subnets          = var.api_private_subnet_ids
+  }
+
+  depends_on = [
+    terraform_data.api_inputs,
+    aws_iam_role_policy_attachment.api_task_execution,
+    aws_iam_role_policy.api_task_execution_secrets,
+    aws_iam_role_policy.api_task_aws_collector,
+    aws_lb_listener.api_https,
+  ]
+}
+
+resource "aws_appautoscaling_target" "api" {
+  count = var.create_api_hosting_resources && var.api_autoscaling_enabled ? 1 : 0
+
+  max_capacity       = var.api_autoscaling_max_capacity
+  min_capacity       = var.api_autoscaling_min_capacity
+  resource_id        = "service/${aws_ecs_cluster.api[0].name}/${aws_ecs_service.api[0].name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "api_cpu" {
+  count = var.create_api_hosting_resources && var.api_autoscaling_enabled ? 1 : 0
+
+  name               = "${local.api_service_name}-cpu"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.api[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.api[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.api[0].service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    target_value = var.api_autoscaling_target_cpu_percent
+
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+  }
+}

--- a/deploy/aws/terraform/api_hosting.tf
+++ b/deploy/aws/terraform/api_hosting.tf
@@ -187,9 +187,9 @@ resource "terraform_data" "api_inputs" {
 
     precondition {
       condition = length(local.api_runtime_cors_allowed_origins) > 0 && alltrue([
-        for origin in local.api_runtime_cors_allowed_origins : can(regex("^https://[^, ]+$", origin))
+        for origin in local.api_runtime_cors_allowed_origins : can(regex("^https://[A-Za-z0-9.-]+(:[0-9]{1,5})?$", origin))
       ])
-      error_message = "API hosting requires IDENTRAIL_CORS_ALLOWED_ORIGINS to contain at least one HTTPS web origin."
+      error_message = "API hosting requires IDENTRAIL_CORS_ALLOWED_ORIGINS to contain at least one bare HTTPS web origin without paths, queries, fragments, or trailing slashes."
     }
 
     precondition {

--- a/deploy/aws/terraform/api_hosting.tf
+++ b/deploy/aws/terraform/api_hosting.tf
@@ -22,6 +22,8 @@ locals {
     IDENTRAIL_CORS_ALLOWED_ORIGINS = local.api_cors_allowed_origins
     IDENTRAIL_HTTP_ADDR            = ":${var.api_container_port}"
     IDENTRAIL_REQUIRE_LIVE_SOURCES = "true"
+    IDENTRAIL_RUN_MIGRATIONS       = "false"
+    IDENTRAIL_RUN_MIGRATIONS_ONLY  = "false"
     IDENTRAIL_TRUSTED_PROXIES      = local.api_trusted_proxies
   }
   api_runtime_environment_variables = merge(local.api_default_environment_variables, var.api_environment_variables)
@@ -210,6 +212,16 @@ resource "terraform_data" "api_inputs" {
     precondition {
       condition     = lower(local.api_runtime_environment_variables["IDENTRAIL_REQUIRE_LIVE_SOURCES"]) == "true"
       error_message = "API hosting requires IDENTRAIL_REQUIRE_LIVE_SOURCES=true so hosted ECS tasks cannot serve fixture-backed scans."
+    }
+
+    precondition {
+      condition     = lower(local.api_runtime_environment_variables["IDENTRAIL_RUN_MIGRATIONS"]) == "false"
+      error_message = "API hosting requires IDENTRAIL_RUN_MIGRATIONS=false so long-running ECS tasks do not run schema migrations during startup."
+    }
+
+    precondition {
+      condition     = lower(local.api_runtime_environment_variables["IDENTRAIL_RUN_MIGRATIONS_ONLY"]) == "false"
+      error_message = "API hosting requires IDENTRAIL_RUN_MIGRATIONS_ONLY=false so long-running ECS tasks start the API server."
     }
 
     precondition {

--- a/deploy/aws/terraform/api_hosting.tf
+++ b/deploy/aws/terraform/api_hosting.tf
@@ -68,17 +68,17 @@ resource "terraform_data" "api_inputs" {
     }
 
     precondition {
-      condition = length(var.api_public_subnet_ids) >= 2 && alltrue([
+      condition = length(distinct(var.api_public_subnet_ids)) >= 2 && alltrue([
         for subnet_id in var.api_public_subnet_ids : can(regex("^subnet-[0-9a-f]+$", subnet_id))
       ])
-      error_message = "api_public_subnet_ids must include at least two valid subnet IDs when create_api_hosting_resources=true."
+      error_message = "api_public_subnet_ids must include at least two distinct valid subnet IDs, preferably in different Availability Zones, when create_api_hosting_resources=true."
     }
 
     precondition {
-      condition = length(var.api_private_subnet_ids) >= 2 && alltrue([
+      condition = length(distinct(var.api_private_subnet_ids)) >= 2 && alltrue([
         for subnet_id in var.api_private_subnet_ids : can(regex("^subnet-[0-9a-f]+$", subnet_id))
       ])
-      error_message = "api_private_subnet_ids must include at least two valid subnet IDs when create_api_hosting_resources=true."
+      error_message = "api_private_subnet_ids must include at least two distinct valid subnet IDs when create_api_hosting_resources=true."
     }
 
     precondition {

--- a/deploy/aws/terraform/environments/dev/terraform.tfvars.example
+++ b/deploy/aws/terraform/environments/dev/terraform.tfvars.example
@@ -16,6 +16,12 @@ log_retention_days    = 30
 # api_private_subnet_ids = ["<private-subnet-a>", "<private-subnet-b>"]
 # api_certificate_arn    = "<api-certificate-arn>"
 # api_container_image    = "ghcr.io/identrail/identrail-api:<immutable-release-tag>"
+# api_cors_allowed_origins = [
+#   "https://app.identrail.com",
+#   "https://identrail.com",
+#   "https://www.identrail.com",
+# ]
+# api_trusted_proxy_cidr_blocks = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
 # Non-secret task settings only. Put database URLs, API keys, session keys, and
 # OAuth/webhook/HMAC secrets in api_secrets instead.
 # api_environment_variables = {

--- a/deploy/aws/terraform/environments/dev/terraform.tfvars.example
+++ b/deploy/aws/terraform/environments/dev/terraform.tfvars.example
@@ -4,9 +4,31 @@ name_prefix = "identrail"
 
 # Keep false until the API hosting stack and rollback runbook are ready.
 create_foundation_resources = false
+create_api_hosting_resources = false
 
 create_runtime_secret = true
 log_retention_days    = 30
+
+# API hosting inputs are intentionally placeholders until an operator is ready
+# to run a manual plan/apply for AWS API hosting.
+# api_vpc_id             = "<vpc-id>"
+# api_public_subnet_ids  = ["<public-subnet-a>", "<public-subnet-b>"]
+# api_private_subnet_ids = ["<private-subnet-a>", "<private-subnet-b>"]
+# api_certificate_arn    = "<api-certificate-arn>"
+# api_container_image    = "ghcr.io/identrail/identrail-api:<immutable-release-tag>"
+# Non-secret task settings only. Put database URLs, API keys, session keys, and
+# OAuth/webhook/HMAC secrets in api_secrets instead.
+# api_environment_variables = {
+#   IDENTRAIL_PUBLIC_BASE_URL = "https://app.identrail.com"
+# }
+# api_secrets = {
+#   IDENTRAIL_DATABASE_URL    = "<database-url-secret-arn>"
+#   IDENTRAIL_API_KEY_SCOPES  = "<api-key-scopes-secret-arn>"
+#   # Optional but recommended for tenant/workspace isolation.
+#   # IDENTRAIL_API_KEY_SCOPE_BINDINGS = "<api-key-scope-bindings-secret-arn>"
+# }
+# api_secret_kms_key_arns = ["<secret-kms-key-arn>"]
+# api_connector_role_arns = ["<connector-role-arn>"]
 
 tags = {
   Project = "identrail"

--- a/deploy/aws/terraform/environments/dev/terraform.tfvars.example
+++ b/deploy/aws/terraform/environments/dev/terraform.tfvars.example
@@ -14,6 +14,7 @@ log_retention_days    = 30
 # api_vpc_id             = "<vpc-id>"
 # api_public_subnet_ids  = ["<public-subnet-a>", "<public-subnet-b>"]
 # api_private_subnet_ids = ["<private-subnet-a>", "<private-subnet-b>"]
+# api_private_subnet_egress_ready = true
 # api_certificate_arn    = "<api-certificate-arn>"
 # api_container_image    = "ghcr.io/identrail/identrail-api:<immutable-release-tag>"
 # api_cors_allowed_origins = [

--- a/deploy/aws/terraform/main.tf
+++ b/deploy/aws/terraform/main.tf
@@ -1,5 +1,9 @@
 locals {
   service_names = toset(["api", "worker"])
+  enabled_service_names = setunion(
+    var.create_foundation_resources ? local.service_names : toset([]),
+    var.create_api_hosting_resources ? toset(["api"]) : toset([])
+  )
   runtime_secret_name = length(trimspace(var.runtime_secret_name)) > 0 ? trimspace(var.runtime_secret_name) : (
     "${var.name_prefix}/${var.environment}/runtime"
   )
@@ -22,7 +26,7 @@ provider "aws" {
 }
 
 resource "aws_cloudwatch_log_group" "service" {
-  for_each = var.create_foundation_resources ? local.service_names : toset([])
+  for_each = local.enabled_service_names
 
   name              = "/${var.name_prefix}/${var.environment}/${each.key}"
   retention_in_days = var.log_retention_days

--- a/deploy/aws/terraform/outputs.tf
+++ b/deploy/aws/terraform/outputs.tf
@@ -12,3 +12,23 @@ output "runtime_secret_name" {
   description = "Secrets Manager secret metadata name for future runtime configuration."
   value       = try(aws_secretsmanager_secret.runtime[0].name, local.runtime_secret_name)
 }
+
+output "api_hosting_enabled" {
+  description = "Whether this plan creates the AWS API hosting layer."
+  value       = var.create_api_hosting_resources
+}
+
+output "api_load_balancer_dns_name" {
+  description = "DNS name for the API application load balancer when API hosting is enabled."
+  value       = try(aws_lb.api[0].dns_name, null)
+}
+
+output "api_ecs_cluster_name" {
+  description = "ECS cluster name for the API service when API hosting is enabled."
+  value       = try(aws_ecs_cluster.api[0].name, null)
+}
+
+output "api_service_name" {
+  description = "ECS service name for the API service when API hosting is enabled."
+  value       = try(aws_ecs_service.api[0].name, local.api_service_name)
+}

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -278,7 +278,7 @@ variable "api_environment_variables" {
 }
 
 variable "api_secrets" {
-  description = "Map of API environment variable names to Secrets Manager secret ARNs. Values are references only, not secret material."
+  description = "Map of API environment variable names to Secrets Manager secret ARNs or ECS valueFrom selectors. Values are references only, not secret material."
   type        = map(string)
   default     = {}
   validation {

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -122,6 +122,38 @@ variable "api_allowed_cidr_blocks" {
   }
 }
 
+variable "api_cors_allowed_origins" {
+  description = "HTTPS web origins allowed to call the hosted API from browsers. Defaults to Identrail Cloud web origins."
+  type        = list(string)
+  default = [
+    "https://app.identrail.com",
+    "https://identrail.com",
+    "https://www.identrail.com",
+  ]
+  validation {
+    condition = alltrue([
+      for origin in var.api_cors_allowed_origins : can(regex("^https://[^, ]+$", origin))
+    ])
+    error_message = "api_cors_allowed_origins must contain HTTPS origins such as https://app.identrail.com."
+  }
+}
+
+variable "api_trusted_proxy_cidr_blocks" {
+  description = "CIDR blocks for ALB/VPC proxy IPs trusted by the hosted API when reading X-Forwarded-For."
+  type        = list(string)
+  default = [
+    "10.0.0.0/8",
+    "172.16.0.0/12",
+    "192.168.0.0/16",
+  ]
+  validation {
+    condition = alltrue([
+      for cidr_block in var.api_trusted_proxy_cidr_blocks : can(cidrhost(cidr_block, 0)) && can(cidrnetmask(cidr_block))
+    ])
+    error_message = "api_trusted_proxy_cidr_blocks must contain valid IPv4 CIDR blocks."
+  }
+}
+
 variable "api_certificate_arn" {
   description = "ACM certificate ARN for the API HTTPS listener. Required when create_api_hosting_resources=true."
   type        = string

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -87,7 +87,7 @@ variable "api_vpc_id" {
 }
 
 variable "api_public_subnet_ids" {
-  description = "Public subnet IDs for the API application load balancer. Provide at least two distinct subnets in different Availability Zones when API hosting is enabled."
+  description = "Public subnet IDs for the API application load balancer. Provide at least two distinct subnets in different Availability Zones with Internet Gateway default routes when API hosting is enabled."
   type        = list(string)
   default     = []
   validation {

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -138,9 +138,9 @@ variable "api_cors_allowed_origins" {
   ]
   validation {
     condition = alltrue([
-      for origin in var.api_cors_allowed_origins : can(regex("^https://[^, ]+$", origin))
+      for origin in var.api_cors_allowed_origins : can(regex("^https://[A-Za-z0-9.-]+(:[0-9]{1,5})?$", origin))
     ])
-    error_message = "api_cors_allowed_origins must contain HTTPS origins such as https://app.identrail.com."
+    error_message = "api_cors_allowed_origins must contain bare HTTPS origins without paths, queries, fragments, or trailing slashes, such as https://app.identrail.com."
   }
 }
 

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -87,26 +87,26 @@ variable "api_vpc_id" {
 }
 
 variable "api_public_subnet_ids" {
-  description = "Public subnet IDs for the API application load balancer. Provide at least two subnets when API hosting is enabled."
+  description = "Public subnet IDs for the API application load balancer. Provide at least two distinct subnets in different Availability Zones when API hosting is enabled."
   type        = list(string)
   default     = []
   validation {
-    condition = alltrue([
+    condition = length(var.api_public_subnet_ids) == length(distinct(var.api_public_subnet_ids)) && alltrue([
       for subnet_id in var.api_public_subnet_ids : can(regex("^subnet-[0-9a-f]+$", subnet_id))
     ])
-    error_message = "api_public_subnet_ids must contain valid subnet IDs."
+    error_message = "api_public_subnet_ids must contain distinct valid subnet IDs."
   }
 }
 
 variable "api_private_subnet_ids" {
-  description = "Private subnet IDs for the API ECS tasks. Provide at least two subnets when API hosting is enabled."
+  description = "Private subnet IDs for the API ECS tasks. Provide at least two distinct subnets when API hosting is enabled."
   type        = list(string)
   default     = []
   validation {
-    condition = alltrue([
+    condition = length(var.api_private_subnet_ids) == length(distinct(var.api_private_subnet_ids)) && alltrue([
       for subnet_id in var.api_private_subnet_ids : can(regex("^subnet-[0-9a-f]+$", subnet_id))
     ])
-    error_message = "api_private_subnet_ids must contain valid subnet IDs."
+    error_message = "api_private_subnet_ids must contain distinct valid subnet IDs."
   }
 }
 

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -69,3 +69,266 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "create_api_hosting_resources" {
+  description = "Create the AWS ECS/Fargate API hosting layer. Keep false until operator inputs, secrets, database, and DNS are ready."
+  type        = bool
+  default     = false
+}
+
+variable "api_vpc_id" {
+  description = "VPC ID for the API load balancer and ECS service. Required when create_api_hosting_resources=true."
+  type        = string
+  default     = ""
+  validation {
+    condition     = length(trimspace(var.api_vpc_id)) == 0 || can(regex("^vpc-[0-9a-f]+$", var.api_vpc_id))
+    error_message = "api_vpc_id must be blank or a valid VPC ID."
+  }
+}
+
+variable "api_public_subnet_ids" {
+  description = "Public subnet IDs for the API application load balancer. Provide at least two subnets when API hosting is enabled."
+  type        = list(string)
+  default     = []
+  validation {
+    condition = alltrue([
+      for subnet_id in var.api_public_subnet_ids : can(regex("^subnet-[0-9a-f]+$", subnet_id))
+    ])
+    error_message = "api_public_subnet_ids must contain valid subnet IDs."
+  }
+}
+
+variable "api_private_subnet_ids" {
+  description = "Private subnet IDs for the API ECS tasks. Provide at least two subnets when API hosting is enabled."
+  type        = list(string)
+  default     = []
+  validation {
+    condition = alltrue([
+      for subnet_id in var.api_private_subnet_ids : can(regex("^subnet-[0-9a-f]+$", subnet_id))
+    ])
+    error_message = "api_private_subnet_ids must contain valid subnet IDs."
+  }
+}
+
+variable "api_allowed_cidr_blocks" {
+  description = "IPv4 CIDR blocks allowed to reach the public API load balancer."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+  validation {
+    condition = alltrue([
+      for cidr_block in var.api_allowed_cidr_blocks : can(cidrhost(cidr_block, 0)) && can(cidrnetmask(cidr_block))
+    ])
+    error_message = "api_allowed_cidr_blocks must contain valid IPv4 CIDR blocks."
+  }
+}
+
+variable "api_certificate_arn" {
+  description = "ACM certificate ARN for the API HTTPS listener. Required when create_api_hosting_resources=true."
+  type        = string
+  default     = ""
+  validation {
+    condition = length(trimspace(var.api_certificate_arn)) == 0 || can(regex(
+      "^arn:(aws|aws-us-gov|aws-cn):acm:[a-z]{2}(-gov)?-[a-z]+-[0-9]+:[0-9]{12}:certificate/.+$",
+      var.api_certificate_arn
+    ))
+    error_message = "api_certificate_arn must be blank or an ACM certificate ARN."
+  }
+}
+
+variable "api_tls_policy" {
+  description = "TLS policy for the API HTTPS listener."
+  type        = string
+  default     = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+}
+
+variable "api_enable_http_redirect" {
+  description = "Create an HTTP listener that redirects port 80 to HTTPS."
+  type        = bool
+  default     = true
+}
+
+variable "api_load_balancer_deletion_protection" {
+  description = "Enable deletion protection on the API load balancer."
+  type        = bool
+  default     = false
+}
+
+variable "api_container_image" {
+  description = "Immutable Identrail API container image reference. Required when create_api_hosting_resources=true."
+  type        = string
+  default     = ""
+  validation {
+    condition     = length(var.api_container_image) == length(trimspace(var.api_container_image))
+    error_message = "api_container_image must not have leading or trailing whitespace."
+  }
+}
+
+variable "api_container_port" {
+  description = "Port exposed by the Identrail API container."
+  type        = number
+  default     = 8080
+  validation {
+    condition     = var.api_container_port > 0 && var.api_container_port < 65536
+    error_message = "api_container_port must be a valid TCP port."
+  }
+}
+
+variable "api_health_check_path" {
+  description = "HTTP path the load balancer uses to check API health."
+  type        = string
+  default     = "/healthz"
+  validation {
+    condition     = startswith(var.api_health_check_path, "/")
+    error_message = "api_health_check_path must start with /."
+  }
+}
+
+variable "api_health_check_grace_period_seconds" {
+  description = "Seconds ECS should wait before enforcing load balancer health checks after task start."
+  type        = number
+  default     = 60
+  validation {
+    condition     = var.api_health_check_grace_period_seconds >= 0 && var.api_health_check_grace_period_seconds <= 7200
+    error_message = "api_health_check_grace_period_seconds must be between 0 and 7200."
+  }
+}
+
+variable "api_task_cpu" {
+  description = "Fargate CPU units for the API task."
+  type        = number
+  default     = 512
+}
+
+variable "api_task_memory" {
+  description = "Fargate memory in MiB for the API task."
+  type        = number
+  default     = 1024
+}
+
+variable "api_desired_count" {
+  description = "Desired number of API tasks."
+  type        = number
+  default     = 1
+  validation {
+    condition     = var.api_desired_count >= 1 && var.api_desired_count <= 100
+    error_message = "api_desired_count must be between 1 and 100."
+  }
+}
+
+variable "api_environment_variables" {
+  description = "Non-secret environment variables for the API task definition."
+  type        = map(string)
+  default     = {}
+  validation {
+    condition = alltrue([
+      for name in keys(var.api_environment_variables) : !contains([
+        "IDENTRAIL_ALERT_HMAC_SECRET",
+        "IDENTRAIL_API_KEYS",
+        "IDENTRAIL_API_KEY_SCOPE_BINDINGS",
+        "IDENTRAIL_API_KEY_SCOPES",
+        "IDENTRAIL_AUDIT_FINGERPRINT_SECRET",
+        "IDENTRAIL_AUDIT_FORWARD_HMAC_SECRET",
+        "IDENTRAIL_CONNECTOR_SECRET_KEYS",
+        "IDENTRAIL_DATABASE_URL",
+        "IDENTRAIL_EMAIL_API_KEY",
+        "IDENTRAIL_GITHUB_APP_PRIVATE_KEY",
+        "IDENTRAIL_GITHUB_APP_WEBHOOK_SECRET",
+        "IDENTRAIL_METRICS_API_KEY",
+        "IDENTRAIL_SESSION_KEY",
+        "IDENTRAIL_SESSION_KEY_PREVIOUS",
+        "IDENTRAIL_WORKOS_API_KEY",
+        "IDENTRAIL_WORKOS_WEBHOOK_SECRET",
+        "IDENTRAIL_WRITE_API_KEYS",
+      ], name)
+    ])
+    error_message = "api_environment_variables is for non-secret settings only. Put database URLs, API keys, session keys, OAuth/webhook secrets, and HMAC secrets in api_secrets."
+  }
+}
+
+variable "api_secrets" {
+  description = "Map of API environment variable names to Secrets Manager secret ARNs. Values are references only, not secret material."
+  type        = map(string)
+  default     = {}
+  validation {
+    condition = alltrue([
+      for name, value_from in var.api_secrets :
+      can(regex("^[A-Z][A-Z0-9_]*$", name)) &&
+      can(regex("^arn:(aws|aws-us-gov|aws-cn):secretsmanager:[a-z]{2}(-gov)?-[a-z]+-[0-9]+:[0-9]{12}:secret:.+$", value_from))
+    ])
+    error_message = "api_secrets must map uppercase environment variable names to Secrets Manager secret ARNs."
+  }
+}
+
+variable "api_secret_kms_key_arns" {
+  description = "Customer-managed KMS key ARNs needed to decrypt API Secrets Manager references during ECS secret injection. Leave empty when referenced secrets use AWS-managed keys."
+  type        = list(string)
+  default     = []
+  validation {
+    condition = alltrue([
+      for key_arn in var.api_secret_kms_key_arns :
+      can(regex("^arn:(aws|aws-us-gov|aws-cn):kms:[a-z]{2}(-gov)?-[a-z]+-[0-9]+:[0-9]{12}:key/.+$", key_arn))
+    ])
+    error_message = "api_secret_kms_key_arns must contain KMS key ARNs."
+  }
+}
+
+variable "api_connector_role_arns" {
+  description = "AWS connector role ARNs the hosted API task may assume for connector validation and recurring scans. Leave empty until connector roles are ready."
+  type        = list(string)
+  default     = []
+  validation {
+    condition = alltrue([
+      for role_arn in var.api_connector_role_arns :
+      can(regex("^arn:(aws|aws-us-gov|aws-cn):iam::[0-9]{12}:role/.+$", role_arn))
+    ])
+    error_message = "api_connector_role_arns must contain IAM role ARNs."
+  }
+}
+
+variable "api_container_insights_enabled" {
+  description = "Enable ECS Container Insights for the API cluster."
+  type        = bool
+  default     = true
+}
+
+variable "api_enable_execute_command" {
+  description = "Enable ECS Exec for break-glass debugging. Leave false unless operator access controls and audit expectations are ready."
+  type        = bool
+  default     = false
+}
+
+variable "api_autoscaling_enabled" {
+  description = "Enable target-tracking autoscaling for the API ECS service."
+  type        = bool
+  default     = true
+}
+
+variable "api_autoscaling_min_capacity" {
+  description = "Minimum API task count when autoscaling is enabled."
+  type        = number
+  default     = 1
+  validation {
+    condition     = var.api_autoscaling_min_capacity >= 1
+    error_message = "api_autoscaling_min_capacity must be at least 1."
+  }
+}
+
+variable "api_autoscaling_max_capacity" {
+  description = "Maximum API task count when autoscaling is enabled."
+  type        = number
+  default     = 4
+  validation {
+    condition     = var.api_autoscaling_max_capacity >= 1
+    error_message = "api_autoscaling_max_capacity must be at least 1."
+  }
+}
+
+variable "api_autoscaling_target_cpu_percent" {
+  description = "Average CPU utilization target for API autoscaling."
+  type        = number
+  default     = 60
+  validation {
+    condition     = var.api_autoscaling_target_cpu_percent >= 10 && var.api_autoscaling_target_cpu_percent <= 90
+    error_message = "api_autoscaling_target_cpu_percent must be between 10 and 90."
+  }
+}

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -110,6 +110,12 @@ variable "api_private_subnet_ids" {
   }
 }
 
+variable "api_private_subnet_egress_ready" {
+  description = "Set true only after private API subnets have NAT egress or VPC endpoints for ECR, Secrets Manager, and CloudWatch Logs. Required when API hosting is enabled because Fargate tasks run with assign_public_ip=false."
+  type        = bool
+  default     = false
+}
+
 variable "api_allowed_cidr_blocks" {
   description = "IPv4 CIDR blocks allowed to reach the public API load balancer."
   type        = list(string)

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - Deployment runbook: `deploy-runbook.md`
 - AWS OIDC deployment role: `aws-oidc-deployment.md`
 - AWS deployment foundation: `aws-deployment-foundation.md`
+- AWS API hosting: `aws-api-hosting.md`
 
 ## Operator track
 
@@ -20,6 +21,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
   - `../deploy/helm/README.md`
   - `../deploy/terraform/README.md`
   - `../deploy/aws/README.md`
+  - `aws-api-hosting.md`
 - Day-2 operations:
   - `observability.md`
   - `troubleshooting.md`

--- a/docs/auth/production-api-readiness.md
+++ b/docs/auth/production-api-readiness.md
@@ -29,6 +29,8 @@ Before wiring the frontend to the production API URL, the API deployment must ex
 - `GET /readyz` returning `200` only after runtime dependencies are ready
 - `GET /v1/auth/config` returning JSON, not the web HTML shell
 - `IDENTRAIL_CORS_ALLOWED_ORIGINS` containing the web origins that need browser access
+- `IDENTRAIL_TRUSTED_PROXIES` containing the ALB/VPC proxy CIDRs so rate limits
+  and audit events use the real browser client IP from `X-Forwarded-For`
 - `IDENTRAIL_PUBLIC_BASE_URL` set to the API origin when WorkOS callbacks terminate at the API
 - `IDENTRAIL_SESSION_KEY` set from at least 32 bytes of secret key material
 - persistent storage through `IDENTRAIL_DATABASE_URL`
@@ -37,6 +39,7 @@ For Identrail Cloud, the first production API deployment should use:
 
 ```text
 IDENTRAIL_CORS_ALLOWED_ORIGINS=https://identrail.com,https://www.identrail.com,https://app.identrail.com
+IDENTRAIL_TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 IDENTRAIL_PUBLIC_BASE_URL=https://api.identrail.com
 VITE_IDENTRAIL_API_URL=https://api.identrail.com
 ```

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -43,6 +43,9 @@ Before a manual apply, operators must provide:
   tables with an Internet Gateway default route
 - `api_private_subnet_ids` for Fargate tasks, with at least two distinct private
   subnets that belong to `api_vpc_id`
+- `api_private_subnet_egress_ready=true` after confirming those private subnets
+  have NAT egress or VPC endpoints for ECR, Secrets Manager, CloudWatch Logs,
+  and S3 image-layer access; API tasks run with `assign_public_ip=false`
 - `api_certificate_arn` for HTTPS on `api.identrail.com`
 - `api_container_image` pinned to an immutable release tag
 - `api_cors_allowed_origins`, defaulting to the Identrail Cloud web origins
@@ -78,6 +81,11 @@ refuse to plan API hosting without a database reference and at least one auth
 mode so ECS tasks do not boot into a known-bad configuration. It also refuses to
 plan API hosting without at least one HTTPS CORS origin and at least one trusted
 proxy CIDR.
+
+Terraform requires `api_private_subnet_egress_ready=true` before creating API
+hosting resources. Use that only after the private task subnets can pull the
+image, read injected secrets, and write logs through NAT or private VPC
+endpoints.
 
 Leave `api_connector_role_arns` empty for the first single-account API hosting
 plan. Populate it later with reviewed AWS connector role ARNs when the hosted API

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -37,7 +37,9 @@ Before a manual apply, operators must provide:
 
 - `api_vpc_id`
 - `api_public_subnet_ids` for the load balancer, with at least two distinct
-  public subnets in different Availability Zones
+  public subnets in different Availability Zones; Terraform reads the subnet
+  metadata and refuses to plan API hosting when the public subnets collapse to
+  one Availability Zone
 - `api_private_subnet_ids` for Fargate tasks, with at least two distinct private
   subnets
 - `api_certificate_arn` for HTTPS on `api.identrail.com`

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -51,7 +51,9 @@ Before a manual apply, operators must provide:
   and S3 image-layer access; API tasks run with `assign_public_ip=false`
 - `api_certificate_arn` for HTTPS on `api.identrail.com`
 - `api_container_image` pinned to an immutable release tag
-- `api_cors_allowed_origins`, defaulting to the Identrail Cloud web origins
+- `api_cors_allowed_origins`, defaulting to the Identrail Cloud web origins;
+  entries must be bare HTTPS origins such as `https://app.identrail.com`, not
+  URLs with paths, queries, fragments, or trailing slashes
 - `api_trusted_proxy_cidr_blocks`, defaulting to private VPC ranges used by ALB
   nodes in common AWS VPCs
 - `api_secrets`, including `IDENTRAIL_DATABASE_URL` as a Secrets Manager ARN

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -24,7 +24,9 @@ balancer, `IDENTRAIL_CORS_ALLOWED_ORIGINS` from `api_cors_allowed_origins`, and
 `IDENTRAIL_TRUSTED_PROXIES` from `api_trusted_proxy_cidr_blocks` so browser
 requests from the Vercel app and ALB forwarded client IPs work before DNS
 cutover. Terraform refuses overrides that would move the hosted API back to
-fixture-backed AWS scans.
+fixture-backed AWS scans. It also sets `IDENTRAIL_RUN_MIGRATIONS=false` and
+`IDENTRAIL_RUN_MIGRATIONS_ONLY=false` so rolling ECS API deployments do not run
+schema changes during normal service startup.
 
 The API task role receives the read-only IAM discovery permissions that the live
 AWS collector uses. Cross-account connector access is still explicit: add
@@ -87,6 +89,9 @@ Terraform requires `api_private_subnet_egress_ready=true` before creating API
 hosting resources. Use that only after the private task subnets can pull the
 image, read injected secrets, and write logs through NAT or private VPC
 endpoints.
+
+Run database migrations as a separate one-off operation before deploying or
+upgrading the hosted API service. Keep long-running API tasks non-migrating.
 
 Leave `api_connector_role_arns` empty for the first single-account API hosting
 plan. Populate it later with reviewed AWS connector role ARNs when the hosted API

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -36,8 +36,10 @@ exist and have been reviewed.
 Before a manual apply, operators must provide:
 
 - `api_vpc_id`
-- `api_public_subnet_ids` for the load balancer
-- `api_private_subnet_ids` for Fargate tasks
+- `api_public_subnet_ids` for the load balancer, with at least two distinct
+  public subnets in different Availability Zones
+- `api_private_subnet_ids` for Fargate tasks, with at least two distinct private
+  subnets
 - `api_certificate_arn` for HTTPS on `api.identrail.com`
 - `api_container_image` pinned to an immutable release tag
 - `api_cors_allowed_origins`, defaulting to the Identrail Cloud web origins

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -66,6 +66,9 @@ If a referenced secret uses a customer-managed KMS key, add that key ARN to
 `api_secret_kms_key_arns` so ECS can decrypt the secret during task startup.
 Leave the list empty for secrets encrypted with the AWS-managed Secrets Manager
 key.
+`api_secrets` values can use ECS `valueFrom` selectors such as a JSON key or
+secret version suffix. Terraform still grants IAM access to the base Secrets
+Manager ARN so ECS can fetch the underlying secret during task startup.
 
 For the first manual AWS plan, prefer Secrets Manager references for
 `IDENTRAIL_DATABASE_URL`, `IDENTRAIL_API_KEY_SCOPES`, and, when tenant/workspace

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -39,9 +39,9 @@ Before a manual apply, operators must provide:
 - `api_public_subnet_ids` for the load balancer, with at least two distinct
   public subnets in different Availability Zones; Terraform reads the subnet
   metadata and refuses to plan API hosting when the public subnets collapse to
-  one Availability Zone
+  one Availability Zone or do not belong to `api_vpc_id`
 - `api_private_subnet_ids` for Fargate tasks, with at least two distinct private
-  subnets
+  subnets that belong to `api_vpc_id`
 - `api_certificate_arn` for HTTPS on `api.identrail.com`
 - `api_container_image` pinned to an immutable release tag
 - `api_cors_allowed_origins`, defaulting to the Identrail Cloud web origins

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -39,7 +39,8 @@ Before a manual apply, operators must provide:
 - `api_public_subnet_ids` for the load balancer, with at least two distinct
   public subnets in different Availability Zones; Terraform reads the subnet
   metadata and refuses to plan API hosting when the public subnets collapse to
-  one Availability Zone or do not belong to `api_vpc_id`
+  one Availability Zone, do not belong to `api_vpc_id`, or do not have route
+  tables with an Internet Gateway default route
 - `api_private_subnet_ids` for Fargate tasks, with at least two distinct private
   subnets that belong to `api_vpc_id`
 - `api_certificate_arn` for HTTPS on `api.identrail.com`

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -40,7 +40,8 @@ Before a manual apply, operators must provide:
   public subnets in different Availability Zones; Terraform reads the subnet
   metadata and refuses to plan API hosting when the public subnets collapse to
   one Availability Zone, do not belong to `api_vpc_id`, or do not have route
-  tables with an Internet Gateway default route
+  tables with an Internet Gateway default route; explicit subnet route-table
+  associations and inherited VPC main route tables are both supported
 - `api_private_subnet_ids` for Fargate tasks, with at least two distinct private
   subnets that belong to `api_vpc_id`
 - `api_private_subnet_egress_ready=true` after confirming those private subnets

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -1,0 +1,117 @@
+# AWS API Hosting
+
+This document describes the first AWS API hosting layer for Identrail.
+
+The Terraform remains plan-first and safe by default. CI validates the shape, but
+does not create AWS resources or move production traffic.
+
+## What The Layer Defines
+
+When `create_api_hosting_resources=true`, `deploy/aws/terraform` can create:
+
+- an ECS/Fargate API cluster, task definition, service, and CPU autoscaling
+- an application load balancer with HTTPS listener and optional HTTP redirect
+- security groups that allow public HTTPS to the load balancer and private
+  traffic from the load balancer to the API tasks
+- task execution and task IAM roles
+- CloudWatch logs for API runtime output
+
+The ECS task definition sets production-oriented runtime defaults for the hosted
+API: `IDENTRAIL_AWS_SOURCE=sdk`, `IDENTRAIL_REQUIRE_LIVE_SOURCES=true`, and
+`IDENTRAIL_AWS_REGION` from `aws_region`. It also sets `IDENTRAIL_HTTP_ADDR`
+from `api_container_port` so the app listens on the port exposed to the load
+balancer. Terraform refuses overrides that would move the hosted API back to
+fixture-backed AWS scans.
+
+The API task role receives the read-only IAM discovery permissions that the live
+AWS collector uses. Cross-account connector access is still explicit: add
+approved connector role ARNs to `api_connector_role_arns` only after those roles
+exist and have been reviewed.
+
+## Required Operator Inputs
+
+Before a manual apply, operators must provide:
+
+- `api_vpc_id`
+- `api_public_subnet_ids` for the load balancer
+- `api_private_subnet_ids` for Fargate tasks
+- `api_certificate_arn` for HTTPS on `api.identrail.com`
+- `api_container_image` pinned to an immutable release tag
+- `api_secrets`, including `IDENTRAIL_DATABASE_URL` as a Secrets Manager ARN
+- `api_secret_kms_key_arns` when any referenced secret uses a
+  customer-managed KMS key
+- at least one supported API authentication mode:
+  - scoped API keys with `IDENTRAIL_API_KEY_SCOPES`
+  - legacy keys with both `IDENTRAIL_API_KEYS` and `IDENTRAIL_WRITE_API_KEYS`
+  - OIDC with both `IDENTRAIL_OIDC_ISSUER_URL` and `IDENTRAIL_OIDC_AUDIENCE`
+  - hosted session auth with non-secret `IDENTRAIL_FEATURE_NEW_AUTH=true` and
+    `IDENTRAIL_PUBLIC_BASE_URL`, plus `IDENTRAIL_SESSION_KEY` in `api_secrets`
+
+Do not put database URLs, API keys, cookie secrets, or OAuth credentials directly
+in tfvars files, docs, GitHub variables, or Terraform state. Use Secrets Manager
+references through `api_secrets`. Terraform rejects known secret-bearing
+Identrail variables in `api_environment_variables` when API hosting is enabled.
+
+If a referenced secret uses a customer-managed KMS key, add that key ARN to
+`api_secret_kms_key_arns` so ECS can decrypt the secret during task startup.
+Leave the list empty for secrets encrypted with the AWS-managed Secrets Manager
+key.
+
+For the first manual AWS plan, prefer Secrets Manager references for
+`IDENTRAIL_DATABASE_URL`, `IDENTRAIL_API_KEY_SCOPES`, and, when tenant/workspace
+isolation is ready, `IDENTRAIL_API_KEY_SCOPE_BINDINGS`. The Terraform guard will
+refuse to plan API hosting without a database reference and at least one auth
+mode so ECS tasks do not boot into a known-bad configuration.
+
+Leave `api_connector_role_arns` empty for the first single-account API hosting
+plan. Populate it later with reviewed AWS connector role ARNs when the hosted API
+needs to validate connector setup or run recurring scans through assumed roles.
+
+## Health Checks
+
+The load balancer uses `GET /healthz` by default. Before DNS cutover, verify the
+API with the certificate hostname so TLS SNI and hostname validation match the
+`api.identrail.com` certificate:
+
+```bash
+load_balancer_dns_name="$(terraform -chdir=deploy/aws/terraform output -raw api_load_balancer_dns_name)"
+load_balancer_ip="$(dig +short "$load_balancer_dns_name" | head -n 1)"
+curl -fsS --resolve "api.identrail.com:443:${load_balancer_ip}" \
+  "https://api.identrail.com/healthz"
+```
+
+## DNS Cutover
+
+Do not point `api.identrail.com` at the load balancer until:
+
+- the API health check is passing through the load balancer
+- database migrations have been run in the target environment
+- runtime secrets have been reviewed
+- at least one authenticated API smoke test has passed
+- the frontend `VITE_IDENTRAIL_API_URL` production value is ready for
+  `https://api.identrail.com`
+- rollback has been rehearsed
+
+After those are true, create a DNS record for `api.identrail.com` that targets
+the load balancer DNS name. Keep `app.identrail.com` on Vercel.
+
+## Rollback
+
+If the new API service fails before DNS cutover, destroy or disable only the AWS
+API hosting resources and keep the frontend pointed at the previous API.
+
+If the failure happens after DNS cutover:
+
+1. Point `api.identrail.com` back to the last known-good API target.
+2. Scale the ECS service down only after traffic has drained.
+3. Preserve CloudWatch logs and database snapshots for investigation.
+4. Re-run `GET /healthz` and one authenticated API smoke test on the restored
+   target.
+
+## What Still Comes Later
+
+- production database provisioning and backups
+- runtime secret creation and rotation workflow
+- migration job wiring
+- worker hosting
+- final `api.identrail.com` DNS cutover

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -20,7 +20,10 @@ The ECS task definition sets production-oriented runtime defaults for the hosted
 API: `IDENTRAIL_AWS_SOURCE=sdk`, `IDENTRAIL_REQUIRE_LIVE_SOURCES=true`, and
 `IDENTRAIL_AWS_REGION` from `aws_region`. It also sets `IDENTRAIL_HTTP_ADDR`
 from `api_container_port` so the app listens on the port exposed to the load
-balancer. Terraform refuses overrides that would move the hosted API back to
+balancer, `IDENTRAIL_CORS_ALLOWED_ORIGINS` from `api_cors_allowed_origins`, and
+`IDENTRAIL_TRUSTED_PROXIES` from `api_trusted_proxy_cidr_blocks` so browser
+requests from the Vercel app and ALB forwarded client IPs work before DNS
+cutover. Terraform refuses overrides that would move the hosted API back to
 fixture-backed AWS scans.
 
 The API task role receives the read-only IAM discovery permissions that the live
@@ -37,6 +40,9 @@ Before a manual apply, operators must provide:
 - `api_private_subnet_ids` for Fargate tasks
 - `api_certificate_arn` for HTTPS on `api.identrail.com`
 - `api_container_image` pinned to an immutable release tag
+- `api_cors_allowed_origins`, defaulting to the Identrail Cloud web origins
+- `api_trusted_proxy_cidr_blocks`, defaulting to private VPC ranges used by ALB
+  nodes in common AWS VPCs
 - `api_secrets`, including `IDENTRAIL_DATABASE_URL` as a Secrets Manager ARN
 - `api_secret_kms_key_arns` when any referenced secret uses a
   customer-managed KMS key
@@ -61,7 +67,9 @@ For the first manual AWS plan, prefer Secrets Manager references for
 `IDENTRAIL_DATABASE_URL`, `IDENTRAIL_API_KEY_SCOPES`, and, when tenant/workspace
 isolation is ready, `IDENTRAIL_API_KEY_SCOPE_BINDINGS`. The Terraform guard will
 refuse to plan API hosting without a database reference and at least one auth
-mode so ECS tasks do not boot into a known-bad configuration.
+mode so ECS tasks do not boot into a known-bad configuration. It also refuses to
+plan API hosting without at least one HTTPS CORS origin and at least one trusted
+proxy CIDR.
 
 Leave `api_connector_role_arns` empty for the first single-account API hosting
 plan. Populate it later with reviewed AWS connector role ARNs when the hosted API

--- a/docs/aws-deployment-foundation.md
+++ b/docs/aws-deployment-foundation.md
@@ -4,18 +4,21 @@ The AWS deployment foundation is the step after GitHub OIDC verification.
 
 PR 7A proved that GitHub Actions can request short-lived AWS credentials without
 long-lived access keys. This foundation gives the repository a safe place to
-validate AWS deployment plans before the production API hosting stack is added.
+validate AWS deployment plans before production traffic is moved.
 
 ## What This Does Now
 
 - Adds an AWS Terraform root at `deploy/aws/terraform`.
 - Adds safe, opt-in foundation resources for future API and worker hosting.
+- Adds a safe, opt-in API hosting layer for ECS/Fargate, HTTPS load balancing,
+  task roles, logs, health checks, and autoscaling.
 - Adds a dev workflow that assumes the AWS OIDC role and runs Terraform plan.
 - Keeps `terraform apply` manual and out of CI.
 
 ## What It Does Not Do Yet
 
-- It does not deploy the Identrail API to AWS.
+- It does not deploy the Identrail API to AWS unless an operator explicitly
+  enables `create_api_hosting_resources=true` and runs a manual apply.
 - It does not create a production database.
 - It does not change `app.identrail.com` or `api.identrail.com`.
 - It does not move traffic away from the current Vercel deployment.
@@ -24,11 +27,13 @@ validate AWS deployment plans before the production API hosting stack is added.
 
 The first AWS deployment PR should prove the path without spending money or
 creating surprise infrastructure. The Terraform root defaults
-`create_foundation_resources=false`, so CI can validate the stack and later PRs
-can intentionally enable resources when the API hosting design is ready.
+`create_foundation_resources=false` and
+`create_api_hosting_resources=false`, so CI can validate the stack without
+creating spend. Operators can intentionally enable each resource group when the
+API hosting design, secrets, database, image tag, and rollback plan are ready.
 
 ## Next Deployment Step
 
-The next PR should add the actual API hosting layer on top of this foundation,
-including service shape, database connectivity, runtime secrets, health checks,
-and rollback instructions.
+The next deployment step is a manual AWS plan for a real environment, then the
+database, runtime secrets, migration path, and `api.identrail.com` DNS cutover.
+See `aws-api-hosting.md`.

--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -9,6 +9,7 @@ Portable deployment profiles:
 - Guide: `docs/deployment-anywhere.md`
 - AWS OIDC deployment role: `docs/aws-oidc-deployment.md`
 - AWS deployment foundation: `docs/aws-deployment-foundation.md`
+- AWS API hosting: `docs/aws-api-hosting.md`
 - Operator readiness: `docs/operator-readiness.md`
 - Troubleshooting playbook: `docs/troubleshooting.md`
 - Incident workflow: `docs/incident-response.md`
@@ -96,6 +97,14 @@ Portable deployment profiles:
    - trigger `POST /v1/repo-scans`
    - verify `GET /v1/repo-scans`
    - verify `GET /v1/repo-findings?repo_scan_id=<id>`
+
+### AWS API Hosting Notes
+
+For AWS-hosted API rollout, keep `create_api_hosting_resources=false` until the
+VPC, subnets, ACM certificate, immutable API image, database, and Secrets
+Manager references are ready. Plan the stack first, verify the load balancer
+health endpoint, and only then point `api.identrail.com` at the load balancer.
+Keep `app.identrail.com` on Vercel.
 
 ## 3) Rollback Sequence
 


### PR DESCRIPTION
Fixes #1101

## What changed

- Added a safe, opt-in AWS API hosting layer under `deploy/aws/terraform/api_hosting.tf`.
- Defined ECS/Fargate API service primitives, HTTPS load balancer, target group, security groups, task roles, task definition, CloudWatch log wiring, deployment circuit breaker, and CPU autoscaling.
- Kept resource creation disabled by default with `create_api_hosting_resources=false`.
- Documented operator inputs, Secrets Manager references, health checks, rollback, and the future `api.identrail.com` DNS cutover path.

## Why it changed

Identrail had AWS OIDC verification and a Terraform foundation, but no concrete API hosting shape for AWS. This PR gives the project a reviewable, plan-first API runtime layer without applying infrastructure or moving production traffic.

## Impact and risk

- Backward compatible: default plans still create no AWS resources.
- No secret values are added; docs use placeholder ARNs only.
- No DNS cutover or Vercel app changes happen in this PR.
- Operators must still provide real VPC/subnet/certificate/image/secret inputs before any manual apply.

## Validation performed

- `terraform fmt -check -recursive deploy/aws/terraform` passed.
- `terraform init -backend=false` passed in `deploy/aws/terraform`.
- `terraform validate` passed in `deploy/aws/terraform`.
- `terraform plan -refresh=false -input=false -var-file=environments/dev/terraform.tfvars.example -var='aws_region=us-east-1'` passed and creates no infrastructure.
- Dummy opt-in API hosting plan passed with placeholder VPC, subnet, ACM, image, and Secrets Manager references.
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -shellcheck= .github/workflows/aws-deployment-foundation.yml` passed.
- YAML parse check for `.github/workflows/aws-deployment-foundation.yml` passed.
- `git diff --check` passed.
- Commit and push hooks passed, including `go vet`.

AI-assisted: yes
Tools used: Codex
Where used: AWS Terraform and deployment documentation
Human verification performed: reviewed diff and ran the validation commands listed above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt‑in AWS API hosting layer in Terraform (ECS/Fargate + HTTPS ALB) with strict input, secret, auth, CORS (bare HTTPS origins only), proxy, and migration guards. Validates VPC/subnets (AZ spread, VPC membership, and IGW routes via explicit subnet tables or inherited VPC main route tables), requires private‑subnet egress readiness, and checks the ACM certificate partition; off by default for plan‑first, cost‑safe CI. Fixes #1101.

- New Features
  - Added `deploy/aws/terraform/api_hosting.tf`: ECS cluster/service/task, HTTPS ALB with optional HTTP→HTTPS redirect, security groups, IAM roles, CloudWatch logs, CPU autoscaling, deployment circuit breaker, optional ECS Exec, and Container Insights.
  - Inputs/guards: require VPC; ≥2 distinct public subnets in different AZs; ≥2 distinct private subnets; all subnets in the VPC; public LB subnets must have a 0.0.0.0/0 IGW route (explicit or inherited VPC main route table); operator‑confirmed private‑subnet egress; ACM cert ARN partition match; immutable `api_container_image`; `IDENTRAIL_DATABASE_URL` via Secrets Manager; valid Fargate CPU/mem; one auth mode (scoped keys, legacy keys, OIDC, or session auth with `IDENTRAIL_FEATURE_NEW_AUTH=true`, `IDENTRAIL_PUBLIC_BASE_URL`, `IDENTRAIL_SESSION_KEY`); enforce `IDENTRAIL_AWS_SOURCE=sdk`, `IDENTRAIL_REQUIRE_LIVE_SOURCES=true`, CORS as bare HTTPS origins only (no paths), trusted ALB/VPC proxy CIDRs, and both `IDENTRAIL_RUN_MIGRATIONS=false` and `IDENTRAIL_RUN_MIGRATIONS_ONLY=false`; reject known secret vars in `api_environment_variables`.
  - Runtime defaults: bind `IDENTRAIL_HTTP_ADDR` to `api_container_port`; set `IDENTRAIL_CORS_ALLOWED_ORIGINS` and `IDENTRAIL_TRUSTED_PROXIES` so browser calls and real client IPs work through ALB.
  - Secrets/connectors: inject via `api_secrets` with optional CMK decrypt grants in `api_secret_kms_key_arns`; IAM grants on base Secrets Manager ARNs so ECS can resolve JSON-key/version selectors; task role includes read‑only IAM discovery and optional `sts:AssumeRole` limited to `api_connector_role_arns`.
  - Gating/observability/outputs: gated by `create_api_hosting_resources` (default false); CloudWatch log groups follow enabled services; outputs include `api_hosting_enabled`, ALB DNS, ECS cluster, and ECS service. Docs: `docs/aws-api-hosting.md`; READMEs and runbook updated.

- Migration
  - Keep `create_api_hosting_resources=false` until VPC, subnets (≥2 AZ public, ≥2 private in the same VPC) with IGW routes (explicit or inherited), NAT/VPC endpoint egress (`api_private_subnet_egress_ready=true`), ACM cert, image tag, database, and secrets are ready. Plan with both `create_foundation_resources=true` and `create_api_hosting_resources=true`; verify `GET /healthz` via ALB DNS (with SNI) before pointing `api.identrail.com`. Run schema migrations separately; long‑running tasks are non‑migrating by design. Enable ECS Exec only when operator access/audit are ready; keep `api_connector_role_arns=[]` until reviewed roles exist.

<sup>Written for commit 8b1598643f471003f9256c2621d2711ec4e17619. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

