### PR TITLE
docs: clarify source-specific quickstarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   Kubernetes machine identity scans, Docker-based runs, or the hosted app. The
   install docs now point at the published Homebrew tap and released CLI image
   instead of pre-publication wording, and the README badges now avoid forced
-  green CI states and flaky GitHub-backed version lookup.
+  green CI states, flaky GitHub-backed version lookup, and include the OpenSSF
+  Best Practices badge.
 - Fixed the branch-protection enforcement workflow, which had failed on every
   run since `actions/github-script` was bumped to v9. The injected `octokit`
   binding collided with the script's own `const octokit`, producing a parse-time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
   source they care about: GitHub repository scans, AWS machine identity scans,
   Kubernetes machine identity scans, Docker-based runs, or the hosted app. The
   install docs now point at the published Homebrew tap and released CLI image
-  instead of pre-publication wording.
+  instead of pre-publication wording, and the README badges now avoid forced
+  green CI states and flaky GitHub-backed version lookup.
 - Fixed the branch-protection enforcement workflow, which had failed on every
   run since `actions/github-script` was bumped to v9. The injected `octokit`
   binding collided with the script's own `const octokit`, producing a parse-time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## Unreleased
+- Refreshed the public onboarding docs so first-time users can start from the
+  source they care about: GitHub repository scans, AWS machine identity scans,
+  Kubernetes machine identity scans, Docker-based runs, or the hosted app. The
+  install docs now point at the published Homebrew tap and released CLI image
+  instead of pre-publication wording.
 - Fixed the branch-protection enforcement workflow, which had failed on every
   run since `actions/github-script` was bumped to v9. The injected `octokit`
   binding collided with the script's own `const octokit`, producing a parse-time

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 <p align="center">
   <a href="https://github.com/identrail/identrail/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/identrail/identrail/ci.yml?branch=dev&style=flat&label=ci&labelColor=000000" alt="CI status" /></a>
   <a href="https://github.com/identrail/identrail/releases/tag/v1.0.1"><img src="https://img.shields.io/badge/version-v1.0.1-0969da?style=flat&labelColor=000000" alt="Version v1.0.1" /></a>
+  <a href="https://www.bestpractices.dev/projects/12950"><img src="https://www.bestpractices.dev/projects/12950/badge" alt="OpenSSF Best Practices" /></a>
   <a href="https://github.com/identrail/identrail/stargazers"><img src="https://img.shields.io/github/stars/identrail/identrail?style=flat&label=stars&labelColor=000000&color=d4af37" alt="GitHub stars" /></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
   <br />
   <br />
 
-  <p><strong>Open-source machine identity security for AWS and Kubernetes.</strong></p>
-  <p>Discover trust paths, detect high-signal exposure risk, and apply authorization guardrails with explainable decisions.</p>
+  <p><strong>Open-source machine identity security for GitHub, AWS, and Kubernetes.</strong></p>
+  <p>Find risky trust paths, repository exposure, and authorization gaps before they become incidents.</p>
 </div>
 
 <p align="center">
@@ -28,44 +28,29 @@
 
 ## Who This Is For
 
-Identrail is for security and platform teams that need to answer three questions quickly:
+Identrail is for security and platform teams that need fast answers to practical machine identity questions:
 
-- Which machine identities can reach sensitive resources?
-- Where does trust sprawl create blast-radius risk?
-- How can we enforce safer access with auditable decisions?
+- Which GitHub workflows, secrets, or automation paths can expose sensitive access?
+- Which AWS roles and trust relationships create unnecessary blast radius?
+- Which Kubernetes service accounts and RBAC bindings can reach more than they should?
+- How can teams turn those signals into explainable findings and safer authorization decisions?
 
-Use it when you run AWS and/or Kubernetes workloads and want identity risk visibility plus deployment-safe control surfaces.
+Use Identrail when you want read-only visibility first, then a clear path to
+hosted scans, source onboarding, trends, and audit-ready evidence.
 
-## 5-Minute Quickstart
+## Quickstart
 
-Identrail is AWS/Kubernetes machine identity security first. Use the hosted app
-for the full source-onboarding workflow, and use the CLI when you want a quick
-repository-exposure scan from your terminal.
+Choose the source you want to check first. GitHub, AWS, and Kubernetes each have a separate first-run path.
 
-### Use the hosted app
+### 1. Install Identrail
 
-Go to [identrail.com](https://www.identrail.com), sign in, create or select a
-workspace, and connect the sources your project owns: AWS, Kubernetes, and
-GitHub.
-
-For enterprise auth scope, tenant/workspace context, live source setup, and
-decision audit verification, use the [Enterprise Quickstart](./docs/enterprise-quickstart.md).
-
-### Install or run the CLI
-
-After the Homebrew tap is published, install the CLI on macOS or Linux:
+Install the CLI with Homebrew:
 
 ```bash
 brew install identrail/tap/identrail
 ```
 
-Run the CLI without installing it locally:
-
-```bash
-docker run --rm ghcr.io/identrail/identrail-cli:dev scan owner/repo
-```
-
-Build from source when you want to contribute or test development code:
+Or build from source when you want to contribute:
 
 ```bash
 git clone https://github.com/identrail/identrail.git
@@ -73,57 +58,158 @@ cd identrail
 go build -o ./bin/identrail ./cmd/cli
 ```
 
-The release workflow publishes the Homebrew formula when the
-`identrail/homebrew-tap` repository and `HOMEBREW_TAP_TOKEN` secret are in
-place. Until then, use Docker or a source build.
+If you build from source, replace `identrail` with `./bin/identrail` in the
+commands below unless you add the binary to your `PATH`.
 
-### Scan from the terminal
+### 2. Scan a GitHub Repository
 
-After installing the CLI, run the AWS/Kubernetes provider scan path:
-
-```bash
-identrail scan
-```
-
-Scan a public GitHub repository:
+Scan a public repository:
 
 ```bash
 identrail scan owner/repo
 ```
 
-Scan a local checkout, including a private repository you already cloned:
+Use limits when you want a faster first look:
 
 ```bash
+identrail scan owner/repo --history-limit 5 --max-findings 5
+```
+
+Scan a private repository you already cloned:
+
+```bash
+cd private-repo
 identrail scan .
 ```
 
-Use `IDENTRAIL_PROVIDER=kubernetes identrail scan` when you want the Kubernetes
-provider defaults explicitly. If you built from source, use `./bin/identrail`
-instead of `identrail` unless you add the binary to your `PATH`. Repository
-signals complement the AWS/Kubernetes identity graph; they do not replace it.
-For hosted, project-scoped private repository scans, connect the GitHub App in
-the Identrail web app. See [Install Identrail](./docs/install.md) for CLI
-install details.
+For hosted private-repository scans, sign in to
+[identrail.com](https://www.identrail.com), create or select a project, and
+connect the Identrail GitHub App.
+
+### 3. Scan AWS
+
+Make sure your terminal has read-only AWS credentials:
+
+```bash
+aws sts get-caller-identity
+```
+
+Run an AWS machine identity scan:
+
+```bash
+IDENTRAIL_PROVIDER=aws \
+IDENTRAIL_AWS_SOURCE=sdk \
+IDENTRAIL_AWS_REGION=us-east-1 \
+identrail scan
+```
+
+Change `IDENTRAIL_AWS_REGION` to the AWS region you want to inspect.
+
+### 4. Scan Kubernetes
+
+Make sure `kubectl` can reach the cluster:
+
+```bash
+kubectl config current-context
+```
+
+Check that your current identity can list the objects Identrail needs:
+
+```bash
+kubectl auth can-i list serviceaccounts --all-namespaces
+kubectl auth can-i list rolebindings --all-namespaces
+kubectl auth can-i list clusterrolebindings
+kubectl auth can-i list roles --all-namespaces
+kubectl auth can-i list clusterroles
+kubectl auth can-i list pods --all-namespaces
+```
+
+Run a Kubernetes machine identity scan:
+
+```bash
+IDENTRAIL_PROVIDER=kubernetes \
+IDENTRAIL_K8S_SOURCE=kubectl \
+identrail scan
+```
+
+Use a specific kube context when needed:
+
+```bash
+IDENTRAIL_PROVIDER=kubernetes \
+IDENTRAIL_K8S_SOURCE=kubectl \
+IDENTRAIL_KUBE_CONTEXT=my-cluster-context \
+identrail scan
+```
+
+### 5. Run with Docker
+
+Use Docker when you do not want to install the CLI locally.
+
+Scan a GitHub repository:
+
+```bash
+docker run --rm ghcr.io/identrail/identrail-cli:latest scan owner/repo
+```
+
+Scan a private repository you already cloned:
+
+```bash
+cd private-repo
+docker run --rm -v "$PWD:/repo" -w /repo ghcr.io/identrail/identrail-cli:latest scan .
+```
+
+Run an AWS scan with a local AWS profile:
+
+```bash
+docker run --rm \
+  -v "$HOME/.aws:/aws:ro" \
+  -e AWS_CONFIG_FILE=/aws/config \
+  -e AWS_SHARED_CREDENTIALS_FILE=/aws/credentials \
+  -e AWS_PROFILE=default \
+  -e IDENTRAIL_PROVIDER=aws \
+  -e IDENTRAIL_AWS_SOURCE=sdk \
+  -e IDENTRAIL_AWS_REGION=us-east-1 \
+  ghcr.io/identrail/identrail-cli:latest scan
+```
+
+For live Kubernetes scans, use the Homebrew or source-built CLI where `kubectl`
+is installed and configured. The CLI container stays small and does not include
+`kubectl`.
+
+### 6. Use the Hosted App
+
+Go to [identrail.com](https://www.identrail.com), sign in, create or select a
+workspace, and connect the sources your project owns: GitHub, AWS, and
+Kubernetes.
+
+Use the hosted app when you want project-scoped source onboarding, GitHub App
+scans, scan history, findings, trends, and owner-ready review workflows.
+
+For production deployment, SSO, tenant/workspace scope, connector secrets, and
+audit logging, use the [Enterprise Quickstart](./docs/enterprise-quickstart.md).
 
 ## What Identrail Does
 
-- Discovers machine identities and trust relationships across AWS and Kubernetes.
-- Adds repository exposure signals for secrets, GitHub Actions, and CI risk.
-- Produces explainable findings with evidence, severity, and remediation context.
-- Provides CLI, API, worker, and web workflows for local scans, hosted scans, trends, and review.
+- Scans GitHub repositories for secrets, risky GitHub Actions workflows, CI exposure, and repository posture signals.
+- Discovers AWS IAM trust paths, role relationships, and machine identity risk from live AWS accounts or fixtures.
+- Discovers Kubernetes service accounts, RBAC bindings, and cluster identity paths from live clusters or fixtures.
+- Produces explainable findings with evidence, severity, confidence, ownership, and remediation context.
+- Provides CLI, Docker, API, worker, and web workflows for local scans, hosted
+  scans, source onboarding, trends, and review.
 
 ## What Identrail Does Not Do
 
 - It is not a cloud SIEM replacement.
 - It is not an endpoint runtime agent.
-- It is not a generic CSPM for every cloud/provider in V1.
+- It is not a generic CSPM for every cloud and SaaS provider.
+- It does not mutate your cloud, cluster, or repository state during read-only scans.
 
-V1 is intentionally focused on machine identity security workflows for AWS and Kubernetes.
+V1 focuses on machine identity security across GitHub, AWS, and Kubernetes.
 
 ## How It Works
 
 ```text
-Collector -> Raw Assets -> Normalizer -> Graph -> Risk Rules -> Findings Store -> API/CLI/Web
+Source -> Collector -> Normalizer -> Graph -> Risk Rules -> Findings -> CLI/API/Web
 ```
 
 The CLI runs local scans directly. The API enqueues hosted scans, the worker
@@ -131,21 +217,23 @@ processes them, and results are available through the API, CLI, and web UI.
 
 ## Deployment Options
 
-Choose the rollout path that matches your environment maturity:
+Choose the path that matches how you want to run Identrail:
 
-- Local / single host: Docker Compose (`deploy/docker`)
-- Cluster-native: Kubernetes manifests (`deploy/kubernetes`)
-- Upgrade-safe Kubernetes: Helm chart (`deploy/helm/identrail`)
-- IaC rollout: Terraform Helm module (`deploy/terraform`)
-- Non-Kubernetes runtime: Linux VM + systemd (`deploy/systemd`)
+- Hosted app: use [identrail.com](https://www.identrail.com) for source onboarding and scan review.
+- Local CLI: use Homebrew, Docker, or a source build for quick read-only scans.
+- Local stack: use Docker Compose from `deploy/docker`.
+- Kubernetes: use manifests in `deploy/kubernetes` or the Helm chart in `deploy/helm/identrail`.
+- Infrastructure as code: use the Terraform modules in `deploy/terraform`.
+- Linux VM: use the systemd units in `deploy/systemd`.
 
-See [Deployment Anywhere](./docs/deployment-anywhere.md) for exact commands.
+See [Deployment Anywhere](./docs/deployment-anywhere.md) for operator commands.
 
 ## Comparison (Where Identrail Fits)
 
-- Versus broad CSPM tools: Identrail is narrower and deeper on machine identity trust and authorization workflows.
+- Versus broad CSPM tools: Identrail is narrower and deeper on machine identity
+  trust, repository automation exposure, and authorization workflows.
 - Versus secret scanners alone: Identrail links repository findings into identity risk context.
-- Versus policy engines alone: Identrail adds discovery + risk evidence, not only policy evaluation.
+- Versus policy engines alone: Identrail adds discovery and risk evidence, not only policy evaluation.
 
 <details>
   <summary><strong>Security and Support SLA</strong></summary>

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/identrail/identrail/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/identrail/identrail/ci.yml?branch=dev&style=flat&label=ci&colorA=000000&colorB=2ea043" alt="CI" /></a>
-  <a href="https://github.com/identrail/identrail/tags"><img src="https://img.shields.io/github/v/tag/identrail/identrail?sort=semver&style=flat&label=version&colorA=000000&colorB=0969da" alt="Latest version" /></a>
-  <a href="https://github.com/identrail/identrail/stargazers"><img src="https://img.shields.io/github/stars/identrail/identrail?style=flat&colorA=000000&colorB=d4af37" alt="GitHub stars" /></a>
+  <a href="https://github.com/identrail/identrail/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/identrail/identrail/ci.yml?branch=dev&style=flat&label=ci&labelColor=000000" alt="CI status" /></a>
+  <a href="https://github.com/identrail/identrail/releases/tag/v1.0.1"><img src="https://img.shields.io/badge/version-v1.0.1-0969da?style=flat&labelColor=000000" alt="Version v1.0.1" /></a>
+  <a href="https://github.com/identrail/identrail/stargazers"><img src="https://img.shields.io/github/stars/identrail/identrail?style=flat&label=stars&labelColor=000000&color=d4af37" alt="GitHub stars" /></a>
 </p>
 
 <p align="center">

--- a/docs/enterprise-quickstart.md
+++ b/docs/enterprise-quickstart.md
@@ -1,11 +1,29 @@
-# Enterprise 5-Minute Quickstart
+# Enterprise Quickstart
 
-This quickstart gets Identrail running with enterprise-safe defaults for auth scope, tenant/workspace context, and decision audit logging.
+Use this guide when you are setting up Identrail for a team or production-like
+environment. It keeps the first run understandable while covering the enterprise
+pieces that matter: scoped API access, tenant/workspace context, source
+onboarding, SSO, SCIM, audit logging, and executive reporting.
+
+For a quick one-off scan from your terminal, start with the public
+[README](../README.md). This guide is for operators who need durable
+configuration and repeatable team access.
+
+## What You Will Set Up
+
+- A local Docker Compose stack with API, web, worker, and database services.
+- Scoped API keys bound to a tenant and workspace.
+- Audit logging for authorization decisions.
+- Optional native SAML SSO and SCIM provisioning.
+- Source onboarding links for GitHub, AWS, and Kubernetes.
+- Executive report verification for leadership-facing review.
 
 ## Prerequisites
 
 - Docker + Docker Compose
 - `curl` + `jq`
+- Admin access to the identity provider if you are configuring SSO or SCIM
+- Read-only source access for any GitHub, AWS, or Kubernetes systems you connect
 
 ## 1. Configure Environment
 
@@ -68,7 +86,19 @@ curl -sS "${IDENTRAIL_API_URL}/v1/scans?limit=5" \
   -H "X-Identrail-Workspace-ID: ${IDENTRAIL_WORKSPACE_ID}" | jq .
 ```
 
-## 5. Trigger and Verify a Scan
+## 5. Choose a Source Onboarding Path
+
+For team deployments, connect sources through project-scoped onboarding so
+findings stay tied to the tenant, workspace, and project that owns the risk.
+
+- GitHub App repository scans: [GitHub connector](./auth/github-connector.md)
+- AWS account onboarding: [AWS connector](./auth/aws-connector.md)
+- Kubernetes cluster onboarding: [Kubernetes connector](./auth/kubernetes-connector.md)
+
+Keep the first connector read-only. After it validates cleanly, trigger a scan
+and review findings in the web app or API.
+
+## 6. Trigger and Verify a Scan
 
 ```bash
 SCAN_ID=$(
@@ -88,7 +118,7 @@ curl -sS "${IDENTRAIL_API_URL}/v1/scans/${SCAN_ID}/events?limit=10" \
   -H "X-Identrail-Workspace-ID: ${IDENTRAIL_WORKSPACE_ID}" | jq .
 ```
 
-## 6. Verify AuthZ Decision Explainability
+## 7. Verify AuthZ Decision Explainability
 
 `/v1/authz/policies/simulate` requires an API key mapped to `admin` scope.
 
@@ -110,7 +140,7 @@ Expected:
 - `decision` contains `allowed`, `stage`, `reason`
 - `trace` includes ordered stages from tenant isolation through default deny
 
-## 7. Verify Decision Audit Log
+## 8. Verify Decision Audit Log
 
 ```bash
 docker exec identrail-api sh -lc 'tail -n 50 /tmp/identrail-audit.jsonl' \
@@ -122,7 +152,7 @@ Confirm:
 - no raw API key values in audit payload
 - subject/resource IDs appear only as hashed identifiers (`*_id_hash`)
 
-## 8. Set Up SSO With Okta
+## 9. Set Up SSO With Okta
 
 Native enterprise SSO requires `IDENTRAIL_FEATURE_NATIVE_SSO=true` on the API.
 Native SAML admin and login routes also require `IDENTRAIL_FEATURE_NEW_AUTH=true`,
@@ -151,12 +181,7 @@ Okta click path:
 9. In **SAML Signing Certificates**, copy **Identity Provider metadata** or **Metadata URL**.
 10. In Identrail, open the enterprise SSO connection and paste the metadata URL, then confirm the parsed Entity ID, SSO URL, and certificate fingerprint.
 
-Screenshot placeholders:
-- `[Screenshot placeholder: Okta Create App Integration modal with SAML 2.0 selected]`
-- `[Screenshot placeholder: Okta Configure SAML page showing Single sign-on URL and Audience URI fields]`
-- `[Screenshot placeholder: Okta Sign On tab showing Identity Provider metadata link]`
-
-## 9. Set Up SSO With Azure AD
+## 10. Set Up SSO With Azure AD
 
 Microsoft now labels Azure AD as **Microsoft Entra ID** in the admin center. The click path below uses the current Entra labels while keeping the Azure AD wording operators still recognize.
 
@@ -178,12 +203,7 @@ Azure AD / Entra click path:
 9. In **SAML Certificates**, copy **App Federation Metadata Url**.
 10. In Identrail, open the enterprise SSO connection and paste the metadata URL, then confirm the parsed Entity ID, SSO URL, and certificate fingerprint.
 
-Screenshot placeholders:
-- `[Screenshot placeholder: Entra Enterprise applications page with New application selected]`
-- `[Screenshot placeholder: Entra SAML Basic SAML Configuration editor]`
-- `[Screenshot placeholder: Entra SAML Certificates area showing App Federation Metadata Url]`
-
-## 10. Enable SCIM Provisioning
+## 11. Enable SCIM Provisioning
 
 Each native SAML connection receives one SCIM bearer token when it is created. Identrail returns the plaintext token once; store it in the IdP immediately. The API stores only the token hash.
 
@@ -217,13 +237,7 @@ Azure AD / Entra SCIM click path:
 9. Keep the default user attribute mappings for `userName`, `active`, `displayName`, and `emails`.
 10. Set **Provisioning Status** to `On` when ready.
 
-Screenshot placeholders:
-- `[Screenshot placeholder: Okta Provisioning Integration tab with Base URL and API Token fields]`
-- `[Screenshot placeholder: Okta To App tab with Create, Update, and Deactivate enabled]`
-- `[Screenshot placeholder: Entra Provisioning page with Tenant URL and Secret Token fields]`
-- `[Screenshot placeholder: Entra Provisioning Status set to On]`
-
-## 11. Roll Out SSO-Only (`sso_required`)
+## 12. Roll Out SSO-Only (`sso_required`)
 
 Keep `sso_required=false` until at least one SAML admin has completed a
 successful sign-in and SCIM provisioning has created or matched the expected
@@ -250,7 +264,7 @@ Confirm:
 - `scim_op` matches the SCIM lifecycle operation
 - failed Slack/Jira/Linear attempts include `success=false` and an `error` string
 
-## 12. Executive Report (Board-Ready)
+## 13. Executive Report (Board-Ready)
 
 Fetch the leadership rollup for the current organization. The response is
 JSON only — there is no server-side PDF; use the printable web report page
@@ -279,7 +293,7 @@ Notes:
   carries a trustworthy `resolved_at`; it is derived solely from `resolved_at`
   (never the mutable `updated_at`), so the figure is not a guess.
 
-## 13. Clean Shutdown
+## 14. Clean Shutdown
 
 ```bash
 docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env down

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,15 +1,19 @@
 # Install Identrail
 
-Use Homebrew when the tap is published, Docker when you do not want to install
-anything locally, and a source build when you want to contribute or test
-development code.
+Use Homebrew for the simplest local install, Docker when you do not want to
+install the CLI, and a source build when you want to contribute.
 
 ## Homebrew
 
-After the Homebrew tap has been published, install the CLI on macOS or Linux:
+Install the CLI on macOS or Linux:
 
 ```bash
 brew install identrail/tap/identrail
+```
+
+Run your first GitHub repository scan:
+
+```bash
 identrail scan owner/repo
 ```
 
@@ -18,22 +22,36 @@ requires Homebrew to accept an Identrail formula.
 
 ## Docker
 
-Run Identrail without installing it on your machine:
+Scan a GitHub repository without installing Identrail locally:
 
 ```bash
-docker run --rm ghcr.io/identrail/identrail-cli:dev scan owner/repo
+docker run --rm ghcr.io/identrail/identrail-cli:latest scan owner/repo
 ```
 
-For a private repository, clone it first and mount the checkout:
+Scan a private repository you already cloned:
 
 ```bash
-git clone git@github.com:owner/private-repo.git
 cd private-repo
-docker run --rm -v "$PWD:/repo" -w /repo ghcr.io/identrail/identrail-cli:dev scan .
+docker run --rm -v "$PWD:/repo" -w /repo ghcr.io/identrail/identrail-cli:latest scan .
 ```
 
-The Docker image uses the same command shape as the installed CLI. Put CLI
-arguments after the image name.
+Run an AWS scan with a local AWS profile:
+
+```bash
+docker run --rm \
+  -v "$HOME/.aws:/aws:ro" \
+  -e AWS_CONFIG_FILE=/aws/config \
+  -e AWS_SHARED_CREDENTIALS_FILE=/aws/credentials \
+  -e AWS_PROFILE=default \
+  -e IDENTRAIL_PROVIDER=aws \
+  -e IDENTRAIL_AWS_SOURCE=sdk \
+  -e IDENTRAIL_AWS_REGION=us-east-1 \
+  ghcr.io/identrail/identrail-cli:latest scan
+```
+
+For live Kubernetes scans, use the Homebrew or source-built CLI where `kubectl`
+is installed and configured. The CLI container stays small and does not include
+`kubectl`.
 
 ## Source Build
 
@@ -49,28 +67,22 @@ go build -o ./bin/identrail ./cmd/cli
 If you want to run `identrail` without the `./bin/` prefix, move the built
 binary into a directory on your `PATH`.
 
-## Scan Commands
+## First Scan Commands
 
 These commands assume `identrail` is installed or on your `PATH`. If you built
 from source and did not move the binary, replace `identrail` with
 `./bin/identrail`.
 
-Run the AWS/Kubernetes provider scan path:
-
-```bash
-identrail scan
-```
-
-Use the Kubernetes provider defaults explicitly:
-
-```bash
-IDENTRAIL_PROVIDER=kubernetes identrail scan
-```
-
 Scan a public GitHub repository:
 
 ```bash
 identrail scan owner/repo
+```
+
+Limit the scan for a fast first look:
+
+```bash
+identrail scan owner/repo --history-limit 5 --max-findings 5
 ```
 
 Scan a private repository you already cloned:
@@ -80,15 +92,32 @@ cd private-repo
 identrail scan .
 ```
 
-Repository scans report secrets, GitHub Actions, and CI risk. They complement
-the AWS/Kubernetes machine identity workflow; they do not replace it. Hosted
-private repository scans use the GitHub App connector in the Identrail web app.
+Run an AWS machine identity scan:
 
-## Homebrew Tap Maintenance
+```bash
+IDENTRAIL_PROVIDER=aws \
+IDENTRAIL_AWS_SOURCE=sdk \
+IDENTRAIL_AWS_REGION=us-east-1 \
+identrail scan
+```
 
-Release automation renders and publishes `Formula/identrail.rb` to
-`identrail/homebrew-tap` when maintainers create that repository, configure a
-`HOMEBREW_TAP_TOKEN` secret with write access, and cut a release that includes
-the Homebrew workflow. The formula is pinned to a stable uploaded release source
-archive, not GitHub's generated tag archive. Until the tap is published, use
-Docker or a source build.
+Run a Kubernetes machine identity scan:
+
+```bash
+kubectl config current-context
+kubectl auth can-i list serviceaccounts --all-namespaces
+kubectl auth can-i list rolebindings --all-namespaces
+kubectl auth can-i list clusterrolebindings
+kubectl auth can-i list roles --all-namespaces
+kubectl auth can-i list clusterroles
+kubectl auth can-i list pods --all-namespaces
+
+IDENTRAIL_PROVIDER=kubernetes \
+IDENTRAIL_K8S_SOURCE=kubectl \
+identrail scan
+```
+
+Repository scans report secrets, GitHub Actions, CI risk, and repository posture
+signals. AWS and Kubernetes scans report machine identity trust paths and
+authorization risk. Hosted private repository scans use the GitHub App connector
+in the Identrail web app.


### PR DESCRIPTION
No issue: documentation-only onboarding refresh.

## What changed
- Reworked the public README quickstart into separate GitHub, AWS, Kubernetes, Docker, and hosted-app paths.
- Updated install docs to use the published Homebrew tap and released CLI image commands.
- Tightened the enterprise quickstart with clearer prerequisites, source onboarding links, and no stale screenshot placeholders.
- Added a changelog entry for the onboarding-doc refresh.

## Why
- First-time users should be able to choose the source they care about and run a matching command without reading through unrelated setup.
- The previous README underplayed GitHub scans, kept stale pre-publication Homebrew/Docker wording, and made AWS/Kubernetes setup less direct than the product now supports.
- Enterprise operators still need a path to durable auth, source onboarding, SSO, SCIM, audit logging, and executive reporting without making the public quickstart heavy.

## Impact and risk
- Docs-only change; no runtime behavior changes.
- Kubernetes Docker guidance is explicit that live cluster scans should use the Homebrew or source-built CLI because the CLI container does not include kubectl.
- GitHub private repository guidance distinguishes local cloned scans from hosted GitHub App scans.

## Validation
- `git diff --check`
- Confirmed no stale pre-publication wording with `rg "after the Homebrew|After the Homebrew|:dev scan|Screenshot placeholder|Until then" -n README.md docs/install.md docs/enterprise-quickstart.md` returning no matches.
- `go run ./cmd/cli scan --help`
- `go run ./cmd/cli scan identrail/identrail --history-limit 1 --max-findings 1`
- `docker manifest inspect ghcr.io/identrail/identrail-cli:latest`
- Verified GitHub, AWS, and Kubernetes connector doc links exist.

AI-assisted: yes
Tools used: Codex
Where used: README.md, docs/install.md, docs/enterprise-quickstart.md, CHANGELOG.md
Human verification performed: reviewed the final diff, checked command availability/help text, ran a GitHub repository scan smoke test, confirmed the CLI image manifest exists, and verified linked connector docs exist.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies source-specific quickstarts and install steps so users can run GitHub, AWS, Kubernetes, or Docker scans immediately via Homebrew and `ghcr.io/identrail/identrail-cli:latest`. Adds the OpenSSF Best Practices badge, stabilizes README badges, and updates copy to clearly include GitHub coverage.

- **Refactors**
  - README: per-source quickstarts (GitHub, AWS, Kubernetes, Docker, hosted app); numbered install/scan steps; examples for repo scans with limits, AWS env vars, Kubernetes `kubectl` context and `auth can-i` checks; Docker examples (incl. AWS profile mount); notes the CLI container omits `kubectl`; updated tagline and “What It Does/Does Not” and Deployment sections; adds OpenSSF badge.
  - Install: `brew install identrail/tap/identrail`; first-scan commands for GitHub, AWS, and Kubernetes; Docker uses `ghcr.io/identrail/identrail-cli:latest` and documents AWS profile mount; calls out missing `kubectl` in the image.
  - Enterprise: renamed “Enterprise Quickstart”; adds “Choose a Source Onboarding Path” with connector links; clearer prerequisites; removes screenshot placeholders.
  - Changelog: records the onboarding-doc refresh and badge updates, including OpenSSF.

- **Bug Fixes**
  - README badges no longer force green CI; version badge is pinned to `v1.0.1` with stable labels.

<sup>Written for commit e4a06472f8430d86889211a39bf9c9e9572905f0. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1311?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

