### PR TITLE
Add onboarding route coverage to production API preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 - Redesigned the read-only scan intake page with a full-width black Vercel-style hero, sharper SpaceX-inspired headline typography, and high-contrast intake controls with no blurred or gradient details.
+- Extended the production API preflight (`make production-api-preflight`) to probe
+  `POST /v1/onboarding/start` so the frontend onboarding wizard cannot be wired
+  against an API origin that does not serve the onboarding route:
+  - treats the unauthenticated JSON `401` session-required response as success,
+    matching the deliberate unauthenticated contract from the onboarding route
+    visibility fix
+  - fails closed on `404`, plain-text framework `404`, HTML, and frontend-shell
+    responses, with a failure prefix (`api-url-wiring`, `missing-route`,
+    `non-json`/`unexpected-status`) that names the root cause
+  - scoped to route presence and the unauthenticated JSON contract shape;
+    backend `IDENTRAIL_FEATURE_ONBOARDING_WIZARD` state is intentionally not
+    observable from an unauthenticated probe and stays covered by the
+    authenticated post-deploy verification steps in the readiness runbook
+  - kept generic for Identrail Cloud and self-hosted production API URLs by
+    asserting the contract shape rather than a specific host
+  - added offline shell-script tests for the response classification and
+    documented the behavior in the production API readiness runbook
 - Kept authenticated onboarding API routes registered when the onboarding feature flag is off, returning JSON `401` or `503` responses instead of a raw framework `404` so production flag mismatches are visible and diagnosable.
 - Added the `GET /v1/enterprise/reports/executive` endpoint returning the organization's leadership rollup (open volume by severity, top finding types, week-over-week trend, and MTTR):
   - calls the shipped `BuildExecutiveReport` builder; JSON only, no server-side PDF generation

--- a/docs/auth/production-api-readiness.md
+++ b/docs/auth/production-api-readiness.md
@@ -33,6 +33,10 @@ Before wiring the frontend to the production API URL, the API deployment must ex
 - `GET /healthz` returning `200`
 - `GET /readyz` returning `200` only after runtime dependencies are ready
 - `GET /v1/auth/config` returning JSON, not the web HTML shell
+- `POST /v1/onboarding/start` returning the unauthenticated JSON `401`
+  session-required response (not a `404`, plain-text framework `404`, or web
+  HTML shell) so the onboarding wizard is never enabled against a backend that
+  cannot serve `/v1/onboarding/*`
 - `IDENTRAIL_CORS_ALLOWED_ORIGINS` containing the web origins that need browser access
 - `IDENTRAIL_TRUSTED_PROXIES` containing the ALB/VPC proxy CIDRs so rate limits
   and audit events use the real browser client IP from `X-Forwarded-For`
@@ -94,10 +98,36 @@ Static URL validation catches missing values, non-HTTPS values, and accidental w
 VITE_IDENTRAIL_API_URL=https://api.identrail.com make production-api-url-check
 ```
 
-Full preflight probes the live API endpoints:
+Full preflight probes the live API endpoints — `GET /healthz`,
+`GET /v1/auth/config`, and `POST /v1/onboarding/start`:
 
 ```bash
 VITE_IDENTRAIL_API_URL=https://api.identrail.com make production-api-preflight
 ```
+
+The onboarding probe passes only on the unauthenticated JSON `401`
+session-required response. It fails closed otherwise, and the failure prefix
+names the cause so it is clear whether the problem is API URL wiring, a missing
+route registration, or a non-JSON frontend/404 response:
+
+- `api-url-wiring` — an HTML frontend shell was returned; `VITE_IDENTRAIL_API_URL`
+  points at the web app instead of the API origin.
+- `missing-route` — the route returned `404`; the API build does not register
+  `/v1/onboarding/start` (an API image predating the onboarding route, or a
+  wrong API base path).
+- `non-json` / `unexpected-status` — a plain-text framework `401` or any other
+  status; the route is not serving the expected JSON contract.
+
+Scope: this is an unauthenticated check of route presence and JSON contract
+shape. The backend `IDENTRAIL_FEATURE_ONBOARDING_WIZARD` flag is intentionally
+not observable here — the onboarding routes deliberately answer unauthenticated
+callers with the same JSON `401` whether the flag is on or off (an authenticated
+caller gets `503 {"error":"onboarding disabled"}` when it is off). Verifying the
+flag is enabled is therefore covered by the authenticated post-deploy steps
+above (a new user with no workspace must land on `/onboarding/org`), not by this
+preflight.
+
+This keeps the check generic for both Identrail Cloud and self-hosted production
+API URLs: it asserts the unauthenticated contract shape, not a specific host.
 
 Run the full preflight after DNS and TLS are live for `api.identrail.com`, and before changing Vercel production variables.

--- a/scripts/check_public_api_url.sh
+++ b/scripts/check_public_api_url.sh
@@ -12,7 +12,8 @@ Inputs:
   IDENTRAIL_WEB_ORIGINS        Optional comma-separated web origins to reject.
 
 Options:
-  --probe                      Also call /healthz and /v1/auth/config.
+  --probe                      Also call /healthz, /v1/auth/config, and
+                               POST /v1/onboarding/start.
   --allow-local                Permit http://localhost and http://127.0.0.1.
   -h, --help                   Show this help text.
 USAGE
@@ -39,76 +40,157 @@ fail() {
   exit 1
 }
 
-probe=false
-allow_local=false
-api_url="${VITE_IDENTRAIL_API_URL:-}"
-
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    --probe)
-      probe=true
-      ;;
-    --allow-local)
-      allow_local=true
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    --*)
-      fail "unknown option $1"
-      ;;
-    *)
-      api_url="$1"
-      ;;
-  esac
-  shift
-done
-
-api_url="$(trim "$api_url")"
-api_url="${api_url%/}"
-
-if [ -z "$api_url" ]; then
-  fail "VITE_IDENTRAIL_API_URL is required"
-fi
-
-if [[ "$api_url" =~ ^http://(localhost|127\.0\.0\.1)(:[0-9]+)?($|/) ]]; then
-  if [ "$allow_local" != "true" ]; then
-    fail "local HTTP URLs are not allowed for production API wiring"
+looks_like_html() {
+  local content_type="$1" body_prefix="$2"
+  if printf '%s' "$content_type" | grep -Eiq 'text/html'; then
+    return 0
   fi
-elif [[ ! "$api_url" =~ ^https://[^/[:space:]]+($|/) ]]; then
-  fail "use an absolute HTTPS API URL such as https://api.identrail.com"
-fi
-
-api_origin="$(lower "$(extract_origin "$api_url")")"
-web_origins="${IDENTRAIL_WEB_ORIGINS:-https://identrail.com,https://www.identrail.com,https://app.identrail.com}"
-IFS=',' read -r -a rejected_origins <<< "$web_origins"
-for rejected in "${rejected_origins[@]}"; do
-  rejected="$(lower "$(trim "${rejected%/}")")"
-  if [ -n "$rejected" ] && [ "$api_origin" = "$rejected" ]; then
-    fail "API URL points at web origin $rejected; use a dedicated API origin such as https://api.identrail.com"
+  if printf '%s' "$body_prefix" | grep -Eiq '<!doctype html|<html'; then
+    return 0
   fi
-done
+  return 1
+}
 
-if [ "$probe" = "true" ]; then
-  for path in /healthz /v1/auth/config; do
-    tmp_body="$(mktemp)"
-    tmp_headers="$(mktemp)"
-    status="$(curl -L -sS -o "$tmp_body" -D "$tmp_headers" -w '%{http_code}' "${api_url}${path}" || true)"
-    content_type="$(tr -d '\r' < "$tmp_headers" | awk 'BEGIN{IGNORECASE=1} /^content-type:/ {print $0}' | tail -n 1)"
-    body_prefix="$(head -c 256 "$tmp_body" | tr '\n' ' ')"
-    rm -f "$tmp_body" "$tmp_headers"
+looks_like_json() {
+  local content_type="$1" body_prefix="$2"
+  if printf '%s' "$content_type" | grep -Eiq 'application/json'; then
+    return 0
+  fi
+  if printf '%s' "$body_prefix" | grep -Eq '^[[:space:]]*[\{\[]'; then
+    return 0
+  fi
+  return 1
+}
 
-    if [ "$status" != "200" ]; then
-      fail "${api_url}${path} returned HTTP ${status}, expected 200"
+# classify_onboarding_probe STATUS CONTENT_TYPE BODY_PREFIX
+#
+# The unauthenticated production preflight expects POST /v1/onboarding/start to
+# answer with a JSON 401 ("session required"). Any other shape means the
+# onboarding wizard would be enabled against a backend that cannot serve it.
+# Prints a single-line diagnostic and returns non-zero on failure. The leading
+# token classifies the failure so operators can tell wiring problems from a
+# missing route from a non-JSON frontend/404 response.
+classify_onboarding_probe() {
+  local status="$1" content_type="$2" body_prefix="$3"
+
+  if looks_like_html "$content_type" "$body_prefix"; then
+    printf 'api-url-wiring: returned an HTML frontend shell instead of a JSON API response; VITE_IDENTRAIL_API_URL likely points at the web frontend, not the API'
+    return 1
+  fi
+
+  if [ "$status" = "404" ]; then
+    printf 'missing-route: returned HTTP 404; the onboarding route is not registered (deploy the onboarding API fix and set IDENTRAIL_FEATURE_ONBOARDING_WIZARD=true before enabling the web wizard)'
+    return 1
+  fi
+
+  if [ "$status" != "401" ]; then
+    printf 'unexpected-status: returned HTTP %s, expected the unauthenticated JSON 401 session-required response' "$status"
+    return 1
+  fi
+
+  if ! looks_like_json "$content_type" "$body_prefix"; then
+    printf 'non-json: returned HTTP 401 without a JSON body; expected a JSON session-required response, got a framework/plain-text 401'
+    return 1
+  fi
+
+  return 0
+}
+
+probe_endpoint() {
+  # probe_endpoint METHOD URL -> sets PROBE_STATUS, PROBE_CONTENT_TYPE,
+  # PROBE_BODY_PREFIX in the caller's scope.
+  local method="$1" url="$2"
+  local tmp_body tmp_headers
+  tmp_body="$(mktemp)"
+  tmp_headers="$(mktemp)"
+  PROBE_STATUS="$(curl -L -sS -X "$method" -o "$tmp_body" -D "$tmp_headers" -w '%{http_code}' "$url" || true)"
+  PROBE_CONTENT_TYPE="$(tr -d '\r' < "$tmp_headers" | awk 'BEGIN{IGNORECASE=1} /^content-type:/ {print $0}' | tail -n 1)"
+  PROBE_BODY_PREFIX="$(head -c 256 "$tmp_body" | tr '\n' ' ')"
+  rm -f "$tmp_body" "$tmp_headers"
+}
+
+main() {
+  local probe=false
+  local allow_local=false
+  local api_url="${VITE_IDENTRAIL_API_URL:-}"
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --probe)
+        probe=true
+        ;;
+      --allow-local)
+        allow_local=true
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      --*)
+        fail "unknown option $1"
+        ;;
+      *)
+        api_url="$1"
+        ;;
+    esac
+    shift
+  done
+
+  api_url="$(trim "$api_url")"
+  api_url="${api_url%/}"
+
+  if [ -z "$api_url" ]; then
+    fail "VITE_IDENTRAIL_API_URL is required"
+  fi
+
+  if [[ "$api_url" =~ ^http://(localhost|127\.0\.0\.1)(:[0-9]+)?($|/) ]]; then
+    if [ "$allow_local" != "true" ]; then
+      fail "local HTTP URLs are not allowed for production API wiring"
     fi
-    if printf '%s' "$content_type" | grep -Eiq 'text/html'; then
-      fail "${api_url}${path} returned HTML, which usually means the URL points at the frontend"
-    fi
-    if printf '%s' "$body_prefix" | grep -Eiq '<!doctype html|<html'; then
-      fail "${api_url}${path} returned an HTML page, not an API response"
+  elif [[ ! "$api_url" =~ ^https://[^/[:space:]]+($|/) ]]; then
+    fail "use an absolute HTTPS API URL such as https://api.identrail.com"
+  fi
+
+  local api_origin web_origins
+  api_origin="$(lower "$(extract_origin "$api_url")")"
+  web_origins="${IDENTRAIL_WEB_ORIGINS:-https://identrail.com,https://www.identrail.com,https://app.identrail.com}"
+  local rejected_origins rejected
+  IFS=',' read -r -a rejected_origins <<< "$web_origins"
+  for rejected in "${rejected_origins[@]}"; do
+    rejected="$(lower "$(trim "${rejected%/}")")"
+    if [ -n "$rejected" ] && [ "$api_origin" = "$rejected" ]; then
+      fail "API URL points at web origin $rejected; use a dedicated API origin such as https://api.identrail.com"
     fi
   done
-fi
 
-printf 'Identrail API URL check passed: %s\n' "$api_url"
+  if [ "$probe" = "true" ]; then
+    local path
+    for path in /healthz /v1/auth/config; do
+      probe_endpoint GET "${api_url}${path}"
+      if [ "$PROBE_STATUS" != "200" ]; then
+        fail "${api_url}${path} returned HTTP ${PROBE_STATUS}, expected 200"
+      fi
+      if looks_like_html "$PROBE_CONTENT_TYPE" "$PROBE_BODY_PREFIX"; then
+        fail "${api_url}${path} returned HTML, which usually means the URL points at the frontend"
+      fi
+    done
+
+    # Onboarding route coverage: a healthy /v1/auth/config alongside a 404 (or
+    # frontend shell) onboarding route is exactly the regression that let
+    # production enable the wizard against a missing backend route.
+    path=/v1/onboarding/start
+    probe_endpoint POST "${api_url}${path}"
+    local reason
+    if ! reason="$(classify_onboarding_probe "$PROBE_STATUS" "$PROBE_CONTENT_TYPE" "$PROBE_BODY_PREFIX")"; then
+      fail "${api_url}${path} ${reason}"
+    fi
+  fi
+
+  printf 'Identrail API URL check passed: %s\n' "$api_url"
+}
+
+# Allow the test harness to source this file and exercise the pure
+# classification helpers without running the CLI.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi

--- a/scripts/check_public_api_url_test.sh
+++ b/scripts/check_public_api_url_test.sh
@@ -24,6 +24,48 @@ expect_fail() {
   fi
 }
 
+# shellcheck source=scripts/check_public_api_url.sh
+. "$check_script"
+
+expect_onboarding_pass() {
+  local name="$1" status="$2" content_type="$3" body="$4"
+  if ! classify_onboarding_probe "$status" "$content_type" "$body" >/dev/null; then
+    printf 'FAIL expected onboarding pass: %s\n' "$name" >&2
+    exit 1
+  fi
+}
+
+expect_onboarding_fail() {
+  local name="$1" want_class="$2" status="$3" content_type="$4" body="$5"
+  local reason
+  if reason="$(classify_onboarding_probe "$status" "$content_type" "$body")"; then
+    printf 'FAIL expected onboarding failure: %s\n' "$name" >&2
+    exit 1
+  fi
+  if [ "${reason%%:*}" != "$want_class" ]; then
+    printf 'FAIL onboarding classification for %s: want %s, got %q\n' "$name" "$want_class" "$reason" >&2
+    exit 1
+  fi
+}
+
+expect_onboarding_pass "json 401 session required" \
+  "401" "content-type: application/json" '{"error":"session required"}'
+expect_onboarding_pass "json 401 without content-type header" \
+  "401" "" '{"error":"session required"}'
+
+expect_onboarding_fail "missing route 404" missing-route \
+  "404" "text/plain; charset=utf-8" "404 page not found"
+expect_onboarding_fail "html frontend shell" api-url-wiring \
+  "200" "content-type: text/html; charset=utf-8" "<!doctype html><html><head>"
+expect_onboarding_fail "html shell served with 401" api-url-wiring \
+  "401" "text/html" "<html><body>login</body></html>"
+expect_onboarding_fail "plain text 401" non-json \
+  "401" "text/plain; charset=utf-8" "Unauthorized"
+expect_onboarding_fail "unexpected 500" unexpected-status \
+  "500" "application/json" '{"error":"boom"}'
+expect_onboarding_fail "unexpected 200 html-free" unexpected-status \
+  "200" "application/json" '{"ok":true}'
+
 expect_pass "dedicated https api origin" "https://api.identrail.com"
 expect_pass "api origin with base path" "https://api.identrail.com/service"
 expect_pass "local dev with opt-in" --allow-local "http://localhost:8080"


### PR DESCRIPTION
## Summary
- Extends `make production-api-preflight` to probe `POST /v1/onboarding/start` in addition to `/healthz` and `/v1/auth/config`, so the frontend onboarding wizard can no longer be wired against a backend missing the onboarding route — the regression behind #1172 (fixed in #1180).
- The probe treats the unauthenticated JSON `401` session-required response as success, and fails closed on `404`, plain-text framework `404`, HTML, and frontend-shell responses. The failure message is prefixed (`api-url-wiring`, `missing-route`, `non-json`, `unexpected-status`) so it is clear whether the cause is API URL wiring, a missing route registration, or a non-JSON frontend/404 response.
- Kept generic for Identrail Cloud and self-hosted production API URLs: it asserts the unauthenticated contract shape, not a specific host.
- Refactored `check_public_api_url.sh` so response classification is a pure, sourceable helper, and added offline tests in `check_public_api_url_test.sh` covering each pass/fail class (matching the repo's existing offline script-test pattern).
- Documented the behavior in `docs/auth/production-api-readiness.md` and `CHANGELOG.md`.

Static URL validation (`make production-api-url-check`) and the CI `vercel-production-deploy` static invocation are unchanged — the new probe only runs under `--probe`.

## Acceptance criteria
- [x] `make production-api-preflight` fails if `/v1/onboarding/start` returns 404 (verified end-to-end against a local mock returning 404).
- [x] `make production-api-preflight` passes when `/v1/onboarding/start` returns the expected unauthenticated JSON 401.
- [x] The check still validates `/healthz` and `/v1/auth/config`.
- [x] Failure output distinguishes API URL wiring vs. missing route registration vs. non-JSON frontend/404 response.

## Test plan
- [x] `bash scripts/check_public_api_url_test.sh` (offline classification + arg-validation tests pass)
- [x] `make production-api-url-check` still passes (existing static behavior preserved)
- [x] End-to-end `--probe` run against a local mock API for good / missing-route / HTML-shell scenarios
- [ ] Run `make production-api-preflight` against `https://api.identrail.com` now that #1172 (#1180) is deployed

## AI assistance disclosure
This change was prepared with AI assistance (Claude Code). All logic, tests, and docs were reviewed before submission.

Closes #1173

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend the production API preflight to probe POST /v1/onboarding/start so the onboarding wizard can’t point at a backend missing the route. Treat the unauthenticated JSON 401 as success and fail with clear, prefixed reasons otherwise. Addresses #1173.

- New Features
  - Probe POST /v1/onboarding/start alongside /healthz and /v1/auth/config.
  - Classify failures with prefixes: api-url-wiring, missing-route, non-json, unexpected-status.
  - Scope is unauthenticated route + JSON contract; the feature flag isn’t observable. Generic for Cloud and self‑hosted.

- Refactors
  - Moved response classification into a pure, sourceable helper in scripts/check_public_api_url.sh.
  - Added offline tests in scripts/check_public_api_url_test.sh covering pass/fail classes.
  - Documented behavior in docs/auth/production-api-readiness.md and updated CHANGELOG.

<sup>Written for commit cf905220ef01e45e615de5df150f746aaf40cd67. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1181?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

