### PR TITLE
Add resolved_at to finding triage for accurate MTTR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Added a server-managed `resolved_at` timestamp to finding triage so the executive report can compute an accurate mean-time-to-resolve (MTTR):
+  - exposed on the `FindingTriage` API response, OpenAPI schema, and web client types
+  - set when a finding transitions into the resolved state, preserved across edits while it stays resolved, and cleared when it is reopened or moved out of resolved
+  - migration `000026_finding_triage_resolved_at` adds the nullable column and best-effort backfills existing resolved rows with `resolved_at = updated_at`
 - Mirrored public container image publishing to Docker Hub under `docker.io/identrail/*`,
   made Docker Hub the default public-image quickstart source, and pointed the homepage Docker pull metric at the published Docker Hub repositories.
 - Routed successful native SCIM user lifecycle operations through the workflow router:

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -5421,6 +5421,13 @@ components:
           type: string
           format: date-time
           nullable: true
+        resolved_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Server-managed. Set when the finding enters the resolved state and
+            cleared when it leaves; powers executive-report MTTR.
         updated_at:
           type: string
           format: date-time

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1828,6 +1828,7 @@ func (s *Service) TriageFinding(ctx context.Context, findingID string, scanID st
 	if nextState.Status == "" {
 		nextState.Status = domain.FindingLifecycleOpen
 	}
+	nextState.ResolvedAt = resolveResolvedAt(currentState, nextState, now)
 
 	action := deriveFindingTriageAction(currentState, nextState, comment)
 	if err := s.Store.ApplyFindingTriageTransition(ctx, nextState, db.FindingTriageEvent{
@@ -2470,6 +2471,7 @@ func (s *Service) applyFindingTriageStates(ctx context.Context, findings []domai
 				Status:               state.Status,
 				Assignee:             state.Assignee,
 				SuppressionExpiresAt: state.SuppressionExpiresAt,
+				ResolvedAt:           state.ResolvedAt,
 				UpdatedAt:            &updatedAt,
 				UpdatedBy:            state.UpdatedBy,
 			}
@@ -2518,7 +2520,27 @@ func normalizeFindingTriageState(state db.FindingTriageState, now time.Time) db.
 	if state.Status != domain.FindingLifecycleSuppressed {
 		state.SuppressionExpiresAt = nil
 	}
+	if state.Status != domain.FindingLifecycleResolved {
+		state.ResolvedAt = nil
+	}
 	return state
+}
+
+// resolveResolvedAt computes the resolution timestamp for the next triage
+// state. It is set only when a finding transitions into the resolved state;
+// while a finding stays resolved (e.g. an assignee or comment edit) the
+// original resolution time is preserved, and any non-resolved state clears it
+// so reopened findings never report a stale MTTR source.
+func resolveResolvedAt(current, next db.FindingTriageState, now time.Time) *time.Time {
+	if next.Status != domain.FindingLifecycleResolved {
+		return nil
+	}
+	if current.Status == domain.FindingLifecycleResolved && current.ResolvedAt != nil {
+		preserved := current.ResolvedAt.UTC()
+		return &preserved
+	}
+	resolved := now.UTC()
+	return &resolved
 }
 
 func parseFindingLifecycleStatus(raw string) (domain.FindingLifecycleStatus, error) {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -1142,6 +1142,91 @@ func TestServiceFindingTriageLifecycleAndHistory(t *testing.T) {
 	}
 }
 
+func TestServiceFindingTriageResolvedAtLifecycle(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 4, 1, 8, 0, 0, 0, time.UTC)
+	scan, err := store.CreateScan(defaultScopeContext(), "aws", now)
+	if err != nil {
+		t.Fatalf("create scan: %v", err)
+	}
+	if err := store.UpsertFindings(defaultScopeContext(), scan.ID, []domain.Finding{
+		{ID: "finding-1", Type: domain.FindingOwnerless, Severity: domain.SeverityHigh, CreatedAt: now},
+	}); err != nil {
+		t.Fatalf("upsert findings: %v", err)
+	}
+
+	clock := now
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return clock }
+
+	resolved := string(domain.FindingLifecycleResolved)
+	open := string(domain.FindingLifecycleOpen)
+
+	// Transition into resolved records the actual resolution time.
+	resolvedTime := clock
+	got, err := svc.TriageFinding(defaultScopeContext(), "finding-1", scan.ID,
+		FindingTriageRequest{Status: &resolved, Comment: "patched"}, "subject:user-1")
+	if err != nil {
+		t.Fatalf("resolve finding: %v", err)
+	}
+	if got.Triage.ResolvedAt == nil || !got.Triage.ResolvedAt.Equal(resolvedTime) {
+		t.Fatalf("expected resolved_at %v, got %v", resolvedTime, got.Triage.ResolvedAt)
+	}
+
+	// The primary filtered findings list must also expose resolved_at.
+	listed, err := svc.ListFindingsFiltered(defaultScopeContext(), 10, FindingsFilter{LifecycleStatus: "resolved"})
+	if err != nil {
+		t.Fatalf("list filtered findings: %v", err)
+	}
+	if len(listed) != 1 || listed[0].Triage.ResolvedAt == nil || !listed[0].Triage.ResolvedAt.Equal(resolvedTime) {
+		t.Fatalf("expected filtered list to expose resolved_at %v, got %+v", resolvedTime, listed)
+	}
+
+	// A comment while still resolved preserves the original resolution time.
+	clock = clock.Add(2 * time.Hour)
+	got, err = svc.TriageFinding(defaultScopeContext(), "finding-1", scan.ID,
+		FindingTriageRequest{Comment: "still resolved"}, "subject:user-1")
+	if err != nil {
+		t.Fatalf("comment while resolved: %v", err)
+	}
+	if got.Triage.ResolvedAt == nil || !got.Triage.ResolvedAt.Equal(resolvedTime) {
+		t.Fatalf("expected resolved_at preserved at %v, got %v", resolvedTime, got.Triage.ResolvedAt)
+	}
+
+	// Reopening must not keep a stale resolution time.
+	clock = clock.Add(time.Hour)
+	got, err = svc.TriageFinding(defaultScopeContext(), "finding-1", scan.ID,
+		FindingTriageRequest{Status: &open, Comment: "regressed"}, "subject:user-1")
+	if err != nil {
+		t.Fatalf("reopen finding: %v", err)
+	}
+	if got.Triage.ResolvedAt != nil {
+		t.Fatalf("expected resolved_at cleared after reopen, got %v", got.Triage.ResolvedAt)
+	}
+	openListed, err := svc.ListFindingsFiltered(defaultScopeContext(), 10, FindingsFilter{LifecycleStatus: "open"})
+	if err != nil {
+		t.Fatalf("list filtered findings after reopen: %v", err)
+	}
+	if len(openListed) != 1 || openListed[0].Triage.ResolvedAt != nil {
+		t.Fatalf("expected filtered list to drop resolved_at after reopen, got %+v", openListed)
+	}
+
+	// Re-resolving records a fresh resolution time, not the prior one.
+	clock = clock.Add(4 * time.Hour)
+	reResolvedTime := clock
+	got, err = svc.TriageFinding(defaultScopeContext(), "finding-1", scan.ID,
+		FindingTriageRequest{Status: &resolved, Comment: "patched again"}, "subject:user-1")
+	if err != nil {
+		t.Fatalf("re-resolve finding: %v", err)
+	}
+	if got.Triage.ResolvedAt == nil || !got.Triage.ResolvedAt.Equal(reResolvedTime) {
+		t.Fatalf("expected fresh resolved_at %v, got %v", reResolvedTime, got.Triage.ResolvedAt)
+	}
+	if got.Triage.ResolvedAt.Equal(resolvedTime) {
+		t.Fatal("re-resolve must not reuse the original resolution time")
+	}
+}
+
 func TestServiceTriageFindingRejectsInvalidRequest(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 22, 9, 0, 0, 0, time.UTC)

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -876,6 +876,7 @@ func (m *MemoryStore) findingTriageForScopeLocked(scope Scope, findingID string,
 		Status:               state.Status,
 		Assignee:             state.Assignee,
 		SuppressionExpiresAt: state.SuppressionExpiresAt,
+		ResolvedAt:           state.ResolvedAt,
 		UpdatedAt:            &updatedAt,
 		UpdatedBy:            state.UpdatedBy,
 	}
@@ -1822,6 +1823,7 @@ func normalizeFindingTriageStateForWrite(state FindingTriageState) (FindingTriag
 	state.FindingID = normalizedID
 	state.Assignee = strings.TrimSpace(state.Assignee)
 	state.UpdatedBy = strings.TrimSpace(state.UpdatedBy)
+	state.ResolvedAt = resolvedAtForStatus(state.Status, state.ResolvedAt)
 	if state.UpdatedAt.IsZero() {
 		state.UpdatedAt = time.Now().UTC()
 	} else {

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -872,6 +872,47 @@ func TestMemoryStoreFindingTriageStateAndHistory(t *testing.T) {
 	}
 }
 
+func TestMemoryStoreFindingTriageResolvedAtInvariant(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 4, 2, 10, 0, 0, 0, time.UTC)
+
+	if err := store.UpsertFindingTriageState(defaultScopeContext(), FindingTriageState{
+		FindingID:  "finding-1",
+		Status:     domain.FindingLifecycleResolved,
+		ResolvedAt: &now,
+		UpdatedAt:  now,
+		UpdatedBy:  "subject:alice",
+	}); err != nil {
+		t.Fatalf("upsert resolved triage state: %v", err)
+	}
+	got, err := store.GetFindingTriageState(defaultScopeContext(), "finding-1")
+	if err != nil {
+		t.Fatalf("get resolved triage state: %v", err)
+	}
+	if got.ResolvedAt == nil || !got.ResolvedAt.Equal(now) {
+		t.Fatalf("expected resolved_at %v, got %v", now, got.ResolvedAt)
+	}
+
+	// A non-resolved write must drop any resolution time, even if supplied.
+	stale := now
+	if err := store.UpsertFindingTriageState(defaultScopeContext(), FindingTriageState{
+		FindingID:  "finding-1",
+		Status:     domain.FindingLifecycleOpen,
+		ResolvedAt: &stale,
+		UpdatedAt:  now.Add(time.Hour),
+		UpdatedBy:  "subject:alice",
+	}); err != nil {
+		t.Fatalf("upsert reopened triage state: %v", err)
+	}
+	got, err = store.GetFindingTriageState(defaultScopeContext(), "finding-1")
+	if err != nil {
+		t.Fatalf("get reopened triage state: %v", err)
+	}
+	if got.ResolvedAt != nil {
+		t.Fatalf("expected resolved_at cleared for non-resolved status, got %v", got.ResolvedAt)
+	}
+}
+
 func TestMemoryStoreApplyFindingTriageTransitionAtomic(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 28, 12, 0, 0, 0, time.UTC)

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -832,7 +832,7 @@ func (p *PostgresStore) GetFindingTriageState(ctx context.Context, findingID str
 	}
 	row := p.queryRowContext(
 		ctx,
-		`SELECT finding_id, status, assignee, suppression_expires_at, updated_at, updated_by
+		`SELECT finding_id, status, assignee, suppression_expires_at, resolved_at, updated_at, updated_by
 		 FROM finding_triage_states
 		 WHERE finding_id = $1
 		   AND tenant_id = $2
@@ -843,11 +843,13 @@ func (p *PostgresStore) GetFindingTriageState(ctx context.Context, findingID str
 	)
 	var state FindingTriageState
 	var suppressionExpiresAt sql.NullTime
+	var resolvedAt sql.NullTime
 	if err := row.Scan(
 		&state.FindingID,
 		&state.Status,
 		&state.Assignee,
 		&suppressionExpiresAt,
+		&resolvedAt,
 		&state.UpdatedAt,
 		&state.UpdatedBy,
 	); err != nil {
@@ -859,6 +861,10 @@ func (p *PostgresStore) GetFindingTriageState(ctx context.Context, findingID str
 	if suppressionExpiresAt.Valid {
 		value := suppressionExpiresAt.Time.UTC()
 		state.SuppressionExpiresAt = &value
+	}
+	if resolvedAt.Valid {
+		value := resolvedAt.Time.UTC()
+		state.ResolvedAt = &value
 	}
 	state.UpdatedAt = state.UpdatedAt.UTC()
 	return state, nil
@@ -895,7 +901,7 @@ func (p *PostgresStore) ListFindingTriageStates(ctx context.Context, findingIDs 
 		args = append(args, findingID)
 	}
 	query := fmt.Sprintf(
-		`SELECT finding_id, status, assignee, suppression_expires_at, updated_at, updated_by
+		`SELECT finding_id, status, assignee, suppression_expires_at, resolved_at, updated_at, updated_by
 		 FROM finding_triage_states
 		 WHERE tenant_id = $1
 		   AND workspace_id = $2
@@ -912,11 +918,13 @@ func (p *PostgresStore) ListFindingTriageStates(ctx context.Context, findingIDs 
 	for rows.Next() {
 		var state FindingTriageState
 		var suppressionExpiresAt sql.NullTime
+		var resolvedAt sql.NullTime
 		if err := rows.Scan(
 			&state.FindingID,
 			&state.Status,
 			&state.Assignee,
 			&suppressionExpiresAt,
+			&resolvedAt,
 			&state.UpdatedAt,
 			&state.UpdatedBy,
 		); err != nil {
@@ -925,6 +933,10 @@ func (p *PostgresStore) ListFindingTriageStates(ctx context.Context, findingIDs 
 		if suppressionExpiresAt.Valid {
 			value := suppressionExpiresAt.Time.UTC()
 			state.SuppressionExpiresAt = &value
+		}
+		if resolvedAt.Valid {
+			value := resolvedAt.Time.UTC()
+			state.ResolvedAt = &value
 		}
 		state.UpdatedAt = state.UpdatedAt.UTC()
 		result = append(result, state)
@@ -949,15 +961,17 @@ func (p *PostgresStore) upsertFindingTriageStateWithExecutor(ctx context.Context
 	if updatedAt.IsZero() {
 		updatedAt = time.Now().UTC()
 	}
+	resolvedAt := resolvedAtForStatus(state.Status, state.ResolvedAt)
 	_, err = executor.ExecContext(
 		ctx,
-		`INSERT INTO finding_triage_states (tenant_id, workspace_id, finding_id, status, assignee, suppression_expires_at, updated_at, updated_by)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		`INSERT INTO finding_triage_states (tenant_id, workspace_id, finding_id, status, assignee, suppression_expires_at, resolved_at, updated_at, updated_by)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		 ON CONFLICT (tenant_id, workspace_id, finding_id)
 		 DO UPDATE SET
 		   status = EXCLUDED.status,
 		   assignee = EXCLUDED.assignee,
 		   suppression_expires_at = EXCLUDED.suppression_expires_at,
+		   resolved_at = EXCLUDED.resolved_at,
 		   updated_at = EXCLUDED.updated_at,
 		   updated_by = EXCLUDED.updated_by`,
 		scope.TenantID,
@@ -966,6 +980,7 @@ func (p *PostgresStore) upsertFindingTriageStateWithExecutor(ctx context.Context
 		strings.TrimSpace(string(state.Status)),
 		strings.TrimSpace(state.Assignee),
 		state.SuppressionExpiresAt,
+		resolvedAt,
 		updatedAt.UTC(),
 		strings.TrimSpace(state.UpdatedBy),
 	)
@@ -1246,6 +1261,7 @@ func (p *PostgresStore) ListFindingsFiltered(ctx context.Context, filter Finding
 			%s AS triage_status,
 			COALESCE(ts.assignee, ''),
 			ts.suppression_expires_at,
+			ts.resolved_at,
 			ts.updated_at,
 			COALESCE(ts.updated_by, '')
 		FROM findings f
@@ -4242,6 +4258,7 @@ func findingsWithTriageFromSQLRows(rows rowsScanner, now time.Time) ([]domain.Fi
 			TriageStatus         string
 			TriageAssignee       string
 			SuppressionExpiresAt sql.NullTime
+			ResolvedAt           sql.NullTime
 			TriageUpdatedAt      sql.NullTime
 			TriageUpdatedBy      string
 		}
@@ -4259,6 +4276,7 @@ func findingsWithTriageFromSQLRows(rows rowsScanner, now time.Time) ([]domain.Fi
 			&row.TriageStatus,
 			&row.TriageAssignee,
 			&row.SuppressionExpiresAt,
+			&row.ResolvedAt,
 			&row.TriageUpdatedAt,
 			&row.TriageUpdatedBy,
 		); err != nil {
@@ -4282,6 +4300,10 @@ func findingsWithTriageFromSQLRows(rows rowsScanner, now time.Time) ([]domain.Fi
 		if row.SuppressionExpiresAt.Valid {
 			value := row.SuppressionExpiresAt.Time.UTC()
 			finding.Triage.SuppressionExpiresAt = &value
+		}
+		if row.ResolvedAt.Valid {
+			value := row.ResolvedAt.Time.UTC()
+			finding.Triage.ResolvedAt = &value
 		}
 		if row.TriageUpdatedAt.Valid {
 			value := row.TriageUpdatedAt.Time.UTC()

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -325,10 +325,10 @@ func TestPostgresStoreListFindingsFiltered(t *testing.T) {
 	now := time.Now().UTC()
 	rows := sqlmock.NewRows([]string{
 		"scan_id", "finding_id", "type", "severity", "title", "human_summary", "path", "evidence", "remediation", "created_at",
-		"triage_status", "assignee", "suppression_expires_at", "updated_at", "updated_by",
+		"triage_status", "assignee", "suppression_expires_at", "resolved_at", "updated_at", "updated_by",
 	}).AddRow(
 		"scan-1", "finding-1", "ownerless_identity", "critical", "Ownerless", "summary", []byte("[\"a\"]"), []byte("{\"x\":1}"), "fix", now,
-		"ack", "secops", nil, now, "subject:user-1",
+		"ack", "secops", nil, nil, now, "subject:user-1",
 	)
 	mock.ExpectQuery("SELECT\\s+f\\.scan_id,").
 		WithArgs("default", "default", "critical", sqlmock.AnyArg(), 0, 11).
@@ -346,6 +346,50 @@ func TestPostgresStoreListFindingsFiltered(t *testing.T) {
 	}
 	if items[0].Triage.Status != domain.FindingLifecycleAck || items[0].Triage.Assignee != "secops" {
 		t.Fatalf("unexpected triage payload: %+v", items[0].Triage)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreListFindingsFilteredExposesResolvedAt(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	now := time.Now().UTC()
+	resolvedAt := now.Add(-6 * time.Hour)
+	rows := sqlmock.NewRows([]string{
+		"scan_id", "finding_id", "type", "severity", "title", "human_summary", "path", "evidence", "remediation", "created_at",
+		"triage_status", "assignee", "suppression_expires_at", "resolved_at", "updated_at", "updated_by",
+	}).AddRow(
+		"scan-1", "finding-1", "ownerless_identity", "high", "Ownerless", "summary", []byte("null"), []byte("null"), "", now,
+		"resolved", "secops", nil, resolvedAt, now, "subject:user-1",
+	).AddRow(
+		// Defensive: a stale resolved_at on a non-resolved row must be dropped.
+		"scan-1", "finding-2", "secret_exposure", "high", "Secret", "summary", []byte("null"), []byte("null"), "", now,
+		"open", "secops", nil, resolvedAt, now, "subject:user-2",
+	)
+	mock.ExpectQuery("SELECT\\s+f\\.scan_id,").
+		WithArgs("default", "default", sqlmock.AnyArg(), 0, 11).
+		WillReturnRows(rows)
+
+	items, err := store.ListFindingsFiltered(defaultScopeContext(), FindingListFilter{Limit: 10})
+	if err != nil {
+		t.Fatalf("list filtered findings failed: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(items))
+	}
+	if items[0].Triage.ResolvedAt == nil || !items[0].Triage.ResolvedAt.Equal(resolvedAt) {
+		t.Fatalf("expected resolved finding to expose resolved_at %v, got %v", resolvedAt, items[0].Triage.ResolvedAt)
+	}
+	if items[1].Triage.ResolvedAt != nil {
+		t.Fatalf("expected non-resolved finding to drop resolved_at, got %v", items[1].Triage.ResolvedAt)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -374,10 +418,10 @@ func TestPostgresStoreListFindingsFilteredByScanAndLifecycle(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{
 		"scan_id", "finding_id", "type", "severity", "title", "human_summary", "path", "evidence", "remediation", "created_at",
-		"triage_status", "assignee", "suppression_expires_at", "updated_at", "updated_by",
+		"triage_status", "assignee", "suppression_expires_at", "resolved_at", "updated_at", "updated_by",
 	}).AddRow(
 		"scan-1", "finding-2", "secret_exposure", "high", "Secret", "summary", []byte("null"), []byte("null"), "", now,
-		"suppressed", "secops", now.Add(-time.Minute), now, "subject:user-2",
+		"suppressed", "secops", now.Add(-time.Minute), nil, now, "subject:user-2",
 	)
 	mock.ExpectQuery("SELECT\\s+f\\.scan_id,").
 		WithArgs("default", "default", "scan-1", sqlmock.AnyArg(), "open", "secops", 0, 2).
@@ -895,7 +939,7 @@ func TestPostgresStoreFindingTriageStateAndHistory(t *testing.T) {
 	expiry := now.Add(2 * time.Hour)
 
 	mock.ExpectExec("INSERT INTO finding_triage_states").
-		WithArgs("default", "default", "finding-1", "ack", "sec-oncall", sqlmock.AnyArg(), sqlmock.AnyArg(), "subject:alice").
+		WithArgs("default", "default", "finding-1", "ack", "sec-oncall", sqlmock.AnyArg(), nil, sqlmock.AnyArg(), "subject:alice").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	if err := store.UpsertFindingTriageState(defaultScopeContext(), FindingTriageState{
@@ -909,9 +953,9 @@ func TestPostgresStoreFindingTriageStateAndHistory(t *testing.T) {
 		t.Fatalf("upsert triage state failed: %v", err)
 	}
 
-	stateRows := sqlmock.NewRows([]string{"finding_id", "status", "assignee", "suppression_expires_at", "updated_at", "updated_by"}).
-		AddRow("finding-1", "ack", "sec-oncall", expiry, now, "subject:alice")
-	mock.ExpectQuery("SELECT finding_id, status, assignee, suppression_expires_at, updated_at, updated_by").
+	stateRows := sqlmock.NewRows([]string{"finding_id", "status", "assignee", "suppression_expires_at", "resolved_at", "updated_at", "updated_by"}).
+		AddRow("finding-1", "ack", "sec-oncall", expiry, nil, now, "subject:alice")
+	mock.ExpectQuery("SELECT finding_id, status, assignee, suppression_expires_at, resolved_at, updated_at, updated_by").
 		WithArgs("finding-1", "default", "default").
 		WillReturnRows(stateRows)
 
@@ -923,9 +967,9 @@ func TestPostgresStoreFindingTriageStateAndHistory(t *testing.T) {
 		t.Fatalf("unexpected triage state: %+v", state)
 	}
 
-	listRows := sqlmock.NewRows([]string{"finding_id", "status", "assignee", "suppression_expires_at", "updated_at", "updated_by"}).
-		AddRow("finding-1", "ack", "sec-oncall", expiry, now, "subject:alice")
-	mock.ExpectQuery("SELECT finding_id, status, assignee, suppression_expires_at, updated_at, updated_by").
+	listRows := sqlmock.NewRows([]string{"finding_id", "status", "assignee", "suppression_expires_at", "resolved_at", "updated_at", "updated_by"}).
+		AddRow("finding-1", "ack", "sec-oncall", expiry, nil, now, "subject:alice")
+	mock.ExpectQuery("SELECT finding_id, status, assignee, suppression_expires_at, resolved_at, updated_at, updated_by").
 		WithArgs("default", "default", "finding-1", "finding-2").
 		WillReturnRows(listRows)
 
@@ -975,6 +1019,63 @@ func TestPostgresStoreFindingTriageStateAndHistory(t *testing.T) {
 	}
 }
 
+func TestPostgresStoreFindingTriageResolvedAt(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	now := time.Now().UTC()
+	resolvedAt := now.Add(-3 * time.Hour)
+
+	// A resolved write persists the resolution time.
+	mock.ExpectExec("INSERT INTO finding_triage_states").
+		WithArgs("default", "default", "finding-1", "resolved", "", nil, resolvedAt, sqlmock.AnyArg(), "subject:alice").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	if err := store.UpsertFindingTriageState(defaultScopeContext(), FindingTriageState{
+		FindingID:  "finding-1",
+		Status:     domain.FindingLifecycleResolved,
+		ResolvedAt: &resolvedAt,
+		UpdatedAt:  now,
+		UpdatedBy:  "subject:alice",
+	}); err != nil {
+		t.Fatalf("upsert resolved triage state failed: %v", err)
+	}
+
+	// A non-resolved write must null the resolution time even if supplied.
+	mock.ExpectExec("INSERT INTO finding_triage_states").
+		WithArgs("default", "default", "finding-1", "open", "", nil, nil, sqlmock.AnyArg(), "subject:alice").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	if err := store.UpsertFindingTriageState(defaultScopeContext(), FindingTriageState{
+		FindingID:  "finding-1",
+		Status:     domain.FindingLifecycleOpen,
+		ResolvedAt: &resolvedAt,
+		UpdatedAt:  now,
+		UpdatedBy:  "subject:alice",
+	}); err != nil {
+		t.Fatalf("upsert reopened triage state failed: %v", err)
+	}
+
+	stateRows := sqlmock.NewRows([]string{"finding_id", "status", "assignee", "suppression_expires_at", "resolved_at", "updated_at", "updated_by"}).
+		AddRow("finding-1", "resolved", "", nil, resolvedAt, now, "subject:alice")
+	mock.ExpectQuery("SELECT finding_id, status, assignee, suppression_expires_at, resolved_at, updated_at, updated_by").
+		WithArgs("finding-1", "default", "default").
+		WillReturnRows(stateRows)
+	state, err := store.GetFindingTriageState(defaultScopeContext(), "finding-1")
+	if err != nil {
+		t.Fatalf("get triage state failed: %v", err)
+	}
+	if state.ResolvedAt == nil || !state.ResolvedAt.Equal(resolvedAt) {
+		t.Fatalf("expected resolved_at %v, got %v", resolvedAt, state.ResolvedAt)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestPostgresStoreApplyFindingTriageTransition(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -987,7 +1088,7 @@ func TestPostgresStoreApplyFindingTriageTransition(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectExec("INSERT INTO finding_triage_states").
-		WithArgs("default", "default", "finding-1", "ack", "sec-oncall", nil, sqlmock.AnyArg(), "subject:alice").
+		WithArgs("default", "default", "finding-1", "ack", "sec-oncall", nil, nil, sqlmock.AnyArg(), "subject:alice").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO finding_triage_events").
 		WithArgs(sqlmock.AnyArg(), "default", "default", "finding-1", FindingTriageActionAcknowledged, "open", "ack", "sec-oncall", nil, "acknowledged", "subject:alice", sqlmock.AnyArg()).
@@ -1031,7 +1132,7 @@ func TestPostgresStoreApplyFindingTriageTransitionRollsBackOnEventFailure(t *tes
 
 	mock.ExpectBegin()
 	mock.ExpectExec("INSERT INTO finding_triage_states").
-		WithArgs("default", "default", "finding-1", "ack", "sec-oncall", nil, sqlmock.AnyArg(), "subject:alice").
+		WithArgs("default", "default", "finding-1", "ack", "sec-oncall", nil, nil, sqlmock.AnyArg(), "subject:alice").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO finding_triage_events").
 		WithArgs(sqlmock.AnyArg(), "default", "default", "finding-1", FindingTriageActionAcknowledged, "open", "ack", "sec-oncall", nil, "acknowledged", "subject:alice", sqlmock.AnyArg()).
@@ -2500,7 +2601,7 @@ func TestPostgresStoreUpsertFindingTriageStateUsesScopedExecWhenRLSEnabled(t *te
 		WithArgs("default", "default", "on").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT INTO finding_triage_states").
-		WithArgs("default", "default", "finding-1", "ack", "sec-oncall", nil, sqlmock.AnyArg(), "subject:alice").
+		WithArgs("default", "default", "finding-1", "ack", "sec-oncall", nil, nil, sqlmock.AnyArg(), "subject:alice").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -244,8 +244,22 @@ type FindingTriageState struct {
 	Status               domain.FindingLifecycleStatus `json:"status"`
 	Assignee             string                        `json:"assignee,omitempty"`
 	SuppressionExpiresAt *time.Time                    `json:"suppression_expires_at,omitempty"`
-	UpdatedAt            time.Time                     `json:"updated_at"`
-	UpdatedBy            string                        `json:"updated_by,omitempty"`
+	// ResolvedAt is non-nil only while Status is resolved; it captures the
+	// resolution time so the executive report can compute accurate MTTR.
+	ResolvedAt *time.Time `json:"resolved_at,omitempty"`
+	UpdatedAt  time.Time  `json:"updated_at"`
+	UpdatedBy  string     `json:"updated_by,omitempty"`
+}
+
+// resolvedAtForStatus enforces the resolved_at invariant shared by every store
+// backend: a finding only carries a resolution time while it is resolved, so a
+// reopened (or otherwise non-resolved) finding never reports a stale value.
+func resolvedAtForStatus(status domain.FindingLifecycleStatus, resolvedAt *time.Time) *time.Time {
+	if status != domain.FindingLifecycleResolved || resolvedAt == nil {
+		return nil
+	}
+	value := resolvedAt.UTC()
+	return &value
 }
 
 // FindingTriageEvent records one immutable workflow action.
@@ -1988,6 +2002,9 @@ func NormalizeFindingTriage(triage domain.FindingTriage, now time.Time) domain.F
 	}
 	if normalized.Status != domain.FindingLifecycleSuppressed {
 		normalized.SuppressionExpiresAt = nil
+	}
+	if normalized.Status != domain.FindingLifecycleResolved {
+		normalized.ResolvedAt = nil
 	}
 	return normalized
 }

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -72,8 +72,12 @@ type FindingTriage struct {
 	Status               FindingLifecycleStatus `json:"status"`
 	Assignee             string                 `json:"assignee,omitempty"`
 	SuppressionExpiresAt *time.Time             `json:"suppression_expires_at,omitempty"`
-	UpdatedAt            *time.Time             `json:"updated_at,omitempty"`
-	UpdatedBy            string                 `json:"updated_by,omitempty"`
+	// ResolvedAt records when the finding most recently entered the resolved
+	// state. It is nil unless Status is resolved, so reopened findings never
+	// report a stale resolution time and MTTR reporting stays trustworthy.
+	ResolvedAt *time.Time `json:"resolved_at,omitempty"`
+	UpdatedAt  *time.Time `json:"updated_at,omitempty"`
+	UpdatedBy  string     `json:"updated_by,omitempty"`
 }
 
 // DefaultFindingTriage returns the baseline lifecycle state for new findings.

--- a/migrations/000026_finding_triage_resolved_at.down.sql
+++ b/migrations/000026_finding_triage_resolved_at.down.sql
@@ -1,0 +1,6 @@
+-- 000026_finding_triage_resolved_at.down.sql
+
+DROP INDEX IF EXISTS idx_finding_triage_states_scope_resolved_at;
+
+ALTER TABLE finding_triage_states
+    DROP COLUMN IF EXISTS resolved_at;

--- a/migrations/000026_finding_triage_resolved_at.up.sql
+++ b/migrations/000026_finding_triage_resolved_at.up.sql
@@ -1,0 +1,22 @@
+-- 000026_finding_triage_resolved_at.up.sql
+-- Additive: records when a finding entered the resolved state so the
+-- executive report can compute an accurate mean-time-to-resolve (MTTR).
+
+ALTER TABLE finding_triage_states
+    ADD COLUMN IF NOT EXISTS resolved_at TIMESTAMPTZ;
+
+-- Best-effort historical backfill: existing resolved rows only have a mutable
+-- updated_at, so use it as the closest available proxy for the resolution time.
+UPDATE finding_triage_states
+SET resolved_at = updated_at
+WHERE status = 'resolved'
+  AND resolved_at IS NULL;
+
+-- Defensive: a non-resolved row must never carry a resolution time.
+UPDATE finding_triage_states
+SET resolved_at = NULL
+WHERE status <> 'resolved'
+  AND resolved_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_finding_triage_states_scope_resolved_at
+    ON finding_triage_states (tenant_id, workspace_id, resolved_at);

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -368,6 +368,7 @@ export type FindingTriage = {
   status: FindingLifecycleStatus;
   assignee?: string;
   suppression_expires_at?: string;
+  resolved_at?: string;
   updated_at?: string;
   updated_by?: string;
 };


### PR DESCRIPTION
Fixes #1165

## What changed
Added a server-managed `resolved_at` timestamp to finding triage.

- Set when a finding transitions **into** the resolved state, **preserved** across non-status edits (assignee/comment) while it stays resolved, and **cleared** when the finding is reopened or moved out of resolved.
- The invariant (`resolved_at` is non-null only while `status = resolved`) is enforced consistently in the service transition logic, the shared `NormalizeFindingTriage` read path, and at both store backends via a shared helper — so it holds on **every** read path, including the primary filtered `GET /findings` list (addressed a Codex review finding that the filtered list path originally omitted the field).
- Exposed on the `FindingTriage` domain type, API response, OpenAPI schema, and web client types. It is server-managed, so it is intentionally **not** part of `FindingTriageRequest`.
- Migration `000026_finding_triage_resolved_at` (additive, forward-safe, `IF NOT EXISTS`): adds the nullable column, best-effort backfills existing resolved rows with `resolved_at = updated_at`, defensively clears non-resolved rows, adds a scoped index; paired `.down.sql` reverses it.

## Why
The executive report needs a trustworthy mean-time-to-resolve (MTTR). With only a mutable `updated_at`, resolution time could not be determined without guessing. This is the standalone data-correctness change Track 2 PR-6 calls for.

## Impact and risk
Low. Purely additive schema and response field; existing unresolved findings are unchanged; resolved findings get a best-effort historical value via backfill. No request-side surface changes.

## Validation performed
- `go build ./...`, `go vet ./internal/...` — clean
- `go test ./internal/db/ ./internal/api/` — full packages pass, including new regression tests:
  - service: resolve → comment-while-resolved (preserved) → reopen (cleared) → re-resolve (fresh), with assertions on both `GetFinding` and the filtered list
  - Postgres: `resolved_at` round-trip + non-resolved clearing on direct store and on the filtered findings list
  - memory: invariant on direct store writes
- OpenAPI YAML validates; `./scripts/check_api_example_contract.sh` passes
- web `tsc -b` typecheck passes

## Linked issue
Fixes #1165

## AI-Assisted and AI-Generated Code Policy disclosure
- AI-assisted: yes
- Tools used: Claude Code
- Where used: finding triage `resolved_at` across domain/store/service/migration/OpenAPI/web client types and tests
- Human verification performed: reviewed the full diff; ran go build/vet, full `internal/db` + `internal/api` test packages, OpenAPI + API example contract checks, and web `tsc -b`; addressed automated review feedback on the filtered-list read path