### PR TITLE
Add enterprise SCIM, SAML, residency, and executive report models (ITR-035)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## Unreleased
+- Added the foundational enterprise-tier domain models in `internal/enterprise`:
+  - `SCIMUser` + `SCIMProvisioningEvent` modelling the core SCIM 2.0 user schema and lifecycle operations (create/update/deactivate/delete) for directory-sync sources
+  - `SAMLConnection` with PEM X.509 certificate parsing, https-only SSO URL enforcement, attribute mapping, and `pending → active → disabled` status transitions
+  - `ResidencyPolicy` with a curated region allowlist, advisory/strict enforcement modes, case-insensitive evaluation, and deterministic region ordering for governance hashing
+  - `BuildExecutiveReport` aggregator producing open findings by severity/type, top-N callouts, mean time to resolve, and a week-over-week trend rollup
 - Added a feature-gated authenticated onboarding wizard:
   - persists server-owned setup progress for organization, workspace, connector, first scan, invite, and dashboard-tour steps
   - adds `/v1/onboarding/*` APIs with OpenAPI/authz metadata and memory/Postgres storage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   - `SCIMUser` + `SCIMProvisioningEvent` modelling the core SCIM 2.0 user schema and lifecycle operations (create/update/deactivate/delete) for directory-sync sources
   - `SAMLConnection` with PEM X.509 certificate parsing, https-only SSO URL enforcement, attribute mapping, and `pending → active → disabled` status transitions
   - `ResidencyPolicy` with a curated region allowlist, advisory/strict enforcement modes, case-insensitive evaluation, and deterministic region ordering for governance hashing
-  - `BuildExecutiveReport` aggregator producing open findings by severity/type, top-N callouts, mean time to resolve, and a week-over-week trend rollup
+  - `BuildExecutiveReport` aggregator producing open findings by severity/type, top-N callouts, and a week-over-week trend rollup; expired suppressions are normalized back to open before rollup so leadership metrics do not under-count lapsed work
 - Added a feature-gated authenticated onboarding wizard:
   - persists server-owned setup progress for organization, workspace, connector, first scan, invite, and dashboard-tour steps
   - adds `/v1/onboarding/*` APIs with OpenAPI/authz metadata and memory/Postgres storage

--- a/internal/enterprise/enterprise_test.go
+++ b/internal/enterprise/enterprise_test.go
@@ -21,11 +21,16 @@ func sampleSCIMUser() SCIMUser {
 	return SCIMUser{
 		ID:          "scim-user-1",
 		UserName:    "alice@example.com",
-		Email:       "alice@example.com",
 		DisplayName: "Alice Example",
 		Active:      true,
-		CreatedAt:   time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
-		UpdatedAt:   time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		Emails: []SCIMEmail{
+			{Value: "alice@example.com", Type: "work", Primary: true},
+		},
+		Meta: SCIMMeta{
+			ResourceType: "User",
+			Created:      time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			LastModified: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		},
 	}
 }
 
@@ -39,11 +44,17 @@ func TestSCIMUser_Validate(t *testing.T) {
 	}{
 		{"missing_id", func(u *SCIMUser) { u.ID = "" }},
 		{"missing_username", func(u *SCIMUser) { u.UserName = "" }},
-		{"invalid_email", func(u *SCIMUser) { u.Email = "not-an-email" }},
-		// mail.ParseAddress accepts these mailbox/display forms; SCIMUser.Email
+		{"no_emails", func(u *SCIMUser) { u.Emails = nil }},
+		{"emails_all_empty_values", func(u *SCIMUser) { u.Emails = []SCIMEmail{{Value: "   "}, {Value: ""}} }},
+		{"invalid_email", func(u *SCIMUser) { u.Emails = []SCIMEmail{{Value: "not-an-email", Primary: true}} }},
+		// mail.ParseAddress accepts these mailbox/display forms; SCIM emails
 		// must persist as a canonical addr-spec only.
-		{"email_with_display_name", func(u *SCIMUser) { u.Email = "Alice <alice@example.com>" }},
-		{"email_with_trailing_comment", func(u *SCIMUser) { u.Email = "alice@example.com (Alice)" }},
+		{"email_with_display_name", func(u *SCIMUser) {
+			u.Emails = []SCIMEmail{{Value: "Alice <alice@example.com>", Primary: true}}
+		}},
+		{"email_with_trailing_comment", func(u *SCIMUser) {
+			u.Emails = []SCIMEmail{{Value: "alice@example.com (Alice)", Primary: true}}
+		}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -101,18 +112,26 @@ func TestSCIMProvisioningEvent_Validate(t *testing.T) {
 }
 
 func TestSCIMUser_DecodesStandardSCIMWirePayload(t *testing.T) {
-	// Verbatim payload shape an Okta/Azure AD SCIM client would POST. The
-	// struct tags must use SCIM camelCase attribute names so a future
-	// /scim/v2/Users handler can decode directly without an intermediate DTO.
+	// Verbatim payload shape an Okta/Azure AD SCIM client would POST per
+	// RFC 7643: emails is multi-valued and resource timestamps live under
+	// meta.created / meta.lastModified.
 	const payload = `{
+		"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
 		"id": "scim-user-1",
 		"externalId": "ext-1",
 		"userName": "alice@example.com",
 		"displayName": "Alice Example",
-		"email": "alice@example.com",
 		"active": true,
-		"createdAt": "2026-05-01T00:00:00Z",
-		"updatedAt": "2026-05-01T00:00:00Z"
+		"emails": [
+			{"value": "alice.alt@example.com", "type": "home", "primary": false},
+			{"value": "alice@example.com", "type": "work", "primary": true}
+		],
+		"meta": {
+			"resourceType": "User",
+			"created": "2026-05-01T00:00:00Z",
+			"lastModified": "2026-05-01T00:00:00Z",
+			"location": "https://scim.example.com/v2/Users/scim-user-1"
+		}
 	}`
 	var u SCIMUser
 	if err := json.Unmarshal([]byte(payload), &u); err != nil {
@@ -127,6 +146,15 @@ func TestSCIMUser_DecodesStandardSCIMWirePayload(t *testing.T) {
 	if u.DisplayName != "Alice Example" {
 		t.Errorf("DisplayName: want Alice Example, got %q", u.DisplayName)
 	}
+	if got := u.PrimaryEmail(); got != "alice@example.com" {
+		t.Errorf("PrimaryEmail: want alice@example.com, got %q", got)
+	}
+	if u.Meta.ResourceType != "User" {
+		t.Errorf("Meta.ResourceType: want User, got %q", u.Meta.ResourceType)
+	}
+	if u.Meta.Created.IsZero() {
+		t.Error("Meta.Created should be populated from meta.created")
+	}
 	if err := u.Validate(); err != nil {
 		t.Errorf("decoded SCIM user should validate: %v", err)
 	}
@@ -139,17 +167,38 @@ func TestSCIMUser_MarshalsToSCIMCamelCase(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	want := []string{`"userName":`, `"externalId":`, `"displayName":`, `"createdAt":`, `"updatedAt":`}
+	want := []string{`"userName":`, `"externalId":`, `"displayName":`, `"emails":`, `"meta":`, `"created":`, `"lastModified":`}
 	for _, key := range want {
 		if !strings.Contains(string(encoded), key) {
 			t.Errorf("marshaled output missing SCIM key %s; got %s", key, string(encoded))
 		}
 	}
-	forbidden := []string{`"user_name":`, `"external_id":`, `"display_name":`, `"created_at":`, `"updated_at":`}
+	forbidden := []string{`"user_name":`, `"external_id":`, `"display_name":`, `"created_at":`, `"updated_at":`, `"createdAt":`, `"updatedAt":`}
 	for _, key := range forbidden {
 		if strings.Contains(string(encoded), key) {
-			t.Errorf("marshaled output should not use snake_case key %s; got %s", key, string(encoded))
+			t.Errorf("marshaled output should not use non-SCIM key %s; got %s", key, string(encoded))
 		}
+	}
+}
+
+func TestSCIMUser_PrimaryEmail_PrefersPrimaryThenFirstNonEmpty(t *testing.T) {
+	cases := []struct {
+		name   string
+		emails []SCIMEmail
+		want   string
+	}{
+		{"primary_wins", []SCIMEmail{{Value: "a@example.com"}, {Value: "b@example.com", Primary: true}}, "b@example.com"},
+		{"first_non_empty_when_no_primary", []SCIMEmail{{Value: "   "}, {Value: "c@example.com"}, {Value: "d@example.com"}}, "c@example.com"},
+		{"all_empty", []SCIMEmail{{Value: "  "}, {Value: ""}}, ""},
+		{"nil", nil, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := (SCIMUser{Emails: tc.emails}).PrimaryEmail()
+			if got != tc.want {
+				t.Errorf("PrimaryEmail: want %q, got %q", tc.want, got)
+			}
+		})
 	}
 }
 

--- a/internal/enterprise/enterprise_test.go
+++ b/internal/enterprise/enterprise_test.go
@@ -187,7 +187,9 @@ func TestCanTransitionSAMLStatus(t *testing.T) {
 		want     bool
 	}{
 		{SAMLConnectionPending, SAMLConnectionActive, true},
-		{SAMLConnectionPending, SAMLConnectionDisabled, true},
+		// Pending -> disabled is rejected: a connection must prove a successful
+		// IdP handshake before it can be parked in a disabled state.
+		{SAMLConnectionPending, SAMLConnectionDisabled, false},
 		{SAMLConnectionActive, SAMLConnectionDisabled, true},
 		{SAMLConnectionDisabled, SAMLConnectionActive, true},
 		{SAMLConnectionActive, SAMLConnectionPending, false},
@@ -352,8 +354,45 @@ func TestBuildExecutiveReport_RollsUpOpenBySeverityAndType(t *testing.T) {
 	if _, ok := report.OpenByType[domain.FindingStaleIdentity]; ok {
 		t.Errorf("suppressed findings must not count toward open type rollup")
 	}
-	if report.MeanTimeToResolve != 15*24*time.Hour {
-		t.Errorf("MTTR: want 360h, got %v", report.MeanTimeToResolve)
+}
+
+func TestBuildExecutiveReport_ExpiredSuppressionCountsAsOpen(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	expired := now.Add(-2 * 24 * time.Hour)   // suppression lapsed two days ago
+	stillValid := now.Add(7 * 24 * time.Hour) // suppression still in effect
+
+	findings := []domain.Finding{
+		// Lapsed suppression — should count as open again.
+		{
+			ID: "lapsed", Type: domain.FindingOverPrivileged, Severity: domain.SeverityHigh,
+			CreatedAt: now.Add(-3 * 24 * time.Hour),
+			Triage: domain.FindingTriage{
+				Status:               domain.FindingLifecycleSuppressed,
+				SuppressionExpiresAt: &expired,
+			},
+		},
+		// Still-valid suppression — must remain excluded.
+		{
+			ID: "active-suppression", Type: domain.FindingStaleIdentity, Severity: domain.SeverityMedium,
+			CreatedAt: now.Add(-3 * 24 * time.Hour),
+			Triage: domain.FindingTriage{
+				Status:               domain.FindingLifecycleSuppressed,
+				SuppressionExpiresAt: &stillValid,
+			},
+		},
+	}
+	report := BuildExecutiveReport(findings, ReportOptions{
+		OrganizationID: "org-1",
+		Now:            func() time.Time { return now },
+	})
+	if report.TotalOpenFindings != 1 {
+		t.Errorf("expired suppression should count as open: want 1, got %d", report.TotalOpenFindings)
+	}
+	if report.OpenByType[domain.FindingOverPrivileged] != 1 {
+		t.Errorf("expired suppression should appear in open type rollup, got %v", report.OpenByType)
+	}
+	if _, ok := report.OpenByType[domain.FindingStaleIdentity]; ok {
+		t.Errorf("active suppression must not appear in open type rollup, got %v", report.OpenByType)
 	}
 }
 
@@ -424,9 +463,6 @@ func TestBuildExecutiveReport_EmptyInputIsSafe(t *testing.T) {
 	})
 	if report.TotalOpenFindings != 0 {
 		t.Errorf("empty input: want 0 open, got %d", report.TotalOpenFindings)
-	}
-	if report.MeanTimeToResolve != 0 {
-		t.Errorf("MTTR with no resolved: want 0, got %v", report.MeanTimeToResolve)
 	}
 	if report.TopFindingTypes != nil {
 		t.Errorf("top types must be nil when no findings, got %v", report.TopFindingTypes)

--- a/internal/enterprise/enterprise_test.go
+++ b/internal/enterprise/enterprise_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"encoding/pem"
 	"math/big"
 	"strings"
@@ -96,6 +97,59 @@ func TestSCIMProvisioningEvent_Validate(t *testing.T) {
 	bad.User.Active = false
 	if err := bad.Validate(); err != nil {
 		t.Errorf("deactivate with active=false should pass: %v", err)
+	}
+}
+
+func TestSCIMUser_DecodesStandardSCIMWirePayload(t *testing.T) {
+	// Verbatim payload shape an Okta/Azure AD SCIM client would POST. The
+	// struct tags must use SCIM camelCase attribute names so a future
+	// /scim/v2/Users handler can decode directly without an intermediate DTO.
+	const payload = `{
+		"id": "scim-user-1",
+		"externalId": "ext-1",
+		"userName": "alice@example.com",
+		"displayName": "Alice Example",
+		"email": "alice@example.com",
+		"active": true,
+		"createdAt": "2026-05-01T00:00:00Z",
+		"updatedAt": "2026-05-01T00:00:00Z"
+	}`
+	var u SCIMUser
+	if err := json.Unmarshal([]byte(payload), &u); err != nil {
+		t.Fatalf("unmarshal SCIM payload: %v", err)
+	}
+	if u.UserName != "alice@example.com" {
+		t.Errorf("UserName: want alice@example.com, got %q", u.UserName)
+	}
+	if u.ExternalID != "ext-1" {
+		t.Errorf("ExternalID: want ext-1, got %q", u.ExternalID)
+	}
+	if u.DisplayName != "Alice Example" {
+		t.Errorf("DisplayName: want Alice Example, got %q", u.DisplayName)
+	}
+	if err := u.Validate(); err != nil {
+		t.Errorf("decoded SCIM user should validate: %v", err)
+	}
+}
+
+func TestSCIMUser_MarshalsToSCIMCamelCase(t *testing.T) {
+	u := sampleSCIMUser()
+	u.ExternalID = "ext-99"
+	encoded, err := json.Marshal(u)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := []string{`"userName":`, `"externalId":`, `"displayName":`, `"createdAt":`, `"updatedAt":`}
+	for _, key := range want {
+		if !strings.Contains(string(encoded), key) {
+			t.Errorf("marshaled output missing SCIM key %s; got %s", key, string(encoded))
+		}
+	}
+	forbidden := []string{`"user_name":`, `"external_id":`, `"display_name":`, `"created_at":`, `"updated_at":`}
+	for _, key := range forbidden {
+		if strings.Contains(string(encoded), key) {
+			t.Errorf("marshaled output should not use snake_case key %s; got %s", key, string(encoded))
+		}
 	}
 }
 

--- a/internal/enterprise/enterprise_test.go
+++ b/internal/enterprise/enterprise_test.go
@@ -1,0 +1,434 @@
+package enterprise
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+// ---------- SCIM ----------
+
+func sampleSCIMUser() SCIMUser {
+	return SCIMUser{
+		ID:          "scim-user-1",
+		UserName:    "alice@example.com",
+		Email:       "alice@example.com",
+		DisplayName: "Alice Example",
+		Active:      true,
+		CreatedAt:   time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestSCIMUser_Validate(t *testing.T) {
+	if err := sampleSCIMUser().Validate(); err != nil {
+		t.Errorf("valid user rejected: %v", err)
+	}
+	cases := []struct {
+		name   string
+		mutate func(*SCIMUser)
+	}{
+		{"missing_id", func(u *SCIMUser) { u.ID = "" }},
+		{"missing_username", func(u *SCIMUser) { u.UserName = "" }},
+		{"invalid_email", func(u *SCIMUser) { u.Email = "not-an-email" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u := sampleSCIMUser()
+			tc.mutate(&u)
+			if err := u.Validate(); err == nil {
+				t.Error("expected validation error")
+			}
+		})
+	}
+}
+
+func TestSCIMProvisioningEvent_Validate(t *testing.T) {
+	base := SCIMProvisioningEvent{
+		Op:           SCIMProvisioningCreate,
+		User:         sampleSCIMUser(),
+		SourceTenant: "tenant-1",
+		OccurredAt:   time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+	}
+	if err := base.Validate(); err != nil {
+		t.Errorf("valid event rejected: %v", err)
+	}
+
+	bad := base
+	bad.Op = "rename"
+	if err := bad.Validate(); err == nil {
+		t.Error("expected unknown op rejection")
+	}
+
+	bad = base
+	bad.SourceTenant = ""
+	if err := bad.Validate(); err == nil {
+		t.Error("expected missing tenant rejection")
+	}
+
+	bad = base
+	bad.OccurredAt = time.Time{}
+	if err := bad.Validate(); err == nil {
+		t.Error("expected missing timestamp rejection")
+	}
+
+	bad = base
+	bad.Op = SCIMProvisioningDeactivate
+	bad.User.Active = true
+	if err := bad.Validate(); err == nil {
+		t.Error("deactivate event with active=true should be rejected")
+	}
+
+	bad = base
+	bad.Op = SCIMProvisioningDeactivate
+	bad.User.Active = false
+	if err := bad.Validate(); err != nil {
+		t.Errorf("deactivate with active=false should pass: %v", err)
+	}
+}
+
+// ---------- SAML ----------
+
+// generateSelfSignedCertPEM produces a short-lived self-signed certificate so
+// SAML validation can be exercised without committing real cert material.
+func generateSelfSignedCertPEM(t *testing.T) string {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa keygen: %v", err)
+	}
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "identrail-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+func sampleSAMLConnection(t *testing.T) SAMLConnection {
+	t.Helper()
+	return SAMLConnection{
+		ID:             "saml-1",
+		OrganizationID: "org-1",
+		DisplayName:    "Okta",
+		EntityID:       "https://idp.example.com/entity",
+		SSOURL:         "https://idp.example.com/sso",
+		CertificatePEM: generateSelfSignedCertPEM(t),
+		AttributeMapping: AttributeMapping{
+			Email:  "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+			Name:   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name",
+			Groups: "http://schemas.xmlsoap.org/claims/Group",
+		},
+		Status:    SAMLConnectionPending,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+}
+
+func TestSAMLConnection_Validate(t *testing.T) {
+	if err := sampleSAMLConnection(t).Validate(); err != nil {
+		t.Errorf("valid connection rejected: %v", err)
+	}
+	cases := []struct {
+		name    string
+		mutate  func(*SAMLConnection)
+		wantMsg string
+	}{
+		{"missing_org", func(c *SAMLConnection) { c.OrganizationID = "" }, "organization_id"},
+		{"missing_entity", func(c *SAMLConnection) { c.EntityID = "" }, "entity_id"},
+		{"http_sso_url", func(c *SAMLConnection) { c.SSOURL = "http://idp.example.com/sso" }, "https"},
+		{"empty_attribute_email", func(c *SAMLConnection) { c.AttributeMapping.Email = "" }, "attribute_mapping.email"},
+		{"invalid_status", func(c *SAMLConnection) { c.Status = "rejected" }, "status"},
+		{"bad_certificate", func(c *SAMLConnection) { c.CertificatePEM = "not-a-pem" }, "certificate"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := sampleSAMLConnection(t)
+			tc.mutate(&c)
+			err := c.Validate()
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("error should mention %q, got: %v", tc.wantMsg, err)
+			}
+		})
+	}
+}
+
+func TestParseSAMLCertificate_RejectsNonCertPEMBlock(t *testing.T) {
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(priv),
+	})
+	_, err := ParseSAMLCertificate(string(keyPEM))
+	if err == nil || !strings.Contains(err.Error(), "CERTIFICATE") {
+		t.Errorf("expected non-cert PEM rejection, got: %v", err)
+	}
+}
+
+func TestCanTransitionSAMLStatus(t *testing.T) {
+	cases := []struct {
+		from, to SAMLConnectionStatus
+		want     bool
+	}{
+		{SAMLConnectionPending, SAMLConnectionActive, true},
+		{SAMLConnectionPending, SAMLConnectionDisabled, true},
+		{SAMLConnectionActive, SAMLConnectionDisabled, true},
+		{SAMLConnectionDisabled, SAMLConnectionActive, true},
+		{SAMLConnectionActive, SAMLConnectionPending, false},
+		{SAMLConnectionDisabled, SAMLConnectionPending, false},
+		{"unknown", SAMLConnectionActive, false},
+		{SAMLConnectionActive, "unknown", false},
+	}
+	for _, tc := range cases {
+		got := CanTransitionSAMLStatus(tc.from, tc.to)
+		if got != tc.want {
+			t.Errorf("%s -> %s: want %v, got %v", tc.from, tc.to, tc.want, got)
+		}
+	}
+}
+
+// ---------- Residency ----------
+
+func TestResidencyPolicy_Validate(t *testing.T) {
+	base := ResidencyPolicy{
+		OrganizationID: "org-1",
+		AllowedRegions: []string{"us-east-1"},
+		Mode:           ResidencyModeStrict,
+		UpdatedAt:      time.Now(),
+	}
+	if err := base.Validate(); err != nil {
+		t.Errorf("valid policy rejected: %v", err)
+	}
+
+	bad := base
+	bad.OrganizationID = ""
+	if err := bad.Validate(); err == nil {
+		t.Error("expected missing org rejection")
+	}
+
+	bad = base
+	bad.Mode = "loose"
+	if err := bad.Validate(); err == nil {
+		t.Error("expected unknown mode rejection")
+	}
+
+	bad = base
+	bad.AllowedRegions = nil
+	if err := bad.Validate(); err == nil {
+		t.Error("expected empty allowlist rejection")
+	}
+
+	bad = base
+	bad.AllowedRegions = []string{"us-east1"} // typo
+	if err := bad.Validate(); err == nil {
+		t.Error("expected unrecognized region rejection")
+	}
+}
+
+func TestResidencyPolicy_Evaluate(t *testing.T) {
+	strict := ResidencyPolicy{
+		OrganizationID: "org-1",
+		AllowedRegions: []string{"us-east-1", "eu-west-1"},
+		Mode:           ResidencyModeStrict,
+	}
+	if d := strict.Evaluate("us-east-1"); !d.Allowed {
+		t.Errorf("strict mode should allow us-east-1, got: %+v", d)
+	}
+	if d := strict.Evaluate("ap-northeast-1"); d.Allowed {
+		t.Errorf("strict mode must block disallowed region, got: %+v", d)
+	} else if !strings.Contains(d.Reason, "not in the organization's allowed residency set") {
+		t.Errorf("expected reason text, got: %q", d.Reason)
+	}
+
+	advisory := strict
+	advisory.Mode = ResidencyModeAdvisory
+	d := advisory.Evaluate("ap-northeast-1")
+	if !d.Allowed {
+		t.Error("advisory mode should always allow")
+	}
+	if d.Reason == "" {
+		t.Error("advisory mode should record reason on violation")
+	}
+}
+
+func TestResidencyPolicy_EvaluateNormalizesCase(t *testing.T) {
+	p := ResidencyPolicy{
+		OrganizationID: "org-1",
+		AllowedRegions: []string{"US-East-1"},
+		Mode:           ResidencyModeStrict,
+	}
+	if d := p.Evaluate("us-east-1"); !d.Allowed {
+		t.Errorf("region comparison must be case-insensitive, got: %+v", d)
+	}
+}
+
+func TestIsRecognizedResidencyRegion(t *testing.T) {
+	if !IsRecognizedResidencyRegion("us-east-1") {
+		t.Error("us-east-1 should be recognized")
+	}
+	if !IsRecognizedResidencyRegion("EU-WEST-1") {
+		t.Error("case-insensitive match expected")
+	}
+	if IsRecognizedResidencyRegion("us-east1") {
+		t.Error("us-east1 typo must not be recognized")
+	}
+}
+
+func TestResidencyPolicy_SortedAllowedRegionsDeterministic(t *testing.T) {
+	p := ResidencyPolicy{AllowedRegions: []string{"eu-west-1", "us-east-1", "ap-southeast-1"}}
+	got := p.SortedAllowedRegions()
+	want := []string{"ap-southeast-1", "eu-west-1", "us-east-1"}
+	if len(got) != len(want) {
+		t.Fatalf("length: want %d, got %d", len(want), len(got))
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("position %d: want %s, got %s", i, w, got[i])
+		}
+	}
+}
+
+// ---------- Executive report ----------
+
+func ptrTime(t time.Time) *time.Time { return &t }
+
+func TestBuildExecutiveReport_RollsUpOpenBySeverityAndType(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	findings := []domain.Finding{
+		{
+			ID: "f1", Type: domain.FindingOverPrivileged, Severity: domain.SeverityHigh,
+			CreatedAt: now.Add(-3 * 24 * time.Hour),
+			Triage:    domain.FindingTriage{Status: domain.FindingLifecycleOpen},
+		},
+		{
+			ID: "f2", Type: domain.FindingOverPrivileged, Severity: domain.SeverityCritical,
+			CreatedAt: now.Add(-2 * 24 * time.Hour),
+			Triage:    domain.FindingTriage{Status: domain.FindingLifecycleAck},
+		},
+		{
+			ID: "f3", Type: domain.FindingStaleIdentity, Severity: domain.SeverityMedium,
+			CreatedAt: now.Add(-1 * 24 * time.Hour),
+			Triage:    domain.FindingTriage{Status: domain.FindingLifecycleSuppressed},
+		},
+		{
+			ID: "f4", Type: domain.FindingEscalationPath, Severity: domain.SeverityCritical,
+			CreatedAt: now.Add(-30 * 24 * time.Hour),
+			Triage: domain.FindingTriage{
+				Status:    domain.FindingLifecycleResolved,
+				UpdatedAt: ptrTime(now.Add(-15 * 24 * time.Hour)),
+			},
+		},
+	}
+	report := BuildExecutiveReport(findings, ReportOptions{
+		OrganizationID: "org-1",
+		Now:            func() time.Time { return now },
+	})
+
+	if report.TotalOpenFindings != 2 {
+		t.Errorf("total open: want 2 (open + ack), got %d", report.TotalOpenFindings)
+	}
+	if report.OpenBySeverity[domain.SeverityHigh] != 1 {
+		t.Errorf("severity high count: want 1, got %d", report.OpenBySeverity[domain.SeverityHigh])
+	}
+	if report.OpenBySeverity[domain.SeverityCritical] != 1 {
+		t.Errorf("severity critical count: want 1, got %d", report.OpenBySeverity[domain.SeverityCritical])
+	}
+	if _, ok := report.OpenByType[domain.FindingStaleIdentity]; ok {
+		t.Errorf("suppressed findings must not count toward open type rollup")
+	}
+	if report.MeanTimeToResolve != 15*24*time.Hour {
+		t.Errorf("MTTR: want 360h, got %v", report.MeanTimeToResolve)
+	}
+}
+
+func TestBuildExecutiveReport_TopFindingTypesAreOrderedAndCapped(t *testing.T) {
+	now := time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC)
+	findings := []domain.Finding{}
+	add := func(typ domain.FindingType, n int) {
+		for i := 0; i < n; i++ {
+			findings = append(findings, domain.Finding{
+				ID: string(typ) + "-" + string(rune('a'+i)), Type: typ, Severity: domain.SeverityHigh,
+				CreatedAt: now.Add(-1 * time.Hour),
+				Triage:    domain.FindingTriage{Status: domain.FindingLifecycleOpen},
+			})
+		}
+	}
+	add(domain.FindingOverPrivileged, 5)
+	add(domain.FindingStaleIdentity, 3)
+	add(domain.FindingEscalationPath, 4)
+	add(domain.FindingOwnerless, 1)
+
+	report := BuildExecutiveReport(findings, ReportOptions{
+		OrganizationID: "org-1",
+		Now:            func() time.Time { return now },
+		TopN:           3,
+	})
+
+	if len(report.TopFindingTypes) != 3 {
+		t.Fatalf("top types: want 3, got %d", len(report.TopFindingTypes))
+	}
+	if report.TopFindingTypes[0].Type != domain.FindingOverPrivileged || report.TopFindingTypes[0].Count != 5 {
+		t.Errorf("top entry: want overprivileged(5), got %+v", report.TopFindingTypes[0])
+	}
+	if report.TopFindingTypes[1].Type != domain.FindingEscalationPath || report.TopFindingTypes[1].Count != 4 {
+		t.Errorf("second entry: want escalation(4), got %+v", report.TopFindingTypes[1])
+	}
+}
+
+func TestBuildExecutiveReport_WeekOverWeekTrend(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	findings := []domain.Finding{
+		// Current week (within 7 days).
+		{ID: "a", Type: domain.FindingOverPrivileged, CreatedAt: now.Add(-2 * 24 * time.Hour)},
+		{ID: "b", Type: domain.FindingOverPrivileged, CreatedAt: now.Add(-3 * 24 * time.Hour)},
+		// Previous week (7-14 days ago).
+		{ID: "c", Type: domain.FindingOverPrivileged, CreatedAt: now.Add(-9 * 24 * time.Hour)},
+		// Older — should not count in either window.
+		{ID: "d", Type: domain.FindingOverPrivileged, CreatedAt: now.Add(-30 * 24 * time.Hour)},
+	}
+	report := BuildExecutiveReport(findings, ReportOptions{
+		OrganizationID: "org-1",
+		Now:            func() time.Time { return now },
+	})
+	if report.WeekOverWeek.CurrentCount != 2 {
+		t.Errorf("current count: want 2, got %d", report.WeekOverWeek.CurrentCount)
+	}
+	if report.WeekOverWeek.PreviousCount != 1 {
+		t.Errorf("previous count: want 1, got %d", report.WeekOverWeek.PreviousCount)
+	}
+	if report.WeekOverWeek.Delta != 1 {
+		t.Errorf("delta: want 1, got %d", report.WeekOverWeek.Delta)
+	}
+}
+
+func TestBuildExecutiveReport_EmptyInputIsSafe(t *testing.T) {
+	report := BuildExecutiveReport(nil, ReportOptions{
+		OrganizationID: "org-1",
+		Now:            func() time.Time { return time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC) },
+	})
+	if report.TotalOpenFindings != 0 {
+		t.Errorf("empty input: want 0 open, got %d", report.TotalOpenFindings)
+	}
+	if report.MeanTimeToResolve != 0 {
+		t.Errorf("MTTR with no resolved: want 0, got %v", report.MeanTimeToResolve)
+	}
+	if report.TopFindingTypes != nil {
+		t.Errorf("top types must be nil when no findings, got %v", report.TopFindingTypes)
+	}
+}

--- a/internal/enterprise/enterprise_test.go
+++ b/internal/enterprise/enterprise_test.go
@@ -39,6 +39,10 @@ func TestSCIMUser_Validate(t *testing.T) {
 		{"missing_id", func(u *SCIMUser) { u.ID = "" }},
 		{"missing_username", func(u *SCIMUser) { u.UserName = "" }},
 		{"invalid_email", func(u *SCIMUser) { u.Email = "not-an-email" }},
+		// mail.ParseAddress accepts these mailbox/display forms; SCIMUser.Email
+		// must persist as a canonical addr-spec only.
+		{"email_with_display_name", func(u *SCIMUser) { u.Email = "Alice <alice@example.com>" }},
+		{"email_with_trailing_comment", func(u *SCIMUser) { u.Email = "alice@example.com (Alice)" }},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/enterprise/enterprise_test.go
+++ b/internal/enterprise/enterprise_test.go
@@ -99,6 +99,28 @@ func TestSCIMProvisioningEvent_Validate(t *testing.T) {
 	}
 }
 
+func TestSCIMProvisioningEvent_DeleteAcceptsIDOnlyPayload(t *testing.T) {
+	// SCIM DELETE /Users/{id} carries no resource body, so the event only
+	// needs the user ID — full user payload validation must not be required.
+	event := SCIMProvisioningEvent{
+		Op:           SCIMProvisioningDelete,
+		User:         SCIMUser{ID: "scim-user-1"},
+		SourceTenant: "tenant-1",
+		OccurredAt:   time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+	}
+	if err := event.Validate(); err != nil {
+		t.Errorf("id-only delete event should pass: %v", err)
+	}
+
+	// But the user ID itself remains mandatory so the consumer knows what to
+	// deprovision.
+	noID := event
+	noID.User = SCIMUser{}
+	if err := noID.Validate(); err == nil {
+		t.Error("delete event without user.id should be rejected")
+	}
+}
+
 // ---------- SAML ----------
 
 // generateSelfSignedCertPEM produces a short-lived self-signed certificate so

--- a/internal/enterprise/enterprise_test.go
+++ b/internal/enterprise/enterprise_test.go
@@ -42,11 +42,16 @@ func TestSCIMUser_Validate(t *testing.T) {
 		name   string
 		mutate func(*SCIMUser)
 	}{
-		{"missing_id", func(u *SCIMUser) { u.ID = "" }},
 		{"missing_username", func(u *SCIMUser) { u.UserName = "" }},
 		{"no_emails", func(u *SCIMUser) { u.Emails = nil }},
 		{"emails_all_empty_values", func(u *SCIMUser) { u.Emails = []SCIMEmail{{Value: "   "}, {Value: ""}} }},
 		{"invalid_email", func(u *SCIMUser) { u.Emails = []SCIMEmail{{Value: "not-an-email", Primary: true}} }},
+		{"multiple_primaries", func(u *SCIMUser) {
+			u.Emails = []SCIMEmail{
+				{Value: "alice@example.com", Primary: true},
+				{Value: "alice.alt@example.com", Primary: true},
+			}
+		}},
 		// mail.ParseAddress accepts these mailbox/display forms; SCIM emails
 		// must persist as a canonical addr-spec only.
 		{"email_with_display_name", func(u *SCIMUser) {
@@ -199,6 +204,49 @@ func TestSCIMUser_PrimaryEmail_PrefersPrimaryThenFirstNonEmpty(t *testing.T) {
 				t.Errorf("PrimaryEmail: want %q, got %q", tc.want, got)
 			}
 		})
+	}
+}
+
+func TestSCIMUser_ValidateAcceptsMissingIDForCreatePath(t *testing.T) {
+	// SCIM 2.0 servers assign `id` on POST /Users, so the resource arrives
+	// without one. The user-level validator must not block that case; the
+	// provisioning event validator enforces id for update/deactivate/delete.
+	u := sampleSCIMUser()
+	u.ID = ""
+	if err := u.Validate(); err != nil {
+		t.Errorf("SCIMUser.Validate must accept a missing id (create path): %v", err)
+	}
+}
+
+func TestSCIMProvisioningEvent_CreateAllowsMissingUserID(t *testing.T) {
+	user := sampleSCIMUser()
+	user.ID = ""
+	event := SCIMProvisioningEvent{
+		Op:           SCIMProvisioningCreate,
+		User:         user,
+		SourceTenant: "tenant-1",
+		OccurredAt:   time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+	}
+	if err := event.Validate(); err != nil {
+		t.Errorf("create event must accept missing user.id: %v", err)
+	}
+}
+
+func TestSCIMProvisioningEvent_UpdateRequiresUserID(t *testing.T) {
+	user := sampleSCIMUser()
+	user.ID = ""
+	event := SCIMProvisioningEvent{
+		Op:           SCIMProvisioningUpdate,
+		User:         user,
+		SourceTenant: "tenant-1",
+		OccurredAt:   time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+	}
+	err := event.Validate()
+	if err == nil {
+		t.Fatal("update event without user.id should be rejected")
+	}
+	if !strings.Contains(err.Error(), "user.id") {
+		t.Errorf("error should mention user.id, got: %v", err)
 	}
 }
 

--- a/internal/enterprise/report.go
+++ b/internal/enterprise/report.go
@@ -1,0 +1,157 @@
+package enterprise
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+// ExecutiveReport is a deterministic rollup of finding state suitable for
+// leadership consumption: open volume by severity, top finding types, mean
+// time to resolve, and week-over-week trend.
+type ExecutiveReport struct {
+	OrganizationID    string                         `json:"organization_id"`
+	GeneratedAt       time.Time                      `json:"generated_at"`
+	WindowStart       time.Time                      `json:"window_start"`
+	WindowEnd         time.Time                      `json:"window_end"`
+	TotalOpenFindings int                            `json:"total_open_findings"`
+	OpenBySeverity    map[domain.FindingSeverity]int `json:"open_by_severity"`
+	OpenByType        map[domain.FindingType]int     `json:"open_by_type"`
+	TopFindingTypes   []TopFindingType               `json:"top_finding_types"`
+	MeanTimeToResolve time.Duration                  `json:"mean_time_to_resolve"`
+	WeekOverWeek      WeekOverWeekTrend              `json:"week_over_week"`
+}
+
+// TopFindingType records the count of one finding type within the report
+// window, used for the executive top-N callout.
+type TopFindingType struct {
+	Type  domain.FindingType `json:"type"`
+	Count int                `json:"count"`
+}
+
+// WeekOverWeekTrend captures the delta in created-findings volume between the
+// trailing 7-day window and the prior 7-day window.
+type WeekOverWeekTrend struct {
+	CurrentCount  int `json:"current_count"`
+	PreviousCount int `json:"previous_count"`
+	Delta         int `json:"delta"`
+}
+
+// ReportOptions parameterizes BuildExecutiveReport. Now defaults to time.Now()
+// when nil so callers in tests can inject a deterministic clock.
+type ReportOptions struct {
+	OrganizationID string
+	Now            func() time.Time
+	TopN           int
+}
+
+// BuildExecutiveReport aggregates a finding slice into an ExecutiveReport.
+// The function is pure (no I/O) and deterministic given fixed inputs, which
+// keeps it cheap to call from the API layer and easy to unit-test.
+func BuildExecutiveReport(findings []domain.Finding, opts ReportOptions) ExecutiveReport {
+	now := opts.now()
+	windowStart := now.Add(-7 * 24 * time.Hour)
+	previousWindowStart := now.Add(-14 * 24 * time.Hour)
+	topN := opts.TopN
+	if topN <= 0 {
+		topN = 5
+	}
+
+	report := ExecutiveReport{
+		OrganizationID: strings.TrimSpace(opts.OrganizationID),
+		GeneratedAt:    now,
+		WindowStart:    windowStart,
+		WindowEnd:      now,
+		OpenBySeverity: map[domain.FindingSeverity]int{},
+		OpenByType:     map[domain.FindingType]int{},
+	}
+
+	var totalResolveDuration time.Duration
+	var resolvedCount int
+	currentWeek := 0
+	previousWeek := 0
+
+	for _, finding := range findings {
+		status := finding.Triage.Status
+		if status == "" {
+			status = domain.FindingLifecycleOpen
+		}
+
+		// Open rollups exclude suppressed/resolved findings.
+		if status == domain.FindingLifecycleOpen || status == domain.FindingLifecycleAck {
+			report.TotalOpenFindings++
+			report.OpenBySeverity[finding.Severity]++
+			report.OpenByType[finding.Type]++
+		}
+
+		if status == domain.FindingLifecycleResolved && !finding.CreatedAt.IsZero() {
+			resolvedAt := triageResolutionTime(finding)
+			if !resolvedAt.IsZero() && resolvedAt.After(finding.CreatedAt) {
+				totalResolveDuration += resolvedAt.Sub(finding.CreatedAt)
+				resolvedCount++
+			}
+		}
+
+		created := finding.CreatedAt
+		if created.IsZero() {
+			continue
+		}
+		switch {
+		case !created.Before(windowStart) && !created.After(now):
+			currentWeek++
+		case !created.Before(previousWindowStart) && created.Before(windowStart):
+			previousWeek++
+		}
+	}
+
+	if resolvedCount > 0 {
+		report.MeanTimeToResolve = totalResolveDuration / time.Duration(resolvedCount)
+	}
+	report.WeekOverWeek = WeekOverWeekTrend{
+		CurrentCount:  currentWeek,
+		PreviousCount: previousWeek,
+		Delta:         currentWeek - previousWeek,
+	}
+	report.TopFindingTypes = topFindingTypes(report.OpenByType, topN)
+	return report
+}
+
+func topFindingTypes(counts map[domain.FindingType]int, topN int) []TopFindingType {
+	if len(counts) == 0 {
+		return nil
+	}
+	items := make([]TopFindingType, 0, len(counts))
+	for typ, count := range counts {
+		items = append(items, TopFindingType{Type: typ, Count: count})
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].Count != items[j].Count {
+			return items[i].Count > items[j].Count
+		}
+		return items[i].Type < items[j].Type
+	})
+	if len(items) > topN {
+		items = items[:topN]
+	}
+	return items
+}
+
+// triageResolutionTime returns the most reliable resolution timestamp we can
+// derive from the finding's triage metadata. Triage.UpdatedAt is the moment of
+// the most recent lifecycle transition; for findings whose terminal status is
+// "resolved", that timestamp is a faithful proxy for resolution time.
+func triageResolutionTime(finding domain.Finding) time.Time {
+	if finding.Triage.UpdatedAt != nil && !finding.Triage.UpdatedAt.IsZero() {
+		return *finding.Triage.UpdatedAt
+	}
+	return time.Time{}
+}
+
+func (o ReportOptions) now() time.Time {
+	if o.Now != nil {
+		return o.Now()
+	}
+	return time.Now().UTC()
+}

--- a/internal/enterprise/report.go
+++ b/internal/enterprise/report.go
@@ -9,8 +9,15 @@ import (
 )
 
 // ExecutiveReport is a deterministic rollup of finding state suitable for
-// leadership consumption: open volume by severity, top finding types, mean
-// time to resolve, and week-over-week trend.
+// leadership consumption: open volume by severity, top finding types, and
+// week-over-week trend.
+//
+// MeanTimeToResolve is deliberately omitted from this first cut: the current
+// FindingTriage schema only records a `last-updated` timestamp that mutates on
+// every triage change (including comment-only and assignee edits), so deriving
+// a faithful MTTR requires a dedicated resolved-at timestamp or a lifecycle
+// history table. That work is tracked separately so the executive report
+// cannot silently surface a materially incorrect figure.
 type ExecutiveReport struct {
 	OrganizationID    string                         `json:"organization_id"`
 	GeneratedAt       time.Time                      `json:"generated_at"`
@@ -20,7 +27,6 @@ type ExecutiveReport struct {
 	OpenBySeverity    map[domain.FindingSeverity]int `json:"open_by_severity"`
 	OpenByType        map[domain.FindingType]int     `json:"open_by_type"`
 	TopFindingTypes   []TopFindingType               `json:"top_finding_types"`
-	MeanTimeToResolve time.Duration                  `json:"mean_time_to_resolve"`
 	WeekOverWeek      WeekOverWeekTrend              `json:"week_over_week"`
 }
 
@@ -68,30 +74,17 @@ func BuildExecutiveReport(findings []domain.Finding, opts ReportOptions) Executi
 		OpenByType:     map[domain.FindingType]int{},
 	}
 
-	var totalResolveDuration time.Duration
-	var resolvedCount int
 	currentWeek := 0
 	previousWeek := 0
 
 	for _, finding := range findings {
-		status := finding.Triage.Status
-		if status == "" {
-			status = domain.FindingLifecycleOpen
-		}
+		status := effectiveStatus(finding, now)
 
 		// Open rollups exclude suppressed/resolved findings.
 		if status == domain.FindingLifecycleOpen || status == domain.FindingLifecycleAck {
 			report.TotalOpenFindings++
 			report.OpenBySeverity[finding.Severity]++
 			report.OpenByType[finding.Type]++
-		}
-
-		if status == domain.FindingLifecycleResolved && !finding.CreatedAt.IsZero() {
-			resolvedAt := triageResolutionTime(finding)
-			if !resolvedAt.IsZero() && resolvedAt.After(finding.CreatedAt) {
-				totalResolveDuration += resolvedAt.Sub(finding.CreatedAt)
-				resolvedCount++
-			}
 		}
 
 		created := finding.CreatedAt
@@ -106,9 +99,6 @@ func BuildExecutiveReport(findings []domain.Finding, opts ReportOptions) Executi
 		}
 	}
 
-	if resolvedCount > 0 {
-		report.MeanTimeToResolve = totalResolveDuration / time.Duration(resolvedCount)
-	}
 	report.WeekOverWeek = WeekOverWeekTrend{
 		CurrentCount:  currentWeek,
 		PreviousCount: previousWeek,
@@ -138,15 +128,22 @@ func topFindingTypes(counts map[domain.FindingType]int, topN int) []TopFindingTy
 	return items
 }
 
-// triageResolutionTime returns the most reliable resolution timestamp we can
-// derive from the finding's triage metadata. Triage.UpdatedAt is the moment of
-// the most recent lifecycle transition; for findings whose terminal status is
-// "resolved", that timestamp is a faithful proxy for resolution time.
-func triageResolutionTime(finding domain.Finding) time.Time {
-	if finding.Triage.UpdatedAt != nil && !finding.Triage.UpdatedAt.IsZero() {
-		return *finding.Triage.UpdatedAt
+// effectiveStatus normalizes a finding's triage status against the current
+// clock so the executive rollup does not under-count open work. A finding
+// marked suppressed whose SuppressionExpiresAt has already passed is treated
+// as open again — the suppression has lapsed even if the persistence layer has
+// not yet rewritten the row.
+func effectiveStatus(finding domain.Finding, now time.Time) domain.FindingLifecycleStatus {
+	status := finding.Triage.Status
+	if status == "" {
+		return domain.FindingLifecycleOpen
 	}
-	return time.Time{}
+	if status == domain.FindingLifecycleSuppressed {
+		if expires := finding.Triage.SuppressionExpiresAt; expires != nil && !expires.IsZero() && !now.Before(*expires) {
+			return domain.FindingLifecycleOpen
+		}
+	}
+	return status
 }
 
 func (o ReportOptions) now() time.Time {

--- a/internal/enterprise/residency.go
+++ b/internal/enterprise/residency.go
@@ -1,0 +1,113 @@
+package enterprise
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ResidencyMode controls how strictly the policy is enforced.
+type ResidencyMode string
+
+const (
+	// ResidencyModeAdvisory records violations but does not block writes; useful
+	// during initial rollout.
+	ResidencyModeAdvisory ResidencyMode = "advisory"
+	// ResidencyModeStrict refuses writes whose target region is not in the
+	// allowlist.
+	ResidencyModeStrict ResidencyMode = "strict"
+)
+
+// recognizedResidencyRegions enumerates the regions Identrail supports for
+// data-residency declarations. Keeping this central avoids accepting typos
+// like "us-east1" or "EU-WEST-1" that would silently fail closed at the
+// storage layer.
+var recognizedResidencyRegions = map[string]struct{}{
+	"us-east-1":      {},
+	"us-east-2":      {},
+	"us-west-2":      {},
+	"eu-west-1":      {},
+	"eu-central-1":   {},
+	"ap-southeast-1": {},
+	"ap-southeast-2": {},
+	"ap-northeast-1": {},
+}
+
+// IsRecognizedResidencyRegion reports whether region is a known data-residency
+// region. Comparison is case-insensitive.
+func IsRecognizedResidencyRegion(region string) bool {
+	_, ok := recognizedResidencyRegions[strings.ToLower(strings.TrimSpace(region))]
+	return ok
+}
+
+// ResidencyPolicy is the per-organization data-residency contract. A workspace
+// or scan whose target region is not in AllowedRegions must be rejected under
+// strict mode and recorded as a violation under advisory mode.
+type ResidencyPolicy struct {
+	OrganizationID string        `json:"organization_id"`
+	AllowedRegions []string      `json:"allowed_regions"`
+	Mode           ResidencyMode `json:"mode"`
+	UpdatedAt      time.Time     `json:"updated_at"`
+}
+
+// Validate enforces ResidencyPolicy invariants.
+func (p ResidencyPolicy) Validate() error {
+	if strings.TrimSpace(p.OrganizationID) == "" {
+		return fmt.Errorf("residency policy organization_id is required")
+	}
+	if !validResidencyMode(p.Mode) {
+		return fmt.Errorf("residency policy mode %q is not recognized", p.Mode)
+	}
+	if len(p.AllowedRegions) == 0 {
+		return fmt.Errorf("residency policy must declare at least one allowed_region")
+	}
+	for _, region := range p.AllowedRegions {
+		if !IsRecognizedResidencyRegion(region) {
+			return fmt.Errorf("residency policy allowed_region %q is not recognized", region)
+		}
+	}
+	return nil
+}
+
+// ResidencyDecision is the outcome of evaluating one write against a policy.
+type ResidencyDecision struct {
+	Allowed bool
+	Reason  string
+}
+
+// Evaluate decides whether a write targeted at the given region is permitted.
+// Under advisory mode the decision always allows the write, but Reason carries
+// any violation so the caller can record it for governance.
+func (p ResidencyPolicy) Evaluate(region string) ResidencyDecision {
+	normalized := strings.ToLower(strings.TrimSpace(region))
+	for _, allowed := range p.AllowedRegions {
+		if strings.ToLower(strings.TrimSpace(allowed)) == normalized {
+			return ResidencyDecision{Allowed: true}
+		}
+	}
+	reason := fmt.Sprintf("region %q is not in the organization's allowed residency set", region)
+	if p.Mode == ResidencyModeAdvisory {
+		return ResidencyDecision{Allowed: true, Reason: reason}
+	}
+	return ResidencyDecision{Allowed: false, Reason: reason}
+}
+
+// SortedAllowedRegions returns a copy of the allowlist with deterministic
+// ordering, convenient for hashing/comparison and stable rendering.
+func (p ResidencyPolicy) SortedAllowedRegions() []string {
+	out := make([]string, len(p.AllowedRegions))
+	for i, r := range p.AllowedRegions {
+		out[i] = strings.ToLower(strings.TrimSpace(r))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func validResidencyMode(m ResidencyMode) bool {
+	switch m {
+	case ResidencyModeAdvisory, ResidencyModeStrict:
+		return true
+	}
+	return false
+}

--- a/internal/enterprise/saml.go
+++ b/internal/enterprise/saml.go
@@ -92,8 +92,10 @@ func ParseSAMLCertificate(pemEncoded string) (*x509.Certificate, error) {
 }
 
 // CanTransitionSAMLStatus reports whether a SAML connection may move from one
-// status to another. Connections must enroll via pending → active and may be
-// disabled/re-enabled afterward; outright deletion is handled separately.
+// status to another. Connections must enroll via pending → active before they
+// can be disabled/re-enabled; jumping straight from pending to disabled is
+// rejected so that a connection cannot be parked in a disabled state without
+// ever having proved a successful IdP handshake.
 func CanTransitionSAMLStatus(from, to SAMLConnectionStatus) bool {
 	if !validSAMLConnectionStatus(from) || !validSAMLConnectionStatus(to) {
 		return false
@@ -103,7 +105,7 @@ func CanTransitionSAMLStatus(from, to SAMLConnectionStatus) bool {
 	}
 	switch from {
 	case SAMLConnectionPending:
-		return to == SAMLConnectionActive || to == SAMLConnectionDisabled
+		return to == SAMLConnectionActive
 	case SAMLConnectionActive:
 		return to == SAMLConnectionDisabled
 	case SAMLConnectionDisabled:

--- a/internal/enterprise/saml.go
+++ b/internal/enterprise/saml.go
@@ -1,0 +1,139 @@
+package enterprise
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// SAMLConnectionStatus tracks the rollout state of a SAML connection.
+type SAMLConnectionStatus string
+
+const (
+	SAMLConnectionPending  SAMLConnectionStatus = "pending"
+	SAMLConnectionActive   SAMLConnectionStatus = "active"
+	SAMLConnectionDisabled SAMLConnectionStatus = "disabled"
+)
+
+// SAMLConnection models a federated SAML identity provider trust between an
+// Identrail organization and an external IdP. The certificate is stored as a
+// PEM-encoded X.509 string so the operator can hot-rotate via update without
+// touching DER blobs.
+type SAMLConnection struct {
+	ID               string               `json:"id"`
+	OrganizationID   string               `json:"organization_id"`
+	DisplayName      string               `json:"display_name"`
+	EntityID         string               `json:"entity_id"`
+	SSOURL           string               `json:"sso_url"`
+	CertificatePEM   string               `json:"certificate_pem"`
+	AttributeMapping AttributeMapping     `json:"attribute_mapping"`
+	Status           SAMLConnectionStatus `json:"status"`
+	CreatedAt        time.Time            `json:"created_at"`
+	UpdatedAt        time.Time            `json:"updated_at"`
+}
+
+// AttributeMapping describes how IdP-provided SAML attributes map onto
+// Identrail's internal user attributes. Empty values fall back to sensible
+// defaults at the consumer.
+type AttributeMapping struct {
+	Email  string `json:"email"`
+	Name   string `json:"name,omitempty"`
+	Groups string `json:"groups,omitempty"`
+}
+
+// Validate enforces SAML connection invariants relevant for safe federation.
+// The SSO URL must use https (the SAML POST binding embeds the assertion in
+// the response body; plaintext transport would leak credentials), and the
+// certificate must be a parseable X.509 PEM block.
+func (c SAMLConnection) Validate() error {
+	if strings.TrimSpace(c.OrganizationID) == "" {
+		return fmt.Errorf("saml connection organization_id is required")
+	}
+	if strings.TrimSpace(c.EntityID) == "" {
+		return fmt.Errorf("saml connection entity_id is required")
+	}
+	if err := validateHTTPSURL(c.SSOURL); err != nil {
+		return fmt.Errorf("saml sso_url %q is invalid: %w", c.SSOURL, err)
+	}
+	if strings.TrimSpace(c.AttributeMapping.Email) == "" {
+		return fmt.Errorf("saml attribute_mapping.email is required")
+	}
+	if !validSAMLConnectionStatus(c.Status) {
+		return fmt.Errorf("saml connection status %q is not recognized", c.Status)
+	}
+	if _, err := ParseSAMLCertificate(c.CertificatePEM); err != nil {
+		return fmt.Errorf("saml certificate invalid: %w", err)
+	}
+	return nil
+}
+
+// ParseSAMLCertificate parses a PEM-encoded X.509 certificate and returns it.
+// Exported so API and persistence layers can reuse the same parse path.
+func ParseSAMLCertificate(pemEncoded string) (*x509.Certificate, error) {
+	pemEncoded = strings.TrimSpace(pemEncoded)
+	if pemEncoded == "" {
+		return nil, fmt.Errorf("certificate_pem is empty")
+	}
+	block, _ := pem.Decode([]byte(pemEncoded))
+	if block == nil {
+		return nil, fmt.Errorf("certificate_pem is not a valid PEM block")
+	}
+	if block.Type != "CERTIFICATE" {
+		return nil, fmt.Errorf("certificate_pem must contain a CERTIFICATE block, got %q", block.Type)
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse x509 certificate: %w", err)
+	}
+	return cert, nil
+}
+
+// CanTransitionSAMLStatus reports whether a SAML connection may move from one
+// status to another. Connections must enroll via pending → active and may be
+// disabled/re-enabled afterward; outright deletion is handled separately.
+func CanTransitionSAMLStatus(from, to SAMLConnectionStatus) bool {
+	if !validSAMLConnectionStatus(from) || !validSAMLConnectionStatus(to) {
+		return false
+	}
+	if from == to {
+		return true
+	}
+	switch from {
+	case SAMLConnectionPending:
+		return to == SAMLConnectionActive || to == SAMLConnectionDisabled
+	case SAMLConnectionActive:
+		return to == SAMLConnectionDisabled
+	case SAMLConnectionDisabled:
+		return to == SAMLConnectionActive
+	}
+	return false
+}
+
+func validSAMLConnectionStatus(s SAMLConnectionStatus) bool {
+	switch s {
+	case SAMLConnectionPending, SAMLConnectionActive, SAMLConnectionDisabled:
+		return true
+	}
+	return false
+}
+
+func validateHTTPSURL(raw string) error {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return fmt.Errorf("url is empty")
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return fmt.Errorf("parse url: %w", err)
+	}
+	if !strings.EqualFold(parsed.Scheme, "https") {
+		return fmt.Errorf("url scheme must be https, got %q", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("url host is empty")
+	}
+	return nil
+}

--- a/internal/enterprise/scim.go
+++ b/internal/enterprise/scim.go
@@ -79,7 +79,16 @@ func (u SCIMUser) PrimaryEmail() string {
 	return firstNonEmpty
 }
 
-// Validate enforces SCIM core schema invariants relevant to Identrail.
+// Validate enforces SCIM core schema invariants relevant to Identrail. The
+// `id` attribute is intentionally NOT required here because SCIM 2.0 servers
+// assign it on a successful POST /Users create — the resource arrives without
+// one. Operations that semantically require an existing identifier
+// (update/deactivate/delete) are enforced in SCIMProvisioningEvent.Validate.
+//
+// At most one email entry may be marked primary. Standard SCIM clients honor
+// the multi-valued `primary` sub-attribute and assume it is unique; accepting
+// duplicates silently would let a provider quirk reorder the login-identity
+// selection on every payload.
 //
 // The selected primary email must be a plain addr-spec (e.g.
 // "alice@example.com") rather than the mailbox display syntax accepted by
@@ -87,11 +96,17 @@ func (u SCIMUser) PrimaryEmail() string {
 // upserts this string into the users/identities tables as a login identifier,
 // so accepting display syntax would persist a non-canonical email.
 func (u SCIMUser) Validate() error {
-	if strings.TrimSpace(u.ID) == "" {
-		return fmt.Errorf("scim user id is required")
-	}
 	if strings.TrimSpace(u.UserName) == "" {
 		return fmt.Errorf("scim user userName is required")
+	}
+	primaryCount := 0
+	for _, e := range u.Emails {
+		if e.Primary {
+			primaryCount++
+		}
+	}
+	if primaryCount > 1 {
+		return fmt.Errorf("scim user must declare at most one primary email, got %d", primaryCount)
 	}
 	email := u.PrimaryEmail()
 	if email == "" {
@@ -133,10 +148,11 @@ type SCIMProvisioningEvent struct {
 
 // Validate enforces the invariants every provisioning consumer relies on.
 //
-// For delete events the SCIM DELETE protocol does not carry a user resource
-// body — only the resource ID in the path — so this method requires just
-// User.ID for that op and falls back to the full SCIMUser.Validate for any op
-// that semantically updates user state.
+// Per RFC 7644, SCIM `id` is server-assigned on POST /Users (create), so it
+// is intentionally optional on create events; update/deactivate/delete events
+// must carry the resource id since they reference an existing user. The SCIM
+// DELETE protocol does not carry a user body at all — only the id in the path
+// — so this method skips the full SCIMUser.Validate for that op.
 func (e SCIMProvisioningEvent) Validate() error {
 	if !validSCIMProvisioningOp(e.Op) {
 		return fmt.Errorf("scim provisioning op %q is not recognized", e.Op)
@@ -152,6 +168,9 @@ func (e SCIMProvisioningEvent) Validate() error {
 			return fmt.Errorf("scim provisioning delete event requires user.id")
 		}
 		return nil
+	}
+	if e.Op != SCIMProvisioningCreate && strings.TrimSpace(e.User.ID) == "" {
+		return fmt.Errorf("scim provisioning %s event requires user.id", e.Op)
 	}
 	if err := e.User.Validate(); err != nil {
 		return fmt.Errorf("scim provisioning event user invalid: %w", err)

--- a/internal/enterprise/scim.go
+++ b/internal/enterprise/scim.go
@@ -24,16 +24,21 @@ type SCIMUserActiveStatus bool
 // for tenant onboarding and lifecycle are modeled here so a directory-sync
 // provider can drive create / update / deactivate without leaking provider
 // specifics into the rest of the system.
+//
+// JSON tags use the SCIM 2.0 on-wire attribute names (camelCase) so the
+// future /scim/v2/Users handler can decode standard provider payloads (Okta,
+// Azure AD, OneLogin, etc.) directly into this struct without an intermediate
+// wire DTO. CreatedAt/UpdatedAt are exposed under the SCIM `meta` semantics.
 type SCIMUser struct {
 	ID          string    `json:"id"`
-	ExternalID  string    `json:"external_id,omitempty"`
-	UserName    string    `json:"user_name"`
+	ExternalID  string    `json:"externalId,omitempty"`
+	UserName    string    `json:"userName"`
 	Email       string    `json:"email"`
-	DisplayName string    `json:"display_name,omitempty"`
+	DisplayName string    `json:"displayName,omitempty"`
 	Active      bool      `json:"active"`
 	Groups      []string  `json:"groups,omitempty"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
 }
 
 // Validate enforces SCIM core schema invariants relevant to Identrail.

--- a/internal/enterprise/scim.go
+++ b/internal/enterprise/scim.go
@@ -37,6 +37,12 @@ type SCIMUser struct {
 }
 
 // Validate enforces SCIM core schema invariants relevant to Identrail.
+//
+// The email field must be a plain addr-spec (e.g. "alice@example.com") rather
+// than the mailbox display syntax accepted by net/mail ("Alice
+// <alice@example.com>"). The downstream provisioning path upserts this string
+// into the users/identities tables as a login identifier, so accepting display
+// syntax would persist a non-canonical email.
 func (u SCIMUser) Validate() error {
 	if strings.TrimSpace(u.ID) == "" {
 		return fmt.Errorf("scim user id is required")
@@ -44,8 +50,13 @@ func (u SCIMUser) Validate() error {
 	if strings.TrimSpace(u.UserName) == "" {
 		return fmt.Errorf("scim user userName is required")
 	}
-	if _, err := mail.ParseAddress(u.Email); err != nil {
+	trimmedEmail := strings.TrimSpace(u.Email)
+	parsed, err := mail.ParseAddress(trimmedEmail)
+	if err != nil {
 		return fmt.Errorf("scim user email %q is invalid: %w", u.Email, err)
+	}
+	if !strings.EqualFold(parsed.Address, trimmedEmail) {
+		return fmt.Errorf("scim user email %q must be a plain address without display name", u.Email)
 	}
 	return nil
 }

--- a/internal/enterprise/scim.go
+++ b/internal/enterprise/scim.go
@@ -1,0 +1,103 @@
+// Package enterprise provides the foundational domain models for Identrail's
+// enterprise-tier controls: SCIM provisioning, SAML federation, data-residency
+// policy enforcement, and executive risk reporting.
+//
+// This package is intentionally I/O-free. It defines the types, validation,
+// and aggregation logic that API and persistence layers later wire to HTTP
+// endpoints and storage. Keeping the models pure makes them testable in
+// isolation and reusable across CLI, API, and worker entry points.
+package enterprise
+
+import (
+	"fmt"
+	"net/mail"
+	"strings"
+	"time"
+)
+
+// SCIMUserActiveStatus reflects whether a SCIM-provisioned principal is enabled.
+type SCIMUserActiveStatus bool
+
+// SCIMUser is the subset of the SCIM 2.0 core user schema Identrail consumes
+// for enterprise provisioning. Fields map to the canonical schema URN
+// "urn:ietf:params:scim:schemas:core:2.0:User"; only the attributes required
+// for tenant onboarding and lifecycle are modeled here so a directory-sync
+// provider can drive create / update / deactivate without leaking provider
+// specifics into the rest of the system.
+type SCIMUser struct {
+	ID          string    `json:"id"`
+	ExternalID  string    `json:"external_id,omitempty"`
+	UserName    string    `json:"user_name"`
+	Email       string    `json:"email"`
+	DisplayName string    `json:"display_name,omitempty"`
+	Active      bool      `json:"active"`
+	Groups      []string  `json:"groups,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// Validate enforces SCIM core schema invariants relevant to Identrail.
+func (u SCIMUser) Validate() error {
+	if strings.TrimSpace(u.ID) == "" {
+		return fmt.Errorf("scim user id is required")
+	}
+	if strings.TrimSpace(u.UserName) == "" {
+		return fmt.Errorf("scim user userName is required")
+	}
+	if _, err := mail.ParseAddress(u.Email); err != nil {
+		return fmt.Errorf("scim user email %q is invalid: %w", u.Email, err)
+	}
+	return nil
+}
+
+// SCIMProvisioningOp enumerates the lifecycle operations a SCIM source can
+// apply to a user. These mirror SCIM 2.0 protocol verbs (POST/PUT/PATCH/DELETE)
+// reduced to the semantic transitions Identrail persists.
+type SCIMProvisioningOp string
+
+const (
+	SCIMProvisioningCreate     SCIMProvisioningOp = "create"
+	SCIMProvisioningUpdate     SCIMProvisioningOp = "update"
+	SCIMProvisioningDeactivate SCIMProvisioningOp = "deactivate"
+	SCIMProvisioningDelete     SCIMProvisioningOp = "delete"
+)
+
+// SCIMProvisioningEvent records one provisioning operation for audit and
+// downstream workflow routing. It is emitted by the SCIM endpoint handler and
+// can be persisted, dispatched to the workflow router for governance, or
+// replayed against secondary stores.
+type SCIMProvisioningEvent struct {
+	Op            SCIMProvisioningOp `json:"op"`
+	User          SCIMUser           `json:"user"`
+	SourceTenant  string             `json:"source_tenant"`
+	OccurredAt    time.Time          `json:"occurred_at"`
+	CorrelationID string             `json:"correlation_id,omitempty"`
+}
+
+// Validate enforces the invariants every provisioning consumer relies on.
+func (e SCIMProvisioningEvent) Validate() error {
+	if !validSCIMProvisioningOp(e.Op) {
+		return fmt.Errorf("scim provisioning op %q is not recognized", e.Op)
+	}
+	if strings.TrimSpace(e.SourceTenant) == "" {
+		return fmt.Errorf("scim provisioning event source_tenant is required")
+	}
+	if e.OccurredAt.IsZero() {
+		return fmt.Errorf("scim provisioning event occurred_at is required")
+	}
+	if err := e.User.Validate(); err != nil {
+		return fmt.Errorf("scim provisioning event user invalid: %w", err)
+	}
+	if e.Op == SCIMProvisioningDeactivate && e.User.Active {
+		return fmt.Errorf("deactivate event must carry user.active=false")
+	}
+	return nil
+}
+
+func validSCIMProvisioningOp(op SCIMProvisioningOp) bool {
+	switch op {
+	case SCIMProvisioningCreate, SCIMProvisioningUpdate, SCIMProvisioningDeactivate, SCIMProvisioningDelete:
+		return true
+	}
+	return false
+}

--- a/internal/enterprise/scim.go
+++ b/internal/enterprise/scim.go
@@ -86,6 +86,11 @@ type SCIMProvisioningEvent struct {
 }
 
 // Validate enforces the invariants every provisioning consumer relies on.
+//
+// For delete events the SCIM DELETE protocol does not carry a user resource
+// body — only the resource ID in the path — so this method requires just
+// User.ID for that op and falls back to the full SCIMUser.Validate for any op
+// that semantically updates user state.
 func (e SCIMProvisioningEvent) Validate() error {
 	if !validSCIMProvisioningOp(e.Op) {
 		return fmt.Errorf("scim provisioning op %q is not recognized", e.Op)
@@ -95,6 +100,12 @@ func (e SCIMProvisioningEvent) Validate() error {
 	}
 	if e.OccurredAt.IsZero() {
 		return fmt.Errorf("scim provisioning event occurred_at is required")
+	}
+	if e.Op == SCIMProvisioningDelete {
+		if strings.TrimSpace(e.User.ID) == "" {
+			return fmt.Errorf("scim provisioning delete event requires user.id")
+		}
+		return nil
 	}
 	if err := e.User.Validate(); err != nil {
 		return fmt.Errorf("scim provisioning event user invalid: %w", err)

--- a/internal/enterprise/scim.go
+++ b/internal/enterprise/scim.go
@@ -25,29 +25,67 @@ type SCIMUserActiveStatus bool
 // provider can drive create / update / deactivate without leaking provider
 // specifics into the rest of the system.
 //
-// JSON tags use the SCIM 2.0 on-wire attribute names (camelCase) so the
-// future /scim/v2/Users handler can decode standard provider payloads (Okta,
-// Azure AD, OneLogin, etc.) directly into this struct without an intermediate
-// wire DTO. CreatedAt/UpdatedAt are exposed under the SCIM `meta` semantics.
+// JSON tags follow the SCIM 2.0 on-wire shape so the future /scim/v2/Users
+// handler can decode standard provider payloads (Okta, Azure AD, OneLogin,
+// etc.) directly into this struct without an intermediate wire DTO. In
+// particular, email addresses are carried in the SCIM `emails` multi-valued
+// attribute and resource timestamps live under the SCIM `meta` complex
+// attribute (`meta.created`, `meta.lastModified`).
 type SCIMUser struct {
-	ID          string    `json:"id"`
-	ExternalID  string    `json:"externalId,omitempty"`
-	UserName    string    `json:"userName"`
-	Email       string    `json:"email"`
-	DisplayName string    `json:"displayName,omitempty"`
-	Active      bool      `json:"active"`
-	Groups      []string  `json:"groups,omitempty"`
-	CreatedAt   time.Time `json:"createdAt"`
-	UpdatedAt   time.Time `json:"updatedAt"`
+	ID          string      `json:"id"`
+	ExternalID  string      `json:"externalId,omitempty"`
+	UserName    string      `json:"userName"`
+	DisplayName string      `json:"displayName,omitempty"`
+	Active      bool        `json:"active"`
+	Emails      []SCIMEmail `json:"emails,omitempty"`
+	Groups      []string    `json:"groups,omitempty"`
+	Meta        SCIMMeta    `json:"meta"`
+}
+
+// SCIMEmail mirrors one entry of the SCIM `emails` multi-valued attribute.
+type SCIMEmail struct {
+	Value   string `json:"value"`
+	Type    string `json:"type,omitempty"`
+	Primary bool   `json:"primary,omitempty"`
+}
+
+// SCIMMeta carries the SCIM `meta` complex attribute. Only the fields
+// Identrail relies on are modeled.
+type SCIMMeta struct {
+	ResourceType string    `json:"resourceType,omitempty"`
+	Created      time.Time `json:"created,omitempty"`
+	LastModified time.Time `json:"lastModified,omitempty"`
+	Location     string    `json:"location,omitempty"`
+	Version      string    `json:"version,omitempty"`
+}
+
+// PrimaryEmail returns the canonical login identifier for the user: the
+// primary entry in Emails when one is marked, otherwise the first non-empty
+// value. Empty string when no usable email is present.
+func (u SCIMUser) PrimaryEmail() string {
+	firstNonEmpty := ""
+	for _, e := range u.Emails {
+		value := strings.TrimSpace(e.Value)
+		if value == "" {
+			continue
+		}
+		if e.Primary {
+			return value
+		}
+		if firstNonEmpty == "" {
+			firstNonEmpty = value
+		}
+	}
+	return firstNonEmpty
 }
 
 // Validate enforces SCIM core schema invariants relevant to Identrail.
 //
-// The email field must be a plain addr-spec (e.g. "alice@example.com") rather
-// than the mailbox display syntax accepted by net/mail ("Alice
-// <alice@example.com>"). The downstream provisioning path upserts this string
-// into the users/identities tables as a login identifier, so accepting display
-// syntax would persist a non-canonical email.
+// The selected primary email must be a plain addr-spec (e.g.
+// "alice@example.com") rather than the mailbox display syntax accepted by
+// net/mail ("Alice <alice@example.com>"). The downstream provisioning path
+// upserts this string into the users/identities tables as a login identifier,
+// so accepting display syntax would persist a non-canonical email.
 func (u SCIMUser) Validate() error {
 	if strings.TrimSpace(u.ID) == "" {
 		return fmt.Errorf("scim user id is required")
@@ -55,13 +93,16 @@ func (u SCIMUser) Validate() error {
 	if strings.TrimSpace(u.UserName) == "" {
 		return fmt.Errorf("scim user userName is required")
 	}
-	trimmedEmail := strings.TrimSpace(u.Email)
-	parsed, err := mail.ParseAddress(trimmedEmail)
-	if err != nil {
-		return fmt.Errorf("scim user email %q is invalid: %w", u.Email, err)
+	email := u.PrimaryEmail()
+	if email == "" {
+		return fmt.Errorf("scim user must include at least one email value")
 	}
-	if !strings.EqualFold(parsed.Address, trimmedEmail) {
-		return fmt.Errorf("scim user email %q must be a plain address without display name", u.Email)
+	parsed, err := mail.ParseAddress(email)
+	if err != nil {
+		return fmt.Errorf("scim user email %q is invalid: %w", email, err)
+	}
+	if !strings.EqualFold(parsed.Address, email) {
+		return fmt.Errorf("scim user email %q must be a plain address without display name", email)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- New `internal/enterprise/` package introduces the foundational, I/O-free domain models for the enterprise tier: SCIM provisioning, SAML federation, data-residency policy, and executive risk reporting
- API and persistence integration are intentionally deferred to follow-up PRs so this change stays reviewable while delivering a complete, validated model layer

## Components

| File | Purpose |
|---|---|
| `scim.go` | `SCIMUser` subset of SCIM 2.0 core schema + `SCIMProvisioningEvent` for create/update/deactivate/delete with contradictory-state validation |
| `saml.go` | `SAMLConnection` with PEM X.509 cert parsing, https-only SSO URL enforcement, attribute mapping, and `pending → active → disabled` transitions |
| `residency.go` | `ResidencyPolicy` with curated region allowlist, case-insensitive evaluation, advisory + strict enforcement modes, deterministic region ordering |
| `report.go` | `BuildExecutiveReport` aggregating open findings by severity/type, top-N callouts, MTTR (from `Triage.UpdatedAt` on resolved findings), and 7d-vs-prior-7d trend |

## Why

The issue identifies four enterprise capabilities currently absent: SCIM provisioning hooks, SAML federation, data-residency policies, and executive trend/report views. Today SAML appears only as a string literal in `validIdentityConnectionProviders`; the other three have no representation. This PR adds the validated domain models so subsequent PRs can wire HTTP handlers (`/scim/v2/Users`, `/v1/enterprise/saml`, etc.) and persistence without churning the model surface.

## Security notes

- SAML SSO URL **must** be `https://` — the POST binding embeds the assertion in the response body, so plaintext transport would leak credentials. Validation rejects any other scheme.
- SAML certificates are parsed via `crypto/x509` so malformed/non-CERTIFICATE PEM blocks are rejected at validation time, not at first IdP handshake.
- Residency policies validate against a curated set of regions to prevent typos (`us-east1`) from silently failing closed at the storage layer.

## Test plan

- [ ] `go test ./internal/enterprise/... -v` — 14 tests covering SCIM user/event validation, SAML connection validation (incl. cert parsing, https enforcement, status transitions), residency policy (validation, advisory vs strict, case-insensitive evaluation, deterministic sort), executive report (severity/type rollups, MTTR, top-N ordering, week-over-week trend, empty input)
- [ ] `go test ./...` — full suite green
- [ ] Pre-commit hooks pass (gofmt, go vet, hygiene checks)

## Validation performed

```
go test ./internal/enterprise/... -v   # all PASS (14 tests)
go test ./...                           # all packages PASS
make fmt-check                          # clean
make vet                                # clean
```

`CHANGELOG.md` updated under `## Unreleased`.

## AI-assisted

- AI-assisted: yes
- Tools used: Claude Code
- Where used: `internal/enterprise/` (all files) and `CHANGELOG.md`
- Human verification performed: full test suite run, manual review of SAML certificate handling, residency region curation, executive report aggregation math, and policy validation paths

Closes #576

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `internal/enterprise` package with validated, I/O‑free models for SCIM, SAML, data residency, and executive reporting to unblock enterprise controls and SSO onboarding. Implements ITR‑035.

- **New Features**
  - SCIM: `SCIMUser` + `SCIMProvisioningEvent` with validation; SCIM 2.0 camelCase; multi‑valued `emails` and `meta.created/lastModified`; canonical addr‑spec email only; create accepts missing `user.id`; reject multiple primary `emails`; DELETE accepts ID‑only (`user.id` required); deactivate requires `active=false`.
  - SAML: `SAMLConnection` with https‑only SSO URL, PEM X.509 parsing, attribute mapping, and `pending → active → disabled` lifecycle (no `pending → disabled`).
  - Residency: `ResidencyPolicy` with curated allowlist, advisory/strict modes, case‑insensitive checks, and deterministic region ordering.
  - Reporting: `BuildExecutiveReport` for open‑by‑severity/type, top‑N types, 7‑day vs prior‑7‑day trend; expired suppressions count as open.

<sup>Written for commit e97467e211ea0be3f06ec390504d6e93aa15cec9. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1130?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

