### PR TITLE
Continue WorkOS MFA sign-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Added WorkOS MFA continuation for hosted sign-in: when GitHub OAuth requires MFA enrollment or an existing MFA challenge, Identrail now redirects to an app MFA page, keeps the WorkOS pending-auth token in an encrypted HttpOnly cookie, and completes session creation after TOTP verification.
 - Fixed hosted GitHub sign-in by requesting GitHub's verified-email OAuth scope through WorkOS, so GitHub users with private primary emails can complete the callback instead of failing during login.
 - Added the org-admin API for managing native SAML identity connections (behind `IDENTRAIL_FEATURE_NATIVE_SSO`, defaulted off):
   - `POST/GET/PUT/DELETE /v1/enterprise/identity-connections/saml(/:id)` covers the full connection lifecycle and is gated by org-admin RBAC via the existing route policy bundle

--- a/docs/auth/identity-linking-rules.md
+++ b/docs/auth/identity-linking-rules.md
@@ -103,6 +103,8 @@ WorkOS is the primary IdP for hosted Identrail. The WorkOS user `sub` becomes `u
 
 When WorkOS sends a `user.deleted` webhook, we set the `users.status` to `deactivated`, revoke all sessions, but retain the row for audit. The `user_identities` row stays in place; it is the historical record of which WorkOS account was that user.
 
+If WorkOS requires MFA enrollment or an MFA challenge during hosted sign-in, Identrail does not create a local session from the first callback. The API stores the WorkOS pending-auth token only in a short-lived encrypted HttpOnly cookie scoped to `/auth/mfa`, redirects the browser to the app MFA page, and creates the Identrail session only after WorkOS accepts the TOTP verification response.
+
 ### GitHub
 
 GitHub identities use `provider="github"` and `subject` set to the GitHub user ID (numeric, stable, never reused). Do not use the GitHub username as the subject; usernames can be renamed and reassigned.

--- a/internal/api/auth/mfa_pending.go
+++ b/internal/api/auth/mfa_pending.go
@@ -117,6 +117,9 @@ func (m *MFAPendingStateManager) Open(raw string) (WorkOSMFAPendingState, error)
 	if err != nil {
 		return WorkOSMFAPendingState{}, err
 	}
+	if len(nonce) != gcm.NonceSize() {
+		return WorkOSMFAPendingState{}, ErrMFAPendingStateInvalid
+	}
 	payload, err := gcm.Open(nil, nonce, ciphertext, []byte(mfaPendingStateAAD))
 	if err != nil {
 		return WorkOSMFAPendingState{}, ErrMFAPendingStateInvalid

--- a/internal/api/auth/mfa_pending.go
+++ b/internal/api/auth/mfa_pending.go
@@ -1,0 +1,141 @@
+package auth
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"time"
+)
+
+const (
+	PendingMFACookieName = "identrail_mfa_pending"
+	DefaultMFAPendingTTL = 10 * time.Minute
+
+	mfaPendingStateVersion = "v1"
+	mfaPendingStateAAD     = "identrail.workos.mfa.pending.v1"
+)
+
+var (
+	ErrMFAPendingStateInvalid = errors.New("mfa pending state invalid")
+	ErrMFAPendingStateExpired = errors.New("mfa pending state expired")
+)
+
+type WorkOSMFAPendingState struct {
+	Mode                       string             `json:"mode"`
+	ReturnTo                   string             `json:"return_to,omitempty"`
+	PendingAuthenticationToken string             `json:"pending_authentication_token"`
+	User                       WorkOSProfile      `json:"user"`
+	AuthenticationFactors      []WorkOSMFAFactor  `json:"authentication_factors,omitempty"`
+	ChallengeID                string             `json:"challenge_id,omitempty"`
+	ChallengeExpiresAt         string             `json:"challenge_expires_at,omitempty"`
+	TOTP                       *WorkOSPendingTOTP `json:"totp,omitempty"`
+	ExpiresAt                  int64              `json:"expires_at"`
+}
+
+type WorkOSPendingTOTP struct {
+	FactorID string `json:"factor_id"`
+	QRCode   string `json:"qr_code"`
+	Secret   string `json:"secret"`
+	URI      string `json:"uri"`
+}
+
+type MFAPendingStateManager struct {
+	secret []byte
+	ttl    time.Duration
+	now    func() time.Time
+}
+
+func NewMFAPendingStateManager(secret string, now func() time.Time) *MFAPendingStateManager {
+	if now == nil {
+		now = time.Now
+	}
+	return &MFAPendingStateManager{
+		secret: []byte(strings.TrimSpace(secret)),
+		ttl:    DefaultMFAPendingTTL,
+		now:    now,
+	}
+}
+
+func (m *MFAPendingStateManager) TTL() time.Duration {
+	if m == nil || m.ttl <= 0 {
+		return DefaultMFAPendingTTL
+	}
+	return m.ttl
+}
+
+func (m *MFAPendingStateManager) Seal(state WorkOSMFAPendingState) (string, error) {
+	if m == nil || len(m.secret) == 0 {
+		return "", ErrMFAPendingStateInvalid
+	}
+	now := m.now().UTC()
+	if state.ExpiresAt <= 0 {
+		state.ExpiresAt = now.Add(m.TTL()).Unix()
+	}
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return "", err
+	}
+	gcm, err := m.cipher()
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	ciphertext := gcm.Seal(nil, nonce, payload, []byte(mfaPendingStateAAD))
+	return strings.Join([]string{
+		mfaPendingStateVersion,
+		base64.RawURLEncoding.EncodeToString(nonce),
+		base64.RawURLEncoding.EncodeToString(ciphertext),
+	}, "."), nil
+}
+
+func (m *MFAPendingStateManager) Open(raw string) (WorkOSMFAPendingState, error) {
+	if m == nil || len(m.secret) == 0 {
+		return WorkOSMFAPendingState{}, ErrMFAPendingStateInvalid
+	}
+	parts := strings.Split(strings.TrimSpace(raw), ".")
+	if len(parts) != 3 || parts[0] != mfaPendingStateVersion {
+		return WorkOSMFAPendingState{}, ErrMFAPendingStateInvalid
+	}
+	nonce, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return WorkOSMFAPendingState{}, ErrMFAPendingStateInvalid
+	}
+	ciphertext, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return WorkOSMFAPendingState{}, ErrMFAPendingStateInvalid
+	}
+	gcm, err := m.cipher()
+	if err != nil {
+		return WorkOSMFAPendingState{}, err
+	}
+	payload, err := gcm.Open(nil, nonce, ciphertext, []byte(mfaPendingStateAAD))
+	if err != nil {
+		return WorkOSMFAPendingState{}, ErrMFAPendingStateInvalid
+	}
+	var state WorkOSMFAPendingState
+	if err := json.Unmarshal(payload, &state); err != nil {
+		return WorkOSMFAPendingState{}, ErrMFAPendingStateInvalid
+	}
+	if state.ExpiresAt <= 0 || !time.Unix(state.ExpiresAt, 0).After(m.now().UTC()) {
+		return WorkOSMFAPendingState{}, ErrMFAPendingStateExpired
+	}
+	return state, nil
+}
+
+func (m *MFAPendingStateManager) cipher() (cipher.AEAD, error) {
+	key := sha256.Sum256(m.secret)
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}

--- a/internal/api/auth/mfa_pending_test.go
+++ b/internal/api/auth/mfa_pending_test.go
@@ -48,3 +48,24 @@ func TestMFAPendingStateManagerRejectsExpiredState(t *testing.T) {
 		t.Fatalf("expected expired pending mfa state, got %v", err)
 	}
 }
+
+func TestMFAPendingStateManagerRejectsInvalidState(t *testing.T) {
+	if _, err := (*MFAPendingStateManager)(nil).Seal(WorkOSMFAPendingState{}); !errors.Is(err, ErrMFAPendingStateInvalid) {
+		t.Fatalf("expected nil manager seal to fail, got %v", err)
+	}
+	manager := NewMFAPendingStateManager(strings.Repeat("a", 64), nil)
+	raw, err := manager.Seal(WorkOSMFAPendingState{
+		Mode:                       WorkOSMFAModeChallenge,
+		PendingAuthenticationToken: "pending-token",
+		User:                       WorkOSProfile{ID: "user_123", Email: "user@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("seal pending mfa state: %v", err)
+	}
+	if _, err := manager.Open(raw + "tampered"); !errors.Is(err, ErrMFAPendingStateInvalid) {
+		t.Fatalf("expected tampered state to fail, got %v", err)
+	}
+	if _, err := manager.Open("bad"); !errors.Is(err, ErrMFAPendingStateInvalid) {
+		t.Fatalf("expected malformed state to fail, got %v", err)
+	}
+}

--- a/internal/api/auth/mfa_pending_test.go
+++ b/internal/api/auth/mfa_pending_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"encoding/base64"
 	"errors"
 	"strings"
 	"testing"
@@ -67,5 +68,13 @@ func TestMFAPendingStateManagerRejectsInvalidState(t *testing.T) {
 	}
 	if _, err := manager.Open("bad"); !errors.Is(err, ErrMFAPendingStateInvalid) {
 		t.Fatalf("expected malformed state to fail, got %v", err)
+	}
+	badNonce := strings.Join([]string{
+		mfaPendingStateVersion,
+		base64.RawURLEncoding.EncodeToString([]byte("short")),
+		base64.RawURLEncoding.EncodeToString([]byte("ciphertext")),
+	}, ".")
+	if _, err := manager.Open(badNonce); !errors.Is(err, ErrMFAPendingStateInvalid) {
+		t.Fatalf("expected short nonce state to fail, got %v", err)
 	}
 }

--- a/internal/api/auth/mfa_pending_test.go
+++ b/internal/api/auth/mfa_pending_test.go
@@ -1,0 +1,50 @@
+package auth
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMFAPendingStateManagerSealsEncryptedState(t *testing.T) {
+	now := time.Date(2026, 5, 16, 18, 45, 0, 0, time.UTC)
+	manager := NewMFAPendingStateManager(strings.Repeat("a", 64), func() time.Time { return now })
+	raw, err := manager.Seal(WorkOSMFAPendingState{
+		Mode:                       WorkOSMFAModeEnrollment,
+		PendingAuthenticationToken: "pending-token",
+		User:                       WorkOSProfile{ID: "user_123", Email: "user@example.com"},
+		ReturnTo:                   "https://app.identrail.test/app",
+	})
+	if err != nil {
+		t.Fatalf("seal pending mfa state: %v", err)
+	}
+	if strings.Contains(raw, "pending-token") || strings.Contains(raw, "user@example.com") {
+		t.Fatalf("sealed state must not expose sensitive values: %q", raw)
+	}
+	opened, err := manager.Open(raw)
+	if err != nil {
+		t.Fatalf("open pending mfa state: %v", err)
+	}
+	if opened.PendingAuthenticationToken != "pending-token" || opened.User.Email != "user@example.com" || opened.Mode != WorkOSMFAModeEnrollment {
+		t.Fatalf("unexpected pending mfa state: %+v", opened)
+	}
+}
+
+func TestMFAPendingStateManagerRejectsExpiredState(t *testing.T) {
+	now := time.Date(2026, 5, 16, 18, 45, 0, 0, time.UTC)
+	managerNow := now
+	manager := NewMFAPendingStateManager(strings.Repeat("a", 64), func() time.Time { return managerNow })
+	raw, err := manager.Seal(WorkOSMFAPendingState{
+		Mode:                       WorkOSMFAModeChallenge,
+		PendingAuthenticationToken: "pending-token",
+		User:                       WorkOSProfile{ID: "user_123", Email: "user@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("seal pending mfa state: %v", err)
+	}
+	managerNow = now.Add(DefaultMFAPendingTTL + time.Second)
+	if _, err := manager.Open(raw); !errors.Is(err, ErrMFAPendingStateExpired) {
+		t.Fatalf("expected expired pending mfa state, got %v", err)
+	}
+}

--- a/internal/api/auth/workos.go
+++ b/internal/api/auth/workos.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"strings"
 
+	"github.com/workos/workos-go/v6/pkg/mfa"
 	"github.com/workos/workos-go/v6/pkg/usermanagement"
 )
 
@@ -48,17 +49,22 @@ type WorkOSAuthentication struct {
 type WorkOSClient interface {
 	AuthorizationURL(input WorkOSAuthorizationRequest) (string, error)
 	AuthenticateWithCode(ctx context.Context, input WorkOSAuthenticationRequest) (WorkOSAuthentication, error)
+	EnrollAuthFactor(ctx context.Context, input WorkOSMFAEnrollRequest) (WorkOSMFAEnrollResponse, error)
+	ChallengeAuthFactor(ctx context.Context, input WorkOSMFAChallengeRequest) (WorkOSMFAChallengeResponse, error)
+	AuthenticateWithTOTP(ctx context.Context, input WorkOSMFAVerifyRequest) (WorkOSAuthentication, error)
 }
 
 type WorkOSSDKClient struct {
 	clientID string
 	client   *usermanagement.Client
+	mfa      *mfa.Client
 }
 
 func NewWorkOSSDKClient(apiKey string, clientID string) *WorkOSSDKClient {
 	return &WorkOSSDKClient{
 		clientID: strings.TrimSpace(clientID),
 		client:   usermanagement.NewClient(strings.TrimSpace(apiKey)),
+		mfa:      &mfa.Client{APIKey: strings.TrimSpace(apiKey)},
 	}
 }
 
@@ -97,28 +103,106 @@ func (c *WorkOSSDKClient) AuthenticateWithCode(ctx context.Context, input WorkOS
 		UserAgent: strings.TrimSpace(input.UserAgent),
 	})
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-			return WorkOSAuthentication{}, ErrWorkOSUnavailable
-		}
-		var netErr net.Error
-		if errors.As(err, &netErr) {
-			return WorkOSAuthentication{}, ErrWorkOSUnavailable
-		}
-		return WorkOSAuthentication{}, err
+		return WorkOSAuthentication{}, normalizeWorkOSAuthenticationError(err)
 	}
-	rawClaims, _ := json.Marshal(response.User)
+	return workOSAuthenticationFromResponse(response), nil
+}
+
+func (c *WorkOSSDKClient) EnrollAuthFactor(ctx context.Context, input WorkOSMFAEnrollRequest) (WorkOSMFAEnrollResponse, error) {
+	if c == nil || c.client == nil || c.clientID == "" {
+		return WorkOSMFAEnrollResponse{}, ErrWorkOSUnavailable
+	}
+	response, err := c.client.EnrollAuthFactor(ctx, usermanagement.EnrollAuthFactorOpts{
+		User:       strings.TrimSpace(input.UserID),
+		Type:       mfa.TOTP,
+		TOTPIssuer: strings.TrimSpace(input.TOTPIssuer),
+		TOTPUser:   strings.TrimSpace(input.TOTPUser),
+	})
+	if err != nil {
+		return WorkOSMFAEnrollResponse{}, normalizeWorkOSAuthenticationError(err)
+	}
+	return WorkOSMFAEnrollResponse{
+		FactorID:    response.Factor.ID,
+		FactorType:  string(response.Factor.Type),
+		ChallengeID: response.Challenge.ID,
+		ExpiresAt:   response.Challenge.ExpiresAt,
+		TOTPQRCode:  response.Factor.TOTP.QRCode,
+		TOTPSecret:  response.Factor.TOTP.Secret,
+		TOTPURI:     response.Factor.TOTP.URI,
+	}, nil
+}
+
+func (c *WorkOSSDKClient) ChallengeAuthFactor(ctx context.Context, input WorkOSMFAChallengeRequest) (WorkOSMFAChallengeResponse, error) {
+	if c == nil || c.mfa == nil || c.clientID == "" {
+		return WorkOSMFAChallengeResponse{}, ErrWorkOSUnavailable
+	}
+	response, err := c.mfa.ChallengeFactor(ctx, mfa.ChallengeFactorOpts{
+		FactorID: strings.TrimSpace(input.FactorID),
+	})
+	if err != nil {
+		return WorkOSMFAChallengeResponse{}, normalizeWorkOSAuthenticationError(err)
+	}
+	return WorkOSMFAChallengeResponse{
+		ChallengeID: response.ID,
+		FactorID:    response.FactorID,
+		ExpiresAt:   response.ExpiresAt,
+	}, nil
+}
+
+func (c *WorkOSSDKClient) AuthenticateWithTOTP(ctx context.Context, input WorkOSMFAVerifyRequest) (WorkOSAuthentication, error) {
+	if c == nil || c.client == nil || c.clientID == "" {
+		return WorkOSAuthentication{}, ErrWorkOSUnavailable
+	}
+	response, err := c.client.AuthenticateWithTOTP(ctx, usermanagement.AuthenticateWithTOTPOpts{
+		ClientID:                   c.clientID,
+		Code:                       strings.TrimSpace(input.Code),
+		IPAddress:                  strings.TrimSpace(input.IPAddress),
+		UserAgent:                  strings.TrimSpace(input.UserAgent),
+		PendingAuthenticationToken: strings.TrimSpace(input.PendingAuthenticationToken),
+		AuthenticationChallengeID:  strings.TrimSpace(input.AuthenticationChallengeID),
+	})
+	if err != nil {
+		return WorkOSAuthentication{}, normalizeWorkOSAuthenticationError(err)
+	}
+	return workOSAuthenticationFromResponse(response), nil
+}
+
+func normalizeWorkOSAuthenticationError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return ErrWorkOSUnavailable
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return ErrWorkOSUnavailable
+	}
+	if required, ok := AsWorkOSMFARequired(err); ok {
+		return required
+	}
+	return err
+}
+
+func workOSAuthenticationFromResponse(response usermanagement.AuthenticateResponse) WorkOSAuthentication {
+	profile := workOSProfileFromUser(response.User, response.OrganizationID)
 	return WorkOSAuthentication{
-		User: WorkOSProfile{
-			ID:                response.User.ID,
-			Email:             response.User.Email,
-			OrganizationID:    response.OrganizationID,
-			FirstName:         response.User.FirstName,
-			LastName:          response.User.LastName,
-			EmailVerified:     response.User.EmailVerified,
-			ProfilePictureURL: response.User.ProfilePictureURL,
-			RawClaims:         rawClaims,
-		},
+		User:                 profile,
 		OrganizationID:       response.OrganizationID,
 		AuthenticationMethod: string(response.AuthenticationMethod),
-	}, nil
+	}
+}
+
+func workOSProfileFromUser(user usermanagement.User, organizationID string) WorkOSProfile {
+	rawClaims, _ := json.Marshal(user)
+	return WorkOSProfile{
+		ID:                user.ID,
+		Email:             user.Email,
+		OrganizationID:    organizationID,
+		FirstName:         user.FirstName,
+		LastName:          user.LastName,
+		EmailVerified:     user.EmailVerified,
+		ProfilePictureURL: user.ProfilePictureURL,
+		RawClaims:         rawClaims,
+	}
 }

--- a/internal/api/auth/workos_mfa.go
+++ b/internal/api/auth/workos_mfa.go
@@ -1,0 +1,136 @@
+package auth
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/workos/workos-go/v6/pkg/workos_errors"
+)
+
+const (
+	WorkOSMFAModeEnrollment = "enrollment"
+	WorkOSMFAModeChallenge  = "challenge"
+)
+
+type WorkOSMFAFactor struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+}
+
+type WorkOSMFARequired struct {
+	Mode                       string
+	User                       WorkOSProfile
+	PendingAuthenticationToken string
+	AuthenticationFactors      []WorkOSMFAFactor
+}
+
+func (e *WorkOSMFARequired) Error() string {
+	mode := strings.TrimSpace(e.Mode)
+	if mode == "" {
+		mode = "completion"
+	}
+	return "workos mfa " + mode + " required"
+}
+
+type WorkOSMFAEnrollRequest struct {
+	UserID     string
+	TOTPIssuer string
+	TOTPUser   string
+}
+
+type WorkOSMFAEnrollResponse struct {
+	FactorID    string
+	FactorType  string
+	ChallengeID string
+	ExpiresAt   string
+	TOTPQRCode  string
+	TOTPSecret  string
+	TOTPURI     string
+}
+
+type WorkOSMFAChallengeRequest struct {
+	FactorID string
+}
+
+type WorkOSMFAChallengeResponse struct {
+	ChallengeID string
+	FactorID    string
+	ExpiresAt   string
+}
+
+type WorkOSMFAVerifyRequest struct {
+	PendingAuthenticationToken string
+	AuthenticationChallengeID  string
+	Code                       string
+	IPAddress                  string
+	UserAgent                  string
+}
+
+func AsWorkOSMFARequired(err error) (*WorkOSMFARequired, bool) {
+	if err == nil {
+		return nil, false
+	}
+	var required *WorkOSMFARequired
+	if errors.As(err, &required) && required != nil {
+		return required, true
+	}
+	var enrollmentErr *workos_errors.MFAEnrollmentError
+	if errors.As(err, &enrollmentErr) && enrollmentErr != nil {
+		return &WorkOSMFARequired{
+			Mode:                       WorkOSMFAModeEnrollment,
+			User:                       workOSProfileFromUser(enrollmentErr.User, ""),
+			PendingAuthenticationToken: enrollmentErr.PendingAuthenticationToken,
+		}, true
+	}
+	var challengeErr *workos_errors.MFAChallengeError
+	if errors.As(err, &challengeErr) && challengeErr != nil {
+		return &WorkOSMFARequired{
+			Mode:                       WorkOSMFAModeChallenge,
+			User:                       workOSProfileFromUser(challengeErr.User, ""),
+			PendingAuthenticationToken: challengeErr.PendingAuthenticationToken,
+			AuthenticationFactors:      workOSMFAFactorsFromWorkOSError(challengeErr.AuthenticationFactors),
+		}, true
+	}
+	var httpErr workos_errors.HTTPError
+	if errors.As(err, &httpErr) {
+		switch httpErr.ErrorCode {
+		case workos_errors.MFAEnrollmentCode:
+			required := &WorkOSMFARequired{
+				Mode:                       WorkOSMFAModeEnrollment,
+				PendingAuthenticationToken: httpErr.PendingAuthenticationToken,
+			}
+			if httpErr.User != nil {
+				required.User = workOSProfileFromUser(*httpErr.User, "")
+			}
+			return required, true
+		case workos_errors.MFAChallengeCode:
+			required := &WorkOSMFARequired{
+				Mode:                       WorkOSMFAModeChallenge,
+				PendingAuthenticationToken: httpErr.PendingAuthenticationToken,
+				AuthenticationFactors:      workOSMFAFactorsFromWorkOSError(httpErr.AuthenticationFactors),
+			}
+			if httpErr.User != nil {
+				required.User = workOSProfileFromUser(*httpErr.User, "")
+			}
+			return required, true
+		}
+	}
+	return nil, false
+}
+
+func workOSMFAFactorsFromWorkOSError(factors []workos_errors.AuthenticationFactor) []WorkOSMFAFactor {
+	if len(factors) == 0 {
+		return nil
+	}
+	result := make([]WorkOSMFAFactor, 0, len(factors))
+	for _, factor := range factors {
+		if strings.TrimSpace(factor.ID) == "" {
+			continue
+		}
+		result = append(result, WorkOSMFAFactor{
+			ID:   strings.TrimSpace(factor.ID),
+			Type: string(factor.Type),
+		})
+	}
+	return result
+}

--- a/internal/api/auth/workos_test.go
+++ b/internal/api/auth/workos_test.go
@@ -7,6 +7,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/workos/workos-go/v6/pkg/common"
+	"github.com/workos/workos-go/v6/pkg/workos_errors"
 )
 
 func TestWorkOSSDKClientAuthorizationURL(t *testing.T) {
@@ -114,11 +117,147 @@ func TestWorkOSSDKClientAuthenticateWithCodeNetworkError(t *testing.T) {
 	}
 }
 
+func TestWorkOSSDKClientMFAFlow(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/user_management/users/user_123/auth_factors":
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode enroll request: %v", err)
+			}
+			if payload["type"] != "totp" || payload["totp_issuer"] != "Identrail" || payload["totp_user"] != "user@example.com" {
+				t.Fatalf("unexpected enroll request: %+v", payload)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"authentication_factor": map[string]any{
+					"id":   "auth_factor_123",
+					"type": "totp",
+					"totp": map[string]any{
+						"qr_code": "data:image/png;base64,qr",
+						"secret":  "SECRET",
+						"uri":     "otpauth://totp/Identrail:user@example.com",
+					},
+				},
+				"authentication_challenge": map[string]any{
+					"id":         "auth_challenge_123",
+					"expires_at": "2026-05-16T19:30:00Z",
+				},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/auth/factors/auth_factor_123/challenge":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":                       "auth_challenge_456",
+				"authentication_factor_id": "auth_factor_123",
+				"expires_at":               "2026-05-16T19:35:00Z",
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/user_management/authenticate":
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode verify request: %v", err)
+			}
+			if payload["grant_type"] != "urn:workos:oauth:grant-type:mfa-totp" || payload["pending_authentication_token"] != "pending-token" || payload["authentication_challenge_id"] != "auth_challenge_123" || payload["code"] != "123456" {
+				t.Fatalf("unexpected verify request: %+v", payload)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"user": map[string]any{
+					"id":             "user_123",
+					"email":          "user@example.com",
+					"email_verified": true,
+				},
+				"organization_id":       "org_123",
+				"authentication_method": "GitHubOAuth",
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewWorkOSSDKClient("sk_test", "client_123")
+	client.client.Endpoint = server.URL
+	client.client.HTTPClient = server.Client()
+	client.mfa.Endpoint = server.URL
+	client.mfa.HTTPClient = server.Client()
+
+	enrolled, err := client.EnrollAuthFactor(context.Background(), WorkOSMFAEnrollRequest{
+		UserID:     "user_123",
+		TOTPIssuer: "Identrail",
+		TOTPUser:   "user@example.com",
+	})
+	if err != nil {
+		t.Fatalf("enroll auth factor: %v", err)
+	}
+	if enrolled.FactorID != "auth_factor_123" || enrolled.ChallengeID != "auth_challenge_123" || enrolled.TOTPSecret != "SECRET" {
+		t.Fatalf("unexpected enrollment: %+v", enrolled)
+	}
+
+	challenge, err := client.ChallengeAuthFactor(context.Background(), WorkOSMFAChallengeRequest{FactorID: "auth_factor_123"})
+	if err != nil {
+		t.Fatalf("challenge auth factor: %v", err)
+	}
+	if challenge.ChallengeID != "auth_challenge_456" || challenge.FactorID != "auth_factor_123" {
+		t.Fatalf("unexpected challenge: %+v", challenge)
+	}
+
+	authenticated, err := client.AuthenticateWithTOTP(context.Background(), WorkOSMFAVerifyRequest{
+		PendingAuthenticationToken: "pending-token",
+		AuthenticationChallengeID:  "auth_challenge_123",
+		Code:                       "123456",
+	})
+	if err != nil {
+		t.Fatalf("authenticate with totp: %v", err)
+	}
+	if authenticated.User.ID != "user_123" || authenticated.OrganizationID != "org_123" || authenticated.AuthenticationMethod != "GitHubOAuth" {
+		t.Fatalf("unexpected authentication: %+v", authenticated)
+	}
+}
+
+func TestAsWorkOSMFARequiredMapsStructuredChallenge(t *testing.T) {
+	required, ok := AsWorkOSMFARequired(&workos_errors.MFAChallengeError{
+		Code:                       workos_errors.MFAChallengeCode,
+		Message:                    "MFA required",
+		User:                       common.User{ID: "user_123", Email: "user@example.com", EmailVerified: true},
+		AuthenticationFactors:      []workos_errors.AuthenticationFactor{{ID: "auth_factor_123", Type: workos_errors.TOTP}},
+		PendingAuthenticationToken: "pending-token",
+	})
+	if !ok {
+		t.Fatal("expected mfa required error")
+	}
+	if required.Mode != WorkOSMFAModeChallenge || required.User.ID != "user_123" || len(required.AuthenticationFactors) != 1 || required.AuthenticationFactors[0].ID != "auth_factor_123" {
+		t.Fatalf("unexpected mfa requirement: %+v", required)
+	}
+	if strings.Contains(required.Error(), "pending-token") {
+		t.Fatalf("mfa required error must not expose pending token: %q", required.Error())
+	}
+}
+
+func TestAsWorkOSMFARequiredMapsGenericHTTPError(t *testing.T) {
+	required, ok := AsWorkOSMFARequired(workos_errors.HTTPError{
+		ErrorCode:                  workos_errors.MFAEnrollmentCode,
+		PendingAuthenticationToken: "pending-token",
+		User:                       &common.User{ID: "user_123", Email: "user@example.com", EmailVerified: true},
+	})
+	if !ok {
+		t.Fatal("expected mfa enrollment requirement")
+	}
+	if required.Mode != WorkOSMFAModeEnrollment || required.User.Email != "user@example.com" || required.PendingAuthenticationToken != "pending-token" {
+		t.Fatalf("unexpected enrollment requirement: %+v", required)
+	}
+}
+
 func TestWorkOSSDKClientUnavailable(t *testing.T) {
 	if _, err := (*WorkOSSDKClient)(nil).AuthorizationURL(WorkOSAuthorizationRequest{}); err != ErrWorkOSUnavailable {
 		t.Fatalf("expected unavailable auth url error, got %v", err)
 	}
 	if _, err := (*WorkOSSDKClient)(nil).AuthenticateWithCode(context.Background(), WorkOSAuthenticationRequest{}); err != ErrWorkOSUnavailable {
 		t.Fatalf("expected unavailable authenticate error, got %v", err)
+	}
+	if _, err := (*WorkOSSDKClient)(nil).EnrollAuthFactor(context.Background(), WorkOSMFAEnrollRequest{}); err != ErrWorkOSUnavailable {
+		t.Fatalf("expected unavailable enroll error, got %v", err)
+	}
+	if _, err := (*WorkOSSDKClient)(nil).ChallengeAuthFactor(context.Background(), WorkOSMFAChallengeRequest{}); err != ErrWorkOSUnavailable {
+		t.Fatalf("expected unavailable challenge error, got %v", err)
+	}
+	if _, err := (*WorkOSSDKClient)(nil).AuthenticateWithTOTP(context.Background(), WorkOSMFAVerifyRequest{}); err != ErrWorkOSUnavailable {
+		t.Fatalf("expected unavailable totp error, got %v", err)
 	}
 }

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -27,6 +27,7 @@ type authSessionRouteOptions struct {
 	WorkOSClient        sessionauth.WorkOSClient
 	WorkOSWebhookSecret string
 	StateManager        *sessionauth.OAuthStateManager
+	PendingMFAManager   *sessionauth.MFAPendingStateManager
 	PublicBaseURL       string
 	ReturnToOrigins     []string
 }
@@ -40,6 +41,10 @@ func registerAuthSessionRoutes(r *gin.Engine, logger *zap.Logger, svc *Service, 
 		authGroup.GET("/login", rateLimitMiddleware(10, 10), workOSStartHandler(logger, svc, opts, "login"))
 		authGroup.GET("/signup", rateLimitMiddleware(10, 10), workOSStartHandler(logger, svc, opts, "signup"))
 		authGroup.GET("/callback", rateLimitMiddleware(30, 30), workOSCallbackHandler(logger, svc, manager, opts))
+		authGroup.GET("/mfa/pending", rateLimitMiddleware(30, 30), workOSMFAPendingHandler(opts))
+		authGroup.POST("/mfa/enroll", rateLimitMiddleware(20, 20), workOSMFAEnrollHandler(logger, opts))
+		authGroup.POST("/mfa/challenge", rateLimitMiddleware(20, 20), workOSMFAChallengeHandler(logger, opts))
+		authGroup.POST("/mfa/verify", rateLimitMiddleware(30, 30), workOSMFAVerifyHandler(logger, svc, manager, opts))
 		authGroup.POST("/webhooks/workos", rateLimitMiddleware(60, 60), workOSWebhookHandler(logger, svc, opts))
 	}
 	if opts.ManualMode {
@@ -188,6 +193,10 @@ func workOSCallbackHandler(logger *zap.Logger, svc *Service, manager sessionauth
 		})
 		if err != nil {
 			auditAuthAction(c.Request.Context(), "auth.login.failure", "", "denied")
+			if required, ok := sessionauth.AsWorkOSMFARequired(err); ok {
+				handleWorkOSMFARequired(c, logger, opts, state, required)
+				return
+			}
 			if logger != nil {
 				logger.Warn("authenticate workos callback", telemetry.ZapError(err))
 			}
@@ -199,53 +208,427 @@ func workOSCallbackHandler(logger *zap.Logger, svc *Service, manager sessionauth
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "login failed"})
 			return
 		}
-		profile := authenticated.User
-		if strings.TrimSpace(profile.OrganizationID) == "" {
-			profile.OrganizationID = authenticated.OrganizationID
-		}
-		result, err := svc.UpsertWorkOSUser(c.Request.Context(), profile)
-		if err != nil {
-			if errors.Is(err, ErrAuthIdentityConflict) {
-				c.JSON(http.StatusConflict, gin.H{"error": "identity conflict"})
-				return
-			}
-			if logger != nil {
-				logger.Error("upsert workos user", telemetry.ZapError(err))
-			}
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to complete login"})
+		redirectTo, ok := completeWorkOSLogin(c, logger, svc, manager, opts, authenticated, state.ReturnTo)
+		if !ok {
 			return
-		}
-		now := time.Now().UTC()
-		if svc.Now != nil {
-			now = svc.Now().UTC()
-		}
-		cookieValue, _, err := manager.CreateSession(c.Request.Context(), db.Session{
-			UserID:             result.User.ID,
-			CurrentOrgID:       result.CurrentOrgID,
-			CurrentWorkspaceID: result.CurrentWorkspace,
-			AuthMethod:         sessionauth.WorkOSProvider,
-			IP:                 c.ClientIP(),
-			UserAgent:          c.Request.UserAgent(),
-			CreatedAt:          now,
-			LastSeenAt:         now,
-			IdleExpiresAt:      now.Add(sessionauth.IdleTimeout),
-			AbsoluteExpiresAt:  now.Add(sessionauth.AbsoluteTimeout),
-		})
-		if err != nil {
-			if logger != nil {
-				logger.Error("create workos session", telemetry.ZapError(err))
-			}
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create session"})
-			return
-		}
-		auditAuthAction(c.Request.Context(), "auth.login.success", result.User.ID, "success")
-		http.SetCookie(c.Writer, manager.Cookie(cookieValue))
-		redirectTo := sanitizeAuthReturnTo(state.ReturnTo, opts.ReturnToOrigins)
-		if redirectTo == "" || redirectTo == "/" {
-			redirectTo = result.RedirectPath
 		}
 		c.Redirect(http.StatusFound, redirectTo)
 	}
+}
+
+func handleWorkOSMFARequired(c *gin.Context, logger *zap.Logger, opts authSessionRouteOptions, state sessionauth.OAuthState, required *sessionauth.WorkOSMFARequired) {
+	if required == nil || opts.PendingMFAManager == nil || strings.TrimSpace(required.PendingAuthenticationToken) == "" {
+		if logger != nil {
+			logger.Warn("workos mfa required without resumable pending token")
+		}
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "mfa required"})
+		return
+	}
+	pending := sessionauth.WorkOSMFAPendingState{
+		Mode:                       required.Mode,
+		ReturnTo:                   sanitizeAuthReturnTo(state.ReturnTo, opts.ReturnToOrigins),
+		PendingAuthenticationToken: required.PendingAuthenticationToken,
+		User:                       required.User,
+		AuthenticationFactors:      required.AuthenticationFactors,
+	}
+	if pending.Mode == "" {
+		pending.Mode = sessionauth.WorkOSMFAModeChallenge
+	}
+	sealed, err := opts.PendingMFAManager.Seal(pending)
+	if err != nil {
+		if logger != nil {
+			logger.Error("seal workos mfa pending state", telemetry.ZapError(err))
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to continue login"})
+		return
+	}
+	if logger != nil {
+		logger.Info("workos mfa required", zap.String("mode", pending.Mode))
+	}
+	http.SetCookie(c.Writer, workOSMFAPendingCookie(opts.PublicBaseURL, sealed, opts.PendingMFAManager.TTL()))
+	c.Redirect(http.StatusFound, workOSMFARedirectURL(pending.ReturnTo, opts.PublicBaseURL, opts.ReturnToOrigins))
+}
+
+func completeWorkOSLogin(c *gin.Context, logger *zap.Logger, svc *Service, manager sessionauth.Manager, opts authSessionRouteOptions, authenticated sessionauth.WorkOSAuthentication, returnTo string) (string, bool) {
+	profile := authenticated.User
+	if strings.TrimSpace(profile.OrganizationID) == "" {
+		profile.OrganizationID = authenticated.OrganizationID
+	}
+	result, err := svc.UpsertWorkOSUser(c.Request.Context(), profile)
+	if err != nil {
+		if errors.Is(err, ErrAuthIdentityConflict) {
+			c.JSON(http.StatusConflict, gin.H{"error": "identity conflict"})
+			return "", false
+		}
+		if logger != nil {
+			logger.Error("upsert workos user", telemetry.ZapError(err))
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to complete login"})
+		return "", false
+	}
+	now := time.Now().UTC()
+	if svc.Now != nil {
+		now = svc.Now().UTC()
+	}
+	cookieValue, _, err := manager.CreateSession(c.Request.Context(), db.Session{
+		UserID:             result.User.ID,
+		CurrentOrgID:       result.CurrentOrgID,
+		CurrentWorkspaceID: result.CurrentWorkspace,
+		AuthMethod:         sessionauth.WorkOSProvider,
+		IP:                 c.ClientIP(),
+		UserAgent:          c.Request.UserAgent(),
+		CreatedAt:          now,
+		LastSeenAt:         now,
+		IdleExpiresAt:      now.Add(sessionauth.IdleTimeout),
+		AbsoluteExpiresAt:  now.Add(sessionauth.AbsoluteTimeout),
+	})
+	if err != nil {
+		if logger != nil {
+			logger.Error("create workos session", telemetry.ZapError(err))
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create session"})
+		return "", false
+	}
+	auditAuthAction(c.Request.Context(), "auth.login.success", result.User.ID, "success")
+	http.SetCookie(c.Writer, manager.Cookie(cookieValue))
+	redirectTo := sanitizeAuthReturnTo(returnTo, opts.ReturnToOrigins)
+	if redirectTo == "" || redirectTo == "/" {
+		redirectTo = result.RedirectPath
+	}
+	return redirectTo, true
+}
+
+func workOSMFAPendingHandler(opts authSessionRouteOptions) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		state, ok := readWorkOSMFAPendingState(c, opts)
+		if !ok {
+			return
+		}
+		c.JSON(http.StatusOK, workOSMFAPendingResponse(state))
+	}
+}
+
+type workOSMFAChallengeRequest struct {
+	FactorID string `json:"factor_id"`
+}
+
+type workOSMFAVerifyRequest struct {
+	Code string `json:"code"`
+}
+
+func workOSMFAEnrollHandler(logger *zap.Logger, opts authSessionRouteOptions) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		state, ok := readWorkOSMFAPendingState(c, opts)
+		if !ok {
+			return
+		}
+		if state.Mode != sessionauth.WorkOSMFAModeEnrollment {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "mfa enrollment is not pending"})
+			return
+		}
+		if state.TOTP != nil && state.ChallengeID != "" {
+			c.JSON(http.StatusOK, workOSMFAEnrollResponse(state))
+			return
+		}
+		if opts.WorkOSClient == nil || strings.TrimSpace(state.User.ID) == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "mfa enrollment cannot be started"})
+			return
+		}
+		totpUser := strings.TrimSpace(state.User.Email)
+		if totpUser == "" {
+			totpUser = state.User.ID
+		}
+		enrolled, err := opts.WorkOSClient.EnrollAuthFactor(c.Request.Context(), sessionauth.WorkOSMFAEnrollRequest{
+			UserID:     state.User.ID,
+			TOTPIssuer: "Identrail",
+			TOTPUser:   totpUser,
+		})
+		if err != nil {
+			writeWorkOSMFAProviderError(c, logger, err, "enroll workos mfa factor")
+			return
+		}
+		state.ChallengeID = enrolled.ChallengeID
+		state.ChallengeExpiresAt = enrolled.ExpiresAt
+		state.AuthenticationFactors = []sessionauth.WorkOSMFAFactor{{
+			ID:   enrolled.FactorID,
+			Type: enrolled.FactorType,
+		}}
+		state.TOTP = &sessionauth.WorkOSPendingTOTP{
+			FactorID: enrolled.FactorID,
+			QRCode:   enrolled.TOTPQRCode,
+			Secret:   enrolled.TOTPSecret,
+			URI:      enrolled.TOTPURI,
+		}
+		if !writeWorkOSMFAPendingState(c, logger, opts, state) {
+			return
+		}
+		c.JSON(http.StatusOK, workOSMFAEnrollResponse(state))
+	}
+}
+
+func workOSMFAChallengeHandler(logger *zap.Logger, opts authSessionRouteOptions) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		state, ok := readWorkOSMFAPendingState(c, opts)
+		if !ok {
+			return
+		}
+		if state.Mode != sessionauth.WorkOSMFAModeChallenge {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "mfa challenge is not pending"})
+			return
+		}
+		if opts.WorkOSClient == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "auth service unavailable"})
+			return
+		}
+		var req workOSMFAChallengeRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid challenge request"})
+			return
+		}
+		factorID := strings.TrimSpace(req.FactorID)
+		if !workOSMFAFactorAllowed(state.AuthenticationFactors, factorID) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "unsupported mfa factor"})
+			return
+		}
+		challenge, err := opts.WorkOSClient.ChallengeAuthFactor(c.Request.Context(), sessionauth.WorkOSMFAChallengeRequest{
+			FactorID: factorID,
+		})
+		if err != nil {
+			writeWorkOSMFAProviderError(c, logger, err, "challenge workos mfa factor")
+			return
+		}
+		state.ChallengeID = challenge.ChallengeID
+		state.ChallengeExpiresAt = challenge.ExpiresAt
+		if !writeWorkOSMFAPendingState(c, logger, opts, state) {
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"challenge_started": true,
+			"factor_id":         factorID,
+			"expires_at":        challenge.ExpiresAt,
+		})
+	}
+}
+
+func workOSMFAVerifyHandler(logger *zap.Logger, svc *Service, manager sessionauth.Manager, opts authSessionRouteOptions) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if svc == nil || svc.Store == nil || opts.WorkOSClient == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "auth service unavailable"})
+			return
+		}
+		state, ok := readWorkOSMFAPendingState(c, opts)
+		if !ok {
+			return
+		}
+		var req workOSMFAVerifyRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid verification request"})
+			return
+		}
+		code := strings.TrimSpace(req.Code)
+		if code == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "verification code is required"})
+			return
+		}
+		if strings.TrimSpace(state.ChallengeID) == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "mfa challenge has not started"})
+			return
+		}
+		authenticated, err := opts.WorkOSClient.AuthenticateWithTOTP(c.Request.Context(), sessionauth.WorkOSMFAVerifyRequest{
+			PendingAuthenticationToken: state.PendingAuthenticationToken,
+			AuthenticationChallengeID:  state.ChallengeID,
+			Code:                       code,
+			IPAddress:                  c.ClientIP(),
+			UserAgent:                  c.Request.UserAgent(),
+		})
+		if err != nil {
+			writeWorkOSMFAVerifyError(c, logger, err)
+			return
+		}
+		redirectTo, ok := completeWorkOSLogin(c, logger, svc, manager, opts, authenticated, state.ReturnTo)
+		if !ok {
+			return
+		}
+		http.SetCookie(c.Writer, workOSMFAClearCookie(opts.PublicBaseURL))
+		c.JSON(http.StatusOK, gin.H{
+			"ok":          true,
+			"redirect_to": redirectTo,
+		})
+	}
+}
+
+func readWorkOSMFAPendingState(c *gin.Context, opts authSessionRouteOptions) (sessionauth.WorkOSMFAPendingState, bool) {
+	if opts.PendingMFAManager == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "auth service unavailable"})
+		return sessionauth.WorkOSMFAPendingState{}, false
+	}
+	cookie, err := c.Request.Cookie(sessionauth.PendingMFACookieName)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "mfa session expired"})
+		return sessionauth.WorkOSMFAPendingState{}, false
+	}
+	state, err := opts.PendingMFAManager.Open(cookie.Value)
+	if err != nil {
+		http.SetCookie(c.Writer, workOSMFAClearCookie(opts.PublicBaseURL))
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "mfa session expired"})
+		return sessionauth.WorkOSMFAPendingState{}, false
+	}
+	return state, true
+}
+
+func writeWorkOSMFAPendingState(c *gin.Context, logger *zap.Logger, opts authSessionRouteOptions, state sessionauth.WorkOSMFAPendingState) bool {
+	sealed, err := opts.PendingMFAManager.Seal(state)
+	if err != nil {
+		if logger != nil {
+			logger.Error("seal workos mfa pending state", telemetry.ZapError(err))
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to continue login"})
+		return false
+	}
+	http.SetCookie(c.Writer, workOSMFAPendingCookie(opts.PublicBaseURL, sealed, opts.PendingMFAManager.TTL()))
+	return true
+}
+
+func workOSMFAPendingResponse(state sessionauth.WorkOSMFAPendingState) gin.H {
+	response := gin.H{
+		"mode":              state.Mode,
+		"user_email":        state.User.Email,
+		"challenge_started": strings.TrimSpace(state.ChallengeID) != "",
+		"factors":           workOSMFAFactorsResponse(state.AuthenticationFactors),
+	}
+	if state.TOTP != nil {
+		response["totp"] = gin.H{
+			"factor_id": state.TOTP.FactorID,
+			"qr_code":   state.TOTP.QRCode,
+			"secret":    state.TOTP.Secret,
+			"uri":       state.TOTP.URI,
+		}
+	}
+	return response
+}
+
+func workOSMFAEnrollResponse(state sessionauth.WorkOSMFAPendingState) gin.H {
+	response := workOSMFAPendingResponse(state)
+	response["expires_at"] = state.ChallengeExpiresAt
+	return response
+}
+
+func workOSMFAFactorsResponse(factors []sessionauth.WorkOSMFAFactor) []gin.H {
+	result := make([]gin.H, 0, len(factors))
+	for _, factor := range factors {
+		if strings.TrimSpace(factor.ID) == "" {
+			continue
+		}
+		result = append(result, gin.H{
+			"id":   factor.ID,
+			"type": factor.Type,
+		})
+	}
+	return result
+}
+
+func workOSMFAFactorAllowed(factors []sessionauth.WorkOSMFAFactor, factorID string) bool {
+	factorID = strings.TrimSpace(factorID)
+	if factorID == "" {
+		return false
+	}
+	for _, factor := range factors {
+		if strings.EqualFold(strings.TrimSpace(factor.ID), factorID) && strings.EqualFold(strings.TrimSpace(factor.Type), "totp") {
+			return true
+		}
+	}
+	return false
+}
+
+func writeWorkOSMFAProviderError(c *gin.Context, logger *zap.Logger, err error, message string) {
+	if logger != nil {
+		logger.Warn(message, zap.String("error", "workos mfa provider returned an error"))
+	}
+	if errors.Is(err, sessionauth.ErrWorkOSUnavailable) {
+		c.Header("Retry-After", "30")
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "auth provider unavailable"})
+		return
+	}
+	c.JSON(http.StatusBadGateway, gin.H{"error": "mfa provider failed"})
+}
+
+func writeWorkOSMFAVerifyError(c *gin.Context, logger *zap.Logger, err error) {
+	if logger != nil {
+		logger.Warn("verify workos mfa challenge", zap.String("error", "workos mfa verification failed"))
+	}
+	if errors.Is(err, sessionauth.ErrWorkOSUnavailable) {
+		c.Header("Retry-After", "30")
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "auth provider unavailable"})
+		return
+	}
+	c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid verification code"})
+}
+
+func workOSMFAPendingCookie(publicBaseURL string, value string, ttl time.Duration) *http.Cookie {
+	if ttl <= 0 {
+		ttl = sessionauth.DefaultMFAPendingTTL
+	}
+	return &http.Cookie{
+		Name:     sessionauth.PendingMFACookieName,
+		Value:    value,
+		Path:     "/auth/mfa",
+		MaxAge:   int(ttl.Seconds()),
+		HttpOnly: true,
+		Secure:   sessionauthCookieSecure(publicBaseURL),
+		SameSite: http.SameSiteLaxMode,
+	}
+}
+
+func workOSMFAClearCookie(publicBaseURL string) *http.Cookie {
+	return &http.Cookie{
+		Name:     sessionauth.PendingMFACookieName,
+		Value:    "",
+		Path:     "/auth/mfa",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   sessionauthCookieSecure(publicBaseURL),
+		SameSite: http.SameSiteLaxMode,
+	}
+}
+
+func sessionauthCookieSecure(publicBaseURL string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(publicBaseURL))
+	if err != nil {
+		return true
+	}
+	return !strings.EqualFold(parsed.Scheme, "http")
+}
+
+func workOSMFARedirectURL(returnTo string, publicBaseURL string, allowedOrigins []string) string {
+	sanitizedReturnTo := sanitizeAuthReturnTo(returnTo, allowedOrigins)
+	if sanitizedReturnTo == "" {
+		sanitizedReturnTo = "/app"
+	}
+	targetOrigin := ""
+	if parsed, err := url.Parse(sanitizedReturnTo); err == nil && parsed.IsAbs() {
+		targetOrigin = strings.ToLower(parsed.Scheme + "://" + parsed.Host)
+	}
+	if targetOrigin == "" {
+		targetOrigin = preferredAuthFrontendOrigin(publicBaseURL, allowedOrigins)
+	}
+	query := url.Values{}
+	query.Set("return_to", sanitizedReturnTo)
+	targetPath := "/auth/mfa?" + query.Encode()
+	if targetOrigin == "" {
+		return targetPath
+	}
+	return strings.TrimRight(targetOrigin, "/") + targetPath
+}
+
+func preferredAuthFrontendOrigin(publicBaseURL string, allowedOrigins []string) string {
+	publicOrigin, _ := authReturnToOrigin(publicBaseURL)
+	for _, allowed := range allowedOrigins {
+		origin, ok := authReturnToOrigin(allowed)
+		if ok && !strings.EqualFold(origin, publicOrigin) {
+			return origin
+		}
+	}
+	return publicOrigin
 }
 
 type manualLoginRequest struct {

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -192,11 +192,11 @@ func workOSCallbackHandler(logger *zap.Logger, svc *Service, manager sessionauth
 			UserAgent: c.Request.UserAgent(),
 		})
 		if err != nil {
-			auditAuthAction(c.Request.Context(), "auth.login.failure", "", "denied")
 			if required, ok := sessionauth.AsWorkOSMFARequired(err); ok {
 				handleWorkOSMFARequired(c, logger, opts, state, required)
 				return
 			}
+			auditAuthAction(c.Request.Context(), "auth.login.failure", "", "denied")
 			if logger != nil {
 				logger.Warn("authenticate workos callback", telemetry.ZapError(err))
 			}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -313,6 +313,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			WorkOSClient:        workOSClient,
 			WorkOSWebhookSecret: opts.WorkOSWebhookSecret,
 			StateManager:        sessionauth.NewOAuthStateManager(opts.SessionKey, nil),
+			PendingMFAManager:   sessionauth.NewMFAPendingStateManager(opts.SessionKey, nil),
 			PublicBaseURL:       opts.PublicBaseURL,
 			ReturnToOrigins:     authReturnToOrigins(opts.PublicBaseURL, opts.CORSAllowedOrigins),
 		})

--- a/internal/api/workos_auth_routes_test.go
+++ b/internal/api/workos_auth_routes_test.go
@@ -21,9 +21,15 @@ import (
 
 type fakeWorkOSClient struct {
 	authorizationInput sessionauth.WorkOSAuthorizationRequest
+	verifyInput        sessionauth.WorkOSMFAVerifyRequest
 	authentication     sessionauth.WorkOSAuthentication
+	enrollResponse     sessionauth.WorkOSMFAEnrollResponse
+	challengeResponse  sessionauth.WorkOSMFAChallengeResponse
 	authURLErr         error
 	err                error
+	enrollErr          error
+	challengeErr       error
+	verifyErr          error
 }
 
 func (f *fakeWorkOSClient) AuthorizationURL(input sessionauth.WorkOSAuthorizationRequest) (string, error) {
@@ -46,6 +52,41 @@ func (f *fakeWorkOSClient) AuthorizationURL(input sessionauth.WorkOSAuthorizatio
 func (f *fakeWorkOSClient) AuthenticateWithCode(ctx context.Context, input sessionauth.WorkOSAuthenticationRequest) (sessionauth.WorkOSAuthentication, error) {
 	if f.err != nil {
 		return sessionauth.WorkOSAuthentication{}, f.err
+	}
+	return f.authentication, nil
+}
+
+func (f *fakeWorkOSClient) EnrollAuthFactor(ctx context.Context, input sessionauth.WorkOSMFAEnrollRequest) (sessionauth.WorkOSMFAEnrollResponse, error) {
+	if f.enrollErr != nil {
+		return sessionauth.WorkOSMFAEnrollResponse{}, f.enrollErr
+	}
+	if f.enrollResponse.FactorID != "" {
+		return f.enrollResponse, nil
+	}
+	return sessionauth.WorkOSMFAEnrollResponse{
+		FactorID:    "auth_factor_1",
+		FactorType:  "totp",
+		ChallengeID: "auth_challenge_1",
+		TOTPQRCode:  "data:image/png;base64,qr",
+		TOTPSecret:  "secret",
+		TOTPURI:     "otpauth://totp/Identrail:user@example.com",
+	}, nil
+}
+
+func (f *fakeWorkOSClient) ChallengeAuthFactor(ctx context.Context, input sessionauth.WorkOSMFAChallengeRequest) (sessionauth.WorkOSMFAChallengeResponse, error) {
+	if f.challengeErr != nil {
+		return sessionauth.WorkOSMFAChallengeResponse{}, f.challengeErr
+	}
+	if f.challengeResponse.ChallengeID != "" {
+		return f.challengeResponse, nil
+	}
+	return sessionauth.WorkOSMFAChallengeResponse{ChallengeID: "auth_challenge_1", FactorID: input.FactorID}, nil
+}
+
+func (f *fakeWorkOSClient) AuthenticateWithTOTP(ctx context.Context, input sessionauth.WorkOSMFAVerifyRequest) (sessionauth.WorkOSAuthentication, error) {
+	f.verifyInput = input
+	if f.verifyErr != nil {
+		return sessionauth.WorkOSAuthentication{}, f.verifyErr
 	}
 	return f.authentication, nil
 }
@@ -514,6 +555,116 @@ func TestWorkOSCallbackRejectsInvalidStateAndUnavailableProvider(t *testing.T) {
 	if missingCodeResp.Code != http.StatusBadRequest {
 		t.Fatalf("expected missing code 400, got %d", missingCodeResp.Code)
 	}
+}
+
+func TestWorkOSCallbackContinuesMFAEnrollment(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 5, 16, 18, 45, 0, 0, time.UTC)
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	workOS := &fakeWorkOSClient{
+		err: &sessionauth.WorkOSMFARequired{
+			Mode:                       sessionauth.WorkOSMFAModeEnrollment,
+			PendingAuthenticationToken: "pending-token",
+			User: sessionauth.WorkOSProfile{
+				ID:            "user_workos_mfa",
+				Email:         "mfa@example.com",
+				EmailVerified: true,
+			},
+		},
+		authentication: sessionauth.WorkOSAuthentication{
+			User: sessionauth.WorkOSProfile{
+				ID:            "user_workos_mfa",
+				Email:         "mfa@example.com",
+				EmailVerified: true,
+			},
+			AuthenticationMethod: "GitHubOAuth",
+		},
+	}
+	router := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{
+		FeatureNewAuth:     true,
+		FeatureWorkOSLogin: true,
+		PublicBaseURL:      "https://api.identrail.test",
+		CORSAllowedOrigins: []string{"https://app.identrail.test"},
+		SessionKey:         strings.Repeat("a", 64),
+		WorkOSClientID:     "client_123",
+		WorkOSAuthClient:   workOS,
+		RateLimitRPM:       1000,
+		RateLimitBurst:     1000,
+	})
+
+	startResp := httptest.NewRecorder()
+	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/login?provider=github_oauth&return_to=https%3A%2F%2Fapp.identrail.test%2Fapp", nil))
+	if startResp.Code != http.StatusFound {
+		t.Fatalf("expected login redirect, got %d body=%s", startResp.Code, startResp.Body.String())
+	}
+
+	callbackResp := httptest.NewRecorder()
+	router.ServeHTTP(callbackResp, httptest.NewRequest(http.MethodGet, "/auth/callback?code=code-1&state="+url.QueryEscape(workOS.authorizationInput.State), nil))
+	if callbackResp.Code != http.StatusFound {
+		t.Fatalf("expected mfa redirect, got %d body=%s", callbackResp.Code, callbackResp.Body.String())
+	}
+	if got := callbackResp.Header().Get("Location"); !strings.HasPrefix(got, "https://app.identrail.test/auth/mfa?") || !strings.Contains(got, "return_to=https%3A%2F%2Fapp.identrail.test%2Fapp") {
+		t.Fatalf("unexpected mfa redirect: %q", got)
+	}
+	pendingCookie := findTestCookie(callbackResp.Result().Cookies(), sessionauth.PendingMFACookieName)
+	if pendingCookie == nil || pendingCookie.Value == "" {
+		t.Fatalf("expected pending mfa cookie, got %+v", callbackResp.Result().Cookies())
+	}
+	if strings.Contains(pendingCookie.Value, "pending-token") {
+		t.Fatalf("pending mfa cookie must not expose the raw workos token: %q", pendingCookie.Value)
+	}
+
+	pendingReq := httptest.NewRequest(http.MethodGet, "/auth/mfa/pending", nil)
+	pendingReq.AddCookie(pendingCookie)
+	pendingResp := httptest.NewRecorder()
+	router.ServeHTTP(pendingResp, pendingReq)
+	if pendingResp.Code != http.StatusOK || !strings.Contains(pendingResp.Body.String(), `"mode":"enrollment"`) {
+		t.Fatalf("unexpected pending response: code=%d body=%s", pendingResp.Code, pendingResp.Body.String())
+	}
+
+	enrollReq := httptest.NewRequest(http.MethodPost, "/auth/mfa/enroll", nil)
+	enrollReq.AddCookie(pendingCookie)
+	enrollResp := httptest.NewRecorder()
+	router.ServeHTTP(enrollResp, enrollReq)
+	if enrollResp.Code != http.StatusOK || !strings.Contains(enrollResp.Body.String(), `"qr_code":"data:image/png;base64,qr"`) {
+		t.Fatalf("unexpected enroll response: code=%d body=%s", enrollResp.Code, enrollResp.Body.String())
+	}
+	updatedPendingCookie := findTestCookie(enrollResp.Result().Cookies(), sessionauth.PendingMFACookieName)
+	if updatedPendingCookie == nil || updatedPendingCookie.Value == "" {
+		t.Fatalf("expected refreshed pending mfa cookie, got %+v", enrollResp.Result().Cookies())
+	}
+
+	verifyReq := httptest.NewRequest(http.MethodPost, "/auth/mfa/verify", strings.NewReader(`{"code":"123456"}`))
+	verifyReq.Header.Set("Content-Type", "application/json")
+	verifyReq.AddCookie(updatedPendingCookie)
+	verifyResp := httptest.NewRecorder()
+	router.ServeHTTP(verifyResp, verifyReq)
+	if verifyResp.Code != http.StatusOK || !strings.Contains(verifyResp.Body.String(), `"redirect_to":"https://app.identrail.test/app"`) {
+		t.Fatalf("unexpected verify response: code=%d body=%s", verifyResp.Code, verifyResp.Body.String())
+	}
+	if workOS.verifyInput.PendingAuthenticationToken != "pending-token" || workOS.verifyInput.AuthenticationChallengeID != "auth_challenge_1" || workOS.verifyInput.Code != "123456" {
+		t.Fatalf("unexpected verify input: %+v", workOS.verifyInput)
+	}
+	if findTestCookie(verifyResp.Result().Cookies(), sessionauth.CookieName) == nil {
+		t.Fatalf("expected session cookie after mfa verify, got %+v", verifyResp.Result().Cookies())
+	}
+	clearedPending := findTestCookie(verifyResp.Result().Cookies(), sessionauth.PendingMFACookieName)
+	if clearedPending == nil || clearedPending.MaxAge >= 0 {
+		t.Fatalf("expected pending mfa cookie to be cleared, got %+v", verifyResp.Result().Cookies())
+	}
+	if _, err := store.GetUserIdentity(context.Background(), sessionauth.WorkOSProvider, "user_workos_mfa"); err != nil {
+		t.Fatalf("expected workos identity after mfa verify: %v", err)
+	}
+}
+
+func findTestCookie(cookies []*http.Cookie, name string) *http.Cookie {
+	for _, cookie := range cookies {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+	return nil
 }
 
 func TestWorkOSUserDeletedWebhookRevokesSessions(t *testing.T) {

--- a/internal/api/workos_auth_routes_test.go
+++ b/internal/api/workos_auth_routes_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -13,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	sessionauth "github.com/identrail/identrail/internal/api/auth"
 	"github.com/identrail/identrail/internal/db"
 	"github.com/identrail/identrail/internal/telemetry"
@@ -658,6 +660,152 @@ func TestWorkOSCallbackContinuesMFAEnrollment(t *testing.T) {
 	}
 }
 
+func TestWorkOSCallbackContinuesExistingMFAChallenge(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 5, 16, 18, 45, 0, 0, time.UTC)
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	workOS := &fakeWorkOSClient{
+		err: &sessionauth.WorkOSMFARequired{
+			Mode:                       sessionauth.WorkOSMFAModeChallenge,
+			PendingAuthenticationToken: "pending-token",
+			User: sessionauth.WorkOSProfile{
+				ID:            "user_workos_challenge",
+				Email:         "challenge@example.com",
+				EmailVerified: true,
+			},
+			AuthenticationFactors: []sessionauth.WorkOSMFAFactor{{ID: "auth_factor_existing", Type: "totp"}},
+		},
+		challengeResponse: sessionauth.WorkOSMFAChallengeResponse{
+			ChallengeID: "auth_challenge_existing",
+			FactorID:    "auth_factor_existing",
+			ExpiresAt:   "2026-05-16T19:30:00Z",
+		},
+		authentication: sessionauth.WorkOSAuthentication{
+			User: sessionauth.WorkOSProfile{
+				ID:            "user_workos_challenge",
+				Email:         "challenge@example.com",
+				EmailVerified: true,
+			},
+			AuthenticationMethod: "GitHubOAuth",
+		},
+	}
+	router := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{
+		FeatureNewAuth:     true,
+		FeatureWorkOSLogin: true,
+		PublicBaseURL:      "https://api.identrail.test",
+		CORSAllowedOrigins: []string{"https://app.identrail.test"},
+		SessionKey:         strings.Repeat("a", 64),
+		WorkOSClientID:     "client_123",
+		WorkOSAuthClient:   workOS,
+		RateLimitRPM:       1000,
+		RateLimitBurst:     1000,
+	})
+
+	startResp := httptest.NewRecorder()
+	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/login?provider=github_oauth&return_to=https%3A%2F%2Fapp.identrail.test%2Fapp", nil))
+	callbackResp := httptest.NewRecorder()
+	router.ServeHTTP(callbackResp, httptest.NewRequest(http.MethodGet, "/auth/callback?code=code-1&state="+url.QueryEscape(workOS.authorizationInput.State), nil))
+	pendingCookie := findTestCookie(callbackResp.Result().Cookies(), sessionauth.PendingMFACookieName)
+	if callbackResp.Code != http.StatusFound || pendingCookie == nil {
+		t.Fatalf("expected mfa redirect and cookie, code=%d cookies=%+v body=%s", callbackResp.Code, callbackResp.Result().Cookies(), callbackResp.Body.String())
+	}
+
+	challengeReq := httptest.NewRequest(http.MethodPost, "/auth/mfa/challenge", strings.NewReader(`{"factor_id":"auth_factor_existing"}`))
+	challengeReq.Header.Set("Content-Type", "application/json")
+	challengeReq.AddCookie(pendingCookie)
+	challengeResp := httptest.NewRecorder()
+	router.ServeHTTP(challengeResp, challengeReq)
+	if challengeResp.Code != http.StatusOK || !strings.Contains(challengeResp.Body.String(), `"challenge_started":true`) {
+		t.Fatalf("unexpected challenge response: code=%d body=%s", challengeResp.Code, challengeResp.Body.String())
+	}
+	updatedPendingCookie := findTestCookie(challengeResp.Result().Cookies(), sessionauth.PendingMFACookieName)
+	if updatedPendingCookie == nil || updatedPendingCookie.Value == "" {
+		t.Fatalf("expected refreshed pending mfa cookie, got %+v", challengeResp.Result().Cookies())
+	}
+
+	verifyReq := httptest.NewRequest(http.MethodPost, "/auth/mfa/verify", strings.NewReader(`{"code":"654321"}`))
+	verifyReq.Header.Set("Content-Type", "application/json")
+	verifyReq.AddCookie(updatedPendingCookie)
+	verifyResp := httptest.NewRecorder()
+	router.ServeHTTP(verifyResp, verifyReq)
+	if verifyResp.Code != http.StatusOK || !strings.Contains(verifyResp.Body.String(), `"redirect_to":"https://app.identrail.test/app"`) {
+		t.Fatalf("unexpected verify response: code=%d body=%s", verifyResp.Code, verifyResp.Body.String())
+	}
+	if workOS.verifyInput.PendingAuthenticationToken != "pending-token" || workOS.verifyInput.AuthenticationChallengeID != "auth_challenge_existing" || workOS.verifyInput.Code != "654321" {
+		t.Fatalf("unexpected verify input: %+v", workOS.verifyInput)
+	}
+}
+
+func TestWorkOSMFAChallengeRejectsBadFactorAndInvalidCode(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	workOS := &fakeWorkOSClient{
+		err: &sessionauth.WorkOSMFARequired{
+			Mode:                       sessionauth.WorkOSMFAModeChallenge,
+			PendingAuthenticationToken: "pending-token",
+			User:                       sessionauth.WorkOSProfile{ID: "user_workos_challenge", Email: "challenge@example.com", EmailVerified: true},
+			AuthenticationFactors:      []sessionauth.WorkOSMFAFactor{{ID: "auth_factor_existing", Type: "totp"}},
+		},
+		challengeResponse: sessionauth.WorkOSMFAChallengeResponse{ChallengeID: "auth_challenge_existing", FactorID: "auth_factor_existing"},
+		verifyErr:         errors.New("invalid code"),
+	}
+	router := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{
+		FeatureNewAuth:     true,
+		FeatureWorkOSLogin: true,
+		PublicBaseURL:      "https://api.identrail.test",
+		CORSAllowedOrigins: []string{"https://app.identrail.test"},
+		SessionKey:         strings.Repeat("a", 64),
+		WorkOSClientID:     "client_123",
+		WorkOSAuthClient:   workOS,
+		RateLimitRPM:       1000,
+		RateLimitBurst:     1000,
+	})
+
+	noCookieResp := httptest.NewRecorder()
+	router.ServeHTTP(noCookieResp, httptest.NewRequest(http.MethodGet, "/auth/mfa/pending", nil))
+	if noCookieResp.Code != http.StatusUnauthorized {
+		t.Fatalf("expected pending mfa without cookie to be unauthorized, got %d", noCookieResp.Code)
+	}
+
+	startResp := httptest.NewRecorder()
+	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/login?provider=github_oauth&return_to=https%3A%2F%2Fapp.identrail.test%2Fapp", nil))
+	callbackResp := httptest.NewRecorder()
+	router.ServeHTTP(callbackResp, httptest.NewRequest(http.MethodGet, "/auth/callback?code=code-1&state="+url.QueryEscape(workOS.authorizationInput.State), nil))
+	pendingCookie := findTestCookie(callbackResp.Result().Cookies(), sessionauth.PendingMFACookieName)
+	if pendingCookie == nil {
+		t.Fatalf("expected pending cookie, got %+v", callbackResp.Result().Cookies())
+	}
+
+	badChallengeReq := httptest.NewRequest(http.MethodPost, "/auth/mfa/challenge", strings.NewReader(`{"factor_id":"missing"}`))
+	badChallengeReq.Header.Set("Content-Type", "application/json")
+	badChallengeReq.AddCookie(pendingCookie)
+	badChallengeResp := httptest.NewRecorder()
+	router.ServeHTTP(badChallengeResp, badChallengeReq)
+	if badChallengeResp.Code != http.StatusBadRequest || !strings.Contains(badChallengeResp.Body.String(), "unsupported mfa factor") {
+		t.Fatalf("unexpected bad challenge response: code=%d body=%s", badChallengeResp.Code, badChallengeResp.Body.String())
+	}
+
+	challengeReq := httptest.NewRequest(http.MethodPost, "/auth/mfa/challenge", strings.NewReader(`{"factor_id":"auth_factor_existing"}`))
+	challengeReq.Header.Set("Content-Type", "application/json")
+	challengeReq.AddCookie(pendingCookie)
+	challengeResp := httptest.NewRecorder()
+	router.ServeHTTP(challengeResp, challengeReq)
+	updatedPendingCookie := findTestCookie(challengeResp.Result().Cookies(), sessionauth.PendingMFACookieName)
+	if challengeResp.Code != http.StatusOK || updatedPendingCookie == nil {
+		t.Fatalf("expected challenge to start, code=%d cookies=%+v body=%s", challengeResp.Code, challengeResp.Result().Cookies(), challengeResp.Body.String())
+	}
+
+	verifyReq := httptest.NewRequest(http.MethodPost, "/auth/mfa/verify", strings.NewReader(`{"code":"000000"}`))
+	verifyReq.Header.Set("Content-Type", "application/json")
+	verifyReq.AddCookie(updatedPendingCookie)
+	verifyResp := httptest.NewRecorder()
+	router.ServeHTTP(verifyResp, verifyReq)
+	if verifyResp.Code != http.StatusUnauthorized || !strings.Contains(verifyResp.Body.String(), "invalid verification code") {
+		t.Fatalf("unexpected invalid verify response: code=%d body=%s", verifyResp.Code, verifyResp.Body.String())
+	}
+}
+
 func findTestCookie(cookies []*http.Cookie, name string) *http.Cookie {
 	for _, cookie := range cookies {
 		if cookie.Name == name {
@@ -665,6 +813,133 @@ func findTestCookie(cookies []*http.Cookie, name string) *http.Cookie {
 		}
 	}
 	return nil
+}
+
+func sealedPendingMFACookie(t *testing.T, secret string, state sessionauth.WorkOSMFAPendingState) *http.Cookie {
+	t.Helper()
+	manager := sessionauth.NewMFAPendingStateManager(secret, nil)
+	value, err := manager.Seal(state)
+	if err != nil {
+		t.Fatalf("seal pending mfa state: %v", err)
+	}
+	return &http.Cookie{Name: sessionauth.PendingMFACookieName, Value: value}
+}
+
+func TestWorkOSMFAEndpointErrorBranches(t *testing.T) {
+	secret := strings.Repeat("a", 64)
+	svc := NewService(db.NewMemoryStore(), fakeScanner{}, "aws")
+	workOS := &fakeWorkOSClient{
+		enrollErr:    sessionauth.ErrWorkOSUnavailable,
+		challengeErr: errors.New("challenge provider failed"),
+		verifyErr:    sessionauth.ErrWorkOSUnavailable,
+	}
+	router := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{
+		FeatureNewAuth:     true,
+		FeatureWorkOSLogin: true,
+		PublicBaseURL:      "https://api.identrail.test",
+		CORSAllowedOrigins: []string{"https://app.identrail.test"},
+		SessionKey:         secret,
+		WorkOSClientID:     "client_123",
+		WorkOSAuthClient:   workOS,
+		RateLimitRPM:       1000,
+		RateLimitBurst:     1000,
+	})
+	postWithCookie := func(path string, body string, cookie *http.Cookie) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.AddCookie(cookie)
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+		return resp
+	}
+	baseState := sessionauth.WorkOSMFAPendingState{
+		ReturnTo:                   "https://app.identrail.test/app",
+		PendingAuthenticationToken: "pending-token",
+		User:                       sessionauth.WorkOSProfile{ID: "user_workos_mfa", Email: "mfa@example.com", EmailVerified: true},
+	}
+
+	existingEnrollment := baseState
+	existingEnrollment.Mode = sessionauth.WorkOSMFAModeEnrollment
+	existingEnrollment.ChallengeID = "auth_challenge_existing"
+	existingEnrollment.TOTP = &sessionauth.WorkOSPendingTOTP{FactorID: "auth_factor_existing", QRCode: "qr", Secret: "secret", URI: "otpauth://totp/Identrail:mfa@example.com"}
+	resp := postWithCookie("/auth/mfa/enroll", "", sealedPendingMFACookie(t, secret, existingEnrollment))
+	if resp.Code != http.StatusOK || !strings.Contains(resp.Body.String(), `"factor_id":"auth_factor_existing"`) {
+		t.Fatalf("expected cached enrollment response, got code=%d body=%s", resp.Code, resp.Body.String())
+	}
+
+	challengeState := baseState
+	challengeState.Mode = sessionauth.WorkOSMFAModeChallenge
+	challengeState.AuthenticationFactors = []sessionauth.WorkOSMFAFactor{{ID: "auth_factor_existing", Type: "totp"}}
+	resp = postWithCookie("/auth/mfa/enroll", "", sealedPendingMFACookie(t, secret, challengeState))
+	if resp.Code != http.StatusBadRequest || !strings.Contains(resp.Body.String(), "mfa enrollment is not pending") {
+		t.Fatalf("expected wrong-mode enrollment rejection, got code=%d body=%s", resp.Code, resp.Body.String())
+	}
+
+	missingUserEnrollment := baseState
+	missingUserEnrollment.Mode = sessionauth.WorkOSMFAModeEnrollment
+	missingUserEnrollment.User = sessionauth.WorkOSProfile{}
+	resp = postWithCookie("/auth/mfa/enroll", "", sealedPendingMFACookie(t, secret, missingUserEnrollment))
+	if resp.Code != http.StatusBadRequest || !strings.Contains(resp.Body.String(), "mfa enrollment cannot be started") {
+		t.Fatalf("expected missing-user enrollment rejection, got code=%d body=%s", resp.Code, resp.Body.String())
+	}
+
+	newEnrollment := baseState
+	newEnrollment.Mode = sessionauth.WorkOSMFAModeEnrollment
+	resp = postWithCookie("/auth/mfa/enroll", "", sealedPendingMFACookie(t, secret, newEnrollment))
+	if resp.Code != http.StatusServiceUnavailable || resp.Header().Get("Retry-After") == "" {
+		t.Fatalf("expected enrollment provider outage, got code=%d headers=%v body=%s", resp.Code, resp.Header(), resp.Body.String())
+	}
+
+	resp = postWithCookie("/auth/mfa/challenge", "{", sealedPendingMFACookie(t, secret, challengeState))
+	if resp.Code != http.StatusBadRequest || !strings.Contains(resp.Body.String(), "invalid challenge request") {
+		t.Fatalf("expected invalid challenge request, got code=%d body=%s", resp.Code, resp.Body.String())
+	}
+	resp = postWithCookie("/auth/mfa/challenge", `{"factor_id":"auth_factor_existing"}`, sealedPendingMFACookie(t, secret, challengeState))
+	if resp.Code != http.StatusBadGateway || !strings.Contains(resp.Body.String(), "mfa provider failed") {
+		t.Fatalf("expected challenge provider failure, got code=%d body=%s", resp.Code, resp.Body.String())
+	}
+
+	startedChallengeState := challengeState
+	startedChallengeState.ChallengeID = "auth_challenge_existing"
+	resp = postWithCookie("/auth/mfa/verify", `{"code":" "}`, sealedPendingMFACookie(t, secret, startedChallengeState))
+	if resp.Code != http.StatusBadRequest || !strings.Contains(resp.Body.String(), "verification code is required") {
+		t.Fatalf("expected empty verification rejection, got code=%d body=%s", resp.Code, resp.Body.String())
+	}
+	resp = postWithCookie("/auth/mfa/verify", `{"code":"123456"}`, sealedPendingMFACookie(t, secret, challengeState))
+	if resp.Code != http.StatusBadRequest || !strings.Contains(resp.Body.String(), "mfa challenge has not started") {
+		t.Fatalf("expected missing challenge rejection, got code=%d body=%s", resp.Code, resp.Body.String())
+	}
+	resp = postWithCookie("/auth/mfa/verify", `{"code":"123456"}`, sealedPendingMFACookie(t, secret, startedChallengeState))
+	if resp.Code != http.StatusServiceUnavailable || resp.Header().Get("Retry-After") == "" {
+		t.Fatalf("expected verify provider outage, got code=%d headers=%v body=%s", resp.Code, resp.Header(), resp.Body.String())
+	}
+}
+
+func TestWorkOSMFAHelperErrorPaths(t *testing.T) {
+	target := workOSMFARedirectURL("", "https://api.identrail.test", []string{"https://api.identrail.test", "https://app.identrail.test"})
+	if target != "https://app.identrail.test/auth/mfa?return_to=%2Fapp" {
+		t.Fatalf("unexpected fallback mfa redirect: %q", target)
+	}
+	if !workOSMFAFactorAllowed([]sessionauth.WorkOSMFAFactor{{ID: "factor-1", Type: "totp"}}, "factor-1") {
+		t.Fatal("expected totp factor to be allowed")
+	}
+	if workOSMFAFactorAllowed([]sessionauth.WorkOSMFAFactor{{ID: "factor-1", Type: "sms"}}, "factor-1") {
+		t.Fatal("expected non-totp factor to be rejected")
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	writeWorkOSMFAProviderError(c, zap.NewNop(), sessionauth.ErrWorkOSUnavailable, "provider")
+	if w.Code != http.StatusServiceUnavailable || w.Header().Get("Retry-After") == "" {
+		t.Fatalf("expected unavailable provider response, code=%d body=%s", w.Code, w.Body.String())
+	}
+
+	verifyW := httptest.NewRecorder()
+	verifyC, _ := gin.CreateTestContext(verifyW)
+	writeWorkOSMFAVerifyError(verifyC, zap.NewNop(), errors.New("invalid"))
+	if verifyW.Code != http.StatusUnauthorized || !strings.Contains(verifyW.Body.String(), "invalid verification code") {
+		t.Fatalf("expected invalid verification response, code=%d body=%s", verifyW.Code, verifyW.Body.String())
+	}
 }
 
 func TestWorkOSUserDeletedWebhookRevokesSessions(t *testing.T) {

--- a/internal/api/workos_auth_routes_test.go
+++ b/internal/api/workos_auth_routes_test.go
@@ -564,6 +564,7 @@ func TestWorkOSCallbackContinuesMFAEnrollment(t *testing.T) {
 	now := time.Date(2026, 5, 16, 18, 45, 0, 0, time.UTC)
 	svc := NewService(store, fakeScanner{}, "aws")
 	svc.Now = func() time.Time { return now }
+	sink := &recordingAuditSink{}
 	workOS := &fakeWorkOSClient{
 		err: &sessionauth.WorkOSMFARequired{
 			Mode:                       sessionauth.WorkOSMFAModeEnrollment,
@@ -588,6 +589,7 @@ func TestWorkOSCallbackContinuesMFAEnrollment(t *testing.T) {
 		FeatureWorkOSLogin: true,
 		PublicBaseURL:      "https://api.identrail.test",
 		CORSAllowedOrigins: []string{"https://app.identrail.test"},
+		AuditSink:          sink,
 		SessionKey:         strings.Repeat("a", 64),
 		WorkOSClientID:     "client_123",
 		WorkOSAuthClient:   workOS,
@@ -657,6 +659,13 @@ func TestWorkOSCallbackContinuesMFAEnrollment(t *testing.T) {
 	}
 	if _, err := store.GetUserIdentity(context.Background(), sessionauth.WorkOSProvider, "user_workos_mfa"); err != nil {
 		t.Fatalf("expected workos identity after mfa verify: %v", err)
+	}
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	for _, event := range sink.events {
+		if event.Action == "auth.login.failure" {
+			t.Fatalf("mfa continuation must not write denied login failure audit event: %+v", event)
+		}
 	}
 }
 

--- a/web/prerender-routes.ts
+++ b/web/prerender-routes.ts
@@ -19,6 +19,7 @@ export const PRERENDER_ROUTES = [
   '/demo',
   '/signin',
   '/signup',
+  '/auth/mfa',
   '/why-no-passwords',
   '/docs',
   '/faq',

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -20,6 +20,7 @@
   <url><loc>https://www.identrail.com/demo</loc></url>
   <url><loc>https://www.identrail.com/signin</loc></url>
   <url><loc>https://www.identrail.com/signup</loc></url>
+  <url><loc>https://www.identrail.com/auth/mfa</loc></url>
   <url><loc>https://www.identrail.com/why-no-passwords</loc></url>
   <url><loc>https://www.identrail.com/docs</loc></url>
   <url><loc>https://www.identrail.com/faq</loc></url>

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1047,6 +1047,53 @@ describe('App', () => {
     expect(window.location.search).toContain('reason=callback_error');
   });
 
+  it('completes a WorkOS MFA enrollment challenge before opening the app', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        okJSON({
+          mode: 'enrollment',
+          user_email: 'owner@example.com',
+          challenge_started: false,
+          factors: []
+        })
+      )
+      .mockResolvedValueOnce(
+        okJSON({
+          mode: 'enrollment',
+          user_email: 'owner@example.com',
+          challenge_started: true,
+          factors: [{ id: 'auth_factor_1', type: 'totp' }],
+          totp: {
+            factor_id: 'auth_factor_1',
+            qr_code: 'data:image/png;base64,qr',
+            secret: 'SECRET',
+            uri: 'otpauth://totp/Identrail:owner@example.com'
+          }
+        })
+      )
+      .mockResolvedValueOnce(okJSON({ ok: true, redirect_to: '/app/tenant-a/workspace-a' }))
+      .mockResolvedValueOnce(okJSON(currentMePayload('tenant-a', 'workspace-a')));
+    vi.stubGlobal('fetch', fetchMock);
+
+    setCurrentPath('/auth/mfa?return_to=%2Fapp');
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { level: 1, name: /Set up two-factor authentication/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Set up authenticator app/i }));
+
+    expect(await screen.findByAltText(/Authenticator QR code/i)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText(/Authentication code/i), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: /Verify and continue/i }));
+
+    expect(await screen.findByRole('heading', { level: 1, name: /Identrail Workspace/i })).toBeInTheDocument();
+    expect(window.location.pathname).toBe('/app/tenant-a/workspace-a');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:8080/auth/mfa/verify',
+      expect.objectContaining({ body: JSON.stringify({ code: '123456' }), credentials: 'include', method: 'POST' })
+    );
+  });
+
   it('lists account security sessions and revokes other browsers', async () => {
     const fetchMock = vi
       .fn()

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15,6 +15,7 @@ import { AccountSecurityPage } from './pages/AccountSecurityPage';
 import { AuthCallbackPage } from './pages/AuthCallbackPage';
 import { SignInPage } from './pages/SignInPage';
 import { SignUpPage } from './pages/SignUpPage';
+import { WorkOSMFAPage } from './pages/WorkOSMFAPage';
 import { WhyNoPasswordsPage } from './pages/WhyNoPasswordsPage';
 import { ConnectPage } from './pages/onboarding/ConnectPage';
 import { InvitePage } from './pages/onboarding/InvitePage';
@@ -3350,7 +3351,7 @@ export function RoutedSite() {
   const isProductShellRoute = location.pathname.startsWith('/app');
   const isOnboardingRoute = location.pathname.startsWith('/onboarding');
   const normalizedPath = location.pathname.replace(/\/+$/, '') || '/';
-  const isAuthChoiceRoute = normalizedPath === '/signin' || normalizedPath === '/signup';
+  const isAuthChoiceRoute = normalizedPath === '/signin' || normalizedPath === '/signup' || normalizedPath === '/auth/mfa';
 
   useEffect(() => {
     document.documentElement.dataset.theme = 'light';
@@ -3379,6 +3380,7 @@ export function RoutedSite() {
           <Route path="/signin" element={<SignInPage />} />
           <Route path="/signup" element={<SignUpPage />} />
           <Route path="/auth/callback" element={<AuthCallbackPage />} />
+          <Route path="/auth/mfa" element={<WorkOSMFAPage />} />
           <Route path="/why-no-passwords" element={<WhyNoPasswordsPage />} />
           <Route path="/app/login" element={<ProductLoginPage />} />
           <Route path="/app/callback" element={<ProductAuthCallbackRedirectPage />} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -252,6 +252,38 @@ export type ManualLoginResponse = {
   redirect_to: string;
 };
 
+export type WorkOSMFAFactor = {
+  id: string;
+  type: string;
+};
+
+export type WorkOSMFATOTP = {
+  factor_id: string;
+  qr_code: string;
+  secret: string;
+  uri: string;
+};
+
+export type WorkOSMFAPendingResponse = {
+  mode: 'enrollment' | 'challenge' | string;
+  user_email?: string;
+  challenge_started: boolean;
+  factors: WorkOSMFAFactor[];
+  totp?: WorkOSMFATOTP;
+  expires_at?: string;
+};
+
+export type WorkOSMFAChallengeResponse = {
+  challenge_started: boolean;
+  factor_id: string;
+  expires_at?: string;
+};
+
+export type WorkOSMFAVerifyResponse = {
+  ok: boolean;
+  redirect_to: string;
+};
+
 export type ProjectRecord = {
   tenant_id: string;
   workspace_id: string;
@@ -809,6 +841,31 @@ export const apiClient = {
     return request<ManualLoginResponse>('/auth/manual', undefined, {
       method: 'POST',
       body: JSON.stringify(payload),
+      redirectOnUnauthorized: false
+    });
+  },
+  getWorkOSMFAPending() {
+    return request<WorkOSMFAPendingResponse>('/auth/mfa/pending', undefined, {
+      redirectOnUnauthorized: false
+    });
+  },
+  enrollWorkOSMFA() {
+    return request<WorkOSMFAPendingResponse>('/auth/mfa/enroll', undefined, {
+      method: 'POST',
+      redirectOnUnauthorized: false
+    });
+  },
+  challengeWorkOSMFA(factorID: string) {
+    return request<WorkOSMFAChallengeResponse>('/auth/mfa/challenge', undefined, {
+      method: 'POST',
+      body: JSON.stringify({ factor_id: factorID }),
+      redirectOnUnauthorized: false
+    });
+  },
+  verifyWorkOSMFA(code: string) {
+    return request<WorkOSMFAVerifyResponse>('/auth/mfa/verify', undefined, {
+      method: 'POST',
+      body: JSON.stringify({ code }),
       redirectOnUnauthorized: false
     });
   },

--- a/web/src/pages/WorkOSMFAPage.test.ts
+++ b/web/src/pages/WorkOSMFAPage.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { ApiError } from '../api/client';
+import { mfaErrorMessage, normalizeCompletedSessionRedirect, normalizeReturnTo } from './WorkOSMFAPage';
+
+describe('WorkOSMFAPage helpers', () => {
+  it('normalizes return_to to same-origin app paths only', () => {
+    window.history.pushState({}, '', '/auth/mfa');
+    const origin = window.location.origin;
+
+    expect(normalizeReturnTo('/app/tenant-a/workspace-a?tab=scan#findings')).toBe(
+      '/app/tenant-a/workspace-a?tab=scan#findings'
+    );
+    expect(normalizeReturnTo(`${origin}/app/tenant-a`)).toBe('/app/tenant-a');
+    expect(normalizeReturnTo('https://evil.example/app/tenant-a')).toBe('/app');
+    expect(normalizeReturnTo('javascript:alert(1)')).toBe('/app');
+    expect(normalizeReturnTo('/signin')).toBe('/app');
+  });
+
+  it('keeps completed-session redirects same-origin', () => {
+    window.history.pushState({}, '', '/auth/mfa');
+    const origin = window.location.origin;
+
+    expect(normalizeCompletedSessionRedirect('/onboarding/org')).toBe('/onboarding/org');
+    expect(normalizeCompletedSessionRedirect(`${origin}/app`)).toBe('/app');
+    expect(normalizeCompletedSessionRedirect('https://evil.example/app')).toBe('/app');
+  });
+
+  it('preserves API verification errors instead of rewriting every unauthorized response', () => {
+    expect(mfaErrorMessage(new ApiError('invalid verification code', 401))).toBe('invalid verification code');
+    expect(mfaErrorMessage(new ApiError('mfa session expired', 401))).toBe(
+      'This verification session expired. Start sign-in again.'
+    );
+  });
+});

--- a/web/src/pages/WorkOSMFAPage.tsx
+++ b/web/src/pages/WorkOSMFAPage.tsx
@@ -1,0 +1,196 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { ApiError, apiClient, type WorkOSMFAPendingResponse } from '../api/client';
+
+function normalizeReturnTo(value: string | null): string {
+  const candidate = value?.trim() ?? '';
+  if (!candidate) {
+    return '/app';
+  }
+  try {
+    const parsed = new URL(candidate, window.location.origin);
+    if (parsed.origin === window.location.origin) {
+      return `${parsed.pathname}${parsed.search}${parsed.hash}` || '/app';
+    }
+    return parsed.toString();
+  } catch {
+    return '/app';
+  }
+}
+
+function redirectToCompletedSession(target: string, navigate: ReturnType<typeof useNavigate>) {
+  try {
+    const parsed = new URL(target, window.location.origin);
+    if (parsed.origin !== window.location.origin) {
+      window.location.assign(parsed.toString());
+      return;
+    }
+    navigate(`${parsed.pathname}${parsed.search}${parsed.hash}` || '/app', { replace: true });
+  } catch {
+    navigate('/app', { replace: true });
+  }
+}
+
+function mfaErrorMessage(error: unknown): string {
+  if (error instanceof ApiError && error.status === 401) {
+    return 'This verification session expired. Start sign-in again.';
+  }
+  return error instanceof Error ? error.message : 'Unable to continue verification.';
+}
+
+export function WorkOSMFAPage() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const query = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const returnTo = normalizeReturnTo(query.get('return_to'));
+  const [pending, setPending] = useState<WorkOSMFAPendingResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [code, setCode] = useState('');
+
+  useEffect(() => {
+    let mounted = true;
+    const run = async () => {
+      setLoading(true);
+      setError('');
+      try {
+        const response = await apiClient.getWorkOSMFAPending();
+        if (mounted) {
+          setPending(response);
+        }
+      } catch (loadError) {
+        if (mounted) {
+          setError(mfaErrorMessage(loadError));
+        }
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    };
+    void run();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const startEnrollment = async () => {
+    setBusy(true);
+    setError('');
+    try {
+      const response = await apiClient.enrollWorkOSMFA();
+      setPending(response);
+    } catch (enrollError) {
+      setError(mfaErrorMessage(enrollError));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const startChallenge = async (factorID: string) => {
+    setBusy(true);
+    setError('');
+    try {
+      await apiClient.challengeWorkOSMFA(factorID);
+      setPending((current) => (current ? { ...current, challenge_started: true } : current));
+    } catch (challengeError) {
+      setError(mfaErrorMessage(challengeError));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const submitCode = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setBusy(true);
+    setError('');
+    try {
+      const response = await apiClient.verifyWorkOSMFA(code);
+      redirectToCompletedSession(response.redirect_to || returnTo, navigate);
+    } catch (verifyError) {
+      setError(mfaErrorMessage(verifyError));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const isEnrollment = pending?.mode === 'enrollment';
+  const needsChallengeStart = pending?.mode === 'challenge' && !pending.challenge_started;
+  const canEnterCode = Boolean(pending?.challenge_started || pending?.totp);
+
+  return (
+    <section className="idt-auth-page idt-auth-page-login">
+      <div className="idt-auth-topbar">
+        <Link to="/" className="idt-auth-logo is-mark-only" aria-label="Identrail homepage">
+          <img src="/identrail-logo.png" alt="" />
+          <span>Identrail</span>
+        </Link>
+        <Link className="idt-auth-switch" to="/signin">
+          Sign In
+        </Link>
+      </div>
+
+      <article className="idt-auth-panel idt-auth-panel-login idt-auth-mfa-panel">
+        <h1>{isEnrollment ? 'Set up two-factor authentication' : 'Verify your sign-in'}</h1>
+        {pending?.user_email ? <p className="idt-auth-mfa-subtitle">{pending.user_email}</p> : null}
+        {error ? <p className="idt-app-alert idt-app-alert-error">{error}</p> : null}
+        {loading ? <p className="idt-auth-mfa-subtitle">Loading verification...</p> : null}
+
+        {!loading && pending && isEnrollment && !pending.totp ? (
+          <button className="idt-btn idt-btn-primary idt-auth-mfa-full" type="button" onClick={startEnrollment} disabled={busy}>
+            {busy ? 'Starting setup...' : 'Set up authenticator app'}
+          </button>
+        ) : null}
+
+        {!loading && pending?.totp ? (
+          <div className="idt-auth-mfa-setup">
+            <img className="idt-auth-mfa-qr" src={pending.totp.qr_code} alt="Authenticator QR code" />
+            {pending.totp.secret ? <code className="idt-auth-mfa-secret">{pending.totp.secret}</code> : null}
+          </div>
+        ) : null}
+
+        {!loading && pending && needsChallengeStart ? (
+          <div className="idt-auth-provider-stack">
+            {pending.factors
+              .filter((factor) => factor.type === 'totp')
+              .map((factor) => (
+                <button
+                  className="idt-auth-provider"
+                  key={factor.id}
+                  type="button"
+                  onClick={() => startChallenge(factor.id)}
+                  disabled={busy}
+                >
+                  Use authenticator app
+                </button>
+              ))}
+          </div>
+        ) : null}
+
+        {!loading && pending && canEnterCode ? (
+          <form className="idt-auth-manual-form idt-auth-mfa-form" onSubmit={submitCode}>
+            <label>
+              Authentication code
+              <input
+                autoComplete="one-time-code"
+                inputMode="numeric"
+                maxLength={10}
+                onChange={(event) => setCode(event.target.value)}
+                required
+                value={code}
+              />
+            </label>
+            <button className="idt-btn idt-btn-primary" type="submit" disabled={busy}>
+              {busy ? 'Verifying...' : 'Verify and continue'}
+            </button>
+          </form>
+        ) : null}
+
+        <p className="idt-auth-footer-line">
+          <Link to="/signin">Start sign-in again</Link>
+        </p>
+      </article>
+    </section>
+  );
+}

--- a/web/src/pages/WorkOSMFAPage.tsx
+++ b/web/src/pages/WorkOSMFAPage.tsx
@@ -2,37 +2,45 @@ import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { ApiError, apiClient, type WorkOSMFAPendingResponse } from '../api/client';
 
-function normalizeReturnTo(value: string | null): string {
-  const candidate = value?.trim() ?? '';
+function sameOriginPath(value: string | null | undefined, fallback: string, pathPrefix?: string): string {
+  const candidate = value?.trim();
   if (!candidate) {
-    return '/app';
+    return fallback;
   }
   try {
-    const parsed = new URL(candidate, window.location.origin);
-    if (parsed.origin === window.location.origin) {
-      return `${parsed.pathname}${parsed.search}${parsed.hash}` || '/app';
+    const parsed = new URL(candidate, `${window.location.origin}/`);
+    if (parsed.origin !== window.location.origin) {
+      return fallback;
     }
-    return parsed.toString();
+    if (pathPrefix && parsed.pathname !== pathPrefix && !parsed.pathname.startsWith(`${pathPrefix}/`)) {
+      return fallback;
+    }
+    return `${parsed.pathname}${parsed.search}${parsed.hash}` || fallback;
   } catch {
-    return '/app';
+    return fallback;
   }
+}
+
+export function normalizeReturnTo(value: string | null): string {
+  return sameOriginPath(value, '/app', '/app');
+}
+
+export function normalizeCompletedSessionRedirect(value: string | null | undefined): string {
+  return sameOriginPath(value, '/app');
 }
 
 function redirectToCompletedSession(target: string, navigate: ReturnType<typeof useNavigate>) {
-  try {
-    const parsed = new URL(target, window.location.origin);
-    if (parsed.origin !== window.location.origin) {
-      window.location.assign(parsed.toString());
-      return;
-    }
-    navigate(`${parsed.pathname}${parsed.search}${parsed.hash}` || '/app', { replace: true });
-  } catch {
-    navigate('/app', { replace: true });
-  }
+  navigate(normalizeCompletedSessionRedirect(target), { replace: true });
 }
 
-function mfaErrorMessage(error: unknown): string {
+export function mfaErrorMessage(error: unknown): string {
   if (error instanceof ApiError && error.status === 401) {
+    if (error.message && error.message !== `Request failed (${error.status})`) {
+      if (error.message === 'mfa session expired') {
+        return 'This verification session expired. Start sign-in again.';
+      }
+      return error.message;
+    }
     return 'This verification session expired. Start sign-in again.';
   }
   return error instanceof Error ? error.message : 'Unable to continue verification.';

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5017,6 +5017,62 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   padding: 0.65rem 0.8rem;
 }
 
+.idt-auth-mfa-panel {
+  width: min(100%, 25rem);
+}
+
+.idt-auth-mfa-subtitle {
+  margin: -0.45rem 0 0.35rem;
+  color: #525252;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  text-align: center;
+  overflow-wrap: anywhere;
+}
+
+.idt-auth-mfa-full {
+  width: 100%;
+}
+
+.idt-auth-mfa-setup {
+  display: grid;
+  gap: 0.75rem;
+  justify-items: center;
+}
+
+.idt-auth-mfa-qr {
+  width: 11rem;
+  height: 11rem;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  background: #ffffff;
+  object-fit: contain;
+}
+
+.idt-auth-mfa-secret {
+  width: 100%;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  padding: 0.7rem;
+  color: #171717;
+  background: #fafafa;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  text-align: center;
+  overflow-wrap: anywhere;
+}
+
+.idt-auth-mfa-form {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.idt-auth-mfa-form input {
+  text-align: center;
+  font-size: 1.18rem;
+  letter-spacing: 0;
+}
+
 .idt-dev-mode-banner {
   width: fit-content;
   margin: 0;


### PR DESCRIPTION
Fixes #1147

## What changed
- Detect WorkOS MFA enrollment/challenge responses during hosted callback instead of returning generic login failed JSON.
- Store the WorkOS pending-auth token in a short-lived encrypted HttpOnly cookie scoped to /auth/mfa, then complete login after TOTP verification.
- Add the app MFA page, API client methods, backend route coverage, frontend route coverage, docs, and changelog notes.

## Why
Production GitHub sign-in now reaches GitHub/WorkOS, but WorkOS is enforcing MFA enrollment for the user. Identrail needed to continue that flow instead of treating it as an unrecoverable provider error.

## Impact and risk
- Hosted GitHub/AuthKit users who hit WorkOS MFA requirements can enroll or complete an authenticator challenge and then land in the normal Identrail session path.
- The pending WorkOS token is not placed in URLs or frontend-readable storage, and MFA provider failures avoid logging token-bearing error strings.
- Risk is concentrated in hosted WorkOS auth routes and the new MFA page.

## Validation
- go test ./...
- go vet ./...
- npm test --prefix web -- --run
- npm run build --prefix web
- git diff --check

AI-assisted: yes
Tools used: OpenAI Codex
Where used: Auth route implementation, WorkOS wrapper updates, React MFA page, tests, docs
Human verification performed: Reviewed code paths and ran the validation commands above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables WorkOS MFA continuation for hosted sign‑in so users can enroll or verify TOTP and finish login instead of failing at the callback. Adds a secure, short‑lived pending‑auth cookie and strict same‑origin return_to handling for safe redirects.

- **New Features**
  - Detects MFA enrollment/challenge during `/auth/callback`, maps WorkOS MFA errors, and redirects to `/auth/mfa`.
  - Seals the WorkOS pending token in an encrypted HttpOnly cookie scoped to `/auth/mfa` with a 10‑minute TTL.
  - Backend routes: `GET /auth/mfa/pending`, `POST /auth/mfa/enroll`, `POST /auth/mfa/challenge`, `POST /auth/mfa/verify`; integrates WorkOS TOTP Enroll/Challenge/Authenticate.
  - Frontend: adds the `/auth/mfa` page with QR enrollment and code entry, plus API client methods; route is prerendered and added to the sitemap.
  - On success, creates the standard session, clears the MFA cookie, and redirects to a sanitized, same‑origin `return_to` (enforced in backend and page).
  - Error handling: 401 for invalid codes, 502 for provider failures, 503 with `Retry‑After` for outages; never include pending tokens in URLs, errors, or logs; includes tests and docs.

<sup>Written for commit f520997f56a6f8305ea7a65ab857336db3bef9e0. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1148?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

