### PR TITLE
Wire app repo scans to GitHub connector context

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -42,6 +42,8 @@ export type RepoScanRecord = {
 
 export type RepoScanRequest = {
   repository: string;
+  project_id?: string;
+  connector_id?: string;
   history_limit?: number;
   max_findings?: number;
 };

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -346,7 +346,7 @@ describe('ProductProjectDetailPage', () => {
 
     await waitFor(() =>
       expect(runRepoScan).toHaveBeenCalledWith(
-        { repository: 'identrail/identrail' },
+        { repository: 'identrail/identrail', project_id: 'project-1', connector_id: 'github-app' },
         expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
       )
     );

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -70,7 +70,7 @@ const disconnectedAWS: AWSConnectionStatus = {
 };
 
 const connectedGitHub: GitHubConnectionStatus = {
-  provider: 'github',
+  provider: 'github_app',
   connected: true,
   connector_id: 'github-app',
   display_name: 'GitHub App',
@@ -92,6 +92,13 @@ const queuedRepoScan: RepoScanRecord = {
   files_scanned: 0,
   finding_count: 0,
   truncated: false
+};
+
+const connectedGitHubPAT: GitHubConnectionStatus = {
+  ...connectedGitHub,
+  provider: 'github_pat',
+  connector_id: 'github-enterprise',
+  display_name: 'GitHub Enterprise'
 };
 
 function deferred<T>() {
@@ -356,6 +363,22 @@ describe('ProductProjectDetailPage', () => {
       '/app/tenant-a/workspace-a/findings'
     );
     expect(screen.getByLabelText(/recent repository scan activity/i)).toHaveTextContent('Queued');
+  });
+
+  it('preserves the generic scan payload for GitHub PAT connections', async () => {
+    const { runRepoScan } = await renderProjectDetail(true, connectedGitHubPAT, { repoScans: [queuedRepoScan] });
+
+    const queueButton = await screen.findByRole('button', { name: /Queue first scan/i });
+    await waitFor(() => expect(queueButton).not.toBeDisabled());
+
+    fireEvent.click(queueButton);
+
+    await waitFor(() =>
+      expect(runRepoScan).toHaveBeenCalledWith(
+        { repository: 'identrail/identrail' },
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
   });
 
   it('keeps stale repo scan refresh responses from overwriting refreshed activity', async () => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -3531,7 +3531,10 @@ export function ProductProjectDetailPage() {
     const requestSequence = refreshSequenceRef.current;
     const submitSequence = nextRepoScanSubmitSequence();
     try {
-      const request: RepoScanRequest = { repository };
+      const request: RepoScanRequest = { repository, project_id: projectID };
+      if (connections.github?.connector_id) {
+        request.connector_id = connections.github.connector_id;
+      }
       const historyLimit = parseOptionalPositiveInteger(repoScanForm.historyLimit, 'History limit');
       const maxFindings = parseOptionalPositiveInteger(repoScanForm.maxFindings, 'Max findings');
       if (historyLimit) {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -3531,9 +3531,13 @@ export function ProductProjectDetailPage() {
     const requestSequence = refreshSequenceRef.current;
     const submitSequence = nextRepoScanSubmitSequence();
     try {
-      const request: RepoScanRequest = { repository, project_id: projectID };
-      if (connections.github?.connector_id) {
-        request.connector_id = connections.github.connector_id;
+      const githubConnection = connections.github;
+      const request: RepoScanRequest = { repository };
+      if (githubConnection?.provider === 'github_app') {
+        request.project_id = projectID;
+        if (githubConnection.connector_id) {
+          request.connector_id = githubConnection.connector_id;
+        }
       }
       const historyLimit = parseOptionalPositiveInteger(repoScanForm.historyLimit, 'History limit');
       const maxFindings = parseOptionalPositiveInteger(repoScanForm.maxFindings, 'Max findings');


### PR DESCRIPTION
Fixes #1227

## What changed
- Added `project_id` and `connector_id` to the web repo scan request type.
- Updated the project detail scan submit flow to include the current project id and GitHub connector id when queueing a repository scan.
- Tightened the product shell regression test so app-queued scans prove they use the connector-backed payload.

## Why it changed
The backend GitHub App/private repository scan path only activates when the queued scan includes connector context. The app already loads the project-scoped GitHub connection, but it only submitted the repository name, so UI-triggered scans could fall back to the unauthenticated scanner path.

## Impact and risk
Connected GitHub App scans started from the app now resolve the project installation and can mint a short-lived token for selected private repositories. The change is low risk because the existing public/manual repo scan path remains compatible and `connector_id` stays optional.

## Validation performed
- `npm run test --prefix web -- src/productShell.test.tsx --run` passed.
- `npm run test --prefix web -- src/api/client.test.ts --run` passed.
- `npm run test:ci --prefix web` passed.
- `npm run build --prefix web` passed.
- Commit and push hooks passed, including `go vet` during push.

## AI-assisted disclosure
- AI-assisted: yes
- Tools used: OpenAI Codex
- Where used: web repo scan payload wiring and regression test
- Human verification performed: reviewed the diff and ran the validation commands listed above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass project and GitHub App connector context when queueing repo scans so private repos authenticate correctly; PAT scans keep the generic payload. Fixes #1227.

- **Bug Fixes**
  - Include `project_id` and optional `connector_id` in `RepoScanRequest` only for GitHub App scans; leave PAT scans unchanged.
  - Update UI wiring and tests to assert connector-backed payload for GitHub App and generic payload for PAT.

<sup>Written for commit 95cf3acc4ac498cae50b7d3334b9fc68e93804fb. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1245?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

