### PR TITLE
Add incremental GitHub repo scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## Unreleased
+- Added incremental repository scan execution. Repo scans now track scan mode,
+  base/head revisions, cursor before/after values, and changed paths; GitHub
+  push and pull-request webhooks enqueue delta scans when revision metadata is
+  available; scheduled policies continue to enqueue deep scans; and successful
+  scans update per-repository cursors so already-current deltas are skipped
+  before worker time is spent.
 - Added a GitHub repository risk graph domain model for repository findings.
   Repo findings can now be deterministically associated with repository,
   workflow, job, environment, secret/token, OIDC subject, cloud role,

--- a/docs/auth/github-connector.md
+++ b/docs/auth/github-connector.md
@@ -68,7 +68,14 @@ This fallback is for self-hosted GitHub Enterprise and development environments.
 
 Installation lifecycle events can mark matching connectors disconnected. Repository events are matched by installation ID and repository allowlist before queueing scans.
 
-Webhook-triggered scans still honor the repo scan allowlist and queue controls.
+Webhook-triggered scans still honor the repo scan allowlist, per-repository
+cursor, and queue controls. Push and pull-request events enqueue `delta` scans
+when GitHub supplies a usable head revision. Push events use `before` and
+`after` as the base/head revisions and fold commit `added`, `modified`, and
+`removed` paths into the scan request. Duplicate delivery IDs, burst-window
+repeats, queue pressure, disabled scanning, target-deny decisions, and
+already-current cursors are recorded as skipped work instead of creating
+unbounded duplicate queue entries.
 Before enabling `IDENTRAIL_REPO_SCAN_ENABLED=true` for hosted production, set an
 explicit `IDENTRAIL_REPO_SCAN_ALLOWLIST` or equivalent scoped target guard so a
 GitHub webhook cannot enqueue scans outside approved repositories.
@@ -91,10 +98,10 @@ API responses. The worker mints a short-lived installation token immediately
 before cloning and passes it to git through an askpass helper so the token does
 not appear in clone URLs or command-line arguments.
 
-Scheduled policy scans and GitHub webhook-triggered scans automatically attach
-the project/connector source context when they enqueue selected repositories,
-so private repositories use the same short-lived GitHub App path as manually
-queued connector-backed scans.
+Scheduled policy scans enqueue `deep` scans, while GitHub webhook-triggered
+scans attach the project/connector source context and enqueue `delta` or
+`quick` scans depending on event metadata. Private repositories use the same
+short-lived GitHub App path as manually queued connector-backed scans.
 
 ## Repository Posture Collection
 

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -17,15 +17,24 @@ API behavior:
 ## Repository Scans
 
 1. Client calls `POST /v1/repo-scans`.
-2. API validates request and enqueues repo-scan record.
+2. API validates request, scan mode, source context, allowlist, and per-repo cursor.
 3. Worker claims and executes repo scan.
 4. Repo findings and scan lifecycle records are persisted.
+5. Successful scans update the repository cursor with the scanned head revision.
+
+Scan modes:
+- `deep`: bounded full-history scan plus HEAD configuration inspection. Manual
+  API requests default to this mode and scheduled policies enqueue this mode.
+- `delta`: commit-range scan scoped by `base_revision`, `head_revision`, and
+  optional `changed_paths`. GitHub push and pull-request webhooks enqueue this
+  mode when revision metadata is present.
+- `quick`: HEAD-focused scan mode for lightweight event refreshes.
 
 API behavior:
 - `202` accepted
 - `400` invalid request
 - `403` target outside allowlist
-- `409` target already in progress
+- `409` target already in progress or delta head already matches the stored cursor
 - `429` queue full
 - `503` repo scan disabled
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -84,6 +84,7 @@ Current sequence in `migrations/`:
 31. `000028_webhook_events` - durable provider webhook idempotency ledger
 32. `000029_webhook_events_processing_status` - processing-state metadata for webhook event replay safety
 33. `000030_repo_scan_source_metadata` - non-secret repo scan source metadata for connector-backed private repository scans
+34. `000031_incremental_repo_scans` - repo scan mode/revision metadata plus per-repository scan cursors for delta and deep scan scheduling
 
 Notes:
 - Each migration has matching `.up.sql` and `.down.sql` files.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -30,6 +30,8 @@ Repository scan metrics:
 - `identrail_repo_scan_failure_total`
 - `identrail_repo_scan_truncated_total`
 - `identrail_repo_scan_duration_milliseconds`
+- `identrail_repo_scan_mode_runs_total{mode="quick|delta|deep",outcome="succeeded|failed|partial|skipped|requeued|queued"}`: bounded counter for scan-mode execution outcomes.
+- `identrail_repo_scan_skipped_total{mode="quick|delta|deep",reason="cursor_current|queue_full|in_progress|invalid_delta|disabled|target_not_allowed|throttled|replay|other"}`: bounded counter for repo scan work intentionally skipped before execution.
 
 Automation reliability metrics:
 - `identrail_queue_depth{queue="scan|repo_scan"}`: current API/worker queue backlog.
@@ -57,6 +59,7 @@ Allowed label examples:
 - Rollout labels controlled by configuration or code: `policy_source`, `policy_version`, `rollout_mode`.
 - Worker labels controlled by code constants: `queue`, `runner`, `source`.
 - Automation labels controlled by code constants: `connector`, `outcome`.
+- Repository scan labels controlled by code constants: `mode`, `reason`.
 
 Forbidden label examples:
 - Request-scoped identifiers: `request_id`, trace IDs, correlation IDs.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -3511,10 +3511,10 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "429":
           $ref: "#/components/responses/TooManyRequests"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /v1/scans/{scan_id}/replay:
     parameters:
       - $ref: "#/components/parameters/scopeTenantID"
@@ -6209,6 +6209,25 @@ components:
         files_scanned: { type: integer }
         finding_count: { type: integer }
         truncated: { type: boolean }
+        scan_mode:
+          type: string
+          enum: [quick, delta, deep]
+        base_revision:
+          type: string
+          description: Base git revision used for delta scans.
+        head_revision:
+          type: string
+          description: Resolved head git revision scanned.
+        cursor_before:
+          type: string
+          description: Stored repository cursor before the scan was queued or started.
+        cursor_after:
+          type: string
+          description: Repository cursor written after a successful scan.
+        changed_paths:
+          type: array
+          items: { type: string }
+          description: Normalized path list supplied by webhook or request metadata for delta scans.
         error_message: { type: string }
     RepoScanRequest:
       type: object
@@ -6221,6 +6240,20 @@ components:
         connector_id:
           type: string
           description: Optional connector id for connector-backed scans. Defaults to the project's standard GitHub App connector.
+        scan_mode:
+          type: string
+          enum: [quick, delta, deep]
+          description: Optional scan mode. Manual API requests default to deep. Delta scans require head_revision.
+        base_revision:
+          type: string
+          description: Optional base git revision for delta scans.
+        head_revision:
+          type: string
+          description: Required head git revision for delta scans.
+        changed_paths:
+          type: array
+          items: { type: string }
+          description: Optional normalized changed path list used to scope delta history and HEAD file inspection.
         history_limit:
           type: integer
           minimum: 1

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -323,12 +323,32 @@ workflow layer.
 - External adapter evidence stores normalized metadata only and explicitly
   records `raw_adapter_result_stored: false`.
 - Repo scan metadata/findings are persisted in dedicated storage (`repo_scans`, `repo_findings`) to avoid changing existing cloud scan APIs.
+- Repo scan records now include `scan_mode`, base/head revision, cursor before
+  and after values, changed paths, and truncation status. Successful scans also
+  update a scoped `repo_scan_cursors` row so repeated delta requests at the
+  same head revision can be skipped before worker time is spent.
 - GitHub App private-repo scans persist only non-secret connector context
   (`source_provider`, project id, connector id, installation id). The worker
   mints the short-lived installation token at execution time and passes it to
   git through `GIT_ASKPASS`, not through clone URLs, process arguments,
   findings, scan rows, logs, or API responses.
 - Snapshot-based repo misconfiguration findings now persist the resolved HEAD commit SHA on new scans so GitHub links stay pinned to the scanned revision.
+
+## Scan Modes
+
+- `deep`: full bounded history scan plus HEAD configuration inspection. Manual
+  API requests and scheduled scan policies use this mode unless a request
+  explicitly asks for another mode.
+- `delta`: commit-range scan for `base_revision..head_revision`, with optional
+  `changed_paths` used as a git pathspec and as the HEAD file-inspection scope.
+  Push and pull-request webhooks enqueue this mode only when the webhook payload
+  includes enough revision metadata.
+- `quick`: HEAD/configuration-focused scan mode for event types that should
+  refresh repository posture without replaying commit history.
+
+Delta scans require `head_revision`. If the stored cursor already matches the
+requested head revision, the API returns a conflict and the webhook path records
+the scan as skipped instead of queueing duplicate work.
 
 ## Useful Flags
 

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -40,9 +40,10 @@ The worker runs scans on a schedule and drains API-enqueued jobs.
 - Uses same persistence flow as API-triggered scan
 - Skips overlapping runs via existing service lock
 - Optional repo scan scheduler is additive and disabled by default
-- Project scan policies with `scheduled` or `hybrid` trigger mode are checked periodically. The worker claims each due cron tick before enqueueing selected GitHub repositories, so missed ticks recover on the next worker pass and concurrent workers do not duplicate the same policy run.
+- Project scan policies with `scheduled` or `hybrid` trigger mode are checked periodically. The worker claims each due cron tick before enqueueing selected GitHub repositories as `deep` repo scans, so missed ticks recover on the next worker pass and concurrent workers do not duplicate the same policy run.
 - API `POST /v1/scans` and `POST /v1/repo-scans` enqueue work; worker queue runner executes queued jobs asynchronously
 - Queue runner applies bounded batch processing per tick (`IDENTRAIL_WORKER_API_JOB_QUEUE_BATCH_SIZE`)
 - Heartbeat files are written at worker startup and before each configured runner tick when `IDENTRAIL_WORKER_HEARTBEAT_PATH` is set. Supervisors can alert when the file timestamp stops advancing.
 - Repo scans use per-target lock key (`repo-scan:<target>`) to avoid overlap between API and worker triggers
+- Successful repo scans update per-repository cursors; queued `delta` scans whose head revision already matches the cursor are skipped before execution.
 - In database mode, `IDENTRAIL_LOCK_BACKEND=auto` uses PostgreSQL advisory locks for multi-instance safety

--- a/internal/api/enterprise_report_routes_test.go
+++ b/internal/api/enterprise_report_routes_test.go
@@ -51,7 +51,7 @@ func seedExecReportFinding(t *testing.T, store db.Store, scope db.Scope, scanID,
 func seedExecReportRepoFinding(t *testing.T, store db.Store, scope db.Scope, repo, id string, sev domain.FindingSeverity, typ domain.FindingType, createdAt time.Time, resolvedAt *time.Time) {
 	t.Helper()
 	ctx := db.WithScope(context.Background(), scope)
-	repoScan, err := store.CreateRepoScan(ctx, repo, db.RepoScanSource{}, createdAt)
+	repoScan, err := store.CreateRepoScan(ctx, repo, db.RepoScanSource{}, db.RepoScanContext{}, createdAt)
 	if err != nil {
 		t.Fatalf("create repo scan for %s: %v", id, err)
 	}

--- a/internal/api/github_connect.go
+++ b/internal/api/github_connect.go
@@ -270,10 +270,16 @@ type githubWebhookEnvelope struct {
 	} `json:"commits"`
 	PullRequest struct {
 		Base struct {
-			SHA string `json:"sha"`
+			SHA  string `json:"sha"`
+			Repo struct {
+				FullName string `json:"full_name"`
+			} `json:"repo"`
 		} `json:"base"`
 		Head struct {
-			SHA string `json:"sha"`
+			SHA  string `json:"sha"`
+			Repo struct {
+				FullName string `json:"full_name"`
+			} `json:"repo"`
 		} `json:"head"`
 	} `json:"pull_request"`
 	Repository struct {
@@ -2050,6 +2056,9 @@ func githubWebhookRepoScanContext(eventType string, envelope githubWebhookEnvelo
 			ChangedPaths: githubWebhookChangedPaths(envelope),
 		}), true
 	case "pull_request":
+		if !githubPullRequestHeadAvailableInBaseRepo(envelope) {
+			return db.NormalizeRepoScanContext(db.RepoScanContext{ScanMode: db.RepoScanModeQuick}), true
+		}
 		headRevision := strings.TrimSpace(envelope.PullRequest.Head.SHA)
 		if headRevision == "" || webhookZeroRevision(headRevision) {
 			return db.NormalizeRepoScanContext(db.RepoScanContext{ScanMode: db.RepoScanModeDelta}), false
@@ -2069,6 +2078,23 @@ func githubWebhookRepoScanContext(eventType string, envelope githubWebhookEnvelo
 	default:
 		return db.NormalizeRepoScanContext(db.RepoScanContext{ScanMode: db.RepoScanModeDeep}), false
 	}
+}
+
+func githubPullRequestHeadAvailableInBaseRepo(envelope githubWebhookEnvelope) bool {
+	baseRepo := strings.TrimSpace(envelope.PullRequest.Base.Repo.FullName)
+	if baseRepo == "" {
+		baseRepo = strings.TrimSpace(envelope.Repository.FullName)
+	}
+	headRepo := strings.TrimSpace(envelope.PullRequest.Head.Repo.FullName)
+	if baseRepo == "" || headRepo == "" {
+		return true
+	}
+	normalizedBase := normalizeGitHubRepositoryPath(baseRepo)
+	normalizedHead := normalizeGitHubRepositoryPath(headRepo)
+	if normalizedBase == "" || normalizedHead == "" {
+		return strings.EqualFold(baseRepo, headRepo)
+	}
+	return strings.EqualFold(normalizedBase, normalizedHead)
 }
 
 func githubWebhookChangedPaths(envelope githubWebhookEnvelope) []string {

--- a/internal/api/github_connect.go
+++ b/internal/api/github_connect.go
@@ -259,6 +259,23 @@ type githubProjectConnection struct {
 }
 
 type githubWebhookEnvelope struct {
+	Before  string `json:"before"`
+	After   string `json:"after"`
+	Deleted bool   `json:"deleted"`
+	Commits []struct {
+		ID       string   `json:"id"`
+		Added    []string `json:"added"`
+		Modified []string `json:"modified"`
+		Removed  []string `json:"removed"`
+	} `json:"commits"`
+	PullRequest struct {
+		Base struct {
+			SHA string `json:"sha"`
+		} `json:"base"`
+		Head struct {
+			SHA string `json:"sha"`
+		} `json:"head"`
+	} `json:"pull_request"`
 	Repository struct {
 		FullName string `json:"full_name"`
 	} `json:"repository"`
@@ -965,7 +982,8 @@ func (s *Service) HandleGitHubWebhook(ctx context.Context, eventType string, del
 		return GitHubWebhookResult{}, ErrGitHubWebhookSignatureInvalid
 	}
 
-	result, err := s.processGitHubWebhookConnections(ctx, span, normalizedEventType, deliveryID, repository, validConnections)
+	scanContext, scanContextOK := githubWebhookRepoScanContext(normalizedEventType, envelope)
+	result, err := s.processGitHubWebhookConnections(ctx, span, normalizedEventType, deliveryID, repository, scanContext, scanContextOK, validConnections)
 	if err != nil {
 		return GitHubWebhookResult{}, err
 	}
@@ -1014,10 +1032,11 @@ func (s *Service) HandleGitHubAppWebhook(ctx context.Context, eventType string, 
 	}
 	ctx, span := otel.Tracer("identrail/automation").Start(ctx, "automation.github_app_webhook")
 	defer span.End()
-	return s.processGitHubWebhookConnections(ctx, span, normalizedEventType, deliveryID, repository, candidates)
+	scanContext, scanContextOK := githubWebhookRepoScanContext(normalizedEventType, envelope)
+	return s.processGitHubWebhookConnections(ctx, span, normalizedEventType, deliveryID, repository, scanContext, scanContextOK, candidates)
 }
 
-func (s *Service) processGitHubWebhookConnections(ctx context.Context, span trace.Span, eventType string, deliveryID string, repository string, connections []githubProjectConnection) (GitHubWebhookResult, error) {
+func (s *Service) processGitHubWebhookConnections(ctx context.Context, span trace.Span, eventType string, deliveryID string, repository string, scanContext db.RepoScanContext, scanContextOK bool, connections []githubProjectConnection) (GitHubWebhookResult, error) {
 	result := GitHubWebhookResult{
 		EventType:       eventType,
 		Repository:      repository,
@@ -1033,37 +1052,53 @@ func (s *Service) processGitHubWebhookConnections(ctx context.Context, span trac
 		if replayed && scanTriggerEvent {
 			result.SkippedScans++
 			s.recordAutomationRun("event", "github", "skipped")
+			s.recordRepoScanSkipped(scanContext.ScanMode, "replay")
 			continue
 		}
 		if !scanTriggerEvent {
 			s.recordGitHubWebhookDelivery(ctx, connection, eventType, normalizedDeliveryID, now)
 			continue
 		}
+		if !scanContextOK {
+			result.SkippedScans++
+			s.recordAutomationRun("event", "github", "skipped")
+			s.recordRepoScanSkipped(scanContext.ScanMode, "invalid_delta")
+			s.recordGitHubWebhookDelivery(ctx, connection, eventType, normalizedDeliveryID, now)
+			continue
+		}
 		if s.shouldThrottleGitHubWebhookScan(connection, repository, now) {
 			result.SkippedScans++
 			s.recordAutomationRun("event", "github", "skipped")
+			s.recordRepoScanSkipped(scanContext.ScanMode, "throttled")
 			s.recordGitHubWebhookDelivery(ctx, connection, eventType, normalizedDeliveryID, now)
 			continue
 		}
 
 		scopedCtx := db.WithScope(ctx, db.Scope{TenantID: connection.TenantID, WorkspaceID: connection.WorkspaceID})
 		_, err := s.EnqueueRepoScan(scopedCtx, RepoScanRequest{
-			Repository:  repository,
-			ProjectID:   connection.ProjectID,
-			ConnectorID: firstNonEmptyString(connection.ConnectorID, githubConnectorID),
+			Repository:   repository,
+			ProjectID:    connection.ProjectID,
+			ConnectorID:  firstNonEmptyString(connection.ConnectorID, githubConnectorID),
+			ScanMode:     scanContext.ScanMode,
+			BaseRevision: scanContext.BaseRevision,
+			HeadRevision: scanContext.HeadRevision,
+			ChangedPaths: append([]string(nil), scanContext.ChangedPaths...),
 		})
 		if err != nil {
 			if errors.Is(err, ErrRepoScanQueueFull) {
 				result.SkippedScans++
 				s.recordAutomationRun("event", "github", "skipped")
+				s.recordRepoScanSkipped(scanContext.ScanMode, "queue_full")
 				continue
 			}
 			if errors.Is(err, ErrRepoScanInProgress) ||
+				errors.Is(err, ErrRepoScanAlreadyCurrent) ||
 				errors.Is(err, ErrRepoScanDisabled) ||
 				errors.Is(err, ErrRepoTargetNotAllowed) ||
 				errors.Is(err, ErrInvalidRepoScanRequest) {
 				result.SkippedScans++
 				s.recordAutomationRun("event", "github", "skipped")
+				s.recordRepoScanSkipped(scanContext.ScanMode, repoScanWebhookSkipReason(err))
 				s.recordGitHubWebhookDelivery(ctx, connection, eventType, normalizedDeliveryID, now)
 				continue
 			}
@@ -1995,6 +2030,76 @@ func githubWebhookTriggersScan(eventType string) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+func githubWebhookRepoScanContext(eventType string, envelope githubWebhookEnvelope) (db.RepoScanContext, bool) {
+	switch strings.ToLower(strings.TrimSpace(eventType)) {
+	case "push":
+		if envelope.Deleted || strings.TrimSpace(envelope.After) == "" || webhookZeroRevision(envelope.After) {
+			return db.NormalizeRepoScanContext(db.RepoScanContext{ScanMode: db.RepoScanModeDelta}), false
+		}
+		baseRevision := strings.TrimSpace(envelope.Before)
+		if webhookZeroRevision(baseRevision) {
+			baseRevision = ""
+		}
+		return db.NormalizeRepoScanContext(db.RepoScanContext{
+			ScanMode:     db.RepoScanModeDelta,
+			BaseRevision: baseRevision,
+			HeadRevision: envelope.After,
+			ChangedPaths: githubWebhookChangedPaths(envelope),
+		}), true
+	case "pull_request":
+		headRevision := strings.TrimSpace(envelope.PullRequest.Head.SHA)
+		if headRevision == "" || webhookZeroRevision(headRevision) {
+			return db.NormalizeRepoScanContext(db.RepoScanContext{ScanMode: db.RepoScanModeDelta}), false
+		}
+		baseRevision := strings.TrimSpace(envelope.PullRequest.Base.SHA)
+		if webhookZeroRevision(baseRevision) {
+			baseRevision = ""
+		}
+		return db.NormalizeRepoScanContext(db.RepoScanContext{
+			ScanMode:     db.RepoScanModeDelta,
+			BaseRevision: baseRevision,
+			HeadRevision: headRevision,
+			ChangedPaths: githubWebhookChangedPaths(envelope),
+		}), true
+	case "repository_dispatch", "workflow_dispatch":
+		return db.NormalizeRepoScanContext(db.RepoScanContext{ScanMode: db.RepoScanModeQuick}), true
+	default:
+		return db.NormalizeRepoScanContext(db.RepoScanContext{ScanMode: db.RepoScanModeDeep}), false
+	}
+}
+
+func githubWebhookChangedPaths(envelope githubWebhookEnvelope) []string {
+	paths := []string{}
+	for _, commit := range envelope.Commits {
+		paths = append(paths, commit.Added...)
+		paths = append(paths, commit.Modified...)
+		paths = append(paths, commit.Removed...)
+	}
+	return db.NormalizeRepoScanContext(db.RepoScanContext{ChangedPaths: paths}).ChangedPaths
+}
+
+func webhookZeroRevision(revision string) bool {
+	trimmed := strings.TrimSpace(revision)
+	return len(trimmed) >= 40 && strings.Trim(trimmed, "0") == ""
+}
+
+func repoScanWebhookSkipReason(err error) string {
+	switch {
+	case errors.Is(err, ErrRepoScanInProgress):
+		return "in_progress"
+	case errors.Is(err, ErrRepoScanAlreadyCurrent):
+		return "cursor_current"
+	case errors.Is(err, ErrRepoScanDisabled):
+		return "disabled"
+	case errors.Is(err, ErrRepoTargetNotAllowed):
+		return "target_not_allowed"
+	case errors.Is(err, ErrInvalidRepoScanRequest):
+		return "invalid_delta"
+	default:
+		return "other"
 	}
 }
 

--- a/internal/api/github_connect_test.go
+++ b/internal/api/github_connect_test.go
@@ -423,7 +423,7 @@ func TestHandleGitHubWebhookReplayDeliverySkipsDuplicateScan(t *testing.T) {
 	if len(claimed.ChangedPaths) != 2 {
 		t.Fatalf("expected push webhook changed paths, got %+v", claimed.ChangedPaths)
 	}
-	if err := store.CompleteRepoScan(ctx, claimed.ID, "succeeded", now, 1, 1, 0, false, "", ""); err != nil {
+	if err := store.CompleteRepoScan(ctx, claimed.ID, "succeeded", now, 1, 1, 0, false, db.RepoScanContext{}, ""); err != nil {
 		t.Fatalf("complete claimed repo scan: %v", err)
 	}
 
@@ -855,7 +855,7 @@ func TestHandleGitHubWebhookBurstControlSkipsRapidRepeatedQueues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("claim queued repo scan: %v", err)
 	}
-	if err := store.CompleteRepoScan(ctx, claimed.ID, "succeeded", now, 1, 1, 0, false, "", ""); err != nil {
+	if err := store.CompleteRepoScan(ctx, claimed.ID, "succeeded", now, 1, 1, 0, false, db.RepoScanContext{}, ""); err != nil {
 		t.Fatalf("complete claimed repo scan: %v", err)
 	}
 

--- a/internal/api/github_connect_test.go
+++ b/internal/api/github_connect_test.go
@@ -69,6 +69,40 @@ func TestGitHubWebhookTriggersScan(t *testing.T) {
 	}
 }
 
+func TestGitHubWebhookRepoScanContextPullRequestSameRepoDelta(t *testing.T) {
+	var envelope githubWebhookEnvelope
+	envelope.Repository.FullName = "owner/repo"
+	envelope.PullRequest.Base.SHA = "1111111111111111111111111111111111111111"
+	envelope.PullRequest.Base.Repo.FullName = "owner/repo"
+	envelope.PullRequest.Head.SHA = "2222222222222222222222222222222222222222"
+	envelope.PullRequest.Head.Repo.FullName = "owner/repo"
+
+	scanContext, ok := githubWebhookRepoScanContext("pull_request", envelope)
+	if !ok {
+		t.Fatal("expected same-repo pull_request webhook to queue a scan")
+	}
+	if scanContext.ScanMode != db.RepoScanModeDelta || scanContext.BaseRevision != envelope.PullRequest.Base.SHA || scanContext.HeadRevision != envelope.PullRequest.Head.SHA {
+		t.Fatalf("expected same-repo pull_request to queue delta scan, got %+v", scanContext)
+	}
+}
+
+func TestGitHubWebhookRepoScanContextPullRequestForkFallsBackToQuick(t *testing.T) {
+	var envelope githubWebhookEnvelope
+	envelope.Repository.FullName = "owner/repo"
+	envelope.PullRequest.Base.SHA = "1111111111111111111111111111111111111111"
+	envelope.PullRequest.Base.Repo.FullName = "owner/repo"
+	envelope.PullRequest.Head.SHA = "2222222222222222222222222222222222222222"
+	envelope.PullRequest.Head.Repo.FullName = "contributor/repo"
+
+	scanContext, ok := githubWebhookRepoScanContext("pull_request", envelope)
+	if !ok {
+		t.Fatal("expected fork pull_request webhook to queue fallback scan")
+	}
+	if scanContext.ScanMode != db.RepoScanModeQuick || scanContext.HeadRevision != "" || scanContext.BaseRevision != "" {
+		t.Fatalf("expected fork pull_request to fall back to quick scan, got %+v", scanContext)
+	}
+}
+
 func TestValidateGitHubWebhookSignature(t *testing.T) {
 	payload := []byte(`{"test":true}`)
 

--- a/internal/api/github_connect_test.go
+++ b/internal/api/github_connect_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -47,6 +48,10 @@ func TestParseGitHubInstallationID(t *testing.T) {
 			t.Errorf("parseGitHubInstallationID(%q) = %d, want %d", tc.input, got, tc.wantID)
 		}
 	}
+}
+
+func githubPushWebhookPayload(repository string, installationID int64) []byte {
+	return []byte(fmt.Sprintf(`{"before":"1111111111111111111111111111111111111111","after":"2222222222222222222222222222222222222222","commits":[{"id":"2222222222222222222222222222222222222222","added":["app.env"],"modified":[".github/workflows/build.yml"],"removed":[]}],"repository":{"full_name":%q},"installation":{"id":%d}}`, repository, installationID))
 }
 
 func TestGitHubWebhookTriggersScan(t *testing.T) {
@@ -198,7 +203,7 @@ func TestGitHubConnectionEncryptsAndRotatesWebhookSecret(t *testing.T) {
 		t.Fatalf("expected freshly rotated secret to not require immediate rotation, got %+v", rotateBody.Connection)
 	}
 
-	webhookPayload := []byte(`{"repository":{"full_name":"owner/repo"},"installation":{"id":77}}`)
+	webhookPayload := githubPushWebhookPayload("owner/repo", 77)
 	if _, err := svc.HandleGitHubWebhook(
 		httptest.NewRequest(http.MethodPost, "/webhooks/github", nil).Context(),
 		"installation",
@@ -332,7 +337,7 @@ func TestGitHubConnectionPersistsAcrossServiceInstances(t *testing.T) {
 		t.Fatalf("expected installation id 77, got %+v", connection)
 	}
 
-	webhookPayload := []byte(`{"repository":{"full_name":"owner/repo"},"installation":{"id":77}}`)
+	webhookPayload := githubPushWebhookPayload("owner/repo", 77)
 	webhookResult, err := svcB.HandleGitHubWebhook(
 		ctx,
 		"installation",
@@ -398,7 +403,7 @@ func TestHandleGitHubWebhookReplayDeliverySkipsDuplicateScan(t *testing.T) {
 		t.Fatalf("complete github connection: %v", err)
 	}
 
-	webhookPayload := []byte(`{"repository":{"full_name":"owner/repo"},"installation":{"id":77}}`)
+	webhookPayload := githubPushWebhookPayload("owner/repo", 77)
 	signature := githubWebhookSignature("persisted-secret", webhookPayload)
 	first, err := svc.HandleGitHubWebhook(ctx, "push", "delivery-1", signature, webhookPayload)
 	if err != nil {
@@ -412,7 +417,13 @@ func TestHandleGitHubWebhookReplayDeliverySkipsDuplicateScan(t *testing.T) {
 	if err != nil {
 		t.Fatalf("claim queued repo scan: %v", err)
 	}
-	if err := store.CompleteRepoScan(ctx, claimed.ID, "succeeded", now, 1, 1, 0, false, ""); err != nil {
+	if claimed.ScanMode != db.RepoScanModeDelta || claimed.BaseRevision == "" || claimed.HeadRevision == "" {
+		t.Fatalf("expected push webhook to queue a delta scan, got %+v", claimed)
+	}
+	if len(claimed.ChangedPaths) != 2 {
+		t.Fatalf("expected push webhook changed paths, got %+v", claimed.ChangedPaths)
+	}
+	if err := store.CompleteRepoScan(ctx, claimed.ID, "succeeded", now, 1, 1, 0, false, "", ""); err != nil {
 		t.Fatalf("complete claimed repo scan: %v", err)
 	}
 
@@ -500,7 +511,7 @@ func TestHandleGitHubWebhookReplayWindowExpiresPersistedDeliveryID(t *testing.T)
 	svc.githubWebhookSeen = map[string]time.Time{}
 	svc.githubConnectMu.Unlock()
 
-	webhookPayload := []byte(`{"repository":{"full_name":"owner/repo"},"installation":{"id":77}}`)
+	webhookPayload := githubPushWebhookPayload("owner/repo", 77)
 	signature := githubWebhookSignature("persisted-secret", webhookPayload)
 	result, err := svc.HandleGitHubWebhook(ctx, "push", "delivery-1", signature, webhookPayload)
 	if err != nil {
@@ -571,7 +582,7 @@ func TestHandleGitHubWebhookReplayWindowUsesPersistedDeliveryTimestamp(t *testin
 	svc.githubWebhookSeen = map[string]time.Time{}
 	svc.githubConnectMu.Unlock()
 
-	webhookPayload := []byte(`{"repository":{"full_name":"owner/repo"},"installation":{"id":77}}`)
+	webhookPayload := githubPushWebhookPayload("owner/repo", 77)
 	signature := githubWebhookSignature("persisted-secret", webhookPayload)
 	result, err := svc.HandleGitHubWebhook(ctx, "push", "delivery-1", signature, webhookPayload)
 	if err != nil {
@@ -587,12 +598,12 @@ type failOnceQueuedRepoStore struct {
 	failuresRemaining int
 }
 
-func (s *failOnceQueuedRepoStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, source db.RepoScanSource, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (db.RepoScanRecord, error) {
+func (s *failOnceQueuedRepoStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, source db.RepoScanSource, scanContext db.RepoScanContext, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (db.RepoScanRecord, error) {
 	if s.failuresRemaining > 0 {
 		s.failuresRemaining--
 		return db.RepoScanRecord{}, errors.New("simulated enqueue failure")
 	}
-	return s.MemoryStore.CreateQueuedRepoScanWithinLimit(ctx, repository, source, historyLimit, maxFindings, queuedAt, maxPending)
+	return s.MemoryStore.CreateQueuedRepoScanWithinLimit(ctx, repository, source, scanContext, historyLimit, maxFindings, queuedAt, maxPending)
 }
 
 type failOnceQueueFullRepoStore struct {
@@ -600,12 +611,12 @@ type failOnceQueueFullRepoStore struct {
 	failuresRemaining int
 }
 
-func (s *failOnceQueueFullRepoStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, source db.RepoScanSource, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (db.RepoScanRecord, error) {
+func (s *failOnceQueueFullRepoStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, source db.RepoScanSource, scanContext db.RepoScanContext, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (db.RepoScanRecord, error) {
 	if s.failuresRemaining > 0 {
 		s.failuresRemaining--
 		return db.RepoScanRecord{}, db.ErrQueueLimitReached
 	}
-	return s.MemoryStore.CreateQueuedRepoScanWithinLimit(ctx, repository, source, historyLimit, maxFindings, queuedAt, maxPending)
+	return s.MemoryStore.CreateQueuedRepoScanWithinLimit(ctx, repository, source, scanContext, historyLimit, maxFindings, queuedAt, maxPending)
 }
 
 func TestHandleGitHubWebhookRetryDeliveryAfterTransientEnqueueFailure(t *testing.T) {
@@ -661,7 +672,7 @@ func TestHandleGitHubWebhookRetryDeliveryAfterTransientEnqueueFailure(t *testing
 		t.Fatalf("complete github connection: %v", err)
 	}
 
-	webhookPayload := []byte(`{"repository":{"full_name":"owner/repo"},"installation":{"id":77}}`)
+	webhookPayload := githubPushWebhookPayload("owner/repo", 77)
 	signature := githubWebhookSignature("persisted-secret", webhookPayload)
 	if _, err := svc.HandleGitHubWebhook(ctx, "push", "delivery-1", signature, webhookPayload); err == nil {
 		t.Fatal("expected first webhook delivery to fail due to transient enqueue error")
@@ -745,7 +756,7 @@ func TestHandleGitHubWebhookRetryDeliveryAfterQueueFull(t *testing.T) {
 		t.Fatalf("complete github connection: %v", err)
 	}
 
-	webhookPayload := []byte(`{"repository":{"full_name":"owner/repo"},"installation":{"id":77}}`)
+	webhookPayload := githubPushWebhookPayload("owner/repo", 77)
 	signature := githubWebhookSignature("persisted-secret", webhookPayload)
 	first, err := svc.HandleGitHubWebhook(ctx, "push", "delivery-1", signature, webhookPayload)
 	if err != nil {
@@ -830,7 +841,7 @@ func TestHandleGitHubWebhookBurstControlSkipsRapidRepeatedQueues(t *testing.T) {
 		t.Fatalf("complete github connection: %v", err)
 	}
 
-	webhookPayload := []byte(`{"repository":{"full_name":"owner/repo"},"installation":{"id":88}}`)
+	webhookPayload := githubPushWebhookPayload("owner/repo", 88)
 	signature := githubWebhookSignature("burst-secret", webhookPayload)
 	first, err := svc.HandleGitHubWebhook(ctx, "push", "delivery-1", signature, webhookPayload)
 	if err != nil {
@@ -844,7 +855,7 @@ func TestHandleGitHubWebhookBurstControlSkipsRapidRepeatedQueues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("claim queued repo scan: %v", err)
 	}
-	if err := store.CompleteRepoScan(ctx, claimed.ID, "succeeded", now, 1, 1, 0, false, ""); err != nil {
+	if err := store.CompleteRepoScan(ctx, claimed.ID, "succeeded", now, 1, 1, 0, false, "", ""); err != nil {
 		t.Fatalf("complete claimed repo scan: %v", err)
 	}
 
@@ -1053,7 +1064,7 @@ func TestGitHubConnectionReloadUpdateAndRotateAfterCacheMiss(t *testing.T) {
 		t.Fatalf("expected rotated secret reference, got %+v", status)
 	}
 
-	webhookPayload := []byte(`{"repository":{"full_name":"owner/infra"},"installation":{"id":101}}`)
+	webhookPayload := githubPushWebhookPayload("owner/infra", 101)
 	if _, err := svc.HandleGitHubWebhook(
 		ctx,
 		"push",

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -143,6 +143,8 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		metrics.RepoScanSuccessTotal,
 		metrics.RepoScanFailureTotal,
 		metrics.RepoScanTruncatedTotal,
+		metrics.RepoScanModeRunsTotal,
+		metrics.RepoScanSkippedTotal,
 		metrics.RepoScanDurationMS,
 		metrics.ServiceAuthzDenialsTotal,
 		metrics.QueueDepth,
@@ -1096,6 +1098,10 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			}
 			if errors.Is(err, ErrRepoScanInProgress) {
 				c.JSON(http.StatusConflict, gin.H{"error": "repo scan already in progress"})
+				return
+			}
+			if errors.Is(err, ErrRepoScanAlreadyCurrent) {
+				c.JSON(http.StatusConflict, gin.H{"error": "repo scan already current"})
 				return
 			}
 			if errors.Is(err, ErrRepoTargetNotAllowed) {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -853,7 +853,7 @@ func TestRouterRepoFindingsCanBeFilteredByTriageState(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 5, 13, 11, 10, 0, 0, time.UTC)
 
-	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, now)
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, db.RepoScanContext{}, now)
 	if err != nil {
 		t.Fatalf("create repo scan: %v", err)
 	}
@@ -946,7 +946,7 @@ func TestRouterRepoFindingsSeveritySortUsesFullResultSet(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 5, 13, 11, 10, 0, 0, time.UTC)
 
-	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, now)
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, db.RepoScanContext{}, now)
 	if err != nil {
 		t.Fatalf("create repo scan: %v", err)
 	}
@@ -3502,7 +3502,7 @@ func TestRouterGitHubConnectionAndWebhookFlow(t *testing.T) {
 		t.Fatalf("unexpected github connection status: %+v", statusBody.Connection)
 	}
 
-	webhookPayload := []byte(`{"repository":{"full_name":"owner/repo"},"installation":{"id":123456}}`)
+	webhookPayload := githubPushWebhookPayload("owner/repo", 123456)
 	webhookReq := httptest.NewRequest(http.MethodPost, "/webhooks/github", bytes.NewReader(webhookPayload))
 	webhookReq.Header.Set("X-GitHub-Event", "push")
 	webhookReq.Header.Set("X-GitHub-Delivery", "delivery-1")
@@ -3534,6 +3534,9 @@ func TestRouterGitHubConnectionAndWebhookFlow(t *testing.T) {
 	}
 	if len(scansBody.Items) == 0 || scansBody.Items[0].Repository != "owner/repo" {
 		t.Fatalf("expected queued repo scan for owner/repo, got %+v", scansBody.Items)
+	}
+	if scansBody.Items[0].ScanMode != db.RepoScanModeDelta || scansBody.Items[0].HeadRevision == "" || len(scansBody.Items[0].ChangedPaths) == 0 {
+		t.Fatalf("expected queued delta repo scan metadata, got %+v", scansBody.Items[0])
 	}
 }
 

--- a/internal/api/scan_policy_scheduler.go
+++ b/internal/api/scan_policy_scheduler.go
@@ -137,6 +137,7 @@ func (s *Service) enqueueDueScanPolicy(ctx context.Context, store scanPolicySche
 
 		request := RepoScanRequest{
 			Repository:   repository,
+			ScanMode:     db.RepoScanModeDeep,
 			HistoryLimit: policy.HistoryLimit,
 			MaxFindings:  policy.MaxFindings,
 		}

--- a/internal/api/scan_policy_scheduler_test.go
+++ b/internal/api/scan_policy_scheduler_test.go
@@ -34,6 +34,18 @@ func TestEnqueueDueScanPoliciesRecoversLatestMissedTick(t *testing.T) {
 	if count != 2 {
 		t.Fatalf("queued repo scans = %d, want 2", count)
 	}
+	scans, err := store.ListRepoScans(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListRepoScans returned error: %v", err)
+	}
+	if len(scans) != 2 {
+		t.Fatalf("repo scans = %d, want 2", len(scans))
+	}
+	for _, scan := range scans {
+		if scan.ScanMode != db.RepoScanModeDeep {
+			t.Fatalf("scheduled policies must enqueue deep scans, got %+v", scan)
+		}
+	}
 
 	policy, err := store.GetTenancyScanPolicy(ctx, "default", "project-1", "default")
 	if err != nil {

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -83,6 +83,11 @@ type RepoScanExecutor interface {
 	ScanRepository(ctx context.Context, target string) (repoexposure.ScanResult, error)
 }
 
+// RepoScanExecutorWithOptions supports incremental repository scan execution.
+type RepoScanExecutorWithOptions interface {
+	ScanRepositoryWithOptions(ctx context.Context, target string, options repoexposure.ScanOptions) (repoexposure.ScanResult, error)
+}
+
 // RepoScannerFactory creates a repository scanner with bounded scan parameters.
 type RepoScannerFactory func(historyLimit int, maxFindings int) RepoScanExecutor
 
@@ -208,11 +213,15 @@ type RunRepoScanResult struct {
 
 // RepoScanRequest captures one repository exposure scan request.
 type RepoScanRequest struct {
-	Repository   string `json:"repository"`
-	ProjectID    string `json:"project_id,omitempty"`
-	ConnectorID  string `json:"connector_id,omitempty"`
-	HistoryLimit int    `json:"history_limit"`
-	MaxFindings  int    `json:"max_findings"`
+	Repository   string   `json:"repository"`
+	ProjectID    string   `json:"project_id,omitempty"`
+	ConnectorID  string   `json:"connector_id,omitempty"`
+	ScanMode     string   `json:"scan_mode,omitempty"`
+	BaseRevision string   `json:"base_revision,omitempty"`
+	HeadRevision string   `json:"head_revision,omitempty"`
+	ChangedPaths []string `json:"changed_paths,omitempty"`
+	HistoryLimit int      `json:"history_limit"`
+	MaxFindings  int      `json:"max_findings"`
 }
 
 // OrganizationUpsertRequest captures one tenancy organization write payload.
@@ -364,6 +373,9 @@ var ErrRepoTargetNotAllowed = errors.New("repo target is not allowed")
 
 // ErrInvalidRepoScanRequest indicates invalid repository scan request input.
 var ErrInvalidRepoScanRequest = errors.New("invalid repo scan request")
+
+// ErrRepoScanAlreadyCurrent indicates a delta scan target already matches the stored cursor.
+var ErrRepoScanAlreadyCurrent = errors.New("repo scan already current")
 
 // ErrRepoScanInProgress is returned when the same repository scan target is already running.
 var ErrRepoScanInProgress = errors.New("repo scan already in progress")
@@ -951,6 +963,18 @@ func (s *Service) recordWorkerDeadLetter(runner string) {
 	}
 }
 
+func (s *Service) recordRepoScanModeRun(mode string, outcome string) {
+	if s.Metrics != nil {
+		s.Metrics.RepoScanModeRunsTotal.WithLabelValues(repoScanModeLabel(mode), automationOutcomeLabel(outcome)).Inc()
+	}
+}
+
+func (s *Service) recordRepoScanSkipped(mode string, reason string) {
+	if s.Metrics != nil {
+		s.Metrics.RepoScanSkippedTotal.WithLabelValues(repoScanModeLabel(mode), repoScanSkipReasonLabel(reason)).Inc()
+	}
+}
+
 func (s *Service) recordAutomationRun(source string, connector string, outcome string) {
 	s.recordAutomationRuns(source, connector, outcome, 1)
 }
@@ -1013,9 +1037,9 @@ func automationOutcomeLabel(outcome string) string {
 	switch strings.ToLower(strings.TrimSpace(outcome)) {
 	case "queued":
 		return "queued"
-	case "succeeded":
+	case "succeeded", "success":
 		return "succeeded"
-	case "failed":
+	case "failed", "failure":
 		return "failed"
 	case "partial":
 		return "partial"
@@ -1034,6 +1058,42 @@ func automationQueueLabel(queue string) string {
 		return "scan"
 	case "repo_scan":
 		return "repo_scan"
+	default:
+		return "other"
+	}
+}
+
+func repoScanModeLabel(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case db.RepoScanModeQuick:
+		return db.RepoScanModeQuick
+	case db.RepoScanModeDelta:
+		return db.RepoScanModeDelta
+	case db.RepoScanModeDeep:
+		return db.RepoScanModeDeep
+	default:
+		return db.RepoScanModeDeep
+	}
+}
+
+func repoScanSkipReasonLabel(reason string) string {
+	switch strings.ToLower(strings.TrimSpace(reason)) {
+	case "cursor_current":
+		return "cursor_current"
+	case "queue_full":
+		return "queue_full"
+	case "in_progress":
+		return "in_progress"
+	case "invalid_delta":
+		return "invalid_delta"
+	case "disabled":
+		return "disabled"
+	case "target_not_allowed":
+		return "target_not_allowed"
+	case "throttled":
+		return "throttled"
+	case "replay":
+		return "replay"
 	default:
 		return "other"
 	}
@@ -1063,15 +1123,26 @@ func (s *Service) RunRepoScan(ctx context.Context, request RepoScanRequest) (rep
 func (s *Service) EnqueueRepoScan(ctx context.Context, request RepoScanRequest) (db.RepoScanRecord, error) {
 	ctx = s.scopeContext(ctx)
 	ctx = withQueueTraceContext(ctx)
-	target, source, historyLimit, maxFindings, err := s.validateRepoScanRequest(ctx, request)
+	target, source, scanContext, historyLimit, maxFindings, err := s.validateRepoScanRequest(ctx, request)
 	if err != nil {
 		return db.RepoScanRecord{}, err
+	}
+	cursor, hasCursor, err := s.repoScanCursor(ctx, target, source)
+	if err != nil {
+		return db.RepoScanRecord{}, err
+	}
+	if hasCursor && scanContext.CursorBefore == "" {
+		scanContext.CursorBefore = cursor.LastScannedRevision
+	}
+	if scanContext.ScanMode == db.RepoScanModeDelta && scanContext.HeadRevision != "" && hasCursor && strings.EqualFold(cursor.LastScannedRevision, scanContext.HeadRevision) {
+		s.recordRepoScanSkipped(scanContext.ScanMode, "cursor_current")
+		return db.RepoScanRecord{}, ErrRepoScanAlreadyCurrent
 	}
 	maxPending := s.RepoQueueMaxPending
 	if maxPending <= 0 {
 		maxPending = defaultRepoQueueMaxPending
 	}
-	record, err := s.Store.CreateQueuedRepoScanWithinLimit(ctx, target, source, historyLimit, maxFindings, s.Now().UTC(), maxPending)
+	record, err := s.Store.CreateQueuedRepoScanWithinLimit(ctx, target, source, scanContext, historyLimit, maxFindings, s.Now().UTC(), maxPending)
 	if err != nil {
 		switch {
 		case errors.Is(err, db.ErrPendingRepoScanExists):
@@ -1202,9 +1273,20 @@ func (s *Service) emitRepoScanQueueEvent(event RepoScanQueueEvent) {
 // RunRepoScanPersisted runs one repository scan and persists repo scan metadata + findings.
 func (s *Service) RunRepoScanPersisted(ctx context.Context, request RepoScanRequest) (RunRepoScanResult, error) {
 	ctx = s.scopeContext(ctx)
-	target, source, historyLimit, maxFindings, err := s.validateRepoScanRequest(ctx, request)
+	target, source, scanContext, historyLimit, maxFindings, err := s.validateRepoScanRequest(ctx, request)
 	if err != nil {
 		return RunRepoScanResult{}, err
+	}
+	cursor, hasCursor, err := s.repoScanCursor(ctx, target, source)
+	if err != nil {
+		return RunRepoScanResult{}, err
+	}
+	if hasCursor && scanContext.CursorBefore == "" {
+		scanContext.CursorBefore = cursor.LastScannedRevision
+	}
+	if scanContext.ScanMode == db.RepoScanModeDelta && scanContext.HeadRevision != "" && hasCursor && strings.EqualFold(cursor.LastScannedRevision, scanContext.HeadRevision) {
+		s.recordRepoScanSkipped(scanContext.ScanMode, "cursor_current")
+		return RunRepoScanResult{}, ErrRepoScanAlreadyCurrent
 	}
 	if s.Locker != nil {
 		release, ok := s.Locker.TryAcquire(ctx, s.lockKey("repo-scan:"+strings.ToLower(target)))
@@ -1213,60 +1295,69 @@ func (s *Service) RunRepoScanPersisted(ctx context.Context, request RepoScanRequ
 		}
 		defer release(context.Background())
 	}
-	record, err := s.Store.CreateRepoScan(ctx, target, source, s.Now().UTC())
+	record, err := s.Store.CreateRepoScan(ctx, target, source, scanContext, s.Now().UTC())
 	if err != nil {
 		return RunRepoScanResult{}, fmt.Errorf("create repo scan: %w", err)
 	}
 	return s.runRepoScanWithRecord(ctx, record, historyLimit, maxFindings)
 }
 
-func (s *Service) validateRepoScanRequest(ctx context.Context, request RepoScanRequest) (string, db.RepoScanSource, int, int, error) {
+func (s *Service) validateRepoScanRequest(ctx context.Context, request RepoScanRequest) (string, db.RepoScanSource, db.RepoScanContext, int, int, error) {
 	if !s.RepoScanEnabled {
-		return "", db.RepoScanSource{}, 0, 0, ErrRepoScanDisabled
+		return "", db.RepoScanSource{}, db.RepoScanContext{}, 0, 0, ErrRepoScanDisabled
 	}
 	target := strings.TrimSpace(request.Repository)
 	if target == "" {
-		return "", db.RepoScanSource{}, 0, 0, ErrInvalidRepoScanRequest
+		return "", db.RepoScanSource{}, db.RepoScanContext{}, 0, 0, ErrInvalidRepoScanRequest
 	}
 	if repoTargetContainsURLCredentials(target) {
-		return "", db.RepoScanSource{}, 0, 0, repoScanRequestValidationError{"repository target must not include credentials in URL userinfo"}
+		return "", db.RepoScanSource{}, db.RepoScanContext{}, 0, 0, repoScanRequestValidationError{"repository target must not include credentials in URL userinfo"}
 	}
 	if repoexposure.IsLocalRepositoryTarget(target) {
 		s.recordServiceAuthzDenial(ctx, "repo_scans.run", "repo_scan_target", target)
-		return "", db.RepoScanSource{}, 0, 0, ErrRepoTargetNotAllowed
+		return "", db.RepoScanSource{}, db.RepoScanContext{}, 0, 0, ErrRepoTargetNotAllowed
 	}
 	historyLimit, err := sanitizeRepoScanLimit(request.HistoryLimit, s.RepoScanDefaultHistoryLimit, s.RepoScanMaxHistoryLimit)
 	if err != nil {
-		return "", db.RepoScanSource{}, 0, 0, ErrInvalidRepoScanRequest
+		return "", db.RepoScanSource{}, db.RepoScanContext{}, 0, 0, ErrInvalidRepoScanRequest
 	}
 	maxFindings, err := sanitizeRepoScanLimit(request.MaxFindings, s.RepoScanDefaultMaxFindings, s.RepoScanMaxFindingsLimit)
 	if err != nil {
-		return "", db.RepoScanSource{}, 0, 0, ErrInvalidRepoScanRequest
+		return "", db.RepoScanSource{}, db.RepoScanContext{}, 0, 0, ErrInvalidRepoScanRequest
+	}
+	scanContext := db.NormalizeRepoScanContext(db.RepoScanContext{
+		ScanMode:     request.ScanMode,
+		BaseRevision: request.BaseRevision,
+		HeadRevision: request.HeadRevision,
+		ChangedPaths: request.ChangedPaths,
+	})
+	if scanContext.ScanMode == db.RepoScanModeDelta && scanContext.HeadRevision == "" {
+		return "", db.RepoScanSource{}, db.RepoScanContext{}, 0, 0, ErrInvalidRepoScanRequest
 	}
 
 	if repoScanRequestUsesConnector(request) {
 		normalizedTarget := normalizeGitHubRepositoryPath(target)
 		if normalizedTarget == "" {
-			return "", db.RepoScanSource{}, 0, 0, ErrInvalidRepoScanRequest
+			return "", db.RepoScanSource{}, db.RepoScanContext{}, 0, 0, ErrInvalidRepoScanRequest
 		}
 		target = normalizeGitHubRepository(normalizedTarget)
 
 		source, err := s.resolveRepoScanSource(ctx, target, request)
 		if err != nil {
-			return "", db.RepoScanSource{}, 0, 0, err
+			return "", db.RepoScanSource{}, db.RepoScanContext{}, 0, 0, err
 		}
 
 		if !repoTargetAllowed(target, s.RepoScanAllowedTargets) {
 			s.recordServiceAuthzDenial(ctx, "repo_scans.run", "repo_scan_target", target)
-			return "", db.RepoScanSource{}, 0, 0, ErrRepoTargetNotAllowed
+			return "", db.RepoScanSource{}, db.RepoScanContext{}, 0, 0, ErrRepoTargetNotAllowed
 		}
-		return target, source, historyLimit, maxFindings, nil
+		return target, source, scanContext, historyLimit, maxFindings, nil
 	}
 	if !repoTargetAllowed(target, s.RepoScanAllowedTargets) {
 		s.recordServiceAuthzDenial(ctx, "repo_scans.run", "repo_scan_target", target)
-		return "", db.RepoScanSource{}, 0, 0, ErrRepoTargetNotAllowed
+		return "", db.RepoScanSource{}, db.RepoScanContext{}, 0, 0, ErrRepoTargetNotAllowed
 	}
-	return target, db.RepoScanSource{}, historyLimit, maxFindings, nil
+	return target, db.RepoScanSource{}, scanContext, historyLimit, maxFindings, nil
 }
 
 func repoScanRequestUsesConnector(request RepoScanRequest) bool {
@@ -1364,37 +1455,50 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 		s.recordRepoScanExecutionFailure()
 		return RunRepoScanResult{}, ErrInvalidRepoScanRequest
 	}
+	record.ScanMode = db.NormalizeRepoScanContext(db.RepoScanContext{ScanMode: record.ScanMode}).ScanMode
 	normalizedHistory, err := sanitizeRepoScanLimit(historyLimit, s.RepoScanDefaultHistoryLimit, s.RepoScanMaxHistoryLimit)
 	if err != nil {
 		s.recordRepoScanExecutionFailure()
-		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, ErrInvalidRepoScanRequest.Error())
+		s.recordRepoScanModeRun(record.ScanMode, "failure")
+		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, "", ErrInvalidRepoScanRequest.Error())
 		return RunRepoScanResult{}, ErrInvalidRepoScanRequest
 	}
 	normalizedMaxFindings, err := sanitizeRepoScanLimit(maxFindings, s.RepoScanDefaultMaxFindings, s.RepoScanMaxFindingsLimit)
 	if err != nil {
 		s.recordRepoScanExecutionFailure()
-		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, ErrInvalidRepoScanRequest.Error())
+		s.recordRepoScanModeRun(record.ScanMode, "failure")
+		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, "", ErrInvalidRepoScanRequest.Error())
 		return RunRepoScanResult{}, ErrInvalidRepoScanRequest
 	}
 	executor, scanSecrets, err := s.repoScanExecutorForRecord(ctx, record, normalizedHistory, normalizedMaxFindings)
 	if err != nil {
 		s.recordRepoScanExecutionFailure()
-		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, err.Error())
+		s.recordRepoScanModeRun(record.ScanMode, "failure")
+		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, "", err.Error())
 		return RunRepoScanResult{}, err
 	}
-	result, err := executor.ScanRepository(ctx, target)
+	scanContext := db.NormalizeRepoScanContext(db.RepoScanContext{
+		ScanMode:     record.ScanMode,
+		BaseRevision: record.BaseRevision,
+		HeadRevision: record.HeadRevision,
+		ChangedPaths: record.ChangedPaths,
+	})
+	result, err := runRepoScanExecutor(ctx, executor, target, scanContext)
 	if err != nil {
 		safeErr := sanitizeRepoScanError(err, scanSecrets...)
 		s.recordRepoScanExecutionFailure()
-		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, safeErr.Error())
+		s.recordRepoScanModeRun(record.ScanMode, "failure")
+		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, "", safeErr.Error())
 		return RunRepoScanResult{}, safeErr
 	}
+	result = applyRepoScanContextToResult(result, target, scanContext)
 	if !result.Truncated {
 		externalFindings, externalErr := s.repoScanExternalFindings(ctx, record, s.Now().UTC())
 		if externalErr != nil {
 			if errors.Is(externalErr, context.Canceled) || errors.Is(externalErr, context.DeadlineExceeded) {
 				s.recordRepoScanExecutionFailure()
-				_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), result.CommitsScanned, result.FilesScanned, len(result.Findings), result.Truncated, externalErr.Error())
+				s.recordRepoScanModeRun(record.ScanMode, "failure")
+				_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), result.CommitsScanned, result.FilesScanned, len(result.Findings), result.Truncated, "", externalErr.Error())
 				return RunRepoScanResult{}, externalErr
 			}
 		} else if len(externalFindings) > 0 {
@@ -1406,9 +1510,11 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 	result.Findings = enrichFindingsWithRepoContext(result.Findings, result.Repository, record.Repository)
 	if err := s.Store.UpsertRepoFindings(ctx, record.ID, result.Findings); err != nil {
 		s.recordRepoScanExecutionFailure()
-		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), result.CommitsScanned, result.FilesScanned, 0, result.Truncated, err.Error())
+		s.recordRepoScanModeRun(record.ScanMode, "failure")
+		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), result.CommitsScanned, result.FilesScanned, 0, result.Truncated, "", err.Error())
 		return RunRepoScanResult{}, fmt.Errorf("persist repo findings: %w", err)
 	}
+	cursorAfter := firstNonEmptyString(result.HeadRevision, record.HeadRevision)
 	if err := s.completeRepoScanTerminal(
 		ctx,
 		record.ID,
@@ -1418,11 +1524,33 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 		result.FilesScanned,
 		len(result.Findings),
 		result.Truncated,
+		cursorAfter,
 		"",
 	); err != nil {
 		s.recordRepoScanExecutionFailure()
+		s.recordRepoScanModeRun(record.ScanMode, "failure")
 		return RunRepoScanResult{}, fmt.Errorf("complete repo scan: %w", err)
 	}
+	if cursorAfter != "" {
+		completedAt := s.Now().UTC()
+		record.CursorAfter = cursorAfter
+		record.HeadRevision = firstNonEmptyString(record.HeadRevision, result.HeadRevision)
+		if err := s.Store.UpsertRepoScanCursor(ctx, db.RepoScanCursor{
+			Repository:          record.Repository,
+			Source:              record.Source,
+			LastScannedRevision: cursorAfter,
+			LastDeepScannedAt:   repoScanLastDeepScannedAt(record.ScanMode, completedAt),
+			LastScanID:          record.ID,
+			LastScanMode:        record.ScanMode,
+			LastScanCompletedAt: completedAt,
+			UpdatedAt:           completedAt,
+		}); err != nil {
+			s.recordRepoScanExecutionFailure()
+			s.recordRepoScanModeRun(record.ScanMode, "failure")
+			return RunRepoScanResult{}, fmt.Errorf("update repo scan cursor: %w", err)
+		}
+	}
+	s.recordRepoScanModeRun(record.ScanMode, "succeeded")
 	record.Status = "succeeded"
 	finished := s.Now().UTC()
 	record.FinishedAt = &finished
@@ -1430,6 +1558,10 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 	record.FilesScanned = result.FilesScanned
 	record.FindingCount = len(result.Findings)
 	record.Truncated = result.Truncated
+	record.ScanMode = result.ScanMode
+	record.BaseRevision = result.BaseRevision
+	record.HeadRevision = result.HeadRevision
+	record.ChangedPaths = append([]string(nil), result.ChangedPaths...)
 	record.HistoryLimit = normalizedHistory
 	record.MaxFindings = normalizedMaxFindings
 	if s.Metrics != nil {
@@ -1463,6 +1595,58 @@ func (s *Service) repoScanExecutorForRecord(ctx context.Context, record db.RepoS
 	default:
 		return nil, nil, ErrInvalidRepoScanRequest
 	}
+}
+
+func runRepoScanExecutor(ctx context.Context, executor RepoScanExecutor, target string, scanContext db.RepoScanContext) (repoexposure.ScanResult, error) {
+	options := repoexposure.ScanOptions{
+		Mode:         scanContext.ScanMode,
+		BaseRevision: scanContext.BaseRevision,
+		HeadRevision: scanContext.HeadRevision,
+		ChangedPaths: append([]string(nil), scanContext.ChangedPaths...),
+	}
+	if withOptions, ok := executor.(RepoScanExecutorWithOptions); ok {
+		return withOptions.ScanRepositoryWithOptions(ctx, target, options)
+	}
+	return executor.ScanRepository(ctx, target)
+}
+
+func applyRepoScanContextToResult(result repoexposure.ScanResult, target string, scanContext db.RepoScanContext) repoexposure.ScanResult {
+	normalized := db.NormalizeRepoScanContext(scanContext)
+	if strings.TrimSpace(result.Repository) == "" {
+		result.Repository = strings.TrimSpace(target)
+	}
+	if strings.TrimSpace(result.ScanMode) == "" {
+		result.ScanMode = normalized.ScanMode
+	}
+	if strings.TrimSpace(result.BaseRevision) == "" {
+		result.BaseRevision = normalized.BaseRevision
+	}
+	if strings.TrimSpace(result.HeadRevision) == "" {
+		result.HeadRevision = normalized.HeadRevision
+	}
+	if len(result.ChangedPaths) == 0 {
+		result.ChangedPaths = append([]string(nil), normalized.ChangedPaths...)
+	}
+	return result
+}
+
+func (s *Service) repoScanCursor(ctx context.Context, repository string, source db.RepoScanSource) (db.RepoScanCursor, bool, error) {
+	cursor, err := s.Store.GetRepoScanCursor(ctx, repository, source)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return db.RepoScanCursor{}, false, nil
+		}
+		return db.RepoScanCursor{}, false, fmt.Errorf("get repo scan cursor: %w", err)
+	}
+	return cursor, true, nil
+}
+
+func repoScanLastDeepScannedAt(mode string, completedAt time.Time) *time.Time {
+	if !strings.EqualFold(strings.TrimSpace(mode), db.RepoScanModeDeep) {
+		return nil
+	}
+	converted := completedAt.UTC()
+	return &converted
 }
 
 func (s *Service) repoScanExternalFindings(ctx context.Context, record db.RepoScanRecord, detectedAt time.Time) ([]domain.Finding, error) {
@@ -3239,6 +3423,7 @@ func (s *Service) completeRepoScanTerminal(
 	filesScanned int,
 	findingCount int,
 	truncated bool,
+	cursorAfter string,
 	errorMessage string,
 ) error {
 	writeCtx := ctx
@@ -3254,6 +3439,7 @@ func (s *Service) completeRepoScanTerminal(
 		filesScanned,
 		findingCount,
 		truncated,
+		cursorAfter,
 		errorMessage,
 	)
 	if !shouldRetryTerminalWrite(err) {
@@ -3268,6 +3454,7 @@ func (s *Service) completeRepoScanTerminal(
 		filesScanned,
 		findingCount,
 		truncated,
+		cursorAfter,
 		errorMessage,
 	)
 }

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1460,21 +1460,21 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 	if err != nil {
 		s.recordRepoScanExecutionFailure()
 		s.recordRepoScanModeRun(record.ScanMode, "failure")
-		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, "", ErrInvalidRepoScanRequest.Error())
+		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, db.RepoScanContext{}, ErrInvalidRepoScanRequest.Error())
 		return RunRepoScanResult{}, ErrInvalidRepoScanRequest
 	}
 	normalizedMaxFindings, err := sanitizeRepoScanLimit(maxFindings, s.RepoScanDefaultMaxFindings, s.RepoScanMaxFindingsLimit)
 	if err != nil {
 		s.recordRepoScanExecutionFailure()
 		s.recordRepoScanModeRun(record.ScanMode, "failure")
-		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, "", ErrInvalidRepoScanRequest.Error())
+		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, db.RepoScanContext{}, ErrInvalidRepoScanRequest.Error())
 		return RunRepoScanResult{}, ErrInvalidRepoScanRequest
 	}
 	executor, scanSecrets, err := s.repoScanExecutorForRecord(ctx, record, normalizedHistory, normalizedMaxFindings)
 	if err != nil {
 		s.recordRepoScanExecutionFailure()
 		s.recordRepoScanModeRun(record.ScanMode, "failure")
-		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, "", err.Error())
+		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, db.RepoScanContext{}, err.Error())
 		return RunRepoScanResult{}, err
 	}
 	scanContext := db.NormalizeRepoScanContext(db.RepoScanContext{
@@ -1488,7 +1488,7 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 		safeErr := sanitizeRepoScanError(err, scanSecrets...)
 		s.recordRepoScanExecutionFailure()
 		s.recordRepoScanModeRun(record.ScanMode, "failure")
-		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, "", safeErr.Error())
+		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), 0, 0, 0, false, db.RepoScanContext{}, safeErr.Error())
 		return RunRepoScanResult{}, safeErr
 	}
 	result = applyRepoScanContextToResult(result, target, scanContext)
@@ -1498,7 +1498,7 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 			if errors.Is(externalErr, context.Canceled) || errors.Is(externalErr, context.DeadlineExceeded) {
 				s.recordRepoScanExecutionFailure()
 				s.recordRepoScanModeRun(record.ScanMode, "failure")
-				_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), result.CommitsScanned, result.FilesScanned, len(result.Findings), result.Truncated, "", externalErr.Error())
+				_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), result.CommitsScanned, result.FilesScanned, len(result.Findings), result.Truncated, db.RepoScanContext{}, externalErr.Error())
 				return RunRepoScanResult{}, externalErr
 			}
 		} else if len(externalFindings) > 0 {
@@ -1511,7 +1511,7 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 	if err := s.Store.UpsertRepoFindings(ctx, record.ID, result.Findings); err != nil {
 		s.recordRepoScanExecutionFailure()
 		s.recordRepoScanModeRun(record.ScanMode, "failure")
-		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), result.CommitsScanned, result.FilesScanned, 0, result.Truncated, "", err.Error())
+		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), result.CommitsScanned, result.FilesScanned, 0, result.Truncated, db.RepoScanContext{}, err.Error())
 		return RunRepoScanResult{}, fmt.Errorf("persist repo findings: %w", err)
 	}
 	cursorAfter := firstNonEmptyString(result.HeadRevision, record.HeadRevision)
@@ -1524,7 +1524,13 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 		result.FilesScanned,
 		len(result.Findings),
 		result.Truncated,
-		cursorAfter,
+		db.RepoScanContext{
+			ScanMode:     result.ScanMode,
+			BaseRevision: result.BaseRevision,
+			HeadRevision: result.HeadRevision,
+			CursorAfter:  cursorAfter,
+			ChangedPaths: append([]string(nil), result.ChangedPaths...),
+		},
 		"",
 	); err != nil {
 		s.recordRepoScanExecutionFailure()
@@ -1535,7 +1541,8 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 		completedAt := s.Now().UTC()
 		record.CursorAfter = cursorAfter
 		record.HeadRevision = firstNonEmptyString(record.HeadRevision, result.HeadRevision)
-		if err := s.Store.UpsertRepoScanCursor(ctx, db.RepoScanCursor{
+		// The scan row is already terminal-success; cursor persistence must not turn it into a failed worker run.
+		_ = s.Store.UpsertRepoScanCursor(ctx, db.RepoScanCursor{
 			Repository:          record.Repository,
 			Source:              record.Source,
 			LastScannedRevision: cursorAfter,
@@ -1544,11 +1551,7 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 			LastScanMode:        record.ScanMode,
 			LastScanCompletedAt: completedAt,
 			UpdatedAt:           completedAt,
-		}); err != nil {
-			s.recordRepoScanExecutionFailure()
-			s.recordRepoScanModeRun(record.ScanMode, "failure")
-			return RunRepoScanResult{}, fmt.Errorf("update repo scan cursor: %w", err)
-		}
+		})
 	}
 	s.recordRepoScanModeRun(record.ScanMode, "succeeded")
 	record.Status = "succeeded"
@@ -3423,7 +3426,7 @@ func (s *Service) completeRepoScanTerminal(
 	filesScanned int,
 	findingCount int,
 	truncated bool,
-	cursorAfter string,
+	scanContext db.RepoScanContext,
 	errorMessage string,
 ) error {
 	writeCtx := ctx
@@ -3439,7 +3442,7 @@ func (s *Service) completeRepoScanTerminal(
 		filesScanned,
 		findingCount,
 		truncated,
-		cursorAfter,
+		scanContext,
 		errorMessage,
 	)
 	if !shouldRetryTerminalWrite(err) {
@@ -3454,7 +3457,7 @@ func (s *Service) completeRepoScanTerminal(
 		filesScanned,
 		findingCount,
 		truncated,
-		cursorAfter,
+		scanContext,
 		errorMessage,
 	)
 }

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -137,6 +137,14 @@ func (s *failingCompleteScanStore) CompleteScan(
 	return errors.New("finalize failed")
 }
 
+type failingRepoScanCursorStore struct {
+	*db.MemoryStore
+}
+
+func (s *failingRepoScanCursorStore) UpsertRepoScanCursor(context.Context, db.RepoScanCursor) error {
+	return errors.New("cursor update failed")
+}
+
 type failingAnyScopeDepthStore struct {
 	*db.MemoryStore
 }
@@ -181,7 +189,7 @@ func (s *completionContextStore) CompleteRepoScan(
 	filesScanned int,
 	findingCount int,
 	truncated bool,
-	cursorAfter string,
+	scanContext db.RepoScanContext,
 	errorMessage string,
 ) error {
 	s.lastRepoScanCompletionCtxErr = ctx.Err()
@@ -194,7 +202,7 @@ func (s *completionContextStore) CompleteRepoScan(
 		filesScanned,
 		findingCount,
 		truncated,
-		cursorAfter,
+		scanContext,
 		errorMessage,
 	)
 }
@@ -2154,6 +2162,7 @@ func TestServiceRunRepoScanPersistedStoresRecords(t *testing.T) {
 				Repository:     "owner/repo",
 				CommitsScanned: historyLimit,
 				FilesScanned:   5,
+				HeadRevision:   "3333333333333333333333333333333333333333",
 				Findings: []domain.Finding{
 					{
 						ID:                  "rf-1",
@@ -2191,6 +2200,9 @@ func TestServiceRunRepoScanPersistedStoresRecords(t *testing.T) {
 	if stored.ID != run.RepoScan.ID || stored.CommitsScanned != 10 {
 		t.Fatalf("unexpected persisted repo scan: %+v", stored)
 	}
+	if stored.HeadRevision != "3333333333333333333333333333333333333333" {
+		t.Fatalf("expected completed scan head revision to be persisted, got %+v", stored)
+	}
 
 	findings, err := svc.ListRepoFindings(defaultScopeContext(), 10, db.RepoFindingFilter{RepoScanID: run.RepoScan.ID})
 	if err != nil {
@@ -2210,6 +2222,43 @@ func TestServiceRunRepoScanPersistedStoresRecords(t *testing.T) {
 	}
 	if findings[0].SourceURL != "https://github.com/owner/repo/blob/abc123/config/app.env#L7" {
 		t.Fatalf("expected GitHub source URL, got %+v", findings[0].SourceURL)
+	}
+}
+
+func TestServiceRunRepoScanPersistedPersistsComputedDeltaMetadata(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.RepoScanAllowedTargets = []string{"owner/repo"}
+	request := RepoScanRequest{
+		Repository:   "owner/repo",
+		ScanMode:     db.RepoScanModeDelta,
+		BaseRevision: "1111111111111111111111111111111111111111",
+		HeadRevision: "2222222222222222222222222222222222222222",
+	}
+	svc.RepoScannerFactory = func(int, int) RepoScanExecutor {
+		return &fakeRepoExecutor{
+			result: repoexposure.ScanResult{
+				Repository:     "owner/repo",
+				CommitsScanned: 1,
+				FilesScanned:   1,
+				ScanMode:       db.RepoScanModeDelta,
+				BaseRevision:   request.BaseRevision,
+				HeadRevision:   request.HeadRevision,
+				ChangedPaths:   []string{"app.env", ".github/workflows/build.yml"},
+			},
+		}
+	}
+
+	run, err := svc.RunRepoScanPersisted(defaultScopeContext(), request)
+	if err != nil {
+		t.Fatalf("run delta repo scan persisted: %v", err)
+	}
+	stored, err := svc.GetRepoScan(defaultScopeContext(), run.RepoScan.ID)
+	if err != nil {
+		t.Fatalf("get repo scan: %v", err)
+	}
+	if stored.HeadRevision != request.HeadRevision || len(stored.ChangedPaths) != 2 {
+		t.Fatalf("expected completed delta metadata to be persisted, got %+v", stored)
 	}
 }
 
@@ -2264,6 +2313,37 @@ func TestServiceRunRepoScanPersistedUpdatesCursorAndSkipsCurrentDelta(t *testing
 	}
 	if executor.calls != 1 {
 		t.Fatalf("expected current delta skip to avoid executor, got %d calls", executor.calls)
+	}
+}
+
+func TestServiceRunRepoScanPersistedDoesNotFailAfterSuccessfulCursorUpdateMiss(t *testing.T) {
+	store := &failingRepoScanCursorStore{MemoryStore: db.NewMemoryStore()}
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.RepoScanAllowedTargets = []string{"owner/repo"}
+	svc.RepoScannerFactory = func(int, int) RepoScanExecutor {
+		return &fakeRepoExecutor{
+			result: repoexposure.ScanResult{
+				Repository:     "owner/repo",
+				CommitsScanned: 1,
+				FilesScanned:   1,
+				HeadRevision:   "2222222222222222222222222222222222222222",
+			},
+		}
+	}
+
+	run, err := svc.RunRepoScanPersisted(defaultScopeContext(), RepoScanRequest{Repository: "owner/repo"})
+	if err != nil {
+		t.Fatalf("expected successful repo scan despite cursor update failure, got %v", err)
+	}
+	if run.RepoScan.Status != "succeeded" {
+		t.Fatalf("expected successful repo scan result, got %+v", run.RepoScan)
+	}
+	stored, err := svc.GetRepoScan(defaultScopeContext(), run.RepoScan.ID)
+	if err != nil {
+		t.Fatalf("get repo scan: %v", err)
+	}
+	if stored.Status != "succeeded" {
+		t.Fatalf("expected persisted success despite cursor update failure, got %+v", stored)
 	}
 }
 

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -44,11 +44,12 @@ func (a *fakeAlerter) NotifyScan(context.Context, string, db.ScanRecord, []domai
 }
 
 type fakeRepoExecutor struct {
-	result repoexposure.ScanResult
-	err    error
-	target string
-	runCtx context.Context
-	calls  int
+	result  repoexposure.ScanResult
+	err     error
+	target  string
+	runCtx  context.Context
+	options repoexposure.ScanOptions
+	calls   int
 }
 
 func (f *fakeRepoExecutor) ScanRepository(ctx context.Context, target string) (repoexposure.ScanResult, error) {
@@ -59,6 +60,11 @@ func (f *fakeRepoExecutor) ScanRepository(ctx context.Context, target string) (r
 		return repoexposure.ScanResult{}, f.err
 	}
 	return f.result, nil
+}
+
+func (f *fakeRepoExecutor) ScanRepositoryWithOptions(ctx context.Context, target string, options repoexposure.ScanOptions) (repoexposure.ScanResult, error) {
+	f.options = options
+	return f.ScanRepository(ctx, target)
 }
 
 type fakeGitHubInstallationTokenMinter struct {
@@ -175,6 +181,7 @@ func (s *completionContextStore) CompleteRepoScan(
 	filesScanned int,
 	findingCount int,
 	truncated bool,
+	cursorAfter string,
 	errorMessage string,
 ) error {
 	s.lastRepoScanCompletionCtxErr = ctx.Err()
@@ -187,6 +194,7 @@ func (s *completionContextStore) CompleteRepoScan(
 		filesScanned,
 		findingCount,
 		truncated,
+		cursorAfter,
 		errorMessage,
 	)
 }
@@ -875,7 +883,7 @@ func TestServiceListFindingsFilteredMatchesOlderRowsBeyondLegacyWindow(t *testin
 func TestServiceListRepoFindingsFilterTriagedResultsBeyondLegacyWindow(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
-	repoScan, _ := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, now)
+	repoScan, _ := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, db.RepoScanContext{}, now)
 
 	repoFindings := make([]domain.Finding, 0, 5001)
 	for i := 0; i < 5001; i++ {
@@ -923,7 +931,7 @@ func TestServiceListRepoFindingsFilterTriagedResultsBeyondLegacyWindow(t *testin
 func TestServiceListRepoFindingsSortBySeverityHonorsLimitBeyondLegacyWindow(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
-	repoScan, _ := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, now)
+	repoScan, _ := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, db.RepoScanContext{}, now)
 
 	repoFindings := make([]domain.Finding, 0, 5001)
 	for i := 0; i < 5001; i++ {
@@ -966,8 +974,8 @@ func TestServiceListRepoFindingsSortBySeverityHonorsLimitBeyondLegacyWindow(t *t
 func TestServiceRepoFindingTriageScopesStateToRepoScan(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
-	firstScan, _ := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, now)
-	secondScan, _ := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, now.Add(time.Hour))
+	firstScan, _ := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, db.RepoScanContext{}, now)
+	secondScan, _ := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, db.RepoScanContext{}, now.Add(time.Hour))
 
 	if err := store.UpsertRepoFindings(defaultScopeContext(), firstScan.ID, []domain.Finding{{
 		ID:        "shared-id",
@@ -2023,7 +2031,7 @@ func TestServiceGetRepoFindingsTrend(t *testing.T) {
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
 	ctx := defaultScopeContext()
 
-	scanA, err := store.CreateRepoScan(ctx, "owner/repo-a", db.RepoScanSource{}, now)
+	scanA, err := store.CreateRepoScan(ctx, "owner/repo-a", db.RepoScanSource{}, db.RepoScanContext{}, now)
 	if err != nil {
 		t.Fatalf("create repo scan A: %v", err)
 	}
@@ -2033,7 +2041,7 @@ func TestServiceGetRepoFindingsTrend(t *testing.T) {
 		t.Fatalf("upsert repo findings for scan A: %v", err)
 	}
 
-	scanB, err := store.CreateRepoScan(ctx, "owner/repo-b", db.RepoScanSource{}, now.Add(3*time.Minute))
+	scanB, err := store.CreateRepoScan(ctx, "owner/repo-b", db.RepoScanSource{}, db.RepoScanContext{}, now.Add(3*time.Minute))
 	if err != nil {
 		t.Fatalf("create repo scan B: %v", err)
 	}
@@ -2064,7 +2072,7 @@ func TestServiceGetRepoFindingsTrendFiltered(t *testing.T) {
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
 	ctx := defaultScopeContext()
 
-	scanA, err := store.CreateRepoScan(ctx, "owner/repo-a", db.RepoScanSource{}, now)
+	scanA, err := store.CreateRepoScan(ctx, "owner/repo-a", db.RepoScanSource{}, db.RepoScanContext{}, now)
 	if err != nil {
 		t.Fatalf("create repo scan A: %v", err)
 	}
@@ -2075,7 +2083,7 @@ func TestServiceGetRepoFindingsTrendFiltered(t *testing.T) {
 		t.Fatalf("upsert repo findings for scan A: %v", err)
 	}
 
-	scanB, err := store.CreateRepoScan(ctx, "owner/repo-b", db.RepoScanSource{}, now.Add(3*time.Minute))
+	scanB, err := store.CreateRepoScan(ctx, "owner/repo-b", db.RepoScanSource{}, db.RepoScanContext{}, now.Add(3*time.Minute))
 	if err != nil {
 		t.Fatalf("create repo scan B: %v", err)
 	}
@@ -2205,13 +2213,67 @@ func TestServiceRunRepoScanPersistedStoresRecords(t *testing.T) {
 	}
 }
 
+func TestServiceRunRepoScanPersistedUpdatesCursorAndSkipsCurrentDelta(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.RepoScanAllowedTargets = []string{"owner/repo"}
+	now := time.Date(2026, 5, 20, 9, 30, 0, 0, time.UTC)
+	svc.Now = func() time.Time { return now }
+	executor := &fakeRepoExecutor{
+		result: repoexposure.ScanResult{
+			Repository:     "owner/repo",
+			CommitsScanned: 1,
+			FilesScanned:   1,
+		},
+	}
+	svc.RepoScannerFactory = func(int, int) RepoScanExecutor {
+		return executor
+	}
+
+	request := RepoScanRequest{
+		Repository:   "owner/repo",
+		ScanMode:     db.RepoScanModeDelta,
+		BaseRevision: "1111111111111111111111111111111111111111",
+		HeadRevision: "2222222222222222222222222222222222222222",
+		ChangedPaths: []string{"app.env", "app.env", ".github/workflows/build.yml"},
+	}
+	run, err := svc.RunRepoScanPersisted(defaultScopeContext(), request)
+	if err != nil {
+		t.Fatalf("run delta repo scan persisted: %v", err)
+	}
+	if run.RepoScan.ScanMode != db.RepoScanModeDelta || run.RepoScan.HeadRevision != request.HeadRevision {
+		t.Fatalf("expected delta scan metadata, got %+v", run.RepoScan)
+	}
+	if executor.options.Mode != db.RepoScanModeDelta || executor.options.BaseRevision != request.BaseRevision || executor.options.HeadRevision != request.HeadRevision {
+		t.Fatalf("expected executor delta options, got %+v", executor.options)
+	}
+	if len(executor.options.ChangedPaths) != 2 {
+		t.Fatalf("expected normalized changed paths, got %+v", executor.options.ChangedPaths)
+	}
+
+	cursor, err := store.GetRepoScanCursor(defaultScopeContext(), "owner/repo", db.RepoScanSource{})
+	if err != nil {
+		t.Fatalf("get repo scan cursor: %v", err)
+	}
+	if cursor.LastScannedRevision != request.HeadRevision || cursor.LastScanMode != db.RepoScanModeDelta || cursor.LastScanID != run.RepoScan.ID {
+		t.Fatalf("unexpected cursor after delta scan: %+v", cursor)
+	}
+
+	if _, err := svc.EnqueueRepoScan(defaultScopeContext(), request); !errors.Is(err, ErrRepoScanAlreadyCurrent) {
+		t.Fatalf("expected current delta enqueue to be skipped, got %v", err)
+	}
+	if executor.calls != 1 {
+		t.Fatalf("expected current delta skip to avoid executor, got %d calls", executor.calls)
+	}
+}
+
 func TestServiceGetRepoRiskGraphUsesServiceClock(t *testing.T) {
 	store := db.NewMemoryStore()
 	svc := NewService(store, fakeScanner{}, "aws")
 	now := time.Date(2030, 1, 2, 12, 0, 0, 0, time.UTC)
 	svc.Now = func() time.Time { return now }
 
-	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, now.Add(-time.Hour))
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, db.RepoScanContext{}, now.Add(-time.Hour))
 	if err != nil {
 		t.Fatalf("create repo scan: %v", err)
 	}
@@ -2240,11 +2302,11 @@ func TestServiceListRepoFindingClusters(t *testing.T) {
 	store := db.NewMemoryStore()
 	svc := NewService(store, fakeScanner{}, "aws")
 
-	firstScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC))
+	firstScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, db.RepoScanContext{}, time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("create first repo scan: %v", err)
 	}
-	secondScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	secondScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, db.RepoScanContext{}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("create second repo scan: %v", err)
 	}
@@ -2342,7 +2404,7 @@ func TestServiceListRepoFindingClustersUsesBoundedPageFilter(t *testing.T) {
 	store := &repoFindingClusterFilterCaptureStore{MemoryStore: db.NewMemoryStore()}
 	svc := NewService(store, fakeScanner{}, "aws")
 
-	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, db.RepoScanContext{}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("create repo scan: %v", err)
 	}
@@ -2375,11 +2437,11 @@ func TestServiceListRepoFindingClustersBackfillsLegacyRepositoryContext(t *testi
 	store := db.NewMemoryStore()
 	svc := NewService(store, fakeScanner{}, "aws")
 
-	firstScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo-a", db.RepoScanSource{}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	firstScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo-a", db.RepoScanSource{}, db.RepoScanContext{}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("create first repo scan: %v", err)
 	}
-	secondScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo-b", db.RepoScanSource{}, time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC))
+	secondScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo-b", db.RepoScanSource{}, db.RepoScanContext{}, time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("create second repo scan: %v", err)
 	}
@@ -3710,7 +3772,7 @@ func TestServiceCountQueuedRepoScansForDepthReturnsZeroWhenAnyScopeCountFails(t 
 	scopedCtx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
 	now := time.Date(2026, 5, 10, 11, 45, 0, 0, time.UTC)
 
-	if _, err := store.CreateQueuedRepoScanWithinLimit(scopedCtx, "owner/repo", db.RepoScanSource{}, 50, 200, now, 5); err != nil {
+	if _, err := store.CreateQueuedRepoScanWithinLimit(scopedCtx, "owner/repo", db.RepoScanSource{}, db.RepoScanContext{}, 50, 200, now, 5); err != nil {
 		t.Fatalf("create queued repo scan: %v", err)
 	}
 	scopedCount, err := store.CountQueuedRepoScans(scopedCtx)
@@ -3804,7 +3866,7 @@ func TestServiceProcessNextQueuedRepoScanFailsStaleRunningScan(t *testing.T) {
 	svc.RepoScannerFactory = func(historyLimit int, maxFindings int) RepoScanExecutor {
 		return executor
 	}
-	staleRunning, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, now.Add(-40*time.Minute))
+	staleRunning, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, db.RepoScanContext{}, now.Add(-40*time.Minute))
 	if err != nil {
 		t.Fatalf("create stale running repo scan: %v", err)
 	}

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -25,6 +25,7 @@ type MemoryStore struct {
 	events         map[string][]ScanEvent
 	repoScans      map[string]RepoScanRecord
 	repoScanIDs    []string
+	repoCursors    map[string]RepoScanCursor
 	repoFindings   map[string]domain.Finding
 	repoFindingIDs map[string][]string
 
@@ -74,6 +75,7 @@ func NewMemoryStore() *MemoryStore {
 		events:         map[string][]ScanEvent{},
 		repoScans:      map[string]RepoScanRecord{},
 		repoScanIDs:    []string{},
+		repoCursors:    map[string]RepoScanCursor{},
 		repoFindings:   map[string]domain.Finding{},
 		repoFindingIDs: map[string][]string{},
 
@@ -1858,7 +1860,7 @@ func normalizeFindingTriageEventForWrite(event FindingTriageEvent) (FindingTriag
 }
 
 // CreateRepoScan persists one repository exposure scan start event.
-func (m *MemoryStore) CreateRepoScan(ctx context.Context, repository string, source RepoScanSource, startedAt time.Time) (RepoScanRecord, error) {
+func (m *MemoryStore) CreateRepoScan(ctx context.Context, repository string, source RepoScanSource, scanContext RepoScanContext, startedAt time.Time) (RepoScanRecord, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -1866,11 +1868,11 @@ func (m *MemoryStore) CreateRepoScan(ctx context.Context, repository string, sou
 	if err != nil {
 		return RepoScanRecord{}, err
 	}
-	return m.createRepoScanLocked(scope, strings.TrimSpace(repository), source, "running", 0, 0, startedAt), nil
+	return m.createRepoScanLocked(scope, strings.TrimSpace(repository), source, scanContext, "running", 0, 0, startedAt), nil
 }
 
 // CreateQueuedRepoScan persists one queued repository exposure scan request.
-func (m *MemoryStore) CreateQueuedRepoScan(ctx context.Context, repository string, source RepoScanSource, historyLimit int, maxFindings int, queuedAt time.Time) (RepoScanRecord, error) {
+func (m *MemoryStore) CreateQueuedRepoScan(ctx context.Context, repository string, source RepoScanSource, scanContext RepoScanContext, historyLimit int, maxFindings int, queuedAt time.Time) (RepoScanRecord, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -1878,14 +1880,14 @@ func (m *MemoryStore) CreateQueuedRepoScan(ctx context.Context, repository strin
 	if err != nil {
 		return RepoScanRecord{}, err
 	}
-	record := m.createRepoScanLocked(scope, strings.TrimSpace(repository), source, "queued", historyLimit, maxFindings, queuedAt)
+	record := m.createRepoScanLocked(scope, strings.TrimSpace(repository), source, scanContext, "queued", historyLimit, maxFindings, queuedAt)
 	record.TraceParent, record.TraceState = QueueTraceContextFromContext(ctx)
 	m.repoScans[record.ID] = record
 	return record, nil
 }
 
 // CreateQueuedRepoScanWithinLimit persists one queued repository scan only when the target is idle and queue capacity remains.
-func (m *MemoryStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, source RepoScanSource, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (RepoScanRecord, error) {
+func (m *MemoryStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, source RepoScanSource, scanContext RepoScanContext, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (RepoScanRecord, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -1912,7 +1914,7 @@ func (m *MemoryStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, repos
 	if queued >= maxPending {
 		return RepoScanRecord{}, ErrQueueLimitReached
 	}
-	record := m.createRepoScanLocked(scope, normalizedRepository, source, "queued", historyLimit, maxFindings, queuedAt)
+	record := m.createRepoScanLocked(scope, normalizedRepository, source, scanContext, "queued", historyLimit, maxFindings, queuedAt)
 	record.TraceParent, record.TraceState = QueueTraceContextFromContext(ctx)
 	m.repoScans[record.ID] = record
 	return record, nil
@@ -2087,8 +2089,9 @@ func (m *MemoryStore) FailStaleRepoScansAnyScope(_ context.Context, staleBefore 
 	return len(candidates), nil
 }
 
-func (m *MemoryStore) createRepoScanLocked(scope Scope, repository string, source RepoScanSource, status string, historyLimit int, maxFindings int, startedAt time.Time) RepoScanRecord {
+func (m *MemoryStore) createRepoScanLocked(scope Scope, repository string, source RepoScanSource, scanContext RepoScanContext, status string, historyLimit int, maxFindings int, startedAt time.Time) RepoScanRecord {
 	normalizedScope := scope.Normalize()
+	normalizedContext := NormalizeRepoScanContext(scanContext)
 	record := RepoScanRecord{
 		ID:           uuid.NewString(),
 		TenantID:     normalizedScope.TenantID,
@@ -2096,6 +2099,12 @@ func (m *MemoryStore) createRepoScanLocked(scope Scope, repository string, sourc
 		Repository:   strings.TrimSpace(repository),
 		Status:       strings.TrimSpace(status),
 		StartedAt:    startedAt.UTC(),
+		ScanMode:     normalizedContext.ScanMode,
+		BaseRevision: normalizedContext.BaseRevision,
+		HeadRevision: normalizedContext.HeadRevision,
+		CursorBefore: normalizedContext.CursorBefore,
+		CursorAfter:  normalizedContext.CursorAfter,
+		ChangedPaths: append([]string(nil), normalizedContext.ChangedPaths...),
 		HistoryLimit: historyLimit,
 		MaxFindings:  maxFindings,
 		Source:       source.Normalize(),
@@ -2122,7 +2131,7 @@ func (m *MemoryStore) GetRepoScan(ctx context.Context, repoScanID string) (RepoS
 }
 
 // CompleteRepoScan finalizes repo scan metadata.
-func (m *MemoryStore) CompleteRepoScan(ctx context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, errorMessage string) error {
+func (m *MemoryStore) CompleteRepoScan(ctx context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, cursorAfter string, errorMessage string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -2141,9 +2150,60 @@ func (m *MemoryStore) CompleteRepoScan(ctx context.Context, repoScanID string, s
 	record.FilesScanned = filesScanned
 	record.FindingCount = findingCount
 	record.Truncated = truncated
+	record.CursorAfter = strings.TrimSpace(cursorAfter)
 	record.ErrorMessage = strings.TrimSpace(errorMessage)
 	m.repoScans[repoScanID] = record
 	return nil
+}
+
+// GetRepoScanCursor returns the last successful scan cursor for one repository source.
+func (m *MemoryStore) GetRepoScanCursor(ctx context.Context, repository string, source RepoScanSource) (RepoScanCursor, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return RepoScanCursor{}, err
+	}
+	cursor, exists := m.repoCursors[repoScanCursorKey(scope, repository, source)]
+	if !exists {
+		return RepoScanCursor{}, ErrNotFound
+	}
+	return cursor, nil
+}
+
+// UpsertRepoScanCursor stores the latest successful scan cursor for one repository source.
+func (m *MemoryStore) UpsertRepoScanCursor(ctx context.Context, cursor RepoScanCursor) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	normalized := cursor.Normalize()
+	normalized.TenantID = scope.Normalize().TenantID
+	normalized.WorkspaceID = scope.Normalize().WorkspaceID
+	if strings.TrimSpace(normalized.Repository) == "" || strings.TrimSpace(normalized.LastScannedRevision) == "" {
+		return ErrNotFound
+	}
+	m.repoCursors[repoScanCursorKey(scope, normalized.Repository, normalized.Source)] = normalized
+	return nil
+}
+
+func repoScanCursorKey(scope Scope, repository string, source RepoScanSource) string {
+	normalizedScope := scope.Normalize()
+	normalizedSource := source.Normalize()
+	parts := []string{
+		normalizedScope.TenantID,
+		normalizedScope.WorkspaceID,
+		strings.ToLower(strings.TrimSpace(repository)),
+		normalizedSource.Provider,
+		normalizedSource.ProjectID,
+		normalizedSource.ConnectorID,
+		fmt.Sprint(normalizedSource.InstallationID),
+	}
+	return strings.Join(parts, "\x00")
 }
 
 // UpsertRepoFindings persists repository findings idempotently by repo_scan_id + finding_id.

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -2131,7 +2131,7 @@ func (m *MemoryStore) GetRepoScan(ctx context.Context, repoScanID string) (RepoS
 }
 
 // CompleteRepoScan finalizes repo scan metadata.
-func (m *MemoryStore) CompleteRepoScan(ctx context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, cursorAfter string, errorMessage string) error {
+func (m *MemoryStore) CompleteRepoScan(ctx context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, scanContext RepoScanContext, errorMessage string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -2143,6 +2143,7 @@ func (m *MemoryStore) CompleteRepoScan(ctx context.Context, repoScanID string, s
 	if !exists || !MatchScope(scope, record.TenantID, record.WorkspaceID) {
 		return ErrNotFound
 	}
+	normalizedContext := NormalizeRepoScanContext(scanContext)
 	finished := finishedAt.UTC()
 	record.Status = strings.TrimSpace(status)
 	record.FinishedAt = &finished
@@ -2150,7 +2151,16 @@ func (m *MemoryStore) CompleteRepoScan(ctx context.Context, repoScanID string, s
 	record.FilesScanned = filesScanned
 	record.FindingCount = findingCount
 	record.Truncated = truncated
-	record.CursorAfter = strings.TrimSpace(cursorAfter)
+	record.CursorAfter = normalizedContext.CursorAfter
+	if normalizedContext.BaseRevision != "" {
+		record.BaseRevision = normalizedContext.BaseRevision
+	}
+	if normalizedContext.HeadRevision != "" {
+		record.HeadRevision = normalizedContext.HeadRevision
+	}
+	if len(normalizedContext.ChangedPaths) > 0 {
+		record.ChangedPaths = append([]string(nil), normalizedContext.ChangedPaths...)
+	}
 	record.ErrorMessage = strings.TrimSpace(errorMessage)
 	m.repoScans[repoScanID] = record
 	return nil
@@ -2168,6 +2178,10 @@ func (m *MemoryStore) GetRepoScanCursor(ctx context.Context, repository string, 
 	cursor, exists := m.repoCursors[repoScanCursorKey(scope, repository, source)]
 	if !exists {
 		return RepoScanCursor{}, ErrNotFound
+	}
+	if cursor.LastDeepScannedAt != nil {
+		copied := cursor.LastDeepScannedAt.UTC()
+		cursor.LastDeepScannedAt = &copied
 	}
 	return cursor, nil
 }

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -506,11 +506,11 @@ func TestMemoryStoreListRepoFindingTrendCounts(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
 	ctx := defaultScopeContext()
-	scanA, err := store.CreateRepoScan(ctx, "owner/repo-a", RepoScanSource{}, now)
+	scanA, err := store.CreateRepoScan(ctx, "owner/repo-a", RepoScanSource{}, RepoScanContext{}, now)
 	if err != nil {
 		t.Fatalf("create repo scan A: %v", err)
 	}
-	scanB, err := store.CreateRepoScan(ctx, "owner/repo-b", RepoScanSource{}, now.Add(time.Minute))
+	scanB, err := store.CreateRepoScan(ctx, "owner/repo-b", RepoScanSource{}, RepoScanContext{}, now.Add(time.Minute))
 	if err != nil {
 		t.Fatalf("create repo scan B: %v", err)
 	}
@@ -619,7 +619,7 @@ func TestMemoryStoreRepoScanLifecycle(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 17, 14, 0, 0, 0, time.UTC)
 
-	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", RepoScanSource{}, now)
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", RepoScanSource{}, RepoScanContext{}, now)
 	if err != nil {
 		t.Fatalf("create repo scan: %v", err)
 	}
@@ -634,7 +634,7 @@ func TestMemoryStoreRepoScanLifecycle(t *testing.T) {
 	if err := store.UpsertRepoFindings(defaultScopeContext(), repoScan.ID, findings); err != nil {
 		t.Fatalf("upsert repo findings: %v", err)
 	}
-	if err := store.CompleteRepoScan(defaultScopeContext(), repoScan.ID, "completed", now.Add(2*time.Minute), 10, 6, 2, false, ""); err != nil {
+	if err := store.CompleteRepoScan(defaultScopeContext(), repoScan.ID, "completed", now.Add(2*time.Minute), 10, 6, 2, false, "", ""); err != nil {
 		t.Fatalf("complete repo scan: %v", err)
 	}
 
@@ -683,7 +683,7 @@ func TestMemoryStoreListRepoFindingsDoesNotMutateLegacyStoredEvidence(t *testing
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 17, 14, 0, 0, 0, time.UTC)
 
-	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", RepoScanSource{}, now)
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", RepoScanSource{}, RepoScanContext{}, now)
 	if err != nil {
 		t.Fatalf("create repo scan: %v", err)
 	}
@@ -734,15 +734,15 @@ func TestMemoryStoreListRepoFindingsDoesNotMutateLegacyStoredEvidence(t *testing
 func TestMemoryStoreListRepoFindingClustersPaginatesClusters(t *testing.T) {
 	store := NewMemoryStore()
 
-	firstScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo-a", RepoScanSource{}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	firstScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo-a", RepoScanSource{}, RepoScanContext{}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("create first repo scan: %v", err)
 	}
-	secondScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo-a", RepoScanSource{}, time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC))
+	secondScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo-a", RepoScanSource{}, RepoScanContext{}, time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("create second repo scan: %v", err)
 	}
-	thirdScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo-b", RepoScanSource{}, time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC))
+	thirdScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo-b", RepoScanSource{}, RepoScanContext{}, time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("create third repo scan: %v", err)
 	}
@@ -799,7 +799,7 @@ func TestMemoryStoreRepoScanErrors(t *testing.T) {
 	if err := store.UpsertRepoFindings(defaultScopeContext(), "missing", []domain.Finding{{ID: "x"}}); err == nil {
 		t.Fatal("expected missing repo scan error for findings upsert")
 	}
-	if err := store.CompleteRepoScan(defaultScopeContext(), "missing", "failed", time.Now(), 0, 0, 0, false, "boom"); err == nil {
+	if err := store.CompleteRepoScan(defaultScopeContext(), "missing", "failed", time.Now(), 0, 0, 0, false, "", "boom"); err == nil {
 		t.Fatal("expected missing repo scan error for completion")
 	}
 	if _, err := store.ListRepoFindings(defaultScopeContext(), RepoFindingFilter{RepoScanID: "missing"}, 10); err == nil {
@@ -1148,7 +1148,7 @@ func TestMemoryStoreRepoQueueLifecycle(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 21, 9, 5, 0, 0, time.UTC)
 	scopedCtx := WithQueueTraceContext(defaultScopeContext(), "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", "congo=t61rcWkgMzE")
-	queued, err := store.CreateQueuedRepoScan(scopedCtx, "owner/repo", RepoScanSource{}, 50, 80, now)
+	queued, err := store.CreateQueuedRepoScan(scopedCtx, "owner/repo", RepoScanSource{}, RepoScanContext{}, 50, 80, now)
 	if err != nil {
 		t.Fatalf("create queued repo scan: %v", err)
 	}
@@ -1215,10 +1215,10 @@ func TestMemoryStoreCountQueuedRepoScansAnyScope(t *testing.T) {
 	now := time.Date(2026, 3, 21, 9, 5, 0, 0, time.UTC)
 	otherScope := WithScope(context.Background(), Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
 
-	if _, err := store.CreateQueuedRepoScan(defaultScopeContext(), "owner/repo-a", RepoScanSource{}, 10, 20, now); err != nil {
+	if _, err := store.CreateQueuedRepoScan(defaultScopeContext(), "owner/repo-a", RepoScanSource{}, RepoScanContext{}, 10, 20, now); err != nil {
 		t.Fatalf("create default queued repo scan: %v", err)
 	}
-	if _, err := store.CreateQueuedRepoScan(otherScope, "owner/repo-b", RepoScanSource{}, 10, 20, now.Add(time.Minute)); err != nil {
+	if _, err := store.CreateQueuedRepoScan(otherScope, "owner/repo-b", RepoScanSource{}, RepoScanContext{}, 10, 20, now.Add(time.Minute)); err != nil {
 		t.Fatalf("create scoped queued repo scan: %v", err)
 	}
 
@@ -1235,17 +1235,17 @@ func TestMemoryStoreCreateQueuedRepoScanWithinLimit(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 21, 9, 5, 0, 0, time.UTC)
 
-	first, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo-a", RepoScanSource{}, 10, 20, now, 1)
+	first, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo-a", RepoScanSource{}, RepoScanContext{}, 10, 20, now, 1)
 	if err != nil {
 		t.Fatalf("create queued repo scan within limit: %v", err)
 	}
 	if first.Status != "queued" || first.HistoryLimit != 10 || first.MaxFindings != 20 {
 		t.Fatalf("unexpected queued repo scan within limit: %+v", first)
 	}
-	if _, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo-b", RepoScanSource{}, 10, 20, now.Add(time.Minute), 1); !errors.Is(err, ErrQueueLimitReached) {
+	if _, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo-b", RepoScanSource{}, RepoScanContext{}, 10, 20, now.Add(time.Minute), 1); !errors.Is(err, ErrQueueLimitReached) {
 		t.Fatalf("expected repo queue limit to be reached, got %v", err)
 	}
-	if _, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo-a", RepoScanSource{}, 10, 20, now.Add(2*time.Minute), 2); !errors.Is(err, ErrPendingRepoScanExists) {
+	if _, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo-a", RepoScanSource{}, RepoScanContext{}, 10, 20, now.Add(2*time.Minute), 2); !errors.Is(err, ErrPendingRepoScanExists) {
 		t.Fatalf("expected duplicate pending repo scan to be rejected, got %v", err)
 	}
 }
@@ -1255,11 +1255,11 @@ func TestMemoryStoreClaimNextQueuedRepoScanAnyScope(t *testing.T) {
 	now := time.Date(2026, 3, 21, 9, 5, 0, 0, time.UTC)
 	otherScope := WithScope(context.Background(), Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
 
-	first, err := store.CreateQueuedRepoScan(otherScope, "owner/repo-b", RepoScanSource{}, 10, 20, now)
+	first, err := store.CreateQueuedRepoScan(otherScope, "owner/repo-b", RepoScanSource{}, RepoScanContext{}, 10, 20, now)
 	if err != nil {
 		t.Fatalf("create earlier scoped queued repo scan: %v", err)
 	}
-	if _, err := store.CreateQueuedRepoScan(defaultScopeContext(), "owner/repo-a", RepoScanSource{}, 10, 20, now.Add(time.Minute)); err != nil {
+	if _, err := store.CreateQueuedRepoScan(defaultScopeContext(), "owner/repo-a", RepoScanSource{}, RepoScanContext{}, 10, 20, now.Add(time.Minute)); err != nil {
 		t.Fatalf("create default queued repo scan: %v", err)
 	}
 
@@ -1278,15 +1278,15 @@ func TestMemoryStoreFailStaleRepoScansAnyScope(t *testing.T) {
 	cutoff := staleAt.Add(35 * time.Minute)
 	otherScope := WithScope(context.Background(), Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
 
-	firstStale, err := store.CreateRepoScan(defaultScopeContext(), "owner/stale-a", RepoScanSource{}, staleAt)
+	firstStale, err := store.CreateRepoScan(defaultScopeContext(), "owner/stale-a", RepoScanSource{}, RepoScanContext{}, staleAt)
 	if err != nil {
 		t.Fatalf("create first stale repo scan: %v", err)
 	}
-	secondStale, err := store.CreateRepoScan(otherScope, "owner/stale-b", RepoScanSource{}, staleAt.Add(time.Minute))
+	secondStale, err := store.CreateRepoScan(otherScope, "owner/stale-b", RepoScanSource{}, RepoScanContext{}, staleAt.Add(time.Minute))
 	if err != nil {
 		t.Fatalf("create second stale repo scan: %v", err)
 	}
-	fresh, err := store.CreateRepoScan(defaultScopeContext(), "owner/fresh", RepoScanSource{}, cutoff.Add(time.Minute))
+	fresh, err := store.CreateRepoScan(defaultScopeContext(), "owner/fresh", RepoScanSource{}, RepoScanContext{}, cutoff.Add(time.Minute))
 	if err != nil {
 		t.Fatalf("create fresh repo scan: %v", err)
 	}
@@ -1339,7 +1339,7 @@ func TestMemoryStoreFailStaleRepoScansAnyScope(t *testing.T) {
 func TestMemoryStorePendingRepoCountMatchingIsCaseInsensitive(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 21, 9, 25, 0, 0, time.UTC)
-	if _, err := store.CreateQueuedRepoScan(defaultScopeContext(), "Owner/Repo", RepoScanSource{}, 10, 20, now); err != nil {
+	if _, err := store.CreateQueuedRepoScan(defaultScopeContext(), "Owner/Repo", RepoScanSource{}, RepoScanContext{}, 10, 20, now); err != nil {
 		t.Fatalf("create queued repo scan: %v", err)
 	}
 
@@ -1391,11 +1391,11 @@ func TestMemoryStoreScopeIsolation(t *testing.T) {
 		t.Fatalf("unexpected other scope scans: %+v", otherScans)
 	}
 
-	defaultRepo, err := store.CreateQueuedRepoScan(defaultCtx, "owner/repo", RepoScanSource{}, 10, 10, now)
+	defaultRepo, err := store.CreateQueuedRepoScan(defaultCtx, "owner/repo", RepoScanSource{}, RepoScanContext{}, 10, 10, now)
 	if err != nil {
 		t.Fatalf("create default repo scan: %v", err)
 	}
-	otherRepo, err := store.CreateQueuedRepoScan(otherCtx, "owner/repo", RepoScanSource{}, 10, 10, now.Add(2*time.Minute))
+	otherRepo, err := store.CreateQueuedRepoScan(otherCtx, "owner/repo", RepoScanSource{}, RepoScanContext{}, 10, 10, now.Add(2*time.Minute))
 	if err != nil {
 		t.Fatalf("create other repo scan: %v", err)
 	}

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -634,7 +634,7 @@ func TestMemoryStoreRepoScanLifecycle(t *testing.T) {
 	if err := store.UpsertRepoFindings(defaultScopeContext(), repoScan.ID, findings); err != nil {
 		t.Fatalf("upsert repo findings: %v", err)
 	}
-	if err := store.CompleteRepoScan(defaultScopeContext(), repoScan.ID, "completed", now.Add(2*time.Minute), 10, 6, 2, false, "", ""); err != nil {
+	if err := store.CompleteRepoScan(defaultScopeContext(), repoScan.ID, "completed", now.Add(2*time.Minute), 10, 6, 2, false, RepoScanContext{}, ""); err != nil {
 		t.Fatalf("complete repo scan: %v", err)
 	}
 
@@ -676,6 +676,38 @@ func TestMemoryStoreRepoScanLifecycle(t *testing.T) {
 	}
 	if len(repoScans) != 1 || repoScans[0].ID != repoScan.ID {
 		t.Fatalf("unexpected repo scans: %+v", repoScans)
+	}
+}
+
+func TestMemoryStoreGetRepoScanCursorCopiesPointerFields(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	deepScannedAt := now.Add(-1 * time.Hour)
+
+	if err := store.UpsertRepoScanCursor(defaultScopeContext(), RepoScanCursor{
+		Repository:          "owner/repo",
+		LastScannedRevision: "1111111111111111111111111111111111111111",
+		LastDeepScannedAt:   &deepScannedAt,
+		LastScanID:          "scan-1",
+		LastScanMode:        RepoScanModeDeep,
+		LastScanCompletedAt: now,
+		UpdatedAt:           now,
+	}); err != nil {
+		t.Fatalf("upsert repo scan cursor: %v", err)
+	}
+
+	cursor, err := store.GetRepoScanCursor(defaultScopeContext(), "owner/repo", RepoScanSource{})
+	if err != nil {
+		t.Fatalf("get repo scan cursor: %v", err)
+	}
+	*cursor.LastDeepScannedAt = cursor.LastDeepScannedAt.Add(24 * time.Hour)
+
+	stored, err := store.GetRepoScanCursor(defaultScopeContext(), "owner/repo", RepoScanSource{})
+	if err != nil {
+		t.Fatalf("get repo scan cursor again: %v", err)
+	}
+	if !stored.LastDeepScannedAt.Equal(deepScannedAt.UTC()) {
+		t.Fatalf("expected stored cursor timestamp to be isolated, got %v", stored.LastDeepScannedAt)
 	}
 }
 
@@ -799,7 +831,7 @@ func TestMemoryStoreRepoScanErrors(t *testing.T) {
 	if err := store.UpsertRepoFindings(defaultScopeContext(), "missing", []domain.Finding{{ID: "x"}}); err == nil {
 		t.Fatal("expected missing repo scan error for findings upsert")
 	}
-	if err := store.CompleteRepoScan(defaultScopeContext(), "missing", "failed", time.Now(), 0, 0, 0, false, "", "boom"); err == nil {
+	if err := store.CompleteRepoScan(defaultScopeContext(), "missing", "failed", time.Now(), 0, 0, 0, false, RepoScanContext{}, "boom"); err == nil {
 		t.Fatal("expected missing repo scan error for completion")
 	}
 	if _, err := store.ListRepoFindings(defaultScopeContext(), RepoFindingFilter{RepoScanID: "missing"}, 10); err == nil {

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -3047,10 +3047,19 @@ func (p *PostgresStore) GetRepoScan(ctx context.Context, repoScanID string) (Rep
 }
 
 // CompleteRepoScan updates repository scan completion metadata.
-func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, cursorAfter string, errorMessage string) error {
+func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, scanContext RepoScanContext, errorMessage string) error {
 	scope, err := RequireScope(ctx)
 	if err != nil {
 		return err
+	}
+	normalizedContext := NormalizeRepoScanContext(scanContext)
+	changedPaths := normalizedContext.ChangedPaths
+	if len(changedPaths) == 0 {
+		changedPaths = []string{}
+	}
+	changedPathsJSON, err := json.Marshal(changedPaths)
+	if err != nil {
+		return fmt.Errorf("marshal repo scan completion changed paths: %w", err)
 	}
 	result, err := p.execContext(
 		ctx,
@@ -3062,10 +3071,13 @@ func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string,
 		     finding_count = $6,
 		     truncated = $7,
 		     cursor_after = NULLIF($8, ''),
-		     error_message = $9
+		     base_revision = COALESCE(NULLIF($9, ''), base_revision),
+		     head_revision = COALESCE(NULLIF($10, ''), head_revision),
+		     changed_paths = CASE WHEN $11::jsonb <> '[]'::jsonb THEN $11::jsonb ELSE changed_paths END,
+		     error_message = $12
 		 WHERE id = $1
-		   AND tenant_id = $10
-		   AND workspace_id = $11`,
+		   AND tenant_id = $13
+		   AND workspace_id = $14`,
 		repoScanID,
 		strings.TrimSpace(status),
 		finishedAt.UTC(),
@@ -3073,7 +3085,10 @@ func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string,
 		filesScanned,
 		findingCount,
 		truncated,
-		strings.TrimSpace(cursorAfter),
+		normalizedContext.CursorAfter,
+		normalizedContext.BaseRevision,
+		normalizedContext.HeadRevision,
+		string(changedPathsJSON),
 		nullableString(errorMessage),
 		scope.TenantID,
 		scope.WorkspaceID,

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -2586,17 +2586,17 @@ func (p *PostgresStore) ListScanEvents(ctx context.Context, scanID string, limit
 }
 
 // CreateRepoScan inserts a new repository exposure scan row.
-func (p *PostgresStore) CreateRepoScan(ctx context.Context, repository string, source RepoScanSource, startedAt time.Time) (RepoScanRecord, error) {
-	return p.createRepoScanWithStatus(ctx, repository, source, "running", 0, 0, startedAt)
+func (p *PostgresStore) CreateRepoScan(ctx context.Context, repository string, source RepoScanSource, scanContext RepoScanContext, startedAt time.Time) (RepoScanRecord, error) {
+	return p.createRepoScanWithStatus(ctx, repository, source, scanContext, "running", 0, 0, startedAt)
 }
 
 // CreateQueuedRepoScan inserts one queued repository scan request row.
-func (p *PostgresStore) CreateQueuedRepoScan(ctx context.Context, repository string, source RepoScanSource, historyLimit int, maxFindings int, queuedAt time.Time) (RepoScanRecord, error) {
-	return p.createRepoScanWithStatus(ctx, repository, source, "queued", historyLimit, maxFindings, queuedAt)
+func (p *PostgresStore) CreateQueuedRepoScan(ctx context.Context, repository string, source RepoScanSource, scanContext RepoScanContext, historyLimit int, maxFindings int, queuedAt time.Time) (RepoScanRecord, error) {
+	return p.createRepoScanWithStatus(ctx, repository, source, scanContext, "queued", historyLimit, maxFindings, queuedAt)
 }
 
 // CreateQueuedRepoScanWithinLimit inserts one queued repository scan only when the target is idle and queue capacity remains.
-func (p *PostgresStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, source RepoScanSource, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (RepoScanRecord, error) {
+func (p *PostgresStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, source RepoScanSource, scanContext RepoScanContext, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (RepoScanRecord, error) {
 	scope, err := RequireScope(ctx)
 	if err != nil {
 		return RepoScanRecord{}, err
@@ -2656,6 +2656,11 @@ func (p *PostgresStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, rep
 		return RepoScanRecord{}, ErrQueueLimitReached
 	}
 	normalizedSource := source.Normalize()
+	normalizedContext := NormalizeRepoScanContext(scanContext)
+	changedPathsJSON, err := json.Marshal(repoScanChangedPathsForJSON(normalizedContext.ChangedPaths))
+	if err != nil {
+		return RepoScanRecord{}, fmt.Errorf("marshal queued repo scan changed paths: %w", err)
+	}
 
 	record := RepoScanRecord{
 		ID:           uuid.NewString(),
@@ -2664,6 +2669,12 @@ func (p *PostgresStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, rep
 		Repository:   normalizedRepository,
 		Status:       "queued",
 		StartedAt:    queuedAt.UTC(),
+		ScanMode:     normalizedContext.ScanMode,
+		BaseRevision: normalizedContext.BaseRevision,
+		HeadRevision: normalizedContext.HeadRevision,
+		CursorBefore: normalizedContext.CursorBefore,
+		CursorAfter:  normalizedContext.CursorAfter,
+		ChangedPaths: append([]string(nil), normalizedContext.ChangedPaths...),
 		HistoryLimit: historyLimit,
 		MaxFindings:  maxFindings,
 		Source:       normalizedSource,
@@ -2671,14 +2682,20 @@ func (p *PostgresStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, rep
 	record.TraceParent, record.TraceState = QueueTraceContextFromContext(ctx)
 	if _, err := tx.ExecContext(
 		ctx,
-		`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id, trace_parent, trace_state)
-		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8, $9, $10, $11, $12, NULLIF($13, ''), NULLIF($14, ''))`,
+		`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, scan_mode, base_revision, head_revision, cursor_before, cursor_after, changed_paths, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id, trace_parent, trace_state)
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, NULLIF($8, ''), NULLIF($9, ''), NULLIF($10, ''), NULLIF($11, ''), $12::jsonb, $13, $14, $15, $16, $17, $18, NULLIF($19, ''), NULLIF($20, ''))`,
 		record.ID,
 		record.TenantID,
 		record.WorkspaceID,
 		record.Repository,
 		record.Status,
 		record.StartedAt,
+		record.ScanMode,
+		record.BaseRevision,
+		record.HeadRevision,
+		record.CursorBefore,
+		record.CursorAfter,
+		string(changedPathsJSON),
 		record.HistoryLimit,
 		record.MaxFindings,
 		record.Source.Provider,
@@ -2738,6 +2755,12 @@ func (p *PostgresStore) claimNextQueuedRepoScan(ctx context.Context, scope *Scop
 			r.files_scanned,
 			r.finding_count,
 			r.truncated,
+			COALESCE(r.scan_mode, 'deep'),
+			COALESCE(r.base_revision, ''),
+			COALESCE(r.head_revision, ''),
+			COALESCE(r.cursor_before, ''),
+			COALESCE(r.cursor_after, ''),
+			COALESCE(r.changed_paths, '[]'::jsonb),
 			COALESCE(r.error_message, ''),
 			r.history_limit,
 			r.max_findings_limit,
@@ -2778,6 +2801,12 @@ func (p *PostgresStore) claimNextQueuedRepoScan(ctx context.Context, scope *Scop
 			r.files_scanned,
 			r.finding_count,
 			r.truncated,
+			COALESCE(r.scan_mode, 'deep'),
+			COALESCE(r.base_revision, ''),
+			COALESCE(r.head_revision, ''),
+			COALESCE(r.cursor_before, ''),
+			COALESCE(r.cursor_after, ''),
+			COALESCE(r.changed_paths, '[]'::jsonb),
 			COALESCE(r.error_message, ''),
 			r.history_limit,
 			r.max_findings_limit,
@@ -2933,12 +2962,17 @@ func (p *PostgresStore) FailStaleRepoScansAnyScope(ctx context.Context, staleBef
 	return int(affected), nil
 }
 
-func (p *PostgresStore) createRepoScanWithStatus(ctx context.Context, repository string, source RepoScanSource, status string, historyLimit int, maxFindings int, startedAt time.Time) (RepoScanRecord, error) {
+func (p *PostgresStore) createRepoScanWithStatus(ctx context.Context, repository string, source RepoScanSource, scanContext RepoScanContext, status string, historyLimit int, maxFindings int, startedAt time.Time) (RepoScanRecord, error) {
 	scope, err := RequireScope(ctx)
 	if err != nil {
 		return RepoScanRecord{}, err
 	}
 	normalizedSource := source.Normalize()
+	normalizedContext := NormalizeRepoScanContext(scanContext)
+	changedPathsJSON, err := json.Marshal(repoScanChangedPathsForJSON(normalizedContext.ChangedPaths))
+	if err != nil {
+		return RepoScanRecord{}, fmt.Errorf("marshal repo scan changed paths: %w", err)
+	}
 	record := RepoScanRecord{
 		ID:           uuid.NewString(),
 		TenantID:     scope.TenantID,
@@ -2946,20 +2980,32 @@ func (p *PostgresStore) createRepoScanWithStatus(ctx context.Context, repository
 		Repository:   strings.TrimSpace(repository),
 		Status:       strings.TrimSpace(status),
 		StartedAt:    startedAt.UTC(),
+		ScanMode:     normalizedContext.ScanMode,
+		BaseRevision: normalizedContext.BaseRevision,
+		HeadRevision: normalizedContext.HeadRevision,
+		CursorBefore: normalizedContext.CursorBefore,
+		CursorAfter:  normalizedContext.CursorAfter,
+		ChangedPaths: append([]string(nil), normalizedContext.ChangedPaths...),
 		HistoryLimit: historyLimit,
 		MaxFindings:  maxFindings,
 		Source:       normalizedSource,
 	}
 	_, err = p.execContext(
 		ctx,
-		`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id)
-		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8, $9, $10, $11, $12)`,
+		`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, scan_mode, base_revision, head_revision, cursor_before, cursor_after, changed_paths, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, NULLIF($8, ''), NULLIF($9, ''), NULLIF($10, ''), NULLIF($11, ''), $12::jsonb, $13, $14, $15, $16, $17, $18)`,
 		record.ID,
 		record.TenantID,
 		record.WorkspaceID,
 		record.Repository,
 		record.Status,
 		record.StartedAt,
+		record.ScanMode,
+		record.BaseRevision,
+		record.HeadRevision,
+		record.CursorBefore,
+		record.CursorAfter,
+		string(changedPathsJSON),
 		record.HistoryLimit,
 		record.MaxFindings,
 		record.Source.Provider,
@@ -2981,7 +3027,7 @@ func (p *PostgresStore) GetRepoScan(ctx context.Context, repoScanID string) (Rep
 	}
 	row := p.queryRowContext(
 		ctx,
-		`SELECT id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(error_message, ''), history_limit, max_findings_limit, COALESCE(source_provider, ''), COALESCE(source_project_id, ''), COALESCE(source_connector_id, ''), COALESCE(source_installation_id, 0)
+		`SELECT id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(scan_mode, 'deep'), COALESCE(base_revision, ''), COALESCE(head_revision, ''), COALESCE(cursor_before, ''), COALESCE(cursor_after, ''), COALESCE(changed_paths, '[]'::jsonb), COALESCE(error_message, ''), history_limit, max_findings_limit, COALESCE(source_provider, ''), COALESCE(source_project_id, ''), COALESCE(source_connector_id, ''), COALESCE(source_installation_id, 0)
 		 FROM repo_scans
 		 WHERE id = $1
 		   AND tenant_id = $2
@@ -3001,7 +3047,7 @@ func (p *PostgresStore) GetRepoScan(ctx context.Context, repoScanID string) (Rep
 }
 
 // CompleteRepoScan updates repository scan completion metadata.
-func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, errorMessage string) error {
+func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, cursorAfter string, errorMessage string) error {
 	scope, err := RequireScope(ctx)
 	if err != nil {
 		return err
@@ -3015,10 +3061,11 @@ func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string,
 		     files_scanned = $5,
 		     finding_count = $6,
 		     truncated = $7,
-		     error_message = $8
+		     cursor_after = NULLIF($8, ''),
+		     error_message = $9
 		 WHERE id = $1
-		   AND tenant_id = $9
-		   AND workspace_id = $10`,
+		   AND tenant_id = $10
+		   AND workspace_id = $11`,
 		repoScanID,
 		strings.TrimSpace(status),
 		finishedAt.UTC(),
@@ -3026,6 +3073,7 @@ func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string,
 		filesScanned,
 		findingCount,
 		truncated,
+		strings.TrimSpace(cursorAfter),
 		nullableString(errorMessage),
 		scope.TenantID,
 		scope.WorkspaceID,
@@ -3035,6 +3083,100 @@ func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string,
 	}
 	if err := ensureRowsAffected(result); err != nil {
 		return err
+	}
+	return nil
+}
+
+// GetRepoScanCursor returns the latest successful scan cursor for one repository source.
+func (p *PostgresStore) GetRepoScanCursor(ctx context.Context, repository string, source RepoScanSource) (RepoScanCursor, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return RepoScanCursor{}, err
+	}
+	normalizedSource := source.Normalize()
+	row := p.queryRowContext(
+		ctx,
+		`SELECT tenant_id, workspace_id, repository, source_provider, source_project_id, source_connector_id, source_installation_id, COALESCE(last_scanned_revision, ''), last_deep_scanned_at, COALESCE(last_scan_id::text, ''), COALESCE(last_scan_mode, 'deep'), last_scan_completed_at, updated_at
+		 FROM repo_scan_cursors
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND LOWER(repository) = LOWER($3)
+		   AND source_provider = $4
+		   AND source_project_id = $5
+		   AND source_connector_id = $6
+		   AND source_installation_id = $7`,
+		scope.TenantID,
+		scope.WorkspaceID,
+		strings.TrimSpace(repository),
+		normalizedSource.Provider,
+		normalizedSource.ProjectID,
+		normalizedSource.ConnectorID,
+		normalizedSource.InstallationID,
+	)
+	cursor, err := scanRepoScanCursor(row)
+	if err != nil {
+		if errorsIsNoRows(err) {
+			return RepoScanCursor{}, ErrNotFound
+		}
+		return RepoScanCursor{}, fmt.Errorf("query repo scan cursor: %w", err)
+	}
+	return cursor, nil
+}
+
+// UpsertRepoScanCursor stores the latest successful scan cursor for one repository source.
+func (p *PostgresStore) UpsertRepoScanCursor(ctx context.Context, cursor RepoScanCursor) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	normalized := cursor.Normalize()
+	normalizedScope := scope.Normalize()
+	if strings.TrimSpace(normalized.Repository) == "" || strings.TrimSpace(normalized.LastScannedRevision) == "" {
+		return ErrNotFound
+	}
+	var lastScanID any
+	if normalized.LastScanID != "" {
+		lastScanID = normalized.LastScanID
+	}
+	var lastDeepScannedAt any
+	if normalized.LastDeepScannedAt != nil {
+		lastDeepScannedAt = normalized.LastDeepScannedAt.UTC()
+	}
+	if normalized.UpdatedAt.IsZero() {
+		normalized.UpdatedAt = time.Now().UTC()
+	}
+	if normalized.LastScanCompletedAt.IsZero() {
+		normalized.LastScanCompletedAt = normalized.UpdatedAt
+	}
+	_, err = p.execContext(
+		ctx,
+		`INSERT INTO repo_scan_cursors (tenant_id, workspace_id, repository, source_provider, source_project_id, source_connector_id, source_installation_id, last_scanned_revision, last_deep_scanned_at, last_scan_id, last_scan_mode, last_scan_completed_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, NULLIF($8, ''), $9, $10::uuid, $11, $12, $13)
+		 ON CONFLICT (tenant_id, workspace_id, (lower(repository)), source_provider, source_project_id, source_connector_id, source_installation_id)
+		 DO UPDATE SET
+		    repository = EXCLUDED.repository,
+		    last_scanned_revision = EXCLUDED.last_scanned_revision,
+		    last_deep_scanned_at = COALESCE(EXCLUDED.last_deep_scanned_at, repo_scan_cursors.last_deep_scanned_at),
+		    last_scan_id = EXCLUDED.last_scan_id,
+		    last_scan_mode = EXCLUDED.last_scan_mode,
+		    last_scan_completed_at = EXCLUDED.last_scan_completed_at,
+		    updated_at = EXCLUDED.updated_at`,
+		normalizedScope.TenantID,
+		normalizedScope.WorkspaceID,
+		normalized.Repository,
+		normalized.Source.Provider,
+		normalized.Source.ProjectID,
+		normalized.Source.ConnectorID,
+		normalized.Source.InstallationID,
+		normalized.LastScannedRevision,
+		lastDeepScannedAt,
+		lastScanID,
+		normalized.LastScanMode,
+		normalized.LastScanCompletedAt.UTC(),
+		normalized.UpdatedAt.UTC(),
+	)
+	if err != nil {
+		return fmt.Errorf("upsert repo scan cursor: %w", err)
 	}
 	return nil
 }
@@ -3118,7 +3260,7 @@ func (p *PostgresStore) ListRepoScans(ctx context.Context, limit int) ([]RepoSca
 	}
 	rows, err := p.queryContext(
 		ctx,
-		`SELECT id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(error_message, ''), history_limit, max_findings_limit, COALESCE(source_provider, ''), COALESCE(source_project_id, ''), COALESCE(source_connector_id, ''), COALESCE(source_installation_id, 0)
+		`SELECT id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(scan_mode, 'deep'), COALESCE(base_revision, ''), COALESCE(head_revision, ''), COALESCE(cursor_before, ''), COALESCE(cursor_after, ''), COALESCE(changed_paths, '[]'::jsonb), COALESCE(error_message, ''), history_limit, max_findings_limit, COALESCE(source_provider, ''), COALESCE(source_project_id, ''), COALESCE(source_connector_id, ''), COALESCE(source_installation_id, 0)
 		 FROM repo_scans
 		 WHERE tenant_id = $1
 		   AND workspace_id = $2
@@ -3916,6 +4058,7 @@ type scanner interface {
 func scanRepoScanRecord(scanner scanner) (RepoScanRecord, error) {
 	var record RepoScanRecord
 	var finishedAt sql.NullTime
+	var changedPaths []byte
 	if err := scanner.Scan(
 		&record.ID,
 		&record.TenantID,
@@ -3928,6 +4071,12 @@ func scanRepoScanRecord(scanner scanner) (RepoScanRecord, error) {
 		&record.FilesScanned,
 		&record.FindingCount,
 		&record.Truncated,
+		&record.ScanMode,
+		&record.BaseRevision,
+		&record.HeadRevision,
+		&record.CursorBefore,
+		&record.CursorAfter,
+		&changedPaths,
 		&record.ErrorMessage,
 		&record.HistoryLimit,
 		&record.MaxFindings,
@@ -3939,6 +4088,8 @@ func scanRepoScanRecord(scanner scanner) (RepoScanRecord, error) {
 		return RepoScanRecord{}, err
 	}
 	record.StartedAt = record.StartedAt.UTC()
+	record.ScanMode = NormalizeRepoScanContext(RepoScanContext{ScanMode: record.ScanMode}).ScanMode
+	record.ChangedPaths = decodeRepoScanChangedPaths(changedPaths)
 	record.Source = record.Source.Normalize()
 	if finishedAt.Valid {
 		converted := finishedAt.Time.UTC()
@@ -3950,6 +4101,7 @@ func scanRepoScanRecord(scanner scanner) (RepoScanRecord, error) {
 func scanQueuedRepoScanRecord(scanner scanner) (RepoScanRecord, error) {
 	var record RepoScanRecord
 	var finishedAt sql.NullTime
+	var changedPaths []byte
 	if err := scanner.Scan(
 		&record.ID,
 		&record.TenantID,
@@ -3962,6 +4114,12 @@ func scanQueuedRepoScanRecord(scanner scanner) (RepoScanRecord, error) {
 		&record.FilesScanned,
 		&record.FindingCount,
 		&record.Truncated,
+		&record.ScanMode,
+		&record.BaseRevision,
+		&record.HeadRevision,
+		&record.CursorBefore,
+		&record.CursorAfter,
+		&changedPaths,
 		&record.ErrorMessage,
 		&record.HistoryLimit,
 		&record.MaxFindings,
@@ -3975,6 +4133,8 @@ func scanQueuedRepoScanRecord(scanner scanner) (RepoScanRecord, error) {
 		return RepoScanRecord{}, err
 	}
 	record.StartedAt = record.StartedAt.UTC()
+	record.ScanMode = NormalizeRepoScanContext(RepoScanContext{ScanMode: record.ScanMode}).ScanMode
+	record.ChangedPaths = decodeRepoScanChangedPaths(changedPaths)
 	record.Source = record.Source.Normalize()
 	record.TraceParent = strings.TrimSpace(record.TraceParent)
 	record.TraceState = strings.TrimSpace(record.TraceState)
@@ -3983,6 +4143,55 @@ func scanQueuedRepoScanRecord(scanner scanner) (RepoScanRecord, error) {
 		record.FinishedAt = &converted
 	}
 	return record, nil
+}
+
+func scanRepoScanCursor(scanner scanner) (RepoScanCursor, error) {
+	var cursor RepoScanCursor
+	var lastDeepScannedAt sql.NullTime
+	var lastScanID sql.NullString
+	if err := scanner.Scan(
+		&cursor.TenantID,
+		&cursor.WorkspaceID,
+		&cursor.Repository,
+		&cursor.Source.Provider,
+		&cursor.Source.ProjectID,
+		&cursor.Source.ConnectorID,
+		&cursor.Source.InstallationID,
+		&cursor.LastScannedRevision,
+		&lastDeepScannedAt,
+		&lastScanID,
+		&cursor.LastScanMode,
+		&cursor.LastScanCompletedAt,
+		&cursor.UpdatedAt,
+	); err != nil {
+		return RepoScanCursor{}, err
+	}
+	if lastDeepScannedAt.Valid {
+		converted := lastDeepScannedAt.Time.UTC()
+		cursor.LastDeepScannedAt = &converted
+	}
+	if lastScanID.Valid {
+		cursor.LastScanID = strings.TrimSpace(lastScanID.String)
+	}
+	return cursor.Normalize(), nil
+}
+
+func decodeRepoScanChangedPaths(raw []byte) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var paths []string
+	if err := json.Unmarshal(raw, &paths); err != nil {
+		return nil
+	}
+	return normalizeRepoScanChangedPaths(paths)
+}
+
+func repoScanChangedPathsForJSON(paths []string) []string {
+	if len(paths) == 0 {
+		return []string{}
+	}
+	return paths
 }
 
 func scanScanRecord(scanner scanner) (ScanRecord, error) {

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -711,14 +711,17 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		     finding_count = $6,
 		     truncated = $7,
 		     cursor_after = NULLIF($8, ''),
-		     error_message = $9
+		     base_revision = COALESCE(NULLIF($9, ''), base_revision),
+		     head_revision = COALESCE(NULLIF($10, ''), head_revision),
+		     changed_paths = CASE WHEN $11::jsonb <> '[]'::jsonb THEN $11::jsonb ELSE changed_paths END,
+		     error_message = $12
 		 WHERE id = $1
-		   AND tenant_id = $10
-		   AND workspace_id = $11`)).
-		WithArgs(record.ID, "completed", sqlmock.AnyArg(), 12, 8, 1, false, "", nil, "default", "default").
+		   AND tenant_id = $13
+		   AND workspace_id = $14`)).
+		WithArgs(record.ID, "completed", sqlmock.AnyArg(), 12, 8, 1, false, "", "", "", "[]", nil, "default", "default").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	if err := store.CompleteRepoScan(defaultScopeContext(), record.ID, "completed", now, 12, 8, 1, false, "", ""); err != nil {
+	if err := store.CompleteRepoScan(defaultScopeContext(), record.ID, "completed", now, 12, 8, 1, false, RepoScanContext{}, ""); err != nil {
 		t.Fatalf("complete repo scan failed: %v", err)
 	}
 

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -664,12 +664,12 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 	store := NewPostgresStoreWithDB(db)
 	now := time.Now().UTC()
 
-	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id)
-		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8, $9, $10, $11, $12)`)).
-		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "running", sqlmock.AnyArg(), 0, 0, "", "", "", int64(0)).
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, scan_mode, base_revision, head_revision, cursor_before, cursor_after, changed_paths, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, NULLIF($8, ''), NULLIF($9, ''), NULLIF($10, ''), NULLIF($11, ''), $12::jsonb, $13, $14, $15, $16, $17, $18)`)).
+		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "running", sqlmock.AnyArg(), "deep", "", "", "", "", "[]", 0, 0, "", "", "", int64(0)).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	record, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", RepoScanSource{}, now)
+	record, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", RepoScanSource{}, RepoScanContext{}, now)
 	if err != nil {
 		t.Fatalf("create repo scan failed: %v", err)
 	}
@@ -710,19 +710,20 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		     files_scanned = $5,
 		     finding_count = $6,
 		     truncated = $7,
-		     error_message = $8
+		     cursor_after = NULLIF($8, ''),
+		     error_message = $9
 		 WHERE id = $1
-		   AND tenant_id = $9
-		   AND workspace_id = $10`)).
-		WithArgs(record.ID, "completed", sqlmock.AnyArg(), 12, 8, 1, false, nil, "default", "default").
+		   AND tenant_id = $10
+		   AND workspace_id = $11`)).
+		WithArgs(record.ID, "completed", sqlmock.AnyArg(), 12, 8, 1, false, "", nil, "default", "default").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	if err := store.CompleteRepoScan(defaultScopeContext(), record.ID, "completed", now, 12, 8, 1, false, ""); err != nil {
+	if err := store.CompleteRepoScan(defaultScopeContext(), record.ID, "completed", now, 12, 8, 1, false, "", ""); err != nil {
 		t.Fatalf("complete repo scan failed: %v", err)
 	}
 
-	repoScanRows := sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "error_message", "history_limit", "max_findings_limit", "source_provider", "source_project_id", "source_connector_id", "source_installation_id"}).
-		AddRow(record.ID, "default", "default", "owner/repo", "completed", now, now, 12, 8, 1, false, "", 0, 0, "", "", "", int64(0))
+	repoScanRows := sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "scan_mode", "base_revision", "head_revision", "cursor_before", "cursor_after", "changed_paths", "error_message", "history_limit", "max_findings_limit", "source_provider", "source_project_id", "source_connector_id", "source_installation_id"}).
+		AddRow(record.ID, "default", "default", "owner/repo", "completed", now, now, 12, 8, 1, false, "deep", "", "", "", "", []byte("[]"), "", 0, 0, "", "", "", int64(0))
 	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, repository, status").WithArgs("default", "default", 20).WillReturnRows(repoScanRows)
 	repoScans, err := store.ListRepoScans(defaultScopeContext(), 20)
 	if err != nil {
@@ -778,8 +779,8 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		t.Fatalf("expected repository backfill from repo scan, got %+v", unboundedRepoFindings[0])
 	}
 
-	repoScanRow := sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "error_message", "history_limit", "max_findings_limit", "source_provider", "source_project_id", "source_connector_id", "source_installation_id"}).
-		AddRow(record.ID, "default", "default", "owner/repo", "completed", now, now, 12, 8, 1, false, "", 0, 0, "", "", "", int64(0))
+	repoScanRow := sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "scan_mode", "base_revision", "head_revision", "cursor_before", "cursor_after", "changed_paths", "error_message", "history_limit", "max_findings_limit", "source_provider", "source_project_id", "source_connector_id", "source_installation_id"}).
+		AddRow(record.ID, "default", "default", "owner/repo", "completed", now, now, 12, 8, 1, false, "deep", "", "", "", "", []byte("[]"), "", 0, 0, "", "", "", int64(0))
 	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, repository, status").WithArgs(record.ID, "default", "default").WillReturnRows(repoScanRow)
 	gotRepoScan, err := store.GetRepoScan(defaultScopeContext(), record.ID)
 	if err != nil {
@@ -1419,12 +1420,12 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 	store := NewPostgresStoreWithDB(db)
 	now := time.Now().UTC()
 
-	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id)
-		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8, $9, $10, $11, $12)`)).
-		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "queued", sqlmock.AnyArg(), 50, 80, "", "", "", int64(0)).
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, scan_mode, base_revision, head_revision, cursor_before, cursor_after, changed_paths, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, NULLIF($8, ''), NULLIF($9, ''), NULLIF($10, ''), NULLIF($11, ''), $12::jsonb, $13, $14, $15, $16, $17, $18)`)).
+		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "queued", sqlmock.AnyArg(), "deep", "", "", "", "", "[]", 50, 80, "", "", "", int64(0)).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	queued, err := store.CreateQueuedRepoScan(defaultScopeContext(), "owner/repo", RepoScanSource{}, 50, 80, now)
+	queued, err := store.CreateQueuedRepoScan(defaultScopeContext(), "owner/repo", RepoScanSource{}, RepoScanContext{}, 50, 80, now)
 	if err != nil {
 		t.Fatalf("create queued repo scan failed: %v", err)
 	}
@@ -1482,7 +1483,13 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 		"files_scanned",
 		"finding_count",
 		"truncated",
-		"coalesce",
+		"scan_mode",
+		"base_revision",
+		"head_revision",
+		"cursor_before",
+		"cursor_after",
+		"changed_paths",
+		"error_message",
 		"history_limit",
 		"max_findings_limit",
 		"source_provider",
@@ -1491,7 +1498,7 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 		"source_installation_id",
 		"trace_parent",
 		"trace_state",
-	}).AddRow(queued.ID, "default", "default", "owner/repo", "running", now, nil, 0, 0, 0, false, "", 50, 80, "", "", "", int64(0), "", "")
+	}).AddRow(queued.ID, "default", "default", "owner/repo", "running", now, nil, 0, 0, 0, false, "deep", "", "", "", "", []byte("[]"), "", 50, 80, "", "", "", int64(0), "", "")
 	mock.ExpectQuery("WITH next_repo_scan AS").WithArgs("default", "default").WillReturnRows(claimRows)
 
 	claimed, err := store.ClaimNextQueuedRepoScan(defaultScopeContext())
@@ -1516,6 +1523,92 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 
 	if err := store.RequeueRepoScan(defaultScopeContext(), claimed.ID); err != nil {
 		t.Fatalf("requeue repo scan failed: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreRepoScanCursorLifecycle(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	completedAt := time.Date(2026, 5, 20, 11, 0, 0, 0, time.UTC)
+	lastScanID := "11111111-1111-1111-1111-111111111111"
+	source := RepoScanSource{
+		Provider:       "github_app",
+		ProjectID:      "project-1",
+		ConnectorID:    "github",
+		InstallationID: 77,
+	}
+
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scan_cursors (tenant_id, workspace_id, repository, source_provider, source_project_id, source_connector_id, source_installation_id, last_scanned_revision, last_deep_scanned_at, last_scan_id, last_scan_mode, last_scan_completed_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, NULLIF($8, ''), $9, $10::uuid, $11, $12, $13)
+		 ON CONFLICT (tenant_id, workspace_id, (lower(repository)), source_provider, source_project_id, source_connector_id, source_installation_id)
+		 DO UPDATE SET
+		    repository = EXCLUDED.repository,
+		    last_scanned_revision = EXCLUDED.last_scanned_revision,
+		    last_deep_scanned_at = COALESCE(EXCLUDED.last_deep_scanned_at, repo_scan_cursors.last_deep_scanned_at),
+		    last_scan_id = EXCLUDED.last_scan_id,
+		    last_scan_mode = EXCLUDED.last_scan_mode,
+		    last_scan_completed_at = EXCLUDED.last_scan_completed_at,
+		    updated_at = EXCLUDED.updated_at`)).
+		WithArgs("default", "default", "owner/repo", "github_app", "project-1", "github", int64(77), "2222222222222222222222222222222222222222", nil, lastScanID, "delta", completedAt, completedAt).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := store.UpsertRepoScanCursor(defaultScopeContext(), RepoScanCursor{
+		Repository:          "owner/repo",
+		Source:              source,
+		LastScannedRevision: "2222222222222222222222222222222222222222",
+		LastScanID:          lastScanID,
+		LastScanMode:        RepoScanModeDelta,
+		LastScanCompletedAt: completedAt,
+		UpdatedAt:           completedAt,
+	}); err != nil {
+		t.Fatalf("upsert repo scan cursor: %v", err)
+	}
+
+	cursorRows := sqlmock.NewRows([]string{
+		"tenant_id",
+		"workspace_id",
+		"repository",
+		"source_provider",
+		"source_project_id",
+		"source_connector_id",
+		"source_installation_id",
+		"last_scanned_revision",
+		"last_deep_scanned_at",
+		"last_scan_id",
+		"last_scan_mode",
+		"last_scan_completed_at",
+		"updated_at",
+	}).AddRow("default", "default", "owner/repo", "github_app", "project-1", "github", int64(77), "2222222222222222222222222222222222222222", nil, lastScanID, "delta", completedAt, completedAt)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, workspace_id, repository, source_provider, source_project_id, source_connector_id, source_installation_id, COALESCE(last_scanned_revision, ''), last_deep_scanned_at, COALESCE(last_scan_id::text, ''), COALESCE(last_scan_mode, 'deep'), last_scan_completed_at, updated_at
+		 FROM repo_scan_cursors
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND LOWER(repository) = LOWER($3)
+		   AND source_provider = $4
+		   AND source_project_id = $5
+		   AND source_connector_id = $6
+		   AND source_installation_id = $7`)).
+		WithArgs("default", "default", "OWNER/REPO", "github_app", "project-1", "github", int64(77)).
+		WillReturnRows(cursorRows)
+
+	cursor, err := store.GetRepoScanCursor(defaultScopeContext(), "OWNER/REPO", source)
+	if err != nil {
+		t.Fatalf("get repo scan cursor: %v", err)
+	}
+	if cursor.LastScannedRevision != "2222222222222222222222222222222222222222" || cursor.LastScanMode != RepoScanModeDelta || cursor.LastScanID != lastScanID {
+		t.Fatalf("unexpected repo scan cursor: %+v", cursor)
+	}
+	if cursor.LastDeepScannedAt != nil {
+		t.Fatalf("delta cursor should not overwrite deep scan timestamp, got %+v", cursor.LastDeepScannedAt)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -1622,13 +1715,13 @@ func TestPostgresStoreCreateQueuedRepoScanWithinLimit(t *testing.T) {
 		   AND status = 'queued'`)).
 		WithArgs("default", "default").
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id, trace_parent, trace_state)
-		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8, $9, $10, $11, $12, NULLIF($13, ''), NULLIF($14, ''))`)).
-		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "queued", now, 50, 80, "", "", "", int64(0), "", "").
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, scan_mode, base_revision, head_revision, cursor_before, cursor_after, changed_paths, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id, trace_parent, trace_state)
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, NULLIF($8, ''), NULLIF($9, ''), NULLIF($10, ''), NULLIF($11, ''), $12::jsonb, $13, $14, $15, $16, $17, $18, NULLIF($19, ''), NULLIF($20, ''))`)).
+		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "queued", now, "deep", "", "", "", "", "[]", 50, 80, "", "", "", int64(0), "", "").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
-	record, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo", RepoScanSource{}, 50, 80, now, 2)
+	record, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo", RepoScanSource{}, RepoScanContext{}, 50, 80, now, 2)
 	if err != nil {
 		t.Fatalf("create queued repo scan within limit: %v", err)
 	}
@@ -1653,7 +1746,7 @@ func TestPostgresStoreCreateQueuedRepoScanWithinLimit(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 	mock.ExpectRollback()
 
-	if _, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo", RepoScanSource{}, 50, 80, now.Add(time.Minute), 2); !errors.Is(err, ErrPendingRepoScanExists) {
+	if _, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo", RepoScanSource{}, RepoScanContext{}, 50, 80, now.Add(time.Minute), 2); !errors.Is(err, ErrPendingRepoScanExists) {
 		t.Fatalf("expected ErrPendingRepoScanExists, got %v", err)
 	}
 
@@ -1681,7 +1774,7 @@ func TestPostgresStoreCreateQueuedRepoScanWithinLimit(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
 	mock.ExpectRollback()
 
-	if _, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/other", RepoScanSource{}, 50, 80, now.Add(2*time.Minute), 2); !errors.Is(err, ErrQueueLimitReached) {
+	if _, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/other", RepoScanSource{}, RepoScanContext{}, 50, 80, now.Add(2*time.Minute), 2); !errors.Is(err, ErrQueueLimitReached) {
 		t.Fatalf("expected ErrQueueLimitReached, got %v", err)
 	}
 
@@ -2803,9 +2896,11 @@ func TestPostgresStoreClaimNextQueuedRepoScanAnyScopeBypassesScopeInjection(t *t
 	now := time.Now().UTC()
 	rows := sqlmock.NewRows([]string{
 		"id", "tenant_id", "workspace_id", "repository", "status", "started_at", "finished_at",
-		"commits_scanned", "files_scanned", "finding_count", "truncated", "coalesce", "history_limit", "max_findings_limit",
+		"commits_scanned", "files_scanned", "finding_count", "truncated",
+		"scan_mode", "base_revision", "head_revision", "cursor_before", "cursor_after", "changed_paths",
+		"coalesce", "history_limit", "max_findings_limit",
 		"source_provider", "source_project_id", "source_connector_id", "source_installation_id", "trace_parent", "trace_state",
-	}).AddRow("repo-scan-1", "tenant-a", "workspace-a", "owner/repo", "running", now, nil, 0, 0, 0, false, "", 500, 200, "", "", "", int64(0), "", "")
+	}).AddRow("repo-scan-1", "tenant-a", "workspace-a", "owner/repo", "running", now, nil, 0, 0, 0, false, "deep", "", "", "", "", []byte("[]"), "", 500, 200, "", "", "", int64(0), "", "")
 	mock.ExpectQuery("WITH next_repo_scan AS").
 		WillReturnRows(rows)
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -52,6 +52,10 @@ const (
 	ScanEventLevelWarn  = "warn"
 	ScanEventLevelError = "error"
 
+	RepoScanModeDeep  = "deep"
+	RepoScanModeDelta = "delta"
+	RepoScanModeQuick = "quick"
+
 	FindingTriageActionAcknowledged = "acknowledged"
 	FindingTriageActionSuppressed   = "suppressed"
 	FindingTriageActionResolved     = "resolved"
@@ -178,6 +182,12 @@ var validIdentityConnectionStatuses = map[string]struct{}{
 	"disabled": {},
 }
 
+var validRepoScanModes = map[string]struct{}{
+	RepoScanModeDeep:  {},
+	RepoScanModeDelta: {},
+	RepoScanModeQuick: {},
+}
+
 // ScanRecord tracks persisted scan execution metadata.
 type ScanRecord struct {
 	ID              string     `json:"id"`
@@ -213,12 +223,88 @@ type RepoScanRecord struct {
 	FilesScanned   int            `json:"files_scanned"`
 	FindingCount   int            `json:"finding_count"`
 	Truncated      bool           `json:"truncated"`
+	ScanMode       string         `json:"scan_mode"`
+	BaseRevision   string         `json:"base_revision,omitempty"`
+	HeadRevision   string         `json:"head_revision,omitempty"`
+	CursorBefore   string         `json:"cursor_before,omitempty"`
+	CursorAfter    string         `json:"cursor_after,omitempty"`
+	ChangedPaths   []string       `json:"changed_paths,omitempty"`
 	ErrorMessage   string         `json:"error_message,omitempty"`
 	HistoryLimit   int            `json:"-"`
 	MaxFindings    int            `json:"-"`
 	Source         RepoScanSource `json:"-"`
 	TraceParent    string         `json:"-"`
 	TraceState     string         `json:"-"`
+}
+
+// RepoScanContext captures incremental execution metadata for one scan.
+type RepoScanContext struct {
+	ScanMode     string
+	BaseRevision string
+	HeadRevision string
+	CursorBefore string
+	CursorAfter  string
+	ChangedPaths []string
+}
+
+// NormalizeRepoScanContext returns stable scan-mode and revision metadata.
+func NormalizeRepoScanContext(scanContext RepoScanContext) RepoScanContext {
+	mode := strings.ToLower(strings.TrimSpace(scanContext.ScanMode))
+	if _, ok := validRepoScanModes[mode]; !ok {
+		mode = RepoScanModeDeep
+	}
+	normalized := RepoScanContext{
+		ScanMode:     mode,
+		BaseRevision: strings.TrimSpace(scanContext.BaseRevision),
+		HeadRevision: strings.TrimSpace(scanContext.HeadRevision),
+		CursorBefore: strings.TrimSpace(scanContext.CursorBefore),
+		CursorAfter:  strings.TrimSpace(scanContext.CursorAfter),
+		ChangedPaths: normalizeRepoScanChangedPaths(scanContext.ChangedPaths),
+	}
+	return normalized
+}
+
+// RepoScanCursor stores the latest scanned revision for one scoped repository source.
+type RepoScanCursor struct {
+	TenantID            string         `json:"-"`
+	WorkspaceID         string         `json:"-"`
+	Repository          string         `json:"repository"`
+	Source              RepoScanSource `json:"-"`
+	LastScannedRevision string         `json:"last_scanned_revision,omitempty"`
+	LastDeepScannedAt   *time.Time     `json:"last_deep_scanned_at,omitempty"`
+	LastScanID          string         `json:"last_scan_id,omitempty"`
+	LastScanMode        string         `json:"last_scan_mode,omitempty"`
+	LastScanCompletedAt time.Time      `json:"last_scan_completed_at"`
+	UpdatedAt           time.Time      `json:"updated_at"`
+}
+
+// Normalize returns a stable cursor key and payload.
+func (c RepoScanCursor) Normalize() RepoScanCursor {
+	normalized := RepoScanCursor{
+		TenantID:            strings.TrimSpace(c.TenantID),
+		WorkspaceID:         strings.TrimSpace(c.WorkspaceID),
+		Repository:          strings.TrimSpace(c.Repository),
+		Source:              c.Source.Normalize(),
+		LastScannedRevision: strings.TrimSpace(c.LastScannedRevision),
+		LastScanID:          strings.TrimSpace(c.LastScanID),
+		LastScanMode:        strings.ToLower(strings.TrimSpace(c.LastScanMode)),
+		LastScanCompletedAt: c.LastScanCompletedAt.UTC(),
+		UpdatedAt:           c.UpdatedAt.UTC(),
+	}
+	if _, ok := validRepoScanModes[normalized.LastScanMode]; !ok {
+		normalized.LastScanMode = RepoScanModeDeep
+	}
+	if c.LastDeepScannedAt != nil {
+		converted := c.LastDeepScannedAt.UTC()
+		normalized.LastDeepScannedAt = &converted
+	}
+	if normalized.LastScanCompletedAt.IsZero() {
+		normalized.LastScanCompletedAt = normalized.UpdatedAt
+	}
+	if normalized.UpdatedAt.IsZero() {
+		normalized.UpdatedAt = normalized.LastScanCompletedAt
+	}
+	return normalized
 }
 
 // RepoScanSource carries non-secret connector context for repository scans.
@@ -248,6 +334,29 @@ func (s RepoScanSource) Empty() bool {
 		normalized.ProjectID == "" &&
 		normalized.ConnectorID == "" &&
 		normalized.InstallationID == 0
+}
+
+func normalizeRepoScanChangedPaths(paths []string) []string {
+	if len(paths) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(paths))
+	for _, path := range paths {
+		item := strings.TrimSpace(strings.ReplaceAll(path, "\\", "/"))
+		item = strings.TrimPrefix(item, "/")
+		item = strings.TrimPrefix(item, "./")
+		if item == "" || strings.Contains(item, "\x00") || strings.HasPrefix(item, "../") || strings.Contains(item, "/../") {
+			continue
+		}
+		if _, exists := seen[item]; exists {
+			continue
+		}
+		seen[item] = struct{}{}
+		normalized = append(normalized, item)
+	}
+	sort.Strings(normalized)
+	return normalized
 }
 
 // ScanArtifacts contains raw and normalized scan outputs to persist idempotently.
@@ -2293,9 +2402,9 @@ type Store interface {
 	AppendScanEvent(ctx context.Context, scanID string, level string, message string, metadata map[string]any) error
 	ListScanEvents(ctx context.Context, scanID string, limit int) ([]ScanEvent, error)
 	SummarizeFindings(ctx context.Context) (FindingSummaryCounts, error)
-	CreateRepoScan(ctx context.Context, repository string, source RepoScanSource, startedAt time.Time) (RepoScanRecord, error)
-	CreateQueuedRepoScan(ctx context.Context, repository string, source RepoScanSource, historyLimit int, maxFindings int, queuedAt time.Time) (RepoScanRecord, error)
-	CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, source RepoScanSource, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (RepoScanRecord, error)
+	CreateRepoScan(ctx context.Context, repository string, source RepoScanSource, scanContext RepoScanContext, startedAt time.Time) (RepoScanRecord, error)
+	CreateQueuedRepoScan(ctx context.Context, repository string, source RepoScanSource, scanContext RepoScanContext, historyLimit int, maxFindings int, queuedAt time.Time) (RepoScanRecord, error)
+	CreateQueuedRepoScanWithinLimit(ctx context.Context, repository string, source RepoScanSource, scanContext RepoScanContext, historyLimit int, maxFindings int, queuedAt time.Time, maxPending int) (RepoScanRecord, error)
 	ClaimNextQueuedRepoScan(ctx context.Context) (RepoScanRecord, error)
 	ClaimNextQueuedRepoScanAnyScope(ctx context.Context) (RepoScanRecord, error)
 	CountQueuedRepoScans(ctx context.Context) (int, error)
@@ -2303,7 +2412,9 @@ type Store interface {
 	RequeueRepoScan(ctx context.Context, repoScanID string) error
 	FailStaleRepoScansAnyScope(ctx context.Context, staleBefore time.Time, limit int, errorMessage string) (int, error)
 	GetRepoScan(ctx context.Context, repoScanID string) (RepoScanRecord, error)
-	CompleteRepoScan(ctx context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, errorMessage string) error
+	CompleteRepoScan(ctx context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, cursorAfter string, errorMessage string) error
+	GetRepoScanCursor(ctx context.Context, repository string, source RepoScanSource) (RepoScanCursor, error)
+	UpsertRepoScanCursor(ctx context.Context, cursor RepoScanCursor) error
 	UpsertRepoFindings(ctx context.Context, repoScanID string, findings []domain.Finding) error
 	ListRepoScans(ctx context.Context, limit int) ([]RepoScanRecord, error)
 	ListRepoFindings(ctx context.Context, filter RepoFindingFilter, limit int) ([]domain.Finding, error)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2412,7 +2412,7 @@ type Store interface {
 	RequeueRepoScan(ctx context.Context, repoScanID string) error
 	FailStaleRepoScansAnyScope(ctx context.Context, staleBefore time.Time, limit int, errorMessage string) (int, error)
 	GetRepoScan(ctx context.Context, repoScanID string) (RepoScanRecord, error)
-	CompleteRepoScan(ctx context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, cursorAfter string, errorMessage string) error
+	CompleteRepoScan(ctx context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, scanContext RepoScanContext, errorMessage string) error
 	GetRepoScanCursor(ctx context.Context, repository string, source RepoScanSource) (RepoScanCursor, error)
 	UpsertRepoScanCursor(ctx context.Context, cursor RepoScanCursor) error
 	UpsertRepoFindings(ctx context.Context, repoScanID string, findings []domain.Finding) error

--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -28,6 +28,10 @@ const (
 	defaultHistoryLimit = 500
 	defaultMaxFindings  = 200
 	maxFileSizeBytes    = 1 << 20
+
+	ScanModeDeep  = "deep"
+	ScanModeDelta = "delta"
+	ScanModeQuick = "quick"
 )
 
 var hunkHeaderPattern = regexp.MustCompile(`@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@`)
@@ -77,6 +81,14 @@ type Scanner struct {
 	adapters        []ExternalFindingAdapter
 }
 
+// ScanOptions scopes repository scanning for full backfills, push deltas, and quick HEAD checks.
+type ScanOptions struct {
+	Mode         string   `json:"mode,omitempty"`
+	BaseRevision string   `json:"base_revision,omitempty"`
+	HeadRevision string   `json:"head_revision,omitempty"`
+	ChangedPaths []string `json:"changed_paths,omitempty"`
+}
+
 // ScanResult summarizes one repository exposure scan.
 type ScanResult struct {
 	Repository     string           `json:"repository"`
@@ -84,6 +96,10 @@ type ScanResult struct {
 	FilesScanned   int              `json:"files_scanned"`
 	Findings       []domain.Finding `json:"findings"`
 	Truncated      bool             `json:"truncated"`
+	ScanMode       string           `json:"scan_mode"`
+	BaseRevision   string           `json:"base_revision,omitempty"`
+	HeadRevision   string           `json:"head_revision,omitempty"`
+	ChangedPaths   []string         `json:"changed_paths,omitempty"`
 	StartedAt      time.Time        `json:"started_at"`
 	CompletedAt    time.Time        `json:"completed_at"`
 }
@@ -158,12 +174,18 @@ func WithHTTPSCloneCredential(credential HTTPSCloneCredential) Option {
 	}
 }
 
-// ScanRepository performs read-only scanning for commit-history secret exposure and HEAD misconfigurations.
+// ScanRepository performs a full read-only repository exposure scan.
 func (s *Scanner) ScanRepository(ctx context.Context, target string) (ScanResult, error) {
+	return s.ScanRepositoryWithOptions(ctx, target, ScanOptions{Mode: ScanModeDeep})
+}
+
+// ScanRepositoryWithOptions performs read-only scanning for commit-history secret exposure and HEAD misconfigurations.
+func (s *Scanner) ScanRepositoryWithOptions(ctx context.Context, target string, options ScanOptions) (ScanResult, error) {
 	repo := strings.TrimSpace(target)
 	if repo == "" {
 		return ScanResult{}, fmt.Errorf("repository target is required")
 	}
+	options = normalizeScanOptions(options)
 
 	started := s.now().UTC()
 	location, cleanup, err := s.prepareRepository(ctx, repo)
@@ -172,56 +194,65 @@ func (s *Scanner) ScanRepository(ctx context.Context, target string) (ScanResult
 	}
 	defer cleanup()
 
-	commits, err := s.listCommits(ctx, location)
+	headCommit, err := s.resolveRevision(ctx, location, firstNonEmptyScanString(options.HeadRevision, "HEAD"))
 	if err != nil {
 		return ScanResult{}, err
 	}
+	if options.HeadRevision == "" {
+		options.HeadRevision = headCommit
+	}
+	commits, err := s.listCommitsForOptions(ctx, location, options)
+	if err != nil {
+		return ScanResult{}, err
+	}
+	changedPaths, err := s.changedPathsForOptions(ctx, location, options)
+	if err != nil {
+		return ScanResult{}, err
+	}
+	options.ChangedPaths = changedPaths
 
 	findings := make([]domain.Finding, 0, s.maxFindings)
 	seen := map[string]struct{}{}
 	truncated := false
-	secretPolicy := s.loadSecretFindingPolicy(ctx, location)
+	secretPolicy := s.loadSecretFindingPolicy(ctx, location, options.HeadRevision)
 	secretOptions := []secretFindingOption{withSecretFindingPolicy(secretPolicy)}
 
-	logArgs := []string{"log", "--all", "--max-count", strconv.Itoa(s.historyLimit), "--no-color", "--unified=0", "--format=commit:%H", "-p"}
-	historyReader, waitLog, logErr := s.gitStream(ctx, location, logArgs...)
-	if logErr != nil {
-		return ScanResult{}, fmt.Errorf("scan commit history: %w", logErr)
-	}
-	scanErr := scanHistoryLines(ctx, historyReader, func(added addedLine) bool {
-		secretFindings := detectSecretFindings(location.Display, added.Commit, added.Path, added.Line, added.Text, started, secretOptions...)
-		for _, finding := range secretFindings {
-			if _, exists := seen[finding.ID]; exists {
-				continue
-			}
-			seen[finding.ID] = struct{}{}
-			findings = append(findings, finding)
-			if len(findings) >= s.maxFindings {
-				truncated = true
-				return false
-			}
+	if options.Mode != ScanModeQuick {
+		logArgs := s.historyLogArgs(options)
+		historyReader, waitLog, logErr := s.gitStream(ctx, location, logArgs...)
+		if logErr != nil {
+			return ScanResult{}, fmt.Errorf("scan commit history: %w", logErr)
 		}
-		return true
-	})
-	waitErr := waitLog()
-	if ctx.Err() != nil {
-		return ScanResult{}, ctx.Err()
-	}
-	if scanErr != nil && !truncated {
-		return ScanResult{}, fmt.Errorf("scan commit history: %w", scanErr)
-	}
-	if waitErr != nil && !truncated {
-		return ScanResult{}, fmt.Errorf("scan commit history: %w", waitErr)
+		scanErr := scanHistoryLines(ctx, historyReader, func(added addedLine) bool {
+			secretFindings := detectSecretFindings(location.Display, added.Commit, added.Path, added.Line, added.Text, started, secretOptions...)
+			for _, finding := range secretFindings {
+				if _, exists := seen[finding.ID]; exists {
+					continue
+				}
+				seen[finding.ID] = struct{}{}
+				findings = append(findings, finding)
+				if len(findings) >= s.maxFindings {
+					truncated = true
+					return false
+				}
+			}
+			return true
+		})
+		waitErr := waitLog()
+		if ctx.Err() != nil {
+			return ScanResult{}, ctx.Err()
+		}
+		if scanErr != nil && !truncated {
+			return ScanResult{}, fmt.Errorf("scan commit history: %w", scanErr)
+		}
+		if waitErr != nil && !truncated {
+			return ScanResult{}, fmt.Errorf("scan commit history: %w", waitErr)
+		}
 	}
 
 	filesScanned := 0
-	headCommit := ""
 	if !truncated {
-		headCommit, headCommitErr := s.resolveHeadCommit(ctx, location)
-		if headCommitErr != nil {
-			return ScanResult{}, headCommitErr
-		}
-		headFiles, fileErr := s.listHeadFiles(ctx, location)
+		headFiles, fileErr := s.filesForHeadInspection(ctx, location, options)
 		if fileErr != nil {
 			return ScanResult{}, fileErr
 		}
@@ -232,9 +263,9 @@ func (s *Scanner) ScanRepository(ctx context.Context, target string) (ScanResult
 			if !shouldInspectMisconfiguration(filePath) {
 				continue
 			}
-			content, readErr := s.git(ctx, location, "show", "HEAD:"+filePath)
+			content, readErr := s.git(ctx, location, "show", options.HeadRevision+":"+filePath)
 			if readErr != nil {
-				return ScanResult{}, fmt.Errorf("read HEAD file %s: %w", filePath, readErr)
+				return ScanResult{}, fmt.Errorf("read %s file %s: %w", options.HeadRevision, filePath, readErr)
 			}
 			if len(content) == 0 || len(content) > maxFileSizeBytes || !utf8.Valid(content) {
 				continue
@@ -297,6 +328,10 @@ func (s *Scanner) ScanRepository(ctx context.Context, target string) (ScanResult
 		FilesScanned:   filesScanned,
 		Findings:       findings,
 		Truncated:      truncated,
+		ScanMode:       options.Mode,
+		BaseRevision:   options.BaseRevision,
+		HeadRevision:   headCommit,
+		ChangedPaths:   append([]string(nil), options.ChangedPaths...),
 		StartedAt:      started,
 		CompletedAt:    s.now().UTC(),
 	}, nil
@@ -432,10 +467,42 @@ func (s *Scanner) listCommits(ctx context.Context, repo repositoryLocation) ([]s
 	return commits, nil
 }
 
+func (s *Scanner) listCommitsForOptions(ctx context.Context, repo repositoryLocation, options ScanOptions) ([]string, error) {
+	switch options.Mode {
+	case ScanModeDelta:
+		args := []string{"rev-list", "--max-count", strconv.Itoa(s.historyLimit)}
+		if isZeroRevision(options.BaseRevision) || options.BaseRevision == "" {
+			args = append(args, options.HeadRevision)
+		} else {
+			args = append(args, options.BaseRevision+".."+options.HeadRevision)
+		}
+		output, err := s.git(ctx, repo, args...)
+		if err != nil {
+			return nil, fmt.Errorf("list delta commits: %w", err)
+		}
+		return parseRevisionLines(output), nil
+	case ScanModeQuick:
+		if strings.TrimSpace(options.HeadRevision) == "" {
+			return nil, nil
+		}
+		return []string{options.HeadRevision}, nil
+	default:
+		return s.listCommits(ctx, repo)
+	}
+}
+
 func (s *Scanner) listHeadFiles(ctx context.Context, repo repositoryLocation) ([]string, error) {
-	output, err := s.git(ctx, repo, "ls-tree", "-r", "--name-only", "HEAD")
+	return s.listFilesAtRevision(ctx, repo, "HEAD")
+}
+
+func (s *Scanner) listFilesAtRevision(ctx context.Context, repo repositoryLocation, revision string) ([]string, error) {
+	revision = strings.TrimSpace(revision)
+	if revision == "" {
+		revision = "HEAD"
+	}
+	output, err := s.git(ctx, repo, "ls-tree", "-r", "--name-only", revision)
 	if err != nil {
-		return nil, fmt.Errorf("list HEAD files: %w", err)
+		return nil, fmt.Errorf("list %s files: %w", revision, err)
 	}
 	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
 	files := make([]string, 0, len(lines))
@@ -449,8 +516,12 @@ func (s *Scanner) listHeadFiles(ctx context.Context, repo repositoryLocation) ([
 	return files, nil
 }
 
-func (s *Scanner) loadSecretFindingPolicy(ctx context.Context, repo repositoryLocation) secretFindingPolicy {
-	output, err := s.git(ctx, repo, "show", "HEAD:.identrailignore")
+func (s *Scanner) loadSecretFindingPolicy(ctx context.Context, repo repositoryLocation, revision string) secretFindingPolicy {
+	revision = strings.TrimSpace(revision)
+	if revision == "" {
+		revision = "HEAD"
+	}
+	output, err := s.git(ctx, repo, "show", revision+":.identrailignore")
 	if err != nil {
 		return secretFindingPolicy{}
 	}
@@ -458,11 +529,73 @@ func (s *Scanner) loadSecretFindingPolicy(ctx context.Context, repo repositoryLo
 }
 
 func (s *Scanner) resolveHeadCommit(ctx context.Context, repo repositoryLocation) (string, error) {
-	output, err := s.git(ctx, repo, "rev-parse", "HEAD")
+	return s.resolveRevision(ctx, repo, "HEAD")
+}
+
+func (s *Scanner) resolveRevision(ctx context.Context, repo repositoryLocation, revision string) (string, error) {
+	revision = strings.TrimSpace(revision)
+	if revision == "" {
+		revision = "HEAD"
+	}
+	output, err := s.git(ctx, repo, "rev-parse", revision)
 	if err != nil {
-		return "", fmt.Errorf("resolve HEAD commit: %w", err)
+		return "", fmt.Errorf("resolve %s commit: %w", revision, err)
 	}
 	return strings.TrimSpace(string(output)), nil
+}
+
+func (s *Scanner) changedPathsForOptions(ctx context.Context, repo repositoryLocation, options ScanOptions) ([]string, error) {
+	if len(options.ChangedPaths) > 0 {
+		return normalizeScanChangedPaths(options.ChangedPaths), nil
+	}
+	if options.Mode != ScanModeDelta {
+		return nil, nil
+	}
+	if strings.TrimSpace(options.HeadRevision) == "" {
+		return nil, nil
+	}
+	var output []byte
+	var err error
+	if options.BaseRevision != "" && !isZeroRevision(options.BaseRevision) {
+		output, err = s.git(ctx, repo, "diff", "--name-only", options.BaseRevision, options.HeadRevision)
+	} else {
+		output, err = s.git(ctx, repo, "diff-tree", "--no-commit-id", "--name-only", "-r", options.HeadRevision)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("list delta changed files: %w", err)
+	}
+	return normalizeScanChangedPaths(strings.Split(strings.TrimSpace(string(output)), "\n")), nil
+}
+
+func (s *Scanner) filesForHeadInspection(ctx context.Context, repo repositoryLocation, options ScanOptions) ([]string, error) {
+	if options.Mode == ScanModeDelta && len(options.ChangedPaths) > 0 {
+		existing := make([]string, 0, len(options.ChangedPaths))
+		for _, path := range options.ChangedPaths {
+			if _, err := s.git(ctx, repo, "cat-file", "-e", options.HeadRevision+":"+path); err == nil {
+				existing = append(existing, path)
+			}
+		}
+		return existing, nil
+	}
+	return s.listFilesAtRevision(ctx, repo, options.HeadRevision)
+}
+
+func (s *Scanner) historyLogArgs(options ScanOptions) []string {
+	args := []string{"log", "--max-count", strconv.Itoa(s.historyLimit), "--no-color", "--unified=0", "--format=commit:%H", "-p"}
+	if options.Mode == ScanModeDelta {
+		if options.BaseRevision != "" && !isZeroRevision(options.BaseRevision) {
+			args = append(args, options.BaseRevision+".."+options.HeadRevision)
+		} else {
+			args = append(args, options.HeadRevision)
+		}
+	} else {
+		args = append(args, "--all")
+	}
+	if options.Mode == ScanModeDelta && len(options.ChangedPaths) > 0 {
+		args = append(args, "--")
+		args = append(args, options.ChangedPaths...)
+	}
+	return args
 }
 
 func (s *Scanner) git(ctx context.Context, repo repositoryLocation, args ...string) ([]byte, error) {
@@ -592,6 +725,71 @@ type addedLine struct {
 	Path   string
 	Line   int
 	Text   string
+}
+
+func normalizeScanOptions(options ScanOptions) ScanOptions {
+	mode := strings.ToLower(strings.TrimSpace(options.Mode))
+	switch mode {
+	case ScanModeQuick, ScanModeDelta, ScanModeDeep:
+	default:
+		mode = ScanModeDeep
+	}
+	return ScanOptions{
+		Mode:         mode,
+		BaseRevision: strings.TrimSpace(options.BaseRevision),
+		HeadRevision: strings.TrimSpace(options.HeadRevision),
+		ChangedPaths: normalizeScanChangedPaths(options.ChangedPaths),
+	}
+}
+
+func normalizeScanChangedPaths(paths []string) []string {
+	if len(paths) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(paths))
+	for _, path := range paths {
+		item := strings.TrimSpace(strings.ReplaceAll(path, "\\", "/"))
+		item = strings.TrimPrefix(item, "/")
+		item = strings.TrimPrefix(item, "./")
+		if item == "" || strings.Contains(item, "\x00") || strings.HasPrefix(item, "../") || strings.Contains(item, "/../") {
+			continue
+		}
+		if _, exists := seen[item]; exists {
+			continue
+		}
+		seen[item] = struct{}{}
+		normalized = append(normalized, item)
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func parseRevisionLines(output []byte) []string {
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	commits := make([]string, 0, len(lines))
+	for _, line := range lines {
+		sha := strings.TrimSpace(line)
+		if sha == "" {
+			continue
+		}
+		commits = append(commits, sha)
+	}
+	return commits
+}
+
+func isZeroRevision(revision string) bool {
+	trimmed := strings.TrimSpace(revision)
+	return len(trimmed) >= 40 && strings.Trim(trimmed, "0") == ""
+}
+
+func firstNonEmptyScanString(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }
 
 func parseAddedLines(patch []byte) []addedLine {

--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -554,13 +554,10 @@ func (s *Scanner) changedPathsForOptions(ctx context.Context, repo repositoryLoc
 	if strings.TrimSpace(options.HeadRevision) == "" {
 		return nil, nil
 	}
-	var output []byte
-	var err error
-	if options.BaseRevision != "" && !isZeroRevision(options.BaseRevision) {
-		output, err = s.git(ctx, repo, "diff", "--name-only", options.BaseRevision, options.HeadRevision)
-	} else {
-		output, err = s.git(ctx, repo, "diff-tree", "--no-commit-id", "--name-only", "-r", options.HeadRevision)
+	if options.BaseRevision == "" || isZeroRevision(options.BaseRevision) {
+		return nil, nil
 	}
+	output, err := s.git(ctx, repo, "diff", "--name-only", options.BaseRevision, options.HeadRevision)
 	if err != nil {
 		return nil, fmt.Errorf("list delta changed files: %w", err)
 	}
@@ -569,9 +566,17 @@ func (s *Scanner) changedPathsForOptions(ctx context.Context, repo repositoryLoc
 
 func (s *Scanner) filesForHeadInspection(ctx context.Context, repo repositoryLocation, options ScanOptions) ([]string, error) {
 	if options.Mode == ScanModeDelta && len(options.ChangedPaths) > 0 {
+		headFiles, err := s.listFilesAtRevision(ctx, repo, options.HeadRevision)
+		if err != nil {
+			return nil, err
+		}
+		headSet := make(map[string]struct{}, len(headFiles))
+		for _, file := range headFiles {
+			headSet[file] = struct{}{}
+		}
 		existing := make([]string, 0, len(options.ChangedPaths))
 		for _, path := range options.ChangedPaths {
-			if _, err := s.git(ctx, repo, "cat-file", "-e", options.HeadRevision+":"+path); err == nil {
+			if _, ok := headSet[path]; ok {
 				existing = append(existing, path)
 			}
 		}

--- a/internal/repoexposure/scanner_test.go
+++ b/internal/repoexposure/scanner_test.go
@@ -237,6 +237,56 @@ jobs:
 	}
 }
 
+func TestScanRepositoryWithOptionsDeltaWithoutBaseScansAllRecentPaths(t *testing.T) {
+	repo := t.TempDir()
+	runGit(t, repo, "init", "-q")
+
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("# demo\n"), 0o600); err != nil {
+		t.Fatalf("write readme: %v", err)
+	}
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-q", "-m", "initial commit")
+
+	if err := os.WriteFile(filepath.Join(repo, "old.env"), []byte("AWS_SECRET_ACCESS_KEY="+testSecretValue+"\n"), 0o600); err != nil {
+		t.Fatalf("write secret file: %v", err)
+	}
+	runGit(t, repo, "add", "old.env")
+	runGit(t, repo, "commit", "-q", "-m", "add older secret")
+	secretCommit := strings.TrimSpace(runGit(t, repo, "rev-parse", "HEAD"))
+
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("# demo\n\nfinal docs\n"), 0o600); err != nil {
+		t.Fatalf("update readme: %v", err)
+	}
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-q", "-m", "final docs")
+	head := strings.TrimSpace(runGit(t, repo, "rev-parse", "HEAD"))
+
+	scanner := NewScanner(nil,
+		WithHistoryLimit(100),
+		WithMaxFindings(50),
+		WithNow(func() time.Time { return time.Date(2026, 5, 20, 11, 0, 0, 0, time.UTC) }),
+	)
+	result, err := scanner.ScanRepositoryWithOptions(context.Background(), repo, ScanOptions{
+		Mode:         ScanModeDelta,
+		HeadRevision: head,
+	})
+	if err != nil {
+		t.Fatalf("scan repository delta failed: %v", err)
+	}
+	if len(result.ChangedPaths) != 0 {
+		t.Fatalf("expected no path restriction without a base revision, got %+v", result.ChangedPaths)
+	}
+	if result.CommitsScanned < 2 {
+		t.Fatalf("expected delta fallback to scan recent history, got %d commit(s)", result.CommitsScanned)
+	}
+	for _, finding := range result.Findings {
+		if finding.Type == domain.FindingSecretExposure && finding.Commit == secretCommit && finding.FilePath == "old.env" {
+			return
+		}
+	}
+	t.Fatalf("expected older changed path to be scanned without base revision, got %+v", result.Findings)
+}
+
 func TestDetectMisconfigFindingsParsesWorkflowSignals(t *testing.T) {
 	content := []byte(`name: ci
 on:

--- a/internal/repoexposure/scanner_test.go
+++ b/internal/repoexposure/scanner_test.go
@@ -160,6 +160,83 @@ func TestScanRepositoryDetectsHeadMisconfiguration(t *testing.T) {
 	}
 }
 
+func TestScanRepositoryWithOptionsDeltaScopesHistoryAndHeadFiles(t *testing.T) {
+	repo := t.TempDir()
+	runGit(t, repo, "init", "-q")
+
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("# demo\n"), 0o600); err != nil {
+		t.Fatalf("write readme: %v", err)
+	}
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-q", "-m", "initial commit")
+	base := strings.TrimSpace(runGit(t, repo, "rev-parse", "HEAD"))
+
+	if err := os.WriteFile(filepath.Join(repo, "app.env"), []byte("AWS_SECRET_ACCESS_KEY="+testSecretValue+"\n"), 0o600); err != nil {
+		t.Fatalf("write secret file: %v", err)
+	}
+	workflowDir := filepath.Join(repo, ".github", "workflows")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatalf("create workflow dir: %v", err)
+	}
+	workflow := `name: ci
+on:
+  pull_request_target:
+jobs:
+  test:
+    permissions: write-all
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+`
+	if err := os.WriteFile(filepath.Join(workflowDir, "build.yml"), []byte(workflow), 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	runGit(t, repo, "add", ".")
+	runGit(t, repo, "commit", "-q", "-m", "introduce repo risks")
+	head := strings.TrimSpace(runGit(t, repo, "rev-parse", "HEAD"))
+
+	scanner := NewScanner(nil,
+		WithHistoryLimit(100),
+		WithMaxFindings(50),
+		WithNow(func() time.Time { return time.Date(2026, 5, 20, 10, 0, 0, 0, time.UTC) }),
+	)
+	result, err := scanner.ScanRepositoryWithOptions(context.Background(), repo, ScanOptions{
+		Mode:         ScanModeDelta,
+		BaseRevision: base,
+		HeadRevision: head,
+		ChangedPaths: []string{"app.env", ".github/workflows/build.yml", "README.md"},
+	})
+	if err != nil {
+		t.Fatalf("scan repository delta failed: %v", err)
+	}
+	if result.ScanMode != ScanModeDelta || result.BaseRevision != base || result.HeadRevision != head {
+		t.Fatalf("unexpected delta scan metadata: %+v", result)
+	}
+	if result.CommitsScanned != 1 {
+		t.Fatalf("expected one delta commit, got %d", result.CommitsScanned)
+	}
+	if result.FilesScanned != 1 {
+		t.Fatalf("expected only changed misconfiguration file to be inspected, got %d", result.FilesScanned)
+	}
+
+	var foundSecret, foundMisconfig bool
+	for _, finding := range result.Findings {
+		switch finding.Type {
+		case domain.FindingSecretExposure:
+			if finding.Commit == head && finding.FilePath == "app.env" {
+				foundSecret = true
+			}
+		case domain.FindingRepoMisconfig:
+			if finding.Commit == head && finding.FilePath == ".github/workflows/build.yml" {
+				foundMisconfig = true
+			}
+		}
+	}
+	if !foundSecret || !foundMisconfig {
+		t.Fatalf("expected delta secret and misconfiguration findings, got %+v", result.Findings)
+	}
+}
+
 func TestDetectMisconfigFindingsParsesWorkflowSignals(t *testing.T) {
 	content := []byte(`name: ci
 on:

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -21,6 +21,8 @@ type Metrics struct {
 	RepoScanSuccessTotal                   prometheus.Counter
 	RepoScanFailureTotal                   prometheus.Counter
 	RepoScanTruncatedTotal                 prometheus.Counter
+	RepoScanModeRunsTotal                  *prometheus.CounterVec
+	RepoScanSkippedTotal                   *prometheus.CounterVec
 	RepoScanDurationMS                     prometheus.Histogram
 	ServiceAuthzDenialsTotal               *prometheus.CounterVec
 	RepoFindingsGenerated                  prometheus.Counter
@@ -160,6 +162,18 @@ func NewMetrics() *Metrics {
 			Name:      "truncated_total",
 			Help:      "Total number of repository exposure scans that reached configured scan limits.",
 		}),
+		RepoScanModeRunsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "identrail",
+			Subsystem: "repo_scan",
+			Name:      "mode_runs_total",
+			Help:      "Total repository exposure scan executions by scan mode and outcome.",
+		}, []string{"mode", "outcome"}),
+		RepoScanSkippedTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "identrail",
+			Subsystem: "repo_scan",
+			Name:      "skipped_total",
+			Help:      "Total repository exposure scans skipped before execution by mode and bounded reason.",
+		}, []string{"mode", "reason"}),
 		RepoScanDurationMS: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "identrail",
 			Subsystem: "repo_scan",

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -29,6 +29,8 @@ func TestNewMetricsCountersAndHistogram(t *testing.T) {
 	m.RepoScanSuccessTotal.Add(1)
 	m.RepoScanFailureTotal.Add(1)
 	m.RepoScanTruncatedTotal.Add(1)
+	m.RepoScanModeRunsTotal.WithLabelValues("delta", "succeeded").Add(1)
+	m.RepoScanSkippedTotal.WithLabelValues("delta", "cursor_current").Add(1)
 	m.RepoScanDurationMS.Observe(300)
 	m.ServiceAuthzDenialsTotal.WithLabelValues("repo_scans.run", "repo_scan_target").Add(1)
 	m.QueueDepth.WithLabelValues("scan").Set(2)
@@ -85,6 +87,12 @@ func TestNewMetricsCountersAndHistogram(t *testing.T) {
 	}
 	if got := testutil.ToFloat64(m.RepoScanFailureTotal); got != 1 {
 		t.Fatalf("expected repo scan failures 1, got %v", got)
+	}
+	if got := testutil.ToFloat64(m.RepoScanModeRunsTotal.WithLabelValues("delta", "succeeded")); got != 1 {
+		t.Fatalf("expected repo scan delta successes 1, got %v", got)
+	}
+	if got := testutil.ToFloat64(m.RepoScanSkippedTotal.WithLabelValues("delta", "cursor_current")); got != 1 {
+		t.Fatalf("expected repo scan skipped cursor_current 1, got %v", got)
 	}
 	if got := testutil.ToFloat64(m.ServiceAuthzDenialsTotal.WithLabelValues("repo_scans.run", "repo_scan_target")); got != 1 {
 		t.Fatalf("expected service authz denials 1, got %v", got)

--- a/migrations/000031_incremental_repo_scans.down.sql
+++ b/migrations/000031_incremental_repo_scans.down.sql
@@ -1,0 +1,21 @@
+DROP POLICY IF EXISTS repo_scan_cursors_scope_isolation ON repo_scan_cursors;
+ALTER TABLE IF EXISTS repo_scan_cursors NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS repo_scan_cursors DISABLE ROW LEVEL SECURITY;
+
+DROP INDEX IF EXISTS idx_repo_scan_cursors_scope_updated_at;
+DROP INDEX IF EXISTS idx_repo_scan_cursors_scope_repository_source;
+DROP TABLE IF EXISTS repo_scan_cursors;
+
+DROP INDEX IF EXISTS idx_repo_scans_scope_repository_head_revision;
+DROP INDEX IF EXISTS idx_repo_scans_scope_mode_started_at;
+
+ALTER TABLE repo_scans
+    DROP CONSTRAINT IF EXISTS repo_scans_scan_mode_valid;
+
+ALTER TABLE repo_scans
+    DROP COLUMN IF EXISTS changed_paths,
+    DROP COLUMN IF EXISTS cursor_after,
+    DROP COLUMN IF EXISTS cursor_before,
+    DROP COLUMN IF EXISTS head_revision,
+    DROP COLUMN IF EXISTS base_revision,
+    DROP COLUMN IF EXISTS scan_mode;

--- a/migrations/000031_incremental_repo_scans.up.sql
+++ b/migrations/000031_incremental_repo_scans.up.sql
@@ -1,0 +1,63 @@
+ALTER TABLE repo_scans
+    ADD COLUMN IF NOT EXISTS scan_mode TEXT NOT NULL DEFAULT 'deep',
+    ADD COLUMN IF NOT EXISTS base_revision TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS head_revision TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS cursor_before TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS cursor_after TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS changed_paths JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+ALTER TABLE repo_scans
+    DROP CONSTRAINT IF EXISTS repo_scans_scan_mode_valid;
+
+ALTER TABLE repo_scans
+    ADD CONSTRAINT repo_scans_scan_mode_valid
+        CHECK (scan_mode IN ('quick', 'delta', 'deep')) NOT VALID;
+
+ALTER TABLE repo_scans VALIDATE CONSTRAINT repo_scans_scan_mode_valid;
+
+CREATE INDEX IF NOT EXISTS idx_repo_scans_scope_mode_started_at
+    ON repo_scans (tenant_id, workspace_id, scan_mode, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_repo_scans_scope_repository_head_revision
+    ON repo_scans (tenant_id, workspace_id, repository, head_revision);
+
+CREATE TABLE IF NOT EXISTS repo_scan_cursors (
+    tenant_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    repository TEXT NOT NULL,
+    source_provider TEXT NOT NULL DEFAULT '',
+    source_project_id TEXT NOT NULL DEFAULT '',
+    source_connector_id TEXT NOT NULL DEFAULT '',
+    source_installation_id BIGINT NOT NULL DEFAULT 0,
+    last_scanned_revision TEXT NOT NULL,
+    last_deep_scanned_at TIMESTAMPTZ,
+    last_scan_id UUID,
+    last_scan_mode TEXT NOT NULL DEFAULT 'deep',
+    last_scan_completed_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    CONSTRAINT repo_scan_cursors_last_scanned_revision_non_empty
+        CHECK (LENGTH(TRIM(last_scanned_revision)) > 0),
+    CONSTRAINT repo_scan_cursors_last_scan_mode_valid
+        CHECK (last_scan_mode IN ('quick', 'delta', 'deep'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_repo_scan_cursors_scope_repository_source
+    ON repo_scan_cursors (
+        tenant_id,
+        workspace_id,
+        (lower(repository)),
+        source_provider,
+        source_project_id,
+        source_connector_id,
+        source_installation_id
+    );
+
+CREATE INDEX IF NOT EXISTS idx_repo_scan_cursors_scope_updated_at
+    ON repo_scan_cursors (tenant_id, workspace_id, updated_at DESC);
+
+ALTER TABLE repo_scan_cursors ENABLE ROW LEVEL SECURITY;
+ALTER TABLE repo_scan_cursors FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS repo_scan_cursors_scope_isolation ON repo_scan_cursors;
+CREATE POLICY repo_scan_cursors_scope_isolation ON repo_scan_cursors
+USING (identrail_rls_scope_matches(tenant_id, workspace_id))
+WITH CHECK (identrail_rls_scope_matches(tenant_id, workspace_id));

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -37,6 +37,12 @@ export type RepoScanRecord = {
   files_scanned: number;
   finding_count: number;
   truncated: boolean;
+  scan_mode?: 'quick' | 'delta' | 'deep';
+  base_revision?: string;
+  head_revision?: string;
+  cursor_before?: string;
+  cursor_after?: string;
+  changed_paths?: string[];
   error_message?: string;
 };
 
@@ -44,6 +50,10 @@ export type RepoScanRequest = {
   repository: string;
   project_id?: string;
   connector_id?: string;
+  scan_mode?: 'quick' | 'delta' | 'deep';
+  base_revision?: string;
+  head_revision?: string;
+  changed_paths?: string[];
   history_limit?: number;
   max_findings?: number;
 };


### PR DESCRIPTION
Fixes #1234

## What changed
- Added repo scan modes (`deep`, `delta`, `quick`) with persisted scan-mode, revision, cursor, changed-path, and truncation metadata.
- Added per-repository scan cursors so successful scans record the latest scanned head revision and already-current delta scans are skipped before queueing or execution.
- Wired GitHub push and pull-request webhooks to enqueue delta scans from commit metadata, while scheduled scan policies continue to enqueue deep scans.
- Updated repo scan storage, migrations, API/OpenAPI/client types, Prometheus metrics, docs, and tests for the new execution model.

## Why
Large GitHub estates should not repeatedly spend full-scan worker time on every webhook. Incremental scans let Identrail react quickly to changed commits/files while keeping deep scans available for scheduled backfills and drift detection.

## Impact and risk
- Adds migration `000031_incremental_repo_scans` for new repo scan metadata columns and scoped `repo_scan_cursors` storage.
- Existing manual repo scan requests remain backward compatible and default to `deep` mode.
- Delta scans require `head_revision`; invalid or already-current webhook scans are counted as skipped work rather than creating duplicate queue entries.

## Validation
- `go test ./internal/repoexposure ./internal/db ./internal/api ./internal/telemetry`
- `go test ./...`
- `go vet ./...`
- `npm run test:ci --prefix web`
- `npm run build --prefix web`
- `go test ./... -coverprofile=coverage.out`
- `go tool cover -func=coverage.out` (total: 80.1%)

## AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds incremental GitHub repo scans with `deep`, `delta`, and `quick` modes to cut redundant full scans and speed up webhook-driven checks. Push and pull-request webhooks (including forks) enqueue `delta` scans using commit/PR metadata; per-repo cursors skip already-current work and the API returns 409 when applicable.

- **New Features**
  - Persist scan metadata: `scan_mode`, base/head revisions, `cursor_before/after`, `changed_paths`, truncation.
  - Push/PR webhooks enqueue `delta` scans from `before`/`after` and changed paths; fork PRs resolve base/head repo and SHAs safely.
  - Scheduled policies enqueue `deep`; manual scans default to `deep`.
  - Skips duplicate/replayed deliveries, throttled/disabled/denylisted targets, invalid deltas, in-progress runs, queue pressure, and cursor-current heads; API may return 409 "already current".
  - Storage, `docs/openapi-v1.yaml`, `web` client types, worker, and tests updated; new Prometheus counters: `identrail_repo_scan_mode_runs_total{mode,outcome}` and `identrail_repo_scan_skipped_total{mode,reason}`.

- **Migration**
  - Run `000031_incremental_repo_scans` to add scan-mode/revision columns and `repo_scan_cursors` (with indexes and RLS). Webhook events without a valid head are recorded as skipped.

<sup>Written for commit bed04a40f20886070334250b51ecf624f303dabd. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1261?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

