### PR TITLE
Add printable executive report page

### DIFF
--- a/docs/enterprise-quickstart.md
+++ b/docs/enterprise-quickstart.md
@@ -42,6 +42,7 @@ Use the exact keys configured in `deploy/docker/.env`:
 
 ```bash
 export IDENTRAIL_API_URL="http://localhost:8080"
+export IDENTRAIL_WEB_URL="http://localhost:8081"
 export IDENTRAIL_TENANT_ID="tenant-a"
 export IDENTRAIL_WORKSPACE_ID="workspace-a"
 export IDENTRAIL_READER_KEY="<reader-key-from-.env>"
@@ -254,6 +255,15 @@ Confirm:
 Fetch the leadership rollup for the current organization. The response is
 JSON only — there is no server-side PDF; use the printable web report page
 and your browser's Save as PDF for a board-ready document.
+
+Open the web route after signing in:
+```text
+${IDENTRAIL_WEB_URL}/reports/executive
+```
+
+Use the browser print dialog (`Cmd+P` on macOS or `Ctrl+P` on Windows/Linux)
+and choose Save as PDF. The print stylesheet removes navigation and action
+chrome so the exported document contains only the executive report.
 
 ```bash
 curl -fsS "${IDENTRAIL_API_URL}/v1/enterprise/reports/executive" \

--- a/scripts/check_web_route_integrity.sh
+++ b/scripts/check_web_route_integrity.sh
@@ -20,6 +20,7 @@ function parseAppRoutes(src) {
     '/onboarding/org',
     '/onboarding/scan',
     '/onboarding/workspace',
+    '/reports/executive',
   ]);
 
   // Identify routes that exist purely to 301-redirect a legacy URL

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1532,4 +1532,52 @@ describe('App', () => {
     expect(window.location.pathname).toBe('/app/logout');
     expect(screen.queryByText(/Signed out successfully/i)).not.toBeInTheDocument();
   });
+
+  it('renders the printable executive report from the API response', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/v1/me')) {
+        return okJSON(currentMePayload('tenant-a', 'workspace-a', 'viewer'));
+      }
+      if (url.endsWith('/v1/enterprise/reports/executive')) {
+        return okJSON({
+          organization_id: 'tenant-a',
+          generated_at: '2026-05-17T12:00:00Z',
+          window_start: '2026-05-10T12:00:00Z',
+          window_end: '2026-05-17T12:00:00Z',
+          total_open_findings: 7,
+          open_by_severity: { critical: 2, high: 3, medium: 1, low: 1 },
+          open_by_type: { secret_exposure: 4, repo_misconfiguration: 3 },
+          top_finding_types: [
+            { type: 'secret_exposure', count: 4 },
+            { type: 'repo_misconfiguration', count: 3 }
+          ],
+          week_over_week: { current_count: 5, previous_count: 2, delta: 3 },
+          mean_time_to_resolve: { resolved_count: 2, seconds: 1800 }
+        });
+      }
+      return errorJSON(404, `unexpected ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    setCurrentPath('/reports/executive');
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { level: 1, name: /Board-ready risk posture/i })).toBeInTheDocument();
+    expect(screen.getByText('tenant-a')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+    expect(screen.getByText('5 critical or high priority')).toBeInTheDocument();
+    expect(screen.getAllByText('30m').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Secret Exposure').length).toBeGreaterThan(0);
+    expect(screen.getByText('Authorized workspaces')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Review findings/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Print report/i })).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:8080/v1/enterprise/reports/executive',
+      expect.objectContaining({
+        credentials: 'include',
+        headers: expect.any(Headers)
+      })
+    );
+  });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -26,6 +26,7 @@ import { FEATURE_ONBOARDING_WIZARD } from './pages/onboarding/onboardingUtils';
 import {
   ProductAppIndexRedirect,
   ProductAuthCallbackRedirectPage,
+  ProductExecutiveReportPage,
   ProductFindingsPage,
   ProductGitHubCallbackPage,
   ProductLoginPage,
@@ -3546,7 +3547,7 @@ function NotFoundPage() {
 export function RoutedSite() {
   useAnalytics();
   const location = useLocation();
-  const isProductShellRoute = location.pathname.startsWith('/app');
+  const isProductShellRoute = location.pathname.startsWith('/app') || location.pathname.startsWith('/reports');
   const isOnboardingRoute = location.pathname.startsWith('/onboarding');
   const normalizedPath = location.pathname.replace(/\/+$/, '') || '/';
   const isAuthChoiceRoute = normalizedPath === '/signin' || normalizedPath === '/signup' || normalizedPath === '/auth/mfa';
@@ -3591,6 +3592,14 @@ export function RoutedSite() {
             }
           />
           <Route path="/app/logout" element={<ProductLogoutPage />} />
+          <Route
+            path="/reports/executive"
+            element={
+              <RequireProductAuth>
+                <ProductExecutiveReportPage />
+              </RequireProductAuth>
+            }
+          />
           <Route
             path="/onboarding/org"
             element={

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -58,6 +58,26 @@ export type TrendPoint = {
   by_severity: Record<string, number>;
 };
 
+export type ExecutiveReport = {
+  organization_id: string;
+  generated_at: string;
+  window_start: string;
+  window_end: string;
+  total_open_findings: number;
+  open_by_severity: Record<string, number>;
+  open_by_type: Record<string, number>;
+  top_finding_types?: Array<{ type: string; count: number }> | null;
+  week_over_week: {
+    current_count: number;
+    previous_count: number;
+    delta: number;
+  };
+  mean_time_to_resolve?: {
+    resolved_count: number;
+    seconds: number;
+  } | null;
+};
+
 export type ScanDiff = {
   scan_id: string;
   previous_scan_id?: string;
@@ -1038,6 +1058,9 @@ export const apiClient = {
     auth?: RequestAuthContext
   ) {
     return request<{ items: TrendPoint[] }>(`/v1/repo-findings/trends${buildQuery(filters)}`, auth);
+  },
+  getExecutiveReport(auth?: RequestAuthContext) {
+    return request<ExecutiveReport>('/v1/enterprise/reports/executive', auth);
   },
   listScans(auth?: RequestAuthContext) {
     return request<{ items: ScanRecord[] }>('/v1/scans?sort_by=started_at&sort_order=desc', auth);

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -8,6 +8,7 @@ import {
   type AWSConnectionStatus,
   type AWSPermissionPreviewItem,
   type CurrentUserContext,
+  type ExecutiveReport,
   type Finding as ApiFinding,
   type FindingLifecycleStatus,
   type GitHubConnectorStartResponse,
@@ -148,6 +149,7 @@ const OVERVIEW_FINDING_LIMIT = 50;
 const OVERVIEW_RISK_DISPLAY_LIMIT = 8;
 const OVERVIEW_SCAN_LIMIT = 5;
 const OVERVIEW_PROJECT_PAGE_LIMIT = 100;
+const EXECUTIVE_REPORT_SEVERITY_ORDER = ['critical', 'high', 'medium', 'low', 'info'] as const;
 
 const SORT_LABEL_BY_FIELD: Record<(typeof REPO_FINDING_SORT_FIELDS)[number], string> = {
   severity: 'Risk (high → low)',
@@ -208,6 +210,41 @@ function formatDateLabel(value: string): string {
     return value;
   }
   return parsed.toLocaleString();
+}
+
+function formatShortDateLabel(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric'
+  });
+}
+
+function formatExecutiveDuration(seconds: number | undefined): string {
+  if (!Number.isFinite(seconds ?? NaN)) {
+    return 'N/A';
+  }
+  const totalSeconds = Math.max(0, Math.round(seconds ?? 0));
+  if (totalSeconds < 3600) {
+    if (totalSeconds === 0) {
+      return '0m';
+    }
+    return `${Math.max(1, Math.round(totalSeconds / 60))}m`;
+  }
+  if (totalSeconds >= 86400) {
+    const days = Math.round(totalSeconds / 86400);
+    return `${days}d`;
+  }
+  const hours = Math.round(totalSeconds / 3600);
+  return `${hours}h`;
+}
+
+function countHighPriorityExecutiveFindings(report: ExecutiveReport): number {
+  return (report.open_by_severity.critical ?? 0) + (report.open_by_severity.high ?? 0);
 }
 
 function toLocalDateTimeInputValue(value: string): string {
@@ -843,6 +880,7 @@ export function ProductShellLayout() {
           <NavLink to={`${basePath}/workspaces`}>Workspaces</NavLink>
           <NavLink to={`${basePath}/projects`}>Projects</NavLink>
           <NavLink to={`${basePath}/findings`}>Findings</NavLink>
+          <NavLink to="/reports/executive">Executive report</NavLink>
           <NavLink to={`${basePath}/settings`}>Settings</NavLink>
           <NavLink to="/app/account/security">Security</NavLink>
         </nav>
@@ -1188,6 +1226,251 @@ export function ProductOverviewPage() {
         </aside>
       ) : null}
     </>
+  );
+}
+
+export function ProductExecutiveReportPage() {
+  const { me, loading: sessionLoading, error: sessionError, unauthenticated } = useMe();
+  const [report, setReport] = useState<ExecutiveReport | null>(null);
+  const [loadingReport, setLoadingReport] = useState(false);
+  const [reportError, setReportError] = useState('');
+
+  useEffect(() => {
+    if (!me?.org_id || !me.workspace_id) {
+      return;
+    }
+
+    let mounted = true;
+    const loadReport = async () => {
+      setLoadingReport(true);
+      setReportError('');
+      try {
+        const response = await apiClient.getExecutiveReport({
+          tenantID: me.org_id,
+          workspaceID: me.workspace_id
+        });
+        if (mounted) {
+          setReport(response);
+        }
+      } catch (requestError) {
+        if (!mounted) {
+          return;
+        }
+        if (requestError instanceof ApiError && requestError.status === 403) {
+          setReportError('You do not have access to the executive report for this organization.');
+          return;
+        }
+        const message = requestError instanceof Error ? requestError.message : 'Unable to load executive report.';
+        setReportError(message);
+      } finally {
+        if (mounted) {
+          setLoadingReport(false);
+        }
+      }
+    };
+
+    void loadReport();
+
+    return () => {
+      mounted = false;
+    };
+  }, [me?.org_id, me?.workspace_id]);
+
+  if (sessionLoading || loadingReport) {
+    return <AppShellLoading message="Loading executive report" />;
+  }
+
+  if (unauthenticated) {
+    return <Navigate to="/signin?return_to=%2Freports%2Fexecutive" replace />;
+  }
+
+  if (sessionError || reportError) {
+    return (
+      <section className="idt-app-shell-screen idt-executive-report-shell" role="alert">
+        <article className="idt-app-panel idt-app-panel-error">
+          <p className="idt-app-kicker">Executive report</p>
+          <h1>Unable to load executive report</h1>
+          <p>{sessionError || reportError}</p>
+          <Link className="idt-btn idt-btn-ghost" to="/app">
+            Return to app
+          </Link>
+        </article>
+      </section>
+    );
+  }
+
+  if (!me?.org_id || !me.workspace_id) {
+    return (
+      <section className="idt-app-shell-screen idt-executive-report-shell">
+        <article className="idt-app-panel">
+          <p className="idt-app-kicker">Executive report</p>
+          <h1>Organization context required</h1>
+          <p>Your account needs an active organization and workspace before the executive report can be rendered.</p>
+        </article>
+      </section>
+    );
+  }
+
+  if (!report) {
+    return <AppShellLoading message="Preparing executive report" />;
+  }
+
+  const highPriorityFindings = countHighPriorityExecutiveFindings(report);
+  const weekDelta = report.week_over_week.delta;
+  const topFindingTypes = report.top_finding_types ?? [];
+  const severityRows = EXECUTIVE_REPORT_SEVERITY_ORDER.map((severity) => ({
+    severity,
+    count: report.open_by_severity[severity] ?? 0
+  }));
+  const maxSeverityCount = Math.max(1, ...severityRows.map((row) => row.count));
+  const maxTypeCount = Math.max(1, ...topFindingTypes.map((item) => item.count));
+  const appPath = buildCurrentUserAppPath(me);
+
+  return (
+    <section className="idt-app-shell-screen idt-executive-report-shell">
+      <article className="idt-app-panel idt-executive-report-page">
+        <header className="idt-executive-report-header">
+          <div>
+            <p className="idt-app-kicker">Executive report</p>
+            <h1>Board-ready risk posture</h1>
+            <p>
+              Organization <strong>{report.organization_id}</strong> · {formatShortDateLabel(report.window_start)} to{' '}
+              {formatShortDateLabel(report.window_end)} · Generated {formatDateLabel(report.generated_at)}
+            </p>
+          </div>
+          <div className="idt-executive-report-actions">
+            <Link className="idt-btn idt-btn-ghost" to={appPath}>
+              Workspace
+            </Link>
+            <button className="idt-btn idt-btn-primary" type="button" onClick={() => window.print()}>
+              Print report
+            </button>
+          </div>
+        </header>
+
+        <div className="idt-executive-report-metrics" aria-label="Executive report summary">
+          <article>
+            <span>Open findings</span>
+            <strong>{report.total_open_findings}</strong>
+            <p>{highPriorityFindings} critical or high priority</p>
+          </article>
+          <article>
+            <span>Week trend</span>
+            <strong>{weekDelta > 0 ? `+${weekDelta}` : weekDelta}</strong>
+            <p>
+              {report.week_over_week.current_count} current · {report.week_over_week.previous_count} previous
+            </p>
+          </article>
+          <article>
+            <span>Mean time to resolve</span>
+            <strong>{formatExecutiveDuration(report.mean_time_to_resolve?.seconds)}</strong>
+            <p>
+              {report.mean_time_to_resolve
+                ? `${report.mean_time_to_resolve.resolved_count} resolved findings`
+                : 'No reliable resolved sample yet'}
+            </p>
+          </article>
+          <article>
+            <span>Top risk type</span>
+            <strong>{topFindingTypes[0] ? formatTokenLabel(topFindingTypes[0].type) : 'None'}</strong>
+            <p>{topFindingTypes[0] ? `${topFindingTypes[0].count} open findings` : 'No open findings in scope'}</p>
+          </article>
+        </div>
+
+        {report.total_open_findings === 0 ? (
+          <AppShellEmptyState
+            title="No open findings in this report window"
+            body="The current organization report has no open findings to prioritize."
+          />
+        ) : (
+          <div className="idt-executive-report-grid">
+            <section className="idt-executive-report-section">
+              <div className="idt-executive-report-section-header">
+                <div>
+                  <p className="idt-app-kicker">Current posture</p>
+                  <h2>Open findings by severity</h2>
+                </div>
+                <span className="idt-executive-report-scope">Authorized workspaces</span>
+              </div>
+              <div className="idt-executive-severity-list">
+                {severityRows.map((row) => (
+                  <article key={row.severity}>
+                    <div>
+                      <strong>{formatTokenLabel(row.severity)}</strong>
+                      <span>{row.count}</span>
+                    </div>
+                    <div className="idt-executive-bar" aria-hidden="true">
+                      <span style={{ width: `${Math.round((row.count / maxSeverityCount) * 100)}%` }} />
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </section>
+
+            <section className="idt-executive-report-section">
+              <div className="idt-executive-report-section-header">
+                <div>
+                  <p className="idt-app-kicker">Prioritized themes</p>
+                  <h2>Top finding types</h2>
+                </div>
+              </div>
+              {topFindingTypes.length > 0 ? (
+                <div className="idt-executive-type-list">
+                  {topFindingTypes.map((item) => (
+                    <article key={item.type}>
+                      <div>
+                        <strong>{formatTokenLabel(item.type)}</strong>
+                        <span>{item.count}</span>
+                      </div>
+                      <div className="idt-executive-bar" aria-hidden="true">
+                        <span style={{ width: `${Math.round((item.count / maxTypeCount) * 100)}%` }} />
+                      </div>
+                    </article>
+                  ))}
+                </div>
+              ) : (
+                <AppShellEmptyState
+                  title="No dominant finding types"
+                  body="Finding type priorities will appear after open findings are present."
+                />
+              )}
+            </section>
+
+            <section className="idt-executive-report-section idt-executive-report-wide">
+              <div className="idt-executive-report-section-header">
+                <div>
+                  <p className="idt-app-kicker">Leadership interpretation</p>
+                  <h2>Trend and response signal</h2>
+                </div>
+              </div>
+              <div className="idt-executive-narrative">
+                <article>
+                  <strong>
+                    {weekDelta > 0
+                      ? 'Risk creation increased'
+                      : weekDelta < 0
+                        ? 'Risk creation decreased'
+                        : 'Risk creation is flat'}
+                  </strong>
+                  <p>
+                    The current seven-day window has {report.week_over_week.current_count} new findings versus{' '}
+                    {report.week_over_week.previous_count} in the prior window.
+                  </p>
+                </article>
+                <article>
+                  <strong>{report.mean_time_to_resolve ? 'Resolution sample is available' : 'Resolution sample is not available'}</strong>
+                  <p>
+                    {report.mean_time_to_resolve
+                      ? `Mean time to resolve is ${formatExecutiveDuration(report.mean_time_to_resolve.seconds)} across ${report.mean_time_to_resolve.resolved_count} findings with trustworthy resolved timestamps.`
+                      : 'MTTR is intentionally omitted until resolved findings carry trustworthy resolved timestamps.'}
+                  </p>
+                </article>
+              </div>
+            </section>
+          </div>
+        )}
+      </article>
+    </section>
   );
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4512,6 +4512,192 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   overflow-wrap: anywhere;
 }
 
+.idt-executive-report-shell {
+  align-items: start;
+  padding: clamp(1rem, 3vw, 2.5rem);
+}
+
+.idt-executive-report-page {
+  display: grid;
+  gap: 1rem;
+  width: min(100%, 1180px);
+}
+
+.idt-executive-report-header,
+.idt-executive-report-section-header,
+.idt-executive-narrative article,
+.idt-executive-severity-list article,
+.idt-executive-type-list article {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.idt-executive-report-header {
+  align-items: flex-start;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid rgba(130, 160, 214, 0.24);
+}
+
+.idt-executive-report-header h1,
+.idt-executive-report-section h2 {
+  margin-bottom: 0.35rem;
+}
+
+.idt-executive-report-header p,
+.idt-executive-report-section p,
+.idt-executive-narrative p {
+  margin: 0;
+  color: #c9d8ee;
+}
+
+.idt-executive-report-actions,
+.idt-executive-report-metrics,
+.idt-executive-report-grid,
+.idt-executive-severity-list,
+.idt-executive-type-list,
+.idt-executive-narrative {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.idt-executive-report-actions {
+  grid-auto-flow: column;
+  justify-content: end;
+  align-items: center;
+}
+
+.idt-executive-report-metrics {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.idt-executive-report-metrics article,
+.idt-executive-report-section,
+.idt-executive-severity-list article,
+.idt-executive-type-list article,
+.idt-executive-narrative article {
+  border: 1px solid rgba(130, 160, 214, 0.28);
+  border-radius: 0.65rem;
+  background: rgba(8, 14, 25, 0.52);
+}
+
+.idt-executive-report-metrics article,
+.idt-executive-report-section {
+  padding: 1rem;
+}
+
+.idt-executive-report-metrics span,
+.idt-executive-severity-list span,
+.idt-executive-type-list span {
+  color: #9fb8de;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.idt-executive-report-metrics strong {
+  display: block;
+  margin-top: 0.25rem;
+  color: #f2f7ff;
+  font-family: var(--idt-display);
+  font-size: 1.55rem;
+  line-height: 1.1;
+}
+
+.idt-executive-report-metrics p {
+  margin: 0.25rem 0 0;
+  color: #c2d4f0;
+}
+
+.idt-executive-report-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: start;
+}
+
+.idt-executive-report-section {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.idt-executive-report-wide {
+  grid-column: 1 / -1;
+}
+
+.idt-executive-report-section-header {
+  align-items: flex-start;
+}
+
+.idt-executive-report-section-header a {
+  color: #b8cef0;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.idt-executive-report-scope {
+  color: #9fb8de;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.idt-executive-report-section-header a:hover,
+.idt-executive-report-section-header a:focus-visible {
+  color: #e8f2ff;
+  text-decoration: underline;
+}
+
+.idt-executive-severity-list article,
+.idt-executive-type-list article,
+.idt-executive-narrative article {
+  align-items: center;
+  padding: 0.75rem;
+}
+
+.idt-executive-severity-list strong,
+.idt-executive-type-list strong,
+.idt-executive-narrative strong {
+  color: #eef5ff;
+}
+
+.idt-executive-severity-list article > div:first-child,
+.idt-executive-type-list article > div:first-child {
+  min-width: 8rem;
+}
+
+.idt-executive-severity-list span,
+.idt-executive-type-list span {
+  display: block;
+  margin-top: 0.15rem;
+}
+
+.idt-executive-bar {
+  flex: 1;
+  height: 0.55rem;
+  min-width: 8rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(130, 160, 214, 0.18);
+}
+
+.idt-executive-bar span {
+  display: block;
+  height: 100%;
+  min-width: 0.35rem;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #8fd8ff, #b8f3d6);
+}
+
+.idt-executive-narrative {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.idt-executive-narrative article {
+  display: grid;
+  align-content: start;
+}
+
 .idt-repo-findings-header {
   display: flex;
   justify-content: space-between;
@@ -5735,6 +5921,7 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   .idt-source-summary,
   .idt-source-meta,
   .idt-overview-metrics,
+  .idt-executive-report-metrics,
   .idt-settings-counts,
   .idt-settings-facts {
     grid-template-columns: 1fr 1fr;
@@ -5744,6 +5931,8 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   .idt-projects-grid,
   .idt-source-wizard-grid,
   .idt-overview-grid,
+  .idt-executive-report-grid,
+  .idt-executive-narrative,
   .idt-settings-grid {
     grid-template-columns: 1fr;
   }
@@ -5770,6 +5959,7 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   .idt-source-inline-fields,
   .idt-source-meta,
   .idt-overview-metrics,
+  .idt-executive-report-metrics,
   .idt-settings-counts,
   .idt-settings-facts {
     grid-template-columns: 1fr;
@@ -5782,11 +5972,15 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   .idt-source-config-header,
   .idt-source-install-card,
   .idt-overview-header,
+  .idt-executive-report-header,
+  .idt-executive-report-section-header,
   .idt-settings-header,
   .idt-overview-card-header,
   .idt-settings-card-header,
   .idt-overview-risk-row,
-  .idt-overview-scan-row {
+  .idt-overview-scan-row,
+  .idt-executive-severity-list article,
+  .idt-executive-type-list article {
     display: grid;
   }
 }
@@ -5889,6 +6083,43 @@ html[data-theme='light'] .idt-settings-facts dd {
   color: #1c355d;
 }
 
+html[data-theme='light'] .idt-executive-report-header p,
+html[data-theme='light'] .idt-executive-report-section p,
+html[data-theme='light'] .idt-executive-report-metrics p,
+html[data-theme='light'] .idt-executive-narrative p {
+  color: #35598d;
+}
+
+html[data-theme='light'] .idt-executive-report-metrics article,
+html[data-theme='light'] .idt-executive-report-section,
+html[data-theme='light'] .idt-executive-severity-list article,
+html[data-theme='light'] .idt-executive-type-list article,
+html[data-theme='light'] .idt-executive-narrative article {
+  background: rgba(245, 250, 255, 0.95);
+  border-color: rgba(42, 71, 119, 0.24);
+}
+
+html[data-theme='light'] .idt-executive-report-metrics span,
+html[data-theme='light'] .idt-executive-severity-list span,
+html[data-theme='light'] .idt-executive-type-list span {
+  color: #385f95;
+}
+
+html[data-theme='light'] .idt-executive-report-metrics strong,
+html[data-theme='light'] .idt-executive-severity-list strong,
+html[data-theme='light'] .idt-executive-type-list strong,
+html[data-theme='light'] .idt-executive-narrative strong {
+  color: #1c355d;
+}
+
+html[data-theme='light'] .idt-executive-report-section-header a {
+  color: #1f4f96;
+}
+
+html[data-theme='light'] .idt-executive-report-scope {
+  color: #385f95;
+}
+
 html[data-theme='light'] .idt-overview-card-header a,
 html[data-theme='light'] .idt-settings-card-header a {
   color: #1f4f96;
@@ -5902,6 +6133,81 @@ html[data-theme='light'] .idt-settings-route-grid a:hover,
 html[data-theme='light'] .idt-settings-route-grid a:focus-visible {
   background: rgba(224, 244, 235, 0.95);
   border-color: rgba(33, 124, 83, 0.32);
+}
+
+@media print {
+  @page {
+    margin: 0.55in;
+  }
+
+  html,
+  body,
+  .idt-site,
+  #main-content,
+  .idt-app-shell-screen,
+  .idt-executive-report-shell {
+    background: #ffffff !important;
+    color: #111827 !important;
+  }
+
+  .idt-skip,
+  .idt-site > header,
+  .idt-app-shell-header,
+  .idt-app-shell-nav,
+  .idt-executive-report-actions {
+    display: none !important;
+  }
+
+  .idt-executive-report-shell {
+    display: block;
+    min-height: auto;
+    padding: 0;
+  }
+
+  .idt-app-panel,
+  .idt-executive-report-page,
+  .idt-executive-report-metrics article,
+  .idt-executive-report-section,
+  .idt-executive-severity-list article,
+  .idt-executive-type-list article,
+  .idt-executive-narrative article {
+    border-color: #d7dee9 !important;
+    background: #ffffff !important;
+    box-shadow: none !important;
+  }
+
+  .idt-app-panel {
+    padding: 0 !important;
+  }
+
+  .idt-executive-report-page {
+    width: 100%;
+  }
+
+  .idt-executive-report-grid,
+  .idt-executive-narrative {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .idt-app-kicker,
+  .idt-executive-report-header p,
+  .idt-executive-report-section p,
+  .idt-executive-report-metrics p,
+  .idt-executive-report-metrics span,
+  .idt-executive-severity-list span,
+  .idt-executive-type-list span,
+  .idt-executive-narrative p {
+    color: #4b5563 !important;
+  }
+
+  .idt-executive-report-header h1,
+  .idt-executive-report-section h2,
+  .idt-executive-report-metrics strong,
+  .idt-executive-severity-list strong,
+  .idt-executive-type-list strong,
+  .idt-executive-narrative strong {
+    color: #111827 !important;
+  }
 }
 
 html[data-theme='light'] .idt-repo-finding-stat,


### PR DESCRIPTION
Fixes #1164

## What changed
- Added the authenticated `/reports/executive` web route backed by `/v1/enterprise/reports/executive`.
- Rendered a printable leadership report with summary metrics, severity and finding-type breakdowns, trend/MTTR interpretation, loading/error/empty/unauthorized states, and a browser print action.
- Added print styles that hide app navigation/action chrome and documented browser Print / Save as PDF usage.
- Added regression coverage for the printable route and executive-report API request.
- Marked the authenticated report route as runtime-only for the route-integrity guard.

## Why
- The executive report API needed a browser-printable page that leaders can save as PDF without introducing server-side PDF generation.

## Impact and risk
- Read-only frontend change; no API or database behavior changes.
- The report route uses the existing authenticated product shell and current organization/workspace context.
- Print behavior relies on the browser print dialog, matching the issue scope.

## Validation
- [x] `./scripts/check_web_route_integrity.sh`
- [x] `npm run test --prefix web -- App.test.tsx -t "printable executive report"`
- [x] `npm run build --prefix web`
- [x] `npm run test:ci --prefix web`
- [x] Browser route check at `http://127.0.0.1:4174/reports/executive` with a mock API confirmed the report content rendered, print CSS was present, and there were no console errors.

## AI-assisted
- AI-assisted: No
- Tools used: None
- Where used: N/A
- Human verification performed: reviewed the diff, ran focused and full web test suites, ran production build, checked route integrity, and checked the report route with a mock API.
