### PR TITLE
Replace product shell scaffolds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Replaced the authenticated Overview and Settings scaffold routes with real product views:
+  - Overview now loads workspace projects, repository scans, open repository findings, and trend signals to show operating metrics, risk queue, scan activity, coverage, and next-action routing.
+  - Settings now loads live workspace identity, member access counts, current account role/scopes, authentication mode, providers, and links to the routes that manage each setting area.
 - Enabled Identrail Cloud self-serve onboarding deployment wiring:
   - production AWS API deploys now set `IDENTRAIL_FEATURE_ONBOARDING_WIZARD=true` by default alongside new auth, with `API_FEATURE_ONBOARDING_WIZARD=false` available as the explicit rollback knob
   - Vercel production deploys upsert `VITE_FEATURE_ONBOARDING_WIZARD` before building the web app, defaulting to `true` and honoring a repository variable override for rollback

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -271,10 +271,16 @@ describe('App', () => {
         return okJSON({
           items: [
             {
+              scan_id: 'repo-scan-0',
+              started_at: '2026-01-01T00:00:00Z',
+              total: 10,
+              by_severity: { critical: 1, high: 3, medium: 3, low: 2, info: 1 }
+            },
+            {
               scan_id: 'repo-scan-1',
               started_at: '2026-01-02T00:00:00Z',
-              total: 1,
-              by_severity: { critical: 0, high: 1, medium: 0, low: 0, info: 0 }
+              total: 4,
+              by_severity: { critical: 0, high: 1, medium: 2, low: 1, info: 0 }
             }
           ]
         });
@@ -313,6 +319,8 @@ describe('App', () => {
     expect(await screen.findByText(/Open risk/i)).toBeInTheDocument();
     expect(await screen.findByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
     expect(await screen.findByText(/Production GitHub/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Latest scan total 4/i)).toBeInTheDocument();
+    expect(await screen.findByText('-6')).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledWith(
       'http://localhost:8080/auth/manual',
       expect.objectContaining({ credentials: 'include' })

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -235,6 +235,23 @@ describe('App', () => {
         return okJSON(currentMePayload('tenant-a', 'workspace-a'));
       }
       if (url.includes('/v1/workspaces/workspace-a/projects')) {
+        if (url.includes('include_archived=true')) {
+          return okJSON({
+            items: [
+              {
+                tenant_id: 'tenant-a',
+                workspace_id: 'workspace-a',
+                project_id: 'legacy-project',
+                name: 'Legacy GitHub',
+                slug: 'legacy-github',
+                description: 'Archived repository coverage.',
+                archived_at: '2026-01-01T00:00:00Z',
+                created_at: '2025-12-01T00:00:00Z',
+                updated_at: '2026-01-01T00:00:00Z'
+              }
+            ]
+          });
+        }
         return okJSON({
           items: [
             {
@@ -320,8 +337,18 @@ describe('App', () => {
     expect(await screen.findByText(/Priority findings/i)).toBeInTheDocument();
     expect(await screen.findByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
     expect(await screen.findByText(/Production GitHub/i)).toBeInTheDocument();
+    expect(await screen.findByText(/1 archived/i)).toBeInTheDocument();
     expect(await screen.findByText(/Latest scan total 4/i)).toBeInTheDocument();
     expect(await screen.findByText('-6')).toBeInTheDocument();
+    expect(
+      fetchMock.mock.calls.some(([url]) => {
+        return (
+          typeof url === 'string' &&
+          url.includes('/v1/workspaces/workspace-a/projects') &&
+          url.includes('include_archived=false')
+        );
+      })
+    ).toBe(true);
     expect(
       fetchMock.mock.calls.some(([url]) => {
         return (

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -321,6 +321,16 @@ describe('App', () => {
     expect(await screen.findByText(/Production GitHub/i)).toBeInTheDocument();
     expect(await screen.findByText(/Latest scan total 4/i)).toBeInTheDocument();
     expect(await screen.findByText('-6')).toBeInTheDocument();
+    expect(
+      fetchMock.mock.calls.some(([url]) => {
+        return (
+          typeof url === 'string' &&
+          url.includes('/v1/repo-findings') &&
+          url.includes('sort_by=severity') &&
+          url.includes('sort_order=desc')
+        );
+      })
+    ).toBe(true);
     expect(fetchMock).toHaveBeenCalledWith(
       'http://localhost:8080/auth/manual',
       expect.objectContaining({ credentials: 'include' })

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -365,6 +365,59 @@ describe('App', () => {
     );
   });
 
+  it('keeps the overview trend delta neutral until two trend points exist', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/v1/me')) {
+        return okJSON(currentMePayload('tenant-a', 'workspace-a'));
+      }
+      if (url.includes('/v1/workspaces/workspace-a/projects')) {
+        return okJSON({
+          items: [
+            {
+              tenant_id: 'tenant-a',
+              workspace_id: 'workspace-a',
+              project_id: 'project-1',
+              name: 'Production GitHub',
+              slug: 'production-github',
+              description: 'Repositories that feed production identity risk.',
+              created_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-02T00:00:00Z'
+            }
+          ]
+        });
+      }
+      if (url.includes('/v1/repo-scans')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/repo-findings/trends')) {
+        return okJSON({
+          items: [
+            {
+              scan_id: 'repo-scan-1',
+              started_at: '2026-01-02T00:00:00Z',
+              total: 12,
+              by_severity: { critical: 1, high: 2, medium: 4, low: 4, info: 1 }
+            }
+          ]
+        });
+      }
+      if (url.includes('/v1/repo-findings')) {
+        return okJSON({ items: [] });
+      }
+      throw new Error(`Unexpected URL ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    setCurrentPath('/app/tenant-a/workspace-a');
+    render(<App />);
+
+    expect(await screen.findByText(/Trend delta/i)).toBeInTheDocument();
+    expect(await screen.findByText('N/A')).toBeInTheDocument();
+    expect(await screen.findByText(/Latest scan total 12; awaiting another scan/i)).toBeInTheDocument();
+    expect(screen.queryByText('+12')).not.toBeInTheDocument();
+  });
+
   it('hides manual workspace entry when auth config disables manual mode', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(authConfig(false, true)));
 

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -222,12 +222,84 @@ describe('App', () => {
     expect(window.location.search).toContain('return_to=%2Fapp%2Fdefault%2Fdefault');
   });
 
-  it('creates a dev manual cookie session and loads product shell placeholders', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(authConfig(true, false))
-      .mockResolvedValueOnce(okJSON({ ok: true, redirect_to: '/app/tenant-a/workspace-a' }))
-      .mockResolvedValueOnce(okJSON(currentMePayload('tenant-a', 'workspace-a')));
+  it('creates a dev manual cookie session and loads the product overview', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/v1/auth/config')) {
+        return authConfig(true, false);
+      }
+      if (url.endsWith('/auth/manual')) {
+        return okJSON({ ok: true, redirect_to: '/app/tenant-a/workspace-a' });
+      }
+      if (url.endsWith('/v1/me')) {
+        return okJSON(currentMePayload('tenant-a', 'workspace-a'));
+      }
+      if (url.includes('/v1/workspaces/workspace-a/projects')) {
+        return okJSON({
+          items: [
+            {
+              tenant_id: 'tenant-a',
+              workspace_id: 'workspace-a',
+              project_id: 'project-1',
+              name: 'Production GitHub',
+              slug: 'production-github',
+              description: 'Repositories that feed production identity risk.',
+              created_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-02T00:00:00Z'
+            }
+          ]
+        });
+      }
+      if (url.includes('/v1/repo-scans')) {
+        return okJSON({
+          items: [
+            {
+              id: 'repo-scan-1',
+              repository: 'owner/repo',
+              status: 'succeeded',
+              started_at: '2026-01-02T00:00:00Z',
+              finished_at: '2026-01-02T00:05:00Z',
+              commits_scanned: 12,
+              files_scanned: 4,
+              finding_count: 1,
+              truncated: false
+            }
+          ]
+        });
+      }
+      if (url.includes('/v1/repo-findings/trends')) {
+        return okJSON({
+          items: [
+            {
+              scan_id: 'repo-scan-1',
+              started_at: '2026-01-02T00:00:00Z',
+              total: 1,
+              by_severity: { critical: 0, high: 1, medium: 0, low: 0, info: 0 }
+            }
+          ]
+        });
+      }
+      if (url.includes('/v1/repo-findings')) {
+        return okJSON({
+          items: [
+            {
+              id: 'repo-f1',
+              scan_id: 'repo-scan-1',
+              type: 'secret_exposure',
+              severity: 'high',
+              title: 'Potential AWS access key exposed in commit history',
+              human_summary: 'A line added in commit history appears to contain an AWS access key identifier.',
+              repository: 'owner/repo',
+              file_path: 'config/app.env',
+              line_number: 7,
+              remediation: 'Rotate the key and move the credential to a secret manager.',
+              created_at: '2026-01-02T00:00:00Z'
+            }
+          ]
+        });
+      }
+      throw new Error(`Unexpected URL ${url}`);
+    });
     vi.stubGlobal('fetch', fetchMock);
 
     setCurrentPath('/signin');
@@ -238,7 +310,9 @@ describe('App', () => {
     fireEvent.click(screen.getByRole('button', { name: /Continue in dev mode/i }));
 
     expect(await screen.findByRole('heading', { level: 1, name: /Identrail Workspace/i })).toBeInTheDocument();
+    expect(await screen.findByText(/Open risk/i)).toBeInTheDocument();
     expect(await screen.findByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
+    expect(await screen.findByText(/Production GitHub/i)).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledWith(
       'http://localhost:8080/auth/manual',
       expect.objectContaining({ credentials: 'include' })
@@ -361,6 +435,89 @@ describe('App', () => {
     expect(openInGitHub).toHaveAttribute('href', 'https://github.com/owner/repo/blob/abc123/config/app.env#L7');
     expect((await screen.findAllByText('config/app.env:7')).length).toBeGreaterThan(0);
     expect((await screen.findAllByText('owner/repo')).length).toBeGreaterThan(0);
+  });
+
+  it('renders real workspace settings from account, member, and auth config APIs', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/v1/me')) {
+        return okJSON(currentMePayload('tenant-a', 'workspace-a', 'admin'));
+      }
+      if (url.endsWith('/v1/whoami')) {
+        return okJSON({
+          principal: { type: 'subject', id: 'user-1' },
+          roles: ['admin'],
+          scopes: ['tenancy.read', 'tenancy.write'],
+          scope: { tenant_id: 'tenant-a', workspace_id: 'workspace-a' },
+          active_workspace: {
+            workspace: {
+              tenant_id: 'tenant-a',
+              workspace_id: 'workspace-a',
+              display_name: 'Security Workspace',
+              slug: 'security-workspace',
+              created_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-03T00:00:00Z'
+            },
+            member: {
+              tenant_id: 'tenant-a',
+              workspace_id: 'workspace-a',
+              member_id: 'member-user-1',
+              user_id: 'user-1',
+              email: 'owner@example.com',
+              role: 'admin',
+              status: 'active',
+              joined_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-03T00:00:00Z'
+            },
+            is_active: true
+          },
+          workspaces: []
+        });
+      }
+      if (url.includes('/v1/workspaces/workspace-a/members')) {
+        return okJSON({
+          items: [
+            {
+              tenant_id: 'tenant-a',
+              workspace_id: 'workspace-a',
+              member_id: 'member-user-1',
+              user_id: 'user-1',
+              email: 'owner@example.com',
+              role: 'admin',
+              status: 'active',
+              joined_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-03T00:00:00Z'
+            },
+            {
+              tenant_id: 'tenant-a',
+              workspace_id: 'workspace-a',
+              member_id: 'member-analyst',
+              user_id: 'analyst',
+              email: 'analyst@example.com',
+              role: 'analyst',
+              status: 'invited',
+              joined_at: '2026-01-02T00:00:00Z',
+              updated_at: '2026-01-02T00:00:00Z'
+            }
+          ]
+        });
+      }
+      if (url.endsWith('/v1/auth/config')) {
+        return authConfig(false, true);
+      }
+      throw new Error(`Unexpected URL ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    setCurrentPath('/app/tenant-a/workspace-a/settings');
+    render(<App />);
+
+    expect(await screen.findByText(/Security Workspace/i)).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: /Settings/i })).toBeInTheDocument();
+    expect(await screen.findByText(/Hosted WorkOS login/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Total members/i)).toBeInTheDocument();
+    const accountSecurityLinks = await screen.findAllByRole('link', { name: /Account security/i });
+    expect(accountSecurityLinks.some((link) => link.getAttribute('href') === '/app/account/security')).toBe(true);
   });
 
   it('supports workspace member invite workflow from app shell administration route', async () => {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -317,6 +317,7 @@ describe('App', () => {
 
     expect(await screen.findByRole('heading', { level: 1, name: /Identrail Workspace/i })).toBeInTheDocument();
     expect(await screen.findByText(/Open risk/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Priority findings/i)).toBeInTheDocument();
     expect(await screen.findByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
     expect(await screen.findByText(/Production GitHub/i)).toBeInTheDocument();
     expect(await screen.findByText(/Latest scan total 4/i)).toBeInTheDocument();

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -3,6 +3,7 @@ import { Link, Navigate, NavLink, Outlet, useLocation, useNavigate, useParams } 
 import {
   ApiError,
   apiClient,
+  type AuthConfigResponse,
   type AWSConnectorStartResponse,
   type AWSConnectionStatus,
   type AWSPermissionPreviewItem,
@@ -44,13 +45,6 @@ type ScopeRouteParams = {
   tenantID?: string;
   workspaceID?: string;
   projectID?: string;
-};
-
-type ScopedShellPageProps = {
-  title: string;
-  description: string;
-  actionLabel?: string;
-  actionTo?: string;
 };
 
 type SourceProvider = 'github' | 'aws' | 'kubernetes';
@@ -150,6 +144,10 @@ const REPO_FINDING_SEVERITY_FILTERS = ['all', 'critical', 'high', 'medium', 'low
 const REPO_FINDING_TYPE_FILTERS = ['all', 'secret_exposure', 'repo_misconfiguration'] as const;
 const REPO_FINDING_SORT_FIELDS = ['severity', 'created_at', 'type', 'title'] as const;
 const REPO_FINDING_STATUS_FILTERS = ['all', 'open', 'ack', 'suppressed', 'resolved'] as const;
+const OVERVIEW_FINDING_LIMIT = 50;
+const OVERVIEW_RISK_DISPLAY_LIMIT = 8;
+const OVERVIEW_SCAN_LIMIT = 5;
+const OVERVIEW_PROJECT_LIMIT = 50;
 
 const SORT_LABEL_BY_FIELD: Record<(typeof REPO_FINDING_SORT_FIELDS)[number], string> = {
   severity: 'Risk (high → low)',
@@ -291,6 +289,34 @@ function repoFindingSeverityClass(severity: string): string {
   return `idt-repo-finding-severity is-${normalized}`;
 }
 
+function severityRank(severity: string): number {
+  const normalized = normalizeValue(severity).toLowerCase();
+  if (normalized === 'critical') return 5;
+  if (normalized === 'high') return 4;
+  if (normalized === 'medium') return 3;
+  if (normalized === 'low') return 2;
+  if (normalized === 'info') return 1;
+  return 0;
+}
+
+function isActiveScanStatus(status: string): boolean {
+  const normalized = normalizeValue(status).toLowerCase();
+  return normalized === 'queued' || normalized === 'running' || normalized === 'in_progress' || normalized === 'pending';
+}
+
+function isCompletedScanStatus(status: string): boolean {
+  const normalized = normalizeValue(status).toLowerCase();
+  return normalized === 'succeeded' || normalized === 'completed' || normalized === 'failed' || normalized === 'canceled';
+}
+
+function countMembersByStatus(members: WorkspaceMemberRecord[], status: WorkspaceMemberStatus): number {
+  return members.filter((member) => member.status === status).length;
+}
+
+function countMembersByRole(members: WorkspaceMemberRecord[], role: WorkspaceMemberRole): number {
+  return members.filter((member) => member.role === role).length;
+}
+
 function hasWorkspaceAdminAccess(scope: ProductSession, whoAmI: WhoAmIResponse | null): boolean {
   if (!whoAmI) {
     return false;
@@ -382,17 +408,6 @@ function parseGitHubRepositories(value: string): string[] {
       seen.add(entry);
       return true;
     });
-}
-
-function useScaffoldDataState(delayMS = 320) {
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const timer = window.setTimeout(() => setLoading(false), delayMS);
-    return () => window.clearTimeout(timer);
-  }, [delayMS]);
-
-  return loading;
 }
 
 function ProductErrorBoundary({ children }: { children: ReactNode }) {
@@ -803,43 +818,16 @@ export function ProductShellLayout() {
   );
 }
 
-function ScopedShellPage({ title, description, actionLabel, actionTo }: ScopedShellPageProps) {
-  const loading = useScaffoldDataState();
-
-  if (loading) {
-    return (
-      <section className="idt-app-panel" aria-busy="true" aria-live="polite">
-        <p className="idt-app-kicker">Loading</p>
-        <h2>{title}</h2>
-        <p>Fetching scoped data for this workspace route.</p>
-      </section>
-    );
-  }
-
-  return (
-    <section className="idt-app-panel">
-      <p className="idt-app-kicker">Scaffold</p>
-      <h2>{title}</h2>
-      <p>{description}</p>
-      <AppShellEmptyState
-        title="No data yet"
-        body="This placeholder is intentionally empty until backend wiring and feature-specific views are connected."
-      />
-      {actionLabel && actionTo ? (
-        <div className="idt-inline-actions">
-          <Link className="idt-btn idt-btn-primary" to={actionTo}>
-            {actionLabel}
-          </Link>
-        </div>
-      ) : null}
-    </section>
-  );
-}
-
 export function ProductOverviewPage() {
   const params = useParams<ScopeRouteParams>();
   const scope = resolveScopeFromParams(params);
   const [showTour, setShowTour] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [projects, setProjects] = useState<ProjectRecord[]>([]);
+  const [repoScans, setRepoScans] = useState<RepoScanRecord[]>([]);
+  const [repoFindings, setRepoFindings] = useState<ApiFinding[]>([]);
+  const [trendPoints, setTrendPoints] = useState<TrendPoint[]>([]);
 
   useEffect(() => {
     if (!FEATURE_ONBOARDING_WIZARD) {
@@ -865,6 +853,64 @@ export function ProductOverviewPage() {
     };
   }, []);
 
+  useEffect(() => {
+    if (!scope) {
+      setError('Choose a workspace before loading the overview.');
+      setLoading(false);
+      return;
+    }
+
+    let mounted = true;
+    const loadOverview = async () => {
+      setLoading(true);
+      setError('');
+      try {
+        const auth = buildProductAuthContext(scope);
+        const [projectResponse, scanResponse, findingResponse, trendResponse] = await Promise.all([
+          apiClient.listProjects(
+            scope.workspaceID,
+            {
+              limit: OVERVIEW_PROJECT_LIMIT,
+              sort_by: 'updated_at',
+              sort_order: 'desc',
+              include_archived: true
+            },
+            auth
+          ),
+          apiClient.listRepoScans({ limit: OVERVIEW_SCAN_LIMIT }, auth),
+          apiClient.listRepoFindings({ limit: OVERVIEW_FINDING_LIMIT, lifecycle_status: 'open' }, auth),
+          apiClient.getRepoFindingsTrends({ points: TREND_POINTS }, auth)
+        ]);
+        if (!mounted) {
+          return;
+        }
+        setProjects(projectResponse.items);
+        setRepoScans(scanResponse.items);
+        setRepoFindings(
+          findingResponse.items
+            .slice()
+            .sort((left, right) => severityRank(right.severity) - severityRank(left.severity))
+        );
+        setTrendPoints(trendResponse.items);
+      } catch (err) {
+        if (!mounted) {
+          return;
+        }
+        setError(err instanceof Error ? err.message : 'Unable to load workspace overview');
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void loadOverview();
+
+    return () => {
+      mounted = false;
+    };
+  }, [scope?.tenantID, scope?.workspaceID, scope?.projectID]);
+
   const dismissTour = async () => {
     setShowTour(false);
     try {
@@ -874,14 +920,210 @@ export function ProductOverviewPage() {
     }
   };
 
+  const activeProjects = projects.filter((project) => !project.archived_at);
+  const archivedProjects = projects.length - activeProjects.length;
+  const openFindingCount = repoFindings.filter((finding) => normalizeFindingStatus(finding.triage?.status) === 'open').length;
+  const urgentFindingCount = repoFindings.filter((finding) => {
+    const severity = normalizeValue(finding.severity).toLowerCase();
+    return severity === 'critical' || severity === 'high';
+  }).length;
+  const activeScanCount = repoScans.filter((scan) => isActiveScanStatus(scan.status)).length;
+  const completedScanCount = repoScans.filter((scan) => isCompletedScanStatus(scan.status)).length;
+  const latestTrend = trendPoints[0];
+  const previousTrend = trendPoints[1];
+  const trendDelta =
+    latestTrend && previousTrend ? latestTrend.total - previousTrend.total : latestTrend ? latestTrend.total : 0;
+  const projectsPath = scope ? buildProjectsPath(scope) : '/app';
+  const findingsPath = scope ? buildScopedPath(scope, 'findings') : '/app';
+  const workspacesPath = scope ? buildScopedPath(scope, 'workspaces') : '/app';
+
+  if (loading) {
+    return (
+      <section className="idt-app-panel" aria-busy="true" aria-live="polite">
+        <p className="idt-app-kicker">Workspace overview</p>
+        <h2>Overview</h2>
+        <p>Loading workspace activity, project coverage, scans, and open findings.</p>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section className="idt-app-panel idt-app-panel-error" role="alert">
+        <p className="idt-app-kicker">Workspace overview</p>
+        <h2>Overview</h2>
+        <p>{error}</p>
+      </section>
+    );
+  }
+
   return (
     <>
-      <ScopedShellPage
-        title="Overview"
-        description={`Choose a project for tenant ${scope?.tenantID ?? 'unknown'} and workspace ${scope?.workspaceID ?? 'unknown'} before connecting source telemetry.`}
-        actionLabel="Select project"
-        actionTo={scope ? buildProjectsPath(scope) : undefined}
-      />
+      <section className="idt-app-panel idt-overview-page">
+        <header className="idt-overview-header">
+          <div>
+            <p className="idt-app-kicker">Workspace overview</p>
+            <h2>Overview</h2>
+            <p>
+              Operating view for tenant <strong>{scope?.tenantID ?? 'unknown'}</strong> and workspace{' '}
+              <strong>{scope?.workspaceID ?? 'unknown'}</strong>.
+            </p>
+          </div>
+          <div className="idt-inline-actions">
+            <Link className="idt-btn idt-btn-primary" to={projectsPath}>
+              Manage projects
+            </Link>
+            <Link className="idt-btn idt-btn-ghost" to={findingsPath}>
+              Review findings
+            </Link>
+          </div>
+        </header>
+
+        <div className="idt-overview-metrics" aria-label="Workspace health metrics">
+          <article>
+            <span>Active projects</span>
+            <strong>{activeProjects.length}</strong>
+            <p>{archivedProjects > 0 ? `${archivedProjects} archived` : 'All listed projects are active'}</p>
+          </article>
+          <article>
+            <span>Open findings</span>
+            <strong>{openFindingCount}</strong>
+            <p>{urgentFindingCount} critical or high priority</p>
+          </article>
+          <article>
+            <span>Recent scans</span>
+            <strong>{repoScans.length}</strong>
+            <p>{activeScanCount > 0 ? `${activeScanCount} still running` : `${completedScanCount} completed`}</p>
+          </article>
+          <article>
+            <span>Trend delta</span>
+            <strong>{trendDelta > 0 ? `+${trendDelta}` : trendDelta}</strong>
+            <p>{latestTrend ? `Latest scan total ${latestTrend.total}` : 'No trend points yet'}</p>
+          </article>
+        </div>
+
+        <div className="idt-overview-grid">
+          <section className="idt-overview-card">
+            <div className="idt-overview-card-header">
+              <div>
+                <p className="idt-app-kicker">Priority queue</p>
+                <h3>Open risk</h3>
+              </div>
+              <Link to={findingsPath}>All findings</Link>
+            </div>
+            {repoFindings.length > 0 ? (
+              <div className="idt-overview-list">
+                {repoFindings.slice(0, OVERVIEW_RISK_DISPLAY_LIMIT).map((finding) => {
+                  const repository = canonicalGitHubRepositoryDisplay(finding.repository ?? '');
+                  return (
+                    <article key={`${finding.scan_id}:${finding.id}`} className="idt-overview-risk-row">
+                      <div>
+                        <strong>{finding.title}</strong>
+                        <p>
+                          {repository || 'Repository unavailable'} · {repoFindingLocationLabel(finding)}
+                        </p>
+                      </div>
+                      <span className={repoFindingSeverityClass(finding.severity)}>{formatTokenLabel(finding.severity)}</span>
+                    </article>
+                  );
+                })}
+              </div>
+            ) : (
+              <AppShellEmptyState
+                title="No open repository findings"
+                body="New repository scan findings will appear here with severity, repository, and line context."
+              />
+            )}
+          </section>
+
+          <section className="idt-overview-card">
+            <div className="idt-overview-card-header">
+              <div>
+                <p className="idt-app-kicker">Scan activity</p>
+                <h3>Recent scans</h3>
+              </div>
+              <Link to={findingsPath}>Open scans</Link>
+            </div>
+            {repoScans.length > 0 ? (
+              <div className="idt-overview-list">
+                {repoScans.map((scan) => (
+                  <article key={scan.id} className="idt-overview-scan-row">
+                    <div>
+                      <strong>{canonicalGitHubRepositoryDisplay(scan.repository) || scan.repository}</strong>
+                      <p>
+                        {scan.finding_count} findings · {scan.files_scanned} files · {formatDateLabel(scan.started_at)}
+                      </p>
+                    </div>
+                    <span className={`idt-source-status-pill is-${isActiveScanStatus(scan.status) ? 'warning' : scan.status === 'failed' ? 'error' : 'success'}`}>
+                      {formatTokenLabel(scan.status)}
+                    </span>
+                  </article>
+                ))}
+              </div>
+            ) : (
+              <AppShellEmptyState
+                title="No scans yet"
+                body="Connect a project source and run the first scan to populate repository activity."
+              />
+            )}
+          </section>
+        </div>
+
+        <div className="idt-overview-grid">
+          <section className="idt-overview-card">
+            <div className="idt-overview-card-header">
+              <div>
+                <p className="idt-app-kicker">Coverage</p>
+                <h3>Project coverage</h3>
+              </div>
+              <Link to={projectsPath}>Project settings</Link>
+            </div>
+            {activeProjects.length > 0 ? (
+              <div className="idt-overview-projects">
+                {activeProjects.slice(0, 6).map((project) => (
+                  <Link key={project.project_id} to={scope ? buildProjectPath(scope, project.project_id) : projectsPath}>
+                    <strong>{project.name}</strong>
+                    <span>{project.description || `Project ${project.project_id}`}</span>
+                    <small>Updated {formatDateLabel(project.updated_at)}</small>
+                  </Link>
+                ))}
+              </div>
+            ) : (
+              <AppShellEmptyState
+                title="No active projects"
+                body="Create the first project to connect source telemetry and scan policies for this workspace."
+              />
+            )}
+          </section>
+
+          <section className="idt-overview-card">
+            <div className="idt-overview-card-header">
+              <div>
+                <p className="idt-app-kicker">Next actions</p>
+                <h3>Make the workspace useful</h3>
+              </div>
+            </div>
+            <div className="idt-overview-actions">
+              <Link to={projectsPath}>
+                <strong>Create or select a project</strong>
+                <span>Define the scope that connectors and scan policies will attach to.</span>
+              </Link>
+              <Link to={scope?.projectID ? buildProjectPath(scope, scope.projectID) : projectsPath}>
+                <strong>Connect sources</strong>
+                <span>Attach GitHub, AWS, or Kubernetes telemetry to an active project.</span>
+              </Link>
+              <Link to={findingsPath}>
+                <strong>Triage open findings</strong>
+                <span>Review direct GitHub line links, severity, remediation, and workflow status.</span>
+              </Link>
+              <Link to={workspacesPath}>
+                <strong>Invite operators</strong>
+                <span>Give analysts and admins access to the workspace they operate.</span>
+              </Link>
+            </div>
+          </section>
+        </div>
+      </section>
       {showTour ? (
         <aside className="idt-onboarding-tour" aria-label="Onboarding tour">
           <div>
@@ -3709,5 +3951,245 @@ export function ProductFindingsPage() {
 }
 
 export function ProductSettingsPage() {
-  return <ScopedShellPage title="Settings" description="Tenant/workspace app settings, auth provider mapping, and shell preferences will render here." />;
+  const params = useParams<ScopeRouteParams>();
+  const scope = resolveScopeFromParams(params);
+  const { me } = useMe();
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [whoAmI, setWhoAmI] = useState<WhoAmIResponse | null>(null);
+  const [members, setMembers] = useState<WorkspaceMemberRecord[]>([]);
+  const [authConfig, setAuthConfig] = useState<AuthConfigResponse | null>(null);
+
+  useEffect(() => {
+    if (!scope) {
+      setError('Choose a workspace before loading settings.');
+      setLoading(false);
+      return;
+    }
+
+    let mounted = true;
+    const loadSettings = async () => {
+      setLoading(true);
+      setError('');
+      try {
+        const auth = buildProductAuthContext(scope);
+        const [whoAmIResponse, memberResponse, authConfigResponse] = await Promise.all([
+          apiClient.getWhoAmI(auth),
+          apiClient.listWorkspaceMembers(scope.workspaceID, { limit: 100 }, auth),
+          apiClient.getAuthConfig()
+        ]);
+        if (!mounted) {
+          return;
+        }
+        setWhoAmI(whoAmIResponse);
+        setMembers(memberResponse.items);
+        setAuthConfig(authConfigResponse);
+      } catch (err) {
+        if (!mounted) {
+          return;
+        }
+        setError(err instanceof Error ? err.message : 'Unable to load workspace settings');
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void loadSettings();
+
+    return () => {
+      mounted = false;
+    };
+  }, [scope?.tenantID, scope?.workspaceID, scope?.projectID]);
+
+  const activeWorkspace = whoAmI?.active_workspace?.workspace ?? me?.workspace;
+  const activeMember =
+    whoAmI?.active_workspace?.member ??
+    whoAmI?.workspaces?.find((item) => item.workspace.workspace_id === scope?.workspaceID)?.member;
+  const activeRole = activeMember?.role ?? me?.role ?? 'viewer';
+  const workspaceDisplayName = activeWorkspace?.display_name ?? scope?.workspaceID ?? 'Workspace';
+  const authProviders = authConfig?.auth.providers ?? [];
+  const authModeLabel = authConfig?.auth.workos_login_enabled
+    ? 'Hosted WorkOS login'
+    : authConfig?.auth.manual_mode
+      ? 'Manual development login'
+      : 'Session-only';
+  const projectsPath = scope ? buildProjectsPath(scope) : '/app';
+  const findingsPath = scope ? buildScopedPath(scope, 'findings') : '/app';
+  const workspacesPath = scope ? buildScopedPath(scope, 'workspaces') : '/app';
+
+  if (loading) {
+    return (
+      <section className="idt-app-panel" aria-busy="true" aria-live="polite">
+        <p className="idt-app-kicker">Workspace settings</p>
+        <h2>Settings</h2>
+        <p>Loading workspace identity, access, and authentication state.</p>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section className="idt-app-panel idt-app-panel-error" role="alert">
+        <p className="idt-app-kicker">Workspace settings</p>
+        <h2>Settings</h2>
+        <p>{error}</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="idt-app-panel idt-settings-page">
+      <header className="idt-settings-header">
+        <div>
+          <p className="idt-app-kicker">Workspace settings</p>
+          <h2>Settings</h2>
+          <p>
+            Review the live workspace, access model, authentication mode, and the real routes that manage this tenant.
+          </p>
+        </div>
+        <div className="idt-inline-actions">
+          <Link className="idt-btn idt-btn-primary" to={workspacesPath}>
+            Manage members
+          </Link>
+          <Link className="idt-btn idt-btn-ghost" to="/app/account/security">
+            Account security
+          </Link>
+        </div>
+      </header>
+
+      <div className="idt-settings-grid">
+        <section className="idt-settings-card">
+          <div>
+            <p className="idt-app-kicker">Workspace identity</p>
+            <h3>{workspaceDisplayName}</h3>
+          </div>
+          <dl className="idt-settings-facts">
+            <div>
+              <dt>Tenant</dt>
+              <dd>{scope?.tenantID ?? 'Unavailable'}</dd>
+            </div>
+            <div>
+              <dt>Workspace</dt>
+              <dd>{scope?.workspaceID ?? 'Unavailable'}</dd>
+            </div>
+            <div>
+              <dt>Project context</dt>
+              <dd>{scope?.projectID ?? me?.project_id ?? 'All projects'}</dd>
+            </div>
+            <div>
+              <dt>Updated</dt>
+              <dd>{activeWorkspace?.updated_at ? formatDateLabel(activeWorkspace.updated_at) : 'Unavailable'}</dd>
+            </div>
+          </dl>
+        </section>
+
+        <section className="idt-settings-card">
+          <div>
+            <p className="idt-app-kicker">Your access</p>
+            <h3>{formatTokenLabel(activeRole)}</h3>
+          </div>
+          <dl className="idt-settings-facts">
+            <div>
+              <dt>User</dt>
+              <dd>{me?.user.primary_email ?? whoAmI?.principal.id ?? 'Unavailable'}</dd>
+            </div>
+            <div>
+              <dt>Status</dt>
+              <dd>{me?.user.status ? formatTokenLabel(me.user.status) : 'Unavailable'}</dd>
+            </div>
+            <div>
+              <dt>Principal</dt>
+              <dd>{whoAmI ? `${formatTokenLabel(whoAmI.principal.type)} · ${whoAmI.principal.id}` : 'Unavailable'}</dd>
+            </div>
+            <div>
+              <dt>Scopes</dt>
+              <dd>{whoAmI?.scopes.length ? whoAmI.scopes.map(formatTokenLabel).join(', ') : 'None granted'}</dd>
+            </div>
+          </dl>
+        </section>
+      </div>
+
+      <div className="idt-settings-grid">
+        <section className="idt-settings-card">
+          <div className="idt-settings-card-header">
+            <div>
+              <p className="idt-app-kicker">Members</p>
+              <h3>Access model</h3>
+            </div>
+            <Link to={workspacesPath}>Open workspaces</Link>
+          </div>
+          <div className="idt-settings-counts">
+            <article>
+              <strong>{members.length}</strong>
+              <span>Total members</span>
+            </article>
+            <article>
+              <strong>{countMembersByStatus(members, 'active')}</strong>
+              <span>Active</span>
+            </article>
+            <article>
+              <strong>{countMembersByStatus(members, 'invited')}</strong>
+              <span>Invited</span>
+            </article>
+            <article>
+              <strong>{countMembersByRole(members, 'owner') + countMembersByRole(members, 'admin')}</strong>
+              <span>Admins</span>
+            </article>
+          </div>
+        </section>
+
+        <section className="idt-settings-card">
+          <div className="idt-settings-card-header">
+            <div>
+              <p className="idt-app-kicker">Authentication</p>
+              <h3>{authModeLabel}</h3>
+            </div>
+            <Link to="/app/account/security">Security</Link>
+          </div>
+          <dl className="idt-settings-facts">
+            <div>
+              <dt>Hosted login</dt>
+              <dd>{authConfig?.auth.workos_login_enabled ? 'Enabled' : 'Disabled'}</dd>
+            </div>
+            <div>
+              <dt>Manual mode</dt>
+              <dd>{authConfig?.auth.manual_mode ? 'Enabled' : 'Disabled'}</dd>
+            </div>
+            <div>
+              <dt>Providers</dt>
+              <dd>{authProviders.length ? authProviders.map(formatTokenLabel).join(', ') : 'None advertised'}</dd>
+            </div>
+          </dl>
+        </section>
+      </div>
+
+      <section className="idt-settings-card">
+        <div>
+          <p className="idt-app-kicker">Operating routes</p>
+          <h3>Where changes happen</h3>
+        </div>
+        <div className="idt-settings-route-grid">
+          <Link to={projectsPath}>
+            <strong>Projects and source setup</strong>
+            <span>Create projects, connect GitHub/AWS/Kubernetes, and manage scan policies.</span>
+          </Link>
+          <Link to={findingsPath}>
+            <strong>Findings workflow</strong>
+            <span>Inspect repository risk, open GitHub line links, and apply triage status.</span>
+          </Link>
+          <Link to={workspacesPath}>
+            <strong>Workspace members</strong>
+            <span>Invite users, adjust roles, suspend stale access, and switch active workspaces.</span>
+          </Link>
+          <Link to="/app/account/security">
+            <strong>Account sessions</strong>
+            <span>Review active sessions, revoke access, and sign out cleanly.</span>
+          </Link>
+        </div>
+      </section>
+    </section>
+  );
 }

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -994,9 +994,9 @@ export function ProductOverviewPage() {
             <p>{archivedProjects > 0 ? `${archivedProjects} archived` : 'All listed projects are active'}</p>
           </article>
           <article>
-            <span>Open findings</span>
+            <span>Priority findings</span>
             <strong>{openFindingCount}</strong>
-            <p>{urgentFindingCount} critical or high priority</p>
+            <p>{urgentFindingCount} critical or high in the ranked queue</p>
           </article>
           <article>
             <span>Recent scans</span>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -929,8 +929,8 @@ export function ProductOverviewPage() {
   }).length;
   const activeScanCount = repoScans.filter((scan) => isActiveScanStatus(scan.status)).length;
   const completedScanCount = repoScans.filter((scan) => isCompletedScanStatus(scan.status)).length;
-  const latestTrend = trendPoints[0];
-  const previousTrend = trendPoints[1];
+  const latestTrend = trendPoints[trendPoints.length - 1];
+  const previousTrend = trendPoints[trendPoints.length - 2];
   const trendDelta =
     latestTrend && previousTrend ? latestTrend.total - previousTrend.total : latestTrend ? latestTrend.total : 0;
   const projectsPath = scope ? buildProjectsPath(scope) : '/app';

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -147,7 +147,7 @@ const REPO_FINDING_STATUS_FILTERS = ['all', 'open', 'ack', 'suppressed', 'resolv
 const OVERVIEW_FINDING_LIMIT = 50;
 const OVERVIEW_RISK_DISPLAY_LIMIT = 8;
 const OVERVIEW_SCAN_LIMIT = 5;
-const OVERVIEW_PROJECT_LIMIT = 50;
+const OVERVIEW_PROJECT_PAGE_LIMIT = 100;
 
 const SORT_LABEL_BY_FIELD: Record<(typeof REPO_FINDING_SORT_FIELDS)[number], string> = {
   severity: 'Risk (high → low)',
@@ -157,6 +157,43 @@ const SORT_LABEL_BY_FIELD: Record<(typeof REPO_FINDING_SORT_FIELDS)[number], str
 };
 
 const TREND_POINTS = 10;
+async function listOverviewProjects(
+  workspaceID: string,
+  filters: { include_archived: boolean },
+  auth: RequestAuthContext
+): Promise<ProjectRecord[]> {
+  const items: ProjectRecord[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+
+  do {
+    const response = await apiClient.listProjects(
+      workspaceID,
+      {
+        limit: OVERVIEW_PROJECT_PAGE_LIMIT,
+        cursor,
+        sort_by: 'updated_at',
+        sort_order: 'desc',
+        include_archived: filters.include_archived
+      },
+      auth
+    );
+    items.push(...response.items);
+
+    const nextCursor = response.next_cursor?.trim();
+    if (!nextCursor) {
+      break;
+    }
+    if (seenCursors.has(nextCursor)) {
+      throw new Error('Project pagination returned a repeated cursor');
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  } while (cursor);
+
+  return items;
+}
+
 function formatConfidenceScore(value: number | undefined): string {
   if (!Number.isFinite(value ?? NaN)) {
     return 'N/A';
@@ -824,7 +861,8 @@ export function ProductOverviewPage() {
   const [showTour, setShowTour] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-  const [projects, setProjects] = useState<ProjectRecord[]>([]);
+  const [activeProjects, setActiveProjects] = useState<ProjectRecord[]>([]);
+  const [archivedProjectCount, setArchivedProjectCount] = useState(0);
   const [repoScans, setRepoScans] = useState<RepoScanRecord[]>([]);
   const [repoFindings, setRepoFindings] = useState<ApiFinding[]>([]);
   const [trendPoints, setTrendPoints] = useState<TrendPoint[]>([]);
@@ -866,17 +904,9 @@ export function ProductOverviewPage() {
       setError('');
       try {
         const auth = buildProductAuthContext(scope);
-        const [projectResponse, scanResponse, findingResponse, trendResponse] = await Promise.all([
-          apiClient.listProjects(
-            scope.workspaceID,
-            {
-              limit: OVERVIEW_PROJECT_LIMIT,
-              sort_by: 'updated_at',
-              sort_order: 'desc',
-              include_archived: true
-            },
-            auth
-          ),
+        const [allProjectItems, activeProjectItems, scanResponse, findingResponse, trendResponse] = await Promise.all([
+          listOverviewProjects(scope.workspaceID, { include_archived: true }, auth),
+          listOverviewProjects(scope.workspaceID, { include_archived: false }, auth),
           apiClient.listRepoScans({ limit: OVERVIEW_SCAN_LIMIT }, auth),
           apiClient.listRepoFindings(
             {
@@ -892,7 +922,12 @@ export function ProductOverviewPage() {
         if (!mounted) {
           return;
         }
-        setProjects(projectResponse.items);
+        setActiveProjects(
+          activeProjectItems
+            .slice()
+            .sort((left, right) => new Date(right.updated_at).getTime() - new Date(left.updated_at).getTime())
+        );
+        setArchivedProjectCount(allProjectItems.filter((project) => project.archived_at).length);
         setRepoScans(scanResponse.items);
         setRepoFindings(
           findingResponse.items
@@ -928,8 +963,6 @@ export function ProductOverviewPage() {
     }
   };
 
-  const activeProjects = projects.filter((project) => !project.archived_at);
-  const archivedProjects = projects.length - activeProjects.length;
   const openFindingCount = repoFindings.filter((finding) => normalizeFindingStatus(finding.triage?.status) === 'open').length;
   const urgentFindingCount = repoFindings.filter((finding) => {
     const severity = normalizeValue(finding.severity).toLowerCase();
@@ -991,7 +1024,7 @@ export function ProductOverviewPage() {
           <article>
             <span>Active projects</span>
             <strong>{activeProjects.length}</strong>
-            <p>{archivedProjects > 0 ? `${archivedProjects} archived` : 'All listed projects are active'}</p>
+            <p>{archivedProjectCount > 0 ? `${archivedProjectCount} archived` : 'All listed projects are active'}</p>
           </article>
           <article>
             <span>Priority findings</span>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -972,8 +972,7 @@ export function ProductOverviewPage() {
   const completedScanCount = repoScans.filter((scan) => isCompletedScanStatus(scan.status)).length;
   const latestTrend = trendPoints[trendPoints.length - 1];
   const previousTrend = trendPoints[trendPoints.length - 2];
-  const trendDelta =
-    latestTrend && previousTrend ? latestTrend.total - previousTrend.total : latestTrend ? latestTrend.total : 0;
+  const trendDelta = latestTrend && previousTrend ? latestTrend.total - previousTrend.total : null;
   const projectsPath = scope ? buildProjectsPath(scope) : '/app';
   const findingsPath = scope ? buildScopedPath(scope, 'findings') : '/app';
   const workspacesPath = scope ? buildScopedPath(scope, 'workspaces') : '/app';
@@ -1038,8 +1037,14 @@ export function ProductOverviewPage() {
           </article>
           <article>
             <span>Trend delta</span>
-            <strong>{trendDelta > 0 ? `+${trendDelta}` : trendDelta}</strong>
-            <p>{latestTrend ? `Latest scan total ${latestTrend.total}` : 'No trend points yet'}</p>
+            <strong>{trendDelta === null ? 'N/A' : trendDelta > 0 ? `+${trendDelta}` : trendDelta}</strong>
+            <p>
+              {latestTrend
+                ? previousTrend
+                  ? `Latest scan total ${latestTrend.total}`
+                  : `Latest scan total ${latestTrend.total}; awaiting another scan`
+                : 'No trend points yet'}
+            </p>
           </article>
         </div>
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -878,7 +878,15 @@ export function ProductOverviewPage() {
             auth
           ),
           apiClient.listRepoScans({ limit: OVERVIEW_SCAN_LIMIT }, auth),
-          apiClient.listRepoFindings({ limit: OVERVIEW_FINDING_LIMIT, lifecycle_status: 'open' }, auth),
+          apiClient.listRepoFindings(
+            {
+              limit: OVERVIEW_FINDING_LIMIT,
+              lifecycle_status: 'open',
+              sort_by: 'severity',
+              sort_order: 'desc'
+            },
+            auth
+          ),
           apiClient.getRepoFindingsTrends({ points: TREND_POINTS }, auth)
         ]);
         if (!mounted) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4304,6 +4304,214 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   color: #d7ffdf;
 }
 
+.idt-overview-page,
+.idt-settings-page {
+  display: grid;
+  gap: 1rem;
+}
+
+.idt-overview-header,
+.idt-settings-header,
+.idt-overview-card-header,
+.idt-settings-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.idt-overview-header h2,
+.idt-settings-header h2,
+.idt-overview-card h3,
+.idt-settings-card h3 {
+  margin-bottom: 0.4rem;
+}
+
+.idt-overview-header p,
+.idt-settings-header p,
+.idt-overview-card p,
+.idt-settings-card p {
+  margin: 0;
+  color: #c9d8ee;
+}
+
+.idt-overview-metrics,
+.idt-settings-counts {
+  display: grid;
+  gap: 0.7rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.idt-overview-metrics article,
+.idt-settings-counts article,
+.idt-overview-card,
+.idt-settings-card,
+.idt-overview-projects a,
+.idt-overview-actions a,
+.idt-settings-route-grid a,
+.idt-overview-risk-row,
+.idt-overview-scan-row {
+  border: 1px solid rgba(130, 160, 214, 0.28);
+  border-radius: 0.7rem;
+  background: rgba(8, 14, 25, 0.52);
+}
+
+.idt-overview-metrics article,
+.idt-settings-counts article,
+.idt-overview-risk-row,
+.idt-overview-scan-row {
+  padding: 0.75rem;
+}
+
+.idt-overview-metrics span,
+.idt-settings-counts span {
+  display: block;
+  color: #9fb8de;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.idt-overview-metrics strong,
+.idt-settings-counts strong {
+  display: block;
+  margin-top: 0.2rem;
+  color: #f2f7ff;
+  font-family: var(--idt-display);
+  font-size: 1.55rem;
+  line-height: 1.1;
+}
+
+.idt-overview-metrics p {
+  margin: 0.25rem 0 0;
+  color: #c2d4f0;
+}
+
+.idt-overview-grid,
+.idt-settings-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  align-items: start;
+}
+
+.idt-overview-card,
+.idt-settings-card {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1rem;
+}
+
+.idt-overview-card-header a,
+.idt-settings-card-header a {
+  color: #b8cef0;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.idt-overview-card-header a:hover,
+.idt-overview-card-header a:focus-visible,
+.idt-settings-card-header a:hover,
+.idt-settings-card-header a:focus-visible {
+  color: #e8f2ff;
+  text-decoration: underline;
+}
+
+.idt-overview-list {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.idt-overview-risk-row,
+.idt-overview-scan-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.idt-overview-risk-row strong,
+.idt-overview-scan-row strong,
+.idt-overview-projects strong,
+.idt-overview-actions strong,
+.idt-settings-route-grid strong {
+  color: #eef5ff;
+}
+
+.idt-overview-risk-row p,
+.idt-overview-scan-row p {
+  margin-top: 0.22rem;
+  color: #adc2e2;
+  font-size: 0.9rem;
+}
+
+.idt-overview-projects,
+.idt-overview-actions,
+.idt-settings-route-grid {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.idt-overview-projects a,
+.idt-overview-actions a,
+.idt-settings-route-grid a {
+  display: grid;
+  gap: 0.28rem;
+  padding: 0.8rem;
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.18s ease, background-color 0.18s ease, transform 0.18s ease;
+}
+
+.idt-overview-projects a:hover,
+.idt-overview-projects a:focus-visible,
+.idt-overview-actions a:hover,
+.idt-overview-actions a:focus-visible,
+.idt-settings-route-grid a:hover,
+.idt-settings-route-grid a:focus-visible {
+  border-color: rgba(184, 243, 214, 0.5);
+  background: rgba(15, 31, 39, 0.76);
+  transform: translateY(-1px);
+}
+
+.idt-overview-projects span,
+.idt-overview-actions span,
+.idt-settings-route-grid span,
+.idt-overview-projects small {
+  color: #adc2e2;
+  line-height: 1.45;
+}
+
+.idt-settings-facts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+  margin: 0;
+}
+
+.idt-settings-facts div {
+  border: 1px solid rgba(130, 160, 214, 0.24);
+  border-radius: 0.65rem;
+  padding: 0.65rem;
+  background: rgba(9, 15, 26, 0.64);
+  min-width: 0;
+}
+
+.idt-settings-facts dt {
+  color: #9fb8de;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.idt-settings-facts dd {
+  margin: 0.18rem 0 0;
+  color: #e1ebfb;
+  overflow-wrap: anywhere;
+}
+
 .idt-repo-findings-header {
   display: flex;
   justify-content: space-between;
@@ -5863,13 +6071,18 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   .idt-workspace-admin-grid,
   .idt-projects-summary,
   .idt-source-summary,
-  .idt-source-meta {
+  .idt-source-meta,
+  .idt-overview-metrics,
+  .idt-settings-counts,
+  .idt-settings-facts {
     grid-template-columns: 1fr 1fr;
   }
 
   .idt-workspace-member-toolbar,
   .idt-projects-grid,
-  .idt-source-wizard-grid {
+  .idt-source-wizard-grid,
+  .idt-overview-grid,
+  .idt-settings-grid {
     grid-template-columns: 1fr;
   }
 }
@@ -5924,7 +6137,10 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   .idt-source-summary,
   .idt-source-stepper,
   .idt-source-inline-fields,
-  .idt-source-meta {
+  .idt-source-meta,
+  .idt-overview-metrics,
+  .idt-settings-counts,
+  .idt-settings-facts {
     grid-template-columns: 1fr;
   }
 
@@ -5933,7 +6149,13 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   .idt-project-card-header,
   .idt-source-onboarding-header,
   .idt-source-config-header,
-  .idt-source-install-card {
+  .idt-source-install-card,
+  .idt-overview-header,
+  .idt-settings-header,
+  .idt-overview-card-header,
+  .idt-settings-card-header,
+  .idt-overview-risk-row,
+  .idt-overview-scan-row {
     display: grid;
   }
 }
@@ -5989,6 +6211,66 @@ html[data-theme='light'] .idt-app-alert-error {
 html[data-theme='light'] .idt-app-alert-success {
   border-color: rgba(44, 122, 70, 0.35);
   color: #1e5a31;
+}
+
+html[data-theme='light'] .idt-overview-header p,
+html[data-theme='light'] .idt-settings-header p,
+html[data-theme='light'] .idt-overview-card p,
+html[data-theme='light'] .idt-settings-card p,
+html[data-theme='light'] .idt-overview-metrics p,
+html[data-theme='light'] .idt-overview-risk-row p,
+html[data-theme='light'] .idt-overview-scan-row p,
+html[data-theme='light'] .idt-overview-projects span,
+html[data-theme='light'] .idt-overview-actions span,
+html[data-theme='light'] .idt-settings-route-grid span,
+html[data-theme='light'] .idt-overview-projects small {
+  color: #35598d;
+}
+
+html[data-theme='light'] .idt-overview-metrics article,
+html[data-theme='light'] .idt-settings-counts article,
+html[data-theme='light'] .idt-overview-card,
+html[data-theme='light'] .idt-settings-card,
+html[data-theme='light'] .idt-overview-projects a,
+html[data-theme='light'] .idt-overview-actions a,
+html[data-theme='light'] .idt-settings-route-grid a,
+html[data-theme='light'] .idt-overview-risk-row,
+html[data-theme='light'] .idt-overview-scan-row,
+html[data-theme='light'] .idt-settings-facts div {
+  background: rgba(245, 250, 255, 0.95);
+  border-color: rgba(42, 71, 119, 0.24);
+}
+
+html[data-theme='light'] .idt-overview-metrics span,
+html[data-theme='light'] .idt-settings-counts span,
+html[data-theme='light'] .idt-settings-facts dt {
+  color: #385f95;
+}
+
+html[data-theme='light'] .idt-overview-metrics strong,
+html[data-theme='light'] .idt-settings-counts strong,
+html[data-theme='light'] .idt-overview-risk-row strong,
+html[data-theme='light'] .idt-overview-scan-row strong,
+html[data-theme='light'] .idt-overview-projects strong,
+html[data-theme='light'] .idt-overview-actions strong,
+html[data-theme='light'] .idt-settings-route-grid strong,
+html[data-theme='light'] .idt-settings-facts dd {
+  color: #1c355d;
+}
+
+html[data-theme='light'] .idt-overview-card-header a,
+html[data-theme='light'] .idt-settings-card-header a {
+  color: #1f4f96;
+}
+
+html[data-theme='light'] .idt-overview-projects a:hover,
+html[data-theme='light'] .idt-overview-projects a:focus-visible,
+html[data-theme='light'] .idt-overview-actions a:hover,
+html[data-theme='light'] .idt-overview-actions a:focus-visible,
+html[data-theme='light'] .idt-settings-route-grid a:hover,
+html[data-theme='light'] .idt-settings-route-grid a:focus-visible {
+  background: rgba(224, 244, 235, 0.95);
+  border-color: rgba(33, 124, 83, 0.32);
 }
 
 html[data-theme='light'] .idt-repo-finding-stat,


### PR DESCRIPTION
## Summary

Replaces the authenticated product shell scaffolds for Overview and Settings with real workspace-backed product views.

## Why

Overview and Settings were still placeholder routes, which made the authenticated app feel unfinished after login. This gives operators useful SaaS surfaces immediately: a workspace operating dashboard and a settings/control-center view backed by existing APIs.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

Changes included:
- Overview now loads workspace projects, repository scans, open repository findings, and trend data to render metrics, risk queue, recent scan activity, project coverage, and next-action routing.
- Settings now loads current user context, whoami, workspace members, and auth config to render workspace identity, access counts, auth mode/providers, and links to the real management routes.
- Removes the old `ScopedShellPage` placeholder helper and updates app-route tests for the real views.
- Updates `CHANGELOG.md` for the user-facing product shell improvement.

Impact and risk:
- Impact: authenticated users get useful Overview and Settings screens instead of scaffolds.
- Risk: low-to-medium frontend risk; the pages call existing APIs only and preserve existing auth/session routing.
- Backward compatibility: no API contract changes and no route changes.

## Validation

```bash
npm ci --prefix web
npm run test --prefix web -- App.test.tsx
# 28 passed
npm run test:ci --prefix web
# 10 files passed, 87 tests passed
npm run build --prefix web
# built successfully and prerendered 41 routes
git diff --check
# passed
```

Manual browser smoke:
- Opened `http://127.0.0.1:5174/app/tenant-a/workspace-a` against a local mock API and verified Overview rendered the risk queue, scan activity, and project coverage.
- Opened `http://127.0.0.1:5174/app/tenant-a/workspace-a/settings` and verified Settings rendered workspace identity, hosted auth mode, and member counts.
- Captured no browser console errors during the smoke check.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: yes
- Tools used: OpenAI Codex
- Areas where used: product shell implementation, styles, tests, changelog, and validation workflow
- Human verification performed: reviewed the diff, ran focused and full web tests, ran production build, ran diff hygiene, and completed a local browser smoke check

## Related Issues

No issue: product shell polish from SaaS readiness audit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the Overview and Settings scaffolds with real, workspace-backed pages that load live data, add focused metrics and navigation, and keep APIs and auth/session flows unchanged. Removed `ScopedShellPage` and added responsive styles and tests.

- New Features
  - Overview loads active and archived projects separately (with pagination), shows an archived count, and fetches repository scans, open findings (sorted by severity), and trend points; renders metric cards, a prioritized risk list, recent scans, project coverage, and next steps.
  - Settings loads user context, whoami, members, and auth config; shows workspace identity, your role/scopes, member and admin/invite counts, auth mode/providers, and links to real management routes.
  - Added loading/error states and tests that verify project filters, severity sorting, and rendering for both pages.

- Bug Fixes
  - Trend delta now compares the latest two trend points and shows N/A when only one point exists.

<sup>Written for commit baab720d742cf9a5be198b8f6e557417afbfc3fd. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1150?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

