### PR TITLE
Route WorkOS social sign-ins directly

### DIFF
--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -562,6 +562,13 @@ paths:
           required: false
           schema:
             type: string
+        - in: query
+          name: provider
+          required: false
+          description: Optional hosted provider selector. Defaults to AuthKit when omitted.
+          schema:
+            type: string
+            enum: [authkit, google_oauth, github_oauth]
       responses:
         "302":
           description: Redirect to WorkOS AuthKit
@@ -579,6 +586,13 @@ paths:
           required: false
           schema:
             type: string
+        - in: query
+          name: provider
+          required: false
+          description: Optional hosted provider selector. Defaults to AuthKit when omitted.
+          schema:
+            type: string
+            enum: [authkit, google_oauth, github_oauth]
       responses:
         "302":
           description: Redirect to WorkOS AuthKit sign-up screen

--- a/internal/api/auth/workos.go
+++ b/internal/api/auth/workos.go
@@ -18,6 +18,7 @@ type WorkOSAuthorizationRequest struct {
 	RedirectURI string
 	State       string
 	ScreenHint  string
+	Provider    string
 }
 
 type WorkOSAuthenticationRequest struct {
@@ -67,8 +68,11 @@ func (c *WorkOSSDKClient) AuthorizationURL(input WorkOSAuthorizationRequest) (st
 	opts := usermanagement.GetAuthorizationURLOpts{
 		ClientID:    c.clientID,
 		RedirectURI: strings.TrimSpace(input.RedirectURI),
-		Provider:    "authkit",
+		Provider:    strings.TrimSpace(input.Provider),
 		State:       strings.TrimSpace(input.State),
+	}
+	if opts.Provider == "" {
+		opts.Provider = "authkit"
 	}
 	if strings.EqualFold(strings.TrimSpace(input.ScreenHint), "sign-up") {
 		opts.ScreenHint = usermanagement.SignUp

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -99,6 +99,11 @@ func workOSStartHandler(logger *zap.Logger, svc *Service, opts authSessionRouteO
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "auth service unavailable"})
 			return
 		}
+		provider, ok := workOSProviderFromPublicID(c.Query("provider"))
+		if !ok {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "unsupported auth provider"})
+			return
+		}
 		returnTo := sanitizeAuthReturnTo(c.Query("return_to"), opts.ReturnToOrigins)
 		state, err := opts.StateManager.Issue(intent, returnTo)
 		if err != nil {
@@ -119,6 +124,7 @@ func workOSStartHandler(logger *zap.Logger, svc *Service, opts authSessionRouteO
 			RedirectURI: workOSCallbackURL(opts.PublicBaseURL),
 			State:       state,
 			ScreenHint:  screenHint,
+			Provider:    provider,
 		})
 		if err != nil {
 			auditAuthAction(c.Request.Context(), "auth.login.failure", "", "denied")
@@ -130,6 +136,19 @@ func workOSStartHandler(logger *zap.Logger, svc *Service, opts authSessionRouteO
 			return
 		}
 		c.Redirect(http.StatusFound, authorizationURL)
+	}
+}
+
+func workOSProviderFromPublicID(provider string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "", "authkit":
+		return "authkit", true
+	case "google_oauth":
+		return "GoogleOAuth", true
+	case "github_oauth":
+		return "GitHubOAuth", true
+	default:
+		return "", false
 	}
 }
 

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -116,7 +116,9 @@ func workOSStartHandler(logger *zap.Logger, svc *Service, opts authSessionRouteO
 		screenHint := ""
 		action := "auth.login.start"
 		if intent == "signup" {
-			screenHint = "sign-up"
+			if provider == "authkit" {
+				screenHint = "sign-up"
+			}
 			action = "auth.signup"
 		}
 		auditAuthAction(c.Request.Context(), action, "", "success")

--- a/internal/api/workos_auth_routes_test.go
+++ b/internal/api/workos_auth_routes_test.go
@@ -161,6 +161,48 @@ func TestWorkOSStartRoutesConfiguredSocialProviders(t *testing.T) {
 	}
 }
 
+func TestWorkOSSignupOnlySendsScreenHintForAuthKit(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		provider       string
+		wantProvider   string
+		wantScreenHint string
+	}{
+		{name: "google", provider: "google_oauth", wantProvider: "GoogleOAuth"},
+		{name: "github", provider: "github_oauth", wantProvider: "GitHubOAuth"},
+		{name: "authkit", provider: "authkit", wantProvider: "authkit", wantScreenHint: "sign-up"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := db.NewMemoryStore()
+			svc := NewService(store, fakeScanner{}, "aws")
+			workOS := &fakeWorkOSClient{}
+			router := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{
+				FeatureNewAuth:      true,
+				FeatureWorkOSLogin:  true,
+				PublicBaseURL:       "https://app.identrail.test",
+				SessionKey:          strings.Repeat("a", 64),
+				WorkOSClientID:      "client_123",
+				WorkOSWebhookSecret: "whsec_123",
+				WorkOSAuthClient:    workOS,
+				RateLimitRPM:        1000,
+				RateLimitBurst:      1000,
+			})
+
+			resp := httptest.NewRecorder()
+			router.ServeHTTP(resp, httptest.NewRequest(http.MethodGet, "/auth/signup?provider="+tc.provider, nil))
+			if resp.Code != http.StatusFound {
+				t.Fatalf("expected signup redirect, got %d body=%s", resp.Code, resp.Body.String())
+			}
+			if workOS.authorizationInput.Provider != tc.wantProvider {
+				t.Fatalf("expected provider %q, got %q", tc.wantProvider, workOS.authorizationInput.Provider)
+			}
+			if workOS.authorizationInput.ScreenHint != tc.wantScreenHint {
+				t.Fatalf("expected screen hint %q, got %q", tc.wantScreenHint, workOS.authorizationInput.ScreenHint)
+			}
+		})
+	}
+}
+
 func TestWorkOSStartRejectsUnsupportedProvider(t *testing.T) {
 	store := db.NewMemoryStore()
 	svc := NewService(store, fakeScanner{}, "aws")

--- a/internal/api/workos_auth_routes_test.go
+++ b/internal/api/workos_auth_routes_test.go
@@ -37,6 +37,9 @@ func (f *fakeWorkOSClient) AuthorizationURL(input sessionauth.WorkOSAuthorizatio
 	if input.ScreenHint != "" {
 		values.Set("screen_hint", input.ScreenHint)
 	}
+	if input.Provider != "" {
+		values.Set("provider", input.Provider)
+	}
 	return "https://authkit.example/authorize?" + values.Encode(), nil
 }
 
@@ -91,6 +94,9 @@ func TestWorkOSHostedLoginCreatesSessionAndIdentity(t *testing.T) {
 	if workOS.authorizationInput.RedirectURI != "https://app.identrail.test/auth/callback" {
 		t.Fatalf("unexpected callback url: %q", workOS.authorizationInput.RedirectURI)
 	}
+	if workOS.authorizationInput.Provider != "authkit" {
+		t.Fatalf("expected default authkit provider, got %q", workOS.authorizationInput.Provider)
+	}
 
 	callbackReq := httptest.NewRequest(http.MethodGet, "/auth/callback?code=code-1&state="+url.QueryEscape(workOS.authorizationInput.State), nil)
 	callbackResp := httptest.NewRecorder()
@@ -114,6 +120,66 @@ func TestWorkOSHostedLoginCreatesSessionAndIdentity(t *testing.T) {
 	}
 	if user.PrimaryEmail != "new@example.com" || user.DisplayName != "New User" {
 		t.Fatalf("unexpected user: %+v", user)
+	}
+}
+
+func TestWorkOSStartRoutesConfiguredSocialProviders(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		provider string
+		want     string
+	}{
+		{name: "google", provider: "google_oauth", want: "GoogleOAuth"},
+		{name: "github", provider: "github_oauth", want: "GitHubOAuth"},
+		{name: "authkit", provider: "authkit", want: "authkit"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := db.NewMemoryStore()
+			svc := NewService(store, fakeScanner{}, "aws")
+			workOS := &fakeWorkOSClient{}
+			router := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{
+				FeatureNewAuth:      true,
+				FeatureWorkOSLogin:  true,
+				PublicBaseURL:       "https://app.identrail.test",
+				SessionKey:          strings.Repeat("a", 64),
+				WorkOSClientID:      "client_123",
+				WorkOSWebhookSecret: "whsec_123",
+				WorkOSAuthClient:    workOS,
+				RateLimitRPM:        1000,
+				RateLimitBurst:      1000,
+			})
+
+			resp := httptest.NewRecorder()
+			router.ServeHTTP(resp, httptest.NewRequest(http.MethodGet, "/auth/login?provider="+tc.provider, nil))
+			if resp.Code != http.StatusFound {
+				t.Fatalf("expected login redirect, got %d body=%s", resp.Code, resp.Body.String())
+			}
+			if workOS.authorizationInput.Provider != tc.want {
+				t.Fatalf("expected provider %q, got %q", tc.want, workOS.authorizationInput.Provider)
+			}
+		})
+	}
+}
+
+func TestWorkOSStartRejectsUnsupportedProvider(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	router := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{
+		FeatureNewAuth:      true,
+		FeatureWorkOSLogin:  true,
+		PublicBaseURL:       "https://app.identrail.test",
+		SessionKey:          strings.Repeat("a", 64),
+		WorkOSClientID:      "client_123",
+		WorkOSWebhookSecret: "whsec_123",
+		WorkOSAuthClient:    &fakeWorkOSClient{},
+		RateLimitRPM:        1000,
+		RateLimitBurst:      1000,
+	})
+
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, httptest.NewRequest(http.MethodGet, "/auth/login?provider=apple_oauth", nil))
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected unsupported provider 400, got %d body=%s", resp.Code, resp.Body.String())
 	}
 }
 

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -230,7 +230,7 @@ describe('App', () => {
     expect(hostedSignIn).toBeInTheDocument();
     expect(hostedSignIn).toHaveAttribute(
       'href',
-      `http://localhost:8080/auth/login?return_to=${encodeURIComponent(`${window.location.origin}/app/team/workspace`)}`
+      `http://localhost:8080/auth/login?return_to=${encodeURIComponent(`${window.location.origin}/app/team/workspace`)}&provider=google_oauth`
     );
   });
 

--- a/web/src/pages/SignInPage.tsx
+++ b/web/src/pages/SignInPage.tsx
@@ -52,10 +52,11 @@ function authConfigErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : 'Unable to load authentication options.';
 }
 
-function workOSURL(intent: AuthIntent, returnTo: string): string {
+function workOSURL(intent: AuthIntent, returnTo: string, provider: HostedProvider): string {
   const query = new URLSearchParams();
   const webReturnTo = typeof window === 'undefined' ? returnTo : new URL(returnTo, window.location.origin).toString();
   query.set('return_to', webReturnTo);
+  query.set('provider', provider.id);
   return buildAPIURL(`/auth/${intent === 'signup' ? 'signup' : 'login'}?${query.toString()}`);
 }
 
@@ -188,7 +189,7 @@ export function AuthChoicePage({ intent }: AuthChoicePageProps) {
                 className={`idt-auth-provider ${
                   intent === 'signup' && provider.signUpTone === 'dark' ? 'idt-auth-provider-dark' : ''
                 }`}
-                href={workOSURL(intent, returnTo)}
+                href={workOSURL(intent, returnTo, provider)}
               >
                 {providerIcon(provider)}
                 <span>{provider.label}</span>


### PR DESCRIPTION
Fixes #1125

## Summary
- route hosted auth buttons through explicit WorkOS provider selectors for Google, GitHub, and AuthKit
- keep `/auth/login` and `/auth/signup` backward compatible by defaulting omitted providers to AuthKit
- document the optional `provider` query parameter in the OpenAPI contract

## Why
Google and GitHub are now configured in WorkOS Production. This makes the product experience cleaner: choosing Google starts Google through WorkOS, choosing GitHub starts GitHub through WorkOS, and enterprise SSO still uses AuthKit.

## Validation
- `go test ./internal/api ./internal/api/auth`
- `npm test --prefix web -- --run App.test.tsx`
- `npm run build --prefix web`
- `git diff --check`
