### PR TITLE
Expose backend feature availability to the frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 - Redesigned the product page as a full-bleed Vercel-style surface with a dark hero, spread-out trust graph connections, alternating neutral sections, and no centered container around the main product story.
+- Exposed backend feature availability to the frontend so the web bundle no
+  longer shows a backend-gated self-serve flow purely from a Vite build flag:
+  - `/v1/auth/config` now returns a `features` object (`onboarding_wizard` and
+    per-connector `github`/`aws`/`kubernetes` booleans). It is additive and
+    session-safe — only availability booleans, never credentials or config.
+  - The app discovers onboarding/connector availability from the API before
+    entering those flows. When the bundle ships a feature the API does not
+    serve, it shows a clear "not enabled on this API" state instead of a raw
+    `Request failed (404)`, and the onboarding connector picker marks such
+    connectors unavailable rather than actionable.
+  - Resilient by design: an older API without `features`, or a failed
+    `auth/config` call, falls back to the existing Vite-flag behavior; the
+    strict block only applies when the API explicitly reports a route missing.
 - Redesigned the read-only scan intake page with a full-width black Vercel-style hero, sharper SpaceX-inspired headline typography, and high-contrast intake controls with no blurred or gradient details.
 - Extended the production API preflight (`make production-api-preflight`) to probe
   `POST /v1/onboarding/start` so the frontend onboarding wizard cannot be wired

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -1366,6 +1366,26 @@ paths:
                         type: array
                         items:
                           type: string
+                  features:
+                    type: object
+                    description: >-
+                      Backend-gated, self-serve feature availability so the web
+                      bundle does not show a flow the API cannot serve. Carries
+                      only availability booleans; never credentials or config.
+                    required: [onboarding_wizard, connectors]
+                    properties:
+                      onboarding_wizard:
+                        type: boolean
+                      connectors:
+                        type: object
+                        required: [github, aws, kubernetes]
+                        properties:
+                          github:
+                            type: boolean
+                          aws:
+                            type: boolean
+                          kubernetes:
+                            type: boolean
   /v1/onboarding/start:
     parameters:
       - $ref: "#/components/parameters/scopeTenantID"

--- a/internal/api/auth_config_test.go
+++ b/internal/api/auth_config_test.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+type authConfigBody struct {
+	Auth struct {
+		ManualMode         bool     `json:"manual_mode"`
+		WorkOSLoginEnabled bool     `json:"workos_login_enabled"`
+		NativeSAMLEnabled  bool     `json:"native_saml_enabled"`
+		Providers          []string `json:"providers"`
+	} `json:"auth"`
+	Features struct {
+		OnboardingWizard bool `json:"onboarding_wizard"`
+		Connectors       struct {
+			GitHub     bool `json:"github"`
+			AWS        bool `json:"aws"`
+			Kubernetes bool `json:"kubernetes"`
+		} `json:"connectors"`
+	} `json:"features"`
+}
+
+func fetchAuthConfig(t *testing.T, opts RouterOptions) authConfigBody {
+	t.Helper()
+	opts.FeatureNewAuth = true
+	if opts.RateLimitRPM == 0 {
+		opts.RateLimitRPM = 1000
+	}
+	if opts.RateLimitBurst == 0 {
+		opts.RateLimitBurst = 1000
+	}
+	router := NewRouter(zap.NewNop(), telemetry.NewMetrics(), NewService(db.NewMemoryStore(), fakeScanner{}, "aws"), opts)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/auth/config", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var body authConfigBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode auth config: %v body=%s", err, rec.Body.String())
+	}
+	return body
+}
+
+func TestAuthConfigFeaturesDefaultToDisabled(t *testing.T) {
+	body := fetchAuthConfig(t, RouterOptions{})
+
+	if body.Features.OnboardingWizard {
+		t.Fatalf("expected onboarding_wizard false by default")
+	}
+	if body.Features.Connectors.GitHub || body.Features.Connectors.AWS || body.Features.Connectors.Kubernetes {
+		t.Fatalf("expected all connectors false by default, got %+v", body.Features.Connectors)
+	}
+}
+
+func TestAuthConfigFeaturesReflectEnabledFlags(t *testing.T) {
+	body := fetchAuthConfig(t, RouterOptions{
+		FeatureOnboardingWizard:  true,
+		FeatureConnectorGitHubV2: true,
+		FeatureConnectorAWS:      true,
+		FeatureConnectorK8S:      false,
+	})
+
+	if !body.Features.OnboardingWizard {
+		t.Fatalf("expected onboarding_wizard true")
+	}
+	if !body.Features.Connectors.GitHub || !body.Features.Connectors.AWS {
+		t.Fatalf("expected github and aws connectors true, got %+v", body.Features.Connectors)
+	}
+	if body.Features.Connectors.Kubernetes {
+		t.Fatalf("expected kubernetes connector false, got %+v", body.Features.Connectors)
+	}
+}
+
+func TestAuthConfigPreservesExistingAuthContractAndLeaksNoSecrets(t *testing.T) {
+	rec := httptest.NewRecorder()
+	router := NewRouter(zap.NewNop(), telemetry.NewMetrics(), NewService(db.NewMemoryStore(), fakeScanner{}, "aws"), RouterOptions{
+		FeatureNewAuth:      true,
+		FeatureWorkOSLogin:  true,
+		RateLimitRPM:        1000,
+		RateLimitBurst:      1000,
+		WorkOSClientID:      "client_should_not_leak",
+		WorkOSAPIKey:        "sk_should_not_leak",
+		WorkOSWebhookSecret: "whsec_should_not_leak",
+		SessionKey:          strings.Repeat("a", 64),
+	})
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/auth/config", nil))
+
+	raw := rec.Body.String()
+	if !strings.Contains(raw, `"workos_login_enabled":true`) {
+		t.Fatalf("existing auth contract changed: %s", raw)
+	}
+	for _, secret := range []string{"client_should_not_leak", "sk_should_not_leak", "whsec_should_not_leak", strings.Repeat("a", 64)} {
+		if strings.Contains(raw, secret) {
+			t.Fatalf("auth config leaked sensitive value %q: %s", secret, raw)
+		}
+	}
+}

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -82,7 +82,18 @@ func registerAuthSessionRoutes(r *gin.Engine, logger *zap.Logger, svc *Service, 
 	})
 }
 
-func registerAuthConfigRoute(v1 *gin.RouterGroup, manualMode bool, workOSEnabled bool, nativeSSOEnabled bool) {
+// authConfigFeatures advertises whether backend-gated, self-serve flows are
+// actually registered on this API. It exists so the web bundle can avoid
+// showing an onboarding/connector flow that the API cannot serve. It carries
+// only availability booleans — never credentials, secrets, or provider config.
+type authConfigFeatures struct {
+	OnboardingWizard bool
+	ConnectorGitHub  bool
+	ConnectorAWS     bool
+	ConnectorK8S     bool
+}
+
+func registerAuthConfigRoute(v1 *gin.RouterGroup, manualMode bool, workOSEnabled bool, nativeSSOEnabled bool, features authConfigFeatures) {
 	v1.GET("/auth/config", func(c *gin.Context) {
 		providers := []string{}
 		if workOSEnabled {
@@ -101,6 +112,14 @@ func registerAuthConfigRoute(v1 *gin.RouterGroup, manualMode bool, workOSEnabled
 				"workos_login_enabled": workOSEnabled,
 				"native_saml_enabled":  nativeSSOEnabled,
 				"providers":            providers,
+			},
+			"features": gin.H{
+				"onboarding_wizard": features.OnboardingWizard,
+				"connectors": gin.H{
+					"github":     features.ConnectorGitHub,
+					"aws":        features.ConnectorAWS,
+					"kubernetes": features.ConnectorK8S,
+				},
 			},
 		})
 	})

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -347,7 +347,12 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 	publicV1.Use(rateLimitMiddleware(opts.RateLimitRPM, opts.RateLimitBurst))
 	publicV1.Use(jsonBodyLimitMiddleware(defaultJSONBodyLimit))
 	if opts.FeatureNewAuth {
-		registerAuthConfigRoute(publicV1, opts.AuthManualMode, opts.FeatureWorkOSLogin, opts.FeatureNativeSSO)
+		registerAuthConfigRoute(publicV1, opts.AuthManualMode, opts.FeatureWorkOSLogin, opts.FeatureNativeSSO, authConfigFeatures{
+			OnboardingWizard: opts.FeatureOnboardingWizard,
+			ConnectorGitHub:  opts.FeatureConnectorGitHubV2,
+			ConnectorAWS:     opts.FeatureConnectorAWS,
+			ConnectorK8S:     opts.FeatureConnectorK8S,
+		})
 	}
 	registerKubernetesAgentRoutes(publicV1, logger, svc, opts.FeatureConnectorK8S, opts.PublicBaseURL)
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,7 +22,7 @@ import { InvitePage } from './pages/onboarding/InvitePage';
 import { OrgPage } from './pages/onboarding/OrgPage';
 import { ScanPage } from './pages/onboarding/ScanPage';
 import { WorkspacePage } from './pages/onboarding/WorkspacePage';
-import { FEATURE_ONBOARDING_WIZARD } from './pages/onboarding/onboardingUtils';
+import { RequireOnboardingBackend } from './components/onboarding/OnboardingAvailability';
 import {
   ProductAppIndexRedirect,
   ProductAuthCallbackRedirectPage,
@@ -3678,7 +3678,9 @@ export function RoutedSite() {
             path="/onboarding/org"
             element={
               <RequireProductAuth>
-                {FEATURE_ONBOARDING_WIZARD ? <OrgPage /> : <ProductAppIndexRedirect />}
+                <RequireOnboardingBackend fallback={<ProductAppIndexRedirect />}>
+                  <OrgPage />
+                </RequireOnboardingBackend>
               </RequireProductAuth>
             }
           />
@@ -3686,7 +3688,9 @@ export function RoutedSite() {
             path="/onboarding/workspace"
             element={
               <RequireProductAuth>
-                {FEATURE_ONBOARDING_WIZARD ? <WorkspacePage /> : <ProductAppIndexRedirect />}
+                <RequireOnboardingBackend fallback={<ProductAppIndexRedirect />}>
+                  <WorkspacePage />
+                </RequireOnboardingBackend>
               </RequireProductAuth>
             }
           />
@@ -3694,7 +3698,9 @@ export function RoutedSite() {
             path="/onboarding/connect"
             element={
               <RequireProductAuth>
-                {FEATURE_ONBOARDING_WIZARD ? <ConnectPage /> : <ProductAppIndexRedirect />}
+                <RequireOnboardingBackend fallback={<ProductAppIndexRedirect />}>
+                  <ConnectPage />
+                </RequireOnboardingBackend>
               </RequireProductAuth>
             }
           />
@@ -3702,7 +3708,9 @@ export function RoutedSite() {
             path="/onboarding/scan"
             element={
               <RequireProductAuth>
-                {FEATURE_ONBOARDING_WIZARD ? <ScanPage /> : <ProductAppIndexRedirect />}
+                <RequireOnboardingBackend fallback={<ProductAppIndexRedirect />}>
+                  <ScanPage />
+                </RequireOnboardingBackend>
               </RequireProductAuth>
             }
           />
@@ -3710,7 +3718,9 @@ export function RoutedSite() {
             path="/onboarding/invite"
             element={
               <RequireProductAuth>
-                {FEATURE_ONBOARDING_WIZARD ? <InvitePage /> : <ProductAppIndexRedirect />}
+                <RequireOnboardingBackend fallback={<ProductAppIndexRedirect />}>
+                  <InvitePage />
+                </RequireOnboardingBackend>
               </RequireProductAuth>
             }
           />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -179,6 +179,17 @@ export type AuthConfigResponse = {
     native_saml_enabled: boolean;
     providers: string[];
   };
+  // Advertised by the API so the web bundle does not show a backend-gated
+  // self-serve flow the API cannot serve. Optional for resilience against an
+  // older API that predates this contract.
+  features?: {
+    onboarding_wizard: boolean;
+    connectors: {
+      github: boolean;
+      aws: boolean;
+      kubernetes: boolean;
+    };
+  };
 };
 
 export type CurrentUser = {

--- a/web/src/components/onboarding/OnboardingAvailability.test.tsx
+++ b/web/src/components/onboarding/OnboardingAvailability.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { BackendFeatureState } from '../../hooks/useBackendFeatures';
+
+async function renderGuard(opts: {
+  featureEnabled: boolean;
+  loading: boolean;
+  onboardingWizard?: BackendFeatureState;
+}) {
+  vi.resetModules();
+  vi.doMock('../../pages/onboarding/onboardingUtils', () => ({
+    FEATURE_ONBOARDING_WIZARD: opts.featureEnabled
+  }));
+  vi.doMock('../../hooks/useBackendFeatures', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../hooks/useBackendFeatures')>();
+    return {
+      ...actual,
+      useBackendFeatures: () => ({
+        features: {
+          onboardingWizard: opts.onboardingWizard,
+          connectors: { github: undefined, aws: undefined, kubernetes: undefined }
+        },
+        loading: opts.loading
+      })
+    };
+  });
+
+  const { RequireOnboardingBackend } = await import('./OnboardingAvailability');
+  render(
+    <RequireOnboardingBackend fallback={<h1>Fallback shown</h1>}>
+      <h1>Onboarding page</h1>
+    </RequireOnboardingBackend>
+  );
+}
+
+describe('RequireOnboardingBackend', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.doUnmock('../../pages/onboarding/onboardingUtils');
+    vi.doUnmock('../../hooks/useBackendFeatures');
+    vi.resetModules();
+  });
+
+  it('returns the fallback immediately when the bundle disables onboarding, even while backend features load', async () => {
+    await renderGuard({ featureEnabled: false, loading: true });
+
+    expect(await screen.findByRole('heading', { name: 'Fallback shown' })).toBeInTheDocument();
+    expect(screen.queryByText(/Checking onboarding availability/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Onboarding page' })).not.toBeInTheDocument();
+  });
+
+  it('shows the loading state while backend availability resolves when the bundle enables onboarding', async () => {
+    await renderGuard({ featureEnabled: true, loading: true });
+
+    expect(await screen.findByText(/Checking onboarding availability/i)).toBeInTheDocument();
+  });
+
+  it('renders the page when the bundle and API both enable onboarding', async () => {
+    await renderGuard({ featureEnabled: true, loading: false, onboardingWizard: true });
+
+    expect(await screen.findByRole('heading', { name: 'Onboarding page' })).toBeInTheDocument();
+  });
+
+  it('renders the fallback when the API does not serve onboarding', async () => {
+    await renderGuard({ featureEnabled: true, loading: false, onboardingWizard: false });
+
+    expect(await screen.findByRole('heading', { name: 'Fallback shown' })).toBeInTheDocument();
+  });
+});

--- a/web/src/components/onboarding/OnboardingAvailability.tsx
+++ b/web/src/components/onboarding/OnboardingAvailability.tsx
@@ -7,6 +7,12 @@ import { isFeatureAvailable, useBackendFeatures } from '../../hooks/useBackendFe
 // route as missing. Returns undefined while backend availability is loading.
 export function useOnboardingAvailable(): boolean | undefined {
   const { features, loading } = useBackendFeatures();
+  if (!FEATURE_ONBOARDING_WIZARD) {
+    // The bundle does not ship the wizard, so onboarding can never be shown
+    // regardless of the API. Decide immediately instead of stranding a direct
+    // /onboarding/* visit on a loading panel while auth/config settles.
+    return false;
+  }
   if (loading) {
     return undefined;
   }

--- a/web/src/components/onboarding/OnboardingAvailability.tsx
+++ b/web/src/components/onboarding/OnboardingAvailability.tsx
@@ -1,0 +1,65 @@
+import { ReactElement, ReactNode } from 'react';
+import { FEATURE_ONBOARDING_WIZARD } from '../../pages/onboarding/onboardingUtils';
+import { isFeatureAvailable, useBackendFeatures } from '../../hooks/useBackendFeatures';
+
+// Whether self-serve onboarding should be shown: the web bundle must ship the
+// wizard (Vite flag) AND the API must not explicitly report the onboarding
+// route as missing. Returns undefined while backend availability is loading.
+export function useOnboardingAvailable(): boolean | undefined {
+  const { features, loading } = useBackendFeatures();
+  if (loading) {
+    return undefined;
+  }
+  return isFeatureAvailable(FEATURE_ONBOARDING_WIZARD, features.onboardingWizard);
+}
+
+export function OnboardingFeatureLoading() {
+  return (
+    <section className="idt-app-shell-screen" aria-live="polite">
+      <article className="idt-app-panel">
+        <p className="idt-app-kicker">Loading</p>
+        <h1>Checking onboarding availability</h1>
+        <p>Confirming the API supports self-serve onboarding before continuing.</p>
+      </article>
+    </section>
+  );
+}
+
+// Shown when the web bundle supports onboarding but the API does not register
+// the onboarding routes. This replaces a raw "Request failed (404)" with a
+// clear, user-safe explanation and a path forward.
+export function OnboardingUnavailableNotice() {
+  return (
+    <section className="idt-app-shell-screen" role="alert">
+      <article className="idt-app-panel">
+        <p className="idt-app-kicker">Onboarding unavailable</p>
+        <h1>Self-serve onboarding is not enabled on this API</h1>
+        <p>
+          Your account is active, but this Identrail API does not have the self-serve onboarding routes enabled, so the
+          setup wizard cannot run here. Ask an administrator to assign your workspace, or enable onboarding on the API.
+        </p>
+      </article>
+    </section>
+  );
+}
+
+// Route guard for onboarding pages. While backend availability is loading it
+// shows a neutral state; if onboarding is unavailable it renders the supplied
+// fallback (kept generic so it does not import the product shell and create a
+// cycle) instead of letting the page call a 404 backend route.
+export function RequireOnboardingBackend({
+  fallback,
+  children
+}: {
+  fallback: ReactElement;
+  children: ReactNode;
+}) {
+  const available = useOnboardingAvailable();
+  if (available === undefined) {
+    return <OnboardingFeatureLoading />;
+  }
+  if (!available) {
+    return fallback;
+  }
+  return <>{children}</>;
+}

--- a/web/src/hooks/useBackendFeatures.test.ts
+++ b/web/src/hooks/useBackendFeatures.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { apiClient, type AuthConfigResponse } from '../api/client';
+import {
+  isFeatureAvailable,
+  loadBackendFeatures,
+  resetBackendFeaturesCacheForTests
+} from './useBackendFeatures';
+
+const baseAuth: AuthConfigResponse['auth'] = {
+  manual_mode: false,
+  workos_login_enabled: true,
+  native_saml_enabled: false,
+  providers: ['github_oauth']
+};
+
+afterEach(() => {
+  resetBackendFeaturesCacheForTests();
+  vi.restoreAllMocks();
+});
+
+describe('isFeatureAvailable', () => {
+  it('keeps the Vite flag result when the API does not advertise the feature', () => {
+    expect(isFeatureAvailable(true, undefined)).toBe(true);
+    expect(isFeatureAvailable(false, undefined)).toBe(false);
+  });
+
+  it('requires both the bundle flag and the API to agree when the API advertises it', () => {
+    expect(isFeatureAvailable(true, true)).toBe(true);
+    expect(isFeatureAvailable(true, false)).toBe(false);
+    expect(isFeatureAvailable(false, true)).toBe(false);
+  });
+});
+
+describe('loadBackendFeatures', () => {
+  it('maps the API features object', async () => {
+    vi.spyOn(apiClient, 'getAuthConfig').mockResolvedValue({
+      auth: baseAuth,
+      features: {
+        onboarding_wizard: true,
+        connectors: { github: false, aws: true, kubernetes: false }
+      }
+    });
+
+    const features = await loadBackendFeatures();
+    expect(features.onboardingWizard).toBe(true);
+    expect(features.connectors).toEqual({ github: false, aws: true, kubernetes: false });
+  });
+
+  it('treats a missing features object as unknown (legacy API)', async () => {
+    vi.spyOn(apiClient, 'getAuthConfig').mockResolvedValue({ auth: baseAuth });
+
+    const features = await loadBackendFeatures();
+    expect(features.onboardingWizard).toBeUndefined();
+    expect(features.connectors).toEqual({ github: undefined, aws: undefined, kubernetes: undefined });
+  });
+
+  it('degrades to unknown rather than throwing when auth/config fails', async () => {
+    vi.spyOn(apiClient, 'getAuthConfig').mockRejectedValue(new Error('network down'));
+
+    const features = await loadBackendFeatures();
+    expect(features.onboardingWizard).toBeUndefined();
+  });
+
+  it('memoizes a single auth/config call across callers', async () => {
+    const spy = vi.spyOn(apiClient, 'getAuthConfig').mockResolvedValue({ auth: baseAuth });
+
+    await Promise.all([loadBackendFeatures(), loadBackendFeatures()]);
+    await loadBackendFeatures();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/hooks/useBackendFeatures.ts
+++ b/web/src/hooks/useBackendFeatures.ts
@@ -23,6 +23,10 @@ const UNKNOWN_FEATURES: BackendFeatures = {
 };
 
 let cachedFeatures: Promise<BackendFeatures> | null = null;
+// Synchronous snapshot once the one-shot fetch has resolved. This keeps
+// remounts (e.g. navigating between onboarding steps, each wrapped by the
+// route guard) from flashing a loading interstitial.
+let resolvedFeatures: BackendFeatures | null = null;
 
 async function fetchBackendFeatures(): Promise<BackendFeatures> {
   try {
@@ -51,13 +55,17 @@ async function fetchBackendFeatures(): Promise<BackendFeatures> {
 
 export function loadBackendFeatures(): Promise<BackendFeatures> {
   if (!cachedFeatures) {
-    cachedFeatures = fetchBackendFeatures();
+    cachedFeatures = fetchBackendFeatures().then((resolved) => {
+      resolvedFeatures = resolved;
+      return resolved;
+    });
   }
   return cachedFeatures;
 }
 
 export function resetBackendFeaturesCacheForTests(): void {
   cachedFeatures = null;
+  resolvedFeatures = null;
 }
 
 // The effective rule: a backend-dependent flow is shown only when the web
@@ -76,10 +84,16 @@ type UseBackendFeaturesResult = {
 };
 
 export function useBackendFeatures(): UseBackendFeaturesResult {
-  const [features, setFeatures] = useState<BackendFeatures>(UNKNOWN_FEATURES);
-  const [loading, setLoading] = useState(true);
+  const [features, setFeatures] = useState<BackendFeatures>(resolvedFeatures ?? UNKNOWN_FEATURES);
+  const [loading, setLoading] = useState(resolvedFeatures === null);
 
   useEffect(() => {
+    if (resolvedFeatures) {
+      // Cache is already warm: serve it without a loading flash on remount.
+      setFeatures(resolvedFeatures);
+      setLoading(false);
+      return;
+    }
     let mounted = true;
     setLoading(true);
     loadBackendFeatures()

--- a/web/src/hooks/useBackendFeatures.ts
+++ b/web/src/hooks/useBackendFeatures.ts
@@ -1,0 +1,102 @@
+import { useEffect, useState } from 'react';
+import { apiClient } from '../api/client';
+
+// A tri-state per feature:
+//   true      -> API explicitly advertises the backend route is registered
+//   false     -> API explicitly advertises it is NOT registered
+//   undefined -> API did not advertise availability (older API, or the
+//                auth/config call failed) -> fall back to the Vite build flag
+export type BackendFeatureState = boolean | undefined;
+
+export type BackendFeatures = {
+  onboardingWizard: BackendFeatureState;
+  connectors: {
+    github: BackendFeatureState;
+    aws: BackendFeatureState;
+    kubernetes: BackendFeatureState;
+  };
+};
+
+const UNKNOWN_FEATURES: BackendFeatures = {
+  onboardingWizard: undefined,
+  connectors: { github: undefined, aws: undefined, kubernetes: undefined }
+};
+
+let cachedFeatures: Promise<BackendFeatures> | null = null;
+
+async function fetchBackendFeatures(): Promise<BackendFeatures> {
+  try {
+    const config = await apiClient.getAuthConfig();
+    const features = config.features;
+    if (!features) {
+      // Older API that predates this contract: stay on the Vite-flag
+      // behavior. The production API preflight is the deploy-time guard
+      // against an API that does not serve a backend-gated flow.
+      return UNKNOWN_FEATURES;
+    }
+    return {
+      onboardingWizard: features.onboarding_wizard,
+      connectors: {
+        github: features.connectors?.github,
+        aws: features.connectors?.aws,
+        kubernetes: features.connectors?.kubernetes
+      }
+    };
+  } catch {
+    // A failed auth/config call must not be more disruptive than today's
+    // Vite-only behavior, so degrade to "unknown" rather than blocking.
+    return UNKNOWN_FEATURES;
+  }
+}
+
+export function loadBackendFeatures(): Promise<BackendFeatures> {
+  if (!cachedFeatures) {
+    cachedFeatures = fetchBackendFeatures();
+  }
+  return cachedFeatures;
+}
+
+export function resetBackendFeaturesCacheForTests(): void {
+  cachedFeatures = null;
+}
+
+// The effective rule: a backend-dependent flow is shown only when the web
+// bundle ships its UI (Vite flag) AND the API does not explicitly say the
+// route is missing. Unknown backend state keeps the legacy Vite-only result.
+export function isFeatureAvailable(viteFlag: boolean, backendState: BackendFeatureState): boolean {
+  if (backendState === undefined) {
+    return viteFlag;
+  }
+  return viteFlag && backendState;
+}
+
+type UseBackendFeaturesResult = {
+  features: BackendFeatures;
+  loading: boolean;
+};
+
+export function useBackendFeatures(): UseBackendFeaturesResult {
+  const [features, setFeatures] = useState<BackendFeatures>(UNKNOWN_FEATURES);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    setLoading(true);
+    loadBackendFeatures()
+      .then((resolved) => {
+        if (mounted) {
+          setFeatures(resolved);
+        }
+      })
+      .finally(() => {
+        if (mounted) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return { features, loading };
+}

--- a/web/src/pages/onboarding/ConnectPage.tsx
+++ b/web/src/pages/onboarding/ConnectPage.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { apiClient, type OnboardingState } from '../../api/client';
 import { SkipForNow } from '../../components/onboarding/SkipForNow';
+import { isFeatureAvailable, useBackendFeatures } from '../../hooks/useBackendFeatures';
 import {
   FEATURE_ONBOARDING_CONNECTOR_AWS,
   FEATURE_ONBOARDING_CONNECTOR_GITHUB,
@@ -15,44 +16,64 @@ import {
   type OnboardingProvider
 } from './onboardingUtils';
 
-const PROVIDERS: Array<{
+const PROVIDER_META: Array<{
   id: OnboardingProvider;
   name: string;
   signal: string;
   detail: string;
-  enabled: boolean;
+  viteFlag: boolean;
 }> = [
   {
     id: 'aws',
     name: 'AWS',
     signal: 'IAM roles, trust policies, account paths',
     detail: 'Best first source for cloud identity blast-radius discovery.',
-    enabled: FEATURE_ONBOARDING_CONNECTOR_AWS
+    viteFlag: FEATURE_ONBOARDING_CONNECTOR_AWS
   },
   {
     id: 'kubernetes',
     name: 'Kubernetes',
     signal: 'Service accounts, RBAC, workload identity',
     detail: 'Use when cluster access and service account paths matter most.',
-    enabled: FEATURE_ONBOARDING_CONNECTOR_K8S
+    viteFlag: FEATURE_ONBOARDING_CONNECTOR_K8S
   },
   {
     id: 'github',
     name: 'GitHub',
     signal: 'Repositories, workflow identity, webhook scans',
     detail: 'Use when code and OIDC workflow access are the first security boundary.',
-    enabled: FEATURE_ONBOARDING_CONNECTOR_GITHUB
+    viteFlag: FEATURE_ONBOARDING_CONNECTOR_GITHUB
   }
 ];
 
 export function ConnectPage() {
   const navigate = useNavigate();
-  const enabledProviders = useMemo(() => PROVIDERS.filter((provider) => provider.enabled), []);
+  const { features } = useBackendFeatures();
+  const providers = useMemo(
+    () =>
+      PROVIDER_META.map((meta) => ({
+        ...meta,
+        enabled: isFeatureAvailable(meta.viteFlag, features.connectors[meta.id])
+      })),
+    [features]
+  );
+  const enabledProviders = useMemo(() => providers.filter((provider) => provider.enabled), [providers]);
   const [state, setState] = useState<OnboardingState | null>(null);
-  const [selectedProvider, setSelectedProvider] = useState<OnboardingProvider>(enabledProviders[0]?.id ?? 'aws');
+  const [selectedProvider, setSelectedProvider] = useState<OnboardingProvider>('aws');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
+
+  const enabledProviderIdsRef = useRef<OnboardingProvider[]>([]);
+  enabledProviderIdsRef.current = enabledProviders.map((provider) => provider.id);
+
+  // Keep the selection on an actionable connector once API-discovered
+  // availability resolves (the bundle may ship a connector the API lacks).
+  useEffect(() => {
+    if (enabledProviders.length && !enabledProviders.some((provider) => provider.id === selectedProvider)) {
+      setSelectedProvider(enabledProviders[0].id);
+    }
+  }, [enabledProviders, selectedProvider]);
 
   useEffect(() => {
     if (!FEATURE_ONBOARDING_WIZARD) {
@@ -76,7 +97,7 @@ export function ConnectPage() {
         if (routeToOnboardingStep(navigate, response, '/onboarding/connect', '/onboarding/connect')) {
           return;
         }
-        if (nextState.connector_type && enabledProviders.some((provider) => provider.id === nextState.connector_type)) {
+        if (nextState.connector_type && enabledProviderIdsRef.current.includes(nextState.connector_type)) {
           setSelectedProvider(nextState.connector_type);
         }
       } catch (requestError) {
@@ -94,7 +115,7 @@ export function ConnectPage() {
     return () => {
       mounted = false;
     };
-  }, [enabledProviders, navigate]);
+  }, [navigate]);
 
   if (!FEATURE_ONBOARDING_WIZARD) {
     return <Navigate to="/app" replace />;
@@ -179,7 +200,7 @@ export function ConnectPage() {
         </div>
       ) : null}
       <div className="idt-onboarding-provider-grid">
-        {PROVIDERS.map((provider) => (
+        {providers.map((provider) => (
           <button
             type="button"
             key={provider.id}
@@ -189,7 +210,13 @@ export function ConnectPage() {
           >
             <span>{provider.name}</span>
             <strong>{provider.signal}</strong>
-            <small>{provider.enabled ? provider.detail : 'Enable the connector feature flag to use this source.'}</small>
+            <small>
+              {provider.enabled
+                ? provider.detail
+                : provider.viteFlag
+                  ? 'Not available on this API server.'
+                  : 'Not included in this web build.'}
+            </small>
           </button>
         ))}
       </div>

--- a/web/src/pages/onboarding/onboarding.test.tsx
+++ b/web/src/pages/onboarding/onboarding.test.tsx
@@ -195,6 +195,40 @@ describe('onboarding pages', () => {
     });
   });
 
+  it('marks connectors the API does not serve as unavailable', async () => {
+    const { apiClient, ConnectPage } = await loadOnboardingModules();
+    const { resetBackendFeaturesCacheForTests } = await import('../../hooks/useBackendFeatures');
+    resetBackendFeaturesCacheForTests();
+
+    vi.spyOn(apiClient, 'getAuthConfig').mockResolvedValue({
+      auth: { manual_mode: false, workos_login_enabled: true, native_saml_enabled: false, providers: [] },
+      features: {
+        onboarding_wizard: true,
+        connectors: { github: false, aws: true, kubernetes: false }
+      }
+    });
+    vi.spyOn(apiClient, 'getOnboardingState').mockResolvedValue({
+      state: state({
+        current_step: 'connect',
+        org_id: 'tenant-a',
+        workspace_id: 'production',
+        project_id: 'production'
+      }),
+      redirect_path: '/onboarding/connect'
+    });
+
+    renderOnboarding(<ConnectPage />, '/onboarding/connect');
+
+    const githubButton = await screen.findByRole('button', { name: /GitHub/i });
+    await waitFor(() => {
+      expect(githubButton).toBeDisabled();
+    });
+    expect(githubButton).toHaveTextContent('Not available on this API server.');
+
+    const awsButton = screen.getByRole('button', { name: /AWS/i });
+    expect(awsButton).toBeEnabled();
+  });
+
   it('continues after a successful first scan', async () => {
     const { apiClient, ScanPage } = await loadOnboardingModules();
     vi.spyOn(apiClient, 'getOnboardingState').mockResolvedValue({

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { CurrentUserContext } from './api/client';
+import type { BackendFeatureState } from './hooks/useBackendFeatures';
 
 const loggedInWithoutWorkspace: CurrentUserContext = {
   user: {
@@ -14,7 +15,7 @@ const loggedInWithoutWorkspace: CurrentUserContext = {
   }
 };
 
-async function renderProductIndexRedirect(featureEnabled: boolean) {
+async function renderProductIndexRedirect(featureEnabled: boolean, backendOnboarding: BackendFeatureState) {
   vi.resetModules();
   vi.doMock('./hooks/useMe', () => ({
     useMe: () => ({
@@ -28,6 +29,19 @@ async function renderProductIndexRedirect(featureEnabled: boolean) {
   vi.doMock('./pages/onboarding/onboardingUtils', () => ({
     FEATURE_ONBOARDING_WIZARD: featureEnabled
   }));
+  vi.doMock('./hooks/useBackendFeatures', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('./hooks/useBackendFeatures')>();
+    return {
+      ...actual,
+      useBackendFeatures: () => ({
+        features: {
+          onboardingWizard: backendOnboarding,
+          connectors: { github: undefined, aws: undefined, kubernetes: undefined }
+        },
+        loading: false
+      })
+    };
+  });
 
   const { ProductAppIndexRedirect } = await import('./productShell');
 
@@ -46,18 +60,34 @@ describe('ProductAppIndexRedirect', () => {
     vi.restoreAllMocks();
     vi.doUnmock('./hooks/useMe');
     vi.doUnmock('./pages/onboarding/onboardingUtils');
+    vi.doUnmock('./hooks/useBackendFeatures');
     vi.resetModules();
   });
 
-  it('starts self-serve onboarding for logged-in users without a workspace when the wizard is enabled', async () => {
-    await renderProductIndexRedirect(true);
+  it('starts self-serve onboarding when the bundle and API both enable it', async () => {
+    await renderProductIndexRedirect(true, true);
 
     expect(await screen.findByRole('heading', { level: 1, name: 'Start onboarding' })).toBeInTheDocument();
     expect(screen.queryByText(/No workspace is attached yet/i)).not.toBeInTheDocument();
   });
 
-  it('keeps the explicit workspace-required state when self-serve onboarding is disabled', async () => {
-    await renderProductIndexRedirect(false);
+  it('falls back to the bundle flag when the API does not advertise onboarding', async () => {
+    await renderProductIndexRedirect(true, undefined);
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Start onboarding' })).toBeInTheDocument();
+  });
+
+  it('shows a clear unavailable state instead of a 404 when the API lacks onboarding', async () => {
+    await renderProductIndexRedirect(true, false);
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /Self-serve onboarding is not enabled on this API/i })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Start onboarding' })).not.toBeInTheDocument();
+  });
+
+  it('keeps the explicit workspace-required state when the bundle disables onboarding', async () => {
+    await renderProductIndexRedirect(false, undefined);
 
     expect(await screen.findByRole('heading', { level: 1, name: /No workspace is attached yet/i })).toBeInTheDocument();
   });

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -29,6 +29,7 @@ import {
 import { PermissionPreviewModal } from './components/connector/PermissionPreviewModal';
 import { useMe } from './hooks/useMe';
 import { FEATURE_ONBOARDING_WIZARD } from './pages/onboarding/onboardingUtils';
+import { OnboardingUnavailableNotice, useOnboardingAvailable } from './components/onboarding/OnboardingAvailability';
 import {
   buildRepoFindingSelectionKey,
   findRepoFindingBySelectionKey,
@@ -782,6 +783,7 @@ export function ProductLogoutPage() {
 
 export function ProductAppIndexRedirect() {
   const { me, loading, error, unauthenticated } = useMe();
+  const onboardingAvailable = useOnboardingAvailable();
   if (loading) {
     return <AppShellLoading message="Resolving workspace scope" />;
   }
@@ -800,8 +802,17 @@ export function ProductAppIndexRedirect() {
     );
   }
   if (!me?.org_id || !me.workspace_id) {
-    if (FEATURE_ONBOARDING_WIZARD) {
+    if (onboardingAvailable === undefined) {
+      return <AppShellLoading message="Resolving workspace scope" />;
+    }
+    if (onboardingAvailable) {
       return <Navigate to="/onboarding/org" replace />;
+    }
+    if (FEATURE_ONBOARDING_WIZARD) {
+      // The web bundle ships the wizard but the API does not register the
+      // onboarding routes. Show a clear state instead of redirecting into a
+      // flow that would fail with a raw 404.
+      return <OnboardingUnavailableNotice />;
     }
     return (
       <section className="idt-app-shell-screen">

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -802,7 +802,7 @@ export function ProductAppIndexRedirect() {
     );
   }
   if (!me?.org_id || !me.workspace_id) {
-    if (onboardingAvailable === undefined) {
+    if (FEATURE_ONBOARDING_WIZARD && onboardingAvailable === undefined) {
       return <AppShellLoading message="Resolving workspace scope" />;
     }
     if (onboardingAvailable) {


### PR DESCRIPTION
## Summary
The web bundle decided whether to show onboarding/connector flows purely from Vite build flags, while the API independently decided whether those routes were registered from `IDENTRAIL_FEATURE_*`. That split is what let the UI enter a self-serve flow the API answered with a raw `404`. This PR makes the frontend discover backend feature availability from the API before entering a backend-gated flow.

Depends on #1173 (merged in [identrail#1181](https://github.com/identrail/identrail/pull/1181)) — the deploy-time preflight guard lands first; this makes the running app resilient and explicit.

- **API contract**: `/v1/auth/config` now returns a session-safe `features` object — `onboarding_wizard` and per-connector `github`/`aws`/`kubernetes` booleans. Additive (existing `auth` consumers unaffected); availability booleans only, never credentials or provider config.
- **Shared discovery**: a memoized loader + `useBackendFeatures` hook fetches `auth/config` once and combines the Vite flag with API availability. Rule: a backend-dependent flow shows only when the bundle ships its UI **and** the API does not explicitly report the route missing.
- **Resilient by design**: an older API without `features`, or a failed `auth/config` call, falls back to the existing Vite-only behavior. The strict block only applies when the API explicitly says a route is missing — so nothing regresses for existing deployments.
- **No more raw 404**: onboarding routes and the workspaceless landing show a clear "Self-serve onboarding is not enabled on this API" state instead of redirecting into a flow that 404s. The onboarding connector picker marks connectors the API does not serve as unavailable rather than actionable.
- Documented the contract in `docs/openapi-v1.yaml` and `CHANGELOG.md`.

## Scope notes
Scoped to the self-serve onboarding flow that caused the production failure (onboarding gate + onboarding connector selection). The post-onboarding product-shell source picker (`productShell.tsx` `SOURCE_ORDER`) is intentionally left Vite-gated — refactoring those module-level constants to runtime in a 4k-line, coverage-excluded file is a separate, riskier change and is not the named regression.

## Acceptance criteria
- [x] Frontend can tell whether the API supports onboarding before calling `/v1/onboarding/start`.
- [x] Users no longer see raw `Request failed (404)` when a backend-gated feature is unavailable.
- [x] Connector selection clearly marks disabled connectors based on API-discovered availability.
- [x] Existing auth config consumers keep working (additive optional field; sign-in/settings unaffected).
- [x] Tests cover API response shape and frontend fallback behavior.

## Test plan
- [x] `go test ./internal/api/` — new `auth_config_test.go` (defaults disabled, enabled flags reflected, existing auth contract preserved, no secret leakage)
- [x] `go build ./...`, `go vet ./internal/api/`, `make fmt`, `make api-example-contract-check`
- [x] `npx vitest run` — 106 passing incl. new hook unit tests, backend-aware `ProductAppIndexRedirect` states, and ConnectPage API-driven unavailable connectors
- [x] `npx vitest run --coverage` — thresholds met (lines 74.5%, branches 65.4%)
- [x] `npm run build --prefix web`
- [ ] Manual: verify UI with `IDENTRAIL_FEATURE_ONBOARDING_WIZARD` enabled vs disabled on the API side

## AI assistance disclosure
Prepared with AI assistance (Claude Code). All logic, tests, and docs were reviewed before submission.

Closes #1174

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes backend feature availability to the frontend so onboarding and connector flows only show when the API serves them. Removes raw 404s and avoids flicker while staying backward compatible.

- **New Features**
  - API: `/v1/auth/config` now returns session-safe `features` with `onboarding_wizard` and `connectors` (`github`/`aws`/`kubernetes`); additive and no secrets.
  - Frontend: one-shot memoized loader and `useBackendFeatures` combine Vite flags with API availability; `RequireOnboardingBackend` guards onboarding routes and the product landing shows a clear unavailable notice when the API lacks onboarding.
  - Docs: updated OpenAPI spec.

- **Bug Fixes**
  - Replaces onboarding 404s with “Self-serve onboarding is not enabled on this API”; connector picker reflects API-driven availability.
  - Backward compatible: if `features` is missing or the call fails, the app falls back to Vite-only behavior.
  - Smoother UX: warm snapshot prevents loading flashes; `ProductAppIndexRedirect` no longer waits when the bundle disables onboarding; onboarding guard short-circuits when the bundle flag is off to avoid loading panels on direct `/onboarding/*` visits.

<sup>Written for commit 58cf1f0e19baa2aaac9b895242f17fdbdc31943d. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1183?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

