### PR TITLE
Add visual richness to app console

### DIFF
--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -225,6 +225,52 @@ describe('ProductAppIndexRedirect', () => {
   });
 });
 
+describe('ProductShellLayout', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.doUnmock('./pages/onboarding/onboardingUtils');
+    vi.resetModules();
+  });
+
+  it('limits default source logo stacks to feature-enabled connectors', async () => {
+    vi.resetModules();
+    vi.doMock('./pages/onboarding/onboardingUtils', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('./pages/onboarding/onboardingUtils')>();
+      return {
+        ...actual,
+        FEATURE_ONBOARDING_CONNECTOR_GITHUB: false,
+        FEATURE_ONBOARDING_CONNECTOR_K8S: false
+      };
+    });
+
+    const { ProductShellLayout, SourceLogoMark } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID" element={<ProductShellLayout />}>
+            <Route
+              index
+              element={
+                <>
+                  <p>Child view</p>
+                  <SourceLogoMark provider="github" />
+                  <SourceLogoMark provider="kubernetes" />
+                </>
+              }
+            />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getAllByRole('img', { name: 'AWS' }).length).toBeGreaterThan(0);
+    expect(screen.queryByRole('img', { name: 'GitHub' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('img', { name: 'Kubernetes' })).not.toBeInTheDocument();
+    expect(screen.getByText(/AWS signals stay visible across the workflow/i)).toBeInTheDocument();
+  });
+});
+
 describe('ProductProjectDetailPage', () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -71,6 +71,7 @@ type SourceProfile = {
   summary: string;
   primarySignal: string;
   requiredAccess: string;
+  logo: string;
 };
 
 type SourceAvailability = {
@@ -116,7 +117,8 @@ const SOURCE_PROFILES: Record<SourceProvider, SourceProfile> = {
     eyebrow: 'Code and workflow identity',
     summary: 'Connect a GitHub App installation and select repositories that should feed exposure telemetry.',
     primarySignal: 'Repositories, workflow identity, webhook scan triggers',
-    requiredAccess: 'GitHub App installation with selected repository access'
+    requiredAccess: 'GitHub App installation with selected repository access',
+    logo: '/brand-logos/github.svg'
   },
   aws: {
     provider: 'aws',
@@ -124,7 +126,8 @@ const SOURCE_PROFILES: Record<SourceProvider, SourceProfile> = {
     eyebrow: 'Cloud IAM identity',
     summary: 'Validate a read-only IAM role before Identrail records the account connector.',
     primarySignal: 'Roles, trust policies, account identity, IAM read checks',
-    requiredAccess: 'Assumable read-only IAM role ARN'
+    requiredAccess: 'Assumable read-only IAM role ARN',
+    logo: '/brand-logos/aws.svg'
   },
   kubernetes: {
     provider: 'kubernetes',
@@ -132,7 +135,8 @@ const SOURCE_PROFILES: Record<SourceProvider, SourceProfile> = {
     eyebrow: 'Cluster service identity',
     summary: 'Install a read-only in-cluster agent or use kubeconfig fallback for ad-hoc development.',
     primarySignal: 'Service accounts, RBAC bindings, pods, cluster metadata',
-    requiredAccess: 'Read-only ClusterRole through the Identrail agent'
+    requiredAccess: 'Read-only ClusterRole through the Identrail agent',
+    logo: '/brand-logos/kubernetes.svg'
   }
 };
 const CONNECT_SOURCE_STEPS = ['Choose', 'Configure', 'Validate', 'Active'] as const;
@@ -143,6 +147,7 @@ const SOURCE_ORDER: SourceProvider[] = [
   'aws',
   ...(FEATURE_CONNECTOR_K8S ? (['kubernetes'] as SourceProvider[]) : [])
 ];
+const SOURCE_STACK: SourceProvider[] = ['github', 'aws', 'kubernetes'];
 const SCAN_POLICY_TRIGGER_MODES: ScanTriggerMode[] = ['manual', 'scheduled', 'event', 'hybrid'];
 const REPO_FINDING_SEVERITY_FILTERS = ['all', 'critical', 'high', 'medium', 'low', 'info'] as const;
 const REPO_FINDING_TYPE_FILTERS = ['all', 'secret_exposure', 'repo_misconfiguration'] as const;
@@ -162,6 +167,36 @@ const SORT_LABEL_BY_FIELD: Record<(typeof REPO_FINDING_SORT_FIELDS)[number], str
 };
 
 const TREND_POINTS = 10;
+
+function SourceLogoMark({ provider, className = '' }: { provider: SourceProvider; className?: string }) {
+  const profile = SOURCE_PROFILES[provider];
+  const classes = ['idt-source-logo-mark', `is-${provider}`, className].filter(Boolean).join(' ');
+  return (
+    <span className={classes} role="img" aria-label={profile.name}>
+      <img src={profile.logo} alt="" aria-hidden="true" loading="lazy" />
+    </span>
+  );
+}
+
+function SourceLogoStack({
+  providers = SOURCE_STACK,
+  label = 'Source coverage stack',
+  className = ''
+}: {
+  providers?: SourceProvider[];
+  label?: string;
+  className?: string;
+}) {
+  const classes = ['idt-source-logo-stack', className].filter(Boolean).join(' ');
+  return (
+    <div className={classes} role="group" aria-label={label}>
+      {providers.map((provider) => (
+        <SourceLogoMark key={provider} provider={provider} />
+      ))}
+    </div>
+  );
+}
+
 async function listOverviewProjects(
   workspaceID: string,
   filters: { include_archived: boolean },
@@ -913,7 +948,7 @@ export function ProductShellLayout() {
         <aside className="idt-app-sidebar" aria-label="Workspace navigation">
           <div className="idt-app-sidebar-brand">
             <Link className="idt-app-sidebar-mark" to={basePath} aria-label="Identrail app home">
-              I
+              <img src="/identrail-logo.png" alt="" aria-hidden="true" />
             </Link>
             <div>
               <strong>Identrail</strong>
@@ -951,6 +986,7 @@ export function ProductShellLayout() {
           </nav>
 
           <div className="idt-app-sidebar-footer">
+            <SourceLogoStack className="idt-app-sidebar-logo-stack" label="Workspace source logos" />
             <span>Read-only evidence first</span>
             <strong>Operator-ready workflow</strong>
           </div>
@@ -970,6 +1006,10 @@ export function ProductShellLayout() {
                   </>
                 ) : null}
               </p>
+              <div className="idt-app-header-stack">
+                <SourceLogoStack label="Available machine identity sources" />
+                <span>GitHub, AWS, and Kubernetes signals stay visible across the workflow.</span>
+              </div>
             </div>
             <div className="idt-app-shell-actions">
               <Link to="/app/account/security" className="idt-btn idt-btn-ghost">
@@ -1152,6 +1192,10 @@ export function ProductOverviewPage() {
               Operating view for tenant <strong>{scope?.tenantID ?? 'unknown'}</strong> and workspace{' '}
               <strong>{scope?.workspaceID ?? 'unknown'}</strong>.
             </p>
+            <div className="idt-overview-source-strip">
+              <SourceLogoStack label="Workspace source stack" />
+              <span>Source telemetry, cloud IAM, and runtime identity in one queue.</span>
+            </div>
           </div>
           <div className="idt-inline-actions">
             <Link className="idt-btn idt-btn-primary" to={projectsPath}>
@@ -1164,23 +1208,35 @@ export function ProductOverviewPage() {
         </header>
 
         <div className="idt-overview-metrics" aria-label="Workspace health metrics">
-          <article>
-            <span>Active projects</span>
+          <article className="idt-overview-metric-card is-light-surface">
+            <div className="idt-overview-metric-top">
+              <span>Active projects</span>
+              <SourceLogoStack label="Project source coverage" />
+            </div>
             <strong>{activeProjects.length}</strong>
             <p>{archivedProjectCount > 0 ? `${archivedProjectCount} archived` : 'All listed projects are active'}</p>
           </article>
-          <article>
-            <span>Priority findings</span>
+          <article className="idt-overview-metric-card is-danger-surface">
+            <div className="idt-overview-metric-top">
+              <span>Priority findings</span>
+              <SourceLogoMark provider="github" />
+            </div>
             <strong>{openFindingCount}</strong>
             <p>{urgentFindingCount} critical or high in the ranked queue</p>
           </article>
-          <article>
-            <span>Recent scans</span>
+          <article className="idt-overview-metric-card is-provider-surface">
+            <div className="idt-overview-metric-top">
+              <span>Recent scans</span>
+              <SourceLogoMark provider="github" />
+            </div>
             <strong>{repoScans.length}</strong>
             <p>{activeScanCount > 0 ? `${activeScanCount} still running` : `${completedScanCount} completed`}</p>
           </article>
-          <article>
-            <span>Trend delta</span>
+          <article className="idt-overview-metric-card">
+            <div className="idt-overview-metric-top">
+              <span>Trend delta</span>
+              <SourceLogoMark provider="aws" />
+            </div>
             <strong>{trendDelta === null ? 'N/A' : trendDelta > 0 ? `+${trendDelta}` : trendDelta}</strong>
             <p>
               {latestTrend
@@ -1207,13 +1263,16 @@ export function ProductOverviewPage() {
                   const repository = canonicalGitHubRepositoryDisplay(finding.repository ?? '');
                   return (
                     <article key={`${finding.scan_id}:${finding.id}`} className="idt-overview-risk-row">
-                      <div>
-                        <strong>{finding.title}</strong>
-                        <p>
-                          {repository || 'Repository unavailable'} · {repoFindingLocationLabel(finding)}
-                        </p>
+                      <SourceLogoMark provider="github" className="is-row" />
+                      <div className="idt-overview-row-copy">
+                        <div>
+                          <strong>{finding.title}</strong>
+                          <p>
+                            {repository || 'Repository unavailable'} · {repoFindingLocationLabel(finding)}
+                          </p>
+                        </div>
+                        <span className={repoFindingSeverityClass(finding.severity)}>{formatTokenLabel(finding.severity)}</span>
                       </div>
-                      <span className={repoFindingSeverityClass(finding.severity)}>{formatTokenLabel(finding.severity)}</span>
                     </article>
                   );
                 })}
@@ -1238,15 +1297,18 @@ export function ProductOverviewPage() {
               <div className="idt-overview-list">
                 {repoScans.map((scan) => (
                   <article key={scan.id} className="idt-overview-scan-row">
-                    <div>
-                      <strong>{canonicalGitHubRepositoryDisplay(scan.repository) || scan.repository}</strong>
-                      <p>
-                        {scan.finding_count} findings · {scan.files_scanned} files · {formatDateLabel(scan.started_at)}
-                      </p>
+                    <SourceLogoMark provider="github" className="is-row" />
+                    <div className="idt-overview-row-copy">
+                      <div>
+                        <strong>{canonicalGitHubRepositoryDisplay(scan.repository) || scan.repository}</strong>
+                        <p>
+                          {scan.finding_count} findings · {scan.files_scanned} files · {formatDateLabel(scan.started_at)}
+                        </p>
+                      </div>
+                      <span className={`idt-source-status-pill is-${isActiveScanStatus(scan.status) ? 'warning' : scan.status === 'failed' ? 'error' : 'success'}`}>
+                        {formatTokenLabel(scan.status)}
+                      </span>
                     </div>
-                    <span className={`idt-source-status-pill is-${isActiveScanStatus(scan.status) ? 'warning' : scan.status === 'failed' ? 'error' : 'success'}`}>
-                      {formatTokenLabel(scan.status)}
-                    </span>
                   </article>
                 ))}
               </div>
@@ -1272,7 +1334,10 @@ export function ProductOverviewPage() {
               <div className="idt-overview-projects">
                 {activeProjects.slice(0, 6).map((project) => (
                   <Link key={project.project_id} to={scope ? buildProjectPath(scope, project.project_id) : projectsPath}>
-                    <strong>{project.name}</strong>
+                    <div className="idt-overview-project-title">
+                      <strong>{project.name}</strong>
+                      <SourceLogoStack label={`${project.name} source stack`} />
+                    </div>
                     <span>{project.description || `Project ${project.project_id}`}</span>
                     <small>Updated {formatDateLabel(project.updated_at)}</small>
                   </Link>
@@ -1295,18 +1360,22 @@ export function ProductOverviewPage() {
             </div>
             <div className="idt-overview-actions">
               <Link to={projectsPath}>
+                <SourceLogoStack label="Project action source stack" />
                 <strong>Create or select a project</strong>
                 <span>Define the scope that connectors and scan policies will attach to.</span>
               </Link>
               <Link to={scope?.projectID ? buildProjectPath(scope, scope.projectID) : projectsPath}>
+                <SourceLogoStack label="Connector action source stack" />
                 <strong>Connect sources</strong>
                 <span>Attach GitHub, AWS, or Kubernetes telemetry to an active project.</span>
               </Link>
               <Link to={findingsPath}>
+                <SourceLogoMark provider="github" />
                 <strong>Triage open findings</strong>
                 <span>Review direct GitHub line links, severity, remediation, and workflow status.</span>
               </Link>
               <Link to={workspacesPath}>
+                <SourceLogoMark provider="kubernetes" />
                 <strong>Invite operators</strong>
                 <span>Give analysts and admins access to the workspace they operate.</span>
               </Link>
@@ -2276,6 +2345,10 @@ export function ProductProjectsPage() {
           <p className="idt-app-kicker">Project registry</p>
           <h2>Choose a project before connecting source data</h2>
           <p>Projects set the workspace boundary for GitHub, AWS, and Kubernetes onboarding.</p>
+          <div className="idt-overview-source-strip">
+            <SourceLogoStack label="Project source stack" />
+            <span>Each project can carry code, cloud, and cluster signals without losing ownership context.</span>
+          </div>
         </div>
         <div className="idt-inline-actions">
           <Link className="idt-btn idt-btn-ghost" to={buildScopedPath(scope)}>
@@ -2285,16 +2358,25 @@ export function ProductProjectsPage() {
       </div>
 
       <div className="idt-projects-summary">
-        <article>
-          <span>{projects.length}</span>
+        <article className="is-light-surface">
+          <div className="idt-overview-metric-top">
+            <span>{projects.length}</span>
+            <SourceLogoStack label="All projects source coverage" />
+          </div>
           <p>Total projects</p>
         </article>
         <article>
-          <span>{activeProjectCount}</span>
+          <div className="idt-overview-metric-top">
+            <span>{activeProjectCount}</span>
+            <SourceLogoMark provider="kubernetes" />
+          </div>
           <p>Active boundaries</p>
         </article>
         <article>
-          <span>{latestProject ? formatConnectionTime(latestProject.updated_at) : 'No activity yet'}</span>
+          <div className="idt-overview-metric-top">
+            <span>{latestProject ? formatConnectionTime(latestProject.updated_at) : 'No activity yet'}</span>
+            <SourceLogoMark provider="aws" />
+          </div>
           <p>Latest update</p>
         </article>
       </div>
@@ -2327,7 +2409,10 @@ export function ProductProjectsPage() {
                   <article key={project.project_id} className="idt-project-card">
                     <div className="idt-project-card-header">
                       <div>
-                        <h4>{project.name}</h4>
+                        <div className="idt-project-card-title">
+                          <h4>{project.name}</h4>
+                          <SourceLogoStack label={`${project.name} source stack`} />
+                        </div>
                         <p>{project.description || 'No description yet. Use this project to scope connector onboarding and scan ownership.'}</p>
                       </div>
                       <span
@@ -3197,9 +3282,9 @@ export function ProductProjectDetailPage() {
         historyLimit: String(policy.history_limit),
         maxFindings: String(policy.max_findings)
       });
-	      setSuccessMessage('Scan policy saved.');
-	      setPolicySaving(false);
-	      void refreshConnections(true);
+      setSuccessMessage('Scan policy saved.');
+      setPolicySaving(false);
+      void refreshConnections(true);
     } catch (error) {
       if (isStaleRequestSequence(requestSequence)) {
         return;
@@ -3227,9 +3312,9 @@ export function ProductProjectDetailPage() {
       if (isStaleRequestSequence(requestSequence)) {
         return;
       }
-	      setSuccessMessage(`Scan policy ${normalizedPolicyID} deleted.`);
-	      setPolicyDeletingID('');
-	      void refreshConnections(true);
+      setSuccessMessage(`Scan policy ${normalizedPolicyID} deleted.`);
+      setPolicyDeletingID('');
+      void refreshConnections(true);
     } catch (error) {
       if (isStaleRequestSequence(requestSequence)) {
         return;
@@ -3252,6 +3337,10 @@ export function ProductProjectDetailPage() {
             Add GitHub, AWS, or Kubernetes signals for workspace <strong>{scope.workspaceID}</strong> with live
             validation and remediation feedback.
           </p>
+          <div className="idt-overview-source-strip">
+            <SourceLogoStack providers={sourceOrder} label="Available project sources" />
+            <span>Connect only the systems this project actually owns.</span>
+          </div>
         </div>
         <button
           type="button"
@@ -3266,16 +3355,25 @@ export function ProductProjectDetailPage() {
       </div>
 
       <div className="idt-source-summary" aria-label="source connection summary">
-        <article>
-          <span>{connectedCount}</span>
+        <article className="is-light-surface">
+          <div className="idt-overview-metric-top">
+            <span>{connectedCount}</span>
+            <SourceLogoStack providers={actionableSourceOrder.length > 0 ? actionableSourceOrder : sourceOrder} label="Connected source count" />
+          </div>
           <p>Active sources</p>
         </article>
         <article>
-          <span>{remainingCount}</span>
+          <div className="idt-overview-metric-top">
+            <span>{remainingCount}</span>
+            <SourceLogoMark provider={selectedSource} />
+          </div>
           <p>Remaining</p>
         </article>
         <article>
-          <span>{selectedUnavailable ? 'Unavailable' : connectionLifecycle(selectedStatus)}</span>
+          <div className="idt-overview-metric-top">
+            <span>{selectedUnavailable ? 'Unavailable' : connectionLifecycle(selectedStatus)}</span>
+            <SourceLogoMark provider={selectedSource} />
+          </div>
           <p>Selected status</p>
         </article>
       </div>
@@ -3306,7 +3404,7 @@ export function ProductProjectDetailPage() {
               <button
                 key={provider}
                 type="button"
-                className={`idt-source-card ${selectedSource === provider ? 'is-selected' : ''} ${
+                className={`idt-source-card is-provider-${provider} ${selectedSource === provider ? 'is-selected' : ''} ${
                   availability.available ? '' : 'is-unavailable'
                 }`}
                 aria-pressed={selectedSource === provider}
@@ -3315,7 +3413,10 @@ export function ProductProjectDetailPage() {
                 disabled={!availability.available}
               >
                 <span className="idt-source-card-topline">
-                  <span>{profile.eyebrow}</span>
+                  <span className="idt-source-card-identity">
+                    <SourceLogoMark provider={provider} />
+                    <span>{profile.eyebrow}</span>
+                  </span>
                   <span className={`idt-source-status-pill is-${sourceAvailabilityTone(availability, status)}`}>
                     {!availability.available ? 'Unavailable' : error ? 'Needs retry' : connectionLifecycle(status)}
                   </span>
@@ -3329,10 +3430,13 @@ export function ProductProjectDetailPage() {
 
         <div className="idt-source-config">
           <div className="idt-source-config-header">
-            <div>
-              <p className="idt-app-kicker">{selectedProfile.eyebrow}</p>
-              <h3>{selectedProfile.name}</h3>
-              <p>{selectedProfile.summary}</p>
+            <div className="idt-source-config-title">
+              <SourceLogoMark provider={selectedSource} className="is-hero" />
+              <div>
+                <p className="idt-app-kicker">{selectedProfile.eyebrow}</p>
+                <h3>{selectedProfile.name}</h3>
+                <p>{selectedProfile.summary}</p>
+              </div>
             </div>
             <span className={`idt-source-status-pill is-${sourceAvailabilityTone(selectedAvailability, selectedStatus)}`}>
               {selectedUnavailable ? 'Unavailable' : connectionLifecycle(selectedStatus)}
@@ -3381,8 +3485,8 @@ export function ProductProjectDetailPage() {
                       }
                       placeholder="GitHub App"
                     />
-	                  </label>
-	                </div>
+                  </label>
+                </div>
                 <button className="idt-btn idt-btn-primary" type="submit" disabled={submitting !== ''}>
                   {submitting === 'github' ? 'Preparing...' : 'Generate install link'}
                 </button>
@@ -4363,6 +4467,10 @@ export function ProductFindingsPage() {
           <p className="idt-app-kicker">Repository Exposure</p>
           <h2>Findings</h2>
           <p>Review repository findings and jump directly to the exact GitHub line when link metadata is available.</p>
+          <div className="idt-overview-source-strip">
+            <SourceLogoMark provider="github" />
+            <span>GitHub evidence stays tied to triage, remediation, and ownership state.</span>
+          </div>
         </div>
         <div className="idt-inline-actions">
           <button className="idt-btn idt-btn-ghost" type="button" onClick={handleRefresh} disabled={refreshing}>
@@ -4391,19 +4499,31 @@ export function ProductFindingsPage() {
 
       <div className="idt-repo-finding-stats" aria-label="Repository finding summary">
         <article className="idt-repo-finding-stat">
-          <span>Total repo findings</span>
+          <div className="idt-overview-metric-top">
+            <span>Total repo findings</span>
+            <SourceLogoMark provider="github" />
+          </div>
           <strong>{filteredFindings.length}</strong>
         </article>
         <article className="idt-repo-finding-stat">
-          <span>GitHub-linked findings</span>
+          <div className="idt-overview-metric-top">
+            <span>GitHub-linked findings</span>
+            <SourceLogoMark provider="github" />
+          </div>
           <strong>{linkedFindingCount}</strong>
         </article>
         <article className="idt-repo-finding-stat">
-          <span>Open findings</span>
+          <div className="idt-overview-metric-top">
+            <span>Open findings</span>
+            <SourceLogoMark provider="aws" />
+          </div>
           <strong>{openFindingCount}</strong>
         </article>
         <article className="idt-repo-finding-stat">
-          <span>Critical findings</span>
+          <div className="idt-overview-metric-top">
+            <span>Critical findings</span>
+            <SourceLogoMark provider="kubernetes" />
+          </div>
           <strong>{criticalFindingCount}</strong>
         </article>
         <article className="idt-repo-finding-stat">
@@ -4550,20 +4670,23 @@ export function ProductFindingsPage() {
                           className={`idt-repo-finding-row${isSelected ? ' is-selected' : ''}`}
                           onClick={() => setSelectedFindingKey(selectionKey)}
                         >
-                          <div className="idt-repo-finding-row-top">
-                            <strong>{finding.title}</strong>
-                            <span className={repoFindingSeverityClass(finding.severity)}>{formatTokenLabel(finding.severity)}</span>
-                          </div>
-                          <p>{finding.human_summary}</p>
-                          <div className="idt-repo-finding-row-meta">
-                            <span>{repositoryLabel}</span>
-                            <span>{repoFindingLocationLabel(finding)}</span>
-                            <span>{formatTokenLabel(finding.type)}</span>
-                            <span>{`Confidence ${formatConfidenceScore(finding.confidence_score)}`}</span>
-                          </div>
-                          <div className="idt-repo-finding-row-meta">
-                            <span className={repoFindingStatusClass(lifecycle)}>{formatTokenLabel(lifecycle)}</span>
-                            <span>{`Assignee ${finding.triage?.assignee || 'Unassigned'}`}</span>
+                          <SourceLogoMark provider="github" className="is-row" />
+                          <div className="idt-repo-finding-row-copy">
+                            <div className="idt-repo-finding-row-top">
+                              <strong>{finding.title}</strong>
+                              <span className={repoFindingSeverityClass(finding.severity)}>{formatTokenLabel(finding.severity)}</span>
+                            </div>
+                            <p>{finding.human_summary}</p>
+                            <div className="idt-repo-finding-row-meta">
+                              <span>{repositoryLabel}</span>
+                              <span>{repoFindingLocationLabel(finding)}</span>
+                              <span>{formatTokenLabel(finding.type)}</span>
+                              <span>{`Confidence ${formatConfidenceScore(finding.confidence_score)}`}</span>
+                            </div>
+                            <div className="idt-repo-finding-row-meta">
+                              <span className={repoFindingStatusClass(lifecycle)}>{formatTokenLabel(lifecycle)}</span>
+                              <span>{`Assignee ${finding.triage?.assignee || 'Unassigned'}`}</span>
+                            </div>
                           </div>
                         </button>
                       );
@@ -4592,9 +4715,14 @@ export function ProductFindingsPage() {
           {selectedFinding ? (
             <>
               <div className="idt-repo-finding-detail-copy">
-                <p className="idt-app-kicker">Finding detail</p>
-                <h3>{selectedFinding.title}</h3>
-                <p>{selectedFinding.human_summary}</p>
+                <div className="idt-source-config-title">
+                  <SourceLogoMark provider="github" className="is-hero" />
+                  <div>
+                    <p className="idt-app-kicker">Finding detail</p>
+                    <h3>{selectedFinding.title}</h3>
+                    <p>{selectedFinding.human_summary}</p>
+                  </div>
+                </div>
               </div>
 
               <dl className="idt-repo-finding-facts">

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -168,12 +168,16 @@ const SORT_LABEL_BY_FIELD: Record<(typeof REPO_FINDING_SORT_FIELDS)[number], str
 
 const TREND_POINTS = 10;
 
-function resolveEnabledSourceProvider(provider: SourceProvider): SourceProvider {
-  return SOURCE_STACK.includes(provider) ? provider : SOURCE_STACK[0] ?? provider;
+function resolveEnabledSourceProvider(provider: SourceProvider): SourceProvider | null {
+  return SOURCE_STACK.includes(provider) ? provider : null;
 }
 
 export function SourceLogoMark({ provider, className = '' }: { provider: SourceProvider; className?: string }) {
   const enabledProvider = resolveEnabledSourceProvider(provider);
+  if (!enabledProvider) {
+    return null;
+  }
+
   const profile = SOURCE_PROFILES[enabledProvider];
   const classes = ['idt-source-logo-mark', `is-${enabledProvider}`, className].filter(Boolean).join(' ');
   return (

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -147,7 +147,7 @@ const SOURCE_ORDER: SourceProvider[] = [
   'aws',
   ...(FEATURE_CONNECTOR_K8S ? (['kubernetes'] as SourceProvider[]) : [])
 ];
-const SOURCE_STACK: SourceProvider[] = ['github', 'aws', 'kubernetes'];
+const SOURCE_STACK: SourceProvider[] = [...SOURCE_ORDER];
 const SCAN_POLICY_TRIGGER_MODES: ScanTriggerMode[] = ['manual', 'scheduled', 'event', 'hybrid'];
 const REPO_FINDING_SEVERITY_FILTERS = ['all', 'critical', 'high', 'medium', 'low', 'info'] as const;
 const REPO_FINDING_TYPE_FILTERS = ['all', 'secret_exposure', 'repo_misconfiguration'] as const;
@@ -168,9 +168,14 @@ const SORT_LABEL_BY_FIELD: Record<(typeof REPO_FINDING_SORT_FIELDS)[number], str
 
 const TREND_POINTS = 10;
 
-function SourceLogoMark({ provider, className = '' }: { provider: SourceProvider; className?: string }) {
-  const profile = SOURCE_PROFILES[provider];
-  const classes = ['idt-source-logo-mark', `is-${provider}`, className].filter(Boolean).join(' ');
+function resolveEnabledSourceProvider(provider: SourceProvider): SourceProvider {
+  return SOURCE_STACK.includes(provider) ? provider : SOURCE_STACK[0] ?? provider;
+}
+
+export function SourceLogoMark({ provider, className = '' }: { provider: SourceProvider; className?: string }) {
+  const enabledProvider = resolveEnabledSourceProvider(provider);
+  const profile = SOURCE_PROFILES[enabledProvider];
+  const classes = ['idt-source-logo-mark', `is-${enabledProvider}`, className].filter(Boolean).join(' ');
   return (
     <span className={classes} role="img" aria-label={profile.name}>
       <img src={profile.logo} alt="" aria-hidden="true" loading="lazy" />
@@ -195,6 +200,20 @@ function SourceLogoStack({
       ))}
     </div>
   );
+}
+
+function formatSourceNameList(providers: SourceProvider[]): string {
+  const names = providers.map((provider) => SOURCE_PROFILES[provider].name);
+  if (names.length === 0) {
+    return 'source';
+  }
+  if (names.length === 1) {
+    return names[0];
+  }
+  if (names.length === 2) {
+    return `${names[0]} and ${names[1]}`;
+  }
+  return `${names.slice(0, -1).join(', ')}, and ${names[names.length - 1]}`;
 }
 
 async function listOverviewProjects(
@@ -941,6 +960,7 @@ export function ProductShellLayout() {
   }
 
   const basePath = buildScopedPath(scope);
+  const enabledSourceLabel = formatSourceNameList(SOURCE_STACK);
 
   return (
     <ProductErrorBoundary>
@@ -1008,7 +1028,7 @@ export function ProductShellLayout() {
               </p>
               <div className="idt-app-header-stack">
                 <SourceLogoStack label="Available machine identity sources" />
-                <span>GitHub, AWS, and Kubernetes signals stay visible across the workflow.</span>
+                <span>{enabledSourceLabel} signals stay visible across the workflow.</span>
               </div>
             </div>
             <div className="idt-app-shell-actions">
@@ -1219,7 +1239,7 @@ export function ProductOverviewPage() {
           <article className="idt-overview-metric-card is-danger-surface">
             <div className="idt-overview-metric-top">
               <span>Priority findings</span>
-              <SourceLogoMark provider="github" />
+              <SourceLogoStack label="Priority finding source coverage" />
             </div>
             <strong>{openFindingCount}</strong>
             <p>{urgentFindingCount} critical or high in the ranked queue</p>
@@ -1235,7 +1255,7 @@ export function ProductOverviewPage() {
           <article className="idt-overview-metric-card">
             <div className="idt-overview-metric-top">
               <span>Trend delta</span>
-              <SourceLogoMark provider="aws" />
+              <SourceLogoStack label="Trend source coverage" />
             </div>
             <strong>{trendDelta === null ? 'N/A' : trendDelta > 0 ? `+${trendDelta}` : trendDelta}</strong>
             <p>
@@ -1367,7 +1387,7 @@ export function ProductOverviewPage() {
               <Link to={scope?.projectID ? buildProjectPath(scope, scope.projectID) : projectsPath}>
                 <SourceLogoStack label="Connector action source stack" />
                 <strong>Connect sources</strong>
-                <span>Attach GitHub, AWS, or Kubernetes telemetry to an active project.</span>
+                <span>Attach enabled source telemetry to an active project.</span>
               </Link>
               <Link to={findingsPath}>
                 <SourceLogoMark provider="github" />
@@ -1375,7 +1395,7 @@ export function ProductOverviewPage() {
                 <span>Review direct GitHub line links, severity, remediation, and workflow status.</span>
               </Link>
               <Link to={workspacesPath}>
-                <SourceLogoMark provider="kubernetes" />
+                <SourceLogoStack label="Operator access source coverage" />
                 <strong>Invite operators</strong>
                 <span>Give analysts and admins access to the workspace they operate.</span>
               </Link>
@@ -2264,6 +2284,7 @@ export function ProductProjectsPage() {
   );
   const archivedProjectCount = projects.length - activeProjectCount;
   const latestProject = projects[0];
+  const enabledSourceLabel = formatSourceNameList(SOURCE_STACK);
 
   if (!scope) {
     return <AppShellLoading message="Resolving workspace scope" />;
@@ -2344,10 +2365,10 @@ export function ProductProjectsPage() {
         <div>
           <p className="idt-app-kicker">Project registry</p>
           <h2>Choose a project before connecting source data</h2>
-          <p>Projects set the workspace boundary for GitHub, AWS, and Kubernetes onboarding.</p>
+          <p>Projects set the workspace boundary for {enabledSourceLabel} onboarding.</p>
           <div className="idt-overview-source-strip">
             <SourceLogoStack label="Project source stack" />
-            <span>Each project can carry code, cloud, and cluster signals without losing ownership context.</span>
+            <span>Each project can carry enabled source signals without losing ownership context.</span>
           </div>
         </div>
         <div className="idt-inline-actions">
@@ -2368,14 +2389,14 @@ export function ProductProjectsPage() {
         <article>
           <div className="idt-overview-metric-top">
             <span>{activeProjectCount}</span>
-            <SourceLogoMark provider="kubernetes" />
+            <SourceLogoStack label="Active project source coverage" />
           </div>
           <p>Active boundaries</p>
         </article>
         <article>
           <div className="idt-overview-metric-top">
             <span>{latestProject ? formatConnectionTime(latestProject.updated_at) : 'No activity yet'}</span>
-            <SourceLogoMark provider="aws" />
+            <SourceLogoStack label="Latest project source coverage" />
           </div>
           <p>Latest update</p>
         </article>
@@ -2628,6 +2649,7 @@ export function ProductProjectDetailPage() {
   const repoScanRepository = normalizeValue(repoScanForm.repository);
   const effectiveRepoScanRepository = repoScanRepository || githubSelectedRepositories[0] || '';
   const repoScanFindingsPath = scope ? buildScopedPath(scope, 'findings') : '/app';
+  const enabledSourceLabel = formatSourceNameList(sourceOrder);
 
   const nextRequestSequence = () => {
     const nextSequence = refreshSequenceRef.current + 1;
@@ -3334,7 +3356,7 @@ export function ProductProjectDetailPage() {
           <p className="idt-app-kicker">Project source onboarding</p>
           <h2>Connect sources for {projectID}</h2>
           <p>
-            Add GitHub, AWS, or Kubernetes signals for workspace <strong>{scope.workspaceID}</strong> with live
+            Add {enabledSourceLabel} signals for workspace <strong>{scope.workspaceID}</strong> with live
             validation and remediation feedback.
           </p>
           <div className="idt-overview-source-strip">
@@ -4515,14 +4537,14 @@ export function ProductFindingsPage() {
         <article className="idt-repo-finding-stat">
           <div className="idt-overview-metric-top">
             <span>Open findings</span>
-            <SourceLogoMark provider="aws" />
+            <SourceLogoStack label="Open finding source coverage" />
           </div>
           <strong>{openFindingCount}</strong>
         </article>
         <article className="idt-repo-finding-stat">
           <div className="idt-overview-metric-top">
             <span>Critical findings</span>
-            <SourceLogoMark provider="kubernetes" />
+            <SourceLogoStack label="Critical finding source coverage" />
           </div>
           <strong>{criticalFindingCount}</strong>
         </article>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -18492,3 +18492,430 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-form textarea {
   background: #050505;
   color: #ffffff;
 }
+
+/* Product app visual richness */
+.idt-app-console-layout,
+.idt-account-security-page,
+.idt-app-shell-screen,
+.idt-executive-report-shell {
+  --source-github: #f5f5f5;
+  --source-aws: #ff9900;
+  --source-kubernetes: #326ce5;
+  --app-ink: #050505;
+  --app-paper: #f6f6f4;
+  --app-paper-muted: #646464;
+  --app-blueprint: #0b1220;
+}
+
+.idt-app-console-layout {
+  background:
+    radial-gradient(circle at 78% 8%, rgba(50, 108, 229, 0.16), transparent 20rem),
+    radial-gradient(circle at 14% 18%, rgba(255, 153, 0, 0.1), transparent 16rem),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.038) 1px, transparent 1px) 0 0 / 72px 72px,
+    linear-gradient(180deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px) 0 0 / 72px 72px,
+    #000000;
+}
+
+.idt-app-sidebar {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.045), transparent 15rem),
+    rgba(5, 5, 5, 0.98);
+}
+
+.idt-app-sidebar-mark {
+  overflow: hidden;
+  padding: 0;
+}
+
+.idt-app-sidebar-mark img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.idt-app-sidebar-logo-stack {
+  margin-bottom: 0.75rem;
+}
+
+.idt-source-logo-mark {
+  --source-accent: #ffffff;
+  display: inline-grid;
+  width: 2.1rem;
+  height: 2.1rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.26), 0 0 22px color-mix(in srgb, var(--source-accent) 28%, transparent);
+}
+
+.idt-source-logo-mark.is-github {
+  --source-accent: var(--source-github);
+}
+
+.idt-source-logo-mark.is-aws {
+  --source-accent: var(--source-aws);
+}
+
+.idt-source-logo-mark.is-kubernetes {
+  --source-accent: var(--source-kubernetes);
+}
+
+.idt-source-logo-mark img {
+  width: 1.28rem;
+  height: 1.28rem;
+  object-fit: contain;
+}
+
+.idt-source-logo-mark.is-row {
+  width: 2.25rem;
+  height: 2.25rem;
+}
+
+.idt-source-logo-mark.is-hero {
+  width: 3.35rem;
+  height: 3.35rem;
+  border-radius: 10px;
+}
+
+.idt-source-logo-mark.is-hero img {
+  width: 2rem;
+  height: 2rem;
+}
+
+.idt-source-logo-stack {
+  display: flex;
+  align-items: center;
+}
+
+.idt-source-logo-stack .idt-source-logo-mark {
+  width: 2rem;
+  height: 2rem;
+}
+
+.idt-source-logo-stack .idt-source-logo-mark + .idt-source-logo-mark {
+  margin-left: -0.45rem;
+}
+
+.idt-source-logo-stack .idt-source-logo-mark img {
+  width: 1.16rem;
+  height: 1.16rem;
+}
+
+.idt-app-header-stack,
+.idt-overview-source-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.85rem;
+}
+
+.idt-app-header-stack > span,
+.idt-overview-source-strip > span {
+  max-width: 52ch;
+  color: #c6c6c6;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.idt-app-console-layout .idt-overview-header,
+.idt-app-console-layout .idt-projects-header,
+.idt-app-console-layout .idt-source-onboarding-header,
+.idt-app-console-layout .idt-repo-findings-header,
+.idt-app-console-layout .idt-settings-header {
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.065), rgba(255, 255, 255, 0.012) 50%, rgba(50, 108, 229, 0.08)),
+    #050505;
+}
+
+.idt-app-console-layout .idt-overview-metrics article,
+.idt-app-console-layout .idt-projects-summary article,
+.idt-app-console-layout .idt-source-summary article,
+.idt-app-console-layout .idt-repo-finding-stat {
+  min-height: 8.25rem;
+  display: grid;
+  align-content: space-between;
+  gap: 0.8rem;
+  overflow: hidden;
+  position: relative;
+}
+
+.idt-app-console-layout .idt-overview-metrics article::after,
+.idt-app-console-layout .idt-projects-summary article::after,
+.idt-app-console-layout .idt-source-summary article::after,
+.idt-app-console-layout .idt-repo-finding-stat::after {
+  content: '';
+  position: absolute;
+  right: -2.25rem;
+  bottom: -2.25rem;
+  width: 7rem;
+  height: 7rem;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.08), transparent 68%);
+  pointer-events: none;
+}
+
+.idt-overview-metric-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.8rem;
+}
+
+.idt-app-console-layout .idt-overview-metric-top > span {
+  color: #a3a3a3;
+}
+
+.idt-app-console-layout .is-light-surface,
+.idt-app-console-layout .idt-overview-metrics article.is-light-surface,
+.idt-app-console-layout .idt-projects-summary article.is-light-surface,
+.idt-app-console-layout .idt-source-summary article.is-light-surface,
+html[data-theme='light'] .idt-app-console-layout .is-light-surface,
+html[data-theme='light'] .idt-app-console-layout .idt-overview-metrics article.is-light-surface,
+html[data-theme='light'] .idt-app-console-layout .idt-projects-summary article.is-light-surface,
+html[data-theme='light'] .idt-app-console-layout .idt-source-summary article.is-light-surface {
+  border-color: rgba(255, 255, 255, 0.9);
+  background:
+    radial-gradient(circle at 85% 0%, rgba(255, 153, 0, 0.18), transparent 10rem),
+    var(--app-paper);
+  color: var(--app-ink);
+}
+
+.idt-app-console-layout .is-light-surface strong,
+.idt-app-console-layout .is-light-surface h3,
+.idt-app-console-layout .is-light-surface h4,
+.idt-app-console-layout .is-light-surface .idt-overview-metric-top > span,
+.idt-app-console-layout .is-light-surface span,
+.idt-app-console-layout .idt-overview-metrics article.is-light-surface strong,
+.idt-app-console-layout .idt-overview-metrics article.is-light-surface span,
+.idt-app-console-layout .idt-projects-summary article.is-light-surface strong,
+.idt-app-console-layout .idt-projects-summary article.is-light-surface span,
+.idt-app-console-layout .idt-source-summary article.is-light-surface strong,
+.idt-app-console-layout .idt-source-summary article.is-light-surface span,
+html[data-theme='light'] .idt-app-console-layout .is-light-surface strong,
+html[data-theme='light'] .idt-app-console-layout .is-light-surface h3,
+html[data-theme='light'] .idt-app-console-layout .is-light-surface h4,
+html[data-theme='light'] .idt-app-console-layout .is-light-surface .idt-overview-metric-top > span,
+html[data-theme='light'] .idt-app-console-layout .is-light-surface span,
+html[data-theme='light'] .idt-app-console-layout .idt-overview-metrics article.is-light-surface strong,
+html[data-theme='light'] .idt-app-console-layout .idt-overview-metrics article.is-light-surface span,
+html[data-theme='light'] .idt-app-console-layout .idt-projects-summary article.is-light-surface strong,
+html[data-theme='light'] .idt-app-console-layout .idt-projects-summary article.is-light-surface span,
+html[data-theme='light'] .idt-app-console-layout .idt-source-summary article.is-light-surface strong,
+html[data-theme='light'] .idt-app-console-layout .idt-source-summary article.is-light-surface span {
+  color: var(--app-ink);
+}
+
+.idt-app-console-layout .is-light-surface p,
+html[data-theme='light'] .idt-app-console-layout .is-light-surface p,
+html[data-theme='light'] .idt-app-console-layout .idt-overview-metrics article.is-light-surface p,
+html[data-theme='light'] .idt-app-console-layout .idt-projects-summary article.is-light-surface p,
+html[data-theme='light'] .idt-app-console-layout .idt-source-summary article.is-light-surface p {
+  color: var(--app-paper-muted);
+}
+
+.idt-app-console-layout .is-danger-surface {
+  border-color: rgba(255, 107, 107, 0.38);
+  background:
+    radial-gradient(circle at 100% 0%, rgba(255, 107, 107, 0.17), transparent 10rem),
+    #080808;
+}
+
+.idt-app-console-layout .is-provider-surface {
+  border-color: rgba(50, 108, 229, 0.42);
+  background:
+    radial-gradient(circle at 100% 0%, rgba(50, 108, 229, 0.2), transparent 10rem),
+    #080808;
+}
+
+.idt-overview-risk-row,
+.idt-overview-scan-row,
+.idt-repo-finding-row {
+  align-items: flex-start;
+  gap: 0.85rem;
+}
+
+.idt-overview-row-copy,
+.idt-repo-finding-row-copy {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.idt-overview-row-copy {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: flex-start;
+}
+
+.idt-overview-project-title,
+.idt-project-card-title,
+.idt-source-card-identity,
+.idt-source-config-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.idt-overview-project-title,
+.idt-project-card-title {
+  justify-content: space-between;
+}
+
+.idt-overview-project-title .idt-source-logo-stack,
+.idt-project-card-title .idt-source-logo-stack {
+  flex: 0 0 auto;
+}
+
+.idt-app-console-layout .idt-overview-actions a {
+  display: grid;
+  align-content: start;
+  gap: 0.55rem;
+  min-height: 8.5rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.idt-app-console-layout .idt-overview-actions a:nth-child(2),
+html[data-theme='light'] .idt-app-console-layout .idt-overview-actions a:nth-child(2) {
+  border-color: rgba(255, 255, 255, 0.9);
+  background: var(--app-paper);
+  color: var(--app-ink);
+}
+
+.idt-app-console-layout .idt-overview-actions a:nth-child(2) strong,
+.idt-app-console-layout .idt-overview-actions a:nth-child(2) span,
+html[data-theme='light'] .idt-app-console-layout .idt-overview-actions a:nth-child(2) strong,
+html[data-theme='light'] .idt-app-console-layout .idt-overview-actions a:nth-child(2) span {
+  color: var(--app-ink);
+}
+
+.idt-app-console-layout .idt-overview-actions a:nth-child(2) .idt-source-logo-mark {
+  border-color: rgba(0, 0, 0, 0.14);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.08);
+}
+
+.idt-source-card {
+  --provider-accent: rgba(255, 255, 255, 0.6);
+  position: relative;
+  overflow: hidden;
+}
+
+.idt-source-card.is-provider-aws {
+  --provider-accent: var(--source-aws);
+}
+
+.idt-source-card.is-provider-kubernetes {
+  --provider-accent: var(--source-kubernetes);
+}
+
+.idt-source-card.is-provider-github {
+  --provider-accent: #ffffff;
+}
+
+.idt-source-card::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--provider-accent);
+  opacity: 0.75;
+}
+
+.idt-app-console-layout .idt-source-card.is-selected {
+  border-color: color-mix(in srgb, var(--provider-accent) 70%, #ffffff);
+  background:
+    radial-gradient(circle at 100% 0%, color-mix(in srgb, var(--provider-accent) 18%, transparent), transparent 10rem),
+    #111111;
+}
+
+.idt-source-card-topline {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.7rem;
+}
+
+.idt-source-card-identity {
+  min-width: 0;
+}
+
+.idt-source-card-identity > span:last-child {
+  overflow-wrap: anywhere;
+}
+
+.idt-source-config-title {
+  min-width: 0;
+  align-items: flex-start;
+}
+
+.idt-source-config-title > div {
+  min-width: 0;
+}
+
+.idt-app-console-layout .idt-source-meta {
+  gap: 0.75rem;
+}
+
+.idt-app-console-layout .idt-source-meta div,
+html[data-theme='light'] .idt-app-console-layout .idt-source-meta div {
+  border-color: rgba(255, 255, 255, 0.16);
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.055), transparent),
+    #060606;
+}
+
+.idt-app-console-layout .idt-source-install-card {
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.06), transparent),
+    #060606;
+}
+
+.idt-app-console-layout .idt-repo-finding-row {
+  display: flex;
+  text-align: left;
+}
+
+.idt-app-console-layout .idt-repo-finding-row.is-selected {
+  border-color: rgba(255, 255, 255, 0.86);
+  background:
+    radial-gradient(circle at 100% 0%, rgba(255, 255, 255, 0.12), transparent 12rem),
+    #111111;
+}
+
+.idt-app-console-layout .idt-repo-finding-row-top {
+  align-items: flex-start;
+  gap: 0.7rem;
+}
+
+.idt-app-console-layout .idt-repo-finding-trend {
+  background:
+    linear-gradient(90deg, rgba(255, 255, 255, 0.055) 1px, transparent 1px) 0 0 / 56px 56px,
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px) 0 0 / 56px 56px,
+    #080808;
+}
+
+.idt-app-console-layout .idt-repo-finding-trend-bar {
+  background: linear-gradient(90deg, #ffffff, rgba(50, 108, 229, 0.88));
+}
+
+@media (max-width: 700px) {
+  .idt-app-header-stack,
+  .idt-overview-source-strip,
+  .idt-source-config-title {
+    align-items: flex-start;
+  }
+
+  .idt-overview-row-copy {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-source-card-topline,
+  .idt-overview-project-title,
+  .idt-project-card-title {
+    display: grid;
+    justify-content: stretch;
+  }
+}


### PR DESCRIPTION
Fixes #1208

## What changed
- Added a reusable source-logo layer for GitHub, AWS, and Kubernetes across the app console.
- Threaded provider identity through the sidebar, overview metrics, project registry, source onboarding, and findings workflow.
- Added restrained light contrast cards, provider accents, richer row rhythm, and grid/blueprint surfaces so the app stays dark without feeling flat.

## Why
The merged app shell had the right dark foundation, but the experience was too uniformly black. This pass keeps the Vercel-like console direction while adding modern product-app variety and recognizable source context.

## Impact and risk
UI-only change in the web app console. No API contract changes. Uses existing public logo assets and keeps unrelated screenshots/artifacts out of the PR.

## Validation
- npm test -- --run src/productShell.test.tsx src/App.test.tsx
- VITE_IDENTRAIL_API_URL=http://localhost:8080 npm run build
- git diff --check
- Local browser smoke check against a mocked API for overview, projects, source onboarding, and findings: no page errors, logos render, light contrast surfaces apply, and horizontal overflow stays at 0.

## AI-assisted disclosure
- AI-assisted: yes
- Tools used: Codex
- Where used: web/src/productShell.tsx and web/src/styles.css
- Human verification performed: local tests, production build, diff hygiene check, and browser smoke verification