### PR TITLE
Keep AWS and Kubernetes prominent while wiring Homebrew tap publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,9 @@ jobs:
           tag="${{ needs.prepare.outputs.tag }}"
           mkdir -p dist
 
+          source_archive="dist/identrail-source-${tag}.tar.gz"
+          git archive --format=tar.gz --prefix="identrail-${tag}/" -o "${source_archive}" HEAD
+
           targets=(
             "linux/amd64"
             "linux/arm64"
@@ -490,11 +493,11 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ needs.prepare.outputs.tag }}"
-          source_url="https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${tag}.tar.gz"
+          source_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${tag}/identrail-source-${tag}.tar.gz"
           source_sha256="$(curl -fsSL "${source_url}" | sha256sum | awk '{print $1}')"
 
           mkdir -p dist
-          bash scripts/render_homebrew_formula.sh "${tag}" "${source_sha256}" > dist/identrail.rb
+          bash scripts/render_homebrew_formula.sh "${tag}" "${source_url}" "${source_sha256}" > dist/identrail.rb
           grep -F "url \"${source_url}\"" dist/identrail.rb
           grep -F "sha256 \"${source_sha256}\"" dist/identrail.rb
           grep -F "bin/\"identrail\"" dist/identrail.rb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -456,3 +456,70 @@ jobs:
           prerelease: ${{ needs.prepare.outputs.prerelease == 'true' }}
           files: |
             dist/*
+
+  publish-homebrew-tap:
+    name: Publish Homebrew Tap
+    needs: [prepare, build-binaries, publish-release, publish-release-with-images]
+    if: >-
+      always() &&
+      needs.prepare.result == 'success' &&
+      needs.build-binaries.result == 'success' &&
+      (needs.publish-release.result == 'success' || needs.publish-release-with-images.result == 'success')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    env:
+      HOMEBREW_TAP_REPOSITORY: identrail/homebrew-tap
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+    steps:
+      - name: Skip when Homebrew tap token is not configured
+        if: env.HOMEBREW_TAP_TOKEN == ''
+        run: echo "HOMEBREW_TAP_TOKEN is not configured; skipping Homebrew tap publish."
+
+      - name: Checkout release tag
+        if: env.HOMEBREW_TAP_TOKEN != ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: refs/tags/${{ needs.prepare.outputs.tag }}
+
+      - name: Render Homebrew formula
+        if: env.HOMEBREW_TAP_TOKEN != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ needs.prepare.outputs.tag }}"
+          source_url="https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${tag}.tar.gz"
+          source_sha256="$(curl -fsSL "${source_url}" | sha256sum | awk '{print $1}')"
+
+          mkdir -p dist
+          bash scripts/render_homebrew_formula.sh "${tag}" "${source_sha256}" > dist/identrail.rb
+          grep -F "url \"${source_url}\"" dist/identrail.rb
+          grep -F "sha256 \"${source_sha256}\"" dist/identrail.rb
+          grep -F "bin/\"identrail\"" dist/identrail.rb
+
+      - name: Publish formula to Homebrew tap
+        if: env.HOMEBREW_TAP_TOKEN != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/${HOMEBREW_TAP_REPOSITORY}.git" tap
+          mkdir -p tap/Formula
+          cp dist/identrail.rb tap/Formula/identrail.rb
+
+          cd tap
+          if ! git rev-parse --verify HEAD >/dev/null 2>&1; then
+            git switch -c main
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if [ -z "$(git status --porcelain -- Formula/identrail.rb)" ]; then
+            echo "Homebrew formula is already current."
+            exit 0
+          fi
+
+          git add Formula/identrail.rb
+          git commit -m "Update Identrail formula for ${{ needs.prepare.outputs.tag }}"
+          git push origin HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,9 @@
   publish a dedicated CLI container image with release documentation for
   binaries, Docker, and Homebrew tap readiness.
 - Added Homebrew tap release publishing. Release automation now renders
-  `Formula/identrail.rb` and can push it to `identrail/homebrew-tap`, installing
-  the CLI as `identrail` so `identrail scan owner/repo` works after the tap is
-  published.
+  `Formula/identrail.rb` from a stable uploaded source archive and can push it
+  to `identrail/homebrew-tap`, installing the CLI as `identrail` so
+  `identrail scan owner/repo` works after the tap is published.
 - Added repository finding lifecycle intelligence. Repo findings now carry
   stable lifecycle keys, first/last seen timestamps, fixed/reopened/suppressed
   state, owner and detector metadata, list filters for lifecycle, ownership,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
   accepts positional targets and the `repo` alias, and release workflows now
   publish a dedicated CLI container image with release documentation for
   binaries, Docker, and Homebrew tap readiness.
+- Added Homebrew tap release publishing. Release automation now renders
+  `Formula/identrail.rb` and can push it to `identrail/homebrew-tap`, installing
+  the CLI as `identrail` so `identrail scan owner/repo` works after the tap is
+  published.
 - Added repository finding lifecycle intelligence. Repo findings now carry
   stable lifecycle keys, first/last seen timestamps, fixed/reopened/suppressed
   state, owner and detector metadata, list filters for lifecycle, ownership,

--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ Run the CLI without installing it locally:
 docker run --rm ghcr.io/identrail/identrail-cli:dev scan identrail/identrail
 ```
 
+After the Homebrew tap is published, install the CLI on macOS or Linux:
+
+```bash
+brew install identrail/tap/identrail
+identrail scan identrail/identrail
+```
+
 Or build from source:
 
 ```bash
@@ -68,7 +75,9 @@ go build -o ./bin/identrail ./cmd/cli
 ./bin/identrail scan identrail/identrail
 ```
 
-Homebrew support is planned, but the Homebrew tap is not published yet.
+The release workflow publishes the Homebrew formula when the
+`identrail/homebrew-tap` repository and `HOMEBREW_TAP_TOKEN` secret are in
+place.
 
 ### Scan from the terminal
 

--- a/README.md
+++ b/README.md
@@ -53,69 +53,57 @@ decision audit verification, use the [Enterprise Quickstart](./docs/enterprise-q
 
 ### Install or run the CLI
 
-Run the CLI without installing it locally:
-
-```bash
-docker run --rm ghcr.io/identrail/identrail-cli:dev scan identrail/identrail
-```
-
 After the Homebrew tap is published, install the CLI on macOS or Linux:
 
 ```bash
 brew install identrail/tap/identrail
-identrail scan identrail/identrail
 ```
 
-Or build from source:
+Run the CLI without installing it locally:
+
+```bash
+docker run --rm ghcr.io/identrail/identrail-cli:dev scan owner/repo
+```
+
+Build from source when you want to contribute or test development code:
 
 ```bash
 git clone https://github.com/identrail/identrail.git
 cd identrail
 go build -o ./bin/identrail ./cmd/cli
-./bin/identrail scan identrail/identrail
 ```
 
 The release workflow publishes the Homebrew formula when the
 `identrail/homebrew-tap` repository and `HOMEBREW_TAP_TOKEN` secret are in
-place.
+place. Until then, use Docker or a source build.
 
 ### Scan from the terminal
 
-After installing or building the CLI, run the AWS/Kubernetes provider scan path:
+After installing the CLI, run the AWS/Kubernetes provider scan path:
 
 ```bash
 identrail scan
 ```
 
-Use the Kubernetes provider defaults explicitly:
-
-```bash
-IDENTRAIL_PROVIDER=kubernetes identrail scan
-```
-
-Scan any public GitHub repository:
+Scan a public GitHub repository:
 
 ```bash
 identrail scan owner/repo
 ```
 
-If you built from source, use `./bin/identrail` instead of `identrail` unless
-you add the binary to your `PATH`.
-
-To scan a private repository locally, clone it with your normal GitHub access
-and scan the checkout:
+Scan a local checkout, including a private repository you already cloned:
 
 ```bash
-git clone git@github.com:owner/private-repo.git
-cd private-repo
 identrail scan .
 ```
 
-The repository scanner reports secrets, GitHub Actions, and CI risk. These
+Use `IDENTRAIL_PROVIDER=kubernetes identrail scan` when you want the Kubernetes
+provider defaults explicitly. If you built from source, use `./bin/identrail`
+instead of `identrail` unless you add the binary to your `PATH`. Repository
 signals complement the AWS/Kubernetes identity graph; they do not replace it.
 For hosted, project-scoped private repository scans, connect the GitHub App in
-the Identrail web app and select the repository. See [Install Identrail](./docs/install.md)
-for CLI install details.
+the Identrail web app. See [Install Identrail](./docs/install.md) for CLI
+install details.
 
 ## What Identrail Does
 

--- a/README.md
+++ b/README.md
@@ -38,35 +38,63 @@ Use it when you run AWS and/or Kubernetes workloads and want identity risk visib
 
 ## 5-Minute Quickstart
 
-### Scan a public GitHub repository
+Identrail is AWS/Kubernetes machine identity security first. Use the hosted app
+for the full source-onboarding workflow, and use the CLI when you want a quick
+repository-exposure scan from your terminal.
 
-You can scan a public GitHub repository without creating an Identrail account or
-connecting the hosted app. With Docker:
+### Use the hosted app
 
-```bash
-docker run --rm ghcr.io/identrail/identrail-cli:dev scan owner/repo
-```
+Go to [identrail.com](https://www.identrail.com), sign in, create or select a
+workspace, and connect the sources your project owns: AWS, Kubernetes, and
+GitHub.
 
-Example:
+For enterprise auth scope, tenant/workspace context, live source setup, and
+decision audit verification, use the [Enterprise Quickstart](./docs/enterprise-quickstart.md).
+
+### Install or run the CLI
+
+Run the CLI without installing it locally:
 
 ```bash
 docker run --rm ghcr.io/identrail/identrail-cli:dev scan identrail/identrail
 ```
 
-If you installed the CLI from a release binary or source build, use:
+Or build from source:
+
+```bash
+git clone https://github.com/identrail/identrail.git
+cd identrail
+go build -o ./bin/identrail ./cmd/cli
+./bin/identrail scan identrail/identrail
+```
+
+Homebrew support is planned, but the Homebrew tap is not published yet.
+
+### Scan from the terminal
+
+After installing or building the CLI, run the AWS/Kubernetes provider scan path:
+
+```bash
+identrail scan
+```
+
+Use the Kubernetes provider defaults explicitly:
+
+```bash
+IDENTRAIL_PROVIDER=kubernetes identrail scan
+```
+
+Scan any public GitHub repository:
 
 ```bash
 identrail scan owner/repo
 ```
 
-The scan prints repository exposure findings for secrets, GitHub Actions risk,
-and CI configuration issues. See [Install Identrail](./docs/install.md) for
-binary, Docker, and source install paths.
+If you built from source, use `./bin/identrail` instead of `identrail` unless
+you add the binary to your `PATH`.
 
-### Scan a private repository locally
-
-Clone the private repository with your normal GitHub access, then scan the local
-checkout:
+To scan a private repository locally, clone it with your normal GitHub access
+and scan the checkout:
 
 ```bash
 git clone git@github.com:owner/private-repo.git
@@ -74,48 +102,16 @@ cd private-repo
 identrail scan .
 ```
 
-With Docker:
-
-```bash
-docker run --rm -v "$PWD:/repo" -w /repo ghcr.io/identrail/identrail-cli:dev scan .
-```
-
+The repository scanner reports secrets, GitHub Actions, and CI risk. These
+signals complement the AWS/Kubernetes identity graph; they do not replace it.
 For hosted, project-scoped private repository scans, connect the GitHub App in
-the Identrail web app and select the repository.
-
-### Run the local dashboard
-
-Prerequisites: Docker, Docker Compose, and `curl`.
-
-Start the published local stack:
-
-```bash
-mkdir identrail-docker && cd identrail-docker
-curl -fsSLO https://raw.githubusercontent.com/identrail/identrail/dev/deploy/docker/docker-compose.public.yml
-docker compose -f docker-compose.public.yml up -d
-curl http://localhost:8080/healthz
-```
-
-Open `http://localhost:8081` for the web UI.
-
-For source development from a cloned repository:
-
-```bash
-make quickstart
-```
-
-Stop the stack:
-
-```bash
-make quickstart-down
-```
-
-For enterprise auth scope, tenant/workspace context, and decision audit verification, use the full [Enterprise Quickstart](./docs/enterprise-quickstart.md).
+the Identrail web app and select the repository. See [Install Identrail](./docs/install.md)
+for CLI install details.
 
 ## What Identrail Does
 
 - Discovers machine identities and trust relationships across AWS and Kubernetes.
-- Scans repositories for secret exposure, GitHub Actions, and CI risk.
+- Adds repository exposure signals for secrets, GitHub Actions, and CI risk.
 - Produces explainable findings with evidence, severity, and remediation context.
 - Provides CLI, API, worker, and web workflows for local scans, hosted scans, trends, and review.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,7 +1,20 @@
 # Install Identrail
 
-Use Docker when you do not want to install anything locally. Use a source build
-when you want to contribute or test the latest development code.
+Use Homebrew when the tap is published, Docker when you do not want to install
+anything locally, and a source build when you want to contribute or test the
+latest development code.
+
+## Homebrew
+
+After the Homebrew tap has been published, install the CLI on macOS or Linux:
+
+```bash
+brew install identrail/tap/identrail
+identrail scan owner/repo
+```
+
+The shorter `brew install identrail` command is a later Homebrew core goal. It
+requires Homebrew to accept an Identrail formula.
 
 ## Docker
 
@@ -85,14 +98,9 @@ identrail repo-scan owner/repo
 identrail repo owner/repo
 ```
 
-## Homebrew Status
+## Homebrew Tap Maintenance
 
-Homebrew support is planned, but it is not available yet. The command below will
-fail until the `identrail/homebrew-tap` repository is published:
-
-```bash
-brew install identrail/tap/identrail
-```
-
-The shorter `brew install identrail` command is a later Homebrew core goal. It
-requires Homebrew to accept an Identrail formula.
+Release automation renders and publishes `Formula/identrail.rb` to
+`identrail/homebrew-tap` when maintainers create that repository and configure a
+`HOMEBREW_TAP_TOKEN` secret with write access. Until the tap is published, use
+Docker or a source build.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,8 +1,8 @@
 # Install Identrail
 
 Use Homebrew when the tap is published, Docker when you do not want to install
-anything locally, and a source build when you want to contribute or test the
-latest development code.
+anything locally, and a source build when you want to contribute or test
+development code.
 
 ## Homebrew
 
@@ -13,7 +13,7 @@ brew install identrail/tap/identrail
 identrail scan owner/repo
 ```
 
-The shorter `brew install identrail` command is a later Homebrew core goal. It
+The shorter `brew install identrail` command is a later Homebrew core goal and
 requires Homebrew to accept an Identrail formula.
 
 ## Docker
@@ -22,12 +22,6 @@ Run Identrail without installing it on your machine:
 
 ```bash
 docker run --rm ghcr.io/identrail/identrail-cli:dev scan owner/repo
-```
-
-Example:
-
-```bash
-docker run --rm ghcr.io/identrail/identrail-cli:dev scan identrail/identrail
 ```
 
 For a private repository, clone it first and mount the checkout:
@@ -67,7 +61,7 @@ Run the AWS/Kubernetes provider scan path:
 identrail scan
 ```
 
-Use Kubernetes fixtures/provider defaults explicitly:
+Use the Kubernetes provider defaults explicitly:
 
 ```bash
 IDENTRAIL_PROVIDER=kubernetes identrail scan
@@ -90,17 +84,11 @@ Repository scans report secrets, GitHub Actions, and CI risk. They complement
 the AWS/Kubernetes machine identity workflow; they do not replace it. Hosted
 private repository scans use the GitHub App connector in the Identrail web app.
 
-The backward-compatible long commands still work for scripts:
-
-```bash
-identrail repo-scan --repo owner/repo
-identrail repo-scan owner/repo
-identrail repo owner/repo
-```
-
 ## Homebrew Tap Maintenance
 
 Release automation renders and publishes `Formula/identrail.rb` to
-`identrail/homebrew-tap` when maintainers create that repository and configure a
-`HOMEBREW_TAP_TOKEN` secret with write access. Until the tap is published, use
+`identrail/homebrew-tap` when maintainers create that repository, configure a
+`HOMEBREW_TAP_TOKEN` secret with write access, and cut a release that includes
+the Homebrew workflow. The formula is pinned to a stable uploaded release source
+archive, not GitHub's generated tag archive. Until the tap is published, use
 Docker or a source build.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,112 +1,36 @@
 # Install Identrail
 
-This page covers the end-user install paths for the Identrail command-line
-scanner. The hosted API, worker, and web stack remain documented in the
-deployment guides.
+Use Docker when you do not want to install anything locally. Use a source build
+when you want to contribute or test the latest development code.
 
-## Recommended CLI usage
+## Docker
 
-Use the short repository scan form when you want to inspect a public GitHub
-repository:
-
-```bash
-identrail scan owner/repo
-```
-
-Examples:
-
-```bash
-identrail scan identrail/identrail
-identrail scan owner/repo --history-limit 50 --max-findings 20
-identrail scan https://github.com/owner/repo.git --output json
-```
-
-For a private repository, clone it first with your normal GitHub access and
-scan the local checkout:
-
-```bash
-git clone git@github.com:owner/private-repo.git
-cd private-repo
-identrail scan .
-```
-
-With Docker:
-
-```bash
-docker run --rm -v "$PWD:/repo" -w /repo ghcr.io/identrail/identrail-cli:dev scan .
-```
-
-Hosted private repository scans use the GitHub App connector in the Identrail
-web app.
-
-The longer command remains supported for scripts and backward compatibility:
-
-```bash
-identrail repo-scan --repo owner/repo
-identrail repo-scan owner/repo
-identrail repo owner/repo
-```
-
-Running `identrail scan` without a repository still runs the provider scan
-pipeline for AWS or Kubernetes identities.
-
-## Download a release binary
-
-Published GitHub releases include `identrail-cli` archives for macOS, Linux,
-and Windows:
-
-- macOS Intel and Apple Silicon: `darwin-amd64`, `darwin-arm64`
-- Linux Intel and ARM: `linux-amd64`, `linux-arm64`
-- Windows Intel: `windows-amd64`
-
-Download the archive that matches your machine from the GitHub release page,
-extract it, and put the `identrail-cli-*` binary on your `PATH` as
-`identrail`.
-
-## Homebrew (planned)
-
-The release assets and CLI command shape are ready for a Homebrew tap formula,
-but the `identrail/homebrew-tap` repository has not been published yet. Once
-that tap exists, the install command should be:
-
-```bash
-brew install identrail/tap/identrail
-```
-
-After Homebrew core acceptance, the shorter command can become:
-
-```bash
-brew install identrail
-```
-
-Core acceptance is a later distribution step outside this repository PR. It
-requires a public Homebrew formula review, stable releases, source-build
-support, tests, and enough user adoption for Homebrew maintainers to accept the
-formula.
-
-## Docker CLI image
-
-For machines that already use Docker, run the CLI without installing Go:
+Run Identrail without installing it on your machine:
 
 ```bash
 docker run --rm ghcr.io/identrail/identrail-cli:dev scan owner/repo
 ```
 
-The Docker image uses the same `identrail` entrypoint as the binary, so any CLI
-arguments after the image name are passed directly to Identrail.
-
-Release tags follow the normal image scheme:
+Example:
 
 ```bash
-docker run --rm ghcr.io/identrail/identrail-cli:v1.2.3 scan owner/repo
-docker run --rm docker.io/identrail/identrail-cli:v1.2.3 scan owner/repo
+docker run --rm ghcr.io/identrail/identrail-cli:dev scan identrail/identrail
 ```
 
-Use immutable `sha-<12-char-sha>` tags when you need repeatable scans in CI.
+For a private repository, clone it first and mount the checkout:
 
-## Build from source
+```bash
+git clone git@github.com:owner/private-repo.git
+cd private-repo
+docker run --rm -v "$PWD:/repo" -w /repo ghcr.io/identrail/identrail-cli:dev scan .
+```
 
-Contributors can still build locally from a clone:
+The Docker image uses the same command shape as the installed CLI. Put CLI
+arguments after the image name.
+
+## Source Build
+
+Use this path when you want to contribute or test the latest development code:
 
 ```bash
 git clone https://github.com/identrail/identrail.git
@@ -114,3 +38,61 @@ cd identrail
 go build -o ./bin/identrail ./cmd/cli
 ./bin/identrail scan owner/repo
 ```
+
+If you want to run `identrail` without the `./bin/` prefix, move the built
+binary into a directory on your `PATH`.
+
+## Scan Commands
+
+These commands assume `identrail` is installed or on your `PATH`. If you built
+from source and did not move the binary, replace `identrail` with
+`./bin/identrail`.
+
+Run the AWS/Kubernetes provider scan path:
+
+```bash
+identrail scan
+```
+
+Use Kubernetes fixtures/provider defaults explicitly:
+
+```bash
+IDENTRAIL_PROVIDER=kubernetes identrail scan
+```
+
+Scan a public GitHub repository:
+
+```bash
+identrail scan owner/repo
+```
+
+Scan a private repository you already cloned:
+
+```bash
+cd private-repo
+identrail scan .
+```
+
+Repository scans report secrets, GitHub Actions, and CI risk. They complement
+the AWS/Kubernetes machine identity workflow; they do not replace it. Hosted
+private repository scans use the GitHub App connector in the Identrail web app.
+
+The backward-compatible long commands still work for scripts:
+
+```bash
+identrail repo-scan --repo owner/repo
+identrail repo-scan owner/repo
+identrail repo owner/repo
+```
+
+## Homebrew Status
+
+Homebrew support is planned, but it is not available yet. The command below will
+fail until the `identrail/homebrew-tap` repository is published:
+
+```bash
+brew install identrail/tap/identrail
+```
+
+The shorter `brew install identrail` command is a later Homebrew core goal. It
+requires Homebrew to accept an Identrail formula.

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -17,6 +17,9 @@ Identrail release automation is defined in:
   `VITE_FEATURE_ONBOARDING_WIZARD` values are baked into release web images.
 - Image publishing requires `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repository
   secrets so the workflow can mirror GHCR images to Docker Hub.
+- Homebrew tap publishing requires a public `identrail/homebrew-tap` repository
+  and a `HOMEBREW_TAP_TOKEN` repository secret with write access to that tap.
+  Without the secret, releases still succeed and skip the tap publish step.
 - For manual runs with `publish_images=false`, image configuration is not required.
 - Manual image backfills for historical tags that predate `deploy/docker/release-web.env`
   use the legacy release URL recorded by the workflow and attach that source in
@@ -46,6 +49,8 @@ their first organization, workspace, and GitHub connector after login.
    - `docker.io/identrail/identrail-cli:<tag>`
 4. Image digests and web build input metadata.
 5. Auto-generated GitHub Release notes.
+6. Homebrew formula updates to `identrail/homebrew-tap` when tap publishing is
+   configured.
 
 ## Continuous Public Images
 

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -33,8 +33,9 @@ their first organization, workspace, and GitHub connector after login.
 ## What the Pipeline Publishes
 
 1. Cross-platform binaries (`cli`, `server`, `worker`) as archives.
-2. SHA-256 checksum manifest (`checksums.txt`).
-3. Container images to GHCR and Docker Hub:
+2. Stable release source archive (`identrail-source-<tag>.tar.gz`).
+3. SHA-256 checksum manifest (`checksums.txt`).
+4. Container images to GHCR and Docker Hub:
    - `ghcr.io/<owner>/identrail:<tag>`
    - `ghcr.io/<owner>/identrail-api:<tag>`
    - `ghcr.io/<owner>/identrail-worker:<tag>`
@@ -47,9 +48,9 @@ their first organization, workspace, and GitHub connector after login.
    - `docker.io/identrail/identrail-web:<tag>`
    - `docker.io/identrail/identrail-agent:<tag>`
    - `docker.io/identrail/identrail-cli:<tag>`
-4. Image digests and web build input metadata.
-5. Auto-generated GitHub Release notes.
-6. Homebrew formula updates to `identrail/homebrew-tap` when tap publishing is
+5. Image digests and web build input metadata.
+6. Auto-generated GitHub Release notes.
+7. Homebrew formula updates to `identrail/homebrew-tap` when tap publishing is
    configured.
 
 ## Continuous Public Images

--- a/scripts/render_homebrew_formula.sh
+++ b/scripts/render_homebrew_formula.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 <tag> <source-sha256>" >&2
+  exit 2
+fi
+
+tag="$1"
+source_sha256="$2"
+
+if ! [[ "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+  echo "invalid release tag: ${tag}" >&2
+  exit 2
+fi
+
+if ! [[ "${source_sha256}" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "invalid source sha256: ${source_sha256}" >&2
+  exit 2
+fi
+
+cat <<FORMULA
+class Identrail < Formula
+  desc "Open-source machine identity security for AWS and Kubernetes"
+  homepage "https://www.identrail.com"
+  url "https://github.com/identrail/identrail/archive/refs/tags/${tag}.tar.gz"
+  sha256 "${source_sha256}"
+  license "Apache-2.0"
+  head "https://github.com/identrail/identrail.git", branch: "dev"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", "-trimpath", "-ldflags", "-s -w", "-o", bin/"identrail", "./cmd/cli"
+  end
+
+  test do
+    assert_match "Machine identity security scanner", shell_output("#{bin}/identrail --help")
+    assert_match "scan [repository]", shell_output("#{bin}/identrail scan --help")
+  end
+end
+FORMULA

--- a/scripts/render_homebrew_formula.sh
+++ b/scripts/render_homebrew_formula.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -ne 2 ]; then
-  echo "usage: $0 <tag> <source-sha256>" >&2
+if [ "$#" -ne 3 ]; then
+  echo "usage: $0 <tag> <source-url> <source-sha256>" >&2
   exit 2
 fi
 
 tag="$1"
-source_sha256="$2"
+source_url="$2"
+source_sha256="$3"
 
 if ! [[ "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
   echo "invalid release tag: ${tag}" >&2
@@ -19,11 +20,17 @@ if ! [[ "${source_sha256}" =~ ^[0-9a-f]{64}$ ]]; then
   exit 2
 fi
 
+expected_url_prefix="https://github.com/identrail/identrail/releases/download/${tag}/"
+if [[ "${source_url}" != "${expected_url_prefix}"* ]]; then
+  echo "invalid source url for ${tag}: ${source_url}" >&2
+  exit 2
+fi
+
 cat <<FORMULA
 class Identrail < Formula
   desc "Open-source machine identity security for AWS and Kubernetes"
   homepage "https://www.identrail.com"
-  url "https://github.com/identrail/identrail/archive/refs/tags/${tag}.tar.gz"
+  url "${source_url}"
   sha256 "${source_sha256}"
   license "Apache-2.0"
   head "https://github.com/identrail/identrail.git", branch: "dev"


### PR DESCRIPTION
Fixes #1292

## Summary
- Lead the README quickstart with the hosted app for the full AWS, Kubernetes, and GitHub source-onboarding workflow.
- Keep the working CLI paths simple: Docker no-install usage, source builds, and the short `identrail scan owner/repo` scan command.
- Add Homebrew tap release publishing: releases now render `Formula/identrail.rb` and can push it to `identrail/homebrew-tap`, installing the CLI as `identrail`.
- Document the real Homebrew activation boundary: maintainers still need the public `identrail/homebrew-tap` repo and a `HOMEBREW_TAP_TOKEN` secret with write access before `brew install identrail/tap/identrail` works.
- Keep GitHub repository scanning framed as complementary to the AWS/Kubernetes identity graph, not a replacement.

## Impact
- Existing Docker, source-build, API, worker, and hosted app flows remain backward compatible.
- Releases skip Homebrew tap publishing when `HOMEBREW_TAP_TOKEN` is not configured, so current releases do not break before the tap repo exists.
- Once the tap repo and token exist, a release updates Homebrew automatically and users can install with `brew install identrail/tap/identrail`.

## Validation
- `bash scripts/render_homebrew_formula.sh v1.2.3 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
- `go test ./cmd/cli ./internal/cli -run 'TestRunCallsExecute|TestExecuteScanRepositoryShortcut|TestExecuteRepoScanPositionalTarget' -count=1`
- `go run ./cmd/cli scan . --history-limit 5 --max-findings 3`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/release.yml`
- `git diff --check`
- Push hooks: merge conflict check, YAML check, EOF/trailing whitespace, gofmt check, go vet, local env token hygiene, Vercel artifact hygiene

AI-assisted: No