### PR TITLE
Add repo exposure remediation previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Added repository finding remediation previews. Repo misconfiguration findings
+  now map to detector-specific remediation guidance and safe fix-PR plans for
+  deterministic patches, while secret findings return rotation guidance only so
+  raw secret material is never copied into generated branches or PRs.
 - Fixed repository scan cursor safety so quick-scan cursors no longer suppress
   later delta scans for the same head revision, and truncated scans no longer
   advance `cursor_after` or the per-repository cursor before all findings have

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -115,6 +115,11 @@ x-identrail-route-authorizations:
     path: /v1/repo-findings
     action: repo_scans.read
     resource_type: repo_finding
+  - method: POST
+    path: /v1/repo-findings/{finding_id}/remediation/preview
+    action: repo_scans.read
+    resource_type: repo_finding
+    resource_id_param: finding_id
   - method: GET
     path: /v1/repo-finding-clusters
     action: repo_scans.read
@@ -3866,6 +3871,45 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /v1/repo-findings/{finding_id}/remediation/preview:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+    post:
+      tags: [RepositoryExposure]
+      summary: Preview repository finding remediation
+      operationId: previewRepoFindingRemediation
+      parameters:
+        - in: path
+          name: finding_id
+          required: true
+          schema: { type: string }
+        - in: query
+          name: repo_scan_id
+          schema: { type: string }
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RepoFindingRemediationPreviewRequest"
+      responses:
+        "200":
+          description: Repository finding remediation preview
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RepoFindingRemediationPreview"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /v1/repo-finding-clusters:
     parameters:
       - $ref: "#/components/parameters/scopeTenantID"
@@ -4056,6 +4100,12 @@ components:
             $ref: "#/components/schemas/ErrorResponse"
     NotFound:
       description: Not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    UnprocessableEntity:
+      description: Unprocessable entity
       content:
         application/json:
           schema:
@@ -5818,6 +5868,106 @@ components:
           format: date-time
         triage:
           $ref: "#/components/schemas/FindingTriage"
+    RepoFindingRemediationPreviewRequest:
+      type: object
+      properties:
+        repo_scan_id:
+          type: string
+          description: Optional repo scan scope when the finding id exists in more than one scan.
+        source_content:
+          type: string
+          description: Current affected file content. When supplied for deterministic patchable detectors, the response includes an exact fix PR plan.
+        base_branch:
+          type: string
+          description: Base branch for an optional generated fix PR plan.
+        branch_prefix:
+          type: string
+          description: Branch prefix for an optional generated fix PR plan.
+        finding_url:
+          type: string
+          format: uri
+          description: Optional app URL included in generated PR traceability.
+        require_fix_plan:
+          type: boolean
+          description: Return 400 when a deterministic fix PR plan cannot be produced.
+    RepoExposurePatchTemplate:
+      type: object
+      properties:
+        strategy:
+          type: string
+          enum: [line_literal, line_regex, workflow_permissions_read_default, workflow_pull_request_trigger]
+        description: { type: string }
+        match: { type: string }
+        match_pattern: { type: string }
+        replacement: { type: string }
+        requires_source_content: { type: boolean }
+        placeholder:
+          type: boolean
+          description: True when the replacement contains operator-supplied values and must not be published automatically.
+    RepoExposureRemediationScope:
+      type: object
+      properties:
+        finding_id: { type: string }
+        scan_id: { type: string }
+        repository: { type: string }
+        commit: { type: string }
+        file_path: { type: string }
+        line_number:
+          type: integer
+          minimum: 1
+        line_snippet: { type: string }
+    RepoExposureRemediation:
+      type: object
+      properties:
+        detector: { type: string }
+        summary: { type: string }
+        risk_summary: { type: string }
+        steps:
+          type: array
+          items: { type: string }
+        safety_notes:
+          type: array
+          items: { type: string }
+        validation:
+          type: array
+          items: { type: string }
+        patch:
+          $ref: "#/components/schemas/RepoExposurePatchTemplate"
+        secret_rotation: { type: boolean }
+        publishable:
+          type: boolean
+          description: True only for deterministic patches that can be published after explicit operator approval and write-capable credentials.
+        publish_blocked_reason: { type: string }
+        evidence:
+          $ref: "#/components/schemas/RepoExposureRemediationScope"
+    FixPRPlanFile:
+      type: object
+      properties:
+        path: { type: string }
+        content: { type: string }
+    FixPRPlan:
+      type: object
+      properties:
+        base_branch: { type: string }
+        branch_name: { type: string }
+        commit_message: { type: string }
+        pr_title: { type: string }
+        pr_body: { type: string }
+        files:
+          type: array
+          items:
+            $ref: "#/components/schemas/FixPRPlanFile"
+        finding_id: { type: string }
+        finding_type: { type: string }
+    RepoFindingRemediationPreview:
+      type: object
+      properties:
+        finding:
+          $ref: "#/components/schemas/Finding"
+        remediation:
+          $ref: "#/components/schemas/RepoExposureRemediation"
+        fix_pr_plan:
+          $ref: "#/components/schemas/FixPRPlan"
     FindingBaseline:
       type: object
       properties:

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -64,12 +64,59 @@ Read APIs:
 - `GET /v1/repo-scans`
 - `GET /v1/repo-scans/:repo_scan_id`
 - `GET /v1/repo-findings?repo_scan_id=&severity=&type=`
+- `POST /v1/repo-findings/:finding_id/remediation/preview?repo_scan_id=`
 - `GET /v1/repo-finding-clusters?repo_scan_id=&severity=&type=`
 - `GET /v1/repo-risk-graph?repo_scan_id=&repository=&default_branch=&severity=&type=`
 - list endpoints support cursor pagination (`?limit=...&cursor=...`) and return `next_cursor` when more results exist
 - repo finding responses expose stable repository and location fields when available: `repository`, `file_path`, `line_number`, `commit`, `detector`, `line_snippet`, `line_snippet_redacted`, and `source_url`
 - `source_url` is a direct GitHub blob link pinned to the detected commit when Identrail can derive one
 - grouped cluster responses roll duplicate repo findings into cluster counts with `first_seen_at`, `last_seen_at`, `spread`, and a per-occurrence `members` list
+
+## Safe Remediation Previews
+
+Repository findings can be converted into rule-specific remediation previews
+without publishing a branch:
+
+```bash
+curl -X POST http://localhost:8080/v1/repo-findings/:finding_id/remediation/preview \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: <read-enabled-key>" \
+  -d '{
+    "repo_scan_id": "<repo-scan-id>",
+    "base_branch": "main",
+    "source_content": "name: ci\npermissions: write-all\n"
+  }'
+```
+
+Preview mode returns:
+
+- detector-specific risk summary, remediation steps, safety notes, and validation notes
+- non-secret traceability fields such as finding ID, scan ID, repository, commit, path, and line
+- an optional `fix_pr_plan` only when the detector has a deterministic patch and the caller supplies current affected-file content
+
+Generated fix-PR plans are intentionally constrained:
+
+- they modify only the affected repository file, never a default branch directly
+- they include finding ID, scan ID, detector, risk summary, validation notes, and safety notes in the PR body
+- they are preview-only until an operator explicitly approves publication and supplies write-capable GitHub credentials
+- read-only scanner installations can request previews but cannot publish PRs by default
+
+Secret findings are handled differently. Identrail returns rotation and
+revocation guidance, but does not generate source patches or PR plans for
+secret exposure findings. This prevents raw secret values from being copied
+into generated branches, commits, PR descriptions, logs, or review comments.
+
+Deterministic publishable templates currently cover:
+
+- GitHub Actions `permissions: write-all`
+- GitHub Actions `pull_request_target` trigger replacement when the workflow owner approves moving to `pull_request`
+- Kubernetes `privileged: true`
+- Terraform S3 `public-read` / `public-read-write` ACLs
+
+Guidance-only templates cover workflow attack-path findings that need owner
+review, Docker `latest` image pinning where the correct version/digest must be
+chosen, and open SSH/RDP Terraform ingress where approved administrative CIDRs
+are environment-specific.
 
 ## What It Scans
 

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -659,6 +659,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/repo-scans", Action: policyActionRepoScansRead, ResourceType: "repo_scan"},
 		{Method: http.MethodGet, Path: "/v1/repo-scans/:repo_scan_id", Action: policyActionRepoScansRead, ResourceType: "repo_scan", ResourceIDParam: "repo_scan_id"},
 		{Method: http.MethodGet, Path: "/v1/repo-findings", Action: policyActionRepoScansRead, ResourceType: "repo_finding"},
+		{Method: http.MethodPost, Path: "/v1/repo-findings/:finding_id/remediation/preview", Action: policyActionRepoScansRead, ResourceType: "repo_finding", ResourceIDParam: "finding_id"},
 		{Method: http.MethodGet, Path: "/v1/repo-finding-clusters", Action: policyActionRepoScansRead, ResourceType: "repo_finding_cluster"},
 		{Method: http.MethodGet, Path: "/v1/repo-risk-graph", Action: policyActionRepoScansRead, ResourceType: "repo_risk_graph"},
 		{Method: http.MethodPost, Path: "/v1/repo-scans", Action: policyActionRepoScansRun, ResourceType: "repo_scan"},

--- a/internal/api/authz_policy_bundle_runtime_test.go
+++ b/internal/api/authz_policy_bundle_runtime_test.go
@@ -97,6 +97,16 @@ func TestDefaultRoutePolicyBundleUsesRepoScansReadForRepoFindingsTrends(t *testi
 	if policy.Action != policyActionRepoScansRead {
 		t.Fatalf("expected action %q, got %q", policyActionRepoScansRead, policy.Action)
 	}
+	policy, exists = compiled.RouteRegistry.lookup("POST", "/v1/repo-findings/:finding_id/remediation/preview")
+	if !exists {
+		t.Fatal("expected built-in authz policy for POST /v1/repo-findings/:finding_id/remediation/preview")
+	}
+	if policy.Action != policyActionRepoScansRead {
+		t.Fatalf("expected action %q, got %q", policyActionRepoScansRead, policy.Action)
+	}
+	if policy.ResourceIDParam != "finding_id" {
+		t.Fatalf("expected finding_id resource param, got %q", policy.ResourceIDParam)
+	}
 }
 
 func TestCentralPolicyRuntimeResolverFallsBackWhenNoActiveRollout(t *testing.T) {

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -212,6 +212,26 @@ func TestOpenAPIV1SpecContainsTenancyProjectContracts(t *testing.T) {
 	}
 }
 
+func TestOpenAPIV1SpecDocumentsRepoExposurePatchStrategies(t *testing.T) {
+	spec := readOpenAPISpec(t)
+	blockPattern := regexp.MustCompile(`(?s)\n    RepoExposurePatchTemplate:.*?\n    RepoExposureRemediationScope:`)
+	block := blockPattern.FindString(spec)
+	if block == "" {
+		t.Fatalf("openapi schema %q not found", "RepoExposurePatchTemplate")
+	}
+
+	for _, strategy := range []string{
+		"line_literal",
+		"line_regex",
+		"workflow_permissions_read_default",
+		"workflow_pull_request_trigger",
+	} {
+		if !strings.Contains(block, strategy) {
+			t.Fatalf("openapi schema %q missing patch strategy %q", "RepoExposurePatchTemplate", strategy)
+		}
+	}
+}
+
 func TestOpenAPIV1SpecCoversRegisteredV1RouteMethods(t *testing.T) {
 	spec := readOpenAPISpec(t)
 	router := readRouterSource(t)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -484,6 +484,9 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		v1.GET("/repo-findings", func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"items": []any{}})
 		})
+		v1.POST("/repo-findings/:finding_id/remediation/preview", func(c *gin.Context) {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "repo scan service unavailable"})
+		})
 		v1.GET("/repo-finding-clusters", func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"items": []any{}})
 		})
@@ -947,6 +950,47 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			return
 		}
 		c.JSON(http.StatusOK, paginatedItemsResponse(items, offset, limit))
+	})
+
+	v1.POST("/repo-findings/:finding_id/remediation/preview", func(c *gin.Context) {
+		var request RepoFindingRemediationPreviewRequest
+		if c.Request.Body != nil && c.Request.Body != http.NoBody && c.Request.ContentLength != 0 {
+			if err := c.ShouldBindJSON(&request); err != nil && !errors.Is(err, io.EOF) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+				return
+			}
+		}
+		if repoScanID := strings.TrimSpace(c.Query("repo_scan_id")); repoScanID != "" {
+			if !isValidUUID(repoScanID) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid repo_scan_id"})
+				return
+			}
+			request.RepoScanID = repoScanID
+		}
+		if request.RepoScanID != "" && !isValidUUID(request.RepoScanID) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid repo_scan_id"})
+			return
+		}
+		preview, err := svc.PreviewRepoFindingRemediation(
+			c.Request.Context(),
+			strings.TrimSpace(c.Param("finding_id")),
+			request,
+		)
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "repo finding not found"})
+			case errors.Is(err, ErrUnsupportedRepoRemediation):
+				c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "unsupported repo remediation"})
+			case errors.Is(err, ErrInvalidRepoRemediationRequest):
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid repo remediation request"})
+			default:
+				logger.Error("preview repo finding remediation", telemetry.ZapError(err))
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to preview repo finding remediation"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, preview)
 	})
 
 	v1.GET("/repo-finding-clusters", func(c *gin.Context) {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -940,6 +940,72 @@ func TestRouterRepoFindingsCanBeFilteredByTriageState(t *testing.T) {
 	}
 }
 
+func TestRouterRepoFindingRemediationPreview(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 5, 13, 11, 10, 0, 0, time.UTC)
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, db.RepoScanContext{}, now)
+	if err != nil {
+		t.Fatalf("create repo scan: %v", err)
+	}
+	finding := domain.Finding{
+		ID:           "repo-remediation-route",
+		Type:         domain.FindingRepoMisconfig,
+		Severity:     domain.SeverityHigh,
+		Title:        "workflow write all",
+		HumanSummary: "Workflow uses write-all.",
+		Repository:   "owner/repo",
+		Commit:       "abc123",
+		FilePath:     ".github/workflows/ci.yml",
+		LineNumber:   2,
+		Detector:     "workflow_write_all_permissions",
+		LineSnippet:  "permissions: write-all",
+		CreatedAt:    now,
+	}
+	if err := store.UpsertRepoFindings(defaultScopeContext(), repoScan.ID, []domain.Finding{finding}); err != nil {
+		t.Fatalf("upsert repo findings: %v", err)
+	}
+	svc := NewService(store, routerScanner{}, "aws")
+	r := NewRouter(logger, metrics, svc, RouterOptions{})
+	payload := []byte(`{"source_content":"name: ci\npermissions: write-all\n","base_branch":"dev"}`)
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/repo-findings/repo-remediation-route/remediation/preview?repo_scan_id="+repoScan.ID,
+		bytes.NewReader(payload),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected remediation preview 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var body RepoFindingRemediationPreview
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode remediation preview: %v", err)
+	}
+	if body.Remediation.Detector != "workflow_write_all_permissions" || body.FixPRPlan == nil {
+		t.Fatalf("expected detector preview and fix plan, got %+v", body)
+	}
+	if len(body.FixPRPlan.Files) != 1 || body.FixPRPlan.Files[0].Path != ".github/workflows/ci.yml" {
+		t.Fatalf("expected affected file only, got %+v", body.FixPRPlan.Files)
+	}
+}
+
+func TestRouterRepoFindingRemediationPreviewRejectsInvalidRepoScanID(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	metrics := telemetry.NewMetrics()
+	svc := NewService(db.NewMemoryStore(), routerScanner{}, "aws")
+	r := NewRouter(logger, metrics, svc, RouterOptions{})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/repo-findings/finding-1/remediation/preview?repo_scan_id=not-a-uuid", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected invalid repo_scan_id 400, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
 func TestRouterRepoFindingsSeveritySortUsesFullResultSet(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	metrics := telemetry.NewMetrics()

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/url"
 	"path"
 	"sort"
@@ -19,6 +20,7 @@ import (
 	"github.com/identrail/identrail/internal/domain"
 	"github.com/identrail/identrail/internal/findings/standards"
 	"github.com/identrail/identrail/internal/providers"
+	"github.com/identrail/identrail/internal/remediation/fixpr"
 	"github.com/identrail/identrail/internal/repoallowlist"
 	"github.com/identrail/identrail/internal/repoexposure"
 	"github.com/identrail/identrail/internal/scheduler"
@@ -301,6 +303,27 @@ type RepoRiskGraphFilter struct {
 	DefaultBranch string
 }
 
+// RepoFindingRemediationPreviewRequest captures a request to preview safe
+// remediation for one repository finding. SourceContent is optional; when
+// present and the detector has a deterministic patch, the response also
+// includes the exact fix-PR plan.
+type RepoFindingRemediationPreviewRequest struct {
+	RepoScanID     string `json:"repo_scan_id,omitempty"`
+	SourceContent  string `json:"source_content,omitempty"`
+	BaseBranch     string `json:"base_branch,omitempty"`
+	BranchPrefix   string `json:"branch_prefix,omitempty"`
+	FindingURL     string `json:"finding_url,omitempty"`
+	RequireFixPlan bool   `json:"require_fix_plan,omitempty"`
+}
+
+// RepoFindingRemediationPreview is the API-facing preview for one repo finding
+// remediation workflow.
+type RepoFindingRemediationPreview struct {
+	Finding     domain.Finding                    `json:"finding"`
+	Remediation standards.RepoExposureRemediation `json:"remediation"`
+	FixPRPlan   *fixpr.FixPRPlan                  `json:"fix_pr_plan,omitempty"`
+}
+
 // FindingsPage captures one paginated findings response.
 type FindingsPage struct {
 	Items      []domain.Finding
@@ -382,6 +405,12 @@ var ErrRepoScanInProgress = errors.New("repo scan already in progress")
 
 // ErrInvalidFindingTriageRequest indicates invalid triage payload or state transition.
 var ErrInvalidFindingTriageRequest = errors.New("invalid finding triage request")
+
+// ErrUnsupportedRepoRemediation indicates no safe remediation workflow is registered.
+var ErrUnsupportedRepoRemediation = errors.New("unsupported repo remediation")
+
+// ErrInvalidRepoRemediationRequest indicates stale source content or invalid preview inputs.
+var ErrInvalidRepoRemediationRequest = errors.New("invalid repo remediation request")
 
 // ErrRepoScanQueueFull is returned when queued repo scan requests exceed configured capacity.
 var ErrRepoScanQueueFull = errors.New("repo scan queue is full")
@@ -1941,6 +1970,84 @@ func (s *Service) GetRepoRiskGraph(ctx context.Context, filter RepoRiskGraphFilt
 		DefaultBranch: strings.TrimSpace(filter.DefaultBranch),
 		Now:           s.Now().UTC(),
 	}), nil
+}
+
+// PreviewRepoFindingRemediation returns rule-specific remediation guidance for
+// one repository finding. When source content is provided for a deterministic
+// patchable detector, the response includes the exact fix-PR plan without
+// publishing anything.
+func (s *Service) PreviewRepoFindingRemediation(ctx context.Context, findingID string, request RepoFindingRemediationPreviewRequest) (RepoFindingRemediationPreview, error) {
+	id := strings.TrimSpace(findingID)
+	if id == "" {
+		return RepoFindingRemediationPreview{}, db.ErrNotFound
+	}
+	request.RepoScanID = strings.TrimSpace(request.RepoScanID)
+	finding, err := s.getRepoFindingForRemediation(ctx, id, request.RepoScanID)
+	if err != nil {
+		return RepoFindingRemediationPreview{}, err
+	}
+	domain.NormalizeRepoFindingMetadata(&finding)
+	remediation, ok := standards.SuggestRepoExposureRemediation(finding)
+	if !ok {
+		return RepoFindingRemediationPreview{}, ErrUnsupportedRepoRemediation
+	}
+
+	responseFinding := finding
+	if responseFinding.Type == domain.FindingSecretExposure {
+		responseFinding.LineSnippet = ""
+		redacted := true
+		responseFinding.LineSnippetRedacted = &redacted
+		if len(responseFinding.Evidence) > 0 {
+			evidence := maps.Clone(responseFinding.Evidence)
+			delete(evidence, "line_snippet")
+			delete(evidence, "redacted_line_snip")
+			delete(evidence, "match_snippet")
+			evidence["line_snippet_redacted"] = true
+			responseFinding.Evidence = evidence
+		}
+	}
+	response := RepoFindingRemediationPreview{
+		Finding:     responseFinding,
+		Remediation: remediation,
+	}
+
+	sourceContentProvided := request.SourceContent != ""
+	if !sourceContentProvided {
+		if request.RequireFixPlan {
+			return RepoFindingRemediationPreview{}, ErrInvalidRepoRemediationRequest
+		}
+		return response, nil
+	}
+	plan, _, err := fixpr.BuildRepoExposureFixPRPlan(finding, request.SourceContent, fixpr.PlanOptions{
+		BaseBranch:   request.BaseBranch,
+		BranchPrefix: request.BranchPrefix,
+		FindingURL:   request.FindingURL,
+	})
+	if err != nil {
+		if errors.Is(err, fixpr.ErrRepoExposureRemediationUnsupported) {
+			return RepoFindingRemediationPreview{}, ErrUnsupportedRepoRemediation
+		}
+		if errors.Is(err, fixpr.ErrRepoExposureRemediationUnsafe) && !request.RequireFixPlan {
+			return response, nil
+		}
+		return RepoFindingRemediationPreview{}, ErrInvalidRepoRemediationRequest
+	}
+	response.FixPRPlan = &plan
+	return response, nil
+}
+
+func (s *Service) getRepoFindingForRemediation(ctx context.Context, findingID string, repoScanID string) (domain.Finding, error) {
+	findings, err := s.ListRepoFindings(ctx, 1, db.RepoFindingFilter{
+		FindingID:  strings.TrimSpace(findingID),
+		RepoScanID: strings.TrimSpace(repoScanID),
+	})
+	if err != nil {
+		return domain.Finding{}, err
+	}
+	if len(findings) == 0 {
+		return domain.Finding{}, db.ErrNotFound
+	}
+	return findings[0], nil
 }
 
 // GetOrganization returns the current scoped organization record.

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -2532,6 +2532,201 @@ func TestServiceGetRepoRiskGraphUsesServiceClock(t *testing.T) {
 	}
 }
 
+func TestServicePreviewRepoFindingRemediationReturnsGuidanceAndFixPlan(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, db.RepoScanContext{}, now)
+	if err != nil {
+		t.Fatalf("create repo scan: %v", err)
+	}
+	finding := domain.Finding{
+		ID:           "repo-finding-remediate",
+		ScanID:       repoScan.ID,
+		Type:         domain.FindingRepoMisconfig,
+		Severity:     domain.SeverityHigh,
+		Title:        "Workflow grants broad token permissions",
+		HumanSummary: "Workflow permissions are set to write-all.",
+		Repository:   "owner/repo",
+		Commit:       "abc123",
+		FilePath:     ".github/workflows/ci.yml",
+		LineNumber:   2,
+		Detector:     "workflow_write_all_permissions",
+		LineSnippet:  "permissions: write-all",
+		Remediation:  "Restrict workflow permissions.",
+		CreatedAt:    now,
+	}
+	if err := store.UpsertRepoFindings(defaultScopeContext(), repoScan.ID, []domain.Finding{finding}); err != nil {
+		t.Fatalf("upsert repo findings: %v", err)
+	}
+
+	preview, err := svc.PreviewRepoFindingRemediation(defaultScopeContext(), finding.ID, RepoFindingRemediationPreviewRequest{
+		RepoScanID:    repoScan.ID,
+		SourceContent: "name: ci\npermissions: write-all\n",
+		BaseBranch:    "dev",
+		FindingURL:    "https://app.example.com/findings/repo-finding-remediate",
+	})
+	if err != nil {
+		t.Fatalf("preview remediation: %v", err)
+	}
+	if preview.Remediation.Detector != "workflow_write_all_permissions" || !preview.Remediation.Publishable {
+		t.Fatalf("unexpected remediation preview: %+v", preview.Remediation)
+	}
+	if preview.FixPRPlan == nil {
+		t.Fatal("expected fix PR plan when source content is supplied")
+	}
+	if len(preview.FixPRPlan.Files) != 1 || preview.FixPRPlan.Files[0].Path != ".github/workflows/ci.yml" {
+		t.Fatalf("expected affected workflow-only plan, got %+v", preview.FixPRPlan.Files)
+	}
+	if !strings.Contains(preview.FixPRPlan.Files[0].Content, "permissions:\n  contents: read\n") {
+		t.Fatalf("expected patched permissions, got:\n%s", preview.FixPRPlan.Files[0].Content)
+	}
+}
+
+func TestServicePreviewRepoFindingRemediationUsesRepoFindingOnly(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	regularScan, err := store.CreateScan(defaultScopeContext(), "aws", now.Add(5*time.Minute))
+	if err != nil {
+		t.Fatalf("create regular scan: %v", err)
+	}
+	if err := store.UpsertFindings(defaultScopeContext(), regularScan.ID, []domain.Finding{{
+		ID:           "shared-finding-id",
+		ScanID:       regularScan.ID,
+		Type:         domain.FindingOverPrivileged,
+		Severity:     domain.SeverityHigh,
+		Title:        "Cloud finding with same id",
+		HumanSummary: "This non-repo finding must not be used by repo remediation previews.",
+		CreatedAt:    now.Add(5 * time.Minute),
+	}}); err != nil {
+		t.Fatalf("upsert regular finding: %v", err)
+	}
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, db.RepoScanContext{}, now)
+	if err != nil {
+		t.Fatalf("create repo scan: %v", err)
+	}
+	repoFinding := domain.Finding{
+		ID:           "shared-finding-id",
+		ScanID:       repoScan.ID,
+		Type:         domain.FindingRepoMisconfig,
+		Severity:     domain.SeverityHigh,
+		Title:        "Repository misconfiguration",
+		HumanSummary: "Workflow permissions are set to write-all.",
+		Repository:   "owner/repo",
+		FilePath:     ".github/workflows/ci.yml",
+		LineNumber:   1,
+		Detector:     "workflow_write_all_permissions",
+		LineSnippet:  "permissions: write-all",
+		CreatedAt:    now,
+	}
+	if err := store.UpsertRepoFindings(defaultScopeContext(), repoScan.ID, []domain.Finding{repoFinding}); err != nil {
+		t.Fatalf("upsert repo finding: %v", err)
+	}
+
+	preview, err := svc.PreviewRepoFindingRemediation(defaultScopeContext(), repoFinding.ID, RepoFindingRemediationPreviewRequest{
+		SourceContent: "permissions: write-all\n",
+	})
+	if err != nil {
+		t.Fatalf("preview remediation: %v", err)
+	}
+	if preview.Finding.Type != domain.FindingRepoMisconfig || preview.Finding.ScanID != repoScan.ID {
+		t.Fatalf("expected repo finding preview, got %+v", preview.Finding)
+	}
+	if preview.Remediation.Detector != "workflow_write_all_permissions" {
+		t.Fatalf("expected repo remediation detector, got %+v", preview.Remediation)
+	}
+}
+
+func TestServicePreviewRepoFindingRemediationKeepsSecretRotationOnly(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, db.RepoScanContext{}, now)
+	if err != nil {
+		t.Fatalf("create repo scan: %v", err)
+	}
+	secretRedacted := false
+	finding := domain.Finding{
+		ID:                  "repo-secret-remediate",
+		ScanID:              repoScan.ID,
+		Type:                domain.FindingSecretExposure,
+		Severity:            domain.SeverityCritical,
+		Title:               "Repository contains a secret",
+		HumanSummary:        "A credential-like value was committed.",
+		Repository:          "owner/repo",
+		Commit:              "abc123",
+		FilePath:            "app.env",
+		LineNumber:          1,
+		Detector:            "github_token",
+		LineSnippet:         "GITHUB_TOKEN=ghp_exampleSecretValue",
+		LineSnippetRedacted: &secretRedacted,
+		Remediation:         "Rotate the token.",
+		CreatedAt:           now,
+	}
+	if err := store.UpsertRepoFindings(defaultScopeContext(), repoScan.ID, []domain.Finding{finding}); err != nil {
+		t.Fatalf("upsert repo findings: %v", err)
+	}
+
+	preview, err := svc.PreviewRepoFindingRemediation(defaultScopeContext(), finding.ID, RepoFindingRemediationPreviewRequest{
+		RepoScanID:    repoScan.ID,
+		SourceContent: "GITHUB_TOKEN=ghp_exampleSecretValue\n",
+	})
+	if err != nil {
+		t.Fatalf("preview remediation: %v", err)
+	}
+	if !preview.Remediation.SecretRotation || preview.Remediation.Patch != nil || preview.Remediation.Publishable {
+		t.Fatalf("expected rotation-only secret remediation, got %+v", preview.Remediation)
+	}
+	if preview.FixPRPlan != nil {
+		t.Fatalf("secret remediation must not include fix PR plan, got %+v", preview.FixPRPlan)
+	}
+	if preview.Finding.LineSnippet != "" || preview.Remediation.Evidence.LineSnippet != "" {
+		t.Fatalf("secret preview must not echo raw snippet, got finding=%q evidence=%q", preview.Finding.LineSnippet, preview.Remediation.Evidence.LineSnippet)
+	}
+	for _, key := range []string{"line_snippet", "redacted_line_snip", "match_snippet"} {
+		if value, exists := preview.Finding.Evidence[key]; exists {
+			t.Fatalf("secret preview must not echo evidence key %s=%v", key, value)
+		}
+	}
+	if preview.Finding.Evidence["line_snippet_redacted"] != true {
+		t.Fatalf("expected secret preview evidence to remain explicitly redacted, got %+v", preview.Finding.Evidence)
+	}
+}
+
+func TestServicePreviewRepoFindingRemediationRequireFixPlanRejectsGuidanceOnly(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	repoScan, err := store.CreateRepoScan(defaultScopeContext(), "owner/repo", db.RepoScanSource{}, db.RepoScanContext{}, now)
+	if err != nil {
+		t.Fatalf("create repo scan: %v", err)
+	}
+	finding := domain.Finding{
+		ID:         "repo-finding-guidance",
+		ScanID:     repoScan.ID,
+		Type:       domain.FindingRepoMisconfig,
+		Severity:   domain.SeverityMedium,
+		Repository: "owner/repo",
+		FilePath:   "Dockerfile",
+		LineNumber: 1,
+		Detector:   "docker_latest_tag",
+		CreatedAt:  now,
+	}
+	if err := store.UpsertRepoFindings(defaultScopeContext(), repoScan.ID, []domain.Finding{finding}); err != nil {
+		t.Fatalf("upsert repo findings: %v", err)
+	}
+
+	_, err = svc.PreviewRepoFindingRemediation(defaultScopeContext(), finding.ID, RepoFindingRemediationPreviewRequest{
+		RepoScanID:     repoScan.ID,
+		SourceContent:  "FROM golang:latest\n",
+		RequireFixPlan: true,
+	})
+	if !errors.Is(err, ErrInvalidRepoRemediationRequest) {
+		t.Fatalf("expected invalid request for required placeholder fix plan, got %v", err)
+	}
+}
+
 func TestServiceListRepoFindingClusters(t *testing.T) {
 	store := db.NewMemoryStore()
 	svc := NewService(store, fakeScanner{}, "aws")

--- a/internal/findings/standards/repo_remediation.go
+++ b/internal/findings/standards/repo_remediation.go
@@ -452,7 +452,7 @@ func terraformPublicACLRemediation(finding domain.Finding, detector string) Repo
 		&RepoExposurePatchTemplate{
 			Strategy:              RepoPatchStrategyLineRegex,
 			Description:           "Replace public-read/public-read-write ACL values with private.",
-			MatchPattern:          `(?i)^\s*acl\s*=\s*"public-(?:read|read-write)"\s*$`,
+			MatchPattern:          `(?i)^\s*acl\s*=\s*"public-(?:read|read-write)"\s*(?:#.*)?$`,
 			Replacement:           `acl = "private"`,
 			RequiresSourceContent: true,
 		})

--- a/internal/findings/standards/repo_remediation.go
+++ b/internal/findings/standards/repo_remediation.go
@@ -1,0 +1,604 @@
+package standards
+
+import (
+	"strings"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+const (
+	RepoPatchStrategyLineLiteral                    = "line_literal"
+	RepoPatchStrategyLineRegex                      = "line_regex"
+	RepoPatchStrategyWorkflowPermissionsReadDefault = "workflow_permissions_read_default"
+	RepoPatchStrategyWorkflowPullRequestTrigger     = "workflow_pull_request_trigger"
+)
+
+// RepoExposurePatchTemplate describes one deterministic source patch that can
+// be previewed from a repo exposure finding. Templates with Placeholder=true
+// are guidance-only and must not be published without an operator replacing the
+// placeholder with a real value.
+type RepoExposurePatchTemplate struct {
+	Strategy              string `json:"strategy"`
+	Description           string `json:"description"`
+	Match                 string `json:"match,omitempty"`
+	MatchPattern          string `json:"match_pattern,omitempty"`
+	Replacement           string `json:"replacement"`
+	RequiresSourceContent bool   `json:"requires_source_content"`
+	Placeholder           bool   `json:"placeholder"`
+}
+
+// RepoExposureRemediation is a rule-specific remediation plan for repository
+// findings. Secret findings intentionally use guidance without patches so raw
+// secrets are never preserved or moved around by generated PRs.
+type RepoExposureRemediation struct {
+	Detector             string                       `json:"detector"`
+	Summary              string                       `json:"summary"`
+	RiskSummary          string                       `json:"risk_summary"`
+	Steps                []string                     `json:"steps"`
+	SafetyNotes          []string                     `json:"safety_notes"`
+	Validation           []string                     `json:"validation"`
+	Patch                *RepoExposurePatchTemplate   `json:"patch,omitempty"`
+	SecretRotation       bool                         `json:"secret_rotation"`
+	Publishable          bool                         `json:"publishable"`
+	PublishBlockedReason string                       `json:"publish_blocked_reason,omitempty"`
+	Evidence             RepoExposureRemediationScope `json:"evidence"`
+}
+
+// RepoExposureRemediationScope captures non-secret traceability details that
+// are safe to show in previews and generated PR bodies.
+type RepoExposureRemediationScope struct {
+	FindingID   string `json:"finding_id"`
+	ScanID      string `json:"scan_id,omitempty"`
+	Repository  string `json:"repository,omitempty"`
+	Commit      string `json:"commit,omitempty"`
+	FilePath    string `json:"file_path,omitempty"`
+	LineNumber  int    `json:"line_number,omitempty"`
+	LineSnippet string `json:"line_snippet,omitempty"`
+}
+
+// SuggestRepoExposureRemediation returns a remediation workflow for repository
+// exposure findings, including guidance-only secret handling and deterministic
+// patch templates for safe misconfiguration fixes.
+func SuggestRepoExposureRemediation(finding domain.Finding) (RepoExposureRemediation, bool) {
+	domain.NormalizeRepoFindingMetadata(&finding)
+	switch finding.Type {
+	case domain.FindingSecretExposure:
+		return secretRotationRemediation(finding), true
+	case domain.FindingRepoMisconfig:
+		return repoMisconfigRemediation(finding)
+	default:
+		if detector := strings.TrimSpace(finding.Detector); detector != "" {
+			if strings.HasPrefix(detector, "workflow_") ||
+				strings.HasPrefix(detector, "terraform_") ||
+				strings.HasPrefix(detector, "docker_") ||
+				strings.HasPrefix(detector, "k8s_") {
+				finding.Type = domain.FindingRepoMisconfig
+				return repoMisconfigRemediation(finding)
+			}
+		}
+		return RepoExposureRemediation{}, false
+	}
+}
+
+func secretRotationRemediation(finding domain.Finding) RepoExposureRemediation {
+	detector := repoDetectorOrDefault(finding, "secret_exposure")
+	return RepoExposureRemediation{
+		Detector:       detector,
+		Summary:        "Rotate and revoke the exposed credential; do not generate a PR containing secret material.",
+		RiskSummary:    firstNonEmpty(finding.HumanSummary, "A repository finding indicates credential-like material was exposed in source history or file content."),
+		SecretRotation: true,
+		Publishable:    false,
+		PublishBlockedReason: "secret findings require rotation and revocation guidance instead of generated code patches " +
+			"so raw secret values are never copied into branches, commits, or pull requests",
+		Steps: []string{
+			"Revoke or rotate the exposed credential at the issuing provider before editing repository history.",
+			"Remove the credential from the affected file and replace it with a secret-manager, environment, or OIDC-based reference.",
+			"Review audit logs for usage after the first exposed commit and scope incident response to that window.",
+			"Only consider history rewriting after rotation, stakeholder coordination, and backup-retention review.",
+			"Add provider-native secret scanning or push protection so the same credential family is blocked before commit.",
+		},
+		SafetyNotes: []string{
+			"Do not paste the raw secret into issue comments, PR bodies, remediation branches, logs, or chat tools.",
+			"Generated PRs are intentionally disabled for secret findings because a PR can preserve or redistribute the leaked value.",
+			"Treat redacted snippets as evidence pointers only; the provider is the source of truth for revocation.",
+		},
+		Validation: []string{
+			"Confirm the old credential is revoked or inactive at the provider.",
+			"Re-run the repository scanner and provider-native secret scanner after rotation.",
+			"Verify no new commits contain the same secret fingerprint.",
+		},
+		Evidence: repoExposureScope(finding, false),
+	}
+}
+
+func repoMisconfigRemediation(finding domain.Finding) (RepoExposureRemediation, bool) {
+	detector := repoDetectorOrDefault(finding, "")
+	if detector == "" {
+		return RepoExposureRemediation{}, false
+	}
+	switch detector {
+	case "workflow_write_all_permissions":
+		return workflowWriteAllRemediation(finding, detector), true
+	case "workflow_pull_request_target":
+		return workflowPullRequestTargetRemediation(finding, detector), true
+	case "workflow_broad_token_permissions":
+		return workflowBroadTokenRemediation(finding, detector), true
+	case "workflow_pull_request_target_privileged_context":
+		return workflowPrivilegedContextRemediation(finding, detector), true
+	case "workflow_pull_request_target_untrusted_checkout":
+		return workflowUntrustedCheckoutRemediation(finding, detector), true
+	case "workflow_unpinned_third_party_action":
+		return workflowUnpinnedActionRemediation(finding, detector), true
+	case "workflow_shell_injection_user_context":
+		return workflowShellInjectionRemediation(finding, detector), true
+	case "workflow_run_privilege_chain":
+		return workflowRunPrivilegeRemediation(finding, detector), true
+	case "workflow_oidc_broad_trust":
+		return workflowOIDCTrustRemediation(finding, detector), true
+	case "workflow_cache_poisoning":
+		return workflowCachePoisoningRemediation(finding, detector), true
+	case "workflow_artifact_poisoning":
+		return workflowArtifactPoisoningRemediation(finding, detector), true
+	case "k8s_privileged_true":
+		return k8sPrivilegedRemediation(finding, detector), true
+	case "terraform_public_s3_acl":
+		return terraformPublicACLRemediation(finding, detector), true
+	case "terraform_open_ssh_rdp":
+		return terraformOpenManagementPortRemediation(finding, detector), true
+	case "docker_latest_tag":
+		return dockerLatestTagRemediation(finding, detector), true
+	default:
+		if strings.HasPrefix(detector, "workflow_") {
+			return workflowGenericRemediation(finding, detector), true
+		}
+		return RepoExposureRemediation{}, false
+	}
+}
+
+func workflowWriteAllRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return deterministicRepoRemediation(finding, detector,
+		"Replace workflow write-all token permissions with least-privilege read defaults.",
+		"Workflow GITHUB_TOKEN permissions are set to write-all, giving automation broad write capability.",
+		[]string{
+			"Replace `permissions: write-all` with explicit least-privilege permissions.",
+			"Start from `contents: read` and grant write scopes only on jobs that genuinely publish or mutate repository state.",
+			"Move deploy, release, or package write scopes behind protected branch or environment gates.",
+		},
+		[]string{
+			"Some release jobs may need explicit write scopes after the default is tightened.",
+			"Keep `id-token: write` only on jobs that exchange OIDC tokens with a scoped cloud trust policy.",
+		},
+		[]string{
+			"Run the workflow on a test branch and confirm read-only jobs still pass.",
+			"Review the Actions run permissions summary before merging.",
+		},
+		&RepoExposurePatchTemplate{
+			Strategy:              RepoPatchStrategyWorkflowPermissionsReadDefault,
+			Description:           "Replace workflow write-all permissions with read-only permission values.",
+			Match:                 "permissions: write-all",
+			Replacement:           "permissions:\n  contents: read",
+			RequiresSourceContent: true,
+		})
+}
+
+func workflowPullRequestTargetRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return deterministicRepoRemediation(finding, detector,
+		"Move untrusted pull-request execution away from pull_request_target.",
+		"`pull_request_target` can run with elevated repository token context when workflow logic handles untrusted PR input.",
+		[]string{
+			"Use `pull_request` for workflows that build, test, or checkout untrusted contributor code.",
+			"Keep any remaining `pull_request_target` workflow metadata-only and remove checkout, shell, release, deploy, and secret usage.",
+			"Split privileged labeling or commenting into a separate minimal workflow if repository writes are required.",
+		},
+		[]string{
+			"`pull_request_target` can be appropriate for metadata-only automation; review the workflow behavior before replacing it.",
+			"Never checkout PR head code in a privileged `pull_request_target` job.",
+		},
+		[]string{
+			"Open a fork PR or test branch PR and confirm the workflow runs without write-token access.",
+			"Confirm privileged jobs no longer receive secrets on untrusted PR paths.",
+		},
+		&RepoExposurePatchTemplate{
+			Strategy:              RepoPatchStrategyWorkflowPullRequestTrigger,
+			Description:           "Replace the privileged PR trigger with the unprivileged pull_request trigger.",
+			Match:                 "pull_request_target",
+			Replacement:           "pull_request",
+			RequiresSourceContent: true,
+		})
+}
+
+func workflowBroadTokenRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return guidanceRepoRemediation(finding, detector,
+		"Constrain workflow or job token permissions to explicit least-privilege scopes.",
+		"A workflow/job grants write-capable GITHUB_TOKEN scopes beyond the minimum needed for that job.",
+		[]string{
+			"Set the workflow-level default to `permissions: { contents: read }`.",
+			"Move required write scopes to the smallest job that needs them and remove broad inherited write scopes.",
+			"Gate release, package, deployment, or environment-mutating jobs with protected branches or environments.",
+		},
+		[]string{
+			"Do not remove `id-token: write` from jobs that legitimately mint OIDC tokens; instead scope cloud trust policies tightly.",
+			"Validate release/deploy workflows after reducing token scopes.",
+		},
+		[]string{
+			"Run the affected workflow and inspect the permissions summary for each job.",
+			"Confirm jobs without write behavior no longer receive write scopes.",
+		},
+		"broad workflow permission blocks require workflow-owner review before a source patch can be published safely")
+}
+
+func workflowPrivilegedContextRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return guidanceRepoRemediation(finding, detector,
+		"Remove privileged behavior from pull_request_target workflows.",
+		"`pull_request_target` is reachable with write-token permissions, secrets, cloud login, release, or deployment behavior.",
+		[]string{
+			"Split untrusted PR code execution into a `pull_request` workflow with read-only permissions.",
+			"Keep `pull_request_target` jobs metadata-only; remove secrets, write permissions, deploy steps, and cloud authentication.",
+			"Use environment approvals or protected branches for any remaining privileged path.",
+		},
+		[]string{
+			"Review every job in the workflow because the dangerous behavior may be inherited from workflow-level permissions.",
+			"Do not trust artifacts, caches, or checkout content produced by untrusted PRs in privileged jobs.",
+		},
+		[]string{
+			"Run a fork PR and confirm privileged jobs do not execute with secrets or write scopes.",
+			"Verify environment protection rules gate deploy or release jobs.",
+		},
+		"privileged pull_request_target workflows require structural workflow review before automated publication")
+}
+
+func workflowUntrustedCheckoutRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return guidanceRepoRemediation(finding, detector,
+		"Stop checking out untrusted PR head code inside pull_request_target.",
+		"A privileged `pull_request_target` job checks out PR-controlled code, allowing untrusted code to run with elevated context.",
+		[]string{
+			"Remove checkout of `github.event.pull_request.head.*` from privileged jobs.",
+			"Run untrusted checkout and build steps in a separate `pull_request` workflow with read-only permissions and no secrets.",
+			"If metadata is needed, checkout the trusted base ref only and avoid running PR-controlled scripts.",
+		},
+		[]string{
+			"Changing checkout refs can alter which code is tested; split workflows instead of silently changing build semantics.",
+			"Treat PR artifacts from untrusted workflows as untrusted inputs.",
+		},
+		[]string{
+			"Run a fork PR and confirm the privileged workflow does not checkout or execute PR head code.",
+			"Confirm any downstream workflow_run consumer validates artifact provenance.",
+		},
+		"untrusted checkout fixes require workflow restructuring before a safe generated PR can be published")
+}
+
+func workflowUnpinnedActionRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return placeholderRepoRemediation(finding, detector,
+		"Pin third-party GitHub Actions to audited commit SHAs.",
+		"A workflow uses a mutable third-party action reference, so upstream changes can alter CI behavior without review.",
+		[]string{
+			"Resolve the referenced action tag or branch to an audited full commit SHA.",
+			"Replace the mutable ref with the SHA and record the update process in dependency automation.",
+			"Prefer allowlisted first-party actions or reusable workflows for privileged jobs.",
+		},
+		[]string{
+			"Do not replace the action ref with an unaudited SHA; review upstream source and release notes first.",
+			"Pinning by SHA improves determinism but still requires periodic updates.",
+		},
+		[]string{
+			"Re-run the workflow and confirm the pinned action executes from the intended SHA.",
+			"Enable dependency update review for future action upgrades.",
+		},
+		"uses: owner/action@<audited-full-commit-sha>",
+		"action pinning requires an operator-supplied audited SHA")
+}
+
+func workflowShellInjectionRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return guidanceRepoRemediation(finding, detector,
+		"Move PR or issue-controlled GitHub context out of direct shell interpolation.",
+		"A shell step interpolates user-controlled GitHub context directly, creating command-injection risk.",
+		[]string{
+			"Pass user-controlled values through environment variables instead of embedding expressions directly in `run` scripts.",
+			"Quote shell variables and avoid `eval`, command substitution, or unquoted heredocs around PR/issue/comment fields.",
+			"Prefer purpose-built actions or scripts that treat user input as data.",
+		},
+		[]string{
+			"Review the entire shell block, not only the flagged line, because injection can cross line boundaries.",
+			"Do not log untrusted values if they may contain secrets or terminal control characters.",
+		},
+		[]string{
+			"Run the workflow with PR titles and branch names containing shell metacharacters.",
+			"Confirm the step treats the value as data and does not execute injected commands.",
+		},
+		"shell blocks need context-specific quoting and tests before automated publication")
+}
+
+func workflowRunPrivilegeRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return guidanceRepoRemediation(finding, detector,
+		"Gate workflow_run privilege chains and validate upstream artifacts.",
+		"`workflow_run` can connect upstream workflow output to privileged repository, release, deployment, or cloud behavior.",
+		[]string{
+			"Limit `workflow_run` triggers to trusted upstream workflows and protected branches.",
+			"Validate artifact provenance before using upstream files in privileged jobs.",
+			"Move release, deploy, and cloud-auth behavior behind protected environments.",
+		},
+		[]string{
+			"Treat upstream artifacts as untrusted unless they were produced by a trusted branch and workflow.",
+			"Do not grant write scopes to workflow_run jobs unless an approval gate exists.",
+		},
+		[]string{
+			"Trigger the upstream workflow from an untrusted PR and confirm privileged consumers do not run.",
+			"Verify deployment environments require approval before privileged actions.",
+		},
+		"workflow_run remediation depends on repository workflow topology and approval gates")
+}
+
+func workflowOIDCTrustRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return guidanceRepoRemediation(finding, detector,
+		"Restrict OIDC token minting and cloud trust to protected workflow contexts.",
+		"`id-token: write` is reachable from workflow contexts that may be influenced by PRs, workflow_run chains, or broad branch triggers.",
+		[]string{
+			"Remove `id-token: write` from untrusted PR, workflow_run, or all-branch workflow paths.",
+			"Scope cloud trust policies to exact repository, workflow, branch, tag, and environment claims.",
+			"Require protected environments for production cloud credentials.",
+		},
+		[]string{
+			"Changing OIDC permissions can break cloud deployments; update cloud trust policy and workflow permissions together.",
+			"Review the cloud-side trust relationship because repository-only changes may not close the path.",
+		},
+		[]string{
+			"Run cloud login jobs from untrusted and trusted branches and confirm only trusted contexts mint credentials.",
+			"Inspect cloud audit logs for denied and allowed OIDC assumption attempts.",
+		},
+		"OIDC remediation requires both repository workflow changes and cloud trust policy review")
+}
+
+func workflowCachePoisoningRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return guidanceRepoRemediation(finding, detector,
+		"Separate untrusted PR caches from trusted build caches.",
+		"Cache keys or restore paths can be influenced by untrusted PR context, allowing poisoned cache reuse.",
+		[]string{
+			"Avoid PR-controlled fields in cache keys used by privileged or trusted jobs.",
+			"Use separate cache namespaces for pull requests and protected-branch builds.",
+			"Keep restore keys narrow and avoid broad fallbacks from untrusted workflow runs.",
+		},
+		[]string{
+			"Cache poisoning fixes can increase cache misses; prioritize correctness over reuse for privileged jobs.",
+			"Do not reuse artifacts or caches from untrusted PRs in release or deploy workflows.",
+		},
+		[]string{
+			"Run PR and protected-branch workflows and confirm their cache keys do not overlap.",
+			"Verify privileged jobs cannot restore PR-controlled cache entries.",
+		},
+		"cache remediation depends on project package-manager and workflow layout")
+}
+
+func workflowArtifactPoisoningRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return guidanceRepoRemediation(finding, detector,
+		"Isolate untrusted artifacts and restrict release publishing paths.",
+		"Untrusted PR or workflow_run output can upload artifacts or release assets consumed by privileged workflows.",
+		[]string{
+			"Keep untrusted PR artifacts isolated from privileged workflow_run consumers.",
+			"Validate artifact checksums, workflow provenance, and branch protection before reuse.",
+			"Restrict release publishing to protected branches, environments, and minimal write-token jobs.",
+		},
+		[]string{
+			"Do not treat artifact download as trusted input merely because it came from GitHub Actions.",
+			"Review all downstream consumers of the uploaded artifact before changing only the producing job.",
+		},
+		[]string{
+			"Run a fork PR and confirm its artifacts cannot reach privileged release or deploy jobs.",
+			"Verify release jobs require protected branch or environment context.",
+		},
+		"artifact remediation depends on producer and consumer workflow pairing")
+}
+
+func workflowGenericRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return guidanceRepoRemediation(finding, detector,
+		"Harden the affected GitHub Actions workflow path.",
+		firstNonEmpty(finding.HumanSummary, "The workflow contains a repository automation pattern that can increase machine-identity blast radius."),
+		[]string{
+			"Review the workflow trigger, token permissions, checkout behavior, secrets, caches, artifacts, and cloud authentication path.",
+			"Move untrusted PR code execution to read-only workflows without secrets.",
+			"Gate privileged jobs with protected branches or environments and explicit least-privilege permissions.",
+		},
+		[]string{
+			"Generic workflow remediation should be reviewed by the workflow owner before publication.",
+		},
+		[]string{
+			"Run the workflow from trusted and untrusted contexts and compare permissions, secrets, and artifacts.",
+		},
+		"generic workflow remediation requires detector-specific owner review")
+}
+
+func k8sPrivilegedRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return deterministicRepoRemediation(finding, detector,
+		"Disable privileged containers in Kubernetes manifests.",
+		"A Kubernetes container is configured with `privileged: true`, which can bypass workload isolation boundaries.",
+		[]string{
+			"Set `privileged: false` on the affected container securityContext.",
+			"Apply Pod Security standards and add only the specific Linux capabilities the workload actually needs.",
+			"Review hostPath, hostNetwork, hostPID, and hostIPC settings in the same manifest before merging.",
+		},
+		[]string{
+			"Some node-level agents legitimately require elevated settings; confirm workload requirements before merging.",
+			"Prefer a dedicated namespace and service account for workloads that need exceptional privileges.",
+		},
+		[]string{
+			"Run `kubectl apply --dry-run=server` or policy validation against the manifest.",
+			"Confirm admission policy rejects `privileged: true` for normal application namespaces.",
+		},
+		&RepoExposurePatchTemplate{
+			Strategy:              RepoPatchStrategyLineLiteral,
+			Description:           "Replace the privileged container flag with false.",
+			Match:                 "privileged: true",
+			Replacement:           "privileged: false",
+			RequiresSourceContent: true,
+		})
+}
+
+func terraformPublicACLRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return deterministicRepoRemediation(finding, detector,
+		"Replace public S3 ACLs with private ACLs.",
+		"Terraform sets an S3 ACL to public-read or public-read-write, which can expose bucket data.",
+		[]string{
+			"Change public ACL values to `private`.",
+			"Use explicit bucket policies for the smallest set of principals that require access.",
+			"Enable public access blocks unless a documented exception is approved.",
+		},
+		[]string{
+			"Changing ACLs can break intentionally public static assets; confirm the bucket purpose first.",
+			"Prefer bucket policies and CloudFront/OAC over public bucket ACLs for public delivery.",
+		},
+		[]string{
+			"Run `terraform plan` and verify no unintended public access remains.",
+			"Run cloud provider public-access checks for the affected bucket.",
+		},
+		&RepoExposurePatchTemplate{
+			Strategy:              RepoPatchStrategyLineRegex,
+			Description:           "Replace public-read/public-read-write ACL values with private.",
+			MatchPattern:          `(?i)^\s*acl\s*=\s*"public-(?:read|read-write)"\s*$`,
+			Replacement:           `acl = "private"`,
+			RequiresSourceContent: true,
+		})
+}
+
+func terraformOpenManagementPortRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return placeholderRepoRemediation(finding, detector,
+		"Restrict SSH/RDP ingress CIDRs to approved administrative networks.",
+		"Terraform security group configuration appears to expose SSH or RDP to the internet.",
+		[]string{
+			"Replace `0.0.0.0/0` and `::/0` management-port ingress with approved bastion, VPN, or zero-trust access CIDRs.",
+			"Prefer SSM Session Manager or identity-aware access over direct public SSH/RDP.",
+			"Add tests or policy checks that reject public management-port ingress.",
+		},
+		[]string{
+			"Do not replace open CIDRs with a placeholder in a real PR; use an approved network list.",
+			"Confirm emergency access and break-glass paths before tightening management ingress.",
+		},
+		[]string{
+			"Run `terraform plan` and verify management ingress no longer includes `0.0.0.0/0` or `::/0`.",
+			"Run infrastructure policy checks against the plan output.",
+		},
+		"cidr_blocks = var.approved_admin_cidrs",
+		"approved administrative CIDRs are environment-specific and must be supplied by an operator")
+}
+
+func dockerLatestTagRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return placeholderRepoRemediation(finding, detector,
+		"Pin Docker base images to immutable versions or digests.",
+		"A Dockerfile uses a mutable `latest` tag, reducing build reproducibility and supply-chain traceability.",
+		[]string{
+			"Resolve the base image to an approved version tag or digest.",
+			"Replace `:latest` with the approved immutable reference.",
+			"Document the image update process through dependency automation or release notes.",
+		},
+		[]string{
+			"Do not publish a PR with a placeholder image tag; choose a tested version or digest.",
+			"Digest pinning improves reproducibility but should be paired with update automation.",
+		},
+		[]string{
+			"Rebuild the image and run the application test suite.",
+			"Confirm the image reference no longer depends on the mutable `latest` tag.",
+		},
+		"FROM <image>:<pinned-version-or-digest>",
+		"Docker image pinning requires an operator-selected tested version or digest")
+}
+
+func deterministicRepoRemediation(
+	finding domain.Finding,
+	detector string,
+	summary string,
+	risk string,
+	steps []string,
+	safety []string,
+	validation []string,
+	patch *RepoExposurePatchTemplate,
+) RepoExposureRemediation {
+	remediation := guidanceRepoRemediation(finding, detector, summary, risk, steps, safety, validation, "")
+	remediation.Patch = patch
+	remediation.Publishable = patch != nil && !patch.Placeholder
+	if remediation.Publishable {
+		remediation.PublishBlockedReason = ""
+	}
+	return remediation
+}
+
+func placeholderRepoRemediation(
+	finding domain.Finding,
+	detector string,
+	summary string,
+	risk string,
+	steps []string,
+	safety []string,
+	validation []string,
+	replacement string,
+	blockedReason string,
+) RepoExposureRemediation {
+	remediation := guidanceRepoRemediation(finding, detector, summary, risk, steps, safety, validation, blockedReason)
+	remediation.Patch = &RepoExposurePatchTemplate{
+		Strategy:              RepoPatchStrategyLineLiteral,
+		Description:           "Preview-only replacement requiring operator-supplied values.",
+		Replacement:           replacement,
+		RequiresSourceContent: true,
+		Placeholder:           true,
+	}
+	return remediation
+}
+
+func guidanceRepoRemediation(
+	finding domain.Finding,
+	detector string,
+	summary string,
+	risk string,
+	steps []string,
+	safety []string,
+	validation []string,
+	blockedReason string,
+) RepoExposureRemediation {
+	publishable := blockedReason == ""
+	if blockedReason == "" {
+		blockedReason = "no deterministic source patch is available for this detector"
+		publishable = false
+	}
+	return RepoExposureRemediation{
+		Detector:             detector,
+		Summary:              summary,
+		RiskSummary:          firstNonEmpty(risk, finding.HumanSummary, finding.Title),
+		Steps:                append([]string(nil), steps...),
+		SafetyNotes:          append([]string(nil), safety...),
+		Validation:           append([]string(nil), validation...),
+		Publishable:          publishable,
+		PublishBlockedReason: blockedReason,
+		Evidence:             repoExposureScope(finding, true),
+	}
+}
+
+func repoExposureScope(finding domain.Finding, includeSnippet bool) RepoExposureRemediationScope {
+	scope := RepoExposureRemediationScope{
+		FindingID:  strings.TrimSpace(finding.ID),
+		ScanID:     strings.TrimSpace(finding.ScanID),
+		Repository: strings.TrimSpace(finding.Repository),
+		Commit:     strings.TrimSpace(finding.Commit),
+		FilePath:   strings.TrimSpace(finding.FilePath),
+		LineNumber: finding.LineNumber,
+	}
+	if includeSnippet && finding.Type != domain.FindingSecretExposure && (finding.LineSnippetRedacted == nil || !*finding.LineSnippetRedacted) {
+		scope.LineSnippet = strings.TrimSpace(finding.LineSnippet)
+	}
+	return scope
+}
+
+func repoDetectorOrDefault(finding domain.Finding, fallback string) string {
+	if detector := strings.TrimSpace(finding.Detector); detector != "" {
+		return detector
+	}
+	if detector := stringEvidence(finding.Evidence, "detector"); detector != "" {
+		return detector
+	}
+	return fallback
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/findings/standards/repo_remediation_test.go
+++ b/internal/findings/standards/repo_remediation_test.go
@@ -1,0 +1,120 @@
+package standards
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+func TestSuggestRepoExposureRemediationSupportsMisconfigDetectors(t *testing.T) {
+	cases := []struct {
+		detector    string
+		publishable bool
+		wantPatch   bool
+	}{
+		{"workflow_write_all_permissions", true, true},
+		{"workflow_pull_request_target", true, true},
+		{"workflow_broad_token_permissions", false, false},
+		{"workflow_pull_request_target_privileged_context", false, false},
+		{"workflow_pull_request_target_untrusted_checkout", false, false},
+		{"workflow_unpinned_third_party_action", false, true},
+		{"workflow_shell_injection_user_context", false, false},
+		{"workflow_run_privilege_chain", false, false},
+		{"workflow_oidc_broad_trust", false, false},
+		{"workflow_cache_poisoning", false, false},
+		{"workflow_artifact_poisoning", false, false},
+		{"k8s_privileged_true", true, true},
+		{"terraform_public_s3_acl", true, true},
+		{"terraform_open_ssh_rdp", false, true},
+		{"docker_latest_tag", false, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.detector, func(t *testing.T) {
+			remediation, ok := SuggestRepoExposureRemediation(domain.Finding{
+				ID:          "finding-1",
+				ScanID:      "scan-1",
+				Type:        domain.FindingRepoMisconfig,
+				Detector:    tc.detector,
+				Repository:  "owner/repo",
+				Commit:      "abc123",
+				FilePath:    ".github/workflows/ci.yml",
+				LineNumber:  7,
+				LineSnippet: "permissions: write-all",
+			})
+			if !ok {
+				t.Fatalf("expected remediation for %s", tc.detector)
+			}
+			if remediation.Detector != tc.detector {
+				t.Fatalf("detector: want %s, got %s", tc.detector, remediation.Detector)
+			}
+			if remediation.Summary == "" || remediation.RiskSummary == "" {
+				t.Fatalf("expected summary and risk summary, got %+v", remediation)
+			}
+			if len(remediation.Steps) == 0 || len(remediation.SafetyNotes) == 0 || len(remediation.Validation) == 0 {
+				t.Fatalf("expected steps, safety notes, and validation, got %+v", remediation)
+			}
+			if remediation.Publishable != tc.publishable {
+				t.Fatalf("publishable: want %t, got %t (%s)", tc.publishable, remediation.Publishable, remediation.PublishBlockedReason)
+			}
+			if tc.publishable && remediation.PublishBlockedReason != "" {
+				t.Fatalf("publishable remediation must not include blocked reason, got %q", remediation.PublishBlockedReason)
+			}
+			if gotPatch := remediation.Patch != nil; gotPatch != tc.wantPatch {
+				t.Fatalf("patch presence: want %t, got %t", tc.wantPatch, gotPatch)
+			}
+			if !tc.publishable && remediation.PublishBlockedReason == "" {
+				t.Fatal("expected blocked publish reason for non-publishable remediation")
+			}
+			if remediation.Evidence.FindingID != "finding-1" || remediation.Evidence.ScanID != "scan-1" {
+				t.Fatalf("expected traceability evidence, got %+v", remediation.Evidence)
+			}
+		})
+	}
+}
+
+func TestSuggestRepoExposureRemediationSecretExposureIsRotationOnly(t *testing.T) {
+	secretSnippet := "aws_secret_access_key = \"0123456789abcdef0123456789abcdef01234567\""
+	remediation, ok := SuggestRepoExposureRemediation(domain.Finding{
+		ID:          "secret-1",
+		ScanID:      "scan-1",
+		Type:        domain.FindingSecretExposure,
+		Detector:    "aws_secret_access_key",
+		Repository:  "owner/repo",
+		FilePath:    "app.env",
+		LineNumber:  3,
+		LineSnippet: secretSnippet,
+	})
+	if !ok {
+		t.Fatal("expected secret remediation guidance")
+	}
+	if !remediation.SecretRotation {
+		t.Fatal("expected secret remediation to require rotation")
+	}
+	if remediation.Publishable || remediation.Patch != nil {
+		t.Fatalf("secret remediation must not be publishable or patched: %+v", remediation)
+	}
+	if remediation.Evidence.LineSnippet != "" {
+		t.Fatalf("secret remediation must not echo raw line snippets, got %q", remediation.Evidence.LineSnippet)
+	}
+	combined := remediation.Summary + " " + remediation.RiskSummary + " " + strings.Join(remediation.Steps, " ") + " " + strings.Join(remediation.SafetyNotes, " ") + " " + strings.Join(remediation.Validation, " ")
+	if strings.Contains(combined, "0123456789abcdef") {
+		t.Fatalf("secret remediation leaked raw secret material: %s", combined)
+	}
+	if !strings.Contains(strings.ToLower(combined), "rotate") {
+		t.Fatalf("expected rotation guidance, got %s", combined)
+	}
+}
+
+func TestSuggestRepoExposureRemediationRejectsUnsupportedFinding(t *testing.T) {
+	if _, ok := SuggestRepoExposureRemediation(domain.Finding{Type: domain.FindingOwnerless}); ok {
+		t.Fatal("expected unsupported non-repo finding to return false")
+	}
+	if _, ok := SuggestRepoExposureRemediation(domain.Finding{
+		Type:     domain.FindingRepoMisconfig,
+		Detector: "unknown_detector",
+	}); ok {
+		t.Fatal("expected unknown repo detector to return false")
+	}
+}

--- a/internal/remediation/fixpr/publisher_test.go
+++ b/internal/remediation/fixpr/publisher_test.go
@@ -3,6 +3,7 @@ package fixpr
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -183,6 +184,112 @@ func TestGitHubPublisher_Publish_HappyPath(t *testing.T) {
 	}
 	if base, _ := prReq.Body["base"].(string); base != plan.BaseBranch {
 		t.Errorf("PR base: want %s, got %s", plan.BaseBranch, base)
+	}
+}
+
+func TestGitHubPublisher_PublishRepoExposureRemediationRequiresApprovalAndCredentials(t *testing.T) {
+	publisher := GitHubPublisher{APIBaseURL: "http://example.invalid"}
+	finding := repoMisconfigFinding("workflow_write_all_permissions")
+	source := "name: ci\npermissions: write-all\n"
+
+	_, _, err := publisher.PublishRepoExposureRemediation(context.Background(), finding, RepoExposurePublishOptions{
+		Owner:                      "acme",
+		Repo:                       "repo",
+		Token:                      "tok",
+		SourceContent:              source,
+		OperatorApproved:           false,
+		WritePermissionsConfigured: true,
+	})
+	if !errors.Is(err, ErrRepoExposurePublishApprovalRequired) {
+		t.Fatalf("expected approval error, got %v", err)
+	}
+
+	_, _, err = publisher.PublishRepoExposureRemediation(context.Background(), finding, RepoExposurePublishOptions{
+		Owner:                      "acme",
+		Repo:                       "repo",
+		Token:                      "tok",
+		SourceContent:              source,
+		OperatorApproved:           true,
+		WritePermissionsConfigured: false,
+	})
+	if !errors.Is(err, ErrRepoExposurePublishCredentialsMissing) {
+		t.Fatalf("expected credentials error when write permissions are not configured, got %v", err)
+	}
+
+	_, _, err = publisher.PublishRepoExposureRemediation(context.Background(), finding, RepoExposurePublishOptions{
+		Owner:                      "acme",
+		Repo:                       "repo",
+		SourceContent:              source,
+		OperatorApproved:           true,
+		WritePermissionsConfigured: true,
+	})
+	if !errors.Is(err, ErrRepoExposurePublishCredentialsMissing) {
+		t.Fatalf("expected credentials error when token is missing, got %v", err)
+	}
+}
+
+func TestGitHubPublisher_PublishRepoExposureRemediationHappyPath(t *testing.T) {
+	srv, recorded, mu := newFakeGitHubServer(t)
+	publisher := GitHubPublisher{APIBaseURL: srv.URL}
+	finding := repoMisconfigFinding("workflow_write_all_permissions")
+	finding.LineNumber = 2
+	source := "name: ci\npermissions: write-all\njobs:\n  test:\n    runs-on: ubuntu-latest\n"
+
+	result, remediation, err := publisher.PublishRepoExposureRemediation(context.Background(), finding, RepoExposurePublishOptions{
+		Owner:                      "acme",
+		Repo:                       "repo",
+		Token:                      " tok-repo-write \n",
+		SourceContent:              source,
+		OperatorApproved:           true,
+		WritePermissionsConfigured: true,
+		PlanOptions: PlanOptions{
+			BaseBranch:   "dev",
+			BranchPrefix: "identrail/remediate",
+			FindingURL:   "https://app.example.com/findings/repo-finding-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("PublishRepoExposureRemediation returned error: %v", err)
+	}
+	if !remediation.Publishable {
+		t.Fatalf("expected publishable remediation, got %+v", remediation)
+	}
+	if result.PRNumber != 42 || result.BranchName != "identrail/remediate/repo-finding-1" {
+		t.Fatalf("unexpected publish result: %+v", result)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*recorded) != 7 {
+		t.Fatalf("expected 7 GitHub API requests for one-file repo remediation, got %d: %+v", len(*recorded), *recorded)
+	}
+	for i, req := range *recorded {
+		if req.Auth != "Bearer tok-repo-write" {
+			t.Fatalf("request %d used untrimmed or missing token: %q", i, req.Auth)
+		}
+	}
+	treeReq := (*recorded)[3]
+	entries, ok := treeReq.Body["tree"].([]any)
+	if !ok || len(entries) != 1 {
+		t.Fatalf("expected one tree entry for the affected file only, got %+v", treeReq.Body)
+	}
+	entry, ok := entries[0].(map[string]any)
+	if !ok || entry["path"] != ".github/workflows/ci.yml" {
+		t.Fatalf("expected workflow file tree entry, got %+v", entries[0])
+	}
+	prReq := (*recorded)[6]
+	body, _ := prReq.Body["body"].(string)
+	for _, required := range []string{
+		"Finding ID: `repo-finding-1`",
+		"Scan ID: `repo-scan-1`",
+		"Detector: `workflow_write_all_permissions`",
+		"Risk summary",
+		"Validation notes",
+		"Safety notes",
+	} {
+		if !strings.Contains(body, required) {
+			t.Fatalf("repo exposure PR body missing %q:\n%s", required, body)
+		}
 	}
 }
 

--- a/internal/remediation/fixpr/repo_exposure.go
+++ b/internal/remediation/fixpr/repo_exposure.go
@@ -1,0 +1,399 @@
+package fixpr
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/findings/standards"
+)
+
+var (
+	ErrRepoExposureRemediationUnsupported = errors.New("repo exposure remediation unsupported")
+	ErrRepoExposureRemediationUnsafe      = errors.New("repo exposure remediation is not safe to publish")
+	ErrRepoExposureSourceRequired         = errors.New("repo exposure source content required")
+	ErrRepoExposurePatchApplyFailed       = errors.New("repo exposure patch could not be applied")
+
+	workflowPermissionsScalarWriteAllPattern = regexp.MustCompile(`^(\s*)permissions\s*:\s*write-all\s*(?:#.*)?$`)
+	workflowPermissionValueWriteAllPattern   = regexp.MustCompile(`^(\s*[^:#]+:\s*)write-all(\s*(?:#.*)?)$`)
+	workflowPermissionFlowWriteAllPattern    = regexp.MustCompile(`(:\s*)write-all(\s*(?:[,}#]|$))`)
+	workflowPullRequestTargetTokenPattern    = regexp.MustCompile(`\bpull_request_target\b`)
+	workflowOnKeyPattern                     = regexp.MustCompile(`^\s*on\s*:\s*(?:#.*)?$`)
+	workflowPermissionsKeyPattern            = regexp.MustCompile(`^\s*permissions\s*:\s*(?:#.*)?$`)
+)
+
+// RepoExposureFixPRPlan composes a FixPRPlan for one repo exposure finding and
+// its affected file content. It only writes the affected repository file; secret
+// findings and placeholder-only remediations are rejected before publication.
+func BuildRepoExposureFixPRPlan(finding domain.Finding, sourceContent string, opts PlanOptions) (FixPRPlan, standards.RepoExposureRemediation, error) {
+	domain.NormalizeRepoFindingMetadata(&finding)
+	remediation, ok := standards.SuggestRepoExposureRemediation(finding)
+	if !ok {
+		return FixPRPlan{}, standards.RepoExposureRemediation{}, ErrRepoExposureRemediationUnsupported
+	}
+	if remediation.Patch == nil || !remediation.Publishable || remediation.Patch.Placeholder {
+		return FixPRPlan{}, remediation, fmt.Errorf("%w: %s", ErrRepoExposureRemediationUnsafe, remediation.PublishBlockedReason)
+	}
+	if strings.TrimSpace(sourceContent) == "" {
+		return FixPRPlan{}, remediation, ErrRepoExposureSourceRequired
+	}
+	targetPath, err := repoExposureTargetPath(finding)
+	if err != nil {
+		return FixPRPlan{}, remediation, err
+	}
+	patched, err := applyRepoExposurePatch(sourceContent, finding, *remediation.Patch)
+	if err != nil {
+		return FixPRPlan{}, remediation, err
+	}
+	if patched == sourceContent {
+		return FixPRPlan{}, remediation, fmt.Errorf("%w: no source changes produced", ErrRepoExposurePatchApplyFailed)
+	}
+
+	base := strings.TrimSpace(opts.BaseBranch)
+	if base == "" {
+		base = "main"
+	}
+	prefix := strings.TrimSpace(opts.BranchPrefix)
+	if prefix == "" {
+		prefix = "identrail/fix"
+	}
+	slug := slugifyFindingID(firstNonEmpty(finding.ID, remediation.Detector))
+	branch := prefix + "/" + slug
+
+	return FixPRPlan{
+		BaseBranch:    base,
+		BranchName:    branch,
+		CommitMessage: buildRepoExposureCommitMessage(finding, remediation),
+		PRTitle:       buildRepoExposurePRTitle(finding, remediation),
+		PRBody:        buildRepoExposurePRBody(finding, remediation, opts.FindingURL),
+		Files: []PlanFile{{
+			Path:    targetPath,
+			Content: patched,
+		}},
+		FindingID:   finding.ID,
+		FindingType: string(finding.Type),
+	}, remediation, nil
+}
+
+func repoExposureTargetPath(finding domain.Finding) (string, error) {
+	rawTarget := strings.TrimSpace(finding.FilePath)
+	if rawTarget == "" && len(finding.Path) == 1 {
+		rawTarget = strings.TrimSpace(finding.Path[0])
+	}
+	if path.IsAbs(rawTarget) {
+		return "", fmt.Errorf("%w: invalid repo file path", ErrRepoExposurePatchApplyFailed)
+	}
+	target := strings.Trim(rawTarget, "/")
+	if target == "." || target == ".." || strings.Contains(target, `\`) || path.IsAbs(target) ||
+		strings.HasPrefix(target, "../") ||
+		strings.Contains(target, "/../") ||
+		strings.HasSuffix(target, "/..") {
+		return "", fmt.Errorf("%w: invalid repo file path", ErrRepoExposurePatchApplyFailed)
+	}
+	clean := path.Clean(target)
+	if clean == "." || clean == "" || clean == ".." || path.IsAbs(clean) || strings.HasPrefix(clean, "../") || strings.Contains(clean, "/../") {
+		return "", fmt.Errorf("%w: invalid repo file path", ErrRepoExposurePatchApplyFailed)
+	}
+	return clean, nil
+}
+
+func applyRepoExposurePatch(source string, finding domain.Finding, patch standards.RepoExposurePatchTemplate) (string, error) {
+	lines, trailingNewline := splitLines(source)
+	if len(lines) == 0 {
+		return "", fmt.Errorf("%w: empty source", ErrRepoExposurePatchApplyFailed)
+	}
+
+	if finding.LineNumber <= 0 {
+		return "", fmt.Errorf("%w: finding line number required", ErrRepoExposurePatchApplyFailed)
+	}
+
+	lineIndex := finding.LineNumber - 1
+	if lineIndex < 0 || lineIndex >= len(lines) {
+		return "", fmt.Errorf("%w: finding line %d is outside the supplied source", ErrRepoExposurePatchApplyFailed, finding.LineNumber)
+	}
+	switch patch.Strategy {
+	case standards.RepoPatchStrategyWorkflowPermissionsReadDefault:
+		return applyWorkflowPermissionsReadDefaultPatch(lines, trailingNewline, lineIndex, patch)
+	case standards.RepoPatchStrategyWorkflowPullRequestTrigger:
+		return applyWorkflowPullRequestTriggerPatch(lines, trailingNewline, lineIndex, patch)
+	}
+	if repoExposureLineMatches(lines[lineIndex], patch) {
+		return replaceLine(lines, trailingNewline, lineIndex, patch), nil
+	}
+	return "", fmt.Errorf("%w: finding line %d did not match template", ErrRepoExposurePatchApplyFailed, finding.LineNumber)
+}
+
+func repoExposureLineMatches(line string, patch standards.RepoExposurePatchTemplate) bool {
+	switch patch.Strategy {
+	case standards.RepoPatchStrategyLineRegex:
+		re, err := regexp.Compile(patch.MatchPattern)
+		return err == nil && re.MatchString(line)
+	case standards.RepoPatchStrategyLineLiteral, "":
+		match := strings.TrimSpace(patch.Match)
+		return match != "" && strings.TrimSpace(line) == match
+	default:
+		return false
+	}
+}
+
+func replaceLine(lines []string, trailingNewline bool, index int, patch standards.RepoExposurePatchTemplate) string {
+	indent := leadingWhitespace(lines[index])
+	replacementLines := strings.Split(patch.Replacement, "\n")
+	for i, line := range replacementLines {
+		if strings.TrimSpace(line) == "" {
+			replacementLines[i] = ""
+			continue
+		}
+		replacementLines[i] = indent + line
+	}
+	updated := make([]string, 0, len(lines)+len(replacementLines)-1)
+	updated = append(updated, lines[:index]...)
+	updated = append(updated, replacementLines...)
+	updated = append(updated, lines[index+1:]...)
+	joined := strings.Join(updated, "\n")
+	if trailingNewline {
+		joined += "\n"
+	}
+	return joined
+}
+
+func applyWorkflowPermissionsReadDefaultPatch(lines []string, trailingNewline bool, lineIndex int, patch standards.RepoExposurePatchTemplate) (string, error) {
+	line := lines[lineIndex]
+	if workflowPermissionsScalarWriteAllPattern.MatchString(line) {
+		return replaceLine(lines, trailingNewline, lineIndex, patch), nil
+	}
+	if strings.HasPrefix(strings.TrimSpace(line), "permissions:") {
+		if patched, ok := replaceWorkflowPermissionWriteAllValue(line); ok {
+			return replaceLineWithContent(lines, trailingNewline, lineIndex, patched), nil
+		}
+	}
+
+	blockStart, ok := workflowParentKeyLine(lines, lineIndex, "permissions")
+	if ok && blockStart != lineIndex {
+		if patched, ok := replaceWorkflowPermissionWriteAllValue(line); ok {
+			return replaceLineWithContent(lines, trailingNewline, lineIndex, patched), nil
+		}
+	}
+	if !ok {
+		return "", fmt.Errorf("%w: finding line %d is not in a permissions block", ErrRepoExposurePatchApplyFailed, lineIndex+1)
+	}
+	if blockStart != lineIndex && !workflowPermissionsKeyPattern.MatchString(lines[blockStart]) {
+		return "", fmt.Errorf("%w: finding line %d is not in a permissions block", ErrRepoExposurePatchApplyFailed, lineIndex+1)
+	}
+	if patched, ok := replaceWorkflowPermissionWriteAllValue(lines[blockStart]); ok {
+		return replaceLineWithContent(lines, trailingNewline, blockStart, patched), nil
+	}
+	updated := append([]string(nil), lines...)
+	replaced := false
+	for i := blockStart + 1; i < len(updated); i++ {
+		if strings.TrimSpace(updated[i]) == "" {
+			continue
+		}
+		if indentationWidth(updated[i]) <= indentationWidth(updated[blockStart]) {
+			break
+		}
+		if patched, ok := replaceWorkflowPermissionWriteAllValue(updated[i]); ok {
+			updated[i] = patched
+			replaced = true
+		}
+	}
+	if !replaced {
+		return "", fmt.Errorf("%w: permissions block did not contain write-all values", ErrRepoExposurePatchApplyFailed)
+	}
+	return joinLines(updated, trailingNewline), nil
+}
+
+func replaceWorkflowPermissionWriteAllValue(line string) (string, bool) {
+	if workflowPermissionValueWriteAllPattern.MatchString(line) {
+		return workflowPermissionValueWriteAllPattern.ReplaceAllString(line, "${1}read${2}"), true
+	}
+	if workflowPermissionFlowWriteAllPattern.MatchString(line) {
+		return workflowPermissionFlowWriteAllPattern.ReplaceAllString(line, "${1}read${2}"), true
+	}
+	return "", false
+}
+
+func applyWorkflowPullRequestTriggerPatch(lines []string, trailingNewline bool, lineIndex int, patch standards.RepoExposurePatchTemplate) (string, error) {
+	targetIndex := lineIndex
+	if !workflowPullRequestTargetTokenPattern.MatchString(lines[targetIndex]) {
+		var ok bool
+		targetIndex, ok = workflowPullRequestTargetLineInLocalBlock(lines, lineIndex)
+		if !ok {
+			return "", fmt.Errorf("%w: finding line %d is not in a pull_request_target trigger block", ErrRepoExposurePatchApplyFailed, lineIndex+1)
+		}
+	}
+	patched := workflowPullRequestTargetTokenPattern.ReplaceAllString(lines[targetIndex], patch.Replacement)
+	if patched == lines[targetIndex] {
+		return "", fmt.Errorf("%w: pull_request_target trigger line did not change", ErrRepoExposurePatchApplyFailed)
+	}
+	return replaceLineWithContent(lines, trailingNewline, targetIndex, patched), nil
+}
+
+func workflowPullRequestTargetLineInLocalBlock(lines []string, lineIndex int) (int, bool) {
+	blockStart := lineIndex
+	if !workflowOnKeyPattern.MatchString(lines[blockStart]) {
+		var ok bool
+		blockStart, ok = workflowParentKeyLine(lines, lineIndex, "on")
+		if !ok {
+			return -1, false
+		}
+	}
+	parentIndent := indentationWidth(lines[blockStart])
+	for i := blockStart + 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "" {
+			continue
+		}
+		if indentationWidth(lines[i]) <= parentIndent {
+			break
+		}
+		if workflowPullRequestTargetTokenPattern.MatchString(lines[i]) {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+func workflowParentKeyLine(lines []string, lineIndex int, key string) (int, bool) {
+	keyPattern := workflowOnKeyPattern
+	if key == "permissions" {
+		keyPattern = workflowPermissionsKeyPattern
+	}
+	lineIndent := indentationWidth(lines[lineIndex])
+	for i := lineIndex; i >= 0; i-- {
+		if strings.TrimSpace(lines[i]) == "" {
+			continue
+		}
+		indent := indentationWidth(lines[i])
+		if i != lineIndex && indent >= lineIndent {
+			continue
+		}
+		if keyPattern.MatchString(lines[i]) {
+			return i, true
+		}
+		if i != lineIndex && indent <= lineIndent {
+			lineIndent = indent
+		}
+	}
+	return -1, false
+}
+
+func replaceLineWithContent(lines []string, trailingNewline bool, index int, content string) string {
+	updated := append([]string(nil), lines...)
+	updated[index] = content
+	return joinLines(updated, trailingNewline)
+}
+
+func joinLines(lines []string, trailingNewline bool) string {
+	joined := strings.Join(lines, "\n")
+	if trailingNewline {
+		joined += "\n"
+	}
+	return joined
+}
+
+func splitLines(source string) ([]string, bool) {
+	trailingNewline := strings.HasSuffix(source, "\n")
+	lines := strings.Split(source, "\n")
+	if trailingNewline {
+		lines = lines[:len(lines)-1]
+	}
+	return lines, trailingNewline
+}
+
+func leadingWhitespace(line string) string {
+	for i, r := range line {
+		if r != ' ' && r != '\t' {
+			return line[:i]
+		}
+	}
+	return line
+}
+
+func indentationWidth(line string) int {
+	width := 0
+	for _, r := range line {
+		switch r {
+		case ' ':
+			width++
+		case '\t':
+			width += 2
+		default:
+			return width
+		}
+	}
+	return width
+}
+
+func buildRepoExposureCommitMessage(finding domain.Finding, remediation standards.RepoExposureRemediation) string {
+	subject := truncate("remediate "+remediation.Detector, 72)
+	return fmt.Sprintf("identrail: %s\n\nFinding: %s (%s)\n", subject, finding.ID, finding.Type)
+}
+
+func buildRepoExposurePRTitle(finding domain.Finding, remediation standards.RepoExposureRemediation) string {
+	location := strings.TrimSpace(finding.FilePath)
+	if location == "" {
+		return "identrail: remediate " + remediation.Detector
+	}
+	return "identrail: remediate " + remediation.Detector + " in " + location
+}
+
+func buildRepoExposurePRBody(finding domain.Finding, remediation standards.RepoExposureRemediation, findingURL string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "## Summary\n\n%s\n\n", remediation.Summary)
+	fmt.Fprintf(&b, "## Risk summary\n\n%s\n\n", remediation.RiskSummary)
+	b.WriteString("## Traceability\n\n")
+	fmt.Fprintf(&b, "- Finding ID: `%s`\n", finding.ID)
+	if finding.ScanID != "" {
+		fmt.Fprintf(&b, "- Scan ID: `%s`\n", finding.ScanID)
+	}
+	fmt.Fprintf(&b, "- Detector: `%s`\n", remediation.Detector)
+	fmt.Fprintf(&b, "- Finding type: `%s`\n", finding.Type)
+	if finding.Repository != "" {
+		fmt.Fprintf(&b, "- Repository: `%s`\n", finding.Repository)
+	}
+	if finding.FilePath != "" {
+		if finding.LineNumber > 0 {
+			fmt.Fprintf(&b, "- Location: `%s:%d`\n", finding.FilePath, finding.LineNumber)
+		} else {
+			fmt.Fprintf(&b, "- Location: `%s`\n", finding.FilePath)
+		}
+	}
+	if finding.Commit != "" {
+		fmt.Fprintf(&b, "- Commit: `%s`\n", finding.Commit)
+	}
+	if findingURL != "" {
+		fmt.Fprintf(&b, "- Finding link: %s\n", findingURL)
+	}
+	if len(remediation.Steps) > 0 {
+		b.WriteString("\n## Remediation steps\n\n")
+		for _, step := range remediation.Steps {
+			fmt.Fprintf(&b, "- %s\n", step)
+		}
+	}
+	if len(remediation.Validation) > 0 {
+		b.WriteString("\n## Validation notes\n\n")
+		for _, note := range remediation.Validation {
+			fmt.Fprintf(&b, "- %s\n", note)
+		}
+	}
+	if len(remediation.SafetyNotes) > 0 {
+		b.WriteString("\n## Safety notes\n\n")
+		for _, note := range remediation.SafetyNotes {
+			fmt.Fprintf(&b, "- %s\n", note)
+		}
+	}
+	b.WriteString("\n---\n*Generated by Identrail from a repository exposure finding. Review before merging.*\n")
+	return b.String()
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/remediation/fixpr/repo_exposure.go
+++ b/internal/remediation/fixpr/repo_exposure.go
@@ -21,13 +21,14 @@ var (
 	workflowPermissionValueWriteAllPattern   = regexp.MustCompile(`^(\s*[^:#]+:\s*)write-all(\s*(?:#.*)?)$`)
 	workflowPermissionFlowWriteAllPattern    = regexp.MustCompile(`(:\s*)write-all(\s*(?:[,}#]|$))`)
 	workflowPullRequestTargetTokenPattern    = regexp.MustCompile(`\bpull_request_target\b`)
-	workflowPullRequestTargetMappingPattern  = regexp.MustCompile(`^(\s*)pull_request_target(\s*:.*)$`)
-	workflowPullRequestTargetSequencePattern = regexp.MustCompile(`^(\s*-\s*)pull_request_target(\s*)$`)
-	workflowPullRequestTargetScalarPattern   = regexp.MustCompile(`^(\s*on\s*:\s*)pull_request_target(\s*)$`)
+	workflowPullRequestTargetMappingPattern  = regexp.MustCompile(`^(\s*)(?:"pull_request_target"|'pull_request_target'|pull_request_target)(\s*:.*)$`)
+	workflowPullRequestTargetSequencePattern = regexp.MustCompile(`^(\s*-\s*)(?:"pull_request_target"|'pull_request_target'|pull_request_target)(\s*)$`)
+	workflowPullRequestTargetScalarPattern   = regexp.MustCompile(`^(\s*on\s*:\s*)(?:"pull_request_target"|'pull_request_target'|pull_request_target)(\s*)$`)
 	workflowOnFlowSequencePattern            = regexp.MustCompile(`^\s*on\s*:\s*\[`)
 	workflowOnFlowMappingPattern             = regexp.MustCompile(`^\s*on\s*:\s*\{`)
 	workflowOnKeyPattern                     = regexp.MustCompile(`^\s*on\s*:\s*(?:#.*)?$`)
 	workflowPermissionsKeyPattern            = regexp.MustCompile(`^\s*permissions\s*:\s*(?:#.*)?$`)
+	windowsDriveAbsolutePathPattern          = regexp.MustCompile(`^[A-Za-z]:[/\\]`)
 )
 
 // RepoExposureFixPRPlan composes a FixPRPlan for one repo exposure finding and
@@ -88,18 +89,19 @@ func repoExposureTargetPath(finding domain.Finding) (string, error) {
 	if rawTarget == "" && len(finding.Path) == 1 {
 		rawTarget = strings.TrimSpace(finding.Path[0])
 	}
-	if path.IsAbs(rawTarget) {
+	if path.IsAbs(rawTarget) || windowsDriveAbsolutePathPattern.MatchString(rawTarget) {
 		return "", fmt.Errorf("%w: invalid repo file path", ErrRepoExposurePatchApplyFailed)
 	}
 	target := strings.Trim(rawTarget, "/")
 	if target == "." || target == ".." || strings.Contains(target, `\`) || path.IsAbs(target) ||
+		windowsDriveAbsolutePathPattern.MatchString(target) ||
 		strings.HasPrefix(target, "../") ||
 		strings.Contains(target, "/../") ||
 		strings.HasSuffix(target, "/..") {
 		return "", fmt.Errorf("%w: invalid repo file path", ErrRepoExposurePatchApplyFailed)
 	}
 	clean := path.Clean(target)
-	if clean == "." || clean == "" || clean == ".." || path.IsAbs(clean) || strings.HasPrefix(clean, "../") || strings.Contains(clean, "/../") {
+	if clean == "." || clean == "" || clean == ".." || path.IsAbs(clean) || windowsDriveAbsolutePathPattern.MatchString(clean) || strings.HasPrefix(clean, "../") || strings.Contains(clean, "/../") {
 		return "", fmt.Errorf("%w: invalid repo file path", ErrRepoExposurePatchApplyFailed)
 	}
 	return clean, nil
@@ -304,6 +306,15 @@ func replaceTopLevelWorkflowTriggerKey(line string, key string, replacement stri
 			escaped = true
 			continue
 		}
+		if !inSingleQuote && !inDoubleQuote && afterDelimiter && braceDepth == 1 && bracketDepth == 0 {
+			if ch == ' ' || ch == '\t' {
+				continue
+			}
+			if keyLength, ok := workflowTriggerKeyLength(line[i:], key); ok {
+				return line[:i] + replacement + line[i+keyLength:], true
+			}
+			afterDelimiter = false
+		}
 		if ch == '\'' && !inDoubleQuote {
 			inSingleQuote = !inSingleQuote
 			continue
@@ -348,26 +359,37 @@ func replaceTopLevelWorkflowTriggerKey(line string, key string, replacement stri
 			continue
 		}
 
-		if !afterDelimiter || braceDepth != 1 || bracketDepth != 0 {
-			continue
-		}
-		if ch == ' ' || ch == '\t' {
-			continue
-		}
-		if strings.HasPrefix(line[i:], key) {
-			valueStart := i + len(key)
-			valueEnd := valueStart
-			for valueEnd < len(line) && (line[valueEnd] == ' ' || line[valueEnd] == '\t') {
-				valueEnd++
-			}
-			if valueEnd < len(line) && line[valueEnd] == ':' {
-				return line[:i] + replacement + line[valueStart:], true
-			}
-		}
-		afterDelimiter = false
 	}
 
 	return "", false
+}
+
+func workflowTriggerKeyLength(value string, key string) (int, bool) {
+	if strings.HasPrefix(value, key) && workflowTriggerKeyHasColon(value, len(key)) {
+		return len(key), true
+	}
+	if len(value) < len(key)+2 {
+		return 0, false
+	}
+	quote := value[0]
+	if quote != '\'' && quote != '"' {
+		return 0, false
+	}
+	keyEnd := 1 + len(key)
+	if !strings.HasPrefix(value[1:], key) || value[keyEnd] != quote {
+		return 0, false
+	}
+	if !workflowTriggerKeyHasColon(value, keyEnd+1) {
+		return 0, false
+	}
+	return keyEnd + 1, true
+}
+
+func workflowTriggerKeyHasColon(value string, index int) bool {
+	for index < len(value) && (value[index] == ' ' || value[index] == '\t') {
+		index++
+	}
+	return index < len(value) && value[index] == ':'
 }
 
 func workflowPullRequestTargetLineInLocalBlock(lines []string, lineIndex int) (int, bool) {

--- a/internal/remediation/fixpr/repo_exposure.go
+++ b/internal/remediation/fixpr/repo_exposure.go
@@ -133,7 +133,14 @@ func repoExposureLineMatches(line string, patch standards.RepoExposurePatchTempl
 		return err == nil && re.MatchString(line)
 	case standards.RepoPatchStrategyLineLiteral, "":
 		match := strings.TrimSpace(patch.Match)
-		return match != "" && strings.TrimSpace(line) == match
+		if match == "" {
+			return false
+		}
+		if strings.TrimSpace(line) == match {
+			return true
+		}
+		lineWithoutComment, _, ok := splitInlineHashComment(line)
+		return ok && strings.TrimSpace(lineWithoutComment) == match
 	default:
 		return false
 	}
@@ -142,6 +149,11 @@ func repoExposureLineMatches(line string, patch standards.RepoExposurePatchTempl
 func replaceLine(lines []string, trailingNewline bool, index int, patch standards.RepoExposurePatchTemplate) string {
 	indent := leadingWhitespace(lines[index])
 	replacementLines := strings.Split(patch.Replacement, "\n")
+	if len(replacementLines) == 1 {
+		if _, comment, ok := splitInlineHashComment(lines[index]); ok && !hasInlineHashComment(replacementLines[0]) {
+			replacementLines[0] += comment
+		}
+	}
 	for i, line := range replacementLines {
 		if strings.TrimSpace(line) == "" {
 			replacementLines[i] = ""
@@ -301,6 +313,47 @@ func splitLines(source string) ([]string, bool) {
 		lines = lines[:len(lines)-1]
 	}
 	return lines, trailingNewline
+}
+
+func splitInlineHashComment(line string) (string, string, bool) {
+	inSingleQuote := false
+	inDoubleQuote := false
+	escaped := false
+	for i, r := range line {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if inDoubleQuote && r == '\\' {
+			escaped = true
+			continue
+		}
+		switch r {
+		case '\'':
+			if !inDoubleQuote {
+				inSingleQuote = !inSingleQuote
+			}
+		case '"':
+			if !inSingleQuote {
+				inDoubleQuote = !inDoubleQuote
+			}
+		case '#':
+			if inSingleQuote || inDoubleQuote {
+				continue
+			}
+			commentStart := i
+			for commentStart > 0 && (line[commentStart-1] == ' ' || line[commentStart-1] == '\t') {
+				commentStart--
+			}
+			return strings.TrimRight(line[:commentStart], " \t"), line[commentStart:], true
+		}
+	}
+	return line, "", false
+}
+
+func hasInlineHashComment(line string) bool {
+	_, _, ok := splitInlineHashComment(line)
+	return ok
 }
 
 func leadingWhitespace(line string) string {

--- a/internal/remediation/fixpr/repo_exposure.go
+++ b/internal/remediation/fixpr/repo_exposure.go
@@ -21,6 +21,11 @@ var (
 	workflowPermissionValueWriteAllPattern   = regexp.MustCompile(`^(\s*[^:#]+:\s*)write-all(\s*(?:#.*)?)$`)
 	workflowPermissionFlowWriteAllPattern    = regexp.MustCompile(`(:\s*)write-all(\s*(?:[,}#]|$))`)
 	workflowPullRequestTargetTokenPattern    = regexp.MustCompile(`\bpull_request_target\b`)
+	workflowPullRequestTargetMappingPattern  = regexp.MustCompile(`^(\s*)pull_request_target(\s*:.*)$`)
+	workflowPullRequestTargetSequencePattern = regexp.MustCompile(`^(\s*-\s*)pull_request_target(\s*)$`)
+	workflowPullRequestTargetScalarPattern   = regexp.MustCompile(`^(\s*on\s*:\s*)pull_request_target(\s*)$`)
+	workflowOnFlowSequencePattern            = regexp.MustCompile(`^\s*on\s*:\s*\[`)
+	workflowOnFlowMappingPattern             = regexp.MustCompile(`^\s*on\s*:\s*\{`)
 	workflowOnKeyPattern                     = regexp.MustCompile(`^\s*on\s*:\s*(?:#.*)?$`)
 	workflowPermissionsKeyPattern            = regexp.MustCompile(`^\s*permissions\s*:\s*(?:#.*)?$`)
 )
@@ -229,19 +234,140 @@ func replaceWorkflowPermissionWriteAllValue(line string) (string, bool) {
 }
 
 func applyWorkflowPullRequestTriggerPatch(lines []string, trailingNewline bool, lineIndex int, patch standards.RepoExposurePatchTemplate) (string, error) {
-	targetIndex := lineIndex
-	if !workflowPullRequestTargetTokenPattern.MatchString(lines[targetIndex]) {
-		var ok bool
-		targetIndex, ok = workflowPullRequestTargetLineInLocalBlock(lines, lineIndex)
-		if !ok {
-			return "", fmt.Errorf("%w: finding line %d is not in a pull_request_target trigger block", ErrRepoExposurePatchApplyFailed, lineIndex+1)
-		}
+	if patched, ok := patchWorkflowPullRequestTargetTriggerLine(lines[lineIndex], patch.Replacement); ok {
+		return replaceLineWithContent(lines, trailingNewline, lineIndex, patched), nil
 	}
-	patched := workflowPullRequestTargetTokenPattern.ReplaceAllString(lines[targetIndex], patch.Replacement)
-	if patched == lines[targetIndex] {
+
+	targetIndex, ok := workflowPullRequestTargetLineInLocalBlock(lines, lineIndex)
+	if !ok {
+		return "", fmt.Errorf("%w: finding line %d is not in a pull_request_target trigger block", ErrRepoExposurePatchApplyFailed, lineIndex+1)
+	}
+
+	patched, ok := patchWorkflowPullRequestTargetTriggerLine(lines[targetIndex], patch.Replacement)
+	if !ok {
 		return "", fmt.Errorf("%w: pull_request_target trigger line did not change", ErrRepoExposurePatchApplyFailed)
 	}
+
 	return replaceLineWithContent(lines, trailingNewline, targetIndex, patched), nil
+}
+
+func patchWorkflowPullRequestTargetTriggerLine(line string, replacement string) (string, bool) {
+	content, comment, hasComment := splitInlineHashComment(line)
+	if !hasComment {
+		content = line
+	}
+
+	if workflowPullRequestTargetMappingPattern.MatchString(content) {
+		patched := workflowPullRequestTargetMappingPattern.ReplaceAllString(content, "${1}"+replacement+"${2}")
+		return patched + comment, true
+	}
+	if workflowPullRequestTargetSequencePattern.MatchString(content) {
+		patched := workflowPullRequestTargetSequencePattern.ReplaceAllString(content, "${1}"+replacement+"${2}")
+		return patched + comment, true
+	}
+	if workflowPullRequestTargetScalarPattern.MatchString(content) {
+		patched := workflowPullRequestTargetScalarPattern.ReplaceAllString(content, "${1}"+replacement+"${2}")
+		return patched + comment, true
+	}
+	if workflowOnFlowSequencePattern.MatchString(content) && workflowPullRequestTargetTokenPattern.MatchString(content) {
+		patched := workflowPullRequestTargetTokenPattern.ReplaceAllString(content, replacement)
+		return patched + comment, patched != content
+	}
+	if workflowOnFlowMappingPattern.MatchString(content) {
+		if patched, ok := replaceTopLevelWorkflowTriggerKey(content, "pull_request_target", replacement); ok {
+			return patched + comment, true
+		}
+	}
+	return "", false
+}
+
+func replaceTopLevelWorkflowTriggerKey(line string, key string, replacement string) (string, bool) {
+	open := strings.Index(line, "{")
+	if open < 0 {
+		return "", false
+	}
+
+	braceDepth := 0
+	bracketDepth := 0
+	inSingleQuote := false
+	inDoubleQuote := false
+	escaped := false
+	afterDelimiter := false
+
+	for i := open; i < len(line); i++ {
+		ch := line[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if inDoubleQuote && ch == '\\' {
+			escaped = true
+			continue
+		}
+		if ch == '\'' && !inDoubleQuote {
+			inSingleQuote = !inSingleQuote
+			continue
+		}
+		if ch == '"' && !inSingleQuote {
+			inDoubleQuote = !inDoubleQuote
+			continue
+		}
+		if inSingleQuote || inDoubleQuote {
+			continue
+		}
+
+		switch ch {
+		case '{':
+			braceDepth++
+			if braceDepth == 1 {
+				afterDelimiter = true
+			}
+			continue
+		case '}':
+			if braceDepth == 1 {
+				afterDelimiter = false
+			}
+			if braceDepth > 0 {
+				braceDepth--
+			}
+			continue
+		case '[':
+			if braceDepth > 0 {
+				bracketDepth++
+			}
+			continue
+		case ']':
+			if bracketDepth > 0 {
+				bracketDepth--
+			}
+			continue
+		case ',':
+			if braceDepth == 1 && bracketDepth == 0 {
+				afterDelimiter = true
+			}
+			continue
+		}
+
+		if !afterDelimiter || braceDepth != 1 || bracketDepth != 0 {
+			continue
+		}
+		if ch == ' ' || ch == '\t' {
+			continue
+		}
+		if strings.HasPrefix(line[i:], key) {
+			valueStart := i + len(key)
+			valueEnd := valueStart
+			for valueEnd < len(line) && (line[valueEnd] == ' ' || line[valueEnd] == '\t') {
+				valueEnd++
+			}
+			if valueEnd < len(line) && line[valueEnd] == ':' {
+				return line[:i] + replacement + line[valueStart:], true
+			}
+		}
+		afterDelimiter = false
+	}
+
+	return "", false
 }
 
 func workflowPullRequestTargetLineInLocalBlock(lines []string, lineIndex int) (int, bool) {
@@ -261,7 +387,7 @@ func workflowPullRequestTargetLineInLocalBlock(lines []string, lineIndex int) (i
 		if indentationWidth(lines[i]) <= parentIndent {
 			break
 		}
-		if workflowPullRequestTargetTokenPattern.MatchString(lines[i]) {
+		if _, ok := patchWorkflowPullRequestTargetTriggerLine(lines[i], "pull_request"); ok {
 			return i, true
 		}
 	}

--- a/internal/remediation/fixpr/repo_exposure.go
+++ b/internal/remediation/fixpr/repo_exposure.go
@@ -402,18 +402,43 @@ func workflowPullRequestTargetLineInLocalBlock(lines []string, lineIndex int) (i
 		}
 	}
 	parentIndent := indentationWidth(lines[blockStart])
+	childIndent := -1
 	for i := blockStart + 1; i < len(lines); i++ {
-		if strings.TrimSpace(lines[i]) == "" {
+		if strings.TrimSpace(lines[i]) == "" || isCommentOnlyLine(lines[i]) {
 			continue
 		}
-		if indentationWidth(lines[i]) <= parentIndent {
+		indent := indentationWidth(lines[i])
+		if indent <= parentIndent {
 			break
+		}
+		if childIndent == -1 || indent < childIndent {
+			childIndent = indent
+		}
+	}
+	if childIndent == -1 {
+		return -1, false
+	}
+
+	for i := blockStart + 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "" || isCommentOnlyLine(lines[i]) {
+			continue
+		}
+		indent := indentationWidth(lines[i])
+		if indent <= parentIndent {
+			break
+		}
+		if indent != childIndent {
+			continue
 		}
 		if _, ok := patchWorkflowPullRequestTargetTriggerLine(lines[i], "pull_request"); ok {
 			return i, true
 		}
 	}
 	return -1, false
+}
+
+func isCommentOnlyLine(line string) bool {
+	return strings.HasPrefix(strings.TrimSpace(line), "#")
 }
 
 func workflowParentKeyLine(lines []string, lineIndex int, key string) (int, bool) {

--- a/internal/remediation/fixpr/repo_exposure.go
+++ b/internal/remediation/fixpr/repo_exposure.go
@@ -21,6 +21,8 @@ var (
 	workflowPermissionValueWriteAllPattern   = regexp.MustCompile(`^(\s*[^:#]+:\s*)write-all(\s*(?:#.*)?)$`)
 	workflowPermissionFlowWriteAllPattern    = regexp.MustCompile(`(:\s*)write-all(\s*(?:[,}#]|$))`)
 	workflowPullRequestTargetTokenPattern    = regexp.MustCompile(`\bpull_request_target\b`)
+	workflowPullRequestMappingPattern        = regexp.MustCompile(`^(\s*)(?:"pull_request"|'pull_request'|pull_request)(\s*:.*)$`)
+	workflowPullRequestSequencePattern       = regexp.MustCompile(`^(\s*-\s*)(?:"pull_request"|'pull_request'|pull_request)(\s*)$`)
 	workflowPullRequestTargetMappingPattern  = regexp.MustCompile(`^(\s*)(?:"pull_request_target"|'pull_request_target'|pull_request_target)(\s*:.*)$`)
 	workflowPullRequestTargetSequencePattern = regexp.MustCompile(`^(\s*-\s*)(?:"pull_request_target"|'pull_request_target'|pull_request_target)(\s*)$`)
 	workflowPullRequestTargetScalarPattern   = regexp.MustCompile(`^(\s*on\s*:\s*)(?:"pull_request_target"|'pull_request_target'|pull_request_target)(\s*)$`)
@@ -237,6 +239,9 @@ func replaceWorkflowPermissionWriteAllValue(line string) (string, bool) {
 
 func applyWorkflowPullRequestTriggerPatch(lines []string, trailingNewline bool, lineIndex int, patch standards.RepoExposurePatchTemplate) (string, error) {
 	if patched, ok := patchWorkflowPullRequestTargetTriggerLine(lines[lineIndex], patch.Replacement); ok {
+		if deduped, ok := removeWorkflowPullRequestTargetIfReplacementExists(lines, trailingNewline, lineIndex, patch.Replacement); ok {
+			return deduped, nil
+		}
 		return replaceLineWithContent(lines, trailingNewline, lineIndex, patched), nil
 	}
 
@@ -245,6 +250,9 @@ func applyWorkflowPullRequestTriggerPatch(lines []string, trailingNewline bool, 
 		return "", fmt.Errorf("%w: finding line %d is not in a pull_request_target trigger block", ErrRepoExposurePatchApplyFailed, lineIndex+1)
 	}
 
+	if deduped, ok := removeWorkflowPullRequestTargetIfReplacementExists(lines, trailingNewline, targetIndex, patch.Replacement); ok {
+		return deduped, nil
+	}
 	patched, ok := patchWorkflowPullRequestTargetTriggerLine(lines[targetIndex], patch.Replacement)
 	if !ok {
 		return "", fmt.Errorf("%w: pull_request_target trigger line did not change", ErrRepoExposurePatchApplyFailed)
@@ -392,15 +400,82 @@ func workflowTriggerKeyHasColon(value string, index int) bool {
 	return index < len(value) && value[index] == ':'
 }
 
-func workflowPullRequestTargetLineInLocalBlock(lines []string, lineIndex int) (int, bool) {
-	blockStart := lineIndex
-	if !workflowOnKeyPattern.MatchString(lines[blockStart]) {
-		var ok bool
-		blockStart, ok = workflowParentKeyLine(lines, lineIndex, "on")
-		if !ok {
-			return -1, false
+func removeWorkflowPullRequestTargetIfReplacementExists(lines []string, trailingNewline bool, targetIndex int, replacement string) (string, bool) {
+	blockStart, ok := workflowParentKeyLine(lines, targetIndex, "on")
+	if !ok {
+		return "", false
+	}
+	childIndent, ok := workflowDirectChildIndent(lines, blockStart)
+	if !ok || indentationWidth(lines[targetIndex]) != childIndent {
+		return "", false
+	}
+	if !workflowDirectTriggerExists(lines, blockStart, targetIndex, replacement) {
+		return "", false
+	}
+	return removeWorkflowDirectTrigger(lines, trailingNewline, targetIndex), true
+}
+
+func workflowDirectTriggerExists(lines []string, blockStart int, excludeIndex int, trigger string) bool {
+	childIndent, ok := workflowDirectChildIndent(lines, blockStart)
+	if !ok {
+		return false
+	}
+	parentIndent := indentationWidth(lines[blockStart])
+	for i := blockStart + 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "" || isCommentOnlyLine(lines[i]) {
+			continue
+		}
+		indent := indentationWidth(lines[i])
+		if indent <= parentIndent {
+			break
+		}
+		if i == excludeIndex || indent != childIndent {
+			continue
+		}
+		content, _, hasComment := splitInlineHashComment(lines[i])
+		if !hasComment {
+			content = lines[i]
+		}
+		if workflowDirectTriggerLineMatches(content, trigger) {
+			return true
 		}
 	}
+	return false
+}
+
+func workflowDirectTriggerLineMatches(line string, trigger string) bool {
+	switch trigger {
+	case "pull_request":
+		return workflowPullRequestMappingPattern.MatchString(line) || workflowPullRequestSequencePattern.MatchString(line)
+	case "pull_request_target":
+		return workflowPullRequestTargetMappingPattern.MatchString(line) || workflowPullRequestTargetSequencePattern.MatchString(line)
+	default:
+		return false
+	}
+}
+
+func removeWorkflowDirectTrigger(lines []string, trailingNewline bool, targetIndex int) string {
+	targetIndent := indentationWidth(lines[targetIndex])
+	end := targetIndex + 1
+	if workflowPullRequestTargetMappingPattern.MatchString(lines[targetIndex]) {
+		for end < len(lines) {
+			if strings.TrimSpace(lines[end]) == "" || isCommentOnlyLine(lines[end]) {
+				end++
+				continue
+			}
+			if indentationWidth(lines[end]) <= targetIndent {
+				break
+			}
+			end++
+		}
+	}
+	updated := make([]string, 0, len(lines)-(end-targetIndex))
+	updated = append(updated, lines[:targetIndex]...)
+	updated = append(updated, lines[end:]...)
+	return joinLines(updated, trailingNewline)
+}
+
+func workflowDirectChildIndent(lines []string, blockStart int) (int, bool) {
 	parentIndent := indentationWidth(lines[blockStart])
 	childIndent := -1
 	for i := blockStart + 1; i < len(lines); i++ {
@@ -416,9 +491,26 @@ func workflowPullRequestTargetLineInLocalBlock(lines []string, lineIndex int) (i
 		}
 	}
 	if childIndent == -1 {
+		return 0, false
+	}
+	return childIndent, true
+}
+
+func workflowPullRequestTargetLineInLocalBlock(lines []string, lineIndex int) (int, bool) {
+	blockStart := lineIndex
+	if !workflowOnKeyPattern.MatchString(lines[blockStart]) {
+		var ok bool
+		blockStart, ok = workflowParentKeyLine(lines, lineIndex, "on")
+		if !ok {
+			return -1, false
+		}
+	}
+	childIndent, ok := workflowDirectChildIndent(lines, blockStart)
+	if !ok {
 		return -1, false
 	}
 
+	parentIndent := indentationWidth(lines[blockStart])
 	for i := blockStart + 1; i < len(lines); i++ {
 		if strings.TrimSpace(lines[i]) == "" || isCommentOnlyLine(lines[i]) {
 			continue

--- a/internal/remediation/fixpr/repo_exposure_publish.go
+++ b/internal/remediation/fixpr/repo_exposure_publish.go
@@ -1,0 +1,53 @@
+package fixpr
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/findings/standards"
+)
+
+var (
+	ErrRepoExposurePublishApprovalRequired   = errors.New("repo exposure publish requires operator approval")
+	ErrRepoExposurePublishCredentialsMissing = errors.New("repo exposure publish requires explicit write-capable credentials")
+)
+
+// RepoExposurePublishOptions controls the publish boundary for repository
+// exposure remediation PRs. Callers must set both OperatorApproved and
+// WritePermissionsConfigured before any GitHub write is attempted.
+type RepoExposurePublishOptions struct {
+	Owner                      string
+	Repo                       string
+	Token                      string
+	SourceContent              string
+	PlanOptions                PlanOptions
+	OperatorApproved           bool
+	WritePermissionsConfigured bool
+}
+
+// PublishRepoExposureRemediation builds and publishes a repository exposure
+// remediation PR only after the caller confirms operator approval and explicit
+// write-capable credentials. GitHub still validates token scope server-side;
+// this gate prevents read-only scanner installs from entering the write path.
+func (p GitHubPublisher) PublishRepoExposureRemediation(
+	ctx context.Context,
+	finding domain.Finding,
+	opts RepoExposurePublishOptions,
+) (PublishResult, standards.RepoExposureRemediation, error) {
+	if !opts.OperatorApproved {
+		return PublishResult{}, standards.RepoExposureRemediation{}, ErrRepoExposurePublishApprovalRequired
+	}
+	token := strings.TrimSpace(opts.Token)
+	if !opts.WritePermissionsConfigured || token == "" {
+		return PublishResult{}, standards.RepoExposureRemediation{}, ErrRepoExposurePublishCredentialsMissing
+	}
+
+	plan, remediation, err := BuildRepoExposureFixPRPlan(finding, opts.SourceContent, opts.PlanOptions)
+	if err != nil {
+		return PublishResult{}, remediation, err
+	}
+	result, err := p.Publish(ctx, opts.Owner, opts.Repo, token, plan)
+	return result, remediation, err
+}

--- a/internal/remediation/fixpr/repo_exposure_test.go
+++ b/internal/remediation/fixpr/repo_exposure_test.go
@@ -283,6 +283,12 @@ func TestBuildRepoExposureFixPRPlanPatchesPullRequestTargetSyntaxes(t *testing.T
 			want:       "name: ci\non:\n  # pull_request_target legacy path\n  pull_request:\n    branches: [pull_request_target]\n  pull_request:\n    branches: [main]\n",
 		},
 		{
+			name:       "block_mapping_from_parent_line_skips_nested_input_key",
+			lineNumber: 2,
+			source:     "name: ci\non:\n  workflow_dispatch:\n    inputs:\n      pull_request_target:\n        description: target branch\n  pull_request_target:\n    branches: [main]\n",
+			want:       "name: ci\non:\n  workflow_dispatch:\n    inputs:\n      pull_request_target:\n        description: target branch\n  pull_request:\n    branches: [main]\n",
+		},
+		{
 			name:       "block_sequence_from_parent_line_skips_comment",
 			lineNumber: 2,
 			source:     "name: ci\non:\n  # pull_request_target legacy path\n  - pull_request_target\n",
@@ -321,6 +327,17 @@ func TestBuildRepoExposureFixPRPlanPatchesPullRequestTargetSyntaxes(t *testing.T
 				t.Fatalf("unexpected patched content:\nwant:\n%s\ngot:\n%s", tc.want, plan.Files[0].Content)
 			}
 		})
+	}
+}
+
+func TestBuildRepoExposureFixPRPlanRejectsNestedPullRequestTargetFallback(t *testing.T) {
+	finding := repoMisconfigFinding("workflow_pull_request_target")
+	finding.LineNumber = 2
+	source := "name: ci\non:\n  workflow_dispatch:\n    inputs:\n      pull_request_target:\n        description: target branch\n"
+
+	_, _, err := BuildRepoExposureFixPRPlan(finding, source, PlanOptions{})
+	if !errors.Is(err, ErrRepoExposurePatchApplyFailed) {
+		t.Fatalf("expected nested trigger fallback to fail, got %v", err)
 	}
 }
 

--- a/internal/remediation/fixpr/repo_exposure_test.go
+++ b/internal/remediation/fixpr/repo_exposure_test.go
@@ -1,0 +1,312 @@
+package fixpr
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+func repoMisconfigFinding(detector string) domain.Finding {
+	return domain.Finding{
+		ID:           "repo-finding-1",
+		ScanID:       "repo-scan-1",
+		Type:         domain.FindingRepoMisconfig,
+		Severity:     domain.SeverityHigh,
+		Title:        "Repository misconfiguration",
+		HumanSummary: "Repository automation grants too much trust.",
+		Repository:   "owner/repo",
+		Commit:       "abc123",
+		FilePath:     ".github/workflows/ci.yml",
+		LineNumber:   4,
+		Detector:     detector,
+	}
+}
+
+func TestBuildRepoExposureFixPRPlanModifiesOnlyAffectedWorkflowFile(t *testing.T) {
+	finding := repoMisconfigFinding("workflow_write_all_permissions")
+	source := "name: ci\non: push\njobs:\n  permissions: write-all\n  build:\n    runs-on: ubuntu-latest\n"
+
+	plan, remediation, err := BuildRepoExposureFixPRPlan(finding, source, PlanOptions{
+		BaseBranch:   "dev",
+		BranchPrefix: "identrail/remediate",
+		FindingURL:   "https://app.example.com/findings/repo-finding-1",
+	})
+	if err != nil {
+		t.Fatalf("BuildRepoExposureFixPRPlan returned error: %v", err)
+	}
+	if !remediation.Publishable {
+		t.Fatalf("expected publishable remediation, got %+v", remediation)
+	}
+	if plan.BaseBranch != "dev" {
+		t.Fatalf("expected base branch dev, got %s", plan.BaseBranch)
+	}
+	if plan.BranchName != "identrail/remediate/repo-finding-1" {
+		t.Fatalf("unexpected branch name %s", plan.BranchName)
+	}
+	if len(plan.Files) != 1 {
+		t.Fatalf("expected exactly one affected file, got %+v", plan.Files)
+	}
+	if plan.Files[0].Path != ".github/workflows/ci.yml" {
+		t.Fatalf("expected affected workflow path, got %s", plan.Files[0].Path)
+	}
+	if strings.Contains(plan.Files[0].Path, ".identrail/remediations") {
+		t.Fatalf("repo exposure plans must not write advisory files: %+v", plan.Files)
+	}
+	if !strings.Contains(plan.Files[0].Content, "  permissions:\n    contents: read\n") {
+		t.Fatalf("expected indented least-privilege permission replacement, got:\n%s", plan.Files[0].Content)
+	}
+	for _, required := range []string{
+		"Finding ID: `repo-finding-1`",
+		"Scan ID: `repo-scan-1`",
+		"Detector: `workflow_write_all_permissions`",
+		"Validation notes",
+		"Safety notes",
+		"https://app.example.com/findings/repo-finding-1",
+	} {
+		if !strings.Contains(plan.PRBody, required) {
+			t.Fatalf("PR body missing %q:\n%s", required, plan.PRBody)
+		}
+	}
+}
+
+func TestBuildRepoExposureFixPRPlanAppliesRegexPatch(t *testing.T) {
+	finding := repoMisconfigFinding("terraform_public_s3_acl")
+	finding.FilePath = "terraform/main.tf"
+	finding.LineNumber = 2
+	source := "resource \"aws_s3_bucket\" \"public\" {\n  acl = \"public-read-write\"\n}\n"
+
+	plan, _, err := BuildRepoExposureFixPRPlan(finding, source, PlanOptions{})
+	if err != nil {
+		t.Fatalf("BuildRepoExposureFixPRPlan returned error: %v", err)
+	}
+	if !strings.Contains(plan.Files[0].Content, "  acl = \"private\"") {
+		t.Fatalf("expected ACL replacement, got:\n%s", plan.Files[0].Content)
+	}
+	if strings.Contains(plan.Files[0].Content, "public-read") {
+		t.Fatalf("public ACL still present:\n%s", plan.Files[0].Content)
+	}
+}
+
+func TestBuildRepoExposureFixPRPlanPatchesOnlyFindingLineWhenRepeated(t *testing.T) {
+	finding := repoMisconfigFinding("workflow_write_all_permissions")
+	finding.LineNumber = 3
+	source := "permissions: write-all\njobs:\n  permissions: write-all\n"
+
+	plan, _, err := BuildRepoExposureFixPRPlan(finding, source, PlanOptions{})
+	if err != nil {
+		t.Fatalf("BuildRepoExposureFixPRPlan returned error: %v", err)
+	}
+	if !strings.Contains(plan.Files[0].Content, "permissions: write-all\njobs:\n  permissions:\n    contents: read\n") {
+		t.Fatalf("expected only the finding line to be patched, got:\n%s", plan.Files[0].Content)
+	}
+}
+
+func TestBuildRepoExposureFixPRPlanPatchesMappedWriteAllPermissions(t *testing.T) {
+	cases := []struct {
+		name       string
+		lineNumber int
+		source     string
+		want       string
+	}{
+		{
+			name:       "block_mapping",
+			lineNumber: 2,
+			source:     "name: ci\npermissions:\n  contents: write-all\n  issues: read\njobs:\n  test:\n    runs-on: ubuntu-latest\n",
+			want:       "name: ci\npermissions:\n  contents: read\n  issues: read\njobs:\n  test:\n    runs-on: ubuntu-latest\n",
+		},
+		{
+			name:       "block_child_line",
+			lineNumber: 3,
+			source:     "name: ci\npermissions:\n  contents: write-all\n  packages: read\n",
+			want:       "name: ci\npermissions:\n  contents: read\n  packages: read\n",
+		},
+		{
+			name:       "flow_mapping",
+			lineNumber: 2,
+			source:     "name: ci\npermissions: { contents: write-all, issues: read }\n",
+			want:       "name: ci\npermissions: { contents: read, issues: read }\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			finding := repoMisconfigFinding("workflow_write_all_permissions")
+			finding.LineNumber = tc.lineNumber
+
+			plan, _, err := BuildRepoExposureFixPRPlan(finding, tc.source, PlanOptions{})
+			if err != nil {
+				t.Fatalf("BuildRepoExposureFixPRPlan returned error: %v", err)
+			}
+			if plan.Files[0].Content != tc.want {
+				t.Fatalf("unexpected patched content:\nwant:\n%s\ngot:\n%s", tc.want, plan.Files[0].Content)
+			}
+		})
+	}
+}
+
+func TestBuildRepoExposureFixPRPlanDoesNotFallbackWhenFindingLineMismatches(t *testing.T) {
+	finding := repoMisconfigFinding("workflow_write_all_permissions")
+	finding.LineNumber = 3
+	source := "permissions: write-all\njobs:\n  permissions: read-all\n"
+
+	_, _, err := BuildRepoExposureFixPRPlan(finding, source, PlanOptions{})
+	if !errors.Is(err, ErrRepoExposurePatchApplyFailed) {
+		t.Fatalf("expected patch apply failure instead of global fallback, got %v", err)
+	}
+}
+
+func TestBuildRepoExposureFixPRPlanRejectsCaseChangedLiteralMatch(t *testing.T) {
+	finding := repoMisconfigFinding("workflow_write_all_permissions")
+	finding.LineNumber = 1
+	source := "Permissions: write-all\n"
+
+	_, _, err := BuildRepoExposureFixPRPlan(finding, source, PlanOptions{})
+	if !errors.Is(err, ErrRepoExposurePatchApplyFailed) {
+		t.Fatalf("expected case-sensitive literal mismatch to fail, got %v", err)
+	}
+}
+
+func TestBuildRepoExposureFixPRPlanRejectsMissingFindingLine(t *testing.T) {
+	finding := repoMisconfigFinding("workflow_write_all_permissions")
+	finding.LineNumber = 0
+	source := "permissions: write-all\njobs:\n  permissions: write-all\n"
+
+	_, _, err := BuildRepoExposureFixPRPlan(finding, source, PlanOptions{})
+	if !errors.Is(err, ErrRepoExposurePatchApplyFailed) {
+		t.Fatalf("expected missing finding line to fail instead of first-match patching, got %v", err)
+	}
+}
+
+func TestBuildRepoExposureFixPRPlanPatchesPullRequestTargetSyntaxes(t *testing.T) {
+	cases := []struct {
+		name       string
+		lineNumber int
+		source     string
+		want       string
+	}{
+		{
+			name:       "mapping_key",
+			lineNumber: 3,
+			source:     "name: ci\non:\n  pull_request_target:\n    branches: [main]\n",
+			want:       "name: ci\non:\n  pull_request:\n    branches: [main]\n",
+		},
+		{
+			name:       "scalar",
+			lineNumber: 2,
+			source:     "name: ci\non: pull_request_target\n",
+			want:       "name: ci\non: pull_request\n",
+		},
+		{
+			name:       "flow_sequence",
+			lineNumber: 2,
+			source:     "name: ci\non: [push, pull_request_target]\n",
+			want:       "name: ci\non: [push, pull_request]\n",
+		},
+		{
+			name:       "block_sequence_from_parent_line",
+			lineNumber: 2,
+			source:     "name: ci\non:\n  - push\n  - pull_request_target\n",
+			want:       "name: ci\non:\n  - push\n  - pull_request\n",
+		},
+		{
+			name:       "block_sequence_from_first_item_line",
+			lineNumber: 3,
+			source:     "name: ci\non:\n  - push\n  - pull_request_target\n",
+			want:       "name: ci\non:\n  - push\n  - pull_request\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			finding := repoMisconfigFinding("workflow_pull_request_target")
+			finding.LineNumber = tc.lineNumber
+
+			plan, _, err := BuildRepoExposureFixPRPlan(finding, tc.source, PlanOptions{})
+			if err != nil {
+				t.Fatalf("BuildRepoExposureFixPRPlan returned error: %v", err)
+			}
+			if plan.Files[0].Content != tc.want {
+				t.Fatalf("unexpected patched content:\nwant:\n%s\ngot:\n%s", tc.want, plan.Files[0].Content)
+			}
+		})
+	}
+}
+
+func TestBuildRepoExposureFixPRPlanRejectsSecretFindings(t *testing.T) {
+	_, remediation, err := BuildRepoExposureFixPRPlan(domain.Finding{
+		ID:         "secret-1",
+		Type:       domain.FindingSecretExposure,
+		Detector:   "github_token",
+		FilePath:   "app.env",
+		LineNumber: 1,
+	}, "GITHUB_TOKEN=ghp_example\n", PlanOptions{})
+	if !errors.Is(err, ErrRepoExposureRemediationUnsafe) {
+		t.Fatalf("expected unsafe remediation error, got %v", err)
+	}
+	if !remediation.SecretRotation || remediation.Patch != nil {
+		t.Fatalf("expected rotation-only remediation, got %+v", remediation)
+	}
+}
+
+func TestBuildRepoExposureFixPRPlanRejectsPlaceholderPatches(t *testing.T) {
+	finding := repoMisconfigFinding("docker_latest_tag")
+	finding.FilePath = "Dockerfile"
+	finding.LineNumber = 1
+	_, remediation, err := BuildRepoExposureFixPRPlan(finding, "FROM golang:latest\n", PlanOptions{})
+	if !errors.Is(err, ErrRepoExposureRemediationUnsafe) {
+		t.Fatalf("expected unsafe remediation error, got %v", err)
+	}
+	if remediation.Patch == nil || !remediation.Patch.Placeholder {
+		t.Fatalf("expected placeholder remediation patch, got %+v", remediation.Patch)
+	}
+	if remediation.PublishBlockedReason == "" {
+		t.Fatal("expected publish blocked reason")
+	}
+}
+
+func TestBuildRepoExposureFixPRPlanRejectsStaleSourceContent(t *testing.T) {
+	finding := repoMisconfigFinding("k8s_privileged_true")
+	finding.FilePath = "deploy/app.yaml"
+	finding.LineNumber = 3
+	_, _, err := BuildRepoExposureFixPRPlan(finding, "securityContext:\n  allowPrivilegeEscalation: false\n", PlanOptions{})
+	if !errors.Is(err, ErrRepoExposurePatchApplyFailed) {
+		t.Fatalf("expected patch apply failure, got %v", err)
+	}
+}
+
+func TestBuildRepoExposureFixPRPlanRejectsUnsafeTargetPath(t *testing.T) {
+	for _, filePath := range []string{
+		"../outside.yaml",
+		"..",
+		"deploy/../outside.yaml",
+		"deploy/..",
+		"/etc/app.yaml",
+		"/deploy/app.yaml",
+		`..\outside.yaml`,
+		`deploy\..\outside.yaml`,
+		`deploy\..`,
+		`\absolute.yaml`,
+	} {
+		t.Run(filePath, func(t *testing.T) {
+			finding := repoMisconfigFinding("k8s_privileged_true")
+			finding.FilePath = filePath
+			_, _, err := BuildRepoExposureFixPRPlan(finding, "privileged: true\n", PlanOptions{})
+			if !errors.Is(err, ErrRepoExposurePatchApplyFailed) {
+				t.Fatalf("expected path validation failure, got %v", err)
+			}
+		})
+	}
+}
+
+func TestBuildRepoExposureFixPRPlanRejectsUnsafeFallbackPath(t *testing.T) {
+	finding := repoMisconfigFinding("k8s_privileged_true")
+	finding.FilePath = ""
+	finding.Path = []string{"/etc/app.yaml"}
+
+	_, _, err := BuildRepoExposureFixPRPlan(finding, "privileged: true\n", PlanOptions{})
+	if !errors.Is(err, ErrRepoExposurePatchApplyFailed) {
+		t.Fatalf("expected fallback path validation failure, got %v", err)
+	}
+}

--- a/internal/remediation/fixpr/repo_exposure_test.go
+++ b/internal/remediation/fixpr/repo_exposure_test.go
@@ -229,9 +229,27 @@ func TestBuildRepoExposureFixPRPlanPatchesPullRequestTargetSyntaxes(t *testing.T
 			want:       "name: ci\non:\n  pull_request:\n    branches: [main]\n",
 		},
 		{
+			name:       "double_quoted_mapping_key",
+			lineNumber: 3,
+			source:     "name: ci\non:\n  \"pull_request_target\":\n    branches: [main]\n",
+			want:       "name: ci\non:\n  pull_request:\n    branches: [main]\n",
+		},
+		{
+			name:       "single_quoted_mapping_key",
+			lineNumber: 3,
+			source:     "name: ci\non:\n  'pull_request_target':\n    branches: [main]\n",
+			want:       "name: ci\non:\n  pull_request:\n    branches: [main]\n",
+		},
+		{
 			name:       "scalar",
 			lineNumber: 2,
 			source:     "name: ci\non: pull_request_target\n",
+			want:       "name: ci\non: pull_request\n",
+		},
+		{
+			name:       "quoted_scalar",
+			lineNumber: 2,
+			source:     "name: ci\non: \"pull_request_target\"\n",
 			want:       "name: ci\non: pull_request\n",
 		},
 		{
@@ -244,6 +262,12 @@ func TestBuildRepoExposureFixPRPlanPatchesPullRequestTargetSyntaxes(t *testing.T
 			name:       "block_sequence_from_parent_line",
 			lineNumber: 2,
 			source:     "name: ci\non:\n  - push\n  - pull_request_target\n",
+			want:       "name: ci\non:\n  - push\n  - pull_request\n",
+		},
+		{
+			name:       "quoted_block_sequence_from_parent_line",
+			lineNumber: 2,
+			source:     "name: ci\non:\n  - push\n  - \"pull_request_target\"\n",
 			want:       "name: ci\non:\n  - push\n  - pull_request\n",
 		},
 		{
@@ -268,6 +292,18 @@ func TestBuildRepoExposureFixPRPlanPatchesPullRequestTargetSyntaxes(t *testing.T
 			name:       "flow_mapping_only_patches_top_level_trigger_key",
 			lineNumber: 2,
 			source:     "name: ci\non: { pull_request: { branches: [pull_request_target] }, pull_request_target: { branches: [main] } }\n",
+			want:       "name: ci\non: { pull_request: { branches: [pull_request_target] }, pull_request: { branches: [main] } }\n",
+		},
+		{
+			name:       "flow_mapping_patches_double_quoted_top_level_trigger_key",
+			lineNumber: 2,
+			source:     "name: ci\non: { pull_request: { branches: [pull_request_target] }, \"pull_request_target\": { branches: [main] } }\n",
+			want:       "name: ci\non: { pull_request: { branches: [pull_request_target] }, pull_request: { branches: [main] } }\n",
+		},
+		{
+			name:       "flow_mapping_patches_single_quoted_top_level_trigger_key",
+			lineNumber: 2,
+			source:     "name: ci\non: { pull_request: { branches: [pull_request_target] }, 'pull_request_target': { branches: [main] } }\n",
 			want:       "name: ci\non: { pull_request: { branches: [pull_request_target] }, pull_request: { branches: [main] } }\n",
 		},
 	}
@@ -338,9 +374,12 @@ func TestBuildRepoExposureFixPRPlanRejectsUnsafeTargetPath(t *testing.T) {
 		"deploy/..",
 		"/etc/app.yaml",
 		"/deploy/app.yaml",
+		"C:/tmp/app.yaml",
+		"c:/tmp/app.yaml",
 		`..\outside.yaml`,
 		`deploy\..\outside.yaml`,
 		`deploy\..`,
+		`C:\tmp\app.yaml`,
 		`\absolute.yaml`,
 	} {
 		t.Run(filePath, func(t *testing.T) {

--- a/internal/remediation/fixpr/repo_exposure_test.go
+++ b/internal/remediation/fixpr/repo_exposure_test.go
@@ -280,7 +280,25 @@ func TestBuildRepoExposureFixPRPlanPatchesPullRequestTargetSyntaxes(t *testing.T
 			name:       "block_mapping_from_parent_line_skips_comment_and_filter_value",
 			lineNumber: 2,
 			source:     "name: ci\non:\n  # pull_request_target legacy path\n  pull_request:\n    branches: [pull_request_target]\n  pull_request_target:\n    branches: [main]\n",
-			want:       "name: ci\non:\n  # pull_request_target legacy path\n  pull_request:\n    branches: [pull_request_target]\n  pull_request:\n    branches: [main]\n",
+			want:       "name: ci\non:\n  # pull_request_target legacy path\n  pull_request:\n    branches: [pull_request_target]\n",
+		},
+		{
+			name:       "block_mapping_from_target_line_removes_duplicate_replacement_trigger",
+			lineNumber: 5,
+			source:     "name: ci\non:\n  pull_request:\n    branches: [main]\n  pull_request_target:\n    branches: [release]\n",
+			want:       "name: ci\non:\n  pull_request:\n    branches: [main]\n",
+		},
+		{
+			name:       "block_mapping_removes_target_when_replacement_trigger_appears_later",
+			lineNumber: 2,
+			source:     "name: ci\non:\n  pull_request_target:\n    branches: [release]\n  pull_request:\n    branches: [main]\n",
+			want:       "name: ci\non:\n  pull_request:\n    branches: [main]\n",
+		},
+		{
+			name:       "block_sequence_from_parent_line_removes_duplicate_replacement_trigger",
+			lineNumber: 2,
+			source:     "name: ci\non:\n  - pull_request\n  - pull_request_target\n",
+			want:       "name: ci\non:\n  - pull_request\n",
 		},
 		{
 			name:       "block_mapping_from_parent_line_skips_nested_input_key",

--- a/internal/remediation/fixpr/repo_exposure_test.go
+++ b/internal/remediation/fixpr/repo_exposure_test.go
@@ -89,6 +89,42 @@ func TestBuildRepoExposureFixPRPlanAppliesRegexPatch(t *testing.T) {
 	}
 }
 
+func TestBuildRepoExposureFixPRPlanAppliesRegexPatchWithInlineComment(t *testing.T) {
+	finding := repoMisconfigFinding("terraform_public_s3_acl")
+	finding.FilePath = "terraform/main.tf"
+	finding.LineNumber = 2
+	source := "resource \"aws_s3_bucket\" \"public\" {\n  acl = \"public-read\" # temporary exception\n}\n"
+
+	plan, _, err := BuildRepoExposureFixPRPlan(finding, source, PlanOptions{})
+	if err != nil {
+		t.Fatalf("BuildRepoExposureFixPRPlan returned error: %v", err)
+	}
+	if !strings.Contains(plan.Files[0].Content, "  acl = \"private\" # temporary exception") {
+		t.Fatalf("expected ACL replacement to preserve inline comment, got:\n%s", plan.Files[0].Content)
+	}
+	if strings.Contains(plan.Files[0].Content, "public-read") {
+		t.Fatalf("public ACL still present:\n%s", plan.Files[0].Content)
+	}
+}
+
+func TestBuildRepoExposureFixPRPlanAppliesLiteralPatchWithInlineComment(t *testing.T) {
+	finding := repoMisconfigFinding("k8s_privileged_true")
+	finding.FilePath = "deploy/app.yaml"
+	finding.LineNumber = 2
+	source := "securityContext:\n  privileged: true # legacy exception\n"
+
+	plan, _, err := BuildRepoExposureFixPRPlan(finding, source, PlanOptions{})
+	if err != nil {
+		t.Fatalf("BuildRepoExposureFixPRPlan returned error: %v", err)
+	}
+	if !strings.Contains(plan.Files[0].Content, "  privileged: false # legacy exception") {
+		t.Fatalf("expected literal replacement to preserve inline comment, got:\n%s", plan.Files[0].Content)
+	}
+	if strings.Contains(plan.Files[0].Content, "privileged: true") {
+		t.Fatalf("privileged container flag still present:\n%s", plan.Files[0].Content)
+	}
+}
+
 func TestBuildRepoExposureFixPRPlanPatchesOnlyFindingLineWhenRepeated(t *testing.T) {
 	finding := repoMisconfigFinding("workflow_write_all_permissions")
 	finding.LineNumber = 3

--- a/internal/remediation/fixpr/repo_exposure_test.go
+++ b/internal/remediation/fixpr/repo_exposure_test.go
@@ -252,6 +252,24 @@ func TestBuildRepoExposureFixPRPlanPatchesPullRequestTargetSyntaxes(t *testing.T
 			source:     "name: ci\non:\n  - push\n  - pull_request_target\n",
 			want:       "name: ci\non:\n  - push\n  - pull_request\n",
 		},
+		{
+			name:       "block_mapping_from_parent_line_skips_comment_and_filter_value",
+			lineNumber: 2,
+			source:     "name: ci\non:\n  # pull_request_target legacy path\n  pull_request:\n    branches: [pull_request_target]\n  pull_request_target:\n    branches: [main]\n",
+			want:       "name: ci\non:\n  # pull_request_target legacy path\n  pull_request:\n    branches: [pull_request_target]\n  pull_request:\n    branches: [main]\n",
+		},
+		{
+			name:       "block_sequence_from_parent_line_skips_comment",
+			lineNumber: 2,
+			source:     "name: ci\non:\n  # pull_request_target legacy path\n  - pull_request_target\n",
+			want:       "name: ci\non:\n  # pull_request_target legacy path\n  - pull_request\n",
+		},
+		{
+			name:       "flow_mapping_only_patches_top_level_trigger_key",
+			lineNumber: 2,
+			source:     "name: ci\non: { pull_request: { branches: [pull_request_target] }, pull_request_target: { branches: [main] } }\n",
+			want:       "name: ci\non: { pull_request: { branches: [pull_request_target] }, pull_request: { branches: [main] } }\n",
+		},
 	}
 
 	for _, tc := range cases {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -58,6 +58,75 @@ export type RepoScanRequest = {
   max_findings?: number;
 };
 
+export type RepoExposurePatchTemplate = {
+  strategy:
+    | 'line_literal'
+    | 'line_regex'
+    | 'workflow_permissions_read_default'
+    | 'workflow_pull_request_trigger';
+  description: string;
+  match?: string;
+  match_pattern?: string;
+  replacement: string;
+  requires_source_content: boolean;
+  placeholder: boolean;
+};
+
+export type RepoExposureRemediationScope = {
+  finding_id: string;
+  scan_id?: string;
+  repository?: string;
+  commit?: string;
+  file_path?: string;
+  line_number?: number;
+  line_snippet?: string;
+};
+
+export type RepoExposureRemediation = {
+  detector: string;
+  summary: string;
+  risk_summary: string;
+  steps: string[];
+  safety_notes: string[];
+  validation: string[];
+  patch?: RepoExposurePatchTemplate;
+  secret_rotation: boolean;
+  publishable: boolean;
+  publish_blocked_reason?: string;
+  evidence: RepoExposureRemediationScope;
+};
+
+export type FixPRPlanFile = {
+  path: string;
+  content: string;
+};
+
+export type FixPRPlan = {
+  base_branch: string;
+  branch_name: string;
+  commit_message: string;
+  pr_title: string;
+  pr_body: string;
+  files: FixPRPlanFile[];
+  finding_id: string;
+  finding_type: string;
+};
+
+export type RepoFindingRemediationPreviewRequest = {
+  repo_scan_id?: string;
+  source_content?: string;
+  base_branch?: string;
+  branch_prefix?: string;
+  finding_url?: string;
+  require_fix_plan?: boolean;
+};
+
+export type RepoFindingRemediationPreview = {
+  finding: Finding;
+  remediation: RepoExposureRemediation;
+  fix_pr_plan?: FixPRPlan;
+};
+
 export type ScanRecord = {
   id: string;
   provider: string;
@@ -1177,6 +1246,21 @@ export const apiClient = {
     return request<{ items: Finding[] }>(
       `/v1/repo-findings${buildQuery({ sort_by: 'created_at', sort_order: 'desc', ...filters })}`,
       auth
+    );
+  },
+  previewRepoFindingRemediation(
+    findingID: string,
+    payload: RepoFindingRemediationPreviewRequest = {},
+    auth?: RequestAuthContext
+  ) {
+    const query = buildQuery({ repo_scan_id: payload.repo_scan_id });
+    return request<RepoFindingRemediationPreview>(
+      `/v1/repo-findings/${encodeURIComponent(findingID)}/remediation/preview${query}`,
+      auth,
+      {
+        method: 'POST',
+        body: JSON.stringify(payload)
+      }
     );
   },
   getFinding(findingID: string, scanID?: string, auth?: RequestAuthContext) {


### PR DESCRIPTION
Fixes #1235

## Summary
- Add detector-specific repository exposure remediation guidance for GitHub Actions, Docker, Terraform, and Kubernetes findings.
- Add safe fix-PR plan generation that only patches the affected repository file and keeps secret findings rotation-only.
- Add a repository finding remediation preview API, OpenAPI contract, web client method, authz route policy, docs, changelog, and regression tests.
- Gate repo-exposure PR publication behind explicit operator approval and write-capable credentials.

## Why
Repo exposure findings already identify risky repository paths, but operators still had to translate every finding into a safe patch by hand. This gives Identrail a preview-first remediation workflow: deterministic misconfiguration fixes can produce reviewable PR plans, while secrets stay out of generated branches, commits, PR bodies, and logs.

## Impact and risk
- Preview mode is read-authorized and does not publish branches.
- Generated plans modify only the detected file and include finding ID, scan ID, detector, risk summary, validation notes, and safety notes.
- Secret exposure findings return rotation and revocation guidance only, with snippet evidence scrubbed from the preview response.
- Publish mode remains disabled unless callers provide operator approval, a configured write path, and a GitHub token that GitHub accepts server-side.

## Validation
- `go test ./internal/findings/standards ./internal/remediation/fixpr ./internal/api`
- `go test ./...`
- `go vet ./...`
- `go test ./... -coverprofile=coverage.out && go tool cover -func=coverage.out | tail -n 1` -> `total: 80.3%`
- `./scripts/check_api_example_contract.sh`
- `npm run test:ci --prefix web`
- `npm run build --prefix web`
- `git diff --cached --check`

## AI-assisted
AI-assisted: No
Tools used: Not applicable
Where used: Not applicable
Human verification performed: reviewed the diff, ran the validation commands above, and confirmed the signed-off commit passed local hooks.
