### PR TITLE
Prepare low-cost API hosting cutover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Added a plan-first AWS API hosting layer:
   - defines ECS/Fargate API service, HTTPS load balancer, task roles, security groups, health checks, and CPU autoscaling primitives
   - keeps API hosting resource creation disabled by default for cost-safe CI validation
+  - adds an explicit low-cost public-task bootstrap mode for the first `api.identrail.com` cutover, avoiding NAT Gateway or VPC endpoint hourly charges while keeping inbound traffic behind the ALB security group
   - configures hosted API CORS origins and trusted ALB proxy CIDRs so the split web/API domains preserve browser access and real client IPs
   - validates distinct public/private subnet inputs, public subnet Availability Zone spread, subnet VPC membership, and public-subnet Internet Gateway routes, including inherited main route tables, before planning the load balancer and Fargate service
   - requires operator confirmation that private API task subnets have NAT or VPC endpoint egress before planning Fargate tasks with `assign_public_ip=false`

--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -20,6 +20,13 @@ When `create_api_hosting_resources=true`, the root can also create:
 - API load balancer and ECS service security groups
 - task execution and task IAM roles
 
+The default network shape keeps API tasks in private subnets. For the first
+Identrail Cloud cutover, operators may opt into a lower-cost bootstrap mode by
+setting `api_task_subnet_ids` to public subnets and `api_task_assign_public_ip=true`.
+That avoids NAT Gateway or private VPC endpoint hourly charges while preserving
+the public ingress boundary at the load balancer security group. Move back to
+private task subnets before higher-volume production use.
+
 It does not write secret values. Runtime secrets should be created by the
 operator or a dedicated secrets workflow and referenced through `api_secrets`.
 If those secrets use customer-managed KMS keys, list the key ARNs in
@@ -82,15 +89,14 @@ terraform plan \
 ## Manual Dev Plan With API Hosting Enabled
 
 Only run this after the VPC, at least two distinct public subnets in different
-Availability Zones, at least two distinct private subnets, ACM certificate,
-immutable API image, database, auth configuration, and Secrets Manager
-references are ready. The API-hosting plan reads public and private subnet
-metadata from AWS and fails before apply if the load balancer subnets are not
-spread across at least two Availability Zones or if any provided subnet is
-outside `api_vpc_id`. It also reads the public subnet route tables and requires
-an Internet Gateway default route so the public API load balancer is reachable.
-public subnets may use either an explicit subnet route-table association or the
-VPC main route table.
+Availability Zones, task subnets, ACM certificate, immutable API image,
+database, auth configuration, and Secrets Manager references are ready. The
+API-hosting plan reads subnet metadata from AWS and fails before apply if the
+load balancer or task subnets are not spread across at least two Availability
+Zones or if any provided subnet is outside `api_vpc_id`. It also reads route
+tables and requires an Internet Gateway default route for public load balancer
+subnets. Public subnets may use either an explicit subnet route-table
+association or the VPC main route table.
 
 ```bash
 cd deploy/aws/terraform
@@ -112,6 +118,37 @@ terraform plan \
   -var='api_connector_role_arns=[]'
 ```
 
+For the lowest-cost first cutover, avoid NAT Gateway by using public task
+subnets with public IP assignment:
+
+```bash
+cd deploy/aws/terraform
+terraform plan \
+  -input=false \
+  -var-file=environments/dev/terraform.tfvars.example \
+  -var='create_foundation_resources=true' \
+  -var='create_api_hosting_resources=true' \
+  -var='api_vpc_id=<vpc-id>' \
+  -var='api_public_subnet_ids=["<public-subnet-a>","<public-subnet-b>"]' \
+  -var='api_task_subnet_ids=["<public-subnet-a>","<public-subnet-b>"]' \
+  -var='api_task_assign_public_ip=true' \
+  -var='api_certificate_arn=<api-certificate-arn>' \
+  -var='api_container_image=ghcr.io/identrail/identrail-api:<immutable-release-tag>' \
+  -var='api_cors_allowed_origins=["https://app.identrail.com","https://identrail.com","https://www.identrail.com"]' \
+  -var='api_trusted_proxy_cidr_blocks=["10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"]' \
+  -var='api_environment_variables={"IDENTRAIL_FEATURE_NEW_AUTH":"true","IDENTRAIL_PUBLIC_BASE_URL":"https://api.identrail.com"}' \
+  -var='api_secrets={"IDENTRAIL_DATABASE_URL":"<database-url-secret-arn>","IDENTRAIL_SESSION_KEY":"<session-key-secret-arn>"}' \
+  -var='api_secret_kms_key_arns=[]' \
+  -var='api_connector_role_arns=[]'
+```
+
+This mode is intentionally still behind the ALB. The ECS service security group
+allows inbound traffic only from the ALB security group, not directly from the
+internet. The public IP is used for task egress to pull images, read Secrets
+Manager, and write logs without a NAT Gateway. Treat it as a budget-conscious
+bootstrap path and migrate to private task subnets plus NAT/VPC endpoints when
+traffic or compliance needs justify the extra cost.
+
 Do not run `terraform apply` until the database, runtime secrets, container
 image tag, health checks, rollback plan, and DNS cutover plan have all been
 reviewed.
@@ -124,6 +161,8 @@ Set `api_private_subnet_egress_ready=true` only after the private task subnets
 have NAT egress or private VPC endpoints for the services Fargate needs at
 startup, including ECR API, ECR Docker, CloudWatch Logs, Secrets Manager, and
 S3 access for image layers. Identrail API tasks run with `assign_public_ip=false`.
+If using the low-cost bootstrap path, leave `api_private_subnet_egress_ready=false`
+and set `api_task_assign_public_ip=true` with public `api_task_subnet_ids`.
 
 Set `api_enable_execute_command=true` only when operator IAM and audit
 expectations are ready. The task role receives the required SSM Messages

--- a/deploy/aws/terraform/api_hosting.tf
+++ b/deploy/aws/terraform/api_hosting.tf
@@ -16,6 +16,7 @@ locals {
   api_fargate_memory_options = lookup(local.api_fargate_memory_by_cpu, tostring(var.api_task_cpu), [])
   api_cors_allowed_origins   = join(",", var.api_cors_allowed_origins)
   api_trusted_proxies        = join(",", var.api_trusted_proxy_cidr_blocks)
+  api_task_subnet_ids        = length(var.api_task_subnet_ids) > 0 ? var.api_task_subnet_ids : var.api_private_subnet_ids
   api_default_environment_variables = {
     IDENTRAIL_AWS_REGION           = var.aws_region
     IDENTRAIL_AWS_SOURCE           = "sdk"
@@ -55,6 +56,19 @@ locals {
       local.api_main_route_table_ids
     )
   }
+  api_task_subnet_explicit_route_table_ids = {
+    for subnet_id in local.api_task_subnet_ids : subnet_id => [
+      for route_table_id, route_table in data.aws_route_table.api_vpc : route_table_id
+      if anytrue([for association in route_table.associations : association.subnet_id == subnet_id])
+    ]
+  }
+  api_task_subnet_effective_route_table_ids = {
+    for subnet_id in local.api_task_subnet_ids : subnet_id => (
+      length(local.api_task_subnet_explicit_route_table_ids[subnet_id]) > 0 ?
+      local.api_task_subnet_explicit_route_table_ids[subnet_id] :
+      local.api_main_route_table_ids
+    )
+  }
   api_new_auth_enabled = lower(lookup(local.api_runtime_environment_variables, "IDENTRAIL_FEATURE_NEW_AUTH", "")) == "true"
   api_has_supported_auth = (
     contains(local.api_secret_config_names, "IDENTRAIL_API_KEY_SCOPES") ||
@@ -84,10 +98,10 @@ data "aws_subnet" "api_public" {
   id = var.api_public_subnet_ids[count.index]
 }
 
-data "aws_subnet" "api_private" {
-  count = var.create_api_hosting_resources ? length(var.api_private_subnet_ids) : 0
+data "aws_subnet" "api_task" {
+  count = var.create_api_hosting_resources ? length(local.api_task_subnet_ids) : 0
 
-  id = var.api_private_subnet_ids[count.index]
+  id = local.api_task_subnet_ids[count.index]
 }
 
 data "aws_route_tables" "api_vpc" {
@@ -144,17 +158,22 @@ resource "terraform_data" "api_inputs" {
     }
 
     precondition {
-      condition = length(distinct(var.api_private_subnet_ids)) >= 2 && alltrue([
-        for subnet_id in var.api_private_subnet_ids : can(regex("^subnet-[0-9a-f]+$", subnet_id))
+      condition = length(distinct(local.api_task_subnet_ids)) >= 2 && alltrue([
+        for subnet_id in local.api_task_subnet_ids : can(regex("^subnet-[0-9a-f]+$", subnet_id))
       ])
-      error_message = "api_private_subnet_ids must include at least two distinct valid subnet IDs when create_api_hosting_resources=true."
+      error_message = "API hosting requires at least two distinct valid ECS task subnet IDs. Set api_task_subnet_ids, or leave it empty and set api_private_subnet_ids."
     }
 
     precondition {
       condition = alltrue([
-        for subnet in data.aws_subnet.api_private : subnet.vpc_id == var.api_vpc_id
+        for subnet in data.aws_subnet.api_task : subnet.vpc_id == var.api_vpc_id
       ])
-      error_message = "api_private_subnet_ids must all belong to api_vpc_id when create_api_hosting_resources=true."
+      error_message = "ECS task subnets must all belong to api_vpc_id when create_api_hosting_resources=true."
+    }
+
+    precondition {
+      condition     = length(distinct(data.aws_subnet.api_task[*].availability_zone_id)) >= 2
+      error_message = "ECS task subnets must span at least two distinct Availability Zones when create_api_hosting_resources=true."
     }
 
     precondition {
@@ -166,8 +185,19 @@ resource "terraform_data" "api_inputs" {
     }
 
     precondition {
-      condition     = var.api_private_subnet_egress_ready
-      error_message = "api_private_subnet_egress_ready must be true when create_api_hosting_resources=true after confirming private API subnets have NAT egress or VPC endpoints for ECR, Secrets Manager, and CloudWatch Logs."
+      condition     = var.api_task_assign_public_ip || var.api_private_subnet_egress_ready
+      error_message = "API hosting requires egress for ECS tasks: set api_private_subnet_egress_ready=true for private task subnets, or set api_task_assign_public_ip=true with public task subnets for the low-cost first cutover path."
+    }
+
+    precondition {
+      condition = !var.api_task_assign_public_ip || alltrue([
+        for route_table_ids in values(local.api_task_subnet_effective_route_table_ids) : anytrue([
+          for route_table_id in route_table_ids : anytrue([
+            for route in data.aws_route_table.api_vpc[route_table_id].routes : route.cidr_block == "0.0.0.0/0" && can(regex("^igw-", route.gateway_id))
+          ])
+        ])
+      ])
+      error_message = "api_task_assign_public_ip=true requires ECS task subnets to have an Internet Gateway default route."
     }
 
     precondition {
@@ -554,10 +584,12 @@ resource "aws_ecs_service" "api" {
   }
 
   network_configuration {
-    assign_public_ip = false
+    assign_public_ip = var.api_task_assign_public_ip
     security_groups  = [aws_security_group.api_service[0].id]
-    # terraform_data.api_inputs requires operator-confirmed NAT or VPC endpoints before these private subnets are used.
-    subnets = var.api_private_subnet_ids
+    # Private tasks require operator-confirmed NAT/VPC endpoints. The optional
+    # public-IP path keeps ingress restricted to the ALB security group while
+    # avoiding NAT Gateway cost for the first cutover.
+    subnets = local.api_task_subnet_ids
   }
 
   depends_on = [

--- a/deploy/aws/terraform/environments/dev/terraform.tfvars.example
+++ b/deploy/aws/terraform/environments/dev/terraform.tfvars.example
@@ -15,6 +15,11 @@ log_retention_days    = 30
 # api_public_subnet_ids  = ["<public-subnet-a>", "<public-subnet-b>"]
 # api_private_subnet_ids = ["<private-subnet-a>", "<private-subnet-b>"]
 # api_private_subnet_egress_ready = true
+# Low-cost first cutover option: use public task subnets and public task egress
+# to avoid NAT Gateway or VPC endpoint hourly costs. Keep service ingress
+# restricted to the ALB security group, and move to private task subnets later.
+# api_task_subnet_ids       = ["<public-subnet-a>", "<public-subnet-b>"]
+# api_task_assign_public_ip = true
 # api_certificate_arn    = "<api-certificate-arn>"
 # api_container_image    = "ghcr.io/identrail/identrail-api:<immutable-release-tag>"
 # api_cors_allowed_origins = [

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -110,8 +110,26 @@ variable "api_private_subnet_ids" {
   }
 }
 
+variable "api_task_subnet_ids" {
+  description = "Optional ECS task subnet IDs. Leave empty to use api_private_subnet_ids. For a low-cost first cutover, operators may set this to public subnets and enable api_task_assign_public_ip to avoid NAT Gateway or VPC endpoint costs."
+  type        = list(string)
+  default     = []
+  validation {
+    condition = length(var.api_task_subnet_ids) == length(distinct(var.api_task_subnet_ids)) && alltrue([
+      for subnet_id in var.api_task_subnet_ids : can(regex("^subnet-[0-9a-f]+$", subnet_id))
+    ])
+    error_message = "api_task_subnet_ids must contain distinct valid subnet IDs."
+  }
+}
+
+variable "api_task_assign_public_ip" {
+  description = "Assign public IPs to API ECS tasks. Keep false for private-subnet production; set true only for the low-cost first cutover path where task subnets are public and service ingress remains restricted to the ALB security group."
+  type        = bool
+  default     = false
+}
+
 variable "api_private_subnet_egress_ready" {
-  description = "Set true only after private API subnets have NAT egress or VPC endpoints for ECR, Secrets Manager, and CloudWatch Logs. Required when API hosting is enabled because Fargate tasks run with assign_public_ip=false."
+  description = "Set true only after private API task subnets have NAT egress or VPC endpoints for ECR, Secrets Manager, and CloudWatch Logs. Required when API hosting uses private tasks with api_task_assign_public_ip=false."
   type        = bool
   default     = false
 }

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -49,6 +49,10 @@ Before a manual apply, operators must provide:
 - `api_private_subnet_egress_ready=true` after confirming those private subnets
   have NAT egress or VPC endpoints for ECR, Secrets Manager, CloudWatch Logs,
   and S3 image-layer access; API tasks run with `assign_public_ip=false`
+- for the low-cost first cutover only, `api_task_subnet_ids` may point at the
+  same two public subnets used by the load balancer with
+  `api_task_assign_public_ip=true`; this avoids NAT Gateway or VPC endpoint
+  hourly charges while keeping task ingress restricted to the ALB security group
 - `api_certificate_arn` for HTTPS on `api.identrail.com`
 - `api_container_image` pinned to an immutable release tag
 - `api_cors_allowed_origins`, defaulting to the Identrail Cloud web origins;
@@ -87,10 +91,16 @@ mode so ECS tasks do not boot into a known-bad configuration. It also refuses to
 plan API hosting without at least one HTTPS CORS origin and at least one trusted
 proxy CIDR.
 
-Terraform requires `api_private_subnet_egress_ready=true` before creating API
-hosting resources. Use that only after the private task subnets can pull the
-image, read injected secrets, and write logs through NAT or private VPC
-endpoints.
+Terraform requires either private task egress or the explicit low-cost public
+task mode before creating API hosting resources. Use
+`api_private_subnet_egress_ready=true` only after the private task subnets can
+pull the image, read injected secrets, and write logs through NAT or private VPC
+endpoints. For the first budget-conscious Identrail Cloud cutover, set
+`api_task_subnet_ids` to two public subnets and `api_task_assign_public_ip=true`
+instead. This is cheaper because it avoids NAT Gateway, but it is still treated
+as a bootstrap mode: keep task security-group ingress limited to the ALB, keep
+`api_allowed_cidr_blocks` on the ALB, and move to private task subnets when
+traffic, compliance, or customer requirements justify the extra cost.
 
 Run database migrations as a separate one-off operation before deploying or
 upgrading the hosted API service. Keep long-running API tasks non-migrating.

--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -107,6 +107,15 @@ Manager references are ready. Plan the stack first, verify the load balancer
 health endpoint, and only then point `api.identrail.com` at the load balancer.
 Keep `app.identrail.com` on Vercel.
 
+For the first cost-controlled Identrail Cloud cutover, prefer the documented
+public-task bootstrap mode instead of creating NAT Gateways. Set
+`api_task_subnet_ids` to two public subnets and `api_task_assign_public_ip=true`
+so ECS tasks can pull images, read Secrets Manager, and write logs without NAT
+hourly charges. The service security group still accepts inbound traffic only
+from the ALB security group. Revisit private task subnets plus NAT/VPC endpoints
+after the API is live and traffic or customer requirements justify the added
+cost.
+
 ## 3) Rollback Sequence
 
 Before any migration or rollback, capture a fresh Postgres backup or managed database

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -234,6 +234,15 @@ describe('App', () => {
     );
   });
 
+  it('shows a clear API reachability error when auth config cannot be fetched', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new TypeError('Failed to fetch')));
+
+    setCurrentPath('/signin');
+    render(<App />);
+
+    expect(await screen.findByText(/Identrail API is not reachable yet/i)).toBeInTheDocument();
+  });
+
   it('renders tenancy-scoped project detail placeholder route inside app shell', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(okJSON(currentMePayload('tenant-a', 'workspace-a'))));
     setCurrentPath('/app/tenant-a/workspace-a/projects/project-1');

--- a/web/src/pages/SignInPage.tsx
+++ b/web/src/pages/SignInPage.tsx
@@ -45,6 +45,13 @@ function authReasonMessage(reason: string): string {
   }
 }
 
+function authConfigErrorMessage(error: unknown): string {
+  if (error instanceof TypeError && /fetch/i.test(error.message)) {
+    return 'Identrail API is not reachable yet. Please retry after the production API is online.';
+  }
+  return error instanceof Error ? error.message : 'Unable to load authentication options.';
+}
+
 function workOSURL(intent: AuthIntent, returnTo: string): string {
   const query = new URLSearchParams();
   const webReturnTo = typeof window === 'undefined' ? returnTo : new URL(returnTo, window.location.origin).toString();
@@ -108,8 +115,7 @@ export function AuthChoicePage({ intent }: AuthChoicePageProps) {
         }
       } catch (error) {
         if (mounted) {
-          const message = error instanceof Error ? error.message : 'Unable to load authentication options.';
-          setConfigError(message);
+          setConfigError(authConfigErrorMessage(error));
         }
       } finally {
         if (mounted) {


### PR DESCRIPTION
## Summary

Adds a low-cost API hosting cutover path for `api.identrail.com` and makes the auth UI show a clearer production API reachability message.

## Why

The current hosted web app can load the sign-in and sign-up pages, but the production API endpoint is not online yet. The AWS API hosting plan already expects private ECS task subnets, which is the stronger long-term shape, but that can require NAT Gateway or VPC endpoint hourly costs before the product has traffic. This PR gives us a budget-conscious bootstrap path while keeping the public boundary at the HTTPS load balancer.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

What changed:

- Keeps private ECS task networking as the Terraform default.
- Adds optional `api_task_subnet_ids` plus `api_task_assign_public_ip` for the first low-cost cutover.
- Validates that public task mode uses subnets with Internet Gateway default routes.
- Documents the cheap first cutover path and when to migrate back to private task subnets.
- Replaces the raw browser `Failed to fetch` auth message with a clearer production API reachability message.
- Adds web regression coverage for that clearer auth error.

Impact and risk:

- Existing Terraform callers are backward-compatible because the new variables default to the previous private-task behavior.
- The public-task mode is explicit opt-in and still keeps inbound service traffic restricted to the ALB security group.
- No AWS resources are created by default; API hosting remains disabled unless operators opt in.

## Validation

```bash
terraform fmt -check -recursive deploy/aws/terraform
terraform -chdir=deploy/aws/terraform validate
terraform -chdir=deploy/aws/terraform plan -refresh=false -input=false -var-file=environments/dev/terraform.tfvars.example
npm run test:ci --prefix web
npm run build --prefix web
git diff --check
```

Results: all passed. Web tests passed with 80 tests across 8 files. The Vite production build completed and prerendered 40 routes.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: yes
- Tools used: Codex
- Areas where used: Terraform API hosting inputs, deployment docs, auth UI error handling, test coverage
- Human verification performed: reviewed diff for scope/secrets and ran the validation commands listed above

## Related Issues

No issue: deployment-readiness follow-up for the auth production API cutover path; no standalone tracking issue exists for this operator bootstrap step.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables a low-cost bootstrap path to host `api.identrail.com` by allowing ECS tasks to run in public subnets with public IPs while keeping ingress behind the ALB. Also adds a clearer auth UI message when the production API is not reachable.

- New Features
  - Terraform: add `api_task_subnet_ids` and `api_task_assign_public_ip` (defaults keep private-subnet behavior); validate VPC membership, two-AZ spread, and IGW default routes when public-task mode is enabled.
  - ECS: service now uses the chosen task subnets and `assign_public_ip`; inbound remains restricted to the ALB security group; API hosting stays opt-in.
  - Web: show a clear “Identrail API is not reachable yet” message on auth config fetch failure, with test coverage.
  - Docs: updated README, runbook, and examples to document the bootstrap path and when to switch back to private task subnets.

- Migration
  - First cutover without NAT/VPC endpoints: set `api_task_subnet_ids` to two public subnets and `api_task_assign_public_ip=true` (keep existing `api_public_subnet_ids` for the ALB).
  - In this mode, leave `api_private_subnet_egress_ready=false`; later migrate to private task subnets with NAT/VPC endpoints by setting `api_task_assign_public_ip=false` and `api_private_subnet_egress_ready=true`.
  - Plan and verify health checks before pointing DNS for `api.identrail.com` to the ALB.

<sup>Written for commit 33e693d4e4b0ce6703f4677b206680810bd49d93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

