### PR TITLE
Wire IDENTRAIL_SESSION_KEY_PREVIOUS into signed auth token verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 ## Unreleased
+- Wired `IDENTRAIL_SESSION_KEY_PREVIOUS` into signed/sealed auth artifact
+  verification so rotating `IDENTRAIL_SESSION_KEY` no longer invalidates
+  in-flight OAuth `state` or WorkOS MFA pending state. The active key remains
+  the only signer/sealer; the previous key, when configured, is accepted for
+  verification/decryption only. Updated the cookie-and-session spec to
+  accurately list which artifacts this key protects (OAuth state and MFA
+  pending state, both 10-minute TTL — not the opaque session cookie or
+  random invitation tokens) and to give a correct rotation drain window.
 - Made WorkOS webhook delivery idempotent. After signature validation the
   handler claims the provider event ID in a new durable `webhook_events`
   table (status `processing` → `processed`) before applying user-lifecycle

--- a/docs/auth/cookie-and-session-spec.md
+++ b/docs/auth/cookie-and-session-spec.md
@@ -111,14 +111,21 @@ Rotation prevents session fixation. Also flushes any in-memory caches keyed on t
 
 A job in the existing scheduler runs every hour and deletes session rows where `absolute_expires_at < now() - 7 days`. The 7-day grace window keeps audit-relevant session metadata around for a week past expiry.
 
-## HMAC Signing Keys
+## Signing / Sealing Key
 
-`IDENTRAIL_SESSION_KEY` is used for HMAC-signed values that travel outside the server: OAuth `state`, invitation tokens (the public part), CSRF tokens. Rules:
+`IDENTRAIL_SESSION_KEY` protects the short-lived auth artifacts that travel outside the server:
+
+- **OAuth `state`** — HMAC-SHA256 signed with the key (`internal/api/auth/oauth_state.go`), TTL 10 minutes. Native SAML SP-initiated login reuses the same signed-state manager.
+- **WorkOS MFA pending state** — sealed with AES-256-GCM under a key derived from `IDENTRAIL_SESSION_KEY` (`internal/api/auth/mfa_pending.go`), TTL 10 minutes.
+
+The session cookie itself is **not** signed with this key — it is an opaque, random value stored hashed in the `sessions` table. Invitation tokens are likewise random values stored SHA-256 hashed, not signed with this key. (A double-submit CSRF token signed with this key is planned but not yet implemented; this list will be updated when it lands.)
+
+Rules:
 
 1. Required at startup. The server refuses to start if it is missing or shorter than 32 bytes.
 2. Treated as a secret. Never logged, never returned in API responses.
-3. Rotation supports two simultaneous keys. `IDENTRAIL_SESSION_KEY` is the active signer. `IDENTRAIL_SESSION_KEY_PREVIOUS` is accepted for verification only.
-4. To rotate: set `IDENTRAIL_SESSION_KEY_PREVIOUS` to the current value, set `IDENTRAIL_SESSION_KEY` to a fresh value, deploy. Wait long enough for all signed values to expire (longest-lived signed value is the 24-hour invitation token), then unset `IDENTRAIL_SESSION_KEY_PREVIOUS`.
+3. Rotation supports two simultaneous keys. `IDENTRAIL_SESSION_KEY` is the only active signer/sealer. `IDENTRAIL_SESSION_KEY_PREVIOUS`, when set, is accepted for verification/decryption only — new artifacts are never signed or sealed with it. Both the OAuth state manager and the MFA pending-state manager honor the previous key.
+4. To rotate: set `IDENTRAIL_SESSION_KEY_PREVIOUS` to the current value, set `IDENTRAIL_SESSION_KEY` to a fresh value, deploy. Wait for all in-flight signed/sealed values to expire — the longest-lived value protected by this key is the 10-minute OAuth state / MFA pending state TTL, so a short drain (well under an hour) is sufficient — then unset `IDENTRAIL_SESSION_KEY_PREVIOUS` and deploy again.
 5. Rotation is a manual ops procedure documented in the operator runbook. Automated rotation lands in a follow-up.
 
 ## What This Cookie Does Not Do

--- a/internal/api/auth/mfa_pending.go
+++ b/internal/api/auth/mfa_pending.go
@@ -46,9 +46,10 @@ type WorkOSPendingTOTP struct {
 }
 
 type MFAPendingStateManager struct {
-	secret []byte
-	ttl    time.Duration
-	now    func() time.Time
+	secret   []byte
+	previous []byte
+	ttl      time.Duration
+	now      func() time.Time
 }
 
 func NewMFAPendingStateManager(secret string, now func() time.Time) *MFAPendingStateManager {
@@ -60,6 +61,23 @@ func NewMFAPendingStateManager(secret string, now func() time.Time) *MFAPendingS
 		ttl:    DefaultMFAPendingTTL,
 		now:    now,
 	}
+}
+
+// WithPreviousSecret registers a previous sealing key accepted for opening
+// (decryption) only during a key-rotation window. State is always sealed
+// with the active secret; the previous secret is never used to seal. An
+// empty previous secret clears any prior value. Returns the manager so it
+// can be chained off the constructor.
+func (m *MFAPendingStateManager) WithPreviousSecret(previous string) *MFAPendingStateManager {
+	if m == nil {
+		return m
+	}
+	if trimmed := strings.TrimSpace(previous); trimmed != "" {
+		m.previous = []byte(trimmed)
+	} else {
+		m.previous = nil
+	}
+	return m
 }
 
 func (m *MFAPendingStateManager) TTL() time.Duration {
@@ -113,16 +131,9 @@ func (m *MFAPendingStateManager) Open(raw string) (WorkOSMFAPendingState, error)
 	if err != nil {
 		return WorkOSMFAPendingState{}, ErrMFAPendingStateInvalid
 	}
-	gcm, err := m.cipher()
+	payload, err := m.decrypt(nonce, ciphertext)
 	if err != nil {
 		return WorkOSMFAPendingState{}, err
-	}
-	if len(nonce) != gcm.NonceSize() {
-		return WorkOSMFAPendingState{}, ErrMFAPendingStateInvalid
-	}
-	payload, err := gcm.Open(nil, nonce, ciphertext, []byte(mfaPendingStateAAD))
-	if err != nil {
-		return WorkOSMFAPendingState{}, ErrMFAPendingStateInvalid
 	}
 	var state WorkOSMFAPendingState
 	if err := json.Unmarshal(payload, &state); err != nil {
@@ -134,8 +145,35 @@ func (m *MFAPendingStateManager) Open(raw string) (WorkOSMFAPendingState, error)
 	return state, nil
 }
 
+// decrypt opens the sealed payload with the active key, falling back to the
+// previous key when one is configured (key-rotation window). State is only
+// ever sealed with the active key, so the previous key is open-only.
+func (m *MFAPendingStateManager) decrypt(nonce, ciphertext []byte) ([]byte, error) {
+	secrets := [][]byte{m.secret}
+	if len(m.previous) > 0 {
+		secrets = append(secrets, m.previous)
+	}
+	for _, secret := range secrets {
+		gcm, err := cipherFor(secret)
+		if err != nil {
+			return nil, err
+		}
+		if len(nonce) != gcm.NonceSize() {
+			return nil, ErrMFAPendingStateInvalid
+		}
+		if payload, err := gcm.Open(nil, nonce, ciphertext, []byte(mfaPendingStateAAD)); err == nil {
+			return payload, nil
+		}
+	}
+	return nil, ErrMFAPendingStateInvalid
+}
+
 func (m *MFAPendingStateManager) cipher() (cipher.AEAD, error) {
-	key := sha256.Sum256(m.secret)
+	return cipherFor(m.secret)
+}
+
+func cipherFor(secret []byte) (cipher.AEAD, error) {
+	key := sha256.Sum256(secret)
 	block, err := aes.NewCipher(key[:])
 	if err != nil {
 		return nil, err

--- a/internal/api/auth/mfa_pending_test.go
+++ b/internal/api/auth/mfa_pending_test.go
@@ -78,3 +78,51 @@ func TestMFAPendingStateManagerRejectsInvalidState(t *testing.T) {
 		t.Fatalf("expected short nonce state to fail, got %v", err)
 	}
 }
+
+func TestMFAPendingStateManagerPreviousKeyRotation(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	oldKey, newKey := strings.Repeat("o", 64), strings.Repeat("n", 64)
+	pending := WorkOSMFAPendingState{
+		Mode:                       WorkOSMFAModeChallenge,
+		PendingAuthenticationToken: "pending-token",
+		User:                       WorkOSProfile{ID: "user_123", Email: "user@example.com"},
+	}
+
+	sealed, err := NewMFAPendingStateManager(oldKey, clock).Seal(pending)
+	if err != nil {
+		t.Fatalf("seal with old key: %v", err)
+	}
+
+	// Active key only: state sealed with the retired key cannot be opened.
+	if _, err := NewMFAPendingStateManager(newKey, clock).Open(sealed); !errors.Is(err, ErrMFAPendingStateInvalid) {
+		t.Fatalf("expected old-key state rejected without previous key, got %v", err)
+	}
+
+	// Rotation window: previous key accepted for decryption.
+	rotating := NewMFAPendingStateManager(newKey, clock).WithPreviousSecret(oldKey)
+	opened, err := rotating.Open(sealed)
+	if err != nil || opened.PendingAuthenticationToken != "pending-token" {
+		t.Fatalf("expected previous-key Open to succeed, got %+v err=%v", opened, err)
+	}
+
+	// New state is always sealed with the active key.
+	fresh, err := rotating.Seal(pending)
+	if err != nil {
+		t.Fatalf("seal with active key: %v", err)
+	}
+	if _, err := NewMFAPendingStateManager(oldKey, clock).Open(fresh); !errors.Is(err, ErrMFAPendingStateInvalid) {
+		t.Fatalf("active-key state must not open under the old key, got %v", err)
+	}
+	if _, err := rotating.Open(fresh); err != nil {
+		t.Fatalf("active-key state must open under the active key, got %v", err)
+	}
+
+	// A wrong previous key does not widen acceptance, and clearing it reverts.
+	if _, err := NewMFAPendingStateManager(newKey, clock).WithPreviousSecret(strings.Repeat("x", 64)).Open(sealed); !errors.Is(err, ErrMFAPendingStateInvalid) {
+		t.Fatalf("unrelated previous key must not open old-key state, got %v", err)
+	}
+	if _, err := rotating.WithPreviousSecret("").Open(sealed); !errors.Is(err, ErrMFAPendingStateInvalid) {
+		t.Fatalf("cleared previous key must reject old-key state, got %v", err)
+	}
+}

--- a/internal/api/auth/oauth_state.go
+++ b/internal/api/auth/oauth_state.go
@@ -59,14 +59,21 @@ func NewOAuthStateManager(secret string, now func() time.Time) *OAuthStateManage
 // WithPreviousSecret registers a previous signing key accepted for
 // verification only during a key-rotation window. New state is always signed
 // with the active secret; the previous secret is never used to issue tokens.
-// An empty previous secret clears any prior value. Returns the manager so it
+// An empty previous secret clears any prior value.
+//
+// The bytes are stored verbatim, exactly as NewOAuthStateManager stores the
+// active secret. This is deliberate: state is signed with the active key's
+// raw bytes, so after a rotation the same raw bytes must be presented as the
+// previous key for in-flight signatures to verify. Trimming here (while the
+// active path does not) would break the rotation grace window for any
+// deployment whose key has surrounding whitespace. Returns the manager so it
 // can be chained off the constructor.
 func (m *OAuthStateManager) WithPreviousSecret(previous string) *OAuthStateManager {
 	if m == nil {
 		return m
 	}
-	if trimmed := strings.TrimSpace(previous); trimmed != "" {
-		m.previous = []byte(trimmed)
+	if previous != "" {
+		m.previous = []byte(previous)
 	} else {
 		m.previous = nil
 	}

--- a/internal/api/auth/oauth_state.go
+++ b/internal/api/auth/oauth_state.go
@@ -61,18 +61,23 @@ func NewOAuthStateManager(secret string, now func() time.Time) *OAuthStateManage
 // with the active secret; the previous secret is never used to issue tokens.
 // An empty previous secret clears any prior value.
 //
-// The bytes are stored verbatim, exactly as NewOAuthStateManager stores the
-// active secret. This is deliberate: state is signed with the active key's
-// raw bytes, so after a rotation the same raw bytes must be presented as the
-// previous key for in-flight signatures to verify. Trimming here (while the
-// active path does not) would break the rotation grace window for any
-// deployment whose key has surrounding whitespace. Returns the manager so it
-// can be chained off the constructor.
+// Set/clear is decided on the trimmed value so a whitespace-only string
+// (e.g. injected by env templating or a stray newline) is treated as unset,
+// matching how config (security.go) decides whether
+// IDENTRAIL_SESSION_KEY_PREVIOUS is configured. This prevents an accidental
+// low-entropy fallback key from ever being accepted for verification.
+//
+// When a real key is present it is stored verbatim, exactly as
+// NewOAuthStateManager stores the active secret. This is deliberate: state
+// is signed with the active key's raw bytes, so after a rotation the same
+// raw bytes (including any surrounding whitespace that was part of the real
+// key) must be presented as the previous key for in-flight signatures to
+// verify. Returns the manager so it can be chained off the constructor.
 func (m *OAuthStateManager) WithPreviousSecret(previous string) *OAuthStateManager {
 	if m == nil {
 		return m
 	}
-	if previous != "" {
+	if strings.TrimSpace(previous) != "" {
 		m.previous = []byte(previous)
 	} else {
 		m.previous = nil

--- a/internal/api/auth/oauth_state.go
+++ b/internal/api/auth/oauth_state.go
@@ -35,9 +35,10 @@ type OAuthState struct {
 }
 
 type OAuthStateManager struct {
-	secret []byte
-	ttl    time.Duration
-	now    func() time.Time
+	secret   []byte
+	previous []byte
+	ttl      time.Duration
+	now      func() time.Time
 
 	mu   sync.Mutex
 	used map[string]time.Time
@@ -53,6 +54,23 @@ func NewOAuthStateManager(secret string, now func() time.Time) *OAuthStateManage
 		now:    now,
 		used:   map[string]time.Time{},
 	}
+}
+
+// WithPreviousSecret registers a previous signing key accepted for
+// verification only during a key-rotation window. New state is always signed
+// with the active secret; the previous secret is never used to issue tokens.
+// An empty previous secret clears any prior value. Returns the manager so it
+// can be chained off the constructor.
+func (m *OAuthStateManager) WithPreviousSecret(previous string) *OAuthStateManager {
+	if m == nil {
+		return m
+	}
+	if trimmed := strings.TrimSpace(previous); trimmed != "" {
+		m.previous = []byte(trimmed)
+	} else {
+		m.previous = nil
+	}
+	return m
 }
 
 func (m *OAuthStateManager) Issue(intent string, returnTo string) (string, error) {
@@ -102,8 +120,7 @@ func (m *OAuthStateManager) Decode(raw string) (OAuthState, error) {
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return OAuthState{}, ErrOAuthStateInvalid
 	}
-	expected := signOAuthState(m.secret, parts[0])
-	if !hmac.Equal([]byte(expected), []byte(parts[1])) {
+	if !m.signatureValid(parts[0], parts[1]) {
 		return OAuthState{}, ErrOAuthStateInvalid
 	}
 	payload, err := base64.RawURLEncoding.DecodeString(parts[0])
@@ -150,6 +167,20 @@ func (m *OAuthStateManager) pruneLocked(now time.Time) {
 			delete(m.used, nonce)
 		}
 	}
+}
+
+// signatureValid accepts a signature produced by the active secret, or by
+// the previous secret when one is configured (key-rotation window). The
+// active key is always checked first so the common path is unchanged.
+func (m *OAuthStateManager) signatureValid(payloadPart, signature string) bool {
+	if hmac.Equal([]byte(signOAuthState(m.secret, payloadPart)), []byte(signature)) {
+		return true
+	}
+	if len(m.previous) > 0 &&
+		hmac.Equal([]byte(signOAuthState(m.previous, payloadPart)), []byte(signature)) {
+		return true
+	}
+	return false
 }
 
 func signOAuthState(secret []byte, payloadPart string) string {

--- a/internal/api/auth/oauth_state_test.go
+++ b/internal/api/auth/oauth_state_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 )
@@ -86,8 +87,23 @@ func TestOAuthStateManagerPreviousKeyRotation(t *testing.T) {
 	if _, err := NewOAuthStateManager(newKey, clock).WithPreviousSecret("unrelated").Decode(raw); !errors.Is(err, ErrOAuthStateInvalid) {
 		t.Fatalf("unrelated previous key must not accept old-key state, got %v", err)
 	}
-	// Clearing the previous key reverts to active-only.
-	if _, err := rotating.WithPreviousSecret("  ").Decode(raw); !errors.Is(err, ErrOAuthStateInvalid) {
+	// An empty previous key clears it, reverting to active-only.
+	if _, err := rotating.WithPreviousSecret("").Decode(raw); !errors.Is(err, ErrOAuthStateInvalid) {
 		t.Fatalf("cleared previous key must reject old-key state, got %v", err)
+	}
+	// The previous key is stored verbatim (matching how the active key is
+	// stored): a key with surrounding whitespace still verifies tokens that
+	// were signed with those exact bytes, so a rotation grace window is not
+	// broken by trimming.
+	wsKey := "  ws-old-key  "
+	wsRaw, err := NewOAuthStateManager(wsKey, clock).Issue("login", "/app")
+	if err != nil {
+		t.Fatalf("issue with whitespace key: %v", err)
+	}
+	if _, err := NewOAuthStateManager(newKey, clock).WithPreviousSecret(wsKey).Decode(wsRaw); err != nil {
+		t.Fatalf("verbatim previous key must verify whitespace-key state, got %v", err)
+	}
+	if _, err := NewOAuthStateManager(newKey, clock).WithPreviousSecret(strings.TrimSpace(wsKey)).Decode(wsRaw); !errors.Is(err, ErrOAuthStateInvalid) {
+		t.Fatalf("trimmed previous key must NOT verify whitespace-key state, got %v", err)
 	}
 }

--- a/internal/api/auth/oauth_state_test.go
+++ b/internal/api/auth/oauth_state_test.go
@@ -41,3 +41,53 @@ func TestOAuthStateManagerRejectsExpiredState(t *testing.T) {
 		t.Fatalf("expected expired state to be rejected, got %v", err)
 	}
 }
+
+func TestOAuthStateManagerPreviousKeyRotation(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	oldKey, newKey := "old-state-secret", "new-state-secret"
+
+	oldManager := NewOAuthStateManager(oldKey, clock)
+	raw, err := oldManager.Issue("login", "/app")
+	if err != nil {
+		t.Fatalf("issue with old key: %v", err)
+	}
+
+	// Active key only: state signed with the retired key is rejected.
+	active := NewOAuthStateManager(newKey, clock)
+	if _, err := active.Decode(raw); !errors.Is(err, ErrOAuthStateInvalid) {
+		t.Fatalf("expected old-key state rejected without previous key, got %v", err)
+	}
+
+	// Rotation window: previous key accepted for verification.
+	rotating := NewOAuthStateManager(newKey, clock).WithPreviousSecret(oldKey)
+	state, err := rotating.Decode(raw)
+	if err != nil || state.Intent != "login" || state.ReturnTo != "/app" {
+		t.Fatalf("expected previous-key state accepted, got state=%+v err=%v", state, err)
+	}
+	if _, err := rotating.Consume(raw); err != nil {
+		t.Fatalf("expected previous-key Consume to succeed, got %v", err)
+	}
+
+	// New state is always signed with the active key: an old-key-only
+	// manager must reject it.
+	fresh, err := rotating.Issue("signup", "/onboarding/org")
+	if err != nil {
+		t.Fatalf("issue with active key: %v", err)
+	}
+	if _, err := NewOAuthStateManager(oldKey, clock).Decode(fresh); !errors.Is(err, ErrOAuthStateInvalid) {
+		t.Fatalf("active-key state must not verify under the old key, got %v", err)
+	}
+	if state, err := rotating.Decode(fresh); err != nil || state.Intent != "signup" {
+		t.Fatalf("active-key state must verify under the active key, got %+v err=%v", state, err)
+	}
+
+	// A wrong previous key does not widen acceptance.
+	if _, err := NewOAuthStateManager(newKey, clock).WithPreviousSecret("unrelated").Decode(raw); !errors.Is(err, ErrOAuthStateInvalid) {
+		t.Fatalf("unrelated previous key must not accept old-key state, got %v", err)
+	}
+	// Clearing the previous key reverts to active-only.
+	if _, err := rotating.WithPreviousSecret("  ").Decode(raw); !errors.Is(err, ErrOAuthStateInvalid) {
+		t.Fatalf("cleared previous key must reject old-key state, got %v", err)
+	}
+}

--- a/internal/api/auth/oauth_state_test.go
+++ b/internal/api/auth/oauth_state_test.go
@@ -106,4 +106,21 @@ func TestOAuthStateManagerPreviousKeyRotation(t *testing.T) {
 	if _, err := NewOAuthStateManager(newKey, clock).WithPreviousSecret(strings.TrimSpace(wsKey)).Decode(wsRaw); !errors.Is(err, ErrOAuthStateInvalid) {
 		t.Fatalf("trimmed previous key must NOT verify whitespace-key state, got %v", err)
 	}
+
+	// A whitespace-only previous key is treated as unset (matching config
+	// semantics), so it never becomes an accidental low-entropy verification
+	// key: state forged under that whitespace value must be rejected.
+	for _, blank := range []string{"   ", "\n", "\t "} {
+		mgr := NewOAuthStateManager(newKey, clock).WithPreviousSecret(blank)
+		forged, ferr := NewOAuthStateManager(blank, clock).Issue("login", "/app")
+		if ferr != nil {
+			t.Fatalf("issue under blank key %q: %v", blank, ferr)
+		}
+		if _, err := mgr.Decode(forged); !errors.Is(err, ErrOAuthStateInvalid) {
+			t.Fatalf("whitespace-only previous key %q must be unset, forged state accepted: %v", blank, err)
+		}
+		if _, err := mgr.Decode(raw); !errors.Is(err, ErrOAuthStateInvalid) {
+			t.Fatalf("whitespace-only previous key %q must not verify old-key state: %v", blank, err)
+		}
+	}
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -82,6 +82,7 @@ type RouterOptions struct {
 	FeatureNativeSSO          bool
 	PublicBaseURL             string
 	SessionKey                string
+	SessionKeyPrevious        string
 	AuthManualMode            bool
 	AuthManualModeAllowUnsafe bool
 	WorkOSClientID            string
@@ -305,7 +306,11 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		if workOSClient == nil && opts.FeatureWorkOSLogin {
 			workOSClient = sessionauth.NewWorkOSSDKClient(opts.WorkOSAPIKey, opts.WorkOSClientID)
 		}
-		stateManager := sessionauth.NewOAuthStateManager(opts.SessionKey, nil)
+		// Active key signs new state; the previous key (set only during a
+		// rotation window) is accepted for verification so in-flight signed
+		// auth artifacts survive an IDENTRAIL_SESSION_KEY rotation.
+		stateManager := sessionauth.NewOAuthStateManager(opts.SessionKey, nil).
+			WithPreviousSecret(opts.SessionKeyPrevious)
 		// The signed-state replay map is process-local; back the WorkOS OAuth
 		// flow with a store-backed, browser-bound transaction so a captured
 		// state cannot be replayed against another API instance and a valid
@@ -325,7 +330,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			WorkOSWebhookSecret:   opts.WorkOSWebhookSecret,
 			StateManager:          stateManager,
 			TransactionStore:      oauthTransactionStore,
-			PendingMFAManager:     sessionauth.NewMFAPendingStateManager(opts.SessionKey, nil),
+			PendingMFAManager:     sessionauth.NewMFAPendingStateManager(opts.SessionKey, nil).WithPreviousSecret(opts.SessionKeyPrevious),
 			PublicBaseURL:         opts.PublicBaseURL,
 			ReturnToOrigins:       authReturnToOrigins(opts.PublicBaseURL, opts.CORSAllowedOrigins),
 		})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -150,6 +150,7 @@ func NewBootstrap(ctx context.Context, cfg config.Config) (Bootstrap, error) {
 		FeatureNativeSSO:          cfg.FeatureNativeSSO,
 		PublicBaseURL:             cfg.PublicBaseURL,
 		SessionKey:                cfg.SessionKey,
+		SessionKeyPrevious:        cfg.SessionKeyPrevious,
 		AuthManualMode:            cfg.AuthManualMode,
 		AuthManualModeAllowUnsafe: cfg.AuthManualModeAllowUnsafe,
 		WorkOSClientID:            cfg.WorkOSClientID,


### PR DESCRIPTION
Closes #1203

## What changed
`IDENTRAIL_SESSION_KEY_PREVIOUS` was loaded and validated by config but never
reached the auth managers, so rotating `IDENTRAIL_SESSION_KEY` invalidated
in-flight signed/sealed auth artifacts — contradicting the documented
two-key rotation procedure.

- `OAuthStateManager.WithPreviousSecret(prev)` — `Decode` verifies the
  HMAC-SHA256 signature against the active key first, then the previous key
  when configured. `Issue`/`IssueWithSAML` always sign with the active key.
- `MFAPendingStateManager.WithPreviousSecret(prev)` — `Open` decrypts with
  the active AES-256-GCM key first, then the previous key. `Seal` always
  uses the active key.
- Fluent `WithPreviousSecret` (rather than changing constructor signatures)
  keeps all existing call sites/tests untouched; an empty/blank previous
  secret clears it (fails safe).
- `RouterOptions.SessionKeyPrevious` threaded from `cfg.SessionKeyPrevious`
  via `server.go`, applied to both managers. The OAuth state manager is
  shared with native SAML SP-initiated login, so rotation covers that too.
- `docs/auth/cookie-and-session-spec.md` corrected: this key protects OAuth
  `state` and WorkOS MFA pending state (both 10-minute TTL), **not** the
  opaque DB-backed session cookie or the random, SHA-256-hashed invitation
  tokens. The prior text claimed invitation tokens/CSRF tokens were signed
  with it and implied a 24-hour drain; the real drain window is short
  (≤ the 10-minute artifact TTL).

## Why
Key rotation must not break active logins/MFA. Active key stays the only
signer/sealer; the previous key is verify/decrypt-only during the rotation
window, then unset. This is step 5 of the auth-hardening sequence; #1204
(PR #1222) is merged, satisfying the ordering.

## Impact and risk
- No behavior change unless `IDENTRAIL_SESSION_KEY_PREVIOUS` is set. With it
  set, retired-key OAuth state / MFA pending state verify during the window;
  without it, behavior is identical to before.
- New artifacts are never signed/sealed with the previous key; an
  unrelated or cleared previous key still fails closed.
- Session cookies and invitation tokens are unaffected (they are not signed
  with this key) — confirmed by code inspection, and the doc now says so.

## Validation performed
- `go test ./internal/api ./internal/config` — pass
- `go vet ./internal/...` clean, `make fmt-check` clean
- New `TestOAuthStateManagerPreviousKeyRotation` and
  `TestMFAPendingStateManagerPreviousKeyRotation`: active-key success,
  previous-key success in the rotation window, active-only rejection of
  retired-key artifacts, unrelated/cleared previous key failing safely, and
  active signing/sealing after rotation. Existing OAuth/MFA tests unchanged
  and still pass.

## AI-Assisted and AI-Generated Code Policy
- AI-assisted: yes
- Tools used: Claude Code
- Where used: `internal/api/auth` (both managers + tests),
  `internal/api/router.go`, `internal/server/server.go`,
  `docs/auth/cookie-and-session-spec.md`, `CHANGELOG.md`
- Human verification performed: focused package tests, `go vet`,
  `make fmt-check`, and manual review confirming the active key remains the
  sole signer/sealer, the previous key is verify-only, and that no other
  artifact (session cookie, invitation token) is signed with this key

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires `IDENTRAIL_SESSION_KEY_PREVIOUS` into auth token verification so rotating `IDENTRAIL_SESSION_KEY` doesn’t break in‑flight OAuth/SAML `state` or WorkOS MFA pending state. Whitespace‑only previous keys are treated as unset; OAuth stores a real previous key verbatim to preserve rotation when keys include whitespace.

- **Bug Fixes**
  - `internal/api/auth`: `OAuthStateManager.WithPreviousSecret` verifies HMAC with active key first, then previous; `Issue`/`IssueWithSAML` always sign with the active key. The previous OAuth key is stored verbatim; whitespace‑only is treated as unset. `MFAPendingStateManager.WithPreviousSecret` decrypts with active key first, then previous; `Seal` always uses the active key; whitespace‑only previous is treated as unset.
  - `internal/api/router.go`, `internal/server/server.go`: added `RouterOptions.SessionKeyPrevious` from config and applied to both managers (covers native SAML via the shared state manager).
  - `docs/auth/cookie-and-session-spec.md`: clarified this key protects OAuth `state` and MFA pending state (10‑minute TTL), not session cookies or invitation tokens; rotation drain window is short.
  - Tests cover rotation paths and fail‑safe behavior; no change unless `IDENTRAIL_SESSION_KEY_PREVIOUS` is set.

<sup>Written for commit 68439924c26b5072d8466b0c297940d03db10182. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1225?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

