### PR TITLE
fix: add expiring finding suppression baselines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Added expiring suppression baselines for findings:
+  - findings now expose deterministic `confidence_score` values to help analysts judge likely false positives
+  - finding suppressions now require a future `suppression_expires_at` when a finding is moved into `suppressed`
+  - new `/v1/findings/baseline/export` and `/v1/findings/baseline/import` endpoints let teams carry forward known false positives without auto-suppressing changed future variants
 - Added a plan-first AWS API hosting layer:
   - defines ECS/Fargate API service, HTTPS load balancer, task roles, security groups, health checks, and CPU autoscaling primitives
   - keeps API hosting resource creation disabled by default for cost-safe CI validation

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -42,6 +42,14 @@ x-identrail-route-authorizations:
     resource_type: finding_export
     resource_id_param: finding_id
   - method: GET
+    path: /v1/findings/baseline/export
+    action: findings.read
+    resource_type: finding_baseline
+  - method: POST
+    path: /v1/findings/baseline/import
+    action: findings.triage
+    resource_type: finding_baseline
+  - method: GET
     path: /v1/findings/trends
     action: findings.read
     resource_type: finding_trend
@@ -1949,6 +1957,69 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/FindingsSummary"
+  /v1/findings/baseline/export:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+    get:
+      tags: [Findings]
+      summary: Export suppressed findings as one reusable baseline
+      operationId: exportFindingBaseline
+      parameters:
+        - $ref: "#/components/parameters/limit"
+        - in: query
+          name: scan_id
+          schema: { type: string }
+      responses:
+        "200":
+          description: Finding suppression baseline
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FindingBaseline"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/findings/baseline/import:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+    post:
+      tags: [Findings]
+      summary: Import one finding suppression baseline into a scan
+      operationId: importFindingBaseline
+      parameters:
+        - in: query
+          name: scan_id
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FindingBaselineImportRequest"
+      responses:
+        "200":
+          description: Baseline import results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FindingBaselineImportResult"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Forbidden
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /v1/findings/trends:
     parameters:
       - $ref: "#/components/parameters/scopeTenantID"
@@ -3590,6 +3661,7 @@ components:
           type: string
           format: date-time
           nullable: true
+          description: Required and must be in the future when `status` is `suppressed`.
         comment:
           type: string
     FindingTriageEvent:
@@ -3619,6 +3691,10 @@ components:
         scan_id: { type: string }
         type: { $ref: "#/components/schemas/FindingType" }
         severity: { $ref: "#/components/schemas/FindingSeverity" }
+        confidence_score:
+          type: number
+          format: double
+          description: Deterministic analyst-facing confidence score for the finding, from 0.0 to 1.0.
         title: { type: string }
         human_summary: { type: string }
         path:
@@ -3659,6 +3735,80 @@ components:
           format: date-time
         triage:
           $ref: "#/components/schemas/FindingTriage"
+    FindingBaseline:
+      type: object
+      properties:
+        schema_version: { type: string }
+        match_mode: { type: string }
+        exported_at:
+          type: string
+          format: date-time
+        source_scan_id: { type: string }
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/FindingBaselineEntry"
+    FindingBaselineEntry:
+      type: object
+      properties:
+        finding_id: { type: string }
+        type: { $ref: "#/components/schemas/FindingType" }
+        severity: { $ref: "#/components/schemas/FindingSeverity" }
+        confidence_score:
+          type: number
+          format: double
+        title: { type: string }
+        human_summary: { type: string }
+        path:
+          type: array
+          items: { type: string }
+        repository: { type: string }
+        file_path: { type: string }
+        detector: { type: string }
+        match_fingerprint: { type: string }
+        suppression_expires_at:
+          type: string
+          format: date-time
+          nullable: true
+        assignee: { type: string }
+    FindingBaselineImportRequest:
+      type: object
+      properties:
+        baseline:
+          $ref: "#/components/schemas/FindingBaseline"
+        comment:
+          type: string
+    FindingBaselineImportResult:
+      type: object
+      properties:
+        scan_id: { type: string }
+        imported_at:
+          type: string
+          format: date-time
+        applied_count:
+          type: integer
+          minimum: 0
+        skipped_count:
+          type: integer
+          minimum: 0
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/FindingBaselineImportItem"
+    FindingBaselineImportItem:
+      type: object
+      properties:
+        baseline_finding_id: { type: string }
+        finding_id: { type: string }
+        match_confidence_score:
+          type: number
+          format: double
+        status: { type: string }
+        reason: { type: string }
+        suppression_expires_at:
+          type: string
+          format: date-time
+          nullable: true
     RepoFindingClusterSpread:
       type: object
       properties:

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -642,6 +642,8 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/findings/:finding_id", Action: policyActionFindingsRead, ResourceType: "finding", ResourceIDParam: "finding_id"},
 		{Method: http.MethodGet, Path: "/v1/findings/:finding_id/history", Action: policyActionFindingsRead, ResourceType: "finding_history", ResourceIDParam: "finding_id"},
 		{Method: http.MethodGet, Path: "/v1/findings/:finding_id/exports", Action: policyActionFindingsRead, ResourceType: "finding_export", ResourceIDParam: "finding_id"},
+		{Method: http.MethodGet, Path: "/v1/findings/baseline/export", Action: policyActionFindingsRead, ResourceType: "finding_baseline"},
+		{Method: http.MethodPost, Path: "/v1/findings/baseline/import", Action: policyActionFindingsTriage, ResourceType: "finding_baseline"},
 		{Method: http.MethodGet, Path: "/v1/findings/trends", Action: policyActionFindingsRead, ResourceType: "finding_trend"},
 		{Method: http.MethodGet, Path: "/v1/findings/summary", Action: policyActionFindingsRead, ResourceType: "finding_summary"},
 		{Method: http.MethodPatch, Path: "/v1/findings/:finding_id/triage", Action: policyActionFindingsTriage, ResourceType: "finding", ResourceIDParam: "finding_id"},

--- a/internal/api/finding_baselines.go
+++ b/internal/api/finding_baselines.go
@@ -11,12 +11,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/identrail/identrail/internal/db"
 	"github.com/identrail/identrail/internal/domain"
 )
 
 const (
 	findingBaselineSchemaVersion        = "v1"
 	findingBaselineImportMatchThreshold = 0.95
+	findingBaselineImportPageSize       = 1000
 )
 
 // ErrInvalidFindingBaselineRequest indicates invalid baseline export/import input.
@@ -121,22 +123,9 @@ func (s *Service) ImportFindingBaseline(ctx context.Context, request FindingBase
 		}
 		normalizedScanID = latest
 	}
-	targetFindings, err := s.ListFindingsFiltered(ctx, max(len(request.Baseline.Items)*4, 5000), FindingsFilter{
-		ScanID: normalizedScanID,
-		SortBy: "created_at",
-	})
+	findingsByID, findingsByFingerprint, err := s.loadTargetFindingsForBaselineImport(ctx, normalizedScanID, now)
 	if err != nil {
 		return FindingBaselineImportResult{}, err
-	}
-	findingsByID := make(map[string]domain.Finding, len(targetFindings))
-	findingsByFingerprint := make(map[string][]domain.Finding, len(targetFindings))
-	for _, finding := range targetFindings {
-		findingsByID[strings.TrimSpace(finding.ID)] = finding
-		fingerprint := findingBaselineFingerprint(finding)
-		if fingerprint == "" {
-			continue
-		}
-		findingsByFingerprint[fingerprint] = append(findingsByFingerprint[fingerprint], finding)
 	}
 
 	result := FindingBaselineImportResult{
@@ -223,6 +212,52 @@ func (s *Service) ImportFindingBaseline(ctx context.Context, request FindingBase
 	}
 
 	return result, nil
+}
+
+func (s *Service) loadTargetFindingsForBaselineImport(
+	ctx context.Context,
+	scanID string,
+	now time.Time,
+) (map[string]domain.Finding, map[string][]domain.Finding, error) {
+	findingsByID := map[string]domain.Finding{}
+	findingsByFingerprint := map[string][]domain.Finding{}
+	offset := 0
+
+	for {
+		page, err := s.Store.ListFindingsFiltered(ctx, db.FindingListFilter{
+			ScanID:   scanID,
+			SortBy:   "created_at",
+			SortDesc: true,
+			Limit:    findingBaselineImportPageSize,
+			Offset:   offset,
+			Now:      now,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(page) == 0 {
+			break
+		}
+
+		hasMore := len(page) > findingBaselineImportPageSize
+		if hasMore {
+			page = page[:findingBaselineImportPageSize]
+		}
+		for _, finding := range enrichFindings(page) {
+			findingsByID[strings.TrimSpace(finding.ID)] = finding
+			fingerprint := findingBaselineFingerprint(finding)
+			if fingerprint == "" {
+				continue
+			}
+			findingsByFingerprint[fingerprint] = append(findingsByFingerprint[fingerprint], finding)
+		}
+		if !hasMore {
+			break
+		}
+		offset += findingBaselineImportPageSize
+	}
+
+	return findingsByID, findingsByFingerprint, nil
 }
 
 func scoreFindingConfidence(finding domain.Finding) float64 {

--- a/internal/api/finding_baselines.go
+++ b/internal/api/finding_baselines.go
@@ -1,0 +1,405 @@
+package api
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"math"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+const (
+	findingBaselineSchemaVersion        = "v1"
+	findingBaselineImportMatchThreshold = 0.95
+)
+
+// ErrInvalidFindingBaselineRequest indicates invalid baseline export/import input.
+var ErrInvalidFindingBaselineRequest = errors.New("invalid finding baseline request")
+
+// FindingBaseline captures one portable false-positive suppression baseline.
+type FindingBaseline struct {
+	SchemaVersion string                 `json:"schema_version"`
+	MatchMode     string                 `json:"match_mode"`
+	ExportedAt    time.Time              `json:"exported_at"`
+	SourceScanID  string                 `json:"source_scan_id,omitempty"`
+	Items         []FindingBaselineEntry `json:"items"`
+}
+
+// FindingBaselineEntry stores one exact finding match target plus suppression metadata.
+type FindingBaselineEntry struct {
+	FindingID            string                 `json:"finding_id"`
+	Type                 domain.FindingType     `json:"type"`
+	Severity             domain.FindingSeverity `json:"severity"`
+	ConfidenceScore      float64                `json:"confidence_score,omitempty"`
+	Title                string                 `json:"title"`
+	HumanSummary         string                 `json:"human_summary"`
+	Path                 []string               `json:"path,omitempty"`
+	Repository           string                 `json:"repository,omitempty"`
+	FilePath             string                 `json:"file_path,omitempty"`
+	Detector             string                 `json:"detector,omitempty"`
+	MatchFingerprint     string                 `json:"match_fingerprint"`
+	SuppressionExpiresAt *time.Time             `json:"suppression_expires_at,omitempty"`
+	Assignee             string                 `json:"assignee,omitempty"`
+}
+
+// FindingBaselineImportRequest captures one baseline application request.
+type FindingBaselineImportRequest struct {
+	ScanID   string          `json:"scan_id,omitempty"`
+	Baseline FindingBaseline `json:"baseline"`
+	Comment  string          `json:"comment,omitempty"`
+}
+
+// FindingBaselineImportResult returns baseline import outcomes per entry.
+type FindingBaselineImportResult struct {
+	ScanID       string                      `json:"scan_id"`
+	ImportedAt   time.Time                   `json:"imported_at"`
+	AppliedCount int                         `json:"applied_count"`
+	SkippedCount int                         `json:"skipped_count"`
+	Items        []FindingBaselineImportItem `json:"items"`
+}
+
+// FindingBaselineImportItem reports one entry application decision.
+type FindingBaselineImportItem struct {
+	BaselineFindingID    string     `json:"baseline_finding_id"`
+	FindingID            string     `json:"finding_id,omitempty"`
+	MatchConfidenceScore float64    `json:"match_confidence_score,omitempty"`
+	Status               string     `json:"status"`
+	Reason               string     `json:"reason,omitempty"`
+	SuppressionExpiresAt *time.Time `json:"suppression_expires_at,omitempty"`
+}
+
+func (s *Service) ExportFindingBaseline(ctx context.Context, scanID string, limit int) (FindingBaseline, error) {
+	ctx = s.scopeContext(ctx)
+	normalizedScanID := strings.TrimSpace(scanID)
+	if normalizedScanID == "" {
+		latest, err := s.latestScanID(ctx)
+		if err != nil {
+			return FindingBaseline{}, err
+		}
+		normalizedScanID = latest
+	}
+	findings, err := s.ListFindingsFiltered(ctx, limit, FindingsFilter{
+		ScanID:          normalizedScanID,
+		LifecycleStatus: string(domain.FindingLifecycleSuppressed),
+		SortBy:          "created_at",
+		SortDesc:        true,
+	})
+	if err != nil {
+		return FindingBaseline{}, err
+	}
+	items := make([]FindingBaselineEntry, 0, len(findings))
+	for _, finding := range findings {
+		items = append(items, findingBaselineEntryFromFinding(finding))
+	}
+	sortFindingBaselineEntries(items)
+	return FindingBaseline{
+		SchemaVersion: findingBaselineSchemaVersion,
+		MatchMode:     "exact_fingerprint_v1",
+		ExportedAt:    s.Now().UTC(),
+		SourceScanID:  normalizedScanID,
+		Items:         items,
+	}, nil
+}
+
+func (s *Service) ImportFindingBaseline(ctx context.Context, request FindingBaselineImportRequest, actor string) (FindingBaselineImportResult, error) {
+	ctx = s.scopeContext(ctx)
+	if err := validateFindingBaselineImportRequest(request); err != nil {
+		return FindingBaselineImportResult{}, err
+	}
+	now := s.Now().UTC()
+	normalizedScanID := strings.TrimSpace(request.ScanID)
+	if normalizedScanID == "" {
+		latest, err := s.latestScanID(ctx)
+		if err != nil {
+			return FindingBaselineImportResult{}, err
+		}
+		normalizedScanID = latest
+	}
+	targetFindings, err := s.ListFindingsFiltered(ctx, max(len(request.Baseline.Items)*4, 5000), FindingsFilter{
+		ScanID: normalizedScanID,
+		SortBy: "created_at",
+	})
+	if err != nil {
+		return FindingBaselineImportResult{}, err
+	}
+	findingsByID := make(map[string]domain.Finding, len(targetFindings))
+	findingsByFingerprint := make(map[string][]domain.Finding, len(targetFindings))
+	for _, finding := range targetFindings {
+		findingsByID[strings.TrimSpace(finding.ID)] = finding
+		fingerprint := findingBaselineFingerprint(finding)
+		if fingerprint == "" {
+			continue
+		}
+		findingsByFingerprint[fingerprint] = append(findingsByFingerprint[fingerprint], finding)
+	}
+
+	result := FindingBaselineImportResult{
+		ScanID:     normalizedScanID,
+		ImportedAt: now,
+		Items:      make([]FindingBaselineImportItem, 0, len(request.Baseline.Items)),
+	}
+	comment := strings.TrimSpace(request.Comment)
+	if comment == "" {
+		comment = "suppressed from imported finding baseline"
+	}
+	suppressedStatus := string(domain.FindingLifecycleSuppressed)
+
+	for _, entry := range request.Baseline.Items {
+		itemResult := FindingBaselineImportItem{
+			BaselineFindingID:    strings.TrimSpace(entry.FindingID),
+			SuppressionExpiresAt: cloneTimePointer(entry.SuppressionExpiresAt),
+			Status:               "skipped",
+		}
+		if entry.SuppressionExpiresAt == nil {
+			itemResult.Reason = "suppression expiry missing"
+			result.Items = append(result.Items, itemResult)
+			result.SkippedCount++
+			continue
+		}
+		if !entry.SuppressionExpiresAt.After(now) {
+			itemResult.Reason = "suppression expiry already elapsed"
+			result.Items = append(result.Items, itemResult)
+			result.SkippedCount++
+			continue
+		}
+
+		finding, reason, ok := resolveBaselineImportFinding(entry, findingsByID, findingsByFingerprint)
+		if !ok {
+			itemResult.Reason = reason
+			result.Items = append(result.Items, itemResult)
+			result.SkippedCount++
+			continue
+		}
+		itemResult.FindingID = finding.ID
+		itemResult.MatchConfidenceScore = scoreFindingBaselineMatch(entry, finding)
+		if itemResult.MatchConfidenceScore < findingBaselineImportMatchThreshold {
+			itemResult.Reason = "baseline match confidence below required threshold"
+			result.Items = append(result.Items, itemResult)
+			result.SkippedCount++
+			continue
+		}
+
+		if finding.Triage.Status == domain.FindingLifecycleSuppressed &&
+			timePointersEqual(finding.Triage.SuppressionExpiresAt, entry.SuppressionExpiresAt) &&
+			strings.TrimSpace(finding.Triage.Assignee) == strings.TrimSpace(entry.Assignee) {
+			itemResult.Reason = "finding already suppressed with matching expiry"
+			result.Items = append(result.Items, itemResult)
+			result.SkippedCount++
+			continue
+		}
+
+		expiry := entry.SuppressionExpiresAt.UTC().Format(time.RFC3339)
+		triageRequest := FindingTriageRequest{
+			Status:               &suppressedStatus,
+			SuppressionExpiresAt: &expiry,
+			Comment:              comment,
+		}
+		if strings.TrimSpace(entry.Assignee) != "" {
+			assignee := strings.TrimSpace(entry.Assignee)
+			triageRequest.Assignee = &assignee
+		}
+		updated, err := s.TriageFinding(ctx, finding.ID, normalizedScanID, triageRequest, actor)
+		if err != nil {
+			if errors.Is(err, ErrInvalidFindingTriageRequest) {
+				itemResult.Reason = "finding triage update rejected"
+				result.Items = append(result.Items, itemResult)
+				result.SkippedCount++
+				continue
+			}
+			return FindingBaselineImportResult{}, err
+		}
+		itemResult.FindingID = updated.ID
+		itemResult.SuppressionExpiresAt = cloneTimePointer(updated.Triage.SuppressionExpiresAt)
+		itemResult.Status = "applied"
+		itemResult.Reason = ""
+		result.Items = append(result.Items, itemResult)
+		result.AppliedCount++
+	}
+
+	return result, nil
+}
+
+func scoreFindingConfidence(finding domain.Finding) float64 {
+	score := 0.70
+	switch finding.Type {
+	case domain.FindingOwnerless:
+		score = 0.92
+	case domain.FindingRiskyTrustPolicy:
+		score = 0.88
+	case domain.FindingEscalationPath:
+		score = 0.86
+	case domain.FindingOverPrivileged:
+		score = 0.78
+	case domain.FindingStaleIdentity:
+		score = 0.74
+	case domain.FindingSecretExposure:
+		score = 0.96
+	case domain.FindingRepoMisconfig:
+		score = 0.84
+	}
+	if len(finding.Path) > 0 {
+		score += 0.03
+	}
+	if len(finding.Evidence) > 0 {
+		score += 0.03
+	}
+	if strings.TrimSpace(finding.Repository) != "" || strings.TrimSpace(finding.FilePath) != "" {
+		score += 0.02
+	}
+	if score > 0.99 {
+		score = 0.99
+	}
+	return roundConfidenceScore(score)
+}
+
+func scoreFindingBaselineMatch(entry FindingBaselineEntry, finding domain.Finding) float64 {
+	fingerprint := findingBaselineFingerprint(finding)
+	if fingerprint != "" && strings.TrimSpace(entry.MatchFingerprint) == fingerprint {
+		if strings.TrimSpace(entry.FindingID) == strings.TrimSpace(finding.ID) {
+			return 1.00
+		}
+		return 0.97
+	}
+	score := 0.0
+	if strings.TrimSpace(entry.FindingID) == strings.TrimSpace(finding.ID) {
+		score += 0.40
+	}
+	if entry.Type == finding.Type {
+		score += 0.15
+	}
+	if entry.Severity == finding.Severity {
+		score += 0.10
+	}
+	if normalizeComparableText(entry.Title) == normalizeComparableText(finding.Title) {
+		score += 0.10
+	}
+	if slices.Equal(entry.Path, finding.Path) {
+		score += 0.10
+	}
+	if strings.TrimSpace(entry.MatchFingerprint) == findingBaselineFingerprint(finding) {
+		score += 0.15
+	}
+	return roundConfidenceScore(score)
+}
+
+func findingBaselineEntryFromFinding(finding domain.Finding) FindingBaselineEntry {
+	return FindingBaselineEntry{
+		FindingID:            finding.ID,
+		Type:                 finding.Type,
+		Severity:             finding.Severity,
+		ConfidenceScore:      scoreFindingConfidence(finding),
+		Title:                finding.Title,
+		HumanSummary:         finding.HumanSummary,
+		Path:                 append([]string(nil), finding.Path...),
+		Repository:           finding.Repository,
+		FilePath:             finding.FilePath,
+		Detector:             finding.Detector,
+		MatchFingerprint:     findingBaselineFingerprint(finding),
+		SuppressionExpiresAt: cloneTimePointer(finding.Triage.SuppressionExpiresAt),
+		Assignee:             finding.Triage.Assignee,
+	}
+}
+
+func findingBaselineFingerprint(finding domain.Finding) string {
+	payload := struct {
+		Type         domain.FindingType     `json:"type"`
+		Severity     domain.FindingSeverity `json:"severity"`
+		Title        string                 `json:"title"`
+		HumanSummary string                 `json:"human_summary"`
+		Path         []string               `json:"path,omitempty"`
+		Repository   string                 `json:"repository,omitempty"`
+		FilePath     string                 `json:"file_path,omitempty"`
+		Detector     string                 `json:"detector,omitempty"`
+		Evidence     map[string]any         `json:"evidence,omitempty"`
+		Remediation  string                 `json:"remediation,omitempty"`
+	}{
+		Type:         finding.Type,
+		Severity:     finding.Severity,
+		Title:        strings.TrimSpace(finding.Title),
+		HumanSummary: strings.TrimSpace(finding.HumanSummary),
+		Path:         append([]string(nil), finding.Path...),
+		Repository:   strings.TrimSpace(finding.Repository),
+		FilePath:     strings.TrimSpace(finding.FilePath),
+		Detector:     strings.TrimSpace(finding.Detector),
+		Evidence:     finding.Evidence,
+		Remediation:  strings.TrimSpace(finding.Remediation),
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:])
+}
+
+func validateFindingBaselineImportRequest(request FindingBaselineImportRequest) error {
+	if strings.TrimSpace(request.Baseline.SchemaVersion) != findingBaselineSchemaVersion {
+		return ErrInvalidFindingBaselineRequest
+	}
+	if len(request.Baseline.Items) == 0 {
+		return ErrInvalidFindingBaselineRequest
+	}
+	for _, entry := range request.Baseline.Items {
+		if strings.TrimSpace(entry.FindingID) == "" || strings.TrimSpace(entry.MatchFingerprint) == "" {
+			return ErrInvalidFindingBaselineRequest
+		}
+	}
+	return nil
+}
+
+func sortFindingBaselineEntries(items []FindingBaselineEntry) {
+	slices.SortFunc(items, func(a, b FindingBaselineEntry) int {
+		if a.FindingID == b.FindingID {
+			return strings.Compare(a.Title, b.Title)
+		}
+		return strings.Compare(a.FindingID, b.FindingID)
+	})
+}
+
+func roundConfidenceScore(value float64) float64 {
+	return math.Round(value*100) / 100
+}
+
+func normalizeComparableText(raw string) string {
+	return strings.ToLower(strings.TrimSpace(raw))
+}
+
+func cloneTimePointer(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	copied := value.UTC()
+	return &copied
+}
+
+func resolveBaselineImportFinding(
+	entry FindingBaselineEntry,
+	findingsByID map[string]domain.Finding,
+	findingsByFingerprint map[string][]domain.Finding,
+) (domain.Finding, string, bool) {
+	if finding, exists := findingsByID[strings.TrimSpace(entry.FindingID)]; exists {
+		return finding, "", true
+	}
+	matches := findingsByFingerprint[strings.TrimSpace(entry.MatchFingerprint)]
+	switch len(matches) {
+	case 0:
+		return domain.Finding{}, "finding not present in target scan", false
+	case 1:
+		return matches[0], "", true
+	default:
+		return domain.Finding{}, "multiple exact baseline matches found in target scan", false
+	}
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/api/finding_baselines_test.go
+++ b/internal/api/finding_baselines_test.go
@@ -1,0 +1,135 @@
+package api
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+func TestScoreFindingBaselineMatch(t *testing.T) {
+	now := time.Date(2026, 3, 25, 12, 0, 0, 0, time.UTC)
+	base := domain.Finding{
+		ID:           "finding-1",
+		Type:         domain.FindingOwnerless,
+		Severity:     domain.SeverityHigh,
+		Title:        "Ownerless identity: payments-role",
+		HumanSummary: "No ownership metadata is attached to this identity.",
+		Path:         []string{"identity:payments-role"},
+		Evidence:     map[string]any{"identity_id": "identity:payments-role"},
+		CreatedAt:    now,
+	}
+	entry := findingBaselineEntryFromFinding(base)
+
+	if score := scoreFindingBaselineMatch(entry, base); score != 1 {
+		t.Fatalf("expected exact id+fingerprint match score 1.00, got %.2f", score)
+	}
+
+	renumbered := base
+	renumbered.ID = "finding-2"
+	if score := scoreFindingBaselineMatch(entry, renumbered); score != 0.97 {
+		t.Fatalf("expected exact fingerprint fallback score 0.97, got %.2f", score)
+	}
+
+	changed := base
+	changed.HumanSummary = "Ownership metadata is still missing after the latest scan."
+	if score := scoreFindingBaselineMatch(entry, changed); score >= findingBaselineImportMatchThreshold {
+		t.Fatalf("expected changed variant score below threshold, got %.2f", score)
+	}
+}
+
+func TestValidateFindingBaselineImportRequestRejectsInvalidShapes(t *testing.T) {
+	valid := FindingBaselineImportRequest{
+		Baseline: FindingBaseline{
+			SchemaVersion: findingBaselineSchemaVersion,
+			Items: []FindingBaselineEntry{{
+				FindingID:        "finding-1",
+				MatchFingerprint: "abc123",
+			}},
+		},
+	}
+	if err := validateFindingBaselineImportRequest(valid); err != nil {
+		t.Fatalf("expected valid baseline import request, got %v", err)
+	}
+
+	cases := []FindingBaselineImportRequest{
+		{},
+		{Baseline: FindingBaseline{SchemaVersion: "v0", Items: valid.Baseline.Items}},
+		{Baseline: FindingBaseline{SchemaVersion: findingBaselineSchemaVersion}},
+		{Baseline: FindingBaseline{SchemaVersion: findingBaselineSchemaVersion, Items: []FindingBaselineEntry{{MatchFingerprint: "abc123"}}}},
+		{Baseline: FindingBaseline{SchemaVersion: findingBaselineSchemaVersion, Items: []FindingBaselineEntry{{FindingID: "finding-1"}}}},
+	}
+	for _, tc := range cases {
+		if err := validateFindingBaselineImportRequest(tc); !errors.Is(err, ErrInvalidFindingBaselineRequest) {
+			t.Fatalf("expected invalid request error for %+v, got %v", tc, err)
+		}
+	}
+}
+
+func TestResolveBaselineImportFinding(t *testing.T) {
+	findingByID := domain.Finding{ID: "finding-1"}
+	findingByFingerprint := domain.Finding{ID: "finding-2"}
+
+	byID, reason, ok := resolveBaselineImportFinding(
+		FindingBaselineEntry{FindingID: "finding-1", MatchFingerprint: "fp-1"},
+		map[string]domain.Finding{"finding-1": findingByID},
+		map[string][]domain.Finding{},
+	)
+	if !ok || reason != "" || byID.ID != "finding-1" {
+		t.Fatalf("expected id lookup to win, got finding=%+v reason=%q ok=%v", byID, reason, ok)
+	}
+
+	byFingerprint, reason, ok := resolveBaselineImportFinding(
+		FindingBaselineEntry{FindingID: "missing", MatchFingerprint: "fp-1"},
+		map[string]domain.Finding{},
+		map[string][]domain.Finding{"fp-1": {findingByFingerprint}},
+	)
+	if !ok || reason != "" || byFingerprint.ID != "finding-2" {
+		t.Fatalf("expected fingerprint fallback to resolve, got finding=%+v reason=%q ok=%v", byFingerprint, reason, ok)
+	}
+
+	if _, reason, ok := resolveBaselineImportFinding(
+		FindingBaselineEntry{FindingID: "missing", MatchFingerprint: "missing"},
+		map[string]domain.Finding{},
+		map[string][]domain.Finding{},
+	); ok || reason != "finding not present in target scan" {
+		t.Fatalf("expected missing finding reason, got reason=%q ok=%v", reason, ok)
+	}
+
+	if _, reason, ok := resolveBaselineImportFinding(
+		FindingBaselineEntry{FindingID: "missing", MatchFingerprint: "fp-2"},
+		map[string]domain.Finding{},
+		map[string][]domain.Finding{"fp-2": {findingByFingerprint, findingByID}},
+	); ok || reason != "multiple exact baseline matches found in target scan" {
+		t.Fatalf("expected ambiguous fingerprint reason, got reason=%q ok=%v", reason, ok)
+	}
+}
+
+func TestSortFindingBaselineEntriesAndHelpers(t *testing.T) {
+	now := time.Date(2026, 3, 25, 12, 0, 0, 0, time.UTC)
+	items := []FindingBaselineEntry{
+		{FindingID: "finding-2", Title: "zeta"},
+		{FindingID: "finding-1", Title: "omega"},
+		{FindingID: "finding-1", Title: "alpha"},
+	}
+	sortFindingBaselineEntries(items)
+	if items[0].Title != "alpha" || items[1].Title != "omega" || items[2].FindingID != "finding-2" {
+		t.Fatalf("unexpected baseline sort order: %+v", items)
+	}
+
+	cloned := cloneTimePointer(&now)
+	if cloned == nil || !cloned.Equal(now) || cloned == &now {
+		t.Fatalf("expected cloned time pointer, got %+v", cloned)
+	}
+	if cloneTimePointer(nil) != nil {
+		t.Fatal("expected nil clone for nil input")
+	}
+
+	if got := normalizeComparableText("  Risky Trust  "); got != "risky trust" {
+		t.Fatalf("unexpected comparable text normalization %q", got)
+	}
+	if got := max(2, 5); got != 5 {
+		t.Fatalf("expected max helper to return 5, got %d", got)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -328,6 +328,12 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		v1.GET("/findings/:finding_id/exports", func(c *gin.Context) {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "scan service unavailable"})
 		})
+		v1.GET("/findings/baseline/export", func(c *gin.Context) {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "scan service unavailable"})
+		})
+		v1.POST("/findings/baseline/import", func(c *gin.Context) {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "scan service unavailable"})
+		})
 		v1.GET("/findings/trends", func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"items": []any{}})
 		})
@@ -422,6 +428,56 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			return
 		}
 		c.JSON(http.StatusOK, summary)
+	})
+
+	v1.GET("/findings/baseline/export", func(c *gin.Context) {
+		limit := parseLimit(c.Query("limit"), defaultFindingsLimit, maxListLimit)
+		scanID, ok := optionalUUIDParam(c, c.Query("scan_id"), "scan_id")
+		if !ok {
+			return
+		}
+		baseline, err := svc.ExportFindingBaseline(c.Request.Context(), scanID, limit)
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "scan not found"})
+				return
+			}
+			logger.Error("export finding baseline", telemetry.ZapError(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to export finding baseline"})
+			return
+		}
+		c.JSON(http.StatusOK, baseline)
+	})
+
+	v1.POST("/findings/baseline/import", func(c *gin.Context) {
+		scanID, ok := optionalUUIDParam(c, c.Query("scan_id"), "scan_id")
+		if !ok {
+			return
+		}
+		var request FindingBaselineImportRequest
+		if err := c.ShouldBindJSON(&request); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid finding baseline request"})
+			return
+		}
+		request.ScanID = scanID
+		result, err := svc.ImportFindingBaseline(
+			c.Request.Context(),
+			request,
+			triageActorFromContext(c, opts.AuditFingerprinter),
+		)
+		if err != nil {
+			switch {
+			case errors.Is(err, ErrInvalidFindingBaselineRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid finding baseline request"})
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "scan not found"})
+			default:
+				logger.Error("import finding baseline", telemetry.ZapError(err))
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to import finding baseline"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, result)
 	})
 
 	v1.GET("/findings/:finding_id", func(c *gin.Context) {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1569,6 +1569,115 @@ func TestRouterFindingTriageWorkflowEndpoints(t *testing.T) {
 	}
 }
 
+func TestRouterFindingBaselineEndpoints(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+	svc.Now = func() time.Time { return time.Date(2026, 3, 24, 10, 0, 0, 0, time.UTC) }
+	r := NewRouter(logger, metrics, svc, RouterOptions{
+		APIKeys:      []string{"read-key", "write-key"},
+		WriteAPIKeys: []string{"write-key"},
+	})
+
+	triggerReq := httptest.NewRequest(http.MethodPost, "/v1/scans", nil)
+	triggerReq.Header.Set("X-API-Key", "write-key")
+	triggerW := httptest.NewRecorder()
+	r.ServeHTTP(triggerW, triggerReq)
+	if triggerW.Code != http.StatusAccepted {
+		t.Fatalf("expected scan trigger 202, got %d", triggerW.Code)
+	}
+	var triggerBody struct {
+		Scan db.ScanRecord `json:"scan"`
+	}
+	if err := json.Unmarshal(triggerW.Body.Bytes(), &triggerBody); err != nil {
+		t.Fatalf("decode scan trigger body: %v", err)
+	}
+	if processed, err := svc.ProcessNextQueuedScan(defaultScopeContext()); err != nil || !processed {
+		t.Fatalf("process queued scan: processed=%v err=%v", processed, err)
+	}
+
+	secondScan, err := store.CreateScan(defaultScopeContext(), "aws", svc.Now().Add(2*time.Hour))
+	if err != nil {
+		t.Fatalf("create second scan: %v", err)
+	}
+	if err := store.UpsertFindings(defaultScopeContext(), secondScan.ID, []domain.Finding{{
+		ID:           "f2",
+		Type:         domain.FindingRiskyTrustPolicy,
+		Severity:     domain.SeverityHigh,
+		Title:        "Risky trust",
+		HumanSummary: "summary",
+		CreatedAt:    svc.Now().Add(2 * time.Hour),
+	}}); err != nil {
+		t.Fatalf("upsert second scan findings: %v", err)
+	}
+
+	missingExpiryReq := httptest.NewRequest(http.MethodPatch, "/v1/findings/f1/triage?scan_id="+triggerBody.Scan.ID, bytes.NewBufferString(`{"status":"suppressed"}`))
+	missingExpiryReq.Header.Set("Content-Type", "application/json")
+	missingExpiryReq.Header.Set("X-API-Key", "write-key")
+	missingExpiryW := httptest.NewRecorder()
+	r.ServeHTTP(missingExpiryW, missingExpiryReq)
+	if missingExpiryW.Code != http.StatusBadRequest {
+		t.Fatalf("expected missing suppression expiry to be rejected, got %d", missingExpiryW.Code)
+	}
+
+	expiry := svc.Now().Add(24 * time.Hour).Format(time.RFC3339)
+	triageReq := httptest.NewRequest(http.MethodPatch, "/v1/findings/f1/triage?scan_id="+triggerBody.Scan.ID, bytes.NewBufferString(`{"status":"suppressed","suppression_expires_at":"`+expiry+`","comment":"known false positive"}`))
+	triageReq.Header.Set("Content-Type", "application/json")
+	triageReq.Header.Set("X-API-Key", "write-key")
+	triageW := httptest.NewRecorder()
+	r.ServeHTTP(triageW, triageReq)
+	if triageW.Code != http.StatusOK {
+		t.Fatalf("expected suppression triage 200, got %d", triageW.Code)
+	}
+
+	exportReq := httptest.NewRequest(http.MethodGet, "/v1/findings/baseline/export?scan_id="+triggerBody.Scan.ID, nil)
+	exportReq.Header.Set("X-API-Key", "read-key")
+	exportW := httptest.NewRecorder()
+	r.ServeHTTP(exportW, exportReq)
+	if exportW.Code != http.StatusOK {
+		t.Fatalf("expected baseline export 200, got %d", exportW.Code)
+	}
+	var exported FindingBaseline
+	if err := json.Unmarshal(exportW.Body.Bytes(), &exported); err != nil {
+		t.Fatalf("decode baseline export: %v", err)
+	}
+	if len(exported.Items) != 1 || exported.Items[0].ConfidenceScore <= 0 {
+		t.Fatalf("unexpected baseline export payload: %+v", exported)
+	}
+
+	importBody, err := json.Marshal(FindingBaselineImportRequest{
+		Baseline: exported,
+		Comment:  "carry forward false positive",
+	})
+	if err != nil {
+		t.Fatalf("marshal import request: %v", err)
+	}
+	importReq := httptest.NewRequest(http.MethodPost, "/v1/findings/baseline/import?scan_id="+secondScan.ID, bytes.NewBuffer(importBody))
+	importReq.Header.Set("Content-Type", "application/json")
+	importReq.Header.Set("X-API-Key", "write-key")
+	importW := httptest.NewRecorder()
+	r.ServeHTTP(importW, importReq)
+	if importW.Code != http.StatusOK {
+		t.Fatalf("expected baseline import 200, got %d body=%s", importW.Code, importW.Body.String())
+	}
+	var imported FindingBaselineImportResult
+	if err := json.Unmarshal(importW.Body.Bytes(), &imported); err != nil {
+		t.Fatalf("decode baseline import: %v", err)
+	}
+	if imported.AppliedCount != 1 || len(imported.Items) != 1 || imported.Items[0].Status != "applied" {
+		t.Fatalf("unexpected baseline import payload: %+v", imported)
+	}
+
+	applied, err := svc.GetFinding(defaultScopeContext(), "f2", secondScan.ID)
+	if err != nil {
+		t.Fatalf("get imported finding: %v", err)
+	}
+	if applied.Triage.Status != domain.FindingLifecycleSuppressed || applied.Triage.SuppressionExpiresAt == nil {
+		t.Fatalf("expected imported suppression to apply, got %+v", applied.Triage)
+	}
+}
+
 func TestRouterWriteAuthorizationRequiresConfiguredWriteKeys(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	metrics := telemetry.NewMetrics()

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1689,6 +1689,9 @@ func (s *Service) TriageFinding(ctx context.Context, findingID string, scanID st
 		nextState.SuppressionExpiresAt = nil
 		changed = true
 	}
+	if nextState.Status == domain.FindingLifecycleSuppressed && nextState.SuppressionExpiresAt == nil {
+		return domain.Finding{}, ErrInvalidFindingTriageRequest
+	}
 	if nextState.Status == domain.FindingLifecycleSuppressed && nextState.SuppressionExpiresAt != nil && !nextState.SuppressionExpiresAt.After(now) {
 		return domain.Finding{}, ErrInvalidFindingTriageRequest
 	}
@@ -2160,6 +2163,7 @@ func enrichFindingsWithRepoContext(findings []domain.Finding, repositoryHints ..
 		if finding.SourceURL == "" {
 			finding.SourceURL = repoFindingSourceURL(finding.Repository, finding.Commit, finding.FilePath, finding.LineNumber)
 		}
+		finding.ConfidenceScore = scoreFindingConfidence(finding)
 		enriched = append(enriched, standards.EnrichFinding(finding))
 	}
 	return enriched

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -1111,6 +1111,88 @@ func TestServiceImportFindingBaselineSkipsChangedVariants(t *testing.T) {
 	}
 }
 
+func TestServiceImportFindingBaselinePagesLargeScansForFingerprintFallback(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 3, 23, 11, 0, 0, 0, time.UTC)
+	sourceScan, _ := store.CreateScan(defaultScopeContext(), "aws", now)
+	targetScan, _ := store.CreateScan(defaultScopeContext(), "aws", now.Add(2*time.Hour))
+
+	sourceFinding := domain.Finding{
+		ID:           "finding-source",
+		Type:         domain.FindingOwnerless,
+		Severity:     domain.SeverityHigh,
+		Title:        "Ownerless identity: payments-role",
+		HumanSummary: "No ownership metadata is attached to this identity.",
+		Path:         []string{"identity:payments-role"},
+		Evidence:     map[string]any{"identity_id": "identity:payments-role"},
+		CreatedAt:    now,
+	}
+	targetFinding := sourceFinding
+	targetFinding.ID = "finding-target"
+	targetFinding.CreatedAt = now
+
+	if err := store.UpsertFindings(defaultScopeContext(), sourceScan.ID, []domain.Finding{sourceFinding}); err != nil {
+		t.Fatalf("upsert source findings: %v", err)
+	}
+
+	targetFindings := make([]domain.Finding, 0, 5201)
+	for i := 0; i < 5200; i++ {
+		targetFindings = append(targetFindings, domain.Finding{
+			ID:           fmt.Sprintf("noise-%04d", i),
+			Type:         domain.FindingOwnerless,
+			Severity:     domain.SeverityLow,
+			Title:        fmt.Sprintf("Noise finding %04d", i),
+			HumanSummary: "Synthetic filler finding",
+			Path:         []string{fmt.Sprintf("identity:noise-%04d", i)},
+			Evidence:     map[string]any{"identity_id": fmt.Sprintf("identity:noise-%04d", i)},
+			CreatedAt:    now.Add(time.Duration(i+1) * time.Second),
+		})
+	}
+	targetFindings = append(targetFindings, targetFinding)
+	if err := store.UpsertFindings(defaultScopeContext(), targetScan.ID, targetFindings); err != nil {
+		t.Fatalf("upsert target findings: %v", err)
+	}
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	suppressed := string(domain.FindingLifecycleSuppressed)
+	expiry := now.Add(24 * time.Hour).Format(time.RFC3339)
+	if _, err := svc.TriageFinding(defaultScopeContext(), sourceFinding.ID, sourceScan.ID, FindingTriageRequest{
+		Status:               &suppressed,
+		SuppressionExpiresAt: &expiry,
+		Comment:              "known false positive",
+	}, "subject:owner"); err != nil {
+		t.Fatalf("triage source finding: %v", err)
+	}
+
+	baseline, err := svc.ExportFindingBaseline(defaultScopeContext(), sourceScan.ID, 10)
+	if err != nil {
+		t.Fatalf("export baseline: %v", err)
+	}
+
+	imported, err := svc.ImportFindingBaseline(defaultScopeContext(), FindingBaselineImportRequest{
+		ScanID:   targetScan.ID,
+		Baseline: baseline,
+	}, "subject:owner")
+	if err != nil {
+		t.Fatalf("import baseline: %v", err)
+	}
+	if imported.AppliedCount != 1 || imported.SkippedCount != 0 {
+		t.Fatalf("unexpected import counts for paged scan: %+v", imported)
+	}
+	if imported.Items[0].FindingID != targetFinding.ID || imported.Items[0].Status != "applied" {
+		t.Fatalf("expected paged fallback to apply to target finding, got %+v", imported.Items[0])
+	}
+
+	applied, err := svc.GetFinding(defaultScopeContext(), targetFinding.ID, targetScan.ID)
+	if err != nil {
+		t.Fatalf("get paged target finding: %v", err)
+	}
+	if applied.Triage.Status != domain.FindingLifecycleSuppressed || applied.Triage.SuppressionExpiresAt == nil {
+		t.Fatalf("expected paged target finding to be suppressed, got %+v", applied.Triage)
+	}
+}
+
 func TestServiceGetFindingExports(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -928,6 +928,18 @@ func TestServiceTriageFindingRejectsInvalidRequest(t *testing.T) {
 	}
 
 	suppressed := string(domain.FindingLifecycleSuppressed)
+	if _, err := svc.TriageFinding(
+		defaultScopeContext(),
+		"finding-1",
+		scan.ID,
+		FindingTriageRequest{
+			Status: &suppressed,
+		},
+		"subject:user-1",
+	); !errors.Is(err, ErrInvalidFindingTriageRequest) {
+		t.Fatalf("expected invalid triage request error for missing suppression expiry, got %v", err)
+	}
+
 	pastExpiry := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	if _, err := svc.TriageFinding(
 		defaultScopeContext(),
@@ -940,6 +952,162 @@ func TestServiceTriageFindingRejectsInvalidRequest(t *testing.T) {
 		"subject:user-1",
 	); !errors.Is(err, ErrInvalidFindingTriageRequest) {
 		t.Fatalf("expected invalid triage request error for past suppression expiry, got %v", err)
+	}
+}
+
+func TestServiceExportAndImportFindingBaseline(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 3, 23, 11, 0, 0, 0, time.UTC)
+	sourceScan, err := store.CreateScan(defaultScopeContext(), "aws", now)
+	if err != nil {
+		t.Fatalf("create source scan: %v", err)
+	}
+	targetScan, err := store.CreateScan(defaultScopeContext(), "aws", now.Add(2*time.Hour))
+	if err != nil {
+		t.Fatalf("create target scan: %v", err)
+	}
+
+	sourceFinding := domain.Finding{
+		ID:           "finding-1",
+		Type:         domain.FindingOwnerless,
+		Severity:     domain.SeverityHigh,
+		Title:        "Ownerless identity: payments-role",
+		HumanSummary: "No ownership metadata is attached to this identity.",
+		Path:         []string{"identity:payments-role"},
+		Evidence:     map[string]any{"identity_id": "identity:payments-role"},
+		CreatedAt:    now,
+	}
+	targetFinding := sourceFinding
+	targetFinding.ID = "finding-2"
+	targetFinding.CreatedAt = now.Add(2 * time.Hour)
+
+	if err := store.UpsertFindings(defaultScopeContext(), sourceScan.ID, []domain.Finding{sourceFinding}); err != nil {
+		t.Fatalf("upsert source findings: %v", err)
+	}
+	if err := store.UpsertFindings(defaultScopeContext(), targetScan.ID, []domain.Finding{targetFinding}); err != nil {
+		t.Fatalf("upsert target findings: %v", err)
+	}
+
+	clock := now
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return clock }
+
+	suppressed := string(domain.FindingLifecycleSuppressed)
+	expiry := clock.Add(24 * time.Hour).Format(time.RFC3339)
+	updated, err := svc.TriageFinding(defaultScopeContext(), sourceFinding.ID, sourceScan.ID, FindingTriageRequest{
+		Status:               &suppressed,
+		SuppressionExpiresAt: &expiry,
+		Comment:              "known false positive",
+	}, "subject:owner")
+	if err != nil {
+		t.Fatalf("triage source finding: %v", err)
+	}
+	if updated.ConfidenceScore <= 0 {
+		t.Fatalf("expected exported finding confidence score, got %+v", updated)
+	}
+
+	baseline, err := svc.ExportFindingBaseline(defaultScopeContext(), sourceScan.ID, 10)
+	if err != nil {
+		t.Fatalf("export baseline: %v", err)
+	}
+	if baseline.SchemaVersion != findingBaselineSchemaVersion || baseline.MatchMode != "exact_fingerprint_v1" {
+		t.Fatalf("unexpected baseline metadata: %+v", baseline)
+	}
+	if len(baseline.Items) != 1 {
+		t.Fatalf("expected one baseline item, got %+v", baseline.Items)
+	}
+	if baseline.Items[0].ConfidenceScore <= 0 || baseline.Items[0].SuppressionExpiresAt == nil {
+		t.Fatalf("expected baseline confidence and expiry, got %+v", baseline.Items[0])
+	}
+
+	imported, err := svc.ImportFindingBaseline(defaultScopeContext(), FindingBaselineImportRequest{
+		ScanID:   targetScan.ID,
+		Baseline: baseline,
+		Comment:  "carry forward false positive",
+	}, "subject:owner")
+	if err != nil {
+		t.Fatalf("import baseline: %v", err)
+	}
+	if imported.AppliedCount != 1 || imported.SkippedCount != 0 {
+		t.Fatalf("unexpected import counts: %+v", imported)
+	}
+	if len(imported.Items) != 1 || imported.Items[0].Status != "applied" || imported.Items[0].MatchConfidenceScore < findingBaselineImportMatchThreshold {
+		t.Fatalf("unexpected import items: %+v", imported.Items)
+	}
+
+	applied, err := svc.GetFinding(defaultScopeContext(), targetFinding.ID, targetScan.ID)
+	if err != nil {
+		t.Fatalf("get imported finding: %v", err)
+	}
+	if applied.Triage.Status != domain.FindingLifecycleSuppressed || applied.Triage.SuppressionExpiresAt == nil {
+		t.Fatalf("expected imported suppression to apply, got %+v", applied.Triage)
+	}
+}
+
+func TestServiceImportFindingBaselineSkipsChangedVariants(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 3, 23, 11, 0, 0, 0, time.UTC)
+	sourceScan, _ := store.CreateScan(defaultScopeContext(), "aws", now)
+	targetScan, _ := store.CreateScan(defaultScopeContext(), "aws", now.Add(2*time.Hour))
+
+	sourceFinding := domain.Finding{
+		ID:           "finding-1",
+		Type:         domain.FindingOwnerless,
+		Severity:     domain.SeverityHigh,
+		Title:        "Ownerless identity: payments-role",
+		HumanSummary: "No ownership metadata is attached to this identity.",
+		Path:         []string{"identity:payments-role"},
+		Evidence:     map[string]any{"identity_id": "identity:payments-role"},
+		CreatedAt:    now,
+	}
+	changedVariant := sourceFinding
+	changedVariant.ID = "finding-2"
+	changedVariant.HumanSummary = "Ownership metadata is still missing after the latest scan."
+	changedVariant.CreatedAt = now.Add(2 * time.Hour)
+
+	if err := store.UpsertFindings(defaultScopeContext(), sourceScan.ID, []domain.Finding{sourceFinding}); err != nil {
+		t.Fatalf("upsert source findings: %v", err)
+	}
+	if err := store.UpsertFindings(defaultScopeContext(), targetScan.ID, []domain.Finding{changedVariant}); err != nil {
+		t.Fatalf("upsert target findings: %v", err)
+	}
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	suppressed := string(domain.FindingLifecycleSuppressed)
+	expiry := now.Add(24 * time.Hour).Format(time.RFC3339)
+	if _, err := svc.TriageFinding(defaultScopeContext(), sourceFinding.ID, sourceScan.ID, FindingTriageRequest{
+		Status:               &suppressed,
+		SuppressionExpiresAt: &expiry,
+	}, "subject:owner"); err != nil {
+		t.Fatalf("triage source finding: %v", err)
+	}
+
+	baseline, err := svc.ExportFindingBaseline(defaultScopeContext(), sourceScan.ID, 10)
+	if err != nil {
+		t.Fatalf("export baseline: %v", err)
+	}
+
+	imported, err := svc.ImportFindingBaseline(defaultScopeContext(), FindingBaselineImportRequest{
+		ScanID:   targetScan.ID,
+		Baseline: baseline,
+	}, "subject:owner")
+	if err != nil {
+		t.Fatalf("import baseline: %v", err)
+	}
+	if imported.AppliedCount != 0 || imported.SkippedCount != 1 {
+		t.Fatalf("unexpected import counts: %+v", imported)
+	}
+	if imported.Items[0].Status != "skipped" || imported.Items[0].MatchConfidenceScore >= findingBaselineImportMatchThreshold {
+		t.Fatalf("expected changed variant to be skipped, got %+v", imported.Items[0])
+	}
+
+	targetState, err := svc.GetFinding(defaultScopeContext(), changedVariant.ID, targetScan.ID)
+	if err != nil {
+		t.Fatalf("get changed variant: %v", err)
+	}
+	if targetState.Triage.Status != domain.FindingLifecycleOpen {
+		t.Fatalf("expected changed variant to remain open, got %+v", targetState.Triage)
 	}
 }
 

--- a/internal/domain/json_tags_test.go
+++ b/internal/domain/json_tags_test.go
@@ -14,6 +14,7 @@ func TestFindingJSONUsesSnakeCaseFields(t *testing.T) {
 		ScanID:              "scan-1",
 		Type:                FindingSecretExposure,
 		Severity:            SeverityHigh,
+		ConfidenceScore:     0.96,
 		Title:               "title",
 		HumanSummary:        "summary",
 		Path:                []string{"app.env"},
@@ -34,7 +35,7 @@ func TestFindingJSONUsesSnakeCaseFields(t *testing.T) {
 		t.Fatalf("marshal finding: %v", err)
 	}
 	text := string(payload)
-	for _, expected := range []string{`"id"`, `"scan_id"`, `"human_summary"`, `"created_at"`, `"repository"`, `"file_path"`, `"line_number"`, `"line_snippet_redacted"`, `"source_url"`} {
+	for _, expected := range []string{`"id"`, `"scan_id"`, `"confidence_score"`, `"human_summary"`, `"created_at"`, `"repository"`, `"file_path"`, `"line_number"`, `"line_snippet_redacted"`, `"source_url"`} {
 		if !strings.Contains(text, expected) {
 			t.Fatalf("expected field %s in %s", expected, text)
 		}

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -132,6 +132,7 @@ type Finding struct {
 	ScanID              string          `json:"scan_id"`
 	Type                FindingType     `json:"type"`
 	Severity            FindingSeverity `json:"severity"`
+	ConfidenceScore     float64         `json:"confidence_score,omitempty"`
 	Title               string          `json:"title"`
 	HumanSummary        string          `json:"human_summary"`
 	Path                []string        `json:"path,omitempty"`

--- a/testdata/contracts/api_v1_findings_list_response.snapshot.json
+++ b/testdata/contracts/api_v1_findings_list_response.snapshot.json
@@ -1,6 +1,7 @@
 {
   "items": [
     {
+      "confidence_score": 0.91,
       "created_at": "\u003ctimestamp\u003e",
       "evidence": {
         "compliance_frameworks": [


### PR DESCRIPTION
Fixes #570

## Summary
- add analyst-facing `confidence_score` values plus finding baseline export/import endpoints for false-positive workflows
- require a future `suppression_expires_at` whenever a finding is moved into `suppressed`
- only reapply baselines to exact high-confidence matches so changed future variants stay open

## Impact
- gives teams a portable suppression baseline they can carry between scans without permanently hiding drifted findings
- keeps new suppressions explicitly time-bounded instead of allowing indefinite silent suppression
- documents the new contract in OpenAPI, authz route policy metadata, and the API contract snapshot

## Validation
- `go test ./internal/api ./internal/domain`
- `go vet ./...`
- `go test ./... -coverprofile=coverage.out`
- `go tool cover -func=coverage.out | tail -n 1` (`total: (statements) 80.0%`)
- `npm run test:ci --prefix web`
- `npm run build --prefix web`

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds expiring suppression baselines for findings with export/import endpoints and a new `confidence_score`. Suppressing a finding now requires a future `suppression_expires_at`; baseline import is now paged to handle large scans, and baselines only reapply to exact high-confidence matches so drifted variants stay open.

- **New Features**
  - `GET /v1/findings/baseline/export` and `POST /v1/findings/baseline/import` to carry forward known false positives between scans.
  - Deterministic `confidence_score` on findings and in baselines to aid analyst decisions.
  - Baseline import pages through large scans to find exact fingerprint matches.
  - OpenAPI and route policy updates for new endpoints; responses and contracts updated.

- **Migration**
  - When triaging to `suppressed`, you must set a future `suppression_expires_at`.
  - Use export from a scan with suppressed findings, then import into a new scan; only exact, high-confidence matches are auto-suppressed, ensuring changed variants remain open.
  - Update any clients parsing findings to handle the new `confidence_score` field.

<sup>Written for commit 07200f2a26324dc84e5852cafa6edd7ece9a71de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

