### PR TITLE
Fix hosted repo scan terminal recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   `secure`, `insecure`, `permission_limited`, and `unavailable` states, capture
   rate-limit metadata, keep webhook evidence redacted, and document the
   read-only GitHub App permissions required for the collector.
+- Marked stale hosted repository scans as terminal `failed` records instead of
+  requeueing them into another silent `running` loop. Queue workers now emit
+  explicit claim-attempt and scan-start lifecycle events so hosted repo scan
+  incidents identify the exact boundary before scanner execution.
 - Hardened hosted repository scan execution so cancelled git subprocesses are
   terminated as a process group with a bounded wait, preventing worker timeouts
   from leaving scans stuck in `running`. Worker logs now include repository

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -38,7 +38,8 @@ const (
 	defaultScanRetryMaxDelay         = 15 * time.Minute
 	defaultRepoQueueMaxPending       = 100
 	defaultRepoScanRunningStaleAfter = 35 * time.Minute
-	defaultRepoScanStaleRequeueLimit = 100
+	defaultRepoScanStaleFailureLimit = 100
+	staleRepoScanFailureMessage      = "repository scan exceeded worker timeout before reporting a terminal result"
 	defaultGitHubWebhookReplayWindow = 24 * time.Hour
 	defaultGitHubWebhookBurstWindow  = 30 * time.Second
 	maxSourceErrorsInEvent           = 25
@@ -1074,21 +1075,29 @@ func (s *Service) EnqueueRepoScan(ctx context.Context, request RepoScanRequest) 
 // ProcessNextQueuedRepoScan claims and executes one queued repository scan. It returns false when no job is available.
 func (s *Service) ProcessNextQueuedRepoScan(ctx context.Context) (bool, error) {
 	ctx = s.scopeContext(ctx)
-	requeuedStale, err := s.Store.RequeueStaleRepoScansAnyScope(
+	failedStale, err := s.Store.FailStaleRepoScansAnyScope(
 		ctx,
 		s.Now().UTC().Add(-defaultRepoScanRunningStaleAfter),
-		defaultRepoScanStaleRequeueLimit,
+		defaultRepoScanStaleFailureLimit,
+		staleRepoScanFailureMessage,
 	)
 	if err != nil {
 		s.recordWorkerJob("repo_scan", "failure")
-		return false, fmt.Errorf("requeue stale repo scans: %w", err)
+		return false, fmt.Errorf("fail stale repo scans: %w", err)
 	}
-	if requeuedStale > 0 {
-		for i := 0; i < requeuedStale; i++ {
-			s.recordWorkerRequeue("repo_scan")
+	if failedStale > 0 {
+		for i := 0; i < failedStale; i++ {
+			s.recordWorkerJob("repo_scan", "failure")
+			s.recordWorkerDeadLetter("repo_scan")
 		}
-		s.recordAutomationRun("api_queue", "repo_scan", "requeued")
-		s.emitRepoScanQueueEvent(RepoScanQueueEvent{Kind: "stale_requeued", Status: "queued", Reason: "stale_running", Count: requeuedStale})
+		s.recordAutomationRun("api_queue", "repo_scan", "failed")
+		s.emitRepoScanQueueEvent(RepoScanQueueEvent{Kind: "stale_failed", Status: "failed", Reason: "stale_running", Count: failedStale})
+		return true, nil
+	}
+	queuedCount := s.countQueuedRepoScansForDepth(ctx)
+	s.recordQueueDepth("repo_scan", queuedCount)
+	if queuedCount > 0 {
+		s.emitRepoScanQueueEvent(RepoScanQueueEvent{Kind: "claim_attempt", Status: "pending", Count: queuedCount})
 	}
 	record, err := s.Store.ClaimNextQueuedRepoScanAnyScope(ctx)
 	if err != nil {
@@ -1139,6 +1148,12 @@ func (s *Service) ProcessNextQueuedRepoScan(ctx context.Context) (bool, error) {
 		// Returning true lets the worker keep draining other queued targets in the same tick.
 		return true, nil
 	}
+	s.emitRepoScanQueueEvent(RepoScanQueueEvent{
+		Kind:       "scan_started",
+		RepoScanID: record.ID,
+		Repository: record.Repository,
+		Status:     "running",
+	})
 	_, runErr := s.runRepoScanWithRecord(recordScopeCtx, record, record.HistoryLimit, record.MaxFindings)
 	if runErr != nil {
 		s.recordAutomationRun("api_queue", "repo_scan", "failed")

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -48,9 +48,11 @@ type fakeRepoExecutor struct {
 	err    error
 	target string
 	runCtx context.Context
+	calls  int
 }
 
 func (f *fakeRepoExecutor) ScanRepository(ctx context.Context, target string) (repoexposure.ScanResult, error) {
+	f.calls++
 	f.target = target
 	f.runCtx = ctx
 	if f.err != nil {
@@ -3361,14 +3363,20 @@ func TestServiceEnqueueRepoScanAndProcessQueue(t *testing.T) {
 	if stored.Status != "succeeded" || stored.CommitsScanned != 25 {
 		t.Fatalf("unexpected processed repo scan record: %+v", stored)
 	}
-	if len(events) != 2 {
-		t.Fatalf("expected claimed and succeeded queue events, got %+v", events)
+	if len(events) != 4 {
+		t.Fatalf("expected claim attempt, claimed, scan started, and succeeded queue events, got %+v", events)
 	}
-	if events[0].Kind != "claimed" || events[0].RepoScanID != record.ID || events[0].Repository != "owner/repo" || events[0].Status != "running" {
-		t.Fatalf("unexpected claimed queue event: %+v", events[0])
+	if events[0].Kind != "claim_attempt" || events[0].Status != "pending" || events[0].Count != 1 {
+		t.Fatalf("unexpected claim attempt queue event: %+v", events[0])
 	}
-	if events[1].Kind != "succeeded" || events[1].RepoScanID != record.ID || events[1].Repository != "owner/repo" || events[1].Status != "succeeded" {
-		t.Fatalf("unexpected succeeded queue event: %+v", events[1])
+	if events[1].Kind != "claimed" || events[1].RepoScanID != record.ID || events[1].Repository != "owner/repo" || events[1].Status != "running" {
+		t.Fatalf("unexpected claimed queue event: %+v", events[1])
+	}
+	if events[2].Kind != "scan_started" || events[2].RepoScanID != record.ID || events[2].Repository != "owner/repo" || events[2].Status != "running" {
+		t.Fatalf("unexpected scan started queue event: %+v", events[2])
+	}
+	if events[3].Kind != "succeeded" || events[3].RepoScanID != record.ID || events[3].Repository != "owner/repo" || events[3].Status != "succeeded" {
+		t.Fatalf("unexpected succeeded queue event: %+v", events[3])
 	}
 }
 
@@ -3655,19 +3663,20 @@ func TestServiceProcessQueuedRepoScanAcrossScopes(t *testing.T) {
 	}
 }
 
-func TestServiceProcessNextQueuedRepoScanRecoversStaleRunningScan(t *testing.T) {
+func TestServiceProcessNextQueuedRepoScanFailsStaleRunningScan(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 5, 18, 23, 45, 0, 0, time.UTC)
 	svc := NewService(store, fakeScanner{}, "aws")
 	svc.Now = func() time.Time { return now }
+	executor := &fakeRepoExecutor{
+		result: repoexposure.ScanResult{
+			Repository:     "owner/repo",
+			CommitsScanned: 10,
+			FilesScanned:   2,
+		},
+	}
 	svc.RepoScannerFactory = func(historyLimit int, maxFindings int) RepoScanExecutor {
-		return &fakeRepoExecutor{
-			result: repoexposure.ScanResult{
-				Repository:     "owner/repo",
-				CommitsScanned: historyLimit,
-				FilesScanned:   2,
-			},
-		}
+		return executor
 	}
 	staleRunning, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, now.Add(-40*time.Minute))
 	if err != nil {
@@ -3679,14 +3688,23 @@ func TestServiceProcessNextQueuedRepoScanRecoversStaleRunningScan(t *testing.T) 
 		t.Fatalf("process stale running repo scan: %v", err)
 	}
 	if !processed {
-		t.Fatal("expected stale running repo scan to be recovered and processed")
+		t.Fatal("expected stale running repo scan to be handled")
 	}
 	stored, err := svc.GetRepoScan(defaultScopeContext(), staleRunning.ID)
 	if err != nil {
-		t.Fatalf("get recovered repo scan: %v", err)
+		t.Fatalf("get failed stale repo scan: %v", err)
 	}
-	if stored.Status != "succeeded" || stored.FilesScanned != 2 {
-		t.Fatalf("expected stale running repo scan to complete, got %+v", stored)
+	if stored.Status != "failed" {
+		t.Fatalf("expected stale running repo scan to fail, got %+v", stored)
+	}
+	if stored.FinishedAt == nil {
+		t.Fatalf("expected stale running repo scan to have finished_at set, got %+v", stored)
+	}
+	if stored.ErrorMessage != staleRepoScanFailureMessage {
+		t.Fatalf("expected stale running repo scan error %q, got %q", staleRepoScanFailureMessage, stored.ErrorMessage)
+	}
+	if executor.calls != 0 {
+		t.Fatalf("expected stale running repo scan not to run scanner, got %d calls", executor.calls)
 	}
 }
 

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -2054,8 +2054,8 @@ func (m *MemoryStore) RequeueRepoScan(ctx context.Context, repoScanID string) er
 	return nil
 }
 
-// RequeueStaleRepoScansAnyScope moves stale running repository scans back to queued state across all scopes.
-func (m *MemoryStore) RequeueStaleRepoScansAnyScope(_ context.Context, staleBefore time.Time, limit int) (int, error) {
+// FailStaleRepoScansAnyScope marks stale running repository scans failed across all scopes.
+func (m *MemoryStore) FailStaleRepoScansAnyScope(_ context.Context, staleBefore time.Time, limit int, errorMessage string) (int, error) {
 	if limit <= 0 {
 		return 0, nil
 	}
@@ -2077,12 +2077,11 @@ func (m *MemoryStore) RequeueStaleRepoScansAnyScope(_ context.Context, staleBefo
 	if len(candidates) > limit {
 		candidates = candidates[:limit]
 	}
-	now := time.Now().UTC()
+	finishedAt := time.Now().UTC()
 	for _, record := range candidates {
-		record.Status = "queued"
-		record.StartedAt = now
-		record.FinishedAt = nil
-		record.ErrorMessage = ""
+		record.Status = "failed"
+		record.FinishedAt = &finishedAt
+		record.ErrorMessage = strings.TrimSpace(errorMessage)
 		m.repoScans[record.ID] = record
 	}
 	return len(candidates), nil

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -1264,7 +1264,7 @@ func TestMemoryStoreClaimNextQueuedRepoScanAnyScope(t *testing.T) {
 	}
 }
 
-func TestMemoryStoreRequeueStaleRepoScansAnyScope(t *testing.T) {
+func TestMemoryStoreFailStaleRepoScansAnyScope(t *testing.T) {
 	store := NewMemoryStore()
 	staleAt := time.Date(2026, 5, 18, 20, 0, 0, 0, time.UTC)
 	cutoff := staleAt.Add(35 * time.Minute)
@@ -1283,19 +1283,19 @@ func TestMemoryStoreRequeueStaleRepoScansAnyScope(t *testing.T) {
 		t.Fatalf("create fresh repo scan: %v", err)
 	}
 
-	requeued, err := store.RequeueStaleRepoScansAnyScope(context.Background(), cutoff, 1)
+	failed, err := store.FailStaleRepoScansAnyScope(context.Background(), cutoff, 1, " worker timed out ")
 	if err != nil {
-		t.Fatalf("requeue stale repo scans: %v", err)
+		t.Fatalf("fail stale repo scans: %v", err)
 	}
-	if requeued != 1 {
-		t.Fatalf("expected one stale repo scan requeued, got %d", requeued)
+	if failed != 1 {
+		t.Fatalf("expected one stale repo scan failed, got %d", failed)
 	}
 	firstStored, err := store.GetRepoScan(defaultScopeContext(), firstStale.ID)
 	if err != nil {
 		t.Fatalf("get first stale repo scan: %v", err)
 	}
-	if firstStored.Status != "queued" {
-		t.Fatalf("expected first stale scan to be queued, got %q", firstStored.Status)
+	if firstStored.Status != "failed" || firstStored.FinishedAt == nil || firstStored.ErrorMessage != "worker timed out" {
+		t.Fatalf("expected first stale scan to be failed with terminal details, got %+v", firstStored)
 	}
 	secondStored, err := store.GetRepoScan(otherScope, secondStale.ID)
 	if err != nil {
@@ -1305,19 +1305,19 @@ func TestMemoryStoreRequeueStaleRepoScansAnyScope(t *testing.T) {
 		t.Fatalf("expected second stale scan to remain running after limited recovery, got %q", secondStored.Status)
 	}
 
-	requeued, err = store.RequeueStaleRepoScansAnyScope(context.Background(), cutoff, 10)
+	failed, err = store.FailStaleRepoScansAnyScope(context.Background(), cutoff, 10, "worker timed out")
 	if err != nil {
-		t.Fatalf("requeue remaining stale repo scans: %v", err)
+		t.Fatalf("fail remaining stale repo scans: %v", err)
 	}
-	if requeued != 1 {
-		t.Fatalf("expected one remaining stale repo scan requeued, got %d", requeued)
+	if failed != 1 {
+		t.Fatalf("expected one remaining stale repo scan failed, got %d", failed)
 	}
 	secondStored, err = store.GetRepoScan(otherScope, secondStale.ID)
 	if err != nil {
-		t.Fatalf("get requeued second stale repo scan: %v", err)
+		t.Fatalf("get failed second stale repo scan: %v", err)
 	}
-	if secondStored.Status != "queued" {
-		t.Fatalf("expected second stale scan to be queued, got %q", secondStored.Status)
+	if secondStored.Status != "failed" || secondStored.FinishedAt == nil || secondStored.ErrorMessage != "worker timed out" {
+		t.Fatalf("expected second stale scan to be failed with terminal details, got %+v", secondStored)
 	}
 	freshStored, err := store.GetRepoScan(defaultScopeContext(), fresh.ID)
 	if err != nil {

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -2897,8 +2897,8 @@ func (p *PostgresStore) RequeueRepoScan(ctx context.Context, repoScanID string) 
 	return nil
 }
 
-// RequeueStaleRepoScansAnyScope moves stale running repository scans back to queued across all scopes.
-func (p *PostgresStore) RequeueStaleRepoScansAnyScope(ctx context.Context, staleBefore time.Time, limit int) (int, error) {
+// FailStaleRepoScansAnyScope marks stale running repository scans failed across all scopes.
+func (p *PostgresStore) FailStaleRepoScansAnyScope(ctx context.Context, staleBefore time.Time, limit int, errorMessage string) (int, error) {
 	if limit <= 0 {
 		return 0, nil
 	}
@@ -2914,21 +2914,21 @@ func (p *PostgresStore) RequeueStaleRepoScansAnyScope(ctx context.Context, stale
 			LIMIT $2
 		)
 		UPDATE repo_scans AS r
-		SET status = 'queued',
-		    started_at = NOW(),
-		    finished_at = NULL,
-		    error_message = NULL
+		SET status = 'failed',
+		    finished_at = NOW(),
+		    error_message = NULLIF($3, '')
 		FROM stale_repo_scans
 		WHERE r.id = stale_repo_scans.id`,
 		staleBefore.UTC(),
 		limit,
+		strings.TrimSpace(errorMessage),
 	)
 	if err != nil {
-		return 0, fmt.Errorf("requeue stale repo scans: %w", err)
+		return 0, fmt.Errorf("fail stale repo scans: %w", err)
 	}
 	affected, err := result.RowsAffected()
 	if err != nil {
-		return 0, fmt.Errorf("requeue stale repo scans rows affected: %w", err)
+		return 0, fmt.Errorf("fail stale repo scans rows affected: %w", err)
 	}
 	return int(affected), nil
 }

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -1550,7 +1550,7 @@ func TestPostgresStoreCountQueuedRepoScansAnyScope(t *testing.T) {
 	}
 }
 
-func TestPostgresStoreRequeueStaleRepoScansAnyScope(t *testing.T) {
+func TestPostgresStoreFailStaleRepoScansAnyScope(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock: %v", err)
@@ -1569,21 +1569,20 @@ func TestPostgresStoreRequeueStaleRepoScansAnyScope(t *testing.T) {
 			LIMIT $2
 		)
 		UPDATE repo_scans AS r
-		SET status = 'queued',
-		    started_at = NOW(),
-		    finished_at = NULL,
-		    error_message = NULL
+		SET status = 'failed',
+		    finished_at = NOW(),
+		    error_message = NULLIF($3, '')
 		FROM stale_repo_scans
 		WHERE r.id = stale_repo_scans.id`)).
-		WithArgs(staleBefore, 25).
+		WithArgs(staleBefore, 25, "worker timed out").
 		WillReturnResult(sqlmock.NewResult(0, 2))
 
-	requeued, err := store.RequeueStaleRepoScansAnyScope(context.Background(), staleBefore, 25)
+	failed, err := store.FailStaleRepoScansAnyScope(context.Background(), staleBefore, 25, " worker timed out ")
 	if err != nil {
-		t.Fatalf("requeue stale repo scans any scope: %v", err)
+		t.Fatalf("fail stale repo scans any scope: %v", err)
 	}
-	if requeued != 2 {
-		t.Fatalf("expected two stale repo scans requeued, got %d", requeued)
+	if failed != 2 {
+		t.Fatalf("expected two stale repo scans failed, got %d", failed)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2299,7 +2299,7 @@ type Store interface {
 	CountQueuedRepoScans(ctx context.Context) (int, error)
 	CountPendingRepoScansByRepository(ctx context.Context, repository string) (int, error)
 	RequeueRepoScan(ctx context.Context, repoScanID string) error
-	RequeueStaleRepoScansAnyScope(ctx context.Context, staleBefore time.Time, limit int) (int, error)
+	FailStaleRepoScansAnyScope(ctx context.Context, staleBefore time.Time, limit int, errorMessage string) (int, error)
 	GetRepoScan(ctx context.Context, repoScanID string) (RepoScanRecord, error)
 	CompleteRepoScan(ctx context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, errorMessage string) error
 	UpsertRepoFindings(ctx context.Context, repoScanID string, findings []domain.Finding) error


### PR DESCRIPTION
Fixes #1251

## Summary

Hosted repository scans now fail stale `running` records instead of requeueing them into another silent `running` loop.

This PR also adds explicit repo queue lifecycle events before scanner execution:

- `claim_attempt` when queued work exists before claiming
- `scan_started` after the execution lock is acquired and before the scanner runs
- `stale_failed` when stale `running` records are moved to a terminal failed state

## Why

Production scans were staying `running` for long periods with zero files and zero findings, including on a fresh account. The hosted worker was alive, but stale recovery could move old `running` rows back into the queue and immediately make them appear active again without surfacing a terminal error to the user.

That behavior made the UI look permanently busy and hid the real failure boundary. A stale scan should become visible as failed so the user can queue a fresh scan and operators can see that the worker timed out before reporting a terminal result.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

Risk is limited to stale repository scan recovery and queue lifecycle telemetry. Normal queued scans still claim and execute through the existing path. Lock-held scans still use the existing per-record requeue path.

## Validation

```bash
go test ./internal/db -run 'FailStaleRepoScans|RequeueStaleRepoScans|ClaimNextQueuedRepoScan'
go test ./internal/api -run 'TestServiceEnqueueRepoScanAndProcessQueue|TestServiceProcessNextQueuedRepoScan|TestServiceProcessQueuedRepoScan'
go test ./internal/db ./internal/api ./internal/worker
git diff --check
git diff --cached --check
```

All checks passed locally. The push hook also ran merge-conflict checks, gofmt, go vet, local env token hygiene, and Vercel artifact hygiene successfully.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: yes
- Tools used: OpenAI Codex
- Areas where used: repo scan queue recovery logic, store tests, service tests, PR preparation
- Human verification performed: reviewed production evidence, reviewed the diff, ran targeted and package-level Go tests, ran diff whitespace checks

## Related Issues

Fixes #1251


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hosted repo scans now mark stale running records as terminal failed instead of requeueing, so users see a clear error and the UI stops looking busy forever. Added queue lifecycle events to make claim attempts and scan start boundaries visible.

- New Features
  - Emit queue events: `claim_attempt`, `scan_started`, `stale_failed`.
  - Record queue depth before claiming and emit `claim_attempt` when pending work exists.

- Bug Fixes
  - Replace requeue loop with terminal failure for stale `running` scans, with a clear error: "repository scan exceeded worker timeout before reporting a terminal result".
  - Report failures as dead-letter and skip executing the scanner for stale records.
  - Update store API to `FailStaleRepoScansAnyScope(...)` (memory and Postgres) and wire through service logic.

<sup>Written for commit 61134fde29fe24f629dd3fb3a2f161958dbe832c. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1252?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

