### PR TITLE
Wire GitHub intelligence into the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Wired GitHub repository intelligence into the product app. Project source
+  onboarding now surfaces selected-repository posture checks, and repository
+  findings now show risk-graph summaries, top finding scores, and on-demand
+  remediation previews.
 - Added repository finding lifecycle intelligence. Repo findings now carry
   stable lifecycle keys, first/last seen timestamps, fixed/reopened/suppressed
   state, owner and detector metadata, list filters for lifecycle, ownership,

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -30,6 +30,85 @@ function authConfig(manualMode = false, workOSLoginEnabled = true) {
   });
 }
 
+function repoRiskGraphPayload() {
+  return {
+    repository: 'owner/repo',
+    nodes: [
+      { id: 'repo:owner/repo', kind: 'repository', label: 'owner/repo', repository: 'owner/repo', evidence_state: 'known' },
+      { id: 'finding:repo-f1', kind: 'finding', label: 'Potential AWS access key exposed', repository: 'owner/repo', evidence_state: 'known' },
+      { id: 'token:aws_access_key', kind: 'token', label: 'AWS access key', repository: 'owner/repo', evidence_state: 'known' },
+      { id: 'role:unknown', kind: 'cloud_role', label: 'Unknown cloud role', repository: 'owner/repo', evidence_state: 'unknown' }
+    ],
+    edges: [
+      { id: 'repo-f1-exposes-token', kind: 'finding_exposes_token', from_node_id: 'finding:repo-f1', to_node_id: 'token:aws_access_key', evidence_state: 'known' },
+      { id: 'token-reaches-role', kind: 'token_reaches_role', from_node_id: 'token:aws_access_key', to_node_id: 'role:unknown', evidence_state: 'unknown' },
+      { id: 'repo-contains-finding', kind: 'repository_contains_finding', from_node_id: 'repo:owner/repo', to_node_id: 'finding:repo-f1', evidence_state: 'known' }
+    ],
+    scores: [
+      {
+        finding_id: 'repo-f1',
+        finding_node_id: 'finding:repo-f1',
+        score: 91,
+        severity: 'high',
+        confidence: 0.98,
+        factors: {
+          severity: 80,
+          confidence: 98,
+          exploitability: 90,
+          privilege: 70,
+          exposure: 95,
+          environment_criticality: 80,
+          freshness: 88
+        },
+        unknowns: ['cloud_role']
+      }
+    ],
+    summary: {
+      finding_count: 1,
+      node_count: 4,
+      edge_count: 3,
+      unknown_node_count: 1,
+      unknown_edge_count: 1,
+      high_risk_findings: 1,
+      critical_findings: 0
+    }
+  };
+}
+
+function repoRemediationPreviewPayload() {
+  return {
+    finding: {
+      id: 'repo-f1',
+      scan_id: 'repo-scan-1',
+      type: 'secret_exposure',
+      severity: 'high',
+      title: 'Potential AWS access key exposed in commit history',
+      human_summary: 'A line added in commit history appears to contain an AWS access key identifier.',
+      repository: 'owner/repo',
+      file_path: 'config/app.env',
+      line_number: 7,
+      remediation: 'Rotate the key and move the credential to a secret manager.',
+      created_at: '2026-01-01T00:00:00Z'
+    },
+    remediation: {
+      detector: 'aws_access_key_id',
+      summary: 'Rotate exposed AWS credential',
+      risk_summary: 'The credential may still authorize access outside the repository.',
+      steps: ['Revoke the leaked access key', 'Move workload auth to short-lived credentials'],
+      safety_notes: ['Do not copy secret material into the fix branch.'],
+      validation: ['Confirm the key is disabled in IAM', 'Rescan the repository after rotation'],
+      secret_rotation: true,
+      publishable: false,
+      publish_blocked_reason: 'Secret rotation required',
+      evidence: {
+        finding_id: 'repo-f1',
+        scan_id: 'repo-scan-1',
+        repository: 'owner/repo'
+      }
+    }
+  };
+}
+
 function currentMePayload(tenantID = 'default', workspaceID = 'default', role = 'owner') {
   return {
     me: {
@@ -832,6 +911,12 @@ describe('App', () => {
           ]
         });
       }
+      if (url.includes('/v1/repo-risk-graph')) {
+        return okJSON(repoRiskGraphPayload());
+      }
+      if (url.includes('/v1/repo-findings/repo-f1/remediation/preview')) {
+        return okJSON(repoRemediationPreviewPayload());
+      }
       if (url.includes('/v1/repo-findings')) {
         return okJSON({
           items: [
@@ -865,14 +950,22 @@ describe('App', () => {
 
     expect(await screen.findByRole('heading', { level: 2, name: /Findings/i })).toBeInTheDocument();
     expect(await screen.findByText(/Review repository findings and jump directly to the exact GitHub line/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Risk graph/i)).toBeInTheDocument();
+    expect(await screen.findByText(/High-risk findings/i)).toBeInTheDocument();
+    expect(await screen.findByText('91')).toBeInTheDocument();
     expect(await screen.findByText(/Finding trend/i)).toBeInTheDocument();
     expect(await screen.findByText(/Critical 0 \/ High 1 \/ Medium 0 \/ Low 0 \/ Info 0/i)).toBeInTheDocument();
-    expect(await screen.findByText(/Risk/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Risk \(high/i)).toBeInTheDocument();
 
     const openInGitHub = await screen.findByRole('link', { name: /Open in GitHub/i });
     expect(openInGitHub).toHaveAttribute('href', 'https://github.com/owner/repo/blob/abc123/config/app.env#L7');
     expect((await screen.findAllByText('config/app.env:7')).length).toBeGreaterThan(0);
     expect((await screen.findAllByText('owner/repo')).length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole('button', { name: /Preview remediation plan/i }));
+    expect(await screen.findByText(/Rotate exposed AWS credential/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Revoke the leaked access key/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Secret rotation required/i)).toBeInTheDocument();
   });
 
   it('allows suppressed repository finding assignee edits without a new suppression reason', async () => {
@@ -919,6 +1012,9 @@ describe('App', () => {
       }
       if (url.includes('/v1/repo-findings/trends')) {
         return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/repo-risk-graph')) {
+        return okJSON(repoRiskGraphPayload());
       }
       if (url.includes('/v1/repo-findings')) {
         return okJSON({

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -165,6 +165,62 @@ export type RepoFindingRemediationPreview = {
   fix_pr_plan?: FixPRPlan;
 };
 
+export type RepoRiskGraphNode = {
+  id: string;
+  kind: string;
+  label: string;
+  repository?: string;
+  evidence_state: 'known' | 'unknown';
+  evidence?: Record<string, unknown>;
+};
+
+export type RepoRiskGraphEdge = {
+  id: string;
+  kind: string;
+  from_node_id: string;
+  to_node_id: string;
+  evidence_state: 'known' | 'unknown';
+  evidence?: Record<string, unknown>;
+};
+
+export type RepoRiskGraphScoreFactors = {
+  severity: number;
+  confidence: number;
+  exploitability: number;
+  privilege: number;
+  exposure: number;
+  environment_criticality: number;
+  freshness: number;
+};
+
+export type RepoRiskGraphFindingScore = {
+  finding_id: string;
+  finding_node_id: string;
+  score: number;
+  severity: string;
+  confidence: number;
+  factors: RepoRiskGraphScoreFactors;
+  unknowns: string[];
+};
+
+export type RepoRiskGraphSummary = {
+  finding_count: number;
+  node_count: number;
+  edge_count: number;
+  unknown_node_count: number;
+  unknown_edge_count: number;
+  high_risk_findings: number;
+  critical_findings: number;
+};
+
+export type RepoRiskGraph = {
+  repository: string;
+  nodes: RepoRiskGraphNode[];
+  edges: RepoRiskGraphEdge[];
+  scores: RepoRiskGraphFindingScore[];
+  summary: RepoRiskGraphSummary;
+};
+
 export type ScanRecord = {
   id: string;
   provider: string;
@@ -785,6 +841,37 @@ export type GitHubRepositoryListResponse = {
   repositories: GitHubRepositoryStatus[];
 };
 
+export type GitHubRepositoryPostureState = 'secure' | 'insecure' | 'unavailable' | 'permission_limited';
+
+export type GitHubRepositoryPostureCheck = {
+  id: string;
+  category: string;
+  state: GitHubRepositoryPostureState;
+  reason?: string;
+  summary: string;
+  evidence?: Record<string, unknown>;
+};
+
+export type GitHubRateLimitState = {
+  limit?: number;
+  remaining?: number;
+  reset_at?: string;
+};
+
+export type GitHubRepositoryPosture = {
+  repository: string;
+  installation_id?: number;
+  collected_at: string;
+  checks: GitHubRepositoryPostureCheck[];
+  rate_limit?: GitHubRateLimitState;
+};
+
+export type GitHubRepositoryPostureResponse = {
+  connector_id: string;
+  provider: string;
+  posture: GitHubRepositoryPosture;
+};
+
 export type GitHubConnectionCompleteRequest = {
   state: string;
   installation_id: number;
@@ -1301,6 +1388,18 @@ export const apiClient = {
       auth
     );
   },
+  getRepoRiskGraph(
+    filters: {
+      repo_scan_id?: string;
+      repository?: string;
+      default_branch?: string;
+      severity?: string;
+      type?: string;
+    } = {},
+    auth?: RequestAuthContext
+  ) {
+    return request<RepoRiskGraph>(`/v1/repo-risk-graph${buildQuery(filters)}`, auth);
+  },
   previewRepoFindingRemediation(
     findingID: string,
     payload: RepoFindingRemediationPreviewRequest = {},
@@ -1430,6 +1529,22 @@ export const apiClient = {
   listGitHubConnectorRepositories(connectorID: string, workspaceID: string, projectID: string, auth?: RequestAuthContext) {
     return request<GitHubRepositoryListResponse>(
       `/v1/connectors/github/${encodeURIComponent(connectorID)}/repos${buildQuery({ workspace_id: workspaceID, project_id: projectID })}`,
+      auth
+    );
+  },
+  getGitHubConnectorRepositoryPosture(
+    connectorID: string,
+    workspaceID: string,
+    projectID: string,
+    repository: string,
+    auth?: RequestAuthContext
+  ) {
+    return request<GitHubRepositoryPostureResponse>(
+      `/v1/connectors/github/${encodeURIComponent(connectorID)}/posture${buildQuery({
+        workspace_id: workspaceID,
+        project_id: projectID,
+        repository
+      })}`,
       auth
     );
   },

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -172,6 +172,34 @@ async function renderProjectDetail(
     runRepoScan.mockResolvedValue({ repo_scan: queuedRepoScan });
   }
   const cancelRepoScan = vi.spyOn(api.apiClient, 'cancelRepoScan').mockResolvedValue({ repo_scan: canceledRepoScan });
+  const getGitHubConnectorRepositoryPosture = vi
+    .spyOn(api.apiClient, 'getGitHubConnectorRepositoryPosture')
+    .mockResolvedValue({
+      connector_id: 'github-app',
+      provider: 'github_app',
+      posture: {
+        repository: 'identrail/identrail',
+        installation_id: 12345,
+        collected_at: '2026-05-17T10:02:00Z',
+        checks: [
+          {
+            id: 'default_branch_protection',
+            category: 'branch_protection',
+            state: 'secure',
+            reason: 'protection_enforced',
+            summary: 'Default branch requires pull request reviews.'
+          },
+          {
+            id: 'actions_permissions',
+            category: 'actions',
+            state: 'insecure',
+            reason: 'write_workflow_token',
+            summary: 'Actions token can write by default.'
+          }
+        ],
+        rate_limit: { limit: 5000, remaining: 4990 }
+      }
+    });
 
   const { ProductProjectDetailPage } = await import('./productShell');
   function ProjectDetailHarness() {
@@ -196,7 +224,7 @@ async function renderProjectDetail(
     </MemoryRouter>
   );
 
-  return { getGitHubConnectorStatus, listRepoScans, runRepoScan, cancelRepoScan };
+  return { getGitHubConnectorStatus, getGitHubConnectorRepositoryPosture, listRepoScans, runRepoScan, cancelRepoScan };
 }
 
 describe('ProductAppIndexRedirect', () => {
@@ -347,6 +375,20 @@ describe('ProductProjectDetailPage', () => {
     expect(getGitHubConnectorStatus).toHaveBeenCalledWith(
       'workspace-a',
       'project-1',
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+  });
+
+  it('loads GitHub repository posture for the selected app repository', async () => {
+    const { getGitHubConnectorRepositoryPosture } = await renderProjectDetail(true);
+
+    expect(await screen.findByText('Repository posture')).toBeInTheDocument();
+    expect(await screen.findByText(/Actions token can write by default/i)).toBeInTheDocument();
+    expect(getGitHubConnectorRepositoryPosture).toHaveBeenCalledWith(
+      'github-app',
+      'workspace-a',
+      'project-1',
+      'identrail/identrail',
       expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
     );
   });

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -14,11 +14,16 @@ import {
   type FindingLifecycleStatus,
   type GitHubConnectorStartResponse,
   type GitHubConnectionStatus,
+  type GitHubRepositoryPosture,
+  type GitHubRepositoryPostureCheck,
   type KubernetesConnectorStartResponse,
   type KubernetesConnectionStatus,
   type ProjectRecord,
+  type RepoFindingRemediationPreview,
   type RepoFindingsSummary,
   type RepoFindingLifecycleStatus,
+  type RepoRiskGraph,
+  type RepoRiskGraphFindingScore,
   type RepoScanRequest,
   type RepoScanRecord,
   type TrendPoint,
@@ -481,6 +486,35 @@ function repoScanStatusTone(status: string): 'success' | 'warning' | 'error' | '
     return 'warning';
   }
   return 'neutral';
+}
+
+function githubPostureStateTone(state: GitHubRepositoryPostureCheck['state']): 'success' | 'warning' | 'error' | 'neutral' {
+  if (state === 'secure') {
+    return 'success';
+  }
+  if (state === 'insecure') {
+    return 'error';
+  }
+  if (state === 'permission_limited') {
+    return 'warning';
+  }
+  return 'neutral';
+}
+
+function countGitHubPostureChecks(
+  posture: GitHubRepositoryPosture | null,
+  state: GitHubRepositoryPostureCheck['state']
+): number {
+  return posture?.checks.filter((check) => check.state === state).length ?? 0;
+}
+
+function sortRepoRiskGraphScores(scores: RepoRiskGraphFindingScore[]): RepoRiskGraphFindingScore[] {
+  return [...scores].sort((left, right) => {
+    if (right.score !== left.score) {
+      return right.score - left.score;
+    }
+    return severityRank(right.severity) - severityRank(left.severity);
+  });
 }
 
 function uniqueGitHubRepositories(repositories: string[]): string[] {
@@ -3357,6 +3391,7 @@ export function ProductProjectDetailPage() {
   const { features: backendFeatures, loading: backendFeaturesLoading } = useBackendFeatures();
   const refreshSequenceRef = useRef(0);
   const repoScanSubmitSequenceRef = useRef(0);
+  const githubPostureRequestRef = useRef(0);
   const sourceAvailability = useMemo<Record<SourceProvider, SourceAvailability>>(
     () => ({
       github: {
@@ -3413,6 +3448,9 @@ export function ProductProjectDetailPage() {
   const [repoScanSubmitting, setRepoScanSubmitting] = useState(false);
   const [repoScanCancelingID, setRepoScanCancelingID] = useState('');
   const [repoScanError, setRepoScanError] = useState('');
+  const [githubPosture, setGitHubPosture] = useState<GitHubRepositoryPosture | null>(null);
+  const [githubPostureLoading, setGitHubPostureLoading] = useState(false);
+  const [githubPostureError, setGitHubPostureError] = useState('');
   const [awsForm, setAWSForm] = useState({
     roleARN: '',
     externalID: '',
@@ -3467,6 +3505,10 @@ export function ProductProjectDetailPage() {
   const repoScanRepository = normalizeValue(repoScanForm.repository);
   const effectiveRepoScanRepository = repoScanRepository || githubSelectedRepositories[0] || '';
   const effectiveRepoScanRepositoryKey = canonicalGitHubRepositoryDisplay(effectiveRepoScanRepository).toLowerCase();
+  const githubPostureSecureCount = countGitHubPostureChecks(githubPosture, 'secure');
+  const githubPostureAttentionCount = countGitHubPostureChecks(githubPosture, 'insecure');
+  const githubPostureLimitedCount = countGitHubPostureChecks(githubPosture, 'permission_limited');
+  const githubPostureUnavailableCount = countGitHubPostureChecks(githubPosture, 'unavailable');
   const githubHasActiveRepoScan = githubRecentRepoScans.some((scan) => isActiveScanStatus(scan.status));
   const githubHasActiveSelectedRepoScan =
     effectiveRepoScanRepositoryKey !== '' &&
@@ -3654,9 +3696,13 @@ export function ProductProjectDetailPage() {
     setRepoScanForm({ repository: '', historyLimit: '', maxFindings: '' });
     setRecentRepoScans([]);
     repoScanSubmitSequenceRef.current += 1;
+    githubPostureRequestRef.current += 1;
     setRepoScanSubmitting(false);
     setRepoScanCancelingID('');
     setRepoScanError('');
+    setGitHubPosture(null);
+    setGitHubPostureLoading(false);
+    setGitHubPostureError('');
     setAWSCloudFormationStart(null);
     setAWSPermissionPreview([]);
     setAWSPreviewOpen(false);
@@ -3702,6 +3748,73 @@ export function ProductProjectDetailPage() {
       return { ...current, repository: githubSelectedRepositories[0] ?? current.repository };
     });
   }, [connections.github?.connected, githubSelectedRepositories, githubSelectedRepositoriesKey]);
+
+  useEffect(() => {
+    const connection = connections.github;
+    const repository = canonicalGitHubRepositoryDisplay(effectiveRepoScanRepository);
+    const requestID = githubPostureRequestRef.current + 1;
+    githubPostureRequestRef.current = requestID;
+
+    if (
+      !scope ||
+      !projectID ||
+      selectedSource !== 'github' ||
+      !connection?.connected ||
+      connection.provider !== 'github_app' ||
+      !connection.connector_id ||
+      !repository
+    ) {
+      setGitHubPosture(null);
+      setGitHubPostureLoading(false);
+      setGitHubPostureError('');
+      return undefined;
+    }
+
+    setGitHubPostureLoading(true);
+    setGitHubPostureError('');
+    setGitHubPosture(null);
+    void apiClient
+      .getGitHubConnectorRepositoryPosture(
+        connection.connector_id,
+        scope.workspaceID,
+        projectID,
+        repository,
+        buildProductAuthContext(scope)
+      )
+      .then((response) => {
+        if (githubPostureRequestRef.current !== requestID) {
+          return;
+        }
+        setGitHubPosture(response.posture);
+      })
+      .catch((error) => {
+        if (githubPostureRequestRef.current !== requestID) {
+          return;
+        }
+        setGitHubPosture(null);
+        setGitHubPostureError(error instanceof Error ? error.message : 'Unable to load GitHub repository posture.');
+      })
+      .finally(() => {
+        if (githubPostureRequestRef.current === requestID) {
+          setGitHubPostureLoading(false);
+        }
+      });
+
+    return () => {
+      if (githubPostureRequestRef.current === requestID) {
+        githubPostureRequestRef.current += 1;
+      }
+    };
+  }, [
+    connections.github?.connected,
+    connections.github?.connector_id,
+    connections.github?.provider,
+    effectiveRepoScanRepository,
+    projectID,
+    scope?.tenantID,
+    scope?.workspaceID,
+    selectedSource
+  ]);
 
   useEffect(() => {
     if (!scope || !githubHasActiveRepoScan) {
@@ -4824,6 +4937,46 @@ export function ProductProjectDetailPage() {
                   <span>Selected</span>
                 </article>
               ))}
+              {githubPostureLoading ? (
+                <article>
+                  <strong>{effectiveRepoScanRepository || 'Selected repository'}</strong>
+                  <span>Loading posture</span>
+                  <p>Collecting GitHub repository posture signals.</p>
+                </article>
+              ) : null}
+              {githubPostureError ? (
+                <p role="alert" className="idt-app-alert idt-app-alert-error">
+                  {githubPostureError}
+                </p>
+              ) : null}
+              {githubPosture ? (
+                <>
+                  <article>
+                    <strong>Repository posture</strong>
+                    <span>{formatConnectionTime(githubPosture.collected_at)}</span>
+                    <p>
+                      {githubPostureSecureCount} secure · {githubPostureAttentionCount} attention ·{' '}
+                      {githubPostureLimitedCount} permission limited · {githubPostureUnavailableCount} unavailable
+                    </p>
+                    {githubPosture.rate_limit?.remaining !== undefined ? (
+                      <small>
+                        GitHub API remaining {githubPosture.rate_limit.remaining}
+                        {githubPosture.rate_limit.limit ? ` of ${githubPosture.rate_limit.limit}` : ''}
+                      </small>
+                    ) : null}
+                  </article>
+                  {githubPosture.checks.slice(0, 6).map((check) => (
+                    <article key={check.id}>
+                      <strong>{formatTokenLabel(check.category || check.id)}</strong>
+                      <span className={`idt-source-status-pill is-${githubPostureStateTone(check.state)}`}>
+                        {formatTokenLabel(check.state)}
+                      </span>
+                      <p>{check.summary}</p>
+                      {check.reason ? <small>{formatTokenLabel(check.reason)}</small> : null}
+                    </article>
+                  ))}
+                </>
+              ) : null}
             </div>
           ) : null}
         </div>
@@ -5024,6 +5177,8 @@ export function ProductFindingsPage() {
   const [repoFindings, setRepoFindings] = useState<ApiFinding[]>([]);
   const [repoFindingSummary, setRepoFindingSummary] = useState<RepoFindingsSummary | null>(null);
   const [trendPoints, setTrendPoints] = useState<TrendPoint[]>([]);
+  const [repoRiskGraph, setRepoRiskGraph] = useState<RepoRiskGraph | null>(null);
+  const [riskGraphError, setRiskGraphError] = useState('');
   const [repoScanFilter, setRepoScanFilter] = useState('');
   const [severityFilter, setSeverityFilter] = useState<(typeof REPO_FINDING_SEVERITY_FILTERS)[number]>('all');
   const [typeFilter, setTypeFilter] = useState<(typeof REPO_FINDING_TYPE_FILTERS)[number]>('all');
@@ -5039,9 +5194,14 @@ export function ProductFindingsPage() {
   const [workflowLoading, setWorkflowLoading] = useState(false);
   const [workflowSuccess, setWorkflowSuccess] = useState('');
   const [workflowError, setWorkflowError] = useState('');
+  const [remediationPreview, setRemediationPreview] = useState<RepoFindingRemediationPreview | null>(null);
+  const [remediationPreviewFindingKey, setRemediationPreviewFindingKey] = useState('');
+  const [remediationPreviewLoading, setRemediationPreviewLoading] = useState(false);
+  const [remediationPreviewError, setRemediationPreviewError] = useState('');
 
   const requestRef = useRef(0);
   const signalRequestRef = useRef(0);
+  const remediationPreviewRequestRef = useRef(0);
 
   const hasTriageAccess = Boolean(me?.role === 'owner' || me?.role === 'admin');
 
@@ -5079,6 +5239,19 @@ export function ProductFindingsPage() {
   const selectedFinding = useMemo(
     () => findRepoFindingBySelectionKey(filteredFindings, selectedFindingKey) ?? filteredFindings[0] ?? null,
     [filteredFindings, selectedFindingKey]
+  );
+
+  const topRiskGraphScores = useMemo(
+    () => {
+      if (filteredFindings.length === 0) {
+        return [];
+      }
+      const visibleFindingIDs = new Set(filteredFindings.map((finding) => finding.id));
+      return sortRepoRiskGraphScores(repoRiskGraph?.scores ?? [])
+        .filter((score) => visibleFindingIDs.has(score.finding_id))
+        .slice(0, 3);
+    },
+    [filteredFindings, repoRiskGraph]
   );
 
   const linkedFindingCount = useMemo(
@@ -5177,26 +5350,51 @@ export function ProductFindingsPage() {
     }
     setSignalError('');
     setTrendError('');
+    setRiskGraphError('');
     try {
       const auth = buildProductAuthContext(targetScope);
-      const trendResponse = await apiClient.getRepoFindingsTrends(
-        {
-          points: TREND_POINTS,
-          severity: severityFilter !== 'all' ? severityFilter : undefined,
-          type: typeFilter !== 'all' ? typeFilter : undefined
-        },
-        auth
-      );
+      const severity = severityFilter !== 'all' ? severityFilter : undefined;
+      const type = typeFilter !== 'all' ? typeFilter : undefined;
+      const repoScanID = normalizeValue(repoScanFilter) || undefined;
+      const [trendResult, riskGraphResult] = await Promise.allSettled([
+        apiClient.getRepoFindingsTrends(
+          {
+            points: TREND_POINTS,
+            severity,
+            type
+          },
+          auth
+        ),
+        apiClient.getRepoRiskGraph(
+          {
+            repo_scan_id: repoScanID,
+            severity,
+            type
+          },
+          auth
+        )
+      ]);
       if (requestID !== signalRequestRef.current) {
         return;
       }
-      setTrendPoints(trendResponse.items);
-    } catch (requestError) {
-      if (requestID !== signalRequestRef.current) {
-        return;
+      if (trendResult.status === 'fulfilled') {
+        setTrendPoints(trendResult.value.items);
+      } else {
+        setTrendPoints([]);
+        setTrendError(
+          trendResult.reason instanceof Error ? trendResult.reason.message : 'Failed to load finding trend metrics.'
+        );
       }
-      const message = requestError instanceof Error ? requestError.message : 'Failed to load finding trend metrics.';
-      setTrendError(message);
+      if (riskGraphResult.status === 'fulfilled') {
+        setRepoRiskGraph(riskGraphResult.value);
+      } else {
+        setRepoRiskGraph(null);
+        setRiskGraphError(
+          riskGraphResult.reason instanceof Error
+            ? riskGraphResult.reason.message
+            : 'Failed to load repository risk graph.'
+        );
+      }
     } finally {
       if (requestID === signalRequestRef.current) {
         setSignalsLoading(false);
@@ -5282,6 +5480,42 @@ export function ProductFindingsPage() {
     }
   };
 
+  const handleLoadRemediationPreview = async () => {
+    if (!scope || !selectedFinding || remediationPreviewLoading) {
+      return;
+    }
+
+    const selectionKey = buildRepoFindingSelectionKey(selectedFinding);
+    const requestID = ++remediationPreviewRequestRef.current;
+    setRemediationPreviewLoading(true);
+    setRemediationPreviewError('');
+    setRemediationPreview(null);
+    setRemediationPreviewFindingKey(selectionKey);
+    try {
+      const preview = await apiClient.previewRepoFindingRemediation(
+        selectedFinding.id,
+        { repo_scan_id: selectedFinding.scan_id },
+        buildProductAuthContext(scope)
+      );
+      if (requestID !== remediationPreviewRequestRef.current) {
+        return;
+      }
+      setRemediationPreview(preview);
+    } catch (requestError) {
+      if (requestID !== remediationPreviewRequestRef.current) {
+        return;
+      }
+      setRemediationPreview(null);
+      setRemediationPreviewError(
+        requestError instanceof Error ? requestError.message : 'Failed to load remediation preview.'
+      );
+    } finally {
+      if (requestID === remediationPreviewRequestRef.current) {
+        setRemediationPreviewLoading(false);
+      }
+    }
+  };
+
   useEffect(() => {
     if (!scope) {
       setLoading(false);
@@ -5312,6 +5546,11 @@ export function ProductFindingsPage() {
       setWorkflowAssignee('');
       setWorkflowComment('');
       setWorkflowSuppressionExpiresAt('');
+      remediationPreviewRequestRef.current += 1;
+      setRemediationPreview(null);
+      setRemediationPreviewFindingKey('');
+      setRemediationPreviewLoading(false);
+      setRemediationPreviewError('');
       return;
     }
 
@@ -5321,6 +5560,11 @@ export function ProductFindingsPage() {
     setWorkflowSuppressionExpiresAt(
       selectedFinding.triage?.suppression_expires_at ? toLocalDateTimeInputValue(selectedFinding.triage.suppression_expires_at) : ''
     );
+    remediationPreviewRequestRef.current += 1;
+    setRemediationPreview(null);
+    setRemediationPreviewFindingKey('');
+    setRemediationPreviewLoading(false);
+    setRemediationPreviewError('');
   }, [
     selectedFinding?.id,
     selectedFinding?.scan_id,
@@ -5385,6 +5629,12 @@ export function ProductFindingsPage() {
   });
 
   const trendDisplayLoading = signalsLoading;
+  const riskGraphSummary = repoRiskGraph?.summary;
+  const riskGraphUnknownEvidenceCount =
+    (riskGraphSummary?.unknown_node_count ?? 0) + (riskGraphSummary?.unknown_edge_count ?? 0);
+  const selectedFindingPreviewKey = selectedFinding ? buildRepoFindingSelectionKey(selectedFinding) : '';
+  const activeRemediationPreview =
+    remediationPreview && remediationPreviewFindingKey === selectedFindingPreviewKey ? remediationPreview : null;
 
   return (
     <section className="idt-app-panel idt-repo-findings-page">
@@ -5422,6 +5672,7 @@ export function ProductFindingsPage() {
       {error ? <div className="idt-app-alert idt-app-alert-error">{error}</div> : null}
       {signalError ? <div className="idt-app-alert idt-app-alert-error">{signalError}</div> : null}
       {trendError ? <div className="idt-app-alert idt-app-alert-error">{trendError}</div> : null}
+      {riskGraphError ? <div className="idt-app-alert idt-app-alert-error">{riskGraphError}</div> : null}
 
       <div className="idt-repo-finding-stats" aria-label="Repository finding summary">
         <article className="idt-repo-finding-stat">
@@ -5476,6 +5727,60 @@ export function ProductFindingsPage() {
           <span>Completed repo scans</span>
           <strong>{activeScanCount}</strong>
         </article>
+      </div>
+
+      <div className="idt-repo-finding-trend" aria-label="Repository risk graph summary">
+        <div className="idt-repo-finding-trend-head">
+          <h3>Risk graph</h3>
+          {trendDisplayLoading ? <span className="idt-app-alert idt-app-alert-success">Loading graph</span> : null}
+          <span className="idt-repo-finding-trend-subtitle">
+            {repoRiskGraph
+              ? `${repoRiskGraph.nodes.length} nodes · ${repoRiskGraph.edges.length} paths · ${canonicalGitHubRepositoryDisplay(repoRiskGraph.repository) || repoRiskGraph.repository || 'repository scope'}`
+              : 'No graph loaded yet'}
+          </span>
+        </div>
+        {riskGraphSummary ? (
+          <div className="idt-repo-finding-trend-rows">
+            <article className="idt-repo-finding-trend-row">
+              <div className="idt-repo-finding-trend-meta">
+                <span>High-risk findings</span>
+                <strong>{riskGraphSummary.high_risk_findings}</strong>
+              </div>
+              <p>
+                {riskGraphSummary.critical_findings} critical · {riskGraphUnknownEvidenceCount} unknown evidence gaps
+              </p>
+            </article>
+            {topRiskGraphScores.length > 0 ? (
+              topRiskGraphScores.map((score) => (
+                <article key={score.finding_id} className="idt-repo-finding-trend-row">
+                  <div className="idt-repo-finding-trend-meta">
+                    <span>{score.finding_id}</span>
+                    <strong>{Math.round(score.score)}</strong>
+                  </div>
+                  <p>
+                    {formatTokenLabel(score.severity)} · confidence {formatConfidenceScore(score.confidence)}
+                    {(score.unknowns ?? []).length > 0
+                      ? ` · unknown ${(score.unknowns ?? []).map(formatTokenLabel).join(', ')}`
+                      : ''}
+                  </p>
+                </article>
+              ))
+            ) : (
+              <article className="idt-repo-finding-trend-row">
+                <div className="idt-repo-finding-trend-meta">
+                  <span>No scored findings</span>
+                  <strong>{riskGraphSummary.finding_count}</strong>
+                </div>
+                <p>Risk scores will appear after graph evidence is available for repository findings.</p>
+              </article>
+            )}
+          </div>
+        ) : (
+          <AppShellEmptyState
+            title="Risk graph unavailable"
+            body="Run a repository exposure scan so machine-identity paths and finding risk scores can appear here."
+          />
+        )}
       </div>
 
       <div className="idt-repo-finding-trend">
@@ -5746,6 +6051,56 @@ export function ProductFindingsPage() {
               <div className="idt-repo-finding-remediation">
                 <h4>Remediation</h4>
                 <p>{selectedFinding.remediation}</p>
+                <button
+                  className="idt-btn idt-btn-ghost"
+                  type="button"
+                  onClick={() => void handleLoadRemediationPreview()}
+                  disabled={remediationPreviewLoading}
+                >
+                  {remediationPreviewLoading ? 'Loading remediation...' : 'Preview remediation plan'}
+                </button>
+                {remediationPreviewError ? (
+                  <div className="idt-app-alert idt-app-alert-error">{remediationPreviewError}</div>
+                ) : null}
+                {activeRemediationPreview ? (
+                  <div className="idt-repo-remediation-preview">
+                    <h5>{activeRemediationPreview.remediation.summary}</h5>
+                    <p>{activeRemediationPreview.remediation.risk_summary}</p>
+                    <div className="idt-repo-remediation-preview-grid">
+                      <div>
+                        <strong>Steps</strong>
+                        <ul>
+                          {(activeRemediationPreview.remediation.steps ?? []).map((step) => (
+                            <li key={step}>{step}</li>
+                          ))}
+                        </ul>
+                      </div>
+                      <div>
+                        <strong>Validation</strong>
+                        <ul>
+                          {(activeRemediationPreview.remediation.validation ?? []).map((item) => (
+                            <li key={item}>{item}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    </div>
+                    {(activeRemediationPreview.remediation.safety_notes ?? []).length > 0 ? (
+                      <div>
+                        <strong>Safety notes</strong>
+                        <ul>
+                          {(activeRemediationPreview.remediation.safety_notes ?? []).map((note) => (
+                            <li key={note}>{note}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    ) : null}
+                    <p>
+                      {activeRemediationPreview.remediation.publishable
+                        ? 'A deterministic fix branch can be prepared for this finding.'
+                        : activeRemediationPreview.remediation.publish_blocked_reason || 'Manual remediation is required.'}
+                    </p>
+                  </div>
+                ) : null}
               </div>
 
               <div className="idt-repo-finding-triage-form">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5125,6 +5125,38 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   gap: 0.35rem;
 }
 
+.idt-repo-remediation-preview {
+  display: grid;
+  gap: 0.55rem;
+  padding-top: 0.35rem;
+}
+
+.idt-repo-remediation-preview h5 {
+  margin: 0;
+  color: #f4f8ff;
+  font-size: 0.98rem;
+}
+
+.idt-repo-remediation-preview-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.idt-repo-remediation-preview strong {
+  color: #dce9ff;
+}
+
+.idt-repo-remediation-preview ul {
+  margin: 0.35rem 0 0;
+  padding-left: 1.05rem;
+}
+
+.idt-repo-remediation-preview li {
+  color: #ccdaef;
+  margin-bottom: 0.22rem;
+}
+
 @media (max-width: 960px) {
   .idt-repo-findings-header,
   .idt-repo-finding-row-top {
@@ -5134,7 +5166,8 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   .idt-repo-finding-stats,
   .idt-repo-finding-filters,
   .idt-repo-finding-layout,
-  .idt-repo-finding-facts {
+  .idt-repo-finding-facts,
+  .idt-repo-remediation-preview-grid {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
Fixes #1276

## What changed
- Added typed web API client support for repository risk graphs and GitHub App repository posture.
- Wired project source onboarding to collect and display selected-repository GitHub posture checks for GitHub App connections.
- Wired repository findings to display a risk-graph summary, top scored findings, and detector-specific remediation previews on demand.
- Added focused tests for the app surfaces and updated the changelog.

## Why
The backend already exposes richer GitHub repository intelligence, but the app did not make those signals visible. This lets users inspect posture, risk graph context, and remediation guidance from the same app flows where they queue scans and triage findings.

## Impact and risk
- User-facing app behavior changes only; no backend scanner or detector semantics changed.
- New intelligence calls are non-blocking. Findings, trends, and source onboarding still render if posture, graph, or preview calls fail.
- GitHub posture is only requested for GitHub App connections with a selected repository and connector ID.

## Validation
- [x] `git diff --check`
- [x] `npm run test --prefix web -- --run App.test.tsx productShell.test.tsx` (71 tests passed)
- [x] `npm run test:ci --prefix web` (160 tests passed)
- [x] `npm run build --prefix web`
- [x] `npm audit --prefix web --omit=dev --audit-level=moderate` (0 production vulnerabilities)
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go test ./... -coverprofile=coverage.out` and `go tool cover -func=coverage.out` (total 80.2%)
- [x] Vite dev-server smoke: `/app/tenant-a/workspace-a/findings` returned the app shell HTML from `127.0.0.1:5174`

## AI-assisted
- AI-assisted: yes
- Tools used: Codex
- Where used: web API client, product shell UI, tests, changelog, validation workflow
- Human verification performed: reviewed the scoped diff, ran the validation commands above, confirmed the branch is based on `dev`, and signed the commit with DCO.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires GitHub intelligence into the app so users can see repository posture, risk graph context, and remediation guidance directly in onboarding and findings flows. Calls are non‑blocking, so existing pages render even if intelligence requests fail.

- **New Features**
  - Added typed web API client for repository risk graph and GitHub App repository posture (scoped to a selected repository and connector ID).
  - Project source onboarding shows posture checks for the selected repository (GitHub App only), including check counts and GitHub rate‑limit details.
  - Findings page adds a Risk graph section (nodes/edges, high/critical counts), shows top scored findings, and supports on‑demand remediation previews with steps, validation, and safety notes.

<sup>Written for commit 3b0dae4ee5be71b3430c9d476572efd7a9b8eb95. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1277?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

