### PR TITLE
Add Create Fix PR workflow from findings (ITR-033)

### DIFF
--- a/internal/remediation/fixpr/plan.go
+++ b/internal/remediation/fixpr/plan.go
@@ -170,18 +170,37 @@ func buildCommitMessage(finding domain.Finding, template standards.PatchTemplate
 	return fmt.Sprintf("identrail: %s\n\nFinding: %s (%s)\n", subject, finding.ID, finding.Type)
 }
 
-var slugRe = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
+var (
+	slugRe        = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
+	multiDotRe    = regexp.MustCompile(`\.{2,}`)
+	leadingDotRe  = regexp.MustCompile(`(^|/)\.+`)
+	trailingDotRe = regexp.MustCompile(`\.+(/|$)`)
+)
 
+// slugifyFindingID produces a string that is safe to use as a single git ref
+// component. git-check-ref-format(1) rejects refs that begin with ".", contain
+// "..", or end in ".lock", so those patterns are normalized to "-" rather than
+// preserved.
 func slugifyFindingID(id string) string {
 	s := slugRe.ReplaceAllString(strings.TrimSpace(id), "-")
-	s = strings.Trim(s, "-")
+	s = multiDotRe.ReplaceAllString(s, "-")
+	s = leadingDotRe.ReplaceAllString(s, "${1}")
+	s = trailingDotRe.ReplaceAllString(s, "${1}")
+	s = strings.Trim(s, "-.")
+	s = strings.ToLower(s)
+	if strings.HasSuffix(s, ".lock") {
+		s = strings.TrimSuffix(s, ".lock") + "-lock"
+	}
 	if s == "" {
 		return "finding"
 	}
 	if len(s) > 80 {
-		s = s[:80]
+		s = strings.TrimRight(s[:80], "-.")
 	}
-	return strings.ToLower(s)
+	if s == "" {
+		return "finding"
+	}
+	return s
 }
 
 func templateExtension(template standards.PatchTemplate) string {

--- a/internal/remediation/fixpr/plan.go
+++ b/internal/remediation/fixpr/plan.go
@@ -1,0 +1,217 @@
+// Package fixpr converts a finding and its remediation patch template into a
+// deterministic source-control plan (branch, commit, PR title/body, files) and
+// publishes that plan as a real GitHub pull request via the Git Data API.
+//
+// Direct commit to the default branch is intentionally out of scope; every plan
+// targets a fresh branch off the configured base, leaving review and merge to
+// the operator.
+package fixpr
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/findings/standards"
+)
+
+// PlanOptions parameterizes plan generation with deployment-specific values.
+type PlanOptions struct {
+	// BaseBranch is the branch the fix PR targets (defaults to "main").
+	BaseBranch string
+	// BranchPrefix is prepended to the generated branch slug (defaults to
+	// "identrail/fix"). The full branch name is "<prefix>/<finding-slug>".
+	BranchPrefix string
+	// FindingURL is a clickable link back to the finding in the UI; included
+	// in the README and PR body for traceability. Optional.
+	FindingURL string
+}
+
+// FixPRPlan is a deterministic, source-agnostic description of the branch,
+// commit, files, and PR metadata required to publish a remediation PR.
+type FixPRPlan struct {
+	BaseBranch    string     `json:"base_branch"`
+	BranchName    string     `json:"branch_name"`
+	CommitMessage string     `json:"commit_message"`
+	PRTitle       string     `json:"pr_title"`
+	PRBody        string     `json:"pr_body"`
+	Files         []PlanFile `json:"files"`
+	FindingID     string     `json:"finding_id"`
+	FindingType   string     `json:"finding_type"`
+}
+
+// PlanFile is a single file added or replaced by the plan's commit.
+type PlanFile struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+// BuildPlan composes the deterministic fix-PR plan for one finding and its
+// remediation suggestion. Returns an error when the inputs cannot produce a
+// minimally viable plan.
+func BuildPlan(finding domain.Finding, template standards.PatchTemplate, opts PlanOptions) (FixPRPlan, error) {
+	if strings.TrimSpace(finding.ID) == "" {
+		return FixPRPlan{}, fmt.Errorf("finding id required")
+	}
+	if strings.TrimSpace(template.Summary) == "" {
+		return FixPRPlan{}, fmt.Errorf("template summary required")
+	}
+
+	base := strings.TrimSpace(opts.BaseBranch)
+	if base == "" {
+		base = "main"
+	}
+	prefix := strings.TrimSpace(opts.BranchPrefix)
+	if prefix == "" {
+		prefix = "identrail/fix"
+	}
+
+	slug := slugifyFindingID(finding.ID)
+	branch := prefix + "/" + slug
+	dir := ".identrail/remediations/" + slug
+
+	files := []PlanFile{
+		{Path: dir + "/README.md", Content: buildReadme(finding, template, opts.FindingURL)},
+	}
+	if strings.TrimSpace(template.Template) != "" {
+		files = append(files, PlanFile{
+			Path:    dir + "/patch" + templateExtension(template),
+			Content: ensureTrailingNewline(template.Template),
+		})
+	}
+
+	return FixPRPlan{
+		BaseBranch:    base,
+		BranchName:    branch,
+		CommitMessage: buildCommitMessage(finding, template),
+		PRTitle:       buildPRTitle(finding),
+		PRBody:        buildPRBody(finding, template, opts.FindingURL),
+		Files:         files,
+		FindingID:     finding.ID,
+		FindingType:   string(finding.Type),
+	}, nil
+}
+
+func buildReadme(finding domain.Finding, template standards.PatchTemplate, findingURL string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Remediation for finding %s\n\n", finding.ID)
+	fmt.Fprintf(&b, "- **Finding type:** `%s`\n", finding.Type)
+	fmt.Fprintf(&b, "- **Severity:** `%s`\n", finding.Severity)
+	if finding.Title != "" {
+		fmt.Fprintf(&b, "- **Title:** %s\n", finding.Title)
+	}
+	if findingURL != "" {
+		fmt.Fprintf(&b, "- **Finding link:** %s\n", findingURL)
+	}
+	b.WriteString("\n## Summary\n\n")
+	b.WriteString(template.Summary)
+	if len(template.Steps) > 0 {
+		b.WriteString("\n\n## Suggested steps\n\n")
+		for i, step := range template.Steps {
+			fmt.Fprintf(&b, "%d. %s\n", i+1, step)
+		}
+	}
+	if len(template.SafetyNotes) > 0 {
+		b.WriteString("\n## Safety notes\n\n")
+		for _, note := range template.SafetyNotes {
+			fmt.Fprintf(&b, "- %s\n", note)
+		}
+	}
+	if strings.TrimSpace(template.Template) != "" {
+		fmt.Fprintf(&b, "\n## Patch template\n\nSee `patch%s` in this directory.\n", templateExtension(template))
+	}
+	b.WriteString("\n> This PR is generated from an Identrail finding and is preview-only.\n")
+	b.WriteString("> Review the suggested patch, adapt placeholders, and validate before merging.\n")
+	return b.String()
+}
+
+func buildPRTitle(finding domain.Finding) string {
+	if finding.Title != "" {
+		return "identrail: fix " + finding.Title
+	}
+	return fmt.Sprintf("identrail: remediation suggestion for %s", finding.Type)
+}
+
+func buildPRBody(finding domain.Finding, template standards.PatchTemplate, findingURL string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "## Summary\n\n%s\n\n", template.Summary)
+	if finding.HumanSummary != "" {
+		fmt.Fprintf(&b, "## Finding context\n\n%s\n\n", finding.HumanSummary)
+	}
+	b.WriteString("## Traceability\n\n")
+	fmt.Fprintf(&b, "- Finding ID: `%s`\n", finding.ID)
+	fmt.Fprintf(&b, "- Finding type: `%s`\n", finding.Type)
+	fmt.Fprintf(&b, "- Severity: `%s`\n", finding.Severity)
+	if finding.ScanID != "" {
+		fmt.Fprintf(&b, "- Scan ID: `%s`\n", finding.ScanID)
+	}
+	if findingURL != "" {
+		fmt.Fprintf(&b, "- Finding link: %s\n", findingURL)
+	}
+	if len(template.Steps) > 0 {
+		b.WriteString("\n## Suggested steps\n\n")
+		for _, step := range template.Steps {
+			fmt.Fprintf(&b, "- %s\n", step)
+		}
+	}
+	if len(template.SafetyNotes) > 0 {
+		b.WriteString("\n## Safety notes\n\n")
+		for _, note := range template.SafetyNotes {
+			fmt.Fprintf(&b, "- %s\n", note)
+		}
+	}
+	b.WriteString("\n---\n*Generated by Identrail. Review before merging.*\n")
+	return b.String()
+}
+
+func buildCommitMessage(finding domain.Finding, template standards.PatchTemplate) string {
+	subject := truncate(template.Summary, 72)
+	return fmt.Sprintf("identrail: %s\n\nFinding: %s (%s)\n", subject, finding.ID, finding.Type)
+}
+
+var slugRe = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
+
+func slugifyFindingID(id string) string {
+	s := slugRe.ReplaceAllString(strings.TrimSpace(id), "-")
+	s = strings.Trim(s, "-")
+	if s == "" {
+		return "finding"
+	}
+	if len(s) > 80 {
+		s = s[:80]
+	}
+	return strings.ToLower(s)
+}
+
+func templateExtension(template standards.PatchTemplate) string {
+	trimmed := strings.TrimSpace(template.Template)
+	if trimmed == "" {
+		return ".md"
+	}
+	if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+		return ".json"
+	}
+	if strings.Contains(trimmed, "apiVersion:") || strings.Contains(trimmed, "\nkind:") {
+		return ".yaml"
+	}
+	return ".txt"
+}
+
+func ensureTrailingNewline(s string) string {
+	if strings.HasSuffix(s, "\n") {
+		return s
+	}
+	return s + "\n"
+}
+
+func truncate(s string, max int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= max {
+		return s
+	}
+	if max <= 3 {
+		return s[:max]
+	}
+	return strings.TrimSpace(s[:max-3]) + "..."
+}

--- a/internal/remediation/fixpr/plan_test.go
+++ b/internal/remediation/fixpr/plan_test.go
@@ -167,6 +167,13 @@ func TestBuildPlan_BranchSlugIsSafe(t *testing.T) {
 		{"finding/abc:123", "identrail/fix/finding-abc-123"},
 		{"  FINDING-X  ", "identrail/fix/finding-x"},
 		{"ARN:aws:iam::1:role/My Role", "identrail/fix/arn-aws-iam-1-role-my-role"},
+		// git-check-ref-format rejects refs starting with "." or containing "..".
+		{".hidden-finding", "identrail/fix/hidden-finding"},
+		{"..relative", "identrail/fix/relative"},
+		{"finding..with..dots", "identrail/fix/finding-with-dots"},
+		{"trailing-dot.", "identrail/fix/trailing-dot"},
+		{"finding.lock", "identrail/fix/finding-lock"},
+		{"...", "identrail/fix/finding"},
 	}
 	template := standards.PatchTemplate{Summary: "test"}
 	for _, tc := range cases {

--- a/internal/remediation/fixpr/plan_test.go
+++ b/internal/remediation/fixpr/plan_test.go
@@ -1,0 +1,232 @@
+package fixpr
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/findings/standards"
+)
+
+func sampleFinding() domain.Finding {
+	return domain.Finding{
+		ID:           "finding-abc-123",
+		ScanID:       "scan-42",
+		Type:         domain.FindingOverPrivileged,
+		Severity:     domain.SeverityHigh,
+		Title:        "Overprivileged role: WorkerRole",
+		HumanSummary: "This role has wildcard permissions on multiple services.",
+		Path:         []string{"aws:iam::123456789012:role/WorkerRole"},
+	}
+}
+
+func TestBuildPlan_ProducesDeterministicFields(t *testing.T) {
+	template, ok := standards.SuggestPatch(sampleFinding())
+	if !ok {
+		t.Fatal("expected patch for sample finding")
+	}
+	plan, err := BuildPlan(sampleFinding(), template, PlanOptions{
+		BaseBranch: "main",
+		FindingURL: "https://app.example.com/findings/finding-abc-123",
+	})
+	if err != nil {
+		t.Fatalf("BuildPlan returned error: %v", err)
+	}
+
+	if plan.BaseBranch != "main" {
+		t.Errorf("BaseBranch: want main, got %s", plan.BaseBranch)
+	}
+	if plan.BranchName != "identrail/fix/finding-abc-123" {
+		t.Errorf("BranchName: want identrail/fix/finding-abc-123, got %s", plan.BranchName)
+	}
+	if plan.FindingID != "finding-abc-123" {
+		t.Errorf("FindingID: want finding-abc-123, got %s", plan.FindingID)
+	}
+	if !strings.Contains(plan.PRTitle, "identrail") {
+		t.Errorf("PRTitle missing identrail prefix: %s", plan.PRTitle)
+	}
+	if !strings.Contains(plan.PRBody, "finding-abc-123") {
+		t.Errorf("PRBody missing finding ID traceability")
+	}
+	if !strings.Contains(plan.PRBody, "scan-42") {
+		t.Errorf("PRBody missing scan ID traceability")
+	}
+	if !strings.Contains(plan.PRBody, "https://app.example.com/findings/finding-abc-123") {
+		t.Errorf("PRBody missing finding URL")
+	}
+	if !strings.Contains(plan.CommitMessage, "finding-abc-123") {
+		t.Errorf("CommitMessage missing finding ID")
+	}
+}
+
+func TestBuildPlan_DeterministicAcrossCalls(t *testing.T) {
+	template, _ := standards.SuggestPatch(sampleFinding())
+	opts := PlanOptions{BaseBranch: "main"}
+	first, err := BuildPlan(sampleFinding(), template, opts)
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	second, err := BuildPlan(sampleFinding(), template, opts)
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	if first.BranchName != second.BranchName {
+		t.Errorf("branch name not deterministic: %q vs %q", first.BranchName, second.BranchName)
+	}
+	if first.CommitMessage != second.CommitMessage {
+		t.Errorf("commit message not deterministic")
+	}
+	if first.PRBody != second.PRBody {
+		t.Errorf("PR body not deterministic")
+	}
+	if len(first.Files) != len(second.Files) {
+		t.Fatalf("file count differs: %d vs %d", len(first.Files), len(second.Files))
+	}
+	for i := range first.Files {
+		if first.Files[i].Path != second.Files[i].Path || first.Files[i].Content != second.Files[i].Content {
+			t.Errorf("file %d differs between calls", i)
+		}
+	}
+}
+
+func TestBuildPlan_WritesPatchFileWithCorrectExtension(t *testing.T) {
+	cases := []struct {
+		name     string
+		finding  domain.Finding
+		wantExt  string
+		mustHave string
+	}{
+		{
+			name:     "aws_json_template",
+			finding:  domain.Finding{ID: "f1", Type: domain.FindingOverPrivileged, Path: []string{"aws:iam::1:role/X"}},
+			wantExt:  ".json",
+			mustHave: "Version",
+		},
+		{
+			name:     "k8s_yaml_template",
+			finding:  domain.Finding{ID: "f2", Type: domain.FindingOverPrivileged, Path: []string{"k8s:sa:ns/n"}},
+			wantExt:  ".yaml",
+			mustHave: "apiVersion",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			template, _ := standards.SuggestPatch(tc.finding)
+			plan, err := BuildPlan(tc.finding, template, PlanOptions{})
+			if err != nil {
+				t.Fatalf("BuildPlan: %v", err)
+			}
+			foundPatch := false
+			for _, f := range plan.Files {
+				if strings.HasSuffix(f.Path, "patch"+tc.wantExt) {
+					foundPatch = true
+					if !strings.Contains(f.Content, tc.mustHave) {
+						t.Errorf("patch %s missing expected content %q", f.Path, tc.mustHave)
+					}
+				}
+			}
+			if !foundPatch {
+				paths := []string{}
+				for _, f := range plan.Files {
+					paths = append(paths, f.Path)
+				}
+				t.Errorf("expected file ending in patch%s, got: %v", tc.wantExt, paths)
+			}
+		})
+	}
+}
+
+func TestBuildPlan_AlwaysWritesReadme(t *testing.T) {
+	template, _ := standards.SuggestPatch(sampleFinding())
+	plan, err := BuildPlan(sampleFinding(), template, PlanOptions{})
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	foundReadme := false
+	for _, f := range plan.Files {
+		if strings.HasSuffix(f.Path, "/README.md") {
+			foundReadme = true
+			if !strings.Contains(f.Content, "finding-abc-123") {
+				t.Errorf("README missing finding id")
+			}
+			if !strings.Contains(f.Content, "preview-only") {
+				t.Errorf("README missing preview-only disclaimer")
+			}
+		}
+	}
+	if !foundReadme {
+		t.Error("expected README.md in plan files")
+	}
+}
+
+func TestBuildPlan_BranchSlugIsSafe(t *testing.T) {
+	cases := []struct {
+		id   string
+		want string
+	}{
+		{"finding/abc:123", "identrail/fix/finding-abc-123"},
+		{"  FINDING-X  ", "identrail/fix/finding-x"},
+		{"ARN:aws:iam::1:role/My Role", "identrail/fix/arn-aws-iam-1-role-my-role"},
+	}
+	template := standards.PatchTemplate{Summary: "test"}
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			finding := domain.Finding{ID: tc.id, Type: domain.FindingOverPrivileged}
+			plan, err := BuildPlan(finding, template, PlanOptions{})
+			if err != nil {
+				t.Fatalf("BuildPlan: %v", err)
+			}
+			if plan.BranchName != tc.want {
+				t.Errorf("branch: want %s, got %s", tc.want, plan.BranchName)
+			}
+		})
+	}
+}
+
+func TestBuildPlan_RejectsMissingFindingID(t *testing.T) {
+	_, err := BuildPlan(domain.Finding{}, standards.PatchTemplate{Summary: "x"}, PlanOptions{})
+	if err == nil {
+		t.Error("expected error for missing finding id")
+	}
+}
+
+func TestBuildPlan_RejectsEmptyTemplate(t *testing.T) {
+	_, err := BuildPlan(domain.Finding{ID: "f1"}, standards.PatchTemplate{}, PlanOptions{})
+	if err == nil {
+		t.Error("expected error for empty template summary")
+	}
+}
+
+func TestBuildPlan_DefaultsBaseBranch(t *testing.T) {
+	template, _ := standards.SuggestPatch(sampleFinding())
+	plan, _ := BuildPlan(sampleFinding(), template, PlanOptions{})
+	if plan.BaseBranch != "main" {
+		t.Errorf("expected default base main, got %s", plan.BaseBranch)
+	}
+}
+
+func TestBuildPlan_CustomBranchPrefix(t *testing.T) {
+	template, _ := standards.SuggestPatch(sampleFinding())
+	plan, _ := BuildPlan(sampleFinding(), template, PlanOptions{BranchPrefix: "bots/identrail"})
+	if !strings.HasPrefix(plan.BranchName, "bots/identrail/") {
+		t.Errorf("expected custom prefix, got %s", plan.BranchName)
+	}
+}
+
+func TestBuildPlan_NoTemplateBodyStillProducesPlan(t *testing.T) {
+	finding := domain.Finding{ID: "f-stale", Type: domain.FindingStaleIdentity}
+	template, _ := standards.SuggestPatch(finding)
+	if template.Template != "" {
+		t.Fatalf("expected stale identity template to be empty for this assertion")
+	}
+	plan, err := BuildPlan(finding, template, PlanOptions{})
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	for _, f := range plan.Files {
+		if strings.HasSuffix(f.Path, "/README.md") {
+			return
+		}
+	}
+	t.Error("expected README.md even when patch template body is empty")
+}

--- a/internal/remediation/fixpr/publisher.go
+++ b/internal/remediation/fixpr/publisher.go
@@ -1,0 +1,238 @@
+package fixpr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	defaultGitHubAPIBaseURL = "https://api.github.com"
+	publisherHTTPTimeout    = 15 * time.Second
+)
+
+// PublishResult is the outcome of a successful PR publish.
+type PublishResult struct {
+	PRNumber   int    `json:"pr_number"`
+	PRURL      string `json:"pr_url"`
+	BranchName string `json:"branch_name"`
+	CommitSHA  string `json:"commit_sha"`
+}
+
+// GitHubPublisher publishes a FixPRPlan to a GitHub repository using the Git
+// Data API: it reads the base ref, builds blobs + tree + commit, creates the
+// branch, then opens a pull request. Authentication uses a short-lived bearer
+// token supplied per call so callers can mint installation tokens for the
+// target installation.
+type GitHubPublisher struct {
+	HTTPClient *http.Client
+	APIBaseURL string
+}
+
+// Publish creates the branch, commit, and PR for the plan in repo {owner}/{name}
+// using token as the bearer credential. Returns the created PR metadata.
+func (p GitHubPublisher) Publish(ctx context.Context, owner, repo, token string, plan FixPRPlan) (PublishResult, error) {
+	if strings.TrimSpace(owner) == "" || strings.TrimSpace(repo) == "" {
+		return PublishResult{}, fmt.Errorf("owner and repo are required")
+	}
+	if strings.TrimSpace(token) == "" {
+		return PublishResult{}, fmt.Errorf("github token is required")
+	}
+	if len(plan.Files) == 0 {
+		return PublishResult{}, fmt.Errorf("plan has no files")
+	}
+
+	baseRefSHA, baseTreeSHA, err := p.getBaseRef(ctx, owner, repo, token, plan.BaseBranch)
+	if err != nil {
+		return PublishResult{}, fmt.Errorf("read base branch %q: %w", plan.BaseBranch, err)
+	}
+
+	treeEntries := make([]map[string]any, 0, len(plan.Files))
+	for _, file := range plan.Files {
+		blobSHA, err := p.createBlob(ctx, owner, repo, token, file.Content)
+		if err != nil {
+			return PublishResult{}, fmt.Errorf("create blob for %s: %w", file.Path, err)
+		}
+		treeEntries = append(treeEntries, map[string]any{
+			"path": file.Path,
+			"mode": "100644",
+			"type": "blob",
+			"sha":  blobSHA,
+		})
+	}
+
+	treeSHA, err := p.createTree(ctx, owner, repo, token, baseTreeSHA, treeEntries)
+	if err != nil {
+		return PublishResult{}, fmt.Errorf("create tree: %w", err)
+	}
+	commitSHA, err := p.createCommit(ctx, owner, repo, token, plan.CommitMessage, treeSHA, baseRefSHA)
+	if err != nil {
+		return PublishResult{}, fmt.Errorf("create commit: %w", err)
+	}
+	if err := p.createBranch(ctx, owner, repo, token, plan.BranchName, commitSHA); err != nil {
+		return PublishResult{}, fmt.Errorf("create branch %s: %w", plan.BranchName, err)
+	}
+	prNumber, prURL, err := p.openPullRequest(ctx, owner, repo, token, plan)
+	if err != nil {
+		return PublishResult{}, fmt.Errorf("open pull request: %w", err)
+	}
+
+	return PublishResult{
+		PRNumber:   prNumber,
+		PRURL:      prURL,
+		BranchName: plan.BranchName,
+		CommitSHA:  commitSHA,
+	}, nil
+}
+
+func (p GitHubPublisher) getBaseRef(ctx context.Context, owner, repo, token, base string) (string, string, error) {
+	var refBody struct {
+		Object struct {
+			SHA string `json:"sha"`
+		} `json:"object"`
+	}
+	refPath := fmt.Sprintf("/repos/%s/%s/git/ref/heads/%s", url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(base))
+	if err := p.doJSON(ctx, http.MethodGet, refPath, token, nil, &refBody); err != nil {
+		return "", "", err
+	}
+	var commitBody struct {
+		Tree struct {
+			SHA string `json:"sha"`
+		} `json:"tree"`
+	}
+	commitPath := fmt.Sprintf("/repos/%s/%s/git/commits/%s", url.PathEscape(owner), url.PathEscape(repo), refBody.Object.SHA)
+	if err := p.doJSON(ctx, http.MethodGet, commitPath, token, nil, &commitBody); err != nil {
+		return "", "", err
+	}
+	return refBody.Object.SHA, commitBody.Tree.SHA, nil
+}
+
+func (p GitHubPublisher) createBlob(ctx context.Context, owner, repo, token, content string) (string, error) {
+	var resp struct {
+		SHA string `json:"sha"`
+	}
+	body := map[string]any{"content": content, "encoding": "utf-8"}
+	path := fmt.Sprintf("/repos/%s/%s/git/blobs", url.PathEscape(owner), url.PathEscape(repo))
+	if err := p.doJSON(ctx, http.MethodPost, path, token, body, &resp); err != nil {
+		return "", err
+	}
+	return resp.SHA, nil
+}
+
+func (p GitHubPublisher) createTree(ctx context.Context, owner, repo, token, baseTree string, entries []map[string]any) (string, error) {
+	var resp struct {
+		SHA string `json:"sha"`
+	}
+	body := map[string]any{"base_tree": baseTree, "tree": entries}
+	path := fmt.Sprintf("/repos/%s/%s/git/trees", url.PathEscape(owner), url.PathEscape(repo))
+	if err := p.doJSON(ctx, http.MethodPost, path, token, body, &resp); err != nil {
+		return "", err
+	}
+	return resp.SHA, nil
+}
+
+func (p GitHubPublisher) createCommit(ctx context.Context, owner, repo, token, message, tree, parent string) (string, error) {
+	var resp struct {
+		SHA string `json:"sha"`
+	}
+	body := map[string]any{
+		"message": message,
+		"tree":    tree,
+		"parents": []string{parent},
+	}
+	path := fmt.Sprintf("/repos/%s/%s/git/commits", url.PathEscape(owner), url.PathEscape(repo))
+	if err := p.doJSON(ctx, http.MethodPost, path, token, body, &resp); err != nil {
+		return "", err
+	}
+	return resp.SHA, nil
+}
+
+func (p GitHubPublisher) createBranch(ctx context.Context, owner, repo, token, branch, sha string) error {
+	body := map[string]any{
+		"ref": "refs/heads/" + branch,
+		"sha": sha,
+	}
+	path := fmt.Sprintf("/repos/%s/%s/git/refs", url.PathEscape(owner), url.PathEscape(repo))
+	return p.doJSON(ctx, http.MethodPost, path, token, body, nil)
+}
+
+func (p GitHubPublisher) openPullRequest(ctx context.Context, owner, repo, token string, plan FixPRPlan) (int, string, error) {
+	var resp struct {
+		Number  int    `json:"number"`
+		HTMLURL string `json:"html_url"`
+	}
+	body := map[string]any{
+		"title": plan.PRTitle,
+		"head":  plan.BranchName,
+		"base":  plan.BaseBranch,
+		"body":  plan.PRBody,
+	}
+	path := fmt.Sprintf("/repos/%s/%s/pulls", url.PathEscape(owner), url.PathEscape(repo))
+	if err := p.doJSON(ctx, http.MethodPost, path, token, body, &resp); err != nil {
+		return 0, "", err
+	}
+	return resp.Number, resp.HTMLURL, nil
+}
+
+func (p GitHubPublisher) doJSON(ctx context.Context, method, path, token string, payload any, out any) error {
+	var reqBody io.Reader
+	if payload != nil {
+		raw, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("encode request: %w", err)
+		}
+		reqBody = bytes.NewReader(raw)
+	}
+	full := strings.TrimRight(p.apiBaseURL(), "/") + path
+	req, err := http.NewRequestWithContext(ctx, method, full, reqBody)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	if reqBody != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	res, err := p.httpClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("github request: %w", err)
+	}
+	defer res.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(res.Body, 1<<20))
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		snippet := strings.TrimSpace(string(body))
+		if len(snippet) > 200 {
+			snippet = snippet[:200] + "..."
+		}
+		return fmt.Errorf("github %s %s: status %d: %s", method, path, res.StatusCode, snippet)
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("decode github response: %w", err)
+	}
+	return nil
+}
+
+func (p GitHubPublisher) apiBaseURL() string {
+	if p.APIBaseURL != "" {
+		return p.APIBaseURL
+	}
+	return defaultGitHubAPIBaseURL
+}
+
+func (p GitHubPublisher) httpClient() *http.Client {
+	if p.HTTPClient != nil {
+		return p.HTTPClient
+	}
+	return &http.Client{Timeout: publisherHTTPTimeout}
+}

--- a/internal/remediation/fixpr/publisher.go
+++ b/internal/remediation/fixpr/publisher.go
@@ -97,7 +97,10 @@ func (p GitHubPublisher) getBaseRef(ctx context.Context, owner, repo, token, bas
 			SHA string `json:"sha"`
 		} `json:"object"`
 	}
-	refPath := fmt.Sprintf("/repos/%s/%s/git/ref/heads/%s", url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(base))
+	// GitHub's git refs endpoint expects the branch portion of the path to
+	// preserve "/" separators (e.g. "release/2026.05"); escape each segment
+	// individually instead of treating the whole ref as one component.
+	refPath := fmt.Sprintf("/repos/%s/%s/git/ref/heads/%s", url.PathEscape(owner), url.PathEscape(repo), escapeRefPath(base))
 	if err := p.doJSON(ctx, http.MethodGet, refPath, token, nil, &refBody); err != nil {
 		return "", "", err
 	}
@@ -221,6 +224,16 @@ func (p GitHubPublisher) doJSON(ctx context.Context, method, path, token string,
 		return fmt.Errorf("decode github response: %w", err)
 	}
 	return nil
+}
+
+// escapeRefPath escapes a git ref so it can be safely interpolated into a URL
+// path while preserving the "/" separators that GitHub's ref endpoints require.
+func escapeRefPath(ref string) string {
+	parts := strings.Split(ref, "/")
+	for i, segment := range parts {
+		parts[i] = url.PathEscape(segment)
+	}
+	return strings.Join(parts, "/")
 }
 
 func (p GitHubPublisher) apiBaseURL() string {

--- a/internal/remediation/fixpr/publisher_test.go
+++ b/internal/remediation/fixpr/publisher_test.go
@@ -1,0 +1,231 @@
+package fixpr
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type recordedRequest struct {
+	Method string
+	Path   string
+	Body   map[string]any
+	Auth   string
+}
+
+func newFakeGitHubServer(t *testing.T) (*httptest.Server, *[]recordedRequest, *sync.Mutex) {
+	t.Helper()
+	var mu sync.Mutex
+	var requests []recordedRequest
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		var parsed map[string]any
+		if len(body) > 0 {
+			_ = json.Unmarshal(body, &parsed)
+		}
+		mu.Lock()
+		requests = append(requests, recordedRequest{
+			Method: r.Method,
+			Path:   r.URL.Path,
+			Body:   parsed,
+			Auth:   r.Header.Get("Authorization"),
+		})
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/repos/") && strings.Contains(r.URL.Path, "/git/ref/heads/"):
+			_, _ = w.Write([]byte(`{"object":{"sha":"base-sha-001","type":"commit"}}`))
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/repos/") && strings.Contains(r.URL.Path, "/git/commits/"):
+			_, _ = w.Write([]byte(`{"sha":"base-sha-001","tree":{"sha":"base-tree-001"}}`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/git/blobs"):
+			content, _ := parsed["content"].(string)
+			sha := "blob-" + shortHash(content)
+			writeJSON(w, map[string]any{"sha": sha})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/git/trees"):
+			writeJSON(w, map[string]any{"sha": "tree-sha-001"})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/git/commits"):
+			writeJSON(w, map[string]any{"sha": "commit-sha-001"})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/git/refs"):
+			writeJSON(w, map[string]any{"ref": parsed["ref"]})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/pulls"):
+			writeJSON(w, map[string]any{
+				"number":   42,
+				"html_url": "https://github.example.com/acme/repo/pull/42",
+			})
+		default:
+			http.Error(w, "unexpected request: "+r.Method+" "+r.URL.Path, http.StatusInternalServerError)
+		}
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(handler))
+	t.Cleanup(srv.Close)
+	return srv, &requests, &mu
+}
+
+func writeJSON(w http.ResponseWriter, body map[string]any) {
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func shortHash(s string) string {
+	sum := 0
+	for _, c := range s {
+		sum = (sum*131 + int(c)) & 0xffff
+	}
+	return jsonHex(sum)
+}
+
+func jsonHex(n int) string {
+	const hex = "0123456789abcdef"
+	out := make([]byte, 4)
+	for i := 3; i >= 0; i-- {
+		out[i] = hex[n&0xf]
+		n >>= 4
+	}
+	return string(out)
+}
+
+func TestGitHubPublisher_Publish_HappyPath(t *testing.T) {
+	srv, recorded, mu := newFakeGitHubServer(t)
+
+	plan := FixPRPlan{
+		BaseBranch:    "main",
+		BranchName:    "identrail/fix/finding-1",
+		CommitMessage: "identrail: fix something",
+		PRTitle:       "identrail: fix overprivileged role",
+		PRBody:        "trace: finding-1",
+		FindingID:     "finding-1",
+		FindingType:   "overprivileged_identity",
+		Files: []PlanFile{
+			{Path: ".identrail/remediations/finding-1/README.md", Content: "# Remediation\n"},
+			{Path: ".identrail/remediations/finding-1/patch.json", Content: `{"Version":"2012-10-17"}` + "\n"},
+		},
+	}
+
+	publisher := GitHubPublisher{APIBaseURL: srv.URL}
+	result, err := publisher.Publish(context.Background(), "acme", "repo", "tok-xyz", plan)
+	if err != nil {
+		t.Fatalf("Publish returned error: %v", err)
+	}
+	if result.PRNumber != 42 {
+		t.Errorf("PR number: want 42, got %d", result.PRNumber)
+	}
+	if result.PRURL != "https://github.example.com/acme/repo/pull/42" {
+		t.Errorf("PR URL unexpected: %s", result.PRURL)
+	}
+	if result.BranchName != "identrail/fix/finding-1" {
+		t.Errorf("branch name unexpected: %s", result.BranchName)
+	}
+	if result.CommitSHA != "commit-sha-001" {
+		t.Errorf("commit SHA unexpected: %s", result.CommitSHA)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	wantSequence := []struct {
+		method   string
+		pathPart string
+	}{
+		{http.MethodGet, "/git/ref/heads/main"},
+		{http.MethodGet, "/git/commits/base-sha-001"},
+		{http.MethodPost, "/git/blobs"},
+		{http.MethodPost, "/git/blobs"},
+		{http.MethodPost, "/git/trees"},
+		{http.MethodPost, "/git/commits"},
+		{http.MethodPost, "/git/refs"},
+		{http.MethodPost, "/pulls"},
+	}
+	if len(*recorded) != len(wantSequence) {
+		t.Fatalf("expected %d requests, got %d: %+v", len(wantSequence), len(*recorded), *recorded)
+	}
+	for i, want := range wantSequence {
+		got := (*recorded)[i]
+		if got.Method != want.method || !strings.Contains(got.Path, want.pathPart) {
+			t.Errorf("request %d: want %s %s, got %s %s", i, want.method, want.pathPart, got.Method, got.Path)
+		}
+		if got.Auth != "Bearer tok-xyz" {
+			t.Errorf("request %d: missing/wrong auth header: %s", i, got.Auth)
+		}
+	}
+
+	// Verify the tree create included both files.
+	treeReq := (*recorded)[4]
+	entries, ok := treeReq.Body["tree"].([]any)
+	if !ok {
+		t.Fatalf("tree body missing 'tree' array: %+v", treeReq.Body)
+	}
+	if len(entries) != 2 {
+		t.Errorf("expected 2 tree entries, got %d", len(entries))
+	}
+
+	// Verify ref creation used refs/heads prefix.
+	refReq := (*recorded)[6]
+	ref, _ := refReq.Body["ref"].(string)
+	if ref != "refs/heads/identrail/fix/finding-1" {
+		t.Errorf("unexpected ref: %s", ref)
+	}
+
+	// Verify PR creation carried plan metadata.
+	prReq := (*recorded)[7]
+	if title, _ := prReq.Body["title"].(string); title != plan.PRTitle {
+		t.Errorf("PR title: want %s, got %s", plan.PRTitle, title)
+	}
+	if head, _ := prReq.Body["head"].(string); head != plan.BranchName {
+		t.Errorf("PR head: want %s, got %s", plan.BranchName, head)
+	}
+	if base, _ := prReq.Body["base"].(string); base != plan.BaseBranch {
+		t.Errorf("PR base: want %s, got %s", plan.BaseBranch, base)
+	}
+}
+
+func TestGitHubPublisher_Publish_RejectsMissingInputs(t *testing.T) {
+	publisher := GitHubPublisher{APIBaseURL: "http://example.invalid"}
+	cases := []struct {
+		name  string
+		owner string
+		repo  string
+		token string
+		plan  FixPRPlan
+	}{
+		{"missing_owner", "", "repo", "tok", FixPRPlan{Files: []PlanFile{{Path: "a"}}}},
+		{"missing_repo", "acme", "", "tok", FixPRPlan{Files: []PlanFile{{Path: "a"}}}},
+		{"missing_token", "acme", "repo", "", FixPRPlan{Files: []PlanFile{{Path: "a"}}}},
+		{"empty_files", "acme", "repo", "tok", FixPRPlan{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := publisher.Publish(context.Background(), tc.owner, tc.repo, tc.token, tc.plan)
+			if err == nil {
+				t.Error("expected error")
+			}
+		})
+	}
+}
+
+func TestGitHubPublisher_Publish_ReturnsErrorOnAPIFailure(t *testing.T) {
+	failServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"ref not found"}`, http.StatusNotFound)
+	}))
+	t.Cleanup(failServer.Close)
+
+	publisher := GitHubPublisher{APIBaseURL: failServer.URL}
+	_, err := publisher.Publish(context.Background(), "acme", "repo", "tok", FixPRPlan{
+		BaseBranch: "missing",
+		BranchName: "identrail/fix/x",
+		Files:      []PlanFile{{Path: "x", Content: "y"}},
+	})
+	if err == nil {
+		t.Fatal("expected error from failing GitHub API")
+	}
+	if !strings.Contains(err.Error(), "read base branch") {
+		t.Errorf("expected wrapped error, got: %v", err)
+	}
+}

--- a/internal/remediation/fixpr/publisher_test.go
+++ b/internal/remediation/fixpr/publisher_test.go
@@ -210,6 +210,52 @@ func TestGitHubPublisher_Publish_RejectsMissingInputs(t *testing.T) {
 	}
 }
 
+func TestGitHubPublisher_Publish_PreservesSlashesInBaseBranchRef(t *testing.T) {
+	srv, recorded, mu := newFakeGitHubServer(t)
+
+	plan := FixPRPlan{
+		BaseBranch:    "release/2026.05",
+		BranchName:    "identrail/fix/finding-2",
+		CommitMessage: "identrail: fix",
+		PRTitle:       "title",
+		PRBody:        "body",
+		Files:         []PlanFile{{Path: "x", Content: "y"}},
+	}
+	publisher := GitHubPublisher{APIBaseURL: srv.URL}
+	if _, err := publisher.Publish(context.Background(), "acme", "repo", "tok", plan); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	first := (*recorded)[0]
+	want := "/repos/acme/repo/git/ref/heads/release/2026.05"
+	if first.Path != want {
+		t.Errorf("base ref path: want %s, got %s", want, first.Path)
+	}
+	if strings.Contains(first.Path, "%2F") {
+		t.Errorf("base branch slash was URL-encoded: %s", first.Path)
+	}
+}
+
+func TestEscapeRefPath_PreservesSlashesEscapesSegments(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"main", "main"},
+		{"release/2026.05", "release/2026.05"},
+		{"feature/with space", "feature/with%20space"},
+		{"a/b/c", "a/b/c"},
+	}
+	for _, tc := range cases {
+		got := escapeRefPath(tc.in)
+		if got != tc.want {
+			t.Errorf("escapeRefPath(%q): want %q, got %q", tc.in, tc.want, got)
+		}
+	}
+}
+
 func TestGitHubPublisher_Publish_ReturnsErrorOnAPIFailure(t *testing.T) {
 	failServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"message":"ref not found"}`, http.StatusNotFound)


### PR DESCRIPTION
## Summary

- New `internal/remediation/fixpr/` package that turns a `domain.Finding` plus its `standards.PatchTemplate` into a real GitHub pull request
- `BuildPlan` produces a deterministic, I/O-free `FixPRPlan` (branch name from slugified finding id, commit message, PR title/body with traceability links, files to commit)
- `GitHubPublisher.Publish` uses the GitHub Git Data API (ref → blobs → tree → commit → branch → pull) so all generated files land in a single clean commit on a fresh branch off the configured base
- Direct commit to the default branch remains out of scope; every plan targets a fresh `identrail/fix/<finding-slug>` branch

## Plan output layout

```
.identrail/remediations/<finding-slug>/
  README.md     # finding context, summary, steps, safety notes, link back
  patch.json    # for AWS IAM templates
  patch.yaml    # for Kubernetes RBAC templates
```

## Why

`RemediationJobTypeCreateFixPR` was a declared domain type with no engine behind it. ITR-016 (GitHub connect flow, merged) provides the installation/token plumbing, and ITR-032 (patch template engine, merged) provides the structured suggestions. This PR is the natural completion of the remediation pipeline.

## Test plan

- [ ] `go test ./internal/remediation/fixpr/... -v` — 15 tests cover plan determinism, branch slug safety, file extension routing (json/yaml), README presence, missing-input validation, publisher happy path with full GitHub API call sequence verification, and API failure handling via `httptest`
- [ ] `go test ./...` — full suite green
- [ ] Pre-commit hooks pass (gofmt, go vet)

## Validation performed

```
go test ./internal/remediation/fixpr/... -v   # all PASS (15 tests)
go test ./...                                  # all packages PASS
make fmt-check                                 # clean
make vet                                       # clean
```

## AI-assisted

- AI-assisted: yes
- Tools used: Claude Code
- Where used: `internal/remediation/fixpr/`
- Human verification performed: full test suite run, manual review of GitHub API call sequence (matches Git Data API ordering), confirmed branch/PR scope stays off default branch

Closes #574

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements ITR-033 with a workflow that turns a `domain.Finding` + `standards.PatchTemplate` into a GitHub pull request with a single clean commit. Also hardens ref handling to ensure valid branch names and correct base-branch lookups.

- **New Features**
  - Added `internal/remediation/fixpr` with `BuildPlan` (deterministic plan: branch, commit, PR title/body, files) and `GitHubPublisher.Publish` (Git Data API: blobs → tree → commit → branch → PR).
  - Branch is `identrail/fix/<finding-slug>` off a configurable base (defaults to `main`); direct commits are out of scope.
  - Writes `.identrail/remediations/<slug>/README.md` and `patch.{json|yaml|txt}` with traceability links and safety notes.

- **Bug Fixes**
  - Safer branch slugs: normalize leading/trailing dots, `..`, and `.lock` to produce valid git refs.
  - Preserve slashes in base branch refs (e.g., `release/2026.05`) by escaping path segments, fixing 404s when fetching `/git/ref/heads/<branch>`.

<sup>Written for commit 58a106acea594825266b70095d94ed016d309651. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

