### PR TITLE
Add repo finding lifecycle intelligence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## Unreleased
+- Added repository finding lifecycle intelligence. Repo findings now carry
+  stable lifecycle keys, first/last seen timestamps, fixed/reopened/suppressed
+  state, owner and detector metadata, list filters for lifecycle, ownership,
+  confidence, and age, plus dashboard summary metrics for open, fixed,
+  reopened, SLA-aged, and MTTR-ready repository risk.
 - Added repository finding remediation previews. Repo misconfiguration findings
   now map to detector-specific remediation guidance and safe fix-PR plans for
   deterministic patches, while secret findings return rotation guidance only so

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -3885,9 +3885,10 @@ paths:
           name: repository
           schema: { type: string }
         - in: query
-          name: status
+          name: repo_lifecycle_status
           schema:
             $ref: "#/components/schemas/RepoFindingLifecycleStatus"
+          description: Scanner-observed repository finding lifecycle status.
         - in: query
           name: severity
           schema:
@@ -3921,6 +3922,7 @@ paths:
           schema:
             type: string
             enum: [open, ack, suppressed, resolved]
+          description: Operator triage workflow status.
         - in: query
           name: assignee
           schema:

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -3882,6 +3882,13 @@ paths:
           name: repo_scan_id
           schema: { type: string }
         - in: query
+          name: repository
+          schema: { type: string }
+        - in: query
+          name: status
+          schema:
+            $ref: "#/components/schemas/RepoFindingLifecycleStatus"
+        - in: query
           name: severity
           schema:
             $ref: "#/components/schemas/FindingSeverity"
@@ -3889,6 +3896,26 @@ paths:
           name: type
           schema:
             $ref: "#/components/schemas/FindingType"
+        - in: query
+          name: detector
+          schema: { type: string }
+        - in: query
+          name: owner
+          schema: { type: string }
+        - in: query
+          name: confidence
+          schema:
+            type: number
+            format: double
+            minimum: 0
+            maximum: 1
+          description: Minimum confidence score to include.
+        - in: query
+          name: age_days
+          schema:
+            type: integer
+            minimum: 0
+          description: Minimum age in days, measured from `first_seen_at`.
         - in: query
           name: lifecycle_status
           schema:
@@ -3904,7 +3931,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/FindingPage"
+                $ref: "#/components/schemas/RepoFindingPage"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -5801,6 +5828,9 @@ components:
     FindingLifecycleStatus:
       type: string
       enum: [open, ack, suppressed, resolved]
+    RepoFindingLifecycleStatus:
+      type: string
+      enum: [open, fixed, reopened, suppressed, risk_accepted, false_positive]
     FindingTriage:
       type: object
       properties:
@@ -5836,7 +5866,7 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: Required and must be in the future when `status` is `suppressed`.
+          description: "Optional expiry for suppressed findings. When supplied for `status: suppressed`, it must be in the future; a suppression comment is required as the reason."
         comment:
           type: string
     FindingTriageEvent:
@@ -5901,6 +5931,50 @@ components:
           type: string
           format: uri
           description: Direct GitHub blob URL for the repository file and line when Identrail can derive one.
+        lifecycle_key:
+          type: string
+          description: Stable scanner identity used to connect the finding across repeated repository scans.
+        lifecycle_status:
+          $ref: "#/components/schemas/RepoFindingLifecycleStatus"
+        owner:
+          type: string
+          description: Owner or team routed from finding evidence, triage assignment, or ownership metadata.
+        first_seen_at:
+          type: string
+          format: date-time
+        last_seen_at:
+          type: string
+          format: date-time
+        fixed_at:
+          type: string
+          format: date-time
+          nullable: true
+        reopened_at:
+          type: string
+          format: date-time
+          nullable: true
+        dismissed_at:
+          type: string
+          format: date-time
+          nullable: true
+        suppression_expires_at:
+          type: string
+          format: date-time
+          nullable: true
+        rule_version:
+          type: string
+        detector_version:
+          type: string
+        adapter_source:
+          type: string
+        confidence_state:
+          type: string
+        verification_status:
+          type: string
+        scan_mode:
+          type: string
+        evidence_version:
+          type: string
         evidence:
           type: object
           additionalProperties: true
@@ -5910,6 +5984,43 @@ components:
           format: date-time
         triage:
           $ref: "#/components/schemas/FindingTriage"
+    RepoFindingsSummary:
+      type: object
+      properties:
+        total_open: { type: integer }
+        fixed_count: { type: integer }
+        reopened_count: { type: integer }
+        suppressed_count: { type: integer }
+        sla_aged_count: { type: integer }
+        mttr_ready_resolved_count: { type: integer }
+        mean_time_to_resolve_seconds:
+          type: number
+          format: double
+          nullable: true
+        oldest_open_first_seen_at:
+          type: string
+          format: date-time
+          nullable: true
+        by_owner:
+          type: object
+          additionalProperties: { type: integer }
+        by_detector:
+          type: object
+          additionalProperties: { type: integer }
+        by_severity:
+          type: object
+          additionalProperties: { type: integer }
+    RepoFindingPage:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Finding"
+        next_cursor:
+          type: string
+        summary:
+          $ref: "#/components/schemas/RepoFindingsSummary"
     RepoFindingRemediationPreviewRequest:
       type: object
       properties:

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -96,7 +96,7 @@ they did not inspect the whole repository.
 
 Operational guidance:
 
-- Use `status=open&age_days=7&severity=high` to find high-risk findings that are aging beyond the default SLA window.
+- Use `repo_lifecycle_status=open&age_days=7&severity=high` to find high-risk findings that are aging beyond the default SLA window.
 - Use `owner=` and `detector=` filters to route queues to repository owners or detector specialists.
 - Treat `mean_time_to_resolve_seconds` as MTTR-ready only for findings with both `first_seen_at` and `fixed_at`.
 - Prefer suppression comments that explain the business reason; leave `suppression_expires_at` empty only for durable, reviewed exceptions.

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -63,14 +63,43 @@ Read APIs:
 
 - `GET /v1/repo-scans`
 - `GET /v1/repo-scans/:repo_scan_id`
-- `GET /v1/repo-findings?repo_scan_id=&severity=&type=`
+- `GET /v1/repo-findings?repo_scan_id=&repository=&status=&severity=&type=&detector=&owner=&confidence=&age_days=`
 - `POST /v1/repo-findings/:finding_id/remediation/preview?repo_scan_id=`
 - `GET /v1/repo-finding-clusters?repo_scan_id=&severity=&type=`
 - `GET /v1/repo-risk-graph?repo_scan_id=&repository=&default_branch=&severity=&type=`
 - list endpoints support cursor pagination (`?limit=...&cursor=...`) and return `next_cursor` when more results exist
-- repo finding responses expose stable repository and location fields when available: `repository`, `file_path`, `line_number`, `commit`, `detector`, `line_snippet`, `line_snippet_redacted`, and `source_url`
+- repo finding responses expose stable repository, lifecycle, and location fields when available: `repository`, `file_path`, `line_number`, `commit`, `detector`, `line_snippet`, `line_snippet_redacted`, `source_url`, `lifecycle_key`, `lifecycle_status`, `owner`, `first_seen_at`, `last_seen_at`, `fixed_at`, `reopened_at`, `dismissed_at`, and `suppression_expires_at`
 - `source_url` is a direct GitHub blob link pinned to the detected commit when Identrail can derive one
+- repo finding pages include a `summary` object with open, fixed, reopened, suppressed, SLA-aged, and MTTR-ready counts plus owner, detector, and severity rollups
 - grouped cluster responses roll duplicate repo findings into cluster counts with `first_seen_at`, `last_seen_at`, `spread`, and a per-occurrence `members` list
+
+## Finding Lifecycle
+
+Repository finding lifecycle is computed from a stable `lifecycle_key`, not only
+from the per-scan row id. This lets Identrail connect the same secret,
+misconfiguration, or external scanner alert across repeated scans even when a
+commit-scoped finding id changes.
+
+Lifecycle semantics:
+
+- `open`: first observed in the current repository state or still present after a later scan
+- `fixed`: previously open/reopened finding was absent from a completed, non-truncated deep scan
+- `reopened`: previously fixed finding appeared again in a later scan
+- `suppressed`: operator suppression is active; a suppression reason is required and expiry is optional
+- `risk_accepted` / `false_positive`: reserved lifecycle states for ownership workflows that need durable dismissal semantics
+
+Identrail preserves `first_seen_at` when a finding persists, updates
+`last_seen_at` when it is observed again, sets `fixed_at` when a full deep scan
+no longer sees it, and sets `reopened_at` when a fixed finding returns. Delta,
+quick, changed-path, and truncated scans do not close missing findings because
+they did not inspect the whole repository.
+
+Operational guidance:
+
+- Use `status=open&age_days=7&severity=high` to find high-risk findings that are aging beyond the default SLA window.
+- Use `owner=` and `detector=` filters to route queues to repository owners or detector specialists.
+- Treat `mean_time_to_resolve_seconds` as MTTR-ready only for findings with both `first_seen_at` and `fixed_at`.
+- Prefer suppression comments that explain the business reason; leave `suppression_expires_at` empty only for durable, reviewed exceptions.
 
 ## Safe Remediation Previews
 

--- a/internal/api/enterprise_report_routes.go
+++ b/internal/api/enterprise_report_routes.go
@@ -202,7 +202,7 @@ func executiveReportHandler(logger *zap.Logger, svc *Service, cache *executiveRe
 				return
 			}
 			repoFindings = enrichFindingsWithRepoContext(repoFindings)
-			repoFindings, err = svc.applyFindingTriageStates(wsCtx, repoFindings)
+			repoFindings, err = svc.applyRepoFindingTriageStates(wsCtx, repoFindings)
 			if err != nil {
 				if logger != nil {
 					logger.Error("hydrate repo finding triage for executive report", telemetry.ZapError(err))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -952,7 +952,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			Repository:      strings.TrimSpace(c.Query("repository")),
 			Severity:        strings.TrimSpace(c.Query("severity")),
 			Type:            strings.TrimSpace(c.Query("type")),
-			Status:          strings.TrimSpace(c.Query("status")),
+			Status:          strings.TrimSpace(firstNonEmpty(firstNonEmpty(c.Query("repo_lifecycle_status"), c.Query("repo_status")), c.Query("status"))),
 			Detector:        strings.TrimSpace(c.Query("detector")),
 			Owner:           strings.TrimSpace(c.Query("owner")),
 			MinConfidence:   minConfidence,

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -930,18 +930,43 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid repo_scan_id"})
 			return
 		}
+		minConfidence, ok, err := parseOptionalFloat(c.Query("confidence"))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid confidence"})
+			return
+		}
+		if !ok {
+			minConfidence, _, err = parseOptionalFloat(c.Query("min_confidence"))
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid min_confidence"})
+				return
+			}
+		}
+		minAgeDays, err := parseOptionalNonNegativeInt(firstNonEmpty(c.Query("age_days"), c.Query("min_age_days")))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid age_days"})
+			return
+		}
+		filter := db.RepoFindingFilter{
+			RepoScanID:      repoScanID,
+			Repository:      strings.TrimSpace(c.Query("repository")),
+			Severity:        strings.TrimSpace(c.Query("severity")),
+			Type:            strings.TrimSpace(c.Query("type")),
+			Status:          strings.TrimSpace(c.Query("status")),
+			Detector:        strings.TrimSpace(c.Query("detector")),
+			Owner:           strings.TrimSpace(c.Query("owner")),
+			MinConfidence:   minConfidence,
+			MinAgeDays:      minAgeDays,
+			LifecycleStatus: strings.TrimSpace(c.Query("lifecycle_status")),
+			Assignee:        strings.TrimSpace(c.Query("assignee")),
+			SortBy:          sortBy,
+			SortDesc:        sortDesc,
+			Now:             time.Now().UTC(),
+		}
 		items, err := svc.ListRepoFindings(
 			c.Request.Context(),
 			pageFetchLimit(offset, limit),
-			db.RepoFindingFilter{
-				RepoScanID:      repoScanID,
-				Severity:        strings.TrimSpace(c.Query("severity")),
-				Type:            strings.TrimSpace(c.Query("type")),
-				LifecycleStatus: strings.TrimSpace(c.Query("lifecycle_status")),
-				Assignee:        strings.TrimSpace(c.Query("assignee")),
-				SortBy:          sortBy,
-				SortDesc:        sortDesc,
-			},
+			filter,
 		)
 		if err != nil {
 			if errors.Is(err, db.ErrNotFound) {
@@ -952,7 +977,15 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list repo findings"})
 			return
 		}
-		c.JSON(http.StatusOK, paginatedItemsResponse(items, offset, limit))
+		summary, err := svc.GetRepoFindingsSummary(c.Request.Context(), filter)
+		if err != nil {
+			logger.Error("summarize repo findings", telemetry.ZapError(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to summarize repo findings"})
+			return
+		}
+		response := paginatedItemsResponse(items, offset, limit)
+		response["summary"] = summary
+		c.JSON(http.StatusOK, response)
 	})
 
 	v1.POST("/repo-findings/:finding_id/remediation/preview", func(c *gin.Context) {
@@ -2367,6 +2400,36 @@ func parseLimit(raw string, fallback int, max int) int {
 		return max
 	}
 	return parsed
+}
+
+func parseOptionalFloat(raw string) (float64, bool, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return 0, false, nil
+	}
+	parsed, err := strconv.ParseFloat(trimmed, 64)
+	if err != nil {
+		return 0, false, err
+	}
+	if parsed < 0 || parsed > 1 {
+		return 0, false, errors.New("float outside range")
+	}
+	return parsed, true, nil
+}
+
+func parseOptionalNonNegativeInt(raw string) (int, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return 0, nil
+	}
+	parsed, err := strconv.Atoi(trimmed)
+	if err != nil {
+		return 0, err
+	}
+	if parsed < 0 {
+		return 0, errors.New("negative integer")
+	}
+	return parsed, nil
 }
 
 func parseCursor(raw string) int {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -900,7 +900,7 @@ func TestRouterRepoFindingsCanBeFilteredByTriageState(t *testing.T) {
 
 	filteredReq := httptest.NewRequest(
 		http.MethodGet,
-		"/v1/repo-findings?repo_scan_id="+repoScan.ID+"&status=open&detector=workflow_pull_request_target&owner=platform&confidence=0.9&age_days=7&lifecycle_status=ack&assignee=platform&limit=50",
+		"/v1/repo-findings?repo_scan_id="+repoScan.ID+"&repo_lifecycle_status=open&detector=workflow_pull_request_target&owner=platform&confidence=0.9&age_days=7&lifecycle_status=ack&assignee=platform&limit=50",
 		nil,
 	)
 	filteredW := httptest.NewRecorder()

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -867,12 +867,15 @@ func TestRouterRepoFindingsCanBeFilteredByTriageState(t *testing.T) {
 			CreatedAt:    now,
 		},
 		{
-			ID:           "repo-ack",
-			Type:         domain.FindingRepoMisconfig,
-			Severity:     domain.SeverityHigh,
-			Title:        "ack finding",
-			HumanSummary: "ack finding",
-			CreatedAt:    now.Add(5 * time.Minute),
+			ID:              "repo-ack",
+			Type:            domain.FindingRepoMisconfig,
+			Severity:        domain.SeverityHigh,
+			ConfidenceScore: 0.91,
+			Title:           "ack finding",
+			HumanSummary:    "ack finding",
+			Detector:        "workflow_pull_request_target",
+			Owner:           "platform",
+			CreatedAt:       now.Add(-10 * 24 * time.Hour),
 		},
 	}); err != nil {
 		t.Fatalf("upsert repo findings: %v", err)
@@ -897,7 +900,7 @@ func TestRouterRepoFindingsCanBeFilteredByTriageState(t *testing.T) {
 
 	filteredReq := httptest.NewRequest(
 		http.MethodGet,
-		"/v1/repo-findings?repo_scan_id="+repoScan.ID+"&lifecycle_status=ack&assignee=platform&limit=50",
+		"/v1/repo-findings?repo_scan_id="+repoScan.ID+"&status=open&detector=workflow_pull_request_target&owner=platform&confidence=0.9&age_days=7&lifecycle_status=ack&assignee=platform&limit=50",
 		nil,
 	)
 	filteredW := httptest.NewRecorder()
@@ -907,7 +910,8 @@ func TestRouterRepoFindingsCanBeFilteredByTriageState(t *testing.T) {
 	}
 
 	var filteredBody struct {
-		Items []domain.Finding `json:"items"`
+		Items   []domain.Finding    `json:"items"`
+		Summary RepoFindingsSummary `json:"summary"`
 	}
 	if err := json.Unmarshal(filteredW.Body.Bytes(), &filteredBody); err != nil {
 		t.Fatalf("decode filtered repo findings: %v", err)
@@ -920,6 +924,9 @@ func TestRouterRepoFindingsCanBeFilteredByTriageState(t *testing.T) {
 	}
 	if filteredBody.Items[0].Triage.Status != domain.FindingLifecycleAck {
 		t.Fatalf("expected triage status ack, got %q", filteredBody.Items[0].Triage.Status)
+	}
+	if filteredBody.Summary.TotalOpen != 1 || filteredBody.Summary.SLAAgedCount != 1 || filteredBody.Summary.ByOwner["platform"] != 1 {
+		t.Fatalf("expected lifecycle summary to follow repo filters, got %+v", filteredBody.Summary)
 	}
 
 	detailReq := httptest.NewRequest(http.MethodGet, "/v1/findings/repo-ack?scan_id="+repoScan.ID, nil)

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -48,6 +48,7 @@ const (
 	maxSourceErrorsInEvent           = 25
 	repoFindingsTriageFilterStep     = maxCursorFetchLimit
 	repoFindingsTriageFilterCap      = maxCursorFetchLimit * 4
+	repoFindingSLAHighCritical       = 7 * 24 * time.Hour
 )
 
 const (
@@ -344,6 +345,21 @@ type FindingsSummary struct {
 	Total      int            `json:"total"`
 	BySeverity map[string]int `json:"by_severity"`
 	ByType     map[string]int `json:"by_type"`
+}
+
+// RepoFindingsSummary exposes lifecycle intelligence for repository findings.
+type RepoFindingsSummary struct {
+	TotalOpen                int            `json:"total_open"`
+	FixedCount               int            `json:"fixed_count"`
+	ReopenedCount            int            `json:"reopened_count"`
+	SuppressedCount          int            `json:"suppressed_count"`
+	SLAAgedCount             int            `json:"sla_aged_count"`
+	MTTRReadyResolvedCount   int            `json:"mttr_ready_resolved_count"`
+	MeanTimeToResolveSeconds *float64       `json:"mean_time_to_resolve_seconds,omitempty"`
+	OldestOpenFirstSeenAt    *time.Time     `json:"oldest_open_first_seen_at,omitempty"`
+	ByOwner                  map[string]int `json:"by_owner"`
+	ByDetector               map[string]int `json:"by_detector"`
+	BySeverity               map[string]int `json:"by_severity"`
 }
 
 // ScanDiff captures delta between one scan and its previous scan for same provider.
@@ -1929,6 +1945,26 @@ func (s *Service) ListRepoFindings(ctx context.Context, limit int, filter db.Rep
 	return filtered, nil
 }
 
+// GetRepoFindingsSummary returns lifecycle and ownership rollups for the
+// repository finding list using the same filters as the list endpoint.
+func (s *Service) GetRepoFindingsSummary(ctx context.Context, filter db.RepoFindingFilter) (RepoFindingsSummary, error) {
+	ctx = s.scopeContext(ctx)
+	normalized := db.NormalizeRepoFindingFilter(filter)
+	findings, err := s.Store.ListRepoFindings(ctx, normalized, 0)
+	if err != nil {
+		return RepoFindingsSummary{}, err
+	}
+	findings = enrichFindingsWithRepoContext(findings)
+	withTriage, err := s.applyFindingTriageStates(ctx, findings)
+	if err != nil {
+		return RepoFindingsSummary{}, err
+	}
+	if normalized.LifecycleStatus != "" || normalized.Assignee != "" {
+		withTriage = filterRepoFindingsByTriage(withTriage, normalized.LifecycleStatus, normalized.Assignee)
+	}
+	return summarizeRepoFindings(withTriage, s.Now().UTC()), nil
+}
+
 func (s *Service) listRepoFindingsWithTriageFilter(
 	ctx context.Context,
 	repoLimit int,
@@ -2487,6 +2523,71 @@ func filterRepoFindingsByTriage(
 	return filtered
 }
 
+func summarizeRepoFindings(findings []domain.Finding, now time.Time) RepoFindingsSummary {
+	summary := RepoFindingsSummary{
+		ByOwner:    map[string]int{},
+		ByDetector: map[string]int{},
+		BySeverity: map[string]int{},
+	}
+	var totalResolveSeconds float64
+	for _, finding := range findings {
+		status := finding.LifecycleStatus
+		if status == "" {
+			status = domain.RepoFindingLifecycleOpen
+		}
+		switch status {
+		case domain.RepoFindingLifecycleFixed:
+			summary.FixedCount++
+			if finding.FirstSeenAt != nil && finding.FixedAt != nil && finding.FixedAt.After(*finding.FirstSeenAt) {
+				totalResolveSeconds += finding.FixedAt.Sub(*finding.FirstSeenAt).Seconds()
+				summary.MTTRReadyResolvedCount++
+			}
+		case domain.RepoFindingLifecycleReopened:
+			summary.ReopenedCount++
+			summary.TotalOpen++
+		case domain.RepoFindingLifecycleSuppressed, domain.RepoFindingLifecycleRiskAccepted, domain.RepoFindingLifecycleFalsePositive:
+			summary.SuppressedCount++
+		default:
+			summary.TotalOpen++
+		}
+		if status == domain.RepoFindingLifecycleOpen || status == domain.RepoFindingLifecycleReopened {
+			firstSeen := finding.CreatedAt
+			if finding.FirstSeenAt != nil {
+				firstSeen = finding.FirstSeenAt.UTC()
+			}
+			if summary.OldestOpenFirstSeenAt == nil || firstSeen.Before(*summary.OldestOpenFirstSeenAt) {
+				value := firstSeen.UTC()
+				summary.OldestOpenFirstSeenAt = &value
+			}
+			if (finding.Severity == domain.SeverityHigh || finding.Severity == domain.SeverityCritical) &&
+				!firstSeen.IsZero() &&
+				now.Sub(firstSeen) >= repoFindingSLAHighCritical {
+				summary.SLAAgedCount++
+			}
+		}
+		owner := strings.TrimSpace(finding.Owner)
+		if owner == "" {
+			owner = "unassigned"
+		}
+		summary.ByOwner[owner]++
+		detector := strings.TrimSpace(finding.Detector)
+		if detector == "" {
+			detector = "unknown"
+		}
+		summary.ByDetector[detector]++
+		severity := strings.TrimSpace(string(finding.Severity))
+		if severity == "" {
+			severity = "unknown"
+		}
+		summary.BySeverity[severity]++
+	}
+	if summary.MTTRReadyResolvedCount > 0 {
+		mean := totalResolveSeconds / float64(summary.MTTRReadyResolvedCount)
+		summary.MeanTimeToResolveSeconds = &mean
+	}
+	return summary
+}
+
 // TriageFinding applies one workflow mutation and records audit history.
 func (s *Service) TriageFinding(ctx context.Context, findingID string, scanID string, request FindingTriageRequest, actor string) (domain.Finding, error) {
 	id := strings.TrimSpace(findingID)
@@ -2548,13 +2649,13 @@ func (s *Service) TriageFinding(ctx context.Context, findingID string, scanID st
 		nextState.SuppressionExpiresAt = nil
 		changed = true
 	}
-	if nextState.Status == domain.FindingLifecycleSuppressed && nextState.SuppressionExpiresAt == nil {
+	comment := strings.TrimSpace(request.Comment)
+	if nextState.Status == domain.FindingLifecycleSuppressed && comment == "" {
 		return domain.Finding{}, ErrInvalidFindingTriageRequest
 	}
 	if nextState.Status == domain.FindingLifecycleSuppressed && nextState.SuppressionExpiresAt != nil && !nextState.SuppressionExpiresAt.After(now) {
 		return domain.Finding{}, ErrInvalidFindingTriageRequest
 	}
-	comment := strings.TrimSpace(request.Comment)
 	if !changed && comment == "" {
 		return domain.Finding{}, ErrInvalidFindingTriageRequest
 	}
@@ -3214,6 +3315,7 @@ func (s *Service) applyFindingTriageStates(ctx context.Context, findings []domai
 			}
 		}
 		finding.Triage = triage
+		domain.ApplyRepoFindingTriageToLifecycle(&finding)
 		result = append(result, finding)
 	}
 	return result, nil

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1912,37 +1912,32 @@ func (s *Service) GetRepoScan(ctx context.Context, repoScanID string) (db.RepoSc
 func (s *Service) ListRepoFindings(ctx context.Context, limit int, filter db.RepoFindingFilter) ([]domain.Finding, error) {
 	ctx = s.scopeContext(ctx)
 	normalized := db.NormalizeRepoFindingFilter(filter)
-	hasTriageFilter := normalized.LifecycleStatus != "" || normalized.Assignee != ""
+	storeFilter := normalized
+	storeFilter.Status = ""
+	hasPostTriageFilter := normalized.Status != "" || normalized.LifecycleStatus != "" || normalized.Assignee != ""
 	requestLimit := limit
 	if requestLimit <= 0 {
 		requestLimit = defaultFindingsLimit
 	}
 	repoLimit := requestLimit
-	if hasTriageFilter && repoLimit < repoFindingsTriageFilterStep {
+	if hasPostTriageFilter && repoLimit < repoFindingsTriageFilterStep {
 		repoLimit = repoFindingsTriageFilterStep
 	}
 
-	if hasTriageFilter {
-		return s.listRepoFindingsWithTriageFilter(ctx, repoLimit, requestLimit, normalized)
+	if hasPostTriageFilter {
+		return s.listRepoFindingsWithPostTriageFilter(ctx, repoLimit, requestLimit, storeFilter, normalized)
 	}
 
-	findings, err := s.Store.ListRepoFindings(ctx, normalized, repoLimit)
+	findings, err := s.Store.ListRepoFindings(ctx, storeFilter, repoLimit)
 	if err != nil {
 		return nil, err
 	}
 	findings = enrichFindingsWithRepoContext(findings)
-	withTriage, err := s.applyFindingTriageStates(ctx, findings)
+	withTriage, err := s.applyRepoFindingTriageStates(ctx, findings)
 	if err != nil {
 		return nil, err
 	}
-	if normalized.LifecycleStatus == "" && normalized.Assignee == "" {
-		return withTriage, nil
-	}
-	filtered := filterRepoFindingsByTriage(withTriage, normalized.LifecycleStatus, normalized.Assignee)
-	if len(filtered) > requestLimit {
-		filtered = filtered[:requestLimit]
-	}
-	return filtered, nil
+	return withTriage, nil
 }
 
 // GetRepoFindingsSummary returns lifecycle and ownership rollups for the
@@ -1950,39 +1945,42 @@ func (s *Service) ListRepoFindings(ctx context.Context, limit int, filter db.Rep
 func (s *Service) GetRepoFindingsSummary(ctx context.Context, filter db.RepoFindingFilter) (RepoFindingsSummary, error) {
 	ctx = s.scopeContext(ctx)
 	normalized := db.NormalizeRepoFindingFilter(filter)
-	findings, err := s.Store.ListRepoFindings(ctx, normalized, 0)
+	storeFilter := normalized
+	storeFilter.Status = ""
+	findings, err := s.Store.ListRepoFindings(ctx, storeFilter, 0)
 	if err != nil {
 		return RepoFindingsSummary{}, err
 	}
 	findings = enrichFindingsWithRepoContext(findings)
-	withTriage, err := s.applyFindingTriageStates(ctx, findings)
+	withTriage, err := s.applyRepoFindingTriageStates(ctx, findings)
 	if err != nil {
 		return RepoFindingsSummary{}, err
 	}
-	if normalized.LifecycleStatus != "" || normalized.Assignee != "" {
-		withTriage = filterRepoFindingsByTriage(withTriage, normalized.LifecycleStatus, normalized.Assignee)
+	if normalized.Status != "" || normalized.LifecycleStatus != "" || normalized.Assignee != "" {
+		withTriage = filterRepoFindingsByLifecycleAndTriage(withTriage, normalized.Status, normalized.LifecycleStatus, normalized.Assignee)
 	}
 	return summarizeRepoFindings(withTriage, s.Now().UTC()), nil
 }
 
-func (s *Service) listRepoFindingsWithTriageFilter(
+func (s *Service) listRepoFindingsWithPostTriageFilter(
 	ctx context.Context,
 	repoLimit int,
 	requestLimit int,
-	filter db.RepoFindingFilter,
+	storeFilter db.RepoFindingFilter,
+	postFilter db.RepoFindingFilter,
 ) ([]domain.Finding, error) {
 	for {
-		findings, err := s.Store.ListRepoFindings(ctx, filter, repoLimit)
+		findings, err := s.Store.ListRepoFindings(ctx, storeFilter, repoLimit)
 		if err != nil {
 			return nil, err
 		}
 
 		findings = enrichFindingsWithRepoContext(findings)
-		withTriage, err := s.applyFindingTriageStates(ctx, findings)
+		withTriage, err := s.applyRepoFindingTriageStates(ctx, findings)
 		if err != nil {
 			return nil, err
 		}
-		filtered := filterRepoFindingsByTriage(withTriage, filter.LifecycleStatus, filter.Assignee)
+		filtered := filterRepoFindingsByLifecycleAndTriage(withTriage, postFilter.Status, postFilter.LifecycleStatus, postFilter.Assignee)
 		if len(filtered) > requestLimit {
 			filtered = filtered[:requestLimit]
 		}
@@ -2492,27 +2490,39 @@ func (s *Service) GetFinding(ctx context.Context, findingID string, scanID strin
 	return withTriage[0], nil
 }
 
-func filterRepoFindingsByTriage(
+func filterRepoFindingsByLifecycleAndTriage(
 	findings []domain.Finding,
-	rawStatus string,
+	rawRepoStatus string,
+	rawTriageStatus string,
 	rawAssignee string,
 ) []domain.Finding {
-	statusFilter := domain.FindingLifecycleStatus(strings.ToLower(strings.TrimSpace(rawStatus)))
+	repoStatusFilter := domain.NormalizeRepoFindingLifecycleStatus(rawRepoStatus)
+	triageStatusFilter := domain.FindingLifecycleStatus(strings.ToLower(strings.TrimSpace(rawTriageStatus)))
 	assigneeFilter := strings.ToLower(strings.TrimSpace(rawAssignee))
-	if statusFilter == "" && assigneeFilter == "" {
+	if repoStatusFilter == "" && triageStatusFilter == "" && assigneeFilter == "" {
 		return findings
 	}
-	if statusFilter != "" && !isValidFindingLifecycleStatus(statusFilter) {
+	if strings.TrimSpace(rawRepoStatus) != "" && repoStatusFilter == "" {
+		return nil
+	}
+	if triageStatusFilter != "" && !isValidFindingLifecycleStatus(triageStatusFilter) {
 		return nil
 	}
 	filtered := make([]domain.Finding, 0, len(findings))
 	for _, finding := range findings {
+		repoStatus := finding.LifecycleStatus
+		if repoStatus == "" {
+			repoStatus = domain.RepoFindingLifecycleOpen
+		}
+		if repoStatusFilter != "" && repoStatus != repoStatusFilter {
+			continue
+		}
 		triage := finding.Triage
 		status := triage.Status
 		if !isValidFindingLifecycleStatus(status) {
 			status = domain.FindingLifecycleOpen
 		}
-		if statusFilter != "" && status != statusFilter {
+		if triageStatusFilter != "" && status != triageStatusFilter {
 			continue
 		}
 		if assigneeFilter != "" && strings.ToLower(strings.TrimSpace(triage.Assignee)) != assigneeFilter {
@@ -3315,10 +3325,20 @@ func (s *Service) applyFindingTriageStates(ctx context.Context, findings []domai
 			}
 		}
 		finding.Triage = triage
-		domain.ApplyRepoFindingTriageToLifecycle(&finding)
 		result = append(result, finding)
 	}
 	return result, nil
+}
+
+func (s *Service) applyRepoFindingTriageStates(ctx context.Context, findings []domain.Finding) ([]domain.Finding, error) {
+	withTriage, err := s.applyFindingTriageStates(ctx, findings)
+	if err != nil {
+		return nil, err
+	}
+	for i := range withTriage {
+		domain.ApplyRepoFindingTriageToLifecycle(&withTriage[i])
+	}
+	return withTriage, nil
 }
 
 const repoFindingTriageStatePrefix = "repo-finding-triage"

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -1067,13 +1067,15 @@ func TestServiceRepoFindingTriageScopesStateToRepoScan(t *testing.T) {
 		t.Fatalf("triage second repo finding: %v", err)
 	}
 
-	findings, err := svc.ListRepoFindings(defaultScopeContext(), 10, db.RepoFindingFilter{})
+	firstFindings, err := svc.ListRepoFindings(defaultScopeContext(), 10, db.RepoFindingFilter{RepoScanID: firstScan.ID})
 	if err != nil {
-		t.Fatalf("list repo findings: %v", err)
+		t.Fatalf("list first repo findings: %v", err)
 	}
-	if len(findings) != 2 {
-		t.Fatalf("expected two repo findings, got %+v", findings)
+	secondFindings, err := svc.ListRepoFindings(defaultScopeContext(), 10, db.RepoFindingFilter{RepoScanID: secondScan.ID})
+	if err != nil {
+		t.Fatalf("list second repo findings: %v", err)
 	}
+	findings := append(firstFindings, secondFindings...)
 
 	triageByScan := map[string]domain.FindingTriage{}
 	for _, finding := range findings {
@@ -1090,6 +1092,7 @@ func TestServiceRepoFindingTriageScopesStateToRepoScan(t *testing.T) {
 		defaultScopeContext(),
 		10,
 		db.RepoFindingFilter{
+			RepoScanID:      firstScan.ID,
 			LifecycleStatus: string(domain.FindingLifecycleAck),
 		},
 	)
@@ -1106,6 +1109,122 @@ func TestServiceRepoFindingTriageScopesStateToRepoScan(t *testing.T) {
 	}
 	if len(history) != 1 || history[0].ToStatus != domain.FindingLifecycleResolved || history[0].Assignee != secondAssignee {
 		t.Fatalf("expected second scan history to stay isolated, got %+v", history)
+	}
+}
+
+func TestServiceRepoFindingLifecycleTracksFixedAndReopenedAcrossScans(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC)
+
+	firstScan, err := store.CreateRepoScan(ctx, "owner/repo", db.RepoScanSource{}, db.RepoScanContext{ScanMode: "deep"}, now)
+	if err != nil {
+		t.Fatalf("create first repo scan: %v", err)
+	}
+	firstFinding := domain.Finding{
+		ID:              "finding:first-commit",
+		Type:            domain.FindingSecretExposure,
+		Severity:        domain.SeverityHigh,
+		ConfidenceScore: 0.92,
+		Title:           "GitHub token exposed",
+		HumanSummary:    "A token-like value was committed.",
+		Repository:      "owner/repo",
+		Commit:          "abc123",
+		FilePath:        "config/app.env",
+		LineNumber:      7,
+		Detector:        "github_token",
+		Owner:           "platform",
+		Evidence: map[string]any{
+			"repository":         "owner/repo",
+			"detector":           "github_token",
+			"file_path":          "config/app.env",
+			"line_number":        7,
+			"secret_fingerprint": "fp-token",
+			"confidence_score":   0.92,
+			"owner":              "platform",
+		},
+		CreatedAt: now,
+	}
+	if err := store.UpsertRepoFindings(ctx, firstScan.ID, []domain.Finding{firstFinding}); err != nil {
+		t.Fatalf("upsert first repo finding: %v", err)
+	}
+	if err := store.CompleteRepoScan(ctx, firstScan.ID, "succeeded", now.Add(time.Minute), 10, 8, 1, false, db.RepoScanContext{ScanMode: "deep"}, ""); err != nil {
+		t.Fatalf("complete first repo scan: %v", err)
+	}
+
+	secondScan, err := store.CreateRepoScan(ctx, "owner/repo", db.RepoScanSource{}, db.RepoScanContext{ScanMode: "deep"}, now.Add(24*time.Hour))
+	if err != nil {
+		t.Fatalf("create second repo scan: %v", err)
+	}
+	if err := store.CompleteRepoScan(ctx, secondScan.ID, "succeeded", now.Add(24*time.Hour+time.Minute), 10, 8, 0, false, db.RepoScanContext{ScanMode: "deep"}, ""); err != nil {
+		t.Fatalf("complete second repo scan: %v", err)
+	}
+
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now.Add(48 * time.Hour) }
+	fixed, err := svc.ListRepoFindings(ctx, 10, db.RepoFindingFilter{Status: string(domain.RepoFindingLifecycleFixed)})
+	if err != nil {
+		t.Fatalf("list fixed repo findings: %v", err)
+	}
+	if len(fixed) != 1 || fixed[0].LifecycleStatus != domain.RepoFindingLifecycleFixed || fixed[0].FixedAt == nil {
+		t.Fatalf("expected one fixed lifecycle row, got %+v", fixed)
+	}
+	openAfterFixed, err := svc.ListRepoFindings(ctx, 10, db.RepoFindingFilter{Status: string(domain.RepoFindingLifecycleOpen)})
+	if err != nil {
+		t.Fatalf("list open repo findings after fixed lifecycle: %v", err)
+	}
+	if len(openAfterFixed) != 0 {
+		t.Fatalf("expected stale open lifecycle rows to be hidden, got %+v", openAfterFixed)
+	}
+
+	thirdScan, err := store.CreateRepoScan(ctx, "owner/repo", db.RepoScanSource{}, db.RepoScanContext{ScanMode: "deep"}, now.Add(48*time.Hour))
+	if err != nil {
+		t.Fatalf("create third repo scan: %v", err)
+	}
+	reopenedFinding := firstFinding
+	reopenedFinding.ID = "finding:second-commit"
+	reopenedFinding.Commit = "def456"
+	reopenedFinding.CreatedAt = now.Add(48 * time.Hour)
+	reopenedFinding.Evidence["commit"] = "def456"
+	if err := store.UpsertRepoFindings(ctx, thirdScan.ID, []domain.Finding{reopenedFinding}); err != nil {
+		t.Fatalf("upsert reopened repo finding: %v", err)
+	}
+	if err := store.CompleteRepoScan(ctx, thirdScan.ID, "succeeded", now.Add(48*time.Hour+time.Minute), 10, 8, 1, false, db.RepoScanContext{ScanMode: "deep"}, ""); err != nil {
+		t.Fatalf("complete third repo scan: %v", err)
+	}
+
+	reopened, err := svc.ListRepoFindings(ctx, 10, db.RepoFindingFilter{
+		Status:        string(domain.RepoFindingLifecycleReopened),
+		Repository:    "owner/repo",
+		Detector:      "github_token",
+		Owner:         "platform",
+		MinConfidence: 0.9,
+		MinAgeDays:    1,
+		Now:           now.Add(49 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("list reopened repo findings: %v", err)
+	}
+	if len(reopened) != 1 || reopened[0].ID != "finding:second-commit" {
+		t.Fatalf("expected latest reopened finding only, got %+v", reopened)
+	}
+	if reopened[0].FirstSeenAt == nil || !reopened[0].FirstSeenAt.Equal(now) {
+		t.Fatalf("expected first_seen_at to be preserved from first scan, got %+v", reopened[0].FirstSeenAt)
+	}
+	if reopened[0].LastSeenAt == nil || !reopened[0].LastSeenAt.Equal(now.Add(48*time.Hour)) {
+		t.Fatalf("expected last_seen_at from reopened scan, got %+v", reopened[0].LastSeenAt)
+	}
+	if reopened[0].ReopenedAt == nil {
+		t.Fatalf("expected reopened_at to be populated, got %+v", reopened[0])
+	}
+
+	svc.Now = func() time.Time { return now.Add(10 * 24 * time.Hour) }
+	summary, err := svc.GetRepoFindingsSummary(ctx, db.RepoFindingFilter{Repository: "owner/repo"})
+	if err != nil {
+		t.Fatalf("summarize repo findings: %v", err)
+	}
+	if summary.TotalOpen != 1 || summary.ReopenedCount != 1 || summary.FixedCount != 0 || summary.SLAAgedCount != 1 {
+		t.Fatalf("unexpected repo finding summary: %+v", summary)
 	}
 }
 
@@ -1369,7 +1488,7 @@ func TestServiceTriageFindingRejectsInvalidRequest(t *testing.T) {
 		},
 		"subject:user-1",
 	); !errors.Is(err, ErrInvalidFindingTriageRequest) {
-		t.Fatalf("expected invalid triage request error for missing suppression expiry, got %v", err)
+		t.Fatalf("expected invalid triage request error for missing suppression reason, got %v", err)
 	}
 
 	pastExpiry := now.Add(-1 * time.Hour).Format(time.RFC3339)
@@ -1380,10 +1499,29 @@ func TestServiceTriageFindingRejectsInvalidRequest(t *testing.T) {
 		FindingTriageRequest{
 			Status:               &suppressed,
 			SuppressionExpiresAt: &pastExpiry,
+			Comment:              "past exception window",
 		},
 		"subject:user-1",
 	); !errors.Is(err, ErrInvalidFindingTriageRequest) {
 		t.Fatalf("expected invalid triage request error for past suppression expiry, got %v", err)
+	}
+
+	reason := "accepted test fixture"
+	suppressedFinding, err := svc.TriageFinding(
+		defaultScopeContext(),
+		"finding-1",
+		scan.ID,
+		FindingTriageRequest{
+			Status:  &suppressed,
+			Comment: reason,
+		},
+		"subject:user-1",
+	)
+	if err != nil {
+		t.Fatalf("expected suppression with reason and no expiry to pass: %v", err)
+	}
+	if suppressedFinding.Triage.Status != domain.FindingLifecycleSuppressed || suppressedFinding.Triage.SuppressionExpiresAt != nil {
+		t.Fatalf("expected suppressed finding without expiry, got %+v", suppressedFinding.Triage)
 	}
 }
 
@@ -1511,6 +1649,7 @@ func TestServiceImportFindingBaselineSkipsChangedVariants(t *testing.T) {
 	if _, err := svc.TriageFinding(defaultScopeContext(), sourceFinding.ID, sourceScan.ID, FindingTriageRequest{
 		Status:               &suppressed,
 		SuppressionExpiresAt: &expiry,
+		Comment:              "known false positive",
 	}, "subject:owner"); err != nil {
 		t.Fatalf("triage source finding: %v", err)
 	}

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -1075,6 +1075,12 @@ func TestServiceRepoFindingTriageScopesStateToRepoScan(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list second repo findings: %v", err)
 	}
+	if len(firstFindings) != 1 {
+		t.Fatalf("expected one row for first scan filter, got %+v", firstFindings)
+	}
+	if len(secondFindings) != 1 {
+		t.Fatalf("expected one row for second scan filter, got %+v", secondFindings)
+	}
 	findings := append(firstFindings, secondFindings...)
 
 	triageByScan := map[string]domain.FindingTriage{}
@@ -1101,6 +1107,36 @@ func TestServiceRepoFindingTriageScopesStateToRepoScan(t *testing.T) {
 	}
 	if len(filtered) != 1 || filtered[0].ScanID != firstScan.ID {
 		t.Fatalf("expected ack filter to return only first scan row, got %+v", filtered)
+	}
+
+	fixedByRepoStatus, err := svc.ListRepoFindings(
+		defaultScopeContext(),
+		10,
+		db.RepoFindingFilter{
+			RepoScanID: secondScan.ID,
+			Status:     string(domain.RepoFindingLifecycleFixed),
+		},
+	)
+	if err != nil {
+		t.Fatalf("list repo findings by repo lifecycle status: %v", err)
+	}
+	if len(fixedByRepoStatus) != 1 || fixedByRepoStatus[0].ScanID != secondScan.ID || fixedByRepoStatus[0].LifecycleStatus != domain.RepoFindingLifecycleFixed {
+		t.Fatalf("expected resolved triage to satisfy fixed repo lifecycle filter, got %+v", fixedByRepoStatus)
+	}
+
+	staleOpenByRepoStatus, err := svc.ListRepoFindings(
+		defaultScopeContext(),
+		10,
+		db.RepoFindingFilter{
+			RepoScanID: secondScan.ID,
+			Status:     string(domain.RepoFindingLifecycleOpen),
+		},
+	)
+	if err != nil {
+		t.Fatalf("list open repo findings by repo lifecycle status: %v", err)
+	}
+	if len(staleOpenByRepoStatus) != 0 {
+		t.Fatalf("expected resolved triage to be excluded from open repo lifecycle filter, got %+v", staleOpenByRepoStatus)
 	}
 
 	history, err := svc.ListFindingTriageHistory(defaultScopeContext(), "shared-id", secondScan.ID, 10)

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -135,6 +135,14 @@ func sortFindingsForQuery(items []domain.Finding, sortBy string, desc bool) {
 			cmp = compareMemoryString(string(left.Type), string(right.Type))
 		case "title":
 			cmp = compareMemoryString(left.Title, right.Title)
+		case "first_seen_at":
+			cmp = compareMemoryTime(timeValue(left.FirstSeenAt, left.CreatedAt), timeValue(right.FirstSeenAt, right.CreatedAt))
+		case "last_seen_at":
+			cmp = compareMemoryTime(timeValue(left.LastSeenAt, left.CreatedAt), timeValue(right.LastSeenAt, right.CreatedAt))
+		case "status":
+			cmp = compareMemoryString(string(left.LifecycleStatus), string(right.LifecycleStatus))
+		case "owner":
+			cmp = compareMemoryString(left.Owner, right.Owner)
 		default:
 			cmp = compareMemoryTime(left.CreatedAt, right.CreatedAt)
 		}
@@ -2190,6 +2198,9 @@ func (m *MemoryStore) CompleteRepoScan(ctx context.Context, repoScanID string, s
 	}
 	record.ErrorMessage = strings.TrimSpace(errorMessage)
 	m.repoScans[repoScanID] = record
+	if shouldCloseMissingRepoFindings(record.Status, record.Truncated, normalizedContext) {
+		m.markMissingRepoFindingsFixedLocked(scope, record, finished)
+	}
 	return nil
 }
 
@@ -2265,7 +2276,22 @@ func (m *MemoryStore) UpsertRepoFindings(ctx context.Context, repoScanID string,
 	}
 	for _, finding := range findings {
 		finding.ScanID = repoScanID
+		if finding.Repository == "" {
+			finding.Repository = strings.TrimSpace(repoScan.Repository)
+		}
+		if finding.ScanMode == "" {
+			finding.ScanMode = strings.TrimSpace(repoScan.ScanMode)
+		}
+		observedAt := finding.CreatedAt.UTC()
+		if observedAt.IsZero() {
+			observedAt = repoScan.StartedAt.UTC()
+		}
+		if observedAt.IsZero() {
+			observedAt = time.Now().UTC()
+		}
+		finding.CreatedAt = observedAt
 		domain.NormalizeRepoFindingMetadata(&finding)
+		m.applyRepoFindingLifecycleLocked(scope, repoScan, &finding, observedAt)
 		key := repoScanID + "|" + finding.ID
 		m.repoFindings[key] = finding
 		m.repoFindingIDs[repoScanID] = appendUniqueID(m.repoFindingIDs[repoScanID], key)
@@ -2364,6 +2390,9 @@ func (m *MemoryStore) ListRepoFindings(ctx context.Context, filter RepoFindingFi
 			if !repoFindingMatchesRepository(finding, repositoryFilter) {
 				continue
 			}
+			if !repoFindingMatchesFilter(finding, normalized) {
+				continue
+			}
 			result = append(result, finding)
 		}
 	} else {
@@ -2390,6 +2419,16 @@ func (m *MemoryStore) ListRepoFindings(ctx context.Context, filter RepoFindingFi
 			}
 			result = append(result, finding)
 		}
+		if !normalized.IncludeHistorical {
+			result = latestRepoFindingLifecycleRows(result)
+		}
+		filtered := result[:0]
+		for _, finding := range result {
+			if repoFindingMatchesFilter(finding, normalized) {
+				filtered = append(filtered, finding)
+			}
+		}
+		result = filtered
 	}
 	sortFindingsForQuery(result, normalized.SortBy, normalized.SortDesc)
 	if limit > 0 && len(result) > limit {
@@ -2406,12 +2445,201 @@ func repoFindingMatchesRepository(finding domain.Finding, repository string) boo
 	return strings.EqualFold(strings.TrimSpace(finding.Repository), repository)
 }
 
+func (m *MemoryStore) applyRepoFindingLifecycleLocked(scope Scope, repoScan RepoScanRecord, finding *domain.Finding, observedAt time.Time) {
+	if finding == nil {
+		return
+	}
+	if finding.LifecycleKey == "" {
+		finding.LifecycleKey = domain.RepoFindingLifecycleKey(*finding)
+	}
+	firstSeen := observedAt.UTC()
+	status := domain.RepoFindingLifecycleOpen
+	previous, exists := m.latestRepoFindingLifecycleLocked(scope, strings.TrimSpace(repoScan.Repository), finding.LifecycleKey, repoScan.ID)
+	if exists {
+		if previous.FirstSeenAt != nil && !previous.FirstSeenAt.IsZero() {
+			firstSeen = previous.FirstSeenAt.UTC()
+		} else if !previous.CreatedAt.IsZero() {
+			firstSeen = previous.CreatedAt.UTC()
+		}
+		switch previous.LifecycleStatus {
+		case domain.RepoFindingLifecycleFixed:
+			status = domain.RepoFindingLifecycleReopened
+			reopenedAt := observedAt.UTC()
+			finding.ReopenedAt = &reopenedAt
+		case domain.RepoFindingLifecycleSuppressed, domain.RepoFindingLifecycleRiskAccepted, domain.RepoFindingLifecycleFalsePositive:
+			status = previous.LifecycleStatus
+			finding.DismissedAt = cloneTimePointer(previous.DismissedAt)
+			finding.SuppressionExpiresAt = cloneTimePointer(previous.SuppressionExpiresAt)
+		case domain.RepoFindingLifecycleReopened:
+			status = domain.RepoFindingLifecycleReopened
+			finding.ReopenedAt = cloneTimePointer(previous.ReopenedAt)
+		default:
+			status = domain.RepoFindingLifecycleOpen
+		}
+		if finding.Owner == "" {
+			finding.Owner = previous.Owner
+		}
+	}
+	firstSeenCopy := firstSeen.UTC()
+	lastSeenCopy := observedAt.UTC()
+	finding.FirstSeenAt = &firstSeenCopy
+	finding.LastSeenAt = &lastSeenCopy
+	finding.FixedAt = nil
+	finding.LifecycleStatus = status
+	domain.NormalizeRepoFindingMetadata(finding)
+}
+
+func (m *MemoryStore) latestRepoFindingLifecycleLocked(scope Scope, repository string, lifecycleKey string, excludeRepoScanID string) (domain.Finding, bool) {
+	lifecycleKey = strings.TrimSpace(lifecycleKey)
+	if lifecycleKey == "" {
+		return domain.Finding{}, false
+	}
+	var latest domain.Finding
+	found := false
+	for _, candidate := range m.repoFindings {
+		if strings.TrimSpace(candidate.ScanID) == strings.TrimSpace(excludeRepoScanID) {
+			continue
+		}
+		record, exists := m.repoScans[candidate.ScanID]
+		if !exists || !MatchScope(scope, record.TenantID, record.WorkspaceID) {
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(record.Repository), strings.TrimSpace(repository)) {
+			continue
+		}
+		if candidate.Repository == "" {
+			candidate.Repository = record.Repository
+		}
+		domain.NormalizeRepoFindingMetadata(&candidate)
+		if strings.TrimSpace(candidate.LifecycleKey) != lifecycleKey {
+			continue
+		}
+		if !found || repoFindingObservedAt(candidate).After(repoFindingObservedAt(latest)) {
+			latest = candidate
+			found = true
+		}
+	}
+	return latest, found
+}
+
+func (m *MemoryStore) markMissingRepoFindingsFixedLocked(scope Scope, repoScan RepoScanRecord, fixedAt time.Time) {
+	currentKeys := map[string]struct{}{}
+	for _, key := range m.repoFindingIDs[repoScan.ID] {
+		finding, exists := m.repoFindings[key]
+		if !exists {
+			continue
+		}
+		domain.NormalizeRepoFindingMetadata(&finding)
+		if finding.LifecycleKey != "" {
+			currentKeys[finding.LifecycleKey] = struct{}{}
+		}
+	}
+	for key, finding := range m.repoFindings {
+		if strings.TrimSpace(finding.ScanID) == strings.TrimSpace(repoScan.ID) {
+			continue
+		}
+		record, exists := m.repoScans[finding.ScanID]
+		if !exists || !MatchScope(scope, record.TenantID, record.WorkspaceID) {
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(record.Repository), strings.TrimSpace(repoScan.Repository)) {
+			continue
+		}
+		if finding.Repository == "" {
+			finding.Repository = record.Repository
+		}
+		domain.NormalizeRepoFindingMetadata(&finding)
+		if finding.LifecycleKey == "" {
+			continue
+		}
+		if _, stillObserved := currentKeys[finding.LifecycleKey]; stillObserved {
+			continue
+		}
+		if finding.LifecycleStatus != domain.RepoFindingLifecycleOpen && finding.LifecycleStatus != domain.RepoFindingLifecycleReopened {
+			continue
+		}
+		latest, exists := m.latestRepoFindingLifecycleLocked(scope, repoScan.Repository, finding.LifecycleKey, repoScan.ID)
+		if !exists || latest.ScanID != finding.ScanID || latest.ID != finding.ID {
+			continue
+		}
+		fixed := fixedAt.UTC()
+		finding.FixedAt = &fixed
+		finding.LifecycleStatus = domain.RepoFindingLifecycleFixed
+		domain.NormalizeRepoFindingMetadata(&finding)
+		m.repoFindings[key] = finding
+	}
+}
+
+func repoFindingMatchesFilter(finding domain.Finding, filter RepoFindingFilter) bool {
+	if filter.Status != "" && strings.ToLower(string(finding.LifecycleStatus)) != filter.Status {
+		return false
+	}
+	if filter.Detector != "" && strings.ToLower(strings.TrimSpace(finding.Detector)) != filter.Detector {
+		return false
+	}
+	if filter.Owner != "" && strings.ToLower(strings.TrimSpace(finding.Owner)) != filter.Owner {
+		return false
+	}
+	if filter.MinConfidence > 0 && finding.ConfidenceScore < filter.MinConfidence {
+		return false
+	}
+	if filter.MinAgeDays > 0 {
+		cutoff := filter.Now.Add(-time.Duration(filter.MinAgeDays) * 24 * time.Hour)
+		if timeValue(finding.FirstSeenAt, finding.CreatedAt).After(cutoff) {
+			return false
+		}
+	}
+	return true
+}
+
+func latestRepoFindingLifecycleRows(findings []domain.Finding) []domain.Finding {
+	if len(findings) <= 1 {
+		return findings
+	}
+	latest := map[string]domain.Finding{}
+	order := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		key := strings.TrimSpace(finding.LifecycleKey)
+		if key == "" {
+			key = finding.ScanID + "|" + finding.ID
+		}
+		existing, exists := latest[key]
+		if !exists {
+			order = append(order, key)
+			latest[key] = finding
+			continue
+		}
+		if repoFindingObservedAt(finding).After(repoFindingObservedAt(existing)) {
+			latest[key] = finding
+		}
+	}
+	result := make([]domain.Finding, 0, len(latest))
+	for _, key := range order {
+		if finding, exists := latest[key]; exists {
+			result = append(result, finding)
+		}
+	}
+	return result
+}
+
+func repoFindingObservedAt(finding domain.Finding) time.Time {
+	return timeValue(finding.LastSeenAt, finding.CreatedAt)
+}
+
+func timeValue(value *time.Time, fallback time.Time) time.Time {
+	if value != nil && !value.IsZero() {
+		return value.UTC()
+	}
+	return fallback.UTC()
+}
+
 // ListRepoFindingClusters returns repository finding clusters using store-backed pagination semantics.
 func (m *MemoryStore) ListRepoFindingClusters(ctx context.Context, filter RepoFindingClusterListFilter) ([]domain.RepoFindingCluster, error) {
 	findings, err := m.ListRepoFindings(ctx, RepoFindingFilter{
-		RepoScanID: filter.RepoScanID,
-		Severity:   filter.Severity,
-		Type:       filter.Type,
+		RepoScanID:        filter.RepoScanID,
+		Severity:          filter.Severity,
+		Type:              filter.Type,
+		IncludeHistorical: true,
 	}, 0)
 	if err != nil {
 		return nil, err

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -2514,7 +2514,7 @@ func (m *MemoryStore) latestRepoFindingLifecycleLocked(scope Scope, repository s
 		if strings.TrimSpace(candidate.LifecycleKey) != lifecycleKey {
 			continue
 		}
-		if !found || repoFindingObservedAt(candidate).After(repoFindingObservedAt(latest)) {
+		if !found || repoFindingNewer(candidate, latest) {
 			latest = candidate
 			found = true
 		}
@@ -2571,9 +2571,6 @@ func (m *MemoryStore) markMissingRepoFindingsFixedLocked(scope Scope, repoScan R
 }
 
 func repoFindingMatchesFilter(finding domain.Finding, filter RepoFindingFilter) bool {
-	if filter.Status != "" && strings.ToLower(string(finding.LifecycleStatus)) != filter.Status {
-		return false
-	}
 	if filter.Detector != "" && strings.ToLower(strings.TrimSpace(finding.Detector)) != filter.Detector {
 		return false
 	}
@@ -2609,7 +2606,7 @@ func latestRepoFindingLifecycleRows(findings []domain.Finding) []domain.Finding 
 			latest[key] = finding
 			continue
 		}
-		if repoFindingObservedAt(finding).After(repoFindingObservedAt(existing)) {
+		if repoFindingNewer(finding, existing) {
 			latest[key] = finding
 		}
 	}
@@ -2624,6 +2621,20 @@ func latestRepoFindingLifecycleRows(findings []domain.Finding) []domain.Finding 
 
 func repoFindingObservedAt(finding domain.Finding) time.Time {
 	return timeValue(finding.LastSeenAt, finding.CreatedAt)
+}
+
+func repoFindingNewer(left domain.Finding, right domain.Finding) bool {
+	leftObserved := repoFindingObservedAt(left)
+	rightObserved := repoFindingObservedAt(right)
+	if !leftObserved.Equal(rightObserved) {
+		return leftObserved.After(rightObserved)
+	}
+	leftCreated := left.CreatedAt.UTC()
+	rightCreated := right.CreatedAt.UTC()
+	if !leftCreated.Equal(rightCreated) {
+		return leftCreated.After(rightCreated)
+	}
+	return compareMemoryString(left.ScanID+"|"+left.ID, right.ScanID+"|"+right.ID) > 0
 }
 
 func timeValue(value *time.Time, fallback time.Time) time.Time {

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -2461,21 +2461,7 @@ func (m *MemoryStore) applyRepoFindingLifecycleLocked(scope Scope, repoScan Repo
 		} else if !previous.CreatedAt.IsZero() {
 			firstSeen = previous.CreatedAt.UTC()
 		}
-		switch previous.LifecycleStatus {
-		case domain.RepoFindingLifecycleFixed:
-			status = domain.RepoFindingLifecycleReopened
-			reopenedAt := observedAt.UTC()
-			finding.ReopenedAt = &reopenedAt
-		case domain.RepoFindingLifecycleSuppressed, domain.RepoFindingLifecycleRiskAccepted, domain.RepoFindingLifecycleFalsePositive:
-			status = previous.LifecycleStatus
-			finding.DismissedAt = cloneTimePointer(previous.DismissedAt)
-			finding.SuppressionExpiresAt = cloneTimePointer(previous.SuppressionExpiresAt)
-		case domain.RepoFindingLifecycleReopened:
-			status = domain.RepoFindingLifecycleReopened
-			finding.ReopenedAt = cloneTimePointer(previous.ReopenedAt)
-		default:
-			status = domain.RepoFindingLifecycleOpen
-		}
+		status = applyRepoFindingLifecycleSnapshot(finding, previous, observedAt)
 		if finding.Owner == "" {
 			finding.Owner = previous.Owner
 		}

--- a/internal/db/memory_test.go
+++ b/internal/db/memory_test.go
@@ -549,6 +549,84 @@ func TestMemoryStoreListRepoFindingTrendCounts(t *testing.T) {
 	}
 }
 
+func TestMemoryStoreUpsertRepoFindingsReopensExpiredSuppressionSnapshot(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := defaultScopeContext()
+	now := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	firstSeen := now.Add(-48 * time.Hour)
+	dismissedAt := now.Add(-36 * time.Hour)
+	expiredAt := now.Add(-24 * time.Hour)
+	lifecycleKey := "repo_finding\x1fowner/repo\x1fsecret_exposure\x1fgithub_token\x1fconfig/app.env\x1f7\x1fgithub token exposed"
+
+	previousScan, err := store.CreateRepoScan(ctx, "owner/repo", RepoScanSource{}, RepoScanContext{ScanMode: "deep"}, firstSeen)
+	if err != nil {
+		t.Fatalf("create previous repo scan: %v", err)
+	}
+	previousKey := previousScan.ID + "|rf-old"
+	store.mu.Lock()
+	store.repoFindings[previousKey] = domain.Finding{
+		ScanID:               previousScan.ID,
+		ID:                   "rf-old",
+		Type:                 domain.FindingSecretExposure,
+		Severity:             domain.SeverityHigh,
+		Title:                "GitHub token exposed",
+		HumanSummary:         "A token-like value was committed.",
+		Repository:           "owner/repo",
+		FilePath:             "config/app.env",
+		LineNumber:           7,
+		Detector:             "github_token",
+		LifecycleKey:         lifecycleKey,
+		LifecycleStatus:      domain.RepoFindingLifecycleSuppressed,
+		Owner:                "secops",
+		FirstSeenAt:          &firstSeen,
+		LastSeenAt:           &firstSeen,
+		DismissedAt:          &dismissedAt,
+		SuppressionExpiresAt: &expiredAt,
+		CreatedAt:            firstSeen,
+	}
+	store.repoFindingIDs[previousScan.ID] = []string{previousKey}
+	store.mu.Unlock()
+
+	nextScan, err := store.CreateRepoScan(ctx, "owner/repo", RepoScanSource{}, RepoScanContext{ScanMode: "deep"}, now)
+	if err != nil {
+		t.Fatalf("create next repo scan: %v", err)
+	}
+	if err := store.UpsertRepoFindings(ctx, nextScan.ID, []domain.Finding{{
+		ID:           "rf-new",
+		Type:         domain.FindingSecretExposure,
+		Severity:     domain.SeverityHigh,
+		Title:        "GitHub token exposed",
+		HumanSummary: "A token-like value was committed.",
+		Repository:   "owner/repo",
+		FilePath:     "config/app.env",
+		LineNumber:   7,
+		Detector:     "github_token",
+		CreatedAt:    now,
+	}}); err != nil {
+		t.Fatalf("upsert resurfaced repo finding: %v", err)
+	}
+
+	findings, err := store.ListRepoFindings(ctx, RepoFindingFilter{RepoScanID: nextScan.ID}, 10)
+	if err != nil {
+		t.Fatalf("list resurfaced repo finding: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one resurfaced finding, got %+v", findings)
+	}
+	if findings[0].LifecycleStatus != domain.RepoFindingLifecycleReopened {
+		t.Fatalf("expected expired suppression to reopen, got %+v", findings[0])
+	}
+	if findings[0].ReopenedAt == nil || !findings[0].ReopenedAt.Equal(now) {
+		t.Fatalf("expected reopened_at to use current observation time, got %+v", findings[0].ReopenedAt)
+	}
+	if findings[0].SuppressionExpiresAt != nil || findings[0].DismissedAt != nil {
+		t.Fatalf("expected expired dismissal metadata to be cleared, got dismissed_at=%v suppression_expires_at=%v", findings[0].DismissedAt, findings[0].SuppressionExpiresAt)
+	}
+	if findings[0].FirstSeenAt == nil || !findings[0].FirstSeenAt.Equal(firstSeen) || findings[0].Owner != "secops" {
+		t.Fatalf("expected lifecycle history and owner to carry forward, got %+v", findings[0])
+	}
+}
+
 func TestMemoryStoreIdentityAndRelationshipFilters(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -3362,21 +3362,7 @@ func (p *PostgresStore) UpsertRepoFindings(ctx context.Context, repoScanID strin
 			if snapshot.FirstSeenAt != nil && !snapshot.FirstSeenAt.IsZero() {
 				firstSeenAt = snapshot.FirstSeenAt.UTC()
 			}
-			switch snapshot.LifecycleStatus {
-			case domain.RepoFindingLifecycleFixed:
-				status = domain.RepoFindingLifecycleReopened
-				reopenedAt := createdAt.UTC()
-				finding.ReopenedAt = &reopenedAt
-			case domain.RepoFindingLifecycleSuppressed, domain.RepoFindingLifecycleRiskAccepted, domain.RepoFindingLifecycleFalsePositive:
-				status = snapshot.LifecycleStatus
-				finding.DismissedAt = cloneTimePointer(snapshot.DismissedAt)
-				finding.SuppressionExpiresAt = cloneTimePointer(snapshot.SuppressionExpiresAt)
-			case domain.RepoFindingLifecycleReopened:
-				status = domain.RepoFindingLifecycleReopened
-				finding.ReopenedAt = cloneTimePointer(snapshot.ReopenedAt)
-			default:
-				status = domain.RepoFindingLifecycleOpen
-			}
+			status = applyRepoFindingLifecycleSnapshot(&finding, snapshot, createdAt)
 			if finding.Owner == "" {
 				finding.Owner = snapshot.Owner
 			}

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -3100,7 +3100,13 @@ func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string,
 	if err != nil {
 		return fmt.Errorf("marshal repo scan completion changed paths: %w", err)
 	}
-	result, err := p.execContext(
+	tx, err := p.beginTx(ctx)
+	if err != nil {
+		return fmt.Errorf("begin complete repo scan transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	result, err := tx.ExecContext(
 		ctx,
 		`UPDATE repo_scans
 		 SET status = $2,
@@ -3138,6 +3144,7 @@ func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string,
 	}
 	if err := ensureRowsAffected(result); err != nil {
 		if errors.Is(err, ErrNotFound) {
+			_ = tx.Rollback()
 			_, getErr := p.GetRepoScan(ctx, repoScanID)
 			if getErr == nil {
 				return ErrConflict
@@ -3149,35 +3156,37 @@ func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string,
 		return err
 	}
 	if shouldCloseMissingRepoFindings(strings.TrimSpace(status), truncated, normalizedContext) {
-		record, getErr := p.GetRepoScan(ctx, repoScanID)
-		if getErr != nil {
-			return fmt.Errorf("load completed repo scan for lifecycle closure: %w", getErr)
-		}
-		if err := p.markMissingRepoFindingsFixed(ctx, scope, record, finishedAt.UTC()); err != nil {
+		if err := p.markMissingRepoFindingsFixed(ctx, tx, scope, repoScanID, finishedAt.UTC()); err != nil {
 			return err
 		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit complete repo scan transaction: %w", err)
 	}
 	return nil
 }
 
-func (p *PostgresStore) markMissingRepoFindingsFixed(ctx context.Context, scope Scope, repoScan RepoScanRecord, fixedAt time.Time) error {
-	_, err := p.execContext(
+func (p *PostgresStore) markMissingRepoFindingsFixed(ctx context.Context, executor sqlExecutor, scope Scope, repoScanID string, fixedAt time.Time) error {
+	_, err := executor.ExecContext(
 		ctx,
 		`UPDATE repo_findings rf
 		 SET lifecycle_status = 'fixed',
 		     fixed_at = $1
-		 FROM repo_scans rs
+		 FROM repo_scans rs, repo_scans current_rs
 		 WHERE rf.repo_scan_id = rs.id
+		   AND current_rs.id = $4::uuid
+		   AND current_rs.tenant_id = $2
+		   AND current_rs.workspace_id = $3
 		   AND rs.tenant_id = $2
 		   AND rs.workspace_id = $3
-		   AND LOWER(rs.repository) = LOWER($4)
-		   AND rf.repo_scan_id <> $5::uuid
+		   AND LOWER(rs.repository) = LOWER(current_rs.repository)
+		   AND rf.repo_scan_id <> $4::uuid
 		   AND COALESCE(rf.lifecycle_key, '') <> ''
 		   AND COALESCE(rf.lifecycle_status, 'open') IN ('open', 'reopened')
 		   AND NOT EXISTS (
 		       SELECT 1
 		       FROM repo_findings current_rf
-		       WHERE current_rf.repo_scan_id = $5::uuid
+		       WHERE current_rf.repo_scan_id = $4::uuid
 		         AND COALESCE(current_rf.lifecycle_key, '') = COALESCE(rf.lifecycle_key, '')
 		   )
 		   AND NOT EXISTS (
@@ -3193,8 +3202,7 @@ func (p *PostgresStore) markMissingRepoFindingsFixed(ctx context.Context, scope 
 		fixedAt.UTC(),
 		scope.TenantID,
 		scope.WorkspaceID,
-		strings.TrimSpace(repoScan.Repository),
-		repoScan.ID,
+		repoScanID,
 	)
 	if err != nil {
 		return fmt.Errorf("mark missing repo findings fixed: %w", err)
@@ -3652,9 +3660,6 @@ func (p *PostgresStore) ListRepoFindings(ctx context.Context, filter RepoFinding
 		conditions = append(conditions, fmt.Sprintf("LOWER(%s) = LOWER(%s)", repositoryExpr, addArg(normalized.Repository)))
 	}
 	outerConditions := []string{"f.lifecycle_rank = 1"}
-	if normalized.Status != "" {
-		outerConditions = append(outerConditions, fmt.Sprintf("LOWER(f.lifecycle_status) = %s", addArg(normalized.Status)))
-	}
 	if normalized.Detector != "" {
 		outerConditions = append(outerConditions, fmt.Sprintf("LOWER(f.detector) = %s", addArg(normalized.Detector)))
 	}

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -3621,7 +3621,7 @@ func (p *PostgresStore) ListRepoFindings(ctx context.Context, filter RepoFinding
 	}
 	repositoryExpr := `COALESCE(NULLIF(rf.evidence->>'repository', ''), rs.repository)`
 	detectorExpr := `COALESCE(NULLIF(rf.evidence->>'detector', ''), '')`
-	ownerExpr := `COALESCE(NULLIF(rf.owner, ''), NULLIF(rf.evidence->>'owner', ''), NULLIF(rf.evidence->>'owner_hint', ''), NULLIF(rf.evidence->>'owner_team', ''), NULLIF(rf.evidence->>'assignee', ''), '')`
+	ownerExpr := `COALESCE(NULLIF(rf.owner, ''), NULLIF(rf.evidence->>'owner', ''), NULLIF(rf.evidence->>'owner_hint', ''), NULLIF(rf.evidence->>'owner_team', ''), NULLIF(rf.evidence->>'codeowners', ''), NULLIF(rf.evidence->>'assignee', ''), '')`
 	statusExpr := `COALESCE(NULLIF(rf.lifecycle_status, ''), 'open')`
 	confidenceExpr := `CASE
 		WHEN COALESCE(rf.evidence->>'confidence_score', '') ~ '^[0-9]+(\.[0-9]+)?$' THEN (rf.evidence->>'confidence_score')::double precision

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -3148,6 +3148,57 @@ func (p *PostgresStore) CompleteRepoScan(ctx context.Context, repoScanID string,
 		}
 		return err
 	}
+	if shouldCloseMissingRepoFindings(strings.TrimSpace(status), truncated, normalizedContext) {
+		record, getErr := p.GetRepoScan(ctx, repoScanID)
+		if getErr != nil {
+			return fmt.Errorf("load completed repo scan for lifecycle closure: %w", getErr)
+		}
+		if err := p.markMissingRepoFindingsFixed(ctx, scope, record, finishedAt.UTC()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *PostgresStore) markMissingRepoFindingsFixed(ctx context.Context, scope Scope, repoScan RepoScanRecord, fixedAt time.Time) error {
+	_, err := p.execContext(
+		ctx,
+		`UPDATE repo_findings rf
+		 SET lifecycle_status = 'fixed',
+		     fixed_at = $1
+		 FROM repo_scans rs
+		 WHERE rf.repo_scan_id = rs.id
+		   AND rs.tenant_id = $2
+		   AND rs.workspace_id = $3
+		   AND LOWER(rs.repository) = LOWER($4)
+		   AND rf.repo_scan_id <> $5::uuid
+		   AND COALESCE(rf.lifecycle_key, '') <> ''
+		   AND COALESCE(rf.lifecycle_status, 'open') IN ('open', 'reopened')
+		   AND NOT EXISTS (
+		       SELECT 1
+		       FROM repo_findings current_rf
+		       WHERE current_rf.repo_scan_id = $5::uuid
+		         AND COALESCE(current_rf.lifecycle_key, '') = COALESCE(rf.lifecycle_key, '')
+		   )
+		   AND NOT EXISTS (
+		       SELECT 1
+		       FROM repo_findings newer_rf
+		       JOIN repo_scans newer_rs ON newer_rs.id = newer_rf.repo_scan_id
+		       WHERE newer_rs.tenant_id = rs.tenant_id
+		         AND newer_rs.workspace_id = rs.workspace_id
+		         AND LOWER(newer_rs.repository) = LOWER(rs.repository)
+		         AND COALESCE(newer_rf.lifecycle_key, '') = COALESCE(rf.lifecycle_key, '')
+		         AND COALESCE(newer_rf.last_seen_at, newer_rf.created_at) > COALESCE(rf.last_seen_at, rf.created_at)
+		   )`,
+		fixedAt.UTC(),
+		scope.TenantID,
+		scope.WorkspaceID,
+		strings.TrimSpace(repoScan.Repository),
+		repoScan.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("mark missing repo findings fixed: %w", err)
+	}
 	return nil
 }
 
@@ -3247,7 +3298,15 @@ func (p *PostgresStore) UpsertRepoScanCursor(ctx context.Context, cursor RepoSca
 
 // UpsertRepoFindings inserts repository findings idempotently.
 func (p *PostgresStore) UpsertRepoFindings(ctx context.Context, repoScanID string, findings []domain.Finding) error {
-	if err := p.ensureActiveRepoScanInScope(ctx, repoScanID); err != nil {
+	repoScan, err := p.GetRepoScan(ctx, repoScanID)
+	if err != nil {
+		return err
+	}
+	if repoScan.Status != "queued" && repoScan.Status != "running" {
+		return ErrConflict
+	}
+	scope, err := RequireScope(ctx)
+	if err != nil {
 		return err
 	}
 	tx, err := p.beginTx(ctx)
@@ -3263,6 +3322,12 @@ func (p *PostgresStore) UpsertRepoFindings(ctx context.Context, repoScanID strin
 			continue
 		}
 		seenRepoFindings[finding.ID] = struct{}{}
+		if finding.Repository == "" {
+			finding.Repository = strings.TrimSpace(repoScan.Repository)
+		}
+		if finding.ScanMode == "" {
+			finding.ScanMode = strings.TrimSpace(repoScan.ScanMode)
+		}
 		domain.NormalizeRepoFindingMetadata(&finding)
 		pathJSON, pathErr := json.Marshal(finding.Path)
 		if pathErr != nil {
@@ -3274,11 +3339,59 @@ func (p *PostgresStore) UpsertRepoFindings(ctx context.Context, repoScanID strin
 		}
 		createdAt := finding.CreatedAt
 		if createdAt.IsZero() {
+			createdAt = repoScan.StartedAt.UTC()
+		}
+		if createdAt.IsZero() {
 			createdAt = time.Now().UTC()
+		}
+		snapshot, hasSnapshot, snapshotErr := p.latestRepoFindingLifecycleTx(ctx, tx, scope, repoScan.Repository, finding.LifecycleKey, repoScanID)
+		if snapshotErr != nil {
+			return snapshotErr
+		}
+		firstSeenAt := createdAt.UTC()
+		status := domain.RepoFindingLifecycleOpen
+		if hasSnapshot {
+			if snapshot.FirstSeenAt != nil && !snapshot.FirstSeenAt.IsZero() {
+				firstSeenAt = snapshot.FirstSeenAt.UTC()
+			}
+			switch snapshot.LifecycleStatus {
+			case domain.RepoFindingLifecycleFixed:
+				status = domain.RepoFindingLifecycleReopened
+				reopenedAt := createdAt.UTC()
+				finding.ReopenedAt = &reopenedAt
+			case domain.RepoFindingLifecycleSuppressed, domain.RepoFindingLifecycleRiskAccepted, domain.RepoFindingLifecycleFalsePositive:
+				status = snapshot.LifecycleStatus
+				finding.DismissedAt = cloneTimePointer(snapshot.DismissedAt)
+				finding.SuppressionExpiresAt = cloneTimePointer(snapshot.SuppressionExpiresAt)
+			case domain.RepoFindingLifecycleReopened:
+				status = domain.RepoFindingLifecycleReopened
+				finding.ReopenedAt = cloneTimePointer(snapshot.ReopenedAt)
+			default:
+				status = domain.RepoFindingLifecycleOpen
+			}
+			if finding.Owner == "" {
+				finding.Owner = snapshot.Owner
+			}
+		}
+		firstSeenCopy := firstSeenAt.UTC()
+		lastSeenCopy := createdAt.UTC()
+		finding.FirstSeenAt = &firstSeenCopy
+		finding.LastSeenAt = &lastSeenCopy
+		finding.FixedAt = nil
+		finding.LifecycleStatus = status
+		domain.NormalizeRepoFindingMetadata(&finding)
+		pathJSON, pathErr = json.Marshal(finding.Path)
+		if pathErr != nil {
+			return fmt.Errorf("marshal repo finding path: %w", pathErr)
+		}
+		evidenceJSON, evidenceErr = json.Marshal(finding.Evidence)
+		if evidenceErr != nil {
+			return fmt.Errorf("marshal repo finding evidence: %w", evidenceErr)
 		}
 		rows = append(rows, []any{
 			repoScanID,
 			finding.ID,
+			finding.LifecycleKey,
 			string(finding.Type),
 			string(finding.Severity),
 			finding.Title,
@@ -3287,14 +3400,30 @@ func (p *PostgresStore) UpsertRepoFindings(ctx context.Context, repoScanID strin
 			evidenceJSON,
 			finding.Remediation,
 			createdAt.UTC(),
+			nullableTimePointer(finding.FirstSeenAt),
+			nullableTimePointer(finding.LastSeenAt),
+			nullableTimePointer(finding.FixedAt),
+			nullableTimePointer(finding.ReopenedAt),
+			nullableTimePointer(finding.DismissedAt),
+			nullableTimePointer(finding.SuppressionExpiresAt),
+			string(finding.LifecycleStatus),
+			nullableString(finding.Owner),
+			nullableString(finding.RuleVersion),
+			nullableString(finding.DetectorVersion),
+			nullableString(finding.AdapterSource),
+			nullableString(finding.ConfidenceState),
+			nullableString(finding.VerificationStatus),
+			nullableString(finding.ScanMode),
+			nullableString(finding.EvidenceVersion),
 		})
 	}
 	if err := executeBulkInsert(
 		ctx,
 		tx,
-		`INSERT INTO repo_findings (repo_scan_id, finding_id, type, severity, title, human_summary, path, evidence, remediation, created_at) VALUES `,
+		`INSERT INTO repo_findings (repo_scan_id, finding_id, lifecycle_key, type, severity, title, human_summary, path, evidence, remediation, created_at, first_seen_at, last_seen_at, fixed_at, reopened_at, dismissed_at, suppression_expires_at, lifecycle_status, owner, rule_version, detector_version, adapter_source, confidence_state, verification_status, scan_mode, evidence_version) VALUES `,
 		` ON CONFLICT (repo_scan_id, finding_id)
 		  DO UPDATE SET
+		    lifecycle_key = EXCLUDED.lifecycle_key,
 		    type = EXCLUDED.type,
 		    severity = EXCLUDED.severity,
 		    title = EXCLUDED.title,
@@ -3302,7 +3431,22 @@ func (p *PostgresStore) UpsertRepoFindings(ctx context.Context, repoScanID strin
 		    path = EXCLUDED.path,
 		    evidence = EXCLUDED.evidence,
 		    remediation = EXCLUDED.remediation,
-		    created_at = EXCLUDED.created_at`,
+		    created_at = EXCLUDED.created_at,
+		    first_seen_at = EXCLUDED.first_seen_at,
+		    last_seen_at = EXCLUDED.last_seen_at,
+		    fixed_at = EXCLUDED.fixed_at,
+		    reopened_at = EXCLUDED.reopened_at,
+		    dismissed_at = EXCLUDED.dismissed_at,
+		    suppression_expires_at = EXCLUDED.suppression_expires_at,
+		    lifecycle_status = EXCLUDED.lifecycle_status,
+		    owner = EXCLUDED.owner,
+		    rule_version = EXCLUDED.rule_version,
+		    detector_version = EXCLUDED.detector_version,
+		    adapter_source = EXCLUDED.adapter_source,
+		    confidence_state = EXCLUDED.confidence_state,
+		    verification_status = EXCLUDED.verification_status,
+		    scan_mode = EXCLUDED.scan_mode,
+		    evidence_version = EXCLUDED.evidence_version`,
 		rows,
 	); err != nil {
 		return fmt.Errorf("upsert repo findings: %w", err)
@@ -3311,6 +3455,81 @@ func (p *PostgresStore) UpsertRepoFindings(ctx context.Context, repoScanID strin
 		return fmt.Errorf("commit repo findings transaction: %w", err)
 	}
 	return nil
+}
+
+func (p *PostgresStore) latestRepoFindingLifecycleTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	scope Scope,
+	repository string,
+	lifecycleKey string,
+	excludeRepoScanID string,
+) (domain.Finding, bool, error) {
+	lifecycleKey = strings.TrimSpace(lifecycleKey)
+	if lifecycleKey == "" {
+		return domain.Finding{}, false, nil
+	}
+	row := tx.QueryRowContext(
+		ctx,
+		`SELECT
+		     COALESCE(rf.first_seen_at, rf.created_at),
+		     COALESCE(rf.lifecycle_status, 'open'),
+		     rf.fixed_at,
+		     rf.reopened_at,
+		     rf.dismissed_at,
+		     rf.suppression_expires_at,
+		     COALESCE(rf.owner, '')
+		 FROM repo_findings rf
+		 JOIN repo_scans rs ON rs.id = rf.repo_scan_id
+		 WHERE rs.tenant_id = $1
+		   AND rs.workspace_id = $2
+		   AND LOWER(rs.repository) = LOWER($3)
+		   AND COALESCE(rf.lifecycle_key, '') = $4
+		   AND rf.repo_scan_id <> $5::uuid
+		 ORDER BY COALESCE(rf.last_seen_at, rf.created_at) DESC, rf.created_at DESC
+		 LIMIT 1`,
+		scope.TenantID,
+		scope.WorkspaceID,
+		strings.TrimSpace(repository),
+		lifecycleKey,
+		excludeRepoScanID,
+	)
+	var firstSeenAt time.Time
+	var status string
+	var fixedAt sql.NullTime
+	var reopenedAt sql.NullTime
+	var dismissedAt sql.NullTime
+	var suppressionExpiresAt sql.NullTime
+	var owner string
+	if err := row.Scan(&firstSeenAt, &status, &fixedAt, &reopenedAt, &dismissedAt, &suppressionExpiresAt, &owner); err != nil {
+		if errorsIsNoRows(err) {
+			return domain.Finding{}, false, nil
+		}
+		return domain.Finding{}, false, fmt.Errorf("query repo finding lifecycle snapshot: %w", err)
+	}
+	firstSeen := firstSeenAt.UTC()
+	snapshot := domain.Finding{
+		FirstSeenAt:     &firstSeen,
+		LifecycleStatus: domain.NormalizeRepoFindingLifecycleStatus(status),
+		Owner:           owner,
+	}
+	if fixedAt.Valid {
+		value := fixedAt.Time.UTC()
+		snapshot.FixedAt = &value
+	}
+	if reopenedAt.Valid {
+		value := reopenedAt.Time.UTC()
+		snapshot.ReopenedAt = &value
+	}
+	if dismissedAt.Valid {
+		value := dismissedAt.Time.UTC()
+		snapshot.DismissedAt = &value
+	}
+	if suppressionExpiresAt.Valid {
+		value := suppressionExpiresAt.Time.UTC()
+		snapshot.SuppressionExpiresAt = &value
+	}
+	return snapshot, true, nil
 }
 
 // DeleteRepoFindings removes repository findings for one scan.
@@ -3392,29 +3611,147 @@ func (p *PostgresStore) ListRepoFindings(ctx context.Context, filter RepoFinding
 	if err != nil {
 		return nil, err
 	}
-	query := `SELECT rf.repo_scan_id, rf.finding_id, rf.type, rf.severity, rf.title, rf.human_summary, rf.path, rf.evidence, COALESCE(rf.remediation, ''), rf.created_at, rs.repository
-		 FROM repo_findings rf
-		 JOIN repo_scans rs ON rs.id = rf.repo_scan_id
-		 WHERE ($1 = '' OR rf.repo_scan_id = $1::uuid)
-		   AND ($2 = '' OR rf.finding_id = $2)
-		   AND ($3 = '' OR rf.severity = $3)
-		   AND ($4 = '' OR rf.type = $4)
-		   AND ($5 = '' OR lower(rs.repository) = lower($5))
-		   AND rs.tenant_id = $6
-		   AND rs.workspace_id = $7
-		 ORDER BY ` + repoFindingOrderClause(normalized.SortBy, normalized.SortDesc)
-	args := []any{
-		repoScanID,
-		normalized.FindingID,
-		normalized.Severity,
-		normalized.Type,
-		normalized.Repository,
-		scope.TenantID,
-		scope.WorkspaceID,
+	repositoryExpr := `COALESCE(NULLIF(rf.evidence->>'repository', ''), rs.repository)`
+	detectorExpr := `COALESCE(NULLIF(rf.evidence->>'detector', ''), '')`
+	ownerExpr := `COALESCE(NULLIF(rf.owner, ''), NULLIF(rf.evidence->>'owner', ''), NULLIF(rf.evidence->>'owner_hint', ''), NULLIF(rf.evidence->>'owner_team', ''), NULLIF(rf.evidence->>'assignee', ''), '')`
+	statusExpr := `COALESCE(NULLIF(rf.lifecycle_status, ''), 'open')`
+	confidenceExpr := `CASE
+		WHEN COALESCE(rf.evidence->>'confidence_score', '') ~ '^[0-9]+(\.[0-9]+)?$' THEN (rf.evidence->>'confidence_score')::double precision
+		ELSE 0
+	END`
+	lifecycleKeyExpr := fmt.Sprintf(
+		`COALESCE(NULLIF(rf.lifecycle_key, ''), CONCAT_WS(E'\x1f', 'repo_finding', LOWER(%s), rf.type, LOWER(%s), LOWER(COALESCE(NULLIF(rf.evidence->>'file_path', ''), '')), COALESCE(NULLIF(rf.evidence->>'line_number', ''), ''), rf.finding_id))`,
+		repositoryExpr,
+		detectorExpr,
+	)
+	partitionExpr := lifecycleKeyExpr
+	if repoScanID != "" || normalized.IncludeHistorical {
+		partitionExpr = `rf.repo_scan_id::text || E'\x1f' || rf.finding_id`
 	}
+	conditions := []string{}
+	args := []any{}
+	addArg := func(value any) string {
+		args = append(args, value)
+		return fmt.Sprintf("$%d", len(args))
+	}
+	conditions = append(conditions, fmt.Sprintf("rs.tenant_id = %s", addArg(scope.TenantID)))
+	conditions = append(conditions, fmt.Sprintf("rs.workspace_id = %s", addArg(scope.WorkspaceID)))
+	if repoScanID != "" {
+		conditions = append(conditions, fmt.Sprintf("rf.repo_scan_id = %s::uuid", addArg(repoScanID)))
+	}
+	if normalized.FindingID != "" {
+		conditions = append(conditions, fmt.Sprintf("rf.finding_id = %s", addArg(normalized.FindingID)))
+	}
+	if normalized.Severity != "" {
+		conditions = append(conditions, fmt.Sprintf("LOWER(rf.severity) = %s", addArg(normalized.Severity)))
+	}
+	if normalized.Type != "" {
+		conditions = append(conditions, fmt.Sprintf("LOWER(rf.type) = %s", addArg(normalized.Type)))
+	}
+	if normalized.Repository != "" {
+		conditions = append(conditions, fmt.Sprintf("LOWER(%s) = LOWER(%s)", repositoryExpr, addArg(normalized.Repository)))
+	}
+	outerConditions := []string{"f.lifecycle_rank = 1"}
+	if normalized.Status != "" {
+		outerConditions = append(outerConditions, fmt.Sprintf("LOWER(f.lifecycle_status) = %s", addArg(normalized.Status)))
+	}
+	if normalized.Detector != "" {
+		outerConditions = append(outerConditions, fmt.Sprintf("LOWER(f.detector) = %s", addArg(normalized.Detector)))
+	}
+	if normalized.Owner != "" {
+		outerConditions = append(outerConditions, fmt.Sprintf("LOWER(f.owner) = %s", addArg(normalized.Owner)))
+	}
+	if normalized.MinConfidence > 0 {
+		outerConditions = append(outerConditions, fmt.Sprintf("f.confidence_score >= %s", addArg(normalized.MinConfidence)))
+	}
+	if normalized.MinAgeDays > 0 {
+		cutoff := normalized.Now.Add(-time.Duration(normalized.MinAgeDays) * 24 * time.Hour)
+		outerConditions = append(outerConditions, fmt.Sprintf("COALESCE(f.first_seen_at, f.created_at) <= %s", addArg(cutoff.UTC())))
+	}
+	query := fmt.Sprintf(
+		`WITH filtered AS (
+	SELECT
+		rf.repo_scan_id,
+		rf.finding_id,
+		rf.type,
+		rf.severity,
+		rf.title,
+		rf.human_summary,
+		rf.path,
+		rf.evidence,
+		COALESCE(rf.remediation, '') AS remediation,
+		rf.created_at,
+		%s AS repository,
+		%s AS lifecycle_key,
+		%s AS lifecycle_status,
+		%s AS detector,
+		%s AS confidence_score,
+		rf.first_seen_at,
+		rf.last_seen_at,
+		rf.fixed_at,
+		rf.reopened_at,
+		rf.dismissed_at,
+		rf.suppression_expires_at,
+		%s AS owner,
+		COALESCE(rf.rule_version, '') AS rule_version,
+		COALESCE(rf.detector_version, '') AS detector_version,
+		COALESCE(rf.adapter_source, '') AS adapter_source,
+		COALESCE(rf.confidence_state, '') AS confidence_state,
+		COALESCE(rf.verification_status, '') AS verification_status,
+		COALESCE(rf.scan_mode, '') AS scan_mode,
+		COALESCE(rf.evidence_version, '') AS evidence_version,
+		ROW_NUMBER() OVER (
+			PARTITION BY %s
+			ORDER BY COALESCE(rf.last_seen_at, rf.created_at) DESC, rf.created_at DESC, rf.repo_scan_id DESC, rf.finding_id ASC
+		) AS lifecycle_rank
+	FROM repo_findings rf
+	JOIN repo_scans rs ON rs.id = rf.repo_scan_id
+	WHERE %s
+)
+SELECT
+	f.repo_scan_id,
+	f.finding_id,
+	f.type,
+	f.severity,
+	f.title,
+	f.human_summary,
+	f.path,
+	f.evidence,
+	f.remediation,
+	f.created_at,
+	f.repository,
+	f.lifecycle_key,
+	f.lifecycle_status,
+	f.first_seen_at,
+	f.last_seen_at,
+	f.fixed_at,
+	f.reopened_at,
+	f.dismissed_at,
+	f.suppression_expires_at,
+	f.owner,
+	f.rule_version,
+	f.detector_version,
+	f.adapter_source,
+	f.confidence_state,
+	f.verification_status,
+	f.scan_mode,
+	f.evidence_version
+FROM filtered f
+WHERE %s
+ORDER BY %s`,
+		repositoryExpr,
+		lifecycleKeyExpr,
+		statusExpr,
+		detectorExpr,
+		confidenceExpr,
+		ownerExpr,
+		partitionExpr,
+		strings.Join(conditions, " AND "),
+		strings.Join(outerConditions, " AND "),
+		repoFindingOrderClause(normalized.SortBy, normalized.SortDesc),
+	)
 	if limit > 0 {
-		query += "\n\t\t LIMIT $8"
-		args = append(args, limit)
+		query += "\n\t\t LIMIT " + addArg(limit)
 	}
 	rows, err := p.queryContext(
 		ctx,
@@ -3428,17 +3765,33 @@ func (p *PostgresStore) ListRepoFindings(ctx context.Context, filter RepoFinding
 	result := []domain.Finding{}
 	for rows.Next() {
 		var row struct {
-			RepoScanID   string
-			FindingID    string
-			Type         string
-			Severity     string
-			Title        string
-			HumanSummary string
-			Path         []byte
-			Evidence     []byte
-			Remediation  string
-			CreatedAt    time.Time
-			Repository   string
+			RepoScanID           string
+			FindingID            string
+			Type                 string
+			Severity             string
+			Title                string
+			HumanSummary         string
+			Path                 []byte
+			Evidence             []byte
+			Remediation          string
+			CreatedAt            time.Time
+			Repository           string
+			LifecycleKey         string
+			LifecycleStatus      string
+			FirstSeenAt          sql.NullTime
+			LastSeenAt           sql.NullTime
+			FixedAt              sql.NullTime
+			ReopenedAt           sql.NullTime
+			DismissedAt          sql.NullTime
+			SuppressionExpiresAt sql.NullTime
+			Owner                string
+			RuleVersion          string
+			DetectorVersion      string
+			AdapterSource        string
+			ConfidenceState      string
+			VerificationStatus   string
+			ScanMode             string
+			EvidenceVersion      string
 		}
 		if err := rows.Scan(
 			&row.RepoScanID,
@@ -3452,21 +3805,69 @@ func (p *PostgresStore) ListRepoFindings(ctx context.Context, filter RepoFinding
 			&row.Remediation,
 			&row.CreatedAt,
 			&row.Repository,
+			&row.LifecycleKey,
+			&row.LifecycleStatus,
+			&row.FirstSeenAt,
+			&row.LastSeenAt,
+			&row.FixedAt,
+			&row.ReopenedAt,
+			&row.DismissedAt,
+			&row.SuppressionExpiresAt,
+			&row.Owner,
+			&row.RuleVersion,
+			&row.DetectorVersion,
+			&row.AdapterSource,
+			&row.ConfidenceState,
+			&row.VerificationStatus,
+			&row.ScanMode,
+			&row.EvidenceVersion,
 		); err != nil {
 			return nil, fmt.Errorf("repo finding row: %w", err)
 		}
 		finding := domain.Finding{
-			ScanID:       row.RepoScanID,
-			ID:           row.FindingID,
-			Type:         domain.FindingType(row.Type),
-			Severity:     domain.FindingSeverity(row.Severity),
-			Title:        row.Title,
-			HumanSummary: row.HumanSummary,
-			Remediation:  row.Remediation,
-			CreatedAt:    row.CreatedAt,
+			ScanID:             row.RepoScanID,
+			ID:                 row.FindingID,
+			Type:               domain.FindingType(row.Type),
+			Severity:           domain.FindingSeverity(row.Severity),
+			Title:              row.Title,
+			HumanSummary:       row.HumanSummary,
+			Remediation:        row.Remediation,
+			CreatedAt:          row.CreatedAt,
+			Repository:         strings.TrimSpace(row.Repository),
+			LifecycleKey:       row.LifecycleKey,
+			LifecycleStatus:    domain.NormalizeRepoFindingLifecycleStatus(row.LifecycleStatus),
+			Owner:              row.Owner,
+			RuleVersion:        row.RuleVersion,
+			DetectorVersion:    row.DetectorVersion,
+			AdapterSource:      row.AdapterSource,
+			ConfidenceState:    row.ConfidenceState,
+			VerificationStatus: row.VerificationStatus,
+			ScanMode:           row.ScanMode,
+			EvidenceVersion:    row.EvidenceVersion,
 		}
-		if finding.Repository == "" {
-			finding.Repository = strings.TrimSpace(row.Repository)
+		if row.FirstSeenAt.Valid {
+			value := row.FirstSeenAt.Time.UTC()
+			finding.FirstSeenAt = &value
+		}
+		if row.LastSeenAt.Valid {
+			value := row.LastSeenAt.Time.UTC()
+			finding.LastSeenAt = &value
+		}
+		if row.FixedAt.Valid {
+			value := row.FixedAt.Time.UTC()
+			finding.FixedAt = &value
+		}
+		if row.ReopenedAt.Valid {
+			value := row.ReopenedAt.Time.UTC()
+			finding.ReopenedAt = &value
+		}
+		if row.DismissedAt.Valid {
+			value := row.DismissedAt.Time.UTC()
+			finding.DismissedAt = &value
+		}
+		if row.SuppressionExpiresAt.Valid {
+			value := row.SuppressionExpiresAt.Time.UTC()
+			finding.SuppressionExpiresAt = &value
 		}
 		if len(row.Path) > 0 {
 			if err := json.Unmarshal(row.Path, &finding.Path); err != nil {
@@ -3898,6 +4299,21 @@ func nullableTime(value time.Time) any {
 		return nil
 	}
 	return value.UTC()
+}
+
+func nullableTimePointer(value *time.Time) any {
+	if value == nil || value.IsZero() {
+		return nil
+	}
+	return value.UTC()
+}
+
+func cloneTimePointer(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	normalized := value.UTC()
+	return &normalized
 }
 
 const bulkInsertChunkSize = 100
@@ -4729,20 +5145,28 @@ func repoFindingOrderClause(sortBy string, desc bool) string {
 	}
 	switch sortBy {
 	case "severity":
-		return fmt.Sprintf(`CASE LOWER(rf.severity)
+		return fmt.Sprintf(`CASE LOWER(f.severity)
 			WHEN 'critical' THEN 5
 			WHEN 'high' THEN 4
 			WHEN 'medium' THEN 3
 			WHEN 'low' THEN 2
 			WHEN 'info' THEN 1
 			ELSE 0
-		END %s, rf.repo_scan_id %s, rf.finding_id %s`, direction, direction, direction)
+		END %s, f.repo_scan_id %s, f.finding_id %s`, direction, direction, direction)
 	case "type":
-		return fmt.Sprintf("LOWER(rf.type) %s, rf.repo_scan_id %s, rf.finding_id %s", direction, direction, direction)
+		return fmt.Sprintf("LOWER(f.type) %s, f.repo_scan_id %s, f.finding_id %s", direction, direction, direction)
 	case "title":
-		return fmt.Sprintf("LOWER(rf.title) %s, rf.repo_scan_id %s, rf.finding_id %s", direction, direction, direction)
+		return fmt.Sprintf("LOWER(f.title) %s, f.repo_scan_id %s, f.finding_id %s", direction, direction, direction)
+	case "first_seen_at":
+		return fmt.Sprintf("COALESCE(f.first_seen_at, f.created_at) %s, f.repo_scan_id %s, f.finding_id %s", direction, direction, direction)
+	case "last_seen_at":
+		return fmt.Sprintf("COALESCE(f.last_seen_at, f.created_at) %s, f.repo_scan_id %s, f.finding_id %s", direction, direction, direction)
+	case "status":
+		return fmt.Sprintf("LOWER(f.lifecycle_status) %s, f.repo_scan_id %s, f.finding_id %s", direction, direction, direction)
+	case "owner":
+		return fmt.Sprintf("LOWER(f.owner) %s, f.repo_scan_id %s, f.finding_id %s", direction, direction, direction)
 	default:
-		return fmt.Sprintf("rf.created_at %s, rf.repo_scan_id %s, rf.finding_id %s", direction, direction, direction)
+		return fmt.Sprintf("f.created_at %s, f.repo_scan_id %s, f.finding_id %s", direction, direction, direction)
 	}
 }
 

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -719,6 +719,7 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		t.Fatalf("upsert repo findings failed: %v", err)
 	}
 
+	mock.ExpectBegin()
 	mock.ExpectExec(regexp.QuoteMeta(`UPDATE repo_scans
 		 SET status = $2,
 		     finished_at = $3,
@@ -737,12 +738,10 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		   AND status IN ('queued', 'running')`)).
 		WithArgs(record.ID, "completed", sqlmock.AnyArg(), 12, 8, 1, false, "", "", "", "[]", nil, "default", "default").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, repository, status").
-		WithArgs(record.ID, "default", "default").
-		WillReturnRows(repoScanRows(record.ID, "completed", now, now))
 	mock.ExpectExec("UPDATE repo_findings rf").
-		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", record.ID).
+		WithArgs(sqlmock.AnyArg(), "default", "default", record.ID).
 		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
 
 	if err := store.CompleteRepoScan(defaultScopeContext(), record.ID, "completed", now, 12, 8, 1, false, RepoScanContext{}, ""); err != nil {
 		t.Fatalf("complete repo scan failed: %v", err)
@@ -1708,6 +1707,7 @@ func TestPostgresStoreCompleteRepoScanReturnsConflictForTerminalScan(t *testing.
 	scanID := "11111111-1111-1111-1111-111111111111"
 	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
 
+	mock.ExpectBegin()
 	mock.ExpectExec(regexp.QuoteMeta(`UPDATE repo_scans
 		 SET status = $2,
 		     finished_at = $3,
@@ -1726,6 +1726,7 @@ func TestPostgresStoreCompleteRepoScanReturnsConflictForTerminalScan(t *testing.
 		   AND status IN ('queued', 'running')`)).
 		WithArgs(scanID, "completed", now, 4, 2, 1, false, "", "", "", "[]", nil, "default", "default").
 		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectRollback()
 
 	rows := sqlmock.NewRows([]string{
 		"id",

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -841,6 +841,81 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 	}
 }
 
+func TestPostgresStoreUpsertRepoFindingsReopensExpiredSuppressionSnapshot(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	now := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	firstSeen := now.Add(-48 * time.Hour)
+	dismissedAt := now.Add(-36 * time.Hour)
+	expiredAt := now.Add(-24 * time.Hour)
+	scanID := "11111111-1111-1111-1111-111111111111"
+
+	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, repository, status").
+		WithArgs(scanID, "default", "default").
+		WillReturnRows(repoScanRows(scanID, "running", now, nil))
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT COALESCE\\(rf.first_seen_at").
+		WithArgs("default", "default", "owner/repo", sqlmock.AnyArg(), scanID).
+		WillReturnRows(sqlmock.NewRows([]string{"first_seen_at", "lifecycle_status", "fixed_at", "reopened_at", "dismissed_at", "suppression_expires_at", "owner"}).
+			AddRow(firstSeen, string(domain.RepoFindingLifecycleSuppressed), nil, nil, dismissedAt, expiredAt, "secops"))
+	mock.ExpectExec("INSERT INTO repo_findings").
+		WithArgs(
+			scanID,
+			"rf-new",
+			sqlmock.AnyArg(),
+			string(domain.FindingSecretExposure),
+			string(domain.SeverityHigh),
+			"GitHub token exposed",
+			"A token-like value was committed.",
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			"Rotate the token.",
+			now,
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			nil,
+			sqlmock.AnyArg(),
+			nil,
+			nil,
+			string(domain.RepoFindingLifecycleReopened),
+			"secops",
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			"deep",
+			nil,
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	if err := store.UpsertRepoFindings(defaultScopeContext(), scanID, []domain.Finding{{
+		ID:           "rf-new",
+		Type:         domain.FindingSecretExposure,
+		Severity:     domain.SeverityHigh,
+		Title:        "GitHub token exposed",
+		HumanSummary: "A token-like value was committed.",
+		Repository:   "owner/repo",
+		FilePath:     "config/app.env",
+		LineNumber:   7,
+		Detector:     "github_token",
+		Remediation:  "Rotate the token.",
+		CreatedAt:    now,
+	}}); err != nil {
+		t.Fatalf("upsert resurfaced repo finding: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestPostgresStoreUpsertRepoFindingsRejectsTerminalScan(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -674,6 +674,35 @@ func repoFindingLifecycleRows(recordID string, now time.Time) *sqlmock.Rows {
 			"platform", "", "", "", "", "", "deep", "")
 }
 
+func TestPostgresStoreListRepoFindingsOwnerFilterIncludesCodeowners(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPostgresStoreWithDB(db)
+	now := time.Now().UTC()
+
+	mock.ExpectQuery(regexp.QuoteMeta("NULLIF(rf.evidence->>'codeowners', '')")).
+		WithArgs("default", "default", "secops", 100).
+		WillReturnRows(sqlmock.NewRows(repoFindingLifecycleColumns()).
+			AddRow("repo-scan-1", "rf-codeowners", "repo_misconfig", "medium", "workflow", "summary", []byte(`[".github/workflows/build.yml"]`), []byte(`{"codeowners":"secops"}`), "fix", now, "owner/repo",
+				"repo_finding\x1fowner/repo\x1frepo_misconfig\x1fworkflow\x1f.github/workflows/build.yml\x1f\x1frf-codeowners", "open", now, now, nil, nil, nil, nil,
+				"secops", "", "", "", "", "", "deep", ""))
+
+	findings, err := store.ListRepoFindings(defaultScopeContext(), RepoFindingFilter{Owner: " SECOPS "}, 100)
+	if err != nil {
+		t.Fatalf("list repo findings by codeowners owner: %v", err)
+	}
+	if len(findings) != 1 || findings[0].ID != "rf-codeowners" || findings[0].Owner != "secops" {
+		t.Fatalf("expected codeowners-backed owner result, got %+v", findings)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -654,6 +654,26 @@ func TestNewPostgresStoreWithDB(t *testing.T) {
 	}
 }
 
+func repoScanRows(recordID string, status string, startedAt time.Time, finishedAt any) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "scan_mode", "base_revision", "head_revision", "cursor_before", "cursor_after", "changed_paths", "error_message", "history_limit", "max_findings_limit", "source_provider", "source_project_id", "source_connector_id", "source_installation_id"}).
+		AddRow(recordID, "default", "default", "owner/repo", status, startedAt, finishedAt, 12, 8, 1, false, "deep", "", "", "", "", []byte("[]"), "", 0, 0, "", "", "", int64(0))
+}
+
+func repoFindingLifecycleColumns() []string {
+	return []string{
+		"repo_scan_id", "finding_id", "type", "severity", "title", "human_summary", "path", "evidence", "remediation", "created_at", "repository",
+		"lifecycle_key", "lifecycle_status", "first_seen_at", "last_seen_at", "fixed_at", "reopened_at", "dismissed_at", "suppression_expires_at",
+		"owner", "rule_version", "detector_version", "adapter_source", "confidence_state", "verification_status", "scan_mode", "evidence_version",
+	}
+}
+
+func repoFindingLifecycleRows(recordID string, now time.Time) *sqlmock.Rows {
+	return sqlmock.NewRows(repoFindingLifecycleColumns()).
+		AddRow(recordID, "rf-1", "secret_exposure", "high", "secret", "summary", []byte(`["app.env"]`), []byte(`{"k":"v"}`), "fix", now, "owner/repo",
+			"repo_finding\x1fowner/repo\x1fsecret_exposure\x1f\x1fapp.env\x1f\x1frf-1", "open", now, now, nil, nil, nil, nil,
+			"platform", "", "", "", "", "", "deep", "")
+}
+
 func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -674,16 +694,14 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		t.Fatalf("create repo scan failed: %v", err)
 	}
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT status
-		 FROM repo_scans
-		 WHERE id = $1
-		   AND tenant_id = $2
-		   AND workspace_id = $3`)).
+	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, repository, status").
 		WithArgs(record.ID, "default", "default").
-		WillReturnRows(sqlmock.NewRows([]string{"status"}).AddRow("running"))
+		WillReturnRows(repoScanRows(record.ID, "running", now, nil))
 	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT COALESCE\\(rf.first_seen_at").
+		WithArgs("default", "default", "owner/repo", sqlmock.AnyArg(), record.ID).
+		WillReturnRows(sqlmock.NewRows([]string{"first_seen_at", "lifecycle_status", "fixed_at", "reopened_at", "dismissed_at", "suppression_expires_at", "owner"}))
 	mock.ExpectExec("INSERT INTO repo_findings").
-		WithArgs(record.ID, "rf-1", "secret_exposure", "high", "secret", "summary", sqlmock.AnyArg(), sqlmock.AnyArg(), "fix", sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
@@ -719,14 +737,18 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		   AND status IN ('queued', 'running')`)).
 		WithArgs(record.ID, "completed", sqlmock.AnyArg(), 12, 8, 1, false, "", "", "", "[]", nil, "default", "default").
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, repository, status").
+		WithArgs(record.ID, "default", "default").
+		WillReturnRows(repoScanRows(record.ID, "completed", now, now))
+	mock.ExpectExec("UPDATE repo_findings rf").
+		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", record.ID).
+		WillReturnResult(sqlmock.NewResult(0, 0))
 
 	if err := store.CompleteRepoScan(defaultScopeContext(), record.ID, "completed", now, 12, 8, 1, false, RepoScanContext{}, ""); err != nil {
 		t.Fatalf("complete repo scan failed: %v", err)
 	}
 
-	repoScanRows := sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "scan_mode", "base_revision", "head_revision", "cursor_before", "cursor_after", "changed_paths", "error_message", "history_limit", "max_findings_limit", "source_provider", "source_project_id", "source_connector_id", "source_installation_id"}).
-		AddRow(record.ID, "default", "default", "owner/repo", "completed", now, now, 12, 8, 1, false, "deep", "", "", "", "", []byte("[]"), "", 0, 0, "", "", "", int64(0))
-	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, repository, status").WithArgs("default", "default", 20).WillReturnRows(repoScanRows)
+	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, repository, status").WithArgs("default", "default", 20).WillReturnRows(repoScanRows(record.ID, "completed", now, now))
 	repoScans, err := store.ListRepoScans(defaultScopeContext(), 20)
 	if err != nil {
 		t.Fatalf("list repo scans failed: %v", err)
@@ -735,8 +757,6 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		t.Fatalf("unexpected repo scans: %+v", repoScans)
 	}
 
-	repoFindingsRows := sqlmock.NewRows([]string{"repo_scan_id", "finding_id", "type", "severity", "title", "human_summary", "path", "evidence", "remediation", "created_at", "repository"}).
-		AddRow(record.ID, "rf-1", "secret_exposure", "high", "secret", "summary", []byte(`["app.env"]`), []byte(`{"k":"v"}`), "fix", now, "owner/repo")
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT EXISTS (
 			SELECT 1
 			FROM repo_scans
@@ -746,7 +766,7 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		)`)).
 		WithArgs(record.ID, "default", "default").
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
-	mock.ExpectQuery("SELECT rf.repo_scan_id, rf.finding_id, rf.type").WithArgs(record.ID, "", "", "", "", "default", "default", 100).WillReturnRows(repoFindingsRows)
+	mock.ExpectQuery("WITH filtered AS").WithArgs("default", "default", record.ID, 100).WillReturnRows(repoFindingLifecycleRows(record.ID, now))
 	repoFindings, err := store.ListRepoFindings(defaultScopeContext(), RepoFindingFilter{RepoScanID: record.ID}, 100)
 	if err != nil {
 		t.Fatalf("list repo findings failed: %v", err)
@@ -758,8 +778,6 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		t.Fatalf("expected repository backfill from repo scan, got %+v", repoFindings[0])
 	}
 
-	unboundedRepoFindingsRows := sqlmock.NewRows([]string{"repo_scan_id", "finding_id", "type", "severity", "title", "human_summary", "path", "evidence", "remediation", "created_at", "repository"}).
-		AddRow(record.ID, "rf-1", "secret_exposure", "high", "secret", "summary", []byte(`["app.env"]`), []byte(`{"k":"v"}`), "fix", now, "owner/repo")
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT EXISTS (
 			SELECT 1
 			FROM repo_scans
@@ -769,7 +787,7 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		)`)).
 		WithArgs(record.ID, "default", "default").
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
-	mock.ExpectQuery("SELECT rf.repo_scan_id, rf.finding_id, rf.type").WithArgs(record.ID, "", "", "", "", "default", "default").WillReturnRows(unboundedRepoFindingsRows)
+	mock.ExpectQuery("WITH filtered AS").WithArgs("default", "default", record.ID).WillReturnRows(repoFindingLifecycleRows(record.ID, now))
 	unboundedRepoFindings, err := store.ListRepoFindings(defaultScopeContext(), RepoFindingFilter{RepoScanID: record.ID}, 0)
 	if err != nil {
 		t.Fatalf("list repo findings unbounded failed: %v", err)
@@ -781,9 +799,7 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 		t.Fatalf("expected repository backfill from repo scan, got %+v", unboundedRepoFindings[0])
 	}
 
-	repoScanRow := sqlmock.NewRows([]string{"id", "tenant_id", "workspace_id", "repository", "status", "started_at", "finished_at", "commits_scanned", "files_scanned", "finding_count", "truncated", "scan_mode", "base_revision", "head_revision", "cursor_before", "cursor_after", "changed_paths", "error_message", "history_limit", "max_findings_limit", "source_provider", "source_project_id", "source_connector_id", "source_installation_id"}).
-		AddRow(record.ID, "default", "default", "owner/repo", "completed", now, now, 12, 8, 1, false, "deep", "", "", "", "", []byte("[]"), "", 0, 0, "", "", "", int64(0))
-	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, repository, status").WithArgs(record.ID, "default", "default").WillReturnRows(repoScanRow)
+	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, repository, status").WithArgs(record.ID, "default", "default").WillReturnRows(repoScanRows(record.ID, "completed", now, now))
 	gotRepoScan, err := store.GetRepoScan(defaultScopeContext(), record.ID)
 	if err != nil {
 		t.Fatalf("get repo scan failed: %v", err)
@@ -807,13 +823,9 @@ func TestPostgresStoreUpsertRepoFindingsRejectsTerminalScan(t *testing.T) {
 	store := NewPostgresStoreWithDB(db)
 	scanID := "11111111-1111-1111-1111-111111111111"
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT status
-		 FROM repo_scans
-		 WHERE id = $1
-		   AND tenant_id = $2
-		   AND workspace_id = $3`)).
+	mock.ExpectQuery("SELECT id, tenant_id, workspace_id, repository, status").
 		WithArgs(scanID, "default", "default").
-		WillReturnRows(sqlmock.NewRows([]string{"status"}).AddRow("failed"))
+		WillReturnRows(repoScanRows(scanID, "failed", time.Now().UTC(), time.Now().UTC()))
 
 	err = store.UpsertRepoFindings(defaultScopeContext(), scanID, []domain.Finding{{
 		ID:       "rf-canceled",

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2067,15 +2067,22 @@ type RelationshipFilter struct {
 
 // RepoFindingFilter controls repository finding list queries.
 type RepoFindingFilter struct {
-	RepoScanID      string
-	FindingID       string
-	Repository      string
-	Severity        string
-	Type            string
-	LifecycleStatus string
-	Assignee        string
-	SortBy          string
-	SortDesc        bool
+	RepoScanID        string
+	FindingID         string
+	Repository        string
+	Severity          string
+	Type              string
+	Status            string
+	Detector          string
+	Owner             string
+	MinConfidence     float64
+	MinAgeDays        int
+	LifecycleStatus   string
+	Assignee          string
+	SortBy            string
+	SortDesc          bool
+	Now               time.Time
+	IncludeHistorical bool
 }
 
 // RepoFindingClusterListFilter controls repository finding cluster list queries.
@@ -2167,26 +2174,59 @@ func NormalizeRepoFindingFilter(filter RepoFindingFilter) RepoFindingFilter {
 	sortBy := rawSortBy
 	sortDesc := filter.SortDesc
 	switch sortBy {
-	case "severity", "type", "title", "created_at":
+	case "severity", "type", "title", "created_at", "first_seen_at", "last_seen_at", "status", "owner":
 	default:
 		sortBy = "created_at"
 		if rawSortBy == "" {
 			sortDesc = true
 		}
 	}
+	now := filter.Now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	minConfidence := filter.MinConfidence
+	if minConfidence < 0 {
+		minConfidence = 0
+	}
+	if minConfidence > 1 {
+		minConfidence = 1
+	}
 
 	normalized := RepoFindingFilter{
-		RepoScanID:      strings.TrimSpace(filter.RepoScanID),
-		FindingID:       strings.TrimSpace(filter.FindingID),
-		Repository:      strings.TrimSpace(filter.Repository),
-		Severity:        strings.ToLower(strings.TrimSpace(filter.Severity)),
-		Type:            strings.ToLower(strings.TrimSpace(filter.Type)),
-		LifecycleStatus: strings.ToLower(strings.TrimSpace(filter.LifecycleStatus)),
-		Assignee:        strings.ToLower(strings.TrimSpace(filter.Assignee)),
-		SortBy:          sortBy,
-		SortDesc:        sortDesc,
+		RepoScanID:        strings.TrimSpace(filter.RepoScanID),
+		FindingID:         strings.TrimSpace(filter.FindingID),
+		Repository:        strings.TrimSpace(filter.Repository),
+		Severity:          strings.ToLower(strings.TrimSpace(filter.Severity)),
+		Type:              strings.ToLower(strings.TrimSpace(filter.Type)),
+		Status:            strings.ToLower(strings.TrimSpace(filter.Status)),
+		Detector:          strings.ToLower(strings.TrimSpace(filter.Detector)),
+		Owner:             strings.ToLower(strings.TrimSpace(filter.Owner)),
+		MinConfidence:     minConfidence,
+		MinAgeDays:        filter.MinAgeDays,
+		LifecycleStatus:   strings.ToLower(strings.TrimSpace(filter.LifecycleStatus)),
+		Assignee:          strings.ToLower(strings.TrimSpace(filter.Assignee)),
+		SortBy:            sortBy,
+		SortDesc:          sortDesc,
+		Now:               now,
+		IncludeHistorical: filter.IncludeHistorical,
+	}
+	if normalized.MinAgeDays < 0 {
+		normalized.MinAgeDays = 0
 	}
 	return normalized
+}
+
+func shouldCloseMissingRepoFindings(status string, truncated bool, scanContext RepoScanContext) bool {
+	normalizedStatus := strings.ToLower(strings.TrimSpace(status))
+	if normalizedStatus != "succeeded" && normalizedStatus != "completed" {
+		return false
+	}
+	if truncated {
+		return false
+	}
+	normalizedContext := NormalizeRepoScanContext(scanContext)
+	return normalizedContext.ScanMode == "deep" && len(normalizedContext.ChangedPaths) == 0
 }
 
 // NormalizeFindingTriage returns a stable, API-shaped finding triage state.

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2255,6 +2255,45 @@ func NormalizeFindingTriage(triage domain.FindingTriage, now time.Time) domain.F
 	return normalized
 }
 
+func applyRepoFindingLifecycleSnapshot(finding *domain.Finding, snapshot domain.Finding, observedAt time.Time) domain.RepoFindingLifecycleStatus {
+	if finding == nil {
+		return domain.RepoFindingLifecycleOpen
+	}
+	switch snapshot.LifecycleStatus {
+	case domain.RepoFindingLifecycleFixed:
+		reopenedAt := observedAt.UTC()
+		finding.ReopenedAt = &reopenedAt
+		return domain.RepoFindingLifecycleReopened
+	case domain.RepoFindingLifecycleSuppressed, domain.RepoFindingLifecycleRiskAccepted, domain.RepoFindingLifecycleFalsePositive:
+		if repoFindingDismissalExpired(snapshot, observedAt) {
+			reopenedAt := observedAt.UTC()
+			finding.ReopenedAt = &reopenedAt
+			finding.DismissedAt = nil
+			finding.SuppressionExpiresAt = nil
+			return domain.RepoFindingLifecycleReopened
+		}
+		finding.DismissedAt = cloneTimePointer(snapshot.DismissedAt)
+		finding.SuppressionExpiresAt = cloneTimePointer(snapshot.SuppressionExpiresAt)
+		return snapshot.LifecycleStatus
+	case domain.RepoFindingLifecycleReopened:
+		finding.ReopenedAt = cloneTimePointer(snapshot.ReopenedAt)
+		return domain.RepoFindingLifecycleReopened
+	default:
+		return domain.RepoFindingLifecycleOpen
+	}
+}
+
+func repoFindingDismissalExpired(snapshot domain.Finding, observedAt time.Time) bool {
+	if snapshot.SuppressionExpiresAt == nil || snapshot.SuppressionExpiresAt.IsZero() {
+		return false
+	}
+	evaluationTime := observedAt.UTC()
+	if evaluationTime.IsZero() {
+		evaluationTime = time.Now().UTC()
+	}
+	return !snapshot.SuppressionExpiresAt.After(evaluationTime)
+}
+
 // FindingMeta is the lightweight shape used for trend/diff set operations.
 type FindingMeta struct {
 	ID        string

--- a/internal/domain/repo_finding_metadata.go
+++ b/internal/domain/repo_finding_metadata.go
@@ -3,6 +3,9 @@ package domain
 import (
 	"encoding/json"
 	"maps"
+	"strconv"
+	"strings"
+	"time"
 )
 
 // NormalizeRepoFindingMetadata keeps structured repo-finding fields and legacy
@@ -17,7 +20,23 @@ func NormalizeRepoFindingMetadata(finding *Finding) {
 		finding.LineNumber > 0 ||
 		finding.Detector != "" ||
 		finding.LineSnippet != "" ||
-		finding.LineSnippetRedacted != nil
+		finding.LineSnippetRedacted != nil ||
+		finding.LifecycleKey != "" ||
+		finding.LifecycleStatus != "" ||
+		finding.Owner != "" ||
+		finding.FirstSeenAt != nil ||
+		finding.LastSeenAt != nil ||
+		finding.FixedAt != nil ||
+		finding.ReopenedAt != nil ||
+		finding.DismissedAt != nil ||
+		finding.SuppressionExpiresAt != nil ||
+		finding.RuleVersion != "" ||
+		finding.DetectorVersion != "" ||
+		finding.AdapterSource != "" ||
+		finding.ConfidenceState != "" ||
+		finding.VerificationStatus != "" ||
+		finding.ScanMode != "" ||
+		finding.EvidenceVersion != ""
 	hasEvidence := hasRepoFindingEvidence(finding.Evidence)
 	if !hasFields && !hasEvidence && finding.Type != FindingSecretExposure && finding.Type != FindingRepoMisconfig {
 		return
@@ -49,6 +68,59 @@ func NormalizeRepoFindingMetadata(finding *Finding) {
 			finding.ConfidenceScore = confidence
 		}
 	}
+	if finding.LifecycleKey == "" {
+		finding.LifecycleKey = stringFromAny(finding.Evidence["lifecycle_key"])
+	}
+	if finding.LifecycleStatus == "" {
+		finding.LifecycleStatus = NormalizeRepoFindingLifecycleStatus(stringFromAny(finding.Evidence["lifecycle_status"]))
+	}
+	if finding.Owner == "" {
+		for _, key := range []string{"owner", "owner_hint", "owner_team", "codeowners", "assignee"} {
+			if owner := stringFromAny(finding.Evidence[key]); owner != "" {
+				finding.Owner = owner
+				break
+			}
+		}
+	}
+	if finding.FirstSeenAt == nil {
+		finding.FirstSeenAt = timeFromAny(finding.Evidence["first_seen_at"])
+	}
+	if finding.LastSeenAt == nil {
+		finding.LastSeenAt = timeFromAny(finding.Evidence["last_seen_at"])
+	}
+	if finding.FixedAt == nil {
+		finding.FixedAt = timeFromAny(finding.Evidence["fixed_at"])
+	}
+	if finding.ReopenedAt == nil {
+		finding.ReopenedAt = timeFromAny(finding.Evidence["reopened_at"])
+	}
+	if finding.DismissedAt == nil {
+		finding.DismissedAt = timeFromAny(finding.Evidence["dismissed_at"])
+	}
+	if finding.SuppressionExpiresAt == nil {
+		finding.SuppressionExpiresAt = timeFromAny(finding.Evidence["suppression_expires_at"])
+	}
+	if finding.RuleVersion == "" {
+		finding.RuleVersion = stringFromAny(finding.Evidence["rule_version"])
+	}
+	if finding.DetectorVersion == "" {
+		finding.DetectorVersion = stringFromAny(finding.Evidence["detector_version"])
+	}
+	if finding.AdapterSource == "" {
+		finding.AdapterSource = stringFromAny(finding.Evidence["adapter_source"])
+	}
+	if finding.ConfidenceState == "" {
+		finding.ConfidenceState = stringFromAny(finding.Evidence["confidence_state"])
+	}
+	if finding.VerificationStatus == "" {
+		finding.VerificationStatus = stringFromAny(finding.Evidence["verification_status"])
+	}
+	if finding.ScanMode == "" {
+		finding.ScanMode = stringFromAny(finding.Evidence["scan_mode"])
+	}
+	if finding.EvidenceVersion == "" {
+		finding.EvidenceVersion = stringFromAny(finding.Evidence["evidence_version"])
+	}
 	if finding.LineSnippet == "" {
 		for _, key := range []string{"line_snippet", "redacted_line_snip", "match_snippet"} {
 			if snippet := stringFromAny(finding.Evidence[key]); snippet != "" {
@@ -69,6 +141,22 @@ func NormalizeRepoFindingMetadata(finding *Finding) {
 
 	if finding.FilePath != "" && len(finding.Path) == 0 {
 		finding.Path = []string{finding.FilePath}
+	}
+	if finding.LifecycleStatus == "" {
+		finding.LifecycleStatus = RepoFindingLifecycleOpen
+	}
+	if finding.LifecycleKey == "" {
+		finding.LifecycleKey = RepoFindingLifecycleKey(*finding)
+	}
+	if !finding.CreatedAt.IsZero() {
+		if finding.FirstSeenAt == nil {
+			value := finding.CreatedAt.UTC()
+			finding.FirstSeenAt = &value
+		}
+		if finding.LastSeenAt == nil {
+			value := finding.CreatedAt.UTC()
+			finding.LastSeenAt = &value
+		}
 	}
 
 	if finding.Evidence == nil && (hasFields || finding.FilePath != "" || finding.LineSnippet != "") {
@@ -95,6 +183,42 @@ func NormalizeRepoFindingMetadata(finding *Finding) {
 	if finding.ConfidenceScore > 0 {
 		finding.Evidence["confidence_score"] = finding.ConfidenceScore
 	}
+	if finding.LifecycleKey != "" {
+		finding.Evidence["lifecycle_key"] = finding.LifecycleKey
+	}
+	if finding.LifecycleStatus != "" {
+		finding.Evidence["lifecycle_status"] = finding.LifecycleStatus
+	}
+	if finding.Owner != "" {
+		finding.Evidence["owner"] = finding.Owner
+	}
+	putEvidenceTime(finding.Evidence, "first_seen_at", finding.FirstSeenAt)
+	putEvidenceTime(finding.Evidence, "last_seen_at", finding.LastSeenAt)
+	putEvidenceTime(finding.Evidence, "fixed_at", finding.FixedAt)
+	putEvidenceTime(finding.Evidence, "reopened_at", finding.ReopenedAt)
+	putEvidenceTime(finding.Evidence, "dismissed_at", finding.DismissedAt)
+	putEvidenceTime(finding.Evidence, "suppression_expires_at", finding.SuppressionExpiresAt)
+	if finding.RuleVersion != "" {
+		finding.Evidence["rule_version"] = finding.RuleVersion
+	}
+	if finding.DetectorVersion != "" {
+		finding.Evidence["detector_version"] = finding.DetectorVersion
+	}
+	if finding.AdapterSource != "" {
+		finding.Evidence["adapter_source"] = finding.AdapterSource
+	}
+	if finding.ConfidenceState != "" {
+		finding.Evidence["confidence_state"] = finding.ConfidenceState
+	}
+	if finding.VerificationStatus != "" {
+		finding.Evidence["verification_status"] = finding.VerificationStatus
+	}
+	if finding.ScanMode != "" {
+		finding.Evidence["scan_mode"] = finding.ScanMode
+	}
+	if finding.EvidenceVersion != "" {
+		finding.Evidence["evidence_version"] = finding.EvidenceVersion
+	}
 	if finding.LineSnippet != "" {
 		finding.Evidence["line_snippet"] = finding.LineSnippet
 		if finding.LineSnippetRedacted != nil && *finding.LineSnippetRedacted {
@@ -110,12 +234,97 @@ func hasRepoFindingEvidence(evidence map[string]any) bool {
 	if len(evidence) == 0 {
 		return false
 	}
-	for _, key := range []string{"commit", "file_path", "line_number", "detector", "line_snippet", "line_snippet_redacted", "redacted_line_snip", "match_snippet"} {
+	for _, key := range []string{"commit", "file_path", "line_number", "detector", "line_snippet", "line_snippet_redacted", "redacted_line_snip", "match_snippet", "lifecycle_key", "lifecycle_status", "owner", "first_seen_at", "last_seen_at", "fixed_at", "reopened_at", "dismissed_at", "suppression_expires_at", "rule_version", "detector_version", "adapter_source", "confidence_state", "verification_status", "scan_mode", "evidence_version"} {
 		if _, ok := evidence[key]; ok {
 			return true
 		}
 	}
 	return false
+}
+
+// NormalizeRepoFindingLifecycleStatus returns a known repo finding lifecycle
+// value, or the empty value when the caller provided no recognizable state.
+func NormalizeRepoFindingLifecycleStatus(raw string) RepoFindingLifecycleStatus {
+	switch RepoFindingLifecycleStatus(strings.ToLower(strings.TrimSpace(raw))) {
+	case RepoFindingLifecycleOpen:
+		return RepoFindingLifecycleOpen
+	case RepoFindingLifecycleFixed:
+		return RepoFindingLifecycleFixed
+	case RepoFindingLifecycleReopened:
+		return RepoFindingLifecycleReopened
+	case RepoFindingLifecycleSuppressed:
+		return RepoFindingLifecycleSuppressed
+	case RepoFindingLifecycleRiskAccepted:
+		return RepoFindingLifecycleRiskAccepted
+	case RepoFindingLifecycleFalsePositive:
+		return RepoFindingLifecycleFalsePositive
+	default:
+		return ""
+	}
+}
+
+// RepoFindingLifecycleKey returns the scanner-stable identity used to connect a
+// repo finding across repeated scans. It avoids commit-scoped IDs when stronger
+// evidence such as a secret fingerprint is available.
+func RepoFindingLifecycleKey(finding Finding) string {
+	repository := strings.ToLower(strings.TrimSpace(firstNonEmptyString(
+		finding.Repository,
+		stringFromAny(finding.Evidence["repository"]),
+	)))
+	detector := strings.ToLower(strings.TrimSpace(firstNonEmptyString(
+		finding.Detector,
+		stringFromAny(finding.Evidence["detector"]),
+	)))
+	filePath := strings.ToLower(strings.TrimSpace(firstNonEmptyString(
+		finding.FilePath,
+		stringFromAny(finding.Evidence["file_path"]),
+	)))
+	fingerprint := strings.ToLower(strings.TrimSpace(firstNonEmptyString(
+		stringFromAny(finding.Evidence["secret_fingerprint"]),
+		stringFromAny(finding.Evidence["match_fingerprint"]),
+		stringFromAny(finding.Evidence["finding_fingerprint"]),
+		stringFromAny(finding.Evidence["fingerprint"]),
+	)))
+	parts := []string{"repo_finding", repository, string(finding.Type), detector}
+	if fingerprint != "" {
+		parts = append(parts, "fingerprint", fingerprint, filePath)
+		return strings.Join(parts, "\x1f")
+	}
+	lineNumber := finding.LineNumber
+	if lineNumber == 0 {
+		lineNumber = intFromAny(finding.Evidence["line_number"])
+	}
+	if filePath != "" || lineNumber > 0 || detector != "" {
+		parts = append(parts, filePath, strconv.Itoa(lineNumber), strings.ToLower(strings.TrimSpace(finding.Title)))
+		return strings.Join(parts, "\x1f")
+	}
+	return strings.Join(append(parts, strings.TrimSpace(finding.ID)), "\x1f")
+}
+
+// ApplyRepoFindingTriageToLifecycle overlays operator workflow state onto the
+// scanner lifecycle that was persisted from repo scans.
+func ApplyRepoFindingTriageToLifecycle(finding *Finding) {
+	if finding == nil {
+		return
+	}
+	switch finding.Triage.Status {
+	case FindingLifecycleSuppressed:
+		finding.LifecycleStatus = RepoFindingLifecycleSuppressed
+		finding.SuppressionExpiresAt = cloneTimePointer(finding.Triage.SuppressionExpiresAt)
+		if finding.DismissedAt == nil && finding.Triage.UpdatedAt != nil {
+			finding.DismissedAt = cloneTimePointer(finding.Triage.UpdatedAt)
+		}
+	case FindingLifecycleResolved:
+		if finding.LifecycleStatus == "" || finding.LifecycleStatus == RepoFindingLifecycleOpen || finding.LifecycleStatus == RepoFindingLifecycleReopened {
+			finding.LifecycleStatus = RepoFindingLifecycleFixed
+		}
+		if finding.FixedAt == nil && finding.Triage.ResolvedAt != nil {
+			finding.FixedAt = cloneTimePointer(finding.Triage.ResolvedAt)
+		}
+	}
+	if finding.Owner == "" && strings.TrimSpace(finding.Triage.Assignee) != "" {
+		finding.Owner = strings.TrimSpace(finding.Triage.Assignee)
+	}
 }
 
 func stringFromAny(value any) string {
@@ -175,4 +384,51 @@ func boolFromAny(value any) (bool, bool) {
 
 func boolPtr(value bool) *bool {
 	return &value
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func timeFromAny(value any) *time.Time {
+	switch typed := value.(type) {
+	case time.Time:
+		normalized := typed.UTC()
+		return &normalized
+	case string:
+		trimmed := strings.TrimSpace(typed)
+		if trimmed == "" {
+			return nil
+		}
+		for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+			parsed, err := time.Parse(layout, trimmed)
+			if err == nil {
+				normalized := parsed.UTC()
+				return &normalized
+			}
+		}
+	default:
+		return nil
+	}
+	return nil
+}
+
+func putEvidenceTime(evidence map[string]any, key string, value *time.Time) {
+	if evidence == nil || value == nil || value.IsZero() {
+		return
+	}
+	evidence[key] = value.UTC().Format(time.RFC3339)
+}
+
+func cloneTimePointer(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	normalized := value.UTC()
+	return &normalized
 }

--- a/internal/domain/repo_finding_metadata_test.go
+++ b/internal/domain/repo_finding_metadata_test.go
@@ -1,6 +1,10 @@
 package domain
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
 
 func TestNormalizeRepoFindingMetadataBackfillsFieldsFromEvidence(t *testing.T) {
 	finding := Finding{
@@ -96,5 +100,102 @@ func TestNormalizeRepoFindingMetadataClonesEvidenceBeforeCanonicalization(t *tes
 	}
 	if finding.Evidence["line_snippet"] != "GITHUB_TOKEN=ghp_****" {
 		t.Fatalf("expected normalized evidence to contain canonical line_snippet, got %+v", finding.Evidence)
+	}
+}
+
+func TestNormalizeRepoFindingLifecycleMetadataAndTriageOverlay(t *testing.T) {
+	firstSeen := time.Date(2026, 5, 20, 9, 0, 0, 123, time.UTC)
+	lastSeen := firstSeen.Add(2 * time.Hour)
+	finding := Finding{
+		ID:        "repo-finding-1",
+		Type:      FindingSecretExposure,
+		CreatedAt: firstSeen.Add(-time.Hour),
+		Evidence: map[string]any{
+			"repository":         "Owner/Repo",
+			"detector":           "github-token",
+			"file_path":          "config/app.env",
+			"line_number":        json.Number("9"),
+			"secret_fingerprint": "fp-token",
+			"confidence_score":   json.Number("0.73"),
+			"lifecycle_status":   "REOPENED",
+			"owner_hint":         "platform",
+			"first_seen_at":      firstSeen.Format(time.RFC3339Nano),
+			"last_seen_at":       lastSeen,
+			"scan_mode":          "deep",
+			"evidence_version":   "v2",
+		},
+	}
+
+	NormalizeRepoFindingMetadata(&finding)
+
+	if finding.LifecycleStatus != RepoFindingLifecycleReopened {
+		t.Fatalf("expected reopened lifecycle status, got %q", finding.LifecycleStatus)
+	}
+	if finding.Owner != "platform" || finding.LineNumber != 9 || finding.ConfidenceScore != 0.73 {
+		t.Fatalf("expected owner, line, and confidence from evidence, got %+v", finding)
+	}
+	if finding.FirstSeenAt == nil || !finding.FirstSeenAt.Equal(firstSeen) {
+		t.Fatalf("expected first_seen_at from evidence, got %+v", finding.FirstSeenAt)
+	}
+	if finding.LastSeenAt == nil || !finding.LastSeenAt.Equal(lastSeen) {
+		t.Fatalf("expected last_seen_at from evidence, got %+v", finding.LastSeenAt)
+	}
+	if finding.ScanMode != "deep" || finding.EvidenceVersion != "v2" {
+		t.Fatalf("expected lifecycle version metadata, got scan_mode=%q evidence_version=%q", finding.ScanMode, finding.EvidenceVersion)
+	}
+	if finding.LifecycleKey == "" || finding.Evidence["lifecycle_key"] != finding.LifecycleKey {
+		t.Fatalf("expected stable lifecycle key to be mirrored into evidence, got key=%q evidence=%+v", finding.LifecycleKey, finding.Evidence)
+	}
+
+	for raw, want := range map[string]RepoFindingLifecycleStatus{
+		"open":           RepoFindingLifecycleOpen,
+		"fixed":          RepoFindingLifecycleFixed,
+		"reopened":       RepoFindingLifecycleReopened,
+		"suppressed":     RepoFindingLifecycleSuppressed,
+		"risk_accepted":  RepoFindingLifecycleRiskAccepted,
+		"false_positive": RepoFindingLifecycleFalsePositive,
+		"unknown":        "",
+	} {
+		if got := NormalizeRepoFindingLifecycleStatus(raw); got != want {
+			t.Fatalf("NormalizeRepoFindingLifecycleStatus(%q) = %q, want %q", raw, got, want)
+		}
+	}
+
+	suppressionExpiry := firstSeen.Add(7 * 24 * time.Hour)
+	triageUpdated := firstSeen.Add(30 * time.Minute)
+	suppressed := Finding{
+		LifecycleStatus: RepoFindingLifecycleOpen,
+		Triage: FindingTriage{
+			Status:               FindingLifecycleSuppressed,
+			Assignee:             "appsec",
+			UpdatedAt:            &triageUpdated,
+			SuppressionExpiresAt: &suppressionExpiry,
+		},
+	}
+	ApplyRepoFindingTriageToLifecycle(&suppressed)
+	if suppressed.LifecycleStatus != RepoFindingLifecycleSuppressed || suppressed.Owner != "appsec" {
+		t.Fatalf("expected suppression overlay to set lifecycle and owner, got %+v", suppressed)
+	}
+	if suppressed.DismissedAt == nil || !suppressed.DismissedAt.Equal(triageUpdated) {
+		t.Fatalf("expected dismissed_at from triage update time, got %+v", suppressed.DismissedAt)
+	}
+	if suppressed.SuppressionExpiresAt == nil || !suppressed.SuppressionExpiresAt.Equal(suppressionExpiry) {
+		t.Fatalf("expected suppression expiry overlay, got %+v", suppressed.SuppressionExpiresAt)
+	}
+
+	resolvedAt := firstSeen.Add(48 * time.Hour)
+	resolved := Finding{
+		LifecycleStatus: RepoFindingLifecycleReopened,
+		Triage: FindingTriage{
+			Status:     FindingLifecycleResolved,
+			ResolvedAt: &resolvedAt,
+		},
+	}
+	ApplyRepoFindingTriageToLifecycle(&resolved)
+	if resolved.LifecycleStatus != RepoFindingLifecycleFixed {
+		t.Fatalf("expected resolved triage to mark reopened repo finding fixed, got %q", resolved.LifecycleStatus)
+	}
+	if resolved.FixedAt == nil || !resolved.FixedAt.Equal(resolvedAt) {
+		t.Fatalf("expected fixed_at from triage resolved time, got %+v", resolved.FixedAt)
 	}
 }

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -67,6 +67,19 @@ const (
 	FindingLifecycleResolved   FindingLifecycleStatus = "resolved"
 )
 
+// RepoFindingLifecycleStatus tracks scanner-observed state for a repository
+// finding across repeated scans.
+type RepoFindingLifecycleStatus string
+
+const (
+	RepoFindingLifecycleOpen          RepoFindingLifecycleStatus = "open"
+	RepoFindingLifecycleFixed         RepoFindingLifecycleStatus = "fixed"
+	RepoFindingLifecycleReopened      RepoFindingLifecycleStatus = "reopened"
+	RepoFindingLifecycleSuppressed    RepoFindingLifecycleStatus = "suppressed"
+	RepoFindingLifecycleRiskAccepted  RepoFindingLifecycleStatus = "risk_accepted"
+	RepoFindingLifecycleFalsePositive RepoFindingLifecycleStatus = "false_positive"
+)
+
 // FindingTriage stores mutable workflow metadata for one finding id.
 type FindingTriage struct {
 	Status               FindingLifecycleStatus `json:"status"`
@@ -132,26 +145,42 @@ type Relationship struct {
 
 // Finding is a typed risk detected by the analysis engine.
 type Finding struct {
-	ID                  string          `json:"id"`
-	ScanID              string          `json:"scan_id"`
-	Type                FindingType     `json:"type"`
-	Severity            FindingSeverity `json:"severity"`
-	ConfidenceScore     float64         `json:"confidence_score,omitempty"`
-	Title               string          `json:"title"`
-	HumanSummary        string          `json:"human_summary"`
-	Path                []string        `json:"path,omitempty"`
-	Repository          string          `json:"repository,omitempty"`
-	Commit              string          `json:"commit,omitempty"`
-	FilePath            string          `json:"file_path,omitempty"`
-	LineNumber          int             `json:"line_number,omitempty"`
-	Detector            string          `json:"detector,omitempty"`
-	LineSnippet         string          `json:"line_snippet,omitempty"`
-	LineSnippetRedacted *bool           `json:"line_snippet_redacted,omitempty"`
-	SourceURL           string          `json:"source_url,omitempty"`
-	Evidence            map[string]any  `json:"evidence,omitempty"`
-	Remediation         string          `json:"remediation"`
-	CreatedAt           time.Time       `json:"created_at"`
-	Triage              FindingTriage   `json:"triage,omitzero"`
+	ID                   string                     `json:"id"`
+	ScanID               string                     `json:"scan_id"`
+	Type                 FindingType                `json:"type"`
+	Severity             FindingSeverity            `json:"severity"`
+	ConfidenceScore      float64                    `json:"confidence_score,omitempty"`
+	Title                string                     `json:"title"`
+	HumanSummary         string                     `json:"human_summary"`
+	Path                 []string                   `json:"path,omitempty"`
+	Repository           string                     `json:"repository,omitempty"`
+	Commit               string                     `json:"commit,omitempty"`
+	FilePath             string                     `json:"file_path,omitempty"`
+	LineNumber           int                        `json:"line_number,omitempty"`
+	Detector             string                     `json:"detector,omitempty"`
+	LineSnippet          string                     `json:"line_snippet,omitempty"`
+	LineSnippetRedacted  *bool                      `json:"line_snippet_redacted,omitempty"`
+	SourceURL            string                     `json:"source_url,omitempty"`
+	LifecycleKey         string                     `json:"lifecycle_key,omitempty"`
+	LifecycleStatus      RepoFindingLifecycleStatus `json:"lifecycle_status,omitempty"`
+	Owner                string                     `json:"owner,omitempty"`
+	FirstSeenAt          *time.Time                 `json:"first_seen_at,omitempty"`
+	LastSeenAt           *time.Time                 `json:"last_seen_at,omitempty"`
+	FixedAt              *time.Time                 `json:"fixed_at,omitempty"`
+	ReopenedAt           *time.Time                 `json:"reopened_at,omitempty"`
+	DismissedAt          *time.Time                 `json:"dismissed_at,omitempty"`
+	SuppressionExpiresAt *time.Time                 `json:"suppression_expires_at,omitempty"`
+	RuleVersion          string                     `json:"rule_version,omitempty"`
+	DetectorVersion      string                     `json:"detector_version,omitempty"`
+	AdapterSource        string                     `json:"adapter_source,omitempty"`
+	ConfidenceState      string                     `json:"confidence_state,omitempty"`
+	VerificationStatus   string                     `json:"verification_status,omitempty"`
+	ScanMode             string                     `json:"scan_mode,omitempty"`
+	EvidenceVersion      string                     `json:"evidence_version,omitempty"`
+	Evidence             map[string]any             `json:"evidence,omitempty"`
+	Remediation          string                     `json:"remediation"`
+	CreatedAt            time.Time                  `json:"created_at"`
+	Triage               FindingTriage              `json:"triage,omitzero"`
 }
 
 // OwnershipSignal tracks ownership hints and confidence.

--- a/migrations/000032_repo_finding_lifecycle.down.sql
+++ b/migrations/000032_repo_finding_lifecycle.down.sql
@@ -1,0 +1,25 @@
+DROP INDEX IF EXISTS idx_repo_findings_owner_last_seen;
+DROP INDEX IF EXISTS idx_repo_findings_lifecycle_status_last_seen;
+DROP INDEX IF EXISTS idx_repo_findings_lifecycle_scope_key;
+
+ALTER TABLE repo_findings
+    DROP CONSTRAINT IF EXISTS repo_findings_lifecycle_time_order,
+    DROP CONSTRAINT IF EXISTS repo_findings_lifecycle_status_valid;
+
+ALTER TABLE repo_findings
+    DROP COLUMN IF EXISTS evidence_version,
+    DROP COLUMN IF EXISTS scan_mode,
+    DROP COLUMN IF EXISTS verification_status,
+    DROP COLUMN IF EXISTS confidence_state,
+    DROP COLUMN IF EXISTS adapter_source,
+    DROP COLUMN IF EXISTS detector_version,
+    DROP COLUMN IF EXISTS rule_version,
+    DROP COLUMN IF EXISTS owner,
+    DROP COLUMN IF EXISTS lifecycle_status,
+    DROP COLUMN IF EXISTS suppression_expires_at,
+    DROP COLUMN IF EXISTS dismissed_at,
+    DROP COLUMN IF EXISTS reopened_at,
+    DROP COLUMN IF EXISTS fixed_at,
+    DROP COLUMN IF EXISTS last_seen_at,
+    DROP COLUMN IF EXISTS first_seen_at,
+    DROP COLUMN IF EXISTS lifecycle_key;

--- a/migrations/000032_repo_finding_lifecycle.up.sql
+++ b/migrations/000032_repo_finding_lifecycle.up.sql
@@ -16,25 +16,47 @@ ALTER TABLE repo_findings
     ADD COLUMN IF NOT EXISTS scan_mode TEXT,
     ADD COLUMN IF NOT EXISTS evidence_version TEXT;
 
+WITH repo_finding_backfill AS (
+    SELECT
+        rf.repo_scan_id,
+        rf.finding_id,
+        LOWER(COALESCE(NULLIF(rf.evidence->>'repository', ''), rs.repository)) AS repository_key,
+        LOWER(COALESCE(NULLIF(rf.evidence->>'detector', ''), '')) AS detector_key,
+        LOWER(COALESCE(NULLIF(rf.evidence->>'file_path', ''), '')) AS file_path_key,
+        COALESCE(NULLIF(rf.evidence->>'line_number', ''), '') AS line_number_key,
+        LOWER(COALESCE(
+            NULLIF(rf.evidence->>'secret_fingerprint', ''),
+            NULLIF(rf.evidence->>'match_fingerprint', ''),
+            NULLIF(rf.evidence->>'finding_fingerprint', ''),
+            NULLIF(rf.evidence->>'fingerprint', '')
+        )) AS fingerprint_key,
+        LOWER(TRIM(COALESCE(rf.title, ''))) AS title_key,
+        CASE LOWER(TRIM(COALESCE(rf.evidence->>'lifecycle_status', '')))
+            WHEN 'open' THEN 'open'
+            WHEN 'fixed' THEN 'fixed'
+            WHEN 'reopened' THEN 'reopened'
+            WHEN 'suppressed' THEN 'suppressed'
+            WHEN 'risk_accepted' THEN 'risk_accepted'
+            WHEN 'false_positive' THEN 'false_positive'
+            ELSE COALESCE(NULLIF(rf.lifecycle_status, ''), 'open')
+        END AS lifecycle_status_key
+    FROM repo_findings rf
+    JOIN repo_scans rs ON rs.id = rf.repo_scan_id
+)
 UPDATE repo_findings rf
 SET
     lifecycle_key = COALESCE(
         NULLIF(rf.lifecycle_key, ''),
         NULLIF(rf.evidence->>'lifecycle_key', ''),
-        CONCAT_WS(
-            E'\x1f',
-            'repo_finding',
-            LOWER(COALESCE(NULLIF(rf.evidence->>'repository', ''), rs.repository)),
-            rf.type,
-            LOWER(COALESCE(NULLIF(rf.evidence->>'detector', ''), '')),
-            LOWER(COALESCE(NULLIF(rf.evidence->>'file_path', ''), '')),
-            COALESCE(NULLIF(rf.evidence->>'line_number', ''), ''),
-            rf.finding_id
-        )
+        CASE
+            WHEN bf.fingerprint_key <> '' THEN CONCAT_WS(E'\x1f', 'repo_finding', bf.repository_key, rf.type, bf.detector_key, 'fingerprint', bf.fingerprint_key, bf.file_path_key)
+            WHEN bf.file_path_key <> '' OR bf.line_number_key <> '' OR bf.detector_key <> '' THEN CONCAT_WS(E'\x1f', 'repo_finding', bf.repository_key, rf.type, bf.detector_key, bf.file_path_key, bf.line_number_key, bf.title_key)
+            ELSE CONCAT_WS(E'\x1f', 'repo_finding', bf.repository_key, rf.type, bf.detector_key, TRIM(rf.finding_id))
+        END
     ),
     first_seen_at = COALESCE(rf.first_seen_at, rf.created_at),
     last_seen_at = COALESCE(rf.last_seen_at, rf.created_at),
-    lifecycle_status = COALESCE(NULLIF(rf.lifecycle_status, ''), NULLIF(rf.evidence->>'lifecycle_status', ''), 'open'),
+    lifecycle_status = bf.lifecycle_status_key,
     owner = COALESCE(NULLIF(rf.owner, ''), NULLIF(rf.evidence->>'owner', ''), NULLIF(rf.evidence->>'owner_hint', ''), NULLIF(rf.evidence->>'owner_team', ''), NULLIF(rf.evidence->>'assignee', '')),
     rule_version = COALESCE(NULLIF(rf.rule_version, ''), NULLIF(rf.evidence->>'rule_version', '')),
     detector_version = COALESCE(NULLIF(rf.detector_version, ''), NULLIF(rf.evidence->>'detector_version', '')),
@@ -43,8 +65,9 @@ SET
     verification_status = COALESCE(NULLIF(rf.verification_status, ''), NULLIF(rf.evidence->>'verification_status', '')),
     scan_mode = COALESCE(NULLIF(rf.scan_mode, ''), NULLIF(rf.evidence->>'scan_mode', '')),
     evidence_version = COALESCE(NULLIF(rf.evidence_version, ''), NULLIF(rf.evidence->>'evidence_version', ''))
-FROM repo_scans rs
-WHERE rs.id = rf.repo_scan_id;
+FROM repo_finding_backfill bf
+WHERE bf.repo_scan_id = rf.repo_scan_id
+  AND bf.finding_id = rf.finding_id;
 
 ALTER TABLE repo_findings
     DROP CONSTRAINT IF EXISTS repo_findings_lifecycle_status_valid,

--- a/migrations/000032_repo_finding_lifecycle.up.sql
+++ b/migrations/000032_repo_finding_lifecycle.up.sql
@@ -1,0 +1,73 @@
+ALTER TABLE repo_findings
+    ADD COLUMN IF NOT EXISTS lifecycle_key TEXT,
+    ADD COLUMN IF NOT EXISTS first_seen_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS last_seen_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS fixed_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS reopened_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS dismissed_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS suppression_expires_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS lifecycle_status TEXT NOT NULL DEFAULT 'open',
+    ADD COLUMN IF NOT EXISTS owner TEXT,
+    ADD COLUMN IF NOT EXISTS rule_version TEXT,
+    ADD COLUMN IF NOT EXISTS detector_version TEXT,
+    ADD COLUMN IF NOT EXISTS adapter_source TEXT,
+    ADD COLUMN IF NOT EXISTS confidence_state TEXT,
+    ADD COLUMN IF NOT EXISTS verification_status TEXT,
+    ADD COLUMN IF NOT EXISTS scan_mode TEXT,
+    ADD COLUMN IF NOT EXISTS evidence_version TEXT;
+
+UPDATE repo_findings rf
+SET
+    lifecycle_key = COALESCE(
+        NULLIF(rf.lifecycle_key, ''),
+        NULLIF(rf.evidence->>'lifecycle_key', ''),
+        CONCAT_WS(
+            E'\x1f',
+            'repo_finding',
+            LOWER(COALESCE(NULLIF(rf.evidence->>'repository', ''), rs.repository)),
+            rf.type,
+            LOWER(COALESCE(NULLIF(rf.evidence->>'detector', ''), '')),
+            LOWER(COALESCE(NULLIF(rf.evidence->>'file_path', ''), '')),
+            COALESCE(NULLIF(rf.evidence->>'line_number', ''), ''),
+            rf.finding_id
+        )
+    ),
+    first_seen_at = COALESCE(rf.first_seen_at, rf.created_at),
+    last_seen_at = COALESCE(rf.last_seen_at, rf.created_at),
+    lifecycle_status = COALESCE(NULLIF(rf.lifecycle_status, ''), NULLIF(rf.evidence->>'lifecycle_status', ''), 'open'),
+    owner = COALESCE(NULLIF(rf.owner, ''), NULLIF(rf.evidence->>'owner', ''), NULLIF(rf.evidence->>'owner_hint', ''), NULLIF(rf.evidence->>'owner_team', ''), NULLIF(rf.evidence->>'assignee', '')),
+    rule_version = COALESCE(NULLIF(rf.rule_version, ''), NULLIF(rf.evidence->>'rule_version', '')),
+    detector_version = COALESCE(NULLIF(rf.detector_version, ''), NULLIF(rf.evidence->>'detector_version', '')),
+    adapter_source = COALESCE(NULLIF(rf.adapter_source, ''), NULLIF(rf.evidence->>'adapter_source', '')),
+    confidence_state = COALESCE(NULLIF(rf.confidence_state, ''), NULLIF(rf.evidence->>'confidence_state', '')),
+    verification_status = COALESCE(NULLIF(rf.verification_status, ''), NULLIF(rf.evidence->>'verification_status', '')),
+    scan_mode = COALESCE(NULLIF(rf.scan_mode, ''), NULLIF(rf.evidence->>'scan_mode', '')),
+    evidence_version = COALESCE(NULLIF(rf.evidence_version, ''), NULLIF(rf.evidence->>'evidence_version', ''))
+FROM repo_scans rs
+WHERE rs.id = rf.repo_scan_id;
+
+ALTER TABLE repo_findings
+    DROP CONSTRAINT IF EXISTS repo_findings_lifecycle_status_valid,
+    DROP CONSTRAINT IF EXISTS repo_findings_lifecycle_time_order;
+
+ALTER TABLE repo_findings
+    ADD CONSTRAINT repo_findings_lifecycle_status_valid
+        CHECK (lifecycle_status IN ('open', 'fixed', 'reopened', 'suppressed', 'risk_accepted', 'false_positive')) NOT VALID,
+    ADD CONSTRAINT repo_findings_lifecycle_time_order
+        CHECK (
+            first_seen_at IS NULL
+            OR last_seen_at IS NULL
+            OR first_seen_at <= last_seen_at
+        ) NOT VALID;
+
+ALTER TABLE repo_findings VALIDATE CONSTRAINT repo_findings_lifecycle_status_valid;
+ALTER TABLE repo_findings VALIDATE CONSTRAINT repo_findings_lifecycle_time_order;
+
+CREATE INDEX IF NOT EXISTS idx_repo_findings_lifecycle_scope_key
+    ON repo_findings (lifecycle_key, lifecycle_status, last_seen_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_repo_findings_lifecycle_status_last_seen
+    ON repo_findings (lifecycle_status, last_seen_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_repo_findings_owner_last_seen
+    ON repo_findings (owner, last_seen_at DESC);

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { renderToString } from 'react-dom/server';
 import { StaticRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -90,6 +90,7 @@ describe('App', () => {
   });
 
   afterEach(() => {
+    cleanup();
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { renderToString } from 'react-dom/server';
 import { StaticRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -873,6 +873,98 @@ describe('App', () => {
     expect(openInGitHub).toHaveAttribute('href', 'https://github.com/owner/repo/blob/abc123/config/app.env#L7');
     expect((await screen.findAllByText('config/app.env:7')).length).toBeGreaterThan(0);
     expect((await screen.findAllByText('owner/repo')).length).toBeGreaterThan(0);
+  });
+
+  it('allows suppressed repository finding assignee edits without a new suppression reason', async () => {
+    const suppressionExpiresAt = '2027-01-01T00:00:00Z';
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/v1/me')) {
+        return okJSON(currentMePayload('tenant-a', 'workspace-a'));
+      }
+      if (url.includes('/v1/findings/repo-f1/triage')) {
+        return okJSON({
+          finding: {
+            id: 'repo-f1',
+            scan_id: 'repo-scan-1',
+            type: 'secret_exposure',
+            severity: 'high',
+            title: 'Potential AWS access key exposed in commit history',
+            human_summary: 'A line added in commit history appears to contain an AWS access key identifier.',
+            repository: 'owner/repo',
+            file_path: 'config/app.env',
+            line_number: 7,
+            remediation: 'Rotate the key and move the credential to a secret manager.',
+            triage: { status: 'suppressed', assignee: 'platform', suppression_expires_at: suppressionExpiresAt },
+            created_at: '2026-01-01T00:00:00Z'
+          }
+        });
+      }
+      if (url.includes('/v1/repo-scans')) {
+        return okJSON({
+          items: [
+            {
+              id: 'repo-scan-1',
+              repository: 'owner/repo',
+              status: 'succeeded',
+              started_at: '2026-01-01T00:00:00Z',
+              finished_at: '2026-01-01T00:05:00Z',
+              commits_scanned: 12,
+              files_scanned: 4,
+              finding_count: 1,
+              truncated: false
+            }
+          ]
+        });
+      }
+      if (url.includes('/v1/repo-findings/trends')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/repo-findings')) {
+        return okJSON({
+          items: [
+            {
+              id: 'repo-f1',
+              scan_id: 'repo-scan-1',
+              type: 'secret_exposure',
+              severity: 'high',
+              title: 'Potential AWS access key exposed in commit history',
+              human_summary: 'A line added in commit history appears to contain an AWS access key identifier.',
+              repository: 'owner/repo',
+              file_path: 'config/app.env',
+              line_number: 7,
+              remediation: 'Rotate the key and move the credential to a secret manager.',
+              triage: { status: 'suppressed', assignee: 'secops', suppression_expires_at: suppressionExpiresAt },
+              created_at: '2026-01-01T00:00:00Z'
+            }
+          ]
+        });
+      }
+      throw new Error(`Unexpected URL ${url} ${init?.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    setCurrentPath('/app/tenant-a/workspace-a/findings');
+    render(<App />);
+
+    const workflowControls = (await screen.findByText(/Workflow controls/i)).closest('.idt-repo-finding-triage-form');
+    expect(workflowControls).toBeInTheDocument();
+
+    fireEvent.change(within(workflowControls as HTMLElement).getByLabelText(/Assignee/i), { target: { value: 'platform' } });
+    fireEvent.click(within(workflowControls as HTMLElement).getByRole('button', { name: /Apply workflow/i }));
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([url]) => typeof url === 'string' && url.includes('/v1/findings/repo-f1/triage'))
+      ).toBe(true);
+    });
+
+    const triageCall = fetchMock.mock.calls.find(([url]) => typeof url === 'string' && url.includes('/v1/findings/repo-f1/triage'));
+    const payload = JSON.parse(String((triageCall?.[1] as RequestInit | undefined)?.body));
+    expect(payload.assignee).toBe('platform');
+    expect(payload.comment).toBeUndefined();
+    expect(payload.status).toBeUndefined();
+    expect(screen.queryByText(/Suppression requires a reason/i)).not.toBeInTheDocument();
   });
 
   it('renders real workspace settings from account, member, and auth config APIs', async () => {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -84,6 +84,7 @@ function leadCaptureCalls(fetchMock: ReturnType<typeof vi.fn>) {
 
 describe('App', () => {
   beforeEach(() => {
+    cleanup();
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1280,7 +1280,7 @@ export const apiClient = {
       repository?: string;
       severity?: string;
       type?: string;
-      status?: RepoFindingLifecycleStatus;
+      repo_lifecycle_status?: RepoFindingLifecycleStatus;
       detector?: string;
       owner?: string;
       confidence?: number;

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -21,10 +21,48 @@ export type Finding = {
   line_snippet?: string;
   line_snippet_redacted?: boolean;
   source_url?: string;
+  lifecycle_key?: string;
+  lifecycle_status?: RepoFindingLifecycleStatus;
+  owner?: string;
+  first_seen_at?: string;
+  last_seen_at?: string;
+  fixed_at?: string;
+  reopened_at?: string;
+  dismissed_at?: string;
+  suppression_expires_at?: string;
+  rule_version?: string;
+  detector_version?: string;
+  adapter_source?: string;
+  confidence_state?: string;
+  verification_status?: string;
+  scan_mode?: string;
+  evidence_version?: string;
   evidence?: Record<string, unknown>;
   remediation: string;
   created_at: string;
   triage?: FindingTriage;
+};
+
+export type RepoFindingLifecycleStatus =
+  | 'open'
+  | 'fixed'
+  | 'reopened'
+  | 'suppressed'
+  | 'risk_accepted'
+  | 'false_positive';
+
+export type RepoFindingsSummary = {
+  total_open: number;
+  fixed_count: number;
+  reopened_count: number;
+  suppressed_count: number;
+  sla_aged_count: number;
+  mttr_ready_resolved_count: number;
+  mean_time_to_resolve_seconds?: number;
+  oldest_open_first_seen_at?: string;
+  by_owner: Record<string, number>;
+  by_detector: Record<string, number>;
+  by_severity: Record<string, number>;
 };
 
 export type RepoScanRecord = {
@@ -1239,8 +1277,16 @@ export const apiClient = {
       limit?: number;
       cursor?: string;
       repo_scan_id?: string;
+      repository?: string;
       severity?: string;
       type?: string;
+      status?: RepoFindingLifecycleStatus;
+      detector?: string;
+      owner?: string;
+      confidence?: number;
+      min_confidence?: number;
+      age_days?: number;
+      min_age_days?: number;
       lifecycle_status?: FindingLifecycleStatus;
       assignee?: string;
       sort_by?: string;
@@ -1248,7 +1294,7 @@ export const apiClient = {
     } = {},
     auth?: RequestAuthContext
   ) {
-    return request<{ items: Finding[] }>(
+    return request<{ items: Finding[]; summary?: RepoFindingsSummary }>(
       `/v1/repo-findings${buildQuery({ sort_by: 'created_at', sort_order: 'desc', ...filters })}`,
       auth
     );

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -4623,9 +4623,8 @@ export function ProductFindingsPage() {
   const reopenedFindingCount =
     repoFindingSummary?.reopened_count ?? filteredFindings.filter((finding) => normalizeRepoFindingLifecycleStatus(finding.lifecycle_status) === 'reopened').length;
   const slaAgedFindingCount = repoFindingSummary?.sla_aged_count ?? 0;
-  const mttrLabel = repoFindingSummary?.mean_time_to_resolve_seconds
-    ? formatExecutiveDuration(repoFindingSummary.mean_time_to_resolve_seconds)
-    : 'N/A';
+  const mttrSeconds = repoFindingSummary?.mean_time_to_resolve_seconds;
+  const mttrLabel = typeof mttrSeconds === 'number' && Number.isFinite(mttrSeconds) ? formatExecutiveDuration(mttrSeconds) : 'N/A';
 
   const averageConfidence = useMemo(() => {
     const findingsWithConfidence = filteredFindings.filter((finding) => Number.isFinite(finding.confidence_score ?? NaN));

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -5215,6 +5215,7 @@ export function ProductFindingsPage() {
     const currentStatus = normalizeFindingStatus(selectedFinding.triage?.status);
     const currentAssignee = normalizeValue(selectedFinding.triage?.assignee ?? '');
     const trackingSuppression = nextStatus === 'suppressed';
+    const enteringSuppression = currentStatus !== 'suppressed' && trackingSuppression;
     const currentSuppression = normalizeValue(toLocalDateTimeInputValue(selectedFinding.triage?.suppression_expires_at ?? ''));
     const nextSuppression = normalizeValue(workflowSuppressionExpiresAt);
     const hasChanges =
@@ -5240,7 +5241,7 @@ export function ProductFindingsPage() {
         comment?: string;
       } = {};
       const trimmedComment = normalizeValue(workflowComment);
-      if (trackingSuppression && !trimmedComment) {
+      if (enteringSuppression && !trimmedComment) {
         setWorkflowError('Suppression requires a reason.');
         setWorkflowLoading(false);
         return;

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -17,6 +17,8 @@ import {
   type KubernetesConnectorStartResponse,
   type KubernetesConnectionStatus,
   type ProjectRecord,
+  type RepoFindingsSummary,
+  type RepoFindingLifecycleStatus,
   type RepoScanRequest,
   type RepoScanRecord,
   type TrendPoint,
@@ -334,7 +336,21 @@ function normalizeFindingStatus(value: string | undefined): FindingLifecycleStat
   return 'open';
 }
 
-function repoFindingStatusClass(status: FindingLifecycleStatus): string {
+function normalizeRepoFindingLifecycleStatus(value: string | undefined): RepoFindingLifecycleStatus {
+  const normalized = normalizeValue(value ?? '').toLowerCase();
+  if (
+    normalized === 'fixed' ||
+    normalized === 'reopened' ||
+    normalized === 'suppressed' ||
+    normalized === 'risk_accepted' ||
+    normalized === 'false_positive'
+  ) {
+    return normalized;
+  }
+  return 'open';
+}
+
+function repoFindingStatusClass(status: FindingLifecycleStatus | RepoFindingLifecycleStatus): string {
   return `idt-repo-finding-status is-${status}`;
 }
 
@@ -4519,6 +4535,7 @@ export function ProductFindingsPage() {
   const [trendError, setTrendError] = useState('');
   const [repoScans, setRepoScans] = useState<RepoScanRecord[]>([]);
   const [repoFindings, setRepoFindings] = useState<ApiFinding[]>([]);
+  const [repoFindingSummary, setRepoFindingSummary] = useState<RepoFindingsSummary | null>(null);
   const [trendPoints, setTrendPoints] = useState<TrendPoint[]>([]);
   const [repoScanFilter, setRepoScanFilter] = useState('');
   const [severityFilter, setSeverityFilter] = useState<(typeof REPO_FINDING_SEVERITY_FILTERS)[number]>('all');
@@ -4593,9 +4610,22 @@ export function ProductFindingsPage() {
   );
 
   const openFindingCount = useMemo(
-    () => filteredFindings.filter((finding) => normalizeFindingStatus(finding.triage?.status) === 'open').length,
-    [filteredFindings]
+    () =>
+      repoFindingSummary?.total_open ??
+      filteredFindings.filter((finding) => {
+        const lifecycle = normalizeRepoFindingLifecycleStatus(finding.lifecycle_status);
+        return lifecycle === 'open' || lifecycle === 'reopened';
+      }).length,
+    [filteredFindings, repoFindingSummary?.total_open]
   );
+
+  const fixedFindingCount = repoFindingSummary?.fixed_count ?? filteredFindings.filter((finding) => normalizeRepoFindingLifecycleStatus(finding.lifecycle_status) === 'fixed').length;
+  const reopenedFindingCount =
+    repoFindingSummary?.reopened_count ?? filteredFindings.filter((finding) => normalizeRepoFindingLifecycleStatus(finding.lifecycle_status) === 'reopened').length;
+  const slaAgedFindingCount = repoFindingSummary?.sla_aged_count ?? 0;
+  const mttrLabel = repoFindingSummary?.mean_time_to_resolve_seconds
+    ? formatExecutiveDuration(repoFindingSummary.mean_time_to_resolve_seconds)
+    : 'N/A';
 
   const averageConfidence = useMemo(() => {
     const findingsWithConfidence = filteredFindings.filter((finding) => Number.isFinite(finding.confidence_score ?? NaN));
@@ -4637,6 +4667,7 @@ export function ProductFindingsPage() {
       }
       setRepoScans(repoScanResponse.items);
       setRepoFindings(repoFindingResponse.items);
+      setRepoFindingSummary(repoFindingResponse.summary ?? null);
     } catch (requestError) {
       if (requestID !== requestRef.current) {
         return;
@@ -4722,8 +4753,9 @@ export function ProductFindingsPage() {
         suppression_expires_at?: string;
         comment?: string;
       } = {};
-      if (trackingSuppression && !nextSuppression) {
-        setWorkflowError('Suppression requires an expiry date/time.');
+      const trimmedComment = normalizeValue(workflowComment);
+      if (trackingSuppression && !trimmedComment) {
+        setWorkflowError('Suppression requires a reason.');
         setWorkflowLoading(false);
         return;
       }
@@ -4747,7 +4779,6 @@ export function ProductFindingsPage() {
       if (nextAssignee !== currentAssignee) {
         request.assignee = nextAssignee;
       }
-      const trimmedComment = normalizeValue(workflowComment);
       if (trimmedComment) {
         request.comment = trimmedComment;
       }
@@ -4928,6 +4959,22 @@ export function ProductFindingsPage() {
           <strong>{openFindingCount}</strong>
         </article>
         <article className="idt-repo-finding-stat">
+          <span>Fixed findings</span>
+          <strong>{fixedFindingCount}</strong>
+        </article>
+        <article className="idt-repo-finding-stat">
+          <span>Reopened findings</span>
+          <strong>{reopenedFindingCount}</strong>
+        </article>
+        <article className="idt-repo-finding-stat">
+          <span>SLA-aged highs</span>
+          <strong>{slaAgedFindingCount}</strong>
+        </article>
+        <article className="idt-repo-finding-stat">
+          <span>Mean time to fix</span>
+          <strong>{mttrLabel}</strong>
+        </article>
+        <article className="idt-repo-finding-stat">
           <div className="idt-overview-metric-top">
             <span>Critical findings</span>
             <SourceLogoStack label="Critical finding source coverage" />
@@ -5075,7 +5122,8 @@ export function ProductFindingsPage() {
                       const repositoryLabel = canonicalGitHubRepositoryDisplay(repositoryValue) || 'Repository unavailable';
                       const selectionKey = buildRepoFindingSelectionKey(finding);
                       const isSelected = selectedFindingKey === selectionKey;
-                      const lifecycle = normalizeFindingStatus(finding.triage?.status);
+                      const lifecycle = normalizeRepoFindingLifecycleStatus(finding.lifecycle_status);
+                      const triageStatus = normalizeFindingStatus(finding.triage?.status);
                       return (
                         <button
                           key={selectionKey}
@@ -5099,7 +5147,8 @@ export function ProductFindingsPage() {
                             </div>
                             <div className="idt-repo-finding-row-meta">
                               <span className={repoFindingStatusClass(lifecycle)}>{formatTokenLabel(lifecycle)}</span>
-                              <span>{`Assignee ${finding.triage?.assignee || 'Unassigned'}`}</span>
+                              <span>{`Owner ${finding.owner || finding.triage?.assignee || 'Unassigned'}`}</span>
+                              <span>{`Triage ${formatTokenLabel(triageStatus)}`}</span>
                             </div>
                           </div>
                         </button>
@@ -5158,11 +5207,27 @@ export function ProductFindingsPage() {
                 </div>
                 <div>
                   <dt>Lifecycle status</dt>
-                  <dd>{formatTokenLabel(normalizeFindingStatus(selectedFinding.triage?.status))}</dd>
+                  <dd>{formatTokenLabel(normalizeRepoFindingLifecycleStatus(selectedFinding.lifecycle_status))}</dd>
                 </div>
                 <div>
-                  <dt>Assignee</dt>
-                  <dd>{selectedFinding.triage?.assignee || 'Unassigned'}</dd>
+                  <dt>Owner</dt>
+                  <dd>{selectedFinding.owner || selectedFinding.triage?.assignee || 'Unassigned'}</dd>
+                </div>
+                <div>
+                  <dt>First seen</dt>
+                  <dd>{selectedFinding.first_seen_at ? formatDateLabel(selectedFinding.first_seen_at) : formatDateLabel(selectedFinding.created_at)}</dd>
+                </div>
+                <div>
+                  <dt>Last seen</dt>
+                  <dd>{selectedFinding.last_seen_at ? formatDateLabel(selectedFinding.last_seen_at) : formatDateLabel(selectedFinding.created_at)}</dd>
+                </div>
+                <div>
+                  <dt>Fixed at</dt>
+                  <dd>{selectedFinding.fixed_at ? formatDateLabel(selectedFinding.fixed_at) : 'Not fixed yet'}</dd>
+                </div>
+                <div>
+                  <dt>Triage status</dt>
+                  <dd>{formatTokenLabel(normalizeFindingStatus(selectedFinding.triage?.status))}</dd>
                 </div>
                 <div>
                   <dt>Detector</dt>


### PR DESCRIPTION
Fixes #1236

## Summary
- Adds persisted repo-finding lifecycle metadata, migrations, stable lifecycle keys, and fixed/reopened transition logic across repeated scans.
- Adds current-state API filters plus summary metrics for open, fixed, reopened, suppressed, SLA-aged, owner, detector, severity, and MTTR-ready findings.
- Wires the product findings view to lifecycle status, ownership, first/last seen timestamps, fixed timestamps, and summary cards.
- Updates OpenAPI, repository exposure docs, changelog, and regression coverage for lifecycle filtering, suppression, stale-open hiding, and test isolation.

## Impact and risk
- Repeated GitHub scans can now show what is new, still open, fixed, reopened, suppressed, and owned instead of presenting raw duplicate findings only.
- Missing findings are marked fixed only after a successful, non-truncated deep scan with no changed-path scope, so incremental or partial scans do not accidentally close risk.
- Suppression requires a reason while expiry remains optional, keeping operator intent auditable without forcing permanent exceptions into artificial windows.

## Validation
- go test ./...
- go test ./... -coverprofile=coverage.out
- go tool cover -func=coverage.out => total 80.1%
- go vet ./...
- npm test -- --run src/api/client.test.ts src/App.test.tsx src/productShell.test.tsx
- npm run build
- git diff --check
- Commit/push hooks: check-yaml, gofmt check, go vet, local env token hygiene, Vercel artifact hygiene

## AI disclosure
AI-assisted: No
Tools used: N/A
Where used: N/A
Human verification performed: Reviewed the lifecycle/storage/API/UI diff, ran the Go, coverage, vet, web test, build, YAML, and whitespace checks above.