### PR TITLE
Add external repo scanner adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## Unreleased
+- Added opt-in external repository finding adapters. SARIF 2.1.0 output and
+  GitHub code-scanning alerts can now be normalized into Identrail repo
+  findings with adapter name/version/rule/location/confidence evidence,
+  severity mapping, secret-like evidence redaction, stable dedupe against
+  native findings, and no external scanner execution unless explicitly wired by
+  the caller.
 - Added context-aware GitHub Actions workflow attack analysis to repository
   exposure scans. Workflow findings now distinguish shallow
   `pull_request_target` / `write-all` signals from dangerous combinations such

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -190,7 +190,7 @@ installation cannot read code-scanning alerts, the native Identrail scan still
 completes and adapter findings are simply absent for that run.
 
 Adapter findings are normalized into the same `domain.Finding` shape as native
-repository findings:
+repository findings, and include adapter-specific evidence metadata:
 
 - `adapter_name`
 - `adapter_version`

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -170,6 +170,49 @@ write permissions is emitted as a critical workflow attack path.
 
 To add a new secret detector, add a new entry to the registry with a unique ID, a new version if needed for compatibility, and test fixtures.
 
+## External Scanner Adapters
+
+The scanner can import findings from explicit, caller-provided adapters. No
+external scanner binaries are executed by default. This keeps hosted scans
+read-only and deterministic unless a future caller deliberately wires a scanner
+runner with its own allowlist, timeout, filesystem, and network controls.
+
+Supported ingestion surfaces:
+
+- SARIF 2.1.0 results, including tools such as Semgrep, Gitleaks, CodeQL, and
+  other scanners that emit SARIF.
+- GitHub code-scanning alerts fetched through the GitHub App connector's
+  `security_events: read` permission.
+
+Connector-backed GitHub App repository scans collect open code-scanning alerts
+for selected repositories when the installation permission allows it. If the
+installation cannot read code-scanning alerts, the native Identrail scan still
+completes and adapter findings are simply absent for that run.
+
+Adapter findings are normalized into the same `domain.Finding` shape as native
+repository findings:
+
+- `adapter_name`
+- `adapter_version`
+- `adapter_source_type`
+- `adapter_rule_id`
+- `adapter_rule_name`
+- `adapter_confidence`
+- `adapter_severity_source`
+- `adapter_location_path`
+- `adapter_location_line`
+- `adapter_location_column`
+
+Secret-like adapter findings are treated as secret exposure findings and do not
+store raw messages or snippets. Identrail stores a redacted snippet marker,
+sets `line_snippet_redacted: true`, and records `raw_secret_stored: false`,
+`secret_value_masked: true`, and `raw_adapter_result_stored: false` evidence.
+
+External findings are deduplicated by stable IDs, adapter dedupe keys, detector
+location, and same-line snippet fingerprints. This prevents a native detector
+and an external scanner from flooding the same path/line with repeated copies
+of the same underlying issue.
+
 ## Secret Confidence Classification
 
 Secret findings are not silently dropped when they look like examples or test
@@ -214,6 +257,11 @@ workflow layer.
   - redacted line snippets
 - Findings are deterministic and deduplicated by stable IDs/fingerprints.
 - Output is capped by `--max-findings` to prevent runaway payloads.
+- External adapters are opt-in. Identrail imports already-produced SARIF or
+  GitHub alert data; it does not execute Gitleaks, Semgrep, CodeQL, or other
+  third-party scanner binaries by default.
+- External adapter evidence stores normalized metadata only and explicitly
+  records `raw_adapter_result_stored: false`.
 - Repo scan metadata/findings are persisted in dedicated storage (`repo_scans`, `repo_findings`) to avoid changing existing cloud scan APIs.
 - GitHub App private-repo scans persist only non-secret connector context
   (`source_provider`, project id, connector id, installation id). The worker
@@ -266,3 +314,6 @@ workflow layer.
   or worker scans can authenticate to them.
 - CLI scans support public remotes and local repository paths, but do not use
   saved Identrail connector credentials.
+- External scanner execution is intentionally not enabled as a runtime feature
+  in this release. Add execution only behind explicit operator-controlled
+  allowlists, resource limits, and sandboxing.

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -94,6 +94,11 @@ type GitHubInstallationTokenMinter interface {
 	Mint(ctx context.Context, installationID int64) (githubconnector.InstallationToken, error)
 }
 
+// GitHubCodeScanningAlertCollector lists code-scanning alerts visible to one GitHub App installation.
+type GitHubCodeScanningAlertCollector interface {
+	ListCodeScanningAlerts(ctx context.Context, installationID int64, repository string) ([]githubconnector.CodeScanningAlert, error)
+}
+
 // AWSScannerFactory creates a scanner bound to one persisted AWS connector.
 type AWSScannerFactory func(ctx context.Context, connection AWSConnectionStatus) (ScannerRunner, error)
 
@@ -145,6 +150,7 @@ type Service struct {
 	GitHubRepositoryLister           GitHubRepositoryLister
 	GitHubRepositoryPostureCollector GitHubRepositoryPostureCollector
 	GitHubInstallationTokenMinter    GitHubInstallationTokenMinter
+	GitHubCodeScanningAlertCollector GitHubCodeScanningAlertCollector
 	GitHubWebhookReplayWindow        time.Duration
 	GitHubWebhookBurstWindow         time.Duration
 	githubConnectMu                  sync.RWMutex
@@ -1374,6 +1380,20 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, safeErr.Error())
 		return RunRepoScanResult{}, safeErr
 	}
+	if !result.Truncated {
+		externalFindings, externalErr := s.repoScanExternalFindings(ctx, record, s.Now().UTC())
+		if externalErr != nil {
+			if errors.Is(externalErr, context.Canceled) || errors.Is(externalErr, context.DeadlineExceeded) {
+				s.recordRepoScanExecutionFailure()
+				_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), result.CommitsScanned, result.FilesScanned, len(result.Findings), result.Truncated, externalErr.Error())
+				return RunRepoScanResult{}, externalErr
+			}
+		} else if len(externalFindings) > 0 {
+			var externalTruncated bool
+			result.Findings, externalTruncated = repoexposure.MergeExternalFindings(result.Findings, externalFindings, normalizedMaxFindings)
+			result.Truncated = result.Truncated || externalTruncated
+		}
+	}
 	result.Findings = enrichFindingsWithRepoContext(result.Findings, result.Repository, record.Repository)
 	if err := s.Store.UpsertRepoFindings(ctx, record.ID, result.Findings); err != nil {
 		s.recordRepoScanExecutionFailure()
@@ -1434,6 +1454,64 @@ func (s *Service) repoScanExecutorForRecord(ctx context.Context, record db.RepoS
 	default:
 		return nil, nil, ErrInvalidRepoScanRequest
 	}
+}
+
+func (s *Service) repoScanExternalFindings(ctx context.Context, record db.RepoScanRecord, detectedAt time.Time) ([]domain.Finding, error) {
+	source := record.Source.Normalize()
+	if source.Provider != "github_app" || source.InstallationID <= 0 || s.GitHubCodeScanningAlertCollector == nil {
+		return nil, nil
+	}
+	alerts, err := s.GitHubCodeScanningAlertCollector.ListCodeScanningAlerts(ctx, source.InstallationID, record.Repository)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		// Code-scanning alerts are an enrichment source. Permission-limited
+		// installations should still complete the native repo scan.
+		return nil, nil
+	}
+	return repoexposure.NormalizeGitHubCodeScanningAlerts(ctx, record.Repository, "", githubCodeScanningAlertsToRepoExposure(alerts), detectedAt)
+}
+
+func githubCodeScanningAlertsToRepoExposure(alerts []githubconnector.CodeScanningAlert) []repoexposure.GitHubCodeScanningAlert {
+	converted := make([]repoexposure.GitHubCodeScanningAlert, 0, len(alerts))
+	for _, alert := range alerts {
+		converted = append(converted, repoexposure.GitHubCodeScanningAlert{
+			Number: alert.Number,
+			State:  alert.State,
+			Rule: repoexposure.GitHubCodeScanningRule{
+				ID:                    alert.Rule.ID,
+				Name:                  alert.Rule.Name,
+				Severity:              alert.Rule.Severity,
+				Description:           alert.Rule.Description,
+				SecuritySeverityLevel: alert.Rule.SecuritySeverityLevel,
+				Tags:                  append([]string(nil), alert.Rule.Tags...),
+			},
+			Tool: repoexposure.GitHubCodeScanningTool{
+				Name:    alert.Tool.Name,
+				Version: alert.Tool.Version,
+			},
+			MostRecentInstance: repoexposure.GitHubCodeScanningAlertInstance{
+				Ref:         alert.MostRecentInstance.Ref,
+				AnalysisKey: alert.MostRecentInstance.AnalysisKey,
+				Category:    alert.MostRecentInstance.Category,
+				State:       alert.MostRecentInstance.State,
+				CommitSHA:   alert.MostRecentInstance.CommitSHA,
+				Message: repoexposure.GitHubCodeScanningMessage{
+					Text: alert.MostRecentInstance.Message.Text,
+				},
+				Location: repoexposure.GitHubCodeScanningLocation{
+					Path:        alert.MostRecentInstance.Location.Path,
+					StartLine:   alert.MostRecentInstance.Location.StartLine,
+					EndLine:     alert.MostRecentInstance.Location.EndLine,
+					StartColumn: alert.MostRecentInstance.Location.StartColumn,
+					EndColumn:   alert.MostRecentInstance.Location.EndColumn,
+				},
+			},
+			HTMLURL: alert.HTMLURL,
+		})
+	}
+	return converted
 }
 
 func (s *Service) githubAppRepoScanCredential(ctx context.Context, record db.RepoScanRecord) (repoexposure.HTTPSCloneCredential, error) {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -77,6 +77,24 @@ func (f *fakeGitHubInstallationTokenMinter) Mint(ctx context.Context, installati
 	return f.token, nil
 }
 
+type fakeGitHubCodeScanningAlertCollector struct {
+	alerts         []githubconnector.CodeScanningAlert
+	err            error
+	installationID int64
+	repository     string
+	calls          int
+}
+
+func (f *fakeGitHubCodeScanningAlertCollector) ListCodeScanningAlerts(ctx context.Context, installationID int64, repository string) ([]githubconnector.CodeScanningAlert, error) {
+	f.calls++
+	f.installationID = installationID
+	f.repository = repository
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.alerts, nil
+}
+
 type traceCapturingScanner struct {
 	result app.ScanResult
 	err    error
@@ -3492,6 +3510,83 @@ func TestServiceProcessQueuedGitHubAppRepoScanUsesInstallationToken(t *testing.T
 	}
 	if gotCredential.Host != "github.com" || gotCredential.Username != "x-access-token" || gotCredential.Password != "ghs_installation_token" {
 		t.Fatalf("unexpected clone credential %+v", gotCredential)
+	}
+}
+
+func TestServiceProcessQueuedGitHubAppRepoScanImportsCodeScanningAlerts(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	ctx := defaultScopeContext()
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedGitHubAppConnection(t, svc, ctx, "project-1", 101, []string{"owner/private"})
+	svc.RepoScanAllowedTargets = []string{"owner/*"}
+	svc.GitHubInstallationTokenMinter = &fakeGitHubInstallationTokenMinter{
+		token: githubconnector.InstallationToken{Token: "ghs_installation_token", ExpiresAt: time.Now().Add(time.Hour)},
+	}
+	svc.GitHubCodeScanningAlertCollector = &fakeGitHubCodeScanningAlertCollector{
+		alerts: []githubconnector.CodeScanningAlert{
+			{
+				Number: 12,
+				State:  "open",
+				Rule: githubconnector.CodeScanningRule{
+					ID:                    "js/sql-injection",
+					Name:                  "SQL query built from user-controlled sources",
+					Severity:              "warning",
+					SecuritySeverityLevel: "high",
+					Tags:                  []string{"security"},
+				},
+				Tool: githubconnector.CodeScanningTool{Name: "CodeQL", Version: "2.17.0"},
+				MostRecentInstance: githubconnector.CodeScanningAlertInstance{
+					State:     "open",
+					CommitSHA: "def456",
+					Message:   githubconnector.CodeScanningMessage{Text: "Query string includes user input."},
+					Location:  githubconnector.CodeScanningLocation{Path: "src/db.ts", StartLine: 88, StartColumn: 11},
+				},
+				HTMLURL: "https://github.com/owner/private/security/code-scanning/12",
+			},
+		},
+	}
+	svc.AuthenticatedRepoScannerFactory = func(historyLimit int, maxFindings int, credential repoexposure.HTTPSCloneCredential) RepoScanExecutor {
+		return &fakeRepoExecutor{
+			result: repoexposure.ScanResult{
+				Repository:     "owner/private",
+				CommitsScanned: 1,
+				FilesScanned:   1,
+			},
+		}
+	}
+
+	record, err := svc.EnqueueRepoScan(ctx, RepoScanRequest{
+		Repository: "owner/private",
+		ProjectID:  "project-1",
+	})
+	if err != nil {
+		t.Fatalf("enqueue connector-backed repo scan: %v", err)
+	}
+	processed, err := svc.ProcessNextQueuedRepoScan(ctx)
+	if err != nil {
+		t.Fatalf("process connector-backed repo scan: %v", err)
+	}
+	if !processed {
+		t.Fatal("expected queued connector-backed repo scan to be processed")
+	}
+	collector := svc.GitHubCodeScanningAlertCollector.(*fakeGitHubCodeScanningAlertCollector)
+	if collector.calls != 1 || collector.installationID != 101 || collector.repository != "owner/private" {
+		t.Fatalf("unexpected code scanning collector call: calls=%d installation=%d repository=%q", collector.calls, collector.installationID, collector.repository)
+	}
+	stored, err := svc.GetRepoScan(ctx, record.ID)
+	if err != nil {
+		t.Fatalf("get repo scan: %v", err)
+	}
+	if stored.FindingCount != 1 {
+		t.Fatalf("expected one imported code-scanning finding, got %+v", stored)
+	}
+	findings, err := svc.ListRepoFindings(ctx, 10, db.RepoFindingFilter{RepoScanID: record.ID})
+	if err != nil {
+		t.Fatalf("list repo findings: %v", err)
+	}
+	if len(findings) != 1 || findings[0].Detector != "github_code_scanning:codeql:js_sql-injection" || findings[0].SourceURL == "" {
+		t.Fatalf("unexpected imported finding: %+v", findings)
 	}
 }
 

--- a/internal/connectors/github/code_scanning.go
+++ b/internal/connectors/github/code_scanning.go
@@ -1,0 +1,83 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// CodeScanningAlert is the GitHub API shape needed for repository finding ingestion.
+type CodeScanningAlert struct {
+	Number             int                       `json:"number"`
+	State              string                    `json:"state"`
+	Rule               CodeScanningRule          `json:"rule"`
+	Tool               CodeScanningTool          `json:"tool"`
+	MostRecentInstance CodeScanningAlertInstance `json:"most_recent_instance"`
+	HTMLURL            string                    `json:"html_url"`
+}
+
+type CodeScanningRule struct {
+	ID                    string   `json:"id"`
+	Name                  string   `json:"name"`
+	Severity              string   `json:"severity"`
+	Description           string   `json:"description"`
+	SecuritySeverityLevel string   `json:"security_severity_level"`
+	Tags                  []string `json:"tags"`
+}
+
+type CodeScanningTool struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type CodeScanningAlertInstance struct {
+	Ref         string               `json:"ref"`
+	AnalysisKey string               `json:"analysis_key"`
+	Category    string               `json:"category"`
+	State       string               `json:"state"`
+	CommitSHA   string               `json:"commit_sha"`
+	Message     CodeScanningMessage  `json:"message"`
+	Location    CodeScanningLocation `json:"location"`
+}
+
+type CodeScanningMessage struct {
+	Text string `json:"text"`
+}
+
+type CodeScanningLocation struct {
+	Path        string `json:"path"`
+	StartLine   int    `json:"start_line"`
+	EndLine     int    `json:"end_line"`
+	StartColumn int    `json:"start_column"`
+	EndColumn   int    `json:"end_column"`
+}
+
+// ListCodeScanningAlerts returns all open GitHub code-scanning alerts for a repository.
+func (c RepositoryClient) ListCodeScanningAlerts(ctx context.Context, installationID int64, repository string) ([]CodeScanningAlert, error) {
+	if c.TokenClient == nil {
+		return nil, fmt.Errorf("github installation token client is required")
+	}
+	normalizedRepository, err := normalizeRepositoryName(repository)
+	if err != nil {
+		return nil, err
+	}
+	token, err := c.TokenClient.Mint(ctx, installationID)
+	if err != nil {
+		return nil, err
+	}
+	alerts := []CodeScanningAlert{}
+	endpoint := c.repositoryEndpoint(normalizedRepository, "/code-scanning/alerts?state=open&per_page="+strconv.Itoa(defaultRepoPageLimit))
+	_, err = c.getJSONPages(ctx, token.Token, endpoint, func(body []byte) error {
+		var page []CodeScanningAlert
+		if err := json.Unmarshal(body, &page); err != nil {
+			return err
+		}
+		alerts = append(alerts, page...)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list github code scanning alerts: %w", err)
+	}
+	return alerts, nil
+}

--- a/internal/connectors/github/code_scanning_test.go
+++ b/internal/connectors/github/code_scanning_test.go
@@ -1,0 +1,104 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRepositoryClientListCodeScanningAlerts(t *testing.T) {
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.Header.Get("Authorization") != "Bearer inst-token" {
+			t.Fatalf("missing installation token")
+		}
+		if r.Header.Get("X-GitHub-Api-Version") != "2022-11-28" {
+			t.Fatalf("missing GitHub API version header")
+		}
+		switch calls {
+		case 1:
+			if r.URL.Path != "/repos/owner/repo/code-scanning/alerts" {
+				t.Fatalf("unexpected path %s", r.URL.Path)
+			}
+			if r.URL.Query().Get("state") != "open" || r.URL.Query().Get("per_page") != "100" {
+				t.Fatalf("unexpected first page query %s", r.URL.RawQuery)
+			}
+			w.Header().Set("Link", fmt.Sprintf(`<%s/repos/owner/repo/code-scanning/alerts?state=open&per_page=100&page=2>; rel="next"`, serverURLFromRequest(r)))
+			_, _ = w.Write([]byte(`[{
+				"number": 1,
+				"state": "open",
+				"rule": {"id": "js/sql-injection", "name": "SQL injection", "severity": "warning", "security_severity_level": "high", "tags": ["security"]},
+				"tool": {"name": "CodeQL", "version": "2.17.0"},
+				"most_recent_instance": {
+					"state": "open",
+					"commit_sha": "abc123",
+					"message": {"text": "Query includes user input."},
+					"location": {"path": "src/db.ts", "start_line": 88, "start_column": 11}
+				},
+				"html_url": "https://github.com/owner/repo/security/code-scanning/1"
+			}]`))
+		case 2:
+			if r.URL.Query().Get("page") != "2" {
+				t.Fatalf("unexpected second page query %s", r.URL.RawQuery)
+			}
+			_, _ = w.Write([]byte(`[{
+				"number": 2,
+				"state": "open",
+				"rule": {"id": "go/path-injection", "name": "Path injection", "severity": "error"},
+				"tool": {"name": "CodeQL"},
+				"most_recent_instance": {
+					"commit_sha": "def456",
+					"message": {"text": "Path includes user input."},
+					"location": {"path": "main.go", "start_line": 12}
+				}
+			}]`))
+		default:
+			t.Fatalf("unexpected extra page")
+		}
+	}))
+	defer server.Close()
+
+	alerts, err := (RepositoryClient{
+		TokenClient: minter,
+		APIBaseURL:  server.URL,
+	}).ListCodeScanningAlerts(context.Background(), 456, "Owner/Repo")
+	if err != nil {
+		t.Fatalf("list code scanning alerts: %v", err)
+	}
+	if minter.seenInstallationID != 456 {
+		t.Fatalf("unexpected installation id %d", minter.seenInstallationID)
+	}
+	if len(alerts) != 2 {
+		t.Fatalf("expected two alerts, got %+v", alerts)
+	}
+	if alerts[0].Rule.ID != "js/sql-injection" || alerts[0].Tool.Name != "CodeQL" || alerts[0].MostRecentInstance.Location.Path != "src/db.ts" {
+		t.Fatalf("unexpected first alert %+v", alerts[0])
+	}
+	if alerts[1].Number != 2 || alerts[1].MostRecentInstance.CommitSHA != "def456" {
+		t.Fatalf("unexpected second alert %+v", alerts[1])
+	}
+}
+
+func TestRepositoryClientListCodeScanningAlertsErrors(t *testing.T) {
+	if _, err := (RepositoryClient{}).ListCodeScanningAlerts(context.Background(), 1, "owner/repo"); err == nil {
+		t.Fatal("expected missing token client error")
+	}
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	if _, err := (RepositoryClient{TokenClient: minter}).ListCodeScanningAlerts(context.Background(), 1, "not-a-repo"); err == nil || !strings.Contains(err.Error(), "owner/name") {
+		t.Fatalf("expected owner/name validation error, got %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"permission denied"}`, http.StatusForbidden)
+	}))
+	defer server.Close()
+	_, err := (RepositoryClient{TokenClient: minter, APIBaseURL: server.URL}).ListCodeScanningAlerts(context.Background(), 1, "owner/repo")
+	if err == nil || !strings.Contains(err.Error(), "status 403") {
+		t.Fatalf("expected status error, got %v", err)
+	}
+}

--- a/internal/repoexposure/adapters.go
+++ b/internal/repoexposure/adapters.go
@@ -1,0 +1,242 @@
+package repoexposure
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+const (
+	externalAdapterHistorySource = "external_adapter"
+	externalAdapterVersion       = "2026.05"
+)
+
+// ExternalAdapterInput gives an adapter the scan context needed to normalize
+// imported findings without granting it repository execution privileges.
+type ExternalAdapterInput struct {
+	Repository string
+	Commit     string
+	DetectedAt time.Time
+}
+
+// ExternalFindingAdapter imports already-produced scanner output into
+// Identrail repo findings. Adapters are opt-in; Scanner runs none by default.
+type ExternalFindingAdapter interface {
+	Name() string
+	Version() string
+	Findings(ctx context.Context, input ExternalAdapterInput) ([]domain.Finding, error)
+}
+
+// WithExternalAdapters adds opt-in external finding adapters to a scanner.
+// Identrail does not execute external binaries unless callers provide an
+// adapter that does so under their own explicit controls.
+func WithExternalAdapters(adapters ...ExternalFindingAdapter) Option {
+	return func(s *Scanner) {
+		for _, adapter := range adapters {
+			if adapter != nil {
+				s.adapters = append(s.adapters, adapter)
+			}
+		}
+	}
+}
+
+// MergeExternalFindings merges adapter findings into an existing finding set
+// while enforcing the same stable dedupe and cap behavior used by Scanner.
+func MergeExternalFindings(existing []domain.Finding, external []domain.Finding, maxFindings int) ([]domain.Finding, bool) {
+	return appendExternalFindings(existing, external, map[string]struct{}{}, maxFindings)
+}
+
+func appendExternalFindings(existing []domain.Finding, external []domain.Finding, seen map[string]struct{}, maxFindings int) ([]domain.Finding, bool) {
+	if maxFindings <= 0 {
+		maxFindings = defaultMaxFindings
+	}
+	if len(existing) >= maxFindings {
+		return existing, true
+	}
+	known := map[string]struct{}{}
+	for key := range seen {
+		known[key] = struct{}{}
+	}
+	for _, finding := range existing {
+		for _, key := range repoFindingDedupeKeys(finding) {
+			known[key] = struct{}{}
+		}
+	}
+
+	merged := existing
+	for _, finding := range external {
+		finding = normalizeExternalFinding(finding)
+		if finding.ID == "" {
+			finding.ID = deterministicExternalFindingID(finding)
+		}
+		keys := repoFindingDedupeKeys(finding)
+		duplicate := false
+		for _, key := range keys {
+			if _, ok := known[key]; ok {
+				duplicate = true
+				break
+			}
+		}
+		if duplicate {
+			continue
+		}
+		merged = append(merged, finding)
+		for _, key := range keys {
+			known[key] = struct{}{}
+			seen[key] = struct{}{}
+		}
+		if finding.ID != "" {
+			seen[finding.ID] = struct{}{}
+		}
+		if len(merged) >= maxFindings {
+			return merged, true
+		}
+	}
+	return merged, false
+}
+
+func normalizeExternalFinding(finding domain.Finding) domain.Finding {
+	if finding.Evidence == nil {
+		finding.Evidence = map[string]any{}
+	}
+	if _, ok := finding.Evidence["history_source"]; !ok {
+		finding.Evidence["history_source"] = externalAdapterHistorySource
+	}
+	if _, ok := finding.Evidence["raw_adapter_result_stored"]; !ok {
+		finding.Evidence["raw_adapter_result_stored"] = false
+	}
+	if finding.Repository == "" {
+		finding.Repository = evidenceString(finding.Evidence, "repository")
+	}
+	if finding.FilePath == "" {
+		finding.FilePath = evidenceString(finding.Evidence, "file_path")
+	}
+	if finding.LineNumber == 0 {
+		finding.LineNumber = evidenceInt(finding.Evidence, "line_number")
+	}
+	if finding.Detector == "" {
+		finding.Detector = evidenceString(finding.Evidence, "detector")
+	}
+	if finding.Commit == "" {
+		finding.Commit = evidenceString(finding.Evidence, "commit")
+	}
+	if finding.LineSnippet == "" {
+		finding.LineSnippet = evidenceString(finding.Evidence, "line_snippet")
+	}
+	return finding
+}
+
+func deterministicExternalFindingID(finding domain.Finding) string {
+	return "finding:" + hashDeterministicID(
+		"repo-adapter",
+		string(finding.Type),
+		finding.Repository,
+		finding.FilePath,
+		strconv.Itoa(finding.LineNumber),
+		finding.Detector,
+		hashSHA256(finding.LineSnippet),
+	)
+}
+
+func repoFindingDedupeKeys(finding domain.Finding) []string {
+	normalized := findingContextFrom(finding)
+	keys := []string{}
+	if strings.TrimSpace(normalized.ID) != "" {
+		keys = append(keys, "id:"+strings.TrimSpace(normalized.ID))
+	}
+	if key := evidenceString(finding.Evidence, "adapter_dedupe_key"); key != "" {
+		keys = append(keys, "adapter:"+key)
+	}
+	repository := strings.ToLower(strings.TrimSpace(normalized.Repository))
+	filePath := strings.TrimSpace(normalized.FilePath)
+	line := normalized.LineNumber
+	detector := strings.ToLower(strings.TrimSpace(normalized.Detector))
+	if repository != "" && filePath != "" && line > 0 && detector != "" {
+		keys = append(keys, fmt.Sprintf("detector:%s:%s:%d:%s:%s", normalized.Type, repository, line, filePath, detector))
+	}
+	snippet := compactFindingText(normalized.LineSnippet)
+	if repository != "" && filePath != "" && line > 0 && snippet != "" {
+		keys = append(keys, fmt.Sprintf("line:%s:%s:%d:%s:%s", normalized.Type, repository, line, filePath, hashSHA256(snippet)))
+	}
+	return keys
+}
+
+type findingContext struct {
+	ID          string
+	Type        domain.FindingType
+	Repository  string
+	FilePath    string
+	LineNumber  int
+	Detector    string
+	LineSnippet string
+}
+
+func findingContextFrom(finding domain.Finding) findingContext {
+	context := findingContext{
+		ID:          finding.ID,
+		Type:        finding.Type,
+		Repository:  finding.Repository,
+		FilePath:    finding.FilePath,
+		LineNumber:  finding.LineNumber,
+		Detector:    finding.Detector,
+		LineSnippet: finding.LineSnippet,
+	}
+	if context.Repository == "" {
+		context.Repository = evidenceString(finding.Evidence, "repository")
+	}
+	if context.FilePath == "" {
+		context.FilePath = evidenceString(finding.Evidence, "file_path")
+	}
+	if context.LineNumber == 0 {
+		context.LineNumber = evidenceInt(finding.Evidence, "line_number")
+	}
+	if context.Detector == "" {
+		context.Detector = evidenceString(finding.Evidence, "detector")
+	}
+	if context.LineSnippet == "" {
+		context.LineSnippet = evidenceString(finding.Evidence, "line_snippet")
+	}
+	return context
+}
+
+func evidenceString(evidence map[string]any, key string) string {
+	if evidence == nil {
+		return ""
+	}
+	value, ok := evidence[key]
+	if !ok || value == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
+}
+
+func evidenceInt(evidence map[string]any, key string) int {
+	if evidence == nil {
+		return 0
+	}
+	switch value := evidence[key].(type) {
+	case int:
+		return value
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	case json.Number:
+		parsed, _ := strconv.Atoi(value.String())
+		return parsed
+	case string:
+		parsed, _ := strconv.Atoi(strings.TrimSpace(value))
+		return parsed
+	default:
+		return 0
+	}
+}
+
+func compactFindingText(value string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
+}

--- a/internal/repoexposure/external_adapter_test.go
+++ b/internal/repoexposure/external_adapter_test.go
@@ -1,0 +1,279 @@
+package repoexposure
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+func TestIngestSARIFNormalizesEvidenceSeverityAndDedupe(t *testing.T) {
+	content := []byte(`{
+  "version": "2.1.0",
+  "runs": [{
+    "tool": {
+      "driver": {
+        "name": "Semgrep",
+        "semanticVersion": "1.99.0",
+        "rules": [{
+          "id": "go.lang.security.audit.crypto.math_random",
+          "name": "Weak random number generator",
+          "shortDescription": {"text": "Weak random number generator"},
+          "help": {"text": "Use crypto/rand for security-sensitive values."},
+          "properties": {"precision": "high", "security-severity": "8.1", "tags": ["security"]}
+        }]
+      }
+    },
+    "results": [
+      {
+        "ruleId": "go.lang.security.audit.crypto.math_random",
+        "level": "warning",
+        "message": {"text": "math/rand is not safe for security-sensitive identifiers."},
+        "locations": [{
+          "physicalLocation": {
+            "artifactLocation": {"uri": "internal/token.go"},
+            "region": {"startLine": 42, "startColumn": 7, "snippet": {"text": "id := rand.Int()"}}
+          }
+        }]
+      },
+      {
+        "ruleId": "go.lang.security.audit.crypto.math_random",
+        "level": "warning",
+        "message": {"text": "math/rand is not safe for security-sensitive identifiers."},
+        "locations": [{
+          "physicalLocation": {
+            "artifactLocation": {"uri": "internal/token.go"},
+            "region": {"startLine": 42, "startColumn": 7, "snippet": {"text": "id := rand.Int()"}}
+          }
+        }]
+      }
+    ]
+  }]
+}`)
+	detectedAt := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	findings, err := IngestSARIF(context.Background(), "owner/repo", "abc123", content, detectedAt)
+	if err != nil {
+		t.Fatalf("ingest SARIF: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected duplicate SARIF results to collapse to one finding, got %d: %+v", len(findings), findings)
+	}
+	finding := findings[0]
+	if finding.Type != domain.FindingRepoMisconfig || finding.Severity != domain.SeverityHigh {
+		t.Fatalf("unexpected finding classification: %+v", finding)
+	}
+	if finding.ConfidenceScore != 0.90 {
+		t.Fatalf("expected high precision confidence, got %.2f", finding.ConfidenceScore)
+	}
+	if finding.LineSnippetRedacted == nil || *finding.LineSnippetRedacted {
+		t.Fatalf("expected non-secret SARIF snippet to remain visible, got %+v", finding.LineSnippetRedacted)
+	}
+	if got := finding.Evidence["adapter_name"]; got != "Semgrep" {
+		t.Fatalf("expected adapter name Semgrep, got %v", got)
+	}
+	if got := finding.Evidence["adapter_version"]; got != "1.99.0" {
+		t.Fatalf("expected adapter version, got %v", got)
+	}
+	if got := finding.Evidence["adapter_rule_id"]; got != "go.lang.security.audit.crypto.math_random" {
+		t.Fatalf("expected rule id in evidence, got %v", got)
+	}
+	if got := finding.Evidence["adapter_location_line"]; got != 42 {
+		t.Fatalf("expected location line in evidence, got %v", got)
+	}
+	if got, _ := finding.Evidence["raw_adapter_result_stored"].(bool); got {
+		t.Fatal("adapter findings must not store raw external result payloads")
+	}
+}
+
+func TestIngestSARIFRedactsSecretLikeEvidence(t *testing.T) {
+	rawSecret := strings.Join([]string{"ghp_", "0123456789abcdef0123456789abcdef0123"}, "")
+	content := []byte(`{
+  "version": "2.1.0",
+  "runs": [{
+    "tool": {
+      "driver": {
+        "name": "Gitleaks",
+        "version": "8.18.0",
+        "rules": [{
+          "id": "gitleaks.generic-api-key",
+          "name": "Generic API secret",
+          "properties": {"tags": ["secrets", "credential"]}
+        }]
+      }
+    },
+    "results": [{
+      "ruleId": "gitleaks.generic-api-key",
+      "level": "error",
+      "message": {"text": "hard-coded token ` + rawSecret + `"},
+      "locations": [{
+        "physicalLocation": {
+          "artifactLocation": {"uri": ".env"},
+          "region": {"startLine": 3, "snippet": {"text": "GITHUB_TOKEN=` + rawSecret + `"}}
+        }
+      }]
+    }]
+  }]
+}`)
+	findings, err := IngestSARIF(context.Background(), "owner/repo", "abc123", content, time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("ingest SARIF: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+	finding := findings[0]
+	if finding.Type != domain.FindingSecretExposure {
+		t.Fatalf("expected secret exposure finding, got %+v", finding)
+	}
+	if strings.Contains(finding.LineSnippet, rawSecret) || strings.Contains(finding.HumanSummary, rawSecret) {
+		t.Fatalf("secret-like adapter evidence leaked raw secret: %+v", finding)
+	}
+	if finding.LineSnippetRedacted == nil || !*finding.LineSnippetRedacted {
+		t.Fatalf("expected redacted snippet flag, got %+v", finding.LineSnippetRedacted)
+	}
+	if _, exists := finding.Evidence["adapter_message"]; exists {
+		t.Fatalf("secret-like adapter message must not be stored verbatim: %+v", finding.Evidence)
+	}
+	if got, _ := finding.Evidence["raw_secret_stored"].(bool); got {
+		t.Fatal("raw_secret_stored must be false")
+	}
+	if got, _ := finding.Evidence["secret_value_masked"].(bool); !got {
+		t.Fatalf("expected secret_value_masked evidence flag, got %+v", finding.Evidence)
+	}
+}
+
+func TestGitHubCodeScanningAlertsNormalizeToRepoFindings(t *testing.T) {
+	alerts := []GitHubCodeScanningAlert{
+		{
+			Number: 7,
+			State:  "open",
+			Rule: GitHubCodeScanningRule{
+				ID:                    "js/sql-injection",
+				Name:                  "SQL query built from user-controlled sources",
+				Severity:              "warning",
+				SecuritySeverityLevel: "high",
+				Tags:                  []string{"security", "external/cwe/cwe-089"},
+			},
+			Tool: GitHubCodeScanningTool{Name: "CodeQL", Version: "2.17.0"},
+			MostRecentInstance: GitHubCodeScanningAlertInstance{
+				State:     "open",
+				CommitSHA: "def456",
+				Message:   GitHubCodeScanningMessage{Text: "Query string includes user input."},
+				Location:  GitHubCodeScanningLocation{Path: "src/db.ts", StartLine: 88, StartColumn: 11},
+			},
+			HTMLURL: "https://github.com/owner/repo/security/code-scanning/7",
+		},
+	}
+	findings, err := NormalizeGitHubCodeScanningAlerts(context.Background(), "owner/repo", "abc123", alerts, time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("normalize alerts: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+	finding := findings[0]
+	if finding.Type != domain.FindingRepoMisconfig || finding.Severity != domain.SeverityHigh {
+		t.Fatalf("unexpected GitHub code scanning finding: %+v", finding)
+	}
+	if finding.SourceURL != alerts[0].HTMLURL {
+		t.Fatalf("expected source URL to be preserved, got %q", finding.SourceURL)
+	}
+	if got := finding.Evidence["adapter_tool_name"]; got != "CodeQL" {
+		t.Fatalf("expected CodeQL tool evidence, got %v", got)
+	}
+	if got := finding.Evidence["adapter_rule_id"]; got != "js/sql-injection" {
+		t.Fatalf("expected rule id evidence, got %v", got)
+	}
+}
+
+func TestMergeExternalFindingsDedupeNativeAndAdapterFlood(t *testing.T) {
+	native := domain.Finding{
+		ID:          "finding:native",
+		Type:        domain.FindingRepoMisconfig,
+		Repository:  "owner/repo",
+		FilePath:    ".github/workflows/ci.yml",
+		LineNumber:  9,
+		Detector:    "workflow_write_all_permissions",
+		LineSnippet: "permissions: write-all",
+		Evidence: map[string]any{
+			"repository":   "owner/repo",
+			"file_path":    ".github/workflows/ci.yml",
+			"line_number":  9,
+			"detector":     "workflow_write_all_permissions",
+			"line_snippet": "permissions: write-all",
+		},
+	}
+	external := domain.Finding{
+		ID:          "finding:adapter",
+		Type:        domain.FindingRepoMisconfig,
+		Repository:  "owner/repo",
+		FilePath:    ".github/workflows/ci.yml",
+		LineNumber:  9,
+		Detector:    "sarif:semgrep:github-actions-write-all",
+		LineSnippet: "permissions: write-all",
+		Evidence: map[string]any{
+			"adapter_name": "Semgrep",
+		},
+	}
+	merged, truncated := MergeExternalFindings([]domain.Finding{native}, []domain.Finding{external}, 10)
+	if truncated {
+		t.Fatal("did not expect merge to truncate")
+	}
+	if len(merged) != 1 {
+		t.Fatalf("expected native/adapter duplicate to collapse, got %+v", merged)
+	}
+}
+
+type staticExternalAdapter struct {
+	findings []domain.Finding
+}
+
+func (s staticExternalAdapter) Name() string { return "static-test" }
+
+func (s staticExternalAdapter) Version() string { return "test" }
+
+func (s staticExternalAdapter) Findings(context.Context, ExternalAdapterInput) ([]domain.Finding, error) {
+	return s.findings, nil
+}
+
+func TestScanRepositoryRunsOptInExternalAdapters(t *testing.T) {
+	repoPath, headCommit := initTestRepoWithHeadMisconfig(t)
+	external := domain.Finding{
+		ID:          "finding:external-only",
+		Type:        domain.FindingRepoMisconfig,
+		Severity:    domain.SeverityLow,
+		Repository:  repoPath,
+		Commit:      headCommit,
+		FilePath:    "README.md",
+		LineNumber:  1,
+		Detector:    "sarif:example:readme-rule",
+		LineSnippet: "README finding",
+		Evidence: map[string]any{
+			"adapter_name": "Example",
+		},
+		CreatedAt: time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC),
+	}
+	scanner := NewScanner(nil,
+		WithHistoryLimit(10),
+		WithMaxFindings(20),
+		WithExternalAdapters(staticExternalAdapter{findings: []domain.Finding{external}}),
+	)
+	result, err := scanner.ScanRepository(context.Background(), repoPath)
+	if err != nil {
+		t.Fatalf("scan repository: %v", err)
+	}
+	found := false
+	for _, finding := range result.Findings {
+		if finding.ID == "finding:external-only" {
+			found = true
+			if got := finding.Evidence["raw_adapter_result_stored"]; got != false {
+				t.Fatalf("expected adapter safety evidence, got %v", got)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected external adapter finding in scan result, got %+v", result.Findings)
+	}
+}

--- a/internal/repoexposure/github_code_scanning_adapter.go
+++ b/internal/repoexposure/github_code_scanning_adapter.go
@@ -1,0 +1,256 @@
+package repoexposure
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+const adapterSourceGitHubCodeScanning = "github_code_scanning"
+
+// GitHubCodeScanningAlert is the subset of GitHub's code-scanning alert API
+// needed to normalize alerts into Identrail repo findings.
+type GitHubCodeScanningAlert struct {
+	Number             int                             `json:"number"`
+	State              string                          `json:"state"`
+	Rule               GitHubCodeScanningRule          `json:"rule"`
+	Tool               GitHubCodeScanningTool          `json:"tool"`
+	MostRecentInstance GitHubCodeScanningAlertInstance `json:"most_recent_instance"`
+	HTMLURL            string                          `json:"html_url"`
+}
+
+type GitHubCodeScanningRule struct {
+	ID                    string   `json:"id"`
+	Name                  string   `json:"name"`
+	Severity              string   `json:"severity"`
+	Description           string   `json:"description"`
+	SecuritySeverityLevel string   `json:"security_severity_level"`
+	Tags                  []string `json:"tags"`
+}
+
+type GitHubCodeScanningTool struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type GitHubCodeScanningAlertInstance struct {
+	Ref         string                     `json:"ref"`
+	AnalysisKey string                     `json:"analysis_key"`
+	Category    string                     `json:"category"`
+	State       string                     `json:"state"`
+	CommitSHA   string                     `json:"commit_sha"`
+	Message     GitHubCodeScanningMessage  `json:"message"`
+	Location    GitHubCodeScanningLocation `json:"location"`
+}
+
+type GitHubCodeScanningMessage struct {
+	Text string `json:"text"`
+}
+
+type GitHubCodeScanningLocation struct {
+	Path        string `json:"path"`
+	StartLine   int    `json:"start_line"`
+	EndLine     int    `json:"end_line"`
+	StartColumn int    `json:"start_column"`
+	EndColumn   int    `json:"end_column"`
+}
+
+// GitHubCodeScanningAlertAdapter imports GitHub code-scanning alerts that were
+// already fetched through the GitHub App connector.
+type GitHubCodeScanningAlertAdapter struct {
+	alerts []GitHubCodeScanningAlert
+}
+
+func NewGitHubCodeScanningAlertAdapter(alerts []GitHubCodeScanningAlert) GitHubCodeScanningAlertAdapter {
+	return GitHubCodeScanningAlertAdapter{alerts: append([]GitHubCodeScanningAlert(nil), alerts...)}
+}
+
+func (a GitHubCodeScanningAlertAdapter) Name() string {
+	return adapterSourceGitHubCodeScanning
+}
+
+func (a GitHubCodeScanningAlertAdapter) Version() string {
+	return externalAdapterVersion
+}
+
+func (a GitHubCodeScanningAlertAdapter) Findings(ctx context.Context, input ExternalAdapterInput) ([]domain.Finding, error) {
+	return NormalizeGitHubCodeScanningAlerts(ctx, input.Repository, input.Commit, a.alerts, input.DetectedAt)
+}
+
+// NormalizeGitHubCodeScanningAlerts converts GitHub code-scanning alerts into
+// the same repo-finding model used by native repository scanning.
+func NormalizeGitHubCodeScanningAlerts(ctx context.Context, repository string, commit string, alerts []GitHubCodeScanningAlert, detectedAt time.Time) ([]domain.Finding, error) {
+	findings := []domain.Finding{}
+	seen := map[string]struct{}{}
+	for _, alert := range alerts {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		finding, ok := githubCodeScanningAlertToFinding(repository, commit, alert, detectedAt)
+		if !ok {
+			continue
+		}
+		for _, key := range repoFindingDedupeKeys(finding) {
+			if _, exists := seen[key]; exists {
+				ok = false
+				break
+			}
+		}
+		if !ok {
+			continue
+		}
+		findings = append(findings, finding)
+		for _, key := range repoFindingDedupeKeys(finding) {
+			seen[key] = struct{}{}
+		}
+	}
+	return findings, nil
+}
+
+func githubCodeScanningAlertToFinding(repository string, commit string, alert GitHubCodeScanningAlert, detectedAt time.Time) (domain.Finding, bool) {
+	path := normalizeAdapterPath(alert.MostRecentInstance.Location.Path)
+	line := alert.MostRecentInstance.Location.StartLine
+	if path == "" || line <= 0 {
+		return domain.Finding{}, false
+	}
+	ruleID := firstNonEmpty(alert.Rule.ID, alert.Rule.Name, strconv.Itoa(alert.Number), "unknown")
+	toolName := firstNonEmpty(alert.Tool.Name, "github-code-scanning")
+	toolVersion := firstNonEmpty(alert.Tool.Version, externalAdapterVersion)
+	alertCommit := firstNonEmpty(alert.MostRecentInstance.CommitSHA, commit)
+	secretLike := isSecretLikeAdapterResult(ruleID, alert.Rule.Name, alert.Rule.Description, alert.MostRecentInstance.Message.Text, alert.Rule.Tags)
+	severity, severitySource := githubCodeScanningSeverity(alert)
+	confidence := githubCodeScanningConfidence(alert.Rule.SecuritySeverityLevel, alert.Rule.Severity)
+	detector := adapterDetectorID(adapterSourceGitHubCodeScanning, toolName, ruleID)
+	message := sanitizeAdapterText(firstNonEmpty(alert.MostRecentInstance.Message.Text, alert.Rule.Description))
+	snippet := message
+	findingType := domain.FindingRepoMisconfig
+	lineRedacted := false
+	title := "GitHub code scanning: " + firstNonEmpty(alert.Rule.Name, ruleID)
+	summary := firstNonEmpty(message, "GitHub code scanning reported an open repository alert.")
+	remediation := "Review the GitHub code-scanning alert and remediate the affected repository path."
+	if secretLike {
+		findingType = domain.FindingSecretExposure
+		lineRedacted = true
+		snippet = redactedExternalSecretEvidence
+		summary = "GitHub code scanning reported a secret-like repository alert; raw secret material was not stored."
+		remediation = "Rotate the affected credential, remove it from repository history where needed, and move it to a secret manager."
+	}
+
+	evidence := map[string]any{
+		"repository":                repository,
+		"commit":                    alertCommit,
+		"file_path":                 path,
+		"line_number":               line,
+		"line_snippet":              snippet,
+		"line_snippet_redacted":     lineRedacted,
+		"detector":                  detector,
+		"adapter_name":              adapterSourceGitHubCodeScanning,
+		"adapter_version":           externalAdapterVersion,
+		"adapter_source_type":       adapterSourceGitHubCodeScanning,
+		"adapter_tool_name":         toolName,
+		"adapter_tool_version":      toolVersion,
+		"adapter_rule_id":           ruleID,
+		"adapter_rule_name":         firstNonEmpty(alert.Rule.Name, alert.Rule.Description),
+		"adapter_alert_number":      alert.Number,
+		"adapter_alert_state":       strings.TrimSpace(alert.State),
+		"adapter_instance_state":    strings.TrimSpace(alert.MostRecentInstance.State),
+		"adapter_confidence":        confidence,
+		"adapter_confidence_source": "github_code_scanning_rule",
+		"adapter_severity_source":   severitySource,
+		"adapter_location_path":     path,
+		"adapter_location_line":     line,
+		"adapter_location_column":   alert.MostRecentInstance.Location.StartColumn,
+		"adapter_dedupe_key":        externalAdapterDedupeKey(repository, findingType, path, line, detector, snippet),
+		"history_source":            externalAdapterHistorySource,
+		"raw_secret_stored":         false,
+		"raw_adapter_result_stored": false,
+	}
+	if !secretLike && message != "" {
+		evidence["adapter_message"] = message
+	}
+	if secretLike {
+		evidence["adapter_message_redacted"] = true
+		evidence["secret_value_masked"] = true
+	}
+	if alert.HTMLURL != "" {
+		evidence["adapter_alert_url"] = alert.HTMLURL
+	}
+
+	id := "finding:" + hashDeterministicID(
+		"repo-adapter",
+		adapterSourceGitHubCodeScanning,
+		repository,
+		strconv.Itoa(alert.Number),
+		path,
+		strconv.Itoa(line),
+		detector,
+		hashSHA256(firstNonEmpty(alert.MostRecentInstance.Message.Text, alert.Rule.Description, ruleID)),
+	)
+	return domain.Finding{
+		ID:                  id,
+		Type:                findingType,
+		Severity:            severity,
+		ConfidenceScore:     confidence,
+		Title:               title,
+		HumanSummary:        summary,
+		Path:                []string{path},
+		Repository:          repository,
+		Commit:              alertCommit,
+		FilePath:            path,
+		LineNumber:          line,
+		Detector:            detector,
+		LineSnippet:         snippet,
+		LineSnippetRedacted: boolPtr(lineRedacted),
+		SourceURL:           strings.TrimSpace(alert.HTMLURL),
+		Evidence:            evidence,
+		Remediation:         remediation,
+		CreatedAt:           detectedAt,
+	}, true
+}
+
+func githubCodeScanningSeverity(alert GitHubCodeScanningAlert) (domain.FindingSeverity, string) {
+	switch strings.ToLower(strings.TrimSpace(alert.Rule.SecuritySeverityLevel)) {
+	case "critical":
+		return domain.SeverityCritical, "security_severity_level"
+	case "high":
+		return domain.SeverityHigh, "security_severity_level"
+	case "medium", "moderate":
+		return domain.SeverityMedium, "security_severity_level"
+	case "low":
+		return domain.SeverityLow, "security_severity_level"
+	}
+	switch strings.ToLower(strings.TrimSpace(alert.Rule.Severity)) {
+	case "critical":
+		return domain.SeverityCritical, "rule_severity"
+	case "error", "high":
+		return domain.SeverityHigh, "rule_severity"
+	case "warning", "medium":
+		return domain.SeverityMedium, "rule_severity"
+	case "note", "recommendation", "low":
+		return domain.SeverityLow, "rule_severity"
+	case "none", "info", "informational":
+		return domain.SeverityInfo, "rule_severity"
+	default:
+		return domain.SeverityMedium, "default"
+	}
+}
+
+func githubCodeScanningConfidence(securitySeverityLevel string, severity string) float64 {
+	if strings.TrimSpace(securitySeverityLevel) != "" {
+		return 0.90
+	}
+	switch strings.ToLower(strings.TrimSpace(severity)) {
+	case "error", "warning":
+		return 0.80
+	case "note", "recommendation":
+		return 0.65
+	default:
+		return 0.70
+	}
+}
+
+var _ ExternalFindingAdapter = SARIFAdapter{}
+var _ ExternalFindingAdapter = GitHubCodeScanningAlertAdapter{}

--- a/internal/repoexposure/sarif_adapter.go
+++ b/internal/repoexposure/sarif_adapter.go
@@ -1,0 +1,470 @@
+package repoexposure
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+const (
+	adapterSourceSARIF             = "sarif"
+	redactedExternalSecretEvidence = "[redacted external secret evidence]"
+	maxAdapterEvidenceTextLength   = 500
+)
+
+var adapterDetectorCleaner = regexp.MustCompile(`[^a-z0-9._:-]+`)
+
+// SARIFAdapter imports SARIF 2.1.0 results into repo findings.
+type SARIFAdapter struct {
+	content []byte
+}
+
+// NewSARIFAdapter returns an opt-in adapter for already-produced SARIF output.
+func NewSARIFAdapter(content []byte) SARIFAdapter {
+	return SARIFAdapter{content: append([]byte(nil), content...)}
+}
+
+func (a SARIFAdapter) Name() string {
+	return adapterSourceSARIF
+}
+
+func (a SARIFAdapter) Version() string {
+	return externalAdapterVersion
+}
+
+func (a SARIFAdapter) Findings(ctx context.Context, input ExternalAdapterInput) ([]domain.Finding, error) {
+	return IngestSARIF(ctx, input.Repository, input.Commit, a.content, input.DetectedAt)
+}
+
+// IngestSARIF converts SARIF results into normalized Identrail repo findings.
+func IngestSARIF(ctx context.Context, repository string, commit string, content []byte, detectedAt time.Time) ([]domain.Finding, error) {
+	var log sarifLog
+	if err := json.Unmarshal(content, &log); err != nil {
+		return nil, fmt.Errorf("decode SARIF: %w", err)
+	}
+	if strings.TrimSpace(log.Version) != "" && strings.TrimSpace(log.Version) != "2.1.0" {
+		return nil, fmt.Errorf("unsupported SARIF version %q", log.Version)
+	}
+	findings := []domain.Finding{}
+	seen := map[string]struct{}{}
+	for _, run := range log.Runs {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		rules := sarifRulesByID(run.Tool.Driver.Rules)
+		toolName := firstNonEmpty(run.Tool.Driver.Name, adapterSourceSARIF)
+		toolVersion := firstNonEmpty(run.Tool.Driver.SemanticVersion, run.Tool.Driver.Version, externalAdapterVersion)
+		for _, result := range run.Results {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			rule := rules[result.RuleID]
+			if rule.ID == "" {
+				rule.ID = result.RuleID
+			}
+			finding, ok := sarifResultToFinding(repository, commit, toolName, toolVersion, rule, result, detectedAt)
+			if !ok {
+				continue
+			}
+			for _, key := range repoFindingDedupeKeys(finding) {
+				if _, exists := seen[key]; exists {
+					ok = false
+					break
+				}
+			}
+			if !ok {
+				continue
+			}
+			findings = append(findings, finding)
+			for _, key := range repoFindingDedupeKeys(finding) {
+				seen[key] = struct{}{}
+			}
+		}
+	}
+	return findings, nil
+}
+
+type sarifLog struct {
+	Version string     `json:"version"`
+	Runs    []sarifRun `json:"runs"`
+}
+
+type sarifRun struct {
+	Tool    sarifTool     `json:"tool"`
+	Results []sarifResult `json:"results"`
+}
+
+type sarifTool struct {
+	Driver sarifDriver `json:"driver"`
+}
+
+type sarifDriver struct {
+	Name            string      `json:"name"`
+	Version         string      `json:"version"`
+	SemanticVersion string      `json:"semanticVersion"`
+	Rules           []sarifRule `json:"rules"`
+}
+
+type sarifRule struct {
+	ID                   string         `json:"id"`
+	Name                 string         `json:"name"`
+	ShortDescription     sarifMessage   `json:"shortDescription"`
+	FullDescription      sarifMessage   `json:"fullDescription"`
+	Help                 sarifMessage   `json:"help"`
+	DefaultConfiguration sarifConfig    `json:"defaultConfiguration"`
+	Properties           map[string]any `json:"properties"`
+}
+
+type sarifConfig struct {
+	Level string `json:"level"`
+}
+
+type sarifResult struct {
+	RuleID     string          `json:"ruleId"`
+	Level      string          `json:"level"`
+	Message    sarifMessage    `json:"message"`
+	Locations  []sarifLocation `json:"locations"`
+	Properties map[string]any  `json:"properties"`
+}
+
+type sarifMessage struct {
+	Text string `json:"text"`
+}
+
+type sarifLocation struct {
+	PhysicalLocation sarifPhysicalLocation `json:"physicalLocation"`
+}
+
+type sarifPhysicalLocation struct {
+	ArtifactLocation sarifArtifactLocation `json:"artifactLocation"`
+	Region           sarifRegion           `json:"region"`
+}
+
+type sarifArtifactLocation struct {
+	URI string `json:"uri"`
+}
+
+type sarifRegion struct {
+	StartLine   int          `json:"startLine"`
+	StartColumn int          `json:"startColumn"`
+	EndLine     int          `json:"endLine"`
+	EndColumn   int          `json:"endColumn"`
+	Snippet     sarifMessage `json:"snippet"`
+}
+
+func sarifRulesByID(rules []sarifRule) map[string]sarifRule {
+	byID := make(map[string]sarifRule, len(rules))
+	for _, rule := range rules {
+		if strings.TrimSpace(rule.ID) != "" {
+			byID[rule.ID] = rule
+		}
+	}
+	return byID
+}
+
+func sarifResultToFinding(repository string, commit string, toolName string, toolVersion string, rule sarifRule, result sarifResult, detectedAt time.Time) (domain.Finding, bool) {
+	if len(result.Locations) == 0 {
+		return domain.Finding{}, false
+	}
+	location := result.Locations[0].PhysicalLocation
+	filePath := normalizeAdapterPath(location.ArtifactLocation.URI)
+	line := location.Region.StartLine
+	if filePath == "" || line <= 0 {
+		return domain.Finding{}, false
+	}
+	ruleID := firstNonEmpty(result.RuleID, rule.ID, "unknown")
+	secretLike := isSecretLikeAdapterResult(ruleID, rule.Name, result.Message.Text, sarifTags(rule.Properties), sarifTags(result.Properties))
+	severity, severitySource := sarifSeverity(result, rule)
+	confidence, confidenceSource := sarifConfidence(result.Properties, rule.Properties)
+	detector := adapterDetectorID(adapterSourceSARIF, toolName, ruleID)
+	message := sanitizeAdapterText(firstNonEmpty(result.Message.Text, rule.ShortDescription.Text, rule.FullDescription.Text))
+	snippet := sanitizeAdapterText(firstNonEmpty(location.Region.Snippet.Text, result.Message.Text, rule.ShortDescription.Text))
+	findingType := domain.FindingRepoMisconfig
+	lineRedacted := false
+	title := firstNonEmpty(rule.Name, rule.ShortDescription.Text, ruleID)
+	summary := firstNonEmpty(message, "External scanner reported a repository finding.")
+	remediation := firstNonEmpty(sanitizeAdapterText(rule.Help.Text), "Review the external scanner guidance and remediate the affected repository path.")
+	if secretLike {
+		findingType = domain.FindingSecretExposure
+		lineRedacted = true
+		snippet = redactedExternalSecretEvidence
+		summary = "External scanner reported a secret-like repository finding; raw secret material was not stored."
+		remediation = "Rotate the affected credential, remove it from repository history where needed, and move it to a secret manager."
+	}
+
+	evidence := map[string]any{
+		"repository":                repository,
+		"commit":                    commit,
+		"file_path":                 filePath,
+		"line_number":               line,
+		"line_snippet":              snippet,
+		"line_snippet_redacted":     lineRedacted,
+		"detector":                  detector,
+		"adapter_name":              toolName,
+		"adapter_version":           toolVersion,
+		"adapter_source_type":       adapterSourceSARIF,
+		"adapter_rule_id":           ruleID,
+		"adapter_rule_name":         firstNonEmpty(rule.Name, rule.ShortDescription.Text),
+		"adapter_result_level":      strings.TrimSpace(result.Level),
+		"adapter_confidence":        confidence,
+		"adapter_confidence_source": confidenceSource,
+		"adapter_severity_source":   severitySource,
+		"adapter_location_path":     filePath,
+		"adapter_location_line":     line,
+		"adapter_location_column":   location.Region.StartColumn,
+		"adapter_dedupe_key":        externalAdapterDedupeKey(repository, findingType, filePath, line, detector, snippet),
+		"history_source":            externalAdapterHistorySource,
+		"raw_secret_stored":         false,
+		"raw_adapter_result_stored": false,
+	}
+	if !secretLike && message != "" {
+		evidence["adapter_message"] = message
+	}
+	if secretLike {
+		evidence["adapter_message_redacted"] = true
+		evidence["secret_value_masked"] = true
+	}
+
+	id := "finding:" + hashDeterministicID(
+		"repo-adapter",
+		adapterSourceSARIF,
+		repository,
+		filePath,
+		strconv.Itoa(line),
+		detector,
+		hashSHA256(firstNonEmpty(result.Message.Text, location.Region.Snippet.Text, ruleID)),
+	)
+	return domain.Finding{
+		ID:                  id,
+		Type:                findingType,
+		Severity:            severity,
+		ConfidenceScore:     confidence,
+		Title:               title,
+		HumanSummary:        summary,
+		Path:                []string{filePath},
+		Repository:          repository,
+		Commit:              commit,
+		FilePath:            filePath,
+		LineNumber:          line,
+		Detector:            detector,
+		LineSnippet:         snippet,
+		LineSnippetRedacted: boolPtr(lineRedacted),
+		Evidence:            evidence,
+		Remediation:         remediation,
+		CreatedAt:           detectedAt,
+	}, true
+}
+
+func sarifSeverity(result sarifResult, rule sarifRule) (domain.FindingSeverity, string) {
+	if score, ok := firstSecurityScore(result.Properties, rule.Properties); ok {
+		switch {
+		case score >= 9:
+			return domain.SeverityCritical, "security-severity"
+		case score >= 7:
+			return domain.SeverityHigh, "security-severity"
+		case score >= 4:
+			return domain.SeverityMedium, "security-severity"
+		case score > 0:
+			return domain.SeverityLow, "security-severity"
+		default:
+			return domain.SeverityInfo, "security-severity"
+		}
+	}
+	level := strings.ToLower(firstNonEmpty(
+		sarifPropertyString(result.Properties, "problem.severity", "severity"),
+		result.Level,
+		rule.DefaultConfiguration.Level,
+	))
+	switch level {
+	case "critical":
+		return domain.SeverityCritical, "level"
+	case "error", "high":
+		return domain.SeverityHigh, "level"
+	case "warning", "medium":
+		return domain.SeverityMedium, "level"
+	case "note", "recommendation", "low":
+		return domain.SeverityLow, "level"
+	case "none", "info", "informational":
+		return domain.SeverityInfo, "level"
+	default:
+		return domain.SeverityMedium, "default"
+	}
+}
+
+func sarifConfidence(resultProperties map[string]any, ruleProperties map[string]any) (float64, string) {
+	precision := strings.ToLower(firstNonEmpty(
+		sarifPropertyString(resultProperties, "precision"),
+		sarifPropertyString(ruleProperties, "precision"),
+	))
+	switch precision {
+	case "very-high", "very_high":
+		return 0.95, "precision"
+	case "high":
+		return 0.90, "precision"
+	case "medium", "moderate":
+		return 0.75, "precision"
+	case "low":
+		return 0.50, "precision"
+	default:
+		return 0.70, "adapter_default"
+	}
+}
+
+func firstSecurityScore(propertySets ...map[string]any) (float64, bool) {
+	for _, properties := range propertySets {
+		for _, key := range []string{"security-severity", "security_severity", "securitySeverity"} {
+			raw, ok := properties[key]
+			if !ok || raw == nil {
+				continue
+			}
+			switch value := raw.(type) {
+			case float64:
+				return value, true
+			case json.Number:
+				score, err := value.Float64()
+				return score, err == nil
+			case string:
+				score, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+				return score, err == nil
+			}
+		}
+	}
+	return 0, false
+}
+
+func sarifPropertyString(properties map[string]any, names ...string) string {
+	for _, name := range names {
+		if value, ok := properties[name]; ok && value != nil {
+			return strings.TrimSpace(fmt.Sprint(value))
+		}
+	}
+	return ""
+}
+
+func sarifTags(properties map[string]any) []string {
+	raw, ok := properties["tags"]
+	if !ok || raw == nil {
+		return nil
+	}
+	switch tags := raw.(type) {
+	case []string:
+		return tags
+	case []any:
+		values := make([]string, 0, len(tags))
+		for _, tag := range tags {
+			if value := strings.TrimSpace(fmt.Sprint(tag)); value != "" {
+				values = append(values, value)
+			}
+		}
+		return values
+	case string:
+		return strings.Split(tags, ",")
+	default:
+		return nil
+	}
+}
+
+func isSecretLikeAdapterResult(values ...any) bool {
+	for _, value := range values {
+		switch typed := value.(type) {
+		case []string:
+			for _, item := range typed {
+				if isSecretLikeAdapterText(item) {
+					return true
+				}
+			}
+		default:
+			if isSecretLikeAdapterText(fmt.Sprint(typed)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isSecretLikeAdapterText(value string) bool {
+	lower := strings.ToLower(value)
+	for _, marker := range []string{
+		"secret", "credential", "password", "passwd", "token", "private key",
+		"private_key", "api-key", "api_key", "apikey", "access key",
+	} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeAdapterPath(value string) string {
+	path := strings.TrimSpace(value)
+	if path == "" {
+		return ""
+	}
+	if parsed, err := url.Parse(path); err == nil && parsed.Scheme == "file" {
+		path = parsed.Path
+	}
+	path = strings.ReplaceAll(path, "\\", "/")
+	for _, prefix := range []string{"/github/workspace/", "/workspace/"} {
+		if idx := strings.Index(path, prefix); idx >= 0 {
+			path = path[idx+len(prefix):]
+			break
+		}
+	}
+	path = strings.TrimPrefix(path, "./")
+	return strings.TrimSpace(path)
+}
+
+func sanitizeAdapterText(value string) string {
+	text := strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
+	if len(text) <= maxAdapterEvidenceTextLength {
+		return text
+	}
+	return text[:maxAdapterEvidenceTextLength] + "..."
+}
+
+func adapterDetectorID(source string, tool string, ruleID string) string {
+	parts := []string{source, tool, ruleID}
+	for i, part := range parts {
+		part = strings.ToLower(strings.TrimSpace(part))
+		part = adapterDetectorCleaner.ReplaceAllString(part, "_")
+		parts[i] = strings.Trim(part, "_")
+	}
+	return firstNonEmpty(strings.Join(nonEmptyStrings(parts...), ":"), source+":unknown")
+}
+
+func externalAdapterDedupeKey(repository string, findingType domain.FindingType, filePath string, line int, detector string, snippet string) string {
+	return strings.Join([]string{
+		string(findingType),
+		strings.ToLower(strings.TrimSpace(repository)),
+		strings.TrimSpace(filePath),
+		strconv.Itoa(line),
+		strings.ToLower(strings.TrimSpace(detector)),
+		hashSHA256(compactFindingText(snippet)),
+	}, "|")
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func nonEmptyStrings(values ...string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}

--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -74,6 +74,7 @@ type Scanner struct {
 	historyLimit    int
 	maxFindings     int
 	cloneCredential HTTPSCloneCredential
+	adapters        []ExternalFindingAdapter
 }
 
 // ScanResult summarizes one repository exposure scan.
@@ -214,6 +215,7 @@ func (s *Scanner) ScanRepository(ctx context.Context, target string) (ScanResult
 	}
 
 	filesScanned := 0
+	headCommit := ""
 	if !truncated {
 		headCommit, headCommitErr := s.resolveHeadCommit(ctx, location)
 		if headCommitErr != nil {
@@ -250,6 +252,30 @@ func (s *Scanner) ScanRepository(ctx context.Context, target string) (ScanResult
 				}
 			}
 			if truncated {
+				break
+			}
+		}
+	}
+	if !truncated && len(s.adapters) > 0 {
+		for _, adapter := range s.adapters {
+			if err := ctx.Err(); err != nil {
+				return ScanResult{}, err
+			}
+			if adapter == nil {
+				continue
+			}
+			adapterFindings, adapterErr := adapter.Findings(ctx, ExternalAdapterInput{
+				Repository: location.Display,
+				Commit:     headCommit,
+				DetectedAt: started,
+			})
+			if adapterErr != nil {
+				return ScanResult{}, fmt.Errorf("run external repo finding adapter %s: %w", adapter.Name(), adapterErr)
+			}
+			var adapterTruncated bool
+			findings, adapterTruncated = appendExternalFindings(findings, adapterFindings, seen, s.maxFindings)
+			if adapterTruncated {
+				truncated = true
 				break
 			}
 		}

--- a/internal/runtime/service_builder.go
+++ b/internal/runtime/service_builder.go
@@ -142,6 +142,7 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 	repositoryClient := githubconnector.RepositoryClient{TokenClient: tokenClient}
 	svc.GitHubRepositoryLister = repositoryClient
 	svc.GitHubRepositoryPostureCollector = repositoryClient
+	svc.GitHubCodeScanningAlertCollector = repositoryClient
 	svc.GitHubInstallationTokenMinter = tokenClient
 	svc.AWSScannerFactory = func(ctx context.Context, connection api.AWSConnectionStatus) (api.ScannerRunner, error) {
 		iamAPI, iamErr := awsprovider.NewSDKIAMAPIFromAssumeRole(ctx, connection.Region, cfg.AWSProfile, connection.RoleARN, connection.ExternalID, "identrail-recurring-scan")


### PR DESCRIPTION
Fixes #1232

## What changed
- Added an opt-in external repository finding adapter interface and scanner merge path with stable dedupe against native findings.
- Added SARIF 2.1.0 ingestion that maps external results into repo findings with adapter name, version, rule, location, severity, confidence, and safe evidence metadata.
- Added GitHub code-scanning alert collection through the GitHub App repository client, plus normalization into repo findings for connector-backed selected repositories when permissions allow.
- Added redaction handling for secret-like adapter output so raw secret messages and snippets are not persisted.
- Documented adapter trust boundaries, disabled-by-default external execution, and adapter evidence behavior.

## Why
Identrail should benefit from mature scanner ecosystems such as SARIF-producing tools and GitHub code scanning without replacing the native scanner or storing unsafe raw external payloads.

## Impact
- Hosted GitHub App repo scans can now enrich native scanner results with open code-scanning alerts when `security_events: read` is available.
- SARIF can be ingested through the new adapter layer by callers that explicitly provide SARIF content.
- No third-party scanner binary execution is introduced; external execution remains disabled unless a future caller deliberately wires a controlled runner.

## Validation
- `go test ./internal/repoexposure`
- `go test ./internal/connectors/github`
- `go test ./internal/api`
- `go test ./...`
- `go vet ./...`

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in external repo scanner adapters to import SARIF 2.1.0 and GitHub code-scanning alerts into repo scans. Enriches native findings with safe redaction, deterministic IDs, and stable dedupe without executing third-party binaries. Addresses #1232.

- New Features
  - Added an external adapter interface that runs during scans and merges findings with max caps and stable dedupe (includes `adapter_dedupe_key`).
  - Implemented SARIF 2.1.0 ingestion with rule/location mapping, severity from `security-severity` or level, confidence from `precision`, deterministic IDs, and evidence via `adapter_*` fields.
  - Fetched open GitHub code-scanning alerts via the GitHub App when `security_events: read` is granted; normalized into repo findings, mapped severity/confidence, preserved the alert URL, and merged without failing scans when permission is missing. Wired into the runtime service.
  - Secret-like outputs are redacted; evidence records `raw_adapter_result_stored: false`, `secret_value_masked: true`, and `line_snippet_redacted: true`. Docs updated on trust boundaries, opt-in execution, evidence fields, and dedupe keys.

- Migration
  - No action required; adapters are opt-in.
  - GitHub App installs with `security_events: read` auto-enrich scans with open alerts.
  - To ingest SARIF, provide SARIF content through the adapter layer; external scanner binaries are not executed.

<sup>Written for commit 4da60b97f8d06f50c0ad54b471f27664435f2638. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1256?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

