### PR TITLE
Fix auth provider light mode icon states

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -473,6 +473,7 @@ describe('App', () => {
     const themeTrigger = screen.getByRole('button', { name: /Color theme: Dark/i });
     fireEvent.click(themeTrigger);
     fireEvent.click(screen.getByRole('menuitemradio', { name: /Light/i }));
+    expect(await screen.findByRole('button', { name: /Color theme: Light/i })).toBeInTheDocument();
 
     const githubProvider = await screen.findByRole('link', { name: /Continue with GitHub/i });
     const githubIcon = githubProvider.querySelector('.idt-auth-provider-icon-github');

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -464,6 +464,23 @@ describe('App', () => {
     expect(screen.getByRole('menuitemradio', { name: /Dark/i })).toBeInTheDocument();
   });
 
+  it('renders the GitHub provider mark on the light sign-up page', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(authConfig(false, true)));
+
+    setCurrentPath('/signup');
+    render(<App />);
+
+    const themeTrigger = screen.getByRole('button', { name: /Color theme: Dark/i });
+    fireEvent.click(themeTrigger);
+    fireEvent.click(screen.getByRole('menuitemradio', { name: /Light/i }));
+
+    const githubProvider = await screen.findByRole('link', { name: /Continue with GitHub/i });
+    const githubIcon = githubProvider.querySelector('.idt-auth-provider-icon-github');
+
+    expect(githubIcon).toBeInTheDocument();
+    expect(githubIcon).toHaveAttribute('src', '/brand-logos/github.svg');
+  });
+
   it('shows a clear API reachability error when auth config cannot be fetched', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new TypeError('Failed to fetch')));
 

--- a/web/src/pages/SignInPage.tsx
+++ b/web/src/pages/SignInPage.tsx
@@ -128,7 +128,7 @@ function providerIcon(provider: HostedProvider) {
         </svg>
       );
     case 'github':
-      return <img className="idt-auth-provider-icon" src="/brand-logos/github.svg" alt="" />;
+      return <img className="idt-auth-provider-icon idt-auth-provider-icon-github" src="/brand-logos/github.svg" alt="" />;
     case 'sso':
       return (
         <span className="idt-auth-provider-icon idt-auth-provider-icon-sso" aria-hidden="true">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6214,6 +6214,7 @@ html[data-theme='light'] .idt-auth-panel-signup h1 {
 html[data-theme='light'] .idt-auth-provider {
   width: 100%;
   min-height: 3.5rem;
+  position: relative;
   display: grid;
   grid-template-columns: 1.45rem minmax(12.75rem, 12.75rem) 1.45rem;
   align-items: center;
@@ -6230,17 +6231,46 @@ html[data-theme='light'] .idt-auth-provider {
   line-height: 1.2;
   text-decoration: none;
   cursor: pointer;
-  box-shadow: none;
+  overflow: hidden;
+  isolation: isolate;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
   transition:
-    border-color 0.16s ease,
-    background-color 0.16s ease,
-    transform 0.16s ease;
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    box-shadow 0.18s ease,
+    color 0.18s ease,
+    transform 0.18s ease;
+}
+
+.idt-auth-provider::before {
+  content: '';
+  position: absolute;
+  inset: 1px;
+  z-index: 0;
+  border-radius: 6px;
+  background: linear-gradient(105deg, transparent 5%, rgba(255, 255, 255, 0.1) 48%, transparent 72%);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(-35%);
+  transition:
+    opacity 0.22s ease,
+    transform 0.32s ease;
+}
+
+.idt-auth-page[data-auth-theme='light'] .idt-auth-provider::before,
+html[data-theme='light'] .idt-auth-page[data-auth-theme='light'] .idt-auth-provider::before {
+  background: linear-gradient(105deg, transparent 5%, rgba(15, 23, 42, 0.055) 48%, transparent 72%);
 }
 
 .idt-auth-provider::after {
   content: '';
   width: 1.45rem;
   height: 1px;
+}
+
+.idt-auth-provider > * {
+  position: relative;
+  z-index: 1;
 }
 
 .idt-auth-provider > span:not(.idt-auth-provider-icon) {
@@ -6263,10 +6293,34 @@ html[data-theme='light'] .idt-auth-provider-plain::after {
 .idt-auth-provider:focus-visible,
 html[data-theme='light'] .idt-auth-provider:hover,
 html[data-theme='light'] .idt-auth-provider:focus-visible {
-  transform: none;
-  border-color: var(--auth-muted);
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--auth-muted) 72%, var(--auth-text));
   background: var(--auth-button-muted-hover);
-  box-shadow: none;
+  box-shadow:
+    0 14px 34px rgba(0, 0, 0, 0.34),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.idt-auth-page[data-auth-theme='light'] .idt-auth-provider:hover,
+.idt-auth-page[data-auth-theme='light'] .idt-auth-provider:focus-visible,
+html[data-theme='light'] .idt-auth-page[data-auth-theme='light'] .idt-auth-provider:hover,
+html[data-theme='light'] .idt-auth-page[data-auth-theme='light'] .idt-auth-provider:focus-visible {
+  box-shadow:
+    0 14px 32px rgba(15, 23, 42, 0.1),
+    inset 0 1px 0 rgba(255, 255, 255, 0.92);
+}
+
+.idt-auth-provider:hover::before,
+.idt-auth-provider:focus-visible::before {
+  opacity: 1;
+  transform: translateX(35%);
+}
+
+.idt-auth-provider:active {
+  transform: translateY(0) scale(0.998);
+  box-shadow:
+    0 8px 18px rgba(0, 0, 0, 0.22),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
 .idt-auth-provider:focus-visible,
@@ -6284,10 +6338,31 @@ html[data-theme='light'] .idt-auth-provider-google {
   background: var(--auth-button-muted);
 }
 
-.idt-auth-page-signup .idt-auth-provider-github {
+.idt-auth-page[data-auth-theme='dark'].idt-auth-page-signup .idt-auth-provider-github {
   border-color: var(--auth-github);
   background: var(--auth-github);
   color: #ffffff;
+}
+
+.idt-auth-page[data-auth-theme='light'].idt-auth-page-signup .idt-auth-provider-github,
+html[data-theme='light'] .idt-auth-page[data-auth-theme='light'].idt-auth-page-signup .idt-auth-provider-github {
+  border-color: var(--auth-line-strong);
+  background: var(--auth-button-muted);
+  color: var(--auth-text);
+}
+
+.idt-auth-page[data-auth-theme='dark'].idt-auth-page-signup .idt-auth-provider-github:hover,
+.idt-auth-page[data-auth-theme='dark'].idt-auth-page-signup .idt-auth-provider-github:focus-visible {
+  border-color: #4b5563;
+  background: #2b3138;
+}
+
+.idt-auth-page[data-auth-theme='light'].idt-auth-page-signup .idt-auth-provider-github:hover,
+.idt-auth-page[data-auth-theme='light'].idt-auth-page-signup .idt-auth-provider-github:focus-visible,
+html[data-theme='light'] .idt-auth-page[data-auth-theme='light'].idt-auth-page-signup .idt-auth-provider-github:hover,
+html[data-theme='light'] .idt-auth-page[data-auth-theme='light'].idt-auth-page-signup .idt-auth-provider-github:focus-visible {
+  border-color: color-mix(in srgb, var(--auth-muted) 58%, var(--auth-line-strong));
+  background: var(--auth-button-muted-hover);
 }
 
 .idt-auth-provider-dark,
@@ -6314,9 +6389,34 @@ html[data-theme='light'] .idt-auth-provider-dark {
   font-weight: unset;
 }
 
-.idt-auth-page[data-auth-theme='dark'] .idt-auth-provider-icon:not(.idt-auth-provider-icon-google),
-.idt-auth-page-signup .idt-auth-provider-github .idt-auth-provider-icon {
+.idt-auth-provider-icon-github {
+  display: block;
+  opacity: 1;
+  filter: none;
+}
+
+.idt-auth-page[data-auth-theme='dark'] .idt-auth-provider-icon:not(.idt-auth-provider-icon-google) {
   filter: brightness(0) invert(1);
+}
+
+.idt-auth-page[data-auth-theme='light'] .idt-auth-provider-icon-github,
+html[data-theme='light'] .idt-auth-page[data-auth-theme='light'] .idt-auth-provider-icon-github {
+  filter: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .idt-auth-provider,
+  .idt-auth-provider::before {
+    transition: none;
+  }
+
+  .idt-auth-provider:hover,
+  .idt-auth-provider:focus-visible,
+  html[data-theme='light'] .idt-auth-provider:hover,
+  html[data-theme='light'] .idt-auth-provider:focus-visible,
+  .idt-auth-provider:active {
+    transform: none;
+  }
 }
 
 .idt-auth-provider-icon-sso {


### PR DESCRIPTION
No issue: directly reported auth-page visual polish bug on the sign-up page.

## Summary
- Restores the GitHub provider mark on the light sign-up page by giving it a dedicated icon class and explicit light-mode filter handling.
- Keeps the sign-up GitHub provider light in light mode while preserving the dark treatment in dark mode.
- Adds refined hover, focus, and press states to the auth provider buttons, including reduced-motion handling.

## Why
The GitHub logo could disappear on the light sign-up page because the provider icon was relying on broad filter rules intended for dark surfaces. The provider buttons also felt static on hover, so this adds a more polished interaction without changing the auth flow.

## Scope
- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation
```bash
npm test -- --run src/App.test.tsx
npm run build
```

Additional verification:
- Production preview smoke-tested with Playwright using a mocked auth config.
- Confirmed the light sign-up GitHub provider renders the GitHub SVG at 18px, with `filter: none`, visible opacity, and hover/focus styling applied.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes (not applicable)
- [x] CHANGELOG.md updated when relevant (not applicable)
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure
- AI-assisted: No
- Tools used: None
- Areas where used: None
- Human verification performed: Reviewed the auth CSS/TSX diff, ran the focused web test suite, built the production web bundle, and smoke-tested the sign-up provider rendering in Playwright.

## Related Issues
No issue: directly reported auth-page visual polish bug on the sign-up page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GitHub provider icon disappearing on the light sign-up page and adds polished hover/focus/press states for auth buttons. Dark mode behavior is unchanged and reduced motion is respected.

- **Bug Fixes**
  - Added `.idt-auth-provider-icon-github` with explicit light/dark filters and updated the light sign-up GitHub button styles and interaction states, with reduced-motion handling.
  - Strengthened test: switches to the light theme on `/signup` and asserts the GitHub provider link renders with `.idt-auth-provider-icon-github` and `src="/brand-logos/github.svg"`.

<sup>Written for commit 781970b7da90425084ddcb0ba7733a02e44ca48d. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1158?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

