### PR TITLE
Redesign homepage lower story with better layout

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -85,6 +85,8 @@ describe('App', () => {
     expect(
       screen.getByRole('heading', { level: 2, name: /From connector setup to evidence-ready remediation/i })
     ).toBeInTheDocument();
+    expect(document.querySelector('.idt-trust-strip + .idt-home-after-stack')).toBeInTheDocument();
+    expect(document.querySelector('.idt-home-after-stack .idt-shell')).not.toBeInTheDocument();
   });
 
   it('renders pricing page routes and key elements', () => {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -85,6 +85,8 @@ describe('App', () => {
     expect(
       screen.getByRole('heading', { level: 2, name: /From connector setup to evidence-ready remediation/i })
     ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Need enterprise procurement/i })).toHaveAttribute('href', '/enterprise');
+    expect(document.querySelector('#risk-scan-form')).not.toBeInTheDocument();
     expect(document.querySelector('.idt-trust-strip + .idt-home-after-stack')).toBeInTheDocument();
     expect(document.querySelector('.idt-home-after-stack .idt-shell')).not.toBeInTheDocument();
   });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -569,13 +569,15 @@ function PageHero({
   body,
   actions,
   visual,
+  visualHidden = true,
   variant
 }: {
   eyebrow: string;
   title: string;
   body?: ReactNode;
   actions?: ReactNode;
-  visual: ReactNode;
+  visual?: ReactNode;
+  visualHidden?: boolean;
   variant: PageHeroVariant;
 }) {
   return (
@@ -586,9 +588,11 @@ function PageHero({
         {body ? <p>{body}</p> : null}
         {actions ? <div className="idt-inline-actions">{actions}</div> : null}
       </div>
-      <div className="idt-page-hero-visual" aria-hidden="true">
-        {visual}
-      </div>
+      {visual ? (
+        <div className="idt-page-hero-visual" aria-hidden={visualHidden ? 'true' : undefined}>
+          {visual}
+        </div>
+      ) : null}
     </section>
   );
 }
@@ -611,17 +615,17 @@ function ProductHeroVisual() {
             </div>
             <svg viewBox="0 0 720 420" aria-hidden="true" focusable="false">
               <defs>
-                <marker id="idt-product-hero-arrow" viewBox="0 0 10 10" refX="8.4" refY="5" markerWidth="8" markerHeight="8" orient="auto">
-                  <path d="M 0 0 L 10 5 L 0 10 z" />
+                <marker id="idt-product-hero-arrow" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="12" markerHeight="12" orient="auto">
+                  <path d="M 1 1 L 11 6 L 1 11 L 3.4 6 Z" />
                 </marker>
-                <marker id="idt-product-hero-arrow-muted" viewBox="0 0 10 10" refX="8.4" refY="5" markerWidth="7" markerHeight="7" orient="auto">
-                  <path d="M 0 0 L 10 5 L 0 10 z" />
+                <marker id="idt-product-hero-arrow-muted" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="10" markerHeight="10" orient="auto">
+                  <path d="M 1 1 L 11 6 L 1 11 L 3.4 6 Z" />
                 </marker>
               </defs>
-              <path className="idt-product-graph-edge is-muted" d="M142 126 C216 146 244 184 314 214" />
-              <path className="idt-product-graph-edge is-safe" d="M398 226 C454 196 493 139 548 104" />
-              <path className="idt-product-graph-edge is-risk" d="M400 245 C442 274 487 298 538 315" />
-              <path className="idt-product-graph-edge is-proof" d="M182 324 C235 294 270 257 314 232" />
+              <path className="idt-product-graph-edge is-muted" d="M150 152 C230 166 284 209 338 248" />
+              <path className="idt-product-graph-edge is-proof" d="M162 334 C226 320 282 288 336 266" />
+              <path className="idt-product-graph-edge is-safe" d="M426 250 C500 220 545 164 606 128" />
+              <path className="idt-product-graph-edge is-risk" d="M428 278 C472 318 515 333 560 344" />
             </svg>
             <div className="idt-graph-pill is-github">
               <strong>GitHub OIDC</strong>
@@ -657,26 +661,11 @@ function ProductHeroVisual() {
 }
 
 function PricingHeroVisual() {
-  const plans = [
-    ['OSS', '$0', 'Self-hosted'],
-    ['Pro', '$59', 'Hosted trial'],
-    ['Enterprise', '$50k+', 'Private tenancy']
-  ] as const;
-
   return (
     <div className="idt-pricing-hero-visual">
       <div className="idt-pricing-hero-toggle">
         <span>Monthly</span>
         <strong>Annual - save 25%</strong>
-      </div>
-      <div className="idt-pricing-hero-plans">
-        {plans.map(([name, price, note]) => (
-          <div key={name} className={name === 'Pro' ? 'is-featured' : ''}>
-            <span>{name}</span>
-            <strong>{price}</strong>
-            <p>{note}</p>
-          </div>
-        ))}
       </div>
       <div className="idt-pricing-hero-matrix">
         <span>Capability</span>
@@ -706,29 +695,99 @@ function PricingHeroVisual() {
   );
 }
 
+const DOCS_PREVIEW_TABS = [
+  {
+    id: 'quickstart',
+    label: 'Quickstart',
+    kicker: 'Runbook',
+    title: 'Deploy read-only source collection',
+    bullets: ['Validate connector scope', 'Import trust-path evidence', 'Review first risk queue'],
+    command: [
+      ['identrail', 'command'],
+      ['scan', 'subcommand'],
+      ['--source', 'flag'],
+      ['kubernetes', 'value'],
+      ['--read-only', 'flag']
+    ]
+  },
+  {
+    id: 'connectors',
+    label: 'Connectors',
+    kicker: 'Integration',
+    title: 'Connect cloud and cluster identity sources',
+    bullets: ['Register AWS IAM role access', 'Attach Kubernetes read-only RBAC', 'Link GitHub OIDC workflow context'],
+    command: [
+      ['identrail', 'command'],
+      ['connector', 'subcommand'],
+      ['add', 'subcommand'],
+      ['kubernetes', 'value'],
+      ['--scope', 'flag'],
+      ['read-only', 'value']
+    ]
+  },
+  {
+    id: 'architecture',
+    label: 'Architecture',
+    kicker: 'Model',
+    title: 'Trace ingestion into the trust graph',
+    bullets: ['Normalize principals and assumptions', 'Build source-linked graph edges', 'Keep evidence packets attached'],
+    command: [
+      ['identrail', 'command'],
+      ['graph', 'subcommand'],
+      ['explain', 'subcommand'],
+      ['--path', 'flag'],
+      ['oidc-to-iam', 'value']
+    ]
+  },
+  {
+    id: 'operations',
+    label: 'Operations',
+    kicker: 'Workflow',
+    title: 'Simulate remediation before rollout',
+    bullets: ['Preview owner-ready fixes', 'Estimate workload impact', 'Export audit-ready timeline'],
+    command: [
+      ['identrail', 'command'],
+      ['fix', 'subcommand'],
+      ['simulate', 'subcommand'],
+      ['--target', 'flag'],
+      ['billing-prod', 'value']
+    ]
+  }
+] as const;
+
 function DocsHeroVisual() {
+  const [activeTabId, setActiveTabId] = useState<(typeof DOCS_PREVIEW_TABS)[number]['id']>('quickstart');
+  const activeTab = DOCS_PREVIEW_TABS.find((tab) => tab.id === activeTabId) ?? DOCS_PREVIEW_TABS[0];
+
   return (
     <div className="idt-docs-hero-visual">
       <div className="idt-docs-search-preview">
         <span>Search docs topics</span>
-        <strong>kubernetes connector hardening</strong>
+        <strong>{activeTab.title.toLowerCase()}</strong>
       </div>
       <div className="idt-docs-preview-shell">
-        <nav>
-          <span className="is-active">Quickstart</span>
-          <span>Connectors</span>
-          <span>Architecture</span>
-          <span>Operations</span>
+        <nav aria-label="Docs preview topics">
+          {DOCS_PREVIEW_TABS.map((tab) => (
+            <button key={tab.id} type="button" className={tab.id === activeTab.id ? 'is-active' : ''} onClick={() => setActiveTabId(tab.id)}>
+              {tab.label}
+            </button>
+          ))}
         </nav>
         <article>
-          <p>Runbook</p>
-          <h3>Deploy read-only source collection</h3>
+          <p>{activeTab.kicker}</p>
+          <h3>{activeTab.title}</h3>
           <ul>
-            <li>Validate connector scope</li>
-            <li>Import trust-path evidence</li>
-            <li>Review first risk queue</li>
+            {activeTab.bullets.map((bullet) => (
+              <li key={bullet}>{bullet}</li>
+            ))}
           </ul>
-          <code>identrail scan --source kubernetes --read-only</code>
+          <code aria-label={`${activeTab.command.map(([token]) => token).join(' ')} command`}>
+            {activeTab.command.map(([token, kind]) => (
+              <span key={`${activeTab.id}-${token}`} className={`is-${kind}`}>
+                {token}
+              </span>
+            ))}
+          </code>
         </article>
       </div>
     </div>
@@ -763,6 +822,59 @@ function BlogHeroVisual() {
         <strong>Cloud identity</strong>
       </div>
     </div>
+  );
+}
+
+const BLOG_ARTICLE_TREATMENTS = {
+  'Machine Identity Security': {
+    icon: '/brand-logos/openid.svg',
+    label: 'OpenID',
+    className: 'is-identity'
+  },
+  'AWS Security': {
+    icon: '/brand-logos/aws.svg',
+    label: 'AWS',
+    className: 'is-aws'
+  },
+  'Kubernetes Security': {
+    icon: '/brand-logos/kubernetes.svg',
+    label: 'Kubernetes',
+    className: 'is-kubernetes'
+  },
+  'Software Supply Chain': {
+    icon: '/brand-logos/github.svg',
+    label: 'GitHub',
+    className: 'is-supply-chain'
+  },
+  'Buying Guide': {
+    icon: '/identrail-logo.png',
+    label: 'Identrail',
+    className: 'is-buying'
+  },
+  Compliance: {
+    icon: '/brand-logos/amazoniam.svg',
+    label: 'AWS IAM',
+    className: 'is-compliance'
+  },
+  'Platform Engineering': {
+    icon: '/brand-logos/terraform.svg',
+    label: 'Terraform',
+    className: 'is-platform'
+  },
+  'Security Leadership': {
+    icon: '/brand-logos/prometheus.svg',
+    label: 'Prometheus',
+    className: 'is-leadership'
+  }
+} as const;
+
+function getBlogArticleTreatment(category: string) {
+  return (
+    BLOG_ARTICLE_TREATMENTS[category as keyof typeof BLOG_ARTICLE_TREATMENTS] ?? {
+      icon: '/identrail-logo.png',
+      label: 'Identrail',
+      className: 'is-default'
+    }
   );
 }
 
@@ -1041,12 +1153,6 @@ function CalendlyEmbed() {
               Talk to Sales
             </Link>
           </div>
-          <p className="idt-inline-link-note">
-            Need async scheduling?{' '}
-            <SafeLink href="mailto:sales@identrail.com" className="idt-inline-link">
-              Email sales
-            </SafeLink>
-          </p>
         </article>
         <aside className="idt-calendly-preview" aria-label="Demo agenda preview">
           <p className="idt-eyebrow">Sample agenda</p>
@@ -1165,12 +1271,19 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
 
     const dx = to.x - from.x;
     const dy = to.y - from.y;
+    const length = Math.hypot(dx, dy) || 1;
+    const ux = dx / length;
+    const uy = dy / length;
+    const startX = from.x + ux * 5.8;
+    const startY = from.y + uy * 5.8;
+    const endX = to.x - ux * 7.2;
+    const endY = to.y - uy * 7.2;
     const bend = Math.min(12, Math.max(4.5, Math.abs(dx) * 0.14 + Math.abs(dy) * 0.06));
-    const c1x = from.x + dx * 0.32;
-    const c1y = from.y + dy * 0.16 - bend;
-    const c2x = to.x - dx * 0.26;
-    const c2y = to.y - dy * 0.12 + bend * 0.16;
-    return `M ${from.x} ${from.y} C ${c1x} ${c1y} ${c2x} ${c2y} ${to.x} ${to.y}`;
+    const c1x = startX + dx * 0.32;
+    const c1y = startY + dy * 0.16 - bend;
+    const c2x = endX - dx * 0.26;
+    const c2y = endY - dy * 0.12 + bend * 0.16;
+    return `M ${startX} ${startY} C ${c1x} ${c1y} ${c2x} ${c2y} ${endX} ${endY}`;
   };
 
   const connectedEdges = edges.filter((edge) => edge.from === selected.id || edge.to === selected.id);
@@ -1227,8 +1340,8 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
                 <stop offset="55%" stopColor="rgba(203, 222, 255, 0.95)" />
                 <stop offset="100%" stopColor="rgba(154, 184, 238, 0.42)" />
               </linearGradient>
-              <marker id={`idt-demo-edge-arrow-${variant}`} viewBox="0 0 10 10" refX="8.6" refY="5" markerWidth="6" markerHeight="6" orient="auto">
-                <path fill="context-stroke" d="M 0 0 L 10 5 L 0 10 z" />
+              <marker id={`idt-demo-edge-arrow-${variant}`} viewBox="0 0 12 12" refX="10" refY="6" markerWidth="10" markerHeight="10" orient="auto">
+                <path fill="context-stroke" d="M 1 1 L 11 6 L 1 11 L 3.2 6 Z" />
               </marker>
             </defs>
             {edges.map((edge, index) => {
@@ -2503,7 +2616,7 @@ function PricingPage() {
   const [annual, setAnnual] = useState(true);
   const [salesModalOpen, setSalesModalOpen] = useState(false);
 
-  const proPrice = annual ? 59 : 79;
+  const proPrice = annual ? 30 : 39;
 
   return (
     <div className="idt-marketing-page idt-pricing-page">
@@ -2516,7 +2629,7 @@ function PricingPage() {
         actions={
           <>
             <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-              Start Free Risk Scan
+              Start Pro Trial
             </Link>
             <button type="button" className="idt-btn idt-btn-dark" onClick={() => setSalesModalOpen(true)}>
               Talk to Enterprise
@@ -2574,13 +2687,13 @@ function PricingPage() {
               <li>14-day hosted trial with guided setup</li>
             </ul>
             <Link to="/enterprise" className="idt-btn idt-btn-primary">
-              Start Free Risk Scan
+              Start Pro Trial
             </Link>
           </article>
 
           <article className="idt-pricing-card">
             <h2>Enterprise</h2>
-            <p className="idt-price">Starting at $50k/yr</p>
+            <p className="idt-price">Custom quote</p>
             <p className="idt-plan-fit">
               <strong>Best for:</strong> Private deployment, procurement workflows, and advanced governance.
             </p>
@@ -2971,6 +3084,7 @@ function DocsPage() {
         body="Fast search, practical runbooks, and source-linked operator docs for production rollouts."
         variant="docs"
         visual={<DocsHeroVisual />}
+        visualHidden={false}
         actions={
           <SafeLink href={DOCS_REPO} className="idt-btn idt-btn-primary">
             Open Full GitHub Docs
@@ -3052,29 +3166,31 @@ function BlogPage() {
         title="Actionable content for security and platform teams operating machine identities"
         body="Educational deep dives, implementation playbooks, and strategic guidance for enterprise buyers."
         variant="blog"
-        visual={<BlogHeroVisual />}
-        actions={
-          <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-            Start Free Risk Scan
-          </Link>
-        }
       />
 
       <section className="idt-section idt-shell">
         <div className="idt-card-grid two-col idt-blog-grid">
-          {BLOG_POSTS.map((post) => (
-            <article key={post.slug} className="idt-card">
-              <p className="idt-chip-row">
-                <span>{post.category}</span>
-                <span>{post.readTime}</span>
-              </p>
-              <h2>{post.title}</h2>
-              <p>{post.description}</p>
-              <Link to={`/blog/${post.slug}`} className="idt-btn idt-btn-ghost">
-                Read article
-              </Link>
-            </article>
-          ))}
+          {BLOG_POSTS.map((post) => {
+            const treatment = getBlogArticleTreatment(post.category);
+            return (
+              <article key={post.slug} className={`idt-card idt-blog-card ${treatment.className}`}>
+                <div className="idt-blog-card-head">
+                  <span className="idt-blog-card-logo">
+                    <img src={treatment.icon} alt={`${treatment.label} logo`} loading="lazy" />
+                  </span>
+                  <p className="idt-chip-row">
+                    <span>{post.category}</span>
+                    <span>{post.readTime}</span>
+                  </p>
+                </div>
+                <h2>{post.title}</h2>
+                <p>{post.description}</p>
+                <Link to={`/blog/${post.slug}`} className="idt-btn idt-btn-ghost">
+                  Read article
+                </Link>
+              </article>
+            );
+          })}
         </div>
       </section>
     </div>
@@ -3312,7 +3428,7 @@ function AboutPage() {
   });
 
   return (
-    <>
+    <div className="idt-marketing-page idt-about-page">
       <PageHero
         eyebrow="Company"
         title="Building the future control plane for machine identity security"
@@ -3351,7 +3467,7 @@ function AboutPage() {
           </article>
         </div>
       </section>
-    </>
+    </div>
   );
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -601,22 +601,27 @@ function ProductHeroVisual() {
           <span />
           <span />
           <span />
-          <strong>Trust graph</strong>
+          <strong>Production trust graph</strong>
         </div>
         <div className="idt-product-hero-body">
-          <div className="idt-product-hero-sidebar">
-            <span className="is-active">Paths</span>
-            <span>Evidence</span>
-            <span>Fixes</span>
-          </div>
           <div className="idt-product-hero-graph">
+            <div className="idt-product-graph-title">
+              <span>Live path</span>
+              <strong>CI/CD identity to billing data</strong>
+            </div>
             <svg viewBox="0 0 720 420" aria-hidden="true" focusable="false">
-              <path className="is-muted" d="M118 118 C236 82 316 154 430 132 S600 92 658 166" />
-              <path className="is-risk" d="M310 236 C400 236 450 296 520 330 S620 358 675 318" />
-              <path className="is-safe" d="M196 330 C274 286 354 264 452 258" />
-              <circle className="idt-graph-node is-risk" cx="118" cy="118" r="6" />
-              <circle className="idt-graph-node is-risk" cx="452" cy="258" r="6" />
-              <circle className="idt-graph-node is-risk" cx="675" cy="318" r="6" />
+              <defs>
+                <marker id="idt-product-hero-arrow" viewBox="0 0 10 10" refX="8.4" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+                  <path d="M 0 0 L 10 5 L 0 10 z" />
+                </marker>
+                <marker id="idt-product-hero-arrow-muted" viewBox="0 0 10 10" refX="8.4" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+                  <path d="M 0 0 L 10 5 L 0 10 z" />
+                </marker>
+              </defs>
+              <path className="idt-product-graph-edge is-muted" d="M142 126 C216 146 244 184 314 214" />
+              <path className="idt-product-graph-edge is-safe" d="M398 226 C454 196 493 139 548 104" />
+              <path className="idt-product-graph-edge is-risk" d="M400 245 C442 274 487 298 538 315" />
+              <path className="idt-product-graph-edge is-proof" d="M182 324 C235 294 270 257 314 232" />
             </svg>
             <div className="idt-graph-pill is-github">
               <strong>GitHub OIDC</strong>
@@ -1222,11 +1227,13 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
                 <stop offset="55%" stopColor="rgba(203, 222, 255, 0.95)" />
                 <stop offset="100%" stopColor="rgba(154, 184, 238, 0.42)" />
               </linearGradient>
+              <marker id={`idt-demo-edge-arrow-${variant}`} viewBox="0 0 10 10" refX="8.6" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+                <path fill="context-stroke" d="M 0 0 L 10 5 L 0 10 z" />
+              </marker>
             </defs>
             {edges.map((edge, index) => {
               const path = edgePath(edge.from, edge.to);
-              const toNode = getNode(edge.to);
-              if (!path || !toNode) {
+              if (!path) {
                 return null;
               }
 
@@ -1235,12 +1242,12 @@ function TrustGraphDemo({ variant = 'compact' }: { variant?: 'compact' | 'full' 
               return (
                 <g key={edge.id} className={edgeClass}>
                   <path className="idt-demo-edge-base" d={path} stroke={`url(#idt-demo-edge-base-gradient-${variant})`} />
+                  <path className="idt-demo-edge-arrow" d={path} markerEnd={`url(#idt-demo-edge-arrow-${variant})`} />
                   <path
                     className={`idt-demo-edge-flow idt-demo-edge-delay-${index}`}
                     d={path}
                     stroke={`url(#idt-demo-edge-flow-gradient-${variant})`}
                   />
-                  <circle className="idt-demo-edge-end" cx={toNode.x} cy={toNode.y} r={isConnected ? 0.72 : 0.56} />
                 </g>
               );
             })}
@@ -1826,11 +1833,8 @@ function HomePage() {
             body="Start with a read-only scan, review evidence, then decide whether to self-host, use hosted SaaS, or move to enterprise deployment."
           />
           <div className="idt-inline-actions">
-            <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-              Start Free Risk Scan
-            </Link>
-            <Link to="/enterprise" className="idt-final-cta-link">
-              Need enterprise procurement? Contact Sales →
+            <Link to="/enterprise" className="idt-btn idt-btn-primary">
+              Need enterprise procurement? Contact Sales
             </Link>
           </div>
         </section>
@@ -2502,7 +2506,7 @@ function PricingPage() {
   const proPrice = annual ? 59 : 79;
 
   return (
-    <>
+    <div className="idt-marketing-page idt-pricing-page">
       <PageHero
         eyebrow="Pricing"
         title="Pricing aligned to how teams adopt machine identity security"
@@ -2659,7 +2663,7 @@ function PricingPage() {
           />
         </ModalShell>
       ) : null}
-    </>
+    </div>
   );
 }
 
@@ -2960,7 +2964,7 @@ function DocsPage() {
   });
 
   return (
-    <>
+    <div className="idt-marketing-page idt-docs-page">
       <PageHero
         eyebrow="Docs"
         title="Deploy, connect, and operate Identrail in production"
@@ -3028,7 +3032,7 @@ function DocsPage() {
       <section className="idt-section idt-shell">
         <CalendlyEmbed />
       </section>
-    </>
+    </div>
   );
 }
 
@@ -3042,7 +3046,7 @@ function BlogPage() {
   });
 
   return (
-    <>
+    <div className="idt-marketing-page idt-blog-page">
       <PageHero
         eyebrow="Blog & Resources"
         title="Actionable content for security and platform teams operating machine identities"
@@ -3073,7 +3077,7 @@ function BlogPage() {
           ))}
         </div>
       </section>
-    </>
+    </div>
   );
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -847,7 +847,7 @@ const BLOG_ARTICLE_TREATMENTS = {
     className: 'is-supply-chain'
   },
   'Buying Guide': {
-    icon: '/identrail-logo.png',
+    icon: '/favicon-64.png',
     label: 'Identrail',
     className: 'is-buying'
   },
@@ -871,7 +871,7 @@ const BLOG_ARTICLE_TREATMENTS = {
 function getBlogArticleTreatment(category: string) {
   return (
     BLOG_ARTICLE_TREATMENTS[category as keyof typeof BLOG_ARTICLE_TREATMENTS] ?? {
-      icon: '/identrail-logo.png',
+      icon: '/favicon-64.png',
       label: 'Identrail',
       className: 'is-default'
     }
@@ -2686,7 +2686,7 @@ function PricingPage() {
               <li>SAML SSO, alerts, and workflow integrations</li>
               <li>14-day hosted trial with guided setup</li>
             </ul>
-            <Link to="/enterprise" className="idt-btn idt-btn-primary">
+            <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
               Start Pro Trial
             </Link>
           </article>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1466,7 +1466,7 @@ function RoiCalculator() {
 
 function DeploymentPathBanner() {
   return (
-    <section className="idt-section idt-shell idt-deployment-bridge" aria-label="Adoption paths">
+    <section className="idt-section idt-deployment-bridge" aria-label="Adoption paths">
       <div className="idt-deployment-panel">
         <p className="idt-eyebrow">Adoption Paths</p>
         <h2>Choose the deployment model that fits your operating constraints.</h2>
@@ -1545,7 +1545,7 @@ function DeploymentPathBanner() {
 
 function ProductTourSection() {
   return (
-    <section className="idt-section idt-shell idt-product-tour" aria-labelledby="product-tour-title">
+    <section className="idt-section idt-product-tour" aria-labelledby="product-tour-title">
       <div className="idt-product-tour-copy">
         <p className="idt-eyebrow">Product tour</p>
         <h2 id="product-tour-title">From connector setup to evidence-ready remediation.</h2>
@@ -1780,59 +1780,61 @@ function HomePage() {
 
       <TrustProofStrip />
 
-      <ProblemFramingSection />
+      <div className="idt-home-after-stack">
+        <ProblemFramingSection />
 
-      <CommandCenterSection />
+        <CommandCenterSection />
 
-      <ProductTourSection />
+        <ProductTourSection />
 
-      <HowItWorksSection />
+        <HowItWorksSection />
 
-      <DeploymentPathBanner />
+        <DeploymentPathBanner />
 
-      <section className="idt-section idt-shell">
-        <SectionTitle
-          eyebrow="Comparison"
-          title="Why teams choose Identrail over closed black-box workflows"
-          body="Compare on explainability, rollout safety, and day-two operability."
-        />
-        <div className="idt-table-wrap idt-home-compare">
-          <table className="idt-compare-table">
-            <thead>
-              <tr>
-                <th scope="col">Category</th>
-                <th scope="col">Identrail</th>
-                <th scope="col">Typical closed alternatives</th>
-              </tr>
-            </thead>
-            <tbody>
-              {DIFFERENTIATION_ROWS.map((row) => (
-                <tr key={row.area}>
-                  <th scope="row">{row.area}</th>
-                  <td>{row.identrail}</td>
-                  <td>{row.closed}</td>
+        <section className="idt-section idt-home-compare-section">
+          <SectionTitle
+            eyebrow="Comparison"
+            title="Why teams choose Identrail over closed black-box workflows"
+            body="Compare on explainability, rollout safety, and day-two operability."
+          />
+          <div className="idt-table-wrap idt-home-compare">
+            <table className="idt-compare-table">
+              <thead>
+                <tr>
+                  <th scope="col">Category</th>
+                  <th scope="col">Identrail</th>
+                  <th scope="col">Typical closed alternatives</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </section>
+              </thead>
+              <tbody>
+                {DIFFERENTIATION_ROWS.map((row) => (
+                  <tr key={row.area}>
+                    <th scope="row">{row.area}</th>
+                    <td>{row.identrail}</td>
+                    <td>{row.closed}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
 
-      <section className="idt-section idt-shell idt-final-cta" id="risk-scan-form">
-        <SectionTitle
-          eyebrow="Ready to evaluate"
-          title="Map your first production trust path in minutes"
-          body="Start with a read-only scan, review evidence, then decide whether to self-host, use hosted SaaS, or move to enterprise deployment."
-        />
-        <div className="idt-inline-actions">
-          <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-            Start Free Risk Scan
-          </Link>
-          <Link to="/enterprise" className="idt-final-cta-link">
-            Need enterprise procurement? Contact Sales →
-          </Link>
-        </div>
-      </section>
+        <section className="idt-section idt-final-cta idt-home-final-cta" id="risk-scan-form">
+          <SectionTitle
+            eyebrow="Ready to evaluate"
+            title="Map your first production trust path in minutes"
+            body="Start with a read-only scan, review evidence, then decide whether to self-host, use hosted SaaS, or move to enterprise deployment."
+          />
+          <div className="idt-inline-actions">
+            <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
+              Start Free Risk Scan
+            </Link>
+            <Link to="/enterprise" className="idt-final-cta-link">
+              Need enterprise procurement? Contact Sales →
+            </Link>
+          </div>
+        </section>
+      </div>
     </>
   );
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1826,7 +1826,7 @@ function HomePage() {
           </div>
         </section>
 
-        <section className="idt-section idt-final-cta idt-home-final-cta" id="risk-scan-form">
+        <section className="idt-section idt-final-cta idt-home-final-cta" id="enterprise-procurement">
           <SectionTitle
             eyebrow="Ready to evaluate"
             title="Map your first production trust path in minutes"

--- a/web/src/components/home/CommandCenterSection.tsx
+++ b/web/src/components/home/CommandCenterSection.tsx
@@ -64,7 +64,7 @@ export function CommandCenterSection() {
 
   return (
     <section className="idt-section idt-command-center" aria-labelledby="command-center-title">
-      <div className="idt-shell idt-command-center-grid">
+      <div className="idt-command-center-grid">
         <div className="idt-command-copy">
           <p className="idt-eyebrow">Trust operations layer</p>
           <h2 id="command-center-title">A premium control room for machine identity risk.</h2>

--- a/web/src/components/home/HowItWorksSection.tsx
+++ b/web/src/components/home/HowItWorksSection.tsx
@@ -27,7 +27,7 @@ const WORKFLOW_STEPS = [
 
 export function HowItWorksSection() {
   return (
-    <section className="idt-section idt-shell idt-workflow-section" aria-labelledby="workflow-title">
+    <section className="idt-section idt-workflow-section" aria-labelledby="workflow-title">
       <div className="idt-section-title">
         <p className="idt-eyebrow">Operational Workflow</p>
         <h2 id="workflow-title">From read-only discovery to safe enforcement</h2>

--- a/web/src/components/home/ProblemFramingSection.tsx
+++ b/web/src/components/home/ProblemFramingSection.tsx
@@ -36,7 +36,7 @@ const storyStages = [
 
 export function ProblemFramingSection() {
   return (
-    <section className="idt-section idt-shell idt-problem-frame" aria-labelledby="problem-frame-title">
+    <section className="idt-section idt-problem-frame" aria-labelledby="problem-frame-title">
       <div className="idt-problem-frame-grid">
         <div className="idt-problem-copy">
           <p className="idt-eyebrow">Why teams miss machine identity risk</p>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -16823,3 +16823,407 @@ html[data-theme='light'] .idt-docs-page .idt-empty-state {
     min-height: 440px;
   }
 }
+
+/* Detail polish for the marketing pass. */
+.idt-home-after-stack .idt-problem-frame .idt-problem-map-core,
+html[data-theme='light'] .idt-home-after-stack .idt-problem-frame .idt-problem-map-core {
+  justify-content: start;
+  align-content: center;
+  padding-inline: clamp(2.4rem, 5vw, 5.6rem) clamp(1.5rem, 3vw, 3rem);
+}
+
+.idt-home-after-stack .idt-problem-frame .idt-problem-map-core strong,
+html[data-theme='light'] .idt-home-after-stack .idt-problem-frame .idt-problem-map-core strong {
+  max-width: 13ch;
+}
+
+.idt-hero-admin-window,
+.idt-hero-login-card {
+  font-family: var(--idt-nav-font);
+}
+
+.idt-admin-profile-row strong,
+.idt-admin-field-grid span,
+.idt-admin-path-strip span,
+.idt-admin-activity li strong,
+.idt-mobile-live-row strong,
+.idt-mobile-header h3,
+.idt-mobile-summary strong,
+.idt-mini-path li strong,
+.idt-path-input {
+  font-family: 'Barlow Semi Condensed', 'Arial Narrow', Arial, sans-serif;
+  font-weight: 800;
+  letter-spacing: 0;
+}
+
+.idt-admin-profile-row strong,
+.idt-mobile-header h3 {
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.idt-admin-field-grid > div,
+.idt-admin-activity li,
+.idt-admin-path-strip span,
+.idt-mobile-summary div,
+.idt-path-input,
+.idt-mini-path li {
+  border-radius: 8px;
+}
+
+.idt-product-page .idt-product-hero-graph {
+  background:
+    linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+    linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+    radial-gradient(circle at 45% 52%, rgba(255, 255, 255, 0.095), transparent 16rem),
+    #050505;
+  background-size: 72px 72px, 72px 72px, auto, auto;
+}
+
+.idt-product-page .idt-product-hero-graph .idt-product-graph-edge.is-safe {
+  stroke-width: 3.2;
+}
+
+.idt-product-page .idt-product-hero-graph .idt-product-graph-edge.is-risk {
+  stroke-width: 3.8;
+}
+
+.idt-product-page .idt-product-hero-graph .idt-product-graph-edge.is-proof {
+  stroke-width: 2.5;
+}
+
+.idt-product-page .idt-graph-pill {
+  min-width: 178px;
+}
+
+.idt-product-page .idt-graph-pill.is-k8s {
+  top: 49%;
+  left: 40%;
+}
+
+.idt-product-page .idt-graph-pill.is-data {
+  top: 64%;
+  left: 56%;
+}
+
+.idt-product-page .idt-graph-pill.is-aws {
+  top: 18%;
+  right: 5%;
+}
+
+.idt-demo-edge-arrow {
+  stroke-width: 1.35;
+}
+
+.idt-demo-edges g.is-connected .idt-demo-edge-arrow {
+  stroke-width: 1.7;
+}
+
+.idt-product-graph-band .idt-demo-graph,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-demo-graph {
+  background:
+    linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+    linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+    radial-gradient(circle at 43% 50%, rgba(255, 255, 255, 0.105), transparent 17rem),
+    #050505;
+  background-size: 80px 80px, 80px 80px, auto, auto;
+}
+
+.idt-product-graph-band .idt-demo-node {
+  min-width: 158px;
+  padding: 0.58rem 0.78rem;
+  font-size: 0.72rem;
+}
+
+.idt-product-graph-band .idt-demo-node small {
+  font-size: 0.64rem;
+}
+
+.idt-product-graph-band .idt-demo-edge-arrow {
+  stroke-width: 2.2;
+  opacity: 1;
+}
+
+.idt-product-graph-band .idt-demo-edges g.is-connected .idt-demo-edge-arrow {
+  stroke-width: 2.8;
+}
+
+.idt-product-graph-band .idt-demo-edge-flow {
+  stroke-width: 1.8;
+  opacity: 0.45;
+}
+
+.idt-product-graph-band .idt-demo-edges g.is-connected .idt-demo-edge-flow {
+  stroke-width: 2.1;
+  opacity: 0.68;
+}
+
+.idt-docs-search-preview,
+html[data-theme='light'] .idt-docs-search-preview {
+  max-width: 680px;
+  padding: 1.15rem 1.25rem;
+}
+
+.idt-docs-search-preview span,
+html[data-theme='light'] .idt-docs-search-preview span {
+  font-size: 0.78rem;
+}
+
+.idt-docs-search-preview strong,
+html[data-theme='light'] .idt-docs-search-preview strong {
+  font-size: 1.18rem;
+}
+
+.idt-docs-preview-shell,
+html[data-theme='light'] .idt-docs-preview-shell {
+  grid-template-columns: 170px 1fr;
+  min-height: 340px;
+}
+
+.idt-docs-preview-shell nav button,
+html[data-theme='light'] .idt-docs-preview-shell nav button {
+  width: 100%;
+  border: 0;
+  border-radius: 7px;
+  padding: 0.58rem 0.65rem;
+  background: transparent;
+  color: #a1a1aa;
+  font-family: var(--idt-nav-font);
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-align: left;
+  cursor: pointer;
+}
+
+.idt-docs-preview-shell nav button:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+
+.idt-docs-preview-shell nav button.is-active,
+html[data-theme='light'] .idt-docs-preview-shell nav button.is-active {
+  background: #ffffff;
+  color: #000000;
+}
+
+.idt-docs-preview-shell code,
+html[data-theme='light'] .idt-docs-preview-shell code {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  align-items: center;
+  background: #080f1d;
+  color: #e5e7eb;
+  white-space: normal;
+  text-overflow: clip;
+}
+
+.idt-docs-preview-shell code span.is-command {
+  color: #7dd3fc;
+}
+
+.idt-docs-preview-shell code span.is-subcommand {
+  color: #c4b5fd;
+}
+
+.idt-docs-preview-shell code span.is-flag {
+  color: #86efac;
+}
+
+.idt-docs-preview-shell code span.is-value {
+  color: #fbbf24;
+}
+
+.idt-calendly-card .idt-inline-actions {
+  margin-top: clamp(2rem, 4vw, 3.2rem);
+}
+
+.idt-pricing-hero-visual {
+  align-content: stretch;
+}
+
+.idt-pricing-hero-matrix {
+  min-height: 240px;
+}
+
+.idt-pricing-hero-plans {
+  display: none;
+}
+
+.idt-pricing-page .idt-pricing-grid {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.18fr) minmax(0, 1fr);
+}
+
+.idt-pricing-page .idt-pricing-card.is-featured .idt-btn-primary,
+html[data-theme='light'] .idt-pricing-page .idt-pricing-card.is-featured .idt-btn-primary {
+  border-color: #ffffff;
+  background: #ffffff;
+  color: #000000;
+}
+
+.idt-about-page .idt-about-hero-visual,
+html[data-theme='light'] .idt-about-page .idt-about-hero-visual {
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 0.72fr);
+}
+
+.idt-about-page .idt-about-orbit,
+html[data-theme='light'] .idt-about-page .idt-about-orbit {
+  border: 1px solid #242424;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.08), transparent 8rem),
+    radial-gradient(circle at 50% 50%, transparent 0 4.8rem, rgba(255, 255, 255, 0.11) 4.86rem 4.95rem, transparent 5rem 8.9rem, rgba(255, 255, 255, 0.1) 8.96rem 9.05rem, transparent 9.1rem),
+    #080808;
+  box-shadow: none;
+}
+
+.idt-about-page .idt-about-orbit span,
+html[data-theme='light'] .idt-about-page .idt-about-orbit span {
+  border-color: #303030;
+  border-radius: 8px;
+  background: #111111;
+  color: #ffffff;
+  box-shadow: none;
+}
+
+.idt-about-page .idt-about-orbit .is-core,
+html[data-theme='light'] .idt-about-page .idt-about-orbit .is-core {
+  border-radius: 999px;
+  background: #ffffff;
+  color: #000000;
+}
+
+.idt-about-page .idt-about-timeline li,
+html[data-theme='light'] .idt-about-page .idt-about-timeline li {
+  border-color: #242424;
+  background: #080808;
+  box-shadow: none;
+}
+
+.idt-about-page .idt-about-timeline strong,
+html[data-theme='light'] .idt-about-page .idt-about-timeline strong {
+  color: #ffffff;
+}
+
+.idt-about-page .idt-about-timeline span,
+html[data-theme='light'] .idt-about-page .idt-about-timeline span {
+  color: #ffffff;
+}
+
+.idt-blog-page > .idt-page-hero-rich,
+html[data-theme='light'] .idt-blog-page > .idt-page-hero-rich {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.idt-blog-page .idt-page-hero-copy,
+html[data-theme='light'] .idt-blog-page .idt-page-hero-copy {
+  max-width: min(1120px, 100%);
+}
+
+.idt-blog-page .idt-page-hero-rich h1,
+html[data-theme='light'] .idt-blog-page .idt-page-hero-rich h1 {
+  max-width: 20ch;
+}
+
+.idt-blog-page .idt-page-hero-copy > p,
+html[data-theme='light'] .idt-blog-page .idt-page-hero-copy > p {
+  max-width: 66ch;
+}
+
+.idt-blog-card {
+  --blog-accent: #ffffff;
+  position: relative;
+  isolation: isolate;
+}
+
+.idt-blog-card::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto;
+  height: 3px;
+  background: var(--blog-accent);
+}
+
+.idt-blog-card-head {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 2.2rem;
+}
+
+.idt-blog-card-logo {
+  display: grid;
+  width: 44px;
+  height: 44px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid #303030;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.idt-blog-card-logo img {
+  width: 26px;
+  height: 26px;
+  object-fit: contain;
+}
+
+.idt-blog-card .idt-chip-row {
+  justify-content: end;
+  margin: 0;
+}
+
+.idt-blog-card.is-identity {
+  --blog-accent: #38bdf8;
+}
+
+.idt-blog-card.is-aws {
+  --blog-accent: #ff9900;
+}
+
+.idt-blog-card.is-kubernetes {
+  --blog-accent: #326ce5;
+}
+
+.idt-blog-card.is-supply-chain {
+  --blog-accent: #ffffff;
+}
+
+.idt-blog-card.is-buying {
+  --blog-accent: #d4d4d8;
+}
+
+.idt-blog-card.is-compliance {
+  --blog-accent: #f59e0b;
+}
+
+.idt-blog-card.is-platform {
+  --blog-accent: #844fba;
+}
+
+.idt-blog-card.is-leadership {
+  --blog-accent: #e6522c;
+}
+
+@media (max-width: 820px) {
+  .idt-product-page .idt-graph-pill {
+    min-width: 132px;
+  }
+
+  .idt-docs-preview-shell,
+  html[data-theme='light'] .idt-docs-preview-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-docs-preview-shell nav,
+  html[data-theme='light'] .idt-docs-preview-shell nav {
+    border-right: 0;
+    border-bottom: 1px solid #242424;
+  }
+
+  .idt-pricing-page .idt-pricing-grid,
+  .idt-about-page .idt-about-hero-visual,
+  html[data-theme='light'] .idt-about-page .idt-about-hero-visual {
+    grid-template-columns: 1fr;
+  }
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15922,3 +15922,232 @@ html[data-theme='light'] .idt-home-after-stack .idt-home-final-cta .idt-final-ct
     display: grid;
   }
 }
+
+/* Homepage and product contrast polish follow-up. */
+.idt-hero-copy h1,
+html[data-theme='light'] .idt-hero-copy h1 {
+  max-width: 9.4ch;
+  color: #0f1f19;
+  font-family: 'Barlow Semi Condensed', 'Arial Narrow', Arial, sans-serif;
+  font-size: clamp(3.1rem, 5.1vw, 5.7rem);
+  font-weight: 800;
+  line-height: 0.96;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.idt-hero-copy h1 span,
+html[data-theme='light'] .idt-hero-copy h1 span {
+  color: #6d37dd;
+  font-family: inherit;
+}
+
+.idt-hero .idt-btn,
+html[data-theme='light'] .idt-hero .idt-btn {
+  border-radius: 8px;
+  font-family: var(--idt-nav-font);
+}
+
+.idt-home-after-stack .idt-command-surface,
+html[data-theme='light'] .idt-home-after-stack .idt-command-surface {
+  margin-top: clamp(1.6rem, 3vw, 3.4rem);
+}
+
+.idt-home-after-stack .idt-command-surface-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 1.5rem;
+}
+
+.idt-home-after-stack .idt-workflow-track li,
+html[data-theme='light'] .idt-home-after-stack .idt-workflow-track li {
+  border: 1px solid #242424;
+  background: #070707;
+  color: #ffffff;
+  box-shadow: none;
+}
+
+.idt-home-after-stack .idt-workflow-track li:nth-child(even),
+html[data-theme='light'] .idt-home-after-stack .idt-workflow-track li:nth-child(even) {
+  background: #0d0d0d;
+}
+
+.idt-home-after-stack .idt-workflow-track h3,
+html[data-theme='light'] .idt-home-after-stack .idt-workflow-track h3 {
+  color: #ffffff;
+}
+
+.idt-home-after-stack .idt-workflow-track li > p:not(.idt-workflow-output),
+html[data-theme='light'] .idt-home-after-stack .idt-workflow-track li > p:not(.idt-workflow-output) {
+  color: #d4d4d8;
+}
+
+.idt-home-after-stack .idt-workflow-stage,
+html[data-theme='light'] .idt-home-after-stack .idt-workflow-stage {
+  color: #a1a1aa;
+}
+
+.idt-home-after-stack .idt-workflow-output,
+html[data-theme='light'] .idt-home-after-stack .idt-workflow-output {
+  border: 1px solid #3f3f46;
+  border-left: 2px solid #ffffff;
+  border-radius: 8px;
+  background: #111111;
+  color: #ffffff;
+}
+
+.idt-product-graph-band .idt-demo-surface,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-demo-surface {
+  gap: 1px;
+  padding: 1px;
+  border: 1px solid #262626;
+  border-radius: 8px;
+  background: #262626;
+  box-shadow: none;
+}
+
+.idt-product-graph-band .idt-demo-toolbar,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-demo-toolbar {
+  border: 0;
+  border-radius: 7px 7px 0 0;
+  background: #ffffff;
+  color: #09090b;
+  box-shadow: none;
+}
+
+.idt-product-graph-band .idt-demo-toolbar p,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-demo-toolbar p,
+.idt-product-graph-band .idt-finding-label,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-finding-label {
+  color: #52525b;
+}
+
+.idt-product-graph-band .idt-demo-scenario-row button,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-demo-scenario-row button {
+  border-color: #d4d4d8;
+  background: #ffffff;
+  color: #18181b;
+  box-shadow: none;
+}
+
+.idt-product-graph-band .idt-demo-scenario-row button.is-active,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-demo-scenario-row button.is-active {
+  border-color: #09090b;
+  background: #09090b;
+  color: #ffffff;
+}
+
+.idt-product-graph-band .idt-demo-view-toggle {
+  background: #000000;
+  padding: 0.9rem 0;
+}
+
+.idt-product-graph-band .idt-demo-view-toggle button,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-demo-view-toggle button {
+  border-color: #303030;
+  background: #050505;
+  color: #a1a1aa;
+}
+
+.idt-product-graph-band .idt-demo-view-toggle button.is-active,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-demo-view-toggle button[aria-selected='true'] {
+  border-color: #ffffff;
+  background: #ffffff;
+  color: #000000;
+}
+
+.idt-product-graph-band .idt-demo-graph,
+.idt-product-graph-band .idt-demo-list-view,
+.idt-product-graph-band .idt-demo-sidebar,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-demo-graph,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-demo-list-view,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-demo-sidebar {
+  border: 0;
+  border-radius: 0;
+  background: #050505;
+  color: #ffffff;
+  box-shadow: none;
+}
+
+.idt-product-graph-band .idt-demo-graph {
+  border-right: 1px solid #262626;
+}
+
+.idt-product-graph-band .idt-demo-node,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-demo-node {
+  border-color: #d4d4d8;
+  background: #ffffff;
+  color: #0f172a;
+  box-shadow: none;
+}
+
+.idt-product-graph-band .idt-demo-node small,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-demo-node small {
+  color: #64748b;
+}
+
+.idt-product-graph-band .idt-demo-node.is-active,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-demo-node.is-active {
+  border-color: #ffffff;
+  background: #ffffff;
+  color: #000000;
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.16);
+}
+
+.idt-product-graph-band .idt-demo-sidebar h3,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-demo-sidebar h3 {
+  color: #ffffff;
+}
+
+.idt-product-graph-band .idt-demo-sidebar p,
+.idt-product-graph-band .idt-demo-sidebar li,
+.idt-product-graph-band .idt-demo-follow-up,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-demo-sidebar p,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-demo-sidebar li,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-demo-follow-up {
+  color: #d4d4d8;
+}
+
+.idt-product-graph-band .idt-demo-evidence,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-demo-evidence {
+  border: 1px solid #3f3f46;
+  border-radius: 8px;
+  background: #111111;
+  color: #ffffff;
+}
+
+.idt-product-graph-band .idt-demo-evidence strong,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-demo-evidence strong {
+  color: #ffffff;
+}
+
+.idt-product-graph-band .idt-inline-link,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-inline-link {
+  color: #ffffff;
+}
+
+@media (max-width: 1180px) {
+  .idt-home-after-stack .idt-command-surface,
+  html[data-theme='light'] .idt-home-after-stack .idt-command-surface {
+    margin-top: 0;
+  }
+}
+
+@media (max-width: 820px) {
+  .idt-hero-copy h1,
+  html[data-theme='light'] .idt-hero-copy h1 {
+    max-width: 9.6ch;
+    font-size: clamp(2.65rem, 12vw, 3.35rem);
+    line-height: 1;
+  }
+
+  .idt-home-after-stack .idt-command-surface-head {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-product-graph-band .idt-demo-graph {
+    border-right: 0;
+    border-bottom: 1px solid #262626;
+  }
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -16465,7 +16465,7 @@ html[data-theme='light'] .idt-marketing-page .idt-page-hero-copy > p {
 
 .idt-blog-page > .idt-page-hero-rich,
 html[data-theme='light'] .idt-blog-page > .idt-page-hero-rich {
-  grid-template-columns: minmax(520px, 1.05fr) minmax(500px, 0.95fr);
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
 }
 
 .idt-blog-page .idt-page-hero-rich h1,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15924,10 +15924,9 @@ html[data-theme='light'] .idt-home-after-stack .idt-home-final-cta .idt-final-ct
 }
 
 /* Homepage and product contrast polish follow-up. */
-.idt-hero-copy h1,
-html[data-theme='light'] .idt-hero-copy h1 {
+.idt-hero-copy h1 {
   max-width: 9.4ch;
-  color: #0f1f19;
+  color: var(--idt-premium-text);
   font-family: 'Barlow Semi Condensed', 'Arial Narrow', Arial, sans-serif;
   font-size: clamp(3.1rem, 5.1vw, 5.7rem);
   font-weight: 800;
@@ -15936,7 +15935,15 @@ html[data-theme='light'] .idt-hero-copy h1 {
   text-transform: uppercase;
 }
 
-.idt-hero-copy h1 span,
+.idt-hero-copy h1 span {
+  color: var(--idt-premium-mint);
+  font-family: inherit;
+}
+
+html[data-theme='light'] .idt-hero-copy h1 {
+  color: #0f1f19;
+}
+
 html[data-theme='light'] .idt-hero-copy h1 span {
   color: #6d37dd;
   font-family: inherit;
@@ -16149,5 +16156,670 @@ html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-inline-l
   .idt-product-graph-band .idt-demo-graph {
     border-right: 0;
     border-bottom: 1px solid #262626;
+  }
+}
+
+/* Cross-page finish pass: consistent black overscroll, footer, graphs, and dark marketing pages. */
+html,
+html[data-theme='light'],
+body,
+html[data-theme='light'] body,
+#root,
+.idt-site {
+  background: #000000;
+}
+
+html,
+body {
+  overscroll-behavior-y: none;
+}
+
+.idt-site > main {
+  background: #ffffff;
+}
+
+.idt-footer,
+html[data-theme='light'] .idt-footer {
+  margin-top: 0;
+  background: #000000;
+}
+
+.idt-footer-bar,
+html[data-theme='light'] .idt-footer-bar {
+  border-top: 1px solid #242424;
+  background: #000000;
+  color: #ffffff;
+}
+
+.idt-footer-bar-row {
+  min-height: 78px;
+}
+
+.idt-footer-meta small,
+.idt-footer-trust-links a,
+html[data-theme='light'] .idt-footer-meta small,
+html[data-theme='light'] .idt-footer-trust-links a {
+  color: #a1a1aa;
+}
+
+.idt-social-link,
+html[data-theme='light'] .idt-social-link {
+  border-color: #303030;
+  background: #080808;
+  color: #ffffff;
+}
+
+.idt-social-link:hover,
+.idt-social-link:focus-visible {
+  border-color: #ffffff;
+  background: #ffffff;
+  color: #000000;
+}
+
+.idt-home-after-stack .idt-home-final-cta,
+html[data-theme='light'] .idt-home-after-stack .idt-home-final-cta {
+  border-bottom: 0;
+  padding-bottom: clamp(5rem, 8vw, 7rem);
+}
+
+.idt-home-after-stack .idt-home-final-cta .idt-btn-primary,
+html[data-theme='light'] .idt-home-after-stack .idt-home-final-cta .idt-btn-primary {
+  min-height: 52px;
+  border-color: #ffffff;
+  background: #ffffff;
+  color: #000000;
+  font-weight: 850;
+}
+
+.idt-product-page .idt-product-hero-body {
+  grid-template-columns: 1fr;
+}
+
+.idt-product-page .idt-product-hero-sidebar {
+  display: none;
+}
+
+.idt-product-page .idt-product-hero-graph {
+  isolation: isolate;
+  min-height: 516px;
+  background:
+    linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+    linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+    radial-gradient(circle at 38% 48%, rgba(255, 255, 255, 0.07), transparent 15rem),
+    #050505;
+  background-size: 72px 72px, 72px 72px, auto, auto;
+}
+
+.idt-product-graph-title {
+  position: absolute;
+  top: 1.15rem;
+  left: 1.15rem;
+  z-index: 4;
+  display: grid;
+  gap: 0.2rem;
+  max-width: 18rem;
+}
+
+.idt-product-graph-title span {
+  color: #a1a1aa;
+  font-size: 0.68rem;
+  font-weight: 850;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.idt-product-graph-title strong {
+  color: #ffffff;
+  font-family: 'Barlow Semi Condensed', 'Arial Narrow', Arial, sans-serif;
+  font-size: 1.5rem;
+  font-weight: 800;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.idt-product-hero-graph svg {
+  z-index: 1;
+}
+
+#idt-product-hero-arrow path {
+  fill: #ffffff;
+}
+
+#idt-product-hero-arrow-muted path {
+  fill: #71717a;
+}
+
+.idt-product-page .idt-product-hero-graph .idt-product-graph-edge {
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+}
+
+.idt-product-page .idt-product-hero-graph .idt-product-graph-edge.is-muted {
+  marker-end: url('#idt-product-hero-arrow-muted');
+  stroke: #71717a;
+  stroke-width: 2;
+  opacity: 0.72;
+}
+
+.idt-product-page .idt-product-hero-graph .idt-product-graph-edge.is-safe {
+  marker-end: url('#idt-product-hero-arrow');
+  stroke: #d4d4d8;
+  stroke-width: 2.8;
+  opacity: 0.92;
+}
+
+.idt-product-page .idt-product-hero-graph .idt-product-graph-edge.is-risk {
+  marker-end: url('#idt-product-hero-arrow');
+  stroke: #ffffff;
+  stroke-width: 3.4;
+  filter: none;
+}
+
+.idt-product-page .idt-product-hero-graph .idt-product-graph-edge.is-proof {
+  marker-end: url('#idt-product-hero-arrow-muted');
+  stroke: #a1a1aa;
+  stroke-width: 2.2;
+  opacity: 0.82;
+}
+
+.idt-product-page .idt-graph-pill,
+.idt-product-page .idt-product-evidence-card,
+.idt-product-page .idt-product-hero-queue {
+  z-index: 3;
+}
+
+.idt-product-page .idt-graph-pill.is-github {
+  top: 23%;
+  left: 7%;
+}
+
+.idt-product-page .idt-graph-pill.is-aws {
+  top: 18%;
+  right: 6%;
+}
+
+.idt-product-page .idt-graph-pill.is-k8s {
+  top: 48%;
+  left: 39%;
+}
+
+.idt-product-page .idt-graph-pill.is-data {
+  top: 68%;
+  left: 58%;
+  right: auto;
+  bottom: auto;
+}
+
+.idt-demo-edge-base,
+.idt-demo-edge-flow,
+.idt-demo-edge-arrow {
+  fill: none;
+  stroke-linecap: round;
+  vector-effect: non-scaling-stroke;
+}
+
+.idt-demo-edge-arrow {
+  stroke: #d4d4d8;
+  stroke-width: 0.92;
+  opacity: 0.76;
+}
+
+.idt-demo-edges g.is-connected .idt-demo-edge-arrow {
+  stroke: #ffffff;
+  stroke-width: 1.12;
+  opacity: 1;
+}
+
+.idt-demo-edge-flow {
+  stroke-dasharray: 18 120;
+  opacity: 0.36;
+}
+
+.idt-demo-edges g.is-connected .idt-demo-edge-flow {
+  stroke-dasharray: 22 116;
+  opacity: 0.66;
+}
+
+.idt-product-graph-band .idt-demo-graph,
+html[data-theme='light'] .idt-product-page .idt-product-graph-band .idt-demo-graph {
+  background:
+    linear-gradient(90deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px),
+    linear-gradient(rgba(255, 255, 255, 0.035) 1px, transparent 1px),
+    #050505;
+  background-size: 80px 80px, 80px 80px, auto;
+}
+
+.idt-product-graph-band .idt-demo-edge-base {
+  stroke-width: 1.18;
+  opacity: 0.58;
+}
+
+.idt-product-graph-band .idt-demo-edge-arrow {
+  stroke-width: 1.38;
+  opacity: 0.9;
+}
+
+.idt-product-graph-band .idt-demo-edges g.is-connected .idt-demo-edge-arrow {
+  stroke-width: 1.72;
+}
+
+.idt-product-graph-band .idt-demo-edge-flow {
+  stroke-width: 1.24;
+  stroke-dasharray: 26 128;
+  opacity: 0.38;
+}
+
+.idt-product-graph-band .idt-demo-edges g.is-connected .idt-demo-edge-flow {
+  stroke-width: 1.42;
+  stroke-dasharray: 30 124;
+  opacity: 0.58;
+}
+
+.idt-marketing-page {
+  min-height: 100%;
+  background: #000000;
+  color: #ffffff;
+}
+
+.idt-marketing-page > .idt-page-hero-rich,
+html[data-theme='light'] .idt-marketing-page > .idt-page-hero-rich {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  grid-template-columns: minmax(380px, 0.9fr) minmax(520px, 1.1fr);
+  padding: clamp(4.25rem, 7vw, 6.2rem) clamp(1.25rem, 5vw, 6rem);
+  border-bottom: 1px solid #202020;
+  background: #000000;
+  color: #ffffff;
+}
+
+.idt-marketing-page > .idt-page-hero-rich::before,
+.idt-marketing-page > .idt-page-hero-rich::after,
+html[data-theme='light'] .idt-marketing-page > .idt-page-hero-rich::before,
+html[data-theme='light'] .idt-marketing-page > .idt-page-hero-rich::after {
+  display: none;
+}
+
+.idt-marketing-page .idt-page-hero-rich .idt-eyebrow,
+html[data-theme='light'] .idt-marketing-page .idt-page-hero-rich .idt-eyebrow {
+  color: #ffffff;
+}
+
+.idt-marketing-page .idt-page-hero-rich h1,
+html[data-theme='light'] .idt-marketing-page .idt-page-hero-rich h1 {
+  max-width: 14ch;
+  color: #ffffff;
+  font-family: 'Barlow Semi Condensed', 'Arial Narrow', Arial, sans-serif;
+  font-size: clamp(3rem, 4.7vw, 4.75rem);
+  font-weight: 800;
+  line-height: 0.97;
+  text-transform: uppercase;
+}
+
+.idt-marketing-page .idt-page-hero-copy > p,
+html[data-theme='light'] .idt-marketing-page .idt-page-hero-copy > p {
+  color: #a1a1aa;
+}
+
+.idt-blog-page > .idt-page-hero-rich,
+html[data-theme='light'] .idt-blog-page > .idt-page-hero-rich {
+  grid-template-columns: minmax(520px, 1.05fr) minmax(500px, 0.95fr);
+}
+
+.idt-blog-page .idt-page-hero-rich h1,
+html[data-theme='light'] .idt-blog-page .idt-page-hero-rich h1 {
+  max-width: 17ch;
+  font-size: clamp(3rem, 4.3vw, 4.55rem);
+}
+
+.idt-marketing-page .idt-page-hero-rich .idt-btn-primary,
+html[data-theme='light'] .idt-marketing-page .idt-page-hero-rich .idt-btn-primary {
+  border-color: #ffffff;
+  background: #ffffff;
+  color: #000000;
+  box-shadow: none;
+}
+
+.idt-marketing-page .idt-page-hero-rich .idt-btn-dark,
+html[data-theme='light'] .idt-marketing-page .idt-page-hero-rich .idt-btn-dark {
+  border-color: #303030;
+  background: #050505;
+  color: #ffffff;
+  box-shadow: none;
+}
+
+.idt-marketing-page > .idt-section.idt-shell,
+html[data-theme='light'] .idt-marketing-page > .idt-section.idt-shell {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  padding: clamp(4rem, 7vw, 6rem) clamp(1.25rem, 5vw, 6rem);
+  border-bottom: 1px solid #202020;
+  background: #000000;
+  color: #ffffff;
+}
+
+.idt-marketing-page .idt-card-grid,
+.idt-marketing-page .idt-pricing-grid {
+  gap: 1px;
+  background: #242424;
+}
+
+.idt-marketing-page .idt-card,
+.idt-marketing-page .idt-pricing-card,
+html[data-theme='light'] .idt-marketing-page .idt-card,
+html[data-theme='light'] .idt-marketing-page .idt-pricing-card {
+  border: 0;
+  border-radius: 0;
+  background: #080808;
+  color: #ffffff;
+  box-shadow: none;
+}
+
+.idt-marketing-page .idt-card h2,
+.idt-marketing-page .idt-pricing-card h2,
+html[data-theme='light'] .idt-marketing-page .idt-card h2,
+html[data-theme='light'] .idt-marketing-page .idt-pricing-card h2 {
+  color: #ffffff;
+  font-family: 'Barlow Semi Condensed', 'Arial Narrow', Arial, sans-serif;
+  font-weight: 800;
+  letter-spacing: 0;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.idt-marketing-page .idt-card p,
+.idt-marketing-page .idt-card li,
+.idt-marketing-page .idt-pricing-card p,
+.idt-marketing-page .idt-pricing-card li,
+html[data-theme='light'] .idt-marketing-page .idt-card p,
+html[data-theme='light'] .idt-marketing-page .idt-card li,
+html[data-theme='light'] .idt-marketing-page .idt-pricing-card p,
+html[data-theme='light'] .idt-marketing-page .idt-pricing-card li {
+  color: #a1a1aa;
+}
+
+.idt-marketing-page .idt-btn-ghost,
+html[data-theme='light'] .idt-marketing-page .idt-btn-ghost {
+  border-color: #303030;
+  background: #050505;
+  color: #ffffff;
+  box-shadow: none;
+}
+
+.idt-marketing-page .idt-inline-link,
+html[data-theme='light'] .idt-marketing-page .idt-inline-link {
+  color: #ffffff;
+}
+
+.idt-pricing-page .idt-pricing-toggle,
+html[data-theme='light'] .idt-pricing-page .idt-pricing-toggle,
+.idt-docs-page .idt-search,
+html[data-theme='light'] .idt-docs-page .idt-search {
+  border: 1px solid #303030;
+  border-radius: 8px;
+  background: #080808;
+  color: #ffffff;
+  box-shadow: none;
+}
+
+.idt-pricing-page .idt-pricing-toggle button,
+html[data-theme='light'] .idt-pricing-page .idt-pricing-toggle button {
+  color: #a1a1aa;
+}
+
+.idt-pricing-page .idt-pricing-toggle button.is-active,
+html[data-theme='light'] .idt-pricing-page .idt-pricing-toggle button.is-active {
+  background: #ffffff;
+  color: #000000;
+}
+
+.idt-pricing-page .idt-pricing-note,
+html[data-theme='light'] .idt-pricing-page .idt-pricing-note {
+  color: #a1a1aa;
+}
+
+.idt-pricing-page .idt-pricing-card.is-featured,
+html[data-theme='light'] .idt-pricing-page .idt-pricing-card.is-featured {
+  background: #ffffff;
+  color: #000000;
+}
+
+.idt-pricing-page .idt-pricing-card.is-featured h2,
+.idt-pricing-page .idt-pricing-card.is-featured .idt-price,
+.idt-pricing-page .idt-pricing-card.is-featured p,
+.idt-pricing-page .idt-pricing-card.is-featured li,
+html[data-theme='light'] .idt-pricing-page .idt-pricing-card.is-featured h2,
+html[data-theme='light'] .idt-pricing-page .idt-pricing-card.is-featured .idt-price,
+html[data-theme='light'] .idt-pricing-page .idt-pricing-card.is-featured p,
+html[data-theme='light'] .idt-pricing-page .idt-pricing-card.is-featured li {
+  color: #000000;
+}
+
+.idt-pricing-page .idt-badge,
+html[data-theme='light'] .idt-pricing-page .idt-badge {
+  border-radius: 8px;
+  background: #000000;
+  color: #ffffff;
+}
+
+.idt-pricing-page .idt-table-wrap,
+html[data-theme='light'] .idt-pricing-page .idt-table-wrap {
+  border: 1px solid #242424;
+  border-radius: 0;
+  background: #242424;
+  box-shadow: none;
+}
+
+.idt-pricing-page .idt-compare-table,
+html[data-theme='light'] .idt-pricing-page .idt-compare-table {
+  border-collapse: separate;
+  border-spacing: 1px;
+  background: #242424;
+}
+
+.idt-pricing-page .idt-compare-table th,
+.idt-pricing-page .idt-compare-table td,
+html[data-theme='light'] .idt-pricing-page .idt-compare-table th,
+html[data-theme='light'] .idt-pricing-page .idt-compare-table td {
+  border: 0;
+  background: #080808;
+  color: #d4d4d8;
+}
+
+.idt-pricing-page .idt-compare-table thead th,
+html[data-theme='light'] .idt-pricing-page .idt-compare-table thead th {
+  background: #ffffff;
+  color: #000000;
+}
+
+.idt-pricing-hero-toggle,
+.idt-pricing-hero-plans div,
+.idt-pricing-hero-procurement,
+.idt-pricing-hero-matrix,
+.idt-docs-search-preview,
+.idt-docs-preview-shell,
+.idt-blog-hero-featured,
+.idt-blog-hero-stack article,
+.idt-blog-hero-radar,
+html[data-theme='light'] .idt-pricing-hero-toggle,
+html[data-theme='light'] .idt-pricing-hero-plans div,
+html[data-theme='light'] .idt-pricing-hero-procurement,
+html[data-theme='light'] .idt-pricing-hero-matrix,
+html[data-theme='light'] .idt-docs-search-preview,
+html[data-theme='light'] .idt-docs-preview-shell,
+html[data-theme='light'] .idt-blog-hero-featured,
+html[data-theme='light'] .idt-blog-hero-stack article,
+html[data-theme='light'] .idt-blog-hero-radar {
+  border-color: #242424;
+  background: #080808;
+  color: #ffffff;
+  box-shadow: none;
+}
+
+.idt-pricing-hero-toggle strong,
+html[data-theme='light'] .idt-pricing-hero-toggle strong,
+.idt-pricing-hero-plans .is-featured,
+html[data-theme='light'] .idt-pricing-hero-plans .is-featured {
+  background: #ffffff;
+  color: #000000;
+}
+
+.idt-pricing-hero-plans .is-featured {
+  transform: none;
+}
+
+.idt-pricing-hero-plans span,
+.idt-pricing-hero-plans p,
+.idt-pricing-hero-matrix > *,
+.idt-pricing-hero-procurement strong,
+.idt-docs-search-preview span,
+.idt-docs-preview-shell nav span,
+.idt-docs-preview-shell article p,
+.idt-docs-preview-shell li,
+.idt-blog-hero-featured span,
+.idt-blog-hero-featured p,
+.idt-blog-hero-stack span,
+.idt-blog-hero-stack p,
+.idt-blog-hero-radar span,
+html[data-theme='light'] .idt-pricing-hero-plans span,
+html[data-theme='light'] .idt-pricing-hero-plans p,
+html[data-theme='light'] .idt-pricing-hero-matrix > *,
+html[data-theme='light'] .idt-pricing-hero-procurement strong,
+html[data-theme='light'] .idt-docs-search-preview span,
+html[data-theme='light'] .idt-docs-preview-shell nav span,
+html[data-theme='light'] .idt-docs-preview-shell article p,
+html[data-theme='light'] .idt-docs-preview-shell li,
+html[data-theme='light'] .idt-blog-hero-featured span,
+html[data-theme='light'] .idt-blog-hero-featured p,
+html[data-theme='light'] .idt-blog-hero-stack span,
+html[data-theme='light'] .idt-blog-hero-stack p,
+html[data-theme='light'] .idt-blog-hero-radar span {
+  color: #a1a1aa;
+}
+
+.idt-pricing-hero-plans strong,
+.idt-docs-search-preview strong,
+.idt-docs-preview-shell h3,
+.idt-blog-hero-featured h3,
+.idt-blog-hero-stack strong,
+html[data-theme='light'] .idt-pricing-hero-plans strong,
+html[data-theme='light'] .idt-docs-search-preview strong,
+html[data-theme='light'] .idt-docs-preview-shell h3,
+html[data-theme='light'] .idt-blog-hero-featured h3,
+html[data-theme='light'] .idt-blog-hero-stack strong {
+  color: #ffffff;
+}
+
+.idt-pricing-hero-plans .is-featured strong,
+.idt-pricing-hero-plans .is-featured span,
+.idt-pricing-hero-plans .is-featured p,
+html[data-theme='light'] .idt-pricing-hero-plans .is-featured strong,
+html[data-theme='light'] .idt-pricing-hero-plans .is-featured span,
+html[data-theme='light'] .idt-pricing-hero-plans .is-featured p {
+  color: #000000;
+}
+
+.idt-pricing-hero-matrix span,
+html[data-theme='light'] .idt-pricing-hero-matrix span,
+.idt-docs-preview-shell nav,
+html[data-theme='light'] .idt-docs-preview-shell nav {
+  background: #000000;
+}
+
+.idt-pricing-hero-matrix b,
+html[data-theme='light'] .idt-pricing-hero-matrix b {
+  color: #ffffff;
+}
+
+.idt-pricing-hero-procurement span,
+.idt-blog-hero-radar strong,
+html[data-theme='light'] .idt-pricing-hero-procurement span,
+html[data-theme='light'] .idt-blog-hero-radar strong {
+  border: 1px solid #303030;
+  background: #ffffff;
+  color: #000000;
+}
+
+.idt-docs-preview-shell nav .is-active,
+html[data-theme='light'] .idt-docs-preview-shell nav .is-active {
+  background: #ffffff;
+  color: #000000;
+}
+
+.idt-docs-preview-shell code,
+html[data-theme='light'] .idt-docs-preview-shell code {
+  background: #ffffff;
+  color: #000000;
+}
+
+.idt-docs-page .idt-search {
+  display: grid;
+  gap: 0.45rem;
+  max-width: 620px;
+  padding: 1rem;
+}
+
+.idt-docs-page .idt-search input,
+html[data-theme='light'] .idt-docs-page .idt-search input {
+  border-color: #303030;
+  background: #000000;
+  color: #ffffff;
+}
+
+.idt-docs-page .idt-search input::placeholder {
+  color: #71717a;
+}
+
+.idt-docs-page .idt-empty-state,
+html[data-theme='light'] .idt-docs-page .idt-empty-state {
+  border: 1px solid #242424;
+}
+
+.idt-blog-hero-featured {
+  background:
+    linear-gradient(90deg, rgba(255, 255, 255, 0.05) 1px, transparent 1px),
+    linear-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px),
+    #080808;
+  background-size: 56px 56px, 56px 56px, auto;
+}
+
+@media (max-width: 1080px) {
+  .idt-marketing-page > .idt-page-hero-rich,
+  html[data-theme='light'] .idt-marketing-page > .idt-page-hero-rich {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 820px) {
+  .idt-footer-bar-row {
+    grid-template-columns: 1fr;
+    justify-items: start;
+  }
+
+  .idt-marketing-page > .idt-page-hero-rich,
+  .idt-marketing-page > .idt-section.idt-shell,
+  html[data-theme='light'] .idt-marketing-page > .idt-page-hero-rich,
+  html[data-theme='light'] .idt-marketing-page > .idt-section.idt-shell {
+    padding-inline: 1rem;
+  }
+
+  .idt-marketing-page .idt-page-hero-rich h1,
+  html[data-theme='light'] .idt-marketing-page .idt-page-hero-rich h1 {
+    max-width: 10.5ch;
+    font-size: clamp(2.65rem, 12vw, 3.45rem);
+  }
+
+  .idt-product-graph-title {
+    position: relative;
+    top: auto;
+    left: auto;
+    padding: 1rem;
+  }
+
+  .idt-product-page .idt-product-hero-graph {
+    min-height: 440px;
   }
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15113,7 +15113,7 @@ html[data-theme='light'] .idt-scan-form .idt-btn-ghost,
 
 /* Homepage lower story: full-bleed Vercel/SpaceX pass below the identity-stack strip. */
 .idt-home-after-stack {
-  overflow-x: hidden;
+  overflow-x: clip;
   background: #ffffff;
   color: #09090b;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15110,3 +15110,815 @@ html[data-theme='light'] .idt-scan-form .idt-btn-ghost,
     width: 100%;
   }
 }
+
+/* Homepage lower story: full-bleed Vercel/SpaceX pass below the identity-stack strip. */
+.idt-home-after-stack {
+  overflow-x: hidden;
+  background: #ffffff;
+  color: #09090b;
+}
+
+.idt-home-after-stack .idt-section {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  padding: clamp(4.8rem, 8vw, 7.2rem) clamp(1.1rem, 5vw, 6rem);
+}
+
+.idt-home-after-stack .idt-eyebrow,
+html[data-theme='light'] .idt-home-after-stack .idt-eyebrow {
+  color: currentColor;
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+}
+
+.idt-home-after-stack h2,
+.idt-home-after-stack .idt-section-title h2,
+.idt-home-after-stack .idt-problem-copy h2,
+.idt-home-after-stack .idt-command-copy h2,
+.idt-home-after-stack .idt-product-tour-copy h2,
+html[data-theme='light'] .idt-home-after-stack .idt-section-title h2,
+html[data-theme='light'] .idt-home-after-stack .idt-problem-copy h2,
+html[data-theme='light'] .idt-home-after-stack .idt-command-copy h2,
+html[data-theme='light'] .idt-home-after-stack .idt-product-tour-copy h2 {
+  max-width: 13.5ch;
+  margin: 0.55rem 0 0;
+  color: inherit;
+  font-family: 'Barlow Semi Condensed', 'Arial Narrow', Arial, sans-serif;
+  font-size: clamp(3rem, 6vw, 5rem);
+  font-weight: 800;
+  line-height: 0.98;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.idt-home-after-stack .idt-section-title,
+.idt-home-after-stack .idt-product-tour-copy {
+  max-width: 74rem;
+}
+
+.idt-home-after-stack .idt-section-title p,
+.idt-home-after-stack .idt-problem-copy > p,
+.idt-home-after-stack .idt-command-copy > p,
+.idt-home-after-stack .idt-product-tour-copy p:not(.idt-eyebrow),
+html[data-theme='light'] .idt-home-after-stack .idt-section-title p,
+html[data-theme='light'] .idt-home-after-stack .idt-problem-copy > p,
+html[data-theme='light'] .idt-home-after-stack .idt-command-copy > p,
+html[data-theme='light'] .idt-home-after-stack .idt-product-tour-copy p:not(.idt-eyebrow) {
+  max-width: 46rem;
+  margin-top: 1.1rem;
+  color: #52525b;
+  font-size: 1.05rem;
+  line-height: 1.72;
+}
+
+.idt-home-after-stack .idt-btn {
+  border-radius: 8px;
+  box-shadow: none;
+}
+
+.idt-home-after-stack .idt-btn-primary,
+html[data-theme='light'] .idt-home-after-stack .idt-btn-primary {
+  border-color: #ffffff;
+  background: #ffffff;
+  color: #000000;
+  box-shadow: none;
+}
+
+.idt-home-after-stack .idt-btn-ghost,
+html[data-theme='light'] .idt-home-after-stack .idt-btn-ghost {
+  border-color: #111111;
+  background: #ffffff;
+  color: #000000;
+  box-shadow: none;
+}
+
+.idt-home-after-stack .idt-inline-link,
+.idt-home-after-stack .idt-final-cta-link,
+html[data-theme='light'] .idt-home-after-stack .idt-inline-link,
+html[data-theme='light'] .idt-home-after-stack .idt-final-cta-link {
+  color: currentColor;
+}
+
+.idt-home-after-stack .idt-problem-frame,
+html[data-theme='light'] .idt-home-after-stack .idt-problem-frame {
+  border-top: 1px solid #1f1f1f;
+  border-bottom: 1px solid #1f1f1f;
+  background: #000000;
+  color: #ffffff;
+}
+
+.idt-home-after-stack .idt-problem-frame-grid {
+  display: grid;
+  grid-template-columns: minmax(300px, 0.48fr) minmax(0, 1.52fr);
+  gap: clamp(2rem, 5vw, 5rem);
+  align-items: center;
+}
+
+.idt-home-after-stack .idt-problem-copy > p,
+html[data-theme='light'] .idt-home-after-stack .idt-problem-copy > p {
+  color: #a1a1aa;
+}
+
+.idt-home-after-stack .idt-problem-path-visual {
+  min-height: 560px;
+  grid-template-columns: minmax(220px, 0.52fr) 88px minmax(320px, 1fr);
+  padding: 1px;
+  border: 1px solid #262626;
+  border-radius: 8px;
+  background: #050505;
+  box-shadow: none;
+}
+
+.idt-home-after-stack .idt-problem-path-visual::before {
+  display: none;
+}
+
+.idt-home-after-stack .idt-problem-source-stack {
+  gap: 1px;
+  align-self: stretch;
+  background: #262626;
+}
+
+.idt-home-after-stack .idt-problem-source-card,
+html[data-theme='light'] .idt-home-after-stack .idt-problem-source-card {
+  min-height: 0;
+  align-content: center;
+  border: 0;
+  border-radius: 0;
+  background: #0a0a0a;
+  box-shadow: none;
+  transform: none;
+}
+
+.idt-home-after-stack .idt-problem-source-icon {
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: none;
+}
+
+.idt-home-after-stack .idt-problem-source-card span:not(.idt-problem-source-icon),
+html[data-theme='light'] .idt-home-after-stack .idt-problem-source-card span:not(.idt-problem-source-icon) {
+  color: #ffffff;
+}
+
+.idt-home-after-stack .idt-problem-source-card small,
+html[data-theme='light'] .idt-home-after-stack .idt-problem-source-card small {
+  color: #a1a1aa;
+}
+
+.idt-home-after-stack .idt-problem-path-spine::before {
+  background: #3f3f46;
+  box-shadow: none;
+}
+
+.idt-home-after-stack .idt-problem-path-spine::after {
+  background: #ffffff;
+  box-shadow: 0 0 0 6px #111111;
+}
+
+.idt-home-after-stack .idt-problem-path-spine span {
+  background: #27272a;
+}
+
+.idt-home-after-stack .idt-problem-frame .idt-problem-map-core,
+html[data-theme='light'] .idt-home-after-stack .idt-problem-frame .idt-problem-map-core {
+  min-height: calc(560px - 2px);
+  border: 0;
+  border-left: 1px solid #262626;
+  border-radius: 0 7px 7px 0;
+  background: #ffffff;
+  color: #000000;
+  box-shadow: none;
+}
+
+.idt-home-after-stack .idt-problem-frame .idt-problem-map-core p,
+html[data-theme='light'] .idt-home-after-stack .idt-problem-frame .idt-problem-map-core p {
+  color: #52525b;
+}
+
+.idt-home-after-stack .idt-problem-frame .idt-problem-map-core strong,
+html[data-theme='light'] .idt-home-after-stack .idt-problem-frame .idt-problem-map-core strong {
+  max-width: 12ch;
+  color: #000000;
+  font-family: 'Barlow Semi Condensed', 'Arial Narrow', Arial, sans-serif;
+  font-size: clamp(2.3rem, 4vw, 3.7rem);
+  font-weight: 800;
+  line-height: 0.98;
+  text-transform: uppercase;
+}
+
+.idt-home-after-stack .idt-problem-frame .idt-problem-map-core div span,
+html[data-theme='light'] .idt-home-after-stack .idt-problem-frame .idt-problem-map-core div span {
+  border-color: #d4d4d8;
+  border-radius: 8px;
+  background: #f5f5f5;
+  color: #18181b;
+}
+
+.idt-home-after-stack .idt-problem-timeline {
+  gap: 1px;
+  margin-top: clamp(2rem, 4vw, 3.2rem);
+  background: #262626;
+}
+
+.idt-home-after-stack .idt-problem-timeline::before {
+  display: none;
+}
+
+.idt-home-after-stack .idt-problem-timeline article,
+html[data-theme='light'] .idt-home-after-stack .idt-problem-timeline article {
+  min-height: 260px;
+  border: 0;
+  border-radius: 0;
+  background: #050505;
+  box-shadow: none;
+}
+
+.idt-home-after-stack .idt-problem-timeline article > span {
+  border-radius: 8px;
+  background: #ffffff;
+  color: #000000;
+}
+
+.idt-home-after-stack .idt-problem-timeline article small {
+  color: #a1a1aa;
+}
+
+.idt-home-after-stack .idt-problem-timeline article h3 {
+  color: #ffffff;
+  font-size: 1.2rem;
+}
+
+.idt-home-after-stack .idt-problem-timeline article p {
+  color: #a1a1aa;
+}
+
+.idt-home-after-stack .idt-command-center,
+html[data-theme='light'] .idt-home-after-stack .idt-command-center {
+  background: #f5f5f5;
+  color: #09090b;
+}
+
+.idt-home-after-stack .idt-command-center-grid {
+  display: grid;
+  grid-template-columns: minmax(300px, 0.42fr) minmax(0, 1.58fr);
+  gap: clamp(2rem, 5vw, 5rem);
+  align-items: start;
+}
+
+.idt-home-after-stack .idt-command-copy {
+  position: sticky;
+  top: 6rem;
+}
+
+.idt-home-after-stack .idt-command-copy > p,
+html[data-theme='light'] .idt-home-after-stack .idt-command-copy > p {
+  color: #52525b;
+}
+
+.idt-home-after-stack .idt-command-tabs,
+html[data-theme='light'] .idt-home-after-stack .idt-command-tabs {
+  display: grid;
+  margin-top: 2rem;
+  padding: 0;
+  border: 1px solid #d4d4d8;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.idt-home-after-stack .idt-command-tabs button,
+html[data-theme='light'] .idt-home-after-stack .idt-command-tabs button {
+  border-radius: 0;
+  border-bottom: 1px solid #d4d4d8;
+  background: transparent;
+  color: #52525b;
+  justify-content: flex-start;
+}
+
+.idt-home-after-stack .idt-command-tabs button:last-child {
+  border-bottom: 0;
+}
+
+.idt-home-after-stack .idt-command-tabs button.is-active,
+html[data-theme='light'] .idt-home-after-stack .idt-command-tabs button.is-active {
+  background: #000000;
+  color: #ffffff;
+}
+
+.idt-home-after-stack .idt-command-tabs button span,
+.idt-home-after-stack .idt-command-tabs button.is-active span,
+html[data-theme='light'] .idt-home-after-stack .idt-command-tabs button span,
+html[data-theme='light'] .idt-home-after-stack .idt-command-tabs button.is-active span {
+  background: currentColor;
+}
+
+.idt-home-after-stack .idt-command-surface,
+html[data-theme='light'] .idt-home-after-stack .idt-command-surface {
+  min-height: 640px;
+  border: 1px solid #242424;
+  border-radius: 8px;
+  background: #000000;
+  color: #ffffff;
+  box-shadow: none;
+}
+
+.idt-home-after-stack .idt-command-surface-head {
+  border-bottom: 1px solid #242424;
+  padding-bottom: 1.35rem;
+}
+
+.idt-home-after-stack .idt-command-surface-head h3,
+html[data-theme='light'] .idt-home-after-stack .idt-command-surface-head h3 {
+  max-width: 19ch;
+  color: #ffffff;
+  font-family: 'Barlow Semi Condensed', 'Arial Narrow', Arial, sans-serif;
+  font-size: clamp(2.2rem, 4vw, 3.35rem);
+  font-weight: 800;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.idt-home-after-stack .idt-command-surface-head p,
+.idt-home-after-stack .idt-command-label,
+.idt-home-after-stack .idt-command-metrics small,
+html[data-theme='light'] .idt-home-after-stack .idt-command-surface-head p,
+html[data-theme='light'] .idt-home-after-stack .idt-command-label,
+html[data-theme='light'] .idt-home-after-stack .idt-command-metrics small {
+  color: #a1a1aa;
+}
+
+.idt-home-after-stack .idt-command-surface-head > span,
+html[data-theme='light'] .idt-home-after-stack .idt-command-surface-head > span {
+  border-color: #3f3f46;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #000000;
+}
+
+.idt-home-after-stack .idt-command-metrics {
+  gap: 1px;
+  margin-top: 1.4rem;
+  background: #242424;
+}
+
+.idt-home-after-stack .idt-command-metrics div,
+.idt-home-after-stack .idt-command-list li,
+.idt-home-after-stack .idt-command-playbook li,
+html[data-theme='light'] .idt-home-after-stack .idt-command-metrics div,
+html[data-theme='light'] .idt-home-after-stack .idt-command-list li,
+html[data-theme='light'] .idt-home-after-stack .idt-command-playbook li {
+  border: 0;
+  border-radius: 0;
+  background: #090909;
+  color: #ffffff;
+  box-shadow: none;
+}
+
+.idt-home-after-stack .idt-command-metrics strong,
+html[data-theme='light'] .idt-home-after-stack .idt-command-metrics strong {
+  color: #ffffff;
+}
+
+.idt-home-after-stack .idt-command-detail-grid {
+  margin-top: 1.4rem;
+}
+
+.idt-home-after-stack .idt-product-tour,
+html[data-theme='light'] .idt-home-after-stack .idt-product-tour {
+  border-top: 1px solid #e4e4e7;
+  border-bottom: 1px solid #e4e4e7;
+  background: #ffffff;
+  color: #09090b;
+}
+
+.idt-home-after-stack .idt-product-tour-shell,
+html[data-theme='light'] .idt-home-after-stack .idt-product-tour-shell {
+  grid-template-columns: minmax(300px, 0.42fr) minmax(0, 1.58fr);
+  gap: 1px;
+  margin-top: 2.5rem;
+  padding: 1px;
+  border: 1px solid #18181b;
+  border-radius: 8px;
+  background: #18181b;
+  box-shadow: none;
+}
+
+.idt-home-after-stack .idt-tour-rail {
+  gap: 1px;
+  background: #18181b;
+}
+
+.idt-home-after-stack .idt-tour-step,
+html[data-theme='light'] .idt-home-after-stack .idt-tour-step,
+.idt-home-after-stack .idt-tour-step.is-active,
+html[data-theme='light'] .idt-home-after-stack .idt-tour-step.is-active {
+  min-height: 150px;
+  border: 0;
+  border-radius: 0;
+  background: #050505;
+  color: #ffffff;
+  box-shadow: none;
+}
+
+.idt-home-after-stack .idt-tour-step.is-active,
+html[data-theme='light'] .idt-home-after-stack .idt-tour-step.is-active {
+  background: #ffffff;
+  color: #000000;
+}
+
+.idt-home-after-stack .idt-tour-step-index,
+.idt-home-after-stack .idt-tour-step > span,
+html[data-theme='light'] .idt-home-after-stack .idt-tour-step > span {
+  border-radius: 8px;
+  background: #ffffff;
+  color: #000000;
+}
+
+.idt-home-after-stack .idt-tour-step.is-active .idt-tour-step-index,
+html[data-theme='light'] .idt-home-after-stack .idt-tour-step.is-active .idt-tour-step-index {
+  background: #000000;
+  color: #ffffff;
+}
+
+.idt-home-after-stack .idt-tour-step h3,
+html[data-theme='light'] .idt-home-after-stack .idt-tour-step h3 {
+  color: #ffffff;
+}
+
+.idt-home-after-stack .idt-tour-step.is-active h3,
+html[data-theme='light'] .idt-home-after-stack .idt-tour-step.is-active h3 {
+  color: #000000;
+}
+
+.idt-home-after-stack .idt-tour-step small,
+.idt-home-after-stack .idt-tour-step p,
+html[data-theme='light'] .idt-home-after-stack .idt-tour-step p {
+  color: #a1a1aa;
+}
+
+.idt-home-after-stack .idt-tour-step.is-active small,
+.idt-home-after-stack .idt-tour-step.is-active p,
+html[data-theme='light'] .idt-home-after-stack .idt-tour-step.is-active p {
+  color: #52525b;
+}
+
+.idt-home-after-stack .idt-tour-screen,
+html[data-theme='light'] .idt-home-after-stack .idt-tour-screen {
+  border: 0;
+  border-radius: 0 7px 7px 0;
+  background: #f5f5f5;
+  box-shadow: none;
+}
+
+.idt-home-after-stack .idt-tour-screen-head {
+  border-bottom-color: #d4d4d8;
+  background: #ffffff;
+}
+
+.idt-home-after-stack .idt-tour-screen-head p,
+.idt-home-after-stack .idt-tour-path-head p,
+.idt-home-after-stack .idt-tour-connector-scope > p,
+.idt-home-after-stack .idt-tour-simulation p,
+.idt-home-after-stack .idt-tour-evidence-packet p,
+html[data-theme='light'] .idt-home-after-stack .idt-tour-screen-head p {
+  color: #52525b;
+}
+
+.idt-home-after-stack .idt-tour-screen-head h3,
+.idt-home-after-stack .idt-tour-path-head h4,
+html[data-theme='light'] .idt-home-after-stack .idt-tour-screen-head h3 {
+  color: #000000;
+}
+
+.idt-home-after-stack .idt-tour-screen-head > span,
+html[data-theme='light'] .idt-home-after-stack .idt-tour-screen-head > span {
+  border-color: #d4d4d8;
+  border-radius: 8px;
+  background: #000000;
+  color: #ffffff;
+}
+
+.idt-home-after-stack .idt-tour-connector-scope,
+.idt-home-after-stack .idt-tour-path-panel,
+.idt-home-after-stack .idt-tour-simulation,
+.idt-home-after-stack .idt-tour-evidence-packet {
+  border-color: #d4d4d8;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: none;
+}
+
+.idt-home-after-stack .idt-tour-connector-scope article,
+.idt-home-after-stack .idt-tour-path-chain article,
+.idt-home-after-stack .idt-tour-evidence-packet li {
+  border-color: #e4e4e7;
+  border-radius: 8px;
+  background: #f5f5f5;
+}
+
+.idt-home-after-stack .idt-tour-simulation code {
+  border-color: #27272a;
+  border-radius: 8px;
+  background: #000000;
+}
+
+.idt-home-after-stack .idt-workflow-section,
+html[data-theme='light'] .idt-home-after-stack .idt-workflow-section {
+  border-top: 1px solid #1f1f1f;
+  border-bottom: 1px solid #1f1f1f;
+  background: #000000;
+  color: #ffffff;
+}
+
+.idt-home-after-stack .idt-workflow-section .idt-section-title p,
+html[data-theme='light'] .idt-home-after-stack .idt-workflow-section .idt-section-title p {
+  color: #a1a1aa;
+}
+
+.idt-home-after-stack .idt-workflow-track {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1px;
+  margin-top: 3rem;
+  padding: 0;
+  background: #27272a;
+}
+
+.idt-home-after-stack .idt-workflow-track::before {
+  display: none;
+}
+
+.idt-home-after-stack .idt-workflow-track li {
+  min-height: 340px;
+  margin: 0;
+  padding: 1.35rem;
+  border: 0;
+  border-radius: 0;
+  background: #050505;
+  color: #ffffff;
+}
+
+.idt-home-after-stack .idt-workflow-track h3 {
+  margin-top: 5rem;
+  color: #ffffff;
+  font-size: 1.45rem;
+  line-height: 1.08;
+}
+
+.idt-home-after-stack .idt-workflow-track li > p {
+  color: #a1a1aa;
+}
+
+.idt-home-after-stack .idt-workflow-stage,
+html[data-theme='light'] .idt-home-after-stack .idt-workflow-stage {
+  color: #ffffff;
+}
+
+.idt-home-after-stack .idt-workflow-output,
+html[data-theme='light'] .idt-home-after-stack .idt-workflow-output {
+  border-left: 2px solid #ffffff;
+  background: transparent;
+  color: #ffffff;
+}
+
+.idt-home-after-stack .idt-deployment-bridge,
+html[data-theme='light'] .idt-home-after-stack .idt-deployment-bridge {
+  background: #f5f5f5;
+  color: #09090b;
+}
+
+.idt-home-after-stack .idt-deployment-panel,
+html[data-theme='light'] .idt-home-after-stack .idt-deployment-panel {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  box-shadow: none;
+}
+
+.idt-home-after-stack .idt-deployment-panel h2 {
+  color: #09090b;
+}
+
+.idt-home-after-stack .idt-adoption-grid {
+  gap: 1px;
+  margin-top: 3rem;
+  background: #d4d4d8;
+}
+
+.idt-home-after-stack .idt-adoption-card,
+html[data-theme='light'] .idt-home-after-stack .idt-adoption-card {
+  min-height: 380px;
+  border: 0;
+  border-radius: 0;
+  background: #f5f5f5;
+  color: #09090b;
+  box-shadow: none;
+}
+
+.idt-home-after-stack .idt-adoption-card.is-featured,
+html[data-theme='light'] .idt-home-after-stack .idt-adoption-card.is-featured {
+  background: #ffffff;
+  box-shadow: none;
+}
+
+.idt-home-after-stack .idt-adoption-card h3 {
+  margin-top: auto;
+  color: #09090b;
+  font-size: 1.6rem;
+}
+
+.idt-home-after-stack .idt-adoption-card p,
+.idt-home-after-stack .idt-adoption-card dd,
+html[data-theme='light'] .idt-home-after-stack .idt-adoption-card p {
+  color: #52525b;
+}
+
+.idt-home-after-stack .idt-adoption-card dt {
+  color: #09090b;
+}
+
+.idt-home-after-stack .idt-adoption-actions .idt-btn-ghost,
+html[data-theme='light'] .idt-home-after-stack .idt-adoption-actions .idt-btn-ghost {
+  border-color: #09090b;
+  background: #09090b;
+  color: #ffffff;
+}
+
+.idt-home-after-stack .idt-home-compare-section,
+html[data-theme='light'] .idt-home-after-stack .idt-home-compare-section {
+  background: #ffffff;
+  color: #09090b;
+}
+
+.idt-home-after-stack .idt-home-compare-section .idt-section-title p,
+html[data-theme='light'] .idt-home-after-stack .idt-home-compare-section .idt-section-title p {
+  color: #52525b;
+}
+
+.idt-home-after-stack .idt-home-compare,
+html[data-theme='light'] .idt-home-after-stack .idt-home-compare {
+  margin-top: 3rem;
+  border: 1px solid #18181b;
+  border-radius: 0;
+  background: #18181b;
+  box-shadow: none;
+}
+
+.idt-home-after-stack .idt-home-compare .idt-compare-table {
+  border-collapse: separate;
+  border-spacing: 1px;
+  background: #18181b;
+}
+
+.idt-home-after-stack .idt-home-compare .idt-compare-table th,
+.idt-home-after-stack .idt-home-compare .idt-compare-table td,
+html[data-theme='light'] .idt-home-after-stack .idt-home-compare .idt-compare-table th,
+html[data-theme='light'] .idt-home-after-stack .idt-home-compare .idt-compare-table td {
+  border: 0;
+  background: #ffffff;
+  color: #09090b;
+}
+
+.idt-home-after-stack .idt-home-compare .idt-compare-table thead th,
+html[data-theme='light'] .idt-home-after-stack .idt-home-compare .idt-compare-table thead th {
+  background: #000000;
+  color: #ffffff;
+}
+
+.idt-home-after-stack .idt-home-compare .idt-compare-table td,
+html[data-theme='light'] .idt-home-after-stack .idt-home-compare .idt-compare-table td {
+  color: #52525b;
+}
+
+.idt-home-after-stack .idt-home-final-cta,
+html[data-theme='light'] .idt-home-after-stack .idt-home-final-cta {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 2rem;
+  align-items: end;
+  border-top: 1px solid #1f1f1f;
+  background: #000000;
+  color: #ffffff;
+}
+
+.idt-home-after-stack .idt-home-final-cta .idt-section-title p,
+html[data-theme='light'] .idt-home-after-stack .idt-home-final-cta .idt-section-title p {
+  color: #a1a1aa;
+}
+
+.idt-home-after-stack .idt-home-final-cta .idt-inline-actions {
+  margin: 0;
+  justify-content: flex-end;
+}
+
+.idt-home-after-stack .idt-home-final-cta .idt-final-cta-link,
+html[data-theme='light'] .idt-home-after-stack .idt-home-final-cta .idt-final-cta-link {
+  color: #ffffff;
+}
+
+@media (max-width: 1180px) {
+  .idt-home-after-stack .idt-problem-frame-grid,
+  .idt-home-after-stack .idt-command-center-grid,
+  .idt-home-after-stack .idt-product-tour-shell,
+  html[data-theme='light'] .idt-home-after-stack .idt-product-tour-shell,
+  .idt-home-after-stack .idt-home-final-cta {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-home-after-stack .idt-command-copy {
+    position: static;
+  }
+
+  .idt-home-after-stack .idt-problem-path-visual {
+    grid-template-columns: minmax(220px, 0.58fr) 80px minmax(320px, 1fr);
+  }
+
+  .idt-home-after-stack .idt-workflow-track,
+  .idt-home-after-stack .idt-adoption-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .idt-home-after-stack .idt-home-final-cta .idt-inline-actions {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 820px) {
+  .idt-home-after-stack .idt-section {
+    padding: 3.8rem 1rem;
+  }
+
+  .idt-home-after-stack h2,
+  .idt-home-after-stack .idt-section-title h2,
+  .idt-home-after-stack .idt-problem-copy h2,
+  .idt-home-after-stack .idt-command-copy h2,
+  .idt-home-after-stack .idt-product-tour-copy h2,
+  html[data-theme='light'] .idt-home-after-stack .idt-section-title h2,
+  html[data-theme='light'] .idt-home-after-stack .idt-problem-copy h2,
+  html[data-theme='light'] .idt-home-after-stack .idt-command-copy h2,
+  html[data-theme='light'] .idt-home-after-stack .idt-product-tour-copy h2 {
+    font-size: clamp(2.55rem, 11vw, 3.35rem);
+  }
+
+  .idt-home-after-stack .idt-problem-path-visual {
+    display: block;
+    min-height: 0;
+  }
+
+  .idt-home-after-stack .idt-problem-source-stack {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .idt-home-after-stack .idt-problem-path-spine {
+    display: none;
+  }
+
+  .idt-home-after-stack .idt-problem-frame .idt-problem-map-core,
+  html[data-theme='light'] .idt-home-after-stack .idt-problem-frame .idt-problem-map-core {
+    min-height: 250px;
+    border-left: 0;
+    border-top: 1px solid #262626;
+    border-radius: 0 0 7px 7px;
+  }
+
+  .idt-home-after-stack .idt-problem-timeline,
+  .idt-home-after-stack .idt-workflow-track,
+  .idt-home-after-stack .idt-adoption-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-home-after-stack .idt-product-tour-shell,
+  html[data-theme='light'] .idt-home-after-stack .idt-product-tour-shell {
+    display: grid;
+  }
+
+  .idt-home-after-stack .idt-tour-rail,
+  .idt-home-after-stack .idt-tour-product-preview,
+  .idt-home-after-stack .idt-command-detail-grid,
+  .idt-home-after-stack .idt-command-metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-home-after-stack .idt-tour-screen,
+  html[data-theme='light'] .idt-home-after-stack .idt-tour-screen {
+    border-radius: 0 0 7px 7px;
+  }
+
+  .idt-home-after-stack .idt-workflow-track li,
+  .idt-home-after-stack .idt-adoption-card {
+    min-height: 0;
+  }
+
+  .idt-home-after-stack .idt-workflow-track h3,
+  .idt-home-after-stack .idt-adoption-card h3 {
+    margin-top: 2.2rem;
+  }
+
+  .idt-home-after-stack .idt-home-final-cta .idt-inline-actions {
+    display: grid;
+  }
+}


### PR DESCRIPTION
No issue: user-requested homepage redesign.

## What changed
- Preserved the homepage hero and "Reviewed across your identity stack" strip as-is.
- Rebuilt the sections below that strip as full-bleed product story bands instead of centered shell containers.
- Applied the product-page visual language: black anchor sections, alternating light sections, condensed SpaceX-style headings, sharper borders, and less color/gradient noise.
- Kept the existing problem framing, command center, product tour, workflow, adoption, comparison, and CTA content while making each section wider and more premium.
- Added homepage route coverage to assert the lower story starts after the trust strip and avoids `idt-shell` containers.

## Why
The homepage already had strong product ideas below the review strip, but those sections felt too boxed-in and visually separate from the new product page. This makes the homepage continue naturally from the hero into the same premium Vercel-inspired product story without turning the entire page into one flat black surface.

## Impact and risk
- Public web UI only; no API or backend behavior changes.
- The hero and identity-stack strip are intentionally left intact.
- Risk is mainly responsive layout regressions, covered by tests, build, and browser preview checks.

## Validation
- `npm ci --prefix web`
- `npm test --prefix web -- --run src/App.test.tsx -t "renders homepage hero and conversion CTAs"`
- `npm run build --prefix web`
- `npm run test:ci --prefix web`
- `git diff --check`
- Browser preview checks at 1440x1000 and 390x844: no horizontal overflow, lower story starts immediately after the identity-stack strip, redesigned sections are full-width, and no `idt-shell` containers remain below the strip.

## AI usage
- AI-assisted: yes
- Tools used: Codex
- Where used: `web/src/App.tsx`, `web/src/App.test.tsx`, `web/src/components/home/*`, `web/src/styles.css`
- Human verification performed: local tests, production build, and browser preview checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the homepage lower story as full‑bleed bands and refined the product hero into a live “Production trust graph” with arrowed edges. Unified a black marketing theme across Pricing, Docs, Blog, and About with dark overscroll and footer.

- **Refactors**
  - Wrapped all sections after the trust strip in `.idt-home-after-stack`; removed `.idt-shell`; Command Center stays sticky on desktop.
  - Product hero and demo: added `.idt-product-graph-title`, switched to SVG arrowed edges with trimmed endpoints, and increased graph contrast.
  - Final CTA: replaced the risk scan form with a single primary button to `/enterprise` (id `#enterprise-procurement`).
  - Marketing pages: wrapped Pricing/Docs/Blog/About in `.idt-marketing-page` with per‑page classes; unified dark theme, black overscroll, and footer; Docs hero adds interactive preview tabs with accessible tokenized commands; Blog cards show category logos with accent bars.
  - Pricing: simplified hero, set Pro to $30/mo annual ($39 monthly), CTAs now “Start Pro Trial,” and Enterprise is “Custom quote.”
  - Accessibility: `PageHero` visual is optional via `visualHidden`; Docs hero visual is exposed for assistive tech.
  - Tests updated to assert the enterprise CTA link, absence of `#risk-scan-form`, presence of `.idt-trust-strip + .idt-home-after-stack`, and no `.idt-shell` within that stack.

<sup>Written for commit 906607abab74d4eae15f0d879320af76e9b81399. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1185?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

