### PR TITLE
feat(web): make repository Findings page state-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 ## Unreleased
+- Made the repository Findings page state-aware instead of rendering a
+  zero-filled dashboard in every empty case. A never-scanned workspace now shows
+  a first-scan onboarding prompt, an all-failed scan history surfaces the failure
+  reason with a re-run path (so failed scans are no longer silently shown as
+  zeros), and a successful scan with no findings shows a clean "no exposure
+  found" state. Also removed the redundant "Reload trend" button (Refresh now
+  reloads everything) and collapsed the finding trend so it no longer repeats
+  empty zero rows.
 - Re-scan dependencies with osv-scanner on every push to `dev` so resolved
   dependency CVEs clear from the code-scanning dashboard right after a fix
   merges, instead of waiting for the daily scheduled run. Restyled the README

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -708,3 +708,84 @@ describe('ProductProjectDetailPage', () => {
     ).toBeInTheDocument();
   });
 });
+
+async function renderFindings(options: { repoScans?: RepoScanRecord[] } = {}) {
+  vi.resetModules();
+  vi.doMock('./hooks/useMe', () => ({
+    useMe: () => ({
+      me: { ...loggedInWithoutWorkspace, role: 'owner' } as CurrentUserContext,
+      loading: false,
+      error: '',
+      unauthenticated: false,
+      refresh: vi.fn()
+    })
+  }));
+
+  const api = await import('./api/client');
+  const listRepoScans = vi
+    .spyOn(api.apiClient, 'listRepoScans')
+    .mockResolvedValue({ items: options.repoScans ?? [] });
+  const listRepoFindings = vi
+    .spyOn(api.apiClient, 'listRepoFindings')
+    .mockResolvedValue({ items: [], summary: undefined });
+  vi.spyOn(api.apiClient, 'getRepoFindingsTrends').mockResolvedValue({ items: [] });
+  vi.spyOn(api.apiClient, 'getRepoRiskGraph').mockRejectedValue(new Error('no graph'));
+
+  const { ProductFindingsPage } = await import('./productShell');
+  render(
+    <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/findings']}>
+      <Routes>
+        <Route path="/app/:tenantID/:workspaceID/findings" element={<ProductFindingsPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+  return { listRepoScans, listRepoFindings };
+}
+
+describe('ProductFindingsPage states', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('shows a first-scan onboarding state when no scans have run', async () => {
+    await renderFindings({ repoScans: [] });
+
+    expect(await screen.findByText('Run your first repository scan')).toBeInTheDocument();
+    // The zero-filled dashboard chrome must not render in the empty state.
+    expect(screen.queryByText('Completed repo scans')).not.toBeInTheDocument();
+  });
+
+  it('surfaces a failure state instead of zeros when every scan failed', async () => {
+    const failedScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-failed',
+      status: 'failed',
+      finished_at: '2026-05-17T11:05:00Z',
+      error_message: 'Repository not found or access revoked'
+    };
+
+    await renderFindings({ repoScans: [failedScan] });
+
+    expect(await screen.findByText('Your last repository scan failed')).toBeInTheDocument();
+    expect(screen.getByText(/Repository not found or access revoked/i)).toBeInTheDocument();
+    expect(screen.queryByText('Completed repo scans')).not.toBeInTheDocument();
+  });
+
+  it('shows a clean "no exposure" state when a scan succeeded with zero findings', async () => {
+    const succeededScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-succeeded',
+      status: 'succeeded',
+      finished_at: '2026-05-17T11:05:00Z',
+      finding_count: 0
+    };
+
+    await renderFindings({ repoScans: [succeededScan] });
+
+    expect(await screen.findByText('No exposure found')).toBeInTheDocument();
+    // The dashboard chrome renders for a succeeded scan.
+    expect(screen.getByText('Completed repo scans')).toBeInTheDocument();
+  });
+});

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -341,6 +341,7 @@ describe('ProductShellLayout', () => {
 
 describe('ProductShellLayout', () => {
   afterEach(() => {
+    vi.doUnmock('./hooks/useMe');
     vi.restoreAllMocks();
     vi.resetModules();
   });

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -747,6 +747,7 @@ async function renderFindings(options: { repoScans?: RepoScanRecord[] } = {}) {
 describe('ProductFindingsPage states', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.doUnmock('./hooks/useMe');
     vi.resetModules();
   });
 

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -791,6 +791,28 @@ describe('ProductFindingsPage states', () => {
     expect(screen.getByText('Completed repo scans')).toBeInTheDocument();
   });
 
+  it('does not show failed state when a canceled scan is the latest', async () => {
+    const failedScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-failed-legacy',
+      status: 'failed',
+      finished_at: '2026-05-17T11:00:00Z',
+      error_message: 'Repository not found or access revoked'
+    };
+    const canceledScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-canceled-latest',
+      status: 'canceled',
+      finished_at: '2026-05-17T11:05:00Z',
+      error_message: 'User canceled scan from API'
+    };
+
+    await renderFindings({ repoScans: [canceledScan, failedScan] });
+
+    expect(await screen.findByText('No completed scan results')).toBeInTheDocument();
+    expect(screen.queryByText('Your last repository scan failed')).not.toBeInTheDocument();
+  });
+
   it('shows "No completed scan results" while an active scan is still running', async () => {
     const failedScan: RepoScanRecord = {
       ...queuedRepoScan,

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -1,7 +1,13 @@
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { AWSConnectionStatus, CurrentUserContext, GitHubConnectionStatus, RepoScanRecord } from './api/client';
+import type {
+  AWSConnectionStatus,
+  CurrentUserContext,
+  GitHubConnectionStatus,
+  Finding,
+  RepoScanRecord
+} from './api/client';
 import type { BackendFeatureState } from './hooks/useBackendFeatures';
 
 const loggedInWithoutWorkspace: CurrentUserContext = {
@@ -711,7 +717,7 @@ describe('ProductProjectDetailPage', () => {
   });
 });
 
-async function renderFindings(options: { repoScans?: RepoScanRecord[] } = {}) {
+async function renderFindings(options: { repoScans?: RepoScanRecord[]; repoFindings?: Finding[] } = {}) {
   vi.resetModules();
   vi.doMock('./hooks/useMe', () => ({
     useMe: () => ({
@@ -729,7 +735,7 @@ async function renderFindings(options: { repoScans?: RepoScanRecord[] } = {}) {
     .mockResolvedValue({ items: options.repoScans ?? [] });
   const listRepoFindings = vi
     .spyOn(api.apiClient, 'listRepoFindings')
-    .mockResolvedValue({ items: [], summary: undefined });
+    .mockResolvedValue({ items: options.repoFindings ?? [], summary: undefined });
   vi.spyOn(api.apiClient, 'getRepoFindingsTrends').mockResolvedValue({ items: [] });
   vi.spyOn(api.apiClient, 'getRepoRiskGraph').mockRejectedValue(new Error('no graph'));
 
@@ -834,6 +840,44 @@ describe('ProductFindingsPage states', () => {
     expect(await screen.findByText('No completed scan results')).toBeInTheDocument();
     expect(screen.queryByText('No exposure found')).not.toBeInTheDocument();
     expect(screen.queryByText('Your last repository scan failed')).not.toBeInTheDocument();
+  });
+
+  it('keeps findings visible when failed scans still return historical findings', async () => {
+    const failedScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-failed-latest',
+      status: 'failed',
+      started_at: '2026-05-17T12:00:00Z',
+      finished_at: '2026-05-17T12:01:00Z',
+      error_message: 'Repository not found or access revoked'
+    };
+    const oldSucceededScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-succeeded-older',
+      status: 'succeeded',
+      started_at: '2026-05-17T11:00:00Z',
+      finished_at: '2026-05-17T11:30:00Z',
+      finding_count: 2
+    };
+    const historicFinding: Finding = {
+      id: 'finding-legacy',
+      scan_id: 'repo-scan-succeeded-older',
+      type: 'secrets',
+      severity: 'high',
+      title: 'Legacy finding',
+      human_summary: 'Legacy risky secret exposure',
+      remediation: 'Rotate and clean up repository secret.',
+      created_at: '2026-05-17T11:10:00Z'
+    };
+
+    await renderFindings({
+      repoScans: [failedScan, oldSucceededScan],
+      repoFindings: [historicFinding]
+    });
+
+    expect(screen.queryByText('Your last repository scan failed')).not.toBeInTheDocument();
+    expect(screen.getByText('Completed repo scans')).toBeInTheDocument();
+    expect(screen.getByText('Legacy finding')).toBeInTheDocument();
   });
 
   it('does not report cancellation as a failed scan', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -812,4 +812,19 @@ describe('ProductFindingsPage states', () => {
     expect(screen.queryByText('No exposure found')).not.toBeInTheDocument();
     expect(screen.queryByText('Your last repository scan failed')).not.toBeInTheDocument();
   });
+
+  it('does not report cancellation as a failed scan', async () => {
+    const canceledScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-canceled',
+      status: 'canceled',
+      finished_at: '2026-05-17T11:09:00Z',
+      error_message: 'User canceled scan from API'
+    };
+
+    await renderFindings({ repoScans: [canceledScan] });
+
+    expect(await screen.findByText('No completed scan results')).toBeInTheDocument();
+    expect(screen.queryByText('Your last repository scan failed')).not.toBeInTheDocument();
+  });
 });

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -876,7 +876,7 @@ describe('ProductFindingsPage states', () => {
     });
 
     expect(screen.queryByText('Your last repository scan failed')).not.toBeInTheDocument();
-    expect(screen.getByText('Completed repo scans')).toBeInTheDocument();
+    expect(await screen.findByText(/Completed\s+repo\s+scans/i)).toBeInTheDocument();
     expect(screen.getByText('Legacy finding')).toBeInTheDocument();
   });
 

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -877,7 +877,7 @@ describe('ProductFindingsPage states', () => {
 
     expect(screen.queryByText('Your last repository scan failed')).not.toBeInTheDocument();
     expect(await screen.findByText(/Completed\s+repo\s+scans/i)).toBeInTheDocument();
-    expect(screen.getByText('Legacy finding')).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Legacy finding' })).toBeInTheDocument();
   });
 
   it('does not report cancellation as a failed scan', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -790,4 +790,26 @@ describe('ProductFindingsPage states', () => {
     // The dashboard chrome renders for a succeeded scan.
     expect(screen.getByText('Completed repo scans')).toBeInTheDocument();
   });
+
+  it('shows "No completed scan results" while an active scan is still running', async () => {
+    const failedScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-failed-in-flight',
+      status: 'failed',
+      finished_at: '2026-05-17T11:03:00Z',
+      error_message: 'Repository access revoked'
+    };
+    const queuedScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-queued-in-flight',
+      status: 'queued',
+      finished_at: undefined
+    };
+
+    await renderFindings({ repoScans: [queuedScan, failedScan] });
+
+    expect(await screen.findByText('No completed scan results')).toBeInTheDocument();
+    expect(screen.queryByText('No exposure found')).not.toBeInTheDocument();
+    expect(screen.queryByText('Your last repository scan failed')).not.toBeInTheDocument();
+  });
 });

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -6019,7 +6019,7 @@ export function ProductFindingsPage() {
   const hasQueuedOrRunningScan = scansByRecency.some((scan) => isActiveScanStatus(scan.status));
   const latestScanSucceeded = latestScan ? repoScanStatusTone(latestScan.status) === 'success' : false;
   const neverScanned = repoScans.length === 0;
-  const allScansFailed = !neverScanned && !hasQueuedOrRunningScan && succeededScanCount === 0 && failedScans.length > 0;
+  const allScansFailed = !neverScanned && !hasQueuedOrRunningScan && succeededScanCount === 0 && latestScanFailed;
   const latestScanFailed = latestScan ? isFailedScanStatus(latestScan.status) : false;
   const filtersActive =
     normalizeValue(repoScanFilter) !== '' ||

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -6018,9 +6018,9 @@ export function ProductFindingsPage() {
   const latestFailedScan = failedScans[0] ?? null;
   const hasQueuedOrRunningScan = scansByRecency.some((scan) => isActiveScanStatus(scan.status));
   const latestScanSucceeded = latestScan ? repoScanStatusTone(latestScan.status) === 'success' : false;
+  const latestScanFailed = latestScan ? isFailedScanStatus(latestScan.status) : false;
   const neverScanned = repoScans.length === 0;
   const allScansFailed = !neverScanned && !hasQueuedOrRunningScan && succeededScanCount === 0 && latestScanFailed;
-  const latestScanFailed = latestScan ? isFailedScanStatus(latestScan.status) : false;
   const filtersActive =
     normalizeValue(repoScanFilter) !== '' ||
     severityFilter !== 'all' ||

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -6003,6 +6003,104 @@ export function ProductFindingsPage() {
     void loadTrendSignals(scope, 'refresh');
   };
 
+  const projectsPath = buildProjectsPath(scope);
+  const scansByRecency = [...repoScans].sort(
+    (left, right) => new Date(right.started_at).getTime() - new Date(left.started_at).getTime()
+  );
+  const succeededScanCount = repoScans.filter((scan) => repoScanStatusTone(scan.status) === 'success').length;
+  const failedScans = scansByRecency.filter((scan) => repoScanStatusTone(scan.status) === 'error');
+  const latestScan = scansByRecency[0] ?? null;
+  const latestFailedScan = failedScans[0] ?? null;
+  const neverScanned = repoScans.length === 0;
+  const allScansFailed = !neverScanned && succeededScanCount === 0 && failedScans.length > 0;
+  const latestScanFailed = latestScan ? repoScanStatusTone(latestScan.status) === 'error' : false;
+  const filtersActive =
+    normalizeValue(repoScanFilter) !== '' ||
+    severityFilter !== 'all' ||
+    typeFilter !== 'all' ||
+    statusFilter !== 'all' ||
+    normalizeValue(assigneeFilter) !== '';
+
+  const formatScanDate = (scan: RepoScanRecord | null): string => {
+    if (!scan) {
+      return '';
+    }
+    const when = new Date(scan.finished_at || scan.started_at);
+    return Number.isNaN(when.getTime()) ? '' : when.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  };
+
+  const describeScanFailure = (scan: RepoScanRecord | null): string => {
+    if (!scan) {
+      return 'The scan did not complete.';
+    }
+    const parts = [summarizeScanFailure(scan)];
+    const repository = canonicalGitHubRepositoryDisplay(scan.repository);
+    if (repository) {
+      parts.push(repository);
+    }
+    const when = formatScanDate(scan);
+    if (when) {
+      parts.push(when);
+    }
+    return parts.join(' · ');
+  };
+
+  // Distinct empty/failed states: never showing the populated dashboard chrome
+  // (KPI grid, risk graph, trend, filters) filled with zeros when no scan has
+  // produced findings. A failed-only state surfaces the failure instead of
+  // silently rendering zeros.
+  if (neverScanned || allScansFailed) {
+    return (
+      <section className="idt-app-panel idt-repo-findings-page">
+        <div className="idt-repo-findings-header">
+          <div>
+            <p className="idt-app-kicker">Repository Exposure</p>
+            <h2>Findings</h2>
+            <p>Review repository findings and jump directly to the exact GitHub line when link metadata is available.</p>
+          </div>
+          <div className="idt-inline-actions">
+            <button
+              className="idt-btn idt-btn-ghost"
+              type="button"
+              onClick={handleRefresh}
+              disabled={refreshing || signalsRefreshing}
+            >
+              {refreshing || signalsRefreshing ? 'Refreshing...' : 'Refresh'}
+            </button>
+          </div>
+        </div>
+
+        {error ? <div className="idt-app-alert idt-app-alert-error">{error}</div> : null}
+
+        {neverScanned ? (
+          <AppShellEmptyState
+            title="Run your first repository scan"
+            body="Scan a connected repository to surface risky trust paths, exposed secrets, and authorization gaps — then jump straight to the exact GitHub line."
+            action={{ label: 'Go to projects', to: projectsPath }}
+          />
+        ) : (
+          <article className="idt-app-empty-state idt-repo-scan-failure-state">
+            <h2>Your last repository scan failed</h2>
+            <p>{describeScanFailure(latestFailedScan)}</p>
+            <div className="idt-inline-actions">
+              <Link className="idt-app-empty-state-action" to={projectsPath}>
+                Review &amp; re-run scan
+              </Link>
+              <button
+                className="idt-btn idt-btn-ghost"
+                type="button"
+                onClick={handleRefresh}
+                disabled={refreshing || signalsRefreshing}
+              >
+                {refreshing || signalsRefreshing ? 'Refreshing...' : 'Refresh'}
+              </button>
+            </div>
+          </article>
+        )}
+      </section>
+    );
+  }
+
   const totalTrendItems = trendPoints.reduce((acc, point) => acc + point.total, 0);
   const trendRows = trendPoints.map((point, index) => {
     const bySeverity = point.by_severity ?? ({} as Record<string, number>);
@@ -6043,17 +6141,13 @@ export function ProductFindingsPage() {
           </div>
         </div>
         <div className="idt-inline-actions">
-          <button className="idt-btn idt-btn-ghost" type="button" onClick={handleRefresh} disabled={refreshing}>
-            {refreshing ? 'Refreshing...' : 'Refresh'}
-          </button>
           <button
             className="idt-btn idt-btn-ghost"
             type="button"
             onClick={handleRefresh}
-            disabled={signalsRefreshing || signalsLoading}
-            style={{ marginLeft: '0.45rem' }}
+            disabled={refreshing || signalsRefreshing}
           >
-            {signalsRefreshing ? 'Loading signals...' : 'Reload trend'}
+            {refreshing || signalsRefreshing ? 'Refreshing...' : 'Refresh'}
           </button>
           {selectedFinding?.source_url ? (
             <a className="idt-btn idt-btn-primary" href={selectedFinding.source_url} target="_blank" rel="noreferrer">
@@ -6067,6 +6161,13 @@ export function ProductFindingsPage() {
       {signalError ? <div className="idt-app-alert idt-app-alert-error">{signalError}</div> : null}
       {trendError ? <div className="idt-app-alert idt-app-alert-error">{trendError}</div> : null}
       {riskGraphError ? <div className="idt-app-alert idt-app-alert-error">{riskGraphError}</div> : null}
+
+      {latestScanFailed ? (
+        <div className="idt-app-alert idt-app-alert-error idt-repo-scan-health">
+          <span>Last scan failed: {describeScanFailure(latestFailedScan)}</span>
+          <Link to={projectsPath}>Review &amp; re-run</Link>
+        </div>
+      ) : null}
 
       <div className="idt-repo-finding-stats" aria-label="Repository finding summary">
         <article className="idt-repo-finding-stat">
@@ -6184,10 +6285,10 @@ export function ProductFindingsPage() {
           <span className="idt-repo-finding-trend-subtitle">{totalTrendItems > 0 ? `${totalTrendItems} total events in window` : 'No trend items yet'}</span>
         </div>
         <div className="idt-repo-finding-trend-rows">
-          {trendRows.length === 0 ? (
+          {totalTrendItems === 0 ? (
             <AppShellEmptyState
-              title="Trend unavailable"
-              body="Run a scan so finding trend snapshots can appear with severity distribution over time."
+              title="No trend yet"
+              body="Trend snapshots with severity distribution will appear here once a scan produces findings."
             />
           ) : (
             trendRows.map((row) => (
@@ -6294,10 +6395,17 @@ export function ProductFindingsPage() {
             <p>{filteredFindings.length ? `${filteredFindings.length} findings in scope` : 'No findings match the current filters.'}</p>
           </div>
           {findingGroups.length === 0 ? (
-            <AppShellEmptyState
-              title="No repository findings"
-              body="Run a repository exposure scan or loosen the current filters to inspect GitHub-linked findings."
-            />
+            filtersActive ? (
+              <AppShellEmptyState
+                title="No findings match these filters"
+                body="Loosen the current filters to inspect GitHub-linked findings from your scans."
+              />
+            ) : (
+              <AppShellEmptyState
+                title="No exposure found"
+                body="Your latest repository scan completed and surfaced no findings. New findings will appear here after the next scan."
+              />
+            )
           ) : (
             <div>
               {findingGroups.map((group) => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -6029,7 +6029,8 @@ export function ProductFindingsPage() {
   const latestScanSucceeded = latestScan ? repoScanStatusTone(latestScan.status) === 'success' : false;
   const latestScanFailed = latestScan ? isFailedScanStatus(latestScan.status) : false;
   const neverScanned = repoScans.length === 0;
-  const allScansFailed = !neverScanned && !hasQueuedOrRunningScan && succeededScanCount === 0 && latestScanFailed;
+  const hasRepoFindings = repoFindings.length > 0;
+  const allScansFailed = !neverScanned && !hasQueuedOrRunningScan && !hasRepoFindings && succeededScanCount === 0 && latestScanFailed;
   const filtersActive =
     normalizeValue(repoScanFilter) !== '' ||
     severityFilter !== 'all' ||

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -534,6 +534,11 @@ function isCompletedScanStatus(status: string): boolean {
   return normalized === 'succeeded' || normalized === 'completed' || normalized === 'failed' || normalized === 'canceled';
 }
 
+function isFailedScanStatus(status: string): boolean {
+  const normalized = normalizeValue(status).toLowerCase();
+  return normalized === 'failed';
+}
+
 function repoScanStatusTone(status: string): 'success' | 'warning' | 'error' | 'neutral' {
   const normalized = normalizeValue(status).toLowerCase();
   if (normalized === 'succeeded' || normalized === 'completed') {
@@ -6008,14 +6013,14 @@ export function ProductFindingsPage() {
     (left, right) => new Date(right.started_at).getTime() - new Date(left.started_at).getTime()
   );
   const succeededScanCount = repoScans.filter((scan) => repoScanStatusTone(scan.status) === 'success').length;
-  const failedScans = scansByRecency.filter((scan) => repoScanStatusTone(scan.status) === 'error');
+  const failedScans = scansByRecency.filter((scan) => isFailedScanStatus(scan.status));
   const latestScan = scansByRecency[0] ?? null;
   const latestFailedScan = failedScans[0] ?? null;
   const hasQueuedOrRunningScan = scansByRecency.some((scan) => isActiveScanStatus(scan.status));
   const latestScanSucceeded = latestScan ? repoScanStatusTone(latestScan.status) === 'success' : false;
   const neverScanned = repoScans.length === 0;
   const allScansFailed = !neverScanned && !hasQueuedOrRunningScan && succeededScanCount === 0 && failedScans.length > 0;
-  const latestScanFailed = latestScan ? repoScanStatusTone(latestScan.status) === 'error' : false;
+  const latestScanFailed = latestScan ? isFailedScanStatus(latestScan.status) : false;
   const filtersActive =
     normalizeValue(repoScanFilter) !== '' ||
     severityFilter !== 'all' ||

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -6011,8 +6011,8 @@ export function ProductFindingsPage() {
   const failedScans = scansByRecency.filter((scan) => repoScanStatusTone(scan.status) === 'error');
   const latestScan = scansByRecency[0] ?? null;
   const latestFailedScan = failedScans[0] ?? null;
-  const hasQueuedOrRunningScan = scansByRecency.some((scan) => isRepoScanQueuedOrRunning(scan.status));
-  const hasCompletedScan = scansByRecency.some((scan) => isRepoScanCompleted(scan.status));
+  const hasQueuedOrRunningScan = scansByRecency.some((scan) => isActiveScanStatus(scan.status));
+  const hasCompletedScan = scansByRecency.some((scan) => isCompletedScanStatus(scan.status));
   const neverScanned = repoScans.length === 0;
   const allScansFailed = !neverScanned && !hasQueuedOrRunningScan && succeededScanCount === 0 && failedScans.length > 0;
   const latestScanFailed = latestScan ? repoScanStatusTone(latestScan.status) === 'error' : false;

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -6012,7 +6012,7 @@ export function ProductFindingsPage() {
   const latestScan = scansByRecency[0] ?? null;
   const latestFailedScan = failedScans[0] ?? null;
   const hasQueuedOrRunningScan = scansByRecency.some((scan) => isActiveScanStatus(scan.status));
-  const hasCompletedScan = scansByRecency.some((scan) => isCompletedScanStatus(scan.status));
+  const latestScanSucceeded = latestScan ? repoScanStatusTone(latestScan.status) === 'success' : false;
   const neverScanned = repoScans.length === 0;
   const allScansFailed = !neverScanned && !hasQueuedOrRunningScan && succeededScanCount === 0 && failedScans.length > 0;
   const latestScanFailed = latestScan ? repoScanStatusTone(latestScan.status) === 'error' : false;
@@ -6402,7 +6402,7 @@ export function ProductFindingsPage() {
                 title="No findings match these filters"
                 body="Loosen the current filters to inspect GitHub-linked findings from your scans."
               />
-            ) : hasCompletedScan ? (
+            ) : latestScanSucceeded ? (
               <AppShellEmptyState
                 title="No exposure found"
                 body="Your latest repository scan completed and surfaced no findings. New findings will appear here after the next scan."
@@ -6410,7 +6410,7 @@ export function ProductFindingsPage() {
             ) : (
               <AppShellEmptyState
                 title="No completed scan results"
-                body="Your repository scan is still running; findings will appear here once a scan completes."
+                body="No completed scan has surfaced findings yet. New findings will appear here after the next successful scan."
               />
             )
           ) : (

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -6011,8 +6011,10 @@ export function ProductFindingsPage() {
   const failedScans = scansByRecency.filter((scan) => repoScanStatusTone(scan.status) === 'error');
   const latestScan = scansByRecency[0] ?? null;
   const latestFailedScan = failedScans[0] ?? null;
+  const hasQueuedOrRunningScan = scansByRecency.some((scan) => isRepoScanQueuedOrRunning(scan.status));
+  const hasCompletedScan = scansByRecency.some((scan) => isRepoScanCompleted(scan.status));
   const neverScanned = repoScans.length === 0;
-  const allScansFailed = !neverScanned && succeededScanCount === 0 && failedScans.length > 0;
+  const allScansFailed = !neverScanned && !hasQueuedOrRunningScan && succeededScanCount === 0 && failedScans.length > 0;
   const latestScanFailed = latestScan ? repoScanStatusTone(latestScan.status) === 'error' : false;
   const filtersActive =
     normalizeValue(repoScanFilter) !== '' ||
@@ -6400,10 +6402,15 @@ export function ProductFindingsPage() {
                 title="No findings match these filters"
                 body="Loosen the current filters to inspect GitHub-linked findings from your scans."
               />
-            ) : (
+            ) : hasCompletedScan ? (
               <AppShellEmptyState
                 title="No exposure found"
                 body="Your latest repository scan completed and surfaced no findings. New findings will appear here after the next scan."
+              />
+            ) : (
+              <AppShellEmptyState
+                title="No completed scan results"
+                body="Your repository scan is still running; findings will appear here once a scan completes."
               />
             )
           ) : (


### PR DESCRIPTION
No issue: first of three sequential Findings-page UX PRs (state handling → IA/KPIs → visual polish).

## What changed
The repository Findings page rendered a full zero-filled dashboard (10 KPI cards, risk graph, a repeating trend, filters, master/detail) in every empty case — which hid scan failures behind a wall of `0`s. It's now state-aware:

- **Never scanned** → a first-scan onboarding prompt (with a link to Projects), not a zeros dashboard.
- **All scans failed** → a failure state showing the reason + a re-run path, so failed scans are no longer silently shown as zeros. A compact "Last scan failed" line also appears in the populated view when the most recent scan failed but earlier ones succeeded.
- **Scan succeeded, no findings** → a clean "No exposure found" state (distinct from the filtered-empty "No findings match these filters" copy).

Also:
- **Removed the redundant "Reload trend" button** — "Refresh" now reloads findings and trend together (folded `signalsRefreshing` into the single button).
- **Collapsed the finding trend** so all-zero windows show one empty state instead of repeated "May 23 · 0" rows.

## Impact and risk
- `web` only; no API/behavior change to scanning. Pure presentation/state-branching on `ProductFindingsPage`.
- No new imports; relies on existing helpers (`summarizeScanFailure`, `repoScanStatusTone`, `AppShellEmptyState`, `buildProjectsPath`).

## Validation
- `tsc -b` clean.
- `vitest run src/productShell.test.tsx` — 23 passed, incl. 3 new tests covering the never-scanned, all-failed, and clean states.

## Follow-ups (next PRs in this series)
- PR 2: consolidate 10 KPIs → ~4, lead with the findings table, gate filters + master/detail when empty.
- PR 3: copy unification + premium visual system pass.

## AI-Assisted and AI-Generated Code Policy
- AI-assisted: yes
- Tools used: Claude Code
- Where used: `web/src/productShell.tsx`, `web/src/productShell.test.tsx`, `CHANGELOG.md`
- Human verification performed: typecheck + component test suite (incl. new state tests); reviewed the diff to confirm no scan/API behavior change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the repository Findings page state-aware so empty and failed scans don’t render a zero-filled dashboard. Adds clear states for never scanned, in-progress, failed, and clean scans; keeps historical findings visible when the latest scan fails; unifies Refresh and collapses the trend.

- **New Features**
  - Never scanned → onboarding prompt linking to Projects.
  - Latest scan failed → if no successful scans, show failure state with reason + re-run link; if findings exist, keep them visible and show a compact “Last scan failed” alert.
  - Successful scan with 0 findings → “No exposure found” (distinct from filtered-empty).
  - Single “Refresh” reloads findings and trend; removed “Reload trend”. Trend shows “No trend yet” when totals are 0.

- **Bug Fixes**
  - Gate states on scan activity and the latest completed scan; while a scan is queued or running, show “No completed scan results”.
  - Treat canceled scans as non-failing.

<sup>Written for commit b0cd0ee410746daf5c458d0ef43e51f18b9207a4. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1317?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

