### PR TITLE
Add GitHub Actions workflow attack analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ## Unreleased
+- Added context-aware GitHub Actions workflow attack analysis to repository
+  exposure scans. Workflow findings now distinguish shallow
+  `pull_request_target` / `write-all` signals from dangerous combinations such
+  as untrusted PR-head checkout, privileged `pull_request_target` jobs,
+  unpinned third-party actions, shell interpolation of PR metadata,
+  workflow_run privilege chains, broad OIDC trust, cache poisoning, and
+  artifact or release publishing reachable from untrusted inputs.
 - Added GitHub App repository posture collection. The connector can now collect
   normalized posture checks for selected repositories, including repository
   metadata, default branch protection, branch rulesets, Actions permissions,

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -103,6 +103,16 @@ The scanner uses a versioned secret detector registry for commit-history secret 
 - Misconfiguration detectors (HEAD):
   - GitHub Actions `permissions: write-all`
   - GitHub Actions `pull_request_target` trigger
+  - GitHub Actions workflow attack paths:
+    - `pull_request_target` checking out untrusted PR head code
+    - privileged `pull_request_target` jobs with write-token scopes or secrets
+    - workflow/job-level broad token write scopes
+    - unpinned third-party actions that use mutable refs
+    - shell interpolation of PR or issue-controlled GitHub context
+    - unsafe `workflow_run` privilege chains
+    - broad OIDC credential-minting context
+    - cache keys or restore paths influenced by untrusted PR context
+    - artifact or release publishing reachable from untrusted inputs
   - Kubernetes `privileged: true`
   - Terraform public S3 ACL
   - Terraform SSH/RDP open to world (`0.0.0.0/0`)
@@ -126,6 +136,37 @@ The scanner uses a versioned secret detector registry for commit-history secret 
   - `confidence_score`
   - `confidence_state`
   - `confidence_reasons`
+
+GitHub Actions workflow findings also include contextual evidence such as:
+
+- `workflow_events`
+- `workflow_job`
+- `workflow_step_index`
+- `workflow_action`
+- `permission_summary`
+- `write_scopes`
+- detector-specific evidence such as `checkout_ref`, `untrusted_context`,
+  `cache_key`, `cache_restore_keys`, or `publishes_release`
+
+This lets Identrail report the dangerous combination instead of only reporting
+that a keyword exists. For example, a hardened `pull_request_target` metadata
+workflow can remain a lower-context signal, while a `pull_request_target`
+workflow that checks out `${{ github.event.pull_request.head.sha }}` and grants
+write permissions is emitted as a critical workflow attack path.
+
+### GitHub Actions Workflow Detectors
+
+| Detector | Signal | Typical severity | Recommended remediation |
+| --- | --- | --- | --- |
+| `workflow_broad_token_permissions` | Workflow or job `GITHUB_TOKEN` permissions grant write-capable scopes beyond `id-token: write`. | High | Default to read-only workflow permissions and move write scopes to the smallest job that needs them. |
+| `workflow_pull_request_target_privileged_context` | `pull_request_target` runs with write-token permissions or secret access. | Critical | Keep `pull_request_target` metadata-only, remove secrets, and move untrusted code execution to `pull_request`. |
+| `workflow_pull_request_target_untrusted_checkout` | `pull_request_target` checks out PR head ref, SHA, or fork repository. | Critical | Checkout only trusted base code in privileged workflows, or split the untrusted build into an unprivileged workflow. |
+| `workflow_unpinned_third_party_action` | A non-local action outside `actions/*` uses a mutable tag or branch instead of a full commit SHA. | Medium | Pin third-party actions to audited commit SHAs and update them through reviewed dependency changes. |
+| `workflow_shell_injection_user_context` | A shell step interpolates PR title/body/branch, issue text, or comment body directly. | High | Pass user-controlled context through quoted environment variables or avoid shell interpolation entirely. |
+| `workflow_run_privilege_chain` | `workflow_run` reaches write permissions, secrets, cloud login, or release behavior. | High | Treat upstream artifacts as untrusted, validate them before privileged use, and gate deploy jobs with environments. |
+| `workflow_oidc_broad_trust` | `id-token: write` is available from untrusted events, `workflow_run`, or broad all-branch push deploys. | High | Restrict cloud trust policies to protected branches and environments, and avoid OIDC on untrusted workflow paths. |
+| `workflow_cache_poisoning` | Cache keys or restore paths are influenced by PR-controlled context, or broad restore keys are used on untrusted events. | Medium | Separate untrusted PR caches from trusted build caches and avoid broad restore keys in privileged jobs. |
+| `workflow_artifact_poisoning` | PR or `workflow_run` context can upload artifacts or release assets consumed later. | Medium to high | Keep untrusted artifacts isolated, verify provenance before reuse, and publish releases only from protected contexts. |
 
 To add a new secret detector, add a new entry to the registry with a unique ID, a new version if needed for compatibility, and test fixtures.
 

--- a/internal/repoexposure/rules.go
+++ b/internal/repoexposure/rules.go
@@ -1178,6 +1178,7 @@ func detectYAMLMisconfigFindings(
 			}
 		}
 
+		findings = append(findings, analyzeGitHubWorkflowFindings(repo, commit, path, ast, seen, detectedAt)...)
 		findings = append(findings, findYAMLPrivilegedFindings(repo, commit, path, ast, seen, detectedAt)...)
 	}
 

--- a/internal/repoexposure/workflow_analyzer.go
+++ b/internal/repoexposure/workflow_analyzer.go
@@ -611,7 +611,15 @@ func workflowHasEvent(workflow githubWorkflowModel, event string) bool {
 }
 
 func workflowHasUntrustedEvent(workflow githubWorkflowModel) bool {
-	for _, event := range []string{"pull_request", "pull_request_target", "issues", "issue_comment", "workflow_run"} {
+	for _, event := range []string{
+		"pull_request",
+		"pull_request_target",
+		"pull_request_review",
+		"pull_request_review_comment",
+		"issues",
+		"issue_comment",
+		"workflow_run",
+	} {
 		if workflowHasEvent(workflow, event) {
 			return true
 		}
@@ -627,30 +635,24 @@ func workflowHasBroadPushEvent(workflow githubWorkflowModel) bool {
 	if node == nil || node.Kind != yaml.MappingNode {
 		return true
 	}
-	if workflowEventHasRestrictiveRefFilter(node, "branches") || workflowEventHasRestrictiveRefFilter(node, "tags") {
-		return false
+	branches, hasBranches := yamlMappingValue(node, "branches")
+	tags, hasTags := yamlMappingValue(node, "tags")
+	if hasBranches || hasTags {
+		return workflowNodeHasBroadRefFilter(branches) || workflowNodeHasBroadRefFilter(tags)
 	}
 	return true
 }
 
-func workflowEventHasRestrictiveRefFilter(node *yaml.Node, key string) bool {
-	value, ok := yamlMappingValue(node, key)
-	if !ok {
-		return false
-	}
-	return workflowNodeHasNonWildcardValue(value)
-}
-
-func workflowNodeHasNonWildcardValue(node *yaml.Node) bool {
+func workflowNodeHasBroadRefFilter(node *yaml.Node) bool {
 	if node == nil {
 		return false
 	}
 	switch node.Kind {
 	case yaml.ScalarNode:
-		return workflowRefFilterIsRestrictive(node.Value)
+		return workflowRefFilterIsBroad(node.Value)
 	case yaml.SequenceNode:
 		for _, item := range node.Content {
-			if item != nil && workflowRefFilterIsRestrictive(item.Value) {
+			if item != nil && workflowRefFilterIsBroad(item.Value) {
 				return true
 			}
 		}
@@ -658,9 +660,9 @@ func workflowNodeHasNonWildcardValue(node *yaml.Node) bool {
 	return false
 }
 
-func workflowRefFilterIsRestrictive(value string) bool {
+func workflowRefFilterIsBroad(value string) bool {
 	trimmed := strings.TrimSpace(value)
-	return trimmed != "" && trimmed != "*" && trimmed != "**"
+	return trimmed == "*" || trimmed == "**"
 }
 
 func sortedWorkflowEventNames(events map[string]*yaml.Node) []string {
@@ -744,6 +746,7 @@ func workflowUntrustedPRCodeTokens(value string) []string {
 		"github.head_ref",
 		"github.event.issue.title",
 		"github.event.issue.body",
+		"github.event.review.body",
 		"github.event.comment.body",
 	} {
 		if strings.Contains(lower, token) {
@@ -765,6 +768,7 @@ func workflowUserControlledTokens(value string) []string {
 		"github.head_ref",
 		"github.event.issue.title",
 		"github.event.issue.body",
+		"github.event.review.body",
 		"github.event.comment.body",
 	} {
 		if strings.Contains(lower, token) {

--- a/internal/repoexposure/workflow_analyzer.go
+++ b/internal/repoexposure/workflow_analyzer.go
@@ -15,6 +15,7 @@ import (
 const workflowAnalyzerVersion = "2026.05"
 
 var gitHubActionCommitRefPattern = regexp.MustCompile(`^[a-f0-9]{40}$`)
+var workflowSecretsExpressionPattern = regexp.MustCompile(`\$\{\{\s*secrets\.`)
 
 type githubWorkflowModel struct {
 	Events      map[string]*yaml.Node
@@ -155,7 +156,7 @@ func analyzeGitHubWorkflowFindings(repo string, commit string, path string, ast 
 					}))
 			}
 
-			if tokens := step.untrustedExpressionTokens(); len(tokens) > 0 {
+			if tokens := step.untrustedExpressionTokens(untrustedEvent || workflowRun); len(tokens) > 0 {
 				appendWorkflowFinding(&findings, seen, repo, commit, path, step.RunLine, "workflow_shell_injection_user_context", domain.SeverityHigh,
 					"Workflow interpolates untrusted PR context into shell",
 					"A run step directly interpolates pull request or issue-controlled GitHub context, which can become shell injection when the workflow executes.",
@@ -479,8 +480,8 @@ func (step githubWorkflowStep) checkoutUsesUntrustedHead() bool {
 	return false
 }
 
-func (step githubWorkflowStep) untrustedExpressionTokens() []string {
-	if strings.TrimSpace(step.Run) == "" {
+func (step githubWorkflowStep) untrustedExpressionTokens(untrustedEvent bool) []string {
+	if !untrustedEvent || strings.TrimSpace(step.Run) == "" {
 		return nil
 	}
 	return workflowUserControlledTokens(step.Run)
@@ -712,7 +713,7 @@ func workflowActionRef(action string) string {
 }
 
 func workflowStringReferencesSecrets(value string) bool {
-	return strings.Contains(strings.ToLower(value), "${{ secrets.")
+	return workflowSecretsExpressionPattern.MatchString(strings.ToLower(value))
 }
 
 func workflowStringMapReferencesSecrets(values map[string]string) bool {

--- a/internal/repoexposure/workflow_analyzer.go
+++ b/internal/repoexposure/workflow_analyzer.go
@@ -25,6 +25,7 @@ type githubWorkflowModel struct {
 }
 
 type workflowPermissions struct {
+	Configured  bool
 	Line        int
 	Raw         string
 	WriteAll    bool
@@ -327,7 +328,7 @@ func parseWorkflowSecrets(node *yaml.Node) (map[string]string, string) {
 }
 
 func parseWorkflowPermissions(node *yaml.Node) workflowPermissions {
-	permissions := workflowPermissions{Line: workflowLine(node), Scopes: map[string]string{}}
+	permissions := workflowPermissions{Configured: node != nil, Line: workflowLine(node), Scopes: map[string]string{}}
 	if node == nil {
 		return permissions
 	}
@@ -370,7 +371,7 @@ func (workflow githubWorkflowModel) effectivePermissions(job githubWorkflowJob) 
 }
 
 func (permissions workflowPermissions) configured() bool {
-	return permissions.Raw != "" || permissions.WriteAll || len(permissions.Scopes) > 0
+	return permissions.Configured
 }
 
 func (permissions workflowPermissions) hasBroadGitHubTokenWrite() bool {
@@ -387,6 +388,9 @@ func (permissions workflowPermissions) hasBroadGitHubTokenWrite() bool {
 }
 
 func (permissions workflowPermissions) idTokenWrite() bool {
+	if permissions.WriteAll {
+		return true
+	}
 	return strings.EqualFold(strings.TrimSpace(permissions.Scopes["id-token"]), "write")
 }
 

--- a/internal/repoexposure/workflow_analyzer.go
+++ b/internal/repoexposure/workflow_analyzer.go
@@ -98,7 +98,7 @@ func analyzeGitHubWorkflowFindings(repo string, commit string, path string, ast 
 				}))
 		}
 
-		if action := normalizeWorkflowUses(job.Uses); mutableThirdPartyAction(action) {
+		if action := normalizeWorkflowUses(job.Uses); mutableThirdPartyAction(repo, action) {
 			appendWorkflowFinding(&findings, seen, repo, commit, path, job.UsesLine, "workflow_unpinned_third_party_action", domain.SeverityMedium,
 				"Workflow uses an unpinned third-party action",
 				"A third-party reusable workflow is referenced by a mutable tag or branch, so upstream changes can alter workflow behavior without a repository change.",
@@ -161,7 +161,7 @@ func analyzeGitHubWorkflowFindings(repo string, commit string, path string, ast 
 					}))
 			}
 
-			if mutableThirdPartyAction(action) {
+			if mutableThirdPartyAction(repo, action) {
 				appendWorkflowFinding(&findings, seen, repo, commit, path, step.UsesLine, "workflow_unpinned_third_party_action", domain.SeverityMedium,
 					"Workflow uses an unpinned third-party action",
 					"A third-party GitHub Action is referenced by a mutable tag or branch, so upstream changes can alter workflow behavior without a repository change.",
@@ -438,7 +438,7 @@ func (permissions workflowPermissions) writeScopeEvidence() []string {
 
 func (workflow githubWorkflowModel) oidcRiskContext(job githubWorkflowJob) string {
 	switch {
-	case workflowHasEvent(workflow, "pull_request") || workflowHasEvent(workflow, "pull_request_target") || workflowHasEvent(workflow, "issue_comment"):
+	case workflowHasUserControlledEvent(workflow):
 		return "untrusted_event"
 	case workflowHasEvent(workflow, "workflow_run"):
 		return "workflow_run"
@@ -635,6 +635,13 @@ func workflowHasEvent(workflow githubWorkflowModel, event string) bool {
 }
 
 func workflowHasUntrustedEvent(workflow githubWorkflowModel) bool {
+	if workflowHasUserControlledEvent(workflow) || workflowHasEvent(workflow, "workflow_run") {
+		return true
+	}
+	return false
+}
+
+func workflowHasUserControlledEvent(workflow githubWorkflowModel) bool {
 	for _, event := range []string{
 		"pull_request",
 		"pull_request_target",
@@ -712,7 +719,7 @@ func workflowActionMatches(action string, prefix string) bool {
 	return actionLower == prefixLower || strings.HasPrefix(actionLower, prefixLower+"@") || strings.HasPrefix(actionLower, prefixLower+"/")
 }
 
-func mutableThirdPartyAction(action string) bool {
+func mutableThirdPartyAction(repo string, action string) bool {
 	normalized := strings.ToLower(strings.TrimSpace(action))
 	if normalized == "" || strings.HasPrefix(normalized, "./") || strings.HasPrefix(normalized, "docker://") {
 		return false
@@ -721,13 +728,43 @@ func mutableThirdPartyAction(action string) bool {
 	if len(parts) != 2 {
 		return false
 	}
-	repo := parts[0]
+	actionPath := parts[0]
 	ref := parts[1]
-	owner := strings.SplitN(repo, "/", 2)[0]
+	owner := strings.SplitN(actionPath, "/", 2)[0]
 	if owner == "actions" {
 		return false
 	}
+	if sameWorkflowRepository(repo, workflowActionRepository(normalized)) {
+		return false
+	}
 	return !gitHubActionCommitRefPattern.MatchString(ref)
+}
+
+func workflowActionRepository(action string) string {
+	actionWithoutRef := strings.SplitN(strings.TrimSpace(action), "@", 2)[0]
+	parts := strings.Split(actionWithoutRef, "/")
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[0] + "/" + parts[1]
+}
+
+func sameWorkflowRepository(repo string, actionRepo string) bool {
+	return normalizeWorkflowRepository(repo) != "" && normalizeWorkflowRepository(repo) == normalizeWorkflowRepository(actionRepo)
+}
+
+func normalizeWorkflowRepository(repo string) string {
+	normalized := strings.ToLower(strings.TrimSpace(repo))
+	normalized = strings.TrimPrefix(normalized, "https://github.com/")
+	normalized = strings.TrimPrefix(normalized, "http://github.com/")
+	normalized = strings.TrimPrefix(normalized, "github.com/")
+	normalized = strings.TrimPrefix(normalized, "git@github.com:")
+	normalized = strings.TrimSuffix(normalized, ".git")
+	parts := strings.Split(normalized, "/")
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[0] + "/" + parts[1]
 }
 
 func workflowActionRef(action string) string {

--- a/internal/repoexposure/workflow_analyzer.go
+++ b/internal/repoexposure/workflow_analyzer.go
@@ -36,6 +36,8 @@ type workflowPermissions struct {
 type githubWorkflowJob struct {
 	ID          string
 	Line        int
+	Uses        string
+	UsesLine    int
 	Env         map[string]string
 	Secrets     map[string]string
 	SecretsRaw  string
@@ -93,6 +95,18 @@ func analyzeGitHubWorkflowFindings(repo string, commit string, path string, ast 
 					"permission_scope":   "job",
 					"permission_summary": job.Permissions.summary(),
 					"write_scopes":       job.Permissions.writeScopeEvidence(),
+				}))
+		}
+
+		if action := normalizeWorkflowUses(job.Uses); mutableThirdPartyAction(action) {
+			appendWorkflowFinding(&findings, seen, repo, commit, path, job.UsesLine, "workflow_unpinned_third_party_action", domain.SeverityMedium,
+				"Workflow uses an unpinned third-party action",
+				"A third-party reusable workflow is referenced by a mutable tag or branch, so upstream changes can alter workflow behavior without a repository change.",
+				"Pin third-party reusable workflows to full commit SHAs and review updates through dependency-management pull requests.",
+				job.Uses, detectedAt, workflowEvidence(eventNames, job.ID, 0, action, map[string]any{
+					"action_ref":               workflowActionRef(action),
+					"reusable_workflow_call":   true,
+					"reusable_workflow_source": job.Uses,
 				}))
 		}
 
@@ -235,6 +249,10 @@ func parseWorkflowJobs(node *yaml.Node) []githubWorkflowJob {
 		}
 		if secretsNode, ok := yamlMappingValue(value, "secrets"); ok {
 			job.Secrets, job.SecretsRaw = parseWorkflowSecrets(secretsNode)
+		}
+		if usesNode, ok := yamlMappingValue(value, "uses"); ok {
+			job.Uses = yamlScalarValue(usesNode)
+			job.UsesLine = workflowLine(usesNode)
 		}
 		if permissionsNode, ok := yamlMappingValue(value, "permissions"); ok {
 			job.Permissions = parseWorkflowPermissions(permissionsNode)
@@ -493,7 +511,9 @@ func (step githubWorkflowStep) untrustedExpressionTokens(untrustedEvent bool) []
 
 func (step githubWorkflowStep) usesPoisonableCache(untrustedEvent bool) bool {
 	action := normalizeWorkflowUses(step.Uses)
-	if !workflowActionMatches(action, "actions/cache") && !workflowActionMatches(action, "actions/cache/restore") {
+	if !workflowActionMatches(action, "actions/cache") &&
+		!workflowActionMatches(action, "actions/cache/restore") &&
+		!workflowActionMatches(action, "actions/cache/save") {
 		return false
 	}
 	key := step.With["key"]

--- a/internal/repoexposure/workflow_analyzer.go
+++ b/internal/repoexposure/workflow_analyzer.go
@@ -15,7 +15,7 @@ import (
 const workflowAnalyzerVersion = "2026.05"
 
 var gitHubActionCommitRefPattern = regexp.MustCompile(`^[a-f0-9]{40}$`)
-var workflowSecretsExpressionPattern = regexp.MustCompile(`\$\{\{\s*secrets\.`)
+var workflowSecretsExpressionPattern = regexp.MustCompile(`\$\{\{\s*secrets\s*(?:\.|\[)`)
 
 type githubWorkflowModel struct {
 	Events      map[string]*yaml.Node
@@ -611,7 +611,7 @@ func workflowHasEvent(workflow githubWorkflowModel, event string) bool {
 }
 
 func workflowHasUntrustedEvent(workflow githubWorkflowModel) bool {
-	for _, event := range []string{"pull_request", "pull_request_target", "issue_comment", "workflow_run"} {
+	for _, event := range []string{"pull_request", "pull_request_target", "issues", "issue_comment", "workflow_run"} {
 		if workflowHasEvent(workflow, event) {
 			return true
 		}
@@ -743,6 +743,7 @@ func workflowUntrustedPRCodeTokens(value string) []string {
 		"github.event.pull_request.head.repo.full_name",
 		"github.head_ref",
 		"github.event.issue.title",
+		"github.event.issue.body",
 		"github.event.comment.body",
 	} {
 		if strings.Contains(lower, token) {
@@ -763,6 +764,7 @@ func workflowUserControlledTokens(value string) []string {
 		"github.event.pull_request.head.repo.full_name",
 		"github.head_ref",
 		"github.event.issue.title",
+		"github.event.issue.body",
 		"github.event.comment.body",
 	} {
 		if strings.Contains(lower, token) {

--- a/internal/repoexposure/workflow_analyzer.go
+++ b/internal/repoexposure/workflow_analyzer.go
@@ -1,0 +1,811 @@
+package repoexposure
+
+import (
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+const workflowAnalyzerVersion = "2026.05"
+
+var gitHubActionCommitRefPattern = regexp.MustCompile(`^[a-f0-9]{40}$`)
+
+type githubWorkflowModel struct {
+	Events      map[string]*yaml.Node
+	Env         map[string]string
+	Permissions workflowPermissions
+	Jobs        []githubWorkflowJob
+}
+
+type workflowPermissions struct {
+	Line        int
+	Raw         string
+	WriteAll    bool
+	Scopes      map[string]string
+	WriteScopes []string
+}
+
+type githubWorkflowJob struct {
+	ID          string
+	Line        int
+	Env         map[string]string
+	Secrets     map[string]string
+	SecretsRaw  string
+	Permissions workflowPermissions
+	Steps       []githubWorkflowStep
+}
+
+type githubWorkflowStep struct {
+	Index    int
+	Line     int
+	Name     string
+	Uses     string
+	UsesLine int
+	Run      string
+	RunLine  int
+	With     map[string]string
+	Env      map[string]string
+}
+
+func analyzeGitHubWorkflowFindings(repo string, commit string, path string, ast *yaml.Node, seen map[string]struct{}, detectedAt time.Time) []domain.Finding {
+	findings := []domain.Finding{}
+	if !isGitHubWorkflowPath(path) {
+		return findings
+	}
+	workflow := parseGitHubWorkflow(ast)
+	if len(workflow.Events) == 0 {
+		return findings
+	}
+
+	eventNames := sortedWorkflowEventNames(workflow.Events)
+	pullRequestTarget := workflowHasEvent(workflow, "pull_request_target")
+	workflowRun := workflowHasEvent(workflow, "workflow_run")
+	untrustedEvent := workflowHasUntrustedEvent(workflow)
+
+	if workflow.Permissions.hasBroadGitHubTokenWrite() {
+		appendWorkflowFinding(&findings, seen, repo, commit, path, workflow.Permissions.Line, "workflow_broad_token_permissions", domain.SeverityHigh,
+			"GitHub workflow grants broad token write permissions",
+			"Workflow-level GITHUB_TOKEN permissions grant write-capable scopes that increase repository automation blast radius.",
+			"Set workflow permissions to read-only by default and grant write scopes only on the specific jobs that need them.",
+			"permissions: "+workflow.Permissions.summary(), detectedAt, workflowEvidence(eventNames, "", 0, "", map[string]any{
+				"permission_scope":   "workflow",
+				"permission_summary": workflow.Permissions.summary(),
+				"write_scopes":       workflow.Permissions.writeScopeEvidence(),
+			}))
+	}
+
+	for _, job := range workflow.Jobs {
+		effectivePermissions := workflow.effectivePermissions(job)
+		if job.Permissions.hasBroadGitHubTokenWrite() {
+			appendWorkflowFinding(&findings, seen, repo, commit, path, job.Permissions.Line, "workflow_broad_token_permissions", domain.SeverityHigh,
+				"GitHub workflow grants broad token write permissions",
+				"Job-level GITHUB_TOKEN permissions grant write-capable scopes that increase repository automation blast radius.",
+				"Grant the job only the read or write scopes required for its exact task.",
+				"permissions: "+job.Permissions.summary(), detectedAt, workflowEvidence(eventNames, job.ID, 0, "", map[string]any{
+					"permission_scope":   "job",
+					"permission_summary": job.Permissions.summary(),
+					"write_scopes":       job.Permissions.writeScopeEvidence(),
+				}))
+		}
+
+		jobSecrets := job.referencesSecrets(workflow.Env)
+		if pullRequestTarget && (effectivePermissions.hasBroadGitHubTokenWrite() || jobSecrets) {
+			appendWorkflowFinding(&findings, seen, repo, commit, path, job.Line, "workflow_pull_request_target_privileged_context", domain.SeverityCritical,
+				"pull_request_target workflow exposes privileged context",
+				"A pull_request_target job has explicit write-token permissions or secret access, so untrusted PR influence can reach privileged repository context.",
+				"Move untrusted PR processing to pull_request, split privileged follow-up work into a reviewed workflow, and keep pull_request_target jobs read-only with no secrets.",
+				"pull_request_target privileged job", detectedAt, workflowEvidence(eventNames, job.ID, 0, "", map[string]any{
+					"permission_summary": effectivePermissions.summary(),
+					"write_scopes":       effectivePermissions.writeScopeEvidence(),
+					"references_secrets": jobSecrets,
+				}))
+		}
+
+		if workflowRun && (effectivePermissions.hasBroadGitHubTokenWrite() || jobSecrets || job.usesReleaseOrCloudStep()) {
+			appendWorkflowFinding(&findings, seen, repo, commit, path, job.Line, "workflow_run_privilege_chain", domain.SeverityHigh,
+				"workflow_run chain reaches privileged job behavior",
+				"A workflow_run trigger can connect an upstream workflow result to write permissions, secrets, cloud credentials, or release behavior.",
+				"Require trusted upstream workflows, validate artifacts before use, and keep workflow_run jobs read-only unless an environment approval gates privileged actions.",
+				"on: workflow_run", detectedAt, workflowEvidence(eventNames, job.ID, 0, "", map[string]any{
+					"permission_summary": effectivePermissions.summary(),
+					"write_scopes":       effectivePermissions.writeScopeEvidence(),
+					"references_secrets": jobSecrets,
+				}))
+		}
+
+		oidcContext := workflow.oidcRiskContext(job)
+		if effectivePermissions.idTokenWrite() && oidcContext != "" {
+			appendWorkflowFinding(&findings, seen, repo, commit, path, effectivePermissions.Line, "workflow_oidc_broad_trust", domain.SeverityHigh,
+				"Workflow can mint cloud credentials from broad OIDC context",
+				"An id-token: write permission is reachable from a workflow context that can be influenced by pull requests, workflow_run chains, or broadly scoped deploy triggers.",
+				"Scope cloud trust policies to protected branches/environments and keep OIDC permissions off untrusted PR, workflow_run, or all-branch push paths.",
+				"id-token: write", detectedAt, workflowEvidence(eventNames, job.ID, 0, "", map[string]any{
+					"permission_summary": effectivePermissions.summary(),
+					"cloud_auth_action":  job.cloudAuthAction(),
+					"oidc_risk_context":  oidcContext,
+				}))
+		}
+
+		for _, step := range job.Steps {
+			action := normalizeWorkflowUses(step.Uses)
+			if pullRequestTarget && step.checkoutUsesUntrustedHead() {
+				appendWorkflowFinding(&findings, seen, repo, commit, path, stepLine(step), "workflow_pull_request_target_untrusted_checkout", domain.SeverityCritical,
+					"pull_request_target checks out untrusted PR code",
+					"A pull_request_target job checks out the contributor-controlled PR head, which can run attacker code in a privileged workflow context.",
+					"Do not checkout PR head code in pull_request_target. Use pull_request for untrusted code or checkout only the trusted base ref before performing privileged operations.",
+					"actions/checkout with PR head ref", detectedAt, workflowEvidence(eventNames, job.ID, step.Index, action, map[string]any{
+						"checkout_ref":       firstNonEmptyWorkflowString(step.With["ref"], step.With["repository"]),
+						"permission_summary": effectivePermissions.summary(),
+					}))
+			}
+
+			if mutableThirdPartyAction(action) {
+				appendWorkflowFinding(&findings, seen, repo, commit, path, step.UsesLine, "workflow_unpinned_third_party_action", domain.SeverityMedium,
+					"Workflow uses an unpinned third-party action",
+					"A third-party GitHub Action is referenced by a mutable tag or branch, so upstream changes can alter workflow behavior without a repository change.",
+					"Pin third-party actions to full commit SHAs and review updates through dependency-management pull requests.",
+					step.Uses, detectedAt, workflowEvidence(eventNames, job.ID, step.Index, action, map[string]any{
+						"action_ref": workflowActionRef(action),
+					}))
+			}
+
+			if tokens := step.untrustedExpressionTokens(); len(tokens) > 0 {
+				appendWorkflowFinding(&findings, seen, repo, commit, path, step.RunLine, "workflow_shell_injection_user_context", domain.SeverityHigh,
+					"Workflow interpolates untrusted PR context into shell",
+					"A run step directly interpolates pull request or issue-controlled GitHub context, which can become shell injection when the workflow executes.",
+					"Pass untrusted GitHub context through environment variables, quote safely, or avoid using user-controlled PR metadata in shell commands.",
+					truncateWorkflowSnippet(step.Run), detectedAt, workflowEvidence(eventNames, job.ID, step.Index, action, map[string]any{
+						"untrusted_context": tokens,
+					}))
+			}
+
+			if step.usesPoisonableCache(untrustedEvent || workflowRun) {
+				appendWorkflowFinding(&findings, seen, repo, commit, path, stepLine(step), "workflow_cache_poisoning", domain.SeverityMedium,
+					"Workflow cache key can be influenced by untrusted context",
+					"A cache step uses PR-controlled context or broad restore keys, which can allow poisoned dependency or build cache reuse.",
+					"Scope cache keys to trusted refs, avoid broad restore keys for untrusted PRs, and separate read-only PR caches from privileged build caches.",
+					"actions/cache", detectedAt, workflowEvidence(eventNames, job.ID, step.Index, action, map[string]any{
+						"cache_key":          step.With["key"],
+						"cache_restore_keys": step.With["restore-keys"],
+					}))
+			}
+
+			if step.exposesUntrustedArtifactOrRelease(untrustedEvent || workflowRun) {
+				severity := domain.SeverityMedium
+				if step.usesReleaseBehavior() {
+					severity = domain.SeverityHigh
+				}
+				appendWorkflowFinding(&findings, seen, repo, commit, path, stepLine(step), "workflow_artifact_poisoning", severity,
+					"Workflow publishes artifacts from untrusted context",
+					"A workflow reachable from pull requests or workflow_run can upload artifacts or release assets, allowing untrusted build output to be reused downstream.",
+					"Keep untrusted PR artifacts isolated, validate workflow_run artifacts before privileged use, and restrict release publishing to protected branches or environments.",
+					firstNonEmptyWorkflowString(step.Uses, truncateWorkflowSnippet(step.Run)), detectedAt, workflowEvidence(eventNames, job.ID, step.Index, action, map[string]any{
+						"publishes_release": step.usesReleaseBehavior(),
+					}))
+			}
+		}
+	}
+
+	return findings
+}
+
+func parseGitHubWorkflow(root *yaml.Node) githubWorkflowModel {
+	workflow := githubWorkflowModel{Events: map[string]*yaml.Node{}}
+	ast := root
+	if ast != nil && ast.Kind == yaml.DocumentNode && len(ast.Content) > 0 {
+		ast = ast.Content[0]
+	}
+	if ast == nil || ast.Kind != yaml.MappingNode {
+		return workflow
+	}
+	if onNode, ok := yamlMappingValue(ast, "on"); ok {
+		workflow.Events = workflowEvents(onNode)
+	}
+	if envNode, ok := yamlMappingValue(ast, "env"); ok {
+		workflow.Env = yamlScalarMap(envNode)
+	}
+	if permissionsNode, ok := yamlMappingValue(ast, "permissions"); ok {
+		workflow.Permissions = parseWorkflowPermissions(permissionsNode)
+	}
+	if jobsNode, ok := yamlMappingValue(ast, "jobs"); ok && jobsNode.Kind == yaml.MappingNode {
+		workflow.Jobs = parseWorkflowJobs(jobsNode)
+	}
+	return workflow
+}
+
+func parseWorkflowJobs(node *yaml.Node) []githubWorkflowJob {
+	jobs := []githubWorkflowJob{}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i]
+		value := node.Content[i+1]
+		if key == nil || value == nil || value.Kind != yaml.MappingNode {
+			continue
+		}
+		job := githubWorkflowJob{ID: strings.TrimSpace(key.Value), Line: key.Line, Env: map[string]string{}, Secrets: map[string]string{}}
+		if envNode, ok := yamlMappingValue(value, "env"); ok {
+			job.Env = yamlScalarMap(envNode)
+		}
+		if secretsNode, ok := yamlMappingValue(value, "secrets"); ok {
+			job.Secrets, job.SecretsRaw = parseWorkflowSecrets(secretsNode)
+		}
+		if permissionsNode, ok := yamlMappingValue(value, "permissions"); ok {
+			job.Permissions = parseWorkflowPermissions(permissionsNode)
+		}
+		if stepsNode, ok := yamlMappingValue(value, "steps"); ok && stepsNode.Kind == yaml.SequenceNode {
+			job.Steps = parseWorkflowSteps(stepsNode)
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs
+}
+
+func parseWorkflowSteps(node *yaml.Node) []githubWorkflowStep {
+	steps := []githubWorkflowStep{}
+	for idx, item := range node.Content {
+		if item == nil || item.Kind != yaml.MappingNode {
+			continue
+		}
+		step := githubWorkflowStep{Index: idx + 1, Line: item.Line, With: map[string]string{}, Env: map[string]string{}}
+		for i := 0; i+1 < len(item.Content); i += 2 {
+			key := item.Content[i]
+			value := item.Content[i+1]
+			if key == nil || value == nil {
+				continue
+			}
+			switch strings.ToLower(strings.TrimSpace(key.Value)) {
+			case "name":
+				step.Name = yamlScalarValue(value)
+			case "uses":
+				step.Uses = yamlScalarValue(value)
+				step.UsesLine = value.Line
+			case "run":
+				step.Run = yamlScalarValue(value)
+				step.RunLine = value.Line
+			case "with":
+				step.With = yamlScalarMap(value)
+			case "env":
+				step.Env = yamlScalarMap(value)
+			}
+		}
+		steps = append(steps, step)
+	}
+	return steps
+}
+
+func workflowEvents(node *yaml.Node) map[string]*yaml.Node {
+	events := map[string]*yaml.Node{}
+	if node == nil {
+		return events
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		event := normalizeWorkflowEvent(node.Value)
+		if event != "" {
+			events[event] = node
+		}
+	case yaml.SequenceNode:
+		for _, item := range node.Content {
+			if item == nil {
+				continue
+			}
+			event := normalizeWorkflowEvent(item.Value)
+			if event != "" {
+				events[event] = item
+			}
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := node.Content[i]
+			value := node.Content[i+1]
+			if key == nil {
+				continue
+			}
+			event := normalizeWorkflowEvent(key.Value)
+			if event != "" {
+				events[event] = value
+			}
+		}
+	}
+	return events
+}
+
+func parseWorkflowSecrets(node *yaml.Node) (map[string]string, string) {
+	if node == nil {
+		return map[string]string{}, ""
+	}
+	if node.Kind == yaml.ScalarNode {
+		return map[string]string{}, strings.ToLower(strings.TrimSpace(node.Value))
+	}
+	return yamlScalarMap(node), ""
+}
+
+func parseWorkflowPermissions(node *yaml.Node) workflowPermissions {
+	permissions := workflowPermissions{Line: workflowLine(node), Scopes: map[string]string{}}
+	if node == nil {
+		return permissions
+	}
+	if node.Kind == yaml.ScalarNode {
+		permissions.Raw = strings.ToLower(strings.TrimSpace(node.Value))
+		permissions.WriteAll = strings.EqualFold(permissions.Raw, "write-all")
+		if permissions.WriteAll {
+			permissions.WriteScopes = []string{"write-all"}
+		}
+		return permissions
+	}
+	if node.Kind != yaml.MappingNode {
+		return permissions
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i]
+		value := node.Content[i+1]
+		if key == nil || value == nil || value.Kind != yaml.ScalarNode {
+			continue
+		}
+		scope := strings.ToLower(strings.TrimSpace(key.Value))
+		permission := strings.ToLower(strings.TrimSpace(value.Value))
+		if scope == "" || permission == "" {
+			continue
+		}
+		permissions.Scopes[scope] = permission
+		if permission == "write" || permission == "write-all" {
+			permissions.WriteScopes = append(permissions.WriteScopes, scope)
+		}
+	}
+	sort.Strings(permissions.WriteScopes)
+	return permissions
+}
+
+func (workflow githubWorkflowModel) effectivePermissions(job githubWorkflowJob) workflowPermissions {
+	if job.Permissions.configured() {
+		return job.Permissions
+	}
+	return workflow.Permissions
+}
+
+func (permissions workflowPermissions) configured() bool {
+	return permissions.Raw != "" || permissions.WriteAll || len(permissions.Scopes) > 0
+}
+
+func (permissions workflowPermissions) hasBroadGitHubTokenWrite() bool {
+	if permissions.WriteAll {
+		return true
+	}
+	for _, scope := range permissions.WriteScopes {
+		if scope == "id-token" {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func (permissions workflowPermissions) idTokenWrite() bool {
+	return strings.EqualFold(strings.TrimSpace(permissions.Scopes["id-token"]), "write")
+}
+
+func (permissions workflowPermissions) summary() string {
+	if permissions.WriteAll {
+		return "write-all"
+	}
+	if len(permissions.Scopes) == 0 {
+		if permissions.Raw != "" {
+			return permissions.Raw
+		}
+		return "not_explicit"
+	}
+	scopes := make([]string, 0, len(permissions.Scopes))
+	for scope, permission := range permissions.Scopes {
+		scopes = append(scopes, scope+":"+permission)
+	}
+	sort.Strings(scopes)
+	return strings.Join(scopes, ",")
+}
+
+func (permissions workflowPermissions) writeScopeEvidence() []string {
+	scopes := append([]string(nil), permissions.WriteScopes...)
+	sort.Strings(scopes)
+	return scopes
+}
+
+func (workflow githubWorkflowModel) oidcRiskContext(job githubWorkflowJob) string {
+	switch {
+	case workflowHasEvent(workflow, "pull_request") || workflowHasEvent(workflow, "pull_request_target") || workflowHasEvent(workflow, "issue_comment"):
+		return "untrusted_event"
+	case workflowHasEvent(workflow, "workflow_run"):
+		return "workflow_run"
+	case job.usesCloudAuthAction() && workflowHasBroadPushEvent(workflow):
+		return "broad_push_event"
+	default:
+		return ""
+	}
+}
+
+func (job githubWorkflowJob) referencesSecrets(workflowEnv map[string]string) bool {
+	if strings.EqualFold(job.SecretsRaw, "inherit") || workflowStringMapReferencesSecrets(job.Secrets) || workflowStringMapReferencesSecrets(job.Env) || workflowStringMapReferencesSecrets(workflowEnv) {
+		return true
+	}
+	for _, step := range job.Steps {
+		if workflowStringReferencesSecrets(step.Run) || workflowStringMapReferencesSecrets(step.With) || workflowStringMapReferencesSecrets(step.Env) {
+			return true
+		}
+	}
+	return false
+}
+
+func (job githubWorkflowJob) usesCloudAuthAction() bool {
+	return job.cloudAuthAction() != ""
+}
+
+func (job githubWorkflowJob) cloudAuthAction() string {
+	for _, step := range job.Steps {
+		action := normalizeWorkflowUses(step.Uses)
+		if workflowActionMatches(action, "aws-actions/configure-aws-credentials") ||
+			workflowActionMatches(action, "azure/login") ||
+			workflowActionMatches(action, "google-github-actions/auth") {
+			return action
+		}
+	}
+	return ""
+}
+
+func (job githubWorkflowJob) usesReleaseOrCloudStep() bool {
+	if job.usesCloudAuthAction() {
+		return true
+	}
+	for _, step := range job.Steps {
+		if step.usesReleaseBehavior() {
+			return true
+		}
+	}
+	return false
+}
+
+func (step githubWorkflowStep) checkoutUsesUntrustedHead() bool {
+	if !workflowActionMatches(normalizeWorkflowUses(step.Uses), "actions/checkout") {
+		return false
+	}
+	for _, key := range []string{"ref", "repository"} {
+		value := step.With[key]
+		if workflowStringUsesUntrustedPRCodeContext(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func (step githubWorkflowStep) untrustedExpressionTokens() []string {
+	if strings.TrimSpace(step.Run) == "" {
+		return nil
+	}
+	return workflowUserControlledTokens(step.Run)
+}
+
+func (step githubWorkflowStep) usesPoisonableCache(untrustedEvent bool) bool {
+	action := normalizeWorkflowUses(step.Uses)
+	if !workflowActionMatches(action, "actions/cache") && !workflowActionMatches(action, "actions/cache/restore") {
+		return false
+	}
+	key := step.With["key"]
+	restoreKeys := step.With["restore-keys"]
+	if workflowStringUsesUserControlledPRContext(key) || workflowStringUsesUserControlledPRContext(restoreKeys) {
+		return true
+	}
+	return untrustedEvent && strings.TrimSpace(restoreKeys) != ""
+}
+
+func (step githubWorkflowStep) exposesUntrustedArtifactOrRelease(untrustedEvent bool) bool {
+	if !untrustedEvent {
+		return false
+	}
+	action := normalizeWorkflowUses(step.Uses)
+	return workflowActionMatches(action, "actions/upload-artifact") ||
+		step.usesReleaseBehavior() ||
+		strings.Contains(strings.ToLower(step.Run), "upload-artifact")
+}
+
+func (step githubWorkflowStep) usesReleaseBehavior() bool {
+	action := normalizeWorkflowUses(step.Uses)
+	lowerRun := strings.ToLower(step.Run)
+	return workflowActionMatches(action, "softprops/action-gh-release") ||
+		workflowActionMatches(action, "actions/upload-release-asset") ||
+		strings.Contains(lowerRun, "gh release upload") ||
+		strings.Contains(lowerRun, "gh release create")
+}
+
+func workflowEvidence(events []string, job string, stepIndex int, action string, extra map[string]any) map[string]any {
+	evidence := map[string]any{
+		"detector_version":   workflowAnalyzerVersion,
+		"detector_category":  "github_actions_workflow",
+		"detector_provider":  "GitHub",
+		"workflow_events":    events,
+		"history_source":     "head_snapshot",
+		"raw_secret_data":    false,
+		"contextual_finding": true,
+	}
+	if job != "" {
+		evidence["workflow_job"] = job
+	}
+	if stepIndex > 0 {
+		evidence["workflow_step_index"] = stepIndex
+	}
+	if action != "" {
+		evidence["workflow_action"] = action
+	}
+	for key, value := range extra {
+		evidence[key] = value
+	}
+	return evidence
+}
+
+func appendWorkflowFinding(
+	findings *[]domain.Finding,
+	seen map[string]struct{},
+	repo string,
+	commit string,
+	path string,
+	line int,
+	ruleID string,
+	severity domain.FindingSeverity,
+	title string,
+	summary string,
+	remediation string,
+	snippet string,
+	detectedAt time.Time,
+	extraEvidence map[string]any,
+) {
+	if line <= 0 {
+		line = 1
+	}
+	appendMisconfigFinding(findings, seen, repo, commit, path, line, ruleID, severity, title, summary, remediation, snippet, detectedAt, extraEvidence)
+}
+
+func yamlMappingValue(node *yaml.Node, key string) (*yaml.Node, bool) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil, false
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		if keyNode == nil {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(keyNode.Value), key) {
+			return node.Content[i+1], true
+		}
+	}
+	return nil, false
+}
+
+func yamlScalarValue(node *yaml.Node) string {
+	if node == nil || node.Kind != yaml.ScalarNode {
+		return ""
+	}
+	return strings.TrimSpace(node.Value)
+}
+
+func yamlScalarMap(node *yaml.Node) map[string]string {
+	values := map[string]string{}
+	if node == nil || node.Kind != yaml.MappingNode {
+		return values
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i]
+		value := node.Content[i+1]
+		if key == nil || value == nil {
+			continue
+		}
+		values[strings.ToLower(strings.TrimSpace(key.Value))] = yamlScalarValue(value)
+	}
+	return values
+}
+
+func workflowHasEvent(workflow githubWorkflowModel, event string) bool {
+	_, ok := workflow.Events[normalizeWorkflowEvent(event)]
+	return ok
+}
+
+func workflowHasUntrustedEvent(workflow githubWorkflowModel) bool {
+	for _, event := range []string{"pull_request", "pull_request_target", "issue_comment", "workflow_run"} {
+		if workflowHasEvent(workflow, event) {
+			return true
+		}
+	}
+	return false
+}
+
+func workflowHasBroadPushEvent(workflow githubWorkflowModel) bool {
+	node, ok := workflow.Events["push"]
+	if !ok {
+		return false
+	}
+	if node == nil || node.Kind != yaml.MappingNode {
+		return true
+	}
+	if workflowEventHasRestrictiveRefFilter(node, "branches") || workflowEventHasRestrictiveRefFilter(node, "tags") {
+		return false
+	}
+	return true
+}
+
+func workflowEventHasRestrictiveRefFilter(node *yaml.Node, key string) bool {
+	value, ok := yamlMappingValue(node, key)
+	if !ok {
+		return false
+	}
+	return workflowNodeHasNonWildcardValue(value)
+}
+
+func workflowNodeHasNonWildcardValue(node *yaml.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		return workflowRefFilterIsRestrictive(node.Value)
+	case yaml.SequenceNode:
+		for _, item := range node.Content {
+			if item != nil && workflowRefFilterIsRestrictive(item.Value) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func workflowRefFilterIsRestrictive(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	return trimmed != "" && trimmed != "*" && trimmed != "**"
+}
+
+func sortedWorkflowEventNames(events map[string]*yaml.Node) []string {
+	names := make([]string, 0, len(events))
+	for event := range events {
+		names = append(names, event)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func normalizeWorkflowEvent(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func normalizeWorkflowUses(value string) string {
+	return strings.TrimSpace(value)
+}
+
+func workflowActionMatches(action string, prefix string) bool {
+	actionLower := strings.ToLower(strings.TrimSpace(action))
+	prefixLower := strings.ToLower(strings.TrimSpace(prefix))
+	return actionLower == prefixLower || strings.HasPrefix(actionLower, prefixLower+"@") || strings.HasPrefix(actionLower, prefixLower+"/")
+}
+
+func mutableThirdPartyAction(action string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(action))
+	if normalized == "" || strings.HasPrefix(normalized, "./") || strings.HasPrefix(normalized, "docker://") {
+		return false
+	}
+	parts := strings.SplitN(normalized, "@", 2)
+	if len(parts) != 2 {
+		return false
+	}
+	repo := parts[0]
+	ref := parts[1]
+	owner := strings.SplitN(repo, "/", 2)[0]
+	if owner == "actions" {
+		return false
+	}
+	return !gitHubActionCommitRefPattern.MatchString(ref)
+}
+
+func workflowActionRef(action string) string {
+	parts := strings.SplitN(strings.TrimSpace(action), "@", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	return parts[1]
+}
+
+func workflowStringReferencesSecrets(value string) bool {
+	return strings.Contains(strings.ToLower(value), "${{ secrets.")
+}
+
+func workflowStringMapReferencesSecrets(values map[string]string) bool {
+	for _, value := range values {
+		if workflowStringReferencesSecrets(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func workflowStringUsesUntrustedPRCodeContext(value string) bool {
+	return len(workflowUntrustedPRCodeTokens(value)) > 0
+}
+
+func workflowStringUsesUserControlledPRContext(value string) bool {
+	return len(workflowUserControlledTokens(value)) > 0
+}
+
+func workflowUntrustedPRCodeTokens(value string) []string {
+	lower := strings.ToLower(value)
+	tokens := []string{}
+	for _, token := range []string{
+		"github.event.pull_request.head.ref",
+		"github.event.pull_request.head.sha",
+		"github.event.pull_request.head.label",
+		"github.event.pull_request.head.repo.full_name",
+		"github.head_ref",
+		"github.event.issue.title",
+		"github.event.comment.body",
+	} {
+		if strings.Contains(lower, token) {
+			tokens = append(tokens, token)
+		}
+	}
+	return tokens
+}
+
+func workflowUserControlledTokens(value string) []string {
+	lower := strings.ToLower(value)
+	tokens := []string{}
+	for _, token := range []string{
+		"github.event.pull_request.title",
+		"github.event.pull_request.body",
+		"github.event.pull_request.head.ref",
+		"github.event.pull_request.head.label",
+		"github.event.pull_request.head.repo.full_name",
+		"github.head_ref",
+		"github.event.issue.title",
+		"github.event.comment.body",
+	} {
+		if strings.Contains(lower, token) {
+			tokens = append(tokens, token)
+		}
+	}
+	return tokens
+}
+
+func isGitHubWorkflowPath(path string) bool {
+	lower := filepath.ToSlash(strings.ToLower(strings.TrimSpace(path)))
+	return strings.HasPrefix(lower, ".github/workflows/") && (strings.HasSuffix(lower, ".yml") || strings.HasSuffix(lower, ".yaml"))
+}
+
+func workflowLine(node *yaml.Node) int {
+	if node == nil || node.Line <= 0 {
+		return 1
+	}
+	return node.Line
+}
+
+func stepLine(step githubWorkflowStep) int {
+	for _, line := range []int{step.UsesLine, step.RunLine, step.Line} {
+		if line > 0 {
+			return line
+		}
+	}
+	return 1
+}
+
+func truncateWorkflowSnippet(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if len(trimmed) > 240 {
+		return trimmed[:240] + "..."
+	}
+	return trimmed
+}
+
+func firstNonEmptyWorkflowString(values ...string) string {
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/repoexposure/workflow_analyzer_test.go
+++ b/internal/repoexposure/workflow_analyzer_test.go
@@ -1,0 +1,230 @@
+package repoexposure
+
+import (
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+func TestGitHubWorkflowAnalyzerDetectsContextualAttackPaths(t *testing.T) {
+	content := []byte(`name: dangerous-pr-target
+on:
+  pull_request_target:
+    branches: [main]
+jobs:
+  publish:
+    permissions:
+      contents: write
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: evilcorp/build-action@v1
+      - run: echo "${{ github.event.pull_request.title }}"
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::123456789012:role/deploy
+      - uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: deps-${{ github.head_ref }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: deps-${{ github.head_ref }}-
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: dist/
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/pr-target.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	assertWorkflowDetectors(t, findings, []string{
+		"workflow_pull_request_target",
+		"workflow_broad_token_permissions",
+		"workflow_pull_request_target_privileged_context",
+		"workflow_pull_request_target_untrusted_checkout",
+		"workflow_unpinned_third_party_action",
+		"workflow_shell_injection_user_context",
+		"workflow_oidc_broad_trust",
+		"workflow_cache_poisoning",
+		"workflow_artifact_poisoning",
+	})
+
+	checkout := firstDetectorFinding(t, findings, "workflow_pull_request_target_untrusted_checkout")
+	if checkout.Severity != domain.SeverityCritical {
+		t.Fatalf("expected untrusted checkout to be critical, got %+v", checkout)
+	}
+	if got := checkout.Evidence["workflow_job"]; got != "publish" {
+		t.Fatalf("expected workflow job evidence, got %+v", checkout.Evidence)
+	}
+	if events, _ := checkout.Evidence["workflow_events"].([]string); len(events) != 1 || events[0] != "pull_request_target" {
+		t.Fatalf("expected event evidence, got %+v", checkout.Evidence)
+	}
+
+	injection := firstDetectorFinding(t, findings, "workflow_shell_injection_user_context")
+	if tokens, _ := injection.Evidence["untrusted_context"].([]string); len(tokens) == 0 || tokens[0] != "github.event.pull_request.title" {
+		t.Fatalf("expected untrusted context evidence, got %+v", injection.Evidence)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerDetectsWorkflowRunPrivilegeChain(t *testing.T) {
+	content := []byte(`name: release-after-build
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh release upload "$TAG" dist/app.tar.gz
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/release.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	assertWorkflowDetectors(t, findings, []string{
+		"workflow_broad_token_permissions",
+		"workflow_run_privilege_chain",
+		"workflow_artifact_poisoning",
+	})
+}
+
+func TestGitHubWorkflowAnalyzerDetectsPullRequestTargetSecretInheritance(t *testing.T) {
+	content := []byte(`name: inherited-secret-pr-target
+on: pull_request_target
+permissions:
+  contents: read
+jobs:
+  reusable:
+    uses: octo-org/reusable/.github/workflows/build.yml@main
+    secrets: inherit
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/reusable.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	assertWorkflowDetectors(t, findings, []string{
+		"workflow_pull_request_target",
+		"workflow_pull_request_target_privileged_context",
+	})
+}
+
+func TestGitHubWorkflowAnalyzerKeepsHardenedPullRequestTargetShallow(t *testing.T) {
+	content := []byte(`name: safe-labeler
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        with:
+          script: core.info("metadata only")
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/labeler.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	if !containsDetector(findings, "workflow_pull_request_target") {
+		t.Fatalf("expected compatibility pull_request_target finding, got %+v", findings)
+	}
+	for _, detector := range []string{
+		"workflow_broad_token_permissions",
+		"workflow_pull_request_target_privileged_context",
+		"workflow_pull_request_target_untrusted_checkout",
+		"workflow_unpinned_third_party_action",
+		"workflow_shell_injection_user_context",
+		"workflow_oidc_broad_trust",
+		"workflow_cache_poisoning",
+		"workflow_artifact_poisoning",
+	} {
+		if containsDetector(findings, detector) {
+			t.Fatalf("expected hardened workflow not to emit %s, got %+v", detector, findings)
+		}
+	}
+}
+
+func TestGitHubWorkflowAnalyzerDoesNotTreatHeadSHAAsShellInjection(t *testing.T) {
+	content := []byte(`name: pr-info
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  inspect:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ github.event.pull_request.head.sha }}"
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/pr-info.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	if containsDetector(findings, "workflow_shell_injection_user_context") {
+		t.Fatalf("expected PR head SHA not to be treated as shell injection evidence, got %+v", findings)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerDoesNotFlagBranchScopedOIDCDeploy(t *testing.T) {
+	content := []byte(`name: deploy
+on:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/configure-aws-credentials@f00dbabe1234567890abcdef1234567890abcdef
+        with:
+          role-to-assume: arn:aws:iam::123456789012:role/deploy
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/deploy.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	if containsDetector(findings, "workflow_oidc_broad_trust") {
+		t.Fatalf("expected branch-scoped deploy OIDC not to be flagged as broad trust, got %+v", findings)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerFlagsBroadPushOIDCDeploy(t *testing.T) {
+	content := []byte(`name: broad-deploy
+on: push
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/auth@v2
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/broad-deploy.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	assertWorkflowDetectors(t, findings, []string{
+		"workflow_unpinned_third_party_action",
+		"workflow_oidc_broad_trust",
+	})
+}
+
+func assertWorkflowDetectors(t *testing.T, findings []domain.Finding, detectors []string) {
+	t.Helper()
+	for _, detector := range detectors {
+		if !containsDetector(findings, detector) {
+			t.Fatalf("expected detector %s, got %+v", detector, findings)
+		}
+	}
+}
+
+func firstDetectorFinding(t *testing.T, findings []domain.Finding, detector string) domain.Finding {
+	t.Helper()
+	for _, finding := range findings {
+		if finding.Detector == detector {
+			return finding
+		}
+	}
+	t.Fatalf("expected detector %s, got %+v", detector, findings)
+	return domain.Finding{}
+}

--- a/internal/repoexposure/workflow_analyzer_test.go
+++ b/internal/repoexposure/workflow_analyzer_test.go
@@ -107,7 +107,34 @@ jobs:
 	assertWorkflowDetectors(t, findings, []string{
 		"workflow_pull_request_target",
 		"workflow_pull_request_target_privileged_context",
+		"workflow_unpinned_third_party_action",
 	})
+}
+
+func TestGitHubWorkflowAnalyzerDetectsReusableWorkflowAttackSurface(t *testing.T) {
+	content := []byte(`name: release-reusable
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+jobs:
+  release:
+    permissions:
+      contents: write
+    uses: evilcorp/reusable/.github/workflows/release.yml@main
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/release-reusable.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	assertWorkflowDetectors(t, findings, []string{
+		"workflow_broad_token_permissions",
+		"workflow_run_privilege_chain",
+		"workflow_unpinned_third_party_action",
+	})
+
+	reusable := firstDetectorFinding(t, findings, "workflow_unpinned_third_party_action")
+	if got, _ := reusable.Evidence["reusable_workflow_call"].(bool); !got {
+		t.Fatalf("expected reusable workflow evidence, got %+v", reusable.Evidence)
+	}
 }
 
 func TestGitHubWorkflowAnalyzerDetectsCompactSecretExpression(t *testing.T) {
@@ -250,6 +277,27 @@ jobs:
 	if containsDetector(findings, "workflow_shell_injection_user_context") {
 		t.Fatalf("expected trusted push event not to emit shell injection finding, got %+v", findings)
 	}
+}
+
+func TestGitHubWorkflowAnalyzerDetectsCacheSavePoisoning(t *testing.T) {
+	content := []byte(`name: save-cache
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/cache/save@v4
+        with:
+          path: node_modules
+          key: deps-${{ github.head_ref }}
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/save-cache.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	assertWorkflowDetectors(t, findings, []string{
+		"workflow_cache_poisoning",
+	})
 }
 
 func TestGitHubWorkflowAnalyzerTreatsIssuesEventBodyAsUntrusted(t *testing.T) {

--- a/internal/repoexposure/workflow_analyzer_test.go
+++ b/internal/repoexposure/workflow_analyzer_test.go
@@ -249,6 +249,29 @@ jobs:
 	}
 }
 
+func TestGitHubWorkflowAnalyzerTreatsPullRequestReviewBodyAsUntrusted(t *testing.T) {
+	content := []byte(`name: review-triage
+on: pull_request_review
+permissions:
+  contents: read
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ github.event.review.body }}"
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/review.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	assertWorkflowDetectors(t, findings, []string{
+		"workflow_shell_injection_user_context",
+	})
+
+	injection := firstDetectorFinding(t, findings, "workflow_shell_injection_user_context")
+	if tokens, _ := injection.Evidence["untrusted_context"].([]string); len(tokens) == 0 || tokens[0] != "github.event.review.body" {
+		t.Fatalf("expected review body evidence, got %+v", injection.Evidence)
+	}
+}
+
 func TestGitHubWorkflowAnalyzerDoesNotFlagBranchScopedOIDCDeploy(t *testing.T) {
 	content := []byte(`name: deploy
 on:
@@ -270,6 +293,28 @@ jobs:
 	if containsDetector(findings, "workflow_oidc_broad_trust") {
 		t.Fatalf("expected branch-scoped deploy OIDC not to be flagged as broad trust, got %+v", findings)
 	}
+}
+
+func TestGitHubWorkflowAnalyzerFlagsBroadTagOIDCDeployWithNarrowBranches(t *testing.T) {
+	content := []byte(`name: mixed-deploy
+on:
+  push:
+    branches: [main]
+    tags: ['*']
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/configure-aws-credentials@f00dbabe1234567890abcdef1234567890abcdef
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/mixed-deploy.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	assertWorkflowDetectors(t, findings, []string{
+		"workflow_oidc_broad_trust",
+	})
 }
 
 func TestGitHubWorkflowAnalyzerFlagsBroadPushOIDCDeploy(t *testing.T) {

--- a/internal/repoexposure/workflow_analyzer_test.go
+++ b/internal/repoexposure/workflow_analyzer_test.go
@@ -131,6 +131,27 @@ jobs:
 	})
 }
 
+func TestGitHubWorkflowAnalyzerDetectsBracketSecretExpression(t *testing.T) {
+	content := []byte(`name: bracket-secret-pr-target
+on: pull_request_target
+permissions:
+  contents: read
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - run: ./scripts/publish.sh
+        env:
+          TOKEN: ${{ secrets['release-token'] }}
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/bracket-secret.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	assertWorkflowDetectors(t, findings, []string{
+		"workflow_pull_request_target",
+		"workflow_pull_request_target_privileged_context",
+	})
+}
+
 func TestGitHubWorkflowAnalyzerKeepsHardenedPullRequestTargetShallow(t *testing.T) {
 	content := []byte(`name: safe-labeler
 on:
@@ -202,6 +223,29 @@ jobs:
 	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/push.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
 	if containsDetector(findings, "workflow_shell_injection_user_context") {
 		t.Fatalf("expected trusted push event not to emit shell injection finding, got %+v", findings)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerTreatsIssuesEventBodyAsUntrusted(t *testing.T) {
+	content := []byte(`name: issue-triage
+on: issues
+permissions:
+  contents: read
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ github.event.issue.body }}"
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/issues.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	assertWorkflowDetectors(t, findings, []string{
+		"workflow_shell_injection_user_context",
+	})
+
+	injection := firstDetectorFinding(t, findings, "workflow_shell_injection_user_context")
+	if tokens, _ := injection.Evidence["untrusted_context"].([]string); len(tokens) == 0 || tokens[0] != "github.event.issue.body" {
+		t.Fatalf("expected issue body evidence, got %+v", injection.Evidence)
 	}
 }
 

--- a/internal/repoexposure/workflow_analyzer_test.go
+++ b/internal/repoexposure/workflow_analyzer_test.go
@@ -137,6 +137,22 @@ jobs:
 	}
 }
 
+func TestGitHubWorkflowAnalyzerDoesNotFlagSameRepoReusableWorkflowAsThirdParty(t *testing.T) {
+	content := []byte(`name: same-repo-reusable
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  build:
+    uses: octo-org/octo-repo/.github/workflows/build.yml@main
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/same-repo-reusable.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	if containsDetector(findings, "workflow_unpinned_third_party_action") {
+		t.Fatalf("expected same-repo reusable workflow not to be third-party, got %+v", findings)
+	}
+}
+
 func TestGitHubWorkflowAnalyzerDetectsCompactSecretExpression(t *testing.T) {
 	content := []byte(`name: compact-secret-pr-target
 on: pull_request_target
@@ -344,6 +360,25 @@ jobs:
 	if tokens, _ := injection.Evidence["untrusted_context"].([]string); len(tokens) == 0 || tokens[0] != "github.event.review.body" {
 		t.Fatalf("expected review body evidence, got %+v", injection.Evidence)
 	}
+}
+
+func TestGitHubWorkflowAnalyzerTreatsPullRequestReviewOIDCAsBroadTrust(t *testing.T) {
+	content := []byte(`name: review-deploy
+on: pull_request_review
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/configure-aws-credentials@f00dbabe1234567890abcdef1234567890abcdef
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/review-deploy.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	assertWorkflowDetectors(t, findings, []string{
+		"workflow_oidc_broad_trust",
+	})
 }
 
 func TestGitHubWorkflowAnalyzerDoesNotFlagBranchScopedOIDCDeploy(t *testing.T) {

--- a/internal/repoexposure/workflow_analyzer_test.go
+++ b/internal/repoexposure/workflow_analyzer_test.go
@@ -190,6 +190,32 @@ jobs:
 	}
 }
 
+func TestGitHubWorkflowAnalyzerHonorsEmptyJobPermissionsOverride(t *testing.T) {
+	content := []byte(`name: empty-job-permissions
+on: pull_request_target
+permissions: write-all
+jobs:
+  analyze:
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/configure-aws-credentials@f00dbabe1234567890abcdef1234567890abcdef
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/empty-job-permissions.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	if !containsDetector(findings, "workflow_broad_token_permissions") {
+		t.Fatalf("expected workflow-level broad token compatibility finding, got %+v", findings)
+	}
+	for _, detector := range []string{
+		"workflow_pull_request_target_privileged_context",
+		"workflow_oidc_broad_trust",
+	} {
+		if containsDetector(findings, detector) {
+			t.Fatalf("expected empty job permissions override not to emit %s, got %+v", detector, findings)
+		}
+	}
+}
+
 func TestGitHubWorkflowAnalyzerDoesNotTreatHeadSHAAsShellInjection(t *testing.T) {
 	content := []byte(`name: pr-info
 on: pull_request
@@ -333,6 +359,24 @@ jobs:
 	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/broad-deploy.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
 	assertWorkflowDetectors(t, findings, []string{
 		"workflow_unpinned_third_party_action",
+		"workflow_oidc_broad_trust",
+	})
+}
+
+func TestGitHubWorkflowAnalyzerTreatsWriteAllAsOIDCWrite(t *testing.T) {
+	content := []byte(`name: write-all-oidc
+on: pull_request
+permissions: write-all
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/auth@v2
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/write-all-oidc.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	assertWorkflowDetectors(t, findings, []string{
+		"workflow_broad_token_permissions",
 		"workflow_oidc_broad_trust",
 	})
 }

--- a/internal/repoexposure/workflow_analyzer_test.go
+++ b/internal/repoexposure/workflow_analyzer_test.go
@@ -110,6 +110,27 @@ jobs:
 	})
 }
 
+func TestGitHubWorkflowAnalyzerDetectsCompactSecretExpression(t *testing.T) {
+	content := []byte(`name: compact-secret-pr-target
+on: pull_request_target
+permissions:
+  contents: read
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - run: ./scripts/publish.sh
+        env:
+          TOKEN: ${{secrets.RELEASE_TOKEN}}
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/compact-secret.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	assertWorkflowDetectors(t, findings, []string{
+		"workflow_pull_request_target",
+		"workflow_pull_request_target_privileged_context",
+	})
+}
+
 func TestGitHubWorkflowAnalyzerKeepsHardenedPullRequestTargetShallow(t *testing.T) {
 	content := []byte(`name: safe-labeler
 on:
@@ -163,6 +184,24 @@ jobs:
 	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/pr-info.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
 	if containsDetector(findings, "workflow_shell_injection_user_context") {
 		t.Fatalf("expected PR head SHA not to be treated as shell injection evidence, got %+v", findings)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerDoesNotFlagTrustedEventShellContext(t *testing.T) {
+	content := []byte(`name: trusted-push
+on: push
+permissions:
+  contents: read
+jobs:
+  inspect:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ github.event.pull_request.title }}"
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/push.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	if containsDetector(findings, "workflow_shell_injection_user_context") {
+		t.Fatalf("expected trusted push event not to emit shell injection finding, got %+v", findings)
 	}
 }
 


### PR DESCRIPTION
Fixes #1231

## What changed
- Added a semantic GitHub Actions workflow analyzer for `.github/workflows/*.yml` and `.github/workflows/*.yaml` files.
- Added context-aware detectors for privileged `pull_request_target` paths, untrusted PR-head checkout, broad token permissions, mutable third-party action refs, shell interpolation of user-controlled PR or issue context, `workflow_run` privilege chains, broad OIDC credential minting, cache poisoning, and artifact or release publishing from untrusted workflow context.
- Preserved the existing shallow `workflow_pull_request_target` and `workflow_write_all_permissions` compatibility findings while adding richer evidence for dangerous combinations.
- Documented every workflow detector and remediation path in `docs/repo-exposure.md` and added an Unreleased changelog entry.

## Why it changed
The repository exposure scanner previously recognized only obvious workflow keywords. That made it hard to distinguish a hardened `pull_request_target` metadata workflow from an exploitable workflow that checks out contributor code while holding write permissions or secrets. This change gives Identrail native GitHub workflow intelligence before external scanner adapters are added.

## Impact and risk
- Scanner output becomes more actionable because workflow findings include event, job, step/action, permission, and detector-specific evidence.
- Safe counterexamples are covered so lower-context `pull_request_target` usage does not automatically turn into critical attack-path findings.
- Existing compatibility detectors are still emitted, so downstream consumers that already rely on those detector IDs are not broken.
- Risk is contained to repository exposure YAML misconfiguration analysis and is covered by focused tests plus the repo-wide Go suite.

## Validation performed
- `git diff --check` passed.
- `go test ./internal/repoexposure` passed.
- `go test ./internal/...` passed.
- `go vet ./...` passed.
- `go test ./...` passed.
- Commit and push hooks passed, including gofmt, merge-conflict checks, token hygiene, Vercel artifact hygiene, and go vet.

## AI disclosure
- AI-assisted: No
- Tools used: N/A
- Where used: N/A
- Human verification performed: `git diff --check`, `go test ./internal/repoexposure`, `go test ./internal/...`, `go vet ./...`, and `go test ./...`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a context-aware GitHub Actions workflow analyzer that finds real attack paths in `/.github/workflows/*.yml|*.yaml`, including reusable workflow calls, and feeds them into repo exposure scans with clear evidence. Addresses #1231.

- New Features
  - Semantic analyzer for workflows under `/.github/workflows/` detecting: privileged `pull_request_target`, untrusted PR‑head checkout, broad token permissions, unpinned third‑party actions (e.g., `softprops/action-gh-release`, `aws-actions/configure-aws-credentials`), reusable workflow calls with mutable refs, shell interpolation of PR/issue/review context, risky `workflow_run` chains, broad OIDC minting, cache poisoning (including in reusable paths), and artifact/release publishing from untrusted inputs.
  - Evidence includes: `workflow_events`, `workflow_job`, `workflow_step_index`, `workflow_action`, `permission_summary`, `write_scopes`, plus detector‑specific fields like `checkout_ref`, `untrusted_context`, `cache_key`, `cache_restore_keys`, `action_ref`, `cloud_auth_action`, `oidc_risk_context`, `publishes_release`, `references_secrets`, `reusable_workflow_call`, and `reusable_workflow_source`.
  - Preserves compatibility signals (`workflow_pull_request_target`, `workflow_write_all_permissions`); integrated into repo exposure scans; adds tests; updates `docs/repo-exposure.md` and `CHANGELOG.md`.

- Bug Fixes
  - OIDC: do not flag branch‑scoped push deploys; do flag when push includes broad tag filters (e.g., `tags: ['*']`); treat `write-all` as implying `id-token: write`.
  - Shell: do not treat PR head SHA echo as injection; only flag interpolation on untrusted events.
  - Privileged context: keep metadata‑only `pull_request_target` shallow; detect secrets via `secrets: inherit` and compact/bracket forms (e.g., `${{secrets.X}}`, `${{ secrets['x'] }}`).
  - Review/issue events: align trust handling; treat `issues`, `pull_request_review`, and `pull_request_review_comment` bodies as untrusted input.
  - Permissions: honor job‑level overrides (including `permissions: {}`) over workflow‑level settings.

<sup>Written for commit 49ffd554f99a72ef6a848c48f5bc02f704d9dbfa. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1253?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

