### PR TITLE
Fix GitHub App install target UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,9 @@
   instead of raw JSON, login no longer provisions unknown identities, signup can
   reactivate a deactivated/deleted account that still owns the same email, login
   now points retained removed accounts to the reactivation signup path, and the
-  GitHub App setup now continues directly to GitHub with copy covering both
-  personal accounts and organizations.
+  GitHub App setup now opens GitHub in a new tab with an explicit personal
+  account versus organization choice, backed by a public app manifest for
+  Any-account installation.
 - Fixed app workspace navigation so route changes inside an already-validated
   workspace no longer rerun the full session gate, and hardened repository
   finding display helpers against partially populated API records.

--- a/deploy/connectors/github/app-manifest.json
+++ b/deploy/connectors/github/app-manifest.json
@@ -6,7 +6,7 @@
     "active": true
   },
   "redirect_url": "https://app.identrail.com/app/github/callback",
-  "public": false,
+  "public": true,
   "default_permissions": {
     "actions": "read",
     "administration": "read",

--- a/docs/auth/github-connector.md
+++ b/docs/auth/github-connector.md
@@ -22,11 +22,11 @@ Older project-scoped GitHub routes are not the product path. They remain interna
 ## Hosted GitHub.com Flow
 
 `POST /v1/connectors/github` creates a pending connector and returns a GitHub
-App install URL. The product immediately continues the user to that GitHub URL
-and keeps a fallback button visible if the browser blocks navigation. GitHub
-asks the user whether to install the App on a personal account or an
-organization, then asks which repositories Identrail can access. The product
-sends GitHub back to `/app/github/callback`, and that callback calls
+App install URL. The product asks whether the user expects to install on a
+personal account or an organization, opens GitHub in a new tab, and keeps a
+fallback button visible if the browser blocks navigation. GitHub controls the
+final account picker and selected-repository screen. The product sends GitHub
+back to `/app/github/callback`, and that callback calls
 `POST /v1/connectors/github/complete` with the returned state and installation
 ID. The backend owns the GitHub App slug and webhook secret through environment
 variables, so users do not paste app credentials into the browser.
@@ -41,7 +41,7 @@ Required runtime configuration for the hosted GitHub App flow:
   `IDENTRAIL_CONNECTOR_SECRET_KEYS_REQUIRED=true` for durable connector
   credential storage
 
-The GitHub App manifest lives at `deploy/connectors/github/app-manifest.json`. It requests read-only permissions for repository metadata, contents, pull requests, administration settings, Actions settings, repository environments, code scanning alerts, secret scanning alerts, Dependabot alerts, and repository webhooks.
+The GitHub App manifest lives at `deploy/connectors/github/app-manifest.json`. It requests read-only permissions for repository metadata, contents, pull requests, administration settings, Actions settings, repository environments, code scanning alerts, secret scanning alerts, Dependabot alerts, and repository webhooks. The manifest is public so GitHub can offer both personal-account and organization installation targets; production app settings should keep "Where can this GitHub App be installed?" on "Any account" rather than "Only on this account."
 
 For Identrail Cloud, the AWS API manual deploy workflow exposes first-class
 inputs for this path:

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -5276,6 +5276,10 @@ components:
         redirect_uri:
           type: string
           format: uri
+        install_account_type:
+          type: string
+          enum: [any, personal, organization]
+          description: Preferred GitHub account picker context for the installation flow. GitHub still controls the final personal-account or organization target.
     GitHubConnectorStartResponse:
       type: object
       properties:
@@ -5288,6 +5292,9 @@ components:
         install_url:
           type: string
           format: uri
+        install_account_type:
+          type: string
+          enum: [any, personal, organization]
         webhook_url:
           type: string
         expires_at:

--- a/internal/api/github_connect.go
+++ b/internal/api/github_connect.go
@@ -88,21 +88,23 @@ type GitHubRepositoryPostureCollector interface {
 
 // GitHubConnectorStartRequest captures the flat connector GitHub App bootstrap request.
 type GitHubConnectorStartRequest struct {
-	WorkspaceID string `json:"workspace_id,omitempty"`
-	ProjectID   string `json:"project_id,omitempty"`
-	ConnectorID string `json:"connector_id,omitempty"`
-	DisplayName string `json:"display_name,omitempty"`
-	RedirectURI string `json:"redirect_uri,omitempty"`
+	WorkspaceID        string `json:"workspace_id,omitempty"`
+	ProjectID          string `json:"project_id,omitempty"`
+	ConnectorID        string `json:"connector_id,omitempty"`
+	DisplayName        string `json:"display_name,omitempty"`
+	RedirectURI        string `json:"redirect_uri,omitempty"`
+	InstallAccountType string `json:"install_account_type,omitempty"`
 }
 
 // GitHubConnectorStartResponse returns the hosted GitHub App installation flow.
 type GitHubConnectorStartResponse struct {
-	Connection  GitHubConnectionStatus `json:"connection"`
-	ConnectorID string                 `json:"connector_id"`
-	State       string                 `json:"state"`
-	InstallURL  string                 `json:"install_url"`
-	WebhookURL  string                 `json:"webhook_url,omitempty"`
-	ExpiresAt   time.Time              `json:"expires_at"`
+	Connection         GitHubConnectionStatus `json:"connection"`
+	ConnectorID        string                 `json:"connector_id"`
+	State              string                 `json:"state"`
+	InstallURL         string                 `json:"install_url"`
+	InstallAccountType string                 `json:"install_account_type"`
+	WebhookURL         string                 `json:"webhook_url,omitempty"`
+	ExpiresAt          time.Time              `json:"expires_at"`
 }
 
 // GitHubConnectorCompleteRequest captures the GitHub App installation callback payload.
@@ -333,6 +335,10 @@ func (s *Service) StartGitHubConnector(ctx context.Context, request GitHubConnec
 	if strings.TrimSpace(request.ProjectID) == "" {
 		return GitHubConnectorStartResponse{}, ErrInvalidGitHubConnectionRequest
 	}
+	installAccountType, err := normalizeGitHubInstallAccountType(request.InstallAccountType)
+	if err != nil {
+		return GitHubConnectorStartResponse{}, ErrInvalidGitHubConnectionRequest
+	}
 	project, scope, err := s.requireScopedProject(ctx, request.WorkspaceID, request.ProjectID)
 	if err != nil {
 		return GitHubConnectorStartResponse{}, err
@@ -369,6 +375,7 @@ func (s *Service) StartGitHubConnector(ctx context.Context, request GitHubConnec
 		"provider":              "github_app",
 		"state":                 state,
 		"install_url":           installURL,
+		"install_account_type":  installAccountType,
 		"app_slug":              appSlug,
 		"redirect_uri":          strings.TrimSpace(request.RedirectURI),
 		"state_expires_at":      expiresAt.Format(time.RFC3339Nano),
@@ -410,12 +417,13 @@ func (s *Service) StartGitHubConnector(ctx context.Context, request GitHubConnec
 		UpdatedAt:            &now,
 	}
 	return GitHubConnectorStartResponse{
-		Connection:  status,
-		ConnectorID: connectorID,
-		State:       state,
-		InstallURL:  installURL,
-		WebhookURL:  "/auth/webhooks/github",
-		ExpiresAt:   expiresAt,
+		Connection:         status,
+		ConnectorID:        connectorID,
+		State:              state,
+		InstallURL:         installURL,
+		InstallAccountType: installAccountType,
+		WebhookURL:         "/auth/webhooks/github",
+		ExpiresAt:          expiresAt,
 	}, nil
 }
 
@@ -1788,6 +1796,18 @@ func timePtr(value time.Time) *time.Time {
 
 func githubConnectionKey(tenantID string, workspaceID string, projectID string) string {
 	return strings.ToLower(strings.TrimSpace(tenantID)) + "::" + strings.ToLower(strings.TrimSpace(workspaceID)) + "::" + strings.ToLower(strings.TrimSpace(projectID))
+}
+
+func normalizeGitHubInstallAccountType(value string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	switch normalized {
+	case "":
+		return "any", nil
+	case "any", "personal", "organization":
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("invalid github install account type")
+	}
 }
 
 func normalizeGitHubRepositories(repositories []string) ([]string, error) {

--- a/internal/api/github_connector_v2_test.go
+++ b/internal/api/github_connector_v2_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -69,7 +70,8 @@ func TestRouterGitHubConnectorV2StartsAppInstall(t *testing.T) {
 		"workspace_id":"workspace-a",
 		"project_id":"project-1",
 		"display_name":"GitHub production",
-		"redirect_uri":"https://app.identrail.com/app/tenant-a/workspace-a/projects/project-1"
+		"redirect_uri":"https://app.identrail.com/app/tenant-a/workspace-a/projects/project-1",
+		"install_account_type":"personal"
 	}`)
 	if resp.Code != http.StatusOK {
 		t.Fatalf("expected github connector start 200, got %d body=%s", resp.Code, resp.Body.String())
@@ -86,6 +88,25 @@ func TestRouterGitHubConnectorV2StartsAppInstall(t *testing.T) {
 	}
 	if body.InstallURL == "" || body.WebhookURL != "/auth/webhooks/github" {
 		t.Fatalf("expected install and webhook urls, got %+v", body)
+	}
+	if body.InstallAccountType != "personal" {
+		t.Fatalf("expected personal account install type, got %q", body.InstallAccountType)
+	}
+	if strings.Contains(body.InstallURL, "/organizations/") {
+		t.Fatalf("install url must use GitHub's account picker, got %q", body.InstallURL)
+	}
+}
+
+func TestRouterGitHubConnectorV2RejectsInvalidInstallAccountType(t *testing.T) {
+	r := newGitHubConnectorV2TestRouter(t, &fakeGitHubPATValidator{}, nil)
+
+	resp := doAWSConnectionAPI(t, r, http.MethodPost, "/v1/connectors/github", `{
+		"workspace_id":"workspace-a",
+		"project_id":"project-1",
+		"install_account_type":"enterprise"
+	}`)
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected github connector start 400, got %d body=%s", resp.Code, resp.Body.String())
 	}
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -794,6 +794,7 @@ export type GitHubConnectorStartRequest = {
   connector_id?: string;
   display_name?: string;
   redirect_uri?: string;
+  install_account_type?: 'any' | 'personal' | 'organization';
 };
 
 export type GitHubConnectorStartResponse = {
@@ -801,6 +802,7 @@ export type GitHubConnectorStartResponse = {
   connector_id: string;
   state: string;
   install_url: string;
+  install_account_type: 'any' | 'personal' | 'organization';
   webhook_url?: string;
   expires_at: string;
 };

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -200,6 +200,24 @@ async function renderProjectDetail(
         rate_limit: { limit: 5000, remaining: 4990 }
       }
     });
+  const startGitHubConnector = vi.spyOn(api.apiClient, 'startGitHubConnector').mockImplementation(async (payload) => ({
+    connection: {
+      provider: 'github_app',
+      connected: false,
+      connector_id: 'github-app',
+      display_name: 'GitHub App',
+      status: 'pending',
+      health_status: 'unknown',
+      webhook_secret_rotation_required: false,
+      selected_repositories: []
+    },
+    connector_id: 'github-app',
+    state: 'github-state',
+    install_url: 'https://github.com/apps/identrail/installations/new?state=github-state',
+    install_account_type: payload.install_account_type ?? 'any',
+    webhook_url: '/auth/webhooks/github',
+    expires_at: '2026-05-17T10:10:00Z'
+  }));
 
   const { ProductProjectDetailPage } = await import('./productShell');
   function ProjectDetailHarness() {
@@ -224,7 +242,14 @@ async function renderProjectDetail(
     </MemoryRouter>
   );
 
-  return { getGitHubConnectorStatus, getGitHubConnectorRepositoryPosture, listRepoScans, runRepoScan, cancelRepoScan };
+  return {
+    getGitHubConnectorStatus,
+    getGitHubConnectorRepositoryPosture,
+    startGitHubConnector,
+    listRepoScans,
+    runRepoScan,
+    cancelRepoScan
+  };
 }
 
 describe('ProductAppIndexRedirect', () => {
@@ -377,6 +402,38 @@ describe('ProductProjectDetailPage', () => {
       'project-1',
       expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
     );
+  });
+
+  it('opens GitHub installation in a new tab for the selected account type', async () => {
+    const assign = vi.fn();
+    const close = vi.fn();
+    const popup = {
+      closed: false,
+      opener: {},
+      document: { title: '', body: { innerHTML: '' } },
+      location: { assign },
+      close
+    } as unknown as Window;
+    const userAgent = vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue('Mozilla/5.0');
+    const open = vi.spyOn(window, 'open').mockReturnValue(popup);
+    const { startGitHubConnector } = await renderProjectDetail(true);
+
+    expect(await screen.findByText('Install the GitHub App')).toBeInTheDocument();
+    const installTarget = screen.getByRole('group', { name: /Install on/i });
+    fireEvent.click(within(installTarget).getByRole('button', { name: /Organization repositories/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Continue to GitHub/i }));
+
+    await waitFor(() =>
+      expect(startGitHubConnector).toHaveBeenCalledWith(
+        expect.objectContaining({ install_account_type: 'organization' }),
+        expect.any(Object)
+      )
+    );
+    expect(open).toHaveBeenCalledWith('', '_blank');
+    expect(assign).toHaveBeenCalledWith('https://github.com/apps/identrail/installations/new?state=github-state');
+    expect(await screen.findByText(/GitHub opened in a new tab/i)).toBeInTheDocument();
+
+    userAgent.mockRestore();
   });
 
   it('keeps advanced GitHub and scan policy controls collapsed until requested', async () => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -84,6 +84,7 @@ type ScopeRouteParams = {
 };
 
 type SourceProvider = 'github' | 'aws' | 'kubernetes';
+type GitHubInstallAccountType = 'personal' | 'organization';
 
 type SourceConnectionMap = {
   github?: GitHubConnectionStatus;
@@ -670,20 +671,79 @@ function sourceAvailabilityTone(
   return availability.available ? connectionTone(status) : 'error';
 }
 
-function openGitHubInstallURL(installURL: string) {
-  if (typeof window === 'undefined' || !installURL) {
-    return;
+function openPendingGitHubInstallWindow(): Window | null {
+  if (typeof window === 'undefined') {
+    return null;
   }
   if (/jsdom/i.test(window.navigator.userAgent)) {
+    return null;
+  }
+  let popup: Window | null = null;
+  try {
+    popup = window.open('', '_blank');
+  } catch {
+    return null;
+  }
+  if (!popup) {
+    return null;
+  }
+  try {
+    popup.opener = null;
+    popup.document.title = 'Opening GitHub';
+    if (popup.document.body) {
+      popup.document.body.innerHTML =
+        '<main style="font:16px system-ui,sans-serif;padding:24px;color:#111827">Opening GitHub...</main>';
+    }
+  } catch {
+    // The tab is still useful even if the browser blocks temporary about:blank edits.
+  }
+  return popup;
+}
+
+function openGitHubInstallURL(installURL: string, popup?: Window | null) {
+  if (typeof window === 'undefined' || !installURL) {
+    return false;
+  }
+  if (/jsdom/i.test(window.navigator.userAgent)) {
+    return false;
+  }
+  if (popup && !popup.closed) {
+    try {
+      popup.location.assign(installURL);
+      return true;
+    } catch {
+      closeGitHubInstallWindow(popup);
+      // Fall through to opening a fresh tab if the pre-opened tab is no longer writable.
+    }
+  }
+  try {
+    return window.open(installURL, '_blank', 'noopener,noreferrer') !== null;
+  } catch {
+    return false;
+  }
+}
+
+function closeGitHubInstallWindow(popup: Window | null) {
+  if (!popup) {
     return;
   }
   try {
-    window.location.assign(installURL);
-    return;
+    if (!popup.closed) {
+      popup.close();
+    }
   } catch {
-    // Fall back to a same-tab open when a test/browser shim blocks assign().
+    // Ignore browser restrictions after the tab has navigated away.
   }
-  window.open(installURL, '_self', 'noopener,noreferrer');
+}
+
+function describeGitHubInstallAccountType(value: GitHubConnectorStartResponse['install_account_type']) {
+  if (value === 'organization') {
+    return 'an organization';
+  }
+  if (value === 'personal') {
+    return 'a personal account';
+  }
+  return 'a personal account or organization';
 }
 
 function formatRepoScanSubmitError(error: unknown): string {
@@ -3688,7 +3748,8 @@ export function ProductProjectDetailPage() {
   const [successMessage, setSuccessMessage] = useState('');
   const [githubStart, setGitHubStart] = useState<GitHubConnectorStartResponse | null>(null);
   const [githubAppForm, setGitHubAppForm] = useState({
-    displayName: 'GitHub App'
+    displayName: 'GitHub App',
+    installAccountType: 'personal' as GitHubInstallAccountType
   });
   const [githubPATForm, setGitHubPATForm] = useState({
     displayName: 'GitHub Enterprise',
@@ -4129,6 +4190,7 @@ export function ProductProjectDetailPage() {
     setSuccessMessage('');
     setSourceErrors((current) => ({ ...current, github: undefined }));
     const requestSequence = refreshSequenceRef.current;
+    const installWindow = openPendingGitHubInstallWindow();
     try {
       const auth = buildProductAuthContext(scope);
       const redirectURI =
@@ -4138,18 +4200,25 @@ export function ProductProjectDetailPage() {
           workspace_id: scope.workspaceID,
           project_id: projectID,
           display_name: normalizeValue(githubAppForm.displayName) || undefined,
+          install_account_type: githubAppForm.installAccountType,
           redirect_uri: redirectURI
         },
         auth
       );
       if (isStaleRequestSequence(requestSequence)) {
+        closeGitHubInstallWindow(installWindow);
         return;
       }
       setGitHubStart(response);
       setConnections((current) => ({ ...current, github: response.connection }));
-      setSuccessMessage('Opening GitHub installation.');
-      openGitHubInstallURL(response.install_url);
+      const opened = openGitHubInstallURL(response.install_url, installWindow);
+      setSuccessMessage(
+        opened
+          ? 'GitHub opened in a new tab. Finish the installation there to complete setup.'
+          : 'GitHub installation is ready. Continue with the GitHub button below.'
+      );
     } catch (error) {
+      closeGitHubInstallWindow(installWindow);
       if (isStaleRequestSequence(requestSequence)) {
         return;
       }
@@ -4773,6 +4842,31 @@ export function ProductProjectDetailPage() {
                       placeholder="GitHub App"
                     />
                   </label>
+                  <fieldset className="idt-source-account-choice">
+                    <legend>Install on</legend>
+                    <div className="idt-source-account-options">
+                      {(
+                        [
+                          ['personal', 'Personal account', 'Personal repositories'],
+                          ['organization', 'Organization', 'Organization repositories']
+                        ] as const
+                      ).map(([value, label, caption]) => (
+                        <button
+                          key={value}
+                          type="button"
+                          className={githubAppForm.installAccountType === value ? 'is-selected' : ''}
+                          aria-pressed={githubAppForm.installAccountType === value}
+                          disabled={submitting !== ''}
+                          onClick={() =>
+                            setGitHubAppForm((current) => ({ ...current, installAccountType: value }))
+                          }
+                        >
+                          <strong>{label}</strong>
+                          <span>{caption}</span>
+                        </button>
+                      ))}
+                    </div>
+                  </fieldset>
                   <button className="idt-btn idt-btn-primary" type="submit" disabled={submitting !== ''}>
                     {submitting === 'github' ? 'Preparing GitHub...' : 'Continue to GitHub'}
                   </button>
@@ -4783,7 +4877,10 @@ export function ProductProjectDetailPage() {
                 <article className="idt-source-install-card">
                   <div>
                     <h4>GitHub did not open automatically?</h4>
-                    <p>Continue with a personal account or organization. State expires {formatConnectionTime(githubStart.expires_at)}.</p>
+                    <p>
+                      Continue with {describeGitHubInstallAccountType(githubStart.install_account_type)}.
+                      State expires {formatConnectionTime(githubStart.expires_at)}.
+                    </p>
                   </div>
                   <a className="idt-btn idt-btn-dark" href={githubStart.install_url} target="_blank" rel="noreferrer">
                     Continue to GitHub

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5817,6 +5817,60 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+.idt-source-account-choice {
+  display: grid;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.idt-source-account-choice legend {
+  padding: 0;
+  color: #d3e1f7;
+  font-size: 0.95rem;
+}
+
+.idt-source-account-options {
+  display: grid;
+  gap: 0.55rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.idt-source-account-options button {
+  min-height: 4.25rem;
+  border: 1px solid rgba(126, 157, 211, 0.35);
+  border-radius: 0.55rem;
+  background: rgba(9, 15, 26, 0.84);
+  color: #dbe8fb;
+  display: grid;
+  gap: 0.25rem;
+  justify-items: start;
+  padding: 0.65rem 0.7rem;
+  text-align: left;
+}
+
+.idt-source-account-options button:hover,
+.idt-source-account-options button:focus-visible {
+  border-color: rgba(139, 184, 255, 0.74);
+  color: #ffffff;
+}
+
+.idt-source-account-options button.is-selected {
+  border-color: rgba(62, 211, 131, 0.7);
+  background: rgba(16, 75, 50, 0.45);
+}
+
+.idt-source-account-options strong,
+.idt-source-account-options span {
+  display: block;
+}
+
+.idt-source-account-options span {
+  color: #9eb4d5;
+  font-size: 0.85rem;
+}
+
 .idt-app-form textarea,
 .idt-app-form select {
   border: 1px solid rgba(126, 157, 211, 0.35);
@@ -6114,6 +6168,10 @@ html[data-theme='light'] .idt-app-kicker {
 }
 
 html[data-theme='light'] .idt-app-form label {
+  color: #2b456c;
+}
+
+html[data-theme='light'] .idt-source-account-choice legend {
   color: #2b456c;
 }
 
@@ -7297,6 +7355,26 @@ html[data-theme='light'] .idt-app-form select {
   color: #1c355d;
   background: #ffffff;
   border-color: rgba(42, 71, 119, 0.32);
+}
+
+html[data-theme='light'] .idt-source-account-options button {
+  color: #1c355d;
+  background: #ffffff;
+  border-color: rgba(42, 71, 119, 0.32);
+}
+
+html[data-theme='light'] .idt-source-account-options button:hover,
+html[data-theme='light'] .idt-source-account-options button:focus-visible {
+  border-color: rgba(37, 99, 235, 0.48);
+}
+
+html[data-theme='light'] .idt-source-account-options button.is-selected {
+  background: rgba(224, 244, 235, 0.95);
+  border-color: rgba(33, 124, 83, 0.36);
+}
+
+html[data-theme='light'] .idt-source-account-options span {
+  color: #557096;
 }
 
 html[data-theme='light'] .idt-source-diagnostics span {


### PR DESCRIPTION
No issue: follow-up to merged PR #1306 after testing showed the GitHub App install flow still behaved like an organization-only path.

## What changed
- Open the GitHub App installation in a new tab while keeping the Identrail app tab intact.
- Preserve the existing GitHub callback state/redirect path so completing setup on GitHub still returns to Identrail.
- Add an explicit Personal account vs Organization choice before launching GitHub.
- Record the requested install account type in the connector start API response/metadata.
- Mark the GitHub App manifest public so GitHub can offer Any-account installation targets, and document the matching production GitHub App setting.

## Impact and risk
- Personal and organization repositories now use the same selected-repository completion path instead of the UI implying organization-only setup.
- Existing API callers that omit install_account_type continue to work and are recorded as any.
- Existing production GitHub App settings may still need to be updated to Any account; code cannot override a GitHub App registration that is still private/org-only.

## Validation
- go test ./...
- npm run test:ci --prefix web
- npm run build --prefix web
- git diff --check HEAD~1..HEAD
- Local Vite route smoke with curl against /app/tenant-a/workspace-a/projects/project-1

AI-assisted: yes
Tools used: OpenAI Codex
Where used: GitHub connector UX, API contract, tests, docs
Human verification performed: reviewed the final diff, reran backend and frontend gates, and confirmed the dev route serves the app shell locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the GitHub App installation flow with a clear Personal vs Organization choice and opens GitHub in a new tab while keeping the app tab. Sets the App manifest to public so GitHub offers Any-account installs and captures the preferred target in the API.

- **New Features**
  - Added account selector (Personal or Organization) and pre-opened GitHub in a new tab with a fallback button and clearer copy.
  - Added `install_account_type` to `POST /v1/connectors/github` request and response; defaults to `any`; invalid values return 400.
  - Kept existing callback state/redirect; install URL uses GitHub’s account picker (no org-scoped path).
  - Updated OpenAPI, docs, tests, UI, and styles; manifest set to public with docs noting production should use “Any account”.

- **Migration**
  - No breaking API changes; calls omitting `install_account_type` default to `any`.
  - Confirm production GitHub App settings are “Any account”.

<sup>Written for commit 26e9a9f3e3235b3283e516055b34118907921a88. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1315?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

