### PR TITLE
Add GitHub repository intelligence CLI parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Added API-backed CLI parity for GitHub repository intelligence. Operators can
+  now queue hosted repository scans, list/show/cancel repo scans, filter repo
+  findings by lifecycle and confidence, fetch risk graphs, collect GitHub
+  repository posture, and preview remediation plans from the terminal.
 - Wired GitHub repository intelligence into the product app. Project source
   onboarding now surfaces selected-repository posture checks, and repository
   findings now show risk-graph summaries, top finding scores, and on-demand

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -26,12 +26,132 @@ Key flags:
 
 ## `identrail repo-scan`
 
-Runs repository exposure scanner.
+Runs the local repository exposure scanner.
 
 Key flags:
 - `--repo` (required)
 - `--history-limit` (default `500`)
 - `--max-findings` (default `200`)
+- `--output table|json`
+
+## `identrail repo-scan queue`
+
+Queues an API-backed repository intelligence scan. Use this for hosted scans,
+private repositories, GitHub App installation credentials, and incremental scan
+metadata.
+
+Key flags:
+- `--api-url`
+- `--api-key`
+- `--tenant-id`
+- `--workspace-id`
+- `--repo` (required)
+- `--project-id` (required for GitHub App private repo scans)
+- `--connector-id`
+- `--scan-mode quick|delta|deep`
+- `--base-revision`
+- `--head-revision`
+- `--changed-path` (repeatable or comma-separated)
+- `--history-limit` (default `0`, server default)
+- `--max-findings` (default `0`, server default)
+- `--timeout`
+- `--output table|json`
+
+## `identrail repo-scan list|show|cancel`
+
+Reads or cancels API-backed repository scans.
+
+Examples:
+```bash
+identrail repo-scan list --limit 20
+identrail repo-scan show <repo-scan-id>
+identrail repo-scan cancel <repo-scan-id>
+```
+
+Common flags:
+- `--api-url`
+- `--api-key`
+- `--tenant-id`
+- `--workspace-id`
+- `--timeout`
+- `--output table|json`
+
+## `identrail repo-findings list`
+
+Lists repository findings with lifecycle, ownership, detector, confidence, and
+age filters.
+
+Key flags:
+- `--api-url`
+- `--api-key`
+- `--tenant-id`
+- `--workspace-id`
+- `--repo-scan-id`
+- `--repo`
+- `--severity`
+- `--type`
+- `--status`
+- `--detector`
+- `--owner`
+- `--min-confidence`
+- `--min-age-days`
+- `--limit`
+- `--cursor`
+- `--sort-by`
+- `--sort-order`
+- `--timeout`
+- `--output table|json`
+
+## `identrail repo-risk-graph`
+
+Fetches the repository-to-machine-identity risk graph from the API.
+
+Key flags:
+- `--api-url`
+- `--api-key`
+- `--tenant-id`
+- `--workspace-id`
+- `--repo-scan-id`
+- `--repo`
+- `--default-branch`
+- `--severity`
+- `--type`
+- `--timeout`
+- `--output table|json`
+
+## `identrail repo-posture`
+
+Collects GitHub repository posture through a connected GitHub App.
+
+Key flags:
+- `--api-url`
+- `--api-key`
+- `--tenant-id`
+- `--workspace-id`
+- `--connector-id` (required)
+- `--project-id` (required)
+- `--repo` (required)
+- `--timeout`
+- `--output table|json`
+
+## `identrail repo-remediation preview`
+
+Previews detector-specific remediation for one repository finding and can return
+a safe fix-PR plan when source content is supplied.
+
+Key flags:
+- `--api-url`
+- `--api-key`
+- `--tenant-id`
+- `--workspace-id`
+- `--repo-scan-id`
+- `--source-file`
+- `--source-content`
+- `--base-branch`
+- `--branch-prefix`
+- `--finding-url`
+- `--require-fix-plan`
+- `--timeout`
 - `--output table|json`
 
 ## `identrail authz rollback`
@@ -52,5 +172,5 @@ Key flags:
 ## Environment variables used by CLI
 
 - `IDENTRAIL_API_URL` (default API base URL)
-- `IDENTRAIL_API_KEY` (default rollback auth key)
+- `IDENTRAIL_API_KEY` (default API auth key for API-backed CLI commands)
 - `IDENTRAIL_PROVIDER` (affects default fixtures for `scan`)

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -17,6 +17,24 @@ identrail repo-scan --repo https://github.com/owner/repo.git
 identrail repo-scan --repo /path/to/local/repo
 ```
 
+The terminal also exposes the hosted/API-backed GitHub intelligence surface:
+
+```bash
+identrail repo-scan queue \
+  --repo owner/private-repo \
+  --project-id project-1 \
+  --connector-id github-app
+
+identrail repo-scan list
+identrail repo-findings list --repo owner/private-repo --status open --min-confidence 0.8
+identrail repo-risk-graph --repo owner/private-repo
+identrail repo-posture --connector-id github-app --project-id project-1 --repo owner/private-repo
+identrail repo-remediation preview <finding-id> --repo-scan-id <repo-scan-id>
+```
+
+API-backed CLI commands use `IDENTRAIL_API_URL`, `IDENTRAIL_API_KEY`,
+`--tenant-id`, and `--workspace-id` the same way other API CLI commands do.
+
 ## API
 
 You can trigger the same scanner through API:
@@ -436,6 +454,8 @@ the scan as skipped instead of queueing duplicate work.
 - `--history-limit` (default: `500`): max commits to inspect.
 - `--max-findings` (default: `200`): hard cap on findings.
 - `--output table|json`.
+- API-backed terminal commands also accept `--api-url`, `--api-key`,
+  `--tenant-id`, `--workspace-id`, `--timeout`, and `--output table|json`.
 
 ## Runtime Configuration
 

--- a/internal/cli/repo_intelligence.go
+++ b/internal/cli/repo_intelligence.go
@@ -1,0 +1,951 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/api"
+	"github.com/identrail/identrail/internal/config"
+	githubconnector "github.com/identrail/identrail/internal/connectors/github"
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/spf13/cobra"
+)
+
+type cliAPIOptions struct {
+	APIURL      string
+	APIKey      string
+	TenantID    string
+	WorkspaceID string
+	Timeout     time.Duration
+}
+
+type cliAPIErrorResponse struct {
+	Error string `json:"error"`
+}
+
+type repoScanCLIResponse struct {
+	RepoScan db.RepoScanRecord `json:"repo_scan"`
+}
+
+type repoScanPageCLIResponse struct {
+	Items      []db.RepoScanRecord `json:"items"`
+	NextCursor string              `json:"next_cursor,omitempty"`
+}
+
+type repoFindingPageCLIResponse struct {
+	Items      []domain.Finding         `json:"items"`
+	Summary    *api.RepoFindingsSummary `json:"summary,omitempty"`
+	NextCursor string                   `json:"next_cursor,omitempty"`
+}
+
+func defaultCLIAPIOptions(cfg config.Config) cliAPIOptions {
+	return cliAPIOptions{
+		APIURL:      defaultCLIAPIURL(),
+		APIKey:      strings.TrimSpace(os.Getenv("IDENTRAIL_API_KEY")),
+		TenantID:    strings.TrimSpace(cfg.DefaultTenantID),
+		WorkspaceID: strings.TrimSpace(cfg.DefaultWorkspaceID),
+		Timeout:     10 * time.Second,
+	}
+}
+
+func bindCLIAPIFlags(cmd *cobra.Command, options *cliAPIOptions, apiKeyUse string) {
+	cmd.Flags().StringVar(&options.APIURL, "api-url", options.APIURL, "Identrail API base URL")
+	cmd.Flags().StringVar(&options.APIKey, "api-key", options.APIKey, apiKeyUse)
+	cmd.Flags().StringVar(&options.TenantID, "tenant-id", options.TenantID, "Tenant scope header")
+	cmd.Flags().StringVar(&options.WorkspaceID, "workspace-id", options.WorkspaceID, "Workspace scope header")
+	cmd.Flags().DurationVar(&options.Timeout, "timeout", options.Timeout, "HTTP timeout")
+}
+
+func doCLIAPIRequest(ctx context.Context, options cliAPIOptions, method string, path string, query url.Values, payload any, response any) error {
+	apiURL := strings.TrimRight(strings.TrimSpace(options.APIURL), "/")
+	if apiURL == "" {
+		return fmt.Errorf("--api-url is required")
+	}
+	fullURL := apiURL + path
+	if len(query) > 0 {
+		fullURL += "?" + query.Encode()
+	}
+
+	var body io.Reader
+	if payload != nil {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("encode request: %w", err)
+		}
+		body = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, body)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if normalizedKey := strings.TrimSpace(options.APIKey); normalizedKey != "" {
+		req.Header.Set("X-API-Key", normalizedKey)
+	}
+	if normalizedTenant := strings.TrimSpace(options.TenantID); normalizedTenant != "" {
+		req.Header.Set("X-Identrail-Tenant-ID", normalizedTenant)
+	}
+	if normalizedWorkspace := strings.TrimSpace(options.WorkspaceID); normalizedWorkspace != "" {
+		req.Header.Set("X-Identrail-Workspace-ID", normalizedWorkspace)
+	}
+
+	timeout := options.Timeout
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	resp, err := (&http.Client{Timeout: timeout}).Do(req)
+	if err != nil {
+		return fmt.Errorf("api request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var apiErr cliAPIErrorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&apiErr); err == nil && strings.TrimSpace(apiErr.Error) != "" {
+			return fmt.Errorf("api request failed: %s (status %d)", strings.TrimSpace(apiErr.Error), resp.StatusCode)
+		}
+		return fmt.Errorf("api request failed with status %d", resp.StatusCode)
+	}
+
+	if response == nil {
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(response); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}
+
+func buildRepoScanQueueCmd(cfg config.Config, out io.Writer) *cobra.Command {
+	options := defaultCLIAPIOptions(cfg)
+	var (
+		repository   string
+		projectID    string
+		connectorID  string
+		scanMode     string
+		baseRevision string
+		headRevision string
+		changedPaths []string
+		historyLimit int
+		maxFindings  int
+		outputFormat string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "queue",
+		Short: "Queue an API-backed repository intelligence scan",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if strings.TrimSpace(repository) == "" {
+				return fmt.Errorf("--repo is required")
+			}
+			if strings.TrimSpace(connectorID) != "" && strings.TrimSpace(projectID) == "" {
+				return fmt.Errorf("--project-id is required when --connector-id is set")
+			}
+			if historyLimit < 0 {
+				return fmt.Errorf("--history-limit must be zero or greater")
+			}
+			if maxFindings < 0 {
+				return fmt.Errorf("--max-findings must be zero or greater")
+			}
+			if err := validateRepoScanMode(scanMode); err != nil {
+				return err
+			}
+			formatter, err := parseOutputFormat(outputFormat)
+			if err != nil {
+				return err
+			}
+
+			request := api.RepoScanRequest{
+				Repository:   strings.TrimSpace(repository),
+				ProjectID:    strings.TrimSpace(projectID),
+				ConnectorID:  strings.TrimSpace(connectorID),
+				ScanMode:     strings.TrimSpace(scanMode),
+				BaseRevision: strings.TrimSpace(baseRevision),
+				HeadRevision: strings.TrimSpace(headRevision),
+				ChangedPaths: normalizeCLIStringSlice(changedPaths),
+				HistoryLimit: historyLimit,
+				MaxFindings:  maxFindings,
+			}
+			var response repoScanCLIResponse
+			ctx, cancel := context.WithTimeout(context.Background(), options.Timeout)
+			defer cancel()
+			if err := doCLIAPIRequest(ctx, options, http.MethodPost, "/v1/repo-scans", nil, request, &response); err != nil {
+				return err
+			}
+			switch formatter {
+			case outputJSON:
+				return writeJSON(out, response)
+			default:
+				return renderRepoScanQueuedOutput(out, response.RepoScan)
+			}
+		},
+	}
+
+	bindCLIAPIFlags(cmd, &options, "API key used to queue repository scans")
+	cmd.Flags().StringVar(&repository, "repo", "", "Repository target (owner/repo)")
+	cmd.Flags().StringVar(&projectID, "project-id", "", "Project ID for GitHub App private repository scans")
+	cmd.Flags().StringVar(&connectorID, "connector-id", "", "Connector ID for GitHub App private repository scans")
+	cmd.Flags().StringVar(&scanMode, "scan-mode", "", "Scan mode: quick|delta|deep (empty uses server default)")
+	cmd.Flags().StringVar(&baseRevision, "base-revision", "", "Base revision for delta scans")
+	cmd.Flags().StringVar(&headRevision, "head-revision", "", "Head revision for delta scans")
+	cmd.Flags().StringSliceVar(&changedPaths, "changed-path", nil, "Changed path for quick or delta scans (repeatable or comma-separated)")
+	cmd.Flags().IntVar(&historyLimit, "history-limit", 0, "Maximum commits to inspect (0 uses server default)")
+	cmd.Flags().IntVar(&maxFindings, "max-findings", 0, "Maximum findings to emit (0 uses server default)")
+	cmd.Flags().StringVar(&outputFormat, "output", formatTable, "Output format: table|json")
+	return cmd
+}
+
+func buildRepoScanListCmd(cfg config.Config, out io.Writer) *cobra.Command {
+	options := defaultCLIAPIOptions(cfg)
+	var (
+		limit        int
+		cursor       string
+		sortBy       string
+		sortOrder    string
+		outputFormat string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List API-backed repository scans",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if limit < 1 {
+				return fmt.Errorf("--limit must be at least 1")
+			}
+			formatter, err := parseOutputFormat(outputFormat)
+			if err != nil {
+				return err
+			}
+			query := url.Values{}
+			addCLIQueryInt(query, "limit", limit)
+			addCLIQuery(query, "cursor", cursor)
+			addCLIQuery(query, "sort_by", sortBy)
+			addCLIQuery(query, "sort_order", sortOrder)
+
+			var response repoScanPageCLIResponse
+			ctx, cancel := context.WithTimeout(context.Background(), options.Timeout)
+			defer cancel()
+			if err := doCLIAPIRequest(ctx, options, http.MethodGet, "/v1/repo-scans", query, nil, &response); err != nil {
+				return err
+			}
+			switch formatter {
+			case outputJSON:
+				return writeJSON(out, response)
+			default:
+				return renderRepoScanListOutput(out, response)
+			}
+		},
+	}
+	bindCLIAPIFlags(cmd, &options, "API key used to list repository scans")
+	cmd.Flags().IntVar(&limit, "limit", 20, "Maximum repository scans to list")
+	cmd.Flags().StringVar(&cursor, "cursor", "", "Pagination cursor")
+	cmd.Flags().StringVar(&sortBy, "sort-by", "started_at", "Sort field")
+	cmd.Flags().StringVar(&sortOrder, "sort-order", "desc", "Sort order: asc|desc")
+	cmd.Flags().StringVar(&outputFormat, "output", formatTable, "Output format: table|json")
+	return cmd
+}
+
+func buildRepoScanShowCmd(cfg config.Config, out io.Writer) *cobra.Command {
+	options := defaultCLIAPIOptions(cfg)
+	var outputFormat string
+	cmd := &cobra.Command{
+		Use:   "show <repo-scan-id>",
+		Short: "Show one API-backed repository scan",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			formatter, err := parseOutputFormat(outputFormat)
+			if err != nil {
+				return err
+			}
+			var response db.RepoScanRecord
+			ctx, cancel := context.WithTimeout(context.Background(), options.Timeout)
+			defer cancel()
+			path := "/v1/repo-scans/" + url.PathEscape(strings.TrimSpace(args[0]))
+			if err := doCLIAPIRequest(ctx, options, http.MethodGet, path, nil, nil, &response); err != nil {
+				return err
+			}
+			switch formatter {
+			case outputJSON:
+				return writeJSON(out, response)
+			default:
+				return renderRepoScanRecordOutput(out, response)
+			}
+		},
+	}
+	bindCLIAPIFlags(cmd, &options, "API key used to read repository scans")
+	cmd.Flags().StringVar(&outputFormat, "output", formatTable, "Output format: table|json")
+	return cmd
+}
+
+func buildRepoScanCancelCmd(cfg config.Config, out io.Writer) *cobra.Command {
+	options := defaultCLIAPIOptions(cfg)
+	var outputFormat string
+	cmd := &cobra.Command{
+		Use:   "cancel <repo-scan-id>",
+		Short: "Cancel a queued or running API-backed repository scan",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			formatter, err := parseOutputFormat(outputFormat)
+			if err != nil {
+				return err
+			}
+			var response repoScanCLIResponse
+			ctx, cancel := context.WithTimeout(context.Background(), options.Timeout)
+			defer cancel()
+			path := "/v1/repo-scans/" + url.PathEscape(strings.TrimSpace(args[0])) + "/cancel"
+			if err := doCLIAPIRequest(ctx, options, http.MethodPost, path, nil, nil, &response); err != nil {
+				return err
+			}
+			switch formatter {
+			case outputJSON:
+				return writeJSON(out, response)
+			default:
+				return renderRepoScanCanceledOutput(out, response.RepoScan)
+			}
+		},
+	}
+	bindCLIAPIFlags(cmd, &options, "API key used to cancel repository scans")
+	cmd.Flags().StringVar(&outputFormat, "output", formatTable, "Output format: table|json")
+	return cmd
+}
+
+func buildRepoFindingsCmd(cfg config.Config, out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "repo-findings",
+		Short: "Repository finding intelligence",
+	}
+	cmd.AddCommand(buildRepoFindingsListCmd(cfg, out))
+	return cmd
+}
+
+func buildRepoFindingsListCmd(cfg config.Config, out io.Writer) *cobra.Command {
+	options := defaultCLIAPIOptions(cfg)
+	var (
+		limit           int
+		cursor          string
+		repoScanID      string
+		repository      string
+		severity        string
+		findingType     string
+		lifecycleStatus string
+		detector        string
+		owner           string
+		minConfidence   float64
+		minAgeDays      int
+		sortBy          string
+		sortOrder       string
+		outputFormat    string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List repository findings with lifecycle and confidence filters",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if limit < 1 {
+				return fmt.Errorf("--limit must be at least 1")
+			}
+			if cmd.Flags().Changed("min-confidence") && (minConfidence < 0 || minConfidence > 1) {
+				return fmt.Errorf("--min-confidence must be between 0 and 1")
+			}
+			if minAgeDays < 0 {
+				return fmt.Errorf("--min-age-days must be zero or greater")
+			}
+			formatter, err := parseOutputFormat(outputFormat)
+			if err != nil {
+				return err
+			}
+			query := url.Values{}
+			addCLIQueryInt(query, "limit", limit)
+			addCLIQuery(query, "cursor", cursor)
+			addCLIQuery(query, "repo_scan_id", repoScanID)
+			addCLIQuery(query, "repository", repository)
+			addCLIQuery(query, "severity", severity)
+			addCLIQuery(query, "type", findingType)
+			addCLIQuery(query, "repo_lifecycle_status", lifecycleStatus)
+			addCLIQuery(query, "detector", detector)
+			addCLIQuery(query, "owner", owner)
+			if minConfidence >= 0 {
+				query.Set("min_confidence", fmt.Sprintf("%.4f", minConfidence))
+			}
+			if minAgeDays > 0 {
+				addCLIQueryInt(query, "min_age_days", minAgeDays)
+			}
+			addCLIQuery(query, "sort_by", sortBy)
+			addCLIQuery(query, "sort_order", sortOrder)
+
+			var response repoFindingPageCLIResponse
+			ctx, cancel := context.WithTimeout(context.Background(), options.Timeout)
+			defer cancel()
+			if err := doCLIAPIRequest(ctx, options, http.MethodGet, "/v1/repo-findings", query, nil, &response); err != nil {
+				return err
+			}
+			switch formatter {
+			case outputJSON:
+				return writeJSON(out, response)
+			default:
+				return renderRepoFindingsListOutput(out, response)
+			}
+		},
+	}
+	bindCLIAPIFlags(cmd, &options, "API key used to list repository findings")
+	cmd.Flags().IntVar(&limit, "limit", 25, "Maximum repository findings to list")
+	cmd.Flags().StringVar(&cursor, "cursor", "", "Pagination cursor")
+	cmd.Flags().StringVar(&repoScanID, "repo-scan-id", "", "Filter by repository scan ID")
+	cmd.Flags().StringVar(&repository, "repo", "", "Filter by repository")
+	cmd.Flags().StringVar(&severity, "severity", "", "Filter by severity")
+	cmd.Flags().StringVar(&findingType, "type", "", "Filter by finding type")
+	cmd.Flags().StringVar(&lifecycleStatus, "status", "", "Filter by repository finding lifecycle status")
+	cmd.Flags().StringVar(&detector, "detector", "", "Filter by detector")
+	cmd.Flags().StringVar(&owner, "owner", "", "Filter by owner")
+	cmd.Flags().Float64Var(&minConfidence, "min-confidence", -1, "Minimum confidence score from 0 to 1")
+	cmd.Flags().IntVar(&minAgeDays, "min-age-days", 0, "Minimum finding age in days")
+	cmd.Flags().StringVar(&sortBy, "sort-by", "created_at", "Sort field")
+	cmd.Flags().StringVar(&sortOrder, "sort-order", "desc", "Sort order: asc|desc")
+	cmd.Flags().StringVar(&outputFormat, "output", formatTable, "Output format: table|json")
+	return cmd
+}
+
+func buildRepoRiskGraphCmd(cfg config.Config, out io.Writer) *cobra.Command {
+	options := defaultCLIAPIOptions(cfg)
+	var (
+		repoScanID    string
+		repository    string
+		defaultBranch string
+		severity      string
+		findingType   string
+		outputFormat  string
+	)
+	cmd := &cobra.Command{
+		Use:   "repo-risk-graph",
+		Short: "Fetch the repository-to-machine-identity risk graph",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			formatter, err := parseOutputFormat(outputFormat)
+			if err != nil {
+				return err
+			}
+			query := url.Values{}
+			addCLIQuery(query, "repo_scan_id", repoScanID)
+			addCLIQuery(query, "repository", repository)
+			addCLIQuery(query, "default_branch", defaultBranch)
+			addCLIQuery(query, "severity", severity)
+			addCLIQuery(query, "type", findingType)
+
+			var graph domain.RepoRiskGraph
+			ctx, cancel := context.WithTimeout(context.Background(), options.Timeout)
+			defer cancel()
+			if err := doCLIAPIRequest(ctx, options, http.MethodGet, "/v1/repo-risk-graph", query, nil, &graph); err != nil {
+				return err
+			}
+			switch formatter {
+			case outputJSON:
+				return writeJSON(out, graph)
+			default:
+				return renderRepoRiskGraphOutput(out, graph)
+			}
+		},
+	}
+	bindCLIAPIFlags(cmd, &options, "API key used to read repository risk graphs")
+	cmd.Flags().StringVar(&repoScanID, "repo-scan-id", "", "Filter by repository scan ID")
+	cmd.Flags().StringVar(&repository, "repo", "", "Filter by repository")
+	cmd.Flags().StringVar(&defaultBranch, "default-branch", "", "Default branch used when graph evidence omits branch context")
+	cmd.Flags().StringVar(&severity, "severity", "", "Filter graph findings by severity")
+	cmd.Flags().StringVar(&findingType, "type", "", "Filter graph findings by type")
+	cmd.Flags().StringVar(&outputFormat, "output", formatTable, "Output format: table|json")
+	return cmd
+}
+
+func buildRepoPostureCmd(cfg config.Config, out io.Writer) *cobra.Command {
+	options := defaultCLIAPIOptions(cfg)
+	var (
+		connectorID  string
+		projectID    string
+		repository   string
+		outputFormat string
+	)
+	cmd := &cobra.Command{
+		Use:   "repo-posture",
+		Short: "Collect GitHub repository posture through a GitHub App connector",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if strings.TrimSpace(connectorID) == "" {
+				return fmt.Errorf("--connector-id is required")
+			}
+			if strings.TrimSpace(projectID) == "" {
+				return fmt.Errorf("--project-id is required")
+			}
+			if strings.TrimSpace(repository) == "" {
+				return fmt.Errorf("--repo is required")
+			}
+			formatter, err := parseOutputFormat(outputFormat)
+			if err != nil {
+				return err
+			}
+			query := url.Values{}
+			addCLIQuery(query, "workspace_id", options.WorkspaceID)
+			addCLIQuery(query, "project_id", projectID)
+			addCLIQuery(query, "repository", repository)
+			path := "/v1/connectors/github/" + url.PathEscape(strings.TrimSpace(connectorID)) + "/posture"
+
+			var response api.GitHubRepositoryPostureResponse
+			ctx, cancel := context.WithTimeout(context.Background(), options.Timeout)
+			defer cancel()
+			if err := doCLIAPIRequest(ctx, options, http.MethodGet, path, query, nil, &response); err != nil {
+				return err
+			}
+			switch formatter {
+			case outputJSON:
+				return writeJSON(out, response)
+			default:
+				return renderRepoPostureOutput(out, response)
+			}
+		},
+	}
+	bindCLIAPIFlags(cmd, &options, "API key used to collect GitHub repository posture")
+	cmd.Flags().StringVar(&connectorID, "connector-id", "", "GitHub connector ID")
+	cmd.Flags().StringVar(&projectID, "project-id", "", "Project ID that owns the GitHub connector")
+	cmd.Flags().StringVar(&repository, "repo", "", "Repository target (owner/repo)")
+	cmd.Flags().StringVar(&outputFormat, "output", formatTable, "Output format: table|json")
+	return cmd
+}
+
+func buildRepoRemediationCmd(cfg config.Config, out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "repo-remediation",
+		Short: "Repository finding remediation intelligence",
+	}
+	cmd.AddCommand(buildRepoRemediationPreviewCmd(cfg, out))
+	return cmd
+}
+
+func buildRepoRemediationPreviewCmd(cfg config.Config, out io.Writer) *cobra.Command {
+	options := defaultCLIAPIOptions(cfg)
+	var (
+		repoScanID     string
+		sourceFile     string
+		sourceContent  string
+		baseBranch     string
+		branchPrefix   string
+		findingURL     string
+		requireFixPlan bool
+		outputFormat   string
+	)
+	cmd := &cobra.Command{
+		Use:   "preview <finding-id>",
+		Short: "Preview safe remediation for one repository finding",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if strings.TrimSpace(sourceFile) != "" && strings.TrimSpace(sourceContent) != "" {
+				return fmt.Errorf("use either --source-file or --source-content, not both")
+			}
+			formatter, err := parseOutputFormat(outputFormat)
+			if err != nil {
+				return err
+			}
+			content := sourceContent
+			if strings.TrimSpace(sourceFile) != "" {
+				data, err := os.ReadFile(strings.TrimSpace(sourceFile))
+				if err != nil {
+					return fmt.Errorf("read source file: %w", err)
+				}
+				content = string(data)
+			}
+			request := api.RepoFindingRemediationPreviewRequest{
+				RepoScanID:     strings.TrimSpace(repoScanID),
+				SourceContent:  content,
+				BaseBranch:     strings.TrimSpace(baseBranch),
+				BranchPrefix:   strings.TrimSpace(branchPrefix),
+				FindingURL:     strings.TrimSpace(findingURL),
+				RequireFixPlan: requireFixPlan,
+			}
+			query := url.Values{}
+			addCLIQuery(query, "repo_scan_id", repoScanID)
+			path := "/v1/repo-findings/" + url.PathEscape(strings.TrimSpace(args[0])) + "/remediation/preview"
+
+			var response api.RepoFindingRemediationPreview
+			ctx, cancel := context.WithTimeout(context.Background(), options.Timeout)
+			defer cancel()
+			if err := doCLIAPIRequest(ctx, options, http.MethodPost, path, query, request, &response); err != nil {
+				return err
+			}
+			switch formatter {
+			case outputJSON:
+				return writeJSON(out, response)
+			default:
+				return renderRepoRemediationPreviewOutput(out, response)
+			}
+		},
+	}
+	bindCLIAPIFlags(cmd, &options, "API key used to preview repository remediation")
+	cmd.Flags().StringVar(&repoScanID, "repo-scan-id", "", "Repository scan ID for finding lookup")
+	cmd.Flags().StringVar(&sourceFile, "source-file", "", "Path to source file content for deterministic patch preview")
+	cmd.Flags().StringVar(&sourceContent, "source-content", "", "Inline source content for deterministic patch preview")
+	cmd.Flags().StringVar(&baseBranch, "base-branch", "", "Base branch for generated fix PR plan")
+	cmd.Flags().StringVar(&branchPrefix, "branch-prefix", "", "Branch prefix for generated fix PR plan")
+	cmd.Flags().StringVar(&findingURL, "finding-url", "", "URL to include in generated remediation context")
+	cmd.Flags().BoolVar(&requireFixPlan, "require-fix-plan", false, "Fail unless a deterministic fix PR plan can be produced")
+	cmd.Flags().StringVar(&outputFormat, "output", formatTable, "Output format: table|json")
+	return cmd
+}
+
+func validateRepoScanMode(mode string) error {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "", "quick", "delta", "deep":
+		return nil
+	default:
+		return fmt.Errorf("--scan-mode must be quick, delta, or deep")
+	}
+}
+
+func normalizeCLIStringSlice(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		for _, part := range strings.Split(value, ",") {
+			trimmed := strings.TrimSpace(part)
+			if trimmed != "" {
+				normalized = append(normalized, trimmed)
+			}
+		}
+	}
+	return normalized
+}
+
+func addCLIQuery(query url.Values, key string, value string) {
+	if normalized := strings.TrimSpace(value); normalized != "" {
+		query.Set(key, normalized)
+	}
+}
+
+func addCLIQueryInt(query url.Values, key string, value int) {
+	if value > 0 {
+		query.Set(key, fmt.Sprintf("%d", value))
+	}
+}
+
+func renderRepoScanQueuedOutput(out io.Writer, scan db.RepoScanRecord) error {
+	_, err := fmt.Fprintf(
+		out,
+		"Repo scan queued: id=%s repo=%s status=%s mode=%s\n",
+		scan.ID,
+		scan.Repository,
+		scan.Status,
+		formatOptionalString(scan.ScanMode, "deep"),
+	)
+	return err
+}
+
+func renderRepoScanCanceledOutput(out io.Writer, scan db.RepoScanRecord) error {
+	_, err := fmt.Fprintf(
+		out,
+		"Repo scan canceled: id=%s repo=%s status=%s\n",
+		scan.ID,
+		scan.Repository,
+		scan.Status,
+	)
+	return err
+}
+
+func renderRepoScanListOutput(out io.Writer, response repoScanPageCLIResponse) error {
+	if _, err := fmt.Fprintf(out, "Repo scans: %d\n", len(response.Items)); err != nil {
+		return err
+	}
+	if len(response.Items) == 0 {
+		if _, err := fmt.Fprintln(out, "No repository scans."); err != nil {
+			return err
+		}
+	} else {
+		for i, scan := range response.Items {
+			if err := renderRepoScanRecordLine(out, i+1, scan); err != nil {
+				return err
+			}
+		}
+	}
+	if response.NextCursor != "" {
+		_, err := fmt.Fprintf(out, "Next cursor: %s\n", response.NextCursor)
+		return err
+	}
+	return nil
+}
+
+func renderRepoScanRecordOutput(out io.Writer, scan db.RepoScanRecord) error {
+	if err := renderRepoScanRecordLine(out, 1, scan); err != nil {
+		return err
+	}
+	if scan.ErrorMessage != "" {
+		_, err := fmt.Fprintf(out, "   error=%s\n", scan.ErrorMessage)
+		return err
+	}
+	return nil
+}
+
+func renderRepoScanRecordLine(out io.Writer, index int, scan db.RepoScanRecord) error {
+	finished := "running"
+	if scan.FinishedAt != nil {
+		finished = scan.FinishedAt.Format(time.RFC3339)
+	}
+	_, err := fmt.Fprintf(
+		out,
+		"%d. %s repo=%s status=%s mode=%s findings=%d files=%d commits=%d finished=%s\n",
+		index,
+		scan.ID,
+		scan.Repository,
+		scan.Status,
+		formatOptionalString(scan.ScanMode, "deep"),
+		scan.FindingCount,
+		scan.FilesScanned,
+		scan.CommitsScanned,
+		finished,
+	)
+	return err
+}
+
+func renderRepoFindingsListOutput(out io.Writer, response repoFindingPageCLIResponse) error {
+	if response.Summary != nil {
+		if _, err := fmt.Fprintf(
+			out,
+			"Repo findings: %d listed | open=%d fixed=%d reopened=%d suppressed=%d sla_aged=%d\n",
+			len(response.Items),
+			response.Summary.TotalOpen,
+			response.Summary.FixedCount,
+			response.Summary.ReopenedCount,
+			response.Summary.SuppressedCount,
+			response.Summary.SLAAgedCount,
+		); err != nil {
+			return err
+		}
+	} else if _, err := fmt.Fprintf(out, "Repo findings: %d\n", len(response.Items)); err != nil {
+		return err
+	}
+	if len(response.Items) == 0 {
+		if _, err := fmt.Fprintln(out, "No repository findings."); err != nil {
+			return err
+		}
+	} else {
+		for i, finding := range response.Items {
+			if err := renderRepoFindingLine(out, i+1, finding); err != nil {
+				return err
+			}
+		}
+	}
+	if response.NextCursor != "" {
+		_, err := fmt.Fprintf(out, "Next cursor: %s\n", response.NextCursor)
+		return err
+	}
+	return nil
+}
+
+func renderRepoFindingLine(out io.Writer, index int, finding domain.Finding) error {
+	location := finding.Repository
+	if finding.FilePath != "" {
+		location = strings.Trim(strings.Join([]string{finding.Repository, finding.FilePath}, " "), " ")
+		if finding.LineNumber > 0 {
+			location = fmt.Sprintf("%s:%d", location, finding.LineNumber)
+		}
+	}
+	if strings.TrimSpace(location) == "" {
+		location = "unknown location"
+	}
+	if _, err := fmt.Fprintf(
+		out,
+		"%d. [%s] %s (%s)\n",
+		index,
+		strings.ToUpper(string(finding.Severity)),
+		finding.Title,
+		finding.Type,
+	); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(
+		out,
+		"   %s detector=%s status=%s confidence=%.2f owner=%s\n   %s\n",
+		location,
+		formatOptionalString(finding.Detector, "unknown"),
+		formatOptionalString(string(finding.LifecycleStatus), "open"),
+		finding.ConfidenceScore,
+		formatOptionalString(finding.Owner, "unassigned"),
+		finding.HumanSummary,
+	)
+	return err
+}
+
+func renderRepoRiskGraphOutput(out io.Writer, graph domain.RepoRiskGraph) error {
+	if _, err := fmt.Fprintf(
+		out,
+		"Repo risk graph: repo=%s findings=%d nodes=%d edges=%d high_risk=%d critical=%d unknown_nodes=%d unknown_edges=%d\n",
+		formatOptionalString(graph.Repository, "all"),
+		graph.Summary.FindingCount,
+		graph.Summary.NodeCount,
+		graph.Summary.EdgeCount,
+		graph.Summary.HighRiskFindings,
+		graph.Summary.CriticalFindings,
+		graph.Summary.UnknownNodeCount,
+		graph.Summary.UnknownEdgeCount,
+	); err != nil {
+		return err
+	}
+	if len(graph.Scores) == 0 {
+		_, err := fmt.Fprintln(out, "No scored findings.")
+		return err
+	}
+	scores := append([]domain.RepoRiskGraphFindingScore(nil), graph.Scores...)
+	sort.SliceStable(scores, func(i, j int) bool {
+		return scores[i].Score > scores[j].Score
+	})
+	limit := len(scores)
+	if limit > 5 {
+		limit = 5
+	}
+	for i := 0; i < limit; i++ {
+		score := scores[i]
+		unknowns := "none"
+		if len(score.Unknowns) > 0 {
+			unknowns = strings.Join(score.Unknowns, ",")
+		}
+		if _, err := fmt.Fprintf(
+			out,
+			"%d. finding=%s score=%d severity=%s confidence=%.2f unknowns=%s\n",
+			i+1,
+			score.FindingID,
+			score.Score,
+			score.Severity,
+			score.Confidence,
+			unknowns,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func renderRepoPostureOutput(out io.Writer, response api.GitHubRepositoryPostureResponse) error {
+	posture := response.Posture
+	insecure, limited, unavailable := countPostureStates(posture.Checks)
+	if _, err := fmt.Fprintf(
+		out,
+		"GitHub posture: repo=%s connector=%s provider=%s checks=%d insecure=%d permission_limited=%d unavailable=%d collected_at=%s\n",
+		posture.Repository,
+		response.ConnectorID,
+		response.Provider,
+		len(posture.Checks),
+		insecure,
+		limited,
+		unavailable,
+		posture.CollectedAt.Format(time.RFC3339),
+	); err != nil {
+		return err
+	}
+	if len(posture.Checks) == 0 {
+		_, err := fmt.Fprintln(out, "No posture checks.")
+		return err
+	}
+	for i, check := range posture.Checks {
+		if _, err := fmt.Fprintf(
+			out,
+			"%d. [%s] %s/%s - %s\n",
+			i+1,
+			strings.ToUpper(string(check.State)),
+			check.Category,
+			check.ID,
+			check.Summary,
+		); err != nil {
+			return err
+		}
+		if strings.TrimSpace(check.Reason) != "" {
+			if _, err := fmt.Fprintf(out, "   reason=%s\n", check.Reason); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func countPostureStates(checks []githubconnector.RepositoryPostureCheck) (int, int, int) {
+	var insecure, limited, unavailable int
+	for _, check := range checks {
+		switch check.State {
+		case githubconnector.RepositoryPostureStateInsecure:
+			insecure++
+		case githubconnector.RepositoryPostureStatePermissionLimited:
+			limited++
+		case githubconnector.RepositoryPostureStateUnavailable:
+			unavailable++
+		}
+	}
+	return insecure, limited, unavailable
+}
+
+func renderRepoRemediationPreviewOutput(out io.Writer, response api.RepoFindingRemediationPreview) error {
+	remediation := response.Remediation
+	if _, err := fmt.Fprintf(
+		out,
+		"Repo remediation: finding=%s detector=%s publishable=%t fix_plan=%t\n",
+		response.Finding.ID,
+		remediation.Detector,
+		remediation.Publishable,
+		response.FixPRPlan != nil,
+	); err != nil {
+		return err
+	}
+	if strings.TrimSpace(remediation.RiskSummary) != "" {
+		if _, err := fmt.Fprintf(out, "Risk: %s\n", remediation.RiskSummary); err != nil {
+			return err
+		}
+	}
+	if len(remediation.Steps) > 0 {
+		if _, err := fmt.Fprintln(out, "Steps:"); err != nil {
+			return err
+		}
+		for _, step := range remediation.Steps {
+			if _, err := fmt.Fprintf(out, "- %s\n", step); err != nil {
+				return err
+			}
+		}
+	}
+	if len(remediation.SafetyNotes) > 0 {
+		if _, err := fmt.Fprintln(out, "Safety notes:"); err != nil {
+			return err
+		}
+		for _, note := range remediation.SafetyNotes {
+			if _, err := fmt.Fprintf(out, "- %s\n", note); err != nil {
+				return err
+			}
+		}
+	}
+	if response.FixPRPlan != nil {
+		_, err := fmt.Fprintf(
+			out,
+			"Fix PR plan: branch=%s base=%s files=%d title=%s\n",
+			response.FixPRPlan.BranchName,
+			response.FixPRPlan.BaseBranch,
+			len(response.FixPRPlan.Files),
+			response.FixPRPlan.PRTitle,
+		)
+		return err
+	}
+	if remediation.PublishBlockedReason != "" {
+		_, err := fmt.Fprintf(out, "Publish blocked: %s\n", remediation.PublishBlockedReason)
+		return err
+	}
+	return nil
+}
+
+func formatOptionalString(value string, fallback string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return fallback
+	}
+	return trimmed
+}

--- a/internal/cli/repo_intelligence.go
+++ b/internal/cli/repo_intelligence.go
@@ -29,6 +29,8 @@ type cliAPIOptions struct {
 	Timeout     time.Duration
 }
 
+const defaultCLIAPITimeout = 10 * time.Second
+
 type cliAPIErrorResponse struct {
 	Error string `json:"error"`
 }
@@ -54,7 +56,7 @@ func defaultCLIAPIOptions(cfg config.Config) cliAPIOptions {
 		APIKey:      strings.TrimSpace(os.Getenv("IDENTRAIL_API_KEY")),
 		TenantID:    strings.TrimSpace(cfg.DefaultTenantID),
 		WorkspaceID: strings.TrimSpace(cfg.DefaultWorkspaceID),
-		Timeout:     10 * time.Second,
+		Timeout:     defaultCLIAPITimeout,
 	}
 }
 
@@ -64,6 +66,17 @@ func bindCLIAPIFlags(cmd *cobra.Command, options *cliAPIOptions, apiKeyUse strin
 	cmd.Flags().StringVar(&options.TenantID, "tenant-id", options.TenantID, "Tenant scope header")
 	cmd.Flags().StringVar(&options.WorkspaceID, "workspace-id", options.WorkspaceID, "Workspace scope header")
 	cmd.Flags().DurationVar(&options.Timeout, "timeout", options.Timeout, "HTTP timeout")
+}
+
+func normalizeCLIAPITimeout(timeout time.Duration) time.Duration {
+	if timeout <= 0 {
+		return defaultCLIAPITimeout
+	}
+	return timeout
+}
+
+func newCLIAPIRequestContext(options cliAPIOptions) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), normalizeCLIAPITimeout(options.Timeout))
 }
 
 func doCLIAPIRequest(ctx context.Context, options cliAPIOptions, method string, path string, query url.Values, payload any, response any) error {
@@ -103,11 +116,7 @@ func doCLIAPIRequest(ctx context.Context, options cliAPIOptions, method string, 
 		req.Header.Set("X-Identrail-Workspace-ID", normalizedWorkspace)
 	}
 
-	timeout := options.Timeout
-	if timeout <= 0 {
-		timeout = 10 * time.Second
-	}
-	resp, err := (&http.Client{Timeout: timeout}).Do(req)
+	resp, err := (&http.Client{Timeout: normalizeCLIAPITimeout(options.Timeout)}).Do(req)
 	if err != nil {
 		return fmt.Errorf("api request failed: %w", err)
 	}
@@ -181,7 +190,7 @@ func buildRepoScanQueueCmd(cfg config.Config, out io.Writer) *cobra.Command {
 				MaxFindings:  maxFindings,
 			}
 			var response repoScanCLIResponse
-			ctx, cancel := context.WithTimeout(context.Background(), options.Timeout)
+			ctx, cancel := newCLIAPIRequestContext(options)
 			defer cancel()
 			if err := doCLIAPIRequest(ctx, options, http.MethodPost, "/v1/repo-scans", nil, request, &response); err != nil {
 				return err
@@ -236,7 +245,7 @@ func buildRepoScanListCmd(cfg config.Config, out io.Writer) *cobra.Command {
 			addCLIQuery(query, "sort_order", sortOrder)
 
 			var response repoScanPageCLIResponse
-			ctx, cancel := context.WithTimeout(context.Background(), options.Timeout)
+			ctx, cancel := newCLIAPIRequestContext(options)
 			defer cancel()
 			if err := doCLIAPIRequest(ctx, options, http.MethodGet, "/v1/repo-scans", query, nil, &response); err != nil {
 				return err
@@ -271,7 +280,7 @@ func buildRepoScanShowCmd(cfg config.Config, out io.Writer) *cobra.Command {
 				return err
 			}
 			var response db.RepoScanRecord
-			ctx, cancel := context.WithTimeout(context.Background(), options.Timeout)
+			ctx, cancel := newCLIAPIRequestContext(options)
 			defer cancel()
 			path := "/v1/repo-scans/" + url.PathEscape(strings.TrimSpace(args[0]))
 			if err := doCLIAPIRequest(ctx, options, http.MethodGet, path, nil, nil, &response); err != nil {
@@ -303,7 +312,7 @@ func buildRepoScanCancelCmd(cfg config.Config, out io.Writer) *cobra.Command {
 				return err
 			}
 			var response repoScanCLIResponse
-			ctx, cancel := context.WithTimeout(context.Background(), options.Timeout)
+			ctx, cancel := newCLIAPIRequestContext(options)
 			defer cancel()
 			path := "/v1/repo-scans/" + url.PathEscape(strings.TrimSpace(args[0])) + "/cancel"
 			if err := doCLIAPIRequest(ctx, options, http.MethodPost, path, nil, nil, &response); err != nil {
@@ -386,7 +395,7 @@ func buildRepoFindingsListCmd(cfg config.Config, out io.Writer) *cobra.Command {
 			addCLIQuery(query, "sort_order", sortOrder)
 
 			var response repoFindingPageCLIResponse
-			ctx, cancel := context.WithTimeout(context.Background(), options.Timeout)
+			ctx, cancel := newCLIAPIRequestContext(options)
 			defer cancel()
 			if err := doCLIAPIRequest(ctx, options, http.MethodGet, "/v1/repo-findings", query, nil, &response); err != nil {
 				return err
@@ -443,7 +452,7 @@ func buildRepoRiskGraphCmd(cfg config.Config, out io.Writer) *cobra.Command {
 			addCLIQuery(query, "type", findingType)
 
 			var graph domain.RepoRiskGraph
-			ctx, cancel := context.WithTimeout(context.Background(), options.Timeout)
+			ctx, cancel := newCLIAPIRequestContext(options)
 			defer cancel()
 			if err := doCLIAPIRequest(ctx, options, http.MethodGet, "/v1/repo-risk-graph", query, nil, &graph); err != nil {
 				return err
@@ -498,7 +507,7 @@ func buildRepoPostureCmd(cfg config.Config, out io.Writer) *cobra.Command {
 			path := "/v1/connectors/github/" + url.PathEscape(strings.TrimSpace(connectorID)) + "/posture"
 
 			var response api.GitHubRepositoryPostureResponse
-			ctx, cancel := context.WithTimeout(context.Background(), options.Timeout)
+			ctx, cancel := newCLIAPIRequestContext(options)
 			defer cancel()
 			if err := doCLIAPIRequest(ctx, options, http.MethodGet, path, query, nil, &response); err != nil {
 				return err
@@ -573,7 +582,7 @@ func buildRepoRemediationPreviewCmd(cfg config.Config, out io.Writer) *cobra.Com
 			path := "/v1/repo-findings/" + url.PathEscape(strings.TrimSpace(args[0])) + "/remediation/preview"
 
 			var response api.RepoFindingRemediationPreview
-			ctx, cancel := context.WithTimeout(context.Background(), options.Timeout)
+			ctx, cancel := newCLIAPIRequestContext(options)
 			defer cancel()
 			if err := doCLIAPIRequest(ctx, options, http.MethodPost, path, query, request, &response); err != nil {
 				return err

--- a/internal/cli/repo_intelligence_test.go
+++ b/internal/cli/repo_intelligence_test.go
@@ -1,0 +1,311 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/api"
+	"github.com/identrail/identrail/internal/config"
+	githubconnector "github.com/identrail/identrail/internal/connectors/github"
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/findings/standards"
+	"github.com/identrail/identrail/internal/remediation/fixpr"
+)
+
+func TestExecuteRepoScanQueueCallsAPI(t *testing.T) {
+	cfg := config.Config{DefaultTenantID: "tenant-a", DefaultWorkspaceID: "workspace-a"}
+	startedAt := time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST request, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/repo-scans" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		assertRepoIntelligenceHeaders(t, r)
+		var request api.RepoScanRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode queue request: %v", err)
+		}
+		if request.Repository != "identrail/identrail" || request.ProjectID != "project-1" || request.ConnectorID != "github-app" {
+			t.Fatalf("unexpected queue request: %+v", request)
+		}
+		if request.ScanMode != "delta" || request.HeadRevision != "abc123" || len(request.ChangedPaths) != 1 || request.ChangedPaths[0] != ".github/workflows/ci.yml" {
+			t.Fatalf("unexpected delta request metadata: %+v", request)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(repoScanCLIResponse{
+			RepoScan: db.RepoScanRecord{
+				ID:         "11111111-1111-1111-1111-111111111111",
+				Repository: "identrail/identrail",
+				Status:     "queued",
+				StartedAt:  startedAt,
+				ScanMode:   "delta",
+			},
+		})
+	}))
+	defer server.Close()
+
+	var out bytes.Buffer
+	err := Execute(cfg, []string{
+		"repo-scan", "queue",
+		"--api-url", server.URL,
+		"--api-key", "admin-key",
+		"--tenant-id", "tenant-a",
+		"--workspace-id", "workspace-a",
+		"--repo", "identrail/identrail",
+		"--project-id", "project-1",
+		"--connector-id", "github-app",
+		"--scan-mode", "delta",
+		"--head-revision", "abc123",
+		"--changed-path", ".github/workflows/ci.yml",
+		"--history-limit", "50",
+		"--max-findings", "20",
+	}, &out)
+	if err != nil {
+		t.Fatalf("repo scan queue failed: %v", err)
+	}
+	if !strings.Contains(out.String(), "Repo scan queued: id=11111111-1111-1111-1111-111111111111 repo=identrail/identrail status=queued mode=delta") {
+		t.Fatalf("unexpected queue output: %q", out.String())
+	}
+}
+
+func TestExecuteRepoScanListShowAndCancel(t *testing.T) {
+	cfg := config.Config{DefaultTenantID: "tenant-a", DefaultWorkspaceID: "workspace-a"}
+	startedAt := time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC)
+	scan := db.RepoScanRecord{
+		ID:             "22222222-2222-2222-2222-222222222222",
+		Repository:     "identrail/identrail",
+		Status:         "running",
+		StartedAt:      startedAt,
+		CommitsScanned: 5,
+		FilesScanned:   7,
+		FindingCount:   2,
+		ScanMode:       "deep",
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRepoIntelligenceHeaders(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/repo-scans":
+			if r.URL.Query().Get("limit") != "2" {
+				t.Fatalf("expected limit query, got %s", r.URL.RawQuery)
+			}
+			_ = json.NewEncoder(w).Encode(repoScanPageCLIResponse{Items: []db.RepoScanRecord{scan}, NextCursor: "2"})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/repo-scans/"+scan.ID:
+			_ = json.NewEncoder(w).Encode(scan)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/repo-scans/"+scan.ID+"/cancel":
+			scan.Status = "failed"
+			_ = json.NewEncoder(w).Encode(repoScanCLIResponse{RepoScan: scan})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "list", args: []string{"repo-scan", "list", "--api-url", server.URL, "--api-key", "admin-key", "--tenant-id", "tenant-a", "--workspace-id", "workspace-a", "--limit", "2"}, want: "Repo scans: 1"},
+		{name: "show", args: []string{"repo-scan", "show", scan.ID, "--api-url", server.URL, "--api-key", "admin-key", "--tenant-id", "tenant-a", "--workspace-id", "workspace-a"}, want: scan.ID},
+		{name: "cancel", args: []string{"repo-scan", "cancel", scan.ID, "--api-url", server.URL, "--api-key", "admin-key", "--tenant-id", "tenant-a", "--workspace-id", "workspace-a"}, want: "Repo scan canceled"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			if err := Execute(cfg, tc.args, &out); err != nil {
+				t.Fatalf("%s failed: %v", tc.name, err)
+			}
+			if !strings.Contains(out.String(), tc.want) {
+				t.Fatalf("expected %q in output, got %q", tc.want, out.String())
+			}
+		})
+	}
+}
+
+func TestExecuteRepoFindingsAndRiskGraphCommands(t *testing.T) {
+	cfg := config.Config{DefaultTenantID: "tenant-a", DefaultWorkspaceID: "workspace-a"}
+	now := time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC)
+	finding := domain.Finding{
+		ID:              "finding-1",
+		ScanID:          "33333333-3333-3333-3333-333333333333",
+		Type:            domain.FindingRepoMisconfig,
+		Severity:        domain.SeverityHigh,
+		ConfidenceScore: 0.91,
+		Title:           "Workflow token can write broadly",
+		HumanSummary:    "The workflow grants broad write permissions.",
+		Repository:      "identrail/identrail",
+		FilePath:        ".github/workflows/ci.yml",
+		LineNumber:      9,
+		Detector:        "workflow_broad_token_permissions",
+		LifecycleStatus: domain.RepoFindingLifecycleOpen,
+		Owner:           "platform",
+		CreatedAt:       now,
+	}
+	graph := domain.RepoRiskGraph{
+		Repository: "identrail/identrail",
+		Summary: domain.RepoRiskGraphSummary{
+			FindingCount:     1,
+			NodeCount:        2,
+			EdgeCount:        1,
+			HighRiskFindings: 1,
+		},
+		Scores: []domain.RepoRiskGraphFindingScore{{
+			FindingID:  finding.ID,
+			Score:      88,
+			Severity:   domain.SeverityHigh,
+			Confidence: 0.91,
+		}},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRepoIntelligenceHeaders(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/repo-findings":
+			if r.URL.Query().Get("repository") != "identrail/identrail" || r.URL.Query().Get("repo_lifecycle_status") != "open" {
+				t.Fatalf("unexpected findings query: %s", r.URL.RawQuery)
+			}
+			_ = json.NewEncoder(w).Encode(repoFindingPageCLIResponse{
+				Items: []domain.Finding{finding},
+				Summary: &api.RepoFindingsSummary{
+					TotalOpen:  1,
+					ByOwner:    map[string]int{"platform": 1},
+					ByDetector: map[string]int{"workflow_broad_token_permissions": 1},
+					BySeverity: map[string]int{"high": 1},
+				},
+			})
+		case "/v1/repo-risk-graph":
+			if r.URL.Query().Get("repository") != "identrail/identrail" {
+				t.Fatalf("unexpected graph query: %s", r.URL.RawQuery)
+			}
+			_ = json.NewEncoder(w).Encode(graph)
+		default:
+			t.Fatalf("unexpected request %s", r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "findings", args: []string{"repo-findings", "list", "--api-url", server.URL, "--api-key", "admin-key", "--tenant-id", "tenant-a", "--workspace-id", "workspace-a", "--repo", "identrail/identrail", "--status", "open"}, want: "Workflow token can write broadly"},
+		{name: "graph", args: []string{"repo-risk-graph", "--api-url", server.URL, "--api-key", "admin-key", "--tenant-id", "tenant-a", "--workspace-id", "workspace-a", "--repo", "identrail/identrail"}, want: "Repo risk graph: repo=identrail/identrail findings=1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			if err := Execute(cfg, tc.args, &out); err != nil {
+				t.Fatalf("%s failed: %v", tc.name, err)
+			}
+			if !strings.Contains(out.String(), tc.want) {
+				t.Fatalf("expected %q in output, got %q", tc.want, out.String())
+			}
+		})
+	}
+}
+
+func TestExecuteRepoPostureAndRemediationCommands(t *testing.T) {
+	cfg := config.Config{DefaultTenantID: "tenant-a", DefaultWorkspaceID: "workspace-a"}
+	now := time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRepoIntelligenceHeaders(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/connectors/github/github-app/posture":
+			if r.URL.Query().Get("workspace_id") != "workspace-a" || r.URL.Query().Get("project_id") != "project-1" || r.URL.Query().Get("repository") != "identrail/identrail" {
+				t.Fatalf("unexpected posture query: %s", r.URL.RawQuery)
+			}
+			_ = json.NewEncoder(w).Encode(api.GitHubRepositoryPostureResponse{
+				ConnectorID: "github-app",
+				Provider:    "github_app",
+				Posture: githubconnector.RepositoryPosture{
+					Repository:  "identrail/identrail",
+					CollectedAt: now,
+					Checks: []githubconnector.RepositoryPostureCheck{{
+						ID:       "branch_protection",
+						Category: "default_branch",
+						State:    githubconnector.RepositoryPostureStateInsecure,
+						Summary:  "Default branch protection is missing required reviews.",
+						Reason:   "required pull request reviews are disabled",
+					}},
+				},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/repo-findings/finding-1/remediation/preview":
+			if r.URL.Query().Get("repo_scan_id") != "33333333-3333-3333-3333-333333333333" {
+				t.Fatalf("unexpected remediation query: %s", r.URL.RawQuery)
+			}
+			var request api.RepoFindingRemediationPreviewRequest
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatalf("decode remediation request: %v", err)
+			}
+			if request.BaseBranch != "dev" || !request.RequireFixPlan {
+				t.Fatalf("unexpected remediation request: %+v", request)
+			}
+			_ = json.NewEncoder(w).Encode(api.RepoFindingRemediationPreview{
+				Finding: domain.Finding{
+					ID:        "finding-1",
+					Type:      domain.FindingRepoMisconfig,
+					Severity:  domain.SeverityHigh,
+					Title:     "Workflow token can write broadly",
+					CreatedAt: now,
+				},
+				Remediation: standards.RepoExposureRemediation{
+					Detector:    "workflow_write_all_permissions",
+					RiskSummary: "Workflow token permissions are too broad.",
+					Steps:       []string{"Set workflow permissions to read by default."},
+					SafetyNotes: []string{"Review deploy jobs before applying."},
+					Publishable: true,
+				},
+				FixPRPlan: &fixpr.FixPRPlan{
+					BaseBranch: "dev",
+					BranchName: "identrail/fix/finding-1",
+					PRTitle:    "Harden workflow permissions",
+					Files:      []fixpr.PlanFile{{Path: ".github/workflows/ci.yml", Content: "permissions: read-all\n"}},
+				},
+			})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "posture", args: []string{"repo-posture", "--api-url", server.URL, "--api-key", "admin-key", "--tenant-id", "tenant-a", "--workspace-id", "workspace-a", "--connector-id", "github-app", "--project-id", "project-1", "--repo", "identrail/identrail"}, want: "GitHub posture: repo=identrail/identrail connector=github-app"},
+		{name: "remediation", args: []string{"repo-remediation", "preview", "finding-1", "--api-url", server.URL, "--api-key", "admin-key", "--tenant-id", "tenant-a", "--workspace-id", "workspace-a", "--repo-scan-id", "33333333-3333-3333-3333-333333333333", "--base-branch", "dev", "--require-fix-plan"}, want: "Fix PR plan: branch=identrail/fix/finding-1 base=dev files=1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			if err := Execute(cfg, tc.args, &out); err != nil {
+				t.Fatalf("%s failed: %v", tc.name, err)
+			}
+			if !strings.Contains(out.String(), tc.want) {
+				t.Fatalf("expected %q in output, got %q", tc.want, out.String())
+			}
+		})
+	}
+}
+
+func assertRepoIntelligenceHeaders(t *testing.T, r *http.Request) {
+	t.Helper()
+	if got := strings.TrimSpace(r.Header.Get("X-API-Key")); got != "admin-key" {
+		t.Fatalf("expected api key header, got %q", got)
+	}
+	if got := strings.TrimSpace(r.Header.Get("X-Identrail-Tenant-ID")); got != "tenant-a" {
+		t.Fatalf("expected tenant header, got %q", got)
+	}
+	if got := strings.TrimSpace(r.Header.Get("X-Identrail-Workspace-ID")); got != "workspace-a" {
+		t.Fatalf("expected workspace header, got %q", got)
+	}
+}

--- a/internal/cli/repo_intelligence_test.go
+++ b/internal/cli/repo_intelligence_test.go
@@ -59,6 +59,7 @@ func TestExecuteRepoScanQueueCallsAPI(t *testing.T) {
 		"--api-key", "admin-key",
 		"--tenant-id", "tenant-a",
 		"--workspace-id", "workspace-a",
+		"--timeout", "0",
 		"--repo", "identrail/identrail",
 		"--project-id", "project-1",
 		"--connector-id", "github-app",
@@ -73,6 +74,17 @@ func TestExecuteRepoScanQueueCallsAPI(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "Repo scan queued: id=11111111-1111-1111-1111-111111111111 repo=identrail/identrail status=queued mode=delta") {
 		t.Fatalf("unexpected queue output: %q", out.String())
+	}
+}
+
+func TestNormalizeCLIAPITimeoutFallsBackForNonPositiveValues(t *testing.T) {
+	for _, timeout := range []time.Duration{0, -time.Second} {
+		if got := normalizeCLIAPITimeout(timeout); got != defaultCLIAPITimeout {
+			t.Fatalf("expected default timeout for %s, got %s", timeout, got)
+		}
+	}
+	if got := normalizeCLIAPITimeout(3 * time.Second); got != 3*time.Second {
+		t.Fatalf("expected explicit timeout, got %s", got)
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -61,7 +61,11 @@ func BuildRootCmd(cfg config.Config, out io.Writer) *cobra.Command {
 	root.AddCommand(buildScanCmd(cfg, out, &stateFile))
 	root.AddCommand(buildScanReplayCmd(cfg, out))
 	root.AddCommand(buildFindingsCmd(out, &stateFile))
-	root.AddCommand(buildRepoScanCmd(out))
+	root.AddCommand(buildRepoScanCmd(cfg, out))
+	root.AddCommand(buildRepoFindingsCmd(cfg, out))
+	root.AddCommand(buildRepoRiskGraphCmd(cfg, out))
+	root.AddCommand(buildRepoPostureCmd(cfg, out))
+	root.AddCommand(buildRepoRemediationCmd(cfg, out))
 	root.AddCommand(buildAuthzCmd(cfg, out))
 
 	return root
@@ -241,7 +245,7 @@ func buildScanReplayCmd(cfg config.Config, out io.Writer) *cobra.Command {
 	return cmd
 }
 
-func buildRepoScanCmd(out io.Writer) *cobra.Command {
+func buildRepoScanCmd(cfg config.Config, out io.Writer) *cobra.Command {
 	var (
 		repository   string
 		outputFormat string
@@ -302,6 +306,10 @@ func buildRepoScanCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&outputFormat, "output", formatTable, "Output format: table|json")
 	cmd.Flags().IntVar(&historyLimit, "history-limit", 500, "Maximum number of commits to inspect for history secret exposure")
 	cmd.Flags().IntVar(&maxFindings, "max-findings", 200, "Maximum findings to emit before truncating scan output")
+	cmd.AddCommand(buildRepoScanQueueCmd(cfg, out))
+	cmd.AddCommand(buildRepoScanListCmd(cfg, out))
+	cmd.AddCommand(buildRepoScanShowCmd(cfg, out))
+	cmd.AddCommand(buildRepoScanCancelCmd(cfg, out))
 	return cmd
 }
 


### PR DESCRIPTION
Fixes #1284
Refs #1227, #1228, #1229, #1230, #1231, #1232, #1233, #1234, #1235, #1236
Refs #1277

## What changed
- Added API-backed CLI commands for GitHub repository intelligence: hosted repo scan queue/list/show/cancel, repo findings list, repo risk graph, GitHub repository posture, and repo remediation preview.
- Kept the existing local `identrail repo-scan --repo ...` workflow working for local paths, URLs, and owner/repo targets.
- Added request/response tests for the new terminal commands, including API path, auth headers, scope headers, filters, payloads, and table output.
- Updated the CLI reference, repository exposure docs, and changelog.

## Why
The GitHub intelligence engine and app surfaces were already merged, but the terminal only exposed the local repository scanner. This adds CLI parity by calling the same API surfaces the app uses instead of duplicating scanner logic.

## Impact and risk
- Operators can now drive hosted/private GitHub intelligence from the terminal using the same API auth, tenant, and workspace scope headers as existing API CLI commands.
- Existing local repository scan behavior remains backward compatible.
- The change is isolated to CLI command wiring, CLI tests, and docs; no API routes or scanner behavior changed.

## Validation
- `go test ./internal/cli`
- `go test ./internal/repoexposure ./internal/api ./internal/domain ./internal/remediation/fixpr ./internal/cli`
- `go vet ./internal/cli`
- `git diff --check`
- `go run ./cmd/cli scan identrail/identrail --help`
- `go run ./cmd/cli repo-scan queue --help`
- `go run ./cmd/cli repo-findings list --help`
- `go run ./cmd/cli repo-risk-graph --help`
- `go run ./cmd/cli repo-posture --help`
- `go run ./cmd/cli repo-remediation preview --help`

## AI-assisted disclosure
- AI-assisted: yes
- Tools used: OpenAI coding assistant
- Where used: CLI implementation, tests, and documentation updates
- Human verification performed: reviewed the diff and ran the validation commands listed above
