### PR TITLE
Add native SCIM provisioning endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## Unreleased
+- Added native SCIM 2.0 user provisioning endpoints (behind `IDENTRAIL_FEATURE_NATIVE_SSO`, with `IDENTRAIL_ENABLE_NATIVE_SSO` accepted as a compatibility alias):
+  - `GET /scim/v2/ServiceProviderConfig`, `/Schemas`, and `/ResourceTypes` return Okta/Azure-friendly discovery documents using SCIM-shaped responses
+  - `GET/POST/GET by id/PUT/PATCH/DELETE /scim/v2/Users` supports server-assigned ids, `filter=userName eq "..."`, pagination, full user replacement, PATCH `replace`, and deactivation/delete lifecycle handling
+  - Requests authenticate with the per-connection bearer token issued by the native SAML admin API; only active native SAML connections can provision users
+  - SCIM users persist through the existing `users` + `user_identities` model with provider `scim:<connection_uuid>`, and every create/update/deactivate/delete writes a `scim_provisioning_events` audit record
 - Added migration `000025_saml_relay_states_and_session_saml`:
   - New `saml_relay_states` table persists in-flight SP-initiated SAML AuthnRequest context (handle, connection_id FK, AuthnRequest id, return_to, intent, expires_at, consumed_at) so the matching ACS POST resolves correctly even when callbacks land on a different API instance than the one that issued the redirect
   - Widens the `sessions.auth_method` CHECK constraint to accept `'saml'` so SAML-issued sessions no longer trip a 23514 constraint violation

--- a/docs/auth/architecture.md
+++ b/docs/auth/architecture.md
@@ -235,6 +235,26 @@ This is the [Vercel pattern](https://vercel.com/docs/saml). It is the smallest p
 
 See [`identity-linking-rules.md`](./identity-linking-rules.md) for the rules around linking identities and joining orgs.
 
+## Native SCIM Provisioning
+
+Native SAML connections issue one per-connection SCIM bearer token when the admin creates the connection. The plaintext token is returned once; the database stores only the SHA-256 hash on `identity_connections.scim_bearer_token_hash`.
+
+When `IDENTRAIL_FEATURE_NATIVE_SSO=true` (or the compatibility alias `IDENTRAIL_ENABLE_NATIVE_SSO=true`) the API registers `/scim/v2` endpoints for IdP directory provisioning:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /scim/v2/ServiceProviderConfig` | SCIM capability discovery |
+| `GET /scim/v2/Schemas` | Core User schema discovery |
+| `GET /scim/v2/ResourceTypes` | User resource-type discovery |
+| `GET /scim/v2/Users` | List users with `startIndex`, `count`, and `filter=userName eq "..."` |
+| `POST /scim/v2/Users` | Create a user with a server-assigned SCIM id |
+| `GET /scim/v2/Users/{id}` | Read a provisioned user |
+| `PUT /scim/v2/Users/{id}` | Replace a provisioned user |
+| `PATCH /scim/v2/Users/{id}` | Apply SCIM PATCH `replace` operations |
+| `DELETE /scim/v2/Users/{id}` | Deactivate a provisioned user and record a delete event |
+
+SCIM resources reuse the auth tables instead of introducing a separate user store: `users.id` is the SCIM resource id, and `user_identities` stores `(provider="scim:<connection_uuid>", subject=<userName>)`. Each create, update, deactivate, and delete appends a `scim_provisioning_events` row for tenant-visible audit.
+
 ## Connector Foundation Preview
 
 Every connector (AWS, Kubernetes, GitHub, future ones) implements one Go interface and shares one status state machine and one error taxonomy. PR 6 ships this foundation; PRs 7, 8, 9 fill it in for the three providers.

--- a/docs/auth/env-vars-reference.md
+++ b/docs/auth/env-vars-reference.md
@@ -82,6 +82,8 @@ Feature flags follow the existing `IDENTRAIL_FEATURE_*` and `VITE_FEATURE_*` pat
 | `IDENTRAIL_FEATURE_CONNECTOR_GITHUB_V2` | `false` | PR 8 |
 | `IDENTRAIL_FEATURE_CONNECTOR_K8S` | `false` | PR 9 |
 | `IDENTRAIL_FEATURE_ONBOARDING_WIZARD` | `false` | PR 10 |
+| `IDENTRAIL_FEATURE_NATIVE_SSO` | `false` | PR 3 / PR 4 native SAML + SCIM |
+| `IDENTRAIL_ENABLE_NATIVE_SSO` | empty | Compatibility alias for `IDENTRAIL_FEATURE_NATIVE_SSO`; when set, it overrides the canonical flag. |
 | `IDENTRAIL_FEATURE_SSO_ADMIN` | `false` | PR 11 |
 | `IDENTRAIL_FEATURE_SCIM` | `false` | PR 12 |
 | `IDENTRAIL_FEATURE_ENTITLEMENTS` | `false` | PR 12 |

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -9,6 +9,7 @@ servers:
     description: Local development
 tags:
   - name: Health
+  - name: SCIM
   - name: Authorization
   - name: EnterpriseAuth
   - name: Tenancy
@@ -556,6 +557,197 @@ paths:
             text/plain:
               schema:
                 type: string
+  /scim/v2/ServiceProviderConfig:
+    get:
+      tags: [SCIM]
+      summary: SCIM service-provider configuration
+      operationId: getSCIMServiceProviderConfig
+      security:
+        - SCIMBearerAuth: []
+      responses:
+        "200":
+          description: SCIM service capabilities
+          content:
+            application/scim+json:
+              schema:
+                type: object
+        "401":
+          $ref: "#/components/responses/SCIMError"
+  /scim/v2/Schemas:
+    get:
+      tags: [SCIM]
+      summary: SCIM schemas
+      operationId: getSCIMSchemas
+      security:
+        - SCIMBearerAuth: []
+      responses:
+        "200":
+          description: SCIM schema list response
+          content:
+            application/scim+json:
+              schema:
+                type: object
+        "401":
+          $ref: "#/components/responses/SCIMError"
+  /scim/v2/ResourceTypes:
+    get:
+      tags: [SCIM]
+      summary: SCIM resource types
+      operationId: getSCIMResourceTypes
+      security:
+        - SCIMBearerAuth: []
+      responses:
+        "200":
+          description: SCIM resource-type list response
+          content:
+            application/scim+json:
+              schema:
+                type: object
+        "401":
+          $ref: "#/components/responses/SCIMError"
+  /scim/v2/Users:
+    get:
+      tags: [SCIM]
+      summary: List SCIM users
+      operationId: listSCIMUsers
+      security:
+        - SCIMBearerAuth: []
+      parameters:
+        - in: query
+          name: filter
+          required: false
+          schema: { type: string }
+          description: Supports `userName eq "value"`.
+        - in: query
+          name: startIndex
+          required: false
+          schema: { type: integer, minimum: 1, default: 1 }
+        - in: query
+          name: count
+          required: false
+          schema: { type: integer, minimum: 1, maximum: 500, default: 100 }
+      responses:
+        "200":
+          description: SCIM user list
+          content:
+            application/scim+json:
+              schema:
+                $ref: "#/components/schemas/SCIMUserListResponse"
+        "400":
+          $ref: "#/components/responses/SCIMError"
+        "401":
+          $ref: "#/components/responses/SCIMError"
+    post:
+      tags: [SCIM]
+      summary: Create a SCIM user
+      operationId: createSCIMUser
+      security:
+        - SCIMBearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/scim+json:
+            schema:
+              $ref: "#/components/schemas/SCIMUser"
+      responses:
+        "201":
+          description: Created SCIM user
+          content:
+            application/scim+json:
+              schema:
+                $ref: "#/components/schemas/SCIMUser"
+        "400":
+          $ref: "#/components/responses/SCIMError"
+        "401":
+          $ref: "#/components/responses/SCIMError"
+        "409":
+          $ref: "#/components/responses/SCIMError"
+  /scim/v2/Users/{id}:
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema: { type: string, format: uuid }
+    get:
+      tags: [SCIM]
+      summary: Get a SCIM user
+      operationId: getSCIMUser
+      security:
+        - SCIMBearerAuth: []
+      responses:
+        "200":
+          description: SCIM user
+          content:
+            application/scim+json:
+              schema:
+                $ref: "#/components/schemas/SCIMUser"
+        "401":
+          $ref: "#/components/responses/SCIMError"
+        "404":
+          $ref: "#/components/responses/SCIMError"
+    put:
+      tags: [SCIM]
+      summary: Replace a SCIM user
+      operationId: putSCIMUser
+      security:
+        - SCIMBearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/scim+json:
+            schema:
+              $ref: "#/components/schemas/SCIMUser"
+      responses:
+        "200":
+          description: Updated SCIM user
+          content:
+            application/scim+json:
+              schema:
+                $ref: "#/components/schemas/SCIMUser"
+        "400":
+          $ref: "#/components/responses/SCIMError"
+        "401":
+          $ref: "#/components/responses/SCIMError"
+        "404":
+          $ref: "#/components/responses/SCIMError"
+    patch:
+      tags: [SCIM]
+      summary: Patch a SCIM user
+      operationId: patchSCIMUser
+      security:
+        - SCIMBearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/scim+json:
+            schema:
+              $ref: "#/components/schemas/SCIMPatchRequest"
+      responses:
+        "200":
+          description: Patched SCIM user
+          content:
+            application/scim+json:
+              schema:
+                $ref: "#/components/schemas/SCIMUser"
+        "400":
+          $ref: "#/components/responses/SCIMError"
+        "401":
+          $ref: "#/components/responses/SCIMError"
+        "404":
+          $ref: "#/components/responses/SCIMError"
+    delete:
+      tags: [SCIM]
+      summary: Deactivate a SCIM user
+      operationId: deleteSCIMUser
+      security:
+        - SCIMBearerAuth: []
+      responses:
+        "204":
+          description: SCIM user deactivated
+        "401":
+          $ref: "#/components/responses/SCIMError"
+        "404":
+          $ref: "#/components/responses/SCIMError"
   /auth/logout:
     post:
       tags: [Authorization]
@@ -3442,6 +3634,10 @@ components:
       in: header
       name: WorkOS-Signature
       description: WorkOS HMAC SHA-256 signature of the raw webhook request body.
+    SCIMBearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: per-connection SCIM token
   parameters:
     scopeTenantID:
       in: header
@@ -3546,6 +3742,12 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
+    SCIMError:
+      description: SCIM error response
+      content:
+        application/scim+json:
+          schema:
+            $ref: "#/components/schemas/SCIMError"
   schemas:
     ServiceStatusResponse:
       type: object
@@ -3560,6 +3762,108 @@ components:
       properties:
         error:
           type: string
+    SCIMError:
+      type: object
+      required: [schemas, status, detail]
+      properties:
+        schemas:
+          type: array
+          items: { type: string }
+        status:
+          type: string
+        scimType:
+          type: string
+        detail:
+          type: string
+    SCIMEmail:
+      type: object
+      properties:
+        value:
+          type: string
+          format: email
+        type:
+          type: string
+        primary:
+          type: boolean
+    SCIMMeta:
+      type: object
+      properties:
+        resourceType:
+          type: string
+        created:
+          type: string
+          format: date-time
+        lastModified:
+          type: string
+          format: date-time
+        location:
+          type: string
+        version:
+          type: string
+    SCIMUser:
+      type: object
+      required: [userName, emails]
+      properties:
+        schemas:
+          type: array
+          items: { type: string }
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        externalId:
+          type: string
+        userName:
+          type: string
+        displayName:
+          type: string
+        active:
+          type: boolean
+        emails:
+          type: array
+          items:
+            $ref: "#/components/schemas/SCIMEmail"
+        groups:
+          type: array
+          items: { type: string }
+        meta:
+          $ref: "#/components/schemas/SCIMMeta"
+    SCIMUserListResponse:
+      type: object
+      required: [schemas, totalResults, Resources, startIndex, itemsPerPage]
+      properties:
+        schemas:
+          type: array
+          items: { type: string }
+        totalResults:
+          type: integer
+        Resources:
+          type: array
+          items:
+            $ref: "#/components/schemas/SCIMUser"
+        startIndex:
+          type: integer
+        itemsPerPage:
+          type: integer
+    SCIMPatchRequest:
+      type: object
+      required: [Operations]
+      properties:
+        schemas:
+          type: array
+          items: { type: string }
+        Operations:
+          type: array
+          items:
+            type: object
+            required: [op]
+            properties:
+              op:
+                type: string
+                enum: [replace]
+              path:
+                type: string
+              value: {}
     CreateInvitationRequest:
       type: object
       properties:

--- a/internal/api/enterprise_saml_acs_test.go
+++ b/internal/api/enterprise_saml_acs_test.go
@@ -768,7 +768,7 @@ func TestUpsertSAMLAssertedUser_AttachesFromSCIMIdentity(t *testing.T) {
 	if _, err := store.UpsertUserIdentity(ctx, db.UserIdentity{
 		UserID:   user.ID,
 		Provider: "scim:conn-scim",
-		Subject:  "scim-nameid",
+		Subject:  "opaque-scim-username",
 		Email:    "scim@example.com",
 	}); err != nil {
 		t.Fatalf("seed scim identity: %v", err)
@@ -799,7 +799,7 @@ func TestUpsertSAMLAssertedUser_AttachesFromSCIMIdentity(t *testing.T) {
 		Provider:               "saml",
 		JITProvisioningEnabled: false,
 	}, SAMLAssertedProfile{
-		NameID:      "scim-nameid",
+		NameID:      "saml-nameid",
 		Email:       "scim@example.com",
 		DisplayName: "Attached User",
 	})
@@ -812,11 +812,57 @@ func TestUpsertSAMLAssertedUser_AttachesFromSCIMIdentity(t *testing.T) {
 	if result.User.ID != user.ID {
 		t.Fatalf("attached wrong user: got %q want %q", result.User.ID, user.ID)
 	}
-	if result.Identity.Provider != "saml:conn-scim" || result.Identity.Subject != "scim-nameid" {
+	if result.Identity.Provider != "saml:conn-scim" || result.Identity.Subject != "saml-nameid" {
 		t.Fatalf("unexpected attached identity: %+v", result.Identity)
 	}
 	if result.RedirectPath != "/app/tenant-scim/workspace-scim" {
 		t.Fatalf("unexpected redirect path: %q", result.RedirectPath)
+	}
+}
+
+func TestUpsertSAMLAssertedUser_RejectsDeactivatedSCIMUser(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+	ctx := context.Background()
+	user, err := store.UpsertUser(ctx, db.User{
+		PrimaryEmail: "disabled@example.com",
+		DisplayName:  "Disabled User",
+		Status:       "deactivated",
+	})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	if _, err := store.UpsertUserIdentity(ctx, db.UserIdentity{
+		UserID:   user.ID,
+		Provider: "scim:conn-disabled",
+		Subject:  "disabled-nameid",
+		Email:    "disabled@example.com",
+	}); err != nil {
+		t.Fatalf("seed scim identity: %v", err)
+	}
+
+	_, err = svc.UpsertSAMLAssertedUser(ctx, db.IdentityConnection{
+		ID:                     "conn-disabled",
+		OrgID:                  "tenant-disabled",
+		Provider:               "saml",
+		JITProvisioningEnabled: false,
+	}, SAMLAssertedProfile{
+		NameID:      "disabled-nameid",
+		Email:       "disabled@example.com",
+		DisplayName: "Disabled User",
+	})
+	if !errors.Is(err, ErrSAMLUnprovisionedUser) {
+		t.Fatalf("expected deactivated SCIM user to be denied, got %v", err)
+	}
+	if _, err := store.GetUserIdentity(ctx, "saml:conn-disabled", "disabled-nameid"); !errors.Is(err, db.ErrNotFound) {
+		t.Fatalf("deactivated user should not receive a SAML identity, got %v", err)
+	}
+	gotUser, err := store.GetUser(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if gotUser.Status != "deactivated" {
+		t.Fatalf("deactivated user should not be reactivated: %+v", gotUser)
 	}
 }
 

--- a/internal/api/enterprise_saml_metadata.go
+++ b/internal/api/enterprise_saml_metadata.go
@@ -446,7 +446,10 @@ func NewSCIMBearerToken() (plain string, hash string, err error) {
 		return "", "", fmt.Errorf("read random bytes for scim token: %w", err)
 	}
 	plain = "idntr_scim_" + base64.RawURLEncoding.EncodeToString(buf)
-	sum := sha256.Sum256([]byte(plain))
-	hash = hex.EncodeToString(sum[:])
-	return plain, hash, nil
+	return plain, HashSCIMBearerToken(plain), nil
+}
+
+func HashSCIMBearerToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
 }

--- a/internal/api/enterprise_scim_routes.go
+++ b/internal/api/enterprise_scim_routes.go
@@ -1,0 +1,719 @@
+package api
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
+	"github.com/google/uuid"
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/enterprise"
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+const (
+	scimContentType                 = "application/scim+json"
+	scimCoreUserSchema              = "urn:ietf:params:scim:schemas:core:2.0:User"
+	scimListResponseSchema          = "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+	scimErrorSchema                 = "urn:ietf:params:scim:api:messages:2.0:Error"
+	scimPatchOpSchema               = "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+	scimServiceProviderConfigSchema = "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"
+	scimDefaultListLimit            = 100
+	scimMaxListLimit                = 500
+)
+
+var scimUserNameFilterRE = regexp.MustCompile(`(?i)^\s*userName\s+eq\s+"([^"]+)"\s*$`)
+
+type enterpriseSCIMRouteOptions struct {
+	Enabled       bool
+	PublicBaseURL string
+}
+
+type scimAuthContext struct {
+	Connection db.IdentityConnection
+	Provider   string
+}
+
+type scimUserResponse struct {
+	Schemas []string `json:"schemas"`
+	enterprise.SCIMUser
+}
+
+type scimListResponse struct {
+	Schemas      []string           `json:"schemas"`
+	TotalResults int                `json:"totalResults"`
+	Resources    []scimUserResponse `json:"Resources"`
+	StartIndex   int                `json:"startIndex"`
+	ItemsPerPage int                `json:"itemsPerPage"`
+}
+
+type scimPatchRequest struct {
+	Schemas    []string             `json:"schemas,omitempty"`
+	Operations []scimPatchOperation `json:"Operations"`
+}
+
+type scimPatchOperation struct {
+	Op    string          `json:"op"`
+	Path  string          `json:"path,omitempty"`
+	Value json.RawMessage `json:"value,omitempty"`
+}
+
+func registerEnterpriseSCIMRoutes(r *gin.Engine, logger *zap.Logger, svc *Service, opts enterpriseSCIMRouteOptions) {
+	if !opts.Enabled {
+		return
+	}
+	scim := r.Group("/scim/v2")
+	scim.Use(jsonBodyLimitMiddleware(defaultJSONBodyLimit))
+	scim.Use(scimAuthMiddleware(logger, svc))
+	scim.GET("/ServiceProviderConfig", getSCIMServiceProviderConfig)
+	scim.GET("/Schemas", getSCIMSchemas)
+	scim.GET("/ResourceTypes", getSCIMResourceTypes)
+	scim.GET("/Users", listSCIMUsers(logger, svc, opts.PublicBaseURL))
+	scim.POST("/Users", createSCIMUser(logger, svc, opts.PublicBaseURL))
+	scim.GET("/Users/:id", getSCIMUser(logger, svc, opts.PublicBaseURL))
+	scim.PUT("/Users/:id", putSCIMUser(logger, svc, opts.PublicBaseURL))
+	scim.PATCH("/Users/:id", patchSCIMUser(logger, svc, opts.PublicBaseURL))
+	scim.DELETE("/Users/:id", deleteSCIMUser(logger, svc, opts.PublicBaseURL))
+}
+
+func scimAuthMiddleware(logger *zap.Logger, svc *Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if svc == nil || svc.Store == nil {
+			writeSCIMError(c, http.StatusServiceUnavailable, "", "SCIM service is unavailable")
+			c.Abort()
+			return
+		}
+		auth := strings.TrimSpace(c.GetHeader("Authorization"))
+		if !strings.HasPrefix(strings.ToLower(auth), "bearer ") {
+			c.Header("WWW-Authenticate", `Bearer realm="Identrail SCIM"`)
+			writeSCIMError(c, http.StatusUnauthorized, "", "missing bearer token")
+			c.Abort()
+			return
+		}
+		token := strings.TrimSpace(auth[len("Bearer "):])
+		if token == "" {
+			c.Header("WWW-Authenticate", `Bearer realm="Identrail SCIM"`)
+			writeSCIMError(c, http.StatusUnauthorized, "", "missing bearer token")
+			c.Abort()
+			return
+		}
+		tokenHash := HashSCIMBearerToken(token)
+		conn, err := svc.Store.GetIdentityConnectionBySCIMBearerTokenHash(c.Request.Context(), tokenHash)
+		if err != nil {
+			if logger != nil && !errors.Is(err, db.ErrNotFound) {
+				logger.Error("resolve scim bearer token", telemetry.ZapError(err))
+			}
+			c.Header("WWW-Authenticate", `Bearer realm="Identrail SCIM"`)
+			writeSCIMError(c, http.StatusUnauthorized, "", "invalid bearer token")
+			c.Abort()
+			return
+		}
+		if subtle.ConstantTimeCompare([]byte(conn.SCIMBearerTokenHash), []byte(tokenHash)) != 1 {
+			c.Header("WWW-Authenticate", `Bearer realm="Identrail SCIM"`)
+			writeSCIMError(c, http.StatusUnauthorized, "", "invalid bearer token")
+			c.Abort()
+			return
+		}
+		if !conn.IsNativeSAML() || conn.Status != "active" {
+			writeSCIMError(c, http.StatusForbidden, "", "SCIM provisioning is not active for this connection")
+			c.Abort()
+			return
+		}
+		c.Set("enterprise.scim", scimAuthContext{
+			Connection: conn,
+			Provider:   scimProviderForConnection(conn.ID),
+		})
+		c.Next()
+	}
+}
+
+func getSCIMServiceProviderConfig(c *gin.Context) {
+	writeSCIMJSON(c, http.StatusOK, gin.H{
+		"schemas":          []string{scimServiceProviderConfigSchema},
+		"documentationUri": "https://www.rfc-editor.org/rfc/rfc7644",
+		"patch":            gin.H{"supported": true},
+		"bulk":             gin.H{"supported": false, "maxOperations": 0, "maxPayloadSize": 0},
+		"filter":           gin.H{"supported": true, "maxResults": scimMaxListLimit},
+		"changePassword":   gin.H{"supported": false},
+		"sort":             gin.H{"supported": false},
+		"etag":             gin.H{"supported": false},
+		"authenticationSchemes": []gin.H{{
+			"type":        "oauthbearertoken",
+			"name":        "Bearer Token",
+			"description": "Per-connection bearer token",
+			"primary":     true,
+		}},
+	})
+}
+
+func getSCIMSchemas(c *gin.Context) {
+	writeSCIMJSON(c, http.StatusOK, gin.H{
+		"schemas":      []string{scimListResponseSchema},
+		"totalResults": 1,
+		"Resources": []gin.H{{
+			"id":          scimCoreUserSchema,
+			"name":        "User",
+			"description": "User Account",
+			"attributes": []gin.H{
+				{"name": "userName", "type": "string", "required": true, "uniqueness": "server"},
+				{"name": "displayName", "type": "string"},
+				{"name": "active", "type": "boolean"},
+				{"name": "emails", "type": "complex", "multiValued": true, "required": true},
+			},
+		}},
+		"startIndex":   1,
+		"itemsPerPage": 1,
+	})
+}
+
+func getSCIMResourceTypes(c *gin.Context) {
+	writeSCIMJSON(c, http.StatusOK, gin.H{
+		"schemas":      []string{scimListResponseSchema},
+		"totalResults": 1,
+		"Resources": []gin.H{{
+			"id":               "User",
+			"name":             "User",
+			"endpoint":         "/Users",
+			"description":      "User Account",
+			"schema":           scimCoreUserSchema,
+			"schemaExtensions": []any{},
+		}},
+		"startIndex":   1,
+		"itemsPerPage": 1,
+	})
+}
+
+func listSCIMUsers(logger *zap.Logger, svc *Service, publicBaseURL string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		auth := mustSCIMAuth(c)
+		startIndex := positiveQueryInt(c, "startIndex", 1)
+		count := positiveQueryInt(c, "count", scimDefaultListLimit)
+		if count > scimMaxListLimit {
+			count = scimMaxListLimit
+		}
+		var users []scimUserResponse
+		if filter := strings.TrimSpace(c.Query("filter")); filter != "" {
+			match := scimUserNameFilterRE.FindStringSubmatch(filter)
+			if len(match) != 2 {
+				writeSCIMError(c, http.StatusBadRequest, "invalidFilter", `only filter=userName eq "value" is supported`)
+				return
+			}
+			user, err := loadSCIMUserBySubject(c, svc, auth, match[1], publicBaseURL)
+			if err != nil {
+				if !errors.Is(err, db.ErrNotFound) {
+					writeSCIMStoreError(c, logger, err, "filter scim users")
+					return
+				}
+				users = []scimUserResponse{}
+			} else {
+				users = []scimUserResponse{user}
+			}
+		} else {
+			var err error
+			users, err = loadSCIMUsers(c, svc, auth, publicBaseURL)
+			if err != nil {
+				writeSCIMStoreError(c, logger, err, "list scim users")
+				return
+			}
+		}
+		total := len(users)
+		start := startIndex - 1
+		if start > total {
+			users = []scimUserResponse{}
+		} else {
+			end := start + count
+			if end > total {
+				end = total
+			}
+			users = users[start:end]
+		}
+		writeSCIMJSON(c, http.StatusOK, scimListResponse{
+			Schemas:      []string{scimListResponseSchema},
+			TotalResults: total,
+			Resources:    users,
+			StartIndex:   startIndex,
+			ItemsPerPage: len(users),
+		})
+	}
+}
+
+func createSCIMUser(logger *zap.Logger, svc *Service, publicBaseURL string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		auth := mustSCIMAuth(c)
+		req, err := bindSCIMUserDefaultActive(c)
+		if err != nil {
+			writeSCIMError(c, http.StatusBadRequest, "invalidSyntax", "invalid SCIM user payload")
+			return
+		}
+		if strings.TrimSpace(req.ID) != "" {
+			writeSCIMError(c, http.StatusBadRequest, "mutability", "id is server assigned")
+			return
+		}
+		req.UserName = strings.TrimSpace(req.UserName)
+		if _, err := svc.Store.GetUserIdentity(c.Request.Context(), auth.Provider, req.UserName); err == nil {
+			writeSCIMError(c, http.StatusConflict, "uniqueness", "userName already exists")
+			return
+		} else if !errors.Is(err, db.ErrNotFound) {
+			writeSCIMStoreError(c, logger, err, "check scim user uniqueness")
+			return
+		}
+		user, err := saveSCIMUser(c, svc, auth, req, "", publicBaseURL)
+		if err != nil {
+			writeSCIMSaveError(c, logger, err)
+			return
+		}
+		if err := recordSCIMEvent(c, svc, auth.Connection, enterprise.SCIMProvisioningCreate, user.SCIMUser); err != nil {
+			writeSCIMStoreError(c, logger, err, "record scim create")
+			return
+		}
+		c.Header("Location", user.Meta.Location)
+		writeSCIMJSON(c, http.StatusCreated, user)
+	}
+}
+
+func getSCIMUser(logger *zap.Logger, svc *Service, publicBaseURL string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		auth := mustSCIMAuth(c)
+		user, err := loadSCIMUserByID(c, svc, auth, c.Param("id"), publicBaseURL)
+		if err != nil {
+			writeSCIMStoreError(c, logger, err, "get scim user")
+			return
+		}
+		writeSCIMJSON(c, http.StatusOK, user)
+	}
+}
+
+func putSCIMUser(logger *zap.Logger, svc *Service, publicBaseURL string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		auth := mustSCIMAuth(c)
+		if _, err := loadSCIMUserByID(c, svc, auth, c.Param("id"), publicBaseURL); err != nil {
+			writeSCIMStoreError(c, logger, err, "load scim user for put")
+			return
+		}
+		req, err := bindSCIMUserDefaultActive(c)
+		if err != nil {
+			writeSCIMError(c, http.StatusBadRequest, "invalidSyntax", "invalid SCIM user payload")
+			return
+		}
+		req.ID = c.Param("id")
+		user, err := saveSCIMUser(c, svc, auth, req, req.ID, publicBaseURL)
+		if err != nil {
+			writeSCIMSaveError(c, logger, err)
+			return
+		}
+		op := enterprise.SCIMProvisioningUpdate
+		if !user.Active {
+			op = enterprise.SCIMProvisioningDeactivate
+		}
+		if err := recordSCIMEvent(c, svc, auth.Connection, op, user.SCIMUser); err != nil {
+			writeSCIMStoreError(c, logger, err, "record scim update")
+			return
+		}
+		writeSCIMJSON(c, http.StatusOK, user)
+	}
+}
+
+func patchSCIMUser(logger *zap.Logger, svc *Service, publicBaseURL string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		auth := mustSCIMAuth(c)
+		existing, err := loadSCIMUserByID(c, svc, auth, c.Param("id"), publicBaseURL)
+		if err != nil {
+			writeSCIMStoreError(c, logger, err, "load scim user for patch")
+			return
+		}
+		var req scimPatchRequest
+		if err := c.ShouldBindJSON(&req); err != nil || len(req.Operations) == 0 {
+			writeSCIMError(c, http.StatusBadRequest, "invalidSyntax", "invalid SCIM PATCH payload")
+			return
+		}
+		updated := existing.SCIMUser
+		for _, op := range req.Operations {
+			if !strings.EqualFold(strings.TrimSpace(op.Op), "replace") {
+				writeSCIMError(c, http.StatusBadRequest, "mutability", "only PATCH replace operations are supported")
+				return
+			}
+			if err := applySCIMReplace(&updated, op); err != nil {
+				writeSCIMError(c, http.StatusBadRequest, "invalidValue", err.Error())
+				return
+			}
+		}
+		user, err := saveSCIMUser(c, svc, auth, updated, updated.ID, publicBaseURL)
+		if err != nil {
+			writeSCIMSaveError(c, logger, err)
+			return
+		}
+		op := enterprise.SCIMProvisioningUpdate
+		if !user.Active {
+			op = enterprise.SCIMProvisioningDeactivate
+		}
+		if err := recordSCIMEvent(c, svc, auth.Connection, op, user.SCIMUser); err != nil {
+			writeSCIMStoreError(c, logger, err, "record scim patch")
+			return
+		}
+		writeSCIMJSON(c, http.StatusOK, user)
+	}
+}
+
+func deleteSCIMUser(logger *zap.Logger, svc *Service, publicBaseURL string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		auth := mustSCIMAuth(c)
+		existing, err := loadSCIMUserByID(c, svc, auth, c.Param("id"), publicBaseURL)
+		if err != nil {
+			writeSCIMStoreError(c, logger, err, "load scim user for delete")
+			return
+		}
+		updated := existing.SCIMUser
+		updated.Active = false
+		if _, err := saveSCIMUser(c, svc, auth, updated, updated.ID, publicBaseURL); err != nil {
+			writeSCIMSaveError(c, logger, err)
+			return
+		}
+		if err := recordSCIMEvent(c, svc, auth.Connection, enterprise.SCIMProvisioningDelete, updated); err != nil {
+			writeSCIMStoreError(c, logger, err, "record scim delete")
+			return
+		}
+		c.Status(http.StatusNoContent)
+	}
+}
+
+func bindSCIMUserDefaultActive(c *gin.Context) (enterprise.SCIMUser, error) {
+	var req enterprise.SCIMUser
+	if err := c.ShouldBindBodyWith(&req, binding.JSON); err != nil {
+		return enterprise.SCIMUser{}, err
+	}
+	var activeAttr struct {
+		Active *bool `json:"active"`
+	}
+	raw, ok := c.Get(gin.BodyBytesKey)
+	if !ok {
+		return enterprise.SCIMUser{}, fmt.Errorf("missing request body")
+	}
+	body, ok := raw.([]byte)
+	if !ok {
+		return enterprise.SCIMUser{}, fmt.Errorf("invalid request body")
+	}
+	if err := json.Unmarshal(body, &activeAttr); err != nil {
+		return enterprise.SCIMUser{}, err
+	}
+	if activeAttr.Active == nil {
+		req.Active = true
+	}
+	return req, nil
+}
+
+func saveSCIMUser(c *gin.Context, svc *Service, auth scimAuthContext, incoming enterprise.SCIMUser, existingID string, publicBaseURL string) (scimUserResponse, error) {
+	incoming.UserName = strings.TrimSpace(incoming.UserName)
+	incoming.DisplayName = strings.TrimSpace(incoming.DisplayName)
+	if err := incoming.Validate(); err != nil {
+		return scimUserResponse{}, fmt.Errorf("invalid scim user: %w", err)
+	}
+	now := time.Now().UTC()
+	userID := strings.TrimSpace(existingID)
+	if userID == "" {
+		userID = uuid.NewString()
+	}
+	if _, err := uuid.Parse(userID); err != nil {
+		return scimUserResponse{}, db.ErrNotFound
+	}
+	primaryEmail := strings.ToLower(strings.TrimSpace(incoming.PrimaryEmail()))
+	status := "deactivated"
+	if incoming.Active {
+		status = "active"
+	}
+	user := db.User{
+		ID:           userID,
+		PrimaryEmail: primaryEmail,
+		DisplayName:  incoming.DisplayName,
+		Status:       status,
+		UpdatedAt:    now,
+	}
+	var existingIdentity db.UserIdentity
+	subjectChanged := false
+	if existingID != "" {
+		existing, err := svc.Store.GetUser(c.Request.Context(), existingID)
+		if err != nil {
+			return scimUserResponse{}, err
+		}
+		user.CreatedAt = existing.CreatedAt
+		existingIdentity, err = findSCIMIdentityByUserID(c, svc, auth.Provider, existingID)
+		if err != nil {
+			return scimUserResponse{}, err
+		}
+		subjectChanged = existingIdentity.Subject != incoming.UserName
+		if subjectChanged {
+			if bySubject, err := svc.Store.GetUserIdentity(c.Request.Context(), auth.Provider, incoming.UserName); err == nil && bySubject.UserID != existingID {
+				return scimUserResponse{}, db.ErrConflict
+			} else if err != nil && !errors.Is(err, db.ErrNotFound) {
+				return scimUserResponse{}, err
+			}
+		}
+	}
+	savedUser, err := svc.Store.UpsertUser(c.Request.Context(), user)
+	if err != nil {
+		return scimUserResponse{}, err
+	}
+	incoming.ID = savedUser.ID
+	incoming.Meta = enterprise.SCIMMeta{
+		ResourceType: "User",
+		Created:      savedUser.CreatedAt,
+		LastModified: now,
+		Location:     scimUserLocation(c, publicBaseURL, savedUser.ID),
+		Version:      fmt.Sprintf(`W/"%s"`, savedUser.UpdatedAt.UTC().Format(time.RFC3339Nano)),
+	}
+	rawClaims, err := json.Marshal(incoming)
+	if err != nil {
+		return scimUserResponse{}, err
+	}
+	identity := db.UserIdentity{
+		UserID:              savedUser.ID,
+		Provider:            auth.Provider,
+		Subject:             incoming.UserName,
+		Email:               primaryEmail,
+		EmailVerified:       true,
+		RawClaims:           rawClaims,
+		LastAuthenticatedAt: now,
+	}
+	if existingID != "" {
+		if subjectChanged {
+			if err := svc.Store.DeleteUserIdentity(c.Request.Context(), auth.Provider, existingIdentity.Subject); err != nil && !errors.Is(err, db.ErrNotFound) {
+				return scimUserResponse{}, err
+			}
+		} else {
+			identity.ID = existingIdentity.ID
+			identity.CreatedAt = existingIdentity.CreatedAt
+		}
+	}
+	savedIdentity, err := svc.Store.UpsertUserIdentity(c.Request.Context(), identity)
+	if err != nil {
+		return scimUserResponse{}, err
+	}
+	return scimUserFromRecords(c, publicBaseURL, savedUser, savedIdentity), nil
+}
+
+func loadSCIMUsers(c *gin.Context, svc *Service, auth scimAuthContext, publicBaseURL string) ([]scimUserResponse, error) {
+	identities, err := svc.Store.ListUserIdentitiesByProvider(c.Request.Context(), auth.Provider, 0)
+	if err != nil {
+		return nil, err
+	}
+	users := make([]scimUserResponse, 0, len(identities))
+	for _, identity := range identities {
+		user, err := svc.Store.GetUser(c.Request.Context(), identity.UserID)
+		if errors.Is(err, db.ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		users = append(users, scimUserFromRecords(c, publicBaseURL, user, identity))
+	}
+	return users, nil
+}
+
+func loadSCIMUserBySubject(c *gin.Context, svc *Service, auth scimAuthContext, subject string, publicBaseURL string) (scimUserResponse, error) {
+	identity, err := svc.Store.GetUserIdentity(c.Request.Context(), auth.Provider, strings.TrimSpace(subject))
+	if err != nil {
+		return scimUserResponse{}, err
+	}
+	user, err := svc.Store.GetUser(c.Request.Context(), identity.UserID)
+	if err != nil {
+		return scimUserResponse{}, err
+	}
+	return scimUserFromRecords(c, publicBaseURL, user, identity), nil
+}
+
+func loadSCIMUserByID(c *gin.Context, svc *Service, auth scimAuthContext, id string, publicBaseURL string) (scimUserResponse, error) {
+	if _, err := uuid.Parse(strings.TrimSpace(id)); err != nil {
+		return scimUserResponse{}, db.ErrNotFound
+	}
+	identity, err := findSCIMIdentityByUserID(c, svc, auth.Provider, id)
+	if err != nil {
+		return scimUserResponse{}, err
+	}
+	user, err := svc.Store.GetUser(c.Request.Context(), identity.UserID)
+	if err != nil {
+		return scimUserResponse{}, err
+	}
+	return scimUserFromRecords(c, publicBaseURL, user, identity), nil
+}
+
+func findSCIMIdentityByUserID(c *gin.Context, svc *Service, provider string, userID string) (db.UserIdentity, error) {
+	return svc.Store.GetUserIdentityByProviderUserID(c.Request.Context(), provider, userID)
+}
+
+func scimUserFromRecords(c *gin.Context, publicBaseURL string, user db.User, identity db.UserIdentity) scimUserResponse {
+	scimUser := enterprise.SCIMUser{}
+	if len(identity.RawClaims) > 0 {
+		_ = json.Unmarshal(identity.RawClaims, &scimUser)
+	}
+	scimUser.ID = user.ID
+	if strings.TrimSpace(scimUser.UserName) == "" {
+		scimUser.UserName = identity.Subject
+	}
+	if strings.TrimSpace(scimUser.DisplayName) == "" {
+		scimUser.DisplayName = user.DisplayName
+	}
+	email := strings.TrimSpace(user.PrimaryEmail)
+	if email == "" {
+		email = strings.TrimSpace(identity.Email)
+	}
+	if len(scimUser.Emails) == 0 && email != "" {
+		scimUser.Emails = []enterprise.SCIMEmail{{Value: email, Type: "work", Primary: true}}
+	}
+	scimUser.Active = user.Status == "active"
+	scimUser.Meta = enterprise.SCIMMeta{
+		ResourceType: "User",
+		Created:      user.CreatedAt,
+		LastModified: user.UpdatedAt,
+		Location:     scimUserLocation(c, publicBaseURL, user.ID),
+		Version:      fmt.Sprintf(`W/"%s"`, user.UpdatedAt.UTC().Format(time.RFC3339Nano)),
+	}
+	return scimUserResponse{
+		Schemas:  []string{scimCoreUserSchema},
+		SCIMUser: scimUser,
+	}
+}
+
+func recordSCIMEvent(c *gin.Context, svc *Service, conn db.IdentityConnection, op enterprise.SCIMProvisioningOp, user enterprise.SCIMUser) error {
+	payloadBytes, err := json.Marshal(user)
+	if err != nil {
+		return err
+	}
+	payload := map[string]any{}
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		return err
+	}
+	_, err = svc.Store.CreateSCIMProvisioningEvent(c.Request.Context(), db.SCIMProvisioningEventRecord{
+		OrgID:        conn.OrgID,
+		ConnectionID: conn.ID,
+		Op:           string(op),
+		ExternalID:   user.ExternalID,
+		UserID:       user.ID,
+		Payload:      payload,
+		OccurredAt:   time.Now().UTC(),
+	})
+	return err
+}
+
+func applySCIMReplace(user *enterprise.SCIMUser, op scimPatchOperation) error {
+	path := strings.TrimSpace(op.Path)
+	if path == "" {
+		values := map[string]json.RawMessage{}
+		if err := json.Unmarshal(op.Value, &values); err != nil {
+			return fmt.Errorf("replace value must be an object when path is omitted")
+		}
+		for key, raw := range values {
+			if err := replaceSCIMField(user, key, raw); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return replaceSCIMField(user, path, op.Value)
+}
+
+func replaceSCIMField(user *enterprise.SCIMUser, path string, raw json.RawMessage) error {
+	switch strings.ToLower(strings.TrimSpace(path)) {
+	case "active":
+		return json.Unmarshal(raw, &user.Active)
+	case "username":
+		return json.Unmarshal(raw, &user.UserName)
+	case "displayname":
+		return json.Unmarshal(raw, &user.DisplayName)
+	case "externalid":
+		return json.Unmarshal(raw, &user.ExternalID)
+	case "emails":
+		return json.Unmarshal(raw, &user.Emails)
+	default:
+		return fmt.Errorf("unsupported replace path %q", path)
+	}
+}
+
+func mustSCIMAuth(c *gin.Context) scimAuthContext {
+	value, _ := c.Get("enterprise.scim")
+	auth, _ := value.(scimAuthContext)
+	return auth
+}
+
+func scimProviderForConnection(connectionID string) string {
+	return "scim:" + strings.TrimSpace(connectionID)
+}
+
+func positiveQueryInt(c *gin.Context, key string, fallback int) int {
+	raw := strings.TrimSpace(c.Query(key))
+	if raw == "" {
+		return fallback
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value <= 0 {
+		return fallback
+	}
+	return value
+}
+
+func scimUserLocation(c *gin.Context, publicBaseURL string, userID string) string {
+	base := strings.TrimRight(strings.TrimSpace(publicBaseURL), "/")
+	if base == "" {
+		scheme := "http"
+		if c.Request.TLS != nil || strings.EqualFold(c.GetHeader("X-Forwarded-Proto"), "https") {
+			scheme = "https"
+		}
+		base = scheme + "://" + c.Request.Host
+	}
+	return base + "/scim/v2/Users/" + userID
+}
+
+func writeSCIMSaveError(c *gin.Context, logger *zap.Logger, err error) {
+	if err == nil {
+		return
+	}
+	if strings.HasPrefix(err.Error(), "invalid scim user:") {
+		writeSCIMError(c, http.StatusBadRequest, "invalidValue", strings.TrimPrefix(err.Error(), "invalid scim user: "))
+		return
+	}
+	if errors.Is(err, db.ErrConflict) {
+		writeSCIMError(c, http.StatusConflict, "uniqueness", "SCIM user conflicts with an existing user")
+		return
+	}
+	writeSCIMStoreError(c, logger, err, "save scim user")
+}
+
+func writeSCIMStoreError(c *gin.Context, logger *zap.Logger, err error, msg string) {
+	if errors.Is(err, db.ErrNotFound) {
+		writeSCIMError(c, http.StatusNotFound, "", "SCIM resource not found")
+		return
+	}
+	if errors.Is(err, db.ErrConflict) {
+		writeSCIMError(c, http.StatusConflict, "uniqueness", "SCIM resource conflict")
+		return
+	}
+	if logger != nil {
+		logger.Error(msg, telemetry.ZapError(err))
+	}
+	writeSCIMError(c, http.StatusInternalServerError, "", "SCIM request failed")
+}
+
+func writeSCIMError(c *gin.Context, status int, scimType string, detail string) {
+	body := gin.H{
+		"schemas": []string{scimErrorSchema},
+		"status":  strconv.Itoa(status),
+		"detail":  detail,
+	}
+	if strings.TrimSpace(scimType) != "" {
+		body["scimType"] = scimType
+	}
+	writeSCIMJSON(c, status, body)
+}
+
+func writeSCIMJSON(c *gin.Context, status int, body any) {
+	c.Header("Content-Type", scimContentType)
+	c.JSON(status, body)
+}

--- a/internal/api/enterprise_scim_routes_test.go
+++ b/internal/api/enterprise_scim_routes_test.go
@@ -1,0 +1,374 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+func newSCIMTestRouter(t *testing.T, enabled bool) (*gin.Engine, *db.MemoryStore, db.IdentityConnection, string) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	store := db.NewMemoryStore()
+	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	if err := store.UpsertOrganization(ctx, db.TenancyOrganization{DisplayName: "Tenant A", Slug: "tenant-a"}); err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+	token := "idntr_scim_test_token"
+	conn, err := store.CreateIdentityConnection(ctx, db.IdentityConnection{
+		OrgID:               "tenant-a",
+		Provider:            "saml",
+		Type:                "directory_sync",
+		Status:              "active",
+		EntityID:            "https://idp.example.com/entity",
+		SSOURL:              "https://idp.example.com/sso",
+		CertificatePEM:      generateTestCertPEM(t),
+		AttributeMapping:    map[string]string{"email": "email"},
+		SCIMBearerTokenHash: HashSCIMBearerToken(token),
+	})
+	if err != nil {
+		t.Fatalf("seed connection: %v", err)
+	}
+	svc := NewService(store, routerScanner{}, "aws")
+	router := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{
+		FeatureNativeSSO: enabled,
+		PublicBaseURL:    "https://api.example.com",
+		RateLimitRPM:     10000,
+		RateLimitBurst:   1000,
+	})
+	return router, store, conn, token
+}
+
+func doSCIM(t *testing.T, router *gin.Engine, token string, method string, path string, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", scimContentType)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func TestEnterpriseSCIMRoutes_DisabledAndUnauthorized(t *testing.T) {
+	router, _, _, token := newSCIMTestRouter(t, false)
+	w := doSCIM(t, router, token, http.MethodGet, "/scim/v2/ServiceProviderConfig", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("disabled routes should be 404, got %d body %s", w.Code, w.Body.String())
+	}
+
+	router, _, _, _ = newSCIMTestRouter(t, true)
+	w = doSCIM(t, router, "", http.MethodGet, "/scim/v2/ServiceProviderConfig", "")
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("missing bearer should be 401, got %d body %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("WWW-Authenticate"); got == "" {
+		t.Fatalf("missing WWW-Authenticate header")
+	}
+	w = doSCIM(t, router, "wrong-token", http.MethodGet, "/scim/v2/ServiceProviderConfig", "")
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("bad bearer should be 401, got %d body %s", w.Code, w.Body.String())
+	}
+}
+
+func TestEnterpriseSCIMRoutes_DefaultsOmittedActiveToEnabled(t *testing.T) {
+	router, store, _, token := newSCIMTestRouter(t, true)
+	createBody := `{
+		"userName":"default-active@example.com",
+		"displayName":"Default Active",
+		"emails":[{"value":"default-active@example.com","type":"work","primary":true}]
+	}`
+	created := doSCIM(t, router, token, http.MethodPost, "/scim/v2/Users", createBody)
+	if created.Code != http.StatusCreated {
+		t.Fatalf("create without active: code %d body %s", created.Code, created.Body.String())
+	}
+	var response struct {
+		ID     string `json:"id"`
+		Active bool   `json:"active"`
+	}
+	if err := json.Unmarshal(created.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !response.Active {
+		t.Fatalf("omitted active should default to true")
+	}
+	user, err := store.GetUser(context.Background(), response.ID)
+	if err != nil {
+		t.Fatalf("get created user: %v", err)
+	}
+	if user.Status != "active" {
+		t.Fatalf("omitted active should persist active user, got %q", user.Status)
+	}
+}
+
+func TestEnterpriseSCIMRoutes_SingleResourceLookupUsesDirectUserIDLookup(t *testing.T) {
+	router, store, conn, token := newSCIMTestRouter(t, true)
+	ctx := context.Background()
+	baseTime := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	const historicalListLimit = 10000
+	targetID := "11111111-1111-1111-1111-111111111111"
+	if _, err := store.UpsertUser(ctx, db.User{
+		ID:           targetID,
+		PrimaryEmail: "oldest@example.com",
+		DisplayName:  "Oldest User",
+		Status:       "active",
+		CreatedAt:    baseTime,
+		UpdatedAt:    baseTime,
+	}); err != nil {
+		t.Fatalf("seed target user: %v", err)
+	}
+	if _, err := store.UpsertUserIdentity(ctx, db.UserIdentity{
+		ID:                  "22222222-2222-2222-2222-222222222222",
+		UserID:              targetID,
+		Provider:            "scim:" + conn.ID,
+		Subject:             "oldest@example.com",
+		Email:               "oldest@example.com",
+		EmailVerified:       true,
+		RawClaims:           []byte(`{"userName":"oldest@example.com","active":true,"emails":[{"value":"oldest@example.com","primary":true}]}`),
+		LastAuthenticatedAt: baseTime,
+		CreatedAt:           baseTime,
+	}); err != nil {
+		t.Fatalf("seed target identity: %v", err)
+	}
+	for i := 0; i < historicalListLimit; i++ {
+		userID := uuid.NewString()
+		email := fmt.Sprintf("bulk-%05d@example.com", i)
+		createdAt := baseTime.Add(time.Duration(i+1) * time.Second)
+		if _, err := store.UpsertUser(ctx, db.User{
+			ID:           userID,
+			PrimaryEmail: email,
+			DisplayName:  email,
+			Status:       "active",
+			CreatedAt:    createdAt,
+			UpdatedAt:    createdAt,
+		}); err != nil {
+			t.Fatalf("seed bulk user %d: %v", i, err)
+		}
+		if _, err := store.UpsertUserIdentity(ctx, db.UserIdentity{
+			UserID:              userID,
+			Provider:            "scim:" + conn.ID,
+			Subject:             email,
+			Email:               email,
+			EmailVerified:       true,
+			RawClaims:           []byte(fmt.Sprintf(`{"userName":%q,"active":true,"emails":[{"value":%q,"primary":true}]}`, email, email)),
+			LastAuthenticatedAt: createdAt,
+			CreatedAt:           createdAt,
+		}); err != nil {
+			t.Fatalf("seed bulk identity %d: %v", i, err)
+		}
+	}
+
+	got := doSCIM(t, router, token, http.MethodGet, "/scim/v2/Users/"+targetID, "")
+	if got.Code != http.StatusOK {
+		t.Fatalf("oldest user should remain addressable beyond list scan limit, got %d body %s", got.Code, got.Body.String())
+	}
+	filtered := doSCIM(t, router, token, http.MethodGet, `/scim/v2/Users?filter=userName%20eq%20%22oldest@example.com%22`, "")
+	if filtered.Code != http.StatusOK {
+		t.Fatalf("oldest user filter should bypass list scan limit, got %d body %s", filtered.Code, filtered.Body.String())
+	}
+	var filteredBody struct {
+		TotalResults int `json:"totalResults"`
+		Resources    []struct {
+			ID string `json:"id"`
+		} `json:"Resources"`
+	}
+	if err := json.Unmarshal(filtered.Body.Bytes(), &filteredBody); err != nil {
+		t.Fatalf("decode filtered oldest response: %v", err)
+	}
+	if filteredBody.TotalResults != 1 || len(filteredBody.Resources) != 1 || filteredBody.Resources[0].ID != targetID {
+		t.Fatalf("unexpected filtered oldest response: %+v", filteredBody)
+	}
+	paged := doSCIM(t, router, token, http.MethodGet, fmt.Sprintf("/scim/v2/Users?startIndex=%d&count=1", historicalListLimit+1), "")
+	if paged.Code != http.StatusOK {
+		t.Fatalf("oldest user page should not be truncated, got %d body %s", paged.Code, paged.Body.String())
+	}
+	var pagedBody struct {
+		Resources []struct {
+			ID string `json:"id"`
+		} `json:"Resources"`
+	}
+	if err := json.Unmarshal(paged.Body.Bytes(), &pagedBody); err != nil {
+		t.Fatalf("decode paged oldest response: %v", err)
+	}
+	if len(pagedBody.Resources) != 1 || pagedBody.Resources[0].ID != targetID {
+		t.Fatalf("unexpected paged oldest response: %+v", pagedBody)
+	}
+}
+
+func TestEnterpriseSCIMRoutes_UserLifecycle(t *testing.T) {
+	router, store, conn, token := newSCIMTestRouter(t, true)
+
+	discovery := doSCIM(t, router, token, http.MethodGet, "/scim/v2/ServiceProviderConfig", "")
+	if discovery.Code != http.StatusOK {
+		t.Fatalf("discovery: code %d body %s", discovery.Code, discovery.Body.String())
+	}
+	for _, path := range []string{"/scim/v2/Schemas", "/scim/v2/ResourceTypes"} {
+		w := doSCIM(t, router, token, http.MethodGet, path, "")
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s: code %d body %s", path, w.Code, w.Body.String())
+		}
+	}
+
+	createBody := `{
+		"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],
+		"userName":"alice@example.com",
+		"displayName":"Alice Adams",
+		"active":true,
+		"emails":[{"value":"alice@example.com","type":"work","primary":true}]
+	}`
+	created := doSCIM(t, router, token, http.MethodPost, "/scim/v2/Users", createBody)
+	if created.Code != http.StatusCreated {
+		t.Fatalf("create: code %d body %s", created.Code, created.Body.String())
+	}
+	var createdBody struct {
+		ID       string `json:"id"`
+		UserName string `json:"userName"`
+		Meta     struct {
+			Location string `json:"location"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal(created.Body.Bytes(), &createdBody); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if createdBody.ID == "" || createdBody.UserName != "alice@example.com" {
+		t.Fatalf("unexpected create response: %+v", createdBody)
+	}
+	if createdBody.Meta.Location != "https://api.example.com/scim/v2/Users/"+createdBody.ID {
+		t.Fatalf("unexpected location %q", createdBody.Meta.Location)
+	}
+	invalidCreate := doSCIM(t, router, token, http.MethodPost, "/scim/v2/Users", `{"userName":"missing-email@example.com","active":true}`)
+	if invalidCreate.Code != http.StatusBadRequest {
+		t.Fatalf("invalid create should be 400, got %d body %s", invalidCreate.Code, invalidCreate.Body.String())
+	}
+	duplicate := doSCIM(t, router, token, http.MethodPost, "/scim/v2/Users", createBody)
+	if duplicate.Code != http.StatusConflict {
+		t.Fatalf("duplicate create should be 409, got %d body %s", duplicate.Code, duplicate.Body.String())
+	}
+
+	filtered := doSCIM(t, router, token, http.MethodGet, `/scim/v2/Users?filter=userName%20eq%20%22alice@example.com%22&startIndex=1&count=1`, "")
+	if filtered.Code != http.StatusOK {
+		t.Fatalf("filter: code %d body %s", filtered.Code, filtered.Body.String())
+	}
+	badFilter := doSCIM(t, router, token, http.MethodGet, `/scim/v2/Users?filter=emails.value%20eq%20%22alice@example.com%22`, "")
+	if badFilter.Code != http.StatusBadRequest {
+		t.Fatalf("bad filter should be 400, got %d body %s", badFilter.Code, badFilter.Body.String())
+	}
+	var listBody struct {
+		TotalResults int `json:"totalResults"`
+		Resources    []struct {
+			ID string `json:"id"`
+		} `json:"Resources"`
+	}
+	if err := json.Unmarshal(filtered.Body.Bytes(), &listBody); err != nil {
+		t.Fatalf("decode filter response: %v", err)
+	}
+	if listBody.TotalResults != 1 || len(listBody.Resources) != 1 || listBody.Resources[0].ID != createdBody.ID {
+		t.Fatalf("unexpected filter response: %+v", listBody)
+	}
+	got := doSCIM(t, router, token, http.MethodGet, "/scim/v2/Users/"+createdBody.ID, "")
+	if got.Code != http.StatusOK {
+		t.Fatalf("get: code %d body %s", got.Code, got.Body.String())
+	}
+	missing := doSCIM(t, router, token, http.MethodGet, "/scim/v2/Users/00000000-0000-0000-0000-000000000000", "")
+	if missing.Code != http.StatusNotFound {
+		t.Fatalf("missing get should be 404, got %d body %s", missing.Code, missing.Body.String())
+	}
+
+	putBody := `{
+		"userName":"alice.renamed@example.com",
+		"displayName":"Alice Renamed",
+		"active":true,
+		"emails":[{"value":"alice.renamed@example.com","type":"work","primary":true}]
+	}`
+	updated := doSCIM(t, router, token, http.MethodPut, "/scim/v2/Users/"+createdBody.ID, putBody)
+	if updated.Code != http.StatusOK {
+		t.Fatalf("put: code %d body %s", updated.Code, updated.Body.String())
+	}
+	oldFilter := doSCIM(t, router, token, http.MethodGet, `/scim/v2/Users?filter=userName%20eq%20%22alice@example.com%22`, "")
+	if oldFilter.Code != http.StatusOK {
+		t.Fatalf("old filter: code %d body %s", oldFilter.Code, oldFilter.Body.String())
+	}
+	var oldList struct {
+		TotalResults int `json:"totalResults"`
+	}
+	if err := json.Unmarshal(oldFilter.Body.Bytes(), &oldList); err != nil {
+		t.Fatalf("decode old filter response: %v", err)
+	}
+	if oldList.TotalResults != 0 {
+		t.Fatalf("old userName should no longer resolve, got %+v", oldList)
+	}
+
+	caseOnlyBody := `{
+		"userName":"Alice.Renamed@Example.com",
+		"displayName":"Alice Renamed",
+		"active":true,
+		"emails":[{"value":"alice.renamed@example.com","type":"work","primary":true}]
+	}`
+	caseOnlyUpdated := doSCIM(t, router, token, http.MethodPut, "/scim/v2/Users/"+createdBody.ID, caseOnlyBody)
+	if caseOnlyUpdated.Code != http.StatusOK {
+		t.Fatalf("case-only put: code %d body %s", caseOnlyUpdated.Code, caseOnlyUpdated.Body.String())
+	}
+	if _, err := store.GetUserIdentity(context.Background(), "scim:"+conn.ID, "Alice.Renamed@Example.com"); err != nil {
+		t.Fatalf("case-only subject should be stored exactly: %v", err)
+	}
+	if _, err := store.GetUserIdentity(context.Background(), "scim:"+conn.ID, "alice.renamed@example.com"); err == nil {
+		t.Fatalf("old case subject should be removed")
+	}
+
+	objectPatchBody := `{"schemas":["` + scimPatchOpSchema + `"],"Operations":[{"op":"replace","value":{"displayName":"Alice Patched","active":true}}]}`
+	objectPatched := doSCIM(t, router, token, http.MethodPatch, "/scim/v2/Users/"+createdBody.ID, objectPatchBody)
+	if objectPatched.Code != http.StatusOK {
+		t.Fatalf("object patch: code %d body %s", objectPatched.Code, objectPatched.Body.String())
+	}
+	unsupportedOp := doSCIM(t, router, token, http.MethodPatch, "/scim/v2/Users/"+createdBody.ID, `{"Operations":[{"op":"add","path":"displayName","value":"Nope"}]}`)
+	if unsupportedOp.Code != http.StatusBadRequest {
+		t.Fatalf("unsupported op should be 400, got %d body %s", unsupportedOp.Code, unsupportedOp.Body.String())
+	}
+	unsupportedPath := doSCIM(t, router, token, http.MethodPatch, "/scim/v2/Users/"+createdBody.ID, `{"Operations":[{"op":"replace","path":"title","value":"Engineer"}]}`)
+	if unsupportedPath.Code != http.StatusBadRequest {
+		t.Fatalf("unsupported path should be 400, got %d body %s", unsupportedPath.Code, unsupportedPath.Body.String())
+	}
+
+	patchBody := `{"schemas":["` + scimPatchOpSchema + `"],"Operations":[{"op":"replace","path":"active","value":false}]}`
+	patched := doSCIM(t, router, token, http.MethodPatch, "/scim/v2/Users/"+createdBody.ID, patchBody)
+	if patched.Code != http.StatusOK {
+		t.Fatalf("patch: code %d body %s", patched.Code, patched.Body.String())
+	}
+	var patchResponse struct {
+		Active bool `json:"active"`
+	}
+	if err := json.Unmarshal(patched.Body.Bytes(), &patchResponse); err != nil {
+		t.Fatalf("decode patch response: %v", err)
+	}
+	if patchResponse.Active {
+		t.Fatalf("patch should deactivate the user")
+	}
+
+	deleted := doSCIM(t, router, token, http.MethodDelete, "/scim/v2/Users/"+createdBody.ID, "")
+	if deleted.Code != http.StatusNoContent {
+		t.Fatalf("delete: code %d body %s", deleted.Code, deleted.Body.String())
+	}
+
+	events, err := store.ListSCIMProvisioningEvents(context.Background(), conn.OrgID, conn.ID, 10)
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if len(events) != 6 {
+		t.Fatalf("expected create/update/update/update/deactivate/delete events, got %d", len(events))
+	}
+	if events[0].Op != "delete" || events[1].Op != "deactivate" || events[2].Op != "update" || events[3].Op != "update" || events[4].Op != "update" || events[5].Op != "create" {
+		t.Fatalf("unexpected event order/ops: %+v", events)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -337,6 +337,10 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			ReturnToOrigins:    authReturnToOrigins(opts.PublicBaseURL, opts.CORSAllowedOrigins),
 		})
 	}
+	registerEnterpriseSCIMRoutes(r, logger, svc, enterpriseSCIMRouteOptions{
+		Enabled:       opts.FeatureNativeSSO,
+		PublicBaseURL: opts.PublicBaseURL,
+	})
 
 	publicV1 := r.Group("/v1")
 	publicV1.Use(auditLogMiddleware(logger, opts.AuditSink, opts.AuditFingerprinter))

--- a/internal/api/service_auth.go
+++ b/internal/api/service_auth.go
@@ -253,13 +253,24 @@ func (s *Service) UpsertSAMLAssertedUser(ctx context.Context, conn db.IdentityCo
 		return SAMLLoginResult{}, err
 	}
 
-	// Path 2: pre-provisioned via SCIM (subject = NameID, then email).
+	// Path 2: pre-provisioned via SCIM (subject = NameID/email, then primary email).
 	for _, scimSubject := range []string{nameID, email} {
 		if scimSubject == "" {
 			continue
 		}
 		if identity, err := s.Store.GetUserIdentity(ctx, scimProvider, scimSubject); err == nil {
 			return s.attachSAMLIdentityToExistingUser(ctx, conn, identity.UserID, nameID, email, displayName, rawClaims, now)
+		} else if !errors.Is(err, db.ErrNotFound) {
+			return SAMLLoginResult{}, err
+		}
+	}
+	if email != "" {
+		if existing, err := s.Store.GetUserByPrimaryEmail(ctx, email); err == nil {
+			if _, err := s.Store.GetUserIdentityByProviderUserID(ctx, scimProvider, existing.ID); err == nil {
+				return s.attachSAMLIdentityToExistingUser(ctx, conn, existing.ID, nameID, email, displayName, rawClaims, now)
+			} else if !errors.Is(err, db.ErrNotFound) {
+				return SAMLLoginResult{}, err
+			}
 		} else if !errors.Is(err, db.ErrNotFound) {
 			return SAMLLoginResult{}, err
 		}
@@ -331,6 +342,10 @@ func (s *Service) refreshSAMLIdentity(ctx context.Context, conn db.IdentityConne
 	if err != nil {
 		return SAMLLoginResult{}, err
 	}
+	if user.Status != "active" {
+		auditAuthAction(ctx, "auth.saml.deprovisioned", user.ID, "denied")
+		return SAMLLoginResult{}, ErrSAMLUnprovisionedUser
+	}
 	user.PrimaryEmail = email
 	user.DisplayName = displayName
 	user.Status = "active"
@@ -358,6 +373,10 @@ func (s *Service) attachSAMLIdentityToExistingUser(ctx context.Context, conn db.
 	user, err := s.Store.GetUser(ctx, userID)
 	if err != nil {
 		return SAMLLoginResult{}, err
+	}
+	if user.Status != "active" {
+		auditAuthAction(ctx, "auth.saml.deprovisioned", user.ID, "denied")
+		return SAMLLoginResult{}, ErrSAMLUnprovisionedUser
 	}
 	user.PrimaryEmail = email
 	user.DisplayName = displayName

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -220,6 +220,10 @@ func Load() Config {
 	if apiKeyScopeBindingsError != "" {
 		parseErrors = append(parseErrors, "invalid IDENTRAIL_API_KEY_SCOPE_BINDINGS: "+apiKeyScopeBindingsError)
 	}
+	featureNativeSSO := boolEnv("IDENTRAIL_FEATURE_NATIVE_SSO", defaultFeatureNativeSSO)
+	if strings.TrimSpace(os.Getenv("IDENTRAIL_ENABLE_NATIVE_SSO")) != "" {
+		featureNativeSSO = boolEnv("IDENTRAIL_ENABLE_NATIVE_SSO", featureNativeSSO)
+	}
 
 	return Config{
 		HTTPAddr:                     getEnv("IDENTRAIL_HTTP_ADDR", defaultHTTPAddr),
@@ -311,7 +315,7 @@ func Load() Config {
 		FeatureConnectorGitHubV2:     boolEnv("IDENTRAIL_FEATURE_CONNECTOR_GITHUB_V2", defaultFeatureConnectorGitHubV2),
 		FeatureConnectorK8S:          boolEnv("IDENTRAIL_FEATURE_CONNECTOR_K8S", defaultFeatureConnectorK8S),
 		FeatureOnboardingWizard:      boolEnv("IDENTRAIL_FEATURE_ONBOARDING_WIZARD", defaultFeatureOnboardingWizard),
-		FeatureNativeSSO:             boolEnv("IDENTRAIL_FEATURE_NATIVE_SSO", defaultFeatureNativeSSO),
+		FeatureNativeSSO:             featureNativeSSO,
 		GitHubAppID:                  getEnv("IDENTRAIL_GITHUB_APP_ID", ""),
 		GitHubAppName:                getEnv("IDENTRAIL_GITHUB_APP_NAME", ""),
 		GitHubAppPrivateKey:          getEnv("IDENTRAIL_GITHUB_APP_PRIVATE_KEY", ""),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -79,6 +79,8 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("IDENTRAIL_DEFAULT_WORKSPACE_ID", "")
 	t.Setenv("IDENTRAIL_REQUIRE_EXPLICIT_SCOPE", "")
 	t.Setenv("IDENTRAIL_FEATURE_NEW_AUTH", "")
+	t.Setenv("IDENTRAIL_FEATURE_NATIVE_SSO", "")
+	t.Setenv("IDENTRAIL_ENABLE_NATIVE_SSO", "")
 	t.Setenv("IDENTRAIL_FEATURE_CONNECTOR_GITHUB_V2", "")
 	t.Setenv("IDENTRAIL_GITHUB_PAT_ALLOWED_BASE_URLS", "")
 	t.Setenv("IDENTRAIL_PUBLIC_BASE_URL", "")
@@ -308,6 +310,9 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.FeatureWorkOSLogin {
 		t.Fatal("expected WorkOS login feature disabled by default")
 	}
+	if cfg.FeatureNativeSSO {
+		t.Fatal("expected native SSO feature disabled by default")
+	}
 	if cfg.FeatureConnectorAWS {
 		t.Fatal("expected AWS connector feature disabled by default")
 	}
@@ -430,6 +435,8 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("IDENTRAIL_DEFAULT_WORKSPACE_ID", "workspace-blue")
 	t.Setenv("IDENTRAIL_REQUIRE_EXPLICIT_SCOPE", "true")
 	t.Setenv("IDENTRAIL_FEATURE_NEW_AUTH", "true")
+	t.Setenv("IDENTRAIL_FEATURE_NATIVE_SSO", "false")
+	t.Setenv("IDENTRAIL_ENABLE_NATIVE_SSO", "true")
 	t.Setenv("IDENTRAIL_FEATURE_CONNECTOR_AWS", "true")
 	t.Setenv("IDENTRAIL_FEATURE_ONBOARDING_WIZARD", "true")
 	t.Setenv("IDENTRAIL_PUBLIC_BASE_URL", "https://app.identrail.example")
@@ -664,6 +671,9 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if !cfg.FeatureNewAuth {
 		t.Fatal("expected new auth feature enabled from env")
+	}
+	if !cfg.FeatureNativeSSO {
+		t.Fatal("expected native SSO feature enabled by compatibility alias")
 	}
 	if !cfg.FeatureConnectorAWS {
 		t.Fatal("expected AWS connector feature enabled from env")

--- a/internal/db/memory_auth.go
+++ b/internal/db/memory_auth.go
@@ -82,6 +82,11 @@ func (m *MemoryStore) UpsertUserIdentity(ctx context.Context, identity UserIdent
 	if existingID, exists := m.userIdentityByProviderSubject[lookupKey]; exists && existingID != normalized.ID {
 		delete(m.userIdentityByID, existingID)
 	}
+	for key, existingID := range m.userIdentityByProviderSubject {
+		if existingID == normalized.ID && key != lookupKey {
+			delete(m.userIdentityByProviderSubject, key)
+		}
+	}
 	m.userIdentityByID[normalized.ID] = normalized
 	m.userIdentityByProviderSubject[lookupKey] = normalized.ID
 	m.mu.Unlock()
@@ -107,6 +112,77 @@ func (m *MemoryStore) GetUserIdentity(ctx context.Context, provider string, subj
 		return UserIdentity{}, ErrNotFound
 	}
 	return identity, nil
+}
+
+// GetUserIdentityByProviderUserID returns one provider identity for a user.
+func (m *MemoryStore) GetUserIdentityByProviderUserID(ctx context.Context, provider string, userID string) (UserIdentity, error) {
+	normalizedProvider := strings.ToLower(strings.TrimSpace(provider))
+	normalizedUserID := strings.TrimSpace(userID)
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var match UserIdentity
+	found := false
+	for _, identity := range m.userIdentityByID {
+		if identity.Provider != normalizedProvider || identity.UserID != normalizedUserID {
+			continue
+		}
+		if found {
+			return UserIdentity{}, ErrConflict
+		}
+		match = identity
+		found = true
+	}
+	if !found {
+		return UserIdentity{}, ErrNotFound
+	}
+	return match, nil
+}
+
+// ListUserIdentitiesByProvider returns provider identities ordered by newest first.
+// A non-positive limit returns all matching identities.
+func (m *MemoryStore) ListUserIdentitiesByProvider(ctx context.Context, provider string, limit int) ([]UserIdentity, error) {
+	normalizedProvider := strings.ToLower(strings.TrimSpace(provider))
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	items := make([]UserIdentity, 0)
+	for _, identity := range m.userIdentityByID {
+		if identity.Provider != normalizedProvider {
+			continue
+		}
+		items = append(items, identity)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].CreatedAt.After(items[j].CreatedAt)
+	})
+	if limit > 0 && len(items) > limit {
+		items = items[:limit]
+	}
+	return items, nil
+}
+
+// DeleteUserIdentity removes one provider identity by provider and subject.
+func (m *MemoryStore) DeleteUserIdentity(ctx context.Context, provider string, subject string) error {
+	lookupKey := userIdentityLookupKey(provider, subject)
+	m.mu.Lock()
+	id, exists := m.userIdentityByProviderSubject[lookupKey]
+	if !exists {
+		m.mu.Unlock()
+		return ErrNotFound
+	}
+	for key, mappedID := range m.userIdentityByProviderSubject {
+		if mappedID == id {
+			delete(m.userIdentityByProviderSubject, key)
+		}
+	}
+	delete(m.userIdentityByID, id)
+	m.mu.Unlock()
+	audit.WriteAction(ctx, audit.AuditEvent{
+		Action:       "auth.identity.delete",
+		ResourceType: "user_identity",
+		ResourceID:   id,
+		Outcome:      "success",
+	})
+	return nil
 }
 
 // CreateSession persists one server-side session.

--- a/internal/db/memory_auth_test.go
+++ b/internal/db/memory_auth_test.go
@@ -58,6 +58,50 @@ func TestMemoryAuthUserIdentityAndSessionLifecycle(t *testing.T) {
 	if gotIdentity.ID != identity.ID {
 		t.Fatalf("unexpected identity: %+v", gotIdentity)
 	}
+	if _, err := store.UpsertUserIdentity(ctx, UserIdentity{
+		ID:                  identity.ID,
+		UserID:              user.ID,
+		Provider:            "github",
+		Subject:             "alice-subject-renamed",
+		Email:               "alice@example.com",
+		RawClaims:           []byte(`{"login":"alice-renamed"}`),
+		LastAuthenticatedAt: now.Add(time.Minute),
+	}); err != nil {
+		t.Fatalf("rename identity subject: %v", err)
+	}
+	if _, err := store.GetUserIdentity(ctx, "github", "alice-subject"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("old identity subject should not remain aliased, got %v", err)
+	}
+	gotIdentity, err = store.GetUserIdentity(ctx, "github", "alice-subject-renamed")
+	if err != nil {
+		t.Fatalf("get renamed identity: %v", err)
+	}
+	if gotIdentity.ID != identity.ID {
+		t.Fatalf("unexpected renamed identity: %+v", gotIdentity)
+	}
+	gotIdentityByUserID, err := store.GetUserIdentityByProviderUserID(ctx, "github", user.ID)
+	if err != nil {
+		t.Fatalf("get identity by provider user id: %v", err)
+	}
+	if gotIdentityByUserID.Subject != "alice-subject-renamed" {
+		t.Fatalf("unexpected identity by user id: %+v", gotIdentityByUserID)
+	}
+	providerIdentities, err := store.ListUserIdentitiesByProvider(ctx, "GITHUB", 10)
+	if err != nil {
+		t.Fatalf("list identities by provider: %v", err)
+	}
+	if len(providerIdentities) != 1 || providerIdentities[0].ID != identity.ID {
+		t.Fatalf("unexpected provider identities: %+v", providerIdentities)
+	}
+	if err := store.DeleteUserIdentity(ctx, "github", "alice-subject-renamed"); err != nil {
+		t.Fatalf("delete identity: %v", err)
+	}
+	if _, err := store.GetUserIdentity(ctx, "github", "alice-subject-renamed"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected deleted identity to be missing, got %v", err)
+	}
+	if err := store.DeleteUserIdentity(ctx, "github", "alice-subject-renamed"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected deleting missing identity to return ErrNotFound, got %v", err)
+	}
 
 	firstHash := sha256.Sum256([]byte("first-session"))
 	secondHash := sha256.Sum256([]byte("second-session"))

--- a/internal/db/memory_enterprise_auth.go
+++ b/internal/db/memory_enterprise_auth.go
@@ -268,6 +268,33 @@ func (m *MemoryStore) GetIdentityConnectionByID(ctx context.Context, connectionI
 	return match, nil
 }
 
+// GetIdentityConnectionBySCIMBearerTokenHash resolves a connection by its
+// stored SCIM bearer-token hash for unauthenticated SCIM entry points.
+func (m *MemoryStore) GetIdentityConnectionBySCIMBearerTokenHash(ctx context.Context, tokenHash string) (IdentityConnection, error) {
+	tokenHash = strings.TrimSpace(tokenHash)
+	if tokenHash == "" {
+		return IdentityConnection{}, ErrNotFound
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var match IdentityConnection
+	found := false
+	for _, connection := range m.identityConnections {
+		if connection.SCIMBearerTokenHash != tokenHash {
+			continue
+		}
+		if found {
+			return IdentityConnection{}, ErrConflict
+		}
+		match = connection
+		found = true
+	}
+	if !found {
+		return IdentityConnection{}, ErrNotFound
+	}
+	return match, nil
+}
+
 // ListIdentityConnections returns organization identity connection scaffolds ordered by newest first.
 func (m *MemoryStore) ListIdentityConnections(ctx context.Context, orgID string, limit int) ([]IdentityConnection, error) {
 	m.mu.RLock()

--- a/internal/db/memory_enterprise_auth_test.go
+++ b/internal/db/memory_enterprise_auth_test.go
@@ -168,6 +168,33 @@ func TestMemoryEnterpriseAuthLifecycle(t *testing.T) {
 	}); !errors.Is(err, ErrConflict) {
 		t.Fatalf("expected duplicate identity connection to return ErrConflict, got %v", err)
 	}
+
+	scimConnection, err := store.CreateIdentityConnection(ctx, IdentityConnection{
+		ID:                  "99999999-9999-9999-9999-999999999999",
+		OrgID:               "tenant-a",
+		Provider:            "saml",
+		Type:                "directory_sync",
+		Status:              "active",
+		EntityID:            "https://idp.example.com/entity",
+		SSOURL:              "https://idp.example.com/sso",
+		CertificatePEM:      "-----BEGIN CERTIFICATE-----\nMIID\n-----END CERTIFICATE-----",
+		SCIMBearerTokenHash: "scim-token-hash",
+		CreatedAt:           now.Add(2 * time.Minute),
+		UpdatedAt:           now.Add(2 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("create scim identity connection: %v", err)
+	}
+	gotSCIMConnection, err := store.GetIdentityConnectionBySCIMBearerTokenHash(ctx, " scim-token-hash ")
+	if err != nil {
+		t.Fatalf("get identity connection by scim hash: %v", err)
+	}
+	if gotSCIMConnection.ID != scimConnection.ID {
+		t.Fatalf("unexpected scim connection: %+v", gotSCIMConnection)
+	}
+	if _, err := store.GetIdentityConnectionBySCIMBearerTokenHash(ctx, "missing"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected missing scim hash to return ErrNotFound, got %v", err)
+	}
 }
 
 func TestEnterpriseAuthNormalizationRejectsInvalidInputs(t *testing.T) {

--- a/internal/db/postgres_auth.go
+++ b/internal/db/postgres_auth.go
@@ -205,6 +205,121 @@ func (p *PostgresStore) GetUserIdentity(ctx context.Context, provider string, su
 	return identity, nil
 }
 
+// GetUserIdentityByProviderUserID returns one provider identity for a user.
+func (p *PostgresStore) GetUserIdentityByProviderUserID(ctx context.Context, provider string, userID string) (UserIdentity, error) {
+	rows, err := p.queryContextAnyScope(
+		ctx,
+		`SELECT id::text, user_id::text, provider, subject, COALESCE(email::text, ''), email_verified, raw_claims, last_authenticated_at, created_at
+		 FROM user_identities
+		 WHERE provider = $1
+		   AND user_id = NULLIF($2, '')::uuid
+		 LIMIT 2`,
+		strings.ToLower(strings.TrimSpace(provider)),
+		strings.TrimSpace(userID),
+	)
+	if err != nil {
+		return UserIdentity{}, err
+	}
+	defer rows.Close()
+	var match UserIdentity
+	found := false
+	for rows.Next() {
+		var identity UserIdentity
+		if err := rows.Scan(
+			&identity.ID,
+			&identity.UserID,
+			&identity.Provider,
+			&identity.Subject,
+			&identity.Email,
+			&identity.EmailVerified,
+			&identity.RawClaims,
+			&identity.LastAuthenticatedAt,
+			&identity.CreatedAt,
+		); err != nil {
+			return UserIdentity{}, err
+		}
+		if found {
+			return UserIdentity{}, ErrConflict
+		}
+		match = identity
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return UserIdentity{}, err
+	}
+	if !found {
+		return UserIdentity{}, ErrNotFound
+	}
+	return match, nil
+}
+
+// ListUserIdentitiesByProvider returns provider identities ordered by newest first.
+// A non-positive limit returns all matching identities.
+func (p *PostgresStore) ListUserIdentitiesByProvider(ctx context.Context, provider string, limit int) ([]UserIdentity, error) {
+	query := `SELECT id::text, user_id::text, provider, subject, COALESCE(email::text, ''), email_verified, raw_claims, last_authenticated_at, created_at
+		 FROM user_identities
+		 WHERE provider = $1
+		 ORDER BY created_at DESC`
+	args := []any{strings.ToLower(strings.TrimSpace(provider))}
+	if limit > 0 {
+		query += ` LIMIT $2`
+		args = append(args, limit)
+	}
+	rows, err := p.queryContextAnyScope(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := make([]UserIdentity, 0)
+	for rows.Next() {
+		var identity UserIdentity
+		if err := rows.Scan(
+			&identity.ID,
+			&identity.UserID,
+			&identity.Provider,
+			&identity.Subject,
+			&identity.Email,
+			&identity.EmailVerified,
+			&identity.RawClaims,
+			&identity.LastAuthenticatedAt,
+			&identity.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, identity)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+// DeleteUserIdentity removes one provider identity by provider and subject.
+func (p *PostgresStore) DeleteUserIdentity(ctx context.Context, provider string, subject string) error {
+	result, err := p.execContextAnyScope(
+		ctx,
+		`DELETE FROM user_identities
+		 WHERE provider = $1
+		   AND subject = $2`,
+		strings.ToLower(strings.TrimSpace(provider)),
+		strings.TrimSpace(subject),
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err == nil && affected == 0 {
+		return ErrNotFound
+	}
+	audit.WriteAction(ctx, audit.AuditEvent{
+		Action:       "auth.identity.delete",
+		ResourceType: "user_identity",
+		ResourceID:   strings.ToLower(strings.TrimSpace(provider)) + ":" + strings.TrimSpace(subject),
+		Outcome:      "success",
+	})
+	return nil
+}
+
 func scanSessionWithUser(row rowScanner) (Session, error) {
 	var session Session
 	var orgID, workspaceID, projectID, ip, userAgent sql.NullString

--- a/internal/db/postgres_auth_test.go
+++ b/internal/db/postgres_auth_test.go
@@ -94,6 +94,35 @@ func TestPostgresAuthUserIdentityAndSessionLifecycle(t *testing.T) {
 		t.Fatalf("unexpected fetched identity: %+v", gotIdentity)
 	}
 
+	mock.ExpectQuery("FROM user_identities").
+		WithArgs("github", userID).
+		WillReturnRows(postgresAuthIdentityRows(now).AddRow(identityID, userID, "github", "alice-subject", "alice@example.com", true, []byte(`{"login":"alice"}`), now, now))
+	gotIdentityByUserID, err := store.GetUserIdentityByProviderUserID(ctx, "GITHUB", userID)
+	if err != nil {
+		t.Fatalf("get identity by provider user id: %v", err)
+	}
+	if gotIdentityByUserID.ID != identityID {
+		t.Fatalf("unexpected fetched identity by user id: %+v", gotIdentityByUserID)
+	}
+
+	mock.ExpectQuery("FROM user_identities").
+		WithArgs("github", 10).
+		WillReturnRows(postgresAuthIdentityRows(now).AddRow(identityID, userID, "github", "alice-subject", "alice@example.com", true, []byte(`{"login":"alice"}`), now, now))
+	providerIdentities, err := store.ListUserIdentitiesByProvider(ctx, "GITHUB", 10)
+	if err != nil {
+		t.Fatalf("list identities by provider: %v", err)
+	}
+	if len(providerIdentities) != 1 || providerIdentities[0].ID != identityID {
+		t.Fatalf("unexpected provider identities: %+v", providerIdentities)
+	}
+
+	mock.ExpectExec("DELETE FROM user_identities").
+		WithArgs("github", "alice-subject").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	if err := store.DeleteUserIdentity(ctx, "GITHUB", "alice-subject"); err != nil {
+		t.Fatalf("delete identity: %v", err)
+	}
+
 	mock.ExpectQuery("WITH inserted AS").
 		WithArgs(sessionHash[:], userID, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), "manual", "203.0.113.10", sqlmock.AnyArg(), now.Add(15*time.Minute), now.Add(24*time.Hour), now, sqlmock.AnyArg(), now).
 		WillReturnRows(postgresAuthSessionRows().AddRow(sessionHash[:], userID, "tenant-a", "workspace-a", "project-a", "manual", "203.0.113.10", "browser", now.Add(15*time.Minute), now.Add(24*time.Hour), now, nil, now, userID, "alice@example.com", "Alice", "", "active", now, now, nil))

--- a/internal/db/postgres_enterprise_auth.go
+++ b/internal/db/postgres_enterprise_auth.go
@@ -537,6 +537,43 @@ func (p *PostgresStore) GetIdentityConnectionByID(ctx context.Context, connectio
 	))
 }
 
+// GetIdentityConnectionBySCIMBearerTokenHash resolves a connection by its
+// stored SCIM bearer-token hash without requiring an org-scoped context.
+func (p *PostgresStore) GetIdentityConnectionBySCIMBearerTokenHash(ctx context.Context, tokenHash string) (IdentityConnection, error) {
+	rows, err := p.queryContextAnyScope(
+		ctx,
+		`SELECT `+identityConnectionColumns+`
+		 FROM identity_connections
+		 WHERE scim_bearer_token_hash = NULLIF($1, '')
+		 LIMIT 2`,
+		strings.TrimSpace(tokenHash),
+	)
+	if err != nil {
+		return IdentityConnection{}, err
+	}
+	defer rows.Close()
+	var match IdentityConnection
+	found := false
+	for rows.Next() {
+		connection, scanErr := scanIdentityConnection(rows)
+		if scanErr != nil {
+			return IdentityConnection{}, scanErr
+		}
+		if found {
+			return IdentityConnection{}, ErrConflict
+		}
+		match = connection
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return IdentityConnection{}, err
+	}
+	if !found {
+		return IdentityConnection{}, ErrNotFound
+	}
+	return match, nil
+}
+
 // ListIdentityConnections returns organization identity connection scaffolds ordered by newest first.
 func (p *PostgresStore) ListIdentityConnections(ctx context.Context, orgID string, limit int) ([]IdentityConnection, error) {
 	if limit <= 0 {

--- a/internal/db/postgres_enterprise_auth_test.go
+++ b/internal/db/postgres_enterprise_auth_test.go
@@ -405,6 +405,123 @@ func TestPostgresGetIdentityConnectionByIDBypassesScope(t *testing.T) {
 	if connection.ID != "44444444-4444-4444-4444-444444444444" || connection.OrgID != "tenant-a" {
 		t.Fatalf("unexpected connection: %+v", connection)
 	}
+	mock.ExpectQuery("FROM identity_connections").
+		WithArgs("scim-token-hash").
+		WillReturnRows(postgresEnterpriseConnectionRows().AddRow(
+			"44444444-4444-4444-4444-444444444444",
+			"tenant-a",
+			"saml",
+			"sso",
+			nil,
+			"active",
+			[]byte(`{}`),
+			false,
+			true,
+			"https://idp.example.com/entity",
+			"https://idp.example.com/sso",
+			"-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----",
+			[]byte(`{"email":"mail"}`),
+			"scim-token-hash",
+			now,
+			now,
+		))
+	scimConnection, err := store.GetIdentityConnectionBySCIMBearerTokenHash(ctx, " scim-token-hash ")
+	if err != nil {
+		t.Fatalf("get identity connection by scim hash: %v", err)
+	}
+	if scimConnection.SCIMBearerTokenHash != "scim-token-hash" {
+		t.Fatalf("unexpected scim connection: %+v", scimConnection)
+	}
+	mock.ExpectQuery("FROM identity_connections").
+		WithArgs("duplicate-hash").
+		WillReturnRows(postgresEnterpriseConnectionRows().
+			AddRow(
+				"55555555-5555-5555-5555-555555555555",
+				"tenant-a",
+				"saml",
+				"sso",
+				nil,
+				"active",
+				[]byte(`{}`),
+				false,
+				true,
+				"https://idp.example.com/entity",
+				"https://idp.example.com/sso",
+				"-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----",
+				[]byte(`{"email":"mail"}`),
+				"duplicate-hash",
+				now,
+				now,
+			).
+			AddRow(
+				"66666666-6666-6666-6666-666666666666",
+				"tenant-b",
+				"saml",
+				"sso",
+				nil,
+				"active",
+				[]byte(`{}`),
+				false,
+				true,
+				"https://idp2.example.com/entity",
+				"https://idp2.example.com/sso",
+				"-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----",
+				[]byte(`{"email":"mail"}`),
+				"duplicate-hash",
+				now,
+				now,
+			))
+	if _, err := store.GetIdentityConnectionBySCIMBearerTokenHash(ctx, "duplicate-hash"); !errors.Is(err, ErrConflict) {
+		t.Fatalf("duplicate scim hash should return ErrConflict, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestPostgresSCIMProvisioningEvents(t *testing.T) {
+	rawDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer rawDB.Close()
+	store := NewPostgresStoreWithDB(rawDB)
+	ctx := context.Background()
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	eventID := "55555555-5555-5555-5555-555555555555"
+	connectionID := "44444444-4444-4444-4444-444444444444"
+	userID := "66666666-6666-6666-6666-666666666666"
+
+	mock.ExpectQuery("INSERT INTO scim_provisioning_events").
+		WithArgs(eventID, "tenant-a", connectionID, "create", sqlmock.AnyArg(), userID, `{"userName":"alice@example.com"}`, now).
+		WillReturnRows(postgresSCIMProvisioningEventRows().AddRow(eventID, "tenant-a", connectionID, "create", "external-alice", userID, []byte(`{"userName":"alice@example.com"}`), now))
+	event, err := store.CreateSCIMProvisioningEvent(ctx, SCIMProvisioningEventRecord{
+		ID:           eventID,
+		OrgID:        "tenant-a",
+		ConnectionID: connectionID,
+		Op:           "create",
+		ExternalID:   "external-alice",
+		UserID:       userID,
+		Payload:      map[string]any{"userName": "alice@example.com"},
+		OccurredAt:   now,
+	})
+	if err != nil {
+		t.Fatalf("create scim event: %v", err)
+	}
+	if event.Payload["userName"] != "alice@example.com" {
+		t.Fatalf("unexpected event: %+v", event)
+	}
+
+	mock.ExpectQuery("FROM scim_provisioning_events").
+		WithArgs("tenant-a", connectionID, 5).
+		WillReturnRows(postgresSCIMProvisioningEventRows().AddRow(eventID, "tenant-a", connectionID, "create", "external-alice", userID, []byte(`{"userName":"alice@example.com"}`), now))
+	events, err := store.ListSCIMProvisioningEvents(ctx, "tenant-a", connectionID, 5)
+	if err != nil {
+		t.Fatalf("list scim events: %v", err)
+	}
+	if len(events) != 1 || events[0].ID != eventID {
+		t.Fatalf("unexpected scim events: %+v", events)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet sql expectations: %v", err)
 	}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2089,6 +2089,9 @@ type Store interface {
 	GetUserByPrimaryEmail(ctx context.Context, email string) (User, error)
 	UpsertUserIdentity(ctx context.Context, identity UserIdentity) (UserIdentity, error)
 	GetUserIdentity(ctx context.Context, provider string, subject string) (UserIdentity, error)
+	GetUserIdentityByProviderUserID(ctx context.Context, provider string, userID string) (UserIdentity, error)
+	ListUserIdentitiesByProvider(ctx context.Context, provider string, limit int) ([]UserIdentity, error)
+	DeleteUserIdentity(ctx context.Context, provider string, subject string) error
 	CreateSession(ctx context.Context, session Session) (Session, error)
 	TouchSession(ctx context.Context, sessionIDHash []byte, now time.Time) (Session, error)
 	UpdateSessionContext(ctx context.Context, userID string, sessionIDHash []byte, orgID string, workspaceID string, projectID string, now time.Time) (Session, error)
@@ -2114,6 +2117,7 @@ type Store interface {
 	// for unauthenticated entry points like /auth/saml/login/:connection_id
 	// where the org context is determined by the connection itself.
 	GetIdentityConnectionByID(ctx context.Context, connectionID string) (IdentityConnection, error)
+	GetIdentityConnectionBySCIMBearerTokenHash(ctx context.Context, tokenHash string) (IdentityConnection, error)
 	// CreateSAMLRelayState persists one in-flight SAML SP-initiated request
 	// so the matching ACS POST (potentially handled by a different API
 	// instance) can look the AuthnRequest id, connection scope, and


### PR DESCRIPTION
Fixes #1136

## What changed
- Added feature-gated `/scim/v2` discovery and Users endpoints for native SCIM 2.0 provisioning.
- Authenticates SCIM requests with the per-connection bearer token hash and restricts provisioning to active native SAML connections.
- Persists SCIM users through `users` plus `user_identities` using `provider="scim:<connection_uuid>"`, records provisioning events, and supports create, list/filter, get, PUT, PATCH replace, and DELETE/deactivate.
- Documented the routes in the auth architecture, changelog, env flag reference, and OpenAPI contract.

## Validation
- `go vet ./...`
- `python3 - <<'PY' ... yaml.safe_load(open('docs/openapi-v1.yaml')) ... PY`
- `go test ./... -coverprofile=coverage.out`
- `go tool cover -func=coverage.out | tail -1` => `total: (statements) 80.0%`

## AI disclosure
AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native SCIM 2.0 provisioning under `/scim/v2` to sync users from an IdP for native SAML connections, and blocks SAML sign-in for users deactivated via SCIM. Implements Linear #1136.

- **New Features**
  - Endpoints: `GET /scim/v2/ServiceProviderConfig`, `/Schemas`, `/ResourceTypes`, and `GET/POST/GET by id/PUT/PATCH/DELETE /scim/v2/Users` (server-assigned ids, `filter=userName eq "..."`, pagination, PUT replace, PATCH replace-only, DELETE deactivates; omitted `active` defaults to `true`).
  - Auth: per-connection SCIM bearer token hash; only active native SAML connections allowed; OpenAPI adds `SCIMBearerAuth`.
  - SAML: denies sign-in for SCIM-deactivated users; no auto-reactivation.
  - Persistence: users stored via `users` + `user_identities` (`provider="scim:<connection_uuid>"`, `users.id` is the SCIM id); every create/update/deactivate/delete records a `scim_provisioning_events` audit entry.
  - API: responds `application/scim+json`, sets `meta.location` and the HTTP `Location` header on create.
  - Store: adds `GetIdentityConnectionBySCIMBearerTokenHash`, `GetUserIdentityByProviderUserID`, `ListUserIdentitiesByProvider`, `DeleteUserIdentity`; extracts `HashSCIMBearerToken`.
  - Config/Docs: gated by `IDENTRAIL_FEATURE_NATIVE_SSO` (compat alias `IDENTRAIL_ENABLE_NATIVE_SSO` overrides), updates architecture and OpenAPI.

<sup>Written for commit ba7ee70a98a68ff7362385909927f90a60643588. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1156?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

