### PR TITLE
Fix container publish Buildx handling

### DIFF
--- a/.github/workflows/publish-container-images.yml
+++ b/.github/workflows/publish-container-images.yml
@@ -16,13 +16,13 @@ permissions:
 
 concurrency:
   group: publish-container-images-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'push' && github.ref == 'refs/heads/dev' }}
 
 jobs:
   publish:
     name: Build and Publish Container Images
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write
@@ -83,8 +83,10 @@ jobs:
           revision="${{ steps.meta.outputs.source_sha }}"
           backend_platforms="linux/amd64,linux/arm64"
 
-          if ! grep -Eq '^ARG[[:space:]]+TARGETARCH([[:space:]=]|$)' deploy/docker/Dockerfile.backend; then
-            echo "deploy/docker/Dockerfile.backend does not support TARGETARCH; publishing backend images for linux/amd64 only." >&2
+          if ! grep -Eq '^FROM[[:space:]]+--platform=\$BUILDPLATFORM[[:space:]]+' deploy/docker/Dockerfile.backend ||
+             ! grep -Eq '^ARG[[:space:]]+TARGETOS([[:space:]]*(#.*)?)?$' deploy/docker/Dockerfile.backend ||
+             ! grep -Eq '^ARG[[:space:]]+TARGETARCH([[:space:]]*(#.*)?)?$' deploy/docker/Dockerfile.backend; then
+            echo "deploy/docker/Dockerfile.backend does not support native Buildx cross-compilation; publishing backend images for linux/amd64 only." >&2
             backend_platforms="linux/amd64"
           fi
 

--- a/deploy/docker/Dockerfile.backend
+++ b/deploy/docker/Dockerfile.backend
@@ -1,4 +1,4 @@
-FROM golang:1.25.10-alpine@sha256:8d22e29d960bc50cd025d93d5b7c7d220b1ee9aa7a239b3c8f55a57e987e8d45 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.10-alpine@sha256:8d22e29d960bc50cd025d93d5b7c7d220b1ee9aa7a239b3c8f55a57e987e8d45 AS builder
 WORKDIR /src
 
 RUN apk add --no-cache ca-certificates tzdata git
@@ -9,9 +9,9 @@ RUN go mod download
 COPY . .
 
 ARG TARGET=server
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
-RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
+ARG TARGETOS
+ARG TARGETARCH
+RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} CGO_ENABLED=0 \
     go build -trimpath -ldflags="-s -w" -o /out/identrail ./cmd/${TARGET}
 
 FROM alpine:3.22@sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601


### PR DESCRIPTION
No issue: fixes container publish reliability after repeated dev merge timeouts.

## Summary
- Build backend images from the native Buildx build platform while honoring `TARGETOS` and `TARGETARCH` for the final target image.
- Keep backend multi-arch publishing only when the Dockerfile has the expected native Buildx cross-compilation hooks.
- Increase the publish job timeout from 35 to 60 minutes as a safety margin.
- Cancel stale push-triggered `dev` image publishes when a newer `dev` merge arrives.

## Why
Recent `Publish Container Images` runs were being reported as cancelled because the single publish job hit its 35 minute timeout during multi-arch backend image builds. The logs showed the slow path in the arm64 builder while compiling an amd64 binary, which meant the Dockerfile was not using Buildx platform arguments correctly.

This keeps the existing image names, tags, registries, and AWS release flow intact while making the publish path less likely to waste runner time or leave the latest `dev` image unpublished.

## Impact and risk
- No application runtime behavior changes.
- No database, AWS, auth, or repository scan logic changes.
- `dev` push publishes now prefer the newest merge; older in-flight `dev` image publishes can be cancelled when superseded.
- Manual workflow dispatch behavior is preserved unless a newer `dev` push supersedes the same concurrency group.

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-container-images.yml")'`
- Workflow guard shell check confirmed backend platforms remain `linux/amd64,linux/arm64` with the updated Dockerfile.
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/publish-container-images.yml`
- Commit hooks: merge conflict check, YAML check, EOF check, trailing whitespace, gofmt check, Vercel artifact hygiene.
- Push hooks: merge conflict check, YAML check, EOF check, trailing whitespace, gofmt check, `go vet`, local env token hygiene, Vercel artifact hygiene.

Local Docker build validation was not run because the configured Docker Desktop socket was not available and the Colima socket was absent on this machine.

## AI-assisted disclosure
- AI-assisted: yes
- Tools used: OpenAI coding assistant
- Where used: Dockerfile and GitHub Actions workflow changes
- Human verification performed: diff review, lint/static checks, commit and push hooks listed above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky image publishes by using the native Buildx platform for backend builds and enabling multi-arch only when the Dockerfile supports cross-compilation. Also extends the publish timeout and cancels stale dev publishes to save runner time.

- **Bug Fixes**
  - Backend Dockerfile now opts into native Buildx (`FROM --platform=$BUILDPLATFORM`) and declares `ARG TARGETOS`/`TARGETARCH` with safe defaults; build falls back to `linux/amd64` when cross-compilation hooks are missing.
  - Publish job timeout increased from 35 to 60 minutes.
  - For `dev` branch pushes, cancels in-progress publishes when a newer merge arrives.
  - No changes to image names, tags, registries, or the release flow.

<sup>Written for commit 00776d28f82603f11fd389aa3b610abbbcf19d5a. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1310?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

