### PR TITLE
feat(web): streamline Findings IA — fewer KPIs, table-first, gated chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## Unreleased
+- Reworked the repository Findings page information architecture. Consolidated
+  the ten summary tiles into four (open, critical, mean-time-to-fix, completed
+  scans) with supporting detail in captions, led with the findings table by
+  demoting the risk graph and finding trend below it, and gated the filter panel
+  and the finding detail pane so empty scopes no longer show redundant empty
+  placeholders.
 - Made the repository Findings page state-aware instead of rendering a
   zero-filled dashboard in every empty case. A never-scanned workspace now shows
   a first-scan onboarding prompt, an all-failed scan history surfaces the failure

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -763,7 +763,7 @@ describe('ProductFindingsPage states', () => {
 
     expect(await screen.findByText('Run your first repository scan')).toBeInTheDocument();
     // The zero-filled dashboard chrome must not render in the empty state.
-    expect(screen.queryByText('Completed repo scans')).not.toBeInTheDocument();
+    expect(screen.queryByText('Completed scans')).not.toBeInTheDocument();
   });
 
   it('surfaces a failure state instead of zeros when every scan failed', async () => {
@@ -779,7 +779,7 @@ describe('ProductFindingsPage states', () => {
 
     expect(await screen.findByText('Your last repository scan failed')).toBeInTheDocument();
     expect(screen.getByText(/Repository not found or access revoked/i)).toBeInTheDocument();
-    expect(screen.queryByText('Completed repo scans')).not.toBeInTheDocument();
+    expect(screen.queryByText('Completed scans')).not.toBeInTheDocument();
   });
 
   it('shows a clean "no exposure" state when a scan succeeded with zero findings', async () => {
@@ -794,8 +794,12 @@ describe('ProductFindingsPage states', () => {
     await renderFindings({ repoScans: [succeededScan] });
 
     expect(await screen.findByText('No exposure found')).toBeInTheDocument();
-    // The dashboard chrome renders for a succeeded scan.
-    expect(screen.getByText('Completed repo scans')).toBeInTheDocument();
+    // The consolidated KPI strip renders for a succeeded scan.
+    expect(screen.getByText('Completed scans')).toBeInTheDocument();
+    // With no findings and no active filters, the filter panel and the empty
+    // detail pane are gated out (no redundant empty placeholders).
+    expect(screen.queryByText('Filters and sorting')).not.toBeInTheDocument();
+    expect(screen.queryByText('Select a finding')).not.toBeInTheDocument();
   });
 
   it('does not show failed state when a canceled scan is the latest', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4,8 +4,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type {
   AWSConnectionStatus,
   CurrentUserContext,
-  GitHubConnectionStatus,
   Finding,
+  GitHubConnectionStatus,
   RepoScanRecord
 } from './api/client';
 import type { BackendFeatureState } from './hooks/useBackendFeatures';
@@ -735,7 +735,18 @@ async function renderFindings(options: { repoScans?: RepoScanRecord[]; repoFindi
     .mockResolvedValue({ items: options.repoScans ?? [] });
   const listRepoFindings = vi
     .spyOn(api.apiClient, 'listRepoFindings')
-    .mockResolvedValue({ items: options.repoFindings ?? [], summary: undefined });
+    .mockImplementation(async (params) => {
+      // Apply the server-side filters (severity/type) the component passes so
+      // tests that exercise filtering observe a realistic empty result.
+      let items = options.repoFindings ?? [];
+      if (params?.severity) {
+        items = items.filter((finding) => finding.severity === params.severity);
+      }
+      if (params?.type) {
+        items = items.filter((finding) => finding.type === params.type);
+      }
+      return { items, summary: undefined };
+    });
   vi.spyOn(api.apiClient, 'getRepoFindingsTrends').mockResolvedValue({ items: [] });
   vi.spyOn(api.apiClient, 'getRepoRiskGraph').mockRejectedValue(new Error('no graph'));
 
@@ -880,7 +891,7 @@ describe('ProductFindingsPage states', () => {
     });
 
     expect(screen.queryByText('Your last repository scan failed')).not.toBeInTheDocument();
-    expect(await screen.findByText(/Completed\s+repo\s+scans/i)).toBeInTheDocument();
+    expect(await screen.findByText('Completed scans')).toBeInTheDocument();
     expect(await screen.findByRole('heading', { name: 'Legacy finding' })).toBeInTheDocument();
   });
 
@@ -897,5 +908,42 @@ describe('ProductFindingsPage states', () => {
 
     expect(await screen.findByText('No completed scan results')).toBeInTheDocument();
     expect(screen.queryByText('Your last repository scan failed')).not.toBeInTheDocument();
+  });
+
+  it('keeps the finding detail pane visible when filters are active but no findings match', async () => {
+    const scan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-with-findings',
+      status: 'succeeded',
+      finished_at: '2026-05-17T11:06:00Z',
+      finding_count: 1
+    };
+
+    const finding: Finding = {
+      id: 'finding-1',
+      scan_id: scan.id,
+      type: 'aws_access_key',
+      severity: 'critical',
+      title: 'IAM role with wildcard trust',
+      human_summary: 'AssumeRole trust policy allows any principal.',
+      remediation: 'Tighten trust policy principals.',
+      created_at: '2026-05-17T11:06:00Z'
+    };
+
+    await renderFindings({
+      repoScans: [scan],
+      repoFindings: [finding]
+    });
+
+    expect((await screen.findAllByText('IAM role with wildcard trust')).length).toBeGreaterThan(0);
+
+    const filtersSummary = await screen.findByText('Filters and sorting');
+    fireEvent.click(filtersSummary);
+
+    const severityFilter = screen.getByLabelText('Severity');
+    fireEvent.change(severityFilter, { target: { value: 'high' } });
+
+    expect(await screen.findByText('No findings match the current filters.')).toBeInTheDocument();
+    expect(screen.getByText('Select a finding')).toBeInTheDocument();
   });
 });

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -6188,144 +6188,32 @@ export function ProductFindingsPage() {
 
       <div className="idt-repo-finding-stats" aria-label="Repository finding summary">
         <article className="idt-repo-finding-stat">
-          <div className="idt-overview-metric-top">
-            <span>Total repo findings</span>
-            <SourceLogoMark provider="github" />
-          </div>
-          <strong>{filteredFindings.length}</strong>
-        </article>
-        <article className="idt-repo-finding-stat">
-          <div className="idt-overview-metric-top">
-            <span>GitHub-linked findings</span>
-            <SourceLogoMark provider="github" />
-          </div>
-          <strong>{linkedFindingCount}</strong>
-        </article>
-        <article className="idt-repo-finding-stat">
-          <div className="idt-overview-metric-top">
-            <span>Open findings</span>
-            <SourceLogoStack label="Open finding source coverage" />
-          </div>
+          <span>Open findings</span>
           <strong>{openFindingCount}</strong>
+          <small className="idt-repo-finding-stat-note">
+            {filteredFindings.length} total · {fixedFindingCount} fixed · {reopenedFindingCount} reopened
+          </small>
         </article>
         <article className="idt-repo-finding-stat">
-          <span>Fixed findings</span>
-          <strong>{fixedFindingCount}</strong>
-        </article>
-        <article className="idt-repo-finding-stat">
-          <span>Reopened findings</span>
-          <strong>{reopenedFindingCount}</strong>
-        </article>
-        <article className="idt-repo-finding-stat">
-          <span>SLA-aged highs</span>
-          <strong>{slaAgedFindingCount}</strong>
+          <span>Critical findings</span>
+          <strong>{criticalFindingCount}</strong>
+          <small className="idt-repo-finding-stat-note">
+            {slaAgedFindingCount} SLA-aged high{slaAgedFindingCount === 1 ? '' : 's'}
+          </small>
         </article>
         <article className="idt-repo-finding-stat">
           <span>Mean time to fix</span>
           <strong>{mttrLabel}</strong>
+          <small className="idt-repo-finding-stat-note">avg confidence {averageConfidence}</small>
         </article>
         <article className="idt-repo-finding-stat">
-          <div className="idt-overview-metric-top">
-            <span>Critical findings</span>
-            <SourceLogoStack label="Critical finding source coverage" />
-          </div>
-          <strong>{criticalFindingCount}</strong>
-        </article>
-        <article className="idt-repo-finding-stat">
-          <span>Avg confidence</span>
-          <strong>{averageConfidence}</strong>
-        </article>
-        <article className="idt-repo-finding-stat">
-          <span>Completed repo scans</span>
+          <span>Completed scans</span>
           <strong>{activeScanCount}</strong>
+          <small className="idt-repo-finding-stat-note">{linkedFindingCount} GitHub-linked</small>
         </article>
       </div>
 
-      <div className="idt-repo-finding-trend" aria-label="Repository risk graph summary">
-        <div className="idt-repo-finding-trend-head">
-          <h3>Risk graph</h3>
-          {trendDisplayLoading ? <span className="idt-app-alert idt-app-alert-success">Loading graph</span> : null}
-          <span className="idt-repo-finding-trend-subtitle">
-            {repoRiskGraph
-              ? `${repoRiskGraph.nodes.length} nodes · ${repoRiskGraph.edges.length} paths · ${canonicalGitHubRepositoryDisplay(repoRiskGraph.repository) || repoRiskGraph.repository || 'repository scope'}`
-              : 'No graph loaded yet'}
-          </span>
-        </div>
-        {riskGraphSummary ? (
-          <div className="idt-repo-finding-trend-rows">
-            <article className="idt-repo-finding-trend-row">
-              <div className="idt-repo-finding-trend-meta">
-                <span>High-risk findings</span>
-                <strong>{riskGraphSummary.high_risk_findings}</strong>
-              </div>
-              <p>
-                {riskGraphSummary.critical_findings} critical · {riskGraphUnknownEvidenceCount} unknown evidence gaps
-              </p>
-            </article>
-            {topRiskGraphScores.length > 0 ? (
-              topRiskGraphScores.map((score) => (
-                <article key={score.finding_id} className="idt-repo-finding-trend-row">
-                  <div className="idt-repo-finding-trend-meta">
-                    <span>{score.finding_id}</span>
-                    <strong>{Math.round(score.score)}</strong>
-                  </div>
-                  <p>
-                    {formatTokenLabel(score.severity)} · confidence {formatConfidenceScore(score.confidence)}
-                    {(score.unknowns ?? []).length > 0
-                      ? ` · unknown ${(score.unknowns ?? []).map(formatTokenLabel).join(', ')}`
-                      : ''}
-                  </p>
-                </article>
-              ))
-            ) : (
-              <article className="idt-repo-finding-trend-row">
-                <div className="idt-repo-finding-trend-meta">
-                  <span>No scored findings</span>
-                  <strong>{riskGraphSummary.finding_count}</strong>
-                </div>
-                <p>Risk scores will appear after graph evidence is available for repository findings.</p>
-              </article>
-            )}
-          </div>
-        ) : (
-          <AppShellEmptyState
-            title="Risk graph unavailable"
-            body="Run a repository exposure scan so machine-identity paths and finding risk scores can appear here."
-          />
-        )}
-      </div>
-
-      <div className="idt-repo-finding-trend">
-        <div className="idt-repo-finding-trend-head">
-          <h3>Finding trend</h3>
-          {trendDisplayLoading ? <span className="idt-app-alert idt-app-alert-success">Loading trend</span> : null}
-          <span className="idt-repo-finding-trend-subtitle">{totalTrendItems > 0 ? `${totalTrendItems} total events in window` : 'No trend items yet'}</span>
-        </div>
-        <div className="idt-repo-finding-trend-rows">
-          {totalTrendItems === 0 ? (
-            <AppShellEmptyState
-              title="No trend yet"
-              body="Trend snapshots with severity distribution will appear here once a scan produces findings."
-            />
-          ) : (
-            trendRows.map((row) => (
-              <article key={row.key} className="idt-repo-finding-trend-row">
-                <div className="idt-repo-finding-trend-meta">
-                  <span>{row.label}</span>
-                  <strong>{row.total}</strong>
-                </div>
-                <div className="idt-repo-finding-trend-bar-track" role="img" aria-label={`Trend point ${row.label}`}>
-                  <div className="idt-repo-finding-trend-bar" style={{ width: `${row.percentage}%` }} />
-                </div>
-                <p>
-                  {`Critical ${row.critical} / High ${row.high} / Medium ${row.medium} / Low ${row.low} / Info ${row.info}`}
-                </p>
-              </article>
-            ))
-          )}
-        </div>
-      </div>
-
+      {filteredFindings.length > 0 || filtersActive ? (
       <details className="idt-repo-filter-panel">
         <summary>
           <span>Filters and sorting</span>
@@ -6404,6 +6292,7 @@ export function ProductFindingsPage() {
           </label>
         </div>
       </details>
+      ) : null}
 
       <div className="idt-repo-finding-layout">
         <div className="idt-repo-finding-list">
@@ -6490,6 +6379,7 @@ export function ProductFindingsPage() {
           )}
         </div>
 
+        {findingGroups.length > 0 ? (
         <aside className="idt-repo-finding-detail">
           {selectedFinding ? (
             <>
@@ -6707,6 +6597,92 @@ export function ProductFindingsPage() {
             />
           )}
         </aside>
+        ) : null}
+      </div>
+
+      <div className="idt-repo-finding-trend" aria-label="Repository risk graph summary">
+        <div className="idt-repo-finding-trend-head">
+          <h3>Risk graph</h3>
+          {trendDisplayLoading ? <span className="idt-app-alert idt-app-alert-success">Loading graph</span> : null}
+          <span className="idt-repo-finding-trend-subtitle">
+            {repoRiskGraph
+              ? `${repoRiskGraph.nodes.length} nodes · ${repoRiskGraph.edges.length} paths · ${canonicalGitHubRepositoryDisplay(repoRiskGraph.repository) || repoRiskGraph.repository || 'repository scope'}`
+              : 'No graph loaded yet'}
+          </span>
+        </div>
+        {riskGraphSummary ? (
+          <div className="idt-repo-finding-trend-rows">
+            <article className="idt-repo-finding-trend-row">
+              <div className="idt-repo-finding-trend-meta">
+                <span>High-risk findings</span>
+                <strong>{riskGraphSummary.high_risk_findings}</strong>
+              </div>
+              <p>
+                {riskGraphSummary.critical_findings} critical · {riskGraphUnknownEvidenceCount} unknown evidence gaps
+              </p>
+            </article>
+            {topRiskGraphScores.length > 0 ? (
+              topRiskGraphScores.map((score) => (
+                <article key={score.finding_id} className="idt-repo-finding-trend-row">
+                  <div className="idt-repo-finding-trend-meta">
+                    <span>{score.finding_id}</span>
+                    <strong>{Math.round(score.score)}</strong>
+                  </div>
+                  <p>
+                    {formatTokenLabel(score.severity)} · confidence {formatConfidenceScore(score.confidence)}
+                    {(score.unknowns ?? []).length > 0
+                      ? ` · unknown ${(score.unknowns ?? []).map(formatTokenLabel).join(', ')}`
+                      : ''}
+                  </p>
+                </article>
+              ))
+            ) : (
+              <article className="idt-repo-finding-trend-row">
+                <div className="idt-repo-finding-trend-meta">
+                  <span>No scored findings</span>
+                  <strong>{riskGraphSummary.finding_count}</strong>
+                </div>
+                <p>Risk scores will appear after graph evidence is available for repository findings.</p>
+              </article>
+            )}
+          </div>
+        ) : (
+          <AppShellEmptyState
+            title="Risk graph unavailable"
+            body="Run a repository exposure scan so machine-identity paths and finding risk scores can appear here."
+          />
+        )}
+      </div>
+
+      <div className="idt-repo-finding-trend">
+        <div className="idt-repo-finding-trend-head">
+          <h3>Finding trend</h3>
+          {trendDisplayLoading ? <span className="idt-app-alert idt-app-alert-success">Loading trend</span> : null}
+          <span className="idt-repo-finding-trend-subtitle">{totalTrendItems > 0 ? `${totalTrendItems} total events in window` : 'No trend items yet'}</span>
+        </div>
+        <div className="idt-repo-finding-trend-rows">
+          {totalTrendItems === 0 ? (
+            <AppShellEmptyState
+              title="No trend yet"
+              body="Trend snapshots with severity distribution will appear here once a scan produces findings."
+            />
+          ) : (
+            trendRows.map((row) => (
+              <article key={row.key} className="idt-repo-finding-trend-row">
+                <div className="idt-repo-finding-trend-meta">
+                  <span>{row.label}</span>
+                  <strong>{row.total}</strong>
+                </div>
+                <div className="idt-repo-finding-trend-bar-track" role="img" aria-label={`Trend point ${row.label}`}>
+                  <div className="idt-repo-finding-trend-bar" style={{ width: `${row.percentage}%` }} />
+                </div>
+                <p>
+                  {`Critical ${row.critical} / High ${row.high} / Medium ${row.medium} / Low ${row.low} / Info ${row.info}`}
+                </p>
+              </article>
+            ))
+          )}
+        </div>
       </div>
     </section>
   );

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -6379,7 +6379,7 @@ export function ProductFindingsPage() {
           )}
         </div>
 
-        {findingGroups.length > 0 ? (
+        {findingGroups.length > 0 || filtersActive ? (
         <aside className="idt-repo-finding-detail">
           {selectedFinding ? (
             <>


### PR DESCRIPTION
No issue: PR 2 of 3 in the Findings-page UX series. **Stacked on #1317** (base branch is `feat/findings-state-aware-pr1`, not `dev`) — review/merge #1317 first.

## What changed
- **Consolidated the KPI strip from 10 tiles to 4** — Open findings, Critical findings, Mean time to fix, Completed scans — with the remaining metrics (total/fixed/reopened, SLA-aged, avg confidence, GitHub-linked) folded into per-card captions. Removed the inconsistent per-card provider icons.
- **Table-first IA** — moved the risk graph and finding trend *below* the findings table so the page leads with the work, not the analytics.
- **Gated empty chrome** — the filter panel and the finding detail pane no longer render when there are no findings and no active filters, so an empty scope shows one clear state instead of stacked empty placeholders.

## Impact and risk
- `web` only; presentation/IA. No API or scan-behavior change. The populated path is unchanged (filters + detail render whenever findings exist).

## Validation
- `tsc -b` clean (JSX balance of the new gating conditionals verified).
- `vitest run src/productShell.test.tsx` — 23 passed; the clean-state test now also asserts the filter panel and empty detail pane are gated out, and the KPI label update.

## Follow-up
- PR 3: copy unification + premium visual system pass (surfaces, type, spacing, accent, micro-interactions).

## AI-Assisted and AI-Generated Code Policy
- AI-assisted: yes
- Tools used: Claude Code
- Where used: `web/src/productShell.tsx`, `web/src/productShell.test.tsx`, `CHANGELOG.md`
- Human verification performed: typecheck + component test suite (incl. updated gating assertions); reviewed the diff to confirm the populated path and analytics blocks moved intact

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamlined the Findings page: 4 KPIs (Open, Critical, Mean time to fix, Completed scans), a table-first layout, and gated panels for clean empty states.

- **Refactors**
  - Consolidated 10 KPI tiles into 4 with per-card captions; removed provider icons.
  - Moved the risk graph and finding trend below the findings table.
  - Gated the filter panel and detail pane when there are no findings and no active filters; updated tests (incl. realistic server-side filters) and copy; web-only, no API changes.

- **Bug Fixes**
  - Keep the finding detail pane visible when filters are active even if no rows match.

<sup>Written for commit 6505d37dcd0014e31f782d0f6b1fdea0293e0d90. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1318?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

