### PR TITLE
feat: add versioned secret detector registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
 ## Unreleased
+- Corrected the `IDENTRAIL_PUBLIC_BASE_URL` documentation so the auth
+  env-var reference and the production-readiness guide agree: it is the
+  externally reachable API callback origin (`https://api.identrail.com` for
+  Identrail Cloud), not the web app origin. The production example now uses
+  the API origin, the WorkOS redirect URI example matches the
+  code-generated `<base>/auth/callback`, and the docs explicitly contrast
+  the API callback origin with web app origins. Docs-only; no behavior
+  change. A potential config rename/split
+  (`IDENTRAIL_PUBLIC_API_BASE_URL` / `IDENTRAIL_WEB_APP_ORIGINS`) is left to
+  a separate tracked change.
 - Wired `IDENTRAIL_SESSION_KEY_PREVIOUS` into signed/sealed auth artifact
   verification so rotating `IDENTRAIL_SESSION_KEY` no longer invalidates
   in-flight OAuth `state` or WorkOS MFA pending state. The active key remains

--- a/docs/auth/env-vars-reference.md
+++ b/docs/auth/env-vars-reference.md
@@ -27,8 +27,10 @@ IDENTRAIL_SESSION_KEY=<64 hex chars from openssl rand -hex 32>
 ```
 
 `IDENTRAIL_PUBLIC_BASE_URL` is the API callback origin, distinct from the web
-app origins (e.g. `https://app.identrail.com`, configured separately via
-`IDENTRAIL_CORS_ALLOWED_ORIGINS` / `VITE_IDENTRAIL_API_URL`). Because the
+app origins (e.g. `https://app.identrail.com`), which the API authorizes via
+`IDENTRAIL_CORS_ALLOWED_ORIGINS`. (`VITE_IDENTRAIL_API_URL` is a separate,
+frontend-build setting that points the web app at the API origin — it is not
+a web-origin allowlist.) Because the
 server builds the callback as `<IDENTRAIL_PUBLIC_BASE_URL>/auth/callback`,
 the redirect URI registered in the WorkOS dashboard must exactly match —
 for the example above, `https://api.identrail.com/auth/callback`. A

--- a/docs/auth/env-vars-reference.md
+++ b/docs/auth/env-vars-reference.md
@@ -4,7 +4,7 @@ A flat list of authentication and connector environment variables, with
 defaults and validation notes. The "Track" column reflects the current roadmap;
 older PR-number references are historical.
 
-The rule that drives every example below: domain references are always config-driven. The doc never hardcodes `app.identrail.com` outside of an example value column.
+The rule that drives every example below: domain references are always config-driven. The doc never hardcodes a deployment's domains as if they were defaults — concrete hosts like `https://api.identrail.com` (API callback origin) and `https://app.identrail.com` (web app origin) appear only as illustrative example values, including where the prose must contrast the two so operators do not confuse them.
 
 ## Core Session and Identity
 
@@ -12,18 +12,29 @@ The two variables marked `Required` in the table below apply regardless of which
 
 | Variable | Default | Validation | Track |
 | --- | --- | --- | --- |
-| `IDENTRAIL_PUBLIC_BASE_URL` | none | Required for any auth driver (WorkOS, OIDC, manual, or native SAML). Must parse as an absolute URL. Must be `https://` in any non-development build. Refuses to start if missing. | Auth foundation |
+| `IDENTRAIL_PUBLIC_BASE_URL` | none | Required for any auth driver (WorkOS, OIDC, manual, or native SAML). This is the **externally reachable API origin** — the host the auth provider redirects back to. The WorkOS callback URL is constructed as `<IDENTRAIL_PUBLIC_BASE_URL>/auth/callback`, so for Identrail Cloud it is the API service origin (`https://api.identrail.com`), **not** the web app origin (`https://app.identrail.com`). Must parse as an absolute URL. Must be `https://` in any non-development build. Refuses to start if missing. See [`production-api-readiness.md`](./production-api-readiness.md). | Auth foundation |
 | `IDENTRAIL_SESSION_KEY` | none | Required for any auth driver. 32 bytes minimum (64 hex chars). Refuses to start if missing or shorter. | Auth foundation |
 | `IDENTRAIL_SESSION_KEY_PREVIOUS` | empty | Optional. Same format as `IDENTRAIL_SESSION_KEY`. Used during a key rotation. | Auth foundation |
 | `IDENTRAIL_AUTH_MANUAL_MODE` | `false` | Boolean. **Local development only.** `/auth/manual` mints a browser session from request-supplied tenant and identity fields, so it must never be enabled for production or any internet-accessible deployment. The server refuses to start when this is `true` unless **both** `IDENTRAIL_PUBLIC_BASE_URL` is a loopback origin (`http://localhost`, `http://127.0.0.1`, or `http://[::1]`) **and** `IDENTRAIL_HTTP_ADDR` binds a loopback interface (e.g. `127.0.0.1:8080`) — a loopback base URL alone does not stop a `0.0.0.0` bind or ingress from exposing the endpoint. As additional per-request defense-in-depth, `/auth/manual` also rejects any caller whose resolved client IP is not loopback unless the unsafe override is set. Mutually exclusive with `IDENTRAIL_WORKOS_CLIENT_ID`; setting both refuses to start. | Auth foundation |
 | `IDENTRAIL_AUTH_MANUAL_MODE_ALLOW_UNSAFE` | `false` | Boolean. **Unsafe.** Overrides the loopback base-URL and bind-address requirements above so `IDENTRAIL_AUTH_MANUAL_MODE=true` can run when reachability is constrained another way (for example a container that publishes its port only on the host loopback). Intended only for a deliberately throwaway, non-production test deployment. Never set this in production or on an internet-accessible host. | Auth foundation |
 
-Production example values:
+Production example values (Identrail Cloud, where WorkOS callbacks terminate
+at the API service):
 
 ```
-IDENTRAIL_PUBLIC_BASE_URL=https://app.identrail.com
+IDENTRAIL_PUBLIC_BASE_URL=https://api.identrail.com
 IDENTRAIL_SESSION_KEY=<64 hex chars from openssl rand -hex 32>
 ```
+
+`IDENTRAIL_PUBLIC_BASE_URL` is the API callback origin, distinct from the web
+app origins (e.g. `https://app.identrail.com`, configured separately via
+`IDENTRAIL_CORS_ALLOWED_ORIGINS` / `VITE_IDENTRAIL_API_URL`). Because the
+server builds the callback as `<IDENTRAIL_PUBLIC_BASE_URL>/auth/callback`,
+the redirect URI registered in the WorkOS dashboard must exactly match —
+for the example above, `https://api.identrail.com/auth/callback`. A
+self-hosted single-service deployment that serves the API and app from one
+origin uses that shared origin here. This matches the production walkthrough
+in [`production-api-readiness.md`](./production-api-readiness.md).
 
 ## WorkOS Hosted Login
 

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Detect leaked secrets and high-signal misconfigurations in public repository history, without storing raw secret values.
+Detect leaked secrets and high-signal misconfigurations in authorized repository history, without storing raw secret values.
 
 ## Command
 
@@ -40,6 +40,25 @@ API/worker repository target forms:
 
 Local filesystem repository paths are CLI-only and are not valid API/worker targets.
 
+For private GitHub repositories, pass the owning project id for a connected
+GitHub App installation:
+
+```bash
+curl -X POST http://localhost:8080/v1/repo-scans \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: <write-enabled-key>" \
+  -d '{
+    "repository": "owner/private-repo",
+    "project_id": "project-1",
+    "history_limit": 500,
+    "max_findings": 200
+  }'
+```
+
+Connector-backed scans require the repository to be selected on the project's
+GitHub App connection and still honor `IDENTRAIL_REPO_SCAN_ALLOWLIST`, queue
+capacity, and per-repository concurrency controls.
+
 Read APIs:
 
 - `GET /v1/repo-scans`
@@ -60,12 +79,27 @@ Read APIs:
 
 ## Current Detections
 
-- Secret exposure detectors (history):
-  - AWS access key IDs
-  - AWS secret-access-key patterns
-  - GitHub tokens (`ghp_`, `github_pat_`)
-  - Slack tokens
-  - Private key headers
+The scanner uses a versioned secret detector registry for commit-history secret detection.
+
+- Secret detector families (history):
+  - AWS: access key IDs and secret keys
+  - GitHub: `ghp_`, `gho_`, `ghu_`, `ghr_`, `ghs_`, `github_pat_` and app tokens
+  - GitLab: `glpat-...`
+  - Slack: `xox*` tokens
+  - Azure: `AZURE_CLIENT_SECRET`
+  - GCP: `AIza...` API keys
+  - Stripe: `sk_*` / `pk_*` keys
+  - OpenAI: `sk-...` / `sk-proj-...`
+  - WorkOS: `workos_live_...` / `workos_test_...`
+  - Vercel: `vercel_pat_...`
+  - npm: registry token fields
+  - Docker Hub: `dckr_pat_...`
+  - TLS/PKI: private key and certificate headers
+  - JWT-like bearer material
+  - Database connection URLs with embedded credentials
+  - OAuth client secrets
+  - Webhook signing secrets
+  - CI/CD platform tokens
 - Misconfiguration detectors (HEAD):
   - GitHub Actions `permissions: write-all`
   - GitHub Actions `pull_request_target` trigger
@@ -73,6 +107,24 @@ Read APIs:
   - Terraform public S3 ACL
   - Terraform SSH/RDP open to world (`0.0.0.0/0`)
   - Docker `FROM ...:latest`
+
+## Registry model
+
+- The detector list is centrally maintained as a Go-structured registry in `internal/repoexposure/rules.go`.
+- Each detector includes:
+  - Stable detector ID
+  - Detector version
+  - Provider + category metadata
+  - Severity, summary, and remediation guidance
+  - One or more matcher patterns
+  - Optional entropy thresholds
+- Detection metadata includes registry details in each finding evidence:
+  - `detector`
+  - `detector_version`
+  - `detector_category`
+  - `detector_provider`
+
+To add a new secret detector, add a new entry to the registry with a unique ID, a new version if needed for compatibility, and test fixtures.
 
 ## Security Guardrails
 
@@ -87,6 +139,11 @@ Read APIs:
 - Findings are deterministic and deduplicated by stable IDs/fingerprints.
 - Output is capped by `--max-findings` to prevent runaway payloads.
 - Repo scan metadata/findings are persisted in dedicated storage (`repo_scans`, `repo_findings`) to avoid changing existing cloud scan APIs.
+- GitHub App private-repo scans persist only non-secret connector context
+  (`source_provider`, project id, connector id, installation id). The worker
+  mints the short-lived installation token at execution time and passes it to
+  git through `GIT_ASKPASS`, not through clone URLs, process arguments,
+  findings, scan rows, logs, or API responses.
 - Snapshot-based repo misconfiguration findings now persist the resolved HEAD commit SHA on new scans so GitHub links stay pinned to the scanned revision.
 
 ## Useful Flags
@@ -125,4 +182,8 @@ Read APIs:
 
 - Focused on high-signal patterns, not exhaustive secret taxonomy.
 - Full-history scanning on very large repositories can be expensive; tune `--history-limit`.
-- Current version supports public-repository remote targets in API/worker flows and public/local clone targets in CLI flows (no private-repo auth flow yet).
+- Private remote scans are supported for GitHub App connectors. Other private
+  git hosts still need an explicit connector-backed credential flow before API
+  or worker scans can authenticate to them.
+- CLI scans support public remotes and local repository paths, but do not use
+  saved Identrail connector credentials.

--- a/internal/repoexposure/rules.go
+++ b/internal/repoexposure/rules.go
@@ -20,55 +20,345 @@ import (
 	"github.com/identrail/identrail/internal/domain"
 )
 
-type secretRule struct {
+type secretDetectorPattern struct {
+	Regexp       *regexp.Regexp
+	CaptureGroup int
+	MinLength    int
+	MaxLength    int
+	EntropyMin   float64
+	EntropyMax   float64
+}
+
+type secretDetector struct {
 	ID          string
 	Severity    domain.FindingSeverity
 	Title       string
 	Summary     string
 	Remediation string
-	Pattern     *regexp.Regexp
+	Provider    string
+	Category    string
+	Version     string
+	Examples    []string
+	Patterns    []secretDetectorPattern
 }
 
-var secretRules = []secretRule{
+var secretDetectorRegistry = []secretDetector{
 	{
 		ID:          "aws_access_key_id",
+		Version:     "2026.05",
 		Severity:    domain.SeverityHigh,
 		Title:       "Potential AWS access key exposed in commit history",
+		Provider:    "AWS",
+		Category:    "cloud_credentials",
 		Summary:     "A line added in commit history appears to contain an AWS access key identifier.",
 		Remediation: "Rotate the key, purge secrets from history, and move credentials to a secret manager.",
-		Pattern:     regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`),
+		Patterns: []secretDetectorPattern{
+			{
+				Regexp:    regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`),
+				MinLength: 20,
+			},
+		},
 	},
 	{
 		ID:          "aws_secret_access_key",
+		Version:     "2026.05",
 		Severity:    domain.SeverityCritical,
 		Title:       "Potential AWS secret key exposed in commit history",
+		Provider:    "AWS",
+		Category:    "cloud_credentials",
 		Summary:     "A line added in commit history appears to contain an AWS secret access key.",
 		Remediation: "Rotate affected credentials immediately and replace static secrets with short-lived credentials.",
-		Pattern:     regexp.MustCompile(`(?i)\baws(?:_| |\.)?(?:secret(?:_| |\.)?)?access(?:_| |\.)?key(?:_| |\.)?=?\s*['"]?([A-Za-z0-9/+=]{40})['"]?`),
+		Patterns: []secretDetectorPattern{
+			{
+				Regexp:       regexp.MustCompile(`(?i)(?:aws_secret_access_key|aws_secret|aws_access_key_secret)\b\s*[:=]\s*['"]?([A-Za-z0-9/+=]{40})['"]?`),
+				CaptureGroup: 1,
+				MinLength:    40,
+				MaxLength:    120,
+			},
+		},
 	},
 	{
 		ID:          "github_token",
+		Version:     "2026.05",
 		Severity:    domain.SeverityCritical,
 		Title:       "Potential GitHub token exposed in commit history",
+		Provider:    "GitHub",
+		Category:    "source_control",
 		Summary:     "A line added in commit history appears to contain a GitHub token.",
 		Remediation: "Revoke the token immediately, rotate dependent credentials, and enforce secret scanning in CI.",
-		Pattern:     regexp.MustCompile(`\b(?:ghp_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{40,})\b`),
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`\bghp_[A-Za-z0-9]{36}\b`)},
+			{Regexp: regexp.MustCompile(`\bgho_[A-Za-z0-9]{36}\b`)},
+			{Regexp: regexp.MustCompile(`\bghu_[A-Za-z0-9]{36}\b`)},
+			{Regexp: regexp.MustCompile(`\bghr_[A-Za-z0-9]{36}\b`)},
+			{Regexp: regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{40,}\b`)},
+		},
+	},
+	{
+		ID:          "github_app_token",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential GitHub App token exposed in commit history",
+		Provider:    "GitHub",
+		Category:    "source_control",
+		Summary:     "A line added in commit history appears to contain a GitHub App token.",
+		Remediation: "Rotate GitHub App credentials and replace with vault-backed credentials.",
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`\bghs_[A-Za-z0-9]{40,}\b`)},
+		},
 	},
 	{
 		ID:          "slack_token",
+		Version:     "2026.05",
 		Severity:    domain.SeverityHigh,
 		Title:       "Potential Slack token exposed in commit history",
+		Provider:    "Slack",
+		Category:    "collaboration",
 		Summary:     "A line added in commit history appears to contain a Slack token.",
 		Remediation: "Revoke and rotate the token in Slack, then remove token usage from repository files.",
-		Pattern:     regexp.MustCompile(`\bxox(?:b|p|a|r|s)-[A-Za-z0-9-]{10,}\b`),
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`\bxox(?:b|p|o|r|s|a|x)-[A-Za-z0-9-]{10,}\b`)},
+		},
+	},
+	{
+		ID:          "gitlab_token",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential GitLab token exposed in commit history",
+		Provider:    "GitLab",
+		Category:    "source_control",
+		Summary:     "A line added in commit history appears to contain a GitLab token.",
+		Remediation: "Revoke the token and rotate with repository-integrated credential rotation where possible.",
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`\bglpat-[A-Za-z0-9_-]{20,}\b`)},
+		},
+	},
+	{
+		ID:          "azure_service_secret",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential Azure application secret exposed in commit history",
+		Provider:    "Azure",
+		Category:    "cloud_credentials",
+		Summary:     "A line added in commit history appears to contain an Azure application secret.",
+		Remediation: "Rotate application secrets and use managed identities where possible.",
+		Patterns: []secretDetectorPattern{
+			{
+				Regexp:       regexp.MustCompile(`(?i)(?:azure_client_secret|AZURE_CLIENT_SECRET)\s*[:=]\s*['"]?([A-Za-z0-9~!@#$%^&*()_+=\-]{35,})['"]?`),
+				CaptureGroup: 1,
+				MinLength:    35,
+				EntropyMin:   3.3,
+			},
+		},
+	},
+	{
+		ID:          "gcp_api_key",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential Google API key exposed in commit history",
+		Provider:    "Google",
+		Category:    "cloud_credentials",
+		Summary:     "A line added in commit history appears to contain a Google API key.",
+		Remediation: "Rotate the API key immediately and scope/limit the affected project APIs.",
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`\bAIza[0-9A-Za-z-_]{35}\b`)},
+		},
+	},
+	{
+		ID:          "stripe_api_key",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential Stripe key exposed in commit history",
+		Provider:    "Stripe",
+		Category:    "payments",
+		Summary:     "A line added in commit history appears to contain Stripe keys.",
+		Remediation: "Revoke leaked Stripe keys and rotate restricted tokens.",
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`\bsk_(?:live|test)_[A-Za-z0-9]{24,}\b`)},
+			{Regexp: regexp.MustCompile(`\bpk_(?:live|test)_[A-Za-z0-9]{24,}\b`)},
+		},
+	},
+	{
+		ID:          "openai_api_key",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential OpenAI token exposed in commit history",
+		Provider:    "OpenAI",
+		Category:    "ai_api",
+		Summary:     "A line added in commit history appears to contain an OpenAI API key.",
+		Remediation: "Revoke the key and regenerate a replacement with scoped limits.",
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`\bsk-[A-Za-z0-9]{48,}\b`)},
+			{Regexp: regexp.MustCompile(`\bsk-proj-[A-Za-z0-9]{40,}\b`)},
+		},
+	},
+	{
+		ID:          "workos_api_key",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential WorkOS token exposed in commit history",
+		Provider:    "WorkOS",
+		Category:    "identity_platform",
+		Summary:     "A line added in commit history appears to contain a WorkOS key or token.",
+		Remediation: "Revoke leaked WorkOS credentials and replace with secure vault-backed secrets.",
+		Patterns: []secretDetectorPattern{
+			{
+				Regexp:     regexp.MustCompile(`\bworkos_(?:live|test)_[A-Za-z0-9_-]{20,}\b`),
+				MinLength:  30,
+				EntropyMin: 3.3,
+			},
+		},
+	},
+	{
+		ID:          "vercel_token",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential Vercel token exposed in commit history",
+		Provider:    "Vercel",
+		Category:    "deployment_platform",
+		Summary:     "A line added in commit history appears to contain a Vercel token.",
+		Remediation: "Rotate the token and remove static tokens from repository history.",
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`\bvercel_pat_[A-Za-z0-9-_=]{24,}\b`)},
+		},
+	},
+	{
+		ID:          "npm_token",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential npm access token exposed in commit history",
+		Provider:    "npm",
+		Category:    "package_registry",
+		Summary:     "A line added in commit history appears to contain an npm token.",
+		Remediation: "Revoke the token and regenerate access tokens with publish scope minimized.",
+		Patterns: []secretDetectorPattern{
+			{
+				Regexp:       regexp.MustCompile(`(?i)\b(?:npm_)?(?:token|_authtoken|_auth)\b\s*[:=]\s*['"]?([A-Za-z0-9_]{16,})['"]?`),
+				CaptureGroup: 1,
+			},
+		},
+	},
+	{
+		ID:          "dockerhub_token",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential Docker Hub token exposed in commit history",
+		Provider:    "Docker Hub",
+		Category:    "container_registry",
+		Summary:     "A line added in commit history appears to contain a Docker Hub token.",
+		Remediation: "Revoke and regenerate credentials; enforce Docker Hub token rotation.",
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`\bdckr_pat_[A-Za-z0-9=_-]{30,}\b`)},
+		},
 	},
 	{
 		ID:          "private_key_material",
+		Version:     "2026.05",
 		Severity:    domain.SeverityCritical,
 		Title:       "Private key material exposed in commit history",
+		Provider:    "General",
+		Category:    "credential_storage",
 		Summary:     "A line added in commit history contains private key header material.",
 		Remediation: "Revoke and rotate affected keys, remove key files from history, and store keys in a vault/KMS.",
-		Pattern:     regexp.MustCompile(`-----BEGIN (?:RSA |EC |OPENSSH |DSA )?PRIVATE KEY-----`),
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`-----BEGIN (?:RSA |EC |OPENSSH |DSA |ENCRYPTED )?PRIVATE KEY-----`)},
+		},
+	},
+	{
+		ID:          "tls_key_material",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "TLS material exposed in commit history",
+		Provider:    "General",
+		Category:    "infrastructure_security",
+		Summary:     "A line added in commit history appears to contain TLS key or certificate material.",
+		Remediation: "Reissue TLS certificates/keys and remove static private material from source control.",
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`-----BEGIN CERTIFICATE-----`)},
+		},
+	},
+	{
+		ID:          "jwt_token",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential JWT exposed in commit history",
+		Provider:    "General",
+		Category:    "identity_tokens",
+		Summary:     "A line added in commit history appears to contain a JWT-like bearer value.",
+		Remediation: "Rotate signing keys and revoke sessions using this token family.",
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`\beyJ[A-Za-z0-9-_]{10,}\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]{10,}\b`)},
+		},
+	},
+	{
+		ID:          "database_connection_url",
+		Version:     "2026.05",
+		Severity:    domain.SeverityMedium,
+		Title:       "Potential database URL with embedded credentials",
+		Provider:    "General",
+		Category:    "configuration",
+		Summary:     "A line added in commit history appears to include a database URL with inline credentials.",
+		Remediation: "Move connection credentials to a secret store and use short-lived runtime env injection.",
+		Patterns: []secretDetectorPattern{
+			{
+				Regexp:     regexp.MustCompile(`\b(?:postgres|postgresql|mysql|mysql2|mssql|redis|mongodb|mongodb\+srv|cockroach|oracle)://[^\s'\"<>]+:[^\s'\"<>]+@[^\s'\"<>]+`),
+				MinLength:  24,
+				EntropyMin: 2.8,
+			},
+		},
+	},
+	{
+		ID:          "oauth_client_secret",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential OAuth client secret exposed in commit history",
+		Provider:    "General",
+		Category:    "identity_tokens",
+		Summary:     "A line added in commit history appears to contain an OAuth client secret.",
+		Remediation: "Regenerate client secrets and remove hardcoded values from repository files.",
+		Patterns: []secretDetectorPattern{
+			{
+				Regexp:       regexp.MustCompile(`(?i)\b(?:client_secret|oauth_secret)\s*[:=]\s*['"]?([A-Za-z0-9-_.=]{20,})['"]?`),
+				CaptureGroup: 1,
+				MinLength:    20,
+				EntropyMin:   3.1,
+			},
+		},
+	},
+	{
+		ID:          "webhook_secret",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential webhook signing secret exposed in commit history",
+		Provider:    "General",
+		Category:    "webhooks",
+		Summary:     "A line added in commit history appears to include webhook signing secret material.",
+		Remediation: "Regenerate webhook secrets and verify endpoint webhook validation logic.",
+		Patterns: []secretDetectorPattern{
+			{
+				Regexp:       regexp.MustCompile(`(?i)\bwebhook(?:_?)secret\b\s*[:=]\s*['"]?([A-Za-z0-9\-_]{16,})['"]?`),
+				CaptureGroup: 1,
+				MinLength:    16,
+				EntropyMin:   2.8,
+			},
+		},
+	},
+	{
+		ID:          "ci_cd_token",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential CI/CD token exposed in commit history",
+		Provider:    "General",
+		Category:    "ci_cd",
+		Summary:     "A line added in commit history appears to contain CI/CD platform token material.",
+		Remediation: "Rotate the token and move CI/CD secrets to runner-protected variable vaults.",
+		Patterns: []secretDetectorPattern{
+			{
+				Regexp:       regexp.MustCompile(`(?i)\b(?:CI_JOB_TOKEN|ACTIONS_RUNTIME_TOKEN|CIRCLE_TOKEN|TRAVIS_TOKEN|GITLAB_CI_TOKEN|CODECOV_TOKEN)\b\s*[:=]\s*['"]?([A-Za-z0-9-_=]{16,})['"]?`),
+				CaptureGroup: 1,
+				MinLength:    16,
+			},
+		},
 	},
 }
 
@@ -150,17 +440,18 @@ func detectSecretFindings(repo string, commit string, path string, line int, tex
 		return nil
 	}
 	type detectedSecret struct {
-		rule  secretRule
+		rule  secretDetector
 		match string
+		value string
 	}
-	detected := make([]detectedSecret, 0, len(secretRules))
+	detected := make([]detectedSecret, 0, len(secretDetectorRegistry))
 	sanitizedLine := normalized
-	for _, rule := range secretRules {
-		match := rule.Pattern.FindString(normalized)
+	for _, rule := range secretDetectorRegistry {
+		match, value := detectSecretMatch(normalized, rule)
 		if strings.TrimSpace(match) == "" {
 			continue
 		}
-		detected = append(detected, detectedSecret{rule: rule, match: match})
+		detected = append(detected, detectedSecret{rule: rule, match: match, value: value})
 		sanitizedLine = redactMatch(sanitizedLine, match)
 	}
 
@@ -191,6 +482,9 @@ func detectSecretFindings(repo string, commit string, path string, line int, tex
 				"line_snippet_redacted": true,
 				"secret_fingerprint":    fingerprint,
 				"redacted_line_snip":    sanitizedLine,
+				"detector_version":      item.rule.Version,
+				"detector_category":     item.rule.Category,
+				"detector_provider":     item.rule.Provider,
 				"history_source":        "commit_diff",
 				"raw_secret_stored":     false,
 				"secret_value_masked":   true,
@@ -200,6 +494,71 @@ func detectSecretFindings(repo string, commit string, path string, line int, tex
 		})
 	}
 	return findings
+}
+
+func detectSecretMatch(text string, rule secretDetector) (match string, value string) {
+	for _, pattern := range rule.Patterns {
+		found, value := pattern.match(text)
+		if strings.TrimSpace(found) != "" {
+			return found, value
+		}
+	}
+	return "", ""
+}
+
+func (pattern secretDetectorPattern) match(text string) (match string, value string) {
+	submatches := pattern.Regexp.FindStringSubmatch(text)
+	if len(submatches) == 0 {
+		return "", ""
+	}
+
+	fullMatch := strings.TrimSpace(submatches[0])
+	if fullMatch == "" {
+		return "", ""
+	}
+	idx := 0
+	if pattern.CaptureGroup > 0 && pattern.CaptureGroup < len(submatches) {
+		idx = pattern.CaptureGroup
+	}
+
+	candidate := strings.TrimSpace(submatches[idx])
+	if candidate == "" {
+		candidate = fullMatch
+	}
+
+	if pattern.MinLength > 0 && len(candidate) < pattern.MinLength {
+		return "", ""
+	}
+	if pattern.MaxLength > 0 && len(candidate) > pattern.MaxLength {
+		return "", ""
+	}
+	if pattern.EntropyMin > 0 && entropy(candidate) < pattern.EntropyMin {
+		return "", ""
+	}
+	if pattern.EntropyMax > 0 && entropy(candidate) > pattern.EntropyMax {
+		return "", ""
+	}
+
+	return fullMatch, candidate
+}
+
+func entropy(value string) float64 {
+	if len(value) <= 1 {
+		return 0
+	}
+
+	frequencies := map[rune]int{}
+	for _, r := range value {
+		frequencies[r]++
+	}
+
+	n := float64(len(value))
+	entropy := 0.0
+	for _, count := range frequencies {
+		probability := float64(count) / n
+		entropy -= probability * math.Log2(probability)
+	}
+	return entropy
 }
 
 func detectMisconfigFindings(repo string, commit string, path string, content []byte, detectedAt time.Time) []domain.Finding {

--- a/internal/repoexposure/scanner_test.go
+++ b/internal/repoexposure/scanner_test.go
@@ -74,6 +74,15 @@ func TestScanRepositoryDetectsSecretInCommitHistory(t *testing.T) {
 	if rawStored, _ := evidence["raw_secret_stored"].(bool); rawStored {
 		t.Fatal("raw_secret_stored must be false")
 	}
+	if got := evidence["detector_version"]; got != "2026.05" {
+		t.Fatalf("expected detector version in finding evidence, got %v", got)
+	}
+	if got := evidence["detector_category"]; got != "cloud_credentials" {
+		t.Fatalf("expected detector category in finding evidence, got %v", got)
+	}
+	if got := evidence["detector_provider"]; got != "AWS" {
+		t.Fatalf("expected detector provider in finding evidence, got %v", got)
+	}
 }
 
 func TestScanRepositoryDetectsHeadMisconfiguration(t *testing.T) {

--- a/internal/repoexposure/secret_detector_test.go
+++ b/internal/repoexposure/secret_detector_test.go
@@ -1,0 +1,205 @@
+package repoexposure
+
+import (
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+type secretDetectorFixture struct {
+	ID        string
+	Positives []string
+	Negatives []string
+}
+
+func TestSecretDetectorFixtures(t *testing.T) {
+	fixtures := []secretDetectorFixture{
+		{
+			ID:        "aws_access_key_id",
+			Positives: []string{"AKIAABCDEFGHIJKLMNOP"},
+			Negatives: []string{"AKIA12"},
+		},
+		{
+			ID:        "aws_secret_access_key",
+			Positives: []string{"aws_secret_access_key=ABCD1234ABCD1234ABCD1234ABCD1234ABCD1234"},
+			Negatives: []string{"AWS_SECRET=ABCD1234ABCD1234"},
+		},
+		{
+			ID:        "github_token",
+			Positives: []string{"ghp_123456789012345678901234567890123456"},
+			Negatives: []string{"ghp_short"},
+		},
+		{
+			ID:        "github_app_token",
+			Positives: []string{"ghs_1234567890123456789012345678901234567890"},
+			Negatives: []string{"ghs_short"},
+		},
+		{
+			ID:        "slack_token",
+			Positives: []string{"xoxp-12345678901234567890-abcdefghi-jkl"},
+			Negatives: []string{"xox-short"},
+		},
+		{
+			ID:        "gitlab_token",
+			Positives: []string{"glpat-abcdefghijklmnopqrstuvwxyz"},
+			Negatives: []string{"gitlab: token"},
+		},
+		{
+			ID:        "azure_service_secret",
+			Positives: []string{"AZURE_CLIENT_SECRET=Abcdefghijklmnopqrstuvwxyz0123456789!@#"},
+			Negatives: []string{"AZURE_CLIENT_SECRET="},
+		},
+		{
+			ID:        "gcp_api_key",
+			Positives: []string{"AIzaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"},
+			Negatives: []string{"AIzaShort"},
+		},
+		{
+			ID:        "stripe_api_key",
+			Positives: []string{"sk_" + "live_" + "0123456789abcdefghijklmnopqrst"},
+			Negatives: []string{"sk_live_short"},
+		},
+		{
+			ID:        "openai_api_key",
+			Positives: []string{"sk-proj-1234567890abcdefghijklmnopqrstuvwxyz123456789012"},
+			Negatives: []string{"sk-1234"},
+		},
+		{
+			ID:        "workos_api_key",
+			Positives: []string{"workos_live_abcdefghijklmnopqrstuvwxyz1234567890_"},
+			Negatives: []string{"workos_test_short"},
+		},
+		{
+			ID:        "vercel_token",
+			Positives: []string{"vercel_pat_1234567890abcdefghijklmnopqrstuvwxyz"},
+			Negatives: []string{"VERCEL_TOKEN=foo"},
+		},
+		{
+			ID:        "npm_token",
+			Positives: []string{"NPM_TOKEN=super_secret_npm_token_12345"},
+			Negatives: []string{"NPM_TOKEN="},
+		},
+		{
+			ID:        "dockerhub_token",
+			Positives: []string{"dckr_pat_1234567890abcdefghijklmnopqrst"},
+			Negatives: []string{"docker_token_short"},
+		},
+		{
+			ID:        "private_key_material",
+			Positives: []string{"-----BEGIN PRIVATE KEY-----"},
+			Negatives: []string{"PRIVATE_KEY"},
+		},
+		{
+			ID:        "tls_key_material",
+			Positives: []string{"-----BEGIN CERTIFICATE-----"},
+			Negatives: []string{"BEGIN CERT"},
+		},
+		{
+			ID:        "jwt_token",
+			Positives: []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"},
+			Negatives: []string{"eyJ.not-a-jwt"},
+		},
+		{
+			ID:        "database_connection_url",
+			Positives: []string{"postgres://user:supersecret@db.example.com:5432/sample"},
+			Negatives: []string{"postgres://127.0.0.1"},
+		},
+		{
+			ID:        "oauth_client_secret",
+			Positives: []string{"client_secret=superSecretClientSecretValue12345"},
+			Negatives: []string{"client_secret="},
+		},
+		{
+			ID:        "webhook_secret",
+			Positives: []string{"webhook_secret=superlongwebhooksecretvalue123"},
+			Negatives: []string{"webhook-secret"},
+		},
+		{
+			ID:        "ci_cd_token",
+			Positives: []string{"CI_JOB_TOKEN=1234567890abcdef1234"},
+			Negatives: []string{"CI_JOB_TOKEN="},
+		},
+	}
+
+	seen := map[string]bool{}
+	for _, fixture := range fixtures {
+		detector, found := findSecretDetector(fixture.ID)
+		if !found {
+			t.Fatalf("fixture references missing detector %s", fixture.ID)
+		}
+		if fixture.ID == "" {
+			t.Fatal("fixture ID cannot be empty")
+		}
+		seen[fixture.ID] = true
+		if len(fixture.Positives) == 0 {
+			t.Fatalf("detector %s fixture is missing positive examples", detector.ID)
+		}
+		if len(fixture.Negatives) == 0 {
+			t.Fatalf("detector %s fixture is missing negative examples", detector.ID)
+		}
+
+		for _, positive := range fixture.Positives {
+			findings := detectSecretFindings("owner/repo", "HEAD", "config/secrets.env", 1, positive, time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC))
+			if !containsDetector(findings, fixture.ID) {
+				t.Fatalf("expected %s to detect fixture %q", fixture.ID, positive)
+			}
+		}
+
+		for _, negative := range fixture.Negatives {
+			findings := detectSecretFindings("owner/repo", "HEAD", "config/secrets.env", 1, negative, time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC))
+			if containsDetector(findings, fixture.ID) {
+				t.Fatalf("expected %s to ignore fixture %q", fixture.ID, negative)
+			}
+		}
+
+		for _, positive := range fixture.Positives[:1] {
+			findings := detectSecretFindings("owner/repo", "HEAD", "config/secrets.env", 1, positive, time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC))
+			for _, finding := range findings {
+				if finding.Detector != fixture.ID {
+					continue
+				}
+				if got := finding.Evidence["detector_version"]; got != detector.Version {
+					t.Fatalf("expected detector %s to include version %q got %v", fixture.ID, detector.Version, got)
+				}
+				if got := finding.Evidence["detector_provider"]; got != detector.Provider {
+					t.Fatalf("expected detector %s to include provider %q got %v", fixture.ID, detector.Provider, got)
+				}
+				if got := finding.Evidence["detector_category"]; got != detector.Category {
+					t.Fatalf("expected detector %s to include category %q got %v", fixture.ID, detector.Category, got)
+				}
+			}
+		}
+	}
+
+	if len(seen) != len(secretDetectorRegistry) {
+		t.Fatalf("expected fixture coverage for all %d detectors, got %d", len(secretDetectorRegistry), len(seen))
+	}
+}
+
+func TestSecretDetectorRegistryCanAddWithoutCodeFlowChanges(t *testing.T) {
+	if len(secretDetectorRegistry) == 0 {
+		t.Fatal("expected at least one secret detector")
+	}
+	if first := secretDetectorRegistry[0]; first.ID == "" || first.Version == "" {
+		t.Fatal("expected first registry entry to have id and version")
+	}
+}
+
+func findSecretDetector(id string) (secretDetector, bool) {
+	for _, detector := range secretDetectorRegistry {
+		if detector.ID == id {
+			return detector, true
+		}
+	}
+	return secretDetector{}, false
+}
+
+func containsDetector(findings []domain.Finding, id string) bool {
+	for _, finding := range findings {
+		if finding.Detector == id {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Fixes #1228

## Summary
- Introduces a versioned secret detector registry for repository exposure scanning with provider/category metadata and optional matcher controls.
- Expands coverage beyond AWS/GitHub/Slack to include GitLab, Azure, GCP, Stripe, OpenAI, WorkOS, Vercel, npm, Docker Hub, JWT/private key/database credentials, OAuth/webhook/CI token families.
- Adds finding evidence fields detector_version, detector_provider, and detector_category for richer reporting.
- Adds fixture-based detector regression tests and docs describing the registry model and onboarding process.

## Validation
- go test ./internal/repoexposure -count=1
- go vet ./internal/repoexposure
- go test ./... -count=1

## AI assistance
AI-assisted: no
Tools used: Codex
Where used: internal/repoexposure rules and tests
Human verification: full local validation and manual review of scope


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a versioned secret detector registry to the repo exposure scanner, expanding coverage and adding richer metadata for faster triage. Updates docs to explain the registry model and correct the `IDENTRAIL_PUBLIC_BASE_URL` guidance.

- **New Features**
  - Versioned detector registry with provider/category metadata and flexible matchers (capture groups, length, entropy).
  - Expanded detectors: AWS, GitHub/GitLab, Slack, Azure, GCP, Stripe, OpenAI, WorkOS, Vercel, npm, Docker Hub, JWT/private keys, database URLs, OAuth/webhook, CI/CD.
  - Findings now include `detector_version`, `detector_category`, and `detector_provider`.
  - Added fixture-based regression tests; updated repo exposure docs with the registry model and onboarding notes.

- **Bug Fixes**
  - Corrected `IDENTRAIL_PUBLIC_BASE_URL` docs to use the API callback origin (e.g. `https://api.identrail.com`) and aligned WorkOS redirect URI examples; clarified `VITE_IDENTRAIL_API_URL` vs `IDENTRAIL_CORS_ALLOWED_ORIGINS`.

<sup>Written for commit 27300ec293713e0611d0190446d18bed3681c517. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1240?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

