### PR TITLE
Recover stale running repository scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## Unreleased
+- Recovered stale repository scans after worker replacement. Hosted workers now
+  requeue `running` repository scan rows older than the worker timeout grace
+  period before claiming new work, and repo scan claims refresh the stored
+  run timestamp so future recovery decisions measure execution age instead of
+  queue age.
 - Added GitHub App connector-backed private repository scans. Repo scan queue
   rows now store only non-secret source metadata, while API, scheduled, and
   webhook-triggered scans resolve the selected project connection and workers

--- a/docs/security-controls/background-job-lease-recovery.md
+++ b/docs/security-controls/background-job-lease-recovery.md
@@ -8,6 +8,11 @@ Worker failures should not leave scans stuck or duplicated.
 
 ## Current partial state
 Queue claims exist, but stale/crashed-job recovery with heartbeat leases is not comprehensive.
+Repository scan workers also perform bounded stale-running recovery: before
+claiming work, the worker moves `repo_scans` rows that have remained `running`
+beyond the repo worker timeout grace period back to `queued`. This prevents a
+worker restart or replacement from leaving GitHub repository scans permanently
+blocked, while the broader heartbeat/lease design remains tracked here.
 
 ## Priority
 High

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -37,6 +37,8 @@ const (
 	defaultScanRetryBaseDelay        = 30 * time.Second
 	defaultScanRetryMaxDelay         = 15 * time.Minute
 	defaultRepoQueueMaxPending       = 100
+	defaultRepoScanRunningStaleAfter = 35 * time.Minute
+	defaultRepoScanStaleRequeueLimit = 100
 	defaultGitHubWebhookReplayWindow = 24 * time.Hour
 	defaultGitHubWebhookBurstWindow  = 30 * time.Second
 	maxSourceErrorsInEvent           = 25
@@ -1059,6 +1061,21 @@ func (s *Service) EnqueueRepoScan(ctx context.Context, request RepoScanRequest) 
 // ProcessNextQueuedRepoScan claims and executes one queued repository scan. It returns false when no job is available.
 func (s *Service) ProcessNextQueuedRepoScan(ctx context.Context) (bool, error) {
 	ctx = s.scopeContext(ctx)
+	requeuedStale, err := s.Store.RequeueStaleRepoScansAnyScope(
+		ctx,
+		s.Now().UTC().Add(-defaultRepoScanRunningStaleAfter),
+		defaultRepoScanStaleRequeueLimit,
+	)
+	if err != nil {
+		s.recordWorkerJob("repo_scan", "failure")
+		return false, fmt.Errorf("requeue stale repo scans: %w", err)
+	}
+	if requeuedStale > 0 {
+		for i := 0; i < requeuedStale; i++ {
+			s.recordWorkerRequeue("repo_scan")
+		}
+		s.recordAutomationRun("api_queue", "repo_scan", "requeued")
+	}
 	record, err := s.Store.ClaimNextQueuedRepoScanAnyScope(ctx)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -3642,6 +3642,41 @@ func TestServiceProcessQueuedRepoScanAcrossScopes(t *testing.T) {
 	}
 }
 
+func TestServiceProcessNextQueuedRepoScanRecoversStaleRunningScan(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 5, 18, 23, 45, 0, 0, time.UTC)
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	svc.RepoScannerFactory = func(historyLimit int, maxFindings int) RepoScanExecutor {
+		return &fakeRepoExecutor{
+			result: repoexposure.ScanResult{
+				Repository:     "owner/repo",
+				CommitsScanned: historyLimit,
+				FilesScanned:   2,
+			},
+		}
+	}
+	staleRunning, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, now.Add(-40*time.Minute))
+	if err != nil {
+		t.Fatalf("create stale running repo scan: %v", err)
+	}
+
+	processed, err := svc.ProcessNextQueuedRepoScan(defaultScopeContext())
+	if err != nil {
+		t.Fatalf("process stale running repo scan: %v", err)
+	}
+	if !processed {
+		t.Fatal("expected stale running repo scan to be recovered and processed")
+	}
+	stored, err := svc.GetRepoScan(defaultScopeContext(), staleRunning.ID)
+	if err != nil {
+		t.Fatalf("get recovered repo scan: %v", err)
+	}
+	if stored.Status != "succeeded" || stored.FilesScanned != 2 {
+		t.Fatalf("expected stale running repo scan to complete, got %+v", stored)
+	}
+}
+
 func TestServiceEnqueueRepoScanConcurrentDeduplicatesTarget(t *testing.T) {
 	svc := NewService(db.NewMemoryStore(), fakeScanner{}, "aws")
 	svc.RepoScanAllowedTargets = []string{"owner/*"}

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -1957,10 +1957,13 @@ func (m *MemoryStore) claimNextQueuedRepoScanLocked(scope *Scope) (RepoScanRecor
 	if !found {
 		return RepoScanRecord{}, ErrNotFound
 	}
+	queuedAt := claimed.StartedAt
 	claimed.Status = "running"
+	claimed.StartedAt = time.Now().UTC()
 	claimed.FinishedAt = nil
 	claimed.ErrorMessage = ""
 	m.repoScans[claimed.ID] = claimed
+	claimed.StartedAt = queuedAt
 	return claimed, nil
 }
 
@@ -2049,6 +2052,40 @@ func (m *MemoryStore) RequeueRepoScan(ctx context.Context, repoScanID string) er
 	record.ErrorMessage = ""
 	m.repoScans[repoScanID] = record
 	return nil
+}
+
+// RequeueStaleRepoScansAnyScope moves stale running repository scans back to queued state across all scopes.
+func (m *MemoryStore) RequeueStaleRepoScansAnyScope(_ context.Context, staleBefore time.Time, limit int) (int, error) {
+	if limit <= 0 {
+		return 0, nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cutoff := staleBefore.UTC()
+	candidates := make([]RepoScanRecord, 0)
+	for _, scanID := range m.repoScanIDs {
+		record := m.repoScans[scanID]
+		if record.Status != "running" || !record.StartedAt.Before(cutoff) {
+			continue
+		}
+		candidates = append(candidates, record)
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return candidates[i].StartedAt.Before(candidates[j].StartedAt)
+	})
+	if len(candidates) > limit {
+		candidates = candidates[:limit]
+	}
+	now := time.Now().UTC()
+	for _, record := range candidates {
+		record.Status = "queued"
+		record.StartedAt = now
+		record.FinishedAt = nil
+		record.ErrorMessage = ""
+		m.repoScans[record.ID] = record
+	}
+	return len(candidates), nil
 }
 
 func (m *MemoryStore) createRepoScanLocked(scope Scope, repository string, source RepoScanSource, status string, historyLimit int, maxFindings int, startedAt time.Time) RepoScanRecord {

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -1180,6 +1180,13 @@ func TestMemoryStoreRepoQueueLifecycle(t *testing.T) {
 	if claimed.TraceParent == "" {
 		t.Fatal("expected claimed repo scan to retain queue traceparent")
 	}
+	storedClaimed, err := store.GetRepoScan(defaultScopeContext(), claimed.ID)
+	if err != nil {
+		t.Fatalf("get claimed repo scan: %v", err)
+	}
+	if !storedClaimed.StartedAt.After(claimed.StartedAt) {
+		t.Fatal("expected stored running repo scan to receive a fresh start timestamp")
+	}
 	if err := store.RequeueRepoScan(defaultScopeContext(), claimed.ID); err != nil {
 		t.Fatalf("requeue repo scan: %v", err)
 	}
@@ -1254,6 +1261,70 @@ func TestMemoryStoreClaimNextQueuedRepoScanAnyScope(t *testing.T) {
 	}
 	if claimed.ID != first.ID || claimed.TenantID != "tenant-b" || claimed.Status != "running" {
 		t.Fatalf("unexpected claimed repo scan across scopes: %+v", claimed)
+	}
+}
+
+func TestMemoryStoreRequeueStaleRepoScansAnyScope(t *testing.T) {
+	store := NewMemoryStore()
+	staleAt := time.Date(2026, 5, 18, 20, 0, 0, 0, time.UTC)
+	cutoff := staleAt.Add(35 * time.Minute)
+	otherScope := WithScope(context.Background(), Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
+
+	firstStale, err := store.CreateRepoScan(defaultScopeContext(), "owner/stale-a", RepoScanSource{}, staleAt)
+	if err != nil {
+		t.Fatalf("create first stale repo scan: %v", err)
+	}
+	secondStale, err := store.CreateRepoScan(otherScope, "owner/stale-b", RepoScanSource{}, staleAt.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("create second stale repo scan: %v", err)
+	}
+	fresh, err := store.CreateRepoScan(defaultScopeContext(), "owner/fresh", RepoScanSource{}, cutoff.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("create fresh repo scan: %v", err)
+	}
+
+	requeued, err := store.RequeueStaleRepoScansAnyScope(context.Background(), cutoff, 1)
+	if err != nil {
+		t.Fatalf("requeue stale repo scans: %v", err)
+	}
+	if requeued != 1 {
+		t.Fatalf("expected one stale repo scan requeued, got %d", requeued)
+	}
+	firstStored, err := store.GetRepoScan(defaultScopeContext(), firstStale.ID)
+	if err != nil {
+		t.Fatalf("get first stale repo scan: %v", err)
+	}
+	if firstStored.Status != "queued" {
+		t.Fatalf("expected first stale scan to be queued, got %q", firstStored.Status)
+	}
+	secondStored, err := store.GetRepoScan(otherScope, secondStale.ID)
+	if err != nil {
+		t.Fatalf("get second stale repo scan: %v", err)
+	}
+	if secondStored.Status != "running" {
+		t.Fatalf("expected second stale scan to remain running after limited recovery, got %q", secondStored.Status)
+	}
+
+	requeued, err = store.RequeueStaleRepoScansAnyScope(context.Background(), cutoff, 10)
+	if err != nil {
+		t.Fatalf("requeue remaining stale repo scans: %v", err)
+	}
+	if requeued != 1 {
+		t.Fatalf("expected one remaining stale repo scan requeued, got %d", requeued)
+	}
+	secondStored, err = store.GetRepoScan(otherScope, secondStale.ID)
+	if err != nil {
+		t.Fatalf("get requeued second stale repo scan: %v", err)
+	}
+	if secondStored.Status != "queued" {
+		t.Fatalf("expected second stale scan to be queued, got %q", secondStored.Status)
+	}
+	freshStored, err := store.GetRepoScan(defaultScopeContext(), fresh.ID)
+	if err != nil {
+		t.Fatalf("get fresh repo scan: %v", err)
+	}
+	if freshStored.Status != "running" {
+		t.Fatalf("expected fresh running scan to remain running, got %q", freshStored.Status)
 	}
 }
 

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -2712,7 +2712,7 @@ func (p *PostgresStore) ClaimNextQueuedRepoScanAnyScope(ctx context.Context) (Re
 
 func (p *PostgresStore) claimNextQueuedRepoScan(ctx context.Context, scope *Scope) (RepoScanRecord, error) {
 	query := `WITH next_repo_scan AS (
-			SELECT id
+		SELECT id, started_at
 			FROM repo_scans
 			WHERE status = 'queued'
 			ORDER BY started_at ASC
@@ -2721,6 +2721,7 @@ func (p *PostgresStore) claimNextQueuedRepoScan(ctx context.Context, scope *Scop
 		)
 		UPDATE repo_scans AS r
 		SET status = 'running',
+		    started_at = NOW(),
 		    finished_at = NULL,
 		    error_message = NULL
 		FROM next_repo_scan
@@ -2731,7 +2732,7 @@ func (p *PostgresStore) claimNextQueuedRepoScan(ctx context.Context, scope *Scop
 			r.workspace_id,
 			r.repository,
 			r.status,
-			r.started_at,
+			next_repo_scan.started_at,
 			r.finished_at,
 			r.commits_scanned,
 			r.files_scanned,
@@ -2749,7 +2750,7 @@ func (p *PostgresStore) claimNextQueuedRepoScan(ctx context.Context, scope *Scop
 	args := []any{}
 	if scope != nil {
 		query = `WITH next_repo_scan AS (
-			SELECT id
+			SELECT id, started_at
 			FROM repo_scans
 			WHERE tenant_id = $1
 			  AND workspace_id = $2
@@ -2760,6 +2761,7 @@ func (p *PostgresStore) claimNextQueuedRepoScan(ctx context.Context, scope *Scop
 		)
 		UPDATE repo_scans AS r
 		SET status = 'running',
+		    started_at = NOW(),
 		    finished_at = NULL,
 		    error_message = NULL
 		FROM next_repo_scan
@@ -2770,7 +2772,7 @@ func (p *PostgresStore) claimNextQueuedRepoScan(ctx context.Context, scope *Scop
 			r.workspace_id,
 			r.repository,
 			r.status,
-			r.started_at,
+			next_repo_scan.started_at,
 			r.finished_at,
 			r.commits_scanned,
 			r.files_scanned,
@@ -2893,6 +2895,42 @@ func (p *PostgresStore) RequeueRepoScan(ctx context.Context, repoScanID string) 
 		return ErrNotFound
 	}
 	return nil
+}
+
+// RequeueStaleRepoScansAnyScope moves stale running repository scans back to queued across all scopes.
+func (p *PostgresStore) RequeueStaleRepoScansAnyScope(ctx context.Context, staleBefore time.Time, limit int) (int, error) {
+	if limit <= 0 {
+		return 0, nil
+	}
+	result, err := p.execContextAnyScope(
+		ctx,
+		`WITH stale_repo_scans AS (
+			SELECT id
+			FROM repo_scans
+			WHERE status = 'running'
+			  AND started_at < $1
+			ORDER BY started_at ASC
+			FOR UPDATE SKIP LOCKED
+			LIMIT $2
+		)
+		UPDATE repo_scans AS r
+		SET status = 'queued',
+		    started_at = NOW(),
+		    finished_at = NULL,
+		    error_message = NULL
+		FROM stale_repo_scans
+		WHERE r.id = stale_repo_scans.id`,
+		staleBefore.UTC(),
+		limit,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("requeue stale repo scans: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("requeue stale repo scans rows affected: %w", err)
+	}
+	return int(affected), nil
 }
 
 func (p *PostgresStore) createRepoScanWithStatus(ctx context.Context, repository string, source RepoScanSource, status string, historyLimit int, maxFindings int, startedAt time.Time) (RepoScanRecord, error) {

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -1550,6 +1550,47 @@ func TestPostgresStoreCountQueuedRepoScansAnyScope(t *testing.T) {
 	}
 }
 
+func TestPostgresStoreRequeueStaleRepoScansAnyScope(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	staleBefore := time.Date(2026, 5, 18, 22, 40, 0, 0, time.UTC)
+	mock.ExpectExec(regexp.QuoteMeta(`WITH stale_repo_scans AS (
+			SELECT id
+			FROM repo_scans
+			WHERE status = 'running'
+			  AND started_at < $1
+			ORDER BY started_at ASC
+			FOR UPDATE SKIP LOCKED
+			LIMIT $2
+		)
+		UPDATE repo_scans AS r
+		SET status = 'queued',
+		    started_at = NOW(),
+		    finished_at = NULL,
+		    error_message = NULL
+		FROM stale_repo_scans
+		WHERE r.id = stale_repo_scans.id`)).
+		WithArgs(staleBefore, 25).
+		WillReturnResult(sqlmock.NewResult(0, 2))
+
+	requeued, err := store.RequeueStaleRepoScansAnyScope(context.Background(), staleBefore, 25)
+	if err != nil {
+		t.Fatalf("requeue stale repo scans any scope: %v", err)
+	}
+	if requeued != 2 {
+		t.Fatalf("expected two stale repo scans requeued, got %d", requeued)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestPostgresStoreCreateQueuedRepoScanWithinLimit(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2299,6 +2299,7 @@ type Store interface {
 	CountQueuedRepoScans(ctx context.Context) (int, error)
 	CountPendingRepoScansByRepository(ctx context.Context, repository string) (int, error)
 	RequeueRepoScan(ctx context.Context, repoScanID string) error
+	RequeueStaleRepoScansAnyScope(ctx context.Context, staleBefore time.Time, limit int) (int, error)
 	GetRepoScan(ctx context.Context, repoScanID string) (RepoScanRecord, error)
 	CompleteRepoScan(ctx context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, errorMessage string) error
 	UpsertRepoFindings(ctx context.Context, repoScanID string, findings []domain.Finding) error


### PR DESCRIPTION
Fixes #1242

## What changed
- Requeue stale `running` repository scan rows before a worker claims the next queued scan.
- Refresh the stored run timestamp when a queued repository scan is claimed, so stale recovery measures execution age instead of old queue age.
- Added memory-store, PostgreSQL-store, and service regression coverage for stale running recovery.
- Updated the changelog and background job recovery note for the operator-facing behavior change.

## Why
A worker restart or replacement can leave a repository scan stuck in `running`. Because the queue only claims `queued` rows and enqueue dedupe treats `running` rows as pending, the project can remain blocked and the UI keeps showing `RUNNING`.

## Impact and risk
This is backward compatible for normal queued, running, succeeded, and failed scans. The recovery is bounded, uses skip-locked PostgreSQL selection, and only requeues scans older than the stale-running threshold.

## Validation
- `go test ./internal/db -run 'Test(MemoryStoreRepoScanLifecycle|MemoryStoreRequeueStaleRepoScansAnyScope|PostgresStoreQueuedRepoScanLifecycle|PostgresStoreRequeueStaleRepoScansAnyScope|PostgresStoreClaimNextQueuedRepoScanAnyScopeBypassesScopeInjection)' -count=1`
- `go test ./internal/api -run 'TestServiceProcessNextQueuedRepoScanRecoversStaleRunningScan|TestServiceProcessQueuedRepoScanAcrossScopes|TestServiceProcessQueuedRepoScanRequeuesWhenExecutionLockHeld|TestServiceProcessQueuedRepoScanContinuesToNextTargetAfterRequeue|TestServiceProcessQueuedRepoScanFailureDoesNotBlockLaterQueuedTarget' -count=1`
- `go test ./internal/db ./internal/api -count=1`
- `go vet ./...`
- `go test ./... -count=1`
- `git diff --check`

## AI disclosure
- AI-assisted: No
- Tools used: N/A
- Where used: N/A
- Human verification performed: code review plus the validation commands above
