### PR TITLE
fix(docker): keep quickstart database internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ Open `http://localhost:8081` for the web UI.
 `docker pull` by itself only downloads images into Docker; it does not create a
 project directory or the Compose file needed to start the full stack.
 
-The no-clone public quickstart keeps the API on `http://localhost:8080`; only
-the web and Postgres host ports are intended to be customized in that profile.
+The no-clone public quickstart keeps the API on `http://localhost:8080` and
+publishes only the web UI plus API onto your machine. Postgres stays inside the
+Docker network so an existing local database does not break the first run.
 
 For local development from a cloned repository:
 

--- a/deploy/docker/.env.public.example
+++ b/deploy/docker/.env.public.example
@@ -4,7 +4,6 @@
 
 IDENTRAIL_IMAGE_TAG=dev
 IDENTRAIL_POSTGRES_PASSWORD=identrail-local-password
-IDENTRAIL_POSTGRES_PORT=5432
 IDENTRAIL_WEB_PORT=8081
 IDENTRAIL_API_KEYS=identrail-local-read-key-change-me,identrail-local-write-key-change-me
 IDENTRAIL_WRITE_API_KEYS=identrail-local-write-key-change-me

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -52,6 +52,9 @@ curl http://localhost:8080/healthz
 
 Open `http://localhost:8081` for the web UI, use **Continue in dev mode**, and
 the stack will create a disposable local session against the API container.
+The quickstart exposes only the web UI and API on your machine. Postgres stays
+inside the Docker network, which avoids conflicting with an existing local
+database.
 
 If you want to customize the image tag, local secrets, or ports before running:
 
@@ -61,12 +64,19 @@ cp .env.public.example .env
 docker compose -f docker-compose.public.yml --env-file .env up -d
 ```
 
-If `5432` or `8081` are already in use on your machine, set
-`IDENTRAIL_POSTGRES_PORT` or `IDENTRAIL_WEB_PORT` in the downloaded `.env`
-file before starting the stack. If you change `IDENTRAIL_WEB_PORT`, update
-`IDENTRAIL_CORS_ALLOWED_ORIGINS` to the matching `http://localhost:<port>`
-value too. The public web image is published against `http://localhost:8080`
-for the API, so the no-clone quickstart keeps the API port fixed on `8080`.
+If `8081` is already in use on your machine, set `IDENTRAIL_WEB_PORT` in the
+downloaded `.env` file before starting the stack. If you change
+`IDENTRAIL_WEB_PORT`, update `IDENTRAIL_CORS_ALLOWED_ORIGINS` to the matching
+`http://localhost:<port>` value too. The public web image is published against
+`http://localhost:8080` for the API, so the no-clone quickstart keeps the API
+port fixed on `8080`.
+
+If you need direct access to the quickstart database for debugging, use
+`docker compose exec` instead of exposing the port by default:
+
+```bash
+docker compose -f docker-compose.public.yml exec postgres psql -U identrail -d identrail
+```
 
 You can still pull the main image directly when you want to inspect or run just
 the API server:
@@ -102,8 +112,10 @@ The public stack starts Postgres, API, worker, and web without building from
 source. Open `http://localhost:8081` for the web UI and use
 `http://localhost:8080` for the API. The public profile enables the new auth
 flow in local-only manual mode, so the dashboard can establish a disposable
-session without any hosted identity provider. For anything beyond localhost
-evaluation, rotate the example secrets and disable manual mode.
+session without any hosted identity provider. Postgres is intentionally not
+published onto the host in this profile, so existing local database services do
+not block the quickstart. For anything beyond localhost evaluation, rotate the
+example secrets and disable manual mode.
 
 Supporting images are published for multi-service deployments:
 

--- a/deploy/docker/docker-compose.public.yml
+++ b/deploy/docker/docker-compose.public.yml
@@ -30,14 +30,11 @@ x-identrail-env: &identrail-env
 services:
   postgres:
     image: postgres:16-alpine
-    container_name: identrail-postgres
     restart: unless-stopped
     environment:
       POSTGRES_DB: identrail
       POSTGRES_USER: identrail
       POSTGRES_PASSWORD: "${IDENTRAIL_POSTGRES_PASSWORD:-identrail-local-password}"
-    ports:
-      - "127.0.0.1:${IDENTRAIL_POSTGRES_PORT:-5432}:5432"
     volumes:
       - identrail_pgdata:/var/lib/postgresql/data
     healthcheck:
@@ -48,7 +45,6 @@ services:
 
   api:
     image: ghcr.io/identrail/identrail:${IDENTRAIL_IMAGE_TAG:-dev}
-    container_name: identrail-api
     restart: unless-stopped
     depends_on:
       postgres:
@@ -62,7 +58,6 @@ services:
 
   worker:
     image: ghcr.io/identrail/identrail-worker:${IDENTRAIL_IMAGE_TAG:-dev}
-    container_name: identrail-worker
     restart: unless-stopped
     depends_on:
       postgres:
@@ -75,7 +70,6 @@ services:
 
   web:
     image: ghcr.io/identrail/identrail-web:${IDENTRAIL_IMAGE_TAG:-dev}
-    container_name: identrail-web
     restart: unless-stopped
     depends_on:
       api:


### PR DESCRIPTION
No issue: public Docker quickstart usability polish after the public-image path shipped.

What changed
- remove the default host Postgres port publishing from `deploy/docker/docker-compose.public.yml`
- remove fixed `container_name` values from the public quickstart profile so repeated evaluations do not collide with stale containers
- update the public quickstart docs to explain that only the API and web UI are published by default
- switch the database debugging note to `docker compose exec postgres ...` instead of telling users to expose Postgres to the host

Why it changed
- neutral users should be able to run the public Identrail stack without tripping over an existing local Postgres on `5432`
- the previous public profile exposed a database port that the quickstart itself did not need
- hard-coded container names made repeat runs and side-by-side evaluations more brittle than necessary

Impact and risk
- smoother no-clone Docker onboarding for first-time evaluators
- no change to the API or web entrypoints that the quickstart depends on (`8080` and `8081` remain the same)
- low risk because the change is isolated to the public-image compose profile and docs

Validation performed
- `docker compose -f deploy/docker/docker-compose.public.yml config`
- copied `deploy/docker/docker-compose.public.yml` and `.env.public.example` into a fresh temp directory to simulate the no-clone flow
- `docker compose -f docker-compose.public.yml up -d`
- `curl http://localhost:8080/healthz`
- `curl http://localhost:8080/v1/auth/config`
- `docker compose -f docker-compose.public.yml ps`
- `docker compose -f docker-compose.public.yml exec -T postgres psql -U identrail -d identrail -c 'select 1;'`
- `docker compose -f docker-compose.public.yml down -v --remove-orphans`

AI-assisted: yes
Tools used: Codex
Where used: public Docker compose profile and quickstart docs
Human verification performed: compose config validation, fresh-folder public stack boot, API health check, auth config check, database exec check, teardown


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the public Docker quickstart database internal to avoid host port conflicts and make repeat runs more reliable. API on `8080` and web UI on `8081` remain published as before.

- **Bug Fixes**
  - Stop publishing Postgres to the host; keep it on the Docker network.
  - Remove fixed `container_name` values to prevent stale container collisions.
  - Drop `IDENTRAIL_POSTGRES_PORT` from `.env.public.example`.
  - Update docs to note only API and web are exposed, and show `docker compose exec postgres psql ...` for DB access.

<sup>Written for commit b96bc7ba8819ed7b01521dae8bfbb3fe9f938c05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

