### PR TITLE
fix(repo): fetch required refs for delta scans

### DIFF
--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -35,6 +35,7 @@ const (
 )
 
 var hunkHeaderPattern = regexp.MustCompile(`@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@`)
+var fullHexRevisionPattern = regexp.MustCompile(`(?i)^[0-9a-f]{40}$`)
 var repositorySharedAddressRange = mustParseCIDR("100.64.0.0/10")
 var repositoryHostLookupIPs = func(ctx context.Context, host string) ([]net.IP, error) {
 	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
@@ -188,7 +189,7 @@ func (s *Scanner) ScanRepositoryWithOptions(ctx context.Context, target string, 
 	options = normalizeScanOptions(options)
 
 	started := s.now().UTC()
-	location, cleanup, err := s.prepareRepository(ctx, repo)
+	location, cleanup, err := s.prepareRepositoryWithOptions(ctx, repo, options)
 	if err != nil {
 		return ScanResult{}, err
 	}
@@ -353,13 +354,20 @@ type remoteRepositoryRef struct {
 }
 
 type remoteRepositoryClonePlan struct {
-	DefaultRef   remoteRepositoryRef
-	DefaultDepth int
-	ExtraRefs    []remoteRepositoryRef
-	ExtraDepth   int
+	DefaultRef        remoteRepositoryRef
+	DefaultDepth      int
+	RequiredRefs      []remoteRepositoryRef
+	RequiredRevisions []string
+	RequiredDepth     int
+	ExtraRefs         []remoteRepositoryRef
+	ExtraDepth        int
 }
 
 func (s *Scanner) prepareRepository(ctx context.Context, target string) (repositoryLocation, func(), error) {
+	return s.prepareRepositoryWithOptions(ctx, target, ScanOptions{})
+}
+
+func (s *Scanner) prepareRepositoryWithOptions(ctx context.Context, target string, options ScanOptions) (repositoryLocation, func(), error) {
 	if local, ok := localRepository(target); ok {
 		return local, func() {}, nil
 	}
@@ -374,7 +382,7 @@ func (s *Scanner) prepareRepository(ctx context.Context, target string) (reposit
 	}
 	cleanup := func() { _ = os.RemoveAll(workdir) }
 	repoPath := filepath.Join(workdir, "repo.git")
-	if runErr := s.cloneRemoteRepository(ctx, workdir, cloneURL, repoPath); runErr != nil {
+	if runErr := s.cloneRemoteRepositoryWithOptions(ctx, workdir, cloneURL, repoPath, options); runErr != nil {
 		cleanup()
 		return repositoryLocation{}, nil, fmt.Errorf("clone repository: %w", runErr)
 	}
@@ -382,6 +390,10 @@ func (s *Scanner) prepareRepository(ctx context.Context, target string) (reposit
 }
 
 func (s *Scanner) cloneRemoteRepository(ctx context.Context, workdir string, cloneURL string, repoPath string) error {
+	return s.cloneRemoteRepositoryWithOptions(ctx, workdir, cloneURL, repoPath, ScanOptions{})
+}
+
+func (s *Scanner) cloneRemoteRepositoryWithOptions(ctx context.Context, workdir string, cloneURL string, repoPath string, options ScanOptions) error {
 	runner, cleanup, err := s.cloneCommandRunner(workdir, cloneURL)
 	if err != nil {
 		return err
@@ -393,7 +405,7 @@ func (s *Scanner) cloneRemoteRepository(ctx context.Context, workdir string, clo
 		return fmt.Errorf("list remote refs: %w", err)
 	}
 	refs, defaultRefName := parseRemoteRepositoryRefs(refsOutput)
-	plan, err := buildRemoteRepositoryClonePlan(refs, defaultRefName, s.historyLimit)
+	plan, err := buildRemoteRepositoryClonePlanForRevisions(refs, defaultRefName, s.historyLimit, requiredCloneRevisions(options))
 	if err != nil {
 		return err
 	}
@@ -408,6 +420,12 @@ func (s *Scanner) cloneRemoteRepository(ctx context.Context, workdir string, clo
 		return err
 	}
 	if err := fetchRemoteRepositoryRefs(ctx, runner, repoPath, []remoteRepositoryRef{plan.DefaultRef}, plan.DefaultDepth); err != nil {
+		return err
+	}
+	if err := fetchRemoteRepositoryRefs(ctx, runner, repoPath, plan.RequiredRefs, plan.RequiredDepth); err != nil {
+		return err
+	}
+	if err := fetchRemoteRepositoryRevisions(ctx, runner, repoPath, plan.RequiredRevisions, plan.RequiredDepth); err != nil {
 		return err
 	}
 	if err := pointRemoteRepositoryHead(ctx, runner, repoPath, plan.DefaultRef); err != nil {
@@ -460,6 +478,50 @@ func fetchRemoteRepositoryRefs(ctx context.Context, runner CommandRunner, repoPa
 		return fmt.Errorf("fetch bounded repository refs: %w", err)
 	}
 	return nil
+}
+
+func fetchRemoteRepositoryRevisions(ctx context.Context, runner CommandRunner, repoPath string, revisions []string, depth int) error {
+	missing := missingRemoteRepositoryRevisions(ctx, runner, repoPath, revisions)
+	if len(missing) == 0 {
+		return nil
+	}
+	if depth < 1 {
+		depth = 1
+	}
+	args := []string{
+		"--git-dir", repoPath,
+		"fetch",
+		"--quiet",
+		"--no-tags",
+	}
+	args = appendBoundedFetchDepthArgs(args, depth)
+	args = append(args, "origin")
+	args = append(args, missing...)
+	if _, err := runner(ctx, "git", args...); err != nil {
+		return fmt.Errorf("fetch required repository revisions: %w", err)
+	}
+	stillMissing := missingRemoteRepositoryRevisions(ctx, runner, repoPath, missing)
+	if len(stillMissing) > 0 {
+		return fmt.Errorf("fetch required repository revisions: unavailable revisions: %s", strings.Join(stillMissing, ", "))
+	}
+	return nil
+}
+
+func missingRemoteRepositoryRevisions(ctx context.Context, runner CommandRunner, repoPath string, revisions []string) []string {
+	if len(revisions) == 0 {
+		return nil
+	}
+	missing := make([]string, 0, len(revisions))
+	for _, revision := range revisions {
+		normalized := strings.ToLower(strings.TrimSpace(revision))
+		if normalized == "" {
+			continue
+		}
+		if _, err := runner(ctx, "git", "--git-dir", repoPath, "cat-file", "-e", normalized+"^{commit}"); err != nil {
+			missing = append(missing, normalized)
+		}
+	}
+	return missing
 }
 
 func appendBoundedFetchDepthArgs(args []string, depth int) []string {
@@ -559,6 +621,10 @@ func parseRemoteRepositoryRefs(output []byte) ([]remoteRepositoryRef, string) {
 }
 
 func buildRemoteRepositoryClonePlan(refs []remoteRepositoryRef, defaultRefName string, historyLimit int) (remoteRepositoryClonePlan, error) {
+	return buildRemoteRepositoryClonePlanForRevisions(refs, defaultRefName, historyLimit, nil)
+}
+
+func buildRemoteRepositoryClonePlanForRevisions(refs []remoteRepositoryRef, defaultRefName string, historyLimit int, requiredRevisions []string) (remoteRepositoryClonePlan, error) {
 	if historyLimit < 1 {
 		historyLimit = defaultHistoryLimit
 	}
@@ -576,9 +642,18 @@ func buildRemoteRepositoryClonePlan(refs []remoteRepositoryRef, defaultRefName s
 		}
 	}
 
+	requiredRefs := requiredRemoteRepositoryRefs(refs, defaultRef, requiredRevisions)
+	requiredNames := map[string]struct{}{}
+	for _, ref := range requiredRefs {
+		requiredNames[ref.Name] = struct{}{}
+	}
+
 	extras := make([]remoteRepositoryRef, 0, len(refs)-1)
 	for _, ref := range refs {
 		if ref.Name == defaultRef.Name {
+			continue
+		}
+		if _, required := requiredNames[ref.Name]; required {
 			continue
 		}
 		extras = append(extras, ref)
@@ -612,11 +687,84 @@ func buildRemoteRepositoryClonePlan(refs []remoteRepositoryRef, defaultRefName s
 		defaultDepth = minFetchDepthForPatchScan
 	}
 	return remoteRepositoryClonePlan{
-		DefaultRef:   defaultRef,
-		DefaultDepth: defaultDepth,
-		ExtraRefs:    extras,
-		ExtraDepth:   extraDepth,
+		DefaultRef:        defaultRef,
+		DefaultDepth:      defaultDepth,
+		RequiredRefs:      requiredRefs,
+		RequiredRevisions: append([]string(nil), requiredRevisions...),
+		RequiredDepth:     fetchDepthBudget,
+		ExtraRefs:         extras,
+		ExtraDepth:        extraDepth,
 	}, nil
+}
+
+func requiredCloneRevisions(options ScanOptions) []string {
+	options = normalizeScanOptions(options)
+	revisions := make([]string, 0, 2)
+	seen := map[string]struct{}{}
+	for _, revision := range []string{options.HeadRevision, options.BaseRevision} {
+		normalized := strings.ToLower(strings.TrimSpace(revision))
+		if normalized == "" || isZeroRevision(normalized) || !fullHexRevisionPattern.MatchString(normalized) {
+			continue
+		}
+		if _, exists := seen[normalized]; exists {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		revisions = append(revisions, normalized)
+	}
+	return revisions
+}
+
+func requiredRemoteRepositoryRefs(refs []remoteRepositoryRef, defaultRef remoteRepositoryRef, requiredRevisions []string) []remoteRepositoryRef {
+	if len(requiredRevisions) == 0 {
+		return nil
+	}
+	required := map[string]struct{}{}
+	for _, revision := range requiredRevisions {
+		normalized := strings.ToLower(strings.TrimSpace(revision))
+		if normalized != "" {
+			required[normalized] = struct{}{}
+		}
+	}
+	if len(required) == 0 {
+		return nil
+	}
+	bestByRevision := map[string]remoteRepositoryRef{}
+	for _, ref := range refs {
+		revision := strings.ToLower(strings.TrimSpace(ref.SHA))
+		if _, ok := required[revision]; !ok {
+			continue
+		}
+		if ref.Name == defaultRef.Name {
+			continue
+		}
+		if current, exists := bestByRevision[revision]; !exists || compareRequiredRemoteRefs(ref, current) < 0 {
+			bestByRevision[revision] = ref
+		}
+	}
+	requiredRefs := make([]remoteRepositoryRef, 0, len(bestByRevision))
+	for _, ref := range bestByRevision {
+		requiredRefs = append(requiredRefs, ref)
+	}
+	sort.Slice(requiredRefs, func(i, j int) bool {
+		return compareRequiredRemoteRefs(requiredRefs[i], requiredRefs[j]) < 0
+	})
+	return requiredRefs
+}
+
+func compareRequiredRemoteRefs(left remoteRepositoryRef, right remoteRepositoryRef) int {
+	leftPriority := remoteRepositoryRequiredRefPriority(left.Name)
+	rightPriority := remoteRepositoryRequiredRefPriority(right.Name)
+	if leftPriority != rightPriority {
+		return leftPriority - rightPriority
+	}
+	if left.Name < right.Name {
+		return -1
+	}
+	if left.Name > right.Name {
+		return 1
+	}
+	return 0
 }
 
 func remoteRepositoryRefPriority(ref string) int {
@@ -624,6 +772,17 @@ func remoteRepositoryRefPriority(ref string) int {
 	case strings.HasPrefix(ref, "refs/tags/"):
 		return 0
 	case !strings.HasPrefix(ref, "refs/heads/"):
+		return 1
+	default:
+		return 2
+	}
+}
+
+func remoteRepositoryRequiredRefPriority(ref string) int {
+	switch {
+	case strings.HasPrefix(ref, "refs/heads/"):
+		return 0
+	case !strings.HasPrefix(ref, "refs/tags/"):
 		return 1
 	default:
 		return 2

--- a/internal/repoexposure/scanner_test.go
+++ b/internal/repoexposure/scanner_test.go
@@ -907,6 +907,52 @@ func TestCloneRemoteRepositoryUsesBoundedFetchPlan(t *testing.T) {
 	}
 }
 
+func TestCloneRemoteRepositoryFetchesRequiredDeltaRef(t *testing.T) {
+	head := strings.Repeat("b", 40)
+	var gotCommands [][]string
+	scanner := NewScanner(
+		func(_ context.Context, name string, args ...string) ([]byte, error) {
+			command := append([]string{name}, args...)
+			gotCommands = append(gotCommands, command)
+			if reflect.DeepEqual(command, []string{"git", "ls-remote", "--symref", "https://github.com/owner/repo.git"}) {
+				return []byte(strings.Join([]string{
+					"ref: refs/heads/main\tHEAD",
+					strings.Repeat("a", 40) + "\tHEAD",
+					strings.Repeat("a", 40) + "\trefs/heads/main",
+					strings.Repeat("c", 40) + "\trefs/tags/release-keep",
+					head + "\trefs/pull/12/head",
+					head + "\trefs/heads/feature",
+				}, "\n")), nil
+			}
+			return []byte("ok"), nil
+		},
+		WithHistoryLimit(4),
+	)
+	repoPath := filepath.Join(t.TempDir(), "repo.git")
+
+	err := scanner.cloneRemoteRepositoryWithOptions(context.Background(), t.TempDir(), "https://github.com/owner/repo.git", repoPath, ScanOptions{
+		Mode:         ScanModeDelta,
+		HeadRevision: head,
+	})
+	if err != nil {
+		t.Fatalf("clone remote repository: %v", err)
+	}
+
+	expected := [][]string{
+		{"git", "ls-remote", "--symref", "https://github.com/owner/repo.git"},
+		{"git", "init", "--bare", "--quiet", repoPath},
+		{"git", "--git-dir", repoPath, "remote", "add", "origin", "https://github.com/owner/repo.git"},
+		{"git", "--git-dir", repoPath, "fetch", "--quiet", "--no-tags", "--depth", "2", "origin", "+refs/tags/release-keep:refs/tags/release-keep"},
+		{"git", "--git-dir", repoPath, "fetch", "--quiet", "--no-tags", "--depth", "2", "origin", "+refs/heads/main:refs/heads/main"},
+		{"git", "--git-dir", repoPath, "fetch", "--quiet", "--no-tags", "--depth", "4", "origin", "+refs/heads/feature:refs/heads/feature"},
+		{"git", "--git-dir", repoPath, "cat-file", "-e", head + "^{commit}"},
+		{"git", "--git-dir", repoPath, "symbolic-ref", "HEAD", "refs/heads/main"},
+	}
+	if !reflect.DeepEqual(gotCommands, expected) {
+		t.Fatalf("unexpected clone commands\ngot:  %+v\nwant: %+v", gotCommands, expected)
+	}
+}
+
 func TestCloneRemoteRepositoryPreservesNonBranchRefs(t *testing.T) {
 	source := t.TempDir()
 	runGit(t, source, "init", "-q")
@@ -980,6 +1026,94 @@ func TestCloneRemoteRepositoryExtraRefsDoNotTruncateDefaultHistory(t *testing.T)
 	}
 }
 
+func TestCloneRemoteRepositoryRequiredDeltaRefIsResolvable(t *testing.T) {
+	source := t.TempDir()
+	runGit(t, source, "init", "-q", "-b", "main")
+
+	for i := 1; i <= 5; i++ {
+		if err := os.WriteFile(filepath.Join(source, "main.txt"), []byte(fmt.Sprintf("%d\n", i)), 0o600); err != nil {
+			t.Fatalf("write main fixture: %v", err)
+		}
+		runGit(t, source, "add", "main.txt")
+		runGit(t, source, "commit", "-q", "-m", fmt.Sprintf("main %d", i))
+		runGit(t, source, "tag", fmt.Sprintf("release-%d", i))
+	}
+	runGit(t, source, "checkout", "-q", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(source, "feature.txt"), []byte("feature\n"), 0o600); err != nil {
+		t.Fatalf("write feature fixture: %v", err)
+	}
+	runGit(t, source, "add", "feature.txt")
+	runGit(t, source, "commit", "-q", "-m", "feature")
+	head := strings.TrimSpace(runGit(t, source, "rev-parse", "HEAD"))
+	runGit(t, source, "checkout", "-q", "main")
+
+	remotePath := filepath.Join(t.TempDir(), "remote.git")
+	runGitCommand(t, "git", "clone", "--quiet", "--mirror", source, remotePath)
+
+	clonedPath := filepath.Join(t.TempDir(), "repo.git")
+	scanner := NewScanner(nil, WithHistoryLimit(4))
+	err := scanner.cloneRemoteRepositoryWithOptions(context.Background(), t.TempDir(), "file://"+remotePath, clonedPath, ScanOptions{
+		Mode:         ScanModeDelta,
+		HeadRevision: head,
+	})
+	if err != nil {
+		t.Fatalf("clone remote repository: %v", err)
+	}
+
+	gotHead := strings.TrimSpace(runGitCommand(t, "git", "--git-dir", clonedPath, "rev-parse", head+"^{commit}"))
+	if gotHead != head {
+		t.Fatalf("expected required delta head %s to be fetchable, got %s", head, gotHead)
+	}
+	if output := runGitCommand(t, "git", "--git-dir", clonedPath, "rev-list", "--max-count", "4", head); !strings.Contains(output, head) {
+		t.Fatalf("expected required delta head in rev-list output, got %q", output)
+	}
+}
+
+func TestCloneRemoteRepositoryFetchesMissingRequiredBaseRevision(t *testing.T) {
+	source := t.TempDir()
+	runGit(t, source, "init", "-q", "-b", "main")
+
+	for i := 1; i <= 6; i++ {
+		if err := os.WriteFile(filepath.Join(source, "history.txt"), []byte(fmt.Sprintf("%d\n", i)), 0o600); err != nil {
+			t.Fatalf("write history fixture: %v", err)
+		}
+		runGit(t, source, "add", "history.txt")
+		runGit(t, source, "commit", "-q", "-m", fmt.Sprintf("main %d", i))
+	}
+	base := strings.TrimSpace(runGit(t, source, "rev-parse", "HEAD~4"))
+	runGit(t, source, "checkout", "-q", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(source, "feature.txt"), []byte("feature\n"), 0o600); err != nil {
+		t.Fatalf("write feature fixture: %v", err)
+	}
+	runGit(t, source, "add", "feature.txt")
+	runGit(t, source, "commit", "-q", "-m", "feature")
+	head := strings.TrimSpace(runGit(t, source, "rev-parse", "HEAD"))
+	runGit(t, source, "checkout", "-q", "main")
+
+	remotePath := filepath.Join(t.TempDir(), "remote.git")
+	runGitCommand(t, "git", "clone", "--quiet", "--mirror", source, remotePath)
+
+	clonedPath := filepath.Join(t.TempDir(), "repo.git")
+	scanner := NewScanner(nil, WithHistoryLimit(2))
+	err := scanner.cloneRemoteRepositoryWithOptions(context.Background(), t.TempDir(), "file://"+remotePath, clonedPath, ScanOptions{
+		Mode:         ScanModeDelta,
+		BaseRevision: base,
+		HeadRevision: head,
+	})
+	if err != nil {
+		t.Fatalf("clone remote repository: %v", err)
+	}
+
+	gotBase := strings.TrimSpace(runGitCommand(t, "git", "--git-dir", clonedPath, "rev-parse", base+"^{commit}"))
+	if gotBase != base {
+		t.Fatalf("expected required delta base %s to be fetchable, got %s", base, gotBase)
+	}
+	gotHead := strings.TrimSpace(runGitCommand(t, "git", "--git-dir", clonedPath, "rev-parse", head+"^{commit}"))
+	if gotHead != head {
+		t.Fatalf("expected required delta head %s to be fetchable, got %s", head, gotHead)
+	}
+}
+
 func TestCloneRemoteRepositoryHandlesAnnotatedTagDefaultRef(t *testing.T) {
 	source := t.TempDir()
 	runGit(t, source, "init", "-q")
@@ -1039,6 +1173,38 @@ func TestBuildRemoteRepositoryClonePlanCapsExtraRefs(t *testing.T) {
 	expectedExtras := []string{"refs/tags/release-keep", "refs/identrail/archive"}
 	if !reflect.DeepEqual(gotExtras, expectedExtras) {
 		t.Fatalf("expected non-branch refs to be prioritized within ref budget, got %+v", gotExtras)
+	}
+}
+
+func TestBuildRemoteRepositoryClonePlanKeepsRequiredDeltaRefOutsideExtraBudget(t *testing.T) {
+	head := strings.Repeat("b", 40)
+	refs := []remoteRepositoryRef{
+		{Name: "refs/heads/main", SHA: strings.Repeat("a", 40)},
+		{Name: "refs/tags/release-keep", SHA: strings.Repeat("c", 40)},
+		{Name: "refs/pull/12/head", SHA: head},
+		{Name: "refs/heads/feature", SHA: head},
+	}
+
+	plan, err := buildRemoteRepositoryClonePlanForRevisions(refs, "refs/heads/main", 4, []string{head})
+	if err != nil {
+		t.Fatalf("build clone plan: %v", err)
+	}
+	if plan.RequiredDepth != 4 {
+		t.Fatalf("expected required ref to use the full history budget, got %+v", plan)
+	}
+	gotRequired := make([]string, 0, len(plan.RequiredRefs))
+	for _, ref := range plan.RequiredRefs {
+		gotRequired = append(gotRequired, ref.Name)
+	}
+	if !reflect.DeepEqual(gotRequired, []string{"refs/heads/feature"}) {
+		t.Fatalf("expected required delta commit to fetch branch ref, got %+v", gotRequired)
+	}
+	gotExtras := make([]string, 0, len(plan.ExtraRefs))
+	for _, ref := range plan.ExtraRefs {
+		gotExtras = append(gotExtras, ref.Name)
+	}
+	if !reflect.DeepEqual(gotExtras, []string{"refs/tags/release-keep"}) {
+		t.Fatalf("expected non-required extras to keep normal budget, got %+v", gotExtras)
 	}
 }
 


### PR DESCRIPTION
No issue: live production repo scan delta failure root-caused from worker logs.

## What changed
- Pass delta scan options into the bounded remote clone plan.
- Fetch advertised refs for exact webhook head/base commit SHAs with the full scan history depth before running `git rev-list`.
- Prefer branch refs over pull/tag aliases for required delta commits, without consuming the normal extra-ref budget.

## Why
After the queue-claim fix deployed, worker diagnostics showed scans were claimed and started, then failed in `git rev-list` because the webhook head SHA lived on a branch that the bounded shallow clone had not fetched.

## Impact and risk
This keeps clone behavior bounded: it only adds refs whose advertised SHA exactly matches the requested 40-character revision. Deep/manual scans keep the existing clone plan, and delta scans should now fail less often instead of skipping needed refs.

## Validation
- `go test ./internal/repoexposure -run 'TestCloneRemoteRepositoryRequiredDeltaRefIsResolvable|TestCloneRemoteRepositoryFetchesRequiredDeltaRef|TestBuildRemoteRepositoryClonePlanKeepsRequiredDeltaRefOutsideExtraBudget' -count=1`\n- `go test ./internal/repoexposure -count=1`\n- `go test ./internal/api -run 'TestServiceRunRepoScan|TestGitHubWebhook|TestHandleGitHubWebhook|TestRunDeltaRepoScan|TestEnqueueRepoScan' -count=1`\n- `git diff --check`\n- Commit/push hooks: gofmt, go vet, env-token hygiene, Vercel artifact hygiene\n\nAI-assisted: yes\nTools used: OpenAI coding assistant\nWhere used: internal/repoexposure scanner clone planning and regression tests\nHuman verification performed: reviewed worker diagnostics, inspected code paths, and ran the validation commands above\n

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes delta repo scans that failed when the webhook head/base SHA wasn’t in the shallow clone by fetching required branch refs and exact SHA revisions at full depth, while keeping the clone bounded.

- **Bug Fixes**
  - Propagate delta scan options into repository preparation and bounded remote clone planning/fetching.
  - Add `RequiredRefs` and `RequiredRevisions` for exact 40‑char `HeadRevision`/`BaseRevision` SHAs; fetch the chosen branch refs and the SHAs themselves with the full history budget, outside the extra‑ref budget.
  - Verify required commits exist after fetch; prefer `refs/heads/*` over PR/tag aliases. Default ref behavior and extra‑ref limits stay the same.

<sup>Written for commit 8095bb53e9cd7c81bc01be265f76a44975d2b945. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1314?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

