### PR TITLE
Polish pricing and trust graph visuals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   state, owner and detector metadata, list filters for lifecycle, ownership,
   confidence, and age, plus dashboard summary metrics for open, fixed,
   reopened, SLA-aged, and MTTR-ready repository risk.
+- Redesigned the marketing pricing hero decision console and product trust
+  graph visual with larger plan guidance, precise SVG path arrows, and clearer
+  trust-path labels.
 - Replaced public demo calendar placeholders with the first-party demo booking
   form, including preferred day/time capture in lead delivery emails and
   clearer dark-page contrast for the demo booking and evidence panels.

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -250,7 +250,9 @@ describe('App', () => {
     ).toBeInTheDocument();
 
     expect(screen.getByRole('button', { name: /Annual/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Contact Sales' })).toBeInTheDocument();
+    expect(screen.getByText(/Choose deployment model/i)).toBeInTheDocument();
+    expect(screen.getByText(/Procurement ready/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Talk to Enterprise/i })).toBeInTheDocument();
   });
 
   it('renders the full-bleed product page story', () => {
@@ -270,6 +272,8 @@ describe('App', () => {
     expect(screen.getAllByRole('button', { name: /Request Trust Path Review/i }).length).toBeGreaterThan(0);
     expect(document.querySelector('main main')).not.toBeInTheDocument();
     expect(document.querySelector('.idt-product-hero-visual')).toHaveAttribute('aria-hidden', 'true');
+    expect(document.querySelector('.idt-product-trust-svg')).toBeInTheDocument();
+    expect(document.querySelectorAll('.idt-product-path-edge.is-active')).toHaveLength(3);
   });
 
   it('renders read-only scan intake flow route', () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -842,63 +842,177 @@ function ProductHeroVisual() {
         </div>
         <div className="idt-product-hero-body">
           <div className="idt-product-hero-graph">
-            <div className="idt-product-graph-title">
-              <span>Live path</span>
-              <strong>CI/CD identity to billing data</strong>
-            </div>
-            <svg viewBox="0 0 720 420" aria-hidden="true" focusable="false">
+            <svg className="idt-product-trust-svg" viewBox="0 0 920 520" aria-hidden="true" focusable="false">
               <defs>
-                <marker id="idt-product-hero-arrow" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="12" markerHeight="12" orient="auto">
-                  <path d="M 1 1 L 11 6 L 1 11 L 3.4 6 Z" />
-                </marker>
-                <marker id="idt-product-hero-arrow-muted" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="10" markerHeight="10" orient="auto">
-                  <path d="M 1 1 L 11 6 L 1 11 L 3.4 6 Z" />
+                <marker
+                  id="idt-product-trust-arrow"
+                  viewBox="0 0 18 18"
+                  refX="15"
+                  refY="9"
+                  markerWidth="18"
+                  markerHeight="18"
+                  orient="auto"
+                  markerUnits="userSpaceOnUse"
+                >
+                  <path className="idt-product-trust-arrow-head" d="M3 3 L15 9 L3 15" />
                 </marker>
               </defs>
-              <path className="idt-product-graph-edge is-muted" d="M150 152 C230 166 284 209 338 248" />
-              <path className="idt-product-graph-edge is-proof" d="M162 334 C226 320 282 288 336 266" />
-              <path className="idt-product-graph-edge is-safe" d="M426 250 C500 220 545 164 606 128" />
-              <path className="idt-product-graph-edge is-risk" d="M428 278 C472 318 515 333 560 344" />
+              <circle className="idt-product-focus-halo" cx="475" cy="276" r="150" />
+
+              <g className="idt-product-graph-title" transform="translate(34 34)">
+                <text className="idt-product-node-kicker" x="0" y="12">
+                  Live path
+                </text>
+                <text className="idt-product-svg-title" x="0" y="48">
+                  CI/CD identity to billing
+                </text>
+                <text className="idt-product-svg-title" x="0" y="76">
+                  data
+                </text>
+              </g>
+
+              <path className="idt-product-path-edge is-active" d="M250 168 C318 172 326 266 370 266" />
+              <path className="idt-product-path-edge is-active" d="M570 260 C626 236 636 174 668 174" />
+              <path className="idt-product-path-edge is-active" d="M570 302 C598 318 604 365 626 374" />
+
+              <g className="idt-product-path-tag" transform="translate(284 178)">
+                <rect width="92" height="30" rx="15" />
+                <text x="46" y="20">
+                  federates
+                </text>
+              </g>
+              <g className="idt-product-path-tag" transform="translate(586 214)">
+                <rect width="108" height="30" rx="15" />
+                <text x="54" y="20">
+                  assumes role
+                </text>
+              </g>
+              <g className="idt-product-path-tag" transform="translate(580 338)">
+                <rect width="100" height="30" rx="15" />
+                <text x="50" y="20">
+                  reaches data
+                </text>
+              </g>
+
+              <g className="idt-product-path-node is-source" transform="translate(70 128)">
+                <rect width="180" height="80" rx="10" />
+                <text className="idt-product-node-kicker" x="18" y="26">
+                  Source identity
+                </text>
+                <text className="idt-product-node-title" x="18" y="50">
+                  GitHub OIDC
+                </text>
+                <text className="idt-product-node-status is-good" x="18" y="68">
+                  Verified
+                </text>
+              </g>
+              <g className="idt-product-path-node is-workload" transform="translate(370 230)">
+                <rect width="200" height="86" rx="10" />
+                <text className="idt-product-node-kicker" x="18" y="28">
+                  Workload
+                </text>
+                <text className="idt-product-node-title" x="18" y="52">
+                  K8s service account
+                </text>
+                <text className="idt-product-node-status is-good" x="18" y="72">
+                  Namespace bridge
+                </text>
+              </g>
+              <g className="idt-product-path-node is-privilege" transform="translate(668 136)">
+                <rect width="186" height="80" rx="10" />
+                <text className="idt-product-node-kicker" x="18" y="26">
+                  Privilege
+                </text>
+                <text className="idt-product-node-title" x="18" y="50">
+                  AWS Role
+                </text>
+                <text className="idt-product-node-status is-risk" x="18" y="68">
+                  High risk
+                </text>
+              </g>
+              <g className="idt-product-path-node is-resource" transform="translate(626 340)">
+                <rect width="204" height="82" rx="10" />
+                <text className="idt-product-node-kicker" x="18" y="27">
+                  Resource
+                </text>
+                <text className="idt-product-node-title" x="18" y="51">
+                  Billing datastore
+                </text>
+                <text className="idt-product-node-status is-risk" x="18" y="70">
+                  Critical target
+                </text>
+              </g>
+
+              <g className="idt-product-svg-card is-evidence" transform="translate(70 350)">
+                <rect width="274" height="96" rx="10" />
+                <text className="idt-product-card-kicker" x="18" y="28">
+                  Evidence packet
+                </text>
+                <text className="idt-product-card-title" x="18" y="56">
+                  OIDC wildcard can reach
+                </text>
+                <text className="idt-product-card-title" x="18" y="76">
+                  production data
+                </text>
+                <text className="idt-product-card-note" x="18" y="91">
+                  JWT claims, trust policy, API call proof
+                </text>
+              </g>
+              <g className="idt-product-svg-card is-queue" transform="translate(698 432)">
+                <rect width="156" height="72" rx="10" />
+                <text className="idt-product-card-kicker" x="18" y="25">
+                  Live queue
+                </text>
+                <text className="idt-product-card-metric" x="18" y="52">
+                  37 risky paths
+                </text>
+              </g>
             </svg>
-            <div className="idt-graph-pill is-github">
-              <strong>GitHub OIDC</strong>
-              <span>Verified</span>
-            </div>
-            <div className="idt-graph-pill is-aws">
-              <strong>AWS Role</strong>
-              <span>High risk</span>
-            </div>
-            <div className="idt-graph-pill is-k8s">
-              <strong>K8s service account</strong>
-              <span>Namespace bridge</span>
-            </div>
-            <div className="idt-graph-pill is-data">
-              <strong>Billing datastore</strong>
-              <span>Critical target</span>
-            </div>
-            <aside className="idt-product-evidence-card">
-              <span>Evidence packet</span>
-              <strong>OIDC wildcard can reach production data</strong>
-              <p>JWT claims, trust policy, API call proof</p>
-            </aside>
           </div>
         </div>
-      </div>
-      <div className="idt-product-hero-queue">
-        <span>Live queue</span>
-        <strong>37 risky paths</strong>
-        <p>12 have owner-ready fixes</p>
       </div>
     </div>
   );
 }
 
-function PricingHeroVisual() {
+type PricingHeroVisualProps = {
+  annual: boolean;
+  proPrice: number;
+};
+
+function PricingHeroVisual({ annual, proPrice }: PricingHeroVisualProps) {
   return (
-    <div className="idt-pricing-hero-visual">
-      <div className="idt-pricing-hero-toggle">
-        <span>Monthly</span>
-        <strong>Annual - save 25%</strong>
+    <div className="idt-pricing-hero-visual idt-pricing-decision-console">
+      <div className="idt-pricing-console-top">
+        <div>
+          <span className="idt-pricing-console-eyebrow">Pricing console</span>
+          <strong>Choose deployment model</strong>
+          <p>Compare the adoption path without hunting through a tiny matrix.</p>
+        </div>
+        <div className="idt-pricing-hero-toggle" role="presentation">
+          <span className={!annual ? 'is-active' : undefined}>Monthly</span>
+          <strong className={annual ? 'is-active' : undefined}>Annual - save 25%</strong>
+        </div>
+      </div>
+      <div className="idt-pricing-hero-plans">
+        <div>
+          <span>Open Source</span>
+          <strong>$0</strong>
+          <p>Self-hosted core</p>
+        </div>
+        <div className="is-featured">
+          <span>Pro</span>
+          <strong>
+            ${proPrice}
+            <small>/user/mo</small>
+          </strong>
+          <p>Hosted graph + SSO</p>
+        </div>
+        <div>
+          <span>Enterprise</span>
+          <strong>Custom</strong>
+          <p>Private tenancy</p>
+        </div>
       </div>
       <div className="idt-pricing-hero-matrix">
         <span>Capability</span>
@@ -3310,7 +3424,7 @@ function PricingPage() {
         title="Pricing aligned to how teams adopt machine identity security"
         body="Start with open source, move to hosted Pro for speed, then scale to enterprise controls when needed."
         variant="pricing"
-        visual={<PricingHeroVisual />}
+        visual={<PricingHeroVisual annual={annual} proPrice={proPrice} />}
         actions={
           <>
             <ScanIntakeCTA className="idt-btn idt-btn-primary" />

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -22447,3 +22447,395 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 .idt-app-console-layout .idt-app-quick-find-icon > svg {
   display: block;
 }
+
+/* Pricing and product graph polish. */
+.idt-product-page .idt-product-hero-window,
+html[data-theme='light'] .idt-product-page .idt-product-hero-window {
+  height: auto;
+  border-color: #242424;
+  background: #050505;
+  box-shadow: none;
+}
+
+.idt-product-page .idt-product-hero-visual,
+html[data-theme='light'] .idt-product-page .idt-product-hero-visual {
+  align-self: start;
+  margin-top: clamp(1rem, 3vw, 2.5rem);
+  min-height: 0;
+}
+
+.idt-product-page .idt-product-hero-body,
+html[data-theme='light'] .idt-product-page .idt-product-hero-body {
+  min-height: 0;
+  height: auto;
+  aspect-ratio: 920 / 520;
+}
+
+.idt-product-page .idt-product-hero-graph,
+html[data-theme='light'] .idt-product-page .idt-product-hero-graph {
+  min-height: 0;
+  height: 100%;
+  background:
+    linear-gradient(90deg, rgba(255, 255, 255, 0.05) 1px, transparent 1px),
+    linear-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px),
+    #050505;
+  background-size: 72px 72px, 72px 72px, auto;
+}
+
+.idt-product-page .idt-product-hero-graph .idt-product-trust-svg {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+.idt-product-trust-svg .idt-product-graph-title {
+  position: static;
+  display: block;
+  max-width: none;
+}
+
+.idt-product-focus-halo {
+  fill: rgba(255, 255, 255, 0.09);
+  filter: blur(28px);
+}
+
+.idt-product-path-edge {
+  fill: none;
+  marker-end: url(#idt-product-trust-arrow);
+  stroke: #f5f5f5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 3.4;
+  vector-effect: non-scaling-stroke;
+}
+
+.idt-product-trust-arrow-head {
+  fill: none;
+  stroke: #f5f5f5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2.7;
+}
+
+.idt-product-path-tag rect {
+  fill: #0b0b0b;
+  stroke: #303030;
+  stroke-width: 1;
+}
+
+.idt-product-path-tag text {
+  fill: #d4d4d8;
+  font-family: var(--idt-nav-font);
+  font-size: 12px;
+  font-weight: 800;
+  text-anchor: middle;
+}
+
+.idt-product-svg-title {
+  fill: #ffffff;
+  font-family: 'Barlow Semi Condensed', 'Arial Narrow', Arial, sans-serif;
+  font-size: 26px;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.idt-product-path-node rect {
+  fill: #0d0d0d;
+  stroke: #303030;
+  stroke-width: 1.2;
+}
+
+.idt-product-path-node.is-workload rect {
+  fill: #101010;
+  stroke: #3f3f46;
+}
+
+.idt-product-node-kicker,
+.idt-product-card-kicker {
+  fill: #a1a1aa;
+  font-family: var(--idt-nav-font);
+  font-size: 11px;
+  font-weight: 850;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.idt-product-node-title {
+  fill: #ffffff;
+  font-family: var(--idt-nav-font);
+  font-size: 17px;
+  font-weight: 850;
+}
+
+.idt-product-node-status {
+  font-family: var(--idt-nav-font);
+  font-size: 13px;
+  font-weight: 850;
+  filter: none;
+  stroke: none;
+}
+
+.idt-product-node-status.is-good {
+  fill: #11c784;
+}
+
+.idt-product-node-status.is-risk {
+  fill: #ff5252;
+}
+
+.idt-product-svg-card rect {
+  fill: #ffffff;
+  stroke: #d4d4d8;
+  stroke-width: 1;
+}
+
+.idt-product-card-title,
+.idt-product-card-metric {
+  fill: #050505;
+  font-family: var(--idt-nav-font);
+  font-size: 16px;
+  font-weight: 850;
+}
+
+.idt-product-card-metric {
+  font-size: 21px;
+}
+
+.idt-product-card-note {
+  fill: #52525b;
+  font-family: var(--idt-nav-font);
+  font-size: 10px;
+  font-weight: 650;
+}
+
+.idt-pricing-page > .idt-page-hero-rich,
+html[data-theme='light'] .idt-pricing-page > .idt-page-hero-rich {
+  grid-template-columns: minmax(360px, 0.68fr) minmax(720px, 1.32fr);
+}
+
+.idt-pricing-decision-console,
+html[data-theme='light'] .idt-pricing-decision-console {
+  align-content: stretch;
+  min-height: 520px;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid #242424;
+  border-radius: 8px;
+  background:
+    radial-gradient(circle at 76% 10%, rgba(255, 255, 255, 0.08), transparent 14rem),
+    #050505;
+  box-shadow: none;
+}
+
+.idt-pricing-console-top {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: start;
+}
+
+.idt-pricing-console-top > div:first-child {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.idt-pricing-console-eyebrow {
+  color: #a1a1aa;
+  font-family: var(--idt-nav-font);
+  font-size: 0.72rem;
+  font-weight: 850;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.idt-pricing-console-top > div:first-child > strong {
+  color: #ffffff;
+  font-family: 'Barlow Semi Condensed', 'Arial Narrow', Arial, sans-serif;
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+  font-weight: 800;
+  line-height: 0.95;
+  text-transform: uppercase;
+}
+
+.idt-pricing-console-top p {
+  max-width: 34ch;
+  margin: 0;
+  color: #a1a1aa;
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.idt-pricing-decision-console .idt-pricing-hero-toggle,
+html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-toggle {
+  border-color: #303030;
+  background: #0a0a0a;
+  box-shadow: none;
+}
+
+.idt-pricing-decision-console .idt-pricing-hero-toggle span,
+.idt-pricing-decision-console .idt-pricing-hero-toggle strong,
+html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-toggle span,
+html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-toggle strong {
+  min-height: 40px;
+  display: inline-flex;
+  align-items: center;
+  background: transparent;
+  color: #a1a1aa;
+  font-size: 0.78rem;
+}
+
+.idt-pricing-decision-console .idt-pricing-hero-toggle .is-active,
+html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-toggle .is-active {
+  background: #ffffff;
+  color: #000000;
+}
+
+.idt-pricing-decision-console .idt-pricing-hero-plans,
+html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-plans {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.idt-pricing-decision-console .idt-pricing-hero-plans div,
+html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-plans div {
+  min-height: 154px;
+  display: grid;
+  align-content: start;
+  gap: 0.48rem;
+  padding: 1rem;
+  border-color: #242424;
+  background: #090909;
+  box-shadow: none;
+}
+
+.idt-pricing-decision-console .idt-pricing-hero-plans .is-featured,
+html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-plans .is-featured {
+  background: #ffffff;
+  color: #000000;
+  transform: none;
+}
+
+.idt-pricing-decision-console .idt-pricing-hero-plans span,
+.idt-pricing-decision-console .idt-pricing-hero-plans p,
+html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-plans span,
+html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-plans p {
+  color: #a1a1aa;
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.idt-pricing-decision-console .idt-pricing-hero-plans strong,
+html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-plans strong {
+  margin: 0;
+  color: #ffffff;
+  font-size: clamp(2rem, 3.4vw, 3rem);
+  line-height: 0.94;
+}
+
+.idt-pricing-decision-console .idt-pricing-hero-plans small {
+  margin-left: 0.2rem;
+  font-size: 0.82rem;
+}
+
+.idt-pricing-decision-console .idt-pricing-hero-plans .is-featured span,
+.idt-pricing-decision-console .idt-pricing-hero-plans .is-featured p,
+.idt-pricing-decision-console .idt-pricing-hero-plans .is-featured strong,
+html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-plans .is-featured span,
+html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-plans .is-featured p,
+html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-plans .is-featured strong {
+  color: #000000;
+}
+
+.idt-pricing-decision-console .idt-pricing-hero-matrix,
+html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-matrix {
+  min-height: 176px;
+  grid-template-columns: minmax(180px, 1.25fr) repeat(3, minmax(116px, 0.75fr));
+  border-color: #242424;
+  background: #242424;
+  box-shadow: none;
+}
+
+.idt-pricing-decision-console .idt-pricing-hero-matrix > *,
+html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-matrix > * {
+  display: flex;
+  align-items: center;
+  min-height: 44px;
+  border-right: 1px solid #242424;
+  border-bottom: 1px solid #242424;
+  background: #090909;
+  color: #d4d4d8;
+  font-size: 0.9rem;
+}
+
+.idt-pricing-decision-console .idt-pricing-hero-matrix span,
+html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-matrix span {
+  background: #111111;
+  color: #ffffff;
+}
+
+.idt-pricing-decision-console .idt-pricing-hero-matrix b,
+html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-matrix b {
+  color: #ffffff;
+  font-size: 0.95rem;
+}
+
+.idt-pricing-decision-console .idt-pricing-hero-procurement,
+html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-procurement {
+  border-color: #242424;
+  background: #090909;
+  box-shadow: none;
+}
+
+.idt-pricing-decision-console .idt-pricing-hero-procurement strong,
+html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-procurement strong {
+  color: #ffffff;
+  font-size: 0.92rem;
+}
+
+.idt-pricing-decision-console .idt-pricing-hero-procurement span,
+html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-procurement span {
+  border-color: #ffffff;
+  background: #ffffff;
+  color: #000000;
+  font-size: 0.78rem;
+}
+
+@media (max-width: 1180px) {
+  .idt-pricing-page > .idt-page-hero-rich,
+  html[data-theme='light'] .idt-pricing-page > .idt-page-hero-rich {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-pricing-decision-console,
+  html[data-theme='light'] .idt-pricing-decision-console {
+    min-height: auto;
+  }
+}
+
+@media (max-width: 760px) {
+  .idt-product-page .idt-product-hero-graph,
+  html[data-theme='light'] .idt-product-page .idt-product-hero-graph {
+    min-height: 430px;
+  }
+
+  .idt-product-page .idt-product-trust-svg {
+    min-width: 760px;
+    transform: translateX(-3rem);
+  }
+
+  .idt-pricing-console-top,
+  .idt-pricing-decision-console .idt-pricing-hero-plans,
+  html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-plans {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-pricing-decision-console .idt-pricing-hero-matrix,
+  html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-matrix {
+    overflow-x: auto;
+  }
+}


### PR DESCRIPTION
Fixes #1278

## Summary
- Rebuild the product hero trust graph as one SVG surface with consistent V-shaped arrows, labels, and node cards.
- Expand the pricing hero visual into a larger decision console with plan cards, a capability snapshot, and procurement badges.
- Add regression coverage for the new pricing and product visual structure.

## Impact
- Improves the public product and pricing pages without changing backend/API behavior.
- Keeps the change scoped to marketing React/CSS plus changelog and test coverage.

## Validation
- npm test -- --run src/App.test.tsx
- npm run build
- Browser preview spot-check on /product and /pricing: product graph visible with 3 active connectors, pricing console visible with 3 plan cards, no horizontal overflow, no console errors.

## AI-assisted
No

## Tools used
None

## Human verification
Verified locally with tests, production build, and browser preview spot-check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the product trust graph and pricing visuals to meet #1278 with a redesigned SVG graph and a larger pricing decision console. No backend changes.

- New Features
  - Product trust graph: single SVG (`.idt-product-trust-svg`) with precise path arrows, three active edges, labeled nodes/tags, and evidence/queue cards.
  - Pricing: decision console with “Choose deployment model,” active monthly/annual toggle; `PricingHeroVisual` now accepts `annual` and `proPrice` for dynamic UI; CTA updated to “Talk to Enterprise”; capability matrix and procurement badges included.
  - Updated tests for new copy and SVG graph presence; `CHANGELOG.md` entry added.

<sup>Written for commit 3c47da3a5b3f39081c2b03b7152a27245c560135. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1281?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

