### PR TITLE
fix(web): report docker pulls for primary image only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Changed the homepage "Docker pulls" proof pill to report the primary
+  `identrail/identrail` image only, instead of summing pull counts across all
+  five published service images. The previous sum overstated adoption because a
+  single quickstart/CI run pulls multiple images at once.
 - Improved hosted auth and GitHub connector onboarding UX. WorkOS callback
   failures now redirect back to the web sign-in page with user-facing reasons
   instead of raw JSON, login no longer provisions unknown identities, signup can

--- a/web/src/components/home/HeroOpenSourceProofPills.test.tsx
+++ b/web/src/components/home/HeroOpenSourceProofPills.test.tsx
@@ -43,14 +43,14 @@ describe('HeroOpenSourceProofPills', () => {
     expect(within(dockerPill as HTMLElement).queryByText('0')).not.toBeInTheDocument();
   });
 
-  it('loads pull metrics from the published Docker Hub repositories', async () => {
+  it('loads pull metrics from the primary published Docker Hub repository', async () => {
     const dockerMetricPaths: string[] = [];
     const fetchMock = vi.fn(async (input: string | URL | Request) => {
       const url = new URL(fetchURL(input));
       if (url.hostname === 'api.github.com') return okJSON({ stargazers_count: 3 });
       if (url.hostname === 'img.shields.io' && url.pathname.includes('/docker/pulls')) {
         dockerMetricPaths.push(url.pathname);
-        return okJSON({ message: '1' });
+        return okJSON({ message: '2.4k' });
       }
       return okJSON({});
     });
@@ -58,14 +58,8 @@ describe('HeroOpenSourceProofPills', () => {
 
     render(<HeroOpenSourceProofPills />);
 
-    await waitFor(() => expect(screen.getByText('5')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('2.4k+')).toBeInTheDocument());
 
-    expect(dockerMetricPaths).toEqual([
-      '/docker/pulls/identrail/identrail.json',
-      '/docker/pulls/identrail/identrail-api.json',
-      '/docker/pulls/identrail/identrail-worker.json',
-      '/docker/pulls/identrail/identrail-web.json',
-      '/docker/pulls/identrail/identrail-agent.json'
-    ]);
+    expect(dockerMetricPaths).toEqual(['/docker/pulls/identrail/identrail.json']);
   });
 });

--- a/web/src/siteConfig.ts
+++ b/web/src/siteConfig.ts
@@ -54,11 +54,5 @@ export const githubRepo = {
 
 export const projectMetricsSource = {
   github: githubRepo,
-  dockerHubRepos: [
-    'identrail/identrail',
-    'identrail/identrail-api',
-    'identrail/identrail-worker',
-    'identrail/identrail-web',
-    'identrail/identrail-agent'
-  ]
+  dockerHubRepos: ['identrail/identrail']
 } as const;


### PR DESCRIPTION
## What changed
The homepage "Docker pulls" proof pill now reports the pull count of the primary `identrail/identrail` image only, instead of summing the pull counts of all five published service images (`identrail`, `identrail-api`, `identrail-worker`, `identrail-web`, `identrail-agent`).

## Why
The summed figure (~11.4k+) materially overstated real-world adoption. A single `make quickstart` or CI run pulls several of those images at once, so the sum counts one logical deployment as multiple pulls. Reporting the primary image (~2.4k) is a more honest, defensible adoption signal next to the GitHub stars pill.

## Impact and risk
- Frontend-only, marketing/landing copy. No API, schema, or runtime behavior change.
- The pill remains live-fetched from shields.io with the existing cache/fallback behavior; only the set of summed repos changed.
- Low risk; the displayed number drops to reflect the single image.

## Validation
- `npx vitest run src/components/home/HeroOpenSourceProofPills.test.tsx` — 2 passed (updated the multi-repo test to assert a single `identrail/identrail` request).
- `npm run build` — clean (tsc + vite build + prerender of 41 routes).
- Verified in the dev server: the pill renders "2.4k+ Docker pulls" (down from 11.4k+).

## AI-Assisted and AI-Generated Code Policy
- AI-assisted: yes
- Tools used: Claude Code
- Where used: `web/src/siteConfig.ts`, `web/src/components/home/HeroOpenSourceProofPills.test.tsx`, `CHANGELOG.md`
- Human verification performed: reviewed the diff, ran the component test suite and full web build locally, confirmed the rendered value in the dev server

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the homepage “Docker pulls” pill to show pulls for the primary `identrail/identrail` image only to avoid inflated counts from multiple service images.

- **Bug Fixes**
  - Limit `projectMetricsSource.dockerHubRepos` to `identrail/identrail` (drop other `identrail-*` entries).
  - Update `HeroOpenSourceProofPills` test to expect a single repo and the “2.4k+” display.
  - Add a changelog entry documenting the change.

<sup>Written for commit 2cc4fd4ef4f8025630af602c795a6e190663b3a4. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1301?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

