### PR TITLE
Fix read-only scan lead capture delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
   requests now send an internal notification and requester confirmation when
   `RESEND_API_KEY`, `LEAD_NOTIFY_TO`, and a verified `LEAD_EMAIL_FROM` are
   configured, while preserving the signed webhook forwarding option for
-  CRM/automation fanout.
+  CRM/automation fanout even when Resend rejects or times out.
 - Redesigned the product page as a full-bleed Vercel-style surface with a dark hero, spread-out trust graph connections, alternating neutral sections, and no centered container around the main product story.
 - Exposed backend feature availability to the frontend so the web bundle no
   longer shows a backend-gated self-serve flow purely from a Vite build flag:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@
   `RESEND_API_KEY`, `LEAD_NOTIFY_TO`, and a verified `LEAD_EMAIL_FROM` are
   configured, while preserving the signed webhook forwarding option for
   CRM/automation fanout even when Resend rejects or times out, and accepting
-  the submission once either configured delivery channel succeeds.
+  the submission once either configured delivery channel succeeds or the
+  internal team notification has been accepted.
 - Redesigned the product page as a full-bleed Vercel-style surface with a dark hero, spread-out trust graph connections, alternating neutral sections, and no centered container around the main product story.
 - Exposed backend feature availability to the frontend so the web bundle no
   longer shows a backend-gated self-serve flow purely from a Vite build flag:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
     `/v1/me`, the workspaces list, the members list (active owner), the default
     project, and the scoped `/app/<org>/<workspace>` redirect all agree, and
     that re-running start is idempotent.
+- Wired public lead capture to a production-style Resend email path: scan
+  requests now send an internal notification and requester confirmation when
+  `RESEND_API_KEY` and `LEAD_NOTIFY_TO` are configured, while preserving the
+  signed webhook forwarding option for CRM/automation fanout.
 - Redesigned the product page as a full-bleed Vercel-style surface with a dark hero, spread-out trust graph connections, alternating neutral sections, and no centered container around the main product story.
 - Exposed backend feature availability to the frontend so the web bundle no
   longer shows a backend-gated self-serve flow purely from a Vite build flag:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@
   requests now send an internal notification and requester confirmation when
   `RESEND_API_KEY`, `LEAD_NOTIFY_TO`, and a verified `LEAD_EMAIL_FROM` are
   configured, while preserving the signed webhook forwarding option for
-  CRM/automation fanout even when Resend rejects or times out.
+  CRM/automation fanout even when Resend rejects or times out, and accepting
+  the submission once either configured delivery channel succeeds.
 - Redesigned the product page as a full-bleed Vercel-style surface with a dark hero, spread-out trust graph connections, alternating neutral sections, and no centered container around the main product story.
 - Exposed backend feature availability to the frontend so the web bundle no
   longer shows a backend-gated self-serve flow purely from a Vite build flag:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@
     that re-running start is idempotent.
 - Wired public lead capture to a production-style Resend email path: scan
   requests now send an internal notification and requester confirmation when
-  `RESEND_API_KEY` and `LEAD_NOTIFY_TO` are configured, while preserving the
-  signed webhook forwarding option for CRM/automation fanout.
+  `RESEND_API_KEY`, `LEAD_NOTIFY_TO`, and a verified `LEAD_EMAIL_FROM` are
+  configured, while preserving the signed webhook forwarding option for
+  CRM/automation fanout.
 - Redesigned the product page as a full-bleed Vercel-style surface with a dark hero, spread-out trust graph connections, alternating neutral sections, and no centered container around the main product story.
 - Exposed backend feature availability to the frontend so the web bundle no
   longer shows a backend-gated self-serve flow purely from a Vite build flag:

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -191,8 +191,8 @@ For the standard hosted setup, configure Resend:
 - `LEAD_CONFIRMATION_SUBJECT` (optional requester confirmation subject override)
 - `LEAD_EMAIL_TIMEOUT_MS` (default: `3000`, bounded to `500..10000`)
 
-Optional webhook forwarding can be enabled alongside email, or used as a
-fallback delivery channel:
+Optional webhook forwarding can be enabled alongside email, or used as the sole
+delivery channel when Resend is not configured:
 
 - `LEAD_WEBHOOK_URL` (must use `https`, or `http` only for localhost targets)
 - `LEAD_WEBHOOK_TIMEOUT_MS` (default: `3000`, bounded to `500..10000`)

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -198,6 +198,9 @@ delivery channel when Resend is not configured:
 - `LEAD_WEBHOOK_TIMEOUT_MS` (default: `3000`, bounded to `500..10000`)
 - `LEAD_WEBHOOK_HMAC_SECRET` (optional; when set, emits `X-Identrail-Signature: sha256=<digest>` for receiver-side verification)
 
+When Resend and webhook forwarding are both configured, webhook forwarding is
+still attempted if Resend rejects or times out on the lead notification.
+
 Shared lead-capture control:
 
 - `LEAD_CAPTURE_RATE_LIMIT_PER_MIN` (default: `15`, bounded to `1..120`, applied per client IP window)

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -184,7 +184,7 @@ For the standard hosted setup, configure Resend:
 
 - `RESEND_API_KEY` (required for direct email delivery)
 - `LEAD_NOTIFY_TO` (required with Resend; comma-separated internal recipients such as `sales@identrail.com,security@identrail.com`)
-- `LEAD_EMAIL_FROM` (default: `Identrail <onboarding@resend.dev>`; use a verified Identrail domain in production)
+- `LEAD_EMAIL_FROM` (required with Resend; use a verified Identrail sender such as `Identrail <scan@identrail.com>`)
 - `LEAD_REPLY_TO` (optional; defaults to the submitter for internal notifications and the first `LEAD_NOTIFY_TO` address for confirmations)
 - `LEAD_EMAIL_SUBJECT_PREFIX` (default: `Identrail`)
 - `LEAD_CONFIRMATION_ENABLED` (default: `true`; set `false` to skip the requester confirmation email)

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -174,14 +174,33 @@ The web app supports OIDC login/callback/refresh/logout flows when these Vite en
 - `VITE_OIDC_WORKSPACE_CLAIM` (default: `workspace_id`)
 - `VITE_OIDC_ROLES_CLAIM` (default: `roles`)
 
-## Web Lead Capture Forwarding
+## Web Lead Capture Email and Forwarding
 
-Server-side `/api/leads` forwarding uses these optional runtime environment variables:
+Server-side `/api/leads` validates the public scan and lead forms, applies a
+per-IP rate limit, ignores honeypot spam submissions, and then delivers the
+lead through the configured runtime channel.
 
-- `LEAD_WEBHOOK_URL` (required to enable forwarding; must use `https`, or `http` only for localhost targets)
+For the standard hosted setup, configure Resend:
+
+- `RESEND_API_KEY` (required for direct email delivery)
+- `LEAD_NOTIFY_TO` (required with Resend; comma-separated internal recipients such as `sales@identrail.com,security@identrail.com`)
+- `LEAD_EMAIL_FROM` (default: `Identrail <onboarding@resend.dev>`; use a verified Identrail domain in production)
+- `LEAD_REPLY_TO` (optional; defaults to the submitter for internal notifications and the first `LEAD_NOTIFY_TO` address for confirmations)
+- `LEAD_EMAIL_SUBJECT_PREFIX` (default: `Identrail`)
+- `LEAD_CONFIRMATION_ENABLED` (default: `true`; set `false` to skip the requester confirmation email)
+- `LEAD_CONFIRMATION_SUBJECT` (optional requester confirmation subject override)
+- `LEAD_EMAIL_TIMEOUT_MS` (default: `3000`, bounded to `500..10000`)
+
+Optional webhook forwarding can be enabled alongside email, or used as a
+fallback delivery channel:
+
+- `LEAD_WEBHOOK_URL` (must use `https`, or `http` only for localhost targets)
 - `LEAD_WEBHOOK_TIMEOUT_MS` (default: `3000`, bounded to `500..10000`)
-- `LEAD_CAPTURE_RATE_LIMIT_PER_MIN` (default: `15`, bounded to `1..120`, applied per client IP window)
 - `LEAD_WEBHOOK_HMAC_SECRET` (optional; when set, emits `X-Identrail-Signature: sha256=<digest>` for receiver-side verification)
+
+Shared lead-capture control:
+
+- `LEAD_CAPTURE_RATE_LIMIT_PER_MIN` (default: `15`, bounded to `1..120`, applied per client IP window)
 
 ## Validation and Limits
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -191,6 +191,9 @@ For the standard hosted setup, configure Resend:
 - `LEAD_CONFIRMATION_SUBJECT` (optional requester confirmation subject override)
 - `LEAD_EMAIL_TIMEOUT_MS` (default: `3000`, bounded to `500..10000`)
 
+Requester confirmation email is best-effort after the internal notification is
+accepted; confirmation rejection or timeout does not fail the captured lead.
+
 Optional webhook forwarding can be enabled alongside email, or used as the sole
 delivery channel when Resend is not configured:
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -199,7 +199,8 @@ delivery channel when Resend is not configured:
 - `LEAD_WEBHOOK_HMAC_SECRET` (optional; when set, emits `X-Identrail-Signature: sha256=<digest>` for receiver-side verification)
 
 When Resend and webhook forwarding are both configured, webhook forwarding is
-still attempted if Resend rejects or times out on the lead notification.
+still attempted if Resend rejects or times out on the lead notification. The
+endpoint accepts the submission once either configured channel succeeds.
 
 Shared lead-capture control:
 

--- a/web/api/leads.test.ts
+++ b/web/api/leads.test.ts
@@ -340,6 +340,37 @@ describe('web/api/leads handler', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('accepts the lead when requester confirmation fails after notifying the team', async () => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: false });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = createMockResponse();
+    await handler(
+      {
+        method: 'POST',
+        body: {
+          email: 'security@company.com',
+          environment: 'AWS IAM + Kubernetes'
+        }
+      },
+      res
+    );
+
+    expect(res.statusCode).toBe(202);
+    expect(res.body).toEqual({ status: 'accepted' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [notificationURL] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const [confirmationURL] = fetchMock.mock.calls[1] as unknown as [string, RequestInit];
+    expect(notificationURL).toBe('https://api.resend.com/emails');
+    expect(confirmationURL).toBe('https://api.resend.com/emails');
+  });
+
   it('returns 502 when Resend email delivery fails', async () => {
     process.env.RESEND_API_KEY = 're_test_key';
     process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';

--- a/web/api/leads.test.ts
+++ b/web/api/leads.test.ts
@@ -293,9 +293,33 @@ describe('web/api/leads handler', () => {
     });
   });
 
+  it('requires an explicit sender address for Resend delivery', async () => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = createMockResponse();
+    await handler(
+      {
+        method: 'POST',
+        body: {
+          email: 'security@company.com',
+          environment: 'AWS IAM + Kubernetes'
+        }
+      },
+      res
+    );
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toEqual({ error: 'Lead capture is not configured.' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('can disable requester confirmation while still notifying the team', async () => {
     process.env.RESEND_API_KEY = 're_test_key';
     process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
     process.env.LEAD_CONFIRMATION_ENABLED = 'false';
     const fetchMock = vi.fn(async () => ({ ok: true }));
     vi.stubGlobal('fetch', fetchMock);
@@ -319,6 +343,7 @@ describe('web/api/leads handler', () => {
   it('returns 502 when Resend email delivery fails', async () => {
     process.env.RESEND_API_KEY = 're_test_key';
     process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
     const fetchMock = vi.fn(async () => ({ ok: false }));
     vi.stubGlobal('fetch', fetchMock);
 

--- a/web/api/leads.test.ts
+++ b/web/api/leads.test.ts
@@ -401,6 +401,39 @@ describe('web/api/leads handler', () => {
     });
   });
 
+  it('accepts the lead when Resend succeeds and optional webhook forwarding fails', async () => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    process.env.LEAD_CONFIRMATION_ENABLED = 'false';
+    process.env.LEAD_WEBHOOK_URL = 'https://example.test/webhook';
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: false });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = createMockResponse();
+    await handler(
+      {
+        method: 'POST',
+        body: {
+          email: 'security@company.com',
+          environment: 'AWS IAM + Kubernetes'
+        }
+      },
+      res
+    );
+
+    expect(res.statusCode).toBe(202);
+    expect(res.body).toEqual({ status: 'accepted' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [emailURL] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const [webhookURL] = fetchMock.mock.calls[1] as unknown as [string, RequestInit];
+    expect(emailURL).toBe('https://api.resend.com/emails');
+    expect(webhookURL).toBe('https://example.test/webhook');
+  });
+
   it('signs outbound requests when webhook signing secret is configured', async () => {
     process.env.LEAD_WEBHOOK_URL = 'https://example.test/webhook';
     process.env.LEAD_WEBHOOK_HMAC_SECRET = 'test-signing-secret';

--- a/web/api/leads.test.ts
+++ b/web/api/leads.test.ts
@@ -363,6 +363,44 @@ describe('web/api/leads handler', () => {
     expect(res.body).toEqual({ error: 'Lead email delivery failed.' });
   });
 
+  it('still forwards to the webhook when Resend email delivery fails', async () => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    process.env.LEAD_WEBHOOK_URL = 'https://example.test/webhook';
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = createMockResponse();
+    await handler(
+      {
+        method: 'POST',
+        body: {
+          email: 'security@company.com',
+          environment: 'AWS IAM + Kubernetes',
+          source: 'Read-Only Scan Intake',
+          page_path: '/read-only-scan'
+        }
+      },
+      res
+    );
+
+    expect(res.statusCode).toBe(202);
+    expect(res.body).toEqual({ status: 'accepted' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [emailURL] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(emailURL).toBe('https://api.resend.com/emails');
+    const [webhookURL, webhookInit] = fetchMock.mock.calls[1] as unknown as [string, RequestInit];
+    expect(webhookURL).toBe('https://example.test/webhook');
+    expect(JSON.parse(String(webhookInit.body))).toMatchObject({
+      email: 'security@company.com',
+      source: 'Read-Only Scan Intake'
+    });
+  });
+
   it('signs outbound requests when webhook signing secret is configured', async () => {
     process.env.LEAD_WEBHOOK_URL = 'https://example.test/webhook';
     process.env.LEAD_WEBHOOK_HMAC_SECRET = 'test-signing-secret';

--- a/web/api/leads.test.ts
+++ b/web/api/leads.test.ts
@@ -25,6 +25,14 @@ function createMockResponse(): MockResponse {
 describe('web/api/leads handler', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    delete process.env.RESEND_API_KEY;
+    delete process.env.LEAD_NOTIFY_TO;
+    delete process.env.LEAD_EMAIL_FROM;
+    delete process.env.LEAD_EMAIL_SUBJECT_PREFIX;
+    delete process.env.LEAD_EMAIL_TIMEOUT_MS;
+    delete process.env.LEAD_REPLY_TO;
+    delete process.env.LEAD_CONFIRMATION_ENABLED;
+    delete process.env.LEAD_CONFIRMATION_SUBJECT;
     delete process.env.LEAD_WEBHOOK_URL;
     delete process.env.LEAD_WEBHOOK_HMAC_SECRET;
     delete process.env.LEAD_WEBHOOK_TIMEOUT_MS;
@@ -49,7 +57,7 @@ describe('web/api/leads handler', () => {
     expect(res.body).toEqual({ error: 'Valid work email is required.' });
   });
 
-  it('returns 503 when lead webhook is not configured', async () => {
+  it('returns 503 when no lead delivery channel is configured', async () => {
     const res = createMockResponse();
     await handler(
       {
@@ -209,7 +217,7 @@ describe('web/api/leads handler', () => {
     vi.useRealTimers();
   });
 
-  it('silently accepts honeypot challenge submissions without forwarding', async () => {
+  it('silently accepts honeypot website submissions without forwarding', async () => {
     process.env.LEAD_WEBHOOK_URL = 'https://example.test/webhook';
     const fetchMock = vi.fn(async () => ({ ok: true }));
     vi.stubGlobal('fetch', fetchMock);
@@ -221,7 +229,7 @@ describe('web/api/leads handler', () => {
         body: {
           email: 'security@company.com',
           environment: 'AWS IAM + Kubernetes',
-          challenge: 'bot-filled'
+          website: 'bot-filled'
         }
       },
       res
@@ -230,6 +238,104 @@ describe('web/api/leads handler', () => {
     expect(res.statusCode).toBe(202);
     expect(res.body).toEqual({ status: 'accepted' });
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('sends internal and confirmation emails through Resend when configured', async () => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com, security@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = createMockResponse();
+    await handler(
+      {
+        method: 'POST',
+        body: {
+          email: 'security@company.com',
+          company: 'Acme Corp',
+          environment: 'AWS IAM + Kubernetes',
+          challenge: 'Trust path visibility',
+          deployment_model: 'Hosted SaaS',
+          urgency: 'This quarter',
+          team_size: '6-20',
+          scan_goal: 'AWS IAM + Kubernetes trust-path risk reduction',
+          source: 'Read-Only Scan Intake',
+          page_path: '/read-only-scan'
+        }
+      },
+      res
+    );
+
+    expect(res.statusCode).toBe(202);
+    expect(res.body).toEqual({ status: 'accepted' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [notificationURL, notificationInit] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(notificationURL).toBe('https://api.resend.com/emails');
+    const notificationHeaders = (notificationInit.headers ?? {}) as Record<string, string>;
+    expect(notificationHeaders.Authorization).toBe('Bearer re_test_key');
+    expect(notificationHeaders['Idempotency-Key']).toMatch(/lead-notification$/);
+    expect(JSON.parse(String(notificationInit.body))).toMatchObject({
+      from: 'Identrail <scan@identrail.com>',
+      to: ['sales@identrail.com', 'security@identrail.com'],
+      reply_to: 'security@company.com',
+      subject: '[Identrail] New risk scan request from Acme Corp (security@company.com)'
+    });
+
+    const [, confirmationInit] = fetchMock.mock.calls[1] as unknown as [string, RequestInit];
+    const confirmationHeaders = (confirmationInit.headers ?? {}) as Record<string, string>;
+    expect(confirmationHeaders['Idempotency-Key']).toMatch(/lead-confirmation$/);
+    expect(JSON.parse(String(confirmationInit.body))).toMatchObject({
+      from: 'Identrail <scan@identrail.com>',
+      to: 'security@company.com',
+      reply_to: 'sales@identrail.com',
+      subject: 'We received your Identrail risk scan request'
+    });
+  });
+
+  it('can disable requester confirmation while still notifying the team', async () => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
+    process.env.LEAD_CONFIRMATION_ENABLED = 'false';
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = createMockResponse();
+    await handler(
+      {
+        method: 'POST',
+        body: {
+          email: 'security@company.com',
+          environment: 'AWS IAM + Kubernetes'
+        }
+      },
+      res
+    );
+
+    expect(res.statusCode).toBe(202);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 502 when Resend email delivery fails', async () => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
+    const fetchMock = vi.fn(async () => ({ ok: false }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = createMockResponse();
+    await handler(
+      {
+        method: 'POST',
+        body: {
+          email: 'security@company.com',
+          environment: 'AWS IAM + Kubernetes'
+        }
+      },
+      res
+    );
+
+    expect(res.statusCode).toBe(502);
+    expect(res.body).toEqual({ error: 'Lead email delivery failed.' });
   });
 
   it('signs outbound requests when webhook signing secret is configured', async () => {
@@ -252,7 +358,7 @@ describe('web/api/leads handler', () => {
 
     expect(res.statusCode).toBe(202);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     const headers = (init.headers ?? {}) as Record<string, string>;
     expect(headers['X-Identrail-Signature']).toMatch(/^sha256=[0-9a-f]{64}$/);
     expect(headers['X-Identrail-Lead-Request-ID']).toBeTruthy();
@@ -271,6 +377,7 @@ describe('web/api/leads handler', () => {
         body: {
           email: 'security@company.com',
           environment: 'AWS IAM + Kubernetes',
+          challenge: 'Trust path visibility',
           deployment_model: 'Hosted SaaS',
           urgency: 'This quarter',
           team_size: '6-20',
@@ -285,5 +392,11 @@ describe('web/api/leads handler', () => {
     expect(res.statusCode).toBe(202);
     expect(res.body).toEqual({ status: 'accepted' });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      email: 'security@company.com',
+      environment: 'AWS IAM + Kubernetes',
+      challenge: 'Trust path visibility'
+    });
   });
 });

--- a/web/api/leads.ts
+++ b/web/api/leads.ts
@@ -515,6 +515,7 @@ export default async function handler(
     requestID,
     timeoutMS: emailTimeoutMS
   });
+  const emailDelivered = emailResult === 'sent';
   if (emailResult === 'failed' && !webhookURL) {
     res.status(502).json({ error: 'Lead email delivery failed.' });
     return;
@@ -551,10 +552,18 @@ export default async function handler(
       signal: abortController.signal
     });
     if (!forward.ok) {
+      if (emailDelivered) {
+        res.status(202).json({ status: 'accepted' });
+        return;
+      }
       res.status(502).json({ error: 'Lead forwarding failed.' });
       return;
     }
   } catch {
+    if (emailDelivered) {
+      res.status(202).json({ status: 'accepted' });
+      return;
+    }
     res.status(502).json({ error: 'Lead forwarding failed.' });
     return;
   } finally {

--- a/web/api/leads.ts
+++ b/web/api/leads.ts
@@ -5,6 +5,7 @@ type LeadCapturePayload = {
   environment?: string;
   company?: string;
   challenge?: string;
+  website?: string;
   deployment_model?: string;
   scan_goal?: string;
   urgency?: string;
@@ -33,7 +34,23 @@ const MAX_PAGE_PATH_LENGTH = 240;
 const MAX_TEAM_SIZE_LENGTH = 16;
 const MAX_URGENCY_LENGTH = 32;
 const MAX_DEPLOYMENT_MODEL_LENGTH = 64;
+const DEFAULT_EMAIL_FROM = 'Identrail <onboarding@resend.dev>';
+const RESEND_EMAILS_URL = 'https://api.resend.com/emails';
 const leadRequestBuckets = new Map<string, number[]>();
+
+type LeadDeliveryPayload = {
+  email: string;
+  environment: string;
+  company?: string;
+  challenge?: string;
+  deployment_model?: string;
+  scan_goal?: string;
+  urgency?: string;
+  team_size?: string;
+  source: string;
+  page_path: string;
+  captured_at: string;
+};
 
 export function __resetLeadRequestBucketsForTests() {
   leadRequestBuckets.clear();
@@ -155,6 +172,214 @@ function hasValidWebhookURL(webhookURL: URL): boolean {
   return webhookURL.protocol === 'http:' && isLocalHost(webhookURL.hostname);
 }
 
+function parseEmailList(raw: string | undefined): string[] {
+  if (!raw) {
+    return [];
+  }
+  return raw
+    .split(/[,\n;]/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function booleanEnvEnabled(value: string | undefined, fallback: boolean): boolean {
+  if (!value) {
+    return fallback;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (['0', 'false', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
+  return fallback;
+}
+
+function escapeHTML(value: string | undefined): string {
+  return (value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function leadDisplayName(payload: LeadDeliveryPayload): string {
+  return payload.company ? `${payload.company} (${payload.email})` : payload.email;
+}
+
+function leadRows(payload: LeadDeliveryPayload): Array<[string, string | undefined]> {
+  return [
+    ['Work email', payload.email],
+    ['Company', payload.company],
+    ['Environment', payload.environment],
+    ['Challenge', payload.challenge],
+    ['Deployment model', payload.deployment_model],
+    ['Urgency', payload.urgency],
+    ['Team size', payload.team_size],
+    ['Scan goal', payload.scan_goal],
+    ['Source', payload.source],
+    ['Page path', payload.page_path],
+    ['Captured at', payload.captured_at]
+  ];
+}
+
+function renderLeadText(payload: LeadDeliveryPayload): string {
+  return [
+    `New Identrail risk scan request from ${leadDisplayName(payload)}.`,
+    '',
+    ...leadRows(payload).map(([label, value]) => `${label}: ${value || 'Not provided'}`),
+    '',
+    'Reply directly to the requester to schedule the next step.'
+  ].join('\n');
+}
+
+function renderLeadHTML(payload: LeadDeliveryPayload): string {
+  const rows = leadRows(payload)
+    .map(
+      ([label, value]) => `
+        <tr>
+          <th align="left" style="padding:8px 12px;border-bottom:1px solid #e5e7eb;color:#374151;font-size:13px;">${escapeHTML(label)}</th>
+          <td style="padding:8px 12px;border-bottom:1px solid #e5e7eb;color:#111827;font-size:13px;">${escapeHTML(value || 'Not provided')}</td>
+        </tr>`
+    )
+    .join('');
+
+  return `
+    <div style="font-family:Inter,Arial,sans-serif;color:#111827;line-height:1.5;">
+      <h1 style="font-size:20px;margin:0 0 12px;">New Identrail risk scan request</h1>
+      <p style="margin:0 0 16px;">${escapeHTML(leadDisplayName(payload))} submitted the public scan intake form.</p>
+      <table cellspacing="0" cellpadding="0" style="border-collapse:collapse;width:100%;max-width:640px;border:1px solid #e5e7eb;border-radius:8px;overflow:hidden;">
+        ${rows}
+      </table>
+      <p style="margin:16px 0 0;color:#4b5563;">Reply directly to the requester to schedule the next step.</p>
+    </div>`;
+}
+
+function renderConfirmationText(payload: LeadDeliveryPayload): string {
+  return [
+    'Thanks for requesting an Identrail read-only risk scan.',
+    '',
+    'We received your intake and will review the context before following up.',
+    '',
+    `Environment: ${payload.environment}`,
+    `Focus area: ${payload.challenge || 'Trust path visibility'}`,
+    `Deployment preference: ${payload.deployment_model || 'Not provided'}`,
+    '',
+    'We never ask for production credentials in this intake flow.'
+  ].join('\n');
+}
+
+function renderConfirmationHTML(payload: LeadDeliveryPayload): string {
+  return `
+    <div style="font-family:Inter,Arial,sans-serif;color:#111827;line-height:1.5;">
+      <h1 style="font-size:20px;margin:0 0 12px;">We received your Identrail risk scan request</h1>
+      <p style="margin:0 0 16px;">Thanks for requesting a read-only machine identity risk scan. We will review the context before following up.</p>
+      <ul style="padding-left:20px;margin:0 0 16px;color:#374151;">
+        <li><strong>Environment:</strong> ${escapeHTML(payload.environment)}</li>
+        <li><strong>Focus area:</strong> ${escapeHTML(payload.challenge || 'Trust path visibility')}</li>
+        <li><strong>Deployment preference:</strong> ${escapeHTML(payload.deployment_model || 'Not provided')}</li>
+      </ul>
+      <p style="margin:0;color:#4b5563;">We never ask for production credentials in this intake flow.</p>
+    </div>`;
+}
+
+async function postResendEmail({
+  apiKey,
+  requestID,
+  suffix,
+  timeoutMS,
+  body
+}: {
+  apiKey: string;
+  requestID: string;
+  suffix: string;
+  timeoutMS: number;
+  body: Record<string, unknown>;
+}): Promise<boolean> {
+  const abortController = new AbortController();
+  const timeoutHandle = setTimeout(() => abortController.abort(), timeoutMS);
+
+  try {
+    const response = await fetch(RESEND_EMAILS_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+        'Idempotency-Key': `${requestID}-${suffix}`
+      },
+      body: JSON.stringify(body),
+      signal: abortController.signal
+    });
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+}
+
+async function sendLeadEmails({
+  env,
+  payload,
+  requestID,
+  timeoutMS
+}: {
+  env: Record<string, string | undefined>;
+  payload: LeadDeliveryPayload;
+  requestID: string;
+  timeoutMS: number;
+}): Promise<'not_configured' | 'sent' | 'failed'> {
+  const apiKey = env.RESEND_API_KEY?.trim();
+  const notifyTo = parseEmailList(env.LEAD_NOTIFY_TO);
+  if (!apiKey || notifyTo.length === 0) {
+    return 'not_configured';
+  }
+
+  const from = env.LEAD_EMAIL_FROM?.trim() || DEFAULT_EMAIL_FROM;
+  const replyTo = env.LEAD_REPLY_TO?.trim() || payload.email;
+  const subjectPrefix = env.LEAD_EMAIL_SUBJECT_PREFIX?.trim() || 'Identrail';
+  const notificationSent = await postResendEmail({
+    apiKey,
+    requestID,
+    suffix: 'lead-notification',
+    timeoutMS,
+    body: {
+      from,
+      to: notifyTo,
+      reply_to: replyTo,
+      subject: `[${subjectPrefix}] New risk scan request from ${leadDisplayName(payload)}`,
+      text: renderLeadText(payload),
+      html: renderLeadHTML(payload)
+    }
+  });
+  if (!notificationSent) {
+    return 'failed';
+  }
+
+  if (!booleanEnvEnabled(env.LEAD_CONFIRMATION_ENABLED, true)) {
+    return 'sent';
+  }
+
+  const confirmationSent = await postResendEmail({
+    apiKey,
+    requestID,
+    suffix: 'lead-confirmation',
+    timeoutMS,
+    body: {
+      from,
+      to: payload.email,
+      reply_to: env.LEAD_REPLY_TO?.trim() || notifyTo[0],
+      subject: env.LEAD_CONFIRMATION_SUBJECT?.trim() || 'We received your Identrail risk scan request',
+      text: renderConfirmationText(payload),
+      html: renderConfirmationHTML(payload)
+    }
+  });
+
+  return confirmationSent ? 'sent' : 'failed';
+}
+
 function assertLength(res: HandlerResponse, value: string, maxLength: number, message: string): boolean {
   if (value.length <= maxLength) {
     return true;
@@ -189,6 +414,7 @@ export default async function handler(
   const environment = trimOptional(body.environment) ?? '';
   const company = trimOptional(body.company);
   const challenge = trimOptional(body.challenge);
+  const website = trimOptional(body.website);
   const scanGoal = trimOptional(body.scan_goal);
   const source = trimOptional(body.source) || 'unknown';
   const pagePath = trimOptional(body.page_path) || '/';
@@ -225,7 +451,7 @@ export default async function handler(
     return;
   }
 
-  if (challenge) {
+  if (website) {
     res.status(202).json({ status: 'accepted' });
     return;
   }
@@ -245,11 +471,11 @@ export default async function handler(
     return;
   }
 
-  const payload = {
+  const payload: LeadDeliveryPayload = {
     email,
     environment,
     company,
-    challenge: undefined,
+    challenge,
     deployment_model: deploymentModel && ALLOWED_DEPLOYMENT_MODELS.has(deploymentModel) ? deploymentModel : undefined,
     scan_goal: scanGoal,
     urgency: urgency && ALLOWED_URGENCY.has(urgency) ? urgency : undefined,
@@ -260,19 +486,42 @@ export default async function handler(
   };
 
   const webhook = env.LEAD_WEBHOOK_URL?.trim();
-
-  if (!webhook) {
-    res.status(503).json({ error: 'Lead capture is not configured.' });
-    return;
-  }
-  const webhookURL = parseWebhookURL(webhook);
-  if (!webhookURL || !hasValidWebhookURL(webhookURL)) {
+  const webhookURL = webhook ? parseWebhookURL(webhook) : null;
+  if (webhook && (!webhookURL || !hasValidWebhookURL(webhookURL))) {
     res.status(503).json({ error: 'Lead capture is not configured.' });
     return;
   }
 
   const payloadJSON = JSON.stringify(payload);
   const requestID = randomUUID();
+  const emailConfigured = Boolean(env.RESEND_API_KEY?.trim() && parseEmailList(env.LEAD_NOTIFY_TO).length > 0);
+  if (!emailConfigured && !webhookURL) {
+    res.status(503).json({ error: 'Lead capture is not configured.' });
+    return;
+  }
+
+  const emailTimeoutMS = parseBoundedInt(
+    env.LEAD_EMAIL_TIMEOUT_MS ?? env.LEAD_WEBHOOK_TIMEOUT_MS,
+    DEFAULT_FORWARD_TIMEOUT_MS,
+    MIN_FORWARD_TIMEOUT_MS,
+    MAX_FORWARD_TIMEOUT_MS
+  );
+  const emailResult = await sendLeadEmails({
+    env,
+    payload,
+    requestID,
+    timeoutMS: emailTimeoutMS
+  });
+  if (emailResult === 'failed') {
+    res.status(502).json({ error: 'Lead email delivery failed.' });
+    return;
+  }
+
+  if (!webhookURL) {
+    res.status(202).json({ status: 'accepted' });
+    return;
+  }
+
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     'X-Identrail-Lead-Request-ID': requestID

--- a/web/api/leads.ts
+++ b/web/api/leads.ts
@@ -515,7 +515,7 @@ export default async function handler(
     requestID,
     timeoutMS: emailTimeoutMS
   });
-  if (emailResult === 'failed') {
+  if (emailResult === 'failed' && !webhookURL) {
     res.status(502).json({ error: 'Lead email delivery failed.' });
     return;
   }

--- a/web/api/leads.ts
+++ b/web/api/leads.ts
@@ -34,7 +34,6 @@ const MAX_PAGE_PATH_LENGTH = 240;
 const MAX_TEAM_SIZE_LENGTH = 16;
 const MAX_URGENCY_LENGTH = 32;
 const MAX_DEPLOYMENT_MODEL_LENGTH = 64;
-const DEFAULT_EMAIL_FROM = 'Identrail <onboarding@resend.dev>';
 const RESEND_EMAILS_URL = 'https://api.resend.com/emails';
 const leadRequestBuckets = new Map<string, number[]>();
 
@@ -333,11 +332,11 @@ async function sendLeadEmails({
 }): Promise<'not_configured' | 'sent' | 'failed'> {
   const apiKey = env.RESEND_API_KEY?.trim();
   const notifyTo = parseEmailList(env.LEAD_NOTIFY_TO);
-  if (!apiKey || notifyTo.length === 0) {
+  const from = env.LEAD_EMAIL_FROM?.trim();
+  if (!apiKey || notifyTo.length === 0 || !from) {
     return 'not_configured';
   }
 
-  const from = env.LEAD_EMAIL_FROM?.trim() || DEFAULT_EMAIL_FROM;
   const replyTo = env.LEAD_REPLY_TO?.trim() || payload.email;
   const subjectPrefix = env.LEAD_EMAIL_SUBJECT_PREFIX?.trim() || 'Identrail';
   const notificationSent = await postResendEmail({
@@ -494,7 +493,11 @@ export default async function handler(
 
   const payloadJSON = JSON.stringify(payload);
   const requestID = randomUUID();
-  const emailConfigured = Boolean(env.RESEND_API_KEY?.trim() && parseEmailList(env.LEAD_NOTIFY_TO).length > 0);
+  const emailConfigured = Boolean(
+    env.RESEND_API_KEY?.trim() &&
+      parseEmailList(env.LEAD_NOTIFY_TO).length > 0 &&
+      env.LEAD_EMAIL_FROM?.trim()
+  );
   if (!emailConfigured && !webhookURL) {
     res.status(503).json({ error: 'Lead capture is not configured.' });
     return;

--- a/web/api/leads.ts
+++ b/web/api/leads.ts
@@ -361,7 +361,7 @@ async function sendLeadEmails({
     return 'sent';
   }
 
-  const confirmationSent = await postResendEmail({
+  await postResendEmail({
     apiKey,
     requestID,
     suffix: 'lead-confirmation',
@@ -376,7 +376,7 @@ async function sendLeadEmails({
     }
   });
 
-  return confirmationSent ? 'sent' : 'failed';
+  return 'sent';
 }
 
 function assertLength(res: HandlerResponse, value: string, maxLength: number, message: string): boolean {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -76,7 +76,9 @@ describe('App', () => {
       })
     ).toBeInTheDocument();
 
-    expect(screen.getAllByRole('link', { name: 'Start Free Risk Scan' }).length).toBeGreaterThan(0);
+    const scanLinks = screen.getAllByRole('link', { name: 'Start Free Risk Scan' });
+    expect(scanLinks.length).toBeGreaterThan(0);
+    expect(scanLinks[0]).toHaveAttribute('href', '/read-only-scan');
     expect(screen.getByRole('link', { name: /Book Demo/i })).toBeInTheDocument();
     expect(screen.getAllByText(/Adoption Paths/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Reachable Risk Paths/i).length).toBeGreaterThan(0);
@@ -132,6 +134,33 @@ describe('App', () => {
 
     expect(screen.getByText(/Step 1 of 3/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument();
+  });
+
+  it('submits read-only scan challenge details to lead capture', async () => {
+    setCurrentPath('/read-only-scan');
+    const fetchMock = vi.fn(async () => okJSON({ status: 'accepted' }));
+    vi.stubGlobal('fetch', fetchMock);
+    render(<App />);
+
+    fireEvent.change(screen.getByLabelText(/Work email/i), {
+      target: { value: 'security@example.com' }
+    });
+    fireEvent.change(screen.getByLabelText(/Company/i), {
+      target: { value: 'Example Co' }
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Start Free Risk Scan' }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/leads', expect.any(Object)));
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      email: 'security@example.com',
+      company: 'Example Co',
+      environment: 'AWS IAM + Kubernetes',
+      challenge: 'Trust path visibility',
+      page_path: '/read-only-scan'
+    });
   });
 
   it('renders deployment models route', () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -841,6 +841,7 @@ function LeadCaptureForm({
     const environment = String(formData.get('environment') ?? '').trim();
     const company = String(formData.get('company') ?? '').trim();
     const challenge = String(formData.get('challenge') ?? '').trim();
+    const website = String(formData.get('website') ?? '').trim();
 
     setSubmitting(true);
     setError(null);
@@ -851,6 +852,7 @@ function LeadCaptureForm({
         environment,
         company: company || undefined,
         challenge: challenge || undefined,
+        website: website || undefined,
         source: title,
         page_path: window.location.pathname
       });
@@ -872,6 +874,14 @@ function LeadCaptureForm({
 
       {!submitted ? (
         <form onSubmit={handleSubmit} className={`idt-form-grid ${variant === 'short' ? 'is-short' : ''}`}>
+          <input
+            className="idt-honeypot"
+            type="text"
+            name="website"
+            tabIndex={-1}
+            autoComplete="off"
+            aria-hidden="true"
+          />
           <label>
             Work email
             <input required type="email" name="email" autoComplete="email" placeholder="you@company.com" />
@@ -1738,9 +1748,9 @@ function HomePage() {
               sensitive resources, then packages the proof and safest first fix for the owner.
             </p>
             <div className="idt-inline-actions" data-ab-slot="hero_primary_cta">
-              <a href="#risk-scan-form" className="idt-btn idt-btn-primary">
+              <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
                 Start Free Risk Scan
-              </a>
+              </Link>
               <HeroOpenSourceProofPills />
             </div>
             <dl className="idt-hero-metrics" aria-label="Product assurances">
@@ -1852,6 +1862,8 @@ function ReadOnlyScanPage() {
     if (submitting) {
       return;
     }
+    const formData = new FormData(event.currentTarget);
+    const website = String(formData.get('website') ?? '').trim();
 
     setSubmitting(true);
     setError(null);
@@ -1862,6 +1874,7 @@ function ReadOnlyScanPage() {
         environment,
         company: company.trim() || undefined,
         challenge: challenge,
+        website: website || undefined,
         deployment_model: deployment,
         urgency,
         team_size: teamSize,
@@ -1919,6 +1932,14 @@ function ReadOnlyScanPage() {
 
       <section className="idt-scan-intake" aria-labelledby="scan-intake-title">
         <form className="idt-scan-form" onSubmit={submitIntake}>
+          <input
+            className="idt-honeypot"
+            type="text"
+            name="website"
+            tabIndex={-1}
+            autoComplete="off"
+            aria-hidden="true"
+          />
           <div className="idt-scan-form-header">
             <p className="idt-intake-step">Step {submitted ? 3 : step} of 3</p>
             <h2 id="scan-intake-title">{submitted ? 'Request received' : 'Tell us where to start'}</h2>

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -387,6 +387,7 @@ export type LeadCapturePayload = {
   environment: string;
   company?: string;
   challenge?: string;
+  website?: string;
   deployment_model?: string;
   scan_goal?: string;
   urgency?: string;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1382,6 +1382,17 @@ h3 {
   gap: 0.75rem;
 }
 
+.idt-honeypot {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
 .idt-form-grid.is-short {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   align-items: start;


### PR DESCRIPTION
No issue: user-reported production scan intake routing and email delivery bug from support session.

## Summary

- Route the homepage Start Free Risk Scan hero CTA directly to `/read-only-scan` instead of the lower homepage CTA anchor.
- Split the lead-capture honeypot into a dedicated hidden `website` field so the real `challenge` answer is forwarded as lead context.
- Add production-style Resend delivery for public lead capture: internal notification email, requester confirmation email, idempotency keys, and optional webhook forwarding for CRM/automation fanout.
- Document the required Resend lead-capture environment variables and update the changelog.

## Why

The public scan intake looked complete but did not behave like a standard production lead flow. The hero CTA repeated the homepage experience by scrolling to the lower CTA, and the backend treated the real "Biggest challenge" field as a bot honeypot, so legitimate scan submissions could be accepted without forwarding meaningful lead data.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

Risk is moderate-low: existing signed webhook forwarding still works, and Resend delivery is enabled only when `RESEND_API_KEY` plus `LEAD_NOTIFY_TO` are configured. If neither email nor webhook delivery is configured, the endpoint continues to return a clear 503.

## Validation

```bash
npm test -- --run api/leads.test.ts src/App.test.tsx
# 2 files passed, 49 tests passed

npm run build
# production build passed, prerendered 41 routes

npm run test:ci
# 10 files passed, 100 tests passed; coverage thresholds passed
```

Manual browser check:
- Verified the homepage hero CTA href is `/read-only-scan`.
- Verified `/read-only-scan` renders the intake form without console errors.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: yes
- Tools used: Codex
- Areas where used: web lead-capture endpoint, public scan CTA/form wiring, tests, configuration docs, changelog
- Human verification performed: reviewed diff, ran targeted web tests, production web build, web test coverage gate, and browser sanity check

## Related Issues

No issue: user-reported production scan intake routing and email delivery bug from support session.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes read-only scan lead capture so real submissions are delivered, requesters get a best‑effort confirmation, and submissions are accepted once either email or webhook delivery succeeds. Routes the homepage hero CTA to `/read-only-scan`, replaces the honeypot with a hidden `website` field, and adds Resend-based email delivery with webhook fallback.

- **New Features**
  - Resend email delivery for public leads: internal notification + requester confirmation (best‑effort), idempotency keys, HTML/text bodies, reply-to defaults, bounded timeouts, and acceptance once email or webhook succeeds. Requires an explicit, verified sender.
  - Config via env: `RESEND_API_KEY`, `LEAD_NOTIFY_TO`, required `LEAD_EMAIL_FROM`, optional `LEAD_REPLY_TO`, `LEAD_EMAIL_SUBJECT_PREFIX`, `LEAD_CONFIRMATION_ENABLED`, `LEAD_CONFIRMATION_SUBJECT`, `LEAD_EMAIL_TIMEOUT_MS`. Webhook fanout via `LEAD_WEBHOOK_URL`, `LEAD_WEBHOOK_TIMEOUT_MS`, optional `LEAD_WEBHOOK_HMAC_SECRET`. Shared: `LEAD_CAPTURE_RATE_LIMIT_PER_MIN`.

- **Bug Fixes**
  - Uses hidden `website` honeypot; forwards the real `challenge` in lead context.
  - Returns 503 when no delivery channel is configured; returns 502 on Resend failures when no webhook is set; still forwards to the webhook if email delivery fails and accepts the lead when email succeeds but webhook fails.
  - Points the homepage “Start Free Risk Scan” CTA directly to `/read-only-scan`.

<sup>Written for commit 815985ba4e2ccde8fc87c42b636a5adade4c8c99. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1184?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

