### PR TITLE
Fail closed when onboarding feature metadata is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Failed closed when the API does not explicitly advertise self-serve
+  onboarding support, so authenticated users without a workspace see the
+  existing onboarding-unavailable state instead of entering a wizard that
+  immediately fails with a raw `Request failed (404)`.
 - Added the first GitHub repository scan action after connection:
   - the product source screen can queue `POST /v1/repo-scans` for a selected
     GitHub repository, show queued/running/completed/failed activity, and link

--- a/web/src/components/onboarding/OnboardingAvailability.test.tsx
+++ b/web/src/components/onboarding/OnboardingAvailability.test.tsx
@@ -66,4 +66,11 @@ describe('RequireOnboardingBackend', () => {
 
     expect(await screen.findByRole('heading', { name: 'Fallback shown' })).toBeInTheDocument();
   });
+
+  it('renders the fallback when the API does not advertise onboarding availability', async () => {
+    await renderGuard({ featureEnabled: true, loading: false, onboardingWizard: undefined });
+
+    expect(await screen.findByRole('heading', { name: 'Fallback shown' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Onboarding page' })).not.toBeInTheDocument();
+  });
 });

--- a/web/src/components/onboarding/OnboardingAvailability.tsx
+++ b/web/src/components/onboarding/OnboardingAvailability.tsx
@@ -1,10 +1,10 @@
 import { ReactElement, ReactNode } from 'react';
 import { FEATURE_ONBOARDING_WIZARD } from '../../pages/onboarding/onboardingUtils';
-import { isFeatureAvailable, useBackendFeatures } from '../../hooks/useBackendFeatures';
+import { useBackendFeatures } from '../../hooks/useBackendFeatures';
 
 // Whether self-serve onboarding should be shown: the web bundle must ship the
-// wizard (Vite flag) AND the API must not explicitly report the onboarding
-// route as missing. Returns undefined while backend availability is loading.
+// wizard (Vite flag) AND the API must explicitly report that the onboarding
+// route is available. Returns undefined while backend availability is loading.
 export function useOnboardingAvailable(): boolean | undefined {
   const { features, loading } = useBackendFeatures();
   if (!FEATURE_ONBOARDING_WIZARD) {
@@ -16,7 +16,7 @@ export function useOnboardingAvailable(): boolean | undefined {
   if (loading) {
     return undefined;
   }
-  return isFeatureAvailable(FEATURE_ONBOARDING_WIZARD, features.onboardingWizard);
+  return features.onboardingWizard === true;
 }
 
 export function OnboardingFeatureLoading() {

--- a/web/src/hooks/useBackendFeatures.ts
+++ b/web/src/hooks/useBackendFeatures.ts
@@ -5,7 +5,8 @@ import { apiClient } from '../api/client';
 //   true      -> API explicitly advertises the backend route is registered
 //   false     -> API explicitly advertises it is NOT registered
 //   undefined -> API did not advertise availability (older API, or the
-//                auth/config call failed) -> fall back to the Vite build flag
+//                auth/config call failed). Callers decide whether that should
+//                preserve a Vite-only fallback or fail closed.
 export type BackendFeatureState = boolean | undefined;
 
 export type BackendFeatures = {
@@ -68,9 +69,9 @@ export function resetBackendFeaturesCacheForTests(): void {
   resolvedFeatures = null;
 }
 
-// The effective rule: a backend-dependent flow is shown only when the web
-// bundle ships its UI (Vite flag) AND the API does not explicitly say the
-// route is missing. Unknown backend state keeps the legacy Vite-only result.
+// Generic connector gates keep the legacy Vite-only fallback when backend
+// availability is unknown. Stateful flows that would call missing API routes
+// should fail closed at the caller instead.
 export function isFeatureAvailable(viteFlag: boolean, backendState: BackendFeatureState): boolean {
   if (backendState === undefined) {
     return viteFlag;

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -198,10 +198,13 @@ describe('ProductAppIndexRedirect', () => {
     expect(screen.queryByText(/No workspace is attached yet/i)).not.toBeInTheDocument();
   });
 
-  it('falls back to the bundle flag when the API does not advertise onboarding', async () => {
+  it('shows a clear unavailable state when the API does not advertise onboarding', async () => {
     await renderProductIndexRedirect(true, undefined);
 
-    expect(await screen.findByRole('heading', { level: 1, name: 'Start onboarding' })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /Self-serve onboarding is not enabled on this API/i })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Start onboarding' })).not.toBeInTheDocument();
   });
 
   it('shows a clear unavailable state instead of a 404 when the API lacks onboarding', async () => {


### PR DESCRIPTION
Fixes #1189

## Summary

Require the backend to explicitly advertise `features.onboarding_wizard: true` before the product app redirects a signed-in user without a workspace into the self-serve onboarding wizard.

## Why

The live production API currently returns an `auth/config` response without a `features` object and returns a plain `404 page not found` for `POST /v1/onboarding/start`. The previous frontend behavior treated missing feature metadata as a legacy unknown state and fell back to the Vite flag, which let users enter a server-owned onboarding flow that immediately failed with `Request failed (404)`.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

This keeps the generic connector feature helper's existing Vite fallback behavior, but makes the stateful onboarding flow fail closed when backend support is unknown or false. Users now see the existing onboarding-unavailable state instead of a broken setup wizard.

## Validation

```bash
git diff --check
npm run test --prefix web -- OnboardingAvailability productShell --run
npm run test:ci --prefix web
npm run build --prefix web
```

All checks passed. The earlier two-file `npm run test:ci --prefix web -- OnboardingAvailability productShell` subset passed its tests but exited nonzero because global coverage thresholds do not apply meaningfully to a two-file subset; the full `npm run test:ci --prefix web` passed with 12 files and 126 tests.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: yes
- Tools used: OpenAI coding assistant
- Areas where used: frontend onboarding guard, regression tests, changelog entry, validation
- Human verification performed: reviewed the live API failure, inspected the repo contract, and ran the validation commands above

## Related Issues

- Fixes #1189

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail closed when the API does not advertise onboarding support. If `GET /v1/auth/config` is unreachable, keep the Vite-only fallback so transient errors don’t block users.

- **Bug Fixes**
  - Require `features.onboardingWizard === true` before redirecting; otherwise show the onboarding-unavailable state.
  - Track `features.configReachable` to distinguish missing feature metadata from an unreachable config call; unreachable preserves Vite-only behavior, while reachable-but-missing fails closed.
  - Keep the generic `isFeatureAvailable` Vite fallback for other features; updated tests for missing metadata, unreachable config, and the unavailable state.

<sup>Written for commit 3b8793a1c9b30149c1cc3fc247d44ecc8c4fa4c1. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1190?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

