### PR TITLE
Harden WorkOS AWS deploy wiring

### DIFF
--- a/.github/workflows/aws-api-manual-deploy.yml
+++ b/.github/workflows/aws-api-manual-deploy.yml
@@ -73,6 +73,11 @@ jobs:
       API_CONTAINER_IMAGE: ${{ inputs.api_container_image }}
       API_DATABASE_URL_SECRET_ARN: ${{ secrets.API_DATABASE_URL_SECRET_ARN }}
       API_SESSION_KEY_SECRET_ARN: ${{ secrets.API_SESSION_KEY_SECRET_ARN }}
+      API_FEATURE_WORKOS_LOGIN: ${{ vars.API_FEATURE_WORKOS_LOGIN || '' }}
+      API_WORKOS_CLIENT_ID: ${{ vars.API_WORKOS_CLIENT_ID || '' }}
+      API_WORKOS_ENVIRONMENT_ID: ${{ vars.API_WORKOS_ENVIRONMENT_ID || '' }}
+      API_WORKOS_API_KEY_SECRET_ARN: ${{ secrets.API_WORKOS_API_KEY_SECRET_ARN || '' }}
+      API_WORKOS_WEBHOOK_SECRET_ARN: ${{ secrets.API_WORKOS_WEBHOOK_SECRET_ARN || '' }}
       API_ALLOWED_CIDR_BLOCKS_JSON: ${{ vars.API_ALLOWED_CIDR_BLOCKS_JSON || '["0.0.0.0/0"]' }}
       API_CORS_ALLOWED_ORIGINS_JSON: ${{ vars.API_CORS_ALLOWED_ORIGINS_JSON || '["https://app.identrail.com","https://identrail.com","https://www.identrail.com"]' }}
       API_TRUSTED_PROXY_CIDR_BLOCKS_JSON: ${{ vars.API_TRUSTED_PROXY_CIDR_BLOCKS_JSON || '["10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"]' }}
@@ -120,6 +125,12 @@ jobs:
           fi
           echo "::add-mask::${API_DATABASE_URL_SECRET_ARN}"
           echo "::add-mask::${API_SESSION_KEY_SECRET_ARN}"
+          if [ -n "${API_WORKOS_API_KEY_SECRET_ARN}" ]; then
+            echo "::add-mask::${API_WORKOS_API_KEY_SECRET_ARN}"
+          fi
+          if [ -n "${API_WORKOS_WEBHOOK_SECRET_ARN}" ]; then
+            echo "::add-mask::${API_WORKOS_WEBHOOK_SECRET_ARN}"
+          fi
 
       - name: Configure AWS credentials from GitHub OIDC
         shell: bash

--- a/deploy/aws/terraform/api_hosting.tf
+++ b/deploy/aws/terraform/api_hosting.tf
@@ -39,6 +39,7 @@ locals {
   api_runtime_trusted_proxies = compact([
     for cidr_block in split(",", lookup(local.api_runtime_environment_variables, "IDENTRAIL_TRUSTED_PROXIES", "")) : trimspace(cidr_block)
   ])
+  api_workos_login_enabled = lower(lookup(local.api_runtime_environment_variables, "IDENTRAIL_FEATURE_WORKOS_LOGIN", "")) == "true"
   api_main_route_table_ids = [
     for route_table_id, route_table in data.aws_route_table.api_vpc : route_table_id
     if anytrue([for association in route_table.associations : association.main])
@@ -213,6 +214,16 @@ resource "terraform_data" "api_inputs" {
     precondition {
       condition     = local.api_has_supported_auth
       error_message = "API hosting requires at least one supported auth mode: IDENTRAIL_API_KEY_SCOPES in api_secrets, legacy IDENTRAIL_API_KEYS plus IDENTRAIL_WRITE_API_KEYS in api_secrets, OIDC issuer plus audience, or new auth with IDENTRAIL_FEATURE_NEW_AUTH=true, IDENTRAIL_PUBLIC_BASE_URL, and IDENTRAIL_SESSION_KEY in api_secrets."
+    }
+
+    precondition {
+      condition = !local.api_workos_login_enabled || (
+        contains(local.api_config_names, "IDENTRAIL_WORKOS_CLIENT_ID") &&
+        contains(local.api_config_names, "IDENTRAIL_WORKOS_ENVIRONMENT_ID") &&
+        contains(local.api_secret_config_names, "IDENTRAIL_WORKOS_API_KEY") &&
+        contains(local.api_secret_config_names, "IDENTRAIL_WORKOS_WEBHOOK_SECRET")
+      )
+      error_message = "WorkOS login requires IDENTRAIL_WORKOS_CLIENT_ID and IDENTRAIL_WORKOS_ENVIRONMENT_ID in api_environment_variables, plus IDENTRAIL_WORKOS_API_KEY and IDENTRAIL_WORKOS_WEBHOOK_SECRET in api_secrets."
     }
 
     precondition {

--- a/deploy/aws/terraform/api_hosting.tf
+++ b/deploy/aws/terraform/api_hosting.tf
@@ -218,12 +218,13 @@ resource "terraform_data" "api_inputs" {
 
     precondition {
       condition = !local.api_workos_login_enabled || (
+        local.api_new_auth_enabled &&
         contains(local.api_config_names, "IDENTRAIL_WORKOS_CLIENT_ID") &&
         contains(local.api_config_names, "IDENTRAIL_WORKOS_ENVIRONMENT_ID") &&
         contains(local.api_secret_config_names, "IDENTRAIL_WORKOS_API_KEY") &&
         contains(local.api_secret_config_names, "IDENTRAIL_WORKOS_WEBHOOK_SECRET")
       )
-      error_message = "WorkOS login requires IDENTRAIL_WORKOS_CLIENT_ID and IDENTRAIL_WORKOS_ENVIRONMENT_ID in api_environment_variables, plus IDENTRAIL_WORKOS_API_KEY and IDENTRAIL_WORKOS_WEBHOOK_SECRET in api_secrets."
+      error_message = "WorkOS login requires IDENTRAIL_FEATURE_NEW_AUTH=true, IDENTRAIL_WORKOS_CLIENT_ID, and IDENTRAIL_WORKOS_ENVIRONMENT_ID in api_environment_variables, plus IDENTRAIL_WORKOS_API_KEY and IDENTRAIL_WORKOS_WEBHOOK_SECRET in api_secrets."
     }
 
     precondition {

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -96,6 +96,14 @@ Repository configuration required before the workflow can plan:
   `IDENTRAIL_DATABASE_URL`
 - secret `API_SESSION_KEY_SECRET_ARN`: Secrets Manager ARN containing
   `IDENTRAIL_SESSION_KEY`
+- variable `API_WORKOS_CLIENT_ID`: WorkOS production client ID, such as
+  `client_...`
+- variable `API_WORKOS_ENVIRONMENT_ID`: WorkOS production environment ID, such
+  as `environment_...`
+- secret `API_WORKOS_API_KEY_SECRET_ARN`: Secrets Manager ARN containing
+  `IDENTRAIL_WORKOS_API_KEY`
+- secret `API_WORKOS_WEBHOOK_SECRET_ARN`: Secrets Manager ARN containing
+  `IDENTRAIL_WORKOS_WEBHOOK_SECRET`
 
 The workflow dispatch input `api_container_image` must be immutable, such as
 `ghcr.io/identrail/identrail-api:sha-<commit>`. Do not deploy the mutable `dev`
@@ -106,6 +114,8 @@ Optional repository variables:
 - `API_ALLOWED_CIDR_BLOCKS_JSON`
 - `API_CORS_ALLOWED_ORIGINS_JSON`
 - `API_TRUSTED_PROXY_CIDR_BLOCKS_JSON`
+- `API_FEATURE_WORKOS_LOGIN`: defaults to `true` when the first-class WorkOS
+  deployment settings above are provided
 - `API_EXTRA_ENVIRONMENT_JSON`
 - `API_SECRET_KMS_KEY_ARNS_JSON`
 - `API_CONNECTOR_ROLE_ARNS_JSON`
@@ -113,8 +123,8 @@ Optional repository variables:
 Optional repository secret:
 
 - `API_EXTRA_SECRETS_JSON`: JSON object mapping additional runtime secret
-  environment variable names to Secrets Manager ARNs, such as WorkOS or future
-  provider secrets.
+  environment variable names to Secrets Manager ARNs for future provider
+  secrets. Prefer the first-class WorkOS settings above for hosted auth.
 
 Do not put database URLs, API keys, cookie secrets, or OAuth credentials directly
 in tfvars files, docs, GitHub variables, or Terraform state. Use Secrets Manager

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -96,6 +96,10 @@ Repository configuration required before the workflow can plan:
   `IDENTRAIL_DATABASE_URL`
 - secret `API_SESSION_KEY_SECRET_ARN`: Secrets Manager ARN containing
   `IDENTRAIL_SESSION_KEY`
+
+Hosted WorkOS login is optional. Configure these values only when deploying the
+hosted sign-in/sign-up flow:
+
 - variable `API_WORKOS_CLIENT_ID`: WorkOS production client ID, such as
   `client_...`
 - variable `API_WORKOS_ENVIRONMENT_ID`: WorkOS production environment ID, such

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -179,6 +179,9 @@ func workOSCallbackHandler(logger *zap.Logger, svc *Service, manager sessionauth
 		})
 		if err != nil {
 			auditAuthAction(c.Request.Context(), "auth.login.failure", "", "denied")
+			if logger != nil {
+				logger.Warn("authenticate workos callback", telemetry.ZapError(err))
+			}
 			if errors.Is(err, sessionauth.ErrWorkOSUnavailable) {
 				c.Header("Retry-After", "30")
 				c.JSON(http.StatusServiceUnavailable, gin.H{"error": "auth provider unavailable"})

--- a/scripts/prepare_aws_api_deploy.sh
+++ b/scripts/prepare_aws_api_deploy.sh
@@ -118,6 +118,66 @@ secret_kms_keys="$(json_string_array API_SECRET_KMS_KEY_ARNS_JSON '[]')"
 extra_environment="$(json_string_map API_EXTRA_ENVIRONMENT_JSON)"
 extra_secrets="$(json_string_map API_EXTRA_SECRETS_JSON)"
 
+workos_feature_enabled="$(trim "${API_FEATURE_WORKOS_LOGIN:-}")"
+workos_client_id="$(trim "${API_WORKOS_CLIENT_ID:-}")"
+workos_environment_id="$(trim "${API_WORKOS_ENVIRONMENT_ID:-}")"
+workos_api_key_secret="$(trim "${API_WORKOS_API_KEY_SECRET_ARN:-}")"
+workos_webhook_secret="$(trim "${API_WORKOS_WEBHOOK_SECRET_ARN:-}")"
+workos_environment="{}"
+workos_secrets="{}"
+if [ -n "${workos_feature_enabled}" ] || [ -n "${workos_client_id}" ] || [ -n "${workos_environment_id}" ] || [ -n "${workos_api_key_secret}" ] || [ -n "${workos_webhook_secret}" ]; then
+  if [ -z "${workos_feature_enabled}" ]; then
+    workos_feature_enabled="true"
+  fi
+  case "${workos_feature_enabled}" in
+    true|false) ;;
+    *) fail "API_FEATURE_WORKOS_LOGIN must be true or false when set" ;;
+  esac
+  if [ "${workos_feature_enabled}" = "true" ]; then
+    if [ -z "${workos_client_id}" ]; then
+      fail "API_WORKOS_CLIENT_ID is required when WorkOS login is enabled"
+    fi
+    if [ -z "${workos_environment_id}" ]; then
+      fail "API_WORKOS_ENVIRONMENT_ID is required when WorkOS login is enabled"
+    fi
+    if [ -z "${workos_api_key_secret}" ]; then
+      fail "API_WORKOS_API_KEY_SECRET_ARN is required when WorkOS login is enabled"
+    fi
+    if [ -z "${workos_webhook_secret}" ]; then
+      fail "API_WORKOS_WEBHOOK_SECRET_ARN is required when WorkOS login is enabled"
+    fi
+  fi
+  if [ -n "${workos_client_id}" ] && ! [[ "${workos_client_id}" =~ ^client_[A-Za-z0-9]+$ ]]; then
+    fail "API_WORKOS_CLIENT_ID must look like client_<id>"
+  fi
+  if [ -n "${workos_environment_id}" ] && ! [[ "${workos_environment_id}" =~ ^environment_[A-Za-z0-9]+$ ]]; then
+    fail "API_WORKOS_ENVIRONMENT_ID must look like environment_<id>"
+  fi
+  for secret_arn in "${workos_api_key_secret}" "${workos_webhook_secret}"; do
+    if [ -n "${secret_arn}" ] && ! [[ "${secret_arn}" =~ ^arn:(aws|aws-us-gov|aws-cn):secretsmanager:${aws_region}:[0-9]{12}:secret:.+ ]]; then
+      fail "WorkOS secret references must be Secrets Manager ARNs in ${aws_region}"
+    fi
+  done
+  workos_environment="$(
+    jq -nce \
+      --arg enabled "${workos_feature_enabled}" \
+      --arg client_id "${workos_client_id}" \
+      --arg environment_id "${workos_environment_id}" \
+      '{
+        IDENTRAIL_FEATURE_WORKOS_LOGIN: $enabled
+      }
+      + (if $client_id != "" then {IDENTRAIL_WORKOS_CLIENT_ID: $client_id} else {} end)
+      + (if $environment_id != "" then {IDENTRAIL_WORKOS_ENVIRONMENT_ID: $environment_id} else {} end)'
+  )"
+  workos_secrets="$(
+    jq -nce \
+      --arg api_key_secret "${workos_api_key_secret}" \
+      --arg webhook_secret "${workos_webhook_secret}" \
+      '(if $api_key_secret != "" then {IDENTRAIL_WORKOS_API_KEY: $api_key_secret} else {} end)
+      + (if $webhook_secret != "" then {IDENTRAIL_WORKOS_WEBHOOK_SECRET: $webhook_secret} else {} end)'
+  )"
+fi
+
 api_desired_count="$(trim "${API_DESIRED_COUNT:-1}")"
 api_task_cpu="$(trim "${API_TASK_CPU:-512}")"
 api_task_memory="$(trim "${API_TASK_MEMORY:-1024}")"
@@ -147,6 +207,8 @@ jq -n \
   --argjson api_secret_kms_key_arns "${secret_kms_keys}" \
   --argjson extra_environment "${extra_environment}" \
   --argjson extra_secrets "${extra_secrets}" \
+  --argjson workos_environment "${workos_environment}" \
+  --argjson workos_secrets "${workos_secrets}" \
   --argjson api_desired_count "${api_desired_count}" \
   --argjson api_task_cpu "${api_task_cpu}" \
   --argjson api_task_memory "${api_task_memory}" \
@@ -170,11 +232,11 @@ jq -n \
     api_desired_count: $api_desired_count,
     api_task_cpu: $api_task_cpu,
     api_task_memory: $api_task_memory,
-    api_environment_variables: ($extra_environment + {
+    api_environment_variables: ($extra_environment + $workos_environment + {
       IDENTRAIL_FEATURE_NEW_AUTH: "true",
       IDENTRAIL_PUBLIC_BASE_URL: "https://api.identrail.com"
     }),
-    api_secrets: ($extra_secrets + {
+    api_secrets: ($extra_secrets + $workos_secrets + {
       IDENTRAIL_DATABASE_URL: $api_database_secret,
       IDENTRAIL_SESSION_KEY: $api_session_secret
     }),


### PR DESCRIPTION
No issue: operational WorkOS AWS deploy hardening follow-up.

## What changed

- Adds first-class AWS manual deploy inputs for WorkOS auth: client ID, environment ID, API key secret ARN, and webhook secret ARN.
- Makes the deploy-prep script fail early when WorkOS login is enabled but any required WorkOS setting is missing.
- Adds a Terraform precondition so ECS deploys cannot silently omit WorkOS runtime configuration.
- Logs WorkOS callback exchange failures server-side while keeping the browser response generic.
- Updates the AWS API hosting docs with the exact WorkOS GitHub Actions settings to provide.

## Why

GitHub and Google can correctly hand the browser to WorkOS, but the Identrail API still returns a generic `login failed` if the deployed ECS task is missing WorkOS runtime configuration or WorkOS rejects the callback exchange. The old deploy path only supported generic JSON extras, which made it too easy to miss the WorkOS values while still producing an apparently healthy API.

## Impact and risk

This is backward compatible: existing generic `API_EXTRA_ENVIRONMENT_JSON` and `API_EXTRA_SECRETS_JSON` still work, and WorkOS login remains optional unless the WorkOS deploy inputs are supplied or explicitly enabled. The change makes hosted auth deployment stricter and easier to operate.

## Validation

- `gofmt -w internal/api/auth_routes.go`
- `terraform fmt -check deploy/aws/terraform`
- `git diff --check`
- `bash -n scripts/prepare_aws_api_deploy.sh`
- Positive `scripts/prepare_aws_api_deploy.sh` run verified WorkOS env vars and secret ARNs are emitted into tfvars.
- Negative `scripts/prepare_aws_api_deploy.sh` run verified missing WorkOS secrets fail early.
- `terraform -chdir=deploy/aws/terraform init -backend=false -input=false`
- `terraform -chdir=deploy/aws/terraform validate`
- `go test ./internal/api -run 'WorkOS|Auth'`
- `go test ./internal/api`

AI-assisted: yes
Tools used: Codex
Where used: AWS deploy wiring, Terraform guardrail, auth callback logging, docs
Human verification performed: local formatting, script validation, Terraform validation, and Go tests listed above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened AWS deploy wiring for WorkOS auth with first-class inputs, an explicit feature toggle, stricter validation, and Terraform guardrails. Prevents silent misconfigurations and logs callback failures while keeping browser errors generic.

- **New Features**
  - Adds WorkOS deploy inputs: `API_FEATURE_WORKOS_LOGIN`, `API_WORKOS_CLIENT_ID`, `API_WORKOS_ENVIRONMENT_ID`, `API_WORKOS_API_KEY_SECRET_ARN`, `API_WORKOS_WEBHOOK_SECRET_ARN` (secret ARNs are masked in the workflow).
  - `prepare_aws_api_deploy.sh` auto-enables WorkOS when any WorkOS input is set; fails early if enabled but values are missing; validates `client_...`, `environment_...`, and region-scoped Secrets Manager ARNs; merges WorkOS env/secrets into tfvars.
  - Terraform precondition requires new auth plus all WorkOS env/secrets when WorkOS is enabled and blocks ECS deploys otherwise.
  - Server now logs WorkOS callback exchange failures; client still sees a generic error.
  - Docs updated with exact GitHub Actions settings and guidance to prefer first-class WorkOS settings.

- **Migration**
  - No changes needed unless enabling WorkOS.
  - To enable: set the inputs above; `API_FEATURE_WORKOS_LOGIN` defaults to true when provided. Existing `API_EXTRA_ENVIRONMENT_JSON` and `API_EXTRA_SECRETS_JSON` remain supported.

<sup>Written for commit 159556de51c05c0fb8063574636d500100bbf208. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

