### PR TITLE
Add GitHub line links for repo findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Added clickable GitHub line links for repository findings:
+  - repo findings now expose stable `repository` and `source_url` fields in API payloads
+  - the authenticated findings route now lists repository findings and opens a detail view with direct GitHub blob links
+  - snapshot-based repo misconfiguration findings now record the resolved HEAD commit SHA on new scans so line links stay pinned to the scanned revision
 - Enriched repo findings with stable remediation metadata:
   - exposed `commit`, `file_path`, `line_number`, `detector`, `line_snippet`, and `line_snippet_redacted` in scanner and API finding payloads
   - normalized persisted repo finding evidence so existing rows read back without a storage migration

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -3581,9 +3581,12 @@ components:
         path:
           type: array
           items: { type: string }
+        repository:
+          type: string
+          description: Repository target associated with one repo finding when available.
         commit:
           type: string
-          description: Repository commit SHA, or `HEAD` for snapshot-based repo findings, when available.
+          description: Repository commit reference for one repo finding when available.
         file_path:
           type: string
           description: Repository file path for repo findings when available.
@@ -3600,6 +3603,10 @@ components:
         line_snippet_redacted:
           type: boolean
           description: True when `line_snippet` has been redacted to avoid storing raw secrets.
+        source_url:
+          type: string
+          format: uri
+          description: Direct GitHub blob URL for the repository file and line when Identrail can derive one.
         evidence:
           type: object
           additionalProperties: true

--- a/docs/phase-3.md
+++ b/docs/phase-3.md
@@ -20,11 +20,14 @@ Create a thin React + TypeScript dashboard shell that can consume Identrail APIs
   - `GET /v1/scans`
   - `GET /v1/findings` (supports `severity`, `type`, `scan_id`, `lifecycle_status`, and `assignee` filters)
   - `GET /v1/findings/:finding_id` (finding drill-down)
+  - `GET /v1/repo-scans`
+  - `GET /v1/repo-findings` (supports `repo_scan_id`, `severity`, and `type` filters)
 - Dashboard views now include:
   - findings table with live severity/type filters
   - scan selector and scan diff panel with optional baseline scan selection
   - identity/relationship explorer snapshot
   - recent trend list
+  - tenancy-scoped repository findings list with GitHub line-link drill-in
 - Frontend tests:
   - Vitest + Testing Library
   - API client query contract tests

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -46,7 +46,8 @@ Read APIs:
 - `GET /v1/repo-scans/:repo_scan_id`
 - `GET /v1/repo-findings?repo_scan_id=&severity=&type=`
 - list endpoints support cursor pagination (`?limit=...&cursor=...`) and return `next_cursor` when more results exist
-- repo finding responses expose stable location fields when available: `file_path`, `line_number`, `commit`, `detector`, `line_snippet`, and `line_snippet_redacted`
+- repo finding responses expose stable repository and location fields when available: `repository`, `file_path`, `line_number`, `commit`, `detector`, `line_snippet`, `line_snippet_redacted`, and `source_url`
+- `source_url` is a direct GitHub blob link pinned to the detected commit when Identrail can derive one
 
 ## What It Scans
 
@@ -84,6 +85,7 @@ Read APIs:
 - Findings are deterministic and deduplicated by stable IDs/fingerprints.
 - Output is capped by `--max-findings` to prevent runaway payloads.
 - Repo scan metadata/findings are persisted in dedicated storage (`repo_scans`, `repo_findings`) to avoid changing existing cloud scan APIs.
+- Snapshot-based repo misconfiguration findings now persist the resolved HEAD commit SHA on new scans so GitHub links stay pinned to the scanned revision.
 
 ## Useful Flags
 

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -672,11 +672,14 @@ func TestRouterRunsScanAndListsData(t *testing.T) {
 	if len(repoFindingsBody.Items) != 1 {
 		t.Fatalf("expected one repo finding, got %+v", repoFindingsBody)
 	}
-	if repoFindingsBody.Items[0].FilePath != "config/app.env" || repoFindingsBody.Items[0].LineNumber != 3 || repoFindingsBody.Items[0].Detector != "aws-access-key" {
+	if repoFindingsBody.Items[0].Repository != "owner/repo" || repoFindingsBody.Items[0].FilePath != "config/app.env" || repoFindingsBody.Items[0].LineNumber != 3 || repoFindingsBody.Items[0].Detector != "aws-access-key" {
 		t.Fatalf("expected structured repo findings response, got %+v", repoFindingsBody.Items[0])
 	}
 	if repoFindingsBody.Items[0].LineSnippetRedacted == nil || !*repoFindingsBody.Items[0].LineSnippetRedacted {
 		t.Fatalf("expected structured redaction flag in response, got %+v", repoFindingsBody.Items[0].LineSnippetRedacted)
+	}
+	if repoFindingsBody.Items[0].SourceURL != "https://github.com/owner/repo/blob/abc123/config/app.env#L3" {
+		t.Fatalf("expected GitHub source URL in response, got %+v", repoFindingsBody.Items[0].SourceURL)
 	}
 
 	scansPageOneReq := httptest.NewRequest(http.MethodGet, "/v1/scans?limit=1", nil)

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"path"
 	"sort"
 	"strings"
 	"sync"
@@ -1181,7 +1182,7 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, err.Error())
 		return RunRepoScanResult{}, err
 	}
-	result.Findings = enrichFindings(result.Findings)
+	result.Findings = enrichFindingsWithRepoContext(result.Findings, result.Repository, record.Repository)
 	if err := s.Store.UpsertRepoFindings(ctx, record.ID, result.Findings); err != nil {
 		s.recordRepoScanExecutionFailure()
 		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), result.CommitsScanned, result.FilesScanned, 0, result.Truncated, err.Error())
@@ -1249,7 +1250,7 @@ func (s *Service) ListRepoFindings(ctx context.Context, limit int, filter db.Rep
 	if err != nil {
 		return nil, err
 	}
-	return enrichFindings(findings), nil
+	return enrichFindingsWithRepoContext(findings), nil
 }
 
 // GetOrganization returns the current scoped organization record.
@@ -2103,14 +2104,101 @@ func sanitizeRepoScanLimit(candidate int, fallback int, maxAllowed int) (int, er
 }
 
 func enrichFindings(findings []domain.Finding) []domain.Finding {
+	return enrichFindingsWithRepoContext(findings)
+}
+
+func enrichFindingsWithRepoContext(findings []domain.Finding, repositoryHints ...string) []domain.Finding {
 	if len(findings) == 0 {
 		return findings
 	}
+	defaultRepository := ""
+	for _, hint := range repositoryHints {
+		if trimmed := strings.TrimSpace(hint); trimmed != "" {
+			defaultRepository = trimmed
+			break
+		}
+	}
 	enriched := make([]domain.Finding, 0, len(findings))
 	for _, finding := range findings {
+		if finding.Repository == "" && defaultRepository != "" {
+			finding.Repository = defaultRepository
+		}
+		domain.NormalizeRepoFindingMetadata(&finding)
+		if finding.SourceURL == "" {
+			finding.SourceURL = repoFindingSourceURL(finding.Repository, finding.Commit, finding.FilePath, finding.LineNumber)
+		}
 		enriched = append(enriched, standards.EnrichFinding(finding))
 	}
 	return enriched
+}
+
+func repoFindingSourceURL(repository string, commit string, filePath string, lineNumber int) string {
+	if lineNumber < 1 {
+		return ""
+	}
+	normalizedRepository := normalizeGitHubRepositoryPath(repository)
+	normalizedCommit := strings.TrimSpace(commit)
+	normalizedFilePath := strings.Trim(strings.TrimSpace(filePath), "/")
+	if normalizedRepository == "" || normalizedCommit == "" || normalizedFilePath == "" {
+		return ""
+	}
+	blobURL := url.URL{
+		Scheme: "https",
+		Host:   "github.com",
+		Path:   "/" + path.Join(normalizedRepository, "blob", normalizedCommit, normalizedFilePath),
+	}
+	return fmt.Sprintf("%s#L%d", blobURL.String(), lineNumber)
+}
+
+func normalizeGitHubRepositoryPath(repository string) string {
+	trimmed := strings.TrimSpace(repository)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.Count(trimmed, "/") == 1 &&
+		!strings.HasPrefix(trimmed, "/") &&
+		!strings.HasPrefix(trimmed, ".") &&
+		!strings.HasPrefix(trimmed, "~") &&
+		!strings.Contains(trimmed, "\\") &&
+		!strings.Contains(trimmed, "://") &&
+		!strings.HasPrefix(strings.ToLower(trimmed), "git@") {
+		return canonicalGitHubRepositoryPath(trimmed)
+	}
+
+	if strings.HasPrefix(strings.ToLower(trimmed), "git@") {
+		parts := strings.SplitN(trimmed, ":", 2)
+		if len(parts) != 2 {
+			return ""
+		}
+		host := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(parts[0])), "git@")
+		if host != "github.com" && host != "www.github.com" {
+			return ""
+		}
+		return canonicalGitHubRepositoryPath(parts[1])
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return ""
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if host != "github.com" && host != "www.github.com" {
+		return ""
+	}
+	return canonicalGitHubRepositoryPath(parsed.Path)
+}
+
+func canonicalGitHubRepositoryPath(raw string) string {
+	normalized := strings.Trim(strings.TrimSpace(raw), "/")
+	normalized = strings.TrimSuffix(normalized, ".git")
+	parts := strings.Split(normalized, "/")
+	if len(parts) != 2 {
+		return ""
+	}
+	if strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return ""
+	}
+	return strings.TrimSpace(parts[0]) + "/" + strings.TrimSpace(parts[1])
 }
 
 func (s *Service) applyFindingTriageStates(ctx context.Context, findings []domain.Finding) ([]domain.Finding, error) {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -1478,11 +1478,67 @@ func TestServiceRunRepoScanPersistedStoresRecords(t *testing.T) {
 	if len(findings) != 1 || findings[0].ID != "rf-1" {
 		t.Fatalf("unexpected persisted repo findings: %+v", findings)
 	}
+	if findings[0].Repository != "owner/repo" {
+		t.Fatalf("expected repository metadata, got %+v", findings[0])
+	}
 	if findings[0].Commit != "abc123" || findings[0].FilePath != "config/app.env" || findings[0].LineNumber != 7 || findings[0].Detector != "aws-access-key" {
 		t.Fatalf("expected persisted repo metadata, got %+v", findings[0])
 	}
 	if findings[0].LineSnippet != "AWS_ACCESS_KEY_ID=AKIA****" || findings[0].LineSnippetRedacted == nil || !*findings[0].LineSnippetRedacted {
 		t.Fatalf("expected persisted snippet metadata, got %+v", findings[0])
+	}
+	if findings[0].SourceURL != "https://github.com/owner/repo/blob/abc123/config/app.env#L7" {
+		t.Fatalf("expected GitHub source URL, got %+v", findings[0].SourceURL)
+	}
+}
+
+func TestRepoFindingSourceURLSupportsGitHubRepositoryForms(t *testing.T) {
+	testCases := []struct {
+		name       string
+		repository string
+		want       string
+	}{
+		{
+			name:       "owner slash repo",
+			repository: "owner/repo",
+			want:       "https://github.com/owner/repo/blob/abc123/.github/workflows/release.yml#L18",
+		},
+		{
+			name:       "https clone url",
+			repository: "https://github.com/owner/repo.git",
+			want:       "https://github.com/owner/repo/blob/abc123/.github/workflows/release.yml#L18",
+		},
+		{
+			name:       "ssh clone url",
+			repository: "ssh://git@github.com/owner/repo.git",
+			want:       "https://github.com/owner/repo/blob/abc123/.github/workflows/release.yml#L18",
+		},
+		{
+			name:       "scp style",
+			repository: "git@github.com:owner/repo.git",
+			want:       "https://github.com/owner/repo/blob/abc123/.github/workflows/release.yml#L18",
+		},
+		{
+			name:       "legacy head ref",
+			repository: "owner/repo",
+			want:       "https://github.com/owner/repo/blob/HEAD/.github/workflows/release.yml#L18",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			commit := "abc123"
+			if tc.name == "legacy head ref" {
+				commit = "HEAD"
+			}
+			if got := repoFindingSourceURL(tc.repository, commit, ".github/workflows/release.yml", 18); got != tc.want {
+				t.Fatalf("unexpected source url %q", got)
+			}
+		})
+	}
+
+	if got := repoFindingSourceURL("https://gitlab.com/owner/repo.git", "abc123", "main.tf", 9); got != "" {
+		t.Fatalf("expected non-GitHub repositories to skip source URLs, got %q", got)
 	}
 }
 

--- a/internal/domain/json_tags_test.go
+++ b/internal/domain/json_tags_test.go
@@ -17,12 +17,14 @@ func TestFindingJSONUsesSnakeCaseFields(t *testing.T) {
 		Title:               "title",
 		HumanSummary:        "summary",
 		Path:                []string{"app.env"},
+		Repository:          "owner/repo",
 		Commit:              "abc123",
 		FilePath:            "app.env",
 		LineNumber:          12,
 		Detector:            "aws-access-key",
 		LineSnippet:         "AWS_ACCESS_KEY_ID=AKIA****",
 		LineSnippetRedacted: &redacted,
+		SourceURL:           "https://github.com/owner/repo/blob/abc123/app.env#L12",
 		Remediation:         "fix",
 		CreatedAt:           time.Date(2026, 3, 16, 0, 0, 0, 0, time.UTC),
 	}
@@ -32,7 +34,7 @@ func TestFindingJSONUsesSnakeCaseFields(t *testing.T) {
 		t.Fatalf("marshal finding: %v", err)
 	}
 	text := string(payload)
-	for _, expected := range []string{`"id"`, `"scan_id"`, `"human_summary"`, `"created_at"`, `"file_path"`, `"line_number"`, `"line_snippet_redacted"`} {
+	for _, expected := range []string{`"id"`, `"scan_id"`, `"human_summary"`, `"created_at"`, `"repository"`, `"file_path"`, `"line_number"`, `"line_snippet_redacted"`, `"source_url"`} {
 		if !strings.Contains(text, expected) {
 			t.Fatalf("expected field %s in %s", expected, text)
 		}

--- a/internal/domain/repo_finding_metadata.go
+++ b/internal/domain/repo_finding_metadata.go
@@ -11,7 +11,8 @@ func NormalizeRepoFindingMetadata(finding *Finding) {
 	if finding == nil {
 		return
 	}
-	hasFields := finding.Commit != "" ||
+	hasFields := finding.Repository != "" ||
+		finding.Commit != "" ||
 		finding.FilePath != "" ||
 		finding.LineNumber > 0 ||
 		finding.Detector != "" ||
@@ -25,6 +26,9 @@ func NormalizeRepoFindingMetadata(finding *Finding) {
 		finding.Evidence = maps.Clone(finding.Evidence)
 	}
 
+	if finding.Repository == "" {
+		finding.Repository = stringFromAny(finding.Evidence["repository"])
+	}
 	if finding.Commit == "" {
 		finding.Commit = stringFromAny(finding.Evidence["commit"])
 	}
@@ -67,6 +71,9 @@ func NormalizeRepoFindingMetadata(finding *Finding) {
 	}
 	if finding.Evidence == nil {
 		return
+	}
+	if finding.Repository != "" {
+		finding.Evidence["repository"] = finding.Repository
 	}
 	if finding.Commit != "" {
 		finding.Evidence["commit"] = finding.Commit

--- a/internal/domain/repo_finding_metadata_test.go
+++ b/internal/domain/repo_finding_metadata_test.go
@@ -7,6 +7,7 @@ func TestNormalizeRepoFindingMetadataBackfillsFieldsFromEvidence(t *testing.T) {
 		Type: FindingSecretExposure,
 		Path: []string{"config/app.env"},
 		Evidence: map[string]any{
+			"repository":         "owner/repo",
 			"commit":             "abc123",
 			"file_path":          "config/app.env",
 			"line_number":        float64(42),
@@ -17,7 +18,7 @@ func TestNormalizeRepoFindingMetadataBackfillsFieldsFromEvidence(t *testing.T) {
 
 	NormalizeRepoFindingMetadata(&finding)
 
-	if finding.Commit != "abc123" || finding.FilePath != "config/app.env" || finding.LineNumber != 42 || finding.Detector != "github-token" {
+	if finding.Repository != "owner/repo" || finding.Commit != "abc123" || finding.FilePath != "config/app.env" || finding.LineNumber != 42 || finding.Detector != "github-token" {
 		t.Fatalf("unexpected metadata after normalization: %+v", finding)
 	}
 	if finding.LineSnippet != "GITHUB_TOKEN=ghp_****" {
@@ -35,6 +36,7 @@ func TestNormalizeRepoFindingMetadataBackfillsEvidenceFromFields(t *testing.T) {
 	redacted := false
 	finding := Finding{
 		Type:                FindingRepoMisconfig,
+		Repository:          "git@github.com:owner/repo.git",
 		Commit:              "HEAD",
 		FilePath:            ".github/workflows/release.yml",
 		LineNumber:          18,
@@ -47,6 +49,9 @@ func TestNormalizeRepoFindingMetadataBackfillsEvidenceFromFields(t *testing.T) {
 
 	if len(finding.Path) != 1 || finding.Path[0] != ".github/workflows/release.yml" {
 		t.Fatalf("expected path to be backfilled, got %+v", finding.Path)
+	}
+	if got := finding.Evidence["repository"]; got != "git@github.com:owner/repo.git" {
+		t.Fatalf("expected repository evidence, got %v", got)
 	}
 	if got := finding.Evidence["commit"]; got != "HEAD" {
 		t.Fatalf("expected commit evidence, got %v", got)
@@ -61,6 +66,7 @@ func TestNormalizeRepoFindingMetadataBackfillsEvidenceFromFields(t *testing.T) {
 
 func TestNormalizeRepoFindingMetadataClonesEvidenceBeforeCanonicalization(t *testing.T) {
 	originalEvidence := map[string]any{
+		"repository":         "owner/repo",
 		"commit":             "abc123",
 		"file_path":          "config/app.env",
 		"line_number":        42,
@@ -76,6 +82,9 @@ func TestNormalizeRepoFindingMetadataClonesEvidenceBeforeCanonicalization(t *tes
 
 	if _, exists := originalEvidence["line_snippet"]; exists {
 		t.Fatalf("expected original evidence map to remain unchanged, got %+v", originalEvidence)
+	}
+	if _, exists := originalEvidence["repository"]; !exists {
+		t.Fatalf("expected original repository evidence to remain unchanged, got %+v", originalEvidence)
 	}
 	if finding.Evidence["line_snippet"] != "GITHUB_TOKEN=ghp_****" {
 		t.Fatalf("expected normalized evidence to contain canonical line_snippet, got %+v", finding.Evidence)

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -135,12 +135,14 @@ type Finding struct {
 	Title               string          `json:"title"`
 	HumanSummary        string          `json:"human_summary"`
 	Path                []string        `json:"path,omitempty"`
+	Repository          string          `json:"repository,omitempty"`
 	Commit              string          `json:"commit,omitempty"`
 	FilePath            string          `json:"file_path,omitempty"`
 	LineNumber          int             `json:"line_number,omitempty"`
 	Detector            string          `json:"detector,omitempty"`
 	LineSnippet         string          `json:"line_snippet,omitempty"`
 	LineSnippetRedacted *bool           `json:"line_snippet_redacted,omitempty"`
+	SourceURL           string          `json:"source_url,omitempty"`
 	Evidence            map[string]any  `json:"evidence,omitempty"`
 	Remediation         string          `json:"remediation"`
 	CreatedAt           time.Time       `json:"created_at"`

--- a/internal/repoexposure/rules.go
+++ b/internal/repoexposure/rules.go
@@ -194,10 +194,14 @@ func detectSecretFindings(repo string, commit string, path string, line int, tex
 	return findings
 }
 
-func detectMisconfigFindings(repo string, path string, content []byte, detectedAt time.Time) []domain.Finding {
+func detectMisconfigFindings(repo string, commit string, path string, content []byte, detectedAt time.Time) []domain.Finding {
 	data := string(content)
 	findings := []domain.Finding{}
 	seen := map[string]struct{}{}
+	revision := strings.TrimSpace(commit)
+	if revision == "" {
+		revision = "HEAD"
+	}
 
 	lines := strings.Split(data, "\n")
 	for index, line := range lines {
@@ -220,7 +224,7 @@ func detectMisconfigFindings(repo string, path string, content []byte, detectedA
 				Title:               rule.Title,
 				HumanSummary:        rule.Summary,
 				Path:                []string{path},
-				Commit:              "HEAD",
+				Commit:              revision,
 				FilePath:            path,
 				LineNumber:          lineNumber,
 				Detector:            rule.ID,
@@ -228,7 +232,7 @@ func detectMisconfigFindings(repo string, path string, content []byte, detectedA
 				LineSnippetRedacted: boolPtr(false),
 				Evidence: map[string]any{
 					"repository":            repo,
-					"commit":                "HEAD",
+					"commit":                revision,
 					"file_path":             path,
 					"line_number":           lineNumber,
 					"detector":              rule.ID,
@@ -266,7 +270,7 @@ func detectMisconfigFindings(repo string, path string, content []byte, detectedA
 			Title:               rule.Title,
 			HumanSummary:        rule.Summary,
 			Path:                []string{path},
-			Commit:              "HEAD",
+			Commit:              revision,
 			FilePath:            path,
 			LineNumber:          lineNumber,
 			Detector:            rule.ID,
@@ -274,7 +278,7 @@ func detectMisconfigFindings(repo string, path string, content []byte, detectedA
 			LineSnippetRedacted: boolPtr(false),
 			Evidence: map[string]any{
 				"repository":            repo,
-				"commit":                "HEAD",
+				"commit":                revision,
 				"file_path":             path,
 				"line_number":           lineNumber,
 				"detector":              rule.ID,

--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -174,6 +174,10 @@ func (s *Scanner) ScanRepository(ctx context.Context, target string) (ScanResult
 
 	filesScanned := 0
 	if !truncated {
+		headCommit, headCommitErr := s.resolveHeadCommit(ctx, location)
+		if headCommitErr != nil {
+			return ScanResult{}, headCommitErr
+		}
 		headFiles, fileErr := s.listHeadFiles(ctx, location)
 		if fileErr != nil {
 			return ScanResult{}, fileErr
@@ -193,7 +197,7 @@ func (s *Scanner) ScanRepository(ctx context.Context, target string) (ScanResult
 				continue
 			}
 			filesScanned++
-			for _, finding := range detectMisconfigFindings(location.Display, filePath, content, started) {
+			for _, finding := range detectMisconfigFindings(location.Display, headCommit, filePath, content, started) {
 				if _, exists := seen[finding.ID]; exists {
 					continue
 				}
@@ -292,6 +296,14 @@ func (s *Scanner) listHeadFiles(ctx context.Context, repo repositoryLocation) ([
 		files = append(files, path)
 	}
 	return files, nil
+}
+
+func (s *Scanner) resolveHeadCommit(ctx context.Context, repo repositoryLocation) (string, error) {
+	output, err := s.git(ctx, repo, "rev-parse", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("resolve HEAD commit: %w", err)
+	}
+	return strings.TrimSpace(string(output)), nil
 }
 
 func (s *Scanner) git(ctx context.Context, repo repositoryLocation, args ...string) ([]byte, error) {

--- a/internal/repoexposure/scanner_test.go
+++ b/internal/repoexposure/scanner_test.go
@@ -77,7 +77,7 @@ func TestScanRepositoryDetectsSecretInCommitHistory(t *testing.T) {
 }
 
 func TestScanRepositoryDetectsHeadMisconfiguration(t *testing.T) {
-	repoPath := initTestRepoWithHeadMisconfig(t)
+	repoPath, headCommit := initTestRepoWithHeadMisconfig(t)
 	scanner := NewScanner(nil, WithHistoryLimit(10), WithMaxFindings(20))
 
 	result, err := scanner.ScanRepository(context.Background(), repoPath)
@@ -95,7 +95,7 @@ func TestScanRepositoryDetectsHeadMisconfiguration(t *testing.T) {
 		}
 		path, _ := finding.Evidence["file_path"].(string)
 		if strings.HasSuffix(path, "workflow.yml") {
-			if finding.Commit != "HEAD" || finding.FilePath == "" || finding.LineNumber == 0 || finding.Detector == "" || finding.LineSnippet == "" {
+			if finding.Commit != headCommit || finding.FilePath == "" || finding.LineNumber == 0 || finding.Detector == "" || finding.LineSnippet == "" {
 				t.Fatalf("expected structured repo misconfig metadata, got %+v", finding)
 			}
 			if finding.LineSnippetRedacted == nil || *finding.LineSnippetRedacted {
@@ -111,7 +111,7 @@ func TestScanRepositoryDetectsHeadMisconfiguration(t *testing.T) {
 }
 
 func TestScanRepositoryHonorsMaxFindings(t *testing.T) {
-	repoPath := initTestRepoWithHeadMisconfig(t)
+	repoPath, _ := initTestRepoWithHeadMisconfig(t)
 	scanner := NewScanner(nil, WithHistoryLimit(10), WithMaxFindings(1))
 
 	result, err := scanner.ScanRepository(context.Background(), repoPath)
@@ -430,7 +430,7 @@ func initTestRepoWithHistorySecret(t *testing.T) (string, string) {
 	return repo, firstCommit
 }
 
-func initTestRepoWithHeadMisconfig(t *testing.T) string {
+func initTestRepoWithHeadMisconfig(t *testing.T) (string, string) {
 	t.Helper()
 	repo := t.TempDir()
 	runGit(t, repo, "init", "-q")
@@ -465,7 +465,7 @@ jobs:
 
 	runGit(t, repo, "add", ".")
 	runGit(t, repo, "commit", "-q", "-m", "add misconfig")
-	return repo
+	return repo, strings.TrimSpace(runGit(t, repo, "rev-parse", "HEAD"))
 }
 
 func runGit(t *testing.T, dir string, args ...string) string {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -243,6 +243,69 @@ describe('App', () => {
     expect(await screen.findByText(/Project source onboarding/i)).toBeInTheDocument();
   });
 
+  it('renders repository findings with direct GitHub line links inside the app shell', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/v1/me')) {
+        return okJSON(currentMePayload('tenant-a', 'workspace-a'));
+      }
+      if (url.includes('/v1/repo-scans')) {
+        return okJSON({
+          items: [
+            {
+              id: 'repo-scan-1',
+              repository: 'owner/repo',
+              status: 'succeeded',
+              started_at: '2026-01-01T00:00:00Z',
+              finished_at: '2026-01-01T00:05:00Z',
+              commits_scanned: 12,
+              files_scanned: 4,
+              finding_count: 1,
+              truncated: false
+            }
+          ]
+        });
+      }
+      if (url.includes('/v1/repo-findings')) {
+        return okJSON({
+          items: [
+            {
+              id: 'repo-f1',
+              scan_id: 'repo-scan-1',
+              type: 'secret_exposure',
+              severity: 'high',
+              title: 'Potential AWS access key exposed in commit history',
+              human_summary: 'A line added in commit history appears to contain an AWS access key identifier.',
+              repository: 'owner/repo',
+              commit: 'abc123',
+              file_path: 'config/app.env',
+              line_number: 7,
+              detector: 'aws_access_key_id',
+              line_snippet: 'AWS_ACCESS_KEY_ID=AKIA****',
+              line_snippet_redacted: true,
+              source_url: 'https://github.com/owner/repo/blob/abc123/config/app.env#L7',
+              remediation: 'Rotate the key and move the credential to a secret manager.',
+              created_at: '2026-01-01T00:00:00Z'
+            }
+          ]
+        });
+      }
+      throw new Error(`Unexpected URL ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    setCurrentPath('/app/tenant-a/workspace-a/findings');
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { level: 2, name: /Findings/i })).toBeInTheDocument();
+    expect(await screen.findByText(/Review repository findings and jump directly to the exact GitHub line/i)).toBeInTheDocument();
+
+    const openInGitHub = await screen.findByRole('link', { name: /Open in GitHub/i });
+    expect(openInGitHub).toHaveAttribute('href', 'https://github.com/owner/repo/blob/abc123/config/app.env#L7');
+    expect((await screen.findAllByText('config/app.env:7')).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText('owner/repo')).length).toBeGreaterThan(0);
+  });
+
   it('supports workspace member invite workflow from app shell administration route', async () => {
     const fetchMock = vi
       .fn()

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -59,6 +59,18 @@ describe('apiClient', () => {
     expect(url).toContain('/v1/scans?sort_by=started_at&sort_order=desc');
   });
 
+  it('uses default repo scan listing sort contract', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [] })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.listRepoScans({}, { apiKey: 'reader' });
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toContain('/v1/repo-scans?sort_by=started_at&sort_order=desc');
+  });
+
   it('encodes scan id for diff URL', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -136,6 +148,28 @@ describe('apiClient', () => {
 
     const [url] = fetchMock.mock.calls[0] as [string];
     expect(url).toContain('/v1/findings/finding-1/history?scan_id=scan-1&limit=15');
+  });
+
+  it('builds repo findings URL with filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [] })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.listRepoFindings(
+      {
+        repo_scan_id: 'repo-scan-1',
+        severity: 'high',
+        type: 'secret_exposure'
+      },
+      { apiKey: 'reader' }
+    );
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/v1/repo-findings?sort_by=created_at&sort_order=desc&repo_scan_id=repo-scan-1&severity=high&type=secret_exposure');
+    const headers = new Headers(options.headers);
+    expect(headers.get('x-api-key')).toBe('reader');
   });
 
   it('sends triage patch payload for finding workflow actions', async () => {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -12,16 +12,31 @@ export type Finding = {
   title: string;
   human_summary: string;
   path?: string[];
+  repository?: string;
   commit?: string;
   file_path?: string;
   line_number?: number;
   detector?: string;
   line_snippet?: string;
   line_snippet_redacted?: boolean;
+  source_url?: string;
   evidence?: Record<string, unknown>;
   remediation: string;
   created_at: string;
   triage?: FindingTriage;
+};
+
+export type RepoScanRecord = {
+  id: string;
+  repository: string;
+  status: string;
+  started_at: string;
+  finished_at?: string;
+  commits_scanned: number;
+  files_scanned: number;
+  finding_count: number;
+  truncated: boolean;
+  error_message?: string;
 };
 
 export type ScanRecord = {
@@ -767,6 +782,20 @@ export const apiClient = {
   listScans(auth?: RequestAuthContext) {
     return request<{ items: ScanRecord[] }>('/v1/scans?sort_by=started_at&sort_order=desc', auth);
   },
+  listRepoScans(
+    filters: {
+      limit?: number;
+      cursor?: string;
+      sort_by?: string;
+      sort_order?: 'asc' | 'desc';
+    } = {},
+    auth?: RequestAuthContext
+  ) {
+    return request<{ items: RepoScanRecord[] }>(
+      `/v1/repo-scans${buildQuery({ sort_by: 'started_at', sort_order: 'desc', ...filters })}`,
+      auth
+    );
+  },
   listFindings(
     filters: {
       limit?: number;
@@ -781,6 +810,23 @@ export const apiClient = {
     auth?: RequestAuthContext
   ) {
     return request<{ items: Finding[] }>(`/v1/findings${buildQuery(filters)}`, auth);
+  },
+  listRepoFindings(
+    filters: {
+      limit?: number;
+      cursor?: string;
+      repo_scan_id?: string;
+      severity?: string;
+      type?: string;
+      sort_by?: string;
+      sort_order?: 'asc' | 'desc';
+    } = {},
+    auth?: RequestAuthContext
+  ) {
+    return request<{ items: Finding[] }>(
+      `/v1/repo-findings${buildQuery({ sort_by: 'created_at', sort_order: 'desc', ...filters })}`,
+      auth
+    );
   },
   getFinding(findingID: string, scanID?: string, auth?: RequestAuthContext) {
     const suffix = buildQuery({ scan_id: scanID });

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -5,10 +5,12 @@ import {
   apiClient,
   type AWSConnectionStatus,
   type CurrentUserContext,
+  type Finding as ApiFinding,
   type GitHubConnectionStartResponse,
   type GitHubConnectionStatus,
   type KubernetesConnectionStatus,
   type ProjectRecord,
+  type RepoScanRecord,
   type RequestAuthContext,
   type ScanPolicyRecord,
   type ScanTriggerMode,
@@ -130,6 +132,8 @@ const CONNECT_SOURCE_STEPS = ['Choose', 'Configure', 'Validate', 'Active'] as co
 const GITHUB_REPOSITORY_SPLIT_PATTERN = /[\n,]+/;
 const AWS_ROLE_ARN_PATTERN = /^arn:(aws|aws-us-gov|aws-cn):iam::[0-9]{12}:role\/[A-Za-z0-9+=,.@_/-]{1,512}$/;
 const SCAN_POLICY_TRIGGER_MODES: ScanTriggerMode[] = ['manual', 'scheduled', 'event', 'hybrid'];
+const REPO_FINDING_SEVERITY_FILTERS = ['all', 'critical', 'high', 'medium', 'low', 'info'] as const;
+const REPO_FINDING_TYPE_FILTERS = ['all', 'secret_exposure', 'repo_misconfiguration'] as const;
 
 function buildProductAuthContext(scope: ProductSession): RequestAuthContext {
   return {
@@ -164,6 +168,66 @@ function normalizeProjectToken(value: string): string {
 
 function deriveProjectToken(value: string, fallback = 'project'): string {
   return normalizeProjectToken(value) || fallback;
+}
+
+function formatTokenLabel(value: string): string {
+  const trimmed = normalizeValue(value);
+  if (!trimmed) {
+    return 'Unknown';
+  }
+  return trimmed
+    .replace(/[-_]+/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function canonicalGitHubRepositoryDisplay(value: string): string {
+  const trimmed = normalizeValue(value).replace(/\/+$/g, '');
+  if (!trimmed) {
+    return '';
+  }
+  if (/^git@github\.com:/i.test(trimmed)) {
+    return trimmed
+      .replace(/^git@github\.com:/i, '')
+      .replace(/\.git$/i, '');
+  }
+  if (/^https?:\/\/github\.com\//i.test(trimmed) || /^ssh:\/\/git@github\.com\//i.test(trimmed)) {
+    try {
+      const parsed = new URL(trimmed);
+      return parsed.pathname.replace(/^\/+/, '').replace(/\/+$/g, '').replace(/\.git$/i, '');
+    } catch {
+      return trimmed;
+    }
+  }
+  return trimmed.replace(/\.git$/i, '');
+}
+
+function repoFindingRepositoryValue(finding: ApiFinding, repoScansByID: Record<string, RepoScanRecord>): string {
+  if (normalizeValue(finding.repository ?? '')) {
+    return normalizeValue(finding.repository ?? '');
+  }
+  const evidenceRepository = finding.evidence?.repository;
+  if (typeof evidenceRepository === 'string' && normalizeValue(evidenceRepository)) {
+    return normalizeValue(evidenceRepository);
+  }
+  return normalizeValue(repoScansByID[finding.scan_id]?.repository ?? '');
+}
+
+function repoFindingLocationLabel(finding: ApiFinding): string {
+  if (finding.file_path && finding.line_number) {
+    return `${finding.file_path}:${finding.line_number}`;
+  }
+  if (finding.file_path) {
+    return finding.file_path;
+  }
+  return 'Location unavailable';
+}
+
+function repoFindingSeverityClass(severity: string): string {
+  const normalized = normalizeValue(severity).toLowerCase() || 'unknown';
+  return `idt-repo-finding-severity is-${normalized}`;
 }
 
 function hasWorkspaceAdminAccess(scope: ProductSession, whoAmI: WhoAmIResponse | null): boolean {
@@ -2567,7 +2631,311 @@ export function ProductProjectDetailPage() {
 }
 
 export function ProductFindingsPage() {
-  return <ScopedShellPage title="Findings" description="Finding triage queue placeholder for scoped findings, filters, and ownership assignment." />;
+  const params = useParams<ScopeRouteParams>();
+  const scope = resolveScopeFromParams(params);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+  const [repoScans, setRepoScans] = useState<RepoScanRecord[]>([]);
+  const [repoFindings, setRepoFindings] = useState<ApiFinding[]>([]);
+  const [repoScanFilter, setRepoScanFilter] = useState('');
+  const [severityFilter, setSeverityFilter] = useState<(typeof REPO_FINDING_SEVERITY_FILTERS)[number]>('all');
+  const [typeFilter, setTypeFilter] = useState<(typeof REPO_FINDING_TYPE_FILTERS)[number]>('all');
+  const [selectedFindingID, setSelectedFindingID] = useState('');
+  const requestRef = useRef(0);
+
+  const repoScansByID = useMemo(
+    () =>
+      repoScans.reduce<Record<string, RepoScanRecord>>((acc, scan) => {
+        acc[scan.id] = scan;
+        return acc;
+      }, {}),
+    [repoScans]
+  );
+
+  const selectedFinding = useMemo(
+    () => repoFindings.find((finding) => finding.id === selectedFindingID) ?? repoFindings[0] ?? null,
+    [repoFindings, selectedFindingID]
+  );
+
+  const linkedFindingCount = useMemo(
+    () => repoFindings.filter((finding) => normalizeValue(finding.source_url ?? '')).length,
+    [repoFindings]
+  );
+
+  const criticalFindingCount = useMemo(
+    () => repoFindings.filter((finding) => normalizeValue(finding.severity).toLowerCase() === 'critical').length,
+    [repoFindings]
+  );
+
+  const activeScanCount = useMemo(
+    () => repoScans.filter((scan) => normalizeValue(scan.status).toLowerCase() === 'succeeded').length,
+    [repoScans]
+  );
+
+  const loadRepoFindings = async (targetScope: ProductSession, mode: 'initial' | 'refresh') => {
+    const requestID = ++requestRef.current;
+    if (mode === 'initial') {
+      setLoading(true);
+    } else {
+      setRefreshing(true);
+    }
+    setError('');
+    try {
+      const auth = buildProductAuthContext(targetScope);
+      const [repoScanResponse, repoFindingResponse] = await Promise.all([
+        apiClient.listRepoScans({ limit: 50 }, auth),
+        apiClient.listRepoFindings(
+          {
+            limit: 100,
+            repo_scan_id: normalizeValue(repoScanFilter) || undefined,
+            severity: severityFilter !== 'all' ? severityFilter : undefined,
+            type: typeFilter !== 'all' ? typeFilter : undefined
+          },
+          auth
+        )
+      ]);
+      if (requestID !== requestRef.current) {
+        return;
+      }
+      setRepoScans(repoScanResponse.items);
+      setRepoFindings(repoFindingResponse.items);
+    } catch (requestError) {
+      if (requestID !== requestRef.current) {
+        return;
+      }
+      const message = requestError instanceof Error ? requestError.message : 'Failed to load repository findings.';
+      setError(message);
+    } finally {
+      if (requestID === requestRef.current) {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (!scope) {
+      setLoading(false);
+      setError('Workspace route context is missing.');
+      return;
+    }
+    void loadRepoFindings(scope, 'initial');
+    return () => {
+      requestRef.current += 1;
+    };
+  }, [scope?.tenantID, scope?.workspaceID, repoScanFilter, severityFilter, typeFilter]);
+
+  useEffect(() => {
+    if (repoFindings.length === 0) {
+      if (selectedFindingID) {
+        setSelectedFindingID('');
+      }
+      return;
+    }
+    if (!repoFindings.some((finding) => finding.id === selectedFindingID)) {
+      setSelectedFindingID(repoFindings[0].id);
+    }
+  }, [repoFindings, selectedFindingID]);
+
+  if (!scope) {
+    return (
+      <section className="idt-app-panel idt-app-panel-error">
+        <p className="idt-app-kicker">Findings</p>
+        <h2>Repository findings</h2>
+        <p>Workspace route context is missing.</p>
+      </section>
+    );
+  }
+
+  if (loading) {
+    return <AppShellLoading message="Loading repository findings" />;
+  }
+
+  const handleRefresh = () => {
+    void loadRepoFindings(scope, 'refresh');
+  };
+
+  return (
+    <section className="idt-app-panel">
+      <div className="idt-repo-findings-header">
+        <div>
+          <p className="idt-app-kicker">Repository Exposure</p>
+          <h2>Findings</h2>
+          <p>Review repository findings and jump directly to the exact GitHub line when link metadata is available.</p>
+        </div>
+        <div className="idt-inline-actions">
+          <button className="idt-btn idt-btn-ghost" type="button" onClick={handleRefresh} disabled={refreshing}>
+            {refreshing ? 'Refreshing...' : 'Refresh'}
+          </button>
+          {selectedFinding?.source_url ? (
+            <a className="idt-btn idt-btn-primary" href={selectedFinding.source_url} target="_blank" rel="noreferrer">
+              Open in GitHub
+            </a>
+          ) : null}
+        </div>
+      </div>
+
+      {error ? <div className="idt-app-alert idt-app-alert-error">{error}</div> : null}
+
+      <div className="idt-repo-finding-stats" aria-label="Repository finding summary">
+        <article className="idt-repo-finding-stat">
+          <span>Total repo findings</span>
+          <strong>{repoFindings.length}</strong>
+        </article>
+        <article className="idt-repo-finding-stat">
+          <span>GitHub-linked findings</span>
+          <strong>{linkedFindingCount}</strong>
+        </article>
+        <article className="idt-repo-finding-stat">
+          <span>Critical findings</span>
+          <strong>{criticalFindingCount}</strong>
+        </article>
+        <article className="idt-repo-finding-stat">
+          <span>Completed repo scans</span>
+          <strong>{activeScanCount}</strong>
+        </article>
+      </div>
+
+      <div className="idt-repo-finding-filters">
+        <label>
+          Repository scan
+          <select value={repoScanFilter} onChange={(event) => setRepoScanFilter(event.target.value)}>
+            <option value="">All repository scans</option>
+            {repoScans.map((scan) => (
+              <option key={scan.id} value={scan.id}>
+                {canonicalGitHubRepositoryDisplay(scan.repository)} · {formatTokenLabel(scan.status)}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Severity
+          <select
+            value={severityFilter}
+            onChange={(event) => setSeverityFilter(event.target.value as (typeof REPO_FINDING_SEVERITY_FILTERS)[number])}
+          >
+            {REPO_FINDING_SEVERITY_FILTERS.map((value) => (
+              <option key={value} value={value}>
+                {value === 'all' ? 'All severities' : formatTokenLabel(value)}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Type
+          <select value={typeFilter} onChange={(event) => setTypeFilter(event.target.value as (typeof REPO_FINDING_TYPE_FILTERS)[number])}>
+            {REPO_FINDING_TYPE_FILTERS.map((value) => (
+              <option key={value} value={value}>
+                {value === 'all' ? 'All finding types' : formatTokenLabel(value)}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div className="idt-repo-finding-layout">
+        <div className="idt-repo-finding-list">
+          <div className="idt-repo-finding-list-header">
+            <h3>Repository findings</h3>
+            <p>{repoFindings.length ? `${repoFindings.length} findings in scope` : 'No findings match the current filters.'}</p>
+          </div>
+          {repoFindings.length === 0 ? (
+            <AppShellEmptyState
+              title="No repository findings"
+              body="Run a repository exposure scan or loosen the current filters to inspect GitHub-linked findings."
+            />
+          ) : (
+            <div className="idt-repo-finding-items" role="list">
+              {repoFindings.map((finding) => {
+                const repositoryValue = repoFindingRepositoryValue(finding, repoScansByID);
+                const repositoryLabel = canonicalGitHubRepositoryDisplay(repositoryValue) || 'Repository unavailable';
+                const isSelected = selectedFinding?.id === finding.id;
+                return (
+                  <button
+                    key={finding.id}
+                    type="button"
+                    role="listitem"
+                    className={`idt-repo-finding-row${isSelected ? ' is-selected' : ''}`}
+                    onClick={() => setSelectedFindingID(finding.id)}
+                  >
+                    <div className="idt-repo-finding-row-top">
+                      <strong>{finding.title}</strong>
+                      <span className={repoFindingSeverityClass(finding.severity)}>{formatTokenLabel(finding.severity)}</span>
+                    </div>
+                    <p>{finding.human_summary}</p>
+                    <div className="idt-repo-finding-row-meta">
+                      <span>{repositoryLabel}</span>
+                      <span>{repoFindingLocationLabel(finding)}</span>
+                      <span>{formatTokenLabel(finding.type)}</span>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        <aside className="idt-repo-finding-detail">
+          {selectedFinding ? (
+            <>
+              <div className="idt-repo-finding-detail-copy">
+                <p className="idt-app-kicker">Finding detail</p>
+                <h3>{selectedFinding.title}</h3>
+                <p>{selectedFinding.human_summary}</p>
+              </div>
+
+              <dl className="idt-repo-finding-facts">
+                <div>
+                  <dt>Repository</dt>
+                  <dd>{canonicalGitHubRepositoryDisplay(repoFindingRepositoryValue(selectedFinding, repoScansByID)) || 'Unavailable'}</dd>
+                </div>
+                <div>
+                  <dt>Location</dt>
+                  <dd>{repoFindingLocationLabel(selectedFinding)}</dd>
+                </div>
+                <div>
+                  <dt>Commit</dt>
+                  <dd>{selectedFinding.commit || 'Unavailable'}</dd>
+                </div>
+                <div>
+                  <dt>Detector</dt>
+                  <dd>{selectedFinding.detector ? formatTokenLabel(selectedFinding.detector) : 'Unavailable'}</dd>
+                </div>
+              </dl>
+
+              {selectedFinding.source_url ? (
+                <a className="idt-repo-finding-link" href={selectedFinding.source_url} target="_blank" rel="noreferrer">
+                  {selectedFinding.source_url}
+                </a>
+              ) : (
+                <div className="idt-app-alert">GitHub line link unavailable for this finding. Rescan the repository to refresh line-link metadata.</div>
+              )}
+
+              {selectedFinding.line_snippet ? (
+                <div className="idt-repo-finding-code">
+                  <span>Evidence line</span>
+                  <pre>
+                    <code>{selectedFinding.line_snippet}</code>
+                  </pre>
+                </div>
+              ) : null}
+
+              <div className="idt-repo-finding-remediation">
+                <h4>Remediation</h4>
+                <p>{selectedFinding.remediation}</p>
+              </div>
+            </>
+          ) : (
+            <AppShellEmptyState
+              title="Select a finding"
+              body="Choose one repository finding to inspect commit, detector, and GitHub line-link context."
+            />
+          )}
+        </aside>
+      </div>
+    </section>
+  );
 }
 
 export function ProductSettingsPage() {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4304,6 +4304,283 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   color: #d7ffdf;
 }
 
+.idt-repo-findings-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.idt-repo-findings-header h2,
+.idt-repo-finding-list-header h3,
+.idt-repo-finding-detail h3,
+.idt-repo-finding-remediation h4 {
+  margin: 0;
+}
+
+.idt-repo-findings-header p:last-child,
+.idt-repo-finding-list-header p,
+.idt-repo-finding-detail-copy p:last-child,
+.idt-repo-finding-remediation p {
+  margin-bottom: 0;
+}
+
+.idt-repo-finding-stats {
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
+.idt-repo-finding-stat,
+.idt-repo-finding-list,
+.idt-repo-finding-detail {
+  border: 1px solid rgba(126, 157, 211, 0.24);
+  border-radius: 0.8rem;
+  background: rgba(9, 15, 26, 0.56);
+}
+
+.idt-repo-finding-stat {
+  padding: 0.95rem 1rem;
+  display: grid;
+  gap: 0.22rem;
+}
+
+.idt-repo-finding-stat span {
+  color: #9fb5d8;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.idt-repo-finding-stat strong {
+  font-size: 1.55rem;
+  color: #f4f8ff;
+}
+
+.idt-repo-finding-filters {
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
+.idt-repo-finding-filters label {
+  display: grid;
+  gap: 0.35rem;
+  color: #d3e1f7;
+  font-size: 0.95rem;
+}
+
+.idt-repo-finding-filters select {
+  border: 1px solid rgba(126, 157, 211, 0.35);
+  border-radius: 0.55rem;
+  background: rgba(9, 15, 26, 0.84);
+  color: #e4efff;
+  padding: 0.5rem 0.6rem;
+}
+
+.idt-repo-finding-layout {
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.idt-repo-finding-list,
+.idt-repo-finding-detail {
+  padding: 1rem;
+}
+
+.idt-repo-finding-list-header {
+  display: grid;
+  gap: 0.2rem;
+  margin-bottom: 0.85rem;
+}
+
+.idt-repo-finding-items {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.idt-repo-finding-row {
+  width: 100%;
+  text-align: left;
+  border: 1px solid rgba(126, 157, 211, 0.24);
+  border-radius: 0.75rem;
+  background: rgba(14, 22, 36, 0.9);
+  color: inherit;
+  padding: 0.95rem 1rem;
+  display: grid;
+  gap: 0.55rem;
+  cursor: pointer;
+  transition: border-color 0.18s ease, background-color 0.18s ease, transform 0.18s ease;
+}
+
+.idt-repo-finding-row:hover,
+.idt-repo-finding-row:focus-visible,
+.idt-repo-finding-row.is-selected {
+  border-color: rgba(181, 207, 255, 0.62);
+  background: rgba(17, 28, 46, 0.96);
+  transform: translateY(-1px);
+}
+
+.idt-repo-finding-row-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.8rem;
+  align-items: flex-start;
+}
+
+.idt-repo-finding-row-top strong {
+  font-size: 0.98rem;
+  color: #f4f8ff;
+}
+
+.idt-repo-finding-row p {
+  margin: 0;
+  color: #ccdaef;
+}
+
+.idt-repo-finding-row-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem 0.75rem;
+  color: #9fb5d8;
+  font-size: 0.82rem;
+}
+
+.idt-repo-finding-severity {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.24rem 0.58rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  white-space: nowrap;
+}
+
+.idt-repo-finding-severity.is-critical {
+  background: rgba(179, 38, 30, 0.22);
+  color: #ffd2cb;
+}
+
+.idt-repo-finding-severity.is-high {
+  background: rgba(191, 92, 0, 0.22);
+  color: #ffd8b3;
+}
+
+.idt-repo-finding-severity.is-medium {
+  background: rgba(162, 116, 0, 0.22);
+  color: #ffe6a3;
+}
+
+.idt-repo-finding-severity.is-low,
+.idt-repo-finding-severity.is-info,
+.idt-repo-finding-severity.is-unknown {
+  background: rgba(57, 112, 201, 0.22);
+  color: #d9e6ff;
+}
+
+.idt-repo-finding-detail {
+  display: grid;
+  gap: 1rem;
+}
+
+.idt-repo-finding-detail-copy {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.idt-repo-finding-facts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.8rem;
+  margin: 0;
+}
+
+.idt-repo-finding-facts div {
+  display: grid;
+  gap: 0.18rem;
+}
+
+.idt-repo-finding-facts dt {
+  color: #9fb5d8;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.idt-repo-finding-facts dd {
+  margin: 0;
+  color: #f4f8ff;
+  word-break: break-word;
+}
+
+.idt-repo-finding-link {
+  color: #b9d5ff;
+  text-decoration: none;
+  word-break: break-all;
+}
+
+.idt-repo-finding-link:hover,
+.idt-repo-finding-link:focus-visible {
+  color: #e3efff;
+  text-decoration: underline;
+}
+
+.idt-repo-finding-code {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.idt-repo-finding-code span {
+  color: #9fb5d8;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.idt-repo-finding-code pre {
+  margin: 0;
+  padding: 0.85rem 0.95rem;
+  overflow-x: auto;
+  border: 1px solid rgba(126, 157, 211, 0.24);
+  border-radius: 0.75rem;
+  background: rgba(7, 12, 21, 0.92);
+  color: #edf4ff;
+}
+
+.idt-repo-finding-code code {
+  font-family: var(--idt-mono);
+  font-size: 0.84rem;
+}
+
+.idt-repo-finding-remediation {
+  display: grid;
+  gap: 0.35rem;
+}
+
+@media (max-width: 960px) {
+  .idt-repo-findings-header,
+  .idt-repo-finding-row-top {
+    flex-direction: column;
+  }
+
+  .idt-repo-finding-stats,
+  .idt-repo-finding-filters,
+  .idt-repo-finding-layout,
+  .idt-repo-finding-facts {
+    grid-template-columns: 1fr;
+  }
+}
+
 .idt-auth-page {
   width: 100%;
   min-height: 100svh;
@@ -5434,6 +5711,58 @@ html[data-theme='light'] .idt-app-alert-error {
 html[data-theme='light'] .idt-app-alert-success {
   border-color: rgba(44, 122, 70, 0.35);
   color: #1e5a31;
+}
+
+html[data-theme='light'] .idt-repo-finding-stat,
+html[data-theme='light'] .idt-repo-finding-list,
+html[data-theme='light'] .idt-repo-finding-detail {
+  background: rgba(255, 255, 255, 0.94);
+  border-color: rgba(42, 71, 119, 0.18);
+}
+
+html[data-theme='light'] .idt-repo-finding-stat span,
+html[data-theme='light'] .idt-repo-finding-row-meta,
+html[data-theme='light'] .idt-repo-finding-facts dt,
+html[data-theme='light'] .idt-repo-finding-code span {
+  color: #5473a4;
+}
+
+html[data-theme='light'] .idt-repo-finding-stat strong,
+html[data-theme='light'] .idt-repo-finding-row-top strong,
+html[data-theme='light'] .idt-repo-finding-facts dd {
+  color: #12284c;
+}
+
+html[data-theme='light'] .idt-repo-finding-filters label,
+html[data-theme='light'] .idt-repo-finding-row p {
+  color: #2b456c;
+}
+
+html[data-theme='light'] .idt-repo-finding-filters select {
+  color: #1c355d;
+  background: #ffffff;
+  border-color: rgba(42, 71, 119, 0.32);
+}
+
+html[data-theme='light'] .idt-repo-finding-row {
+  background: rgba(245, 249, 255, 0.98);
+  border-color: rgba(42, 71, 119, 0.18);
+}
+
+html[data-theme='light'] .idt-repo-finding-row:hover,
+html[data-theme='light'] .idt-repo-finding-row:focus-visible,
+html[data-theme='light'] .idt-repo-finding-row.is-selected {
+  background: rgba(232, 241, 255, 0.98);
+  border-color: rgba(75, 110, 167, 0.45);
+}
+
+html[data-theme='light'] .idt-repo-finding-link {
+  color: #1f4f96;
+}
+
+html[data-theme='light'] .idt-repo-finding-code pre {
+  background: #0f1724;
+  border-color: rgba(42, 71, 119, 0.18);
 }
 
 html[data-theme='light'] .idt-auth-visual,


### PR DESCRIPTION
Fixes #567

## What Changed
- added stable repo-finding `repository` and `source_url` fields so API clients can jump directly to GitHub blob lines
- derive GitHub source links from `owner/repo`, `https://`, `ssh://`, and `git@` repository targets
- pin new snapshot-based repo misconfiguration findings to the resolved HEAD commit SHA instead of the literal `HEAD` ref
- replaced the authenticated findings placeholder with a tenancy-scoped repository findings view, detail panel, and direct GitHub jump action
- updated OpenAPI, repo-exposure docs, phase-3 dashboard docs, changelog, and regression tests for the new contract

## Why
- issue #567 is a real product gap: repo findings already carried enough location context to identify the exact source line, but the contract did not expose a stable link and the authenticated app had no repo-finding drill-in surface

## Impact and Risk
- analysts can now move from a repo finding to the exact GitHub line from the authenticated findings route
- new scans produce stable commit-pinned links for HEAD snapshot findings, while existing persisted findings still read back without a migration
- `source_url` is intentionally limited to GitHub-style repositories and only appears when repository, commit, file path, and line data are available

## Validation Performed
- `go test ./internal/api ./internal/domain ./internal/repoexposure`
- `go vet ./...`
- `go test ./...`
- `npm run test:ci --prefix web`
- `npm run build --prefix web`
- browser-verified `http://127.0.0.1:4173/app/tenant-a/workspace-a/findings` with mocked `/v1/me`, `/v1/repo-scans`, and `/v1/repo-findings` responses to confirm the rendered GitHub jump path

## AI Usage Disclosure
- AI-assisted: yes
- Tools used: Codex
- Where used: `internal/api`, `internal/repoexposure`, `internal/domain`, `web/src`, and docs updates for the repo-finding contract
- Human verification performed: reviewed the diff, ran the commands above, and verified the findings route in a browser against mocked API responses


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds direct GitHub line links to repository findings via new `repository` and `source_url` fields, and ships a repo findings UI with an “Open in GitHub” action. New scans pin snapshot misconfig findings to the resolved HEAD SHA for stable links.

- **New Features**
  - API: expose `repository` and `source_url` on repo findings; build GitHub blob links from `owner/repo`, `https://`, `ssh://`, and `git@` targets.
  - Scanner: resolve and record the HEAD commit SHA for snapshot misconfig findings to keep links stable.
  - App: add tenancy-scoped repo findings list with scan/severity/type filters, detail panel, and direct “Open in GitHub” link.
  - Docs/OpenAPI/Tests: updated contracts, docs, and regression coverage.

- **Migration**
  - No data migration needed; existing findings continue to read.
  - `source_url` is emitted only for GitHub repos when repository, commit, file path, and line are available.

<sup>Written for commit 09e4cccaf2599aee6d3a71121cafe0de233b2be2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

