### PR TITLE
Fix repo scan cursor safety after quick and truncated scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Fixed repository scan cursor safety so quick-scan cursors no longer suppress
+  later delta scans for the same head revision, and truncated scans no longer
+  advance `cursor_after` or the per-repository cursor before all findings have
+  been evaluated.
 - Added incremental repository scan execution. Repo scans now track scan mode,
   base/head revisions, cursor before/after values, and changed paths; GitHub
   push and pull-request webhooks enqueue delta scans when revision metadata is

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1134,7 +1134,7 @@ func (s *Service) EnqueueRepoScan(ctx context.Context, request RepoScanRequest) 
 	if hasCursor && scanContext.CursorBefore == "" {
 		scanContext.CursorBefore = cursor.LastScannedRevision
 	}
-	if scanContext.ScanMode == db.RepoScanModeDelta && scanContext.HeadRevision != "" && hasCursor && strings.EqualFold(cursor.LastScannedRevision, scanContext.HeadRevision) {
+	if repoScanCursorAlreadyCoversRequest(scanContext, cursor, hasCursor) {
 		s.recordRepoScanSkipped(scanContext.ScanMode, "cursor_current")
 		return db.RepoScanRecord{}, ErrRepoScanAlreadyCurrent
 	}
@@ -1284,7 +1284,7 @@ func (s *Service) RunRepoScanPersisted(ctx context.Context, request RepoScanRequ
 	if hasCursor && scanContext.CursorBefore == "" {
 		scanContext.CursorBefore = cursor.LastScannedRevision
 	}
-	if scanContext.ScanMode == db.RepoScanModeDelta && scanContext.HeadRevision != "" && hasCursor && strings.EqualFold(cursor.LastScannedRevision, scanContext.HeadRevision) {
+	if repoScanCursorAlreadyCoversRequest(scanContext, cursor, hasCursor) {
 		s.recordRepoScanSkipped(scanContext.ScanMode, "cursor_current")
 		return RunRepoScanResult{}, ErrRepoScanAlreadyCurrent
 	}
@@ -1515,6 +1515,15 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 		return RunRepoScanResult{}, fmt.Errorf("persist repo findings: %w", err)
 	}
 	cursorAfter := firstNonEmptyString(result.HeadRevision, record.HeadRevision)
+	completionContext := db.RepoScanContext{
+		ScanMode:     result.ScanMode,
+		BaseRevision: result.BaseRevision,
+		HeadRevision: result.HeadRevision,
+		ChangedPaths: append([]string(nil), result.ChangedPaths...),
+	}
+	if !result.Truncated {
+		completionContext.CursorAfter = cursorAfter
+	}
 	if err := s.completeRepoScanTerminal(
 		ctx,
 		record.ID,
@@ -1524,20 +1533,14 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 		result.FilesScanned,
 		len(result.Findings),
 		result.Truncated,
-		db.RepoScanContext{
-			ScanMode:     result.ScanMode,
-			BaseRevision: result.BaseRevision,
-			HeadRevision: result.HeadRevision,
-			CursorAfter:  cursorAfter,
-			ChangedPaths: append([]string(nil), result.ChangedPaths...),
-		},
+		completionContext,
 		"",
 	); err != nil {
 		s.recordRepoScanExecutionFailure()
 		s.recordRepoScanModeRun(record.ScanMode, "failure")
 		return RunRepoScanResult{}, fmt.Errorf("complete repo scan: %w", err)
 	}
-	if cursorAfter != "" {
+	if cursorAfter != "" && !result.Truncated {
 		completedAt := s.Now().UTC()
 		record.CursorAfter = cursorAfter
 		record.HeadRevision = firstNonEmptyString(record.HeadRevision, result.HeadRevision)
@@ -1575,6 +1578,23 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 		}
 	}
 	return RunRepoScanResult{RepoScan: record, Result: result}, nil
+}
+
+func repoScanCursorAlreadyCoversRequest(scanContext db.RepoScanContext, cursor db.RepoScanCursor, hasCursor bool) bool {
+	return scanContext.ScanMode == db.RepoScanModeDelta &&
+		scanContext.HeadRevision != "" &&
+		hasCursor &&
+		strings.EqualFold(cursor.LastScannedRevision, scanContext.HeadRevision) &&
+		repoScanCursorCoversDeltaHistory(cursor)
+}
+
+func repoScanCursorCoversDeltaHistory(cursor db.RepoScanCursor) bool {
+	switch strings.ToLower(strings.TrimSpace(cursor.LastScanMode)) {
+	case "", db.RepoScanModeDeep, db.RepoScanModeDelta:
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *Service) repoScanExecutorForRecord(ctx context.Context, record db.RepoScanRecord, historyLimit int, maxFindings int) (RepoScanExecutor, []string, error) {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -2316,6 +2316,160 @@ func TestServiceRunRepoScanPersistedUpdatesCursorAndSkipsCurrentDelta(t *testing
 	}
 }
 
+func TestServiceEnqueueRepoScanDoesNotSkipDeltaAfterQuickCursor(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.RepoScanAllowedTargets = []string{"owner/repo"}
+	now := time.Date(2026, 5, 20, 10, 0, 0, 0, time.UTC)
+	svc.Now = func() time.Time { return now }
+
+	head := "2222222222222222222222222222222222222222"
+	if err := store.UpsertRepoScanCursor(defaultScopeContext(), db.RepoScanCursor{
+		Repository:          "owner/repo",
+		LastScannedRevision: head,
+		LastScanMode:        db.RepoScanModeQuick,
+		LastScanCompletedAt: now.Add(-time.Minute),
+		UpdatedAt:           now.Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("seed quick cursor: %v", err)
+	}
+
+	record, err := svc.EnqueueRepoScan(defaultScopeContext(), RepoScanRequest{
+		Repository:   "owner/repo",
+		ScanMode:     db.RepoScanModeDelta,
+		BaseRevision: "1111111111111111111111111111111111111111",
+		HeadRevision: head,
+		ChangedPaths: []string{"app.env"},
+	})
+	if err != nil {
+		t.Fatalf("expected delta enqueue after quick cursor, got %v", err)
+	}
+	if record.ScanMode != db.RepoScanModeDelta || record.HeadRevision != head || record.CursorBefore != head {
+		t.Fatalf("expected queued delta to keep quick cursor as cursor_before without skipping, got %+v", record)
+	}
+}
+
+func TestServiceRunRepoScanPersistedDoesNotSkipDeltaAfterQuickCursor(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.RepoScanAllowedTargets = []string{"owner/repo"}
+	now := time.Date(2026, 5, 20, 10, 30, 0, 0, time.UTC)
+	svc.Now = func() time.Time { return now }
+
+	head := "2222222222222222222222222222222222222222"
+	if err := store.UpsertRepoScanCursor(defaultScopeContext(), db.RepoScanCursor{
+		Repository:          "owner/repo",
+		LastScannedRevision: head,
+		LastScanMode:        db.RepoScanModeQuick,
+		LastScanCompletedAt: now.Add(-time.Minute),
+		UpdatedAt:           now.Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("seed quick cursor: %v", err)
+	}
+	executor := &fakeRepoExecutor{
+		result: repoexposure.ScanResult{
+			Repository:     "owner/repo",
+			CommitsScanned: 2,
+			FilesScanned:   1,
+			ScanMode:       db.RepoScanModeDelta,
+			HeadRevision:   head,
+		},
+	}
+	svc.RepoScannerFactory = func(int, int) RepoScanExecutor {
+		return executor
+	}
+
+	run, err := svc.RunRepoScanPersisted(defaultScopeContext(), RepoScanRequest{
+		Repository:   "owner/repo",
+		ScanMode:     db.RepoScanModeDelta,
+		BaseRevision: "1111111111111111111111111111111111111111",
+		HeadRevision: head,
+		ChangedPaths: []string{"app.env"},
+	})
+	if err != nil {
+		t.Fatalf("expected delta run after quick cursor, got %v", err)
+	}
+	if executor.calls != 1 {
+		t.Fatalf("expected delta executor to run after quick cursor, got %d calls", executor.calls)
+	}
+	if run.RepoScan.CursorBefore != head || run.RepoScan.CursorAfter != head {
+		t.Fatalf("expected run to carry quick cursor before and completed delta cursor after, got %+v", run.RepoScan)
+	}
+	cursor, err := store.GetRepoScanCursor(defaultScopeContext(), "owner/repo", db.RepoScanSource{})
+	if err != nil {
+		t.Fatalf("get repo scan cursor: %v", err)
+	}
+	if cursor.LastScannedRevision != head || cursor.LastScanMode != db.RepoScanModeDelta || cursor.LastScanID != run.RepoScan.ID {
+		t.Fatalf("expected delta run to replace quick cursor, got %+v", cursor)
+	}
+}
+
+func TestServiceRunRepoScanPersistedDoesNotAdvanceCursorAfterTruncatedScan(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.RepoScanAllowedTargets = []string{"owner/repo"}
+	now := time.Date(2026, 5, 20, 11, 0, 0, 0, time.UTC)
+	svc.Now = func() time.Time { return now }
+
+	oldHead := "1111111111111111111111111111111111111111"
+	newHead := "2222222222222222222222222222222222222222"
+	if err := store.UpsertRepoScanCursor(defaultScopeContext(), db.RepoScanCursor{
+		Repository:          "owner/repo",
+		LastScannedRevision: oldHead,
+		LastScanID:          "old-scan-id",
+		LastScanMode:        db.RepoScanModeDelta,
+		LastScanCompletedAt: now.Add(-time.Hour),
+		UpdatedAt:           now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("seed existing cursor: %v", err)
+	}
+	executor := &fakeRepoExecutor{
+		result: repoexposure.ScanResult{
+			Repository:     "owner/repo",
+			CommitsScanned: 5,
+			FilesScanned:   3,
+			ScanMode:       db.RepoScanModeDelta,
+			BaseRevision:   oldHead,
+			HeadRevision:   newHead,
+			Truncated:      true,
+		},
+	}
+	svc.RepoScannerFactory = func(int, int) RepoScanExecutor {
+		return executor
+	}
+
+	run, err := svc.RunRepoScanPersisted(defaultScopeContext(), RepoScanRequest{
+		Repository:   "owner/repo",
+		ScanMode:     db.RepoScanModeDelta,
+		BaseRevision: oldHead,
+		HeadRevision: newHead,
+		ChangedPaths: []string{"app.env"},
+	})
+	if err != nil {
+		t.Fatalf("run truncated delta repo scan: %v", err)
+	}
+	if !run.RepoScan.Truncated || run.RepoScan.HeadRevision != newHead {
+		t.Fatalf("expected truncated run to persist head metadata, got %+v", run.RepoScan)
+	}
+	if run.RepoScan.CursorAfter != "" {
+		t.Fatalf("truncated run must not advance cursor_after, got %+v", run.RepoScan)
+	}
+	stored, err := svc.GetRepoScan(defaultScopeContext(), run.RepoScan.ID)
+	if err != nil {
+		t.Fatalf("get repo scan: %v", err)
+	}
+	if stored.CursorAfter != "" || !stored.Truncated || stored.HeadRevision != newHead {
+		t.Fatalf("stored truncated scan should retain audit metadata without cursor_after, got %+v", stored)
+	}
+	cursor, err := store.GetRepoScanCursor(defaultScopeContext(), "owner/repo", db.RepoScanSource{})
+	if err != nil {
+		t.Fatalf("get repo scan cursor: %v", err)
+	}
+	if cursor.LastScannedRevision != oldHead || cursor.LastScanID != "old-scan-id" || cursor.LastScanMode != db.RepoScanModeDelta {
+		t.Fatalf("truncated scan must not overwrite existing cursor, got %+v", cursor)
+	}
+}
+
 func TestServiceRunRepoScanPersistedDoesNotFailAfterSuccessfulCursorUpdateMiss(t *testing.T) {
 	store := &failingRepoScanCursorStore{MemoryStore: db.NewMemoryStore()}
 	svc := NewService(store, fakeScanner{}, "aws")


### PR DESCRIPTION
Fixes #1234

## What changed

This is a follow-up to the post-merge review on #1261.

- Centralized the repo-scan "already current" cursor check so delta scans are skipped only when the stored cursor came from a history-covering scan mode (`deep`, `delta`, or legacy empty mode).
- Prevented `quick` scan cursors from suppressing later delta scans for the same head revision, since quick scans do not run commit-history secret detection.
- Prevented truncated scans from writing `cursor_after` or updating the per-repository cursor, while still preserving scan audit metadata such as mode, base/head revision, changed paths, and truncated status.
- Added regression coverage for async enqueue, direct persisted scan execution, existing delta cursor behavior, and truncated scan cursor safety.
- Updated the changelog with the cursor safety fix.

## Why it changed

The late review on #1261 identified two cursor edge cases that could hide repository findings:

- A fork/dispatch quick scan could persist the same `last_scanned_revision` as a later delta request, causing the delta to return `ErrRepoScanAlreadyCurrent` even though commit-history scanning had not run for that revision.
- A truncated scan could mark its head revision as current even though it stopped early at the finding cap, causing future deltas for the same head to be skipped and leaving findings from the unscanned portion hidden.

## Impact and risk

This keeps incremental scan dedupe useful while making it mode-aware. Quick scans still record their own completion metadata, but they no longer prove that history-sensitive delta work is complete. Truncated scans still finish as terminal records with audit metadata, but they do not advance the cursor until a non-truncated run completes.

Risk is low and scoped to repository scan cursor decisions. Existing delta/deep cursor skip behavior is preserved for history-covering scans and legacy cursors.

## Validation performed

- `go test ./internal/api -run 'TestService(EnqueueRepoScanDoesNotSkipDeltaAfterQuickCursor|RunRepoScanPersisted(UpdatesCursorAndSkipsCurrentDelta|DoesNotSkipDeltaAfterQuickCursor|DoesNotAdvanceCursorAfterTruncatedScan))'` passed.
- `git diff --check` passed.
- `go test ./internal/api` passed.
- `go test ./...` passed.
- `go vet ./...` passed.

## AI disclosure

- AI-assisted: No
- Tools used: N/A
- Where used: N/A
- Human verification performed: Reviewed the post-merge review, inspected the merged cursor implementation, added focused regression tests, and ran the validation commands listed above.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make repo-scan cursor checks mode-aware to avoid skipping needed delta scans. Quick and truncated scans no longer mark the head as fully current, preventing hidden findings.

- **Bug Fixes**
  - Skip delta scans only when the stored cursor came from a history-covering mode (`deep`, `delta`, or legacy empty).
  - Quick scan cursors no longer block delta scans at the same head; deltas run and update the cursor.
  - Truncated scans keep audit metadata (mode, base/head, paths, truncated) but do not set `cursor_after` or advance the repo cursor.

<sup>Written for commit e905f956ad45d19a126926943648a8ede27ac5b2. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1263?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

