### PR TITLE
Fix repo scan enqueue cursor defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Fixed hosted repository scan enqueueing after incremental scan metadata. Empty
+  revision and cursor values are now stored as non-null empty strings instead of
+  violating the `repo_scans` cursor constraints.
 - Added API-backed CLI parity for GitHub repository intelligence. Operators can
   now queue hosted repository scans, list/show/cancel repo scans, filter repo
   findings by lifecycle and confidence, fetch risk graphs, collect GitHub

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -2683,7 +2683,7 @@ func (p *PostgresStore) CreateQueuedRepoScanWithinLimit(ctx context.Context, rep
 	if _, err := tx.ExecContext(
 		ctx,
 		`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, scan_mode, base_revision, head_revision, cursor_before, cursor_after, changed_paths, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id, trace_parent, trace_state)
-		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, NULLIF($8, ''), NULLIF($9, ''), NULLIF($10, ''), NULLIF($11, ''), $12::jsonb, $13, $14, $15, $16, $17, $18, NULLIF($19, ''), NULLIF($20, ''))`,
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15, $16, $17, $18, NULLIF($19, ''), NULLIF($20, ''))`,
 		record.ID,
 		record.TenantID,
 		record.WorkspaceID,
@@ -2993,7 +2993,7 @@ func (p *PostgresStore) createRepoScanWithStatus(ctx context.Context, repository
 	_, err = p.execContext(
 		ctx,
 		`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, scan_mode, base_revision, head_revision, cursor_before, cursor_after, changed_paths, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id)
-		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, NULLIF($8, ''), NULLIF($9, ''), NULLIF($10, ''), NULLIF($11, ''), $12::jsonb, $13, $14, $15, $16, $17, $18)`,
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15, $16, $17, $18)`,
 		record.ID,
 		record.TenantID,
 		record.WorkspaceID,

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -714,7 +714,7 @@ func TestPostgresStoreRepoScanLifecycle(t *testing.T) {
 	now := time.Now().UTC()
 
 	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, scan_mode, base_revision, head_revision, cursor_before, cursor_after, changed_paths, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id)
-		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, NULLIF($8, ''), NULLIF($9, ''), NULLIF($10, ''), NULLIF($11, ''), $12::jsonb, $13, $14, $15, $16, $17, $18)`)).
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15, $16, $17, $18)`)).
 		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "running", sqlmock.AnyArg(), "deep", "", "", "", "", "[]", 0, 0, "", "", "", int64(0)).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -1605,7 +1605,7 @@ func TestPostgresStoreRepoQueueLifecycle(t *testing.T) {
 	now := time.Now().UTC()
 
 	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, scan_mode, base_revision, head_revision, cursor_before, cursor_after, changed_paths, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id)
-		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, NULLIF($8, ''), NULLIF($9, ''), NULLIF($10, ''), NULLIF($11, ''), $12::jsonb, $13, $14, $15, $16, $17, $18)`)).
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15, $16, $17, $18)`)).
 		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "queued", sqlmock.AnyArg(), "deep", "", "", "", "", "[]", 50, 80, "", "", "", int64(0)).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -2039,7 +2039,7 @@ func TestPostgresStoreCreateQueuedRepoScanWithinLimit(t *testing.T) {
 		WithArgs("default", "default").
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO repo_scans (id, tenant_id, workspace_id, repository, status, started_at, commits_scanned, files_scanned, finding_count, truncated, scan_mode, base_revision, head_revision, cursor_before, cursor_after, changed_paths, history_limit, max_findings_limit, source_provider, source_project_id, source_connector_id, source_installation_id, trace_parent, trace_state)
-		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, NULLIF($8, ''), NULLIF($9, ''), NULLIF($10, ''), NULLIF($11, ''), $12::jsonb, $13, $14, $15, $16, $17, $18, NULLIF($19, ''), NULLIF($20, ''))`)).
+		 VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, false, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15, $16, $17, $18, NULLIF($19, ''), NULLIF($20, ''))`)).
 		WithArgs(sqlmock.AnyArg(), "default", "default", "owner/repo", "queued", now, "deep", "", "", "", "", "[]", 50, 80, "", "", "", int64(0), "", "").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()


### PR DESCRIPTION
Fixes #1290

## What changed
- Preserve normalized empty strings for repo scan `base_revision`, `head_revision`, `cursor_before`, and `cursor_after` inserts instead of converting them to `NULL`.
- Updated Postgres store expectations so empty repo scan contexts stay compatible with the non-null incremental scan metadata columns.
- Added a changelog note for the hosted enqueue fix.

## Why it changed
Hosted API logs showed repo scan enqueue failures with `null value in column "cursor_before" of relation "repo_scans" violates not-null constraint`, which caused the product app to show `failed to enqueue repo scan`.

## Impact and risk
This is a narrow Postgres persistence fix. It restores queued repo scan creation for deep scans that do not provide explicit revision or cursor metadata and keeps existing non-null schema constraints intact.

## Validation performed
- `go test ./internal/db ./internal/api`
- `go test ./...`

## AI-assisted disclosure
- AI-assisted: yes
- Tools used: OpenAI coding assistant
- Where used: diagnosis, Postgres persistence patch, and validation planning
- Human verification performed: reviewed production log evidence, code diff, and passing Go test suite

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores hosted repo scan enqueueing by storing empty revision and cursor values as empty strings instead of NULL. This avoids NOT NULL violations on `repo_scans` for deep scans without metadata.

- **Bug Fixes**
  - Store empty strings for `base_revision`, `head_revision`, `cursor_before`, and `cursor_after` on insert.
  - Updated Postgres insert SQL and tests to expect non-null empty strings.
  - Added changelog note; no schema changes.

<sup>Written for commit e9cb5bd013d5a494b9ddac2a88a33602dfb580cd. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1291?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

