### PR TITLE
Add GitHub repo risk graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 ## Unreleased
+- Added a GitHub repository risk graph domain model for repository findings.
+  Repo findings can now be deterministically associated with repository,
+  workflow, job, environment, secret/token, OIDC subject, cloud role,
+  Kubernetes service-account, GitHub App, and deploy-key nodes when evidence
+  exists. The graph deduplicates edges, represents missing blast-radius evidence
+  as `unknown` instead of guessing, and attaches inspectable risk-score factors
+  for severity, confidence, exploitability, privilege, exposure, environment
+  criticality, and freshness.
 - Added opt-in external repository finding adapters. SARIF 2.1.0 output and
   GitHub code-scanning alerts can now be normalized into Identrail repo
   findings with adapter name/version/rule/location/confidence evidence,

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -6013,6 +6013,7 @@ components:
       type: object
       properties:
         finding_id: { type: string }
+        finding_node_id: { type: string }
         score:
           type: integer
           minimum: 0

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -119,6 +119,10 @@ x-identrail-route-authorizations:
     path: /v1/repo-finding-clusters
     action: repo_scans.read
     resource_type: repo_finding_cluster
+  - method: GET
+    path: /v1/repo-risk-graph
+    action: repo_scans.read
+    resource_type: repo_risk_graph
   - method: POST
     path: /v1/repo-scans
     action: repo_scans.run
@@ -3901,6 +3905,47 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /v1/repo-risk-graph:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+    get:
+      tags: [RepositoryExposure]
+      summary: Build a repository machine-identity risk graph
+      operationId: getRepoRiskGraph
+      parameters:
+        - in: query
+          name: repo_scan_id
+          schema: { type: string }
+        - in: query
+          name: repository
+          schema: { type: string }
+        - in: query
+          name: default_branch
+          schema: { type: string }
+        - in: query
+          name: severity
+          schema:
+            $ref: "#/components/schemas/FindingSeverity"
+        - in: query
+          name: type
+          schema:
+            $ref: "#/components/schemas/FindingType"
+      responses:
+        "200":
+          description: Repository risk graph
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RepoRiskGraph"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 components:
   securitySchemes:
     ApiKeyAuth:
@@ -5915,6 +5960,130 @@ components:
             $ref: "#/components/schemas/RepoFindingCluster"
         next_cursor:
           type: string
+    RepoRiskGraph:
+      type: object
+      properties:
+        repository:
+          type: string
+        nodes:
+          type: array
+          items:
+            $ref: "#/components/schemas/RepoRiskGraphNode"
+        edges:
+          type: array
+          items:
+            $ref: "#/components/schemas/RepoRiskGraphEdge"
+        scores:
+          type: array
+          items:
+            $ref: "#/components/schemas/RepoRiskGraphFindingScore"
+        summary:
+          $ref: "#/components/schemas/RepoRiskGraphSummary"
+    RepoRiskGraphNode:
+      type: object
+      properties:
+        id: { type: string }
+        kind:
+          type: string
+          enum: [repository, default_branch, finding, workflow, workflow_job, environment, secret, deploy_key, github_app, token, oidc_subject, cloud_role, kubernetes_service_account, unknown]
+        label: { type: string }
+        repository: { type: string }
+        evidence_state:
+          type: string
+          enum: [known, unknown]
+        evidence:
+          type: object
+          additionalProperties: true
+    RepoRiskGraphEdge:
+      type: object
+      properties:
+        id: { type: string }
+        kind:
+          type: string
+          enum: [repository_contains_workflow, repository_default_branch, finding_in_repository, finding_affects_workflow, workflow_runs_job, job_uses_secret, finding_exposes_token, workflow_can_mint_token, oidc_subject_can_assume_role, repo_deploys_to_environment, finding_references_identity, reachability_unknown]
+        from_node_id: { type: string }
+        to_node_id: { type: string }
+        evidence_state:
+          type: string
+          enum: [known, unknown]
+        evidence:
+          type: object
+          additionalProperties: true
+    RepoRiskGraphFindingScore:
+      type: object
+      properties:
+        finding_id: { type: string }
+        score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        severity:
+          $ref: "#/components/schemas/FindingSeverity"
+        confidence:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 1
+        factors:
+          $ref: "#/components/schemas/RepoRiskGraphScoreFactors"
+        unknowns:
+          type: array
+          items: { type: string }
+    RepoRiskGraphScoreFactors:
+      type: object
+      properties:
+        severity:
+          type: integer
+          minimum: 0
+          maximum: 100
+        confidence:
+          type: integer
+          minimum: 0
+          maximum: 100
+        exploitability:
+          type: integer
+          minimum: 0
+          maximum: 100
+        privilege:
+          type: integer
+          minimum: 0
+          maximum: 100
+        exposure:
+          type: integer
+          minimum: 0
+          maximum: 100
+        environment_criticality:
+          type: integer
+          minimum: 0
+          maximum: 100
+        freshness:
+          type: integer
+          minimum: 0
+          maximum: 100
+    RepoRiskGraphSummary:
+      type: object
+      properties:
+        finding_count:
+          type: integer
+          minimum: 0
+        node_count:
+          type: integer
+          minimum: 0
+        edge_count:
+          type: integer
+          minimum: 0
+        unknown_node_count:
+          type: integer
+          minimum: 0
+        unknown_edge_count:
+          type: integer
+          minimum: 0
+        high_risk_findings:
+          type: integer
+          minimum: 0
+        critical_findings:
+          type: integer
+          minimum: 0
     FindingsSummary:
       type: object
       properties:

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -65,6 +65,7 @@ Read APIs:
 - `GET /v1/repo-scans/:repo_scan_id`
 - `GET /v1/repo-findings?repo_scan_id=&severity=&type=`
 - `GET /v1/repo-finding-clusters?repo_scan_id=&severity=&type=`
+- `GET /v1/repo-risk-graph?repo_scan_id=&repository=&default_branch=&severity=&type=`
 - list endpoints support cursor pagination (`?limit=...&cursor=...`) and return `next_cursor` when more results exist
 - repo finding responses expose stable repository and location fields when available: `repository`, `file_path`, `line_number`, `commit`, `detector`, `line_snippet`, `line_snippet_redacted`, and `source_url`
 - `source_url` is a direct GitHub blob link pinned to the detected commit when Identrail can derive one
@@ -212,6 +213,65 @@ External findings are deduplicated by stable IDs, adapter dedupe keys, detector
 location, and same-line snippet fingerprints. This prevents a native detector
 and an external scanner from flooding the same path/line with repeated copies
 of the same underlying issue.
+
+## GitHub-to-Machine-Identity Risk Graph
+
+Repository findings can be projected into a deterministic risk graph through
+`GET /v1/repo-risk-graph` or `domain.BuildRepoRiskGraph`. The graph is built
+from existing finding fields and evidence metadata; it does not execute extra
+scanners or infer cloud state that was not observed.
+
+Supported node concepts:
+
+- Repository and default branch.
+- Repository finding.
+- GitHub Actions workflow and workflow job.
+- GitHub environment.
+- GitHub secret reference or exposed token/credential fingerprint.
+- GitHub Actions OIDC subject.
+- Cloud role or service-account reference when evidence names one.
+- Kubernetes service account when evidence names one.
+- GitHub App and deploy-key references when evidence names them.
+- Unknown node for missing blast-radius evidence that should not be guessed.
+
+Supported edge concepts:
+
+- Finding belongs to repository.
+- Repository contains workflow.
+- Finding affects workflow.
+- Workflow runs job.
+- Job uses secret.
+- Finding exposes token or credential material.
+- Workflow or job can mint an OIDC token.
+- OIDC subject can assume a named role when evidence identifies the role.
+- Repository deploys to an environment.
+- Finding references an identity such as a role, service account, GitHub App,
+  or deploy key.
+- Reachability is unknown when evidence proves a risky path exists but does not
+  name the downstream identity.
+
+Risk scoring is graph-aware and inspectable. Each finding score includes
+separate factors for severity, confidence, exploitability, privilege, exposure,
+environment criticality, and freshness. For example, a high-severity workflow
+finding with `id-token:write`, a cloud-auth action, a production environment,
+and a named role scores higher than a low-severity repository hygiene issue.
+An OIDC finding without a named cloud role still receives an OIDC privilege
+factor, but the missing role is recorded in `unknowns` and represented by an
+unknown reachability edge.
+
+Evidence limits are intentional:
+
+- Identrail links workflow, secret, OIDC, role, environment, and service-account
+  nodes only when fields or finding evidence provide those names.
+- A broad OIDC finding without `aws_role_arn`, `cloud_role_arn`,
+  `cloud_role`, `azure_client_id`, or `gcp_service_account` evidence gets an
+  unknown downstream identity instead of a guessed provider role.
+- Secret findings create token or secret nodes using fingerprints, detector
+  IDs, or non-secret labels. Raw secret values are not required and should not
+  be stored for graph construction.
+- The graph is a repo-finding evidence model. Full cloud-provider posture
+  collection, cross-account trust expansion, UI visualization, and
+  auto-remediation remain separate layers.
 
 ## Secret Confidence Classification
 

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -660,6 +660,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/repo-scans/:repo_scan_id", Action: policyActionRepoScansRead, ResourceType: "repo_scan", ResourceIDParam: "repo_scan_id"},
 		{Method: http.MethodGet, Path: "/v1/repo-findings", Action: policyActionRepoScansRead, ResourceType: "repo_finding"},
 		{Method: http.MethodGet, Path: "/v1/repo-finding-clusters", Action: policyActionRepoScansRead, ResourceType: "repo_finding_cluster"},
+		{Method: http.MethodGet, Path: "/v1/repo-risk-graph", Action: policyActionRepoScansRead, ResourceType: "repo_risk_graph"},
 		{Method: http.MethodPost, Path: "/v1/repo-scans", Action: policyActionRepoScansRun, ResourceType: "repo_scan"},
 		{Method: http.MethodPost, Path: "/v1/authz/policies/simulate", Action: policyActionAuthzSimulate, ResourceType: "authz_policy"},
 		{Method: http.MethodPost, Path: "/v1/authz/policies/rollback", Action: policyActionAuthzRollback, ResourceType: "authz_policy"},

--- a/internal/api/authz_policy_bundle_runtime_test.go
+++ b/internal/api/authz_policy_bundle_runtime_test.go
@@ -90,6 +90,13 @@ func TestDefaultRoutePolicyBundleUsesRepoScansReadForRepoFindingsTrends(t *testi
 	if policy.Action != policyActionRepoScansRead {
 		t.Fatalf("expected action %q, got %q", policyActionRepoScansRead, policy.Action)
 	}
+	policy, exists = compiled.RouteRegistry.lookup("GET", "/v1/repo-risk-graph")
+	if !exists {
+		t.Fatal("expected built-in authz policy for GET /v1/repo-risk-graph")
+	}
+	if policy.Action != policyActionRepoScansRead {
+		t.Fatalf("expected action %q, got %q", policyActionRepoScansRead, policy.Action)
+	}
 }
 
 func TestCentralPolicyRuntimeResolverFallsBackWhenNoActiveRollout(t *testing.T) {

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -260,6 +260,7 @@ func TestOpenAPIV1SpecDocumentsRepresentativeErrorResponses(t *testing.T) {
 		{path: "/v1/repo-scans/{repo_scan_id}", method: "get", required: []string{`"400":`, `#/components/responses/BadRequest`, `"401":`, `#/components/responses/Unauthorized`, `"404":`, `#/components/responses/NotFound`, `"500":`, `#/components/responses/InternalServerError`, `"503":`, `#/components/responses/ServiceUnavailable`}},
 		{path: "/v1/repo-findings", method: "get", required: []string{`"400":`, `#/components/responses/BadRequest`, `"401":`, `#/components/responses/Unauthorized`, `"404":`, `#/components/responses/NotFound`, `"500":`, `#/components/responses/InternalServerError`}},
 		{path: "/v1/repo-finding-clusters", method: "get", required: []string{`"400":`, `#/components/responses/BadRequest`, `"401":`, `#/components/responses/Unauthorized`, `"404":`, `#/components/responses/NotFound`, `"500":`, `#/components/responses/InternalServerError`}},
+		{path: "/v1/repo-risk-graph", method: "get", required: []string{`"400":`, `#/components/responses/BadRequest`, `"401":`, `#/components/responses/Unauthorized`, `"404":`, `#/components/responses/NotFound`, `"500":`, `#/components/responses/InternalServerError`}},
 		{path: "/v1/workspaces/{workspace_id}/projects", method: "get", required: []string{`"400":`, `#/components/responses/BadRequest`, `"401":`, `#/components/responses/Unauthorized`, `"500":`, `#/components/responses/InternalServerError`, `"503":`, `#/components/responses/ServiceUnavailable`}},
 	}
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -485,6 +485,9 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		v1.GET("/repo-finding-clusters", func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"items": []any{}})
 		})
+		v1.GET("/repo-risk-graph", func(c *gin.Context) {
+			c.JSON(http.StatusOK, domain.RepoRiskGraph{})
+		})
 		v1.POST("/scans", func(c *gin.Context) {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "scan service unavailable"})
 		})
@@ -975,6 +978,34 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			return
 		}
 		c.JSON(http.StatusOK, paginatedItemsResponseWithBaseOffset(items, offset, limit))
+	})
+
+	v1.GET("/repo-risk-graph", func(c *gin.Context) {
+		repoScanID := strings.TrimSpace(c.Query("repo_scan_id"))
+		if repoScanID != "" && !isValidUUID(repoScanID) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid repo_scan_id"})
+			return
+		}
+		graph, err := svc.GetRepoRiskGraph(
+			c.Request.Context(),
+			RepoRiskGraphFilter{
+				RepoScanID:    repoScanID,
+				Repository:    strings.TrimSpace(c.Query("repository")),
+				Severity:      strings.TrimSpace(c.Query("severity")),
+				Type:          strings.TrimSpace(c.Query("type")),
+				DefaultBranch: strings.TrimSpace(c.Query("default_branch")),
+			},
+		)
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "repo scan not found"})
+				return
+			}
+			logger.Error("get repo risk graph", telemetry.ZapError(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build repo risk graph"})
+			return
+		}
+		c.JSON(http.StatusOK, graph)
 	})
 
 	v1.POST("/scans", func(c *gin.Context) {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -690,6 +690,23 @@ func TestRouterRunsScanAndListsData(t *testing.T) {
 		t.Fatalf("expected GitHub source URL in response, got %+v", repoFindingsBody.Items[0].SourceURL)
 	}
 
+	repoRiskGraphReq := httptest.NewRequest(http.MethodGet, "/v1/repo-risk-graph?repo_scan_id="+repoScanID+"&default_branch=main", nil)
+	repoRiskGraphW := httptest.NewRecorder()
+	r.ServeHTTP(repoRiskGraphW, repoRiskGraphReq)
+	if repoRiskGraphW.Code != http.StatusOK {
+		t.Fatalf("expected repo risk graph 200, got %d", repoRiskGraphW.Code)
+	}
+	var repoRiskGraph domain.RepoRiskGraph
+	if err := json.Unmarshal(repoRiskGraphW.Body.Bytes(), &repoRiskGraph); err != nil {
+		t.Fatalf("decode repo risk graph body: %v", err)
+	}
+	if repoRiskGraph.Repository != "owner/repo" || repoRiskGraph.Summary.FindingCount != 1 {
+		t.Fatalf("expected repo risk graph summary for scan, got %+v", repoRiskGraph)
+	}
+	if !repoRiskGraphHasNode(repoRiskGraph, domain.RepoRiskNodeToken) || !repoRiskGraphHasEdge(repoRiskGraph, domain.RepoRiskEdgeFindingExposesToken) {
+		t.Fatalf("expected token blast-radius graph for repo finding, got %+v", repoRiskGraph)
+	}
+
 	repoClustersReq := httptest.NewRequest(http.MethodGet, "/v1/repo-finding-clusters?repo_scan_id="+repoScanID, nil)
 	repoClustersW := httptest.NewRecorder()
 	r.ServeHTTP(repoClustersW, repoClustersReq)
@@ -813,6 +830,13 @@ func TestRouterUnavailableWhenServiceMissing(t *testing.T) {
 	r.ServeHTTP(repoFindingsW, repoFindingsReq)
 	if repoFindingsW.Code != http.StatusOK {
 		t.Fatalf("expected repo findings 200 without service, got %d", repoFindingsW.Code)
+	}
+
+	repoRiskGraphReq := httptest.NewRequest(http.MethodGet, "/v1/repo-risk-graph", nil)
+	repoRiskGraphW := httptest.NewRecorder()
+	r.ServeHTTP(repoRiskGraphW, repoRiskGraphReq)
+	if repoRiskGraphW.Code != http.StatusOK {
+		t.Fatalf("expected repo risk graph 200 without service, got %d", repoRiskGraphW.Code)
 	}
 
 	repoTrendsReq := httptest.NewRequest(http.MethodGet, "/v1/repo-findings/trends", nil)
@@ -4209,6 +4233,24 @@ func TestRateLimitKeySeparatesKubernetesHeartbeatBearerCredentials(t *testing.T)
 	if strings.Contains(first, "agent-token-a") || strings.Contains(second, "agent-token-b") {
 		t.Fatalf("rate limit keys must not expose raw bearer credentials: %q %q", first, second)
 	}
+}
+
+func repoRiskGraphHasNode(graph domain.RepoRiskGraph, kind domain.RepoRiskGraphNodeKind) bool {
+	for _, node := range graph.Nodes {
+		if node.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func repoRiskGraphHasEdge(graph domain.RepoRiskGraph, kind domain.RepoRiskGraphEdgeKind) bool {
+	for _, edge := range graph.Edges {
+		if edge.Kind == kind {
+			return true
+		}
+	}
+	return false
 }
 
 func TestRateLimitKeyKeepsGenericBearerBucketOutsideKubernetesHeartbeat(t *testing.T) {

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -283,6 +283,15 @@ type RepoFindingClusterFilter struct {
 	Offset     int
 }
 
+// RepoRiskGraphFilter narrows the repository findings used to build a risk graph.
+type RepoRiskGraphFilter struct {
+	RepoScanID    string
+	Repository    string
+	Severity      string
+	Type          string
+	DefaultBranch string
+}
+
 // FindingsPage captures one paginated findings response.
 type FindingsPage struct {
 	Items      []domain.Finding
@@ -1693,6 +1702,38 @@ func (s *Service) ListRepoFindingClusters(ctx context.Context, limit int, filter
 		return nil, err
 	}
 	return enrichRepoFindingClusters(items), nil
+}
+
+// GetRepoRiskGraph returns the graph-backed machine-identity blast radius for repository findings.
+func (s *Service) GetRepoRiskGraph(ctx context.Context, filter RepoRiskGraphFilter) (domain.RepoRiskGraph, error) {
+	ctx = s.scopeContext(ctx)
+	repository := strings.TrimSpace(filter.Repository)
+	if repoScanID := strings.TrimSpace(filter.RepoScanID); repoScanID != "" {
+		record, err := s.Store.GetRepoScan(ctx, repoScanID)
+		if err != nil {
+			return domain.RepoRiskGraph{}, err
+		}
+		if repository == "" {
+			repository = strings.TrimSpace(record.Repository)
+		}
+	}
+
+	findings, err := s.Store.ListRepoFindings(ctx, db.RepoFindingFilter{
+		RepoScanID: strings.TrimSpace(filter.RepoScanID),
+		Repository: repository,
+		Severity:   strings.TrimSpace(filter.Severity),
+		Type:       strings.TrimSpace(filter.Type),
+		SortBy:     "created_at",
+		SortDesc:   true,
+	}, 0)
+	if err != nil {
+		return domain.RepoRiskGraph{}, err
+	}
+	return domain.BuildRepoRiskGraph(enrichFindingsWithRepoContext(findings), domain.RepoRiskGraphOptions{
+		Repository:    repository,
+		DefaultBranch: strings.TrimSpace(filter.DefaultBranch),
+		Now:           time.Now().UTC(),
+	}), nil
 }
 
 // GetOrganization returns the current scoped organization record.

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1732,7 +1732,7 @@ func (s *Service) GetRepoRiskGraph(ctx context.Context, filter RepoRiskGraphFilt
 	return domain.BuildRepoRiskGraph(enrichFindingsWithRepoContext(findings), domain.RepoRiskGraphOptions{
 		Repository:    repository,
 		DefaultBranch: strings.TrimSpace(filter.DefaultBranch),
-		Now:           time.Now().UTC(),
+		Now:           s.Now().UTC(),
 	}), nil
 }
 

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -2205,6 +2205,37 @@ func TestServiceRunRepoScanPersistedStoresRecords(t *testing.T) {
 	}
 }
 
+func TestServiceGetRepoRiskGraphUsesServiceClock(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	now := time.Date(2030, 1, 2, 12, 0, 0, 0, time.UTC)
+	svc.Now = func() time.Time { return now }
+
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, now.Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("create repo scan: %v", err)
+	}
+	if err := store.UpsertRepoFindings(defaultScopeContext(), repoScan.ID, []domain.Finding{{
+		ID:        "fresh-finding",
+		Type:      domain.FindingRepoMisconfig,
+		Severity:  domain.SeverityMedium,
+		CreatedAt: now.Add(-2 * time.Hour),
+	}}); err != nil {
+		t.Fatalf("upsert repo findings: %v", err)
+	}
+
+	graph, err := svc.GetRepoRiskGraph(defaultScopeContext(), RepoRiskGraphFilter{RepoScanID: repoScan.ID})
+	if err != nil {
+		t.Fatalf("get repo risk graph: %v", err)
+	}
+	if len(graph.Scores) != 1 {
+		t.Fatalf("expected one graph score, got %+v", graph)
+	}
+	if graph.Scores[0].Factors.Freshness != 100 {
+		t.Fatalf("expected service clock to drive freshness score, got %+v", graph.Scores[0])
+	}
+}
+
 func TestServiceListRepoFindingClusters(t *testing.T) {
 	store := db.NewMemoryStore()
 	svc := NewService(store, fakeScanner{}, "aws")

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -2207,6 +2207,7 @@ func (m *MemoryStore) ListRepoFindings(ctx context.Context, filter RepoFindingFi
 	normalized := NormalizeRepoFindingFilter(filter)
 	repoScanID := normalized.RepoScanID
 	findingID := normalized.FindingID
+	repositoryFilter := normalized.Repository
 	repoScanRepository := ""
 	if repoScanID != "" {
 		record, exists := m.repoScans[repoScanID]
@@ -2236,6 +2237,9 @@ func (m *MemoryStore) ListRepoFindings(ctx context.Context, filter RepoFindingFi
 				finding.Repository = repoScanRepository
 			}
 			domain.NormalizeRepoFindingMetadata(&finding)
+			if !repoFindingMatchesRepository(finding, repositoryFilter) {
+				continue
+			}
 			result = append(result, finding)
 		}
 	} else {
@@ -2257,6 +2261,9 @@ func (m *MemoryStore) ListRepoFindings(ctx context.Context, filter RepoFindingFi
 				finding.Repository = strings.TrimSpace(record.Repository)
 			}
 			domain.NormalizeRepoFindingMetadata(&finding)
+			if !repoFindingMatchesRepository(finding, repositoryFilter) {
+				continue
+			}
 			result = append(result, finding)
 		}
 	}
@@ -2265,6 +2272,14 @@ func (m *MemoryStore) ListRepoFindings(ctx context.Context, filter RepoFindingFi
 		result = result[:limit]
 	}
 	return result, nil
+}
+
+func repoFindingMatchesRepository(finding domain.Finding, repository string) bool {
+	repository = strings.TrimSpace(repository)
+	if repository == "" {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(finding.Repository), repository)
 }
 
 // ListRepoFindingClusters returns repository finding clusters using store-backed pagination semantics.

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -662,6 +662,14 @@ func TestMemoryStoreRepoScanLifecycle(t *testing.T) {
 		t.Fatalf("unexpected high severity findings: %+v", highOnly)
 	}
 
+	repositoryOnly, err := store.ListRepoFindings(defaultScopeContext(), RepoFindingFilter{Repository: " OWNER/REPO "}, 10)
+	if err != nil {
+		t.Fatalf("list repo findings by repository: %v", err)
+	}
+	if len(repositoryOnly) != 2 {
+		t.Fatalf("expected repository filter to match stored scan repository, got %+v", repositoryOnly)
+	}
+
 	repoScans, err := store.ListRepoScans(defaultScopeContext(), 10)
 	if err != nil {
 		t.Fatalf("list repo scans: %v", err)

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -3166,19 +3166,21 @@ func (p *PostgresStore) ListRepoFindings(ctx context.Context, filter RepoFinding
 		   AND ($2 = '' OR rf.finding_id = $2)
 		   AND ($3 = '' OR rf.severity = $3)
 		   AND ($4 = '' OR rf.type = $4)
-		   AND rs.tenant_id = $5
-		   AND rs.workspace_id = $6
+		   AND ($5 = '' OR lower(rs.repository) = lower($5))
+		   AND rs.tenant_id = $6
+		   AND rs.workspace_id = $7
 		 ORDER BY ` + repoFindingOrderClause(normalized.SortBy, normalized.SortDesc)
 	args := []any{
 		repoScanID,
 		normalized.FindingID,
 		normalized.Severity,
 		normalized.Type,
+		normalized.Repository,
 		scope.TenantID,
 		scope.WorkspaceID,
 	}
 	if limit > 0 {
-		query += "\n\t\t LIMIT $7"
+		query += "\n\t\t LIMIT $8"
 		args = append(args, limit)
 	}
 	rows, err := p.queryContext(

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -743,7 +743,7 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		)`)).
 		WithArgs(record.ID, "default", "default").
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
-	mock.ExpectQuery("SELECT rf.repo_scan_id, rf.finding_id, rf.type").WithArgs(record.ID, "", "", "", "default", "default", 100).WillReturnRows(repoFindingsRows)
+	mock.ExpectQuery("SELECT rf.repo_scan_id, rf.finding_id, rf.type").WithArgs(record.ID, "", "", "", "", "default", "default", 100).WillReturnRows(repoFindingsRows)
 	repoFindings, err := store.ListRepoFindings(defaultScopeContext(), RepoFindingFilter{RepoScanID: record.ID}, 100)
 	if err != nil {
 		t.Fatalf("list repo findings failed: %v", err)
@@ -766,7 +766,7 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		)`)).
 		WithArgs(record.ID, "default", "default").
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
-	mock.ExpectQuery("SELECT rf.repo_scan_id, rf.finding_id, rf.type").WithArgs(record.ID, "", "", "", "default", "default").WillReturnRows(unboundedRepoFindingsRows)
+	mock.ExpectQuery("SELECT rf.repo_scan_id, rf.finding_id, rf.type").WithArgs(record.ID, "", "", "", "", "default", "default").WillReturnRows(unboundedRepoFindingsRows)
 	unboundedRepoFindings, err := store.ListRepoFindings(defaultScopeContext(), RepoFindingFilter{RepoScanID: record.ID}, 0)
 	if err != nil {
 		t.Fatalf("list repo findings unbounded failed: %v", err)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1960,6 +1960,7 @@ type RelationshipFilter struct {
 type RepoFindingFilter struct {
 	RepoScanID      string
 	FindingID       string
+	Repository      string
 	Severity        string
 	Type            string
 	LifecycleStatus string
@@ -2068,6 +2069,7 @@ func NormalizeRepoFindingFilter(filter RepoFindingFilter) RepoFindingFilter {
 	normalized := RepoFindingFilter{
 		RepoScanID:      strings.TrimSpace(filter.RepoScanID),
 		FindingID:       strings.TrimSpace(filter.FindingID),
+		Repository:      strings.TrimSpace(filter.Repository),
 		Severity:        strings.ToLower(strings.TrimSpace(filter.Severity)),
 		Type:            strings.ToLower(strings.TrimSpace(filter.Type)),
 		LifecycleStatus: strings.ToLower(strings.TrimSpace(filter.LifecycleStatus)),

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -54,6 +54,7 @@ func TestNormalizeRepoFindingFilter(t *testing.T) {
 	normalized := NormalizeRepoFindingFilter(RepoFindingFilter{
 		RepoScanID:      " repo-scan-1 ",
 		FindingID:       " finding-1 ",
+		Repository:      " owner/repo ",
 		Severity:        " HIGH ",
 		Type:            " SECRET_EXPOSURE ",
 		LifecycleStatus: " ACK ",
@@ -61,7 +62,7 @@ func TestNormalizeRepoFindingFilter(t *testing.T) {
 		SortBy:          "severity",
 		SortDesc:        true,
 	})
-	if normalized.RepoScanID != "repo-scan-1" || normalized.FindingID != "finding-1" {
+	if normalized.RepoScanID != "repo-scan-1" || normalized.FindingID != "finding-1" || normalized.Repository != "owner/repo" {
 		t.Fatalf("expected trimmed identifiers, got %+v", normalized)
 	}
 	if normalized.Severity != "high" || normalized.Type != "secret_exposure" {

--- a/internal/domain/repo_risk_graph.go
+++ b/internal/domain/repo_risk_graph.go
@@ -1,0 +1,996 @@
+package domain
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// RepoRiskGraphNodeKind identifies the machine-identity blast-radius concept
+// represented by one graph node.
+type RepoRiskGraphNodeKind string
+
+const (
+	RepoRiskNodeRepository               RepoRiskGraphNodeKind = "repository"
+	RepoRiskNodeDefaultBranch            RepoRiskGraphNodeKind = "default_branch"
+	RepoRiskNodeFinding                  RepoRiskGraphNodeKind = "finding"
+	RepoRiskNodeWorkflow                 RepoRiskGraphNodeKind = "workflow"
+	RepoRiskNodeWorkflowJob              RepoRiskGraphNodeKind = "workflow_job"
+	RepoRiskNodeEnvironment              RepoRiskGraphNodeKind = "environment"
+	RepoRiskNodeSecret                   RepoRiskGraphNodeKind = "secret"
+	RepoRiskNodeDeployKey                RepoRiskGraphNodeKind = "deploy_key"
+	RepoRiskNodeGitHubApp                RepoRiskGraphNodeKind = "github_app"
+	RepoRiskNodeToken                    RepoRiskGraphNodeKind = "token"
+	RepoRiskNodeOIDCSubject              RepoRiskGraphNodeKind = "oidc_subject"
+	RepoRiskNodeCloudRole                RepoRiskGraphNodeKind = "cloud_role"
+	RepoRiskNodeKubernetesServiceAccount RepoRiskGraphNodeKind = "kubernetes_service_account"
+	RepoRiskNodeUnknown                  RepoRiskGraphNodeKind = "unknown"
+)
+
+// RepoRiskGraphEdgeKind describes directional evidence between graph nodes.
+type RepoRiskGraphEdgeKind string
+
+const (
+	RepoRiskEdgeContainsWorkflow       RepoRiskGraphEdgeKind = "repository_contains_workflow"
+	RepoRiskEdgeDefaultBranch          RepoRiskGraphEdgeKind = "repository_default_branch"
+	RepoRiskEdgeFindingInRepository    RepoRiskGraphEdgeKind = "finding_in_repository"
+	RepoRiskEdgeFindingAffectsWorkflow RepoRiskGraphEdgeKind = "finding_affects_workflow"
+	RepoRiskEdgeWorkflowRunsJob        RepoRiskGraphEdgeKind = "workflow_runs_job"
+	RepoRiskEdgeJobUsesSecret          RepoRiskGraphEdgeKind = "job_uses_secret"
+	RepoRiskEdgeFindingExposesToken    RepoRiskGraphEdgeKind = "finding_exposes_token"
+	RepoRiskEdgeWorkflowCanMintToken   RepoRiskGraphEdgeKind = "workflow_can_mint_token"
+	RepoRiskEdgeOIDCCanAssumeRole      RepoRiskGraphEdgeKind = "oidc_subject_can_assume_role"
+	RepoRiskEdgeRepoDeploysEnvironment RepoRiskGraphEdgeKind = "repo_deploys_to_environment"
+	RepoRiskEdgeFindingReferencesID    RepoRiskGraphEdgeKind = "finding_references_identity"
+	RepoRiskEdgeReachabilityUnknown    RepoRiskGraphEdgeKind = "reachability_unknown"
+)
+
+// RepoRiskGraphEvidenceState records whether a node or edge is backed by direct
+// evidence or intentionally represents a gap that the scanner could not prove.
+type RepoRiskGraphEvidenceState string
+
+const (
+	RepoRiskEvidenceKnown   RepoRiskGraphEvidenceState = "known"
+	RepoRiskEvidenceUnknown RepoRiskGraphEvidenceState = "unknown"
+)
+
+// RepoRiskGraphOptions controls repository-level context for graph creation.
+type RepoRiskGraphOptions struct {
+	Repository    string
+	DefaultBranch string
+	Now           time.Time
+}
+
+// RepoRiskGraph links repository findings to workflows, credentials, and
+// machine-identity concepts that can be derived from scanner evidence.
+type RepoRiskGraph struct {
+	Repository string                      `json:"repository,omitempty"`
+	Nodes      []RepoRiskGraphNode         `json:"nodes"`
+	Edges      []RepoRiskGraphEdge         `json:"edges"`
+	Scores     []RepoRiskGraphFindingScore `json:"scores"`
+	Summary    RepoRiskGraphSummary        `json:"summary"`
+}
+
+// RepoRiskGraphSummary provides cheap counters for API clients that do not need
+// to traverse every node and edge.
+type RepoRiskGraphSummary struct {
+	FindingCount     int `json:"finding_count"`
+	NodeCount        int `json:"node_count"`
+	EdgeCount        int `json:"edge_count"`
+	UnknownNodeCount int `json:"unknown_node_count"`
+	UnknownEdgeCount int `json:"unknown_edge_count"`
+	HighRiskFindings int `json:"high_risk_findings"`
+	CriticalFindings int `json:"critical_findings"`
+}
+
+// RepoRiskGraphNode is one vertex in the repo-to-machine-identity graph.
+type RepoRiskGraphNode struct {
+	ID            string                     `json:"id"`
+	Kind          RepoRiskGraphNodeKind      `json:"kind"`
+	Label         string                     `json:"label"`
+	Repository    string                     `json:"repository,omitempty"`
+	EvidenceState RepoRiskGraphEvidenceState `json:"evidence_state"`
+	Evidence      map[string]any             `json:"evidence,omitempty"`
+}
+
+// RepoRiskGraphEdge is one directed relationship in the repo risk graph.
+type RepoRiskGraphEdge struct {
+	ID            string                     `json:"id"`
+	Kind          RepoRiskGraphEdgeKind      `json:"kind"`
+	FromNodeID    string                     `json:"from_node_id"`
+	ToNodeID      string                     `json:"to_node_id"`
+	EvidenceState RepoRiskGraphEvidenceState `json:"evidence_state"`
+	Evidence      map[string]any             `json:"evidence,omitempty"`
+}
+
+// RepoRiskGraphFindingScore records the graph-aware risk score for one finding.
+type RepoRiskGraphFindingScore struct {
+	FindingID  string                    `json:"finding_id"`
+	Score      int                       `json:"score"`
+	Severity   FindingSeverity           `json:"severity"`
+	Confidence float64                   `json:"confidence"`
+	Factors    RepoRiskGraphScoreFactors `json:"factors"`
+	Unknowns   []string                  `json:"unknowns,omitempty"`
+}
+
+// RepoRiskGraphScoreFactors makes graph score inputs inspectable.
+type RepoRiskGraphScoreFactors struct {
+	Severity               int `json:"severity"`
+	Confidence             int `json:"confidence"`
+	Exploitability         int `json:"exploitability"`
+	Privilege              int `json:"privilege"`
+	Exposure               int `json:"exposure"`
+	EnvironmentCriticality int `json:"environment_criticality"`
+	Freshness              int `json:"freshness"`
+}
+
+type repoRiskGraphBuilder struct {
+	graph RepoRiskGraph
+	nodes map[string]RepoRiskGraphNode
+	edges map[string]RepoRiskGraphEdge
+	now   time.Time
+}
+
+// BuildRepoRiskGraph builds a deterministic graph from repository findings and
+// the scanner evidence already attached to them. It never invents cloud roles,
+// environments, or Kubernetes identities when evidence is missing; those paths
+// are represented as unknown nodes and edges.
+func BuildRepoRiskGraph(findings []Finding, options RepoRiskGraphOptions) RepoRiskGraph {
+	if len(findings) == 0 {
+		return RepoRiskGraph{Repository: strings.TrimSpace(options.Repository)}
+	}
+	now := options.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	builder := repoRiskGraphBuilder{
+		nodes: map[string]RepoRiskGraphNode{},
+		edges: map[string]RepoRiskGraphEdge{},
+		now:   now.UTC(),
+	}
+
+	repository := strings.TrimSpace(options.Repository)
+	if repository == "" {
+		repository = commonRepository(findings)
+	}
+	builder.graph.Repository = repository
+
+	repositoryNodeIDs := map[string]string{}
+	if repository != "" {
+		repositoryNodeID := builder.upsertNode(RepoRiskNodeRepository, repository, repository, repository, RepoRiskEvidenceKnown, map[string]any{
+			"repository": repository,
+		})
+		repositoryNodeIDs[repository] = repositoryNodeID
+		if branch := strings.TrimSpace(options.DefaultBranch); branch != "" {
+			branchID := builder.upsertNode(RepoRiskNodeDefaultBranch, repository+":"+branch, branch, repository, RepoRiskEvidenceKnown, map[string]any{
+				"repository":     repository,
+				"default_branch": branch,
+			})
+			builder.upsertEdge(RepoRiskEdgeDefaultBranch, repositoryNodeID, branchID, RepoRiskEvidenceKnown, map[string]any{
+				"source": "scanner_context",
+			})
+		}
+	}
+
+	for _, raw := range findings {
+		finding := raw
+		NormalizeRepoFindingMetadata(&finding)
+		findingRepository := strings.TrimSpace(finding.Repository)
+		if findingRepository == "" {
+			findingRepository = repository
+		}
+		repositoryNodeID := repositoryNodeIDs[findingRepository]
+		if repositoryNodeID == "" && findingRepository != "" {
+			repositoryNodeID = builder.upsertNode(RepoRiskNodeRepository, findingRepository, findingRepository, findingRepository, RepoRiskEvidenceKnown, map[string]any{
+				"repository": findingRepository,
+			})
+			repositoryNodeIDs[findingRepository] = repositoryNodeID
+		}
+
+		findingID := builder.findingNodeID(finding)
+		findingNodeID := builder.upsertNode(RepoRiskNodeFinding, findingID, findingLabel(finding), findingRepository, RepoRiskEvidenceKnown, findingNodeEvidence(finding))
+		if repositoryNodeID != "" {
+			builder.upsertEdge(RepoRiskEdgeFindingInRepository, findingNodeID, repositoryNodeID, RepoRiskEvidenceKnown, map[string]any{
+				"finding_id": finding.ID,
+			})
+		} else {
+			unknownRepoID := builder.upsertUnknownNode(RepoRiskNodeRepository, "unknown repository", findingRepository, map[string]any{
+				"finding_id": finding.ID,
+				"reason":     "repository_missing",
+			})
+			builder.upsertEdge(RepoRiskEdgeFindingInRepository, findingNodeID, unknownRepoID, RepoRiskEvidenceUnknown, map[string]any{
+				"finding_id": finding.ID,
+				"reason":     "repository_missing",
+			})
+		}
+
+		workflowID, jobID := builder.addWorkflowReachability(finding, findingNodeID, repositoryNodeID, findingRepository)
+		builder.addEnvironmentReachability(finding, findingNodeID, repositoryNodeID, findingRepository)
+		builder.addSecretAndTokenReachability(finding, findingNodeID, jobID, findingRepository)
+		builder.addOIDCReachability(finding, findingNodeID, workflowID, jobID, findingRepository)
+		builder.addIdentityReachability(finding, findingNodeID, findingRepository)
+
+		score := scoreRepoRiskFinding(finding, builder.now)
+		builder.graph.Scores = append(builder.graph.Scores, score)
+	}
+
+	builder.finish()
+	return builder.graph
+}
+
+func commonRepository(findings []Finding) string {
+	var repository string
+	for _, raw := range findings {
+		finding := raw
+		NormalizeRepoFindingMetadata(&finding)
+		candidate := strings.TrimSpace(finding.Repository)
+		if candidate == "" {
+			continue
+		}
+		if repository == "" {
+			repository = candidate
+			continue
+		}
+		if repository != candidate {
+			return ""
+		}
+	}
+	return repository
+}
+
+func (builder *repoRiskGraphBuilder) findingNodeID(finding Finding) string {
+	if id := strings.TrimSpace(finding.ID); id != "" {
+		return id
+	}
+	key := strings.Join([]string{
+		strings.TrimSpace(finding.Repository),
+		string(finding.Type),
+		strings.TrimSpace(finding.Detector),
+		strings.TrimSpace(finding.FilePath),
+		strconv.Itoa(finding.LineNumber),
+	}, "\x1f")
+	return "finding:" + repoRiskDigest(key)
+}
+
+func (builder *repoRiskGraphBuilder) addWorkflowReachability(finding Finding, findingNodeID string, repositoryNodeID string, repository string) (string, string) {
+	workflowPath := workflowPathForFinding(finding)
+	if workflowPath == "" {
+		return "", ""
+	}
+
+	workflowID := builder.upsertNode(RepoRiskNodeWorkflow, repository+":"+workflowPath, workflowPath, repository, RepoRiskEvidenceKnown, map[string]any{
+		"file_path":  workflowPath,
+		"repository": repository,
+	})
+	if repositoryNodeID != "" {
+		builder.upsertEdge(RepoRiskEdgeContainsWorkflow, repositoryNodeID, workflowID, RepoRiskEvidenceKnown, map[string]any{
+			"file_path": workflowPath,
+		})
+	}
+	builder.upsertEdge(RepoRiskEdgeFindingAffectsWorkflow, findingNodeID, workflowID, RepoRiskEvidenceKnown, map[string]any{
+		"finding_id": finding.ID,
+		"file_path":  workflowPath,
+	})
+
+	jobName := strings.TrimSpace(stringFromAny(finding.Evidence["workflow_job"]))
+	if jobName == "" {
+		return workflowID, ""
+	}
+	jobID := builder.upsertNode(RepoRiskNodeWorkflowJob, repository+":"+workflowPath+":"+jobName, jobName, repository, RepoRiskEvidenceKnown, map[string]any{
+		"file_path":    workflowPath,
+		"workflow_job": jobName,
+	})
+	builder.upsertEdge(RepoRiskEdgeWorkflowRunsJob, workflowID, jobID, RepoRiskEvidenceKnown, map[string]any{
+		"workflow_job": jobName,
+	})
+	return workflowID, jobID
+}
+
+func (builder *repoRiskGraphBuilder) addEnvironmentReachability(finding Finding, findingNodeID string, repositoryNodeID string, repository string) {
+	environment := firstEvidenceString(finding.Evidence, "environment", "deployment_environment", "github_environment", "repo_environment")
+	if environment == "" {
+		return
+	}
+	environmentID := builder.upsertNode(RepoRiskNodeEnvironment, repository+":"+environment, environment, repository, RepoRiskEvidenceKnown, map[string]any{
+		"environment": environment,
+		"criticality": environmentCriticality(environment),
+	})
+	if repositoryNodeID != "" {
+		builder.upsertEdge(RepoRiskEdgeRepoDeploysEnvironment, repositoryNodeID, environmentID, RepoRiskEvidenceKnown, map[string]any{
+			"environment": environment,
+		})
+	}
+	builder.upsertEdge(RepoRiskEdgeFindingReferencesID, findingNodeID, environmentID, RepoRiskEvidenceKnown, map[string]any{
+		"finding_id": finding.ID,
+		"evidence":   "environment",
+	})
+}
+
+func (builder *repoRiskGraphBuilder) addSecretAndTokenReachability(finding Finding, findingNodeID string, jobID string, repository string) {
+	secretLabel := secretLabelForFinding(finding)
+	if secretLabel == "" && !findingReferencesSecrets(finding) {
+		return
+	}
+	kind := RepoRiskNodeSecret
+	if finding.Type == FindingSecretExposure {
+		kind = RepoRiskNodeToken
+	}
+	if secretLabel == "" {
+		secretLabel = "referenced GitHub secret"
+	}
+	secretID := builder.upsertNode(kind, repository+":"+string(kind)+":"+secretLabel, secretLabel, repository, RepoRiskEvidenceKnown, map[string]any{
+		"secret_label":  secretLabel,
+		"raw_available": false,
+	})
+	if finding.Type == FindingSecretExposure {
+		builder.upsertEdge(RepoRiskEdgeFindingExposesToken, findingNodeID, secretID, RepoRiskEvidenceKnown, map[string]any{
+			"finding_id":        finding.ID,
+			"raw_secret_stored": false,
+		})
+		return
+	}
+	if jobID != "" {
+		builder.upsertEdge(RepoRiskEdgeJobUsesSecret, jobID, secretID, RepoRiskEvidenceKnown, map[string]any{
+			"finding_id": finding.ID,
+		})
+	} else {
+		builder.upsertEdge(RepoRiskEdgeFindingReferencesID, findingNodeID, secretID, RepoRiskEvidenceKnown, map[string]any{
+			"finding_id": finding.ID,
+			"evidence":   "references_secrets",
+		})
+	}
+}
+
+func (builder *repoRiskGraphBuilder) addOIDCReachability(finding Finding, findingNodeID string, workflowID string, jobID string, repository string) {
+	if !findingReferencesOIDC(finding) {
+		return
+	}
+	subject := firstEvidenceString(finding.Evidence, "oidc_subject", "github_oidc_subject")
+	if subject == "" {
+		subject = oidcSubjectFromFinding(finding)
+	}
+	subjectID := builder.upsertNode(RepoRiskNodeOIDCSubject, repository+":"+subject, subject, repository, RepoRiskEvidenceKnown, map[string]any{
+		"oidc_subject": subject,
+	})
+	fromNodeID := workflowID
+	if jobID != "" {
+		fromNodeID = jobID
+	}
+	if fromNodeID == "" {
+		fromNodeID = findingNodeID
+	}
+	builder.upsertEdge(RepoRiskEdgeWorkflowCanMintToken, fromNodeID, subjectID, RepoRiskEvidenceKnown, map[string]any{
+		"finding_id":         finding.ID,
+		"permission_summary": strings.TrimSpace(stringFromAny(finding.Evidence["permission_summary"])),
+		"oidc_risk_context":  strings.TrimSpace(stringFromAny(finding.Evidence["oidc_risk_context"])),
+	})
+
+	if role := cloudRoleForFinding(finding); role != "" {
+		roleID := builder.upsertNode(RepoRiskNodeCloudRole, repository+":"+role, role, repository, RepoRiskEvidenceKnown, map[string]any{
+			"role": role,
+		})
+		builder.upsertEdge(RepoRiskEdgeOIDCCanAssumeRole, subjectID, roleID, RepoRiskEvidenceKnown, map[string]any{
+			"finding_id": finding.ID,
+		})
+		return
+	}
+
+	unknownRoleID := builder.upsertUnknownNode(RepoRiskNodeCloudRole, "unknown cloud role", repository, map[string]any{
+		"finding_id": finding.ID,
+		"reason":     "oidc_target_role_missing",
+	})
+	builder.upsertEdge(RepoRiskEdgeReachabilityUnknown, subjectID, unknownRoleID, RepoRiskEvidenceUnknown, map[string]any{
+		"finding_id": finding.ID,
+		"reason":     "oidc_target_role_missing",
+	})
+}
+
+func (builder *repoRiskGraphBuilder) addIdentityReachability(finding Finding, findingNodeID string, repository string) {
+	if role := cloudRoleForFinding(finding); role != "" {
+		roleID := builder.upsertNode(RepoRiskNodeCloudRole, repository+":"+role, role, repository, RepoRiskEvidenceKnown, map[string]any{
+			"role": role,
+		})
+		builder.upsertEdge(RepoRiskEdgeFindingReferencesID, findingNodeID, roleID, RepoRiskEvidenceKnown, map[string]any{
+			"finding_id": finding.ID,
+			"evidence":   "cloud_role",
+		})
+	}
+	if serviceAccount := firstEvidenceString(finding.Evidence, "kubernetes_service_account", "service_account", "gcp_service_account"); serviceAccount != "" {
+		kind := RepoRiskNodeKubernetesServiceAccount
+		naturalKey := repository + ":" + string(kind) + ":" + serviceAccount
+		if strings.Contains(serviceAccount, "@") && strings.Contains(serviceAccount, ".iam.gserviceaccount.com") {
+			kind = RepoRiskNodeCloudRole
+			naturalKey = repository + ":" + serviceAccount
+		}
+		serviceAccountID := builder.upsertNode(kind, naturalKey, serviceAccount, repository, RepoRiskEvidenceKnown, map[string]any{
+			"service_account": serviceAccount,
+		})
+		builder.upsertEdge(RepoRiskEdgeFindingReferencesID, findingNodeID, serviceAccountID, RepoRiskEvidenceKnown, map[string]any{
+			"finding_id": finding.ID,
+			"evidence":   "service_account",
+		})
+	}
+	if app := firstEvidenceString(finding.Evidence, "github_app", "github_app_slug", "github_app_id"); app != "" {
+		appID := builder.upsertNode(RepoRiskNodeGitHubApp, repository+":"+app, app, repository, RepoRiskEvidenceKnown, map[string]any{
+			"github_app": app,
+		})
+		builder.upsertEdge(RepoRiskEdgeFindingReferencesID, findingNodeID, appID, RepoRiskEvidenceKnown, map[string]any{
+			"finding_id": finding.ID,
+			"evidence":   "github_app",
+		})
+	}
+	if key := firstEvidenceString(finding.Evidence, "deploy_key", "deploy_key_id", "deploy_key_fingerprint"); key != "" {
+		keyID := builder.upsertNode(RepoRiskNodeDeployKey, repository+":"+key, key, repository, RepoRiskEvidenceKnown, map[string]any{
+			"deploy_key": key,
+		})
+		builder.upsertEdge(RepoRiskEdgeFindingReferencesID, findingNodeID, keyID, RepoRiskEvidenceKnown, map[string]any{
+			"finding_id": finding.ID,
+			"evidence":   "deploy_key",
+		})
+	}
+}
+
+func (builder *repoRiskGraphBuilder) upsertNode(kind RepoRiskGraphNodeKind, naturalKey string, label string, repository string, state RepoRiskGraphEvidenceState, evidence map[string]any) string {
+	id := repoRiskNodeID(kind, naturalKey)
+	node, exists := builder.nodes[id]
+	if !exists {
+		node = RepoRiskGraphNode{
+			ID:            id,
+			Kind:          kind,
+			Label:         strings.TrimSpace(label),
+			Repository:    strings.TrimSpace(repository),
+			EvidenceState: state,
+			Evidence:      compactEvidence(evidence),
+		}
+		if node.Label == "" {
+			node.Label = string(kind)
+		}
+		builder.nodes[id] = node
+		return id
+	}
+	if node.Repository == "" {
+		node.Repository = strings.TrimSpace(repository)
+	}
+	if node.Label == "" && strings.TrimSpace(label) != "" {
+		node.Label = strings.TrimSpace(label)
+	}
+	if node.EvidenceState == RepoRiskEvidenceUnknown && state == RepoRiskEvidenceKnown {
+		node.EvidenceState = RepoRiskEvidenceKnown
+	}
+	node.Evidence = mergeEvidence(node.Evidence, evidence)
+	builder.nodes[id] = node
+	return id
+}
+
+func (builder *repoRiskGraphBuilder) upsertUnknownNode(kind RepoRiskGraphNodeKind, label string, repository string, evidence map[string]any) string {
+	naturalKey := strings.Join([]string{strings.TrimSpace(repository), string(kind), strings.TrimSpace(label), strings.TrimSpace(stringFromAny(evidence["reason"]))}, "\x1f")
+	return builder.upsertNode(RepoRiskNodeUnknown, naturalKey, label, repository, RepoRiskEvidenceUnknown, evidence)
+}
+
+func (builder *repoRiskGraphBuilder) upsertEdge(kind RepoRiskGraphEdgeKind, fromNodeID string, toNodeID string, state RepoRiskGraphEvidenceState, evidence map[string]any) string {
+	if fromNodeID == "" || toNodeID == "" {
+		return ""
+	}
+	id := repoRiskEdgeID(kind, fromNodeID, toNodeID)
+	edge, exists := builder.edges[id]
+	if !exists {
+		builder.edges[id] = RepoRiskGraphEdge{
+			ID:            id,
+			Kind:          kind,
+			FromNodeID:    fromNodeID,
+			ToNodeID:      toNodeID,
+			EvidenceState: state,
+			Evidence:      compactEvidence(evidence),
+		}
+		return id
+	}
+	if edge.EvidenceState == RepoRiskEvidenceUnknown && state == RepoRiskEvidenceKnown {
+		edge.EvidenceState = RepoRiskEvidenceKnown
+	}
+	edge.Evidence = mergeEvidence(edge.Evidence, evidence)
+	builder.edges[id] = edge
+	return id
+}
+
+func (builder *repoRiskGraphBuilder) finish() {
+	builder.graph.Nodes = make([]RepoRiskGraphNode, 0, len(builder.nodes))
+	for _, node := range builder.nodes {
+		builder.graph.Nodes = append(builder.graph.Nodes, node)
+		if node.EvidenceState == RepoRiskEvidenceUnknown {
+			builder.graph.Summary.UnknownNodeCount++
+		}
+	}
+	sort.SliceStable(builder.graph.Nodes, func(i, j int) bool {
+		left := builder.graph.Nodes[i]
+		right := builder.graph.Nodes[j]
+		if left.Kind != right.Kind {
+			return left.Kind < right.Kind
+		}
+		if left.Label != right.Label {
+			return left.Label < right.Label
+		}
+		return left.ID < right.ID
+	})
+
+	builder.graph.Edges = make([]RepoRiskGraphEdge, 0, len(builder.edges))
+	for _, edge := range builder.edges {
+		builder.graph.Edges = append(builder.graph.Edges, edge)
+		if edge.EvidenceState == RepoRiskEvidenceUnknown {
+			builder.graph.Summary.UnknownEdgeCount++
+		}
+	}
+	sort.SliceStable(builder.graph.Edges, func(i, j int) bool {
+		left := builder.graph.Edges[i]
+		right := builder.graph.Edges[j]
+		if left.Kind != right.Kind {
+			return left.Kind < right.Kind
+		}
+		if left.FromNodeID != right.FromNodeID {
+			return left.FromNodeID < right.FromNodeID
+		}
+		if left.ToNodeID != right.ToNodeID {
+			return left.ToNodeID < right.ToNodeID
+		}
+		return left.ID < right.ID
+	})
+
+	sort.SliceStable(builder.graph.Scores, func(i, j int) bool {
+		left := builder.graph.Scores[i]
+		right := builder.graph.Scores[j]
+		if left.Score != right.Score {
+			return left.Score > right.Score
+		}
+		return left.FindingID < right.FindingID
+	})
+	for _, score := range builder.graph.Scores {
+		if score.Score >= 85 {
+			builder.graph.Summary.CriticalFindings++
+		} else if score.Score >= 70 {
+			builder.graph.Summary.HighRiskFindings++
+		}
+	}
+	builder.graph.Summary.FindingCount = len(builder.graph.Scores)
+	builder.graph.Summary.NodeCount = len(builder.graph.Nodes)
+	builder.graph.Summary.EdgeCount = len(builder.graph.Edges)
+}
+
+func scoreRepoRiskFinding(finding Finding, now time.Time) RepoRiskGraphFindingScore {
+	factors := RepoRiskGraphScoreFactors{
+		Severity:               repoRiskSeverityFactor(finding.Severity),
+		Confidence:             repoRiskConfidenceFactor(finding),
+		Exploitability:         repoRiskExploitabilityFactor(finding),
+		Privilege:              repoRiskPrivilegeFactor(finding),
+		Exposure:               repoRiskExposureFactor(finding),
+		EnvironmentCriticality: repoRiskEnvironmentFactor(finding),
+		Freshness:              repoRiskFreshnessFactor(finding, now),
+	}
+	weighted := float64(factors.Severity)*0.60 +
+		float64(factors.Confidence)*0.10 +
+		float64(factors.Exploitability)*0.12 +
+		float64(factors.Privilege)*0.10 +
+		float64(factors.Exposure)*0.05 +
+		float64(factors.EnvironmentCriticality)*0.02 +
+		float64(factors.Freshness)*0.01
+	score := int(math.Round(weighted))
+	score = clampInt(score, 0, 100)
+	return RepoRiskGraphFindingScore{
+		FindingID:  strings.TrimSpace(finding.ID),
+		Score:      score,
+		Severity:   finding.Severity,
+		Confidence: confidenceForFinding(finding),
+		Factors:    factors,
+		Unknowns:   repoRiskUnknowns(finding),
+	}
+}
+
+func repoRiskSeverityFactor(severity FindingSeverity) int {
+	switch severity {
+	case SeverityCritical:
+		return 100
+	case SeverityHigh:
+		return 80
+	case SeverityMedium:
+		return 55
+	case SeverityLow:
+		return 30
+	case SeverityInfo:
+		return 10
+	default:
+		return 20
+	}
+}
+
+func repoRiskConfidenceFactor(finding Finding) int {
+	return clampInt(int(math.Round(confidenceForFinding(finding)*100)), 1, 100)
+}
+
+func confidenceForFinding(finding Finding) float64 {
+	if finding.ConfidenceScore > 0 {
+		return clampFloat(finding.ConfidenceScore, 0.01, 0.99)
+	}
+	if confidence, ok := floatFromAny(finding.Evidence["confidence_score"]); ok && confidence > 0 {
+		return clampFloat(confidence, 0.01, 0.99)
+	}
+	return 0.7
+}
+
+func repoRiskExploitabilityFactor(finding Finding) int {
+	score := 0
+	detector := strings.ToLower(strings.TrimSpace(finding.Detector))
+	title := strings.ToLower(finding.Title + " " + finding.HumanSummary)
+	if finding.Type == FindingSecretExposure {
+		score += 35
+	}
+	for _, token := range []string{"pull_request_target", "untrusted_checkout", "shell_injection", "workflow_run", "cache_poisoning", "artifact_poisoning"} {
+		if strings.Contains(detector, token) || strings.Contains(title, token) {
+			score += 16
+			break
+		}
+	}
+	if strings.Contains(detector, "oidc") || strings.Contains(title, "oidc") {
+		score += 18
+	}
+	if workflowHasUntrustedEventEvidence(finding.Evidence) {
+		score += 12
+	}
+	if strings.TrimSpace(stringFromAny(finding.Evidence["cloud_auth_action"])) != "" {
+		score += 10
+	}
+	return clampInt(score, 0, 100)
+}
+
+func repoRiskPrivilegeFactor(finding Finding) int {
+	score := 0
+	permissionSummary := strings.ToLower(strings.TrimSpace(stringFromAny(finding.Evidence["permission_summary"])))
+	if permissionSummary == "write-all" || strings.Contains(permissionSummary, ":write") {
+		score += 30
+	}
+	if evidenceStringSlice(finding.Evidence["write_scopes"]) != nil {
+		score += 20
+	}
+	if findingReferencesSecrets(finding) {
+		score += 18
+	}
+	if findingReferencesOIDC(finding) {
+		score += 20
+	}
+	if finding.Type == FindingSecretExposure {
+		score += 24
+	}
+	if cloudRoleForFinding(finding) != "" {
+		score += 18
+	}
+	return clampInt(score, 0, 100)
+}
+
+func repoRiskExposureFactor(finding Finding) int {
+	score := 0
+	for _, event := range evidenceStringSlice(finding.Evidence["workflow_events"]) {
+		switch strings.ToLower(strings.TrimSpace(event)) {
+		case "pull_request_target":
+			score += 30
+		case "workflow_run":
+			score += 22
+		case "pull_request":
+			score += 15
+		case "push":
+			score += 8
+		}
+	}
+	context := strings.ToLower(strings.TrimSpace(stringFromAny(finding.Evidence["oidc_risk_context"])))
+	switch context {
+	case "untrusted_event":
+		score += 24
+	case "workflow_run":
+		score += 20
+	case "broad_push_event":
+		score += 16
+	}
+	if strings.Contains(strings.ToLower(strings.TrimSpace(finding.FilePath)), ".github/workflows/") {
+		score += 10
+	}
+	return clampInt(score, 0, 100)
+}
+
+func repoRiskEnvironmentFactor(finding Finding) int {
+	environment := firstEvidenceString(finding.Evidence, "environment", "deployment_environment", "github_environment", "repo_environment")
+	switch environmentCriticality(environment) {
+	case "production":
+		return 100
+	case "staging":
+		return 55
+	case "development":
+		return 25
+	default:
+		return 0
+	}
+}
+
+func repoRiskFreshnessFactor(finding Finding, now time.Time) int {
+	if finding.CreatedAt.IsZero() || now.IsZero() {
+		return 0
+	}
+	age := now.Sub(finding.CreatedAt.UTC())
+	switch {
+	case age < 0:
+		return 20
+	case age <= 7*24*time.Hour:
+		return 100
+	case age <= 30*24*time.Hour:
+		return 70
+	case age <= 90*24*time.Hour:
+		return 35
+	default:
+		return 10
+	}
+}
+
+func repoRiskUnknowns(finding Finding) []string {
+	unknowns := []string{}
+	if strings.TrimSpace(finding.Repository) == "" && strings.TrimSpace(stringFromAny(finding.Evidence["repository"])) == "" {
+		unknowns = append(unknowns, "repository")
+	}
+	if findingReferencesOIDC(finding) && cloudRoleForFinding(finding) == "" {
+		unknowns = append(unknowns, "identity_target")
+	}
+	if workflowPathForFinding(finding) != "" && strings.TrimSpace(stringFromAny(finding.Evidence["workflow_job"])) == "" {
+		unknowns = append(unknowns, "workflow_job")
+	}
+	sort.Strings(unknowns)
+	return unknowns
+}
+
+func workflowPathForFinding(finding Finding) string {
+	path := strings.TrimSpace(finding.FilePath)
+	if path == "" && len(finding.Path) == 1 {
+		path = strings.TrimSpace(finding.Path[0])
+	}
+	if path == "" {
+		path = strings.TrimSpace(stringFromAny(finding.Evidence["file_path"]))
+	}
+	clean := filepath.ToSlash(path)
+	if strings.HasPrefix(strings.ToLower(clean), ".github/workflows/") {
+		return clean
+	}
+	return ""
+}
+
+func findingLabel(finding Finding) string {
+	switch {
+	case strings.TrimSpace(finding.Title) != "":
+		return strings.TrimSpace(finding.Title)
+	case strings.TrimSpace(finding.Detector) != "":
+		return strings.TrimSpace(finding.Detector)
+	case strings.TrimSpace(finding.ID) != "":
+		return strings.TrimSpace(finding.ID)
+	default:
+		return string(finding.Type)
+	}
+}
+
+func findingNodeEvidence(finding Finding) map[string]any {
+	evidence := map[string]any{
+		"finding_id": finding.ID,
+		"type":       string(finding.Type),
+		"severity":   string(finding.Severity),
+	}
+	if finding.Detector != "" {
+		evidence["detector"] = finding.Detector
+	}
+	if finding.FilePath != "" {
+		evidence["file_path"] = finding.FilePath
+	}
+	if finding.LineNumber > 0 {
+		evidence["line_number"] = finding.LineNumber
+	}
+	if finding.ScanID != "" {
+		evidence["scan_id"] = finding.ScanID
+	}
+	return evidence
+}
+
+func secretLabelForFinding(finding Finding) string {
+	for _, key := range []string{"secret_name", "github_secret", "env_secret", "secret_key"} {
+		if label := strings.TrimSpace(stringFromAny(finding.Evidence[key])); label != "" {
+			return label
+		}
+	}
+	if fingerprint := strings.TrimSpace(stringFromAny(finding.Evidence["secret_fingerprint"])); fingerprint != "" {
+		return "secret-fingerprint:" + fingerprint
+	}
+	if finding.Type == FindingSecretExposure && strings.TrimSpace(finding.Detector) != "" {
+		return strings.TrimSpace(finding.Detector)
+	}
+	return ""
+}
+
+func findingReferencesSecrets(finding Finding) bool {
+	if finding.Type == FindingSecretExposure {
+		return true
+	}
+	if references, ok := boolFromAny(finding.Evidence["references_secrets"]); ok && references {
+		return true
+	}
+	detector := strings.ToLower(strings.TrimSpace(finding.Detector))
+	return strings.Contains(detector, "secret")
+}
+
+func findingReferencesOIDC(finding Finding) bool {
+	detector := strings.ToLower(strings.TrimSpace(finding.Detector))
+	permissionSummary := strings.ToLower(strings.TrimSpace(stringFromAny(finding.Evidence["permission_summary"])))
+	return strings.Contains(detector, "oidc") ||
+		strings.TrimSpace(stringFromAny(finding.Evidence["oidc_risk_context"])) != "" ||
+		strings.TrimSpace(stringFromAny(finding.Evidence["oidc_subject"])) != "" ||
+		strings.Contains(permissionSummary, "id-token:write") ||
+		strings.Contains(permissionSummary, "id-token: write")
+}
+
+func oidcSubjectFromFinding(finding Finding) string {
+	repository := strings.TrimSpace(finding.Repository)
+	if repository == "" {
+		repository = strings.TrimSpace(stringFromAny(finding.Evidence["repository"]))
+	}
+	ref := strings.TrimSpace(stringFromAny(finding.Evidence["git_ref"]))
+	if ref == "" {
+		ref = strings.TrimSpace(stringFromAny(finding.Evidence["branch"]))
+	}
+	if ref == "" {
+		ref = "*"
+	}
+	job := strings.TrimSpace(stringFromAny(finding.Evidence["workflow_job"]))
+	switch {
+	case repository != "" && job != "":
+		return fmt.Sprintf("repo:%s:ref:%s:job:%s", repository, ref, job)
+	case repository != "":
+		return fmt.Sprintf("repo:%s:ref:%s", repository, ref)
+	default:
+		return "unknown OIDC subject"
+	}
+}
+
+func cloudRoleForFinding(finding Finding) string {
+	return firstEvidenceString(finding.Evidence, "aws_role_arn", "cloud_role_arn", "cloud_role", "azure_client_id", "gcp_service_account")
+}
+
+func workflowHasUntrustedEventEvidence(evidence map[string]any) bool {
+	for _, event := range evidenceStringSlice(evidence["workflow_events"]) {
+		switch strings.ToLower(strings.TrimSpace(event)) {
+		case "pull_request", "pull_request_target", "workflow_run":
+			return true
+		}
+	}
+	return false
+}
+
+func firstEvidenceString(evidence map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value := strings.TrimSpace(stringFromAny(evidence[key])); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func evidenceStringSlice(value any) []string {
+	switch typed := value.(type) {
+	case []string:
+		result := append([]string(nil), typed...)
+		sort.Strings(result)
+		return result
+	case []any:
+		result := []string{}
+		for _, item := range typed {
+			if value := strings.TrimSpace(stringFromAny(item)); value != "" {
+				result = append(result, value)
+			}
+		}
+		sort.Strings(result)
+		return result
+	default:
+		return nil
+	}
+}
+
+func environmentCriticality(environment string) string {
+	normalized := strings.ToLower(strings.TrimSpace(environment))
+	switch {
+	case normalized == "":
+		return "unknown"
+	case strings.Contains(normalized, "prod") || strings.Contains(normalized, "live"):
+		return "production"
+	case strings.Contains(normalized, "stage") || strings.Contains(normalized, "staging") || strings.Contains(normalized, "preprod"):
+		return "staging"
+	case strings.Contains(normalized, "dev") || strings.Contains(normalized, "test") || strings.Contains(normalized, "sandbox"):
+		return "development"
+	default:
+		return "unknown"
+	}
+}
+
+func repoRiskNodeID(kind RepoRiskGraphNodeKind, naturalKey string) string {
+	return "repo-risk-node:" + string(kind) + ":" + repoRiskDigest(strings.TrimSpace(naturalKey))
+}
+
+func repoRiskEdgeID(kind RepoRiskGraphEdgeKind, fromNodeID string, toNodeID string) string {
+	return "repo-risk-edge:" + string(kind) + ":" + repoRiskDigest(strings.Join([]string{fromNodeID, toNodeID}, "\x1f"))
+}
+
+func repoRiskDigest(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:12])
+}
+
+func compactEvidence(evidence map[string]any) map[string]any {
+	if len(evidence) == 0 {
+		return nil
+	}
+	result := map[string]any{}
+	for key, value := range evidence {
+		if strings.TrimSpace(key) == "" || value == nil {
+			continue
+		}
+		switch typed := value.(type) {
+		case string:
+			if strings.TrimSpace(typed) != "" {
+				result[key] = typed
+			}
+		case []string:
+			if len(typed) > 0 {
+				copied := append([]string(nil), typed...)
+				sort.Strings(copied)
+				result[key] = copied
+			}
+		default:
+			result[key] = value
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func mergeEvidence(existing map[string]any, extra map[string]any) map[string]any {
+	if len(extra) == 0 {
+		return existing
+	}
+	merged := compactEvidence(existing)
+	if merged == nil {
+		merged = map[string]any{}
+	}
+	for key, value := range compactEvidence(extra) {
+		if _, exists := merged[key]; !exists {
+			merged[key] = value
+		}
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}
+
+func clampInt(value int, minimum int, maximum int) int {
+	if value < minimum {
+		return minimum
+	}
+	if value > maximum {
+		return maximum
+	}
+	return value
+}
+
+func clampFloat(value float64, minimum float64, maximum float64) float64 {
+	if value < minimum {
+		return minimum
+	}
+	if value > maximum {
+		return maximum
+	}
+	return value
+}

--- a/internal/domain/repo_risk_graph.go
+++ b/internal/domain/repo_risk_graph.go
@@ -111,12 +111,13 @@ type RepoRiskGraphEdge struct {
 
 // RepoRiskGraphFindingScore records the graph-aware risk score for one finding.
 type RepoRiskGraphFindingScore struct {
-	FindingID  string                    `json:"finding_id"`
-	Score      int                       `json:"score"`
-	Severity   FindingSeverity           `json:"severity"`
-	Confidence float64                   `json:"confidence"`
-	Factors    RepoRiskGraphScoreFactors `json:"factors"`
-	Unknowns   []string                  `json:"unknowns,omitempty"`
+	FindingID     string                    `json:"finding_id"`
+	FindingNodeID string                    `json:"finding_node_id"`
+	Score         int                       `json:"score"`
+	Severity      FindingSeverity           `json:"severity"`
+	Confidence    float64                   `json:"confidence"`
+	Factors       RepoRiskGraphScoreFactors `json:"factors"`
+	Unknowns      []string                  `json:"unknowns,omitempty"`
 }
 
 // RepoRiskGraphScoreFactors makes graph score inputs inspectable.
@@ -143,7 +144,12 @@ type repoRiskGraphBuilder struct {
 // are represented as unknown nodes and edges.
 func BuildRepoRiskGraph(findings []Finding, options RepoRiskGraphOptions) RepoRiskGraph {
 	if len(findings) == 0 {
-		return RepoRiskGraph{Repository: strings.TrimSpace(options.Repository)}
+		return RepoRiskGraph{
+			Repository: strings.TrimSpace(options.Repository),
+			Nodes:      []RepoRiskGraphNode{},
+			Edges:      []RepoRiskGraphEdge{},
+			Scores:     []RepoRiskGraphFindingScore{},
+		}
 	}
 	now := options.Now
 	if now.IsZero() {
@@ -193,30 +199,31 @@ func BuildRepoRiskGraph(findings []Finding, options RepoRiskGraphOptions) RepoRi
 			repositoryNodeIDs[findingRepository] = repositoryNodeID
 		}
 
-		findingID := builder.findingNodeID(finding)
-		findingNodeID := builder.upsertNode(RepoRiskNodeFinding, findingID, findingLabel(finding), findingRepository, RepoRiskEvidenceKnown, findingNodeEvidence(finding))
+		findingKey := repoRiskFindingKey(finding)
+		findingPublicID := repoRiskFindingPublicID(finding, findingKey)
+		findingNodeID := builder.upsertNode(RepoRiskNodeFinding, findingKey, findingLabel(finding), findingRepository, RepoRiskEvidenceKnown, findingNodeEvidence(finding, findingPublicID))
 		if repositoryNodeID != "" {
 			builder.upsertEdge(RepoRiskEdgeFindingInRepository, findingNodeID, repositoryNodeID, RepoRiskEvidenceKnown, map[string]any{
-				"finding_id": finding.ID,
+				"finding_id": findingPublicID,
 			})
 		} else {
 			unknownRepoID := builder.upsertUnknownNode(RepoRiskNodeRepository, "unknown repository", findingRepository, map[string]any{
-				"finding_id": finding.ID,
+				"finding_id": findingPublicID,
 				"reason":     "repository_missing",
 			})
 			builder.upsertEdge(RepoRiskEdgeFindingInRepository, findingNodeID, unknownRepoID, RepoRiskEvidenceUnknown, map[string]any{
-				"finding_id": finding.ID,
+				"finding_id": findingPublicID,
 				"reason":     "repository_missing",
 			})
 		}
 
-		workflowID, jobID := builder.addWorkflowReachability(finding, findingNodeID, repositoryNodeID, findingRepository)
-		builder.addEnvironmentReachability(finding, findingNodeID, repositoryNodeID, findingRepository)
-		builder.addSecretAndTokenReachability(finding, findingNodeID, jobID, findingRepository)
-		builder.addOIDCReachability(finding, findingNodeID, workflowID, jobID, findingRepository)
-		builder.addIdentityReachability(finding, findingNodeID, findingRepository)
+		workflowID, jobID := builder.addWorkflowReachability(finding, findingPublicID, findingNodeID, repositoryNodeID, findingRepository)
+		builder.addEnvironmentReachability(finding, findingPublicID, findingNodeID, repositoryNodeID, findingRepository)
+		builder.addSecretAndTokenReachability(finding, findingPublicID, findingNodeID, jobID, findingRepository)
+		builder.addOIDCReachability(finding, findingPublicID, findingNodeID, workflowID, jobID, findingRepository)
+		builder.addIdentityReachability(finding, findingPublicID, findingNodeID, findingRepository)
 
-		score := scoreRepoRiskFinding(finding, builder.now)
+		score := scoreRepoRiskFinding(finding, builder.now, findingPublicID, findingNodeID)
 		builder.graph.Scores = append(builder.graph.Scores, score)
 	}
 
@@ -244,21 +251,26 @@ func commonRepository(findings []Finding) string {
 	return repository
 }
 
-func (builder *repoRiskGraphBuilder) findingNodeID(finding Finding) string {
-	if id := strings.TrimSpace(finding.ID); id != "" {
-		return id
-	}
-	key := strings.Join([]string{
+func repoRiskFindingKey(finding Finding) string {
+	return strings.Join([]string{
+		strings.TrimSpace(finding.ScanID),
 		strings.TrimSpace(finding.Repository),
+		strings.TrimSpace(finding.ID),
 		string(finding.Type),
 		strings.TrimSpace(finding.Detector),
 		strings.TrimSpace(finding.FilePath),
 		strconv.Itoa(finding.LineNumber),
 	}, "\x1f")
+}
+
+func repoRiskFindingPublicID(finding Finding, key string) string {
+	if id := strings.TrimSpace(finding.ID); id != "" {
+		return id
+	}
 	return "finding:" + repoRiskDigest(key)
 }
 
-func (builder *repoRiskGraphBuilder) addWorkflowReachability(finding Finding, findingNodeID string, repositoryNodeID string, repository string) (string, string) {
+func (builder *repoRiskGraphBuilder) addWorkflowReachability(finding Finding, findingPublicID string, findingNodeID string, repositoryNodeID string, repository string) (string, string) {
 	workflowPath := workflowPathForFinding(finding)
 	if workflowPath == "" {
 		return "", ""
@@ -274,7 +286,7 @@ func (builder *repoRiskGraphBuilder) addWorkflowReachability(finding Finding, fi
 		})
 	}
 	builder.upsertEdge(RepoRiskEdgeFindingAffectsWorkflow, findingNodeID, workflowID, RepoRiskEvidenceKnown, map[string]any{
-		"finding_id": finding.ID,
+		"finding_id": findingPublicID,
 		"file_path":  workflowPath,
 	})
 
@@ -292,7 +304,7 @@ func (builder *repoRiskGraphBuilder) addWorkflowReachability(finding Finding, fi
 	return workflowID, jobID
 }
 
-func (builder *repoRiskGraphBuilder) addEnvironmentReachability(finding Finding, findingNodeID string, repositoryNodeID string, repository string) {
+func (builder *repoRiskGraphBuilder) addEnvironmentReachability(finding Finding, findingPublicID string, findingNodeID string, repositoryNodeID string, repository string) {
 	environment := firstEvidenceString(finding.Evidence, "environment", "deployment_environment", "github_environment", "repo_environment")
 	if environment == "" {
 		return
@@ -307,12 +319,12 @@ func (builder *repoRiskGraphBuilder) addEnvironmentReachability(finding Finding,
 		})
 	}
 	builder.upsertEdge(RepoRiskEdgeFindingReferencesID, findingNodeID, environmentID, RepoRiskEvidenceKnown, map[string]any{
-		"finding_id": finding.ID,
+		"finding_id": findingPublicID,
 		"evidence":   "environment",
 	})
 }
 
-func (builder *repoRiskGraphBuilder) addSecretAndTokenReachability(finding Finding, findingNodeID string, jobID string, repository string) {
+func (builder *repoRiskGraphBuilder) addSecretAndTokenReachability(finding Finding, findingPublicID string, findingNodeID string, jobID string, repository string) {
 	secretLabel := secretLabelForFinding(finding)
 	if secretLabel == "" && !findingReferencesSecrets(finding) {
 		return
@@ -330,24 +342,24 @@ func (builder *repoRiskGraphBuilder) addSecretAndTokenReachability(finding Findi
 	})
 	if finding.Type == FindingSecretExposure {
 		builder.upsertEdge(RepoRiskEdgeFindingExposesToken, findingNodeID, secretID, RepoRiskEvidenceKnown, map[string]any{
-			"finding_id":        finding.ID,
+			"finding_id":        findingPublicID,
 			"raw_secret_stored": false,
 		})
 		return
 	}
 	if jobID != "" {
 		builder.upsertEdge(RepoRiskEdgeJobUsesSecret, jobID, secretID, RepoRiskEvidenceKnown, map[string]any{
-			"finding_id": finding.ID,
+			"finding_id": findingPublicID,
 		})
 	} else {
 		builder.upsertEdge(RepoRiskEdgeFindingReferencesID, findingNodeID, secretID, RepoRiskEvidenceKnown, map[string]any{
-			"finding_id": finding.ID,
+			"finding_id": findingPublicID,
 			"evidence":   "references_secrets",
 		})
 	}
 }
 
-func (builder *repoRiskGraphBuilder) addOIDCReachability(finding Finding, findingNodeID string, workflowID string, jobID string, repository string) {
+func (builder *repoRiskGraphBuilder) addOIDCReachability(finding Finding, findingPublicID string, findingNodeID string, workflowID string, jobID string, repository string) {
 	if !findingReferencesOIDC(finding) {
 		return
 	}
@@ -366,7 +378,7 @@ func (builder *repoRiskGraphBuilder) addOIDCReachability(finding Finding, findin
 		fromNodeID = findingNodeID
 	}
 	builder.upsertEdge(RepoRiskEdgeWorkflowCanMintToken, fromNodeID, subjectID, RepoRiskEvidenceKnown, map[string]any{
-		"finding_id":         finding.ID,
+		"finding_id":         findingPublicID,
 		"permission_summary": strings.TrimSpace(stringFromAny(finding.Evidence["permission_summary"])),
 		"oidc_risk_context":  strings.TrimSpace(stringFromAny(finding.Evidence["oidc_risk_context"])),
 	})
@@ -376,28 +388,28 @@ func (builder *repoRiskGraphBuilder) addOIDCReachability(finding Finding, findin
 			"role": role,
 		})
 		builder.upsertEdge(RepoRiskEdgeOIDCCanAssumeRole, subjectID, roleID, RepoRiskEvidenceKnown, map[string]any{
-			"finding_id": finding.ID,
+			"finding_id": findingPublicID,
 		})
 		return
 	}
 
 	unknownRoleID := builder.upsertUnknownNode(RepoRiskNodeCloudRole, "unknown cloud role", repository, map[string]any{
-		"finding_id": finding.ID,
+		"finding_id": findingPublicID,
 		"reason":     "oidc_target_role_missing",
 	})
 	builder.upsertEdge(RepoRiskEdgeReachabilityUnknown, subjectID, unknownRoleID, RepoRiskEvidenceUnknown, map[string]any{
-		"finding_id": finding.ID,
+		"finding_id": findingPublicID,
 		"reason":     "oidc_target_role_missing",
 	})
 }
 
-func (builder *repoRiskGraphBuilder) addIdentityReachability(finding Finding, findingNodeID string, repository string) {
+func (builder *repoRiskGraphBuilder) addIdentityReachability(finding Finding, findingPublicID string, findingNodeID string, repository string) {
 	if role := cloudRoleForFinding(finding); role != "" {
 		roleID := builder.upsertNode(RepoRiskNodeCloudRole, repository+":"+role, role, repository, RepoRiskEvidenceKnown, map[string]any{
 			"role": role,
 		})
 		builder.upsertEdge(RepoRiskEdgeFindingReferencesID, findingNodeID, roleID, RepoRiskEvidenceKnown, map[string]any{
-			"finding_id": finding.ID,
+			"finding_id": findingPublicID,
 			"evidence":   "cloud_role",
 		})
 	}
@@ -412,7 +424,7 @@ func (builder *repoRiskGraphBuilder) addIdentityReachability(finding Finding, fi
 			"service_account": serviceAccount,
 		})
 		builder.upsertEdge(RepoRiskEdgeFindingReferencesID, findingNodeID, serviceAccountID, RepoRiskEvidenceKnown, map[string]any{
-			"finding_id": finding.ID,
+			"finding_id": findingPublicID,
 			"evidence":   "service_account",
 		})
 	}
@@ -421,7 +433,7 @@ func (builder *repoRiskGraphBuilder) addIdentityReachability(finding Finding, fi
 			"github_app": app,
 		})
 		builder.upsertEdge(RepoRiskEdgeFindingReferencesID, findingNodeID, appID, RepoRiskEvidenceKnown, map[string]any{
-			"finding_id": finding.ID,
+			"finding_id": findingPublicID,
 			"evidence":   "github_app",
 		})
 	}
@@ -430,7 +442,7 @@ func (builder *repoRiskGraphBuilder) addIdentityReachability(finding Finding, fi
 			"deploy_key": key,
 		})
 		builder.upsertEdge(RepoRiskEdgeFindingReferencesID, findingNodeID, keyID, RepoRiskEvidenceKnown, map[string]any{
-			"finding_id": finding.ID,
+			"finding_id": findingPublicID,
 			"evidence":   "deploy_key",
 		})
 	}
@@ -560,7 +572,7 @@ func (builder *repoRiskGraphBuilder) finish() {
 	builder.graph.Summary.EdgeCount = len(builder.graph.Edges)
 }
 
-func scoreRepoRiskFinding(finding Finding, now time.Time) RepoRiskGraphFindingScore {
+func scoreRepoRiskFinding(finding Finding, now time.Time, findingID string, findingNodeID string) RepoRiskGraphFindingScore {
 	factors := RepoRiskGraphScoreFactors{
 		Severity:               repoRiskSeverityFactor(finding.Severity),
 		Confidence:             repoRiskConfidenceFactor(finding),
@@ -580,12 +592,13 @@ func scoreRepoRiskFinding(finding Finding, now time.Time) RepoRiskGraphFindingSc
 	score := int(math.Round(weighted))
 	score = clampInt(score, 0, 100)
 	return RepoRiskGraphFindingScore{
-		FindingID:  strings.TrimSpace(finding.ID),
-		Score:      score,
-		Severity:   finding.Severity,
-		Confidence: confidenceForFinding(finding),
-		Factors:    factors,
-		Unknowns:   repoRiskUnknowns(finding),
+		FindingID:     findingID,
+		FindingNodeID: findingNodeID,
+		Score:         score,
+		Severity:      finding.Severity,
+		Confidence:    confidenceForFinding(finding),
+		Factors:       factors,
+		Unknowns:      repoRiskUnknowns(finding),
 	}
 }
 
@@ -651,7 +664,7 @@ func repoRiskPrivilegeFactor(finding Finding) int {
 	if permissionSummary == "write-all" || strings.Contains(permissionSummary, ":write") {
 		score += 30
 	}
-	if evidenceStringSlice(finding.Evidence["write_scopes"]) != nil {
+	if len(evidenceStringSlice(finding.Evidence["write_scopes"])) > 0 {
 		score += 20
 	}
 	if findingReferencesSecrets(finding) {
@@ -774,9 +787,9 @@ func findingLabel(finding Finding) string {
 	}
 }
 
-func findingNodeEvidence(finding Finding) map[string]any {
+func findingNodeEvidence(finding Finding, findingPublicID string) map[string]any {
 	evidence := map[string]any{
-		"finding_id": finding.ID,
+		"finding_id": findingPublicID,
 		"type":       string(finding.Type),
 		"severity":   string(finding.Severity),
 	}

--- a/internal/domain/repo_risk_graph_test.go
+++ b/internal/domain/repo_risk_graph_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -211,6 +212,113 @@ func TestBuildRepoRiskGraphKeepsMultipleRepositoriesSeparate(t *testing.T) {
 	}
 }
 
+func TestBuildRepoRiskGraphReturnsEmptyArrays(t *testing.T) {
+	graph := BuildRepoRiskGraph(nil, RepoRiskGraphOptions{Repository: "owner/repo"})
+	if graph.Repository != "owner/repo" {
+		t.Fatalf("expected repository context to be preserved, got %+v", graph)
+	}
+	if graph.Nodes == nil || graph.Edges == nil || graph.Scores == nil {
+		t.Fatalf("expected empty graph slices to be non-nil arrays, got %+v", graph)
+	}
+	encoded, err := json.Marshal(graph)
+	if err != nil {
+		t.Fatalf("marshal graph: %v", err)
+	}
+	if string(encoded) != `{"repository":"owner/repo","nodes":[],"edges":[],"scores":[],"summary":{"finding_count":0,"node_count":0,"edge_count":0,"unknown_node_count":0,"unknown_edge_count":0,"high_risk_findings":0,"critical_findings":0}}` {
+		t.Fatalf("expected empty arrays in JSON, got %s", encoded)
+	}
+}
+
+func TestBuildRepoRiskGraphUsesDeterministicFindingFallbacks(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	graph := BuildRepoRiskGraph([]Finding{{
+		ScanID:     "scan-blank",
+		Type:       FindingRepoMisconfig,
+		Severity:   SeverityMedium,
+		Repository: "owner/repo",
+		FilePath:   ".github/workflows/build.yml",
+		LineNumber: 9,
+		Detector:   "workflow_unpinned_third_party_action",
+		CreatedAt:  now,
+	}}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
+
+	if len(graph.Scores) != 1 {
+		t.Fatalf("expected one score, got %+v", graph.Scores)
+	}
+	score := graph.Scores[0]
+	if score.FindingID == "" || score.FindingNodeID == "" {
+		t.Fatalf("expected deterministic score identifiers, got %+v", score)
+	}
+	assertGraphNodeID(t, graph, score.FindingNodeID)
+}
+
+func TestBuildRepoRiskGraphIncludesScanContextInFindingNodeIdentity(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	graph := BuildRepoRiskGraph([]Finding{
+		{
+			ID:         "same-finding",
+			ScanID:     "scan-a",
+			Type:       FindingRepoMisconfig,
+			Severity:   SeverityMedium,
+			Repository: "owner/repo",
+			FilePath:   ".github/workflows/build.yml",
+			LineNumber: 11,
+			Detector:   "workflow_unpinned_third_party_action",
+			CreatedAt:  now,
+		},
+		{
+			ID:         "same-finding",
+			ScanID:     "scan-b",
+			Type:       FindingRepoMisconfig,
+			Severity:   SeverityMedium,
+			Repository: "owner/repo",
+			FilePath:   ".github/workflows/build.yml",
+			LineNumber: 11,
+			Detector:   "workflow_unpinned_third_party_action",
+			CreatedAt:  now.Add(time.Minute),
+		},
+	}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
+
+	if countNodes(graph, RepoRiskNodeFinding) != 2 {
+		t.Fatalf("expected duplicate finding ids from separate scans to remain separate nodes, got %+v", graph.Nodes)
+	}
+	nodeIDs := map[string]struct{}{}
+	for _, score := range graph.Scores {
+		if score.FindingID != "same-finding" {
+			t.Fatalf("expected original finding id to be preserved, got %+v", score)
+		}
+		if score.FindingNodeID == "" {
+			t.Fatalf("expected score to link to a graph node, got %+v", score)
+		}
+		nodeIDs[score.FindingNodeID] = struct{}{}
+		assertGraphNodeID(t, graph, score.FindingNodeID)
+	}
+	if len(nodeIDs) != 2 {
+		t.Fatalf("expected scan-aware score node links, got %+v", graph.Scores)
+	}
+}
+
+func TestBuildRepoRiskGraphDoesNotScoreEmptyWriteScopes(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	graph := BuildRepoRiskGraph([]Finding{{
+		ID:         "empty-write-scopes",
+		Type:       FindingRepoMisconfig,
+		Severity:   SeverityMedium,
+		Repository: "owner/repo",
+		FilePath:   ".github/workflows/build.yml",
+		Detector:   "workflow_broad_token_permissions",
+		CreatedAt:  now,
+		Evidence: map[string]any{
+			"write_scopes": []string{},
+		},
+	}}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
+
+	score := scoreForFinding(t, graph, "empty-write-scopes")
+	if score.Factors.Privilege != 0 {
+		t.Fatalf("expected empty write_scopes not to add privilege, got %+v", score.Factors)
+	}
+}
+
 func assertGraphNode(t *testing.T, graph RepoRiskGraph, kind RepoRiskGraphNodeKind, label string) {
 	t.Helper()
 	for _, node := range graph.Nodes {
@@ -231,6 +339,16 @@ func assertGraphEdge(t *testing.T, graph RepoRiskGraph, kind RepoRiskGraphEdgeKi
 	t.Fatalf("expected edge kind=%s state=%s in %+v", kind, state, graph.Edges)
 }
 
+func assertGraphNodeID(t *testing.T, graph RepoRiskGraph, id string) {
+	t.Helper()
+	for _, node := range graph.Nodes {
+		if node.ID == id {
+			return
+		}
+	}
+	t.Fatalf("expected graph node id %q in %+v", id, graph.Nodes)
+}
+
 func scoreForFinding(t *testing.T, graph RepoRiskGraph, findingID string) RepoRiskGraphFindingScore {
 	t.Helper()
 	for _, score := range graph.Scores {
@@ -240,6 +358,16 @@ func scoreForFinding(t *testing.T, graph RepoRiskGraph, findingID string) RepoRi
 	}
 	t.Fatalf("expected score for finding %q in %+v", findingID, graph.Scores)
 	return RepoRiskGraphFindingScore{}
+}
+
+func countNodes(graph RepoRiskGraph, kind RepoRiskGraphNodeKind) int {
+	count := 0
+	for _, node := range graph.Nodes {
+		if node.Kind == kind {
+			count++
+		}
+	}
+	return count
 }
 
 func countEdges(graph RepoRiskGraph, kind RepoRiskGraphEdgeKind) int {

--- a/internal/domain/repo_risk_graph_test.go
+++ b/internal/domain/repo_risk_graph_test.go
@@ -1,0 +1,253 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBuildRepoRiskGraphLinksWorkflowOIDCBlastRadius(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	graph := BuildRepoRiskGraph([]Finding{
+		{
+			ID:              "finding-oidc",
+			Type:            FindingRepoMisconfig,
+			Severity:        SeverityHigh,
+			ConfidenceScore: 0.92,
+			Title:           "GitHub Actions OIDC trust can mint deployment credentials",
+			Repository:      "owner/repo",
+			FilePath:        ".github/workflows/deploy.yml",
+			LineNumber:      17,
+			Detector:        "workflow_oidc_broad_trust",
+			CreatedAt:       now.Add(-2 * time.Hour),
+			Evidence: map[string]any{
+				"workflow_events":    []string{"push"},
+				"workflow_job":       "deploy",
+				"permission_summary": "contents:read,id-token:write",
+				"cloud_auth_action":  "aws-actions/configure-aws-credentials@v4",
+				"oidc_risk_context":  "broad_push_event",
+				"aws_role_arn":       "arn:aws:iam::123456789012:role/prod-deploy",
+				"environment":        "production",
+			},
+		},
+	}, RepoRiskGraphOptions{
+		Repository:    "owner/repo",
+		DefaultBranch: "main",
+		Now:           now,
+	})
+
+	assertGraphNode(t, graph, RepoRiskNodeRepository, "owner/repo")
+	assertGraphNode(t, graph, RepoRiskNodeDefaultBranch, "main")
+	assertGraphNode(t, graph, RepoRiskNodeWorkflow, ".github/workflows/deploy.yml")
+	assertGraphNode(t, graph, RepoRiskNodeWorkflowJob, "deploy")
+	assertGraphNode(t, graph, RepoRiskNodeOIDCSubject, "repo:owner/repo:ref:*:job:deploy")
+	assertGraphNode(t, graph, RepoRiskNodeCloudRole, "arn:aws:iam::123456789012:role/prod-deploy")
+	assertGraphNode(t, graph, RepoRiskNodeEnvironment, "production")
+
+	assertGraphEdge(t, graph, RepoRiskEdgeWorkflowCanMintToken, RepoRiskEvidenceKnown)
+	assertGraphEdge(t, graph, RepoRiskEdgeOIDCCanAssumeRole, RepoRiskEvidenceKnown)
+	assertGraphEdge(t, graph, RepoRiskEdgeRepoDeploysEnvironment, RepoRiskEvidenceKnown)
+
+	score := scoreForFinding(t, graph, "finding-oidc")
+	if score.Score < 70 {
+		t.Fatalf("expected graph-aware OIDC score to be high risk, got %+v", score)
+	}
+	if score.Factors.Privilege == 0 || score.Factors.Exposure == 0 || score.Factors.EnvironmentCriticality == 0 {
+		t.Fatalf("expected score to include privilege, exposure, and environment factors, got %+v", score.Factors)
+	}
+}
+
+func TestBuildRepoRiskGraphRepresentsUnknownOIDCTargetWithoutGuessing(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	graph := BuildRepoRiskGraph([]Finding{
+		{
+			ID:         "finding-unknown-oidc",
+			Type:       FindingRepoMisconfig,
+			Severity:   SeverityHigh,
+			Repository: "owner/repo",
+			FilePath:   ".github/workflows/deploy.yml",
+			Detector:   "workflow_oidc_broad_trust",
+			CreatedAt:  now,
+			Evidence: map[string]any{
+				"workflow_events":    []string{"workflow_run"},
+				"permission_summary": "id-token:write",
+				"oidc_risk_context":  "workflow_run",
+			},
+		},
+	}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
+
+	assertGraphNode(t, graph, RepoRiskNodeUnknown, "unknown cloud role")
+	assertGraphEdge(t, graph, RepoRiskEdgeReachabilityUnknown, RepoRiskEvidenceUnknown)
+
+	for _, node := range graph.Nodes {
+		if node.Kind == RepoRiskNodeCloudRole {
+			t.Fatalf("expected missing OIDC role evidence to remain unknown instead of guessed, got %+v", node)
+		}
+	}
+
+	score := scoreForFinding(t, graph, "finding-unknown-oidc")
+	if len(score.Unknowns) != 2 || score.Unknowns[0] != "identity_target" || score.Unknowns[1] != "workflow_job" {
+		t.Fatalf("expected identity target and workflow job unknowns, got %+v", score.Unknowns)
+	}
+}
+
+func TestBuildRepoRiskGraphDedupesRepeatedEdges(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	graph := BuildRepoRiskGraph([]Finding{
+		{
+			ID:         "finding-one",
+			Type:       FindingRepoMisconfig,
+			Severity:   SeverityHigh,
+			Repository: "owner/repo",
+			FilePath:   ".github/workflows/deploy.yml",
+			Detector:   "workflow_pull_request_target_privileged_context",
+			CreatedAt:  now,
+			Evidence: map[string]any{
+				"workflow_events":    []string{"pull_request_target"},
+				"workflow_job":       "release",
+				"references_secrets": true,
+			},
+		},
+		{
+			ID:         "finding-two",
+			Type:       FindingRepoMisconfig,
+			Severity:   SeverityHigh,
+			Repository: "owner/repo",
+			FilePath:   ".github/workflows/deploy.yml",
+			Detector:   "workflow_pull_request_target_privileged_context",
+			CreatedAt:  now,
+			Evidence: map[string]any{
+				"workflow_events":    []string{"pull_request_target"},
+				"workflow_job":       "release",
+				"references_secrets": true,
+			},
+		},
+	}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
+
+	seen := map[string]struct{}{}
+	for _, edge := range graph.Edges {
+		if _, exists := seen[edge.ID]; exists {
+			t.Fatalf("duplicate edge id %q in %+v", edge.ID, graph.Edges)
+		}
+		seen[edge.ID] = struct{}{}
+	}
+	if countEdges(graph, RepoRiskEdgeWorkflowRunsJob) != 1 {
+		t.Fatalf("expected shared workflow->job edge to dedupe, got %+v", graph.Edges)
+	}
+	if countEdges(graph, RepoRiskEdgeJobUsesSecret) != 1 {
+		t.Fatalf("expected shared job->secret edge to dedupe, got %+v", graph.Edges)
+	}
+}
+
+func TestBuildRepoRiskGraphScoresSecretExposureAboveLowUnknownFinding(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	graph := BuildRepoRiskGraph([]Finding{
+		{
+			ID:              "secret-finding",
+			Type:            FindingSecretExposure,
+			Severity:        SeverityCritical,
+			ConfidenceScore: 0.99,
+			Repository:      "owner/repo",
+			FilePath:        "config/prod.env",
+			Detector:        "github_pat",
+			CreatedAt:       now.Add(-1 * time.Hour),
+			Evidence: map[string]any{
+				"secret_fingerprint": "fp-prod-token",
+				"raw_secret_stored":  false,
+			},
+		},
+		{
+			ID:         "low-finding",
+			Type:       FindingRepoMisconfig,
+			Severity:   SeverityLow,
+			Repository: "owner/repo",
+			FilePath:   "Dockerfile",
+			Detector:   "docker_latest_tag",
+			CreatedAt:  now.Add(-120 * 24 * time.Hour),
+		},
+	}, RepoRiskGraphOptions{Repository: "owner/repo", Now: now})
+
+	secretScore := scoreForFinding(t, graph, "secret-finding")
+	lowScore := scoreForFinding(t, graph, "low-finding")
+	if secretScore.Score <= lowScore.Score {
+		t.Fatalf("expected exposed credential score to outrank low finding, secret=%+v low=%+v", secretScore, lowScore)
+	}
+	if secretScore.Factors.Confidence != 99 || secretScore.Factors.Exploitability == 0 || secretScore.Factors.Privilege == 0 {
+		t.Fatalf("expected secret score factors to include confidence, exploitability, and privilege, got %+v", secretScore.Factors)
+	}
+	assertGraphNode(t, graph, RepoRiskNodeToken, "secret-fingerprint:fp-prod-token")
+	assertGraphEdge(t, graph, RepoRiskEdgeFindingExposesToken, RepoRiskEvidenceKnown)
+}
+
+func TestBuildRepoRiskGraphKeepsMultipleRepositoriesSeparate(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	graph := BuildRepoRiskGraph([]Finding{
+		{
+			ID:         "repo-a-finding",
+			Type:       FindingRepoMisconfig,
+			Severity:   SeverityMedium,
+			Repository: "owner/repo-a",
+			FilePath:   ".github/workflows/build.yml",
+			Detector:   "workflow_unpinned_third_party_action",
+			CreatedAt:  now,
+		},
+		{
+			ID:         "repo-b-finding",
+			Type:       FindingRepoMisconfig,
+			Severity:   SeverityMedium,
+			Repository: "owner/repo-b",
+			FilePath:   ".github/workflows/deploy.yml",
+			Detector:   "workflow_unpinned_third_party_action",
+			CreatedAt:  now,
+		},
+	}, RepoRiskGraphOptions{Now: now})
+
+	if graph.Repository != "" {
+		t.Fatalf("expected mixed-repository graph not to claim one repository, got %q", graph.Repository)
+	}
+	assertGraphNode(t, graph, RepoRiskNodeRepository, "owner/repo-a")
+	assertGraphNode(t, graph, RepoRiskNodeRepository, "owner/repo-b")
+	if countEdges(graph, RepoRiskEdgeFindingInRepository) != 2 {
+		t.Fatalf("expected each finding to link to its own repository, got %+v", graph.Edges)
+	}
+}
+
+func assertGraphNode(t *testing.T, graph RepoRiskGraph, kind RepoRiskGraphNodeKind, label string) {
+	t.Helper()
+	for _, node := range graph.Nodes {
+		if node.Kind == kind && node.Label == label {
+			return
+		}
+	}
+	t.Fatalf("expected node kind=%s label=%q in %+v", kind, label, graph.Nodes)
+}
+
+func assertGraphEdge(t *testing.T, graph RepoRiskGraph, kind RepoRiskGraphEdgeKind, state RepoRiskGraphEvidenceState) {
+	t.Helper()
+	for _, edge := range graph.Edges {
+		if edge.Kind == kind && edge.EvidenceState == state {
+			return
+		}
+	}
+	t.Fatalf("expected edge kind=%s state=%s in %+v", kind, state, graph.Edges)
+}
+
+func scoreForFinding(t *testing.T, graph RepoRiskGraph, findingID string) RepoRiskGraphFindingScore {
+	t.Helper()
+	for _, score := range graph.Scores {
+		if score.FindingID == findingID {
+			return score
+		}
+	}
+	t.Fatalf("expected score for finding %q in %+v", findingID, graph.Scores)
+	return RepoRiskGraphFindingScore{}
+}
+
+func countEdges(graph RepoRiskGraph, kind RepoRiskGraphEdgeKind) int {
+	count := 0
+	for _, edge := range graph.Edges {
+		if edge.Kind == kind {
+			count++
+		}
+	}
+	return count
+}


### PR DESCRIPTION
Fixes #1233

## What changed
- Added a deterministic `domain.RepoRiskGraph` model that maps repository findings to repository, default branch, workflow, job, environment, secret/token, OIDC subject, cloud role, Kubernetes service-account, GitHub App, deploy-key, and unknown evidence nodes.
- Added graph edges for finding ownership, workflow/job reachability, secret usage, exposed credentials, OIDC token minting, OIDC role assumption, environment deployment, identity references, and unknown reachability.
- Added graph-aware finding scores with inspectable severity, confidence, exploitability, privilege, exposure, environment criticality, and freshness factors.
- Exposed `GET /v1/repo-risk-graph` behind the existing `repo_scans.read` policy and documented the endpoint in the OpenAPI contract.
- Added repository filtering to repo finding store queries so graph requests can stay scoped without scanning unrelated workspace findings.
- Documented the graph evidence model and its limits in the repository exposure scanner guide.

## Why
The GitHub scanner should explain what a repository finding can reach, not only list isolated findings. This gives Identrail a durable backend model for machine-identity blast radius while preserving an important safety rule: missing evidence is represented as `unknown`, not guessed.

## Impact and risk
This is additive. Existing repo scan and repo finding APIs keep their current response shapes. The new graph endpoint reads existing repository finding evidence and returns a derived graph. The store-level repository filter is backward-compatible because it is optional and defaults to the existing behavior.

## Validation
- `go test ./internal/domain ./internal/db ./internal/api`
- `go test ./...`
- `go vet ./...`
- `go test ./... -coverprofile=coverage.out`
- `go tool cover -func=coverage.out` (total: 80.3%)
- Local commit hook checks passed: merge conflicts, YAML, EOF, whitespace, gofmt, Vercel artifact hygiene.
- Push hook checks passed: merge conflicts, YAML, EOF, whitespace, gofmt, go vet, local env token hygiene, Vercel artifact hygiene.

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic GitHub repo risk graph that links findings to workflows, credentials, and identities, with graph-aware scoring and deduped edges. Exposes `GET /v1/repo-risk-graph` to explain blast radius and aligns with Linear 1233.

- **New Features**
  - New `RepoRiskGraph` model with nodes for repository, default branch, finding, workflow, job, environment, secret/token, OIDC subject, cloud role, Kubernetes service-account, GitHub App, deploy key, and unknown.
  - Edges for repository ownership, workflow/job reachability, secret usage, exposed credentials, OIDC minting, role assumption, environment deployment, identity references, and unknown reachability; edges are deduplicated.
  - Graph-aware scores with factors for severity, confidence, exploitability, privilege, exposure, environment criticality, and freshness; unknowns are listed. Freshness uses the service clock.
  - New endpoint `GET /v1/repo-risk-graph` (under `repo_scans.read`) with filters: `repo_scan_id`, `repository`, `default_branch`, `severity`, `type`. OpenAPI and authz policy updated.
  - Store-level repository filtering added for repo findings in memory and Postgres to keep graph queries scoped.
  - Docs updated (OpenAPI, repo exposure guide, changelog). Unit, service, and router tests added.

<sup>Written for commit b3ecee908da11d43daec353ff964be0ecbebe6a6. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1259?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

