### PR TITLE
Improve CLI install and repository scan UX

### DIFF
--- a/.github/workflows/publish-container-images.yml
+++ b/.github/workflows/publish-container-images.yml
@@ -142,6 +142,20 @@ jobs:
             .
 
           docker buildx build \
+            --platform "${backend_platforms}" \
+            --push \
+            "${common_labels[@]}" \
+            --label "org.opencontainers.image.title=Identrail CLI" \
+            --label "org.opencontainers.image.description=Identrail command-line scanner for machine identity and repository exposure checks" \
+            -t "${base}-cli:${channel_tag}" \
+            -t "${base}-cli:${sha_tag}" \
+            -t "${docker_base}-cli:${channel_tag}" \
+            -t "${docker_base}-cli:${sha_tag}" \
+            -f deploy/docker/Dockerfile.backend \
+            --build-arg TARGET=cli \
+            .
+
+          docker buildx build \
             --platform linux/amd64,linux/arm64 \
             --push \
             "${common_labels[@]}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -388,6 +388,7 @@ jobs:
           build_server
           build_and_push "worker" "Identrail Worker" "${backend_platforms}" -f deploy/docker/Dockerfile.backend --build-arg TARGET=worker .
           build_and_push "agent" "Identrail Agent" "${backend_platforms}" -f deploy/docker/Dockerfile.backend --build-arg TARGET=identrail-agent .
+          build_and_push "cli" "Identrail CLI" "${backend_platforms}" -f deploy/docker/Dockerfile.backend --build-arg TARGET=cli .
           build_and_push "web" "Identrail Web" "linux/amd64,linux/arm64" \
             -f deploy/docker/Dockerfile.web \
             --build-arg "VITE_IDENTRAIL_API_URL=${web_api_url}" \

--- a/.github/workflows/supply-chain-trust.yml
+++ b/.github/workflows/supply-chain-trust.yml
@@ -101,7 +101,7 @@ jobs:
           owner="$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
           tag="${{ needs.prepare.outputs.tag }}"
 
-          for name in api worker web; do
+          for name in api worker cli web; do
             ref="ghcr.io/${owner}/identrail-${name}:${tag}"
             if docker buildx imagetools inspect "${ref}" >/dev/null 2>&1; then
               syft "${ref}" -o cyclonedx-json="dist/identrail-${name}-${tag}.image.sbom.cdx.json"
@@ -132,7 +132,7 @@ jobs:
           owner="$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
           tag="${{ needs.prepare.outputs.tag }}"
 
-          for name in api worker web; do
+          for name in api worker cli web; do
             ref="ghcr.io/${owner}/identrail-${name}:${tag}"
             if docker buildx imagetools inspect "${ref}" >/dev/null 2>&1; then
               cosign sign --yes "${ref}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
   onboarding now surfaces selected-repository posture checks, and repository
   findings now show risk-graph summaries, top finding scores, and on-demand
   remediation previews.
+- Added first-time CLI install and repository scan ergonomics. `identrail scan
+  <owner/repo>` now runs the repository exposure scanner while `identrail scan`
+  without arguments keeps the existing provider scan behavior, `repo-scan`
+  accepts positional targets and the `repo` alias, and release workflows now
+  publish a dedicated CLI container image with release documentation for
+  binaries, Docker, and Homebrew tap readiness.
 - Added repository finding lifecycle intelligence. Repo findings now carry
   stable lifecycle keys, first/last seen timestamps, fixed/reopened/suppressed
   state, owner and detector metadata, list filters for lifecycle, ownership,

--- a/README.md
+++ b/README.md
@@ -38,9 +38,28 @@ Use it when you run AWS and/or Kubernetes workloads and want identity risk visib
 
 ## 5-Minute Quickstart
 
-Prerequisites: Docker, Docker Compose, `curl`, `jq`.
+### Scan a GitHub repository
 
-Use the published Docker Hub images without building from source:
+Install Identrail from a release binary or Docker image, or build it from
+source, then run your first repository scan:
+
+```bash
+identrail scan owner/repo
+```
+
+See [Install Identrail](./docs/install.md) for each install path.
+
+Docker users can run the CLI without installing Go:
+
+```bash
+docker run --rm ghcr.io/identrail/identrail-cli:dev scan owner/repo
+```
+
+### Run the local dashboard
+
+Prerequisites: Docker, Docker Compose, and `curl`.
+
+Start the published local stack:
 
 ```bash
 mkdir identrail-docker && cd identrail-docker
@@ -51,30 +70,11 @@ curl http://localhost:8080/healthz
 
 Open `http://localhost:8081` for the web UI.
 
-To inspect the main API image directly:
-
-```bash
-docker pull docker.io/identrail/identrail:dev
-```
-
-`docker pull` by itself only downloads images into Docker; it does not create a
-project directory or the Compose file needed to start the full stack.
-
-The no-clone public quickstart keeps the API on `http://localhost:8080` and
-publishes only the web UI plus API onto your machine. Postgres stays inside the
-Docker network so an existing local database does not break the first run.
-
-For local development from a cloned repository:
+For source development from a cloned repository:
 
 ```bash
 make quickstart
 ```
-
-What this does:
-
-- Boots API, worker, web, and Postgres with local-safe defaults.
-- Triggers an initial scan.
-- Prints follow-up commands to inspect findings.
 
 Stop the stack:
 
@@ -87,10 +87,9 @@ For enterprise auth scope, tenant/workspace context, and decision audit verifica
 ## What Identrail Does
 
 - Discovers machine identities and trust relationships across AWS and Kubernetes.
-- Persists raw and normalized scan artifacts for explainability and auditability.
-- Produces deterministic findings with risk evidence and remediation context.
-- Provides API and web workflows for trends and diff analysis, plus CLI workflows for scans, findings, repo exposure scans, and authz rollback.
-- Supports optional repository exposure scanning (secrets and CI/IaC risk) in an isolated pipeline.
+- Scans repositories for secret exposure, GitHub Actions, and CI risk.
+- Produces explainable findings with evidence, severity, and remediation context.
+- Provides CLI, API, worker, and web workflows for local scans, hosted scans, trends, and review.
 
 ## What Identrail Does Not Do
 
@@ -106,11 +105,8 @@ V1 is intentionally focused on machine identity security workflows for AWS and K
 Collector -> Raw Assets -> Normalizer -> Graph -> Risk Rules -> Findings Store -> API/CLI/Web
 ```
 
-Operational model:
-
-- API can enqueue scans (`POST /v1/scans`, `POST /v1/repo-scans`).
-- Worker drains queue and runs scheduled jobs.
-- Results are queryable via API and CLI with scan-aware filtering and history.
+The CLI runs local scans directly. The API enqueues hosted scans, the worker
+processes them, and results are available through the API, CLI, and web UI.
 
 ## Deployment Options
 
@@ -127,7 +123,7 @@ See [Deployment Anywhere](./docs/deployment-anywhere.md) for exact commands.
 ## Comparison (Where Identrail Fits)
 
 - Versus broad CSPM tools: Identrail is narrower and deeper on machine identity trust and authorization workflows.
-- Versus secret scanners alone: Identrail includes optional repo exposure scanning, but also links findings into identity risk context.
+- Versus secret scanners alone: Identrail links repository findings into identity risk context.
 - Versus policy engines alone: Identrail adds discovery + risk evidence, not only policy evaluation.
 
 <details>

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -133,15 +133,24 @@ docker pull docker.io/identrail/identrail-worker:dev
 docker pull docker.io/identrail/identrail-web:dev
 docker pull docker.io/identrail/identrail-api:dev
 docker pull docker.io/identrail/identrail-agent:dev
+docker pull docker.io/identrail/identrail-cli:dev
 # GHCR mirrors:
 docker pull ghcr.io/identrail/identrail-worker:dev
 docker pull ghcr.io/identrail/identrail-web:dev
 docker pull ghcr.io/identrail/identrail-api:dev
 docker pull ghcr.io/identrail/identrail-agent:dev
+docker pull ghcr.io/identrail/identrail-cli:dev
+```
+
+Run a one-off repository exposure scan without installing Go:
+
+```bash
+docker run --rm ghcr.io/identrail/identrail-cli:dev scan identrail/identrail
 ```
 
 Each `dev` publish also creates immutable `sha-<12-char-sha>` tags. Release
-images use SemVer tags such as `ghcr.io/identrail/identrail:v1.0.0` and
+images use SemVer tags such as `ghcr.io/identrail/identrail:v1.0.0`,
+`ghcr.io/identrail/identrail-cli:v1.0.0`, and
 `docker.io/identrail/identrail:v1.0.0`.
 
 After the first publish, a repository maintainer may need to make the GHCR

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - Frontend topology (`web/` vs `site/`): `frontend-topology.md`
 - Development workflow: `development-workflow.md`
 - Local token hygiene (Vercel OIDC): `local-token-hygiene.md`
+- Install Identrail CLI: `install.md`
 - CLI reference: `cli-reference.md`
 - Documentation quality checks: `documentation-quality-checks.md`
 - Testing strategy: `testing.md`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -9,13 +9,28 @@ Global flag:
 
 ## `identrail scan`
 
-Runs provider scan pipeline and prints findings.
+Runs provider scan pipeline and prints findings when no repository argument is
+provided.
 
 Key flags:
 - `--fixture` (repeatable)
 - `--output table|json`
 - `--stale-after-days` (default `90`)
 - `--no-save`
+
+## `identrail scan <repository>`
+
+Runs repository exposure scanner using the short command form.
+
+Examples:
+- `identrail scan identrail/identrail`
+- `identrail scan owner/repo --history-limit 50 --max-findings 20`
+- `identrail scan https://github.com/owner/repo.git --output json`
+
+Key flags:
+- `--history-limit` (default `500`)
+- `--max-findings` (default `200`)
+- `--output table|json`
 
 ## `identrail findings`
 
@@ -26,10 +41,14 @@ Key flags:
 
 ## `identrail repo-scan`
 
-Runs repository exposure scanner.
+Runs repository exposure scanner. This is the backward-compatible long form of
+`identrail scan <repository>`.
+
+Aliases:
+- `identrail repo`
 
 Key flags:
-- `--repo` (required)
+- positional repository target or `--repo`
 - `--history-limit` (default `500`)
 - `--max-findings` (default `200`)
 - `--output table|json`

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,98 @@
+# Install Identrail
+
+This page covers the end-user install paths for the Identrail command-line
+scanner. The hosted API, worker, and web stack remain documented in the
+deployment guides.
+
+## Recommended CLI usage
+
+Use the short repository scan form when you want to inspect one GitHub
+repository:
+
+```bash
+identrail scan owner/repo
+```
+
+Examples:
+
+```bash
+identrail scan identrail/identrail
+identrail scan owner/repo --history-limit 50 --max-findings 20
+identrail scan https://github.com/owner/repo.git --output json
+```
+
+The longer command remains supported for scripts and backward compatibility:
+
+```bash
+identrail repo-scan --repo owner/repo
+identrail repo-scan owner/repo
+identrail repo owner/repo
+```
+
+Running `identrail scan` without a repository still runs the provider scan
+pipeline for AWS or Kubernetes identities.
+
+## Download a release binary
+
+Published GitHub releases include `identrail-cli` archives for macOS, Linux,
+and Windows:
+
+- macOS Intel and Apple Silicon: `darwin-amd64`, `darwin-arm64`
+- Linux Intel and ARM: `linux-amd64`, `linux-arm64`
+- Windows Intel: `windows-amd64`
+
+Download the archive that matches your machine from the GitHub release page,
+extract it, and put the `identrail-cli-*` binary on your `PATH` as
+`identrail`.
+
+## Homebrew (planned)
+
+The release assets and CLI command shape are ready for a Homebrew tap formula,
+but the `identrail/homebrew-tap` repository has not been published yet. Once
+that tap exists, the install command should be:
+
+```bash
+brew install identrail/tap/identrail
+```
+
+After Homebrew core acceptance, the shorter command can become:
+
+```bash
+brew install identrail
+```
+
+Core acceptance is a later distribution step outside this repository PR. It
+requires a public Homebrew formula review, stable releases, source-build
+support, tests, and enough user adoption for Homebrew maintainers to accept the
+formula.
+
+## Docker CLI image
+
+For machines that already use Docker, run the CLI without installing Go:
+
+```bash
+docker run --rm ghcr.io/identrail/identrail-cli:dev scan owner/repo
+```
+
+The Docker image uses the same `identrail` entrypoint as the binary, so any CLI
+arguments after the image name are passed directly to Identrail.
+
+Release tags follow the normal image scheme:
+
+```bash
+docker run --rm ghcr.io/identrail/identrail-cli:v1.2.3 scan owner/repo
+docker run --rm docker.io/identrail/identrail-cli:v1.2.3 scan owner/repo
+```
+
+Use immutable `sha-<12-char-sha>` tags when you need repeatable scans in CI.
+
+## Build from source
+
+Contributors can still build locally from a clone:
+
+```bash
+git clone https://github.com/identrail/identrail.git
+cd identrail
+go build -o ./bin/identrail ./cmd/cli
+./bin/identrail scan owner/repo
+```

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -37,11 +37,13 @@ their first organization, workspace, and GitHub connector after login.
    - `ghcr.io/<owner>/identrail-worker:<tag>`
    - `ghcr.io/<owner>/identrail-web:<tag>`
    - `ghcr.io/<owner>/identrail-agent:<tag>`
+   - `ghcr.io/<owner>/identrail-cli:<tag>`
    - `docker.io/identrail/identrail:<tag>`
    - `docker.io/identrail/identrail-api:<tag>`
    - `docker.io/identrail/identrail-worker:<tag>`
    - `docker.io/identrail/identrail-web:<tag>`
    - `docker.io/identrail/identrail-agent:<tag>`
+   - `docker.io/identrail/identrail-cli:<tag>`
 4. Image digests and web build input metadata.
 5. Auto-generated GitHub Release notes.
 
@@ -55,11 +57,13 @@ every merge to `dev`:
 - `ghcr.io/identrail/identrail-worker:dev`
 - `ghcr.io/identrail/identrail-web:dev`
 - `ghcr.io/identrail/identrail-agent:dev`
+- `ghcr.io/identrail/identrail-cli:dev`
 - `docker.io/identrail/identrail:dev`
 - `docker.io/identrail/identrail-api:dev`
 - `docker.io/identrail/identrail-worker:dev`
 - `docker.io/identrail/identrail-web:dev`
 - `docker.io/identrail/identrail-agent:dev`
+- `docker.io/identrail/identrail-cli:dev`
 
 Each run also publishes immutable SHA tags such as `sha-<12-char-sha>`. Use the
 `dev` tags for quick evaluation and SHA or release tags for repeatable

--- a/docs/supply-chain-trust.md
+++ b/docs/supply-chain-trust.md
@@ -11,7 +11,8 @@ Supply-chain trust automation is defined in:
 ## Artifacts Produced
 
 - Binary SBOM (`CycloneDX JSON`)
-- Image SBOMs (`CycloneDX JSON`) when release images exist in GHCR
+- Image SBOMs (`CycloneDX JSON`) when API, worker, CLI, and web release images
+  exist in GHCR
 - Signed checksum manifest:
   - `checksums.txt`
   - `checksums.txt.sig`

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -72,14 +72,31 @@ func buildScanCmd(cfg config.Config, out io.Writer, stateFile *string) *cobra.Co
 	var outputFormat string
 	var staleAfterDays int
 	var skipSave bool
+	var repoHistoryLimit int
+	var repoMaxFindings int
 
 	defaultFixtures := defaultFixturesForProvider(cfg)
 
 	cmd := &cobra.Command{
-		Use:   "scan",
+		Use:   "scan [repository]",
 		Short: "Run a read-only scan",
-		Long:  "Runs the provider scan pipeline (collector -> normalizer -> graph -> risk rules).",
-		RunE: func(_ *cobra.Command, _ []string) error {
+		Long:  "Runs the provider scan pipeline with no arguments, or scans repository exposure when a repository target is provided.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				if cmd.Flags().Changed("fixture") || cmd.Flags().Changed("stale-after-days") || cmd.Flags().Changed("no-save") {
+					return fmt.Errorf("provider scan flags cannot be used with a repository target")
+				}
+				return runRepoScan(out, repoScanCLIOptions{
+					Repository:   args[0],
+					OutputFormat: outputFormat,
+					HistoryLimit: repoHistoryLimit,
+					MaxFindings:  repoMaxFindings,
+				})
+			}
+			if cmd.Flags().Changed("history-limit") || cmd.Flags().Changed("max-findings") {
+				return fmt.Errorf("--history-limit and --max-findings require a repository target")
+			}
 			if staleAfterDays < 1 {
 				return fmt.Errorf("--stale-after-days must be at least 1")
 			}
@@ -128,6 +145,8 @@ func buildScanCmd(cfg config.Config, out io.Writer, stateFile *string) *cobra.Co
 	cmd.Flags().StringVar(&outputFormat, "output", formatTable, "Output format: table|json")
 	cmd.Flags().IntVar(&staleAfterDays, "stale-after-days", 90, "Staleness threshold in days")
 	cmd.Flags().BoolVar(&skipSave, "no-save", false, "Skip writing local findings state")
+	cmd.Flags().IntVar(&repoHistoryLimit, "history-limit", 500, "Maximum number of repository commits to inspect when a repository target is supplied")
+	cmd.Flags().IntVar(&repoMaxFindings, "max-findings", 200, "Maximum repository findings to emit when a repository target is supplied")
 
 	return cmd
 }
@@ -242,67 +261,100 @@ func buildScanReplayCmd(cfg config.Config, out io.Writer) *cobra.Command {
 }
 
 func buildRepoScanCmd(out io.Writer) *cobra.Command {
-	var (
-		repository   string
-		outputFormat string
-		historyLimit int
-		maxFindings  int
-	)
+	options := repoScanCLIOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "repo-scan",
-		Short: "Scan repository history for secret exposures and misconfigurations",
-		Long:  "Scans all reachable commits for added secret material and scans HEAD configuration files for high-signal misconfigurations.",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			if strings.TrimSpace(repository) == "" {
-				return fmt.Errorf("--repo is required")
-			}
-			if historyLimit < 1 {
-				return fmt.Errorf("--history-limit must be at least 1")
-			}
-			if maxFindings < 1 {
-				return fmt.Errorf("--max-findings must be at least 1")
-			}
-			formatter, err := parseOutputFormat(outputFormat)
+		Use:     "repo-scan [repository]",
+		Aliases: []string{"repo"},
+		Short:   "Scan repository history for secret exposures and misconfigurations",
+		Long:    "Scans all reachable commits for added secret material and scans HEAD configuration files for high-signal misconfigurations.",
+		Args:    cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			repository, err := resolveRepoScanTarget(options.Repository, args)
 			if err != nil {
 				return err
 			}
-
-			scanner := repoexposure.NewScanner(
-				nil,
-				repoexposure.WithHistoryLimit(historyLimit),
-				repoexposure.WithMaxFindings(maxFindings),
-			)
-			result, err := scanner.ScanRepository(context.Background(), repository)
-			if err != nil {
-				return fmt.Errorf("repo scan failed: %w", err)
-			}
-
-			switch formatter {
-			case outputJSON:
-				return writeJSON(out, result)
-			default:
-				if _, err := fmt.Fprintf(
-					out,
-					"Repo scan completed: repo=%s commits=%d files=%d findings=%d truncated=%t\n",
-					result.Repository,
-					result.CommitsScanned,
-					result.FilesScanned,
-					len(result.Findings),
-					result.Truncated,
-				); err != nil {
-					return err
-				}
-				return renderFindingsTable(out, result.Findings)
-			}
+			options.Repository = repository
+			return runRepoScan(out, options)
 		},
 	}
 
-	cmd.Flags().StringVar(&repository, "repo", "", "Repository target (owner/repo, URL, or local git path)")
-	cmd.Flags().StringVar(&outputFormat, "output", formatTable, "Output format: table|json")
-	cmd.Flags().IntVar(&historyLimit, "history-limit", 500, "Maximum number of commits to inspect for history secret exposure")
-	cmd.Flags().IntVar(&maxFindings, "max-findings", 200, "Maximum findings to emit before truncating scan output")
+	cmd.Flags().StringVar(&options.Repository, "repo", "", "Repository target (owner/repo, URL, or local git path)")
+	cmd.Flags().StringVar(&options.OutputFormat, "output", formatTable, "Output format: table|json")
+	cmd.Flags().IntVar(&options.HistoryLimit, "history-limit", 500, "Maximum number of commits to inspect for history secret exposure")
+	cmd.Flags().IntVar(&options.MaxFindings, "max-findings", 200, "Maximum findings to emit before truncating scan output")
 	return cmd
+}
+
+type repoScanCLIOptions struct {
+	Repository   string
+	OutputFormat string
+	HistoryLimit int
+	MaxFindings  int
+}
+
+func resolveRepoScanTarget(flagValue string, args []string) (string, error) {
+	flagTarget := strings.TrimSpace(flagValue)
+	argTarget := ""
+	if len(args) > 0 {
+		argTarget = strings.TrimSpace(args[0])
+	}
+	if flagTarget != "" && argTarget != "" && flagTarget != argTarget {
+		return "", fmt.Errorf("repository argument %q does not match --repo %q", argTarget, flagTarget)
+	}
+	switch {
+	case argTarget != "":
+		return argTarget, nil
+	case flagTarget != "":
+		return flagTarget, nil
+	default:
+		return "", fmt.Errorf("repository argument or --repo is required")
+	}
+}
+
+func runRepoScan(out io.Writer, options repoScanCLIOptions) error {
+	repository := strings.TrimSpace(options.Repository)
+	if repository == "" {
+		return fmt.Errorf("repository argument or --repo is required")
+	}
+	if options.HistoryLimit < 1 {
+		return fmt.Errorf("--history-limit must be at least 1")
+	}
+	if options.MaxFindings < 1 {
+		return fmt.Errorf("--max-findings must be at least 1")
+	}
+	formatter, err := parseOutputFormat(options.OutputFormat)
+	if err != nil {
+		return err
+	}
+
+	scanner := repoexposure.NewScanner(
+		nil,
+		repoexposure.WithHistoryLimit(options.HistoryLimit),
+		repoexposure.WithMaxFindings(options.MaxFindings),
+	)
+	result, err := scanner.ScanRepository(context.Background(), repository)
+	if err != nil {
+		return fmt.Errorf("repo scan failed: %w", err)
+	}
+
+	switch formatter {
+	case outputJSON:
+		return writeJSON(out, result)
+	default:
+		if _, err := fmt.Fprintf(
+			out,
+			"Repo scan completed: repo=%s commits=%d files=%d findings=%d truncated=%t\n",
+			result.Repository,
+			result.CommitsScanned,
+			result.FilesScanned,
+			len(result.Findings),
+			result.Truncated,
+		); err != nil {
+			return err
+		}
+		return renderFindingsTable(out, result.Findings)
+	}
 }
 
 func buildAuthzCmd(cfg config.Config, out io.Writer) *cobra.Command {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -165,6 +165,48 @@ func TestExecuteRepoScan(t *testing.T) {
 	}
 }
 
+func TestExecuteRepoScanPositionalTarget(t *testing.T) {
+	cfg := config.Config{ServiceName: "identrail-test", Provider: "aws"}
+	repo := initCLITestRepoWithSecret(t)
+
+	var out bytes.Buffer
+	err := Execute(cfg, []string{
+		"repo-scan",
+		repo,
+		"--history-limit", "50",
+		"--max-findings", "20",
+	}, &out)
+	if err != nil {
+		t.Fatalf("repo scan failed: %v", err)
+	}
+	if !strings.Contains(out.String(), "Repo scan completed:") {
+		t.Fatalf("expected repo scan summary, got %q", out.String())
+	}
+}
+
+func TestExecuteScanRepositoryShortcut(t *testing.T) {
+	cfg := config.Config{ServiceName: "identrail-test", Provider: "aws"}
+	repo := initCLITestRepoWithSecret(t)
+
+	var out bytes.Buffer
+	err := Execute(cfg, []string{
+		"scan",
+		repo,
+		"--history-limit", "50",
+		"--max-findings", "20",
+	}, &out)
+	if err != nil {
+		t.Fatalf("repo shortcut scan failed: %v", err)
+	}
+	body := out.String()
+	if !strings.Contains(body, "Repo scan completed:") {
+		t.Fatalf("expected repo scan summary, got %q", body)
+	}
+	if !strings.Contains(body, "secret") {
+		t.Fatalf("expected repository finding output, got %q", body)
+	}
+}
+
 func TestExecuteRepoScanValidationErrors(t *testing.T) {
 	cfg := config.Config{ServiceName: "identrail-test", Provider: "aws"}
 	var out bytes.Buffer
@@ -180,6 +222,15 @@ func TestExecuteRepoScanValidationErrors(t *testing.T) {
 	}
 	if err := Execute(cfg, []string{"repo-scan", "--repo", ".", "--output", "xml"}, &out); err == nil {
 		t.Fatal("expected output validation error")
+	}
+	if err := Execute(cfg, []string{"repo-scan", ".", "--repo", "other/repo"}, &out); err == nil {
+		t.Fatal("expected conflicting repository target validation error")
+	}
+	if err := Execute(cfg, []string{"scan", ".", "--fixture", "fixture.json"}, &out); err == nil {
+		t.Fatal("expected provider flag validation error for repository shortcut")
+	}
+	if err := Execute(cfg, []string{"scan", "--history-limit", "10"}, &out); err == nil {
+		t.Fatal("expected repository-only flag validation error")
 	}
 }
 


### PR DESCRIPTION
Fixes #1280

Summary
- Add `identrail scan <repository>` as the short repository exposure scan path while preserving `identrail scan` for provider scans with no arguments.
- Keep backward compatibility for `identrail repo-scan --repo <repository>`, add positional `repo-scan <repository>`, and add the `identrail repo <repository>` alias.
- Publish a dedicated CLI container image from dev and release workflows, and include the CLI image in release SBOM/signing coverage.
- Tighten the public README and install docs so they describe real install paths now, Docker CLI usage, and Homebrew tap readiness without implying that the tap already exists.

Why
- First-time users should be able to try repository scanning with one simple command: `identrail scan owner/repo`.
- Docker should remain useful as the no-Go install path for users who only want to run the CLI once or use it in CI.
- Homebrew can be layered on top of the existing release assets and the cleaner CLI command without changing the hosted API/worker flow.

Validation
- `go test ./internal/cli ./cmd/cli`
- `go build -o ./bin/identrail ./cmd/cli`
- `./bin/identrail scan . --history-limit 1 --max-findings 5`
- `go test ./...`
- `go test ./... -coverprofile=coverage.out`
- `go tool cover -func=coverage.out | tail -n 5` (total: 80.2%)
- `go vet ./...`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/publish-container-images.yml .github/workflows/release.yml .github/workflows/supply-chain-trust.yml`
- `git diff --check`

Not run
- Local Docker image build: Docker CLI is installed, but the local Docker daemon is not running (`failed to connect to the docker API`).

AI-assisted: No
Tools used: N/A
Where used: N/A
Human verification performed: CLI unit tests, full Go suite, coverage gate, go vet, actionlint, README/docs review, and local CLI smoke command.
