### PR TITLE
Fix GitHub install account selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,9 @@
   instead of raw JSON, login no longer provisions unknown identities, signup can
   reactivate a deactivated/deleted account that still owns the same email, login
   now points retained removed accounts to the reactivation signup path, and the
-  GitHub App setup now opens GitHub in a new tab with an explicit personal
-  account versus organization choice, backed by a public app manifest for
-  Any-account installation.
+  GitHub App setup now opens GitHub's account selector in a new tab with an
+  explicit personal account versus organization choice, backed by a public app
+  manifest for Any-account installation.
 - Fixed app workspace navigation so route changes inside an already-validated
   workspace no longer rerun the full session gate, and hardened repository
   finding display helpers against partially populated API records.

--- a/docs/auth/github-connector.md
+++ b/docs/auth/github-connector.md
@@ -22,11 +22,12 @@ Older project-scoped GitHub routes are not the product path. They remain interna
 ## Hosted GitHub.com Flow
 
 `POST /v1/connectors/github` creates a pending connector and returns a GitHub
-App install URL. The product asks whether the user expects to install on a
+App target-picker URL. The product asks whether the user expects to install on a
 personal account or an organization, opens GitHub in a new tab, and keeps a
-fallback button visible if the browser blocks navigation. GitHub controls the
-final account picker and selected-repository screen. The product sends GitHub
-back to `/app/github/callback`, and that callback calls
+fallback button visible if the browser blocks navigation. The URL starts at
+GitHub's account selector (`/installations/select_target`) so GitHub shows the
+personal-account or organization choice before the selected-repository screen.
+The product sends GitHub back to `/app/github/callback`, and that callback calls
 `POST /v1/connectors/github/complete` with the returned state and installation
 ID. The backend owns the GitHub App slug and webhook secret through environment
 variables, so users do not paste app credentials into the browser.
@@ -41,7 +42,7 @@ Required runtime configuration for the hosted GitHub App flow:
   `IDENTRAIL_CONNECTOR_SECRET_KEYS_REQUIRED=true` for durable connector
   credential storage
 
-The GitHub App manifest lives at `deploy/connectors/github/app-manifest.json`. It requests read-only permissions for repository metadata, contents, pull requests, administration settings, Actions settings, repository environments, code scanning alerts, secret scanning alerts, Dependabot alerts, and repository webhooks. The manifest is public so GitHub can offer both personal-account and organization installation targets; production app settings should keep "Where can this GitHub App be installed?" on "Any account" rather than "Only on this account."
+The GitHub App manifest lives at `deploy/connectors/github/app-manifest.json`. It requests read-only permissions for repository metadata, contents, pull requests, administration settings, Actions settings, repository environments, code scanning alerts, secret scanning alerts, Dependabot alerts, and repository webhooks. The manifest is public so GitHub can offer both personal-account and organization installation targets; production app settings should keep "Where can this GitHub App be installed?" on "Any account" rather than "Only on this account." If the production app remains private, GitHub may still only offer the app owner account even when Identrail starts at the account selector.
 
 For Identrail Cloud, the AWS API manual deploy workflow exposes first-class
 inputs for this path:

--- a/internal/api/github_connect.go
+++ b/internal/api/github_connect.go
@@ -311,7 +311,7 @@ func (s *Service) StartGitHubConnection(ctx context.Context, workspaceID string,
 	if redirect := strings.TrimSpace(request.RedirectURI); redirect != "" {
 		values.Set("redirect_uri", redirect)
 	}
-	connectURL := "https://github.com/apps/" + appSlug + "/installations/new?" + values.Encode()
+	connectURL := "https://github.com/apps/" + appSlug + "/installations/select_target?" + values.Encode()
 
 	s.githubConnectMu.Lock()
 	s.ensureGitHubConnectionState()

--- a/internal/api/github_connector_v2_test.go
+++ b/internal/api/github_connector_v2_test.go
@@ -92,6 +92,9 @@ func TestRouterGitHubConnectorV2StartsAppInstall(t *testing.T) {
 	if body.InstallAccountType != "personal" {
 		t.Fatalf("expected personal account install type, got %q", body.InstallAccountType)
 	}
+	if !strings.Contains(body.InstallURL, "/installations/select_target?") {
+		t.Fatalf("install url must start at GitHub's account picker, got %q", body.InstallURL)
+	}
 	if strings.Contains(body.InstallURL, "/organizations/") {
 		t.Fatalf("install url must use GitHub's account picker, got %q", body.InstallURL)
 	}

--- a/internal/connectors/github/app.go
+++ b/internal/connectors/github/app.go
@@ -48,7 +48,7 @@ func NormalizeAppSlug(value string) (string, error) {
 	return slug, nil
 }
 
-// BuildInstallURL returns the GitHub App installation URL with an opaque state.
+// BuildInstallURL returns the GitHub App target-picker URL with an opaque state.
 func BuildInstallURL(appSlug string, state string, redirectURI string) (string, error) {
 	slug, err := NormalizeAppSlug(appSlug)
 	if err != nil {
@@ -67,7 +67,7 @@ func BuildInstallURL(appSlug string, state string, redirectURI string) (string, 
 		}
 		values.Set("redirect_uri", redirect)
 	}
-	return "https://github.com/apps/" + slug + "/installations/new?" + values.Encode(), nil
+	return "https://github.com/apps/" + slug + "/installations/select_target?" + values.Encode(), nil
 }
 
 // SignAppJWT signs a short-lived RS256 JWT accepted by GitHub App APIs.

--- a/internal/connectors/github/app_test.go
+++ b/internal/connectors/github/app_test.go
@@ -89,7 +89,7 @@ func TestBuildInstallURL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build install url: %v", err)
 	}
-	if !strings.HasPrefix(got, "https://github.com/apps/identrail-app/installations/new?") ||
+	if !strings.HasPrefix(got, "https://github.com/apps/identrail-app/installations/select_target?") ||
 		!strings.Contains(got, "state=state-1") {
 		t.Fatalf("unexpected install url: %s", got)
 	}

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -213,7 +213,7 @@ async function renderProjectDetail(
     },
     connector_id: 'github-app',
     state: 'github-state',
-    install_url: 'https://github.com/apps/identrail/installations/new?state=github-state',
+    install_url: 'https://github.com/apps/identrail/installations/select_target?state=github-state',
     install_account_type: payload.install_account_type ?? 'any',
     webhook_url: '/auth/webhooks/github',
     expires_at: '2026-05-17T10:10:00Z'
@@ -420,7 +420,8 @@ describe('ProductProjectDetailPage', () => {
 
     expect(await screen.findByText('Install the GitHub App')).toBeInTheDocument();
     const installTarget = screen.getByRole('group', { name: /Install on/i });
-    fireEvent.click(within(installTarget).getByRole('button', { name: /Organization repositories/i }));
+    fireEvent.click(within(installTarget).getByRole('radio', { name: /Organization/i }));
+    expect(within(installTarget).getByRole('radio', { name: /Organization/i })).toBeChecked();
     fireEvent.click(screen.getByRole('button', { name: /Continue to GitHub/i }));
 
     await waitFor(() =>
@@ -430,7 +431,7 @@ describe('ProductProjectDetailPage', () => {
       )
     );
     expect(open).toHaveBeenCalledWith('', '_blank');
-    expect(assign).toHaveBeenCalledWith('https://github.com/apps/identrail/installations/new?state=github-state');
+    expect(assign).toHaveBeenCalledWith('https://github.com/apps/identrail/installations/select_target?state=github-state');
     expect(await screen.findByText(/GitHub opened in a new tab/i)).toBeInTheDocument();
 
     userAgent.mockRestore();

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -4842,28 +4842,37 @@ export function ProductProjectDetailPage() {
                       placeholder="GitHub App"
                     />
                   </label>
-                  <fieldset className="idt-source-account-choice">
+                  <fieldset className="idt-source-account-choice" aria-describedby="github-install-target-help">
                     <legend>Install on</legend>
+                    <p id="github-install-target-help">
+                      GitHub opens an account picker next. Choose where the repositories live.
+                    </p>
                     <div className="idt-source-account-options">
                       {(
                         [
-                          ['personal', 'Personal account', 'Personal repositories'],
-                          ['organization', 'Organization', 'Organization repositories']
+                          ['personal', 'Personal account', 'Repos owned by your GitHub user'],
+                          ['organization', 'Organization', 'Repos owned by a GitHub organization']
                         ] as const
                       ).map(([value, label, caption]) => (
-                        <button
+                        <label
                           key={value}
-                          type="button"
                           className={githubAppForm.installAccountType === value ? 'is-selected' : ''}
-                          aria-pressed={githubAppForm.installAccountType === value}
-                          disabled={submitting !== ''}
-                          onClick={() =>
-                            setGitHubAppForm((current) => ({ ...current, installAccountType: value }))
-                          }
                         >
+                          <input
+                            type="radio"
+                            name="github-install-account-type"
+                            value={value}
+                            checked={githubAppForm.installAccountType === value}
+                            disabled={submitting !== ''}
+                            onChange={() =>
+                              setGitHubAppForm((current) => ({ ...current, installAccountType: value }))
+                            }
+                          />
+                          <span className="idt-source-account-radio" aria-hidden="true" />
                           <strong>{label}</strong>
-                          <span>{caption}</span>
-                        </button>
+                          <span className="idt-source-account-caption">{caption}</span>
+                          <em>{githubAppForm.installAccountType === value ? 'Selected' : 'Choose'}</em>
+                        </label>
                       ))}
                     </div>
                   </fieldset>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5827,48 +5827,117 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
 
 .idt-source-account-choice legend {
   padding: 0;
-  color: #d3e1f7;
+  color: #2b456c;
   font-size: 0.95rem;
+  font-weight: 800;
+}
+
+.idt-source-account-choice p {
+  margin: 0;
+  color: #35598d;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+html:not([data-theme='light']) .idt-source-account-choice legend {
+  color: #e8f1ff;
+}
+
+html:not([data-theme='light']) .idt-source-account-choice p {
+  color: #aebfda;
 }
 
 .idt-source-account-options {
   display: grid;
-  gap: 0.55rem;
+  gap: 0.65rem;
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.idt-source-account-options button {
-  min-height: 4.25rem;
-  border: 1px solid rgba(126, 157, 211, 0.35);
+.idt-source-account-options label {
+  position: relative;
+  min-height: 5rem;
+  border: 1px solid rgba(130, 160, 214, 0.38);
   border-radius: 0.55rem;
-  background: rgba(9, 15, 26, 0.84);
-  color: #dbe8fb;
+  background: rgba(10, 16, 28, 0.96);
+  color: #f4f8ff;
+  cursor: pointer;
   display: grid;
-  gap: 0.25rem;
-  justify-items: start;
-  padding: 0.65rem 0.7rem;
+  gap: 0.2rem 0.65rem;
+  grid-template-columns: 1.1rem minmax(0, 1fr) auto;
+  grid-template-areas:
+    "radio title state"
+    "radio caption caption";
+  align-items: start;
+  padding: 0.75rem 0.85rem;
   text-align: left;
+  transition:
+    background 0.16s ease,
+    border-color 0.16s ease,
+    box-shadow 0.16s ease;
 }
 
-.idt-source-account-options button:hover,
-.idt-source-account-options button:focus-visible {
-  border-color: rgba(139, 184, 255, 0.74);
-  color: #ffffff;
+.idt-source-account-options label:hover,
+.idt-source-account-options label:has(input:focus-visible) {
+  border-color: rgba(143, 190, 255, 0.88);
+  box-shadow: 0 0 0 3px rgba(69, 125, 218, 0.22);
 }
 
-.idt-source-account-options button.is-selected {
-  border-color: rgba(62, 211, 131, 0.7);
-  background: rgba(16, 75, 50, 0.45);
+.idt-source-account-options label.is-selected {
+  border-color: rgba(79, 219, 145, 0.82);
+  background: rgba(16, 72, 51, 0.72);
+  box-shadow: 0 0 0 1px rgba(79, 219, 145, 0.22);
 }
 
-.idt-source-account-options strong,
-.idt-source-account-options span {
+.idt-source-account-options input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.idt-source-account-radio {
+  grid-area: radio;
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid rgba(180, 200, 231, 0.78);
+  border-radius: 999px;
+  margin-top: 0.16rem;
+  background: rgba(5, 9, 16, 0.85);
+}
+
+.idt-source-account-options label.is-selected .idt-source-account-radio {
+  border-color: #7df0b3;
+  box-shadow: inset 0 0 0 3px rgba(10, 16, 28, 0.96);
+  background: #7df0b3;
+}
+
+.idt-source-account-options strong {
+  grid-area: title;
   display: block;
+  color: #ffffff;
+  font-size: 0.95rem;
+  line-height: 1.25;
 }
 
-.idt-source-account-options span {
+.idt-source-account-caption {
+  grid-area: caption;
   color: #9eb4d5;
+  display: block;
   font-size: 0.85rem;
+  line-height: 1.3;
+}
+
+.idt-source-account-options em {
+  grid-area: state;
+  color: #9eb4d5;
+  font-size: 0.75rem;
+  font-style: normal;
+  font-weight: 800;
+  line-height: 1.25;
+}
+
+.idt-source-account-options label.is-selected .idt-source-account-caption,
+.idt-source-account-options label.is-selected em {
+  color: #d8ffea;
 }
 
 .idt-app-form textarea,
@@ -6173,6 +6242,18 @@ html[data-theme='light'] .idt-app-form label {
 
 html[data-theme='light'] .idt-source-account-choice legend {
   color: #2b456c;
+}
+
+html[data-theme='light'] .idt-source-account-choice p {
+  color: #35598d;
+}
+
+html[data-theme='light'] .idt-app-console-layout .idt-source-account-choice legend {
+  color: #e8f1ff;
+}
+
+html[data-theme='light'] .idt-app-console-layout .idt-source-account-choice p {
+  color: #aebfda;
 }
 
 html[data-theme='light'] .idt-app-form input {
@@ -7357,24 +7438,39 @@ html[data-theme='light'] .idt-app-form select {
   border-color: rgba(42, 71, 119, 0.32);
 }
 
-html[data-theme='light'] .idt-source-account-options button {
-  color: #1c355d;
-  background: #ffffff;
-  border-color: rgba(42, 71, 119, 0.32);
+html[data-theme='light'] .idt-source-account-options label {
+  color: #f4f8ff;
+  background: rgba(10, 16, 28, 0.96);
+  border-color: rgba(130, 160, 214, 0.38);
 }
 
-html[data-theme='light'] .idt-source-account-options button:hover,
-html[data-theme='light'] .idt-source-account-options button:focus-visible {
-  border-color: rgba(37, 99, 235, 0.48);
+html[data-theme='light'] .idt-source-account-options label:hover,
+html[data-theme='light'] .idt-source-account-options label:has(input:focus-visible) {
+  border-color: rgba(143, 190, 255, 0.88);
+  box-shadow: 0 0 0 3px rgba(69, 125, 218, 0.22);
 }
 
-html[data-theme='light'] .idt-source-account-options button.is-selected {
-  background: rgba(224, 244, 235, 0.95);
-  border-color: rgba(33, 124, 83, 0.36);
+html[data-theme='light'] .idt-source-account-options label.is-selected {
+  background: rgba(16, 72, 51, 0.72);
+  border-color: rgba(79, 219, 145, 0.82);
+  box-shadow: 0 0 0 1px rgba(79, 219, 145, 0.22);
 }
 
-html[data-theme='light'] .idt-source-account-options span {
-  color: #557096;
+html[data-theme='light'] .idt-source-account-options strong {
+  color: #ffffff;
+}
+
+html[data-theme='light'] .idt-source-account-caption {
+  color: #9eb4d5;
+}
+
+html[data-theme='light'] .idt-source-account-options em {
+  color: #9eb4d5;
+}
+
+html[data-theme='light'] .idt-source-account-options label.is-selected .idt-source-account-caption,
+html[data-theme='light'] .idt-source-account-options label.is-selected em {
+  color: #d8ffea;
 }
 
 html[data-theme='light'] .idt-source-diagnostics span {


### PR DESCRIPTION
No issue: follow-up to merged PR #1315 after live testing showed GitHub was still skipping the account chooser and the in-app account selector was not readable enough.

## What changed
- Start GitHub App installation at GitHub's `/installations/select_target` route so users see the GitHub account picker before repository selection instead of being dropped directly into the `identrail` organization permissions page.
- Keep the existing new-tab behavior and callback state/redirect handling from #1315.
- Replace the Personal account / Organization placeholder-style buttons with real radio controls that are keyboard-accessible and visibly selectable.
- Restyle the selector with high-contrast dark surfaces so it remains readable even when the global light-theme override is active on the product shell.
- Update tests, docs, and changelog for the account-selector route.

## Impact and risk
- Personal and organization installs now begin at GitHub's target selection step, which is the missing behavior from the live screenshots.
- Existing connector start callers remain compatible; `install_account_type` stays optional and still defaults to `any` server-side.
- The production GitHub App still must be public/Any account for personal-account installs to actually be allowed by GitHub. This PR prevents the app from auto-skipping the chooser, but GitHub can still restrict targets if the app registration is private.

## Validation
- `npm run test:ci --prefix web` passed: 12 files, 175 tests, coverage above thresholds.
- `npm run build --prefix web` passed and prerendered 41 routes.
- `go test ./...` passed.
- `git diff --check` passed.
- Local browser smoke reached the app route, but the real project screen is behind session validation without an authenticated local API.

AI-assisted: yes
Tools used: OpenAI Codex
Where used: GitHub connector install URL, selector UI, tests, docs
Human verification performed: reviewed the diff, reran backend/frontend gates on the fresh branch after #1315 merged, and checked the local route behavior up to the session gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GitHub App install flow by starting at GitHub’s account selector and making the in-app account picker accessible and readable. Users now choose Personal or Organization before selecting repositories.

- **Bug Fixes**
  - Start installs at GitHub’s account picker (`/installations/select_target`) with existing new-tab, state, and `redirect_uri` handling; update server helpers and tests to expect the picker URL.
  - Replace placeholder buttons with real radio inputs and helper text; add clear focus/checked states and high-contrast styles that remain readable under the light-theme override.
  - Update docs and changelog; keep `install_account_type` optional (defaults to `any`) and existing callers unchanged. Note: GitHub may still limit targets if the production app is private.

<sup>Written for commit 71ccd1eb7de37ac3b2998e26a4f7215be7a5a930. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1316?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

