### PR TITLE
Add guarded AWS API deploy workflow

### DIFF
--- a/.github/workflows/aws-api-manual-deploy.yml
+++ b/.github/workflows/aws-api-manual-deploy.yml
@@ -1,0 +1,219 @@
+name: AWS API Manual Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: "Run a Terraform plan or apply for the AWS API hosting stack."
+        required: true
+        type: choice
+        default: plan
+        options:
+          - plan
+          - apply
+      confirm_apply:
+        description: "Required for apply: type apply-api.identrail.com"
+        required: false
+        type: string
+      api_container_image:
+        description: "Immutable API image, for example ghcr.io/identrail/identrail-api:sha-<commit>."
+        required: true
+        type: string
+      api_vpc_id:
+        description: "VPC ID. Leave blank to use repository variable API_VPC_ID."
+        required: false
+        type: string
+      api_public_subnet_ids_json:
+        description: "JSON array of two public subnet IDs. Leave blank to use repository variable API_PUBLIC_SUBNET_IDS_JSON."
+        required: false
+        type: string
+      api_task_subnet_ids_json:
+        description: "Optional JSON array of task subnet IDs. Blank uses the public subnets for low-cost bootstrap mode."
+        required: false
+        type: string
+      api_certificate_arn:
+        description: "ACM certificate ARN. Leave blank to use repository variable API_CERTIFICATE_ARN."
+        required: false
+        type: string
+      terraform_state_bucket:
+        description: "S3 bucket for Terraform state. Leave blank to use repository variable AWS_TERRAFORM_STATE_BUCKET."
+        required: false
+        type: string
+      terraform_state_key:
+        description: "S3 key for Terraform state."
+        required: false
+        type: string
+        default: identrail/dev/aws-api.tfstate
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: aws-api-manual-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: ${{ inputs.operation == 'apply' && 'Apply AWS API hosting' || 'Plan AWS API hosting' }}
+    if: github.repository == 'identrail/identrail'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      API_DEPLOY_OPERATION: ${{ inputs.operation }}
+      API_DEPLOY_CONFIRM: ${{ inputs.confirm_apply }}
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      TF_STATE_BUCKET: ${{ inputs.terraform_state_bucket || vars.AWS_TERRAFORM_STATE_BUCKET }}
+      TF_STATE_KEY: ${{ inputs.terraform_state_key || vars.AWS_TERRAFORM_STATE_KEY || 'identrail/dev/aws-api.tfstate' }}
+      API_VPC_ID: ${{ inputs.api_vpc_id || vars.API_VPC_ID }}
+      API_PUBLIC_SUBNET_IDS_JSON: ${{ inputs.api_public_subnet_ids_json || vars.API_PUBLIC_SUBNET_IDS_JSON }}
+      API_TASK_SUBNET_IDS_JSON: ${{ inputs.api_task_subnet_ids_json || vars.API_TASK_SUBNET_IDS_JSON }}
+      API_CERTIFICATE_ARN: ${{ inputs.api_certificate_arn || vars.API_CERTIFICATE_ARN }}
+      API_CONTAINER_IMAGE: ${{ inputs.api_container_image }}
+      API_DATABASE_URL_SECRET_ARN: ${{ secrets.API_DATABASE_URL_SECRET_ARN }}
+      API_SESSION_KEY_SECRET_ARN: ${{ secrets.API_SESSION_KEY_SECRET_ARN }}
+      API_ALLOWED_CIDR_BLOCKS_JSON: ${{ vars.API_ALLOWED_CIDR_BLOCKS_JSON || '["0.0.0.0/0"]' }}
+      API_CORS_ALLOWED_ORIGINS_JSON: ${{ vars.API_CORS_ALLOWED_ORIGINS_JSON || '["https://app.identrail.com","https://identrail.com","https://www.identrail.com"]' }}
+      API_TRUSTED_PROXY_CIDR_BLOCKS_JSON: ${{ vars.API_TRUSTED_PROXY_CIDR_BLOCKS_JSON || '["10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"]' }}
+      API_EXTRA_ENVIRONMENT_JSON: ${{ vars.API_EXTRA_ENVIRONMENT_JSON || '{}' }}
+      API_EXTRA_SECRETS_JSON: ${{ secrets.API_EXTRA_SECRETS_JSON || '{}' }}
+      API_SECRET_KMS_KEY_ARNS_JSON: ${{ vars.API_SECRET_KMS_KEY_ARNS_JSON || '[]' }}
+      API_CONNECTOR_ROLE_ARNS_JSON: ${{ vars.API_CONNECTOR_ROLE_ARNS_JSON || '[]' }}
+      TF_IN_AUTOMATION: "true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85
+
+      - name: Validate workflow ref
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_NAME}" != "dev" ]; then
+            echo "Run this workflow from the dev branch. The AWS OIDC role trust is intentionally scoped to refs/heads/dev."
+            exit 1
+          fi
+
+      - name: Validate AWS deployment secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${AWS_ROLE_ARN}" ]; then
+            echo "Missing repository secret AWS_ROLE_ARN."
+            exit 1
+          fi
+          if ! [[ "${AWS_ROLE_ARN}" =~ ^arn:aws:iam::[0-9]{12}:role/.+$ ]]; then
+            echo "AWS_ROLE_ARN must look like arn:aws:iam::<account-id>:role/<role-name>."
+            exit 1
+          fi
+          echo "::add-mask::${AWS_ROLE_ARN}"
+          if [ -z "${API_DATABASE_URL_SECRET_ARN}" ]; then
+            echo "Missing repository secret API_DATABASE_URL_SECRET_ARN."
+            exit 1
+          fi
+          if [ -z "${API_SESSION_KEY_SECRET_ARN}" ]; then
+            echo "Missing repository secret API_SESSION_KEY_SECRET_ARN."
+            exit 1
+          fi
+          echo "::add-mask::${API_DATABASE_URL_SECRET_ARN}"
+          echo "::add-mask::${API_SESSION_KEY_SECRET_ARN}"
+
+      - name: Configure AWS credentials from GitHub OIDC
+        shell: bash
+        run: |
+          set -euo pipefail
+          token_response="$(
+            curl -fsSL \
+              -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sts.amazonaws.com"
+          )"
+          oidc_token="$(jq -r '.value // empty' <<< "${token_response}")"
+          if [ -z "${oidc_token}" ]; then
+            echo "GitHub did not return an OIDC token."
+            exit 1
+          fi
+
+          credentials="$(
+            aws sts assume-role-with-web-identity \
+              --role-arn "${AWS_ROLE_ARN}" \
+              --role-session-name "identrail-api-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+              --web-identity-token "${oidc_token}" \
+              --duration-seconds 1800 \
+              --query 'Credentials' \
+              --output json
+          )"
+          access_key_id="$(jq -r '.AccessKeyId' <<< "${credentials}")"
+          secret_access_key="$(jq -r '.SecretAccessKey' <<< "${credentials}")"
+          session_token="$(jq -r '.SessionToken' <<< "${credentials}")"
+          echo "::add-mask::${access_key_id}"
+          echo "::add-mask::${secret_access_key}"
+          echo "::add-mask::${session_token}"
+          {
+            echo "AWS_ACCESS_KEY_ID=${access_key_id}"
+            echo "AWS_SECRET_ACCESS_KEY=${secret_access_key}"
+            echo "AWS_SESSION_TOKEN=${session_token}"
+            echo "AWS_REGION=${AWS_REGION}"
+            echo "AWS_DEFAULT_REGION=${AWS_REGION}"
+          } >> "${GITHUB_ENV}"
+
+      - name: Prepare Terraform inputs
+        id: prepare
+        run: ./scripts/prepare_aws_api_deploy.sh
+
+      - name: Verify Terraform state bucket
+        run: aws s3api head-bucket --bucket "${TF_STATE_BUCKET}"
+
+      - name: Terraform Format Check
+        run: terraform fmt -check -recursive deploy/aws/terraform
+
+      - name: Configure S3 backend
+        run: |
+          cat > deploy/aws/terraform/backend.generated.tf <<'EOF'
+          terraform {
+            backend "s3" {}
+          }
+          EOF
+          terraform fmt deploy/aws/terraform/backend.generated.tf
+
+      - name: Terraform Init
+        working-directory: deploy/aws/terraform
+        run: terraform init -backend-config="${{ steps.prepare.outputs.backend_config_path }}"
+
+      - name: Terraform Validate
+        working-directory: deploy/aws/terraform
+        run: terraform validate
+
+      - name: Terraform Plan
+        working-directory: deploy/aws/terraform
+        run: |
+          terraform plan \
+            -input=false \
+            -out="${RUNNER_TEMP}/identrail-api.tfplan" \
+            -var-file="${{ steps.prepare.outputs.tfvars_path }}"
+
+      - name: Terraform Apply
+        if: inputs.operation == 'apply'
+        working-directory: deploy/aws/terraform
+        run: terraform apply -input=false -auto-approve "${RUNNER_TEMP}/identrail-api.tfplan"
+
+      - name: Publish Apply Outputs
+        if: inputs.operation == 'apply'
+        working-directory: deploy/aws/terraform
+        run: |
+          set -euo pipefail
+          api_lb_dns="$(terraform output -raw api_load_balancer_dns_name)"
+          api_service="$(terraform output -raw api_service_name)"
+          api_cluster="$(terraform output -raw api_ecs_cluster_name)"
+          {
+            echo "## AWS API deploy outputs"
+            echo
+            echo "- API load balancer DNS: \`${api_lb_dns}\`"
+            echo "- ECS cluster: \`${api_cluster}\`"
+            echo "- ECS service: \`${api_service}\`"
+            echo "- Terraform state key: \`${{ steps.prepare.outputs.state_key }}\`"
+            echo
+            echo "After health checks pass, create the Namecheap CNAME for \`api.identrail.com\` to the load balancer DNS name."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Added a plan-first AWS API hosting layer:
   - defines ECS/Fargate API service, HTTPS load balancer, task roles, security groups, health checks, and CPU autoscaling primitives
   - keeps API hosting resource creation disabled by default for cost-safe CI validation
+  - adds a guarded manual GitHub Actions deploy workflow for pre-PR 11 API cutover planning and explicitly confirmed applies
   - adds an explicit low-cost public-task bootstrap mode for the first `api.identrail.com` cutover, avoiding NAT Gateway or VPC endpoint hourly charges while keeping inbound traffic behind the ALB security group
   - configures hosted API CORS origins and trusted ALB proxy CIDRs so the split web/API domains preserve browser access and real client IPs
   - validates distinct public/private subnet inputs, public subnet Availability Zone spread, subnet VPC membership, and public-subnet Internet Gateway routes, including inherited main route tables, before planning the load balancer and Fargate service

--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -63,6 +63,11 @@ The default configuration sets both `create_foundation_resources=false` and
 `terraform init`, `terraform validate`, and `terraform plan` without creating
 billable AWS resources.
 
+The checked-in root stays backendless for validation-only plans. The manual
+GitHub Actions deploy workflow writes a temporary S3 backend file at runtime and
+initializes it with the configured S3 state bucket and key before planning or
+applying AWS API hosting.
+
 ## Local Validation
 
 ```bash
@@ -148,6 +153,12 @@ internet. The public IP is used for task egress to pull images, read Secrets
 Manager, and write logs without a NAT Gateway. Treat it as a budget-conscious
 bootstrap path and migrate to private task subnets plus NAT/VPC endpoints when
 traffic or compliance needs justify the extra cost.
+
+For hosted pre-PR 11 cutover preparation, prefer the `AWS API Manual Deploy`
+GitHub Actions workflow over running `terraform apply` from a laptop. It uses
+the GitHub OIDC deployment role, requires S3-backed Terraform state, plans by
+default, and requires the exact confirmation string `apply-api.identrail.com`
+before it applies.
 
 Do not run `terraform apply` until the database, runtime secrets, container
 image tag, health checks, rollback plan, and DNS cutover plan have all been

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -70,6 +70,52 @@ Before a manual apply, operators must provide:
   - hosted session auth with non-secret `IDENTRAIL_FEATURE_NEW_AUTH=true` and
     `IDENTRAIL_PUBLIC_BASE_URL`, plus `IDENTRAIL_SESSION_KEY` in `api_secrets`
 
+## Manual GitHub Actions Deployment
+
+Use the `AWS API Manual Deploy` workflow for the first controlled
+`api.identrail.com` cutover. The workflow is manual by design: it plans by
+default, stores Terraform state in S3, and only applies when an operator selects
+`apply` and types `apply-api.identrail.com` in the confirmation field.
+Run it from the `dev` branch because the AWS OIDC deployment role trust is
+intentionally scoped to that branch.
+
+Repository configuration required before the workflow can plan:
+
+- secret `AWS_ROLE_ARN`: GitHub OIDC deployment role ARN
+- variable `AWS_REGION`: AWS region, such as `us-east-1`
+- variable `AWS_TERRAFORM_STATE_BUCKET`: existing S3 bucket for Terraform state
+- optional variable `AWS_TERRAFORM_STATE_KEY`: defaults to
+  `identrail/dev/aws-api.tfstate`
+- variable `API_VPC_ID`: VPC for the API load balancer and ECS service
+- variable `API_PUBLIC_SUBNET_IDS_JSON`: JSON array of at least two public
+  subnet IDs, for example `["subnet-aaa","subnet-bbb"]`
+- optional variable `API_TASK_SUBNET_IDS_JSON`: JSON array of task subnet IDs;
+  leave blank for the low-cost public-task bootstrap path
+- variable `API_CERTIFICATE_ARN`: ACM certificate ARN for `api.identrail.com`
+- secret `API_DATABASE_URL_SECRET_ARN`: Secrets Manager ARN containing
+  `IDENTRAIL_DATABASE_URL`
+- secret `API_SESSION_KEY_SECRET_ARN`: Secrets Manager ARN containing
+  `IDENTRAIL_SESSION_KEY`
+
+The workflow dispatch input `api_container_image` must be immutable, such as
+`ghcr.io/identrail/identrail-api:sha-<commit>`. Do not deploy the mutable `dev`
+tag to this hosted API path.
+
+Optional repository variables:
+
+- `API_ALLOWED_CIDR_BLOCKS_JSON`
+- `API_CORS_ALLOWED_ORIGINS_JSON`
+- `API_TRUSTED_PROXY_CIDR_BLOCKS_JSON`
+- `API_EXTRA_ENVIRONMENT_JSON`
+- `API_SECRET_KMS_KEY_ARNS_JSON`
+- `API_CONNECTOR_ROLE_ARNS_JSON`
+
+Optional repository secret:
+
+- `API_EXTRA_SECRETS_JSON`: JSON object mapping additional runtime secret
+  environment variable names to Secrets Manager ARNs, such as WorkOS or future
+  provider secrets.
+
 Do not put database URLs, API keys, cookie secrets, or OAuth credentials directly
 in tfvars files, docs, GitHub variables, or Terraform state. Use Secrets Manager
 references through `api_secrets`. Terraform rejects known secret-bearing
@@ -101,6 +147,11 @@ instead. This is cheaper because it avoids NAT Gateway, but it is still treated
 as a bootstrap mode: keep task security-group ingress limited to the ALB, keep
 `api_allowed_cidr_blocks` on the ALB, and move to private task subnets when
 traffic, compliance, or customer requirements justify the extra cost.
+
+The manual workflow uses the low-cost bootstrap mode by default: public task
+subnets, `api_task_assign_public_ip=true`, and inbound service traffic limited
+to the load balancer security group. That avoids NAT Gateway and private VPC
+endpoint hourly charges during first launch.
 
 Run database migrations as a separate one-off operation before deploying or
 upgrading the hosted API service. Keep long-running API tasks non-migrating.

--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -107,6 +107,11 @@ Manager references are ready. Plan the stack first, verify the load balancer
 health endpoint, and only then point `api.identrail.com` at the load balancer.
 Keep `app.identrail.com` on Vercel.
 
+Use the `AWS API Manual Deploy` GitHub Actions workflow for pre-PR 11 cutover
+preparation. Run `plan` first. Use `apply` only after reviewing the plan; the
+workflow requires the explicit confirmation string `apply-api.identrail.com` and
+persists Terraform state in the configured S3 state bucket.
+
 For the first cost-controlled Identrail Cloud cutover, prefer the documented
 public-task bootstrap mode instead of creating NAT Gateways. Set
 `api_task_subnet_ids` to two public subnets and `api_task_assign_public_ip=true`

--- a/scripts/prepare_aws_api_deploy.sh
+++ b/scripts/prepare_aws_api_deploy.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+trim() {
+  local value="${1:-}"
+  value="${value//$'\r'/}"
+  value="${value//$'\n'/}"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "${value}"
+}
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+require_value() {
+  local name="$1"
+  local value
+  value="$(trim "${!name:-}")"
+  if [ -z "${value}" ]; then
+    fail "missing required environment variable ${name}"
+  fi
+  printf '%s' "${value}"
+}
+
+json_string_array() {
+  local name="$1"
+  local fallback="${2:-}"
+  local raw
+  raw="$(trim "${!name:-}")"
+  if [ -z "${raw}" ]; then
+    raw="${fallback}"
+  fi
+  if [ -z "${raw}" ]; then
+    raw="[]"
+  fi
+  jq -ce --arg name "${name}" '
+    if type == "array" and all(.[]; type == "string" and length > 0) then
+      .
+    else
+      error($name + " must be a JSON array of non-empty strings")
+    end
+  ' <<< "${raw}"
+}
+
+json_string_map() {
+  local name="$1"
+  local raw
+  raw="$(trim "${!name:-}")"
+  if [ -z "${raw}" ]; then
+    raw="{}"
+  fi
+  jq -ce --arg name "${name}" '
+    if type == "object" and all(to_entries[]; (.key | test("^[A-Z][A-Z0-9_]*$")) and (.value | type == "string") and (.value | length > 0)) then
+      .
+    else
+      error($name + " must be a JSON object whose keys are uppercase environment variable names and whose values are non-empty strings")
+    end
+  ' <<< "${raw}"
+}
+
+operation="$(trim "${API_DEPLOY_OPERATION:-plan}")"
+case "${operation}" in
+  plan|apply) ;;
+  *) fail "API_DEPLOY_OPERATION must be plan or apply" ;;
+esac
+
+if [ "${operation}" = "apply" ]; then
+  confirm="$(trim "${API_DEPLOY_CONFIRM:-}")"
+  if [ "${confirm}" != "apply-api.identrail.com" ]; then
+    fail "apply requires API_DEPLOY_CONFIRM=apply-api.identrail.com"
+  fi
+fi
+
+aws_region="$(require_value AWS_REGION)"
+if ! [[ "${aws_region}" =~ ^[a-z]{2}(-gov)?-[a-z]+-[0-9]+$ ]]; then
+  fail "AWS_REGION must be an AWS region such as us-east-1"
+fi
+
+state_bucket="$(require_value TF_STATE_BUCKET)"
+state_key="$(trim "${TF_STATE_KEY:-identrail/dev/aws-api.tfstate}")"
+if [ -z "${state_key}" ]; then
+  fail "TF_STATE_KEY must not be blank"
+fi
+
+api_vpc_id="$(require_value API_VPC_ID)"
+if ! [[ "${api_vpc_id}" =~ ^vpc-[0-9a-f]+$ ]]; then
+  fail "API_VPC_ID must look like vpc-0123456789abcdef0"
+fi
+
+api_certificate_arn="$(require_value API_CERTIFICATE_ARN)"
+if ! [[ "${api_certificate_arn}" =~ ^arn:(aws|aws-us-gov|aws-cn):acm:${aws_region}:[0-9]{12}:certificate/.+ ]]; then
+  fail "API_CERTIFICATE_ARN must be an ACM certificate ARN in ${aws_region}"
+fi
+
+api_container_image="$(require_value API_CONTAINER_IMAGE)"
+if ! [[ "${api_container_image}" =~ ^ghcr\.io/identrail/identrail-api:(sha-[0-9a-f]{12,40}|v[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?)$ || "${api_container_image}" =~ ^ghcr\.io/identrail/identrail-api@sha256:[0-9a-f]{64}$ ]]; then
+  fail "API_CONTAINER_IMAGE must be an immutable ghcr.io/identrail/identrail-api image, such as ghcr.io/identrail/identrail-api:sha-<commit>"
+fi
+
+api_database_secret="$(require_value API_DATABASE_URL_SECRET_ARN)"
+api_session_secret="$(require_value API_SESSION_KEY_SECRET_ARN)"
+for secret_arn in "${api_database_secret}" "${api_session_secret}"; do
+  if ! [[ "${secret_arn}" =~ ^arn:(aws|aws-us-gov|aws-cn):secretsmanager:${aws_region}:[0-9]{12}:secret:.+ ]]; then
+    fail "API secret references must be Secrets Manager ARNs in ${aws_region}"
+  fi
+done
+
+public_subnets="$(json_string_array API_PUBLIC_SUBNET_IDS_JSON)"
+task_subnets="$(json_string_array API_TASK_SUBNET_IDS_JSON "${public_subnets}")"
+allowed_cidrs="$(json_string_array API_ALLOWED_CIDR_BLOCKS_JSON '["0.0.0.0/0"]')"
+cors_origins="$(json_string_array API_CORS_ALLOWED_ORIGINS_JSON '["https://app.identrail.com","https://identrail.com","https://www.identrail.com"]')"
+trusted_proxy_cidrs="$(json_string_array API_TRUSTED_PROXY_CIDR_BLOCKS_JSON '["10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"]')"
+connector_roles="$(json_string_array API_CONNECTOR_ROLE_ARNS_JSON '[]')"
+secret_kms_keys="$(json_string_array API_SECRET_KMS_KEY_ARNS_JSON '[]')"
+extra_environment="$(json_string_map API_EXTRA_ENVIRONMENT_JSON)"
+extra_secrets="$(json_string_map API_EXTRA_SECRETS_JSON)"
+
+api_desired_count="$(trim "${API_DESIRED_COUNT:-1}")"
+api_task_cpu="$(trim "${API_TASK_CPU:-512}")"
+api_task_memory="$(trim "${API_TASK_MEMORY:-1024}")"
+for numeric in api_desired_count api_task_cpu api_task_memory; do
+  if ! [[ "${!numeric}" =~ ^[0-9]+$ ]]; then
+    fail "${numeric^^} must be a positive integer"
+  fi
+done
+
+tfvars_path="$(trim "${OUTPUT_TFVARS_PATH:-${RUNNER_TEMP:-/tmp}/identrail-api.auto.tfvars.json}")"
+backend_config_path="$(trim "${OUTPUT_BACKEND_CONFIG_PATH:-${RUNNER_TEMP:-/tmp}/identrail-api.backend.hcl}")"
+mkdir -p "$(dirname "${tfvars_path}")" "$(dirname "${backend_config_path}")"
+
+jq -n \
+  --arg aws_region "${aws_region}" \
+  --arg api_vpc_id "${api_vpc_id}" \
+  --arg api_certificate_arn "${api_certificate_arn}" \
+  --arg api_container_image "${api_container_image}" \
+  --arg api_database_secret "${api_database_secret}" \
+  --arg api_session_secret "${api_session_secret}" \
+  --argjson api_public_subnet_ids "${public_subnets}" \
+  --argjson api_task_subnet_ids "${task_subnets}" \
+  --argjson api_allowed_cidr_blocks "${allowed_cidrs}" \
+  --argjson api_cors_allowed_origins "${cors_origins}" \
+  --argjson api_trusted_proxy_cidr_blocks "${trusted_proxy_cidrs}" \
+  --argjson api_connector_role_arns "${connector_roles}" \
+  --argjson api_secret_kms_key_arns "${secret_kms_keys}" \
+  --argjson extra_environment "${extra_environment}" \
+  --argjson extra_secrets "${extra_secrets}" \
+  --argjson api_desired_count "${api_desired_count}" \
+  --argjson api_task_cpu "${api_task_cpu}" \
+  --argjson api_task_memory "${api_task_memory}" \
+  '{
+    aws_region: $aws_region,
+    environment: "dev",
+    name_prefix: "identrail",
+    create_foundation_resources: true,
+    create_api_hosting_resources: true,
+    create_runtime_secret: true,
+    api_vpc_id: $api_vpc_id,
+    api_public_subnet_ids: $api_public_subnet_ids,
+    api_task_subnet_ids: $api_task_subnet_ids,
+    api_task_assign_public_ip: true,
+    api_private_subnet_egress_ready: false,
+    api_allowed_cidr_blocks: $api_allowed_cidr_blocks,
+    api_cors_allowed_origins: $api_cors_allowed_origins,
+    api_trusted_proxy_cidr_blocks: $api_trusted_proxy_cidr_blocks,
+    api_certificate_arn: $api_certificate_arn,
+    api_container_image: $api_container_image,
+    api_desired_count: $api_desired_count,
+    api_task_cpu: $api_task_cpu,
+    api_task_memory: $api_task_memory,
+    api_environment_variables: ($extra_environment + {
+      IDENTRAIL_FEATURE_NEW_AUTH: "true",
+      IDENTRAIL_PUBLIC_BASE_URL: "https://api.identrail.com"
+    }),
+    api_secrets: ($extra_secrets + {
+      IDENTRAIL_DATABASE_URL: $api_database_secret,
+      IDENTRAIL_SESSION_KEY: $api_session_secret
+    }),
+    api_secret_kms_key_arns: $api_secret_kms_key_arns,
+    api_connector_role_arns: $api_connector_role_arns,
+    tags: {
+      Project: "identrail",
+      Stage: "auth-rollout",
+      ManagedBy: "github-actions"
+    }
+  }' > "${tfvars_path}"
+
+cat > "${backend_config_path}" <<EOF
+bucket = "${state_bucket}"
+key    = "${state_key}"
+region = "${aws_region}"
+encrypt = true
+EOF
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  {
+    echo "tfvars_path=${tfvars_path}"
+    echo "backend_config_path=${backend_config_path}"
+    echo "state_key=${state_key}"
+  } >> "${GITHUB_OUTPUT}"
+fi
+
+echo "Prepared Terraform inputs for ${operation}."
+echo "Terraform state: s3://${state_bucket}/${state_key}"


### PR DESCRIPTION
## Summary

Adds a guarded manual GitHub Actions workflow for the pre-PR 11 AWS API cutover path.

## Why

The hosted web app cannot complete sign-in/sign-up until `api.identrail.com` points at a real API. We should not auto-create paid AWS infrastructure on every merge, and we also should not run Terraform applies from a laptop with disposable local state. This PR adds the controlled middle step: a manual workflow that plans by default, uses the existing GitHub OIDC AWS role, persists Terraform state in S3, and only applies after an explicit confirmation string.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

What changed:

- Added `AWS API Manual Deploy` workflow.
- Added `scripts/prepare_aws_api_deploy.sh` to validate operator inputs and generate Terraform var/backend config files.
- Kept the checked-in Terraform root backendless for normal validation-only CI.
- The workflow injects a temporary S3 backend only during manual deploy runs.
- The workflow requires immutable `ghcr.io/identrail/identrail-api` image tags, Secrets Manager ARN references, the `dev` branch, and `apply-api.identrail.com` confirmation for applies.
- Updated AWS API hosting docs, deploy runbook, Terraform README, and changelog.

Impact and risk:

- No automatic AWS resources are created by this PR.
- Existing Terraform validation and plan flows remain backendless and cost-safe.
- Applies are manual, auditable, OIDC-based, and stateful through S3.
- The workflow continues to use the low-cost public-task bootstrap path to avoid NAT Gateway costs for the first cutover.

## Validation

```bash
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/aws-api-manual-deploy.yml"); puts "workflow yaml parsed"'
bash -n scripts/prepare_aws_api_deploy.sh
scripts/prepare_aws_api_deploy.sh # with placeholder AWS/Terraform/API inputs
terraform fmt -check -recursive deploy/aws/terraform
terraform -chdir=deploy/aws/terraform init -backend=false
terraform -chdir=deploy/aws/terraform validate
terraform -chdir=deploy/aws/terraform plan -refresh=false -input=false -var-file=environments/dev/terraform.tfvars.example
git diff --check
```

Results: all passed. The placeholder script run generated the expected low-cost API tfvars and S3 backend config. The existing validation-only Terraform plan still works without a backend.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: yes
- Tools used: Codex
- Areas where used: GitHub Actions workflow, deployment input preparation script, AWS API hosting docs
- Human verification performed: reviewed the generated workflow/script for secret handling and ran the validation commands listed above

## Related Issues

No issue: pre-PR 11 deployment-readiness step required before the hosted auth flow can use `api.identrail.com`; no standalone tracking issue exists for this operator workflow.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a guarded manual GitHub Actions workflow to plan/apply the AWS API stack using Terraform with GitHub OIDC and S3-backed state. Enables a safe, auditable pre-PR 11 cutover so `api.identrail.com` can serve the hosted web app.

- **New Features**
  - New `AWS API Manual Deploy` workflow (manual `plan` or `apply`; `apply` requires typing `apply-api.identrail.com`).
  - Runs only from `dev`, assumes the AWS role via OIDC, and requires an immutable `ghcr.io/identrail/identrail-api` image tag.
  - Injects an S3 backend at runtime; Terraform in-repo stays backendless for cost-safe validation.
  - Adds `scripts/prepare_aws_api_deploy.sh` to validate inputs and generate tfvars/backend config.
  - Defaults to the low-cost public-task bootstrap mode; no resources created unless `apply`.
  - Updates AWS hosting docs, deploy runbook, Terraform README, and changelog.

<sup>Written for commit cf436c237a5913bf1501950537398e60fdddeed5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

