### PR TITLE
Authorize repo scan cancellation route

### DIFF
--- a/internal/api/authz_middleware_test.go
+++ b/internal/api/authz_middleware_test.go
@@ -257,6 +257,13 @@ func TestRequireCentralPolicyMiddlewareRepoScanRoleMatrix(t *testing.T) {
 			if runW.Code != tc.runStatus {
 				t.Fatalf("expected repo scan run status %d for role %q, got %d", tc.runStatus, tc.role, runW.Code)
 			}
+
+			cancelReq := httptest.NewRequest(http.MethodPost, "/v1/repo-scans/11111111-1111-1111-1111-111111111111/cancel", nil)
+			cancelW := httptest.NewRecorder()
+			r.ServeHTTP(cancelW, cancelReq)
+			if cancelW.Code != tc.runStatus {
+				t.Fatalf("expected repo scan cancel status %d for role %q, got %d", tc.runStatus, tc.role, cancelW.Code)
+			}
 		})
 	}
 }
@@ -1084,6 +1091,9 @@ func newPolicyTenancyRoleRouter(role string) *gin.Engine {
 		c.Status(http.StatusNoContent)
 	})
 	r.POST("/v1/repo-scans", func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+	r.POST("/v1/repo-scans/:repo_scan_id/cancel", func(c *gin.Context) {
 		c.Status(http.StatusNoContent)
 	})
 	return r

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -662,6 +662,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/repo-finding-clusters", Action: policyActionRepoScansRead, ResourceType: "repo_finding_cluster"},
 		{Method: http.MethodGet, Path: "/v1/repo-risk-graph", Action: policyActionRepoScansRead, ResourceType: "repo_risk_graph"},
 		{Method: http.MethodPost, Path: "/v1/repo-scans", Action: policyActionRepoScansRun, ResourceType: "repo_scan"},
+		{Method: http.MethodPost, Path: "/v1/repo-scans/:repo_scan_id/cancel", Action: policyActionRepoScansRun, ResourceType: "repo_scan", ResourceIDParam: "repo_scan_id"},
 		{Method: http.MethodPost, Path: "/v1/authz/policies/simulate", Action: policyActionAuthzSimulate, ResourceType: "authz_policy"},
 		{Method: http.MethodPost, Path: "/v1/authz/policies/rollback", Action: policyActionAuthzRollback, ResourceType: "authz_policy"},
 		{Method: http.MethodGet, Path: "/v1/me", Action: policyActionMeRead, ResourceType: "user"},

--- a/internal/api/authz_policy_bundle_runtime_test.go
+++ b/internal/api/authz_policy_bundle_runtime_test.go
@@ -99,6 +99,26 @@ func TestDefaultRoutePolicyBundleUsesRepoScansReadForRepoFindingsTrends(t *testi
 	}
 }
 
+func TestDefaultRoutePolicyBundleUsesRepoScansRunForCancel(t *testing.T) {
+	compiled, err := compileRouteAuthorizationPolicyBundle(defaultBuiltInRouteAuthorizationPolicyBundle())
+	if err != nil {
+		t.Fatalf("compile built-in policy bundle: %v", err)
+	}
+	policy, exists := compiled.RouteRegistry.lookup("POST", "/v1/repo-scans/:repo_scan_id/cancel")
+	if !exists {
+		t.Fatal("expected built-in authz policy for POST /v1/repo-scans/:repo_scan_id/cancel")
+	}
+	if policy.Action != policyActionRepoScansRun {
+		t.Fatalf("expected action %q, got %q", policyActionRepoScansRun, policy.Action)
+	}
+	if policy.ResourceType != "repo_scan" {
+		t.Fatalf("expected resource type %q, got %q", "repo_scan", policy.ResourceType)
+	}
+	if policy.ResourceIDParam != "repo_scan_id" {
+		t.Fatalf("expected resource id param %q, got %q", "repo_scan_id", policy.ResourceIDParam)
+	}
+}
+
 func TestCentralPolicyRuntimeResolverFallsBackWhenNoActiveRollout(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := testAuthzPolicyScopeContext()

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -502,6 +502,9 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 		v1.POST("/repo-scans", func(c *gin.Context) {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "repo scan service unavailable"})
 		})
+		v1.POST("/repo-scans/:repo_scan_id/cancel", func(c *gin.Context) {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "repo scan service unavailable"})
+		})
 		return r
 	}
 


### PR DESCRIPTION
Fixes #1267

## Summary
- add `POST /v1/repo-scans/:repo_scan_id/cancel` to the built-in central authz route policy bundle
- keep the service-unavailable router in route parity for repo scan cancellation
- add regression coverage for the cancel route policy and repo scan role matrix

## Why
PR #1264 added scan cancellation, but central authz denied the route before the handler when the route policy registry did not include the cancel path. This follow-up makes cancellation available to the same owner/admin roles that can run repository scans while preserving analyst/viewer denials.

## Impact and risk
Low-risk API authorization fix. It does not change scan execution semantics; it only maps the existing cancel endpoint into the central policy registry and adds route coverage to prevent the same class of miss.

## Validation
- `go test ./internal/api -run 'Test(DefaultRoutePolicyBundleUsesRepoScansRunForCancel|RequireCentralPolicyMiddlewareRepoScanRoleMatrix|RoutePolicyRegistryCoversAllV1Routes|OpenAPIV1SpecDocumentsRouteAuthorizationMetadata)'`\n- `go test ./internal/api`\n- `go test ./...`\n- `git diff --check`\n- push hooks: merge-conflict check, gofmt check, go vet, local env token hygiene, Vercel artifact hygiene\n\nAI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authorize repo scan cancellation by adding the cancel route to the central authz policy so allowed roles can reach the handler. Matches run permissions (owner/admin) and continues to deny analyst/viewer.

- **Bug Fixes**
  - Map POST /v1/repo-scans/:repo_scan_id/cancel to policyActionRepoScansRun with resource id param repo_scan_id.
  - Add service-unavailable stub for the cancel route to keep router parity.
  - Add regression tests for route policy, registry coverage, and the repo scan role matrix.

<sup>Written for commit 10de78b39592b05522116ce90b95625e461bf462. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1268?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

