### PR TITLE
Fix GitHub WorkOS email scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fixed hosted GitHub sign-in by requesting GitHub's verified-email OAuth scope through WorkOS, so GitHub users with private primary emails can complete the callback instead of failing during login.
 - Added the org-admin API for managing native SAML identity connections (behind `IDENTRAIL_FEATURE_NATIVE_SSO`, defaulted off):
   - `POST/GET/PUT/DELETE /v1/enterprise/identity-connections/saml(/:id)` covers the full connection lifecycle and is gated by org-admin RBAC via the existing route policy bundle
   - `POST /v1/enterprise/identity-connections/saml/from-metadata` accepts either a `metadata_url` (https only, 256 KiB cap, 10s timeout) or an inline `metadata_xml` body and auto-fills `entity_id`, `sso_url`, and `certificate_pem` from Okta- or Azure AD-shaped IdP metadata

--- a/docs/auth/identity-linking-rules.md
+++ b/docs/auth/identity-linking-rules.md
@@ -107,7 +107,7 @@ When WorkOS sends a `user.deleted` webhook, we set the `users.status` to `deacti
 
 GitHub identities use `provider="github"` and `subject` set to the GitHub user ID (numeric, stable, never reused). Do not use the GitHub username as the subject; usernames can be renamed and reassigned.
 
-GitHub returns multiple emails. We use the user's primary email if `verified=true`. If no email is verified, we treat the identity as having no email and do not auto-fill any user fields.
+GitHub returns multiple emails. Hosted WorkOS GitHub OAuth requests GitHub's `user:email` scope so users whose primary email is private can still complete sign-in with a verified email. We use the user's primary email if `verified=true`. If no email is verified, we treat the identity as having no email and do not auto-fill any user fields.
 
 ### Google and Microsoft
 

--- a/internal/api/auth/workos.go
+++ b/internal/api/auth/workos.go
@@ -15,10 +15,11 @@ const WorkOSProvider = "workos"
 var ErrWorkOSUnavailable = errors.New("workos unavailable")
 
 type WorkOSAuthorizationRequest struct {
-	RedirectURI string
-	State       string
-	ScreenHint  string
-	Provider    string
+	RedirectURI    string
+	State          string
+	ScreenHint     string
+	Provider       string
+	ProviderScopes []string
 }
 
 type WorkOSAuthenticationRequest struct {
@@ -66,10 +67,11 @@ func (c *WorkOSSDKClient) AuthorizationURL(input WorkOSAuthorizationRequest) (st
 		return "", ErrWorkOSUnavailable
 	}
 	opts := usermanagement.GetAuthorizationURLOpts{
-		ClientID:    c.clientID,
-		RedirectURI: strings.TrimSpace(input.RedirectURI),
-		Provider:    strings.TrimSpace(input.Provider),
-		State:       strings.TrimSpace(input.State),
+		ClientID:       c.clientID,
+		RedirectURI:    strings.TrimSpace(input.RedirectURI),
+		Provider:       strings.TrimSpace(input.Provider),
+		State:          strings.TrimSpace(input.State),
+		ProviderScopes: append([]string(nil), input.ProviderScopes...),
 	}
 	if opts.Provider == "" {
 		opts.Provider = "authkit"

--- a/internal/api/auth/workos_test.go
+++ b/internal/api/auth/workos_test.go
@@ -24,6 +24,22 @@ func TestWorkOSSDKClientAuthorizationURL(t *testing.T) {
 	}
 }
 
+func TestWorkOSSDKClientAuthorizationURLIncludesProviderScopes(t *testing.T) {
+	client := NewWorkOSSDKClient("sk_test", "client_123")
+	got, err := client.AuthorizationURL(WorkOSAuthorizationRequest{
+		RedirectURI:    "https://app.example.com/auth/callback",
+		State:          "state-1",
+		Provider:       "GitHubOAuth",
+		ProviderScopes: []string{"user:email"},
+	})
+	if err != nil {
+		t.Fatalf("authorization url: %v", err)
+	}
+	if !strings.Contains(got, "provider=GitHubOAuth") || !strings.Contains(got, "provider_scopes=user%3Aemail") {
+		t.Fatalf("expected github email provider scope in authorization url: %s", got)
+	}
+}
+
 func TestWorkOSSDKClientAuthenticateWithCode(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/user_management/authenticate" {

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -123,10 +123,11 @@ func workOSStartHandler(logger *zap.Logger, svc *Service, opts authSessionRouteO
 		}
 		auditAuthAction(c.Request.Context(), action, "", "success")
 		authorizationURL, err := opts.WorkOSClient.AuthorizationURL(sessionauth.WorkOSAuthorizationRequest{
-			RedirectURI: workOSCallbackURL(opts.PublicBaseURL),
-			State:       state,
-			ScreenHint:  screenHint,
-			Provider:    provider,
+			RedirectURI:    workOSCallbackURL(opts.PublicBaseURL),
+			State:          state,
+			ScreenHint:     screenHint,
+			Provider:       provider,
+			ProviderScopes: workOSProviderScopes(provider),
 		})
 		if err != nil {
 			auditAuthAction(c.Request.Context(), "auth.login.failure", "", "denied")
@@ -152,6 +153,14 @@ func workOSProviderFromPublicID(provider string) (string, bool) {
 	default:
 		return "", false
 	}
+}
+
+func workOSProviderScopes(provider string) []string {
+	if strings.EqualFold(strings.TrimSpace(provider), "GitHubOAuth") {
+		// GitHub keeps many verified email addresses private unless this scope is requested.
+		return []string{"user:email"}
+	}
+	return nil
 }
 
 func workOSCallbackHandler(logger *zap.Logger, svc *Service, manager sessionauth.Manager, opts authSessionRouteOptions) gin.HandlerFunc {

--- a/internal/api/workos_auth_routes_test.go
+++ b/internal/api/workos_auth_routes_test.go
@@ -125,12 +125,13 @@ func TestWorkOSHostedLoginCreatesSessionAndIdentity(t *testing.T) {
 
 func TestWorkOSStartRoutesConfiguredSocialProviders(t *testing.T) {
 	for _, tc := range []struct {
-		name     string
-		provider string
-		want     string
+		name       string
+		provider   string
+		want       string
+		wantScopes string
 	}{
 		{name: "google", provider: "google_oauth", want: "GoogleOAuth"},
-		{name: "github", provider: "github_oauth", want: "GitHubOAuth"},
+		{name: "github", provider: "github_oauth", want: "GitHubOAuth", wantScopes: "user:email"},
 		{name: "authkit", provider: "authkit", want: "authkit"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -156,6 +157,9 @@ func TestWorkOSStartRoutesConfiguredSocialProviders(t *testing.T) {
 			}
 			if workOS.authorizationInput.Provider != tc.want {
 				t.Fatalf("expected provider %q, got %q", tc.want, workOS.authorizationInput.Provider)
+			}
+			if gotScopes := strings.Join(workOS.authorizationInput.ProviderScopes, ","); gotScopes != tc.wantScopes {
+				t.Fatalf("expected provider scopes %q, got %q", tc.wantScopes, gotScopes)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #1146

## Summary

Fixes the hosted GitHub sign-in failure seen after the WorkOS callback returned `{"error":"login failed"}`.

## Root cause

The production GitHub OAuth start URL used WorkOS with `provider=GitHubOAuth` but did not pass any provider-specific scopes. GitHub keeps many verified primary email addresses private unless the app requests the `user:email` scope, which can make WorkOS unable to complete the GitHub-backed login flow for those accounts.

## Changes

- Carry provider scopes through the WorkOS authorization wrapper.
- Request `user:email` only for `GitHubOAuth`.
- Keep Google OAuth and AuthKit scope behavior unchanged.
- Add route-level and SDK-wrapper regression tests.
- Update the auth identity-linking docs and changelog.

## Impact and risk

GitHub sign-in may now show GitHub's email-address permission during authorization. This is intentional and limited to GitHub OAuth so Identrail can receive the verified email needed to complete hosted sign-in for private-email GitHub accounts.

## Validation

- Confirmed the live production GitHub redirect was missing `provider_scopes` before this patch.
- `git diff --check`
- `go test ./...`
- `go vet ./...`
- Local git hooks during commit/push: merge-conflict check, end-of-file fix, trailing whitespace, gofmt, Vercel artifact hygiene, token hygiene

AI-assisted: yes
Tools used: Codex
Where used: auth route investigation, backend patch, tests, docs
Human verification performed: local diff review plus the validation commands listed above
