### PR TITLE
Fixes #1117 atomic enrollment token claims

### DIFF
--- a/internal/api/kubernetes_connect_test.go
+++ b/internal/api/kubernetes_connect_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -393,6 +394,61 @@ func TestRouterKubernetesAgentEnrollmentSingleUseAndHeartbeat(t *testing.T) {
 	}
 	if statusBody.Connection.ConnectorID != "kubernetes-prod" || statusBody.Connection.AgentID != "agent-a" {
 		t.Fatalf("expected persisted agent status, got %+v", statusBody.Connection)
+	}
+}
+
+func TestRouterKubernetesAgentEnrollmentConcurrentSingleUse(t *testing.T) {
+	r, _ := newKubernetesConnectorV2TestRouter(t)
+	startResp := doKubernetesConnectionAPI(t, r, http.MethodPost, "/v1/connectors/k8s", `{
+		"workspace_id":"workspace-a",
+		"project_id":"project-1",
+		"connector_id":"kubernetes-prod",
+		"display_name":"Production Cluster",
+		"api_url":"https://api.identrail.test"
+	}`)
+	if startResp.Code != http.StatusOK {
+		t.Fatalf("expected start connector 200, got %d body=%s", startResp.Code, startResp.Body.String())
+	}
+	var startBody KubernetesConnectorStartResponse
+	if err := json.Unmarshal(startResp.Body.Bytes(), &startBody); err != nil {
+		t.Fatalf("decode start response: %v", err)
+	}
+
+	body := `{
+		"enrollment_token":` + quoteJSON(startBody.EnrollmentToken) + `,
+		"agent_id":"agent-a",
+		"cluster":"prod-cluster"
+	}`
+	var wg sync.WaitGroup
+	codes := make(chan int, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp := doKubernetesConnectionAPI(t, r, http.MethodPost, "/v1/connectors/k8s/enroll", body)
+			codes <- resp.Code
+		}()
+	}
+	wg.Wait()
+	close(codes)
+
+	successes := 0
+	rejects := 0
+	for code := range codes {
+		switch code {
+		case http.StatusOK:
+			successes++
+		case http.StatusGone:
+			rejects++
+		default:
+			t.Fatalf("unexpected enrollment response code: %d", code)
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("expected exactly one successful enrollment, got %d", successes)
+	}
+	if rejects != 1 {
+		t.Fatalf("expected exactly one rejected enrollment, got %d", rejects)
 	}
 }
 

--- a/internal/api/kubernetes_connector_v2.go
+++ b/internal/api/kubernetes_connector_v2.go
@@ -193,20 +193,39 @@ func (s *Service) EnrollKubernetesAgent(ctx context.Context, request k8sconnecto
 	if err != nil {
 		return KubernetesAgentEnrollResponse{}, fmt.Errorf("encode kubernetes agent metadata: %w", err)
 	}
-	claimed, err := s.Store.ClaimKubernetesEnrollmentToken(scopedCtx, locator.WorkspaceID, locator.ProjectID, locator.ConnectorID, metadata.EnrollmentTokenHash, metadataPayload, now, now)
+	lastErrorCode := ""
+	lastErrorMessage := ""
+	if status != domain.ConnectorStatusActive || health != string(connectors.HealthStatusHealthy) {
+		lastErrorCode = "kubernetes_agent_probe_failed"
+		lastErrorMessage = firstKubernetesRemediation(metadata.Diagnostics, metadata.PermissionChecks)
+	}
+	claimed, err := s.Store.ClaimKubernetesEnrollmentToken(
+		scopedCtx,
+		locator.WorkspaceID,
+		locator.ProjectID,
+		locator.ConnectorID,
+		metadata.EnrollmentTokenHash,
+		metadataPayload,
+		status,
+		health,
+		lastErrorCode,
+		lastErrorMessage,
+		now,
+		now,
+	)
 	if err != nil {
 		return KubernetesAgentEnrollResponse{}, err
 	}
 	if !claimed {
 		return KubernetesAgentEnrollResponse{}, ErrKubernetesConnectorTokenUsed
 	}
-	return s.persistKubernetesAgentMetadata(scopedCtx, stored, metadata, status, health, now, KubernetesAgentEnrollResponse{
+	return KubernetesAgentEnrollResponse{
 		ConnectorID:  locator.ConnectorID,
 		AgentID:      agentID,
 		AgentToken:   agentToken,
 		HeartbeatURL: strings.TrimRight(apiBaseURL, "/") + k8sconnector.DefaultAgentHeartbeatPath,
 		ExpiresAt:    now.Add(365 * 24 * time.Hour),
-	})
+	}, nil
 }
 
 func (s *Service) HeartbeatKubernetesAgent(ctx context.Context, request k8sconnector.AgentHeartbeatRequest, bearerToken string) (KubernetesAgentHeartbeatResponse, error) {

--- a/internal/api/kubernetes_connector_v2.go
+++ b/internal/api/kubernetes_connector_v2.go
@@ -189,6 +189,17 @@ func (s *Service) EnrollKubernetesAgent(ctx context.Context, request k8sconnecto
 	metadata.Diagnostics = kubernetesAgentDiagnostics(request.Diagnostics)
 	metadata.LastValidatedAt = &now
 	status, health := kubernetesAgentStatus(&metadata)
+	metadataPayload, err := metadata.toMap()
+	if err != nil {
+		return KubernetesAgentEnrollResponse{}, fmt.Errorf("encode kubernetes agent metadata: %w", err)
+	}
+	claimed, err := s.Store.ClaimKubernetesEnrollmentToken(scopedCtx, locator.WorkspaceID, locator.ProjectID, locator.ConnectorID, metadata.EnrollmentTokenHash, metadataPayload, now, now)
+	if err != nil {
+		return KubernetesAgentEnrollResponse{}, err
+	}
+	if !claimed {
+		return KubernetesAgentEnrollResponse{}, ErrKubernetesConnectorTokenUsed
+	}
 	return s.persistKubernetesAgentMetadata(scopedCtx, stored, metadata, status, health, now, KubernetesAgentEnrollResponse{
 		ConnectorID:  locator.ConnectorID,
 		AgentID:      agentID,

--- a/internal/db/memory_tenancy.go
+++ b/internal/db/memory_tenancy.go
@@ -937,6 +937,39 @@ func (m *MemoryStore) GetTenancyConnector(ctx context.Context, workspaceID strin
 	return TenancyConnectorWithState{Connector: connector, State: state}, nil
 }
 
+// ClaimKubernetesEnrollmentToken marks a single connector enrollment token as consumed.
+func (m *MemoryStore) ClaimKubernetesEnrollmentToken(ctx context.Context, workspaceID string, projectID string, connectorID string, expectedEnrollmentTokenHash string, updatedMetadata map[string]any, observedAt time.Time, updatedAt time.Time) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return false, err
+	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return false, err
+	}
+	key := tenancyConnectorKey(scope.TenantID, resolvedWorkspaceID, strings.TrimSpace(projectID), strings.TrimSpace(connectorID))
+	state, exists := m.connStates[key]
+	if !exists {
+		return false, ErrNotFound
+	}
+	currentHash, ok := state.Metadata["enrollment_token_sha256"].(string)
+	if !ok || strings.TrimSpace(currentHash) != strings.TrimSpace(expectedEnrollmentTokenHash) {
+		return false, nil
+	}
+	if _, wasUsed := state.Metadata["enrollment_token_used_at"]; wasUsed {
+		return false, nil
+	}
+
+	state.Metadata = cloneMetadataMap(updatedMetadata)
+	state.ObservedAt = observedAt.UTC()
+	state.UpdatedAt = updatedAt.UTC()
+	m.connStates[key] = state
+	return true, nil
+}
+
 // ListTenancyConnectors returns scoped connectors ordered by most recent update.
 func (m *MemoryStore) ListTenancyConnectors(ctx context.Context, workspaceID string, projectID string, connectorType domain.ConnectorType, limit int) ([]TenancyConnectorWithState, error) {
 	m.mu.RLock()

--- a/internal/db/memory_tenancy.go
+++ b/internal/db/memory_tenancy.go
@@ -938,7 +938,7 @@ func (m *MemoryStore) GetTenancyConnector(ctx context.Context, workspaceID strin
 }
 
 // ClaimKubernetesEnrollmentToken marks a single connector enrollment token as consumed.
-func (m *MemoryStore) ClaimKubernetesEnrollmentToken(ctx context.Context, workspaceID string, projectID string, connectorID string, expectedEnrollmentTokenHash string, updatedMetadata map[string]any, observedAt time.Time, updatedAt time.Time) (bool, error) {
+func (m *MemoryStore) ClaimKubernetesEnrollmentToken(ctx context.Context, workspaceID string, projectID string, connectorID string, expectedEnrollmentTokenHash string, updatedMetadata map[string]any, status domain.ConnectorStatus, health string, lastErrorCode string, lastErrorMessage string, observedAt time.Time, updatedAt time.Time) (bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -963,9 +963,20 @@ func (m *MemoryStore) ClaimKubernetesEnrollmentToken(ctx context.Context, worksp
 		return false, nil
 	}
 
+	conn, exists := m.connectors[key]
+	if !exists {
+		return false, ErrNotFound
+	}
+
 	state.Metadata = cloneMetadataMap(updatedMetadata)
+	state.HealthStatus = strings.TrimSpace(health)
+	state.LastErrorCode = strings.TrimSpace(lastErrorCode)
+	state.LastErrorMessage = strings.TrimSpace(lastErrorMessage)
 	state.ObservedAt = observedAt.UTC()
 	state.UpdatedAt = updatedAt.UTC()
+	conn.Status = status
+	conn.UpdatedAt = updatedAt.UTC()
+	m.connectors[key] = conn
 	m.connStates[key] = state
 	return true, nil
 }

--- a/internal/db/memory_tenancy_test.go
+++ b/internal/db/memory_tenancy_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -187,6 +188,106 @@ func TestMemoryStoreListTenancyConnectorsUnscopedWithoutLimit(t *testing.T) {
 	}
 	if len(connectors) != 2 {
 		t.Fatalf("expected both connectors without limit, got %+v", connectors)
+	}
+}
+
+func TestMemoryStoreClaimKubernetesEnrollmentToken(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	seededAt := time.Date(2026, 5, 14, 10, 0, 0, 0, time.UTC)
+	tokenHash := "kubernetes-token-hash"
+
+	if err := store.UpsertOrganization(ctx, TenancyOrganization{DisplayName: "Tenant A", Slug: "tenant-a"}); err != nil {
+		t.Fatalf("seed organization: %v", err)
+	}
+	if err := store.UpsertWorkspace(ctx, TenancyWorkspace{
+		WorkspaceID: "workspace-a",
+		DisplayName: "Workspace A",
+		Slug:        "workspace-a",
+	}); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+	if err := store.UpsertProject(ctx, TenancyProject{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		Name:        "Project 1",
+		Slug:        "project-1",
+	}); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	if err := store.UpsertTenancyConnector(ctx, TenancyConnector{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "kubernetes-agent",
+		Type:        domain.ConnectorTypeKubernetes,
+		DisplayName: "Agent cluster",
+		Status:      domain.ConnectorStatusPending,
+		CreatedAt:   seededAt,
+		UpdatedAt:   seededAt,
+	}, TenancyConnectorState{
+		WorkspaceID:  "workspace-a",
+		ProjectID:    "project-1",
+		ConnectorID:  "kubernetes-agent",
+		HealthStatus: "unknown",
+		Metadata: map[string]any{
+			"enrollment_token_sha256": tokenHash,
+		},
+		ObservedAt: seededAt,
+		UpdatedAt:  seededAt,
+	}); err != nil {
+		t.Fatalf("seed kubernetes connector: %v", err)
+	}
+
+	now := time.Now().UTC()
+	payload := map[string]any{
+		"enrollment_token_sha256": tokenHash,
+		"enrollment_token_used_at": now.Format(time.RFC3339Nano),
+	}
+
+	var wg sync.WaitGroup
+	claims := make(chan bool, 2)
+	errors := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(claimIndex int) {
+			defer wg.Done()
+			claimed, err := store.ClaimKubernetesEnrollmentToken(ctx, "workspace-a", "project-1", "kubernetes-agent", tokenHash, payload, now, now.Add(time.Duration(claimIndex)*time.Millisecond))
+			if err != nil {
+				errors <- err
+				return
+			}
+			claims <- claimed
+		}(i)
+	}
+	wg.Wait()
+	close(errors)
+	close(claims)
+	for err := range errors {
+		if err != nil {
+			t.Fatalf("claim kubernetes enrollment token: %v", err)
+		}
+	}
+
+	successes := 0
+	for claimed := range claims {
+		if claimed {
+			successes++
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("expected exactly one claim success, got %d", successes)
+	}
+
+	reloaded, err := store.GetTenancyConnector(ctx, "workspace-a", "project-1", "kubernetes-agent")
+	if err != nil {
+		t.Fatalf("reload connector: %v", err)
+	}
+	usedAt, ok := reloaded.State.Metadata["enrollment_token_used_at"].(string)
+	if !ok || usedAt == "" {
+		t.Fatalf("expected enrollment_token_used_at to be persisted, got %+v", reloaded.State.Metadata["enrollment_token_used_at"])
+	}
+	if usedAt != now.Format(time.RFC3339Nano) {
+		t.Fatalf("expected enrollment token used time to match claim payload, expected %s got %s", now.Format(time.RFC3339Nano), usedAt)
 	}
 }
 

--- a/internal/db/memory_tenancy_test.go
+++ b/internal/db/memory_tenancy_test.go
@@ -240,7 +240,7 @@ func TestMemoryStoreClaimKubernetesEnrollmentToken(t *testing.T) {
 
 	now := time.Now().UTC()
 	payload := map[string]any{
-		"enrollment_token_sha256": tokenHash,
+		"enrollment_token_sha256":  tokenHash,
 		"enrollment_token_used_at": now.Format(time.RFC3339Nano),
 	}
 

--- a/internal/db/memory_tenancy_test.go
+++ b/internal/db/memory_tenancy_test.go
@@ -251,7 +251,20 @@ func TestMemoryStoreClaimKubernetesEnrollmentToken(t *testing.T) {
 		wg.Add(1)
 		go func(claimIndex int) {
 			defer wg.Done()
-			claimed, err := store.ClaimKubernetesEnrollmentToken(ctx, "workspace-a", "project-1", "kubernetes-agent", tokenHash, payload, now, now.Add(time.Duration(claimIndex)*time.Millisecond))
+			claimed, err := store.ClaimKubernetesEnrollmentToken(
+				ctx,
+				"workspace-a",
+				"project-1",
+				"kubernetes-agent",
+				tokenHash,
+				payload,
+				domain.ConnectorStatusActive,
+				"healthy",
+				"",
+				"",
+				now,
+				now.Add(time.Duration(claimIndex)*time.Millisecond),
+			)
 			if err != nil {
 				errors <- err
 				return
@@ -288,6 +301,12 @@ func TestMemoryStoreClaimKubernetesEnrollmentToken(t *testing.T) {
 	}
 	if usedAt != now.Format(time.RFC3339Nano) {
 		t.Fatalf("expected enrollment token used time to match claim payload, expected %s got %s", now.Format(time.RFC3339Nano), usedAt)
+	}
+	if reloaded.State.HealthStatus != "healthy" {
+		t.Fatalf("expected connector health status to be persisted as healthy, got %q", reloaded.State.HealthStatus)
+	}
+	if reloaded.Connector.Status != domain.ConnectorStatusActive {
+		t.Fatalf("expected connector status to be active, got %q", reloaded.Connector.Status)
 	}
 }
 

--- a/internal/db/postgres_tenancy.go
+++ b/internal/db/postgres_tenancy.go
@@ -1276,7 +1276,7 @@ func (p *PostgresStore) GetTenancyConnector(ctx context.Context, workspaceID str
 }
 
 // ClaimKubernetesEnrollmentToken atomically consumes one connector enrollment token if unused.
-func (p *PostgresStore) ClaimKubernetesEnrollmentToken(ctx context.Context, workspaceID string, projectID string, connectorID string, expectedEnrollmentTokenHash string, updatedMetadata map[string]any, observedAt time.Time, updatedAt time.Time) (bool, error) {
+func (p *PostgresStore) ClaimKubernetesEnrollmentToken(ctx context.Context, workspaceID string, projectID string, connectorID string, expectedEnrollmentTokenHash string, updatedMetadata map[string]any, status domain.ConnectorStatus, health string, lastErrorCode string, lastErrorMessage string, observedAt time.Time, updatedAt time.Time) (bool, error) {
 	scope, err := RequireScope(ctx)
 	if err != nil {
 		return false, err
@@ -1289,37 +1289,81 @@ func (p *PostgresStore) ClaimKubernetesEnrollmentToken(ctx context.Context, work
 	if err != nil {
 		return false, fmt.Errorf("marshal connector state metadata: %w", err)
 	}
-	result, err := p.execContext(
+	tx, err := p.beginTx(ctx)
+	if err != nil {
+		return false, fmt.Errorf("begin kubernetes enrollment token claim transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	result, err := tx.ExecContext(
 		ctx,
 		`UPDATE tenancy_connector_states
 		 SET metadata = $5::jsonb,
-		     observed_at = $6,
-		     updated_at = $7
+		     health_status = $6,
+		     last_error_code = $7,
+		     last_error_message = $8,
+		     observed_at = $9,
+		     updated_at = $10
 		 WHERE tenant_id = $1
 		   AND workspace_id = $2
 		   AND project_id = $3
 		   AND connector_id = $4
-		   AND metadata ->> 'enrollment_token_sha256' = $8
+		   AND metadata ->> 'enrollment_token_sha256' = $11
 		   AND metadata ->> 'enrollment_token_used_at' IS NULL`,
 		scope.TenantID,
 		resolvedWorkspaceID,
 		strings.TrimSpace(projectID),
 		strings.TrimSpace(connectorID),
 		metadataPayload,
+		strings.TrimSpace(string(health)),
+		strings.TrimSpace(lastErrorCode),
+		strings.TrimSpace(lastErrorMessage),
 		observedAt.UTC(),
 		updatedAt.UTC(),
 		strings.TrimSpace(expectedEnrollmentTokenHash),
 	)
 	if err != nil {
+		_ = tx.Rollback()
 		return false, fmt.Errorf("claim kubernetes enrollment token: %w", err)
 	}
 	affected, err := result.RowsAffected()
 	if err != nil {
+		_ = tx.Rollback()
 		return false, err
 	}
 	if affected == 0 {
+		_ = tx.Rollback()
 		return false, nil
 	}
+
+	if _, err := tx.ExecContext(
+		ctx,
+		`UPDATE tenancy_connectors
+		   SET status = $5,
+		       updated_at = $6
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND project_id = $3
+		   AND connector_id = $4`,
+		scope.TenantID,
+		resolvedWorkspaceID,
+		strings.TrimSpace(projectID),
+		strings.TrimSpace(connectorID),
+		strings.TrimSpace(string(status)),
+		updatedAt.UTC(),
+	); err != nil {
+		_ = tx.Rollback()
+		return false, fmt.Errorf("update kubernetes connector status for enrollment claim: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("commit kubernetes enrollment token claim: %w", err)
+	}
+	err = nil
 	return true, nil
 }
 

--- a/internal/db/postgres_tenancy.go
+++ b/internal/db/postgres_tenancy.go
@@ -1275,6 +1275,54 @@ func (p *PostgresStore) GetTenancyConnector(ctx context.Context, workspaceID str
 	return rows[0], nil
 }
 
+// ClaimKubernetesEnrollmentToken atomically consumes one connector enrollment token if unused.
+func (p *PostgresStore) ClaimKubernetesEnrollmentToken(ctx context.Context, workspaceID string, projectID string, connectorID string, expectedEnrollmentTokenHash string, updatedMetadata map[string]any, observedAt time.Time, updatedAt time.Time) (bool, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return false, err
+	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, workspaceID)
+	if err != nil {
+		return false, err
+	}
+	metadataPayload, err := json.Marshal(updatedMetadata)
+	if err != nil {
+		return false, fmt.Errorf("marshal connector state metadata: %w", err)
+	}
+	result, err := p.execContext(
+		ctx,
+		`UPDATE tenancy_connector_states
+		 SET metadata = $5::jsonb,
+		     observed_at = $6,
+		     updated_at = $7
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND project_id = $3
+		   AND connector_id = $4
+		   AND metadata ->> 'enrollment_token_sha256' = $8
+		   AND metadata ->> 'enrollment_token_used_at' IS NULL`,
+		scope.TenantID,
+		resolvedWorkspaceID,
+		strings.TrimSpace(projectID),
+		strings.TrimSpace(connectorID),
+		metadataPayload,
+		observedAt.UTC(),
+		updatedAt.UTC(),
+		strings.TrimSpace(expectedEnrollmentTokenHash),
+	)
+	if err != nil {
+		return false, fmt.Errorf("claim kubernetes enrollment token: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if affected == 0 {
+		return false, nil
+	}
+	return true, nil
+}
+
 // ListTenancyConnectors returns scoped connectors ordered by most recent update.
 func (p *PostgresStore) ListTenancyConnectors(ctx context.Context, workspaceID string, projectID string, connectorType domain.ConnectorType, limit int) ([]TenancyConnectorWithState, error) {
 	scope, err := RequireScope(ctx)

--- a/internal/db/postgres_tenancy_test.go
+++ b/internal/db/postgres_tenancy_test.go
@@ -222,38 +222,84 @@ func TestPostgresStoreKubernetesEnrollmentTokenClaim(t *testing.T) {
 		t.Fatalf("marshal updated metadata: %v", err)
 	}
 
+	mock.ExpectBegin()
 	mock.ExpectExec(regexp.QuoteMeta(`UPDATE tenancy_connector_states
 		 SET metadata = $5::jsonb,
-		     observed_at = $6,
-		     updated_at = $7
+	     health_status = $6,
+	     last_error_code = $7,
+	     last_error_message = $8,
+	     observed_at = $9,
+	     updated_at = $10
 		 WHERE tenant_id = $1
 		   AND workspace_id = $2
 		   AND project_id = $3
 		   AND connector_id = $4
-		   AND metadata ->> 'enrollment_token_sha256' = $8
+		   AND metadata ->> 'enrollment_token_sha256' = $11
 		   AND metadata ->> 'enrollment_token_used_at' IS NULL`)).
-		WithArgs("tenant-a", "workspace-a", "project-1", "kubernetes-agent", payload, now, now, "token-hash").
+		WithArgs("tenant-a", "workspace-a", "project-1", "kubernetes-agent", payload, "healthy", "", "", now, now, "token-hash").
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	claimed, err := store.ClaimKubernetesEnrollmentToken(ctx, "workspace-a", "project-1", "kubernetes-agent", "token-hash", updatedMetadata, now, now)
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE tenancy_connectors
+	     SET status = $5,
+	         updated_at = $6
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND project_id = $3
+		   AND connector_id = $4`)).
+		WithArgs("tenant-a", "workspace-a", "project-1", "kubernetes-agent", string(domain.ConnectorStatusActive), now).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+	claimed, err := store.ClaimKubernetesEnrollmentToken(
+		ctx,
+		"workspace-a",
+		"project-1",
+		"kubernetes-agent",
+		"token-hash",
+		updatedMetadata,
+		domain.ConnectorStatusActive,
+		"healthy",
+		"",
+		"",
+		now,
+		now,
+	)
 	if err != nil {
 		t.Fatalf("claim token first attempt: %v", err)
 	}
 	if !claimed {
 		t.Fatalf("expected first claim to return true")
 	}
+
+	mock.ExpectBegin()
 	mock.ExpectExec(regexp.QuoteMeta(`UPDATE tenancy_connector_states
 		 SET metadata = $5::jsonb,
-		     observed_at = $6,
-		     updated_at = $7
+	     health_status = $6,
+	     last_error_code = $7,
+	     last_error_message = $8,
+	     observed_at = $9,
+	     updated_at = $10
 		 WHERE tenant_id = $1
 		   AND workspace_id = $2
 		   AND project_id = $3
 		   AND connector_id = $4
-		   AND metadata ->> 'enrollment_token_sha256' = $8
+		   AND metadata ->> 'enrollment_token_sha256' = $11
 		   AND metadata ->> 'enrollment_token_used_at' IS NULL`)).
-		WithArgs("tenant-a", "workspace-a", "project-1", "kubernetes-agent", payload, now, now.Add(time.Minute), "token-hash").
+		WithArgs("tenant-a", "workspace-a", "project-1", "kubernetes-agent", payload, "healthy", "", "", now, now.Add(time.Minute), "token-hash").
 		WillReturnResult(sqlmock.NewResult(0, 0))
-	claimed, err = store.ClaimKubernetesEnrollmentToken(ctx, "workspace-a", "project-1", "kubernetes-agent", "token-hash", updatedMetadata, now, now.Add(time.Minute))
+	mock.ExpectRollback()
+	claimed, err = store.ClaimKubernetesEnrollmentToken(
+		ctx,
+		"workspace-a",
+		"project-1",
+		"kubernetes-agent",
+		"token-hash",
+		updatedMetadata,
+		domain.ConnectorStatusActive,
+		"healthy",
+		"",
+		"",
+		now,
+		now.Add(time.Minute),
+	)
 	if err != nil {
 		t.Fatalf("claim token second attempt: %v", err)
 	}

--- a/internal/db/postgres_tenancy_test.go
+++ b/internal/db/postgres_tenancy_test.go
@@ -214,7 +214,7 @@ func TestPostgresStoreKubernetesEnrollmentTokenClaim(t *testing.T) {
 	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
 	now := time.Now().UTC()
 	updatedMetadata := map[string]any{
-		"enrollment_token_sha256": "token-hash",
+		"enrollment_token_sha256":  "token-hash",
 		"enrollment_token_used_at": now.Format(time.RFC3339Nano),
 	}
 	payload, err := json.Marshal(updatedMetadata)

--- a/internal/db/postgres_tenancy_test.go
+++ b/internal/db/postgres_tenancy_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"regexp"
 	"testing"
@@ -197,6 +198,69 @@ func TestPostgresStoreListTenancyConnectors(t *testing.T) {
 	if len(connectors) != 1 || connectors[0].Connector.ConnectorID != "aws-123456789012" {
 		t.Fatalf("unexpected connectors: %+v", connectors)
 	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreKubernetesEnrollmentTokenClaim(t *testing.T) {
+	rawDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer rawDB.Close()
+
+	store := NewPostgresStoreWithDB(rawDB)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	now := time.Now().UTC()
+	updatedMetadata := map[string]any{
+		"enrollment_token_sha256": "token-hash",
+		"enrollment_token_used_at": now.Format(time.RFC3339Nano),
+	}
+	payload, err := json.Marshal(updatedMetadata)
+	if err != nil {
+		t.Fatalf("marshal updated metadata: %v", err)
+	}
+
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE tenancy_connector_states
+		 SET metadata = $5::jsonb,
+		     observed_at = $6,
+		     updated_at = $7
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND project_id = $3
+		   AND connector_id = $4
+		   AND metadata ->> 'enrollment_token_sha256' = $8
+		   AND metadata ->> 'enrollment_token_used_at' IS NULL`)).
+		WithArgs("tenant-a", "workspace-a", "project-1", "kubernetes-agent", payload, now, now, "token-hash").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	claimed, err := store.ClaimKubernetesEnrollmentToken(ctx, "workspace-a", "project-1", "kubernetes-agent", "token-hash", updatedMetadata, now, now)
+	if err != nil {
+		t.Fatalf("claim token first attempt: %v", err)
+	}
+	if !claimed {
+		t.Fatalf("expected first claim to return true")
+	}
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE tenancy_connector_states
+		 SET metadata = $5::jsonb,
+		     observed_at = $6,
+		     updated_at = $7
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND project_id = $3
+		   AND connector_id = $4
+		   AND metadata ->> 'enrollment_token_sha256' = $8
+		   AND metadata ->> 'enrollment_token_used_at' IS NULL`)).
+		WithArgs("tenant-a", "workspace-a", "project-1", "kubernetes-agent", payload, now, now.Add(time.Minute), "token-hash").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	claimed, err = store.ClaimKubernetesEnrollmentToken(ctx, "workspace-a", "project-1", "kubernetes-agent", "token-hash", updatedMetadata, now, now.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("claim token second attempt: %v", err)
+	}
+	if claimed {
+		t.Fatalf("expected second claim to return false")
+	}
+
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
 	}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1817,7 +1817,7 @@ type Store interface {
 	GetTenancyConnector(ctx context.Context, workspaceID string, projectID string, connectorID string) (TenancyConnectorWithState, error)
 	ListTenancyConnectors(ctx context.Context, workspaceID string, projectID string, connectorType domain.ConnectorType, limit int) ([]TenancyConnectorWithState, error)
 	ListTenancyConnectorsUnscoped(ctx context.Context, connectorType domain.ConnectorType, limit int) ([]TenancyConnectorWithState, error)
-	ClaimKubernetesEnrollmentToken(ctx context.Context, workspaceID string, projectID string, connectorID string, expectedEnrollmentTokenHash string, updatedMetadata map[string]any, observedAt time.Time, updatedAt time.Time) (bool, error)
+	ClaimKubernetesEnrollmentToken(ctx context.Context, workspaceID string, projectID string, connectorID string, expectedEnrollmentTokenHash string, updatedMetadata map[string]any, status domain.ConnectorStatus, health string, lastErrorCode string, lastErrorMessage string, observedAt time.Time, updatedAt time.Time) (bool, error)
 	UpsertTenancyScanPolicy(ctx context.Context, policy TenancyScanPolicy) error
 	GetTenancyScanPolicy(ctx context.Context, workspaceID string, projectID string, policyID string) (TenancyScanPolicy, error)
 	ListTenancyScanPolicies(ctx context.Context, workspaceID string, projectID string, triggerMode domain.ScanTriggerMode, enabled *bool, sortBy string, sortDesc bool, limit int) ([]TenancyScanPolicy, error)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1817,6 +1817,7 @@ type Store interface {
 	GetTenancyConnector(ctx context.Context, workspaceID string, projectID string, connectorID string) (TenancyConnectorWithState, error)
 	ListTenancyConnectors(ctx context.Context, workspaceID string, projectID string, connectorType domain.ConnectorType, limit int) ([]TenancyConnectorWithState, error)
 	ListTenancyConnectorsUnscoped(ctx context.Context, connectorType domain.ConnectorType, limit int) ([]TenancyConnectorWithState, error)
+	ClaimKubernetesEnrollmentToken(ctx context.Context, workspaceID string, projectID string, connectorID string, expectedEnrollmentTokenHash string, updatedMetadata map[string]any, observedAt time.Time, updatedAt time.Time) (bool, error)
 	UpsertTenancyScanPolicy(ctx context.Context, policy TenancyScanPolicy) error
 	GetTenancyScanPolicy(ctx context.Context, workspaceID string, projectID string, policyID string) (TenancyScanPolicy, error)
 	ListTenancyScanPolicies(ctx context.Context, workspaceID string, projectID string, triggerMode domain.ScanTriggerMode, enabled *bool, sortBy string, sortDesc bool, limit int) ([]TenancyScanPolicy, error)


### PR DESCRIPTION
## Summary
Fixes the post-review issue from PR #1117: make Kubernetes enrollment token claim atomic so concurrent enroll requests cannot both be accepted.

- Added atomic claim check in API before persisting Kubernetes agent metadata.
- Updated store interface and both Postgres/Memory tenancy implementations with conditional update semantics.
- Added regression coverage including concurrent enrollment / claim race tests.

AI-assisted: no

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1117 by making Kubernetes agent enrollment token claims atomic in a single write path. Exactly one concurrent enroll succeeds; others return HTTP 410.

- **Bug Fixes**
  - `EnrollKubernetesAgent` now claims and persists metadata in one atomic store call (no follow-up write).
  - Added `Store.ClaimKubernetesEnrollmentToken(...)`; Postgres uses a transactional conditional JSONB update plus connector status update, Memory uses a mutex-guarded check.
  - Added concurrency tests for the HTTP enroll route and store implementations (including `sqlmock`) to ensure only one successful claim.

<sup>Written for commit 765fdfd4f0ae19ec39e6e418609207f7fc20b395. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

