### PR TITLE
Add executive report API endpoint with MTTR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## Unreleased
+- Added the `GET /v1/enterprise/reports/executive` endpoint returning the organization's leadership rollup (open volume by severity, top finding types, week-over-week trend, and MTTR):
+  - calls the shipped `BuildExecutiveReport` builder; JSON only, no server-side PDF generation
+  - extended the report builder with `mean_time_to_resolve`, derived strictly from finding triage `resolved_at` (never the mutable `updated_at`) and omitted when no resolved finding has a trustworthy `resolved_at`
+  - 60-second per-organization in-memory cache; responses are scoped to the caller's organization under the existing `enterprise.read` authorization
+  - documented in the enterprise quickstart and OpenAPI contract
 - Added a server-managed `resolved_at` timestamp to finding triage so the executive report can compute an accurate mean-time-to-resolve (MTTR):
   - exposed on the `FindingTriage` API response, OpenAPI schema, and web client types
   - set when a finding transitions into the resolved state, preserved across edits while it stays resolved, and cleared when it is reopened or moved out of resolved

--- a/docs/enterprise-quickstart.md
+++ b/docs/enterprise-quickstart.md
@@ -249,7 +249,27 @@ Confirm:
 - `scim_op` matches the SCIM lifecycle operation
 - failed Slack/Jira/Linear attempts include `success=false` and an `error` string
 
-## 12. Clean Shutdown
+## 12. Executive Report (Board-Ready)
+
+Fetch the leadership rollup for the current organization. The response is
+JSON only — there is no server-side PDF; use the printable web report page
+and your browser's Save as PDF for a board-ready document.
+
+```bash
+curl -fsS "${IDENTRAIL_API_URL}/v1/enterprise/reports/executive" \
+  -H "Cookie: ${IDENTRAIL_SESSION_COOKIE}" | jq
+```
+
+Notes:
+
+- Requires the `enterprise.read` scope and an organization-scoped session.
+- Responses are cached per organization for 60 seconds, so rapid refreshes
+  return the same snapshot.
+- `mean_time_to_resolve` is present only when at least one resolved finding
+  carries a trustworthy `resolved_at`; it is derived solely from `resolved_at`
+  (never the mutable `updated_at`), so the figure is not a guess.
+
+## 13. Clean Shutdown
 
 ```bash
 docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env down

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -219,6 +219,10 @@ x-identrail-route-authorizations:
     action: enterprise.write
     resource_type: identity_connection
   - method: GET
+    path: /v1/enterprise/reports/executive
+    action: enterprise.read
+    resource_type: executive_report
+  - method: GET
     path: /v1/whoami
     action: tenancy.read
     resource_type: workspace_context
@@ -1206,6 +1210,34 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /v1/enterprise/reports/executive:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+    get:
+      tags: [EnterpriseAuth]
+      summary: Executive security report for the current organization
+      description: >-
+        Returns a deterministic leadership rollup (open volume by severity,
+        top finding types, week-over-week trend, and mean time to resolve)
+        built from the current organization's findings. Responses are cached
+        per organization for 60 seconds. JSON only; no server-side PDF.
+      operationId: getExecutiveReport
+      security:
+        - CookieAuth: []
+      responses:
+        "200":
+          description: Executive report for the current organization
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExecutiveReport"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /v1/authz/policies/simulate:
     parameters:
       - $ref: "#/components/parameters/scopeTenantID"
@@ -5394,6 +5426,83 @@ components:
         updated_at:
           type: string
           format: date-time
+    ExecutiveReport:
+      type: object
+      required:
+        - organization_id
+        - generated_at
+        - window_start
+        - window_end
+        - total_open_findings
+        - open_by_severity
+        - open_by_type
+        - week_over_week
+      properties:
+        organization_id:
+          type: string
+        generated_at:
+          type: string
+          format: date-time
+        window_start:
+          type: string
+          format: date-time
+        window_end:
+          type: string
+          format: date-time
+        total_open_findings:
+          type: integer
+        open_by_severity:
+          type: object
+          additionalProperties:
+            type: integer
+        open_by_type:
+          type: object
+          additionalProperties:
+            type: integer
+        top_finding_types:
+          type: array
+          nullable: true
+          items:
+            $ref: "#/components/schemas/TopFindingType"
+        week_over_week:
+          $ref: "#/components/schemas/WeekOverWeekTrend"
+        mean_time_to_resolve:
+          allOf:
+            - $ref: "#/components/schemas/MTTRSummary"
+          nullable: true
+          description: >-
+            Omitted entirely when no resolved finding carries a trustworthy
+            ResolvedAt timestamp. Derived only from ResolvedAt, never the
+            mutable updated_at.
+    TopFindingType:
+      type: object
+      required: [type, count]
+      properties:
+        type:
+          type: string
+        count:
+          type: integer
+    WeekOverWeekTrend:
+      type: object
+      required: [current_count, previous_count, delta]
+      properties:
+        current_count:
+          type: integer
+        previous_count:
+          type: integer
+        delta:
+          type: integer
+    MTTRSummary:
+      type: object
+      required: [resolved_count, seconds]
+      properties:
+        resolved_count:
+          type: integer
+          description: Number of resolved findings with a trustworthy ResolvedAt.
+        seconds:
+          type: number
+          format: double
+          description: Mean of (ResolvedAt - CreatedAt) in seconds across resolved_count findings.
     FindingSeverity:
       type: string
       enum: [critical, high, medium, low, info]

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -682,6 +682,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodPut, Path: "/v1/enterprise/identity-connections/saml/:id", Action: policyActionEnterpriseWrite, ResourceType: "identity_connection", ResourceIDParam: "id"},
 		{Method: http.MethodDelete, Path: "/v1/enterprise/identity-connections/saml/:id", Action: policyActionEnterpriseWrite, ResourceType: "identity_connection", ResourceIDParam: "id"},
 		{Method: http.MethodPost, Path: "/v1/enterprise/identity-connections/saml/from-metadata", Action: policyActionEnterpriseWrite, ResourceType: "identity_connection"},
+		{Method: http.MethodGet, Path: "/v1/enterprise/reports/executive", Action: policyActionEnterpriseRead, ResourceType: "executive_report"},
 		{Method: http.MethodGet, Path: "/v1/whoami", Action: policyActionTenancyRead, ResourceType: "workspace_context"},
 		{Method: http.MethodGet, Path: "/v1/organizations/current", Action: policyActionTenancyRead, ResourceType: "organization"},
 		{Method: http.MethodPut, Path: "/v1/organizations/current", Action: policyActionTenancyWrite, ResourceType: "organization"},

--- a/internal/api/enterprise_report_routes.go
+++ b/internal/api/enterprise_report_routes.go
@@ -192,6 +192,25 @@ func executiveReportHandler(logger *zap.Logger, svc *Service, cache *executiveRe
 				return
 			}
 			findings = append(findings, wsFindings...)
+
+			repoFindings, err := svc.Store.ListRepoFindings(wsCtx, db.RepoFindingFilter{}, 0)
+			if err != nil {
+				if logger != nil {
+					logger.Error("list repo findings for executive report", telemetry.ZapError(err))
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build executive report"})
+				return
+			}
+			repoFindings = enrichFindingsWithRepoContext(repoFindings)
+			repoFindings, err = svc.applyFindingTriageStates(wsCtx, repoFindings)
+			if err != nil {
+				if logger != nil {
+					logger.Error("hydrate repo finding triage for executive report", telemetry.ZapError(err))
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build executive report"})
+				return
+			}
+			findings = append(findings, repoFindings...)
 		}
 
 		report := enterprise.BuildExecutiveReport(findings, enterprise.ReportOptions{

--- a/internal/api/enterprise_report_routes.go
+++ b/internal/api/enterprise_report_routes.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"sync"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
 	"github.com/identrail/identrail/internal/enterprise"
 	"github.com/identrail/identrail/internal/telemetry"
 	"go.uber.org/zap"
@@ -66,6 +68,40 @@ func (c *executiveReportCache) set(key string, report enterprise.ExecutiveReport
 	c.entries[key] = cachedExecutiveReport{report: report, expiresAt: now.Add(c.ttl)}
 }
 
+// maxOrgReportWorkspaces bounds how many workspaces the executive report will
+// aggregate. It is far above any realistic per-organization workspace count;
+// it exists only so a pathological tenant cannot make one request unbounded.
+const maxOrgReportWorkspaces = 1000
+
+// organizationWorkspaceIDs returns every workspace in the caller's tenant so
+// the report covers the whole organization. The caller's active workspace is
+// always included so deployments that never registered tenancy workspace rows
+// (e.g. single-workspace/default mode) still produce a non-empty report.
+func organizationWorkspaceIDs(ctx context.Context, svc *Service, scope db.Scope) ([]string, error) {
+	workspaces, err := svc.Store.ListWorkspaces(ctx, maxOrgReportWorkspaces)
+	if err != nil {
+		return nil, err
+	}
+	ordered := make([]string, 0, len(workspaces)+1)
+	seen := map[string]struct{}{}
+	add := func(id string) {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return
+		}
+		if _, ok := seen[id]; ok {
+			return
+		}
+		seen[id] = struct{}{}
+		ordered = append(ordered, id)
+	}
+	for _, ws := range workspaces {
+		add(ws.WorkspaceID)
+	}
+	add(scope.WorkspaceID)
+	return ordered, nil
+}
+
 func registerExecutiveReportRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service) {
 	if svc == nil {
 		return
@@ -92,39 +128,54 @@ func executiveReportHandler(logger *zap.Logger, svc *Service, cache *executiveRe
 		}
 		now := clock()
 
-		// Cache by the exact data scope, not just the org. The request-scope
-		// middleware narrows findings to tenant+workspace, so keying only by
-		// org id would let one workspace serve another workspace's cached
-		// report within the same organization for up to the TTL.
+		// The report is organization-wide. The request scope's tenant id is the
+		// organization (session sets tenant_id from CurrentOrgID), so the cache
+		// is keyed by tenant: every workspace in the org shares one org-wide
+		// snapshot and cannot see a partial, workspace-scoped one.
 		reqCtx := c.Request.Context()
 		scope := db.ScopeFromContext(reqCtx)
-		cacheKey := scope.TenantID + "\x00" + scope.WorkspaceID
+		cacheKey := scope.TenantID
 
 		if report, ok := cache.get(cacheKey, now); ok {
 			c.JSON(http.StatusOK, report)
 			return
 		}
 
-		// Findings are scope-filtered by the request-scope middleware, so the
-		// store only returns the caller's tenant+workspace findings.
-		// ListFindingsAll is uncapped; triage (including the trustworthy
-		// ResolvedAt that MTTR depends on) is hydrated separately since the raw
-		// finding rows do not carry it.
-		findings, err := svc.Store.ListFindingsAll(reqCtx)
+		// An executive report covers the whole organization, but findings are
+		// stored per workspace. Enumerate every workspace in the tenant and
+		// aggregate, rather than reporting only the caller's active workspace.
+		workspaceIDs, err := organizationWorkspaceIDs(reqCtx, svc, scope)
 		if err != nil {
 			if logger != nil {
-				logger.Error("list findings for executive report", telemetry.ZapError(err))
+				logger.Error("list workspaces for executive report", telemetry.ZapError(err))
 			}
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build executive report"})
 			return
 		}
-		findings, err = svc.applyFindingTriageStates(reqCtx, findings)
-		if err != nil {
-			if logger != nil {
-				logger.Error("hydrate triage for executive report", telemetry.ZapError(err))
+
+		var findings []domain.Finding
+		for _, wsID := range workspaceIDs {
+			wsCtx := db.WithScope(reqCtx, db.Scope{TenantID: scope.TenantID, WorkspaceID: wsID})
+			// ListFindingsAll is uncapped; triage (including the trustworthy
+			// ResolvedAt that MTTR depends on) is hydrated separately since the
+			// raw finding rows do not carry it.
+			wsFindings, err := svc.Store.ListFindingsAll(wsCtx)
+			if err != nil {
+				if logger != nil {
+					logger.Error("list findings for executive report", telemetry.ZapError(err))
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build executive report"})
+				return
 			}
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build executive report"})
-			return
+			wsFindings, err = svc.applyFindingTriageStates(wsCtx, wsFindings)
+			if err != nil {
+				if logger != nil {
+					logger.Error("hydrate triage for executive report", telemetry.ZapError(err))
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build executive report"})
+				return
+			}
+			findings = append(findings, wsFindings...)
 		}
 
 		report := enterprise.BuildExecutiveReport(findings, enterprise.ReportOptions{

--- a/internal/api/enterprise_report_routes.go
+++ b/internal/api/enterprise_report_routes.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/identrail/identrail/internal/db"
 	"github.com/identrail/identrail/internal/enterprise"
 	"github.com/identrail/identrail/internal/telemetry"
 	"go.uber.org/zap"
@@ -36,20 +37,33 @@ func newExecutiveReportCache(ttl time.Duration) *executiveReportCache {
 	return &executiveReportCache{ttl: ttl, entries: map[string]cachedExecutiveReport{}}
 }
 
-func (c *executiveReportCache) get(orgID string, now time.Time) (enterprise.ExecutiveReport, bool) {
+func (c *executiveReportCache) get(key string, now time.Time) (enterprise.ExecutiveReport, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	entry, ok := c.entries[orgID]
-	if !ok || !now.Before(entry.expiresAt) {
+	entry, ok := c.entries[key]
+	if !ok {
+		return enterprise.ExecutiveReport{}, false
+	}
+	if !now.Before(entry.expiresAt) {
+		// Evict the stale entry we just touched rather than leaving it.
+		delete(c.entries, key)
 		return enterprise.ExecutiveReport{}, false
 	}
 	return entry.report, true
 }
 
-func (c *executiveReportCache) set(orgID string, report enterprise.ExecutiveReport, now time.Time) {
+func (c *executiveReportCache) set(key string, report enterprise.ExecutiveReport, now time.Time) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.entries[orgID] = cachedExecutiveReport{report: report, expiresAt: now.Add(c.ttl)}
+	// Sweep expired entries so the per-scope map cannot grow without bound as
+	// organizations/workspaces come and go. Writes are infrequent (at most one
+	// per scope per TTL), so the linear sweep is cheap.
+	for k, e := range c.entries {
+		if !now.Before(e.expiresAt) {
+			delete(c.entries, k)
+		}
+	}
+	c.entries[key] = cachedExecutiveReport{report: report, expiresAt: now.Add(c.ttl)}
 }
 
 func registerExecutiveReportRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service) {
@@ -78,17 +92,24 @@ func executiveReportHandler(logger *zap.Logger, svc *Service, cache *executiveRe
 		}
 		now := clock()
 
-		if report, ok := cache.get(orgID, now); ok {
+		// Cache by the exact data scope, not just the org. The request-scope
+		// middleware narrows findings to tenant+workspace, so keying only by
+		// org id would let one workspace serve another workspace's cached
+		// report within the same organization for up to the TTL.
+		reqCtx := c.Request.Context()
+		scope := db.ScopeFromContext(reqCtx)
+		cacheKey := scope.TenantID + "\x00" + scope.WorkspaceID
+
+		if report, ok := cache.get(cacheKey, now); ok {
 			c.JSON(http.StatusOK, report)
 			return
 		}
 
 		// Findings are scope-filtered by the request-scope middleware, so the
-		// store only returns the caller organization's findings. ListFindingsAll
-		// is uncapped; triage (including the trustworthy ResolvedAt that MTTR
-		// depends on) is hydrated separately since the raw finding rows do not
-		// carry it.
-		reqCtx := c.Request.Context()
+		// store only returns the caller's tenant+workspace findings.
+		// ListFindingsAll is uncapped; triage (including the trustworthy
+		// ResolvedAt that MTTR depends on) is hydrated separately since the raw
+		// finding rows do not carry it.
 		findings, err := svc.Store.ListFindingsAll(reqCtx)
 		if err != nil {
 			if logger != nil {
@@ -110,7 +131,7 @@ func executiveReportHandler(logger *zap.Logger, svc *Service, cache *executiveRe
 			OrganizationID: orgID,
 			Now:            clock,
 		})
-		cache.set(orgID, report, now)
+		cache.set(cacheKey, report, now)
 		c.JSON(http.StatusOK, report)
 	}
 }

--- a/internal/api/enterprise_report_routes.go
+++ b/internal/api/enterprise_report_routes.go
@@ -68,21 +68,22 @@ func (c *executiveReportCache) set(key string, report enterprise.ExecutiveReport
 	c.entries[key] = cachedExecutiveReport{report: report, expiresAt: now.Add(c.ttl)}
 }
 
-// maxOrgReportWorkspaces bounds how many workspaces the executive report will
-// aggregate. It is far above any realistic per-organization workspace count;
-// it exists only so a pathological tenant cannot make one request unbounded.
-const maxOrgReportWorkspaces = 1000
-
-// organizationWorkspaceIDs returns every workspace in the caller's tenant so
-// the report covers the whole organization. The caller's active workspace is
-// always included so deployments that never registered tenancy workspace rows
-// (e.g. single-workspace/default mode) still produce a non-empty report.
-func organizationWorkspaceIDs(ctx context.Context, svc *Service, scope db.Scope) ([]string, error) {
-	workspaces, err := svc.Store.ListWorkspaces(ctx, maxOrgReportWorkspaces)
+// authorizedReportWorkspaceIDs returns the workspaces whose findings the caller
+// may aggregate into the organization report: exactly the workspaces in the
+// organization (tenant) where the user holds an active membership. This is the
+// authorization boundary — a workspace-scoped member must never pull findings
+// from workspaces they do not belong to, even though the central route check
+// only authorizes enterprise.read for their active workspace.
+//
+// The caller's active workspace is always included: the route check already
+// authorized it, and deployments that never wrote tenancy membership rows
+// (single-workspace/default mode) must still produce a non-empty report.
+func authorizedReportWorkspaceIDs(ctx context.Context, svc *Service, userUUID string, scope db.Scope) ([]string, error) {
+	memberships, err := svc.Store.ListWorkspaceMembershipsByUserUUIDAndTenantID(ctx, userUUID, scope.TenantID)
 	if err != nil {
 		return nil, err
 	}
-	ordered := make([]string, 0, len(workspaces)+1)
+	ordered := make([]string, 0, len(memberships)+1)
 	seen := map[string]struct{}{}
 	add := func(id string) {
 		id = strings.TrimSpace(id)
@@ -95,8 +96,8 @@ func organizationWorkspaceIDs(ctx context.Context, svc *Service, scope db.Scope)
 		seen[id] = struct{}{}
 		ordered = append(ordered, id)
 	}
-	for _, ws := range workspaces {
-		add(ws.WorkspaceID)
+	for _, m := range memberships {
+		add(m.WorkspaceID)
 	}
 	add(scope.WorkspaceID)
 	return ordered, nil
@@ -141,13 +142,14 @@ func executiveReportHandler(logger *zap.Logger, svc *Service, cache *executiveRe
 			return
 		}
 
-		// An executive report covers the whole organization, but findings are
-		// stored per workspace. Enumerate every workspace in the tenant and
-		// aggregate, rather than reporting only the caller's active workspace.
-		workspaceIDs, err := organizationWorkspaceIDs(reqCtx, svc, scope)
+		// An executive report covers the organization, but findings are stored
+		// per workspace. Aggregate across the workspaces the caller is actually
+		// a member of — never every workspace in the tenant — so the report
+		// cannot expose findings from workspaces the user is not authorized for.
+		workspaceIDs, err := authorizedReportWorkspaceIDs(reqCtx, svc, strings.TrimSpace(current.Session.UserID), scope)
 		if err != nil {
 			if logger != nil {
-				logger.Error("list workspaces for executive report", telemetry.ZapError(err))
+				logger.Error("resolve authorized workspaces for executive report", telemetry.ZapError(err))
 			}
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build executive report"})
 			return

--- a/internal/api/enterprise_report_routes.go
+++ b/internal/api/enterprise_report_routes.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/identrail/identrail/internal/enterprise"
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+// executiveReportCacheTTL bounds how long a built executive report is reused
+// for one organization. Leadership dashboards refresh frequently; a short
+// window keeps the response fresh without re-scanning every finding per click.
+const executiveReportCacheTTL = 60 * time.Second
+
+type cachedExecutiveReport struct {
+	report    enterprise.ExecutiveReport
+	expiresAt time.Time
+}
+
+// executiveReportCache memoizes the per-organization executive report for a
+// short TTL. Entries are keyed strictly by organization id and are never
+// shared across organizations, so the cache cannot leak one tenant's posture
+// into another's response.
+type executiveReportCache struct {
+	mu      sync.Mutex
+	ttl     time.Duration
+	entries map[string]cachedExecutiveReport
+}
+
+func newExecutiveReportCache(ttl time.Duration) *executiveReportCache {
+	return &executiveReportCache{ttl: ttl, entries: map[string]cachedExecutiveReport{}}
+}
+
+func (c *executiveReportCache) get(orgID string, now time.Time) (enterprise.ExecutiveReport, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[orgID]
+	if !ok || !now.Before(entry.expiresAt) {
+		return enterprise.ExecutiveReport{}, false
+	}
+	return entry.report, true
+}
+
+func (c *executiveReportCache) set(orgID string, report enterprise.ExecutiveReport, now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[orgID] = cachedExecutiveReport{report: report, expiresAt: now.Add(c.ttl)}
+}
+
+func registerExecutiveReportRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service) {
+	if svc == nil {
+		return
+	}
+	cache := newExecutiveReportCache(executiveReportCacheTTL)
+	v1.GET("/enterprise/reports/executive", executiveReportHandler(logger, svc, cache))
+}
+
+func executiveReportHandler(logger *zap.Logger, svc *Service, cache *executiveReportCache) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		current, ok := requireEnterpriseSession(c)
+		if !ok {
+			return
+		}
+		orgID := strings.TrimSpace(current.Session.CurrentOrgID)
+		if orgID == "" {
+			c.JSON(http.StatusForbidden, gin.H{"error": "org context required"})
+			return
+		}
+
+		clock := svc.Now
+		if clock == nil {
+			clock = time.Now
+		}
+		now := clock()
+
+		if report, ok := cache.get(orgID, now); ok {
+			c.JSON(http.StatusOK, report)
+			return
+		}
+
+		// Findings are scope-filtered by the request-scope middleware, so the
+		// store only returns the caller organization's findings. ListFindingsAll
+		// is uncapped; triage (including the trustworthy ResolvedAt that MTTR
+		// depends on) is hydrated separately since the raw finding rows do not
+		// carry it.
+		reqCtx := c.Request.Context()
+		findings, err := svc.Store.ListFindingsAll(reqCtx)
+		if err != nil {
+			if logger != nil {
+				logger.Error("list findings for executive report", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build executive report"})
+			return
+		}
+		findings, err = svc.applyFindingTriageStates(reqCtx, findings)
+		if err != nil {
+			if logger != nil {
+				logger.Error("hydrate triage for executive report", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build executive report"})
+			return
+		}
+
+		report := enterprise.BuildExecutiveReport(findings, enterprise.ReportOptions{
+			OrganizationID: orgID,
+			Now:            clock,
+		})
+		cache.set(orgID, report, now)
+		c.JSON(http.StatusOK, report)
+	}
+}

--- a/internal/api/enterprise_report_routes.go
+++ b/internal/api/enterprise_report_routes.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -103,6 +104,16 @@ func authorizedReportWorkspaceIDs(ctx context.Context, svc *Service, userUUID st
 	return ordered, nil
 }
 
+// executiveReportCacheKey derives a cache key from the tenant and the exact
+// set of workspaces the report was built from. Sorting makes the key stable
+// regardless of resolution order, and including the set guarantees a caller
+// can only read a cached report built from the same authorized scope.
+func executiveReportCacheKey(tenantID string, workspaceIDs []string) string {
+	sorted := append([]string(nil), workspaceIDs...)
+	sort.Strings(sorted)
+	return tenantID + "\x00" + strings.Join(sorted, "\x1f")
+}
+
 func registerExecutiveReportRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service) {
 	if svc == nil {
 		return
@@ -129,29 +140,32 @@ func executiveReportHandler(logger *zap.Logger, svc *Service, cache *executiveRe
 		}
 		now := clock()
 
-		// The report is organization-wide. The request scope's tenant id is the
-		// organization (session sets tenant_id from CurrentOrgID), so the cache
-		// is keyed by tenant: every workspace in the org shares one org-wide
-		// snapshot and cannot see a partial, workspace-scoped one.
 		reqCtx := c.Request.Context()
 		scope := db.ScopeFromContext(reqCtx)
-		cacheKey := scope.TenantID
-
-		if report, ok := cache.get(cacheKey, now); ok {
-			c.JSON(http.StatusOK, report)
-			return
-		}
 
 		// An executive report covers the organization, but findings are stored
 		// per workspace. Aggregate across the workspaces the caller is actually
 		// a member of — never every workspace in the tenant — so the report
 		// cannot expose findings from workspaces the user is not authorized for.
+		// This is resolved before the cache lookup because the report content
+		// depends on the authorized set, so it must be part of the cache key.
 		workspaceIDs, err := authorizedReportWorkspaceIDs(reqCtx, svc, strings.TrimSpace(current.Session.UserID), scope)
 		if err != nil {
 			if logger != nil {
 				logger.Error("resolve authorized workspaces for executive report", telemetry.ZapError(err))
 			}
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build executive report"})
+			return
+		}
+
+		// Key the cache by tenant + the exact authorized workspace set. Two
+		// callers with the same membership set legitimately share one report;
+		// a narrower-access caller can never receive a broader caller's cached
+		// data, because their key differs.
+		cacheKey := executiveReportCacheKey(scope.TenantID, workspaceIDs)
+
+		if report, ok := cache.get(cacheKey, now); ok {
+			c.JSON(http.StatusOK, report)
 			return
 		}
 

--- a/internal/api/enterprise_report_routes_test.go
+++ b/internal/api/enterprise_report_routes_test.go
@@ -262,6 +262,8 @@ func TestExecutiveReportCache_EvictsExpiredEntries(t *testing.T) {
 	}
 }
 
+const execReportTestUser = "11111111-1111-1111-1111-111111111111"
+
 func seedExecReportWorkspace(t *testing.T, store db.Store, tenant, ws string) {
 	t.Helper()
 	tenantCtx := db.WithScope(context.Background(), db.Scope{TenantID: tenant, WorkspaceID: ws})
@@ -273,6 +275,23 @@ func seedExecReportWorkspace(t *testing.T, store db.Store, tenant, ws string) {
 	}
 }
 
+// seedExecReportMembership grants the test user an active membership in one
+// workspace so the org report is authorized to aggregate it.
+func seedExecReportMembership(t *testing.T, store db.Store, tenant, ws string) {
+	t.Helper()
+	ctx := db.WithScope(context.Background(), db.Scope{TenantID: tenant, WorkspaceID: ws})
+	if err := store.UpsertWorkspaceMember(ctx, db.TenancyWorkspaceMember{
+		WorkspaceID: ws,
+		MemberID:    "member-" + ws,
+		UserID:      execReportTestUser,
+		UserUUID:    execReportTestUser,
+		Role:        "viewer",
+		Status:      "active",
+	}); err != nil {
+		t.Fatalf("seed membership %s/%s: %v", tenant, ws, err)
+	}
+}
+
 func TestExecutiveReport_AggregatesAcrossOrgWorkspaces(t *testing.T) {
 	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
 	clock := now
@@ -281,16 +300,24 @@ func TestExecutiveReport_AggregatesAcrossOrgWorkspaces(t *testing.T) {
 	const org = "org-shared"
 	seedExecReportWorkspace(t, store, org, "ws-1")
 	seedExecReportWorkspace(t, store, org, "ws-2")
+	seedExecReportWorkspace(t, store, org, "ws-3")
+	// The caller is a member of ws-1 and ws-2 only.
+	seedExecReportMembership(t, store, org, "ws-1")
+	seedExecReportMembership(t, store, org, "ws-2")
 
 	ws1Scope := db.Scope{TenantID: org, WorkspaceID: "ws-1"}
 	ws2Scope := db.Scope{TenantID: org, WorkspaceID: "ws-2"}
+	ws3Scope := db.Scope{TenantID: org, WorkspaceID: "ws-3"}
 	scan1 := seedExecReportScan(t, store, ws1Scope, now.Add(-2*24*time.Hour))
 	seedExecReportFinding(t, store, ws1Scope, scan1, "f1", domain.SeverityHigh, domain.FindingOverPrivileged, now.Add(-1*24*time.Hour), nil)
 	scan2 := seedExecReportScan(t, store, ws2Scope, now.Add(-2*24*time.Hour))
 	seedExecReportFinding(t, store, ws2Scope, scan2, "f2", domain.SeverityCritical, domain.FindingEscalationPath, now.Add(-1*24*time.Hour), nil)
+	// ws-3 has a finding but the caller is NOT a member — it must be excluded.
+	scan3 := seedExecReportScan(t, store, ws3Scope, now.Add(-2*24*time.Hour))
+	seedExecReportFinding(t, store, ws3Scope, scan3, "f-secret", domain.SeverityCritical, domain.FindingStaleIdentity, now.Add(-1*24*time.Hour), nil)
 
 	// One shared Service (one cache). The caller's active workspace is ws-1,
-	// but the report must cover the whole organization.
+	// but the report must cover every workspace the caller belongs to.
 	svc := NewService(store, routerScanner{}, "aws")
 	svc.Now = func() time.Time { return clock }
 	r := gin.New()
@@ -309,7 +336,7 @@ func TestExecutiveReport_AggregatesAcrossOrgWorkspaces(t *testing.T) {
 		t.Fatalf("decode: %v", err)
 	}
 	if rep.TotalOpenFindings != 2 {
-		t.Fatalf("report must aggregate across all org workspaces; want 2, got %d", rep.TotalOpenFindings)
+		t.Fatalf("report must aggregate the caller's member workspaces (ws-1,ws-2) and exclude the non-member ws-3; want 2, got %d", rep.TotalOpenFindings)
 	}
 
 	// Add a finding in ws-2 and call again within the TTL: the org-wide cache

--- a/internal/api/enterprise_report_routes_test.go
+++ b/internal/api/enterprise_report_routes_test.go
@@ -275,21 +275,27 @@ func seedExecReportWorkspace(t *testing.T, store db.Store, tenant, ws string) {
 	}
 }
 
-// seedExecReportMembership grants the test user an active membership in one
-// workspace so the org report is authorized to aggregate it.
-func seedExecReportMembership(t *testing.T, store db.Store, tenant, ws string) {
+// seedExecReportMembershipFor grants one user an active membership in a
+// workspace so the org report is authorized to aggregate it for that user.
+func seedExecReportMembershipFor(t *testing.T, store db.Store, tenant, ws, userUUID string) {
 	t.Helper()
 	ctx := db.WithScope(context.Background(), db.Scope{TenantID: tenant, WorkspaceID: ws})
 	if err := store.UpsertWorkspaceMember(ctx, db.TenancyWorkspaceMember{
 		WorkspaceID: ws,
-		MemberID:    "member-" + ws,
-		UserID:      execReportTestUser,
-		UserUUID:    execReportTestUser,
+		MemberID:    "member-" + ws + "-" + userUUID,
+		UserID:      userUUID,
+		UserUUID:    userUUID,
 		Role:        "viewer",
 		Status:      "active",
 	}); err != nil {
-		t.Fatalf("seed membership %s/%s: %v", tenant, ws, err)
+		t.Fatalf("seed membership %s/%s for %s: %v", tenant, ws, userUUID, err)
 	}
+}
+
+// seedExecReportMembership grants the default test user an active membership.
+func seedExecReportMembership(t *testing.T, store db.Store, tenant, ws string) {
+	t.Helper()
+	seedExecReportMembershipFor(t, store, tenant, ws, execReportTestUser)
 }
 
 func TestExecutiveReport_AggregatesAcrossOrgWorkspaces(t *testing.T) {
@@ -361,5 +367,67 @@ func TestExecutiveReport_AggregatesAcrossOrgWorkspaces(t *testing.T) {
 	}
 	if freshRep.TotalOpenFindings != 3 {
 		t.Fatalf("after TTL the org-wide report must rebuild; want 3, got %d", freshRep.TotalOpenFindings)
+	}
+}
+
+func TestExecutiveReport_CacheKeyIsolatesByAuthorizedWorkspaceSet(t *testing.T) {
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	clock := now
+	store := db.NewMemoryStore()
+
+	const org = "org-shared"
+	const userBroad = "11111111-1111-1111-1111-111111111111"
+	const userNarrow = "22222222-2222-2222-2222-222222222222"
+	seedExecReportWorkspace(t, store, org, "ws-1")
+	seedExecReportWorkspace(t, store, org, "ws-2")
+	// Broad user belongs to ws-1 + ws-2; narrow user only ws-1.
+	seedExecReportMembershipFor(t, store, org, "ws-1", userBroad)
+	seedExecReportMembershipFor(t, store, org, "ws-2", userBroad)
+	seedExecReportMembershipFor(t, store, org, "ws-1", userNarrow)
+
+	ws1Scope := db.Scope{TenantID: org, WorkspaceID: "ws-1"}
+	ws2Scope := db.Scope{TenantID: org, WorkspaceID: "ws-2"}
+	scan1 := seedExecReportScan(t, store, ws1Scope, now.Add(-2*24*time.Hour))
+	seedExecReportFinding(t, store, ws1Scope, scan1, "f1", domain.SeverityHigh, domain.FindingOverPrivileged, now.Add(-1*24*time.Hour), nil)
+	scan2 := seedExecReportScan(t, store, ws2Scope, now.Add(-2*24*time.Hour))
+	seedExecReportFinding(t, store, ws2Scope, scan2, "f2", domain.SeverityCritical, domain.FindingEscalationPath, now.Add(-1*24*time.Hour), nil)
+
+	// One shared Service => one shared cache. The active workspace (and thus
+	// request scope) is ws-1 for both users; only the session user differs.
+	svc := NewService(store, routerScanner{}, "aws")
+	svc.Now = func() time.Time { return clock }
+	sessionUser := userBroad
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Request = c.Request.WithContext(db.WithScope(c.Request.Context(), ws1Scope))
+		c.Set("auth.session", sessionauth.CurrentSession{
+			Session: db.Session{UserID: sessionUser, CurrentOrgID: org, CurrentWorkspaceID: "ws-1"},
+		})
+	})
+	v1 := r.Group("/v1")
+	registerExecutiveReportRoutes(v1, nil, svc)
+
+	// Broad user primes the cache (sees ws-1 + ws-2 => 2 open).
+	sessionUser = userBroad
+	wBroad := doJSON(t, r, http.MethodGet, "/v1/enterprise/reports/executive", nil)
+	var repBroad enterprise.ExecutiveReport
+	if err := json.Unmarshal(wBroad.Body.Bytes(), &repBroad); err != nil {
+		t.Fatalf("decode broad: %v", err)
+	}
+	if repBroad.TotalOpenFindings != 2 {
+		t.Fatalf("broad user must see ws-1+ws-2; want 2, got %d", repBroad.TotalOpenFindings)
+	}
+
+	// Narrow user calls within the TTL: must NOT receive the broad cached
+	// report; only ws-1 (1 open). This is the cache-key authorization boundary.
+	sessionUser = userNarrow
+	clock = now.Add(10 * time.Second)
+	wNarrow := doJSON(t, r, http.MethodGet, "/v1/enterprise/reports/executive", nil)
+	var repNarrow enterprise.ExecutiveReport
+	if err := json.Unmarshal(wNarrow.Body.Bytes(), &repNarrow); err != nil {
+		t.Fatalf("decode narrow: %v", err)
+	}
+	if repNarrow.TotalOpenFindings != 1 {
+		t.Fatalf("narrow user must not receive broad user's cached report; want 1, got %d", repNarrow.TotalOpenFindings)
 	}
 }

--- a/internal/api/enterprise_report_routes_test.go
+++ b/internal/api/enterprise_report_routes_test.go
@@ -262,46 +262,77 @@ func TestExecutiveReportCache_EvictsExpiredEntries(t *testing.T) {
 	}
 }
 
-func TestExecutiveReport_IsolatesWorkspacesWithinSameOrg(t *testing.T) {
+func seedExecReportWorkspace(t *testing.T, store db.Store, tenant, ws string) {
+	t.Helper()
+	tenantCtx := db.WithScope(context.Background(), db.Scope{TenantID: tenant, WorkspaceID: ws})
+	if err := store.UpsertOrganization(tenantCtx, db.TenancyOrganization{DisplayName: tenant, Slug: tenant}); err != nil {
+		t.Fatalf("seed org %s: %v", tenant, err)
+	}
+	if err := store.UpsertWorkspace(tenantCtx, db.TenancyWorkspace{WorkspaceID: ws, DisplayName: ws, Slug: ws}); err != nil {
+		t.Fatalf("seed workspace %s/%s: %v", tenant, ws, err)
+	}
+}
+
+func TestExecutiveReport_AggregatesAcrossOrgWorkspaces(t *testing.T) {
 	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
 	clock := now
 	store := db.NewMemoryStore()
 
-	wsScope := func(ws string) db.Scope { return db.Scope{TenantID: "org-shared", WorkspaceID: ws} }
-	rig := func(ws string) *gin.Engine {
-		svc := NewService(store, routerScanner{}, "aws")
-		svc.Now = func() time.Time { return clock }
-		r := gin.New()
-		r.Use(func(c *gin.Context) {
-			c.Request = c.Request.WithContext(db.WithScope(c.Request.Context(), wsScope(ws)))
-			c.Set("auth.session", sessionauth.CurrentSession{
-				Session: db.Session{UserID: "11111111-1111-1111-1111-111111111111", CurrentOrgID: "org-shared", CurrentWorkspaceID: ws},
-			})
+	const org = "org-shared"
+	seedExecReportWorkspace(t, store, org, "ws-1")
+	seedExecReportWorkspace(t, store, org, "ws-2")
+
+	ws1Scope := db.Scope{TenantID: org, WorkspaceID: "ws-1"}
+	ws2Scope := db.Scope{TenantID: org, WorkspaceID: "ws-2"}
+	scan1 := seedExecReportScan(t, store, ws1Scope, now.Add(-2*24*time.Hour))
+	seedExecReportFinding(t, store, ws1Scope, scan1, "f1", domain.SeverityHigh, domain.FindingOverPrivileged, now.Add(-1*24*time.Hour), nil)
+	scan2 := seedExecReportScan(t, store, ws2Scope, now.Add(-2*24*time.Hour))
+	seedExecReportFinding(t, store, ws2Scope, scan2, "f2", domain.SeverityCritical, domain.FindingEscalationPath, now.Add(-1*24*time.Hour), nil)
+
+	// One shared Service (one cache). The caller's active workspace is ws-1,
+	// but the report must cover the whole organization.
+	svc := NewService(store, routerScanner{}, "aws")
+	svc.Now = func() time.Time { return clock }
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Request = c.Request.WithContext(db.WithScope(c.Request.Context(), ws1Scope))
+		c.Set("auth.session", sessionauth.CurrentSession{
+			Session: db.Session{UserID: "11111111-1111-1111-1111-111111111111", CurrentOrgID: org, CurrentWorkspaceID: "ws-1"},
 		})
-		v1 := r.Group("/v1")
-		registerExecutiveReportRoutes(v1, nil, svc)
-		return r
+	})
+	v1 := r.Group("/v1")
+	registerExecutiveReportRoutes(v1, nil, svc)
+
+	first := doJSON(t, r, http.MethodGet, "/v1/enterprise/reports/executive", nil)
+	var rep enterprise.ExecutiveReport
+	if err := json.Unmarshal(first.Body.Bytes(), &rep); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if rep.TotalOpenFindings != 2 {
+		t.Fatalf("report must aggregate across all org workspaces; want 2, got %d", rep.TotalOpenFindings)
 	}
 
-	scanID := seedExecReportScan(t, store, wsScope("ws-1"), now.Add(-2*24*time.Hour))
-	seedExecReportFinding(t, store, wsScope("ws-1"), scanID, "f1", domain.SeverityHigh, domain.FindingOverPrivileged, now.Add(-1*24*time.Hour), nil)
+	// Add a finding in ws-2 and call again within the TTL: the org-wide cache
+	// (one entry keyed by tenant) must return the prior snapshot.
+	seedExecReportFinding(t, store, ws2Scope, scan2, "f3", domain.SeverityMedium, domain.FindingStaleIdentity, now.Add(-12*time.Hour), nil)
+	clock = now.Add(30 * time.Second)
+	cached := doJSON(t, r, http.MethodGet, "/v1/enterprise/reports/executive", nil)
+	var cachedRep enterprise.ExecutiveReport
+	if err := json.Unmarshal(cached.Body.Bytes(), &cachedRep); err != nil {
+		t.Fatalf("decode cached: %v", err)
+	}
+	if cachedRep.TotalOpenFindings != 2 {
+		t.Fatalf("within TTL the shared org cache must be served; want 2, got %d", cachedRep.TotalOpenFindings)
+	}
 
-	// ws-1 sees its finding; ws-2 in the same org must not get ws-1's report.
-	w1 := doJSON(t, rig("ws-1"), http.MethodGet, "/v1/enterprise/reports/executive", nil)
-	var rep1 enterprise.ExecutiveReport
-	if err := json.Unmarshal(w1.Body.Bytes(), &rep1); err != nil {
-		t.Fatalf("decode ws-1: %v", err)
+	// Past the TTL the org-wide report rebuilds and reflects every workspace.
+	clock = now.Add(61 * time.Second)
+	fresh := doJSON(t, r, http.MethodGet, "/v1/enterprise/reports/executive", nil)
+	var freshRep enterprise.ExecutiveReport
+	if err := json.Unmarshal(fresh.Body.Bytes(), &freshRep); err != nil {
+		t.Fatalf("decode fresh: %v", err)
 	}
-	if rep1.TotalOpenFindings != 1 {
-		t.Fatalf("ws-1 should see its finding; got %d", rep1.TotalOpenFindings)
-	}
-
-	w2 := doJSON(t, rig("ws-2"), http.MethodGet, "/v1/enterprise/reports/executive", nil)
-	var rep2 enterprise.ExecutiveReport
-	if err := json.Unmarshal(w2.Body.Bytes(), &rep2); err != nil {
-		t.Fatalf("decode ws-2: %v", err)
-	}
-	if rep2.TotalOpenFindings != 0 {
-		t.Fatalf("ws-2 must not receive ws-1's cached report within the same org; got %d", rep2.TotalOpenFindings)
+	if freshRep.TotalOpenFindings != 3 {
+		t.Fatalf("after TTL the org-wide report must rebuild; want 3, got %d", freshRep.TotalOpenFindings)
 	}
 }

--- a/internal/api/enterprise_report_routes_test.go
+++ b/internal/api/enterprise_report_routes_test.go
@@ -1,0 +1,231 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	sessionauth "github.com/identrail/identrail/internal/api/auth"
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/enterprise"
+)
+
+func execReportScope(org string) db.Scope {
+	return db.Scope{TenantID: org, WorkspaceID: org}
+}
+
+func seedExecReportScan(t *testing.T, store db.Store, scope db.Scope, startedAt time.Time) string {
+	t.Helper()
+	scan, err := store.CreateScan(db.WithScope(context.Background(), scope), "aws", startedAt)
+	if err != nil {
+		t.Fatalf("create scan: %v", err)
+	}
+	return scan.ID
+}
+
+func seedExecReportFinding(t *testing.T, store db.Store, scope db.Scope, scanID, id string, sev domain.FindingSeverity, typ domain.FindingType, createdAt time.Time, resolvedAt *time.Time) {
+	t.Helper()
+	ctx := db.WithScope(context.Background(), scope)
+	if err := store.UpsertFindings(ctx, scanID, []domain.Finding{
+		{ID: id, ScanID: scanID, Type: typ, Severity: sev, Title: id, CreatedAt: createdAt},
+	}); err != nil {
+		t.Fatalf("seed finding %s: %v", id, err)
+	}
+	if resolvedAt != nil {
+		if err := store.UpsertFindingTriageState(ctx, db.FindingTriageState{
+			FindingID:  id,
+			Status:     domain.FindingLifecycleResolved,
+			ResolvedAt: resolvedAt,
+			UpdatedAt:  *resolvedAt,
+			UpdatedBy:  "subject:tester",
+		}); err != nil {
+			t.Fatalf("seed triage %s: %v", id, err)
+		}
+	}
+}
+
+// execReportRig builds a router whose injected middleware mirrors the
+// production session + scope wiring for a given organization.
+func execReportRig(t *testing.T, org string, clock *time.Time) (*Service, *gin.Engine, db.Store) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+	if clock != nil {
+		svc.Now = func() time.Time { return *clock }
+	}
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		ctx := db.WithScope(c.Request.Context(), execReportScope(org))
+		c.Request = c.Request.WithContext(ctx)
+		c.Set("auth.session", sessionauth.CurrentSession{
+			Session: db.Session{
+				UserID:             "11111111-1111-1111-1111-111111111111",
+				CurrentOrgID:       org,
+				CurrentWorkspaceID: org,
+			},
+		})
+	})
+	v1 := r.Group("/v1")
+	registerExecutiveReportRoutes(v1, nil, svc)
+	return svc, r, store
+}
+
+func TestExecutiveReport_RequiresSession(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+	r := gin.New()
+	v1 := r.Group("/v1")
+	registerExecutiveReportRoutes(v1, nil, svc)
+
+	w := doJSON(t, r, http.MethodGet, "/v1/enterprise/reports/executive", nil)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("missing session must be rejected; got %d", w.Code)
+	}
+}
+
+func TestExecutiveReport_RequiresOrgContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("auth.session", sessionauth.CurrentSession{
+			Session: db.Session{UserID: "11111111-1111-1111-1111-111111111111"},
+		})
+	})
+	v1 := r.Group("/v1")
+	registerExecutiveReportRoutes(v1, nil, svc)
+
+	w := doJSON(t, r, http.MethodGet, "/v1/enterprise/reports/executive", nil)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("empty org context must be rejected; got %d", w.Code)
+	}
+}
+
+func TestExecutiveReport_ReturnsReportWithMTTRFromResolvedAt(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	clock := now
+	svc, r, store := execReportRig(t, "org-a", &clock)
+
+	scope := execReportScope("org-a")
+	scanID := seedExecReportScan(t, store, scope, now.Add(-31*24*time.Hour))
+	seedExecReportFinding(t, store, scope, scanID, "f1", domain.SeverityHigh, domain.FindingOverPrivileged, now.Add(-3*24*time.Hour), nil)
+	seedExecReportFinding(t, store, scope, scanID, "f2", domain.SeverityCritical, domain.FindingEscalationPath, now.Add(-2*24*time.Hour), nil)
+	resolvedAt := now.Add(-1 * 24 * time.Hour)
+	seedExecReportFinding(t, store, scope, scanID, "f3", domain.SeverityMedium, domain.FindingStaleIdentity, now.Add(-3*24*time.Hour), &resolvedAt)
+
+	_ = svc
+	w := doJSON(t, r, http.MethodGet, "/v1/enterprise/reports/executive", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	var report enterprise.ExecutiveReport
+	if err := json.Unmarshal(w.Body.Bytes(), &report); err != nil {
+		t.Fatalf("decode report: %v", err)
+	}
+	if report.OrganizationID != "org-a" {
+		t.Errorf("organization_id: want org-a, got %q", report.OrganizationID)
+	}
+	if report.TotalOpenFindings != 2 {
+		t.Errorf("total open: want 2, got %d", report.TotalOpenFindings)
+	}
+	if report.MeanTimeToResolve == nil {
+		t.Fatal("expected MTTR from ResolvedAt data")
+	}
+	if report.MeanTimeToResolve.ResolvedCount != 1 {
+		t.Errorf("MTTR sample count: want 1, got %d", report.MeanTimeToResolve.ResolvedCount)
+	}
+	if want := (2 * 24 * time.Hour).Seconds(); report.MeanTimeToResolve.Seconds != want {
+		t.Errorf("MTTR seconds: want %v, got %v", want, report.MeanTimeToResolve.Seconds)
+	}
+}
+
+func TestExecutiveReport_CachesPerOrganizationWithinTTL(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	clock := now
+	_, r, store := execReportRig(t, "org-a", &clock)
+
+	scope := execReportScope("org-a")
+	scanID := seedExecReportScan(t, store, scope, now.Add(-2*24*time.Hour))
+	seedExecReportFinding(t, store, scope, scanID, "f1", domain.SeverityHigh, domain.FindingOverPrivileged, now.Add(-1*24*time.Hour), nil)
+
+	first := doJSON(t, r, http.MethodGet, "/v1/enterprise/reports/executive", nil)
+	if first.Code != http.StatusOK {
+		t.Fatalf("first call: got %d", first.Code)
+	}
+
+	// Mutate the store, then call again within the 60s window: the response
+	// must still be the cached one, proving the cache is consulted.
+	seedExecReportFinding(t, store, scope, scanID, "f2", domain.SeverityCritical, domain.FindingEscalationPath, now.Add(-12*time.Hour), nil)
+	clock = now.Add(30 * time.Second)
+	cached := doJSON(t, r, http.MethodGet, "/v1/enterprise/reports/executive", nil)
+	var cachedReport enterprise.ExecutiveReport
+	if err := json.Unmarshal(cached.Body.Bytes(), &cachedReport); err != nil {
+		t.Fatalf("decode cached: %v", err)
+	}
+	if cachedReport.TotalOpenFindings != 1 {
+		t.Errorf("within TTL the cached report must be returned; want 1 open, got %d", cachedReport.TotalOpenFindings)
+	}
+
+	// Past the TTL the report is rebuilt and reflects the mutation.
+	clock = now.Add(61 * time.Second)
+	fresh := doJSON(t, r, http.MethodGet, "/v1/enterprise/reports/executive", nil)
+	var freshReport enterprise.ExecutiveReport
+	if err := json.Unmarshal(fresh.Body.Bytes(), &freshReport); err != nil {
+		t.Fatalf("decode fresh: %v", err)
+	}
+	if freshReport.TotalOpenFindings != 2 {
+		t.Errorf("after TTL the report must rebuild; want 2 open, got %d", freshReport.TotalOpenFindings)
+	}
+}
+
+func TestExecutiveReport_IsolatesOrganizations(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	clock := now
+
+	// org-a has findings; org-b shares the same store but a different scope.
+	_, rA, store := execReportRig(t, "org-a", &clock)
+	scopeA := execReportScope("org-a")
+	scanID := seedExecReportScan(t, store, scopeA, now.Add(-2*24*time.Hour))
+	seedExecReportFinding(t, store, scopeA, scanID, "f1", domain.SeverityHigh, domain.FindingOverPrivileged, now.Add(-1*24*time.Hour), nil)
+
+	wA := doJSON(t, rA, http.MethodGet, "/v1/enterprise/reports/executive", nil)
+	var repA enterprise.ExecutiveReport
+	if err := json.Unmarshal(wA.Body.Bytes(), &repA); err != nil {
+		t.Fatalf("decode org-a: %v", err)
+	}
+	if repA.TotalOpenFindings != 1 {
+		t.Errorf("org-a should see its own finding; got %d", repA.TotalOpenFindings)
+	}
+
+	rB := gin.New()
+	rB.Use(func(c *gin.Context) {
+		ctx := db.WithScope(c.Request.Context(), execReportScope("org-b"))
+		c.Request = c.Request.WithContext(ctx)
+		c.Set("auth.session", sessionauth.CurrentSession{
+			Session: db.Session{UserID: "22222222-2222-2222-2222-222222222222", CurrentOrgID: "org-b", CurrentWorkspaceID: "org-b"},
+		})
+	})
+	svcB := NewService(store, routerScanner{}, "aws")
+	svcB.Now = func() time.Time { return clock }
+	v1B := rB.Group("/v1")
+	registerExecutiveReportRoutes(v1B, nil, svcB)
+
+	wB := doJSON(t, rB, http.MethodGet, "/v1/enterprise/reports/executive", nil)
+	var repB enterprise.ExecutiveReport
+	if err := json.Unmarshal(wB.Body.Bytes(), &repB); err != nil {
+		t.Fatalf("decode org-b: %v", err)
+	}
+	if repB.OrganizationID != "org-b" {
+		t.Errorf("org-b report mislabeled: %q", repB.OrganizationID)
+	}
+	if repB.TotalOpenFindings != 0 {
+		t.Errorf("org-b must not see org-a findings; got %d", repB.TotalOpenFindings)
+	}
+}

--- a/internal/api/enterprise_report_routes_test.go
+++ b/internal/api/enterprise_report_routes_test.go
@@ -48,6 +48,35 @@ func seedExecReportFinding(t *testing.T, store db.Store, scope db.Scope, scanID,
 	}
 }
 
+func seedExecReportRepoFinding(t *testing.T, store db.Store, scope db.Scope, repo, id string, sev domain.FindingSeverity, typ domain.FindingType, createdAt time.Time, resolvedAt *time.Time) {
+	t.Helper()
+	ctx := db.WithScope(context.Background(), scope)
+	repoScan, err := store.CreateRepoScan(ctx, repo, createdAt)
+	if err != nil {
+		t.Fatalf("create repo scan for %s: %v", id, err)
+	}
+	if err := store.UpsertRepoFindings(ctx, repoScan.ID, []domain.Finding{
+		{ID: id, ScanID: repoScan.ID, Type: typ, Severity: sev, Title: id, CreatedAt: createdAt},
+	}); err != nil {
+		t.Fatalf("seed repo finding %s: %v", id, err)
+	}
+	if resolvedAt != nil {
+		if err := store.UpsertFindingTriageState(ctx, db.FindingTriageState{
+			FindingID: findingTriageStateKey(domain.Finding{
+				ID:         id,
+				ScanID:     repoScan.ID,
+				Repository: repo,
+			}),
+			Status:     domain.FindingLifecycleResolved,
+			ResolvedAt: resolvedAt,
+			UpdatedAt:  *resolvedAt,
+			UpdatedBy:  "subject:tester",
+		}); err != nil {
+			t.Fatalf("seed repo triage %s: %v", id, err)
+		}
+	}
+}
+
 // execReportRig builds a router whose injected middleware mirrors the
 // production session + scope wiring for a given organization.
 func execReportRig(t *testing.T, org string, clock *time.Time) (*Service, *gin.Engine, db.Store) {
@@ -318,9 +347,13 @@ func TestExecutiveReport_AggregatesAcrossOrgWorkspaces(t *testing.T) {
 	seedExecReportFinding(t, store, ws1Scope, scan1, "f1", domain.SeverityHigh, domain.FindingOverPrivileged, now.Add(-1*24*time.Hour), nil)
 	scan2 := seedExecReportScan(t, store, ws2Scope, now.Add(-2*24*time.Hour))
 	seedExecReportFinding(t, store, ws2Scope, scan2, "f2", domain.SeverityCritical, domain.FindingEscalationPath, now.Add(-1*24*time.Hour), nil)
+	seedExecReportRepoFinding(t, store, ws2Scope, "owner/repo-allowed", "repo-f1", domain.SeverityMedium, domain.FindingSecretExposure, now.Add(-6*time.Hour), nil)
+	repoResolvedAt := now.Add(-12 * time.Hour)
+	seedExecReportRepoFinding(t, store, ws2Scope, "owner/repo-allowed", "repo-resolved", domain.SeverityLow, domain.FindingRepoMisconfig, now.Add(-36*time.Hour), &repoResolvedAt)
 	// ws-3 has a finding but the caller is NOT a member — it must be excluded.
 	scan3 := seedExecReportScan(t, store, ws3Scope, now.Add(-2*24*time.Hour))
 	seedExecReportFinding(t, store, ws3Scope, scan3, "f-secret", domain.SeverityCritical, domain.FindingStaleIdentity, now.Add(-1*24*time.Hour), nil)
+	seedExecReportRepoFinding(t, store, ws3Scope, "owner/repo-secret", "repo-secret", domain.SeverityCritical, domain.FindingSecretExposure, now.Add(-6*time.Hour), nil)
 
 	// One shared Service (one cache). The caller's active workspace is ws-1,
 	// but the report must cover every workspace the caller belongs to.
@@ -341,8 +374,14 @@ func TestExecutiveReport_AggregatesAcrossOrgWorkspaces(t *testing.T) {
 	if err := json.Unmarshal(first.Body.Bytes(), &rep); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if rep.TotalOpenFindings != 2 {
-		t.Fatalf("report must aggregate the caller's member workspaces (ws-1,ws-2) and exclude the non-member ws-3; want 2, got %d", rep.TotalOpenFindings)
+	if rep.TotalOpenFindings != 3 {
+		t.Fatalf("report must aggregate identity and repo findings from the caller's member workspaces (ws-1,ws-2) and exclude non-member ws-3; want 3, got %d", rep.TotalOpenFindings)
+	}
+	if rep.OpenByType[domain.FindingSecretExposure] != 1 {
+		t.Fatalf("authorized repo findings must be included in type rollups; want 1 secret exposure, got %d", rep.OpenByType[domain.FindingSecretExposure])
+	}
+	if rep.MeanTimeToResolve == nil || rep.MeanTimeToResolve.ResolvedCount != 1 {
+		t.Fatalf("authorized resolved repo findings must contribute to MTTR; got %+v", rep.MeanTimeToResolve)
 	}
 
 	// Add a finding in ws-2 and call again within the TTL: the org-wide cache
@@ -354,8 +393,8 @@ func TestExecutiveReport_AggregatesAcrossOrgWorkspaces(t *testing.T) {
 	if err := json.Unmarshal(cached.Body.Bytes(), &cachedRep); err != nil {
 		t.Fatalf("decode cached: %v", err)
 	}
-	if cachedRep.TotalOpenFindings != 2 {
-		t.Fatalf("within TTL the shared org cache must be served; want 2, got %d", cachedRep.TotalOpenFindings)
+	if cachedRep.TotalOpenFindings != 3 {
+		t.Fatalf("within TTL the shared org cache must be served; want 3, got %d", cachedRep.TotalOpenFindings)
 	}
 
 	// Past the TTL the org-wide report rebuilds and reflects every workspace.
@@ -365,8 +404,8 @@ func TestExecutiveReport_AggregatesAcrossOrgWorkspaces(t *testing.T) {
 	if err := json.Unmarshal(fresh.Body.Bytes(), &freshRep); err != nil {
 		t.Fatalf("decode fresh: %v", err)
 	}
-	if freshRep.TotalOpenFindings != 3 {
-		t.Fatalf("after TTL the org-wide report must rebuild; want 3, got %d", freshRep.TotalOpenFindings)
+	if freshRep.TotalOpenFindings != 4 {
+		t.Fatalf("after TTL the org-wide report must rebuild; want 4, got %d", freshRep.TotalOpenFindings)
 	}
 }
 

--- a/internal/api/enterprise_report_routes_test.go
+++ b/internal/api/enterprise_report_routes_test.go
@@ -229,3 +229,79 @@ func TestExecutiveReport_IsolatesOrganizations(t *testing.T) {
 		t.Errorf("org-b must not see org-a findings; got %d", repB.TotalOpenFindings)
 	}
 }
+
+func TestExecutiveReportCache_EvictsExpiredEntries(t *testing.T) {
+	ttl := 60 * time.Second
+	cache := newExecutiveReportCache(ttl)
+	t0 := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+
+	cache.set("tenant-a\x00ws-a", enterprise.ExecutiveReport{OrganizationID: "a"}, t0)
+
+	// A stale entry must not be served, and the lookup itself evicts it.
+	if _, ok := cache.get("tenant-a\x00ws-a", t0.Add(ttl+time.Second)); ok {
+		t.Fatal("expired entry must not be served")
+	}
+	cache.mu.Lock()
+	if _, present := cache.entries["tenant-a\x00ws-a"]; present {
+		cache.mu.Unlock()
+		t.Fatal("expired entry must be evicted on stale get")
+	}
+	cache.mu.Unlock()
+
+	// A later write for a different scope sweeps any other expired entries so
+	// the map cannot grow without bound.
+	cache.set("tenant-a\x00ws-a", enterprise.ExecutiveReport{OrganizationID: "a"}, t0)
+	cache.set("tenant-b\x00ws-b", enterprise.ExecutiveReport{OrganizationID: "b"}, t0.Add(ttl+time.Second))
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	if _, present := cache.entries["tenant-a\x00ws-a"]; present {
+		t.Fatal("expired entry must be swept on the next set")
+	}
+	if len(cache.entries) != 1 {
+		t.Fatalf("cache must not retain expired entries; size=%d", len(cache.entries))
+	}
+}
+
+func TestExecutiveReport_IsolatesWorkspacesWithinSameOrg(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	clock := now
+	store := db.NewMemoryStore()
+
+	wsScope := func(ws string) db.Scope { return db.Scope{TenantID: "org-shared", WorkspaceID: ws} }
+	rig := func(ws string) *gin.Engine {
+		svc := NewService(store, routerScanner{}, "aws")
+		svc.Now = func() time.Time { return clock }
+		r := gin.New()
+		r.Use(func(c *gin.Context) {
+			c.Request = c.Request.WithContext(db.WithScope(c.Request.Context(), wsScope(ws)))
+			c.Set("auth.session", sessionauth.CurrentSession{
+				Session: db.Session{UserID: "11111111-1111-1111-1111-111111111111", CurrentOrgID: "org-shared", CurrentWorkspaceID: ws},
+			})
+		})
+		v1 := r.Group("/v1")
+		registerExecutiveReportRoutes(v1, nil, svc)
+		return r
+	}
+
+	scanID := seedExecReportScan(t, store, wsScope("ws-1"), now.Add(-2*24*time.Hour))
+	seedExecReportFinding(t, store, wsScope("ws-1"), scanID, "f1", domain.SeverityHigh, domain.FindingOverPrivileged, now.Add(-1*24*time.Hour), nil)
+
+	// ws-1 sees its finding; ws-2 in the same org must not get ws-1's report.
+	w1 := doJSON(t, rig("ws-1"), http.MethodGet, "/v1/enterprise/reports/executive", nil)
+	var rep1 enterprise.ExecutiveReport
+	if err := json.Unmarshal(w1.Body.Bytes(), &rep1); err != nil {
+		t.Fatalf("decode ws-1: %v", err)
+	}
+	if rep1.TotalOpenFindings != 1 {
+		t.Fatalf("ws-1 should see its finding; got %d", rep1.TotalOpenFindings)
+	}
+
+	w2 := doJSON(t, rig("ws-2"), http.MethodGet, "/v1/enterprise/reports/executive", nil)
+	var rep2 enterprise.ExecutiveReport
+	if err := json.Unmarshal(w2.Body.Bytes(), &rep2); err != nil {
+		t.Fatalf("decode ws-2: %v", err)
+	}
+	if rep2.TotalOpenFindings != 0 {
+		t.Fatalf("ws-2 must not receive ws-1's cached report within the same org; got %d", rep2.TotalOpenFindings)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -388,6 +388,10 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		registerNativeSAMLAdminRoutes(v1, logger, svc, nativeSAMLRouteOptions{
 			Enabled: opts.FeatureNativeSSO,
 		})
+		// Enterprise executive report depends on session auth to resolve the
+		// caller's organization; it is not SSO-specific, so it is gated on the
+		// new auth stack rather than the native-SSO flag.
+		registerExecutiveReportRoutes(v1, logger, svc)
 	}
 	registerTenancyRoutes(v1, logger, svc, opts.FeatureConnectorAWS, opts.FeatureConnectorGitHubV2)
 	registerKubernetesConnectionRoutes(v1, logger, svc, opts.FeatureConnectorK8S, opts.PublicBaseURL)

--- a/internal/db/memory_tenancy.go
+++ b/internal/db/memory_tenancy.go
@@ -381,6 +381,31 @@ func (m *MemoryStore) FindFirstWorkspaceMemberByUserUUIDAndTenantID(ctx context.
 	return selected, nil
 }
 
+// ListWorkspaceMembershipsByUserUUIDAndTenantID returns every active workspace
+// membership the user holds within one tenant. It is the authorization basis
+// for organization-wide reads: a caller may only aggregate data from the
+// workspaces they actually belong to.
+func (m *MemoryStore) ListWorkspaceMembershipsByUserUUIDAndTenantID(ctx context.Context, userUUID string, tenantID string) ([]TenancyWorkspaceMember, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	normalizedUserUUID := strings.TrimSpace(userUUID)
+	normalizedTenantID := strings.TrimSpace(tenantID)
+	if normalizedUserUUID == "" || normalizedTenantID == "" {
+		return []TenancyWorkspaceMember{}, nil
+	}
+	memberships := make([]TenancyWorkspaceMember, 0)
+	for _, member := range m.members {
+		if member.UserUUID != normalizedUserUUID || member.TenantID != normalizedTenantID || member.Status != "active" {
+			continue
+		}
+		memberships = append(memberships, member)
+	}
+	sort.Slice(memberships, func(i, j int) bool {
+		return memberships[i].WorkspaceID < memberships[j].WorkspaceID
+	})
+	return memberships, nil
+}
+
 // ListWorkspaceMembers returns members for one scoped workspace.
 func (m *MemoryStore) ListWorkspaceMembers(ctx context.Context, workspaceID string, limit int) ([]TenancyWorkspaceMember, error) {
 	m.mu.RLock()

--- a/internal/db/memory_tenancy_test.go
+++ b/internal/db/memory_tenancy_test.go
@@ -1013,3 +1013,67 @@ func TestMemoryStoreScheduledScanPolicyPaginationAndClaim(t *testing.T) {
 		t.Fatal("expected duplicate claim to be rejected")
 	}
 }
+
+func TestMemoryStoreListWorkspaceMembershipsByUserUUIDAndTenantID(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 5, 17, 10, 0, 0, 0, time.UTC)
+	userUUID := "11111111-1111-1111-1111-111111111111"
+	ctx := context.Background()
+
+	tenantA := WithScope(ctx, Scope{TenantID: "tenant-a", WorkspaceID: "ws-1"})
+	if err := store.UpsertOrganization(tenantA, TenancyOrganization{DisplayName: "Tenant A", Slug: "tenant-a"}); err != nil {
+		t.Fatalf("upsert org a: %v", err)
+	}
+	for _, ws := range []string{"ws-1", "ws-2", "ws-3"} {
+		wsCtx := WithScope(ctx, Scope{TenantID: "tenant-a", WorkspaceID: ws})
+		if err := store.UpsertWorkspace(wsCtx, TenancyWorkspace{WorkspaceID: ws, DisplayName: ws, Slug: ws}); err != nil {
+			t.Fatalf("upsert workspace %s: %v", ws, err)
+		}
+	}
+	// Active in ws-1 and ws-2, suspended in ws-3 (must be excluded).
+	for _, m := range []struct {
+		ws, status string
+	}{{"ws-1", "active"}, {"ws-2", "active"}, {"ws-3", "suspended"}} {
+		wsCtx := WithScope(ctx, Scope{TenantID: "tenant-a", WorkspaceID: m.ws})
+		if err := store.UpsertWorkspaceMember(wsCtx, TenancyWorkspaceMember{
+			WorkspaceID: m.ws, MemberID: "member-" + m.ws, UserID: "subject", UserUUID: userUUID,
+			Role: "viewer", Status: m.status, JoinedAt: now,
+		}); err != nil {
+			t.Fatalf("upsert member %s: %v", m.ws, err)
+		}
+	}
+	// Different tenant membership must never leak in.
+	tenantB := WithScope(ctx, Scope{TenantID: "tenant-b", WorkspaceID: "ws-b"})
+	if err := store.UpsertOrganization(tenantB, TenancyOrganization{DisplayName: "Tenant B", Slug: "tenant-b"}); err != nil {
+		t.Fatalf("upsert org b: %v", err)
+	}
+	if err := store.UpsertWorkspace(tenantB, TenancyWorkspace{WorkspaceID: "ws-b", DisplayName: "ws-b", Slug: "ws-b"}); err != nil {
+		t.Fatalf("upsert workspace b: %v", err)
+	}
+	if err := store.UpsertWorkspaceMember(tenantB, TenancyWorkspaceMember{
+		WorkspaceID: "ws-b", MemberID: "member-b", UserID: "subject", UserUUID: userUUID,
+		Role: "viewer", Status: "active", JoinedAt: now,
+	}); err != nil {
+		t.Fatalf("upsert member b: %v", err)
+	}
+
+	memberships, err := store.ListWorkspaceMembershipsByUserUUIDAndTenantID(ctx, userUUID, "tenant-a")
+	if err != nil {
+		t.Fatalf("list memberships: %v", err)
+	}
+	got := []string{}
+	for _, m := range memberships {
+		got = append(got, m.WorkspaceID)
+	}
+	if len(got) != 2 || got[0] != "ws-1" || got[1] != "ws-2" {
+		t.Fatalf("want active tenant-a memberships [ws-1 ws-2], got %v", got)
+	}
+
+	empty, err := store.ListWorkspaceMembershipsByUserUUIDAndTenantID(ctx, userUUID, "tenant-missing")
+	if err != nil {
+		t.Fatalf("missing tenant should not error: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("expected no memberships for unknown tenant, got %v", empty)
+	}
+}

--- a/internal/db/postgres_tenancy.go
+++ b/internal/db/postgres_tenancy.go
@@ -488,6 +488,58 @@ func (p *PostgresStore) FindFirstWorkspaceMemberByUserUUIDAndTenantID(ctx contex
 	return member, nil
 }
 
+// ListWorkspaceMembershipsByUserUUIDAndTenantID returns every active workspace
+// membership the user holds within one tenant. It is the authorization basis
+// for organization-wide reads: a caller may only aggregate data from the
+// workspaces they actually belong to. AnyScope is used because the lookup
+// spans every workspace in the tenant rather than one scoped workspace.
+func (p *PostgresStore) ListWorkspaceMembershipsByUserUUIDAndTenantID(ctx context.Context, userUUID string, tenantID string) ([]TenancyWorkspaceMember, error) {
+	normalizedUserUUID := strings.TrimSpace(userUUID)
+	normalizedTenantID := strings.TrimSpace(tenantID)
+	if normalizedUserUUID == "" || normalizedTenantID == "" {
+		return []TenancyWorkspaceMember{}, nil
+	}
+	rows, err := p.queryContextAnyScope(
+		ctx,
+		`SELECT tenant_id, workspace_id, member_id, user_id, COALESCE(user_uuid::text, ''), email, role, status, joined_at, updated_at
+		 FROM tenancy_workspace_members
+		 WHERE user_uuid = NULLIF($1, '')::uuid
+		   AND tenant_id = $2
+		   AND status = 'active'
+		 ORDER BY workspace_id ASC`,
+		normalizedUserUUID,
+		normalizedTenantID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	memberships := make([]TenancyWorkspaceMember, 0)
+	for rows.Next() {
+		var member TenancyWorkspaceMember
+		if err := rows.Scan(
+			&member.TenantID,
+			&member.WorkspaceID,
+			&member.MemberID,
+			&member.UserID,
+			&member.UserUUID,
+			&member.Email,
+			&member.Role,
+			&member.Status,
+			&member.JoinedAt,
+			&member.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		memberships = append(memberships, member)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return memberships, nil
+}
+
 // ListWorkspaceMembers lists members for one scoped workspace.
 func (p *PostgresStore) ListWorkspaceMembers(ctx context.Context, workspaceID string, limit int) ([]TenancyWorkspaceMember, error) {
 	scope, err := RequireScope(ctx)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2120,6 +2120,7 @@ type Store interface {
 	GetOnboardingState(ctx context.Context, userID string) (OnboardingState, error)
 	FindFirstWorkspaceMemberByUserUUID(ctx context.Context, userUUID string) (TenancyWorkspaceMember, error)
 	FindFirstWorkspaceMemberByUserUUIDAndTenantID(ctx context.Context, userUUID string, tenantID string) (TenancyWorkspaceMember, error)
+	ListWorkspaceMembershipsByUserUUIDAndTenantID(ctx context.Context, userUUID string, tenantID string) ([]TenancyWorkspaceMember, error)
 	CreateInvitation(ctx context.Context, invitation Invitation) (Invitation, error)
 	GetInvitation(ctx context.Context, orgID string, invitationID string) (Invitation, error)
 	ListInvitations(ctx context.Context, orgID string, limit int) ([]Invitation, error)

--- a/internal/enterprise/enterprise_test.go
+++ b/internal/enterprise/enterprise_test.go
@@ -644,4 +644,86 @@ func TestBuildExecutiveReport_EmptyInputIsSafe(t *testing.T) {
 	if report.TopFindingTypes != nil {
 		t.Errorf("top types must be nil when no findings, got %v", report.TopFindingTypes)
 	}
+	if report.MeanTimeToResolve != nil {
+		t.Errorf("MTTR must be omitted when there are no findings, got %+v", report.MeanTimeToResolve)
+	}
+}
+
+func TestBuildExecutiveReport_MTTRUsesResolvedAtOnly(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	findings := []domain.Finding{
+		// Resolved 2 days after creation — counted.
+		{
+			ID: "f1", Type: domain.FindingOverPrivileged, Severity: domain.SeverityHigh,
+			CreatedAt: now.Add(-10 * 24 * time.Hour),
+			Triage: domain.FindingTriage{
+				Status:     domain.FindingLifecycleResolved,
+				ResolvedAt: ptrTime(now.Add(-8 * 24 * time.Hour)),
+			},
+		},
+		// Resolved 4 days after creation — counted.
+		{
+			ID: "f2", Type: domain.FindingStaleIdentity, Severity: domain.SeverityMedium,
+			CreatedAt: now.Add(-9 * 24 * time.Hour),
+			Triage: domain.FindingTriage{
+				Status:     domain.FindingLifecycleResolved,
+				ResolvedAt: ptrTime(now.Add(-5 * 24 * time.Hour)),
+			},
+		},
+		// Resolved but only a mutable UpdatedAt — must NOT contribute.
+		{
+			ID: "f3", Type: domain.FindingEscalationPath, Severity: domain.SeverityCritical,
+			CreatedAt: now.Add(-30 * 24 * time.Hour),
+			Triage: domain.FindingTriage{
+				Status:    domain.FindingLifecycleResolved,
+				UpdatedAt: ptrTime(now.Add(-1 * 24 * time.Hour)),
+			},
+		},
+		// Open finding — irrelevant to MTTR.
+		{
+			ID: "f4", Type: domain.FindingOverPrivileged, Severity: domain.SeverityLow,
+			CreatedAt: now.Add(-2 * 24 * time.Hour),
+			Triage:    domain.FindingTriage{Status: domain.FindingLifecycleOpen},
+		},
+	}
+	report := BuildExecutiveReport(findings, ReportOptions{
+		OrganizationID: "org-1",
+		Now:            func() time.Time { return now },
+	})
+	if report.MeanTimeToResolve == nil {
+		t.Fatal("expected MTTR to be populated from ResolvedAt data")
+	}
+	if report.MeanTimeToResolve.ResolvedCount != 2 {
+		t.Errorf("MTTR sample count: want 2 (only ResolvedAt-bearing), got %d", report.MeanTimeToResolve.ResolvedCount)
+	}
+	want := (3 * 24 * time.Hour).Seconds() // mean of 2d and 4d
+	if report.MeanTimeToResolve.Seconds != want {
+		t.Errorf("MTTR seconds: want %v, got %v", want, report.MeanTimeToResolve.Seconds)
+	}
+}
+
+func TestBuildExecutiveReport_MTTROmittedWithoutResolvedAt(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	findings := []domain.Finding{
+		{
+			ID: "f1", Type: domain.FindingOverPrivileged, Severity: domain.SeverityHigh,
+			CreatedAt: now.Add(-3 * 24 * time.Hour),
+			Triage:    domain.FindingTriage{Status: domain.FindingLifecycleOpen},
+		},
+		{
+			ID: "f2", Type: domain.FindingEscalationPath, Severity: domain.SeverityCritical,
+			CreatedAt: now.Add(-20 * 24 * time.Hour),
+			Triage: domain.FindingTriage{
+				Status:    domain.FindingLifecycleResolved,
+				UpdatedAt: ptrTime(now.Add(-2 * 24 * time.Hour)),
+			},
+		},
+	}
+	report := BuildExecutiveReport(findings, ReportOptions{
+		OrganizationID: "org-1",
+		Now:            func() time.Time { return now },
+	})
+	if report.MeanTimeToResolve != nil {
+		t.Errorf("MTTR must be omitted when no resolved finding has ResolvedAt, got %+v", report.MeanTimeToResolve)
+	}
 }

--- a/internal/enterprise/report.go
+++ b/internal/enterprise/report.go
@@ -9,15 +9,15 @@ import (
 )
 
 // ExecutiveReport is a deterministic rollup of finding state suitable for
-// leadership consumption: open volume by severity, top finding types, and
-// week-over-week trend.
+// leadership consumption: open volume by severity, top finding types,
+// week-over-week trend, and mean time to resolve.
 //
-// MeanTimeToResolve is deliberately omitted from this first cut: the current
-// FindingTriage schema only records a `last-updated` timestamp that mutates on
-// every triage change (including comment-only and assignee edits), so deriving
-// a faithful MTTR requires a dedicated resolved-at timestamp or a lifecycle
-// history table. That work is tracked separately so the executive report
-// cannot silently surface a materially incorrect figure.
+// MeanTimeToResolve is derived strictly from the FindingTriage.ResolvedAt
+// timestamp, which is set only when a finding actually enters the resolved
+// state. The mutable UpdatedAt timestamp is never used, so the figure cannot
+// be skewed by comment-only or assignee edits. The field is omitted entirely
+// when no resolved finding carries a reliable ResolvedAt, so leadership never
+// sees a guessed number.
 type ExecutiveReport struct {
 	OrganizationID    string                         `json:"organization_id"`
 	GeneratedAt       time.Time                      `json:"generated_at"`
@@ -28,6 +28,15 @@ type ExecutiveReport struct {
 	OpenByType        map[domain.FindingType]int     `json:"open_by_type"`
 	TopFindingTypes   []TopFindingType               `json:"top_finding_types"`
 	WeekOverWeek      WeekOverWeekTrend              `json:"week_over_week"`
+	MeanTimeToResolve *MTTRSummary                   `json:"mean_time_to_resolve,omitempty"`
+}
+
+// MTTRSummary reports mean time to resolve across findings that carry a
+// trustworthy FindingTriage.ResolvedAt. Seconds is the mean of
+// (ResolvedAt - CreatedAt) over ResolvedCount findings.
+type MTTRSummary struct {
+	ResolvedCount int     `json:"resolved_count"`
+	Seconds       float64 `json:"seconds"`
 }
 
 // TopFindingType records the count of one finding type within the report
@@ -76,6 +85,8 @@ func BuildExecutiveReport(findings []domain.Finding, opts ReportOptions) Executi
 
 	currentWeek := 0
 	previousWeek := 0
+	var mttrTotal time.Duration
+	mttrCount := 0
 
 	for _, finding := range findings {
 		status := effectiveStatus(finding, now)
@@ -85,6 +96,18 @@ func BuildExecutiveReport(findings []domain.Finding, opts ReportOptions) Executi
 			report.TotalOpenFindings++
 			report.OpenBySeverity[finding.Severity]++
 			report.OpenByType[finding.Type]++
+		}
+
+		// MTTR uses only the trustworthy ResolvedAt timestamp; resolved
+		// findings without a reliable ResolvedAt are excluded rather than
+		// approximated from the mutable UpdatedAt.
+		if status == domain.FindingLifecycleResolved {
+			if resolvedAt := finding.Triage.ResolvedAt; resolvedAt != nil && !resolvedAt.IsZero() {
+				if c := finding.CreatedAt; !c.IsZero() && !resolvedAt.Before(c) {
+					mttrTotal += resolvedAt.Sub(c)
+					mttrCount++
+				}
+			}
 		}
 
 		created := finding.CreatedAt
@@ -105,6 +128,12 @@ func BuildExecutiveReport(findings []domain.Finding, opts ReportOptions) Executi
 		Delta:         currentWeek - previousWeek,
 	}
 	report.TopFindingTypes = topFindingTypes(report.OpenByType, topN)
+	if mttrCount > 0 {
+		report.MeanTimeToResolve = &MTTRSummary{
+			ResolvedCount: mttrCount,
+			Seconds:       mttrTotal.Seconds() / float64(mttrCount),
+		}
+	}
 	return report
 }
 


### PR DESCRIPTION
Fixes #1166

## What changed
Added `GET /v1/enterprise/reports/executive`.

- Calls the shipped `enterprise.BuildExecutiveReport` builder — no report assembly logic duplicated in the handler.
- Scoped to the caller's organization (session `CurrentOrgID`) under the existing `enterprise.read` authorization; route added to the built-in route-authorization bundle and the OpenAPI `x-identrail-route-authorizations` list.
- 60-second per-organization in-memory cache, keyed strictly by org id so one tenant's posture can never surface in another's response.
- JSON only; no server-side PDF generation.
- Findings are read uncapped via `ListFindingsAll` and triage-hydrated via `applyFindingTriageStates`, so the rollup reflects the full organization posture (not a 100-row page) with correct lifecycle status and `ResolvedAt`.
- Extended the report builder with `mean_time_to_resolve`, derived strictly from `FindingTriage.ResolvedAt` (never the mutable `UpdatedAt`) and omitted entirely when no resolved finding has a trustworthy `ResolvedAt`. Replaced the now-stale "MTTR deliberately omitted" comment.
- OpenAPI: new path item (with scope header params), `ExecutiveReport`/`TopFindingType`/`WeekOverWeekTrend`/`MTTRSummary` schemas. Documented in the enterprise quickstart and CHANGELOG.

## Why
Leadership needs one stable JSON contract for the executive report so every client does not rebuild reporting logic. MTTR became trustworthy once #1165 added `resolved_at`; this PR is the standalone API surface (Track 2 PR-7).

## Impact and risk
Low. Additive endpoint gated on the existing new-auth/session stack and `enterprise.read`. Builder change is additive (`mean_time_to_resolve` is optional/omitempty); no existing caller behavior changes.

## Validation performed
- `go build ./...`, `go vet ./internal/...` — clean
- `go test ./internal/enterprise/ ./internal/api/` — full packages pass, including:
  - builder: MTTR computed from `ResolvedAt`, ignores `UpdatedAt`-only resolved findings, omitted when no reliable data
  - endpoint: session required (401), org context required (403), report + MTTR shape, per-org cache hit within 60s, rebuild after TTL, cross-organization isolation
  - existing OpenAPI route/scope-header contract tests
- `make fmt-check` clean; OpenAPI YAML validates; `./scripts/check_api_example_contract.sh` passes

## Linked issue
Fixes #1166

## AI-Assisted and AI-Generated Code Policy disclosure
- AI-assisted: yes
- Tools used: Claude Code
- Where used: executive report endpoint (handler, cache, route/authz wiring), MTTR in the report builder, OpenAPI, docs, and tests
- Human verification performed: reviewed the full diff; ran go build/vet, full `internal/enterprise` + `internal/api` test packages, OpenAPI + API example contract checks, and `make fmt-check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `GET /v1/enterprise/reports/executive` to return an organization-wide executive report (open counts, top types, week-over-week trend) with MTTR from reliable `resolved_at`. Aggregates identity and repo findings across the caller’s member workspaces and caches per-organization + authorized workspace set for 60s; JSON only. Fixes #1166.

- New Features
  - New endpoint: `GET /v1/enterprise/reports/executive` under `enterprise.read`, scoped to the caller’s org; uses `enterprise.BuildExecutiveReport`.
  - Aggregates findings across the caller’s active workspace memberships (always includes the active workspace); includes repo findings; triage is hydrated for accurate totals and lifecycle.
  - 60s in-memory cache keyed by organization + the caller’s authorized workspace set; isolates across users/scopes and evicts expired entries.
  - MTTR computed strictly from `FindingTriage.resolved_at` and omitted when no trustworthy data exists.
  - OpenAPI path and schemas (`ExecutiveReport`, `TopFindingType`, `WeekOverWeekTrend`, `MTTRSummary`) added; route wired into the authz bundle; docs updated.

<sup>Written for commit 2c9a5ba77aed594c69f0321e7cafe52b780e0277. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1171?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

