### PR TITLE
test(fuzz): add native Go fuzz targets for untrusted parsers

### DIFF
--- a/internal/providers/aws/fuzz_test.go
+++ b/internal/providers/aws/fuzz_test.go
@@ -1,0 +1,30 @@
+package aws
+
+import "testing"
+
+// FuzzParsePolicyDocument exercises IAM policy/trust-document parsing, which
+// URL-unescapes and JSON-decodes untrusted document strings collected from AWS.
+// Parsing must always return cleanly (document or error) and never panic.
+func FuzzParsePolicyDocument(f *testing.F) {
+	seeds := []string{
+		`{"Version":"2012-10-17","Statement":[]}`,
+		`{"Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::123456789012:root"},"Action":"sts:AssumeRole"}]}`,
+		"%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%5D%7D",
+		`{"Statement":"not-an-array"}`,
+		`{"Statement":[{"Effect":"Allow","Principal":"*"}]}`,
+		"not json",
+		"%zz",
+		"%",
+		"   ",
+		"",
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(_ *testing.T, raw string) {
+		// Result is intentionally ignored: the contract under test is that the
+		// parser never panics on arbitrary, possibly URL-encoded input.
+		_, _ = parsePolicyDocument(raw)
+	})
+}

--- a/internal/urlpolicy/fuzz_test.go
+++ b/internal/urlpolicy/fuzz_test.go
@@ -1,0 +1,32 @@
+package urlpolicy
+
+import "testing"
+
+// FuzzValidateAuditForwardURL exercises the outbound audit-forward URL guard
+// with arbitrary input. The validator must always return cleanly (allow or
+// error) and never panic on untrusted, attacker-controlled URLs.
+func FuzzValidateAuditForwardURL(f *testing.F) {
+	seeds := []string{
+		"https://example.com",
+		"http://localhost:8080/ingest",
+		"http://127.0.0.1",
+		"http://[::1]",
+		"http://evil.example.com",
+		"ftp://example.com",
+		"://nohost",
+		"https://",
+		"   https://example.com   ",
+		"http://localhost@evil.example.com",
+		"",
+		"%",
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(_ *testing.T, raw string) {
+		// Result is intentionally ignored: the contract under test is that the
+		// validator never panics regardless of input.
+		_ = ValidateAuditForwardURL(raw)
+	})
+}


### PR DESCRIPTION
No issue: addresses the OpenSSF Scorecard "Fuzzing" finding surfaced in the repo Security & quality dashboard.

## What changed
Added two native Go fuzz targets for the security-relevant parsers that consume untrusted input:
- `FuzzValidateAuditForwardURL` (`internal/urlpolicy`) — the outbound audit-forward URL scheme/SSRF guard.
- `FuzzParsePolicyDocument` (`internal/providers/aws`) — IAM policy/trust-document parsing, which URL-unescapes then JSON-decodes attacker-influenced documents collected from AWS.

## Why
The Scorecard "Fuzzing" check was the only code-fixable item of the three remaining findings (the other two — `CIIBestPractices` and `Maintained` — are an external badge enrollment and an activity signal). Scorecard detects native Go fuzzing, so adding real `func Fuzz...` targets satisfies it while also hardening genuine untrusted-input entry points against panics.

## Impact and risk
- Test-only; no production code changes. No behavior change, so no CHANGELOG entry.

## Validation
- Seed corpus: `go test ./internal/urlpolicy/ ./internal/providers/aws/ -run=Fuzz` — pass.
- `go test -fuzz=FuzzValidateAuditForwardURL -fuzztime=10s` — 1.5M+ execs, no crashes.
- `go test -fuzz=FuzzParsePolicyDocument -fuzztime=10s` — no crashes.
- `gofmt -l` clean; `go vet` clean on both packages. No fuzz corpus artifacts are committed (interesting inputs go to the build cache, not the repo).

## AI-Assisted and AI-Generated Code Policy
- AI-assisted: yes
- Tools used: Claude Code
- Where used: `internal/urlpolicy/fuzz_test.go`, `internal/providers/aws/fuzz_test.go`
- Human verification performed: selected high-value untrusted-input parsers as targets, ran the seed corpus and timed fuzz runs locally, confirmed no crashes and no stray corpus files