### PR TITLE
Add ordered AWS production release workflow

### DIFF
--- a/.github/workflows/aws-api-database-migrations.yml
+++ b/.github/workflows/aws-api-database-migrations.yml
@@ -16,6 +16,23 @@ on:
         required: true
         type: string
         default: migrations
+  workflow_call:
+    inputs:
+      confirm_migrations:
+        description: "Confirmation string for migration execution."
+        required: false
+        type: string
+        default: run-api-migrations
+      database_url_secret_arn:
+        description: "Optional Secrets Manager ARN. Blank uses repository secret API_DATABASE_URL_SECRET_ARN."
+        required: false
+        type: string
+        default: ""
+      migrations_dir:
+        description: "Migration directory to apply."
+        required: false
+        type: string
+        default: migrations
 
 permissions:
   contents: read

--- a/.github/workflows/aws-api-manual-deploy.yml
+++ b/.github/workflows/aws-api-manual-deploy.yml
@@ -89,7 +89,7 @@ on:
         description: "S3 key for Terraform state."
         required: false
         type: string
-        default: identrail/dev/aws-api.tfstate
+        default: ""
 
 permissions:
   contents: read

--- a/.github/workflows/aws-api-manual-deploy.yml
+++ b/.github/workflows/aws-api-manual-deploy.yml
@@ -35,6 +35,10 @@ on:
         description: "ACM certificate ARN. Leave blank to use repository variable API_CERTIFICATE_ARN."
         required: false
         type: string
+      database_url_secret_arn:
+        description: "Optional Secrets Manager ARN. Blank uses repository secret API_DATABASE_URL_SECRET_ARN."
+        required: false
+        type: string
       terraform_state_bucket:
         description: "S3 bucket for Terraform state. Leave blank to use repository variable AWS_TERRAFORM_STATE_BUCKET."
         required: false
@@ -80,6 +84,11 @@ on:
         required: false
         type: string
         default: ""
+      database_url_secret_arn:
+        description: "Optional Secrets Manager ARN. Blank uses repository secret API_DATABASE_URL_SECRET_ARN."
+        required: false
+        type: string
+        default: ""
       terraform_state_bucket:
         description: "S3 bucket for Terraform state. Leave blank to use repository variable AWS_TERRAFORM_STATE_BUCKET."
         required: false
@@ -122,7 +131,7 @@ jobs:
       API_WORKER_DESIRED_COUNT: ${{ vars.API_WORKER_DESIRED_COUNT || '1' }}
       API_WORKER_TASK_CPU: ${{ vars.API_WORKER_TASK_CPU || '256' }}
       API_WORKER_TASK_MEMORY: ${{ vars.API_WORKER_TASK_MEMORY || '512' }}
-      API_DATABASE_URL_SECRET_ARN: ${{ secrets.API_DATABASE_URL_SECRET_ARN }}
+      API_DATABASE_URL_SECRET_ARN: ${{ inputs.database_url_secret_arn || secrets.API_DATABASE_URL_SECRET_ARN }}
       API_SESSION_KEY_SECRET_ARN: ${{ secrets.API_SESSION_KEY_SECRET_ARN }}
       API_FEATURE_WORKOS_LOGIN: ${{ vars.API_FEATURE_WORKOS_LOGIN || '' }}
       API_FEATURE_ONBOARDING_WIZARD: ${{ vars.API_FEATURE_ONBOARDING_WIZARD || 'true' }}

--- a/.github/workflows/aws-api-manual-deploy.yml
+++ b/.github/workflows/aws-api-manual-deploy.yml
@@ -44,6 +44,52 @@ on:
         required: false
         type: string
         default: identrail/dev/aws-api.tfstate
+  workflow_call:
+    inputs:
+      operation:
+        description: "Run a Terraform plan or apply for the AWS API hosting stack."
+        required: false
+        type: string
+        default: plan
+      confirm_apply:
+        description: "Required for apply: type apply-api.identrail.com"
+        required: false
+        type: string
+        default: ""
+      api_container_image:
+        description: "Immutable API image, for example ghcr.io/identrail/identrail-api:sha-<commit>."
+        required: true
+        type: string
+      api_vpc_id:
+        description: "VPC ID. Leave blank to use repository variable API_VPC_ID."
+        required: false
+        type: string
+        default: ""
+      api_public_subnet_ids_json:
+        description: "JSON array of two public subnet IDs. Leave blank to use repository variable API_PUBLIC_SUBNET_IDS_JSON."
+        required: false
+        type: string
+        default: ""
+      api_task_subnet_ids_json:
+        description: "Optional JSON array of task subnet IDs. Blank uses the public subnets for low-cost bootstrap mode."
+        required: false
+        type: string
+        default: ""
+      api_certificate_arn:
+        description: "ACM certificate ARN. Leave blank to use repository variable API_CERTIFICATE_ARN."
+        required: false
+        type: string
+        default: ""
+      terraform_state_bucket:
+        description: "S3 bucket for Terraform state. Leave blank to use repository variable AWS_TERRAFORM_STATE_BUCKET."
+        required: false
+        type: string
+        default: ""
+      terraform_state_key:
+        description: "S3 key for Terraform state."
+        required: false
+        type: string
+        default: identrail/dev/aws-api.tfstate
 
 permissions:
   contents: read

--- a/.github/workflows/aws-production-release.yml
+++ b/.github/workflows/aws-production-release.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       api_container_image:
-        description: "Immutable API image, for example ghcr.io/identrail/identrail-api:sha-<commit>."
+        description: "Tagged immutable API image, for example ghcr.io/identrail/identrail-api:sha-<commit>."
         required: true
         type: string
       api_base_url:
@@ -79,8 +79,8 @@ jobs:
             exit 1
           fi
 
-          if ! [[ "${API_CONTAINER_IMAGE}" =~ ^ghcr\.io/identrail/identrail-api:(sha-[0-9a-f]{12,40}|v[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?)$ || "${API_CONTAINER_IMAGE}" =~ ^ghcr\.io/identrail/identrail-api@sha256:[0-9a-f]{64}$ ]]; then
-            echo "api_container_image must be an immutable ghcr.io/identrail/identrail-api image."
+          if ! [[ "${API_CONTAINER_IMAGE}" =~ ^ghcr\.io/identrail/identrail-api:(sha-[0-9a-f]{12,40}|v[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?)$ ]]; then
+            echo "api_container_image must be a tagged immutable ghcr.io/identrail/identrail-api image so the deploy workflow can derive the matching worker image."
             exit 1
           fi
 
@@ -144,11 +144,12 @@ jobs:
 
           base="${API_BASE_URL%/}"
           last_error=""
+          curl_args=(-fsS --connect-timeout 3 --max-time 8)
 
           for attempt in $(seq 1 30); do
-            if health="$(curl -fsS "${base}/healthz" 2>&1)" &&
-               ready="$(curl -fsS "${base}/readyz" 2>&1)" &&
-               auth_config="$(curl -fsS "${base}/v1/auth/config" 2>&1)" &&
+            if health="$(curl "${curl_args[@]}" "${base}/healthz" 2>&1)" &&
+               ready="$(curl "${curl_args[@]}" "${base}/readyz" 2>&1)" &&
+               auth_config="$(curl "${curl_args[@]}" "${base}/v1/auth/config" 2>&1)" &&
                jq -e '.status == "ok"' >/dev/null <<< "${health}" &&
                jq -e '.status == "ready"' >/dev/null <<< "${ready}" &&
                jq -e 'has("auth") and has("features")' >/dev/null <<< "${auth_config}"; then

--- a/.github/workflows/aws-production-release.yml
+++ b/.github/workflows/aws-production-release.yml
@@ -114,7 +114,7 @@ jobs:
     uses: ./.github/workflows/aws-api-database-migrations.yml
     with:
       confirm_migrations: run-api-migrations
-      database_url_secret_arn: ${{ inputs.database_url_secret_arn }}
+      database_url_secret_arn: ${{ inputs.database_url_secret_arn || '' }}
       migrations_dir: ${{ inputs.migrations_dir }}
     secrets: inherit
 
@@ -133,7 +133,7 @@ jobs:
       api_public_subnet_ids_json: ${{ inputs.api_public_subnet_ids_json }}
       api_task_subnet_ids_json: ${{ inputs.api_task_subnet_ids_json }}
       api_certificate_arn: ${{ inputs.api_certificate_arn }}
-      database_url_secret_arn: ${{ inputs.database_url_secret_arn }}
+      database_url_secret_arn: ${{ inputs.database_url_secret_arn || '' }}
       terraform_state_bucket: ${{ inputs.terraform_state_bucket || '' }}
       terraform_state_key: ${{ vars.AWS_TERRAFORM_STATE_KEY || '' }}
     secrets: inherit

--- a/.github/workflows/aws-production-release.yml
+++ b/.github/workflows/aws-production-release.yml
@@ -1,0 +1,170 @@
+name: AWS Production Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm_release:
+        description: "Required: type release-api.identrail.com"
+        required: true
+        type: string
+      api_container_image:
+        description: "Immutable API image, for example ghcr.io/identrail/identrail-api:sha-<commit>."
+        required: true
+        type: string
+      api_base_url:
+        description: "Public API base URL for post-deploy smoke checks."
+        required: true
+        type: string
+        default: https://api.identrail.com
+      database_url_secret_arn:
+        description: "Optional Secrets Manager ARN. Blank uses repository secret API_DATABASE_URL_SECRET_ARN."
+        required: false
+        type: string
+      migrations_dir:
+        description: "Migration directory to apply before deploying the API and worker."
+        required: true
+        type: string
+        default: migrations
+      api_vpc_id:
+        description: "VPC ID. Leave blank to use repository variable API_VPC_ID."
+        required: false
+        type: string
+      api_public_subnet_ids_json:
+        description: "JSON array of two public subnet IDs. Leave blank to use repository variable API_PUBLIC_SUBNET_IDS_JSON."
+        required: false
+        type: string
+      api_task_subnet_ids_json:
+        description: "Optional JSON array of task subnet IDs. Blank uses the public subnets for low-cost bootstrap mode."
+        required: false
+        type: string
+      api_certificate_arn:
+        description: "ACM certificate ARN. Leave blank to use repository variable API_CERTIFICATE_ARN."
+        required: false
+        type: string
+      terraform_state_bucket:
+        description: "S3 bucket for Terraform state. Leave blank to use repository variable AWS_TERRAFORM_STATE_BUCKET."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: aws-production-release
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate release inputs
+    if: github.repository == 'identrail/identrail'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      CONFIRM_RELEASE: ${{ inputs.confirm_release }}
+      API_CONTAINER_IMAGE: ${{ inputs.api_container_image }}
+      API_BASE_URL: ${{ inputs.api_base_url }}
+    steps:
+      - name: Validate release request
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_REF_NAME}" != "dev" ]; then
+            echo "Run this workflow from the dev branch. The AWS OIDC role trust is intentionally scoped to refs/heads/dev."
+            exit 1
+          fi
+
+          if [ "${CONFIRM_RELEASE}" != "release-api.identrail.com" ]; then
+            echo "To release the hosted API, type release-api.identrail.com in the confirmation field."
+            exit 1
+          fi
+
+          if ! [[ "${API_CONTAINER_IMAGE}" =~ ^ghcr\.io/identrail/identrail-api:(sha-[0-9a-f]{12,40}|v[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?)$ || "${API_CONTAINER_IMAGE}" =~ ^ghcr\.io/identrail/identrail-api@sha256:[0-9a-f]{64}$ ]]; then
+            echo "api_container_image must be an immutable ghcr.io/identrail/identrail-api image."
+            exit 1
+          fi
+
+          api_base_url="${API_BASE_URL%/}"
+          if ! [[ "${api_base_url}" =~ ^https://[^/[:space:]]+(:[0-9]+)?$ ]]; then
+            echo "api_base_url must be a bare HTTPS origin such as https://api.identrail.com."
+            exit 1
+          fi
+
+          {
+            echo "## AWS production release"
+            echo
+            echo "- API image: \`${API_CONTAINER_IMAGE}\`"
+            echo "- API base URL: \`${api_base_url}\`"
+            echo "- Next step: run database migrations before deploying API and worker."
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  migrate:
+    name: Run database migrations
+    needs: validate
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/aws-api-database-migrations.yml
+    with:
+      confirm_migrations: run-api-migrations
+      database_url_secret_arn: ${{ inputs.database_url_secret_arn }}
+      migrations_dir: ${{ inputs.migrations_dir }}
+    secrets: inherit
+
+  deploy:
+    name: Deploy API and worker
+    needs: migrate
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/aws-api-manual-deploy.yml
+    with:
+      operation: apply
+      confirm_apply: apply-api.identrail.com
+      api_container_image: ${{ inputs.api_container_image }}
+      api_vpc_id: ${{ inputs.api_vpc_id }}
+      api_public_subnet_ids_json: ${{ inputs.api_public_subnet_ids_json }}
+      api_task_subnet_ids_json: ${{ inputs.api_task_subnet_ids_json }}
+      api_certificate_arn: ${{ inputs.api_certificate_arn }}
+      terraform_state_bucket: ${{ inputs.terraform_state_bucket }}
+    secrets: inherit
+
+  smoke:
+    name: Verify hosted API
+    needs: deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    env:
+      API_BASE_URL: ${{ inputs.api_base_url }}
+    steps:
+      - name: Run API smoke checks
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          base="${API_BASE_URL%/}"
+          last_error=""
+
+          for attempt in $(seq 1 30); do
+            if health="$(curl -fsS "${base}/healthz" 2>&1)" &&
+               ready="$(curl -fsS "${base}/readyz" 2>&1)" &&
+               auth_config="$(curl -fsS "${base}/v1/auth/config" 2>&1)" &&
+               jq -e '.status == "ok"' >/dev/null <<< "${health}" &&
+               jq -e '.status == "ready"' >/dev/null <<< "${ready}" &&
+               jq -e 'has("auth") and has("features")' >/dev/null <<< "${auth_config}"; then
+              {
+                echo "## AWS production release smoke checks"
+                echo
+                echo "- \`${base}/healthz\`: ok"
+                echo "- \`${base}/readyz\`: ready"
+                echo "- \`${base}/v1/auth/config\`: returned auth and feature config"
+              } >> "${GITHUB_STEP_SUMMARY}"
+              exit 0
+            fi
+
+            last_error="attempt ${attempt} failed"
+            sleep 10
+          done
+
+          echo "Hosted API smoke checks did not pass after retries: ${last_error}" >&2
+          exit 1

--- a/.github/workflows/aws-production-release.yml
+++ b/.github/workflows/aws-production-release.yml
@@ -127,6 +127,7 @@ jobs:
       api_task_subnet_ids_json: ${{ inputs.api_task_subnet_ids_json }}
       api_certificate_arn: ${{ inputs.api_certificate_arn }}
       terraform_state_bucket: ${{ inputs.terraform_state_bucket }}
+      terraform_state_key: ${{ vars.AWS_TERRAFORM_STATE_KEY || '' }}
     secrets: inherit
 
   smoke:

--- a/.github/workflows/aws-production-release.yml
+++ b/.github/workflows/aws-production-release.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       api_container_image:
-        description: "Tagged immutable API image, for example ghcr.io/identrail/identrail-api:sha-<commit>."
+        description: "Current-commit API image, for example ghcr.io/identrail/identrail-api:sha-<current-dev-commit>."
         required: true
         type: string
       api_base_url:
@@ -79,8 +79,14 @@ jobs:
             exit 1
           fi
 
-          if ! [[ "${API_CONTAINER_IMAGE}" =~ ^ghcr\.io/identrail/identrail-api:(sha-[0-9a-f]{12,40}|v[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?)$ ]]; then
-            echo "api_container_image must be a tagged immutable ghcr.io/identrail/identrail-api image so the deploy workflow can derive the matching worker image."
+          if ! [[ "${API_CONTAINER_IMAGE}" =~ ^ghcr\.io/identrail/identrail-api:sha-([0-9a-f]{12,40})$ ]]; then
+            echo "api_container_image must be a current-commit ghcr.io/identrail/identrail-api:sha-<commit> image so migrations and deployed code come from the same source."
+            exit 1
+          fi
+
+          image_sha="${BASH_REMATCH[1]}"
+          if [[ "${GITHUB_SHA}" != "${image_sha}"* ]]; then
+            echo "api_container_image sha tag must match this workflow commit (${GITHUB_SHA}) so migrations and deployed code stay in lockstep."
             exit 1
           fi
 
@@ -94,6 +100,7 @@ jobs:
             echo "## AWS production release"
             echo
             echo "- API image: \`${API_CONTAINER_IMAGE}\`"
+            echo "- Source commit: \`${GITHUB_SHA}\`"
             echo "- API base URL: \`${api_base_url}\`"
             echo "- Next step: run database migrations before deploying API and worker."
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/aws-production-release.yml
+++ b/.github/workflows/aws-production-release.yml
@@ -126,7 +126,7 @@ jobs:
       api_public_subnet_ids_json: ${{ inputs.api_public_subnet_ids_json }}
       api_task_subnet_ids_json: ${{ inputs.api_task_subnet_ids_json }}
       api_certificate_arn: ${{ inputs.api_certificate_arn }}
-      terraform_state_bucket: ${{ inputs.terraform_state_bucket }}
+      terraform_state_bucket: ${{ inputs.terraform_state_bucket || '' }}
       terraform_state_key: ${{ vars.AWS_TERRAFORM_STATE_KEY || '' }}
     secrets: inherit
 

--- a/.github/workflows/aws-production-release.yml
+++ b/.github/workflows/aws-production-release.yml
@@ -133,6 +133,7 @@ jobs:
       api_public_subnet_ids_json: ${{ inputs.api_public_subnet_ids_json }}
       api_task_subnet_ids_json: ${{ inputs.api_task_subnet_ids_json }}
       api_certificate_arn: ${{ inputs.api_certificate_arn }}
+      database_url_secret_arn: ${{ inputs.database_url_secret_arn }}
       terraform_state_bucket: ${{ inputs.terraform_state_bucket || '' }}
       terraform_state_key: ${{ vars.AWS_TERRAFORM_STATE_KEY || '' }}
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Fixed app workspace navigation so route changes inside an already-validated
   workspace no longer rerun the full session gate, and hardened repository
   finding display helpers against partially populated API records.
+- Added a manual AWS production release workflow that runs hosted database
+  migrations before deploying the selected immutable API/worker image and then
+  performs API smoke checks, reducing the chance of code/schema drift during
+  hosted releases.
 - Fixed web UI polish issues: the workspace overview header no longer crowds the
   "Overview"/"Latest activity" text (the boxed border is removed and the title and
   subtitle get clean spacing with no divider), the sign-in/sign-up logo mark now renders a visible

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -97,13 +97,14 @@ default, stores Terraform state in S3, and only applies when an operator selects
 Run it from the `dev` branch because the AWS OIDC deployment role trust is
 intentionally scoped to that branch.
 
-For routine hosted API releases after an immutable image has been published,
-prefer the `AWS Production Release` workflow. It is still manually approved, but
-it runs the database migration workflow first, deploys the API and worker with
-the selected immutable `ghcr.io/identrail/identrail-api` image, and then checks
-`/healthz`, `/readyz`, and `/v1/auth/config`. This keeps hosted API code,
-worker code, and the database schema in the same release boundary instead of
-requiring operators to remember the migration and deploy order by hand.
+For routine hosted API releases after an immutable image for the current `dev`
+commit has been published, prefer the `AWS Production Release` workflow. It is
+still manually approved, but it runs the database migration workflow first,
+deploys the API and worker with the matching
+`ghcr.io/identrail/identrail-api:sha-<current-dev-commit>` image, and then
+checks `/healthz`, `/readyz`, and `/v1/auth/config`. This keeps hosted API
+code, worker code, and the database schema in the same release boundary instead
+of requiring operators to remember the migration and deploy order by hand.
 
 Repository configuration required before the workflow can plan:
 

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -156,8 +156,9 @@ tag to this hosted API path.
 Worker hosting is enabled by default in this manual workflow through
 `API_WORKER_ENABLED=true`. If `API_WORKER_CONTAINER_IMAGE` is omitted, the
 preparation script derives the matching immutable worker image from the API
-image tag or digest, for example
-`ghcr.io/identrail/identrail-worker:sha-<commit>`. Set
+image tag, for example `ghcr.io/identrail/identrail-worker:sha-<commit>`.
+When deploying the API image by digest, set `API_WORKER_CONTAINER_IMAGE`
+explicitly to the matching immutable worker digest. Set
 `API_WORKER_ENABLED=false` only as a rollback knob when the API should stay up
 but queued scan processing must be paused.
 

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -97,6 +97,14 @@ default, stores Terraform state in S3, and only applies when an operator selects
 Run it from the `dev` branch because the AWS OIDC deployment role trust is
 intentionally scoped to that branch.
 
+For routine hosted API releases after an immutable image has been published,
+prefer the `AWS Production Release` workflow. It is still manually approved, but
+it runs the database migration workflow first, deploys the API and worker with
+the selected immutable `ghcr.io/identrail/identrail-api` image, and then checks
+`/healthz`, `/readyz`, and `/v1/auth/config`. This keeps hosted API code,
+worker code, and the database schema in the same release boundary instead of
+requiring operators to remember the migration and deploy order by hand.
+
 Repository configuration required before the workflow can plan:
 
 - secret `AWS_ROLE_ARN`: GitHub OIDC deployment role ARN

--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -91,9 +91,10 @@ Portable deployment profiles:
 
 1. Ensure CI is green on `dev` (`Go Quality`, `Go Tests`, `Go Integration (Postgres)`, `Web Build`).
 2. For hosted AWS API releases, prefer the `AWS Production Release` workflow
-   after the immutable image is published. It runs migrations, deploys the API
-   and worker with the matching image, and performs hosted API smoke checks in
-   one ordered manual release.
+   after the immutable image for the current `dev` commit is published. It runs
+   migrations, deploys the API and worker with the matching
+   `sha-<current-dev-commit>` image, and performs hosted API smoke checks in one
+   ordered manual release.
 3. For non-AWS or lower-level deployments, run migrations once using the
    dedicated migration job:
    - Kubernetes manifests: apply `deploy/kubernetes/migration-job.yaml` and wait for job completion.

--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -90,21 +90,26 @@ Portable deployment profiles:
 ## 2) Deploy Sequence
 
 1. Ensure CI is green on `dev` (`Go Quality`, `Go Tests`, `Go Integration (Postgres)`, `Web Build`).
-2. Run migrations once using the dedicated migration job:
+2. For hosted AWS API releases, prefer the `AWS Production Release` workflow
+   after the immutable image is published. It runs migrations, deploys the API
+   and worker with the matching image, and performs hosted API smoke checks in
+   one ordered manual release.
+3. For non-AWS or lower-level deployments, run migrations once using the
+   dedicated migration job:
    - Kubernetes manifests: apply `deploy/kubernetes/migration-job.yaml` and wait for job completion.
    - Helm: pre-install/pre-upgrade hook job runs automatically when `migrations.enabled=true`.
-3. Deploy API service with `IDENTRAIL_RUN_MIGRATIONS=false`.
-4. Verify health endpoint: `GET /healthz`.
-5. Deploy worker with same DB + provider config (`IDENTRAIL_RUN_MIGRATIONS=false`).
-6. Trigger one scan (`POST /v1/scans`) with write-authorized key.
-7. Verify:
+4. Deploy API service with `IDENTRAIL_RUN_MIGRATIONS=false`.
+5. Verify health endpoint: `GET /healthz`.
+6. Deploy worker with same DB + provider config (`IDENTRAIL_RUN_MIGRATIONS=false`).
+7. Trigger one scan (`POST /v1/scans`) with write-authorized key.
+8. Verify:
   - scan is accepted as queued (`202`) then completed by worker
   - findings list (`GET /v1/findings`)
   - findings summary (`GET /v1/findings/summary`)
   - findings trends (`GET /v1/findings/trends`)
   - scan diff (`GET /v1/scans/:scan_id/diff`)
   - scan events (`GET /v1/scans/:scan_id/events`)
-8. If repo scan is enabled:
+9. If repo scan is enabled:
    - trigger `POST /v1/repo-scans`
    - verify `GET /v1/repo-scans`
    - verify `GET /v1/repo-findings?repo_scan_id=<id>`


### PR DESCRIPTION
No issue: operational hardening for hosted AWS releases.

## What changed
- Added a manual `AWS Production Release` workflow that validates an immutable API image, runs hosted database migrations, deploys the API and worker, and then runs public API smoke checks.
- Made the existing `AWS API Database Migrations` and `AWS API Manual Deploy` workflows reusable through `workflow_call` while preserving their existing manual dispatch behavior.
- Updated the AWS hosting docs, deploy runbook, and changelog to make the ordered release path the preferred hosted API release process.

## Why it changed
The hosted API and worker can now be released from one controlled workflow instead of relying on operators to remember a separate migration step before/after deploy. This prevents code/schema drift like deploying API code that expects a database column before the migration has been applied.

## Impact and risk
- Existing manual migration and deploy workflows still work independently.
- The new release workflow is manually approved, dev-branch scoped, and requires the confirmation string `release-api.identrail.com`.
- It requires an immutable `ghcr.io/identrail/identrail-api` image and reuses the current Terraform deploy workflow, so worker image derivation remains centralized.
- Smoke checks retry `/healthz`, `/readyz`, and `/v1/auth/config` after deploy.

## Validation performed
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/aws-production-release.yml .github/workflows/aws-api-database-migrations.yml .github/workflows/aws-api-manual-deploy.yml`
- `git diff --check`
- Commit/push hooks passed: merge-conflict check, YAML check, end-of-file fix, trailing whitespace, gofmt check, `go vet`, local env token hygiene, and Vercel artifact hygiene.

## AI Usage Disclosure
- AI-assisted: yes
- Tools used: Codex
- Where used: GitHub Actions workflow and documentation changes
- Human verification performed: reviewed diff, ran actionlint, whitespace checks, and repository hooks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manual, ordered AWS production release workflow that runs hosted DB migrations, deploys an immutable `ghcr.io/identrail/identrail-api` image pinned to the source commit for API and worker, then runs smoke checks to prevent code/schema drift.

- **New Features**
  - Adds `AWS Production Release` (manual on `dev`), with a single concurrency group and `release-api.identrail.com` confirmation.
  - Enforces commit-bound image: requires `ghcr.io/identrail/identrail-api:sha-<commit>` matching the workflow commit; validates a bare HTTPS `api_base_url`; ensures runs from `dev`.
  - Forwards VPC, subnet, cert, Terraform state inputs, and optional `database_url_secret_arn`; threads the state key from `vars.AWS_TERRAFORM_STATE_KEY`.
  - Post-deploy smoke checks retry `/healthz`, `/readyz`, and `/v1/auth/config` with JSON assertions.

- **Refactors**
  - Makes `aws-api-database-migrations.yml` and `aws-api-manual-deploy.yml` reusable via `workflow_call`; both accept `database_url_secret_arn`, and migrations accept `migrations_dir`. The release forwards these and deploy overrides including `terraform_state_bucket`/`terraform_state_key`.
  - Updates `CHANGELOG.md`, `docs/aws-api-hosting.md`, and `docs/deploy-runbook.md` to prefer the ordered release path and clarify worker image derivation from the API tag; when deploying by digest, set the worker image explicitly. Existing standalone workflows still work.

<sup>Written for commit a2b44974bd938f47ea1f1babcdd03d19cb13e81e. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1299?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

