### PR TITLE
Fix hosted repo scan worker runtime

### DIFF
--- a/.github/workflows/aws-api-log-diagnostics.yml
+++ b/.github/workflows/aws-api-log-diagnostics.yml
@@ -1,15 +1,23 @@
-name: AWS API Log Diagnostics
+name: AWS Service Log Diagnostics
 
 on:
   workflow_dispatch:
     inputs:
       minutes:
-        description: "How many recent minutes of API logs to inspect."
+        description: "How many recent minutes of service logs to inspect."
         required: true
         type: string
         default: "60"
+      service:
+        description: "Hosted service log group to inspect."
+        required: true
+        type: choice
+        default: "api"
+        options:
+          - api
+          - worker
       filter_pattern:
-        description: "CloudWatch Logs filter pattern. Use <none> to fetch recent API events without a filter."
+        description: "CloudWatch Logs filter pattern. Use <none> to fetch recent service events without a filter."
         required: false
         type: string
         default: '"authenticate workos callback"'
@@ -24,19 +32,19 @@ permissions:
   id-token: write
 
 concurrency:
-  group: aws-api-log-diagnostics
+  group: aws-service-log-diagnostics
   cancel-in-progress: false
 
 jobs:
   inspect:
-    name: Inspect AWS API logs
+    name: Inspect AWS service logs
     if: github.repository == 'identrail/identrail'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
       AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
-      LOG_GROUP_NAME: /identrail/dev/api
+      LOG_SERVICE: ${{ inputs.service }}
       FILTER_PATTERN: ${{ inputs.filter_pattern }}
       LOOKBACK_MINUTES: ${{ inputs.minutes }}
       MAX_EVENTS: ${{ inputs.max_events }}
@@ -85,10 +93,23 @@ jobs:
             exit 1
           fi
 
+          log_service="$(printf '%s' "${LOG_SERVICE}" | tr -d '[:space:]')"
+          case "${log_service}" in
+            api|worker)
+              log_group_name="/identrail/dev/${log_service}"
+              ;;
+            *)
+              echo "service must be one of: api, worker."
+              exit 1
+              ;;
+          esac
+
           {
             echo "AWS_REGION=${aws_region}"
             echo "AWS_DEFAULT_REGION=${aws_region}"
             echo "AWS_ROLE_ARN=${aws_role_arn}"
+            echo "LOG_GROUP_NAME=${log_group_name}"
+            echo "LOG_SERVICE=${log_service}"
           } >> "${GITHUB_ENV}"
 
       - name: Configure AWS credentials from GitHub OIDC
@@ -110,7 +131,7 @@ jobs:
           credentials="$(
             aws sts assume-role-with-web-identity \
               --role-arn "${AWS_ROLE_ARN}" \
-              --role-session-name "identrail-api-logs-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+              --role-session-name "identrail-${LOG_SERVICE}-logs-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
               --web-identity-token "${oidc_token}" \
               --duration-seconds 900 \
               --query 'Credentials' \
@@ -128,13 +149,13 @@ jobs:
             echo "AWS_SESSION_TOKEN=${session_token}"
           } >> "${GITHUB_ENV}"
 
-      - name: Fetch sanitized API log events
+      - name: Fetch sanitized service log events
         shell: bash
         run: |
           set -euo pipefail
 
           start_time_ms="$(( $(date +%s) * 1000 - LOOKBACK_MINUTES * 60 * 1000 ))"
-          events_file="${RUNNER_TEMP}/identrail-api-log-events.json"
+          events_file="${RUNNER_TEMP}/identrail-${LOG_SERVICE}-log-events.json"
           printf '{"events":[]}\n' > "${events_file}"
           filter_pattern="$(printf '%s' "${FILTER_PATTERN}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
           filter_pattern_lower="${filter_pattern,,}"
@@ -148,7 +169,7 @@ jobs:
           max_pages=20
 
           while :; do
-            page_file="${RUNNER_TEMP}/identrail-api-log-events-page-${pages_scanned}.json"
+            page_file="${RUNNER_TEMP}/identrail-${LOG_SERVICE}-log-events-page-${pages_scanned}.json"
             args=(
               --log-group-name "${LOG_GROUP_NAME}"
               --start-time "${start_time_ms}"
@@ -180,8 +201,9 @@ jobs:
           event_count="$(jq '.events | length' "${events_file}")"
 
           {
-            echo "## AWS API log diagnostics"
+            echo "## AWS service log diagnostics"
             echo
+            echo "- Service: \`${LOG_SERVICE}\`"
             echo "- Log group: \`${LOG_GROUP_NAME}\`"
             echo "- Lookback: \`${LOOKBACK_MINUTES}\` minutes"
             echo "- Filter pattern: \`${filter_pattern:-<none>}\`"
@@ -193,7 +215,7 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
 
           if [ "${event_count}" -eq 0 ]; then
-            echo "No matching API log events found."
+            echo "No matching service log events found."
             exit 0
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,9 @@ jobs:
       - name: Build Worker Image
         run: docker build -f deploy/docker/Dockerfile.backend --build-arg TARGET=worker -t identrail/worker:ci .
 
+      - name: Verify Worker Repo Scan Runtime
+        run: docker run --rm --entrypoint /usr/bin/git identrail/worker:ci --version
+
       - name: Build Web Image
         run: docker build -f deploy/docker/Dockerfile.web --build-arg VITE_IDENTRAIL_API_URL=http://localhost:8080 -t identrail/web:ci .
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Added the runtime `git` dependency to the backend API/worker image so hosted
+  repository exposure scans can clone and inspect selected repositories after
+  deployment, and added a CI smoke check plus worker-selectable AWS log
+  diagnostics for repo scan incidents.
 - Added rule-aware confidence classification for repository secret findings.
   Secret detections now carry deterministic `confidence_score`,
   `confidence_state`, and `confidence_reasons` metadata, distinguish likely

--- a/deploy/docker/Dockerfile.backend
+++ b/deploy/docker/Dockerfile.backend
@@ -14,10 +14,14 @@ ARG TARGETARCH=amd64
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
     go build -trimpath -ldflags="-s -w" -o /out/identrail ./cmd/${TARGET}
 
-FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1
+FROM alpine:3.22@sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601
 WORKDIR /app
 
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+RUN apk add --no-cache ca-certificates tzdata git \
+    && addgroup -S nonroot \
+    && adduser -S -G nonroot -H -h /app nonroot \
+    && git --version >/dev/null
+
 COPY --from=builder /out/identrail /usr/local/bin/identrail
 COPY --from=builder /src/migrations /app/migrations
 COPY --from=builder /src/testdata /app/testdata

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -3,6 +3,9 @@
 ## Files
 
 - `Dockerfile.backend`: builds API or worker image (`TARGET=server|worker`)
+  - the backend runtime image intentionally includes `git` because hosted
+    repository exposure scans perform read-only clone and history inspection at
+    runtime
 - `Dockerfile.web`: builds dashboard web image
   - production builds use the strict nginx CSP by default; Compose passes `NGINX_CONF=default.local.conf` for localhost API access.
 - `docker-compose.yml`: local single-host stack

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -189,6 +189,9 @@ workflow layer.
 
 ## Runtime Configuration
 
+- Hosted API/worker images must include `git` at runtime. The scanner performs
+  read-only clone and history commands inside the running worker, not only
+  during image build.
 - `IDENTRAIL_REPO_SCAN_ENABLED` (default: `false`)
 - `IDENTRAIL_REPO_SCAN_HISTORY_LIMIT` (default: `500`)
 - `IDENTRAIL_REPO_SCAN_MAX_FINDINGS` (default: `200`)


### PR DESCRIPTION
Fixes #1247

## What changed
- Switched the backend runtime stage to a pinned Alpine image and install `git`, CA certificates, and tzdata in the final API/worker image while keeping the container on the existing non-root `nonroot` user.
- Added a CI smoke check that runs `git --version` inside the built worker image so repo scan runtime support is enforced before merge.
- Extended AWS log diagnostics to choose the `api` or `worker` service log group with bounded input validation.
- Documented the runtime `git` requirement and noted the change in the changelog.

## Why
Hosted repository exposure scans execute read-only git clone/history commands from the running worker. The old image installed git only in the builder stage, then ran from a distroless runtime image without git. At the same time, the diagnostic workflow was hardcoded to API logs, so worker failures were difficult to inspect during repo scan incidents.

## Impact and risk
The API, worker, and agent still use the same compiled binary entrypoint and run as non-root. The runtime image now has the package surface required for repository scanning; the main tradeoff is a larger final image than distroless. Diagnostics remain limited to the known hosted API and worker log groups.

## Validation
- `go test ./internal/repoexposure ./internal/worker ./internal/api`
- `ruby -e 'require "yaml"; %w[.github/workflows/aws-api-log-diagnostics.yml .github/workflows/ci.yml].each { |f| YAML.load_file(f); puts "parsed #{f}" }'`\n- `git diff --check`\n- Commit/push hooks: merge conflict check, yaml check, EOF check, whitespace check, gofmt check, go vet, local env token hygiene, Vercel artifact hygiene\n\nLocal Docker validation could not run because the local Docker daemon socket is unavailable. The PR adds the worker-image `git --version` check to CI so the hosted build verifies this before merge.\n\nAI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix hosted repo scan failures by bundling git in the backend runtime image and verifying it in CI. Also allow AWS log diagnostics to target api or worker logs for easier incident debugging.

- **Bug Fixes**
  - Switched backend runtime to pinned `alpine:3.22`; installed `git`, CA certs, and tzdata while keeping the `nonroot` user.
  - Documented the runtime `git` requirement for repository exposure scans.

- **New Features**
  - CI smoke check runs `git --version` inside the built worker image.
  - AWS log diagnostics workflow now accepts a `service` input (`api` or `worker`) with input validation and correct log group selection.

<sup>Written for commit d821a340c256aabfd0094517efdb239aac634e0a. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1248?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

