### PR TITLE
fix(ci): avoid octokit redeclaration in branch-protection workflow

### DIFF
--- a/.github/workflows/enforce-branch-protection.yml
+++ b/.github/workflows/enforce-branch-protection.yml
@@ -136,12 +136,12 @@ jobs:
               return;
             }
 
-            const octokit = github.getOctokit(token);
+            const adminOctokit = github.getOctokit(token);
 
             let liveNormalized = null;
             let branchUnprotected = false;
             try {
-              const liveResponse = await octokit.rest.repos.getBranchProtection({
+              const liveResponse = await adminOctokit.rest.repos.getBranchProtection({
                 owner,
                 repo,
                 branch
@@ -185,14 +185,14 @@ jobs:
               return;
             }
 
-            await octokit.rest.repos.updateBranchProtection({
+            await adminOctokit.rest.repos.updateBranchProtection({
               owner,
               repo,
               branch,
               ...desiredRaw
             });
 
-            const postApply = await octokit.rest.repos.getBranchProtection({
+            const postApply = await adminOctokit.rest.repos.getBranchProtection({
               owner,
               repo,
               branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Fixed the branch-protection enforcement workflow, which had failed on every
+  run since `actions/github-script` was bumped to v9. The injected `octokit`
+  binding collided with the script's own `const octokit`, producing a parse-time
+  `SyntaxError`; the script's admin-token client is now named `adminOctokit`.
 - Remediated open security and quality findings. Bumped vulnerable Go
   dependencies (`golang.org/x/crypto`, `golang.org/x/net`, `golang.org/x/sys`)
   and the Go toolchain to `1.25.10` to clear stdlib CVEs, removed the stale


### PR DESCRIPTION
No issue: fixes the branch-protection enforcement workflow that has been failing on every scheduled run since the github-script v9 bump; surfaced directly from Actions.

## What changed
Renamed the `enforce-branch-protection.yml` script's admin-token client from `octokit` to `adminOctokit`.

## Why
`actions/github-script` v9 injects an `octokit` binding into the script scope. The workflow's own `const octokit = github.getOctokit(token)` (it needs a second client authenticated with `REPO_ADMIN_TOKEN`, not the default `GITHUB_TOKEN`) collided with it, producing a parse-time `SyntaxError: Identifier 'octokit' has already been declared`. The script failed before any code ran.

This has failed on **every run since 2026-05-18**, when Dependabot's #1209 bumped `actions/github-script` to v9 — both the daily scheduled runs and any push that touches the workflow paths.

## Impact and risk
- CI-only; no application code. Restores the branch-protection drift audit/apply automation.
- Minimal: a variable rename (4 references); `getOctokit` (the method) is unchanged.

## Validation
- Confirmed only one `octokit` declaration existed in the script (the collision was with v9's injected binding).
- Workflow file parses as valid YAML after the rename.
- Verified the failure history in Actions (5+ consecutive scheduled failures with the same SyntaxError).

## AI-Assisted and AI-Generated Code Policy
- AI-assisted: yes
- Tools used: Claude Code
- Where used: `.github/workflows/enforce-branch-protection.yml`, `CHANGELOG.md`
- Human verification performed: traced the root cause through the Actions run logs and failure history, confirmed the single colliding declaration, and validated the workflow YAML

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the branch-protection enforcement workflow by renaming the admin-token client from `octokit` to `adminOctokit` to avoid a name collision introduced by `actions/github-script` v9. Restores the scheduled branch-protection audit/apply job.

- **Bug Fixes**
  - Avoids redeclaration with v9-injected `octokit`; script now parses and runs.
  - Admin client uses `REPO_ADMIN_TOKEN`; `GITHUB_TOKEN` usage remains unchanged.

<sup>Written for commit c56036fbf902e54113201501a2d967079c2abd06. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1308?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

