### PR TITLE
Polish app console usability

### DIFF
--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -271,6 +271,38 @@ describe('ProductShellLayout', () => {
   });
 });
 
+describe('ProductShellLayout', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('opens the workspace finder from keyboard shortcuts and routes to a selected section', async () => {
+    const { ProductShellLayout } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID" element={<ProductShellLayout />}>
+            <Route index element={<h2>Overview content</h2>} />
+            <Route path="findings" element={<h2>Findings content</h2>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('button', { name: /Open workspace finder/i })).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: '/' });
+    expect(screen.getByRole('dialog', { name: /Go to anything/i })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/Search workspace commands/i), { target: { value: 'findings' } });
+    fireEvent.keyDown(screen.getByLabelText(/Search workspace commands/i), { key: 'Enter' });
+
+    expect(await screen.findByRole('heading', { level: 2, name: /Findings content/i })).toBeInTheDocument();
+  });
+});
+
 describe('ProductProjectDetailPage', () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -770,7 +770,21 @@ function CommandPalette({
         }
       }}
     >
-      <section className="idt-command-palette" role="dialog" aria-modal="true" aria-labelledby="idt-command-palette-title">
+      <section
+        className="idt-command-palette"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="idt-command-palette-title"
+        onKeyDown={(event) => {
+          if (event.defaultPrevented) {
+            return;
+          }
+          if (event.key === 'Escape') {
+            event.preventDefault();
+            onClose();
+          }
+        }}
+      >
         <header>
           <div>
             <p className="idt-app-kicker">Workspace finder</p>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1,4 +1,5 @@
 import { Component, FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { Link, Navigate, NavLink, Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
 import {
   ApiError,
@@ -672,12 +673,138 @@ function AppShellLoading({ message }: { message: string }) {
   );
 }
 
+function AppRouteLoadingState({ title, body }: { title: string; body: string }) {
+  return (
+    <section className="idt-app-panel idt-app-route-loading" aria-busy="true" aria-live="polite">
+      <p className="idt-app-kicker">Loading</p>
+      <h2>{title}</h2>
+      <p>{body}</p>
+    </section>
+  );
+}
+
 function AppShellEmptyState({ title, body }: { title: string; body: string }) {
   return (
     <article className="idt-app-empty-state">
       <h2>{title}</h2>
       <p>{body}</p>
     </article>
+  );
+}
+
+type CommandPaletteItem = {
+  id: string;
+  label: string;
+  description: string;
+  keywords: string[];
+  shortcut?: string;
+  path?: string;
+  action?: () => void;
+};
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  const tagName = target.tagName.toLowerCase();
+  return target.isContentEditable || tagName === 'input' || tagName === 'select' || tagName === 'textarea';
+}
+
+function CommandPalette({
+  open,
+  items,
+  onClose,
+  onSelect
+}: {
+  open: boolean;
+  items: CommandPaletteItem[];
+  onClose: () => void;
+  onSelect: (item: CommandPaletteItem) => void;
+}) {
+  const [query, setQuery] = useState('');
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery('');
+      return;
+    }
+
+    const focusTimer = window.setTimeout(() => inputRef.current?.focus(), 0);
+    return () => window.clearTimeout(focusTimer);
+  }, [open]);
+
+  const filteredItems = useMemo(() => {
+    const search = normalizeValue(query).toLowerCase();
+    if (!search) {
+      return items;
+    }
+    return items.filter((item) =>
+      [item.label, item.description, ...item.keywords].some((value) => value.toLowerCase().includes(search))
+    );
+  }, [items, query]);
+
+  if (!open) {
+    return null;
+  }
+
+  const handleInputKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onClose();
+      return;
+    }
+    if (event.key === 'Enter' && filteredItems[0]) {
+      event.preventDefault();
+      onSelect(filteredItems[0]);
+    }
+  };
+
+  return (
+    <div
+      className="idt-command-palette-backdrop"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <section className="idt-command-palette" role="dialog" aria-modal="true" aria-labelledby="idt-command-palette-title">
+        <header>
+          <div>
+            <p className="idt-app-kicker">Workspace finder</p>
+            <h2 id="idt-command-palette-title">Go to anything</h2>
+          </div>
+          <button type="button" className="idt-command-palette-close" onClick={onClose} aria-label="Close workspace finder">
+            Esc
+          </button>
+        </header>
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={handleInputKeyDown}
+          placeholder="Search views, reports, settings, and actions"
+          aria-label="Search workspace commands"
+        />
+        <div className="idt-command-palette-results" role="listbox" aria-label="Workspace commands">
+          {filteredItems.length > 0 ? (
+            filteredItems.map((item) => (
+              <button key={item.id} type="button" role="option" onClick={() => onSelect(item)}>
+                <span>
+                  <strong>{item.label}</strong>
+                  <small>{item.description}</small>
+                </span>
+                {item.shortcut ? <kbd>{item.shortcut}</kbd> : null}
+              </button>
+            ))
+          ) : (
+            <p>No matching commands yet.</p>
+          )}
+        </div>
+      </section>
+    </div>
   );
 }
 
@@ -966,16 +1093,130 @@ export function ProductShellLayout() {
   const params = useParams<ScopeRouteParams>();
   const navigate = useNavigate();
   const scope = resolveScopeFromParams(params);
+  const [commandOpen, setCommandOpen] = useState(false);
+  const basePath = scope ? buildScopedPath(scope) : '/app';
+  const commandItems = useMemo<CommandPaletteItem[]>(() => {
+    if (!scope) {
+      return [];
+    }
+    const items: CommandPaletteItem[] = [
+      {
+        id: 'overview',
+        label: 'Overview',
+        description: 'Project coverage, recent scans, and next actions',
+        keywords: ['home', 'dashboard', 'workspace'],
+        shortcut: 'O',
+        path: basePath
+      },
+      {
+        id: 'projects',
+        label: 'Projects',
+        description: 'Choose or create a project boundary',
+        keywords: ['project', 'registry', 'source'],
+        shortcut: 'P',
+        path: `${basePath}/projects`
+      },
+      {
+        id: 'findings',
+        label: 'Findings',
+        description: 'Review repository exposure and triage work',
+        keywords: ['risk', 'repository', 'triage'],
+        shortcut: 'F',
+        path: `${basePath}/findings`
+      },
+      {
+        id: 'workspaces',
+        label: 'Workspaces',
+        description: 'Members, roles, and active workspace scope',
+        keywords: ['members', 'roles', 'invite'],
+        path: `${basePath}/workspaces`
+      },
+      {
+        id: 'settings',
+        label: 'Settings',
+        description: 'Workspace identity, access model, and routes',
+        keywords: ['identity', 'access', 'authentication'],
+        path: `${basePath}/settings`
+      },
+      {
+        id: 'executive-report',
+        label: 'Executive report',
+        description: 'Board-ready risk posture for this workspace',
+        keywords: ['report', 'board', 'risk'],
+        path: '/reports/executive'
+      },
+      {
+        id: 'security',
+        label: 'Account security',
+        description: 'Current session, access scope, and sign-out controls',
+        keywords: ['account', 'session', 'security'],
+        path: '/app/account/security'
+      },
+      {
+        id: 'marketing-site',
+        label: 'Marketing site',
+        description: 'Return to the public Identrail site',
+        keywords: ['public', 'website', 'home'],
+        path: '/'
+      },
+      {
+        id: 'sign-out',
+        label: 'Sign out',
+        description: 'End this workspace session',
+        keywords: ['logout', 'session'],
+        action: () => navigate('/app/logout', { replace: true })
+      }
+    ];
+    if (scope.projectID) {
+      items.splice(2, 0, {
+        id: 'current-project-sources',
+        label: 'Current project sources',
+        description: `Connect and review sources for ${formatScopeDisplay(scope.projectID)}`,
+        keywords: ['source', 'connector', 'github', 'aws', 'kubernetes'],
+        path: buildProjectPath(scope, scope.projectID)
+      });
+    }
+    return items;
+  }, [basePath, navigate, scope]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || isEditableTarget(event.target)) {
+        return;
+      }
+
+      const key = event.key.toLowerCase();
+      if ((event.metaKey || event.ctrlKey) && key === 'k') {
+        event.preventDefault();
+        setCommandOpen(true);
+        return;
+      }
+      if (!event.metaKey && !event.ctrlKey && !event.altKey && (key === '/' || key === 'f')) {
+        event.preventDefault();
+        setCommandOpen(true);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
 
   if (!scope) {
     return <AppShellLoading message="Resolving workspace scope" />;
   }
 
-  const basePath = buildScopedPath(scope);
   const tenantLabel = formatScopeDisplay(scope.tenantID);
   const workspaceLabel = formatScopeDisplay(scope.workspaceID);
   const projectLabel = scope.projectID ? formatScopeDisplay(scope.projectID) : '';
   const enabledSourceLabel = formatSourceNameList(SOURCE_STACK);
+  const runCommand = (item: CommandPaletteItem) => {
+    setCommandOpen(false);
+    if (item.path) {
+      navigate(item.path);
+      return;
+    }
+    item.action?.();
+  };
 
   return (
     <ProductErrorBoundary>
@@ -1007,6 +1248,18 @@ export function ProductShellLayout() {
               ) : null}
             </dl>
           </section>
+
+          <button
+            type="button"
+            className="idt-app-quick-find"
+            onClick={() => setCommandOpen(true)}
+            aria-label="Open workspace finder"
+          >
+            <span>Find</span>
+            <kbd>/</kbd>
+            <kbd>F</kbd>
+            <kbd>⌘K</kbd>
+          </button>
 
           <nav className="idt-app-shell-nav" aria-label="App sections">
             <NavLink to={basePath} end>
@@ -1071,6 +1324,12 @@ export function ProductShellLayout() {
           </main>
         </div>
       </div>
+      <CommandPalette
+        open={commandOpen}
+        items={commandItems}
+        onClose={() => setCommandOpen(false)}
+        onSelect={runCommand}
+      />
     </ProductErrorBoundary>
   );
 }
@@ -1932,7 +2191,12 @@ export function ProductWorkspacesPage() {
   };
 
   if (loading) {
-    return <AppShellLoading message="Loading workspace administration" />;
+    return (
+      <AppRouteLoadingState
+        title="Preparing workspace access"
+        body="Keeping the workspace shell ready while member access details refresh."
+      />
+    );
   }
 
   const availableWorkspaces = whoAmI?.workspaces ?? [];
@@ -2122,7 +2386,6 @@ export function ProductWorkspacesPage() {
           <thead>
             <tr>
               <th>User</th>
-              <th>Member ID</th>
               <th>Role</th>
               <th>Status</th>
               <th>Last updated</th>
@@ -2138,8 +2401,16 @@ export function ProductWorkspacesPage() {
                   <td>
                     <strong>{member.user_id}</strong>
                     {member.email ? <span>{member.email}</span> : null}
+                    <details className="idt-workspace-member-details">
+                      <summary>Member details</summary>
+                      <dl>
+                        <div>
+                          <dt>Member ID</dt>
+                          <dd>{member.member_id}</dd>
+                        </div>
+                      </dl>
+                    </details>
                   </td>
-                  <td>{member.member_id}</td>
                   <td>
                     <select
                       value={draft.role}
@@ -2301,7 +2572,12 @@ export function ProductProjectsPage() {
   }
 
   if (loading) {
-    return <AppShellLoading message="Loading projects" />;
+    return (
+      <AppRouteLoadingState
+        title="Preparing project registry"
+        body="Keeping the workspace shell ready while project boundaries refresh."
+      />
+    );
   }
 
   const handleNameChange = (value: string) => {
@@ -2453,20 +2729,23 @@ export function ProductProjectsPage() {
                       </span>
                     </div>
 
-                    <dl className="idt-project-card-meta">
-                      <div>
-                        <dt>Project ID</dt>
-                        <dd>{project.project_id}</dd>
-                      </div>
-                      <div>
-                        <dt>Slug</dt>
-                        <dd>{project.slug}</dd>
-                      </div>
-                      <div>
-                        <dt>Updated</dt>
-                        <dd>{formatConnectionTime(project.updated_at)}</dd>
-                      </div>
-                    </dl>
+                    <details className="idt-project-card-details">
+                      <summary>Project details</summary>
+                      <dl className="idt-project-card-meta">
+                        <div>
+                          <dt>Project ID</dt>
+                          <dd>{project.project_id}</dd>
+                        </div>
+                        <div>
+                          <dt>Slug</dt>
+                          <dd>{project.slug}</dd>
+                        </div>
+                        <div>
+                          <dt>Updated</dt>
+                          <dd>{formatConnectionTime(project.updated_at)}</dd>
+                        </div>
+                      </dl>
+                    </details>
 
                     <div className="idt-inline-actions">
                       <Link className="idt-btn idt-btn-primary" to={buildProjectPath(scope, project.project_id)}>
@@ -2901,7 +3180,12 @@ export function ProductProjectDetailPage() {
   }
 
   if (loading) {
-    return <AppShellLoading message="Loading source connections" />;
+    return (
+      <AppRouteLoadingState
+        title="Preparing source connections"
+        body="Keeping the project workspace visible while connector status refreshes."
+      />
+    );
   }
 
   const selectedStatus = sourceConnection(connections, selectedSource);
@@ -4463,7 +4747,12 @@ export function ProductFindingsPage() {
   }
 
   if (loading) {
-    return <AppShellLoading message="Loading repository findings" />;
+    return (
+      <AppRouteLoadingState
+        title="Preparing repository findings"
+        body="Keeping the workspace shell ready while finding and trend data refresh."
+      />
+    );
   }
 
   const handleRefresh = () => {
@@ -4599,78 +4888,84 @@ export function ProductFindingsPage() {
         </div>
       </div>
 
-      <div className="idt-repo-finding-filters">
-        <label>
-          Repository scan
-          <select value={repoScanFilter} onChange={(event) => setRepoScanFilter(event.target.value)}>
-            <option value="">All repository scans</option>
-            {repoScans.map((scan) => (
-              <option key={scan.id} value={scan.id}>
-                {canonicalGitHubRepositoryDisplay(scan.repository)} · {formatTokenLabel(scan.status)}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label>
-          Severity
-          <select
-            value={severityFilter}
-            onChange={(event) => setSeverityFilter(event.target.value as (typeof REPO_FINDING_SEVERITY_FILTERS)[number])}
-          >
-            {REPO_FINDING_SEVERITY_FILTERS.map((value) => (
-              <option key={value} value={value}>
-                {value === 'all' ? 'All severities' : formatTokenLabel(value)}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label>
-          Type
-          <select value={typeFilter} onChange={(event) => setTypeFilter(event.target.value as (typeof REPO_FINDING_TYPE_FILTERS)[number])}>
-            {REPO_FINDING_TYPE_FILTERS.map((value) => (
-              <option key={value} value={value}>
-                {value === 'all' ? 'All finding types' : formatTokenLabel(value)}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label>
-          Sort by
-          <select value={sortBy} onChange={(event) => setSortBy(event.target.value as (typeof REPO_FINDING_SORT_FIELDS)[number])}>
-            {REPO_FINDING_SORT_FIELDS.map((value) => (
-              <option key={value} value={value}>
-                {SORT_LABEL_BY_FIELD[value]}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label>
-          Sort order
-          <select value={sortOrder} onChange={(event) => setSortOrder(event.target.value as 'asc' | 'desc')}>
-            <option value="asc">Ascending</option>
-            <option value="desc">Descending</option>
-          </select>
-        </label>
-        <label>
-          Lifecycle status
-          <select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value as (typeof REPO_FINDING_STATUS_FILTERS)[number])}>
-            {REPO_FINDING_STATUS_FILTERS.map((value) => (
-              <option key={value} value={value}>
-                {formatTokenLabel(value)}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label>
-          Assignee
-          <input
-            type="text"
-            placeholder="Filter by assignee"
-            value={assigneeFilter}
-            onChange={(event) => setAssigneeFilter(event.target.value)}
-          />
-        </label>
-      </div>
+      <details className="idt-repo-filter-panel">
+        <summary>
+          <span>Filters and sorting</span>
+          <small>{filteredFindings.length ? `${filteredFindings.length} findings shown` : 'No findings in scope'}</small>
+        </summary>
+        <div className="idt-repo-finding-filters">
+          <label>
+            Repository scan
+            <select value={repoScanFilter} onChange={(event) => setRepoScanFilter(event.target.value)}>
+              <option value="">All repository scans</option>
+              {repoScans.map((scan) => (
+                <option key={scan.id} value={scan.id}>
+                  {canonicalGitHubRepositoryDisplay(scan.repository)} · {formatTokenLabel(scan.status)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Severity
+            <select
+              value={severityFilter}
+              onChange={(event) => setSeverityFilter(event.target.value as (typeof REPO_FINDING_SEVERITY_FILTERS)[number])}
+            >
+              {REPO_FINDING_SEVERITY_FILTERS.map((value) => (
+                <option key={value} value={value}>
+                  {value === 'all' ? 'All severities' : formatTokenLabel(value)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Type
+            <select value={typeFilter} onChange={(event) => setTypeFilter(event.target.value as (typeof REPO_FINDING_TYPE_FILTERS)[number])}>
+              {REPO_FINDING_TYPE_FILTERS.map((value) => (
+                <option key={value} value={value}>
+                  {value === 'all' ? 'All finding types' : formatTokenLabel(value)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Sort by
+            <select value={sortBy} onChange={(event) => setSortBy(event.target.value as (typeof REPO_FINDING_SORT_FIELDS)[number])}>
+              {REPO_FINDING_SORT_FIELDS.map((value) => (
+                <option key={value} value={value}>
+                  {SORT_LABEL_BY_FIELD[value]}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Sort order
+            <select value={sortOrder} onChange={(event) => setSortOrder(event.target.value as 'asc' | 'desc')}>
+              <option value="asc">Ascending</option>
+              <option value="desc">Descending</option>
+            </select>
+          </label>
+          <label>
+            Lifecycle status
+            <select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value as (typeof REPO_FINDING_STATUS_FILTERS)[number])}>
+              {REPO_FINDING_STATUS_FILTERS.map((value) => (
+                <option key={value} value={value}>
+                  {formatTokenLabel(value)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Assignee
+            <input
+              type="text"
+              placeholder="Filter by assignee"
+              value={assigneeFilter}
+              onChange={(event) => setAssigneeFilter(event.target.value)}
+            />
+          </label>
+        </div>
+      </details>
 
       <div className="idt-repo-finding-layout">
         <div className="idt-repo-finding-list">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -18286,6 +18286,8 @@ html[data-theme='light'] .idt-legal-contact-panel .idt-btn-primary {
   --app-warning: #f5c451;
   --app-danger: #ff6b6b;
   color: var(--app-text);
+  font-size: 1rem;
+  line-height: 1.5;
   letter-spacing: 0;
 }
 
@@ -18320,7 +18322,7 @@ html[data-theme='light'] .idt-legal-contact-panel .idt-btn-primary {
   top: 0;
   height: 100dvh;
   display: grid;
-  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  grid-template-rows: auto auto auto minmax(0, 1fr) auto;
   gap: 1rem;
   padding: 1rem;
   overflow-y: auto;
@@ -18414,6 +18416,161 @@ html[data-theme='light'] .idt-legal-contact-panel .idt-btn-primary {
   margin-top: 0.22rem;
   color: #ffffff;
   font-size: 0.88rem;
+}
+
+.idt-app-quick-find,
+html[data-theme='light'] .idt-app-quick-find {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 0.58rem 0.68rem;
+  background: #0b0b0c;
+  color: #ffffff;
+  font: inherit;
+  font-weight: 800;
+  text-align: left;
+  cursor: pointer;
+}
+
+.idt-app-quick-find span {
+  flex: 1 1 auto;
+}
+
+.idt-app-quick-find kbd,
+.idt-command-palette kbd {
+  min-width: 1.45rem;
+  border: 1px solid var(--app-border);
+  border-radius: 6px;
+  padding: 0.14rem 0.34rem;
+  background: #050505;
+  color: #d7d7dd;
+  font-family: var(--idt-mono);
+  font-size: 0.72rem;
+  font-weight: 800;
+  line-height: 1.25;
+  text-align: center;
+}
+
+.idt-app-quick-find:hover,
+.idt-app-quick-find:focus-visible {
+  border-color: #ffffff;
+  outline: none;
+}
+
+.idt-command-palette-backdrop {
+  --app-panel: #0a0a0b;
+  --app-border: #252529;
+  --app-muted: #b8b8c0;
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: grid;
+  place-items: start center;
+  padding: min(12vh, 7rem) 1rem 1rem;
+  background: rgba(0, 0, 0, 0.72);
+  backdrop-filter: blur(12px);
+}
+
+.idt-command-palette {
+  width: min(100%, 42rem);
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 0.9rem;
+  background: var(--app-panel);
+  color: #ffffff;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.55);
+}
+
+.idt-command-palette header,
+.idt-command-palette-results button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.idt-command-palette h2 {
+  margin: 0.15rem 0 0;
+  color: #ffffff;
+  font-family: var(--idt-display);
+  font-size: 1.45rem;
+  line-height: 1.05;
+}
+
+.idt-command-palette .idt-app-kicker {
+  color: #a3a3a3;
+}
+
+.idt-command-palette-close {
+  border: 1px solid var(--app-border);
+  border-radius: 999px;
+  padding: 0.35rem 0.55rem;
+  background: #111113;
+  color: #ffffff;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+.idt-command-palette input {
+  width: 100%;
+  margin: 0.95rem 0 0.75rem;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 0.85rem 0.9rem;
+  background: #050505;
+  color: #ffffff;
+  font: inherit;
+}
+
+.idt-command-palette input:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+
+.idt-command-palette-results {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.idt-command-palette-results button {
+  width: 100%;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 0.72rem;
+  background: transparent;
+  color: #ffffff;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.idt-command-palette-results button:hover,
+.idt-command-palette-results button:focus-visible {
+  border-color: #ffffff;
+  background: #111113;
+  outline: none;
+}
+
+.idt-command-palette-results strong,
+.idt-command-palette-results small {
+  display: block;
+}
+
+.idt-command-palette-results small {
+  margin-top: 0.1rem;
+  color: var(--app-muted);
+}
+
+.idt-command-palette-results p {
+  margin: 0;
+  border: 1px dashed var(--app-border);
+  border-radius: 8px;
+  padding: 0.95rem;
+  color: var(--app-muted);
 }
 
 .idt-app-console {
@@ -18560,7 +18717,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a.active {
   width: 100%;
   max-width: none;
   min-height: 0;
-  padding: 1.25rem clamp(1rem, 4vw, 3.5rem) 4rem;
+  padding: 1.45rem clamp(1.1rem, 4vw, 3.5rem) 4rem;
 }
 
 .idt-app-console-layout .idt-app-kicker,
@@ -18590,6 +18747,17 @@ html[data-theme='light'] .idt-executive-report-shell .idt-app-panel {
   box-shadow: none;
 }
 
+.idt-app-console-layout .idt-app-route-loading {
+  width: min(100%, 42rem);
+  margin: clamp(2rem, 14vh, 8rem) auto 0;
+  padding: 1.15rem;
+}
+
+.idt-app-console-layout .idt-app-route-loading h2 {
+  margin: 0.25rem 0 0.35rem;
+  font-size: clamp(1.55rem, 2vw, 1.95rem);
+}
+
 .idt-app-console-layout .idt-overview-page,
 .idt-app-console-layout .idt-workspace-admin,
 .idt-app-console-layout .idt-projects-page,
@@ -18600,7 +18768,7 @@ html[data-theme='light'] .idt-executive-report-shell .idt-app-panel {
   padding: 0;
   background: transparent;
   display: grid;
-  gap: 1rem;
+  gap: 1.15rem;
 }
 
 .idt-app-console-layout .idt-overview-header,
@@ -18611,7 +18779,7 @@ html[data-theme='light'] .idt-executive-report-shell .idt-app-panel {
 .idt-app-console-layout .idt-settings-header {
   border: 1px solid var(--app-border);
   border-radius: 8px;
-  padding: 1rem;
+  padding: 1.15rem;
   background: #080809;
 }
 
@@ -18639,7 +18807,7 @@ html[data-theme='light'] .idt-executive-report-shell .idt-app-panel {
 .idt-app-console-layout .idt-repo-findings-header h2,
 .idt-app-console-layout .idt-settings-header h2 {
   margin: 0.2rem 0 0.35rem;
-  font-size: clamp(1.65rem, 2.4vw, 2.2rem);
+  font-size: clamp(1.8rem, 2.4vw, 2.35rem);
   line-height: 1.02;
   text-transform: none;
 }
@@ -18652,6 +18820,8 @@ html[data-theme='light'] .idt-executive-report-shell .idt-app-panel {
 .idt-executive-report-shell p,
 .idt-executive-report-shell dd {
   color: var(--app-muted);
+  font-size: 0.98rem;
+  line-height: 1.55;
   overflow-wrap: anywhere;
 }
 
@@ -18682,7 +18852,7 @@ html[data-theme='light'] .idt-executive-report-shell .idt-executive-report-metri
   border-radius: 8px;
   background: var(--app-panel);
   color: var(--app-text);
-  padding: 0.9rem;
+  padding: 1rem;
 }
 
 .idt-app-console-layout .idt-overview-metrics span,
@@ -18773,7 +18943,7 @@ html[data-theme='light'] .idt-executive-report-shell .idt-executive-report-secti
 .idt-app-console-layout .idt-repo-finding-detail,
 .idt-app-console-layout .idt-repo-finding-trend,
 .idt-app-console-layout .idt-settings-card {
-  padding: 1rem;
+  padding: 1.15rem;
 }
 
 .idt-app-console-layout .idt-source-card:hover,
@@ -18944,17 +19114,17 @@ html[data-theme='light'] .idt-account-security-page label {
 
 .idt-app-console-layout .idt-workspace-table th:nth-child(1),
 .idt-app-console-layout .idt-workspace-table td:nth-child(1) {
-  width: 20%;
+  width: 34%;
 }
 
 .idt-app-console-layout .idt-workspace-table th:nth-child(2),
 .idt-app-console-layout .idt-workspace-table td:nth-child(2) {
-  width: 18%;
+  width: 16%;
 }
 
 .idt-app-console-layout .idt-workspace-table th:nth-child(5),
 .idt-app-console-layout .idt-workspace-table td:nth-child(5) {
-  width: 18%;
+  width: 16%;
 }
 
 .idt-app-console-layout .idt-workspace-table th,
@@ -18975,8 +19145,108 @@ html[data-theme='light'] .idt-account-security-page label {
   flex-wrap: wrap;
 }
 
+.idt-workspace-member-details,
+.idt-project-card-details,
+.idt-repo-filter-panel {
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: #080809;
+}
+
+.idt-workspace-member-details {
+  margin-top: 0.65rem;
+  background: transparent;
+}
+
+.idt-workspace-member-details summary,
+.idt-project-card-details summary,
+.idt-repo-filter-panel summary {
+  cursor: pointer;
+  color: #ffffff;
+  font-weight: 900;
+  line-height: 1.25;
+  list-style-position: inside;
+}
+
+.idt-workspace-member-details summary {
+  padding: 0.42rem 0.55rem;
+  font-size: 0.84rem;
+}
+
+.idt-workspace-member-details dl,
+.idt-project-card-meta {
+  display: grid;
+  gap: 0.6rem;
+  margin: 0;
+}
+
+.idt-workspace-member-details dl {
+  padding: 0 0.55rem 0.55rem;
+}
+
+.idt-workspace-member-details dt,
+.idt-project-card-meta dt,
+.idt-repo-filter-panel small {
+  color: var(--app-muted);
+  font-size: 0.75rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.idt-workspace-member-details dd,
+.idt-project-card-meta dd,
+html[data-theme='light'] .idt-workspace-member-details dd,
+html[data-theme='light'] .idt-project-card-meta dd {
+  margin: 0.15rem 0 0;
+  color: #ffffff;
+  font-size: 0.95rem;
+  overflow-wrap: anywhere;
+}
+
+.idt-project-card-details {
+  margin-top: 1rem;
+}
+
+.idt-project-card-details summary {
+  padding: 0.7rem 0.8rem;
+}
+
+.idt-project-card-details[open] summary {
+  border-bottom: 1px solid var(--app-border);
+}
+
+.idt-project-card-meta {
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  padding: 0.8rem;
+}
+
+.idt-project-card-meta div,
+html[data-theme='light'] .idt-app-console-layout .idt-project-card-meta div {
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 0.72rem;
+  background: #050505;
+}
+
+.idt-repo-filter-panel {
+  padding: 0;
+}
+
+.idt-repo-filter-panel summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+}
+
+.idt-repo-filter-panel[open] summary {
+  border-bottom: 1px solid var(--app-border);
+}
+
 .idt-app-console-layout .idt-repo-finding-filters {
   grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+  padding: 1rem;
 }
 
 .idt-app-console-layout .idt-repo-finding-row-top,


### PR DESCRIPTION
Fixes #1237

## Summary

- Add a workspace finder with the sidebar button plus `/`, `F`, and `Cmd/Ctrl+K` shortcuts.
- Replace disruptive full-page app route loading with inline loading states that keep the shell visible.
- Reduce console noise by moving project metadata, member IDs, and findings filters into expandable details.
- Tighten app console spacing, typography, and contrast so subtext and project details remain readable.

## Why

The app console was visually dense, small, and noisy across the workspace views. Route changes could temporarily collapse into a full loading page, and project metadata appeared as pale always-visible tiles that looked disabled. This makes the console easier to scan while keeping advanced details available when needed.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

Risk is limited to the React app shell, workspace/project/findings presentation, and app-console styling.

## Validation

```bash
npm --prefix web test -- --run src/productShell.test.tsx src/App.test.tsx
npm --prefix web run build
```

Also verified locally with the app API and Vite dev server that the workspace shell stays visible, the finder opens and routes to Projects, and project technical metadata is now behind the Project details disclosure.

## Checklist

- [x] Tests added/updated for behavior changes
- [ ] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: yes
- Tools used: OpenAI
- Areas where used: implementation, test updates, local validation
- Human verification performed: local tests, production build, and browser-based app-console verification

## Related Issues

Fixes #1237

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the app console with a quick workspace finder and inline route loading to keep the shell visible and reduce noise. Fixes #1237.

- **New Features**
  - Workspace finder with sidebar button and shortcuts: `/`, `F`, `Cmd/Ctrl+K`.
  - Jump to Overview, Projects, Findings, Workspaces, Settings, current project sources, plus executive report, account security, and sign out.
  - Moved project metadata, member IDs, and findings filters into expandable details to declutter views.
  - Tightened spacing, typography, and contrast for better scanability.

- **Bug Fixes**
  - Replaced full-page route loading with inline states across Workspaces, Projects, Project Detail, and Findings to prevent shell flicker.

<sup>Written for commit 1efb331a98466c0fa3f8ac035f99e704c6c6c92e. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1239?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

