### PR TITLE
feat: classify repo secret confidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## Unreleased
+- Added rule-aware confidence classification for repository secret findings.
+  Secret detections now carry deterministic `confidence_score`,
+  `confidence_state`, and `confidence_reasons` metadata, distinguish likely
+  production leaks from samples, placeholders, docs, test fixtures, and
+  repository-local fingerprint allowlists, and preserve API/backfill
+  compatibility for existing finding records.
 - Added GitHub App connector-backed private repository scans. Repo scan queue
   rows now store only non-secret source metadata, while API, scheduled, and
   webhook-triggered scans resolve the selected project connection and workers

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -123,8 +123,43 @@ The scanner uses a versioned secret detector registry for commit-history secret 
   - `detector_version`
   - `detector_category`
   - `detector_provider`
+  - `confidence_score`
+  - `confidence_state`
+  - `confidence_reasons`
 
 To add a new secret detector, add a new entry to the registry with a unique ID, a new version if needed for compatibility, and test fixtures.
+
+## Secret Confidence Classification
+
+Secret findings are not silently dropped when they look like examples or test
+fixtures. Instead, the scanner emits confidence metadata so API clients and
+analysts can triage the result without losing auditability.
+
+Current `confidence_state` values for repo secret findings:
+
+- `high_confidence`: provider-shaped secret material in a production-like path.
+- `medium_confidence`: matched secret material with weaker detector confidence or generic shape.
+- `sample_or_placeholder`: sample, docs, `.env.example`, obvious placeholder, sequential, repeated, or low-entropy values.
+- `test_fixture`: findings under test, fixture, or `testdata` paths.
+- `allowlisted`: the secret fingerprint is listed in the repository's local `.identrailignore` file.
+
+Confidence is evidence metadata and also populates the top-level
+`confidence_score` field in finding API responses. Scores are deterministic and
+bounded from `0.01` to `0.99`; allowlisted fingerprints are emitted at `0.05`.
+
+The first suppression mechanism is repository-local and fingerprint based. Add a
+`.identrailignore` file at repository HEAD with one fingerprint per line:
+
+```text
+# Comments are ignored.
+secret-fingerprint: <sha256-secret-fingerprint>
+sha256=<sha256-secret-fingerprint>
+```
+
+The scanner still emits allowlisted findings by default, but marks them as
+`allowlisted` and includes `secret_allowlisted: true` in evidence. Organization
+or dashboard-managed suppression policies are intentionally left to a later
+workflow layer.
 
 ## Security Guardrails
 

--- a/internal/api/finding_baselines.go
+++ b/internal/api/finding_baselines.go
@@ -261,6 +261,14 @@ func (s *Service) loadTargetFindingsForBaselineImport(
 }
 
 func scoreFindingConfidence(finding domain.Finding) float64 {
+	if isRepoSecretClassifierFinding(finding) {
+		if finding.ConfidenceScore > 0 {
+			return roundConfidenceScore(finding.ConfidenceScore)
+		}
+		if score, ok := findingEvidenceFloat(finding.Evidence, "confidence_score"); ok && score > 0 {
+			return roundConfidenceScore(score)
+		}
+	}
 	score := 0.70
 	switch finding.Type {
 	case domain.FindingOwnerless:
@@ -291,6 +299,44 @@ func scoreFindingConfidence(finding domain.Finding) float64 {
 		score = 0.99
 	}
 	return roundConfidenceScore(score)
+}
+
+func isRepoSecretClassifierFinding(finding domain.Finding) bool {
+	if finding.Type != domain.FindingSecretExposure {
+		return false
+	}
+	if len(finding.Evidence) == 0 {
+		return false
+	}
+	source, _ := finding.Evidence["confidence_source"].(string)
+	if strings.HasPrefix(source, "repo_secret_classifier_v") {
+		return true
+	}
+	state, _ := finding.Evidence["confidence_state"].(string)
+	return strings.TrimSpace(state) != "" && (strings.TrimSpace(finding.Repository) != "" || strings.TrimSpace(finding.FilePath) != "" || strings.TrimSpace(finding.Detector) != "")
+}
+
+func findingEvidenceFloat(evidence map[string]any, key string) (float64, bool) {
+	if len(evidence) == 0 {
+		return 0, false
+	}
+	switch typed := evidence[key].(type) {
+	case float64:
+		return typed, true
+	case float32:
+		return float64(typed), true
+	case int:
+		return float64(typed), true
+	case int32:
+		return float64(typed), true
+	case int64:
+		return float64(typed), true
+	case json.Number:
+		value, err := typed.Float64()
+		return value, err == nil
+	default:
+		return 0, false
+	}
 }
 
 func scoreFindingBaselineMatch(entry FindingBaselineEntry, finding domain.Finding) float64 {

--- a/internal/api/finding_baselines_test.go
+++ b/internal/api/finding_baselines_test.go
@@ -39,6 +39,24 @@ func TestScoreFindingBaselineMatch(t *testing.T) {
 	}
 }
 
+func TestScoreFindingConfidenceHonorsClassifierScore(t *testing.T) {
+	finding := domain.Finding{
+		Type:            domain.FindingSecretExposure,
+		ConfidenceScore: 0.35,
+		FilePath:        "app.env",
+		Detector:        "github_token",
+		Evidence:        map[string]any{"confidence_score": 0.92, "confidence_source": "repo_secret_classifier_v2026.05"},
+	}
+	if got := scoreFindingConfidence(finding); got != 0.35 {
+		t.Fatalf("expected explicit finding confidence score to win, got %.2f", got)
+	}
+
+	finding.ConfidenceScore = 0
+	if got := scoreFindingConfidence(finding); got != 0.92 {
+		t.Fatalf("expected evidence confidence score to win, got %.2f", got)
+	}
+}
+
 func TestValidateFindingBaselineImportRequestRejectsInvalidShapes(t *testing.T) {
 	valid := FindingBaselineImportRequest{
 		Baseline: FindingBaseline{

--- a/internal/domain/repo_finding_metadata.go
+++ b/internal/domain/repo_finding_metadata.go
@@ -44,6 +44,11 @@ func NormalizeRepoFindingMetadata(finding *Finding) {
 	if finding.Detector == "" {
 		finding.Detector = stringFromAny(finding.Evidence["detector"])
 	}
+	if finding.ConfidenceScore == 0 {
+		if confidence, ok := floatFromAny(finding.Evidence["confidence_score"]); ok {
+			finding.ConfidenceScore = confidence
+		}
+	}
 	if finding.LineSnippet == "" {
 		for _, key := range []string{"line_snippet", "redacted_line_snip", "match_snippet"} {
 			if snippet := stringFromAny(finding.Evidence[key]); snippet != "" {
@@ -86,6 +91,9 @@ func NormalizeRepoFindingMetadata(finding *Finding) {
 	}
 	if finding.Detector != "" {
 		finding.Evidence["detector"] = finding.Detector
+	}
+	if finding.ConfidenceScore > 0 {
+		finding.Evidence["confidence_score"] = finding.ConfidenceScore
 	}
 	if finding.LineSnippet != "" {
 		finding.Evidence["line_snippet"] = finding.LineSnippet
@@ -138,6 +146,26 @@ func intFromAny(value any) int {
 		return 0
 	}
 	return 0
+}
+
+func floatFromAny(value any) (float64, bool) {
+	switch typed := value.(type) {
+	case float64:
+		return typed, true
+	case float32:
+		return float64(typed), true
+	case int:
+		return float64(typed), true
+	case int32:
+		return float64(typed), true
+	case int64:
+		return float64(typed), true
+	case json.Number:
+		number, err := typed.Float64()
+		return number, err == nil
+	default:
+		return 0, false
+	}
 }
 
 func boolFromAny(value any) (bool, bool) {

--- a/internal/domain/repo_finding_metadata_test.go
+++ b/internal/domain/repo_finding_metadata_test.go
@@ -12,6 +12,7 @@ func TestNormalizeRepoFindingMetadataBackfillsFieldsFromEvidence(t *testing.T) {
 			"file_path":          "config/app.env",
 			"line_number":        float64(42),
 			"detector":           "github-token",
+			"confidence_score":   0.37,
 			"redacted_line_snip": "GITHUB_TOKEN=ghp_****",
 		},
 	}
@@ -27,6 +28,9 @@ func TestNormalizeRepoFindingMetadataBackfillsFieldsFromEvidence(t *testing.T) {
 	if finding.LineSnippetRedacted == nil || !*finding.LineSnippetRedacted {
 		t.Fatalf("expected redacted snippet flag, got %+v", finding.LineSnippetRedacted)
 	}
+	if finding.ConfidenceScore != 0.37 {
+		t.Fatalf("expected confidence score to backfill from evidence, got %.2f", finding.ConfidenceScore)
+	}
 	if got := finding.Evidence["line_snippet"]; got != "GITHUB_TOKEN=ghp_****" {
 		t.Fatalf("expected canonical line_snippet evidence, got %v", got)
 	}
@@ -41,6 +45,7 @@ func TestNormalizeRepoFindingMetadataBackfillsEvidenceFromFields(t *testing.T) {
 		FilePath:            ".github/workflows/release.yml",
 		LineNumber:          18,
 		Detector:            "gh-actions-write-all",
+		ConfidenceScore:     0.84,
 		LineSnippet:         "permissions: write-all",
 		LineSnippetRedacted: &redacted,
 	}
@@ -61,6 +66,9 @@ func TestNormalizeRepoFindingMetadataBackfillsEvidenceFromFields(t *testing.T) {
 	}
 	if got := finding.Evidence["line_snippet_redacted"]; got != false {
 		t.Fatalf("expected non-redacted evidence flag, got %v", got)
+	}
+	if got := finding.Evidence["confidence_score"]; got != 0.84 {
+		t.Fatalf("expected confidence evidence, got %v", got)
 	}
 }
 

--- a/internal/repoexposure/rules.go
+++ b/internal/repoexposure/rules.go
@@ -32,6 +32,7 @@ type secretDetectorPattern struct {
 type secretDetector struct {
 	ID          string
 	Severity    domain.FindingSeverity
+	Confidence  float64
 	Title       string
 	Summary     string
 	Remediation string
@@ -42,11 +43,47 @@ type secretDetector struct {
 	Patterns    []secretDetectorPattern
 }
 
+const (
+	secretConfidenceClassifierVersion = "2026.05"
+
+	secretClassificationHighConfidence    = "high_confidence"
+	secretClassificationMediumConfidence  = "medium_confidence"
+	secretClassificationSamplePlaceholder = "sample_or_placeholder"
+	secretClassificationTestFixture       = "test_fixture"
+	secretClassificationAllowlisted       = "allowlisted"
+)
+
+type secretFindingPolicy struct {
+	AllowlistedFingerprints map[string]struct{}
+}
+
+type secretFindingOptions struct {
+	Policy secretFindingPolicy
+}
+
+type secretFindingOption func(*secretFindingOptions)
+
+func withSecretFindingPolicy(policy secretFindingPolicy) secretFindingOption {
+	return func(options *secretFindingOptions) {
+		options.Policy = policy
+	}
+}
+
+type secretConfidenceClassification struct {
+	State       string
+	Score       float64
+	Reasons     []string
+	Allowlisted bool
+}
+
+var secretFingerprintPattern = regexp.MustCompile(`^[a-f0-9]{64}$`)
+
 var secretDetectorRegistry = []secretDetector{
 	{
 		ID:          "aws_access_key_id",
 		Version:     "2026.05",
 		Severity:    domain.SeverityHigh,
+		Confidence:  0.98,
 		Title:       "Potential AWS access key exposed in commit history",
 		Provider:    "AWS",
 		Category:    "cloud_credentials",
@@ -63,6 +100,7 @@ var secretDetectorRegistry = []secretDetector{
 		ID:          "aws_secret_access_key",
 		Version:     "2026.05",
 		Severity:    domain.SeverityCritical,
+		Confidence:  0.96,
 		Title:       "Potential AWS secret key exposed in commit history",
 		Provider:    "AWS",
 		Category:    "cloud_credentials",
@@ -81,6 +119,7 @@ var secretDetectorRegistry = []secretDetector{
 		ID:          "github_token",
 		Version:     "2026.05",
 		Severity:    domain.SeverityCritical,
+		Confidence:  0.98,
 		Title:       "Potential GitHub token exposed in commit history",
 		Provider:    "GitHub",
 		Category:    "source_control",
@@ -98,6 +137,7 @@ var secretDetectorRegistry = []secretDetector{
 		ID:          "github_app_token",
 		Version:     "2026.05",
 		Severity:    domain.SeverityHigh,
+		Confidence:  0.95,
 		Title:       "Potential GitHub App token exposed in commit history",
 		Provider:    "GitHub",
 		Category:    "source_control",
@@ -111,6 +151,7 @@ var secretDetectorRegistry = []secretDetector{
 		ID:          "slack_token",
 		Version:     "2026.05",
 		Severity:    domain.SeverityHigh,
+		Confidence:  0.92,
 		Title:       "Potential Slack token exposed in commit history",
 		Provider:    "Slack",
 		Category:    "collaboration",
@@ -124,6 +165,7 @@ var secretDetectorRegistry = []secretDetector{
 		ID:          "gitlab_token",
 		Version:     "2026.05",
 		Severity:    domain.SeverityHigh,
+		Confidence:  0.92,
 		Title:       "Potential GitLab token exposed in commit history",
 		Provider:    "GitLab",
 		Category:    "source_control",
@@ -137,6 +179,7 @@ var secretDetectorRegistry = []secretDetector{
 		ID:          "azure_service_secret",
 		Version:     "2026.05",
 		Severity:    domain.SeverityHigh,
+		Confidence:  0.90,
 		Title:       "Potential Azure application secret exposed in commit history",
 		Provider:    "Azure",
 		Category:    "cloud_credentials",
@@ -155,6 +198,7 @@ var secretDetectorRegistry = []secretDetector{
 		ID:          "gcp_api_key",
 		Version:     "2026.05",
 		Severity:    domain.SeverityHigh,
+		Confidence:  0.92,
 		Title:       "Potential Google API key exposed in commit history",
 		Provider:    "Google",
 		Category:    "cloud_credentials",
@@ -168,6 +212,7 @@ var secretDetectorRegistry = []secretDetector{
 		ID:          "stripe_api_key",
 		Version:     "2026.05",
 		Severity:    domain.SeverityHigh,
+		Confidence:  0.94,
 		Title:       "Potential Stripe key exposed in commit history",
 		Provider:    "Stripe",
 		Category:    "payments",
@@ -182,6 +227,7 @@ var secretDetectorRegistry = []secretDetector{
 		ID:          "openai_api_key",
 		Version:     "2026.05",
 		Severity:    domain.SeverityHigh,
+		Confidence:  0.94,
 		Title:       "Potential OpenAI token exposed in commit history",
 		Provider:    "OpenAI",
 		Category:    "ai_api",
@@ -196,6 +242,7 @@ var secretDetectorRegistry = []secretDetector{
 		ID:          "workos_api_key",
 		Version:     "2026.05",
 		Severity:    domain.SeverityHigh,
+		Confidence:  0.92,
 		Title:       "Potential WorkOS token exposed in commit history",
 		Provider:    "WorkOS",
 		Category:    "identity_platform",
@@ -213,6 +260,7 @@ var secretDetectorRegistry = []secretDetector{
 		ID:          "vercel_token",
 		Version:     "2026.05",
 		Severity:    domain.SeverityHigh,
+		Confidence:  0.92,
 		Title:       "Potential Vercel token exposed in commit history",
 		Provider:    "Vercel",
 		Category:    "deployment_platform",
@@ -226,6 +274,7 @@ var secretDetectorRegistry = []secretDetector{
 		ID:          "npm_token",
 		Version:     "2026.05",
 		Severity:    domain.SeverityHigh,
+		Confidence:  0.86,
 		Title:       "Potential npm access token exposed in commit history",
 		Provider:    "npm",
 		Category:    "package_registry",
@@ -242,6 +291,7 @@ var secretDetectorRegistry = []secretDetector{
 		ID:          "dockerhub_token",
 		Version:     "2026.05",
 		Severity:    domain.SeverityHigh,
+		Confidence:  0.90,
 		Title:       "Potential Docker Hub token exposed in commit history",
 		Provider:    "Docker Hub",
 		Category:    "container_registry",
@@ -255,6 +305,7 @@ var secretDetectorRegistry = []secretDetector{
 		ID:          "private_key_material",
 		Version:     "2026.05",
 		Severity:    domain.SeverityCritical,
+		Confidence:  0.99,
 		Title:       "Private key material exposed in commit history",
 		Provider:    "General",
 		Category:    "credential_storage",
@@ -268,6 +319,7 @@ var secretDetectorRegistry = []secretDetector{
 		ID:          "tls_key_material",
 		Version:     "2026.05",
 		Severity:    domain.SeverityHigh,
+		Confidence:  0.72,
 		Title:       "TLS material exposed in commit history",
 		Provider:    "General",
 		Category:    "infrastructure_security",
@@ -281,6 +333,7 @@ var secretDetectorRegistry = []secretDetector{
 		ID:          "jwt_token",
 		Version:     "2026.05",
 		Severity:    domain.SeverityHigh,
+		Confidence:  0.82,
 		Title:       "Potential JWT exposed in commit history",
 		Provider:    "General",
 		Category:    "identity_tokens",
@@ -294,6 +347,7 @@ var secretDetectorRegistry = []secretDetector{
 		ID:          "database_connection_url",
 		Version:     "2026.05",
 		Severity:    domain.SeverityMedium,
+		Confidence:  0.86,
 		Title:       "Potential database URL with embedded credentials",
 		Provider:    "General",
 		Category:    "configuration",
@@ -311,6 +365,7 @@ var secretDetectorRegistry = []secretDetector{
 		ID:          "oauth_client_secret",
 		Version:     "2026.05",
 		Severity:    domain.SeverityHigh,
+		Confidence:  0.80,
 		Title:       "Potential OAuth client secret exposed in commit history",
 		Provider:    "General",
 		Category:    "identity_tokens",
@@ -329,6 +384,7 @@ var secretDetectorRegistry = []secretDetector{
 		ID:          "webhook_secret",
 		Version:     "2026.05",
 		Severity:    domain.SeverityHigh,
+		Confidence:  0.78,
 		Title:       "Potential webhook signing secret exposed in commit history",
 		Provider:    "General",
 		Category:    "webhooks",
@@ -347,6 +403,7 @@ var secretDetectorRegistry = []secretDetector{
 		ID:          "ci_cd_token",
 		Version:     "2026.05",
 		Severity:    domain.SeverityHigh,
+		Confidence:  0.82,
 		Title:       "Potential CI/CD token exposed in commit history",
 		Provider:    "General",
 		Category:    "ci_cd",
@@ -434,10 +491,16 @@ var fileMisconfigRules = []fileMisconfigRule{
 	},
 }
 
-func detectSecretFindings(repo string, commit string, path string, line int, text string, detectedAt time.Time) []domain.Finding {
+func detectSecretFindings(repo string, commit string, path string, line int, text string, detectedAt time.Time, options ...secretFindingOption) []domain.Finding {
 	normalized := strings.TrimSpace(text)
 	if normalized == "" {
 		return nil
+	}
+	secretOptions := secretFindingOptions{}
+	for _, option := range options {
+		if option != nil {
+			option(&secretOptions)
+		}
 	}
 	type detectedSecret struct {
 		rule  secretDetector
@@ -462,11 +525,13 @@ func detectSecretFindings(repo string, commit string, path string, line int, tex
 			secretMaterial = item.match
 		}
 		fingerprint := hashSHA256(secretMaterial)
+		classification := classifySecretMatch(item.rule, path, normalized, secretMaterial, fingerprint, secretOptions.Policy)
 		id := hashDeterministicID("repo-secret", repo, commit, path, strconv.Itoa(line), item.rule.ID, fingerprint)
 		findings = append(findings, domain.Finding{
 			ID:                  "finding:" + id,
 			Type:                domain.FindingSecretExposure,
 			Severity:            item.rule.Severity,
+			ConfidenceScore:     classification.Score,
 			Title:               item.rule.Title,
 			HumanSummary:        item.rule.Summary,
 			Path:                []string{path},
@@ -492,12 +557,262 @@ func detectSecretFindings(repo string, commit string, path string, line int, tex
 				"history_source":        "commit_diff",
 				"raw_secret_stored":     false,
 				"secret_value_masked":   true,
+				"confidence_score":      classification.Score,
+				"confidence_state":      classification.State,
+				"confidence_reasons":    classification.Reasons,
+				"confidence_source":     "repo_secret_classifier_v" + secretConfidenceClassifierVersion,
+				"secret_allowlisted":    classification.Allowlisted,
 			},
 			Remediation: item.rule.Remediation,
 			CreatedAt:   detectedAt,
 		})
 	}
 	return findings
+}
+
+func parseSecretFindingPolicy(content []byte) secretFindingPolicy {
+	policy := secretFindingPolicy{AllowlistedFingerprints: map[string]struct{}{}}
+	scanner := bufio.NewScanner(bytes.NewReader(content))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if index := strings.Index(line, "#"); index >= 0 {
+			line = strings.TrimSpace(line[:index])
+		}
+		fingerprint := normalizeSecretFingerprint(line)
+		if fingerprint == "" {
+			continue
+		}
+		policy.AllowlistedFingerprints[fingerprint] = struct{}{}
+	}
+	if len(policy.AllowlistedFingerprints) == 0 {
+		policy.AllowlistedFingerprints = nil
+	}
+	return policy
+}
+
+func normalizeSecretFingerprint(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	for _, prefix := range []string{"secret-fingerprint:", "secret_fingerprint:", "secret-fingerprint=", "secret_fingerprint=", "sha256:", "sha256=", "secret:", "secret="} {
+		if strings.HasPrefix(normalized, prefix) {
+			normalized = strings.TrimSpace(strings.TrimPrefix(normalized, prefix))
+			break
+		}
+	}
+	if secretFingerprintPattern.MatchString(normalized) {
+		return normalized
+	}
+	return ""
+}
+
+func classifySecretMatch(rule secretDetector, filePath string, line string, secretMaterial string, fingerprint string, policy secretFindingPolicy) secretConfidenceClassification {
+	reasons := []string{"detector:" + rule.ID, fmt.Sprintf("detector_confidence:%.2f", baseSecretDetectorConfidence(rule))}
+	if _, allowlisted := policy.AllowlistedFingerprints[strings.ToLower(strings.TrimSpace(fingerprint))]; allowlisted {
+		return secretConfidenceClassification{
+			State:       secretClassificationAllowlisted,
+			Score:       0.05,
+			Reasons:     append(reasons, "fingerprint_allowlisted"),
+			Allowlisted: true,
+		}
+	}
+
+	score := baseSecretDetectorConfidence(rule)
+	state := ""
+	testFixturePath := isSecretTestFixturePath(filePath)
+	samplePath := isSecretSamplePath(filePath)
+	if !testFixturePath && !samplePath && isProductionSecretPath(filePath) {
+		score += 0.03
+		reasons = append(reasons, "path_context:production_secret_file")
+	}
+	if testFixturePath {
+		state = secretClassificationTestFixture
+		score = math.Min(score, 0.35)
+		reasons = append(reasons, "path_context:test_fixture")
+	}
+	if samplePath {
+		if state == "" {
+			state = secretClassificationSamplePlaceholder
+		}
+		score = math.Min(score, 0.40)
+		reasons = append(reasons, "path_context:sample_or_docs")
+	}
+
+	placeholderReasons := secretPlaceholderReasons(line, secretMaterial)
+	if len(placeholderReasons) > 0 {
+		if state == "" {
+			state = secretClassificationSamplePlaceholder
+		}
+		score = math.Min(score, 0.25)
+		reasons = append(reasons, placeholderReasons...)
+	}
+
+	score = roundSecretConfidenceScore(clampSecretConfidence(score))
+	if state == "" {
+		if score >= 0.85 {
+			state = secretClassificationHighConfidence
+		} else {
+			state = secretClassificationMediumConfidence
+		}
+	}
+	return secretConfidenceClassification{State: state, Score: score, Reasons: reasons}
+}
+
+func baseSecretDetectorConfidence(rule secretDetector) float64 {
+	if rule.Confidence > 0 {
+		return clampSecretConfidence(rule.Confidence)
+	}
+	switch rule.Severity {
+	case domain.SeverityCritical:
+		return 0.94
+	case domain.SeverityHigh:
+		return 0.86
+	case domain.SeverityMedium:
+		return 0.74
+	default:
+		return 0.65
+	}
+}
+
+func clampSecretConfidence(score float64) float64 {
+	if score < 0.01 {
+		return 0.01
+	}
+	if score > 0.99 {
+		return 0.99
+	}
+	return score
+}
+
+func roundSecretConfidenceScore(score float64) float64 {
+	return math.Round(score*100) / 100
+}
+
+func isSecretTestFixturePath(filePath string) bool {
+	normalized := normalizeSecretPath(filePath)
+	base := filepath.Base(normalized)
+	return strings.HasSuffix(base, "_test.go") ||
+		strings.HasPrefix(normalized, "testdata/") ||
+		strings.HasPrefix(normalized, "tests/") ||
+		strings.HasPrefix(normalized, "fixtures/") ||
+		strings.HasPrefix(normalized, "fixture/") ||
+		strings.HasPrefix(normalized, "__fixtures__/") ||
+		strings.Contains(normalized, "/testdata/") ||
+		strings.Contains(normalized, "/tests/") ||
+		strings.Contains(normalized, "/fixtures/") ||
+		strings.Contains(normalized, "/fixture/") ||
+		strings.Contains(normalized, "/__fixtures__/")
+}
+
+func isSecretSamplePath(filePath string) bool {
+	normalized := normalizeSecretPath(filePath)
+	base := filepath.Base(normalized)
+	return strings.HasPrefix(normalized, "docs/") ||
+		strings.HasPrefix(normalized, "examples/") ||
+		strings.HasPrefix(normalized, "example/") ||
+		strings.HasPrefix(normalized, "samples/") ||
+		strings.HasPrefix(normalized, "sample/") ||
+		strings.Contains(normalized, "/docs/") ||
+		strings.Contains(normalized, "/examples/") ||
+		strings.Contains(normalized, "/example/") ||
+		strings.Contains(normalized, "/samples/") ||
+		strings.Contains(normalized, "/sample/") ||
+		base == "readme.md" ||
+		base == ".env.example" ||
+		base == ".env.sample" ||
+		base == "env.example" ||
+		base == "env.sample" ||
+		strings.HasSuffix(base, ".example") ||
+		strings.HasSuffix(base, ".sample")
+}
+
+func isProductionSecretPath(filePath string) bool {
+	normalized := normalizeSecretPath(filePath)
+	base := filepath.Base(normalized)
+	switch base {
+	case ".env", "app.env", "secrets.env", "secret.env", "credentials.env", "config.env":
+		return true
+	}
+	return strings.HasPrefix(normalized, "secrets/") ||
+		strings.HasPrefix(normalized, "credentials/") ||
+		strings.Contains(normalized, "/secrets/") ||
+		strings.Contains(normalized, "/credentials/")
+}
+
+func normalizeSecretPath(filePath string) string {
+	normalized := filepath.ToSlash(strings.TrimSpace(filePath))
+	normalized = strings.TrimPrefix(normalized, "./")
+	return strings.ToLower(normalized)
+}
+
+func secretPlaceholderReasons(line string, secretMaterial string) []string {
+	lowerMaterial := strings.ToLower(strings.TrimSpace(secretMaterial))
+	lowerLine := strings.ToLower(strings.TrimSpace(line))
+	reasons := []string{}
+	for _, marker := range []string{"example", "changeme", "change_me", "dummy", "fake", "sample", "placeholder", "notasecret", "not_a_secret", "replace_me", "your_", "todo", "testsecret", "test_secret", "test-secret", "sk_test_", "pk_test_"} {
+		if strings.Contains(lowerMaterial, marker) || strings.Contains(lowerLine, marker) {
+			reasons = append(reasons, "value_marker:"+marker)
+			break
+		}
+	}
+
+	compact := compactSecretValue(secretMaterial)
+	if len(compact) >= 12 && isRepeatedOrLowVarietySecret(compact) {
+		reasons = append(reasons, "value_shape:repeated_or_low_variety")
+	}
+	if len(compact) >= 16 && containsSequentialSecretPattern(compact) {
+		reasons = append(reasons, "value_shape:sequential")
+	}
+	if len(compact) >= 16 && entropy(secretMaterial) < 2.6 && !strings.Contains(lowerMaterial, "-----begin ") {
+		reasons = append(reasons, "value_entropy:low")
+	}
+	return reasons
+}
+
+func compactSecretValue(value string) string {
+	var builder strings.Builder
+	for _, r := range strings.ToLower(value) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			builder.WriteRune(r)
+		}
+	}
+	return builder.String()
+}
+
+func isRepeatedOrLowVarietySecret(compact string) bool {
+	seen := map[rune]struct{}{}
+	for _, r := range compact {
+		seen[r] = struct{}{}
+	}
+	if len(seen) <= 3 {
+		return true
+	}
+	for size := 2; size <= 8; size++ {
+		if len(compact)%size != 0 {
+			continue
+		}
+		prefix := compact[:size]
+		if strings.Repeat(prefix, len(compact)/size) == compact {
+			return true
+		}
+	}
+	return false
+}
+
+func containsSequentialSecretPattern(compact string) bool {
+	for _, pattern := range []string{
+		"0123456789abcdef",
+		"abcdef0123456789",
+		"1234567890abcdef",
+		"abcdefghijklmnopqrstuvwxyz",
+		"abcdefghijklmnop",
+	} {
+		if strings.Contains(compact, pattern) {
+			return true
+		}
+	}
+	return false
 }
 
 func detectSecretMatch(text string, rule secretDetector) (match string, value string) {

--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -179,6 +179,8 @@ func (s *Scanner) ScanRepository(ctx context.Context, target string) (ScanResult
 	findings := make([]domain.Finding, 0, s.maxFindings)
 	seen := map[string]struct{}{}
 	truncated := false
+	secretPolicy := s.loadSecretFindingPolicy(ctx, location)
+	secretOptions := []secretFindingOption{withSecretFindingPolicy(secretPolicy)}
 
 	logArgs := []string{"log", "--all", "--max-count", strconv.Itoa(s.historyLimit), "--no-color", "--unified=0", "--format=commit:%H", "-p"}
 	historyReader, waitLog, logErr := s.gitStream(ctx, location, logArgs...)
@@ -186,7 +188,7 @@ func (s *Scanner) ScanRepository(ctx context.Context, target string) (ScanResult
 		return ScanResult{}, fmt.Errorf("scan commit history: %w", logErr)
 	}
 	scanErr := scanHistoryLines(ctx, historyReader, func(added addedLine) bool {
-		secretFindings := detectSecretFindings(location.Display, added.Commit, added.Path, added.Line, added.Text, started)
+		secretFindings := detectSecretFindings(location.Display, added.Commit, added.Path, added.Line, added.Text, started, secretOptions...)
 		for _, finding := range secretFindings {
 			if _, exists := seen[finding.ID]; exists {
 				continue
@@ -419,6 +421,14 @@ func (s *Scanner) listHeadFiles(ctx context.Context, repo repositoryLocation) ([
 		files = append(files, path)
 	}
 	return files, nil
+}
+
+func (s *Scanner) loadSecretFindingPolicy(ctx context.Context, repo repositoryLocation) secretFindingPolicy {
+	output, err := s.git(ctx, repo, "show", "HEAD:.identrailignore")
+	if err != nil {
+		return secretFindingPolicy{}
+	}
+	return parseSecretFindingPolicy(output)
 }
 
 func (s *Scanner) resolveHeadCommit(ctx context.Context, repo repositoryLocation) (string, error) {

--- a/internal/repoexposure/scanner_test.go
+++ b/internal/repoexposure/scanner_test.go
@@ -85,6 +85,47 @@ func TestScanRepositoryDetectsSecretInCommitHistory(t *testing.T) {
 	}
 }
 
+func TestScanRepositoryClassifiesAllowlistedSecretFingerprint(t *testing.T) {
+	repoPath, _ := initTestRepoWithHistorySecret(t)
+	allowlist := "secret-fingerprint: " + hashSHA256(testSecretValue) + "\n"
+	if err := os.WriteFile(filepath.Join(repoPath, ".identrailignore"), []byte(allowlist), 0o600); err != nil {
+		t.Fatalf("write identrail ignore file: %v", err)
+	}
+	runGit(t, repoPath, "add", ".identrailignore")
+	runGit(t, repoPath, "commit", "-q", "-m", "allowlist known fixture secret")
+
+	scanner := NewScanner(nil,
+		WithHistoryLimit(100),
+		WithMaxFindings(50),
+		WithNow(func() time.Time { return time.Date(2026, 5, 18, 13, 0, 0, 0, time.UTC) }),
+	)
+
+	result, err := scanner.ScanRepository(context.Background(), repoPath)
+	if err != nil {
+		t.Fatalf("scan repository failed: %v", err)
+	}
+
+	var secretFinding domain.Finding
+	for _, finding := range result.Findings {
+		if finding.Type == domain.FindingSecretExposure && finding.Detector == "aws_secret_access_key" {
+			secretFinding = finding
+			break
+		}
+	}
+	if secretFinding.ID == "" {
+		t.Fatalf("expected allowlisted secret finding, got %+v", result.Findings)
+	}
+	if got := secretFinding.Evidence["confidence_state"]; got != secretClassificationAllowlisted {
+		t.Fatalf("expected allowlisted confidence state, got %v in %+v", got, secretFinding.Evidence)
+	}
+	if got, _ := secretFinding.Evidence["secret_allowlisted"].(bool); !got {
+		t.Fatalf("expected secret_allowlisted evidence flag, got %+v", secretFinding.Evidence)
+	}
+	if secretFinding.ConfidenceScore != 0.05 {
+		t.Fatalf("expected allowlisted confidence score 0.05, got %.2f", secretFinding.ConfidenceScore)
+	}
+}
+
 func TestScanRepositoryDetectsHeadMisconfiguration(t *testing.T) {
 	repoPath, headCommit := initTestRepoWithHeadMisconfig(t)
 	scanner := NewScanner(nil, WithHistoryLimit(10), WithMaxFindings(20))

--- a/internal/repoexposure/secret_detector_test.go
+++ b/internal/repoexposure/secret_detector_test.go
@@ -132,6 +132,9 @@ func TestSecretDetectorFixtures(t *testing.T) {
 		if fixture.ID == "" {
 			t.Fatal("fixture ID cannot be empty")
 		}
+		if detector.Confidence <= 0 || detector.Confidence > 1 {
+			t.Fatalf("detector %s must define confidence between 0 and 1, got %.2f", detector.ID, detector.Confidence)
+		}
 		seen[fixture.ID] = true
 		if len(fixture.Positives) == 0 {
 			t.Fatalf("detector %s fixture is missing positive examples", detector.ID)
@@ -169,6 +172,15 @@ func TestSecretDetectorFixtures(t *testing.T) {
 				if got := finding.Evidence["detector_category"]; got != detector.Category {
 					t.Fatalf("expected detector %s to include category %q got %v", fixture.ID, detector.Category, got)
 				}
+				if finding.ConfidenceScore <= 0 {
+					t.Fatalf("expected detector %s to include top-level confidence score, got %+v", fixture.ID, finding)
+				}
+				if got := finding.Evidence["confidence_score"]; got != finding.ConfidenceScore {
+					t.Fatalf("expected detector %s evidence confidence to match top-level score, got %v and %.2f", fixture.ID, got, finding.ConfidenceScore)
+				}
+				if got := finding.Evidence["confidence_state"]; got == "" {
+					t.Fatalf("expected detector %s to include confidence state", fixture.ID)
+				}
 			}
 		}
 	}
@@ -202,6 +214,138 @@ func TestSecretFingerprintUsesCapturedSecretValue(t *testing.T) {
 	}
 	if first.ID != second.ID {
 		t.Fatalf("expected matching IDs for identical captured value in same context, got %q and %q", first.ID, second.ID)
+	}
+}
+
+func TestSecretConfidenceClassifiesLikelyProductionSecret(t *testing.T) {
+	secretValue := fixtureToken("aB3dE5fG7hJ9kLmN2pQrS4tUvW6xYz8", "AbCde")
+	finding := firstFindingForDetector(t,
+		detectSecretFindings("owner/repo", "HEAD", "app.env", 7, fixtureToken("GITHUB_TOKEN=ghp_", secretValue), time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)),
+		"github_token",
+	)
+
+	if got := finding.Evidence["confidence_state"]; got != secretClassificationHighConfidence {
+		t.Fatalf("expected high-confidence classification, got %v in %+v", got, finding.Evidence)
+	}
+	if finding.ConfidenceScore < 0.95 {
+		t.Fatalf("expected high confidence score, got %.2f", finding.ConfidenceScore)
+	}
+}
+
+func TestSecretConfidenceClassifiesSamplePlaceholder(t *testing.T) {
+	finding := firstFindingForDetector(t,
+		detectSecretFindings("owner/repo", "HEAD", "README.md", 7, "client_secret=exampleclientsecretvalue123", time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)),
+		"oauth_client_secret",
+	)
+
+	if got := finding.Evidence["confidence_state"]; got != secretClassificationSamplePlaceholder {
+		t.Fatalf("expected sample placeholder classification, got %v in %+v", got, finding.Evidence)
+	}
+	if finding.ConfidenceScore > 0.40 {
+		t.Fatalf("expected downgraded sample score, got %.2f", finding.ConfidenceScore)
+	}
+}
+
+func TestSecretConfidenceClassifiesRootSampleDirectory(t *testing.T) {
+	secretValue := fixtureToken("aB3dE5fG7hJ9kLmN2pQrS4tUvW6xYz8", "AbCde")
+	finding := firstFindingForDetector(t,
+		detectSecretFindings("owner/repo", "HEAD", "examples/secrets.env", 7, fixtureToken("GITHUB_TOKEN=ghp_", secretValue), time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)),
+		"github_token",
+	)
+
+	if got := finding.Evidence["confidence_state"]; got != secretClassificationSamplePlaceholder {
+		t.Fatalf("expected root sample directory classification, got %v in %+v", got, finding.Evidence)
+	}
+	if finding.ConfidenceScore > 0.40 {
+		t.Fatalf("expected downgraded root sample score, got %.2f", finding.ConfidenceScore)
+	}
+}
+
+func TestSecretConfidenceClassifiesTestModeTokenValue(t *testing.T) {
+	finding := firstFindingForDetector(t,
+		detectSecretFindings("owner/repo", "HEAD", "app.env", 7, fixtureToken("STRIPE_SECRET_KEY=", "sk_test_", "aB3dE5fG7hJ9kLmN2pQrS4tUvW6x"), time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)),
+		"stripe_api_key",
+	)
+
+	if got := finding.Evidence["confidence_state"]; got != secretClassificationSamplePlaceholder {
+		t.Fatalf("expected test-mode token value classification, got %v in %+v", got, finding.Evidence)
+	}
+	if finding.ConfidenceScore > 0.25 {
+		t.Fatalf("expected downgraded test-mode token score, got %.2f", finding.ConfidenceScore)
+	}
+}
+
+func TestSecretConfidenceClassifiesTestFixturePath(t *testing.T) {
+	secretValue := fixtureToken("aB3dE5fG7hJ9kLmN2pQrS4tUvW6xYz8", "AbCde")
+	finding := firstFindingForDetector(t,
+		detectSecretFindings("owner/repo", "HEAD", "testdata/secrets.env", 7, fixtureToken("GITHUB_TOKEN=ghp_", secretValue), time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)),
+		"github_token",
+	)
+
+	if got := finding.Evidence["confidence_state"]; got != secretClassificationTestFixture {
+		t.Fatalf("expected test fixture classification, got %v in %+v", got, finding.Evidence)
+	}
+	if finding.ConfidenceScore > 0.35 {
+		t.Fatalf("expected downgraded test fixture score, got %.2f", finding.ConfidenceScore)
+	}
+}
+
+func TestSecretConfidencePathClassifiersIncludeRepositoryRootDirectories(t *testing.T) {
+	for _, path := range []string{"examples/app.env", "example/app.env", "samples/app.env", "sample/app.env"} {
+		if !isSecretSamplePath(path) {
+			t.Fatalf("expected %s to be a sample path", path)
+		}
+	}
+	if !isSecretTestFixturePath("__fixtures__/secrets.env") {
+		t.Fatal("expected root __fixtures__ directory to be a test fixture path")
+	}
+	for _, path := range []string{"secrets/app.env", "credentials/app.env"} {
+		if !isProductionSecretPath(path) {
+			t.Fatalf("expected %s to be a production secret path", path)
+		}
+	}
+}
+
+func TestSecretConfidenceClassifiesAllowlistedFingerprint(t *testing.T) {
+	secretValue := fixtureToken("A1b2C3d4E5f6G7h8I9j0K", "LmNoPqRsT")
+	fingerprint := hashSHA256(secretValue)
+	finding := firstFindingForDetector(t,
+		detectSecretFindings(
+			"owner/repo",
+			"HEAD",
+			"config/secrets.env",
+			7,
+			"client_secret="+secretValue,
+			time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC),
+			withSecretFindingPolicy(secretFindingPolicy{AllowlistedFingerprints: map[string]struct{}{fingerprint: {}}}),
+		),
+		"oauth_client_secret",
+	)
+
+	if got := finding.Evidence["confidence_state"]; got != secretClassificationAllowlisted {
+		t.Fatalf("expected allowlisted classification, got %v in %+v", got, finding.Evidence)
+	}
+	if got, _ := finding.Evidence["secret_allowlisted"].(bool); !got {
+		t.Fatalf("expected allowlisted evidence flag, got %+v", finding.Evidence)
+	}
+	if finding.ConfidenceScore != 0.05 {
+		t.Fatalf("expected allowlisted confidence score 0.05, got %.2f", finding.ConfidenceScore)
+	}
+}
+
+func TestParseSecretFindingPolicyAcceptsFingerprintForms(t *testing.T) {
+	first := strings.Repeat("a", 64)
+	second := strings.Repeat("b", 64)
+	policy := parseSecretFindingPolicy([]byte("\n# comments are ignored\nsecret-fingerprint: " + first + "\nsha256=" + second + " # inline comment\ninvalid\n"))
+
+	if _, ok := policy.AllowlistedFingerprints[first]; !ok {
+		t.Fatalf("expected first fingerprint to be allowlisted, got %+v", policy.AllowlistedFingerprints)
+	}
+	if _, ok := policy.AllowlistedFingerprints[second]; !ok {
+		t.Fatalf("expected second fingerprint to be allowlisted, got %+v", policy.AllowlistedFingerprints)
+	}
+	if len(policy.AllowlistedFingerprints) != 2 {
+		t.Fatalf("expected exactly two fingerprints, got %+v", policy.AllowlistedFingerprints)
 	}
 }
 


### PR DESCRIPTION
Fixes #1229

## Summary

- Adds rule-aware confidence values to the repository secret detector registry.
- Classifies secret matches as `high_confidence`, `medium_confidence`, `sample_or_placeholder`, `test_fixture`, or `allowlisted` instead of treating every regex hit the same.
- Emits `confidence_score`, `confidence_state`, `confidence_reasons`, `confidence_source`, and `secret_allowlisted` metadata while keeping the raw secret masked.
- Loads repository-local `.identrailignore` fingerprint allowlists from HEAD and documents the first suppression design.
- Keeps finding API/backfill behavior compatible by normalizing confidence metadata and only honoring classifier confidence in baseline scoring for repo secret findings.
- Updates tests, docs, changelog, and scanner documentation for the new behavior.

## Why

Repo secret detection needs to distinguish likely production leaks from docs examples, test fixtures, placeholders, sequential sample strings, and known allowlisted fingerprints. Without this layer, users get noisy findings that look equally urgent even when the evidence clearly says otherwise.

## What Changed

- Added deterministic confidence scoring bounded to `0.01` through `0.99`.
- Added path context for production secret files, docs/examples/samples, testdata, fixtures, and root-level secret/credential directories.
- Added placeholder/test-mode value signals for obvious examples, fake values, low-variety strings, sequential strings, and Stripe test-mode tokens.
- Added `.identrailignore` parsing for SHA-256 secret fingerprints without silently hiding allowlisted findings.
- Added scanner-level coverage for allowlisted findings and unit coverage for high-confidence, placeholder, sample, test fixture, test-mode, path-classifier, and allowlist cases.
- Documented the confidence states and local fingerprint allowlist format in `docs/repo-exposure.md`.

## Impact and Risk

Secret findings continue to be emitted by default, including allowlisted findings, so auditability is preserved. API consumers receive additional confidence metadata and top-level `confidence_score`; existing persisted records can still backfill the same value from evidence. The main risk is heuristic tuning, so the implementation keeps the classifier deterministic, rule-aware, visible in evidence, and covered by focused tests.

## Sequencing

- #1228 is closed, so this third issue is ready for implementation review.
- #1230 should wait for this PR to merge because downstream intelligence features should consume the confidence metadata instead of re-inventing secret classification.

## Validation

- `go test ./internal/repoexposure ./internal/domain ./internal/api -count=1` passed.
- `go test ./...` passed.
- `go vet ./...` passed.
- `go test ./... -coverprofile=coverage.out` passed.
- `go tool cover -func=coverage.out` reported total coverage at `80.2%`.
- `git diff --check` passed.
- Local commit and push hooks passed.

## AI Assistance Disclosure

- AI-assisted: No
- Tools used: None
- Where used: Not applicable
- Human verification performed: focused scanner/domain/API tests, full Go test suite, coverage gate, Go vet, diff review, and local hooks.
