### PR TITLE
Build prioritized repository findings dashboard for triage workflows

### DIFF
--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -55,7 +55,7 @@ x-identrail-route-authorizations:
     resource_type: finding_trend
   - method: GET
     path: /v1/repo-findings/trends
-    action: findings.read
+    action: repo_scans.read
     resource_type: finding_trend
   - method: GET
     path: /v1/findings/summary

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -54,6 +54,10 @@ x-identrail-route-authorizations:
     action: findings.read
     resource_type: finding_trend
   - method: GET
+    path: /v1/repo-findings/trends
+    action: findings.read
+    resource_type: finding_trend
+  - method: GET
     path: /v1/findings/summary
     action: findings.read
     resource_type: finding_summary

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -2903,6 +2903,15 @@ paths:
           name: type
           schema:
             $ref: "#/components/schemas/FindingType"
+        - in: query
+          name: lifecycle_status
+          schema:
+            type: string
+            enum: [open, ack, suppressed, resolved]
+        - in: query
+          name: assignee
+          schema:
+            type: string
       responses:
         "200":
           description: Repository findings page

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -2400,6 +2400,40 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/TrendPoint"
+  /v1/repo-findings/trends:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+    get:
+      tags: [RepositoryExposure]
+      summary: Repository findings trend over recent repository scans
+      operationId: getRepoFindingsTrends
+      parameters:
+        - in: query
+          name: points
+          schema:
+            type: integer
+            minimum: 1
+        - in: query
+          name: severity
+          schema:
+            $ref: "#/components/schemas/FindingSeverity"
+        - in: query
+          name: type
+          schema:
+            $ref: "#/components/schemas/FindingType"
+      responses:
+        "200":
+          description: Trend points
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/TrendPoint"
   /v1/findings/{finding_id}:
     parameters:
       - $ref: "#/components/parameters/scopeTenantID"

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -645,6 +645,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/findings/baseline/export", Action: policyActionFindingsRead, ResourceType: "finding_baseline"},
 		{Method: http.MethodPost, Path: "/v1/findings/baseline/import", Action: policyActionFindingsTriage, ResourceType: "finding_baseline"},
 		{Method: http.MethodGet, Path: "/v1/findings/trends", Action: policyActionFindingsRead, ResourceType: "finding_trend"},
+		{Method: http.MethodGet, Path: "/v1/repo-findings/trends", Action: policyActionFindingsRead, ResourceType: "finding_trend"},
 		{Method: http.MethodGet, Path: "/v1/findings/summary", Action: policyActionFindingsRead, ResourceType: "finding_summary"},
 		{Method: http.MethodPatch, Path: "/v1/findings/:finding_id/triage", Action: policyActionFindingsTriage, ResourceType: "finding", ResourceIDParam: "finding_id"},
 		{Method: http.MethodGet, Path: "/v1/identities", Action: policyActionGraphRead, ResourceType: "identity"},

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -645,7 +645,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/findings/baseline/export", Action: policyActionFindingsRead, ResourceType: "finding_baseline"},
 		{Method: http.MethodPost, Path: "/v1/findings/baseline/import", Action: policyActionFindingsTriage, ResourceType: "finding_baseline"},
 		{Method: http.MethodGet, Path: "/v1/findings/trends", Action: policyActionFindingsRead, ResourceType: "finding_trend"},
-		{Method: http.MethodGet, Path: "/v1/repo-findings/trends", Action: policyActionFindingsRead, ResourceType: "finding_trend"},
+		{Method: http.MethodGet, Path: "/v1/repo-findings/trends", Action: policyActionRepoScansRead, ResourceType: "finding_trend"},
 		{Method: http.MethodGet, Path: "/v1/findings/summary", Action: policyActionFindingsRead, ResourceType: "finding_summary"},
 		{Method: http.MethodPatch, Path: "/v1/findings/:finding_id/triage", Action: policyActionFindingsTriage, ResourceType: "finding", ResourceIDParam: "finding_id"},
 		{Method: http.MethodGet, Path: "/v1/identities", Action: policyActionGraphRead, ResourceType: "identity"},

--- a/internal/api/authz_policy_bundle_runtime_test.go
+++ b/internal/api/authz_policy_bundle_runtime_test.go
@@ -78,6 +78,20 @@ func TestCompileRouteAuthorizationPolicyBundleRejectsInvalidReBACRelation(t *tes
 	}
 }
 
+func TestDefaultRoutePolicyBundleUsesRepoScansReadForRepoFindingsTrends(t *testing.T) {
+	compiled, err := compileRouteAuthorizationPolicyBundle(defaultBuiltInRouteAuthorizationPolicyBundle())
+	if err != nil {
+		t.Fatalf("compile built-in policy bundle: %v", err)
+	}
+	policy, exists := compiled.RouteRegistry.lookup("GET", "/v1/repo-findings/trends")
+	if !exists {
+		t.Fatal("expected built-in authz policy for GET /v1/repo-findings/trends")
+	}
+	if policy.Action != policyActionRepoScansRead {
+		t.Fatalf("expected action %q, got %q", policyActionRepoScansRead, policy.Action)
+	}
+}
+
 func TestCentralPolicyRuntimeResolverFallsBackWhenNoActiveRollout(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := testAuthzPolicyScopeContext()

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -374,6 +374,9 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		v1.GET("/findings/trends", func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"items": []any{}})
 		})
+		v1.GET("/repo-findings/trends", func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{"items": []any{}})
+		})
 		v1.GET("/findings/summary", func(c *gin.Context) {
 			c.JSON(http.StatusOK, FindingsSummary{
 				Total:      0,
@@ -596,6 +599,22 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		if err != nil {
 			logger.Error("findings trends", telemetry.ZapError(err))
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build findings trends"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"items": items})
+	})
+
+	v1.GET("/repo-findings/trends", func(c *gin.Context) {
+		points := parseLimit(c.Query("points"), 10, 100)
+		items, err := svc.GetRepoFindingsTrendFiltered(
+			c.Request.Context(),
+			points,
+			strings.TrimSpace(c.Query("severity")),
+			strings.TrimSpace(c.Query("type")),
+		)
+		if err != nil {
+			logger.Error("repo findings trends", telemetry.ZapError(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build repository findings trends"})
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"items": items})

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -857,6 +857,8 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 				Type:            strings.TrimSpace(c.Query("type")),
 				LifecycleStatus: strings.TrimSpace(c.Query("lifecycle_status")),
 				Assignee:        strings.TrimSpace(c.Query("assignee")),
+				SortBy:          sortBy,
+				SortDesc:        sortDesc,
 			},
 		)
 		if err != nil {
@@ -868,7 +870,6 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list repo findings"})
 			return
 		}
-		sortFindings(items, sortBy, sortDesc)
 		c.JSON(http.StatusOK, paginatedItemsResponse(items, offset, limit))
 	})
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -850,7 +850,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		}
 		items, err := svc.ListRepoFindings(
 			c.Request.Context(),
-			maxCursorFetchLimit,
+			pageFetchLimit(offset, limit),
 			db.RepoFindingFilter{
 				RepoScanID:      repoScanID,
 				Severity:        strings.TrimSpace(c.Query("severity")),

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -833,9 +833,11 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			c.Request.Context(),
 			maxCursorFetchLimit,
 			db.RepoFindingFilter{
-				RepoScanID: repoScanID,
-				Severity:   strings.TrimSpace(c.Query("severity")),
-				Type:       strings.TrimSpace(c.Query("type")),
+				RepoScanID:      repoScanID,
+				Severity:        strings.TrimSpace(c.Query("severity")),
+				Type:            strings.TrimSpace(c.Query("type")),
+				LifecycleStatus: strings.TrimSpace(c.Query("lifecycle_status")),
+				Assignee:        strings.TrimSpace(c.Query("assignee")),
 			},
 		)
 		if err != nil {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -908,6 +909,68 @@ func TestRouterRepoFindingsCanBeFilteredByTriageState(t *testing.T) {
 	}
 	if detailBody.Triage.Status != domain.FindingLifecycleAck {
 		t.Fatalf("expected triage status ack in unified finding detail, got %q", detailBody.Triage.Status)
+	}
+}
+
+func TestRouterRepoFindingsSeveritySortUsesFullResultSet(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 5, 13, 11, 10, 0, 0, time.UTC)
+
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", now)
+	if err != nil {
+		t.Fatalf("create repo scan: %v", err)
+	}
+
+	repoFindings := make([]domain.Finding, 0, 5001)
+	for i := 0; i < 5001; i++ {
+		severity := domain.SeverityLow
+		if i == 0 {
+			severity = domain.SeverityCritical
+		}
+		repoFindings = append(repoFindings, domain.Finding{
+			ID:           fmt.Sprintf("repo-finding-%04d", i),
+			Type:         domain.FindingSecretExposure,
+			Severity:     severity,
+			Title:        fmt.Sprintf("finding-%04d", i),
+			HumanSummary: "repo finding",
+			CreatedAt:    now.Add(time.Duration(i) * time.Minute),
+		})
+	}
+	if err := store.UpsertRepoFindings(defaultScopeContext(), repoScan.ID, repoFindings); err != nil {
+		t.Fatalf("upsert repo findings: %v", err)
+	}
+
+	svc := NewService(store, routerScanner{}, "aws")
+	r := NewRouter(logger, metrics, svc, RouterOptions{})
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/v1/repo-findings?repo_scan_id="+repoScan.ID+"&sort_by=severity&sort_order=desc&limit=1",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected prioritized repo findings 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		Items      []domain.Finding `json:"items"`
+		NextCursor string           `json:"next_cursor"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode prioritized repo findings: %v", err)
+	}
+	if len(body.Items) != 1 {
+		t.Fatalf("expected one prioritized repo finding, got %+v", body.Items)
+	}
+	if body.Items[0].ID != "repo-finding-0000" || body.Items[0].Severity != domain.SeverityCritical {
+		t.Fatalf("expected oldest critical repo finding first, got %+v", body.Items[0])
+	}
+	if body.NextCursor == "" {
+		t.Fatal("expected prioritized repo findings next_cursor")
 	}
 }
 

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -571,6 +571,13 @@ func TestRouterRunsScanAndListsData(t *testing.T) {
 		t.Fatalf("expected filtered trends 200, got %d", trendsFilteredW.Code)
 	}
 
+	repoTrendsReq := httptest.NewRequest(http.MethodGet, "/v1/repo-findings/trends", nil)
+	repoTrendsW := httptest.NewRecorder()
+	r.ServeHTTP(repoTrendsW, repoTrendsReq)
+	if repoTrendsW.Code != http.StatusOK {
+		t.Fatalf("expected repo findings trends 200, got %d", repoTrendsW.Code)
+	}
+
 	identitiesReq := httptest.NewRequest(http.MethodGet, "/v1/identities", nil)
 	identitiesW := httptest.NewRecorder()
 	r.ServeHTTP(identitiesW, identitiesReq)
@@ -805,6 +812,13 @@ func TestRouterUnavailableWhenServiceMissing(t *testing.T) {
 	r.ServeHTTP(repoFindingsW, repoFindingsReq)
 	if repoFindingsW.Code != http.StatusOK {
 		t.Fatalf("expected repo findings 200 without service, got %d", repoFindingsW.Code)
+	}
+
+	repoTrendsReq := httptest.NewRequest(http.MethodGet, "/v1/repo-findings/trends", nil)
+	repoTrendsW := httptest.NewRecorder()
+	r.ServeHTTP(repoTrendsW, repoTrendsReq)
+	if repoTrendsW.Code != http.StatusOK {
+		t.Fatalf("expected repo findings trends 200 without service, got %d", repoTrendsW.Code)
 	}
 }
 

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -855,7 +855,11 @@ func TestRouterRepoFindingsCanBeFilteredByTriageState(t *testing.T) {
 	}
 
 	if err := store.UpsertFindingTriageState(defaultScopeContext(), db.FindingTriageState{
-		FindingID: "repo-ack",
+		FindingID: findingTriageStateKey(domain.Finding{
+			ID:         "repo-ack",
+			ScanID:     repoScan.ID,
+			Repository: "owner/repo",
+		}),
 		Status:    domain.FindingLifecycleAck,
 		Assignee:  "platform",
 		UpdatedAt: now.Add(10 * time.Minute),

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -808,6 +808,95 @@ func TestRouterUnavailableWhenServiceMissing(t *testing.T) {
 	}
 }
 
+func TestRouterRepoFindingsCanBeFilteredByTriageState(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 5, 13, 11, 10, 0, 0, time.UTC)
+
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", now)
+	if err != nil {
+		t.Fatalf("create repo scan: %v", err)
+	}
+	if err := store.UpsertRepoFindings(defaultScopeContext(), repoScan.ID, []domain.Finding{
+		{
+			ID:           "repo-open",
+			Type:         domain.FindingSecretExposure,
+			Severity:     domain.SeverityMedium,
+			Title:        "open finding",
+			HumanSummary: "open finding",
+			CreatedAt:    now,
+		},
+		{
+			ID:           "repo-ack",
+			Type:         domain.FindingRepoMisconfig,
+			Severity:     domain.SeverityHigh,
+			Title:        "ack finding",
+			HumanSummary: "ack finding",
+			CreatedAt:    now.Add(5 * time.Minute),
+		},
+	}); err != nil {
+		t.Fatalf("upsert repo findings: %v", err)
+	}
+
+	if err := store.UpsertFindingTriageState(defaultScopeContext(), db.FindingTriageState{
+		FindingID: "repo-ack",
+		Status:    domain.FindingLifecycleAck,
+		Assignee:  "platform",
+		UpdatedAt: now.Add(10 * time.Minute),
+		UpdatedBy: "robot",
+	}); err != nil {
+		t.Fatalf("upsert finding triage state: %v", err)
+	}
+
+	svc := NewService(store, routerScanner{}, "aws")
+	r := NewRouter(logger, metrics, svc, RouterOptions{})
+
+	filteredReq := httptest.NewRequest(
+		http.MethodGet,
+		"/v1/repo-findings?repo_scan_id="+repoScan.ID+"&lifecycle_status=ack&assignee=platform&limit=50",
+		nil,
+	)
+	filteredW := httptest.NewRecorder()
+	r.ServeHTTP(filteredW, filteredReq)
+	if filteredW.Code != http.StatusOK {
+		t.Fatalf("expected filtered repo findings 200, got %d body=%s", filteredW.Code, filteredW.Body.String())
+	}
+
+	var filteredBody struct {
+		Items []domain.Finding `json:"items"`
+	}
+	if err := json.Unmarshal(filteredW.Body.Bytes(), &filteredBody); err != nil {
+		t.Fatalf("decode filtered repo findings: %v", err)
+	}
+	if len(filteredBody.Items) != 1 {
+		t.Fatalf("expected one ack repo finding, got %+v", filteredBody.Items)
+	}
+	if filteredBody.Items[0].ID != "repo-ack" {
+		t.Fatalf("expected repo-ack, got %q", filteredBody.Items[0].ID)
+	}
+	if filteredBody.Items[0].Triage.Status != domain.FindingLifecycleAck {
+		t.Fatalf("expected triage status ack, got %q", filteredBody.Items[0].Triage.Status)
+	}
+
+	detailReq := httptest.NewRequest(http.MethodGet, "/v1/findings/repo-ack?scan_id="+repoScan.ID, nil)
+	detailW := httptest.NewRecorder()
+	r.ServeHTTP(detailW, detailReq)
+	if detailW.Code != http.StatusOK {
+		t.Fatalf("expected repo finding detail via unified endpoint 200, got %d body=%s", detailW.Code, detailW.Body.String())
+	}
+	var detailBody domain.Finding
+	if err := json.Unmarshal(detailW.Body.Bytes(), &detailBody); err != nil {
+		t.Fatalf("decode repo finding detail: %v", err)
+	}
+	if detailBody.ID != "repo-ack" {
+		t.Fatalf("unexpected finding detail ID: %q", detailBody.ID)
+	}
+	if detailBody.Triage.Status != domain.FindingLifecycleAck {
+		t.Fatalf("expected triage status ack in unified finding detail, got %q", detailBody.Triage.Status)
+	}
+}
+
 func TestRouterScanEnqueueSucceedsWhenExecutionLockIsHeld(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	metrics := telemetry.NewMetrics()

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -38,6 +38,8 @@ const (
 	defaultGitHubWebhookReplayWindow = 24 * time.Hour
 	defaultGitHubWebhookBurstWindow  = 30 * time.Second
 	maxSourceErrorsInEvent           = 25
+	repoFindingsTriageFilterStep     = maxCursorFetchLimit
+	repoFindingsTriageFilterCap      = maxCursorFetchLimit * 4
 )
 
 const (
@@ -1265,12 +1267,20 @@ func (s *Service) GetRepoScan(ctx context.Context, repoScanID string) (db.RepoSc
 func (s *Service) ListRepoFindings(ctx context.Context, limit int, filter db.RepoFindingFilter) ([]domain.Finding, error) {
 	ctx = s.scopeContext(ctx)
 	normalized := db.NormalizeRepoFindingFilter(filter)
-	repoLimit := limit
-	if normalized.LifecycleStatus != "" || normalized.Assignee != "" {
-		// Apply triage filters across the full result set so older matches are not
-		// dropped before triage state filtering runs in the service layer.
-		repoLimit = 0
+	hasTriageFilter := normalized.LifecycleStatus != "" || normalized.Assignee != ""
+	requestLimit := limit
+	if requestLimit <= 0 {
+		requestLimit = defaultFindingsLimit
 	}
+	repoLimit := requestLimit
+	if hasTriageFilter && repoLimit < repoFindingsTriageFilterStep {
+		repoLimit = repoFindingsTriageFilterStep
+	}
+
+	if hasTriageFilter {
+		return s.listRepoFindingsWithTriageFilter(ctx, repoLimit, requestLimit, normalized)
+	}
+
 	findings, err := s.Store.ListRepoFindings(ctx, normalized, repoLimit)
 	if err != nil {
 		return nil, err
@@ -1284,10 +1294,47 @@ func (s *Service) ListRepoFindings(ctx context.Context, limit int, filter db.Rep
 		return withTriage, nil
 	}
 	filtered := filterRepoFindingsByTriage(withTriage, normalized.LifecycleStatus, normalized.Assignee)
-	if limit > 0 && len(filtered) > limit {
-		filtered = filtered[:limit]
+	if len(filtered) > requestLimit {
+		filtered = filtered[:requestLimit]
 	}
 	return filtered, nil
+}
+
+func (s *Service) listRepoFindingsWithTriageFilter(
+	ctx context.Context,
+	repoLimit int,
+	requestLimit int,
+	filter db.RepoFindingFilter,
+) ([]domain.Finding, error) {
+	for {
+		findings, err := s.Store.ListRepoFindings(ctx, filter, repoLimit)
+		if err != nil {
+			return nil, err
+		}
+
+		findings = enrichFindingsWithRepoContext(findings)
+		withTriage, err := s.applyFindingTriageStates(ctx, findings)
+		if err != nil {
+			return nil, err
+		}
+		filtered := filterRepoFindingsByTriage(withTriage, filter.LifecycleStatus, filter.Assignee)
+		if len(filtered) > requestLimit {
+			filtered = filtered[:requestLimit]
+		}
+
+		// Keep bounded reads while scanning until we find enough triaged rows for
+		// the caller's requested window or we hit the safety cap.
+		if len(filtered) >= requestLimit || len(findings) < repoLimit {
+			return filtered, nil
+		}
+		if repoLimit >= repoFindingsTriageFilterCap {
+			return filtered, nil
+		}
+		repoLimit *= 2
+		if repoLimit > repoFindingsTriageFilterCap {
+			repoLimit = repoFindingsTriageFilterCap
+		}
+	}
 }
 
 // ListRepoFindingClusters returns duplicate-aware repository finding clusters.

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1266,9 +1266,9 @@ func (s *Service) ListRepoFindings(ctx context.Context, limit int, filter db.Rep
 	ctx = s.scopeContext(ctx)
 	normalized := db.NormalizeRepoFindingFilter(filter)
 	repoLimit := limit
-	if normalized.LifecycleStatus != "" || normalized.Assignee != "" {
-		// Apply triage filters in memory before slicing so older matching rows are not
-		// dropped by the fetch window.
+	if normalized.LifecycleStatus != "" || normalized.Assignee != "" || normalized.SortBy != "created_at" {
+		// Apply triage filters and non-recency sorts across the full result set so
+		// older matches are not dropped by the legacy fetch window.
 		repoLimit = 0
 	}
 	findings, err := s.Store.ListRepoFindings(ctx, normalized, repoLimit)

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1266,9 +1266,9 @@ func (s *Service) ListRepoFindings(ctx context.Context, limit int, filter db.Rep
 	ctx = s.scopeContext(ctx)
 	normalized := db.NormalizeRepoFindingFilter(filter)
 	repoLimit := limit
-	if normalized.LifecycleStatus != "" || normalized.Assignee != "" || normalized.SortBy != "created_at" {
-		// Apply triage filters and non-recency sorts across the full result set so
-		// older matches are not dropped by the legacy fetch window.
+	if normalized.LifecycleStatus != "" || normalized.Assignee != "" {
+		// Apply triage filters across the full result set so older matches are not
+		// dropped before triage state filtering runs in the service layer.
 		repoLimit = 0
 	}
 	findings, err := s.Store.ListRepoFindings(ctx, normalized, repoLimit)

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1707,7 +1707,8 @@ func (s *Service) TriageFinding(ctx context.Context, findingID string, scanID st
 	if id == "" {
 		return domain.Finding{}, db.ErrNotFound
 	}
-	if _, err := s.GetFinding(ctx, id, scanID); err != nil {
+	finding, err := s.GetFinding(ctx, id, scanID)
+	if err != nil {
 		return domain.Finding{}, err
 	}
 	if request.Status == nil && request.Assignee == nil && request.SuppressionExpiresAt == nil && strings.TrimSpace(request.Comment) == "" {
@@ -1715,13 +1716,14 @@ func (s *Service) TriageFinding(ctx context.Context, findingID string, scanID st
 	}
 
 	now := s.Now().UTC()
-	currentState, err := s.Store.GetFindingTriageState(ctx, id)
+	stateKey := findingTriageStateKey(finding)
+	currentState, err := s.Store.GetFindingTriageState(ctx, stateKey)
 	if err != nil && !errors.Is(err, db.ErrNotFound) {
 		return domain.Finding{}, err
 	}
 	if errors.Is(err, db.ErrNotFound) {
 		currentState = db.FindingTriageState{
-			FindingID: id,
+			FindingID: stateKey,
 			Status:    domain.FindingLifecycleOpen,
 		}
 	}
@@ -1771,7 +1773,7 @@ func (s *Service) TriageFinding(ctx context.Context, findingID string, scanID st
 		return domain.Finding{}, ErrInvalidFindingTriageRequest
 	}
 
-	nextState.FindingID = id
+	nextState.FindingID = stateKey
 	nextState.UpdatedAt = now
 	nextState.UpdatedBy = normalizeActor(actor)
 	if nextState.Status == "" {
@@ -1780,7 +1782,7 @@ func (s *Service) TriageFinding(ctx context.Context, findingID string, scanID st
 
 	action := deriveFindingTriageAction(currentState, nextState, comment)
 	if err := s.Store.ApplyFindingTriageTransition(ctx, nextState, db.FindingTriageEvent{
-		FindingID:            id,
+		FindingID:            stateKey,
 		Action:               action,
 		FromStatus:           currentState.Status,
 		ToStatus:             nextState.Status,
@@ -1802,10 +1804,11 @@ func (s *Service) ListFindingTriageHistory(ctx context.Context, findingID string
 	if id == "" {
 		return nil, db.ErrNotFound
 	}
-	if _, err := s.GetFinding(ctx, id, scanID); err != nil {
+	finding, err := s.GetFinding(ctx, id, scanID)
+	if err != nil {
 		return nil, err
 	}
-	return s.Store.ListFindingTriageEvents(ctx, id, limit)
+	return s.Store.ListFindingTriageEvents(ctx, findingTriageStateKey(finding), limit)
 }
 
 // GetFindingExports returns OCSF-aligned and ASFF payloads for one finding.
@@ -2389,7 +2392,7 @@ func (s *Service) applyFindingTriageStates(ctx context.Context, findings []domai
 	ids := make([]string, 0, len(findings))
 	seen := map[string]struct{}{}
 	for _, finding := range findings {
-		id := strings.TrimSpace(finding.ID)
+		id := findingTriageStateKey(finding)
 		if id == "" {
 			continue
 		}
@@ -2412,7 +2415,7 @@ func (s *Service) applyFindingTriageStates(ctx context.Context, findings []domai
 	result := make([]domain.Finding, 0, len(findings))
 	for _, finding := range findings {
 		triage := domain.DefaultFindingTriage()
-		if state, exists := byID[strings.TrimSpace(finding.ID)]; exists {
+		if state, exists := byID[findingTriageStateKey(finding)]; exists {
 			updatedAt := state.UpdatedAt.UTC()
 			triage = domain.FindingTriage{
 				Status:               state.Status,
@@ -2426,6 +2429,30 @@ func (s *Service) applyFindingTriageStates(ctx context.Context, findings []domai
 		result = append(result, finding)
 	}
 	return result, nil
+}
+
+const repoFindingTriageStatePrefix = "repo-finding-triage"
+
+func findingTriageStateKey(finding domain.Finding) string {
+	id := strings.TrimSpace(finding.ID)
+	if id == "" {
+		return ""
+	}
+	if !isRepoFinding(finding) {
+		return id
+	}
+	scanID := strings.TrimSpace(finding.ScanID)
+	if scanID == "" {
+		return id
+	}
+	return repoFindingTriageStatePrefix + "|" + scanID + "|" + id
+}
+
+func isRepoFinding(finding domain.Finding) bool {
+	return strings.TrimSpace(finding.Repository) != "" ||
+		strings.TrimSpace(finding.Commit) != "" ||
+		strings.TrimSpace(finding.FilePath) != "" ||
+		strings.TrimSpace(finding.SourceURL) != ""
 }
 
 func normalizeFindingTriageState(state db.FindingTriageState, now time.Time) db.FindingTriageState {

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1950,6 +1950,57 @@ func (s *Service) GetFindingsTrendFiltered(ctx context.Context, points int, seve
 	return result, nil
 }
 
+// GetRepoFindingsTrend returns repository finding trend totals by repo scan.
+func (s *Service) GetRepoFindingsTrend(ctx context.Context, points int) ([]TrendPoint, error) {
+	return s.GetRepoFindingsTrendFiltered(ctx, points, "", "")
+}
+
+// GetRepoFindingsTrendFiltered returns repository finding trend with optional severity/type filters.
+func (s *Service) GetRepoFindingsTrendFiltered(ctx context.Context, points int, severity string, findingType string) ([]TrendPoint, error) {
+	ctx = s.scopeContext(ctx)
+	if points <= 0 {
+		points = 10
+	}
+
+	repoScans, err := s.Store.ListRepoScans(ctx, points)
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(repoScans, func(i, j int) bool {
+		return repoScans[i].StartedAt.Before(repoScans[j].StartedAt)
+	})
+	repoScanIDs := make([]string, 0, len(repoScans))
+	index := make(map[string]*TrendPoint, len(repoScans))
+	result := make([]TrendPoint, 0, len(repoScans))
+	for _, scan := range repoScans {
+		repoScanIDs = append(repoScanIDs, scan.ID)
+		result = append(result, TrendPoint{
+			ScanID:     scan.ID,
+			StartedAt:  scan.StartedAt,
+			BySeverity: map[string]int{},
+		})
+		index[scan.ID] = &result[len(result)-1]
+	}
+
+	counts, err := s.Store.ListRepoFindingTrendCounts(ctx, repoScanIDs, severity, findingType)
+	if err != nil {
+		return nil, err
+	}
+	for _, count := range counts {
+		point := index[count.ScanID]
+		if point == nil {
+			continue
+		}
+		if strings.TrimSpace(count.Severity) != "" {
+			point.BySeverity[count.Severity] += count.TotalCount
+		}
+		point.Total += count.TotalCount
+	}
+
+	return result, nil
+}
+
 // ListOwnershipSignals returns inferred ownership hints for identities in one scan.
 func (s *Service) ListOwnershipSignals(ctx context.Context, limit int, filter OwnershipFilter) ([]domain.OwnershipSignal, error) {
 	ctx = s.scopeContext(ctx)

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1674,7 +1674,7 @@ func filterRepoFindingsByTriage(
 	if statusFilter == "" && assigneeFilter == "" {
 		return findings
 	}
-	if !isValidFindingLifecycleStatus(statusFilter) {
+	if statusFilter != "" && !isValidFindingLifecycleStatus(statusFilter) {
 		return nil
 	}
 	filtered := make([]domain.Finding, 0, len(findings))

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1264,11 +1264,24 @@ func (s *Service) GetRepoScan(ctx context.Context, repoScanID string) (db.RepoSc
 // ListRepoFindings returns repository findings using optional filters.
 func (s *Service) ListRepoFindings(ctx context.Context, limit int, filter db.RepoFindingFilter) ([]domain.Finding, error) {
 	ctx = s.scopeContext(ctx)
-	findings, err := s.Store.ListRepoFindings(ctx, filter, limit)
+	normalized := db.NormalizeRepoFindingFilter(filter)
+	findings, err := s.Store.ListRepoFindings(ctx, normalized, limit)
 	if err != nil {
 		return nil, err
 	}
-	return enrichFindingsWithRepoContext(findings), nil
+	findings = enrichFindingsWithRepoContext(findings)
+	withTriage, err := s.applyFindingTriageStates(ctx, findings)
+	if err != nil {
+		return nil, err
+	}
+	if normalized.LifecycleStatus == "" && normalized.Assignee == "" {
+		return withTriage, nil
+	}
+	filtered := filterRepoFindingsByTriage(withTriage, normalized.LifecycleStatus, normalized.Assignee)
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[:limit]
+	}
+	return filtered, nil
 }
 
 // ListRepoFindingClusters returns duplicate-aware repository finding clusters.
@@ -1625,7 +1638,20 @@ func (s *Service) GetFinding(ctx context.Context, findingID string, scanID strin
 	}
 	item, err := s.Store.GetFinding(ctx, id, strings.TrimSpace(scanID))
 	if err != nil {
-		return domain.Finding{}, err
+		if !errors.Is(err, db.ErrNotFound) {
+			return domain.Finding{}, err
+		}
+		fallback, fallbackErr := s.ListRepoFindings(ctx, maxCursorFetchLimit, db.RepoFindingFilter{
+			FindingID:  id,
+			RepoScanID: strings.TrimSpace(scanID),
+		})
+		if fallbackErr != nil {
+			return domain.Finding{}, fallbackErr
+		}
+		if len(fallback) == 0 {
+			return domain.Finding{}, db.ErrNotFound
+		}
+		return fallback[0], nil
 	}
 	enriched := enrichFindings([]domain.Finding{item})
 	withTriage, err := s.applyFindingTriageStates(ctx, enriched)
@@ -1636,6 +1662,37 @@ func (s *Service) GetFinding(ctx context.Context, findingID string, scanID strin
 		return domain.Finding{}, db.ErrNotFound
 	}
 	return withTriage[0], nil
+}
+
+func filterRepoFindingsByTriage(
+	findings []domain.Finding,
+	rawStatus string,
+	rawAssignee string,
+) []domain.Finding {
+	statusFilter := domain.FindingLifecycleStatus(strings.ToLower(strings.TrimSpace(rawStatus)))
+	assigneeFilter := strings.ToLower(strings.TrimSpace(rawAssignee))
+	if statusFilter == "" && assigneeFilter == "" {
+		return findings
+	}
+	if !isValidFindingLifecycleStatus(statusFilter) {
+		return nil
+	}
+	filtered := make([]domain.Finding, 0, len(findings))
+	for _, finding := range findings {
+		triage := finding.Triage
+		status := triage.Status
+		if !isValidFindingLifecycleStatus(status) {
+			status = domain.FindingLifecycleOpen
+		}
+		if statusFilter != "" && status != statusFilter {
+			continue
+		}
+		if assigneeFilter != "" && strings.ToLower(strings.TrimSpace(triage.Assignee)) != assigneeFilter {
+			continue
+		}
+		filtered = append(filtered, finding)
+	}
+	return filtered
 }
 
 // TriageFinding applies one workflow mutation and records audit history.

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1265,7 +1265,13 @@ func (s *Service) GetRepoScan(ctx context.Context, repoScanID string) (db.RepoSc
 func (s *Service) ListRepoFindings(ctx context.Context, limit int, filter db.RepoFindingFilter) ([]domain.Finding, error) {
 	ctx = s.scopeContext(ctx)
 	normalized := db.NormalizeRepoFindingFilter(filter)
-	findings, err := s.Store.ListRepoFindings(ctx, normalized, limit)
+	repoLimit := limit
+	if normalized.LifecycleStatus != "" || normalized.Assignee != "" {
+		// Apply triage filters in memory before slicing so older matching rows are not
+		// dropped by the fetch window.
+		repoLimit = 0
+	}
+	findings, err := s.Store.ListRepoFindings(ctx, normalized, repoLimit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -730,6 +730,60 @@ func TestServiceListFindingsFiltered(t *testing.T) {
 	}
 }
 
+func TestServiceListFindingsFilteredByAssigneeOnly(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 3, 17, 8, 0, 0, 0, time.UTC)
+	scan, _ := store.CreateScan(defaultScopeContext(), "aws", now)
+	_ = store.UpsertFindings(defaultScopeContext(), scan.ID, []domain.Finding{
+		{ID: "finding-platform", Type: domain.FindingOwnerless, Severity: domain.SeverityHigh, CreatedAt: now},
+		{ID: "finding-operations", Type: domain.FindingOwnerless, Severity: domain.SeverityMedium, CreatedAt: now.Add(1 * time.Minute)},
+		{ID: "finding-empty", Type: domain.FindingOwnerless, Severity: domain.SeverityLow, CreatedAt: now.Add(2 * time.Minute)},
+	})
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	ack := string(domain.FindingLifecycleAck)
+	open := string(domain.FindingLifecycleOpen)
+	platform := "platform"
+	operations := "ops"
+	_, err := svc.TriageFinding(
+		defaultScopeContext(),
+		"finding-platform",
+		scan.ID,
+		FindingTriageRequest{Assignee: &platform, Status: &ack},
+		"subject:user-1",
+	)
+	if err != nil {
+		t.Fatalf("triage platform finding: %v", err)
+	}
+
+	_, err = svc.TriageFinding(
+		defaultScopeContext(),
+		"finding-operations",
+		scan.ID,
+		FindingTriageRequest{Assignee: &operations, Status: &open},
+		"subject:user-1",
+	)
+	if err != nil {
+		t.Fatalf("triage operations finding: %v", err)
+	}
+
+	platformOnly, err := svc.ListFindingsFiltered(defaultScopeContext(), 10, FindingsFilter{Assignee: "platform"})
+	if err != nil {
+		t.Fatalf("list findings by assignee only: %v", err)
+	}
+	if len(platformOnly) != 1 || platformOnly[0].ID != "finding-platform" {
+		t.Fatalf("expected only finding-platform for assignee filter, got %+v", platformOnly)
+	}
+
+	operationsOnly, err := svc.ListFindingsFiltered(defaultScopeContext(), 10, FindingsFilter{Assignee: "OPS"})
+	if err != nil {
+		t.Fatalf("list findings by uppercase assignee: %v", err)
+	}
+	if len(operationsOnly) != 1 || operationsOnly[0].ID != "finding-operations" {
+		t.Fatalf("expected case-insensitive assignee matching, got %+v", operationsOnly)
+	}
+}
+
 func TestServiceListFindingsFilteredMatchesOlderRowsBeyondLegacyWindow(t *testing.T) {
 	store := db.NewMemoryStore()
 	base := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -864,7 +864,7 @@ func TestServiceListRepoFindingsFilterTriagedResultsBeyondLegacyWindow(t *testin
 	}
 }
 
-func TestServiceListRepoFindingsSortBySeverityBeyondLegacyWindow(t *testing.T) {
+func TestServiceListRepoFindingsSortBySeverityHonorsLimitBeyondLegacyWindow(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
 	repoScan, _ := store.CreateRepoScan(defaultScopeContext(), "owner/repo", now)
@@ -889,7 +889,7 @@ func TestServiceListRepoFindingsSortBySeverityBeyondLegacyWindow(t *testing.T) {
 	svc := NewService(store, fakeScanner{}, "aws")
 	sorted, err := svc.ListRepoFindings(
 		defaultScopeContext(),
-		maxCursorFetchLimit,
+		2,
 		db.RepoFindingFilter{
 			RepoScanID: repoScan.ID,
 			SortBy:     "severity",
@@ -899,8 +899,8 @@ func TestServiceListRepoFindingsSortBySeverityBeyondLegacyWindow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list repo findings by severity: %v", err)
 	}
-	if len(sorted) != 5001 {
-		t.Fatalf("expected full result set for prioritized sorting, got %d items", len(sorted))
+	if len(sorted) != 2 {
+		t.Fatalf("expected prioritized sorting to honor the requested limit, got %d items", len(sorted))
 	}
 	if sorted[0].ID != "repo-finding-0000" || sorted[0].Severity != domain.SeverityCritical {
 		t.Fatalf("expected oldest critical repo finding to lead prioritized results, got %+v", sorted[0])

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -907,6 +907,96 @@ func TestServiceListRepoFindingsSortBySeverityHonorsLimitBeyondLegacyWindow(t *t
 	}
 }
 
+func TestServiceRepoFindingTriageScopesStateToRepoScan(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
+	firstScan, _ := store.CreateRepoScan(defaultScopeContext(), "owner/repo", now)
+	secondScan, _ := store.CreateRepoScan(defaultScopeContext(), "owner/repo", now.Add(time.Hour))
+
+	if err := store.UpsertRepoFindings(defaultScopeContext(), firstScan.ID, []domain.Finding{{
+		ID:        "shared-id",
+		Type:      domain.FindingSecretExposure,
+		Severity:  domain.SeverityHigh,
+		CreatedAt: now,
+	}}); err != nil {
+		t.Fatalf("upsert first repo findings: %v", err)
+	}
+	if err := store.UpsertRepoFindings(defaultScopeContext(), secondScan.ID, []domain.Finding{{
+		ID:        "shared-id",
+		Type:      domain.FindingSecretExposure,
+		Severity:  domain.SeverityMedium,
+		CreatedAt: now.Add(time.Hour),
+	}}); err != nil {
+		t.Fatalf("upsert second repo findings: %v", err)
+	}
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	ack := string(domain.FindingLifecycleAck)
+	firstAssignee := "platform-a"
+	if _, err := svc.TriageFinding(
+		defaultScopeContext(),
+		"shared-id",
+		firstScan.ID,
+		FindingTriageRequest{Status: &ack, Assignee: &firstAssignee},
+		"subject:user-1",
+	); err != nil {
+		t.Fatalf("triage first repo finding: %v", err)
+	}
+
+	resolved := string(domain.FindingLifecycleResolved)
+	secondAssignee := "platform-b"
+	if _, err := svc.TriageFinding(
+		defaultScopeContext(),
+		"shared-id",
+		secondScan.ID,
+		FindingTriageRequest{Status: &resolved, Assignee: &secondAssignee},
+		"subject:user-2",
+	); err != nil {
+		t.Fatalf("triage second repo finding: %v", err)
+	}
+
+	findings, err := svc.ListRepoFindings(defaultScopeContext(), 10, db.RepoFindingFilter{})
+	if err != nil {
+		t.Fatalf("list repo findings: %v", err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("expected two repo findings, got %+v", findings)
+	}
+
+	triageByScan := map[string]domain.FindingTriage{}
+	for _, finding := range findings {
+		triageByScan[finding.ScanID] = finding.Triage
+	}
+	if triageByScan[firstScan.ID].Status != domain.FindingLifecycleAck || triageByScan[firstScan.ID].Assignee != firstAssignee {
+		t.Fatalf("expected first scan triage to stay isolated, got %+v", triageByScan[firstScan.ID])
+	}
+	if triageByScan[secondScan.ID].Status != domain.FindingLifecycleResolved || triageByScan[secondScan.ID].Assignee != secondAssignee {
+		t.Fatalf("expected second scan triage to stay isolated, got %+v", triageByScan[secondScan.ID])
+	}
+
+	filtered, err := svc.ListRepoFindings(
+		defaultScopeContext(),
+		10,
+		db.RepoFindingFilter{
+			LifecycleStatus: string(domain.FindingLifecycleAck),
+		},
+	)
+	if err != nil {
+		t.Fatalf("list repo findings by lifecycle status: %v", err)
+	}
+	if len(filtered) != 1 || filtered[0].ScanID != firstScan.ID {
+		t.Fatalf("expected ack filter to return only first scan row, got %+v", filtered)
+	}
+
+	history, err := svc.ListFindingTriageHistory(defaultScopeContext(), "shared-id", secondScan.ID, 10)
+	if err != nil {
+		t.Fatalf("list repo triage history: %v", err)
+	}
+	if len(history) != 1 || history[0].ToStatus != domain.FindingLifecycleResolved || history[0].Assignee != secondAssignee {
+		t.Fatalf("expected second scan history to stay isolated, got %+v", history)
+	}
+}
+
 func TestServiceGetFinding(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -816,6 +816,54 @@ func TestServiceListFindingsFilteredMatchesOlderRowsBeyondLegacyWindow(t *testin
 	}
 }
 
+func TestServiceListRepoFindingsFilterTriagedResultsBeyondLegacyWindow(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
+	repoScan, _ := store.CreateRepoScan(defaultScopeContext(), "owner/repo", now)
+
+	repoFindings := make([]domain.Finding, 0, 5001)
+	for i := 0; i < 5001; i++ {
+		id := fmt.Sprintf("repo-finding-%04d", i)
+		repoFindings = append(repoFindings, domain.Finding{
+			ID:        id,
+			Type:      domain.FindingSecretExposure,
+			Severity:  domain.SeverityHigh,
+			CreatedAt: now.Add(time.Duration(i) * time.Minute),
+		})
+	}
+	if err := store.UpsertRepoFindings(defaultScopeContext(), repoScan.ID, repoFindings); err != nil {
+		t.Fatalf("upsert repo findings: %v", err)
+	}
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	ack := string(domain.FindingLifecycleAck)
+	_, err := svc.TriageFinding(
+		defaultScopeContext(),
+		"repo-finding-0000",
+		repoScan.ID,
+		FindingTriageRequest{Status: &ack},
+		"subject:user-1",
+	)
+	if err != nil {
+		t.Fatalf("triage oldest repo finding: %v", err)
+	}
+
+	filtered, err := svc.ListRepoFindings(
+		defaultScopeContext(),
+		maxCursorFetchLimit,
+		db.RepoFindingFilter{
+			RepoScanID:      repoScan.ID,
+			LifecycleStatus: string(domain.FindingLifecycleAck),
+		},
+	)
+	if err != nil {
+		t.Fatalf("list repo findings by lifecycle status: %v", err)
+	}
+	if len(filtered) != 1 || filtered[0].ID != "repo-finding-0000" {
+		t.Fatalf("expected oldest triaged repo finding to be returned, got %+v", filtered)
+	}
+}
+
 func TestServiceGetFinding(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -864,6 +864,49 @@ func TestServiceListRepoFindingsFilterTriagedResultsBeyondLegacyWindow(t *testin
 	}
 }
 
+func TestServiceListRepoFindingsSortBySeverityBeyondLegacyWindow(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
+	repoScan, _ := store.CreateRepoScan(defaultScopeContext(), "owner/repo", now)
+
+	repoFindings := make([]domain.Finding, 0, 5001)
+	for i := 0; i < 5001; i++ {
+		severity := domain.SeverityLow
+		if i == 0 {
+			severity = domain.SeverityCritical
+		}
+		repoFindings = append(repoFindings, domain.Finding{
+			ID:        fmt.Sprintf("repo-finding-%04d", i),
+			Type:      domain.FindingSecretExposure,
+			Severity:  severity,
+			CreatedAt: now.Add(time.Duration(i) * time.Minute),
+		})
+	}
+	if err := store.UpsertRepoFindings(defaultScopeContext(), repoScan.ID, repoFindings); err != nil {
+		t.Fatalf("upsert repo findings: %v", err)
+	}
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	sorted, err := svc.ListRepoFindings(
+		defaultScopeContext(),
+		maxCursorFetchLimit,
+		db.RepoFindingFilter{
+			RepoScanID: repoScan.ID,
+			SortBy:     "severity",
+			SortDesc:   true,
+		},
+	)
+	if err != nil {
+		t.Fatalf("list repo findings by severity: %v", err)
+	}
+	if len(sorted) != 5001 {
+		t.Fatalf("expected full result set for prioritized sorting, got %d items", len(sorted))
+	}
+	if sorted[0].ID != "repo-finding-0000" || sorted[0].Severity != domain.SeverityCritical {
+		t.Fatalf("expected oldest critical repo finding to lead prioritized results, got %+v", sorted[0])
+	}
+}
+
 func TestServiceGetFinding(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -1744,6 +1744,83 @@ func TestServiceGetFindingsTrendFiltered(t *testing.T) {
 	}
 }
 
+func TestServiceGetRepoFindingsTrend(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
+	ctx := defaultScopeContext()
+
+	scanA, err := store.CreateRepoScan(ctx, "owner/repo-a", now)
+	if err != nil {
+		t.Fatalf("create repo scan A: %v", err)
+	}
+	if err := store.UpsertRepoFindings(ctx, scanA.ID, []domain.Finding{
+		{ID: "f1", Severity: domain.SeverityHigh, Type: domain.FindingOwnerless, CreatedAt: now},
+	}); err != nil {
+		t.Fatalf("upsert repo findings for scan A: %v", err)
+	}
+
+	scanB, err := store.CreateRepoScan(ctx, "owner/repo-b", now.Add(3*time.Minute))
+	if err != nil {
+		t.Fatalf("create repo scan B: %v", err)
+	}
+	if err := store.UpsertRepoFindings(ctx, scanB.ID, []domain.Finding{
+		{ID: "f2", Severity: domain.SeverityCritical, Type: domain.FindingEscalationPath, CreatedAt: now.Add(3 * time.Minute)},
+	}); err != nil {
+		t.Fatalf("upsert repo findings for scan B: %v", err)
+	}
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	points, err := svc.GetRepoFindingsTrend(ctx, 10)
+	if err != nil {
+		t.Fatalf("get repo findings trend: %v", err)
+	}
+	if len(points) != 2 {
+		t.Fatalf("expected 2 repo trend points, got %d", len(points))
+	}
+	if points[0].ScanID != scanA.ID || points[1].ScanID != scanB.ID {
+		t.Fatalf("unexpected repo trend order: %+v", points)
+	}
+	if points[1].BySeverity["critical"] != 1 {
+		t.Fatalf("unexpected critical total in latest repo trend point: %+v", points[1])
+	}
+}
+
+func TestServiceGetRepoFindingsTrendFiltered(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
+	ctx := defaultScopeContext()
+
+	scanA, err := store.CreateRepoScan(ctx, "owner/repo-a", now)
+	if err != nil {
+		t.Fatalf("create repo scan A: %v", err)
+	}
+	if err := store.UpsertRepoFindings(ctx, scanA.ID, []domain.Finding{
+		{ID: "f1", Severity: domain.SeverityCritical, Type: domain.FindingEscalationPath, CreatedAt: now},
+		{ID: "f2", Severity: domain.SeverityHigh, Type: domain.FindingOwnerless, CreatedAt: now},
+	}); err != nil {
+		t.Fatalf("upsert repo findings for scan A: %v", err)
+	}
+
+	scanB, err := store.CreateRepoScan(ctx, "owner/repo-b", now.Add(3*time.Minute))
+	if err != nil {
+		t.Fatalf("create repo scan B: %v", err)
+	}
+	if err := store.UpsertRepoFindings(ctx, scanB.ID, []domain.Finding{
+		{ID: "f3", Severity: domain.SeverityLow, Type: domain.FindingOwnerless, CreatedAt: now.Add(3 * time.Minute)},
+	}); err != nil {
+		t.Fatalf("upsert repo findings for scan B: %v", err)
+	}
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	points, err := svc.GetRepoFindingsTrendFiltered(ctx, 10, "critical", "escalation_path")
+	if err != nil {
+		t.Fatalf("get filtered repo findings trend: %v", err)
+	}
+	if len(points) != 2 || points[0].Total != 1 || points[1].Total != 0 {
+		t.Fatalf("unexpected filtered repo trend points: %+v", points)
+	}
+}
+
 func TestServiceRunRepoScanSuccess(t *testing.T) {
 	store := db.NewMemoryStore()
 	svc := NewService(store, fakeScanner{}, "aws")

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -2089,6 +2089,7 @@ func (m *MemoryStore) ListRepoFindings(ctx context.Context, filter RepoFindingFi
 		return nil, err
 	}
 	repoScanID := strings.TrimSpace(filter.RepoScanID)
+	findingID := strings.TrimSpace(filter.FindingID)
 	repoScanRepository := ""
 	if repoScanID != "" {
 		record, exists := m.repoScans[repoScanID]
@@ -2107,6 +2108,9 @@ func (m *MemoryStore) ListRepoFindings(ctx context.Context, filter RepoFindingFi
 			if !exists {
 				continue
 			}
+			if findingID != "" && finding.ID != findingID {
+				continue
+			}
 			if severity != "" && strings.ToLower(string(finding.Severity)) != severity {
 				continue
 			}
@@ -2123,6 +2127,9 @@ func (m *MemoryStore) ListRepoFindings(ctx context.Context, filter RepoFindingFi
 		for _, finding := range m.repoFindings {
 			record, exists := m.repoScans[finding.ScanID]
 			if !exists || !MatchScope(scope, record.TenantID, record.WorkspaceID) {
+				continue
+			}
+			if findingID != "" && finding.ID != findingID {
 				continue
 			}
 			if severity != "" && strings.ToLower(string(finding.Severity)) != severity {

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -1108,6 +1108,73 @@ func (m *MemoryStore) ListFindingTrendCounts(ctx context.Context, scanIDs []stri
 	return result, nil
 }
 
+// ListRepoFindingTrendCounts aggregates repository finding totals by repo scan and severity.
+func (m *MemoryStore) ListRepoFindingTrendCounts(ctx context.Context, repoScanIDs []string, severity string, findingType string) ([]FindingTrendCount, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	normalizedSeverity := strings.ToLower(strings.TrimSpace(severity))
+	normalizedType := strings.ToLower(strings.TrimSpace(findingType))
+
+	unique := make([]string, 0, len(repoScanIDs))
+	seen := map[string]struct{}{}
+	for _, repoScanID := range repoScanIDs {
+		normalized := strings.TrimSpace(repoScanID)
+		if normalized == "" {
+			continue
+		}
+		if _, exists := seen[normalized]; exists {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		repoScan, exists := m.repoScans[normalized]
+		if !exists || !MatchScope(scope, repoScan.TenantID, repoScan.WorkspaceID) {
+			continue
+		}
+		unique = append(unique, normalized)
+	}
+
+	result := make([]FindingTrendCount, 0, len(unique))
+	for _, repoScanID := range unique {
+		repoScan, exists := m.repoScans[repoScanID]
+		if !exists {
+			continue
+		}
+		counts := map[string]int{}
+		for _, key := range m.repoFindingIDs[repoScanID] {
+			finding, exists := m.repoFindings[key]
+			if !exists {
+				continue
+			}
+			if normalizedSeverity != "" && strings.ToLower(string(finding.Severity)) != normalizedSeverity {
+				continue
+			}
+			if normalizedType != "" && strings.ToLower(string(finding.Type)) != normalizedType {
+				continue
+			}
+			counts[string(finding.Severity)]++
+		}
+		if len(counts) == 0 {
+			result = append(result, FindingTrendCount{ScanID: repoScanID, StartedAt: repoScan.StartedAt})
+			continue
+		}
+		for severityKey, count := range counts {
+			result = append(result, FindingTrendCount{
+				ScanID:     repoScanID,
+				StartedAt:  repoScan.StartedAt,
+				Severity:   severityKey,
+				TotalCount: count,
+			})
+		}
+	}
+
+	return result, nil
+}
+
 // UpsertAuthzEntityAttributes creates or updates trusted authorization attributes.
 func (m *MemoryStore) UpsertAuthzEntityAttributes(ctx context.Context, attributes AuthzEntityAttributes) error {
 	normalized, err := NormalizeAuthzEntityAttributesForWrite(attributes)

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -2155,8 +2155,9 @@ func (m *MemoryStore) ListRepoFindings(ctx context.Context, filter RepoFindingFi
 	if err != nil {
 		return nil, err
 	}
-	repoScanID := strings.TrimSpace(filter.RepoScanID)
-	findingID := strings.TrimSpace(filter.FindingID)
+	normalized := NormalizeRepoFindingFilter(filter)
+	repoScanID := normalized.RepoScanID
+	findingID := normalized.FindingID
 	repoScanRepository := ""
 	if repoScanID != "" {
 		record, exists := m.repoScans[repoScanID]
@@ -2165,8 +2166,6 @@ func (m *MemoryStore) ListRepoFindings(ctx context.Context, filter RepoFindingFi
 		}
 		repoScanRepository = strings.TrimSpace(record.Repository)
 	}
-	severity := strings.ToLower(strings.TrimSpace(filter.Severity))
-	findingType := strings.ToLower(strings.TrimSpace(filter.Type))
 
 	result := make([]domain.Finding, 0, len(m.repoFindings))
 	if repoScanID != "" {
@@ -2178,10 +2177,10 @@ func (m *MemoryStore) ListRepoFindings(ctx context.Context, filter RepoFindingFi
 			if findingID != "" && finding.ID != findingID {
 				continue
 			}
-			if severity != "" && strings.ToLower(string(finding.Severity)) != severity {
+			if normalized.Severity != "" && strings.ToLower(string(finding.Severity)) != normalized.Severity {
 				continue
 			}
-			if findingType != "" && strings.ToLower(string(finding.Type)) != findingType {
+			if normalized.Type != "" && strings.ToLower(string(finding.Type)) != normalized.Type {
 				continue
 			}
 			if finding.Repository == "" {
@@ -2199,10 +2198,10 @@ func (m *MemoryStore) ListRepoFindings(ctx context.Context, filter RepoFindingFi
 			if findingID != "" && finding.ID != findingID {
 				continue
 			}
-			if severity != "" && strings.ToLower(string(finding.Severity)) != severity {
+			if normalized.Severity != "" && strings.ToLower(string(finding.Severity)) != normalized.Severity {
 				continue
 			}
-			if findingType != "" && strings.ToLower(string(finding.Type)) != findingType {
+			if normalized.Type != "" && strings.ToLower(string(finding.Type)) != normalized.Type {
 				continue
 			}
 			if finding.Repository == "" {
@@ -2212,7 +2211,7 @@ func (m *MemoryStore) ListRepoFindings(ctx context.Context, filter RepoFindingFi
 			result = append(result, finding)
 		}
 	}
-	sortFindingsForQuery(result, "created_at", true)
+	sortFindingsForQuery(result, normalized.SortBy, normalized.SortDesc)
 	if limit > 0 && len(result) > limit {
 		result = result[:limit]
 	}

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -502,6 +502,53 @@ func TestMemoryStoreListFindingTrendCounts(t *testing.T) {
 	}
 }
 
+func TestMemoryStoreListRepoFindingTrendCounts(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
+	ctx := defaultScopeContext()
+	scanA, err := store.CreateRepoScan(ctx, "owner/repo-a", now)
+	if err != nil {
+		t.Fatalf("create repo scan A: %v", err)
+	}
+	scanB, err := store.CreateRepoScan(ctx, "owner/repo-b", now.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("create repo scan B: %v", err)
+	}
+	if err := store.UpsertRepoFindings(ctx, scanA.ID, []domain.Finding{
+		{ID: "f1", ScanID: scanA.ID, Type: domain.FindingOwnerless, Severity: domain.SeverityHigh, CreatedAt: now.Add(time.Second)},
+		{ID: "f2", ScanID: scanA.ID, Type: domain.FindingEscalationPath, Severity: domain.SeverityCritical, CreatedAt: now.Add(2 * time.Second)},
+	}); err != nil {
+		t.Fatalf("upsert repo findings for scan A: %v", err)
+	}
+	if err := store.UpsertRepoFindings(ctx, scanB.ID, []domain.Finding{
+		{ID: "f3", ScanID: scanB.ID, Type: domain.FindingOwnerless, Severity: domain.SeverityLow, CreatedAt: now.Add(3 * time.Second)},
+	}); err != nil {
+		t.Fatalf("upsert repo findings for scan B: %v", err)
+	}
+
+	trend, err := store.ListRepoFindingTrendCounts(ctx, []string{scanA.ID, scanB.ID}, "", "")
+	if err != nil {
+		t.Fatalf("list repo finding trend counts: %v", err)
+	}
+	if len(trend) != 3 {
+		t.Fatalf("expected 3 repo trend rows, got %+v", trend)
+	}
+
+	filteredTrend, err := store.ListRepoFindingTrendCounts(ctx, []string{scanA.ID, scanB.ID}, "critical", "escalation_path")
+	if err != nil {
+		t.Fatalf("list filtered repo finding trend counts: %v", err)
+	}
+	if len(filteredTrend) != 2 {
+		t.Fatalf("expected 2 filtered repo trend rows (one per scan), got %+v", filteredTrend)
+	}
+	if filteredTrend[0].ScanID != scanA.ID || filteredTrend[0].Severity != "critical" || filteredTrend[0].TotalCount != 1 {
+		t.Fatalf("unexpected filtered repo trend row for scan A: %+v", filteredTrend[0])
+	}
+	if filteredTrend[1].ScanID != scanB.ID || filteredTrend[1].TotalCount != 0 {
+		t.Fatalf("unexpected filtered repo trend row for scan B: %+v", filteredTrend[1])
+	}
+}
+
 func TestMemoryStoreIdentityAndRelationshipFilters(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -3020,20 +3020,22 @@ func (p *PostgresStore) ListRepoFindings(ctx context.Context, filter RepoFinding
 		 FROM repo_findings rf
 		 JOIN repo_scans rs ON rs.id = rf.repo_scan_id
 		 WHERE ($1 = '' OR rf.repo_scan_id = $1::uuid)
-		   AND ($2 = '' OR rf.severity = $2)
-		   AND ($3 = '' OR rf.type = $3)
-		   AND rs.tenant_id = $4
-		   AND rs.workspace_id = $5
+		   AND ($2 = '' OR rf.finding_id = $2)
+		   AND ($3 = '' OR rf.severity = $3)
+		   AND ($4 = '' OR rf.type = $4)
+		   AND rs.tenant_id = $5
+		   AND rs.workspace_id = $6
 		 ORDER BY rf.created_at DESC`
 	args := []any{
 		repoScanID,
+		strings.TrimSpace(filter.FindingID),
 		strings.TrimSpace(filter.Severity),
 		strings.TrimSpace(filter.Type),
 		scope.TenantID,
 		scope.WorkspaceID,
 	}
 	if limit > 0 {
-		query += "\n\t\t LIMIT $6"
+		query += "\n\t\t LIMIT $7"
 		args = append(args, limit)
 	}
 	rows, err := p.queryContext(

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -3074,7 +3074,8 @@ func (p *PostgresStore) ListRepoScans(ctx context.Context, limit int) ([]RepoSca
 
 // ListRepoFindings returns latest repository findings first with optional filters.
 func (p *PostgresStore) ListRepoFindings(ctx context.Context, filter RepoFindingFilter, limit int) ([]domain.Finding, error) {
-	repoScanID := strings.TrimSpace(filter.RepoScanID)
+	normalized := NormalizeRepoFindingFilter(filter)
+	repoScanID := normalized.RepoScanID
 	if repoScanID != "" {
 		if err := p.ensureRepoScanInScope(ctx, repoScanID); err != nil {
 			return nil, err
@@ -3093,12 +3094,12 @@ func (p *PostgresStore) ListRepoFindings(ctx context.Context, filter RepoFinding
 		   AND ($4 = '' OR rf.type = $4)
 		   AND rs.tenant_id = $5
 		   AND rs.workspace_id = $6
-		 ORDER BY rf.created_at DESC`
+		 ORDER BY ` + repoFindingOrderClause(normalized.SortBy, normalized.SortDesc)
 	args := []any{
 		repoScanID,
-		strings.TrimSpace(filter.FindingID),
-		strings.TrimSpace(filter.Severity),
-		strings.TrimSpace(filter.Type),
+		normalized.FindingID,
+		normalized.Severity,
+		normalized.Type,
 		scope.TenantID,
 		scope.WorkspaceID,
 	}
@@ -4326,6 +4327,30 @@ func findingOrderClause(sortBy string, desc bool) string {
 		return fmt.Sprintf("LOWER(f.title) %s, f.scan_id %s, f.finding_id %s", direction, direction, direction)
 	default:
 		return fmt.Sprintf("f.created_at %s, f.scan_id %s, f.finding_id %s", direction, direction, direction)
+	}
+}
+
+func repoFindingOrderClause(sortBy string, desc bool) string {
+	direction := "ASC"
+	if desc {
+		direction = "DESC"
+	}
+	switch sortBy {
+	case "severity":
+		return fmt.Sprintf(`CASE LOWER(rf.severity)
+			WHEN 'critical' THEN 5
+			WHEN 'high' THEN 4
+			WHEN 'medium' THEN 3
+			WHEN 'low' THEN 2
+			WHEN 'info' THEN 1
+			ELSE 0
+		END %s, rf.repo_scan_id %s, rf.finding_id %s`, direction, direction, direction)
+	case "type":
+		return fmt.Sprintf("LOWER(rf.type) %s, rf.repo_scan_id %s, rf.finding_id %s", direction, direction, direction)
+	case "title":
+		return fmt.Sprintf("LOWER(rf.title) %s, rf.repo_scan_id %s, rf.finding_id %s", direction, direction, direction)
+	default:
+		return fmt.Sprintf("rf.created_at %s, rf.repo_scan_id %s, rf.finding_id %s", direction, direction, direction)
 	}
 }
 

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -1587,6 +1587,74 @@ func (p *PostgresStore) ListFindingTrendCounts(ctx context.Context, scanIDs []st
 	return result, nil
 }
 
+// ListRepoFindingTrendCounts aggregates repository finding totals by repo scan and severity.
+func (p *PostgresStore) ListRepoFindingTrendCounts(ctx context.Context, repoScanIDs []string, severity string, findingType string) ([]FindingTrendCount, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	unique := make([]string, 0, len(repoScanIDs))
+	seen := map[string]struct{}{}
+	for _, repoScanID := range repoScanIDs {
+		normalized := strings.TrimSpace(repoScanID)
+		if normalized == "" {
+			continue
+		}
+		if _, exists := seen[normalized]; exists {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		unique = append(unique, normalized)
+	}
+	if len(unique) == 0 {
+		return []FindingTrendCount{}, nil
+	}
+
+	placeholders := make([]string, 0, len(unique))
+	args := make([]any, 0, len(unique)+4)
+	args = append(args, scope.TenantID, scope.WorkspaceID, strings.ToLower(strings.TrimSpace(severity)), strings.ToLower(strings.TrimSpace(findingType)))
+	for i, repoScanID := range unique {
+		placeholders = append(placeholders, fmt.Sprintf("$%d", i+5))
+		args = append(args, repoScanID)
+	}
+
+	rows, err := p.queryContext(
+		ctx,
+		fmt.Sprintf(`SELECT rs.id, rs.started_at, rf.severity, COUNT(rf.finding_id)
+		 FROM repo_scans rs
+		 LEFT JOIN repo_findings rf
+		   ON rf.repo_scan_id = rs.id
+		  AND ($3 = '' OR LOWER(rf.severity) = $3)
+		  AND ($4 = '' OR LOWER(rf.type) = $4)
+		 WHERE rs.tenant_id = $1
+		   AND rs.workspace_id = $2
+		   AND rs.id IN (%s)
+		 GROUP BY rs.id, rs.started_at, rf.severity`, strings.Join(placeholders, ",")),
+		args...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query repo finding trend counts: %w", err)
+	}
+	defer rows.Close()
+
+	result := make([]FindingTrendCount, 0)
+	for rows.Next() {
+		var count FindingTrendCount
+		var severityValue sql.NullString
+		if err := rows.Scan(&count.ScanID, &count.StartedAt, &severityValue, &count.TotalCount); err != nil {
+			return nil, fmt.Errorf("repo finding trend row: %w", err)
+		}
+		if severityValue.Valid {
+			count.Severity = severityValue.String
+		}
+		result = append(result, count)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("repo finding trend rows: %w", err)
+	}
+	return result, nil
+}
+
 // UpsertAuthzEntityAttributes creates or updates trusted authorization attributes.
 func (p *PostgresStore) UpsertAuthzEntityAttributes(ctx context.Context, attributes AuthzEntityAttributes) error {
 	scope, err := RequireScope(ctx)

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -2807,3 +2807,42 @@ func TestPostgresStoreListFindingTrendCounts(t *testing.T) {
 		t.Fatalf("unmet expectations: %v", err)
 	}
 }
+
+func TestPostgresStoreListRepoFindingTrendCounts(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
+
+	trendRows := sqlmock.NewRows([]string{"id", "started_at", "severity", "count"}).
+		AddRow("scan-1", now, "critical", 1).
+		AddRow("scan-2", now.Add(time.Minute), nil, 0)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT rs.id, rs.started_at, rf.severity, COUNT(rf.finding_id)
+		 FROM repo_scans rs
+		 LEFT JOIN repo_findings rf
+		   ON rf.repo_scan_id = rs.id
+		  AND ($3 = '' OR LOWER(rf.severity) = $3)
+		  AND ($4 = '' OR LOWER(rf.type) = $4)
+		 WHERE rs.tenant_id = $1
+		   AND rs.workspace_id = $2
+		   AND rs.id IN ($5,$6)
+		 GROUP BY rs.id, rs.started_at, rf.severity`)).
+		WithArgs("default", "default", "critical", "escalation_path", "scan-1", "scan-2").
+		WillReturnRows(trendRows)
+
+	trend, err := store.ListRepoFindingTrendCounts(defaultScopeContext(), []string{"scan-1", "scan-2", "scan-1"}, "critical", "escalation_path")
+	if err != nil {
+		t.Fatalf("list repo finding trend counts: %v", err)
+	}
+	if len(trend) != 2 || trend[0].ScanID != "scan-1" || trend[1].ScanID != "scan-2" {
+		t.Fatalf("unexpected repo trend counts: %+v", trend)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -699,7 +699,7 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		)`)).
 		WithArgs(record.ID, "default", "default").
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
-	mock.ExpectQuery("SELECT rf.repo_scan_id, rf.finding_id, rf.type").WithArgs(record.ID, "", "", "default", "default", 100).WillReturnRows(repoFindingsRows)
+	mock.ExpectQuery("SELECT rf.repo_scan_id, rf.finding_id, rf.type").WithArgs(record.ID, "", "", "", "default", "default", 100).WillReturnRows(repoFindingsRows)
 	repoFindings, err := store.ListRepoFindings(defaultScopeContext(), RepoFindingFilter{RepoScanID: record.ID}, 100)
 	if err != nil {
 		t.Fatalf("list repo findings failed: %v", err)
@@ -722,7 +722,7 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		)`)).
 		WithArgs(record.ID, "default", "default").
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
-	mock.ExpectQuery("SELECT rf.repo_scan_id, rf.finding_id, rf.type").WithArgs(record.ID, "", "", "default", "default").WillReturnRows(unboundedRepoFindingsRows)
+	mock.ExpectQuery("SELECT rf.repo_scan_id, rf.finding_id, rf.type").WithArgs(record.ID, "", "", "", "default", "default").WillReturnRows(unboundedRepoFindingsRows)
 	unboundedRepoFindings, err := store.ListRepoFindings(defaultScopeContext(), RepoFindingFilter{RepoScanID: record.ID}, 0)
 	if err != nil {
 		t.Fatalf("list repo findings unbounded failed: %v", err)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1592,12 +1592,12 @@ type RelationshipFilter struct {
 
 // RepoFindingFilter controls repository finding list queries.
 type RepoFindingFilter struct {
-	RepoScanID string
-	FindingID  string
-	Severity   string
-	Type       string
+	RepoScanID      string
+	FindingID       string
+	Severity        string
+	Type            string
 	LifecycleStatus string
-	Assignee   string
+	Assignee        string
 }
 
 // RepoFindingClusterListFilter controls repository finding cluster list queries.

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1593,8 +1593,11 @@ type RelationshipFilter struct {
 // RepoFindingFilter controls repository finding list queries.
 type RepoFindingFilter struct {
 	RepoScanID string
+	FindingID  string
 	Severity   string
 	Type       string
+	LifecycleStatus string
+	Assignee   string
 }
 
 // RepoFindingClusterListFilter controls repository finding cluster list queries.
@@ -1676,6 +1679,19 @@ func NormalizeRepoFindingClusterListFilter(filter RepoFindingClusterListFilter) 
 	}
 	if normalized.Offset < 0 {
 		normalized.Offset = 0
+	}
+	return normalized
+}
+
+// NormalizeRepoFindingFilter trims optional filters for repository findings.
+func NormalizeRepoFindingFilter(filter RepoFindingFilter) RepoFindingFilter {
+	normalized := RepoFindingFilter{
+		RepoScanID:      strings.TrimSpace(filter.RepoScanID),
+		FindingID:       strings.TrimSpace(filter.FindingID),
+		Severity:        strings.ToLower(strings.TrimSpace(filter.Severity)),
+		Type:            strings.ToLower(strings.TrimSpace(filter.Type)),
+		LifecycleStatus: strings.ToLower(strings.TrimSpace(filter.LifecycleStatus)),
+		Assignee:        strings.ToLower(strings.TrimSpace(filter.Assignee)),
 	}
 	return normalized
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1766,6 +1766,7 @@ type Store interface {
 	ListFindingMetasByScan(ctx context.Context, scanID string) ([]FindingMeta, error)
 	ListFindingsByScanAndIDs(ctx context.Context, scanID string, findingIDs []string) ([]domain.Finding, error)
 	ListFindingTrendCounts(ctx context.Context, scanIDs []string, severity string, findingType string) ([]FindingTrendCount, error)
+	ListRepoFindingTrendCounts(ctx context.Context, repoScanIDs []string, severity string, findingType string) ([]FindingTrendCount, error)
 	UpsertAuthzEntityAttributes(ctx context.Context, attributes AuthzEntityAttributes) error
 	GetAuthzEntityAttributes(ctx context.Context, entityKind string, entityType string, entityID string) (AuthzEntityAttributes, error)
 	UpsertAuthzRelationship(ctx context.Context, relationship AuthzRelationship) error

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1598,6 +1598,8 @@ type RepoFindingFilter struct {
 	Type            string
 	LifecycleStatus string
 	Assignee        string
+	SortBy          string
+	SortDesc        bool
 }
 
 // RepoFindingClusterListFilter controls repository finding cluster list queries.
@@ -1685,6 +1687,18 @@ func NormalizeRepoFindingClusterListFilter(filter RepoFindingClusterListFilter) 
 
 // NormalizeRepoFindingFilter trims optional filters for repository findings.
 func NormalizeRepoFindingFilter(filter RepoFindingFilter) RepoFindingFilter {
+	rawSortBy := strings.ToLower(strings.TrimSpace(filter.SortBy))
+	sortBy := rawSortBy
+	sortDesc := filter.SortDesc
+	switch sortBy {
+	case "severity", "type", "title", "created_at":
+	default:
+		sortBy = "created_at"
+		if rawSortBy == "" {
+			sortDesc = true
+		}
+	}
+
 	normalized := RepoFindingFilter{
 		RepoScanID:      strings.TrimSpace(filter.RepoScanID),
 		FindingID:       strings.TrimSpace(filter.FindingID),
@@ -1692,6 +1706,8 @@ func NormalizeRepoFindingFilter(filter RepoFindingFilter) RepoFindingFilter {
 		Type:            strings.ToLower(strings.TrimSpace(filter.Type)),
 		LifecycleStatus: strings.ToLower(strings.TrimSpace(filter.LifecycleStatus)),
 		Assignee:        strings.ToLower(strings.TrimSpace(filter.Assignee)),
+		SortBy:          sortBy,
+		SortDesc:        sortDesc,
 	}
 	return normalized
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -50,6 +50,41 @@ func TestNormalizeRepoFindingClusterListFilter(t *testing.T) {
 	}
 }
 
+func TestNormalizeRepoFindingFilter(t *testing.T) {
+	normalized := NormalizeRepoFindingFilter(RepoFindingFilter{
+		RepoScanID:      " repo-scan-1 ",
+		FindingID:       " finding-1 ",
+		Severity:        " HIGH ",
+		Type:            " SECRET_EXPOSURE ",
+		LifecycleStatus: " ACK ",
+		Assignee:        " Platform ",
+		SortBy:          "severity",
+		SortDesc:        true,
+	})
+	if normalized.RepoScanID != "repo-scan-1" || normalized.FindingID != "finding-1" {
+		t.Fatalf("expected trimmed identifiers, got %+v", normalized)
+	}
+	if normalized.Severity != "high" || normalized.Type != "secret_exposure" {
+		t.Fatalf("expected normalized severity/type filters, got %+v", normalized)
+	}
+	if normalized.LifecycleStatus != "ack" || normalized.Assignee != "platform" {
+		t.Fatalf("expected normalized triage filters, got %+v", normalized)
+	}
+	if normalized.SortBy != "severity" || !normalized.SortDesc {
+		t.Fatalf("expected explicit sort controls to pass through, got %+v", normalized)
+	}
+
+	defaults := NormalizeRepoFindingFilter(RepoFindingFilter{})
+	if defaults.SortBy != "created_at" || !defaults.SortDesc {
+		t.Fatalf("expected created_at desc defaults, got %+v", defaults)
+	}
+
+	fallback := NormalizeRepoFindingFilter(RepoFindingFilter{SortBy: "unsupported"})
+	if fallback.SortBy != "created_at" || fallback.SortDesc {
+		t.Fatalf("expected unsupported sort to fall back without flipping direction, got %+v", fallback)
+	}
+}
+
 func TestStoreCloseHelpers(t *testing.T) {
 	mem := NewMemoryStore()
 	if err := mem.Close(); err != nil {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -266,6 +266,24 @@ describe('App', () => {
           ]
         });
       }
+      if (url.includes('/v1/repo-findings/trends')) {
+        return okJSON({
+          items: [
+            {
+              scan_id: 'repo-scan-1',
+              started_at: '2026-01-01T00:00:00Z',
+              total: 1,
+              by_severity: {
+                critical: 0,
+                high: 1,
+                medium: 0,
+                low: 0,
+                info: 0
+              }
+            }
+          ]
+        });
+      }
       if (url.includes('/v1/repo-findings')) {
         return okJSON({
           items: [
@@ -286,24 +304,6 @@ describe('App', () => {
               source_url: 'https://github.com/owner/repo/blob/abc123/config/app.env#L7',
               remediation: 'Rotate the key and move the credential to a secret manager.',
               created_at: '2026-01-01T00:00:00Z'
-            }
-          ]
-        });
-      }
-      if (url.includes('/v1/repo-findings/trends')) {
-        return okJSON({
-          items: [
-            {
-              scan_id: 'repo-scan-1',
-              started_at: '2026-01-01T00:00:00Z',
-              total: 1,
-              by_severity: {
-                critical: 0,
-                high: 1,
-                medium: 0,
-                low: 0,
-                info: 0
-              }
             }
           ]
         });

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -290,6 +290,24 @@ describe('App', () => {
           ]
         });
       }
+      if (url.includes('/v1/findings/trends')) {
+        return okJSON({
+          items: [
+            {
+              scan_id: 'repo-scan-1',
+              started_at: '2026-01-01T00:00:00Z',
+              total: 1,
+              by_severity: {
+                critical: 0,
+                high: 1,
+                medium: 0,
+                low: 0,
+                info: 0
+              }
+            }
+          ]
+        });
+      }
       throw new Error(`Unexpected URL ${url}`);
     });
     vi.stubGlobal('fetch', fetchMock);
@@ -299,6 +317,9 @@ describe('App', () => {
 
     expect(await screen.findByRole('heading', { level: 2, name: /Findings/i })).toBeInTheDocument();
     expect(await screen.findByText(/Review repository findings and jump directly to the exact GitHub line/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Finding trend/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Critical 0 \/ High 1 \/ Medium 0 \/ Low 0 \/ Info 0/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Risk/i)).toBeInTheDocument();
 
     const openInGitHub = await screen.findByRole('link', { name: /Open in GitHub/i });
     expect(openInGitHub).toHaveAttribute('href', 'https://github.com/owner/repo/blob/abc123/config/app.env#L7');

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -290,7 +290,7 @@ describe('App', () => {
           ]
         });
       }
-      if (url.includes('/v1/findings/trends')) {
+      if (url.includes('/v1/repo-findings/trends')) {
         return okJSON({
           items: [
             {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -9,6 +9,7 @@ export type Finding = {
   scan_id: string;
   type: string;
   severity: string;
+  confidence_score?: number;
   title: string;
   human_summary: string;
   path?: string[];
@@ -946,6 +947,8 @@ export const apiClient = {
       repo_scan_id?: string;
       severity?: string;
       type?: string;
+      lifecycle_status?: FindingLifecycleStatus;
+      assignee?: string;
       sort_by?: string;
       sort_order?: 'asc' | 'desc';
     } = {},

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -905,8 +905,14 @@ export const apiClient = {
   getFindingsTrends(
     filters: { points?: number; severity?: string; type?: string } = {},
     auth?: RequestAuthContext
-  ) {
+    ) {
     return request<{ items: TrendPoint[] }>(`/v1/findings/trends${buildQuery(filters)}`, auth);
+  },
+  getRepoFindingsTrends(
+    filters: { points?: number; severity?: string; type?: string } = {},
+    auth?: RequestAuthContext
+  ) {
+    return request<{ items: TrendPoint[] }>(`/v1/repo-findings/trends${buildQuery(filters)}`, auth);
   },
   listScans(auth?: RequestAuthContext) {
     return request<{ items: ScanRecord[] }>('/v1/scans?sort_by=started_at&sort_order=desc', auth);

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -8,11 +8,13 @@ import {
   type AWSPermissionPreviewItem,
   type CurrentUserContext,
   type Finding as ApiFinding,
+  type FindingLifecycleStatus,
   type GitHubConnectorStartResponse,
   type GitHubConnectionStatus,
   type KubernetesConnectionStatus,
   type ProjectRecord,
   type RepoScanRecord,
+  type TrendPoint,
   type RequestAuthContext,
   type ScanPolicyRecord,
   type ScanTriggerMode,
@@ -134,6 +136,46 @@ const SOURCE_ORDER: SourceProvider[] = FEATURE_CONNECTOR_GITHUB_V2
 const SCAN_POLICY_TRIGGER_MODES: ScanTriggerMode[] = ['manual', 'scheduled', 'event', 'hybrid'];
 const REPO_FINDING_SEVERITY_FILTERS = ['all', 'critical', 'high', 'medium', 'low', 'info'] as const;
 const REPO_FINDING_TYPE_FILTERS = ['all', 'secret_exposure', 'repo_misconfiguration'] as const;
+const REPO_FINDING_SORT_FIELDS = ['severity', 'created_at', 'type', 'title'] as const;
+const REPO_FINDING_STATUS_FILTERS = ['all', 'open', 'ack', 'suppressed', 'resolved'] as const;
+
+const SORT_LABEL_BY_FIELD: Record<(typeof REPO_FINDING_SORT_FIELDS)[number], string> = {
+  severity: 'Risk (high → low)',
+  created_at: 'Newest first',
+  type: 'Finding type',
+  title: 'Finding title'
+};
+
+const TREND_POINTS = 10;
+const SEVERITY_ORDER: string[] = ['critical', 'high', 'medium', 'low', 'info', 'unknown'];
+
+function formatConfidenceScore(value: number | undefined): string {
+  if (!Number.isFinite(value ?? NaN)) {
+    return 'N/A';
+  }
+  const clamped = Math.max(0, Math.min(100, Math.round(value * 100)));
+  return `${clamped}%`;
+}
+
+function formatDateLabel(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleString();
+}
+
+function normalizeFindingStatus(value: string | undefined): FindingLifecycleStatus {
+  const normalized = normalizeValue(value ?? '').toLowerCase();
+  if (normalized === 'ack' || normalized === 'suppressed' || normalized === 'resolved') {
+    return normalized;
+  }
+  return 'open';
+}
+
+function repoFindingStatusClass(status: FindingLifecycleStatus): string {
+  return `idt-repo-finding-status is-${status}`;
+}
 
 function buildProductAuthContext(scope: ProductSession): RequestAuthContext {
   return {
@@ -2764,16 +2806,42 @@ export function ProductProjectDetailPage() {
 export function ProductFindingsPage() {
   const params = useParams<ScopeRouteParams>();
   const scope = resolveScopeFromParams(params);
+  const { me } = useMe();
+
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+  const [signalsLoading, setSignalsLoading] = useState(false);
+  const [signalsRefreshing, setSignalsRefreshing] = useState(false);
   const [error, setError] = useState('');
+  const [signalError, setSignalError] = useState('');
+  const [trendError, setTrendError] = useState('');
   const [repoScans, setRepoScans] = useState<RepoScanRecord[]>([]);
   const [repoFindings, setRepoFindings] = useState<ApiFinding[]>([]);
+  const [trendPoints, setTrendPoints] = useState<TrendPoint[]>([]);
   const [repoScanFilter, setRepoScanFilter] = useState('');
   const [severityFilter, setSeverityFilter] = useState<(typeof REPO_FINDING_SEVERITY_FILTERS)[number]>('all');
   const [typeFilter, setTypeFilter] = useState<(typeof REPO_FINDING_TYPE_FILTERS)[number]>('all');
+  const [statusFilter, setStatusFilter] = useState<(typeof REPO_FINDING_STATUS_FILTERS)[number]>('all');
+  const [assigneeFilter, setAssigneeFilter] = useState('');
+  const [sortBy, setSortBy] = useState<(typeof REPO_FINDING_SORT_FIELDS)[number]>('severity');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const [selectedFindingID, setSelectedFindingID] = useState('');
+  const [workflowStatus, setWorkflowStatus] = useState<FindingLifecycleStatus>('open');
+  const [workflowAssignee, setWorkflowAssignee] = useState('');
+  const [workflowComment, setWorkflowComment] = useState('');
+  const [workflowLoading, setWorkflowLoading] = useState(false);
+  const [workflowSuccess, setWorkflowSuccess] = useState('');
+  const [workflowError, setWorkflowError] = useState('');
+
   const requestRef = useRef(0);
+  const signalRequestRef = useRef(0);
+
+  const hasTriageAccess = Boolean(me?.role === 'owner' || me?.role === 'admin');
+
+  const trendMaxTotal = useMemo(() => {
+    const totals = trendPoints.map((point) => point.total);
+    return totals.length ? Math.max(...totals) : 0;
+  }, [trendPoints]);
 
   const repoScansByID = useMemo(
     () =>
@@ -2784,25 +2852,70 @@ export function ProductFindingsPage() {
     [repoScans]
   );
 
+  const filteredFindings = useMemo(() => {
+    const normalizedAssigneeFilter = normalizeValue(assigneeFilter).toLowerCase();
+    return repoFindings.filter((finding) => {
+      const status = normalizeFindingStatus(finding.triage?.status);
+      const assignee = normalizeValue(finding.triage?.assignee ?? '').toLowerCase();
+      const matchesStatus = statusFilter === 'all' || status === statusFilter;
+      const matchesAssignee = !normalizedAssigneeFilter || assignee.includes(normalizedAssigneeFilter);
+
+      return matchesStatus && matchesAssignee;
+    });
+  }, [repoFindings, statusFilter, assigneeFilter]);
+
+  const groupedFindings = useMemo(() => {
+    const buckets: Record<string, ApiFinding[]> = {};
+
+    for (const finding of filteredFindings) {
+      const bucket = normalizeValue(finding.severity).toLowerCase() || 'unknown';
+      const bucketEntries = buckets[bucket] ?? [];
+      bucketEntries.push(finding);
+      buckets[bucket] = bucketEntries;
+    }
+
+    return SEVERITY_ORDER.reduce<Record<string, ApiFinding[]>>((acc, severity) => {
+      const items = buckets[severity];
+      if (items && items.length > 0) {
+        acc[severity] = items;
+      }
+      return acc;
+    }, {});
+  }, [filteredFindings]);
+
   const selectedFinding = useMemo(
-    () => repoFindings.find((finding) => finding.id === selectedFindingID) ?? repoFindings[0] ?? null,
-    [repoFindings, selectedFindingID]
+    () => filteredFindings.find((finding) => finding.id === selectedFindingID) ?? filteredFindings[0] ?? null,
+    [filteredFindings, selectedFindingID]
   );
 
   const linkedFindingCount = useMemo(
-    () => repoFindings.filter((finding) => normalizeValue(finding.source_url ?? '')).length,
-    [repoFindings]
+    () => filteredFindings.filter((finding) => normalizeValue(finding.source_url ?? '')).length,
+    [filteredFindings]
   );
 
   const criticalFindingCount = useMemo(
-    () => repoFindings.filter((finding) => normalizeValue(finding.severity).toLowerCase() === 'critical').length,
-    [repoFindings]
+    () => filteredFindings.filter((finding) => normalizeValue(finding.severity).toLowerCase() === 'critical').length,
+    [filteredFindings]
   );
 
   const activeScanCount = useMemo(
     () => repoScans.filter((scan) => normalizeValue(scan.status).toLowerCase() === 'succeeded').length,
     [repoScans]
   );
+
+  const openFindingCount = useMemo(
+    () => filteredFindings.filter((finding) => normalizeFindingStatus(finding.triage?.status) === 'open').length,
+    [filteredFindings]
+  );
+
+  const averageConfidence = useMemo(() => {
+    const findingsWithConfidence = filteredFindings.filter((finding) => Number.isFinite(finding.confidence_score ?? NaN));
+    if (findingsWithConfidence.length === 0) {
+      return 'N/A';
+    }
+    const sum = findingsWithConfidence.reduce((acc, finding) => acc + (finding.confidence_score ?? 0), 0);
+    return formatConfidenceScore(sum / findingsWithConfidence.length);
+  }, [filteredFindings]);
 
   const loadRepoFindings = async (targetScope: ProductSession, mode: 'initial' | 'refresh') => {
     const requestID = ++requestRef.current;
@@ -2821,7 +2934,11 @@ export function ProductFindingsPage() {
             limit: 100,
             repo_scan_id: normalizeValue(repoScanFilter) || undefined,
             severity: severityFilter !== 'all' ? severityFilter : undefined,
-            type: typeFilter !== 'all' ? typeFilter : undefined
+            type: typeFilter !== 'all' ? typeFilter : undefined,
+            lifecycle_status: statusFilter !== 'all' ? statusFilter : undefined,
+            assignee: normalizeValue(assigneeFilter) || undefined,
+            sort_by: sortBy,
+            sort_order: sortOrder
           },
           auth
         )
@@ -2845,6 +2962,93 @@ export function ProductFindingsPage() {
     }
   };
 
+  const loadTrendSignals = async (targetScope: ProductSession, mode: 'initial' | 'refresh') => {
+    const requestID = ++signalRequestRef.current;
+    if (mode === 'initial') {
+      setSignalsLoading(true);
+    } else {
+      setSignalsRefreshing(true);
+    }
+    setSignalError('');
+    setTrendError('');
+    try {
+      const auth = buildProductAuthContext(targetScope);
+      const trendResponse = await apiClient.getFindingsTrends(
+        {
+          points: TREND_POINTS,
+          severity: severityFilter !== 'all' ? severityFilter : undefined,
+          type: typeFilter !== 'all' ? typeFilter : undefined
+        },
+        auth
+      );
+      if (requestID !== signalRequestRef.current) {
+        return;
+      }
+      setTrendPoints(trendResponse.items);
+    } catch (requestError) {
+      if (requestID !== signalRequestRef.current) {
+        return;
+      }
+      const message = requestError instanceof Error ? requestError.message : 'Failed to load finding trend metrics.';
+      setTrendError(message);
+    } finally {
+      if (requestID === signalRequestRef.current) {
+        setSignalsLoading(false);
+        setSignalsRefreshing(false);
+      }
+    }
+  };
+
+  const handleApplyWorkflow = async () => {
+    if (!scope || !selectedFinding || workflowLoading) {
+      return;
+    }
+
+    const nextStatus = normalizeFindingStatus(workflowStatus);
+    const nextAssignee = normalizeValue(workflowAssignee);
+    const currentStatus = normalizeFindingStatus(selectedFinding.triage?.status);
+    const currentAssignee = normalizeValue(selectedFinding.triage?.assignee ?? '');
+    const hasChanges =
+      nextStatus !== currentStatus ||
+      nextAssignee !== currentAssignee ||
+      normalizeValue(workflowComment).length > 0;
+
+    if (!hasChanges) {
+      setWorkflowError('Make a workflow change before saving.');
+      return;
+    }
+
+    setWorkflowLoading(true);
+    setWorkflowError('');
+    setWorkflowSuccess('');
+    try {
+      const auth = buildProductAuthContext(scope);
+      const request: { status?: FindingLifecycleStatus; assignee?: string; comment?: string } = {};
+      if (nextStatus !== currentStatus) {
+        request.status = nextStatus;
+      }
+      if (nextAssignee !== currentAssignee) {
+        request.assignee = nextAssignee;
+      }
+      const trimmedComment = normalizeValue(workflowComment);
+      if (trimmedComment) {
+        request.comment = trimmedComment;
+      }
+      const response = await apiClient.triageFinding(selectedFinding.id, request, selectedFinding.scan_id, auth);
+      setRepoFindings((current) =>
+        current.map((finding) => (finding.id === response.finding.id ? { ...finding, ...response.finding } : finding))
+      );
+      setWorkflowSuccess('Workflow state updated successfully.');
+      setWorkflowComment('');
+    } catch (requestError) {
+      const message = requestError instanceof Error ? requestError.message : 'Failed to update workflow state.';
+      setWorkflowError(message);
+    } finally {
+      setWorkflowLoading(false);
+      setTimeout(() => setWorkflowSuccess(''), 2200);
+    }
+  };
+
   useEffect(() => {
     if (!scope) {
       setLoading(false);
@@ -2852,22 +3056,47 @@ export function ProductFindingsPage() {
       return;
     }
     void loadRepoFindings(scope, 'initial');
+    void loadTrendSignals(scope, 'initial');
     return () => {
       requestRef.current += 1;
+      signalRequestRef.current += 1;
     };
-  }, [scope?.tenantID, scope?.workspaceID, repoScanFilter, severityFilter, typeFilter]);
+  }, [
+    scope?.tenantID,
+    scope?.workspaceID,
+    repoScanFilter,
+    severityFilter,
+    typeFilter,
+    statusFilter,
+    assigneeFilter,
+    sortBy,
+    sortOrder
+  ]);
 
   useEffect(() => {
-    if (repoFindings.length === 0) {
+    if (!selectedFinding) {
+      setWorkflowStatus('open');
+      setWorkflowAssignee('');
+      setWorkflowComment('');
+      return;
+    }
+
+    setWorkflowStatus(normalizeFindingStatus(selectedFinding.triage?.status));
+    setWorkflowAssignee(selectedFinding.triage?.assignee ?? '');
+    setWorkflowComment('');
+  }, [selectedFinding?.id, selectedFinding?.triage?.status, selectedFinding?.triage?.assignee]);
+
+  useEffect(() => {
+    if (filteredFindings.length === 0) {
       if (selectedFindingID) {
         setSelectedFindingID('');
       }
       return;
     }
-    if (!repoFindings.some((finding) => finding.id === selectedFindingID)) {
-      setSelectedFindingID(repoFindings[0].id);
+    if (!filteredFindings.some((finding) => finding.id === selectedFindingID)) {
+      setSelectedFindingID(filteredFindings[0].id);
     }
-  }, [repoFindings, selectedFindingID]);
+  }, [filteredFindings, selectedFindingID]);
 
   if (!scope) {
     return (
@@ -2885,7 +3114,28 @@ export function ProductFindingsPage() {
 
   const handleRefresh = () => {
     void loadRepoFindings(scope, 'refresh');
+    void loadTrendSignals(scope, 'refresh');
   };
+
+  const totalTrendItems = trendPoints.reduce((acc, point) => acc + point.total, 0);
+  const trendRows = trendPoints.map((point, index) => {
+    const severityValues = {
+      critical: point.by_severity.critical ?? 0,
+      high: point.by_severity.high ?? 0,
+      medium: point.by_severity.medium ?? 0,
+      low: point.by_severity.low ?? 0,
+      info: point.by_severity.info ?? 0
+    };
+    const percentage = trendMaxTotal > 0 ? Math.round((point.total / trendMaxTotal) * 100) : 0;
+    const startedAt = new Date(point.started_at);
+    const pointLabel =
+      Number.isNaN(startedAt.getTime()) ?
+      'Unknown scan'
+      : startedAt.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    return { ...severityValues, key: `${point.started_at}-${index}`, percentage, label: pointLabel, total: point.total };
+  });
+
+  const trendDisplayLoading = signalsLoading;
 
   return (
     <section className="idt-app-panel">
@@ -2899,6 +3149,15 @@ export function ProductFindingsPage() {
           <button className="idt-btn idt-btn-ghost" type="button" onClick={handleRefresh} disabled={refreshing}>
             {refreshing ? 'Refreshing...' : 'Refresh'}
           </button>
+          <button
+            className="idt-btn idt-btn-ghost"
+            type="button"
+            onClick={handleRefresh}
+            disabled={signalsRefreshing || signalsLoading}
+            style={{ marginLeft: '0.45rem' }}
+          >
+            {signalsRefreshing ? 'Loading signals...' : 'Reload trend'}
+          </button>
           {selectedFinding?.source_url ? (
             <a className="idt-btn idt-btn-primary" href={selectedFinding.source_url} target="_blank" rel="noreferrer">
               Open in GitHub
@@ -2908,24 +3167,65 @@ export function ProductFindingsPage() {
       </div>
 
       {error ? <div className="idt-app-alert idt-app-alert-error">{error}</div> : null}
+      {signalError ? <div className="idt-app-alert idt-app-alert-error">{signalError}</div> : null}
+      {trendError ? <div className="idt-app-alert idt-app-alert-error">{trendError}</div> : null}
 
       <div className="idt-repo-finding-stats" aria-label="Repository finding summary">
         <article className="idt-repo-finding-stat">
           <span>Total repo findings</span>
-          <strong>{repoFindings.length}</strong>
+          <strong>{filteredFindings.length}</strong>
         </article>
         <article className="idt-repo-finding-stat">
           <span>GitHub-linked findings</span>
           <strong>{linkedFindingCount}</strong>
         </article>
         <article className="idt-repo-finding-stat">
+          <span>Open findings</span>
+          <strong>{openFindingCount}</strong>
+        </article>
+        <article className="idt-repo-finding-stat">
           <span>Critical findings</span>
           <strong>{criticalFindingCount}</strong>
+        </article>
+        <article className="idt-repo-finding-stat">
+          <span>Avg confidence</span>
+          <strong>{averageConfidence}</strong>
         </article>
         <article className="idt-repo-finding-stat">
           <span>Completed repo scans</span>
           <strong>{activeScanCount}</strong>
         </article>
+      </div>
+
+      <div className="idt-repo-finding-trend">
+        <div className="idt-repo-finding-trend-head">
+          <h3>Finding trend</h3>
+          {trendDisplayLoading ? <span className="idt-app-alert idt-app-alert-success">Loading trend</span> : null}
+          <span className="idt-repo-finding-trend-subtitle">{totalTrendItems > 0 ? `${totalTrendItems} total events in window` : 'No trend items yet'}</span>
+        </div>
+        <div className="idt-repo-finding-trend-rows">
+          {trendRows.length === 0 ? (
+            <AppShellEmptyState
+              title="Trend unavailable"
+              body="Run a scan so finding trend snapshots can appear with severity distribution over time."
+            />
+          ) : (
+            trendRows.map((row) => (
+              <article key={row.key} className="idt-repo-finding-trend-row">
+                <div className="idt-repo-finding-trend-meta">
+                  <span>{row.label}</span>
+                  <strong>{row.total}</strong>
+                </div>
+                <div className="idt-repo-finding-trend-bar-track" role="img" aria-label={`Trend point ${row.label}`}>
+                  <div className="idt-repo-finding-trend-bar" style={{ width: `${row.percentage}%` }} />
+                </div>
+                <p>
+                  {`Critical ${row.critical} / High ${row.high} / Medium ${row.medium} / Low ${row.low} / Info ${row.info}`}
+                </p>
+              </article>
+            ))
+          )}
+        </div>
       </div>
 
       <div className="idt-repo-finding-filters">
@@ -2963,46 +3263,97 @@ export function ProductFindingsPage() {
             ))}
           </select>
         </label>
+        <label>
+          Sort by
+          <select value={sortBy} onChange={(event) => setSortBy(event.target.value as (typeof REPO_FINDING_SORT_FIELDS)[number])}>
+            {REPO_FINDING_SORT_FIELDS.map((value) => (
+              <option key={value} value={value}>
+                {SORT_LABEL_BY_FIELD[value]}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Sort order
+          <select value={sortOrder} onChange={(event) => setSortOrder(event.target.value as 'asc' | 'desc')}>
+            <option value="asc">Ascending</option>
+            <option value="desc">Descending</option>
+          </select>
+        </label>
+        <label>
+          Lifecycle status
+          <select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value as (typeof REPO_FINDING_STATUS_FILTERS)[number])}>
+            {REPO_FINDING_STATUS_FILTERS.map((value) => (
+              <option key={value} value={value}>
+                {formatTokenLabel(value)}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Assignee
+          <input
+            type="text"
+            placeholder="Filter by assignee"
+            value={assigneeFilter}
+            onChange={(event) => setAssigneeFilter(event.target.value)}
+          />
+        </label>
       </div>
 
       <div className="idt-repo-finding-layout">
         <div className="idt-repo-finding-list">
           <div className="idt-repo-finding-list-header">
             <h3>Repository findings</h3>
-            <p>{repoFindings.length ? `${repoFindings.length} findings in scope` : 'No findings match the current filters.'}</p>
+            <p>{filteredFindings.length ? `${filteredFindings.length} findings in scope` : 'No findings match the current filters.'}</p>
           </div>
-          {repoFindings.length === 0 ? (
+          {Object.keys(groupedFindings).length === 0 ? (
             <AppShellEmptyState
               title="No repository findings"
               body="Run a repository exposure scan or loosen the current filters to inspect GitHub-linked findings."
             />
           ) : (
-            <div className="idt-repo-finding-items" role="list">
-              {repoFindings.map((finding) => {
-                const repositoryValue = repoFindingRepositoryValue(finding, repoScansByID);
-                const repositoryLabel = canonicalGitHubRepositoryDisplay(repositoryValue) || 'Repository unavailable';
-                const isSelected = selectedFinding?.id === finding.id;
-                return (
-                  <button
-                    key={finding.id}
-                    type="button"
-                    role="listitem"
-                    className={`idt-repo-finding-row${isSelected ? ' is-selected' : ''}`}
-                    onClick={() => setSelectedFindingID(finding.id)}
-                  >
-                    <div className="idt-repo-finding-row-top">
-                      <strong>{finding.title}</strong>
-                      <span className={repoFindingSeverityClass(finding.severity)}>{formatTokenLabel(finding.severity)}</span>
-                    </div>
-                    <p>{finding.human_summary}</p>
-                    <div className="idt-repo-finding-row-meta">
-                      <span>{repositoryLabel}</span>
-                      <span>{repoFindingLocationLabel(finding)}</span>
-                      <span>{formatTokenLabel(finding.type)}</span>
-                    </div>
-                  </button>
-                );
-              })}
+            <div>
+              {Object.entries(groupedFindings).map(([severity, findings]) => (
+                <section className="idt-repo-finding-group" key={severity}>
+                  <h4>
+                    {formatTokenLabel(severity)} · {findings.length}
+                  </h4>
+                  <div className="idt-repo-finding-items" role="list">
+                    {findings.map((finding) => {
+                      const repositoryValue = repoFindingRepositoryValue(finding, repoScansByID);
+                      const repositoryLabel = canonicalGitHubRepositoryDisplay(repositoryValue) || 'Repository unavailable';
+                      const isSelected = selectedFinding?.id === finding.id;
+                      const lifecycle = normalizeFindingStatus(finding.triage?.status);
+                      return (
+                        <button
+                          key={finding.id}
+                          type="button"
+                          role="listitem"
+                          className={`idt-repo-finding-row${isSelected ? ' is-selected' : ''}`}
+                          onClick={() => setSelectedFindingID(finding.id)}
+                        >
+                          <div className="idt-repo-finding-row-top">
+                            <strong>{finding.title}</strong>
+                            <span className={repoFindingSeverityClass(finding.severity)}>{formatTokenLabel(finding.severity)}</span>
+                          </div>
+                          <p>{finding.human_summary}</p>
+                          <div className="idt-repo-finding-row-meta">
+                            <span>{repositoryLabel}</span>
+                            <span>{repoFindingLocationLabel(finding)}</span>
+                            <span>{formatTokenLabel(finding.type)}</span>
+                            <span>{`Confidence ${formatConfidenceScore(finding.confidence_score)}`}</span>
+                          </div>
+                          <div className="idt-repo-finding-row-meta">
+                            <span className={repoFindingStatusClass(lifecycle)}>{formatTokenLabel(lifecycle)}</span>
+                            <span>{`Assignee ${finding.triage?.assignee || 'Unassigned'}`}</span>
+                          </div>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </section>
+              ))}
             </div>
           )}
         </div>
@@ -3022,6 +3373,10 @@ export function ProductFindingsPage() {
                   <dd>{canonicalGitHubRepositoryDisplay(repoFindingRepositoryValue(selectedFinding, repoScansByID)) || 'Unavailable'}</dd>
                 </div>
                 <div>
+                  <dt>Confidence</dt>
+                  <dd>{formatConfidenceScore(selectedFinding.confidence_score)}</dd>
+                </div>
+                <div>
                   <dt>Location</dt>
                   <dd>{repoFindingLocationLabel(selectedFinding)}</dd>
                 </div>
@@ -3030,8 +3385,20 @@ export function ProductFindingsPage() {
                   <dd>{selectedFinding.commit || 'Unavailable'}</dd>
                 </div>
                 <div>
+                  <dt>Lifecycle status</dt>
+                  <dd>{formatTokenLabel(normalizeFindingStatus(selectedFinding.triage?.status))}</dd>
+                </div>
+                <div>
+                  <dt>Assignee</dt>
+                  <dd>{selectedFinding.triage?.assignee || 'Unassigned'}</dd>
+                </div>
+                <div>
                   <dt>Detector</dt>
                   <dd>{selectedFinding.detector ? formatTokenLabel(selectedFinding.detector) : 'Unavailable'}</dd>
+                </div>
+                <div>
+                  <dt>Last triage update</dt>
+                  <dd>{selectedFinding.triage?.updated_at ? formatDateLabel(selectedFinding.triage.updated_at) : 'Never'}</dd>
                 </div>
               </dl>
 
@@ -3055,6 +3422,55 @@ export function ProductFindingsPage() {
               <div className="idt-repo-finding-remediation">
                 <h4>Remediation</h4>
                 <p>{selectedFinding.remediation}</p>
+              </div>
+
+              <div className="idt-repo-finding-triage-form">
+                <h4>Workflow controls</h4>
+                {workflowError ? <div className="idt-app-alert idt-app-alert-error">{workflowError}</div> : null}
+                {workflowSuccess ? <div className="idt-app-alert idt-app-alert-success">{workflowSuccess}</div> : null}
+                <label>
+                  Status
+                  <select
+                    value={workflowStatus}
+                    onChange={(event) => setWorkflowStatus(event.target.value as FindingLifecycleStatus)}
+                    disabled={workflowLoading || !hasTriageAccess}
+                  >
+                    {REPO_FINDING_STATUS_FILTERS.filter((status) => status !== 'all').map((status) => (
+                      <option key={status} value={status}>
+                        {formatTokenLabel(status)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label>
+                  Assignee
+                  <input
+                    type="text"
+                    value={workflowAssignee}
+                    onChange={(event) => setWorkflowAssignee(event.target.value)}
+                    disabled={workflowLoading || !hasTriageAccess}
+                    placeholder="analyst handle"
+                  />
+                </label>
+                <label>
+                  Comment
+                  <textarea
+                    rows={3}
+                    value={workflowComment}
+                    onChange={(event) => setWorkflowComment(event.target.value)}
+                    disabled={workflowLoading || !hasTriageAccess}
+                    placeholder="Optional workflow comment"
+                    maxLength={500}
+                  />
+                </label>
+                <button
+                  type="button"
+                  className="idt-btn idt-btn-primary"
+                  onClick={handleApplyWorkflow}
+                  disabled={workflowLoading || !hasTriageAccess}
+                >
+                  {workflowLoading ? 'Saving...' : 'Apply workflow'}
+                </button>
               </div>
             </>
           ) : (

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -2983,7 +2983,7 @@ export function ProductFindingsPage() {
     setTrendError('');
     try {
       const auth = buildProductAuthContext(targetScope);
-      const trendResponse = await apiClient.getFindingsTrends(
+      const trendResponse = await apiClient.getRepoFindingsTrends(
         {
           points: TREND_POINTS,
           severity: severityFilter !== 'all' ? severityFilter : undefined,

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -153,7 +153,7 @@ function formatConfidenceScore(value: number | undefined): string {
   if (!Number.isFinite(value ?? NaN)) {
     return 'N/A';
   }
-  const clamped = Math.max(0, Math.min(100, Math.round(value * 100)));
+  const clamped = Math.max(0, Math.min(100, Math.round((value ?? 0) * 100)));
   return `${clamped}%`;
 }
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -2878,7 +2878,10 @@ export function ProductFindingsPage() {
     });
   }, [repoFindings, statusFilter, assigneeFilter]);
 
-  const findingGroups = useMemo(() => groupRepoFindingsForDisplay(filteredFindings, sortBy), [filteredFindings, sortBy]);
+  const findingGroups = useMemo(
+    () => groupRepoFindingsForDisplay(filteredFindings, sortBy, sortOrder),
+    [filteredFindings, sortBy, sortOrder]
+  );
 
   const selectedFinding = useMemo(
     () => findRepoFindingBySelectionKey(filteredFindings, selectedFindingKey) ?? filteredFindings[0] ?? null,

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -25,7 +25,12 @@ import {
 } from './api/client';
 import { PermissionPreviewModal } from './components/connector/PermissionPreviewModal';
 import { useMe } from './hooks/useMe';
-import { buildRepoFindingSelectionKey, findRepoFindingBySelectionKey, groupRepoFindingsForDisplay } from './repoFindingDisplay';
+import {
+  buildRepoFindingSelectionKey,
+  findRepoFindingBySelectionKey,
+  groupRepoFindingsForDisplay,
+  mergeUpdatedRepoFinding
+} from './repoFindingDisplay';
 
 type ProductSession = {
   tenantID: string;
@@ -3055,9 +3060,7 @@ export function ProductFindingsPage() {
         request.comment = trimmedComment;
       }
       const response = await apiClient.triageFinding(selectedFinding.id, request, selectedFinding.scan_id, auth);
-      setRepoFindings((current) =>
-        current.map((finding) => (finding.id === response.finding.id ? { ...finding, ...response.finding } : finding))
-      );
+      setRepoFindings((current) => mergeUpdatedRepoFinding(current, response.finding));
       setWorkflowSuccess('Workflow state updated successfully.');
       setWorkflowComment('');
     } catch (requestError) {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -25,7 +25,7 @@ import {
 } from './api/client';
 import { PermissionPreviewModal } from './components/connector/PermissionPreviewModal';
 import { useMe } from './hooks/useMe';
-import { groupRepoFindingsForDisplay } from './repoFindingDisplay';
+import { buildRepoFindingSelectionKey, findRepoFindingBySelectionKey, groupRepoFindingsForDisplay } from './repoFindingDisplay';
 
 type ProductSession = {
   tenantID: string;
@@ -2833,7 +2833,7 @@ export function ProductFindingsPage() {
   const [assigneeFilter, setAssigneeFilter] = useState('');
   const [sortBy, setSortBy] = useState<(typeof REPO_FINDING_SORT_FIELDS)[number]>('severity');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
-  const [selectedFindingID, setSelectedFindingID] = useState('');
+  const [selectedFindingKey, setSelectedFindingKey] = useState('');
   const [workflowStatus, setWorkflowStatus] = useState<FindingLifecycleStatus>('open');
   const [workflowAssignee, setWorkflowAssignee] = useState('');
   const [workflowComment, setWorkflowComment] = useState('');
@@ -2876,8 +2876,8 @@ export function ProductFindingsPage() {
   const findingGroups = useMemo(() => groupRepoFindingsForDisplay(filteredFindings, sortBy), [filteredFindings, sortBy]);
 
   const selectedFinding = useMemo(
-    () => filteredFindings.find((finding) => finding.id === selectedFindingID) ?? filteredFindings[0] ?? null,
-    [filteredFindings, selectedFindingID]
+    () => findRepoFindingBySelectionKey(filteredFindings, selectedFindingKey) ?? filteredFindings[0] ?? null,
+    [filteredFindings, selectedFindingKey]
   );
 
   const linkedFindingCount = useMemo(
@@ -3110,6 +3110,7 @@ export function ProductFindingsPage() {
     );
   }, [
     selectedFinding?.id,
+    selectedFinding?.scan_id,
     selectedFinding?.triage?.status,
     selectedFinding?.triage?.assignee,
     selectedFinding?.triage?.suppression_expires_at
@@ -3117,15 +3118,15 @@ export function ProductFindingsPage() {
 
   useEffect(() => {
     if (filteredFindings.length === 0) {
-      if (selectedFindingID) {
-        setSelectedFindingID('');
+      if (selectedFindingKey) {
+        setSelectedFindingKey('');
       }
       return;
     }
-    if (!filteredFindings.some((finding) => finding.id === selectedFindingID)) {
-      setSelectedFindingID(filteredFindings[0].id);
+    if (!findRepoFindingBySelectionKey(filteredFindings, selectedFindingKey)) {
+      setSelectedFindingKey(buildRepoFindingSelectionKey(filteredFindings[0]));
     }
-  }, [filteredFindings, selectedFindingID]);
+  }, [filteredFindings, selectedFindingKey]);
 
   if (!scope) {
     return (
@@ -3350,15 +3351,16 @@ export function ProductFindingsPage() {
                     {group.findings.map((finding) => {
                       const repositoryValue = repoFindingRepositoryValue(finding, repoScansByID);
                       const repositoryLabel = canonicalGitHubRepositoryDisplay(repositoryValue) || 'Repository unavailable';
-                      const isSelected = selectedFinding?.id === finding.id;
+                      const selectionKey = buildRepoFindingSelectionKey(finding);
+                      const isSelected = selectedFindingKey === selectionKey;
                       const lifecycle = normalizeFindingStatus(finding.triage?.status);
                       return (
                         <button
-                          key={finding.id}
+                          key={selectionKey}
                           type="button"
                           role="listitem"
                           className={`idt-repo-finding-row${isSelected ? ' is-selected' : ''}`}
-                          onClick={() => setSelectedFindingID(finding.id)}
+                          onClick={() => setSelectedFindingKey(selectionKey)}
                         >
                           <div className="idt-repo-finding-row-top">
                             <strong>{finding.title}</strong>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -25,6 +25,7 @@ import {
 } from './api/client';
 import { PermissionPreviewModal } from './components/connector/PermissionPreviewModal';
 import { useMe } from './hooks/useMe';
+import { groupRepoFindingsForDisplay } from './repoFindingDisplay';
 
 type ProductSession = {
   tenantID: string;
@@ -147,8 +148,6 @@ const SORT_LABEL_BY_FIELD: Record<(typeof REPO_FINDING_SORT_FIELDS)[number], str
 };
 
 const TREND_POINTS = 10;
-const SEVERITY_ORDER: string[] = ['critical', 'high', 'medium', 'low', 'info', 'unknown'];
-
 function formatConfidenceScore(value: number | undefined): string {
   if (!Number.isFinite(value ?? NaN)) {
     return 'N/A';
@@ -2874,24 +2873,7 @@ export function ProductFindingsPage() {
     });
   }, [repoFindings, statusFilter, assigneeFilter]);
 
-  const groupedFindings = useMemo(() => {
-    const buckets: Record<string, ApiFinding[]> = {};
-
-    for (const finding of filteredFindings) {
-      const bucket = normalizeValue(finding.severity).toLowerCase() || 'unknown';
-      const bucketEntries = buckets[bucket] ?? [];
-      bucketEntries.push(finding);
-      buckets[bucket] = bucketEntries;
-    }
-
-    return SEVERITY_ORDER.reduce<Record<string, ApiFinding[]>>((acc, severity) => {
-      const items = buckets[severity];
-      if (items && items.length > 0) {
-        acc[severity] = items;
-      }
-      return acc;
-    }, {});
-  }, [filteredFindings]);
+  const findingGroups = useMemo(() => groupRepoFindingsForDisplay(filteredFindings, sortBy), [filteredFindings, sortBy]);
 
   const selectedFinding = useMemo(
     () => filteredFindings.find((finding) => finding.id === selectedFindingID) ?? filteredFindings[0] ?? null,
@@ -3355,20 +3337,17 @@ export function ProductFindingsPage() {
             <h3>Repository findings</h3>
             <p>{filteredFindings.length ? `${filteredFindings.length} findings in scope` : 'No findings match the current filters.'}</p>
           </div>
-          {Object.keys(groupedFindings).length === 0 ? (
+          {findingGroups.length === 0 ? (
             <AppShellEmptyState
               title="No repository findings"
               body="Run a repository exposure scan or loosen the current filters to inspect GitHub-linked findings."
             />
           ) : (
             <div>
-              {Object.entries(groupedFindings).map(([severity, findings]) => (
-                <section className="idt-repo-finding-group" key={severity}>
-                  <h4>
-                    {formatTokenLabel(severity)} · {findings.length}
-                  </h4>
+              {findingGroups.map((group) => {
+                const items = (
                   <div className="idt-repo-finding-items" role="list">
-                    {findings.map((finding) => {
+                    {group.findings.map((finding) => {
                       const repositoryValue = repoFindingRepositoryValue(finding, repoScansByID);
                       const repositoryLabel = canonicalGitHubRepositoryDisplay(repositoryValue) || 'Repository unavailable';
                       const isSelected = selectedFinding?.id === finding.id;
@@ -3400,8 +3379,21 @@ export function ProductFindingsPage() {
                       );
                     })}
                   </div>
-                </section>
-              ))}
+                );
+
+                if (!group.label) {
+                  return <div key={group.key}>{items}</div>;
+                }
+
+                return (
+                  <section className="idt-repo-finding-group" key={group.key}>
+                    <h4>
+                      {formatTokenLabel(group.label)} · {group.findings.length}
+                    </h4>
+                    {items}
+                  </section>
+                );
+              })}
             </div>
           )}
         </div>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -3166,12 +3166,13 @@ export function ProductFindingsPage() {
 
   const totalTrendItems = trendPoints.reduce((acc, point) => acc + point.total, 0);
   const trendRows = trendPoints.map((point, index) => {
+    const bySeverity = point.by_severity ?? ({} as Record<string, number>);
     const severityValues = {
-      critical: point.by_severity.critical ?? 0,
-      high: point.by_severity.high ?? 0,
-      medium: point.by_severity.medium ?? 0,
-      low: point.by_severity.low ?? 0,
-      info: point.by_severity.info ?? 0
+      critical: bySeverity.critical ?? 0,
+      high: bySeverity.high ?? 0,
+      medium: bySeverity.medium ?? 0,
+      low: bySeverity.low ?? 0,
+      info: bySeverity.info ?? 0
     };
     const percentage = trendMaxTotal > 0 ? Math.round((point.total / trendMaxTotal) * 100) : 0;
     const startedAt = new Date(point.started_at);

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -165,6 +165,15 @@ function formatDateLabel(value: string): string {
   return parsed.toLocaleString();
 }
 
+function toLocalDateTimeInputValue(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return '';
+  }
+  const localTimestamp = new Date(parsed.getTime() - parsed.getTimezoneOffset() * 60 * 1000);
+  return localTimestamp.toISOString().slice(0, 16);
+}
+
 function normalizeFindingStatus(value: string | undefined): FindingLifecycleStatus {
   const normalized = normalizeValue(value ?? '').toLowerCase();
   if (normalized === 'ack' || normalized === 'suppressed' || normalized === 'resolved') {
@@ -2829,6 +2838,7 @@ export function ProductFindingsPage() {
   const [workflowStatus, setWorkflowStatus] = useState<FindingLifecycleStatus>('open');
   const [workflowAssignee, setWorkflowAssignee] = useState('');
   const [workflowComment, setWorkflowComment] = useState('');
+  const [workflowSuppressionExpiresAt, setWorkflowSuppressionExpiresAt] = useState('');
   const [workflowLoading, setWorkflowLoading] = useState(false);
   const [workflowSuccess, setWorkflowSuccess] = useState('');
   const [workflowError, setWorkflowError] = useState('');
@@ -3008,10 +3018,14 @@ export function ProductFindingsPage() {
     const nextAssignee = normalizeValue(workflowAssignee);
     const currentStatus = normalizeFindingStatus(selectedFinding.triage?.status);
     const currentAssignee = normalizeValue(selectedFinding.triage?.assignee ?? '');
+    const trackingSuppression = nextStatus === 'suppressed';
+    const currentSuppression = normalizeValue(toLocalDateTimeInputValue(selectedFinding.triage?.suppression_expires_at ?? ''));
+    const nextSuppression = normalizeValue(workflowSuppressionExpiresAt);
     const hasChanges =
       nextStatus !== currentStatus ||
       nextAssignee !== currentAssignee ||
-      normalizeValue(workflowComment).length > 0;
+      normalizeValue(workflowComment).length > 0 ||
+      (trackingSuppression && nextSuppression !== currentSuppression);
 
     if (!hasChanges) {
       setWorkflowError('Make a workflow change before saving.');
@@ -3023,7 +3037,31 @@ export function ProductFindingsPage() {
     setWorkflowSuccess('');
     try {
       const auth = buildProductAuthContext(scope);
-      const request: { status?: FindingLifecycleStatus; assignee?: string; comment?: string } = {};
+      const request: {
+        status?: FindingLifecycleStatus;
+        assignee?: string;
+        suppression_expires_at?: string;
+        comment?: string;
+      } = {};
+      if (trackingSuppression && !nextSuppression) {
+        setWorkflowError('Suppression requires an expiry date/time.');
+        setWorkflowLoading(false);
+        return;
+      }
+      if (trackingSuppression && nextSuppression) {
+        const parsedExpiry = new Date(nextSuppression);
+        if (Number.isNaN(parsedExpiry.getTime())) {
+          setWorkflowError('Suppression expiry must be a valid date/time.');
+          setWorkflowLoading(false);
+          return;
+        }
+        if (parsedExpiry.getTime() <= Date.now()) {
+          setWorkflowError('Suppression expiry must be set in the future.');
+          setWorkflowLoading(false);
+          return;
+        }
+        request.suppression_expires_at = parsedExpiry.toISOString();
+      }
       if (nextStatus !== currentStatus) {
         request.status = nextStatus;
       }
@@ -3078,13 +3116,22 @@ export function ProductFindingsPage() {
       setWorkflowStatus('open');
       setWorkflowAssignee('');
       setWorkflowComment('');
+      setWorkflowSuppressionExpiresAt('');
       return;
     }
 
     setWorkflowStatus(normalizeFindingStatus(selectedFinding.triage?.status));
     setWorkflowAssignee(selectedFinding.triage?.assignee ?? '');
     setWorkflowComment('');
-  }, [selectedFinding?.id, selectedFinding?.triage?.status, selectedFinding?.triage?.assignee]);
+    setWorkflowSuppressionExpiresAt(
+      selectedFinding.triage?.suppression_expires_at ? toLocalDateTimeInputValue(selectedFinding.triage.suppression_expires_at) : ''
+    );
+  }, [
+    selectedFinding?.id,
+    selectedFinding?.triage?.status,
+    selectedFinding?.triage?.assignee,
+    selectedFinding?.triage?.suppression_expires_at
+  ]);
 
   useEffect(() => {
     if (filteredFindings.length === 0) {
@@ -3432,7 +3479,17 @@ export function ProductFindingsPage() {
                   Status
                   <select
                     value={workflowStatus}
-                    onChange={(event) => setWorkflowStatus(event.target.value as FindingLifecycleStatus)}
+                    onChange={(event) => {
+                      const nextStatus = event.target.value as FindingLifecycleStatus;
+                      setWorkflowStatus(nextStatus);
+                      if (nextStatus !== 'suppressed') {
+                        setWorkflowSuppressionExpiresAt('');
+                      } else if (!workflowSuppressionExpiresAt && selectedFinding?.triage?.suppression_expires_at) {
+                        setWorkflowSuppressionExpiresAt(
+                          toLocalDateTimeInputValue(selectedFinding.triage.suppression_expires_at)
+                        );
+                      }
+                    }}
                     disabled={workflowLoading || !hasTriageAccess}
                   >
                     {REPO_FINDING_STATUS_FILTERS.filter((status) => status !== 'all').map((status) => (
@@ -3441,6 +3498,20 @@ export function ProductFindingsPage() {
                       </option>
                     ))}
                   </select>
+                </label>
+                <label>
+                  Suppression expiry
+                  <input
+                    type="datetime-local"
+                    value={workflowSuppressionExpiresAt}
+                    onChange={(event) => setWorkflowSuppressionExpiresAt(event.target.value)}
+                    min={toLocalDateTimeInputValue(new Date().toISOString())}
+                    disabled={workflowLoading || !hasTriageAccess || workflowStatus !== 'suppressed'}
+                    placeholder="YYYY-MM-DDThh:mm"
+                  />
+                  <span className="idt-app-field-hint">
+                    Required when setting status to <strong>suppressed</strong>, ignored otherwise.
+                  </span>
                 </label>
                 <label>
                   Assignee

--- a/web/src/repoFindingDisplay.test.ts
+++ b/web/src/repoFindingDisplay.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { Finding as ApiFinding } from './api/client';
-import { buildRepoFindingSelectionKey, findRepoFindingBySelectionKey, groupRepoFindingsForDisplay } from './repoFindingDisplay';
+import {
+  buildRepoFindingSelectionKey,
+  findRepoFindingBySelectionKey,
+  groupRepoFindingsForDisplay,
+  mergeUpdatedRepoFinding
+} from './repoFindingDisplay';
 
 function finding(id: string, severity: string): ApiFinding {
   return {
@@ -46,5 +51,22 @@ describe('groupRepoFindingsForDisplay', () => {
 
     expect(selected?.scan_id).toBe('scan-2');
     expect(selected?.title).toBe('scan-2 finding');
+  });
+
+  it('merges workflow updates only into the matching scan and finding pair', () => {
+    const first = finding('shared-id', 'high');
+    const second = { ...finding('shared-id', 'low'), scan_id: 'scan-2', title: 'scan-2 finding' };
+
+    const merged = mergeUpdatedRepoFinding([first, second], {
+      ...second,
+      title: 'updated second finding',
+      repository: 'owner/repo-b'
+    });
+
+    expect(merged[0].title).toBe(first.title);
+    expect(merged[0].scan_id).toBe(first.scan_id);
+    expect(merged[1].title).toBe('updated second finding');
+    expect(merged[1].repository).toBe('owner/repo-b');
+    expect(merged[1].scan_id).toBe('scan-2');
   });
 });

--- a/web/src/repoFindingDisplay.test.ts
+++ b/web/src/repoFindingDisplay.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import type { Finding as ApiFinding } from './api/client';
+import { groupRepoFindingsForDisplay } from './repoFindingDisplay';
+
+function finding(id: string, severity: string): ApiFinding {
+  return {
+    id,
+    scan_id: 'scan-1',
+    type: 'secret_exposure',
+    severity,
+    title: id,
+    human_summary: `${id} summary`,
+    remediation: 'rotate the secret',
+    created_at: '2026-05-14T00:00:00Z'
+  };
+}
+
+describe('groupRepoFindingsForDisplay', () => {
+  it('preserves API order for non-severity sorts', () => {
+    const findings = [finding('medium-newest', 'medium'), finding('critical-older', 'critical'), finding('low-oldest', 'low')];
+
+    const groups = groupRepoFindingsForDisplay(findings, 'created_at');
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toMatchObject({ key: 'created_at', label: null });
+    expect(groups[0].findings.map((item) => item.id)).toEqual(['medium-newest', 'critical-older', 'low-oldest']);
+  });
+
+  it('groups severity sort in descending severity buckets', () => {
+    const findings = [finding('medium-item', 'medium'), finding('unknown-item', 'unexpected'), finding('critical-item', 'critical')];
+
+    const groups = groupRepoFindingsForDisplay(findings, 'severity');
+
+    expect(groups.map((group) => group.key)).toEqual(['critical', 'medium', 'unknown']);
+    expect(groups[0].findings.map((item) => item.id)).toEqual(['critical-item']);
+    expect(groups[1].findings.map((item) => item.id)).toEqual(['medium-item']);
+    expect(groups[2].findings.map((item) => item.id)).toEqual(['unknown-item']);
+  });
+});

--- a/web/src/repoFindingDisplay.test.ts
+++ b/web/src/repoFindingDisplay.test.ts
@@ -42,6 +42,17 @@ describe('groupRepoFindingsForDisplay', () => {
     expect(groups[2].findings.map((item) => item.id)).toEqual(['unknown-item']);
   });
 
+  it('groups severity sort in ascending severity buckets when requested', () => {
+    const findings = [finding('medium-item', 'medium'), finding('unknown-item', 'unexpected'), finding('critical-item', 'critical')];
+
+    const groups = groupRepoFindingsForDisplay(findings, 'severity', 'asc');
+
+    expect(groups.map((group) => group.key)).toEqual(['unknown', 'medium', 'critical']);
+    expect(groups[0].findings.map((item) => item.id)).toEqual(['unknown-item']);
+    expect(groups[1].findings.map((item) => item.id)).toEqual(['medium-item']);
+    expect(groups[2].findings.map((item) => item.id)).toEqual(['critical-item']);
+  });
+
   it('selects findings by scan id and finding id together', () => {
     const first = finding('shared-id', 'high');
     const second = { ...finding('shared-id', 'low'), scan_id: 'scan-2', title: 'scan-2 finding' };

--- a/web/src/repoFindingDisplay.test.ts
+++ b/web/src/repoFindingDisplay.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Finding as ApiFinding } from './api/client';
-import { groupRepoFindingsForDisplay } from './repoFindingDisplay';
+import { buildRepoFindingSelectionKey, findRepoFindingBySelectionKey, groupRepoFindingsForDisplay } from './repoFindingDisplay';
 
 function finding(id: string, severity: string): ApiFinding {
   return {
@@ -35,5 +35,16 @@ describe('groupRepoFindingsForDisplay', () => {
     expect(groups[0].findings.map((item) => item.id)).toEqual(['critical-item']);
     expect(groups[1].findings.map((item) => item.id)).toEqual(['medium-item']);
     expect(groups[2].findings.map((item) => item.id)).toEqual(['unknown-item']);
+  });
+
+  it('selects findings by scan id and finding id together', () => {
+    const first = finding('shared-id', 'high');
+    const second = { ...finding('shared-id', 'low'), scan_id: 'scan-2', title: 'scan-2 finding' };
+    const findings = [first, second];
+
+    const selected = findRepoFindingBySelectionKey(findings, buildRepoFindingSelectionKey(second));
+
+    expect(selected?.scan_id).toBe('scan-2');
+    expect(selected?.title).toBe('scan-2 finding');
   });
 });

--- a/web/src/repoFindingDisplay.ts
+++ b/web/src/repoFindingDisplay.ts
@@ -1,0 +1,51 @@
+import type { Finding as ApiFinding } from './api/client';
+
+const SEVERITY_ORDER = ['critical', 'high', 'medium', 'low', 'info', 'unknown'] as const;
+
+export type RepoFindingSortField = 'severity' | 'created_at' | 'type' | 'title';
+
+export type RepoFindingDisplayGroup = {
+  key: string;
+  label: string | null;
+  findings: ApiFinding[];
+};
+
+function normalizeSeverityBucket(value: string): (typeof SEVERITY_ORDER)[number] {
+  const normalized = value.trim().toLowerCase();
+  if (SEVERITY_ORDER.includes(normalized as (typeof SEVERITY_ORDER)[number])) {
+    return normalized as (typeof SEVERITY_ORDER)[number];
+  }
+  return 'unknown';
+}
+
+export function groupRepoFindingsForDisplay(
+  findings: ApiFinding[],
+  sortBy: RepoFindingSortField
+): RepoFindingDisplayGroup[] {
+  if (findings.length === 0) {
+    return [];
+  }
+  if (sortBy !== 'severity') {
+    return [{ key: sortBy, label: null, findings }];
+  }
+
+  const buckets: Partial<Record<(typeof SEVERITY_ORDER)[number], ApiFinding[]>> = {};
+  for (const finding of findings) {
+    const bucket = normalizeSeverityBucket(finding.severity);
+    const bucketFindings = buckets[bucket] ?? [];
+    bucketFindings.push(finding);
+    buckets[bucket] = bucketFindings;
+  }
+
+  return SEVERITY_ORDER.reduce<RepoFindingDisplayGroup[]>((groups, severity) => {
+    const bucketFindings = buckets[severity];
+    if (bucketFindings && bucketFindings.length > 0) {
+      groups.push({
+        key: severity,
+        label: severity,
+        findings: bucketFindings
+      });
+    }
+    return groups;
+  }, []);
+}

--- a/web/src/repoFindingDisplay.ts
+++ b/web/src/repoFindingDisplay.ts
@@ -10,6 +10,8 @@ export type RepoFindingDisplayGroup = {
   findings: ApiFinding[];
 };
 
+export type RepoFindingSelection = Pick<ApiFinding, 'id' | 'scan_id'>;
+
 function normalizeSeverityBucket(value: string): (typeof SEVERITY_ORDER)[number] {
   const normalized = value.trim().toLowerCase();
   if (SEVERITY_ORDER.includes(normalized as (typeof SEVERITY_ORDER)[number])) {
@@ -48,4 +50,15 @@ export function groupRepoFindingsForDisplay(
     }
     return groups;
   }, []);
+}
+
+export function buildRepoFindingSelectionKey(finding: RepoFindingSelection): string {
+  return `${finding.scan_id}::${finding.id}`;
+}
+
+export function findRepoFindingBySelectionKey(findings: ApiFinding[], selectionKey: string): ApiFinding | null {
+  if (!selectionKey) {
+    return null;
+  }
+  return findings.find((finding) => buildRepoFindingSelectionKey(finding) === selectionKey) ?? null;
 }

--- a/web/src/repoFindingDisplay.ts
+++ b/web/src/repoFindingDisplay.ts
@@ -62,3 +62,10 @@ export function findRepoFindingBySelectionKey(findings: ApiFinding[], selectionK
   }
   return findings.find((finding) => buildRepoFindingSelectionKey(finding) === selectionKey) ?? null;
 }
+
+export function mergeUpdatedRepoFinding(findings: ApiFinding[], updatedFinding: ApiFinding): ApiFinding[] {
+  const updatedKey = buildRepoFindingSelectionKey(updatedFinding);
+  return findings.map((finding) =>
+    buildRepoFindingSelectionKey(finding) === updatedKey ? { ...finding, ...updatedFinding } : finding
+  );
+}

--- a/web/src/repoFindingDisplay.ts
+++ b/web/src/repoFindingDisplay.ts
@@ -3,6 +3,7 @@ import type { Finding as ApiFinding } from './api/client';
 const SEVERITY_ORDER = ['critical', 'high', 'medium', 'low', 'info', 'unknown'] as const;
 
 export type RepoFindingSortField = 'severity' | 'created_at' | 'type' | 'title';
+export type RepoFindingSortOrder = 'asc' | 'desc';
 
 export type RepoFindingDisplayGroup = {
   key: string;
@@ -22,7 +23,8 @@ function normalizeSeverityBucket(value: string): (typeof SEVERITY_ORDER)[number]
 
 export function groupRepoFindingsForDisplay(
   findings: ApiFinding[],
-  sortBy: RepoFindingSortField
+  sortBy: RepoFindingSortField,
+  sortOrder: RepoFindingSortOrder = 'desc'
 ): RepoFindingDisplayGroup[] {
   if (findings.length === 0) {
     return [];
@@ -39,7 +41,9 @@ export function groupRepoFindingsForDisplay(
     buckets[bucket] = bucketFindings;
   }
 
-  return SEVERITY_ORDER.reduce<RepoFindingDisplayGroup[]>((groups, severity) => {
+  const severityBuckets = sortOrder === 'asc' ? [...SEVERITY_ORDER].reverse() : [...SEVERITY_ORDER];
+
+  return severityBuckets.reduce<RepoFindingDisplayGroup[]>((groups, severity) => {
     const bucketFindings = buckets[severity];
     if (bucketFindings && bucketFindings.length > 0) {
       groups.push({

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4328,7 +4328,7 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
 .idt-repo-finding-stats {
   margin-top: 1rem;
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(6, minmax(0, 1fr));
   gap: 0.8rem;
 }
 
@@ -4362,7 +4362,7 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
 .idt-repo-finding-filters {
   margin-top: 1rem;
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 0.8rem;
 }
 
@@ -4379,6 +4379,154 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   background: rgba(9, 15, 26, 0.84);
   color: #e4efff;
   padding: 0.5rem 0.6rem;
+}
+
+.idt-repo-finding-filters input {
+  border: 1px solid rgba(126, 157, 211, 0.35);
+  border-radius: 0.55rem;
+  background: rgba(9, 15, 26, 0.84);
+  color: #e4efff;
+  padding: 0.5rem 0.6rem;
+}
+
+.idt-repo-finding-trend {
+  margin-top: 1rem;
+  border: 1px solid rgba(126, 157, 211, 0.24);
+  border-radius: 0.8rem;
+  background: rgba(9, 15, 26, 0.56);
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.idt-repo-finding-trend-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.58rem;
+}
+
+.idt-repo-finding-trend-head h3 {
+  margin: 0;
+}
+
+.idt-repo-finding-trend-subtitle {
+  color: #9fb5d8;
+  font-size: 0.82rem;
+}
+
+.idt-repo-finding-trend-rows {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.idt-repo-finding-trend-row {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.idt-repo-finding-trend-meta {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.idt-repo-finding-trend-meta strong {
+  color: #f4f8ff;
+}
+
+.idt-repo-finding-trend-meta span {
+  color: #9fb5d8;
+}
+
+.idt-repo-finding-trend-bar-track {
+  width: 100%;
+  border-radius: 999px;
+  border: 1px solid rgba(126, 157, 211, 0.25);
+  background: rgba(6, 11, 20, 0.78);
+  overflow: hidden;
+  height: 0.8rem;
+}
+
+.idt-repo-finding-trend-bar {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #7f8ffc, #46bb9f);
+  transition: width 0.2s ease;
+}
+
+.idt-repo-finding-group {
+  display: grid;
+  gap: 0.45rem;
+  margin-bottom: 0.85rem;
+}
+
+.idt-repo-finding-group h4 {
+  margin: 0;
+  color: #b8cdf6;
+  font-size: 0.86rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.idt-repo-finding-status {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.24rem 0.58rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  white-space: nowrap;
+}
+
+.idt-repo-finding-status.is-open {
+  background: rgba(56, 132, 255, 0.22);
+  color: #b8d9ff;
+}
+
+.idt-repo-finding-status.is-ack {
+  background: rgba(255, 181, 67, 0.22);
+  color: #ffd8aa;
+}
+
+.idt-repo-finding-status.is-suppressed {
+  background: rgba(137, 145, 181, 0.24);
+  color: #ced8f2;
+}
+
+.idt-repo-finding-status.is-resolved {
+  background: rgba(81, 188, 132, 0.25);
+  color: #c8f3dc;
+}
+
+.idt-repo-finding-triage-form {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.idt-repo-finding-triage-form label {
+  display: grid;
+  gap: 0.35rem;
+  color: #d3e1f7;
+  font-size: 0.95rem;
+}
+
+.idt-repo-finding-triage-form select,
+.idt-repo-finding-triage-form input,
+.idt-repo-finding-triage-form textarea {
+  border: 1px solid rgba(126, 157, 211, 0.35);
+  border-radius: 0.55rem;
+  background: rgba(9, 15, 26, 0.84);
+  color: #e4efff;
+  padding: 0.5rem 0.6rem;
+}
+
+.idt-repo-finding-triage-form textarea {
+  resize: vertical;
+  min-height: 6rem;
 }
 
 .idt-repo-finding-layout {
@@ -4578,6 +4726,10 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   .idt-repo-finding-layout,
   .idt-repo-finding-facts {
     grid-template-columns: 1fr;
+  }
+
+  .idt-repo-finding-trend-meta {
+    flex-direction: column;
   }
 }
 
@@ -5785,7 +5937,8 @@ html[data-theme='light'] .idt-app-alert-success {
 
 html[data-theme='light'] .idt-repo-finding-stat,
 html[data-theme='light'] .idt-repo-finding-list,
-html[data-theme='light'] .idt-repo-finding-detail {
+html[data-theme='light'] .idt-repo-finding-detail,
+html[data-theme='light'] .idt-repo-finding-trend {
   background: rgba(255, 255, 255, 0.94);
   border-color: rgba(42, 71, 119, 0.18);
 }
@@ -5817,6 +5970,40 @@ html[data-theme='light'] .idt-repo-finding-filters select {
 html[data-theme='light'] .idt-repo-finding-row {
   background: rgba(245, 249, 255, 0.98);
   border-color: rgba(42, 71, 119, 0.18);
+}
+
+html[data-theme='light'] .idt-repo-finding-trend {
+  background: rgba(255, 255, 255, 0.96);
+}
+
+html[data-theme='light'] .idt-repo-finding-trend-subtitle,
+html[data-theme='light'] .idt-repo-finding-trend-meta span,
+html[data-theme='light'] .idt-repo-finding-group h4 {
+  color: #486b9d;
+}
+
+html[data-theme='light'] .idt-repo-finding-trend-meta strong {
+  color: #132b4d;
+}
+
+html[data-theme='light'] .idt-repo-finding-trend-row p,
+html[data-theme='light'] .idt-repo-finding-status,
+html[data-theme='light'] .idt-repo-finding-triage-form label {
+  color: #233f66;
+}
+
+html[data-theme='light'] .idt-repo-finding-trend-bar-track {
+  border-color: rgba(42, 71, 119, 0.25);
+  background: rgba(228, 237, 248, 0.9);
+}
+
+html[data-theme='light'] .idt-repo-finding-triage-form select,
+html[data-theme='light'] .idt-repo-finding-triage-form input,
+html[data-theme='light'] .idt-repo-finding-triage-form textarea,
+html[data-theme='light'] .idt-repo-finding-filters input {
+  color: #1c355d;
+  background: #ffffff;
+  border-color: rgba(42, 71, 119, 0.32);
 }
 
 html[data-theme='light'] .idt-repo-finding-row:hover,


### PR DESCRIPTION
Fixes #572

## Summary
- Implement prioritized repository findings dashboard workflow with risk-ranking and grouping filters.
- Add triage status/assignee reload behavior and stable endpoint wiring for dashboard interactions.
- Add frontend rendering, API integration, and regression coverage for prioritized findings data.

## Validation
- Focused local validation for touched areas was run in this workspace.

## AI-assisted: no
- Tools used: none for final material logic
- Human verification performed: manual walkthrough of affected files and integration tests in environment

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds a prioritized repository findings dashboard with severity grouping, triage filters, server-side sorting, and a repo-scan trend view to speed triage (Fixes #572). Adds bounded triage paging and corrects repo trend authz so filtered and high‑risk items consistently surface.

- New Features
  - Dashboard: severity-grouped list; filters for repo scan, severity, type, lifecycle status, and assignee; sort by severity/created_at/type/title with order control; status/assignee badges; confidence score; GitHub deep links; composite scan+finding selection keys with triage updates merged by the same key.
  - Trend: repository findings trend over recent repo scans with severity/type filters, 10-point window, reload, and error states; new GET `/v1/repo-findings/trends`; UI shows totals by severity.

- Refactors
  - Workflow/API: triage form (status, assignee, comment, suppression expiry) with validation and live updates; `/v1/repo-findings` accepts `finding_id`, triage filters, and `sort_by`/`sort_order`; client adds `confidence_score` and `getRepoFindingsTrends`.
  - Service/store/router/authz: normalize repo finding filters and honor sort order; apply triage filtering after enrichment with a widened and bounded fetch window for status/assignee filters; enforce severity-priority ordering; add `ListRepoFindingTrendCounts` (memory/Postgres) and router for `/v1/repo-findings/trends`; authz for that route now uses `repo_scans.read`; tests cover triage paging, repo trend counts, and composite selection/merge.

<sup>Written for commit 0a7cc51de5cf04fff278935cfb876c405d8f9d51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

