### PR TITLE
Mirror container images to Docker Hub

### DIFF
--- a/.github/workflows/publish-container-images.yml
+++ b/.github/workflows/publish-container-images.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   publish:
-    name: Build and Publish GHCR Images
+    name: Build and Publish Container Images
     runs-on: ubuntu-latest
     timeout-minutes: 35
     permissions:
@@ -44,6 +44,7 @@ jobs:
           sha_tag="sha-${source_sha::12}"
 
           echo "base=ghcr.io/${owner}/identrail" >> "${GITHUB_OUTPUT}"
+          echo "docker_base=docker.io/identrail/identrail" >> "${GITHUB_OUTPUT}"
           echo "channel_tag=dev" >> "${GITHUB_OUTPUT}"
           echo "sha_tag=${sha_tag}" >> "${GITHUB_OUTPUT}"
           echo "source_sha=${source_sha}" >> "${GITHUB_OUTPUT}"
@@ -63,12 +64,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build and push images
         shell: bash
         run: |
           set -euo pipefail
 
           base="${{ steps.meta.outputs.base }}"
+          docker_base="${{ steps.meta.outputs.docker_base }}"
           channel_tag="${{ steps.meta.outputs.channel_tag }}"
           sha_tag="${{ steps.meta.outputs.sha_tag }}"
           source_url="${{ github.server_url }}/${{ github.repository }}"
@@ -97,6 +105,10 @@ jobs:
             -t "${base}:${sha_tag}" \
             -t "${base}-api:${channel_tag}" \
             -t "${base}-api:${sha_tag}" \
+            -t "${docker_base}:${channel_tag}" \
+            -t "${docker_base}:${sha_tag}" \
+            -t "${docker_base}-api:${channel_tag}" \
+            -t "${docker_base}-api:${sha_tag}" \
             -f deploy/docker/Dockerfile.backend \
             --build-arg TARGET=server \
             .
@@ -109,6 +121,8 @@ jobs:
             --label "org.opencontainers.image.description=Identrail background scan worker" \
             -t "${base}-worker:${channel_tag}" \
             -t "${base}-worker:${sha_tag}" \
+            -t "${docker_base}-worker:${channel_tag}" \
+            -t "${docker_base}-worker:${sha_tag}" \
             -f deploy/docker/Dockerfile.backend \
             --build-arg TARGET=worker \
             .
@@ -121,6 +135,8 @@ jobs:
             --label "org.opencontainers.image.description=Identrail Kubernetes connector agent" \
             -t "${base}-agent:${channel_tag}" \
             -t "${base}-agent:${sha_tag}" \
+            -t "${docker_base}-agent:${channel_tag}" \
+            -t "${docker_base}-agent:${sha_tag}" \
             -f deploy/docker/Dockerfile.backend \
             --build-arg TARGET=identrail-agent \
             .
@@ -133,6 +149,8 @@ jobs:
             --label "org.opencontainers.image.description=Identrail web dashboard for local image evaluation" \
             -t "${base}-web:${channel_tag}" \
             -t "${base}-web:${sha_tag}" \
+            -t "${docker_base}-web:${channel_tag}" \
+            -t "${docker_base}-web:${sha_tag}" \
             -f deploy/docker/Dockerfile.web \
             --build-arg "VITE_IDENTRAIL_API_URL=${{ steps.meta.outputs.web_api_url }}" \
             --build-arg "VITE_ALLOW_MANUAL_PRODUCT_SESSION=true" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,6 +219,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build and push images
         shell: bash
         run: |
@@ -226,6 +232,7 @@ jobs:
 
           owner="$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
           base="ghcr.io/${owner}/identrail"
+          docker_base="docker.io/identrail/identrail"
           tag="${{ needs.prepare.outputs.tag }}"
           publish_latest="${{ needs.prepare.outputs.publish_latest }}"
           source_url="${{ github.server_url }}/${{ github.repository }}"
@@ -317,11 +324,12 @@ jobs:
             shift
             shift
             local image="${base}-${name}"
+            local docker_image="${docker_base}-${name}"
             local args=("$@")
 
-            local tags=("-t" "${image}:${tag}")
+            local tags=("-t" "${image}:${tag}" "-t" "${docker_image}:${tag}")
             if [ "${publish_latest}" = "true" ]; then
-              tags+=("-t" "${image}:latest")
+              tags+=("-t" "${image}:latest" "-t" "${docker_image}:latest")
             fi
 
             docker buildx build \
@@ -335,14 +343,26 @@ jobs:
               "${tags[@]}" \
               "${args[@]}"
 
-            digest="$(docker buildx imagetools inspect "${image}:${tag}" --format '{{json .Manifest.Digest}}' | tr -d '"')"
-            printf '%s\n' "${image}:${tag}@${digest}" >> dist/image-digests.txt
+            for image_ref in "${image}" "${docker_image}"; do
+              digest="$(docker buildx imagetools inspect "${image_ref}:${tag}" --format '{{json .Manifest.Digest}}' | tr -d '"')"
+              printf '%s\n' "${image_ref}:${tag}@${digest}" >> dist/image-digests.txt
+            done
           }
 
           build_server() {
-            local tags=("-t" "${base}:${tag}" "-t" "${base}-api:${tag}")
+            local tags=(
+              "-t" "${base}:${tag}"
+              "-t" "${base}-api:${tag}"
+              "-t" "${docker_base}:${tag}"
+              "-t" "${docker_base}-api:${tag}"
+            )
             if [ "${publish_latest}" = "true" ]; then
-              tags+=("-t" "${base}:latest" "-t" "${base}-api:latest")
+              tags+=(
+                "-t" "${base}:latest"
+                "-t" "${base}-api:latest"
+                "-t" "${docker_base}:latest"
+                "-t" "${docker_base}-api:latest"
+              )
             fi
 
             docker buildx build \
@@ -359,7 +379,7 @@ jobs:
               --build-arg TARGET=server \
               .
 
-            for image in "${base}" "${base}-api"; do
+            for image in "${base}" "${base}-api" "${docker_base}" "${docker_base}-api"; do
               digest="$(docker buildx imagetools inspect "${image}:${tag}" --format '{{json .Manifest.Digest}}' | tr -d '"')"
               printf '%s\n' "${image}:${tag}@${digest}" >> dist/image-digests.txt
             done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 - Mirrored public container image publishing to Docker Hub under `docker.io/identrail/*`,
-  and pointed the homepage Docker pull metric at the published Docker Hub repositories.
+  made Docker Hub the default public-image quickstart source, and pointed the homepage Docker pull metric at the published Docker Hub repositories.
 - Routed successful native SCIM user lifecycle operations through the workflow router:
   - emits `scim.provisioned` events for create/update/deactivate/delete operations so Slack, Jira, and Linear destinations can receive directory-sync deltas
   - extends workflow dispatch audit records with SCIM subject, connection, and operation fields for NDJSON governance review

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Mirrored public container image publishing to Docker Hub under `docker.io/identrail/*`,
+  and pointed the homepage Docker pull metric at the published Docker Hub repositories.
 - Routed successful native SCIM user lifecycle operations through the workflow router:
   - emits `scim.provisioned` events for create/update/deactivate/delete operations so Slack, Jira, and Linear destinations can receive directory-sync deltas
   - extends workflow dispatch audit records with SCIM subject, connection, and operation fields for NDJSON governance review

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Use it when you run AWS and/or Kubernetes workloads and want identity risk visib
 
 Prerequisites: Docker, Docker Compose, `curl`, `jq`.
 
-Use published images without building from source:
+Use the published Docker Hub images without building from source:
 
 ```bash
 mkdir identrail-docker && cd identrail-docker
@@ -50,6 +50,12 @@ curl http://localhost:8080/healthz
 ```
 
 Open `http://localhost:8081` for the web UI.
+
+To inspect the main API image directly:
+
+```bash
+docker pull docker.io/identrail/identrail:dev
+```
 
 `docker pull` by itself only downloads images into Docker; it does not create a
 project directory or the Compose file needed to start the full stack.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -10,7 +10,7 @@ Deployment profiles:
 - `terraform/`: infrastructure modules
 - `policies/`: least-privilege read-only templates for AWS and Kubernetes
 
-Published container image examples use `ghcr.io/identrail/identrail` for the main server image, with `ghcr.io/identrail/identrail-worker`, `ghcr.io/identrail/identrail-web`, and the compatibility alias `ghcr.io/identrail/identrail-api` for multi-service deployments. Pin production deployments to immutable release tags. Helm and Terraform deployment values should use tagged images (`repository` + `tag`), while digest pinning is only for deployment paths that explicitly support digest references.
+Published public evaluation images are available from Docker Hub under `docker.io/identrail/*`, with GHCR mirrors under `ghcr.io/identrail/*`. Deployment examples still use `ghcr.io/identrail/identrail` for the main server image, with `ghcr.io/identrail/identrail-worker`, `ghcr.io/identrail/identrail-web`, and the compatibility alias `ghcr.io/identrail/identrail-api` for multi-service deployments. Pin production deployments to immutable release tags. Helm and Terraform deployment values should use tagged images (`repository` + `tag`), while digest pinning is only for deployment paths that explicitly support digest references.
 
 AWS deployment starts with a validation-only foundation and a plan-first API
 hosting layer. See `aws/README.md` and `../docs/aws-api-hosting.md` before

--- a/deploy/docker/.env.public.example
+++ b/deploy/docker/.env.public.example
@@ -2,6 +2,7 @@
 # The public-image quickstart works without this file; copy it only if you want
 # to customize the default local ports, secrets, or image tag.
 
+IDENTRAIL_IMAGE_REGISTRY=docker.io/identrail
 IDENTRAIL_IMAGE_TAG=dev
 IDENTRAIL_POSTGRES_PASSWORD=identrail-local-password
 IDENTRAIL_WEB_PORT=8081

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -6,7 +6,7 @@
 - `Dockerfile.web`: builds dashboard web image
   - production builds use the strict nginx CSP by default; Compose passes `NGINX_CONF=default.local.conf` for localhost API access.
 - `docker-compose.yml`: local single-host stack
-- `docker-compose.public.yml`: public-image evaluation stack that pulls from GHCR
+- `docker-compose.public.yml`: public-image evaluation stack that pulls from Docker Hub
 - `docker-compose.prod.example.yml`: production profile override (TLS URLs, migration service, exposed ports)
 - `docker-compose.security.example.yml`: least-privilege runtime hardening override (`read_only`, dropped capabilities, `no-new-privileges`)
 - `.env.example`: environment template
@@ -36,7 +36,7 @@ Manual setup:
 create a project folder, `.env` file, or runnable multi-service stack on disk.
 
 For a no-clone, no-build evaluation path, download the published Compose file
-and run it directly:
+and run it directly. The public stack pulls from Docker Hub by default:
 
 ```bash
 mkdir identrail-docker && cd identrail-docker
@@ -71,6 +71,9 @@ downloaded `.env` file before starting the stack. If you change
 `http://localhost:8080` for the API, so the no-clone quickstart keeps the API
 port fixed on `8080`.
 
+To test the GHCR copies instead, set `IDENTRAIL_IMAGE_REGISTRY=ghcr.io/identrail`
+in the downloaded `.env` before starting the stack.
+
 If you need direct access to the quickstart database for debugging, use
 `docker compose exec` instead of exposing the port by default:
 
@@ -82,9 +85,9 @@ You can still pull the main image directly when you want to inspect or run just
 the API server:
 
 ```bash
-docker pull ghcr.io/identrail/identrail:dev
-# Docker Hub mirror:
 docker pull docker.io/identrail/identrail:dev
+# GHCR mirror:
+docker pull ghcr.io/identrail/identrail:dev
 ```
 
 Run the API server by itself with disposable in-memory storage:
@@ -95,7 +98,7 @@ docker run --rm -p 8080:8080 \
   -e IDENTRAIL_RUN_MIGRATIONS=false \
   -e IDENTRAIL_API_KEYS=identrail-local-read-key-change-me,identrail-local-write-key-change-me \
   -e IDENTRAIL_WRITE_API_KEYS=identrail-local-write-key-change-me \
-  ghcr.io/identrail/identrail:dev
+  docker.io/identrail/identrail:dev
 ```
 
 Then verify it with:
@@ -123,15 +126,15 @@ secrets and disable manual mode.
 Supporting images are published for multi-service deployments:
 
 ```bash
-docker pull ghcr.io/identrail/identrail-worker:dev
-docker pull ghcr.io/identrail/identrail-web:dev
-docker pull ghcr.io/identrail/identrail-api:dev
-docker pull ghcr.io/identrail/identrail-agent:dev
-# Docker Hub mirrors:
 docker pull docker.io/identrail/identrail-worker:dev
 docker pull docker.io/identrail/identrail-web:dev
 docker pull docker.io/identrail/identrail-api:dev
 docker pull docker.io/identrail/identrail-agent:dev
+# GHCR mirrors:
+docker pull ghcr.io/identrail/identrail-worker:dev
+docker pull ghcr.io/identrail/identrail-web:dev
+docker pull ghcr.io/identrail/identrail-api:dev
+docker pull ghcr.io/identrail/identrail-agent:dev
 ```
 
 Each `dev` publish also creates immutable `sha-<12-char-sha>` tags. Release

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -83,6 +83,8 @@ the API server:
 
 ```bash
 docker pull ghcr.io/identrail/identrail:dev
+# Docker Hub mirror:
+docker pull docker.io/identrail/identrail:dev
 ```
 
 Run the API server by itself with disposable in-memory storage:
@@ -124,10 +126,17 @@ Supporting images are published for multi-service deployments:
 docker pull ghcr.io/identrail/identrail-worker:dev
 docker pull ghcr.io/identrail/identrail-web:dev
 docker pull ghcr.io/identrail/identrail-api:dev
+docker pull ghcr.io/identrail/identrail-agent:dev
+# Docker Hub mirrors:
+docker pull docker.io/identrail/identrail-worker:dev
+docker pull docker.io/identrail/identrail-web:dev
+docker pull docker.io/identrail/identrail-api:dev
+docker pull docker.io/identrail/identrail-agent:dev
 ```
 
 Each `dev` publish also creates immutable `sha-<12-char-sha>` tags. Release
-images use SemVer tags such as `ghcr.io/identrail/identrail:v1.0.0`.
+images use SemVer tags such as `ghcr.io/identrail/identrail:v1.0.0` and
+`docker.io/identrail/identrail:v1.0.0`.
 
 After the first publish, a repository maintainer may need to make the GHCR
 packages public in GitHub Packages if the organization default is private.

--- a/deploy/docker/docker-compose.public.yml
+++ b/deploy/docker/docker-compose.public.yml
@@ -1,5 +1,5 @@
-# Public-image evaluation stack. This file pulls images from GHCR instead of
-# building local images from source.
+# Public-image evaluation stack. This file pulls published Docker Hub images
+# instead of building local images from source.
 
 x-identrail-env: &identrail-env
   IDENTRAIL_SERVICE_NAME: identrail
@@ -45,7 +45,7 @@ services:
       retries: 10
 
   api:
-    image: ghcr.io/identrail/identrail:${IDENTRAIL_IMAGE_TAG:-dev}
+    image: ${IDENTRAIL_IMAGE_REGISTRY:-docker.io/identrail}/identrail:${IDENTRAIL_IMAGE_TAG:-dev}
     restart: unless-stopped
     depends_on:
       postgres:
@@ -58,7 +58,7 @@ services:
       - "127.0.0.1:8080:8080"
 
   worker:
-    image: ghcr.io/identrail/identrail-worker:${IDENTRAIL_IMAGE_TAG:-dev}
+    image: ${IDENTRAIL_IMAGE_REGISTRY:-docker.io/identrail}/identrail-worker:${IDENTRAIL_IMAGE_TAG:-dev}
     restart: unless-stopped
     depends_on:
       postgres:
@@ -70,7 +70,7 @@ services:
       IDENTRAIL_RUN_MIGRATIONS: "false"
 
   web:
-    image: ghcr.io/identrail/identrail-web:${IDENTRAIL_IMAGE_TAG:-dev}
+    image: ${IDENTRAIL_IMAGE_REGISTRY:-docker.io/identrail}/identrail-web:${IDENTRAIL_IMAGE_TAG:-dev}
     restart: unless-stopped
     depends_on:
       api:

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -85,5 +85,5 @@ If a SemVer tag already exists but no GitHub Release was published (for example 
 1. Open **Actions** -> **Release** -> **Run workflow**.
 2. Set:
    - `tag=v1.0.0`
-   - `publish_images=false` (binary/checksum-only backfill), or `true` if GHCR image publish is required.
+   - `publish_images=false` (binary/checksum-only backfill), or `true` if container image publishing is required.
 3. Run workflow and confirm release assets include archive files plus `checksums.txt`.

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -15,6 +15,8 @@ Identrail release automation is defined in:
 - Keep the versioned web build inputs in `deploy/docker/release-web.env`.
   `VITE_IDENTRAIL_API_URL`, `VITE_FEATURE_CONNECTOR_*`, and
   `VITE_FEATURE_ONBOARDING_WIZARD` values are baked into release web images.
+- Image publishing requires `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repository
+  secrets so the workflow can mirror GHCR images to Docker Hub.
 - For manual runs with `publish_images=false`, image configuration is not required.
 - Manual image backfills for historical tags that predate `deploy/docker/release-web.env`
   use the legacy release URL recorded by the workflow and attach that source in
@@ -29,11 +31,17 @@ login.
 
 1. Cross-platform binaries (`cli`, `server`, `worker`) as archives.
 2. SHA-256 checksum manifest (`checksums.txt`).
-3. Container images to GHCR:
+3. Container images to GHCR and Docker Hub:
    - `ghcr.io/<owner>/identrail:<tag>`
    - `ghcr.io/<owner>/identrail-api:<tag>`
    - `ghcr.io/<owner>/identrail-worker:<tag>`
    - `ghcr.io/<owner>/identrail-web:<tag>`
+   - `ghcr.io/<owner>/identrail-agent:<tag>`
+   - `docker.io/identrail/identrail:<tag>`
+   - `docker.io/identrail/identrail-api:<tag>`
+   - `docker.io/identrail/identrail-worker:<tag>`
+   - `docker.io/identrail/identrail-web:<tag>`
+   - `docker.io/identrail/identrail-agent:<tag>`
 4. Image digests and web build input metadata.
 5. Auto-generated GitHub Release notes.
 
@@ -46,6 +54,12 @@ every merge to `dev`:
 - `ghcr.io/identrail/identrail-api:dev`
 - `ghcr.io/identrail/identrail-worker:dev`
 - `ghcr.io/identrail/identrail-web:dev`
+- `ghcr.io/identrail/identrail-agent:dev`
+- `docker.io/identrail/identrail:dev`
+- `docker.io/identrail/identrail-api:dev`
+- `docker.io/identrail/identrail-worker:dev`
+- `docker.io/identrail/identrail-web:dev`
+- `docker.io/identrail/identrail-agent:dev`
 
 Each run also publishes immutable SHA tags such as `sha-<12-char-sha>`. Use the
 `dev` tags for quick evaluation and SHA or release tags for repeatable

--- a/web/src/components/home/HeroOpenSourceProofPills.test.tsx
+++ b/web/src/components/home/HeroOpenSourceProofPills.test.tsx
@@ -42,4 +42,30 @@ describe('HeroOpenSourceProofPills', () => {
     expect(within(dockerPill as HTMLElement).getByText('Live')).toBeInTheDocument();
     expect(within(dockerPill as HTMLElement).queryByText('0')).not.toBeInTheDocument();
   });
+
+  it('loads pull metrics from the published Docker Hub repositories', async () => {
+    const dockerMetricPaths: string[] = [];
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(fetchURL(input));
+      if (url.hostname === 'api.github.com') return okJSON({ stargazers_count: 3 });
+      if (url.hostname === 'img.shields.io' && url.pathname.includes('/docker/pulls')) {
+        dockerMetricPaths.push(url.pathname);
+        return okJSON({ message: '1' });
+      }
+      return okJSON({});
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<HeroOpenSourceProofPills />);
+
+    await waitFor(() => expect(screen.getByText('5')).toBeInTheDocument());
+
+    expect(dockerMetricPaths).toEqual([
+      '/docker/pulls/identrail/identrail.json',
+      '/docker/pulls/identrail/identrail-api.json',
+      '/docker/pulls/identrail/identrail-worker.json',
+      '/docker/pulls/identrail/identrail-web.json',
+      '/docker/pulls/identrail/identrail-agent.json'
+    ]);
+  });
 });

--- a/web/src/siteConfig.ts
+++ b/web/src/siteConfig.ts
@@ -53,5 +53,11 @@ export const githubRepo = {
 
 export const projectMetricsSource = {
   github: githubRepo,
-  dockerHubRepos: ['identrail/api', 'identrail/worker', 'identrail/web']
+  dockerHubRepos: [
+    'identrail/identrail',
+    'identrail/identrail-api',
+    'identrail/identrail-worker',
+    'identrail/identrail-web',
+    'identrail/identrail-agent'
+  ]
 } as const;


### PR DESCRIPTION
Fixes #1160

## What changed
- Mirrors the existing GHCR development and release image publishes to Docker Hub under `docker.io/identrail/*`.
- Keeps GHCR as the canonical deployment registry while adding Docker Hub tags for public pulls and pull metrics.
- Points the homepage Docker pull badge at the real Docker Hub repositories and adds a regression test for those metric URLs.
- Updates Docker and release pipeline docs plus the changelog.

## Impact and risk
- Requires the existing `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` Actions secrets to remain configured.
- First Docker Hub pull counts will start from Docker Hub activity only; historical GHCR pulls are not backfilled.
- AWS/deployment image validation is unchanged and still expects immutable GHCR images.

## Validation performed
- `git diff --check`
- Ruby YAML parse for `.github/workflows/publish-container-images.yml` and `.github/workflows/release.yml`
- `npm run test --prefix web -- HeroOpenSourceProofPills.test.tsx --run`
- `npm run build --prefix web`
- Pre-commit/push hooks: merge-conflict check, YAML check, end-of-file fix check, trailing whitespace, gofmt check, `go vet`, local env token hygiene, Vercel artifact hygiene

AI-assisted: yes
Tools used: Codex
Where used: workflow wiring, Docker docs, homepage metric config/test
Human verification performed: reviewed diff and ran the validation commands listed above
