### PR TITLE
Bound hosted repository scan clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   severity mapping, secret-like evidence redaction, stable dedupe against
   native findings, and no external scanner execution unless explicitly wired by
   the caller.
+- Bounded hosted repository clone size for GitHub App scans. Remote repository
+  scans now build a shallow bare repository through a batched, ref-budgeted
+  fetch plan, exclude shallow boundary commits from patch-derived findings,
+  and preserve selected tags and custom refs without spending the whole worker
+  timeout on an unbounded clone before analysis can start.
 - Added context-aware GitHub Actions workflow attack analysis to repository
   exposure scans. Workflow findings now distinguish shallow
   `pull_request_target` / `write-all` signals from dangerous combinations such

--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -172,7 +172,12 @@ func (s *Scanner) ScanRepository(ctx context.Context, target string) (ScanResult
 	}
 	defer cleanup()
 
-	commits, err := s.listCommits(ctx, location)
+	shallowExclusionArgs, err := s.shallowBoundaryExclusionArgs(ctx, location)
+	if err != nil {
+		return ScanResult{}, err
+	}
+
+	commits, err := s.listCommits(ctx, location, shallowExclusionArgs)
 	if err != nil {
 		return ScanResult{}, err
 	}
@@ -183,7 +188,9 @@ func (s *Scanner) ScanRepository(ctx context.Context, target string) (ScanResult
 	secretPolicy := s.loadSecretFindingPolicy(ctx, location)
 	secretOptions := []secretFindingOption{withSecretFindingPolicy(secretPolicy)}
 
-	logArgs := []string{"log", "--all", "--max-count", strconv.Itoa(s.historyLimit), "--no-color", "--unified=0", "--format=commit:%H", "-p"}
+	logArgs := []string{"log", "--all"}
+	logArgs = append(logArgs, shallowExclusionArgs...)
+	logArgs = append(logArgs, "--max-count", strconv.Itoa(s.historyLimit), "--no-color", "--unified=0", "--format=commit:%H", "-p")
 	historyReader, waitLog, logErr := s.gitStream(ctx, location, logArgs...)
 	if logErr != nil {
 		return ScanResult{}, fmt.Errorf("scan commit history: %w", logErr)
@@ -308,6 +315,18 @@ type repositoryLocation struct {
 	Display string
 }
 
+type remoteRepositoryRef struct {
+	Name string
+	SHA  string
+}
+
+type remoteRepositoryClonePlan struct {
+	DefaultRef   remoteRepositoryRef
+	DefaultDepth int
+	ExtraRefs    []remoteRepositoryRef
+	ExtraDepth   int
+}
+
 func (s *Scanner) prepareRepository(ctx context.Context, target string) (repositoryLocation, func(), error) {
 	if local, ok := localRepository(target); ok {
 		return local, func() {}, nil
@@ -322,32 +341,117 @@ func (s *Scanner) prepareRepository(ctx context.Context, target string) (reposit
 		return repositoryLocation{}, nil, fmt.Errorf("create temp repository directory: %w", err)
 	}
 	cleanup := func() { _ = os.RemoveAll(workdir) }
-	mirrorPath := filepath.Join(workdir, "repo.git")
-	if runErr := s.cloneMirror(ctx, workdir, cloneURL, mirrorPath); runErr != nil {
+	repoPath := filepath.Join(workdir, "repo.git")
+	if runErr := s.cloneRemoteRepository(ctx, workdir, cloneURL, repoPath); runErr != nil {
 		cleanup()
 		return repositoryLocation{}, nil, fmt.Errorf("clone repository: %w", runErr)
 	}
-	return repositoryLocation{Path: mirrorPath, Bare: true, Display: target}, cleanup, nil
+	return repositoryLocation{Path: repoPath, Bare: true, Display: target}, cleanup, nil
 }
 
-func (s *Scanner) cloneMirror(ctx context.Context, workdir string, cloneURL string, mirrorPath string) error {
-	args := []string{"clone", "--mirror", "--quiet", cloneURL, mirrorPath}
-	credential, useCredential, err := s.credentialForCloneURL(cloneURL)
+func (s *Scanner) cloneRemoteRepository(ctx context.Context, workdir string, cloneURL string, repoPath string) error {
+	runner, cleanup, err := s.cloneCommandRunner(workdir, cloneURL)
 	if err != nil {
 		return err
 	}
+	defer cleanup()
+
+	refsOutput, err := runner(ctx, "git", "ls-remote", "--symref", cloneURL)
+	if err != nil {
+		return fmt.Errorf("list remote refs: %w", err)
+	}
+	refs, defaultRefName := parseRemoteRepositoryRefs(refsOutput)
+	plan, err := buildRemoteRepositoryClonePlan(refs, defaultRefName, s.historyLimit)
+	if err != nil {
+		return err
+	}
+
+	if _, err := runner(ctx, "git", "init", "--bare", "--quiet", repoPath); err != nil {
+		return fmt.Errorf("initialize bounded repository clone: %w", err)
+	}
+	if _, err := runner(ctx, "git", "--git-dir", repoPath, "remote", "add", "origin", cloneURL); err != nil {
+		return fmt.Errorf("configure repository remote: %w", err)
+	}
+	if err := fetchRemoteRepositoryRefs(ctx, runner, repoPath, plan.ExtraRefs, plan.ExtraDepth); err != nil {
+		return err
+	}
+	if err := fetchRemoteRepositoryRefs(ctx, runner, repoPath, []remoteRepositoryRef{plan.DefaultRef}, plan.DefaultDepth); err != nil {
+		return err
+	}
+	if err := pointRemoteRepositoryHead(ctx, runner, repoPath, plan.DefaultRef); err != nil {
+		return err
+	}
+	return nil
+}
+
+func pointRemoteRepositoryHead(ctx context.Context, runner CommandRunner, repoPath string, ref remoteRepositoryRef) error {
+	if strings.HasPrefix(ref.Name, "refs/heads/") {
+		if _, err := runner(ctx, "git", "--git-dir", repoPath, "symbolic-ref", "HEAD", ref.Name); err != nil {
+			return fmt.Errorf("point bounded repository clone HEAD at %s: %w", ref.Name, err)
+		}
+		return nil
+	}
+	commitOutput, err := runner(ctx, "git", "--git-dir", repoPath, "rev-parse", ref.Name+"^{commit}")
+	if err != nil {
+		return fmt.Errorf("resolve bounded repository HEAD commit for %s: %w", ref.Name, err)
+	}
+	commit := strings.TrimSpace(string(commitOutput))
+	if commit == "" {
+		return fmt.Errorf("resolve bounded repository HEAD commit for %s: empty commit", ref.Name)
+	}
+	if _, err := runner(ctx, "git", "--git-dir", repoPath, "update-ref", "--no-deref", "HEAD", commit); err != nil {
+		return fmt.Errorf("point bounded repository clone HEAD at %s: %w", ref.Name, err)
+	}
+	return nil
+}
+
+func fetchRemoteRepositoryRefs(ctx context.Context, runner CommandRunner, repoPath string, refs []remoteRepositoryRef, depth int) error {
+	if len(refs) == 0 {
+		return nil
+	}
+	if depth < 1 {
+		depth = 1
+	}
+	args := []string{
+		"--git-dir", repoPath,
+		"fetch",
+		"--quiet",
+		"--no-tags",
+	}
+	args = appendBoundedFetchDepthArgs(args, depth)
+	args = append(args, "origin")
+	for _, ref := range refs {
+		args = append(args, "+"+ref.Name+":"+ref.Name)
+	}
+	_, err := runner(ctx, "git", args...)
+	if err != nil {
+		return fmt.Errorf("fetch bounded repository refs: %w", err)
+	}
+	return nil
+}
+
+func appendBoundedFetchDepthArgs(args []string, depth int) []string {
+	// ScanRepository excludes shallow boundary commits before running
+	// patch-based secret detection, so bounded fetch roots do not produce
+	// synthetic "added" lines against an empty tree.
+	return append(args, "--depth", strconv.Itoa(depth))
+}
+
+func (s *Scanner) cloneCommandRunner(workdir string, cloneURL string) (CommandRunner, func(), error) {
+	credential, useCredential, err := s.credentialForCloneURL(cloneURL)
+	if err != nil {
+		return nil, nil, err
+	}
 	if !useCredential {
-		_, runErr := s.run(ctx, "git", args...)
-		return runErr
+		return s.run, func() {}, nil
 	}
 	if s.runEnv == nil {
 		s.runEnv = defaultEnvCommandRunner
 	}
 	askpassPath, cleanup, err := writeGitAskPassScript(workdir)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
-	defer cleanup()
 
 	env := []string{
 		"GIT_TERMINAL_PROMPT=0",
@@ -355,14 +459,143 @@ func (s *Scanner) cloneMirror(ctx context.Context, workdir string, cloneURL stri
 		"IDENTRAIL_GIT_USERNAME=" + credential.Username,
 		"IDENTRAIL_GIT_PASSWORD=" + credential.Password,
 	}
-	_, runErr := s.runEnv(ctx, env, "git", args...)
-	if runErr != nil {
-		if errors.Is(runErr, context.Canceled) || errors.Is(runErr, context.DeadlineExceeded) {
-			return runErr
+	return func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		output, runErr := s.runEnv(ctx, env, name, args...)
+		if runErr != nil {
+			if errors.Is(runErr, context.Canceled) || errors.Is(runErr, context.DeadlineExceeded) {
+				return output, runErr
+			}
+			return output, sanitizeError(runErr, credential.Password)
 		}
-		return sanitizeError(runErr, credential.Password)
+		return output, nil
+	}, cleanup, nil
+}
+
+func parseRemoteRepositoryRefs(output []byte) ([]remoteRepositoryRef, string) {
+	defaultRef := ""
+	headSHA := ""
+	refsByName := map[string]remoteRepositoryRef{}
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "ref: ") && strings.HasSuffix(line, "\tHEAD") {
+			defaultRef = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "ref: "), "\tHEAD"))
+			continue
+		}
+		parts := strings.Split(line, "\t")
+		if len(parts) != 2 {
+			continue
+		}
+		sha := strings.TrimSpace(parts[0])
+		name := strings.TrimSpace(parts[1])
+		if name == "HEAD" {
+			headSHA = sha
+			continue
+		}
+		if name == "" || strings.HasSuffix(name, "^{}") {
+			continue
+		}
+		refsByName[name] = remoteRepositoryRef{Name: name, SHA: sha}
 	}
-	return nil
+
+	refs := make([]remoteRepositoryRef, 0, len(refsByName))
+	for _, ref := range refsByName {
+		refs = append(refs, ref)
+	}
+	sort.Slice(refs, func(i, j int) bool {
+		return refs[i].Name < refs[j].Name
+	})
+	if defaultRef == "" && headSHA != "" {
+		for _, ref := range refs {
+			if strings.HasPrefix(ref.Name, "refs/heads/") && ref.SHA == headSHA {
+				defaultRef = ref.Name
+				break
+			}
+		}
+	}
+	if defaultRef == "" {
+		for _, ref := range refs {
+			if strings.HasPrefix(ref.Name, "refs/heads/") {
+				defaultRef = ref.Name
+				break
+			}
+		}
+	}
+	return refs, defaultRef
+}
+
+func buildRemoteRepositoryClonePlan(refs []remoteRepositoryRef, defaultRefName string, historyLimit int) (remoteRepositoryClonePlan, error) {
+	if historyLimit < 1 {
+		historyLimit = defaultHistoryLimit
+	}
+	if len(refs) == 0 {
+		return remoteRepositoryClonePlan{}, fmt.Errorf("remote repository has no advertised refs")
+	}
+
+	defaultRef := refs[0]
+	if defaultRefName != "" {
+		for _, ref := range refs {
+			if ref.Name == defaultRefName {
+				defaultRef = ref
+				break
+			}
+		}
+	}
+
+	extras := make([]remoteRepositoryRef, 0, len(refs)-1)
+	for _, ref := range refs {
+		if ref.Name == defaultRef.Name {
+			continue
+		}
+		extras = append(extras, ref)
+	}
+	sort.SliceStable(extras, func(i, j int) bool {
+		left := remoteRepositoryRefPriority(extras[i].Name)
+		right := remoteRepositoryRefPriority(extras[j].Name)
+		if left == right {
+			return extras[i].Name < extras[j].Name
+		}
+		return left < right
+	})
+
+	const minFetchDepthForPatchScan = 2
+	// Shallow boundary commits are excluded from patch scanning, so each
+	// selected ref needs at least one parent available to keep its tip visible.
+	extraDepth := minFetchDepthForPatchScan
+	fetchDepthBudget := historyLimit
+	if fetchDepthBudget < minFetchDepthForPatchScan {
+		fetchDepthBudget = minFetchDepthForPatchScan
+	}
+	extraBudget := (fetchDepthBudget - minFetchDepthForPatchScan) / extraDepth
+	if extraBudget < 0 {
+		extraBudget = 0
+	}
+	if len(extras) > extraBudget {
+		extras = extras[:extraBudget]
+	}
+	defaultDepth := fetchDepthBudget - (len(extras) * extraDepth)
+	if defaultDepth < minFetchDepthForPatchScan {
+		defaultDepth = minFetchDepthForPatchScan
+	}
+	return remoteRepositoryClonePlan{
+		DefaultRef:   defaultRef,
+		DefaultDepth: defaultDepth,
+		ExtraRefs:    extras,
+		ExtraDepth:   extraDepth,
+	}, nil
+}
+
+func remoteRepositoryRefPriority(ref string) int {
+	switch {
+	case strings.HasPrefix(ref, "refs/tags/"):
+		return 0
+	case !strings.HasPrefix(ref, "refs/heads/"):
+		return 1
+	default:
+		return 2
+	}
 }
 
 func (s *Scanner) credentialForCloneURL(cloneURL string) (HTTPSCloneCredential, bool, error) {
@@ -414,8 +647,41 @@ esac
 	return path, func() { _ = os.Remove(path) }, nil
 }
 
-func (s *Scanner) listCommits(ctx context.Context, repo repositoryLocation) ([]string, error) {
-	args := []string{"rev-list", "--all", "--max-count", strconv.Itoa(s.historyLimit)}
+func (s *Scanner) shallowBoundaryExclusionArgs(ctx context.Context, repo repositoryLocation) ([]string, error) {
+	output, err := s.git(ctx, repo, "rev-parse", "--git-path", "shallow")
+	if err != nil {
+		return nil, fmt.Errorf("resolve shallow boundary path: %w", err)
+	}
+	shallowPath := strings.TrimSpace(string(output))
+	if shallowPath == "" {
+		return nil, nil
+	}
+	if !filepath.IsAbs(shallowPath) {
+		shallowPath = filepath.Join(repo.Path, shallowPath)
+	}
+	data, err := os.ReadFile(shallowPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read shallow boundary commits: %w", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	args := make([]string, 0, len(lines))
+	for _, line := range lines {
+		sha := strings.TrimSpace(line)
+		if sha == "" {
+			continue
+		}
+		args = append(args, "^"+sha)
+	}
+	return args, nil
+}
+
+func (s *Scanner) listCommits(ctx context.Context, repo repositoryLocation, exclusionArgs []string) ([]string, error) {
+	args := []string{"rev-list", "--all"}
+	args = append(args, exclusionArgs...)
+	args = append(args, "--max-count", strconv.Itoa(s.historyLimit))
 	output, err := s.git(ctx, repo, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list commits: %w", err)

--- a/internal/repoexposure/scanner_test.go
+++ b/internal/repoexposure/scanner_test.go
@@ -3,6 +3,7 @@ package repoexposure
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"os/exec"
@@ -82,6 +83,73 @@ func TestScanRepositoryDetectsSecretInCommitHistory(t *testing.T) {
 	}
 	if got := evidence["detector_provider"]; got != "AWS" {
 		t.Fatalf("expected detector provider in finding evidence, got %v", got)
+	}
+}
+
+func TestScanRepositorySkipsShallowBoundaryPatchFindings(t *testing.T) {
+	source := t.TempDir()
+	runGit(t, source, "init", "-q")
+	if err := os.WriteFile(filepath.Join(source, "credentials.txt"), []byte(`aws_secret_access_key = "`+testSecretValue+`"`+"\n"), 0o600); err != nil {
+		t.Fatalf("write credential fixture: %v", err)
+	}
+	runGit(t, source, "add", "credentials.txt")
+	runGit(t, source, "commit", "-q", "-m", "add old credential")
+	if err := os.WriteFile(filepath.Join(source, "README.md"), []byte("current change\n"), 0o600); err != nil {
+		t.Fatalf("write readme fixture: %v", err)
+	}
+	runGit(t, source, "add", "README.md")
+	runGit(t, source, "commit", "-q", "-m", "current change")
+
+	shallow := filepath.Join(t.TempDir(), "repo")
+	runGitCommand(t, "git", "clone", "--quiet", "--depth", "1", "file://"+source, shallow)
+
+	scanner := NewScanner(nil, WithHistoryLimit(10), WithMaxFindings(20))
+	result, err := scanner.ScanRepository(context.Background(), shallow)
+	if err != nil {
+		t.Fatalf("scan shallow repository failed: %v", err)
+	}
+	for _, finding := range result.Findings {
+		if finding.Type == domain.FindingSecretExposure {
+			t.Fatalf("expected shallow boundary commit to be skipped, got %+v", finding)
+		}
+	}
+	if result.CommitsScanned != 0 {
+		t.Fatalf("expected only shallow boundary commits to be excluded from history scan, got %d", result.CommitsScanned)
+	}
+}
+
+func TestScanRepositoryKeepsNonBoundaryShallowPatchFindings(t *testing.T) {
+	source := t.TempDir()
+	runGit(t, source, "init", "-q")
+	if err := os.WriteFile(filepath.Join(source, "README.md"), []byte("safe root\n"), 0o600); err != nil {
+		t.Fatalf("write readme fixture: %v", err)
+	}
+	runGit(t, source, "add", "README.md")
+	runGit(t, source, "commit", "-q", "-m", "safe root")
+	if err := os.WriteFile(filepath.Join(source, "credentials.txt"), []byte(`aws_secret_access_key = "`+testSecretValue+`"`+"\n"), 0o600); err != nil {
+		t.Fatalf("write credential fixture: %v", err)
+	}
+	runGit(t, source, "add", "credentials.txt")
+	runGit(t, source, "commit", "-q", "-m", "add current credential")
+	secretCommit := strings.TrimSpace(runGit(t, source, "rev-parse", "HEAD"))
+
+	shallow := filepath.Join(t.TempDir(), "repo")
+	runGitCommand(t, "git", "clone", "--quiet", "--depth", "2", "file://"+source, shallow)
+
+	scanner := NewScanner(nil, WithHistoryLimit(10), WithMaxFindings(20))
+	result, err := scanner.ScanRepository(context.Background(), shallow)
+	if err != nil {
+		t.Fatalf("scan shallow repository failed: %v", err)
+	}
+	found := false
+	for _, finding := range result.Findings {
+		if finding.Type == domain.FindingSecretExposure && finding.Commit == secretCommit {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected non-boundary shallow commit finding, got %+v", result.Findings)
 	}
 }
 
@@ -668,10 +736,210 @@ func TestPrepareRepositoryRejectsInsecureHTTPRepositoryURL(t *testing.T) {
 	}
 }
 
-func TestCloneMirrorUsesAskPassCredentialWithoutCommandArgLeak(t *testing.T) {
+func TestCloneRemoteRepositoryUsesBoundedFetchPlan(t *testing.T) {
+	var gotCommands [][]string
+	scanner := NewScanner(
+		func(_ context.Context, name string, args ...string) ([]byte, error) {
+			command := append([]string{name}, args...)
+			gotCommands = append(gotCommands, command)
+			if reflect.DeepEqual(command, []string{"git", "ls-remote", "--symref", "https://github.com/owner/repo.git"}) {
+				return []byte(strings.Join([]string{
+					"ref: refs/heads/main\tHEAD",
+					"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\tHEAD",
+					"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\trefs/heads/main",
+					"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\trefs/tags/release-keep",
+					"cccccccccccccccccccccccccccccccccccccccc\trefs/identrail/archive",
+				}, "\n")), nil
+			}
+			return []byte("ok"), nil
+		},
+		WithHistoryLimit(37),
+	)
+	repoPath := filepath.Join(t.TempDir(), "repo.git")
+
+	err := scanner.cloneRemoteRepository(context.Background(), t.TempDir(), "https://github.com/owner/repo.git", repoPath)
+	if err != nil {
+		t.Fatalf("clone remote repository: %v", err)
+	}
+
+	expected := [][]string{
+		{"git", "ls-remote", "--symref", "https://github.com/owner/repo.git"},
+		{"git", "init", "--bare", "--quiet", repoPath},
+		{"git", "--git-dir", repoPath, "remote", "add", "origin", "https://github.com/owner/repo.git"},
+		{"git", "--git-dir", repoPath, "fetch", "--quiet", "--no-tags", "--depth", "2", "origin", "+refs/tags/release-keep:refs/tags/release-keep", "+refs/identrail/archive:refs/identrail/archive"},
+		{"git", "--git-dir", repoPath, "fetch", "--quiet", "--no-tags", "--depth", "33", "origin", "+refs/heads/main:refs/heads/main"},
+		{"git", "--git-dir", repoPath, "symbolic-ref", "HEAD", "refs/heads/main"},
+	}
+	if !reflect.DeepEqual(gotCommands, expected) {
+		t.Fatalf("unexpected clone commands\ngot:  %+v\nwant: %+v", gotCommands, expected)
+	}
+	for _, command := range gotCommands {
+		if hasArg(command, "clone") || hasArg(command, "--no-single-branch") {
+			t.Fatalf("expected bounded fetch plan instead of broad clone command: %+v", gotCommands)
+		}
+	}
+}
+
+func TestCloneRemoteRepositoryPreservesNonBranchRefs(t *testing.T) {
+	source := t.TempDir()
+	runGit(t, source, "init", "-q")
+
+	if err := os.WriteFile(filepath.Join(source, "root.txt"), []byte("root\n"), 0o600); err != nil {
+		t.Fatalf("write root fixture: %v", err)
+	}
+	runGit(t, source, "add", "root.txt")
+	runGit(t, source, "commit", "-q", "-m", "root")
+	rootCommit := strings.TrimSpace(runGit(t, source, "rev-parse", "HEAD"))
+
+	if err := os.WriteFile(filepath.Join(source, "head.txt"), []byte("head\n"), 0o600); err != nil {
+		t.Fatalf("write head fixture: %v", err)
+	}
+	runGit(t, source, "add", "head.txt")
+	runGit(t, source, "commit", "-q", "-m", "head")
+	headCommit := strings.TrimSpace(runGit(t, source, "rev-parse", "HEAD"))
+
+	runGit(t, source, "tag", "-a", "release-keep", "-m", "release keep", headCommit)
+	runGit(t, source, "update-ref", "refs/identrail/archive", rootCommit)
+
+	remotePath := filepath.Join(t.TempDir(), "remote.git")
+	runGitCommand(t, "git", "clone", "--quiet", "--mirror", source, remotePath)
+
+	clonedPath := filepath.Join(t.TempDir(), "repo.git")
+	scanner := NewScanner(nil, WithHistoryLimit(6))
+	err := scanner.cloneRemoteRepository(context.Background(), t.TempDir(), "file://"+remotePath, clonedPath)
+	if err != nil {
+		t.Fatalf("clone remote repository: %v", err)
+	}
+
+	refsOutput := runGitCommand(t, "git", "--git-dir", clonedPath, "for-each-ref", "--format=%(refname)")
+	if !strings.Contains(refsOutput, "refs/tags/release-keep") {
+		t.Fatalf("expected bounded remote clone to preserve tags, got refs:\n%s", refsOutput)
+	}
+	if !strings.Contains(refsOutput, "refs/identrail/archive") {
+		t.Fatalf("expected bounded remote clone to preserve custom refs, got refs:\n%s", refsOutput)
+	}
+}
+
+func TestCloneRemoteRepositoryExtraRefsDoNotTruncateDefaultHistory(t *testing.T) {
+	source := t.TempDir()
+	runGit(t, source, "init", "-q", "-b", "main")
+
+	for i := 1; i <= 10; i++ {
+		if err := os.WriteFile(filepath.Join(source, "history.txt"), []byte(fmt.Sprintf("%d\n", i)), 0o600); err != nil {
+			t.Fatalf("write history fixture: %v", err)
+		}
+		runGit(t, source, "add", "history.txt")
+		runGit(t, source, "commit", "-q", "-m", fmt.Sprintf("main %d", i))
+	}
+	runGit(t, source, "branch", "feature", "HEAD~4")
+
+	remotePath := filepath.Join(t.TempDir(), "remote.git")
+	runGitCommand(t, "git", "clone", "--quiet", "--mirror", source, remotePath)
+
+	clonedPath := filepath.Join(t.TempDir(), "repo.git")
+	scanner := NewScanner(nil, WithHistoryLimit(10))
+	err := scanner.cloneRemoteRepository(context.Background(), t.TempDir(), "file://"+remotePath, clonedPath)
+	if err != nil {
+		t.Fatalf("clone remote repository: %v", err)
+	}
+
+	mainCount := strings.TrimSpace(runGitCommand(t, "git", "--git-dir", clonedPath, "rev-list", "refs/heads/main", "--count"))
+	if mainCount != "8" {
+		t.Fatalf("expected default history to keep reserved depth after extra fetch, got %s commits", mainCount)
+	}
+	featureCount := strings.TrimSpace(runGitCommand(t, "git", "--git-dir", clonedPath, "rev-list", "refs/heads/feature", "--count"))
+	if featureCount == "0" {
+		t.Fatalf("expected extra ref to remain fetchable")
+	}
+}
+
+func TestCloneRemoteRepositoryHandlesAnnotatedTagDefaultRef(t *testing.T) {
+	source := t.TempDir()
+	runGit(t, source, "init", "-q")
+
+	if err := os.WriteFile(filepath.Join(source, "root.txt"), []byte("root\n"), 0o600); err != nil {
+		t.Fatalf("write root fixture: %v", err)
+	}
+	runGit(t, source, "add", "root.txt")
+	runGit(t, source, "commit", "-q", "-m", "root")
+	commit := strings.TrimSpace(runGit(t, source, "rev-parse", "HEAD"))
+	runGit(t, source, "tag", "-a", "release-default", "-m", "release default", commit)
+
+	remotePath := filepath.Join(t.TempDir(), "remote.git")
+	runGitCommand(t, "git", "clone", "--quiet", "--mirror", source, remotePath)
+	runGitCommand(t, "git", "--git-dir", remotePath, "symbolic-ref", "HEAD", "refs/tags/release-default")
+
+	clonedPath := filepath.Join(t.TempDir(), "repo.git")
+	scanner := NewScanner(nil, WithHistoryLimit(2))
+	err := scanner.cloneRemoteRepository(context.Background(), t.TempDir(), "file://"+remotePath, clonedPath)
+	if err != nil {
+		t.Fatalf("clone remote repository: %v", err)
+	}
+
+	gotCommit := strings.TrimSpace(runGitCommand(t, "git", "--git-dir", clonedPath, "rev-parse", "HEAD^{commit}"))
+	if gotCommit != commit {
+		t.Fatalf("expected HEAD to peel annotated tag to %s, got %s", commit, gotCommit)
+	}
+	gotContent := runGitCommand(t, "git", "--git-dir", clonedPath, "show", "HEAD:root.txt")
+	if gotContent != "root\n" {
+		t.Fatalf("expected HEAD to expose tagged tree, got %q", gotContent)
+	}
+}
+
+func TestBuildRemoteRepositoryClonePlanCapsExtraRefs(t *testing.T) {
+	refs := []remoteRepositoryRef{
+		{Name: "refs/heads/main", SHA: strings.Repeat("a", 40)},
+		{Name: "refs/heads/feature-a", SHA: strings.Repeat("b", 40)},
+		{Name: "refs/heads/feature-b", SHA: strings.Repeat("c", 40)},
+		{Name: "refs/tags/release-keep", SHA: strings.Repeat("d", 40)},
+		{Name: "refs/identrail/archive", SHA: strings.Repeat("e", 40)},
+	}
+
+	plan, err := buildRemoteRepositoryClonePlan(refs, "refs/heads/main", 6)
+	if err != nil {
+		t.Fatalf("build clone plan: %v", err)
+	}
+	if plan.DefaultRef.Name != "refs/heads/main" || plan.DefaultDepth != 2 {
+		t.Fatalf("expected default ref to keep non-boundary depth, got %+v", plan)
+	}
+	if plan.ExtraDepth != 2 {
+		t.Fatalf("expected extra refs to keep non-boundary depth, got %+v", plan)
+	}
+	gotExtras := make([]string, 0, len(plan.ExtraRefs))
+	for _, ref := range plan.ExtraRefs {
+		gotExtras = append(gotExtras, ref.Name)
+	}
+	expectedExtras := []string{"refs/tags/release-keep", "refs/identrail/archive"}
+	if !reflect.DeepEqual(gotExtras, expectedExtras) {
+		t.Fatalf("expected non-branch refs to be prioritized within ref budget, got %+v", gotExtras)
+	}
+}
+
+func TestBuildRemoteRepositoryClonePlanKeepsDefaultTipScannable(t *testing.T) {
+	refs := []remoteRepositoryRef{
+		{Name: "refs/heads/main", SHA: strings.Repeat("a", 40)},
+		{Name: "refs/heads/feature-a", SHA: strings.Repeat("b", 40)},
+		{Name: "refs/heads/feature-b", SHA: strings.Repeat("c", 40)},
+		{Name: "refs/tags/release-keep", SHA: strings.Repeat("d", 40)},
+		{Name: "refs/identrail/archive", SHA: strings.Repeat("e", 40)},
+	}
+
+	plan, err := buildRemoteRepositoryClonePlan(refs, "refs/heads/main", 3)
+	if err != nil {
+		t.Fatalf("build clone plan: %v", err)
+	}
+	if plan.DefaultDepth < 2 {
+		t.Fatalf("expected default ref to remain visible after shallow-boundary exclusion, got %+v", plan)
+	}
+	if len(plan.ExtraRefs) != 0 {
+		t.Fatalf("expected low history budget to reserve depth for the default ref, got %+v", plan)
+	}
+}
+
+func TestCloneRemoteRepositoryUsesAskPassCredentialWithoutCommandArgLeak(t *testing.T) {
 	const secret = "ghs_secret_token"
 	var gotEnv []string
-	var gotArgs []string
+	var gotCommands [][]string
 	scanner := NewScanner(
 		func(context.Context, string, ...string) ([]byte, error) {
 			t.Fatal("expected authenticated clone to use env command runner")
@@ -684,7 +952,8 @@ func TestCloneMirrorUsesAskPassCredentialWithoutCommandArgLeak(t *testing.T) {
 		}),
 		WithEnvCommandRunner(func(_ context.Context, env []string, name string, args ...string) ([]byte, error) {
 			gotEnv = append([]string(nil), env...)
-			gotArgs = append([]string{name}, args...)
+			command := append([]string{name}, args...)
+			gotCommands = append(gotCommands, command)
 			askPass := envValue(env, "GIT_ASKPASS")
 			if askPass == "" {
 				t.Fatal("expected GIT_ASKPASS to be configured")
@@ -692,16 +961,25 @@ func TestCloneMirrorUsesAskPassCredentialWithoutCommandArgLeak(t *testing.T) {
 			if _, err := os.Stat(askPass); err != nil {
 				t.Fatalf("expected askpass helper to exist during clone: %v", err)
 			}
+			if reflect.DeepEqual(command, []string{"git", "ls-remote", "--symref", "https://github.com/owner/repo.git"}) {
+				return []byte(strings.Join([]string{
+					"ref: refs/heads/main\tHEAD",
+					"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\tHEAD",
+					"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\trefs/heads/main",
+				}, "\n")), nil
+			}
 			return []byte("ok"), nil
 		}),
 	)
 
-	err := scanner.cloneMirror(context.Background(), t.TempDir(), "https://github.com/owner/repo.git", filepath.Join(t.TempDir(), "repo.git"))
+	err := scanner.cloneRemoteRepository(context.Background(), t.TempDir(), "https://github.com/owner/repo.git", filepath.Join(t.TempDir(), "repo.git"))
 	if err != nil {
-		t.Fatalf("clone mirror: %v", err)
+		t.Fatalf("clone remote repository: %v", err)
 	}
-	if strings.Contains(strings.Join(gotArgs, " "), secret) {
-		t.Fatalf("clone command arguments leaked token: %+v", gotArgs)
+	for _, command := range gotCommands {
+		if strings.Contains(strings.Join(command, " "), secret) {
+			t.Fatalf("clone command arguments leaked token: %+v", gotCommands)
+		}
 	}
 	if envValue(gotEnv, "IDENTRAIL_GIT_USERNAME") != "x-access-token" || envValue(gotEnv, "IDENTRAIL_GIT_PASSWORD") != secret {
 		t.Fatalf("expected clone credential in environment, got %+v", gotEnv)
@@ -711,7 +989,7 @@ func TestCloneMirrorUsesAskPassCredentialWithoutCommandArgLeak(t *testing.T) {
 	}
 }
 
-func TestCloneMirrorRedactsCredentialFromErrors(t *testing.T) {
+func TestCloneRemoteRepositoryRedactsCredentialFromErrors(t *testing.T) {
 	const secret = "ghs_secret_token"
 	scanner := NewScanner(nil,
 		WithHTTPSCloneCredential(HTTPSCloneCredential{
@@ -724,7 +1002,7 @@ func TestCloneMirrorRedactsCredentialFromErrors(t *testing.T) {
 		}),
 	)
 
-	err := scanner.cloneMirror(context.Background(), t.TempDir(), "https://github.com/owner/repo.git", filepath.Join(t.TempDir(), "repo.git"))
+	err := scanner.cloneRemoteRepository(context.Background(), t.TempDir(), "https://github.com/owner/repo.git", filepath.Join(t.TempDir(), "repo.git"))
 	if err == nil {
 		t.Fatal("expected clone error")
 	}
@@ -733,7 +1011,7 @@ func TestCloneMirrorRedactsCredentialFromErrors(t *testing.T) {
 	}
 }
 
-func TestCloneMirrorRejectsCredentialHostMismatch(t *testing.T) {
+func TestCloneRemoteRepositoryRejectsCredentialHostMismatch(t *testing.T) {
 	called := false
 	scanner := NewScanner(nil,
 		WithHTTPSCloneCredential(HTTPSCloneCredential{
@@ -747,7 +1025,7 @@ func TestCloneMirrorRejectsCredentialHostMismatch(t *testing.T) {
 		}),
 	)
 
-	err := scanner.cloneMirror(context.Background(), t.TempDir(), "https://gitlab.com/owner/repo.git", filepath.Join(t.TempDir(), "repo.git"))
+	err := scanner.cloneRemoteRepository(context.Background(), t.TempDir(), "https://gitlab.com/owner/repo.git", filepath.Join(t.TempDir(), "repo.git"))
 	if err == nil {
 		t.Fatal("expected credential host mismatch to fail")
 	}
@@ -843,6 +1121,15 @@ func TestGitInvocationModes(t *testing.T) {
 	if !reflect.DeepEqual(got[1], expectedSecond) {
 		t.Fatalf("unexpected bare invocation %+v", got[1])
 	}
+}
+
+func hasArg(args []string, want string) bool {
+	for _, arg := range args {
+		if arg == want {
+			return true
+		}
+	}
+	return false
 }
 
 func envValue(env []string, key string) string {


### PR DESCRIPTION
Fixes #1257

## What changed
- Replaced the unbounded remote `git clone --mirror` path with an explicit bounded fetch plan.
- Remote scans now list advertised refs first, fetch the default branch with the remaining history budget, and fetch only a capped set of non-default refs at shallow depth.
- Selected tags and custom refs are prioritized inside the scan budget so non-branch evidence remains visible to `git log --all` / `rev-list --all` where budget allows.
- Preserved GitHub App HTTPS clone credential handling through `GIT_ASKPASS`, including command-argument secrecy and error redaction across the multi-step fetch flow.
- Added regression coverage proving remote hosted scans avoid broad clone commands, cap extra refs, preserve selected non-branch refs, and keep clone credentials out of arguments.
- Updated the changelog for the hosted scan reliability fix.

## Why it changed
Hosted scans were reaching the worker timeout before analysis started because the history limit was only applied after an unbounded mirror clone. The UI failure `repository scan exceeded worker timeout before reporting a terminal result` matches that path: the worker can claim the repo scan, but remote preparation can consume the whole job window before the scanner reports a normal terminal result.

## Review follow-up
The first version bounded the clone by switching from `--mirror` to `--bare`, which could drop tags/custom refs. The second version restored mirror semantics with `--depth --no-single-branch`, but review correctly pointed out that Git applies depth per branch tip, so a repository with many branches could still fetch far beyond the intended budget.

This update removes the broad clone command entirely. The scanner now uses `ls-remote` plus explicit shallow fetches so the default branch and selected non-default refs share a deterministic scan budget before analysis starts.

## Impact and risk
This makes remote preparation bounded before analysis while preserving existing local scans, finding generation, queue processing, credential redaction, and terminal-state recovery. Very large repositories with more refs than the scan budget will not fetch every ref; tags and custom refs are prioritized, then remaining branch refs are selected deterministically. That is the intended tradeoff for hosted reliability: complete unbounded mirrors are no longer attempted inside the worker job window.

## Validation performed
- `go test ./internal/repoexposure`
- `go test ./internal/repoexposure ./internal/api ./internal/worker`
- `go test ./...`
- `go vet ./...`
- `git diff --check origin/dev...HEAD`
- `git diff --check`

## AI-assisted disclosure
- AI-assisted: yes
- Tools used: OpenAI assistant
- Where used: investigation, implementation, tests, and PR preparation
- Human verification performed: reviewed the diff, confirmed DCO sign-off, and ran the validation commands listed above
