### PR TITLE
Add hosted API URL fallback

### DIFF
--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -70,16 +70,19 @@ jobs:
         if: steps.normalize-token.outputs.has_token == 'true'
         env:
           VITE_IDENTRAIL_API_URL: ${{ vars.VITE_IDENTRAIL_API_URL }}
+          IDENTRAIL_CLOUD_API_URL: https://api.identrail.com
           IDENTRAIL_WEB_ORIGINS: https://identrail.com,https://www.identrail.com,https://app.identrail.com
         run: |
           set -euo pipefail
+          api_url="$(printf '%s' "${VITE_IDENTRAIL_API_URL:-${IDENTRAIL_CLOUD_API_URL}}" | tr -d '\r\n' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
           if [ -z "${VITE_IDENTRAIL_API_URL}" ]; then
-            echo "Missing vars.VITE_IDENTRAIL_API_URL."
-            echo "Set this GitHub Actions variable before production deploys."
-            exit 1
+            echo "vars.VITE_IDENTRAIL_API_URL is not set; using Identrail Cloud default ${IDENTRAIL_CLOUD_API_URL}."
           fi
-          ./scripts/check_public_api_url.sh "${VITE_IDENTRAIL_API_URL}"
-          echo "has_api_url=true" >> "$GITHUB_OUTPUT"
+          ./scripts/check_public_api_url.sh "${api_url}"
+          {
+            echo "api_url=${api_url}"
+            echo "has_api_url=true"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upsert Vercel env VITE_IDENTRAIL_API_URL
         if: steps.normalize-token.outputs.has_token == 'true' && steps.check-api-url.outputs.has_api_url == 'true'
@@ -87,7 +90,7 @@ jobs:
           VERCEL_TOKEN: ${{ steps.normalize-token.outputs.token }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-          VITE_IDENTRAIL_API_URL: ${{ vars.VITE_IDENTRAIL_API_URL }}
+          VITE_IDENTRAIL_API_URL: ${{ steps.check-api-url.outputs.api_url }}
         run: |
           set -euo pipefail
           payload="$(jq -n --arg value "${VITE_IDENTRAIL_API_URL}" '{

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Added an Identrail Cloud API URL fallback for production web deploys:
+  - canonical hosted web domains now use `https://api.identrail.com` when no build-time API URL is injected
+  - Vercel production deploys default and upsert the same API URL when the GitHub Actions variable is absent
+  - refreshed frontend/auth deployment docs so the `api.identrail.com` split is documented consistently
 - Added expiring suppression baselines for findings:
   - findings now expose deterministic `confidence_score` values to help analysts judge likely false positives
   - finding suppressions now require a future `suppression_expires_at` when a finding is moved into `suppressed`

--- a/docs/auth/architecture.md
+++ b/docs/auth/architecture.md
@@ -106,16 +106,15 @@ See [`cookie-and-session-spec.md`](./cookie-and-session-spec.md) for the full co
 
 ## Domains
 
-Identrail uses two public domains.
+Identrail uses three public domain roles.
 
 | Purpose | Domain | What lives here |
 | --- | --- | --- |
-| Marketing | `www.identrail.com` and apex `identrail.com` | The marketing site. No app code, no cookies. |
-| Application | `app.identrail.com` | The product UI, the API endpoints (`/v1/*`), and the auth endpoints (`/auth/*`). |
+| Marketing | `www.identrail.com` and apex `identrail.com` | The marketing site and public auth entry points. No session cookies. |
+| Application | `app.identrail.com` | The product UI. |
+| API | `api.identrail.com` | API endpoints (`/v1/*`) and auth endpoints (`/auth/*`). |
 
-Cookies are scoped to `app.identrail.com` only, with no leading dot. The marketing site never sees the session cookie.
-
-We do not use `api.identrail.com`. Same-origin between the UI and API simplifies CORS, lets the cookie ride along automatically, and reduces operational surface. If a future API customer use case demands a stable `api.` host, we add it as an alias without changing this architecture.
+Cookies are scoped to the API host that issues them, with no leading dot. The marketing site never sees the session cookie. Browser calls from the web origins to `api.identrail.com` require the production CORS allowlist and credentialed requests described in [`production-api-readiness.md`](./production-api-readiness.md).
 
 The canonical production base URL lives in `IDENTRAIL_PUBLIC_BASE_URL`. The doc references this env var rather than hardcoding the string. See [`env-vars-reference.md`](./env-vars-reference.md).
 

--- a/docs/auth/production-api-readiness.md
+++ b/docs/auth/production-api-readiness.md
@@ -20,6 +20,11 @@ VITE_IDENTRAIL_API_URL=https://api.identrail.com
 ```
 
 It must not point at `https://identrail.com`, `https://www.identrail.com`, or `https://app.identrail.com`.
+When the production web bundle is served from the canonical Identrail Cloud
+domains (`identrail.com`, `www.identrail.com`, or `app.identrail.com`), it uses
+`https://api.identrail.com` as a safe default if `VITE_IDENTRAIL_API_URL` was not
+injected at build time. Self-hosted and custom-domain deployments still need an
+explicit `VITE_IDENTRAIL_API_URL` value so they never guess the wrong API.
 
 ## API Requirements
 

--- a/docs/frontend-topology.md
+++ b/docs/frontend-topology.md
@@ -11,7 +11,7 @@ Identrail uses `web/` as the active tracked frontend on `dev`.
   - Scoped shell paths: `/app/:tenantID/:workspaceID/*`
 - Typical runtime: containerized deployment (`deploy/docker/Dockerfile.web`, optional Helm `web.enabled`)
 - API URL input: `VITE_IDENTRAIL_API_URL`
-- Vercel (marketing/demo deploy): set `VITE_IDENTRAIL_API_URL` in Vercel project environment variables (or set GitHub Actions variable `VITE_IDENTRAIL_API_URL` so the deploy workflow upserts it).
+- Vercel (marketing/demo deploy): Identrail Cloud domains default to `https://api.identrail.com`; custom domains should set `VITE_IDENTRAIL_API_URL` in Vercel project environment variables or as a GitHub Actions variable so the deploy workflow upserts it.
 - Production deploys should be triggered from `dev` (example: `make vercel-prod-deploy` / `task vercel-prod-deploy`) to avoid accidentally deploying from a stale local branch.
 
 ### `VITE_IDENTRAIL_API_URL` value source
@@ -20,8 +20,8 @@ Identrail uses `web/` as the active tracked frontend on `dev`.
 - Typical value shape: `https://api.<your-domain>`
 - If the API is served from the same domain via reverse proxy, use that public API base path.
 - Configure the API deployment with `IDENTRAIL_CORS_ALLOWED_ORIGINS` set to the web app origin when the frontend and API use different origins.
-- The default Vercel CSP allows `https://api.identrail.io`; update `connect-src` when using a custom API host.
-- For Identrail Cloud, use `https://api.identrail.com` once that API domain is live. Do not use `https://identrail.com`, `https://www.identrail.com`, or `https://app.identrail.com`; those are web origins.
+- The default Vercel CSP allows `https://api.identrail.com`, the legacy `https://api.identrail.io`, and any configured `VITE_IDENTRAIL_API_URL` origin; update `connect-src` when using another custom API host.
+- For Identrail Cloud, the production web bundle falls back to `https://api.identrail.com` when it is served from `identrail.com`, `www.identrail.com`, or `app.identrail.com`. Do not use `https://identrail.com`, `https://www.identrail.com`, or `https://app.identrail.com`; those are web origins.
 
 ### Where to configure it
 
@@ -32,7 +32,7 @@ Identrail uses `web/` as the active tracked frontend on `dev`.
    - `Project` -> `Settings` -> `Environment Variables`
    - Add `VITE_IDENTRAIL_API_URL` for Production (and Preview if needed)
 
-For token-based Vercel deployments, if the GitHub Actions variable is missing, the production deploy workflow fails before deployment so the web app cannot ship without an explicit API URL. Hook-only fallback deployments cannot read Vercel project env values from GitHub Actions; keep `VITE_IDENTRAIL_API_URL` configured directly in Vercel and run the preflight manually before relying on the hook fallback.
+For token-based Vercel deployments, if the GitHub Actions variable is missing, the production deploy workflow uses the Identrail Cloud default and upserts `VITE_IDENTRAIL_API_URL=https://api.identrail.com` into Vercel. Hook-only fallback deployments cannot upsert or inspect Vercel project env values from GitHub Actions, so the runtime fallback still protects the canonical Identrail Cloud domains while custom domains must keep `VITE_IDENTRAIL_API_URL` configured directly in Vercel.
 
 ### Production API preflight
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -47,17 +47,18 @@ Checks:
 ## GitHub Action says missing `VITE_IDENTRAIL_API_URL`
 
 Symptoms:
-1. `Vercel Production Deploy` workflow logs show missing `vars.VITE_IDENTRAIL_API_URL`.
-2. Vercel dashboard still shows successful deployments.
+1. Older `Vercel Production Deploy` workflow logs show missing `vars.VITE_IDENTRAIL_API_URL`.
+2. The browser sign-in page shows `Identrail API URL is not configured`.
+3. Vercel dashboard still shows successful deployments.
 
 Why this happens:
-1. GitHub workflow checks repository variable `vars.VITE_IDENTRAIL_API_URL`.
-2. Vercel can still deploy successfully when the variable already exists directly in Vercel project settings.
-3. Hook-only fallback deploys use the env already configured in Vercel and cannot upsert or inspect that value from GitHub Actions.
+1. Vite bakes `VITE_IDENTRAIL_API_URL` into the production web bundle at build time.
+2. Token-based GitHub deploys now default Identrail Cloud to `https://api.identrail.com` and upsert that value into Vercel when the GitHub variable is missing.
+3. Hook-only fallback deploys use the env already configured in Vercel and cannot upsert or inspect that value from GitHub Actions, so canonical Identrail Cloud domains rely on the runtime default while custom domains still need an explicit value.
 
 Checks:
-1. In GitHub: `Settings` -> `Secrets and variables` -> `Actions` -> `Variables`, confirm `VITE_IDENTRAIL_API_URL` exists.
-2. In Vercel: `Project` -> `Settings` -> `Environment Variables`, confirm `VITE_IDENTRAIL_API_URL` exists for Production.
+1. In GitHub: `Settings` -> `Secrets and variables` -> `Actions` -> `Variables`, confirm `VITE_IDENTRAIL_API_URL` exists if using a custom API origin.
+2. In Vercel: `Project` -> `Settings` -> `Environment Variables`, confirm `VITE_IDENTRAIL_API_URL` exists for custom domains or non-hook deploys that must avoid the Identrail Cloud default.
 3. Ensure the value points to the public API URL (not the web frontend URL).
 
 For Identrail Cloud, the intended value is:

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { apiClient, buildQuery, mergeRequestHeaders } from './client';
+import { IDENTRAIL_CLOUD_API_URL, apiClient, buildQuery, mergeRequestHeaders, resolveAPIBaseURL } from './client';
 
 describe('buildQuery', () => {
   it('encodes defined query params only', () => {
@@ -11,6 +11,26 @@ describe('buildQuery', () => {
       missing: undefined
     });
     expect(query).toBe('?scan_id=scan-1&severity=high&include_archived=true');
+  });
+});
+
+describe('resolveAPIBaseURL', () => {
+  it('uses the configured API URL when one is provided', () => {
+    expect(resolveAPIBaseURL(' https://api.example.com ', true, 'identrail.com')).toBe('https://api.example.com');
+  });
+
+  it('uses the Identrail Cloud API default for canonical production hosts', () => {
+    for (const hostname of ['identrail.com', 'www.identrail.com', 'app.identrail.com']) {
+      expect(resolveAPIBaseURL(undefined, true, hostname)).toBe(IDENTRAIL_CLOUD_API_URL);
+    }
+  });
+
+  it('requires explicit configuration for custom production hosts', () => {
+    expect(resolveAPIBaseURL(undefined, true, 'customer.example.com')).toBe('');
+  });
+
+  it('uses localhost for unconfigured development builds', () => {
+    expect(resolveAPIBaseURL(undefined, false, 'localhost')).toBe('http://localhost:8080');
   });
 });
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -498,18 +498,45 @@ export type GitHubConnectionStatus = {
 
 const viteEnv = ((import.meta as unknown as { env?: Record<string, unknown> }).env ?? {}) as Record<string, unknown>;
 const isProd = viteEnv.PROD === true || viteEnv.PROD === 'true';
-const configuredURL = typeof viteEnv.VITE_IDENTRAIL_API_URL === 'string' ? viteEnv.VITE_IDENTRAIL_API_URL : undefined;
+const configuredURL = typeof viteEnv.VITE_IDENTRAIL_API_URL === 'string' ? trimOrUndefined(viteEnv.VITE_IDENTRAIL_API_URL) : undefined;
+const IDENTRAIL_CLOUD_WEB_HOSTNAMES = new Set(['identrail.com', 'www.identrail.com', 'app.identrail.com']);
+export const IDENTRAIL_CLOUD_API_URL = 'https://api.identrail.com';
+
+function trimOrUndefined(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function currentBrowserHostname(): string | undefined {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+  return window.location.hostname;
+}
+
+export function resolveAPIBaseURL(configuredAPIURL: string | undefined, production: boolean, hostname?: string): string {
+  const trimmedConfiguredURL = trimOrUndefined(configuredAPIURL);
+  if (trimmedConfiguredURL) {
+    return trimmedConfiguredURL;
+  }
+  const normalizedHostname = hostname?.trim().toLowerCase();
+  if (production && normalizedHostname && IDENTRAIL_CLOUD_WEB_HOSTNAMES.has(normalizedHostname)) {
+    return IDENTRAIL_CLOUD_API_URL;
+  }
+  return production ? '' : 'http://localhost:8080';
+}
+
+const baseURL = resolveAPIBaseURL(configuredURL, isProd, currentBrowserHostname());
 
 // Never silently fall back to localhost in production builds (for example on Vercel).
-// If the API URL is not configured, requests should fail loudly when invoked.
-if (isProd && configuredURL) {
-  const parsed = new URL(configuredURL);
+// Hosted Identrail domains use the canonical cloud API default; custom
+// production hosts still fail loudly unless explicitly configured.
+if (isProd && baseURL) {
+  const parsed = new URL(baseURL);
   if (parsed.protocol === 'http:' && parsed.hostname !== 'localhost') {
     throw new Error('VITE_IDENTRAIL_API_URL must use HTTPS in production (HTTP only allowed for localhost)');
   }
 }
-
-const baseURL = configuredURL ?? (isProd ? '' : 'http://localhost:8080');
 
 type IdentrailRequestInit = RequestInit & {
   redirectOnUnauthorized?: boolean;
@@ -526,17 +553,12 @@ export class ApiError extends Error {
 }
 
 export function buildAPIURL(path: string): string {
-  if (isProd && !configuredURL) {
+  if (isProd && !baseURL) {
     throw new Error(
-      'Identrail API URL is not configured. Set VITE_IDENTRAIL_API_URL in Vercel project environment variables.'
+      'Identrail API URL is not configured. Set VITE_IDENTRAIL_API_URL or use an Identrail Cloud web domain.'
     );
   }
   return `${baseURL}${path}`;
-}
-
-function trimOrUndefined(value?: string): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed : undefined;
 }
 
 function buildRequestHeaders(auth?: RequestAuthContext): Record<string, string> {
@@ -586,9 +608,9 @@ function redirectToSignInForUnauthorized() {
 }
 
 async function request<T>(path: string, auth?: RequestAuthContext, init: IdentrailRequestInit = {}): Promise<T> {
-  if (isProd && !configuredURL) {
+  if (isProd && !baseURL) {
     throw new Error(
-      'Identrail API URL is not configured. Set VITE_IDENTRAIL_API_URL in Vercel project environment variables.'
+      'Identrail API URL is not configured. Set VITE_IDENTRAIL_API_URL or use an Identrail Cloud web domain.'
     );
   }
   const { redirectOnUnauthorized = true, ...fetchInit } = init;

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -18,6 +18,7 @@ function originFromURL(value?: string): string | null {
 function buildConnectSrc(env: Record<string, string>, isProduction: boolean): string {
   const allowlist = new Set<string>([
     "'self'",
+    'https://api.identrail.com',
     'https://api.identrail.io',
     'https://api.github.com',
     'https://img.shields.io'


### PR DESCRIPTION
No issue: auth roadmap production-readiness side work for the hosted Identrail Cloud sign-in flow.

## What changed

- Adds a hosted Identrail Cloud API URL fallback for canonical production web domains: `identrail.com`, `www.identrail.com`, and `app.identrail.com` now resolve frontend API calls to `https://api.identrail.com` when no build-time `VITE_IDENTRAIL_API_URL` is injected.
- Keeps self-hosted and custom-domain production deployments explicit: unknown production hosts still fail loudly unless `VITE_IDENTRAIL_API_URL` is configured.
- Updates the Vercel production deploy workflow so token-based deploys default and upsert `VITE_IDENTRAIL_API_URL=https://api.identrail.com` when the GitHub Actions variable is absent.
- Adds `https://api.identrail.com` to the production CSP connect allowlist and aligns the auth/frontend troubleshooting docs around the `api.identrail.com` split.

## Why

The merged auth UI is deployed, but production sign-in/sign-up currently fails on Identrail-owned domains with `Identrail API URL is not configured` when Vercel does not inject `VITE_IDENTRAIL_API_URL`. For Identrail Cloud, the API origin is now a stable product decision, so the frontend should not require fragile duplicate configuration to know its own API host.

This does not pretend the API is live. `api.identrail.com` still needs DNS and the AWS API deployment cutover before sign-in completes end to end. This PR removes the frontend configuration failure and keeps the remaining blocker clear.

## Impact and risk

- Hosted Identrail domains become easier to operate and recover from missing Vercel env configuration.
- Custom/self-host deployments remain backward compatible because explicit `VITE_IDENTRAIL_API_URL` still wins, and unknown production hosts do not guess an API URL.
- The deploy workflow remains secret-free: it only uses a public API URL value and existing Vercel credentials.

## Validation

- `./scripts/check_public_api_url_test.sh` passed.
- `npm run test:ci --prefix web` passed: 6 files, 67 tests.
- `npm run build --prefix web` passed and prerendered 40 routes.
- `git diff --check` passed.
- Commit hooks passed: merge-conflict check, YAML check, EOF/trailing whitespace, gofmt check, Vercel artifact hygiene.
- Pre-push hooks passed: merge-conflict check, YAML check, EOF/trailing whitespace, gofmt check, `go vet`, local env token hygiene, Vercel artifact hygiene.
- Manual network check: `https://api.identrail.com/healthz` does not resolve publicly yet, confirming DNS/API cutover is still the next live-service step after this frontend fix.

AI-assisted: yes
Tools used: OpenAI Codex
Where used: implementation, docs alignment, validation orchestration
Human verification performed: reviewed diff scope and ran the validation listed above
