### PR TITLE
Polish app source onboarding controls

### DIFF
--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -379,6 +379,22 @@ describe('ProductProjectDetailPage', () => {
     );
   });
 
+  it('keeps advanced GitHub and scan policy controls collapsed until requested', async () => {
+    await renderProjectDetail(true);
+
+    expect(await screen.findByText('GitHub Enterprise fallback')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Personal access token/i)).not.toBeVisible();
+
+    fireEvent.click(screen.getByText('GitHub Enterprise fallback'));
+    expect(screen.getByLabelText(/Personal access token/i)).toBeVisible();
+
+    expect(screen.getByText('Scan policy editor')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Trigger mode/i)).not.toBeVisible();
+
+    fireEvent.click(screen.getByText('Scan policy editor'));
+    expect(screen.getByLabelText(/Trigger mode/i)).toBeVisible();
+  });
+
   it('loads GitHub repository posture for the selected app repository', async () => {
     const { getGitHubConnectorRepositoryPosture } = await renderProjectDetail(true);
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -3992,6 +3992,17 @@ export function ProductProjectDetailPage() {
   const connectedCount = sourceOrder.filter((provider) => sourceConnection(connections, provider)?.connected).length;
   const remainingCount = Math.max(actionableSourceOrder.length - connectedCount, 0);
   const activeStepIndex = selectedUnavailable ? 0 : selectedStatus?.connected ? 3 : submitting === selectedSource ? 2 : 1;
+  const selectedLifecycle = selectedUnavailable ? 'Unavailable' : connectionLifecycle(selectedStatus);
+  const selectedNextActionTitle = selectedUnavailable
+    ? 'Choose an available source'
+    : selectedStatus?.connected
+      ? `${selectedProfile.name} is ready`
+      : `Connect ${selectedProfile.name}`;
+  const selectedNextActionDescription = selectedUnavailable
+    ? selectedAvailability.unavailableMessage ?? `${selectedProfile.name} is not available on this API server.`
+    : selectedStatus?.connected
+      ? `Review ${selectedProfile.name} health, queue validation work, or refresh status before moving to findings.`
+      : `Use the guided ${selectedProfile.name} setup to collect the exact signals this project owns.`;
 
   const handleGitHubStart = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -4506,28 +4517,34 @@ export function ProductProjectDetailPage() {
         </button>
       </div>
 
-      <div className="idt-source-summary" aria-label="source connection summary">
-        <article className="is-light-surface">
-          <div className="idt-overview-metric-top">
-            <span>{connectedCount}</span>
-            <SourceLogoStack providers={actionableSourceOrder.length > 0 ? actionableSourceOrder : sourceOrder} label="Connected source count" />
+      <div className="idt-source-command-center" aria-label="source onboarding command center">
+        <article className="idt-source-next-action">
+          <div>
+            <p className="idt-app-kicker">Next action</p>
+            <h3>{selectedNextActionTitle}</h3>
+            <p>{selectedNextActionDescription}</p>
           </div>
-          <p>Active sources</p>
+          <span className={`idt-source-status-pill is-${sourceAvailabilityTone(selectedAvailability, selectedStatus)}`}>
+            {selectedLifecycle}
+          </span>
         </article>
-        <article>
-          <div className="idt-overview-metric-top">
-            <span>{remainingCount}</span>
-            <SourceLogoMark provider={selectedSource} />
+        <dl className="idt-source-compact-stats" aria-label="source connection summary">
+          <div>
+            <dt>Connected</dt>
+            <dd>{connectedCount}</dd>
           </div>
-          <p>Remaining</p>
-        </article>
-        <article>
-          <div className="idt-overview-metric-top">
-            <span>{selectedUnavailable ? 'Unavailable' : connectionLifecycle(selectedStatus)}</span>
-            <SourceLogoMark provider={selectedSource} />
+          <div>
+            <dt>Remaining</dt>
+            <dd>{remainingCount}</dd>
           </div>
-          <p>Selected status</p>
-        </article>
+          <div>
+            <dt>Source</dt>
+            <dd>
+              <SourceLogoMark provider={selectedSource} />
+              {selectedProfile.name}
+            </dd>
+          </div>
+        </dl>
       </div>
 
       {successMessage ? (
@@ -4626,8 +4643,13 @@ export function ProductProjectDetailPage() {
 
           {selectedSource === 'github' && !selectedUnavailable ? (
             <div className="idt-source-form-stack">
-              <form className="idt-app-form" onSubmit={handleGitHubStart}>
-                <div className="idt-source-inline-fields">
+              <article className="idt-source-install-card idt-source-primary-action">
+                <div>
+                  <p className="idt-app-kicker">Recommended setup</p>
+                  <h4>Install the GitHub App</h4>
+                  <p>Start with selected repository access, webhook validation, and owner-ready scan context.</p>
+                </div>
+                <form className="idt-app-form" onSubmit={handleGitHubStart}>
                   <label>
                     Display name
                     <input
@@ -4638,11 +4660,11 @@ export function ProductProjectDetailPage() {
                       placeholder="GitHub App"
                     />
                   </label>
-                </div>
-                <button className="idt-btn idt-btn-primary" type="submit" disabled={submitting !== ''}>
-                  {submitting === 'github' ? 'Preparing...' : 'Generate install link'}
-                </button>
-              </form>
+                  <button className="idt-btn idt-btn-primary" type="submit" disabled={submitting !== ''}>
+                    {submitting === 'github' ? 'Preparing...' : 'Generate install link'}
+                  </button>
+                </form>
+              </article>
 
               {githubStart ? (
                 <article className="idt-source-install-card">
@@ -4656,51 +4678,59 @@ export function ProductProjectDetailPage() {
                 </article>
               ) : null}
 
-              <form className="idt-app-form" onSubmit={handleGitHubPATSubmit}>
-                <div className="idt-source-inline-fields">
+              <details className="idt-source-advanced idt-source-enterprise-fallback">
+                <summary>
+                  <span>
+                    <strong>GitHub Enterprise fallback</strong>
+                    <small>Use only for self-hosted GitHub Server or restricted app-install environments.</small>
+                  </span>
+                </summary>
+                <form className="idt-app-form" onSubmit={handleGitHubPATSubmit}>
+                  <div className="idt-source-inline-fields">
+                    <label>
+                      Enterprise base URL
+                      <input
+                        value={githubPATForm.baseURL}
+                        onChange={(event) => setGitHubPATForm((current) => ({ ...current, baseURL: event.target.value }))}
+                        placeholder="https://github.company.com"
+                      />
+                    </label>
+                    <label>
+                      Display name
+                      <input
+                        value={githubPATForm.displayName}
+                        onChange={(event) =>
+                          setGitHubPATForm((current) => ({ ...current, displayName: event.target.value }))
+                        }
+                        placeholder="GitHub Enterprise"
+                      />
+                    </label>
+                  </div>
                   <label>
-                    Enterprise base URL
+                    Personal access token
                     <input
-                      value={githubPATForm.baseURL}
-                      onChange={(event) => setGitHubPATForm((current) => ({ ...current, baseURL: event.target.value }))}
-                      placeholder="https://github.company.com"
+                      type="password"
+                      value={githubPATForm.token}
+                      onChange={(event) => setGitHubPATForm((current) => ({ ...current, token: event.target.value }))}
+                      placeholder="GitHub Enterprise fallback token"
+                      required
                     />
                   </label>
                   <label>
-                    Display name
-                    <input
-                      value={githubPATForm.displayName}
+                    Repository allowlist
+                    <textarea
+                      value={githubPATForm.repositories}
                       onChange={(event) =>
-                        setGitHubPATForm((current) => ({ ...current, displayName: event.target.value }))
+                        setGitHubPATForm((current) => ({ ...current, repositories: event.target.value }))
                       }
-                      placeholder="GitHub Enterprise"
+                      placeholder="owner/repo, owner/security-platform"
                     />
                   </label>
-                </div>
-                <label>
-                  Personal access token
-                  <input
-                    type="password"
-                    value={githubPATForm.token}
-                    onChange={(event) => setGitHubPATForm((current) => ({ ...current, token: event.target.value }))}
-                    placeholder="GitHub Enterprise fallback token"
-                    required
-                  />
-                </label>
-                <label>
-                  Repository allowlist
-                  <textarea
-                    value={githubPATForm.repositories}
-                    onChange={(event) =>
-                      setGitHubPATForm((current) => ({ ...current, repositories: event.target.value }))
-                    }
-                    placeholder="owner/repo, owner/security-platform"
-                  />
-                </label>
-                <button className="idt-btn idt-btn-primary" type="submit" disabled={submitting !== ''}>
-                  {submitting === 'github' ? 'Validating...' : 'Save enterprise fallback'}
-                </button>
-              </form>
+                  <button className="idt-btn idt-btn-primary" type="submit" disabled={submitting !== ''}>
+                    {submitting === 'github' ? 'Validating...' : 'Save enterprise fallback'}
+                  </button>
+                </form>
+              </details>
 
               {connections.github?.connected ? (
                 <form className="idt-app-form idt-repo-scan-launch" onSubmit={handleRepoScanSubmit}>
@@ -4715,9 +4745,13 @@ export function ProductProjectDetailPage() {
                   </article>
 
                   {repoScanError ? (
-                    <p role="alert" className="idt-app-alert idt-app-alert-error">
-                      {repoScanError}
-                    </p>
+                    <article role="alert" className="idt-source-recovery-card">
+                      <strong>Scan could not start</strong>
+                      <p>{repoScanError}</p>
+                      <button className="idt-btn idt-btn-ghost" type="button" onClick={() => setRepoScanError('')}>
+                        Dismiss
+                      </button>
+                    </article>
                   ) : null}
 
                   <div className="idt-source-inline-fields">
@@ -5127,14 +5161,17 @@ export function ProductProjectDetailPage() {
         </div>
       </div>
 
-      <article className="idt-app-panel">
-        <div className="idt-source-onboarding-header">
-          <div>
-            <p className="idt-app-kicker">Automation policies</p>
-            <h3>Scan policy editor</h3>
-            <p>Define trigger mode, schedule cadence, and scan limits for this project.</p>
-          </div>
-        </div>
+      <article className="idt-app-panel idt-source-policy-panel">
+        <details>
+          <summary className="idt-source-policy-summary">
+            <div>
+              <p className="idt-app-kicker">Automation policies</p>
+              <h3>Scan policy editor</h3>
+              <p>Define trigger mode, schedule cadence, and scan limits for this project.</p>
+            </div>
+            <span className="idt-source-status-pill is-warning">Advanced</span>
+          </summary>
+          <div className="idt-source-policy-body">
 
         {scanPolicyError ? (
           <p role="alert" className="idt-app-alert idt-app-alert-error">
@@ -5295,6 +5332,8 @@ export function ProductProjectDetailPage() {
             {policySaving ? 'Saving policy...' : 'Save scan policy'}
           </button>
         </form>
+          </div>
+        </details>
       </article>
       <PermissionPreviewModal
         open={awsPreviewOpen}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -20090,6 +20090,84 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-form textarea {
   color: #ffffff;
 }
 
+.idt-app-console-layout input:not([type='checkbox']):not([type='radio']):not([type='range']),
+.idt-app-console-layout textarea,
+.idt-account-security-page input:not([type='checkbox']):not([type='radio']):not([type='range']),
+.idt-account-security-page textarea,
+.idt-executive-report-shell input:not([type='checkbox']):not([type='radio']):not([type='range']),
+.idt-executive-report-shell textarea,
+.idt-app-shell-screen input:not([type='checkbox']):not([type='radio']):not([type='range']),
+.idt-app-shell-screen textarea,
+html[data-theme='light'] .idt-app-console-layout input:not([type='checkbox']):not([type='radio']):not([type='range']),
+html[data-theme='light'] .idt-app-console-layout textarea,
+html[data-theme='light'] .idt-account-security-page input:not([type='checkbox']):not([type='radio']):not([type='range']),
+html[data-theme='light'] .idt-account-security-page textarea,
+html[data-theme='light'] .idt-executive-report-shell input:not([type='checkbox']):not([type='radio']):not([type='range']),
+html[data-theme='light'] .idt-executive-report-shell textarea,
+html[data-theme='light'] .idt-app-shell-screen input:not([type='checkbox']):not([type='radio']):not([type='range']),
+html[data-theme='light'] .idt-app-shell-screen textarea {
+  min-height: 2.95rem;
+  padding: 0.78rem 0.9rem;
+  border-color: var(--app-border);
+  border-radius: 8px;
+  background: #050505;
+  color: #ffffff;
+  font: inherit;
+  font-size: 0.95rem;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.idt-app-console-layout select,
+.idt-account-security-page select,
+.idt-executive-report-shell select,
+.idt-app-shell-screen select,
+html[data-theme='light'] .idt-app-console-layout select,
+html[data-theme='light'] .idt-account-security-page select,
+html[data-theme='light'] .idt-executive-report-shell select,
+html[data-theme='light'] .idt-app-shell-screen select {
+  appearance: none;
+  min-height: 2.95rem;
+  padding: 0.78rem 2.85rem 0.78rem 0.9rem;
+  border-color: var(--app-border);
+  border-radius: 8px;
+  background-color: #050505;
+  background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 20 20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.5 7.5L10 12L14.5 7.5' stroke='%23ffffff' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.86rem center;
+  background-size: 1.05rem 1.05rem;
+  color: #ffffff;
+  font: inherit;
+  font-size: 0.95rem;
+  font-weight: 800;
+  line-height: 1.25;
+  cursor: pointer;
+}
+
+.idt-app-console-layout textarea,
+.idt-account-security-page textarea,
+.idt-executive-report-shell textarea,
+.idt-app-shell-screen textarea {
+  min-height: 7rem;
+  resize: vertical;
+}
+
+.idt-app-console-layout select:disabled,
+.idt-app-console-layout input:disabled,
+.idt-app-console-layout textarea:disabled,
+.idt-account-security-page select:disabled,
+.idt-account-security-page input:disabled,
+.idt-account-security-page textarea:disabled,
+.idt-executive-report-shell select:disabled,
+.idt-executive-report-shell input:disabled,
+.idt-executive-report-shell textarea:disabled,
+.idt-app-shell-screen select:disabled,
+.idt-app-shell-screen input:disabled,
+.idt-app-shell-screen textarea:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+}
+
 /* Product app visual richness */
 .idt-app-console-layout,
 .idt-account-security-page,
@@ -20454,6 +20532,196 @@ html[data-theme='light'] .idt-app-console-layout .idt-source-meta div {
   background: #080809;
 }
 
+.idt-source-command-center {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(18rem, 0.9fr);
+  gap: 0.75rem;
+  align-items: stretch;
+}
+
+.idt-source-next-action,
+.idt-source-compact-stats,
+.idt-source-recovery-card,
+.idt-source-policy-panel details,
+html[data-theme='light'] .idt-source-next-action,
+html[data-theme='light'] .idt-source-compact-stats,
+html[data-theme='light'] .idt-source-recovery-card,
+html[data-theme='light'] .idt-source-policy-panel details {
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: #080809;
+  color: #ffffff;
+}
+
+.idt-source-next-action {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.idt-source-next-action h3 {
+  margin: 0.12rem 0 0.35rem;
+  font-size: clamp(1.35rem, 2vw, 1.75rem);
+  line-height: 1.05;
+}
+
+.idt-source-next-action p:last-child {
+  margin: 0;
+  max-width: 70ch;
+}
+
+.idt-source-compact-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin: 0;
+  overflow: hidden;
+}
+
+.idt-source-compact-stats div {
+  min-width: 0;
+  display: grid;
+  gap: 0.45rem;
+  align-content: center;
+  border-right: 1px solid var(--app-border);
+  padding: 0.92rem;
+}
+
+.idt-source-compact-stats div:last-child {
+  border-right: 0;
+}
+
+.idt-source-compact-stats dt {
+  color: var(--app-muted);
+  font-size: 0.72rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.idt-source-compact-stats dd {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin: 0;
+  color: #ffffff;
+  font-size: 1.05rem;
+  font-weight: 900;
+  line-height: 1.15;
+}
+
+.idt-source-primary-action {
+  align-items: stretch;
+}
+
+.idt-source-primary-action form {
+  min-width: min(100%, 20rem);
+  flex: 0 1 22rem;
+}
+
+.idt-source-enterprise-fallback,
+.idt-source-policy-panel details {
+  padding: 0;
+  overflow: hidden;
+}
+
+.idt-source-enterprise-fallback summary,
+.idt-source-policy-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  cursor: pointer;
+  list-style: none;
+}
+
+.idt-source-enterprise-fallback summary::-webkit-details-marker,
+.idt-source-policy-summary::-webkit-details-marker {
+  display: none;
+}
+
+.idt-source-enterprise-fallback summary::after,
+.idt-source-policy-summary::after {
+  content: '';
+  width: 0.8rem;
+  height: 0.8rem;
+  flex: 0 0 auto;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  color: #ffffff;
+  transform: rotate(45deg);
+  transition: transform 0.16s ease;
+}
+
+.idt-source-enterprise-fallback[open] summary::after,
+.idt-source-policy-panel details[open] .idt-source-policy-summary::after {
+  transform: rotate(225deg);
+}
+
+.idt-source-enterprise-fallback summary span:first-child,
+.idt-source-policy-summary > div:first-child {
+  min-width: 0;
+  display: grid;
+  gap: 0.22rem;
+}
+
+.idt-source-enterprise-fallback summary strong {
+  color: #ffffff;
+}
+
+.idt-source-enterprise-fallback summary small {
+  color: var(--app-muted);
+  font-size: 0.88rem;
+  line-height: 1.35;
+}
+
+.idt-source-enterprise-fallback .idt-app-form {
+  border-top: 1px solid var(--app-border);
+  padding: 1rem;
+}
+
+.idt-source-recovery-card {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.9rem;
+  border-color: rgba(255, 107, 107, 0.55);
+}
+
+.idt-source-recovery-card strong {
+  color: #ffd0d0;
+}
+
+.idt-source-recovery-card p {
+  margin: 0;
+}
+
+.idt-source-recovery-card .idt-btn {
+  justify-self: start;
+}
+
+.idt-source-policy-panel {
+  border: 0;
+  padding: 0;
+  background: transparent;
+}
+
+.idt-source-policy-summary h3 {
+  margin: 0.1rem 0 0.25rem;
+}
+
+.idt-source-policy-summary p:last-child {
+  margin: 0;
+}
+
+.idt-source-policy-body {
+  display: grid;
+  gap: 1rem;
+  border-top: 1px solid var(--app-border);
+  padding: 1rem;
+}
+
 .idt-app-console-layout .idt-repo-finding-row {
   display: flex;
   text-align: left;
@@ -20494,6 +20762,27 @@ html[data-theme='light'] .idt-app-console-layout .idt-source-meta div {
   .idt-project-card-title {
     display: grid;
     justify-content: stretch;
+  }
+
+  .idt-source-command-center,
+  .idt-source-compact-stats,
+  .idt-source-primary-action {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-source-next-action,
+  .idt-source-enterprise-fallback summary,
+  .idt-source-policy-summary {
+    display: grid;
+  }
+
+  .idt-source-compact-stats div {
+    border-right: 0;
+    border-bottom: 1px solid var(--app-border);
+  }
+
+  .idt-source-compact-stats div:last-child {
+    border-bottom: 0;
   }
 }
 


### PR DESCRIPTION
Fixes #1288

## What changed
- Replaced the cramped source onboarding summary cards with a wider command-center layout that surfaces the selected source, next action, connection count, and remaining setup work.
- Restyled app-wide selects, inputs, and textareas so dropdowns use a larger, intentional control with a visible chevron instead of the tiny native selector affordance.
- Moved GitHub Enterprise fallback and scan policy editing into advanced disclosure panels so the primary onboarding path stays focused and less noisy.
- Added a focused regression test for the collapsed advanced GitHub and scan policy controls.

## Impact and risk
- UI-only app shell/source onboarding change.
- Existing source setup actions and scan policy submit handlers are preserved.
- Advanced controls remain available, but are hidden until requested.

## Validation
- `npm test -- --run src/productShell.test.tsx`
- `npm run build`

AI-assisted: No
Tools used: None
Human verification performed: npm test -- --run src/productShell.test.tsx; npm run build


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes source onboarding with a wider command-center layout, upgraded form controls, and collapsible advanced options to keep the primary path focused. Implements #1288 by surfacing next action and selected source status, and adds a regression test to keep advanced GitHub and policy controls collapsed by default.

- **New Features**
  - Command center: shows next action with status pill, plus compact stats for Connected, Remaining, and Source.
  - GitHub flow: “Recommended setup” App install card; Enterprise fallback moved into a collapsible details panel.
  - Scan policies: editor moved into an advanced, collapsible panel with an “Advanced” badge.
  - Global forms: larger selects/inputs/textareas with visible chevron; improved small-screen layout and a recovery card for scan start errors.

<sup>Written for commit f3a534cd5d0bc640b355f5654088fe8b57a074a4. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1289?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

