### PR TITLE
Polish demo booking flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Replaced public demo calendar placeholders with the first-party demo booking
+  form, including preferred day/time capture in lead delivery emails and
+  clearer dark-page contrast for the demo booking and evidence panels.
 - Added repository finding remediation previews. Repo misconfiguration findings
   now map to detector-specific remediation guidance and safe fix-PR plans for
   deterministic patches, while secret findings return rotation guidance only so

--- a/web/api/leads.test.ts
+++ b/web/api/leads.test.ts
@@ -572,6 +572,8 @@ describe('web/api/leads handler', () => {
           company_domain: 'company.com',
           environment: 'AWS IAM + Kubernetes',
           challenge: 'Trust path visibility',
+          preferred_day: 'Any weekday',
+          preferred_time: 'Any time',
           deployment_model: 'Hosted SaaS',
           urgency: 'This quarter',
           team_size: '6-20',
@@ -603,6 +605,8 @@ describe('web/api/leads handler', () => {
     expect(notificationBody.text).toContain('Name: Alex Morgan');
     expect(notificationBody.text).toContain('Role/title: Security Engineering Lead');
     expect(notificationBody.text).toContain('Public repository: https://gitlab.com/platform/security/identity-risk');
+    expect(notificationBody.text).toContain('Preferred day: Any weekday');
+    expect(notificationBody.text).toContain('Preferred time: Any time');
 
     const [, confirmationInit] = fetchMock.mock.calls[1] as unknown as [string, RequestInit];
     const confirmationHeaders = (confirmationInit.headers ?? {}) as Record<string, string>;

--- a/web/api/leads.ts
+++ b/web/api/leads.ts
@@ -10,6 +10,8 @@ type LeadCapturePayload = {
   company?: string;
   company_domain?: string;
   challenge?: string;
+  preferred_day?: string;
+  preferred_time?: string;
   identity_provider?: string;
   infrastructure_scope?: string;
   repository_url?: string;
@@ -25,6 +27,8 @@ type LeadCapturePayload = {
 const ALLOWED_DEPLOYMENT_MODELS = new Set(['Hosted SaaS', 'Self-hosted open-core', 'Enterprise private tenancy']);
 const ALLOWED_URGENCY = new Set(['This quarter', 'This month', 'Immediate']);
 const ALLOWED_TEAM_SIZE = new Set(['1-5', '6-20', '21-50', '50+']);
+const ALLOWED_PREFERRED_DAYS = new Set(['Any weekday', 'Today', 'Tomorrow', 'This week', 'Next week']);
+const ALLOWED_PREFERRED_TIMES = new Set(['Any time', 'Morning', 'Afternoon', 'Evening']);
 const DEFAULT_FORWARD_TIMEOUT_MS = 3_000;
 const MIN_FORWARD_TIMEOUT_MS = 500;
 const MAX_FORWARD_TIMEOUT_MS = 10_000;
@@ -39,6 +43,8 @@ const MAX_ENVIRONMENT_LENGTH = 180;
 const MAX_COMPANY_LENGTH = 120;
 const MAX_COMPANY_DOMAIN_LENGTH = 253;
 const MAX_CHALLENGE_LENGTH = 2_000;
+const MAX_PREFERRED_DAY_LENGTH = 32;
+const MAX_PREFERRED_TIME_LENGTH = 32;
 const MAX_IDENTITY_PROVIDER_LENGTH = 120;
 const MAX_INFRASTRUCTURE_SCOPE_LENGTH = 120;
 const MAX_REPOSITORY_URL_LENGTH = 240;
@@ -111,6 +117,8 @@ type LeadDeliveryPayload = {
   company?: string;
   company_domain?: string;
   challenge?: string;
+  preferred_day?: string;
+  preferred_time?: string;
   identity_provider?: string;
   infrastructure_scope?: string;
   repository_url?: string;
@@ -407,6 +415,8 @@ function leadRows(payload: LeadDeliveryPayload): Array<[string, string | undefin
     ['Company domain', payload.company_domain],
     ['Environment', payload.environment],
     ['Challenge', payload.challenge],
+    ['Preferred day', payload.preferred_day],
+    ['Preferred time', payload.preferred_time],
     ['Identity provider', payload.identity_provider],
     ['Infrastructure scope', payload.infrastructure_scope],
     ['Public repository', payload.repository_url],
@@ -466,6 +476,8 @@ function renderConfirmationText(payload: LeadDeliveryPayload): string {
     `Infrastructure scope: ${payload.infrastructure_scope || 'Not provided'}`,
     `Public repository: ${payload.repository_url || 'Not provided'}`,
     `Focus area: ${payload.challenge || 'Trust path visibility'}`,
+    `Preferred day: ${payload.preferred_day || 'Not provided'}`,
+    `Preferred time: ${payload.preferred_time || 'Not provided'}`,
     `Deployment preference: ${payload.deployment_model || 'Not provided'}`,
     '',
     'We never ask for production credentials in this intake flow.'
@@ -486,6 +498,8 @@ function renderConfirmationHTML(payload: LeadDeliveryPayload): string {
         <li><strong>Infrastructure scope:</strong> ${escapeHTML(payload.infrastructure_scope || 'Not provided')}</li>
         <li><strong>Public repository:</strong> ${escapeHTML(payload.repository_url || 'Not provided')}</li>
         <li><strong>Focus area:</strong> ${escapeHTML(payload.challenge || 'Trust path visibility')}</li>
+        <li><strong>Preferred day:</strong> ${escapeHTML(payload.preferred_day || 'Not provided')}</li>
+        <li><strong>Preferred time:</strong> ${escapeHTML(payload.preferred_time || 'Not provided')}</li>
         <li><strong>Deployment preference:</strong> ${escapeHTML(payload.deployment_model || 'Not provided')}</li>
       </ul>
       <p style="margin:0;color:#4b5563;">We never ask for production credentials in this intake flow.</p>
@@ -624,6 +638,8 @@ export default async function handler(
   const company = trimOptional(body.company);
   const companyDomain = normalizeCompanyDomainInput(body.company_domain);
   const challenge = trimOptional(body.challenge);
+  const preferredDay = trimOptional(body.preferred_day);
+  const preferredTime = trimOptional(body.preferred_time);
   const identityProvider = trimOptional(body.identity_provider);
   const infrastructureScope = trimOptional(body.infrastructure_scope);
   const repositoryURL = normalizePublicRepositoryURLInput(body.repository_url);
@@ -697,6 +713,12 @@ export default async function handler(
   if (challenge && !assertLength(res, challenge, MAX_CHALLENGE_LENGTH, 'Challenge value is too long.')) {
     return;
   }
+  if (preferredDay && !assertLength(res, preferredDay, MAX_PREFERRED_DAY_LENGTH, 'Preferred day value is too long.')) {
+    return;
+  }
+  if (preferredTime && !assertLength(res, preferredTime, MAX_PREFERRED_TIME_LENGTH, 'Preferred time value is too long.')) {
+    return;
+  }
   if (identityProvider && !assertLength(res, identityProvider, MAX_IDENTITY_PROVIDER_LENGTH, 'Identity provider value is too long.')) {
     return;
   }
@@ -747,6 +769,8 @@ export default async function handler(
     company,
     company_domain: companyDomain || undefined,
     challenge,
+    preferred_day: preferredDay && ALLOWED_PREFERRED_DAYS.has(preferredDay) ? preferredDay : undefined,
+    preferred_time: preferredTime && ALLOWED_PREFERRED_TIMES.has(preferredTime) ? preferredTime : undefined,
     identity_provider: identityProvider,
     infrastructure_scope: infrastructureScope,
     repository_url: repositoryURL || undefined,

--- a/web/index.html
+++ b/web/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src __IDENTRAIL_CONNECT_SRC__; frame-src https://www.youtube.com https://youtube.com https://calendly.com https://assets.calendly.com; media-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
+      content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src __IDENTRAIL_CONNECT_SRC__; frame-src https://www.youtube.com https://youtube.com; media-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
     />
     <meta
       name="description"

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -130,7 +130,18 @@ describe('App', () => {
 
     expect(screen.getByRole('dialog', { name: /Walk through a live trust path/i })).toBeInTheDocument();
     expect(document.querySelector('.idt-modal-backdrop')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Choose Demo Time/i })).toHaveAttribute('href', '/demo#book-demo');
     expect(screen.getByRole('link', { name: /Open Full Demo Page/i })).toHaveAttribute('href', '/demo');
+  });
+
+  it('uses first-party demo booking fields instead of an external calendar placeholder', () => {
+    setCurrentPath('/demo');
+    render(<App />);
+
+    expect(screen.getByLabelText(/Preferred day/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Preferred time/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Choose a preferred time/i })).toHaveAttribute('href', '/demo#book-demo');
+    expect(document.querySelector('a[href*="calendly"]')).not.toBeInTheDocument();
   });
 
   it.each([

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -63,7 +63,7 @@ const DOCS_REPO = 'https://github.com/identrail/identrail/tree/dev/docs';
 const DISCORD_URL = 'https://discord.gg/7jSUSnQC';
 const LINKEDIN_URL = 'https://www.linkedin.com/company/identrail/';
 const X_URL = 'https://x.com/identrail';
-const CALENDLY_URL = 'https://calendly.com/identrail/15min';
+const DEMO_BOOKING_PATH = '/demo#book-demo';
 const THEME_STORAGE_KEY = 'identrail-theme';
 const SCAN_CTA_LABEL = 'Request Trust Path Review';
 const INTAKE_TOTAL_STEPS = 4;
@@ -745,6 +745,17 @@ function RouteScrollReset() {
           target.scrollIntoView({ block: 'start' });
           return;
         }
+        if (target) {
+          const scrollMarginTop = Number.parseFloat(window.getComputedStyle(target).scrollMarginTop || '0') || 0;
+          const targetTop = target.getBoundingClientRect().top + window.scrollY - scrollMarginTop;
+          try {
+            window.scrollTo({ top: Math.max(0, targetTop), left: 0, behavior: 'auto' });
+          } catch {
+            document.documentElement.scrollTop = Math.max(0, targetTop);
+            document.body.scrollTop = Math.max(0, targetTop);
+          }
+          return;
+        }
         resetScrollTop();
       };
       if (typeof window.requestAnimationFrame === 'function') {
@@ -1193,7 +1204,8 @@ function LeadCaptureForm({
   caption,
   ctaLabel,
   compact = false,
-  variant = 'full'
+  variant = 'full',
+  includeScheduleFields = false
 }: {
   id?: string;
   title: string;
@@ -1201,6 +1213,7 @@ function LeadCaptureForm({
   ctaLabel: string;
   compact?: boolean;
   variant?: 'full' | 'short';
+  includeScheduleFields?: boolean;
 }) {
   const [submitted, setSubmitted] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -1214,6 +1227,8 @@ function LeadCaptureForm({
     const environment = String(formData.get('environment') ?? '').trim();
     const company = String(formData.get('company') ?? '').trim();
     const challenge = String(formData.get('challenge') ?? '').trim();
+    const preferredDay = String(formData.get('preferred_day') ?? '').trim();
+    const preferredTime = String(formData.get('preferred_time') ?? '').trim();
     const website = String(formData.get('website') ?? '').trim();
 
     setError(null);
@@ -1230,6 +1245,8 @@ function LeadCaptureForm({
         environment,
         company: company || undefined,
         challenge: challenge || undefined,
+        preferred_day: preferredDay || undefined,
+        preferred_time: preferredTime || undefined,
         website: website || undefined,
         source: title,
         page_path: window.location.pathname
@@ -1287,6 +1304,29 @@ function LeadCaptureForm({
                   <option>Overprivileged service accounts</option>
                   <option>Credential leak response</option>
                   <option>Authorization rollout safety</option>
+                </select>
+              </label>
+            </>
+          ) : null}
+          {includeScheduleFields ? (
+            <>
+              <label>
+                Preferred day
+                <select name="preferred_day" defaultValue="Any weekday">
+                  <option>Any weekday</option>
+                  <option>Today</option>
+                  <option>Tomorrow</option>
+                  <option>This week</option>
+                  <option>Next week</option>
+                </select>
+              </label>
+              <label>
+                Preferred time
+                <select name="preferred_time" defaultValue="Any time">
+                  <option>Any time</option>
+                  <option>Morning</option>
+                  <option>Afternoon</option>
+                  <option>Evening</option>
                 </select>
               </label>
             </>
@@ -1390,44 +1430,44 @@ function ModalShell({
   );
 }
 
-function CalendlyEmbed() {
+function BookingPrompt() {
   return (
-    <section className="idt-calendly">
+    <section className="idt-booking-prompt">
       <SectionTitle
         eyebrow="Book Demo"
         title="Walk through your trust graph in 15 minutes"
         body="Bring one AWS account or Kubernetes namespace, and we will map live trust paths and top risk chains."
       />
-      <div className="idt-calendly-shell">
-        <article className="idt-calendly-card">
-          <p className="idt-calendly-note">
+      <div className="idt-booking-prompt-shell">
+        <article className="idt-booking-prompt-card">
+          <p className="idt-booking-prompt-note">
             Choose a slot and we will review trust-path evidence, blast radius, and rollout-safe remediation priorities.
           </p>
-          <ul className="idt-calendly-checklist">
+          <ul className="idt-booking-prompt-checklist">
             <li>Read-only onboarding review</li>
             <li>Live trust graph walkthrough</li>
             <li>First remediation sequence</li>
           </ul>
           <div className="idt-inline-actions">
-            <SafeLink href={CALENDLY_URL} className="idt-btn idt-btn-primary">
-              Open Booking Calendar
-            </SafeLink>
+            <Link to={DEMO_BOOKING_PATH} className="idt-btn idt-btn-primary">
+              Choose Demo Time
+            </Link>
             <Link to="/enterprise" className="idt-btn idt-btn-dark">
               Talk to Sales
             </Link>
           </div>
         </article>
-        <aside className="idt-calendly-preview" aria-label="Demo agenda preview">
+        <aside className="idt-booking-prompt-preview" aria-label="Demo agenda preview">
           <p className="idt-eyebrow">Sample agenda</p>
           <ol>
             <li>Scope environment and trust boundaries</li>
             <li>Inspect one high-risk path with evidence</li>
             <li>Review safe remediation plan and rollout options</li>
           </ol>
-          <div className="idt-calendly-slot-row" aria-hidden="true">
-            <span>Tue · 10:00</span>
-            <span>Wed · 14:30</span>
-            <span>Fri · 09:00</span>
+          <div className="idt-booking-prompt-slot-row" aria-hidden="true">
+            <span>All-day availability</span>
+            <span>15-minute review</span>
+            <span>Email confirmation</span>
           </div>
         </aside>
       </div>
@@ -1490,11 +1530,12 @@ function BookDemoModal({ onClose }: { onClose: () => void }) {
             caption="Share the environment you want to review and we will route the demo around the trust paths that matter."
             ctaLabel="Request demo time"
             variant="short"
+            includeScheduleFields
           />
           <div className="idt-book-demo-modal-actions">
-            <SafeLink href={CALENDLY_URL} className="idt-btn idt-btn-primary">
-              Open Booking Calendar
-            </SafeLink>
+            <Link to={DEMO_BOOKING_PATH} className="idt-btn idt-btn-primary" onClick={onClose}>
+              Choose Demo Time
+            </Link>
             <Link to="/demo" className="idt-btn idt-btn-dark" onClick={onClose}>
               Open Full Demo Page
             </Link>
@@ -3178,7 +3219,7 @@ function SolutionsPage() {
         </div>
       </section>
       <section className="idt-section idt-shell">
-        <CalendlyEmbed />
+        <BookingPrompt />
       </section>
     </div>
   );
@@ -3660,9 +3701,9 @@ function DemoPage() {
         visual={<DemoBookingVisual />}
         actions={
           <>
-            <SafeLink href={CALENDLY_URL} className="idt-btn idt-btn-primary">
-              Open Booking Calendar
-            </SafeLink>
+            <Link to={DEMO_BOOKING_PATH} className="idt-btn idt-btn-primary">
+              Choose Demo Time
+            </Link>
             <ScanIntakeCTA className="idt-btn idt-btn-dark">Request Trust Path Review</ScanIntakeCTA>
           </>
         }
@@ -3670,10 +3711,12 @@ function DemoPage() {
 
       <section className="idt-section idt-shell idt-demo-booking-section">
         <LeadCaptureForm
+          id="book-demo"
           title="Book a guided walkthrough"
           caption="Share the environment you want to review and we will route the demo around the trust paths that matter to your team."
           ctaLabel="Request demo time"
           variant="full"
+          includeScheduleFields
         />
         <aside className="idt-demo-agenda-panel" aria-label="Demo agenda">
           <p className="idt-eyebrow">What we will cover</p>
@@ -3695,9 +3738,9 @@ function DemoPage() {
               <p>Turn the path into owner-ready remediation and rollout notes.</p>
             </article>
           </div>
-          <SafeLink href={CALENDLY_URL} className="idt-inline-link">
-            Choose a time on the calendar →
-          </SafeLink>
+          <Link to={DEMO_BOOKING_PATH} className="idt-inline-link">
+            Choose a preferred time →
+          </Link>
         </aside>
       </section>
 
@@ -3717,9 +3760,9 @@ function DemoPage() {
             <h2>Book the walkthrough, or send context for a trust path review.</h2>
           </div>
           <div className="idt-inline-actions">
-            <SafeLink href={CALENDLY_URL} className="idt-btn idt-btn-primary">
-              Book calendar slot
-            </SafeLink>
+            <Link to={DEMO_BOOKING_PATH} className="idt-btn idt-btn-primary">
+              Choose Demo Time
+            </Link>
             <ScanIntakeCTA className="idt-btn idt-btn-dark">Request Trust Path Review</ScanIntakeCTA>
           </div>
         </div>
@@ -3816,7 +3859,7 @@ function DocsPage() {
       </section>
 
       <section className="idt-section idt-shell">
-        <CalendlyEmbed />
+        <BookingPrompt />
       </section>
     </div>
   );
@@ -4211,12 +4254,13 @@ function EnterprisePage() {
             title="Talk to Enterprise Sales"
             caption="Share environment scope and business goals to get a deployment blueprint and pricing proposal."
             ctaLabel="Book Demo"
+            includeScheduleFields
           />
         </div>
       </section>
 
       <section className="idt-section idt-shell">
-        <CalendlyEmbed />
+        <BookingPrompt />
       </section>
     </div>
   );

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -477,6 +477,8 @@ export type LeadCapturePayload = {
   company?: string;
   company_domain?: string;
   challenge?: string;
+  preferred_day?: string;
+  preferred_time?: string;
   identity_provider?: string;
   infrastructure_scope?: string;
   repository_url?: string;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -937,7 +937,7 @@ h3 {
 .idt-lead-form,
 .idt-demo-sidebar,
 .idt-demo-graph,
-.idt-calendly,
+.idt-booking-prompt,
 .idt-roi {
   border: 1px solid var(--idt-line);
   border-radius: var(--idt-radius);
@@ -1589,11 +1589,11 @@ h3 {
   font-size: 0.82rem;
 }
 
-.idt-calendly {
+.idt-booking-prompt {
   padding: 1rem;
 }
 
-.idt-calendly iframe {
+.idt-booking-prompt iframe {
   width: 100%;
   min-height: 680px;
   border-radius: 12px;
@@ -3505,7 +3505,7 @@ html[data-theme='light'] .idt-footer-trust-links a {
     text-align: left;
   }
 
-  .idt-calendly iframe {
+  .idt-booking-prompt iframe {
     min-height: 520px;
   }
 }
@@ -3958,31 +3958,31 @@ html[data-theme='light'] .idt-hero-layer-dots button.is-active {
 }
 
 /* PR: light-mode legibility + link clarity + resilient booking panel */
-.idt-calendly {
+.idt-booking-prompt {
   display: grid;
   gap: 0.95rem;
 }
 
-.idt-calendly-shell {
+.idt-booking-prompt-shell {
   display: grid;
   grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
   gap: 0.95rem;
 }
 
-.idt-calendly-card,
-.idt-calendly-preview {
+.idt-booking-prompt-card,
+.idt-booking-prompt-preview {
   border: 1px solid rgba(164, 183, 218, 0.24);
   border-radius: 14px;
   background: linear-gradient(160deg, rgba(9, 14, 22, 0.9), rgba(7, 11, 18, 0.93));
   padding: 1rem;
 }
 
-.idt-calendly-note {
+.idt-booking-prompt-note {
   margin: 0;
   color: #c7d5eb;
 }
 
-.idt-calendly-checklist {
+.idt-booking-prompt-checklist {
   margin: 0.8rem 0 0;
   padding-left: 1.05rem;
   display: grid;
@@ -3990,11 +3990,11 @@ html[data-theme='light'] .idt-hero-layer-dots button.is-active {
   color: #d9e5f8;
 }
 
-.idt-calendly-preview .idt-eyebrow {
+.idt-booking-prompt-preview .idt-eyebrow {
   margin-bottom: 0.7rem;
 }
 
-.idt-calendly-preview ol {
+.idt-booking-prompt-preview ol {
   margin: 0;
   padding-left: 1.05rem;
   display: grid;
@@ -4002,14 +4002,14 @@ html[data-theme='light'] .idt-hero-layer-dots button.is-active {
   color: #d1def4;
 }
 
-.idt-calendly-slot-row {
+.idt-booking-prompt-slot-row {
   margin-top: 0.8rem;
   display: flex;
   flex-wrap: wrap;
   gap: 0.45rem;
 }
 
-.idt-calendly-slot-row span {
+.idt-booking-prompt-slot-row span {
   border: 1px solid rgba(161, 181, 217, 0.36);
   border-radius: 999px;
   background: rgba(16, 25, 41, 0.64);
@@ -4129,38 +4129,38 @@ html[data-theme='light'] .idt-demo-edge-tracer {
   filter: none;
 }
 
-html[data-theme='light'] .idt-calendly-card,
-html[data-theme='light'] .idt-calendly-preview {
+html[data-theme='light'] .idt-booking-prompt-card,
+html[data-theme='light'] .idt-booking-prompt-preview {
   background: linear-gradient(160deg, rgba(252, 254, 255, 0.98), rgba(243, 249, 255, 0.96));
   border-color: rgba(20, 40, 72, 0.16);
   box-shadow: 0 12px 26px rgba(32, 54, 93, 0.1);
 }
 
-html[data-theme='light'] .idt-calendly {
+html[data-theme='light'] .idt-booking-prompt {
   background: linear-gradient(156deg, rgba(248, 252, 255, 0.98), rgba(237, 245, 255, 0.96));
   border-color: rgba(22, 40, 71, 0.16);
   box-shadow: 0 14px 28px rgba(30, 52, 91, 0.12);
 }
 
-html[data-theme='light'] .idt-calendly .idt-section-title .idt-eyebrow {
+html[data-theme='light'] .idt-booking-prompt .idt-section-title .idt-eyebrow {
   color: #5d79a4;
 }
 
-html[data-theme='light'] .idt-calendly .idt-section-title h2 {
+html[data-theme='light'] .idt-booking-prompt .idt-section-title h2 {
   color: #183056;
 }
 
-html[data-theme='light'] .idt-calendly .idt-section-title p {
+html[data-theme='light'] .idt-booking-prompt .idt-section-title p {
   color: #2f486f;
 }
 
-html[data-theme='light'] .idt-calendly-note,
-html[data-theme='light'] .idt-calendly-checklist,
-html[data-theme='light'] .idt-calendly-preview ol {
+html[data-theme='light'] .idt-booking-prompt-note,
+html[data-theme='light'] .idt-booking-prompt-checklist,
+html[data-theme='light'] .idt-booking-prompt-preview ol {
   color: #2f486f;
 }
 
-html[data-theme='light'] .idt-calendly-slot-row span {
+html[data-theme='light'] .idt-booking-prompt-slot-row span {
   border-color: rgba(30, 56, 102, 0.25);
   background: rgba(234, 243, 255, 0.92);
   color: #233d66;
@@ -4174,7 +4174,7 @@ html[data-theme='light'] .idt-header-utility {
 }
 
 @media (max-width: 1080px) {
-  .idt-calendly-shell {
+  .idt-booking-prompt-shell {
     grid-template-columns: 1fr;
   }
 }
@@ -17921,7 +17921,7 @@ html[data-theme='light'] .idt-docs-preview-shell code {
   color: #fbbf24;
 }
 
-.idt-calendly-card .idt-inline-actions {
+.idt-booking-prompt-card .idt-inline-actions {
   margin-top: clamp(2rem, 4vw, 3.2rem);
 }
 
@@ -20812,6 +20812,7 @@ html[data-theme='light'] .idt-demo-booking-section {
   gap: 1px;
   align-items: stretch;
   background: #242424;
+  scroll-margin-top: 7.5rem;
 }
 
 .idt-demo-booking-section > .idt-lead-form,
@@ -20821,6 +20822,34 @@ html[data-theme='light'] .idt-demo-agenda-panel {
   border: 0;
   border-radius: 0;
   background: #080808;
+}
+
+#book-demo {
+  scroll-margin-top: 7.5rem;
+}
+
+.idt-demo-page .idt-demo-booking-section > .idt-lead-form h3,
+html[data-theme='light'] .idt-demo-page .idt-demo-booking-section > .idt-lead-form h3 {
+  color: #ffffff;
+}
+
+.idt-demo-page .idt-demo-booking-section > .idt-lead-form p,
+.idt-demo-page .idt-demo-booking-section > .idt-lead-form .idt-form-note,
+.idt-demo-page .idt-demo-booking-section > .idt-lead-form .idt-form-trust-note,
+html[data-theme='light'] .idt-demo-page .idt-demo-booking-section > .idt-lead-form p,
+html[data-theme='light'] .idt-demo-page .idt-demo-booking-section > .idt-lead-form .idt-form-note,
+html[data-theme='light'] .idt-demo-page .idt-demo-booking-section > .idt-lead-form .idt-form-trust-note {
+  color: #c7c7cf;
+}
+
+.idt-demo-page .idt-demo-booking-section > .idt-lead-form .idt-form-grid label,
+html[data-theme='light'] .idt-demo-page .idt-demo-booking-section > .idt-lead-form .idt-form-grid label {
+  color: #d9d9df;
+}
+
+.idt-demo-page .idt-demo-booking-section > .idt-lead-form input::placeholder,
+html[data-theme='light'] .idt-demo-page .idt-demo-booking-section > .idt-lead-form input::placeholder {
+  color: #9f9fa8;
 }
 
 .idt-demo-agenda-panel {
@@ -20891,6 +20920,23 @@ html[data-theme='light'] .idt-demo-graph-preview .idt-section-title h2,
 .idt-demo-choice-band h2,
 html[data-theme='light'] .idt-demo-choice-band h2 {
   color: #ffffff;
+}
+
+.idt-demo-page .idt-demo-evidence,
+html[data-theme='light'] .idt-demo-page .idt-demo-evidence {
+  border-color: #303030;
+  background: #111111;
+  color: #f4f4f5;
+}
+
+.idt-demo-page .idt-demo-evidence strong,
+html[data-theme='light'] .idt-demo-page .idt-demo-evidence strong {
+  color: #ffffff;
+}
+
+.idt-demo-page .idt-demo-evidence p,
+html[data-theme='light'] .idt-demo-page .idt-demo-evidence p {
+  color: #d4d4d8;
 }
 
 .idt-demo-choice-band,


### PR DESCRIPTION
Fixes #1273

## Summary
- Replace calendar placeholder CTAs with the first-party `/demo#book-demo` booking flow and availability capture.
- Carry preferred day/time through the lead API, internal notification, and confirmation email payloads.
- Fix low-contrast demo booking/evidence panels and remove the stale Calendly frame CSP allowance.

## Impact and risk
- Public marketing booking actions now stay on the Identrail site and submit availability preferences through the existing lead pipeline.
- Low risk; no production credentials are requested, and invalid schedule values are ignored server-side.

## Validation
- `npm test -- --run api/leads.test.ts`
- `npm test -- --run src/App.test.tsx`
- `npm run build`
- Production preview check at `/demo#book-demo`: readable dark booking/evidence panels, target anchor visible, preferred day/time fields present, no Calendly links, and no console errors.

AI-assisted: No
Tools used: None
Where used: Not applicable
Human verification performed: Focused web tests, production web build, and preview-browser inspection of `/demo#book-demo`.
