### PR TITLE
Polish homepage demo entrypoints

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -110,19 +110,19 @@ describe('App', () => {
     expect(scanButtons.length).toBeGreaterThan(0);
     fireEvent.click(scanButtons[0]);
     expect(screen.getByRole('dialog', { name: /Verify company identity/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Book Demo/i })).toBeInTheDocument();
+    expect(screen.queryByText(/Need enterprise procurement/i)).not.toBeInTheDocument();
     expect(screen.getAllByText(/Adoption Paths/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Reachable Risk Paths/i).length).toBeGreaterThan(0);
     expect(
       screen.getByRole('heading', { level: 2, name: /From connector setup to evidence-ready remediation/i })
     ).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /Need enterprise procurement/i })).toHaveAttribute('href', '/enterprise');
+    expect(screen.getByRole('button', { name: /Book Demo/i })).toBeInTheDocument();
     expect(document.querySelector('#risk-scan-form')).not.toBeInTheDocument();
     expect(document.querySelector('.idt-trust-strip + .idt-home-after-stack')).toBeInTheDocument();
     expect(document.querySelector('.idt-home-after-stack .idt-shell')).not.toBeInTheDocument();
   });
 
-  it('opens book demo in a dimmed modal from the header', () => {
+  it('opens book demo in a dimmed modal from the homepage CTA', () => {
     setCurrentPath('/');
     render(<App />);
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1441,7 +1441,42 @@ function BookDemoModal({ onClose }: { onClose: () => void }) {
           <p className="idt-eyebrow">Book Demo</p>
           <h2 id="book-demo-modal-title">Walk through a live trust path</h2>
           <p>Choose a guided walkthrough or send enough context for a prepared review.</p>
-          <DemoBookingVisual />
+          <div className="idt-book-demo-modal-preview" aria-label="Demo walkthrough preview">
+            <div className="idt-book-demo-preview-head">
+              <span>Live agenda</span>
+              <strong>15 minutes</strong>
+            </div>
+            <ol className="idt-book-demo-preview-list">
+              <li>
+                <span>01</span>
+                <div>
+                  <strong>Scope the environment</strong>
+                  <small>AWS account, cluster, or repository</small>
+                </div>
+              </li>
+              <li>
+                <span>02</span>
+                <div>
+                  <strong>Map one reachable path</strong>
+                  <small>Source identity to sensitive target</small>
+                </div>
+              </li>
+              <li>
+                <span>03</span>
+                <div>
+                  <strong>Package the first fix</strong>
+                  <small>Evidence, blast radius, owner handoff</small>
+                </div>
+              </li>
+            </ol>
+            <div className="idt-book-demo-preview-path" aria-hidden="true">
+              <span>OIDC</span>
+              <i />
+              <span>AWS</span>
+              <i />
+              <span>RDS</span>
+            </div>
+          </div>
         </aside>
         <div className="idt-book-demo-modal-body">
           <LeadCaptureForm
@@ -2176,7 +2211,7 @@ function FaqPage() {
   );
 }
 
-function HomePage() {
+function HomePage({ onRequestDemo }: { onRequestDemo?: () => void }) {
   const seo: SeoConfig = {
     title: 'Machine Identity Trust Graph | AWS IAM, Kubernetes, OIDC | Identrail',
     description:
@@ -2278,9 +2313,15 @@ function HomePage() {
             body="Start with a read-only scan, review evidence, then decide whether to self-host, use hosted SaaS, or move to enterprise deployment."
           />
           <div className="idt-inline-actions">
-            <Link to="/enterprise" className="idt-btn idt-btn-primary">
-              Need enterprise procurement? Contact Sales
-            </Link>
+            {onRequestDemo ? (
+              <button type="button" className="idt-btn idt-btn-primary idt-home-demo-cta" onClick={onRequestDemo}>
+                Book Demo
+              </button>
+            ) : (
+              <Link to="/demo" className="idt-btn idt-btn-primary idt-home-demo-cta">
+                Book Demo
+              </Link>
+            )}
           </div>
         </section>
       </div>
@@ -4618,11 +4659,7 @@ export function RoutedSite() {
       </a>
 
       {!isProductShellRoute && !isOnboardingRoute && !isAuthChoiceRoute ? (
-        <Header
-          navLinks={NAV_LINKS}
-          githubRepo={GITHUB_REPO}
-          onRequestDemo={openBookDemoModal}
-        />
+        <Header navLinks={NAV_LINKS} githubRepo={GITHUB_REPO} />
       ) : null}
 
       <main id="main-content">
@@ -4732,7 +4769,7 @@ export function RoutedSite() {
             <Route path="findings" element={<ProductFindingsPage />} />
             <Route path="settings" element={<ProductSettingsPage />} />
           </Route>
-          <Route path="/" element={<HomePage />} />
+          <Route path="/" element={<HomePage onRequestDemo={openBookDemoModal} />} />
           <Route path="/product" element={<ProductPage />} />
           <Route path="/features" element={<FeaturesPage />} />
           <Route path="/integrations" element={<IntegrationsPage />} />

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -8,12 +8,10 @@ type NavLinkItem = {
 };
 
 export function Header({
-  navLinks,
-  onRequestDemo
+  navLinks
 }: {
   navLinks: readonly NavLinkItem[];
   githubRepo: string;
-  onRequestDemo?: () => void;
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const location = useLocation();
@@ -83,22 +81,6 @@ export function Header({
               S
             </span>
           </Link>
-          {onRequestDemo ? (
-            <button
-              type="button"
-              className="idt-header-demo"
-              onClick={() => {
-                setMenuOpen(false);
-                onRequestDemo();
-              }}
-            >
-              Book Demo
-            </button>
-          ) : (
-            <Link to={siteLinks.requestDemo} className="idt-header-demo">
-              Book Demo
-            </Link>
-          )}
         </div>
       </div>
     </header>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -16001,8 +16001,9 @@ html[data-theme='light'] .idt-home-after-stack .idt-tour-step.is-active {
 
 .idt-home-after-stack .idt-tour-step.is-active,
 html[data-theme='light'] .idt-home-after-stack .idt-tour-step.is-active {
-  background: #ffffff;
-  color: #000000;
+  background: #090909;
+  color: #ffffff;
+  box-shadow: inset 4px 0 0 #ffffff;
 }
 
 .idt-home-after-stack .idt-tour-step-index,
@@ -16015,8 +16016,8 @@ html[data-theme='light'] .idt-home-after-stack .idt-tour-step > span {
 
 .idt-home-after-stack .idt-tour-step.is-active .idt-tour-step-index,
 html[data-theme='light'] .idt-home-after-stack .idt-tour-step.is-active .idt-tour-step-index {
-  background: #000000;
-  color: #ffffff;
+  background: #ffffff;
+  color: #000000;
 }
 
 .idt-home-after-stack .idt-tour-step h3,
@@ -16026,7 +16027,7 @@ html[data-theme='light'] .idt-home-after-stack .idt-tour-step h3 {
 
 .idt-home-after-stack .idt-tour-step.is-active h3,
 html[data-theme='light'] .idt-home-after-stack .idt-tour-step.is-active h3 {
-  color: #000000;
+  color: #ffffff;
 }
 
 .idt-home-after-stack .idt-tour-step small,
@@ -16038,7 +16039,7 @@ html[data-theme='light'] .idt-home-after-stack .idt-tour-step p {
 .idt-home-after-stack .idt-tour-step.is-active small,
 .idt-home-after-stack .idt-tour-step.is-active p,
 html[data-theme='light'] .idt-home-after-stack .idt-tour-step.is-active p {
-  color: #52525b;
+  color: #a1a1aa;
 }
 
 .idt-home-after-stack .idt-tour-screen,
@@ -20580,27 +20581,6 @@ html[data-theme='light'] .idt-app-console-layout .idt-source-meta div {
   text-transform: uppercase;
 }
 
-.idt-brand span::before,
-.idt-brand span::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  height: 2px;
-  border-radius: 999px;
-  background: currentColor;
-  pointer-events: none;
-}
-
-.idt-brand span::before {
-  top: -0.2rem;
-  width: 68%;
-}
-
-.idt-brand span::after {
-  right: 18%;
-  bottom: -0.18rem;
-}
-
 .idt-header-actions {
   flex-wrap: nowrap;
 }
@@ -20625,6 +20605,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-source-meta div {
 
 .idt-header-keycap {
   flex: 0 0 auto;
+  pointer-events: none;
 }
 
 @media (max-width: 880px) {
@@ -20905,8 +20886,8 @@ html[data-theme='light'] .idt-demo-choice-band {
 
 .idt-modal.idt-book-demo-modal,
 html[data-theme='light'] .idt-modal.idt-book-demo-modal {
-  width: min(96vw, 1120px);
-  max-height: min(90vh, 860px);
+  width: min(96vw, 1340px);
+  max-height: min(92vh, 900px);
   overflow: hidden;
   border-color: #2d2d30;
   border-radius: 8px;
@@ -20918,26 +20899,33 @@ html[data-theme='light'] .idt-modal.idt-book-demo-modal {
 
 .idt-book-demo-modal-shell {
   display: grid;
-  grid-template-columns: minmax(280px, 0.86fr) minmax(360px, 1fr);
-  max-height: min(90vh, 860px);
+  grid-template-columns: minmax(420px, 0.95fr) minmax(500px, 1.05fr);
+  height: min(82vh, 760px);
+  min-height: 0;
+  max-height: min(92vh, 900px);
 }
 
 .idt-book-demo-modal-visual,
 html[data-theme='light'] .idt-book-demo-modal-visual {
   min-width: 0;
-  overflow: auto;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto auto auto 1fr;
+  align-content: start;
+  gap: clamp(1.1rem, 2.2vw, 1.8rem);
+  overflow: hidden;
   border-right: 1px solid #242427;
   background: #070707;
-  padding: clamp(1.1rem, 2.2vw, 1.5rem);
+  padding: clamp(1.5rem, 3vw, 2.5rem);
 }
 
 .idt-book-demo-modal-visual h2,
 html[data-theme='light'] .idt-book-demo-modal-visual h2 {
-  max-width: 11ch;
+  max-width: 13ch;
   margin: 0;
   color: #ffffff;
   font-family: 'Barlow Semi Condensed', 'Arial Narrow', Arial, sans-serif;
-  font-size: clamp(2.4rem, 5.2vw, 4.8rem);
+  font-size: clamp(2.7rem, 4.5vw, 4.9rem);
   line-height: 0.92;
   text-transform: uppercase;
 }
@@ -20951,37 +20939,139 @@ html[data-theme='light'] .idt-book-demo-modal-visual > p:not(.idt-eyebrow) {
   line-height: 1.55;
 }
 
-.idt-book-demo-modal .idt-demo-booking-visual {
-  min-height: 360px;
-  margin-top: 1rem;
-  box-shadow: none;
+.idt-book-demo-modal-preview,
+html[data-theme='light'] .idt-book-demo-modal-preview {
+  display: grid;
+  align-self: end;
+  gap: 1rem;
+  min-height: 330px;
+  border: 1px solid #262626;
+  border-radius: 8px;
+  background:
+    linear-gradient(#151515 1px, transparent 1px),
+    linear-gradient(90deg, #151515 1px, transparent 1px),
+    radial-gradient(circle at 62% 42%, rgba(255, 255, 255, 0.1), transparent 34%),
+    #070707;
+  background-size:
+    64px 64px,
+    64px 64px,
+    auto,
+    auto;
+  padding: clamp(1rem, 2vw, 1.35rem);
 }
 
-.idt-book-demo-modal .idt-demo-booking-orbit {
-  inset: 1.1rem;
+.idt-book-demo-preview-head,
+html[data-theme='light'] .idt-book-demo-preview-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  color: #ffffff;
 }
 
-.idt-book-demo-modal .idt-demo-booking-card {
-  width: min(300px, calc(100% - 2rem));
+.idt-book-demo-preview-head span,
+html[data-theme='light'] .idt-book-demo-preview-head span {
+  color: #a1a1aa;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
 }
 
-.idt-book-demo-modal .idt-demo-booking-card strong {
-  font-size: clamp(1.8rem, 3vw, 2.8rem);
+.idt-book-demo-preview-head strong,
+html[data-theme='light'] .idt-book-demo-preview-head strong {
+  font-family: 'Barlow Semi Condensed', 'Arial Narrow', Arial, sans-serif;
+  font-size: clamp(1.9rem, 4vw, 3rem);
+  line-height: 0.95;
+  text-transform: uppercase;
 }
 
-.idt-book-demo-modal .idt-demo-booking-agenda {
-  width: min(250px, calc(100% - 2rem));
+.idt-book-demo-preview-list,
+html[data-theme='light'] .idt-book-demo-preview-list {
+  display: grid;
+  gap: 0.72rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.idt-book-demo-preview-list li,
+html[data-theme='light'] .idt-book-demo-preview-list li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.82rem;
+  align-items: start;
+  border: 1px solid #242424;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.035);
+  padding: 0.88rem;
+}
+
+.idt-book-demo-preview-list li > span,
+html[data-theme='light'] .idt-book-demo-preview-list li > span {
+  display: inline-grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #000000;
+  font-size: 0.72rem;
+  font-weight: 900;
+}
+
+.idt-book-demo-preview-list strong,
+html[data-theme='light'] .idt-book-demo-preview-list strong {
+  display: block;
+  color: #ffffff;
+  font-weight: 850;
+}
+
+.idt-book-demo-preview-list small,
+html[data-theme='light'] .idt-book-demo-preview-list small {
+  display: block;
+  margin-top: 0.18rem;
+  color: #a1a1aa;
+  line-height: 1.45;
+}
+
+.idt-book-demo-preview-path,
+html[data-theme='light'] .idt-book-demo-preview-path {
+  display: grid;
+  grid-template-columns: auto 1fr auto 1fr auto;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.idt-book-demo-preview-path span,
+html[data-theme='light'] .idt-book-demo-preview-path span {
+  display: inline-grid;
+  place-items: center;
+  min-width: 3.4rem;
+  min-height: 3.4rem;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #000000;
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+
+.idt-book-demo-preview-path i,
+html[data-theme='light'] .idt-book-demo-preview-path i {
+  height: 1px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.22), #ffffff);
 }
 
 .idt-book-demo-modal-body,
 html[data-theme='light'] .idt-book-demo-modal-body {
   min-width: 0;
+  min-height: 0;
   display: grid;
-  align-content: start;
-  gap: 1rem;
+  align-content: center;
+  gap: 1.1rem;
   overflow: auto;
   background: #050505;
-  padding: clamp(1.1rem, 2.2vw, 1.5rem);
+  padding: clamp(1.5rem, 3vw, 2.5rem);
 }
 
 .idt-book-demo-modal-body .idt-lead-form,
@@ -21022,6 +21112,7 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 
   .idt-book-demo-modal-shell {
     grid-template-columns: 1fr;
+    min-height: 0;
     max-height: none;
   }
 
@@ -21055,7 +21146,14 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
     grid-template-columns: 1fr;
   }
 
-  .idt-book-demo-modal .idt-demo-booking-visual {
+  .idt-book-demo-preview-path,
+  html[data-theme='light'] .idt-book-demo-preview-path {
+    grid-template-columns: repeat(3, auto);
+    justify-content: start;
+  }
+
+  .idt-book-demo-preview-path i,
+  html[data-theme='light'] .idt-book-demo-preview-path i {
     display: none;
   }
 }


### PR DESCRIPTION
No issue: follow-up visual polish requested after the merged homepage/navigation update.

## Summary

- Remove the header Book Demo action so Log in and Sign up have cleaner space.
- Make the Log in and Sign up keycaps click through to their parent links.
- Replace the lower enterprise-procurement CTA with a Book Demo button that opens the dimmed demo modal.
- Rebuild the Book Demo modal preview into a larger, cleaner walkthrough panel.
- Remove the decorative wordmark lines and make product tour step 01 dark like the other steps.

## Why

The previous header and demo surfaces still had a few rough edges: the keycap hit areas could miss navigation, the demo modal felt cramped, the lower CTA did not match the desired action, and the product tour first step looked noisy beside the rest of the dark sequence.

## Impact and Risk

This is a focused website UI polish change. It does not change backend behavior or public API contracts. Risk is limited to header navigation, homepage CTA behavior, and modal/product-tour styling.

## Validation

- `git diff --check`
- `VITE_IDENTRAIL_API_URL=http://localhost:8080 ./node_modules/.bin/vitest run src/App.test.tsx` - 47 passed
- `VITE_IDENTRAIL_API_URL=http://localhost:8080 npm run build` - passed, prerendered 41 routes
- Browser preview on `http://127.0.0.1:4188/`:
  - verified L keycap navigates to `/signin`
  - verified S keycap navigates to `/signup`
  - verified header Book Demo is removed
  - verified lower Book Demo opens a dimmed modal without shell overflow
  - verified product tour step 01 uses the dark active treatment

## Checklist

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed
- [x] Tests added/updated for behavior changes
- [ ] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: yes
- Tools used: Codex
- Areas where used: frontend markup, styling, and test updates
- Human verification performed: reviewed diff, ran tests/build, and performed browser preview checks

## Related Issues

No issue: follow-up visual polish requested after the merged homepage/navigation update.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the homepage demo flow for clearer CTAs and a roomier walkthrough modal. Cleaned up the header and improved keycap interactions.

- New Features
  - Removed header “Book Demo”; replaced the lower enterprise CTA with a homepage “Book Demo” button that opens a dimmed modal (with /demo fallback).
  - Expanded demo modal with a larger preview panel: agenda time, 3-step list, and OIDC → AWS → RDS path.
  - Made Log in (L) and Sign up (S) keycaps click-through to their parent links.
  - Updated product tour: step 01 uses the dark active style; removed decorative wordmark lines.

<sup>Written for commit 7d46320824dc8d6a7c232d0dd2b40789432c6cdb. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1266?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

