### PR TITLE
Update Docker QEMU setup action to Node 24

### DIFF
--- a/.github/workflows/publish-container-images.yml
+++ b/.github/workflows/publish-container-images.yml
@@ -52,7 +52,7 @@ jobs:
           echo "web_onboarding_wizard=true" >> "${GITHUB_OUTPUT}"
 
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,7 +207,7 @@ jobs:
           ref: refs/tags/${{ needs.prepare.outputs.tag }}
 
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd


### PR DESCRIPTION
Fixes #1169

## What changed
- Updates the pinned `docker/setup-qemu-action` SHA in the container publish workflow to the `v4.0.0` commit.
- Applies the same update in the release image publishing workflow.

## Why
GitHub Actions now warns that the previous QEMU action release runs on Node.js 20. The updated action metadata declares `node24`, which removes the warning while preserving pinned action SHAs.

## Validation performed
- `git diff --check`
- Ruby YAML parse for `.github/workflows/publish-container-images.yml` and `.github/workflows/release.yml`
- Verified `docker/setup-qemu-action@v4.0.0` resolves to `ce360397dd3f832beb865e1373c09c0e9f86d70a` and declares `using: node24`
- Pre-commit/push hooks: merge-conflict check, YAML check, end-of-file check, trailing whitespace, gofmt check, `go vet`, local env token hygiene, Vercel artifact hygiene

AI-assisted: yes
Tools used: Codex
Where used: workflow SHA update and validation
Human verification performed: reviewed diff and ran the validation commands listed above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update GitHub Actions to use `docker/setup-qemu-action` v4.0.0 (Node 24) in the container publish and release workflows. This removes the Node 20 runtime warning while keeping the action pinned.

- **Dependencies**
  - Bumped `docker/setup-qemu-action` to v4.0.0 in `.github/workflows/publish-container-images.yml` and `.github/workflows/release.yml`.

<sup>Written for commit f71a738048e07624793239cbeb9653e1f8ff812c. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1170?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

