### PR TITLE
feat(web): real sidebar icons, drag-to-resize, fix collapsed active-nav

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "identrail-web",
       "version": "0.1.0",
       "dependencies": {
+        "lucide-react": "^1.16.0",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-router-dom": "^7.15.1"
@@ -4506,6 +4507,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.16.0.tgz",
+      "integrity": "sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
     "perf:bundle": "vite build --mode production"
   },
   "dependencies": {
+    "lucide-react": "^1.16.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-router-dom": "^7.15.1"

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1376,10 +1376,27 @@ export function ProductShellLayout() {
       return;
     }
     event.preventDefault();
+    const handleEl = event.currentTarget;
+    const pointerId = event.pointerId;
+    // Capture the pointer so every subsequent move / up / cancel for this
+    // gesture is delivered to the handle even if the user releases outside the
+    // viewport, the OS steals focus, or the browser fires `pointercancel`.
+    // Without this, releasing off-window left `isDraggingSidebar` stuck true
+    // and the body `cursor: col-resize` / `user-select: none` overrides
+    // applied to the entire page.
+    try {
+      handleEl.setPointerCapture(pointerId);
+    } catch {
+      // Some test environments (jsdom) don't implement setPointerCapture.
+      // Falling through is safe — the cleanup is still wired up below.
+    }
     setIsDraggingSidebar(true);
     const sidebarEl = sidebarRef.current;
     const startLeft = sidebarEl ? sidebarEl.getBoundingClientRect().left : 0;
     const handlePointerMove = (moveEvent: PointerEvent) => {
+      if (moveEvent.pointerId !== pointerId) {
+        return;
+      }
       const proposed = moveEvent.clientX - startLeft;
       if (proposed < SIDEBAR_COLLAPSE_THRESHOLD) {
         setSidebarCollapsedPref(true);
@@ -1389,18 +1406,45 @@ export function ProductShellLayout() {
       setSidebarCollapsedPref(false);
       setSidebarWidth(clamped);
     };
-    const handlePointerUp = () => {
+    const cleanup = (cleanupEvent?: PointerEvent) => {
+      if (cleanupEvent && cleanupEvent.pointerId !== pointerId) {
+        return;
+      }
       setIsDraggingSidebar(false);
-      window.removeEventListener('pointermove', handlePointerMove);
-      window.removeEventListener('pointerup', handlePointerUp);
-      document.body.style.removeProperty('cursor');
-      document.body.style.removeProperty('user-select');
+      handleEl.removeEventListener('pointermove', handlePointerMove);
+      handleEl.removeEventListener('pointerup', cleanup);
+      handleEl.removeEventListener('pointercancel', cleanup);
+      handleEl.removeEventListener('lostpointercapture', cleanup);
     };
-    document.body.style.cursor = 'col-resize';
-    document.body.style.userSelect = 'none';
-    window.addEventListener('pointermove', handlePointerMove);
-    window.addEventListener('pointerup', handlePointerUp);
+    handleEl.addEventListener('pointermove', handlePointerMove);
+    handleEl.addEventListener('pointerup', cleanup);
+    handleEl.addEventListener('pointercancel', cleanup);
+    // `lostpointercapture` fires whenever capture ends for any reason —
+    // including the OS canceling the gesture or the element being unmounted
+    // by React. It is the most reliable final cleanup signal.
+    handleEl.addEventListener('lostpointercapture', cleanup);
   };
+
+  // Safety net: any time we leave the dragging state, ensure the body style
+  // overrides we applied are released. Also handles the unmount-mid-drag
+  // case (effect cleanup runs once on unmount) without leaving the document
+  // stuck in `cursor: col-resize` / `user-select: none`.
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    if (isDraggingSidebar) {
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+      return () => {
+        document.body.style.removeProperty('cursor');
+        document.body.style.removeProperty('user-select');
+      };
+    }
+    document.body.style.removeProperty('cursor');
+    document.body.style.removeProperty('user-select');
+    return undefined;
+  }, [isDraggingSidebar]);
 
   useEffect(() => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1,6 +1,25 @@
 import { Component, FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
-import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+import type {
+  CSSProperties,
+  KeyboardEvent as ReactKeyboardEvent,
+  PointerEvent as ReactPointerEvent
+} from 'react';
 import { Link, Navigate, NavLink, Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
+import {
+  BarChart3,
+  ChevronDown,
+  ChevronUp,
+  FolderKanban,
+  HelpCircle,
+  LayoutDashboard,
+  LogOut,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Search,
+  Settings as SettingsIcon,
+  Shield,
+  Users
+} from 'lucide-react';
 import {
   ApiError,
   apiClient,
@@ -1145,6 +1164,12 @@ function resolveScopeFromParams(params: ScopeRouteParams): ProductSession | null
 }
 
 const SIDEBAR_COLLAPSED_STORAGE_KEY = 'idt:sidebar:collapsed';
+const SIDEBAR_WIDTH_STORAGE_KEY = 'idt:sidebar:width';
+const SIDEBAR_DEFAULT_WIDTH = 248; // matches the prior 15.5rem
+const SIDEBAR_MIN_EXPANDED_WIDTH = 196;
+const SIDEBAR_MAX_WIDTH = 360;
+const SIDEBAR_COLLAPSE_THRESHOLD = 140; // dragging below this snaps to collapsed
+const SIDEBAR_COLLAPSED_WIDTH = 60;
 
 function readSidebarCollapsed(): boolean {
   if (typeof window === 'undefined') {
@@ -1154,6 +1179,25 @@ function readSidebarCollapsed(): boolean {
     return window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === '1';
   } catch {
     return false;
+  }
+}
+
+function readSidebarWidth(): number {
+  if (typeof window === 'undefined') {
+    return SIDEBAR_DEFAULT_WIDTH;
+  }
+  try {
+    const raw = window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
+    if (!raw) {
+      return SIDEBAR_DEFAULT_WIDTH;
+    }
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isNaN(parsed)) {
+      return SIDEBAR_DEFAULT_WIDTH;
+    }
+    return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_EXPANDED_WIDTH, parsed));
+  } catch {
+    return SIDEBAR_DEFAULT_WIDTH;
   }
 }
 
@@ -1172,6 +1216,8 @@ export function ProductShellLayout() {
   const [accountMenuOpen, setAccountMenuOpen] = useState(false);
   const [workspaceMenuOpen, setWorkspaceMenuOpen] = useState(false);
   const [sidebarCollapsedPref, setSidebarCollapsedPref] = useState<boolean>(() => readSidebarCollapsed());
+  const [sidebarWidth, setSidebarWidth] = useState<number>(() => readSidebarWidth());
+  const [isDraggingSidebar, setIsDraggingSidebar] = useState(false);
   const [isNarrowViewport, setIsNarrowViewport] = useState<boolean>(() => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
       return false;
@@ -1183,8 +1229,14 @@ export function ProductShellLayout() {
   // for a horizontal nav, and persisting a collapsed preference into mobile
   // would otherwise leave users without a way to expand it.
   const sidebarCollapsed = sidebarCollapsedPref && !isNarrowViewport;
+  const renderedSidebarWidth = isNarrowViewport
+    ? undefined
+    : sidebarCollapsed
+      ? SIDEBAR_COLLAPSED_WIDTH
+      : sidebarWidth;
   const accountMenuRef = useRef<HTMLDivElement | null>(null);
   const workspaceMenuRef = useRef<HTMLDivElement | null>(null);
+  const sidebarRef = useRef<HTMLElement | null>(null);
   const basePath = scope ? buildScopedPath(scope) : '/app';
   const commandItems = useMemo<CommandPaletteItem[]>(() => {
     if (!scope) {
@@ -1309,6 +1361,48 @@ export function ProductShellLayout() {
   }, [sidebarCollapsedPref]);
 
   useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    try {
+      window.localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(sidebarWidth));
+    } catch {
+      // Storage failure should not break the layout.
+    }
+  }, [sidebarWidth]);
+
+  const handleSidebarResizeStart = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (isNarrowViewport) {
+      return;
+    }
+    event.preventDefault();
+    setIsDraggingSidebar(true);
+    const sidebarEl = sidebarRef.current;
+    const startLeft = sidebarEl ? sidebarEl.getBoundingClientRect().left : 0;
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      const proposed = moveEvent.clientX - startLeft;
+      if (proposed < SIDEBAR_COLLAPSE_THRESHOLD) {
+        setSidebarCollapsedPref(true);
+        return;
+      }
+      const clamped = Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_EXPANDED_WIDTH, proposed));
+      setSidebarCollapsedPref(false);
+      setSidebarWidth(clamped);
+    };
+    const handlePointerUp = () => {
+      setIsDraggingSidebar(false);
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+      document.body.style.removeProperty('cursor');
+      document.body.style.removeProperty('user-select');
+    };
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+  };
+
+  useEffect(() => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
       return;
     }
@@ -1396,15 +1490,32 @@ export function ProductShellLayout() {
   return (
     <ProductErrorBoundary>
       <div
-        className={`idt-app-shell idt-app-console-layout${sidebarCollapsed ? ' is-sidebar-collapsed' : ''}`}
+        className={`idt-app-shell idt-app-console-layout${sidebarCollapsed ? ' is-sidebar-collapsed' : ''}${isDraggingSidebar ? ' is-sidebar-dragging' : ''}`}
         data-tenant={scope.tenantID}
         data-workspace={scope.workspaceID}
+        style={
+          renderedSidebarWidth !== undefined
+            ? ({ ['--idt-sidebar-width' as string]: `${renderedSidebarWidth}px` } as CSSProperties)
+            : undefined
+        }
       >
         <aside
+          ref={sidebarRef}
           className="idt-app-sidebar"
           aria-label="Workspace navigation"
           data-collapsed={sidebarCollapsed ? 'true' : 'false'}
         >
+          <div
+            className={`idt-app-sidebar-resize-handle${isDraggingSidebar ? ' is-dragging' : ''}`}
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize sidebar (drag, or use ⌘B to collapse)"
+            onPointerDown={handleSidebarResizeStart}
+            onDoubleClick={() => {
+              setSidebarCollapsedPref(false);
+              setSidebarWidth(SIDEBAR_DEFAULT_WIDTH);
+            }}
+          />
           <div className="idt-app-sidebar-workspace" ref={workspaceMenuRef}>
             <button
               type="button"
@@ -1423,9 +1534,7 @@ export function ProductShellLayout() {
                 <span>Identrail</span>
               </span>
               <span className="idt-app-sidebar-workspace-caret" aria-hidden="true">
-                <svg viewBox="0 0 12 12" width="10" height="10" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="m3 4.5 3 3 3-3" />
-                </svg>
+                <ChevronDown size={12} strokeWidth={2} />
               </span>
             </button>
             {workspaceMenuOpen ? (
@@ -1467,10 +1576,7 @@ export function ProductShellLayout() {
             title={sidebarCollapsed ? 'Find (⌘K)' : undefined}
           >
             <span className="idt-app-quick-find-icon" aria-hidden="true">
-              <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-                <circle cx="7" cy="7" r="4.5" />
-                <path d="m13.5 13.5-3-3" />
-              </svg>
+              <Search size={14} strokeWidth={2} />
             </span>
             <span className="idt-app-quick-find-label">Find</span>
             <kbd className="idt-app-quick-find-key">⌘K</kbd>
@@ -1480,37 +1586,25 @@ export function ProductShellLayout() {
             <div className="idt-app-nav-group-label" aria-hidden={sidebarCollapsed}>Workspace</div>
             <NavLink to={basePath} end aria-label="Overview" title={sidebarCollapsed ? 'Overview' : undefined}>
               <span className="idt-app-nav-icon" aria-hidden="true">
-                <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M2 8 8 2.5 14 8" />
-                  <path d="M3.5 7v6.5h9V7" />
-                </svg>
+                <LayoutDashboard size={16} strokeWidth={1.75} />
               </span>
               <span className="idt-app-nav-label">Overview</span>
             </NavLink>
             <NavLink to={`${basePath}/projects`} aria-label="Projects" title={sidebarCollapsed ? 'Projects' : undefined}>
               <span className="idt-app-nav-icon" aria-hidden="true">
-                <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M2 5.5 7 3l5 2.5L7 8Z" />
-                  <path d="M2 5.5v5L7 13l5-2.5v-5" />
-                  <path d="M7 8v5" />
-                </svg>
+                <FolderKanban size={16} strokeWidth={1.75} />
               </span>
               <span className="idt-app-nav-label">Projects</span>
             </NavLink>
             <NavLink to={`${basePath}/findings`} aria-label="Findings" title={sidebarCollapsed ? 'Findings' : undefined}>
               <span className="idt-app-nav-icon" aria-hidden="true">
-                <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M8 1.5 2 4v3.5c0 4 3 6.4 6 7 3-.6 6-3 6-7V4Z" />
-                </svg>
+                <Shield size={16} strokeWidth={1.75} />
               </span>
               <span className="idt-app-nav-label">Findings</span>
             </NavLink>
             <NavLink to="/reports/executive" aria-label="Executive report" title={sidebarCollapsed ? 'Executive report' : undefined}>
               <span className="idt-app-nav-icon" aria-hidden="true">
-                <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-                  <rect x="2.5" y="2.5" width="11" height="11" rx="1.5" />
-                  <path d="M5 11V8M8 11V6M11 11V9" />
-                </svg>
+                <BarChart3 size={16} strokeWidth={1.75} />
               </span>
               <span className="idt-app-nav-label">Executive report</span>
             </NavLink>
@@ -1518,21 +1612,13 @@ export function ProductShellLayout() {
             <div className="idt-app-nav-group-label" aria-hidden={sidebarCollapsed}>Organization</div>
             <NavLink to={`${basePath}/workspaces`} aria-label="Workspaces" title={sidebarCollapsed ? 'Workspaces' : undefined}>
               <span className="idt-app-nav-icon" aria-hidden="true">
-                <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-                  <circle cx="5.5" cy="6" r="2" />
-                  <circle cx="11" cy="6.5" r="1.6" />
-                  <path d="M2 13c.6-2 2-3 3.5-3S8.4 11 9 13" />
-                  <path d="M9.5 13c.4-1.6 1.5-2.4 2.5-2.4s2.1.8 2.5 2.4" />
-                </svg>
+                <Users size={16} strokeWidth={1.75} />
               </span>
               <span className="idt-app-nav-label">Workspaces</span>
             </NavLink>
             <NavLink to={`${basePath}/settings`} aria-label="Settings" title={sidebarCollapsed ? 'Settings' : undefined}>
               <span className="idt-app-nav-icon" aria-hidden="true">
-                <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-                  <circle cx="8" cy="8" r="2" />
-                  <path d="M8 2v1.5M8 12.5V14M2 8h1.5M12.5 8H14M3.8 3.8l1 1M11.2 11.2l1 1M3.8 12.2l1-1M11.2 4.8l1-1" />
-                </svg>
+                <SettingsIcon size={16} strokeWidth={1.75} />
               </span>
               <span className="idt-app-nav-label">Settings</span>
             </NavLink>
@@ -1557,9 +1643,7 @@ export function ProductShellLayout() {
                   {userEmail && userEmail !== userDisplayName ? <span>{userEmail}</span> : null}
                 </span>
                 <span className="idt-app-sidebar-account-caret" aria-hidden="true">
-                  <svg viewBox="0 0 12 12" width="10" height="10" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M3 7.5 6 4.5l3 3" />
-                  </svg>
+                  <ChevronUp size={12} strokeWidth={2} />
                 </span>
               </button>
               {accountMenuOpen ? (
@@ -1573,16 +1657,18 @@ export function ProductShellLayout() {
                     to={`${basePath}/settings`}
                     onClick={() => setAccountMenuOpen(false)}
                   >
+                    <SettingsIcon size={14} strokeWidth={1.75} aria-hidden="true" />
                     Workspace settings
                   </Link>
                   <a
                     role="menuitem"
-                    href="https://docs.identrail.com"
+                    href="https://github.com/identrail/identrail/issues"
                     target="_blank"
                     rel="noopener noreferrer"
                     onClick={() => setAccountMenuOpen(false)}
                   >
-                    Help &amp; docs
+                    <HelpCircle size={14} strokeWidth={1.75} aria-hidden="true" />
+                    Help &amp; feedback
                   </a>
                   <Link role="menuitem" to="/" onClick={() => setAccountMenuOpen(false)}>
                     Marketing site
@@ -1595,6 +1681,7 @@ export function ProductShellLayout() {
                       navigate('/app/logout', { replace: true });
                     }}
                   >
+                    <LogOut size={14} strokeWidth={1.75} aria-hidden="true" />
                     Sign out
                   </button>
                 </div>
@@ -1608,11 +1695,11 @@ export function ProductShellLayout() {
               title={collapseHint}
               onClick={() => setSidebarCollapsedPref((current) => !current)}
             >
-              <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <rect x="2.5" y="3" width="11" height="10" rx="1.5" />
-                <path d="M6.5 3v10" />
-                {sidebarCollapsed ? <path d="m9 6 2 2-2 2" /> : <path d="m11 6-2 2 2 2" />}
-              </svg>
+              {sidebarCollapsed ? (
+                <PanelLeftOpen size={16} strokeWidth={1.75} aria-hidden="true" />
+              ) : (
+                <PanelLeftClose size={16} strokeWidth={1.75} aria-hidden="true" />
+              )}
             </button>
           </div>
         </aside>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -18993,15 +18993,16 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a {
   transition: background-color 0.16s ease, border-color 0.16s ease, color 0.16s ease;
 }
 
+/* Hover / focus / active nav styling is owned by the polish block further down
+ * in this file (search for "Workspace shell redesign"). Keeping only the
+ * shared text-decoration reset here so the higher-specificity light-theme
+ * rule doesn't repaint the active item white in the dark console shell. */
 .idt-app-console-layout .idt-app-shell-nav a:hover,
 .idt-app-console-layout .idt-app-shell-nav a:focus-visible,
 .idt-app-console-layout .idt-app-shell-nav a.active,
 html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a:hover,
 html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a:focus-visible,
 html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a.active {
-  border-color: var(--app-border);
-  background: #ffffff;
-  color: #000000;
   text-decoration: none;
 }
 
@@ -21265,12 +21266,21 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 /* === Workspace shell redesign === */
 
 .idt-app-console-layout {
-  grid-template-columns: 15.5rem minmax(0, 1fr);
-  transition: grid-template-columns 0.2s ease;
+  grid-template-columns: var(--idt-sidebar-width, 15.5rem) minmax(0, 1fr);
+  transition: grid-template-columns 0.18s ease;
+}
+
+/* Suppress the resize transition while the user is actively dragging so the
+ * sidebar tracks the cursor 1:1 instead of lagging behind it. */
+.idt-app-console-layout.is-sidebar-dragging {
+  transition: none;
+}
+.idt-app-console-layout.is-sidebar-dragging * {
+  user-select: none;
 }
 
 .idt-app-console-layout.is-sidebar-collapsed {
-  grid-template-columns: 3.75rem minmax(0, 1fr);
+  grid-template-columns: var(--idt-sidebar-width, 3.75rem) minmax(0, 1fr);
 }
 
 .idt-app-console-layout .idt-app-sidebar {
@@ -22330,4 +22340,109 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   border: 1px solid currentColor;
   width: 0.4rem;
   height: 0.4rem;
+}
+
+/* === Sidebar polish: drag handle, active accent, active-fill, refined hover === */
+
+.idt-app-sidebar {
+  position: relative;
+}
+
+.idt-app-sidebar-resize-handle {
+  position: absolute;
+  top: 0;
+  right: -3px;
+  width: 6px;
+  height: 100%;
+  cursor: col-resize;
+  z-index: 30;
+  background: transparent;
+  transition: background-color 0.12s ease;
+  touch-action: none;
+}
+
+.idt-app-sidebar-resize-handle::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 2px;
+  height: 100%;
+  background: transparent;
+  transition: background-color 0.12s ease;
+}
+
+.idt-app-sidebar-resize-handle:hover::after,
+.idt-app-sidebar-resize-handle.is-dragging::after,
+.idt-app-console-layout.is-sidebar-dragging .idt-app-sidebar-resize-handle::after {
+  background: #3a3a45;
+}
+
+/* Hide the drag handle on narrow viewports — the rail becomes a top bar. */
+@media (max-width: 960px) {
+  .idt-app-sidebar-resize-handle {
+    display: none;
+  }
+}
+
+/* Active-nav fix: dark fill + a left accent bar instead of the broken white
+ * default that bled through from the light theme. */
+.idt-app-console-layout .idt-app-shell-nav a {
+  position: relative;
+}
+
+.idt-app-console-layout .idt-app-shell-nav a.active {
+  background: #1c1c22;
+  color: #ffffff;
+}
+
+.idt-app-console-layout .idt-app-shell-nav a.active::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 6px;
+  bottom: 6px;
+  width: 2px;
+  border-radius: 0 2px 2px 0;
+  background: #ffffff;
+}
+
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-shell-nav a.active::before {
+  top: 4px;
+  bottom: 4px;
+}
+
+/* Hover state is quieter than active — no accent bar, soft background only. */
+.idt-app-console-layout .idt-app-shell-nav a:hover:not(.active),
+.idt-app-console-layout .idt-app-shell-nav a:focus-visible:not(.active) {
+  background: #131318;
+  color: #ffffff;
+}
+
+/* Account menu items: align the new icon to the leading edge */
+.idt-app-sidebar-account-menu a,
+.idt-app-sidebar-account-menu button {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.idt-app-sidebar-account-menu a > svg,
+.idt-app-sidebar-account-menu button > svg {
+  color: var(--app-dim);
+  flex: 0 0 auto;
+}
+
+.idt-app-sidebar-account-menu a:hover > svg,
+.idt-app-sidebar-account-menu button:hover > svg,
+.idt-app-sidebar-account-menu a:focus-visible > svg,
+.idt-app-sidebar-account-menu button:focus-visible > svg {
+  color: #ffffff;
+}
+
+/* Nav icons take real lucide sizing; keep their box uniform. */
+.idt-app-console-layout .idt-app-nav-icon > svg,
+.idt-app-console-layout .idt-app-quick-find-icon > svg {
+  display: block;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -22342,11 +22342,12 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   height: 0.4rem;
 }
 
-/* === Sidebar polish: drag handle, active accent, active-fill, refined hover === */
-
-.idt-app-sidebar {
-  position: relative;
-}
+/* === Sidebar polish: drag handle, active accent, active-fill, refined hover ===
+ * Note: the base shell already sets `.idt-app-sidebar { position: sticky }`,
+ * which is a positioning context for absolutely-positioned descendants. We
+ * intentionally do NOT override `position` here so the rail keeps tracking
+ * with page scroll. The resize handle's `position: absolute` resolves against
+ * the sticky sidebar without further changes. */
 
 .idt-app-sidebar-resize-handle {
   position: absolute;


### PR DESCRIPTION
Polish pass on the workspace overview sidebar after seeing the live shell. Addresses three concrete bugs and one ask from product:

1. **Hand-drawn nav icons → lucide-react.** Every nav, menu, and chrome icon was a path I sketched by hand and looked like it. Replaced with semantically matched Lucide icons (LayoutDashboard, FolderKanban, Shield, BarChart3, Users, Settings, Search, ChevronDown/Up, PanelLeftClose/Open, LogOut, HelpCircle). Adds ~4 KB gzipped for the tree-shaken subset.

2. **Drag-to-resize the sidebar.** A 6 px handle on the right edge (\`cursor: col-resize\`) drives a pointermove loop that writes \`--idt-sidebar-width\` on the layout grid live. Width clamped to [196 px, 360 px] and persisted under \`idt:sidebar:width\`. Dragging below 140 px snaps to collapsed (60 px) — matches the Cursor / VS Code / Linear gesture. Double-click the handle resets to default 248 px. Hidden at ≤ 960 px (where the rail is a top bar).

3. **Fix the white box on active nav in collapsed mode.** The base shell CSS had a higher-specificity rule scoped to \`html[data-theme='light']\` that painted \`.idt-app-shell-nav a.active\` pure white, beating my override. The active item rendered as a white square with an invisible white icon. Stripped the offending declarations from the light-theme rule (it now only resets text-decoration) and gave the polish block ownership of the active state: dark fill plus a 2 px white accent bar on the leading edge so the active page is obvious without depending on the background.

While in the file:

- Hover state separated from active (no accent bar on hover, just a soft background).
- Account-menu items lead with their action icon for visual rhythm.
- Help link in the avatar menu repointed at \`github.com/identrail/identrail/issues\` since \`docs.identrail.com\` doesn't exist yet — stops the menu from lying.

## Validation

- \`npm run test:ci --prefix web\` → 13 files, 161 tests, all green
- \`npm run build --prefix web\` → builds cleanly, 41 prerendered routes; bundle 368 KB / gzip 92 KB (up from 361 / 88 KB, entirely from lucide-react)
- \`npx tsc --noEmit\` clean
- Manually previewed at 1440×900: expanded view shows all Lucide icons, active item has dark fill + white accent bar; collapsed view shows icon-only rail with no white-box artifact; resize handle present on right edge with \`col-resize\` cursor.

## Risk / impact

- UI-only change. No API contracts touched.
- New dependency: \`lucide-react\` (MIT, well-maintained, tree-shakeable, the de-facto standard used by Linear/Vercel/Cal.com).
- Sidebar width preference added under a new localStorage key. Old \`idt:sidebar:collapsed\` key still honored.

## AI-Assisted disclosure

- **AI-assisted:** yes
- **Tools used:** Claude Code (Opus 4.7)
- **Where used:** \`web/src/productShell.tsx\`, \`web/src/styles.css\`, \`web/package.json\`, \`web/package-lock.json\`
- **Human verification performed:** \`npm run test:ci\`, \`npx tsc --noEmit\`, \`npm run build\` all green; previewed sidebar visually in dev server at 1440×900 (expanded + collapsed); inspected resize handle bounding box and cursor in the DOM; reviewed all changed regions of \`productShell.tsx\` end-to-end.

## Test plan

- [ ] Hover the right edge of the sidebar — cursor changes to col-resize. Drag right/left and the sidebar resizes live, clamped between 196 px and 360 px.
- [ ] Drag below ~140 px — sidebar snaps to collapsed (60 px). Drag back out — expands to 196 px.
- [ ] Double-click the handle — resets to 248 px default.
- [ ] Navigate to /overview, /projects, /findings, /settings — each active item shows a dark fill with a 2 px white accent bar at the leading edge (no white box).
- [ ] Collapse via the button or ⌘B / Ctrl+B — collapsed rail shows clean Lucide icons, hover still highlights cleanly, the active item's accent bar is still visible.
- [ ] Open the avatar menu — items show inline action icons (gear / help / log out).
- [ ] Click "Help & feedback" — opens \`github.com/identrail/identrail/issues\` in a new tab.
- [ ] At ≤ 960 px viewport — drag handle is hidden, rail collapses to a horizontal top bar, persisted collapsed pref is ignored.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced hand‑drawn sidebar icons with `lucide-react`, added drag‑to‑resize for the sidebar, and fixed the collapsed active‑nav styling. Improves clarity and gives users quick control of sidebar width.

- **New Features**
  - Swapped all nav and menu icons to `lucide-react` for consistent, recognizable iconography (adds ~4 KB gzip).
  - Sidebar is resizable via a 6px handle; width clamps to 196–360px, is saved to `idt:sidebar:width`, dragging below ~140px snaps to collapsed (60px), double‑click resets to 248px; handle is hidden at 960px and below.

- **Bug Fixes**
  - Fixed white-box artifact on the active item in collapsed mode by removing the conflicting light-theme rule; active now uses a dark fill with a 2px white accent bar.
  - Stability: restored sticky positioning for the sidebar and hardened drag cleanup (pointer capture + `lostpointercapture`) to prevent stuck page cursor/selection after off‑window releases.
  - Small polish: separate hover from active states, add leading icons in the account menu, and update “Help & feedback” to point to GitHub issues.

<sup>Written for commit 855b13d7575852ad0a7703fd6fe7655bb60fd7ac. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1275?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

