### PR TITLE
Fix broad API log diagnostics

### DIFF
--- a/.github/workflows/aws-api-log-diagnostics.yml
+++ b/.github/workflows/aws-api-log-diagnostics.yml
@@ -9,7 +9,7 @@ on:
         type: string
         default: "60"
       filter_pattern:
-        description: "CloudWatch Logs filter pattern. Leave blank to fetch recent API events."
+        description: "CloudWatch Logs filter pattern. Use <none> to fetch recent API events without a filter."
         required: false
         type: string
         default: '"authenticate workos callback"'
@@ -136,6 +136,13 @@ jobs:
           start_time_ms="$(( $(date +%s) * 1000 - LOOKBACK_MINUTES * 60 * 1000 ))"
           events_file="${RUNNER_TEMP}/identrail-api-log-events.json"
           printf '{"events":[]}\n' > "${events_file}"
+          filter_pattern="$(printf '%s' "${FILTER_PATTERN}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+          filter_pattern_lower="${filter_pattern,,}"
+          case "${filter_pattern_lower}" in
+            "<none>"|"none"|"no-filter"|"all")
+              filter_pattern=""
+              ;;
+          esac
           next_token=""
           pages_scanned=0
           max_pages=20
@@ -149,8 +156,8 @@ jobs:
               --no-paginate
               --output json
             )
-            if [ -n "${FILTER_PATTERN}" ]; then
-              args+=(--filter-pattern "${FILTER_PATTERN}")
+            if [ -n "${filter_pattern}" ]; then
+              args+=(--filter-pattern "${filter_pattern}")
             fi
             if [ -n "${next_token}" ]; then
               args+=(--next-token "${next_token}")
@@ -177,7 +184,7 @@ jobs:
             echo
             echo "- Log group: \`${LOG_GROUP_NAME}\`"
             echo "- Lookback: \`${LOOKBACK_MINUTES}\` minutes"
-            echo "- Filter pattern: \`${FILTER_PATTERN:-<none>}\`"
+            echo "- Filter pattern: \`${filter_pattern:-<none>}\`"
             echo "- CloudWatch pages scanned: \`${pages_scanned}\`"
             echo "- Events returned: \`${event_count}\`"
             if [ -n "${next_token}" ] && [ "${event_count}" -lt "${MAX_EVENTS}" ]; then

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -198,8 +198,8 @@ events.
 
 The default filter pattern is `"authenticate workos callback"`, which targets
 the callback exchange failure log emitted before the API returns
-`{"error":"login failed"}`. Leave the filter blank to inspect recent API events
-without narrowing to that auth path.
+`{"error":"login failed"}`. Use `<none>` as the filter pattern to inspect recent
+API events without narrowing to that auth path.
 
 ## DNS Cutover
 

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -198,8 +198,12 @@ events.
 
 The default filter pattern is `"authenticate workos callback"`, which targets
 the callback exchange failure log emitted before the API returns
-`{"error":"login failed"}`. Use `<none>` as the filter pattern to inspect recent
-API events without narrowing to that auth path.
+`{"error":"login failed"}`. To inspect recent API events without narrowing to
+that auth path, use this exact filter pattern:
+
+```text
+<none>
+```
 
 ## DNS Cutover
 


### PR DESCRIPTION
Fixes #1141

## What changed
- Allows the AWS API Log Diagnostics workflow to accept `<none>`, `none`, `no-filter`, or `all` as an explicit no-filter value.
- Keeps the targeted default filter for WorkOS callback failures.
- Updates the AWS API hosting runbook so operators know how to request broad recent API logs.

## Why
GitHub workflow dispatch falls back to the input default when the filter is left blank, so operators could not reliably inspect recent API logs without the default `"authenticate workos callback"` filter. This blocked diagnosis of the live WorkOS callback failure.

## Impact and risk
Low-risk diagnostics-only change. The workflow remains manual, read-only, OIDC-scoped, and still redacts common secret, token, database URL, OAuth code, and OAuth state shapes before printing events.

## Validation
- `git diff --check`
- `bash -lc` smoke test for filter normalization
- pre-push hooks: merge conflict check, YAML check, EOF/whitespace checks, gofmt check, go vet, local env token hygiene, Vercel artifact hygiene

AI-assisted: yes
Tools used: Codex
Where used: workflow and runbook patch
Human verification performed: reviewed diff and ran the validation listed above
