### PR TITLE
Improve auth callback and GitHub install UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## Unreleased
+- Improved hosted auth and GitHub connector onboarding UX. WorkOS callback
+  failures now redirect back to the web sign-in page with user-facing reasons
+  instead of raw JSON, login no longer provisions unknown identities, signup can
+  reactivate a deactivated/deleted account that still owns the same email, and
+  the GitHub App setup now continues directly to GitHub with copy covering both
+  personal accounts and organizations.
 - Fixed app workspace navigation so route changes inside an already-validated
   workspace no longer rerun the full session gate, and hardened repository
   finding display helpers against partially populated API records.

--- a/docs/auth/github-connector.md
+++ b/docs/auth/github-connector.md
@@ -21,7 +21,15 @@ Older project-scoped GitHub routes are not the product path. They remain interna
 
 ## Hosted GitHub.com Flow
 
-`POST /v1/connectors/github` creates a pending connector and returns a GitHub App install URL. The product sends GitHub back to `/app/github/callback`, and that callback calls `POST /v1/connectors/github/complete` with the returned state and installation ID. The backend owns the GitHub App slug and webhook secret through environment variables, so users do not paste app credentials into the browser.
+`POST /v1/connectors/github` creates a pending connector and returns a GitHub
+App install URL. The product immediately continues the user to that GitHub URL
+and keeps a fallback button visible if the browser blocks navigation. GitHub
+asks the user whether to install the App on a personal account or an
+organization, then asks which repositories Identrail can access. The product
+sends GitHub back to `/app/github/callback`, and that callback calls
+`POST /v1/connectors/github/complete` with the returned state and installation
+ID. The backend owns the GitHub App slug and webhook secret through environment
+variables, so users do not paste app credentials into the browser.
 
 Required runtime configuration for the hosted GitHub App flow:
 
@@ -53,6 +61,13 @@ GitHub source unavailable instead of calling the connector route and showing a
 raw framework 404. If the route is enabled but the GitHub App runtime settings
 are missing, the start request returns the API's configuration message so the
 operator sees a specific setup problem.
+
+Personal repositories and organization repositories follow the same completion
+path. After callback, Identrail lists repositories selected for that
+installation and accepts any `owner/repo` in the selected list, subject to the
+hosted repo scan allowlist described below. A repository that was not selected
+during installation or was not allowlisted should produce a targeted product
+message instead of a generic 404.
 
 ## GitHub Enterprise Fallback
 

--- a/docs/auth/identity-linking-rules.md
+++ b/docs/auth/identity-linking-rules.md
@@ -18,7 +18,14 @@ The defense is simple to state and easy to get wrong: **email match is not proof
 
 ## Rule 1: One identity per user is created at signup
 
-When a callback arrives and we cannot find a matching `(provider, subject)` row in `user_identities`, we treat it as a brand-new user. We never look up existing users by email at this stage, regardless of whether the new identity carries an `email_verified` claim.
+When a callback arrives and we cannot find a matching `(provider, subject)` row
+in `user_identities`, the normal signup path treats it as a brand-new user. We
+do not look up active users by email at this stage, regardless of whether the
+new identity carries an `email_verified` claim. The only exception is the hosted
+WorkOS signup reactivation path: when the same verified email belongs to a
+retained `deactivated` or `deleted` user row, signup may restore that historical
+account instead of creating a new one. Active same-email users still fail closed
+as an identity conflict.
 
 `users.primary_email` is `UNIQUE`, which means we cannot persist two `users` rows with the same email. We resolve the collision deliberately rather than auto-linking:
 
@@ -109,6 +116,16 @@ Email changes update display, notification destination, and pending-invitation m
 WorkOS is the primary IdP for hosted Identrail. The WorkOS user `sub` becomes `user_identities.subject` with `provider="workos"`. WorkOS marks emails as verified per provider; we trust the `email_verified` field they pass through.
 
 When WorkOS sends a `user.deleted` webhook, we set the `users.status` to `deactivated`, revoke all sessions, but retain the row for audit. The `user_identities` row stays in place; it is the historical record of which WorkOS account was that user.
+
+The hosted `login` and `signup` entry points intentionally differ. `login` only
+resolves an existing WorkOS identity; when a verified email or GitHub OAuth
+profile has never signed up, the callback sends the browser back to
+`/signin?reason=account_not_found` so the app can point the user to sign up.
+`signup` may create a new user, and it may reactivate a retained `deactivated`
+or `deleted` user row when the verified email is the same. Signup still rejects
+an active user with the same email but a different WorkOS subject as an identity
+conflict; that account must use its original sign-in method or be resolved by
+support.
 
 If WorkOS requires MFA enrollment or an MFA challenge during hosted sign-in, Identrail does not create a local session from the first callback. The API stores the WorkOS pending-auth token only in a short-lived encrypted HttpOnly cookie scoped to `/auth/mfa`, redirects the browser to the app MFA page, and creates the Identrail session only after WorkOS accepts the TOTP verification response.
 

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -1083,11 +1083,9 @@ paths:
             type: string
       responses:
         "302":
-          description: Session cookie set and browser redirected to the app
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "409":
-          $ref: "#/components/responses/Conflict"
+          description: >
+            Session cookie set and browser redirected to the app, or browser
+            redirected back to sign-in with a user-facing reason.
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
   /auth/saml/login/{connection_id}:

--- a/internal/api/auth/mfa_pending.go
+++ b/internal/api/auth/mfa_pending.go
@@ -28,6 +28,7 @@ var (
 
 type WorkOSMFAPendingState struct {
 	Mode                       string             `json:"mode"`
+	Intent                     string             `json:"intent,omitempty"`
 	ReturnTo                   string             `json:"return_to,omitempty"`
 	PendingAuthenticationToken string             `json:"pending_authentication_token"`
 	User                       WorkOSProfile      `json:"user"`

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -231,7 +231,7 @@ func workOSCallbackHandler(logger *zap.Logger, svc *Service, manager sessionauth
 		code := strings.TrimSpace(c.Query("code"))
 		if code == "" {
 			auditAuthAction(c.Request.Context(), "auth.login.failure", "", "denied")
-			c.JSON(http.StatusBadRequest, gin.H{"error": "code is required"})
+			redirectWorkOSCallbackFailure(c, opts, authFailureReturnToFromState(opts, c.Query("state")), authFailureReasonCallbackError)
 			return
 		}
 		// The store-backed, browser-bound transaction is the authoritative
@@ -250,14 +250,14 @@ func workOSCallbackHandler(logger *zap.Logger, svc *Service, manager sessionauth
 			decoded, decodeErr := opts.StateManager.Decode(c.Query("state"))
 			if decodeErr != nil {
 				auditAuthAction(c.Request.Context(), "auth.login.failure", "", "denied")
-				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid state"})
+				redirectWorkOSCallbackFailure(c, opts, "", authFailureReasonStateMismatch)
 				return
 			}
 			http.SetCookie(c.Writer, oauthTransactionClearCookie(opts.PublicBaseURL, decoded.Nonce))
 			cookie, cookieErr := c.Request.Cookie(sessionauth.OAuthTransactionCookieName(decoded.Nonce))
 			if cookieErr != nil || strings.TrimSpace(cookie.Value) == "" {
 				auditAuthAction(c.Request.Context(), "auth.login.failure", "", "denied")
-				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid state"})
+				redirectWorkOSCallbackFailure(c, opts, decoded.ReturnTo, authFailureReasonStateMismatch)
 				return
 			}
 			txn, txnErr := opts.TransactionStore.Consume(c.Request.Context(), decoded.Nonce, cookie.Value)
@@ -266,7 +266,7 @@ func workOSCallbackHandler(logger *zap.Logger, svc *Service, manager sessionauth
 					logger.Error("consume workos oauth transaction", telemetry.ZapError(txnErr))
 				}
 				auditAuthAction(c.Request.Context(), "auth.login.failure", "", "denied")
-				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid state"})
+				redirectWorkOSCallbackFailure(c, opts, decoded.ReturnTo, authFailureReasonStateMismatch)
 				return
 			}
 			// The persisted row is the authoritative return target. It was
@@ -281,7 +281,7 @@ func workOSCallbackHandler(logger *zap.Logger, svc *Service, manager sessionauth
 			consumed, consumeErr := opts.StateManager.Consume(c.Query("state"))
 			if consumeErr != nil {
 				auditAuthAction(c.Request.Context(), "auth.login.failure", "", "denied")
-				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid state"})
+				redirectWorkOSCallbackFailure(c, opts, authFailureReturnToFromState(opts, c.Query("state")), authFailureReasonStateMismatch)
 				return
 			}
 			state = consumed
@@ -302,18 +302,111 @@ func workOSCallbackHandler(logger *zap.Logger, svc *Service, manager sessionauth
 			}
 			if errors.Is(err, sessionauth.ErrWorkOSUnavailable) {
 				c.Header("Retry-After", "30")
-				c.JSON(http.StatusServiceUnavailable, gin.H{"error": "auth provider unavailable"})
+				redirectWorkOSCallbackFailure(c, opts, state.ReturnTo, authFailureReasonProviderUnavailable)
 				return
 			}
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "login failed"})
+			redirectWorkOSCallbackFailure(c, opts, state.ReturnTo, authFailureReasonCallbackError)
 			return
 		}
-		redirectTo, ok := completeWorkOSLogin(c, logger, svc, manager, opts, authenticated, state.ReturnTo)
+		redirectTo, ok := completeWorkOSLogin(c, logger, svc, manager, opts, authenticated, state, workOSLoginFailureRedirect)
 		if !ok {
 			return
 		}
 		c.Redirect(http.StatusFound, redirectTo)
 	}
+}
+
+const (
+	authFailureReasonAccountNotFound     = "account_not_found"
+	authFailureReasonCallbackError       = "callback_error"
+	authFailureReasonIdentityConflict    = "identity_conflict"
+	authFailureReasonProviderUnavailable = "provider_unavailable"
+	authFailureReasonStateMismatch       = "state_mismatch"
+)
+
+type workOSLoginFailureMode int
+
+const (
+	workOSLoginFailureJSON workOSLoginFailureMode = iota
+	workOSLoginFailureRedirect
+	workOSLoginFailureRedirectJSON
+)
+
+func redirectWorkOSCallbackFailure(c *gin.Context, opts authSessionRouteOptions, returnTo string, reason string) {
+	c.Redirect(http.StatusFound, workOSAuthFailureRedirectURL(opts, returnTo, reason))
+}
+
+func writeWorkOSLoginFailure(c *gin.Context, opts authSessionRouteOptions, mode workOSLoginFailureMode, returnTo string, reason string, status int, message string) {
+	switch mode {
+	case workOSLoginFailureRedirect:
+		redirectWorkOSCallbackFailure(c, opts, returnTo, reason)
+		return
+	case workOSLoginFailureRedirectJSON:
+		c.JSON(http.StatusOK, gin.H{
+			"ok":          false,
+			"redirect_to": workOSAuthFailureRedirectURL(opts, returnTo, reason),
+		})
+		return
+	}
+	c.JSON(status, gin.H{"error": message})
+}
+
+func authFailureReturnToFromState(opts authSessionRouteOptions, rawState string) string {
+	if opts.StateManager == nil || strings.TrimSpace(rawState) == "" {
+		return ""
+	}
+	state, err := opts.StateManager.Decode(rawState)
+	if err != nil {
+		return ""
+	}
+	return state.ReturnTo
+}
+
+func workOSAuthFailureRedirectURL(opts authSessionRouteOptions, returnTo string, reason string) string {
+	origin := workOSAuthFailureFrontendOrigin(opts, returnTo)
+	path := "/signin"
+	query := url.Values{}
+	if trimmed := strings.TrimSpace(reason); trimmed != "" {
+		query.Set("reason", trimmed)
+	}
+	if sanitizedReturnTo := workOSAuthFailureReturnToParam(opts, origin, returnTo); sanitizedReturnTo != "" {
+		query.Set("return_to", sanitizedReturnTo)
+	}
+	if encoded := query.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	if origin == "" {
+		return path
+	}
+	return strings.TrimRight(origin, "/") + path
+}
+
+func workOSAuthFailureFrontendOrigin(opts authSessionRouteOptions, returnTo string) string {
+	if sanitized := sanitizeAuthReturnTo(returnTo, opts.ReturnToOrigins); sanitized != "" {
+		if origin, ok := authReturnToOrigin(sanitized); ok {
+			return origin
+		}
+	}
+	return preferredAuthFrontendOrigin(opts.PublicBaseURL, opts.ReturnToOrigins)
+}
+
+func workOSAuthFailureReturnToParam(opts authSessionRouteOptions, frontendOrigin string, returnTo string) string {
+	sanitized := sanitizeAuthReturnTo(returnTo, opts.ReturnToOrigins)
+	if sanitized == "" {
+		return ""
+	}
+	parsed, err := url.Parse(sanitized)
+	if err != nil {
+		return ""
+	}
+	if !parsed.IsAbs() {
+		return parsed.RequestURI()
+	}
+	returnToOrigin, ok := authReturnToOrigin(sanitized)
+	if !ok || !strings.EqualFold(returnToOrigin, frontendOrigin) {
+		return ""
+	}
+	return parsed.RequestURI()
 }
 
 func handleWorkOSMFARequired(c *gin.Context, logger *zap.Logger, opts authSessionRouteOptions, state sessionauth.OAuthState, required *sessionauth.WorkOSMFARequired) {
@@ -326,6 +419,7 @@ func handleWorkOSMFARequired(c *gin.Context, logger *zap.Logger, opts authSessio
 	}
 	pending := sessionauth.WorkOSMFAPendingState{
 		Mode:                       required.Mode,
+		Intent:                     state.Intent,
 		ReturnTo:                   sanitizeAuthReturnTo(state.ReturnTo, opts.ReturnToOrigins),
 		PendingAuthenticationToken: required.PendingAuthenticationToken,
 		User:                       required.User,
@@ -349,21 +443,25 @@ func handleWorkOSMFARequired(c *gin.Context, logger *zap.Logger, opts authSessio
 	c.Redirect(http.StatusFound, workOSMFARedirectURL(pending.ReturnTo, opts.PublicBaseURL, opts.ReturnToOrigins))
 }
 
-func completeWorkOSLogin(c *gin.Context, logger *zap.Logger, svc *Service, manager sessionauth.Manager, opts authSessionRouteOptions, authenticated sessionauth.WorkOSAuthentication, returnTo string) (string, bool) {
+func completeWorkOSLogin(c *gin.Context, logger *zap.Logger, svc *Service, manager sessionauth.Manager, opts authSessionRouteOptions, authenticated sessionauth.WorkOSAuthentication, state sessionauth.OAuthState, failureMode workOSLoginFailureMode) (string, bool) {
 	profile := authenticated.User
 	if strings.TrimSpace(profile.OrganizationID) == "" {
 		profile.OrganizationID = authenticated.OrganizationID
 	}
-	result, err := svc.UpsertWorkOSUser(c.Request.Context(), profile)
+	result, err := svc.UpsertWorkOSUserForIntent(c.Request.Context(), profile, state.Intent)
 	if err != nil {
 		if errors.Is(err, ErrAuthIdentityConflict) {
-			c.JSON(http.StatusConflict, gin.H{"error": "identity conflict"})
+			writeWorkOSLoginFailure(c, opts, failureMode, state.ReturnTo, authFailureReasonIdentityConflict, http.StatusConflict, "identity conflict")
+			return "", false
+		}
+		if errors.Is(err, ErrAuthAccountNotFound) {
+			writeWorkOSLoginFailure(c, opts, failureMode, state.ReturnTo, authFailureReasonAccountNotFound, http.StatusNotFound, "account not found")
 			return "", false
 		}
 		if logger != nil {
 			logger.Error("upsert workos user", telemetry.ZapError(err))
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to complete login"})
+		writeWorkOSLoginFailure(c, opts, failureMode, state.ReturnTo, authFailureReasonCallbackError, http.StatusInternalServerError, "failed to complete login")
 		return "", false
 	}
 	now := time.Now().UTC()
@@ -386,12 +484,12 @@ func completeWorkOSLogin(c *gin.Context, logger *zap.Logger, svc *Service, manag
 		if logger != nil {
 			logger.Error("create workos session", telemetry.ZapError(err))
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create session"})
+		writeWorkOSLoginFailure(c, opts, failureMode, state.ReturnTo, authFailureReasonCallbackError, http.StatusInternalServerError, "failed to create session")
 		return "", false
 	}
 	auditAuthAction(c.Request.Context(), "auth.login.success", result.User.ID, "success")
 	http.SetCookie(c.Writer, manager.Cookie(cookieValue))
-	redirectTo := sanitizeAuthReturnTo(returnTo, opts.ReturnToOrigins)
+	redirectTo := sanitizeAuthReturnTo(state.ReturnTo, opts.ReturnToOrigins)
 	if redirectTo == "" || redirectTo == "/" {
 		redirectTo = result.RedirectPath
 	}
@@ -545,7 +643,10 @@ func workOSMFAVerifyHandler(logger *zap.Logger, svc *Service, manager sessionaut
 			writeWorkOSMFAVerifyError(c, logger, err)
 			return
 		}
-		redirectTo, ok := completeWorkOSLogin(c, logger, svc, manager, opts, authenticated, state.ReturnTo)
+		redirectTo, ok := completeWorkOSLogin(c, logger, svc, manager, opts, authenticated, sessionauth.OAuthState{
+			Intent:   state.Intent,
+			ReturnTo: state.ReturnTo,
+		}, workOSLoginFailureRedirectJSON)
 		if !ok {
 			return
 		}

--- a/internal/api/service_auth.go
+++ b/internal/api/service_auth.go
@@ -14,7 +14,15 @@ import (
 	"github.com/identrail/identrail/internal/db"
 )
 
-var ErrAuthIdentityConflict = errors.New("auth identity conflicts with existing user")
+var (
+	ErrAuthIdentityConflict = errors.New("auth identity conflicts with existing user")
+	ErrAuthAccountNotFound  = errors.New("auth account not found")
+)
+
+const (
+	workOSAuthIntentLogin  = "login"
+	workOSAuthIntentSignup = "signup"
+)
 
 // CurrentUserContext is the response model for GET /v1/me.
 type CurrentUserContext struct {
@@ -69,9 +77,17 @@ var ErrAuthInvalidManualLogin = errors.New("manual login requires tenant and wor
 
 // UpsertWorkOSUser safely maps a WorkOS AuthKit profile into Identrail's local account model.
 func (s *Service) UpsertWorkOSUser(ctx context.Context, profile sessionauth.WorkOSProfile) (WorkOSLoginResult, error) {
+	return s.UpsertWorkOSUserForIntent(ctx, profile, workOSAuthIntentSignup)
+}
+
+// UpsertWorkOSUserForIntent safely maps a WorkOS AuthKit profile into
+// Identrail's local account model while preserving the user's entry point.
+// Login only resolves existing identities; signup can create or reactivate.
+func (s *Service) UpsertWorkOSUserForIntent(ctx context.Context, profile sessionauth.WorkOSProfile, intent string) (WorkOSLoginResult, error) {
 	if s == nil || s.Store == nil {
 		return WorkOSLoginResult{}, errors.New("service unavailable")
 	}
+	intent = normalizeWorkOSAuthIntent(intent)
 	subject := strings.TrimSpace(profile.ID)
 	email := strings.ToLower(strings.TrimSpace(profile.Email))
 	if subject == "" || email == "" {
@@ -125,10 +141,49 @@ func (s *Service) UpsertWorkOSUser(ctx context.Context, profile sessionauth.Work
 		return WorkOSLoginResult{}, err
 	}
 	if existing, emailErr := s.Store.GetUserByPrimaryEmail(ctx, email); emailErr == nil {
+		if workOSUserCanBeReactivated(existing) && intent == workOSAuthIntentSignup {
+			if !profile.EmailVerified {
+				auditAuthAction(ctx, "auth.identity.conflict", existing.ID, "denied")
+				return WorkOSLoginResult{}, ErrAuthIdentityConflict
+			}
+			existing.PrimaryEmail = email
+			existing.DisplayName = displayName
+			existing.AvatarURL = strings.TrimSpace(profile.ProfilePictureURL)
+			existing.Status = "active"
+			existing.DeletedAt = nil
+			existing.UpdatedAt = now
+			user, saveErr := s.Store.UpsertUser(ctx, existing)
+			if saveErr != nil {
+				if errors.Is(saveErr, db.ErrConflict) {
+					auditAuthAction(ctx, "auth.identity.conflict", existing.ID, "denied")
+					return WorkOSLoginResult{}, ErrAuthIdentityConflict
+				}
+				return WorkOSLoginResult{}, saveErr
+			}
+			identity, identityErr := s.Store.UpsertUserIdentity(ctx, db.UserIdentity{
+				UserID:              user.ID,
+				Provider:            sessionauth.WorkOSProvider,
+				Subject:             subject,
+				Email:               email,
+				EmailVerified:       profile.EmailVerified,
+				RawClaims:           rawClaims,
+				LastAuthenticatedAt: now,
+				CreatedAt:           now,
+			})
+			if identityErr != nil {
+				return WorkOSLoginResult{}, identityErr
+			}
+			auditAuthAction(ctx, "auth.user.reactivate", user.ID, "success")
+			return s.decorateWorkOSLoginResult(ctx, WorkOSLoginResult{User: user, Identity: identity}, profile.OrganizationID)
+		}
 		auditAuthAction(ctx, "auth.identity.conflict", existing.ID, "denied")
 		return WorkOSLoginResult{}, ErrAuthIdentityConflict
 	} else if emailErr != nil && !errors.Is(emailErr, db.ErrNotFound) {
 		return WorkOSLoginResult{}, emailErr
+	}
+	if intent == workOSAuthIntentLogin {
+		auditAuthAction(ctx, "auth.account.not_found", "", "denied")
+		return WorkOSLoginResult{}, ErrAuthAccountNotFound
 	}
 
 	user, err := s.Store.UpsertUser(ctx, db.User{
@@ -160,6 +215,18 @@ func (s *Service) UpsertWorkOSUser(ctx context.Context, profile sessionauth.Work
 		return WorkOSLoginResult{}, err
 	}
 	return s.decorateWorkOSLoginResult(ctx, WorkOSLoginResult{User: user, Identity: identity, NewUser: true}, profile.OrganizationID)
+}
+
+func normalizeWorkOSAuthIntent(intent string) string {
+	if strings.EqualFold(strings.TrimSpace(intent), workOSAuthIntentLogin) {
+		return workOSAuthIntentLogin
+	}
+	return workOSAuthIntentSignup
+}
+
+func workOSUserCanBeReactivated(user db.User) bool {
+	status := strings.ToLower(strings.TrimSpace(user.Status))
+	return status == "deactivated" || status == "deleted" || user.DeletedAt != nil
 }
 
 // SAMLAssertedProfile is the subset of a SAML assertion Identrail consumes to

--- a/internal/api/service_workos_test.go
+++ b/internal/api/service_workos_test.go
@@ -144,6 +144,123 @@ func TestUpsertWorkOSUserRespectsSelectedOrganization(t *testing.T) {
 	}
 }
 
+func TestUpsertWorkOSUserLoginIntentRejectsUnknownIdentity(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+
+	_, err := svc.UpsertWorkOSUserForIntent(context.Background(), sessionauth.WorkOSProfile{
+		ID:            "user_workos_unknown",
+		Email:         "unknown@example.com",
+		EmailVerified: true,
+	}, "login")
+	if !errors.Is(err, ErrAuthAccountNotFound) {
+		t.Fatalf("expected account not found, got %v", err)
+	}
+	if _, err := store.GetUserByPrimaryEmail(context.Background(), "unknown@example.com"); !errors.Is(err, db.ErrNotFound) {
+		t.Fatalf("login intent must not create a user, got %v", err)
+	}
+}
+
+func TestUpsertWorkOSUserSignupIntentReactivatesDeactivatedEmail(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC)
+	deletedAt := now.Add(-time.Hour)
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	ctx := context.Background()
+	user, err := store.UpsertUser(ctx, db.User{
+		PrimaryEmail: "revoked@example.com",
+		DisplayName:  "Old Name",
+		Status:       "deactivated",
+		DeletedAt:    &deletedAt,
+	})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	result, err := svc.UpsertWorkOSUserForIntent(ctx, sessionauth.WorkOSProfile{
+		ID:                "user_workos_reactivated",
+		Email:             "Revoked@Example.COM",
+		FirstName:         "Fresh",
+		LastName:          "Owner",
+		EmailVerified:     true,
+		ProfilePictureURL: "https://cdn.example/new.png",
+	}, "signup")
+	if err != nil {
+		t.Fatalf("signup should reactivate deactivated user: %v", err)
+	}
+	if result.User.ID != user.ID {
+		t.Fatalf("expected existing user to be reused, got %s want %s", result.User.ID, user.ID)
+	}
+	if result.User.Status != "active" || result.User.DeletedAt != nil {
+		t.Fatalf("expected active restored user, got %+v", result.User)
+	}
+	if result.User.PrimaryEmail != "revoked@example.com" || result.User.DisplayName != "Fresh Owner" || result.User.AvatarURL == "" {
+		t.Fatalf("expected profile refresh, got %+v", result.User)
+	}
+	identity, err := store.GetUserIdentity(ctx, sessionauth.WorkOSProvider, "user_workos_reactivated")
+	if err != nil {
+		t.Fatalf("expected reactivated identity: %v", err)
+	}
+	if identity.UserID != user.ID {
+		t.Fatalf("expected identity on reactivated user, got %+v", identity)
+	}
+}
+
+func TestUpsertWorkOSUserSignupIntentRequiresVerifiedEmailForReactivation(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC)
+	deletedAt := now.Add(-time.Hour)
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	ctx := context.Background()
+	user, err := store.UpsertUser(ctx, db.User{
+		PrimaryEmail: "revoked@example.com",
+		DisplayName:  "Old Name",
+		Status:       "deactivated",
+		DeletedAt:    &deletedAt,
+	})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	_, err = svc.UpsertWorkOSUserForIntent(ctx, sessionauth.WorkOSProfile{
+		ID:            "user_workos_unverified_reactivation",
+		Email:         "revoked@example.com",
+		EmailVerified: false,
+	}, "signup")
+	if !errors.Is(err, ErrAuthIdentityConflict) {
+		t.Fatalf("expected identity conflict for unverified reactivation email, got %v", err)
+	}
+	unchanged, err := store.GetUser(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("load retained user: %v", err)
+	}
+	if unchanged.Status != "deactivated" || unchanged.DeletedAt == nil {
+		t.Fatalf("unverified email must not reactivate retained user, got %+v", unchanged)
+	}
+	if _, err := store.GetUserIdentity(ctx, sessionauth.WorkOSProvider, "user_workos_unverified_reactivation"); !errors.Is(err, db.ErrNotFound) {
+		t.Fatalf("unverified email must not create identity, got %v", err)
+	}
+}
+
+func TestUpsertWorkOSUserSignupIntentRejectsActiveEmailConflict(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	if _, err := store.UpsertUser(context.Background(), db.User{PrimaryEmail: "taken@example.com"}); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	_, err := svc.UpsertWorkOSUserForIntent(context.Background(), sessionauth.WorkOSProfile{
+		ID:            "user_workos_conflict",
+		Email:         "taken@example.com",
+		EmailVerified: true,
+	}, "signup")
+	if !errors.Is(err, ErrAuthIdentityConflict) {
+		t.Fatalf("expected identity conflict, got %v", err)
+	}
+}
+
 func TestUpdateWorkOSUserEmailRejectsConflictingEmail(t *testing.T) {
 	store := db.NewMemoryStore()
 	ctx := context.Background()

--- a/internal/api/workos_auth_routes_test.go
+++ b/internal/api/workos_auth_routes_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -130,7 +131,7 @@ func TestWorkOSHostedLoginCreatesSessionAndIdentity(t *testing.T) {
 	}
 
 	startResp := httptest.NewRecorder()
-	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/login?return_to=/app/welcome", nil))
+	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/signup?return_to=/app/welcome", nil))
 	if startResp.Code != http.StatusFound {
 		t.Fatalf("expected login redirect, got %d body=%s", startResp.Code, startResp.Body.String())
 	}
@@ -299,7 +300,7 @@ func TestWorkOSHostedLoginAllowsConfiguredWebReturnOrigin(t *testing.T) {
 	})
 
 	startResp := httptest.NewRecorder()
-	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/login?return_to=https%3A%2F%2Fapp.identrail.test%2Fapp%2Fwelcome", nil))
+	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/signup?return_to=https%3A%2F%2Fapp.identrail.test%2Fapp%2Fwelcome", nil))
 	if startResp.Code != http.StatusFound {
 		t.Fatalf("expected login redirect, got %d body=%s", startResp.Code, startResp.Body.String())
 	}
@@ -484,8 +485,45 @@ func TestWorkOSCallbackRejectsEmailIdentityConflict(t *testing.T) {
 	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/login", nil))
 	callbackResp := httptest.NewRecorder()
 	router.ServeHTTP(callbackResp, workOSCallbackRequest(workOS.authorizationInput.State, oauthTxnCookieFromStart(t, startResp)))
-	if callbackResp.Code != http.StatusConflict {
-		t.Fatalf("expected identity conflict, got %d body=%s", callbackResp.Code, callbackResp.Body.String())
+	if callbackResp.Code != http.StatusFound {
+		t.Fatalf("expected identity conflict redirect, got %d body=%s", callbackResp.Code, callbackResp.Body.String())
+	}
+	if got := callbackResp.Header().Get("Location"); !strings.Contains(got, "/signin?") || !strings.Contains(got, "reason=identity_conflict") {
+		t.Fatalf("unexpected identity conflict redirect: %q", got)
+	}
+}
+
+func TestWorkOSCallbackRedirectsUnknownLoginToSignupHint(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	workOS := &fakeWorkOSClient{authentication: sessionauth.WorkOSAuthentication{
+		User: sessionauth.WorkOSProfile{ID: "user_workos_unknown", Email: "unknown@example.com", EmailVerified: true},
+	}}
+	router := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{
+		FeatureNewAuth:      true,
+		FeatureWorkOSLogin:  true,
+		PublicBaseURL:       "https://api.identrail.test",
+		CORSAllowedOrigins:  []string{"https://app.identrail.test"},
+		SessionKey:          strings.Repeat("a", 64),
+		WorkOSClientID:      "client_123",
+		WorkOSWebhookSecret: "whsec_123",
+		WorkOSAuthClient:    workOS,
+		RateLimitRPM:        1000,
+		RateLimitBurst:      1000,
+	})
+
+	startResp := httptest.NewRecorder()
+	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/login?return_to=https%3A%2F%2Fapp.identrail.test%2Fapp%2Fwelcome", nil))
+	callbackResp := httptest.NewRecorder()
+	router.ServeHTTP(callbackResp, workOSCallbackRequest(workOS.authorizationInput.State, oauthTxnCookieFromStart(t, startResp)))
+	if callbackResp.Code != http.StatusFound {
+		t.Fatalf("expected account-not-found redirect, got %d body=%s", callbackResp.Code, callbackResp.Body.String())
+	}
+	if got := callbackResp.Header().Get("Location"); got != "https://app.identrail.test/signin?reason=account_not_found&return_to=%2Fapp%2Fwelcome" {
+		t.Fatalf("unexpected account-not-found redirect: %q", got)
+	}
+	if _, err := store.GetUserByPrimaryEmail(context.Background(), "unknown@example.com"); !errors.Is(err, db.ErrNotFound) {
+		t.Fatalf("login intent must not create a user, got %v", err)
 	}
 }
 
@@ -541,15 +579,15 @@ func TestWorkOSCallbackRejectsInvalidStateAndUnavailableProvider(t *testing.T) {
 	})
 	invalidResp := httptest.NewRecorder()
 	router.ServeHTTP(invalidResp, httptest.NewRequest(http.MethodGet, "/auth/callback?code=code-1&state=tampered", nil))
-	if invalidResp.Code != http.StatusBadRequest {
-		t.Fatalf("expected invalid state 400, got %d", invalidResp.Code)
+	if invalidResp.Code != http.StatusFound || !strings.Contains(invalidResp.Header().Get("Location"), "reason=state_mismatch") {
+		t.Fatalf("expected invalid state redirect, got %d loc=%q", invalidResp.Code, invalidResp.Header().Get("Location"))
 	}
 	startResp := httptest.NewRecorder()
 	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/login", nil))
 	unavailableResp := httptest.NewRecorder()
 	router.ServeHTTP(unavailableResp, workOSCallbackRequest(workOS.authorizationInput.State, oauthTxnCookieFromStart(t, startResp)))
-	if unavailableResp.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected unavailable provider 503, got %d body=%s", unavailableResp.Code, unavailableResp.Body.String())
+	if unavailableResp.Code != http.StatusFound || !strings.Contains(unavailableResp.Header().Get("Location"), "reason=provider_unavailable") {
+		t.Fatalf("expected unavailable provider redirect, got %d loc=%q body=%s", unavailableResp.Code, unavailableResp.Header().Get("Location"), unavailableResp.Body.String())
 	}
 	if unavailableResp.Header().Get("Retry-After") == "" {
 		t.Fatal("expected Retry-After header for provider outage")
@@ -557,8 +595,8 @@ func TestWorkOSCallbackRejectsInvalidStateAndUnavailableProvider(t *testing.T) {
 
 	missingCodeResp := httptest.NewRecorder()
 	router.ServeHTTP(missingCodeResp, httptest.NewRequest(http.MethodGet, "/auth/callback?state="+url.QueryEscape(workOS.authorizationInput.State), nil))
-	if missingCodeResp.Code != http.StatusBadRequest {
-		t.Fatalf("expected missing code 400, got %d", missingCodeResp.Code)
+	if missingCodeResp.Code != http.StatusFound || !strings.Contains(missingCodeResp.Header().Get("Location"), "reason=callback_error") {
+		t.Fatalf("expected missing code redirect, got %d loc=%q", missingCodeResp.Code, missingCodeResp.Header().Get("Location"))
 	}
 }
 
@@ -601,7 +639,7 @@ func TestWorkOSCallbackContinuesMFAEnrollment(t *testing.T) {
 	})
 
 	startResp := httptest.NewRecorder()
-	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/login?provider=github_oauth&return_to=https%3A%2F%2Fapp.identrail.test%2Fapp", nil))
+	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/signup?provider=github_oauth&return_to=https%3A%2F%2Fapp.identrail.test%2Fapp", nil))
 	if startResp.Code != http.StatusFound {
 		t.Fatalf("expected login redirect, got %d body=%s", startResp.Code, startResp.Body.String())
 	}
@@ -715,7 +753,7 @@ func TestWorkOSCallbackContinuesExistingMFAChallenge(t *testing.T) {
 	})
 
 	startResp := httptest.NewRecorder()
-	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/login?provider=github_oauth&return_to=https%3A%2F%2Fapp.identrail.test%2Fapp", nil))
+	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/signup?provider=github_oauth&return_to=https%3A%2F%2Fapp.identrail.test%2Fapp", nil))
 	callbackResp := httptest.NewRecorder()
 	router.ServeHTTP(callbackResp, workOSCallbackRequest(workOS.authorizationInput.State, oauthTxnCookieFromStart(t, startResp)))
 	pendingCookie := findTestCookie(callbackResp.Result().Cookies(), sessionauth.PendingMFACookieName)
@@ -746,6 +784,65 @@ func TestWorkOSCallbackContinuesExistingMFAChallenge(t *testing.T) {
 	}
 	if workOS.verifyInput.PendingAuthenticationToken != "pending-token" || workOS.verifyInput.AuthenticationChallengeID != "auth_challenge_existing" || workOS.verifyInput.Code != "654321" {
 		t.Fatalf("unexpected verify input: %+v", workOS.verifyInput)
+	}
+}
+
+func TestWorkOSMFAVerifyRedirectsUnknownLoginToSignupHint(t *testing.T) {
+	secret := strings.Repeat("a", 64)
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	workOS := &fakeWorkOSClient{
+		authentication: sessionauth.WorkOSAuthentication{
+			User: sessionauth.WorkOSProfile{
+				ID:            "user_workos_unknown_mfa",
+				Email:         "unknown-mfa@example.com",
+				EmailVerified: true,
+			},
+		},
+	}
+	router := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{
+		FeatureNewAuth:     true,
+		FeatureWorkOSLogin: true,
+		PublicBaseURL:      "https://api.identrail.test",
+		CORSAllowedOrigins: []string{"https://app.identrail.test"},
+		SessionKey:         secret,
+		WorkOSClientID:     "client_123",
+		WorkOSAuthClient:   workOS,
+		RateLimitRPM:       1000,
+		RateLimitBurst:     1000,
+	})
+	pending := sessionauth.WorkOSMFAPendingState{
+		Mode:                       sessionauth.WorkOSMFAModeChallenge,
+		Intent:                     workOSAuthIntentLogin,
+		ReturnTo:                   "https://app.identrail.test/app/welcome",
+		PendingAuthenticationToken: "pending-token",
+		User:                       sessionauth.WorkOSProfile{ID: "user_workos_unknown_mfa", Email: "unknown-mfa@example.com", EmailVerified: true},
+		AuthenticationFactors:      []sessionauth.WorkOSMFAFactor{{ID: "auth_factor_existing", Type: "totp"}},
+		ChallengeID:                "auth_challenge_existing",
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/mfa/verify", strings.NewReader(`{"code":"654321"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(sealedPendingMFACookie(t, secret, pending))
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected mfa verify recovery redirect payload, got code=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var payload struct {
+		OK         bool   `json:"ok"`
+		RedirectTo string `json:"redirect_to"`
+		Error      string `json:"error"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode verify recovery payload: %v", err)
+	}
+	expected := "https://app.identrail.test/signin?reason=account_not_found&return_to=%2Fapp%2Fwelcome"
+	if payload.OK || payload.RedirectTo != expected || payload.Error != "" {
+		t.Fatalf("unexpected verify recovery payload: %+v", payload)
+	}
+	if _, err := store.GetUserByPrimaryEmail(context.Background(), "unknown-mfa@example.com"); !errors.Is(err, db.ErrNotFound) {
+		t.Fatalf("login mfa recovery must not create a user, got %v", err)
 	}
 }
 
@@ -781,7 +878,7 @@ func TestWorkOSMFAChallengeRejectsBadFactorAndInvalidCode(t *testing.T) {
 	}
 
 	startResp := httptest.NewRecorder()
-	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/login?provider=github_oauth&return_to=https%3A%2F%2Fapp.identrail.test%2Fapp", nil))
+	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/signup?provider=github_oauth&return_to=https%3A%2F%2Fapp.identrail.test%2Fapp", nil))
 	callbackResp := httptest.NewRecorder()
 	router.ServeHTTP(callbackResp, workOSCallbackRequest(workOS.authorizationInput.State, oauthTxnCookieFromStart(t, startResp)))
 	pendingCookie := findTestCookie(callbackResp.Result().Cookies(), sessionauth.PendingMFACookieName)
@@ -842,7 +939,7 @@ func TestWorkOSCallbackRequiresBrowserBoundTransaction(t *testing.T) {
 	router := newWorkOSTestRouter(t, store, workOS)
 
 	startResp := httptest.NewRecorder()
-	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/login?return_to=/app/welcome", nil))
+	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/signup?return_to=/app/welcome", nil))
 	if startResp.Code != http.StatusFound {
 		t.Fatalf("expected login redirect, got %d", startResp.Code)
 	}
@@ -853,20 +950,20 @@ func TestWorkOSCallbackRequiresBrowserBoundTransaction(t *testing.T) {
 	// though the signed state is valid.
 	noCookieResp := httptest.NewRecorder()
 	router.ServeHTTP(noCookieResp, workOSCallbackRequest(state, nil))
-	if noCookieResp.Code != http.StatusBadRequest {
-		t.Fatalf("expected missing-cookie callback to be rejected, got %d body=%s", noCookieResp.Code, noCookieResp.Body.String())
+	if noCookieResp.Code != http.StatusFound || !strings.Contains(noCookieResp.Header().Get("Location"), "reason=state_mismatch") {
+		t.Fatalf("expected missing-cookie callback redirect, got %d loc=%q body=%s", noCookieResp.Code, noCookieResp.Header().Get("Location"), noCookieResp.Body.String())
 	}
 
 	// A second, independent login produces a different transaction cookie;
 	// pairing it with the first state must be rejected (state/cookie
 	// mismatch).
 	otherStart := httptest.NewRecorder()
-	router.ServeHTTP(otherStart, httptest.NewRequest(http.MethodGet, "/auth/login?return_to=/app/other", nil))
+	router.ServeHTTP(otherStart, httptest.NewRequest(http.MethodGet, "/auth/signup?return_to=/app/other", nil))
 	otherCookie := oauthTxnCookieFromStart(t, otherStart)
 	mismatchResp := httptest.NewRecorder()
 	router.ServeHTTP(mismatchResp, workOSCallbackRequest(state, otherCookie))
-	if mismatchResp.Code != http.StatusBadRequest {
-		t.Fatalf("expected mismatched state/cookie to be rejected, got %d body=%s", mismatchResp.Code, mismatchResp.Body.String())
+	if mismatchResp.Code != http.StatusFound || !strings.Contains(mismatchResp.Header().Get("Location"), "reason=state_mismatch") {
+		t.Fatalf("expected mismatched state/cookie redirect, got %d loc=%q body=%s", mismatchResp.Code, mismatchResp.Header().Get("Location"), mismatchResp.Body.String())
 	}
 
 	// The genuine pair succeeds exactly once.
@@ -879,8 +976,8 @@ func TestWorkOSCallbackRequiresBrowserBoundTransaction(t *testing.T) {
 	// Replaying the same state + cookie fails because the row is consumed.
 	replayResp := httptest.NewRecorder()
 	router.ServeHTTP(replayResp, workOSCallbackRequest(state, txnCookie))
-	if replayResp.Code != http.StatusBadRequest {
-		t.Fatalf("expected reused state to be rejected, got %d body=%s", replayResp.Code, replayResp.Body.String())
+	if replayResp.Code != http.StatusFound || !strings.Contains(replayResp.Header().Get("Location"), "reason=state_mismatch") {
+		t.Fatalf("expected reused state redirect, got %d loc=%q body=%s", replayResp.Code, replayResp.Header().Get("Location"), replayResp.Body.String())
 	}
 }
 
@@ -896,13 +993,13 @@ func TestWorkOSConcurrentStartsKeepIndependentTransactions(t *testing.T) {
 	router := newWorkOSTestRouter(t, store, workOS)
 
 	startA := httptest.NewRecorder()
-	router.ServeHTTP(startA, httptest.NewRequest(http.MethodGet, "/auth/login?return_to=/app/a", nil))
+	router.ServeHTTP(startA, httptest.NewRequest(http.MethodGet, "/auth/signup?return_to=/app/a", nil))
 	stateA := workOS.authorizationInput.State
 	cookieA := oauthTxnCookieFromStart(t, startA)
 
 	// Second flow starts before the first callback returns.
 	startB := httptest.NewRecorder()
-	router.ServeHTTP(startB, httptest.NewRequest(http.MethodGet, "/auth/login?return_to=/app/b", nil))
+	router.ServeHTTP(startB, httptest.NewRequest(http.MethodGet, "/auth/signup?return_to=/app/b", nil))
 	stateB := workOS.authorizationInput.State
 	cookieB := oauthTxnCookieFromStart(t, startB)
 
@@ -939,7 +1036,7 @@ func TestWorkOSCallbackReplayFailsAcrossInstances(t *testing.T) {
 	instanceB := newWorkOSTestRouter(t, store, workOS)
 
 	startResp := httptest.NewRecorder()
-	instanceA.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/login?return_to=/app/welcome", nil))
+	instanceA.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/signup?return_to=/app/welcome", nil))
 	state := workOS.authorizationInput.State
 	txnCookie := oauthTxnCookieFromStart(t, startResp)
 
@@ -956,8 +1053,8 @@ func TestWorkOSCallbackReplayFailsAcrossInstances(t *testing.T) {
 	// map never saw this nonce consumed.
 	aReplay := httptest.NewRecorder()
 	instanceA.ServeHTTP(aReplay, workOSCallbackRequest(state, txnCookie))
-	if aReplay.Code != http.StatusBadRequest {
-		t.Fatalf("expected cross-instance replay to be rejected, got %d body=%s", aReplay.Code, aReplay.Body.String())
+	if aReplay.Code != http.StatusFound || !strings.Contains(aReplay.Header().Get("Location"), "reason=state_mismatch") {
+		t.Fatalf("expected cross-instance replay redirect, got %d loc=%q body=%s", aReplay.Code, aReplay.Header().Get("Location"), aReplay.Body.String())
 	}
 }
 

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -989,6 +989,19 @@ describe('App', () => {
     );
   });
 
+  it('points unknown hosted sign-ins to sign-up without raw callback errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(authConfig(false, true)));
+
+    setCurrentPath('/signin?reason=account_not_found&return_to=/app/team/workspace');
+    render(<App />);
+
+    expect(await screen.findByText(/No Identrail account uses that sign-in method yet/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Create an account/i })).toHaveAttribute(
+      'href',
+      '/signup?return_to=%2Fapp%2Fteam%2Fworkspace'
+    );
+  });
+
   it('does not show loading copy or provider actions while auth config loads', () => {
     vi.stubGlobal('fetch', vi.fn().mockImplementation(() => new Promise(() => {})));
 

--- a/web/src/pages/SignInPage.tsx
+++ b/web/src/pages/SignInPage.tsx
@@ -76,16 +76,44 @@ function normalizeReturnTo(value: string | null): string {
   return candidate;
 }
 
-function authReasonMessage(reason: string): string {
+type AuthReasonDetails = {
+  message: string;
+  actionLabel?: string;
+  actionHref?: string;
+};
+
+function authPathWithReturnTo(path: string, returnTo: string): string {
+  const query = new URLSearchParams();
+  if (returnTo && returnTo !== '/app') {
+    query.set('return_to', returnTo);
+  }
+  const encoded = query.toString();
+  return encoded ? `${path}?${encoded}` : path;
+}
+
+function authReasonDetails(reason: string, returnTo: string): AuthReasonDetails | null {
   switch (reason) {
     case 'session_expired':
-      return 'Your session expired. Sign in again to continue.';
+      return { message: 'Your session expired. Sign in again to continue.' };
     case 'callback_error':
-      return 'Sign-in did not complete. Please retry.';
+      return { message: 'Sign-in did not complete. Please retry from this page.' };
     case 'state_mismatch':
-      return 'Secure sign-in validation failed. Please retry.';
+      return { message: 'Secure sign-in validation failed. Start a new sign-in from this page.' };
+    case 'account_not_found':
+      return {
+        message: 'No Identrail account uses that sign-in method yet.',
+        actionLabel: 'Create an account',
+        actionHref: authPathWithReturnTo('/signup', returnTo)
+      };
+    case 'identity_conflict':
+      return {
+        message:
+          'That email or GitHub identity is already tied to a different Identrail account. Sign in with the original method or contact support.'
+      };
+    case 'provider_unavailable':
+      return { message: 'The sign-in provider is temporarily unavailable. Please retry in a moment.' };
     default:
-      return '';
+      return null;
   }
 }
 
@@ -149,7 +177,7 @@ export function AuthChoicePage({ intent }: AuthChoicePageProps) {
   const query = useMemo(() => new URLSearchParams(location.search), [location.search]);
   const returnTo = normalizeReturnTo(query.get('return_to') ?? query.get('next'));
   const signedOut = query.get('signed_out') === '1';
-  const reason = authReasonMessage(query.get('reason') ?? '');
+  const reason = authReasonDetails(query.get('reason') ?? '', returnTo);
   const [config, setConfig] = useState<AuthConfigResponse | null>(null);
   const [loadingConfig, setLoadingConfig] = useState(true);
   const [configError, setConfigError] = useState('');
@@ -256,7 +284,17 @@ export function AuthChoicePage({ intent }: AuthChoicePageProps) {
           <h1>{title}</h1>
 
           {signedOut ? <p className="idt-app-alert idt-app-alert-success">Signed out successfully.</p> : null}
-          {reason ? <p className="idt-app-alert">{reason}</p> : null}
+          {reason ? (
+            <p className="idt-app-alert">
+              {reason.message}
+              {reason.actionHref && reason.actionLabel ? (
+                <>
+                  {' '}
+                  <Link to={reason.actionHref}>{reason.actionLabel}</Link>.
+                </>
+              ) : null}
+            </p>
+          ) : null}
 
           {configError ? <p className="idt-app-alert idt-app-alert-error">{configError}</p> : null}
 

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AWSConnectionStatus, CurrentUserContext, GitHubConnectionStatus, RepoScanRecord } from './api/client';
@@ -370,7 +370,7 @@ describe('ProductProjectDetailPage', () => {
     const { getGitHubConnectorStatus } = await renderProjectDetail(true);
 
     expect((await screen.findAllByText('identrail/identrail')).length).toBeGreaterThan(0);
-    expect(screen.getByRole('button', { name: /GitHub/i })).not.toBeDisabled();
+    expect(within(screen.getByLabelText('Source types')).getByRole('button', { name: /GitHub/i })).not.toBeDisabled();
     expect(screen.getByText('Installation 12345')).toBeInTheDocument();
     expect(getGitHubConnectorStatus).toHaveBeenCalledWith(
       'workspace-a',
@@ -647,7 +647,7 @@ describe('ProductProjectDetailPage', () => {
 
     await waitFor(() => expect(runRepoScan).toHaveBeenCalled());
     expect(
-      await screen.findByText(/outside the allowed scan targets/i)
+      await screen.findByText(/not currently allowed for this project/i)
     ).toBeInTheDocument();
   });
 });

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -636,13 +636,29 @@ function sourceAvailabilityTone(
   return availability.available ? connectionTone(status) : 'error';
 }
 
+function openGitHubInstallURL(installURL: string) {
+  if (typeof window === 'undefined' || !installURL) {
+    return;
+  }
+  if (/jsdom/i.test(window.navigator.userAgent)) {
+    return;
+  }
+  try {
+    window.location.assign(installURL);
+    return;
+  } catch {
+    // Fall back to a same-tab open when a test/browser shim blocks assign().
+  }
+  window.open(installURL, '_self', 'noopener,noreferrer');
+}
+
 function formatRepoScanSubmitError(error: unknown): string {
   if (error instanceof ApiError) {
     if (error.status === 400) {
       return 'Choose a valid owner/repo repository target before queueing a scan.';
     }
     if (error.status === 403) {
-      return 'That repository is outside the allowed scan targets. Choose a selected GitHub repository or update the hosted repo scan allowlist.';
+      return 'That repository is not currently allowed for this project. Choose a repository selected during GitHub App installation, or ask an operator to allow that owner/repo target.';
     }
     if (error.status === 409) {
       return 'A scan is already queued or running for this repository. Watch recent scan activity below.';
@@ -4065,7 +4081,8 @@ export function ProductProjectDetailPage() {
       }
       setGitHubStart(response);
       setConnections((current) => ({ ...current, github: response.connection }));
-      setSuccessMessage('GitHub installation link generated.');
+      setSuccessMessage('Opening GitHub installation.');
+      openGitHubInstallURL(response.install_url);
     } catch (error) {
       if (isStaleRequestSequence(requestSequence)) {
         return;
@@ -4677,7 +4694,7 @@ export function ProductProjectDetailPage() {
                 <div>
                   <p className="idt-app-kicker">Recommended setup</p>
                   <h4>Install the GitHub App</h4>
-                  <p>Start with selected repository access, webhook validation, and owner-ready scan context.</p>
+                  <p>Choose a personal account or organization on GitHub, then select the repositories Identrail can read.</p>
                 </div>
                 <form className="idt-app-form" onSubmit={handleGitHubStart}>
                   <label>
@@ -4691,7 +4708,7 @@ export function ProductProjectDetailPage() {
                     />
                   </label>
                   <button className="idt-btn idt-btn-primary" type="submit" disabled={submitting !== ''}>
-                    {submitting === 'github' ? 'Preparing...' : 'Generate install link'}
+                    {submitting === 'github' ? 'Preparing GitHub...' : 'Continue to GitHub'}
                   </button>
                 </form>
               </article>
@@ -4699,11 +4716,11 @@ export function ProductProjectDetailPage() {
               {githubStart ? (
                 <article className="idt-source-install-card">
                   <div>
-                    <h4>GitHub installation ready</h4>
-                    <p>State expires {formatConnectionTime(githubStart.expires_at)}.</p>
+                    <h4>GitHub did not open automatically?</h4>
+                    <p>Continue with a personal account or organization. State expires {formatConnectionTime(githubStart.expires_at)}.</p>
                   </div>
                   <a className="idt-btn idt-btn-dark" href={githubStart.install_url} target="_blank" rel="noreferrer">
-                    Open GitHub
+                    Continue to GitHub
                   </a>
                 </article>
               ) : null}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6842,6 +6842,13 @@ html[data-theme='light'] .idt-auth-page[data-auth-theme='light'] .idt-auth-provi
   line-height: 1.45;
 }
 
+.idt-auth-panel .idt-app-alert a {
+  color: var(--auth-text);
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
 .idt-auth-panel .idt-app-alert-error {
   border-color: #7f1d1d;
   background: rgba(127, 29, 29, 0.18);


### PR DESCRIPTION
No issue: user-reported production auth and GitHub connector UX fixes.

## What changed
- Redirect WorkOS callback failures back to the web sign-in page with clear reason codes instead of raw JSON responses.
- Preserve the login/signup distinction: login no longer provisions unknown WorkOS identities, while signup can reactivate a retained deactivated/deleted account that still owns the same email.
- Update the sign-in page to explain account-not-found, identity-conflict, state-mismatch, and provider-outage cases with a direct sign-up action where appropriate.
- Continue users directly to the GitHub App installation URL after start, keep a fallback link, and clarify that personal accounts and organizations are both valid installation targets.
- Update docs, OpenAPI, changelog, and regression coverage for the new auth and connector behavior.

## Why
Users were seeing raw API JSON during hosted sign-in failures, unknown login attempts could behave like signup, revoked accounts could not cleanly re-register with the same verified identity, and GitHub installation copy made the flow feel org-only and unnecessarily manual.

## Impact and risk
- Hosted login now fails closed for unknown identities and sends users to sign up instead of creating accounts from `/auth/login`.
- Signup reactivation is limited to retained deactivated/deleted user rows with the same verified email; active email conflicts remain blocked.
- GitHub App installation still uses the existing backend selected-repository completion path and repo scan allowlist, but the product now navigates to GitHub automatically.

## Validation
- `go test ./internal/api -run 'TestUpsertWorkOSUser|TestWorkOS'`
- `go test ./internal/api`
- `go test ./...`
- `npm --prefix web run test -- --run src/App.test.tsx src/productShell.test.tsx`
- `npm --prefix web run test -- --run`
- `npm --prefix web run build`
- `git diff --check`

## AI disclosure
- AI-assisted: yes
- Tools used: OpenAI Codex
- Where used: backend auth flow, frontend auth/connector UX, tests, and docs
- Human verification performed: reviewed diffs, ran the validation commands above, and published a DCO-signed commit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves hosted sign-in callback handling and the GitHub App install flow. Users now see clear messages, unknown logins are guided to sign-up (including after MFA), and GitHub opens automatically to finish setup.

- **New Features**
  - WorkOS callback failures now redirect to `/signin` with reason codes (`account_not_found`, `identity_conflict`, `state_mismatch`, `provider_unavailable`, `callback_error`) and keep a same‑origin `return_to` path; invalid/missing state or code also redirect, and outages include `Retry-After`. OpenAPI updated to reflect redirect behavior.
  - Login vs. signup enforced end-to-end: `login` never creates unknown accounts; `signup` can reactivate a retained deactivated/deleted account with the same verified email; active email conflicts remain blocked. MFA pending state carries the intent, and failed MFA verify returns JSON with `redirect_to` so the app can recover.
  - Sign‑in page shows targeted messages and adds a “Create an account” link for `account_not_found`; copy is clearer for `identity_conflict`, `state_mismatch`, and provider outages.
  - GitHub install start auto‑opens the install URL, keeps a fallback button, and clarifies personal or organization installs. Repo selection/allowlist 403s now say “not currently allowed for this project.”

<sup>Written for commit 1984ed84e5ad5f31c6716d0cd092f426fb7ecfc1. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1296?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

