### PR TITLE
fix(web): UI polish — overview header, auth logo, eyebrow, finder modal, app scrollbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## Unreleased
+- Fixed web UI polish issues: the workspace overview header no longer crowds the
+  "Overview"/"Latest activity" text against its divider (boxed border replaced
+  with a spaced bottom rule), the sign-in/sign-up logo mark now renders a visible
+  tile on the dark auth background instead of disappearing into it, and the
+  homepage "Adoption Paths" eyebrow uses the brand accent color in light theme so
+  it is no longer washed out.
 - Fixed hosted repository scan enqueueing after incremental scan metadata. Empty
   revision and cursor values are now stored as non-null empty strings instead of
   violating the `repo_scans` cursor constraints.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
   with a spaced bottom rule), the sign-in/sign-up logo mark now renders a visible
   tile on the dark auth background instead of disappearing into it, and the
   homepage "Adoption Paths" eyebrow uses the brand accent color in light theme so
-  it is no longer washed out.
+  it is no longer washed out. The workspace finder ("Go to anything") modal now
+  scrolls its own results and locks the page behind it instead of scrolling the
+  background, and the dark app shell uses a slim, subtle scrollbar instead of
+  inheriting the heavy near-white light-theme scrollbar.
 - Fixed hosted repository scan enqueueing after incremental scan metadata. Empty
   revision and cursor values are now stored as non-null empty strings instead of
   violating the `repo_scans` cursor constraints.

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -825,7 +825,13 @@ function CommandPalette({
     }
 
     const focusTimer = window.setTimeout(() => inputRef.current?.focus(), 0);
-    return () => window.clearTimeout(focusTimer);
+    const root = document.documentElement;
+    const previousOverflow = root.style.overflow;
+    root.style.overflow = 'hidden';
+    return () => {
+      window.clearTimeout(focusTimer);
+      root.style.overflow = previousOverflow;
+    };
   }, [open]);
 
   const filteredItems = useMemo(() => {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6502,7 +6502,8 @@ html[data-theme='light'] .idt-auth-page[data-auth-theme='light'] {
   width: 1.75rem;
   height: 1.75rem;
   border-radius: 7px;
-  box-shadow: none;
+  background: #0e0e11;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.22);
 }
 
 .idt-auth-logo span {
@@ -15635,9 +15636,17 @@ html[data-theme='light'] .idt-scan-stepper li.is-active {
   padding: clamp(4.8rem, 8vw, 7.2rem) clamp(1.1rem, 5vw, 6rem);
 }
 
-.idt-home-after-stack .idt-eyebrow,
-html[data-theme='light'] .idt-home-after-stack .idt-eyebrow {
+.idt-home-after-stack .idt-eyebrow {
   color: currentColor;
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+}
+
+/* Light theme: use the brand accent so the eyebrow stays legible instead of
+   inheriting a washed-out body color via currentColor. */
+html[data-theme='light'] .idt-home-after-stack .idt-eyebrow {
+  color: var(--idt-z-purple-dark);
   font-size: 0.74rem;
   font-weight: 800;
   letter-spacing: 0.14em;
@@ -21956,7 +21965,18 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 
 .idt-app-console-layout .idt-overview-header {
   align-items: center;
-  padding: 0 0 0.25rem;
+  padding: 0 0 1.1rem;
+  border: none;
+  border-bottom: 1px solid var(--app-border-soft);
+  border-radius: 0;
+  background: transparent;
+}
+
+/* The always-on light-theme header rule otherwise re-applies a panel
+   background and a heavier border colour; keep the overview header clean. */
+html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
+  border-color: var(--app-border-soft);
+  background: transparent;
 }
 
 .idt-app-console-layout .idt-overview-header h2 {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -14082,6 +14082,40 @@ html[data-theme='light'] body::-webkit-scrollbar-thumb:hover {
   background: #98a3b3;
 }
 
+/* Dark app shell: the global page scrollbar otherwise inherits the light-theme
+   colours (a near-white track), which reads as a heavy white bar on the dark
+   dashboard. Scope a slim, subtle scrollbar to pages that render the app shell. */
+html:has(.idt-app-console-layout),
+html:has(.idt-app-console-layout) body {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.22) transparent;
+}
+
+html:has(.idt-app-console-layout)::-webkit-scrollbar,
+html:has(.idt-app-console-layout) body::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+html:has(.idt-app-console-layout)::-webkit-scrollbar-track,
+html:has(.idt-app-console-layout) body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+html:has(.idt-app-console-layout)::-webkit-scrollbar-thumb,
+html:has(.idt-app-console-layout) body::-webkit-scrollbar-thumb {
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background-color: rgba(255, 255, 255, 0.18);
+  background-clip: padding-box;
+}
+
+html:has(.idt-app-console-layout)::-webkit-scrollbar-thumb:hover,
+html:has(.idt-app-console-layout) body::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(255, 255, 255, 0.32);
+  background-clip: padding-box;
+}
+
 .idt-btn,
 .idt-header-demo,
 .idt-header-utility,
@@ -18809,6 +18843,10 @@ html[data-theme='light'] .idt-app-quick-find {
 }
 
 .idt-command-palette {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  max-height: 100%;
   width: min(100%, 42rem);
   border: 1px solid var(--app-border);
   border-radius: 8px;
@@ -18868,6 +18906,10 @@ html[data-theme='light'] .idt-app-quick-find {
 .idt-command-palette-results {
   display: grid;
   gap: 0.35rem;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .idt-command-palette-results button {


### PR DESCRIPTION
## Summary
Five small front-end polish fixes (CSS + one effect), all scoped to `web/`:

1. **Workspace overview header** — replaced the leftover boxed border (which crowded the "Overview"/"Latest activity" text against its top/bottom edges) with a clean bottom divider plus breathing room (`padding-bottom: 1.1rem`).
2. **Sign-in/sign-up logo** — the black logo tile vanished against the pure-black auth background. Added a hairline ring + subtle tile background so the mark renders as a defined logo instead of a floating glyph.
3. **Homepage "Adoption Paths" eyebrow** — it inherited a washed-out body color via `currentColor` in light theme; now uses the brand accent (`--idt-z-purple-dark`).
4. **Workspace finder ("Go to anything") modal** — the dialog had no height cap and the results didn't scroll, so a long list scrolled the page behind it. The dialog is now capped to the viewport, the results list scrolls internally (`overflow-y: auto` + `overscroll-behavior: contain`), and the page is scroll-locked while the modal is open (`overflow: hidden` on the root scroller).
5. **Dark app scrollbar** — the global page scrollbar inherited the light-theme colors (near-white track) and read as a heavy white bar on the dark dashboard. A slim, transparent-track, subtly translucent scrollbar is now scoped to pages that render the app shell via `html:has(.idt-app-console-layout)`, leaving the light marketing pages untouched.

## Verification
- `npm run build --prefix web` ✅ (tsc + vite + prerender, 41 routes)
- `npm run test:ci --prefix web` ✅ (exit 0)
- Visual + computed-style verification against the production build served locally:
  - Auth logo renders as a defined tile on the black `/signup` page.
  - Adoption eyebrow computes `rgb(80, 34, 184)` on the light homepage.
  - Overview header (dark theme): no top/side border, 1px bottom divider, 17.6px bottom padding.
  - Finder modal caps to viewport with an internally scrollable results list; scoped scrollbar resolves to `rgba(255,255,255,0.22) / transparent` only when the app shell is present.

## Notes
- A native scrollbar **thumb length** is browser-controlled (content/viewport ratio) and can't be hard-set shorter; the heaviness came mostly from the near-white track, which is now transparent. A fixed-size thumb would require a custom JS scrollbar component (follow-up if desired).
No issue: standalone UI polish fixes reported directly by the maintainer; no tracking issue exists.

## AI assistance disclosure
- AI-assisted: yes
- Tools used: Claude Code
- Where used: `web/src/styles.css`, `web/src/productShell.tsx`, `CHANGELOG.md`
- Human verification performed: local `web` build + `test:ci`, production-build visual review and computed-style checks of each change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished several web UI elements for better readability and scrolling across auth pages and the app shell. Tightens header styling, improves auth logo contrast, fixes eyebrow color, makes the finder modal self-scrolling with page lock, and slims the dark-mode scrollbar.

- **Bug Fixes**
  - Workspace overview header: removed boxed border; added bottom divider and padding.
  - Auth logo: added subtle tile background and hairline ring for contrast on black.
  - Homepage “Adoption Paths” eyebrow: uses brand accent in light theme.
  - Workspace finder (“Go to anything”) modal: capped to viewport; results list scrolls; page scroll locked while open.
  - Dark app shell: slimmer, translucent scrollbar with transparent track, scoped to app pages only.

<sup>Written for commit 0e0854024243e7a74169af3ded4d38fc6eeadd89. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1295?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

