### PR TITLE
Wire GitHub App tokens into private repo scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## Unreleased
+- Added GitHub App connector-backed private repository scans. Repo scan queue
+  rows now store only non-secret source metadata, while API, scheduled, and
+  webhook-triggered scans resolve the selected project connection and workers
+  mint short-lived installation tokens at execution time. Clone credentials are
+  passed through `GIT_ASKPASS` and redacted from persisted scan failures.
 - Corrected the `IDENTRAIL_PUBLIC_BASE_URL` documentation so the auth
   env-var reference and the production-readiness guide agree: it is the
   externally reachable API callback origin (`https://api.identrail.com` for

--- a/docs/auth/github-connector.md
+++ b/docs/auth/github-connector.md
@@ -75,6 +75,26 @@ For the AWS-hosted API workflow, use the first-class repository variables
 `API_REPO_SCAN_ENABLED=true` and `API_REPO_SCAN_ALLOWLIST=<owner/repo>` instead
 of hiding the same runtime values inside `API_EXTRA_ENVIRONMENT_JSON`.
 
+## Private Repository Scans
+
+GitHub App connections can now back private repository exposure scans. When a
+repo scan request includes `project_id`, Identrail verifies that the scoped
+project has an active GitHub App connection, that the requested repository is in
+the selected repository list, and that the normal repo-scan allowlist still
+permits the target.
+
+Queued scans store only non-secret source metadata: provider, project id,
+connector id, and installation id. The API and worker never store the raw
+installation token in `repo_scans`, `repo_findings`, logs, traces, errors, or
+API responses. The worker mints a short-lived installation token immediately
+before cloning and passes it to git through an askpass helper so the token does
+not appear in clone URLs or command-line arguments.
+
+Scheduled policy scans and GitHub webhook-triggered scans automatically attach
+the project/connector source context when they enqueue selected repositories,
+so private repositories use the same short-lived GitHub App path as manually
+queued connector-backed scans.
+
 ## Rollback
 
 Set `IDENTRAIL_FEATURE_CONNECTOR_GITHUB_V2=false` to return the standard GitHub connector API to 404. Set `VITE_FEATURE_CONNECTOR_GITHUB_V2=false` to hide the frontend path.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -79,6 +79,11 @@ Current sequence in `migrations/`:
 26. `000023_onboarding_state` - onboarding wizard server-owned state
 27. `000024_native_sso_scim_scaffold` - native SAML and SCIM 2.0 schema scaffolding: extends `identity_connections` with native SAML fields + a SCIM bearer token hash, adds a composite-FK-backed `scim_provisioning_events` audit table, and reuses the existing `user_identities` table for SCIM-assigned external ids (no new column on `users`)
 28. `000025_saml_relay_states_and_session_saml` - persists in-flight SP-initiated SAML AuthnRequest state across API instances and widens `sessions.auth_method` to accept `'saml'`
+29. `000026_finding_triage_resolved_at` - stores finding triage resolution timestamps for MTTR/reporting queries
+30. `000027_oauth_transactions` - persists browser-bound OAuth transaction state across API instances
+31. `000028_webhook_events` - durable provider webhook idempotency ledger
+32. `000029_webhook_events_processing_status` - processing-state metadata for webhook event replay safety
+33. `000030_repo_scan_source_metadata` - non-secret repo scan source metadata for connector-backed private repository scans
 
 Notes:
 - Each migration has matching `.up.sql` and `.down.sql` files.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -5924,6 +5924,12 @@ components:
       required: [repository]
       properties:
         repository: { type: string }
+        project_id:
+          type: string
+          description: Optional project id for a GitHub App connector-backed scan. When provided, the repository must be selected on that project's GitHub App installation.
+        connector_id:
+          type: string
+          description: Optional connector id for connector-backed scans. Defaults to the project's standard GitHub App connector.
         history_limit:
           type: integer
           minimum: 1

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Detect leaked secrets and high-signal misconfigurations in public repository history, without storing raw secret values.
+Detect leaked secrets and high-signal misconfigurations in authorized repository history, without storing raw secret values.
 
 ## Command
 
@@ -39,6 +39,25 @@ API/worker repository target forms:
 - `git@...`
 
 Local filesystem repository paths are CLI-only and are not valid API/worker targets.
+
+For private GitHub repositories, pass the owning project id for a connected
+GitHub App installation:
+
+```bash
+curl -X POST http://localhost:8080/v1/repo-scans \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: <write-enabled-key>" \
+  -d '{
+    "repository": "owner/private-repo",
+    "project_id": "project-1",
+    "history_limit": 500,
+    "max_findings": 200
+  }'
+```
+
+Connector-backed scans require the repository to be selected on the project's
+GitHub App connection and still honor `IDENTRAIL_REPO_SCAN_ALLOWLIST`, queue
+capacity, and per-repository concurrency controls.
 
 Read APIs:
 
@@ -87,6 +106,11 @@ Read APIs:
 - Findings are deterministic and deduplicated by stable IDs/fingerprints.
 - Output is capped by `--max-findings` to prevent runaway payloads.
 - Repo scan metadata/findings are persisted in dedicated storage (`repo_scans`, `repo_findings`) to avoid changing existing cloud scan APIs.
+- GitHub App private-repo scans persist only non-secret connector context
+  (`source_provider`, project id, connector id, installation id). The worker
+  mints the short-lived installation token at execution time and passes it to
+  git through `GIT_ASKPASS`, not through clone URLs, process arguments,
+  findings, scan rows, logs, or API responses.
 - Snapshot-based repo misconfiguration findings now persist the resolved HEAD commit SHA on new scans so GitHub links stay pinned to the scanned revision.
 
 ## Useful Flags
@@ -125,4 +149,8 @@ Read APIs:
 
 - Focused on high-signal patterns, not exhaustive secret taxonomy.
 - Full-history scanning on very large repositories can be expensive; tune `--history-limit`.
-- Current version supports public-repository remote targets in API/worker flows and public/local clone targets in CLI flows (no private-repo auth flow yet).
+- Private remote scans are supported for GitHub App connectors. Other private
+  git hosts still need an explicit connector-backed credential flow before API
+  or worker scans can authenticate to them.
+- CLI scans support public remotes and local repository paths, but do not use
+  saved Identrail connector credentials.

--- a/internal/api/enterprise_report_routes_test.go
+++ b/internal/api/enterprise_report_routes_test.go
@@ -51,7 +51,7 @@ func seedExecReportFinding(t *testing.T, store db.Store, scope db.Scope, scanID,
 func seedExecReportRepoFinding(t *testing.T, store db.Store, scope db.Scope, repo, id string, sev domain.FindingSeverity, typ domain.FindingType, createdAt time.Time, resolvedAt *time.Time) {
 	t.Helper()
 	ctx := db.WithScope(context.Background(), scope)
-	repoScan, err := store.CreateRepoScan(ctx, repo, createdAt)
+	repoScan, err := store.CreateRepoScan(ctx, repo, db.RepoScanSource{}, createdAt)
 	if err != nil {
 		t.Fatalf("create repo scan for %s: %v", id, err)
 	}

--- a/internal/api/github_connect.go
+++ b/internal/api/github_connect.go
@@ -990,7 +990,11 @@ func (s *Service) processGitHubWebhookConnections(ctx context.Context, span trac
 		}
 
 		scopedCtx := db.WithScope(ctx, db.Scope{TenantID: connection.TenantID, WorkspaceID: connection.WorkspaceID})
-		_, err := s.EnqueueRepoScan(scopedCtx, RepoScanRequest{Repository: repository})
+		_, err := s.EnqueueRepoScan(scopedCtx, RepoScanRequest{
+			Repository:  repository,
+			ProjectID:   connection.ProjectID,
+			ConnectorID: firstNonEmptyString(connection.ConnectorID, githubConnectorID),
+		})
 		if err != nil {
 			if errors.Is(err, ErrRepoScanQueueFull) {
 				result.SkippedScans++
@@ -1775,8 +1779,9 @@ func gitHubConnectionStatus(connection githubProjectConnection, manager *secrets
 		rotationDueAt := rotatedAt.Add(githubWebhookSecretRotationWindow)
 		rotationDueAtPtr = &rotationDueAt
 	}
+	provider := firstNonEmptyString(strings.TrimSpace(connection.Provider), "github_app")
 	status := GitHubConnectionStatus{
-		Provider:                      "github_app",
+		Provider:                      provider,
 		Connected:                     true,
 		ConnectorID:                   firstNonEmptyString(connection.ConnectorID, githubConnectorID),
 		DisplayName:                   firstNonEmptyString(connection.DisplayName, githubConnectorDisplayName),
@@ -1937,9 +1942,20 @@ func githubWebhookTriggersScan(eventType string) bool {
 }
 
 func repositorySelected(selected []string, repository string) bool {
-	normalizedTarget := normalizeGitHubRepository(repository)
+	normalizedTarget := normalizeGitHubRepositoryPath(repository)
+	if normalizedTarget == "" {
+		normalizedTarget = normalizeGitHubRepository(repository)
+	} else {
+		normalizedTarget = strings.ToLower(normalizedTarget)
+	}
 	for _, candidate := range selected {
-		if normalizeGitHubRepository(candidate) == normalizedTarget {
+		normalizedCandidate := normalizeGitHubRepositoryPath(candidate)
+		if normalizedCandidate == "" {
+			normalizedCandidate = normalizeGitHubRepository(candidate)
+		} else {
+			normalizedCandidate = strings.ToLower(normalizedCandidate)
+		}
+		if normalizedCandidate == normalizedTarget {
 			return true
 		}
 	}

--- a/internal/api/github_connect_test.go
+++ b/internal/api/github_connect_test.go
@@ -587,12 +587,12 @@ type failOnceQueuedRepoStore struct {
 	failuresRemaining int
 }
 
-func (s *failOnceQueuedRepoStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (db.RepoScanRecord, error) {
+func (s *failOnceQueuedRepoStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, source db.RepoScanSource, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (db.RepoScanRecord, error) {
 	if s.failuresRemaining > 0 {
 		s.failuresRemaining--
 		return db.RepoScanRecord{}, errors.New("simulated enqueue failure")
 	}
-	return s.MemoryStore.CreateQueuedRepoScanWithinLimit(ctx, repository, historyLimit, maxFindings, queuedAt, maxPending)
+	return s.MemoryStore.CreateQueuedRepoScanWithinLimit(ctx, repository, source, historyLimit, maxFindings, queuedAt, maxPending)
 }
 
 type failOnceQueueFullRepoStore struct {
@@ -600,12 +600,12 @@ type failOnceQueueFullRepoStore struct {
 	failuresRemaining int
 }
 
-func (s *failOnceQueueFullRepoStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (db.RepoScanRecord, error) {
+func (s *failOnceQueueFullRepoStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, source db.RepoScanSource, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (db.RepoScanRecord, error) {
 	if s.failuresRemaining > 0 {
 		s.failuresRemaining--
 		return db.RepoScanRecord{}, db.ErrQueueLimitReached
 	}
-	return s.MemoryStore.CreateQueuedRepoScanWithinLimit(ctx, repository, historyLimit, maxFindings, queuedAt, maxPending)
+	return s.MemoryStore.CreateQueuedRepoScanWithinLimit(ctx, repository, source, historyLimit, maxFindings, queuedAt, maxPending)
 }
 
 func TestHandleGitHubWebhookRetryDeliveryAfterTransientEnqueueFailure(t *testing.T) {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -829,7 +829,7 @@ func TestRouterRepoFindingsCanBeFilteredByTriageState(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 5, 13, 11, 10, 0, 0, time.UTC)
 
-	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", now)
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, now)
 	if err != nil {
 		t.Fatalf("create repo scan: %v", err)
 	}
@@ -922,7 +922,7 @@ func TestRouterRepoFindingsSeveritySortUsesFullResultSet(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 5, 13, 11, 10, 0, 0, time.UTC)
 
-	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", now)
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, now)
 	if err != nil {
 		t.Fatalf("create repo scan: %v", err)
 	}

--- a/internal/api/scan_policy_scheduler.go
+++ b/internal/api/scan_policy_scheduler.go
@@ -134,11 +134,17 @@ func (s *Service) enqueueDueScanPolicy(ctx context.Context, store scanPolicySche
 		if processed >= maxConcurrent {
 			break
 		}
-		_, err := s.EnqueueRepoScan(scopedCtx, RepoScanRequest{
+
+		request := RepoScanRequest{
 			Repository:   repository,
 			HistoryLimit: policy.HistoryLimit,
 			MaxFindings:  policy.MaxFindings,
-		})
+		}
+		if strings.EqualFold(status.Provider, "github_app") {
+			request.ProjectID = policy.ProjectID
+			request.ConnectorID = firstNonEmptyString(status.ConnectorID, githubConnectorID)
+		}
+		_, err := s.EnqueueRepoScan(scopedCtx, request)
 		if err != nil {
 			if isExpectedScheduledRepoSkip(err) {
 				result.SkippedScans++

--- a/internal/api/scan_policy_scheduler_test.go
+++ b/internal/api/scan_policy_scheduler_test.go
@@ -283,6 +283,81 @@ func TestEnqueueDueScanPolicyCountsQueueFullTowardConcurrency(t *testing.T) {
 	}
 }
 
+func TestEnqueueDueScanPolicyAttachesConnectorMetadataForGitHubApp(t *testing.T) {
+	now := time.Date(2026, 5, 12, 12, 5, 0, 0, time.UTC)
+	svc, store, ctx := newScanPolicySchedulerTestService(t, now, []string{"owner/repo-a"})
+	connection := svc.githubConnections[githubConnectionKey("default", "default", "project-1")]
+	connection.Provider = "github_app"
+	connection.ConnectorID = "connector-123"
+	connection.InstallationID = 101
+	connection.SelectedRepositories = []string{"owner/repo-a"}
+	svc.githubConnections[githubConnectionKey("default", "default", "project-1")] = connection
+
+	upsertTestScanPolicy(t, store, ctx, now.Add(-time.Hour), 1)
+
+	result, err := svc.EnqueueDueScanPolicies(ctx)
+	if err != nil {
+		t.Fatalf("EnqueueDueScanPolicies returned error: %v", err)
+	}
+	if result.QueuedScans != 1 {
+		t.Fatalf("queued scans = %d, want 1", result.QueuedScans)
+	}
+
+	scans, err := store.ListRepoScans(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListRepoScans returned error: %v", err)
+	}
+	if len(scans) != 1 {
+		t.Fatalf("repo scans = %d, want 1", len(scans))
+	}
+	if scans[0].Source.Empty() {
+		t.Fatal("expected scan source metadata for github_app connection")
+	}
+	if scans[0].Source.Provider != "github_app" {
+		t.Fatalf("scan source provider = %q, want github_app", scans[0].Source.Provider)
+	}
+	if scans[0].Source.ProjectID != "project-1" {
+		t.Fatalf("scan source project id = %q, want project-1", scans[0].Source.ProjectID)
+	}
+	if scans[0].Source.ConnectorID != "connector-123" {
+		t.Fatalf("scan source connector id = %q, want connector-123", scans[0].Source.ConnectorID)
+	}
+	if scans[0].Source.InstallationID != 101 {
+		t.Fatalf("scan source installation id = %d, want 101", scans[0].Source.InstallationID)
+	}
+}
+
+func TestEnqueueDueScanPolicyDoesNotAttachConnectorMetadataForPAT(t *testing.T) {
+	now := time.Date(2026, 5, 12, 12, 5, 0, 0, time.UTC)
+	svc, store, ctx := newScanPolicySchedulerTestService(t, now, []string{"owner/repo-a"})
+	connection := svc.githubConnections[githubConnectionKey("default", "default", "project-1")]
+	connection.Provider = "github_pat"
+	connection.ConnectorID = "pat-connector"
+	connection.SelectedRepositories = []string{"owner/repo-a"}
+	svc.githubConnections[githubConnectionKey("default", "default", "project-1")] = connection
+
+	upsertTestScanPolicy(t, store, ctx, now.Add(-time.Hour), 1)
+
+	result, err := svc.EnqueueDueScanPolicies(ctx)
+	if err != nil {
+		t.Fatalf("EnqueueDueScanPolicies returned error: %v", err)
+	}
+	if result.QueuedScans != 1 {
+		t.Fatalf("queued scans = %d, want 1", result.QueuedScans)
+	}
+
+	scans, err := store.ListRepoScans(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListRepoScans returned error: %v", err)
+	}
+	if len(scans) != 1 {
+		t.Fatalf("repo scans = %d, want 1", len(scans))
+	}
+	if !scans[0].Source.Empty() {
+		t.Fatalf("unexpected scan source metadata for PAT connection: %+v", scans[0].Source)
+	}
+}
+
 func TestDueScanPolicyTickHandlesNoHistoryAndInvalidCron(t *testing.T) {
 	now := time.Date(2026, 5, 12, 12, 5, 0, 0, time.UTC)
 	policy := db.TenancyScanPolicy{

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/identrail/identrail/internal/app"
 	"github.com/identrail/identrail/internal/audit"
+	githubconnector "github.com/identrail/identrail/internal/connectors/github"
 	"github.com/identrail/identrail/internal/db"
 	"github.com/identrail/identrail/internal/domain"
 	"github.com/identrail/identrail/internal/findings/standards"
@@ -82,6 +83,14 @@ type RepoScanExecutor interface {
 // RepoScannerFactory creates a repository scanner with bounded scan parameters.
 type RepoScannerFactory func(historyLimit int, maxFindings int) RepoScanExecutor
 
+// AuthenticatedRepoScannerFactory creates a repository scanner with a short-lived clone credential.
+type AuthenticatedRepoScannerFactory func(historyLimit int, maxFindings int, credential repoexposure.HTTPSCloneCredential) RepoScanExecutor
+
+// GitHubInstallationTokenMinter mints short-lived GitHub App installation tokens.
+type GitHubInstallationTokenMinter interface {
+	Mint(ctx context.Context, installationID int64) (githubconnector.InstallationToken, error)
+}
+
 // AWSScannerFactory creates a scanner bound to one persisted AWS connector.
 type AWSScannerFactory func(ctx context.Context, connection AWSConnectionStatus) (ScannerRunner, error)
 
@@ -107,37 +116,39 @@ type Service struct {
 	ReadinessCheck func(context.Context) error
 	Metrics        *telemetry.Metrics
 	// Repo scan controls are intentionally separate from cloud identity scan flow.
-	RepoScanEnabled              bool
-	RepoScanDefaultHistoryLimit  int
-	RepoScanDefaultMaxFindings   int
-	RepoScanMaxHistoryLimit      int
-	RepoScanMaxFindingsLimit     int
-	RepoScanAllowedTargets       []string
-	ScanQueueMaxPending          int
-	RepoQueueMaxPending          int
-	RepoScannerFactory           RepoScannerFactory
-	ConnectorSecretManager       *secretstore.Manager
-	KubernetesPreflightFactory   KubernetesConnectorPreflightFactory
-	AWSConnectorValidator        AWSConnectorValidator
-	AWSScannerFactory            AWSScannerFactory
-	AWSCloudFormationTemplateURL string
-	AWSAccountID                 string
-	WorkflowRouter               *workflow.Router
-	GitHubAppID                  int64
-	GitHubAppName                string
-	GitHubAppPrivateKey          string
-	GitHubAppWebhookSecret       string
-	GitHubPATValidator           GitHubPATValidator
-	GitHubRepositoryLister       GitHubRepositoryLister
-	GitHubWebhookReplayWindow    time.Duration
-	GitHubWebhookBurstWindow     time.Duration
-	githubConnectMu              sync.RWMutex
-	githubConnections            map[string]githubProjectConnection
-	githubConnectStates          map[string]githubConnectState
-	githubWebhookSeen            map[string]time.Time
-	githubWebhookLastQueued      map[string]time.Time
-	kubernetesConnectMu          sync.RWMutex
-	kubernetesConnections        map[string]kubernetesProjectConnection
+	RepoScanEnabled                 bool
+	RepoScanDefaultHistoryLimit     int
+	RepoScanDefaultMaxFindings      int
+	RepoScanMaxHistoryLimit         int
+	RepoScanMaxFindingsLimit        int
+	RepoScanAllowedTargets          []string
+	ScanQueueMaxPending             int
+	RepoQueueMaxPending             int
+	RepoScannerFactory              RepoScannerFactory
+	AuthenticatedRepoScannerFactory AuthenticatedRepoScannerFactory
+	ConnectorSecretManager          *secretstore.Manager
+	KubernetesPreflightFactory      KubernetesConnectorPreflightFactory
+	AWSConnectorValidator           AWSConnectorValidator
+	AWSScannerFactory               AWSScannerFactory
+	AWSCloudFormationTemplateURL    string
+	AWSAccountID                    string
+	WorkflowRouter                  *workflow.Router
+	GitHubAppID                     int64
+	GitHubAppName                   string
+	GitHubAppPrivateKey             string
+	GitHubAppWebhookSecret          string
+	GitHubPATValidator              GitHubPATValidator
+	GitHubRepositoryLister          GitHubRepositoryLister
+	GitHubInstallationTokenMinter   GitHubInstallationTokenMinter
+	GitHubWebhookReplayWindow       time.Duration
+	GitHubWebhookBurstWindow        time.Duration
+	githubConnectMu                 sync.RWMutex
+	githubConnections               map[string]githubProjectConnection
+	githubConnectStates             map[string]githubConnectState
+	githubWebhookSeen               map[string]time.Time
+	githubWebhookLastQueued         map[string]time.Time
+	kubernetesConnectMu             sync.RWMutex
+	kubernetesConnections           map[string]kubernetesProjectConnection
 }
 
 // CheckReadiness validates critical runtime dependencies for readiness checks.
@@ -176,6 +187,8 @@ type RunRepoScanResult struct {
 // RepoScanRequest captures one repository exposure scan request.
 type RepoScanRequest struct {
 	Repository   string `json:"repository"`
+	ProjectID    string `json:"project_id,omitempty"`
+	ConnectorID  string `json:"connector_id,omitempty"`
 	HistoryLimit int    `json:"history_limit"`
 	MaxFindings  int    `json:"max_findings"`
 }
@@ -367,6 +380,14 @@ func NewService(store db.Store, scanner ScannerRunner, provider string) *Service
 				nil,
 				repoexposure.WithHistoryLimit(historyLimit),
 				repoexposure.WithMaxFindings(maxFindings),
+			)
+		},
+		AuthenticatedRepoScannerFactory: func(historyLimit int, maxFindings int, credential repoexposure.HTTPSCloneCredential) RepoScanExecutor {
+			return repoexposure.NewScanner(
+				nil,
+				repoexposure.WithHistoryLimit(historyLimit),
+				repoexposure.WithMaxFindings(maxFindings),
+				repoexposure.WithHTTPSCloneCredential(credential),
 			)
 		},
 	}
@@ -1011,7 +1032,7 @@ func (s *Service) RunRepoScan(ctx context.Context, request RepoScanRequest) (rep
 func (s *Service) EnqueueRepoScan(ctx context.Context, request RepoScanRequest) (db.RepoScanRecord, error) {
 	ctx = s.scopeContext(ctx)
 	ctx = withQueueTraceContext(ctx)
-	target, historyLimit, maxFindings, err := s.validateRepoScanRequest(ctx, request)
+	target, source, historyLimit, maxFindings, err := s.validateRepoScanRequest(ctx, request)
 	if err != nil {
 		return db.RepoScanRecord{}, err
 	}
@@ -1019,7 +1040,7 @@ func (s *Service) EnqueueRepoScan(ctx context.Context, request RepoScanRequest) 
 	if maxPending <= 0 {
 		maxPending = defaultRepoQueueMaxPending
 	}
-	record, err := s.Store.CreateQueuedRepoScanWithinLimit(ctx, target, historyLimit, maxFindings, s.Now().UTC(), maxPending)
+	record, err := s.Store.CreateQueuedRepoScanWithinLimit(ctx, target, source, historyLimit, maxFindings, s.Now().UTC(), maxPending)
 	if err != nil {
 		switch {
 		case errors.Is(err, db.ErrPendingRepoScanExists):
@@ -1089,7 +1110,7 @@ func (s *Service) ProcessNextQueuedRepoScan(ctx context.Context) (bool, error) {
 // RunRepoScanPersisted runs one repository scan and persists repo scan metadata + findings.
 func (s *Service) RunRepoScanPersisted(ctx context.Context, request RepoScanRequest) (RunRepoScanResult, error) {
 	ctx = s.scopeContext(ctx)
-	target, historyLimit, maxFindings, err := s.validateRepoScanRequest(ctx, request)
+	target, source, historyLimit, maxFindings, err := s.validateRepoScanRequest(ctx, request)
 	if err != nil {
 		return RunRepoScanResult{}, err
 	}
@@ -1100,41 +1121,110 @@ func (s *Service) RunRepoScanPersisted(ctx context.Context, request RepoScanRequ
 		}
 		defer release(context.Background())
 	}
-	record, err := s.Store.CreateRepoScan(ctx, target, s.Now().UTC())
+	record, err := s.Store.CreateRepoScan(ctx, target, source, s.Now().UTC())
 	if err != nil {
 		return RunRepoScanResult{}, fmt.Errorf("create repo scan: %w", err)
 	}
 	return s.runRepoScanWithRecord(ctx, record, historyLimit, maxFindings)
 }
 
-func (s *Service) validateRepoScanRequest(ctx context.Context, request RepoScanRequest) (string, int, int, error) {
+func (s *Service) validateRepoScanRequest(ctx context.Context, request RepoScanRequest) (string, db.RepoScanSource, int, int, error) {
 	if !s.RepoScanEnabled {
-		return "", 0, 0, ErrRepoScanDisabled
+		return "", db.RepoScanSource{}, 0, 0, ErrRepoScanDisabled
 	}
 	target := strings.TrimSpace(request.Repository)
 	if target == "" {
-		return "", 0, 0, ErrInvalidRepoScanRequest
+		return "", db.RepoScanSource{}, 0, 0, ErrInvalidRepoScanRequest
 	}
 	if repoTargetContainsURLCredentials(target) {
-		return "", 0, 0, repoScanRequestValidationError{"repository target must not include credentials in URL userinfo"}
+		return "", db.RepoScanSource{}, 0, 0, repoScanRequestValidationError{"repository target must not include credentials in URL userinfo"}
 	}
 	if repoexposure.IsLocalRepositoryTarget(target) {
 		s.recordServiceAuthzDenial(ctx, "repo_scans.run", "repo_scan_target", target)
-		return "", 0, 0, ErrRepoTargetNotAllowed
-	}
-	if !repoTargetAllowed(target, s.RepoScanAllowedTargets) {
-		s.recordServiceAuthzDenial(ctx, "repo_scans.run", "repo_scan_target", target)
-		return "", 0, 0, ErrRepoTargetNotAllowed
+		return "", db.RepoScanSource{}, 0, 0, ErrRepoTargetNotAllowed
 	}
 	historyLimit, err := sanitizeRepoScanLimit(request.HistoryLimit, s.RepoScanDefaultHistoryLimit, s.RepoScanMaxHistoryLimit)
 	if err != nil {
-		return "", 0, 0, ErrInvalidRepoScanRequest
+		return "", db.RepoScanSource{}, 0, 0, ErrInvalidRepoScanRequest
 	}
 	maxFindings, err := sanitizeRepoScanLimit(request.MaxFindings, s.RepoScanDefaultMaxFindings, s.RepoScanMaxFindingsLimit)
 	if err != nil {
-		return "", 0, 0, ErrInvalidRepoScanRequest
+		return "", db.RepoScanSource{}, 0, 0, ErrInvalidRepoScanRequest
 	}
-	return target, historyLimit, maxFindings, nil
+
+	if repoScanRequestUsesConnector(request) {
+		normalizedTarget := normalizeGitHubRepositoryPath(target)
+		if normalizedTarget == "" {
+			return "", db.RepoScanSource{}, 0, 0, ErrInvalidRepoScanRequest
+		}
+		target = normalizeGitHubRepository(normalizedTarget)
+
+		source, err := s.resolveRepoScanSource(ctx, target, request)
+		if err != nil {
+			return "", db.RepoScanSource{}, 0, 0, err
+		}
+
+		if !repoTargetAllowed(target, s.RepoScanAllowedTargets) {
+			s.recordServiceAuthzDenial(ctx, "repo_scans.run", "repo_scan_target", target)
+			return "", db.RepoScanSource{}, 0, 0, ErrRepoTargetNotAllowed
+		}
+		return target, source, historyLimit, maxFindings, nil
+	}
+	if !repoTargetAllowed(target, s.RepoScanAllowedTargets) {
+		s.recordServiceAuthzDenial(ctx, "repo_scans.run", "repo_scan_target", target)
+		return "", db.RepoScanSource{}, 0, 0, ErrRepoTargetNotAllowed
+	}
+	return target, db.RepoScanSource{}, historyLimit, maxFindings, nil
+}
+
+func repoScanRequestUsesConnector(request RepoScanRequest) bool {
+	return strings.TrimSpace(request.ProjectID) != "" || strings.TrimSpace(request.ConnectorID) != ""
+}
+
+func (s *Service) resolveRepoScanSource(ctx context.Context, target string, request RepoScanRequest) (db.RepoScanSource, error) {
+	projectID := strings.TrimSpace(request.ProjectID)
+	connectorID := strings.TrimSpace(request.ConnectorID)
+	if projectID == "" && connectorID == "" {
+		return db.RepoScanSource{}, nil
+	}
+	if projectID == "" {
+		return db.RepoScanSource{}, ErrInvalidRepoScanRequest
+	}
+
+	project, _, err := s.requireScopedProject(ctx, "", projectID)
+	if err != nil {
+		if errors.Is(err, ErrInvalidGitHubConnectionRequest) {
+			return db.RepoScanSource{}, ErrInvalidRepoScanRequest
+		}
+		if errors.Is(err, db.ErrNotFound) {
+			return db.RepoScanSource{}, ErrInvalidRepoScanRequest
+		}
+		return db.RepoScanSource{}, err
+	}
+	status, err := s.GetGitHubConnection(ctx, project.WorkspaceID, project.ProjectID)
+	if err != nil {
+		if errors.Is(err, ErrInvalidGitHubConnectionRequest) || errors.Is(err, ErrGitHubConnectionNotFound) || errors.Is(err, db.ErrNotFound) {
+			return db.RepoScanSource{}, ErrRepoTargetNotAllowed
+		}
+		return db.RepoScanSource{}, err
+	}
+	effectiveConnectorID := firstNonEmptyString(status.ConnectorID, githubConnectorID)
+	if connectorID != "" && connectorID != effectiveConnectorID {
+		return db.RepoScanSource{}, ErrInvalidRepoScanRequest
+	}
+	if !status.Connected || !strings.EqualFold(status.Provider, "github_app") || status.InstallationID <= 0 {
+		return db.RepoScanSource{}, ErrRepoTargetNotAllowed
+	}
+	if !repositorySelected(status.SelectedRepositories, target) {
+		s.recordServiceAuthzDenial(ctx, "repo_scans.run", "repo_scan_target", target)
+		return db.RepoScanSource{}, ErrRepoTargetNotAllowed
+	}
+	return db.RepoScanSource{
+		Provider:       "github_app",
+		ProjectID:      project.ProjectID,
+		ConnectorID:    effectiveConnectorID,
+		InstallationID: status.InstallationID,
+	}.Normalize(), nil
 }
 
 // repoScanRequestValidationError keeps the user-facing message while preserving
@@ -1194,15 +1284,18 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, ErrInvalidRepoScanRequest.Error())
 		return RunRepoScanResult{}, ErrInvalidRepoScanRequest
 	}
-	if s.RepoScannerFactory == nil {
-		s.recordRepoScanExecutionFailure()
-		return RunRepoScanResult{}, fmt.Errorf("repo scanner factory is not configured")
-	}
-	result, err := s.RepoScannerFactory(normalizedHistory, normalizedMaxFindings).ScanRepository(ctx, target)
+	executor, scanSecrets, err := s.repoScanExecutorForRecord(ctx, record, normalizedHistory, normalizedMaxFindings)
 	if err != nil {
 		s.recordRepoScanExecutionFailure()
 		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, err.Error())
 		return RunRepoScanResult{}, err
+	}
+	result, err := executor.ScanRepository(ctx, target)
+	if err != nil {
+		safeErr := sanitizeRepoScanError(err, scanSecrets...)
+		s.recordRepoScanExecutionFailure()
+		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, safeErr.Error())
+		return RunRepoScanResult{}, safeErr
 	}
 	result.Findings = enrichFindingsWithRepoContext(result.Findings, result.Repository, record.Repository)
 	if err := s.Store.UpsertRepoFindings(ctx, record.ID, result.Findings); err != nil {
@@ -1241,6 +1334,91 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 		}
 	}
 	return RunRepoScanResult{RepoScan: record, Result: result}, nil
+}
+
+func (s *Service) repoScanExecutorForRecord(ctx context.Context, record db.RepoScanRecord, historyLimit int, maxFindings int) (RepoScanExecutor, []string, error) {
+	source := record.Source.Normalize()
+	if source.Empty() {
+		if s.RepoScannerFactory == nil {
+			return nil, nil, fmt.Errorf("repo scanner factory is not configured")
+		}
+		return s.RepoScannerFactory(historyLimit, maxFindings), nil, nil
+	}
+	switch source.Provider {
+	case "github_app":
+		if s.AuthenticatedRepoScannerFactory == nil {
+			return nil, nil, fmt.Errorf("authenticated repo scanner factory is not configured")
+		}
+		credential, err := s.githubAppRepoScanCredential(ctx, record)
+		if err != nil {
+			return nil, nil, err
+		}
+		return s.AuthenticatedRepoScannerFactory(historyLimit, maxFindings, credential), []string{credential.Password}, nil
+	default:
+		return nil, nil, ErrInvalidRepoScanRequest
+	}
+}
+
+func (s *Service) githubAppRepoScanCredential(ctx context.Context, record db.RepoScanRecord) (repoexposure.HTTPSCloneCredential, error) {
+	source := record.Source.Normalize()
+	if source.ProjectID == "" || source.InstallationID <= 0 {
+		return repoexposure.HTTPSCloneCredential{}, ErrInvalidRepoScanRequest
+	}
+	status, err := s.GetGitHubConnection(ctx, record.WorkspaceID, source.ProjectID)
+	if err != nil {
+		if errors.Is(err, ErrInvalidGitHubConnectionRequest) || errors.Is(err, ErrGitHubConnectionNotFound) || errors.Is(err, db.ErrNotFound) {
+			return repoexposure.HTTPSCloneCredential{}, ErrRepoTargetNotAllowed
+		}
+		return repoexposure.HTTPSCloneCredential{}, err
+	}
+	effectiveConnectorID := firstNonEmptyString(status.ConnectorID, githubConnectorID)
+	if source.ConnectorID != "" && source.ConnectorID != effectiveConnectorID {
+		return repoexposure.HTTPSCloneCredential{}, ErrRepoTargetNotAllowed
+	}
+	if !status.Connected || !strings.EqualFold(status.Provider, "github_app") || status.InstallationID != source.InstallationID {
+		return repoexposure.HTTPSCloneCredential{}, ErrRepoTargetNotAllowed
+	}
+	if !repositorySelected(status.SelectedRepositories, record.Repository) {
+		return repoexposure.HTTPSCloneCredential{}, ErrRepoTargetNotAllowed
+	}
+	if s.GitHubInstallationTokenMinter == nil {
+		return repoexposure.HTTPSCloneCredential{}, fmt.Errorf("github installation token minter is not configured")
+	}
+	token, err := s.GitHubInstallationTokenMinter.Mint(ctx, source.InstallationID)
+	if err != nil {
+		return repoexposure.HTTPSCloneCredential{}, fmt.Errorf("mint github installation token: %w", err)
+	}
+	tokenValue := strings.TrimSpace(token.Token)
+	if tokenValue == "" {
+		return repoexposure.HTTPSCloneCredential{}, fmt.Errorf("github installation token is empty")
+	}
+	return repoexposure.HTTPSCloneCredential{
+		Host:     "github.com",
+		Username: "x-access-token",
+		Password: tokenValue,
+	}, nil
+}
+
+func sanitizeRepoScanError(err error, secrets ...string) error {
+	if err == nil {
+		return nil
+	}
+	message := err.Error()
+	redacted := false
+	for _, secret := range secrets {
+		secret = strings.TrimSpace(secret)
+		if secret == "" {
+			continue
+		}
+		if strings.Contains(message, secret) {
+			redacted = true
+		}
+		message = strings.ReplaceAll(message, secret, "[redacted]")
+	}
+	if !redacted {
+		return err
+	}
+	return errors.New(message)
 }
 
 func (s *Service) recordRepoScanExecutionFailure() {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/identrail/identrail/internal/app"
+	githubconnector "github.com/identrail/identrail/internal/connectors/github"
 	"github.com/identrail/identrail/internal/db"
 	"github.com/identrail/identrail/internal/domain"
 	"github.com/identrail/identrail/internal/providers"
@@ -56,6 +57,22 @@ func (f *fakeRepoExecutor) ScanRepository(ctx context.Context, target string) (r
 		return repoexposure.ScanResult{}, f.err
 	}
 	return f.result, nil
+}
+
+type fakeGitHubInstallationTokenMinter struct {
+	token          githubconnector.InstallationToken
+	err            error
+	installationID int64
+	calls          int
+}
+
+func (f *fakeGitHubInstallationTokenMinter) Mint(ctx context.Context, installationID int64) (githubconnector.InstallationToken, error) {
+	f.calls++
+	f.installationID = installationID
+	if f.err != nil {
+		return githubconnector.InstallationToken{}, f.err
+	}
+	return f.token, nil
 }
 
 type traceCapturingScanner struct {
@@ -364,6 +381,25 @@ func seedDefaultProject(t *testing.T, store db.Store, ctx context.Context, proje
 		Slug:        projectID,
 	}); err != nil {
 		t.Fatalf("seed project: %v", err)
+	}
+}
+
+func seedGitHubAppConnection(t *testing.T, svc *Service, ctx context.Context, projectID string, installationID int64, repositories []string) {
+	t.Helper()
+	scope, err := db.RequireScope(ctx)
+	if err != nil {
+		t.Fatalf("resolve scope: %v", err)
+	}
+	svc.githubConnections[githubConnectionKey(scope.TenantID, scope.WorkspaceID, projectID)] = githubProjectConnection{
+		TenantID:             scope.TenantID,
+		WorkspaceID:          scope.WorkspaceID,
+		ProjectID:            projectID,
+		ConnectorID:          githubConnectorID,
+		Status:               domain.ConnectorStatusActive,
+		HealthStatus:         "healthy",
+		Provider:             "github_app",
+		InstallationID:       installationID,
+		SelectedRepositories: repositories,
 	}
 }
 
@@ -819,7 +855,7 @@ func TestServiceListFindingsFilteredMatchesOlderRowsBeyondLegacyWindow(t *testin
 func TestServiceListRepoFindingsFilterTriagedResultsBeyondLegacyWindow(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
-	repoScan, _ := store.CreateRepoScan(defaultScopeContext(), "owner/repo", now)
+	repoScan, _ := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, now)
 
 	repoFindings := make([]domain.Finding, 0, 5001)
 	for i := 0; i < 5001; i++ {
@@ -867,7 +903,7 @@ func TestServiceListRepoFindingsFilterTriagedResultsBeyondLegacyWindow(t *testin
 func TestServiceListRepoFindingsSortBySeverityHonorsLimitBeyondLegacyWindow(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
-	repoScan, _ := store.CreateRepoScan(defaultScopeContext(), "owner/repo", now)
+	repoScan, _ := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, now)
 
 	repoFindings := make([]domain.Finding, 0, 5001)
 	for i := 0; i < 5001; i++ {
@@ -910,8 +946,8 @@ func TestServiceListRepoFindingsSortBySeverityHonorsLimitBeyondLegacyWindow(t *t
 func TestServiceRepoFindingTriageScopesStateToRepoScan(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
-	firstScan, _ := store.CreateRepoScan(defaultScopeContext(), "owner/repo", now)
-	secondScan, _ := store.CreateRepoScan(defaultScopeContext(), "owner/repo", now.Add(time.Hour))
+	firstScan, _ := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, now)
+	secondScan, _ := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, now.Add(time.Hour))
 
 	if err := store.UpsertRepoFindings(defaultScopeContext(), firstScan.ID, []domain.Finding{{
 		ID:        "shared-id",
@@ -1967,7 +2003,7 @@ func TestServiceGetRepoFindingsTrend(t *testing.T) {
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
 	ctx := defaultScopeContext()
 
-	scanA, err := store.CreateRepoScan(ctx, "owner/repo-a", now)
+	scanA, err := store.CreateRepoScan(ctx, "owner/repo-a", db.RepoScanSource{}, now)
 	if err != nil {
 		t.Fatalf("create repo scan A: %v", err)
 	}
@@ -1977,7 +2013,7 @@ func TestServiceGetRepoFindingsTrend(t *testing.T) {
 		t.Fatalf("upsert repo findings for scan A: %v", err)
 	}
 
-	scanB, err := store.CreateRepoScan(ctx, "owner/repo-b", now.Add(3*time.Minute))
+	scanB, err := store.CreateRepoScan(ctx, "owner/repo-b", db.RepoScanSource{}, now.Add(3*time.Minute))
 	if err != nil {
 		t.Fatalf("create repo scan B: %v", err)
 	}
@@ -2008,7 +2044,7 @@ func TestServiceGetRepoFindingsTrendFiltered(t *testing.T) {
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
 	ctx := defaultScopeContext()
 
-	scanA, err := store.CreateRepoScan(ctx, "owner/repo-a", now)
+	scanA, err := store.CreateRepoScan(ctx, "owner/repo-a", db.RepoScanSource{}, now)
 	if err != nil {
 		t.Fatalf("create repo scan A: %v", err)
 	}
@@ -2019,7 +2055,7 @@ func TestServiceGetRepoFindingsTrendFiltered(t *testing.T) {
 		t.Fatalf("upsert repo findings for scan A: %v", err)
 	}
 
-	scanB, err := store.CreateRepoScan(ctx, "owner/repo-b", now.Add(3*time.Minute))
+	scanB, err := store.CreateRepoScan(ctx, "owner/repo-b", db.RepoScanSource{}, now.Add(3*time.Minute))
 	if err != nil {
 		t.Fatalf("create repo scan B: %v", err)
 	}
@@ -2153,11 +2189,11 @@ func TestServiceListRepoFindingClusters(t *testing.T) {
 	store := db.NewMemoryStore()
 	svc := NewService(store, fakeScanner{}, "aws")
 
-	firstScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC))
+	firstScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("create first repo scan: %v", err)
 	}
-	secondScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	secondScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("create second repo scan: %v", err)
 	}
@@ -2255,7 +2291,7 @@ func TestServiceListRepoFindingClustersUsesBoundedPageFilter(t *testing.T) {
 	store := &repoFindingClusterFilterCaptureStore{MemoryStore: db.NewMemoryStore()}
 	svc := NewService(store, fakeScanner{}, "aws")
 
-	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("create repo scan: %v", err)
 	}
@@ -2288,11 +2324,11 @@ func TestServiceListRepoFindingClustersBackfillsLegacyRepositoryContext(t *testi
 	store := db.NewMemoryStore()
 	svc := NewService(store, fakeScanner{}, "aws")
 
-	firstScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo-a", time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	firstScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo-a", db.RepoScanSource{}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("create first repo scan: %v", err)
 	}
-	secondScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo-b", time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC))
+	secondScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo-b", db.RepoScanSource{}, time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("create second repo scan: %v", err)
 	}
@@ -3323,6 +3359,161 @@ func TestServiceEnqueueRepoScanAndProcessQueue(t *testing.T) {
 	}
 }
 
+func TestServiceEnqueueRepoScanWithGitHubAppSourceStoresConnectorContext(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	ctx := defaultScopeContext()
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedGitHubAppConnection(t, svc, ctx, "project-1", 101, []string{"owner/private"})
+	svc.RepoScanAllowedTargets = []string{"owner/*"}
+
+	record, err := svc.EnqueueRepoScan(ctx, RepoScanRequest{
+		Repository: "owner/private",
+		ProjectID:  "project-1",
+	})
+	if err != nil {
+		t.Fatalf("enqueue connector-backed repo scan: %v", err)
+	}
+	if record.Source.Provider != "github_app" || record.Source.ProjectID != "project-1" || record.Source.InstallationID != 101 {
+		t.Fatalf("expected connector source metadata, got %+v", record.Source)
+	}
+
+	stored, err := svc.GetRepoScan(ctx, record.ID)
+	if err != nil {
+		t.Fatalf("get queued repo scan: %v", err)
+	}
+	if stored.Source.Provider != "github_app" || stored.Source.ProjectID != "project-1" || stored.Source.InstallationID != 101 {
+		t.Fatalf("expected stored connector source metadata, got %+v", stored.Source)
+	}
+}
+
+func TestServiceEnqueueRepoScanWithGitHubAppSourceCanonicalizesGitHubTarget(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	ctx := defaultScopeContext()
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedGitHubAppConnection(t, svc, ctx, "project-1", 101, []string{"owner/private"})
+	svc.RepoScanAllowedTargets = []string{"owner/*"}
+
+	record, err := svc.EnqueueRepoScan(ctx, RepoScanRequest{
+		Repository: "git@github.com:Owner/Private.git",
+		ProjectID:  "project-1",
+	})
+	if err != nil {
+		t.Fatalf("enqueue connector-backed repo scan: %v", err)
+	}
+	if record.Repository != "owner/private" {
+		t.Fatalf("expected canonical github repository target, got %q", record.Repository)
+	}
+}
+
+func TestServiceEnqueueRepoScanUnknownProjectIDIsInvalidRequest(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	ctx := defaultScopeContext()
+	seedDefaultProject(t, store, ctx, "project-1")
+
+	_, err := svc.EnqueueRepoScan(ctx, RepoScanRequest{
+		Repository: "owner/repo",
+		ProjectID:  "project-missing",
+	})
+	if err == nil || !errors.Is(err, ErrInvalidRepoScanRequest) {
+		t.Fatalf("expected invalid repo scan request for missing project, got %v", err)
+	}
+}
+
+func TestServiceProcessQueuedGitHubAppRepoScanUsesInstallationToken(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	ctx := defaultScopeContext()
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedGitHubAppConnection(t, svc, ctx, "project-1", 101, []string{"owner/private"})
+	svc.RepoScanAllowedTargets = []string{"owner/*"}
+	svc.GitHubInstallationTokenMinter = &fakeGitHubInstallationTokenMinter{
+		token: githubconnector.InstallationToken{Token: "ghs_installation_token", ExpiresAt: time.Now().Add(time.Hour)},
+	}
+
+	var gotCredential repoexposure.HTTPSCloneCredential
+	var gotHistory, gotMax int
+	svc.AuthenticatedRepoScannerFactory = func(historyLimit int, maxFindings int, credential repoexposure.HTTPSCloneCredential) RepoScanExecutor {
+		gotHistory, gotMax = historyLimit, maxFindings
+		gotCredential = credential
+		return &fakeRepoExecutor{
+			result: repoexposure.ScanResult{
+				Repository:     "owner/private",
+				CommitsScanned: historyLimit,
+				FilesScanned:   2,
+			},
+		}
+	}
+
+	if _, err := svc.EnqueueRepoScan(ctx, RepoScanRequest{
+		Repository:   "owner/private",
+		ProjectID:    "project-1",
+		HistoryLimit: 25,
+		MaxFindings:  30,
+	}); err != nil {
+		t.Fatalf("enqueue connector-backed repo scan: %v", err)
+	}
+	processed, err := svc.ProcessNextQueuedRepoScan(ctx)
+	if err != nil {
+		t.Fatalf("process connector-backed repo scan: %v", err)
+	}
+	if !processed {
+		t.Fatal("expected queued connector-backed repo scan to be processed")
+	}
+	minter := svc.GitHubInstallationTokenMinter.(*fakeGitHubInstallationTokenMinter)
+	if minter.calls != 1 || minter.installationID != 101 {
+		t.Fatalf("expected one token mint for installation 101, got calls=%d installation=%d", minter.calls, minter.installationID)
+	}
+	if gotHistory != 25 || gotMax != 30 {
+		t.Fatalf("unexpected scanner limits history=%d max=%d", gotHistory, gotMax)
+	}
+	if gotCredential.Host != "github.com" || gotCredential.Username != "x-access-token" || gotCredential.Password != "ghs_installation_token" {
+		t.Fatalf("unexpected clone credential %+v", gotCredential)
+	}
+}
+
+func TestServiceProcessQueuedGitHubAppRepoScanRedactsInstallationTokenErrors(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	ctx := defaultScopeContext()
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedGitHubAppConnection(t, svc, ctx, "project-1", 101, []string{"owner/private"})
+	svc.RepoScanAllowedTargets = []string{"owner/*"}
+	svc.GitHubInstallationTokenMinter = &fakeGitHubInstallationTokenMinter{
+		token: githubconnector.InstallationToken{Token: "ghs_secret_token", ExpiresAt: time.Now().Add(time.Hour)},
+	}
+	svc.AuthenticatedRepoScannerFactory = func(historyLimit int, maxFindings int, credential repoexposure.HTTPSCloneCredential) RepoScanExecutor {
+		return &fakeRepoExecutor{err: errors.New("clone failed with token ghs_secret_token")}
+	}
+
+	record, err := svc.EnqueueRepoScan(ctx, RepoScanRequest{
+		Repository: "owner/private",
+		ProjectID:  "project-1",
+	})
+	if err != nil {
+		t.Fatalf("enqueue connector-backed repo scan: %v", err)
+	}
+	processed, err := svc.ProcessNextQueuedRepoScan(ctx)
+	if err == nil {
+		t.Fatal("expected connector-backed repo scan to fail")
+	}
+	if !processed {
+		t.Fatal("expected queued connector-backed repo scan to be claimed")
+	}
+	if strings.Contains(err.Error(), "ghs_secret_token") || !strings.Contains(err.Error(), "[redacted]") {
+		t.Fatalf("expected returned error to redact token, got %v", err)
+	}
+	stored, getErr := svc.GetRepoScan(ctx, record.ID)
+	if getErr != nil {
+		t.Fatalf("get failed repo scan: %v", getErr)
+	}
+	if strings.Contains(stored.ErrorMessage, "ghs_secret_token") || !strings.Contains(stored.ErrorMessage, "[redacted]") {
+		t.Fatalf("expected persisted error to redact token, got %q", stored.ErrorMessage)
+	}
+}
+
 func TestServiceProcessNextQueuedRepoScanContinuesEnqueuedTraceContext(t *testing.T) {
 	store := db.NewMemoryStore()
 	repoExecutor := &fakeRepoExecutor{
@@ -3372,7 +3563,7 @@ func TestServiceCountQueuedRepoScansForDepthReturnsZeroWhenAnyScopeCountFails(t 
 	scopedCtx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
 	now := time.Date(2026, 5, 10, 11, 45, 0, 0, time.UTC)
 
-	if _, err := store.CreateQueuedRepoScanWithinLimit(scopedCtx, "owner/repo", 50, 200, now, 5); err != nil {
+	if _, err := store.CreateQueuedRepoScanWithinLimit(scopedCtx, "owner/repo", db.RepoScanSource{}, 50, 200, now, 5); err != nil {
 		t.Fatalf("create queued repo scan: %v", err)
 	}
 	scopedCount, err := store.CountQueuedRepoScans(scopedCtx)

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -1858,7 +1858,7 @@ func normalizeFindingTriageEventForWrite(event FindingTriageEvent) (FindingTriag
 }
 
 // CreateRepoScan persists one repository exposure scan start event.
-func (m *MemoryStore) CreateRepoScan(ctx context.Context, repository string, startedAt time.Time) (RepoScanRecord, error) {
+func (m *MemoryStore) CreateRepoScan(ctx context.Context, repository string, source RepoScanSource, startedAt time.Time) (RepoScanRecord, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -1866,11 +1866,11 @@ func (m *MemoryStore) CreateRepoScan(ctx context.Context, repository string, sta
 	if err != nil {
 		return RepoScanRecord{}, err
 	}
-	return m.createRepoScanLocked(scope, strings.TrimSpace(repository), "running", 0, 0, startedAt), nil
+	return m.createRepoScanLocked(scope, strings.TrimSpace(repository), source, "running", 0, 0, startedAt), nil
 }
 
 // CreateQueuedRepoScan persists one queued repository exposure scan request.
-func (m *MemoryStore) CreateQueuedRepoScan(ctx context.Context, repository string, historyLimit int, maxFindings int, queuedAt time.Time) (RepoScanRecord, error) {
+func (m *MemoryStore) CreateQueuedRepoScan(ctx context.Context, repository string, source RepoScanSource, historyLimit int, maxFindings int, queuedAt time.Time) (RepoScanRecord, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -1878,14 +1878,14 @@ func (m *MemoryStore) CreateQueuedRepoScan(ctx context.Context, repository strin
 	if err != nil {
 		return RepoScanRecord{}, err
 	}
-	record := m.createRepoScanLocked(scope, strings.TrimSpace(repository), "queued", historyLimit, maxFindings, queuedAt)
+	record := m.createRepoScanLocked(scope, strings.TrimSpace(repository), source, "queued", historyLimit, maxFindings, queuedAt)
 	record.TraceParent, record.TraceState = QueueTraceContextFromContext(ctx)
 	m.repoScans[record.ID] = record
 	return record, nil
 }
 
 // CreateQueuedRepoScanWithinLimit persists one queued repository scan only when the target is idle and queue capacity remains.
-func (m *MemoryStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (RepoScanRecord, error) {
+func (m *MemoryStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, source RepoScanSource, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (RepoScanRecord, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -1912,7 +1912,7 @@ func (m *MemoryStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, repos
 	if queued >= maxPending {
 		return RepoScanRecord{}, ErrQueueLimitReached
 	}
-	record := m.createRepoScanLocked(scope, normalizedRepository, "queued", historyLimit, maxFindings, queuedAt)
+	record := m.createRepoScanLocked(scope, normalizedRepository, source, "queued", historyLimit, maxFindings, queuedAt)
 	record.TraceParent, record.TraceState = QueueTraceContextFromContext(ctx)
 	m.repoScans[record.ID] = record
 	return record, nil
@@ -2051,7 +2051,7 @@ func (m *MemoryStore) RequeueRepoScan(ctx context.Context, repoScanID string) er
 	return nil
 }
 
-func (m *MemoryStore) createRepoScanLocked(scope Scope, repository string, status string, historyLimit int, maxFindings int, startedAt time.Time) RepoScanRecord {
+func (m *MemoryStore) createRepoScanLocked(scope Scope, repository string, source RepoScanSource, status string, historyLimit int, maxFindings int, startedAt time.Time) RepoScanRecord {
 	normalizedScope := scope.Normalize()
 	record := RepoScanRecord{
 		ID:           uuid.NewString(),
@@ -2062,6 +2062,7 @@ func (m *MemoryStore) createRepoScanLocked(scope Scope, repository string, statu
 		StartedAt:    startedAt.UTC(),
 		HistoryLimit: historyLimit,
 		MaxFindings:  maxFindings,
+		Source:       source.Normalize(),
 	}
 	m.repoScans[record.ID] = record
 	m.repoScanIDs = append(m.repoScanIDs, record.ID)

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -506,11 +506,11 @@ func TestMemoryStoreListRepoFindingTrendCounts(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
 	ctx := defaultScopeContext()
-	scanA, err := store.CreateRepoScan(ctx, "owner/repo-a", now)
+	scanA, err := store.CreateRepoScan(ctx, "owner/repo-a", RepoScanSource{}, now)
 	if err != nil {
 		t.Fatalf("create repo scan A: %v", err)
 	}
-	scanB, err := store.CreateRepoScan(ctx, "owner/repo-b", now.Add(time.Minute))
+	scanB, err := store.CreateRepoScan(ctx, "owner/repo-b", RepoScanSource{}, now.Add(time.Minute))
 	if err != nil {
 		t.Fatalf("create repo scan B: %v", err)
 	}
@@ -619,7 +619,7 @@ func TestMemoryStoreRepoScanLifecycle(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 17, 14, 0, 0, 0, time.UTC)
 
-	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", now)
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", RepoScanSource{}, now)
 	if err != nil {
 		t.Fatalf("create repo scan: %v", err)
 	}
@@ -675,7 +675,7 @@ func TestMemoryStoreListRepoFindingsDoesNotMutateLegacyStoredEvidence(t *testing
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 17, 14, 0, 0, 0, time.UTC)
 
-	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", now)
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", RepoScanSource{}, now)
 	if err != nil {
 		t.Fatalf("create repo scan: %v", err)
 	}
@@ -726,15 +726,15 @@ func TestMemoryStoreListRepoFindingsDoesNotMutateLegacyStoredEvidence(t *testing
 func TestMemoryStoreListRepoFindingClustersPaginatesClusters(t *testing.T) {
 	store := NewMemoryStore()
 
-	firstScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo-a", time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	firstScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo-a", RepoScanSource{}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("create first repo scan: %v", err)
 	}
-	secondScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo-a", time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC))
+	secondScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo-a", RepoScanSource{}, time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("create second repo scan: %v", err)
 	}
-	thirdScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo-b", time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC))
+	thirdScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo-b", RepoScanSource{}, time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("create third repo scan: %v", err)
 	}
@@ -1140,7 +1140,7 @@ func TestMemoryStoreRepoQueueLifecycle(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 21, 9, 5, 0, 0, time.UTC)
 	scopedCtx := WithQueueTraceContext(defaultScopeContext(), "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", "congo=t61rcWkgMzE")
-	queued, err := store.CreateQueuedRepoScan(scopedCtx, "owner/repo", 50, 80, now)
+	queued, err := store.CreateQueuedRepoScan(scopedCtx, "owner/repo", RepoScanSource{}, 50, 80, now)
 	if err != nil {
 		t.Fatalf("create queued repo scan: %v", err)
 	}
@@ -1200,10 +1200,10 @@ func TestMemoryStoreCountQueuedRepoScansAnyScope(t *testing.T) {
 	now := time.Date(2026, 3, 21, 9, 5, 0, 0, time.UTC)
 	otherScope := WithScope(context.Background(), Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
 
-	if _, err := store.CreateQueuedRepoScan(defaultScopeContext(), "owner/repo-a", 10, 20, now); err != nil {
+	if _, err := store.CreateQueuedRepoScan(defaultScopeContext(), "owner/repo-a", RepoScanSource{}, 10, 20, now); err != nil {
 		t.Fatalf("create default queued repo scan: %v", err)
 	}
-	if _, err := store.CreateQueuedRepoScan(otherScope, "owner/repo-b", 10, 20, now.Add(time.Minute)); err != nil {
+	if _, err := store.CreateQueuedRepoScan(otherScope, "owner/repo-b", RepoScanSource{}, 10, 20, now.Add(time.Minute)); err != nil {
 		t.Fatalf("create scoped queued repo scan: %v", err)
 	}
 
@@ -1220,17 +1220,17 @@ func TestMemoryStoreCreateQueuedRepoScanWithinLimit(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 21, 9, 5, 0, 0, time.UTC)
 
-	first, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo-a", 10, 20, now, 1)
+	first, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo-a", RepoScanSource{}, 10, 20, now, 1)
 	if err != nil {
 		t.Fatalf("create queued repo scan within limit: %v", err)
 	}
 	if first.Status != "queued" || first.HistoryLimit != 10 || first.MaxFindings != 20 {
 		t.Fatalf("unexpected queued repo scan within limit: %+v", first)
 	}
-	if _, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo-b", 10, 20, now.Add(time.Minute), 1); !errors.Is(err, ErrQueueLimitReached) {
+	if _, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo-b", RepoScanSource{}, 10, 20, now.Add(time.Minute), 1); !errors.Is(err, ErrQueueLimitReached) {
 		t.Fatalf("expected repo queue limit to be reached, got %v", err)
 	}
-	if _, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo-a", 10, 20, now.Add(2*time.Minute), 2); !errors.Is(err, ErrPendingRepoScanExists) {
+	if _, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo-a", RepoScanSource{}, 10, 20, now.Add(2*time.Minute), 2); !errors.Is(err, ErrPendingRepoScanExists) {
 		t.Fatalf("expected duplicate pending repo scan to be rejected, got %v", err)
 	}
 }
@@ -1240,11 +1240,11 @@ func TestMemoryStoreClaimNextQueuedRepoScanAnyScope(t *testing.T) {
 	now := time.Date(2026, 3, 21, 9, 5, 0, 0, time.UTC)
 	otherScope := WithScope(context.Background(), Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
 
-	first, err := store.CreateQueuedRepoScan(otherScope, "owner/repo-b", 10, 20, now)
+	first, err := store.CreateQueuedRepoScan(otherScope, "owner/repo-b", RepoScanSource{}, 10, 20, now)
 	if err != nil {
 		t.Fatalf("create earlier scoped queued repo scan: %v", err)
 	}
-	if _, err := store.CreateQueuedRepoScan(defaultScopeContext(), "owner/repo-a", 10, 20, now.Add(time.Minute)); err != nil {
+	if _, err := store.CreateQueuedRepoScan(defaultScopeContext(), "owner/repo-a", RepoScanSource{}, 10, 20, now.Add(time.Minute)); err != nil {
 		t.Fatalf("create default queued repo scan: %v", err)
 	}
 
@@ -1260,7 +1260,7 @@ func TestMemoryStoreClaimNextQueuedRepoScanAnyScope(t *testing.T) {
 func TestMemoryStorePendingRepoCountMatchingIsCaseInsensitive(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 21, 9, 25, 0, 0, time.UTC)
-	if _, err := store.CreateQueuedRepoScan(defaultScopeContext(), "Owner/Repo", 10, 20, now); err != nil {
+	if _, err := store.CreateQueuedRepoScan(defaultScopeContext(), "Owner/Repo", RepoScanSource{}, 10, 20, now); err != nil {
 		t.Fatalf("create queued repo scan: %v", err)
 	}
 
@@ -1312,11 +1312,11 @@ func TestMemoryStoreScopeIsolation(t *testing.T) {
 		t.Fatalf("unexpected other scope scans: %+v", otherScans)
 	}
 
-	defaultRepo, err := store.CreateQueuedRepoScan(defaultCtx, "owner/repo", 10, 10, now)
+	defaultRepo, err := store.CreateQueuedRepoScan(defaultCtx, "owner/repo", RepoScanSource{}, 10, 10, now)
 	if err != nil {
 		t.Fatalf("create default repo scan: %v", err)
 	}
-	otherRepo, err := store.CreateQueuedRepoScan(otherCtx, "owner/repo", 10, 10, now.Add(2*time.Minute))
+	otherRepo, err := store.CreateQueuedRepoScan(otherCtx, "owner/repo", RepoScanSource{}, 10, 10, now.Add(2*time.Minute))
 	if err != nil {
 		t.Fatalf("create other repo scan: %v", err)
 	}

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -2586,17 +2586,17 @@ func (p *PostgresStore) ListScanEvents(ctx context.Context, scanID string, limit
 }
 
 // CreateRepoScan inserts a new repository exposure scan row.
-func (p *PostgresStore) CreateRepoScan(ctx context.Context, repository string, startedAt time.Time) (RepoScanRecord, error) {
-	return p.createRepoScanWithStatus(ctx, repository, "running", 0, 0, startedAt)
+func (p *PostgresStore) CreateRepoScan(ctx context.Context, repository string, source RepoScanSource, startedAt time.Time) (RepoScanRecord, error) {
+	return p.createRepoScanWithStatus(ctx, repository, source, "running", 0, 0, startedAt)
 }
 
 // CreateQueuedRepoScan inserts one queued repository scan request row.
-func (p *PostgresStore) CreateQueuedRepoScan(ctx context.Context, repository string, historyLimit int, maxFindings int, queuedAt time.Time) (RepoScanRecord, error) {
-	return p.createRepoScanWithStatus(ctx, repository, "queued", historyLimit, maxFindings, queuedAt)
+func (p *PostgresStore) CreateQueuedRepoScan(ctx context.Context, repository string, source RepoScanSource, historyLimit int, maxFindings int, queuedAt time.Time) (RepoScanRecord, error) {
+	return p.createRepoScanWithStatus(ctx, repository, source, "queued", historyLimit, maxFindings, queuedAt)
 }
 
 // CreateQueuedRepoScanWithinLimit inserts one queued repository scan only when the target is idle and queue capacity remains.
-func (p *PostgresStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (RepoScanRecord, error) {
+func (p *PostgresStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, source RepoScanSource, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (RepoScanRecord, error) {
 	scope, err := RequireScope(ctx)
 	if err != nil {
 		return RepoScanRecord{}, err
@@ -2655,6 +2655,7 @@ func (p *PostgresStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, rep
 	if queued >= maxPending {
 		return RepoScanRecord{}, ErrQueueLimitReached
 	}
+	normalizedSource := source.Normalize()
 
 	record := RepoScanRecord{
 		ID:           uuid.NewString(),
@@ -2665,12 +2666,13 @@ func (p *PostgresStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, rep
 		StartedAt:    queuedAt.UTC(),
 		HistoryLimit: historyLimit,
 		MaxFindings:  maxFindings,
+		Source:       normalizedSource,
 	}
 	record.TraceParent, record.TraceState = QueueTraceContextFromContext(ctx)
 	if _, err := tx.ExecContext(
 		ctx,
-		`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit, trace_parent, trace_state)
-		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8, NULLIF($9, ''), NULLIF($10, ''))`,
+		`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id, trace_parent, trace_state)
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8, $9, $10, $11, $12, NULLIF($13, ''), NULLIF($14, ''))`,
 		record.ID,
 		record.TenantID,
 		record.WorkspaceID,
@@ -2679,6 +2681,10 @@ func (p *PostgresStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, rep
 		record.StartedAt,
 		record.HistoryLimit,
 		record.MaxFindings,
+		record.Source.Provider,
+		record.Source.ProjectID,
+		record.Source.ConnectorID,
+		record.Source.InstallationID,
 		record.TraceParent,
 		record.TraceState,
 	); err != nil {
@@ -2734,6 +2740,10 @@ func (p *PostgresStore) claimNextQueuedRepoScan(ctx context.Context, scope *Scop
 			COALESCE(r.error_message, ''),
 			r.history_limit,
 			r.max_findings_limit,
+			COALESCE(r.source_provider, ''),
+			COALESCE(r.source_project_id, ''),
+			COALESCE(r.source_connector_id, ''),
+			COALESCE(r.source_installation_id, 0),
 			COALESCE(r.trace_parent, ''),
 			COALESCE(r.trace_state, '')`
 	args := []any{}
@@ -2769,6 +2779,10 @@ func (p *PostgresStore) claimNextQueuedRepoScan(ctx context.Context, scope *Scop
 			COALESCE(r.error_message, ''),
 			r.history_limit,
 			r.max_findings_limit,
+			COALESCE(r.source_provider, ''),
+			COALESCE(r.source_project_id, ''),
+			COALESCE(r.source_connector_id, ''),
+			COALESCE(r.source_installation_id, 0),
 			COALESCE(r.trace_parent, ''),
 			COALESCE(r.trace_state, '')`
 		args = []any{scope.TenantID, scope.WorkspaceID}
@@ -2881,11 +2895,12 @@ func (p *PostgresStore) RequeueRepoScan(ctx context.Context, repoScanID string) 
 	return nil
 }
 
-func (p *PostgresStore) createRepoScanWithStatus(ctx context.Context, repository string, status string, historyLimit int, maxFindings int, startedAt time.Time) (RepoScanRecord, error) {
+func (p *PostgresStore) createRepoScanWithStatus(ctx context.Context, repository string, source RepoScanSource, status string, historyLimit int, maxFindings int, startedAt time.Time) (RepoScanRecord, error) {
 	scope, err := RequireScope(ctx)
 	if err != nil {
 		return RepoScanRecord{}, err
 	}
+	normalizedSource := source.Normalize()
 	record := RepoScanRecord{
 		ID:           uuid.NewString(),
 		TenantID:     scope.TenantID,
@@ -2895,11 +2910,12 @@ func (p *PostgresStore) createRepoScanWithStatus(ctx context.Context, repository
 		StartedAt:    startedAt.UTC(),
 		HistoryLimit: historyLimit,
 		MaxFindings:  maxFindings,
+		Source:       normalizedSource,
 	}
 	_, err = p.execContext(
 		ctx,
-		`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit)
-		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8)`,
+		`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8, $9, $10, $11, $12)`,
 		record.ID,
 		record.TenantID,
 		record.WorkspaceID,
@@ -2908,6 +2924,10 @@ func (p *PostgresStore) createRepoScanWithStatus(ctx context.Context, repository
 		record.StartedAt,
 		record.HistoryLimit,
 		record.MaxFindings,
+		record.Source.Provider,
+		record.Source.ProjectID,
+		record.Source.ConnectorID,
+		record.Source.InstallationID,
 	)
 	if err != nil {
 		return RepoScanRecord{}, fmt.Errorf("insert repo scan: %w", err)
@@ -2923,7 +2943,7 @@ func (p *PostgresStore) GetRepoScan(ctx context.Context, repoScanID string) (Rep
 	}
 	row := p.queryRowContext(
 		ctx,
-		`SELECT id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(error_message, ''), history_limit, max_findings_limit
+		`SELECT id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(error_message, ''), history_limit, max_findings_limit, COALESCE(source_provider, ''), COALESCE(source_project_id, ''), COALESCE(source_connector_id, ''), COALESCE(source_installation_id, 0)
 		 FROM repo_scans
 		 WHERE id = $1
 		   AND tenant_id = $2
@@ -3060,7 +3080,7 @@ func (p *PostgresStore) ListRepoScans(ctx context.Context, limit int) ([]RepoSca
 	}
 	rows, err := p.queryContext(
 		ctx,
-		`SELECT id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(error_message, ''), history_limit, max_findings_limit
+		`SELECT id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(error_message, ''), history_limit, max_findings_limit, COALESCE(source_provider, ''), COALESCE(source_project_id, ''), COALESCE(source_connector_id, ''), COALESCE(source_installation_id, 0)
 		 FROM repo_scans
 		 WHERE tenant_id = $1
 		   AND workspace_id = $2
@@ -3871,10 +3891,15 @@ func scanRepoScanRecord(scanner scanner) (RepoScanRecord, error) {
 		&record.ErrorMessage,
 		&record.HistoryLimit,
 		&record.MaxFindings,
+		&record.Source.Provider,
+		&record.Source.ProjectID,
+		&record.Source.ConnectorID,
+		&record.Source.InstallationID,
 	); err != nil {
 		return RepoScanRecord{}, err
 	}
 	record.StartedAt = record.StartedAt.UTC()
+	record.Source = record.Source.Normalize()
 	if finishedAt.Valid {
 		converted := finishedAt.Time.UTC()
 		record.FinishedAt = &converted
@@ -3900,12 +3925,17 @@ func scanQueuedRepoScanRecord(scanner scanner) (RepoScanRecord, error) {
 		&record.ErrorMessage,
 		&record.HistoryLimit,
 		&record.MaxFindings,
+		&record.Source.Provider,
+		&record.Source.ProjectID,
+		&record.Source.ConnectorID,
+		&record.Source.InstallationID,
 		&record.TraceParent,
 		&record.TraceState,
 	); err != nil {
 		return RepoScanRecord{}, err
 	}
 	record.StartedAt = record.StartedAt.UTC()
+	record.Source = record.Source.Normalize()
 	record.TraceParent = strings.TrimSpace(record.TraceParent)
 	record.TraceState = strings.TrimSpace(record.TraceState)
 	if finishedAt.Valid {

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -664,12 +664,12 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 	store := NewPostgresStoreWithDB(db)
 	now := time.Now().UTC()
 
-	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit)
-		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8)`)).
-		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "running", sqlmock.AnyArg(), 0, 0).
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8, $9, $10, $11, $12)`)).
+		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "running", sqlmock.AnyArg(), 0, 0, "", "", "", int64(0)).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	record, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", now)
+	record, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", RepoScanSource{}, now)
 	if err != nil {
 		t.Fatalf("create repo scan failed: %v", err)
 	}
@@ -721,8 +721,8 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		t.Fatalf("complete repo scan failed: %v", err)
 	}
 
-	repoScanRows := sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "error_message", "history_limit", "max_findings_limit"}).
-		AddRow(record.ID, "default", "default", "owner/repo", "completed", now, now, 12, 8, 1, false, "", 0, 0)
+	repoScanRows := sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "error_message", "history_limit", "max_findings_limit", "source_provider", "source_project_id", "source_connector_id", "source_installation_id"}).
+		AddRow(record.ID, "default", "default", "owner/repo", "completed", now, now, 12, 8, 1, false, "", 0, 0, "", "", "", int64(0))
 	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, repository, status").WithArgs("default", "default", 20).WillReturnRows(repoScanRows)
 	repoScans, err := store.ListRepoScans(defaultScopeContext(), 20)
 	if err != nil {
@@ -778,8 +778,8 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		t.Fatalf("expected repository backfill from repo scan, got %+v", unboundedRepoFindings[0])
 	}
 
-	repoScanRow := sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "error_message", "history_limit", "max_findings_limit"}).
-		AddRow(record.ID, "default", "default", "owner/repo", "completed", now, now, 12, 8, 1, false, "", 0, 0)
+	repoScanRow := sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "error_message", "history_limit", "max_findings_limit", "source_provider", "source_project_id", "source_connector_id", "source_installation_id"}).
+		AddRow(record.ID, "default", "default", "owner/repo", "completed", now, now, 12, 8, 1, false, "", 0, 0, "", "", "", int64(0))
 	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, repository, status").WithArgs(record.ID, "default", "default").WillReturnRows(repoScanRow)
 	gotRepoScan, err := store.GetRepoScan(defaultScopeContext(), record.ID)
 	if err != nil {
@@ -1419,12 +1419,12 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 	store := NewPostgresStoreWithDB(db)
 	now := time.Now().UTC()
 
-	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit)
-		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8)`)).
-		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "queued", sqlmock.AnyArg(), 50, 80).
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8, $9, $10, $11, $12)`)).
+		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "queued", sqlmock.AnyArg(), 50, 80, "", "", "", int64(0)).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	queued, err := store.CreateQueuedRepoScan(defaultScopeContext(), "owner/repo", 50, 80, now)
+	queued, err := store.CreateQueuedRepoScan(defaultScopeContext(), "owner/repo", RepoScanSource{}, 50, 80, now)
 	if err != nil {
 		t.Fatalf("create queued repo scan failed: %v", err)
 	}
@@ -1485,9 +1485,13 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 		"coalesce",
 		"history_limit",
 		"max_findings_limit",
+		"source_provider",
+		"source_project_id",
+		"source_connector_id",
+		"source_installation_id",
 		"trace_parent",
 		"trace_state",
-	}).AddRow(queued.ID, "default", "default", "owner/repo", "running", now, nil, 0, 0, 0, false, "", 50, 80, "", "")
+	}).AddRow(queued.ID, "default", "default", "owner/repo", "running", now, nil, 0, 0, 0, false, "", 50, 80, "", "", "", int64(0), "", "")
 	mock.ExpectQuery("WITH next_repo_scan AS").WithArgs("default", "default").WillReturnRows(claimRows)
 
 	claimed, err := store.ClaimNextQueuedRepoScan(defaultScopeContext())
@@ -1578,13 +1582,13 @@ func TestPostgresStoreCreateQueuedRepoScanWithinLimit(t *testing.T) {
 		   AND status = 'queued'`)).
 		WithArgs("default", "default").
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit, trace_parent, trace_state)
-		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8, NULLIF($9, ''), NULLIF($10, ''))`)).
-		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "queued", now, 50, 80, "", "").
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id, trace_parent, trace_state)
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8, $9, $10, $11, $12, NULLIF($13, ''), NULLIF($14, ''))`)).
+		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "queued", now, 50, 80, "", "", "", int64(0), "", "").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
-	record, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo", 50, 80, now, 2)
+	record, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo", RepoScanSource{}, 50, 80, now, 2)
 	if err != nil {
 		t.Fatalf("create queued repo scan within limit: %v", err)
 	}
@@ -1609,7 +1613,7 @@ func TestPostgresStoreCreateQueuedRepoScanWithinLimit(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 	mock.ExpectRollback()
 
-	if _, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo", 50, 80, now.Add(time.Minute), 2); !errors.Is(err, ErrPendingRepoScanExists) {
+	if _, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo", RepoScanSource{}, 50, 80, now.Add(time.Minute), 2); !errors.Is(err, ErrPendingRepoScanExists) {
 		t.Fatalf("expected ErrPendingRepoScanExists, got %v", err)
 	}
 
@@ -1637,7 +1641,7 @@ func TestPostgresStoreCreateQueuedRepoScanWithinLimit(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
 	mock.ExpectRollback()
 
-	if _, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/other", 50, 80, now.Add(2*time.Minute), 2); !errors.Is(err, ErrQueueLimitReached) {
+	if _, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/other", RepoScanSource{}, 50, 80, now.Add(2*time.Minute), 2); !errors.Is(err, ErrQueueLimitReached) {
 		t.Fatalf("expected ErrQueueLimitReached, got %v", err)
 	}
 
@@ -2759,8 +2763,9 @@ func TestPostgresStoreClaimNextQueuedRepoScanAnyScopeBypassesScopeInjection(t *t
 	now := time.Now().UTC()
 	rows := sqlmock.NewRows([]string{
 		"id", "tenant_id", "workspace_id", "repository", "status", "started_at", "finished_at",
-		"commits_scanned", "files_scanned", "finding_count", "truncated", "coalesce", "history_limit", "max_findings_limit", "trace_parent", "trace_state",
-	}).AddRow("repo-scan-1", "tenant-a", "workspace-a", "owner/repo", "running", now, nil, 0, 0, 0, false, "", 500, 200, "", "")
+		"commits_scanned", "files_scanned", "finding_count", "truncated", "coalesce", "history_limit", "max_findings_limit",
+		"source_provider", "source_project_id", "source_connector_id", "source_installation_id", "trace_parent", "trace_state",
+	}).AddRow("repo-scan-1", "tenant-a", "workspace-a", "owner/repo", "running", now, nil, 0, 0, 0, false, "", 500, 200, "", "", "", int64(0), "", "")
 	mock.ExpectQuery("WITH next_repo_scan AS").
 		WillReturnRows(rows)
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -202,22 +202,52 @@ type ScanRecord struct {
 
 // RepoScanRecord tracks persisted repository exposure scan metadata.
 type RepoScanRecord struct {
-	ID             string     `json:"id"`
-	TenantID       string     `json:"-"`
-	WorkspaceID    string     `json:"-"`
-	Repository     string     `json:"repository"`
-	Status         string     `json:"status"`
-	StartedAt      time.Time  `json:"started_at"`
-	FinishedAt     *time.Time `json:"finished_at,omitempty"`
-	CommitsScanned int        `json:"commits_scanned"`
-	FilesScanned   int        `json:"files_scanned"`
-	FindingCount   int        `json:"finding_count"`
-	Truncated      bool       `json:"truncated"`
-	ErrorMessage   string     `json:"error_message,omitempty"`
-	HistoryLimit   int        `json:"-"`
-	MaxFindings    int        `json:"-"`
-	TraceParent    string     `json:"-"`
-	TraceState     string     `json:"-"`
+	ID             string         `json:"id"`
+	TenantID       string         `json:"-"`
+	WorkspaceID    string         `json:"-"`
+	Repository     string         `json:"repository"`
+	Status         string         `json:"status"`
+	StartedAt      time.Time      `json:"started_at"`
+	FinishedAt     *time.Time     `json:"finished_at,omitempty"`
+	CommitsScanned int            `json:"commits_scanned"`
+	FilesScanned   int            `json:"files_scanned"`
+	FindingCount   int            `json:"finding_count"`
+	Truncated      bool           `json:"truncated"`
+	ErrorMessage   string         `json:"error_message,omitempty"`
+	HistoryLimit   int            `json:"-"`
+	MaxFindings    int            `json:"-"`
+	Source         RepoScanSource `json:"-"`
+	TraceParent    string         `json:"-"`
+	TraceState     string         `json:"-"`
+}
+
+// RepoScanSource carries non-secret connector context for repository scans.
+// It lets workers resolve short-lived credentials at execution time without
+// persisting raw tokens in the queue.
+type RepoScanSource struct {
+	Provider       string
+	ProjectID      string
+	ConnectorID    string
+	InstallationID int64
+}
+
+// Normalize returns a copy with stable whitespace/casing.
+func (s RepoScanSource) Normalize() RepoScanSource {
+	return RepoScanSource{
+		Provider:       strings.ToLower(strings.TrimSpace(s.Provider)),
+		ProjectID:      strings.TrimSpace(s.ProjectID),
+		ConnectorID:    strings.TrimSpace(s.ConnectorID),
+		InstallationID: s.InstallationID,
+	}
+}
+
+// Empty reports whether the scan has no connector-backed source.
+func (s RepoScanSource) Empty() bool {
+	normalized := s.Normalize()
+	return normalized.Provider == "" &&
+		normalized.ProjectID == "" &&
+		normalized.ConnectorID == "" &&
+		normalized.InstallationID == 0
 }
 
 // ScanArtifacts contains raw and normalized scan outputs to persist idempotently.
@@ -2261,9 +2291,9 @@ type Store interface {
 	AppendScanEvent(ctx context.Context, scanID string, level string, message string, metadata map[string]any) error
 	ListScanEvents(ctx context.Context, scanID string, limit int) ([]ScanEvent, error)
 	SummarizeFindings(ctx context.Context) (FindingSummaryCounts, error)
-	CreateRepoScan(ctx context.Context, repository string, startedAt time.Time) (RepoScanRecord, error)
-	CreateQueuedRepoScan(ctx context.Context, repository string, historyLimit int, maxFindings int, queuedAt time.Time) (RepoScanRecord, error)
-	CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (RepoScanRecord, error)
+	CreateRepoScan(ctx context.Context, repository string, source RepoScanSource, startedAt time.Time) (RepoScanRecord, error)
+	CreateQueuedRepoScan(ctx context.Context, repository string, source RepoScanSource, historyLimit int, maxFindings int, queuedAt time.Time) (RepoScanRecord, error)
+	CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, source RepoScanSource, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (RepoScanRecord, error)
 	ClaimNextQueuedRepoScan(ctx context.Context) (RepoScanRecord, error)
 	ClaimNextQueuedRepoScanAnyScope(ctx context.Context) (RepoScanRecord, error)
 	CountQueuedRepoScans(ctx context.Context) (int, error)

--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -329,6 +329,9 @@ func (s *Scanner) cloneMirror(ctx context.Context, workdir string, cloneURL stri
 	}
 	_, runErr := s.runEnv(ctx, env, "git", args...)
 	if runErr != nil {
+		if errors.Is(runErr, context.Canceled) || errors.Is(runErr, context.DeadlineExceeded) {
+			return runErr
+		}
 		return sanitizeError(runErr, credential.Password)
 	}
 	return nil

--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -48,15 +49,31 @@ var repositoryHostLookupIPs = func(ctx context.Context, host string) ([]net.IP, 
 // CommandRunner executes git commands. It is injectable for deterministic tests.
 type CommandRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
 
+// EnvCommandRunner executes commands with additional environment variables.
+// The extra environment is kept out of command-line arguments so clone
+// credentials are not exposed through process arguments or error strings.
+type EnvCommandRunner func(ctx context.Context, env []string, name string, args ...string) ([]byte, error)
+
+// HTTPSCloneCredential supplies a temporary credential for HTTPS git clones.
+// Password must never be persisted; Scanner only keeps it in memory for the
+// duration of one scan.
+type HTTPSCloneCredential struct {
+	Host     string
+	Username string
+	Password string
+}
+
 // Option customizes scanner behavior.
 type Option func(*Scanner)
 
 // Scanner detects secret exposure and misconfiguration findings in Git repositories.
 type Scanner struct {
-	run          CommandRunner
-	now          func() time.Time
-	historyLimit int
-	maxFindings  int
+	run             CommandRunner
+	runEnv          EnvCommandRunner
+	now             func() time.Time
+	historyLimit    int
+	maxFindings     int
+	cloneCredential HTTPSCloneCredential
 }
 
 // ScanResult summarizes one repository exposure scan.
@@ -77,6 +94,7 @@ func NewScanner(runner CommandRunner, options ...Option) *Scanner {
 	}
 	s := &Scanner{
 		run:          runner,
+		runEnv:       defaultEnvCommandRunner,
 		now:          time.Now,
 		historyLimit: defaultHistoryLimit,
 		maxFindings:  defaultMaxFindings,
@@ -93,6 +111,16 @@ func NewScanner(runner CommandRunner, options ...Option) *Scanner {
 		s.maxFindings = defaultMaxFindings
 	}
 	return s
+}
+
+// WithEnvCommandRunner overrides command execution that needs extra env vars.
+// It is intended for tests and credential-safe git clone execution.
+func WithEnvCommandRunner(runner EnvCommandRunner) Option {
+	return func(s *Scanner) {
+		if runner != nil {
+			s.runEnv = runner
+		}
+	}
 }
 
 // WithHistoryLimit limits commit history depth for secret scanning.
@@ -115,6 +143,17 @@ func WithNow(now func() time.Time) Option {
 		if now != nil {
 			s.now = now
 		}
+	}
+}
+
+// WithHTTPSCloneCredential configures a short-lived HTTPS clone credential.
+// The credential is used only when the clone target host matches credential.Host.
+func WithHTTPSCloneCredential(credential HTTPSCloneCredential) Option {
+	return func(s *Scanner) {
+		credential.Host = strings.ToLower(strings.TrimSpace(credential.Host))
+		credential.Username = strings.TrimSpace(credential.Username)
+		credential.Password = strings.TrimSpace(credential.Password)
+		s.cloneCredential = credential
 	}
 }
 
@@ -256,11 +295,92 @@ func (s *Scanner) prepareRepository(ctx context.Context, target string) (reposit
 	}
 	cleanup := func() { _ = os.RemoveAll(workdir) }
 	mirrorPath := filepath.Join(workdir, "repo.git")
-	if _, runErr := s.run(ctx, "git", "clone", "--mirror", "--quiet", cloneURL, mirrorPath); runErr != nil {
+	if runErr := s.cloneMirror(ctx, workdir, cloneURL, mirrorPath); runErr != nil {
 		cleanup()
 		return repositoryLocation{}, nil, fmt.Errorf("clone repository: %w", runErr)
 	}
 	return repositoryLocation{Path: mirrorPath, Bare: true, Display: target}, cleanup, nil
+}
+
+func (s *Scanner) cloneMirror(ctx context.Context, workdir string, cloneURL string, mirrorPath string) error {
+	args := []string{"clone", "--mirror", "--quiet", cloneURL, mirrorPath}
+	credential, useCredential, err := s.credentialForCloneURL(cloneURL)
+	if err != nil {
+		return err
+	}
+	if !useCredential {
+		_, runErr := s.run(ctx, "git", args...)
+		return runErr
+	}
+	if s.runEnv == nil {
+		s.runEnv = defaultEnvCommandRunner
+	}
+	askpassPath, cleanup, err := writeGitAskPassScript(workdir)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	env := []string{
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_ASKPASS=" + askpassPath,
+		"IDENTRAIL_GIT_USERNAME=" + credential.Username,
+		"IDENTRAIL_GIT_PASSWORD=" + credential.Password,
+	}
+	_, runErr := s.runEnv(ctx, env, "git", args...)
+	if runErr != nil {
+		return sanitizeError(runErr, credential.Password)
+	}
+	return nil
+}
+
+func (s *Scanner) credentialForCloneURL(cloneURL string) (HTTPSCloneCredential, bool, error) {
+	credential := s.cloneCredential
+	if credential.Password == "" && credential.Username == "" && credential.Host == "" {
+		return HTTPSCloneCredential{}, false, nil
+	}
+	if credential.Username == "" || credential.Password == "" || credential.Host == "" {
+		return HTTPSCloneCredential{}, false, fmt.Errorf("incomplete HTTPS clone credential")
+	}
+	parsed, err := url.Parse(cloneURL)
+	if err != nil || parsed == nil || parsed.Scheme == "" || parsed.Host == "" {
+		return HTTPSCloneCredential{}, false, fmt.Errorf("authenticated clone target must be an absolute HTTPS URL")
+	}
+	if !strings.EqualFold(parsed.Scheme, "https") {
+		return HTTPSCloneCredential{}, false, fmt.Errorf("authenticated clone target must use HTTPS")
+	}
+	if !strings.EqualFold(parsed.Hostname(), credential.Host) {
+		return HTTPSCloneCredential{}, false, fmt.Errorf("authenticated clone target host is not allowed")
+	}
+	return credential, true, nil
+}
+
+func writeGitAskPassScript(dir string) (string, func(), error) {
+	file, err := os.CreateTemp(dir, "identrail-git-askpass-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("create git askpass helper: %w", err)
+	}
+	path := file.Name()
+	script := `#!/bin/sh
+case "$1" in
+  *Username*) printf '%s\n' "${IDENTRAIL_GIT_USERNAME:-x-access-token}" ;;
+  *) printf '%s\n' "${IDENTRAIL_GIT_PASSWORD:-}" ;;
+esac
+`
+	if _, err := file.WriteString(script); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return "", nil, fmt.Errorf("write git askpass helper: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", nil, fmt.Errorf("close git askpass helper: %w", err)
+	}
+	if err := os.Chmod(path, 0o700); err != nil {
+		_ = os.Remove(path)
+		return "", nil, fmt.Errorf("chmod git askpass helper: %w", err)
+	}
+	return path, func() { _ = os.Remove(path) }, nil
 }
 
 func (s *Scanner) listCommits(ctx context.Context, repo repositoryLocation) ([]string, error) {
@@ -845,4 +965,29 @@ func severityRank(severity domain.FindingSeverity) int {
 func defaultCommandRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	return cmd.CombinedOutput()
+}
+
+func defaultEnvCommandRunner(ctx context.Context, env []string, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = append(os.Environ(), env...)
+	return cmd.CombinedOutput()
+}
+
+func sanitizeError(err error, secrets ...string) error {
+	if err == nil {
+		return nil
+	}
+	return errors.New(redactSecrets(err.Error(), secrets...))
+}
+
+func redactSecrets(text string, secrets ...string) string {
+	redacted := text
+	for _, secret := range secrets {
+		secret = strings.TrimSpace(secret)
+		if secret == "" {
+			continue
+		}
+		redacted = strings.ReplaceAll(redacted, secret, "[redacted]")
+	}
+	return redacted
 }

--- a/internal/repoexposure/scanner_test.go
+++ b/internal/repoexposure/scanner_test.go
@@ -618,6 +618,94 @@ func TestPrepareRepositoryRejectsInsecureHTTPRepositoryURL(t *testing.T) {
 	}
 }
 
+func TestCloneMirrorUsesAskPassCredentialWithoutCommandArgLeak(t *testing.T) {
+	const secret = "ghs_secret_token"
+	var gotEnv []string
+	var gotArgs []string
+	scanner := NewScanner(
+		func(context.Context, string, ...string) ([]byte, error) {
+			t.Fatal("expected authenticated clone to use env command runner")
+			return nil, nil
+		},
+		WithHTTPSCloneCredential(HTTPSCloneCredential{
+			Host:     "github.com",
+			Username: "x-access-token",
+			Password: secret,
+		}),
+		WithEnvCommandRunner(func(_ context.Context, env []string, name string, args ...string) ([]byte, error) {
+			gotEnv = append([]string(nil), env...)
+			gotArgs = append([]string{name}, args...)
+			askPass := envValue(env, "GIT_ASKPASS")
+			if askPass == "" {
+				t.Fatal("expected GIT_ASKPASS to be configured")
+			}
+			if _, err := os.Stat(askPass); err != nil {
+				t.Fatalf("expected askpass helper to exist during clone: %v", err)
+			}
+			return []byte("ok"), nil
+		}),
+	)
+
+	err := scanner.cloneMirror(context.Background(), t.TempDir(), "https://github.com/owner/repo.git", filepath.Join(t.TempDir(), "repo.git"))
+	if err != nil {
+		t.Fatalf("clone mirror: %v", err)
+	}
+	if strings.Contains(strings.Join(gotArgs, " "), secret) {
+		t.Fatalf("clone command arguments leaked token: %+v", gotArgs)
+	}
+	if envValue(gotEnv, "IDENTRAIL_GIT_USERNAME") != "x-access-token" || envValue(gotEnv, "IDENTRAIL_GIT_PASSWORD") != secret {
+		t.Fatalf("expected clone credential in environment, got %+v", gotEnv)
+	}
+	if envValue(gotEnv, "GIT_TERMINAL_PROMPT") != "0" {
+		t.Fatalf("expected terminal prompts to be disabled, got %+v", gotEnv)
+	}
+}
+
+func TestCloneMirrorRedactsCredentialFromErrors(t *testing.T) {
+	const secret = "ghs_secret_token"
+	scanner := NewScanner(nil,
+		WithHTTPSCloneCredential(HTTPSCloneCredential{
+			Host:     "github.com",
+			Username: "x-access-token",
+			Password: secret,
+		}),
+		WithEnvCommandRunner(func(context.Context, []string, string, ...string) ([]byte, error) {
+			return nil, errors.New("remote rejected token " + secret)
+		}),
+	)
+
+	err := scanner.cloneMirror(context.Background(), t.TempDir(), "https://github.com/owner/repo.git", filepath.Join(t.TempDir(), "repo.git"))
+	if err == nil {
+		t.Fatal("expected clone error")
+	}
+	if strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), "[redacted]") {
+		t.Fatalf("expected redacted clone error, got %v", err)
+	}
+}
+
+func TestCloneMirrorRejectsCredentialHostMismatch(t *testing.T) {
+	called := false
+	scanner := NewScanner(nil,
+		WithHTTPSCloneCredential(HTTPSCloneCredential{
+			Host:     "github.com",
+			Username: "x-access-token",
+			Password: "ghs_secret_token",
+		}),
+		WithEnvCommandRunner(func(context.Context, []string, string, ...string) ([]byte, error) {
+			called = true
+			return nil, nil
+		}),
+	)
+
+	err := scanner.cloneMirror(context.Background(), t.TempDir(), "https://gitlab.com/owner/repo.git", filepath.Join(t.TempDir(), "repo.git"))
+	if err == nil {
+		t.Fatal("expected credential host mismatch to fail")
+	}
+	if called {
+		t.Fatal("expected clone command not to run for credential host mismatch")
+	}
+}
+
 func TestValidateCloneURL(t *testing.T) {
 	originalLookup := repositoryHostLookupIPs
 	repositoryHostLookupIPs = func(_ context.Context, host string) ([]net.IP, error) {
@@ -705,6 +793,16 @@ func TestGitInvocationModes(t *testing.T) {
 	if !reflect.DeepEqual(got[1], expectedSecond) {
 		t.Fatalf("unexpected bare invocation %+v", got[1])
 	}
+}
+
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for _, item := range env {
+		if strings.HasPrefix(item, prefix) {
+			return strings.TrimPrefix(item, prefix)
+		}
+	}
+	return ""
 }
 
 func TestHelperFunctions(t *testing.T) {

--- a/internal/runtime/service_builder.go
+++ b/internal/runtime/service_builder.go
@@ -140,6 +140,7 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 		},
 	}
 	svc.GitHubRepositoryLister = githubconnector.RepositoryClient{TokenClient: tokenClient}
+	svc.GitHubInstallationTokenMinter = tokenClient
 	svc.AWSScannerFactory = func(ctx context.Context, connection api.AWSConnectionStatus) (api.ScannerRunner, error) {
 		iamAPI, iamErr := awsprovider.NewSDKIAMAPIFromAssumeRole(ctx, connection.Region, cfg.AWSProfile, connection.RoleARN, connection.ExternalID, "identrail-recurring-scan")
 		if iamErr != nil {

--- a/migrations/000030_repo_scan_source_metadata.down.sql
+++ b/migrations/000030_repo_scan_source_metadata.down.sql
@@ -1,0 +1,7 @@
+DROP INDEX IF EXISTS idx_repo_scans_scope_source_started_at;
+
+ALTER TABLE repo_scans
+    DROP COLUMN IF EXISTS source_installation_id,
+    DROP COLUMN IF EXISTS source_connector_id,
+    DROP COLUMN IF EXISTS source_project_id,
+    DROP COLUMN IF EXISTS source_provider;

--- a/migrations/000030_repo_scan_source_metadata.up.sql
+++ b/migrations/000030_repo_scan_source_metadata.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE repo_scans
+    ADD COLUMN IF NOT EXISTS source_provider TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS source_project_id TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS source_connector_id TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS source_installation_id BIGINT NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_repo_scans_scope_source_started_at
+    ON repo_scans (tenant_id, workspace_id, source_provider, source_project_id, started_at DESC);


### PR DESCRIPTION
Fixes #1227

## What changed
- Added non-secret repo scan source metadata so queued scans can remember the GitHub App project, connector, and installation without persisting installation tokens.
- Wired manual API requests, scheduled scan policies, and GitHub webhook-triggered scans to enqueue connector-backed private repository scans when a project GitHub App connection is selected.
- Added a credential-safe HTTPS clone path that uses `GIT_ASKPASS` and environment variables for short-lived installation tokens, with token redaction on scan failures.
- Updated the runtime builder to share the GitHub App installation token minter with repo scan execution.
- Updated docs, OpenAPI, changelog, and migration catalog for the private-repo scan path.

## Why
Private GitHub repositories selected through the GitHub App connector could be listed and scheduled, but repo exposure scans still had no safe way to authenticate clone operations. This left the GitHub intelligence path limited to public repositories or unauthenticated targets.

## Impact
- Private GitHub App repositories can now be scanned through the same repo exposure scanner while preserving existing public scan behavior.
- Raw tokens are not written to `repo_scans`, `repo_findings`, logs, traces, persisted error messages, or API responses.
- Repo scan allowlists, queue capacity, duplicate-target guards, and per-target locking still apply before connector-backed scans run.

## Risk and mitigation
- Schema change: adds four non-secret source metadata columns to `repo_scans` with defaults and a matching down migration.
- Clone auth: tokens are scoped to GitHub HTTPS clones and rejected for host mismatches or non-HTTPS authenticated clone targets.
- Compatibility: requests without `project_id` continue to use the existing public unauthenticated scanner path.

## Validation
- `go test ./internal/repoexposure ./internal/db ./internal/api ./internal/runtime`
- `go test ./...`
- Pre-push hooks: merge-conflict check, yaml check, EOF/whitespace checks, gofmt check, go vet, local env token hygiene, Vercel artifact hygiene

## AI assistance
- AI-assisted: yes
- Tools used: Codex
- Where used: implementation, tests, docs, and validation workflow
- Human verification performed: reviewed staged diff, ran the test suites above, and used a signed commit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds connector‑backed private GitHub repo scans using short‑lived GitHub App tokens. Stores only non‑secret source metadata and redacts tokens from errors, logs, and responses; public scan behavior and queue/locking stay the same. Addresses #1227.

- New Features
  - Private scans via `project_id` (optional `connector_id`). Repo must be selected on the project and pass the allowlist. API, scheduled policies, and GitHub webhooks attach project/connector context; unknown `project_id` is an invalid request.
  - Safe auth: workers mint installation tokens at run time, clone over HTTPS using `GIT_ASKPASS` env vars (no tokens in URLs or process args), and redact tokens in errors/logs/traces/API responses. Enforces HTTPS and host match for authenticated clones. GitHub targets are canonicalized; selection checks normalize paths and casing.
  - DB stores only non‑secret source metadata on `repo_scans` (provider, project, connector, installation). Workers resolve tokens at execution. OpenAPI adds optional `project_id` and `connector_id` to `POST /v1/repo-scans`. Scheduled scans attach source metadata only for GitHub App (not PAT).

- Migration
  - Apply `000030_repo_scan_source_metadata` (adds source columns + index). No backfill needed.
  - To use private scans: connect a project to the GitHub App, select repositories, and ensure targets match the allowlist.

<sup>Written for commit 3e5645a24aca0030e923a39a638a61ebb4193723. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1238?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

