### PR TITLE
Fix read-only scan intake validation

### DIFF
--- a/web/api/leads.test.ts
+++ b/web/api/leads.test.ts
@@ -54,7 +54,31 @@ describe('web/api/leads handler', () => {
     );
 
     expect(res.statusCode).toBe(400);
-    expect(res.body).toEqual({ error: 'Valid work email is required.' });
+    expect(res.body).toEqual({ error: 'Please use a company or work email address.' });
+  });
+
+  it('rejects common personal email domains before delivery', async () => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = createMockResponse();
+    await handler(
+      {
+        method: 'POST',
+        body: {
+          email: 'person@gmail.com',
+          environment: 'AWS IAM'
+        }
+      },
+      res
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 'Please use a company or work email address.' });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('returns 503 when no lead delivery channel is configured', async () => {

--- a/web/api/leads.ts
+++ b/web/api/leads.ts
@@ -35,6 +35,31 @@ const MAX_TEAM_SIZE_LENGTH = 16;
 const MAX_URGENCY_LENGTH = 32;
 const MAX_DEPLOYMENT_MODEL_LENGTH = 64;
 const RESEND_EMAILS_URL = 'https://api.resend.com/emails';
+const WORK_EMAIL_ERROR = 'Please use a company or work email address.';
+const PERSONAL_EMAIL_DOMAINS = new Set([
+  'aol.com',
+  'fastmail.com',
+  'gmail.com',
+  'gmx.com',
+  'gmx.net',
+  'googlemail.com',
+  'hey.com',
+  'hotmail.com',
+  'icloud.com',
+  'live.com',
+  'mac.com',
+  'mail.com',
+  'me.com',
+  'msn.com',
+  'outlook.com',
+  'pm.me',
+  'proton.me',
+  'protonmail.com',
+  'rocketmail.com',
+  'yahoo.com',
+  'ymail.com',
+  'zoho.com'
+]);
 const leadRequestBuckets = new Map<string, number[]>();
 
 type LeadDeliveryPayload = {
@@ -75,6 +100,12 @@ function trimOptional(value: unknown): string | undefined {
 
 function isValidEmail(email: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+function isWorkEmail(email: string): boolean {
+  const trimmed = email.trim().toLowerCase();
+  const domain = trimmed.split('@').pop() ?? '';
+  return isValidEmail(trimmed) && Boolean(domain) && !PERSONAL_EMAIL_DOMAINS.has(domain);
 }
 
 function badRequest(res: HandlerResponse, message: string) {
@@ -418,8 +449,8 @@ export default async function handler(
   const source = trimOptional(body.source) || 'unknown';
   const pagePath = trimOptional(body.page_path) || '/';
 
-  if (!email || !isValidEmail(email)) {
-    badRequest(res, 'Valid work email is required.');
+  if (!email || !isWorkEmail(email)) {
+    badRequest(res, WORK_EMAIL_ERROR);
     return;
   }
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -19,6 +19,7 @@
         "@lhci/cli": "0.15.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
+        "@types/node": "^24.12.4",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
@@ -1628,13 +1629,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/react": {
@@ -6268,9 +6269,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/web/package.json
+++ b/web/package.json
@@ -25,6 +25,7 @@
     "@lhci/cli": "0.15.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
+    "@types/node": "^24.12.4",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -140,6 +140,39 @@ describe('App', () => {
     expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument();
   });
 
+  it('rejects personal email domains before advancing the read-only scan intake', () => {
+    setCurrentPath('/read-only-scan');
+    const fetchMock = vi.fn(async () => okJSON({ status: 'accepted' }));
+    vi.stubGlobal('fetch', fetchMock);
+    render(<App />);
+
+    fireEvent.change(screen.getByLabelText(/Work email/i), {
+      target: { value: 'person@gmail.com' }
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/company or work email/i);
+    expect(screen.getByText(/Step 1 of 3/i)).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not submit the read-only scan intake before the final step', async () => {
+    setCurrentPath('/read-only-scan');
+    const fetchMock = vi.fn(async () => okJSON({ status: 'accepted' }));
+    vi.stubGlobal('fetch', fetchMock);
+    render(<App />);
+
+    fireEvent.change(screen.getByLabelText(/Work email/i), {
+      target: { value: 'security@company.com' }
+    });
+    const form = document.querySelector('form.idt-scan-form');
+    expect(form).toBeTruthy();
+    fireEvent.submit(form as HTMLFormElement);
+
+    await waitFor(() => expect(screen.getByText(/Step 2 of 3/i)).toBeInTheDocument());
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('submits read-only scan challenge details to lead capture', async () => {
     setCurrentPath('/read-only-scan');
     const fetchMock = vi.fn(async () => okJSON({ status: 'accepted' }));
@@ -147,7 +180,7 @@ describe('App', () => {
     render(<App />);
 
     fireEvent.change(screen.getByLabelText(/Work email/i), {
-      target: { value: 'security@example.com' }
+      target: { value: 'security@company.com' }
     });
     fireEvent.change(screen.getByLabelText(/Company/i), {
       target: { value: 'Example Co' }
@@ -159,7 +192,7 @@ describe('App', () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/leads', expect.any(Object)));
     const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     expect(JSON.parse(String(init.body))).toMatchObject({
-      email: 'security@example.com',
+      email: 'security@company.com',
       company: 'Example Co',
       environment: 'AWS IAM + Kubernetes',
       challenge: 'Trust path visibility',

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -65,8 +65,43 @@ const LINKEDIN_URL = 'https://www.linkedin.com/company/identrail/';
 const X_URL = 'https://x.com/identrail';
 const CALENDLY_URL = 'https://calendly.com/identrail/15min';
 const THEME_STORAGE_KEY = 'identrail-theme';
+const WORK_EMAIL_ERROR = 'Please use a company or work email address.';
+const PERSONAL_EMAIL_DOMAINS = new Set([
+  'aol.com',
+  'fastmail.com',
+  'gmail.com',
+  'gmx.com',
+  'gmx.net',
+  'googlemail.com',
+  'hey.com',
+  'hotmail.com',
+  'icloud.com',
+  'live.com',
+  'mac.com',
+  'mail.com',
+  'me.com',
+  'msn.com',
+  'outlook.com',
+  'pm.me',
+  'proton.me',
+  'protonmail.com',
+  'rocketmail.com',
+  'yahoo.com',
+  'ymail.com',
+  'zoho.com'
+]);
 let activeModalLocks = 0;
 let bodyOverflowBeforeModal = '';
+
+function isValidEmailAddress(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+function isWorkEmailAddress(email: string): boolean {
+  const trimmed = email.trim().toLowerCase();
+  const domain = trimmed.split('@').pop() ?? '';
+  return isValidEmailAddress(trimmed) && Boolean(domain) && !PERSONAL_EMAIL_DOMAINS.has(domain);
+}
 
 const NAV_LINKS = [
   { to: '/product', label: 'Product' },
@@ -960,8 +995,13 @@ function LeadCaptureForm({
     const challenge = String(formData.get('challenge') ?? '').trim();
     const website = String(formData.get('website') ?? '').trim();
 
-    setSubmitting(true);
     setError(null);
+    if (!isWorkEmailAddress(email)) {
+      setError(WORK_EMAIL_ERROR);
+      return;
+    }
+
+    setSubmitting(true);
 
     try {
       await apiClient.submitLeadCapture({
@@ -1033,11 +1073,11 @@ function LeadCaptureForm({
           <button type="submit" className="idt-btn idt-btn-primary" disabled={submitting}>
             {submitting ? 'Submitting...' : ctaLabel}
           </button>
-          {error ? <p className="idt-form-error">{error} If urgent, use Book Demo.</p> : null}
+          {error ? <p className="idt-form-error" role="alert">{error} If urgent, use Book Demo.</p> : null}
           <p className="idt-form-note">Receive a practical 30-day machine identity risk reduction plan.</p>
         </form>
       ) : (
-        <p className="idt-form-success">Thanks. We will send your machine identity risk reduction plan within one business day.</p>
+        <p className="idt-form-success">Request sent. The Identrail team will follow up by email with the risk reduction plan.</p>
       )}
     </section>
   );
@@ -1976,11 +2016,39 @@ function ReadOnlyScanPage() {
     path: '/read-only-scan'
   });
 
+  const validateWorkEmail = (form?: HTMLFormElement | null) => {
+    if (form && !form.reportValidity()) {
+      return false;
+    }
+    if (!isWorkEmailAddress(email)) {
+      setError(WORK_EMAIL_ERROR);
+      return false;
+    }
+    setError(null);
+    return true;
+  };
+
+  const advanceStep = (form?: HTMLFormElement | null) => {
+    if (step === 1 && !validateWorkEmail(form)) {
+      return;
+    }
+    setError(null);
+    setStep((value) => Math.min(3, value + 1));
+  };
+
   const submitIntake = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (submitting) {
       return;
     }
+    if (step < 3) {
+      advanceStep(event.currentTarget);
+      return;
+    }
+    if (!validateWorkEmail(event.currentTarget)) {
+      return;
+    }
+
     const formData = new FormData(event.currentTarget);
     const website = String(formData.get('website') ?? '').trim();
 
@@ -2076,7 +2144,12 @@ function ReadOnlyScanPage() {
                       required
                       type="email"
                       value={email}
-                      onChange={(event) => setEmail(event.target.value)}
+                      onChange={(event) => {
+                        setEmail(event.target.value);
+                        if (error === WORK_EMAIL_ERROR) {
+                          setError(null);
+                        }
+                      }}
                       placeholder="you@company.com"
                       autoComplete="email"
                     />
@@ -2156,7 +2229,7 @@ function ReadOnlyScanPage() {
                 </div>
               ) : null}
 
-              {error ? <p className="idt-form-error">{error}</p> : null}
+              {error ? <p className="idt-form-error" role="alert">{error}</p> : null}
 
               <div className="idt-inline-actions">
                 {step > 1 ? (
@@ -2169,11 +2242,7 @@ function ReadOnlyScanPage() {
                     type="button"
                     className="idt-btn idt-btn-primary"
                     onClick={(event) => {
-                      const form = event.currentTarget.form;
-                      if (step === 1 && form && !form.reportValidity()) {
-                        return;
-                      }
-                      setStep((value) => Math.min(3, value + 1));
+                      advanceStep(event.currentTarget.form);
                     }}
                   >
                     Continue
@@ -2188,7 +2257,7 @@ function ReadOnlyScanPage() {
           ) : (
             <div className="idt-intake-confirmation">
               <h3>Intake submitted</h3>
-              <p>Thanks. We will send your first read-only scan onboarding response within one business day.</p>
+              <p>Your read-only scan intake was sent to the Identrail team. We will follow up by email with the next step.</p>
               <div className="idt-inline-actions">
                 <Link to="/demo" className="idt-btn idt-btn-dark">
                   Book Demo


### PR DESCRIPTION
Fixes #1194

## What changed
- Blocks common personal email domains on the read-only scan intake and shared lead capture forms before submission.
- Prevents the multi-step scan form from submitting before step 3, including accidental Enter-key submits.
- Mirrors work-email validation in the `/api/leads` handler and adds direct `@types/node` coverage for the Vercel API route.
- Replaces placeholder-style success copy with a concrete submitted-to-team message.

## Why it changed
The live page could feel like a placeholder because the form allowed early submit behavior and accepted consumer email domains even though the field promises a work email.

## Impact and risk
Low risk. The change is scoped to public lead capture validation and the read-only scan intake UX. Common personal domains now receive a clear validation error.

## Validation performed
- `npm test -- --run api/leads.test.ts src/App.test.tsx`
- `npm exec -- tsc --noEmit --ignoreConfig --types node --moduleResolution Bundler --module ESNext --target ES2020 --lib ES2020,DOM api/leads.ts`
- `npm run build`
- Browser sanity check on `http://127.0.0.1:5174/read-only-scan`: personal email blocked on step 1, company email advanced to step 2, final submit button appeared only on step 3.

AI-assisted: yes
Tools used: OpenAI Codex
Where used: public intake validation, lead API validation, tests
Human verification performed: reviewed diff, ran focused tests, API type-check, production build, and browser sanity check
