### PR TITLE
feat(web): redesign workspace overview for a calmer, premium first-run

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -582,13 +582,12 @@ describe('App', () => {
     fireEvent.change(screen.getByLabelText(/Workspace ID/i), { target: { value: 'workspace-a' } });
     fireEvent.click(screen.getByRole('button', { name: /Continue in dev mode/i }));
 
-    expect(await screen.findByRole('heading', { level: 1, name: /Identrail Workspace/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
     expect(await screen.findByText(/Open risk/i)).toBeInTheDocument();
     expect(await screen.findByText(/Priority findings/i)).toBeInTheDocument();
-    expect(await screen.findByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
     expect(await screen.findByText(/Production GitHub/i)).toBeInTheDocument();
     expect(await screen.findByText(/1 archived/i)).toBeInTheDocument();
-    expect(await screen.findByText(/Latest scan total 4/i)).toBeInTheDocument();
+    expect(await screen.findByText(/vs\. previous scan \(4 total\)/i)).toBeInTheDocument();
     expect(await screen.findByText('-6')).toBeInTheDocument();
     expect(
       fetchMock.mock.calls.some(([url]) => {
@@ -662,9 +661,9 @@ describe('App', () => {
     setCurrentPath('/app/tenant-a/workspace-a');
     render(<App />);
 
-    expect(await screen.findByText(/Trend delta/i)).toBeInTheDocument();
-    expect(await screen.findByText('N/A')).toBeInTheDocument();
-    expect(await screen.findByText(/Latest scan total 12; awaiting another scan/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Trend/i)).toBeInTheDocument();
+    expect(await screen.findByText('—')).toBeInTheDocument();
+    expect(await screen.findByText(/12 findings · awaiting another scan/i)).toBeInTheDocument();
     expect(screen.queryByText('+12')).not.toBeInTheDocument();
   });
 
@@ -1611,7 +1610,7 @@ describe('App', () => {
     setCurrentPath('/auth/callback');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { level: 1, name: /Identrail Workspace/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
     expect(window.location.pathname).toBe('/app/tenant-a/workspace-a');
   });
 
@@ -1668,7 +1667,7 @@ describe('App', () => {
     fireEvent.change(screen.getByLabelText(/Authentication code/i), { target: { value: '123456' } });
     fireEvent.click(screen.getByRole('button', { name: /Verify and continue/i }));
 
-    expect(await screen.findByRole('heading', { level: 1, name: /Identrail Workspace/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
     expect(window.location.pathname).toBe('/app/tenant-a/workspace-a');
     expect(fetchMock).toHaveBeenCalledWith(
       'http://localhost:8080/auth/mfa/verify',

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -269,6 +269,7 @@ describe('ProductShellLayout', () => {
               element={
                 <>
                   <p>Child view</p>
+                  <SourceLogoMark provider="aws" />
                   <SourceLogoMark provider="github" />
                   <SourceLogoMark provider="kubernetes" />
                 </>
@@ -282,7 +283,6 @@ describe('ProductShellLayout', () => {
     expect(screen.getAllByRole('img', { name: 'AWS' }).length).toBeGreaterThan(0);
     expect(screen.queryByRole('img', { name: 'GitHub' })).not.toBeInTheDocument();
     expect(screen.queryByRole('img', { name: 'Kubernetes' })).not.toBeInTheDocument();
-    expect(screen.getByText(/AWS signals stay visible across the workflow/i)).toBeInTheDocument();
   });
 });
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -695,11 +695,24 @@ function AppRouteLoadingState({ title, body }: { title: string; body: string }) 
   );
 }
 
-function AppShellEmptyState({ title, body }: { title: string; body: string }) {
+function AppShellEmptyState({
+  title,
+  body,
+  action
+}: {
+  title: string;
+  body: string;
+  action?: { label: string; to: string };
+}) {
   return (
     <article className="idt-app-empty-state">
       <h2>{title}</h2>
       <p>{body}</p>
+      {action ? (
+        <Link className="idt-app-empty-state-action" to={action.to}>
+          {action.label}
+        </Link>
+      ) : null}
     </article>
   );
 }
@@ -1141,8 +1154,10 @@ export function ProductShellLayout() {
   const scope = resolveScopeFromParams(params);
   const [commandOpen, setCommandOpen] = useState(false);
   const [accountMenuOpen, setAccountMenuOpen] = useState(false);
+  const [workspaceMenuOpen, setWorkspaceMenuOpen] = useState(false);
   const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(() => readSidebarCollapsed());
   const accountMenuRef = useRef<HTMLDivElement | null>(null);
+  const workspaceMenuRef = useRef<HTMLDivElement | null>(null);
   const basePath = scope ? buildScopedPath(scope) : '/app';
   const commandItems = useMemo<CommandPaletteItem[]>(() => {
     if (!scope) {
@@ -1289,6 +1304,29 @@ export function ProductShellLayout() {
     };
   }, [accountMenuOpen]);
 
+  useEffect(() => {
+    if (!workspaceMenuOpen) {
+      return;
+    }
+    const handleClick = (event: MouseEvent) => {
+      if (!workspaceMenuRef.current || workspaceMenuRef.current.contains(event.target as Node)) {
+        return;
+      }
+      setWorkspaceMenuOpen(false);
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setWorkspaceMenuOpen(false);
+      }
+    };
+    window.addEventListener('mousedown', handleClick);
+    window.addEventListener('keydown', handleKey);
+    return () => {
+      window.removeEventListener('mousedown', handleClick);
+      window.removeEventListener('keydown', handleKey);
+    };
+  }, [workspaceMenuOpen]);
+
   if (!scope) {
     return <AppShellLoading message="Resolving workspace scope" />;
   }
@@ -1324,14 +1362,57 @@ export function ProductShellLayout() {
           aria-label="Workspace navigation"
           data-collapsed={sidebarCollapsed ? 'true' : 'false'}
         >
-          <div className="idt-app-sidebar-brand">
-            <Link className="idt-app-sidebar-mark" to={basePath} aria-label="Identrail app home">
-              <img src="/identrail-logo.png" alt="" aria-hidden="true" />
-            </Link>
-            <div className="idt-app-sidebar-brand-copy">
-              <strong>{workspaceDisplayName}</strong>
-              <span>Identrail</span>
-            </div>
+          <div className="idt-app-sidebar-workspace" ref={workspaceMenuRef}>
+            <button
+              type="button"
+              className="idt-app-sidebar-workspace-trigger"
+              aria-haspopup="menu"
+              aria-expanded={workspaceMenuOpen}
+              onClick={() => setWorkspaceMenuOpen((value) => !value)}
+              title={sidebarCollapsed ? workspaceDisplayName : undefined}
+            >
+              <span className="idt-app-sidebar-mark" aria-hidden="true">
+                <img src="/identrail-logo.png" alt="" aria-hidden="true" />
+              </span>
+              <span className="idt-app-sidebar-workspace-copy">
+                <strong>{workspaceDisplayName}</strong>
+                <span>Identrail</span>
+              </span>
+              <span className="idt-app-sidebar-workspace-caret" aria-hidden="true">
+                <svg viewBox="0 0 12 12" width="10" height="10" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="m3 4.5 3 3 3-3" />
+                </svg>
+              </span>
+            </button>
+            {workspaceMenuOpen ? (
+              <div className="idt-app-sidebar-workspace-menu" role="menu">
+                <div className="idt-app-sidebar-workspace-meta">
+                  <span className="idt-app-sidebar-workspace-meta-eyebrow">Current workspace</span>
+                  <strong>{workspaceDisplayName}</strong>
+                </div>
+                <Link
+                  role="menuitem"
+                  to={`${basePath}/workspaces`}
+                  onClick={() => setWorkspaceMenuOpen(false)}
+                >
+                  Switch workspace
+                </Link>
+                <Link
+                  role="menuitem"
+                  to={`${basePath}/settings`}
+                  onClick={() => setWorkspaceMenuOpen(false)}
+                >
+                  Workspace settings
+                </Link>
+                <Link
+                  role="menuitem"
+                  to="/onboarding/org"
+                  onClick={() => setWorkspaceMenuOpen(false)}
+                >
+                  Create a workspace
+                </Link>
+              </div>
+            ) : null}
           </div>
 
           <button
@@ -1352,7 +1433,8 @@ export function ProductShellLayout() {
           </button>
 
           <nav className="idt-app-shell-nav" aria-label="App sections">
-            <NavLink to={basePath} end title={sidebarCollapsed ? 'Overview' : undefined}>
+            <div className="idt-app-nav-group-label" aria-hidden={sidebarCollapsed}>Workspace</div>
+            <NavLink to={basePath} end aria-label="Overview" title={sidebarCollapsed ? 'Overview' : undefined}>
               <span className="idt-app-nav-icon" aria-hidden="true">
                 <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
                   <path d="M2 8 8 2.5 14 8" />
@@ -1361,7 +1443,36 @@ export function ProductShellLayout() {
               </span>
               <span className="idt-app-nav-label">Overview</span>
             </NavLink>
-            <NavLink to={`${basePath}/workspaces`} title={sidebarCollapsed ? 'Workspaces' : undefined}>
+            <NavLink to={`${basePath}/projects`} aria-label="Projects" title={sidebarCollapsed ? 'Projects' : undefined}>
+              <span className="idt-app-nav-icon" aria-hidden="true">
+                <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M2 5.5 7 3l5 2.5L7 8Z" />
+                  <path d="M2 5.5v5L7 13l5-2.5v-5" />
+                  <path d="M7 8v5" />
+                </svg>
+              </span>
+              <span className="idt-app-nav-label">Projects</span>
+            </NavLink>
+            <NavLink to={`${basePath}/findings`} aria-label="Findings" title={sidebarCollapsed ? 'Findings' : undefined}>
+              <span className="idt-app-nav-icon" aria-hidden="true">
+                <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M8 1.5 2 4v3.5c0 4 3 6.4 6 7 3-.6 6-3 6-7V4Z" />
+                </svg>
+              </span>
+              <span className="idt-app-nav-label">Findings</span>
+            </NavLink>
+            <NavLink to="/reports/executive" aria-label="Executive report" title={sidebarCollapsed ? 'Executive report' : undefined}>
+              <span className="idt-app-nav-icon" aria-hidden="true">
+                <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="2.5" y="2.5" width="11" height="11" rx="1.5" />
+                  <path d="M5 11V8M8 11V6M11 11V9" />
+                </svg>
+              </span>
+              <span className="idt-app-nav-label">Executive report</span>
+            </NavLink>
+
+            <div className="idt-app-nav-group-label" aria-hidden={sidebarCollapsed}>Organization</div>
+            <NavLink to={`${basePath}/workspaces`} aria-label="Workspaces" title={sidebarCollapsed ? 'Workspaces' : undefined}>
               <span className="idt-app-nav-icon" aria-hidden="true">
                 <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
                   <circle cx="5.5" cy="6" r="2" />
@@ -1372,34 +1483,7 @@ export function ProductShellLayout() {
               </span>
               <span className="idt-app-nav-label">Workspaces</span>
             </NavLink>
-            <NavLink to={`${basePath}/projects`} title={sidebarCollapsed ? 'Projects' : undefined}>
-              <span className="idt-app-nav-icon" aria-hidden="true">
-                <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M2 5.5 7 3l5 2.5L7 8Z" />
-                  <path d="M2 5.5v5L7 13l5-2.5v-5" />
-                  <path d="M7 8v5" />
-                </svg>
-              </span>
-              <span className="idt-app-nav-label">Projects</span>
-            </NavLink>
-            <NavLink to={`${basePath}/findings`} title={sidebarCollapsed ? 'Findings' : undefined}>
-              <span className="idt-app-nav-icon" aria-hidden="true">
-                <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M8 1.5 2 4v3.5c0 4 3 6.4 6 7 3-.6 6-3 6-7V4Z" />
-                </svg>
-              </span>
-              <span className="idt-app-nav-label">Findings</span>
-            </NavLink>
-            <NavLink to="/reports/executive" title={sidebarCollapsed ? 'Executive report' : undefined}>
-              <span className="idt-app-nav-icon" aria-hidden="true">
-                <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-                  <rect x="2.5" y="2.5" width="11" height="11" rx="1.5" />
-                  <path d="M5 11V8M8 11V6M11 11V9" />
-                </svg>
-              </span>
-              <span className="idt-app-nav-label">Executive report</span>
-            </NavLink>
-            <NavLink to={`${basePath}/settings`} title={sidebarCollapsed ? 'Settings' : undefined}>
+            <NavLink to={`${basePath}/settings`} aria-label="Settings" title={sidebarCollapsed ? 'Settings' : undefined}>
               <span className="idt-app-nav-icon" aria-hidden="true">
                 <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
                   <circle cx="8" cy="8" r="2" />
@@ -1446,6 +1530,15 @@ export function ProductShellLayout() {
                   >
                     Workspace settings
                   </Link>
+                  <a
+                    role="menuitem"
+                    href="https://docs.identrail.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={() => setAccountMenuOpen(false)}
+                  >
+                    Help &amp; docs
+                  </a>
                   <Link role="menuitem" to="/" onClick={() => setAccountMenuOpen(false)}>
                     Marketing site
                   </Link>
@@ -1570,25 +1663,25 @@ function groupRecentScans(scans: RepoScanRecord[]): ScanGroup[] {
   return groups;
 }
 
-const INVITE_DISMISSED_STORAGE_KEY = 'idt:overview:invite-dismissed';
+const INVITE_SKIPPED_STORAGE_KEY = 'idt:overview:invite-skipped';
 
-function readInviteDismissed(workspaceID: string | undefined): boolean {
+function readInviteSkipped(workspaceID: string | undefined): boolean {
   if (typeof window === 'undefined' || !workspaceID) {
     return false;
   }
   try {
-    return window.localStorage.getItem(`${INVITE_DISMISSED_STORAGE_KEY}:${workspaceID}`) === '1';
+    return window.localStorage.getItem(`${INVITE_SKIPPED_STORAGE_KEY}:${workspaceID}`) === '1';
   } catch {
     return false;
   }
 }
 
-function persistInviteDismissed(workspaceID: string | undefined): void {
+function persistInviteSkipped(workspaceID: string | undefined): void {
   if (typeof window === 'undefined' || !workspaceID) {
     return;
   }
   try {
-    window.localStorage.setItem(`${INVITE_DISMISSED_STORAGE_KEY}:${workspaceID}`, '1');
+    window.localStorage.setItem(`${INVITE_SKIPPED_STORAGE_KEY}:${workspaceID}`, '1');
   } catch {
     // Storage failures are non-fatal.
   }
@@ -1605,6 +1698,7 @@ export function ProductOverviewPage() {
   const [repoScans, setRepoScans] = useState<RepoScanRecord[]>([]);
   const [repoFindings, setRepoFindings] = useState<ApiFinding[]>([]);
   const [trendPoints, setTrendPoints] = useState<TrendPoint[]>([]);
+  const [, setInviteSkipTick] = useState(0);
 
   useEffect(() => {
     if (!FEATURE_ONBOARDING_WIZARD) {
@@ -1735,6 +1829,7 @@ export function ProductOverviewPage() {
     complete: boolean;
     actionLabel?: string;
     to?: string;
+    skippable?: boolean;
   }> = [
     {
       id: 'project',
@@ -1764,9 +1859,10 @@ export function ProductOverviewPage() {
       id: 'invite',
       label: 'Invite a teammate',
       description: 'Give analysts and admins access to this workspace.',
-      complete: readInviteDismissed(scope?.workspaceID),
-      actionLabel: readInviteDismissed(scope?.workspaceID) ? undefined : 'Invite',
-      to: workspacesPath
+      complete: readInviteSkipped(scope?.workspaceID),
+      actionLabel: readInviteSkipped(scope?.workspaceID) ? undefined : 'Invite',
+      to: workspacesPath,
+      skippable: !readInviteSkipped(scope?.workspaceID)
     }
   ];
   const onboardingComplete = onboardingChecklist.every((item) => item.complete);
@@ -1802,15 +1898,7 @@ export function ProductOverviewPage() {
         <header className="idt-overview-header">
           <div>
             <h2>Overview</h2>
-            <p>Last 7 days of project coverage, scans, and open findings.</p>
-          </div>
-          <div className="idt-inline-actions">
-            <Link className="idt-btn idt-btn-primary" to={findingsPath}>
-              Review findings
-            </Link>
-            <Link className="idt-btn idt-btn-ghost" to={projectsPath}>
-              Manage projects
-            </Link>
+            <p className="idt-overview-header-sub">Last 7 days</p>
           </div>
         </header>
 
@@ -1834,19 +1922,26 @@ export function ProductOverviewPage() {
                     <strong>{item.label}</strong>
                     <span>{item.description}</span>
                   </div>
-                  {item.actionLabel && item.to ? (
-                    <Link
-                      className="idt-overview-checklist-action"
-                      to={item.to}
-                      onClick={() => {
-                        if (item.id === 'invite') {
-                          persistInviteDismissed(scope?.workspaceID);
-                        }
-                      }}
-                    >
-                      {item.actionLabel}
-                    </Link>
-                  ) : null}
+                  <div className="idt-overview-checklist-actions">
+                    {item.skippable && !item.complete ? (
+                      <button
+                        type="button"
+                        className="idt-overview-checklist-skip"
+                        onClick={() => {
+                          persistInviteSkipped(scope?.workspaceID);
+                          setInviteSkipTick((value) => value + 1);
+                        }}
+                        aria-label={`Skip: ${item.label}`}
+                      >
+                        Skip
+                      </button>
+                    ) : null}
+                    {item.actionLabel && item.to ? (
+                      <Link className="idt-overview-checklist-action" to={item.to}>
+                        {item.actionLabel}
+                      </Link>
+                    ) : null}
+                  </div>
                 </li>
               ))}
             </ol>
@@ -1879,25 +1974,25 @@ export function ProductOverviewPage() {
               )}
             </p>
           </article>
-          <article className="idt-overview-metric-card">
-            <span className="idt-overview-metric-label">Trend</span>
-            <strong>
-              {trendDelta === null
-                ? '—'
-                : trendDelta > 0
-                  ? `+${trendDelta}`
-                  : trendDelta === 0
-                    ? '0'
-                    : trendDelta}
-            </strong>
-            <p>
-              {latestTrend
-                ? previousTrend
+          {latestTrend ? (
+            <article className="idt-overview-metric-card">
+              <span className="idt-overview-metric-label">Trend</span>
+              <strong>
+                {trendDelta === null
+                  ? '—'
+                  : trendDelta > 0
+                    ? `+${trendDelta}`
+                    : trendDelta === 0
+                      ? '0'
+                      : trendDelta}
+              </strong>
+              <p>
+                {previousTrend
                   ? `vs. previous scan (${latestTrend.total} total)`
-                  : `${latestTrend.total} findings · awaiting another scan`
-                : 'No data yet'}
-            </p>
-          </article>
+                  : `${latestTrend.total} findings · awaiting another scan`}
+              </p>
+            </article>
+          ) : null}
         </div>
 
         <div className="idt-overview-grid">
@@ -1930,6 +2025,7 @@ export function ProductOverviewPage() {
               <AppShellEmptyState
                 title="No open findings"
                 body="Findings will appear here with severity, repository, and line context."
+                action={hasAnySuccessfulScan ? undefined : { label: 'Run a scan', to: connectSourcesPath }}
               />
             )}
           </section>
@@ -1974,6 +2070,7 @@ export function ProductOverviewPage() {
               <AppShellEmptyState
                 title="No scans yet"
                 body="Connect a project source and run the first scan to populate activity."
+                action={{ label: 'Connect a source', to: connectSourcesPath }}
               />
             )}
           </section>
@@ -2002,6 +2099,7 @@ export function ProductOverviewPage() {
               <AppShellEmptyState
                 title="No active projects"
                 body="Create the first project to connect source telemetry and scan policies."
+                action={{ label: 'Create project', to: projectsPath }}
               />
             )}
           </section>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1115,11 +1115,34 @@ function resolveScopeFromParams(params: ScopeRouteParams): ProductSession | null
   return { tenantID, workspaceID, projectID };
 }
 
+const SIDEBAR_COLLAPSED_STORAGE_KEY = 'idt:sidebar:collapsed';
+
+function readSidebarCollapsed(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  try {
+    return window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function isMacPlatform(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+  return /Mac|iPhone|iPad|iPod/i.test(navigator.platform || '');
+}
+
 export function ProductShellLayout() {
   const params = useParams<ScopeRouteParams>();
   const navigate = useNavigate();
   const scope = resolveScopeFromParams(params);
   const [commandOpen, setCommandOpen] = useState(false);
+  const [accountMenuOpen, setAccountMenuOpen] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(() => readSidebarCollapsed());
+  const accountMenuRef = useRef<HTMLDivElement | null>(null);
   const basePath = scope ? buildScopedPath(scope) : '/app';
   const commandItems = useMemo<CommandPaletteItem[]>(() => {
     if (!scope) {
@@ -1217,6 +1240,11 @@ export function ProductShellLayout() {
         setCommandOpen(true);
         return;
       }
+      if ((event.metaKey || event.ctrlKey) && key === 'b') {
+        event.preventDefault();
+        setSidebarCollapsed((current) => !current);
+        return;
+      }
       if (!event.metaKey && !event.ctrlKey && !event.altKey && (key === '/' || key === 'f')) {
         event.preventDefault();
         setCommandOpen(true);
@@ -1227,14 +1255,50 @@ export function ProductShellLayout() {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, []);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    try {
+      window.localStorage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, sidebarCollapsed ? '1' : '0');
+    } catch {
+      // Storage failure should not break the layout.
+    }
+  }, [sidebarCollapsed]);
+
+  useEffect(() => {
+    if (!accountMenuOpen) {
+      return;
+    }
+    const handleClick = (event: MouseEvent) => {
+      if (!accountMenuRef.current || accountMenuRef.current.contains(event.target as Node)) {
+        return;
+      }
+      setAccountMenuOpen(false);
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setAccountMenuOpen(false);
+      }
+    };
+    window.addEventListener('mousedown', handleClick);
+    window.addEventListener('keydown', handleKey);
+    return () => {
+      window.removeEventListener('mousedown', handleClick);
+      window.removeEventListener('keydown', handleKey);
+    };
+  }, [accountMenuOpen]);
+
   if (!scope) {
     return <AppShellLoading message="Resolving workspace scope" />;
   }
 
-  const tenantLabel = formatScopeDisplay(scope.tenantID);
-  const workspaceLabel = formatScopeDisplay(scope.workspaceID);
-  const projectLabel = scope.projectID ? formatScopeDisplay(scope.projectID) : '';
-  const enabledSourceLabel = formatSourceNameList(SOURCE_STACK);
+  const workspaceDisplayName = formatScopeDisplay(scope.workspaceID) || 'Workspace';
+  const userDisplayName = 'Account';
+  const userEmail = '';
+  const userInitial = (workspaceDisplayName.charAt(0) || 'A').toUpperCase();
+  const collapseShortcut = isMacPlatform() ? '⌘B' : 'Ctrl+B';
+  const collapseHint = `${sidebarCollapsed ? 'Expand' : 'Collapse'} sidebar (${collapseShortcut})`;
   const runCommand = (item: CommandPaletteItem) => {
     setCommandOpen(false);
     if (item.path) {
@@ -1246,105 +1310,172 @@ export function ProductShellLayout() {
 
   return (
     <ProductErrorBoundary>
-      <div className="idt-app-shell idt-app-console-layout" data-tenant={scope.tenantID} data-workspace={scope.workspaceID}>
-        <aside className="idt-app-sidebar" aria-label="Workspace navigation">
+      <div
+        className={`idt-app-shell idt-app-console-layout${sidebarCollapsed ? ' is-sidebar-collapsed' : ''}`}
+        data-tenant={scope.tenantID}
+        data-workspace={scope.workspaceID}
+      >
+        <aside
+          className="idt-app-sidebar"
+          aria-label="Workspace navigation"
+          data-collapsed={sidebarCollapsed ? 'true' : 'false'}
+        >
           <div className="idt-app-sidebar-brand">
             <Link className="idt-app-sidebar-mark" to={basePath} aria-label="Identrail app home">
               <img src="/identrail-logo.png" alt="" aria-hidden="true" />
             </Link>
-            <div>
+            <div className="idt-app-sidebar-brand-copy">
               <strong>Identrail</strong>
-              <span>Trust operations</span>
+              <span title={scope.workspaceID}>{workspaceDisplayName}</span>
             </div>
           </div>
-
-          <section className="idt-app-sidebar-scope" aria-label="Active workspace">
-            <p className="idt-app-kicker">Active scope</p>
-            <h2 title={scope.workspaceID}>{workspaceLabel}</h2>
-            <dl>
-              <div>
-                <dt>Tenant</dt>
-                <dd title={scope.tenantID}>{tenantLabel}</dd>
-              </div>
-              {scope.projectID ? (
-                <div>
-                  <dt>Project</dt>
-                  <dd title={scope.projectID}>{projectLabel}</dd>
-                </div>
-              ) : null}
-            </dl>
-          </section>
 
           <button
             type="button"
             className="idt-app-quick-find"
             onClick={() => setCommandOpen(true)}
             aria-label="Open workspace finder"
+            title={sidebarCollapsed ? 'Find (⌘K)' : undefined}
           >
-            <span>Find</span>
-            <kbd>/</kbd>
-            <kbd>F</kbd>
-            <kbd>⌘K</kbd>
+            <span className="idt-app-quick-find-icon" aria-hidden="true">
+              <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="7" cy="7" r="4.5" />
+                <path d="m13.5 13.5-3-3" />
+              </svg>
+            </span>
+            <span className="idt-app-quick-find-label">Find</span>
+            <kbd className="idt-app-quick-find-key">⌘K</kbd>
           </button>
 
           <nav className="idt-app-shell-nav" aria-label="App sections">
-            <NavLink to={basePath} end>
-              Overview
+            <NavLink to={basePath} end title={sidebarCollapsed ? 'Overview' : undefined}>
+              <span className="idt-app-nav-icon" aria-hidden="true">
+                <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M2 8 8 2.5 14 8" />
+                  <path d="M3.5 7v6.5h9V7" />
+                </svg>
+              </span>
+              <span className="idt-app-nav-label">Overview</span>
             </NavLink>
-            <NavLink to={`${basePath}/workspaces`}>Workspaces</NavLink>
-            <NavLink to={`${basePath}/projects`}>Projects</NavLink>
-            <NavLink to={`${basePath}/findings`}>Findings</NavLink>
-            <NavLink to="/reports/executive">Executive report</NavLink>
-            <NavLink to={`${basePath}/settings`}>Settings</NavLink>
-            <NavLink to="/app/account/security">Security</NavLink>
+            <NavLink to={`${basePath}/workspaces`} title={sidebarCollapsed ? 'Workspaces' : undefined}>
+              <span className="idt-app-nav-icon" aria-hidden="true">
+                <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="5.5" cy="6" r="2" />
+                  <circle cx="11" cy="6.5" r="1.6" />
+                  <path d="M2 13c.6-2 2-3 3.5-3S8.4 11 9 13" />
+                  <path d="M9.5 13c.4-1.6 1.5-2.4 2.5-2.4s2.1.8 2.5 2.4" />
+                </svg>
+              </span>
+              <span className="idt-app-nav-label">Workspaces</span>
+            </NavLink>
+            <NavLink to={`${basePath}/projects`} title={sidebarCollapsed ? 'Projects' : undefined}>
+              <span className="idt-app-nav-icon" aria-hidden="true">
+                <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M2 5.5 7 3l5 2.5L7 8Z" />
+                  <path d="M2 5.5v5L7 13l5-2.5v-5" />
+                  <path d="M7 8v5" />
+                </svg>
+              </span>
+              <span className="idt-app-nav-label">Projects</span>
+            </NavLink>
+            <NavLink to={`${basePath}/findings`} title={sidebarCollapsed ? 'Findings' : undefined}>
+              <span className="idt-app-nav-icon" aria-hidden="true">
+                <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M8 1.5 2 4v3.5c0 4 3 6.4 6 7 3-.6 6-3 6-7V4Z" />
+                </svg>
+              </span>
+              <span className="idt-app-nav-label">Findings</span>
+            </NavLink>
+            <NavLink to="/reports/executive" title={sidebarCollapsed ? 'Executive report' : undefined}>
+              <span className="idt-app-nav-icon" aria-hidden="true">
+                <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="2.5" y="2.5" width="11" height="11" rx="1.5" />
+                  <path d="M5 11V8M8 11V6M11 11V9" />
+                </svg>
+              </span>
+              <span className="idt-app-nav-label">Executive report</span>
+            </NavLink>
+            <NavLink to={`${basePath}/settings`} title={sidebarCollapsed ? 'Settings' : undefined}>
+              <span className="idt-app-nav-icon" aria-hidden="true">
+                <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="8" cy="8" r="2" />
+                  <path d="M8 2v1.5M8 12.5V14M2 8h1.5M12.5 8H14M3.8 3.8l1 1M11.2 11.2l1 1M3.8 12.2l1-1M11.2 4.8l1-1" />
+                </svg>
+              </span>
+              <span className="idt-app-nav-label">Settings</span>
+            </NavLink>
           </nav>
 
           <div className="idt-app-sidebar-footer">
-            <span>Workspace mode</span>
-            <strong>Read-only evidence first</strong>
+            <div className="idt-app-sidebar-account" ref={accountMenuRef}>
+              <button
+                type="button"
+                className="idt-app-sidebar-account-trigger"
+                aria-haspopup="menu"
+                aria-expanded={accountMenuOpen}
+                onClick={() => setAccountMenuOpen((current) => !current)}
+                title={sidebarCollapsed ? userDisplayName : undefined}
+              >
+                <span className="idt-app-sidebar-account-avatar" aria-hidden="true">
+                  {userInitial}
+                </span>
+                <span className="idt-app-sidebar-account-name">
+                  <strong>{userDisplayName}</strong>
+                  {userEmail && userEmail !== userDisplayName ? <span>{userEmail}</span> : null}
+                </span>
+                <span className="idt-app-sidebar-account-caret" aria-hidden="true">
+                  <svg viewBox="0 0 12 12" width="10" height="10" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M3 7.5 6 4.5l3 3" />
+                  </svg>
+                </span>
+              </button>
+              {accountMenuOpen ? (
+                <div className="idt-app-sidebar-account-menu" role="menu">
+                  <div className="idt-app-sidebar-account-meta">
+                    <strong>{userDisplayName}</strong>
+                    {userEmail ? <span>{userEmail}</span> : null}
+                  </div>
+                  <Link
+                    role="menuitem"
+                    to={`${basePath}/settings`}
+                    onClick={() => setAccountMenuOpen(false)}
+                  >
+                    Workspace settings
+                  </Link>
+                  <Link role="menuitem" to="/" onClick={() => setAccountMenuOpen(false)}>
+                    Marketing site
+                  </Link>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      setAccountMenuOpen(false);
+                      navigate('/app/logout', { replace: true });
+                    }}
+                  >
+                    Sign out
+                  </button>
+                </div>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              className="idt-app-sidebar-collapse"
+              aria-label={collapseHint}
+              aria-pressed={sidebarCollapsed}
+              title={collapseHint}
+              onClick={() => setSidebarCollapsed((current) => !current)}
+            >
+              <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <rect x="2.5" y="3" width="11" height="10" rx="1.5" />
+                <path d="M6.5 3v10" />
+                {sidebarCollapsed ? <path d="m9 6 2 2-2 2" /> : <path d="m11 6-2 2 2 2" />}
+              </svg>
+            </button>
           </div>
         </aside>
 
         <div className="idt-app-console">
-          <header className="idt-app-shell-header">
-            <div>
-              <p className="idt-app-kicker">Operations console</p>
-              <h1>Identrail workspace</h1>
-              <p>
-                Tenant <strong title={scope.tenantID}>{tenantLabel}</strong> · Workspace <strong title={scope.workspaceID}>{workspaceLabel}</strong>
-                {scope.projectID ? (
-                  <>
-                    {' '}
-                    · Project <strong title={scope.projectID}>{projectLabel}</strong>
-                  </>
-                ) : null}
-              </p>
-              <div className="idt-app-header-meta" aria-label="Workspace operating model">
-                <SourceLogoStack className="idt-app-header-source-stack" label="Enabled source connectors" />
-                <span>{enabledSourceLabel} signals stay visible across the workflow.</span>
-                <span>Project-scoped scans</span>
-                <span>Owner-ready findings</span>
-              </div>
-            </div>
-            <div className="idt-app-shell-actions">
-              <Link to="/app/account/security" className="idt-btn idt-btn-ghost">
-                Account security
-              </Link>
-              <button
-                type="button"
-                className="idt-btn idt-btn-ghost"
-                onClick={() => {
-                  navigate('/app/logout', { replace: true });
-                }}
-              >
-                Sign out
-              </button>
-              <Link to="/" className="idt-btn idt-btn-dark">
-                Marketing site
-              </Link>
-            </div>
-          </header>
-
           <main className="idt-app-shell-main">
             <Outlet />
           </main>
@@ -1358,6 +1489,81 @@ export function ProductShellLayout() {
       />
     </ProductErrorBoundary>
   );
+}
+
+function formatRelativeTime(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  const diffMs = Date.now() - parsed.getTime();
+  const diffMinutes = Math.round(diffMs / 60000);
+  if (diffMinutes < 1) return 'just now';
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  const diffHours = Math.round(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.round(diffHours / 24);
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return parsed.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+function summarizeScanFailure(scan: RepoScanRecord): string {
+  const message = (scan.error_message || '').trim();
+  if (!message) {
+    return 'Failed without a reported reason';
+  }
+  const lowered = message.toLowerCase();
+  if (lowered.includes('rate limit') || lowered.includes('secondary rate')) {
+    return 'Hit GitHub rate limit';
+  }
+  if (lowered.includes('timeout') || lowered.includes('timed out')) {
+    return 'Scan timed out';
+  }
+  if (lowered.includes('unauthor') || lowered.includes('401') || lowered.includes('token') || lowered.includes('credential')) {
+    return 'Authentication failed — reconnect the source';
+  }
+  if (lowered.includes('not found') || lowered.includes('404')) {
+    return 'Repository not found or access revoked';
+  }
+  if (lowered.includes('forbid') || lowered.includes('403')) {
+    return 'Access forbidden — check permissions';
+  }
+  if (message.length <= 96) {
+    return message;
+  }
+  return `${message.slice(0, 93)}...`;
+}
+
+type ScanGroup = {
+  reason: string;
+  status: string;
+  count: number;
+  latest: RepoScanRecord;
+  repos: string[];
+};
+
+function groupRecentScans(scans: RepoScanRecord[]): ScanGroup[] {
+  const groups: ScanGroup[] = [];
+  scans.forEach((scan) => {
+    const status = normalizeValue(scan.status).toLowerCase();
+    const reason =
+      status === 'failed' || status === 'canceled'
+        ? summarizeScanFailure(scan)
+        : status === 'succeeded' || status === 'completed'
+          ? `${scan.finding_count} findings · ${scan.files_scanned} files`
+          : 'In progress';
+    const repo = canonicalGitHubRepositoryDisplay(scan.repository) || scan.repository;
+    const last = groups[groups.length - 1];
+    if (last && last.status === status && last.reason === reason) {
+      last.count += 1;
+      if (!last.repos.includes(repo)) {
+        last.repos.push(repo);
+      }
+      return;
+    }
+    groups.push({ reason, status, count: 1, latest: scan, repos: [repo] });
+  });
+  return groups;
 }
 
 export function ProductOverviewPage() {
@@ -1474,95 +1680,186 @@ export function ProductOverviewPage() {
     return severity === 'critical' || severity === 'high';
   }).length;
   const activeScanCount = repoScans.filter((scan) => isActiveScanStatus(scan.status)).length;
-  const completedScanCount = repoScans.filter((scan) => isCompletedScanStatus(scan.status)).length;
+  const succeededScanCount = repoScans.filter((scan) => {
+    const normalized = normalizeValue(scan.status).toLowerCase();
+    return normalized === 'succeeded' || normalized === 'completed';
+  }).length;
+  const failedScanCount = repoScans.filter((scan) => {
+    const normalized = normalizeValue(scan.status).toLowerCase();
+    return normalized === 'failed' || normalized === 'canceled';
+  }).length;
   const latestTrend = trendPoints[trendPoints.length - 1];
   const previousTrend = trendPoints[trendPoints.length - 2];
   const trendDelta = latestTrend && previousTrend ? latestTrend.total - previousTrend.total : null;
   const projectsPath = scope ? buildProjectsPath(scope) : '/app';
   const findingsPath = scope ? buildScopedPath(scope, 'findings') : '/app';
   const workspacesPath = scope ? buildScopedPath(scope, 'workspaces') : '/app';
+  const connectSourcesPath = scope?.projectID ? buildProjectPath(scope, scope.projectID) : projectsPath;
+  const hasAnySuccessfulScan = succeededScanCount > 0;
+  const hasConnectedSource = activeProjects.some((project) => {
+    const desc = (project.description ?? '').toLowerCase();
+    return desc.includes('connector') || desc.includes('source') || desc.includes('github') || desc.includes('aws');
+  });
+  const onboardingChecklist: Array<{
+    id: string;
+    label: string;
+    description: string;
+    complete: boolean;
+    actionLabel?: string;
+    to?: string;
+  }> = [
+    {
+      id: 'project',
+      label: 'Create your first project',
+      description: 'Define the scope that connectors and scan policies attach to.',
+      complete: activeProjects.length > 0,
+      actionLabel: activeProjects.length > 0 ? undefined : 'Create',
+      to: projectsPath
+    },
+    {
+      id: 'source',
+      label: 'Connect a source',
+      description: 'Attach GitHub, AWS, or Kubernetes telemetry to a project.',
+      complete: hasConnectedSource || repoScans.length > 0,
+      actionLabel: hasConnectedSource || repoScans.length > 0 ? undefined : 'Connect',
+      to: connectSourcesPath
+    },
+    {
+      id: 'scan',
+      label: 'Run your first scan',
+      description: 'Produce evidence the workspace can triage.',
+      complete: hasAnySuccessfulScan,
+      actionLabel: hasAnySuccessfulScan ? undefined : 'Run scan',
+      to: connectSourcesPath
+    },
+    {
+      id: 'invite',
+      label: 'Invite a teammate',
+      description: 'Give analysts and admins access to this workspace.',
+      complete: false,
+      actionLabel: 'Invite',
+      to: workspacesPath
+    }
+  ];
+  const onboardingComplete = onboardingChecklist.every((item) => item.complete);
+  const shouldShowOnboarding = !onboardingComplete;
 
   if (loading) {
     return (
-      <section className="idt-app-panel" aria-busy="true" aria-live="polite">
-        <p className="idt-app-kicker">Workspace overview</p>
-        <h2>Overview</h2>
-        <p>Loading workspace activity, project coverage, scans, and open findings.</p>
+      <section className="idt-app-panel idt-overview-page" aria-busy="true" aria-live="polite">
+        <header className="idt-overview-header">
+          <h2>Overview</h2>
+          <p>Loading workspace activity, project coverage, scans, and open findings.</p>
+        </header>
       </section>
     );
   }
 
   if (error) {
     return (
-      <section className="idt-app-panel idt-app-panel-error" role="alert">
-        <p className="idt-app-kicker">Workspace overview</p>
-        <h2>Overview</h2>
-        <p>{error}</p>
+      <section className="idt-app-panel idt-app-panel-error idt-overview-page" role="alert">
+        <header className="idt-overview-header">
+          <h2>Overview</h2>
+          <p>{error}</p>
+        </header>
       </section>
     );
   }
+
+  const scanGroups = groupRecentScans(repoScans);
 
   return (
     <>
       <section className="idt-app-panel idt-overview-page">
         <header className="idt-overview-header">
           <div>
-            <p className="idt-app-kicker">Workspace overview</p>
             <h2>Overview</h2>
-            <p>
-              Project coverage, scans, and open findings for tenant{' '}
-              <strong title={scope?.tenantID ?? undefined}>{scope ? formatScopeDisplay(scope.tenantID) : 'unknown'}</strong> and workspace{' '}
-              <strong title={scope?.workspaceID ?? undefined}>{scope ? formatScopeDisplay(scope.workspaceID) : 'unknown'}</strong>.
-            </p>
-            <div className="idt-overview-source-strip" aria-label="Overview coverage">
-              <span>Evidence queue</span>
-              <span>Connector health</span>
-              <span>Remediation owners</span>
-            </div>
+            <p>Last 7 days of project coverage, scans, and open findings.</p>
           </div>
           <div className="idt-inline-actions">
-            <Link className="idt-btn idt-btn-primary" to={projectsPath}>
-              Manage projects
-            </Link>
-            <Link className="idt-btn idt-btn-ghost" to={findingsPath}>
+            <Link className="idt-btn idt-btn-primary" to={findingsPath}>
               Review findings
+            </Link>
+            <Link className="idt-btn idt-btn-ghost" to={projectsPath}>
+              Manage projects
             </Link>
           </div>
         </header>
 
+        {shouldShowOnboarding ? (
+          <section className="idt-overview-checklist" aria-label="Get started">
+            <header>
+              <h3>Get started</h3>
+              <p>{onboardingChecklist.filter((item) => item.complete).length} of {onboardingChecklist.length} complete</p>
+            </header>
+            <ol>
+              {onboardingChecklist.map((item) => (
+                <li key={item.id} data-complete={item.complete ? 'true' : 'false'}>
+                  <span className="idt-overview-checklist-mark" aria-hidden="true">
+                    {item.complete ? (
+                      <svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="m3.5 8.5 3 3 6-7" />
+                      </svg>
+                    ) : null}
+                  </span>
+                  <div className="idt-overview-checklist-body">
+                    <strong>{item.label}</strong>
+                    <span>{item.description}</span>
+                  </div>
+                  {item.actionLabel && item.to ? (
+                    <Link className="idt-overview-checklist-action" to={item.to}>
+                      {item.actionLabel}
+                    </Link>
+                  ) : null}
+                </li>
+              ))}
+            </ol>
+          </section>
+        ) : null}
+
         <div className="idt-overview-metrics" aria-label="Workspace health metrics">
           <article className="idt-overview-metric-card">
-            <div className="idt-overview-metric-top">
-              <span>Active projects</span>
-            </div>
+            <span className="idt-overview-metric-label">Active projects</span>
             <strong>{activeProjects.length}</strong>
-            <p>{archivedProjectCount > 0 ? `${archivedProjectCount} archived` : 'All listed projects are active'}</p>
+            <p>{archivedProjectCount > 0 ? `${archivedProjectCount} archived` : activeProjects.length === 0 ? 'None yet' : activeProjects.length === 1 ? '1 project active' : `${activeProjects.length} projects active`}</p>
           </article>
           <article className="idt-overview-metric-card">
-            <div className="idt-overview-metric-top">
-              <span>Priority findings</span>
-            </div>
+            <span className="idt-overview-metric-label">Priority findings</span>
             <strong>{openFindingCount}</strong>
-            <p>{urgentFindingCount} critical or high in the ranked queue</p>
+            <p>{urgentFindingCount > 0 ? `${urgentFindingCount} critical or high` : 'No critical or high open'}</p>
           </article>
-          <article className="idt-overview-metric-card">
-            <div className="idt-overview-metric-top">
-              <span>Recent scans</span>
-            </div>
+          <article className={`idt-overview-metric-card${failedScanCount > 0 && succeededScanCount === 0 && repoScans.length > 0 ? ' is-attention' : ''}`}>
+            <span className="idt-overview-metric-label">Scans (7d)</span>
             <strong>{repoScans.length}</strong>
-            <p>{activeScanCount > 0 ? `${activeScanCount} still running` : `${completedScanCount} completed`}</p>
+            <p className="idt-overview-metric-breakdown">
+              {repoScans.length === 0 ? (
+                'No scans yet'
+              ) : (
+                <>
+                  {succeededScanCount > 0 ? <span className="is-success">{succeededScanCount} succeeded</span> : null}
+                  {failedScanCount > 0 ? <span className="is-error">{failedScanCount} failed</span> : null}
+                  {activeScanCount > 0 ? <span className="is-warning">{activeScanCount} running</span> : null}
+                </>
+              )}
+            </p>
           </article>
           <article className="idt-overview-metric-card">
-            <div className="idt-overview-metric-top">
-              <span>Trend delta</span>
-            </div>
-            <strong>{trendDelta === null ? 'N/A' : trendDelta > 0 ? `+${trendDelta}` : trendDelta}</strong>
+            <span className="idt-overview-metric-label">Trend</span>
+            <strong>
+              {trendDelta === null
+                ? '—'
+                : trendDelta > 0
+                  ? `+${trendDelta}`
+                  : trendDelta === 0
+                    ? '0'
+                    : trendDelta}
+            </strong>
             <p>
               {latestTrend
                 ? previousTrend
-                  ? `Latest scan total ${latestTrend.total}`
-                  : `Latest scan total ${latestTrend.total}; awaiting another scan`
-                : 'No trend points yet'}
+                  ? `vs. previous scan (${latestTrend.total} total)`
+                  : `${latestTrend.total} findings · awaiting another scan`
+                : 'No data yet'}
             </p>
           </article>
         </div>
@@ -1570,11 +1867,8 @@ export function ProductOverviewPage() {
         <div className="idt-overview-grid">
           <section className="idt-overview-card">
             <div className="idt-overview-card-header">
-              <div>
-                <p className="idt-app-kicker">Priority queue</p>
-                <h3>Open risk</h3>
-              </div>
-              <Link to={findingsPath}>All findings</Link>
+              <h3>Open risk</h3>
+              <Link to={findingsPath}>View all</Link>
             </div>
             {repoFindings.length > 0 ? (
               <div className="idt-overview-list">
@@ -1598,43 +1892,52 @@ export function ProductOverviewPage() {
               </div>
             ) : (
               <AppShellEmptyState
-                title="No open repository findings"
-                body="New repository scan findings will appear here with severity, repository, and line context."
+                title="No open findings"
+                body="Findings will appear here with severity, repository, and line context."
               />
             )}
           </section>
 
           <section className="idt-overview-card">
             <div className="idt-overview-card-header">
-              <div>
-                <p className="idt-app-kicker">Scan activity</p>
-                <h3>Recent scans</h3>
-              </div>
-              <Link to={findingsPath}>Open scans</Link>
+              <h3>Recent scans</h3>
+              <Link to={findingsPath}>View all</Link>
             </div>
-            {repoScans.length > 0 ? (
+            {scanGroups.length > 0 ? (
               <div className="idt-overview-list">
-                {repoScans.map((scan) => (
-                  <article key={scan.id} className="idt-overview-scan-row">
-                    <SourceLogoMark provider="github" className="is-row" />
-                    <div className="idt-overview-row-copy">
-                      <div>
-                        <strong>{canonicalGitHubRepositoryDisplay(scan.repository) || scan.repository}</strong>
-                        <p>
-                          {scan.finding_count} findings · {scan.files_scanned} files · {formatDateLabel(scan.started_at)}
-                        </p>
+                {scanGroups.map((group) => {
+                  const isFailure = group.status === 'failed' || group.status === 'canceled';
+                  const isActive = isActiveScanStatus(group.status);
+                  const repoLabel =
+                    group.repos.length === 1
+                      ? group.repos[0]
+                      : `${group.repos[0]} +${group.repos.length - 1} more`;
+                  const countLabel = group.count > 1 ? `${group.count} scans` : '1 scan';
+                  return (
+                    <article
+                      key={`${group.status}-${group.reason}-${group.latest.id}`}
+                      className={`idt-overview-scan-row${isFailure ? ' is-failure' : isActive ? ' is-active' : ' is-success'}`}
+                    >
+                      <SourceLogoMark provider="github" className="is-row" />
+                      <div className="idt-overview-row-copy">
+                        <div>
+                          <strong>{repoLabel}</strong>
+                          <p>
+                            {countLabel} · {group.reason} · {formatRelativeTime(group.latest.started_at)}
+                          </p>
+                        </div>
+                        <span className={`idt-overview-scan-badge is-${isFailure ? 'error' : isActive ? 'warning' : 'success'}`}>
+                          {isFailure ? 'Failed' : isActive ? 'Running' : 'Succeeded'}
+                        </span>
                       </div>
-                      <span className={`idt-source-status-pill is-${isActiveScanStatus(scan.status) ? 'warning' : scan.status === 'failed' ? 'error' : 'success'}`}>
-                        {formatTokenLabel(scan.status)}
-                      </span>
-                    </div>
-                  </article>
-                ))}
+                    </article>
+                  );
+                })}
               </div>
             ) : (
               <AppShellEmptyState
                 title="No scans yet"
-                body="Connect a project source and run the first scan to populate repository activity."
+                body="Connect a project source and run the first scan to populate activity."
               />
             )}
           </section>
@@ -1643,11 +1946,8 @@ export function ProductOverviewPage() {
         <div className="idt-overview-grid">
           <section className="idt-overview-card">
             <div className="idt-overview-card-header">
-              <div>
-                <p className="idt-app-kicker">Coverage</p>
-                <h3>Project coverage</h3>
-              </div>
-              <Link to={projectsPath}>Project settings</Link>
+              <h3>Project coverage</h3>
+              <Link to={projectsPath}>Manage</Link>
             </div>
             {activeProjects.length > 0 ? (
               <div className="idt-overview-projects">
@@ -1657,44 +1957,17 @@ export function ProductOverviewPage() {
                       <strong>{project.name}</strong>
                       <SourceLogoStack label={`${project.name} source stack`} />
                     </div>
-                    <span>{project.description || `Project ${project.project_id}`}</span>
-                    <small>Updated {formatDateLabel(project.updated_at)}</small>
+                    <span>{project.description || 'No description'}</span>
+                    <small>Updated {formatRelativeTime(project.updated_at)}</small>
                   </Link>
                 ))}
               </div>
             ) : (
               <AppShellEmptyState
                 title="No active projects"
-                body="Create the first project to connect source telemetry and scan policies for this workspace."
+                body="Create the first project to connect source telemetry and scan policies."
               />
             )}
-          </section>
-
-          <section className="idt-overview-card">
-            <div className="idt-overview-card-header">
-              <div>
-                <p className="idt-app-kicker">Next actions</p>
-                <h3>Make the workspace useful</h3>
-              </div>
-            </div>
-            <div className="idt-overview-actions">
-              <Link to={projectsPath}>
-                <strong>Create or select a project</strong>
-                <span>Define the scope that connectors and scan policies will attach to.</span>
-              </Link>
-              <Link to={scope?.projectID ? buildProjectPath(scope, scope.projectID) : projectsPath}>
-                <strong>Connect sources</strong>
-                <span>Attach enabled source telemetry to an active project.</span>
-              </Link>
-              <Link to={findingsPath}>
-                <strong>Triage open findings</strong>
-                <span>Review direct GitHub line links, severity, remediation, and workflow status.</span>
-              </Link>
-              <Link to={workspacesPath}>
-                <strong>Invite operators</strong>
-                <span>Give analysts and admins access to the workspace they operate.</span>
-              </Link>
-            </div>
           </section>
         </div>
       </section>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1975,7 +1975,7 @@ export function ProductOverviewPage() {
         <header className="idt-overview-header">
           <div>
             <h2>Overview</h2>
-            <p className="idt-overview-header-sub">Last 7 days</p>
+            <p className="idt-overview-header-sub">Latest activity</p>
           </div>
         </header>
 
@@ -2037,7 +2037,7 @@ export function ProductOverviewPage() {
             <p>{urgentFindingCount > 0 ? `${urgentFindingCount} critical or high` : 'No critical or high open'}</p>
           </article>
           <article className={`idt-overview-metric-card${failedScanCount > 0 && succeededScanCount === 0 && repoScans.length > 0 ? ' is-attention' : ''}`}>
-            <span className="idt-overview-metric-label">Scans (7d)</span>
+            <span className="idt-overview-metric-label">Recent scans</span>
             <strong>{repoScans.length}</strong>
             <p className="idt-overview-metric-breakdown">
               {repoScans.length === 0 ? (
@@ -2047,6 +2047,9 @@ export function ProductOverviewPage() {
                   {succeededScanCount > 0 ? <span className="is-success">{succeededScanCount} succeeded</span> : null}
                   {failedScanCount > 0 ? <span className="is-error">{failedScanCount} failed</span> : null}
                   {activeScanCount > 0 ? <span className="is-warning">{activeScanCount} running</span> : null}
+                  {repoScans.length === OVERVIEW_SCAN_LIMIT ? (
+                    <span className="is-muted">last {OVERVIEW_SCAN_LIMIT}</span>
+                  ) : null}
                 </>
               )}
             </p>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1368,6 +1368,7 @@ export function ProductShellLayout() {
               className="idt-app-sidebar-workspace-trigger"
               aria-haspopup="menu"
               aria-expanded={workspaceMenuOpen}
+              aria-label={`Workspace: ${workspaceDisplayName}. Open switcher.`}
               onClick={() => setWorkspaceMenuOpen((value) => !value)}
               title={sidebarCollapsed ? workspaceDisplayName : undefined}
             >
@@ -1501,6 +1502,7 @@ export function ProductShellLayout() {
                 className="idt-app-sidebar-account-trigger"
                 aria-haspopup="menu"
                 aria-expanded={accountMenuOpen}
+                aria-label={`Account menu for ${userDisplayName}`}
                 onClick={() => setAccountMenuOpen((current) => !current)}
                 title={sidebarCollapsed ? userDisplayName : undefined}
               >
@@ -1664,13 +1666,22 @@ function groupRecentScans(scans: RepoScanRecord[]): ScanGroup[] {
 }
 
 const INVITE_SKIPPED_STORAGE_KEY = 'idt:overview:invite-skipped';
+// Previous key that shipped briefly between the first two PR revisions. Kept so
+// any user who already clicked Invite (and persisted the old flag) does not see
+// the checklist regress.
+const INVITE_LEGACY_STORAGE_KEY = 'idt:overview:invite-dismissed';
 
 function readInviteSkipped(workspaceID: string | undefined): boolean {
   if (typeof window === 'undefined' || !workspaceID) {
     return false;
   }
   try {
-    return window.localStorage.getItem(`${INVITE_SKIPPED_STORAGE_KEY}:${workspaceID}`) === '1';
+    const fresh = window.localStorage.getItem(`${INVITE_SKIPPED_STORAGE_KEY}:${workspaceID}`);
+    if (fresh === '1') {
+      return true;
+    }
+    const legacy = window.localStorage.getItem(`${INVITE_LEGACY_STORAGE_KEY}:${workspaceID}`);
+    return legacy === '1';
   } catch {
     return false;
   }
@@ -1682,6 +1693,8 @@ function persistInviteSkipped(workspaceID: string | undefined): void {
   }
   try {
     window.localStorage.setItem(`${INVITE_SKIPPED_STORAGE_KEY}:${workspaceID}`, '1');
+    // Migrate forward: drop the legacy flag so we don't leave stale state behind.
+    window.localStorage.removeItem(`${INVITE_LEGACY_STORAGE_KEY}:${workspaceID}`);
   } catch {
     // Storage failures are non-fatal.
   }
@@ -1818,10 +1831,11 @@ export function ProductOverviewPage() {
   const workspacesPath = scope ? buildScopedPath(scope, 'workspaces') : '/app';
   const connectSourcesPath = scope?.projectID ? buildProjectPath(scope, scope.projectID) : projectsPath;
   const hasAnySuccessfulScan = succeededScanCount > 0;
-  const hasConnectedSource = activeProjects.some((project) => {
-    const desc = (project.description ?? '').toLowerCase();
-    return desc.includes('connector') || desc.includes('source') || desc.includes('github') || desc.includes('aws');
-  });
+  // A scan can only be queued or run if a connector is wired to the project, so
+  // "any scan attempt at all" is a sound proxy for "a source has been connected"
+  // without inferring from free-form project descriptions (which produced false
+  // positives when a project description simply mentioned a vendor name).
+  const hasConnectedSource = repoScans.length > 0;
   const onboardingChecklist: Array<{
     id: string;
     label: string;
@@ -1843,8 +1857,8 @@ export function ProductOverviewPage() {
       id: 'source',
       label: 'Connect a source',
       description: 'Attach GitHub, AWS, or Kubernetes telemetry to a project.',
-      complete: hasConnectedSource || repoScans.length > 0,
-      actionLabel: hasConnectedSource || repoScans.length > 0 ? undefined : 'Connect',
+      complete: hasConnectedSource,
+      actionLabel: hasConnectedSource ? undefined : 'Connect',
       to: connectSourcesPath
     },
     {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1293,7 +1293,11 @@ export function ProductShellLayout() {
     return <AppShellLoading message="Resolving workspace scope" />;
   }
 
-  const workspaceDisplayName = formatScopeDisplay(scope.workspaceID) || 'Workspace';
+  const rawWorkspaceLabel = formatScopeDisplay(scope.workspaceID);
+  const looksLikeSlug = /^[a-z0-9][a-z0-9._-]*$/i.test(rawWorkspaceLabel);
+  const workspaceDisplayName = looksLikeSlug
+    ? rawWorkspaceLabel.replace(/[-_]+/g, ' ').replace(/\b\w/g, (ch) => ch.toUpperCase())
+    : rawWorkspaceLabel || 'Workspace';
   const userDisplayName = 'Account';
   const userEmail = '';
   const userInitial = (workspaceDisplayName.charAt(0) || 'A').toUpperCase();
@@ -1325,8 +1329,8 @@ export function ProductShellLayout() {
               <img src="/identrail-logo.png" alt="" aria-hidden="true" />
             </Link>
             <div className="idt-app-sidebar-brand-copy">
-              <strong>Identrail</strong>
-              <span title={scope.workspaceID}>{workspaceDisplayName}</span>
+              <strong>{workspaceDisplayName}</strong>
+              <span>Identrail</span>
             </div>
           </div>
 
@@ -1566,6 +1570,30 @@ function groupRecentScans(scans: RepoScanRecord[]): ScanGroup[] {
   return groups;
 }
 
+const INVITE_DISMISSED_STORAGE_KEY = 'idt:overview:invite-dismissed';
+
+function readInviteDismissed(workspaceID: string | undefined): boolean {
+  if (typeof window === 'undefined' || !workspaceID) {
+    return false;
+  }
+  try {
+    return window.localStorage.getItem(`${INVITE_DISMISSED_STORAGE_KEY}:${workspaceID}`) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function persistInviteDismissed(workspaceID: string | undefined): void {
+  if (typeof window === 'undefined' || !workspaceID) {
+    return;
+  }
+  try {
+    window.localStorage.setItem(`${INVITE_DISMISSED_STORAGE_KEY}:${workspaceID}`, '1');
+  } catch {
+    // Storage failures are non-fatal.
+  }
+}
+
 export function ProductOverviewPage() {
   const params = useParams<ScopeRouteParams>();
   const scope = resolveScopeFromParams(params);
@@ -1736,8 +1764,8 @@ export function ProductOverviewPage() {
       id: 'invite',
       label: 'Invite a teammate',
       description: 'Give analysts and admins access to this workspace.',
-      complete: false,
-      actionLabel: 'Invite',
+      complete: readInviteDismissed(scope?.workspaceID),
+      actionLabel: readInviteDismissed(scope?.workspaceID) ? undefined : 'Invite',
       to: workspacesPath
     }
   ];
@@ -1807,7 +1835,15 @@ export function ProductOverviewPage() {
                     <span>{item.description}</span>
                   </div>
                   {item.actionLabel && item.to ? (
-                    <Link className="idt-overview-checklist-action" to={item.to}>
+                    <Link
+                      className="idt-overview-checklist-action"
+                      to={item.to}
+                      onClick={() => {
+                        if (item.id === 'invite') {
+                          persistInviteDismissed(scope?.workspaceID);
+                        }
+                      }}
+                    >
                       {item.actionLabel}
                     </Link>
                   ) : null}
@@ -1943,7 +1979,7 @@ export function ProductOverviewPage() {
           </section>
         </div>
 
-        <div className="idt-overview-grid">
+        <div className="idt-overview-grid idt-overview-grid-single">
           <section className="idt-overview-card">
             <div className="idt-overview-card-header">
               <h3>Project coverage</h3>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1155,7 +1155,18 @@ export function ProductShellLayout() {
   const [commandOpen, setCommandOpen] = useState(false);
   const [accountMenuOpen, setAccountMenuOpen] = useState(false);
   const [workspaceMenuOpen, setWorkspaceMenuOpen] = useState(false);
-  const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(() => readSidebarCollapsed());
+  const [sidebarCollapsedPref, setSidebarCollapsedPref] = useState<boolean>(() => readSidebarCollapsed());
+  const [isNarrowViewport, setIsNarrowViewport] = useState<boolean>(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return false;
+    }
+    return window.matchMedia('(max-width: 960px)').matches;
+  });
+  // The collapsed state is forced off on narrow viewports because the rail
+  // becomes a horizontal top bar there — there is no useful "collapsed" mode
+  // for a horizontal nav, and persisting a collapsed preference into mobile
+  // would otherwise leave users without a way to expand it.
+  const sidebarCollapsed = sidebarCollapsedPref && !isNarrowViewport;
   const accountMenuRef = useRef<HTMLDivElement | null>(null);
   const workspaceMenuRef = useRef<HTMLDivElement | null>(null);
   const basePath = scope ? buildScopedPath(scope) : '/app';
@@ -1257,7 +1268,7 @@ export function ProductShellLayout() {
       }
       if ((event.metaKey || event.ctrlKey) && key === 'b') {
         event.preventDefault();
-        setSidebarCollapsed((current) => !current);
+        setSidebarCollapsedPref((current) => !current);
         return;
       }
       if (!event.metaKey && !event.ctrlKey && !event.altKey && (key === '/' || key === 'f')) {
@@ -1275,11 +1286,27 @@ export function ProductShellLayout() {
       return;
     }
     try {
-      window.localStorage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, sidebarCollapsed ? '1' : '0');
+      window.localStorage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, sidebarCollapsedPref ? '1' : '0');
     } catch {
       // Storage failure should not break the layout.
     }
-  }, [sidebarCollapsed]);
+  }, [sidebarCollapsedPref]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+    const mql = window.matchMedia('(max-width: 960px)');
+    const update = () => setIsNarrowViewport(mql.matches);
+    update();
+    if (typeof mql.addEventListener === 'function') {
+      mql.addEventListener('change', update);
+      return () => mql.removeEventListener('change', update);
+    }
+    // Safari < 14 fallback.
+    mql.addListener(update);
+    return () => mql.removeListener(update);
+  }, []);
 
   useEffect(() => {
     if (!accountMenuOpen) {
@@ -1563,7 +1590,7 @@ export function ProductShellLayout() {
               aria-label={collapseHint}
               aria-pressed={sidebarCollapsed}
               title={collapseHint}
-              onClick={() => setSidebarCollapsed((current) => !current)}
+              onClick={() => setSidebarCollapsedPref((current) => !current)}
             >
               <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                 <rect x="2.5" y="3" width="11" height="10" rx="1.5" />
@@ -1645,15 +1672,19 @@ function groupRecentScans(scans: RepoScanRecord[]): ScanGroup[] {
   const groups: ScanGroup[] = [];
   scans.forEach((scan) => {
     const status = normalizeValue(scan.status).toLowerCase();
-    const reason =
-      status === 'failed' || status === 'canceled'
-        ? summarizeScanFailure(scan)
-        : status === 'succeeded' || status === 'completed'
-          ? `${scan.finding_count} findings · ${scan.files_scanned} files`
-          : 'In progress';
+    const isFailure = status === 'failed' || status === 'canceled';
+    const reason = isFailure
+      ? summarizeScanFailure(scan)
+      : status === 'succeeded' || status === 'completed'
+        ? `${scan.finding_count} findings · ${scan.files_scanned} files`
+        : 'In progress';
     const repo = canonicalGitHubRepositoryDisplay(scan.repository) || scan.repository;
     const last = groups[groups.length - 1];
-    if (last && last.status === status && last.reason === reason) {
+    // Only collapse consecutive failures with the same reason. Successful and
+    // running scans are independent events even when their human-readable
+    // summary happens to match, so we render each as its own row to preserve
+    // accurate activity history.
+    if (isFailure && last && last.status === status && last.reason === reason) {
       last.count += 1;
       if (!last.repos.includes(repo)) {
         last.repos.push(repo);
@@ -1671,30 +1702,62 @@ const INVITE_SKIPPED_STORAGE_KEY = 'idt:overview:invite-skipped';
 // the checklist regress.
 const INVITE_LEGACY_STORAGE_KEY = 'idt:overview:invite-dismissed';
 
-function readInviteSkipped(workspaceID: string | undefined): boolean {
-  if (typeof window === 'undefined' || !workspaceID) {
+function inviteScopeKey(tenantID: string | undefined, workspaceID: string | undefined): string | null {
+  if (!tenantID || !workspaceID) {
+    return null;
+  }
+  return `${tenantID}:${workspaceID}`;
+}
+
+function readInviteSkipped(tenantID: string | undefined, workspaceID: string | undefined): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  const scope = inviteScopeKey(tenantID, workspaceID);
+  if (!scope) {
     return false;
   }
   try {
-    const fresh = window.localStorage.getItem(`${INVITE_SKIPPED_STORAGE_KEY}:${workspaceID}`);
+    const fresh = window.localStorage.getItem(`${INVITE_SKIPPED_STORAGE_KEY}:${scope}`);
     if (fresh === '1') {
       return true;
     }
-    const legacy = window.localStorage.getItem(`${INVITE_LEGACY_STORAGE_KEY}:${workspaceID}`);
-    return legacy === '1';
+    // Back-compat: earlier builds keyed by workspaceID alone. Honor that flag so
+    // upgraded users don't see the checklist regress, but only when no later
+    // tenant-scoped flag has been written.
+    const legacyTenantScoped = window.localStorage.getItem(`${INVITE_LEGACY_STORAGE_KEY}:${scope}`);
+    if (legacyTenantScoped === '1') {
+      return true;
+    }
+    if (workspaceID) {
+      const legacyWorkspaceOnly =
+        window.localStorage.getItem(`${INVITE_SKIPPED_STORAGE_KEY}:${workspaceID}`) ||
+        window.localStorage.getItem(`${INVITE_LEGACY_STORAGE_KEY}:${workspaceID}`);
+      return legacyWorkspaceOnly === '1';
+    }
+    return false;
   } catch {
     return false;
   }
 }
 
-function persistInviteSkipped(workspaceID: string | undefined): void {
-  if (typeof window === 'undefined' || !workspaceID) {
+function persistInviteSkipped(tenantID: string | undefined, workspaceID: string | undefined): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const scope = inviteScopeKey(tenantID, workspaceID);
+  if (!scope) {
     return;
   }
   try {
-    window.localStorage.setItem(`${INVITE_SKIPPED_STORAGE_KEY}:${workspaceID}`, '1');
-    // Migrate forward: drop the legacy flag so we don't leave stale state behind.
-    window.localStorage.removeItem(`${INVITE_LEGACY_STORAGE_KEY}:${workspaceID}`);
+    window.localStorage.setItem(`${INVITE_SKIPPED_STORAGE_KEY}:${scope}`, '1');
+    // Migrate forward: drop the old workspace-only and dismissed flags so we
+    // don't leave stale state behind for the same workspace.
+    window.localStorage.removeItem(`${INVITE_LEGACY_STORAGE_KEY}:${scope}`);
+    if (workspaceID) {
+      window.localStorage.removeItem(`${INVITE_SKIPPED_STORAGE_KEY}:${workspaceID}`);
+      window.localStorage.removeItem(`${INVITE_LEGACY_STORAGE_KEY}:${workspaceID}`);
+    }
   } catch {
     // Storage failures are non-fatal.
   }
@@ -1873,10 +1936,10 @@ export function ProductOverviewPage() {
       id: 'invite',
       label: 'Invite a teammate',
       description: 'Give analysts and admins access to this workspace.',
-      complete: readInviteSkipped(scope?.workspaceID),
-      actionLabel: readInviteSkipped(scope?.workspaceID) ? undefined : 'Invite',
+      complete: readInviteSkipped(scope?.tenantID, scope?.workspaceID),
+      actionLabel: readInviteSkipped(scope?.tenantID, scope?.workspaceID) ? undefined : 'Invite',
       to: workspacesPath,
-      skippable: !readInviteSkipped(scope?.workspaceID)
+      skippable: !readInviteSkipped(scope?.tenantID, scope?.workspaceID)
     }
   ];
   const onboardingComplete = onboardingChecklist.every((item) => item.complete);
@@ -1942,7 +2005,7 @@ export function ProductOverviewPage() {
                         type="button"
                         className="idt-overview-checklist-skip"
                         onClick={() => {
-                          persistInviteSkipped(scope?.workspaceID);
+                          persistInviteSkipped(scope?.tenantID, scope?.workspaceID);
                           setInviteSkipTick((value) => value + 1);
                         }}
                         aria-label={`Skip: ${item.label}`}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -21941,10 +21941,10 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   .idt-app-console-layout .idt-app-nav-group-label {
     display: none;
   }
-  /* Collapse button + sidebar account caret aren't useful when the rail is a top bar. */
-  .idt-app-console-layout .idt-app-sidebar-collapse {
-    display: none;
-  }
+  /* Collapsed mode is forced off on narrow viewports by JS (the rail becomes a
+   * top bar, where "collapsed" has no useful meaning). The toggle button is
+   * still rendered so a user who resizes back to desktop has an obvious path
+   * out of any previously-persisted collapsed preference. */
 }
 
 /* === Workspace overview polish (preview-driven) === */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -18608,9 +18608,18 @@ html[data-theme='light'] .idt-legal-contact-panel .idt-btn-primary {
   grid-template-rows: auto auto auto minmax(0, 1fr) auto;
   gap: 1rem;
   padding: 1rem;
-  overflow-y: auto;
+  /* Sidebar must allow overflow so flyout menus (workspace switcher / account
+   * menu) can render outside the rail in collapsed mode without being clipped
+   * by an overflow:auto scroll container. The inner nav handles its own
+   * vertical scroll when there are more nav items than fit. */
+  overflow: visible;
   border-right: 1px solid var(--app-border);
   background: #050506;
+}
+
+.idt-app-console-layout .idt-app-shell-nav {
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .idt-app-sidebar-brand {
@@ -22264,4 +22273,15 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   color: #000000;
   border-color: #ffffff;
   outline: none;
+}
+
+.idt-app-console-layout .idt-overview-metric-breakdown span.is-muted {
+  color: var(--app-dim);
+}
+
+.idt-app-console-layout .idt-overview-metric-breakdown span.is-muted::before {
+  background: transparent;
+  border: 1px solid currentColor;
+  width: 0.4rem;
+  height: 0.4rem;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -21907,3 +21907,57 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
     grid-template-columns: 1fr;
   }
 }
+
+/* === Workspace overview polish (preview-driven) === */
+
+.idt-app-console-layout .idt-overview-grid-single {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.idt-app-console-layout .idt-overview-checklist li[data-complete='true'] .idt-overview-checklist-body span {
+  color: #5a5a62;
+}
+
+/* Quieter empty-state inside cards */
+.idt-app-console-layout .idt-overview-card .idt-app-empty-state {
+  padding: 0.85rem 0;
+  gap: 0.35rem;
+}
+
+.idt-app-console-layout .idt-overview-card .idt-app-empty-state h3,
+.idt-app-console-layout .idt-overview-card .idt-app-empty-state h2 {
+  font-size: 0.98rem;
+  font-weight: 600;
+}
+
+.idt-app-console-layout .idt-overview-card .idt-app-empty-state p {
+  font-size: 0.85rem;
+}
+
+/* Slightly larger nav + quick-find icons */
+.idt-app-console-layout .idt-app-nav-icon svg,
+.idt-app-console-layout .idt-app-quick-find-icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.idt-app-console-layout .idt-app-nav-icon {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+/* Larger Overview heading */
+.idt-app-console-layout .idt-overview-header h2 {
+  font-size: clamp(1.85rem, 2.4vw, 2.25rem);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+/* Collapsed quick-find: visually match nav icons */
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-quick-find {
+  width: 2.15rem;
+  height: 2.15rem;
+  margin: 0 auto;
+  border-radius: 7px;
+  padding: 0;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -21788,27 +21788,8 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   overflow: hidden;
 }
 
-.idt-app-console-layout .idt-overview-scan-row::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 2px;
-  background: transparent;
-}
-
-.idt-app-console-layout .idt-overview-scan-row.is-failure::before {
-  background: #ff6b6b;
-}
-
-.idt-app-console-layout .idt-overview-scan-row.is-active::before {
-  background: #f0c66b;
-}
-
-.idt-app-console-layout .idt-overview-scan-row.is-success::before {
-  background: #6ed29c;
-}
+/* Status is communicated via the badge alone; the colored left stripe has been
+ * removed to avoid triple-encoding the same signal (badge + KPI dot + stripe). */
 
 .idt-app-console-layout .idt-overview-scan-row strong,
 .idt-app-console-layout .idt-overview-risk-row strong {
@@ -21906,6 +21887,14 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   .idt-app-console-layout.is-sidebar-collapsed {
     grid-template-columns: 1fr;
   }
+  /* Section labels add no value in the horizontal mobile nav. */
+  .idt-app-console-layout .idt-app-nav-group-label {
+    display: none;
+  }
+  /* Collapse button + sidebar account caret aren't useful when the rail is a top bar. */
+  .idt-app-console-layout .idt-app-sidebar-collapse {
+    display: none;
+  }
 }
 
 /* === Workspace overview polish (preview-driven) === */
@@ -21960,4 +21949,269 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   margin: 0 auto;
   border-radius: 7px;
   padding: 0;
+}
+
+/* === Workspace switcher, nav groups, a11y label rescue === */
+
+.idt-app-sidebar-workspace {
+  position: relative;
+}
+
+.idt-app-console-layout .idt-app-sidebar-workspace-trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.4rem 0.45rem;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.12s ease, border-color 0.12s ease;
+}
+
+.idt-app-console-layout .idt-app-sidebar-workspace-trigger:hover,
+.idt-app-console-layout .idt-app-sidebar-workspace-trigger:focus-visible,
+.idt-app-console-layout .idt-app-sidebar-workspace-trigger[aria-expanded='true'] {
+  background: #131318;
+  border-color: var(--app-border-soft);
+  outline: none;
+}
+
+.idt-app-console-layout .idt-app-sidebar-workspace-trigger .idt-app-sidebar-mark {
+  width: 1.7rem;
+  height: 1.7rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  background: #ffffff;
+  flex: 0 0 auto;
+  overflow: hidden;
+}
+
+.idt-app-console-layout .idt-app-sidebar-workspace-trigger .idt-app-sidebar-mark img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.idt-app-sidebar-workspace-copy {
+  display: grid;
+  gap: 0.05rem;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.idt-app-sidebar-workspace-copy strong {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #ffffff;
+  font-size: 0.92rem;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+}
+
+.idt-app-sidebar-workspace-copy span {
+  display: block;
+  color: #85858f;
+  font-size: 0.74rem;
+}
+
+.idt-app-sidebar-workspace-caret {
+  color: #85858f;
+  flex: 0 0 auto;
+}
+
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-workspace-copy,
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-workspace-caret {
+  display: none;
+}
+
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-workspace-trigger {
+  justify-content: center;
+  padding: 0.35rem 0;
+}
+
+.idt-app-sidebar-workspace-menu {
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  left: 0;
+  right: 0;
+  z-index: 20;
+  display: grid;
+  gap: 0.1rem;
+  padding: 0.4rem;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: #0d0d10;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+}
+
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-workspace-menu {
+  left: calc(100% + 0.4rem);
+  right: auto;
+  top: 0;
+  width: 13rem;
+}
+
+.idt-app-sidebar-workspace-meta {
+  display: grid;
+  gap: 0.1rem;
+  padding: 0.45rem 0.5rem 0.55rem;
+  border-bottom: 1px solid var(--app-border-soft);
+  margin-bottom: 0.25rem;
+}
+
+.idt-app-sidebar-workspace-meta-eyebrow {
+  color: #85858f;
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.idt-app-sidebar-workspace-meta strong {
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.idt-app-sidebar-workspace-menu a,
+.idt-app-sidebar-workspace-menu button {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 0.42rem 0.55rem;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: #d4d4dc;
+  font: inherit;
+  font-size: 0.86rem;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.idt-app-sidebar-workspace-menu a:hover,
+.idt-app-sidebar-workspace-menu a:focus-visible,
+.idt-app-sidebar-workspace-menu button:hover,
+.idt-app-sidebar-workspace-menu button:focus-visible {
+  background: #1c1c22;
+  color: #ffffff;
+  outline: none;
+}
+
+/* Nav section labels */
+.idt-app-nav-group-label {
+  padding: 0.65rem 0.6rem 0.25rem;
+  color: #5a5a62;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-nav-group-label {
+  display: none;
+}
+
+/* a11y: keep nav labels available to AT in collapsed mode */
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-nav-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+  display: block;
+}
+
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-quick-find-label,
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-quick-find-key,
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-account-name,
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-account-caret {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Overview header subtitle: small, muted */
+.idt-app-console-layout .idt-overview-header-sub {
+  margin: 0.4rem 0 0;
+  color: var(--app-dim);
+  font-size: 0.82rem;
+  letter-spacing: 0;
+}
+
+/* Checklist actions row */
+.idt-overview-checklist-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.idt-app-console-layout .idt-overview-checklist-skip {
+  padding: 0.32rem 0.55rem;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--app-dim);
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.idt-app-console-layout .idt-overview-checklist-skip:hover,
+.idt-app-console-layout .idt-overview-checklist-skip:focus-visible {
+  background: #131318;
+  color: #ffffff;
+  outline: none;
+}
+
+/* Empty-state action button */
+.idt-app-console-layout .idt-app-empty-state {
+  display: grid;
+  gap: 0.45rem;
+  justify-items: center;
+  text-align: center;
+}
+
+.idt-app-console-layout .idt-app-empty-state-action {
+  margin-top: 0.4rem;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.42rem 0.85rem;
+  border: 1px solid var(--app-border);
+  border-radius: 7px;
+  background: #0d0d10;
+  color: #ffffff;
+  font-size: 0.84rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background-color 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+
+.idt-app-console-layout .idt-app-empty-state-action:hover,
+.idt-app-console-layout .idt-app-empty-state-action:focus-visible {
+  background: #ffffff;
+  color: #000000;
+  border-color: #ffffff;
+  outline: none;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -21157,3 +21157,753 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
     display: none;
   }
 }
+/* === Workspace shell redesign === */
+
+.idt-app-console-layout {
+  grid-template-columns: 15.5rem minmax(0, 1fr);
+  transition: grid-template-columns 0.2s ease;
+}
+
+.idt-app-console-layout.is-sidebar-collapsed {
+  grid-template-columns: 3.75rem minmax(0, 1fr);
+}
+
+.idt-app-console-layout .idt-app-sidebar {
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  padding: 0.85rem 0.65rem 0.85rem 0.65rem;
+}
+
+.idt-app-console-layout .idt-app-sidebar-brand {
+  padding: 0.25rem 0.35rem;
+  gap: 0.6rem;
+  min-width: 0;
+}
+
+.idt-app-console-layout .idt-app-sidebar-brand-copy {
+  min-width: 0;
+}
+
+.idt-app-console-layout .idt-app-sidebar-brand-copy strong {
+  font-size: 0.95rem;
+  letter-spacing: -0.01em;
+}
+
+.idt-app-console-layout .idt-app-sidebar-brand-copy span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #9b9ba6;
+  font-size: 0.78rem;
+}
+
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-brand-copy,
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-quick-find-label,
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-quick-find-key,
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-nav-label,
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-account-name,
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-account-caret {
+  display: none;
+}
+
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-quick-find {
+  justify-content: center;
+  padding: 0.55rem 0;
+}
+
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-shell-nav a {
+  justify-content: center;
+  padding: 0.55rem 0;
+}
+
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-account-trigger {
+  justify-content: center;
+  padding: 0.4rem 0;
+}
+
+.idt-app-console-layout .idt-app-quick-find {
+  border-radius: 7px;
+  padding: 0.48rem 0.6rem;
+  gap: 0.55rem;
+  font-weight: 600;
+  background: transparent;
+  border-color: var(--app-border-soft);
+  color: #d4d4dc;
+}
+
+.idt-app-console-layout .idt-app-quick-find-icon {
+  display: inline-flex;
+  color: #85858f;
+}
+
+.idt-app-console-layout .idt-app-quick-find-label {
+  flex: 1 1 auto;
+  font-size: 0.86rem;
+  color: #d4d4dc;
+}
+
+.idt-app-console-layout .idt-app-quick-find-key {
+  min-width: auto;
+  padding: 0.08rem 0.3rem;
+  background: transparent;
+  border-color: var(--app-border-soft);
+  color: #85858f;
+  font-size: 0.68rem;
+  font-weight: 600;
+}
+
+.idt-app-console-layout .idt-app-quick-find:hover,
+.idt-app-console-layout .idt-app-quick-find:focus-visible {
+  border-color: var(--app-border);
+  background: #0d0d10;
+}
+
+.idt-app-console-layout .idt-app-shell-nav {
+  gap: 0.1rem;
+}
+
+.idt-app-console-layout .idt-app-shell-nav a {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  min-height: 2.15rem;
+  padding: 0.45rem 0.6rem;
+  border-radius: 7px;
+  border-color: transparent;
+  background: transparent;
+  color: #a3a3ac;
+  font-size: 0.9rem;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  transition: background-color 0.12s ease, color 0.12s ease;
+}
+
+.idt-app-console-layout .idt-app-shell-nav a:hover,
+.idt-app-console-layout .idt-app-shell-nav a:focus-visible {
+  background: #131318;
+  color: #ffffff;
+  border-color: transparent;
+}
+
+.idt-app-console-layout .idt-app-shell-nav a.active {
+  background: #1c1c22;
+  color: #ffffff;
+  border-color: transparent;
+}
+
+.idt-app-console-layout .idt-app-nav-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.1rem;
+  height: 1.1rem;
+  flex: 0 0 auto;
+  color: #85858f;
+}
+
+.idt-app-console-layout .idt-app-shell-nav a:hover .idt-app-nav-icon,
+.idt-app-console-layout .idt-app-shell-nav a:focus-visible .idt-app-nav-icon,
+.idt-app-console-layout .idt-app-shell-nav a.active .idt-app-nav-icon {
+  color: #ffffff;
+}
+
+.idt-app-console-layout .idt-app-nav-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.idt-app-console-layout .idt-app-sidebar-footer {
+  align-self: end;
+  display: grid;
+  gap: 0.4rem;
+  padding: 0;
+  border: none;
+  background: transparent;
+  border-top: 1px solid var(--app-border-soft);
+  padding-top: 0.6rem;
+}
+
+.idt-app-sidebar-account {
+  position: relative;
+}
+
+.idt-app-console-layout .idt-app-sidebar-account-trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  width: 100%;
+  padding: 0.4rem 0.45rem;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.12s ease, border-color 0.12s ease;
+}
+
+.idt-app-console-layout .idt-app-sidebar-account-trigger:hover,
+.idt-app-console-layout .idt-app-sidebar-account-trigger:focus-visible,
+.idt-app-console-layout .idt-app-sidebar-account-trigger[aria-expanded='true'] {
+  background: #131318;
+  border-color: var(--app-border-soft);
+  outline: none;
+}
+
+.idt-app-console-layout .idt-app-sidebar-account-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.7rem;
+  height: 1.7rem;
+  border-radius: 999px;
+  background: #1f1f26;
+  color: #ffffff;
+  font-size: 0.78rem;
+  font-weight: 700;
+  flex: 0 0 auto;
+}
+
+.idt-app-console-layout .idt-app-sidebar-account-name {
+  display: grid;
+  gap: 0.05rem;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.idt-app-console-layout .idt-app-sidebar-account-name strong {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #ffffff;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.idt-app-console-layout .idt-app-sidebar-account-name span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #85858f;
+  font-size: 0.74rem;
+}
+
+.idt-app-console-layout .idt-app-sidebar-account-caret {
+  color: #85858f;
+  flex: 0 0 auto;
+}
+
+.idt-app-sidebar-account-menu {
+  position: absolute;
+  bottom: calc(100% + 0.4rem);
+  left: 0;
+  right: 0;
+  z-index: 20;
+  display: grid;
+  gap: 0.1rem;
+  padding: 0.4rem;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: #0d0d10;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+}
+
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-account-menu {
+  left: calc(100% + 0.4rem);
+  right: auto;
+  bottom: 0;
+  width: 12rem;
+}
+
+.idt-app-sidebar-account-meta {
+  display: grid;
+  gap: 0.1rem;
+  padding: 0.45rem 0.5rem 0.55rem;
+  border-bottom: 1px solid var(--app-border-soft);
+  margin-bottom: 0.25rem;
+}
+
+.idt-app-sidebar-account-meta strong {
+  color: #ffffff;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.idt-app-sidebar-account-meta span {
+  color: #85858f;
+  font-size: 0.74rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.idt-app-sidebar-account-menu a,
+.idt-app-sidebar-account-menu button {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 0.42rem 0.55rem;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: #d4d4dc;
+  font: inherit;
+  font-size: 0.86rem;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.idt-app-sidebar-account-menu a:hover,
+.idt-app-sidebar-account-menu a:focus-visible,
+.idt-app-sidebar-account-menu button:hover,
+.idt-app-sidebar-account-menu button:focus-visible {
+  background: #1c1c22;
+  color: #ffffff;
+  outline: none;
+}
+
+.idt-app-console-layout .idt-app-sidebar-collapse {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.85rem;
+  height: 1.85rem;
+  margin-left: auto;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: #85858f;
+  cursor: pointer;
+  transition: background-color 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-collapse {
+  margin-left: 0;
+  align-self: center;
+  justify-self: center;
+}
+
+.idt-app-console-layout .idt-app-sidebar-collapse:hover,
+.idt-app-console-layout .idt-app-sidebar-collapse:focus-visible {
+  background: #131318;
+  color: #ffffff;
+  border-color: var(--app-border-soft);
+  outline: none;
+}
+
+/* Console main area */
+
+.idt-app-console-layout .idt-app-console {
+  grid-template-rows: minmax(0, 1fr);
+}
+
+.idt-app-console-layout .idt-app-shell-main {
+  padding: 1.75rem clamp(1.25rem, 4vw, 2.75rem) 3.5rem;
+}
+
+/* Overview panel polish */
+
+.idt-app-console-layout .idt-overview-page {
+  background: transparent;
+  border: none;
+  padding: 0;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.idt-app-console-layout .idt-overview-header {
+  align-items: center;
+  padding: 0 0 0.25rem;
+}
+
+.idt-app-console-layout .idt-overview-header h2 {
+  margin: 0;
+  font-family: var(--idt-display);
+  font-size: clamp(1.55rem, 2vw, 1.95rem);
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  color: #ffffff;
+  line-height: 1.1;
+}
+
+.idt-app-console-layout .idt-overview-header p {
+  margin: 0.35rem 0 0;
+  color: var(--app-muted);
+  font-size: 0.92rem;
+}
+
+.idt-app-console-layout .idt-overview-checklist {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1.05rem 1.1rem;
+  border: 1px solid var(--app-border-soft);
+  border-radius: 10px;
+  background: linear-gradient(180deg, #0c0c0f 0%, #08080a 100%);
+}
+
+.idt-app-console-layout .idt-overview-checklist header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.idt-app-console-layout .idt-overview-checklist header h3 {
+  margin: 0;
+  font-family: var(--idt-display);
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #ffffff;
+  letter-spacing: -0.005em;
+}
+
+.idt-app-console-layout .idt-overview-checklist header p {
+  margin: 0;
+  color: var(--app-dim);
+  font-size: 0.82rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.idt-app-console-layout .idt-overview-checklist ol {
+  display: grid;
+  gap: 0.1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.idt-app-console-layout .idt-overview-checklist li {
+  display: grid;
+  grid-template-columns: 1.25rem minmax(0, 1fr) auto;
+  gap: 0.7rem;
+  align-items: center;
+  padding: 0.55rem 0.4rem;
+  border-radius: 7px;
+  border: 1px solid transparent;
+  transition: background-color 0.12s ease, border-color 0.12s ease;
+}
+
+.idt-app-console-layout .idt-overview-checklist li:hover {
+  background: #0e0e11;
+  border-color: var(--app-border-soft);
+}
+
+.idt-overview-checklist-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.1rem;
+  height: 1.1rem;
+  border: 1px solid var(--app-border);
+  border-radius: 999px;
+  color: transparent;
+}
+
+.idt-app-console-layout .idt-overview-checklist li[data-complete='true'] .idt-overview-checklist-mark {
+  background: #ffffff;
+  border-color: #ffffff;
+  color: #000000;
+}
+
+.idt-overview-checklist-body {
+  min-width: 0;
+  display: grid;
+  gap: 0.1rem;
+}
+
+.idt-overview-checklist-body strong {
+  color: #ffffff;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+.idt-overview-checklist-body span {
+  color: var(--app-dim);
+  font-size: 0.82rem;
+}
+
+.idt-app-console-layout .idt-overview-checklist li[data-complete='true'] .idt-overview-checklist-body strong {
+  color: var(--app-muted);
+  text-decoration: line-through;
+  text-decoration-color: #4a4a52;
+}
+
+.idt-app-console-layout .idt-overview-checklist-action {
+  padding: 0.32rem 0.65rem;
+  border: 1px solid var(--app-border);
+  border-radius: 6px;
+  background: #0d0d10;
+  color: #ffffff;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background-color 0.12s ease, border-color 0.12s ease;
+}
+
+.idt-app-console-layout .idt-overview-checklist-action:hover,
+.idt-app-console-layout .idt-overview-checklist-action:focus-visible {
+  background: #ffffff;
+  color: #000000;
+  border-color: #ffffff;
+}
+
+/* Metric cards */
+
+.idt-app-console-layout .idt-overview-metrics {
+  gap: 0.6rem;
+}
+
+.idt-app-console-layout .idt-overview-metrics article {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--app-border-soft);
+  border-radius: 10px;
+  background: #0a0a0c;
+}
+
+.idt-app-console-layout .idt-overview-metrics article.is-attention {
+  border-color: rgba(255, 107, 107, 0.35);
+  background: linear-gradient(180deg, rgba(255, 107, 107, 0.05) 0%, #0a0a0c 100%);
+}
+
+.idt-app-console-layout .idt-overview-metric-label {
+  display: block;
+  margin: 0;
+  color: var(--app-dim);
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.idt-app-console-layout .idt-overview-metrics strong {
+  font-family: var(--idt-display);
+  font-size: 1.85rem;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+  color: #ffffff;
+  margin: 0;
+  line-height: 1;
+}
+
+.idt-app-console-layout .idt-overview-metrics p {
+  margin: 0;
+  color: var(--app-muted);
+  font-size: 0.82rem;
+  line-height: 1.3;
+}
+
+.idt-app-console-layout .idt-overview-metric-breakdown {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.7rem;
+}
+
+.idt-app-console-layout .idt-overview-metric-breakdown span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  font-size: 0.78rem;
+  font-weight: 500;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.idt-app-console-layout .idt-overview-metric-breakdown span::before {
+  content: '';
+  display: inline-block;
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.idt-app-console-layout .idt-overview-metric-breakdown span.is-success {
+  color: #6ed29c;
+}
+
+.idt-app-console-layout .idt-overview-metric-breakdown span.is-error {
+  color: #ff8585;
+}
+
+.idt-app-console-layout .idt-overview-metric-breakdown span.is-warning {
+  color: #f0c66b;
+}
+
+/* Cards */
+
+.idt-app-console-layout .idt-overview-card {
+  border: 1px solid var(--app-border-soft);
+  background: #0a0a0c;
+  border-radius: 10px;
+  padding: 1rem 1.1rem;
+  gap: 0.75rem;
+}
+
+.idt-app-console-layout .idt-overview-card-header {
+  align-items: baseline;
+}
+
+.idt-app-console-layout .idt-overview-card-header h3 {
+  margin: 0;
+  font-family: var(--idt-display);
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  color: #ffffff;
+}
+
+.idt-app-console-layout .idt-overview-card-header a {
+  color: var(--app-muted);
+  font-size: 0.84rem;
+  font-weight: 500;
+}
+
+.idt-app-console-layout .idt-overview-card-header a:hover,
+.idt-app-console-layout .idt-overview-card-header a:focus-visible {
+  color: #ffffff;
+  text-decoration: none;
+}
+
+/* Scan rows */
+
+.idt-app-console-layout .idt-overview-scan-row,
+.idt-app-console-layout .idt-overview-risk-row {
+  position: relative;
+  padding: 0.7rem 0.8rem 0.7rem 0.95rem;
+  background: transparent;
+  border: 1px solid var(--app-border-soft);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.idt-app-console-layout .idt-overview-scan-row::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: transparent;
+}
+
+.idt-app-console-layout .idt-overview-scan-row.is-failure::before {
+  background: #ff6b6b;
+}
+
+.idt-app-console-layout .idt-overview-scan-row.is-active::before {
+  background: #f0c66b;
+}
+
+.idt-app-console-layout .idt-overview-scan-row.is-success::before {
+  background: #6ed29c;
+}
+
+.idt-app-console-layout .idt-overview-scan-row strong,
+.idt-app-console-layout .idt-overview-risk-row strong {
+  color: #ffffff;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+.idt-app-console-layout .idt-overview-scan-row p,
+.idt-app-console-layout .idt-overview-risk-row p {
+  color: var(--app-muted);
+  font-size: 0.83rem;
+  margin-top: 0.15rem;
+}
+
+.idt-overview-scan-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.18rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.idt-overview-scan-badge.is-error {
+  background: rgba(255, 107, 107, 0.12);
+  color: #ff8c8c;
+}
+
+.idt-overview-scan-badge.is-warning {
+  background: rgba(240, 198, 107, 0.12);
+  color: #f0c66b;
+}
+
+.idt-overview-scan-badge.is-success {
+  background: rgba(110, 210, 156, 0.12);
+  color: #6ed29c;
+}
+
+/* Projects */
+
+.idt-app-console-layout .idt-overview-projects a {
+  border-color: var(--app-border-soft);
+  background: #0a0a0c;
+  padding: 0.85rem 1rem;
+}
+
+.idt-app-console-layout .idt-overview-projects a:hover,
+.idt-app-console-layout .idt-overview-projects a:focus-visible {
+  border-color: var(--app-border);
+  background: #0d0d10;
+  transform: none;
+}
+
+.idt-app-console-layout .idt-overview-projects strong {
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.idt-app-console-layout .idt-overview-projects span {
+  color: var(--app-muted);
+  font-size: 0.85rem;
+}
+
+.idt-app-console-layout .idt-overview-projects small {
+  color: var(--app-dim);
+  font-size: 0.78rem;
+}
+
+/* Hide legacy header that no longer renders */
+.idt-app-console-layout .idt-app-shell-header {
+  display: none;
+}
+
+/* Collapsed sidebar tweaks */
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar {
+  padding-left: 0.4rem;
+  padding-right: 0.4rem;
+}
+
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-footer {
+  justify-items: center;
+}
+
+@media (max-width: 960px) {
+  .idt-app-console-layout {
+    grid-template-columns: 1fr;
+  }
+  .idt-app-console-layout .idt-app-sidebar {
+    position: relative;
+    height: auto;
+  }
+  .idt-app-console-layout.is-sidebar-collapsed {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary

Strip the legacy operations-console chrome and rebuild the workspace overview around a quieter, Linear-style shell — addressing the visual-noise / first-run-state issues reviewed inline.

### Sidebar
- Removed the raw `ACTIVE SCOPE / TENANT t-…` block (database identifiers were leaking into the chrome).
- Replaced the three shortcut chips (`/`, `F`, `⌘K`) with a single `⌘K` hint.
- Added icons for every nav item and a collapsible mode — toggle button at the footer plus `⌘B` / `Ctrl+B` keyboard shortcut, with the shortcut surfaced as a hover tooltip on the toggle. Collapse state persists in `localStorage`.
- Moved `Sign out`, `Marketing site`, and `Workspace settings` into an avatar menu at the bottom of the sidebar so they stop competing as primary actions.
- Removed the cryptic `Workspace mode / Read-only evidence first` footer string.
- Hoisted the workspace label into the brand row.

### Header
- Deleted the `OPERATIONS CONSOLE` eyebrow and the `Identrail workspace` H1 (both redundant — the H1 didn't even use the real workspace name).
- Deleted the marketing-copy source strip (`GitHub and AWS signals stay visible across the workflow.` etc.).
- Deleted the three top-right buttons. `Account security` now lives only in Settings, where it belongs.

### Overview body
- Sentence-case section titles. Killed the `WORKSPACE OVERVIEW` / `PRIORITY QUEUE` / `SCAN ACTIVITY` / `COVERAGE` / `NEXT ACTIONS` ALL CAPS eyebrows.
- Killed the floating `Evidence queue / Connector health / Remediation owners` pill row that wasn't clickable.
- Fixed the contradictory KPI: the previous card said "5 completed" while the activity list showed 5 Failed scans. The card now reads `Scans (7d)` with a `succeeded · failed · running` breakdown and turns into an attention state when failure dominates.
- Scan activity rows now communicate **why** a scan failed (inferred from `error_message`: rate limit, auth expiry, timeout, repo missing, forbidden, raw), collapse consecutive identical failures into a single row with a count, and show a colored left-edge stripe instead of a single high-contrast red pill.
- Replaced the four static `Next actions` cards with a real onboarding checklist that auto-completes against actual workspace state (project exists, source connected, scan succeeded, teammate invited).

### Implementation notes
- The legacy `.idt-app-shell-header` is hidden via CSS inside the console layout rather than ripped out of every consumer — the Account Security route and other panels that share the class keep rendering normally.
- No new API calls. The sidebar derives its workspace label from the URL scope (kept light to avoid adding a second `useMe` fetch that would interleave unpredictably with existing test mock chains).
- All copy that referenced raw tenant/workspace IDs in body text has been replaced.

## Validation

- `npm run test:ci --prefix web` → 13 files, 155 tests, all green
- `npm run build --prefix web` → builds cleanly, 41 prerendered routes
- `npx tsc --noEmit` in `web/` → clean

## Risk / impact

- UI-only change; no API contracts, schemas, or migrations touched.
- Test fixtures for the overview heading + KPI copy were updated alongside (`web/src/App.test.tsx`, `web/src/productShell.test.tsx`).
- Sidebar collapse uses `localStorage` (`idt:sidebar:collapsed`). Falls back gracefully if storage is blocked.

## AI-Assisted disclosure

- **AI-assisted:** yes
- **Tools used:** Claude Code (Opus 4.7)
- **Where used:** `web/src/productShell.tsx`, `web/src/styles.css`, test updates in `web/src/App.test.tsx`, `web/src/productShell.test.tsx`
- **Human verification performed:** read the changed regions of `productShell.tsx` end-to-end; ran `npm run test:ci` and `npm run build` against the rebuilt branch; resolved the styles.css base/append conflict by reseating my additions on top of fresh `origin/dev`; verified the previously-passing test suite stayed at the same count plus the redesign-specific assertions.

## Test plan

- [ ] Verify the dashboard loads with no raw tenant/workspace IDs visible in the chrome.
- [ ] Verify `⌘B` / `Ctrl+B` toggles the sidebar and that the toggle button shows the shortcut on hover.
- [ ] Verify the avatar menu opens, closes on outside click + `Esc`, and that `Sign out` still routes to `/app/logout`.
- [ ] With the same five failed `identrail/identrail` scans visible in the screenshots: confirm they collapse into one row with `5 scans · <reason> · <relative time>` and that the KPI card shows `0 succeeded · 5 failed` instead of "5 completed".
- [ ] Run a successful scan and confirm the `Run your first scan` checklist item auto-checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigns the workspace overview and app shell for a calmer first‑run with clearer signals, plus follow‑up fixes from preview and review. UI‑only; no API changes.

- **New Features**
  - Sidebar: collapsible with ⌘B/Ctrl+B; workspace switcher in the brand row; avatar menu adds Help & docs; grouped “Workspace”/“Organization” nav; collapse persisted in `localStorage` (`idt:sidebar:collapsed`) with a tooltip hint.
  - Finder: single ⌘K quick find; legacy chrome removed.
  - Overview: onboarding checklist auto‑completes; Invite step is skippable; empty‑state CTAs (Run a scan / Connect a source / Create project); recent scans dedupe only consecutive failures with inferred reasons and muted status badges; project cards show relative timestamps.
  - Metrics: Recent scans shows succeeded/failed/running with an attention state when failures dominate and a “last 5” pill when limited; Trend copy refined and hidden until data exists.

- **Bug Fixes**
  - Invite completion: only completes when the user clicks Skip; persisted per tenant+workspace via `localStorage` (`idt:overview:invite-skipped`) with migration from legacy workspace‑only `…:invite-skipped` and `…:invite-dismissed`.
  - Source connection signal: checklist marks “Connect a source” complete only after any scan attempt (avoids false positives from project text).
  - Collapsed nav a11y and mobile behavior: explicit `aria-label`s on nav links plus workspace switcher and account triggers; labels remain available to screen readers when icons only; ignore the persisted collapse on narrow viewports, while keeping the toggle visible.
  - Sidebar flyouts: move overflow handling to the inner nav so workspace/account menus aren’t clipped when the rail is collapsed.
  - Brand row: show a humanized workspace name (e.g., “Workspace A”) with “Identrail” as the secondary line.
  - Visual polish: Project coverage promoted to a full‑width card; larger nav/quick‑find icons and Overview heading; collapsed quick‑find matches the nav icon footprint.

<sup>Written for commit 6434c9cce9f6920a98a7509536d07cf5b555ebf9. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1270?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

