### PR TITLE
Add patch-template engine for top-5 high-volume finding types (ITR-032)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,142 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Prerequisites
+
+- Go `1.25.9` (see `go.mod`)
+- Node.js `24` for `web/`
+- Docker + Docker Compose for local stack and integration tests
+- PostgreSQL (or Docker) for integration tests
+
+## Commands
+
+**Bootstrap:**
+```bash
+make bootstrap  # go mod download + npm ci --prefix web
+```
+
+**Go tests:**
+```bash
+make test                          # all unit tests with coverage
+go test ./internal/<pkg> -run TestName -v  # single test
+make test-integration              # requires local Postgres
+```
+
+Integration tests require the env var:
+```
+IDENTRAIL_INTEGRATION_DATABASE_URL='postgres://identrail:secret@127.0.0.1:5432/identrail?sslmode=disable'
+```
+
+**Formatting and static checks:**
+```bash
+make fmt        # gofmt -w on all tracked .go files
+make fmt-check  # CI-mode check (no writes)
+make vet        # go vet ./...
+```
+
+**Web:**
+```bash
+npm run dev --prefix web       # dev server
+npm run test:ci --prefix web   # CI test run with coverage
+npm run build --prefix web     # production build
+```
+
+**CLI smoke test:**
+```bash
+state_file="/tmp/identrail-smoke-state.json"
+go run ./cmd/cli --state-file "${state_file}" scan \
+  --fixture testdata/aws/role_with_policies.json \
+  --fixture testdata/aws/role_with_urlencoded_trust.json \
+  --output table
+go run ./cmd/cli --state-file "${state_file}" findings --output json
+```
+
+**Full local CI:**
+```bash
+make ci   # fmt-check + vet + test + contract checks + web test + web build
+```
+
+**Local Docker stack:**
+```bash
+make quickstart       # boots API, worker, web, Postgres; triggers initial scan
+make quickstart-down  # tears it down
+```
+
+## Architecture
+
+Identrail is a **modular monolith** for machine identity security across AWS and Kubernetes.
+
+### Data Flow
+
+```
+Collector → Raw Assets → Normalizer → Domain Entities
+                |                          |
+                v                          v
+           Raw Storage               Graph Builder
+                                          |
+                                          v
+                                   Risk Rule Engine
+                                          |
+                                          v
+                              Findings Store → API / CLI / Web
+```
+
+### Runtime Processes (`cmd/`)
+
+| Process | Purpose |
+|---|---|
+| `cmd/server` | REST API — health, scans, findings endpoints |
+| `cmd/worker` | Scheduled scan executor |
+| `cmd/cli` | Operator-facing scanner and findings CLI |
+| `cmd/identrail-agent` | Agent entrypoint |
+
+### Key Internal Packages (`internal/`)
+
+- **`providers/`** — provider pipeline implementations. Each provider implements `Collector → Normalizer → RelationshipResolver → RiskRuleSet` interfaces defined in `providers/interfaces.go`. Current providers: `aws/`, `kubernetes/`.
+- **`app/`** — `Scanner`: the deterministic scan execution pipeline that orchestrates provider stages.
+- **`api/`** — `Service`: scan orchestration + persistence bridge.
+- **`db/`** — dual storage backends (`memory.go`, `postgres.go`) behind a single `store.go` interface. Memory mode is for testing/dev; Postgres is production.
+- **`domain/`** — core types (`Identity`, `Workload`, `Policy`, `Finding`, `Relationship`). Multi-tenant app-mode entities (`Organization`, `Workspace`, `Project`, `Connector`, `ScanPolicy`) are in `domain/appmode.go`.
+- **`connectors/`** — connector lifecycle framework (`lifecycle.go`) with provider hooks for `aws/`, `github/`, `kubernetes/`.
+- **`runtime/`** — shared service bootstrap used by server and worker.
+- **`scheduler/`** — idempotent scan orchestration.
+- **`repoexposure/`** — isolated git history + HEAD scanner for secrets and IaC/CI misconfigurations; results persist in separate repo scan tables.
+- **`telemetry/`** — structured logs (zap), Prometheus metrics, OTel tracing.
+
+### Tenancy Model
+
+`Organization → Workspace → Project → Connector`
+
+Connector credentials are never stored in plaintext; they use encrypted secret envelopes (`tenancy_connector_secret_envelopes`). Connector status transitions: `pending → active|degraded|disconnected`.
+
+### Database Migrations (`migrations/`)
+
+Versioned SQL files with matching `.up.sql` / `.down.sql`. Some numeric prefixes are intentionally duplicated (historical; do not reorder). Key rules:
+- Migrations run via a **one-shot migrator job** (`IDENTRAIL_RUN_MIGRATIONS_ONLY=true`).
+- API and worker processes run with `IDENTRAIL_RUN_MIGRATIONS=false`.
+- New migrations must be forward-safe and use `IF NOT EXISTS` where applicable.
+
+### Provider Contract
+
+All providers implement the interfaces in `internal/providers/interfaces.go`:
+- `Collector` — reads raw cloud/k8s assets.
+- `Normalizer` — converts raw assets into `NormalizedBundle` (Identities, Workloads, Policies).
+- `RelationshipResolver` — builds graph edges.
+- `RiskRuleSet` — evaluates deterministic risk rules, returns `[]domain.Finding`.
+
+Idempotency is a first-class requirement at every scan stage.
+
+### Web Frontend (`web/`)
+
+React + Vite + TypeScript. Static pre-rendering via `prerender.tsx`. API base URL configured via `VITE_IDENTRAIL_API_URL` (must not point at the web frontend — enforced by `make production-api-url-check`).
+
+## Development Conventions
+
+- Branch from `dev`. Naming: `fix/`, `feat/`, `docs/`, `chore/`.
+- PRs must link issues: `Fixes #NNN` or `Closes #NNN`.
+- Target `>= 80%` total Go test coverage.
+- AI-assisted contributions require disclosure in the PR description (see `CONTRIBUTING.md` for format).
+- Run `make fmt` before committing Go changes; CI enforces `make fmt-check`.
+- Commit messages: imperative tense, short subject (e.g. `enforce explicit read scope for oidc tokens`).
+- `CHANGELOG.md` must be updated for user-facing or operator-facing behavior changes.

--- a/internal/findings/standards/patches.go
+++ b/internal/findings/standards/patches.go
@@ -1,0 +1,324 @@
+package standards
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+// PatchTemplate is a preview-only, deterministic remediation suggestion for one finding type.
+// Direct commit to a default branch is out of scope; all templates are advisory.
+type PatchTemplate struct {
+	RuleID      domain.FindingType `json:"rule_id"`
+	Summary     string             `json:"summary"`
+	Steps       []string           `json:"steps"`
+	SafetyNotes []string           `json:"safety_notes"`
+	// Template is a policy/config fragment the operator can adapt and apply.
+	// Empty when no structured template applies to the finding type.
+	Template string `json:"template,omitempty"`
+}
+
+// SuggestPatch returns a deterministic, evidence-aware patch suggestion for a finding.
+// Returns false if no patch template is registered for the finding type.
+func SuggestPatch(finding domain.Finding) (PatchTemplate, bool) {
+	switch finding.Type {
+	case domain.FindingOverPrivileged:
+		return overprivilegedPatch(finding), true
+	case domain.FindingRiskyTrustPolicy:
+		return riskyTrustPatch(finding), true
+	case domain.FindingEscalationPath:
+		return escalationPatch(finding), true
+	case domain.FindingStaleIdentity:
+		return staleIdentityPatch(finding), true
+	case domain.FindingOwnerless:
+		return ownerlessPatch(finding), true
+	}
+	return PatchTemplate{}, false
+}
+
+func overprivilegedPatch(finding domain.Finding) PatchTemplate {
+	arn := stringEvidence(finding.Evidence, "identity_arn")
+	displayARN := arn
+	if displayARN == "" {
+		displayARN = "the identity"
+	}
+	return PatchTemplate{
+		RuleID:  domain.FindingOverPrivileged,
+		Summary: "Replace broad permissions with a least-privilege inline policy.",
+		Steps: []string{
+			fmt.Sprintf("Review the 'permissions' evidence for %s to identify overly broad actions.", displayARN),
+			"Create a scoped IAM inline policy granting only the required actions on specific resource ARNs.",
+			"Attach the scoped policy and detach or restrict the existing broad policy.",
+			"Validate workload behavior in a non-production environment before applying to production.",
+			"Verify with iam:SimulatePrincipalPolicy that the workload retains necessary access.",
+		},
+		SafetyNotes: []string{
+			"Confirm the workload's required actions before narrowing scope.",
+			"Prefer resource-level ARN constraints over wildcard resource grants.",
+			"Test in a non-production environment before applying changes to production.",
+		},
+		Template: scopedInlinePolicyJSON(arn),
+	}
+}
+
+func riskyTrustPatch(finding domain.Finding) PatchTemplate {
+	arn := stringEvidence(finding.Evidence, "identity_arn")
+	principals := stringsEvidence(finding.Evidence, "risky_principals")
+	accountID := stringEvidence(finding.Evidence, "target_account_id")
+	displayARN := arn
+	if displayARN == "" {
+		displayARN = "the role"
+	}
+	return PatchTemplate{
+		RuleID:  domain.FindingRiskyTrustPolicy,
+		Summary: "Restrict trust policy to explicit, scoped principals with condition guards.",
+		Steps: []string{
+			fmt.Sprintf("Identify the risky principals for %s: %s.", displayARN, joinOrUnknown(principals)),
+			"Replace wildcard or cross-account principals with explicit, approved principal ARNs.",
+			"Add a Condition block using aws:PrincipalAccount or aws:PrincipalArn to constrain who can assume the role.",
+			"Test assume-role from each legitimate caller to confirm access is not broken.",
+			"Revoke trust from any principal not in the approved list.",
+		},
+		SafetyNotes: []string{
+			"Verify all legitimate assume-role callers are listed before restricting trust.",
+			"Use aws:PrincipalAccount conditions rather than account-level wildcards.",
+			"Run iam:SimulatePrincipalPolicy after the change to confirm expected access.",
+		},
+		Template: scopedTrustPolicyJSON(arn, accountID),
+	}
+}
+
+func escalationPatch(finding domain.Finding) PatchTemplate {
+	arn := stringEvidence(finding.Evidence, "identity_arn")
+	action := stringEvidence(finding.Evidence, "escalation_action")
+	resource := stringEvidence(finding.Evidence, "resource")
+	displayARN := arn
+	if displayARN == "" {
+		displayARN = "the identity"
+	}
+	displayAction := action
+	if displayAction == "" {
+		displayAction = "the escalation action"
+	}
+	displayResource := resource
+	if displayResource == "" {
+		displayResource = "the target resource"
+	}
+	return PatchTemplate{
+		RuleID:  domain.FindingEscalationPath,
+		Summary: "Remove or scope escalation-capable permissions to break the privilege escalation path.",
+		Steps: []string{
+			fmt.Sprintf("Locate the policy granting '%s' on '%s' for %s.", displayAction, displayResource, displayARN),
+			"Remove iam:CreatePolicyVersion, iam:SetDefaultPolicyVersion, iam:PassRole, and sts:AssumeRole wildcard grants.",
+			"If iam:PassRole is required, scope it to specific role ARNs using a Resource constraint.",
+			"Add an explicit Deny for escalation verbs if the policy is shared across multiple principals.",
+			"Use IAM Access Analyzer to verify no other path grants equivalent escalation capability.",
+		},
+		SafetyNotes: []string{
+			"Confirm no legitimate automation depends on the escalation-capable permission before removing it.",
+			"Use IAM Access Analyzer to identify all paths that could still reach equivalent privilege.",
+			"Prefer an explicit Deny for escalation verbs over removal alone when policies are shared.",
+		},
+		Template: escalationDenyPolicyJSON(arn),
+	}
+}
+
+func staleIdentityPatch(finding domain.Finding) PatchTemplate {
+	arn := stringEvidence(finding.Evidence, "identity_arn")
+	ref := stringEvidence(finding.Evidence, "reference_timestamp")
+	displayARN := arn
+	if displayARN == "" {
+		displayARN = "the identity"
+	}
+	displayRef := ref
+	if displayRef == "" {
+		displayRef = "the reference timestamp in the finding evidence"
+	}
+	return PatchTemplate{
+		RuleID:  domain.FindingStaleIdentity,
+		Summary: "Disable then delete the stale identity after confirming no active dependency.",
+		Steps: []string{
+			fmt.Sprintf("Confirm %s has had no CloudTrail activity since %s.", displayARN, displayRef),
+			"Disable all access keys: aws iam update-access-key --access-key-id <KEY_ID> --status Inactive --user-name <USER>",
+			"Remove the console login profile if present: aws iam delete-login-profile --user-name <USER>",
+			"Wait 30 days with keys disabled. If no objections, delete the access keys and the identity.",
+			"For roles: remove all trust policy principals and tag with 'decommission-pending' before deletion.",
+		},
+		SafetyNotes: []string{
+			"Check CloudTrail for any recent API calls made under this identity before disabling.",
+			"Disable before deleting — deletion cannot be reversed.",
+			"Notify the team owner before proceeding if the identity carries an owner tag.",
+		},
+		Template: "",
+	}
+}
+
+func ownerlessPatch(finding domain.Finding) PatchTemplate {
+	arn := stringEvidence(finding.Evidence, "identity_arn")
+	displayARN := arn
+	if displayARN == "" {
+		displayARN = "the identity"
+	}
+	return PatchTemplate{
+		RuleID:  domain.FindingOwnerless,
+		Summary: "Assign an owner via tags (AWS) or labels (Kubernetes) and register in the ownership registry.",
+		Steps: []string{
+			fmt.Sprintf("Identify the team responsible for %s via git history, cost allocation tags, or service catalog.", displayARN),
+			"Apply the owner tag or label from the template below.",
+			"Register the owner mapping in the centralized ownership registry.",
+			"Enforce owner-label presence in CI policy for future identity creation.",
+		},
+		SafetyNotes: []string{
+			"Confirm the correct owner before tagging — incorrect ownership causes mis-routing during incidents.",
+		},
+		Template: ownerTagTemplate(arn),
+	}
+}
+
+// --- template generators ---
+
+func scopedInlinePolicyJSON(arn string) string {
+	comment := "Replace wildcard actions with the minimum required set."
+	if arn != "" {
+		comment = fmt.Sprintf("Scoped inline policy for %s — replace placeholders with required actions and resource ARNs.", arn)
+	}
+	doc := map[string]any{
+		"_note":   comment,
+		"Version": "2012-10-17",
+		"Statement": []map[string]any{
+			{
+				"Effect":   "Allow",
+				"Action":   []string{"<service>:<RequiredAction>"},
+				"Resource": []string{"arn:aws:<service>:<region>:<account-id>:<resource-type>/<resource-name>"},
+			},
+		},
+	}
+	return mustJSON(doc)
+}
+
+func scopedTrustPolicyJSON(arn, accountID string) string {
+	if accountID == "" {
+		accountID = "<account-id>"
+	}
+	comment := "Replace wildcard trust with explicit approved principal ARNs."
+	if arn != "" {
+		comment = fmt.Sprintf("Scoped trust policy for %s — replace <approved-role> with the explicit caller ARN.", arn)
+	}
+	doc := map[string]any{
+		"_note":   comment,
+		"Version": "2012-10-17",
+		"Statement": []map[string]any{
+			{
+				"Effect": "Allow",
+				"Principal": map[string]any{
+					"AWS": []string{fmt.Sprintf("arn:aws:iam::%s:role/<approved-role>", accountID)},
+				},
+				"Action": "sts:AssumeRole",
+				"Condition": map[string]any{
+					"StringEquals": map[string]any{
+						"aws:PrincipalAccount": accountID,
+					},
+				},
+			},
+		},
+	}
+	return mustJSON(doc)
+}
+
+func escalationDenyPolicyJSON(arn string) string {
+	comment := "Deny escalation-capable actions unless explicitly authorized."
+	if arn != "" {
+		comment = fmt.Sprintf("Deny escalation-capable actions for %s — replace <approved-account-id> with your account.", arn)
+	}
+	doc := map[string]any{
+		"_note":   comment,
+		"Version": "2012-10-17",
+		"Statement": []map[string]any{
+			{
+				"Effect": "Deny",
+				"Action": []string{
+					"iam:CreatePolicyVersion",
+					"iam:SetDefaultPolicyVersion",
+					"iam:PassRole",
+					"sts:AssumeRole",
+				},
+				"Resource": "*",
+				"Condition": map[string]any{
+					"StringNotEquals": map[string]any{
+						"aws:ResourceAccount": "<approved-account-id>",
+					},
+				},
+			},
+		},
+	}
+	return mustJSON(doc)
+}
+
+func ownerTagTemplate(arn string) string {
+	arnLine := `"arn:aws:<service>:<region>:<account-id>:<resource-type>/<resource-name>"`
+	if arn != "" {
+		arnLine = fmt.Sprintf("%q", arn)
+	}
+	lines := []string{
+		"# AWS tag patch — apply owner tags to the identity:",
+		fmt.Sprintf(`aws resourcegroupstaggingapi tag-resources \`),
+		fmt.Sprintf(`  --resource-arn-list %s \`, arnLine),
+		`  --tags '{"owner":"<team-name>","env":"<environment>"}'`,
+		"",
+		"# Kubernetes label patch (if identity is a service account):",
+		"# kubectl label serviceaccount <name> -n <namespace> owner=<team-name> --overwrite",
+	}
+	return strings.Join(lines, "\n")
+}
+
+func mustJSON(v any) string {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+func stringEvidence(evidence map[string]any, key string) string {
+	if evidence == nil {
+		return ""
+	}
+	v, ok := evidence[key]
+	if !ok {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
+}
+
+func stringsEvidence(evidence map[string]any, key string) []string {
+	if evidence == nil {
+		return nil
+	}
+	v, ok := evidence[key]
+	if !ok {
+		return nil
+	}
+	switch t := v.(type) {
+	case []string:
+		return t
+	case []any:
+		out := make([]string, 0, len(t))
+		for _, item := range t {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+func joinOrUnknown(ss []string) string {
+	if len(ss) == 0 {
+		return "unknown"
+	}
+	return strings.Join(ss, ", ")
+}

--- a/internal/findings/standards/patches.go
+++ b/internal/findings/standards/patches.go
@@ -22,14 +22,25 @@ type PatchTemplate struct {
 
 // SuggestPatch returns a deterministic, evidence-aware patch suggestion for a finding.
 // Returns false if no patch template is registered for the finding type.
+//
+// For finding types emitted by multiple providers (overprivileged_identity,
+// escalation_path), the template is routed by provider so AWS findings receive
+// IAM guidance and Kubernetes findings receive RBAC guidance.
 func SuggestPatch(finding domain.Finding) (PatchTemplate, bool) {
+	provider := inferProvider(finding)
 	switch finding.Type {
 	case domain.FindingOverPrivileged:
-		return overprivilegedPatch(finding), true
+		if provider == "kubernetes" {
+			return overprivilegedKubernetesPatch(finding), true
+		}
+		return overprivilegedAWSPatch(finding), true
 	case domain.FindingRiskyTrustPolicy:
 		return riskyTrustPatch(finding), true
 	case domain.FindingEscalationPath:
-		return escalationPatch(finding), true
+		if provider == "kubernetes" {
+			return escalationKubernetesPatch(finding), true
+		}
+		return escalationAWSPatch(finding), true
 	case domain.FindingStaleIdentity:
 		return staleIdentityPatch(finding), true
 	case domain.FindingOwnerless:
@@ -38,7 +49,7 @@ func SuggestPatch(finding domain.Finding) (PatchTemplate, bool) {
 	return PatchTemplate{}, false
 }
 
-func overprivilegedPatch(finding domain.Finding) PatchTemplate {
+func overprivilegedAWSPatch(finding domain.Finding) PatchTemplate {
 	arn := stringEvidence(finding.Evidence, "identity_arn")
 	displayARN := arn
 	if displayARN == "" {
@@ -90,7 +101,7 @@ func riskyTrustPatch(finding domain.Finding) PatchTemplate {
 	}
 }
 
-func escalationPatch(finding domain.Finding) PatchTemplate {
+func escalationAWSPatch(finding domain.Finding) PatchTemplate {
 	arn := stringEvidence(finding.Evidence, "identity_arn")
 	action := stringEvidence(finding.Evidence, "escalation_action")
 	resource := stringEvidence(finding.Evidence, "resource")
@@ -122,6 +133,72 @@ func escalationPatch(finding domain.Finding) PatchTemplate {
 			"Prefer an explicit Deny for escalation verbs over removal alone when policies are shared.",
 		},
 		Template: escalationDenyPolicyJSON(arn),
+	}
+}
+
+func overprivilegedKubernetesPatch(finding domain.Finding) PatchTemplate {
+	identityID := stringEvidence(finding.Evidence, "identity_id")
+	displayID := identityID
+	if displayID == "" {
+		displayID = "the service account"
+	}
+	sample := sampleEvidence(finding.Evidence)
+	return PatchTemplate{
+		RuleID:  domain.FindingOverPrivileged,
+		Summary: "Replace broad ClusterRole/Role bindings with least-privilege RBAC scoped to required namespaces and verbs.",
+		Steps: []string{
+			fmt.Sprintf("Review the cluster bindings for %s and identify broad verbs or wildcard resources (e.g., %s).", displayID, sample),
+			"Define a namespaced Role (or ClusterRole if cluster-scoped resources are required) with only the verbs/resources the workload needs.",
+			"Replace the existing ClusterRoleBinding/RoleBinding with one that targets the scoped Role.",
+			"Audit with `kubectl auth can-i --list --as=system:serviceaccount:<namespace>:<name>` after the change.",
+			"Validate workload behavior in a non-production namespace before applying to production.",
+		},
+		SafetyNotes: []string{
+			"Confirm the workload's required verbs and resources before narrowing scope.",
+			"Prefer namespaced Role over ClusterRole when the workload only needs same-namespace access.",
+			"Avoid `verbs: [\"*\"]` and `resources: [\"*\"]` in the replacement Role.",
+		},
+		Template: scopedRBACYAML(identityID),
+	}
+}
+
+func escalationKubernetesPatch(finding domain.Finding) PatchTemplate {
+	identityID := stringEvidence(finding.Evidence, "identity_id")
+	workloadID := stringEvidence(finding.Evidence, "workload_id")
+	action := stringEvidence(finding.Evidence, "action")
+	resource := stringEvidence(finding.Evidence, "resource")
+	displayID := identityID
+	if displayID == "" {
+		displayID = "the service account"
+	}
+	displayWorkload := workloadID
+	if displayWorkload == "" {
+		displayWorkload = "the workload"
+	}
+	displayAction := action
+	if displayAction == "" {
+		displayAction = "the escalation verb"
+	}
+	displayResource := resource
+	if displayResource == "" {
+		displayResource = "the target resource"
+	}
+	return PatchTemplate{
+		RuleID:  domain.FindingEscalationPath,
+		Summary: "Break the RBAC escalation path by removing escalation verbs and isolating the workload to a dedicated service account.",
+		Steps: []string{
+			fmt.Sprintf("Locate the ClusterRole/Role granting '%s' on '%s' bound to %s via %s.", displayAction, displayResource, displayID, displayWorkload),
+			"Remove escalation verbs (`bind`, `escalate`, `impersonate`) and wildcard rules from the bound Role/ClusterRole.",
+			fmt.Sprintf("Create a dedicated service account for %s rather than sharing a broadly privileged one.", displayWorkload),
+			"Replace the binding to target the new dedicated service account with the minimum required Role.",
+			"Verify with `kubectl auth can-i bind clusterroles --as=system:serviceaccount:<namespace>:<name>` returns 'no' after the change.",
+		},
+		SafetyNotes: []string{
+			"Removing `bind`/`escalate` may break controllers that legitimately manage RBAC — confirm before applying.",
+			"Use audit logs to confirm no other workload depends on the same broadly privileged binding.",
+			"Prefer creating a new dedicated service account over editing a shared one in place.",
+		},
+		Template: rbacEscalationFixYAML(identityID),
 	}
 }
 
@@ -256,6 +333,79 @@ func escalationDenyPolicyJSON(arn string) string {
 	return mustJSON(doc)
 }
 
+func scopedRBACYAML(identityID string) string {
+	displayID := identityID
+	if displayID == "" {
+		displayID = "<service-account-name>"
+	}
+	return strings.Join([]string{
+		fmt.Sprintf("# Scoped Role for %s — replace placeholders with the minimum required verbs/resources.", displayID),
+		"apiVersion: rbac.authorization.k8s.io/v1",
+		"kind: Role",
+		"metadata:",
+		"  name: <scoped-role-name>",
+		"  namespace: <namespace>",
+		"rules:",
+		"  - apiGroups: [\"\"]",
+		"    resources: [\"<resource-type>\"]",
+		"    verbs: [\"get\", \"list\", \"watch\"]",
+		"---",
+		"apiVersion: rbac.authorization.k8s.io/v1",
+		"kind: RoleBinding",
+		"metadata:",
+		"  name: <scoped-binding-name>",
+		"  namespace: <namespace>",
+		"subjects:",
+		"  - kind: ServiceAccount",
+		"    name: <service-account-name>",
+		"    namespace: <namespace>",
+		"roleRef:",
+		"  kind: Role",
+		"  name: <scoped-role-name>",
+		"  apiGroup: rbac.authorization.k8s.io",
+	}, "\n")
+}
+
+func rbacEscalationFixYAML(identityID string) string {
+	displayID := identityID
+	if displayID == "" {
+		displayID = "<workload-service-account>"
+	}
+	return strings.Join([]string{
+		fmt.Sprintf("# Dedicated service account for %s — replace placeholders for your workload.", displayID),
+		"apiVersion: v1",
+		"kind: ServiceAccount",
+		"metadata:",
+		"  name: <workload-service-account>",
+		"  namespace: <namespace>",
+		"---",
+		"# Minimal Role without bind/escalate/impersonate verbs.",
+		"apiVersion: rbac.authorization.k8s.io/v1",
+		"kind: Role",
+		"metadata:",
+		"  name: <workload-role>",
+		"  namespace: <namespace>",
+		"rules:",
+		"  - apiGroups: [\"\"]",
+		"    resources: [\"<resource-type>\"]",
+		"    verbs: [\"get\", \"list\"]",
+		"---",
+		"apiVersion: rbac.authorization.k8s.io/v1",
+		"kind: RoleBinding",
+		"metadata:",
+		"  name: <workload-binding>",
+		"  namespace: <namespace>",
+		"subjects:",
+		"  - kind: ServiceAccount",
+		"    name: <workload-service-account>",
+		"    namespace: <namespace>",
+		"roleRef:",
+		"  kind: Role",
+		"  name: <workload-role>",
+		"  apiGroup: rbac.authorization.k8s.io",
+	}, "\n")
+}
+
 func ownerTagTemplate(arn string) string {
 	arnLine := `"arn:aws:<service>:<region>:<account-id>:<resource-type>/<resource-name>"`
 	if arn != "" {
@@ -314,6 +464,34 @@ func stringsEvidence(evidence map[string]any, key string) []string {
 		return out
 	}
 	return nil
+}
+
+// sampleEvidence renders the kubernetes overprivileged 'sample' evidence as a
+// human-readable "verb on resource" string, falling back to a placeholder when
+// the evidence is absent or malformed.
+func sampleEvidence(evidence map[string]any) string {
+	if evidence == nil {
+		return "wildcard verbs or resources"
+	}
+	raw, ok := evidence["sample"]
+	if !ok {
+		return "wildcard verbs or resources"
+	}
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return "wildcard verbs or resources"
+	}
+	action, _ := m["action"].(string)
+	resource, _ := m["resource"].(string)
+	switch {
+	case action != "" && resource != "":
+		return fmt.Sprintf("%s on %s", action, resource)
+	case action != "":
+		return action
+	case resource != "":
+		return resource
+	}
+	return "wildcard verbs or resources"
 }
 
 func joinOrUnknown(ss []string) string {

--- a/internal/findings/standards/patches_test.go
+++ b/internal/findings/standards/patches_test.go
@@ -1,6 +1,7 @@
 package standards
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -102,7 +103,7 @@ func TestSuggestPatch_EvidenceIncorporatedInSteps(t *testing.T) {
 	}
 }
 
-func TestSuggestPatch_PolicyTemplatesAreJSON(t *testing.T) {
+func TestSuggestPatch_AWSPolicyTemplatesAreValidJSON(t *testing.T) {
 	policyTypes := []domain.FindingType{
 		domain.FindingOverPrivileged,
 		domain.FindingRiskyTrustPolicy,
@@ -110,13 +111,19 @@ func TestSuggestPatch_PolicyTemplatesAreJSON(t *testing.T) {
 	}
 	for _, ft := range policyTypes {
 		t.Run(string(ft), func(t *testing.T) {
-			patch, _ := SuggestPatch(domain.Finding{Type: ft})
+			// Force AWS routing by adding an aws: path node.
+			patch, ok := SuggestPatch(domain.Finding{
+				Type: ft,
+				Path: []string{"aws:iam::123456789012:role/Example"},
+			})
+			if !ok {
+				t.Fatalf("expected patch for %s", ft)
+			}
 			if patch.Template == "" {
 				t.Fatalf("expected non-empty template for %s", ft)
 			}
-			trimmed := strings.TrimSpace(patch.Template)
-			if !strings.HasPrefix(trimmed, "{") {
-				t.Errorf("expected JSON template for %s, got prefix: %s", ft, trimmed[:min(60, len(trimmed))])
+			if !json.Valid([]byte(patch.Template)) {
+				t.Errorf("template for %s is not valid JSON:\n%s", ft, patch.Template)
 			}
 		})
 	}
@@ -152,5 +159,100 @@ func TestSuggestPatch_NoEvidenceProducesValidPatch(t *testing.T) {
 				t.Errorf("patch for %s has empty summary or steps with no evidence", ft)
 			}
 		})
+	}
+}
+
+func TestSuggestPatch_KubernetesOverprivilegedReturnsRBACTemplate(t *testing.T) {
+	patch, ok := SuggestPatch(domain.Finding{
+		Type: domain.FindingOverPrivileged,
+		Path: []string{"k8s:serviceaccount:default/worker", "k8s:role:cluster-admin"},
+		Evidence: map[string]any{
+			"identity_id": "k8s:serviceaccount:default/worker",
+			"sample": map[string]any{
+				"action":   "*",
+				"resource": "*",
+			},
+		},
+	})
+	if !ok {
+		t.Fatal("expected patch for k8s overprivileged")
+	}
+	if strings.Contains(patch.Template, "iam:") || strings.Contains(patch.Template, "aws:") {
+		t.Errorf("k8s overprivileged template must not contain IAM identifiers, got:\n%s", patch.Template)
+	}
+	if !strings.Contains(patch.Template, "rbac.authorization.k8s.io") {
+		t.Errorf("expected RBAC YAML template, got:\n%s", patch.Template)
+	}
+	hasRBACGuidance := false
+	for _, step := range patch.Steps {
+		if strings.Contains(step, "ClusterRole") || strings.Contains(step, "kubectl auth can-i") {
+			hasRBACGuidance = true
+			break
+		}
+	}
+	if !hasRBACGuidance {
+		t.Errorf("expected K8s RBAC guidance in steps, got: %v", patch.Steps)
+	}
+}
+
+func TestSuggestPatch_KubernetesEscalationReturnsRBACTemplate(t *testing.T) {
+	patch, ok := SuggestPatch(domain.Finding{
+		Type: domain.FindingEscalationPath,
+		Path: []string{"k8s:deployment:ns/web", "k8s:serviceaccount:ns/web", "k8s:clusterrole:admin"},
+		Evidence: map[string]any{
+			"workload_id": "k8s:deployment:ns/web",
+			"identity_id": "k8s:serviceaccount:ns/web",
+			"action":      "bind",
+			"resource":    "clusterroles",
+		},
+	})
+	if !ok {
+		t.Fatal("expected patch for k8s escalation")
+	}
+	for _, step := range patch.Steps {
+		if strings.Contains(step, "iam:PassRole") || strings.Contains(step, "IAM Access Analyzer") {
+			t.Errorf("k8s escalation steps leaked IAM guidance: %s", step)
+		}
+	}
+	if !strings.Contains(patch.Template, "rbac.authorization.k8s.io") {
+		t.Errorf("expected RBAC YAML template, got:\n%s", patch.Template)
+	}
+	foundRBACVerb := false
+	for _, step := range patch.Steps {
+		if strings.Contains(step, "bind") && strings.Contains(step, "clusterroles") {
+			foundRBACVerb = true
+			break
+		}
+	}
+	if !foundRBACVerb {
+		t.Errorf("expected RBAC verb/resource in steps, got: %v", patch.Steps)
+	}
+}
+
+func TestSuggestPatch_AWSEscalationKeepsIAMGuidance(t *testing.T) {
+	patch, ok := SuggestPatch(domain.Finding{
+		Type: domain.FindingEscalationPath,
+		Path: []string{"aws:iam::111111111111:role/AttackerRole", "aws:iam::222222222222:role/Target"},
+		Evidence: map[string]any{
+			"identity_arn":      "arn:aws:iam::222222222222:role/Target",
+			"escalation_action": "iam:PassRole",
+			"resource":          "*",
+		},
+	})
+	if !ok {
+		t.Fatal("expected patch for aws escalation")
+	}
+	if strings.Contains(patch.Template, "rbac.authorization.k8s.io") {
+		t.Errorf("aws escalation template leaked RBAC content:\n%s", patch.Template)
+	}
+	hasIAMGuidance := false
+	for _, step := range patch.Steps {
+		if strings.Contains(step, "iam:PassRole") {
+			hasIAMGuidance = true
+			break
+		}
+	}
+	if !hasIAMGuidance {
+		t.Errorf("expected IAM guidance in steps, got: %v", patch.Steps)
 	}
 }

--- a/internal/findings/standards/patches_test.go
+++ b/internal/findings/standards/patches_test.go
@@ -1,0 +1,156 @@
+package standards
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+func TestSuggestPatch_AllHighVolumeFindingTypes(t *testing.T) {
+	types := []domain.FindingType{
+		domain.FindingOverPrivileged,
+		domain.FindingRiskyTrustPolicy,
+		domain.FindingEscalationPath,
+		domain.FindingStaleIdentity,
+		domain.FindingOwnerless,
+	}
+	for _, ft := range types {
+		t.Run(string(ft), func(t *testing.T) {
+			patch, ok := SuggestPatch(domain.Finding{ID: "f1", Type: ft})
+			if !ok {
+				t.Fatalf("expected patch for %s, got none", ft)
+			}
+			if patch.RuleID != ft {
+				t.Errorf("rule_id: want %s, got %s", ft, patch.RuleID)
+			}
+			if patch.Summary == "" {
+				t.Error("expected non-empty summary")
+			}
+			if len(patch.Steps) == 0 {
+				t.Error("expected at least one remediation step")
+			}
+			if len(patch.SafetyNotes) == 0 {
+				t.Error("expected at least one safety note")
+			}
+		})
+	}
+}
+
+func TestSuggestPatch_UnregisteredTypeReturnsFalse(t *testing.T) {
+	_, ok := SuggestPatch(domain.Finding{Type: domain.FindingSecretExposure})
+	if ok {
+		t.Error("expected false for unregistered finding type")
+	}
+}
+
+func TestSuggestPatch_EvidenceIncorporatedInSteps(t *testing.T) {
+	cases := []struct {
+		findingType domain.FindingType
+		evidence    map[string]any
+		wantInStep  string
+	}{
+		{
+			findingType: domain.FindingOverPrivileged,
+			evidence:    map[string]any{"identity_arn": "arn:aws:iam::123456789012:role/WorkerRole"},
+			wantInStep:  "arn:aws:iam::123456789012:role/WorkerRole",
+		},
+		{
+			findingType: domain.FindingRiskyTrustPolicy,
+			evidence: map[string]any{
+				"identity_arn":     "arn:aws:iam::111111111111:role/CrossAccountRole",
+				"risky_principals": []string{"arn:aws:iam::*:root"},
+			},
+			wantInStep: "arn:aws:iam::*:root",
+		},
+		{
+			findingType: domain.FindingEscalationPath,
+			evidence: map[string]any{
+				"identity_arn":      "arn:aws:iam::222222222222:role/EscRole",
+				"escalation_action": "iam:PassRole",
+				"resource":          "*",
+			},
+			wantInStep: "iam:PassRole",
+		},
+		{
+			findingType: domain.FindingStaleIdentity,
+			evidence: map[string]any{
+				"identity_arn":        "arn:aws:iam::333333333333:user/old-svc",
+				"reference_timestamp": "2024-01-01T00:00:00Z",
+			},
+			wantInStep: "2024-01-01T00:00:00Z",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.findingType), func(t *testing.T) {
+			patch, ok := SuggestPatch(domain.Finding{Type: tc.findingType, Evidence: tc.evidence})
+			if !ok {
+				t.Fatalf("expected patch for %s", tc.findingType)
+			}
+			found := false
+			for _, step := range patch.Steps {
+				if strings.Contains(step, tc.wantInStep) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("expected %q to appear in steps for %s; got steps: %v", tc.wantInStep, tc.findingType, patch.Steps)
+			}
+		})
+	}
+}
+
+func TestSuggestPatch_PolicyTemplatesAreJSON(t *testing.T) {
+	policyTypes := []domain.FindingType{
+		domain.FindingOverPrivileged,
+		domain.FindingRiskyTrustPolicy,
+		domain.FindingEscalationPath,
+	}
+	for _, ft := range policyTypes {
+		t.Run(string(ft), func(t *testing.T) {
+			patch, _ := SuggestPatch(domain.Finding{Type: ft})
+			if patch.Template == "" {
+				t.Fatalf("expected non-empty template for %s", ft)
+			}
+			trimmed := strings.TrimSpace(patch.Template)
+			if !strings.HasPrefix(trimmed, "{") {
+				t.Errorf("expected JSON template for %s, got prefix: %s", ft, trimmed[:min(60, len(trimmed))])
+			}
+		})
+	}
+}
+
+func TestSuggestPatch_TrustPolicyTemplateIncludesAccountID(t *testing.T) {
+	patch, _ := SuggestPatch(domain.Finding{
+		Type: domain.FindingRiskyTrustPolicy,
+		Evidence: map[string]any{
+			"target_account_id": "987654321098",
+		},
+	})
+	if !strings.Contains(patch.Template, "987654321098") {
+		t.Errorf("expected account ID in trust policy template, got: %s", patch.Template)
+	}
+}
+
+func TestSuggestPatch_NoEvidenceProducesValidPatch(t *testing.T) {
+	types := []domain.FindingType{
+		domain.FindingOverPrivileged,
+		domain.FindingRiskyTrustPolicy,
+		domain.FindingEscalationPath,
+		domain.FindingStaleIdentity,
+		domain.FindingOwnerless,
+	}
+	for _, ft := range types {
+		t.Run(string(ft), func(t *testing.T) {
+			patch, ok := SuggestPatch(domain.Finding{Type: ft})
+			if !ok {
+				t.Fatalf("expected patch for %s", ft)
+			}
+			if patch.Summary == "" || len(patch.Steps) == 0 {
+				t.Errorf("patch for %s has empty summary or steps with no evidence", ft)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `SuggestPatch(finding domain.Finding) (PatchTemplate, bool)` in `internal/findings/standards/patches.go`
- Maps all 5 high-volume finding types to deterministic, evidence-aware patch suggestions: `overprivileged_identity`, `risky_trust_policy`, `escalation_path`, `stale_identity`, `ownerless_identity`
- Each `PatchTemplate` includes a summary, ordered steps derived from finding evidence, safety notes, and a policy/config fragment (IAM JSON or CLI/YAML snippet)
- Templates are strictly preview-only; direct commit to a default branch is out of scope per the issue definition

## Why

Findings currently stop at a plain-text `Remediation` string. This PR adds the rule-to-remediation mapping and patch template generation layer described in ITR-032, so operators get structured, actionable fix guidance tied to the actual finding evidence (identity ARN, risky principals, escalation action, reference timestamp, etc.).

## Test plan

- [ ] `go test ./internal/findings/standards/...` — 13 new tests pass, covering all 5 finding types, evidence incorporation, JSON template validity, missing evidence fallback, and unregistered type returns false
- [ ] `go test ./...` — full suite green, no regressions
- [ ] Pre-commit hooks pass (gofmt, go vet, merge conflict check)

## Validation performed

```
go test ./internal/findings/standards/... -v   # all PASS
go test ./...                                  # all packages PASS
make fmt-check                                 # clean
make vet                                       # clean
```

## AI-assisted
- AI-assisted: yes
- Tools used: Claude Code
- Where used: patches.go, patches_test.go
- Human verification performed: full test suite run, manual review of template JSON structure and step content, pre-commit hooks

Closes #573

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic patch-template engine with provider-aware routing to turn the top 5 high-volume findings into evidence-aware, preview-only remediation suggestions. Fulfills ITR-032 by giving operators clear, actionable steps and policy snippets tied to each finding.

- **New Features**
  - Introduces `SuggestPatch` in `internal/findings/standards/patches.go` returning a `PatchTemplate` for supported findings.
  - Supports: over-privileged identity, risky trust policy, escalation path, stale identity, and ownerless identity.
  - Routes over-privileged and escalation patches by provider: AWS → IAM JSON; Kubernetes → RBAC YAML with `kubectl auth can-i` verification.
  - Each template includes a summary, ordered steps, safety notes, and a policy/config fragment; templates are preview-only with no direct branch commits.

<sup>Written for commit 173e2d6feffab5eb0f71447b4af9f21622de072a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

