### PR TITLE
Route removed WorkOS logins to signup reactivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@
 - Improved hosted auth and GitHub connector onboarding UX. WorkOS callback
   failures now redirect back to the web sign-in page with user-facing reasons
   instead of raw JSON, login no longer provisions unknown identities, signup can
-  reactivate a deactivated/deleted account that still owns the same email, and
-  the GitHub App setup now continues directly to GitHub with copy covering both
+  reactivate a deactivated/deleted account that still owns the same email, login
+  now points retained removed accounts to the reactivation signup path, and the
+  GitHub App setup now continues directly to GitHub with copy covering both
   personal accounts and organizations.
 - Fixed app workspace navigation so route changes inside an already-validated
   workspace no longer rerun the full session gate, and hardened repository

--- a/docs/auth/identity-linking-rules.md
+++ b/docs/auth/identity-linking-rules.md
@@ -120,12 +120,15 @@ When WorkOS sends a `user.deleted` webhook, we set the `users.status` to `deacti
 The hosted `login` and `signup` entry points intentionally differ. `login` only
 resolves an existing WorkOS identity; when a verified email or GitHub OAuth
 profile has never signed up, the callback sends the browser back to
-`/signin?reason=account_not_found` so the app can point the user to sign up.
-`signup` may create a new user, and it may reactivate a retained `deactivated`
-or `deleted` user row when the verified email is the same. Signup still rejects
-an active user with the same email but a different WorkOS subject as an identity
-conflict; that account must use its original sign-in method or be resolved by
-support.
+`/signin?reason=account_not_found` so the app can point the user to sign up. If
+the same verified email belongs to a retained `deactivated` or `deleted` user
+row with a different WorkOS subject, `login` sends the browser back to
+`/signin?reason=account_reactivation_required` so the app can point the user to
+sign up again and reactivate that account. `signup` may create a new user, and
+it may reactivate a retained `deactivated` or `deleted` user row when the
+verified email is the same. Signup still rejects an active user with the same
+email but a different WorkOS subject as an identity conflict; that account must
+use its original sign-in method or be resolved by support.
 
 If WorkOS requires MFA enrollment or an MFA challenge during hosted sign-in, Identrail does not create a local session from the first callback. The API stores the WorkOS pending-auth token only in a short-lived encrypted HttpOnly cookie scoped to `/auth/mfa`, redirects the browser to the app MFA page, and creates the Identrail session only after WorkOS accepts the TOTP verification response.
 

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -321,6 +321,7 @@ const (
 	authFailureReasonCallbackError       = "callback_error"
 	authFailureReasonIdentityConflict    = "identity_conflict"
 	authFailureReasonProviderUnavailable = "provider_unavailable"
+	authFailureReasonReactivationNeeded  = "account_reactivation_required"
 	authFailureReasonStateMismatch       = "state_mismatch"
 )
 
@@ -456,6 +457,10 @@ func completeWorkOSLogin(c *gin.Context, logger *zap.Logger, svc *Service, manag
 		}
 		if errors.Is(err, ErrAuthAccountNotFound) {
 			writeWorkOSLoginFailure(c, opts, failureMode, state.ReturnTo, authFailureReasonAccountNotFound, http.StatusNotFound, "account not found")
+			return "", false
+		}
+		if errors.Is(err, ErrAuthReactivationRequired) {
+			writeWorkOSLoginFailure(c, opts, failureMode, state.ReturnTo, authFailureReasonReactivationNeeded, http.StatusForbidden, "account reactivation requires signup")
 			return "", false
 		}
 		if logger != nil {

--- a/internal/api/service_auth.go
+++ b/internal/api/service_auth.go
@@ -15,8 +15,9 @@ import (
 )
 
 var (
-	ErrAuthIdentityConflict = errors.New("auth identity conflicts with existing user")
-	ErrAuthAccountNotFound  = errors.New("auth account not found")
+	ErrAuthIdentityConflict     = errors.New("auth identity conflicts with existing user")
+	ErrAuthAccountNotFound      = errors.New("auth account not found")
+	ErrAuthReactivationRequired = errors.New("auth account reactivation requires signup")
 )
 
 const (
@@ -141,10 +142,14 @@ func (s *Service) UpsertWorkOSUserForIntent(ctx context.Context, profile session
 		return WorkOSLoginResult{}, err
 	}
 	if existing, emailErr := s.Store.GetUserByPrimaryEmail(ctx, email); emailErr == nil {
-		if workOSUserCanBeReactivated(existing) && intent == workOSAuthIntentSignup {
+		if workOSUserCanBeReactivated(existing) {
 			if !profile.EmailVerified {
 				auditAuthAction(ctx, "auth.identity.conflict", existing.ID, "denied")
 				return WorkOSLoginResult{}, ErrAuthIdentityConflict
+			}
+			if intent != workOSAuthIntentSignup {
+				auditAuthAction(ctx, "auth.account.reactivation_required", existing.ID, "denied")
+				return WorkOSLoginResult{}, ErrAuthReactivationRequired
 			}
 			existing.PrimaryEmail = email
 			existing.DisplayName = displayName

--- a/internal/api/service_workos_test.go
+++ b/internal/api/service_workos_test.go
@@ -161,6 +161,39 @@ func TestUpsertWorkOSUserLoginIntentRejectsUnknownIdentity(t *testing.T) {
 	}
 }
 
+func TestUpsertWorkOSUserLoginIntentPromptsSignupForDeactivatedEmail(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	ctx := context.Background()
+	user, err := store.UpsertUser(ctx, db.User{
+		PrimaryEmail: "revoked@example.com",
+		DisplayName:  "Old Name",
+		Status:       "deactivated",
+	})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	_, err = svc.UpsertWorkOSUserForIntent(ctx, sessionauth.WorkOSProfile{
+		ID:            "user_workos_new_subject",
+		Email:         "revoked@example.com",
+		EmailVerified: true,
+	}, "login")
+	if !errors.Is(err, ErrAuthReactivationRequired) {
+		t.Fatalf("expected reactivation required, got %v", err)
+	}
+	unchanged, err := store.GetUser(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("load retained user: %v", err)
+	}
+	if unchanged.Status != "deactivated" {
+		t.Fatalf("login prompt must not reactivate retained user, got %+v", unchanged)
+	}
+	if _, err := store.GetUserIdentity(ctx, sessionauth.WorkOSProvider, "user_workos_new_subject"); !errors.Is(err, db.ErrNotFound) {
+		t.Fatalf("login prompt must not create identity, got %v", err)
+	}
+}
+
 func TestUpsertWorkOSUserSignupIntentReactivatesDeactivatedEmail(t *testing.T) {
 	store := db.NewMemoryStore()
 	now := time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC)

--- a/internal/api/workos_auth_routes_test.go
+++ b/internal/api/workos_auth_routes_test.go
@@ -527,6 +527,56 @@ func TestWorkOSCallbackRedirectsUnknownLoginToSignupHint(t *testing.T) {
 	}
 }
 
+func TestWorkOSCallbackRedirectsDeactivatedLoginToReactivationHint(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := context.Background()
+	user, err := store.UpsertUser(ctx, db.User{
+		PrimaryEmail: "revoked@example.com",
+		DisplayName:  "Revoked User",
+		Status:       "deactivated",
+	})
+	if err != nil {
+		t.Fatalf("seed retained user: %v", err)
+	}
+	svc := NewService(store, fakeScanner{}, "aws")
+	workOS := &fakeWorkOSClient{authentication: sessionauth.WorkOSAuthentication{
+		User: sessionauth.WorkOSProfile{ID: "user_workos_recreated", Email: "revoked@example.com", EmailVerified: true},
+	}}
+	router := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{
+		FeatureNewAuth:      true,
+		FeatureWorkOSLogin:  true,
+		PublicBaseURL:       "https://api.identrail.test",
+		CORSAllowedOrigins:  []string{"https://app.identrail.test"},
+		SessionKey:          strings.Repeat("a", 64),
+		WorkOSClientID:      "client_123",
+		WorkOSWebhookSecret: "whsec_123",
+		WorkOSAuthClient:    workOS,
+		RateLimitRPM:        1000,
+		RateLimitBurst:      1000,
+	})
+
+	startResp := httptest.NewRecorder()
+	router.ServeHTTP(startResp, httptest.NewRequest(http.MethodGet, "/auth/login?return_to=https%3A%2F%2Fapp.identrail.test%2Fapp%2Fwelcome", nil))
+	callbackResp := httptest.NewRecorder()
+	router.ServeHTTP(callbackResp, workOSCallbackRequest(workOS.authorizationInput.State, oauthTxnCookieFromStart(t, startResp)))
+	if callbackResp.Code != http.StatusFound {
+		t.Fatalf("expected reactivation redirect, got %d body=%s", callbackResp.Code, callbackResp.Body.String())
+	}
+	if got := callbackResp.Header().Get("Location"); got != "https://app.identrail.test/signin?reason=account_reactivation_required&return_to=%2Fapp%2Fwelcome" {
+		t.Fatalf("unexpected reactivation redirect: %q", got)
+	}
+	unchanged, err := store.GetUser(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("load retained user: %v", err)
+	}
+	if unchanged.Status != "deactivated" {
+		t.Fatalf("login prompt must not reactivate retained user, got %+v", unchanged)
+	}
+	if _, err := store.GetUserIdentity(ctx, sessionauth.WorkOSProvider, "user_workos_recreated"); !errors.Is(err, db.ErrNotFound) {
+		t.Fatalf("login prompt must not create identity, got %v", err)
+	}
+}
+
 func TestWorkOSSignupUsesScreenHintAndFallsBackToOnboarding(t *testing.T) {
 	store := db.NewMemoryStore()
 	svc := NewService(store, fakeScanner{}, "aws")

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1002,6 +1002,19 @@ describe('App', () => {
     );
   });
 
+  it('points removed hosted accounts to sign-up reactivation', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(authConfig(false, true)));
+
+    setCurrentPath('/signin?reason=account_reactivation_required&return_to=/app/team/workspace');
+    render(<App />);
+
+    expect(await screen.findByText(/That Identrail account was previously removed/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Reactivate account/i })).toHaveAttribute(
+      'href',
+      '/signup?return_to=%2Fapp%2Fteam%2Fworkspace'
+    );
+  });
+
   it('does not show loading copy or provider actions while auth config loads', () => {
     vi.stubGlobal('fetch', vi.fn().mockImplementation(() => new Promise(() => {})));
 

--- a/web/src/pages/SignInPage.tsx
+++ b/web/src/pages/SignInPage.tsx
@@ -105,6 +105,12 @@ function authReasonDetails(reason: string, returnTo: string): AuthReasonDetails 
         actionLabel: 'Create an account',
         actionHref: authPathWithReturnTo('/signup', returnTo)
       };
+    case 'account_reactivation_required':
+      return {
+        message: 'That Identrail account was previously removed. Sign up again to reactivate it.',
+        actionLabel: 'Reactivate account',
+        actionHref: authPathWithReturnTo('/signup', returnTo)
+      };
     case 'identity_conflict':
       return {
         message:


### PR DESCRIPTION
## Summary

Route login attempts for retained removed WorkOS accounts to the signup reactivation path instead of the generic identity-conflict flow.

## Why

After PR #1296, signup can reactivate a retained `deactivated` or `deleted` WorkOS account with the same verified email. A user who clicks Log In first can still hit `identity_conflict` because the login path sees the retained email row but intentionally does not reactivate it. This PR preserves that safety boundary while giving users a clear reactivation path.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation

```bash
go test ./...
npm run test:ci --prefix web
npm run build --prefix web
```

All passed locally.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: yes
- Tools used: OpenAI Codex
- Areas where used: implementation, tests, docs, validation
- Human verification performed: reviewed diff and ran the validation commands above

## Related Issues

- No issue: follow-up bug found while validating merged PR #1296 before production rollout.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirects WorkOS login attempts for previously removed accounts to the signup reactivation flow, replacing the generic identity-conflict path. This guides users to safely reactivate without creating a session on login.

- **Bug Fixes**
  - On WorkOS login, if the verified email matches a retained `deactivated`/`deleted` user with a different WorkOS subject, respond with `account_reactivation_required` and do not create an identity or reactivate.
  - Added `ErrAuthReactivationRequired` and wired the new failure reason through the login callback.
  - Updated docs to clarify login vs. signup behavior; added tests for backend routing and web copy.
  - Sign-in page shows a reactivation message with a “Reactivate account” CTA to `/signup` (preserves `return_to`).
  - Updated `CHANGELOG.md` to reflect the new flow.

<sup>Written for commit f9b07b6b61c73d61fe719beb4dfeaaa39c3011fa. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1306?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

