### PR TITLE
Add safe repository scan cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
   later delta scans for the same head revision, and truncated scans no longer
   advance `cursor_after` or the per-repository cursor before all findings have
   been evaluated.
+- Added a scoped repository scan cancellation path. Active queued or running
+  repository scans can now be marked terminal from the API and project UI with
+  a clear `repository scan canceled by user` activity message, freeing the
+  repository target for an immediate retry without operator database edits.
 - Added incremental repository scan execution. Repo scans now track scan mode,
   base/head revisions, cursor before/after values, and changed paths; GitHub
   push and pull-request webhooks enqueue delta scans when revision metadata is

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -3850,6 +3850,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
         "409":

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -111,6 +111,11 @@ x-identrail-route-authorizations:
     action: repo_scans.read
     resource_type: repo_scan
     resource_id_param: repo_scan_id
+  - method: POST
+    path: /v1/repo-scans/{repo_scan_id}/cancel
+    action: repo_scans.run
+    resource_type: repo_scan
+    resource_id_param: repo_scan_id
   - method: GET
     path: /v1/repo-findings
     action: repo_scans.read
@@ -3814,6 +3819,41 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+  /v1/repo-scans/{repo_scan_id}/cancel:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+    post:
+      tags: [RepositoryExposure]
+      summary: Cancel an active repository exposure scan
+      operationId: cancelRepoScan
+      parameters:
+        - in: path
+          name: repo_scan_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Repository scan canceled
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  repo_scan:
+                    $ref: "#/components/schemas/RepoScanRecord"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "500":
           $ref: "#/components/responses/InternalServerError"
         "503":

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -63,6 +63,9 @@ Read APIs:
 
 - `GET /v1/repo-scans`
 - `GET /v1/repo-scans/:repo_scan_id`
+- `POST /v1/repo-scans/:repo_scan_id/cancel` marks a queued or running scan
+  terminal with `repository scan canceled by user`, freeing the repository for
+  a fresh scan.
 - `GET /v1/repo-findings?repo_scan_id=&severity=&type=`
 - `GET /v1/repo-finding-clusters?repo_scan_id=&severity=&type=`
 - `GET /v1/repo-risk-graph?repo_scan_id=&repository=&default_branch=&severity=&type=`

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -63,9 +63,6 @@ Read APIs:
 
 - `GET /v1/repo-scans`
 - `GET /v1/repo-scans/:repo_scan_id`
-- `POST /v1/repo-scans/:repo_scan_id/cancel` marks a queued or running scan
-  terminal with `repository scan canceled by user`, freeing the repository for
-  a fresh scan.
 - `GET /v1/repo-findings?repo_scan_id=&severity=&type=`
 - `GET /v1/repo-finding-clusters?repo_scan_id=&severity=&type=`
 - `GET /v1/repo-risk-graph?repo_scan_id=&repository=&default_branch=&severity=&type=`
@@ -73,6 +70,12 @@ Read APIs:
 - repo finding responses expose stable repository and location fields when available: `repository`, `file_path`, `line_number`, `commit`, `detector`, `line_snippet`, `line_snippet_redacted`, and `source_url`
 - `source_url` is a direct GitHub blob link pinned to the detected commit when Identrail can derive one
 - grouped cluster responses roll duplicate repo findings into cluster counts with `first_seen_at`, `last_seen_at`, `spread`, and a per-occurrence `members` list
+
+Management APIs:
+
+- `POST /v1/repo-scans/:repo_scan_id/cancel` marks a queued or running scan
+  terminal with `repository scan canceled by user`, freeing the repository for
+  a fresh scan.
 
 ## What It Scans
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1126,6 +1126,31 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		})
 	})
 
+	v1.POST("/repo-scans/:repo_scan_id/cancel", func(c *gin.Context) {
+		repoScanID, ok := requiredUUIDParam(c, c.Param("repo_scan_id"), "repo_scan_id")
+		if !ok {
+			return
+		}
+
+		record, err := svc.CancelRepoScan(c.Request.Context(), repoScanID)
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "repo scan not found"})
+			case errors.Is(err, ErrRepoScanCancelUnavailable):
+				c.JSON(http.StatusConflict, gin.H{"error": "repo scan cannot be canceled"})
+			default:
+				logger.Error("cancel repo scan", requestErrorLogFields(c, opts.AuditFingerprinter, "cancel_repo_scan", telemetry.ZapError(err))...)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to cancel repo scan"})
+			}
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"repo_scan": record,
+		})
+	})
+
 	return r
 }
 

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1108,6 +1108,75 @@ func TestRouterRepoScanQueueBackpressureAndDuplicateGuard(t *testing.T) {
 	}
 }
 
+func TestRouterCancelRepoScan(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+	svc.RepoScanAllowedTargets = []string{"owner/*"}
+	svc.RepoQueueMaxPending = 1
+	r := NewRouter(logger, metrics, svc, RouterOptions{})
+
+	firstReq := httptest.NewRequest(http.MethodPost, "/v1/repo-scans", bytes.NewBufferString(`{"repository":"owner/repo"}`))
+	firstReq.Header.Set("Content-Type", "application/json")
+	firstW := httptest.NewRecorder()
+	r.ServeHTTP(firstW, firstReq)
+	if firstW.Code != http.StatusAccepted {
+		t.Fatalf("expected first repo enqueue 202, got %d", firstW.Code)
+	}
+	var firstResponse struct {
+		RepoScan db.RepoScanRecord `json:"repo_scan"`
+	}
+	if err := json.Unmarshal(firstW.Body.Bytes(), &firstResponse); err != nil {
+		t.Fatalf("decode repo scan response: %v", err)
+	}
+
+	cancelReq := httptest.NewRequest(http.MethodPost, "/v1/repo-scans/"+firstResponse.RepoScan.ID+"/cancel", nil)
+	cancelW := httptest.NewRecorder()
+	r.ServeHTTP(cancelW, cancelReq)
+	if cancelW.Code != http.StatusOK {
+		t.Fatalf("expected cancel 200, got %d body=%s", cancelW.Code, cancelW.Body.String())
+	}
+	var cancelResponse struct {
+		RepoScan db.RepoScanRecord `json:"repo_scan"`
+	}
+	if err := json.Unmarshal(cancelW.Body.Bytes(), &cancelResponse); err != nil {
+		t.Fatalf("decode cancel response: %v", err)
+	}
+	if cancelResponse.RepoScan.Status != "failed" || cancelResponse.RepoScan.ErrorMessage != userCanceledRepoScanMessage {
+		t.Fatalf("unexpected cancel response: %+v", cancelResponse.RepoScan)
+	}
+
+	retryReq := httptest.NewRequest(http.MethodPost, "/v1/repo-scans", bytes.NewBufferString(`{"repository":"owner/repo"}`))
+	retryReq.Header.Set("Content-Type", "application/json")
+	retryW := httptest.NewRecorder()
+	r.ServeHTTP(retryW, retryReq)
+	if retryW.Code != http.StatusAccepted {
+		t.Fatalf("expected retry enqueue after cancel 202, got %d", retryW.Code)
+	}
+
+	secondCancelReq := httptest.NewRequest(http.MethodPost, "/v1/repo-scans/"+firstResponse.RepoScan.ID+"/cancel", nil)
+	secondCancelW := httptest.NewRecorder()
+	r.ServeHTTP(secondCancelW, secondCancelReq)
+	if secondCancelW.Code != http.StatusConflict {
+		t.Fatalf("expected terminal cancel conflict 409, got %d", secondCancelW.Code)
+	}
+
+	invalidReq := httptest.NewRequest(http.MethodPost, "/v1/repo-scans/not-a-uuid/cancel", nil)
+	invalidW := httptest.NewRecorder()
+	r.ServeHTTP(invalidW, invalidReq)
+	if invalidW.Code != http.StatusBadRequest {
+		t.Fatalf("expected invalid scan id 400, got %d", invalidW.Code)
+	}
+
+	missingReq := httptest.NewRequest(http.MethodPost, "/v1/repo-scans/11111111-1111-1111-1111-111111111111/cancel", nil)
+	missingW := httptest.NewRecorder()
+	r.ServeHTTP(missingW, missingReq)
+	if missingW.Code != http.StatusNotFound {
+		t.Fatalf("expected missing scan 404, got %d", missingW.Code)
+	}
+}
+
 func TestRouterSupportsFindingsSortParameters(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	metrics := telemetry.NewMetrics()

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -384,6 +384,8 @@ var ErrRepoScanInProgress = errors.New("repo scan already in progress")
 // ErrRepoScanCancelUnavailable is returned when a repository scan is already terminal.
 var ErrRepoScanCancelUnavailable = errors.New("repo scan cancel is unavailable")
 
+var errRepoScanTerminalStateChanged = errors.New("repo scan terminal state changed")
+
 // ErrInvalidFindingTriageRequest indicates invalid triage payload or state transition.
 var ErrInvalidFindingTriageRequest = errors.New("invalid finding triage request")
 
@@ -1267,6 +1269,9 @@ func (s *Service) ProcessNextQueuedRepoScan(ctx context.Context) (bool, error) {
 	})
 	_, runErr := s.runRepoScanWithRecord(recordScopeCtx, record, record.HistoryLimit, record.MaxFindings)
 	if runErr != nil {
+		if errors.Is(runErr, errRepoScanTerminalStateChanged) {
+			return true, nil
+		}
 		s.recordAutomationRun("api_queue", "repo_scan", "failed")
 		s.recordWorkerJob("repo_scan", "failure")
 		s.recordWorkerDeadLetter("repo_scan")
@@ -1561,6 +1566,9 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 		completionContext,
 		"",
 	); err != nil {
+		if errors.Is(err, db.ErrConflict) {
+			return RunRepoScanResult{}, fmt.Errorf("%w: %w", errRepoScanTerminalStateChanged, err)
+		}
 		s.recordRepoScanExecutionFailure()
 		s.recordRepoScanModeRun(record.ScanMode, "failure")
 		return RunRepoScanResult{}, fmt.Errorf("complete repo scan: %w", err)
@@ -3491,7 +3499,7 @@ func (s *Service) completeRepoScanTerminal(
 		errorMessage,
 	)
 	if errors.Is(err, db.ErrConflict) {
-		return nil
+		return err
 	}
 	if !shouldRetryTerminalWrite(err) {
 		return err
@@ -3509,7 +3517,7 @@ func (s *Service) completeRepoScanTerminal(
 		errorMessage,
 	)
 	if errors.Is(err, db.ErrConflict) {
-		return nil
+		return err
 	}
 	return err
 }

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1539,6 +1539,12 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 	}
 	result.Findings = enrichFindingsWithRepoContext(result.Findings, result.Repository, record.Repository)
 	if err := s.Store.UpsertRepoFindings(ctx, record.ID, result.Findings); err != nil {
+		if errors.Is(err, db.ErrConflict) {
+			if cleanupErr := s.clearRepoScanFindingsAfterTerminalChange(ctx, record.ID); cleanupErr != nil {
+				return RunRepoScanResult{}, cleanupErr
+			}
+			return RunRepoScanResult{}, fmt.Errorf("%w: %w", errRepoScanTerminalStateChanged, err)
+		}
 		s.recordRepoScanExecutionFailure()
 		s.recordRepoScanModeRun(record.ScanMode, "failure")
 		_ = s.completeRepoScanTerminal(ctx, record.ID, "failed", s.Now().UTC(), result.CommitsScanned, result.FilesScanned, 0, result.Truncated, db.RepoScanContext{}, err.Error())
@@ -1567,6 +1573,9 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 		"",
 	); err != nil {
 		if errors.Is(err, db.ErrConflict) {
+			if cleanupErr := s.clearRepoScanFindingsAfterTerminalChange(ctx, record.ID); cleanupErr != nil {
+				return RunRepoScanResult{}, cleanupErr
+			}
 			return RunRepoScanResult{}, fmt.Errorf("%w: %w", errRepoScanTerminalStateChanged, err)
 		}
 		s.recordRepoScanExecutionFailure()
@@ -1611,6 +1620,13 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 		}
 	}
 	return RunRepoScanResult{RepoScan: record, Result: result}, nil
+}
+
+func (s *Service) clearRepoScanFindingsAfterTerminalChange(ctx context.Context, repoScanID string) error {
+	if err := s.Store.DeleteRepoFindings(ctx, repoScanID); err != nil && !errors.Is(err, db.ErrNotFound) {
+		return fmt.Errorf("clear terminal repo scan findings: %w", err)
+	}
+	return nil
 }
 
 func repoScanCursorAlreadyCoversRequest(scanContext db.RepoScanContext, cursor db.RepoScanCursor, hasCursor bool) bool {

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -40,6 +40,7 @@ const (
 	defaultRepoScanRunningStaleAfter = 35 * time.Minute
 	defaultRepoScanStaleFailureLimit = 100
 	staleRepoScanFailureMessage      = "repository scan exceeded worker timeout before reporting a terminal result"
+	userCanceledRepoScanMessage      = "repository scan canceled by user"
 	defaultGitHubWebhookReplayWindow = 24 * time.Hour
 	defaultGitHubWebhookBurstWindow  = 30 * time.Second
 	maxSourceErrorsInEvent           = 25
@@ -379,6 +380,9 @@ var ErrRepoScanAlreadyCurrent = errors.New("repo scan already current")
 
 // ErrRepoScanInProgress is returned when the same repository scan target is already running.
 var ErrRepoScanInProgress = errors.New("repo scan already in progress")
+
+// ErrRepoScanCancelUnavailable is returned when a repository scan is already terminal.
+var ErrRepoScanCancelUnavailable = errors.New("repo scan cancel is unavailable")
 
 // ErrInvalidFindingTriageRequest indicates invalid triage payload or state transition.
 var ErrInvalidFindingTriageRequest = errors.New("invalid finding triage request")
@@ -1155,6 +1159,27 @@ func (s *Service) EnqueueRepoScan(ctx context.Context, request RepoScanRequest) 
 	}
 	queuedCount := s.countQueuedRepoScansForDepth(ctx)
 	s.recordQueueDepth("repo_scan", queuedCount)
+	return record, nil
+}
+
+// CancelRepoScan marks an active repository scan terminal so the target can be retried.
+func (s *Service) CancelRepoScan(ctx context.Context, repoScanID string) (db.RepoScanRecord, error) {
+	ctx = s.scopeContext(ctx)
+	record, err := s.Store.CancelRepoScan(ctx, repoScanID, s.Now().UTC(), userCanceledRepoScanMessage)
+	if err != nil {
+		if errors.Is(err, db.ErrConflict) {
+			return db.RepoScanRecord{}, ErrRepoScanCancelUnavailable
+		}
+		return db.RepoScanRecord{}, err
+	}
+	s.recordAutomationRun("api_queue", "repo_scan", "canceled")
+	s.emitRepoScanQueueEvent(RepoScanQueueEvent{
+		Kind:       "canceled",
+		RepoScanID: record.ID,
+		Repository: record.Repository,
+		Status:     "failed",
+		Reason:     "user_canceled",
+	})
 	return record, nil
 }
 
@@ -3465,10 +3490,13 @@ func (s *Service) completeRepoScanTerminal(
 		scanContext,
 		errorMessage,
 	)
+	if errors.Is(err, db.ErrConflict) {
+		return nil
+	}
 	if !shouldRetryTerminalWrite(err) {
 		return err
 	}
-	return s.Store.CompleteRepoScan(
+	err = s.Store.CompleteRepoScan(
 		s.terminalWriteContext(ctx),
 		repoScanID,
 		status,
@@ -3480,6 +3508,10 @@ func (s *Service) completeRepoScanTerminal(
 		scanContext,
 		errorMessage,
 	)
+	if errors.Is(err, db.ErrConflict) {
+		return nil
+	}
+	return err
 }
 
 func shouldRetryTerminalWrite(err error) bool {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -4042,6 +4042,42 @@ func TestServiceEnqueueRepoScanGuards(t *testing.T) {
 	}
 }
 
+func TestServiceCancelRepoScanReleasesTarget(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.RepoScanAllowedTargets = []string{"owner/*"}
+	svc.RepoQueueMaxPending = 1
+	svc.Now = func() time.Time { return time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC) }
+
+	queued, err := svc.EnqueueRepoScan(defaultScopeContext(), RepoScanRequest{Repository: "owner/repo"})
+	if err != nil {
+		t.Fatalf("enqueue repo scan: %v", err)
+	}
+	canceled, err := svc.CancelRepoScan(defaultScopeContext(), queued.ID)
+	if err != nil {
+		t.Fatalf("cancel repo scan: %v", err)
+	}
+	if canceled.Status != "failed" || canceled.ErrorMessage != userCanceledRepoScanMessage {
+		t.Fatalf("unexpected canceled repo scan: %+v", canceled)
+	}
+	if err := svc.completeRepoScanTerminal(defaultScopeContext(), queued.ID, "completed", svc.Now().Add(time.Minute), 3, 2, 1, false, db.RepoScanContext{}, ""); err != nil {
+		t.Fatalf("stale terminal completion after cancel should be ignored: %v", err)
+	}
+	afterCompletion, err := store.GetRepoScan(defaultScopeContext(), queued.ID)
+	if err != nil {
+		t.Fatalf("get canceled repo scan: %v", err)
+	}
+	if afterCompletion.Status != "failed" || afterCompletion.ErrorMessage != userCanceledRepoScanMessage {
+		t.Fatalf("expected stale completion not to overwrite cancel, got %+v", afterCompletion)
+	}
+	if _, err := svc.EnqueueRepoScan(defaultScopeContext(), RepoScanRequest{Repository: "owner/repo"}); err != nil {
+		t.Fatalf("enqueue repo scan after cancel: %v", err)
+	}
+	if _, err := svc.CancelRepoScan(defaultScopeContext(), queued.ID); !errors.Is(err, ErrRepoScanCancelUnavailable) {
+		t.Fatalf("expected cancel unavailable for terminal scan, got %v", err)
+	}
+}
+
 func TestServiceProcessQueuedRepoScanAcrossScopes(t *testing.T) {
 	store := db.NewMemoryStore()
 	svc := NewService(store, fakeScanner{}, "aws")

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -44,18 +44,22 @@ func (a *fakeAlerter) NotifyScan(context.Context, string, db.ScanRecord, []domai
 }
 
 type fakeRepoExecutor struct {
-	result  repoexposure.ScanResult
-	err     error
-	target  string
-	runCtx  context.Context
-	options repoexposure.ScanOptions
-	calls   int
+	result       repoexposure.ScanResult
+	err          error
+	target       string
+	runCtx       context.Context
+	options      repoexposure.ScanOptions
+	beforeReturn func(context.Context, string)
+	calls        int
 }
 
 func (f *fakeRepoExecutor) ScanRepository(ctx context.Context, target string) (repoexposure.ScanResult, error) {
 	f.calls++
 	f.target = target
 	f.runCtx = ctx
+	if f.beforeReturn != nil {
+		f.beforeReturn(ctx, target)
+	}
 	if f.err != nil {
 		return repoexposure.ScanResult{}, f.err
 	}
@@ -4060,8 +4064,8 @@ func TestServiceCancelRepoScanReleasesTarget(t *testing.T) {
 	if canceled.Status != "failed" || canceled.ErrorMessage != userCanceledRepoScanMessage {
 		t.Fatalf("unexpected canceled repo scan: %+v", canceled)
 	}
-	if err := svc.completeRepoScanTerminal(defaultScopeContext(), queued.ID, "completed", svc.Now().Add(time.Minute), 3, 2, 1, false, db.RepoScanContext{}, ""); err != nil {
-		t.Fatalf("stale terminal completion after cancel should be ignored: %v", err)
+	if err := svc.completeRepoScanTerminal(defaultScopeContext(), queued.ID, "completed", svc.Now().Add(time.Minute), 3, 2, 1, false, db.RepoScanContext{}, ""); !errors.Is(err, db.ErrConflict) {
+		t.Fatalf("expected stale terminal completion after cancel to conflict, got %v", err)
 	}
 	afterCompletion, err := store.GetRepoScan(defaultScopeContext(), queued.ID)
 	if err != nil {
@@ -4075,6 +4079,70 @@ func TestServiceCancelRepoScanReleasesTarget(t *testing.T) {
 	}
 	if _, err := svc.CancelRepoScan(defaultScopeContext(), queued.ID); !errors.Is(err, ErrRepoScanCancelUnavailable) {
 		t.Fatalf("expected cancel unavailable for terminal scan, got %v", err)
+	}
+}
+
+func TestServiceProcessQueuedRepoScanDoesNotAdvanceCursorAfterCancelDuringRun(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.RepoScanAllowedTargets = []string{"owner/*"}
+	now := time.Date(2026, 5, 20, 12, 30, 0, 0, time.UTC)
+	svc.Now = func() time.Time { return now }
+	scopeCtx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	head := "2222222222222222222222222222222222222222"
+	var queued db.RepoScanRecord
+	var events []RepoScanQueueEvent
+	svc.OnRepoScanQueueEvent = func(event RepoScanQueueEvent) {
+		events = append(events, event)
+	}
+	svc.RepoScannerFactory = func(int, int) RepoScanExecutor {
+		return &fakeRepoExecutor{
+			beforeReturn: func(context.Context, string) {
+				if _, err := svc.CancelRepoScan(scopeCtx, queued.ID); err != nil {
+					t.Errorf("cancel repo scan during run: %v", err)
+				}
+			},
+			result: repoexposure.ScanResult{
+				Repository:     "owner/repo",
+				CommitsScanned: 1,
+				FilesScanned:   1,
+				ScanMode:       db.RepoScanModeDelta,
+				HeadRevision:   head,
+			},
+		}
+	}
+
+	var err error
+	queued, err = svc.EnqueueRepoScan(scopeCtx, RepoScanRequest{
+		Repository:   "owner/repo",
+		ScanMode:     db.RepoScanModeDelta,
+		HeadRevision: head,
+	})
+	if err != nil {
+		t.Fatalf("enqueue repo scan: %v", err)
+	}
+
+	processed, err := svc.ProcessNextQueuedRepoScan(defaultScopeContext())
+	if err != nil {
+		t.Fatalf("process canceled repo scan: %v", err)
+	}
+	if !processed {
+		t.Fatal("expected canceled repo scan to count as processed")
+	}
+	stored, err := store.GetRepoScan(scopeCtx, queued.ID)
+	if err != nil {
+		t.Fatalf("get canceled repo scan: %v", err)
+	}
+	if stored.Status != "failed" || stored.ErrorMessage != userCanceledRepoScanMessage || stored.CursorAfter != "" {
+		t.Fatalf("expected canceled scan to stay failed without cursor_after, got %+v", stored)
+	}
+	if _, err := store.GetRepoScanCursor(scopeCtx, "owner/repo", db.RepoScanSource{}); !errors.Is(err, db.ErrNotFound) {
+		t.Fatalf("expected canceled scan not to advance cursor, got %v", err)
+	}
+	for _, event := range events {
+		if event.Kind == "succeeded" {
+			t.Fatalf("canceled scan must not emit success event, got events %+v", events)
+		}
 	}
 }
 

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -125,6 +125,11 @@ type completionContextStore struct {
 	lastRepoScanCompletionCtxErr error
 }
 
+type cancelOnCompleteRepoScanStore struct {
+	*db.MemoryStore
+	now time.Time
+}
+
 type failingCompleteScanStore struct {
 	*db.MemoryStore
 }
@@ -197,6 +202,37 @@ func (s *completionContextStore) CompleteRepoScan(
 	errorMessage string,
 ) error {
 	s.lastRepoScanCompletionCtxErr = ctx.Err()
+	return s.MemoryStore.CompleteRepoScan(
+		ctx,
+		repoScanID,
+		status,
+		finishedAt,
+		commitsScanned,
+		filesScanned,
+		findingCount,
+		truncated,
+		scanContext,
+		errorMessage,
+	)
+}
+
+func (s *cancelOnCompleteRepoScanStore) CompleteRepoScan(
+	ctx context.Context,
+	repoScanID string,
+	status string,
+	finishedAt time.Time,
+	commitsScanned int,
+	filesScanned int,
+	findingCount int,
+	truncated bool,
+	scanContext db.RepoScanContext,
+	errorMessage string,
+) error {
+	cancelAt := s.now
+	if cancelAt.IsZero() {
+		cancelAt = finishedAt
+	}
+	_, _ = s.MemoryStore.CancelRepoScan(ctx, repoScanID, cancelAt, userCanceledRepoScanMessage)
 	return s.MemoryStore.CompleteRepoScan(
 		ctx,
 		repoScanID,
@@ -4106,8 +4142,14 @@ func TestServiceProcessQueuedRepoScanDoesNotAdvanceCursorAfterCancelDuringRun(t 
 				Repository:     "owner/repo",
 				CommitsScanned: 1,
 				FilesScanned:   1,
-				ScanMode:       db.RepoScanModeDelta,
-				HeadRevision:   head,
+				Findings: []domain.Finding{{
+					ID:        "rf-canceled-before-upsert",
+					Type:      domain.FindingSecretExposure,
+					Severity:  domain.SeverityHigh,
+					CreatedAt: now,
+				}},
+				ScanMode:     db.RepoScanModeDelta,
+				HeadRevision: head,
 			},
 		}
 	}
@@ -4139,10 +4181,71 @@ func TestServiceProcessQueuedRepoScanDoesNotAdvanceCursorAfterCancelDuringRun(t 
 	if _, err := store.GetRepoScanCursor(scopeCtx, "owner/repo", db.RepoScanSource{}); !errors.Is(err, db.ErrNotFound) {
 		t.Fatalf("expected canceled scan not to advance cursor, got %v", err)
 	}
+	findings, err := svc.ListRepoFindings(scopeCtx, 10, db.RepoFindingFilter{RepoScanID: queued.ID})
+	if err != nil {
+		t.Fatalf("list canceled scan findings: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected canceled scan not to persist findings, got %+v", findings)
+	}
 	for _, event := range events {
 		if event.Kind == "succeeded" {
 			t.Fatalf("canceled scan must not emit success event, got events %+v", events)
 		}
+	}
+}
+
+func TestServiceProcessQueuedRepoScanClearsFindingsWhenCancelWinsCompletion(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 45, 0, 0, time.UTC)
+	store := &cancelOnCompleteRepoScanStore{
+		MemoryStore: db.NewMemoryStore(),
+		now:         now.Add(2 * time.Minute),
+	}
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.RepoScanAllowedTargets = []string{"owner/*"}
+	svc.Now = func() time.Time { return now }
+	scopeCtx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	svc.RepoScannerFactory = func(int, int) RepoScanExecutor {
+		return &fakeRepoExecutor{
+			result: repoexposure.ScanResult{
+				Repository:     "owner/repo",
+				CommitsScanned: 1,
+				FilesScanned:   1,
+				Findings: []domain.Finding{{
+					ID:        "rf-canceled-after-upsert",
+					Type:      domain.FindingSecretExposure,
+					Severity:  domain.SeverityHigh,
+					CreatedAt: now,
+				}},
+			},
+		}
+	}
+
+	queued, err := svc.EnqueueRepoScan(scopeCtx, RepoScanRequest{Repository: "owner/repo"})
+	if err != nil {
+		t.Fatalf("enqueue repo scan: %v", err)
+	}
+
+	processed, err := svc.ProcessNextQueuedRepoScan(defaultScopeContext())
+	if err != nil {
+		t.Fatalf("process canceled repo scan: %v", err)
+	}
+	if !processed {
+		t.Fatal("expected canceled repo scan to count as processed")
+	}
+	stored, err := store.GetRepoScan(scopeCtx, queued.ID)
+	if err != nil {
+		t.Fatalf("get canceled repo scan: %v", err)
+	}
+	if stored.Status != "failed" || stored.ErrorMessage != userCanceledRepoScanMessage {
+		t.Fatalf("expected canceled scan to stay failed, got %+v", stored)
+	}
+	findings, err := svc.ListRepoFindings(scopeCtx, 10, db.RepoFindingFilter{RepoScanID: queued.ID})
+	if err != nil {
+		t.Fatalf("list canceled scan findings: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected terminal conflict cleanup to remove repo findings, got %+v", findings)
 	}
 }
 

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -2260,6 +2260,9 @@ func (m *MemoryStore) UpsertRepoFindings(ctx context.Context, repoScanID string,
 	if !exists || !MatchScope(scope, repoScan.TenantID, repoScan.WorkspaceID) {
 		return ErrNotFound
 	}
+	if repoScan.Status != "queued" && repoScan.Status != "running" {
+		return ErrConflict
+	}
 	for _, finding := range findings {
 		finding.ScanID = repoScanID
 		domain.NormalizeRepoFindingMetadata(&finding)
@@ -2267,6 +2270,26 @@ func (m *MemoryStore) UpsertRepoFindings(ctx context.Context, repoScanID string,
 		m.repoFindings[key] = finding
 		m.repoFindingIDs[repoScanID] = appendUniqueID(m.repoFindingIDs[repoScanID], key)
 	}
+	return nil
+}
+
+// DeleteRepoFindings removes all persisted repository findings for one scan.
+func (m *MemoryStore) DeleteRepoFindings(ctx context.Context, repoScanID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	repoScan, exists := m.repoScans[repoScanID]
+	if !exists || !MatchScope(scope, repoScan.TenantID, repoScan.WorkspaceID) {
+		return ErrNotFound
+	}
+	for _, key := range m.repoFindingIDs[repoScanID] {
+		delete(m.repoFindings, key)
+	}
+	delete(m.repoFindingIDs, repoScanID)
 	return nil
 }
 

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -2130,6 +2130,30 @@ func (m *MemoryStore) GetRepoScan(ctx context.Context, repoScanID string) (RepoS
 	return record, nil
 }
 
+// CancelRepoScan marks a queued or running repository scan as terminal failed.
+func (m *MemoryStore) CancelRepoScan(ctx context.Context, repoScanID string, finishedAt time.Time, errorMessage string) (RepoScanRecord, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return RepoScanRecord{}, err
+	}
+	record, exists := m.repoScans[repoScanID]
+	if !exists || !MatchScope(scope, record.TenantID, record.WorkspaceID) {
+		return RepoScanRecord{}, ErrNotFound
+	}
+	if record.Status != "queued" && record.Status != "running" {
+		return RepoScanRecord{}, ErrConflict
+	}
+	finished := finishedAt.UTC()
+	record.Status = "failed"
+	record.FinishedAt = &finished
+	record.ErrorMessage = strings.TrimSpace(errorMessage)
+	m.repoScans[repoScanID] = record
+	return record, nil
+}
+
 // CompleteRepoScan finalizes repo scan metadata.
 func (m *MemoryStore) CompleteRepoScan(ctx context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, scanContext RepoScanContext, errorMessage string) error {
 	m.mu.Lock()
@@ -2142,6 +2166,9 @@ func (m *MemoryStore) CompleteRepoScan(ctx context.Context, repoScanID string, s
 	record, exists := m.repoScans[repoScanID]
 	if !exists || !MatchScope(scope, record.TenantID, record.WorkspaceID) {
 		return ErrNotFound
+	}
+	if record.Status != "queued" && record.Status != "running" {
+		return ErrConflict
 	}
 	normalizedContext := NormalizeRepoScanContext(scanContext)
 	finished := finishedAt.UTC()

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -1242,6 +1242,48 @@ func TestMemoryStoreRepoQueueLifecycle(t *testing.T) {
 	}
 }
 
+func TestMemoryStoreCancelRepoScanReleasesPendingTarget(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+
+	queued, err := store.CreateQueuedRepoScan(defaultScopeContext(), "owner/repo", RepoScanSource{}, RepoScanContext{}, 50, 80, now)
+	if err != nil {
+		t.Fatalf("create queued repo scan: %v", err)
+	}
+
+	canceled, err := store.CancelRepoScan(defaultScopeContext(), queued.ID, now.Add(time.Minute), "repository scan canceled by user")
+	if err != nil {
+		t.Fatalf("cancel repo scan: %v", err)
+	}
+	if canceled.Status != "failed" || canceled.FinishedAt == nil || canceled.ErrorMessage != "repository scan canceled by user" {
+		t.Fatalf("unexpected canceled scan: %+v", canceled)
+	}
+	if err := store.CompleteRepoScan(defaultScopeContext(), queued.ID, "completed", now.Add(2*time.Minute), 4, 2, 1, false, RepoScanContext{}, ""); !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected canceled scan completion conflict, got %v", err)
+	}
+	afterCompletion, err := store.GetRepoScan(defaultScopeContext(), queued.ID)
+	if err != nil {
+		t.Fatalf("get canceled repo scan: %v", err)
+	}
+	if afterCompletion.Status != "failed" || afterCompletion.ErrorMessage != "repository scan canceled by user" {
+		t.Fatalf("expected canceled scan to stay terminal, got %+v", afterCompletion)
+	}
+
+	pendingCount, err := store.CountPendingRepoScansByRepository(defaultScopeContext(), "owner/repo")
+	if err != nil {
+		t.Fatalf("count pending repo scans: %v", err)
+	}
+	if pendingCount != 0 {
+		t.Fatalf("expected canceled scan to release pending target, got %d", pendingCount)
+	}
+	if _, err := store.CreateQueuedRepoScanWithinLimit(defaultScopeContext(), "owner/repo", RepoScanSource{}, RepoScanContext{}, 50, 80, now.Add(2*time.Minute), 1); err != nil {
+		t.Fatalf("create fresh queued repo scan after cancel: %v", err)
+	}
+	if _, err := store.CancelRepoScan(defaultScopeContext(), queued.ID, now.Add(3*time.Minute), "again"); !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected terminal cancel conflict, got %v", err)
+	}
+}
+
 func TestMemoryStoreCountQueuedRepoScansAnyScope(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 21, 9, 5, 0, 0, time.UTC)

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -679,6 +679,34 @@ func TestMemoryStoreRepoScanLifecycle(t *testing.T) {
 	}
 }
 
+func TestMemoryStoreDeleteRepoFindings(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", RepoScanSource{}, RepoScanContext{}, now)
+	if err != nil {
+		t.Fatalf("create repo scan: %v", err)
+	}
+	if err := store.UpsertRepoFindings(defaultScopeContext(), repoScan.ID, []domain.Finding{{
+		ID:        "rf-1",
+		Type:      domain.FindingSecretExposure,
+		Severity:  domain.SeverityHigh,
+		CreatedAt: now,
+	}}); err != nil {
+		t.Fatalf("upsert repo finding: %v", err)
+	}
+	if err := store.DeleteRepoFindings(defaultScopeContext(), repoScan.ID); err != nil {
+		t.Fatalf("delete repo findings: %v", err)
+	}
+	findings, err := store.ListRepoFindings(defaultScopeContext(), RepoFindingFilter{RepoScanID: repoScan.ID}, 10)
+	if err != nil {
+		t.Fatalf("list repo findings: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected repo findings to be deleted, got %+v", findings)
+	}
+}
+
 func TestMemoryStoreGetRepoScanCursorCopiesPointerFields(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
@@ -1267,6 +1295,14 @@ func TestMemoryStoreCancelRepoScanReleasesPendingTarget(t *testing.T) {
 	}
 	if afterCompletion.Status != "failed" || afterCompletion.ErrorMessage != "repository scan canceled by user" {
 		t.Fatalf("expected canceled scan to stay terminal, got %+v", afterCompletion)
+	}
+	if err := store.UpsertRepoFindings(defaultScopeContext(), queued.ID, []domain.Finding{{
+		ID:        "rf-canceled",
+		Type:      domain.FindingSecretExposure,
+		Severity:  domain.SeverityHigh,
+		CreatedAt: now,
+	}}); !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected canceled scan finding upsert conflict, got %v", err)
 	}
 
 	pendingCount, err := store.CountPendingRepoScansByRepository(defaultScopeContext(), "owner/repo")

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -3046,6 +3046,45 @@ func (p *PostgresStore) GetRepoScan(ctx context.Context, repoScanID string) (Rep
 	return record, nil
 }
 
+// CancelRepoScan atomically marks a queued or running repository scan as terminal failed.
+func (p *PostgresStore) CancelRepoScan(ctx context.Context, repoScanID string, finishedAt time.Time, errorMessage string) (RepoScanRecord, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return RepoScanRecord{}, err
+	}
+	row := p.queryRowContext(
+		ctx,
+		`UPDATE repo_scans
+		 SET status = 'failed',
+		     finished_at = $2,
+		     error_message = NULLIF($3, '')
+		 WHERE id = $1
+		   AND tenant_id = $4
+		   AND workspace_id = $5
+		   AND status IN ('queued', 'running')
+		 RETURNING id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(scan_mode, 'deep'), COALESCE(base_revision, ''), COALESCE(head_revision, ''), COALESCE(cursor_before, ''), COALESCE(cursor_after, ''), COALESCE(changed_paths, '[]'::jsonb), COALESCE(error_message, ''), history_limit, max_findings_limit, COALESCE(source_provider, ''), COALESCE(source_project_id, ''), COALESCE(source_connector_id, ''), COALESCE(source_installation_id, 0)`,
+		repoScanID,
+		finishedAt.UTC(),
+		strings.TrimSpace(errorMessage),
+		scope.TenantID,
+		scope.WorkspaceID,
+	)
+	record, err := scanRepoScanRecord(row)
+	if err == nil {
+		return record, nil
+	}
+	if !errorsIsNoRows(err) {
+		return RepoScanRecord{}, fmt.Errorf("cancel repo scan: %w", err)
+	}
+	_, getErr := p.GetRepoScan(ctx, repoScanID)
+	if getErr == nil {
+		return RepoScanRecord{}, ErrConflict
+	} else if errors.Is(getErr, ErrNotFound) {
+		return RepoScanRecord{}, ErrNotFound
+	}
+	return RepoScanRecord{}, fmt.Errorf("cancel repo scan lookup: %w", getErr)
+}
+
 // CompleteRepoScan updates repository scan completion metadata.
 func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, scanContext RepoScanContext, errorMessage string) error {
 	scope, err := RequireScope(ctx)
@@ -3077,7 +3116,8 @@ func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string,
 		     error_message = $12
 		 WHERE id = $1
 		   AND tenant_id = $13
-		   AND workspace_id = $14`,
+		   AND workspace_id = $14
+		   AND status IN ('queued', 'running')`,
 		repoScanID,
 		strings.TrimSpace(status),
 		finishedAt.UTC(),
@@ -3097,6 +3137,15 @@ func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string,
 		return fmt.Errorf("complete repo scan: %w", err)
 	}
 	if err := ensureRowsAffected(result); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			_, getErr := p.GetRepoScan(ctx, repoScanID)
+			if getErr == nil {
+				return ErrConflict
+			} else if errors.Is(getErr, ErrNotFound) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("complete repo scan lookup: %w", getErr)
+		}
 		return err
 	}
 	return nil

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -3247,7 +3247,7 @@ func (p *PostgresStore) UpsertRepoScanCursor(ctx context.Context, cursor RepoSca
 
 // UpsertRepoFindings inserts repository findings idempotently.
 func (p *PostgresStore) UpsertRepoFindings(ctx context.Context, repoScanID string, findings []domain.Finding) error {
-	if err := p.ensureRepoScanInScope(ctx, repoScanID); err != nil {
+	if err := p.ensureActiveRepoScanInScope(ctx, repoScanID); err != nil {
 		return err
 	}
 	tx, err := p.beginTx(ctx)
@@ -3309,6 +3309,33 @@ func (p *PostgresStore) UpsertRepoFindings(ctx context.Context, repoScanID strin
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit repo findings transaction: %w", err)
+	}
+	return nil
+}
+
+// DeleteRepoFindings removes repository findings for one scan.
+func (p *PostgresStore) DeleteRepoFindings(ctx context.Context, repoScanID string) error {
+	if err := p.ensureRepoScanInScope(ctx, repoScanID); err != nil {
+		return err
+	}
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = p.execContext(
+		ctx,
+		`DELETE FROM repo_findings rf
+		 USING repo_scans rs
+		 WHERE rf.repo_scan_id = rs.id
+		   AND rf.repo_scan_id = $1
+		   AND rs.tenant_id = $2
+		   AND rs.workspace_id = $3`,
+		repoScanID,
+		scope.TenantID,
+		scope.WorkspaceID,
+	)
+	if err != nil {
+		return fmt.Errorf("delete repo findings: %w", err)
 	}
 	return nil
 }
@@ -4785,6 +4812,35 @@ func (p *PostgresStore) ensureRepoScanInScope(ctx context.Context, repoScanID st
 	}
 	if !exists {
 		return ErrNotFound
+	}
+	return nil
+}
+
+func (p *PostgresStore) ensureActiveRepoScanInScope(ctx context.Context, repoScanID string) error {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return err
+	}
+	var status string
+	err = p.queryRowContext(
+		ctx,
+		`SELECT status
+		 FROM repo_scans
+		 WHERE id = $1
+		   AND tenant_id = $2
+		   AND workspace_id = $3`,
+		repoScanID,
+		scope.TenantID,
+		scope.WorkspaceID,
+	).Scan(&status)
+	if err != nil {
+		if errorsIsNoRows(err) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("verify active repo scan scope: %w", err)
+	}
+	if status != "queued" && status != "running" {
+		return ErrConflict
 	}
 	return nil
 }

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -717,7 +717,8 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		     error_message = $12
 		 WHERE id = $1
 		   AND tenant_id = $13
-		   AND workspace_id = $14`)).
+		   AND workspace_id = $14
+		   AND status IN ('queued', 'running')`)).
 		WithArgs(record.ID, "completed", sqlmock.AnyArg(), 12, 8, 1, false, "", "", "", "[]", nil, "default", "default").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -1612,6 +1613,143 @@ func TestPostgresStoreRepoScanCursorLifecycle(t *testing.T) {
 	}
 	if cursor.LastDeepScannedAt != nil {
 		t.Fatalf("delta cursor should not overwrite deep scan timestamp, got %+v", cursor.LastDeepScannedAt)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreCompleteRepoScanReturnsConflictForTerminalScan(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	scanID := "11111111-1111-1111-1111-111111111111"
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE repo_scans
+		 SET status = $2,
+		     finished_at = $3,
+		     commits_scanned = $4,
+		     files_scanned = $5,
+		     finding_count = $6,
+		     truncated = $7,
+		     cursor_after = NULLIF($8, ''),
+		     base_revision = COALESCE(NULLIF($9, ''), base_revision),
+		     head_revision = COALESCE(NULLIF($10, ''), head_revision),
+		     changed_paths = CASE WHEN $11::jsonb <> '[]'::jsonb THEN $11::jsonb ELSE changed_paths END,
+		     error_message = $12
+		 WHERE id = $1
+		   AND tenant_id = $13
+		   AND workspace_id = $14
+		   AND status IN ('queued', 'running')`)).
+		WithArgs(scanID, "completed", now, 4, 2, 1, false, "", "", "", "[]", nil, "default", "default").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	rows := sqlmock.NewRows([]string{
+		"id",
+		"tenant_id",
+		"workspace_id",
+		"repository",
+		"status",
+		"started_at",
+		"finished_at",
+		"commits_scanned",
+		"files_scanned",
+		"finding_count",
+		"truncated",
+		"scan_mode",
+		"base_revision",
+		"head_revision",
+		"cursor_before",
+		"cursor_after",
+		"changed_paths",
+		"error_message",
+		"history_limit",
+		"max_findings_limit",
+		"source_provider",
+		"source_project_id",
+		"source_connector_id",
+		"source_installation_id",
+	}).AddRow(scanID, "default", "default", "owner/repo", "failed", now, now.Add(time.Minute), 0, 0, 0, false, "deep", "", "", "", "", []byte("[]"), "repository scan canceled by user", 50, 80, "github_app", "project-1", "github", int64(77))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(scan_mode, 'deep'), COALESCE(base_revision, ''), COALESCE(head_revision, ''), COALESCE(cursor_before, ''), COALESCE(cursor_after, ''), COALESCE(changed_paths, '[]'::jsonb), COALESCE(error_message, ''), history_limit, max_findings_limit, COALESCE(source_provider, ''), COALESCE(source_project_id, ''), COALESCE(source_connector_id, ''), COALESCE(source_installation_id, 0)
+		 FROM repo_scans
+		 WHERE id = $1
+		   AND tenant_id = $2
+		   AND workspace_id = $3`)).
+		WithArgs(scanID, "default", "default").
+		WillReturnRows(rows)
+
+	err = store.CompleteRepoScan(defaultScopeContext(), scanID, "completed", now, 4, 2, 1, false, RepoScanContext{}, "")
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected terminal repo scan conflict, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreCancelRepoScan(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	scanID := "11111111-1111-1111-1111-111111111111"
+	startedAt := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	finishedAt := startedAt.Add(5 * time.Minute)
+	cancelMessage := "repository scan canceled by user"
+	cancelRows := sqlmock.NewRows([]string{
+		"id",
+		"tenant_id",
+		"workspace_id",
+		"repository",
+		"status",
+		"started_at",
+		"finished_at",
+		"commits_scanned",
+		"files_scanned",
+		"finding_count",
+		"truncated",
+		"scan_mode",
+		"base_revision",
+		"head_revision",
+		"cursor_before",
+		"cursor_after",
+		"changed_paths",
+		"error_message",
+		"history_limit",
+		"max_findings_limit",
+		"source_provider",
+		"source_project_id",
+		"source_connector_id",
+		"source_installation_id",
+	}).AddRow(scanID, "default", "default", "owner/repo", "failed", startedAt, finishedAt, 0, 0, 0, false, "deep", "", "", "", "", []byte("[]"), cancelMessage, 50, 80, "github_app", "project-1", "github", int64(77))
+
+	mock.ExpectQuery(regexp.QuoteMeta(`UPDATE repo_scans
+		 SET status = 'failed',
+		     finished_at = $2,
+		     error_message = NULLIF($3, '')
+		 WHERE id = $1
+		   AND tenant_id = $4
+		   AND workspace_id = $5
+		   AND status IN ('queued', 'running')
+		 RETURNING id, tenant_id, workspace_id, repository, status, started_at, finished_at, commits_scanned, files_scanned, finding_count, truncated, COALESCE(scan_mode, 'deep'), COALESCE(base_revision, ''), COALESCE(head_revision, ''), COALESCE(cursor_before, ''), COALESCE(cursor_after, ''), COALESCE(changed_paths, '[]'::jsonb), COALESCE(error_message, ''), history_limit, max_findings_limit, COALESCE(source_provider, ''), COALESCE(source_project_id, ''), COALESCE(source_connector_id, ''), COALESCE(source_installation_id, 0)`)).
+		WithArgs(scanID, finishedAt, cancelMessage, "default", "default").
+		WillReturnRows(cancelRows)
+
+	canceled, err := store.CancelRepoScan(defaultScopeContext(), scanID, finishedAt, " "+cancelMessage+" ")
+	if err != nil {
+		t.Fatalf("cancel repo scan: %v", err)
+	}
+	if canceled.Status != "failed" || canceled.ErrorMessage != cancelMessage || canceled.FinishedAt == nil {
+		t.Fatalf("unexpected canceled repo scan: %+v", canceled)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -674,15 +674,13 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		t.Fatalf("create repo scan failed: %v", err)
 	}
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT EXISTS (
-			SELECT 1
-			FROM repo_scans
-			WHERE id = $1
-			  AND tenant_id = $2
-			  AND workspace_id = $3
-		)`)).
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT status
+		 FROM repo_scans
+		 WHERE id = $1
+		   AND tenant_id = $2
+		   AND workspace_id = $3`)).
 		WithArgs(record.ID, "default", "default").
-		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+		WillReturnRows(sqlmock.NewRows([]string{"status"}).AddRow("running"))
 	mock.ExpectBegin()
 	mock.ExpectExec("INSERT INTO repo_findings").
 		WithArgs(record.ID, "rf-1", "secret_exposure", "high", "secret", "summary", sqlmock.AnyArg(), sqlmock.AnyArg(), "fix", sqlmock.AnyArg()).
@@ -794,6 +792,73 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		t.Fatalf("unexpected repo scan: %+v", gotRepoScan)
 	}
 
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreUpsertRepoFindingsRejectsTerminalScan(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	scanID := "11111111-1111-1111-1111-111111111111"
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT status
+		 FROM repo_scans
+		 WHERE id = $1
+		   AND tenant_id = $2
+		   AND workspace_id = $3`)).
+		WithArgs(scanID, "default", "default").
+		WillReturnRows(sqlmock.NewRows([]string{"status"}).AddRow("failed"))
+
+	err = store.UpsertRepoFindings(defaultScopeContext(), scanID, []domain.Finding{{
+		ID:       "rf-canceled",
+		Type:     domain.FindingSecretExposure,
+		Severity: domain.SeverityHigh,
+	}})
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected terminal scan conflict, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStoreDeleteRepoFindings(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	scanID := "11111111-1111-1111-1111-111111111111"
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT EXISTS (
+			SELECT 1
+			FROM repo_scans
+			WHERE id = $1
+			  AND tenant_id = $2
+			  AND workspace_id = $3
+		)`)).
+		WithArgs(scanID, "default", "default").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM repo_findings rf
+		 USING repo_scans rs
+		 WHERE rf.repo_scan_id = rs.id
+		   AND rf.repo_scan_id = $1
+		   AND rs.tenant_id = $2
+		   AND rs.workspace_id = $3`)).
+		WithArgs(scanID, "default", "default").
+		WillReturnResult(sqlmock.NewResult(0, 2))
+
+	if err := store.DeleteRepoFindings(defaultScopeContext(), scanID); err != nil {
+		t.Fatalf("delete repo findings: %v", err)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
 	}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2417,6 +2417,7 @@ type Store interface {
 	GetRepoScanCursor(ctx context.Context, repository string, source RepoScanSource) (RepoScanCursor, error)
 	UpsertRepoScanCursor(ctx context.Context, cursor RepoScanCursor) error
 	UpsertRepoFindings(ctx context.Context, repoScanID string, findings []domain.Finding) error
+	DeleteRepoFindings(ctx context.Context, repoScanID string) error
 	ListRepoScans(ctx context.Context, limit int) ([]RepoScanRecord, error)
 	ListRepoFindings(ctx context.Context, filter RepoFindingFilter, limit int) ([]domain.Finding, error)
 	ListRepoFindingClusters(ctx context.Context, filter RepoFindingClusterListFilter) ([]domain.RepoFindingCluster, error)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2412,6 +2412,7 @@ type Store interface {
 	RequeueRepoScan(ctx context.Context, repoScanID string) error
 	FailStaleRepoScansAnyScope(ctx context.Context, staleBefore time.Time, limit int, errorMessage string) (int, error)
 	GetRepoScan(ctx context.Context, repoScanID string) (RepoScanRecord, error)
+	CancelRepoScan(ctx context.Context, repoScanID string, finishedAt time.Time, errorMessage string) (RepoScanRecord, error)
 	CompleteRepoScan(ctx context.Context, repoScanID string, status string, finishedAt time.Time, commitsScanned int, filesScanned int, findingCount int, truncated bool, scanContext RepoScanContext, errorMessage string) error
 	GetRepoScanCursor(ctx context.Context, repository string, source RepoScanSource) (RepoScanCursor, error)
 	UpsertRepoScanCursor(ctx context.Context, cursor RepoScanCursor) error

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -162,6 +162,36 @@ describe('apiClient', () => {
     expect(headers.get('X-Identrail-Workspace-ID')).toBe('workspace-a');
   });
 
+  it('cancels repository scans with the scoped auth headers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        repo_scan: {
+          id: 'repo-scan-1',
+          repository: 'identrail/identrail',
+          status: 'failed',
+          started_at: '2026-05-17T10:00:00Z',
+          finished_at: '2026-05-17T10:01:00Z',
+          commits_scanned: 0,
+          files_scanned: 0,
+          finding_count: 0,
+          truncated: false,
+          error_message: 'repository scan canceled by user'
+        }
+      })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiClient.cancelRepoScan('repo/scan with space', { tenantID: 'tenant-a', workspaceID: 'workspace-a' });
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/v1/repo-scans/repo%2Fscan%20with%20space/cancel');
+    expect(options.method).toBe('POST');
+    const headers = options.headers as Headers;
+    expect(headers.get('X-Identrail-Tenant-ID')).toBe('tenant-a');
+    expect(headers.get('X-Identrail-Workspace-ID')).toBe('workspace-a');
+  });
+
   it('encodes scan id for diff URL', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1145,6 +1145,11 @@ export const apiClient = {
       body: JSON.stringify(payload)
     });
   },
+  cancelRepoScan(repoScanID: string, auth?: RequestAuthContext) {
+    return request<{ repo_scan: RepoScanRecord }>(`/v1/repo-scans/${encodeURIComponent(repoScanID)}/cancel`, auth, {
+      method: 'POST'
+    });
+  },
   listFindings(
     filters: {
       limit?: number;

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -424,6 +424,31 @@ describe('ProductProjectDetailPage', () => {
     expect(screen.getByLabelText(/recent repository scan activity/i)).toHaveTextContent('repository scan canceled by user');
   });
 
+  it('allows queueing another selected repository while a different repository is active', async () => {
+    const multiRepoConnection: GitHubConnectionStatus = {
+      ...connectedGitHub,
+      selected_repositories: ['identrail/identrail', 'identrail/docs']
+    };
+    const { runRepoScan } = await renderProjectDetail(true, multiRepoConnection, {
+      repoScans: [queuedRepoScan]
+    });
+
+    expect(await screen.findByRole('button', { name: /Scan already active/i })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/^Repository$/i), { target: { value: 'identrail/docs' } });
+
+    const queueButton = await screen.findByRole('button', { name: /Queue first scan/i });
+    await waitFor(() => expect(queueButton).not.toBeDisabled());
+    fireEvent.click(queueButton);
+
+    await waitFor(() =>
+      expect(runRepoScan).toHaveBeenCalledWith(
+        { repository: 'identrail/docs', project_id: 'project-1', connector_id: 'github-app' },
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+  });
+
   it('keeps stale repo scan refresh responses from overwriting refreshed activity', async () => {
     const staleRefresh = deferred<{ items: RepoScanRecord[] }>();
     const refreshedRepoScan: RepoScanRecord = {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -94,6 +94,13 @@ const queuedRepoScan: RepoScanRecord = {
   truncated: false
 };
 
+const canceledRepoScan: RepoScanRecord = {
+  ...queuedRepoScan,
+  status: 'failed',
+  finished_at: '2026-05-17T11:01:00Z',
+  error_message: 'repository scan canceled by user'
+};
+
 const connectedGitHubPAT: GitHubConnectionStatus = {
   ...connectedGitHub,
   provider: 'github_pat',
@@ -164,6 +171,7 @@ async function renderProjectDetail(
   } else {
     runRepoScan.mockResolvedValue({ repo_scan: queuedRepoScan });
   }
+  const cancelRepoScan = vi.spyOn(api.apiClient, 'cancelRepoScan').mockResolvedValue({ repo_scan: canceledRepoScan });
 
   const { ProductProjectDetailPage } = await import('./productShell');
   function ProjectDetailHarness() {
@@ -188,7 +196,7 @@ async function renderProjectDetail(
     </MemoryRouter>
   );
 
-  return { getGitHubConnectorStatus, listRepoScans, runRepoScan };
+  return { getGitHubConnectorStatus, listRepoScans, runRepoScan, cancelRepoScan };
 }
 
 describe('ProductAppIndexRedirect', () => {
@@ -344,7 +352,13 @@ describe('ProductProjectDetailPage', () => {
   });
 
   it('queues the first repository scan from the selected GitHub repository', async () => {
-    const { runRepoScan } = await renderProjectDetail(true, connectedGitHub, { repoScans: [queuedRepoScan] });
+    let listCalls = 0;
+    const { runRepoScan } = await renderProjectDetail(true, connectedGitHub, {
+      listRepoScans: () => {
+        listCalls += 1;
+        return Promise.resolve({ items: listCalls === 1 ? [] : [queuedRepoScan] });
+      }
+    });
 
     const queueButton = await screen.findByRole('button', { name: /Queue first scan/i });
     await waitFor(() => expect(queueButton).not.toBeDisabled());
@@ -366,7 +380,13 @@ describe('ProductProjectDetailPage', () => {
   });
 
   it('preserves the generic scan payload for GitHub PAT connections', async () => {
-    const { runRepoScan } = await renderProjectDetail(true, connectedGitHubPAT, { repoScans: [queuedRepoScan] });
+    let listCalls = 0;
+    const { runRepoScan } = await renderProjectDetail(true, connectedGitHubPAT, {
+      listRepoScans: () => {
+        listCalls += 1;
+        return Promise.resolve({ items: listCalls === 1 ? [] : [queuedRepoScan] });
+      }
+    });
 
     const queueButton = await screen.findByRole('button', { name: /Queue first scan/i });
     await waitFor(() => expect(queueButton).not.toBeDisabled());
@@ -379,6 +399,29 @@ describe('ProductProjectDetailPage', () => {
         expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
       )
     );
+  });
+
+  it('cancels an active repository scan before retrying', async () => {
+    let listCalls = 0;
+    const { cancelRepoScan } = await renderProjectDetail(true, connectedGitHub, {
+      listRepoScans: () => {
+        listCalls += 1;
+        return Promise.resolve({ items: listCalls === 1 ? [queuedRepoScan] : [canceledRepoScan] });
+      }
+    });
+
+    expect(await screen.findByRole('button', { name: /Scan already active/i })).toBeDisabled();
+    const cancelButton = screen.getByRole('button', { name: /Cancel scan/i });
+    fireEvent.click(cancelButton);
+
+    await waitFor(() =>
+      expect(cancelRepoScan).toHaveBeenCalledWith(
+        queuedRepoScan.id,
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    expect(await screen.findByText(/Repository scan canceled for identrail\/identrail/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/recent repository scan activity/i)).toHaveTextContent('repository scan canceled by user');
   });
 
   it('keeps stale repo scan refresh responses from overwriting refreshed activity', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -424,6 +424,29 @@ describe('ProductProjectDetailPage', () => {
     expect(screen.getByLabelText(/recent repository scan activity/i)).toHaveTextContent('repository scan canceled by user');
   });
 
+  it('clears canceling state when the cancel response is stale after refresh', async () => {
+    const pendingCancel = deferred<{ repo_scan: RepoScanRecord }>();
+    const { cancelRepoScan, listRepoScans } = await renderProjectDetail(true, connectedGitHub, {
+      listRepoScans: () => Promise.resolve({ items: [queuedRepoScan] })
+    });
+    cancelRepoScan.mockReturnValueOnce(pendingCancel.promise);
+
+    const cancelButton = await screen.findByRole('button', { name: /Cancel scan/i });
+    fireEvent.click(cancelButton);
+
+    expect(await screen.findByRole('button', { name: /Canceling/i })).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: /Refresh status/i }));
+    await waitFor(() => expect(listRepoScans).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      pendingCancel.resolve({ repo_scan: canceledRepoScan });
+      await pendingCancel.promise;
+    });
+
+    await waitFor(() => expect(screen.queryByRole('button', { name: /Canceling/i })).not.toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /Cancel scan/i })).not.toBeDisabled();
+  });
+
   it('allows queueing another selected repository while a different repository is active', async () => {
     const multiRepoConnection: GitHubConnectionStatus = {
       ...connectedGitHub,

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -3619,9 +3619,7 @@ export function ProductProjectDetailPage() {
       }
       setRepoScanError(formatRepoScanCancelError(error));
     } finally {
-      if (!isStaleRequestSequence(requestSequence)) {
-        setRepoScanCancelingID('');
-      }
+      setRepoScanCancelingID((current) => (current === scan.id ? '' : current));
     }
   };
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -582,6 +582,18 @@ function formatRepoScanSubmitError(error: unknown): string {
   return error instanceof Error ? error.message : 'Unable to queue repository scan.';
 }
 
+function formatRepoScanCancelError(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.status === 404) {
+      return 'That repository scan no longer exists. Refresh recent activity before retrying.';
+    }
+    if (error.status === 409) {
+      return 'That repository scan already reached a terminal state. Refresh recent activity before retrying.';
+    }
+  }
+  return error instanceof Error ? error.message : 'Unable to cancel repository scan.';
+}
+
 function formatConnectionTime(value?: string): string {
   if (!value) {
     return 'Never';
@@ -2896,6 +2908,7 @@ export function ProductProjectDetailPage() {
   });
   const [recentRepoScans, setRecentRepoScans] = useState<RepoScanRecord[]>([]);
   const [repoScanSubmitting, setRepoScanSubmitting] = useState(false);
+  const [repoScanCancelingID, setRepoScanCancelingID] = useState('');
   const [repoScanError, setRepoScanError] = useState('');
   const [awsForm, setAWSForm] = useState({
     roleARN: '',
@@ -3131,6 +3144,7 @@ export function ProductProjectDetailPage() {
     setRecentRepoScans([]);
     repoScanSubmitSequenceRef.current += 1;
     setRepoScanSubmitting(false);
+    setRepoScanCancelingID('');
     setRepoScanError('');
     setAWSCloudFormationStart(null);
     setAWSPermissionPreview([]);
@@ -3569,6 +3583,40 @@ export function ProductProjectDetailPage() {
     }
   };
 
+  const handleRepoScanCancel = async (scan: RepoScanRecord) => {
+    if (!scope) {
+      setRepoScanError('Workspace route context is missing.');
+      return;
+    }
+    if (!isActiveScanStatus(scan.status)) {
+      setRepoScanError('Only queued or running repository scans can be canceled.');
+      return;
+    }
+    setRepoScanCancelingID(scan.id);
+    setRepoScanError('');
+    setSuccessMessage('');
+    const requestSequence = refreshSequenceRef.current;
+    try {
+      const auth = buildProductAuthContext(scope);
+      const response = await apiClient.cancelRepoScan(scan.id, auth);
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      setRecentRepoScans((current) => current.map((item) => (item.id === response.repo_scan.id ? response.repo_scan : item)));
+      setSuccessMessage(`Repository scan canceled for ${canonicalGitHubRepositoryDisplay(response.repo_scan.repository)}.`);
+      void refreshRecentRepoScans(scope, 'interactive');
+    } catch (error) {
+      if (isStaleRequestSequence(requestSequence)) {
+        return;
+      }
+      setRepoScanError(formatRepoScanCancelError(error));
+    } finally {
+      if (!isStaleRequestSequence(requestSequence)) {
+        setRepoScanCancelingID('');
+      }
+    }
+  };
+
   const handleScanPolicySubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setPolicySaving(true);
@@ -3966,9 +4014,9 @@ export function ProductProjectDetailPage() {
                   <button
                     className="idt-btn idt-btn-primary"
                     type="submit"
-                    disabled={repoScanSubmitting || submitting !== '' || !effectiveRepoScanRepository}
+                    disabled={repoScanSubmitting || submitting !== '' || !effectiveRepoScanRepository || githubHasActiveRepoScan}
                   >
-                    {repoScanSubmitting ? 'Queueing...' : 'Queue first scan'}
+                    {repoScanSubmitting ? 'Queueing...' : githubHasActiveRepoScan ? 'Scan already active' : 'Queue first scan'}
                   </button>
 
                   <div className="idt-source-diagnostics idt-repo-scan-activity" aria-label="recent repository scan activity">
@@ -3984,6 +4032,16 @@ export function ProductProjectDetailPage() {
                             {scan.finding_count} findings · {scan.files_scanned} files · {formatDateLabel(scan.started_at)}
                           </p>
                           {scan.error_message ? <small>{scan.error_message}</small> : null}
+                          {isActiveScanStatus(scan.status) ? (
+                            <button
+                              className="idt-btn idt-btn-ghost idt-repo-scan-cancel"
+                              type="button"
+                              disabled={repoScanCancelingID === scan.id || submitting !== ''}
+                              onClick={() => void handleRepoScanCancel(scan)}
+                            >
+                              {repoScanCancelingID === scan.id ? 'Canceling...' : 'Cancel scan'}
+                            </button>
+                          ) : null}
                         </article>
                       ))
                     ) : (

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -2961,9 +2961,17 @@ export function ProductProjectDetailPage() {
       githubSelectedRepositoryKeys.has(canonicalGitHubRepositoryDisplay(scan.repository).toLowerCase())
     );
   }, [githubSelectedRepositoryKeys, recentRepoScans]);
-  const githubHasActiveRepoScan = githubRecentRepoScans.some((scan) => isActiveScanStatus(scan.status));
   const repoScanRepository = normalizeValue(repoScanForm.repository);
   const effectiveRepoScanRepository = repoScanRepository || githubSelectedRepositories[0] || '';
+  const effectiveRepoScanRepositoryKey = canonicalGitHubRepositoryDisplay(effectiveRepoScanRepository).toLowerCase();
+  const githubHasActiveRepoScan = githubRecentRepoScans.some((scan) => isActiveScanStatus(scan.status));
+  const githubHasActiveSelectedRepoScan =
+    effectiveRepoScanRepositoryKey !== '' &&
+    githubRecentRepoScans.some(
+      (scan) =>
+        isActiveScanStatus(scan.status) &&
+        canonicalGitHubRepositoryDisplay(scan.repository).toLowerCase() === effectiveRepoScanRepositoryKey
+    );
   const repoScanFindingsPath = scope ? buildScopedPath(scope, 'findings') : '/app';
   const enabledSourceLabel = formatSourceNameList(sourceOrder);
 
@@ -4014,9 +4022,11 @@ export function ProductProjectDetailPage() {
                   <button
                     className="idt-btn idt-btn-primary"
                     type="submit"
-                    disabled={repoScanSubmitting || submitting !== '' || !effectiveRepoScanRepository || githubHasActiveRepoScan}
+                    disabled={
+                      repoScanSubmitting || submitting !== '' || !effectiveRepoScanRepository || githubHasActiveSelectedRepoScan
+                    }
                   >
-                    {repoScanSubmitting ? 'Queueing...' : githubHasActiveRepoScan ? 'Scan already active' : 'Queue first scan'}
+                    {repoScanSubmitting ? 'Queueing...' : githubHasActiveSelectedRepoScan ? 'Scan already active' : 'Queue first scan'}
                   </button>
 
                   <div className="idt-source-diagnostics idt-repo-scan-activity" aria-label="recent repository scan activity">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5976,6 +5976,13 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   grid-column: 1 / -1;
 }
 
+.idt-repo-scan-activity .idt-repo-scan-cancel {
+  grid-column: 1 / -1;
+  justify-self: start;
+  margin-top: 0.25rem;
+  min-width: 7.5rem;
+}
+
 @media (max-width: 980px) {
   .idt-passwordless-grid {
     grid-template-columns: 1fr;


### PR DESCRIPTION
Fixes #1262

## What changed
- Added a scoped API endpoint to cancel active repository scans: `POST /v1/repo-scans/{repo_scan_id}/cancel`.
- Added the project UI cancel action for queued/running repository scans and disabled duplicate queue attempts while an active scan exists.
- Made repository scan completion writes conditional on active scan status so stale workers cannot overwrite a user-canceled scan.
- Documented the cancel endpoint and added OpenAPI coverage.

## Why
A stuck hosted repository scan currently keeps the repository target locked in `running`, so users cannot queue a clean retry without operator database edits. Cancellation gives the app a safe, auditable recovery path.

## Impact and risk
Canceled scans are stored as terminal `failed` records with `repository scan canceled by user` because the existing status constraint already supports `failed`. The completion guard prevents old workers from undoing cancellation if they finish late.

## Validation
- `go test ./internal/db ./internal/api`
- `go test ./...`
- `npm run test:ci --prefix web`

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a safe way to cancel queued or running repository scans so users can immediately retry without operator help. Cancellation is terminal, prevents stale workers from overwriting state, and now also cleans up any findings written during race conditions.

- New Features
  - API: `POST /v1/repo-scans/{repo_scan_id}/cancel`; 200 on success, 404 if missing, 409 if already terminal; OpenAPI route added with `repo_scans.run` auth.
  - Backend: Store-level cancel in memory/Postgres; write paths (`CompleteRepoScan`, `UpsertRepoFindings`) only allow active scans and return conflict for terminal scans; if cancel wins mid-run, any persisted findings are deleted, cursors don’t advance, job counts as processed, and no success events are emitted; cancel emits a "canceled" queue event and ignores stale completion conflicts.
  - UI: “Cancel scan” on active items; “Queue first scan” is disabled only when the selected repository already has an active scan; includes canceling state and clear success/error messages; minor styles.
  - Client/Docs: Added `apiClient.cancelRepoScan`; OpenAPI, repo exposure docs, and CHANGELOG updated.

<sup>Written for commit 3f93ea91666640b804e411cb6a0367696c853c76. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1264?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

