### PR TITLE
Add AWS API log diagnostics workflow

### DIFF
--- a/.github/workflows/aws-api-log-diagnostics.yml
+++ b/.github/workflows/aws-api-log-diagnostics.yml
@@ -1,0 +1,183 @@
+name: AWS API Log Diagnostics
+
+on:
+  workflow_dispatch:
+    inputs:
+      minutes:
+        description: "How many recent minutes of API logs to inspect."
+        required: true
+        type: string
+        default: "60"
+      filter_pattern:
+        description: "CloudWatch Logs filter pattern. Leave blank to fetch recent API events."
+        required: false
+        type: string
+        default: '"authenticate workos callback"'
+      max_events:
+        description: "Maximum matching log events to print."
+        required: true
+        type: string
+        default: "25"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: aws-api-log-diagnostics
+  cancel-in-progress: false
+
+jobs:
+  inspect:
+    name: Inspect AWS API logs
+    if: github.repository == 'identrail/identrail'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      LOG_GROUP_NAME: /identrail/dev/api
+      FILTER_PATTERN: ${{ inputs.filter_pattern }}
+      LOOKBACK_MINUTES: ${{ inputs.minutes }}
+      MAX_EVENTS: ${{ inputs.max_events }}
+    steps:
+      - name: Validate diagnostic inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          aws_region="$(printf '%s' "${AWS_REGION}" | tr -d '[:space:]')"
+          if [ -z "${aws_region}" ]; then
+            echo "Missing repository variable AWS_REGION."
+            exit 1
+          fi
+          if [[ ! "${aws_region}" =~ ^[a-z]{2}(-gov)?-[a-z]+-[0-9]+$ ]]; then
+            echo "AWS_REGION must be an AWS region such as us-east-1."
+            exit 1
+          fi
+
+          aws_role_arn="$(printf '%s' "${AWS_ROLE_ARN}" | tr -d '[:space:]')"
+          if [ -z "${aws_role_arn}" ]; then
+            echo "Missing repository secret AWS_ROLE_ARN."
+            exit 1
+          fi
+          if [[ ! "${aws_role_arn}" =~ ^arn:aws:iam::[0-9]{12}:role/.+$ ]]; then
+            echo "AWS_ROLE_ARN must look like arn:aws:iam::<account-id>:role/<role-name>."
+            exit 1
+          fi
+          echo "::add-mask::${aws_role_arn}"
+
+          if ! [[ "${LOOKBACK_MINUTES}" =~ ^[0-9]+$ ]]; then
+            echo "minutes must be a positive integer."
+            exit 1
+          fi
+          if [ "${LOOKBACK_MINUTES}" -lt 1 ] || [ "${LOOKBACK_MINUTES}" -gt 1440 ]; then
+            echo "minutes must be between 1 and 1440."
+            exit 1
+          fi
+
+          if ! [[ "${MAX_EVENTS}" =~ ^[0-9]+$ ]]; then
+            echo "max_events must be a positive integer."
+            exit 1
+          fi
+          if [ "${MAX_EVENTS}" -lt 1 ] || [ "${MAX_EVENTS}" -gt 200 ]; then
+            echo "max_events must be between 1 and 200."
+            exit 1
+          fi
+
+          {
+            echo "AWS_REGION=${aws_region}"
+            echo "AWS_DEFAULT_REGION=${aws_region}"
+            echo "AWS_ROLE_ARN=${aws_role_arn}"
+          } >> "${GITHUB_ENV}"
+
+      - name: Configure AWS credentials from GitHub OIDC
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          token_response="$(
+            curl -fsSL \
+              -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sts.amazonaws.com"
+          )"
+          oidc_token="$(jq -r '.value // empty' <<< "${token_response}")"
+          if [ -z "${oidc_token}" ]; then
+            echo "GitHub did not return an OIDC token."
+            exit 1
+          fi
+
+          credentials="$(
+            aws sts assume-role-with-web-identity \
+              --role-arn "${AWS_ROLE_ARN}" \
+              --role-session-name "identrail-api-logs-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+              --web-identity-token "${oidc_token}" \
+              --duration-seconds 900 \
+              --query 'Credentials' \
+              --output json
+          )"
+          access_key_id="$(jq -r '.AccessKeyId' <<< "${credentials}")"
+          secret_access_key="$(jq -r '.SecretAccessKey' <<< "${credentials}")"
+          session_token="$(jq -r '.SessionToken' <<< "${credentials}")"
+          echo "::add-mask::${access_key_id}"
+          echo "::add-mask::${secret_access_key}"
+          echo "::add-mask::${session_token}"
+          {
+            echo "AWS_ACCESS_KEY_ID=${access_key_id}"
+            echo "AWS_SECRET_ACCESS_KEY=${secret_access_key}"
+            echo "AWS_SESSION_TOKEN=${session_token}"
+          } >> "${GITHUB_ENV}"
+
+      - name: Fetch sanitized API log events
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          start_time_ms="$(( $(date +%s) * 1000 - LOOKBACK_MINUTES * 60 * 1000 ))"
+          events_file="${RUNNER_TEMP}/identrail-api-log-events.json"
+          args=(
+            --log-group-name "${LOG_GROUP_NAME}"
+            --start-time "${start_time_ms}"
+            --limit "${MAX_EVENTS}"
+            --output json
+          )
+          if [ -n "${FILTER_PATTERN}" ]; then
+            args+=(--filter-pattern "${FILTER_PATTERN}")
+          fi
+
+          aws logs filter-log-events "${args[@]}" > "${events_file}"
+          event_count="$(jq '.events | length' "${events_file}")"
+
+          {
+            echo "## AWS API log diagnostics"
+            echo
+            echo "- Log group: \`${LOG_GROUP_NAME}\`"
+            echo "- Lookback: \`${LOOKBACK_MINUTES}\` minutes"
+            echo "- Filter pattern: \`${FILTER_PATTERN:-<none>}\`"
+            echo "- Events returned: \`${event_count}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          if [ "${event_count}" -eq 0 ]; then
+            echo "No matching API log events found."
+            exit 0
+          fi
+
+          redact() {
+            sed -E \
+              -e 's/sk_[A-Za-z0-9._-]+/[REDACTED_WORKOS_KEY]/g' \
+              -e 's/whsec_[A-Za-z0-9._-]+/[REDACTED_WEBHOOK_SECRET]/g' \
+              -e 's#postgresql://[^[:space:]]+#postgresql://[REDACTED]#g' \
+              -e 's#postgres://[^[:space:]]+#postgres://[REDACTED]#g' \
+              -e 's/(code=)[^&[:space:]]+/\1[REDACTED_CODE]/g' \
+              -e 's/(state=)[^&[:space:]]+/\1[REDACTED_STATE]/g' \
+              -e 's/(Bearer )[A-Za-z0-9._=-]+/\1[REDACTED_TOKEN]/g'
+          }
+
+          jq -r '.events[] | [.timestamp, (.logStreamName // "-"), (.message // "")] | @tsv' "${events_file}" |
+            while IFS=$'\t' read -r timestamp stream message; do
+              iso_time="$(date -u -d "@$((timestamp / 1000))" +"%Y-%m-%dT%H:%M:%SZ")"
+              safe_message="$(printf '%s' "${message}" | redact)"
+              echo "::group::${iso_time} ${stream}"
+              printf '%s\n' "${safe_message}"
+              echo "::endgroup::"
+            done

--- a/.github/workflows/aws-api-log-diagnostics.yml
+++ b/.github/workflows/aws-api-log-diagnostics.yml
@@ -61,8 +61,8 @@ jobs:
             echo "Missing repository secret AWS_ROLE_ARN."
             exit 1
           fi
-          if [[ ! "${aws_role_arn}" =~ ^arn:aws:iam::[0-9]{12}:role/.+$ ]]; then
-            echo "AWS_ROLE_ARN must look like arn:aws:iam::<account-id>:role/<role-name>."
+          if [[ ! "${aws_role_arn}" =~ ^arn:aws(-[a-z0-9]+)*:iam::[0-9]{12}:role/.+$ ]]; then
+            echo "AWS_ROLE_ARN must look like arn:aws[-partition]:iam::<account-id>:role/<role-name>."
             exit 1
           fi
           echo "::add-mask::${aws_role_arn}"
@@ -139,6 +139,7 @@ jobs:
             --log-group-name "${LOG_GROUP_NAME}"
             --start-time "${start_time_ms}"
             --limit "${MAX_EVENTS}"
+            --max-items "${MAX_EVENTS}"
             --output json
           )
           if [ -n "${FILTER_PATTERN}" ]; then
@@ -176,8 +177,11 @@ jobs:
           jq -r '.events[] | [.timestamp, (.logStreamName // "-"), (.message // "")] | @tsv' "${events_file}" |
             while IFS=$'\t' read -r timestamp stream message; do
               iso_time="$(date -u -d "@$((timestamp / 1000))" +"%Y-%m-%dT%H:%M:%SZ")"
+              stop_marker="identrail_log_${GITHUB_RUN_ID}_${RANDOM}_${RANDOM}"
               safe_message="$(printf '%s' "${message}" | redact)"
               echo "::group::${iso_time} ${stream}"
+              echo "::stop-commands::${stop_marker}"
               printf '%s\n' "${safe_message}"
+              echo "::${stop_marker}::"
               echo "::endgroup::"
             done

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -187,6 +187,20 @@ curl -fsS --resolve "api.identrail.com:443:${load_balancer_ip}" \
   "https://api.identrail.com/healthz"
 ```
 
+## Log Diagnostics
+
+Use the `AWS API Log Diagnostics` workflow when the hosted API is healthy but an
+operator needs recent CloudWatch application logs, such as a failed WorkOS auth
+callback. The workflow is read-only: it assumes the same GitHub OIDC AWS role as
+the deployment workflow, reads `/identrail/dev/api`, and redacts common secret,
+token, database URL, OAuth code, and OAuth state shapes before printing matching
+events.
+
+The default filter pattern is `"authenticate workos callback"`, which targets
+the callback exchange failure log emitted before the API returns
+`{"error":"login failed"}`. Leave the filter blank to inspect recent API events
+without narrowing to that auth path.
+
 ## DNS Cutover
 
 Do not point `api.identrail.com` at the load balancer until:


### PR DESCRIPTION
No issue: operational diagnostics for the hosted API auth cutover.

## Summary
- Add a manual AWS API log diagnostics workflow for recent `/identrail/dev/api` CloudWatch events.
- Use the existing GitHub OIDC AWS role, keep the workflow read-only, and redact common secret/token/database/OAuth values before printing logs.
- Document when to use it for WorkOS callback failures such as `{"error":"login failed"}`.

## Why
GitHub OAuth is reaching the hosted API callback, but the API is returning `login failed` during the WorkOS code exchange. We need a safe, repeatable way to inspect the exact server-side WorkOS error without sharing AWS console access or pasting live secrets around.

## Impact and Risk
No runtime path changes and no infrastructure apply. This only adds a `workflow_dispatch` diagnostics workflow and operator docs. The workflow reads recent CloudWatch log events and does not deploy or mutate AWS resources.

## Validation
- `git diff --check`
- Parsed the workflow YAML and ran `bash -n` against all three embedded shell scripts
- Commit/push hooks passed: merge conflict check, YAML check, EOF/trailing whitespace checks, gofmt check, go vet, local env token hygiene, Vercel artifact hygiene

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manual GitHub Actions workflow to fetch and redact recent CloudWatch logs for the dev API to diagnose WorkOS OAuth callback failures without AWS console access. Hardened with strict input validation and credential masking; added docs on when to use it.

- **New Features**
  - New `AWS API Log Diagnostics` workflow (`workflow_dispatch`) with inputs: `minutes`, `filter_pattern` (default `"authenticate workos callback"`, blank for recent events), and `max_events`. Assumes AWS via GitHub OIDC, reads `/identrail/dev/api`, and prints sanitized logs (redacts WorkOS keys, webhook secrets, bearer tokens, DB URLs, and OAuth code/state).
  - Hardening: validates AWS region/role ARN and input ranges, masks role and STS creds, prevents log/command injection, enforces read-only perms, concurrency, and repository guard. Docs updated in `docs/aws-api-hosting.md` with usage guidance.

<sup>Written for commit 733f07ac06c87f03509e54a7a37368d325b4c29c. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1131?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

