### PR TITLE
feat: add versioned secret detector registry

### DIFF
--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -79,12 +79,27 @@ Read APIs:
 
 ## Current Detections
 
-- Secret exposure detectors (history):
-  - AWS access key IDs
-  - AWS secret-access-key patterns
-  - GitHub tokens (`ghp_`, `github_pat_`)
-  - Slack tokens
-  - Private key headers
+The scanner uses a versioned secret detector registry for commit-history secret detection.
+
+- Secret detector families (history):
+  - AWS: access key IDs and secret keys
+  - GitHub: `ghp_`, `gho_`, `ghu_`, `ghr_`, `ghs_`, `github_pat_` and app tokens
+  - GitLab: `glpat-...`
+  - Slack: `xox*` tokens
+  - Azure: `AZURE_CLIENT_SECRET`
+  - GCP: `AIza...` API keys
+  - Stripe: `sk_*` / `pk_*` keys
+  - OpenAI: `sk-...` / `sk-proj-...`
+  - WorkOS: `workos_live_...` / `workos_test_...`
+  - Vercel: `vercel_pat_...`
+  - npm: registry token fields
+  - Docker Hub: `dckr_pat_...`
+  - TLS/PKI: private key and certificate headers
+  - JWT-like bearer material
+  - Database connection URLs with embedded credentials
+  - OAuth client secrets
+  - Webhook signing secrets
+  - CI/CD platform tokens
 - Misconfiguration detectors (HEAD):
   - GitHub Actions `permissions: write-all`
   - GitHub Actions `pull_request_target` trigger
@@ -92,6 +107,24 @@ Read APIs:
   - Terraform public S3 ACL
   - Terraform SSH/RDP open to world (`0.0.0.0/0`)
   - Docker `FROM ...:latest`
+
+## Registry model
+
+- The detector list is centrally maintained as a Go-structured registry in `internal/repoexposure/rules.go`.
+- Each detector includes:
+  - Stable detector ID
+  - Detector version
+  - Provider + category metadata
+  - Severity, summary, and remediation guidance
+  - One or more matcher patterns
+  - Optional entropy thresholds
+- Detection metadata includes registry details in each finding evidence:
+  - `detector`
+  - `detector_version`
+  - `detector_category`
+  - `detector_provider`
+
+To add a new secret detector, add a new entry to the registry with a unique ID, a new version if needed for compatibility, and test fixtures.
 
 ## Security Guardrails
 

--- a/internal/repoexposure/rules.go
+++ b/internal/repoexposure/rules.go
@@ -20,55 +20,345 @@ import (
 	"github.com/identrail/identrail/internal/domain"
 )
 
-type secretRule struct {
+type secretDetectorPattern struct {
+	Regexp       *regexp.Regexp
+	CaptureGroup int
+	MinLength    int
+	MaxLength    int
+	EntropyMin   float64
+	EntropyMax   float64
+}
+
+type secretDetector struct {
 	ID          string
 	Severity    domain.FindingSeverity
 	Title       string
 	Summary     string
 	Remediation string
-	Pattern     *regexp.Regexp
+	Provider    string
+	Category    string
+	Version     string
+	Examples    []string
+	Patterns    []secretDetectorPattern
 }
 
-var secretRules = []secretRule{
+var secretDetectorRegistry = []secretDetector{
 	{
 		ID:          "aws_access_key_id",
+		Version:     "2026.05",
 		Severity:    domain.SeverityHigh,
 		Title:       "Potential AWS access key exposed in commit history",
+		Provider:    "AWS",
+		Category:    "cloud_credentials",
 		Summary:     "A line added in commit history appears to contain an AWS access key identifier.",
 		Remediation: "Rotate the key, purge secrets from history, and move credentials to a secret manager.",
-		Pattern:     regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`),
+		Patterns: []secretDetectorPattern{
+			{
+				Regexp:    regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`),
+				MinLength: 20,
+			},
+		},
 	},
 	{
 		ID:          "aws_secret_access_key",
+		Version:     "2026.05",
 		Severity:    domain.SeverityCritical,
 		Title:       "Potential AWS secret key exposed in commit history",
+		Provider:    "AWS",
+		Category:    "cloud_credentials",
 		Summary:     "A line added in commit history appears to contain an AWS secret access key.",
 		Remediation: "Rotate affected credentials immediately and replace static secrets with short-lived credentials.",
-		Pattern:     regexp.MustCompile(`(?i)\baws(?:_| |\.)?(?:secret(?:_| |\.)?)?access(?:_| |\.)?key(?:_| |\.)?=?\s*['"]?([A-Za-z0-9/+=]{40})['"]?`),
+		Patterns: []secretDetectorPattern{
+			{
+				Regexp:       regexp.MustCompile(`(?i)(?:aws_secret_access_key|aws_secret|aws_access_key_secret)\b\s*[:=]\s*['"]?([A-Za-z0-9/+=]{40})['"]?`),
+				CaptureGroup: 1,
+				MinLength:    40,
+				MaxLength:    120,
+			},
+		},
 	},
 	{
 		ID:          "github_token",
+		Version:     "2026.05",
 		Severity:    domain.SeverityCritical,
 		Title:       "Potential GitHub token exposed in commit history",
+		Provider:    "GitHub",
+		Category:    "source_control",
 		Summary:     "A line added in commit history appears to contain a GitHub token.",
 		Remediation: "Revoke the token immediately, rotate dependent credentials, and enforce secret scanning in CI.",
-		Pattern:     regexp.MustCompile(`\b(?:ghp_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{40,})\b`),
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`\bghp_[A-Za-z0-9]{36}\b`)},
+			{Regexp: regexp.MustCompile(`\bgho_[A-Za-z0-9]{36}\b`)},
+			{Regexp: regexp.MustCompile(`\bghu_[A-Za-z0-9]{36}\b`)},
+			{Regexp: regexp.MustCompile(`\bghr_[A-Za-z0-9]{36}\b`)},
+			{Regexp: regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{40,}\b`)},
+		},
+	},
+	{
+		ID:          "github_app_token",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential GitHub App token exposed in commit history",
+		Provider:    "GitHub",
+		Category:    "source_control",
+		Summary:     "A line added in commit history appears to contain a GitHub App token.",
+		Remediation: "Rotate GitHub App credentials and replace with vault-backed credentials.",
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`\bghs_[A-Za-z0-9]{40,}\b`)},
+		},
 	},
 	{
 		ID:          "slack_token",
+		Version:     "2026.05",
 		Severity:    domain.SeverityHigh,
 		Title:       "Potential Slack token exposed in commit history",
+		Provider:    "Slack",
+		Category:    "collaboration",
 		Summary:     "A line added in commit history appears to contain a Slack token.",
 		Remediation: "Revoke and rotate the token in Slack, then remove token usage from repository files.",
-		Pattern:     regexp.MustCompile(`\bxox(?:b|p|a|r|s)-[A-Za-z0-9-]{10,}\b`),
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`\bxox(?:b|p|o|r|s|a|x)-[A-Za-z0-9-]{10,}\b`)},
+		},
+	},
+	{
+		ID:          "gitlab_token",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential GitLab token exposed in commit history",
+		Provider:    "GitLab",
+		Category:    "source_control",
+		Summary:     "A line added in commit history appears to contain a GitLab token.",
+		Remediation: "Revoke the token and rotate with repository-integrated credential rotation where possible.",
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`\bglpat-[A-Za-z0-9_-]{20,}\b`)},
+		},
+	},
+	{
+		ID:          "azure_service_secret",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential Azure application secret exposed in commit history",
+		Provider:    "Azure",
+		Category:    "cloud_credentials",
+		Summary:     "A line added in commit history appears to contain an Azure application secret.",
+		Remediation: "Rotate application secrets and use managed identities where possible.",
+		Patterns: []secretDetectorPattern{
+			{
+				Regexp:       regexp.MustCompile(`(?i)(?:azure_client_secret|AZURE_CLIENT_SECRET)\s*[:=]\s*['"]?([A-Za-z0-9~!@#$%^&*()_+=\-]{35,})['"]?`),
+				CaptureGroup: 1,
+				MinLength:    35,
+				EntropyMin:   3.3,
+			},
+		},
+	},
+	{
+		ID:          "gcp_api_key",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential Google API key exposed in commit history",
+		Provider:    "Google",
+		Category:    "cloud_credentials",
+		Summary:     "A line added in commit history appears to contain a Google API key.",
+		Remediation: "Rotate the API key immediately and scope/limit the affected project APIs.",
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`\bAIza[0-9A-Za-z-_]{35}\b`)},
+		},
+	},
+	{
+		ID:          "stripe_api_key",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential Stripe key exposed in commit history",
+		Provider:    "Stripe",
+		Category:    "payments",
+		Summary:     "A line added in commit history appears to contain Stripe keys.",
+		Remediation: "Revoke leaked Stripe keys and rotate restricted tokens.",
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`\bsk_(?:live|test)_[A-Za-z0-9]{24,}\b`)},
+			{Regexp: regexp.MustCompile(`\bpk_(?:live|test)_[A-Za-z0-9]{24,}\b`)},
+		},
+	},
+	{
+		ID:          "openai_api_key",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential OpenAI token exposed in commit history",
+		Provider:    "OpenAI",
+		Category:    "ai_api",
+		Summary:     "A line added in commit history appears to contain an OpenAI API key.",
+		Remediation: "Revoke the key and regenerate a replacement with scoped limits.",
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`\bsk-[A-Za-z0-9]{48,}\b`)},
+			{Regexp: regexp.MustCompile(`\bsk-proj-[A-Za-z0-9]{40,}\b`)},
+		},
+	},
+	{
+		ID:          "workos_api_key",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential WorkOS token exposed in commit history",
+		Provider:    "WorkOS",
+		Category:    "identity_platform",
+		Summary:     "A line added in commit history appears to contain a WorkOS key or token.",
+		Remediation: "Revoke leaked WorkOS credentials and replace with secure vault-backed secrets.",
+		Patterns: []secretDetectorPattern{
+			{
+				Regexp:     regexp.MustCompile(`\bworkos_(?:live|test)_[A-Za-z0-9_-]{20,}\b`),
+				MinLength:  30,
+				EntropyMin: 3.3,
+			},
+		},
+	},
+	{
+		ID:          "vercel_token",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential Vercel token exposed in commit history",
+		Provider:    "Vercel",
+		Category:    "deployment_platform",
+		Summary:     "A line added in commit history appears to contain a Vercel token.",
+		Remediation: "Rotate the token and remove static tokens from repository history.",
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`\bvercel_pat_[A-Za-z0-9-_=]{24,}\b`)},
+		},
+	},
+	{
+		ID:          "npm_token",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential npm access token exposed in commit history",
+		Provider:    "npm",
+		Category:    "package_registry",
+		Summary:     "A line added in commit history appears to contain an npm token.",
+		Remediation: "Revoke the token and regenerate access tokens with publish scope minimized.",
+		Patterns: []secretDetectorPattern{
+			{
+				Regexp:       regexp.MustCompile(`(?i)\b(?:npm_)?(?:token|_authtoken|_auth)\b\s*[:=]\s*['"]?([A-Za-z0-9_]{16,})['"]?`),
+				CaptureGroup: 1,
+			},
+		},
+	},
+	{
+		ID:          "dockerhub_token",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential Docker Hub token exposed in commit history",
+		Provider:    "Docker Hub",
+		Category:    "container_registry",
+		Summary:     "A line added in commit history appears to contain a Docker Hub token.",
+		Remediation: "Revoke and regenerate credentials; enforce Docker Hub token rotation.",
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`\bdckr_pat_[A-Za-z0-9=_-]{30,}\b`)},
+		},
 	},
 	{
 		ID:          "private_key_material",
+		Version:     "2026.05",
 		Severity:    domain.SeverityCritical,
 		Title:       "Private key material exposed in commit history",
+		Provider:    "General",
+		Category:    "credential_storage",
 		Summary:     "A line added in commit history contains private key header material.",
 		Remediation: "Revoke and rotate affected keys, remove key files from history, and store keys in a vault/KMS.",
-		Pattern:     regexp.MustCompile(`-----BEGIN (?:RSA |EC |OPENSSH |DSA )?PRIVATE KEY-----`),
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`-----BEGIN (?:RSA |EC |OPENSSH |DSA |ENCRYPTED )?PRIVATE KEY-----`)},
+		},
+	},
+	{
+		ID:          "tls_key_material",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "TLS material exposed in commit history",
+		Provider:    "General",
+		Category:    "infrastructure_security",
+		Summary:     "A line added in commit history appears to contain TLS key or certificate material.",
+		Remediation: "Reissue TLS certificates/keys and remove static private material from source control.",
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`-----BEGIN CERTIFICATE-----`)},
+		},
+	},
+	{
+		ID:          "jwt_token",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential JWT exposed in commit history",
+		Provider:    "General",
+		Category:    "identity_tokens",
+		Summary:     "A line added in commit history appears to contain a JWT-like bearer value.",
+		Remediation: "Rotate signing keys and revoke sessions using this token family.",
+		Patterns: []secretDetectorPattern{
+			{Regexp: regexp.MustCompile(`\beyJ[A-Za-z0-9-_]{10,}\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]{10,}\b`)},
+		},
+	},
+	{
+		ID:          "database_connection_url",
+		Version:     "2026.05",
+		Severity:    domain.SeverityMedium,
+		Title:       "Potential database URL with embedded credentials",
+		Provider:    "General",
+		Category:    "configuration",
+		Summary:     "A line added in commit history appears to include a database URL with inline credentials.",
+		Remediation: "Move connection credentials to a secret store and use short-lived runtime env injection.",
+		Patterns: []secretDetectorPattern{
+			{
+				Regexp:     regexp.MustCompile(`\b(?:postgres|postgresql|mysql|mysql2|mssql|redis|mongodb|mongodb\+srv|cockroach|oracle)://[^\s'\"<>]+:[^\s'\"<>]+@[^\s'\"<>]+`),
+				MinLength:  24,
+				EntropyMin: 2.8,
+			},
+		},
+	},
+	{
+		ID:          "oauth_client_secret",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential OAuth client secret exposed in commit history",
+		Provider:    "General",
+		Category:    "identity_tokens",
+		Summary:     "A line added in commit history appears to contain an OAuth client secret.",
+		Remediation: "Regenerate client secrets and remove hardcoded values from repository files.",
+		Patterns: []secretDetectorPattern{
+			{
+				Regexp:       regexp.MustCompile(`(?i)\b(?:client_secret|oauth_secret)\s*[:=]\s*['"]?([A-Za-z0-9-_.=]{20,})['"]?`),
+				CaptureGroup: 1,
+				MinLength:    20,
+				EntropyMin:   3.1,
+			},
+		},
+	},
+	{
+		ID:          "webhook_secret",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential webhook signing secret exposed in commit history",
+		Provider:    "General",
+		Category:    "webhooks",
+		Summary:     "A line added in commit history appears to include webhook signing secret material.",
+		Remediation: "Regenerate webhook secrets and verify endpoint webhook validation logic.",
+		Patterns: []secretDetectorPattern{
+			{
+				Regexp:       regexp.MustCompile(`(?i)\bwebhook(?:_?)secret\b\s*[:=]\s*['"]?([A-Za-z0-9\-_]{16,})['"]?`),
+				CaptureGroup: 1,
+				MinLength:    16,
+				EntropyMin:   2.8,
+			},
+		},
+	},
+	{
+		ID:          "ci_cd_token",
+		Version:     "2026.05",
+		Severity:    domain.SeverityHigh,
+		Title:       "Potential CI/CD token exposed in commit history",
+		Provider:    "General",
+		Category:    "ci_cd",
+		Summary:     "A line added in commit history appears to contain CI/CD platform token material.",
+		Remediation: "Rotate the token and move CI/CD secrets to runner-protected variable vaults.",
+		Patterns: []secretDetectorPattern{
+			{
+				Regexp:       regexp.MustCompile(`(?i)\b(?:CI_JOB_TOKEN|ACTIONS_RUNTIME_TOKEN|CIRCLE_TOKEN|TRAVIS_TOKEN|GITLAB_CI_TOKEN|CODECOV_TOKEN)\b\s*[:=]\s*['"]?([A-Za-z0-9-_=]{16,})['"]?`),
+				CaptureGroup: 1,
+				MinLength:    16,
+			},
+		},
 	},
 }
 
@@ -150,23 +440,28 @@ func detectSecretFindings(repo string, commit string, path string, line int, tex
 		return nil
 	}
 	type detectedSecret struct {
-		rule  secretRule
+		rule  secretDetector
 		match string
+		value string
 	}
-	detected := make([]detectedSecret, 0, len(secretRules))
+	detected := make([]detectedSecret, 0, len(secretDetectorRegistry))
 	sanitizedLine := normalized
-	for _, rule := range secretRules {
-		match := rule.Pattern.FindString(normalized)
+	for _, rule := range secretDetectorRegistry {
+		match, value := detectSecretMatch(normalized, rule)
 		if strings.TrimSpace(match) == "" {
 			continue
 		}
-		detected = append(detected, detectedSecret{rule: rule, match: match})
+		detected = append(detected, detectedSecret{rule: rule, match: match, value: value})
 		sanitizedLine = redactMatch(sanitizedLine, match)
 	}
 
 	findings := make([]domain.Finding, 0, len(detected))
 	for _, item := range detected {
-		fingerprint := hashSHA256(item.match)
+		secretMaterial := strings.TrimSpace(item.value)
+		if secretMaterial == "" {
+			secretMaterial = item.match
+		}
+		fingerprint := hashSHA256(secretMaterial)
 		id := hashDeterministicID("repo-secret", repo, commit, path, strconv.Itoa(line), item.rule.ID, fingerprint)
 		findings = append(findings, domain.Finding{
 			ID:                  "finding:" + id,
@@ -191,6 +486,9 @@ func detectSecretFindings(repo string, commit string, path string, line int, tex
 				"line_snippet_redacted": true,
 				"secret_fingerprint":    fingerprint,
 				"redacted_line_snip":    sanitizedLine,
+				"detector_version":      item.rule.Version,
+				"detector_category":     item.rule.Category,
+				"detector_provider":     item.rule.Provider,
 				"history_source":        "commit_diff",
 				"raw_secret_stored":     false,
 				"secret_value_masked":   true,
@@ -200,6 +498,71 @@ func detectSecretFindings(repo string, commit string, path string, line int, tex
 		})
 	}
 	return findings
+}
+
+func detectSecretMatch(text string, rule secretDetector) (match string, value string) {
+	for _, pattern := range rule.Patterns {
+		found, value := pattern.match(text)
+		if strings.TrimSpace(found) != "" {
+			return found, value
+		}
+	}
+	return "", ""
+}
+
+func (pattern secretDetectorPattern) match(text string) (match string, value string) {
+	submatches := pattern.Regexp.FindStringSubmatch(text)
+	if len(submatches) == 0 {
+		return "", ""
+	}
+
+	fullMatch := strings.TrimSpace(submatches[0])
+	if fullMatch == "" {
+		return "", ""
+	}
+	idx := 0
+	if pattern.CaptureGroup > 0 && pattern.CaptureGroup < len(submatches) {
+		idx = pattern.CaptureGroup
+	}
+
+	candidate := strings.TrimSpace(submatches[idx])
+	if candidate == "" {
+		candidate = fullMatch
+	}
+
+	if pattern.MinLength > 0 && len(candidate) < pattern.MinLength {
+		return "", ""
+	}
+	if pattern.MaxLength > 0 && len(candidate) > pattern.MaxLength {
+		return "", ""
+	}
+	if pattern.EntropyMin > 0 && entropy(candidate) < pattern.EntropyMin {
+		return "", ""
+	}
+	if pattern.EntropyMax > 0 && entropy(candidate) > pattern.EntropyMax {
+		return "", ""
+	}
+
+	return fullMatch, candidate
+}
+
+func entropy(value string) float64 {
+	if len(value) <= 1 {
+		return 0
+	}
+
+	frequencies := map[rune]int{}
+	for _, r := range value {
+		frequencies[r]++
+	}
+
+	n := float64(len(value))
+	entropy := 0.0
+	for _, count := range frequencies {
+		probability := float64(count) / n
+		entropy -= probability * math.Log2(probability)
+	}
+	return entropy
 }
 
 func detectMisconfigFindings(repo string, commit string, path string, content []byte, detectedAt time.Time) []domain.Finding {

--- a/internal/repoexposure/scanner_test.go
+++ b/internal/repoexposure/scanner_test.go
@@ -74,6 +74,15 @@ func TestScanRepositoryDetectsSecretInCommitHistory(t *testing.T) {
 	if rawStored, _ := evidence["raw_secret_stored"].(bool); rawStored {
 		t.Fatal("raw_secret_stored must be false")
 	}
+	if got := evidence["detector_version"]; got != "2026.05" {
+		t.Fatalf("expected detector version in finding evidence, got %v", got)
+	}
+	if got := evidence["detector_category"]; got != "cloud_credentials" {
+		t.Fatalf("expected detector category in finding evidence, got %v", got)
+	}
+	if got := evidence["detector_provider"]; got != "AWS" {
+		t.Fatalf("expected detector provider in finding evidence, got %v", got)
+	}
 }
 
 func TestScanRepositoryDetectsHeadMisconfiguration(t *testing.T) {

--- a/internal/repoexposure/secret_detector_test.go
+++ b/internal/repoexposure/secret_detector_test.go
@@ -1,0 +1,239 @@
+package repoexposure
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+type secretDetectorFixture struct {
+	ID        string
+	Positives []string
+	Negatives []string
+}
+
+func TestSecretDetectorFixtures(t *testing.T) {
+	fixtures := []secretDetectorFixture{
+		{
+			ID:        "aws_access_key_id",
+			Positives: []string{fixtureToken("AKIA", strings.Repeat("A", 16))},
+			Negatives: []string{"AKIA12"},
+		},
+		{
+			ID:        "aws_secret_access_key",
+			Positives: []string{fixtureToken("aws_secret_access_key=", strings.Repeat("A", 40))},
+			Negatives: []string{"AWS_SECRET=ABCD1234ABCD1234"},
+		},
+		{
+			ID:        "github_token",
+			Positives: []string{fixtureToken("ghp_", strings.Repeat("a", 36))},
+			Negatives: []string{"ghp_short"},
+		},
+		{
+			ID:        "github_app_token",
+			Positives: []string{fixtureToken("ghs_", strings.Repeat("b", 40))},
+			Negatives: []string{"ghs_short"},
+		},
+		{
+			ID:        "slack_token",
+			Positives: []string{fixtureToken("xoxp-", strings.Repeat("c", 20), "-", strings.Repeat("d", 13))},
+			Negatives: []string{"xox-short"},
+		},
+		{
+			ID:        "gitlab_token",
+			Positives: []string{fixtureToken("glpat-", strings.Repeat("e", 24))},
+			Negatives: []string{"gitlab: token"},
+		},
+		{
+			ID:        "azure_service_secret",
+			Positives: []string{fixtureToken("AZURE_CLIENT_SECRET=", "a1B2c3D4e5F6g7H8i9J0kLmN", "!pQrS$tUvWxYz", "12AB34CD56EF78")},
+			Negatives: []string{"AZURE_CLIENT_SECRET="},
+		},
+		{
+			ID:        "gcp_api_key",
+			Positives: []string{fixtureToken("AIza", strings.Repeat("A", 35))},
+			Negatives: []string{"AIzaShort"},
+		},
+		{
+			ID:        "stripe_api_key",
+			Positives: []string{fixtureToken("sk_", "live_", strings.Repeat("g", 24))},
+			Negatives: []string{"sk_live_short"},
+		},
+		{
+			ID:        "openai_api_key",
+			Positives: []string{fixtureToken("sk-proj-", strings.Repeat("h", 40))},
+			Negatives: []string{"sk-1234"},
+		},
+		{
+			ID:        "workos_api_key",
+			Positives: []string{fixtureToken("workos_live_", "A1b2C3d4E5f6G7h8I9j0K1l2M3n4", "p5Q6r7S8t9U0v")},
+			Negatives: []string{"workos_test_short"},
+		},
+		{
+			ID:        "vercel_token",
+			Positives: []string{fixtureToken("vercel_pat_", strings.Repeat("j", 24))},
+			Negatives: []string{"VERCEL_TOKEN=foo"},
+		},
+		{
+			ID:        "npm_token",
+			Positives: []string{fixtureToken("NPM_TOKEN=", strings.Repeat("k", 16))},
+			Negatives: []string{"NPM_TOKEN="},
+		},
+		{
+			ID:        "dockerhub_token",
+			Positives: []string{fixtureToken("dckr_pat_", "A1b2C3d4E5f6G7h8I9j0kL", "m3N4p5Q6r7S8t9U0")},
+			Negatives: []string{"docker_token_short"},
+		},
+		{
+			ID:        "private_key_material",
+			Positives: []string{"-----BEGIN PRIVATE KEY-----"},
+			Negatives: []string{"PRIVATE_KEY"},
+		},
+		{
+			ID:        "tls_key_material",
+			Positives: []string{"-----BEGIN CERTIFICATE-----"},
+			Negatives: []string{"BEGIN CERT"},
+		},
+		{
+			ID:        "jwt_token",
+			Positives: []string{fixtureToken("eyJ", strings.Repeat("m", 30), ".", strings.Repeat("n", 30), ".", strings.Repeat("o", 32))},
+			Negatives: []string{"eyJ.not-a-jwt"},
+		},
+		{
+			ID:        "database_connection_url",
+			Positives: []string{"postgres://user:supersecret@db.example.com:5432/sample"},
+			Negatives: []string{"postgres://127.0.0.1"},
+		},
+		{
+			ID:        "oauth_client_secret",
+			Positives: []string{fixtureToken("client_secret=", "A1b2C3d4E5f6G7h8I9j0K", "LmNoPqRsT")},
+			Negatives: []string{"client_secret="},
+		},
+		{
+			ID:        "webhook_secret",
+			Positives: []string{fixtureToken("webhook_secret=", "A1b2C3d4E5f6G7h8I9j0k", "LmN")},
+			Negatives: []string{"webhook-secret"},
+		},
+		{
+			ID:        "ci_cd_token",
+			Positives: []string{fixtureToken("CI_JOB_TOKEN=", strings.Repeat("r", 20))},
+			Negatives: []string{"CI_JOB_TOKEN="},
+		},
+	}
+
+	seen := map[string]bool{}
+	for _, fixture := range fixtures {
+		detector, found := findSecretDetector(fixture.ID)
+		if !found {
+			t.Fatalf("fixture references missing detector %s", fixture.ID)
+		}
+		if fixture.ID == "" {
+			t.Fatal("fixture ID cannot be empty")
+		}
+		seen[fixture.ID] = true
+		if len(fixture.Positives) == 0 {
+			t.Fatalf("detector %s fixture is missing positive examples", detector.ID)
+		}
+		if len(fixture.Negatives) == 0 {
+			t.Fatalf("detector %s fixture is missing negative examples", detector.ID)
+		}
+
+		for _, positive := range fixture.Positives {
+			findings := detectSecretFindings("owner/repo", "HEAD", "config/secrets.env", 1, positive, time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC))
+			if !containsDetector(findings, fixture.ID) {
+				t.Fatalf("expected %s to detect fixture %q", fixture.ID, positive)
+			}
+		}
+
+		for _, negative := range fixture.Negatives {
+			findings := detectSecretFindings("owner/repo", "HEAD", "config/secrets.env", 1, negative, time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC))
+			if containsDetector(findings, fixture.ID) {
+				t.Fatalf("expected %s to ignore fixture %q", fixture.ID, negative)
+			}
+		}
+
+		for _, positive := range fixture.Positives[:1] {
+			findings := detectSecretFindings("owner/repo", "HEAD", "config/secrets.env", 1, positive, time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC))
+			for _, finding := range findings {
+				if finding.Detector != fixture.ID {
+					continue
+				}
+				if got := finding.Evidence["detector_version"]; got != detector.Version {
+					t.Fatalf("expected detector %s to include version %q got %v", fixture.ID, detector.Version, got)
+				}
+				if got := finding.Evidence["detector_provider"]; got != detector.Provider {
+					t.Fatalf("expected detector %s to include provider %q got %v", fixture.ID, detector.Provider, got)
+				}
+				if got := finding.Evidence["detector_category"]; got != detector.Category {
+					t.Fatalf("expected detector %s to include category %q got %v", fixture.ID, detector.Category, got)
+				}
+			}
+		}
+	}
+
+	if len(seen) != len(secretDetectorRegistry) {
+		t.Fatalf("expected fixture coverage for all %d detectors, got %d", len(secretDetectorRegistry), len(seen))
+	}
+}
+
+func TestSecretDetectorRegistryCanAddWithoutCodeFlowChanges(t *testing.T) {
+	if len(secretDetectorRegistry) == 0 {
+		t.Fatal("expected at least one secret detector")
+	}
+	if first := secretDetectorRegistry[0]; first.ID == "" || first.Version == "" {
+		t.Fatal("expected first registry entry to have id and version")
+	}
+}
+
+func TestSecretFingerprintUsesCapturedSecretValue(t *testing.T) {
+	secretValue := fixtureToken("A1b2C3d4E5f6G7h8I9j0K", "LmNoPqRsT")
+	detectedAt := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	first := firstFindingForDetector(t, detectSecretFindings("owner/repo", "HEAD", "config/secrets.env", 7, "client_secret="+secretValue, detectedAt), "oauth_client_secret")
+	second := firstFindingForDetector(t, detectSecretFindings("owner/repo", "HEAD", "config/secrets.env", 7, "oauth_secret=\""+secretValue+"\"", detectedAt), "oauth_client_secret")
+
+	expectedFingerprint := hashSHA256(secretValue)
+	if got := first.Evidence["secret_fingerprint"]; got != expectedFingerprint {
+		t.Fatalf("expected first fingerprint to hash captured value, got %v", got)
+	}
+	if got := second.Evidence["secret_fingerprint"]; got != expectedFingerprint {
+		t.Fatalf("expected second fingerprint to hash captured value, got %v", got)
+	}
+	if first.ID != second.ID {
+		t.Fatalf("expected matching IDs for identical captured value in same context, got %q and %q", first.ID, second.ID)
+	}
+}
+
+func fixtureToken(parts ...string) string {
+	return strings.Join(parts, "")
+}
+
+func findSecretDetector(id string) (secretDetector, bool) {
+	for _, detector := range secretDetectorRegistry {
+		if detector.ID == id {
+			return detector, true
+		}
+	}
+	return secretDetector{}, false
+}
+
+func containsDetector(findings []domain.Finding, id string) bool {
+	for _, finding := range findings {
+		if finding.Detector == id {
+			return true
+		}
+	}
+	return false
+}
+
+func firstFindingForDetector(t *testing.T, findings []domain.Finding, id string) domain.Finding {
+	t.Helper()
+	for _, finding := range findings {
+		if finding.Detector == id {
+			return finding
+		}
+	}
+	t.Fatalf("expected finding for detector %s, got %+v", id, findings)
+	return domain.Finding{}
+}


### PR DESCRIPTION
Fixes #1228

## Summary

This PR upgrades repository exposure secret detection from a small static rule list into a versioned detector registry with stable metadata, broader provider coverage, and focused regression tests.

The implementation keeps the existing scanner control flow intact while making detector behavior easier to extend, test, and report on.

## Why

Identrail's GitHub repository intelligence needs to detect more than the original V1 token families. Real repositories commonly leak cloud keys, source-control tokens, SaaS API keys, package registry tokens, CI/CD tokens, OAuth client secrets, webhook secrets, database URLs, JWT-like tokens, and private/TLS material.

Without a versioned registry and detector metadata, the scanner would miss important credential families and downstream reporting would have less context for triage, remediation, and future confidence scoring.

## What Changed

- Added a versioned secret detector registry in `internal/repoexposure/rules.go`.
- Added detector metadata for provider, category, version, severity, title, summary, and remediation.
- Added matcher controls for capture groups, minimum/maximum length, and entropy thresholds.
- Expanded detector coverage across AWS, GitHub, GitLab, Slack, Azure, GCP, Stripe, OpenAI, WorkOS, Vercel, npm, Docker Hub, private key material, TLS certificate material, JWTs, database URLs, OAuth secrets, webhook secrets, and CI/CD tokens.
- Added `detector_version`, `detector_provider`, and `detector_category` evidence fields to secret exposure findings.
- Updated secret fingerprinting so captured secret values are hashed instead of surrounding assignment syntax.
- Added fixture-based positive and negative regression coverage for every registered detector.
- Updated repository exposure documentation with the registry model, detector families, and safe extension guidance.

## Impact and Risk

This is a focused repo-exposure scanner improvement. Existing finding structure, redacted snippets, remediation fields, and raw-secret storage guarantees are preserved.

The main behavior change is broader secret detection coverage. That can increase finding volume in repositories with previously undetected token families, which is expected for this issue. Entropy and fixture coverage are included to reduce obvious false positives while keeping the implementation deterministic.

## Scope

- [x] Focused change with no unrelated modifications
- [x] Backward compatibility considered for existing secret exposure findings
- [x] Risk level assessed as medium because detector coverage expands scanner output
- [x] Documentation updated for the new detector registry model
- [x] Tests added for behavior changes

## Validation

Local validation:

```bash
go test ./internal/repoexposure -count=1
go test ./...
```

GitHub validation on PR #1241:

- Go Tests: pass
- Go Integration (Postgres): pass
- Go Quality: pass
- CLI Smoke: pass
- hardened-go-smoke: pass
- gitleaks: pass
- CodeQL: pass
- dependency-review: pass
- osv-pr / osv-scan: pass
- Security Scorecard: pass
- Web Build: pass
- Infra Validate: pass
- Deploy Portability: pass
- dco: pass
- require-linked-issue: pass

External Vercel status is rate-limited by provider quota: `Deployment rate limited — retry in 24 hours`. This is not caused by the PR code.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing scanner behavior
- [x] `CHANGELOG.md` not updated because this is tracked by issue #1228 and docs cover the scanner behavior change
- [x] No secrets, credentials, or sensitive data included
- [x] Review feedback addressed and the resolved thread was closed

## AI Assistance Disclosure

- AI-assisted: No
- Tools used: None
- Areas where used: Not applicable
- Human verification performed: local test suite, focused repo-exposure tests, PR check review, review-thread verification, and manual diff review

## Related Issues

Fixes #1228.

Sequencing note: #1227 is already closed, so this PR satisfies the prerequisite for issue #1228. Issue #1229 should remain next in the GitHub intelligence sequence after this PR is merged.
