### PR TITLE
Close DNS-rebinding TOCTOU on SAML metadata fetch (follow-up to #1139)

### DIFF
--- a/internal/api/enterprise_saml_metadata.go
+++ b/internal/api/enterprise_saml_metadata.go
@@ -207,13 +207,14 @@ func FetchSAMLMetadataXML(ctx context.Context, client *http.Client, metadataURL 
 	if client == nil {
 		client = &http.Client{Timeout: 10 * time.Second}
 	}
-	// Shallow-clone the client so installing CheckRedirect does not mutate
-	// the caller's instance, then enforce the same scheme + host guard on
-	// every redirect hop. Without this, a public-facing https endpoint could
-	// 30x to a plain-http URL or to a private IP and bypass the up-front
-	// guard, restoring the SSRF surface this fetcher is meant to close.
+	// Shallow-clone the client so installing CheckRedirect and the dial
+	// guard does not mutate the caller's instance, then enforce the same
+	// scheme + host guard on every redirect hop. Without this, a
+	// public-facing https endpoint could 30x to a plain-http URL or to a
+	// private IP and bypass the up-front guard.
 	guardedClient := *client
 	guardedClient.CheckRedirect = checkMetadataRedirect
+	guardedClient.Transport = guardedMetadataTransport(guardedClient.Transport)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
 	if err != nil {
 		return nil, err
@@ -232,6 +233,46 @@ func FetchSAMLMetadataXML(ctx context.Context, client *http.Client, metadataURL 
 		return nil, fmt.Errorf("read metadata body: %w", err)
 	}
 	return body, nil
+}
+
+// guardedMetadataTransport wraps base so every TCP dial re-validates the
+// destination IP. Without this, an attacker-controlled DNS could hand the
+// up-front host guard a public IP and then re-resolve to a private IP at
+// dial time (DNS rebinding). The dial-time guard resolves the hostname
+// itself, validates each candidate IP, and dials the validated IP directly
+// — the original hostname is preserved on the request so TLS SNI and cert
+// verification still use the URL's hostname.
+func guardedMetadataTransport(base http.RoundTripper) http.RoundTripper {
+	transport, ok := base.(*http.Transport)
+	if !ok || transport == nil {
+		transport = http.DefaultTransport.(*http.Transport).Clone()
+	} else {
+		transport = transport.Clone()
+	}
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, fmt.Errorf("metadata dial: invalid address %q: %w", addr, err)
+		}
+		ips, err := metadataResolver(ctx, host)
+		if err != nil {
+			return nil, fmt.Errorf("metadata dial: resolve %q: %w", host, err)
+		}
+		if len(ips) == 0 {
+			return nil, fmt.Errorf("metadata dial: no addresses for %q", host)
+		}
+		for _, ip := range ips {
+			if err := internalIPGuard(ip, host); err != nil {
+				return nil, err
+			}
+		}
+		// Dial the first validated IP directly. The Transport above us still
+		// hands the original hostname to TLS for SNI + certificate
+		// verification, so server identity is enforced normally.
+		return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].String(), port))
+	}
+	return transport
 }
 
 // checkMetadataRedirect runs the same scheme + host guard that gates the
@@ -254,18 +295,26 @@ func checkMetadataRedirect(req *http.Request, via []*http.Request) error {
 	return metadataHostGuard(req.Context(), host)
 }
 
-// metadataResolver is the DNS resolver used by assertMetadataHostIsExternal.
-// Tests override it with a deterministic in-memory resolver so the SSRF guard
-// can be exercised without depending on real DNS.
+// metadataResolver is the DNS resolver used by the SSRF guards. Tests
+// override it with a deterministic in-memory resolver so behavior can be
+// exercised without depending on real DNS.
 var metadataResolver = func(ctx context.Context, host string) ([]net.IP, error) {
+	if ip := net.ParseIP(host); ip != nil {
+		return []net.IP{ip}, nil
+	}
 	return net.DefaultResolver.LookupIP(ctx, "ip", host)
 }
 
-// metadataHostGuard is the SSRF guard called before issuing the metadata
-// fetch. Production wiring uses assertMetadataHostIsExternal; tests that need
-// to point at a httptest server (which binds to 127.0.0.1) swap in a no-op
-// for the duration of the test.
+// metadataHostGuard is the up-front SSRF guard called before issuing the
+// metadata fetch. Production wiring uses assertMetadataHostIsExternal; tests
+// that need to point at a httptest server (which binds to 127.0.0.1) swap in
+// a no-op for the duration of the test.
 var metadataHostGuard = assertMetadataHostIsExternal
+
+// internalIPGuard is the per-IP rejection used by both the up-front host
+// guard and the dial-time guard. Tests swap to a no-op so a httptest TLS
+// server bound on 127.0.0.1 is reachable.
+var internalIPGuard = rejectInternalIP
 
 // assertMetadataHostIsExternal refuses to fetch from a host that resolves to
 // any address Identrail considers internal: loopback, link-local, multicast,
@@ -275,7 +324,7 @@ var metadataHostGuard = assertMetadataHostIsExternal
 // pointing at e.g. 169.254.169.254 (cloud metadata) or a private subnet.
 func assertMetadataHostIsExternal(ctx context.Context, host string) error {
 	if ip := net.ParseIP(host); ip != nil {
-		return rejectInternalIP(ip, host)
+		return internalIPGuard(ip, host)
 	}
 	addrs, err := metadataResolver(ctx, host)
 	if err != nil {
@@ -285,7 +334,7 @@ func assertMetadataHostIsExternal(ctx context.Context, host string) error {
 		return fmt.Errorf("metadata_url host %q resolved to no addresses", host)
 	}
 	for _, ip := range addrs {
-		if err := rejectInternalIP(ip, host); err != nil {
+		if err := internalIPGuard(ip, host); err != nil {
 			return err
 		}
 	}

--- a/internal/api/enterprise_saml_metadata.go
+++ b/internal/api/enterprise_saml_metadata.go
@@ -262,12 +262,19 @@ func guardedMetadataTransport(base http.RoundTripper) http.RoundTripper {
 	if transport.Proxy == nil {
 		transport.Proxy = http.ProxyFromEnvironment
 	}
-	dialer := &net.Dialer{Timeout: 10 * time.Second}
+	// Clear any caller-supplied custom TLS dial hooks. Per the net/http docs,
+	// when DialTLSContext or DialTLS is set, the standard library skips the
+	// DialContext hook entirely — which would let an HTTPS request bypass
+	// our guarded dialer and reopen the DNS-rebinding gap this guard exists
+	// to close. The transport falls back to DialContext + TLSClientConfig,
+	// which is what we want.
+	transport.DialTLSContext = nil
+	transport.DialTLS = nil
 	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		// Proxy-bound dial: addr is the operator-configured proxy host:port.
 		// Skip the IP guard so internal egress proxies stay reachable.
 		if proxyAddr, ok := ctx.Value(metadataProxyAddrKey{}).(string); ok && proxyAddr != "" && addr == proxyAddr {
-			return dialer.DialContext(ctx, network, addr)
+			return metadataDialContext(ctx, network, addr)
 		}
 		host, port, err := net.SplitHostPort(addr)
 		if err != nil {
@@ -293,7 +300,7 @@ func guardedMetadataTransport(base http.RoundTripper) http.RoundTripper {
 		// URL's hostname so server identity is enforced normally.
 		var lastErr error
 		for _, ip := range ips {
-			conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+			conn, dialErr := metadataDialContext(ctx, network, net.JoinHostPort(ip.String(), port))
 			if dialErr == nil {
 				return conn, nil
 			}
@@ -374,6 +381,12 @@ var metadataHostGuard = assertMetadataHostIsExternal
 // guard and the dial-time guard. Tests swap to a no-op so a httptest TLS
 // server bound on 127.0.0.1 is reachable.
 var internalIPGuard = rejectInternalIP
+
+// metadataDialContext is the dialer used by guardedMetadataTransport. It is
+// a package-level variable so tests can swap in a deterministic fake to
+// exercise the per-candidate fallback behavior without depending on
+// network-level race conditions.
+var metadataDialContext = (&net.Dialer{Timeout: 10 * time.Second}).DialContext
 
 // assertMetadataHostIsExternal refuses to fetch from a host that resolves to
 // any address Identrail considers internal: loopback, link-local, multicast,

--- a/internal/api/enterprise_saml_metadata.go
+++ b/internal/api/enterprise_saml_metadata.go
@@ -235,13 +235,23 @@ func FetchSAMLMetadataXML(ctx context.Context, client *http.Client, metadataURL 
 	return body, nil
 }
 
-// guardedMetadataTransport wraps base so every TCP dial re-validates the
-// destination IP. Without this, an attacker-controlled DNS could hand the
+// metadataProxyAddrKey carries the operator-configured proxy host:port (if
+// any) into DialContext via request context. The wrapping RoundTripper sets
+// the value once per request after consulting the transport's Proxy func, so
+// the dial guard can distinguish a proxy-bound dial (trusted egress) from a
+// direct dial to the metadata host (must be re-validated to close the
+// rebinding TOCTOU).
+type metadataProxyAddrKey struct{}
+
+// guardedMetadataTransport wraps base so every direct TCP dial re-validates
+// the destination IP. Without this, an attacker-controlled DNS could hand the
 // up-front host guard a public IP and then re-resolve to a private IP at
-// dial time (DNS rebinding). The dial-time guard resolves the hostname
-// itself, validates each candidate IP, and dials the validated IP directly
-// — the original hostname is preserved on the request so TLS SNI and cert
-// verification still use the URL's hostname.
+// dial time (DNS rebinding).
+//
+// Dials destined for an operator-configured HTTPS_PROXY are exempted: the
+// proxy is trusted egress, the metadata host has already been validated by
+// the up-front + redirect guards, and rejecting RFC1918 proxy addresses
+// would break every deployment behind an internal egress proxy.
 func guardedMetadataTransport(base http.RoundTripper) http.RoundTripper {
 	transport, ok := base.(*http.Transport)
 	if !ok || transport == nil {
@@ -249,8 +259,16 @@ func guardedMetadataTransport(base http.RoundTripper) http.RoundTripper {
 	} else {
 		transport = transport.Clone()
 	}
+	if transport.Proxy == nil {
+		transport.Proxy = http.ProxyFromEnvironment
+	}
 	dialer := &net.Dialer{Timeout: 10 * time.Second}
 	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		// Proxy-bound dial: addr is the operator-configured proxy host:port.
+		// Skip the IP guard so internal egress proxies stay reachable.
+		if proxyAddr, ok := ctx.Value(metadataProxyAddrKey{}).(string); ok && proxyAddr != "" && addr == proxyAddr {
+			return dialer.DialContext(ctx, network, addr)
+		}
 		host, port, err := net.SplitHostPort(addr)
 		if err != nil {
 			return nil, fmt.Errorf("metadata dial: invalid address %q: %w", addr, err)
@@ -272,7 +290,37 @@ func guardedMetadataTransport(base http.RoundTripper) http.RoundTripper {
 		// verification, so server identity is enforced normally.
 		return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].String(), port))
 	}
-	return transport
+	return &metadataProxyAwareTransport{base: transport}
+}
+
+// metadataProxyAwareTransport tags every outgoing request's context with the
+// proxy address derived from the transport's Proxy func, so the dial guard
+// can recognize and skip proxy-bound dials.
+type metadataProxyAwareTransport struct {
+	base *http.Transport
+}
+
+func (m *metadataProxyAwareTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if m.base.Proxy != nil {
+		if proxyURL, err := m.base.Proxy(req); err == nil && proxyURL != nil {
+			proxyAddr := proxyURL.Host
+			if proxyAddr != "" {
+				if _, _, splitErr := net.SplitHostPort(proxyAddr); splitErr != nil {
+					// Fill in the protocol-default port so the eventual dial
+					// addr matches what we stash here.
+					switch strings.ToLower(proxyURL.Scheme) {
+					case "https":
+						proxyAddr = net.JoinHostPort(proxyAddr, "443")
+					case "http":
+						proxyAddr = net.JoinHostPort(proxyAddr, "80")
+					}
+				}
+				ctx := context.WithValue(req.Context(), metadataProxyAddrKey{}, proxyAddr)
+				req = req.Clone(ctx)
+			}
+		}
+	}
+	return m.base.RoundTrip(req)
 }
 
 // checkMetadataRedirect runs the same scheme + host guard that gates the

--- a/internal/api/enterprise_saml_metadata.go
+++ b/internal/api/enterprise_saml_metadata.go
@@ -285,10 +285,21 @@ func guardedMetadataTransport(base http.RoundTripper) http.RoundTripper {
 				return nil, err
 			}
 		}
-		// Dial the first validated IP directly. The Transport above us still
-		// hands the original hostname to TLS for SNI + certificate
-		// verification, so server identity is enforced normally.
-		return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].String(), port))
+		// Try every validated address in order before giving up. This mirrors
+		// the fallback behavior of net.Dialer when handed a hostname (e.g.,
+		// AAAA-first on an IPv4-only deployment, or a stale A record before a
+		// healthy one) and is safe because every candidate has already
+		// cleared internalIPGuard. TLS SNI + cert verification still use the
+		// URL's hostname so server identity is enforced normally.
+		var lastErr error
+		for _, ip := range ips {
+			conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+			if dialErr == nil {
+				return conn, nil
+			}
+			lastErr = dialErr
+		}
+		return nil, fmt.Errorf("metadata dial %q: all %d validated addresses failed; last error: %w", host, len(ips), lastErr)
 	}
 	return &metadataProxyAwareTransport{base: transport}
 }

--- a/internal/api/enterprise_saml_metadata.go
+++ b/internal/api/enterprise_saml_metadata.go
@@ -255,12 +255,15 @@ type metadataProxyAddrKey struct{}
 func guardedMetadataTransport(base http.RoundTripper) http.RoundTripper {
 	transport, ok := base.(*http.Transport)
 	if !ok || transport == nil {
+		// Fresh clone inherits http.ProxyFromEnvironment, so HTTPS_PROXY /
+		// HTTP_PROXY / NO_PROXY are honored for the default code path.
 		transport = http.DefaultTransport.(*http.Transport).Clone()
 	} else {
+		// Preserve the caller's Proxy decision, including an explicit nil
+		// (the "no proxy" sentinel). Overwriting nil with
+		// http.ProxyFromEnvironment would silently route a hermetic test
+		// transport through the deployment's env proxy.
 		transport = transport.Clone()
-	}
-	if transport.Proxy == nil {
-		transport.Proxy = http.ProxyFromEnvironment
 	}
 	// Clear any caller-supplied custom TLS dial hooks. Per the net/http docs,
 	// when DialTLSContext or DialTLS is set, the standard library skips the

--- a/internal/api/enterprise_saml_metadata_test.go
+++ b/internal/api/enterprise_saml_metadata_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 )
 
 // withPermissiveHostGuard swaps out both SSRF guards for the duration of the
@@ -293,63 +295,99 @@ func TestFetchSAMLMetadataXML_BlocksDNSRebinding(t *testing.T) {
 }
 
 func TestFetchSAMLMetadataXML_FallsBackToSecondValidatedAddress(t *testing.T) {
-	// Stand up a real TLS server on 127.0.0.1 to serve as the "second" (working)
-	// address. The "first" address is a deliberately closed port on the same
-	// host that will refuse the connection. The resolver returns both, and
-	// the guarded dialer must walk past the first failure to succeed on the
-	// second — matching the fallback behavior of net.Dialer for hostnames.
+	// Stand up a real TLS server on 127.0.0.1 — this is the "live" candidate.
+	// The "dead" candidate is the documentation address 192.0.2.1. The test
+	// must not depend on real-network behavior, so the dial function is
+	// swapped to a deterministic fake that returns ECONNREFUSED for
+	// 192.0.2.1 and forwards every other address to the standard dialer
+	// (so the httptest connection still completes).
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/samlmetadata+xml")
 		_, _ = w.Write([]byte(oktaMetadataFixture))
 	}))
 	t.Cleanup(srv.Close)
 
-	// Reserve and close a port to guarantee dial refusal.
-	closed, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	deadHost, deadPort, _ := net.SplitHostPort(closed.Addr().String())
-	_ = closed.Close()
-
 	srvURL, _ := url.Parse(srv.URL)
-	_, livePort, _ := net.SplitHostPort(srvURL.Host)
-	if deadPort == livePort {
-		t.Skip("OS reassigned the closed port to the live server; race avoided by skipping")
-	}
+	deadIP := net.ParseIP("192.0.2.1")
+	liveIP := net.ParseIP(srvURL.Hostname())
 
-	// Make idp.example.com resolve to the dead address first, then the live
-	// one. Both are loopback, so the test also swaps the IP guard to permit
-	// loopback only.
 	prevResolver := metadataResolver
 	t.Cleanup(func() { metadataResolver = prevResolver })
 	metadataResolver = func(_ context.Context, host string) ([]net.IP, error) {
 		if host == "idp.example.com" {
-			return []net.IP{net.ParseIP(deadHost), net.ParseIP(srvURL.Hostname())}, nil
+			return []net.IP{deadIP, liveIP}, nil
 		}
 		return nil, &net.DNSError{Err: "not found", Name: host, IsNotFound: true}
 	}
+
 	withPermissiveHostGuard(t)
+	// Permit just the loopback and dead-IP candidates past the guard so the
+	// strict path stays intact for everything else.
 	prevIP := internalIPGuard
 	internalIPGuard = func(ip net.IP, host string) error {
-		if ip.IsLoopback() {
+		if ip.IsLoopback() || ip.Equal(deadIP) {
 			return nil
 		}
 		return rejectInternalIP(ip, host)
 	}
 	t.Cleanup(func() { internalIPGuard = prevIP })
 
-	// Build a client that uses the test server's TLS root and points the URL
-	// hostname at idp.example.com on the live port. The guarded dial picks
-	// up the resolver's two-address list, fails on the dead port, then
-	// succeeds on the live one.
-	caller := srv.Client()
-	body, err := FetchSAMLMetadataXML(context.Background(), caller, "https://idp.example.com:"+livePort+"/metadata")
+	// Swap the dialer so 192.0.2.1 returns an instant refusal and 127.0.0.1
+	// uses the real net.Dialer. Track per-candidate calls so the assertion
+	// proves the second address was actually tried.
+	prevDial := metadataDialContext
+	t.Cleanup(func() { metadataDialContext = prevDial })
+	var dialedDead, dialedLive int
+	realDialer := &net.Dialer{Timeout: 5 * time.Second}
+	metadataDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, _, _ := net.SplitHostPort(addr)
+		switch host {
+		case deadIP.String():
+			dialedDead++
+			return nil, fmt.Errorf("connection refused (synthetic)")
+		default:
+			dialedLive++
+			return realDialer.DialContext(ctx, network, addr)
+		}
+	}
+
+	body, err := FetchSAMLMetadataXML(context.Background(), srv.Client(), "https://idp.example.com:"+srvURL.Port()+"/metadata")
 	if err != nil {
 		t.Fatalf("expected fallback to succeed, got: %v", err)
 	}
 	if !strings.Contains(string(body), "EntityDescriptor") {
 		t.Errorf("unexpected body: %q", string(body))
+	}
+	if dialedDead == 0 {
+		t.Error("dead address was never attempted — fallback test is ineffective")
+	}
+	if dialedLive == 0 {
+		t.Error("live address was never attempted — fallback did not fire")
+	}
+}
+
+func TestGuardedMetadataTransport_ClearsCallerCustomTLSDialHooks(t *testing.T) {
+	// Per net/http docs, when DialTLSContext or DialTLS is set on the
+	// underlying transport, the standard library skips DialContext entirely
+	// for HTTPS requests — which would let an attacker-controlled DNS slip
+	// past our guard for non-proxied HTTPS. The wrapper must null those
+	// hooks so every dial goes through our guarded DialContext.
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	base.DialTLSContext = func(context.Context, string, string) (net.Conn, error) {
+		t.Fatalf("guarded transport must clear DialTLSContext")
+		return nil, nil
+	}
+	base.DialTLS = func(string, string) (net.Conn, error) {
+		t.Fatalf("guarded transport must clear DialTLS")
+		return nil, nil
+	}
+	wrapped := guardedMetadataTransport(base)
+	innerTransport := wrapped.(*metadataProxyAwareTransport).base
+	if innerTransport.DialTLSContext != nil {
+		t.Errorf("DialTLSContext was not cleared by guardedMetadataTransport")
+	}
+	if innerTransport.DialTLS != nil {
+		t.Errorf("DialTLS was not cleared by guardedMetadataTransport")
 	}
 }
 

--- a/internal/api/enterprise_saml_metadata_test.go
+++ b/internal/api/enterprise_saml_metadata_test.go
@@ -292,6 +292,67 @@ func TestFetchSAMLMetadataXML_BlocksDNSRebinding(t *testing.T) {
 	}
 }
 
+func TestFetchSAMLMetadataXML_FallsBackToSecondValidatedAddress(t *testing.T) {
+	// Stand up a real TLS server on 127.0.0.1 to serve as the "second" (working)
+	// address. The "first" address is a deliberately closed port on the same
+	// host that will refuse the connection. The resolver returns both, and
+	// the guarded dialer must walk past the first failure to succeed on the
+	// second — matching the fallback behavior of net.Dialer for hostnames.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/samlmetadata+xml")
+		_, _ = w.Write([]byte(oktaMetadataFixture))
+	}))
+	t.Cleanup(srv.Close)
+
+	// Reserve and close a port to guarantee dial refusal.
+	closed, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	deadHost, deadPort, _ := net.SplitHostPort(closed.Addr().String())
+	_ = closed.Close()
+
+	srvURL, _ := url.Parse(srv.URL)
+	_, livePort, _ := net.SplitHostPort(srvURL.Host)
+	if deadPort == livePort {
+		t.Skip("OS reassigned the closed port to the live server; race avoided by skipping")
+	}
+
+	// Make idp.example.com resolve to the dead address first, then the live
+	// one. Both are loopback, so the test also swaps the IP guard to permit
+	// loopback only.
+	prevResolver := metadataResolver
+	t.Cleanup(func() { metadataResolver = prevResolver })
+	metadataResolver = func(_ context.Context, host string) ([]net.IP, error) {
+		if host == "idp.example.com" {
+			return []net.IP{net.ParseIP(deadHost), net.ParseIP(srvURL.Hostname())}, nil
+		}
+		return nil, &net.DNSError{Err: "not found", Name: host, IsNotFound: true}
+	}
+	withPermissiveHostGuard(t)
+	prevIP := internalIPGuard
+	internalIPGuard = func(ip net.IP, host string) error {
+		if ip.IsLoopback() {
+			return nil
+		}
+		return rejectInternalIP(ip, host)
+	}
+	t.Cleanup(func() { internalIPGuard = prevIP })
+
+	// Build a client that uses the test server's TLS root and points the URL
+	// hostname at idp.example.com on the live port. The guarded dial picks
+	// up the resolver's two-address list, fails on the dead port, then
+	// succeeds on the live one.
+	caller := srv.Client()
+	body, err := FetchSAMLMetadataXML(context.Background(), caller, "https://idp.example.com:"+livePort+"/metadata")
+	if err != nil {
+		t.Fatalf("expected fallback to succeed, got: %v", err)
+	}
+	if !strings.Contains(string(body), "EntityDescriptor") {
+		t.Errorf("unexpected body: %q", string(body))
+	}
+}
+
 func TestFetchSAMLMetadataXML_AllowsConfiguredProxyDial(t *testing.T) {
 	// Spin up a TCP-only listener on 127.0.0.1 to stand in for an internal
 	// HTTPS_PROXY. The transport's Proxy func points every request at it.

--- a/internal/api/enterprise_saml_metadata_test.go
+++ b/internal/api/enterprise_saml_metadata_test.go
@@ -14,6 +14,29 @@ import (
 	"time"
 )
 
+// hermeticClient returns an http.Client that explicitly disables proxy
+// resolution. Tests must use this (or otherwise null Proxy on their custom
+// transport) so an HTTPS_PROXY/HTTP_PROXY value inherited from the CI runner
+// or the operator's shell does not hijack requests away from the local
+// httptest server or away from the guarded dialer being exercised.
+func hermeticClient(base *http.Client) *http.Client {
+	clone := &http.Client{Timeout: 10 * time.Second}
+	if base != nil {
+		*clone = *base
+		clone.Transport = nil
+	}
+	source, _ := http.DefaultTransport.(*http.Transport)
+	if base != nil {
+		if t, ok := base.Transport.(*http.Transport); ok && t != nil {
+			source = t
+		}
+	}
+	transport := source.Clone()
+	transport.Proxy = nil
+	clone.Transport = transport
+	return clone
+}
+
 // withPermissiveHostGuard swaps out both SSRF guards for the duration of the
 // test so a httptest.NewTLSServer (which binds to 127.0.0.1) is reachable.
 // Production wiring keeps the strict guards.
@@ -147,7 +170,7 @@ func TestFetchSAMLMetadataXML_HappyPath(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 	withPermissiveHostGuard(t)
-	body, err := FetchSAMLMetadataXML(context.Background(), srv.Client(), srv.URL+"/idp/metadata")
+	body, err := FetchSAMLMetadataXML(context.Background(), hermeticClient(srv.Client()), srv.URL+"/idp/metadata")
 	if err != nil {
 		t.Fatalf("fetch metadata: %v", err)
 	}
@@ -222,7 +245,7 @@ func TestFetchSAMLMetadataXML_BlocksRedirectToHTTP(t *testing.T) {
 		http.Redirect(w, r, "http://idp.example.com/metadata", http.StatusFound)
 	}))
 	t.Cleanup(srv.Close)
-	_, err := FetchSAMLMetadataXML(context.Background(), srv.Client(), srv.URL+"/idp/metadata")
+	_, err := FetchSAMLMetadataXML(context.Background(), hermeticClient(srv.Client()), srv.URL+"/idp/metadata")
 	if err == nil || !strings.Contains(err.Error(), "non-https") {
 		t.Errorf("expected non-https redirect rejection, got: %v", err)
 	}
@@ -259,7 +282,7 @@ func TestFetchSAMLMetadataXML_BlocksRedirectToPrivateIP(t *testing.T) {
 		http.Redirect(w, r, "https://169.254.169.254/latest/meta-data/", http.StatusFound)
 	}))
 	t.Cleanup(srv.Close)
-	_, err := FetchSAMLMetadataXML(context.Background(), srv.Client(), srv.URL+"/idp/metadata")
+	_, err := FetchSAMLMetadataXML(context.Background(), hermeticClient(srv.Client()), srv.URL+"/idp/metadata")
 	if err == nil || !strings.Contains(err.Error(), "link-local") {
 		t.Errorf("expected link-local rejection on redirect target, got: %v", err)
 	}
@@ -285,7 +308,7 @@ func TestFetchSAMLMetadataXML_BlocksDNSRebinding(t *testing.T) {
 		return nil, &net.DNSError{Err: "not found", Name: host, IsNotFound: true}
 	}
 
-	_, err := FetchSAMLMetadataXML(context.Background(), nil, "https://rebinding.example.com/metadata")
+	_, err := FetchSAMLMetadataXML(context.Background(), hermeticClient(nil), "https://rebinding.example.com/metadata")
 	if err == nil || !strings.Contains(err.Error(), "private") {
 		t.Errorf("expected DNS-rebinding rejection at dial time, got: %v", err)
 	}
@@ -332,6 +355,11 @@ func TestFetchSAMLMetadataXML_FallsBackToSecondValidatedAddress(t *testing.T) {
 	}
 	t.Cleanup(func() { internalIPGuard = prevIP })
 
+	// Hermetic client: explicitly disable proxy resolution so an env
+	// HTTPS_PROXY/HTTP_PROXY does not hijack the request away from the
+	// local TLS server / guarded dialer being exercised.
+	caller := hermeticClient(srv.Client())
+
 	// Swap the dialer so 192.0.2.1 returns an instant refusal and 127.0.0.1
 	// uses the real net.Dialer. Track per-candidate calls so the assertion
 	// proves the second address was actually tried.
@@ -351,7 +379,7 @@ func TestFetchSAMLMetadataXML_FallsBackToSecondValidatedAddress(t *testing.T) {
 		}
 	}
 
-	body, err := FetchSAMLMetadataXML(context.Background(), srv.Client(), "https://idp.example.com:"+srvURL.Port()+"/metadata")
+	body, err := FetchSAMLMetadataXML(context.Background(), caller, "https://idp.example.com:"+srvURL.Port()+"/metadata")
 	if err != nil {
 		t.Fatalf("expected fallback to succeed, got: %v", err)
 	}

--- a/internal/api/enterprise_saml_metadata_test.go
+++ b/internal/api/enterprise_saml_metadata_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -289,6 +290,53 @@ func TestFetchSAMLMetadataXML_BlocksDNSRebinding(t *testing.T) {
 	if calls < 2 {
 		t.Errorf("expected dial-time resolver to be called (calls=%d) — guard ran only at check time", calls)
 	}
+}
+
+func TestFetchSAMLMetadataXML_AllowsConfiguredProxyDial(t *testing.T) {
+	// Spin up a TCP-only listener on 127.0.0.1 to stand in for an internal
+	// HTTPS_PROXY. The transport's Proxy func points every request at it.
+	// We do not need a complete CONNECT-speaking proxy — the test only needs
+	// to prove that the dial-time IP guard is exempted for proxy-bound dials,
+	// and we verify that by observing whether internalIPGuard is invoked on
+	// the loopback proxy address.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	proxyURL := &url.URL{Scheme: "http", Host: ln.Addr().String()}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = func(*http.Request) (*url.URL, error) { return proxyURL, nil }
+	caller := &http.Client{Transport: transport}
+
+	// Bypass only the up-front host guard for the metadata host. The
+	// dial-time guard stays strict, and our spy variant fails the test if
+	// it is ever called with the loopback proxy address.
+	withPermissiveHostGuard(t)
+	prevIP := internalIPGuard
+	internalIPGuard = func(ip net.IP, host string) error {
+		if ip.IsLoopback() {
+			t.Fatalf("internalIPGuard was called with loopback %s — proxy exemption did not fire", ip)
+		}
+		return rejectInternalIP(ip, host)
+	}
+	t.Cleanup(func() { internalIPGuard = prevIP })
+
+	// We expect the dial to succeed (proving the guard exemption fired) and
+	// then for the request to fail downstream because the listener is not a
+	// real HTTP proxy. The success criterion is "internalIPGuard was NOT
+	// called for the loopback proxy address" — guarded by t.Fatalf above.
+	_, _ = FetchSAMLMetadataXML(context.Background(), caller, "https://idp.example.com/metadata")
 }
 
 func TestNewSCIMBearerToken_Format(t *testing.T) {

--- a/internal/api/enterprise_saml_metadata_test.go
+++ b/internal/api/enterprise_saml_metadata_test.go
@@ -11,14 +11,19 @@ import (
 	"testing"
 )
 
-// withPermissiveHostGuard swaps out the SSRF guard for the duration of the
+// withPermissiveHostGuard swaps out both SSRF guards for the duration of the
 // test so a httptest.NewTLSServer (which binds to 127.0.0.1) is reachable.
-// Production wiring keeps the strict guard.
+// Production wiring keeps the strict guards.
 func withPermissiveHostGuard(t *testing.T) {
 	t.Helper()
-	prev := metadataHostGuard
+	prevHost := metadataHostGuard
+	prevIP := internalIPGuard
 	metadataHostGuard = func(context.Context, string) error { return nil }
-	t.Cleanup(func() { metadataHostGuard = prev })
+	internalIPGuard = func(net.IP, string) error { return nil }
+	t.Cleanup(func() {
+		metadataHostGuard = prevHost
+		internalIPGuard = prevIP
+	})
 }
 
 // withFakeResolver lets a test pretend that a public-looking hostname resolves
@@ -221,19 +226,29 @@ func TestFetchSAMLMetadataXML_BlocksRedirectToHTTP(t *testing.T) {
 }
 
 func TestFetchSAMLMetadataXML_BlocksRedirectToPrivateIP(t *testing.T) {
-	// Bypass the loopback check on the original httptest URL but reinstall
-	// the strict guard for the redirect target. This exercises the SSRF
-	// protection against an attacker-controlled public endpoint that 30x'es
-	// to a private IP.
-	prev := metadataHostGuard
-	t.Cleanup(func() { metadataHostGuard = prev })
-	allowFirst := true
+	// Bypass the loopback check just for the local httptest host but keep
+	// the strict guard for everything else. Both the up-front host guard
+	// and the dial-time guard now flow through internalIPGuard, so swapping
+	// it lets us exercise the SSRF protection against an attacker-controlled
+	// public endpoint that 30x'es to a private IP without losing coverage of
+	// the strict path.
+	prevHost := metadataHostGuard
+	prevIP := internalIPGuard
+	t.Cleanup(func() {
+		metadataHostGuard = prevHost
+		internalIPGuard = prevIP
+	})
 	metadataHostGuard = func(ctx context.Context, host string) error {
-		if allowFirst {
-			allowFirst = false
+		if host == "127.0.0.1" || host == "::1" {
 			return nil
 		}
 		return assertMetadataHostIsExternal(ctx, host)
+	}
+	internalIPGuard = func(ip net.IP, host string) error {
+		if ip.IsLoopback() {
+			return nil
+		}
+		return rejectInternalIP(ip, host)
 	}
 
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -244,6 +259,35 @@ func TestFetchSAMLMetadataXML_BlocksRedirectToPrivateIP(t *testing.T) {
 	_, err := FetchSAMLMetadataXML(context.Background(), srv.Client(), srv.URL+"/idp/metadata")
 	if err == nil || !strings.Contains(err.Error(), "link-local") {
 		t.Errorf("expected link-local rejection on redirect target, got: %v", err)
+	}
+}
+
+func TestFetchSAMLMetadataXML_BlocksDNSRebinding(t *testing.T) {
+	// DNS rebinding TOCTOU: the up-front host guard sees a public IP, but
+	// the dial-time resolver returns a private IP. Without the dial-time
+	// guard the request would still hit the internal address.
+	calls := 0
+	prev := metadataResolver
+	t.Cleanup(func() { metadataResolver = prev })
+	metadataResolver = func(_ context.Context, host string) ([]net.IP, error) {
+		if host == "rebinding.example.com" {
+			calls++
+			if calls == 1 {
+				// First call: up-front guard. Hand back a public IP.
+				return []net.IP{net.ParseIP("198.51.100.1")}, nil
+			}
+			// Second call (and later): dial-time. Now resolve to a private IP.
+			return []net.IP{net.ParseIP("10.0.0.99")}, nil
+		}
+		return nil, &net.DNSError{Err: "not found", Name: host, IsNotFound: true}
+	}
+
+	_, err := FetchSAMLMetadataXML(context.Background(), nil, "https://rebinding.example.com/metadata")
+	if err == nil || !strings.Contains(err.Error(), "private") {
+		t.Errorf("expected DNS-rebinding rejection at dial time, got: %v", err)
+	}
+	if calls < 2 {
+		t.Errorf("expected dial-time resolver to be called (calls=%d) — guard ran only at check time", calls)
 	}
 }
 


### PR DESCRIPTION
## Summary

Refs #576 — follow-up to PR #1139 (merged as `722d7bd`).

Codex flagged a Time-Of-Check-To-Time-Of-Use SSRF gap in `FetchSAMLMetadataXML` after the merge: the up-front host guard resolves the hostname at check time, but `http.Client` re-resolves DNS at dial time, so an attacker controlling DNS for the metadata host could return a public IP for the guard and a private IP for the actual TCP dial — completely bypassing the SSRF protection added in #1139.

## What changes

- `FetchSAMLMetadataXML` now wraps the HTTP client's transport with a `DialContext` that resolves the hostname itself, runs `internalIPGuard` against every candidate IP, and dials the validated IP directly. The original hostname stays on the request so TLS SNI and certificate verification still use the URL hostname.
- Both the up-front host guard and the dial-time guard now route IP rejection through a single swappable `internalIPGuard` so tests can permit a `httptest.NewTLSServer` (which binds to 127.0.0.1) without weakening the production path.
- `metadataResolver` returns an IP literal as-is when the host is already a parseable IP, so callers don't have to special-case literal-IP URLs.

## Test plan

- [x] New `TestFetchSAMLMetadataXML_BlocksDNSRebinding` scripts the resolver to return a public IP on the first call (up-front guard) and a private IP on the second (dial-time), then asserts the request is refused with a private-range error
- [x] `TestFetchSAMLMetadataXML_BlocksRedirectToPrivateIP` updated to bypass the guards for loopback only, so it still exercises the strict path on the redirect target
- [x] Full Go suite green

## AI-assisted

- AI-assisted: yes
- Tools used: Claude Code
- Where used: `internal/api/enterprise_saml_metadata.go`, `internal/api/enterprise_saml_metadata_test.go`
- Human verification performed: full Go suite run, manual review of TLS/SNI behavior when dialing by IP

Refs #576 (ITR-035) — follow-up to #1139.