### PR TITLE
fix(repo): repair any-scope queue claims

### DIFF
--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -524,9 +524,11 @@ func (p *PostgresStore) claimNextQueuedScan(ctx context.Context, provider string
 		RETURNING s.id, s.tenant_id, s.workspace_id, s.provider, s.status, s.started_at, s.finished_at, s.asset_count, s.finding_count, COALESCE(s.error_message, ''), s.retry_count, s.max_retry_count, COALESCE(s.failure_category, ''), s.next_retry_at, s.dead_lettered, s.dead_lettered_at, COALESCE(s.trace_parent, ''), COALESCE(s.trace_state, '')`
 		args = []any{scope.TenantID, scope.WorkspaceID, strings.TrimSpace(provider)}
 	}
-	row := p.queryRowContext(ctx, query, args...)
+	var row rowScanner
 	if scope == nil {
 		row = p.queryRowContextAnyScope(ctx, query, args...)
+	} else {
+		row = p.queryRowContext(ctx, query, args...)
 	}
 	record, err := scanQueuedScanRecord(row)
 	if err != nil {
@@ -2818,9 +2820,11 @@ func (p *PostgresStore) claimNextQueuedRepoScan(ctx context.Context, scope *Scop
 			COALESCE(r.trace_state, '')`
 		args = []any{scope.TenantID, scope.WorkspaceID}
 	}
-	row := p.queryRowContext(ctx, query, args...)
+	var row rowScanner
 	if scope == nil {
 		row = p.queryRowContextAnyScope(ctx, query, args...)
+	} else {
+		row = p.queryRowContext(ctx, query, args...)
 	}
 	record, err := scanQueuedRepoScanRecord(row)
 	if err != nil {

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -3193,7 +3193,8 @@ func TestPostgresStoreClaimNextQueuedScanAnyScopeBypassesScopeInjection(t *testi
 		WithArgs("aws").
 		WillReturnRows(rows)
 
-	record, err := store.ClaimNextQueuedScanAnyScope(context.Background(), "aws")
+	scopedCtx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	record, err := store.ClaimNextQueuedScanAnyScope(scopedCtx, "aws")
 	if err != nil {
 		t.Fatalf("claim any-scope scan: %v", err)
 	}
@@ -3227,7 +3228,8 @@ func TestPostgresStoreClaimNextQueuedRepoScanAnyScopeBypassesScopeInjection(t *t
 	mock.ExpectQuery("WITH next_repo_scan AS").
 		WillReturnRows(rows)
 
-	record, err := store.ClaimNextQueuedRepoScanAnyScope(context.Background())
+	scopedCtx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	record, err := store.ClaimNextQueuedRepoScanAnyScope(scopedCtx)
 	if err != nil {
 		t.Fatalf("claim any-scope repo scan: %v", err)
 	}


### PR DESCRIPTION
No issue: production repo scan queue regression found from live worker diagnostics.

## What changed
- Select the any-scope PostgreSQL query path before executing queued scan claims.
- Cover the production worker case where any-scope claims receive an already-scoped context.

## Why
The hosted worker logs showed repeated `claim_attempt` events followed later by stale failures, with no `claimed` or `scan_started` events. The claim helpers were creating a scoped query row before switching to the any-scope query path, which can claim or lock the job without the worker actually receiving the record to execute.

## Impact and risk
- Restores queued repo scan and queued cloud scan claiming under scoped worker contexts.
- Low risk: the change only chooses the existing query path before execution and leaves the SQL itself unchanged.

## Validation performed
- `go test ./internal/db -run 'TestPostgresStoreClaimNextQueued.*AnyScopeBypassesScopeInjection|TestPostgresStoreQueryRowContext' -count=1`\n- `go test ./internal/db -count=1`\n- `go test ./internal/worker -run 'TestProcessAPIQueueBatch|TestWithJobTimeout|TestWorker' -count=1`\n- `go test ./internal/api -run 'TestServiceProcessNextQueuedRepoScan|TestServiceProcessNextQueuedScan|TestServiceRunRepoScanPersistedFailureUsesFreshContextForTerminalWrite' -count=1`\n\nAI-assisted: yes\nTools used: OpenAI coding assistant\nWhere used: diagnosis, PostgreSQL queue claim fix, regression tests\nHuman verification performed: reviewed live worker diagnostics, inspected code paths, ran targeted DB/API/worker tests\n

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression in any-scope queue claims for repo and cloud scans by selecting the any-scope query path before execution. Prevents stale locks and restores claiming when workers run with a scoped context.

- **Bug Fixes**
  - In `claimNextQueuedScan` and `claimNextQueuedRepoScan`, use the any-scope query path when scope is nil instead of creating a scoped row first.
  - Bypasses scope injection when any-scope claims are called with a scoped context.

<sup>Written for commit 697f1d27932126c33673b1f62596acf750f66d0e. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1312?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

