### PR TITLE
fix(web): close post-merge codex findings on workspace overview

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -709,6 +709,59 @@ describe('App', () => {
     expect(screen.queryByText('+12')).not.toBeInTheDocument();
   });
 
+  it('does not mark source onboarding complete when onboarding state belongs to another workspace', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/v1/me')) {
+        return okJSON(currentMePayload('tenant-b', 'workspace-b'));
+      }
+      if (url.includes('/v1/onboarding/state')) {
+        return okJSON({
+          state: {
+            user_id: 'user-1',
+            current_step: 'invite',
+            org_id: 'tenant-a',
+            workspace_id: 'workspace-a',
+            project_id: 'project-a',
+            connector_id: 'github-app',
+            connector_type: 'github',
+            connector_skipped: false,
+            scan_skipped: false,
+            started_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z'
+          }
+        });
+      }
+      if (url.includes('/v1/workspaces/workspace-b/projects')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/repo-scans')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/repo-findings/trends')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/repo-findings')) {
+        return okJSON({ items: [] });
+      }
+      throw new Error(`Unexpected URL ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    setCurrentPath('/app/tenant-b/workspace-b');
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { level: 2, name: /Overview/i }, { timeout: 5000 })).toBeInTheDocument();
+    const checklistRegion = await screen.findByRole('region', { name: /Get started/i }, { timeout: 5000 });
+    const sourceChecklistItem = within(checklistRegion).getByText('Connect a source').closest('li');
+    expect(sourceChecklistItem).not.toBeNull();
+    if (!sourceChecklistItem) {
+      throw new Error('missing source checklist item');
+    }
+    expect(sourceChecklistItem).toHaveAttribute('data-complete', 'false');
+    expect(within(sourceChecklistItem).getByRole('link', { name: 'Connect' })).toBeInTheDocument();
+  });
+
   it('hides manual workspace entry when auth config disables manual mode', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(authConfig(false, true)));
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1734,24 +1734,15 @@ function readInviteSkipped(tenantID: string | undefined, workspaceID: string | u
     return false;
   }
   try {
-    const fresh = window.localStorage.getItem(`${INVITE_SKIPPED_STORAGE_KEY}:${scope}`);
-    if (fresh === '1') {
+    if (window.localStorage.getItem(`${INVITE_SKIPPED_STORAGE_KEY}:${scope}`) === '1') {
       return true;
     }
-    // Back-compat: earlier builds keyed by workspaceID alone. Honor that flag so
-    // upgraded users don't see the checklist regress, but only when no later
-    // tenant-scoped flag has been written.
-    const legacyTenantScoped = window.localStorage.getItem(`${INVITE_LEGACY_STORAGE_KEY}:${scope}`);
-    if (legacyTenantScoped === '1') {
-      return true;
-    }
-    if (workspaceID) {
-      const legacyWorkspaceOnly =
-        window.localStorage.getItem(`${INVITE_SKIPPED_STORAGE_KEY}:${workspaceID}`) ||
-        window.localStorage.getItem(`${INVITE_LEGACY_STORAGE_KEY}:${workspaceID}`);
-      return legacyWorkspaceOnly === '1';
-    }
-    return false;
+    // The earlier `idt:overview:invite-dismissed` key was also tenant-scoped in
+    // the previous revision, so honoring it here is safe — it never crossed
+    // tenants. The workspace-only legacy keys are intentionally NOT consulted
+    // so a Skip in tenant A no longer leaks into tenant B that happens to
+    // reuse the same workspace slug in the same browser profile.
+    return window.localStorage.getItem(`${INVITE_LEGACY_STORAGE_KEY}:${scope}`) === '1';
   } catch {
     return false;
   }
@@ -1767,13 +1758,9 @@ function persistInviteSkipped(tenantID: string | undefined, workspaceID: string 
   }
   try {
     window.localStorage.setItem(`${INVITE_SKIPPED_STORAGE_KEY}:${scope}`, '1');
-    // Migrate forward: drop the old workspace-only and dismissed flags so we
-    // don't leave stale state behind for the same workspace.
+    // Drop the matching tenant-scoped legacy key on the same scope, but do NOT
+    // touch the unscoped workspace-only keys that may belong to other tenants.
     window.localStorage.removeItem(`${INVITE_LEGACY_STORAGE_KEY}:${scope}`);
-    if (workspaceID) {
-      window.localStorage.removeItem(`${INVITE_SKIPPED_STORAGE_KEY}:${workspaceID}`);
-      window.localStorage.removeItem(`${INVITE_LEGACY_STORAGE_KEY}:${workspaceID}`);
-    }
   } catch {
     // Storage failures are non-fatal.
   }
@@ -1791,22 +1778,48 @@ export function ProductOverviewPage() {
   const [repoFindings, setRepoFindings] = useState<ApiFinding[]>([]);
   const [trendPoints, setTrendPoints] = useState<TrendPoint[]>([]);
   const [, setInviteSkipTick] = useState(0);
+  const [connectorConfiguredFromOnboarding, setConnectorConfiguredFromOnboarding] = useState(false);
 
   useEffect(() => {
-    if (!FEATURE_ONBOARDING_WIZARD) {
+    const tenantID = scope?.tenantID;
+    const workspaceID = scope?.workspaceID;
+    if (!FEATURE_ONBOARDING_WIZARD || !tenantID || !workspaceID) {
+      setShowTour(false);
+      setConnectorConfiguredFromOnboarding(false);
       return;
     }
     let mounted = true;
+    // Reset immediately when scope changes so stale onboarding data cannot
+    // bleed connector-complete state into another workspace.
+    setConnectorConfiguredFromOnboarding(false);
     const run = async () => {
       try {
-        const response = await apiClient.getOnboardingState();
+        const response = await apiClient.getOnboardingState({ tenantID, workspaceID });
         if (!mounted) {
           return;
         }
-        setShowTour(response.state.current_step === 'complete' && !response.state.dashboard_tour_dismissed_at);
+        const state = response.state;
+        const onboardingMatchesScope =
+          normalizeValue(state.org_id ?? '') === tenantID &&
+          normalizeValue(state.workspace_id ?? '') === workspaceID;
+        setShowTour(
+          onboardingMatchesScope && state.current_step === 'complete' && !state.dashboard_tour_dismissed_at
+        );
+        // Source-checklist signal: the user finished the connect step if either
+        // a connector_id was persisted or onboarding progressed past 'connect'
+        // without an explicit skip. This avoids the false negative where a
+        // connector exists but no scan has run yet (which would otherwise leave
+        // the checklist forever stuck at "Connect a source").
+        const stepsPastConnect: ReadonlyArray<typeof state.current_step> = ['scan', 'invite', 'complete'];
+        const reachedConnect =
+          onboardingMatchesScope &&
+          (Boolean(state.connector_id) ||
+            (!state.connector_skipped && stepsPastConnect.includes(state.current_step)));
+        setConnectorConfiguredFromOnboarding(reachedConnect);
       } catch {
         if (mounted) {
           setShowTour(false);
+          setConnectorConfiguredFromOnboarding(false);
         }
       }
     };
@@ -1814,7 +1827,7 @@ export function ProductOverviewPage() {
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [scope?.tenantID, scope?.workspaceID]);
 
   useEffect(() => {
     if (!scope) {
@@ -1910,11 +1923,12 @@ export function ProductOverviewPage() {
   const workspacesPath = scope ? buildScopedPath(scope, 'workspaces') : '/app';
   const connectSourcesPath = scope?.projectID ? buildProjectPath(scope, scope.projectID) : projectsPath;
   const hasAnySuccessfulScan = succeededScanCount > 0;
-  // A scan can only be queued or run if a connector is wired to the project, so
-  // "any scan attempt at all" is a sound proxy for "a source has been connected"
-  // without inferring from free-form project descriptions (which produced false
-  // positives when a project description simply mentioned a vendor name).
-  const hasConnectedSource = repoScans.length > 0;
+  // A source counts as connected when either (a) onboarding records a connector
+  // configuration on the workspace, or (b) any scan has run (you can't scan
+  // without a connector). The previous "scans-only" signal incorrectly left the
+  // checklist stuck at "Connect a source" for users who had a healthy connector
+  // but hadn't kicked off their first scan yet.
+  const hasConnectedSource = connectorConfiguredFromOnboarding || repoScans.length > 0;
   const onboardingChecklist: Array<{
     id: string;
     label: string;


### PR DESCRIPTION
No issue: post-merge follow-up to previously merged PR #1270.
Refs #1270

Follow-up to [identrail/identrail#1270](https://github.com/identrail/identrail/pull/1270) (merged at `4b6f8d3a`). Addresses the two workspace-overview P2 review findings.

## Summary

- Scope onboarding-derived connector completion to the active tenant/workspace so completion cannot leak across workspace switches.
- Keep the source checklist complete when onboarding already has connector progress, while preserving scan-based fallback behavior.
- Add a regression test proving onboarding data from workspace A does not mark workspace B as connected.

## Validation

- `npm run test -- src/App.test.tsx` (targeted regression)
- `tsc -b` (web type-check build stage)

## Risk / impact

- UI-only behavior change in `web/src/productShell.tsx` and test updates in `web/src/App.test.tsx`.
