### PR TITLE
Require reviewed read-only scan submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Required explicit review before read-only scan intake submission and added
+  stronger lead-quality checks for work emails, disposable domains, matching
+  company websites, and publicly verifiable company DNS.
 - Failed closed when the API does not explicitly advertise self-serve
   onboarding support, so authenticated users without a workspace see the
   existing onboarding-unavailable state instead of entering a wizard that

--- a/web/api/leads.test.ts
+++ b/web/api/leads.test.ts
@@ -1,5 +1,17 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resolve4, resolve6, resolveMx } from 'node:dns/promises';
 import handler, { __resetLeadRequestBucketsForTests } from './leads';
+
+const dnsMocks = vi.hoisted(() => ({
+  resolve4: vi.fn(async () => ['203.0.113.10']),
+  resolve6: vi.fn(async () => []),
+  resolveMx: vi.fn(async () => [])
+}));
+
+vi.mock('node:dns/promises', () => ({
+  ...dnsMocks,
+  default: dnsMocks
+}));
 
 type MockResponse = {
   statusCode: number;
@@ -22,6 +34,24 @@ function createMockResponse(): MockResponse {
   };
 }
 
+const resolve4Mock = vi.mocked(resolve4);
+const resolve6Mock = vi.mocked(resolve6);
+const resolveMxMock = vi.mocked(resolveMx);
+
+function mockCompanyDomainDNS(hasRecords = true) {
+  resolve4Mock.mockReset();
+  resolve6Mock.mockReset();
+  resolveMxMock.mockReset();
+
+  if (hasRecords) {
+    resolve4Mock.mockResolvedValue(['203.0.113.10']);
+  } else {
+    resolve4Mock.mockRejectedValue(new Error('not found'));
+  }
+  resolve6Mock.mockRejectedValue(new Error('not found'));
+  resolveMxMock.mockRejectedValue(new Error('not found'));
+}
+
 describe('web/api/leads handler', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -37,6 +67,7 @@ describe('web/api/leads handler', () => {
     delete process.env.LEAD_WEBHOOK_HMAC_SECRET;
     delete process.env.LEAD_WEBHOOK_TIMEOUT_MS;
     delete process.env.LEAD_CAPTURE_RATE_LIMIT_PER_MIN;
+    mockCompanyDomainDNS(true);
     __resetLeadRequestBucketsForTests();
   });
 
@@ -81,6 +112,87 @@ describe('web/api/leads handler', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('rejects disposable bot email domains before delivery', async () => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = createMockResponse();
+    await handler(
+      {
+        method: 'POST',
+        body: {
+          email: 'person@mailinator.com',
+          environment: 'AWS IAM'
+        }
+      },
+      res
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 'Please use a company or work email address.' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('requires a matching company domain for read-only scan requests', async () => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = createMockResponse();
+    await handler(
+      {
+        method: 'POST',
+        body: {
+          email: 'security@company.com',
+          company: 'Company Inc',
+          company_domain: 'other-company.com',
+          environment: 'AWS IAM',
+          source: 'Read-Only Scan Intake',
+          page_path: '/read-only-scan'
+        }
+      },
+      res
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 'Company website must match the domain in your work email.' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects read-only scan company domains without public DNS records', async () => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    mockCompanyDomainDNS(false);
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = createMockResponse();
+    await handler(
+      {
+        method: 'POST',
+        body: {
+          email: 'security@company.com',
+          company: 'Company Inc',
+          company_domain: 'company.com',
+          environment: 'AWS IAM',
+          source: 'Read-Only Scan Intake',
+          page_path: '/read-only-scan'
+        }
+      },
+      res
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 'Company website must be a registered domain with public DNS records.' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('returns 503 when no lead delivery channel is configured', async () => {
     const res = createMockResponse();
     await handler(
@@ -88,6 +200,8 @@ describe('web/api/leads handler', () => {
         method: 'POST',
         body: {
           email: 'security@company.com',
+          company: 'Company Inc',
+          company_domain: 'company.com',
           environment: 'AWS IAM + Kubernetes',
           deployment_model: 'Hosted SaaS',
           urgency: 'This quarter',
@@ -278,6 +392,7 @@ describe('web/api/leads handler', () => {
         body: {
           email: 'security@company.com',
           company: 'Acme Corp',
+          company_domain: 'company.com',
           environment: 'AWS IAM + Kubernetes',
           challenge: 'Trust path visibility',
           deployment_model: 'Hosted SaaS',
@@ -435,6 +550,8 @@ describe('web/api/leads handler', () => {
         method: 'POST',
         body: {
           email: 'security@company.com',
+          company: 'Company Inc',
+          company_domain: 'company.com',
           environment: 'AWS IAM + Kubernetes',
           source: 'Read-Only Scan Intake',
           page_path: '/read-only-scan'
@@ -527,6 +644,8 @@ describe('web/api/leads handler', () => {
         method: 'POST',
         body: {
           email: 'security@company.com',
+          company: 'Company Inc',
+          company_domain: 'company.com',
           environment: 'AWS IAM + Kubernetes',
           challenge: 'Trust path visibility',
           deployment_model: 'Hosted SaaS',

--- a/web/api/leads.test.ts
+++ b/web/api/leads.test.ts
@@ -193,6 +193,45 @@ describe('web/api/leads handler', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('treats a stalled DNS resolver as no public records instead of hanging', async () => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    resolve4Mock.mockReset();
+    resolve6Mock.mockReset();
+    resolveMxMock.mockReset();
+    const never = new Promise<string[]>(() => {});
+    resolve4Mock.mockReturnValue(never);
+    resolve6Mock.mockReturnValue(never);
+    resolveMxMock.mockReturnValue(never);
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.useFakeTimers();
+
+    const res = createMockResponse();
+    const pending = handler(
+      {
+        method: 'POST',
+        body: {
+          email: 'security@company.com',
+          company: 'Company Inc',
+          company_domain: 'company.com',
+          environment: 'AWS IAM',
+          source: 'Read-Only Scan Intake',
+          page_path: '/read-only-scan'
+        }
+      },
+      res
+    );
+    await vi.advanceTimersByTimeAsync(2_000);
+    await pending;
+    vi.useRealTimers();
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 'Company website must be a registered domain with public DNS records.' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('returns 503 when no lead delivery channel is configured', async () => {
     const res = createMockResponse();
     await handler(

--- a/web/api/leads.ts
+++ b/web/api/leads.ts
@@ -180,8 +180,30 @@ function companyDomainMatchesEmail(email: string, companyDomain: string): boolea
   );
 }
 
+const DNS_LOOKUP_TIMEOUT_MS = 2_000;
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('DNS lookup timeout')), timeoutMs);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      }
+    );
+  });
+}
+
 async function hasPublicDNSRecords(domain: string): Promise<boolean> {
-  const lookups = [resolveMx(domain), resolve4(domain), resolve6(domain)];
+  // Bound each resolver call so a slow/unresponsive DNS server cannot stall
+  // lead submission and degrade overall API responsiveness.
+  const lookups = [resolveMx(domain), resolve4(domain), resolve6(domain)].map((lookup) =>
+    withTimeout(lookup, DNS_LOOKUP_TIMEOUT_MS)
+  );
   const results = await Promise.allSettled(lookups);
   return results.some((result) => result.status === 'fulfilled' && result.value.length > 0);
 }

--- a/web/api/leads.ts
+++ b/web/api/leads.ts
@@ -1,9 +1,12 @@
 import { createHmac, randomUUID } from 'node:crypto';
+import { resolve4, resolve6, resolveMx } from 'node:dns/promises';
+import { isIP } from 'node:net';
 
 type LeadCapturePayload = {
   email?: string;
   environment?: string;
   company?: string;
+  company_domain?: string;
   challenge?: string;
   website?: string;
   deployment_model?: string;
@@ -27,6 +30,7 @@ const RATE_WINDOW_MS = 60_000;
 const MAX_EMAIL_LENGTH = 254;
 const MAX_ENVIRONMENT_LENGTH = 180;
 const MAX_COMPANY_LENGTH = 120;
+const MAX_COMPANY_DOMAIN_LENGTH = 253;
 const MAX_CHALLENGE_LENGTH = 2_000;
 const MAX_SCAN_GOAL_LENGTH = 600;
 const MAX_SOURCE_LENGTH = 120;
@@ -36,6 +40,9 @@ const MAX_URGENCY_LENGTH = 32;
 const MAX_DEPLOYMENT_MODEL_LENGTH = 64;
 const RESEND_EMAILS_URL = 'https://api.resend.com/emails';
 const WORK_EMAIL_ERROR = 'Please use a company or work email address.';
+const COMPANY_DOMAIN_ERROR = 'Please enter a real company website or domain.';
+const COMPANY_DOMAIN_MATCH_ERROR = 'Company website must match the domain in your work email.';
+const COMPANY_DOMAIN_VERIFICATION_ERROR = 'Company website must be a registered domain with public DNS records.';
 const PERSONAL_EMAIL_DOMAINS = new Set([
   'aol.com',
   'fastmail.com',
@@ -60,12 +67,32 @@ const PERSONAL_EMAIL_DOMAINS = new Set([
   'ymail.com',
   'zoho.com'
 ]);
+const DISPOSABLE_EMAIL_DOMAINS = new Set([
+  '10minutemail.com',
+  'dispostable.com',
+  'emailondeck.com',
+  'fakeinbox.com',
+  'getnada.com',
+  'guerrillamail.com',
+  'maildrop.cc',
+  'mailinator.com',
+  'moakt.com',
+  'mytemp.email',
+  'sharklasers.com',
+  'temp-mail.org',
+  'tempmail.com',
+  'throwawaymail.com',
+  'trashmail.com',
+  'yopmail.com'
+]);
+const RESERVED_COMPANY_DOMAINS = new Set(['example.com', 'example.net', 'example.org', 'invalid', 'localhost', 'test']);
 const leadRequestBuckets = new Map<string, number[]>();
 
 type LeadDeliveryPayload = {
   email: string;
   environment: string;
   company?: string;
+  company_domain?: string;
   challenge?: string;
   deployment_model?: string;
   scan_goal?: string;
@@ -102,10 +129,61 @@ function isValidEmail(email: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 }
 
+function emailDomain(email: string): string {
+  return email.trim().toLowerCase().split('@').pop() ?? '';
+}
+
+function isBlockedLeadDomain(domain: string): boolean {
+  return PERSONAL_EMAIL_DOMAINS.has(domain) || DISPOSABLE_EMAIL_DOMAINS.has(domain) || RESERVED_COMPANY_DOMAINS.has(domain);
+}
+
 function isWorkEmail(email: string): boolean {
   const trimmed = email.trim().toLowerCase();
-  const domain = trimmed.split('@').pop() ?? '';
-  return isValidEmail(trimmed) && Boolean(domain) && !PERSONAL_EMAIL_DOMAINS.has(domain);
+  const domain = emailDomain(trimmed);
+  return isValidEmail(trimmed) && Boolean(domain) && !isBlockedLeadDomain(domain);
+}
+
+function normalizeCompanyDomainInput(value: string | undefined): string {
+  const raw = value?.trim().toLowerCase() ?? '';
+  if (!raw || /\s/.test(raw)) {
+    return '';
+  }
+  const candidate = raw.includes('://') ? raw : `https://${raw}`;
+  let hostname = '';
+  try {
+    hostname = new URL(candidate).hostname.toLowerCase().replace(/\.$/, '');
+  } catch {
+    return '';
+  }
+  if (hostname.startsWith('www.')) {
+    hostname = hostname.slice(4);
+  }
+  if (
+    hostname.length > 253 ||
+    !hostname.includes('.') ||
+    isIP(hostname) !== 0 ||
+    !/^[a-z0-9.-]+$/.test(hostname) ||
+    hostname.split('.').some((label) => !label || label.length > 63 || label.startsWith('-') || label.endsWith('-')) ||
+    isBlockedLeadDomain(hostname)
+  ) {
+    return '';
+  }
+  return hostname;
+}
+
+function companyDomainMatchesEmail(email: string, companyDomain: string): boolean {
+  const domain = emailDomain(email);
+  return Boolean(
+    domain &&
+      companyDomain &&
+      (domain === companyDomain || domain.endsWith(`.${companyDomain}`) || companyDomain.endsWith(`.${domain}`))
+  );
+}
+
+async function hasPublicDNSRecords(domain: string): Promise<boolean> {
+  const lookups = [resolveMx(domain), resolve4(domain), resolve6(domain)];
+  const results = await Promise.allSettled(lookups);
+  return results.some((result) => result.status === 'fulfilled' && result.value.length > 0);
 }
 
 function badRequest(res: HandlerResponse, message: string) {
@@ -243,6 +321,7 @@ function leadRows(payload: LeadDeliveryPayload): Array<[string, string | undefin
   return [
     ['Work email', payload.email],
     ['Company', payload.company],
+    ['Company domain', payload.company_domain],
     ['Environment', payload.environment],
     ['Challenge', payload.challenge],
     ['Deployment model', payload.deployment_model],
@@ -294,6 +373,7 @@ function renderConfirmationText(payload: LeadDeliveryPayload): string {
     'We received your intake and will review the context before following up.',
     '',
     `Environment: ${payload.environment}`,
+    `Company domain: ${payload.company_domain || 'Not provided'}`,
     `Focus area: ${payload.challenge || 'Trust path visibility'}`,
     `Deployment preference: ${payload.deployment_model || 'Not provided'}`,
     '',
@@ -308,6 +388,7 @@ function renderConfirmationHTML(payload: LeadDeliveryPayload): string {
       <p style="margin:0 0 16px;">Thanks for requesting a read-only machine identity risk scan. We will review the context before following up.</p>
       <ul style="padding-left:20px;margin:0 0 16px;color:#374151;">
         <li><strong>Environment:</strong> ${escapeHTML(payload.environment)}</li>
+        <li><strong>Company domain:</strong> ${escapeHTML(payload.company_domain || 'Not provided')}</li>
         <li><strong>Focus area:</strong> ${escapeHTML(payload.challenge || 'Trust path visibility')}</li>
         <li><strong>Deployment preference:</strong> ${escapeHTML(payload.deployment_model || 'Not provided')}</li>
       </ul>
@@ -443,11 +524,18 @@ export default async function handler(
   const email = trimOptional(body.email) ?? '';
   const environment = trimOptional(body.environment) ?? '';
   const company = trimOptional(body.company);
+  const companyDomain = normalizeCompanyDomainInput(body.company_domain);
   const challenge = trimOptional(body.challenge);
   const website = trimOptional(body.website);
   const scanGoal = trimOptional(body.scan_goal);
   const source = trimOptional(body.source) || 'unknown';
   const pagePath = trimOptional(body.page_path) || '/';
+  const requiresCompanyDomain = source === 'Read-Only Scan Intake' || pagePath === '/read-only-scan';
+
+  if (website) {
+    res.status(202).json({ status: 'accepted' });
+    return;
+  }
 
   if (!email || !isWorkEmail(email)) {
     badRequest(res, WORK_EMAIL_ERROR);
@@ -456,6 +544,18 @@ export default async function handler(
 
   if (!environment) {
     badRequest(res, 'Environment is required.');
+    return;
+  }
+  if (requiresCompanyDomain && !company) {
+    badRequest(res, 'Company name is required.');
+    return;
+  }
+  if (requiresCompanyDomain && !companyDomain) {
+    badRequest(res, COMPANY_DOMAIN_ERROR);
+    return;
+  }
+  if (companyDomain && !companyDomainMatchesEmail(email, companyDomain)) {
+    badRequest(res, COMPANY_DOMAIN_MATCH_ERROR);
     return;
   }
 
@@ -468,6 +568,9 @@ export default async function handler(
   if (company && !assertLength(res, company, MAX_COMPANY_LENGTH, 'Company value is too long.')) {
     return;
   }
+  if (companyDomain && !assertLength(res, companyDomain, MAX_COMPANY_DOMAIN_LENGTH, 'Company domain value is too long.')) {
+    return;
+  }
   if (challenge && !assertLength(res, challenge, MAX_CHALLENGE_LENGTH, 'Challenge value is too long.')) {
     return;
   }
@@ -478,11 +581,6 @@ export default async function handler(
     return;
   }
   if (!assertLength(res, pagePath, MAX_PAGE_PATH_LENGTH, 'Page path value is too long.')) {
-    return;
-  }
-
-  if (website) {
-    res.status(202).json({ status: 'accepted' });
     return;
   }
 
@@ -500,11 +598,16 @@ export default async function handler(
   if (teamSize && !assertLength(res, teamSize, MAX_TEAM_SIZE_LENGTH, 'Team size value is too long.')) {
     return;
   }
+  if (requiresCompanyDomain && !(await hasPublicDNSRecords(companyDomain))) {
+    badRequest(res, COMPANY_DOMAIN_VERIFICATION_ERROR);
+    return;
+  }
 
   const payload: LeadDeliveryPayload = {
     email,
     environment,
     company,
+    company_domain: companyDomain || undefined,
     challenge,
     deployment_model: deploymentModel && ALLOWED_DEPLOYMENT_MODELS.has(deploymentModel) ? deploymentModel : undefined,
     scan_goal: scanGoal,

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -184,6 +184,28 @@ describe('App', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('rejects a whitespace-only company name before advancing', () => {
+    setCurrentPath('/read-only-scan');
+    const fetchMock = vi.fn(async () => okJSON({ status: 'accepted' }));
+    vi.stubGlobal('fetch', fetchMock);
+    render(<App />);
+
+    fireEvent.change(screen.getByLabelText(/Work email/i), {
+      target: { value: 'security@company.com' }
+    });
+    fireEvent.change(screen.getByLabelText(/Company name/i), {
+      target: { value: '   ' }
+    });
+    fireEvent.change(screen.getByLabelText(/Company website/i), {
+      target: { value: 'company.com' }
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/enter your company name/i);
+    expect(screen.getByText(/Step 1 of 4/i)).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('does not submit the read-only scan intake before the final step', async () => {
     setCurrentPath('/read-only-scan');
     const fetchMock = vi.fn(async () => okJSON({ status: 'accepted' }));

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -136,7 +136,7 @@ describe('App', () => {
       })
     ).toBeInTheDocument();
 
-    expect(screen.getByText(/Step 1 of 3/i)).toBeInTheDocument();
+    expect(screen.getByText(/Step 1 of 4/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument();
   });
 
@@ -149,10 +149,38 @@ describe('App', () => {
     fireEvent.change(screen.getByLabelText(/Work email/i), {
       target: { value: 'person@gmail.com' }
     });
+    fireEvent.change(screen.getByLabelText(/Company name/i), {
+      target: { value: 'Personal Co' }
+    });
+    fireEvent.change(screen.getByLabelText(/Company website/i), {
+      target: { value: 'company.com' }
+    });
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
 
     expect(screen.getByRole('alert')).toHaveTextContent(/company or work email/i);
-    expect(screen.getByText(/Step 1 of 3/i)).toBeInTheDocument();
+    expect(screen.getByText(/Step 1 of 4/i)).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects company domains that do not match the work email domain', () => {
+    setCurrentPath('/read-only-scan');
+    const fetchMock = vi.fn(async () => okJSON({ status: 'accepted' }));
+    vi.stubGlobal('fetch', fetchMock);
+    render(<App />);
+
+    fireEvent.change(screen.getByLabelText(/Work email/i), {
+      target: { value: 'security@company.com' }
+    });
+    fireEvent.change(screen.getByLabelText(/Company name/i), {
+      target: { value: 'Company Inc' }
+    });
+    fireEvent.change(screen.getByLabelText(/Company website/i), {
+      target: { value: 'other-company.com' }
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/match the domain/i);
+    expect(screen.getByText(/Step 1 of 4/i)).toBeInTheDocument();
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -165,11 +193,17 @@ describe('App', () => {
     fireEvent.change(screen.getByLabelText(/Work email/i), {
       target: { value: 'security@company.com' }
     });
+    fireEvent.change(screen.getByLabelText(/Company name/i), {
+      target: { value: 'Company Inc' }
+    });
+    fireEvent.change(screen.getByLabelText(/Company website/i), {
+      target: { value: 'company.com' }
+    });
     const form = document.querySelector('form.idt-scan-form');
     expect(form).toBeTruthy();
     fireEvent.submit(form as HTMLFormElement);
 
-    await waitFor(() => expect(screen.getByText(/Step 2 of 3/i)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/Step 2 of 4/i)).toBeInTheDocument());
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -182,18 +216,28 @@ describe('App', () => {
     fireEvent.change(screen.getByLabelText(/Work email/i), {
       target: { value: 'security@company.com' }
     });
-    fireEvent.change(screen.getByLabelText(/Company/i), {
-      target: { value: 'Example Co' }
+    fireEvent.change(screen.getByLabelText(/Company name/i), {
+      target: { value: 'Company Inc' }
+    });
+    fireEvent.change(screen.getByLabelText(/Company website/i), {
+      target: { value: 'https://www.company.com' }
     });
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Start Free Risk Scan' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Review Request' }));
+    expect(screen.getByText(/Step 4 of 4/i)).toBeInTheDocument();
+    expect(screen.getByText('security@company.com')).toBeInTheDocument();
+    expect(screen.getByText('company.com')).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Risk Scan Request' }));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/leads', expect.any(Object)));
     const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     expect(JSON.parse(String(init.body))).toMatchObject({
       email: 'security@company.com',
-      company: 'Example Co',
+      company: 'Company Inc',
+      company_domain: 'company.com',
       environment: 'AWS IAM + Kubernetes',
       challenge: 'Trust path visibility',
       page_path: '/read-only-scan'

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -65,7 +65,10 @@ const LINKEDIN_URL = 'https://www.linkedin.com/company/identrail/';
 const X_URL = 'https://x.com/identrail';
 const CALENDLY_URL = 'https://calendly.com/identrail/15min';
 const THEME_STORAGE_KEY = 'identrail-theme';
+const INTAKE_TOTAL_STEPS = 4;
 const WORK_EMAIL_ERROR = 'Please use a company or work email address.';
+const COMPANY_DOMAIN_ERROR = 'Please enter a real company website or domain.';
+const COMPANY_DOMAIN_MATCH_ERROR = 'Company website must match the domain in your work email.';
 const PERSONAL_EMAIL_DOMAINS = new Set([
   'aol.com',
   'fastmail.com',
@@ -90,6 +93,25 @@ const PERSONAL_EMAIL_DOMAINS = new Set([
   'ymail.com',
   'zoho.com'
 ]);
+const DISPOSABLE_EMAIL_DOMAINS = new Set([
+  '10minutemail.com',
+  'dispostable.com',
+  'emailondeck.com',
+  'fakeinbox.com',
+  'getnada.com',
+  'guerrillamail.com',
+  'maildrop.cc',
+  'mailinator.com',
+  'moakt.com',
+  'mytemp.email',
+  'sharklasers.com',
+  'temp-mail.org',
+  'tempmail.com',
+  'throwawaymail.com',
+  'trashmail.com',
+  'yopmail.com'
+]);
+const RESERVED_COMPANY_DOMAINS = new Set(['example.com', 'example.net', 'example.org', 'invalid', 'localhost', 'test']);
 let activeModalLocks = 0;
 let bodyOverflowBeforeModal = '';
 
@@ -97,10 +119,57 @@ function isValidEmailAddress(email: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 }
 
+function emailDomain(email: string): string {
+  return email.trim().toLowerCase().split('@').pop() ?? '';
+}
+
+function isBlockedLeadDomain(domain: string): boolean {
+  return PERSONAL_EMAIL_DOMAINS.has(domain) || DISPOSABLE_EMAIL_DOMAINS.has(domain) || RESERVED_COMPANY_DOMAINS.has(domain);
+}
+
 function isWorkEmailAddress(email: string): boolean {
   const trimmed = email.trim().toLowerCase();
-  const domain = trimmed.split('@').pop() ?? '';
-  return isValidEmailAddress(trimmed) && Boolean(domain) && !PERSONAL_EMAIL_DOMAINS.has(domain);
+  const domain = emailDomain(trimmed);
+  return isValidEmailAddress(trimmed) && Boolean(domain) && !isBlockedLeadDomain(domain);
+}
+
+function normalizeCompanyDomainInput(value: string): string {
+  const raw = value.trim().toLowerCase();
+  if (!raw || /\s/.test(raw)) {
+    return '';
+  }
+  const candidate = raw.includes('://') ? raw : `https://${raw}`;
+  let hostname = '';
+  try {
+    hostname = new URL(candidate).hostname.toLowerCase().replace(/\.$/, '');
+  } catch {
+    return '';
+  }
+  if (hostname.startsWith('www.')) {
+    hostname = hostname.slice(4);
+  }
+  if (
+    hostname.length > 253 ||
+    !hostname.includes('.') ||
+    hostname.startsWith('-') ||
+    hostname.endsWith('-') ||
+    /^\d{1,3}(?:\.\d{1,3}){3}$/.test(hostname) ||
+    !/^[a-z0-9.-]+$/.test(hostname) ||
+    hostname.split('.').some((label) => !label || label.length > 63 || label.startsWith('-') || label.endsWith('-')) ||
+    isBlockedLeadDomain(hostname)
+  ) {
+    return '';
+  }
+  return hostname;
+}
+
+function companyDomainMatchesEmail(email: string, companyDomain: string): boolean {
+  const domain = emailDomain(email);
+  return Boolean(
+    domain &&
+      companyDomain &&
+      (domain === companyDomain || domain.endsWith(`.${companyDomain}`) || companyDomain.endsWith(`.${domain}`))
+  );
 }
 
 const NAV_LINKS = [
@@ -2005,6 +2074,7 @@ function ReadOnlyScanPage() {
   const [urgency, setUrgency] = useState('This quarter');
   const [teamSize, setTeamSize] = useState('6-20');
   const [company, setCompany] = useState('');
+  const [companyDomain, setCompanyDomain] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -2016,7 +2086,9 @@ function ReadOnlyScanPage() {
     path: '/read-only-scan'
   });
 
-  const validateWorkEmail = (form?: HTMLFormElement | null) => {
+  const normalizedCompanyDomain = normalizeCompanyDomainInput(companyDomain);
+
+  const validateIdentityStep = (form?: HTMLFormElement | null) => {
     if (form && !form.reportValidity()) {
       return false;
     }
@@ -2024,16 +2096,24 @@ function ReadOnlyScanPage() {
       setError(WORK_EMAIL_ERROR);
       return false;
     }
+    if (!normalizedCompanyDomain) {
+      setError(COMPANY_DOMAIN_ERROR);
+      return false;
+    }
+    if (!companyDomainMatchesEmail(email, normalizedCompanyDomain)) {
+      setError(COMPANY_DOMAIN_MATCH_ERROR);
+      return false;
+    }
     setError(null);
     return true;
   };
 
   const advanceStep = (form?: HTMLFormElement | null) => {
-    if (step === 1 && !validateWorkEmail(form)) {
+    if (step === 1 && !validateIdentityStep(form)) {
       return;
     }
     setError(null);
-    setStep((value) => Math.min(3, value + 1));
+    setStep((value) => Math.min(INTAKE_TOTAL_STEPS, value + 1));
   };
 
   const submitIntake = async (event: FormEvent<HTMLFormElement>) => {
@@ -2041,11 +2121,11 @@ function ReadOnlyScanPage() {
     if (submitting) {
       return;
     }
-    if (step < 3) {
+    if (step < INTAKE_TOTAL_STEPS) {
       advanceStep(event.currentTarget);
       return;
     }
-    if (!validateWorkEmail(event.currentTarget)) {
+    if (!validateIdentityStep(event.currentTarget)) {
       return;
     }
 
@@ -2059,7 +2139,8 @@ function ReadOnlyScanPage() {
       await apiClient.submitLeadCapture({
         email: email.trim(),
         environment,
-        company: company.trim() || undefined,
+        company: company.trim(),
+        company_domain: normalizedCompanyDomain,
         challenge: challenge,
         website: website || undefined,
         deployment_model: deployment,
@@ -2128,10 +2209,10 @@ function ReadOnlyScanPage() {
             aria-hidden="true"
           />
           <div className="idt-scan-form-header">
-            <p className="idt-intake-step">Step {submitted ? 3 : step} of 3</p>
-            <h2 id="scan-intake-title">{submitted ? 'Request received' : 'Tell us where to start'}</h2>
+            <p className="idt-intake-step">Step {submitted ? INTAKE_TOTAL_STEPS : step} of {INTAKE_TOTAL_STEPS}</p>
+            <h2 id="scan-intake-title">{submitted ? 'Request received' : step === INTAKE_TOTAL_STEPS ? 'Review before submitting' : 'Tell us where to start'}</h2>
             <p>
-              A short intake keeps the first scan focused. You can refine environment details with the team after we respond.
+              A short intake keeps the first scan focused. Review your details before anything is sent to the team.
             </p>
           </div>
           {!submitted ? (
@@ -2146,7 +2227,7 @@ function ReadOnlyScanPage() {
                       value={email}
                       onChange={(event) => {
                         setEmail(event.target.value);
-                        if (error === WORK_EMAIL_ERROR) {
+                        if (error === WORK_EMAIL_ERROR || error === COMPANY_DOMAIN_MATCH_ERROR) {
                           setError(null);
                         }
                       }}
@@ -2155,13 +2236,30 @@ function ReadOnlyScanPage() {
                     />
                   </label>
                   <label>
-                    Company (optional)
+                    Company name
                     <input
+                      required
                       type="text"
                       value={company}
                       onChange={(event) => setCompany(event.target.value)}
-                      placeholder="Acme Corp"
+                      placeholder="Your registered company name"
                       autoComplete="organization"
+                    />
+                  </label>
+                  <label>
+                    Company website
+                    <input
+                      required
+                      type="text"
+                      value={companyDomain}
+                      onChange={(event) => {
+                        setCompanyDomain(event.target.value);
+                        if (error === COMPANY_DOMAIN_ERROR || error === COMPANY_DOMAIN_MATCH_ERROR) {
+                          setError(null);
+                        }
+                      }}
+                      placeholder="company.com"
+                      autoComplete="url"
                     />
                   </label>
                 </div>
@@ -2229,6 +2327,50 @@ function ReadOnlyScanPage() {
                 </div>
               ) : null}
 
+              {step === INTAKE_TOTAL_STEPS ? (
+                <article className="idt-intake-review" aria-label="Review scan intake">
+                  <div className="idt-intake-review-row">
+                    <div>
+                      <span>Work email</span>
+                      <strong>{email.trim()}</strong>
+                    </div>
+                    <button type="button" className="idt-btn idt-btn-ghost" onClick={() => setStep(1)}>
+                      Edit
+                    </button>
+                  </div>
+                  <div className="idt-intake-review-row">
+                    <div>
+                      <span>Company</span>
+                      <strong>{company.trim()}</strong>
+                      <p>{normalizedCompanyDomain}</p>
+                    </div>
+                    <button type="button" className="idt-btn idt-btn-ghost" onClick={() => setStep(1)}>
+                      Edit
+                    </button>
+                  </div>
+                  <div className="idt-intake-review-row">
+                    <div>
+                      <span>Environment</span>
+                      <strong>{environment}</strong>
+                      <p>{deployment}</p>
+                    </div>
+                    <button type="button" className="idt-btn idt-btn-ghost" onClick={() => setStep(2)}>
+                      Edit
+                    </button>
+                  </div>
+                  <div className="idt-intake-review-row">
+                    <div>
+                      <span>Focus</span>
+                      <strong>{challenge}</strong>
+                      <p>{urgency} - Team size {teamSize}</p>
+                    </div>
+                    <button type="button" className="idt-btn idt-btn-ghost" onClick={() => setStep(3)}>
+                      Edit
+                    </button>
+                  </div>
+                </article>
+              ) : null}
+
               {error ? <p className="idt-form-error" role="alert">{error}</p> : null}
 
               <div className="idt-inline-actions">
@@ -2237,19 +2379,20 @@ function ReadOnlyScanPage() {
                     Back
                   </button>
                 ) : null}
-                {step < 3 ? (
+                {step < INTAKE_TOTAL_STEPS ? (
                   <button
                     type="button"
                     className="idt-btn idt-btn-primary"
                     onClick={(event) => {
+                      event.preventDefault();
                       advanceStep(event.currentTarget.form);
                     }}
                   >
-                    Continue
+                    {step === 3 ? 'Review Request' : 'Continue'}
                   </button>
                 ) : (
-                  <button type="submit" className="idt-btn idt-btn-primary" disabled={submitting || !email.trim()}>
-                    {submitting ? 'Submitting...' : 'Start Free Risk Scan'}
+                  <button type="submit" className="idt-btn idt-btn-primary" disabled={submitting}>
+                    {submitting ? 'Submitting...' : 'Submit Risk Scan Request'}
                   </button>
                 )}
               </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -67,6 +67,7 @@ const CALENDLY_URL = 'https://calendly.com/identrail/15min';
 const THEME_STORAGE_KEY = 'identrail-theme';
 const INTAKE_TOTAL_STEPS = 4;
 const WORK_EMAIL_ERROR = 'Please use a company or work email address.';
+const COMPANY_NAME_ERROR = 'Please enter your company name.';
 const COMPANY_DOMAIN_ERROR = 'Please enter a real company website or domain.';
 const COMPANY_DOMAIN_MATCH_ERROR = 'Company website must match the domain in your work email.';
 const PERSONAL_EMAIL_DOMAINS = new Set([
@@ -2094,6 +2095,10 @@ function ReadOnlyScanPage() {
     }
     if (!isWorkEmailAddress(email)) {
       setError(WORK_EMAIL_ERROR);
+      return false;
+    }
+    if (!company.trim()) {
+      setError(COMPANY_NAME_ERROR);
       return false;
     }
     if (!normalizedCompanyDomain) {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -392,6 +392,7 @@ export type LeadCapturePayload = {
   email: string;
   environment: string;
   company?: string;
+  company_domain?: string;
   challenge?: string;
   website?: string;
   deployment_model?: string;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -14942,6 +14942,43 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
   color: #d4d4d8;
 }
 
+.idt-scan-form .idt-intake-review {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.idt-scan-form .idt-intake-review-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  border: 1px solid #2a2a2a;
+  border-radius: 8px;
+  background: #050505;
+  padding: 1rem;
+}
+
+.idt-scan-form .idt-intake-review-row span {
+  display: block;
+  margin-bottom: 0.2rem;
+  color: #a1a1aa;
+  font-size: 0.72rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.idt-scan-form .idt-intake-review-row strong {
+  display: block;
+  color: #ffffff;
+  font-size: 1rem;
+}
+
+.idt-scan-form .idt-intake-review-row p {
+  margin: 0.2rem 0 0;
+  color: #d4d4d8;
+}
+
 .idt-scan-form .idt-form-error {
   grid-column: 2;
   color: #ffffff;
@@ -14972,7 +15009,8 @@ html[data-theme='light'] .idt-scan-hero-copy > p,
 html[data-theme='light'] .idt-scan-form-header > p:last-child,
 html[data-theme='light'] .idt-scan-form .idt-intake-summary ul,
 html[data-theme='light'] .idt-scan-form .idt-intake-confirmation,
-html[data-theme='light'] .idt-scan-form .idt-intake-confirmation p {
+html[data-theme='light'] .idt-scan-form .idt-intake-confirmation p,
+html[data-theme='light'] .idt-scan-form .idt-intake-review-row p {
   color: #d4d4d8;
 }
 
@@ -15013,6 +15051,19 @@ html[data-theme='light'] .idt-scan-form .idt-intake-grid select {
   background-color: #050505;
   color: #ffffff;
   box-shadow: none;
+}
+
+html[data-theme='light'] .idt-scan-form .idt-intake-review-row {
+  border-color: #2a2a2a;
+  background: #050505;
+}
+
+html[data-theme='light'] .idt-scan-form .idt-intake-review-row span {
+  color: #a1a1aa;
+}
+
+html[data-theme='light'] .idt-scan-form .idt-intake-review-row strong {
+  color: #ffffff;
 }
 
 html[data-theme='light'] .idt-scan-form .idt-intake-grid input:focus-visible,


### PR DESCRIPTION
Fixes #1196

## What Changed
- Added a required review step to the read-only scan intake so the customer can review submitted details and use edit buttons before final submission.
- Required company name and company website/domain on the scan intake, replacing the generic placeholder-style company field.
- Added frontend validation for work email, disposable/personal domains, and company website/domain matching.
- Added backend enforcement for work/disposable email domains, company-domain matching, and public DNS verification before lead delivery.
- Included company domain in internal lead notifications and requester confirmation emails.

## Why
The intake still behaved like a placeholder after email delivery was wired: it could submit too early, accepted weak lead data, and did not give the customer a confirmation moment before sending.

## Impact and Risk
This improves lead quality and prevents accidental submissions. The stricter company-domain requirement may reject users whose work email domain does not match their company website domain; that is intentional for the read-only scan flow, but can be relaxed later if sales wants manual exceptions.

## Validation
- `npm test -- --run api/leads.test.ts src/App.test.tsx` — 60 tests passed
- `npm exec -- tsc --noEmit --ignoreConfig --types node --moduleResolution Bundler --module ESNext --target ES2020 --lib ES2020,DOM api/leads.ts` — passed
- `npm run build` — passed, prerendered 41 routes
- Browser smoke on `/read-only-scan` — Gmail rejected on step 1, review screen shown before submission, zero `/api/leads` calls before final submit, final payload included `company_domain`
- `git diff --check` — passed

## AI Disclosure
- AI-assisted: yes
- Tools used: OpenAI coding assistant
- Where used: read-only scan frontend, lead API validation, tests, and changelog
- Human verification performed: local tests, production-style build, browser smoke flow, and diff review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a required Review step to the read-only scan intake and tightens lead checks (work email only, matching company domain, and public DNS verification with 2s timeouts) to prevent premature or low-quality submissions. Also adds company domain to notifications/emails and blocks whitespace-only company names.

- **New Features**
  - Added a 4th step “Review” with edit buttons; no `/api/leads` calls until final submit.
  - Required “Company name” and “Company website” (normalized to a domain); trims and rejects whitespace-only names.
  - Frontend validation: blocks personal/disposable domains, enforces email ↔ company-domain match.
  - Backend enforcement: same rules + public DNS check via `node:dns/promises` with a 2s timeout per lookup; clear errors.
  - Included `company_domain` in internal lead notifications and confirmation emails.
  - Updated tests, UI copy, and styles for the review step.

<sup>Written for commit 5fdc2ddebdc631e7366d008ebf3e13e68a28d80b. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1198?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

