### PR TITLE
Fix hosted repo scans stuck after git timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## Unreleased
+- Hardened hosted repository scan execution so cancelled git subprocesses are
+  terminated as a process group with a bounded wait, preventing worker timeouts
+  from leaving scans stuck in `running`. Worker logs now include repository
+  queue claim, requeue, success, and failure lifecycle events for CloudWatch
+  incident diagnosis.
 - Added the runtime `git` dependency to the backend API/worker image so hosted
   repository exposure scans can clone and inspect selected repositories after
   deployment, and added a CI smoke check plus worker-selectable AWS log

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -106,17 +106,18 @@ type queuedRepoScanDepthCounter interface {
 
 // Service orchestrates scan execution and persistence.
 type Service struct {
-	Store          db.Store
-	Scanner        ScannerRunner
-	Provider       string
-	DefaultScope   db.Scope
-	Now            func() time.Time
-	Locker         scheduler.Locker
-	LockNamespace  string
-	Alerter        FindingAlerter
-	OnAlertError   func(error)
-	ReadinessCheck func(context.Context) error
-	Metrics        *telemetry.Metrics
+	Store                db.Store
+	Scanner              ScannerRunner
+	Provider             string
+	DefaultScope         db.Scope
+	Now                  func() time.Time
+	Locker               scheduler.Locker
+	LockNamespace        string
+	Alerter              FindingAlerter
+	OnAlertError         func(error)
+	OnRepoScanQueueEvent func(RepoScanQueueEvent)
+	ReadinessCheck       func(context.Context) error
+	Metrics              *telemetry.Metrics
 	// Repo scan controls are intentionally separate from cloud identity scan flow.
 	RepoScanEnabled                 bool
 	RepoScanDefaultHistoryLimit     int
@@ -151,6 +152,17 @@ type Service struct {
 	githubWebhookLastQueued         map[string]time.Time
 	kubernetesConnectMu             sync.RWMutex
 	kubernetesConnections           map[string]kubernetesProjectConnection
+}
+
+// RepoScanQueueEvent reports visible lifecycle transitions for repository scans
+// drained by the worker API queue.
+type RepoScanQueueEvent struct {
+	Kind       string
+	RepoScanID string
+	Repository string
+	Status     string
+	Reason     string
+	Count      int
 }
 
 // CheckReadiness validates critical runtime dependencies for readiness checks.
@@ -1075,6 +1087,7 @@ func (s *Service) ProcessNextQueuedRepoScan(ctx context.Context) (bool, error) {
 			s.recordWorkerRequeue("repo_scan")
 		}
 		s.recordAutomationRun("api_queue", "repo_scan", "requeued")
+		s.emitRepoScanQueueEvent(RepoScanQueueEvent{Kind: "stale_requeued", Status: "queued", Reason: "stale_running", Count: requeuedStale})
 	}
 	record, err := s.Store.ClaimNextQueuedRepoScanAnyScope(ctx)
 	if err != nil {
@@ -1085,6 +1098,12 @@ func (s *Service) ProcessNextQueuedRepoScan(ctx context.Context) (bool, error) {
 		s.recordWorkerJob("repo_scan", "failure")
 		return false, fmt.Errorf("claim queued repo scan: %w", err)
 	}
+	s.emitRepoScanQueueEvent(RepoScanQueueEvent{
+		Kind:       "claimed",
+		RepoScanID: record.ID,
+		Repository: record.Repository,
+		Status:     "running",
+	})
 	recordScopeCtx := db.WithScope(ctx, db.Scope{
 		TenantID:    record.TenantID,
 		WorkspaceID: record.WorkspaceID,
@@ -1108,6 +1127,13 @@ func (s *Service) ProcessNextQueuedRepoScan(ctx context.Context) (bool, error) {
 		s.recordAutomationRun("api_queue", "repo_scan", "requeued")
 		s.recordWorkerJob("repo_scan", "requeued")
 		s.recordWorkerRequeue("repo_scan")
+		s.emitRepoScanQueueEvent(RepoScanQueueEvent{
+			Kind:       "requeued",
+			RepoScanID: record.ID,
+			Repository: record.Repository,
+			Status:     "queued",
+			Reason:     "execution_lock_held",
+		})
 		// A queued item was handled (requeued) even if this target is currently locked.
 		// Returning true lets the worker keep draining other queued targets in the same tick.
 		return true, nil
@@ -1117,11 +1143,29 @@ func (s *Service) ProcessNextQueuedRepoScan(ctx context.Context) (bool, error) {
 		s.recordAutomationRun("api_queue", "repo_scan", "failed")
 		s.recordWorkerJob("repo_scan", "failure")
 		s.recordWorkerDeadLetter("repo_scan")
+		s.emitRepoScanQueueEvent(RepoScanQueueEvent{
+			Kind:       "failed",
+			RepoScanID: record.ID,
+			Repository: record.Repository,
+			Status:     "failed",
+		})
 		return true, runErr
 	}
 	s.recordAutomationRun("api_queue", "repo_scan", "succeeded")
 	s.recordWorkerJob("repo_scan", "success")
+	s.emitRepoScanQueueEvent(RepoScanQueueEvent{
+		Kind:       "succeeded",
+		RepoScanID: record.ID,
+		Repository: record.Repository,
+		Status:     "succeeded",
+	})
 	return true, nil
+}
+
+func (s *Service) emitRepoScanQueueEvent(event RepoScanQueueEvent) {
+	if s != nil && s.OnRepoScanQueueEvent != nil {
+		s.OnRepoScanQueueEvent(event)
+	}
 }
 
 // RunRepoScanPersisted runs one repository scan and persists repo scan metadata + findings.

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -3319,6 +3319,10 @@ func TestServiceEnqueueRepoScanAndProcessQueue(t *testing.T) {
 	svc := NewService(store, fakeScanner{}, "aws")
 	svc.RepoScanAllowedTargets = []string{"owner/*"}
 	svc.RepoQueueMaxPending = 2
+	events := []RepoScanQueueEvent{}
+	svc.OnRepoScanQueueEvent = func(event RepoScanQueueEvent) {
+		events = append(events, event)
+	}
 	svc.RepoScannerFactory = func(historyLimit int, maxFindings int) RepoScanExecutor {
 		return &fakeRepoExecutor{
 			result: repoexposure.ScanResult{
@@ -3356,6 +3360,15 @@ func TestServiceEnqueueRepoScanAndProcessQueue(t *testing.T) {
 	}
 	if stored.Status != "succeeded" || stored.CommitsScanned != 25 {
 		t.Fatalf("unexpected processed repo scan record: %+v", stored)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected claimed and succeeded queue events, got %+v", events)
+	}
+	if events[0].Kind != "claimed" || events[0].RepoScanID != record.ID || events[0].Repository != "owner/repo" || events[0].Status != "running" {
+		t.Fatalf("unexpected claimed queue event: %+v", events[0])
+	}
+	if events[1].Kind != "succeeded" || events[1].RepoScanID != record.ID || events[1].Repository != "owner/repo" || events[1].Status != "succeeded" {
+		t.Fatalf("unexpected succeeded queue event: %+v", events[1])
 	}
 }
 

--- a/internal/repoexposure/command.go
+++ b/internal/repoexposure/command.go
@@ -1,0 +1,19 @@
+package repoexposure
+
+import (
+	"context"
+	"os/exec"
+	"time"
+)
+
+const defaultCommandWaitDelay = 5 * time.Second
+
+func newRepositoryCommand(ctx context.Context, name string, args ...string) *exec.Cmd {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.WaitDelay = defaultCommandWaitDelay
+	configureRepositoryCommand(cmd)
+	return cmd
+}

--- a/internal/repoexposure/command_other.go
+++ b/internal/repoexposure/command_other.go
@@ -1,0 +1,7 @@
+//go:build !aix && !android && !darwin && !dragonfly && !freebsd && !illumos && !linux && !netbsd && !openbsd && !solaris && !windows
+
+package repoexposure
+
+import "os/exec"
+
+func configureRepositoryCommand(_ *exec.Cmd) {}

--- a/internal/repoexposure/command_unix.go
+++ b/internal/repoexposure/command_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build aix || android || darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd || solaris
 
 package repoexposure
 

--- a/internal/repoexposure/command_unix.go
+++ b/internal/repoexposure/command_unix.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package repoexposure
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func configureRepositoryCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		if pgid, err := syscall.Getpgid(cmd.Process.Pid); err == nil {
+			err = syscall.Kill(-pgid, syscall.SIGKILL)
+			if err == nil || errors.Is(err, syscall.ESRCH) {
+				return nil
+			}
+		}
+		err := cmd.Process.Kill()
+		if errors.Is(err, os.ErrProcessDone) {
+			return nil
+		}
+		return err
+	}
+}

--- a/internal/repoexposure/command_unix_test.go
+++ b/internal/repoexposure/command_unix_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build aix || android || darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd || solaris
 
 package repoexposure
 

--- a/internal/repoexposure/command_unix_test.go
+++ b/internal/repoexposure/command_unix_test.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package repoexposure
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestDefaultCommandRunnerCancelsDescendantProcess(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	started := time.Now()
+	_, err := defaultCommandRunner(ctx, "sh", "-c", "(sleep 30) & wait")
+	if err == nil || !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("expected command cancellation after deadline, err=%v ctx=%v", err, ctx.Err())
+	}
+	if elapsed := time.Since(started); elapsed > 2*time.Second {
+		t.Fatalf("expected command tree to stop promptly, elapsed %s", elapsed)
+	}
+}

--- a/internal/repoexposure/command_windows.go
+++ b/internal/repoexposure/command_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package repoexposure
+
+import "os/exec"
+
+func configureRepositoryCommand(_ *exec.Cmd) {}

--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -465,7 +465,7 @@ func (s *Scanner) gitStream(ctx context.Context, repo repositoryLocation, args .
 	} else {
 		invocation = append([]string{"-C", repo.Path}, args...)
 	}
-	cmd := exec.CommandContext(ctx, "git", invocation...)
+	cmd := newRepositoryCommand(ctx, "git", invocation...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	stdout, err := cmd.StdoutPipe()
@@ -976,12 +976,12 @@ func severityRank(severity domain.FindingSeverity) int {
 }
 
 func defaultCommandRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, name, args...)
+	cmd := newRepositoryCommand(ctx, name, args...)
 	return cmd.CombinedOutput()
 }
 
 func defaultEnvCommandRunner(ctx context.Context, env []string, name string, args ...string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, name, args...)
+	cmd := newRepositoryCommand(ctx, name, args...)
 	cmd.Env = append(os.Environ(), env...)
 	return cmd.CombinedOutput()
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -62,6 +62,27 @@ func Run(ctx context.Context, cfg config.Config, signals <-chan os.Signal) error
 	svc.OnAlertError = func(alertErr error) {
 		logger.Warn("scan alert delivery failed", telemetry.ZapError(alertErr))
 	}
+	svc.OnRepoScanQueueEvent = func(event api.RepoScanQueueEvent) {
+		fields := telemetry.StandardLogFields(
+			"worker",
+			"api_queue_repo_scan",
+			telemetry.String("event", event.Kind),
+			telemetry.String("outcome", event.Status),
+		)
+		if event.RepoScanID != "" {
+			fields = append(fields, telemetry.String("repo_scan_id", event.RepoScanID))
+		}
+		if event.Repository != "" {
+			fields = append(fields, telemetry.String("repository", event.Repository))
+		}
+		if event.Reason != "" {
+			fields = append(fields, telemetry.String("reason", event.Reason))
+		}
+		if event.Count > 0 {
+			fields = append(fields, telemetry.String("count", fmt.Sprint(event.Count)))
+		}
+		logger.Info("repo scan queue event", fields...)
+	}
 	writeHeartbeat := func() {
 		if err := writeWorkerHeartbeat(cfg.WorkerHeartbeatPath); err != nil {
 			logger.Warn("worker heartbeat write failed", telemetry.ZapError(err))


### PR DESCRIPTION
Fixes #1249

## What changed
- Run repository scan git commands in their own process group and kill the full subprocess tree on context cancellation.
- Add a bounded command wait delay so cancelled git commands cannot keep the worker blocked by inherited pipes.
- Emit worker repo queue lifecycle logs for stale requeues, claims, lock requeues, successes, and failures.
- Add regression coverage for descendant process cancellation and queue lifecycle events.
- Document the operator-visible behavior in the changelog.

## Why it changed
Production evidence showed a GitHub repo scan staying `running` beyond the worker repo-scan timeout. The worker remained alive and scan-policy heartbeats continued, but recent repo-scan error logs were absent. That points to the API queue goroutine being trapped in the repository scanner. The scanner previously relied on `exec.CommandContext` for git commands, which can kill only the parent git process and still wait on child processes or inherited pipes.

## Impact and risk
This is a reliability hardening change for hosted repo scans. It does not change detector rules, GitHub App permissions, or repository allowlist behavior. On timeout/cancellation, scans should now fail terminally instead of wedging the worker queue.

## Validation performed
- `go test ./internal/repoexposure ./internal/api ./internal/worker`
- `go test ./...`
- `go test ./... -coverprofile=coverage.out && go tool cover -func=coverage.out | tail -1` -> total coverage `80.2%`
- `go vet ./...`
- `go run ./cmd/cli repo-scan --repo /Users/user1/Documents/Aurelius/identrail --history-limit 20 --max-findings 20 --output json`
- `git diff --check`

AI-assisted: yes
Tools used: OpenAI assistant
Where used: investigation, implementation, tests, and PR text
Human verification performed: reviewed code paths, production logs, and validation output above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents hosted repo scans from getting stuck after git timeouts by running repository commands in their own process group and killing the full subprocess tree on cancellation. Adds a bounded wait and queue lifecycle events so timeouts fail fast without wedging the worker.

- **Bug Fixes**
  - Route all repo command invocations through newRepositoryCommand with process‑group cancel and a 5s WaitDelay (Unix: setpgid + group SIGKILL; Windows/others: no‑op; fixed build tags).
  - Emit RepoScanQueueEvent for stale requeues (with count), claims, lock requeues (with reason), successes, and failures; worker logs these events.
  - Timeouts/cancellations now fail the scan and release the queue instead of staying running.
  - Add regression tests for descendant‑process cancellation and queue events.

<sup>Written for commit 892530f58649f31cf5f60215b8f2a57ad8742b04. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1250?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

