### PR TITLE
Fix workspace settings crash and shell error copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Fixed the authenticated workspace Settings view so a `whoami` response with
+  `scopes: null` renders as `None granted` instead of tripping the app error
+  boundary, and replaced the fallback error copy with user-facing workspace
+  recovery language.
 - Failed closed when the API does not explicitly advertise self-serve
   onboarding support, so authenticated users without a workspace see the
   existing onboarding-unavailable state instead of entering a wizard that

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -680,7 +680,7 @@ describe('App', () => {
         return okJSON({
           principal: { type: 'subject', id: 'user-1' },
           roles: ['admin'],
-          scopes: ['tenancy.read', 'tenancy.write'],
+          scopes: null,
           scope: { tenant_id: 'tenant-a', workspace_id: 'workspace-a' },
           active_workspace: {
             workspace: {
@@ -748,6 +748,7 @@ describe('App', () => {
     expect(await screen.findByText(/Security Workspace/i)).toBeInTheDocument();
     expect(await screen.findByRole('heading', { level: 2, name: /Settings/i })).toBeInTheDocument();
     expect(await screen.findByText(/Hosted WorkOS login/i)).toBeInTheDocument();
+    expect(await screen.findByText(/None granted/i)).toBeInTheDocument();
     expect(await screen.findByText(/Total members/i)).toBeInTheDocument();
     const accountSecurityLinks = await screen.findAllByRole('link', { name: /Account security/i });
     expect(accountSecurityLinks.some((link) => link.getAttribute('href') === '/app/account/security')).toBe(true);

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -377,7 +377,7 @@ export type WhoAmIResponse = {
     id: string;
   };
   roles: string[];
-  scopes: string[];
+  scopes: string[] | null;
   scope: {
     tenant_id: string;
     workspace_id: string;

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -565,7 +565,7 @@ class ProductErrorBoundaryInner extends Component<
   static getDerivedStateFromError(error: unknown): ProductErrorBoundaryState {
     return {
       hasError: true,
-      message: error instanceof Error ? error.message : 'Unexpected app shell failure'
+      message: error instanceof Error ? error.message : 'Unexpected workspace view failure'
     };
   }
 
@@ -578,10 +578,10 @@ class ProductErrorBoundaryInner extends Component<
       return (
         <section className="idt-app-shell-screen" role="alert">
           <article className="idt-app-panel idt-app-panel-error">
-            <p className="idt-app-kicker">App shell error</p>
-            <h1>We hit a shell boundary error</h1>
+            <p className="idt-app-kicker">Workspace view error</p>
+            <h1>Workspace view failed to load</h1>
             <p>{this.state.message}</p>
-            <p>Refresh the page or return to the marketing site while we restore this workspace view.</p>
+            <p>Refresh the page. If it keeps happening, return to the homepage while we restore this workspace view.</p>
             <Link className="idt-btn idt-btn-primary" to="/">
               Back to homepage
             </Link>
@@ -4807,6 +4807,7 @@ export function ProductSettingsPage() {
     : authConfig?.auth.manual_mode
       ? 'Manual development login'
       : 'Session-only';
+  const scopes = Array.isArray(whoAmI?.scopes) ? whoAmI.scopes : [];
   const projectsPath = scope ? buildProjectsPath(scope) : '/app';
   const findingsPath = scope ? buildScopedPath(scope, 'findings') : '/app';
   const workspacesPath = scope ? buildScopedPath(scope, 'workspaces') : '/app';
@@ -4885,11 +4886,11 @@ export function ProductSettingsPage() {
           <dl className="idt-settings-facts">
             <div>
               <dt>User</dt>
-              <dd>{me?.user.primary_email ?? whoAmI?.principal.id ?? 'Unavailable'}</dd>
+              <dd>{me?.user?.primary_email ?? whoAmI?.principal.id ?? 'Unavailable'}</dd>
             </div>
             <div>
               <dt>Status</dt>
-              <dd>{me?.user.status ? formatTokenLabel(me.user.status) : 'Unavailable'}</dd>
+              <dd>{me?.user?.status ? formatTokenLabel(me.user.status) : 'Unavailable'}</dd>
             </div>
             <div>
               <dt>Principal</dt>
@@ -4897,7 +4898,7 @@ export function ProductSettingsPage() {
             </div>
             <div>
               <dt>Scopes</dt>
-              <dd>{whoAmI?.scopes.length ? whoAmI.scopes.map(formatTokenLabel).join(', ') : 'None granted'}</dd>
+              <dd>{scopes.length ? scopes.map(formatTokenLabel).join(', ') : 'None granted'}</dd>
             </div>
           </dl>
         </section>


### PR DESCRIPTION
Fixes #1197

## What changed

- Normalized the Settings page `whoami.scopes` value so `null` or missing scopes render as `None granted` instead of crashing the authenticated workspace view.
- Tightened nearby account-field access with optional chaining for production-shaped responses.
- Replaced the internal error-boundary copy with user-facing workspace recovery language.
- Added a regression test covering the production `scopes: null` response and updated the changelog.

## Why it changed

Production showed the Settings route falling into the app error boundary with `Cannot read properties of null (reading 'length')`. The frontend type and render path assumed `scopes` was always an array, but the deployed API/session path can return `null` there.

## Impact and risk

Authenticated users should now be able to open Settings even when the API does not grant or advertise scopes for their current principal. Risk is low: the change is defensive rendering only, with no API contract or authorization behavior change.

## Validation performed

- `npm run test:ci --prefix web` — 12 files passed, 130 tests passed, coverage thresholds met.
- `npm run build --prefix web` — TypeScript, Vite build, and route prerender completed successfully; 41 routes prerendered.
- Commit and push hooks passed: merge-conflict check, end-of-file fix, trailing whitespace, gofmt check, go vet, local env token hygiene, and Vercel artifact hygiene.

## AI disclosure

- AI-assisted: yes
- Tools used: ChatGPT
- Where used: implementation planning, patch drafting, and validation review
- Human verification performed: reviewed the diff and ran the validation commands above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the workspace Settings view when `whoami.scopes` is null by rendering “None granted” instead of breaking. Also updates the error boundary to “Workspace view” language and hardens account field access; adds a regression test.

- **Bug Fixes**
  - Treat `whoami.scopes` as `[]` when null and render “None granted”; add a test that covers this.
  - Type `WhoAmIResponse.scopes` as `string[] | null`, use optional chaining for `me.user` fields, and replace app-shell error copy with clearer “Workspace view” wording and default message.

<sup>Written for commit c034695ebe823fcc97fbc4af895239cca4845960. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1199?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

