### PR TITLE
Redesign product page with full-bleed Vercel layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Redesigned the product page as a full-bleed Vercel-style surface with a dark hero, spread-out trust graph connections, alternating neutral sections, and no centered container around the main product story.
 - Redesigned the read-only scan intake page with a full-width black Vercel-style hero, sharper SpaceX-inspired headline typography, and high-contrast intake controls with no blurred or gradient details.
 - Extended the production API preflight (`make production-api-preflight`) to probe
   `POST /v1/onboarding/start` so the frontend onboarding wizard cannot be wired

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -115,6 +115,8 @@ describe('App', () => {
     expect(screen.getByRole('heading', { level: 2, name: /The Trust Graph is the control plane/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 2, name: /From discovery to fix/i })).toBeInTheDocument();
     expect(screen.getAllByRole('link', { name: /Start Free Risk Scan/i }).length).toBeGreaterThan(0);
+    expect(document.querySelector('main main')).not.toBeInTheDocument();
+    expect(document.querySelector('.idt-product-hero-visual')).toHaveAttribute('aria-hidden', 'true');
   });
 
   it('renders read-only scan intake flow route', () => {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -100,6 +100,23 @@ describe('App', () => {
     expect(screen.getByRole('button', { name: 'Contact Sales' })).toBeInTheDocument();
   });
 
+  it('renders the full-bleed product page story', () => {
+    setCurrentPath('/product');
+    render(<App />);
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /Machine identity risk, mapped end to end/i
+      })
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole('heading', { level: 2, name: /Four connected surfaces/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: /The Trust Graph is the control plane/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: /From discovery to fix/i })).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: /Start Free Risk Scan/i }).length).toBeGreaterThan(0);
+  });
+
   it('renders read-only scan intake flow route', () => {
     setCurrentPath('/read-only-scan');
     render(<App />);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -595,7 +595,7 @@ function PageHero({
 
 function ProductHeroVisual() {
   return (
-    <div className="idt-product-hero-visual">
+    <div className="idt-product-hero-visual" aria-hidden="true">
       <div className="idt-product-hero-window">
         <div className="idt-visual-window-bar">
           <span />
@@ -2075,7 +2075,7 @@ function ProductPage() {
   });
 
   return (
-    <main className="idt-product-page">
+    <div className="idt-product-page">
       <section className="idt-product-hero-full">
         <div className="idt-product-hero-copy">
           <p className="idt-eyebrow">Product</p>
@@ -2191,7 +2191,7 @@ function ProductPage() {
           </div>
         </div>
       </section>
-    </main>
+    </div>
   );
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -610,13 +610,13 @@ function ProductHeroVisual() {
             <span>Fixes</span>
           </div>
           <div className="idt-product-hero-graph">
-            <svg viewBox="0 0 440 290" aria-hidden="true" focusable="false">
-              <path className="is-muted" d="M142 76 C208 64 248 124 308 116 S384 94 404 122" />
-              <path className="is-risk" d="M146 122 C214 142 255 172 284 212 S352 248 404 234" />
-              <path className="is-safe" d="M193 205 C222 190 248 180 286 178" />
-              <circle className="idt-graph-node is-risk" cx="146" cy="122" r="5" />
-              <circle className="idt-graph-node is-risk" cx="286" cy="178" r="5" />
-              <circle className="idt-graph-node is-risk" cx="404" cy="234" r="5" />
+            <svg viewBox="0 0 720 420" aria-hidden="true" focusable="false">
+              <path className="is-muted" d="M118 118 C236 82 316 154 430 132 S600 92 658 166" />
+              <path className="is-risk" d="M310 236 C400 236 450 296 520 330 S620 358 675 318" />
+              <path className="is-safe" d="M196 330 C274 286 354 264 452 258" />
+              <circle className="idt-graph-node is-risk" cx="118" cy="118" r="6" />
+              <circle className="idt-graph-node is-risk" cx="452" cy="258" r="6" />
+              <circle className="idt-graph-node is-risk" cx="675" cy="318" r="6" />
             </svg>
             <div className="idt-graph-pill is-github">
               <strong>GitHub OIDC</strong>
@@ -2075,28 +2075,35 @@ function ProductPage() {
   });
 
   return (
-    <>
-      <PageHero
-        eyebrow="Product"
-        title="One platform for machine identity visibility, detection, and control"
-        body="Identrail unifies IAM graph discovery, repository exposure scanning, and rollout-safe authorization workflows into one operator-grade platform."
-        variant="product"
-        visual={<ProductHeroVisual />}
-        actions={
-          <>
+    <main className="idt-product-page">
+      <section className="idt-product-hero-full">
+        <div className="idt-product-hero-copy">
+          <p className="idt-eyebrow">Product</p>
+          <h1>Machine identity risk, mapped end to end</h1>
+          <p>
+            Identrail unifies IAM graph discovery, repository exposure scanning, and rollout-safe authorization
+            workflows into one operator-grade platform.
+          </p>
+          <div className="idt-inline-actions">
             <Link to="/demo" className="idt-btn idt-btn-primary">
               Explore Product Demo
             </Link>
             <Link to="/read-only-scan" className="idt-btn idt-btn-dark">
               Start Free Risk Scan
             </Link>
-          </>
-        }
-      />
+          </div>
+        </div>
+        <ProductHeroVisual />
+      </section>
 
-      <section className="idt-section idt-shell">
-        <div className="idt-card-grid two-col idt-product-capabilities">
-          <article className="idt-card">
+      <section className="idt-product-capability-band" aria-labelledby="product-capabilities-title">
+        <div className="idt-product-section-heading">
+          <p className="idt-eyebrow">Platform map</p>
+          <h2 id="product-capabilities-title">Four connected surfaces, spread across one workflow.</h2>
+        </div>
+        <div className="idt-product-capability-grid">
+          <article>
+            <span>01</span>
             <h2>Trust Graph Explorer</h2>
             <p>Interactive mapping of principals, assumptions, actions, and reachable resources across cloud and Kubernetes.</p>
             <ul>
@@ -2105,7 +2112,8 @@ function ProductPage() {
               <li>Compare current and proposed policy states</li>
             </ul>
           </article>
-          <article className="idt-card">
+          <article>
+            <span>02</span>
             <h2>Detection and Triage Engine</h2>
             <p>High-signal detections for overprivileged paths, stale credentials, and risky identity chains.</p>
             <ul>
@@ -2114,7 +2122,8 @@ function ProductPage() {
               <li>Ticket and workflow integrations</li>
             </ul>
           </article>
-          <article className="idt-card">
+          <article>
+            <span>03</span>
             <h2>Repo Exposure Scanner</h2>
             <p>Continuously scan source repositories and CI artifacts for leaked credentials and unsafe patterns.</p>
             <ul>
@@ -2123,7 +2132,8 @@ function ProductPage() {
               <li>Correlates secret leaks to trust paths</li>
             </ul>
           </article>
-          <article className="idt-card">
+          <article>
+            <span>04</span>
             <h2>Rollout-Safe Authorization Controls</h2>
             <p>Enforce least privilege with policy simulation, staged rollout, and fast rollback safety rails.</p>
             <ul>
@@ -2135,23 +2145,53 @@ function ProductPage() {
         </div>
       </section>
 
-      <section className="idt-section idt-shell">
-        <SectionTitle
-          eyebrow="Hero Feature"
-          title="The Trust Graph: your control plane for machine identity risk"
-          body="Investigate every risky path from source identity to sensitive resource with explainable graph evidence."
-        />
-        <TrustGraphDemo />
+      <section className="idt-product-graph-band">
+        <div className="idt-product-section-heading">
+          <p className="idt-eyebrow">Hero feature</p>
+          <h2>The Trust Graph is the control plane for machine identity risk.</h2>
+          <p>
+            Investigate every risky path from source identity to sensitive resource with explainable graph evidence and
+            owner-ready remediation.
+          </p>
+        </div>
+        <TrustGraphDemo variant="full" />
       </section>
 
-      <section className="idt-section idt-shell">
-        <LeadCaptureForm
-          title="Want a technical walkthrough?"
-          caption="Book a product session with platform architects and security engineers."
-          ctaLabel="Book Demo"
-        />
+      <section className="idt-product-workflow-band" aria-labelledby="product-workflow-title">
+        <div className="idt-product-section-heading">
+          <p className="idt-eyebrow">Workflow</p>
+          <h2 id="product-workflow-title">From discovery to fix without collapsing the context.</h2>
+        </div>
+        <div className="idt-product-workflow-grid">
+          <article>
+            <span>Discover</span>
+            <strong>Map the reachable identity graph across repositories, cloud roles, and Kubernetes workloads.</strong>
+          </article>
+          <article>
+            <span>Prioritize</span>
+            <strong>Separate noisy permissions from the paths that can actually reach sensitive resources.</strong>
+          </article>
+          <article>
+            <span>Control</span>
+            <strong>Ship least-privilege fixes with simulation, audit history, and rollback-ready guardrails.</strong>
+          </article>
+        </div>
+        <div className="idt-product-cta-row">
+          <div>
+            <p className="idt-eyebrow">Technical walkthrough</p>
+            <h2>Bring one risky path. Leave with the evidence and rollout plan.</h2>
+          </div>
+          <div className="idt-inline-actions">
+            <Link to="/demo" className="idt-btn idt-btn-primary">
+              Book Demo
+            </Link>
+            <Link to="/docs" className="idt-btn idt-btn-dark">
+              Review Docs
+            </Link>
+          </div>
+        </div>
       </section>
-    </>
+    </main>
   );
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -10388,6 +10388,578 @@ html[data-theme='light'] .idt-page-hero-rich::after,
   font-size: 1.35rem;
 }
 
+.idt-product-page {
+  background: #ffffff;
+  color: #0a0a0a;
+  overflow: hidden;
+}
+
+.idt-product-page .idt-eyebrow {
+  color: currentColor;
+}
+
+.idt-product-hero-full {
+  display: grid;
+  grid-template-columns: minmax(320px, 0.72fr) minmax(580px, 1.28fr);
+  gap: clamp(2rem, 5vw, 6rem);
+  align-items: center;
+  min-height: calc(100vh - 150px);
+  padding: 4.8rem clamp(1.25rem, 5vw, 6rem) 4.6rem;
+  border-bottom: 1px solid #1f1f1f;
+  background: #000000;
+  color: #ffffff;
+}
+
+.idt-product-hero-copy {
+  min-width: 0;
+}
+
+.idt-product-hero-copy h1 {
+  max-width: 12ch;
+  margin: 0.85rem 0 0;
+  color: #ffffff;
+  font-family: 'Barlow Semi Condensed', 'Arial Narrow', Arial, sans-serif;
+  font-size: 5.5rem;
+  font-weight: 800;
+  line-height: 0.96;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.idt-product-hero-copy > p:not(.idt-eyebrow) {
+  max-width: 48rem;
+  margin: 1.35rem 0 0;
+  color: #a1a1aa;
+  font-size: 1.08rem;
+  line-height: 1.75;
+}
+
+.idt-product-hero-copy .idt-inline-actions {
+  margin-top: 1.85rem;
+}
+
+.idt-product-page .idt-btn {
+  border-radius: 8px;
+}
+
+.idt-product-page .idt-btn-primary {
+  border-color: #ffffff;
+  background: #ffffff;
+  color: #000000;
+  box-shadow: none;
+}
+
+.idt-product-page .idt-btn-dark {
+  border-color: #303030;
+  background: #050505;
+  color: #ffffff;
+  box-shadow: none;
+}
+
+.idt-product-page .idt-product-hero-visual {
+  align-self: stretch;
+  min-height: 560px;
+}
+
+.idt-product-page .idt-product-hero-window {
+  height: 100%;
+  border-color: #242424;
+  background: #050505;
+  box-shadow: none;
+}
+
+.idt-product-page .idt-visual-window-bar {
+  min-height: 44px;
+  border-bottom-color: #242424;
+  background: #070707;
+}
+
+.idt-product-page .idt-visual-window-bar span {
+  background: #3f3f46;
+}
+
+.idt-product-page .idt-visual-window-bar strong {
+  color: #ffffff;
+}
+
+.idt-product-page .idt-product-hero-body {
+  grid-template-columns: 132px 1fr;
+  min-height: calc(100% - 44px);
+  height: calc(100% - 44px);
+}
+
+.idt-product-page .idt-product-hero-sidebar {
+  border-right-color: #242424;
+  background: #050505;
+}
+
+.idt-product-page .idt-product-hero-sidebar span {
+  color: #a1a1aa;
+}
+
+.idt-product-page .idt-product-hero-sidebar .is-active {
+  background: #ffffff;
+  color: #000000;
+}
+
+.idt-product-page .idt-product-hero-graph {
+  min-height: 516px;
+  background: #050505;
+}
+
+.idt-product-page .idt-product-hero-graph .is-muted {
+  stroke: #71717a;
+}
+
+.idt-product-page .idt-product-hero-graph .is-risk {
+  stroke: #ffffff;
+  filter: none;
+}
+
+.idt-product-page .idt-product-hero-graph .is-safe {
+  stroke: #a1a1aa;
+}
+
+.idt-product-page .idt-graph-node.is-risk {
+  fill: #ffffff;
+  stroke: #000000;
+  filter: none;
+}
+
+.idt-product-page .idt-graph-pill {
+  min-width: 168px;
+  border-color: #2a2a2a;
+  background: #0b0b0b;
+  box-shadow: none;
+}
+
+.idt-product-page .idt-graph-pill strong {
+  color: #ffffff;
+  font-size: 0.9rem;
+}
+
+.idt-product-page .idt-graph-pill span {
+  color: #10b981;
+  font-size: 0.74rem;
+}
+
+.idt-product-page .idt-graph-pill.is-github {
+  top: 14%;
+  left: 6%;
+}
+
+.idt-product-page .idt-graph-pill.is-aws {
+  top: 18%;
+  right: 5%;
+}
+
+.idt-product-page .idt-graph-pill.is-k8s {
+  top: 48%;
+  left: 39%;
+}
+
+.idt-product-page .idt-graph-pill.is-data {
+  left: 54%;
+  right: auto;
+  bottom: 25%;
+}
+
+.idt-product-page .idt-graph-pill.is-data span,
+.idt-product-page .idt-graph-pill.is-aws span {
+  color: #ef4444;
+}
+
+.idt-product-page .idt-product-evidence-card {
+  left: 7%;
+  bottom: 11%;
+  width: 270px;
+  border: 1px solid #2a2a2a;
+  background: #ffffff;
+  color: #000000;
+  box-shadow: none;
+}
+
+.idt-product-page .idt-product-evidence-card span,
+.idt-product-page .idt-product-evidence-card p {
+  color: #52525b;
+}
+
+.idt-product-page .idt-product-evidence-card strong {
+  color: #000000;
+  font-size: 0.92rem;
+}
+
+.idt-product-page .idt-product-hero-queue {
+  right: 4%;
+  bottom: 4%;
+  width: 222px;
+  border-color: #2a2a2a;
+  background: #ffffff;
+  box-shadow: none;
+}
+
+.idt-product-page .idt-product-hero-queue span,
+.idt-product-page .idt-product-hero-queue p {
+  color: #52525b;
+}
+
+.idt-product-page .idt-product-hero-queue strong {
+  color: #000000;
+}
+
+.idt-product-capability-band,
+.idt-product-graph-band,
+.idt-product-workflow-band {
+  padding: 5.5rem clamp(1.25rem, 5vw, 6rem);
+}
+
+.idt-product-section-heading {
+  max-width: 62rem;
+}
+
+.idt-product-section-heading h2 {
+  margin: 0.55rem 0 0;
+  color: inherit;
+  font-family: 'Barlow Semi Condensed', 'Arial Narrow', Arial, sans-serif;
+  font-size: 4.25rem;
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.idt-product-section-heading > p:not(.idt-eyebrow) {
+  max-width: 44rem;
+  margin: 1rem 0 0;
+  color: #a1a1aa;
+  font-size: 1.04rem;
+  line-height: 1.72;
+}
+
+.idt-product-capability-band {
+  background: #ffffff;
+  color: #09090b;
+}
+
+.idt-product-capability-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-top: 3rem;
+  border-top: 1px solid #e4e4e7;
+  border-bottom: 1px solid #e4e4e7;
+}
+
+.idt-product-capability-grid article {
+  min-height: 420px;
+  padding: 1.5rem;
+  border-right: 1px solid #e4e4e7;
+}
+
+.idt-product-capability-grid article:last-child {
+  border-right: 0;
+}
+
+.idt-product-capability-grid article > span {
+  color: #71717a;
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.idt-product-capability-grid h2 {
+  max-width: 11ch;
+  margin: 5rem 0 0;
+  color: #09090b;
+  font-size: 2.25rem;
+  line-height: 1.02;
+}
+
+.idt-product-capability-grid p {
+  margin: 1rem 0 0;
+  color: #52525b;
+  line-height: 1.65;
+}
+
+.idt-product-capability-grid ul {
+  display: grid;
+  gap: 0.52rem;
+  margin: 1.2rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.idt-product-capability-grid li {
+  color: #27272a;
+  font-size: 0.92rem;
+}
+
+.idt-product-capability-grid li::before {
+  content: '';
+  display: inline-block;
+  width: 0.38rem;
+  height: 0.38rem;
+  margin-right: 0.55rem;
+  border-radius: 999px;
+  background: #09090b;
+  vertical-align: 0.08em;
+}
+
+.idt-product-graph-band {
+  display: grid;
+  grid-template-columns: minmax(300px, 0.46fr) minmax(0, 1.54fr);
+  gap: clamp(2rem, 5vw, 5rem);
+  align-items: start;
+  border-top: 1px solid #202020;
+  border-bottom: 1px solid #202020;
+  background: #000000;
+  color: #ffffff;
+}
+
+.idt-product-graph-band .idt-product-section-heading {
+  position: sticky;
+  top: 6rem;
+}
+
+.idt-product-graph-band .idt-demo-surface {
+  border-color: #262626;
+  border-radius: 8px;
+  background: #050505;
+  box-shadow: none;
+}
+
+.idt-product-graph-band .idt-demo-toolbar,
+.idt-product-graph-band .idt-demo-graph,
+.idt-product-graph-band .idt-demo-detail,
+.idt-product-graph-band .idt-demo-list-panel {
+  border-color: #262626;
+  background: #0a0a0a;
+  box-shadow: none;
+}
+
+.idt-product-workflow-band {
+  background: #f5f5f5;
+  color: #09090b;
+}
+
+.idt-product-workflow-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  margin-top: 3rem;
+  background: #d4d4d8;
+}
+
+.idt-product-workflow-grid article {
+  min-height: 260px;
+  padding: 1.5rem;
+  background: #f5f5f5;
+}
+
+.idt-product-workflow-grid span {
+  color: #71717a;
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.idt-product-workflow-grid strong {
+  display: block;
+  max-width: 19rem;
+  margin-top: 4.6rem;
+  color: #09090b;
+  font-size: 1.6rem;
+  line-height: 1.12;
+}
+
+.idt-product-cta-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 2rem;
+  align-items: end;
+  margin-top: 4rem;
+  padding-top: 2rem;
+  border-top: 1px solid #d4d4d8;
+}
+
+.idt-product-cta-row h2 {
+  max-width: 15ch;
+  margin: 0.45rem 0 0;
+  color: #09090b;
+  font-size: 3.1rem;
+  line-height: 1;
+}
+
+@media (max-width: 1180px) {
+  .idt-product-hero-full,
+  .idt-product-graph-band {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-product-hero-copy h1 {
+    max-width: 12ch;
+    font-size: 4.8rem;
+  }
+
+  .idt-product-page .idt-product-hero-visual {
+    min-height: 520px;
+  }
+
+  .idt-product-capability-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .idt-product-capability-grid article:nth-child(2) {
+    border-right: 0;
+  }
+
+  .idt-product-capability-grid article:nth-child(-n + 2) {
+    border-bottom: 1px solid #e4e4e7;
+  }
+
+  .idt-product-graph-band .idt-product-section-heading {
+    position: static;
+  }
+}
+
+@media (max-width: 760px) {
+  .idt-product-hero-full,
+  .idt-product-capability-band,
+  .idt-product-graph-band,
+  .idt-product-workflow-band {
+    padding-inline: 1rem;
+  }
+
+  .idt-product-hero-full {
+    min-height: 0;
+    padding-block: 2.4rem;
+  }
+
+  .idt-product-hero-copy h1 {
+    font-size: 3.3rem;
+  }
+
+  .idt-product-section-heading h2 {
+    font-size: 2.7rem;
+  }
+
+  .idt-product-page .idt-product-hero-window {
+    height: auto;
+  }
+
+  .idt-product-page .idt-product-hero-body {
+    grid-template-columns: 1fr;
+    height: auto;
+  }
+
+  .idt-product-page .idt-product-hero-sidebar {
+    display: none;
+  }
+
+  .idt-product-page .idt-product-hero-visual {
+    display: none;
+  }
+
+  .idt-product-page .idt-graph-pill {
+    min-width: 132px;
+    padding: 0.68rem;
+  }
+
+  .idt-product-page .idt-graph-pill strong {
+    font-size: 0.78rem;
+  }
+
+  .idt-product-page .idt-graph-pill.is-k8s {
+    left: 24%;
+  }
+
+  .idt-product-page .idt-graph-pill.is-data {
+    right: 4%;
+  }
+
+  .idt-product-page .idt-product-evidence-card,
+  .idt-product-page .idt-product-hero-queue {
+    width: min(72vw, 260px);
+  }
+
+  .idt-product-capability-grid,
+  .idt-product-workflow-grid,
+  .idt-product-cta-row {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-product-capability-grid article,
+  .idt-product-capability-grid article:nth-child(2) {
+    min-height: 0;
+    border-right: 0;
+    border-bottom: 1px solid #e4e4e7;
+  }
+
+  .idt-product-capability-grid article:last-child {
+    border-bottom: 0;
+  }
+
+  .idt-product-capability-grid h2,
+  .idt-product-workflow-grid strong {
+    margin-top: 2.2rem;
+  }
+
+  .idt-product-cta-row {
+    align-items: start;
+  }
+
+  .idt-product-cta-row h2 {
+    font-size: 2.35rem;
+  }
+}
+
+html[data-theme='light'] .idt-product-page .idt-product-hero-full,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band {
+  background: #000000;
+  color: #ffffff;
+}
+
+html[data-theme='light'] .idt-product-page .idt-product-hero-copy h1,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-product-section-heading h2 {
+  color: #ffffff;
+}
+
+html[data-theme='light'] .idt-product-page .idt-product-hero-copy > p:not(.idt-eyebrow),
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-product-section-heading > p:not(.idt-eyebrow) {
+  color: #a1a1aa;
+}
+
+html[data-theme='light'] .idt-product-page .idt-product-hero-copy .idt-eyebrow,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-eyebrow {
+  color: #ffffff;
+}
+
+html[data-theme='light'] .idt-product-page .idt-product-hero-copy .idt-btn-primary,
+html[data-theme='light'] .idt-product-page .idt-product-cta-row .idt-btn-primary {
+  border-color: #ffffff;
+  background: #ffffff;
+  color: #000000;
+  box-shadow: none;
+}
+
+html[data-theme='light'] .idt-product-page .idt-product-hero-copy .idt-btn-dark,
+html[data-theme='light'] .idt-product-page .idt-product-cta-row .idt-btn-dark {
+  border-color: #303030;
+  background: #050505;
+  color: #ffffff;
+  box-shadow: none;
+}
+
+html[data-theme='light'] .idt-product-page .idt-product-capability-band,
+html[data-theme='light'] .idt-product-page .idt-product-workflow-band {
+  color: #09090b;
+}
+
+html[data-theme='light'] .idt-product-page .idt-product-capability-grid h2,
+html[data-theme='light'] .idt-product-page .idt-product-workflow-grid strong,
+html[data-theme='light'] .idt-product-page .idt-product-cta-row h2 {
+  color: #09090b;
+}
+
 .idt-pricing-hero-visual {
   display: grid;
   align-content: center;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -10391,7 +10391,7 @@ html[data-theme='light'] .idt-page-hero-rich::after,
 .idt-product-page {
   background: #ffffff;
   color: #0a0a0a;
-  overflow: hidden;
+  overflow-x: hidden;
 }
 
 .idt-product-page .idt-eyebrow {


### PR DESCRIPTION
No issue: user-requested product page redesign.

## What changed
- Rebuilt `/product` as a dedicated full-bleed product page instead of using the shared centered page shell.
- Added a dark Vercel-style hero with SpaceX-inspired condensed headline typography and a wider trust-graph visual.
- Replaced centered capability cards with edge-to-edge product columns, a dark trust-graph feature band, and a light workflow/CTA section so the page is not all black.
- Added product-route coverage for the new page story.

## Why
The product page felt boxed in and the trust graph connections were packed into the middle. This makes the page feel more premium and spacious while preserving the machine-identity graph story.

## Impact and risk
- Public web UI only; no API or backend behavior changes.
- Mobile hides the large hero graph to keep the page from becoming a long black block and leaves the next section visible.

## Validation
- `npm test -- --run src/App.test.tsx -t "renders the full-bleed product page story"`
- `npm run build`
- `npm run test:ci`
- Browser preview checks at desktop and mobile widths: no horizontal overflow, dark hero colors applied in light theme, graph cards do not overlap, and next section is visible from the hero.

## AI usage
- AI-assisted: yes
- Tools used: Codex
- Where used: `web/src/App.tsx`, `web/src/App.test.tsx`, `web/src/styles.css`, `CHANGELOG.md`
- Human verification performed: local tests, production build, and browser preview checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the `/product` page with a full-bleed, Vercel-style layout featuring a dark hero and wider Trust Graph, replacing the centered shell. Improves readability, accessibility, and mobile behavior.

- **New Features**
  - Full-bleed product surface with dark hero, condensed H1, and expanded Trust Graph visual.
  - Edge-to-edge capability grid; dark Trust Graph feature band with the full demo variant; light workflow + CTA.
  - Responsive tweaks: hide the hero visual on small screens; no horizontal overflow.
  - Added tests for the product story and CTAs.
  - UI-only; no API or backend changes.

- **Bug Fixes**
  - Removed nested main landmark; improved section semantics with `aria-labelledby`.
  - Marked the hero visual `aria-hidden` for assistive tech.

<sup>Written for commit a441476078ddb8f8e5486034130af26a583d0b87. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1182?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

