### PR TITLE
Harden first-use onboarding into a usable workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
 ## Unreleased
+- Hardened the first-use onboarding journey so a newly signed-in user reliably
+  ends up with a usable, scoped workspace:
+  - `StartOnboarding` now reconciles an unbound onboarding row against an
+    existing active workspace membership (partial first attempt, or an
+    admin-provisioned user), so refreshes and second tabs resume the correct
+    step instead of forking a duplicate tenant/workspace.
+  - The organization step can be re-submitted by the onboarding creator before
+    a workspace exists (e.g. correcting a typo) instead of failing with a
+    spurious "workspace access denied"; the owner/admin gate still applies once
+    the user actually belongs to a workspace in the tenant, so a resumed viewer
+    still cannot rename the org.
+  - Added end-to-end coverage proving a brand-new user reaches a workspace where
+    `/v1/me`, the workspaces list, the members list (active owner), the default
+    project, and the scoped `/app/<org>/<workspace>` redirect all agree, and
+    that re-running start is idempotent.
 - Redesigned the product page as a full-bleed Vercel-style surface with a dark hero, spread-out trust graph connections, alternating neutral sections, and no centered container around the main product story.
 - Exposed backend feature availability to the frontend so the web bundle no
   longer shows a backend-gated self-serve flow purely from a Vite build flag:

--- a/internal/api/onboarding.go
+++ b/internal/api/onboarding.go
@@ -62,6 +62,25 @@ func (s *Service) StartOnboarding(ctx context.Context, current sessionauth.Curre
 		return OnboardingStateResponse{}, ErrInvalidOnboardingRequest
 	}
 	if state, err := s.Store.GetOnboardingState(ctx, userID); err == nil {
+		// An existing row that is not yet bound to a workspace must still be
+		// reconciled against any workspace the user already belongs to (a
+		// partial first attempt, or an admin-provisioned membership). Without
+		// this, a stale "org" row would send the user back to create a
+		// duplicate tenant/workspace.
+		if strings.TrimSpace(state.WorkspaceID) == "" && state.CurrentStep != onboardingStepComplete {
+			changed, rErr := s.resumeOnboardingScope(ctx, current, &state, s.onboardingNow())
+			if rErr != nil {
+				return OnboardingStateResponse{}, rErr
+			}
+			if changed {
+				state.UpdatedAt = s.onboardingNow()
+				saved, sErr := s.Store.UpsertOnboardingState(ctx, state)
+				if sErr != nil {
+					return OnboardingStateResponse{}, sErr
+				}
+				return onboardingResponse(saved), nil
+			}
+		}
 		return onboardingResponse(state), nil
 	} else if !errors.Is(err, db.ErrNotFound) {
 		return OnboardingStateResponse{}, err
@@ -74,21 +93,7 @@ func (s *Service) StartOnboarding(ctx context.Context, current sessionauth.Curre
 		StartedAt:   now,
 		UpdatedAt:   now,
 	}
-	if current.Session.CurrentOrgID != "" && current.Session.CurrentWorkspaceID != "" {
-		state.OrgID = current.Session.CurrentOrgID
-		state.WorkspaceID = current.Session.CurrentWorkspaceID
-		state.ProjectID = current.Session.CurrentProjectID
-		state.CurrentStep = onboardingStepForExistingWorkspace(ctx, s.Store, state.OrgID, state.WorkspaceID, &state.ProjectID)
-	} else if member, err := s.Store.FindFirstWorkspaceMemberByUserUUID(ctx, userID); err == nil {
-		state.OrgID = member.TenantID
-		state.WorkspaceID = member.WorkspaceID
-		scopedCtx := db.WithScope(ctx, db.Scope{TenantID: member.TenantID, WorkspaceID: member.WorkspaceID})
-		if projects, listErr := s.Store.ListProjects(scopedCtx, member.WorkspaceID, false, 1); listErr == nil && len(projects) > 0 {
-			state.ProjectID = projects[0].ProjectID
-		}
-		state.CurrentStep = onboardingStepForExistingWorkspace(ctx, s.Store, state.OrgID, state.WorkspaceID, &state.ProjectID)
-		_, _ = s.Store.UpdateSessionContext(ctx, userID, current.IDHash, member.TenantID, member.WorkspaceID, state.ProjectID, now)
-	} else if !errors.Is(err, db.ErrNotFound) {
+	if _, err := s.resumeOnboardingScope(ctx, current, &state, now); err != nil {
 		return OnboardingStateResponse{}, err
 	}
 
@@ -97,6 +102,39 @@ func (s *Service) StartOnboarding(ctx context.Context, current sessionauth.Curre
 		return OnboardingStateResponse{}, err
 	}
 	return onboardingResponse(saved), nil
+}
+
+// resumeOnboardingScope binds an unbound onboarding state onto an existing
+// scope so refreshes, second tabs, and partial first attempts resume the right
+// step instead of forking a new tenant/workspace. It reports whether it changed
+// the state. A state that already carries a workspace is left untouched.
+func (s *Service) resumeOnboardingScope(ctx context.Context, current sessionauth.CurrentSession, state *db.OnboardingState, now time.Time) (bool, error) {
+	if strings.TrimSpace(state.WorkspaceID) != "" {
+		return false, nil
+	}
+	if current.Session.CurrentOrgID != "" && current.Session.CurrentWorkspaceID != "" {
+		state.OrgID = current.Session.CurrentOrgID
+		state.WorkspaceID = current.Session.CurrentWorkspaceID
+		state.ProjectID = current.Session.CurrentProjectID
+		state.CurrentStep = onboardingStepForExistingWorkspace(ctx, s.Store, state.OrgID, state.WorkspaceID, &state.ProjectID)
+		return true, nil
+	}
+	member, err := s.Store.FindFirstWorkspaceMemberByUserUUID(ctx, strings.TrimSpace(current.Session.UserID))
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	state.OrgID = member.TenantID
+	state.WorkspaceID = member.WorkspaceID
+	scopedCtx := db.WithScope(ctx, db.Scope{TenantID: member.TenantID, WorkspaceID: member.WorkspaceID})
+	if projects, listErr := s.Store.ListProjects(scopedCtx, member.WorkspaceID, false, 1); listErr == nil && len(projects) > 0 {
+		state.ProjectID = projects[0].ProjectID
+	}
+	state.CurrentStep = onboardingStepForExistingWorkspace(ctx, s.Store, state.OrgID, state.WorkspaceID, &state.ProjectID)
+	_, _ = s.Store.UpdateSessionContext(ctx, current.Session.UserID, current.IDHash, member.TenantID, member.WorkspaceID, state.ProjectID, now)
+	return true, nil
 }
 
 // GetOnboardingState returns current progress without mutating it.
@@ -222,11 +260,7 @@ func (s *Service) applyOnboardingOrganization(ctx context.Context, current sessi
 		state.OrgID = onboardingScopedID(orgName, "org")
 	}
 	if !creatingOrg {
-		workspaceID := strings.TrimSpace(state.WorkspaceID)
-		if workspaceID == "" {
-			workspaceID = strings.TrimSpace(current.Session.CurrentWorkspaceID)
-		}
-		if err := s.requireOnboardingOrganizationAdmin(ctx, current.Session.UserID, state.OrgID, workspaceID); err != nil {
+		if err := s.requireOnboardingOrganizationAdmin(ctx, current.Session.UserID, state.OrgID); err != nil {
 			return db.OnboardingState{}, err
 		}
 	}
@@ -353,13 +387,33 @@ func (s *Service) requireOnboardingWorkspaceAdmin(ctx context.Context, userID st
 	}
 }
 
-func (s *Service) requireOnboardingOrganizationAdmin(ctx context.Context, userID string, orgID string, workspaceID string) error {
-	workspaceID = strings.TrimSpace(workspaceID)
-	if strings.TrimSpace(orgID) == "" || workspaceID == "" {
+// requireOnboardingOrganizationAdmin authorizes a repeat organization-step
+// write. A brand-new tenant created by this user's own onboarding flow has no
+// workspace membership yet — that user is still the legitimate creator and may
+// refine the org name/slug. Only once the user actually belongs to a workspace
+// in the tenant is the owner/admin gate enforced (so a viewer who resumed onto
+// an existing org cannot rename it).
+func (s *Service) requireOnboardingOrganizationAdmin(ctx context.Context, userID string, orgID string) error {
+	orgID = strings.TrimSpace(orgID)
+	if orgID == "" {
 		return ErrOnboardingWorkspaceAccessDenied
 	}
-	scopedCtx := db.WithScope(ctx, db.Scope{TenantID: orgID, WorkspaceID: workspaceID})
-	return s.requireOnboardingWorkspaceAdmin(scopedCtx, userID, workspaceID)
+	member, err := s.Store.FindFirstWorkspaceMemberByUserUUIDAndTenantID(ctx, strings.TrimSpace(userID), orgID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+	if member.Status != "active" {
+		return ErrOnboardingWorkspaceAccessDenied
+	}
+	switch member.Role {
+	case "owner", "admin":
+		return nil
+	default:
+		return ErrOnboardingWorkspaceAccessDenied
+	}
 }
 
 func (s *Service) onboardingNow() time.Time {

--- a/internal/api/onboarding.go
+++ b/internal/api/onboarding.go
@@ -399,21 +399,32 @@ func (s *Service) requireOnboardingOrganizationAdmin(ctx context.Context, userID
 		return ErrOnboardingWorkspaceAccessDenied
 	}
 	member, err := s.Store.FindFirstWorkspaceMemberByUserUUIDAndTenantID(ctx, strings.TrimSpace(userID), orgID)
-	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
+	if err == nil {
+		switch member.Role {
+		case "owner", "admin":
 			return nil
+		default:
+			return ErrOnboardingWorkspaceAccessDenied
 		}
+	}
+	if !errors.Is(err, db.ErrNotFound) {
 		return err
 	}
-	if member.Status != "active" {
-		return ErrOnboardingWorkspaceAccessDenied
+	// No active membership in this tenant. Allow the write only when the
+	// tenant has no workspace yet — that is the brand-new tenant this user
+	// just created in their own onboarding org step. If a workspace already
+	// exists, a missing active membership means the user is not (or no
+	// longer) a member, so a revoked or deactivated user with stale
+	// onboarding state must not be able to rename the organization.
+	scopedCtx := db.WithScope(ctx, db.Scope{TenantID: orgID, WorkspaceID: db.DefaultWorkspaceID})
+	workspaces, listErr := s.Store.ListWorkspaces(scopedCtx, 1)
+	if listErr != nil {
+		return listErr
 	}
-	switch member.Role {
-	case "owner", "admin":
+	if len(workspaces) == 0 {
 		return nil
-	default:
-		return ErrOnboardingWorkspaceAccessDenied
 	}
+	return ErrOnboardingWorkspaceAccessDenied
 }
 
 func (s *Service) onboardingNow() time.Time {

--- a/internal/api/onboarding.go
+++ b/internal/api/onboarding.go
@@ -398,17 +398,20 @@ func (s *Service) requireOnboardingOrganizationAdmin(ctx context.Context, userID
 	if orgID == "" {
 		return ErrOnboardingWorkspaceAccessDenied
 	}
-	member, err := s.Store.FindFirstWorkspaceMemberByUserUUIDAndTenantID(ctx, strings.TrimSpace(userID), orgID)
-	if err == nil {
-		switch member.Role {
-		case "owner", "admin":
-			return nil
-		default:
-			return ErrOnboardingWorkspaceAccessDenied
-		}
-	}
-	if !errors.Is(err, db.ErrNotFound) {
+	// Consider every active membership in the tenant, not just the newest
+	// one: a user who is a viewer in their most recently joined workspace may
+	// still be an owner/admin in another workspace of the same tenant.
+	memberships, err := s.Store.ListWorkspaceMembershipsByUserUUIDAndTenantID(ctx, strings.TrimSpace(userID), orgID)
+	if err != nil {
 		return err
+	}
+	if len(memberships) > 0 {
+		for _, member := range memberships {
+			if member.Role == "owner" || member.Role == "admin" {
+				return nil
+			}
+		}
+		return ErrOnboardingWorkspaceAccessDenied
 	}
 	// No active membership in this tenant. Allow the write only when the
 	// tenant has no workspace yet — that is the brand-new tenant this user

--- a/internal/api/onboarding_harden_test.go
+++ b/internal/api/onboarding_harden_test.go
@@ -257,3 +257,70 @@ func TestOnboardingOrgStepDeniesRevokedMemberRename(t *testing.T) {
 		t.Fatalf("organization name must be unchanged, got %q", org.DisplayName)
 	}
 }
+
+// A user who is only a viewer in their newest workspace but still an owner in
+// an earlier workspace of the same tenant must still be allowed to re-edit the
+// organization (membership creation order must not decide authorization).
+func TestOnboardingOrgStepAllowsAdminInAnotherWorkspace(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 5, 14, 10, 0, 0, 0, time.UTC)
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	user, err := store.UpsertUser(context.Background(), db.User{
+		PrimaryEmail: "multi@example.com",
+		DisplayName:  "Multi",
+		Status:       "active",
+	})
+	if err != nil {
+		t.Fatalf("upsert user: %v", err)
+	}
+	owned := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "owned-ws"})
+	viewed := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "viewed-ws"})
+	if err := store.UpsertOrganization(owned, db.TenancyOrganization{TenantID: "tenant-a", DisplayName: "Tenant A", Slug: "tenant-a"}); err != nil {
+		t.Fatalf("upsert org: %v", err)
+	}
+	if err := store.UpsertWorkspace(owned, db.TenancyWorkspace{TenantID: "tenant-a", WorkspaceID: "owned-ws", DisplayName: "Owned", Slug: "owned"}); err != nil {
+		t.Fatalf("upsert owned workspace: %v", err)
+	}
+	if err := store.UpsertWorkspace(viewed, db.TenancyWorkspace{TenantID: "tenant-a", WorkspaceID: "viewed-ws", DisplayName: "Viewed", Slug: "viewed"}); err != nil {
+		t.Fatalf("upsert viewed workspace: %v", err)
+	}
+	if err := store.UpsertWorkspaceMember(owned, db.TenancyWorkspaceMember{
+		TenantID: "tenant-a", WorkspaceID: "owned-ws", MemberID: "member-owner",
+		UserID: user.ID, UserUUID: user.ID, Email: user.PrimaryEmail, Role: "owner", Status: "active",
+		JoinedAt: now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("upsert owner member: %v", err)
+	}
+	if err := store.UpsertWorkspaceMember(viewed, db.TenancyWorkspaceMember{
+		TenantID: "tenant-a", WorkspaceID: "viewed-ws", MemberID: "member-viewer",
+		UserID: user.ID, UserUUID: user.ID, Email: user.PrimaryEmail, Role: "viewer", Status: "active",
+		JoinedAt: now,
+	}); err != nil {
+		t.Fatalf("upsert viewer member: %v", err)
+	}
+	if _, err := store.UpsertOnboardingState(context.Background(), db.OnboardingState{
+		UserID: user.ID, CurrentStep: onboardingStepWorkspace, OrgID: "tenant-a", StartedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed onboarding state: %v", err)
+	}
+
+	resp, err := svc.UpdateOnboardingState(context.Background(), sessionauth.CurrentSession{
+		IDHash:  []byte("session-hash"),
+		Session: db.Session{UserID: user.ID, AuthMethod: "manual"},
+	}, OnboardingStateUpdateRequest{CurrentStep: "org", OrgName: "Renamed By Owner"})
+	if err != nil {
+		t.Fatalf("expected owner-in-another-workspace to be allowed, got %v", err)
+	}
+	if resp.State.OrgID != "tenant-a" {
+		t.Fatalf("org re-edit must not fork the tenant: %+v", resp.State)
+	}
+	org, getErr := store.GetOrganization(db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: db.DefaultWorkspaceID}))
+	if getErr != nil {
+		t.Fatalf("get organization: %v", getErr)
+	}
+	if org.DisplayName != "Renamed By Owner" {
+		t.Fatalf("expected updated display name, got %q", org.DisplayName)
+	}
+}

--- a/internal/api/onboarding_harden_test.go
+++ b/internal/api/onboarding_harden_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -199,5 +200,60 @@ func TestStartOnboardingReconcilesIncompleteStateWithExistingWorkspace(t *testin
 	}
 	if again.State.OrgID != "tenant-a" || again.State.WorkspaceID != "workspace-a" {
 		t.Fatalf("second start changed scope: %+v", again.State)
+	}
+}
+
+// A user whose only membership in the tenant has been deactivated/removed is
+// no longer a member. With stale onboarding state they must NOT be able to
+// re-edit (rename) the organization, even though no *active* membership row is
+// returned.
+func TestOnboardingOrgStepDeniesRevokedMemberRename(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 5, 14, 10, 0, 0, 0, time.UTC)
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	user, err := store.UpsertUser(context.Background(), db.User{
+		PrimaryEmail: "revoked@example.com",
+		DisplayName:  "Revoked",
+		Status:       "active",
+	})
+	if err != nil {
+		t.Fatalf("upsert user: %v", err)
+	}
+	scoped := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	if err := store.UpsertOrganization(scoped, db.TenancyOrganization{TenantID: "tenant-a", DisplayName: "Tenant A", Slug: "tenant-a"}); err != nil {
+		t.Fatalf("upsert org: %v", err)
+	}
+	if err := store.UpsertWorkspace(scoped, db.TenancyWorkspace{TenantID: "tenant-a", WorkspaceID: "workspace-a", DisplayName: "Workspace A", Slug: "workspace-a"}); err != nil {
+		t.Fatalf("upsert workspace: %v", err)
+	}
+	if err := store.UpsertWorkspaceMember(scoped, db.TenancyWorkspaceMember{
+		TenantID: "tenant-a", WorkspaceID: "workspace-a", MemberID: "member-revoked",
+		UserID: user.ID, UserUUID: user.ID, Email: user.PrimaryEmail, Role: "owner", Status: "removed", JoinedAt: now,
+	}); err != nil {
+		t.Fatalf("upsert member: %v", err)
+	}
+	// Stale onboarding row already bound to the tenant (so the org step is a
+	// repeat write), but no active membership remains.
+	if _, err := store.UpsertOnboardingState(context.Background(), db.OnboardingState{
+		UserID: user.ID, CurrentStep: onboardingStepWorkspace, OrgID: "tenant-a", StartedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed onboarding state: %v", err)
+	}
+
+	_, err = svc.UpdateOnboardingState(context.Background(), sessionauth.CurrentSession{
+		IDHash:  []byte("session-hash"),
+		Session: db.Session{UserID: user.ID, AuthMethod: "manual"},
+	}, OnboardingStateUpdateRequest{CurrentStep: "org", OrgName: "Hijacked Name"})
+	if !errors.Is(err, ErrOnboardingWorkspaceAccessDenied) {
+		t.Fatalf("expected revoked member to be denied org rename, got %v", err)
+	}
+	org, getErr := store.GetOrganization(db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: db.DefaultWorkspaceID}))
+	if getErr != nil {
+		t.Fatalf("get organization: %v", getErr)
+	}
+	if org.DisplayName != "Tenant A" {
+		t.Fatalf("organization name must be unchanged, got %q", org.DisplayName)
 	}
 }

--- a/internal/api/onboarding_harden_test.go
+++ b/internal/api/onboarding_harden_test.go
@@ -1,0 +1,203 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	sessionauth "github.com/identrail/identrail/internal/api/auth"
+	"github.com/identrail/identrail/internal/db"
+)
+
+// scopedOnboardingRequest is onboardingRequest plus the explicit tenant and
+// workspace scope headers the product-shell APIs require.
+func scopedOnboardingRequest(router http.Handler, cookieValue, method, path, body, tenantID, workspaceID string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("X-Identrail-Tenant-ID", tenantID)
+	req.Header.Set("X-Identrail-Workspace-ID", workspaceID)
+	req.AddCookie(&http.Cookie{Name: sessionauth.CookieName, Value: cookieValue})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func decodeOnboarding(t *testing.T, w *httptest.ResponseRecorder) OnboardingStateResponse {
+	t.Helper()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var body OnboardingStateResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode onboarding response: %v body=%s", err, w.Body.String())
+	}
+	return body
+}
+
+// A brand-new user must be able to go all the way from no workspace to a
+// usable, scoped workspace: /v1/me, the workspaces list, the members list, and
+// the projects list must all agree, and completion must redirect into the
+// scoped app. Re-running start must not fork a second tenant/workspace.
+func TestOnboardingFirstUseProducesUsableWorkspace(t *testing.T) {
+	store, router, cookie := setupOnboardingRouter(t, true)
+
+	decodeOnboarding(t, onboardingRequest(router, cookie, http.MethodPost, "/v1/onboarding/start", ""))
+	orgResp := decodeOnboarding(t, onboardingRequest(router, cookie, http.MethodPost, "/v1/onboarding/state",
+		`{"current_step":"org","org_name":"Aurelius Security"}`))
+	orgID := orgResp.State.OrgID
+	if orgID == "" || orgResp.State.CurrentStep != "workspace" {
+		t.Fatalf("unexpected org step: %+v", orgResp.State)
+	}
+
+	wsResp := decodeOnboarding(t, onboardingRequest(router, cookie, http.MethodPost, "/v1/onboarding/state",
+		`{"current_step":"workspace","workspace_name":"Production"}`))
+	if wsResp.State.WorkspaceID != "production" || wsResp.State.ProjectID != "production" {
+		t.Fatalf("unexpected workspace step: %+v", wsResp.State)
+	}
+
+	me := onboardingRequest(router, cookie, http.MethodGet, "/v1/me", "")
+	if me.Code != http.StatusOK {
+		t.Fatalf("/v1/me status %d body=%s", me.Code, me.Body.String())
+	}
+	for _, want := range []string{`"org_id":"` + orgID + `"`, `"workspace_id":"production"`, `"project_id":"production"`, `"role":"owner"`} {
+		if !strings.Contains(me.Body.String(), want) {
+			t.Fatalf("/v1/me missing %s: %s", want, me.Body.String())
+		}
+	}
+
+	workspaces := scopedOnboardingRequest(router, cookie, http.MethodGet, "/v1/workspaces", "", orgID, "production")
+	if workspaces.Code != http.StatusOK || !strings.Contains(workspaces.Body.String(), `"workspace_id":"production"`) {
+		t.Fatalf("workspaces list missing onboarded workspace: %d %s", workspaces.Code, workspaces.Body.String())
+	}
+
+	members := scopedOnboardingRequest(router, cookie, http.MethodGet, "/v1/workspaces/production/members", "", orgID, "production")
+	if members.Code != http.StatusOK {
+		t.Fatalf("members list status %d body=%s", members.Code, members.Body.String())
+	}
+	if !strings.Contains(members.Body.String(), `"role":"owner"`) || !strings.Contains(members.Body.String(), `"status":"active"`) {
+		t.Fatalf("members list does not show active owner: %s", members.Body.String())
+	}
+
+	projects := scopedOnboardingRequest(router, cookie, http.MethodGet, "/v1/workspaces/production/projects", "", orgID, "production")
+	if projects.Code != http.StatusOK || !strings.Contains(projects.Body.String(), `"project_id":"production"`) {
+		t.Fatalf("projects list missing default project: %d %s", projects.Code, projects.Body.String())
+	}
+
+	complete := decodeOnboarding(t, onboardingRequest(router, cookie, http.MethodPost, "/v1/onboarding/complete", ""))
+	if complete.RedirectPath != "/app/"+orgID+"/production" {
+		t.Fatalf("expected scoped app redirect, got %q", complete.RedirectPath)
+	}
+
+	// Re-running start for the same user must resume, not fork a new tenant.
+	resume := decodeOnboarding(t, onboardingRequest(router, cookie, http.MethodPost, "/v1/onboarding/start", ""))
+	if resume.State.OrgID != orgID || resume.State.WorkspaceID != "production" {
+		t.Fatalf("resume forked scope: %+v", resume.State)
+	}
+	if _, err := store.GetOrganization(db.WithScope(context.Background(), db.Scope{TenantID: orgID, WorkspaceID: db.DefaultWorkspaceID})); err != nil {
+		t.Fatalf("original organization missing after resume: %v", err)
+	}
+}
+
+// Editing the organization name again before the workspace exists is a normal
+// first-use action (the user corrects a typo on the org screen). It must not be
+// rejected as a workspace-access violation.
+func TestOnboardingOrgStepReeditAllowedBeforeWorkspace(t *testing.T) {
+	store, router, cookie := setupOnboardingRouter(t, true)
+
+	decodeOnboarding(t, onboardingRequest(router, cookie, http.MethodPost, "/v1/onboarding/start", ""))
+	first := decodeOnboarding(t, onboardingRequest(router, cookie, http.MethodPost, "/v1/onboarding/state",
+		`{"current_step":"org","org_name":"Typo Inc"}`))
+	orgID := first.State.OrgID
+
+	reedit := onboardingRequest(router, cookie, http.MethodPost, "/v1/onboarding/state",
+		`{"current_step":"org","org_name":"Aurelius Security"}`)
+	if reedit.Code != http.StatusOK {
+		t.Fatalf("expected org re-edit to succeed, got %d body=%s", reedit.Code, reedit.Body.String())
+	}
+	body := decodeOnboarding(t, reedit)
+	if body.State.OrgID != orgID {
+		t.Fatalf("org re-edit must not fork the tenant: was %q now %q", orgID, body.State.OrgID)
+	}
+
+	org, err := store.GetOrganization(db.WithScope(context.Background(), db.Scope{TenantID: orgID, WorkspaceID: db.DefaultWorkspaceID}))
+	if err != nil {
+		t.Fatalf("get organization: %v", err)
+	}
+	if org.DisplayName != "Aurelius Security" {
+		t.Fatalf("expected updated display name, got %q", org.DisplayName)
+	}
+}
+
+// If the user already has an active workspace membership but their onboarding
+// row is still an empty "org" step (e.g. a partial first attempt, or admin
+// pre-provisioned them), start must reconcile onto the existing workspace
+// instead of sending them back to create a duplicate tenant/workspace.
+func TestStartOnboardingReconcilesIncompleteStateWithExistingWorkspace(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 5, 14, 10, 0, 0, 0, time.UTC)
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+
+	user, err := store.UpsertUser(context.Background(), db.User{
+		PrimaryEmail: "rejoin@example.com",
+		DisplayName:  "Rejoin",
+		Status:       "active",
+	})
+	if err != nil {
+		t.Fatalf("upsert user: %v", err)
+	}
+	scoped := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	if err := store.UpsertOrganization(scoped, db.TenancyOrganization{TenantID: "tenant-a", DisplayName: "Tenant A", Slug: "tenant-a"}); err != nil {
+		t.Fatalf("upsert org: %v", err)
+	}
+	if err := store.UpsertWorkspace(scoped, db.TenancyWorkspace{TenantID: "tenant-a", WorkspaceID: "workspace-a", DisplayName: "Workspace A", Slug: "workspace-a"}); err != nil {
+		t.Fatalf("upsert workspace: %v", err)
+	}
+	if err := store.UpsertProject(scoped, db.TenancyProject{TenantID: "tenant-a", WorkspaceID: "workspace-a", ProjectID: "default", Name: "Default", Slug: "default"}); err != nil {
+		t.Fatalf("upsert project: %v", err)
+	}
+	if err := store.UpsertWorkspaceMember(scoped, db.TenancyWorkspaceMember{
+		TenantID: "tenant-a", WorkspaceID: "workspace-a", MemberID: "member-rejoin",
+		UserID: user.ID, UserUUID: user.ID, Email: user.PrimaryEmail, Role: "owner", Status: "active", JoinedAt: now,
+	}); err != nil {
+		t.Fatalf("upsert member: %v", err)
+	}
+	// Seed a stale, unbound onboarding state for this user.
+	if _, err := store.UpsertOnboardingState(context.Background(), db.OnboardingState{
+		UserID: user.ID, CurrentStep: "org", StartedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed onboarding state: %v", err)
+	}
+
+	resp, err := svc.StartOnboarding(context.Background(), sessionauth.CurrentSession{
+		IDHash:  []byte("session-hash"),
+		Session: db.Session{UserID: user.ID, AuthMethod: "manual"},
+	})
+	if err != nil {
+		t.Fatalf("start onboarding: %v", err)
+	}
+	if resp.State.OrgID != "tenant-a" || resp.State.WorkspaceID != "workspace-a" {
+		t.Fatalf("expected reconciliation onto existing workspace, got %+v", resp.State)
+	}
+	if resp.State.CurrentStep == onboardingStepOrg {
+		t.Fatalf("expected resume past the org step, got %q", resp.State.CurrentStep)
+	}
+
+	// Idempotent: a second start must not change scope or fork records.
+	again, err := svc.StartOnboarding(context.Background(), sessionauth.CurrentSession{
+		IDHash:  []byte("session-hash"),
+		Session: db.Session{UserID: user.ID, AuthMethod: "manual"},
+	})
+	if err != nil {
+		t.Fatalf("second start: %v", err)
+	}
+	if again.State.OrgID != "tenant-a" || again.State.WorkspaceID != "workspace-a" {
+		t.Fatalf("second start changed scope: %+v", again.State)
+	}
+}


### PR DESCRIPTION
## Summary
Verified the existing onboarding service end to end (org → workspace → default project → active owner membership → session context) and hardened two real first-use gaps found during verification. The happy path already worked; this makes the enabled journey complete and reliable.

Depends on #1174 (merged in [identrail#1183](https://github.com/identrail/identrail/pull/1183)) — the frontend can now trust API-discovered feature availability; this PR makes the backend journey behind it robust.

**Fix 1 — resume instead of fork.** `StartOnboarding` now reconciles an *unbound* onboarding row (empty workspace, not complete) against an existing active workspace membership — a partial first attempt, a refresh, a second tab, or an admin-provisioned user. Previously a stale `"org"` row was returned verbatim, sending the user back to create a duplicate tenant/workspace. The resume logic is extracted into one helper shared by the new-row and existing-row paths (no behavior change for the already-correct new-user path).

**Fix 2 — let the creator re-edit the org.** Re-submitting the organization step before a workspace exists (e.g. correcting a typo) failed with a spurious `workspace access denied` (403), because the admin gate required a workspace that did not exist yet. The gate is now keyed on actual tenant membership via `FindFirstWorkspaceMemberByUserUUIDAndTenantID`: a brand-new tenant from the user's own flow has no membership yet so the creator may refine it, while a viewer who resumed onto an existing org still cannot rename it (security preserved — covered by the existing viewer-rejection test, still green).

No frontend changes: this is backend hardening; the frontend already consumes the hardened `/v1/me`.

## Acceptance criteria
- [x] Brand-new user completes org + workspace setup without manual tenant/workspace IDs
- [x] After workspace setup, `/v1/me` includes `org_id` and `workspace_id`
- [x] Scoped `/app/<org>/<workspace>` is the completion redirect (server-verified) and `/v1/me` no longer reports the no-workspace fallback
- [x] Projects route shows the default onboarding project
- [x] Workspaces + members routes show the user as active owner
- [x] Re-running start resumes existing progress; no duplicate tenant/workspace
- [x] Tests cover new-user setup, resume/reconcile behavior, and scoped redirect

## Test plan
- [x] `go test ./internal/api/ ./internal/db/` (new `onboarding_harden_test.go`: full first-use E2E across `/v1/me` + workspaces/members/projects + scoped redirect + start idempotency; org re-edit; incomplete-state reconciliation)
- [x] Existing onboarding tests incl. `TestOnboardingRejectsExistingViewerWrites` still pass (security gate preserved)
- [x] `go build ./...`, `go vet`, `make fmt`
- [x] Frontend onboarding + product-shell suites green (`npx vitest run` 111/111) — no regressions
- [ ] Manual: fresh account through org/workspace creation to dashboard landing

## AI assistance disclosure
Prepared with AI assistance (Claude Code). All logic, tests, and docs were reviewed before submission.

Closes #1175

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens first-use onboarding so a signed-in user reliably lands in a usable, scoped workspace. Prevents duplicate tenants/workspaces, allows safe org re-edits, correctly authorizes org edits across all tenant memberships, and blocks revoked members.

- **Bug Fixes**
  - Resume instead of fork: `StartOnboarding` reconciles an unbound onboarding row with an existing active workspace membership or session via a shared helper, updating session context and avoiding duplicate tenant/workspace creation.
  - Safe org re-edit with correct auth: The admin gate checks all active memberships in the tenant; the creator may re-edit before any workspace exists; owner/admin in any workspace may rename; viewers cannot; revoked/removed members remain denied once a workspace exists.
  - Coverage: Added end-to-end tests for new-user flow, start idempotency, org re-edit, revoked-member denial, multi-workspace owner-vs-viewer authorization, `/v1/me`, members (active owner), default project, and the scoped redirect.

<sup>Written for commit 3f33dc3eb50fe97e7117be8d71c12a28f1cb416c. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1186?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

