### PR TITLE
Clarify first repository scan quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,22 +38,50 @@ Use it when you run AWS and/or Kubernetes workloads and want identity risk visib
 
 ## 5-Minute Quickstart
 
-### Scan a GitHub repository
+### Scan a public GitHub repository
 
-Install Identrail from a release binary or Docker image, or build it from
-source, then run your first repository scan:
+You can scan a public GitHub repository without creating an Identrail account or
+connecting the hosted app. With Docker:
+
+```bash
+docker run --rm ghcr.io/identrail/identrail-cli:dev scan owner/repo
+```
+
+Example:
+
+```bash
+docker run --rm ghcr.io/identrail/identrail-cli:dev scan identrail/identrail
+```
+
+If you installed the CLI from a release binary or source build, use:
 
 ```bash
 identrail scan owner/repo
 ```
 
-See [Install Identrail](./docs/install.md) for each install path.
+The scan prints repository exposure findings for secrets, GitHub Actions risk,
+and CI configuration issues. See [Install Identrail](./docs/install.md) for
+binary, Docker, and source install paths.
 
-Docker users can run the CLI without installing Go:
+### Scan a private repository locally
+
+Clone the private repository with your normal GitHub access, then scan the local
+checkout:
 
 ```bash
-docker run --rm ghcr.io/identrail/identrail-cli:dev scan owner/repo
+git clone git@github.com:owner/private-repo.git
+cd private-repo
+identrail scan .
 ```
+
+With Docker:
+
+```bash
+docker run --rm -v "$PWD:/repo" -w /repo ghcr.io/identrail/identrail-cli:dev scan .
+```
+
+For hosted, project-scoped private repository scans, connect the GitHub App in
+the Identrail web app and select the repository.
 
 ### Run the local dashboard
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,7 +6,7 @@ deployment guides.
 
 ## Recommended CLI usage
 
-Use the short repository scan form when you want to inspect one GitHub
+Use the short repository scan form when you want to inspect a public GitHub
 repository:
 
 ```bash
@@ -20,6 +20,24 @@ identrail scan identrail/identrail
 identrail scan owner/repo --history-limit 50 --max-findings 20
 identrail scan https://github.com/owner/repo.git --output json
 ```
+
+For a private repository, clone it first with your normal GitHub access and
+scan the local checkout:
+
+```bash
+git clone git@github.com:owner/private-repo.git
+cd private-repo
+identrail scan .
+```
+
+With Docker:
+
+```bash
+docker run --rm -v "$PWD:/repo" -w /repo ghcr.io/identrail/identrail-cli:dev scan .
+```
+
+Hosted private repository scans use the GitHub App connector in the Identrail
+web app.
 
 The longer command remains supported for scripts and backward compatibility:
 


### PR DESCRIPTION
Fixes #1286

## Summary

- Split the public README quickstart into explicit public-repository and private-local-repository scan paths.
- Put the Docker public repo command first so first-time users can try Identrail without installing Go or creating an account.
- Mirror the private repository local checkout guidance in `docs/install.md`.

## Impact and risk

Docs-only change. No CLI, API, worker, or web runtime behavior changes.

## Validation

- `git diff --check`
- Commit and push hooks: merge conflict check, end-of-file fix, trailing whitespace, gofmt check, go vet, local env token hygiene, Vercel artifact hygiene

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the 5‑minute quickstart by splitting public vs. private scan paths and putting the Docker public scan first so new users can try Identrail without an account. Adds local private‑repo steps (clone + scan .) with a Docker volume example and notes that hosted private scans use the GitHub App; mirrors the guidance in docs/install.md and addresses #1286.

<sup>Written for commit 2333d1a40e43cfe2ce6f9bb3a9acc32eec67bb15. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1287?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

