### PR TITLE
Sync Vercel connector feature flags

### DIFF
--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -92,16 +92,33 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VITE_IDENTRAIL_API_URL: ${{ steps.check-api-url.outputs.api_url }}
           VITE_FEATURE_ONBOARDING_WIZARD: ${{ vars.VITE_FEATURE_ONBOARDING_WIZARD || 'true' }}
+          VITE_FEATURE_CONNECTOR_AWS: ${{ vars.VITE_FEATURE_CONNECTOR_AWS || 'false' }}
+          VITE_FEATURE_CONNECTOR_GITHUB_V2: ${{ vars.VITE_FEATURE_CONNECTOR_GITHUB_V2 || 'false' }}
+          VITE_FEATURE_CONNECTOR_K8S: ${{ vars.VITE_FEATURE_CONNECTOR_K8S || 'false' }}
         run: |
           set -euo pipefail
-          onboarding_flag="$(printf '%s' "${VITE_FEATURE_ONBOARDING_WIZARD}" | tr -d '\r\n' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-          case "${onboarding_flag}" in
-            true|false) ;;
-            *)
-              echo "VITE_FEATURE_ONBOARDING_WIZARD must be true or false; got ${onboarding_flag}." >&2
-              exit 1
-              ;;
-          esac
+
+          normalize_bool_flag() {
+            local key="$1"
+            local value="$2"
+            local normalized
+
+            normalized="$(printf '%s' "${value}" | tr -d '\r\n' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+            case "${normalized}" in
+              true|false)
+                printf '%s' "${normalized}"
+                ;;
+              *)
+                echo "${key} must be true or false; got ${normalized}." >&2
+                exit 1
+                ;;
+            esac
+          }
+
+          onboarding_flag="$(normalize_bool_flag "VITE_FEATURE_ONBOARDING_WIZARD" "${VITE_FEATURE_ONBOARDING_WIZARD}")"
+          connector_aws_flag="$(normalize_bool_flag "VITE_FEATURE_CONNECTOR_AWS" "${VITE_FEATURE_CONNECTOR_AWS}")"
+          connector_github_flag="$(normalize_bool_flag "VITE_FEATURE_CONNECTOR_GITHUB_V2" "${VITE_FEATURE_CONNECTOR_GITHUB_V2}")"
+          connector_k8s_flag="$(normalize_bool_flag "VITE_FEATURE_CONNECTOR_K8S" "${VITE_FEATURE_CONNECTOR_K8S}")"
 
           upsert_env() {
             local key="$1"
@@ -137,6 +154,18 @@ jobs:
             "VITE_FEATURE_ONBOARDING_WIZARD" \
             "${onboarding_flag}" \
             "Enable self-serve onboarding for Identrail Cloud production builds"
+          upsert_env \
+            "VITE_FEATURE_CONNECTOR_AWS" \
+            "${connector_aws_flag}" \
+            "Enable the AWS connector UI for Identrail Cloud production builds"
+          upsert_env \
+            "VITE_FEATURE_CONNECTOR_GITHUB_V2" \
+            "${connector_github_flag}" \
+            "Enable the GitHub connector UI for Identrail Cloud production builds"
+          upsert_env \
+            "VITE_FEATURE_CONNECTOR_K8S" \
+            "${connector_k8s_flag}" \
+            "Enable the Kubernetes connector UI for Identrail Cloud production builds"
 
       - name: Deploy to Vercel
         id: deploy-action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## Unreleased
+- Kept Vercel production connector UI flags in sync with GitHub Actions
+  variables: the production deploy workflow now validates and upserts
+  `VITE_FEATURE_CONNECTOR_AWS`, `VITE_FEATURE_CONNECTOR_GITHUB_V2`, and
+  `VITE_FEATURE_CONNECTOR_K8S` before building so an enabled API connector does
+  not appear as "not included in this web build" after redeploys.
 - Added the first GitHub repository scan action after connection:
   - the product source screen can queue `POST /v1/repo-scans` for a selected
     GitHub repository, show queued/running/completed/failed activity, and link

--- a/docs/frontend-topology.md
+++ b/docs/frontend-topology.md
@@ -12,7 +12,7 @@ Identrail uses `web/` as the active tracked frontend on `dev`.
 - Typical runtime: containerized deployment (`deploy/docker/Dockerfile.web`, optional Helm `web.enabled`)
 - API URL input: `VITE_IDENTRAIL_API_URL`
 - Self-serve onboarding input: `VITE_FEATURE_ONBOARDING_WIZARD=true`
-- Vercel (marketing/demo deploy): Identrail Cloud domains default to `https://api.identrail.com`; custom domains should set `VITE_IDENTRAIL_API_URL` in Vercel project environment variables or as a GitHub Actions variable so the deploy workflow upserts it. Identrail Cloud production deploys also upsert `VITE_FEATURE_ONBOARDING_WIZARD`, defaulting to `true`, so authenticated users without a workspace enter `/onboarding/org`.
+- Vercel (marketing/demo deploy): Identrail Cloud domains default to `https://api.identrail.com`; custom domains should set `VITE_IDENTRAIL_API_URL` in Vercel project environment variables or as a GitHub Actions variable so the deploy workflow upserts it. Identrail Cloud production deploys also upsert `VITE_FEATURE_ONBOARDING_WIZARD`, defaulting to `true`, and the connector build flags (`VITE_FEATURE_CONNECTOR_AWS`, `VITE_FEATURE_CONNECTOR_GITHUB_V2`, `VITE_FEATURE_CONNECTOR_K8S`), defaulting to `false`, so the web bundle cannot drift from the intended connector launch state.
 - Production deploys should be triggered from `dev` (example: `make vercel-prod-deploy` / `task vercel-prod-deploy`) to avoid accidentally deploying from a stale local branch.
 
 ### `VITE_IDENTRAIL_API_URL` value source
@@ -42,6 +42,27 @@ VITE_FEATURE_ONBOARDING_WIZARD=true
 ```
 
 The token-based Vercel production deploy workflow upserts this value before the deploy action runs. It defaults to `true` for Identrail Cloud and reads the repository variable `VITE_FEATURE_ONBOARDING_WIZARD` when an operator needs to set the matching web rollback value to `false`. If the workflow falls back to a deploy hook, GitHub Actions cannot update Vercel project env values; keep `VITE_FEATURE_ONBOARDING_WIZARD=true` configured directly in Vercel before using hook-only deploys, or flip that Vercel value directly during rollback.
+
+### Connector web flags
+
+Connector UI availability is a two-sided contract:
+
+```text
+IDENTRAIL_FEATURE_CONNECTOR_GITHUB_V2=true
+VITE_FEATURE_CONNECTOR_GITHUB_V2=true
+```
+
+The API advertises backend availability through `/v1/auth/config`, but the Vercel web bundle must also be built with the matching `VITE_FEATURE_CONNECTOR_*` flag. Otherwise the onboarding connector card renders as "not included in this web build" even when the API can serve the connector route.
+
+For Identrail Cloud production deploys, configure GitHub Actions variables for each connector flag:
+
+```text
+VITE_FEATURE_CONNECTOR_AWS=false
+VITE_FEATURE_CONNECTOR_GITHUB_V2=true
+VITE_FEATURE_CONNECTOR_K8S=false
+```
+
+The Vercel production deploy workflow validates these values as `true`/`false` and upserts them into the Vercel project before building. Missing connector variables default to `false`.
 
 For token-based Vercel deployments, if the GitHub Actions variable is missing, the production deploy workflow uses the Identrail Cloud default and upserts `VITE_IDENTRAIL_API_URL=https://api.identrail.com` into Vercel. Hook-only fallback deployments cannot upsert or inspect Vercel project env values from GitHub Actions, so the runtime fallback still protects the canonical Identrail Cloud domains while custom domains must keep `VITE_IDENTRAIL_API_URL` configured directly in Vercel.
 


### PR DESCRIPTION
Fixes #1191

## What changed

- Updated the Vercel production deploy workflow to read connector web feature flags from GitHub Actions variables.
- Added strict `true`/`false` validation for `VITE_FEATURE_CONNECTOR_AWS`, `VITE_FEATURE_CONNECTOR_GITHUB_V2`, and `VITE_FEATURE_CONNECTOR_K8S` before deploy.
- Upserts the connector flags into Vercel alongside `VITE_IDENTRAIL_API_URL` and `VITE_FEATURE_ONBOARDING_WIZARD`.
- Documented the two-sided backend/web connector flag contract and added a changelog entry.

## Why

The production API can correctly advertise an enabled connector while the Vercel web bundle still hides it if the matching `VITE_FEATURE_CONNECTOR_*` variable is missing at build time. That is what made the onboarding GitHub card render as `Not included in this web build` even after the API was fixed.

## Impact and risk

This keeps future Vercel production deploys from regressing connector onboarding due to missing web build flags. Defaults remain conservative: missing connector variables resolve to `false`, while onboarding keeps the existing Identrail Cloud default of `true`.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/vercel-production-deploy.yml"); puts "yaml-ok"'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/vercel-production-deploy.yml`
- Commit hooks: merge conflict check, YAML check, EOF check, trailing whitespace, gofmt check, Vercel artifact hygiene
- Push hooks: merge conflict check, YAML check, EOF check, trailing whitespace, gofmt check, `go vet`, local env token hygiene, Vercel artifact hygiene

AI-assisted: yes
Tools used: Codex
Where used: workflow/docs/changelog patching and validation
Human verification performed: reviewed diff and ran the validation listed above


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs Vercel production deploys with connector web flags from GitHub Actions variables to prevent “not included in this web build” drift. Validates and upserts `VITE_FEATURE_CONNECTOR_*` so enabled API connectors show up in the UI.

- **Bug Fixes**
  - Reads and enforces `true`/`false` for `VITE_FEATURE_CONNECTOR_AWS`, `VITE_FEATURE_CONNECTOR_GITHUB_V2`, `VITE_FEATURE_CONNECTOR_K8S`, and `VITE_FEATURE_ONBOARDING_WIZARD`.
  - Upserts these flags into Vercel with `VITE_IDENTRAIL_API_URL`; defaults: connectors `false`, onboarding `true`.
  - Documented the backend/web flag contract and updated the changelog.

<sup>Written for commit 0891e8c7068d6fda4bcfba00073abf6ab5570fa2. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1193?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

