### PR TITLE
Fix product trust graph label readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 - Redesigned the marketing pricing hero decision console and product trust
   graph visual with larger plan guidance, precise SVG path arrows, and clearer
   trust-path labels.
+- Fixed the product trust graph hero so risk badges remain readable and path
+  labels no longer collide with destination cards.
 - Replaced public demo calendar placeholders with the first-party demo booking
   form, including preferred day/time capture in lead delivery emails and
   clearer dark-page contrast for the demo booking and evidence panels.

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -353,6 +353,31 @@ describe('App', () => {
     expect(document.querySelector('.idt-product-hero-visual')).toHaveAttribute('aria-hidden', 'true');
     expect(document.querySelector('.idt-product-trust-svg')).toBeInTheDocument();
     expect(document.querySelectorAll('.idt-product-path-edge.is-active')).toHaveLength(3);
+    expect(document.querySelectorAll('.idt-product-node-badge.is-danger')).toHaveLength(2);
+    expect(document.querySelectorAll('.idt-product-node-status.is-risk')).toHaveLength(0);
+
+    const readSvgBox = (group: Element) => {
+      const [, x = '0', y = '0'] = group.getAttribute('transform')?.match(/translate\(([-.\d]+) ([-.\d]+)\)/) ?? [];
+      const rect = group.querySelector('rect');
+      return {
+        x: Number(x),
+        y: Number(y),
+        width: Number(rect?.getAttribute('width') ?? 0),
+        height: Number(rect?.getAttribute('height') ?? 0)
+      };
+    };
+    const overlaps = (a: ReturnType<typeof readSvgBox>, b: ReturnType<typeof readSvgBox>) =>
+      a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y;
+    const labelBoxes = [...document.querySelectorAll('.idt-product-path-tag')].map(readSvgBox);
+    const nodeBoxes = [...document.querySelectorAll('.idt-product-path-node')].map(readSvgBox);
+
+    expect(labelBoxes).toHaveLength(3);
+    expect(nodeBoxes).toHaveLength(4);
+    for (const labelBox of labelBoxes) {
+      for (const nodeBox of nodeBoxes) {
+        expect(overlaps(labelBox, nodeBox)).toBe(false);
+      }
+    }
   });
 
   it('renders read-only scan intake flow route', () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -881,13 +881,13 @@ function ProductHeroVisual() {
                   federates
                 </text>
               </g>
-              <g className="idt-product-path-tag" transform="translate(586 214)">
+              <g className="idt-product-path-tag" transform="translate(584 226)">
                 <rect width="108" height="30" rx="15" />
                 <text x="54" y="20">
                   assumes role
                 </text>
               </g>
-              <g className="idt-product-path-tag" transform="translate(580 338)">
+              <g className="idt-product-path-tag" transform="translate(520 326)">
                 <rect width="100" height="30" rx="15" />
                 <text x="50" y="20">
                   reaches data
@@ -902,9 +902,12 @@ function ProductHeroVisual() {
                 <text className="idt-product-node-title" x="18" y="50">
                   GitHub OIDC
                 </text>
-                <text className="idt-product-node-status is-good" x="18" y="68">
-                  Verified
-                </text>
+                <g className="idt-product-node-badge is-verified" transform="translate(18 56)">
+                  <rect width="72" height="18" rx="9" />
+                  <text x="36" y="13">
+                    Verified
+                  </text>
+                </g>
               </g>
               <g className="idt-product-path-node is-workload" transform="translate(370 230)">
                 <rect width="200" height="86" rx="10" />
@@ -914,9 +917,12 @@ function ProductHeroVisual() {
                 <text className="idt-product-node-title" x="18" y="52">
                   K8s service account
                 </text>
-                <text className="idt-product-node-status is-good" x="18" y="72">
-                  Namespace bridge
-                </text>
+                <g className="idt-product-node-badge is-verified" transform="translate(18 59)">
+                  <rect width="128" height="18" rx="9" />
+                  <text x="64" y="13">
+                    Namespace bridge
+                  </text>
+                </g>
               </g>
               <g className="idt-product-path-node is-privilege" transform="translate(668 136)">
                 <rect width="186" height="80" rx="10" />
@@ -926,9 +932,12 @@ function ProductHeroVisual() {
                 <text className="idt-product-node-title" x="18" y="50">
                   AWS Role
                 </text>
-                <text className="idt-product-node-status is-risk" x="18" y="68">
-                  High risk
-                </text>
+                <g className="idt-product-node-badge is-danger" transform="translate(18 56)">
+                  <rect width="78" height="18" rx="9" />
+                  <text x="39" y="13">
+                    High risk
+                  </text>
+                </g>
               </g>
               <g className="idt-product-path-node is-resource" transform="translate(626 340)">
                 <rect width="204" height="82" rx="10" />
@@ -938,9 +947,12 @@ function ProductHeroVisual() {
                 <text className="idt-product-node-title" x="18" y="51">
                   Billing datastore
                 </text>
-                <text className="idt-product-node-status is-risk" x="18" y="70">
-                  Critical target
-                </text>
+                <g className="idt-product-node-badge is-danger" transform="translate(18 58)">
+                  <rect width="116" height="18" rx="9" />
+                  <text x="58" y="13">
+                    Critical target
+                  </text>
+                </g>
               </g>
 
               <g className="idt-product-svg-card is-evidence" transform="translate(70 350)">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -22604,20 +22604,35 @@ html[data-theme='light'] .idt-product-page .idt-product-hero-graph {
   font-weight: 850;
 }
 
-.idt-product-node-status {
-  font-family: var(--idt-nav-font);
-  font-size: 13px;
-  font-weight: 850;
-  filter: none;
+.idt-product-page .idt-product-hero-graph .idt-product-node-badge rect {
   stroke: none;
+  filter: none;
 }
 
-.idt-product-node-status.is-good {
+.idt-product-page .idt-product-hero-graph .idt-product-node-badge text {
+  font-family: var(--idt-nav-font);
+  font-size: 11px;
+  font-weight: 850;
+  letter-spacing: 0;
+  text-anchor: middle;
+  stroke: none;
+  filter: none;
+}
+
+.idt-product-page .idt-product-hero-graph .idt-product-node-badge.is-verified rect {
+  fill: rgba(17, 199, 132, 0.12);
+}
+
+.idt-product-page .idt-product-hero-graph .idt-product-node-badge.is-verified text {
   fill: #11c784;
 }
 
-.idt-product-node-status.is-risk {
-  fill: #ff5252;
+.idt-product-page .idt-product-hero-graph .idt-product-node-badge.is-danger rect {
+  fill: rgba(255, 82, 82, 0.12);
+}
+
+.idt-product-page .idt-product-hero-graph .idt-product-node-badge.is-danger text {
+  fill: #ff6b6b;
 }
 
 .idt-product-svg-card rect {


### PR DESCRIPTION
Fixes #1282

## Summary
- Replace the product trust graph status text with scoped SVG badges so existing generic risk graph CSS cannot add the white stroke that washed out the labels.
- Move connector labels away from destination cards while keeping the three active arrow paths intact.
- Add a regression test for badge usage and path-label/node overlap.

## Impact
- Fixes the visual issue seen on the product hero graph without changing backend behavior.
- Keeps the follow-up scoped to the merged marketing graph surface.

## Validation
- npm test -- --run src/App.test.tsx
- npm run build
- Browser preview spot-check on /product: graph visible, 3 active connectors, 4 scoped badges, no generic risk-status text, no label/node overlap, no horizontal overflow.

## AI-assisted
No

## Tools used
None

## Human verification
Verified locally with tests, production build, and browser preview spot-check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve readability of the product trust graph by replacing status text with scoped SVG badges and repositioning path labels to avoid collisions. Removes the unintended white stroke from generic risk graph CSS without changing behavior.

- **Bug Fixes**
  - Introduced `.idt-product-node-badge` SVG groups with scoped styles (verified/danger) to prevent stroke/filter bleed.
  - Adjusted path label and badge positions to eliminate label-to-node overlap while keeping three active connectors.
  - Added regression test to verify badge usage, 3 active edges, 4 badges, and no label–node overlap.

<sup>Written for commit 34e04538676bb31973b22c383c70be9e2c8e2ad2. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1285?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

