### PR TITLE
chore(ci,docs): rescan osv on dev push and restyle OpenSSF badge

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,6 +1,9 @@
 name: OSV Scanner
 
 on:
+  push:
+    branches:
+      - dev
   pull_request:
   schedule:
     - cron: '31 2 * * *'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## Unreleased
+- Re-scan dependencies with osv-scanner on every push to `dev` so resolved
+  dependency CVEs clear from the code-scanning dashboard right after a fix
+  merges, instead of waiting for the daily scheduled run. Restyled the README
+  OpenSSF Best Practices badge to a shields.io badge that matches the other
+  badges (black label, vivid "passing").
 - Refreshed the public onboarding docs so first-time users can start from the
   source they care about: GitHub repository scans, AWS machine identity scans,
   Kubernetes machine identity scans, Docker-based runs, or the hosted app. The

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
   <br />
   <br />
 
-  <p><strong>Open-source machine identity security for GitHub, AWS, and Kubernetes.</strong></p>
+  <p><strong>Open-source machine identity security for AWS, GitHub, and Kubernetes.</strong></p>
   <p>Find risky trust paths, repository exposure, and authorization gaps before they become incidents.</p>
 </div>
 
 <p align="center">
   <a href="https://github.com/identrail/identrail/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/identrail/identrail/ci.yml?branch=dev&style=flat&label=ci&labelColor=000000" alt="CI status" /></a>
   <a href="https://github.com/identrail/identrail/releases/tag/v1.0.1"><img src="https://img.shields.io/badge/version-v1.0.1-0969da?style=flat&labelColor=000000" alt="Version v1.0.1" /></a>
-  <a href="https://www.bestpractices.dev/projects/12950"><img src="https://www.bestpractices.dev/projects/12950/badge" alt="OpenSSF Best Practices" /></a>
+  <a href="https://www.bestpractices.dev/projects/12950"><img src="https://img.shields.io/cii/level/12950?style=flat&label=openssf%20best%20practices&labelColor=000000" alt="OpenSSF Best Practices" /></a>
   <a href="https://github.com/identrail/identrail/stargazers"><img src="https://img.shields.io/github/stars/identrail/identrail?style=flat&label=stars&labelColor=000000&color=d4af37" alt="GitHub stars" /></a>
 </p>
 


### PR DESCRIPTION
No issue: small CI + README follow-ups to the recent security remediation work.

## What changed
1. **osv-scanner re-scans on every push to `dev`.** Added a `push: branches: [dev]` trigger so the `osv-default` job re-scans the default branch immediately after a fix merges. Previously it only ran on a daily cron, so resolved dependency CVEs lingered on the code-scanning dashboard until the next scheduled run (this is exactly what left 33 stale alerts after #1305 merged).
2. **Restyled the OpenSSF Best Practices badge.** Swapped the native `bestpractices.dev` badge image for a shields.io badge (`cii/level/12950`) so it matches the other README badges — black label + vivid "passing" instead of the pale native style.
3. **Reordered the hero tagline** providers to "AWS, GitHub, and Kubernetes".

## Impact and risk
- CI + docs only; no application or API behavior change.
- The push-triggered `osv-default` run uploads SARIF for `dev` (same as the existing cron run); `osv-pr` remains gated to pull requests.

## Validation
- `osv-scanner.yml` parses as valid YAML; confirmed `push` triggers `osv-default` (`if: github.event_name != 'pull_request'`) and skips `osv-pr`.
- Verified the shields.io endpoint for project 12950 returns `passing` / `brightgreen` and the styled URL responds 200.

## Note
The same provider ordering ("GitHub, AWS, and Kubernetes") still appears elsewhere in the README (lines 44, 183, 208); left unchanged for now — can align for consistency on request.

## AI-Assisted and AI-Generated Code Policy
- AI-assisted: yes
- Tools used: Claude Code
- Where used: `.github/workflows/osv-scanner.yml`, `README.md`, `CHANGELOG.md`
- Human verification performed: validated the workflow trigger/job gating, confirmed the badge endpoint renders, reviewed the diff

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CI/docs-only: run `osv-scanner` on every push to `dev` so resolved dependency CVEs clear from the code-scanning dashboard immediately. Also restyled the README OpenSSF Best Practices badge via shields.io to match other badges and reordered the hero tagline to “AWS, GitHub, and Kubernetes.”

<sup>Written for commit 85f9bf8233fb492427e3ca7caa87e192748ce51b. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1313?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

