### PR TITLE
Dispatch SCIM provisioning workflow events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Routed successful native SCIM user lifecycle operations through the workflow router:
+  - emits `scim.provisioned` events for create/update/deactivate/delete operations so Slack, Jira, and Linear destinations can receive directory-sync deltas
+  - extends workflow dispatch audit records with SCIM subject, connection, and operation fields for NDJSON governance review
+  - documents Okta and Azure AD native SSO setup, SCIM provisioning, and safe `sso_required` rollout in the enterprise quickstart
 - Added native SCIM 2.0 user provisioning endpoints (behind `IDENTRAIL_FEATURE_NATIVE_SSO`, with `IDENTRAIL_ENABLE_NATIVE_SSO` accepted as a compatibility alias):
   - `GET /scim/v2/ServiceProviderConfig`, `/Schemas`, and `/ResourceTypes` return Okta/Azure-friendly discovery documents using SCIM-shaped responses
   - `GET/POST/GET by id/PUT/PATCH/DELETE /scim/v2/Users` supports server-assigned ids, `filter=userName eq "..."`, pagination, full user replacement, PATCH `replace`, and deactivation/delete lifecycle handling

--- a/docs/enterprise-quickstart.md
+++ b/docs/enterprise-quickstart.md
@@ -121,7 +121,125 @@ Confirm:
 - no raw API key values in audit payload
 - subject/resource IDs appear only as hashed identifiers (`*_id_hash`)
 
-## 8. Clean Shutdown
+## 8. Set Up SSO With Okta
+
+Native enterprise SSO requires `IDENTRAIL_FEATURE_NATIVE_SSO=true` on the API. Create the Identrail SAML connection first, then paste the IdP metadata URL into Identrail so the connection can validate Okta assertions.
+
+Identrail values to copy into Okta:
+- **Single sign-on URL / ACS URL:** `${IDENTRAIL_API_URL}/auth/saml/acs/<connection_id>`
+- **Audience URI / SP Entity ID:** `${IDENTRAIL_API_URL}/auth/saml/metadata/<connection_id>`
+- **Name ID format:** `EmailAddress`
+- **Application username:** `Email`
+
+Okta click path:
+1. Open **Okta Admin Console -> Applications -> Applications -> Create App Integration**.
+2. Select **SAML 2.0**, then **Next**.
+3. Enter `Identrail` as the app name.
+4. On **Configure SAML**, paste the Identrail ACS URL into **Single sign-on URL**.
+5. Paste the Identrail SP Entity ID into **Audience URI (SP Entity ID)**.
+6. Set **Name ID format** to `EmailAddress` and **Application username** to `Email`.
+7. Finish the wizard.
+8. Open the new app's **Sign On** tab.
+9. In **SAML Signing Certificates**, copy **Identity Provider metadata** or **Metadata URL**.
+10. In Identrail, open the enterprise SSO connection and paste the metadata URL, then confirm the parsed Entity ID, SSO URL, and certificate fingerprint.
+
+Screenshot placeholders:
+- `[Screenshot placeholder: Okta Create App Integration modal with SAML 2.0 selected]`
+- `[Screenshot placeholder: Okta Configure SAML page showing Single sign-on URL and Audience URI fields]`
+- `[Screenshot placeholder: Okta Sign On tab showing Identity Provider metadata link]`
+
+## 9. Set Up SSO With Azure AD
+
+Microsoft now labels Azure AD as **Microsoft Entra ID** in the admin center. The click path below uses the current Entra labels while keeping the Azure AD wording operators still recognize.
+
+Identrail values to copy into Azure AD:
+- **Identifier (Entity ID):** `${IDENTRAIL_API_URL}/auth/saml/metadata/<connection_id>`
+- **Reply URL (Assertion Consumer Service URL):** `${IDENTRAIL_API_URL}/auth/saml/acs/<connection_id>`
+- **Sign on URL:** `${IDENTRAIL_API_URL}/auth/saml/login/<connection_id>`
+- **Unique User Identifier / Name ID:** `user.mail` or `user.userprincipalname`
+
+Azure AD / Entra click path:
+1. Open **Microsoft Entra admin center -> Identity -> Applications -> Enterprise applications**.
+2. Select **New application -> Create your own application**.
+3. Name it `Identrail`, select **Integrate any other application you don't find in the gallery (Non-gallery)**, then **Create**.
+4. Open **Single sign-on -> SAML**.
+5. In **Basic SAML Configuration**, paste the Identrail Entity ID into **Identifier (Entity ID)**.
+6. Paste the Identrail ACS URL into **Reply URL (Assertion Consumer Service URL)**.
+7. Paste the Identrail SAML login URL into **Sign on URL**.
+8. In **Attributes & Claims**, confirm the Name ID claim resolves to the user's email address.
+9. In **SAML Certificates**, copy **App Federation Metadata Url**.
+10. In Identrail, open the enterprise SSO connection and paste the metadata URL, then confirm the parsed Entity ID, SSO URL, and certificate fingerprint.
+
+Screenshot placeholders:
+- `[Screenshot placeholder: Entra Enterprise applications page with New application selected]`
+- `[Screenshot placeholder: Entra SAML Basic SAML Configuration editor]`
+- `[Screenshot placeholder: Entra SAML Certificates area showing App Federation Metadata Url]`
+
+## 10. Enable SCIM Provisioning
+
+Each native SAML connection receives one SCIM bearer token when it is created. Identrail returns the plaintext token once; store it in the IdP immediately. The API stores only the token hash.
+
+SCIM values:
+- **Base URL / Tenant URL:** `${IDENTRAIL_API_URL}/scim/v2`
+- **Secret Token / Bearer token:** the one-time SCIM token from the Identrail connection response
+- **Supported resources:** Users only; Groups are intentionally deferred
+- **Supported filter:** `userName eq "value"`
+
+Okta SCIM click path:
+1. Open **Okta Admin Console -> Applications -> Applications -> Identrail**.
+2. Open the **General** tab.
+3. In **App Settings**, set **Provisioning** to `SCIM`, then save.
+4. Open the **Provisioning** tab.
+5. Select **Integration -> Configure API Integration**.
+6. Check **Enable API integration**.
+7. Paste `${IDENTRAIL_API_URL}/scim/v2` into **Base URL**.
+8. Paste the Identrail SCIM bearer token into **API Token**.
+9. Select **Test API Credentials** and confirm success.
+10. Under **To App**, enable **Create Users**, **Update User Attributes**, and **Deactivate Users**.
+
+Azure AD / Entra SCIM click path:
+1. Open **Microsoft Entra admin center -> Identity -> Applications -> Enterprise applications -> Identrail**.
+2. Open **Provisioning**.
+3. Select **Get started** if provisioning has not been configured.
+4. Set **Provisioning Mode** to `Automatic`.
+5. Paste `${IDENTRAIL_API_URL}/scim/v2` into **Tenant URL**.
+6. Paste the Identrail SCIM bearer token into **Secret Token**.
+7. Select **Test Connection** and confirm success.
+8. Save the provisioning configuration.
+9. Keep the default user attribute mappings for `userName`, `active`, `displayName`, and `emails`.
+10. Set **Provisioning Status** to `On` when ready.
+
+Screenshot placeholders:
+- `[Screenshot placeholder: Okta Provisioning Integration tab with Base URL and API Token fields]`
+- `[Screenshot placeholder: Okta To App tab with Create, Update, and Deactivate enabled]`
+- `[Screenshot placeholder: Entra Provisioning page with Tenant URL and Secret Token fields]`
+- `[Screenshot placeholder: Entra Provisioning Status set to On]`
+
+## 11. Enforce SSO-Only (`sso_required`)
+
+Set `sso_required=true` only after at least one SAML admin has completed a successful sign-in and SCIM provisioning has created or matched the expected users. Enforcing too early can lock out local/manual fallback users.
+
+Recommended rollout:
+1. Create the native SAML connection with `sso_required=false`.
+2. Assign a small admin test group in Okta or Azure AD.
+3. Confirm SAML login creates a `saml:<connection_id>` identity for the admin.
+4. Enable SCIM provisioning and confirm a test create/update/deactivate writes one `scim_provisioning_events` row and, when a workflow router is configured, one workflow dispatch audit record.
+5. Flip `sso_required=true` on the connection.
+6. Keep a break-glass admin path outside the enforced tenant while the first customer tenant is onboarding.
+
+Workflow dispatch verification, when a router is configured:
+```bash
+docker exec identrail-api sh -lc 'tail -n 50 /tmp/identrail-audit.jsonl' \
+  | jq -c 'select(.event_kind == "scim.provisioned") | {event_kind,subject_id,connection_id,scim_op,destination,success}'
+```
+
+Confirm:
+- one `scim.provisioned` workflow audit record appears for each SCIM create/update/deactivate/delete dispatch attempt
+- `connection_id` matches the native SAML connection
+- `scim_op` matches the SCIM lifecycle operation
+- failed Slack/Jira/Linear attempts include `success=false` and an `error` string
+
+## 12. Clean Shutdown
 
 ```bash
 docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env down

--- a/internal/api/enterprise_scim_routes.go
+++ b/internal/api/enterprise_scim_routes.go
@@ -17,6 +17,7 @@ import (
 	"github.com/identrail/identrail/internal/db"
 	"github.com/identrail/identrail/internal/enterprise"
 	"github.com/identrail/identrail/internal/telemetry"
+	"github.com/identrail/identrail/internal/workflow"
 	"go.uber.org/zap"
 )
 
@@ -271,7 +272,7 @@ func createSCIMUser(logger *zap.Logger, svc *Service, publicBaseURL string) gin.
 			writeSCIMSaveError(c, logger, err)
 			return
 		}
-		if err := recordSCIMEvent(c, svc, auth.Connection, enterprise.SCIMProvisioningCreate, user.SCIMUser); err != nil {
+		if err := recordSCIMEvent(c, svc, auth.Connection, enterprise.SCIMProvisioningCreate, user.SCIMUser, publicBaseURL); err != nil {
 			writeSCIMStoreError(c, logger, err, "record scim create")
 			return
 		}
@@ -314,7 +315,7 @@ func putSCIMUser(logger *zap.Logger, svc *Service, publicBaseURL string) gin.Han
 		if !user.Active {
 			op = enterprise.SCIMProvisioningDeactivate
 		}
-		if err := recordSCIMEvent(c, svc, auth.Connection, op, user.SCIMUser); err != nil {
+		if err := recordSCIMEvent(c, svc, auth.Connection, op, user.SCIMUser, publicBaseURL); err != nil {
 			writeSCIMStoreError(c, logger, err, "record scim update")
 			return
 		}
@@ -355,7 +356,7 @@ func patchSCIMUser(logger *zap.Logger, svc *Service, publicBaseURL string) gin.H
 		if !user.Active {
 			op = enterprise.SCIMProvisioningDeactivate
 		}
-		if err := recordSCIMEvent(c, svc, auth.Connection, op, user.SCIMUser); err != nil {
+		if err := recordSCIMEvent(c, svc, auth.Connection, op, user.SCIMUser, publicBaseURL); err != nil {
 			writeSCIMStoreError(c, logger, err, "record scim patch")
 			return
 		}
@@ -377,7 +378,7 @@ func deleteSCIMUser(logger *zap.Logger, svc *Service, publicBaseURL string) gin.
 			writeSCIMSaveError(c, logger, err)
 			return
 		}
-		if err := recordSCIMEvent(c, svc, auth.Connection, enterprise.SCIMProvisioningDelete, updated); err != nil {
+		if err := recordSCIMEvent(c, svc, auth.Connection, enterprise.SCIMProvisioningDelete, updated, publicBaseURL); err != nil {
 			writeSCIMStoreError(c, logger, err, "record scim delete")
 			return
 		}
@@ -582,7 +583,7 @@ func scimUserFromRecords(c *gin.Context, publicBaseURL string, user db.User, ide
 	}
 }
 
-func recordSCIMEvent(c *gin.Context, svc *Service, conn db.IdentityConnection, op enterprise.SCIMProvisioningOp, user enterprise.SCIMUser) error {
+func recordSCIMEvent(c *gin.Context, svc *Service, conn db.IdentityConnection, op enterprise.SCIMProvisioningOp, user enterprise.SCIMUser, publicBaseURL string) error {
 	payloadBytes, err := json.Marshal(user)
 	if err != nil {
 		return err
@@ -591,6 +592,10 @@ func recordSCIMEvent(c *gin.Context, svc *Service, conn db.IdentityConnection, o
 	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
 		return err
 	}
+	now := time.Now().UTC()
+	if svc != nil && svc.Now != nil {
+		now = svc.Now().UTC()
+	}
 	_, err = svc.Store.CreateSCIMProvisioningEvent(c.Request.Context(), db.SCIMProvisioningEventRecord{
 		OrgID:        conn.OrgID,
 		ConnectionID: conn.ID,
@@ -598,9 +603,32 @@ func recordSCIMEvent(c *gin.Context, svc *Service, conn db.IdentityConnection, o
 		ExternalID:   user.ExternalID,
 		UserID:       user.ID,
 		Payload:      payload,
-		OccurredAt:   time.Now().UTC(),
+		OccurredAt:   now,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	if svc == nil || svc.WorkflowRouter == nil {
+		return nil
+	}
+	if _, err := svc.WorkflowRouter.Dispatch(c.Request.Context(), workflow.Event{
+		Kind: workflow.EventSCIMProvisioned,
+		SCIMProvisioning: &workflow.SCIMProvisioningEvent{
+			OrgID:        conn.OrgID,
+			ConnectionID: conn.ID,
+			Operation:    string(op),
+			UserID:       user.ID,
+			UserName:     user.UserName,
+			ExternalID:   user.ExternalID,
+			Active:       user.Active,
+		},
+		Actor:      "scim:" + strings.TrimSpace(conn.ID),
+		EmittedAt:  now,
+		RelatedURL: scimUserLocation(c, publicBaseURL, user.ID),
+	}); err != nil {
+		_ = c.Error(err)
+	}
+	return nil
 }
 
 func applySCIMReplace(user *enterprise.SCIMUser, op scimPatchOperation) error {

--- a/internal/api/enterprise_scim_routes_test.go
+++ b/internal/api/enterprise_scim_routes_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,10 +16,15 @@ import (
 	"github.com/google/uuid"
 	"github.com/identrail/identrail/internal/db"
 	"github.com/identrail/identrail/internal/telemetry"
+	"github.com/identrail/identrail/internal/workflow"
 	"go.uber.org/zap"
 )
 
 func newSCIMTestRouter(t *testing.T, enabled bool) (*gin.Engine, *db.MemoryStore, db.IdentityConnection, string) {
+	return newSCIMTestRouterWithService(t, enabled, nil)
+}
+
+func newSCIMTestRouterWithService(t *testing.T, enabled bool, configure func(*Service)) (*gin.Engine, *db.MemoryStore, db.IdentityConnection, string) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 	store := db.NewMemoryStore()
@@ -41,6 +48,9 @@ func newSCIMTestRouter(t *testing.T, enabled bool) (*gin.Engine, *db.MemoryStore
 		t.Fatalf("seed connection: %v", err)
 	}
 	svc := NewService(store, routerScanner{}, "aws")
+	if configure != nil {
+		configure(svc)
+	}
 	router := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{
 		FeatureNativeSSO: enabled,
 		PublicBaseURL:    "https://api.example.com",
@@ -48,6 +58,21 @@ func newSCIMTestRouter(t *testing.T, enabled bool) (*gin.Engine, *db.MemoryStore
 		RateLimitBurst:   1000,
 	})
 	return router, store, conn, token
+}
+
+type recordingWorkflowDestination struct {
+	name  string
+	calls int
+	event workflow.Event
+	err   error
+}
+
+func (d *recordingWorkflowDestination) Name() string { return d.name }
+
+func (d *recordingWorkflowDestination) Send(_ context.Context, event workflow.Event) error {
+	d.calls++
+	d.event = event
+	return d.err
 }
 
 func doSCIM(t *testing.T, router *gin.Engine, token string, method string, path string, body string) *httptest.ResponseRecorder {
@@ -110,6 +135,94 @@ func TestEnterpriseSCIMRoutes_DefaultsOmittedActiveToEnabled(t *testing.T) {
 	}
 	if user.Status != "active" {
 		t.Fatalf("omitted active should persist active user, got %q", user.Status)
+	}
+}
+
+func TestEnterpriseSCIMRoutes_CreateDispatchesWorkflowEvent(t *testing.T) {
+	destination := &recordingWorkflowDestination{name: "test-workflow"}
+	auditLog := &bytes.Buffer{}
+	dispatchTime := time.Date(2026, 5, 17, 14, 0, 0, 0, time.UTC)
+	router, _, conn, token := newSCIMTestRouterWithService(t, true, func(svc *Service) {
+		svc.Now = func() time.Time { return dispatchTime }
+		svc.WorkflowRouter = &workflow.Router{
+			Destinations: []workflow.RoutedDestination{{Destination: destination, Policy: workflow.AlertPolicy{}}},
+			Audit:        &workflow.JSONLineAuditSink{Writer: auditLog},
+			Now:          func() time.Time { return dispatchTime },
+		}
+	})
+	createBody := `{
+		"userName":"workflow-user@example.com",
+		"displayName":"Workflow User",
+		"active":true,
+		"emails":[{"value":"workflow-user@example.com","type":"work","primary":true}]
+	}`
+	created := doSCIM(t, router, token, http.MethodPost, "/scim/v2/Users", createBody)
+	if created.Code != http.StatusCreated {
+		t.Fatalf("create: code %d body %s", created.Code, created.Body.String())
+	}
+	var response struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(created.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if destination.calls != 1 {
+		t.Fatalf("workflow destination calls: want 1, got %d", destination.calls)
+	}
+	if destination.event.Kind != workflow.EventSCIMProvisioned {
+		t.Fatalf("unexpected workflow kind: %s", destination.event.Kind)
+	}
+	if destination.event.SCIMProvisioning == nil {
+		t.Fatal("missing scim workflow payload")
+	}
+	if got := destination.event.SCIMProvisioning; got.Operation != "create" || got.UserID != response.ID || got.UserName != "workflow-user@example.com" || got.ConnectionID != conn.ID {
+		t.Fatalf("unexpected scim workflow payload: %+v", got)
+	}
+	lines := strings.Split(strings.TrimSpace(auditLog.String()), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("workflow audit lines: want 1, got %d (%q)", len(lines), auditLog.String())
+	}
+	var record workflow.DispatchRecord
+	if err := json.Unmarshal([]byte(lines[0]), &record); err != nil {
+		t.Fatalf("decode workflow audit record: %v", err)
+	}
+	if record.EventKind != workflow.EventSCIMProvisioned || record.SubjectID != response.ID || record.ConnectionID != conn.ID || record.SCIMOp != "create" || !record.Success {
+		t.Fatalf("unexpected workflow audit record: %+v", record)
+	}
+}
+
+func TestEnterpriseSCIMRoutes_WorkflowDispatchFailureDoesNotFailCreate(t *testing.T) {
+	destination := &recordingWorkflowDestination{name: "test-workflow", err: errors.New("workflow unavailable")}
+	auditLog := &bytes.Buffer{}
+	router, _, conn, token := newSCIMTestRouterWithService(t, true, func(svc *Service) {
+		svc.WorkflowRouter = &workflow.Router{
+			Destinations: []workflow.RoutedDestination{{Destination: destination, Policy: workflow.AlertPolicy{}}},
+			Audit:        &workflow.JSONLineAuditSink{Writer: auditLog},
+		}
+	})
+	createBody := `{
+		"userName":"workflow-failure@example.com",
+		"displayName":"Workflow Failure",
+		"active":true,
+		"emails":[{"value":"workflow-failure@example.com","type":"work","primary":true}]
+	}`
+	created := doSCIM(t, router, token, http.MethodPost, "/scim/v2/Users", createBody)
+	if created.Code != http.StatusCreated {
+		t.Fatalf("workflow dispatch failure should not fail persisted SCIM create, got %d body %s", created.Code, created.Body.String())
+	}
+	if destination.calls != 1 {
+		t.Fatalf("workflow destination calls: want 1, got %d", destination.calls)
+	}
+	lines := strings.Split(strings.TrimSpace(auditLog.String()), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("workflow audit lines: want 1, got %d (%q)", len(lines), auditLog.String())
+	}
+	var record workflow.DispatchRecord
+	if err := json.Unmarshal([]byte(lines[0]), &record); err != nil {
+		t.Fatalf("decode workflow audit record: %v", err)
+	}
+	if record.EventKind != workflow.EventSCIMProvisioned || record.ConnectionID != conn.ID || record.SCIMOp != "create" || record.Success || !strings.Contains(record.Error, "workflow unavailable") {
+		t.Fatalf("unexpected workflow failure audit record: %+v", record)
 	}
 }
 

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -23,6 +23,7 @@ import (
 	"github.com/identrail/identrail/internal/scheduler"
 	"github.com/identrail/identrail/internal/secretstore"
 	"github.com/identrail/identrail/internal/telemetry"
+	"github.com/identrail/identrail/internal/workflow"
 	"go.opentelemetry.io/otel/propagation"
 )
 
@@ -121,6 +122,7 @@ type Service struct {
 	AWSScannerFactory            AWSScannerFactory
 	AWSCloudFormationTemplateURL string
 	AWSAccountID                 string
+	WorkflowRouter               *workflow.Router
 	GitHubAppID                  int64
 	GitHubAppName                string
 	GitHubAppPrivateKey          string

--- a/internal/workflow/event.go
+++ b/internal/workflow/event.go
@@ -1,4 +1,4 @@
-// Package workflow routes finding lifecycle events to engineering and security
+// Package workflow routes product lifecycle events to engineering and security
 // workflow destinations (Slack, Jira, Linear) and emits an auditable record of
 // every dispatch attempt for governance.
 //
@@ -16,7 +16,7 @@ import (
 	"github.com/identrail/identrail/internal/domain"
 )
 
-// EventKind enumerates the finding lifecycle transitions that can be routed.
+// EventKind enumerates the lifecycle transitions that can be routed.
 type EventKind string
 
 const (
@@ -25,22 +25,51 @@ const (
 	EventFindingSuppressed   EventKind = "finding.suppressed"
 	EventFindingResolved     EventKind = "finding.resolved"
 	EventFixPROpened         EventKind = "finding.fix_pr_opened"
+	EventSCIMProvisioned     EventKind = "scim.provisioned"
 )
 
-// Event is one finding lifecycle event delivered to workflow destinations.
+// SCIMProvisioningEvent describes one directory-sync user lifecycle delta that
+// should be routed to governance and customer workflow destinations.
+type SCIMProvisioningEvent struct {
+	OrgID        string `json:"org_id,omitempty"`
+	ConnectionID string `json:"connection_id"`
+	Operation    string `json:"operation"`
+	UserID       string `json:"user_id"`
+	UserName     string `json:"user_name,omitempty"`
+	ExternalID   string `json:"external_id,omitempty"`
+	Active       bool   `json:"active"`
+}
+
+// Event is one lifecycle event delivered to workflow destinations.
 type Event struct {
-	Kind       EventKind      `json:"kind"`
-	Finding    domain.Finding `json:"finding"`
-	Actor      string         `json:"actor,omitempty"`
-	Note       string         `json:"note,omitempty"`
-	EmittedAt  time.Time      `json:"emitted_at"`
-	RelatedURL string         `json:"related_url,omitempty"`
+	Kind             EventKind              `json:"kind"`
+	Finding          domain.Finding         `json:"finding,omitzero"`
+	SCIMProvisioning *SCIMProvisioningEvent `json:"scim_provisioning,omitempty"`
+	Actor            string                 `json:"actor,omitempty"`
+	Note             string                 `json:"note,omitempty"`
+	EmittedAt        time.Time              `json:"emitted_at"`
+	RelatedURL       string                 `json:"related_url,omitempty"`
 }
 
 // Validate enforces the minimum invariants every destination relies on.
 func (e Event) Validate() error {
 	if strings.TrimSpace(string(e.Kind)) == "" {
 		return fmt.Errorf("event kind is required")
+	}
+	if e.Kind == EventSCIMProvisioned {
+		if e.SCIMProvisioning == nil {
+			return fmt.Errorf("event scim_provisioning is required")
+		}
+		if strings.TrimSpace(e.SCIMProvisioning.ConnectionID) == "" {
+			return fmt.Errorf("event scim_provisioning.connection_id is required")
+		}
+		if strings.TrimSpace(e.SCIMProvisioning.Operation) == "" {
+			return fmt.Errorf("event scim_provisioning.operation is required")
+		}
+		if strings.TrimSpace(e.SCIMProvisioning.UserID) == "" {
+			return fmt.Errorf("event scim_provisioning.user_id is required")
+		}
+		return nil
 	}
 	if strings.TrimSpace(e.Finding.ID) == "" {
 		return fmt.Errorf("event finding.id is required")
@@ -67,9 +96,11 @@ func (p AlertPolicy) Allow(event Event) bool {
 		if !ok {
 			return false
 		}
-		eventOK, eventRank := severityRankOf(event.Finding.Severity)
-		if !eventOK || eventRank < floorRank {
-			return false
+		if event.Finding.ID != "" {
+			eventOK, eventRank := severityRankOf(event.Finding.Severity)
+			if !eventOK || eventRank < floorRank {
+				return false
+			}
 		}
 	}
 	if len(p.AllowKinds) > 0 && !containsKind(p.AllowKinds, event.Kind) {

--- a/internal/workflow/jira.go
+++ b/internal/workflow/jira.go
@@ -80,13 +80,19 @@ func (j JiraDestination) payload(event Event) map[string]any {
 	issueType := valueOrFallback(j.IssueType, "Task")
 	title := valueOrFallback(event.Finding.Title, fmt.Sprintf("Identrail finding %s", event.Finding.ID))
 	summary := fmt.Sprintf("[%s] %s", strings.ToUpper(string(event.Finding.Severity)), title)
+	labels := []string{"identrail", string(event.Finding.Type), strings.ToLower(string(event.Finding.Severity))}
+	if event.Kind == EventSCIMProvisioned && event.SCIMProvisioning != nil {
+		scim := event.SCIMProvisioning
+		summary = fmt.Sprintf("[SCIM] %s user %s", strings.ToUpper(scim.Operation), valueOrFallback(scim.UserName, scim.UserID))
+		labels = []string{"identrail", "scim", strings.ToLower(scim.Operation)}
+	}
 	return map[string]any{
 		"fields": map[string]any{
 			"project":     map[string]any{"key": j.ProjectKey},
 			"summary":     summary,
 			"description": j.buildADFDescription(event),
 			"issuetype":   map[string]any{"name": issueType},
-			"labels":      []string{"identrail", string(event.Finding.Type), strings.ToLower(string(event.Finding.Severity))},
+			"labels":      labels,
 		},
 	}
 }
@@ -94,6 +100,25 @@ func (j JiraDestination) payload(event Event) map[string]any {
 // buildADFDescription returns an Atlassian Document Format description, the
 // only body format accepted by Jira Cloud REST API v3.
 func (j JiraDestination) buildADFDescription(event Event) map[string]any {
+	if event.Kind == EventSCIMProvisioned && event.SCIMProvisioning != nil {
+		scim := event.SCIMProvisioning
+		paragraphs := []map[string]any{
+			paragraph(fmt.Sprintf("Event: %s", event.Kind)),
+			paragraph(fmt.Sprintf("User ID: %s", scim.UserID)),
+			paragraph(fmt.Sprintf("User name: %s", scim.UserName)),
+			paragraph(fmt.Sprintf("Connection: %s", scim.ConnectionID)),
+			paragraph(fmt.Sprintf("Operation: %s", scim.Operation)),
+			paragraph(fmt.Sprintf("Active: %t", scim.Active)),
+		}
+		if event.RelatedURL != "" {
+			paragraphs = append(paragraphs, paragraph("Related: "+event.RelatedURL))
+		}
+		return map[string]any{
+			"type":    "doc",
+			"version": 1,
+			"content": paragraphs,
+		}
+	}
 	paragraphs := []map[string]any{
 		paragraph(fmt.Sprintf("Event: %s", event.Kind)),
 		paragraph(fmt.Sprintf("Finding ID: %s", event.Finding.ID)),

--- a/internal/workflow/linear.go
+++ b/internal/workflow/linear.go
@@ -38,7 +38,11 @@ func (l LinearDestination) Send(ctx context.Context, event Event) error {
 	}
 
 	title := valueOrFallback(event.Finding.Title, fmt.Sprintf("Identrail finding %s", event.Finding.ID))
-	title = fmt.Sprintf("[%s] %s", strings.ToUpper(string(event.Finding.Severity)), title)
+	if event.Kind == EventSCIMProvisioned && event.SCIMProvisioning != nil {
+		title = fmt.Sprintf("[SCIM] %s user %s", strings.ToUpper(event.SCIMProvisioning.Operation), valueOrFallback(event.SCIMProvisioning.UserName, event.SCIMProvisioning.UserID))
+	} else {
+		title = fmt.Sprintf("[%s] %s", strings.ToUpper(string(event.Finding.Severity)), title)
+	}
 
 	payload := map[string]any{
 		"query": `mutation IssueCreate($input: IssueCreateInput!) {
@@ -108,6 +112,18 @@ func (l LinearDestination) Send(ctx context.Context, event Event) error {
 func (l LinearDestination) buildDescription(event Event) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "**Event:** `%s`\n\n", event.Kind)
+	if event.Kind == EventSCIMProvisioned && event.SCIMProvisioning != nil {
+		scim := event.SCIMProvisioning
+		fmt.Fprintf(&b, "**User ID:** `%s`\n\n", scim.UserID)
+		fmt.Fprintf(&b, "**User name:** `%s`\n\n", scim.UserName)
+		fmt.Fprintf(&b, "**Connection:** `%s`\n\n", scim.ConnectionID)
+		fmt.Fprintf(&b, "**Operation:** `%s`\n\n", scim.Operation)
+		fmt.Fprintf(&b, "**Active:** %t\n\n", scim.Active)
+		if event.RelatedURL != "" {
+			fmt.Fprintf(&b, "Related: %s\n", event.RelatedURL)
+		}
+		return b.String()
+	}
 	fmt.Fprintf(&b, "**Finding ID:** `%s`\n\n", event.Finding.ID)
 	fmt.Fprintf(&b, "**Severity:** %s\n\n", event.Finding.Severity)
 	fmt.Fprintf(&b, "**Type:** `%s`\n\n", event.Finding.Type)

--- a/internal/workflow/router.go
+++ b/internal/workflow/router.go
@@ -19,12 +19,15 @@ type AuditSink interface {
 
 // DispatchRecord captures one delivery attempt by the Router.
 type DispatchRecord struct {
-	EventKind   EventKind `json:"event_kind"`
-	FindingID   string    `json:"finding_id"`
-	Destination string    `json:"destination"`
-	Success     bool      `json:"success"`
-	Error       string    `json:"error,omitempty"`
-	AttemptedAt time.Time `json:"attempted_at"`
+	EventKind    EventKind `json:"event_kind"`
+	FindingID    string    `json:"finding_id,omitempty"`
+	SubjectID    string    `json:"subject_id,omitempty"`
+	ConnectionID string    `json:"connection_id,omitempty"`
+	SCIMOp       string    `json:"scim_op,omitempty"`
+	Destination  string    `json:"destination"`
+	Success      bool      `json:"success"`
+	Error        string    `json:"error,omitempty"`
+	AttemptedAt  time.Time `json:"attempted_at"`
 }
 
 // RoutedDestination binds a Destination to its activation policy.
@@ -60,12 +63,15 @@ func (r Router) Dispatch(ctx context.Context, event Event) ([]DispatchRecord, er
 	for i, routed := range r.Destinations {
 		if routed.Destination == nil {
 			rec := DispatchRecord{
-				EventKind:   event.Kind,
-				FindingID:   event.Finding.ID,
-				Destination: fmt.Sprintf("invalid-route-%d", i),
-				AttemptedAt: now,
-				Success:     false,
-				Error:       "nil destination in router configuration",
+				EventKind:    event.Kind,
+				FindingID:    event.Finding.ID,
+				SubjectID:    eventSubjectID(event),
+				ConnectionID: eventConnectionID(event),
+				SCIMOp:       eventSCIMOp(event),
+				Destination:  fmt.Sprintf("invalid-route-%d", i),
+				AttemptedAt:  now,
+				Success:      false,
+				Error:        "nil destination in router configuration",
 			}
 			if err := r.recordAudit(ctx, rec); err != nil && firstErr == nil {
 				firstErr = fmt.Errorf("audit sink: %w", err)
@@ -80,10 +86,13 @@ func (r Router) Dispatch(ctx context.Context, event Event) ([]DispatchRecord, er
 			continue
 		}
 		rec := DispatchRecord{
-			EventKind:   event.Kind,
-			FindingID:   event.Finding.ID,
-			Destination: routed.Destination.Name(),
-			AttemptedAt: now,
+			EventKind:    event.Kind,
+			FindingID:    event.Finding.ID,
+			SubjectID:    eventSubjectID(event),
+			ConnectionID: eventConnectionID(event),
+			SCIMOp:       eventSCIMOp(event),
+			Destination:  routed.Destination.Name(),
+			AttemptedAt:  now,
 		}
 		if err := routed.Destination.Send(ctx, event); err != nil {
 			rec.Success = false
@@ -117,4 +126,25 @@ func (r Router) now() time.Time {
 		return r.Now()
 	}
 	return time.Now().UTC()
+}
+
+func eventSubjectID(event Event) string {
+	if event.SCIMProvisioning != nil {
+		return event.SCIMProvisioning.UserID
+	}
+	return event.Finding.ID
+}
+
+func eventConnectionID(event Event) string {
+	if event.SCIMProvisioning != nil {
+		return event.SCIMProvisioning.ConnectionID
+	}
+	return ""
+}
+
+func eventSCIMOp(event Event) string {
+	if event.SCIMProvisioning != nil {
+		return event.SCIMProvisioning.Operation
+	}
+	return ""
 }

--- a/internal/workflow/slack.go
+++ b/internal/workflow/slack.go
@@ -57,6 +57,28 @@ func (s SlackDestination) Send(ctx context.Context, event Event) error {
 }
 
 func (s SlackDestination) payload(event Event) map[string]any {
+	if event.Kind == EventSCIMProvisioned && event.SCIMProvisioning != nil {
+		scim := event.SCIMProvisioning
+		title := valueOrFallback(scim.UserName, scim.UserID)
+		summary := fmt.Sprintf("*%s* — %s user `%s`", event.Kind, scim.Operation, title)
+		fields := []map[string]any{
+			{"type": "mrkdwn", "text": fmt.Sprintf("*User ID*\n`%s`", scim.UserID)},
+			{"type": "mrkdwn", "text": fmt.Sprintf("*Connection*\n`%s`", scim.ConnectionID)},
+			{"type": "mrkdwn", "text": fmt.Sprintf("*Operation*\n`%s`", scim.Operation)},
+			{"type": "mrkdwn", "text": fmt.Sprintf("*Active*\n%t", scim.Active)},
+		}
+		blocks := []map[string]any{
+			{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": summary}},
+			{"type": "section", "fields": fields},
+		}
+		if event.RelatedURL != "" {
+			blocks = append(blocks, map[string]any{
+				"type": "section",
+				"text": map[string]any{"type": "mrkdwn", "text": fmt.Sprintf("<%s|Open SCIM resource>", event.RelatedURL)},
+			})
+		}
+		return map[string]any{"text": summary, "blocks": blocks}
+	}
 	title := valueOrFallback(event.Finding.Title, fmt.Sprintf("Finding %s", event.Finding.ID))
 	summary := fmt.Sprintf("*%s* — %s (%s)", event.Kind, title, event.Finding.Severity)
 	fields := []map[string]any{

--- a/internal/workflow/workflow_test.go
+++ b/internal/workflow/workflow_test.go
@@ -31,6 +31,22 @@ func sampleEvent(kind EventKind) Event {
 	}
 }
 
+func sampleSCIMEvent() Event {
+	return Event{
+		Kind: EventSCIMProvisioned,
+		SCIMProvisioning: &SCIMProvisioningEvent{
+			OrgID:        "tenant-a",
+			ConnectionID: "conn-123",
+			Operation:    "create",
+			UserID:       "user-123",
+			UserName:     "alice@example.com",
+			Active:       true,
+		},
+		Actor:     "scim:conn-123",
+		EmittedAt: time.Date(2026, 5, 17, 14, 0, 0, 0, time.UTC),
+	}
+}
+
 type recordingDestination struct {
 	name    string
 	calls   int
@@ -53,8 +69,14 @@ func TestEvent_Validate(t *testing.T) {
 	if err := sampleEvent(EventFindingCreated).Validate(); err != nil {
 		t.Errorf("valid event rejected: %v", err)
 	}
+	if err := sampleSCIMEvent().Validate(); err != nil {
+		t.Errorf("valid scim event rejected: %v", err)
+	}
 	if err := (Event{Kind: EventFindingCreated}).Validate(); err == nil {
 		t.Error("expected error for missing finding id")
+	}
+	if err := (Event{Kind: EventSCIMProvisioned}).Validate(); err == nil {
+		t.Error("expected error for missing scim payload")
 	}
 	if err := (Event{Finding: domain.Finding{ID: "x"}}).Validate(); err == nil {
 		t.Error("expected error for missing kind")
@@ -72,6 +94,7 @@ func TestAlertPolicy_FiltersBySeverityKindAndType(t *testing.T) {
 		{"empty_policy_allows", AlertPolicy{}, base, true},
 		{"severity_floor_high_allows_high", AlertPolicy{MinSeverity: domain.SeverityHigh}, base, true},
 		{"severity_floor_critical_blocks_high", AlertPolicy{MinSeverity: domain.SeverityCritical}, base, false},
+		{"severity_floor_allows_scim_without_finding_severity", AlertPolicy{MinSeverity: domain.SeverityHigh}, sampleSCIMEvent(), true},
 		{"kind_allowlist_blocks_others", AlertPolicy{AllowKinds: []EventKind{EventFindingResolved}}, base, false},
 		{"kind_allowlist_matches", AlertPolicy{AllowKinds: []EventKind{EventFindingCreated}}, base, true},
 		{"type_allowlist_blocks_others", AlertPolicy{AllowTypes: []domain.FindingType{domain.FindingStaleIdentity}}, base, false},
@@ -129,6 +152,43 @@ func TestRouter_DispatchFansOutByPolicy(t *testing.T) {
 	}
 	if rec.Destination != "slack" || !rec.Success {
 		t.Errorf("unexpected audit record: %+v", rec)
+	}
+}
+
+func TestRouter_DispatchesSCIMProvisionedEventToAuditSink(t *testing.T) {
+	dest := &recordingDestination{name: "linear"}
+	auditBuf := &bytes.Buffer{}
+	router := Router{
+		Destinations: []RoutedDestination{{Destination: dest, Policy: AlertPolicy{AllowKinds: []EventKind{EventSCIMProvisioned}}}},
+		Audit:        &JSONLineAuditSink{Writer: auditBuf},
+		Now:          func() time.Time { return time.Date(2026, 5, 17, 14, 0, 0, 0, time.UTC) },
+	}
+	records, err := router.Dispatch(context.Background(), sampleSCIMEvent())
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if dest.calls != 1 {
+		t.Fatalf("destination calls: want 1, got %d", dest.calls)
+	}
+	if dest.lastEv.Kind != EventSCIMProvisioned || dest.lastEv.SCIMProvisioning == nil {
+		t.Fatalf("unexpected dispatched event: %+v", dest.lastEv)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records: want 1, got %d", len(records))
+	}
+	if records[0].EventKind != EventSCIMProvisioned || records[0].SubjectID != "user-123" || records[0].ConnectionID != "conn-123" || records[0].SCIMOp != "create" || !records[0].Success {
+		t.Fatalf("unexpected dispatch record: %+v", records[0])
+	}
+	lines := strings.Split(strings.TrimSpace(auditBuf.String()), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("audit lines: want 1, got %d (%q)", len(lines), auditBuf.String())
+	}
+	var rec DispatchRecord
+	if err := json.Unmarshal([]byte(lines[0]), &rec); err != nil {
+		t.Fatalf("decode audit line: %v", err)
+	}
+	if rec.EventKind != EventSCIMProvisioned || rec.SubjectID != "user-123" || rec.ConnectionID != "conn-123" || rec.SCIMOp != "create" {
+		t.Fatalf("unexpected audit record: %+v", rec)
 	}
 }
 
@@ -378,6 +438,31 @@ func TestSlackDestination_Send_HappyPath(t *testing.T) {
 	}
 }
 
+func TestSlackDestination_Send_SCIMProvisioningPayload(t *testing.T) {
+	srv, captured := captureTLSRequest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	event := sampleSCIMEvent()
+	event.RelatedURL = "https://api.example.com/scim/v2/Users/user-123"
+	dest := SlackDestination{WebhookURL: srv.URL, HTTPClient: srv.Client()}
+	if err := dest.Send(context.Background(), event); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(captured.Body, &payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	text, _ := payload["text"].(string)
+	if !strings.Contains(text, "scim.provisioned") || !strings.Contains(text, "alice@example.com") {
+		t.Fatalf("unexpected slack text: %q", text)
+	}
+	blocks, _ := payload["blocks"].([]any)
+	if len(blocks) != 3 {
+		t.Fatalf("expected SCIM fields plus related link block, got %+v", payload["blocks"])
+	}
+}
+
 func TestSlackDestination_Send_ErrorsOn5xx(t *testing.T) {
 	srv, _ := captureTLSRequest(t, func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "boom", http.StatusInternalServerError)
@@ -464,6 +549,45 @@ func TestJiraDestination_Send_HappyPath(t *testing.T) {
 	}
 }
 
+func TestJiraDestination_Send_SCIMProvisioningPayload(t *testing.T) {
+	srv, captured := captureTLSRequest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"10002","key":"OPS-2"}`))
+	})
+	event := sampleSCIMEvent()
+	event.RelatedURL = "https://api.example.com/scim/v2/Users/user-123"
+	dest := JiraDestination{
+		BaseURL:    srv.URL,
+		Email:      "ops@example.com",
+		APIToken:   "tok",
+		ProjectKey: "OPS",
+		HTTPClient: srv.Client(),
+	}
+	if err := dest.Send(context.Background(), event); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	var body struct {
+		Fields struct {
+			Summary     string         `json:"summary"`
+			Labels      []string       `json:"labels"`
+			Description map[string]any `json:"description"`
+		} `json:"fields"`
+	}
+	if err := json.Unmarshal(captured.Body, &body); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if body.Fields.Summary != "[SCIM] CREATE user alice@example.com" {
+		t.Fatalf("unexpected summary: %s", body.Fields.Summary)
+	}
+	if got := strings.Join(body.Fields.Labels, ","); got != "identrail,scim,create" {
+		t.Fatalf("unexpected labels: %v", body.Fields.Labels)
+	}
+	content, ok := body.Fields.Description["content"].([]any)
+	if !ok || len(content) < 7 {
+		t.Fatalf("expected SCIM ADF description content, got %+v", body.Fields.Description)
+	}
+}
+
 func TestJiraDestination_Send_ValidatesConfig(t *testing.T) {
 	cases := []struct {
 		name string
@@ -527,6 +651,33 @@ func TestLinearDestination_Send_HappyPath(t *testing.T) {
 	input, _ := body.Variables["input"].(map[string]any)
 	if input["teamId"] != "team-1" {
 		t.Errorf("teamId: want team-1, got %v", input["teamId"])
+	}
+}
+
+func TestLinearDestination_Send_SCIMProvisioningPayload(t *testing.T) {
+	srv, captured := captureTLSRequest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"issueCreate":{"success":true,"issue":{"id":"i2","identifier":"OPS-2","url":"https://linear.app/x"}}}}`))
+	})
+	event := sampleSCIMEvent()
+	event.RelatedURL = "https://api.example.com/scim/v2/Users/user-123"
+	dest := LinearDestination{APIURL: srv.URL, APIKey: "lin_xxx", TeamID: "team-1", HTTPClient: srv.Client()}
+	if err := dest.Send(context.Background(), event); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	var body struct {
+		Variables map[string]any `json:"variables"`
+	}
+	if err := json.Unmarshal(captured.Body, &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	input, _ := body.Variables["input"].(map[string]any)
+	if input["title"] != "[SCIM] CREATE user alice@example.com" {
+		t.Fatalf("unexpected title: %v", input["title"])
+	}
+	description, _ := input["description"].(string)
+	if !strings.Contains(description, "**Connection:** `conn-123`") || !strings.Contains(description, "Related: https://api.example.com/scim/v2/Users/user-123") {
+		t.Fatalf("unexpected description: %s", description)
 	}
 }
 


### PR DESCRIPTION
Fixes #1137

## Summary

- Added `scim.provisioned` workflow events for successful native SCIM create, update, deactivate, and delete operations.
- Extended workflow dispatch audit records with SCIM subject, connection, and operation fields, and taught Slack, Jira, and Linear destinations how to render SCIM lifecycle payloads.
- Updated the enterprise quickstart and changelog with Okta, Azure AD / Microsoft Entra, SCIM provisioning, and safe `sso_required` rollout guidance.

## Why

PR #1137 is the final enterprise SSO task after the native SCIM endpoints from #1136 / #1156. Directory sync changes now flow through the workflow router so customer operations teams can see SCIM deltas in their configured destinations and governance NDJSON audit log.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

Risk is moderate and contained to native SCIM workflow dispatch plus workflow destination rendering. When no workflow router is configured, SCIM behavior stays unchanged.

## Validation

```bash
go test ./internal/workflow
go test ./internal/api -run "TestEnterpriseSCIMRoutes_(CreateDispatchesWorkflowEvent|UserLifecycle|DisabledAndUnauthorized|DefaultsOmittedActiveToEnabled|SingleResourceLookupUsesDirectUserIDLookup)"
go test ./internal/workflow ./internal/api ./internal/config
python3 - <<PY
import yaml
with open("docs/openapi-v1.yaml", "r", encoding="utf-8") as fh:
    yaml.safe_load(fh)
print("openapi yaml ok")
PY
git diff --check
go vet ./...
go test ./... -coverprofile=coverage.out
go tool cover -func=coverage.out | tail -1
```

Results: all passed; total Go coverage is 80.1%.

Docs cross-check references:
- Okta SAML app integration wizard: https://help.okta.com/en-us/Content/Topics/Apps/apps_app_integration_wizard_saml.htm
- Okta SAML field reference: https://help.okta.com/en-us/Content/Topics/Apps/aiw-saml-reference.htm
- Microsoft Entra SAML SSO setup: https://learn.microsoft.com/en-us/azure/active-directory/manage-apps/add-application-portal-setup-sso
- Microsoft Entra automatic provisioning: https://learn.microsoft.com/en-us/azure/active-directory/app-provisioning/configure-automatic-user-provisioning-portal

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: No
- Tools used: N/A
- Areas where used: N/A
- Human verification performed: local tests, vet, coverage, diff review, docs source cross-check

## Related Issues

Fixes #1137

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes successful native SCIM user lifecycle operations through the workflow router and emits `scim.provisioned` so Slack, Jira, and Linear receive directory-sync updates. Completes enterprise SSO provisioning for #1137 with richer audit records and updated docs.

- New Features
  - Emit `scim.provisioned` on SCIM create/update/deactivate/delete from `internal/api`, including a related SCIM user URL.
  - Add `workflow.EventSCIMProvisioned` and `SCIMProvisioningEvent` with validation in `internal/workflow`; audit records now include `subject_id`, `connection_id`, and `scim_op`.
  - Dispatch via `Service.WorkflowRouter` with per-destination audit records; destination errors are recorded but do not fail SCIM API operations.
  - Update Slack, Jira, and Linear formatters to render SCIM payloads (user id/name, connection, operation, active, link); `workflow.AlertPolicy` accepts SCIM events without severity.
  - Expand docs: Okta and Azure AD/Entra SSO setup, SCIM provisioning, and safe `sso_required` rollout; changelog updated.

- Migration
  - No breaking changes; if no workflow router is configured, SCIM behavior is unchanged.
  - To receive events, initialize `Service.WorkflowRouter` with destinations and an audit sink.

<sup>Written for commit 715f2f3182743421c5c4c6241d52d88c9866b621. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1157?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

