### PR TITLE
Fix demo shortcuts and visual polish

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -133,6 +133,18 @@ describe('App', () => {
     expect(screen.getByRole('link', { name: /Open Full Demo Page/i })).toHaveAttribute('href', '/demo');
   });
 
+  it.each([
+    ['l', '/signin'],
+    ['S', '/signup']
+  ])('routes the %s header keyboard shortcut to %s', async (key, expectedPath) => {
+    setCurrentPath('/');
+    render(<App />);
+
+    fireEvent.keyDown(document, { key });
+
+    await waitFor(() => expect(window.location.pathname).toBe(expectedPath));
+  });
+
   it('closes the book demo modal when the route changes', async () => {
     setCurrentPath('/');
     render(<App />);

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -145,6 +145,23 @@ describe('App', () => {
     await waitFor(() => expect(window.location.pathname).toBe(expectedPath));
   });
 
+  it.each([
+    ['nested textbox role', <span role="textbox"><span data-testid="editable-shortcut-target">sale note</span></span>],
+    ['plaintext contenteditable', <span contentEditable="plaintext-only"><span data-testid="editable-shortcut-target">login note</span></span>]
+  ])('keeps header shortcuts inactive inside %s editors', async (_name, editor) => {
+    setCurrentPath('/');
+    render(
+      <>
+        <App />
+        {editor}
+      </>
+    );
+
+    fireEvent.keyDown(screen.getByTestId('editable-shortcut-target'), { key: 's' });
+
+    expect(window.location.pathname).toBe('/');
+  });
+
   it('closes the book demo modal when the route changes', async () => {
     setCurrentPath('/');
     render(<App />);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1156,20 +1156,6 @@ function EnterpriseHeroVisual() {
 function DemoBookingVisual() {
   return (
     <div className="idt-demo-booking-visual" aria-hidden="true">
-      <div className="idt-demo-booking-orbit">
-        <span className="is-source">OIDC</span>
-        <span className="is-workload">K8s</span>
-        <span className="is-target">RDS</span>
-        <svg viewBox="0 0 420 260" focusable="false">
-          <path d="M86 64 C158 42 230 61 305 116" />
-          <path d="M122 206 C177 178 237 157 316 136" />
-        </svg>
-      </div>
-      <div className="idt-demo-booking-card">
-        <span>Guided walkthrough</span>
-        <strong>15 minute trust path review</strong>
-        <p>Bring one AWS account, namespace, or repository. Leave with the first path, blast radius, and owner-ready next step.</p>
-      </div>
       <div className="idt-demo-booking-agenda">
         <span>Live agenda</span>
         <ol>
@@ -1177,6 +1163,25 @@ function DemoBookingVisual() {
           <li>Map a reachable high-risk path</li>
           <li>Package the safest first fix</li>
         </ol>
+      </div>
+      <div className="idt-demo-booking-orbit" aria-label="Trust path preview">
+        <svg viewBox="0 0 420 260" focusable="false">
+          <defs>
+            <marker id="idt-demo-booking-arrow" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="8" markerHeight="8" orient="auto">
+              <path d="M1 1 L11 6 L1 11 Z" />
+            </marker>
+          </defs>
+          <path d="M78 74 C145 54 202 74 252 120" />
+          <path d="M252 120 C300 164 316 199 356 211" />
+        </svg>
+        <span className="is-source">OIDC</span>
+        <span className="is-workload">K8s</span>
+        <span className="is-target">RDS</span>
+      </div>
+      <div className="idt-demo-booking-card">
+        <span>Guided walkthrough</span>
+        <strong>15 minute trust path review</strong>
+        <p>Bring one AWS account, namespace, or repository. Leave with the first path, blast radius, and owner-ready next step.</p>
       </div>
     </div>
   );

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link, NavLink, useLocation } from 'react-router-dom';
+import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom';
 import { siteLinks } from '../../siteConfig';
 
 type NavLinkItem = {
@@ -15,6 +15,7 @@ export function Header({
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const location = useLocation();
+  const navigate = useNavigate();
 
   useEffect(() => {
     setMenuOpen(false);
@@ -34,6 +35,34 @@ export function Header({
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [menuOpen]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey || event.repeat) {
+        return;
+      }
+
+      const target = event.target;
+      if (
+        target instanceof HTMLElement &&
+        (target.closest('input, textarea, select, [contenteditable="true"]') || target.getAttribute('role') === 'textbox')
+      ) {
+        return;
+      }
+
+      const key = event.key.toLowerCase();
+      if (key !== 'l' && key !== 's') {
+        return;
+      }
+
+      event.preventDefault();
+      setMenuOpen(false);
+      navigate(key === 'l' ? siteLinks.signIn : '/signup');
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [navigate]);
 
   return (
     <header className="idt-header">

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -7,6 +7,23 @@ type NavLinkItem = {
   label: string;
 };
 
+function isEditableShortcutTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  if (target.closest('input, textarea, select')) {
+    return true;
+  }
+
+  const editableHost = target.closest('[contenteditable]');
+  if (editableHost instanceof HTMLElement && editableHost.contentEditable !== 'false') {
+    return true;
+  }
+
+  return Boolean(target.closest('[role="textbox"], [role="searchbox"], [role="combobox"], [role="spinbutton"]'));
+}
+
 export function Header({
   navLinks
 }: {
@@ -43,10 +60,7 @@ export function Header({
       }
 
       const target = event.target;
-      if (
-        target instanceof HTMLElement &&
-        (target.closest('input, textarea, select, [contenteditable="true"]') || target.getAttribute('role') === 'textbox')
-      ) {
+      if (isEditableShortcutTarget(target)) {
         return;
       }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -16003,7 +16003,7 @@ html[data-theme='light'] .idt-home-after-stack .idt-tour-step.is-active {
 html[data-theme='light'] .idt-home-after-stack .idt-tour-step.is-active {
   background: #090909;
   color: #ffffff;
-  box-shadow: inset 4px 0 0 #ffffff;
+  box-shadow: inset 0 0 0 1px #1f1f1f;
 }
 
 .idt-home-after-stack .idt-tour-step-index,
@@ -20637,40 +20637,56 @@ html[data-theme='light'] .idt-demo-page .idt-page-hero-copy > p {
 
 .idt-demo-booking-visual {
   position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(250px, 0.45fr);
+  grid-template-rows: auto minmax(300px, 1fr);
+  gap: 1px;
   min-height: 520px;
   border: 1px solid #242424;
   border-radius: 8px;
   overflow: hidden;
+  background: #242424;
+  box-shadow: 0 34px 90px rgba(0, 0, 0, 0.38);
+}
+
+.idt-demo-booking-orbit {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  grid-column: 1;
+  grid-row: 2;
+  overflow: hidden;
   background:
     linear-gradient(rgba(255, 255, 255, 0.045) 1px, transparent 1px),
     linear-gradient(90deg, rgba(255, 255, 255, 0.045) 1px, transparent 1px),
-    radial-gradient(circle at 52% 47%, rgba(255, 255, 255, 0.12), transparent 32%),
+    radial-gradient(circle at 50% 52%, rgba(255, 255, 255, 0.14), transparent 32%),
     #050505;
   background-size:
     54px 54px,
     54px 54px,
     auto,
     auto;
-  box-shadow: 0 34px 90px rgba(0, 0, 0, 0.38);
-}
-
-.idt-demo-booking-orbit {
-  position: absolute;
-  inset: 2rem;
 }
 
 .idt-demo-booking-orbit svg {
   position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
+  inset: 5%;
+  width: auto;
+  height: auto;
 }
 
 .idt-demo-booking-orbit path {
   fill: none;
   stroke: rgba(255, 255, 255, 0.68);
-  stroke-width: 2.2;
-  stroke-dasharray: 8 10;
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-dasharray: 9 11;
+  marker-end: url(#idt-demo-booking-arrow);
+}
+
+.idt-demo-booking-orbit marker path {
+  fill: #ffffff;
+  stroke: none;
 }
 
 .idt-demo-booking-orbit span {
@@ -20692,18 +20708,18 @@ html[data-theme='light'] .idt-demo-page .idt-page-hero-copy > p {
 }
 
 .idt-demo-booking-orbit .is-source {
-  top: 8%;
-  left: 8%;
+  top: 18%;
+  left: 13%;
 }
 
 .idt-demo-booking-orbit .is-workload {
-  top: 44%;
-  right: 10%;
+  top: 43%;
+  left: 55%;
 }
 
 .idt-demo-booking-orbit .is-target {
-  left: 24%;
-  bottom: 8%;
+  right: 8%;
+  bottom: 11%;
 }
 
 .idt-demo-booking-card,
@@ -20719,10 +20735,14 @@ html[data-theme='light'] .idt-demo-booking-agenda {
 }
 
 .idt-demo-booking-card {
-  right: 1.4rem;
-  bottom: 1.4rem;
-  width: min(360px, calc(100% - 2.8rem));
-  padding: 1.25rem;
+  position: relative;
+  grid-column: 2;
+  grid-row: 2;
+  width: auto;
+  padding: clamp(1.1rem, 2vw, 1.45rem);
+  border: 0;
+  border-radius: 0;
+  background: #080808;
 }
 
 .idt-demo-booking-card span,
@@ -20739,10 +20759,10 @@ html[data-theme='light'] .idt-demo-booking-agenda {
 
 .idt-demo-booking-card strong {
   display: block;
-  max-width: 11ch;
+  max-width: 10ch;
   color: #ffffff;
   font-family: 'Barlow Semi Condensed', 'Arial Narrow', Arial, sans-serif;
-  font-size: clamp(2.2rem, 4vw, 3.6rem);
+  font-size: clamp(2rem, 3vw, 3.15rem);
   line-height: 0.92;
   text-transform: uppercase;
 }
@@ -20756,23 +20776,33 @@ html[data-theme='light'] .idt-demo-booking-card p {
 }
 
 .idt-demo-booking-agenda {
-  top: 1.4rem;
-  left: 1.4rem;
-  width: min(300px, calc(100% - 2.8rem));
-  padding: 1rem;
+  position: relative;
+  grid-column: 1 / -1;
+  grid-row: 1;
+  width: auto;
+  padding: 1rem 1.15rem;
+  border: 0;
+  border-radius: 0;
+  background: #080808;
 }
 
 .idt-demo-booking-agenda ol {
   display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0.55rem;
   margin: 0;
-  padding-left: 1.1rem;
+  padding: 0;
+  list-style: none;
 }
 
 .idt-demo-booking-agenda li {
+  border: 1px solid #242424;
+  border-radius: 8px;
   color: #f4f4f5;
-  font-size: 0.95rem;
+  font-size: 0.86rem;
   font-weight: 750;
+  line-height: 1.35;
+  padding: 0.72rem 0.8rem;
 }
 
 .idt-demo-booking-section,
@@ -21130,11 +21160,31 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 
 @media (max-width: 720px) {
   .idt-demo-booking-visual {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(260px, 1fr) auto;
     min-height: 500px;
   }
 
+  .idt-demo-booking-orbit,
+  .idt-demo-booking-card,
+  .idt-demo-booking-agenda {
+    grid-column: 1;
+  }
+
   .idt-demo-booking-orbit {
-    inset: 1rem;
+    grid-row: 2;
+  }
+
+  .idt-demo-booking-card {
+    grid-row: 3;
+  }
+
+  .idt-demo-booking-agenda {
+    grid-row: 1;
+  }
+
+  .idt-demo-booking-agenda ol {
+    grid-template-columns: 1fr;
   }
 
   .idt-demo-booking-orbit span {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -20726,7 +20726,7 @@ html[data-theme='light'] .idt-demo-page .idt-page-hero-copy > p {
 .idt-demo-booking-agenda,
 html[data-theme='light'] .idt-demo-booking-card,
 html[data-theme='light'] .idt-demo-booking-agenda {
-  position: absolute;
+  position: relative;
   border: 1px solid #2f2f2f;
   border-radius: 8px;
   background: rgba(8, 8, 8, 0.92);


### PR DESCRIPTION
No issue: follow-up polish after the merged homepage demo entrypoint update.

## Summary
- add real L/S keyboard shortcuts for Log in and Sign up while ignoring form inputs
- remove the light active-step edge in the product tour rail
- rebuild the demo-page graphic into a separated agenda, trust-path map, and walkthrough panel so the right-side visual no longer overlaps

## Validation
- `git diff --check`
- `VITE_IDENTRAIL_API_URL=http://localhost:8080 ./node_modules/.bin/vitest run src/App.test.tsx`
- `VITE_IDENTRAIL_API_URL=http://localhost:8080 npm run build`
- browser-verified L -> /signin, S -> /signup, no demo visual overflow, and no graph-node overlap

AI-assisted: yes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds L/S keyboard shortcuts for Log in/Sign up and rebuilds the demo booking visual into a responsive grid so panels stay in flow without overlap. Also softens the tour step highlight.

- **New Features**
  - Header shortcuts: press L to go to `/signin`, S to `/signup`; ignored in inputs, textareas, selects, `contentEditable`, ARIA editors (`textbox`, `searchbox`, `combobox`, `spinbutton`), and when using modifiers or holding the key.
  - Added tests for shortcut routing and for ignoring shortcuts inside editable fields.

- **Bug Fixes**
  - Demo visual now keeps agenda, trust‑path orbit, and walkthrough card in grid flow across breakpoints; fixes overlap/overflow and improves mobile layout.
  - Trust‑path preview uses clearer dashed paths with arrowheads; replaced the light active‑step edge in the tour rail with a subtle border.

<sup>Written for commit d313ef8bdce3a482fcadfbab99bb54e2c724dbda. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1269?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

