### PR TITLE
Extend identity_connections + add SCIM persistence for native enterprise SSO (PR 1/5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## Unreleased
+- Added schema scaffolding for native SAML SSO and SCIM 2.0 provisioning alongside the existing WorkOS-managed path (migration `000024_native_sso_scim_scaffold`):
+  - `identity_connections` gains nullable `entity_id`, `sso_url`, `certificate_pem`, `attribute_mapping` (JSONB), `jit_provisioning_enabled`, and `scim_bearer_token_hash` columns; a SAML completeness CHECK constraint requires each `provider='saml'` row to be either WorkOS-backed or fully native (https sso_url + entity_id + certificate_pem)
+  - `users.scim_external_id` (nullable, unique-when-set) records the stable IdP-assigned id
+  - New append-only `scim_provisioning_events` table captures every SCIM op for tenant-visible audit; standard RLS tenant-isolation policy applied
+  - `IdentityConnection` Go struct and memory + Postgres CRUD updated; `SCIMProvisioningEventRecord` + `CreateSCIMProvisioningEvent`/`ListSCIMProvisioningEvents` added behind the existing `Store` interface
+  - No HTTP routes, no SAML protocol code, and no SCIM endpoints in this change; the WorkOS sign-in/sign-up path is untouched
 - Added the foundational enterprise-tier domain models in `internal/enterprise`:
   - `SCIMUser` + `SCIMProvisioningEvent` modelling the core SCIM 2.0 user schema and lifecycle operations (create/update/deactivate/delete) for directory-sync sources
   - `SAMLConnection` with PEM X.509 certificate parsing, https-only SSO URL enforcement, attribute mapping, and `pending → active → disabled` status transitions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## Unreleased
 - Added schema scaffolding for native SAML SSO and SCIM 2.0 provisioning alongside the existing WorkOS-managed path (migration `000024_native_sso_scim_scaffold`):
   - `identity_connections` gains nullable `entity_id`, `sso_url`, `certificate_pem`, `attribute_mapping` (JSONB), `jit_provisioning_enabled`, and `scim_bearer_token_hash` columns; a SAML completeness CHECK constraint requires each `provider='saml'` row to be either WorkOS-backed or fully native (https sso_url + entity_id + certificate_pem)
-  - `users.scim_external_id` (nullable, unique-when-set) records the stable IdP-assigned id
-  - New append-only `scim_provisioning_events` table captures every SCIM op for tenant-visible audit; standard RLS tenant-isolation policy applied
+  - SCIM-assigned external ids are stored in the existing `user_identities` table with `provider = 'scim:<connection_uuid>'`, reusing its `UNIQUE (provider, subject)` contract so a per-connection identifier cannot collide with a different tenant's
+  - New append-only `scim_provisioning_events` table captures every SCIM op for tenant-visible audit; standard RLS tenant-isolation policy applied, with a composite `(org_id, connection_id)` foreign key to `identity_connections` so events cannot reference a connection in a different tenant
   - `IdentityConnection` Go struct and memory + Postgres CRUD updated; `SCIMProvisioningEventRecord` + `CreateSCIMProvisioningEvent`/`ListSCIMProvisioningEvents` added behind the existing `Store` interface
   - No HTTP routes, no SAML protocol code, and no SCIM endpoints in this change; the WorkOS sign-in/sign-up path is untouched
 - Added the foundational enterprise-tier domain models in `internal/enterprise`:

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -68,6 +68,9 @@ Current sequence in `migrations/`:
 22. `000019_scan_policy_repo_bounds` - scan policy history and finding limit bounds
 23. `000020_invitations_domains_connections` - invitation, verified-domain, and enterprise identity connection scaffolding
 24. `000021_scan_policy_scheduler_state` - scan policy scheduler tick state and due-policy lookup index
+25. `000022_scan_retry_dlq_replay` - scan retry / DLQ replay scaffolding
+26. `000023_onboarding_state` - onboarding wizard server-owned state
+27. `000024_native_sso_scim_scaffold` - native SAML and SCIM 2.0 schema scaffolding on `identity_connections`, plus `users.scim_external_id` and the `scim_provisioning_events` audit log
 
 Notes:
 - Each migration has matching `.up.sql` and `.down.sql` files.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -70,7 +70,7 @@ Current sequence in `migrations/`:
 24. `000021_scan_policy_scheduler_state` - scan policy scheduler tick state and due-policy lookup index
 25. `000022_scan_retry_dlq_replay` - scan retry / DLQ replay scaffolding
 26. `000023_onboarding_state` - onboarding wizard server-owned state
-27. `000024_native_sso_scim_scaffold` - native SAML and SCIM 2.0 schema scaffolding on `identity_connections`, plus `users.scim_external_id` and the `scim_provisioning_events` audit log
+27. `000024_native_sso_scim_scaffold` - native SAML and SCIM 2.0 schema scaffolding: extends `identity_connections` with native SAML fields + a SCIM bearer token hash, adds a composite-FK-backed `scim_provisioning_events` audit table, and reuses the existing `user_identities` table for SCIM-assigned external ids (no new column on `users`)
 
 Notes:
 - Each migration has matching `.up.sql` and `.down.sql` files.

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -52,6 +52,7 @@ type MemoryStore struct {
 	invitations                   map[string]Invitation
 	verifiedDomains               map[string]VerifiedDomain
 	identityConnections           map[string]IdentityConnection
+	scimEvents                    map[string]SCIMProvisioningEventRecord
 	identities                    map[string]domain.Identity
 	policies                      map[string]domain.Policy
 	relationships                 map[string]domain.Relationship
@@ -97,6 +98,7 @@ func NewMemoryStore() *MemoryStore {
 		invitations:                   map[string]Invitation{},
 		verifiedDomains:               map[string]VerifiedDomain{},
 		identityConnections:           map[string]IdentityConnection{},
+		scimEvents:                    map[string]SCIMProvisioningEventRecord{},
 		identities:                    map[string]domain.Identity{},
 		policies:                      map[string]domain.Policy{},
 		relationships:                 map[string]domain.Relationship{},

--- a/internal/db/memory_enterprise_auth.go
+++ b/internal/db/memory_enterprise_auth.go
@@ -257,3 +257,61 @@ func (m *MemoryStore) ListIdentityConnections(ctx context.Context, orgID string,
 	}
 	return items, nil
 }
+
+// CreateSCIMProvisioningEvent appends one SCIM provisioning event to the
+// append-only audit log scoped to the org + connection.
+func (m *MemoryStore) CreateSCIMProvisioningEvent(ctx context.Context, event SCIMProvisioningEventRecord) (SCIMProvisioningEventRecord, error) {
+	normalized, err := NormalizeSCIMProvisioningEventForWrite(event)
+	if err != nil {
+		return SCIMProvisioningEventRecord{}, err
+	}
+	m.mu.Lock()
+	if _, exists := m.organizations[normalized.OrgID]; !exists {
+		m.mu.Unlock()
+		return SCIMProvisioningEventRecord{}, ErrNotFound
+	}
+	if _, exists := m.identityConnections[orgScopedKey(normalized.OrgID, normalized.ConnectionID)]; !exists {
+		m.mu.Unlock()
+		return SCIMProvisioningEventRecord{}, ErrNotFound
+	}
+	if _, exists := m.scimEvents[normalized.ID]; exists {
+		m.mu.Unlock()
+		return SCIMProvisioningEventRecord{}, ErrConflict
+	}
+	m.scimEvents[normalized.ID] = normalized
+	m.mu.Unlock()
+	audit.WriteAction(ctx, audit.AuditEvent{
+		Action:       "auth.scim_provisioning_event.create",
+		TenantID:     normalized.OrgID,
+		ResourceType: "scim_provisioning_event",
+		ResourceID:   normalized.ID,
+		Outcome:      "success",
+	})
+	return normalized, nil
+}
+
+// ListSCIMProvisioningEvents returns events for one connection ordered newest
+// first, capped at limit (default 100).
+func (m *MemoryStore) ListSCIMProvisioningEvents(ctx context.Context, orgID string, connectionID string, limit int) ([]SCIMProvisioningEventRecord, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	orgID = strings.TrimSpace(orgID)
+	connectionID = strings.TrimSpace(connectionID)
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	items := make([]SCIMProvisioningEventRecord, 0)
+	for _, event := range m.scimEvents {
+		if event.OrgID != orgID || event.ConnectionID != connectionID {
+			continue
+		}
+		items = append(items, event)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].OccurredAt.After(items[j].OccurredAt)
+	})
+	if len(items) > limit {
+		items = items[:limit]
+	}
+	return items, nil
+}

--- a/internal/db/memory_enterprise_auth.go
+++ b/internal/db/memory_enterprise_auth.go
@@ -274,6 +274,15 @@ func (m *MemoryStore) CreateSCIMProvisioningEvent(ctx context.Context, event SCI
 		m.mu.Unlock()
 		return SCIMProvisioningEventRecord{}, ErrNotFound
 	}
+	// Mirror the Postgres FK on users(id): a non-null UserID must reference an
+	// existing user row. Memory mode otherwise silently accepts events that
+	// would FK-fail in production.
+	if normalized.UserID != "" {
+		if _, exists := m.users[normalized.UserID]; !exists {
+			m.mu.Unlock()
+			return SCIMProvisioningEventRecord{}, ErrNotFound
+		}
+	}
 	if _, exists := m.scimEvents[normalized.ID]; exists {
 		m.mu.Unlock()
 		return SCIMProvisioningEventRecord{}, ErrConflict

--- a/internal/db/native_sso_scim_test.go
+++ b/internal/db/native_sso_scim_test.go
@@ -106,6 +106,25 @@ func TestNormalize_RejectsHalfConfiguredNativeSAML(t *testing.T) {
 	}
 }
 
+func TestNormalize_RejectsMixedModeSAML(t *testing.T) {
+	// A WorkOS-backed SAML row must not also carry native fields, otherwise it
+	// is ambiguous which protocol path owns the connection at runtime.
+	_, err := NormalizeIdentityConnectionForWrite(IdentityConnection{
+		OrgID:              "tenant-a",
+		Provider:           "saml",
+		Type:               "sso",
+		Status:             "active",
+		WorkOSConnectionID: "conn_workos_123",
+		EntityID:           "https://idp.example.com/entity",
+	})
+	if err == nil {
+		t.Fatal("expected mixed-mode SAML row to be rejected")
+	}
+	if !strings.Contains(err.Error(), "cannot set native fields") {
+		t.Errorf("error should call out mixed mode, got: %v", err)
+	}
+}
+
 func TestNormalize_NonSAMLProvidersIgnoreNativeFields(t *testing.T) {
 	// A workos or oidc provider does not need native SAML fields, so leaving
 	// them empty must remain valid.
@@ -221,6 +240,79 @@ func TestMemoryStore_SCIMProvisioningEventLifecycle(t *testing.T) {
 	}
 	if events[1].ID != first.ID {
 		t.Errorf("expected oldest event second, got %+v", events[1])
+	}
+}
+
+func TestMemoryStore_SCIMProvisioningEvent_RejectsUnknownUser(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+
+	if err := store.UpsertOrganization(ctx, TenancyOrganization{DisplayName: "Tenant A", Slug: "tenant-a"}); err != nil {
+		t.Fatalf("upsert org: %v", err)
+	}
+	connection, err := store.CreateIdentityConnection(ctx, IdentityConnection{
+		OrgID:              "tenant-a",
+		Provider:           "saml",
+		Type:               "directory_sync",
+		Status:             "active",
+		WorkOSConnectionID: "conn_workos_123",
+		CreatedAt:          now,
+	})
+	if err != nil {
+		t.Fatalf("create connection: %v", err)
+	}
+
+	// Postgres FK on users(id) rejects events that reference a non-existent
+	// user; memory store must enforce the same contract.
+	_, err = store.CreateSCIMProvisioningEvent(ctx, SCIMProvisioningEventRecord{
+		OrgID:        "tenant-a",
+		ConnectionID: connection.ID,
+		Op:           "create",
+		UserID:       "99999999-9999-9999-9999-999999999999",
+		OccurredAt:   now,
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound for unknown user, got: %v", err)
+	}
+}
+
+func TestMemoryStore_SCIMProvisioningEvent_RejectsCrossTenantConnection(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+
+	ctxA := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	ctxB := WithScope(context.Background(), Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
+
+	if err := store.UpsertOrganization(ctxA, TenancyOrganization{DisplayName: "Tenant A", Slug: "tenant-a"}); err != nil {
+		t.Fatalf("upsert org A: %v", err)
+	}
+	if err := store.UpsertOrganization(ctxB, TenancyOrganization{DisplayName: "Tenant B", Slug: "tenant-b"}); err != nil {
+		t.Fatalf("upsert org B: %v", err)
+	}
+	connectionB, err := store.CreateIdentityConnection(ctxB, IdentityConnection{
+		OrgID:              "tenant-b",
+		Provider:           "saml",
+		Type:               "directory_sync",
+		Status:             "active",
+		WorkOSConnectionID: "conn_workos_b",
+		CreatedAt:          now,
+	})
+	if err != nil {
+		t.Fatalf("create connection B: %v", err)
+	}
+
+	// Attempt to forge an event under tenant A that references tenant B's
+	// connection. Must be rejected — this is the cross-tenant exploit the
+	// composite FK closes in Postgres.
+	_, err = store.CreateSCIMProvisioningEvent(ctxA, SCIMProvisioningEventRecord{
+		OrgID:        "tenant-a",
+		ConnectionID: connectionB.ID,
+		Op:           "create",
+		OccurredAt:   now,
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected cross-tenant connection reference to be rejected, got: %v", err)
 	}
 }
 

--- a/internal/db/native_sso_scim_test.go
+++ b/internal/db/native_sso_scim_test.go
@@ -1,0 +1,275 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------- NormalizeIdentityConnectionForWrite: SAML completeness ----------
+
+func TestNormalize_AcceptsLegacyWorkOSSAML(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	connection, err := NormalizeIdentityConnectionForWrite(IdentityConnection{
+		OrgID:              "tenant-a",
+		Provider:           "saml",
+		Type:               "sso",
+		Status:             "active",
+		WorkOSConnectionID: "conn_workos_123",
+		CreatedAt:          now,
+	})
+	if err != nil {
+		t.Fatalf("legacy WorkOS-SAML row rejected: %v", err)
+	}
+	if connection.EntityID != "" || connection.SSOURL != "" || connection.CertificatePEM != "" {
+		t.Errorf("native fields should remain zero for WorkOS-SAML row: %+v", connection)
+	}
+}
+
+func TestNormalize_AcceptsNativeSAML(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	connection, err := NormalizeIdentityConnectionForWrite(IdentityConnection{
+		OrgID:          "tenant-a",
+		Provider:       "saml",
+		Type:           "sso",
+		Status:         "pending",
+		EntityID:       "https://idp.example.com/entity",
+		SSOURL:         "https://idp.example.com/sso",
+		CertificatePEM: "-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----",
+		AttributeMapping: map[string]string{
+			"email": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+		},
+		CreatedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("native SAML row rejected: %v", err)
+	}
+	if !connection.IsNativeSAML() {
+		t.Errorf("IsNativeSAML should be true, got: %+v", connection)
+	}
+	if connection.AttributeMapping["email"] == "" {
+		t.Errorf("attribute mapping not preserved: %+v", connection.AttributeMapping)
+	}
+}
+
+func TestNormalize_RejectsHalfConfiguredNativeSAML(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name    string
+		mutate  func(*IdentityConnection)
+		wantMsg string
+	}{
+		{
+			"missing_entity_id",
+			func(c *IdentityConnection) { c.EntityID = "" },
+			"entity_id",
+		},
+		{
+			"missing_cert",
+			func(c *IdentityConnection) { c.CertificatePEM = "" },
+			"certificate_pem",
+		},
+		{
+			"missing_sso_url",
+			func(c *IdentityConnection) { c.SSOURL = "" },
+			"sso_url",
+		},
+		{
+			"http_sso_url",
+			func(c *IdentityConnection) { c.SSOURL = "http://idp.example.com/sso" },
+			"https",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			base := IdentityConnection{
+				OrgID:          "tenant-a",
+				Provider:       "saml",
+				Type:           "sso",
+				Status:         "pending",
+				EntityID:       "https://idp.example.com/entity",
+				SSOURL:         "https://idp.example.com/sso",
+				CertificatePEM: "-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----",
+				CreatedAt:      now,
+			}
+			tc.mutate(&base)
+			_, err := NormalizeIdentityConnectionForWrite(base)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("error should mention %q, got: %v", tc.wantMsg, err)
+			}
+		})
+	}
+}
+
+func TestNormalize_NonSAMLProvidersIgnoreNativeFields(t *testing.T) {
+	// A workos or oidc provider does not need native SAML fields, so leaving
+	// them empty must remain valid.
+	for _, provider := range []string{"workos", "oidc"} {
+		t.Run(provider, func(t *testing.T) {
+			_, err := NormalizeIdentityConnectionForWrite(IdentityConnection{
+				OrgID:    "tenant-a",
+				Provider: provider,
+				Type:     "sso",
+				Status:   "pending",
+			})
+			if err != nil {
+				t.Errorf("%s provider rejected: %v", provider, err)
+			}
+		})
+	}
+}
+
+func TestNormalize_DefaultsJITProvisioningDisabled(t *testing.T) {
+	connection, err := NormalizeIdentityConnectionForWrite(IdentityConnection{
+		OrgID:    "tenant-a",
+		Provider: "workos",
+		Type:     "sso",
+	})
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if connection.JITProvisioningEnabled {
+		t.Error("JIT provisioning must default to false")
+	}
+}
+
+func TestNormalize_AttributeMappingTrimsAndDropsEmptyEntries(t *testing.T) {
+	connection, err := NormalizeIdentityConnectionForWrite(IdentityConnection{
+		OrgID:    "tenant-a",
+		Provider: "workos",
+		Type:     "sso",
+		AttributeMapping: map[string]string{
+			"email":  "  http://schemas/email  ",
+			"":       "discarded",
+			"name":   "",
+			"groups": "http://schemas/groups",
+		},
+	})
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if connection.AttributeMapping["email"] != "http://schemas/email" {
+		t.Errorf("email mapping should be trimmed: %q", connection.AttributeMapping["email"])
+	}
+	if _, ok := connection.AttributeMapping[""]; ok {
+		t.Error("empty key should be dropped")
+	}
+	if _, ok := connection.AttributeMapping["name"]; ok {
+		t.Error("empty value should be dropped")
+	}
+}
+
+// ---------- SCIM provisioning events: memory CRUD ----------
+
+func TestMemoryStore_SCIMProvisioningEventLifecycle(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+
+	if err := store.UpsertOrganization(ctx, TenancyOrganization{DisplayName: "Tenant A", Slug: "tenant-a"}); err != nil {
+		t.Fatalf("upsert org: %v", err)
+	}
+	connection, err := store.CreateIdentityConnection(ctx, IdentityConnection{
+		OrgID:              "tenant-a",
+		Provider:           "saml",
+		Type:               "directory_sync",
+		Status:             "active",
+		WorkOSConnectionID: "conn_workos_123",
+		CreatedAt:          now,
+	})
+	if err != nil {
+		t.Fatalf("create connection: %v", err)
+	}
+
+	first, err := store.CreateSCIMProvisioningEvent(ctx, SCIMProvisioningEventRecord{
+		OrgID:        "tenant-a",
+		ConnectionID: connection.ID,
+		Op:           "create",
+		ExternalID:   "okta-user-1",
+		Payload:      map[string]any{"userName": "alice@example.com"},
+		OccurredAt:   now,
+	})
+	if err != nil {
+		t.Fatalf("create scim event: %v", err)
+	}
+	second, err := store.CreateSCIMProvisioningEvent(ctx, SCIMProvisioningEventRecord{
+		OrgID:        "tenant-a",
+		ConnectionID: connection.ID,
+		Op:           "deactivate",
+		ExternalID:   "okta-user-1",
+		OccurredAt:   now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("create second scim event: %v", err)
+	}
+
+	events, err := store.ListSCIMProvisioningEvents(ctx, "tenant-a", connection.ID, 10)
+	if err != nil {
+		t.Fatalf("list scim events: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("event count: want 2, got %d", len(events))
+	}
+	// Newest first.
+	if events[0].ID != second.ID {
+		t.Errorf("expected newest event first, got %+v", events[0])
+	}
+	if events[1].ID != first.ID {
+		t.Errorf("expected oldest event second, got %+v", events[1])
+	}
+}
+
+func TestMemoryStore_SCIMProvisioningEvent_RejectsUnknownConnection(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+
+	if err := store.UpsertOrganization(ctx, TenancyOrganization{DisplayName: "Tenant A", Slug: "tenant-a"}); err != nil {
+		t.Fatalf("upsert org: %v", err)
+	}
+	_, err := store.CreateSCIMProvisioningEvent(ctx, SCIMProvisioningEventRecord{
+		OrgID:        "tenant-a",
+		ConnectionID: "99999999-9999-9999-9999-999999999999",
+		Op:           "create",
+		OccurredAt:   time.Now(),
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound for unknown connection, got: %v", err)
+	}
+}
+
+func TestNormalizeSCIMProvisioningEvent_RejectsUnknownOp(t *testing.T) {
+	_, err := NormalizeSCIMProvisioningEventForWrite(SCIMProvisioningEventRecord{
+		OrgID:        "tenant-a",
+		ConnectionID: "33333333-3333-3333-3333-333333333333",
+		Op:           "rename",
+		OccurredAt:   time.Now(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid scim provisioning op") {
+		t.Errorf("expected invalid op error, got: %v", err)
+	}
+}
+
+func TestNormalizeSCIMProvisioningEvent_AssignsIDAndDefaultsPayload(t *testing.T) {
+	event, err := NormalizeSCIMProvisioningEventForWrite(SCIMProvisioningEventRecord{
+		OrgID:        "tenant-a",
+		ConnectionID: "33333333-3333-3333-3333-333333333333",
+		Op:           "create",
+	})
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if event.ID == "" {
+		t.Error("expected normalizer to assign id")
+	}
+	if event.Payload == nil {
+		t.Error("expected payload to default to empty map")
+	}
+	if event.OccurredAt.IsZero() {
+		t.Error("expected occurred_at to default to now")
+	}
+}

--- a/internal/db/postgres_enterprise_auth.go
+++ b/internal/db/postgres_enterprise_auth.go
@@ -272,7 +272,12 @@ func (p *PostgresStore) ListVerifiedDomains(ctx context.Context, orgID string, l
 func scanIdentityConnection(row rowScanner) (IdentityConnection, error) {
 	var connection IdentityConnection
 	var workOSConnectionID sql.NullString
+	var entityID sql.NullString
+	var ssoURL sql.NullString
+	var certificatePEM sql.NullString
+	var scimBearerTokenHash sql.NullString
 	var groupRoleMap []byte
+	var attributeMapping []byte
 	if err := row.Scan(
 		&connection.ID,
 		&connection.OrgID,
@@ -282,6 +287,12 @@ func scanIdentityConnection(row rowScanner) (IdentityConnection, error) {
 		&connection.Status,
 		&groupRoleMap,
 		&connection.SSORequired,
+		&connection.JITProvisioningEnabled,
+		&entityID,
+		&ssoURL,
+		&certificatePEM,
+		&attributeMapping,
+		&scimBearerTokenHash,
 		&connection.CreatedAt,
 		&connection.UpdatedAt,
 	); err != nil {
@@ -296,6 +307,18 @@ func scanIdentityConnection(row rowScanner) (IdentityConnection, error) {
 	if workOSConnectionID.Valid {
 		connection.WorkOSConnectionID = workOSConnectionID.String
 	}
+	if entityID.Valid {
+		connection.EntityID = entityID.String
+	}
+	if ssoURL.Valid {
+		connection.SSOURL = ssoURL.String
+	}
+	if certificatePEM.Valid {
+		connection.CertificatePEM = certificatePEM.String
+	}
+	if scimBearerTokenHash.Valid {
+		connection.SCIMBearerTokenHash = scimBearerTokenHash.String
+	}
 	if len(groupRoleMap) > 0 {
 		if err := json.Unmarshal(groupRoleMap, &connection.GroupRoleMap); err != nil {
 			return IdentityConnection{}, err
@@ -304,8 +327,18 @@ func scanIdentityConnection(row rowScanner) (IdentityConnection, error) {
 	if connection.GroupRoleMap == nil {
 		connection.GroupRoleMap = map[string]string{}
 	}
+	if len(attributeMapping) > 0 {
+		if err := json.Unmarshal(attributeMapping, &connection.AttributeMapping); err != nil {
+			return IdentityConnection{}, err
+		}
+	}
+	if connection.AttributeMapping == nil {
+		connection.AttributeMapping = map[string]string{}
+	}
 	return connection, nil
 }
+
+const identityConnectionColumns = "id::text, org_id, provider, type, workos_connection_id, status, group_role_map, sso_required, jit_provisioning_enabled, entity_id, sso_url, certificate_pem, attribute_mapping, scim_bearer_token_hash, created_at, updated_at"
 
 // CreateIdentityConnection persists one enterprise identity connection scaffold.
 func (p *PostgresStore) CreateIdentityConnection(ctx context.Context, connection IdentityConnection) (IdentityConnection, error) {
@@ -317,13 +350,19 @@ func (p *PostgresStore) CreateIdentityConnection(ctx context.Context, connection
 	if err != nil {
 		return IdentityConnection{}, err
 	}
+	attributeMapping, err := json.Marshal(normalized.AttributeMapping)
+	if err != nil {
+		return IdentityConnection{}, err
+	}
 	saved, err := scanIdentityConnection(p.queryRowContext(
 		ctx,
 		`INSERT INTO identity_connections (
-		     id, org_id, provider, type, workos_connection_id, status, group_role_map, sso_required, created_at, updated_at
+		     id, org_id, provider, type, workos_connection_id, status, group_role_map, sso_required,
+		     jit_provisioning_enabled, entity_id, sso_url, certificate_pem, attribute_mapping,
+		     scim_bearer_token_hash, created_at, updated_at
 		 )
-		 VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, $10)
-		 RETURNING id::text, org_id, provider, type, workos_connection_id, status, group_role_map, sso_required, created_at, updated_at`,
+		 VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, $10, $11, $12, $13::jsonb, $14, $15, $16)
+		 RETURNING `+identityConnectionColumns,
 		normalized.ID,
 		normalized.OrgID,
 		normalized.Provider,
@@ -332,6 +371,12 @@ func (p *PostgresStore) CreateIdentityConnection(ctx context.Context, connection
 		normalized.Status,
 		string(groupRoleMap),
 		normalized.SSORequired,
+		normalized.JITProvisioningEnabled,
+		nullString(normalized.EntityID),
+		nullString(normalized.SSOURL),
+		nullString(normalized.CertificatePEM),
+		string(attributeMapping),
+		nullString(normalized.SCIMBearerTokenHash),
 		normalized.CreatedAt,
 		normalized.UpdatedAt,
 	))
@@ -355,7 +400,7 @@ func (p *PostgresStore) CreateIdentityConnection(ctx context.Context, connection
 func (p *PostgresStore) GetIdentityConnection(ctx context.Context, orgID string, connectionID string) (IdentityConnection, error) {
 	return scanIdentityConnection(p.queryRowContext(
 		ctx,
-		`SELECT id::text, org_id, provider, type, workos_connection_id, status, group_role_map, sso_required, created_at, updated_at
+		`SELECT `+identityConnectionColumns+`
 		 FROM identity_connections
 		 WHERE org_id = $1
 		   AND id = NULLIF($2, '')::uuid`,
@@ -371,7 +416,7 @@ func (p *PostgresStore) ListIdentityConnections(ctx context.Context, orgID strin
 	}
 	rows, err := p.queryContext(
 		ctx,
-		`SELECT id::text, org_id, provider, type, workos_connection_id, status, group_role_map, sso_required, created_at, updated_at
+		`SELECT `+identityConnectionColumns+`
 		 FROM identity_connections
 		 WHERE org_id = $1
 		 ORDER BY created_at DESC
@@ -386,6 +431,127 @@ func (p *PostgresStore) ListIdentityConnections(ctx context.Context, orgID strin
 	items := make([]IdentityConnection, 0)
 	for rows.Next() {
 		item, err := scanIdentityConnection(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const scimProvisioningEventColumns = "id::text, org_id, connection_id::text, op, external_id, user_id::text, payload, occurred_at"
+
+func scanSCIMProvisioningEvent(row rowScanner) (SCIMProvisioningEventRecord, error) {
+	var event SCIMProvisioningEventRecord
+	var externalID sql.NullString
+	var userID sql.NullString
+	var payload []byte
+	if err := row.Scan(
+		&event.ID,
+		&event.OrgID,
+		&event.ConnectionID,
+		&event.Op,
+		&externalID,
+		&userID,
+		&payload,
+		&event.OccurredAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return SCIMProvisioningEventRecord{}, ErrNotFound
+		}
+		if isTenancyFKViolation(err) {
+			return SCIMProvisioningEventRecord{}, ErrNotFound
+		}
+		return SCIMProvisioningEventRecord{}, err
+	}
+	if externalID.Valid {
+		event.ExternalID = externalID.String
+	}
+	if userID.Valid {
+		event.UserID = userID.String
+	}
+	if len(payload) > 0 {
+		if err := json.Unmarshal(payload, &event.Payload); err != nil {
+			return SCIMProvisioningEventRecord{}, err
+		}
+	}
+	if event.Payload == nil {
+		event.Payload = map[string]any{}
+	}
+	return event, nil
+}
+
+// CreateSCIMProvisioningEvent appends one SCIM provisioning event to the audit
+// log scoped to the org + connection. Append-only by design.
+func (p *PostgresStore) CreateSCIMProvisioningEvent(ctx context.Context, event SCIMProvisioningEventRecord) (SCIMProvisioningEventRecord, error) {
+	normalized, err := NormalizeSCIMProvisioningEventForWrite(event)
+	if err != nil {
+		return SCIMProvisioningEventRecord{}, err
+	}
+	payload, err := json.Marshal(normalized.Payload)
+	if err != nil {
+		return SCIMProvisioningEventRecord{}, err
+	}
+	saved, err := scanSCIMProvisioningEvent(p.queryRowContext(
+		ctx,
+		`INSERT INTO scim_provisioning_events (
+		     id, org_id, connection_id, op, external_id, user_id, payload, occurred_at
+		 )
+		 VALUES ($1, $2, $3, $4, $5, NULLIF($6, '')::uuid, $7::jsonb, $8)
+		 RETURNING `+scimProvisioningEventColumns,
+		normalized.ID,
+		normalized.OrgID,
+		normalized.ConnectionID,
+		normalized.Op,
+		nullString(normalized.ExternalID),
+		normalized.UserID,
+		string(payload),
+		normalized.OccurredAt,
+	))
+	if err != nil {
+		if isTenancyUniqueViolation(err) {
+			return SCIMProvisioningEventRecord{}, ErrConflict
+		}
+		return SCIMProvisioningEventRecord{}, err
+	}
+	audit.WriteAction(ctx, audit.AuditEvent{
+		Action:       "auth.scim_provisioning_event.create",
+		TenantID:     saved.OrgID,
+		ResourceType: "scim_provisioning_event",
+		ResourceID:   saved.ID,
+		Outcome:      "success",
+	})
+	return saved, nil
+}
+
+// ListSCIMProvisioningEvents returns events for one connection ordered newest
+// first, capped at limit (default 100).
+func (p *PostgresStore) ListSCIMProvisioningEvents(ctx context.Context, orgID string, connectionID string, limit int) ([]SCIMProvisioningEventRecord, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := p.queryContext(
+		ctx,
+		`SELECT `+scimProvisioningEventColumns+`
+		 FROM scim_provisioning_events
+		 WHERE org_id = $1
+		   AND connection_id = NULLIF($2, '')::uuid
+		 ORDER BY occurred_at DESC
+		 LIMIT $3`,
+		strings.TrimSpace(orgID),
+		strings.TrimSpace(connectionID),
+		limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := make([]SCIMProvisioningEventRecord, 0)
+	for rows.Next() {
+		item, err := scanSCIMProvisioningEvent(rows)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/db/postgres_enterprise_auth_test.go
+++ b/internal/db/postgres_enterprise_auth_test.go
@@ -114,8 +114,8 @@ func TestPostgresEnterpriseAuthStores(t *testing.T) {
 	}
 
 	mock.ExpectQuery("INSERT INTO identity_connections").
-		WithArgs("44444444-4444-4444-4444-444444444444", "tenant-a", "workos", "sso", sqlmock.AnyArg(), "active", `{"Engineering":"admin"}`, true, now, now).
-		WillReturnRows(postgresEnterpriseConnectionRows().AddRow("44444444-4444-4444-4444-444444444444", "tenant-a", "workos", "sso", nil, "active", []byte(`{"Engineering":"admin"}`), true, now, now))
+		WithArgs("44444444-4444-4444-4444-444444444444", "tenant-a", "workos", "sso", sqlmock.AnyArg(), "active", `{"Engineering":"admin"}`, true, false, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), `{}`, sqlmock.AnyArg(), now, now).
+		WillReturnRows(postgresEnterpriseConnectionRows().AddRow("44444444-4444-4444-4444-444444444444", "tenant-a", "workos", "sso", nil, "active", []byte(`{"Engineering":"admin"}`), true, false, nil, nil, nil, []byte(`{}`), nil, now, now))
 	connection, err := store.CreateIdentityConnection(ctx, IdentityConnection{
 		ID:           "44444444-4444-4444-4444-444444444444",
 		OrgID:        "tenant-a",
@@ -136,7 +136,7 @@ func TestPostgresEnterpriseAuthStores(t *testing.T) {
 
 	mock.ExpectQuery("FROM identity_connections").
 		WithArgs("tenant-a", connection.ID).
-		WillReturnRows(postgresEnterpriseConnectionRows().AddRow(connection.ID, "tenant-a", "workos", "sso", nil, "active", []byte(`{"Engineering":"admin"}`), true, now, now))
+		WillReturnRows(postgresEnterpriseConnectionRows().AddRow(connection.ID, "tenant-a", "workos", "sso", nil, "active", []byte(`{"Engineering":"admin"}`), true, false, nil, nil, nil, []byte(`{}`), nil, now, now))
 	gotConnection, err := store.GetIdentityConnection(ctx, "tenant-a", connection.ID)
 	if err != nil {
 		t.Fatalf("get identity connection: %v", err)
@@ -147,7 +147,7 @@ func TestPostgresEnterpriseAuthStores(t *testing.T) {
 
 	mock.ExpectQuery("FROM identity_connections").
 		WithArgs("tenant-a", 10).
-		WillReturnRows(postgresEnterpriseConnectionRows().AddRow(connection.ID, "tenant-a", "workos", "sso", nil, "active", []byte(`{"Engineering":"admin"}`), true, now, now))
+		WillReturnRows(postgresEnterpriseConnectionRows().AddRow(connection.ID, "tenant-a", "workos", "sso", nil, "active", []byte(`{"Engineering":"admin"}`), true, false, nil, nil, nil, []byte(`{}`), nil, now, now))
 	connections, err := store.ListIdentityConnections(ctx, "tenant-a", 10)
 	if err != nil {
 		t.Fatalf("list identity connections: %v", err)
@@ -236,7 +236,7 @@ func TestPostgresEnterpriseAuthUniqueViolationsReturnConflict(t *testing.T) {
 	}
 
 	mock.ExpectQuery("INSERT INTO identity_connections").
-		WithArgs("33333333-3333-3333-3333-333333333333", "tenant-a", "workos", "sso", sqlmock.AnyArg(), "pending", `{}`, false, now, now).
+		WithArgs("33333333-3333-3333-3333-333333333333", "tenant-a", "workos", "sso", sqlmock.AnyArg(), "pending", `{}`, false, false, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), `{}`, sqlmock.AnyArg(), now, now).
 		WillReturnError(testSQLStateError("23505"))
 	if _, err := store.CreateIdentityConnection(ctx, IdentityConnection{
 		ID:        "33333333-3333-3333-3333-333333333333",
@@ -263,5 +263,13 @@ func postgresEnterpriseDomainRows() *sqlmock.Rows {
 }
 
 func postgresEnterpriseConnectionRows() *sqlmock.Rows {
-	return sqlmock.NewRows([]string{"id", "org_id", "provider", "type", "workos_connection_id", "status", "group_role_map", "sso_required", "created_at", "updated_at"})
+	return sqlmock.NewRows([]string{
+		"id", "org_id", "provider", "type", "workos_connection_id", "status", "group_role_map",
+		"sso_required", "jit_provisioning_enabled", "entity_id", "sso_url", "certificate_pem",
+		"attribute_mapping", "scim_bearer_token_hash", "created_at", "updated_at",
+	})
+}
+
+func postgresSCIMProvisioningEventRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"id", "org_id", "connection_id", "op", "external_id", "user_id", "payload", "occurred_at"})
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1324,12 +1324,21 @@ func NormalizeIdentityConnectionForWrite(connection IdentityConnection) (Identit
 
 // validateSAMLCompleteness mirrors the identity_connections_saml_completeness
 // CHECK constraint at the Go layer so memory-mode CRUD enforces the same
-// contract as Postgres.
+// contract as Postgres. A SAML row must be exactly one of:
+//   - WorkOS-backed: workos_connection_id set, native fields empty
+//   - Native: entity_id + certificate_pem + https sso_url all set,
+//     workos_connection_id empty
+//
+// Mixed-mode rows are rejected so the runtime cannot end up confused about
+// which protocol path owns the connection.
 func validateSAMLCompleteness(c IdentityConnection) error {
 	if c.Provider != "saml" {
 		return nil
 	}
 	if c.WorkOSConnectionID != "" {
+		if c.EntityID != "" || c.CertificatePEM != "" || c.SSOURL != "" {
+			return fmt.Errorf("workos-backed saml connection cannot set native fields (entity_id, certificate_pem, sso_url)")
+		}
 		return nil
 	}
 	missing := []string{}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -472,18 +472,51 @@ type VerifiedDomain struct {
 	CreatedAt          time.Time  `json:"created_at"`
 }
 
-// IdentityConnection stores one enterprise SSO or directory-sync connection scaffold.
+// IdentityConnection stores one enterprise SSO or directory-sync connection.
+//
+// A row with Provider == "saml" must be either WorkOS-backed (the legacy path,
+// WorkOSConnectionID populated and native fields zero) or native (EntityID,
+// SSOURL, and CertificatePEM all populated; SSOURL must use https). The two
+// modes are mutually exclusive at write time so callers cannot end up with a
+// half-configured connection.
 type IdentityConnection struct {
-	ID                 string            `json:"id"`
-	OrgID              string            `json:"org_id"`
-	Provider           string            `json:"provider"`
-	Type               string            `json:"type"`
-	WorkOSConnectionID string            `json:"workos_connection_id,omitempty"`
-	Status             string            `json:"status"`
-	GroupRoleMap       map[string]string `json:"group_role_map"`
-	SSORequired        bool              `json:"sso_required"`
-	CreatedAt          time.Time         `json:"created_at"`
-	UpdatedAt          time.Time         `json:"updated_at"`
+	ID                     string            `json:"id"`
+	OrgID                  string            `json:"org_id"`
+	Provider               string            `json:"provider"`
+	Type                   string            `json:"type"`
+	WorkOSConnectionID     string            `json:"workos_connection_id,omitempty"`
+	Status                 string            `json:"status"`
+	GroupRoleMap           map[string]string `json:"group_role_map"`
+	SSORequired            bool              `json:"sso_required"`
+	JITProvisioningEnabled bool              `json:"jit_provisioning_enabled"`
+	EntityID               string            `json:"entity_id,omitempty"`
+	SSOURL                 string            `json:"sso_url,omitempty"`
+	CertificatePEM         string            `json:"certificate_pem,omitempty"`
+	AttributeMapping       map[string]string `json:"attribute_mapping,omitempty"`
+	SCIMBearerTokenHash    string            `json:"scim_bearer_token_hash,omitempty"`
+	CreatedAt              time.Time         `json:"created_at"`
+	UpdatedAt              time.Time         `json:"updated_at"`
+}
+
+// IsNativeSAML reports whether this connection drives native SAML directly
+// (as opposed to delegating to WorkOS). Only meaningful when Provider=="saml".
+func (c IdentityConnection) IsNativeSAML() bool {
+	return strings.ToLower(strings.TrimSpace(c.Provider)) == "saml" &&
+		strings.TrimSpace(c.WorkOSConnectionID) == "" &&
+		strings.TrimSpace(c.EntityID) != ""
+}
+
+// SCIMProvisioningEventRecord is the persisted form of one SCIM op recorded
+// for tenant-visible governance audit. Append-only.
+type SCIMProvisioningEventRecord struct {
+	ID           string         `json:"id"`
+	OrgID        string         `json:"org_id"`
+	ConnectionID string         `json:"connection_id"`
+	Op           string         `json:"op"`
+	ExternalID   string         `json:"external_id,omitempty"`
+	UserID       string         `json:"user_id,omitempty"`
+	Payload      map[string]any `json:"payload,omitempty"`
+	OccurredAt   time.Time      `json:"occurred_at"`
 }
 
 // TenancyProject stores one project metadata record.
@@ -1266,6 +1299,16 @@ func NormalizeIdentityConnectionForWrite(connection IdentityConnection) (Identit
 		return IdentityConnection{}, fmt.Errorf("invalid identity connection status")
 	}
 	normalized.GroupRoleMap = normalizeGroupRoleMap(connection.GroupRoleMap)
+	normalized.EntityID = strings.TrimSpace(connection.EntityID)
+	normalized.SSOURL = strings.TrimSpace(connection.SSOURL)
+	normalized.CertificatePEM = strings.TrimSpace(connection.CertificatePEM)
+	normalized.SCIMBearerTokenHash = strings.TrimSpace(connection.SCIMBearerTokenHash)
+	normalized.AttributeMapping = normalizeAttributeMapping(connection.AttributeMapping)
+
+	if err := validateSAMLCompleteness(normalized); err != nil {
+		return IdentityConnection{}, err
+	}
+
 	if normalized.CreatedAt.IsZero() {
 		normalized.CreatedAt = time.Now().UTC()
 	} else {
@@ -1275,6 +1318,100 @@ func NormalizeIdentityConnectionForWrite(connection IdentityConnection) (Identit
 		normalized.UpdatedAt = normalized.CreatedAt
 	} else {
 		normalized.UpdatedAt = normalized.UpdatedAt.UTC()
+	}
+	return normalized, nil
+}
+
+// validateSAMLCompleteness mirrors the identity_connections_saml_completeness
+// CHECK constraint at the Go layer so memory-mode CRUD enforces the same
+// contract as Postgres.
+func validateSAMLCompleteness(c IdentityConnection) error {
+	if c.Provider != "saml" {
+		return nil
+	}
+	if c.WorkOSConnectionID != "" {
+		return nil
+	}
+	missing := []string{}
+	if c.EntityID == "" {
+		missing = append(missing, "entity_id")
+	}
+	if c.CertificatePEM == "" {
+		missing = append(missing, "certificate_pem")
+	}
+	if c.SSOURL == "" {
+		missing = append(missing, "sso_url")
+	} else if !strings.HasPrefix(strings.ToLower(c.SSOURL), "https://") {
+		return fmt.Errorf("saml sso_url must use https://")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("native saml connection is missing required fields: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+func normalizeAttributeMapping(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(values))
+	for k, v := range values {
+		key := strings.TrimSpace(k)
+		val := strings.TrimSpace(v)
+		if key == "" || val == "" {
+			continue
+		}
+		out[key] = val
+	}
+	return out
+}
+
+var validSCIMProvisioningOps = map[string]struct{}{
+	"create":     {},
+	"update":     {},
+	"deactivate": {},
+	"delete":     {},
+}
+
+// NormalizeSCIMProvisioningEventForWrite validates and canonicalizes one
+// persisted SCIM provisioning event prior to insert.
+func NormalizeSCIMProvisioningEventForWrite(event SCIMProvisioningEventRecord) (SCIMProvisioningEventRecord, error) {
+	normalized := event
+	normalized.ID = strings.TrimSpace(event.ID)
+	if normalized.ID == "" {
+		normalized.ID = uuid.NewString()
+	} else if _, err := uuid.Parse(normalized.ID); err != nil {
+		return SCIMProvisioningEventRecord{}, fmt.Errorf("invalid scim provisioning event id")
+	}
+	normalized.OrgID = strings.TrimSpace(event.OrgID)
+	if normalized.OrgID == "" {
+		return SCIMProvisioningEventRecord{}, fmt.Errorf("org id is required")
+	}
+	normalized.ConnectionID = strings.TrimSpace(event.ConnectionID)
+	if normalized.ConnectionID == "" {
+		return SCIMProvisioningEventRecord{}, fmt.Errorf("connection id is required")
+	}
+	if _, err := uuid.Parse(normalized.ConnectionID); err != nil {
+		return SCIMProvisioningEventRecord{}, fmt.Errorf("invalid connection id")
+	}
+	normalized.Op = strings.ToLower(strings.TrimSpace(event.Op))
+	if _, ok := validSCIMProvisioningOps[normalized.Op]; !ok {
+		return SCIMProvisioningEventRecord{}, fmt.Errorf("invalid scim provisioning op %q", event.Op)
+	}
+	normalized.ExternalID = strings.TrimSpace(event.ExternalID)
+	normalized.UserID = strings.TrimSpace(event.UserID)
+	if normalized.UserID != "" {
+		if _, err := uuid.Parse(normalized.UserID); err != nil {
+			return SCIMProvisioningEventRecord{}, fmt.Errorf("invalid user id")
+		}
+	}
+	if normalized.Payload == nil {
+		normalized.Payload = map[string]any{}
+	}
+	if normalized.OccurredAt.IsZero() {
+		normalized.OccurredAt = time.Now().UTC()
+	} else {
+		normalized.OccurredAt = normalized.OccurredAt.UTC()
 	}
 	return normalized, nil
 }
@@ -1923,6 +2060,8 @@ type Store interface {
 	CreateIdentityConnection(ctx context.Context, connection IdentityConnection) (IdentityConnection, error)
 	GetIdentityConnection(ctx context.Context, orgID string, connectionID string) (IdentityConnection, error)
 	ListIdentityConnections(ctx context.Context, orgID string, limit int) ([]IdentityConnection, error)
+	CreateSCIMProvisioningEvent(ctx context.Context, event SCIMProvisioningEventRecord) (SCIMProvisioningEventRecord, error)
+	ListSCIMProvisioningEvents(ctx context.Context, orgID string, connectionID string, limit int) ([]SCIMProvisioningEventRecord, error)
 	ListIdentities(ctx context.Context, filter IdentityFilter, limit int) ([]domain.Identity, error)
 	ListRelationships(ctx context.Context, filter RelationshipFilter, limit int) ([]domain.Relationship, error)
 	AppendScanEvent(ctx context.Context, scanID string, level string, message string, metadata map[string]any) error

--- a/migrations/000024_native_sso_scim_scaffold.down.sql
+++ b/migrations/000024_native_sso_scim_scaffold.down.sql
@@ -7,10 +7,6 @@ DROP TABLE IF EXISTS scim_provisioning_events;
 
 DROP INDEX IF EXISTS uq_identity_connections_org_id;
 
-DROP INDEX IF EXISTS idx_users_scim_external_id;
-ALTER TABLE users
-    DROP COLUMN IF EXISTS scim_external_id;
-
 ALTER TABLE identity_connections
     DROP CONSTRAINT IF EXISTS identity_connections_attribute_mapping_object,
     DROP CONSTRAINT IF EXISTS identity_connections_saml_completeness,

--- a/migrations/000024_native_sso_scim_scaffold.down.sql
+++ b/migrations/000024_native_sso_scim_scaffold.down.sql
@@ -5,6 +5,8 @@ DROP INDEX IF EXISTS idx_scim_provisioning_events_external_id;
 DROP INDEX IF EXISTS idx_scim_provisioning_events_connection_time;
 DROP TABLE IF EXISTS scim_provisioning_events;
 
+DROP INDEX IF EXISTS uq_identity_connections_org_id;
+
 DROP INDEX IF EXISTS idx_users_scim_external_id;
 ALTER TABLE users
     DROP COLUMN IF EXISTS scim_external_id;

--- a/migrations/000024_native_sso_scim_scaffold.down.sql
+++ b/migrations/000024_native_sso_scim_scaffold.down.sql
@@ -1,0 +1,20 @@
+-- 000024_native_sso_scim_scaffold.down.sql
+
+DROP POLICY IF EXISTS scim_provisioning_events_scope_isolation ON scim_provisioning_events;
+DROP INDEX IF EXISTS idx_scim_provisioning_events_external_id;
+DROP INDEX IF EXISTS idx_scim_provisioning_events_connection_time;
+DROP TABLE IF EXISTS scim_provisioning_events;
+
+DROP INDEX IF EXISTS idx_users_scim_external_id;
+ALTER TABLE users
+    DROP COLUMN IF EXISTS scim_external_id;
+
+ALTER TABLE identity_connections
+    DROP CONSTRAINT IF EXISTS identity_connections_attribute_mapping_object,
+    DROP CONSTRAINT IF EXISTS identity_connections_saml_completeness,
+    DROP COLUMN IF EXISTS scim_bearer_token_hash,
+    DROP COLUMN IF EXISTS jit_provisioning_enabled,
+    DROP COLUMN IF EXISTS attribute_mapping,
+    DROP COLUMN IF EXISTS certificate_pem,
+    DROP COLUMN IF EXISTS sso_url,
+    DROP COLUMN IF EXISTS entity_id;

--- a/migrations/000024_native_sso_scim_scaffold.up.sql
+++ b/migrations/000024_native_sso_scim_scaffold.up.sql
@@ -24,6 +24,14 @@ ALTER TABLE identity_connections
 -- rows continue to satisfy the legacy contract (workos_connection_id set,
 -- native columns NULL). Native rows require entity_id, certificate_pem, and
 -- an https sso_url. Non-saml providers (workos, oidc) are unaffected.
+-- The constraint is added NOT VALID so the migration is forward-safe against
+-- databases that already contain bare provider='saml' scaffold rows created
+-- under the pre-#1138 schema (status='pending', no workos_connection_id, no
+-- native fields). Those legacy rows are grandfathered: they remain in place,
+-- but any subsequent INSERT or UPDATE on identity_connections must satisfy
+-- the constraint. Operators can run
+--   ALTER TABLE identity_connections VALIDATE CONSTRAINT identity_connections_saml_completeness;
+-- once they have backfilled or removed any leftover bare-pending SAML rows.
 DO $$
 BEGIN
     IF NOT EXISTS (
@@ -47,7 +55,7 @@ BEGIN
                     AND certificate_pem IS NOT NULL AND LENGTH(TRIM(certificate_pem)) > 0
                     AND sso_url IS NOT NULL AND sso_url ~* '^https://'
                 )
-            );
+            ) NOT VALID;
     END IF;
 END;
 $$;

--- a/migrations/000024_native_sso_scim_scaffold.up.sql
+++ b/migrations/000024_native_sso_scim_scaffold.up.sql
@@ -1,0 +1,100 @@
+-- 000024_native_sso_scim_scaffold.up.sql
+--
+-- Adds the schema scaffolding for native SAML SSO and SCIM 2.0 provisioning
+-- alongside the existing WorkOS-managed path. Purely additive: existing
+-- WorkOS-SAML rows continue to validate; all new columns are nullable or
+-- defaulted; no existing reads or writes change.
+--
+-- Forward-safe; all column adds, table creates, indexes, and constraints use
+-- IF NOT EXISTS / DO blocks.
+
+------------------------------------------------------------------------------
+-- identity_connections: native SAML + SCIM bearer token columns
+------------------------------------------------------------------------------
+
+ALTER TABLE identity_connections
+    ADD COLUMN IF NOT EXISTS entity_id TEXT,
+    ADD COLUMN IF NOT EXISTS sso_url TEXT,
+    ADD COLUMN IF NOT EXISTS certificate_pem TEXT,
+    ADD COLUMN IF NOT EXISTS attribute_mapping JSONB NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN IF NOT EXISTS jit_provisioning_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS scim_bearer_token_hash TEXT;
+
+-- Constrain SAML rows to be either WorkOS-backed or native-complete. WorkOS
+-- rows continue to satisfy the legacy contract (workos_connection_id set,
+-- native columns NULL). Native rows require entity_id, certificate_pem, and
+-- an https sso_url. Non-saml providers (workos, oidc) are unaffected.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'identity_connections_saml_completeness'
+    ) THEN
+        ALTER TABLE identity_connections
+            ADD CONSTRAINT identity_connections_saml_completeness CHECK (
+                provider <> 'saml'
+                OR workos_connection_id IS NOT NULL
+                OR (
+                    entity_id IS NOT NULL AND LENGTH(TRIM(entity_id)) > 0
+                    AND certificate_pem IS NOT NULL AND LENGTH(TRIM(certificate_pem)) > 0
+                    AND sso_url IS NOT NULL AND sso_url ~* '^https://'
+                )
+            );
+    END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'identity_connections_attribute_mapping_object'
+    ) THEN
+        ALTER TABLE identity_connections
+            ADD CONSTRAINT identity_connections_attribute_mapping_object CHECK (
+                jsonb_typeof(attribute_mapping) = 'object'
+            );
+    END IF;
+END;
+$$;
+
+------------------------------------------------------------------------------
+-- users.scim_external_id: stable foreign id from the IdP (Okta/Azure user id)
+------------------------------------------------------------------------------
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS scim_external_id TEXT;
+
+-- Unique only when populated; one IdP-assigned id per Identrail user.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_scim_external_id
+    ON users (scim_external_id)
+    WHERE scim_external_id IS NOT NULL;
+
+------------------------------------------------------------------------------
+-- scim_provisioning_events: append-only audit of every SCIM op
+------------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS scim_provisioning_events (
+    id UUID PRIMARY KEY,
+    org_id TEXT NOT NULL REFERENCES tenancy_organizations(tenant_id) ON DELETE CASCADE,
+    connection_id UUID NOT NULL REFERENCES identity_connections(id) ON DELETE CASCADE,
+    op TEXT NOT NULL,
+    external_id TEXT,
+    user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+    payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CHECK (op IN ('create', 'update', 'deactivate', 'delete')),
+    CHECK (jsonb_typeof(payload) = 'object')
+);
+
+CREATE INDEX IF NOT EXISTS idx_scim_provisioning_events_connection_time
+    ON scim_provisioning_events (connection_id, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_scim_provisioning_events_external_id
+    ON scim_provisioning_events (external_id)
+    WHERE external_id IS NOT NULL;
+
+ALTER TABLE scim_provisioning_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE scim_provisioning_events FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS scim_provisioning_events_scope_isolation ON scim_provisioning_events;
+CREATE POLICY scim_provisioning_events_scope_isolation ON scim_provisioning_events
+USING (identrail_rls_tenant_matches(org_id))
+WITH CHECK (identrail_rls_tenant_matches(org_id));

--- a/migrations/000024_native_sso_scim_scaffold.up.sql
+++ b/migrations/000024_native_sso_scim_scaffold.up.sql
@@ -32,9 +32,18 @@ BEGIN
         ALTER TABLE identity_connections
             ADD CONSTRAINT identity_connections_saml_completeness CHECK (
                 provider <> 'saml'
-                OR workos_connection_id IS NOT NULL
                 OR (
-                    entity_id IS NOT NULL AND LENGTH(TRIM(entity_id)) > 0
+                    -- WorkOS-backed: workos_connection_id set, native fields empty.
+                    workos_connection_id IS NOT NULL
+                    AND entity_id IS NULL
+                    AND certificate_pem IS NULL
+                    AND sso_url IS NULL
+                )
+                OR (
+                    -- Native: entity_id + certificate_pem + https sso_url all set,
+                    -- workos_connection_id empty.
+                    workos_connection_id IS NULL
+                    AND entity_id IS NOT NULL AND LENGTH(TRIM(entity_id)) > 0
                     AND certificate_pem IS NOT NULL AND LENGTH(TRIM(certificate_pem)) > 0
                     AND sso_url IS NOT NULL AND sso_url ~* '^https://'
                 )
@@ -56,6 +65,14 @@ BEGIN
 END;
 $$;
 
+-- A composite (org_id, id) unique index lets scim_provisioning_events install
+-- a composite foreign key that enforces tenant scope, not just "the connection
+-- uuid exists". Without it, a tenant could insert an event referencing a
+-- connection owned by a different tenant — and the RLS policy on the events
+-- table would then expose that cross-tenant row.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_identity_connections_org_id
+    ON identity_connections (org_id, id);
+
 ------------------------------------------------------------------------------
 -- users.scim_external_id: stable foreign id from the IdP (Okta/Azure user id)
 ------------------------------------------------------------------------------
@@ -75,14 +92,23 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_users_scim_external_id
 CREATE TABLE IF NOT EXISTS scim_provisioning_events (
     id UUID PRIMARY KEY,
     org_id TEXT NOT NULL REFERENCES tenancy_organizations(tenant_id) ON DELETE CASCADE,
-    connection_id UUID NOT NULL REFERENCES identity_connections(id) ON DELETE CASCADE,
+    connection_id UUID NOT NULL,
     op TEXT NOT NULL,
     external_id TEXT,
     user_id UUID REFERENCES users(id) ON DELETE SET NULL,
     payload JSONB NOT NULL DEFAULT '{}'::jsonb,
     occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CHECK (op IN ('create', 'update', 'deactivate', 'delete')),
-    CHECK (jsonb_typeof(payload) = 'object')
+    CHECK (jsonb_typeof(payload) = 'object'),
+    -- Composite foreign key forces (org_id, connection_id) to identify a row
+    -- in identity_connections that belongs to the same tenant. Without this,
+    -- an attacker (or buggy caller) with a valid connection uuid from tenant B
+    -- could insert an event under tenant A; the table's RLS scopes by org_id,
+    -- so that cross-tenant row would then be visible to tenant A.
+    CONSTRAINT scim_provisioning_events_connection_in_org
+        FOREIGN KEY (org_id, connection_id)
+        REFERENCES identity_connections (org_id, id)
+        ON DELETE CASCADE
 );
 
 CREATE INDEX IF NOT EXISTS idx_scim_provisioning_events_connection_time

--- a/migrations/000024_native_sso_scim_scaffold.up.sql
+++ b/migrations/000024_native_sso_scim_scaffold.up.sql
@@ -73,17 +73,12 @@ $$;
 CREATE UNIQUE INDEX IF NOT EXISTS uq_identity_connections_org_id
     ON identity_connections (org_id, id);
 
-------------------------------------------------------------------------------
--- users.scim_external_id: stable foreign id from the IdP (Okta/Azure user id)
-------------------------------------------------------------------------------
-
-ALTER TABLE users
-    ADD COLUMN IF NOT EXISTS scim_external_id TEXT;
-
--- Unique only when populated; one IdP-assigned id per Identrail user.
-CREATE UNIQUE INDEX IF NOT EXISTS idx_users_scim_external_id
-    ON users (scim_external_id)
-    WHERE scim_external_id IS NOT NULL;
+-- Note: the SCIM-assigned external id is a per-connection identifier — two
+-- IdPs (or two tenants on the same IdP) can legitimately emit the same value
+-- without conflict. Identrail therefore stores SCIM identities in the existing
+-- user_identities table with provider = 'scim:<connection_uuid>', reusing its
+-- UNIQUE (provider, subject) contract instead of carrying a per-user column
+-- on users that would either force global uniqueness or violate it.
 
 ------------------------------------------------------------------------------
 -- scim_provisioning_events: append-only audit of every SCIM op


### PR DESCRIPTION
## Summary

First of five PRs delivering native SAML SSO + SCIM 2.0 provisioning alongside the existing WorkOS-managed path. This change is purely additive: no HTTP routes, no SAML protocol code, no SCIM endpoints, and the WorkOS sign-in/sign-up flow is entirely untouched.

## What changes

**Migration `000024_native_sso_scim_scaffold`:**

- `identity_connections` gains nullable `entity_id`, `sso_url`, `certificate_pem`, `attribute_mapping` (JSONB), `jit_provisioning_enabled`, and `scim_bearer_token_hash` columns
- A SAML completeness CHECK constraint requires each `provider='saml'` row to be **either** WorkOS-backed (`workos_connection_id IS NOT NULL`) **or** fully native (`entity_id`, `certificate_pem`, and `https://` `sso_url` all populated). Legacy WorkOS-SAML rows remain valid.
- `users.scim_external_id` (nullable, unique-when-set) records the IdP-assigned identifier so PR-3 (SAML JIT) and PR-4 (SCIM PATCH/DELETE) can resolve users
- New append-only `scim_provisioning_events` table captures every SCIM op for tenant-visible audit; standard RLS tenant-isolation policy applied

**Go layer:**

- `IdentityConnection` struct gains the new fields, plus an `IsNativeSAML()` helper that PR-3's ACS handler will use to route requests
- `NormalizeIdentityConnectionForWrite` mirrors the SQL CHECK constraint at the Go layer so memory-mode CRUD enforces the same contract; the SAML completeness validator names the missing field for clear admin errors
- `SCIMProvisioningEventRecord` + `CreateSCIMProvisioningEvent` / `ListSCIMProvisioningEvents` added to the `Store` interface with memory + Postgres implementations

## What is intentionally not in this PR

- No HTTP routes (PR-2 adds SAML CRUD, PR-4 adds SCIM endpoints)
- No SAML protocol code (PR-3 uses `crewjam/saml`)
- No `/auth/config` changes (PR-3)
- WorkOS sign-in/sign-up untouched

## Test plan

- [x] `go test ./internal/db/...` — full db suite green
- [x] `go test ./...` — full suite green, no regressions
- [x] 14 new tests cover SAML completeness (WorkOS-backed, native, half-configured rejections per missing field, http_sso_url rejection), non-SAML provider backwards compatibility, JIT-default-disabled, attribute-mapping normalization, SCIM event lifecycle (insert + ordered list), and SCIM op enum validation
- [x] Existing identity-connection sqlmock tests updated for the new column list and round-trip cleanly

## Validation performed

```
go test ./internal/db/...          # PASS
go test ./...                       # PASS
make fmt-check                      # clean
make vet                            # clean
```

`CHANGELOG.md` and `docs/migrations.md` updated.

## AI-assisted

- AI-assisted: yes
- Tools used: Claude Code
- Where used: `migrations/000024_*`, `internal/db/*` (struct, normalizer, store interface, CRUD), `internal/db/native_sso_scim_test.go`, `CHANGELOG.md`, `docs/migrations.md`
- Human verification performed: full test suite run, manual review of CHECK constraint logic vs Go normalizer parity, manual review of sqlmock test updates for the new column list

Sub-task of #576 (ITR-035); first of #1133, #1134, #1135, #1136, #1137.

Closes #1133

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add schema and store scaffolding for native SAML SSO and SCIM 2.0 alongside the existing WorkOS path. No routes or protocol code; current sign-in/sign-up stays the same.

- **New Features**
  - Database: extended `identity_connections` with SAML fields (`entity_id`, https-only `sso_url`, `certificate_pem`), `attribute_mapping` (JSONB with object CHECK), `jit_provisioning_enabled` (default false), and `scim_bearer_token_hash`; added a SAML completeness CHECK enforcing strict mutual exclusivity between WorkOS-backed and native SAML rows, installed NOT VALID for forward-safety with legacy rows.
  - Database: SCIM external ids are stored in `user_identities` with provider `scim:<connection_uuid>`; added an append-only `scim_provisioning_events` table with RLS and a composite FK on `(org_id, connection_id)` backed by a unique index on `identity_connections (org_id, id)` to prevent cross-tenant inserts.
  - Go data layer: `IdentityConnection` now includes native fields and `IsNativeSAML()`; write-time validation mirrors DB constraints (mutual exclusivity, https-only `sso_url`, JIT default off, attribute-mapping normalization). Added `SCIMProvisioningEventRecord` plus `CreateSCIMProvisioningEvent`/`ListSCIMProvisioningEvents` (newest first) with memory and Postgres implementations; memory store enforces user FK parity and same-tenant connection checks; audit hooks included.

<sup>Written for commit 0e7a00cb43a7ca484a280d39af7fb1efa5b05c0b. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1138?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

