### PR TITLE
Fix workspace app route crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Fixed app workspace navigation so route changes inside an already-validated
+  workspace no longer rerun the full session gate, and hardened repository
+  finding display helpers against partially populated API records.
 - Added API-backed CLI parity for GitHub repository intelligence. Operators can
   now queue hosted repository scans, list/show/cancel repo scans, filter repo
   findings by lifecycle and confidence, fetch risk graphs, collect GitHub

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -4,6 +4,14 @@ import { StaticRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { App, RoutedSite, ScanIntakeModalProvider } from './App';
 
+function resetBrowserState() {
+  window.history.replaceState({}, '', '/');
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+  document.documentElement.removeAttribute('data-theme');
+  document.body.removeAttribute('style');
+}
+
 function okJSON(payload: unknown) {
   return {
     ok: true,
@@ -164,6 +172,7 @@ function leadCaptureCalls(fetchMock: ReturnType<typeof vi.fn>) {
 describe('App', () => {
   beforeEach(() => {
     cleanup();
+    resetBrowserState();
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
@@ -171,6 +180,7 @@ describe('App', () => {
 
   afterEach(() => {
     cleanup();
+    resetBrowserState();
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
@@ -764,6 +774,56 @@ describe('App', () => {
     );
   });
 
+  it('keeps the workspace shell mounted when switching app sections', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/v1/me')) {
+        return okJSON(currentMePayload('tenant-a', 'workspace-a'));
+      }
+      if (url.includes('/v1/workspaces/workspace-a/projects')) {
+        return okJSON({
+          items: [
+            {
+              tenant_id: 'tenant-a',
+              workspace_id: 'workspace-a',
+              project_id: 'project-1',
+              name: 'Production GitHub',
+              slug: 'production-github',
+              description: 'Repositories that feed production identity risk.',
+              created_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-02T00:00:00Z'
+            }
+          ]
+        });
+      }
+      if (url.includes('/v1/repo-scans')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/repo-findings/trends')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/repo-findings')) {
+        return okJSON({ items: [] });
+      }
+      throw new Error(`Unexpected URL ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    setCurrentPath('/app/tenant-a/workspace-a');
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
+    const meCallsBeforeNavigation = fetchMock.mock.calls.filter(([url]) => typeof url === 'string' && url.endsWith('/v1/me')).length;
+
+    fireEvent.click(screen.getByRole('link', { name: 'Projects' }));
+
+    expect(screen.queryByText(/Validating session/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('navigation', { name: /App sections/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: /Choose a project/i })).toBeInTheDocument();
+    const meCallsAfterNavigation = fetchMock.mock.calls.filter(([url]) => typeof url === 'string' && url.endsWith('/v1/me')).length;
+    expect(meCallsAfterNavigation).toBe(meCallsBeforeNavigation);
+  });
+
   it('keeps the overview trend delta neutral until two trend points exist', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString();
@@ -1019,6 +1079,16 @@ describe('App', () => {
               source_url: 'https://github.com/owner/repo/blob/abc123/config/app.env#L7',
               remediation: 'Rotate the key and move the credential to a secret manager.',
               created_at: '2026-01-01T00:00:00Z'
+            },
+            {
+              id: 'repo-f2',
+              scan_id: 'repo-scan-1',
+              type: 'repo_exposure',
+              severity: undefined,
+              title: 'Finding record with a missing severity',
+              human_summary: 'Legacy API records can omit optional display fields while scans are still being normalized.',
+              repository: 'owner/repo',
+              created_at: '2026-01-01T00:01:00Z'
             }
           ]
         });
@@ -1038,6 +1108,13 @@ describe('App', () => {
     expect(await screen.findByText(/Finding trend/i)).toBeInTheDocument();
     expect(await screen.findByText(/Critical 0 \/ High 1 \/ Medium 0 \/ Low 0 \/ Info 0/i)).toBeInTheDocument();
     expect(await screen.findByText(/Risk \(high/i)).toBeInTheDocument();
+    const missingSeverityFinding = await screen.findByText(/Finding record with a missing severity/i);
+    const missingSeverityRow = missingSeverityFinding.closest('button');
+    expect(missingSeverityRow).not.toBeNull();
+    if (!missingSeverityRow) {
+      throw new Error('missing finding row');
+    }
+    expect(within(missingSeverityRow).getByText('Unknown')).toBeInTheDocument();
 
     const openInGitHub = await screen.findByRole('link', { name: /Open in GitHub/i });
     expect(openInGitHub).toHaveAttribute('href', 'https://github.com/owner/repo/blob/abc123/config/app.env#L7');

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -171,6 +171,7 @@ function leadCaptureCalls(fetchMock: ReturnType<typeof vi.fn>) {
 
 describe('App', () => {
   beforeEach(() => {
+    vi.useRealTimers();
     cleanup();
     resetBrowserState();
     vi.unstubAllEnvs();
@@ -184,6 +185,7 @@ describe('App', () => {
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   it('renders homepage hero and conversion CTAs', () => {
@@ -812,7 +814,8 @@ describe('App', () => {
     setCurrentPath('/app/tenant-a/workspace-a');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
+    await screen.findByRole('region', { name: /Get started/i });
+    expect(screen.getByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
     const meCallsBeforeNavigation = fetchMock.mock.calls.filter(([url]) => typeof url === 'string' && url.endsWith('/v1/me')).length;
 
     fireEvent.click(screen.getByRole('link', { name: 'Projects' }));
@@ -822,6 +825,47 @@ describe('App', () => {
     expect(await screen.findByRole('heading', { level: 2, name: /Choose a project/i })).toBeInTheDocument();
     const meCallsAfterNavigation = fetchMock.mock.calls.filter(([url]) => typeof url === 'string' && url.endsWith('/v1/me')).length;
     expect(meCallsAfterNavigation).toBe(meCallsBeforeNavigation);
+  });
+
+  it('revalidates session after same-workspace navigation from an auth error', async () => {
+    let meCalls = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/v1/me')) {
+        meCalls += 1;
+        return meCalls === 1
+          ? errorJSON(503, 'temporary session outage')
+          : okJSON(currentMePayload('tenant-a', 'workspace-a'));
+      }
+      if (url.includes('/v1/workspaces/workspace-a/projects')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/repo-scans')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/repo-findings/trends')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/repo-findings')) {
+        return okJSON({ items: [] });
+      }
+      throw new Error(`Unexpected URL ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    setCurrentPath('/app/tenant-a/workspace-a');
+    render(<App />);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/Unable to validate account session/i);
+
+    act(() => {
+      window.history.pushState({}, '', '/app/tenant-a/workspace-a/projects');
+      window.dispatchEvent(new PopStateEvent('popstate', { state: {} }));
+    });
+
+    expect(await screen.findByRole('heading', { level: 2, name: /Choose a project/i })).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(meCalls).toBe(2);
   });
 
   it('keeps the overview trend delta neutral until two trend points exist', async () => {
@@ -919,8 +963,8 @@ describe('App', () => {
     setCurrentPath('/app/tenant-b/workspace-b');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { level: 2, name: /Overview/i }, { timeout: 5000 })).toBeInTheDocument();
     const checklistRegion = await screen.findByRole('region', { name: /Get started/i }, { timeout: 5000 });
+    expect(screen.getByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
     const sourceChecklistItem = within(checklistRegion).getByText('Connect a source').closest('li');
     expect(sourceChecklistItem).not.toBeNull();
     if (!sourceChecklistItem) {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -107,11 +107,17 @@ type SourceAvailability = {
   unavailableMessage?: string;
 };
 
-function normalizeValue(value: string): string {
-  return value.trim();
+function normalizeValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value).trim();
+  }
+  return '';
 }
 
-function formatScopeDisplay(value: string): string {
+function formatScopeDisplay(value: unknown): string {
   const normalized = normalizeValue(value);
   if (normalized.length <= 28) {
     return normalized;
@@ -919,22 +925,29 @@ function CommandPalette({
 export function RequireProductAuth({ children }: { children: ReactNode }) {
   const location = useLocation();
   const navigate = useNavigate();
+  const navigateRef = useRef(navigate);
   const params = useParams<ScopeRouteParams>();
-  const routeKey = `${location.pathname}?${location.search}`;
+  const routeTenantID = normalizeValue(params.tenantID);
+  const routeWorkspaceID = normalizeValue(params.workspaceID);
+  const routeScopeKey = `${routeTenantID}::${routeWorkspaceID}`;
   const [status, setStatus] = useState<'checking' | 'authenticated' | 'unauthenticated' | 'error'>('checking');
-  const [validatedRouteKey, setValidatedRouteKey] = useState('');
+  const [validatedScopeKey, setValidatedScopeKey] = useState('');
+  const validatedScopeKeyRef = useRef('');
   const [error, setError] = useState('');
+
+  useEffect(() => {
+    navigateRef.current = navigate;
+  }, [navigate]);
 
   useEffect(() => {
     let mounted = true;
 
     const run = async () => {
-      setStatus('checking');
+      const alreadyValidated = validatedScopeKeyRef.current === routeScopeKey;
+      setStatus((current) => (current === 'authenticated' && alreadyValidated ? current : 'checking'));
       setError('');
       try {
         const current = await apiClient.getMe({ redirectOnUnauthorized: false });
-        const routeTenantID = normalizeValue(params.tenantID ?? '');
-        const routeWorkspaceID = normalizeValue(params.workspaceID ?? '');
         const currentTenantID = normalizeValue(current.me.org_id ?? '');
         const currentWorkspaceID = normalizeValue(current.me.workspace_id ?? '');
         if (
@@ -948,7 +961,7 @@ export function RequireProductAuth({ children }: { children: ReactNode }) {
             if (!mounted) {
               return;
             }
-            navigate(buildTenantWorkspacePath(currentTenantID, currentWorkspaceID), { replace: true });
+            navigateRef.current(buildTenantWorkspacePath(currentTenantID, currentWorkspaceID), { replace: true });
             setStatus('authenticated');
             return;
           }
@@ -960,7 +973,8 @@ export function RequireProductAuth({ children }: { children: ReactNode }) {
         if (!mounted) {
           return;
         }
-        setValidatedRouteKey(routeKey);
+        validatedScopeKeyRef.current = routeScopeKey;
+        setValidatedScopeKey(routeScopeKey);
         setStatus('authenticated');
       } catch (requestError) {
         if (!mounted) {
@@ -971,7 +985,8 @@ export function RequireProductAuth({ children }: { children: ReactNode }) {
           return;
         }
         const message = requestError instanceof Error ? requestError.message : 'Unable to validate account session.';
-        setValidatedRouteKey('');
+        validatedScopeKeyRef.current = '';
+        setValidatedScopeKey('');
         setError(message);
         setStatus('error');
       }
@@ -982,9 +997,9 @@ export function RequireProductAuth({ children }: { children: ReactNode }) {
     return () => {
       mounted = false;
     };
-  }, [navigate, params.tenantID, params.workspaceID, routeKey]);
+  }, [routeTenantID, routeWorkspaceID, routeScopeKey]);
 
-  if (status === 'checking' || (status === 'authenticated' && validatedRouteKey !== routeKey)) {
+  if (status === 'checking' || (status === 'authenticated' && validatedScopeKey !== routeScopeKey)) {
     return <AppShellLoading message="Validating session" />;
   }
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -936,9 +936,11 @@ export function RequireProductAuth({ children }: { children: ReactNode }) {
   const routeTenantID = normalizeValue(params.tenantID);
   const routeWorkspaceID = normalizeValue(params.workspaceID);
   const routeScopeKey = `${routeTenantID}::${routeWorkspaceID}`;
+  const routeLocationKey = `${location.pathname}${location.search}`;
   const [status, setStatus] = useState<'checking' | 'authenticated' | 'unauthenticated' | 'error'>('checking');
   const [validatedScopeKey, setValidatedScopeKey] = useState('');
   const validatedScopeKeyRef = useRef('');
+  const statusRef = useRef(status);
   const [error, setError] = useState('');
 
   useEffect(() => {
@@ -946,11 +948,18 @@ export function RequireProductAuth({ children }: { children: ReactNode }) {
   }, [navigate]);
 
   useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
+
+  useEffect(() => {
     let mounted = true;
 
     const run = async () => {
       const alreadyValidated = validatedScopeKeyRef.current === routeScopeKey;
-      setStatus((current) => (current === 'authenticated' && alreadyValidated ? current : 'checking'));
+      if (alreadyValidated && statusRef.current === 'authenticated') {
+        return;
+      }
+      setStatus('checking');
       setError('');
       try {
         const current = await apiClient.getMe({ redirectOnUnauthorized: false });
@@ -1003,7 +1012,7 @@ export function RequireProductAuth({ children }: { children: ReactNode }) {
     return () => {
       mounted = false;
     };
-  }, [routeTenantID, routeWorkspaceID, routeScopeKey]);
+  }, [routeTenantID, routeWorkspaceID, routeScopeKey, routeLocationKey]);
 
   if (status === 'checking' || (status === 'authenticated' && validatedScopeKey !== routeScopeKey)) {
     return <AppShellLoading message="Validating session" />;

--- a/web/src/repoFindingDisplay.test.ts
+++ b/web/src/repoFindingDisplay.test.ts
@@ -80,10 +80,31 @@ describe('groupRepoFindingsForDisplay', () => {
 
     const firstKey = buildRepoFindingSelectionKey(firstPartialFinding);
     const secondKey = buildRepoFindingSelectionKey(secondPartialFinding);
+    const refreshedFirstKey = buildRepoFindingSelectionKey({ ...firstPartialFinding });
 
     expect(firstKey).toBe(buildRepoFindingSelectionKey(firstPartialFinding));
+    expect(refreshedFirstKey).toBe(firstKey);
     expect(secondKey).toBe(buildRepoFindingSelectionKey(secondPartialFinding));
     expect(firstKey).not.toBe(secondKey);
+  });
+
+  it('finds refreshed fallback records by deterministic selection key', () => {
+    const partialFinding = {
+      ...finding('placeholder-1', 'high'),
+      id: undefined,
+      scan_id: undefined,
+      title: 'Partial finding one',
+      repository: 'owner/repo',
+      file_path: '.github/workflows/deploy.yml',
+      line_number: 42,
+      created_at: '2026-01-01T00:00:00Z'
+    } as unknown as ApiFinding;
+
+    const selectionKey = buildRepoFindingSelectionKey(partialFinding);
+    const refreshedFinding = { ...partialFinding };
+
+    expect(buildRepoFindingSelectionKey(refreshedFinding)).toBe(selectionKey);
+    expect(findRepoFindingBySelectionKey([refreshedFinding], selectionKey)?.title).toBe('Partial finding one');
   });
 
   it('selects findings by scan id and finding id together', () => {

--- a/web/src/repoFindingDisplay.test.ts
+++ b/web/src/repoFindingDisplay.test.ts
@@ -53,6 +53,21 @@ describe('groupRepoFindingsForDisplay', () => {
     expect(groups[2].findings.map((item) => item.id)).toEqual(['critical-item']);
   });
 
+  it('keeps partial finding records in the unknown severity bucket', () => {
+    const partialFinding = { ...finding('missing-severity', 'high'), severity: undefined } as unknown as ApiFinding;
+
+    const groups = groupRepoFindingsForDisplay([partialFinding], 'severity');
+
+    expect(groups.map((group) => group.key)).toEqual(['unknown']);
+    expect(groups[0].findings.map((item) => item.id)).toEqual(['missing-severity']);
+  });
+
+  it('normalizes missing selection fields instead of leaking undefined text into keys', () => {
+    const partialFinding = { id: undefined, scan_id: 'repo-scan-1' } as unknown as ApiFinding;
+
+    expect(buildRepoFindingSelectionKey(partialFinding)).toBe('repo-scan-1::');
+  });
+
   it('selects findings by scan id and finding id together', () => {
     const first = finding('shared-id', 'high');
     const second = { ...finding('shared-id', 'low'), scan_id: 'scan-2', title: 'scan-2 finding' };

--- a/web/src/repoFindingDisplay.ts
+++ b/web/src/repoFindingDisplay.ts
@@ -12,11 +12,24 @@ export type RepoFindingDisplayGroup = {
 };
 
 export type RepoFindingSelection = Partial<
-  Pick<ApiFinding, 'id' | 'scan_id' | 'created_at' | 'repository' | 'type' | 'title' | 'source_url'>
+  Pick<
+    ApiFinding,
+    | 'id'
+    | 'scan_id'
+    | 'created_at'
+    | 'repository'
+    | 'type'
+    | 'title'
+    | 'source_url'
+    | 'lifecycle_key'
+    | 'file_path'
+    | 'line_number'
+    | 'detector'
+    | 'commit'
+    | 'human_summary'
+    | 'remediation'
+  >
 >;
-
-const selectionFallbackKeys = new WeakMap<RepoFindingSelection, string>();
-let selectionFallbackCounter = 0;
 
 function normalizeDisplayValue(value: unknown): string {
   if (typeof value === 'string') {
@@ -34,6 +47,16 @@ function normalizeSeverityBucket(value: unknown): (typeof SEVERITY_ORDER)[number
     return normalized as (typeof SEVERITY_ORDER)[number];
   }
   return 'unknown';
+}
+
+function stableFallbackFingerprint(values: string[]): string {
+  const source = values.join('\u001f');
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < source.length; index += 1) {
+    hash ^= source.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
 }
 
 export function groupRepoFindingsForDisplay(
@@ -78,24 +101,23 @@ export function buildRepoFindingSelectionKey(finding: RepoFindingSelection): str
     return `${scanID}::${findingID}`;
   }
 
-  const existingFallback = selectionFallbackKeys.get(finding);
-  if (existingFallback) {
-    return existingFallback;
-  }
-
-  selectionFallbackCounter += 1;
-  const fallback = [
+  const fallbackParts = [
     scanID,
     findingID,
+    normalizeDisplayValue(finding.lifecycle_key),
     normalizeDisplayValue(finding.repository),
     normalizeDisplayValue(finding.type),
     normalizeDisplayValue(finding.title),
     normalizeDisplayValue(finding.created_at),
     normalizeDisplayValue(finding.source_url),
-    String(selectionFallbackCounter)
-  ].join('::');
-  selectionFallbackKeys.set(finding, fallback);
-  return fallback;
+    normalizeDisplayValue(finding.file_path),
+    normalizeDisplayValue(finding.line_number),
+    normalizeDisplayValue(finding.detector),
+    normalizeDisplayValue(finding.commit),
+    normalizeDisplayValue(finding.human_summary),
+    normalizeDisplayValue(finding.remediation)
+  ];
+  return `partial::${stableFallbackFingerprint(fallbackParts)}`;
 }
 
 export function findRepoFindingBySelectionKey(findings: ApiFinding[], selectionKey: string): ApiFinding | null {

--- a/web/src/repoFindingDisplay.ts
+++ b/web/src/repoFindingDisplay.ts
@@ -11,10 +11,20 @@ export type RepoFindingDisplayGroup = {
   findings: ApiFinding[];
 };
 
-export type RepoFindingSelection = Pick<ApiFinding, 'id' | 'scan_id'>;
+export type RepoFindingSelection = Partial<Pick<ApiFinding, 'id' | 'scan_id'>>;
 
-function normalizeSeverityBucket(value: string): (typeof SEVERITY_ORDER)[number] {
-  const normalized = value.trim().toLowerCase();
+function normalizeDisplayValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value).trim();
+  }
+  return '';
+}
+
+function normalizeSeverityBucket(value: unknown): (typeof SEVERITY_ORDER)[number] {
+  const normalized = normalizeDisplayValue(value).toLowerCase();
   if (SEVERITY_ORDER.includes(normalized as (typeof SEVERITY_ORDER)[number])) {
     return normalized as (typeof SEVERITY_ORDER)[number];
   }
@@ -57,7 +67,7 @@ export function groupRepoFindingsForDisplay(
 }
 
 export function buildRepoFindingSelectionKey(finding: RepoFindingSelection): string {
-  return `${finding.scan_id}::${finding.id}`;
+  return `${normalizeDisplayValue(finding.scan_id)}::${normalizeDisplayValue(finding.id)}`;
 }
 
 export function findRepoFindingBySelectionKey(findings: ApiFinding[], selectionKey: string): ApiFinding | null {


### PR DESCRIPTION
Fixes #1293

## What changed
- Hardened workspace and repository finding display normalization so partially populated API records do not crash the app shell.
- Kept already-authenticated workspace section changes from rerunning the full session validation gate, removing the quick `Validating session` flash when moving between Overview, Projects, Findings, and Settings in the same workspace.
- Reset browser state in app tests and added regressions for missing finding fields and in-shell route transitions.
- Added an Unreleased changelog note for the app reliability fix.

## Why it changed
The findings view could hit an error boundary when a backend record omitted a display field such as severity or selection IDs. The app shell also revalidated the session on internal route changes, which made normal section switches feel like a page reload.

## Impact and risk
This is a focused web reliability and UX change. It does not change API contracts or backend behavior. Risk is low; the main behavior change is that validated same-workspace navigation keeps the shell mounted while section data refreshes.

## Validation performed
- `npm test -- --run src/App.test.tsx src/repoFindingDisplay.test.ts`
- `npm test -- --run`
- `npm run build`
- `git diff --check`

AI-assisted: yes
Tools used: OpenAI Codex
Where used: web app route guard, repository finding display helpers, and regression tests
Human verification performed: reviewed diff, ran targeted tests, full web test suite, production build, and diff whitespace check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workspace app route crashes and removes the “Validating session” flash. Auth checks are now scoped per tenant/workspace, retry after errors, and display/selection logic tolerates partial records.

- **Bug Fixes**
  - Normalized display values in `productShell` and repo finding helpers to accept missing, boolean, number, and non-string fields; unknown severity shows as “Unknown” and groups correctly.
  - Scoped auth validation by tenant/workspace so in-workspace navigation keeps the shell mounted and avoids extra `/v1/me` calls; if a check fails, the next same-workspace navigation retries and recovers.
  - Reworked fallback selection keys to deterministic fingerprints when IDs are missing; keys stay stable across refreshes so refreshed records match; added tests for partial records, unknown severity, in-shell navigation, auth retry, and browser state reset; updated changelog.

<sup>Written for commit c34d344dbddf488784d1eb551003306cf59c74e6. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1297?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

