### PR TITLE
Replace scan CTA with modal trust path review intake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@
   `scopes: null` renders as `None granted` instead of tripping the app error
   boundary, and replaced the fallback error copy with user-facing workspace
   recovery language.
+- Replaced the standalone read-only scan page with a rectangular multi-step
+  modal opened by the new `Request Trust Path Review` CTA, keeping
+  `/read-only-scan` as a compatibility opener and collecting extra verifiable
+  requester, identity-provider, scope, and public repository context before the
+  final review-and-submit step.
 - Required explicit review before read-only scan intake submission and added
   stronger lead-quality checks for work emails, disposable domains, matching
   company websites, and publicly verifiable company DNS.

--- a/web/api/leads.test.ts
+++ b/web/api/leads.test.ts
@@ -52,6 +52,13 @@ function mockCompanyDomainDNS(hasRecords = true) {
   resolveMxMock.mockRejectedValue(new Error('not found'));
 }
 
+const readOnlyScanDetails = {
+  full_name: 'Alex Morgan',
+  role_title: 'Security Engineering Lead',
+  identity_provider: 'AWS IAM Identity Center / SSO',
+  infrastructure_scope: '1-5 cloud accounts or clusters'
+};
+
 describe('web/api/leads handler', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -152,6 +159,7 @@ describe('web/api/leads handler', () => {
           company: 'Company Inc',
           company_domain: 'other-company.com',
           environment: 'AWS IAM',
+          ...readOnlyScanDetails,
           source: 'Read-Only Scan Intake',
           page_path: '/read-only-scan'
         }
@@ -161,6 +169,37 @@ describe('web/api/leads handler', () => {
 
     expect(res.statusCode).toBe(400);
     expect(res.body).toEqual({ error: 'Company website must match the domain in your work email.' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('requires requester details for read-only scan requests', async () => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = createMockResponse();
+    await handler(
+      {
+        method: 'POST',
+        body: {
+          email: 'security@company.com',
+          company: 'Company Inc',
+          company_domain: 'company.com',
+          environment: 'AWS IAM',
+          role_title: readOnlyScanDetails.role_title,
+          identity_provider: readOnlyScanDetails.identity_provider,
+          infrastructure_scope: readOnlyScanDetails.infrastructure_scope,
+          source: 'Read-Only Scan Intake',
+          page_path: '/read-only-scan'
+        }
+      },
+      res
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 'Full name is required.' });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -181,6 +220,7 @@ describe('web/api/leads handler', () => {
           company: 'Company Inc',
           company_domain: 'company.com',
           environment: 'AWS IAM',
+          ...readOnlyScanDetails,
           source: 'Read-Only Scan Intake',
           page_path: '/read-only-scan'
         }
@@ -190,6 +230,102 @@ describe('web/api/leads handler', () => {
 
     expect(res.statusCode).toBe(400);
     expect(res.body).toEqual({ error: 'Company website must be a registered domain with public DNS records.' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid public repository URLs for read-only scan requests', async () => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = createMockResponse();
+    await handler(
+      {
+        method: 'POST',
+        body: {
+          email: 'security@company.com',
+          company: 'Company Inc',
+          company_domain: 'company.com',
+          environment: 'AWS IAM',
+          repository_url: 'https://example.com/company/repo',
+          ...readOnlyScanDetails,
+          source: 'Read-Only Scan Intake',
+          page_path: '/read-only-scan'
+        }
+      },
+      res
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      error: 'Public repository URL must be a valid GitHub, GitLab, or Bitbucket organization or repository URL.'
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-string public repository URL values without throwing', async () => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = createMockResponse();
+    await handler(
+      {
+        method: 'POST',
+        body: {
+          email: 'security@company.com',
+          company: 'Company Inc',
+          company_domain: 'company.com',
+          environment: 'AWS IAM',
+          repository_url: 123,
+          ...readOnlyScanDetails,
+          source: 'Read-Only Scan Intake',
+          page_path: '/read-only-scan'
+        }
+      },
+      res
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      error: 'Public repository URL must be a valid GitHub, GitLab, or Bitbucket organization or repository URL.'
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-web public repository URL schemes', async () => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = createMockResponse();
+    await handler(
+      {
+        method: 'POST',
+        body: {
+          email: 'security@company.com',
+          company: 'Company Inc',
+          company_domain: 'company.com',
+          environment: 'AWS IAM',
+          repository_url: 'ssh://git@github.com/company/repo',
+          ...readOnlyScanDetails,
+          source: 'Read-Only Scan Intake',
+          page_path: '/read-only-scan'
+        }
+      },
+      res
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      error: 'Public repository URL must be a valid GitHub, GitLab, or Bitbucket organization or repository URL.'
+    });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -217,6 +353,7 @@ describe('web/api/leads handler', () => {
           company: 'Company Inc',
           company_domain: 'company.com',
           environment: 'AWS IAM',
+          ...readOnlyScanDetails,
           source: 'Read-Only Scan Intake',
           page_path: '/read-only-scan'
         }
@@ -246,6 +383,7 @@ describe('web/api/leads handler', () => {
           urgency: 'This quarter',
           team_size: '6-20',
           scan_goal: 'AWS IAM + Kubernetes trust-path risk reduction',
+          ...readOnlyScanDetails,
           source: 'Read-Only Scan Intake',
           page_path: '/read-only-scan'
         }
@@ -430,7 +568,7 @@ describe('web/api/leads handler', () => {
         method: 'POST',
         body: {
           email: 'security@company.com',
-          company: 'Acme Corp',
+          company: 'Company Inc',
           company_domain: 'company.com',
           environment: 'AWS IAM + Kubernetes',
           challenge: 'Trust path visibility',
@@ -438,6 +576,8 @@ describe('web/api/leads handler', () => {
           urgency: 'This quarter',
           team_size: '6-20',
           scan_goal: 'AWS IAM + Kubernetes trust-path risk reduction',
+          repository_url: 'gitlab.com/platform/security/identity-risk/-/tree/main',
+          ...readOnlyScanDetails,
           source: 'Read-Only Scan Intake',
           page_path: '/read-only-scan'
         }
@@ -453,12 +593,16 @@ describe('web/api/leads handler', () => {
     const notificationHeaders = (notificationInit.headers ?? {}) as Record<string, string>;
     expect(notificationHeaders.Authorization).toBe('Bearer re_test_key');
     expect(notificationHeaders['Idempotency-Key']).toMatch(/lead-notification$/);
-    expect(JSON.parse(String(notificationInit.body))).toMatchObject({
+    const notificationBody = JSON.parse(String(notificationInit.body));
+    expect(notificationBody).toMatchObject({
       from: 'Identrail <scan@identrail.com>',
       to: ['sales@identrail.com', 'security@identrail.com'],
       reply_to: 'security@company.com',
-      subject: '[Identrail] New risk scan request from Acme Corp (security@company.com)'
+      subject: '[Identrail] New risk scan request from Company Inc (security@company.com)'
     });
+    expect(notificationBody.text).toContain('Name: Alex Morgan');
+    expect(notificationBody.text).toContain('Role/title: Security Engineering Lead');
+    expect(notificationBody.text).toContain('Public repository: https://gitlab.com/platform/security/identity-risk');
 
     const [, confirmationInit] = fetchMock.mock.calls[1] as unknown as [string, RequestInit];
     const confirmationHeaders = (confirmationInit.headers ?? {}) as Record<string, string>;
@@ -592,6 +736,7 @@ describe('web/api/leads handler', () => {
           company: 'Company Inc',
           company_domain: 'company.com',
           environment: 'AWS IAM + Kubernetes',
+          ...readOnlyScanDetails,
           source: 'Read-Only Scan Intake',
           page_path: '/read-only-scan'
         }
@@ -691,6 +836,7 @@ describe('web/api/leads handler', () => {
           urgency: 'This quarter',
           team_size: '6-20',
           scan_goal: 'AWS IAM + Kubernetes trust-path risk reduction',
+          ...readOnlyScanDetails,
           source: 'Read-Only Scan Intake',
           page_path: '/read-only-scan'
         }
@@ -704,8 +850,12 @@ describe('web/api/leads handler', () => {
     const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     expect(JSON.parse(String(init.body))).toMatchObject({
       email: 'security@company.com',
+      full_name: 'Alex Morgan',
+      role_title: 'Security Engineering Lead',
       environment: 'AWS IAM + Kubernetes',
-      challenge: 'Trust path visibility'
+      challenge: 'Trust path visibility',
+      identity_provider: 'AWS IAM Identity Center / SSO',
+      infrastructure_scope: '1-5 cloud accounts or clusters'
     });
   });
 });

--- a/web/api/leads.ts
+++ b/web/api/leads.ts
@@ -4,10 +4,15 @@ import { isIP } from 'node:net';
 
 type LeadCapturePayload = {
   email?: string;
+  full_name?: string;
+  role_title?: string;
   environment?: string;
   company?: string;
   company_domain?: string;
   challenge?: string;
+  identity_provider?: string;
+  infrastructure_scope?: string;
+  repository_url?: string;
   website?: string;
   deployment_model?: string;
   scan_goal?: string;
@@ -28,10 +33,15 @@ const MIN_RATE_LIMIT_PER_MIN = 1;
 const MAX_RATE_LIMIT_PER_MIN = 120;
 const RATE_WINDOW_MS = 60_000;
 const MAX_EMAIL_LENGTH = 254;
+const MAX_PERSON_NAME_LENGTH = 120;
+const MAX_ROLE_TITLE_LENGTH = 120;
 const MAX_ENVIRONMENT_LENGTH = 180;
 const MAX_COMPANY_LENGTH = 120;
 const MAX_COMPANY_DOMAIN_LENGTH = 253;
 const MAX_CHALLENGE_LENGTH = 2_000;
+const MAX_IDENTITY_PROVIDER_LENGTH = 120;
+const MAX_INFRASTRUCTURE_SCOPE_LENGTH = 120;
+const MAX_REPOSITORY_URL_LENGTH = 240;
 const MAX_SCAN_GOAL_LENGTH = 600;
 const MAX_SOURCE_LENGTH = 120;
 const MAX_PAGE_PATH_LENGTH = 240;
@@ -40,9 +50,14 @@ const MAX_URGENCY_LENGTH = 32;
 const MAX_DEPLOYMENT_MODEL_LENGTH = 64;
 const RESEND_EMAILS_URL = 'https://api.resend.com/emails';
 const WORK_EMAIL_ERROR = 'Please use a company or work email address.';
+const FULL_NAME_ERROR = 'Full name is required.';
+const ROLE_TITLE_ERROR = 'Role or title is required.';
+const IDENTITY_PROVIDER_ERROR = 'Identity provider is required.';
+const INFRASTRUCTURE_SCOPE_ERROR = 'Infrastructure scope is required.';
 const COMPANY_DOMAIN_ERROR = 'Please enter a real company website or domain.';
 const COMPANY_DOMAIN_MATCH_ERROR = 'Company website must match the domain in your work email.';
 const COMPANY_DOMAIN_VERIFICATION_ERROR = 'Company website must be a registered domain with public DNS records.';
+const REPOSITORY_URL_ERROR = 'Public repository URL must be a valid GitHub, GitLab, or Bitbucket organization or repository URL.';
 const PERSONAL_EMAIL_DOMAINS = new Set([
   'aol.com',
   'fastmail.com',
@@ -90,10 +105,15 @@ const leadRequestBuckets = new Map<string, number[]>();
 
 type LeadDeliveryPayload = {
   email: string;
+  full_name?: string;
+  role_title?: string;
   environment: string;
   company?: string;
   company_domain?: string;
   challenge?: string;
+  identity_provider?: string;
+  infrastructure_scope?: string;
+  repository_url?: string;
   deployment_model?: string;
   scan_goal?: string;
   urgency?: string;
@@ -180,6 +200,44 @@ function companyDomainMatchesEmail(email: string, companyDomain: string): boolea
   );
 }
 
+function normalizePublicRepositoryURLInput(value: unknown): string {
+  const raw = trimOptional(value) ?? '';
+  if (!raw) {
+    return '';
+  }
+  const candidate = raw.includes('://') ? raw : `https://${raw}`;
+  try {
+    const url = new URL(candidate);
+    if (!['http:', 'https:'].includes(url.protocol)) {
+      return '';
+    }
+    const host = url.hostname.toLowerCase().replace(/^www\./, '');
+    if (!['github.com', 'gitlab.com', 'bitbucket.org'].includes(host)) {
+      return '';
+    }
+    const pathParts = url.pathname.split('/').filter(Boolean);
+    const specialPathIndex = host === 'gitlab.com' ? pathParts.indexOf('-') : -1;
+    const canonicalPathParts = specialPathIndex >= 0 ? pathParts.slice(0, specialPathIndex) : pathParts;
+    const maxPathParts = host === 'gitlab.com' ? 20 : 2;
+    if (canonicalPathParts.length < 1 || canonicalPathParts.length > maxPathParts) {
+      return '';
+    }
+    return `${url.protocol}//${host}/${canonicalPathParts.join('/')}`;
+  } catch {
+    return '';
+  }
+}
+
+function hasPublicRepositoryURLInput(value: unknown): boolean {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  if (typeof value === 'string') {
+    return Boolean(value.trim());
+  }
+  return true;
+}
+
 const DNS_LOOKUP_TIMEOUT_MS = 2_000;
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
@@ -201,10 +259,11 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
 async function hasPublicDNSRecords(domain: string): Promise<boolean> {
   // Bound each resolver call so a slow/unresponsive DNS server cannot stall
   // lead submission and degrade overall API responsiveness.
-  const lookups = [resolveMx(domain), resolve4(domain), resolve6(domain)].map((lookup) =>
+  const lookups: Array<Promise<unknown[]>> = [resolveMx(domain), resolve4(domain), resolve6(domain)];
+  const boundedLookups = lookups.map((lookup) =>
     withTimeout(lookup, DNS_LOOKUP_TIMEOUT_MS)
   );
-  const results = await Promise.allSettled(lookups);
+  const results = await Promise.allSettled(boundedLookups);
   return results.some((result) => result.status === 'fulfilled' && result.value.length > 0);
 }
 
@@ -342,10 +401,15 @@ function leadDisplayName(payload: LeadDeliveryPayload): string {
 function leadRows(payload: LeadDeliveryPayload): Array<[string, string | undefined]> {
   return [
     ['Work email', payload.email],
+    ['Name', payload.full_name],
+    ['Role/title', payload.role_title],
     ['Company', payload.company],
     ['Company domain', payload.company_domain],
     ['Environment', payload.environment],
     ['Challenge', payload.challenge],
+    ['Identity provider', payload.identity_provider],
+    ['Infrastructure scope', payload.infrastructure_scope],
+    ['Public repository', payload.repository_url],
     ['Deployment model', payload.deployment_model],
     ['Urgency', payload.urgency],
     ['Team size', payload.team_size],
@@ -394,8 +458,13 @@ function renderConfirmationText(payload: LeadDeliveryPayload): string {
     '',
     'We received your intake and will review the context before following up.',
     '',
+    `Requester: ${payload.full_name || 'Not provided'}`,
+    `Role/title: ${payload.role_title || 'Not provided'}`,
     `Environment: ${payload.environment}`,
     `Company domain: ${payload.company_domain || 'Not provided'}`,
+    `Identity provider: ${payload.identity_provider || 'Not provided'}`,
+    `Infrastructure scope: ${payload.infrastructure_scope || 'Not provided'}`,
+    `Public repository: ${payload.repository_url || 'Not provided'}`,
     `Focus area: ${payload.challenge || 'Trust path visibility'}`,
     `Deployment preference: ${payload.deployment_model || 'Not provided'}`,
     '',
@@ -409,8 +478,13 @@ function renderConfirmationHTML(payload: LeadDeliveryPayload): string {
       <h1 style="font-size:20px;margin:0 0 12px;">We received your Identrail risk scan request</h1>
       <p style="margin:0 0 16px;">Thanks for requesting a read-only machine identity risk scan. We will review the context before following up.</p>
       <ul style="padding-left:20px;margin:0 0 16px;color:#374151;">
+        <li><strong>Requester:</strong> ${escapeHTML(payload.full_name || 'Not provided')}</li>
+        <li><strong>Role/title:</strong> ${escapeHTML(payload.role_title || 'Not provided')}</li>
         <li><strong>Environment:</strong> ${escapeHTML(payload.environment)}</li>
         <li><strong>Company domain:</strong> ${escapeHTML(payload.company_domain || 'Not provided')}</li>
+        <li><strong>Identity provider:</strong> ${escapeHTML(payload.identity_provider || 'Not provided')}</li>
+        <li><strong>Infrastructure scope:</strong> ${escapeHTML(payload.infrastructure_scope || 'Not provided')}</li>
+        <li><strong>Public repository:</strong> ${escapeHTML(payload.repository_url || 'Not provided')}</li>
         <li><strong>Focus area:</strong> ${escapeHTML(payload.challenge || 'Trust path visibility')}</li>
         <li><strong>Deployment preference:</strong> ${escapeHTML(payload.deployment_model || 'Not provided')}</li>
       </ul>
@@ -544,10 +618,15 @@ export default async function handler(
 
   const body: LeadCapturePayload = req.body && typeof req.body === 'object' ? (req.body as LeadCapturePayload) : {};
   const email = trimOptional(body.email) ?? '';
+  const fullName = trimOptional(body.full_name);
+  const roleTitle = trimOptional(body.role_title);
   const environment = trimOptional(body.environment) ?? '';
   const company = trimOptional(body.company);
   const companyDomain = normalizeCompanyDomainInput(body.company_domain);
   const challenge = trimOptional(body.challenge);
+  const identityProvider = trimOptional(body.identity_provider);
+  const infrastructureScope = trimOptional(body.infrastructure_scope);
+  const repositoryURL = normalizePublicRepositoryURLInput(body.repository_url);
   const website = trimOptional(body.website);
   const scanGoal = trimOptional(body.scan_goal);
   const source = trimOptional(body.source) || 'unknown';
@@ -568,6 +647,22 @@ export default async function handler(
     badRequest(res, 'Environment is required.');
     return;
   }
+  if (requiresCompanyDomain && !fullName) {
+    badRequest(res, FULL_NAME_ERROR);
+    return;
+  }
+  if (requiresCompanyDomain && !roleTitle) {
+    badRequest(res, ROLE_TITLE_ERROR);
+    return;
+  }
+  if (requiresCompanyDomain && !identityProvider) {
+    badRequest(res, IDENTITY_PROVIDER_ERROR);
+    return;
+  }
+  if (requiresCompanyDomain && !infrastructureScope) {
+    badRequest(res, INFRASTRUCTURE_SCOPE_ERROR);
+    return;
+  }
   if (requiresCompanyDomain && !company) {
     badRequest(res, 'Company name is required.');
     return;
@@ -584,6 +679,12 @@ export default async function handler(
   if (!assertLength(res, email, MAX_EMAIL_LENGTH, 'Email is too long.')) {
     return;
   }
+  if (fullName && !assertLength(res, fullName, MAX_PERSON_NAME_LENGTH, 'Name is too long.')) {
+    return;
+  }
+  if (roleTitle && !assertLength(res, roleTitle, MAX_ROLE_TITLE_LENGTH, 'Role or title is too long.')) {
+    return;
+  }
   if (!assertLength(res, environment, MAX_ENVIRONMENT_LENGTH, 'Environment value is too long.')) {
     return;
   }
@@ -594,6 +695,19 @@ export default async function handler(
     return;
   }
   if (challenge && !assertLength(res, challenge, MAX_CHALLENGE_LENGTH, 'Challenge value is too long.')) {
+    return;
+  }
+  if (identityProvider && !assertLength(res, identityProvider, MAX_IDENTITY_PROVIDER_LENGTH, 'Identity provider value is too long.')) {
+    return;
+  }
+  if (infrastructureScope && !assertLength(res, infrastructureScope, MAX_INFRASTRUCTURE_SCOPE_LENGTH, 'Infrastructure scope value is too long.')) {
+    return;
+  }
+  if (hasPublicRepositoryURLInput(body.repository_url) && !repositoryURL) {
+    badRequest(res, REPOSITORY_URL_ERROR);
+    return;
+  }
+  if (repositoryURL && !assertLength(res, repositoryURL, MAX_REPOSITORY_URL_LENGTH, 'Public repository URL is too long.')) {
     return;
   }
   if (scanGoal && !assertLength(res, scanGoal, MAX_SCAN_GOAL_LENGTH, 'Scan goal value is too long.')) {
@@ -627,10 +741,15 @@ export default async function handler(
 
   const payload: LeadDeliveryPayload = {
     email,
+    full_name: fullName,
+    role_title: roleTitle,
     environment,
     company,
     company_domain: companyDomain || undefined,
     challenge,
+    identity_provider: identityProvider,
+    infrastructure_scope: infrastructureScope,
+    repository_url: repositoryURL || undefined,
     deployment_model: deploymentModel && ALLOWED_DEPLOYMENT_MODELS.has(deploymentModel) ? deploymentModel : undefined,
     scan_goal: scanGoal,
     urgency: urgency && ALLOWED_URGENCY.has(urgency) ? urgency : undefined,

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,6 +1,8 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { renderToString } from 'react-dom/server';
+import { StaticRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { App } from './App';
+import { App, RoutedSite, ScanIntakeModalProvider } from './App';
 
 function okJSON(payload: unknown) {
   return {
@@ -52,6 +54,34 @@ function setCurrentPath(pathname: string) {
   });
 }
 
+function fillScanIdentityStep({
+  email = 'security@company.com',
+  fullName = 'Alex Morgan',
+  roleTitle = 'Security Engineering Lead',
+  company = 'Company Inc',
+  companyWebsite = 'company.com'
+} = {}) {
+  fireEvent.change(screen.getByLabelText(/Work email/i), {
+    target: { value: email }
+  });
+  fireEvent.change(screen.getByLabelText(/Your name/i), {
+    target: { value: fullName }
+  });
+  fireEvent.change(screen.getByLabelText(/Role or title/i), {
+    target: { value: roleTitle }
+  });
+  fireEvent.change(screen.getByLabelText(/Company name/i), {
+    target: { value: company }
+  });
+  fireEvent.change(screen.getByLabelText(/Company website/i), {
+    target: { value: companyWebsite }
+  });
+}
+
+function leadCaptureCalls(fetchMock: ReturnType<typeof vi.fn>) {
+  return fetchMock.mock.calls.filter(([url]) => url === '/api/leads');
+}
+
 describe('App', () => {
   beforeEach(() => {
     vi.unstubAllEnvs();
@@ -76,9 +106,10 @@ describe('App', () => {
       })
     ).toBeInTheDocument();
 
-    const scanLinks = screen.getAllByRole('link', { name: 'Start Free Risk Scan' });
-    expect(scanLinks.length).toBeGreaterThan(0);
-    expect(scanLinks[0]).toHaveAttribute('href', '/read-only-scan');
+    const scanButtons = screen.getAllByRole('button', { name: 'Request Trust Path Review' });
+    expect(scanButtons.length).toBeGreaterThan(0);
+    fireEvent.click(scanButtons[0]);
+    expect(screen.getByRole('dialog', { name: /Verify company identity/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Book Demo/i })).toBeInTheDocument();
     expect(screen.getAllByText(/Adoption Paths/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Reachable Risk Paths/i).length).toBeGreaterThan(0);
@@ -120,7 +151,7 @@ describe('App', () => {
     expect(screen.getByRole('heading', { level: 2, name: /Four connected surfaces/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 2, name: /The Trust Graph is the control plane/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 2, name: /From discovery to fix/i })).toBeInTheDocument();
-    expect(screen.getAllByRole('link', { name: /Start Free Risk Scan/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('button', { name: /Request Trust Path Review/i }).length).toBeGreaterThan(0);
     expect(document.querySelector('main main')).not.toBeInTheDocument();
     expect(document.querySelector('.idt-product-hero-visual')).toHaveAttribute('aria-hidden', 'true');
   });
@@ -130,14 +161,28 @@ describe('App', () => {
     render(<App />);
 
     expect(
-      screen.getByRole('heading', {
-        level: 1,
-        name: /Start a read-only identity risk scan/i
+      screen.getByRole('dialog', {
+        name: /Verify company identity/i
       })
     ).toBeInTheDocument();
 
+    expect(screen.getByRole('heading', { name: /Request a trust path review/i })).toBeInTheDocument();
     expect(screen.getByText(/Step 1 of 4/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument();
+  });
+
+  it('prerenders read-only scan intake content without relying on effects', () => {
+    const html = renderToString(
+      <StaticRouter location="/read-only-scan">
+        <ScanIntakeModalProvider>
+          <RoutedSite />
+        </ScanIntakeModalProvider>
+      </StaticRouter>
+    );
+
+    expect(html).toContain('Request a trust path review');
+    expect(html).toContain('Verify company identity');
+    expect(html).toContain('idt-intake-step');
   });
 
   it('rejects personal email domains before advancing the read-only scan intake', () => {
@@ -146,20 +191,15 @@ describe('App', () => {
     vi.stubGlobal('fetch', fetchMock);
     render(<App />);
 
-    fireEvent.change(screen.getByLabelText(/Work email/i), {
-      target: { value: 'person@gmail.com' }
-    });
-    fireEvent.change(screen.getByLabelText(/Company name/i), {
-      target: { value: 'Personal Co' }
-    });
-    fireEvent.change(screen.getByLabelText(/Company website/i), {
-      target: { value: 'company.com' }
+    fillScanIdentityStep({
+      email: 'person@gmail.com',
+      company: 'Personal Co'
     });
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
 
     expect(screen.getByRole('alert')).toHaveTextContent(/company or work email/i);
     expect(screen.getByText(/Step 1 of 4/i)).toBeInTheDocument();
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(leadCaptureCalls(fetchMock)).toHaveLength(0);
   });
 
   it('rejects company domains that do not match the work email domain', () => {
@@ -168,20 +208,14 @@ describe('App', () => {
     vi.stubGlobal('fetch', fetchMock);
     render(<App />);
 
-    fireEvent.change(screen.getByLabelText(/Work email/i), {
-      target: { value: 'security@company.com' }
-    });
-    fireEvent.change(screen.getByLabelText(/Company name/i), {
-      target: { value: 'Company Inc' }
-    });
-    fireEvent.change(screen.getByLabelText(/Company website/i), {
-      target: { value: 'other-company.com' }
+    fillScanIdentityStep({
+      companyWebsite: 'other-company.com'
     });
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
 
     expect(screen.getByRole('alert')).toHaveTextContent(/match the domain/i);
     expect(screen.getByText(/Step 1 of 4/i)).toBeInTheDocument();
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(leadCaptureCalls(fetchMock)).toHaveLength(0);
   });
 
   it('rejects a whitespace-only company name before advancing', () => {
@@ -190,20 +224,14 @@ describe('App', () => {
     vi.stubGlobal('fetch', fetchMock);
     render(<App />);
 
-    fireEvent.change(screen.getByLabelText(/Work email/i), {
-      target: { value: 'security@company.com' }
-    });
-    fireEvent.change(screen.getByLabelText(/Company name/i), {
-      target: { value: '   ' }
-    });
-    fireEvent.change(screen.getByLabelText(/Company website/i), {
-      target: { value: 'company.com' }
+    fillScanIdentityStep({
+      company: '   '
     });
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
 
     expect(screen.getByRole('alert')).toHaveTextContent(/enter your company name/i);
     expect(screen.getByText(/Step 1 of 4/i)).toBeInTheDocument();
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(leadCaptureCalls(fetchMock)).toHaveLength(0);
   });
 
   it('does not submit the read-only scan intake before the final step', async () => {
@@ -212,21 +240,13 @@ describe('App', () => {
     vi.stubGlobal('fetch', fetchMock);
     render(<App />);
 
-    fireEvent.change(screen.getByLabelText(/Work email/i), {
-      target: { value: 'security@company.com' }
-    });
-    fireEvent.change(screen.getByLabelText(/Company name/i), {
-      target: { value: 'Company Inc' }
-    });
-    fireEvent.change(screen.getByLabelText(/Company website/i), {
-      target: { value: 'company.com' }
-    });
+    fillScanIdentityStep();
     const form = document.querySelector('form.idt-scan-form');
     expect(form).toBeTruthy();
     fireEvent.submit(form as HTMLFormElement);
 
     await waitFor(() => expect(screen.getByText(/Step 2 of 4/i)).toBeInTheDocument());
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(leadCaptureCalls(fetchMock)).toHaveLength(0);
   });
 
   it('submits read-only scan challenge details to lead capture', async () => {
@@ -235,33 +255,37 @@ describe('App', () => {
     vi.stubGlobal('fetch', fetchMock);
     render(<App />);
 
-    fireEvent.change(screen.getByLabelText(/Work email/i), {
-      target: { value: 'security@company.com' }
-    });
-    fireEvent.change(screen.getByLabelText(/Company name/i), {
-      target: { value: 'Company Inc' }
-    });
-    fireEvent.change(screen.getByLabelText(/Company website/i), {
-      target: { value: 'https://www.company.com' }
+    fillScanIdentityStep({
+      companyWebsite: 'https://www.company.com'
     });
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    fireEvent.change(screen.getByLabelText(/Public code host/i), {
+      target: { value: 'gitlab.com/platform/security/identity-risk' }
+    });
     fireEvent.click(screen.getByRole('button', { name: 'Review Request' }));
     expect(screen.getByText(/Step 4 of 4/i)).toBeInTheDocument();
     expect(screen.getByText('security@company.com')).toBeInTheDocument();
+    expect(screen.getByText(/Alex Morgan - Security Engineering Lead/i)).toBeInTheDocument();
     expect(screen.getByText('company.com')).toBeInTheDocument();
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(screen.getByText('https://gitlab.com/platform/security/identity-risk')).toBeInTheDocument();
+    expect(leadCaptureCalls(fetchMock)).toHaveLength(0);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Submit Risk Scan Request' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Review Request' }));
 
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/leads', expect.any(Object)));
-    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    await waitFor(() => expect(leadCaptureCalls(fetchMock)).toHaveLength(1));
+    const [, init] = leadCaptureCalls(fetchMock)[0] as unknown as [string, RequestInit];
     expect(JSON.parse(String(init.body))).toMatchObject({
       email: 'security@company.com',
+      full_name: 'Alex Morgan',
+      role_title: 'Security Engineering Lead',
       company: 'Company Inc',
       company_domain: 'company.com',
       environment: 'AWS IAM + Kubernetes',
       challenge: 'Trust path visibility',
+      identity_provider: 'AWS IAM Identity Center / SSO',
+      infrastructure_scope: '1-5 cloud accounts or clusters',
+      repository_url: 'https://gitlab.com/platform/security/identity-risk',
       page_path: '/read-only-scan'
     });
   });

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -373,7 +373,7 @@ describe('App', () => {
     expect(screen.getByRole('heading', { level: 2, name: /Standard terms/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 3, name: /Acceptance and scope/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 3, name: /Acceptable use/i })).toBeInTheDocument();
-    expect(screen.getByText(/Customer data and integrations/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: /Customer data and integrations/i })).toBeInTheDocument();
     expect(screen.getByText(/Questions about these Terms of Use can be sent to security@identrail.com/i)).toBeInTheDocument();
   });
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4044,6 +4044,138 @@ const TERMS_OF_USE_SECTIONS = [
   }
 ] as const;
 
+type LegalDocumentSection = {
+  title: string;
+  body: readonly string[];
+};
+
+type LegalDocumentMeta = {
+  label: string;
+  value: string;
+};
+
+function legalAnchorID(title: string) {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+}
+
+function LegalDocumentPage({
+  tone,
+  eyebrow,
+  title,
+  intro,
+  summaryTitle,
+  summaryItems,
+  meta,
+  sectionsTitle,
+  sectionsIntro,
+  sections,
+  contactTitle,
+  contactBody,
+  contactHref,
+  contactLabel
+}: {
+  tone: 'privacy' | 'terms';
+  eyebrow: string;
+  title: string;
+  intro: string;
+  summaryTitle: string;
+  summaryItems: readonly string[];
+  meta: readonly LegalDocumentMeta[];
+  sectionsTitle: string;
+  sectionsIntro: string;
+  sections: readonly LegalDocumentSection[];
+  contactTitle: string;
+  contactBody: ReactNode;
+  contactHref?: string;
+  contactLabel?: string;
+}) {
+  const sectionsHeadingID = legalAnchorID(sectionsTitle);
+
+  return (
+    <div className={`idt-legal-page is-${tone}`}>
+      <section className="idt-legal-hero idt-shell">
+        <div className="idt-legal-hero-copy">
+          <p className="idt-eyebrow">{eyebrow}</p>
+          <h1>{title}</h1>
+          <p>{intro}</p>
+          <dl className="idt-legal-meta-list" aria-label={`${title} details`}>
+            {meta.map((item) => (
+              <div key={item.label}>
+                <dt>{item.label}</dt>
+                <dd>{item.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+
+        <aside className="idt-legal-summary-card" aria-labelledby={`${tone}-plain-summary`}>
+          <p className="idt-legal-summary-label">Plain-English summary</p>
+          <h2 id={`${tone}-plain-summary`}>{summaryTitle}</h2>
+          <ul>
+            {summaryItems.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </aside>
+      </section>
+
+      <section className="idt-legal-body idt-shell" aria-labelledby={sectionsHeadingID}>
+        <aside className="idt-legal-sidebar">
+          <p>On this page</p>
+          <nav aria-label={`${title} sections`}>
+            <a href={`#${sectionsHeadingID}`}>{sectionsTitle}</a>
+            {sections.map((section) => (
+              <a key={section.title} href={`#${legalAnchorID(section.title)}`}>
+                {section.title}
+              </a>
+            ))}
+          </nav>
+        </aside>
+
+        <div className="idt-legal-main">
+          <div className="idt-legal-section-heading">
+            <p className="idt-eyebrow">Policy detail</p>
+            <h2 id={sectionsHeadingID}>{sectionsTitle}</h2>
+            <p>{sectionsIntro}</p>
+          </div>
+
+          <div className="idt-legal-section-list">
+            {sections.map((section, index) => (
+              <article key={section.title} id={legalAnchorID(section.title)} className="idt-legal-section-card">
+                <span className="idt-legal-section-number" aria-hidden="true">
+                  {String(index + 1).padStart(2, '0')}
+                </span>
+                <div>
+                  <h3>{section.title}</h3>
+                  {section.body.map((paragraph) => (
+                    <p key={paragraph}>{paragraph}</p>
+                  ))}
+                </div>
+              </article>
+            ))}
+          </div>
+
+          <div className="idt-legal-contact-panel">
+            <div>
+              <p className="idt-eyebrow">Need help?</p>
+              <h2>{contactTitle}</h2>
+              <p>{contactBody}</p>
+            </div>
+            {contactHref && contactLabel ? (
+              <a className="idt-btn idt-btn-primary" href={contactHref}>
+                {contactLabel}
+              </a>
+            ) : null}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
 function PrivacyPage() {
   useSeo({
     title: 'Privacy Policy | Identrail',
@@ -4053,47 +4185,36 @@ function PrivacyPage() {
   });
 
   return (
-    <>
-      <section className="idt-page-hero idt-shell">
-        <h1>Privacy Policy</h1>
-        <p>
-          Identrail handles personal data with a security-first posture. This policy explains how we process
-          website, account, and Google sign-in data for Identrail users.
-        </p>
-      </section>
-
-      <section className="idt-section idt-shell idt-legal-policy" aria-labelledby="google-user-data">
-        <div className="idt-section-title">
-          <h2 id="google-user-data">Google user data disclosure</h2>
-          <p>
-            This section documents how Identrail interacts with Google user data when users sign in or sign up
-            with Google.
-          </p>
-        </div>
-
-        <div className="idt-card-grid two-col">
-          {PRIVACY_POLICY_SECTIONS.map((section) => (
-            <article key={section.title} className="idt-card">
-              <h3>{section.title}</h3>
-              {section.body.map((paragraph) => (
-                <p key={paragraph}>{paragraph}</p>
-              ))}
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="idt-section idt-shell idt-section-tight">
-        <div className="idt-card">
-          <h2>Questions and requests</h2>
-          <p>
-            For privacy questions, account deletion requests, or requests about Google-derived user data, email{' '}
-            <a href="mailto:security@identrail.com?subject=Privacy%20Request">security@identrail.com</a> with
-            the subject Privacy Request.
-          </p>
-        </div>
-      </section>
-    </>
+    <LegalDocumentPage
+      tone="privacy"
+      eyebrow="Privacy and data use"
+      title="Privacy Policy"
+      intro="Identrail treats account data as security-sensitive operational data. This policy explains what we collect, how we use it, and the controls available to people who use our website, sign-in flows, and product experiences."
+      summaryTitle="What we keep intentionally narrow"
+      summaryItems={[
+        'Google sign-in is used for identity and account access, not for Gmail, Drive, Calendar, Contacts, or Workspace content.',
+        'We do not sell personal data or use Google user data for advertising, retargeting, data brokerage, or credit decisions.',
+        'Deletion and privacy requests go directly to the security team so they can be verified and handled with care.'
+      ]}
+      meta={[
+        { label: 'Last updated', value: 'May 18, 2026' },
+        { label: 'Applies to', value: 'Website, sign-in, account, and hosted product experiences' },
+        { label: 'Primary contact', value: 'security@identrail.com' }
+      ]}
+      sectionsTitle="Google user data disclosure"
+      sectionsIntro="This section documents how Identrail interacts with Google user data when a user signs in or signs up with Google."
+      sections={PRIVACY_POLICY_SECTIONS}
+      contactTitle="Questions and requests"
+      contactBody={
+        <>
+          For privacy questions, account deletion requests, or requests about Google-derived user data, email{' '}
+          <a href="mailto:security@identrail.com?subject=Privacy%20Request">security@identrail.com</a> with the
+          subject Privacy Request.
+        </>
+      }
+      contactHref="mailto:security@identrail.com?subject=Privacy%20Request"
+      contactLabel="Start privacy request"
+    />
   );
 }
 
@@ -4106,36 +4227,30 @@ function TermsPage() {
   });
 
   return (
-    <>
-      <section className="idt-page-hero idt-shell">
-        <h1>Terms of Use</h1>
-        <p>
-          These terms set the baseline for using Identrail websites, product experiences, documentation,
-          public resources, accounts, and integrations.
-        </p>
-      </section>
-
-      <section className="idt-section idt-shell idt-legal-policy" aria-labelledby="terms-sections">
-        <div className="idt-section-title">
-          <h2 id="terms-sections">Standard terms</h2>
-          <p>
-            This page summarizes the obligations, restrictions, and operational expectations that apply when
-            you use Identrail.
-          </p>
-        </div>
-
-        <div className="idt-card-grid two-col">
-          {TERMS_OF_USE_SECTIONS.map((section) => (
-            <article key={section.title} className="idt-card">
-              <h3>{section.title}</h3>
-              {section.body.map((paragraph) => (
-                <p key={paragraph}>{paragraph}</p>
-              ))}
-            </article>
-          ))}
-        </div>
-      </section>
-    </>
+    <LegalDocumentPage
+      tone="terms"
+      eyebrow="Terms and acceptable use"
+      title="Terms of Use"
+      intro="These terms set the baseline for using Identrail websites, documentation, public resources, hosted product experiences, accounts, and integrations. They are written to make the operating rules clear before a formal enterprise agreement is needed."
+      summaryTitle="The operating baseline"
+      summaryItems={[
+        'Use Identrail only for systems, organizations, and data you are authorized to assess.',
+        'Connector permissions, API keys, and identity-provider scopes remain your responsibility to approve and maintain.',
+        'Separate signed agreements, order forms, data-processing terms, or open-source licenses control where they are more specific.'
+      ]}
+      meta={[
+        { label: 'Last updated', value: 'May 18, 2026' },
+        { label: 'Applies to', value: 'Website, documentation, demos, accounts, and hosted product use' },
+        { label: 'Security testing', value: 'Responsible Disclosure policy required' }
+      ]}
+      sectionsTitle="Standard terms"
+      sectionsIntro="This page summarizes the obligations, restrictions, and operational expectations that apply when you use Identrail."
+      sections={TERMS_OF_USE_SECTIONS}
+      contactTitle="Terms questions"
+      contactBody="For questions about these terms, procurement reviews, or security-testing boundaries, email the Identrail security contact."
+      contactHref="mailto:security@identrail.com?subject=Terms%20of%20Use"
+      contactLabel="Email legal contact"
+    />
   );
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
-import { FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
-import { BrowserRouter, Link, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { createContext, FormEvent, ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { BrowserRouter, Link, Route, Routes, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { SafeLink } from './components/SafeLink';
 import { HeroProductReveal } from './components/home/HeroProductReveal';
 import { HeroOpenSourceProofPills } from './components/home/HeroOpenSourceProofPills';
@@ -65,11 +65,15 @@ const LINKEDIN_URL = 'https://www.linkedin.com/company/identrail/';
 const X_URL = 'https://x.com/identrail';
 const CALENDLY_URL = 'https://calendly.com/identrail/15min';
 const THEME_STORAGE_KEY = 'identrail-theme';
+const SCAN_CTA_LABEL = 'Request Trust Path Review';
 const INTAKE_TOTAL_STEPS = 4;
 const WORK_EMAIL_ERROR = 'Please use a company or work email address.';
+const FULL_NAME_ERROR = 'Please enter your name.';
+const ROLE_TITLE_ERROR = 'Please enter your role or title.';
 const COMPANY_NAME_ERROR = 'Please enter your company name.';
 const COMPANY_DOMAIN_ERROR = 'Please enter a real company website or domain.';
 const COMPANY_DOMAIN_MATCH_ERROR = 'Company website must match the domain in your work email.';
+const REPOSITORY_URL_ERROR = 'Please enter a valid public GitHub, GitLab, or Bitbucket organization or repository URL.';
 const PERSONAL_EMAIL_DOMAINS = new Set([
   'aol.com',
   'fastmail.com',
@@ -170,6 +174,76 @@ function companyDomainMatchesEmail(email: string, companyDomain: string): boolea
     domain &&
       companyDomain &&
       (domain === companyDomain || domain.endsWith(`.${companyDomain}`) || companyDomain.endsWith(`.${domain}`))
+  );
+}
+
+function normalizePublicRepositoryURLInput(value: string): string {
+  const raw = value.trim();
+  if (!raw) {
+    return '';
+  }
+  const candidate = raw.includes('://') ? raw : `https://${raw}`;
+  try {
+    const url = new URL(candidate);
+    if (!['http:', 'https:'].includes(url.protocol)) {
+      return '';
+    }
+    const host = url.hostname.toLowerCase().replace(/^www\./, '');
+    if (!['github.com', 'gitlab.com', 'bitbucket.org'].includes(host)) {
+      return '';
+    }
+    const pathParts = url.pathname.split('/').filter(Boolean);
+    const specialPathIndex = host === 'gitlab.com' ? pathParts.indexOf('-') : -1;
+    const canonicalPathParts = specialPathIndex >= 0 ? pathParts.slice(0, specialPathIndex) : pathParts;
+    const maxPathParts = host === 'gitlab.com' ? 20 : 2;
+    if (canonicalPathParts.length < 1 || canonicalPathParts.length > maxPathParts) {
+      return '';
+    }
+    return `${url.protocol}//${host}/${canonicalPathParts.join('/')}`;
+  } catch {
+    return '';
+  }
+}
+
+type ScanIntakeModalContextValue = {
+  openScanIntake: () => void;
+};
+
+const ScanIntakeModalContext = createContext<ScanIntakeModalContextValue | null>(null);
+
+function useScanIntakeModal() {
+  const context = useContext(ScanIntakeModalContext);
+  if (!context) {
+    throw new Error('Scan intake modal context is missing.');
+  }
+  return context;
+}
+
+function ScanIntakeCTA({
+  className,
+  children = SCAN_CTA_LABEL
+}: {
+  className: string;
+  children?: ReactNode;
+}) {
+  const { openScanIntake } = useScanIntakeModal();
+  return (
+    <button type="button" className={className} onClick={openScanIntake}>
+      {children}
+    </button>
+  );
+}
+
+export function ScanIntakeModalProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const openScanIntake = useCallback(() => setOpen(true), []);
+  const closeScanIntake = useCallback(() => setOpen(false), []);
+
+  return (
+    <ScanIntakeModalContext.Provider value={{ openScanIntake }}>
+      {children}
+      {open ? <ScanIntakeModal onClose={closeScanIntake} /> : null}
+    </ScanIntakeModalContext.Provider>
   );
 }
 
@@ -1127,7 +1201,7 @@ function LeadCaptureForm({
             <>
               <label>
                 Company (optional)
-                <input type="text" name="company" autoComplete="organization" placeholder="Acme Corp" />
+                <input type="text" name="company" autoComplete="organization" placeholder="Registered company name" />
               </label>
               <label>
                 Biggest challenge
@@ -1156,11 +1230,13 @@ function LeadCaptureForm({
 function ModalShell({
   titleId,
   onClose,
-  children
+  children,
+  className = ''
 }: {
   titleId: string;
   onClose: () => void;
   children: ReactNode;
+  className?: string;
 }) {
   const modalRef = useRef<HTMLDivElement | null>(null);
   const previouslyFocusedRef = useRef<HTMLElement | null>(null);
@@ -1225,7 +1301,7 @@ function ModalShell({
     <div className="idt-modal-backdrop" role="presentation" onClick={onClose}>
       <div
         ref={modalRef}
-        className="idt-modal"
+        className={`idt-modal ${className}`.trim()}
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}
@@ -1978,9 +2054,7 @@ function HomePage() {
               sensitive resources, then packages the proof and safest first fix for the owner.
             </p>
             <div className="idt-inline-actions" data-ab-slot="hero_primary_cta">
-              <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-                Start Free Risk Scan
-              </Link>
+              <ScanIntakeCTA className="idt-btn idt-btn-primary" />
               <HeroOpenSourceProofPills />
             </div>
             <dl className="idt-hero-metrics" aria-label="Product assurances">
@@ -2066,12 +2140,17 @@ function HomePage() {
   );
 }
 
-function ReadOnlyScanPage() {
+function ScanIntakeModal({ onClose }: { onClose: () => void }) {
   const [step, setStep] = useState(1);
   const [email, setEmail] = useState('');
+  const [fullName, setFullName] = useState('');
+  const [roleTitle, setRoleTitle] = useState('');
   const [environment, setEnvironment] = useState('AWS IAM + Kubernetes');
   const [deployment, setDeployment] = useState('Hosted SaaS');
+  const [identityProvider, setIdentityProvider] = useState('AWS IAM Identity Center / SSO');
+  const [infrastructureScope, setInfrastructureScope] = useState('1-5 cloud accounts or clusters');
   const [challenge, setChallenge] = useState('Trust path visibility');
+  const [repositoryUrl, setRepositoryUrl] = useState('');
   const [urgency, setUrgency] = useState('This quarter');
   const [teamSize, setTeamSize] = useState('6-20');
   const [company, setCompany] = useState('');
@@ -2080,14 +2159,8 @@ function ReadOnlyScanPage() {
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  useSeo({
-    title: 'Start Free Risk Scan | Identrail',
-    description:
-      'Start a read-only machine identity risk scan with Identrail. Share planning context and receive a prioritized trust path report with rollout-safe remediation guidance.',
-    path: '/read-only-scan'
-  });
-
   const normalizedCompanyDomain = normalizeCompanyDomainInput(companyDomain);
+  const normalizedRepositoryUrl = normalizePublicRepositoryURLInput(repositoryUrl);
 
   const validateIdentityStep = (form?: HTMLFormElement | null) => {
     if (form && !form.reportValidity()) {
@@ -2095,6 +2168,14 @@ function ReadOnlyScanPage() {
     }
     if (!isWorkEmailAddress(email)) {
       setError(WORK_EMAIL_ERROR);
+      return false;
+    }
+    if (!fullName.trim()) {
+      setError(FULL_NAME_ERROR);
+      return false;
+    }
+    if (!roleTitle.trim()) {
+      setError(ROLE_TITLE_ERROR);
       return false;
     }
     if (!company.trim()) {
@@ -2113,8 +2194,23 @@ function ReadOnlyScanPage() {
     return true;
   };
 
+  const validateRepositoryStep = (form?: HTMLFormElement | null) => {
+    if (form && !form.reportValidity()) {
+      return false;
+    }
+    if (repositoryUrl.trim() && !normalizedRepositoryUrl) {
+      setError(REPOSITORY_URL_ERROR);
+      return false;
+    }
+    setError(null);
+    return true;
+  };
+
   const advanceStep = (form?: HTMLFormElement | null) => {
     if (step === 1 && !validateIdentityStep(form)) {
+      return;
+    }
+    if (step === 3 && !validateRepositoryStep(form)) {
       return;
     }
     setError(null);
@@ -2133,6 +2229,9 @@ function ReadOnlyScanPage() {
     if (!validateIdentityStep(event.currentTarget)) {
       return;
     }
+    if (!validateRepositoryStep(event.currentTarget)) {
+      return;
+    }
 
     const formData = new FormData(event.currentTarget);
     const website = String(formData.get('website') ?? '').trim();
@@ -2143,15 +2242,25 @@ function ReadOnlyScanPage() {
     try {
       await apiClient.submitLeadCapture({
         email: email.trim(),
+        full_name: fullName.trim(),
+        role_title: roleTitle.trim(),
         environment,
         company: company.trim(),
         company_domain: normalizedCompanyDomain,
         challenge: challenge,
+        identity_provider: identityProvider,
+        infrastructure_scope: infrastructureScope,
+        repository_url: normalizedRepositoryUrl || undefined,
         website: website || undefined,
         deployment_model: deployment,
         urgency,
         team_size: teamSize,
-        scan_goal: `${environment} trust path risk reduction`,
+        scan_goal: [
+          `${environment} trust path risk reduction`,
+          `identity provider: ${identityProvider}`,
+          `scope: ${infrastructureScope}`,
+          normalizedRepositoryUrl ? `public repo: ${normalizedRepositoryUrl}` : ''
+        ].filter(Boolean).join('; '),
         source: 'Read-Only Scan Intake',
         page_path: '/read-only-scan'
       });
@@ -2164,47 +2273,54 @@ function ReadOnlyScanPage() {
     }
   };
 
-  return (
-    <>
-      <section className="idt-scan-hero">
-        <div className="idt-scan-hero-copy">
-          <p className="idt-eyebrow">Read-only scan</p>
-          <h1>Start a read-only identity risk scan</h1>
-          <p>
-            Share planning context only. We never ask for environment credentials here, and your first report focuses on machine
-            identity trust paths, reachable blast radius, and rollout-safe next steps.
-          </p>
-          <ul className="idt-scan-assurances" aria-label="Read-only scan assurances">
-            <li>No credentials requested</li>
-            <li>Prioritized trust path findings</li>
-            <li>Deployment-safe remediation plan</li>
-          </ul>
-        </div>
-        <div className="idt-scan-visual" aria-hidden="true">
-          <div className="idt-scan-visual-heading">
-            <span>Identity trust path</span>
-            <strong>Preview report</strong>
-          </div>
-          <div className="idt-scan-path">
-            <span className="is-source">GitHub runner</span>
-            <span className="is-hop">OIDC trust</span>
-            <span className="is-risk">AWS admin role</span>
-          </div>
-          <dl className="idt-scan-risk-metrics">
-            <div>
-              <dt>Exposure</dt>
-              <dd>High</dd>
-            </div>
-            <div>
-              <dt>Action</dt>
-              <dd>Sequence safely</dd>
-            </div>
-          </dl>
-        </div>
-      </section>
+  const stepTitle = submitted
+    ? 'Request received'
+    : step === INTAKE_TOTAL_STEPS
+      ? 'Review before submitting'
+      : step === 1
+        ? 'Verify company identity'
+        : step === 2
+          ? 'Describe the environment'
+          : 'Prioritize the first review';
 
-      <section className="idt-scan-intake" aria-labelledby="scan-intake-title">
-        <form className="idt-scan-form" onSubmit={submitIntake}>
+  const guidance = [
+    'Use a company email, not a personal inbox.',
+    'Enter the registered company website that matches the email domain.',
+    'Share public context only: no keys, tokens, credentials, or screenshots of secrets.',
+    'Add a public GitHub, GitLab, or Bitbucket organization or repository URL only if it helps verify the workspace.'
+  ];
+
+  return (
+    <ModalShell titleId="scan-intake-title" onClose={onClose} className="idt-scan-modal">
+      <button type="button" className="idt-modal-close" onClick={onClose} aria-label="Close dialog">
+        x
+      </button>
+      <div className="idt-scan-modal-shell">
+        <aside className="idt-scan-modal-guide" aria-label="Scan request guidance">
+          <p className="idt-eyebrow">Read-only trust review</p>
+          <h2>Request a trust path review</h2>
+          <p>
+            A short, review-first request gives the team enough public context to prepare a useful trust-path report.
+          </p>
+          <ol className="idt-scan-stepper" aria-label="Scan request steps">
+            {['Identity', 'Environment', 'Priority', 'Review'].map((label, index) => (
+              <li key={label} className={step === index + 1 ? 'is-active' : ''}>
+                <span>{index + 1}</span>
+                {label}
+              </li>
+            ))}
+          </ol>
+          <div className="idt-scan-guidance-list">
+            <h3>What to prepare</h3>
+            <ul>
+              {guidance.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </div>
+        </aside>
+
+        <form className="idt-scan-form idt-scan-modal-form" onSubmit={submitIntake}>
           <input
             className="idt-honeypot"
             type="text"
@@ -2215,9 +2331,9 @@ function ReadOnlyScanPage() {
           />
           <div className="idt-scan-form-header">
             <p className="idt-intake-step">Step {submitted ? INTAKE_TOTAL_STEPS : step} of {INTAKE_TOTAL_STEPS}</p>
-            <h2 id="scan-intake-title">{submitted ? 'Request received' : step === INTAKE_TOTAL_STEPS ? 'Review before submitting' : 'Tell us where to start'}</h2>
+            <h2 id="scan-intake-title">{stepTitle}</h2>
             <p>
-              A short intake keeps the first scan focused. Review your details before anything is sent to the team.
+              Nothing is sent until you review and submit the final step.
             </p>
           </div>
           {!submitted ? (
@@ -2241,13 +2357,50 @@ function ReadOnlyScanPage() {
                     />
                   </label>
                   <label>
+                    Your name
+                    <input
+                      required
+                      type="text"
+                      value={fullName}
+                      onChange={(event) => {
+                        setFullName(event.target.value);
+                        if (error === FULL_NAME_ERROR) {
+                          setError(null);
+                        }
+                      }}
+                      placeholder="Alex Morgan"
+                      autoComplete="name"
+                    />
+                  </label>
+                  <label>
+                    Role or title
+                    <input
+                      required
+                      type="text"
+                      value={roleTitle}
+                      onChange={(event) => {
+                        setRoleTitle(event.target.value);
+                        if (error === ROLE_TITLE_ERROR) {
+                          setError(null);
+                        }
+                      }}
+                      placeholder="Security Engineering Lead"
+                      autoComplete="organization-title"
+                    />
+                  </label>
+                  <label>
                     Company name
                     <input
                       required
                       type="text"
                       value={company}
-                      onChange={(event) => setCompany(event.target.value)}
-                      placeholder="Your registered company name"
+                      onChange={(event) => {
+                        setCompany(event.target.value);
+                        if (error === COMPANY_NAME_ERROR) {
+                          setError(null);
+                        }
+                      }}
+                      placeholder="Registered company name"
                       autoComplete="organization"
                     />
                   </label>
@@ -2290,6 +2443,26 @@ function ReadOnlyScanPage() {
                       <option>Enterprise private tenancy</option>
                     </select>
                   </label>
+                  <label>
+                    Identity provider
+                    <select value={identityProvider} onChange={(event) => setIdentityProvider(event.target.value)}>
+                      <option>AWS IAM Identity Center / SSO</option>
+                      <option>GitHub Actions OIDC</option>
+                      <option>Kubernetes service accounts</option>
+                      <option>Okta / WorkOS / SAML</option>
+                      <option>Mixed or unsure</option>
+                    </select>
+                  </label>
+                  <label>
+                    Infrastructure scope
+                    <select value={infrastructureScope} onChange={(event) => setInfrastructureScope(event.target.value)}>
+                      <option>1-5 cloud accounts or clusters</option>
+                      <option>6-20 cloud accounts or clusters</option>
+                      <option>21-50 cloud accounts or clusters</option>
+                      <option>50+ cloud accounts or clusters</option>
+                      <option>Unsure / discovery needed</option>
+                    </select>
+                  </label>
                 </div>
               ) : null}
 
@@ -2321,6 +2494,22 @@ function ReadOnlyScanPage() {
                       <option>50+</option>
                     </select>
                   </label>
+                  <label>
+                    Public code host organization or repository
+                    <input
+                      type="text"
+                      inputMode="url"
+                      value={repositoryUrl}
+                      onChange={(event) => {
+                        setRepositoryUrl(event.target.value);
+                        if (error === REPOSITORY_URL_ERROR) {
+                          setError(null);
+                        }
+                      }}
+                      placeholder="https://github.com/company/repo"
+                      autoComplete="url"
+                    />
+                  </label>
                   <article className="idt-intake-summary">
                     <h3>What you receive</h3>
                     <ul>
@@ -2338,6 +2527,7 @@ function ReadOnlyScanPage() {
                     <div>
                       <span>Work email</span>
                       <strong>{email.trim()}</strong>
+                      <p>{fullName.trim()} - {roleTitle.trim()}</p>
                     </div>
                     <button type="button" className="idt-btn idt-btn-ghost" onClick={() => setStep(1)}>
                       Edit
@@ -2357,7 +2547,8 @@ function ReadOnlyScanPage() {
                     <div>
                       <span>Environment</span>
                       <strong>{environment}</strong>
-                      <p>{deployment}</p>
+                      <p>{deployment} - {identityProvider}</p>
+                      <p>{infrastructureScope}</p>
                     </div>
                     <button type="button" className="idt-btn idt-btn-ghost" onClick={() => setStep(2)}>
                       Edit
@@ -2368,6 +2559,7 @@ function ReadOnlyScanPage() {
                       <span>Focus</span>
                       <strong>{challenge}</strong>
                       <p>{urgency} - Team size {teamSize}</p>
+                      {normalizedRepositoryUrl ? <p>{normalizedRepositoryUrl}</p> : null}
                     </div>
                     <button type="button" className="idt-btn idt-btn-ghost" onClick={() => setStep(3)}>
                       Edit
@@ -2397,27 +2589,43 @@ function ReadOnlyScanPage() {
                   </button>
                 ) : (
                   <button type="submit" className="idt-btn idt-btn-primary" disabled={submitting}>
-                    {submitting ? 'Submitting...' : 'Submit Risk Scan Request'}
+                    {submitting ? 'Submitting...' : 'Submit Review Request'}
                   </button>
                 )}
               </div>
             </>
           ) : (
             <div className="idt-intake-confirmation">
-              <h3>Intake submitted</h3>
-              <p>Your read-only scan intake was sent to the Identrail team. We will follow up by email with the next step.</p>
+              <h3>Review request submitted</h3>
+              <p>Your trust path review request was sent to the Identrail team. We will follow up by email with the next step.</p>
               <div className="idt-inline-actions">
-                <Link to="/demo" className="idt-btn idt-btn-dark">
-                  Book Demo
-                </Link>
-                <Link to="/docs" className="idt-btn idt-btn-ghost">
-                  Review Documentation
-                </Link>
+                <button type="button" className="idt-btn idt-btn-primary" onClick={onClose}>
+                  Close
+                </button>
               </div>
             </div>
           )}
         </form>
-      </section>
+      </div>
+    </ModalShell>
+  );
+}
+
+function ReadOnlyScanPage() {
+  const { openScanIntake } = useScanIntakeModal();
+  const navigate = useNavigate();
+  const [handoffStarted, setHandoffStarted] = useState(false);
+
+  useEffect(() => {
+    setHandoffStarted(true);
+    openScanIntake();
+    navigate('/', { replace: true });
+  }, [navigate, openScanIntake]);
+
+  return (
+    <>
+      <HomePage />
+      {!handoffStarted ? <ScanIntakeModal onClose={() => navigate('/', { replace: true })} /> : null}
     </>
   );
 }
@@ -2445,9 +2653,7 @@ function ProductPage() {
             <Link to="/demo" className="idt-btn idt-btn-primary">
               Explore Product Demo
             </Link>
-            <Link to="/read-only-scan" className="idt-btn idt-btn-dark">
-              Start Free Risk Scan
-            </Link>
+            <ScanIntakeCTA className="idt-btn idt-btn-dark" />
           </div>
         </div>
         <ProductHeroVisual />
@@ -2657,9 +2863,7 @@ function FeatureDetailPage({ page }: { page: (typeof FEATURE_DEEP_PAGES)[number]
           <Link to="/demo" className="idt-btn idt-btn-primary">
             Open Interactive Demo
           </Link>
-          <Link to="/read-only-scan" className="idt-btn idt-btn-dark">
-            Start Free Risk Scan
-          </Link>
+          <ScanIntakeCTA className="idt-btn idt-btn-dark" />
           <SafeLink href={GITHUB_REPO} className="idt-btn idt-btn-ghost">
             Star on GitHub
           </SafeLink>
@@ -2691,7 +2895,7 @@ function FeatureDetailPage({ page }: { page: (typeof FEATURE_DEEP_PAGES)[number]
         <LeadCaptureForm
           title={`Get a ${page.navLabel} workflow walkthrough`}
           caption="Share your environment goals and we will tailor a practical machine identity rollout plan."
-          ctaLabel="Start Free Risk Scan"
+          ctaLabel={SCAN_CTA_LABEL}
         />
       </section>
     </>
@@ -2845,9 +3049,7 @@ function PricingPage() {
         visual={<PricingHeroVisual />}
         actions={
           <>
-            <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-              Start Pro Trial
-            </Link>
+            <ScanIntakeCTA className="idt-btn idt-btn-primary" />
             <button type="button" className="idt-btn idt-btn-dark" onClick={() => setSalesModalOpen(true)}>
               Talk to Enterprise
             </button>
@@ -2903,9 +3105,7 @@ function PricingPage() {
               <li>SAML SSO, alerts, and workflow integrations</li>
               <li>14-day hosted trial with guided setup</li>
             </ul>
-            <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-              Start Pro Trial
-            </Link>
+            <ScanIntakeCTA className="idt-btn idt-btn-primary" />
           </article>
 
           <article className="idt-pricing-card">
@@ -2967,9 +3167,7 @@ function PricingPage() {
           <Link to="/roi-assessment" className="idt-btn idt-btn-primary">
             Open ROI Assessment
           </Link>
-          <Link to="/read-only-scan" className="idt-btn idt-btn-dark">
-            Start Free Risk Scan
-          </Link>
+          <ScanIntakeCTA className="idt-btn idt-btn-dark" />
         </div>
       </section>
 
@@ -3026,9 +3224,7 @@ function RoiAssessmentPage() {
 
       <section className="idt-section idt-shell">
         <div className="idt-inline-actions">
-          <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-            Start Free Risk Scan
-          </Link>
+          <ScanIntakeCTA className="idt-btn idt-btn-primary" />
           <Link to="/pricing" className="idt-btn idt-btn-dark">
             Compare Pricing Plans
           </Link>
@@ -3083,9 +3279,7 @@ function DeploymentModelsPage() {
               <li>Read-only onboarding for first scan</li>
               <li>Accelerated query and collaboration workflows</li>
             </ul>
-            <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-              Start Free Risk Scan
-            </Link>
+            <ScanIntakeCTA className="idt-btn idt-btn-primary" />
           </article>
           <article className="idt-card">
             <h2>Enterprise Private</h2>
@@ -3198,9 +3392,7 @@ function IntegrationsPage() {
               <SafeLink href={DOCS_REPO} className="idt-btn idt-btn-ghost">
                 Open Documentation
               </SafeLink>
-              <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-                Start Free Risk Scan
-              </Link>
+              <ScanIntakeCTA className="idt-btn idt-btn-primary" />
             </div>
           </article>
         </div>
@@ -3241,11 +3433,9 @@ function DemoPage() {
           </article>
           <article className="idt-card">
             <h2>What to do next</h2>
-            <p>Run a free risk scan to map your own trust paths, or book a guided walkthrough with security engineering.</p>
+            <p>Run a read-only risk scan to map your own trust paths, or book a guided walkthrough with security engineering.</p>
             <div className="idt-inline-actions">
-              <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-                Start Free Risk Scan
-              </Link>
+              <ScanIntakeCTA className="idt-btn idt-btn-primary" />
               <Link to="/enterprise" className="idt-btn idt-btn-dark">
                 Book Demo
               </Link>
@@ -3261,9 +3451,7 @@ function DemoPage() {
           body="Start in hosted SaaS or self-host OSS and import your first AWS account or Kubernetes cluster."
         />
         <div className="idt-inline-actions">
-          <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-            Start Free Risk Scan
-          </Link>
+          <ScanIntakeCTA className="idt-btn idt-btn-primary" />
           <SafeLink href={GITHUB_REPO} className="idt-btn idt-btn-ghost">
             Run Self-Hosted
           </SafeLink>
@@ -3479,9 +3667,7 @@ function BlogArticlePage() {
             </ul>
           </section>
           <div className="idt-inline-actions">
-            <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-              Start Free Risk Scan
-            </Link>
+            <ScanIntakeCTA className="idt-btn idt-btn-primary" />
             <Link to="/blog" className="idt-btn idt-btn-ghost">
               Back to Blog
             </Link>
@@ -3577,9 +3763,7 @@ function SecurityPage() {
           <Link to="/responsible-disclosure" className="idt-btn idt-btn-dark">
             Responsible Disclosure
           </Link>
-          <Link to="/read-only-scan" className="idt-btn idt-btn-primary">
-            Start Free Risk Scan
-          </Link>
+          <ScanIntakeCTA className="idt-btn idt-btn-primary" />
           <SafeLink href={DOCS_REPO} className="idt-btn idt-btn-ghost">
             Review Security Docs
           </SafeLink>
@@ -4158,7 +4342,9 @@ export function RoutedSite() {
 export function App() {
   return (
     <BrowserRouter>
-      <RoutedSite />
+      <ScanIntakeModalProvider>
+        <RoutedSite />
+      </ScanIntakeModalProvider>
     </BrowserRouter>
   );
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -760,7 +760,11 @@ function PageHero({
   variant: PageHeroVariant;
 }) {
   return (
-    <section className={`idt-page-hero idt-page-hero-rich idt-shell is-${variant}`}>
+    <section
+      className={`idt-page-hero idt-page-hero-rich idt-shell is-${variant} ${
+        visual ? '' : 'is-no-visual'
+      }`}
+    >
       <div className="idt-page-hero-copy">
         <p className="idt-eyebrow">{eyebrow}</p>
         <h1>{title}</h1>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2008,12 +2008,21 @@ function FaqPage() {
   });
 
   return (
-    <>
-      <section className="idt-page-hero idt-shell">
-        <p className="idt-eyebrow">FAQ</p>
-        <h1>Technical and operational questions teams ask before rollout</h1>
-        <p>Answers focus on read-only collection boundaries, deployment models, and safe remediation workflows.</p>
-      </section>
+    <div className="idt-marketing-page idt-modern-public-page idt-faq-page">
+      <PageHero
+        eyebrow="FAQ"
+        title="Technical and operational questions teams ask before rollout"
+        body="Answers focus on read-only collection boundaries, deployment models, and safe remediation workflows."
+        variant="docs"
+        actions={
+          <>
+            <ScanIntakeCTA className="idt-btn idt-btn-primary" />
+            <Link to="/docs" className="idt-btn idt-btn-dark">
+              Review Docs
+            </Link>
+          </>
+        }
+      />
       <section className="idt-section idt-shell">
         <div className="idt-faq-list">
           {HOME_FAQ_ITEMS.map((item) => (
@@ -2024,7 +2033,7 @@ function FaqPage() {
           ))}
         </div>
       </section>
-    </>
+    </div>
   );
 }
 
@@ -2814,12 +2823,21 @@ function FeaturesPage() {
   ] as const;
 
   return (
-    <>
-      <section className="idt-page-hero idt-shell">
-        <p className="idt-eyebrow">Features</p>
-        <h1>Built for cloud-native machine identity security at scale</h1>
-        <p>Deep technical workflows for security and platform teams, from discovery to rollout-safe control.</p>
-      </section>
+    <div className="idt-marketing-page idt-modern-public-page idt-features-page">
+      <PageHero
+        eyebrow="Features"
+        title="Built for cloud-native machine identity security at scale"
+        body="Deep technical workflows for security and platform teams, from discovery to rollout-safe control."
+        variant="product"
+        actions={
+          <>
+            <ScanIntakeCTA className="idt-btn idt-btn-primary" />
+            <Link to="/demo" className="idt-btn idt-btn-dark">
+              Open Demo
+            </Link>
+          </>
+        }
+      />
 
       {featureSummaries.map((feature) => (
         <section key={feature.id} className="idt-section idt-shell" id={feature.id}>
@@ -2842,7 +2860,7 @@ function FeaturesPage() {
           </article>
         </section>
       ))}
-    </>
+    </div>
   );
 }
 
@@ -2854,21 +2872,24 @@ function FeatureDetailPage({ page }: { page: (typeof FEATURE_DEEP_PAGES)[number]
   });
 
   return (
-    <>
-      <section className="idt-page-hero idt-shell">
-        <p className="idt-eyebrow">Feature: {page.navLabel}</p>
-        <h1>{page.heroTitle}</h1>
-        <p>{page.description}</p>
-        <div className="idt-inline-actions">
-          <Link to="/demo" className="idt-btn idt-btn-primary">
-            Open Interactive Demo
-          </Link>
-          <ScanIntakeCTA className="idt-btn idt-btn-dark" />
-          <SafeLink href={GITHUB_REPO} className="idt-btn idt-btn-ghost">
-            Star on GitHub
-          </SafeLink>
-        </div>
-      </section>
+    <div className="idt-marketing-page idt-modern-public-page idt-feature-detail-page">
+      <PageHero
+        eyebrow={`Feature: ${page.navLabel}`}
+        title={page.heroTitle}
+        body={page.description}
+        variant="product"
+        actions={
+          <>
+            <Link to="/demo" className="idt-btn idt-btn-primary">
+              Open Interactive Demo
+            </Link>
+            <ScanIntakeCTA className="idt-btn idt-btn-dark" />
+            <SafeLink href={GITHUB_REPO} className="idt-btn idt-btn-ghost">
+              Star on GitHub
+            </SafeLink>
+          </>
+        }
+      />
 
       <section className="idt-section idt-shell">
         <div className="idt-card-grid two-col idt-feature-detail-grid">
@@ -2898,7 +2919,7 @@ function FeatureDetailPage({ page }: { page: (typeof FEATURE_DEEP_PAGES)[number]
           ctaLabel={SCAN_CTA_LABEL}
         />
       </section>
-    </>
+    </div>
   );
 }
 
@@ -2944,11 +2965,21 @@ function SolutionsPage() {
   ] as const;
 
   return (
-    <>
-      <section className="idt-page-hero idt-shell">
-        <p className="idt-eyebrow">Solutions</p>
-        <h1>Deployment-ready outcomes for every team responsible for machine identity risk</h1>
-      </section>
+    <div className="idt-marketing-page idt-modern-public-page idt-solutions-page">
+      <PageHero
+        eyebrow="Solutions"
+        title="Deployment-ready outcomes for every team responsible for machine identity risk"
+        body="Choose the operating pattern that matches your cloud footprint, platform model, and remediation ownership."
+        variant="product"
+        actions={
+          <>
+            <ScanIntakeCTA className="idt-btn idt-btn-primary" />
+            <Link to="/enterprise" className="idt-btn idt-btn-dark">
+              Book Demo
+            </Link>
+          </>
+        }
+      />
       <section className="idt-section idt-shell">
         <div className="idt-card-grid two-col idt-solutions-grid">
           {solutions.map((solution) => (
@@ -2968,7 +2999,7 @@ function SolutionsPage() {
       <section className="idt-section idt-shell">
         <CalendlyEmbed />
       </section>
-    </>
+    </div>
   );
 }
 
@@ -2980,12 +3011,23 @@ function SolutionDetailPage({ page }: { page: (typeof SOLUTION_DEEP_PAGES)[numbe
   });
 
   return (
-    <>
-      <section className="idt-page-hero idt-shell">
-        <p className="idt-eyebrow">Solution: {page.navLabel}</p>
-        <h1>{page.heroTitle}</h1>
-        <p>{page.description}</p>
-      </section>
+    <div className="idt-marketing-page idt-modern-public-page idt-solution-detail-page">
+      <PageHero
+        eyebrow={`Solution: ${page.navLabel}`}
+        title={page.heroTitle}
+        body={page.description}
+        variant="product"
+        actions={
+          <>
+            <Link to="/enterprise" className="idt-btn idt-btn-primary">
+              Book Demo
+            </Link>
+            <Link to="/pricing" className="idt-btn idt-btn-dark">
+              Compare Plans
+            </Link>
+          </>
+        }
+      />
 
       <section className="idt-section idt-shell">
         <div className="idt-card-grid two-col idt-solution-detail-grid">
@@ -3021,7 +3063,7 @@ function SolutionDetailPage({ page }: { page: (typeof SOLUTION_DEEP_PAGES)[numbe
           </SafeLink>
         </div>
       </section>
-    </>
+    </div>
   );
 }
 
@@ -3204,15 +3246,21 @@ function RoiAssessmentPage() {
   });
 
   return (
-    <>
-      <section className="idt-page-hero idt-shell">
-        <p className="idt-eyebrow">ROI Assessment</p>
-        <h1>Model risk-reduction impact with transparent assumptions</h1>
-        <p>
-          This tool is a planning model, not a guarantee. Adjust each input to match your environment and validate assumptions with
-          your security and finance stakeholders.
-        </p>
-      </section>
+    <div className="idt-marketing-page idt-modern-public-page idt-roi-page">
+      <PageHero
+        eyebrow="ROI Assessment"
+        title="Model risk-reduction impact with transparent assumptions"
+        body="This tool is a planning model, not a guarantee. Adjust each input to match your environment and validate assumptions with your security and finance stakeholders."
+        variant="pricing"
+        actions={
+          <>
+            <ScanIntakeCTA className="idt-btn idt-btn-primary" />
+            <Link to="/pricing" className="idt-btn idt-btn-dark">
+              Compare Pricing Plans
+            </Link>
+          </>
+        }
+      />
 
       <section className="idt-section idt-shell">
         <RoiCalculator />
@@ -3230,7 +3278,7 @@ function RoiAssessmentPage() {
           </Link>
         </div>
       </section>
-    </>
+    </div>
   );
 }
 
@@ -3243,15 +3291,21 @@ function DeploymentModelsPage() {
   });
 
   return (
-    <>
-      <section className="idt-page-hero idt-shell">
-        <p className="idt-eyebrow">Deployment Models</p>
-        <h1>Choose your control boundary without changing operating model</h1>
-        <p>
-          Identrail keeps the same trust-path workflow across open-core, hosted SaaS, and enterprise deployments. Choose based on
-          control, speed, and governance requirements.
-        </p>
-      </section>
+    <div className="idt-marketing-page idt-modern-public-page idt-deployment-page">
+      <PageHero
+        eyebrow="Deployment Models"
+        title="Choose your control boundary without changing operating model"
+        body="Identrail keeps the same trust-path workflow across open-core, hosted SaaS, and enterprise deployments. Choose based on control, speed, and governance requirements."
+        variant="pricing"
+        actions={
+          <>
+            <ScanIntakeCTA className="idt-btn idt-btn-primary" />
+            <SafeLink href={GITHUB_REPO} className="idt-btn idt-btn-dark">
+              View Open Source
+            </SafeLink>
+          </>
+        }
+      />
 
       <section className="idt-section idt-shell">
         <div className="idt-card-grid three-col">
@@ -3327,7 +3381,7 @@ function DeploymentModelsPage() {
           </table>
         </div>
       </section>
-    </>
+    </div>
   );
 }
 
@@ -3340,15 +3394,21 @@ function IntegrationsPage() {
   });
 
   return (
-    <>
-      <section className="idt-page-hero idt-shell">
-        <p className="idt-eyebrow">Integrations</p>
-        <h1>Identity signal coverage across cloud, cluster, and code workflows</h1>
-        <p>
-          Identrail unifies machine identity telemetry into one trust-path analysis model. Use this page to verify connector depth
-          before rollout.
-        </p>
-      </section>
+    <div className="idt-marketing-page idt-modern-public-page idt-integrations-page">
+      <PageHero
+        eyebrow="Integrations"
+        title="Identity signal coverage across cloud, cluster, and code workflows"
+        body="Identrail unifies machine identity telemetry into one trust-path analysis model. Use this page to verify connector depth before rollout."
+        variant="product"
+        actions={
+          <>
+            <ScanIntakeCTA className="idt-btn idt-btn-primary" />
+            <SafeLink href={DOCS_REPO} className="idt-btn idt-btn-dark">
+              Review Docs
+            </SafeLink>
+          </>
+        }
+      />
 
       <section className="idt-section idt-shell">
         <div className="idt-table-wrap">
@@ -3397,7 +3457,7 @@ function IntegrationsPage() {
           </article>
         </div>
       </section>
-    </>
+    </div>
   );
 }
 
@@ -3410,12 +3470,21 @@ function DemoPage() {
   });
 
   return (
-    <>
-      <section className="idt-page-hero idt-shell">
-        <p className="idt-eyebrow">Interactive Demo</p>
-        <h1>Simulate real trust-path investigation in a production-style environment</h1>
-        <p>Explore node relationships, inspect risk context, and test rollout-safe controls from one console.</p>
-      </section>
+    <div className="idt-marketing-page idt-modern-public-page idt-demo-page">
+      <PageHero
+        eyebrow="Interactive Demo"
+        title="Simulate real trust-path investigation in a production-style environment"
+        body="Explore node relationships, inspect risk context, and test rollout-safe controls from one console."
+        variant="product"
+        actions={
+          <>
+            <ScanIntakeCTA className="idt-btn idt-btn-primary" />
+            <Link to="/enterprise" className="idt-btn idt-btn-dark">
+              Book Demo
+            </Link>
+          </>
+        }
+      />
 
       <section className="idt-section idt-shell">
         <TrustGraphDemo variant="full" />
@@ -3457,7 +3526,7 @@ function DemoPage() {
           </SafeLink>
         </div>
       </section>
-    </>
+    </div>
   );
 }
 
@@ -3621,12 +3690,21 @@ function BlogArticlePage() {
   }
 
   return (
-    <>
-      <section className="idt-page-hero idt-shell">
-        <p className="idt-eyebrow">{post.category}</p>
-        <h1>{post.title}</h1>
-        <p>{post.description}</p>
-      </section>
+    <div className="idt-marketing-page idt-modern-public-page idt-blog-article-page">
+      <PageHero
+        eyebrow={post.category}
+        title={post.title}
+        body={post.description}
+        variant="blog"
+        actions={
+          <>
+            <ScanIntakeCTA className="idt-btn idt-btn-primary" />
+            <Link to="/blog" className="idt-btn idt-btn-dark">
+              Back to Blog
+            </Link>
+          </>
+        }
+      />
 
       <section className="idt-section idt-shell">
         <article className="idt-card idt-blog-article">
@@ -3674,7 +3752,7 @@ function BlogArticlePage() {
           </div>
         </article>
       </section>
-    </>
+    </div>
   );
 }
 
@@ -3687,12 +3765,21 @@ function SecurityPage() {
   });
 
   return (
-    <>
-      <section className="idt-page-hero idt-shell">
-        <p className="idt-eyebrow">Security & Compliance</p>
-        <h1>Security-first architecture with transparent compliance posture</h1>
-        <p>Built for teams that need hardening depth, audit evidence, and enterprise trust controls.</p>
-      </section>
+    <div className="idt-marketing-page idt-modern-public-page idt-security-page">
+      <PageHero
+        eyebrow="Security & Compliance"
+        title="Security-first architecture with transparent compliance posture"
+        body="Built for teams that need hardening depth, audit evidence, and enterprise trust controls."
+        variant="enterprise"
+        actions={
+          <>
+            <Link to="/responsible-disclosure" className="idt-btn idt-btn-primary">
+              Responsible Disclosure
+            </Link>
+            <ScanIntakeCTA className="idt-btn idt-btn-dark" />
+          </>
+        }
+      />
 
       <section className="idt-section idt-shell">
         <SectionTitle
@@ -3769,7 +3856,7 @@ function SecurityPage() {
           </SafeLink>
         </div>
       </section>
-    </>
+    </div>
   );
 }
 
@@ -3782,12 +3869,23 @@ function ResponsibleDisclosurePage() {
   });
 
   return (
-    <>
-      <section className="idt-page-hero idt-shell">
-        <p className="idt-eyebrow">Responsible Disclosure</p>
-        <h1>Report security issues through a coordinated disclosure process</h1>
-        <p>We investigate security reports promptly and coordinate remediation and communication with reporters.</p>
-      </section>
+    <div className="idt-marketing-page idt-modern-public-page idt-disclosure-page">
+      <PageHero
+        eyebrow="Responsible Disclosure"
+        title="Report security issues through a coordinated disclosure process"
+        body="We investigate security reports promptly and coordinate remediation and communication with reporters."
+        variant="enterprise"
+        actions={
+          <>
+            <a className="idt-btn idt-btn-primary" href="mailto:security@identrail.com">
+              Email Security
+            </a>
+            <Link to="/security" className="idt-btn idt-btn-dark">
+              Review Security
+            </Link>
+          </>
+        }
+      />
       <section className="idt-section idt-shell">
         <div className="idt-card-grid two-col">
           <article className="idt-card">
@@ -3815,7 +3913,7 @@ function ResponsibleDisclosurePage() {
           </article>
         </div>
       </section>
-    </>
+    </div>
   );
 }
 
@@ -3881,7 +3979,7 @@ function EnterprisePage() {
   });
 
   return (
-    <>
+    <div className="idt-marketing-page idt-modern-public-page idt-enterprise-page">
       <PageHero
         eyebrow="Enterprise"
         title="Enterprise machine identity programs that satisfy security, platform, and procurement stakeholders"
@@ -3922,7 +4020,7 @@ function EnterprisePage() {
       <section className="idt-section idt-shell">
         <CalendlyEmbed />
       </section>
-    </>
+    </div>
   );
 }
 
@@ -3934,10 +4032,40 @@ function LegalPage({ title, body }: { title: string; body: string }) {
   });
 
   return (
-    <section className="idt-page-hero idt-shell">
-      <h1>{title}</h1>
-      <p>{body}</p>
-    </section>
+    <div className="idt-marketing-page idt-modern-public-page idt-privacy-choices-page">
+      <PageHero
+        eyebrow="Privacy choices"
+        title={title}
+        body={body}
+        variant="docs"
+        actions={
+          <>
+            <a className="idt-btn idt-btn-primary" href="mailto:security@identrail.com?subject=Privacy%20Choices">
+              Contact Privacy
+            </a>
+            <Link to="/privacy" className="idt-btn idt-btn-dark">
+              Read Privacy Policy
+            </Link>
+          </>
+        }
+      />
+      <section className="idt-section idt-shell">
+        <div className="idt-card-grid three-col">
+          <article className="idt-card">
+            <h2>Account data</h2>
+            <p>Request access, correction, or deletion of account information tied to your Identrail profile.</p>
+          </article>
+          <article className="idt-card">
+            <h2>Communications</h2>
+            <p>Update preferences for product updates, security notices, onboarding follow-up, and sales contact.</p>
+          </article>
+          <article className="idt-card">
+            <h2>Website analytics</h2>
+            <p>Ask how web analytics and product telemetry are handled for Identrail website experiences.</p>
+          </article>
+        </div>
+      </section>
+    </div>
   );
 }
 
@@ -4262,18 +4390,47 @@ function NotFoundPage() {
   });
 
   return (
-    <section className="idt-page-hero idt-shell">
-      <h1>404: Page not found</h1>
-      <p>The page may have moved. Use the links below to continue.</p>
-      <div className="idt-inline-actions">
-        <Link to="/" className="idt-btn idt-btn-primary">
-          Go to Homepage
-        </Link>
-        <Link to="/docs" className="idt-btn idt-btn-ghost">
-          Open Docs
-        </Link>
-      </div>
-    </section>
+    <div className="idt-marketing-page idt-modern-public-page idt-not-found-page">
+      <PageHero
+        eyebrow="Page not found"
+        title="This trust path does not exist"
+        body="The page may have moved, the URL may be mistyped, or the resource may no longer be published. Start from a stable destination below."
+        variant="docs"
+        actions={
+          <>
+            <Link to="/" className="idt-btn idt-btn-primary">
+              Go to Homepage
+            </Link>
+            <Link to="/docs" className="idt-btn idt-btn-dark">
+              Open Docs
+            </Link>
+          </>
+        }
+      />
+      <section className="idt-section idt-shell">
+        <div className="idt-card-grid three-col">
+          <article className="idt-card">
+            <h2>Explore product</h2>
+            <p>Review how Identrail maps machine identity trust paths across cloud, cluster, and code surfaces.</p>
+            <Link to="/product" className="idt-inline-link">
+              Open product overview
+            </Link>
+          </article>
+          <article className="idt-card">
+            <h2>Request review</h2>
+            <p>Share public company context and request a focused trust path review from the Identrail team.</p>
+            <ScanIntakeCTA className="idt-btn idt-btn-ghost" />
+          </article>
+          <article className="idt-card">
+            <h2>Security contact</h2>
+            <p>Need to report a sensitive issue or disclosure? Use the coordinated security reporting path.</p>
+            <Link to="/responsible-disclosure" className="idt-inline-link">
+              Responsible disclosure
+            </Link>
+          </article>
+        </div>
+      </section>
+    </div>
   );
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2917,11 +2917,7 @@ function FeatureDetailPage({ page }: { page: (typeof FEATURE_DEEP_PAGES)[number]
       </section>
 
       <section className="idt-section idt-shell">
-        <LeadCaptureForm
-          title={`Get a ${page.navLabel} workflow walkthrough`}
-          caption="Share your environment goals and we will tailor a practical machine identity rollout plan."
-          ctaLabel={SCAN_CTA_LABEL}
-        />
+        <ScanIntakeCTA className="idt-btn idt-btn-primary">Start a {page.navLabel} review</ScanIntakeCTA>
       </section>
     </div>
   );

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -390,10 +390,15 @@ export type FindingLifecycleStatus = 'open' | 'ack' | 'suppressed' | 'resolved';
 
 export type LeadCapturePayload = {
   email: string;
+  full_name?: string;
+  role_title?: string;
   environment: string;
   company?: string;
   company_domain?: string;
   challenge?: string;
+  identity_provider?: string;
+  infrastructure_scope?: string;
+  repository_url?: string;
   website?: string;
   deployment_model?: string;
   scan_goal?: string;

--- a/web/src/prerender.tsx
+++ b/web/src/prerender.tsx
@@ -1,6 +1,6 @@
 import { renderToString } from 'react-dom/server';
 import { StaticRouter } from 'react-router-dom';
-import { RoutedSite } from './App';
+import { RoutedSite, ScanIntakeModalProvider } from './App';
 
 type PrerenderInput = {
   url: string;
@@ -9,7 +9,9 @@ type PrerenderInput = {
 export async function prerender(data: PrerenderInput) {
   const html = renderToString(
     <StaticRouter location={data.url}>
-      <RoutedSite />
+      <ScanIntakeModalProvider>
+        <RoutedSite />
+      </ScanIntakeModalProvider>
     </StaticRouter>
   );
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -17559,6 +17559,434 @@ html[data-theme='light'] .idt-blog-page .idt-page-hero-copy > p {
   --blog-accent: #e6522c;
 }
 
+.idt-legal-page,
+html[data-theme='light'] .idt-legal-page {
+  --legal-accent: #2dd4bf;
+  --legal-accent-strong: #5eead4;
+  --legal-accent-soft: rgba(45, 212, 191, 0.14);
+  --legal-panel: #080808;
+  --legal-panel-strong: #0d0d0d;
+  --legal-border: #242424;
+  --legal-border-strong: #303030;
+  --legal-muted: #a1a1aa;
+  min-height: 100%;
+  background: #000000;
+  color: #ffffff;
+}
+
+.idt-legal-page.is-terms,
+html[data-theme='light'] .idt-legal-page.is-terms {
+  --legal-accent: #f59e0b;
+  --legal-accent-strong: #fbbf24;
+  --legal-accent-soft: rgba(245, 158, 11, 0.14);
+}
+
+.idt-legal-page :where(h1, h2, h3),
+html[data-theme='light'] .idt-legal-page :where(h1, h2, h3) {
+  color: #ffffff;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.idt-legal-hero,
+html[data-theme='light'] .idt-legal-hero {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.52fr);
+  gap: clamp(1.25rem, 4vw, 4.5rem);
+  align-items: stretch;
+  padding: clamp(4rem, 7vw, 6rem) clamp(1.25rem, 5vw, 6rem);
+  border-bottom: 1px solid var(--legal-border);
+  background:
+    linear-gradient(90deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px),
+    linear-gradient(rgba(255, 255, 255, 0.03) 1px, transparent 1px),
+    linear-gradient(120deg, rgba(255, 255, 255, 0.06), transparent 42%),
+    #000000;
+  background-size: 88px 88px, 88px 88px, auto, auto;
+}
+
+.idt-legal-hero-copy,
+html[data-theme='light'] .idt-legal-hero-copy {
+  max-width: 840px;
+}
+
+.idt-legal-page .idt-eyebrow,
+html[data-theme='light'] .idt-legal-page .idt-eyebrow {
+  color: var(--legal-accent-strong);
+  letter-spacing: 0.14em;
+}
+
+.idt-legal-hero h1,
+html[data-theme='light'] .idt-legal-hero h1 {
+  max-width: 12ch;
+  margin: 0;
+  font-family: 'Barlow Semi Condensed', 'Arial Narrow', Arial, sans-serif;
+  font-size: 4.5rem;
+  font-weight: 800;
+  line-height: 0.96;
+}
+
+.idt-legal-hero-copy > p,
+html[data-theme='light'] .idt-legal-hero-copy > p {
+  max-width: 68ch;
+  margin: 1.35rem 0 0;
+  color: #d4d4d8;
+  font-size: 1.05rem;
+  line-height: 1.75;
+}
+
+.idt-legal-meta-list,
+html[data-theme='light'] .idt-legal-meta-list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  margin: 2rem 0 0;
+  border: 1px solid var(--legal-border);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--legal-border);
+}
+
+.idt-legal-meta-list div,
+html[data-theme='light'] .idt-legal-meta-list div {
+  min-width: 0;
+  padding: 1rem;
+  background: var(--legal-panel);
+}
+
+.idt-legal-meta-list dt,
+html[data-theme='light'] .idt-legal-meta-list dt {
+  color: var(--legal-muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.idt-legal-meta-list dd,
+html[data-theme='light'] .idt-legal-meta-list dd {
+  margin: 0.35rem 0 0;
+  color: #ffffff;
+  font-size: 0.92rem;
+  line-height: 1.35;
+}
+
+.idt-legal-summary-card,
+html[data-theme='light'] .idt-legal-summary-card {
+  display: flex;
+  min-height: 100%;
+  flex-direction: column;
+  justify-content: space-between;
+  border: 1px solid var(--legal-border-strong);
+  border-radius: 8px;
+  padding: 1.25rem;
+  background:
+    linear-gradient(180deg, var(--legal-accent-soft), transparent 42%),
+    var(--legal-panel);
+  box-shadow: none;
+}
+
+.idt-legal-summary-label,
+html[data-theme='light'] .idt-legal-summary-label {
+  margin: 0 0 1rem;
+  color: var(--legal-accent-strong);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.idt-legal-summary-card h2,
+html[data-theme='light'] .idt-legal-summary-card h2 {
+  max-width: 12ch;
+  margin-bottom: 1.15rem;
+  font-family: 'Barlow Semi Condensed', 'Arial Narrow', Arial, sans-serif;
+  font-size: 2.35rem;
+  font-weight: 800;
+  line-height: 0.98;
+}
+
+.idt-legal-summary-card ul,
+html[data-theme='light'] .idt-legal-summary-card ul {
+  display: grid;
+  gap: 0.85rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.idt-legal-summary-card li,
+html[data-theme='light'] .idt-legal-summary-card li {
+  position: relative;
+  padding-left: 1.6rem;
+  color: #d4d4d8;
+  line-height: 1.55;
+}
+
+.idt-legal-summary-card li::before,
+html[data-theme='light'] .idt-legal-summary-card li::before {
+  content: '';
+  position: absolute;
+  top: 0.65em;
+  left: 0;
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: var(--legal-accent);
+  box-shadow: 0 0 0 5px var(--legal-accent-soft);
+}
+
+.idt-legal-body,
+html[data-theme='light'] .idt-legal-body {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  display: grid;
+  grid-template-columns: minmax(220px, 0.28fr) minmax(0, 1fr);
+  gap: clamp(1.5rem, 5vw, 5rem);
+  padding: clamp(3.5rem, 7vw, 6rem) clamp(1.25rem, 5vw, 6rem);
+  background: #000000;
+  color: #ffffff;
+}
+
+.idt-legal-sidebar,
+html[data-theme='light'] .idt-legal-sidebar {
+  position: sticky;
+  top: 6rem;
+  align-self: start;
+  border: 1px solid var(--legal-border);
+  border-radius: 8px;
+  padding: 1rem;
+  background: var(--legal-panel);
+}
+
+.idt-legal-sidebar p,
+html[data-theme='light'] .idt-legal-sidebar p {
+  margin: 0 0 0.8rem;
+  color: var(--legal-muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.idt-legal-sidebar nav,
+html[data-theme='light'] .idt-legal-sidebar nav {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.idt-legal-sidebar a,
+html[data-theme='light'] .idt-legal-sidebar a {
+  border-radius: 7px;
+  padding: 0.62rem 0.7rem;
+  color: #d4d4d8;
+  font-family: var(--idt-nav-font);
+  font-size: 0.86rem;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.idt-legal-sidebar a:hover,
+.idt-legal-sidebar a:focus-visible,
+html[data-theme='light'] .idt-legal-sidebar a:hover,
+html[data-theme='light'] .idt-legal-sidebar a:focus-visible {
+  background: #ffffff;
+  color: #000000;
+  outline: 0;
+}
+
+.idt-legal-main,
+html[data-theme='light'] .idt-legal-main {
+  display: grid;
+  gap: 1px;
+  min-width: 0;
+  background: var(--legal-border);
+}
+
+.idt-legal-section-heading,
+.idt-legal-section-card,
+.idt-legal-contact-panel,
+html[data-theme='light'] .idt-legal-section-heading,
+html[data-theme='light'] .idt-legal-section-card,
+html[data-theme='light'] .idt-legal-contact-panel {
+  background: var(--legal-panel);
+}
+
+.idt-legal-section-heading,
+html[data-theme='light'] .idt-legal-section-heading {
+  padding: clamp(1.35rem, 4vw, 2.5rem);
+}
+
+.idt-legal-section-heading h2,
+html[data-theme='light'] .idt-legal-section-heading h2 {
+  max-width: 18ch;
+  margin-bottom: 0.7rem;
+  font-family: 'Barlow Semi Condensed', 'Arial Narrow', Arial, sans-serif;
+  font-size: 3rem;
+  font-weight: 800;
+  line-height: 0.98;
+}
+
+.idt-legal-section-heading > p:last-child,
+html[data-theme='light'] .idt-legal-section-heading > p:last-child {
+  max-width: 72ch;
+  margin: 0;
+  color: #d4d4d8;
+  line-height: 1.7;
+}
+
+.idt-legal-section-list,
+html[data-theme='light'] .idt-legal-section-list {
+  display: grid;
+  gap: 1px;
+}
+
+.idt-legal-section-card,
+html[data-theme='light'] .idt-legal-section-card {
+  display: grid;
+  grid-template-columns: 4.2rem minmax(0, 1fr);
+  gap: 1.25rem;
+  scroll-margin-top: 7rem;
+  padding: clamp(1.35rem, 4vw, 2.5rem);
+}
+
+.idt-legal-section-number,
+html[data-theme='light'] .idt-legal-section-number {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border: 1px solid var(--legal-border-strong);
+  border-radius: 8px;
+  background: var(--legal-panel-strong);
+  color: var(--legal-accent-strong);
+  font-family: var(--idt-nav-font);
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+.idt-legal-section-card h3,
+html[data-theme='light'] .idt-legal-section-card h3 {
+  margin-bottom: 0.85rem;
+  font-family: 'Barlow Semi Condensed', 'Arial Narrow', Arial, sans-serif;
+  font-size: 2rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.idt-legal-section-card p,
+.idt-legal-contact-panel p,
+html[data-theme='light'] .idt-legal-section-card p,
+html[data-theme='light'] .idt-legal-contact-panel p {
+  max-width: 78ch;
+  margin: 0;
+  color: #d4d4d8;
+  line-height: 1.72;
+}
+
+.idt-legal-section-card p + p,
+html[data-theme='light'] .idt-legal-section-card p + p {
+  margin-top: 0.85rem;
+}
+
+.idt-legal-contact-panel,
+html[data-theme='light'] .idt-legal-contact-panel {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: clamp(1.35rem, 4vw, 2.5rem);
+}
+
+.idt-legal-contact-panel h2,
+html[data-theme='light'] .idt-legal-contact-panel h2 {
+  margin-bottom: 0.55rem;
+  font-family: 'Barlow Semi Condensed', 'Arial Narrow', Arial, sans-serif;
+  font-size: 2.35rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.idt-legal-contact-panel a:not(.idt-btn),
+html[data-theme='light'] .idt-legal-contact-panel a:not(.idt-btn) {
+  color: #ffffff;
+  font-weight: 800;
+}
+
+.idt-legal-contact-panel .idt-btn-primary,
+html[data-theme='light'] .idt-legal-contact-panel .idt-btn-primary {
+  flex: 0 0 auto;
+  border-color: #ffffff;
+  background: #ffffff;
+  color: #000000;
+  box-shadow: none;
+}
+
+@media (max-width: 1080px) {
+  .idt-legal-hero,
+  html[data-theme='light'] .idt-legal-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-legal-body,
+  html[data-theme='light'] .idt-legal-body {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-legal-sidebar,
+  html[data-theme='light'] .idt-legal-sidebar {
+    position: static;
+  }
+
+  .idt-legal-sidebar nav,
+  html[data-theme='light'] .idt-legal-sidebar nav {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 820px) {
+  .idt-legal-hero,
+  .idt-legal-body,
+  html[data-theme='light'] .idt-legal-hero,
+  html[data-theme='light'] .idt-legal-body {
+    padding-inline: 1rem;
+  }
+
+  .idt-legal-hero h1,
+  html[data-theme='light'] .idt-legal-hero h1 {
+    font-size: 3.25rem;
+  }
+
+  .idt-legal-meta-list,
+  html[data-theme='light'] .idt-legal-meta-list {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-legal-sidebar nav,
+  html[data-theme='light'] .idt-legal-sidebar nav {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-legal-section-heading h2,
+  html[data-theme='light'] .idt-legal-section-heading h2 {
+    font-size: 2.35rem;
+  }
+
+  .idt-legal-section-card,
+  html[data-theme='light'] .idt-legal-section-card {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-legal-contact-panel,
+  html[data-theme='light'] .idt-legal-contact-panel {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
+
 @media (max-width: 820px) {
   .idt-product-page .idt-graph-pill {
     min-width: 132px;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2220,7 +2220,11 @@ h2 {
   position: fixed;
   inset: 0;
   z-index: 420;
-  background: rgba(4, 11, 23, 0.83);
+  background:
+    radial-gradient(circle at 50% 8%, rgba(98, 58, 196, 0.14), transparent 34%),
+    rgba(2, 5, 12, 0.76);
+  -webkit-backdrop-filter: blur(30px) saturate(0.78) brightness(0.58);
+  backdrop-filter: blur(30px) saturate(0.78) brightness(0.58);
   display: grid;
   place-items: center;
   padding: 1rem;
@@ -15098,6 +15102,253 @@ html[data-theme='light'] .idt-scan-form .idt-btn-ghost,
   box-shadow: none;
 }
 
+.idt-modal.idt-scan-modal {
+  width: min(96vw, 980px);
+  max-height: min(90vh, 860px);
+  overflow: hidden;
+  padding: 0;
+  border-color: #2d2d30;
+  border-radius: 8px;
+  background: #050505;
+  color: #ffffff;
+  box-shadow:
+    0 30px 90px rgba(0, 0, 0, 0.7),
+    0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.idt-scan-modal .idt-modal-close {
+  z-index: 2;
+  top: 0.8rem;
+  right: 0.8rem;
+  border-color: #303033;
+  background: #0f0f10;
+  color: #ffffff;
+  cursor: pointer;
+}
+
+.idt-scan-modal-shell {
+  display: grid;
+  grid-template-columns: minmax(16rem, 0.38fr) minmax(0, 1fr);
+  max-height: min(90vh, 860px);
+}
+
+.idt-scan-modal-guide {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  overflow: auto;
+  border-right: 1px solid #242427;
+  background: #090909;
+  padding: 1.35rem;
+}
+
+.idt-scan-modal-guide h2 {
+  margin: 0;
+  max-width: 12ch;
+  color: #ffffff;
+  font-size: clamp(1.8rem, 3vw, 2.65rem);
+  line-height: 1.02;
+  letter-spacing: 0;
+}
+
+.idt-scan-modal-guide p {
+  margin: 0;
+  color: #c9c9cf;
+  line-height: 1.55;
+}
+
+.idt-scan-stepper {
+  margin: 0.3rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.idt-scan-stepper li {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  min-height: 42px;
+  border: 1px solid #26262a;
+  border-radius: 8px;
+  padding: 0.42rem 0.55rem;
+  color: #b8b8bf;
+  font-weight: 760;
+}
+
+.idt-scan-stepper li span {
+  display: inline-grid;
+  place-items: center;
+  width: 1.65rem;
+  height: 1.65rem;
+  border-radius: 999px;
+  background: #141416;
+  color: #d7d7dc;
+  font-size: 0.78rem;
+}
+
+.idt-scan-stepper li.is-active {
+  border-color: #ffffff;
+  background: #ffffff;
+  color: #000000;
+}
+
+.idt-scan-stepper li.is-active span {
+  background: #000000;
+  color: #ffffff;
+}
+
+.idt-scan-guidance-list {
+  margin-top: auto;
+  border-top: 1px solid #242427;
+  padding-top: 1rem;
+}
+
+.idt-scan-guidance-list h3 {
+  margin: 0 0 0.65rem;
+  color: #ffffff;
+  font-size: 0.9rem;
+}
+
+.idt-scan-guidance-list ul {
+  margin: 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.45rem;
+  color: #c9c9cf;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.idt-scan-modal-form.idt-scan-form {
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  align-content: start;
+  overflow: auto;
+  max-width: none;
+  max-height: min(90vh, 860px);
+  padding: 1.35rem;
+}
+
+.idt-scan-modal-form .idt-scan-form-header {
+  position: static;
+  gap: 0.5rem;
+  border-left: 0;
+  border-bottom: 1px solid #242427;
+  padding: 0 2rem 1rem 0;
+}
+
+.idt-scan-modal-form .idt-scan-form-header h2 {
+  font-family: var(--idt-display);
+  font-size: clamp(1.45rem, 2.5vw, 2rem);
+  line-height: 1.08;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.idt-scan-modal-form .idt-scan-form-header > p:last-child {
+  max-width: 54ch;
+  line-height: 1.5;
+}
+
+.idt-scan-modal-form .idt-intake-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.idt-scan-modal-form .idt-intake-grid label {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.idt-scan-modal-form .idt-intake-grid input,
+.idt-scan-modal-form .idt-intake-grid select {
+  min-height: 52px;
+}
+
+.idt-scan-modal-form .idt-inline-actions,
+.idt-scan-modal-form .idt-form-error {
+  grid-column: auto;
+}
+
+.idt-scan-modal-form .idt-inline-actions {
+  justify-content: flex-end;
+  margin-top: 0;
+}
+
+.idt-scan-modal-form .idt-form-error {
+  margin: 0;
+  border: 1px solid #4b2a2a;
+  border-radius: 8px;
+  background: #1a0909;
+  padding: 0.75rem 0.85rem;
+}
+
+.idt-scan-modal-form .idt-intake-summary {
+  grid-column: 1 / -1;
+  border: 1px solid #2a2a2a;
+  border-left: 3px solid #ffffff;
+  border-radius: 8px;
+  background: #090909;
+  padding: 1rem;
+}
+
+.idt-scan-modal-form .idt-intake-review {
+  gap: 0.65rem;
+}
+
+.idt-scan-modal-form .idt-intake-review-row {
+  padding: 0.85rem;
+}
+
+.idt-scan-modal-form .idt-intake-confirmation {
+  display: grid;
+  gap: 0.8rem;
+  border: 1px solid #2a2a2a;
+  border-radius: 8px;
+  background: #090909;
+  padding: 1rem;
+}
+
+.idt-scan-modal-form .idt-intake-confirmation h3 {
+  margin: 0;
+}
+
+html[data-theme='light'] .idt-modal.idt-scan-modal,
+html[data-theme='light'] .idt-modal.idt-scan-modal h2,
+html[data-theme='light'] .idt-modal.idt-scan-modal h3,
+html[data-theme='light'] .idt-scan-modal-guide h2,
+html[data-theme='light'] .idt-scan-guidance-list h3,
+html[data-theme='light'] .idt-scan-modal-form .idt-scan-form-header h2,
+html[data-theme='light'] .idt-scan-modal-form .idt-intake-summary h3,
+html[data-theme='light'] .idt-scan-modal-form .idt-intake-confirmation h3 {
+  color: #ffffff;
+}
+
+html[data-theme='light'] .idt-scan-modal-guide p,
+html[data-theme='light'] .idt-scan-modal-guide li,
+html[data-theme='light'] .idt-scan-modal-form .idt-scan-form-header > p:last-child,
+html[data-theme='light'] .idt-scan-modal-form .idt-intake-confirmation,
+html[data-theme='light'] .idt-scan-modal-form .idt-intake-confirmation p,
+html[data-theme='light'] .idt-scan-modal-form .idt-intake-review-row p {
+  color: #d9d9df;
+}
+
+html[data-theme='light'] .idt-scan-modal-form .idt-intake-step,
+html[data-theme='light'] .idt-scan-modal-form .idt-intake-grid label {
+  color: #f7f7fa;
+}
+
+html[data-theme='light'] .idt-scan-stepper li {
+  color: #c6c6cc;
+}
+
+html[data-theme='light'] .idt-scan-stepper li.is-active {
+  color: #000000;
+}
+
 @media (max-width: 980px) {
   .idt-scan-hero {
     grid-template-columns: 1fr;
@@ -15123,6 +15374,31 @@ html[data-theme='light'] .idt-scan-form .idt-btn-ghost,
   .idt-scan-form .idt-inline-actions,
   .idt-scan-form .idt-form-error {
     grid-column: auto;
+  }
+
+  .idt-scan-modal-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-scan-modal-guide {
+    border-right: 0;
+    border-bottom: 1px solid #242427;
+  }
+
+  .idt-scan-modal-guide h2 {
+    max-width: none;
+  }
+
+  .idt-scan-stepper {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .idt-scan-stepper li {
+    justify-content: center;
+  }
+
+  .idt-scan-guidance-list {
+    margin-top: 0;
   }
 }
 
@@ -15159,6 +15435,33 @@ html[data-theme='light'] .idt-scan-form .idt-btn-ghost,
 
   .idt-scan-form .idt-inline-actions .idt-btn {
     width: 100%;
+  }
+
+  .idt-modal.idt-scan-modal {
+    width: min(100%, calc(100vw - 1rem));
+    overflow: auto;
+  }
+
+  .idt-scan-modal-shell {
+    max-height: none;
+  }
+
+  .idt-scan-modal-form.idt-scan-form {
+    max-height: none;
+    overflow: visible;
+    padding: 1rem;
+  }
+
+  .idt-scan-modal-guide {
+    padding: 1rem;
+  }
+
+  .idt-scan-stepper {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-scan-modal-form .idt-intake-grid {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -16909,6 +16909,8 @@ html[data-theme='light'] .idt-marketing-page .idt-inline-link {
   color: #ffffff;
 }
 
+.idt-modern-public-page > .idt-page-hero-rich.is-no-visual,
+html[data-theme='light'] .idt-modern-public-page > .idt-page-hero-rich.is-no-visual,
 .idt-modern-public-page > .idt-page-hero-rich:not(:has(.idt-page-hero-visual)),
 html[data-theme='light'] .idt-modern-public-page > .idt-page-hero-rich:not(:has(.idt-page-hero-visual)) {
   grid-template-columns: minmax(0, 1fr);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1384,8 +1384,9 @@ h3 {
 
 .idt-honeypot {
   position: absolute;
-  width: 1px;
-  height: 1px;
+  width: 1px !important;
+  max-width: 1px;
+  height: 1px !important;
   margin: -1px;
   padding: 0;
   border: 0;
@@ -16906,6 +16907,203 @@ html[data-theme='light'] .idt-marketing-page .idt-btn-ghost {
 .idt-marketing-page .idt-inline-link,
 html[data-theme='light'] .idt-marketing-page .idt-inline-link {
   color: #ffffff;
+}
+
+.idt-modern-public-page > .idt-page-hero-rich:not(:has(.idt-page-hero-visual)),
+html[data-theme='light'] .idt-modern-public-page > .idt-page-hero-rich:not(:has(.idt-page-hero-visual)) {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.idt-modern-public-page .idt-page-hero-copy,
+html[data-theme='light'] .idt-modern-public-page .idt-page-hero-copy {
+  max-width: min(980px, 100%);
+}
+
+.idt-modern-public-page .idt-page-hero-rich h1,
+html[data-theme='light'] .idt-modern-public-page .idt-page-hero-rich h1 {
+  max-width: 17ch;
+}
+
+.idt-modern-public-page .idt-page-hero-copy > p,
+html[data-theme='light'] .idt-modern-public-page .idt-page-hero-copy > p {
+  max-width: 72ch;
+}
+
+.idt-modern-public-page .idt-section-title h2,
+.idt-modern-public-page .idt-card h3,
+.idt-modern-public-page .idt-blog-section h2,
+html[data-theme='light'] .idt-modern-public-page .idt-section-title h2,
+html[data-theme='light'] .idt-modern-public-page .idt-card h3,
+html[data-theme='light'] .idt-modern-public-page .idt-blog-section h2 {
+  color: #ffffff;
+}
+
+.idt-modern-public-page .idt-card,
+.idt-modern-public-page .idt-lead-form,
+.idt-modern-public-page .idt-table-wrap,
+.idt-modern-public-page .idt-roi,
+.idt-modern-public-page .idt-demo-sidebar,
+.idt-modern-public-page .idt-demo-graph,
+.idt-modern-public-page .idt-demo-list-view,
+.idt-modern-public-page .idt-faq-item,
+html[data-theme='light'] .idt-modern-public-page .idt-card,
+html[data-theme='light'] .idt-modern-public-page .idt-lead-form,
+html[data-theme='light'] .idt-modern-public-page .idt-table-wrap,
+html[data-theme='light'] .idt-modern-public-page .idt-roi,
+html[data-theme='light'] .idt-modern-public-page .idt-demo-sidebar,
+html[data-theme='light'] .idt-modern-public-page .idt-demo-graph,
+html[data-theme='light'] .idt-modern-public-page .idt-demo-list-view,
+html[data-theme='light'] .idt-modern-public-page .idt-faq-item {
+  border: 1px solid #242424;
+  border-radius: 8px;
+  background: #080808;
+  color: #ffffff;
+  box-shadow: none;
+}
+
+.idt-modern-public-page .idt-card-grid,
+html[data-theme='light'] .idt-modern-public-page .idt-card-grid {
+  gap: 1px;
+  background: #242424;
+}
+
+.idt-modern-public-page .idt-card p,
+.idt-modern-public-page .idt-card li,
+.idt-modern-public-page .idt-lead-form p,
+.idt-modern-public-page .idt-roi label,
+.idt-modern-public-page .idt-roi-output p,
+.idt-modern-public-page .idt-roi-note,
+.idt-modern-public-page .idt-roi-disclaimer,
+.idt-modern-public-page .idt-faq-item p,
+.idt-modern-public-page .idt-blog-article p,
+.idt-modern-public-page .idt-blog-article li,
+html[data-theme='light'] .idt-modern-public-page .idt-card p,
+html[data-theme='light'] .idt-modern-public-page .idt-card li,
+html[data-theme='light'] .idt-modern-public-page .idt-lead-form p,
+html[data-theme='light'] .idt-modern-public-page .idt-roi label,
+html[data-theme='light'] .idt-modern-public-page .idt-roi-output p,
+html[data-theme='light'] .idt-modern-public-page .idt-roi-note,
+html[data-theme='light'] .idt-modern-public-page .idt-roi-disclaimer,
+html[data-theme='light'] .idt-modern-public-page .idt-faq-item p,
+html[data-theme='light'] .idt-modern-public-page .idt-blog-article p,
+html[data-theme='light'] .idt-modern-public-page .idt-blog-article li {
+  color: #a1a1aa;
+}
+
+.idt-modern-public-page .idt-faq-list,
+html[data-theme='light'] .idt-modern-public-page .idt-faq-list {
+  gap: 1px;
+  border: 1px solid #242424;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #242424;
+}
+
+.idt-modern-public-page .idt-faq-item,
+html[data-theme='light'] .idt-modern-public-page .idt-faq-item {
+  border: 0;
+  border-radius: 0;
+}
+
+.idt-modern-public-page .idt-faq-item summary,
+html[data-theme='light'] .idt-modern-public-page .idt-faq-item summary {
+  color: #ffffff;
+}
+
+.idt-modern-public-page .idt-table-wrap,
+html[data-theme='light'] .idt-modern-public-page .idt-table-wrap {
+  overflow: auto;
+}
+
+.idt-modern-public-page .idt-compare-table,
+html[data-theme='light'] .idt-modern-public-page .idt-compare-table {
+  color: #d4d4d8;
+}
+
+.idt-modern-public-page .idt-compare-table th,
+.idt-modern-public-page .idt-compare-table td,
+html[data-theme='light'] .idt-modern-public-page .idt-compare-table th,
+html[data-theme='light'] .idt-modern-public-page .idt-compare-table td {
+  border-color: #242424;
+  color: #d4d4d8;
+}
+
+.idt-modern-public-page .idt-compare-table thead th,
+.idt-modern-public-page .idt-compare-table tbody th,
+html[data-theme='light'] .idt-modern-public-page .idt-compare-table thead th,
+html[data-theme='light'] .idt-modern-public-page .idt-compare-table tbody th {
+  background: #0d0d0d;
+  color: #ffffff;
+}
+
+.idt-modern-public-page .idt-compare-table tbody tr:nth-child(even) td,
+html[data-theme='light'] .idt-modern-public-page .idt-compare-table tbody tr:nth-child(even) td {
+  background: #050505;
+}
+
+.idt-modern-public-page .idt-roi-profiles,
+html[data-theme='light'] .idt-modern-public-page .idt-roi-profiles {
+  border: 1px solid #242424;
+  background: #050505;
+}
+
+.idt-modern-public-page .idt-roi-profiles button,
+html[data-theme='light'] .idt-modern-public-page .idt-roi-profiles button {
+  color: #a1a1aa;
+}
+
+.idt-modern-public-page .idt-roi-profiles button.is-active,
+html[data-theme='light'] .idt-modern-public-page .idt-roi-profiles button.is-active {
+  background: #ffffff;
+  color: #000000;
+}
+
+.idt-modern-public-page .idt-roi-number-input,
+.idt-modern-public-page .idt-lead-form input,
+.idt-modern-public-page .idt-lead-form textarea,
+.idt-modern-public-page .idt-lead-form select,
+html[data-theme='light'] .idt-modern-public-page .idt-roi-number-input,
+html[data-theme='light'] .idt-modern-public-page .idt-lead-form input,
+html[data-theme='light'] .idt-modern-public-page .idt-lead-form textarea,
+html[data-theme='light'] .idt-modern-public-page .idt-lead-form select {
+  border-color: #303030;
+  background: #050505;
+  color: #ffffff;
+}
+
+.idt-modern-public-page .idt-roi-output,
+html[data-theme='light'] .idt-modern-public-page .idt-roi-output {
+  border-color: #303030;
+  background: #0d0d0d;
+}
+
+.idt-modern-public-page .idt-roi-output strong,
+.idt-modern-public-page .idt-roi-total,
+html[data-theme='light'] .idt-modern-public-page .idt-roi-output strong,
+html[data-theme='light'] .idt-modern-public-page .idt-roi-total {
+  color: #ffffff;
+}
+
+.idt-modern-public-page .idt-blog-article,
+html[data-theme='light'] .idt-modern-public-page .idt-blog-article {
+  max-width: 980px;
+  margin-inline: auto;
+}
+
+.idt-modern-public-page .idt-blog-section,
+html[data-theme='light'] .idt-modern-public-page .idt-blog-section {
+  border-top: 1px solid #242424;
+}
+
+.idt-modern-public-page .idt-connect-cloud,
+html[data-theme='light'] .idt-modern-public-page .idt-connect-cloud {
+  background: #000000;
+}
+
+.idt-not-found-page .idt-card .idt-btn,
+html[data-theme='light'] .idt-not-found-page .idt-card .idt-btn {
+  width: fit-content;
+  margin-top: 0.85rem;
 }
 
 .idt-pricing-page .idt-pricing-toggle,


### PR DESCRIPTION
Fixes #1213

## What changed
- Renamed the public scan CTA to `Request Trust Path Review` across the site.
- Replaced the standalone read-only scan page with a rectangular four-step modal: identity, environment, priority, and final review.
- Kept `/read-only-scan` as a compatibility route that opens the modal from the homepage experience.
- Added extra intake fields for requester name, role, identity provider, infrastructure scope, and optional public GitHub/GitLab/Bitbucket URL.
- Extended the lead API contract and email/webhook payloads with those new fields and validation.

## Why it changed
The previous flow felt repetitive and placeholder-like after clicking the homepage CTA, and "free scan" language can reduce buyer trust in a security workflow. The new flow keeps visitors in context, requires review before submission, and collects more verifiable lead-quality context.

## Impact and risk
- User-facing marketing/intake UX changes only; no authenticated product routes are changed.
- Lead submission still uses the existing `/api/leads` endpoint and delivery channels.
- Backend validation now requires the new requester/context fields for read-only scan intake requests.

## Validation performed
- `npm test -- --run api/leads.test.ts src/App.test.tsx` from `web/`: 64 tests passed.
- `npm run build` from `web/`: TypeScript, Vite build, and 41-route prerender passed.
- Production preview smoke at `http://127.0.0.1:4174/`: CTA opened the modal, steps advanced correctly, review showed submitted details, `/api/leads` was not called before the final submit, and the final payload included the new fields.

## AI disclosure
- AI-assisted: yes
- Tools used: OpenAI Codex
- Where used: public web intake UI, lead API validation, tests, changelog
- Human verification performed: local tests, production build, preview smoke flow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the “Start Free Risk Scan” CTA with a 4‑step “Request Trust Path Review” modal that submits only after a final review. Also modernized public site styles and legal pages, added a no‑visual hero fallback, and routed feature detail CTAs into the modal.

- **New Features**
  - All CTAs open the modal via `ScanIntakeModalProvider` and `ScanIntakeCTA` (homepage and feature pages). `/read-only-scan` opens the modal, prerenders with the provider, then redirects home.
  - Four steps: Identity, Environment, Priority, Review. Collects work email, full name, role/title, company + domain, identity provider, infrastructure scope, and optional public GitHub/GitLab/Bitbucket URL; no API call before final submit.
  - `/api/leads`: accepts new fields, adds strict length caps, canonicalizes repository URLs (http/https; `github.com`/`gitlab.com`/`bitbucket.org`), performs 2s DNS checks, and includes requester/repo details in notification and confirmation emails.
  - UI polish: new modal overlay and layout; redesigned legal policy pages via shared `LegalDocumentPage`; added hero “no‑visual” fallback class.

- **Migration**
  - Read-only intake now requires work email, full name, role/title, identity provider, and infrastructure scope; rejects personal emails, domain mismatches, and invalid/non-web repo URLs.
  - Existing `/read-only-scan` links still work; they open the modal and then redirect to `/`.

<sup>Written for commit 6b72c1fe0c4d767e2ebea1a986dda53eb78d8c11. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1214?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

