### PR TITLE
Fix onboarding API route visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Kept authenticated onboarding API routes registered when the onboarding feature flag is off, returning JSON `401` or `503` responses instead of a raw framework `404` so production flag mismatches are visible and diagnosable.
 - Added the `GET /v1/enterprise/reports/executive` endpoint returning the organization's leadership rollup (open volume by severity, top finding types, week-over-week trend, and MTTR):
   - calls the shipped `BuildExecutiveReport` builder; JSON only, no server-side PDF generation
   - extended the report builder with `mean_time_to_resolve`, derived strictly from finding triage `resolved_at` (never the mutable `updated_at`) and omitted when no resolved finding has a trustworthy `resolved_at`

--- a/docs/auth/production-api-readiness.md
+++ b/docs/auth/production-api-readiness.md
@@ -81,9 +81,10 @@ project env value configured directly.
 After deploying both halves, verify:
 
 1. `GET https://api.identrail.com/v1/auth/config` shows hosted GitHub login is available.
-2. GitHub login returns to Identrail without `{"error":"login failed"}`.
-3. A new user with no workspace lands on `/onboarding/org`.
-4. Creating organization and workspace redirects to the scoped `/app/<org>/<workspace>` dashboard.
+2. `POST https://api.identrail.com/v1/onboarding/start` without a session returns JSON `401`, not a plain `404 page not found`.
+3. GitHub login returns to Identrail without `{"error":"login failed"}`.
+4. A new user with no workspace lands on `/onboarding/org`.
+5. Creating organization and workspace redirects to the scoped `/app/<org>/<workspace>` dashboard.
 
 ## Checks
 

--- a/internal/api/onboarding_routes.go
+++ b/internal/api/onboarding_routes.go
@@ -12,16 +12,12 @@ import (
 )
 
 func registerOnboardingRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service, featureEnabled bool) {
-	if !featureEnabled {
-		return
-	}
-
 	v1.POST("/onboarding/start", func(c *gin.Context) {
-		if !requireOnboardingService(c, svc) {
-			return
-		}
 		current, ok := requireOnboardingSession(c)
 		if !ok {
+			return
+		}
+		if !requireOnboardingFeature(c, featureEnabled) || !requireOnboardingService(c, svc) {
 			return
 		}
 		response, err := svc.StartOnboarding(c.Request.Context(), current)
@@ -29,11 +25,11 @@ func registerOnboardingRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Serv
 	})
 
 	v1.GET("/onboarding/state", func(c *gin.Context) {
-		if !requireOnboardingService(c, svc) {
-			return
-		}
 		current, ok := requireOnboardingSession(c)
 		if !ok {
+			return
+		}
+		if !requireOnboardingFeature(c, featureEnabled) || !requireOnboardingService(c, svc) {
 			return
 		}
 		response, err := svc.GetOnboardingState(c.Request.Context(), current)
@@ -41,11 +37,11 @@ func registerOnboardingRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Serv
 	})
 
 	v1.POST("/onboarding/state", func(c *gin.Context) {
-		if !requireOnboardingService(c, svc) {
-			return
-		}
 		current, ok := requireOnboardingSession(c)
 		if !ok {
+			return
+		}
+		if !requireOnboardingFeature(c, featureEnabled) || !requireOnboardingService(c, svc) {
 			return
 		}
 		var request OnboardingStateUpdateRequest
@@ -58,16 +54,24 @@ func registerOnboardingRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Serv
 	})
 
 	v1.POST("/onboarding/complete", func(c *gin.Context) {
-		if !requireOnboardingService(c, svc) {
-			return
-		}
 		current, ok := requireOnboardingSession(c)
 		if !ok {
+			return
+		}
+		if !requireOnboardingFeature(c, featureEnabled) || !requireOnboardingService(c, svc) {
 			return
 		}
 		response, err := svc.CompleteOnboarding(c.Request.Context(), current)
 		writeOnboardingResponse(c, logger, err, response, "complete onboarding")
 	})
+}
+
+func requireOnboardingFeature(c *gin.Context, featureEnabled bool) bool {
+	if !featureEnabled {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "onboarding disabled"})
+		return false
+	}
+	return true
 }
 
 func requireOnboardingService(c *gin.Context, svc *Service) bool {

--- a/internal/api/onboarding_test.go
+++ b/internal/api/onboarding_test.go
@@ -62,11 +62,24 @@ func onboardingRequest(router http.Handler, cookieValue string, method string, p
 	return w
 }
 
-func TestOnboardingRoutesHiddenWhenFeatureDisabled(t *testing.T) {
+func TestOnboardingRoutesReturnJSONWhenFeatureDisabled(t *testing.T) {
 	_, router, cookieValue := setupOnboardingRouter(t, false)
+
+	unauthenticated := httptest.NewRecorder()
+	router.ServeHTTP(unauthenticated, httptest.NewRequest(http.MethodPost, "/v1/onboarding/start", nil))
+	if unauthenticated.Code != http.StatusUnauthorized {
+		t.Fatalf("expected unauthenticated onboarding request 401, got %d body=%s", unauthenticated.Code, unauthenticated.Body.String())
+	}
+	if !strings.Contains(unauthenticated.Body.String(), `"error":"unauthorized"`) {
+		t.Fatalf("expected JSON unauthorized error, got %s", unauthenticated.Body.String())
+	}
+
 	w := onboardingRequest(router, cookieValue, http.MethodPost, "/v1/onboarding/start", "")
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("expected onboarding route to be hidden, got %d body=%s", w.Code, w.Body.String())
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected disabled onboarding route to return 503 JSON, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"error":"onboarding disabled"`) {
+		t.Fatalf("expected disabled onboarding error, got %s", w.Body.String())
 	}
 }
 
@@ -387,6 +400,15 @@ func TestOnboardingRoutesRequireSessionAndService(t *testing.T) {
 	}
 	if serviceUnavailable.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected unavailable onboarding service 503, got %d body=%s", serviceUnavailable.Code, serviceUnavailable.Body.String())
+	}
+
+	featureDisabled := httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(featureDisabled)
+	if requireOnboardingFeature(c, false) {
+		t.Fatal("expected disabled onboarding feature to fail")
+	}
+	if featureDisabled.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected disabled onboarding feature 503, got %d body=%s", featureDisabled.Code, featureDisabled.Body.String())
 	}
 }
 


### PR DESCRIPTION
Fixes #1172

## What changed
- Keep `/v1/onboarding/start`, `/v1/onboarding/state`, and `/v1/onboarding/complete` registered whenever the new session-auth stack is enabled.
- Return JSON `503 {"error":"onboarding disabled"}` for authenticated calls when the onboarding API feature flag is off instead of hiding the route behind a framework 404.
- Add regression coverage for the production-class mismatch: unauthenticated probes now see JSON `401`, and authenticated disabled-feature calls see JSON `503`.
- Update production readiness docs and the changelog with the onboarding route verification behavior.

## Why
The production web build can route first-time signed-in users into onboarding while the API route is missing or disabled. A raw `404 page not found` leaves users stuck on the scaffold screen and makes the deployment mismatch harder to diagnose. The route should be stable under new auth, with feature/service state expressed through JSON API responses.

## Impact and risk
This is a focused API reliability fix. Deployments with onboarding enabled continue to create org/workspace state as before. Deployments with new auth enabled but onboarding disabled now expose a JSON disabled response for authenticated callers instead of hiding the endpoint. The API onboarding rollback knob still prevents onboarding mutations while giving operators a clearer failure mode.

## Validation
- `go test ./internal/api -run 'TestOnboarding|TestWorkOS|TestAuthSession' -count=1`
- `go test ./internal/api -count=1`
- `go vet ./internal/api ./internal/db ./internal/config`
- `go test ./... -coverprofile=/tmp/identrail-1172-coverage.out` (`80.1%` total coverage)
- `go vet ./...`
- `git diff --check`

AI-assisted: yes
Tools used: Codex
Where used: route behavior, regression tests, docs, changelog, validation orchestration
Human verification performed: reviewed the diff, ran the Go tests/vet commands above, checked coverage and whitespace


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make onboarding API routes consistently visible under the new session-auth stack and return clear JSON errors instead of framework 404s. Prevents first-time users from getting stuck when onboarding is disabled in production.

- **Bug Fixes**
  - Always register `POST /v1/onboarding/start`, `GET/POST /v1/onboarding/state`, and `POST /v1/onboarding/complete` with new auth enabled.
  - Unauthenticated requests now return JSON 401; authenticated requests return JSON 503 when the onboarding feature flag is off.
  - Added regression tests for 401/503 behavior.
  - Updated production readiness docs with a verification step and added a changelog entry.

<sup>Written for commit 2cdd1e15d5dccabc1ca0d5d479b2b09842ae6909. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1180?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

