### PR TITLE
Align Track 1 enterprise SSO docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
   - `POST /auth/saml/acs/{connection_id}` is the Assertion Consumer Service. SAML response parsing, signature verification (XML-DSig), audience/recipient/InResponseTo checks, and `NotOnOrAfter` enforcement are delegated to `github.com/crewjam/saml` so we do not ship bespoke SAML protocol code. A 60s clock-skew tolerance is layered on top.
   - `UpsertSAMLAssertedUser` resolves users in three steps: existing `saml:<connection_id>` identity → pre-provisioned `scim:<connection_id>` identity → existing user by primary email. When no match exists, the connection's `jit_provisioning_enabled` flag decides whether to create a fresh user or return 403 with an admin-actionable "ask your admin to provision your account" message
   - Sessions issued from the SAML path carry `AuthMethod: "saml"` (new accepted value) and the org id from the connection
-  - `/v1/auth/config` exposes `native_saml_enabled` so the web frontend can render the "Sign in with company SSO" button only when the feature is on
+  - `/v1/auth/config` exposes `native_saml_enabled` and includes `saml` in the advertised providers list when native SSO is enabled; connection-specific SAML login still comes from the native SAML admin/API flow
   - WorkOS sign-in/sign-up flow is unchanged; both paths share the same `OAuthStateManager` so a `SessionKey` rotation invalidates every half-finished login regardless of which doorway issued it
 - Replaced the authenticated Overview and Settings scaffold routes with real product views:
   - Overview now loads workspace projects, repository scans, open repository findings, and trend signals to show operating metrics, risk queue, scan activity, coverage, and next-action routing.
@@ -69,7 +69,7 @@
 - Added a plan-first AWS API hosting layer:
   - defines ECS/Fargate API service, HTTPS load balancer, task roles, security groups, health checks, and CPU autoscaling primitives
   - keeps API hosting resource creation disabled by default for cost-safe CI validation
-  - adds a guarded manual GitHub Actions deploy workflow for pre-PR 11 API cutover planning and explicitly confirmed applies
+  - adds a guarded manual GitHub Actions deploy workflow for API cutover planning and explicitly confirmed applies
   - adds an explicit low-cost public-task bootstrap mode for the first `api.identrail.com` cutover, avoiding NAT Gateway or VPC endpoint hourly charges while keeping inbound traffic behind the ALB security group
   - configures hosted API CORS origins and trusted ALB proxy CIDRs so the split web/API domains preserve browser access and real client IPs
   - validates distinct public/private subnet inputs, public subnet Availability Zone spread, subnet VPC membership, and public-subnet Internet Gateway routes, including inherited main route tables, before planning the load balancer and Fargate service
@@ -106,7 +106,7 @@
   - documented the session endpoints in OpenAPI and wired feature-flagged startup validation for session-auth configuration
 - Added the auth and connector architecture foundation under `docs/auth/`:
   - decided on WorkOS for hosted login plus a dual-driver OIDC path for self-host
-  - documented the identity model, cookie and session spec, threat model, identity-linking rules, connector-foundation contract, environment-variables reference, and the canonical twelve-PR delivery sequence
+  - documented the identity model, cookie and session spec, threat model, identity-linking rules, connector-foundation contract, environment-variables reference, and the original auth delivery roadmap
   - linked the new doc folder from the main documentation index
 - Refined the public website homepage presentation:
   - adopted a Browserbase-style navigation rail with centered links and a black demo CTA

--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -154,7 +154,7 @@ Manager, and write logs without a NAT Gateway. Treat it as a budget-conscious
 bootstrap path and migrate to private task subnets plus NAT/VPC endpoints when
 traffic or compliance needs justify the extra cost.
 
-For hosted pre-PR 11 cutover preparation, prefer the `AWS API Manual Deploy`
+For hosted API cutover preparation, prefer the `AWS API Manual Deploy`
 GitHub Actions workflow over running `terraform apply` from a laptop. It uses
 the GitHub OIDC deployment role, requires S3-backed Terraform state, plans by
 default, and requires the exact confirmation string `apply-api.identrail.com`

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -31,6 +31,10 @@ IDENTRAIL_POSTGRES_PASSWORD=replace-with-strong-postgres-password
 # IDENTRAIL_OIDC_WORKSPACE_CLAIM=workspace_id
 # IDENTRAIL_OIDC_GROUPS_CLAIM=groups
 # IDENTRAIL_OIDC_ROLES_CLAIM=roles
+# Optional native SAML + SCIM. Native SAML admin/login routes also require
+# IDENTRAIL_FEATURE_NEW_AUTH=true, IDENTRAIL_PUBLIC_BASE_URL, and
+# IDENTRAIL_SESSION_KEY in the API runtime.
+IDENTRAIL_FEATURE_NATIVE_SSO=false
 # Optional postgres scope isolation enforcement
 # IDENTRAIL_POSTGRES_RLS_ENFORCED=false
 # Durable connector secret storage. Generate a 32-byte key with:
@@ -40,17 +44,17 @@ IDENTRAIL_POSTGRES_PASSWORD=replace-with-strong-postgres-password
 # Optional connector secret envelope keys for durable connector credential storage
 # Format: version:base64-encoded-32-byte-key (comma/semicolon separated for rotation sets)
 
-# Optional PR 7 AWS connector onboarding. Keep disabled until the published
+# Optional AWS connector onboarding. Keep disabled until the published
 # CloudFormation template URL and Identrail-side AWS account ID are configured.
 IDENTRAIL_FEATURE_CONNECTOR_AWS=false
 # IDENTRAIL_AWS_CFN_TEMPLATE_URL=https://cdn.example.com/connectors/aws/identrail-readonly.yaml
 # IDENTRAIL_AWS_ACCOUNT_ID=123456789012
 
-# Optional PR 9 Kubernetes connector onboarding. Enable with the matching
+# Optional Kubernetes connector onboarding. Enable with the matching
 # VITE_FEATURE_CONNECTOR_K8S flag when exposing the Kubernetes connector UI.
 IDENTRAIL_FEATURE_CONNECTOR_K8S=false
 
-# Optional PR 8 GitHub connector onboarding. Hosted GitHub.com uses a GitHub
+# Optional GitHub connector onboarding. Hosted GitHub.com uses a GitHub
 # App; GitHub Enterprise Server can use the PAT fallback from the app UI.
 IDENTRAIL_FEATURE_CONNECTOR_GITHUB_V2=false
 # IDENTRAIL_GITHUB_APP_ID=123456
@@ -59,7 +63,7 @@ IDENTRAIL_FEATURE_CONNECTOR_GITHUB_V2=false
 # IDENTRAIL_GITHUB_APP_WEBHOOK_SECRET=replace-with-random-secret
 IDENTRAIL_GITHUB_PAT_ALLOWED_BASE_URLS=https://github.com
 
-# Optional PR 10 onboarding wizard. Enable with VITE_FEATURE_ONBOARDING_WIZARD
+# Optional onboarding wizard. Enable with VITE_FEATURE_ONBOARDING_WIZARD
 # after new auth and at least one connector UI are enabled.
 IDENTRAIL_FEATURE_ONBOARDING_WIZARD=false
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 ## Auth and identity foundation
 
 - Architecture and contracts: `auth/README.md`
-- The twelve-PR delivery sequence: `auth/12-pr-plan.md`
+- Current three-track roadmap: `auth/12-pr-plan.md`
 
 ## API and developer track
 

--- a/docs/auth/12-pr-plan.md
+++ b/docs/auth/12-pr-plan.md
@@ -1,541 +1,100 @@
-# Twelve-PR Auth and Connector Plan
-
-The full sequence for shipping signup, sign-in, SSO, SCIM, and the AWS, Kubernetes, and GitHub connectors. Each section is the canonical scope for that PR. When opening one of these PRs, copy the matching section into the PR description as a checklist.
-
-Total estimate: roughly 23 engineering days end to end. The critical path to a demo-able SaaS (signup to first AWS finding) is roughly 10 days: PRs 1, 2, 4, 5, 6, 7, 10.
-
-## Sequencing
-
-```
-PR 1 (architecture)
-   │
-   ▼
-PR 2 (identity core)
-   │
-   ├──▶ PR 3 (identity enterprise) ──┐
-   │                                 │
-   ▼                                 │
-PR 4 (WorkOS hosted login)           │
-   │                                 │
-   ▼                                 │
-PR 5 (frontend auth)                 │
-   │                                 │
-   ├──▶ PR 6 (connector foundation) ──▶ PR 7, 8, 9 (AWS, GitHub, K8s)
-   │                                          │
-   │                                          ▼
-   │                                   PR 10 (onboarding wizard)
-   │                                          │
-   └──▶ PR 11 (SSO admin) ◄───────────────────┘
-                │
-                ▼
-         PR 12 (SCIM + hardening)
-```
-
-## Index
-
-| # | PR | Branch | Effort | Depends on |
-| --- | --- | --- | --- | --- |
-| 1 | Architecture doc | `docs/auth-architecture-foundation` | 2h | none |
-| 2 | Backend identity core | `auth/02-identity-foundation-core` | 1d | 1 |
-| 3 | Backend identity enterprise prep | `auth/03-identity-foundation-enterprise` | 1d | 2 |
-| 4 | WorkOS hosted login | `auth/04-workos-hosted-login` | 2d | 2 |
-| 5 | Frontend auth UI | `auth/05-frontend-auth-ui` | 2d | 4 |
-| 6 | Connector foundation | `auth/06-connector-foundation` | 1d | 5 |
-| 7 | AWS connector | `auth/07-connector-aws` | 2d | 6 |
-| 8 | GitHub connector | `auth/08-connector-github` | 1.5d | 6 |
-| 9 | Kubernetes connector | `auth/09-connector-kubernetes` | 3d | 6 |
-| 10 | Onboarding wizard | `auth/10-onboarding-wizard` | 2d | 5 + at least one of 7, 8, 9 |
-| 11 | Enterprise SSO admin | `auth/11-sso-admin` | 3d | 3, 4, 5 |
-| 12 | SCIM and hardening | `auth/12-scim-and-hardening` | 4d | 11 |
-
----
-
-## PR 1: Architecture Doc
-
-**Goal.** Lock every contract in writing before any code so the next eleven PRs do not conflict.
-
-**Files (all new).**
-- `docs/auth/architecture.md`
-- `docs/auth/threat-model.md`
-- `docs/auth/cookie-and-session-spec.md`
-- `docs/auth/identity-linking-rules.md`
-- `docs/auth/connector-foundation.md`
-- `docs/auth/env-vars-reference.md`
-- `docs/auth/12-pr-plan.md` (this file)
-- `docs/auth/README.md`
-
-**Acceptance.**
-- Every later PR can be planned by reading these docs alone.
-- Threat model includes the identity-linking exploit narrative explicitly.
-- Every endpoint we plan to add has its shape documented.
-- Every env var has a default and a validation rule.
-
-**Out of scope.** Code, schema changes, frontend changes.
-
-**Rollback.** Not applicable.
-
----
-
-## PR 2: Backend Identity Foundation, Core
-
-**Goal.** `users`, `user_identities`, `sessions` plus the session middleware and `GET /v1/me` and `POST /auth/logout`. Begin the strangler-fig migration on `tenancy_workspace_members.user_id`.
-
-**Schema (migration `000018_users_and_sessions`; originally planned as `000017`, but `000017_queue_trace_context` landed first).**
-- `users(id UUID PK, primary_email CITEXT UNIQUE, display_name, avatar_url, status, created_at, updated_at, deleted_at NULL)`.
-- `user_identities(id UUID PK, user_id FK, provider TEXT, subject TEXT, email CITEXT, email_verified BOOLEAN NOT NULL DEFAULT FALSE, raw_claims JSONB, last_authenticated_at, created_at, UNIQUE(provider, subject))`.
-- `sessions(id BYTEA PK, user_id FK ON DELETE CASCADE, current_org_id, current_workspace_id, current_project_id, auth_method, ip INET, user_agent, idle_expires_at, absolute_expires_at, last_seen_at, revoked_at NULL, created_at)`. `last_seen_at` is bumped to `NOW()` on every authenticated request alongside `idle_expires_at`; powers the "last seen" display on the account/security page.
-- `tenancy_workspace_members.user_uuid UUID NULL` added next to existing `user_id`.
-- Indexes per the cookie/session spec.
-
-**Files (new or modified).**
-- `internal/db/users.go`, `sessions.go`, `user_identities.go` (new).
-- `internal/db/store.go`, `memory.go`, `postgres.go` (extend interface and implementations).
-- `internal/api/auth/session.go`, `middleware.go` (new).
-- `internal/api/router.go` (register `/v1/me`, `/auth/logout`).
-- `internal/config/config.go` (add `IDENTRAIL_PUBLIC_BASE_URL`, `IDENTRAIL_SESSION_KEY`, `IDENTRAIL_AUTH_MANUAL_MODE`).
-- `migrations/000018_users_and_sessions.up.sql` and `.down.sql`.
-- Tests across all of the above.
-
-**New endpoints.**
-- `GET /v1/me` returns the current user, org, workspace, project, and role.
-- `GET /v1/me/sessions` lists active sessions for the current user (id, ip, user_agent, created_at, last_seen_at, idle_expires_at, current flag).
-- `DELETE /v1/me/sessions/:id` revokes one session by id (the current session can be revoked here; the response then clears the cookie too, equivalent to logout).
-- `POST /v1/me/sessions/revoke-others` revokes every session for the current user except the one making the call.
-- `POST /auth/logout` revokes the current session and clears the cookie.
-
-**Out of scope.** Login routes (PR 4). Frontend (PR 5). WorkOS (PR 4).
-
-**Tests.** Cookie tampering rejected. Expired or revoked session rejected within one request. FK cascade on user delete. Two browsers see independent rows. `IDENTRAIL_AUTH_MANUAL_MODE=true` plus `IDENTRAIL_WORKOS_CLIENT_ID` set refuses to start. `IDENTRAIL_PUBLIC_BASE_URL` missing or invalid refuses to start. Session-list endpoint scopes results to the calling user only. Revoking another user's session id returns 404 (no leakage of session existence). Revoking the current session via `DELETE /v1/me/sessions/:id` clears the cookie and behaves like logout. `revoke-others` keeps the calling session alive and revokes every other row for the same user.
-
-**Acceptance.** Existing OIDC and API key paths unchanged (regression tests pass). PR 4 can build on these primitives without modification. PR 5's `AccountSecurityPage` has the backend endpoints it needs to list and revoke sessions.
-
-**Rollback.** Feature flag `IDENTRAIL_FEATURE_NEW_AUTH=false` disables the new middleware. Old auth paths continue.
-
----
-
-## PR 3: Backend Identity Foundation, Enterprise Prep
-
-**Goal.** Tables and endpoint stubs for invitations, verified domains, identity connections. No business logic in this PR; just the scaffolding for PRs 6, 11, 12 to fill in.
-
-**Schema (migration `000020_invitations_domains_connections`).** The original plan reserved `000018` for this PR, but PR 2 consumed that version for `users` and `sessions`, and scan-policy bounds consumed `000019`, so this PR uses the next migration slot.
-- `invitations(id UUID PK, org_id, email CITEXT, role, invited_by_user_id, token_hash BYTEA, expires_at, accepted_at NULL, revoked_at NULL, created_at)`.
-- `verified_domains(id UUID PK, org_id, domain CITEXT, verification_token, verification_method, verified_at NULL, created_at)`.
-- `identity_connections(id UUID PK, org_id, provider, type, workos_connection_id NULL, status, group_role_map JSONB DEFAULT '{}', sso_required BOOLEAN DEFAULT false, created_at, updated_at)`.
-
-`auth_audit_events` is not a separate table. Auth events flow through the existing `audit.AuditEvent` pipeline.
-
-**Files.**
-- `internal/db/store.go`, `internal/db/memory_enterprise_auth.go`, `internal/db/postgres_enterprise_auth.go`.
-- `internal/api/auth/enterprise_audit.go` (helper constructors for `auth.*` events).
-- Endpoint stubs in `internal/api/auth_enterprise_routes.go` returning 501.
-
-**Endpoint stubs (return 501 until later PRs fill them in).**
-- `POST /v1/invitations`, `GET /v1/me/invitations` (PR 11).
-- `POST /v1/orgs/:id/domains`, `POST /v1/orgs/:id/domains/:domain_id/verify` (PR 11).
-- `GET /v1/orgs/:id/sso` (PR 11).
-
-**Out of scope.** Implementations. Email sending. WorkOS Directory Sync (PR 12).
-
-**Tests.** Schemas apply cleanly with correct constraints and indexes. Repo methods (Create, Get, List, Revoke). Audit-event helpers produce well-formed events.
-
-**Acceptance.** Tables exist. Endpoints registered (returning 501). PRs 11 and 12 can fill them in without further schema changes.
-
-**Rollback.** Tables harmless if unused. No production impact until later PRs use them.
-
----
-
-## PR 4: WorkOS Hosted Login
-
-**Goal.** Real login working end to end via WorkOS AuthKit. GitHub OAuth as the primary day-one provider.
-
-**Files.**
-- `internal/api/auth/workos.go` (WorkOS client wrapper).
-- `internal/api/auth/oauth_state.go` (HMAC-signed single-use state).
-- `internal/api/auth/login_handler.go` (`/auth/login`, `/auth/signup`, `/auth/callback`).
-- `internal/api/auth/webhook_handler.go` (`/auth/webhooks/workos`).
-- `internal/api/router.go` (register routes).
-- `internal/config/config.go` (WorkOS env vars).
-- `internal/api/service.go` (UpsertUserFromWorkOS, LinkUserIdentity, FindUserByIdentity).
-- E2E test against WorkOS test environment.
-
-**New endpoints.**
-- `GET /auth/login?return_to=...` (302 to AuthKit).
-- `GET /auth/signup?return_to=...` (302 to AuthKit with `screen_hint=sign-up`).
-- `GET /auth/callback?code=&state=` (exchange, upsert, set cookie, 302).
-- `POST /auth/webhooks/workos` (HMAC-verified, handlers for `user.deleted`, `user.email_changed`).
-- `GET /v1/auth/config` (returns whether manual mode is allowed; the frontend uses this to decide if the manual form renders).
-
-**New env vars.** Per `env-vars-reference.md`: `IDENTRAIL_WORKOS_CLIENT_ID`, `IDENTRAIL_WORKOS_API_KEY`, `IDENTRAIL_WORKOS_WEBHOOK_SECRET`, `IDENTRAIL_WORKOS_ENVIRONMENT_ID`.
-
-**First-callback decision tree.**
-- Existing user with org membership: 302 to dashboard at last-used org.
-- Existing user without org membership: 302 to `/onboarding/org`.
-- New user: create rows, 302 to `/onboarding/org`.
-
-**Audit.** All login/logout/signup events flow through existing `AuditEvent{Kind:"action"}` with actions `auth.login.start`, `auth.login.success`, `auth.login.failure`, `auth.logout`, `auth.signup`, `auth.identity.conflict`.
-
-**Rate limits.** Per architecture doc: `/auth/login` 10 per minute per IP, `/auth/callback` 30 per minute per IP, `/auth/logout` 100 per minute per session.
-
-**Identity-linking enforcement.** Per `identity-linking-rules.md`: never auto-link by email. Conflicts return HTTP 409 with explanation.
-
-**Failure modes.** WorkOS unreachable returns 503 with `Retry-After`. WorkOS user.deleted webhook revokes all sessions. Email-change webhook updates `users.primary_email` and audits.
-
-**Out of scope.** Frontend pages (PR 5). Domain auto-join (PR 11). Onboarding bootstrap (PR 10).
-
-**Tests.** E2E against WorkOS test env. State tampering rejected. Replayed state rejected. Webhook signature verification. Identity conflict produces 409, not silent merge. Rate limits enforced.
-
-**Acceptance.** Visiting `https://app.identrail.com/auth/login` redirects to WorkOS AuthKit. After GitHub OAuth, cookie set, user lands at correct destination. New user creates exactly one row in `users` and one in `user_identities`. Existing user signing in again creates zero new rows.
-
-**Rollback.** Feature flag `IDENTRAIL_FEATURE_WORKOS_LOGIN=false` returns auth routes to 404.
-
----
-
-## PR 5: Frontend Auth UI
-
-**Goal.** Polished sign-in and sign-up plus account/security surface. Marketing site wired up. Manual mode hidden in hosted SaaS, retained behind a flag for self-host and dev.
-
-**Files.**
-- `web/src/pages/SignInPage.tsx`, `SignUpPage.tsx`, `AuthCallbackPage.tsx`, `AccountSecurityPage.tsx`, `WhyNoPasswordsPage.tsx` (new).
-- `web/src/hooks/useMe.ts` (new).
-- `web/src/api/client.ts` (set `credentials: 'include'`, redirect on 401).
-- `web/src/productShell.tsx` (delete `inMemoryTokens` and sessionStorage paths; replace with `useMe()`; remove the manual tenant/workspace form).
-- `web/src/components/layout/Header.tsx` (Sign In to /signin, Sign Up to /signup).
-- `web/src/components/auth/SessionsList.tsx` (new).
-- `web/src/components/common/EmptyState.tsx`, `ErrorState.tsx` (new, reusable).
-- `web/src/styles/tokens.css` (extended palette, spacing, shadow tokens).
-- Routes registered in `App.tsx`: `/signin`, `/signup`, `/auth/callback`, `/why-no-passwords`, `/app/account/security`.
-
-**Pages.**
-- `/signin` and `/signup` are the same component, copy variants. Primary "Continue with GitHub" links to `/auth/login` or `/auth/signup`. Secondary "Continue with email" uses the same path with a hint. Footer link to `/why-no-passwords`.
-- `/auth/callback` is a branded loading state. Calls `GET /v1/me`, routes based on response.
-- `/app/account/security` lists active sessions (IP, UA, location, last seen, "current" badge), revoke per session, revoke all others. The per-user auth-events feed is deferred to PR 12, which adds both the queryable read endpoint and the UI that consumes it; PR 5 leaves a labelled placeholder slot on the page that PR 12 wires up.
-
-**Manual mode visibility.** Frontend reads `GET /v1/auth/config`. If the backend says manual mode is enabled, the manual form renders alongside the OAuth options with a "Dev Mode" banner. Otherwise it does not render.
-
-**Design discipline.** All values from `tokens.css`. Skeleton loaders, not spinners. Reusable empty and error states.
-
-**Out of scope.** Onboarding wizard (PR 10). Org admin pages (PR 11). Connector pages (PRs 6 through 9).
-
-**Tests.** Component tests for the new pages. Playwright E2E covering marketing to /signin to mocked WorkOS to cookie set to `/v1/me`. 401 redirect verified. Cookie persists across reloads. Visual snapshots in light and dark.
-
-**Acceptance.** "Sign In" and "Sign Up" on marketing site go to real working pages. Logged-in user sees their sessions. Manual form does not appear in hosted SaaS. Manual form appears in dev with `IDENTRAIL_AUTH_MANUAL_MODE=true`.
-
-**Rollback.** Feature flag `VITE_FEATURE_NEW_AUTH_UI=false` falls back to old shell.
-
----
-
-## PR 6: Connector Foundation
-
-**Goal.** Shared types, state machine, error taxonomy, and UI primitives that every connector uses. Ships before the actual connectors so they all conform.
-
-**Files.**
-- `internal/connectors/provider.go` (Provider interface).
-- `internal/connectors/status.go` (lifecycle status constants and transition validator).
-- `internal/connectors/errors.go` (error taxonomy and codes).
-- `internal/connectors/health.go` (shared health-check helper).
-- `internal/api/router.go` (register `/v1/connectors`, `/v1/connectors/:id`, `/v1/connectors/:id/health`).
-- `internal/api/service.go` (ListConnectors, GetConnector, GetConnectorHealth).
-- `web/src/components/connector/ConnectorStatusBadge.tsx`, `ConnectorErrorPanel.tsx` (new).
-- `web/src/pages/ConnectorsListPage.tsx` (new, route `/app/{tenant}/{workspace}/connectors`).
-- `migrations/000021_connector_disabled_flag.up.sql` and `.down.sql` (new). Adds `disabled BOOLEAN NOT NULL DEFAULT FALSE` and `config JSONB NOT NULL DEFAULT '{}'::jsonb` to `tenancy_connectors`. Does not modify the existing `status` CHECK constraint.
-
-**Schema (migration `000021_connector_disabled_flag`).**
-- `tenancy_connectors.disabled BOOLEAN NOT NULL DEFAULT FALSE`. Backfills as `false` for existing rows.
-- `tenancy_connectors.config JSONB NOT NULL DEFAULT '{}'::jsonb`. Holds provider-specific non-secret configuration (for example GHES base URL or selected repo IDs).
-
-**Contract.** See `connector-foundation.md` for the full Provider interface, the lifecycle status state machine, the `disabled` flag rules, the error taxonomy, and the heartbeat job rules. Lifecycle status values are limited to the four already in the existing schema (`pending`, `active`, `degraded`, `disconnected`); the foundation does not widen that constraint. The transient `validating` step lives in-process only. Connector handlers are project-scoped via session context (`current_project_id`), even though the route prefix remains `/v1/connectors/*`.
-
-**New endpoints.** `GET /v1/connectors`, `GET /v1/connectors/:id`, `GET /v1/connectors/:id/health`, `DELETE /v1/connectors/:id`, `POST /v1/connectors/:id/disable`, `POST /v1/connectors/:id/enable`.
-
-**Heartbeat job.** Existing scheduler. Polls `Health()` every 5 minutes on active and degraded connectors. Drives state transitions per the state machine. Audit event on every transition.
-
-**Out of scope.** Specific providers (PRs 7 through 9).
-
-**Tests.** State machine: every defined transition reachable; undefined transitions rejected. Error code to UI string snapshot. Health endpoint: 404 on non-existent connector. Disconnect calls Provider.Disconnect.
-
-**Acceptance.** ConnectorsListPage renders empty state when no connectors. PRs 7 through 9 import from `internal/connectors` and `web/src/components/connector` without writing duplicate code.
-
-**Rollback.** Backend flag `IDENTRAIL_FEATURE_CONNECTORS_V2=false` returns the new `/v1/connectors*` endpoints to 404. Frontend flag `VITE_FEATURE_CONNECTORS_V2=false` hides the new connectors page. Both default off; turning them on is what activates this PR.
-
----
-
-## PR 7: AWS Connector
-
-**Goal.** Wiz/Orca-style "Launch CloudFormation Stack" flow with custom least-privilege IAM policy and permission preview.
-
-**Files.**
-- `internal/connectors/aws/provider.go` (implement Provider).
-- `internal/connectors/aws/cfn.go` (CloudFormation template URL generator).
-- `internal/connectors/aws/iam_policy.go` (Go-embedded policy asset).
-- `internal/connectors/aws/validator.go` (sts:AssumeRole probe).
-- `deploy/connectors/aws/identrail-readonly.yaml` (CFN template, versioned).
-- `deploy/connectors/aws/policies/identrail-readonly-policy.json` (strict JSON, no comments).
-- `deploy/connectors/aws/policies/identrail-readonly-policy.md` (per-action rationale, kept next to the JSON file).
-- `deploy/connectors/aws/policies/audit.go` (CI script that diffs IAM actions called in code against the policy file).
-- `web/src/pages/connectors/ConnectAWSPage.tsx`.
-- `web/src/components/connector/PermissionPreviewModal.tsx`.
-
-**Flow.**
-1. User clicks Connect AWS.
-2. Permission preview modal lists every IAM action with a one-line reason.
-3. Backend generates 32-byte External ID, creates connector in `pending` state.
-4. UI shows "Launch Stack in AWS Console" deep link with template URL and parameters pre-filled.
-5. User launches stack. CFN provisions an IAM role with `IdentrailReadOnlyPolicy` and the External ID trust condition.
-6. UI polls `/v1/connectors/aws/:id/poll` every 10 seconds (or accepts manual ARN paste fallback).
-7. Backend runs `sts:AssumeRole` probe, captures account ID and alias, marks `active`.
-8. First scan kicks off automatically.
-
-**New endpoints.** `POST /v1/connectors/aws`, `POST /v1/connectors/aws/:id/validate`, `GET /v1/connectors/aws/:id/poll`, `POST /v1/connectors/aws/:id/refresh-policy`.
-
-**IAM policy rules.** No `ReadOnlyAccess` blanket. Hand-curated minimum: `iam:Get*`, `iam:List*`, `iam:SimulatePrincipalPolicy`, `ec2:Describe*` (scoped), `s3:GetBucketPolicy`, `s3:GetBucketAcl`, `s3:GetBucketPublicAccessBlock`, `kms:DescribeKey`, `kms:GetKeyPolicy`. The `.json` file is strict JSON (no comments, since AWS rejects them). Per-action rationale lives in a sibling `identrail-readonly-policy.md` and a `Sid` field per statement names the feature each block supports. `Resource: "*"` is used only where unavoidable, with the rationale captured in the sibling markdown.
-
-**CI policy audit.** Script greps Identrail's AWS SDK calls; diffs against policy. Fails CI when a new SDK call appears without a policy update.
-
-**Secrets.** Role ARN and External ID stored encrypted via existing `tenancy_connector_secret_envelopes`.
-
-**Out of scope.** StackSets multi-account flow. Cross-region scanning UI. CloudTrail Lake.
-
-**Tests.** IAM policy validates against AWS validator. CFN template validates against AWS validator. AssumeRole probe handles success, ExpiredToken, AccessDenied. State transitions correct. Permission preview snapshot. End-to-end with localstack.
-
-**Acceptance.** New user signs up, runs onboarding, connects AWS, sees first scan finding within 5 minutes. IAM policy passes a least-privilege smell test. Permission preview shows every action with a reason.
-
-**Rollback.** Backend flag `IDENTRAIL_FEATURE_CONNECTOR_AWS=false` returns `/v1/connectors/aws*` endpoints to 404. Frontend flag `VITE_FEATURE_CONNECTOR_AWS=false` hides the connect button.
-
----
-
-## PR 8: GitHub Connector
-
-**Goal.** GitHub App for SaaS GitHub.com. PAT fallback for self-hosted GitHub Enterprise.
-
-**Files.**
-- `internal/connectors/github/provider.go` (standard connector surface; old project-scoped routes are not the product path).
-- `internal/connectors/github/app.go` (App credential management, JWT signing, installation token minting).
-- `internal/connectors/github/pat.go` (PAT path for GHES).
-- `internal/connectors/github/webhook.go` (installation lifecycle).
-- `deploy/connectors/github/app-manifest.json` (committed for re-creation).
-- `web/src/pages/connectors/ConnectGitHubPage.tsx`.
-
-**Flow (App).**
-1. User picks "GitHub.com (recommended)". Backend returns App install URL with state.
-2. User redirected to GitHub, picks org and repos, installs.
-3. GitHub returns to `/app/github/callback`; the app calls `POST /v1/connectors/github/complete`.
-4. Backend captures the installation ID, lists accessible repos, and stores them as scannable targets.
-
-**Flow (PAT).**
-1. User picks "GitHub Enterprise / PAT".
-2. Inputs PAT and GHES base URL. Backend validates scopes, encrypts, stores.
-
-**App permissions.** Read-only: Contents, Metadata, Pull Requests, Code Scanning Alerts.
-
-**New endpoints.** `POST /v1/connectors/github`, `GET /v1/connectors/github`, `POST /v1/connectors/github/complete`, `POST /v1/connectors/github/pat`, `POST /auth/webhooks/github` (HMAC-verified), `GET /v1/connectors/github/:id/repos`.
-
-**New env vars.** `IDENTRAIL_GITHUB_APP_ID`, `IDENTRAIL_GITHUB_APP_PRIVATE_KEY` (PEM), `IDENTRAIL_GITHUB_APP_WEBHOOK_SECRET`, `IDENTRAIL_GITHUB_APP_NAME`, `IDENTRAIL_GITHUB_PAT_ALLOWED_BASE_URLS`.
-
-**Out of scope.** Pushing scan results as PR comments. Code scanning alert ingestion. GraphQL API integration.
-
-**Tests.** App JWT signing. Installation token minting and caching. Webhook signature verification. PAT validation. Repo pagination. End-to-end with mocked GitHub API.
-
-**Acceptance.** User installs Identrail GitHub App on their org and returns to an active connector with selected repos visible. Repository webhooks queue scans for selected repos. `installation.deleted` webhook removes connector cleanly. GHES users with PAT can connect.
-
-**Rollback.** Backend flag `IDENTRAIL_FEATURE_CONNECTOR_GITHUB_V2=false` returns the standard `/v1/connectors/github*` endpoints to 404. Frontend flag `VITE_FEATURE_CONNECTOR_GITHUB_V2=false` hides the GitHub connector UI rather than falling back to old project-scoped setup.
-
----
-
-## PR 9: Kubernetes Connector
-
-**Goal.** In-cluster agent (Helm chart, recommended) plus kubeconfig paste fallback for ad-hoc and dev use.
-
-**Files.**
-- `internal/connectors/kubernetes/provider.go`.
-- `internal/connectors/kubernetes/agent_handlers.go` (enroll and heartbeat endpoints).
-- `internal/connectors/kubernetes/kubeconfig.go` (validation and storage).
-- `cmd/identrail-agent/main.go` (the agent binary).
-- `deploy/connectors/k8s/identrail-agent/` (Helm chart with Chart.yaml, deployment.yaml, serviceaccount.yaml, clusterrole.yaml, clusterrolebinding.yaml, values.yaml).
-- `web/src/pages/connectors/ConnectKubernetesPage.tsx`.
-
-**Flow (Agent).**
-1. User picks "Run agent in cluster (recommended)".
-2. Backend generates connector ID and a single-use 24-hour enrollment token.
-3. UI shows a one-line `helm install` command with token and endpoint.
-4. Agent installs as Deployment plus ServiceAccount with cluster-wide read RBAC.
-5. Agent calls `/v1/connectors/k8s/enroll` with the token, exchanges for a long-lived agent credential, starts scanning and heartbeating.
-6. Heartbeat absent for more than 5 minutes marks the connector degraded.
-
-**Flow (kubeconfig).**
-1. User picks "Bring your own kubeconfig".
-2. Pastes kubeconfig. Backend validates by listing namespaces, encrypts, stores.
-
-**Agent RBAC.** `get`, `list`, `watch` on read-only resources. No `pods/exec`, no `secrets` by default, no mutating verbs. Optional `--scan-secret-values=true` flag enables explicit secret-content scanning (default off).
-
-**New endpoints.** `POST /v1/connectors/k8s`, `POST /v1/connectors/k8s/enroll` (agent-facing), `POST /v1/connectors/k8s/heartbeat` (agent-facing), `POST /v1/connectors/k8s/kubeconfig`.
-
-`/v1/connectors/k8s/enroll` and `/v1/connectors/k8s/heartbeat` are explicitly non-browser machine-to-machine routes. They are authenticated with enrollment/agent credentials, and they are exempt from browser-only CSRF header checks (`Origin` and `Sec-Fetch-Site`) that apply to interactive cookie-backed endpoints.
-
-**Out of scope.** Public OCI registry publication of the Helm chart. Real-time admission webhook integration. eBPF runtime detection.
-
-**Tests.** Enrollment token: single-use, expiry, tampering rejected. Heartbeat updates state. `helm lint` passes. ClusterRole programmatic check that no secrets, pods/exec, or mutating verbs are granted. End-to-end with `kind` (Kubernetes-in-Docker).
-
-**Acceptance.** User installs agent on a real cluster in under 2 minutes. Heartbeat observable within 30 seconds. API disconnect revokes agent credential within one heartbeat cycle.
-
-**Rollback.** Backend flag `IDENTRAIL_FEATURE_CONNECTOR_K8S=false` returns `/v1/connectors/k8s*` endpoints to 404 (the agent's heartbeat and enroll endpoints share the same flag). Frontend flag `VITE_FEATURE_CONNECTOR_K8S=false` hides the connect button.
-
----
-
-## PR 10: Onboarding Wizard
-
-**Goal.** Five-step Snyk-style flow tying signup to org to workspace to connector to first scan to invite. The conversion event.
-
-**Files.**
-- `web/src/pages/onboarding/OrgPage.tsx`, `WorkspacePage.tsx`, `ConnectPage.tsx`, `ScanPage.tsx`, `InvitePage.tsx`.
-- `web/src/components/onboarding/Stepper.tsx`, `SkipForNow.tsx`.
-- `internal/api/onboarding/handler.go`.
-- `internal/db/onboarding_state.go`.
-- `migrations/000022_onboarding_state.up.sql` and `.down.sql` (small auxiliary table).
-- Routes registered in `App.tsx`.
-
-**Five steps.** Each at its own URL, resumable on refresh.
-1. `/onboarding/org`. Org name (default to GitHub login if available). Required.
-2. `/onboarding/workspace`. Workspace name (default "Production"). Required.
-3. `/onboarding/connect`. Pick AWS, Kubernetes, or GitHub. Hands off to PR 7, 8, or 9 flows. Skippable.
-4. `/onboarding/scan`. First scan inline, live progress, finding count animating up. Skippable only if step 3 was skipped.
-5. `/onboarding/invite`. Invite teammates by email. Skippable.
-
-**Schema (migration `000022_onboarding_state`).**
-- `onboarding_state(user_id PK, current_step, org_id NULL, workspace_id NULL, connector_id NULL, completed_at NULL, started_at, updated_at)`.
-
-**State management.** Server-driven. Every step writes to backend via `POST /v1/onboarding/state`. Frontend stores nothing in localStorage. Refresh-safe and resume-safe.
-
-**New endpoints.** `POST /v1/onboarding/start`, `POST /v1/onboarding/state`, `POST /v1/onboarding/complete`, `GET /v1/onboarding/state`.
-
-**Done state.** Dashboard with a four-step tooltip overlay. Tooltip is dismissable; the dismissal state persists.
-
-**Out of scope.** Connector-type-specific tours. A/B testing of step order. Email drip campaigns post-onboarding.
-
-**Tests.** Each step persists state. Refresh on any step routes back correctly. Skipping step 3 also skips step 4. Visual snapshots per step in light and dark. End-to-end happy path: signup, onboarding complete, dashboard, first finding visible.
-
-**Acceptance.** New user from a brand-new GitHub account: signup to first finding visible in under 5 minutes, single tab. The connector type chosen in step 3 (AWS, GitHub, or Kubernetes) determines which path produces the finding; whichever PRs among 7, 8, 9 have shipped at the time PR 10 lands are the connectors the wizard can offer. The "first AWS finding" demo path is unblocked specifically once PR 7 ships alongside PR 10.
-
-**Rollback.** Backend flag `IDENTRAIL_FEATURE_ONBOARDING_WIZARD=false` returns `/v1/onboarding/*` endpoints to 404. Frontend flag `VITE_FEATURE_ONBOARDING_WIZARD=false` falls back to the dashboard with no onboarding (user manually creates org and workspace via settings).
-
----
-
-## PR 11: Enterprise SSO Admin
-
-**Goal.** Per-org SAML or OIDC config via WorkOS Admin Portal launcher. Verified domains. Enforcement guardrails. Group-to-role mapping. Invitations. The PR that makes Identrail enterprise-ready.
-
-**Files.**
-- `internal/api/sso/admin_handler.go`.
-- `internal/api/sso/portal_session.go` (5-minute Admin Portal token).
-- `internal/api/sso/domain_verification.go` (DNS TXT verification poller).
-- `internal/api/sso/test_sso.go` (simulated round-trip).
-- `internal/api/sso/recovery_codes.go` (8-code generator, single-use, hashed).
-- `internal/api/sso/relink_job.go` (force-relink on enable).
-- `internal/api/invitations/handler.go` (fills PR 3 stubs).
-- `internal/api/auth/audit.go` (extend with SSO-specific events).
-- `web/src/pages/admin/SSOAdminPage.tsx`, `DomainsPage.tsx`, `InvitationsPage.tsx`.
-- `web/src/components/admin/AdminPortalLaunchButton.tsx`, `RecoveryCodesModal.tsx`.
-
-**New endpoints.**
-- `GET /v1/orgs/:id/sso`
-- `POST /v1/orgs/:id/sso/connection`
-- `POST /v1/orgs/:id/sso/portal-session`
-- `POST /v1/orgs/:id/sso/test`
-- `POST /v1/orgs/:id/sso/enforce`
-- `POST /v1/orgs/:id/sso/relink-all`
-- `POST /v1/orgs/:id/sso/recovery-codes`
-- `POST /v1/orgs/:id/sso/recovery-codes/use`
-- `POST /v1/orgs/:id/domains`
-- `POST /v1/orgs/:id/domains/:domain_id/verify`
-- `DELETE /v1/orgs/:id/domains/:domain_id`
-- `POST /v1/invitations`
-- `GET /v1/me/invitations`
-- `POST /v1/invitations/:id/accept`
-- `DELETE /v1/invitations/:id`
-
-**Verified domain flow.** Claim, generate `verification_token`, user adds DNS TXT record, backend polls or user clicks Verify, backend marks verified. SSO-required only enforceable on verified domains.
-
-**Enforcement guardrail.** The toggle requires the toggling admin to currently hold a session whose `auth_method` was issued by the org's own SSO connection (SAML or OIDC, whichever the connection uses). Otherwise 403. Per `threat-model.md` SSO Lockout section.
-
-**Force-relink job.** On enforce, async job lists all active sessions for org users, schedules invalidation 5 minutes in the future, emails users with re-auth link.
-
-**Recovery codes.** 8 codes, 256-bit entropy each. Generated on enforce, shown once, stored hashed.
-
-**Group to role mapping.** Stored on `identity_connections.group_role_map` JSONB. UI shows WorkOS-reported groups with role dropdowns. Auto-suggestions from common patterns. Unmapped groups default to `viewer` with a warning.
-
-**Email sending.** Provider configurable (default empty/disabled until configured). Branded HTML and plaintext templates. 100 invites per org per hour.
-
-**New env vars.** `IDENTRAIL_EMAIL_PROVIDER`, `IDENTRAIL_EMAIL_API_KEY`, `IDENTRAIL_EMAIL_FROM_ADDRESS`.
-
-**Out of scope.** SCIM (PR 12). Auth audit log UI (PR 12). Cross-org features.
-
-**Tests.** Verified domain flow (TXT absent vs present). SSO enforce toggle rejects an admin whose current session is not from the org's configured SSO connection. Recovery codes generated, single-use, hashed. Force-relink revokes sessions correctly. Test SSO simulates without persisting. Invitation email rendering. Group-to-role persistence.
-
-**Acceptance.** Admin signs up fresh org, enables SSO with test IdP, verifies domain, enforces SSO, invites colleague, colleague signs in via SSO with correct role. Recovery code can rescue locked-out admin.
-
-**Rollback.** Feature flag `IDENTRAIL_FEATURE_SSO_ADMIN=false`.
-
----
-
-## PR 12: SCIM and Hardening
-
-**Goal.** WorkOS Directory Sync auto-provisioning plus the safety nets every mature security product has plus the entitlements layer.
-
-**Files.**
-- `internal/api/scim/handler.go` (Directory Sync webhook receiver).
-- `internal/api/scim/queue.go` (provisioning queue).
-- `internal/api/scim/jit_provisioning.go` (SAML-before-SCIM-sync fallback).
-- `internal/api/auth/account_deletion.go` (self-serve delete with grace).
-- `internal/api/audit/export.go` (CSV export, license-gated).
-- `internal/scheduler/cleanup_jobs.go` (extended with deletion grace job).
-- `internal/license/entitlements.go`.
-- `migrations/000023_org_entitlements.up.sql` and `.down.sql`.
-- `web/src/pages/admin/AuditLogPage.tsx`, `OrgSessionsPage.tsx`.
-- `web/src/pages/account/DeleteAccountPage.tsx`.
-
-**Schema (migration `000023_org_entitlements`).**
-- `org_entitlements(org_id PK, plan, max_connectors INT, max_scans_per_day INT, sso_enabled BOOL, scim_enabled BOOL, audit_export_enabled BOOL, expires_at NULL, updated_at)`. Free defaults: 1 connector, 100 scans per day, no SSO, no SCIM, no audit export. Ops set entitlements manually for early customers (no Stripe yet).
-- `scim_events_seen(event_id TEXT PRIMARY KEY, received_at TIMESTAMPTZ NOT NULL DEFAULT NOW())`. Idempotency log for WorkOS Directory Sync webhook deliveries. Cleanup job prunes rows older than 30 days.
-
-**SCIM handlers.** `users.created` upserts `users` + `user_identities` + `tenancy_workspace_members`. `users.updated` patches fields. `users.deleted` (or `active=false`) sets `users.status='deactivated'`, revokes all sessions, retains row. `groups.user_added` and `groups.user_removed` update membership.
-
-**Idempotency.** Two distinct concepts kept separate:
-
-- **User mapping** (which Identrail user does this WorkOS event refer to?) uses the existing `user_identities` row keyed by `(provider, subject)` where `provider="workos"` and `subject` is the WorkOS user external id. No new column is needed; the unique constraint already enforces one row per (provider, subject) pair.
-- **Event-level deduplication** (have we already processed this exact webhook delivery?) uses the `scim_events_seen` table added by the migration above. Each WorkOS Directory Sync event carries a unique `event_id`; the handler inserts the id with `ON CONFLICT DO NOTHING` and skips processing if the insert was a no-op. A nightly cleanup job prunes rows older than 30 days.
-
-**JIT fallback.** SAML user lands before SCIM has synced them: create user with default role from SAML attributes, audit warning.
-
-**Auth audit log UI.** Org-admin view filterable by user, action, time range, outcome, with CSV export gated by `entitlements.audit_export_enabled`. The same PR ships the per-user feed at `/app/account/security` (the placeholder slot left by PR 5) backed by `GET /v1/me/auth-events?limit=30`. The query is authenticated against the calling session and scoped to that user's events only. Backing the feed requires a queryable persistence path for `audit.AuditEvent` records of `Action LIKE 'auth.%'`; the simplest implementation is to add an `audit_events` Postgres sink alongside the existing file/HTTP sinks and read from it. The migration that adds the `audit_events` table ships in this PR's `000023_org_entitlements.up.sql` migration to keep PR 12's schema work in one place.
-
-**Org-admin session management.** All active sessions across the org. Filter and revoke.
-
-**Self-serve account deletion.** Confirmation modal. 14-day grace, cancellable. Cleanup job hard-deletes after 14 days. Owner deletion blocked unless ownership transferred.
-
-**Dangerous-path tests.**
-- Deprovisioning user mid-scan: scan continues under service identity.
-- Role downgrade: revokes higher-priv API keys and sessions.
-- SSO enforcement: blocks new logins via non-SSO providers; in-flight requests finish.
-
-**Out of scope.** Stripe and billing automation. Custom roles beyond owner, admin, analyst, viewer. SAML attribute mapping UI.
-
-**Tests.** Idempotent SCIM events. Queue absorbs burst of 1000 events. JIT provisioning warning. CSV export blocked when entitlement is off. Account deletion grace and hard-delete. Mid-scan deprovisioning. License gate disables SCIM toggle.
-
-**Acceptance.** 50-user org with WorkOS Directory Sync: all 50 created within 1 minute. User removed from IdP loses access within 30 seconds. Admin can export 30-day audit log as CSV (Pro tier). User can self-serve delete; data fully removed in 14 days.
-
-**Rollback.** Feature flag `IDENTRAIL_FEATURE_SCIM=false` rejects Directory Sync webhooks gracefully. `IDENTRAIL_FEATURE_ENTITLEMENTS=false` defaults to permissive.
-
----
-
-## Cross-cutting Rules (every PR)
-
-- API key and bearer OIDC paths never break. Repeat in every PR description as a non-removal commitment.
-- Feature flag every new endpoint and UI surface. Listed in each PR's Rollback note.
-- Telemetry contract: every new endpoint emits structured log plus metric plus audit event.
-- Demo-path E2E test grows as PRs land: signup, onboarding, connect AWS, first scan, invite, second-user accept, SSO enable, SCIM sync. Lives in CI from PR 10 onward.
-- Docs ship in the same PR. OpenAPI entry for every endpoint.
-- Visual snapshots on auth, onboarding, account, admin, connector pages.
-- Skeleton, loading, and error states on every async operation.
-- Rate limiting on every `/auth/*`, `/onboarding/*`, `/v1/connectors/*` endpoint.
-- Branch off `dev`, target `dev`. Auth work never shares a branch with the perf PR or other open PRs.
-- DCO sign-off on every commit.
-- Two-reviewer minimum on PRs 4, 7, 11, 12 (security-sensitive). Single reviewer is fine for the rest.
+# Superseded Auth Roadmap
+
+This file used to describe the original twelve-PR auth and connector sequence.
+That sequence is no longer the source of truth. The current roadmap is the
+three-track plan below:
+
+1. Enterprise SSO: native SAML plus SCIM.
+2. Executive report.
+3. Data-residency policy.
+
+The old WorkOS-only SSO admin and WorkOS Directory Sync assumptions were
+replaced by native SAML support alongside the existing WorkOS path. Keep WorkOS
+login untouched; native SAML and SCIM are opt-in behind
+`IDENTRAIL_FEATURE_NATIVE_SSO`.
+
+## Track 1: Enterprise SSO
+
+Track 1 is now implemented on `dev`.
+
+| PR | Scope | Status |
+| --- | --- | --- |
+| PR-1 | Extend `identity_connections` for native SAML and add SCIM persistence. | Shipped |
+| PR-2 | Native SAML connection admin API and Okta/Azure metadata import. | Shipped |
+| PR-3 | Native SAML SP-initiated login and ACS via `crewjam/saml`. | Shipped |
+| PR-4 | SCIM 2.0 endpoints for Okta and Azure/Entra user provisioning. | Shipped |
+| PR-5 | SCIM provisioning workflow audit dispatch and customer setup docs. | Shipped |
+
+Implemented runtime surfaces:
+
+- `POST/GET /v1/enterprise/identity-connections/saml`
+- `GET/PUT/DELETE /v1/enterprise/identity-connections/saml/{id}`
+- `POST /v1/enterprise/identity-connections/saml/from-metadata`
+- `GET /auth/saml/login/{connection_id}`
+- `POST /auth/saml/acs/{connection_id}`
+- `GET /scim/v2/ServiceProviderConfig`
+- `GET /scim/v2/Schemas`
+- `GET /scim/v2/ResourceTypes`
+- `GET/POST /scim/v2/Users`
+- `GET/PUT/PATCH/DELETE /scim/v2/Users/{id}`
+
+Important current constraints:
+
+- Native SSO is disabled by default and registers these routes only when
+  `IDENTRAIL_FEATURE_NATIVE_SSO=true` or the compatibility alias
+  `IDENTRAIL_ENABLE_NATIVE_SSO=true`.
+- Native SAML connection creation returns a one-time SCIM bearer token and
+  stores only `identity_connections.scim_bearer_token_hash`.
+- `sso_required` is persisted on the native SAML connection and should remain
+  `false` until the operator has tested SAML and SCIM. The current Track 1 code
+  does not yet ship recovery-code generation or a full org lockout-rescue flow.
+- JIT user creation is controlled per connection by
+  `jit_provisioning_enabled`; unknown SAML users are rejected when it is false.
+- SCIM creates, updates, deactivations, and deletes append
+  `scim_provisioning_events` and dispatch `workflow.Event` records through the
+  existing workflow router.
+- Native SAML must not silently replace WorkOS. WorkOS-backed SAML rows and
+  native SAML rows are distinct, and the admin API returns a clear conflict when
+  an org already has a WorkOS-managed SAML connection of the same type.
+
+Customer setup lives in [`../enterprise-quickstart.md`](../enterprise-quickstart.md).
+The API contract lives in [`../openapi-v1.yaml`](../openapi-v1.yaml).
+
+## Track 2: Executive Report
+
+Track 2 restores leadership reporting without server-side PDF generation.
+
+| PR | Scope | Status |
+| --- | --- | --- |
+| PR-6 | Add `ResolvedAt` on finding triage, migration, and backfill. | Planned |
+| PR-7 | Add `/v1/enterprise/reports/executive` JSON endpoint with MTTR. | Planned |
+| PR-8 | Add read-only web executive report page with browser print styles. | Planned |
+
+The output target is a page a CISO can bookmark, refresh weekly, and print from
+the browser with Cmd+P or Ctrl+P.
+
+## Track 3: Data-Residency Policy
+
+Track 3 is deferred until a customer needs region-level enforcement.
+
+| PR | Scope | Status |
+| --- | --- | --- |
+| PR-9 | Add `residency_policies` table and CRUD API. | Deferred |
+| PR-10 | Add write-boundary enforcement middleware behind a feature flag. | Deferred |
+
+The intended customer path is advisory mode first, then strict mode after the
+compliance team has reviewed the audit trail.
+
+## Cross-Cutting Rules
+
+Every follow-up PR should preserve these rules:
+
+- No new daemon, worker, queue, Redis, or second database unless explicitly
+  approved.
+- Migrations are additive and backward compatible.
+- Advanced settings need working defaults.
+- New routes are feature-flagged until GA.
+- API behavior changes update OpenAPI and customer-visible docs in the same PR.
+- Okta and Azure/Entra paths use real provider-shaped fixtures in tests.
+- WorkOS remains supported and must not be silently overridden by native SAML.
+- Commits are DCO signed.

--- a/docs/auth/README.md
+++ b/docs/auth/README.md
@@ -1,6 +1,9 @@
 # Auth Documentation
 
-This folder holds the architectural foundation for Identrail's signup, sign-in, SSO, SCIM, and connector onboarding work. The docs are the source of truth for the twelve-PR delivery sequence.
+This folder holds the architectural foundation for Identrail's signup, sign-in,
+SSO, SCIM, and connector onboarding work. The current implementation ships
+WorkOS hosted login plus opt-in native SAML and SCIM behind
+`IDENTRAIL_FEATURE_NATIVE_SSO`.
 
 ## Read Order
 
@@ -15,8 +18,8 @@ Start at the top. Each later doc fills in detail for one section of the first.
 7. [`github-connector.md`](./github-connector.md) - the standard GitHub App and GitHub Enterprise connector path.
 8. [`kubernetes-connector.md`](./kubernetes-connector.md) - the standard in-cluster agent and kubeconfig fallback path.
 9. [`production-api-readiness.md`](./production-api-readiness.md) - the production web/API split required before the frontend auth UI can work on Vercel.
-10. [`env-vars-reference.md`](./env-vars-reference.md) - flat list of every environment variable across the twelve PRs.
-11. [`12-pr-plan.md`](./12-pr-plan.md) - the canonical scope for each of the twelve PRs.
+10. [`env-vars-reference.md`](./env-vars-reference.md) - flat list of authentication-related environment variables.
+11. [`12-pr-plan.md`](./12-pr-plan.md) - superseded roadmap file that now records the current three-track plan.
 
 ## When to Update These Docs
 
@@ -32,4 +35,7 @@ When a doc and the code disagree, the doc is wrong. Fix the doc. Then either cha
 
 ## Status
 
-This doc set lands in PR 1 of the twelve-PR sequence. The other eleven PRs implement what these docs describe.
+The original twelve-PR sequence has been superseded by the three-track roadmap
+in [`12-pr-plan.md`](./12-pr-plan.md). When implementation and docs disagree,
+the implementation on `dev` wins and the docs should be corrected in the same
+PR.

--- a/docs/auth/architecture.md
+++ b/docs/auth/architecture.md
@@ -1,6 +1,9 @@
 # Auth Architecture
 
-This document is the entry point for how authentication, sessions, and identity work in Identrail. It locks down the contracts that the next eleven PRs implement. If a later PR disagrees with this doc, the doc is wrong and we update it before the code lands.
+This document is the entry point for how authentication, sessions, and identity
+work in Identrail. It describes the contracts currently implemented on `dev`
+plus the explicitly planned follow-up tracks. If code and this document
+disagree, update this document or the code in the same PR.
 
 ## Goals
 
@@ -67,8 +70,8 @@ Today, `tenancy_workspace_members.user_id` is a free-text string holding the OID
 
 Stages:
 
-1. Add `user_uuid UUID NULL` in PR 2. New writes populate both `user_id` and `user_uuid`.
-2. PR 4 (WorkOS login) populates `user_uuid` for every new sign-in.
+1. Add `user_uuid UUID NULL`. New writes populate both `user_id` and `user_uuid`.
+2. WorkOS login populates `user_uuid` for every new sign-in.
 3. A backfill job copies `user_uuid` for existing rows by joining on the `(provider, subject)` pair, not `subject` alone. Subjects can collide across IdPs (Google `sub=12345` and Microsoft `sub=12345` are unrelated humans), so the backfill needs the provider too. For each org, the backfill resolves provider from the org's currently-configured OIDC issuer (the common case is one IdP per org); rows that match more than one `user_identities` row are left for manual reconciliation rather than auto-linked. Audit log records every backfill mapping for traceability.
 4. After we observe zero non-UUID reads in production telemetry for at least four weeks, a separate migration drops `user_id` and renames `user_uuid` to `user_id`.
 
@@ -120,84 +123,101 @@ The canonical production base URL lives in `IDENTRAIL_PUBLIC_BASE_URL`. The doc 
 
 ## Endpoint Surface
 
-Every endpoint we plan to add across all twelve PRs. Routes ship in the PR noted in the third column.
+This section lists the auth, native SSO, SCIM, onboarding, and connector
+endpoints that are implemented or intentionally planned. The OpenAPI contract in
+[`../openapi-v1.yaml`](../openapi-v1.yaml) is the authoritative machine-readable
+shape for shipped routes.
 
 ### Sessions and identity
 
 Session context includes `current_org_id`, `current_workspace_id`, and `current_project_id` so project-scoped APIs can resolve tenancy without implicit defaults.
 
-| Method | Path | Adds in |
+| Method | Path | Status |
 | --- | --- | --- |
-| GET | `/v1/me` | PR 2 |
-| GET | `/v1/me/sessions` | PR 2 |
-| DELETE | `/v1/me/sessions/:id` | PR 2 |
-| POST | `/v1/me/sessions/revoke-others` | PR 2 |
-| GET | `/v1/me/auth-events` | PR 12 |
-| POST | `/auth/logout` | PR 2 |
-| GET | `/v1/auth/config` | PR 4 |
+| GET | `/v1/me` | Shipped |
+| GET | `/v1/me/sessions` | Shipped |
+| DELETE | `/v1/me/sessions/:id` | Shipped |
+| POST | `/v1/me/sessions/revoke-others` | Shipped |
+| GET | `/v1/me/auth-events` | Planned |
+| POST | `/auth/logout` | Shipped |
+| GET | `/v1/auth/config` | Shipped |
 
 ### Hosted login
 
-| Method | Path | Adds in |
+| Method | Path | Status |
 | --- | --- | --- |
-| GET | `/auth/login?return_to=...` | PR 4 |
-| GET | `/auth/signup?return_to=...` | PR 4 |
-| GET | `/auth/callback` | PR 4 |
-| POST | `/auth/webhooks/workos` | PR 4 |
+| GET | `/auth/login?return_to=...` | Shipped |
+| GET | `/auth/signup?return_to=...` | Shipped |
+| GET | `/auth/callback` | Shipped |
+| POST | `/auth/webhooks/workos` | Shipped |
 
 ### Onboarding
 
-| Method | Path | Adds in |
+| Method | Path | Status |
 | --- | --- | --- |
-| POST | `/v1/onboarding/start` | PR 10 |
-| GET | `/v1/onboarding/state` | PR 10 |
-| POST | `/v1/onboarding/state` | PR 10 |
-| POST | `/v1/onboarding/complete` | PR 10 |
+| POST | `/v1/onboarding/start` | Shipped |
+| GET | `/v1/onboarding/state` | Shipped |
+| POST | `/v1/onboarding/state` | Shipped |
+| POST | `/v1/onboarding/complete` | Shipped |
 
 ### Connectors
 
 Connector endpoints are project-scoped. The route shape stays flat (`/v1/connectors/*`), but every handler resolves `(tenant_id, workspace_id, project_id)` from the authenticated session context, including `sessions.current_project_id`. Requests without an active project context fail fast.
 
-| Method | Path | Adds in |
+| Method | Path | Status |
 | --- | --- | --- |
-| GET | `/v1/connectors` | PR 6 |
-| GET | `/v1/connectors/:id` | PR 6 |
-| GET | `/v1/connectors/:id/health` | PR 6 |
-| DELETE | `/v1/connectors/:id` | PR 6 |
-| POST | `/v1/connectors/:id/disable` | PR 6 |
-| POST | `/v1/connectors/:id/enable` | PR 6 |
-| POST | `/v1/connectors/aws` | PR 7 |
-| POST | `/v1/connectors/aws/:id/validate` | PR 7 |
-| GET | `/v1/connectors/aws/:id/poll` | PR 7 |
-| POST | `/v1/connectors/aws/:id/refresh-policy` | PR 7 |
-| POST | `/v1/connectors/github` | PR 8 |
-| POST | `/v1/connectors/github/pat` | PR 8 |
-| POST | `/auth/webhooks/github` | PR 8 |
-| GET | `/v1/connectors/github/:id/repos` | PR 8 |
-| POST | `/v1/connectors/k8s` | PR 9 |
-| POST | `/v1/connectors/k8s/enroll` | PR 9 |
-| POST | `/v1/connectors/k8s/heartbeat` | PR 9 |
-| POST | `/v1/connectors/k8s/kubeconfig` | PR 9 |
+| GET | `/v1/connectors` | Shipped |
+| GET | `/v1/connectors/:id` | Shipped |
+| GET | `/v1/connectors/:id/health` | Shipped |
+| DELETE | `/v1/connectors/:id` | Shipped |
+| POST | `/v1/connectors/:id/disable` | Shipped |
+| POST | `/v1/connectors/:id/enable` | Shipped |
+| POST | `/v1/connectors/aws` | Shipped |
+| POST | `/v1/connectors/aws/:id/validate` | Shipped |
+| GET | `/v1/connectors/aws/:id/poll` | Shipped |
+| POST | `/v1/connectors/aws/:id/refresh-policy` | Shipped |
+| POST | `/v1/connectors/github` | Shipped |
+| POST | `/v1/connectors/github/pat` | Shipped |
+| POST | `/auth/webhooks/github` | Shipped |
+| GET | `/v1/connectors/github/:id/repos` | Shipped |
+| POST | `/v1/connectors/k8s` | Shipped |
+| POST | `/v1/connectors/k8s/enroll` | Shipped |
+| POST | `/v1/connectors/k8s/heartbeat` | Shipped |
+| POST | `/v1/connectors/k8s/kubeconfig` | Shipped |
+
+### Native SAML and SCIM
+
+These routes are registered only when `IDENTRAIL_FEATURE_NATIVE_SSO=true` or
+the compatibility alias `IDENTRAIL_ENABLE_NATIVE_SSO=true`. Native SAML admin
+and login routes also require `IDENTRAIL_FEATURE_NEW_AUTH=true` because they
+depend on session-auth middleware and the SAML relay store.
+
+| Method | Path | Status |
+| --- | --- | --- |
+| POST | `/v1/enterprise/identity-connections/saml` | Shipped |
+| GET | `/v1/enterprise/identity-connections/saml` | Shipped |
+| GET | `/v1/enterprise/identity-connections/saml/:id` | Shipped |
+| PUT | `/v1/enterprise/identity-connections/saml/:id` | Shipped |
+| DELETE | `/v1/enterprise/identity-connections/saml/:id` | Shipped |
+| POST | `/v1/enterprise/identity-connections/saml/from-metadata` | Shipped |
+| GET | `/auth/saml/login/:connection_id` | Shipped |
+| POST | `/auth/saml/acs/:connection_id` | Shipped |
+| GET | `/scim/v2/ServiceProviderConfig` | Shipped |
+| GET | `/scim/v2/Schemas` | Shipped |
+| GET | `/scim/v2/ResourceTypes` | Shipped |
+| GET | `/scim/v2/Users` | Shipped |
+| POST | `/scim/v2/Users` | Shipped |
+| GET | `/scim/v2/Users/:id` | Shipped |
+| PUT | `/scim/v2/Users/:id` | Shipped |
+| PATCH | `/scim/v2/Users/:id` | Shipped |
+| DELETE | `/scim/v2/Users/:id` | Shipped |
 
 ### Enterprise admin
 
-| Method | Path | Adds in |
-| --- | --- | --- |
-| GET | `/v1/orgs/:id/sso` | PR 11 |
-| POST | `/v1/orgs/:id/sso/connection` | PR 11 |
-| POST | `/v1/orgs/:id/sso/portal-session` | PR 11 |
-| POST | `/v1/orgs/:id/sso/test` | PR 11 |
-| POST | `/v1/orgs/:id/sso/enforce` | PR 11 |
-| POST | `/v1/orgs/:id/sso/relink-all` | PR 11 |
-| POST | `/v1/orgs/:id/sso/recovery-codes` | PR 11 |
-| POST | `/v1/orgs/:id/sso/recovery-codes/use` | PR 11 |
-| POST | `/v1/orgs/:id/domains` | PR 11 |
-| POST | `/v1/orgs/:id/domains/:domain_id/verify` | PR 11 |
-| DELETE | `/v1/orgs/:id/domains/:domain_id` | PR 11 |
-| POST | `/v1/invitations` | PR 11 |
-| GET | `/v1/me/invitations` | PR 11 |
-| POST | `/v1/invitations/:id/accept` | PR 11 |
-| DELETE | `/v1/invitations/:id` | PR 11 |
+The invitation, verified-domain, and WorkOS Admin Portal routes from the
+original roadmap are no longer the Track 1 source of truth. Keep the current
+WorkOS login path working, but use the native SAML admin API above for native
+SAML configuration.
 
 ### Existing endpoints (unchanged)
 
@@ -205,7 +225,7 @@ The existing API key endpoints, the existing OIDC bearer flow, the existing scan
 
 ## Rate Limit Budgets
 
-The new auth and connector endpoints set explicit rate limits. PR 4 implements them; later PRs inherit the same configuration shape.
+Auth and connector endpoints set explicit rate limits. Later route additions should inherit the same configuration shape.
 
 | Endpoint pattern | Limit | Per |
 | --- | --- | --- |
@@ -221,19 +241,47 @@ The new auth and connector endpoints set explicit rate limits. PR 4 implements t
 
 Limits are enforced server-side and emit metrics. Hitting a limit returns HTTP 429 with `Retry-After`.
 
-## SSO Enforcement Guardrail
+## SSO Rollout Guardrail
 
-Once an org enables SSO and turns on enforcement, all org members must sign in via the configured IdP. SSO can be SAML or OIDC depending on what the IdP exposes. To prevent admins from locking themselves out, the enforcement toggle has one rule:
+Native SAML connections persist two rollout controls:
+`sso_required` and `jit_provisioning_enabled`. Both default to `false`.
 
-> The admin clicking "enforce SSO" must currently hold an active session whose `auth_method` was issued by that org's configured SSO connection (SAML or OIDC, whichever the connection uses).
+The current Track 1 implementation stores `sso_required` and exposes it through
+the native SAML admin API, but it does not yet ship recovery-code generation,
+an IdP-authenticated enforcement toggle, or a full org lockout-rescue flow. Do
+not document or rely on those older roadmap features as shipped behavior.
 
-If the admin is currently signed in via any other method (password OAuth, email OTP, manual mode), the enforce request returns 403 with an explanatory message. The admin signs out, signs back in through the IdP, and tries again.
+The safe operating sequence is:
 
-Enforcing SSO also generates eight single-use recovery codes (256-bit each, stored hashed) shown once to the admin. These can rescue the org if the IdP itself becomes unavailable.
+1. Create the native SAML connection with `sso_required=false`.
+2. Import IdP metadata and verify SAML login with a test admin.
+3. Enable SCIM and confirm create, update, deactivate, and delete events.
+4. Only then set `sso_required=true` as the org's rollout marker and keep a
+   break-glass admin path outside the enforced tenant.
 
-This is the [Vercel pattern](https://vercel.com/docs/saml). It is the smallest piece of UX that prevents the largest support disaster.
+See [`identity-linking-rules.md`](./identity-linking-rules.md) for the rules
+around linking identities and joining orgs.
 
-See [`identity-linking-rules.md`](./identity-linking-rules.md) for the rules around linking identities and joining orgs.
+## Native SAML
+
+Native SAML uses `github.com/crewjam/saml` for protocol handling. Identrail
+constructs a per-connection service provider from the stored entity ID, SSO
+URL, certificate, and public base URL, then delegates assertion parsing,
+signature verification, audience/recipient checks, and time-condition checks to
+the library.
+
+The SP entity ID is:
+
+```text
+${IDENTRAIL_PUBLIC_BASE_URL}/auth/saml/metadata/<connection_id>
+```
+
+That value is an identifier used as the SAML audience. The current API does not
+serve an SP metadata document at that URL.
+
+Unknown SAML users are rejected unless the connection has
+`jit_provisioning_enabled=true`. When JIT is disabled, the ACS returns a clear
+admin-actionable failure telling the user to ask an admin to provision them.
 
 ## Native SCIM Provisioning
 
@@ -253,11 +301,17 @@ When `IDENTRAIL_FEATURE_NATIVE_SSO=true` (or the compatibility alias `IDENTRAIL_
 | `PATCH /scim/v2/Users/{id}` | Apply SCIM PATCH `replace` operations |
 | `DELETE /scim/v2/Users/{id}` | Deactivate a provisioned user and record a delete event |
 
-SCIM resources reuse the auth tables instead of introducing a separate user store: `users.id` is the SCIM resource id, and `user_identities` stores `(provider="scim:<connection_uuid>", subject=<userName>)`. Each create, update, deactivate, and delete appends a `scim_provisioning_events` row for tenant-visible audit.
+SCIM resources reuse the auth tables instead of introducing a separate user
+store: `users.id` is the SCIM resource id, and `user_identities` stores
+`(provider="scim:<connection_uuid>", subject=<userName>)`. Each create, update,
+deactivate, and delete appends a `scim_provisioning_events` row for
+tenant-visible audit and dispatches a `scim.provisioned` workflow event through
+the existing workflow router. Dispatch failures are audited but do not fail the
+SCIM operation.
 
 ## Connector Foundation Preview
 
-Every connector (AWS, Kubernetes, GitHub, future ones) implements one Go interface and shares one status state machine and one error taxonomy. PR 6 ships this foundation; PRs 7, 8, 9 fill it in for the three providers.
+Every connector (AWS, Kubernetes, GitHub, future ones) implements one Go interface and shares one status state machine and one error taxonomy.
 
 The full spec lives in [`connector-foundation.md`](./connector-foundation.md). The short version: never write a bespoke status string or bespoke error code in a connector. Every connector goes through `pending → validating → active ⇄ degraded → disconnected`. Every error maps to one of seven taxonomy codes. Every connector ships a `Health()` implementation that the heartbeat job calls every 5 minutes.
 
@@ -274,15 +328,16 @@ A flat list with defaults, validation, and the PR that introduces each variable 
 
 The most important rule: every domain reference in code, config, and email templates reads from `IDENTRAIL_PUBLIC_BASE_URL` rather than a string literal. The docs use `https://app.identrail.com` as the canonical example throughout because we have to write something concrete down, but the production deployment derives that value from the env var. Code paths that hardcode the domain are caught in CI and rejected. The server refuses to start if `IDENTRAIL_PUBLIC_BASE_URL` is unset or invalid.
 
-## Twelve-PR Sequence
+## Roadmap
 
-The full PR breakdown lives in [`12-pr-plan.md`](./12-pr-plan.md). Each section is the canonical scope for that PR. When opening a PR, copy the matching section into the PR description as a checklist.
+The current roadmap lives in [`12-pr-plan.md`](./12-pr-plan.md). The file name
+is historical; the content now records the three-track plan.
 
 ## Non-Goals for the Auth Foundation
 
 To stay scoped, this work explicitly does not address:
 
-- Stripe or any payment integration. Entitlements ship in PR 12 with manual ops control. Billing is a separate stream.
+- Stripe or any payment integration. Billing is a separate stream.
 - Custom roles beyond `owner`, `admin`, `analyst`, `viewer`. Adding a fifth role is not in scope until at least one design partner needs it.
 - A mobile app. Mobile would need PKCE on a different flow; out of scope.
 - Breaking the existing API key auth. API keys keep working unchanged forever.
@@ -292,8 +347,9 @@ To stay scoped, this work explicitly does not address:
 
 These are the questions we have not answered yet and do not need to answer to ship PRs 1 through 5.
 
-- Email provider: Resend vs Postmark vs SES. Decision deadline: PR 11. Default plan is Resend.
-- Backend hosting: Fly.io vs Render vs AWS for the Go binary. Decision deadline: before PR 4 deploys to production. The dev environment runs on the existing docker-compose.
+- Email provider: Resend vs Postmark vs SES. Default plan is Resend when
+  invitation/email work resumes.
+- Backend hosting: AWS is the current documented hosted API path; local development still runs through docker-compose.
 - Account merge across providers: today an authenticated user can link a second identity. Whether to ever allow merging two existing accounts (one per provider) is deferred. Default answer is no.
 - Free-tier abuse defense beyond rate limits. Captcha vs proof-of-work vs domain blocklists. Deferred until we see actual abuse signals.
 
@@ -305,4 +361,4 @@ These are the questions we have not answered yet and do not need to answer to sh
 - [`identity-linking-rules.md`](./identity-linking-rules.md)
 - [`connector-foundation.md`](./connector-foundation.md)
 - [`env-vars-reference.md`](./env-vars-reference.md)
-- [`12-pr-plan.md`](./12-pr-plan.md)
+- [`12-pr-plan.md`](./12-pr-plan.md) - historical file name, current three-track roadmap

--- a/docs/auth/cookie-and-session-spec.md
+++ b/docs/auth/cookie-and-session-spec.md
@@ -1,6 +1,6 @@
 # Cookie and Session Spec
 
-The exact rules for how Identrail issues, validates, rotates, and revokes session cookies. PR 2 implements this; later PRs reuse without modification.
+The exact rules for how Identrail issues, validates, rotates, and revokes session cookies. These rules are implemented and later auth work reuses them without modification.
 
 ## Cookie
 
@@ -31,7 +31,7 @@ The cookie value is the session ID. The server stores SHA-256 of that ID as the 
 | `current_org_id` | `TEXT NULL` | The org context for this session. NULL during onboarding before org creation. Type matches existing `tenancy_organizations.tenant_id`. |
 | `current_workspace_id` | `TEXT NULL` | The workspace context. NULL similarly. Type matches existing `tenancy_workspaces.workspace_id`. |
 | `current_project_id` | `TEXT NULL` | The active project context for project-scoped APIs such as connectors. Type matches existing `tenancy_projects.project_id`. |
-| `auth_method` | `TEXT NOT NULL` | One of `workos`, `oidc`, `manual`. Used by the SSO enforcement check. |
+| `auth_method` | `TEXT NOT NULL` | One of `workos`, `oidc`, `manual`, `saml`. Used by auth auditing and future SSO enforcement checks. |
 | `ip` | `INET NULL` | Client IP at session creation. Not updated on every request; the audit log captures per-request IP. |
 | `user_agent` | `TEXT NULL` | Client UA at session creation. |
 | `idle_expires_at` | `TIMESTAMPTZ NOT NULL` | Sliding renewal target. |
@@ -88,13 +88,13 @@ Four paths, all going through the same `RevokeSession(ctx, id)` repository metho
 - **User-initiated logout.** `POST /auth/logout` revokes the current session (sets `revoked_at = now()`) and clears the cookie.
 - **User revoking one of their other sessions.** `DELETE /v1/me/sessions/:id` from the account/security page. The endpoint scopes the lookup by `user_id` so a user cannot revoke someone else's session id. If the target id is the current session, the response also clears the cookie.
 - **User revoking every other session.** `POST /v1/me/sessions/revoke-others` revokes every row for the user except the calling session. Used for "Sign me out everywhere else."
-- **Admin or system revocation.** SCIM deactivation, role downgrade past API-key scope, force-relink on SSO enable. All call `RevokeSession(ctx, id)` in a loop over the affected user's sessions.
+- **Admin or system revocation.** SCIM deactivation and role downgrade past API-key scope call `RevokeSession(ctx, id)` in a loop over the affected user's sessions. Future SSO enforcement work should use the same path.
 
 A revoked session is rejected on the next request, no token expiry to wait for. This is the primary reason we use opaque server-side sessions instead of JWTs.
 
 ## Session Listing
 
-`GET /v1/me/sessions` returns the active sessions for the calling user. Each row carries id, ip, user_agent, created_at, last_seen_at, idle_expires_at, and a `current` boolean marking the session that owns the calling cookie. The endpoint never returns sessions for any other user, even with admin scope; admin-side org session management is a separate endpoint that ships in PR 12.
+`GET /v1/me/sessions` returns the active sessions for the calling user. Each row carries id, ip, user_agent, created_at, last_seen_at, idle_expires_at, and a `current` boolean marking the session that owns the calling cookie. The endpoint never returns sessions for any other user, even with admin scope; admin-side org session management is future work.
 
 ## Cookie Rotation on Privilege Change
 
@@ -127,7 +127,7 @@ A job in the existing scheduler runs every hour and deletes session rows where `
 - It does not work cross-site. Embedding the dashboard in a third-party page would require explicit `SameSite=None; Partitioned` and a security review.
 - It does not work for the marketing site. `www.identrail.com` does not see this cookie.
 
-## Test Matrix (PR 2)
+## Test Matrix
 
 | Test | Expected |
 | --- | --- |

--- a/docs/auth/env-vars-reference.md
+++ b/docs/auth/env-vars-reference.md
@@ -1,6 +1,8 @@
 # Auth Environment Variables Reference
 
-A flat list of every environment variable the auth and connector work introduces, with default, validation rule, and the PR that adds it.
+A flat list of authentication and connector environment variables, with
+defaults and validation notes. The "Track" column reflects the current roadmap;
+older PR-number references are historical.
 
 The rule that drives every example below: domain references are always config-driven. The doc never hardcodes `app.identrail.com` outside of an example value column.
 
@@ -8,12 +10,12 @@ The rule that drives every example below: domain references are always config-dr
 
 The two variables marked `Required` in the table below apply regardless of which auth driver is active (WorkOS, generic OIDC, or manual). Self-hosted operators set them just as cloud deployments do. The other two are optional knobs covered in the same table for completeness: `IDENTRAIL_SESSION_KEY_PREVIOUS` is only set during a key rotation, and `IDENTRAIL_AUTH_MANUAL_MODE` defaults to `false`.
 
-| Variable | Default | Validation | Adds in |
+| Variable | Default | Validation | Track |
 | --- | --- | --- | --- |
-| `IDENTRAIL_PUBLIC_BASE_URL` | none | Required for any auth driver (WorkOS, OIDC, or manual). Must parse as an absolute URL. Must be `https://` in any non-development build. Refuses to start if missing. | PR 2 |
-| `IDENTRAIL_SESSION_KEY` | none | Required for any auth driver. 32 bytes minimum (64 hex chars). Refuses to start if missing or shorter. | PR 2 |
-| `IDENTRAIL_SESSION_KEY_PREVIOUS` | empty | Optional. Same format as `IDENTRAIL_SESSION_KEY`. Used during key rotation. | PR 2 |
-| `IDENTRAIL_AUTH_MANUAL_MODE` | `false` | Boolean. Mutually exclusive with `IDENTRAIL_WORKOS_CLIENT_ID`; setting both refuses to start. | PR 2 |
+| `IDENTRAIL_PUBLIC_BASE_URL` | none | Required for any auth driver (WorkOS, OIDC, manual, or native SAML). Must parse as an absolute URL. Must be `https://` in any non-development build. Refuses to start if missing. | Auth foundation |
+| `IDENTRAIL_SESSION_KEY` | none | Required for any auth driver. 32 bytes minimum (64 hex chars). Refuses to start if missing or shorter. | Auth foundation |
+| `IDENTRAIL_SESSION_KEY_PREVIOUS` | empty | Optional. Same format as `IDENTRAIL_SESSION_KEY`. Used during a key rotation. | Auth foundation |
+| `IDENTRAIL_AUTH_MANUAL_MODE` | `false` | Boolean. Mutually exclusive with `IDENTRAIL_WORKOS_CLIENT_ID`; setting both refuses to start. | Auth foundation |
 
 Production example values:
 
@@ -24,75 +26,72 @@ IDENTRAIL_SESSION_KEY=<64 hex chars from openssl rand -hex 32>
 
 ## WorkOS Hosted Login
 
-| Variable | Default | Validation | Adds in |
+| Variable | Default | Validation | Track |
 | --- | --- | --- | --- |
-| `IDENTRAIL_WORKOS_CLIENT_ID` | empty | Required when `IDENTRAIL_FEATURE_WORKOS_LOGIN=true`. Refuses to start if `IDENTRAIL_AUTH_MANUAL_MODE=true` and this is set. | PR 4 |
-| `IDENTRAIL_WORKOS_API_KEY` | empty | Required when `IDENTRAIL_FEATURE_WORKOS_LOGIN=true`. Treated as a secret. | PR 4 |
-| `IDENTRAIL_WORKOS_WEBHOOK_SECRET` | empty | Required when `IDENTRAIL_FEATURE_WORKOS_LOGIN=true`. Used to verify webhook HMAC. | PR 4 |
-| `IDENTRAIL_WORKOS_ENVIRONMENT_ID` | empty | Required when `IDENTRAIL_FEATURE_WORKOS_LOGIN=true`. Picks the WorkOS environment (test, staging, production). | PR 4 |
+| `IDENTRAIL_WORKOS_CLIENT_ID` | empty | Required when `IDENTRAIL_FEATURE_WORKOS_LOGIN=true`. Refuses to start if `IDENTRAIL_AUTH_MANUAL_MODE=true` and this is set. | WorkOS login |
+| `IDENTRAIL_WORKOS_API_KEY` | empty | Required when `IDENTRAIL_FEATURE_WORKOS_LOGIN=true`. Treated as a secret. | WorkOS login |
+| `IDENTRAIL_WORKOS_WEBHOOK_SECRET` | empty | Required when `IDENTRAIL_FEATURE_WORKOS_LOGIN=true`. Used to verify webhook HMAC. | WorkOS login |
+| `IDENTRAIL_WORKOS_ENVIRONMENT_ID` | empty | Required when `IDENTRAIL_FEATURE_WORKOS_LOGIN=true`. Picks the WorkOS environment (test, staging, production). | WorkOS login |
 
 Self-hosted operators leave all four WorkOS variables in this section empty. They still set the two required core variables in the previous section (`IDENTRAIL_PUBLIC_BASE_URL` and `IDENTRAIL_SESSION_KEY`), set the two optional ones if they need them (`IDENTRAIL_SESSION_KEY_PREVIOUS` during a key rotation, `IDENTRAIL_AUTH_MANUAL_MODE` for local dev), and configure their OIDC issuer via the existing `IDENTRAIL_OIDC_*` variables.
 
 ## Email
 
-| Variable | Default | Validation | Adds in |
+| Variable | Default | Validation | Track |
 | --- | --- | --- | --- |
-| `IDENTRAIL_EMAIL_PROVIDER` | empty | One of `resend`, `postmark`, `ses`, or empty. Empty disables outgoing email and refuses to send invitations. | PR 11 |
-| `IDENTRAIL_EMAIL_API_KEY` | empty | Required when `IDENTRAIL_EMAIL_PROVIDER` is set. Treated as a secret. | PR 11 |
-| `IDENTRAIL_EMAIL_FROM_ADDRESS` | empty | Required when `IDENTRAIL_EMAIL_PROVIDER` is set. Must be a valid email under a domain owned by the operator. | PR 11 |
+| `IDENTRAIL_EMAIL_PROVIDER` | empty | One of `resend`, `postmark`, `ses`, or empty. Empty disables outgoing email and refuses to send invitations. | Future invitation/email work |
+| `IDENTRAIL_EMAIL_API_KEY` | empty | Required when `IDENTRAIL_EMAIL_PROVIDER` is set. Treated as a secret. | Future invitation/email work |
+| `IDENTRAIL_EMAIL_FROM_ADDRESS` | empty | Required when `IDENTRAIL_EMAIL_PROVIDER` is set. Must be a valid email under a domain owned by the operator. | Future invitation/email work |
 
 ## Connector Providers
 
 ### AWS Connector
 
-| Variable | Default | Validation | Adds in |
+| Variable | Default | Validation | Track |
 | --- | --- | --- | --- |
-| `IDENTRAIL_AWS_CFN_TEMPLATE_URL` | empty | Required for the CFN one-click flow. Points at the CDN-hosted template. | PR 7 |
-| `IDENTRAIL_AWS_ACCOUNT_ID` | empty | Required. The Identrail-side AWS account that the customer's role trusts. | PR 7 |
+| `IDENTRAIL_AWS_CFN_TEMPLATE_URL` | empty | Required for the CFN one-click flow. Points at the CDN-hosted template. | AWS connector |
+| `IDENTRAIL_AWS_ACCOUNT_ID` | empty | Required. The Identrail-side AWS account that the customer's role trusts. | AWS connector |
 
 ### GitHub Connector
 
-| Variable | Default | Validation | Adds in |
+| Variable | Default | Validation | Track |
 | --- | --- | --- | --- |
-| `IDENTRAIL_GITHUB_APP_ID` | empty | Required only when the hosted GitHub App flow is configured. | PR 8 |
-| `IDENTRAIL_GITHUB_APP_PRIVATE_KEY` | empty | Required only when the hosted GitHub App flow is configured. PEM-formatted RSA private key. Treated as a secret. | PR 8 |
-| `IDENTRAIL_GITHUB_APP_WEBHOOK_SECRET` | empty | Required only when the hosted GitHub App flow is configured. Used to verify webhook HMAC. | PR 8 |
-| `IDENTRAIL_GITHUB_APP_NAME` | empty | Required only when the hosted GitHub App flow is configured. The GitHub App slug used in install URLs. | PR 8 |
-| `IDENTRAIL_GITHUB_PAT_ALLOWED_BASE_URLS` | `https://github.com` | Comma-separated allowlist of GitHub.com or GitHub Enterprise base URLs accepted by the PAT fallback. | PR 8 |
+| `IDENTRAIL_GITHUB_APP_ID` | empty | Required only when the hosted GitHub App flow is configured. | GitHub connector |
+| `IDENTRAIL_GITHUB_APP_PRIVATE_KEY` | empty | Required only when the hosted GitHub App flow is configured. PEM-formatted RSA private key. Treated as a secret. | GitHub connector |
+| `IDENTRAIL_GITHUB_APP_WEBHOOK_SECRET` | empty | Required only when the hosted GitHub App flow is configured. Used to verify webhook HMAC. | GitHub connector |
+| `IDENTRAIL_GITHUB_APP_NAME` | empty | Required only when the hosted GitHub App flow is configured. The GitHub App slug used in install URLs. | GitHub connector |
+| `IDENTRAIL_GITHUB_PAT_ALLOWED_BASE_URLS` | `https://github.com` | Comma-separated allowlist of GitHub.com or GitHub Enterprise base URLs accepted by the PAT fallback. | GitHub connector |
 
 ### Kubernetes Connector
 
-| Variable | Default | Validation | Adds in |
+| Variable | Default | Validation | Track |
 | --- | --- | --- | --- |
-| `IDENTRAIL_K8S_AGENT_HELM_REPO` | `oci://registry.identrail.com/charts` | The Helm OCI registry the operator references when installing the agent. Self-hosters can override. | PR 9 |
-| `IDENTRAIL_K8S_AGENT_VERSION` | empty | Optional. Pins a specific agent version. Empty means latest stable. | PR 9 |
+| `IDENTRAIL_K8S_AGENT_HELM_REPO` | `oci://registry.identrail.com/charts` | The Helm OCI registry the operator references when installing the agent. Self-hosters can override. | Kubernetes connector |
+| `IDENTRAIL_K8S_AGENT_VERSION` | empty | Optional. Pins a specific agent version. Empty means latest stable. | Kubernetes connector |
 
-The PR 9 implementation ships the chart in `deploy/connectors/k8s/identrail-agent`. The API response generates a Helm command against that checked-in chart path; self-hosted operators can publish it to their own OCI registry later without changing the connector API.
+The Kubernetes connector implementation ships the chart in `deploy/connectors/k8s/identrail-agent`. The API response generates a Helm command against that checked-in chart path; self-hosted operators can publish it to their own OCI registry later without changing the connector API.
 
 ## Feature Flags
 
 Feature flags follow the existing `IDENTRAIL_FEATURE_*` and `VITE_FEATURE_*` patterns. Backend flags use `IDENTRAIL_FEATURE_*` and frontend flags use `VITE_FEATURE_*`. Defaults are conservative; every new feature ships off and gets turned on after the PR is reviewed and verified.
 
-| Variable | Default | Adds in |
+| Variable | Default | Track |
 | --- | --- | --- |
-| `IDENTRAIL_FEATURE_NEW_AUTH` | `false` | PR 2 |
-| `IDENTRAIL_FEATURE_WORKOS_LOGIN` | `false` | PR 4 |
-| `IDENTRAIL_FEATURE_CONNECTORS_V2` | `false` | PR 6 |
-| `IDENTRAIL_FEATURE_CONNECTOR_AWS` | `false` | PR 7 |
-| `IDENTRAIL_FEATURE_CONNECTOR_GITHUB_V2` | `false` | PR 8 |
-| `IDENTRAIL_FEATURE_CONNECTOR_K8S` | `false` | PR 9 |
-| `IDENTRAIL_FEATURE_ONBOARDING_WIZARD` | `false` | PR 10 |
-| `IDENTRAIL_FEATURE_NATIVE_SSO` | `false` | PR 3 / PR 4 native SAML + SCIM |
+| `IDENTRAIL_FEATURE_NEW_AUTH` | `false` | Auth foundation |
+| `IDENTRAIL_FEATURE_WORKOS_LOGIN` | `false` | WorkOS login |
+| `IDENTRAIL_FEATURE_CONNECTORS_V2` | `false` | Connector foundation |
+| `IDENTRAIL_FEATURE_CONNECTOR_AWS` | `false` | AWS connector |
+| `IDENTRAIL_FEATURE_CONNECTOR_GITHUB_V2` | `false` | GitHub connector |
+| `IDENTRAIL_FEATURE_CONNECTOR_K8S` | `false` | Kubernetes connector |
+| `IDENTRAIL_FEATURE_ONBOARDING_WIZARD` | `false` | Onboarding |
+| `IDENTRAIL_FEATURE_NATIVE_SSO` | `false` | Track 1 native SAML + SCIM |
 | `IDENTRAIL_ENABLE_NATIVE_SSO` | empty | Compatibility alias for `IDENTRAIL_FEATURE_NATIVE_SSO`; when set, it overrides the canonical flag. |
-| `IDENTRAIL_FEATURE_SSO_ADMIN` | `false` | PR 11 |
-| `IDENTRAIL_FEATURE_SCIM` | `false` | PR 12 |
-| `IDENTRAIL_FEATURE_ENTITLEMENTS` | `false` | PR 12 |
-| `VITE_FEATURE_NEW_AUTH_UI` | `false` | PR 5 |
-| `VITE_FEATURE_CONNECTORS_V2` | `false` | PR 6 |
-| `VITE_FEATURE_CONNECTOR_AWS` | `false` | PR 7 |
-| `VITE_FEATURE_CONNECTOR_GITHUB_V2` | `false` | PR 8 |
-| `VITE_FEATURE_CONNECTOR_K8S` | `false` | PR 9 |
-| `VITE_FEATURE_ONBOARDING_WIZARD` | `false` | PR 10 |
+| `VITE_FEATURE_NEW_AUTH_UI` | `false` | Auth UI |
+| `VITE_FEATURE_CONNECTORS_V2` | `false` | Connector foundation |
+| `VITE_FEATURE_CONNECTOR_AWS` | `false` | AWS connector |
+| `VITE_FEATURE_CONNECTOR_GITHUB_V2` | `false` | GitHub connector |
+| `VITE_FEATURE_CONNECTOR_K8S` | `false` | Kubernetes connector |
+| `VITE_FEATURE_ONBOARDING_WIZARD` | `false` | Onboarding |
 
 The common pattern is paired flags for UI-backed features: the backend flag (`IDENTRAIL_FEATURE_*`) gates API endpoints and the frontend flag (`VITE_FEATURE_*`) gates the UI surface. Both default off, and turning them on activates the PR's behavior. Backend-only capabilities may expose only an `IDENTRAIL_FEATURE_*` flag.
 
@@ -131,4 +130,4 @@ Failure in any pass refuses to start the server. The error message names the var
 
 Production secrets (`IDENTRAIL_SESSION_KEY`, all WorkOS keys, the email provider key, GitHub App private key) live in Vercel's environment variable storage scoped to the Production environment. Preview and Development environments have their own values pointing at WorkOS test environments and a sandbox database.
 
-Self-hosted operators set the same variables in `deploy/docker/.env` or their Helm `values.yaml`. The implementation PRs (4, 7, 8, 9, 11) add each new variable to `deploy/docker/.env.example` and `deploy/helm/identrail/values.yaml` in the same commit that introduces it, with the definitions used here. PR 1 does not modify those files; it only documents the contract they will follow.
+Self-hosted operators set the same variables in `deploy/docker/.env` or their Helm `values.yaml`. Any implementation PR that introduces a new runtime variable should add it to `deploy/docker/.env.example` and `deploy/helm/identrail/values.yaml` in the same commit that introduces it, with the definitions used here.

--- a/docs/auth/identity-linking-rules.md
+++ b/docs/auth/identity-linking-rules.md
@@ -56,7 +56,10 @@ Every link emits `auth.identity.linked` audit event.
 
 A user cannot unlink their last remaining identity. The user must always have at least one active `user_identities` row. The unlink endpoint refuses to delete the last row and returns a clear error.
 
-A user with both Google and GitHub linked who unlinks Google: their Google `user_identities` row is deleted, the Identrail account stays, GitHub still works. They may also use a recovery email (if set) or the org-level recovery codes (if the org has SSO enforcement enabled).
+A user with both Google and GitHub linked who unlinks Google: their Google
+`user_identities` row is deleted, the Identrail account stays, GitHub still
+works. Future recovery-code work can add another break-glass path, but Track 1
+native SAML does not ship recovery codes.
 
 Every unlink emits `auth.identity.unlinked` audit event.
 
@@ -87,7 +90,11 @@ This stops the case where Mallory steals an invite link emailed to Alice and acc
 
 ## Rule 7: Email change does not propagate identity ownership
 
-`primary_email` can change in two ways inside the planned PR set: a user-initiated change from inside Identrail (out of scope for PR 1 through 12), and an IdP-driven change delivered via the `user.email_changed` webhook PR 4 handles. Both updates write to `users.primary_email` through the same code path and follow the same rule below: the change is purely cosmetic for relationship ownership. It does not affect:
+`primary_email` can change in two ways: a user-initiated change from inside
+Identrail, and an IdP-driven change delivered via the `user.email_changed`
+webhook. Both updates write to `users.primary_email` through the same code path
+and follow the same rule below: the change is purely cosmetic for relationship
+ownership. It does not affect:
 
 - Which `user_identities` rows belong to them.
 - Whether they can be invited to a different org tomorrow under the new email.

--- a/docs/auth/production-api-readiness.md
+++ b/docs/auth/production-api-readiness.md
@@ -1,6 +1,6 @@
 # Production API Readiness
 
-PR 6 is the operational bridge between the merged frontend auth UI and the later provider/onboarding work.
+This is the operational bridge between the frontend auth UI and the hosted API.
 
 The frontend auth pages are intentionally unable to call an unknown backend in production. Before Vercel can serve working sign-in and sign-up flows, the public API must exist and the web build must point at it.
 

--- a/docs/auth/threat-model.md
+++ b/docs/auth/threat-model.md
@@ -15,7 +15,7 @@ If you are about to write code that touches sessions, cookies, OAuth state, invi
 3. `SameSite=Lax`. The cookie does not ride along with cross-site POSTs by default.
 4. The cookie value is opaque (an ID, not a token with claims). Possession of the cookie still requires the server's `sessions` row to exist and not be revoked.
 5. Sessions are server-side and revocable. An admin or the user can kill a session immediately from `/app/account/security`.
-6. Every authenticated request emits an audit event with IP and user agent through the existing `audit.AuditEvent` pipeline. A queryable read path over those events lands in PR 12 (the audit log UI), at which point a session used from a suspicious second IP becomes visible to the user as part of the per-user audit feed. PR 5 displays sessions only and leaves the feed as a placeholder until PR 12 wires it up.
+6. Every authenticated request emits an audit event with IP and user agent through the existing `audit.AuditEvent` pipeline. Queryable audit-log UI work is separate from Track 1 native SSO.
 
 **What we accept.** A determined attacker with persistent malware on the user's machine can replay the cookie until the session expires or is revoked. This is true of every cookie-based auth system. We mitigate the blast radius (revocation, audit visibility, idle timeout) rather than try to defeat the threat.
 
@@ -69,13 +69,13 @@ If you are about to write code that touches sessions, cookies, OAuth state, invi
 
 ## SSO Downgrade
 
-**Attack.** Once an org enforces SSO, an attacker with a stolen password tries to bypass SSO by hitting the password endpoint directly.
+**Attack.** Once an org rolls out SSO, an attacker tries to bypass it by hitting a non-SSO login path directly.
 
 **Defenses.**
 
 1. We do not have password endpoints. WorkOS is the auth front door for Cloud, and self-host runs through OIDC.
-2. Org-level enforcement, when on, refuses to issue a session for any auth method other than the configured IdP. The check happens server-side in the callback handler before any session is created.
-3. The check is per-org, so a multi-org user signing in to an enforcing org via the wrong method gets rejected even if their other orgs are not enforcing.
+2. Native SAML and SCIM are feature-flagged behind `IDENTRAIL_FEATURE_NATIVE_SSO`, and native SAML sessions carry `auth_method="saml"` so follow-up enforcement work can distinguish them from WorkOS, OIDC, and manual sessions.
+3. Track 1 persists `sso_required` on the native SAML connection but does not yet ship recovery-code generation or a full org lockout-rescue flow. Operators should keep `sso_required=false` until SAML and SCIM have been tested for the tenant.
 
 ## SSO Lockout
 
@@ -83,9 +83,10 @@ If you are about to write code that touches sessions, cookies, OAuth state, invi
 
 **Defenses.**
 
-1. The "enforce SSO" toggle requires the toggling admin to currently be authenticated via the IdP. They cannot enforce something they have not proven works for them.
-2. Enforcing generates eight single-use recovery codes (256-bit each, stored as SHA-256 hashes). Shown once. The admin must save them before the toggle takes effect.
-3. A "test SSO" flow simulates a full IdP round-trip (SAML or OIDC, whichever the connection uses) without persisting anything. Admins are nudged to use it before enforcement.
+1. Native SAML setup is opt-in and starts with `sso_required=false`.
+2. Admins test real SAML login through `/auth/saml/login/{connection_id}` and `/auth/saml/acs/{connection_id}` before changing the rollout marker.
+3. Admins enable SCIM and verify create/update/deactivate flows before treating the IdP as the source of truth.
+4. The complete recovery-code and enforcement-toggle flow remains follow-up work and should not be represented as shipped Track 1 behavior.
 
 ## Identity-Linking Account Takeover
 
@@ -109,13 +110,13 @@ The short version: Identrail never auto-links identities by email. Email-claim e
 
 ## Mass Session Invalidation Race
 
-**Attack.** When SSO is enforced or a user is removed via SCIM, we need to invalidate all their sessions quickly. A race could let an in-flight request slip through.
+**Attack.** When a user is removed via SCIM or future SSO enforcement revokes non-SSO access, we need to invalidate all their sessions quickly. A race could let an in-flight request slip through.
 
 **Defenses.**
 
 1. The session check happens in middleware on every request, against the database. There is no in-memory cache of "session is valid."
 2. Revocation marks `sessions.revoked_at` and (in the SCIM hard-delete case) deletes the row outright. The next request from that session fails.
-3. The mass-revoke job (PR 11 force-relink, PR 12 SCIM deactivation) processes serially per-org with a small batch size, so a single org cannot starve other orgs.
+3. Future mass-revoke jobs should process serially per org with a small batch size, so a single org cannot starve other orgs.
 4. Per-user revocation is constant-time: one DELETE query keyed on `user_id`.
 
 ## Webhook Replay and Forgery

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -127,7 +127,9 @@ Optional repository variables:
   to `false` only as a rollback knob for the onboarding API
 - `API_FEATURE_WORKOS_LOGIN`: defaults to `true` when the first-class WorkOS
   deployment settings above are provided
-- `API_EXTRA_ENVIRONMENT_JSON`
+- `API_EXTRA_ENVIRONMENT_JSON`: JSON object for additional non-secret runtime
+  variables. Use this to enable native SAML/SCIM, for example
+  `{"IDENTRAIL_FEATURE_NATIVE_SSO":"true"}`.
 - `API_SECRET_KMS_KEY_ARNS_JSON`
 - `API_CONNECTOR_ROLE_ARNS_JSON`
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -32,6 +32,8 @@ Boolean values must parse as Go booleans (`true`, `false`, `1`, `0`, `t`, `f`) a
 - `IDENTRAIL_DEFAULT_TENANT_ID`
 - `IDENTRAIL_DEFAULT_WORKSPACE_ID`
 - `IDENTRAIL_REQUIRE_EXPLICIT_SCOPE` (default: `false`; set `true` in production to require tenant/workspace claims or headers instead of default fallback)
+- `IDENTRAIL_FEATURE_NATIVE_SSO` (default: `false`; enables native SAML admin, SAML login/ACS, and SCIM 2.0 routes)
+- `IDENTRAIL_ENABLE_NATIVE_SSO` (compatibility alias for `IDENTRAIL_FEATURE_NATIVE_SSO`; when set, it overrides the canonical flag)
 
 Notes:
 - `IDENTRAIL_OIDC_ISSUER_URL` and `IDENTRAIL_OIDC_AUDIENCE` must be configured together.
@@ -40,6 +42,7 @@ Notes:
 - `IDENTRAIL_API_KEY_SCOPE_BINDINGS` can optionally bind scoped keys to a tenant/workspace pair: `<api-key>:<tenant-id>/<workspace-id>;...`.
 - API key callers can send `X-Identrail-Tenant-ID` and `X-Identrail-Workspace-ID` only when those headers match the configured binding for that scoped key.
 - Malformed `IDENTRAIL_API_KEY_SCOPES` entries are startup errors. Do not include bare keys, empty keys, empty scope lists, or duplicate key entries.
+- Native SSO is opt-in per deployment. Leave `IDENTRAIL_FEATURE_NATIVE_SSO=false` unless the operator is ready to expose native SAML and SCIM endpoints. Native SAML admin/login routes also require the new session auth stack (`IDENTRAIL_FEATURE_NEW_AUTH=true`, `IDENTRAIL_PUBLIC_BASE_URL`, and `IDENTRAIL_SESSION_KEY`).
 
 ## Provider Collection
 

--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -107,8 +107,8 @@ Manager references are ready. Plan the stack first, verify the load balancer
 health endpoint, and only then point `api.identrail.com` at the load balancer.
 Keep `app.identrail.com` on Vercel.
 
-Use the `AWS API Manual Deploy` GitHub Actions workflow for pre-PR 11 cutover
-preparation. Run `plan` first. Use `apply` only after reviewing the plan; the
+Use the `AWS API Manual Deploy` GitHub Actions workflow for controlled API
+cutover preparation. Run `plan` first. Use `apply` only after reviewing the plan; the
 workflow requires the explicit confirmation string `apply-api.identrail.com` and
 persists Terraform state in the configured S3 state bucket.
 

--- a/docs/enterprise-quickstart.md
+++ b/docs/enterprise-quickstart.md
@@ -123,13 +123,20 @@ Confirm:
 
 ## 8. Set Up SSO With Okta
 
-Native enterprise SSO requires `IDENTRAIL_FEATURE_NATIVE_SSO=true` on the API. Create the Identrail SAML connection first, then paste the IdP metadata URL into Identrail so the connection can validate Okta assertions.
+Native enterprise SSO requires `IDENTRAIL_FEATURE_NATIVE_SSO=true` on the API.
+Native SAML admin and login routes also require `IDENTRAIL_FEATURE_NEW_AUTH=true`,
+`IDENTRAIL_PUBLIC_BASE_URL`, and `IDENTRAIL_SESSION_KEY`. Create the Identrail
+SAML connection first, then paste the IdP metadata URL into Identrail so the
+connection can validate Okta assertions.
 
 Identrail values to copy into Okta:
 - **Single sign-on URL / ACS URL:** `${IDENTRAIL_API_URL}/auth/saml/acs/<connection_id>`
 - **Audience URI / SP Entity ID:** `${IDENTRAIL_API_URL}/auth/saml/metadata/<connection_id>`
 - **Name ID format:** `EmailAddress`
 - **Application username:** `Email`
+
+The SP Entity ID is a SAML audience identifier. The current API does not serve
+an SP metadata document from that URL.
 
 Okta click path:
 1. Open **Okta Admin Console -> Applications -> Applications -> Create App Integration**.
@@ -215,16 +222,19 @@ Screenshot placeholders:
 - `[Screenshot placeholder: Entra Provisioning page with Tenant URL and Secret Token fields]`
 - `[Screenshot placeholder: Entra Provisioning Status set to On]`
 
-## 11. Enforce SSO-Only (`sso_required`)
+## 11. Roll Out SSO-Only (`sso_required`)
 
-Set `sso_required=true` only after at least one SAML admin has completed a successful sign-in and SCIM provisioning has created or matched the expected users. Enforcing too early can lock out local/manual fallback users.
+Keep `sso_required=false` until at least one SAML admin has completed a
+successful sign-in and SCIM provisioning has created or matched the expected
+users. Track 1 persists the flag on the connection as the org's rollout marker;
+it does not yet ship recovery-code generation or a full lockout-rescue flow.
 
 Recommended rollout:
 1. Create the native SAML connection with `sso_required=false`.
 2. Assign a small admin test group in Okta or Azure AD.
 3. Confirm SAML login creates a `saml:<connection_id>` identity for the admin.
 4. Enable SCIM provisioning and confirm a test create/update/deactivate writes one `scim_provisioning_events` row and, when a workflow router is configured, one workflow dispatch audit record.
-5. Flip `sso_required=true` on the connection.
+5. Flip `sso_required=true` only after the operator has verified the break-glass path they intend to use.
 6. Keep a break-glass admin path outside the enforced tenant while the first customer tenant is onboarding.
 
 Workflow dispatch verification, when a router is configured:

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -557,6 +557,180 @@ paths:
             text/plain:
               schema:
                 type: string
+  /v1/enterprise/identity-connections/saml:
+    get:
+      tags: [EnterpriseAuth]
+      summary: List native SAML identity connections
+      operationId: listNativeSAMLConnections
+      security:
+        - CookieAuth: []
+      responses:
+        "200":
+          description: Native SAML connections for the current organization
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [connections]
+                properties:
+                  connections:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/NativeSAMLConnection"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags: [EnterpriseAuth]
+      summary: Create a native SAML identity connection
+      operationId: createNativeSAMLConnection
+      security:
+        - CookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NativeSAMLConnectionRequest"
+      responses:
+        "201":
+          description: Native SAML connection created with a one-time SCIM bearer token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NativeSAMLConnectionResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/Conflict"
+  /v1/enterprise/identity-connections/saml/{id}:
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags: [EnterpriseAuth]
+      summary: Get a native SAML identity connection
+      operationId: getNativeSAMLConnection
+      security:
+        - CookieAuth: []
+      responses:
+        "200":
+          description: Native SAML connection
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [connection]
+                properties:
+                  connection:
+                    $ref: "#/components/schemas/NativeSAMLConnection"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    put:
+      tags: [EnterpriseAuth]
+      summary: Update a native SAML identity connection
+      operationId: updateNativeSAMLConnection
+      security:
+        - CookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NativeSAMLConnectionUpdateRequest"
+      responses:
+        "200":
+          description: Native SAML connection updated
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [connection]
+                properties:
+                  connection:
+                    $ref: "#/components/schemas/NativeSAMLConnection"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      tags: [EnterpriseAuth]
+      summary: Delete a native SAML identity connection
+      operationId: deleteNativeSAMLConnection
+      security:
+        - CookieAuth: []
+      responses:
+        "204":
+          description: Native SAML connection deleted
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /v1/enterprise/identity-connections/saml/from-metadata:
+    post:
+      tags: [EnterpriseAuth]
+      summary: Import native SAML settings from IdP metadata
+      operationId: importNativeSAMLConnectionMetadata
+      security:
+        - CookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              anyOf:
+                - required: [metadata_url]
+                - required: [metadata_xml]
+              properties:
+                metadata_url:
+                  type: string
+                  format: uri
+                  description: HTTPS IdP metadata URL.
+                metadata_xml:
+                  type: string
+                  description: Inline IdP metadata XML.
+      responses:
+        "200":
+          description: Parsed SAML metadata draft
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [entity_id, sso_url, certificate_pem]
+                properties:
+                  entity_id:
+                    type: string
+                  sso_url:
+                    type: string
+                    format: uri
+                  certificate_pem:
+                    type: string
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
   /scim/v2/ServiceProviderConfig:
     get:
       tags: [SCIM]
@@ -1148,11 +1322,13 @@ paths:
                 properties:
                   auth:
                     type: object
-                    required: [manual_mode, workos_login_enabled, providers]
+                    required: [manual_mode, workos_login_enabled, native_saml_enabled, providers]
                     properties:
                       manual_mode:
                         type: boolean
                       workos_login_enabled:
+                        type: boolean
+                      native_saml_enabled:
                         type: boolean
                       providers:
                         type: array
@@ -3932,6 +4108,13 @@ components:
           type: string
           enum: [sso, directory_sync]
         workos_connection_id: { type: string }
+        entity_id: { type: string }
+        sso_url: { type: string, format: uri }
+        certificate_pem: { type: string }
+        attribute_mapping:
+          type: object
+          additionalProperties:
+            type: string
         status:
           type: string
           enum: [pending, active, disabled]
@@ -3941,12 +4124,95 @@ components:
             type: string
         sso_required:
           type: boolean
+        jit_provisioning_enabled:
+          type: boolean
+        has_scim_bearer_token:
+          type: boolean
         created_at:
           type: string
           format: date-time
         updated_at:
           type: string
           format: date-time
+    NativeSAMLConnection:
+      allOf:
+        - $ref: "#/components/schemas/IdentityConnection"
+    NativeSAMLConnectionRequest:
+      type: object
+      required: [entity_id, sso_url, certificate_pem, attribute_mapping]
+      properties:
+        type:
+          type: string
+          default: sso
+        status:
+          type: string
+          enum: [pending, active, disabled]
+        display_name:
+          type: string
+        entity_id:
+          type: string
+        sso_url:
+          type: string
+          format: uri
+        certificate_pem:
+          type: string
+        attribute_mapping:
+          type: object
+          additionalProperties:
+            type: string
+          description: Must include the SAML email attribute mapping.
+        group_role_map:
+          type: object
+          additionalProperties:
+            type: string
+        jit_provisioning_enabled:
+          type: boolean
+          default: false
+        sso_required:
+          type: boolean
+          default: false
+    NativeSAMLConnectionUpdateRequest:
+      type: object
+      properties:
+        type:
+          type: string
+          default: sso
+        status:
+          type: string
+          enum: [pending, active, disabled]
+        display_name:
+          type: string
+        entity_id:
+          type: string
+        sso_url:
+          type: string
+          format: uri
+        certificate_pem:
+          type: string
+        attribute_mapping:
+          type: object
+          additionalProperties:
+            type: string
+          description: When present, must include the SAML email attribute mapping.
+        group_role_map:
+          type: object
+          additionalProperties:
+            type: string
+        jit_provisioning_enabled:
+          type: boolean
+          default: false
+        sso_required:
+          type: boolean
+          default: false
+    NativeSAMLConnectionResponse:
+      type: object
+      required: [connection]
+      properties:
+        connection:
+          $ref: "#/components/schemas/NativeSAMLConnection"
+        scim_bearer_token:
+          type: string
+          description: One-time plaintext SCIM bearer token returned only on create.
     OnboardingState:
       type: object
       required: [user_id, current_step, connector_skipped, scan_skipped, started_at, updated_at]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,8 +41,60 @@
 - Partial scan lifecycle state assertions (`partial` on non-fatal source errors)
 - API list sort contract behavior (`sort_by`, `sort_order`) on findings and scans
 - OpenAPI v1 contract presence checks for core endpoints and parameters
+- Native SAML admin, SAML login/ACS, Okta/Azure metadata import, SCIM 2.0 lifecycle, and SCIM workflow dispatch behavior
 - Migration rollback roundtrip integration test (up -> down -> up)
 - Migration compatibility integration test for existing nullable legacy rows
+
+## Track 1 Enterprise SSO Checks
+
+Run these before moving dependent work forward:
+
+```bash
+go test ./internal/api -run 'Test(SAML|NativeSAML|EnterpriseSCIM)|TestParseSAMLMetadataXML|TestFetchSAMLMetadataXML|TestUpsertSAMLAssertedUser|TestNewSCIMBearerToken'
+go test ./internal/config ./internal/db ./internal/enterprise ./internal/workflow
+python3 - <<'PY'
+import yaml
+with open('docs/openapi-v1.yaml') as f:
+    doc = yaml.safe_load(f)
+required = [
+    '/v1/enterprise/identity-connections/saml',
+    '/v1/enterprise/identity-connections/saml/{id}',
+    '/v1/enterprise/identity-connections/saml/from-metadata',
+    '/auth/saml/login/{connection_id}',
+    '/auth/saml/acs/{connection_id}',
+    '/scim/v2/ServiceProviderConfig',
+    '/scim/v2/Schemas',
+    '/scim/v2/ResourceTypes',
+    '/scim/v2/Users',
+    '/scim/v2/Users/{id}',
+]
+missing = [path for path in required if path not in doc.get('paths', {})]
+if missing:
+    raise SystemExit('missing Track 1 OpenAPI paths: ' + ', '.join(missing))
+print('Track 1 OpenAPI paths present')
+PY
+```
+
+For a live IdP smoke test:
+
+1. Start the API with `IDENTRAIL_FEATURE_NATIVE_SSO=true`,
+   `IDENTRAIL_FEATURE_NEW_AUTH=true`, `IDENTRAIL_PUBLIC_BASE_URL`, and
+   `IDENTRAIL_SESSION_KEY` configured. Native SAML admin/login routes depend on
+   the session-auth stack; SCIM bearer-token routes use the native SSO flag.
+2. Create a native SAML connection with
+   `POST /v1/enterprise/identity-connections/saml/from-metadata`, then create
+   or update the connection with the parsed `entity_id`, `sso_url`,
+   `certificate_pem`, and an `attribute_mapping.email` value.
+3. Store the one-time `scim_bearer_token` returned by the create response.
+4. Call the SCIM discovery endpoints and perform one create, update, patch, and
+   delete against `/scim/v2/Users` using that bearer token.
+5. Confirm a `scim_provisioning_events` row and, when a workflow route is
+   configured, a `scim.provisioned` dispatch audit record.
+6. Configure Okta or Entra with ACS
+   `${IDENTRAIL_PUBLIC_BASE_URL}/auth/saml/acs/<connection_id>` and SP Entity
+   ID `${IDENTRAIL_PUBLIC_BASE_URL}/auth/saml/metadata/<connection_id>`.
+7. Start SAML login through `/auth/saml/login/<connection_id>` and confirm the
+   ACS creates a session with `auth_method="saml"`.
 
 ## CI Pipeline Gates
 

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -89,10 +89,10 @@ func registerAuthConfigRoute(v1 *gin.RouterGroup, manualMode bool, workOSEnabled
 			providers = append(providers, "github_oauth", "google_oauth", "authkit")
 		}
 		if nativeSSOEnabled {
-			// The frontend uses this to decide whether to render a
-			// "Sign in with company SSO" button. The actual SAML
-			// connection id comes from a separate per-org lookup so
-			// nothing org-specific leaks into this public response.
+			// The frontend uses this to advertise native SAML as an available
+			// provider. The actual SAML connection id comes from a separate
+			// per-org lookup so nothing org-specific leaks into this public
+			// response.
 			providers = append(providers, "saml")
 		}
 		c.JSON(http.StatusOK, gin.H{

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -22,6 +22,7 @@ function authConfig(manualMode = false, workOSLoginEnabled = true) {
     auth: {
       manual_mode: manualMode,
       workos_login_enabled: workOSLoginEnabled,
+      native_saml_enabled: false,
       providers: workOSLoginEnabled ? ['github_oauth', 'google_oauth', 'authkit'] : []
     }
   });

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -156,6 +156,7 @@ export type AuthConfigResponse = {
   auth: {
     manual_mode: boolean;
     workos_login_enabled: boolean;
+    native_saml_enabled: boolean;
     providers: string[];
   };
 };

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -4059,6 +4059,8 @@ export function ProductSettingsPage() {
   const authProviders = authConfig?.auth.providers ?? [];
   const authModeLabel = authConfig?.auth.workos_login_enabled
     ? 'Hosted WorkOS login'
+    : authConfig?.auth.native_saml_enabled
+      ? 'Native SAML login'
     : authConfig?.auth.manual_mode
       ? 'Manual development login'
       : 'Session-only';
@@ -4199,6 +4201,10 @@ export function ProductSettingsPage() {
             <div>
               <dt>Hosted login</dt>
               <dd>{authConfig?.auth.workos_login_enabled ? 'Enabled' : 'Disabled'}</dd>
+            </div>
+            <div>
+              <dt>Native SAML</dt>
+              <dd>{authConfig?.auth.native_saml_enabled ? 'Enabled' : 'Disabled'}</dd>
             </div>
             <div>
               <dt>Manual mode</dt>


### PR DESCRIPTION
Fixes #1162

## Summary
- replace the superseded twelve-PR auth roadmap with the current three-track plan and Track 1 implementation status
- document native SAML/SCIM runtime flags, setup constraints, rollout limits, and Track 1 testing steps
- add the native SAML admin API to OpenAPI and align /v1/auth/config with native_saml_enabled
- clean up stale PR-11/PR-12, WorkOS Directory Sync, and pre-PR-11 wording across docs and deploy examples
- align the web auth config type/settings display with the backend response shape

## Why
Track 1 landed on dev, but several docs still described the old WorkOS-only twelve-PR roadmap or omitted the shipped native SAML admin API. This makes operator setup and future Track 2 work harder than it needs to be.

## Validation
- python3 OpenAPI Track 1 path presence check
- go test ./internal/api -run 'Test(SAML|NativeSAML|EnterpriseSCIM)|TestParseSAMLMetadataXML|TestFetchSAMLMetadataXML|TestUpsertSAMLAssertedUser|TestNewSCIMBearerToken'\n- go test ./internal/config ./internal/db ./internal/enterprise ./internal/workflow\n- go test ./...\n- npm ci --prefix web\n- npm run test:ci --prefix web\n- npm run build --prefix web\n\nAI-assisted: yes\nTools used: OpenAI coding assistant\nWhere used: documentation audit, docs edits, OpenAPI contract update, and validation planning\nHuman verification performed: reviewed diffs and ran the validation commands above