### PR TITLE
Fix/auth provider light hover

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -473,6 +473,7 @@ describe('App', () => {
     const themeTrigger = screen.getByRole('button', { name: /Color theme: Dark/i });
     fireEvent.click(themeTrigger);
     fireEvent.click(screen.getByRole('menuitemradio', { name: /Light/i }));
+    expect(await screen.findByRole('button', { name: /Color theme: Light/i })).toBeInTheDocument();
 
     const githubProvider = await screen.findByRole('link', { name: /Continue with GitHub/i });
     const githubIcon = githubProvider.querySelector('.idt-auth-provider-icon-github');

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -464,6 +464,23 @@ describe('App', () => {
     expect(screen.getByRole('menuitemradio', { name: /Dark/i })).toBeInTheDocument();
   });
 
+  it('renders the GitHub provider mark on the light sign-up page', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(authConfig(false, true)));
+
+    setCurrentPath('/signup');
+    render(<App />);
+
+    const themeTrigger = screen.getByRole('button', { name: /Color theme: Dark/i });
+    fireEvent.click(themeTrigger);
+    fireEvent.click(screen.getByRole('menuitemradio', { name: /Light/i }));
+
+    const githubProvider = await screen.findByRole('link', { name: /Continue with GitHub/i });
+    const githubIcon = githubProvider.querySelector('.idt-auth-provider-icon-github');
+
+    expect(githubIcon).toBeInTheDocument();
+    expect(githubIcon).toHaveAttribute('src', '/brand-logos/github.svg');
+  });
+
   it('shows a clear API reachability error when auth config cannot be fetched', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new TypeError('Failed to fetch')));
 

--- a/web/src/pages/SignInPage.tsx
+++ b/web/src/pages/SignInPage.tsx
@@ -128,7 +128,7 @@ function providerIcon(provider: HostedProvider) {
         </svg>
       );
     case 'github':
-      return <img className="idt-auth-provider-icon" src="/brand-logos/github.svg" alt="" />;
+      return <img className="idt-auth-provider-icon idt-auth-provider-icon-github" src="/brand-logos/github.svg" alt="" />;
     case 'sso':
       return (
         <span className="idt-auth-provider-icon idt-auth-provider-icon-sso" aria-hidden="true">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6338,23 +6338,11 @@ html[data-theme='light'] .idt-auth-provider-google {
   background: var(--auth-button-muted);
 }
 
-.idt-auth-page[data-auth-theme='dark'].idt-auth-page-signup .idt-auth-provider-github {
-  border-color: var(--auth-github);
-  background: var(--auth-github);
-  color: #ffffff;
-}
-
 .idt-auth-page[data-auth-theme='light'].idt-auth-page-signup .idt-auth-provider-github,
 html[data-theme='light'] .idt-auth-page[data-auth-theme='light'].idt-auth-page-signup .idt-auth-provider-github {
   border-color: var(--auth-line-strong);
   background: var(--auth-button-muted);
   color: var(--auth-text);
-}
-
-.idt-auth-page[data-auth-theme='dark'].idt-auth-page-signup .idt-auth-provider-github:hover,
-.idt-auth-page[data-auth-theme='dark'].idt-auth-page-signup .idt-auth-provider-github:focus-visible {
-  border-color: #4b5563;
-  background: #2b3138;
 }
 
 .idt-auth-page[data-auth-theme='light'].idt-auth-page-signup .idt-auth-provider-github:hover,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6214,6 +6214,7 @@ html[data-theme='light'] .idt-auth-panel-signup h1 {
 html[data-theme='light'] .idt-auth-provider {
   width: 100%;
   min-height: 3.5rem;
+  position: relative;
   display: grid;
   grid-template-columns: 1.45rem minmax(12.75rem, 12.75rem) 1.45rem;
   align-items: center;
@@ -6230,17 +6231,46 @@ html[data-theme='light'] .idt-auth-provider {
   line-height: 1.2;
   text-decoration: none;
   cursor: pointer;
-  box-shadow: none;
+  overflow: hidden;
+  isolation: isolate;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
   transition:
-    border-color 0.16s ease,
-    background-color 0.16s ease,
-    transform 0.16s ease;
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    box-shadow 0.18s ease,
+    color 0.18s ease,
+    transform 0.18s ease;
+}
+
+.idt-auth-provider::before {
+  content: '';
+  position: absolute;
+  inset: 1px;
+  z-index: 0;
+  border-radius: 6px;
+  background: linear-gradient(105deg, transparent 5%, rgba(255, 255, 255, 0.1) 48%, transparent 72%);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(-35%);
+  transition:
+    opacity 0.22s ease,
+    transform 0.32s ease;
+}
+
+.idt-auth-page[data-auth-theme='light'] .idt-auth-provider::before,
+html[data-theme='light'] .idt-auth-page[data-auth-theme='light'] .idt-auth-provider::before {
+  background: linear-gradient(105deg, transparent 5%, rgba(15, 23, 42, 0.055) 48%, transparent 72%);
 }
 
 .idt-auth-provider::after {
   content: '';
   width: 1.45rem;
   height: 1px;
+}
+
+.idt-auth-provider > * {
+  position: relative;
+  z-index: 1;
 }
 
 .idt-auth-provider > span:not(.idt-auth-provider-icon) {
@@ -6263,10 +6293,34 @@ html[data-theme='light'] .idt-auth-provider-plain::after {
 .idt-auth-provider:focus-visible,
 html[data-theme='light'] .idt-auth-provider:hover,
 html[data-theme='light'] .idt-auth-provider:focus-visible {
-  transform: none;
-  border-color: var(--auth-muted);
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--auth-muted) 72%, var(--auth-text));
   background: var(--auth-button-muted-hover);
-  box-shadow: none;
+  box-shadow:
+    0 14px 34px rgba(0, 0, 0, 0.34),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.idt-auth-page[data-auth-theme='light'] .idt-auth-provider:hover,
+.idt-auth-page[data-auth-theme='light'] .idt-auth-provider:focus-visible,
+html[data-theme='light'] .idt-auth-page[data-auth-theme='light'] .idt-auth-provider:hover,
+html[data-theme='light'] .idt-auth-page[data-auth-theme='light'] .idt-auth-provider:focus-visible {
+  box-shadow:
+    0 14px 32px rgba(15, 23, 42, 0.1),
+    inset 0 1px 0 rgba(255, 255, 255, 0.92);
+}
+
+.idt-auth-provider:hover::before,
+.idt-auth-provider:focus-visible::before {
+  opacity: 1;
+  transform: translateX(35%);
+}
+
+.idt-auth-provider:active {
+  transform: translateY(0) scale(0.998);
+  box-shadow:
+    0 8px 18px rgba(0, 0, 0, 0.22),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
 .idt-auth-provider:focus-visible,
@@ -6284,10 +6338,31 @@ html[data-theme='light'] .idt-auth-provider-google {
   background: var(--auth-button-muted);
 }
 
-.idt-auth-page-signup .idt-auth-provider-github {
+.idt-auth-page[data-auth-theme='dark'].idt-auth-page-signup .idt-auth-provider-github {
   border-color: var(--auth-github);
   background: var(--auth-github);
   color: #ffffff;
+}
+
+.idt-auth-page[data-auth-theme='light'].idt-auth-page-signup .idt-auth-provider-github,
+html[data-theme='light'] .idt-auth-page[data-auth-theme='light'].idt-auth-page-signup .idt-auth-provider-github {
+  border-color: var(--auth-line-strong);
+  background: var(--auth-button-muted);
+  color: var(--auth-text);
+}
+
+.idt-auth-page[data-auth-theme='dark'].idt-auth-page-signup .idt-auth-provider-github:hover,
+.idt-auth-page[data-auth-theme='dark'].idt-auth-page-signup .idt-auth-provider-github:focus-visible {
+  border-color: #4b5563;
+  background: #2b3138;
+}
+
+.idt-auth-page[data-auth-theme='light'].idt-auth-page-signup .idt-auth-provider-github:hover,
+.idt-auth-page[data-auth-theme='light'].idt-auth-page-signup .idt-auth-provider-github:focus-visible,
+html[data-theme='light'] .idt-auth-page[data-auth-theme='light'].idt-auth-page-signup .idt-auth-provider-github:hover,
+html[data-theme='light'] .idt-auth-page[data-auth-theme='light'].idt-auth-page-signup .idt-auth-provider-github:focus-visible {
+  border-color: color-mix(in srgb, var(--auth-muted) 58%, var(--auth-line-strong));
+  background: var(--auth-button-muted-hover);
 }
 
 .idt-auth-provider-dark,
@@ -6314,9 +6389,34 @@ html[data-theme='light'] .idt-auth-provider-dark {
   font-weight: unset;
 }
 
-.idt-auth-page[data-auth-theme='dark'] .idt-auth-provider-icon:not(.idt-auth-provider-icon-google),
-.idt-auth-page-signup .idt-auth-provider-github .idt-auth-provider-icon {
+.idt-auth-provider-icon-github {
+  display: block;
+  opacity: 1;
+  filter: none;
+}
+
+.idt-auth-page[data-auth-theme='dark'] .idt-auth-provider-icon:not(.idt-auth-provider-icon-google) {
   filter: brightness(0) invert(1);
+}
+
+.idt-auth-page[data-auth-theme='light'] .idt-auth-provider-icon-github,
+html[data-theme='light'] .idt-auth-page[data-auth-theme='light'] .idt-auth-provider-icon-github {
+  filter: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .idt-auth-provider,
+  .idt-auth-provider::before {
+    transition: none;
+  }
+
+  .idt-auth-provider:hover,
+  .idt-auth-provider:focus-visible,
+  html[data-theme='light'] .idt-auth-provider:hover,
+  html[data-theme='light'] .idt-auth-provider:focus-visible,
+  .idt-auth-provider:active {
+    transform: none;
+  }
 }
 
 .idt-auth-provider-icon-sso {


### PR DESCRIPTION
## Summary

Describe what changed.

## Why

Describe the problem this PR solves.

## Scope

- [ ] Focused change (no unrelated modifications)
- [ ] Backward compatibility considered
- [ ] Risk level assessed

## Validation

List the checks you ran and their outcomes.

```bash
# Example:
# go test ./...
# npm run test:ci --prefix web
```

## Checklist

- [ ] Tests added/updated for behavior changes
- [ ] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [ ] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

If AI tools were used materially for this PR, complete the fields below.

- AI-assisted: yes/no
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Required for this repository size:

- Include at least one issue reference using closing/reference keywords:
  - `Closes #123`, `Fixes #123`, or `Refs #123`
- If no issue exists, include an explicit exemption with rationale:
  - `No issue: <reason>` (for example: docs-only typo fix, CI-only fix, or emergency hotfix)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes light theme styling and hover interactions for auth provider buttons on the sign-up page. Ensures the GitHub icon displays correctly and the button provides clear hover/active feedback in light mode.

- Bug Fixes
  - Adjusted `.idt-auth-provider` hover/active behavior in light theme (lift, shadows, border, gradient highlight) with reduced-motion fallback.
  - Fixed GitHub provider on light sign-up: neutral button styling and visible GitHub mark via `.idt-auth-provider-icon-github` (no invert).
  - Added a test that verifies the GitHub icon renders on the light sign-up page and points to `/brand-logos/github.svg`.

<sup>Written for commit 4568e05a08c476f188c51d1a13a4048935dcff91. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1168?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

