### PR TITLE
fix(web): keep app auth state warm across route changes

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -3,6 +3,9 @@ import { renderToString } from 'react-dom/server';
 import { StaticRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { App, RoutedSite, ScanIntakeModalProvider } from './App';
+import { clearAuthConfigCacheForTests } from './authConfigCache';
+import { clearMeCacheForTests } from './hooks/useMe';
+import { clearProductAuthSessionCacheForTests } from './productShell';
 
 function resetBrowserState() {
   window.history.replaceState({}, '', '/');
@@ -174,6 +177,9 @@ describe('App', () => {
     vi.useRealTimers();
     cleanup();
     resetBrowserState();
+    clearAuthConfigCacheForTests();
+    clearMeCacheForTests();
+    clearProductAuthSessionCacheForTests();
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
@@ -182,6 +188,9 @@ describe('App', () => {
   afterEach(() => {
     cleanup();
     resetBrowserState();
+    clearAuthConfigCacheForTests();
+    clearMeCacheForTests();
+    clearProductAuthSessionCacheForTests();
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
@@ -241,12 +250,36 @@ describe('App', () => {
     ['l', '/signin'],
     ['S', '/signup']
   ])('routes the %s header keyboard shortcut to %s', async (key, expectedPath) => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(authConfig(false, true)));
     setCurrentPath('/');
     render(<App />);
 
     fireEvent.keyDown(document, { key });
 
     await waitFor(() => expect(window.location.pathname).toBe(expectedPath));
+  });
+
+  it('reuses loaded auth options when switching between log in and sign up', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(authConfig(false, true));
+    vi.stubGlobal('fetch', fetchMock);
+
+    setCurrentPath('/signin');
+    render(<App />);
+
+    expect(await screen.findByRole('link', { name: /Continue with GitHub/i })).toBeInTheDocument();
+    const authCallsBeforeNavigation = fetchMock.mock.calls.filter(
+      ([url]) => typeof url === 'string' && url.endsWith('/v1/auth/config')
+    ).length;
+
+    fireEvent.click(screen.getAllByRole('link', { name: 'Sign Up' })[0]);
+
+    await waitFor(() => expect(window.location.pathname).toBe('/signup'));
+    expect(screen.getByRole('link', { name: /Continue with GitHub/i })).toBeInTheDocument();
+    expect(screen.queryByText(/Loading authentication/i)).not.toBeInTheDocument();
+    const authCallsAfterNavigation = fetchMock.mock.calls.filter(
+      ([url]) => typeof url === 'string' && url.endsWith('/v1/auth/config')
+    ).length;
+    expect(authCallsAfterNavigation).toBe(authCallsBeforeNavigation);
   });
 
   it.each([
@@ -825,6 +858,59 @@ describe('App', () => {
     expect(await screen.findByRole('heading', { level: 2, name: /Choose a project/i })).toBeInTheDocument();
     const meCallsAfterNavigation = fetchMock.mock.calls.filter(([url]) => typeof url === 'string' && url.endsWith('/v1/me')).length;
     expect(meCallsAfterNavigation).toBe(meCallsBeforeNavigation);
+  });
+
+  it('keeps validated session state warm across guarded app routes', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/v1/me')) {
+        return okJSON(currentMePayload('tenant-a', 'workspace-a'));
+      }
+      if (url.endsWith('/v1/me/sessions')) {
+        return okJSON({
+          items: [
+            {
+              id: 'session-1',
+              auth_method: 'manual',
+              created_at: '2026-01-01T00:00:00Z',
+              idle_expires_at: '2026-01-02T00:00:00Z',
+              last_seen_at: '2026-01-01T01:00:00Z',
+              user_agent: 'Safari',
+              ip: '127.0.0.1',
+              current: true
+            }
+          ]
+        });
+      }
+      if (url.includes('/v1/workspaces/workspace-a/projects')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/repo-scans')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/repo-findings/trends')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/repo-findings')) {
+        return okJSON({ items: [] });
+      }
+      throw new Error(`Unexpected URL ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    setCurrentPath('/app/tenant-a/workspace-a');
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
+
+    act(() => {
+      window.history.pushState({}, '', '/app/account/security');
+      window.dispatchEvent(new PopStateEvent('popstate', { state: {} }));
+    });
+
+    expect(screen.queryByText(/Validating session/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Loading account security/i)).not.toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 1, name: /Owner User/i })).toBeInTheDocument();
   });
 
   it('revalidates session after same-workspace navigation from an auth error', async () => {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -856,8 +856,10 @@ describe('App', () => {
     expect(screen.queryByText(/Validating session/i)).not.toBeInTheDocument();
     expect(screen.getByRole('navigation', { name: /App sections/i })).toBeInTheDocument();
     expect(await screen.findByRole('heading', { level: 2, name: /Choose a project/i })).toBeInTheDocument();
-    const meCallsAfterNavigation = fetchMock.mock.calls.filter(([url]) => typeof url === 'string' && url.endsWith('/v1/me')).length;
-    expect(meCallsAfterNavigation).toBe(meCallsBeforeNavigation);
+    await waitFor(() => {
+      const meCallsAfterNavigation = fetchMock.mock.calls.filter(([url]) => typeof url === 'string' && url.endsWith('/v1/me')).length;
+      expect(meCallsAfterNavigation).toBeGreaterThan(meCallsBeforeNavigation);
+    });
   });
 
   it('keeps validated session state warm across guarded app routes', async () => {
@@ -901,7 +903,9 @@ describe('App', () => {
     setCurrentPath('/app/tenant-a/workspace-a');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
+    });
 
     act(() => {
       window.history.pushState({}, '', '/app/account/security');
@@ -911,6 +915,154 @@ describe('App', () => {
     expect(screen.queryByText(/Validating session/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Loading account security/i)).not.toBeInTheDocument();
     expect(await screen.findByRole('heading', { level: 1, name: /Owner User/i })).toBeInTheDocument();
+  });
+
+  it('silently revalidates warm guarded routes and clears a revoked server session', async () => {
+    let meCalls = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/v1/me')) {
+        meCalls += 1;
+        return meCalls === 1 ? okJSON(currentMePayload('tenant-a', 'workspace-a')) : errorJSON(401, 'session revoked');
+      }
+      if (url.endsWith('/v1/auth/config')) {
+        return authConfig(false, true);
+      }
+      if (url.includes('/v1/workspaces/workspace-a/projects')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/repo-scans')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/repo-findings/trends')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/repo-findings')) {
+        return okJSON({ items: [] });
+      }
+      throw new Error(`Unexpected URL ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    setCurrentPath('/app/tenant-a/workspace-a');
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('link', { name: 'Projects' }));
+
+    expect(screen.queryByText(/Validating session/i)).not.toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 1, name: /Log in to Identrail/i })).toBeInTheDocument();
+    expect(window.location.pathname).toBe('/signin');
+    expect(window.location.search).toContain('return_to=%2Fapp%2Ftenant-a%2Fworkspace-a%2Fprojects');
+  });
+
+  it('keeps mismatched scoped routes loading until tenant redirects complete', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/v1/me')) {
+        return okJSON(currentMePayload('tenant-b', 'workspace-b'));
+      }
+      if (url.includes('/v1/workspaces/workspace-b/projects')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/workspaces/workspace-a/projects')) {
+        throw new Error('stale workspace route rendered before tenant redirect completed');
+      }
+      if (url.includes('/v1/repo-scans')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/repo-findings/trends')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/repo-findings')) {
+        return okJSON({ items: [] });
+      }
+      throw new Error(`Unexpected URL ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    setCurrentPath('/app/tenant-a/workspace-a');
+    render(<App />);
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/app/tenant-b/workspace-b');
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
+    });
+    expect(
+      fetchMock.mock.calls.some(([url]) => typeof url === 'string' && url.includes('/v1/workspaces/workspace-a/projects'))
+    ).toBe(false);
+  });
+
+  it('clears stale scoped auth after a session-only validation', async () => {
+    let meCalls = 0;
+    let resolveScopedMe: (response: ReturnType<typeof okJSON>) => void = () => {};
+    const scopedMeResponse = new Promise<ReturnType<typeof okJSON>>((resolve) => {
+      resolveScopedMe = resolve;
+    });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/v1/me')) {
+        meCalls += 1;
+        if (meCalls === 1) {
+          return okJSON(currentMePayload('tenant-a', 'workspace-a'));
+        }
+        if (meCalls === 2) {
+          return okJSON(currentMePayload('', ''));
+        }
+        return scopedMeResponse;
+      }
+      if (url.endsWith('/v1/me/sessions')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/workspaces/workspace-a/projects')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/repo-scans')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/repo-findings/trends')) {
+        return okJSON({ items: [] });
+      }
+      if (url.includes('/v1/repo-findings')) {
+        return okJSON({ items: [] });
+      }
+      throw new Error(`Unexpected URL ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    setCurrentPath('/app/tenant-a/workspace-a');
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
+    });
+
+    act(() => {
+      window.history.pushState({}, '', '/app/account/security');
+      window.dispatchEvent(new PopStateEvent('popstate', { state: {} }));
+    });
+
+    expect(await screen.findByRole('heading', { level: 1, name: /Owner User/i })).toBeInTheDocument();
+
+    act(() => {
+      window.history.pushState({}, '', '/app/tenant-a/workspace-a/projects');
+      window.dispatchEvent(new PopStateEvent('popstate', { state: {} }));
+    });
+
+    expect(await screen.findByText(/Validating session/i)).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 2, name: /Choose a project/i })).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolveScopedMe(okJSON(currentMePayload('tenant-a', 'workspace-a')));
+      await scopedMeResponse;
+    });
+
+    expect(await screen.findByRole('heading', { level: 2, name: /Choose a project/i })).toBeInTheDocument();
   });
 
   it('revalidates session after same-workspace navigation from an auth error', async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,6 +12,7 @@ import { Header } from './components/layout/Header';
 import { apiClient } from './api/client';
 import { BLOG_POSTS, DOC_ENTRIES, HOME_FAQ_ITEMS } from './content/resources';
 import { AccountSecurityPage } from './pages/AccountSecurityPage';
+import { preloadAuthConfig } from './authConfigCache';
 import { AuthCallbackPage } from './pages/AuthCallbackPage';
 import { SignInPage } from './pages/SignInPage';
 import { SignUpPage } from './pages/SignUpPage';
@@ -4825,6 +4826,14 @@ export function RoutedSite() {
       // Ignore storage write failures (blocked/disabled storage).
     }
   }, []);
+
+  useEffect(() => {
+    if (isProductShellRoute || isOnboardingRoute || isAuthChoiceRoute) {
+      return;
+    }
+    const preloadTimer = window.setTimeout(preloadAuthConfig, 50);
+    return () => window.clearTimeout(preloadTimer);
+  }, [isAuthChoiceRoute, isOnboardingRoute, isProductShellRoute]);
 
   return (
     <div className={`idt-site ${isAuthChoiceRoute ? 'idt-site-auth' : ''}`}>

--- a/web/src/authConfigCache.ts
+++ b/web/src/authConfigCache.ts
@@ -1,0 +1,38 @@
+import { apiClient, type AuthConfigResponse } from './api/client';
+
+let cachedAuthConfig: AuthConfigResponse | null = null;
+let pendingAuthConfig: Promise<AuthConfigResponse> | null = null;
+
+export function getCachedAuthConfig(): AuthConfigResponse | null {
+  return cachedAuthConfig;
+}
+
+export function loadAuthConfig(): Promise<AuthConfigResponse> {
+  if (cachedAuthConfig) {
+    return Promise.resolve(cachedAuthConfig);
+  }
+  if (pendingAuthConfig) {
+    return pendingAuthConfig;
+  }
+  pendingAuthConfig = apiClient
+    .getAuthConfig()
+    .then((response) => {
+      cachedAuthConfig = response;
+      return response;
+    })
+    .finally(() => {
+      pendingAuthConfig = null;
+    });
+  return pendingAuthConfig;
+}
+
+export function preloadAuthConfig() {
+  void loadAuthConfig().catch(() => {
+    // Prefetch failures are surfaced when the auth page explicitly loads.
+  });
+}
+
+export function clearAuthConfigCacheForTests() {
+  cachedAuthConfig = null;
+  pendingAuthConfig = null;
+}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom';
+import { preloadAuthConfig } from '../../authConfigCache';
 import { siteLinks } from '../../siteConfig';
 
 type NavLinkItem = {
@@ -71,6 +72,7 @@ export function Header({
 
       event.preventDefault();
       setMenuOpen(false);
+      preloadAuthConfig();
       navigate(key === 'l' ? siteLinks.signIn : '/signup');
     };
 
@@ -112,13 +114,26 @@ export function Header({
         </nav>
 
         <div className={`idt-header-actions ${menuOpen ? 'is-open' : ''}`}>
-          <Link to={siteLinks.signIn} className="idt-header-utility idt-header-auth-chip">
+          <Link
+            to={siteLinks.signIn}
+            className="idt-header-utility idt-header-auth-chip"
+            onFocus={preloadAuthConfig}
+            onMouseEnter={preloadAuthConfig}
+            onPointerDown={preloadAuthConfig}
+          >
             <span>Log in</span>
             <span className="idt-header-keycap" aria-hidden="true">
               L
             </span>
           </Link>
-          <Link to="/signup" className="idt-header-utility idt-header-signup idt-header-auth-chip is-primary" data-ab-slot="header_primary_cta">
+          <Link
+            to="/signup"
+            className="idt-header-utility idt-header-signup idt-header-auth-chip is-primary"
+            data-ab-slot="header_primary_cta"
+            onFocus={preloadAuthConfig}
+            onMouseEnter={preloadAuthConfig}
+            onPointerDown={preloadAuthConfig}
+          >
             <span>Sign up</span>
             <span className="idt-header-keycap" aria-hidden="true">
               S

--- a/web/src/hooks/useMe.ts
+++ b/web/src/hooks/useMe.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ApiError, apiClient, type CurrentUserContext } from '../api/client';
 
 type UseMeState = {
@@ -6,39 +6,115 @@ type UseMeState = {
   loading: boolean;
   error: string;
   unauthenticated: boolean;
-  refresh: () => Promise<CurrentUserContext | null>;
+  refresh: (options?: { silent?: boolean }) => Promise<CurrentUserContext | null>;
 };
 
-export function useMe(): UseMeState {
-  const [me, setMe] = useState<CurrentUserContext | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
-  const [unauthenticated, setUnauthenticated] = useState(false);
+let cachedMe: CurrentUserContext | null = null;
+let cachedError = '';
+let cachedUnauthenticated = false;
+let meCacheVersion = 0;
+const cacheListeners = new Set<() => void>();
 
-  const refresh = useCallback(async () => {
-    setLoading(true);
+function notifyMeCacheListeners() {
+  cacheListeners.forEach((listener) => listener());
+}
+
+export function getCachedMe(): CurrentUserContext | null {
+  return cachedMe;
+}
+
+export function primeMeCache(me: CurrentUserContext) {
+  meCacheVersion += 1;
+  cachedMe = me;
+  cachedError = '';
+  cachedUnauthenticated = false;
+  notifyMeCacheListeners();
+}
+
+export function clearMeCache(options: { unauthenticated?: boolean } = {}) {
+  meCacheVersion += 1;
+  cachedMe = null;
+  cachedError = '';
+  cachedUnauthenticated = options.unauthenticated === true;
+  notifyMeCacheListeners();
+}
+
+export function clearMeCacheForTests() {
+  meCacheVersion += 1;
+  cachedMe = null;
+  cachedError = '';
+  cachedUnauthenticated = false;
+  notifyMeCacheListeners();
+}
+
+export function useMe(): UseMeState {
+  const [me, setMe] = useState<CurrentUserContext | null>(() => cachedMe);
+  const [loading, setLoading] = useState(() => !cachedMe && !cachedUnauthenticated && !cachedError);
+  const [error, setError] = useState(() => cachedError);
+  const [unauthenticated, setUnauthenticated] = useState(() => cachedUnauthenticated);
+  const mountedRef = useRef(false);
+
+  const refresh = useCallback(async (options: { silent?: boolean } = {}) => {
+    const silent = options.silent === true;
+    const hadCachedSession = Boolean(cachedMe);
+    const requestCacheVersion = meCacheVersion;
+    if (!silent) {
+      setLoading(true);
+    }
     setError('');
     setUnauthenticated(false);
     try {
       const response = await apiClient.getMe({ redirectOnUnauthorized: false });
+      if (!mountedRef.current || requestCacheVersion !== meCacheVersion) {
+        return cachedMe;
+      }
+      primeMeCache(response.me);
       setMe(response.me);
       return response.me;
     } catch (requestError) {
-      setMe(null);
+      if (!mountedRef.current || requestCacheVersion !== meCacheVersion) {
+        return null;
+      }
       if (requestError instanceof ApiError && requestError.status === 401) {
+        clearMeCache({ unauthenticated: true });
+        setMe(null);
         setUnauthenticated(true);
         return null;
       }
       const message = requestError instanceof Error ? requestError.message : 'Unable to load account session.';
-      setError(message);
+      if (!silent || !hadCachedSession) {
+        cachedMe = null;
+        cachedError = message;
+        cachedUnauthenticated = false;
+        notifyMeCacheListeners();
+        setMe(null);
+        setError(message);
+      }
       return null;
     } finally {
-      setLoading(false);
+      if (mountedRef.current && requestCacheVersion === meCacheVersion) {
+        setLoading(false);
+      }
     }
   }, []);
 
   useEffect(() => {
-    void refresh();
+    mountedRef.current = true;
+    const syncFromCache = () => {
+      setMe(cachedMe);
+      setError(cachedError);
+      setUnauthenticated(cachedUnauthenticated);
+      setLoading(false);
+    };
+    cacheListeners.add(syncFromCache);
+    return () => {
+      mountedRef.current = false;
+      cacheListeners.delete(syncFromCache);
+    };
+  }, []);
+
+  useEffect(() => {
+    void refresh({ silent: Boolean(cachedMe) });
   }, [refresh]);
 
   return { me, loading, error, unauthenticated, refresh };

--- a/web/src/pages/SignInPage.tsx
+++ b/web/src/pages/SignInPage.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { apiClient, buildAPIURL, type AuthConfigResponse } from '../api/client';
+import { getCachedAuthConfig, loadAuthConfig } from '../authConfigCache';
 
 type AuthIntent = 'login' | 'signup';
 
@@ -184,8 +185,9 @@ export function AuthChoicePage({ intent }: AuthChoicePageProps) {
   const returnTo = normalizeReturnTo(query.get('return_to') ?? query.get('next'));
   const signedOut = query.get('signed_out') === '1';
   const reason = authReasonDetails(query.get('reason') ?? '', returnTo);
-  const [config, setConfig] = useState<AuthConfigResponse | null>(null);
-  const [loadingConfig, setLoadingConfig] = useState(true);
+  const initialConfig = getCachedAuthConfig();
+  const [config, setConfig] = useState<AuthConfigResponse | null>(initialConfig);
+  const [loadingConfig, setLoadingConfig] = useState(!initialConfig);
   const [configError, setConfigError] = useState('');
   const [manualSubmitting, setManualSubmitting] = useState(false);
   const [manualError, setManualError] = useState('');
@@ -203,10 +205,16 @@ export function AuthChoicePage({ intent }: AuthChoicePageProps) {
   useEffect(() => {
     let mounted = true;
     const run = async () => {
-      setLoadingConfig(true);
+      const cached = getCachedAuthConfig();
+      if (cached) {
+        setConfig(cached);
+        setLoadingConfig(false);
+      } else {
+        setLoadingConfig(true);
+      }
       setConfigError('');
       try {
-        const response = await apiClient.getAuthConfig();
+        const response = await loadAuthConfig();
         if (mounted) {
           setConfig(response);
         }

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -211,6 +211,7 @@ const TREND_POINTS = 10;
 const PRODUCT_AUTH_SESSION_SCOPE_KEY = '__product_session__';
 let validatedProductAuthSession = false;
 let validatedProductAuthScopeKey = '';
+let productAuthSessionVersion = 0;
 
 function hasValidatedProductAuthScope(routeScopeKey: string): boolean {
   if (!validatedProductAuthSession) {
@@ -220,19 +221,24 @@ function hasValidatedProductAuthScope(routeScopeKey: string): boolean {
 }
 
 function setValidatedProductAuthScope(routeScopeKey: string) {
+  productAuthSessionVersion += 1;
   validatedProductAuthSession = true;
   if (routeScopeKey !== PRODUCT_AUTH_SESSION_SCOPE_KEY) {
     validatedProductAuthScopeKey = routeScopeKey;
+  } else {
+    validatedProductAuthScopeKey = '';
   }
 }
 
 function resetProductAuthSessionCache(options: { unauthenticated?: boolean } = {}) {
+  productAuthSessionVersion += 1;
   validatedProductAuthSession = false;
   validatedProductAuthScopeKey = '';
   clearMeCache(options);
 }
 
 export function clearProductAuthSessionCacheForTests() {
+  productAuthSessionVersion += 1;
   validatedProductAuthSession = false;
   validatedProductAuthScopeKey = '';
 }
@@ -1002,14 +1008,12 @@ export function RequireProductAuth({ children }: { children: ReactNode }) {
   useEffect(() => {
     let mounted = true;
 
-    const run = async () => {
-      const alreadyValidated = validatedScopeKeyRef.current === routeScopeKey || hasValidatedProductAuthScope(routeScopeKey);
-      if (alreadyValidated && statusRef.current === 'authenticated') {
-        validatedScopeKeyRef.current = routeScopeKey;
-        setValidatedScopeKey(routeScopeKey);
-        return;
+    const validateSession = async (options: { silent?: boolean } = {}) => {
+      const silent = options.silent === true;
+      const requestSessionVersion = productAuthSessionVersion;
+      if (!silent) {
+        setStatus('checking');
       }
-      setStatus('checking');
       setError('');
       try {
         const current = await apiClient.getMe({ redirectOnUnauthorized: false });
@@ -1018,7 +1022,7 @@ export function RequireProductAuth({ children }: { children: ReactNode }) {
         const currentScopeKey =
           currentTenantID && currentWorkspaceID ? `${currentTenantID}::${currentWorkspaceID}` : PRODUCT_AUTH_SESSION_SCOPE_KEY;
         let validatedRouteScopeKey = routeScopeKey;
-        if (!mounted) {
+        if (!mounted || requestSessionVersion !== productAuthSessionVersion) {
           return;
         }
         primeMeCache(current.me);
@@ -1035,8 +1039,8 @@ export function RequireProductAuth({ children }: { children: ReactNode }) {
             }
             navigateRef.current(buildTenantWorkspacePath(currentTenantID, currentWorkspaceID), { replace: true });
             setValidatedProductAuthScope(currentScopeKey);
-            validatedScopeKeyRef.current = routeScopeKey;
-            setValidatedScopeKey(routeScopeKey);
+            validatedScopeKeyRef.current = currentScopeKey;
+            setValidatedScopeKey(currentScopeKey);
             setStatus('authenticated');
             return;
           }
@@ -1053,7 +1057,7 @@ export function RequireProductAuth({ children }: { children: ReactNode }) {
         setValidatedScopeKey(routeScopeKey);
         setStatus('authenticated');
       } catch (requestError) {
-        if (!mounted) {
+        if (!mounted || requestSessionVersion !== productAuthSessionVersion) {
           return;
         }
         if (requestError instanceof ApiError && requestError.status === 401) {
@@ -1061,14 +1065,27 @@ export function RequireProductAuth({ children }: { children: ReactNode }) {
           setStatus('unauthenticated');
           return;
         }
+        if (silent) {
+          return;
+        }
         const message = requestError instanceof Error ? requestError.message : 'Unable to validate account session.';
-        validatedProductAuthSession = false;
-        validatedProductAuthScopeKey = '';
+        resetProductAuthSessionCache();
         validatedScopeKeyRef.current = '';
         setValidatedScopeKey('');
         setError(message);
         setStatus('error');
       }
+    };
+
+    const run = async () => {
+      const alreadyValidated = validatedScopeKeyRef.current === routeScopeKey || hasValidatedProductAuthScope(routeScopeKey);
+      if (alreadyValidated && statusRef.current === 'authenticated') {
+        validatedScopeKeyRef.current = routeScopeKey;
+        setValidatedScopeKey(routeScopeKey);
+        await validateSession({ silent: true });
+        return;
+      }
+      await validateSession();
     };
 
     void run();

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -55,7 +55,7 @@ import {
   type WorkspaceMemberStatus
 } from './api/client';
 import { PermissionPreviewModal } from './components/connector/PermissionPreviewModal';
-import { useMe } from './hooks/useMe';
+import { clearMeCache, primeMeCache, useMe } from './hooks/useMe';
 import { isFeatureAvailable, useBackendFeatures } from './hooks/useBackendFeatures';
 import {
   FEATURE_ONBOARDING_CONNECTOR_AWS as FEATURE_CONNECTOR_AWS,
@@ -208,6 +208,34 @@ const SORT_LABEL_BY_FIELD: Record<(typeof REPO_FINDING_SORT_FIELDS)[number], str
 };
 
 const TREND_POINTS = 10;
+const PRODUCT_AUTH_SESSION_SCOPE_KEY = '__product_session__';
+let validatedProductAuthSession = false;
+let validatedProductAuthScopeKey = '';
+
+function hasValidatedProductAuthScope(routeScopeKey: string): boolean {
+  if (!validatedProductAuthSession) {
+    return false;
+  }
+  return routeScopeKey === PRODUCT_AUTH_SESSION_SCOPE_KEY || validatedProductAuthScopeKey === routeScopeKey;
+}
+
+function setValidatedProductAuthScope(routeScopeKey: string) {
+  validatedProductAuthSession = true;
+  if (routeScopeKey !== PRODUCT_AUTH_SESSION_SCOPE_KEY) {
+    validatedProductAuthScopeKey = routeScopeKey;
+  }
+}
+
+function resetProductAuthSessionCache(options: { unauthenticated?: boolean } = {}) {
+  validatedProductAuthSession = false;
+  validatedProductAuthScopeKey = '';
+  clearMeCache(options);
+}
+
+export function clearProductAuthSessionCacheForTests() {
+  validatedProductAuthSession = false;
+  validatedProductAuthScopeKey = '';
+}
 
 function resolveEnabledSourceProvider(provider: SourceProvider): SourceProvider | null {
   return SOURCE_STACK.includes(provider) ? provider : null;
@@ -951,11 +979,15 @@ export function RequireProductAuth({ children }: { children: ReactNode }) {
   const params = useParams<ScopeRouteParams>();
   const routeTenantID = normalizeValue(params.tenantID);
   const routeWorkspaceID = normalizeValue(params.workspaceID);
-  const routeScopeKey = `${routeTenantID}::${routeWorkspaceID}`;
+  const routeHasExplicitScope = Boolean(routeTenantID && routeWorkspaceID);
+  const routeScopeKey = routeHasExplicitScope ? `${routeTenantID}::${routeWorkspaceID}` : PRODUCT_AUTH_SESSION_SCOPE_KEY;
   const routeLocationKey = `${location.pathname}${location.search}`;
-  const [status, setStatus] = useState<'checking' | 'authenticated' | 'unauthenticated' | 'error'>('checking');
-  const [validatedScopeKey, setValidatedScopeKey] = useState('');
-  const validatedScopeKeyRef = useRef('');
+  const routeAuthWarm = hasValidatedProductAuthScope(routeScopeKey);
+  const [status, setStatus] = useState<'checking' | 'authenticated' | 'unauthenticated' | 'error'>(
+    routeAuthWarm ? 'authenticated' : 'checking'
+  );
+  const [validatedScopeKey, setValidatedScopeKey] = useState(routeAuthWarm ? routeScopeKey : '');
+  const validatedScopeKeyRef = useRef(routeAuthWarm ? routeScopeKey : '');
   const statusRef = useRef(status);
   const [error, setError] = useState('');
 
@@ -971,8 +1003,10 @@ export function RequireProductAuth({ children }: { children: ReactNode }) {
     let mounted = true;
 
     const run = async () => {
-      const alreadyValidated = validatedScopeKeyRef.current === routeScopeKey;
+      const alreadyValidated = validatedScopeKeyRef.current === routeScopeKey || hasValidatedProductAuthScope(routeScopeKey);
       if (alreadyValidated && statusRef.current === 'authenticated') {
+        validatedScopeKeyRef.current = routeScopeKey;
+        setValidatedScopeKey(routeScopeKey);
         return;
       }
       setStatus('checking');
@@ -981,6 +1015,13 @@ export function RequireProductAuth({ children }: { children: ReactNode }) {
         const current = await apiClient.getMe({ redirectOnUnauthorized: false });
         const currentTenantID = normalizeValue(current.me.org_id ?? '');
         const currentWorkspaceID = normalizeValue(current.me.workspace_id ?? '');
+        const currentScopeKey =
+          currentTenantID && currentWorkspaceID ? `${currentTenantID}::${currentWorkspaceID}` : PRODUCT_AUTH_SESSION_SCOPE_KEY;
+        let validatedRouteScopeKey = routeScopeKey;
+        if (!mounted) {
+          return;
+        }
+        primeMeCache(current.me);
         if (
           routeTenantID &&
           routeWorkspaceID &&
@@ -993,6 +1034,9 @@ export function RequireProductAuth({ children }: { children: ReactNode }) {
               return;
             }
             navigateRef.current(buildTenantWorkspacePath(currentTenantID, currentWorkspaceID), { replace: true });
+            setValidatedProductAuthScope(currentScopeKey);
+            validatedScopeKeyRef.current = routeScopeKey;
+            setValidatedScopeKey(routeScopeKey);
             setStatus('authenticated');
             return;
           }
@@ -1000,10 +1044,11 @@ export function RequireProductAuth({ children }: { children: ReactNode }) {
             tenantID: currentTenantID,
             workspaceID: currentWorkspaceID
           });
+          validatedRouteScopeKey = routeScopeKey;
+        } else if (!routeHasExplicitScope) {
+          validatedRouteScopeKey = currentScopeKey;
         }
-        if (!mounted) {
-          return;
-        }
+        setValidatedProductAuthScope(validatedRouteScopeKey);
         validatedScopeKeyRef.current = routeScopeKey;
         setValidatedScopeKey(routeScopeKey);
         setStatus('authenticated');
@@ -1012,10 +1057,13 @@ export function RequireProductAuth({ children }: { children: ReactNode }) {
           return;
         }
         if (requestError instanceof ApiError && requestError.status === 401) {
+          resetProductAuthSessionCache({ unauthenticated: true });
           setStatus('unauthenticated');
           return;
         }
         const message = requestError instanceof Error ? requestError.message : 'Unable to validate account session.';
+        validatedProductAuthSession = false;
+        validatedProductAuthScopeKey = '';
         validatedScopeKeyRef.current = '';
         setValidatedScopeKey('');
         setError(message);
@@ -1028,7 +1076,7 @@ export function RequireProductAuth({ children }: { children: ReactNode }) {
     return () => {
       mounted = false;
     };
-  }, [routeTenantID, routeWorkspaceID, routeScopeKey, routeLocationKey]);
+  }, [routeHasExplicitScope, routeTenantID, routeWorkspaceID, routeScopeKey, routeLocationKey]);
 
   if (status === 'checking' || (status === 'authenticated' && validatedScopeKey !== routeScopeKey)) {
     return <AppShellLoading message="Validating session" />;
@@ -1161,6 +1209,7 @@ export function ProductLogoutPage() {
       }
 
       if (mounted) {
+        resetProductAuthSessionCache({ unauthenticated: true });
         navigate('/signin?signed_out=1', { replace: true });
       }
     };


### PR DESCRIPTION
No issue: post-merge follow-up for app auth/loading flicker.

## What changed
- Cache the active product session and current user across guarded app route remounts.
- Reuse and preload `/v1/auth/config` for Log in / Sign up entry points.
- Guard the session cache against late responses from unmounted routes and add regressions.

## Why
The app was still showing `Validating session`, workspace preparation, and auth-option loading copy during normal navigation even after a session had already been validated.

## Impact and risk
- Reduces route-change flicker without changing auth API behavior.
- Clears cached state on 401/logout and ignores stale in-flight responses after cache resets.
- Risk is limited to web auth/session shell state.

## Validation
- `npm ci` from `web/`
- `npm test -- --run src/App.test.tsx -t "header keyboard|reuses loaded auth options|workspace shell mounted|validated session state warm|revalidates session"` from `web/`
- `npm test -- --run` from `web/`
- `npm run build` from `web/`

AI-assisted: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps app auth and current user state warm across route changes to remove flicker. Adds silent revalidation for warm sessions and stabilizes scoped redirects and stale-state handling.

- **Bug Fixes**
  - Keep validated session warm by scope (workspace or global) across product and account routes; silently revalidate warm routes and, on 401, clear caches and redirect to Sign in with `return_to`.
  - Add `authConfigCache` with `preloadAuthConfig`; reuse `/v1/auth/config`, prefetch from header focus/hover/pointer/keyboard and shortcuts, idle-preload on non-auth pages, and reuse between Sign in/Sign up.
  - Cache `me` in `useMe` with shared listeners; prime after validation, refresh silently when a session exists, ignore stale responses after unmount/cache resets, and clear on 401/logout.
  - Keep mismatched scoped routes loading until tenant/workspace redirects complete; clear stale scoped auth after a session-only validation; expand tests for option reuse, warm guarded routes, silent revalidation, and redirect handling.

<sup>Written for commit 1024230d5a5069cbd3c07291786d33e7fb1b118d. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1307?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

