### PR TITLE
Align PUBLIC_BASE_URL docs and config semantics for API callback origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
 ## Unreleased
+- Corrected the `IDENTRAIL_PUBLIC_BASE_URL` documentation so the auth
+  env-var reference and the production-readiness guide agree: it is the
+  externally reachable API callback origin (`https://api.identrail.com` for
+  Identrail Cloud), not the web app origin. The production example now uses
+  the API origin, the WorkOS redirect URI example matches the
+  code-generated `<base>/auth/callback`, and the docs explicitly contrast
+  the API callback origin with web app origins. Docs-only; no behavior
+  change. A potential config rename/split
+  (`IDENTRAIL_PUBLIC_API_BASE_URL` / `IDENTRAIL_WEB_APP_ORIGINS`) is left to
+  a separate tracked change.
 - Wired `IDENTRAIL_SESSION_KEY_PREVIOUS` into signed/sealed auth artifact
   verification so rotating `IDENTRAIL_SESSION_KEY` no longer invalidates
   in-flight OAuth `state` or WorkOS MFA pending state. The active key remains

--- a/docs/auth/env-vars-reference.md
+++ b/docs/auth/env-vars-reference.md
@@ -27,8 +27,10 @@ IDENTRAIL_SESSION_KEY=<64 hex chars from openssl rand -hex 32>
 ```
 
 `IDENTRAIL_PUBLIC_BASE_URL` is the API callback origin, distinct from the web
-app origins (e.g. `https://app.identrail.com`, configured separately via
-`IDENTRAIL_CORS_ALLOWED_ORIGINS` / `VITE_IDENTRAIL_API_URL`). Because the
+app origins (e.g. `https://app.identrail.com`), which the API authorizes via
+`IDENTRAIL_CORS_ALLOWED_ORIGINS`. (`VITE_IDENTRAIL_API_URL` is a separate,
+frontend-build setting that points the web app at the API origin — it is not
+a web-origin allowlist.) Because the
 server builds the callback as `<IDENTRAIL_PUBLIC_BASE_URL>/auth/callback`,
 the redirect URI registered in the WorkOS dashboard must exactly match —
 for the example above, `https://api.identrail.com/auth/callback`. A

--- a/docs/auth/env-vars-reference.md
+++ b/docs/auth/env-vars-reference.md
@@ -4,7 +4,7 @@ A flat list of authentication and connector environment variables, with
 defaults and validation notes. The "Track" column reflects the current roadmap;
 older PR-number references are historical.
 
-The rule that drives every example below: domain references are always config-driven. The doc never hardcodes `app.identrail.com` outside of an example value column.
+The rule that drives every example below: domain references are always config-driven. The doc never hardcodes a deployment's domains as if they were defaults — concrete hosts like `https://api.identrail.com` (API callback origin) and `https://app.identrail.com` (web app origin) appear only as illustrative example values, including where the prose must contrast the two so operators do not confuse them.
 
 ## Core Session and Identity
 
@@ -12,18 +12,29 @@ The two variables marked `Required` in the table below apply regardless of which
 
 | Variable | Default | Validation | Track |
 | --- | --- | --- | --- |
-| `IDENTRAIL_PUBLIC_BASE_URL` | none | Required for any auth driver (WorkOS, OIDC, manual, or native SAML). Must parse as an absolute URL. Must be `https://` in any non-development build. Refuses to start if missing. | Auth foundation |
+| `IDENTRAIL_PUBLIC_BASE_URL` | none | Required for any auth driver (WorkOS, OIDC, manual, or native SAML). This is the **externally reachable API origin** — the host the auth provider redirects back to. The WorkOS callback URL is constructed as `<IDENTRAIL_PUBLIC_BASE_URL>/auth/callback`, so for Identrail Cloud it is the API service origin (`https://api.identrail.com`), **not** the web app origin (`https://app.identrail.com`). Must parse as an absolute URL. Must be `https://` in any non-development build. Refuses to start if missing. See [`production-api-readiness.md`](./production-api-readiness.md). | Auth foundation |
 | `IDENTRAIL_SESSION_KEY` | none | Required for any auth driver. 32 bytes minimum (64 hex chars). Refuses to start if missing or shorter. | Auth foundation |
 | `IDENTRAIL_SESSION_KEY_PREVIOUS` | empty | Optional. Same format as `IDENTRAIL_SESSION_KEY`. Used during a key rotation. | Auth foundation |
 | `IDENTRAIL_AUTH_MANUAL_MODE` | `false` | Boolean. **Local development only.** `/auth/manual` mints a browser session from request-supplied tenant and identity fields, so it must never be enabled for production or any internet-accessible deployment. The server refuses to start when this is `true` unless **both** `IDENTRAIL_PUBLIC_BASE_URL` is a loopback origin (`http://localhost`, `http://127.0.0.1`, or `http://[::1]`) **and** `IDENTRAIL_HTTP_ADDR` binds a loopback interface (e.g. `127.0.0.1:8080`) — a loopback base URL alone does not stop a `0.0.0.0` bind or ingress from exposing the endpoint. As additional per-request defense-in-depth, `/auth/manual` also rejects any caller whose resolved client IP is not loopback unless the unsafe override is set. Mutually exclusive with `IDENTRAIL_WORKOS_CLIENT_ID`; setting both refuses to start. | Auth foundation |
 | `IDENTRAIL_AUTH_MANUAL_MODE_ALLOW_UNSAFE` | `false` | Boolean. **Unsafe.** Overrides the loopback base-URL and bind-address requirements above so `IDENTRAIL_AUTH_MANUAL_MODE=true` can run when reachability is constrained another way (for example a container that publishes its port only on the host loopback). Intended only for a deliberately throwaway, non-production test deployment. Never set this in production or on an internet-accessible host. | Auth foundation |
 
-Production example values:
+Production example values (Identrail Cloud, where WorkOS callbacks terminate
+at the API service):
 
 ```
-IDENTRAIL_PUBLIC_BASE_URL=https://app.identrail.com
+IDENTRAIL_PUBLIC_BASE_URL=https://api.identrail.com
 IDENTRAIL_SESSION_KEY=<64 hex chars from openssl rand -hex 32>
 ```
+
+`IDENTRAIL_PUBLIC_BASE_URL` is the API callback origin, distinct from the web
+app origins (e.g. `https://app.identrail.com`, configured separately via
+`IDENTRAIL_CORS_ALLOWED_ORIGINS` / `VITE_IDENTRAIL_API_URL`). Because the
+server builds the callback as `<IDENTRAIL_PUBLIC_BASE_URL>/auth/callback`,
+the redirect URI registered in the WorkOS dashboard must exactly match —
+for the example above, `https://api.identrail.com/auth/callback`. A
+self-hosted single-service deployment that serves the API and app from one
+origin uses that shared origin here. This matches the production walkthrough
+in [`production-api-readiness.md`](./production-api-readiness.md).
 
 ## WorkOS Hosted Login
 


### PR DESCRIPTION
Closes #1205

## What changed
`docs/auth/env-vars-reference.md` showed the production example as
`IDENTRAIL_PUBLIC_BASE_URL=https://app.identrail.com` (the **web app**
origin), while `docs/auth/production-api-readiness.md` correctly uses
`https://api.identrail.com`. The server constructs the WorkOS callback as
`<IDENTRAIL_PUBLIC_BASE_URL>/auth/callback`
(`internal/api/auth_routes.go` `workOSCallbackURL`), so the app-origin
example could lead operators to register the wrong WorkOS redirect URI and
break login.

This is a docs-only correction (no code/behavior change):

- The `IDENTRAIL_PUBLIC_BASE_URL` table cell now states it is the
  externally reachable **API origin** the auth provider redirects back to,
  that the callback is `<base>/auth/callback`, and that for Identrail Cloud
  it is `https://api.identrail.com` — **not** the web app origin
  `https://app.identrail.com`. Cross-links `production-api-readiness.md`.
- The production example now uses `https://api.identrail.com`.
- Added a paragraph distinguishing the API callback origin from web app
  origins, stating the WorkOS dashboard redirect URI must exactly match
  `https://api.identrail.com/auth/callback`, and noting a single-origin
  self-hosted deployment uses its shared origin.
- Reconciled the doc's own "domain references" rule so the illustrative
  contrast between API and app origins doesn't violate it.
- `CHANGELOG.md` updated (operator-facing docs correction).

A potential config rename/split (`IDENTRAIL_PUBLIC_API_BASE_URL` /
`IDENTRAIL_WEB_APP_ORIGINS`) is explicitly **out of scope** here and left to
a separate tracked change, per the issue's acceptance criteria.

## Why
Final issue (step 6) in the auth-hardening sequence; #1203 (PR #1225) is
merged, satisfying the ordering. Ambiguity here misroutes WorkOS callbacks
in production.

## Validation performed
- `make api-example-contract-check` — passes
- `go test ./internal/config` — passes (incl.
  `TestAuditFingerprintSecretIsDocumented`)
- Manually verified all `docs/auth/*` now agree on the callback host
  (`api.identrail.com`) and path (`/auth/callback`); `grep` confirms
  `env-vars-reference.md` and `production-api-readiness.md` are the only
  files with a non-local `IDENTRAIL_PUBLIC_BASE_URL=` example and both now
  use the API origin.

## AI-Assisted and AI-Generated Code Policy
- AI-assisted: yes
- Tools used: Claude Code
- Where used: `docs/auth/env-vars-reference.md`, `CHANGELOG.md`
- Human verification performed: cross-doc consistency grep, contract check,
  config package tests, and manual review against
  `workOSCallbackURL` in `internal/api/auth_routes.go`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified that `IDENTRAIL_PUBLIC_BASE_URL` is the externally reachable API origin used for auth callbacks, not the web app origin. Examples now use `https://api.identrail.com`, the WorkOS redirect must match `<base>/auth/callback`, and `VITE_IDENTRAIL_API_URL` is a frontend build pointer to the API origin (web origins are authorized only via `IDENTRAIL_CORS_ALLOWED_ORIGINS`). Closes #1205.

- **Bug Fixes**
  - Updated `docs/auth/env-vars-reference.md` to clearly distinguish API vs app origins, cross-link `production-api-readiness.md`, and correct the `VITE_IDENTRAIL_API_URL` vs `IDENTRAIL_CORS_ALLOWED_ORIGINS` guidance.
  - Updated `CHANGELOG.md`. Docs-only; no behavior change.

<sup>Written for commit 54c9a51682a0f1d415198bdcdcbf43597b157470. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1226?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

