### PR TITLE
Align signup GitHub dark provider styling

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6338,23 +6338,11 @@ html[data-theme='light'] .idt-auth-provider-google {
   background: var(--auth-button-muted);
 }
 
-.idt-auth-page[data-auth-theme='dark'].idt-auth-page-signup .idt-auth-provider-github {
-  border-color: var(--auth-github);
-  background: var(--auth-github);
-  color: #ffffff;
-}
-
 .idt-auth-page[data-auth-theme='light'].idt-auth-page-signup .idt-auth-provider-github,
 html[data-theme='light'] .idt-auth-page[data-auth-theme='light'].idt-auth-page-signup .idt-auth-provider-github {
   border-color: var(--auth-line-strong);
   background: var(--auth-button-muted);
   color: var(--auth-text);
-}
-
-.idt-auth-page[data-auth-theme='dark'].idt-auth-page-signup .idt-auth-provider-github:hover,
-.idt-auth-page[data-auth-theme='dark'].idt-auth-page-signup .idt-auth-provider-github:focus-visible {
-  border-color: #4b5563;
-  background: #2b3138;
 }
 
 .idt-auth-page[data-auth-theme='light'].idt-auth-page-signup .idt-auth-provider-github:hover,


### PR DESCRIPTION
No issue: follow-up to merged auth-page visual polish PR #1158.

## Summary
- Removes the special filled dark-mode styling from the sign-up GitHub provider button.
- Keeps GitHub aligned with the other dark-mode provider buttons while preserving the light-mode icon visibility fix from PR #1158.

## Why
After PR #1158 merged, the sign-up page showed GitHub as a filled/highlighted dark button while Google and SAML remained outlined. The auth options should feel visually consistent unless a button is actively hovered or focused.

## Scope
- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation
```bash
npm test -- --run src/App.test.tsx
npm run build
```

Additional verification:
- Production preview smoke-tested with mocked auth config.
- Confirmed dark-mode signup provider backgrounds/borders match across Google, GitHub, and SAML while GitHub/SAML icons remain visible.
- Confirmed light-mode GitHub remains white with `filter: none` on the GitHub mark.

## Checklist
- [x] Tests added/updated for behavior changes (not needed; CSS-only follow-up covered by existing auth regression test)
- [x] Docs updated for user/operator-facing changes (not applicable)
- [x] CHANGELOG.md updated when relevant (not applicable)
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure
- AI-assisted: No
- Tools used: None
- Areas where used: None
- Human verification performed: Reviewed the CSS diff, ran focused web tests, ran production build, and smoke-tested the signup provider styles in browser preview.

## Related Issues
No issue: follow-up to merged auth-page visual polish PR #1158.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the GitHub sign-up button in dark mode with other providers by removing its filled style and dark hover/focus rules. Light mode is unchanged; the GitHub mark stays visible on white.

<sup>Written for commit cb73af1e2823610b6d1acbfbe996fb96c9670d32. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1163?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

