### PR TITLE
Document email routing contacts

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,4 +5,4 @@ contact_links:
     about: Report security issues privately. Do not open public issues for vulnerabilities.
   - name: Questions and support
     url: https://github.com/identrail/identrail/discussions
-    about: Ask usage questions and share ideas in Discussions.
+    about: Ask usage questions in Discussions, or email support@identrail.com for account and access help.

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,7 @@ This index maps Identrail docs by operator, developer, security/compliance, and 
 - Repository exposure scanner: `repo-exposure.md`
 - Execution model (API enqueue + worker processing): `execution-model.md`
 - Configuration reference: `configuration-reference.md`
+- Email routing: `email-routing.md`
 - Domain entity model: `domain-entities.md`
 
 ## Release and supply chain track

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -183,8 +183,8 @@ lead through the configured runtime channel.
 For the standard hosted setup, configure Resend:
 
 - `RESEND_API_KEY` (required for direct email delivery)
-- `LEAD_NOTIFY_TO` (required with Resend; comma-separated internal recipients such as `sales@identrail.com,security@identrail.com`)
-- `LEAD_EMAIL_FROM` (required with Resend; use a verified Identrail sender such as `Identrail <scan@identrail.com>`)
+- `LEAD_NOTIFY_TO` (required with Resend; comma-separated internal recipients such as `contact@identrail.com,marketing@identrail.com`)
+- `LEAD_EMAIL_FROM` (required with Resend; use a verified Identrail sender such as `Identrail <contact@identrail.com>`)
 - `LEAD_REPLY_TO` (optional; defaults to the submitter for internal notifications and the first `LEAD_NOTIFY_TO` address for confirmations)
 - `LEAD_EMAIL_SUBJECT_PREFIX` (default: `Identrail`)
 - `LEAD_CONFIRMATION_ENABLED` (default: `true`; set `false` to skip the requester confirmation email)

--- a/docs/email-routing.md
+++ b/docs/email-routing.md
@@ -1,0 +1,27 @@
+# Identrail Email Routing
+
+This document records the public mailbox roles used across Identrail websites, apps, docs, and operational configuration.
+
+## Mailboxes
+
+- `security@identrail.com`: vulnerability reports, responsible disclosure, security.txt, security policy, and private security reporting.
+- `support@identrail.com`: account help, access issues, privacy requests, data deletion requests, terms questions, and user support.
+- `contact@identrail.com`: general website contact, partnerships, enterprise inbound, and default lead-capture sender.
+- `marketing@identrail.com`: marketing follow-up, product updates, campaign replies, and lead-capture notification routing.
+- `founder@identrail.com`: founder inbox and private direct contact. Do not publish broadly on public surfaces by default.
+
+## Public Surface Rules
+
+- Do not route privacy, deletion, terms, or support requests to `security@identrail.com` unless the request is a security incident.
+- Use `support@identrail.com` for user-facing account and policy help.
+- Use `contact@identrail.com` for generic public contact links and lead sender configuration.
+- Include `marketing@identrail.com` only where the message is clearly a marketing or lead follow-up workflow.
+- Keep `founder@identrail.com` out of automated forms, footer links, and docs unless a founder-led contact path is intentionally added.
+
+## Current Integration Points
+
+- `web/public/security.txt`, `SECURITY.md`, `README.md`, and `/responsible-disclosure`: `security@identrail.com`.
+- Website footer contact link: `contact@identrail.com`.
+- Privacy and terms pages: `support@identrail.com`.
+- GitHub issue support guidance: `support@identrail.com`.
+- Lead capture docs and test configuration: `LEAD_NOTIFY_TO=contact@identrail.com,marketing@identrail.com` and `LEAD_EMAIL_FROM=Identrail <contact@identrail.com>`.

--- a/web/api/leads.test.ts
+++ b/web/api/leads.test.ts
@@ -97,8 +97,8 @@ describe('web/api/leads handler', () => {
 
   it('rejects common personal email domains before delivery', async () => {
     process.env.RESEND_API_KEY = 're_test_key';
-    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
-    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    process.env.LEAD_NOTIFY_TO = 'contact@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <contact@identrail.com>';
     const fetchMock = vi.fn(async () => ({ ok: true }));
     vi.stubGlobal('fetch', fetchMock);
 
@@ -121,8 +121,8 @@ describe('web/api/leads handler', () => {
 
   it('rejects disposable bot email domains before delivery', async () => {
     process.env.RESEND_API_KEY = 're_test_key';
-    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
-    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    process.env.LEAD_NOTIFY_TO = 'contact@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <contact@identrail.com>';
     const fetchMock = vi.fn(async () => ({ ok: true }));
     vi.stubGlobal('fetch', fetchMock);
 
@@ -145,8 +145,8 @@ describe('web/api/leads handler', () => {
 
   it('requires a matching company domain for read-only scan requests', async () => {
     process.env.RESEND_API_KEY = 're_test_key';
-    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
-    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    process.env.LEAD_NOTIFY_TO = 'contact@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <contact@identrail.com>';
     const fetchMock = vi.fn(async () => ({ ok: true }));
     vi.stubGlobal('fetch', fetchMock);
 
@@ -174,8 +174,8 @@ describe('web/api/leads handler', () => {
 
   it('requires requester details for read-only scan requests', async () => {
     process.env.RESEND_API_KEY = 're_test_key';
-    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
-    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    process.env.LEAD_NOTIFY_TO = 'contact@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <contact@identrail.com>';
     const fetchMock = vi.fn(async () => ({ ok: true }));
     vi.stubGlobal('fetch', fetchMock);
 
@@ -205,8 +205,8 @@ describe('web/api/leads handler', () => {
 
   it('rejects read-only scan company domains without public DNS records', async () => {
     process.env.RESEND_API_KEY = 're_test_key';
-    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
-    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    process.env.LEAD_NOTIFY_TO = 'contact@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <contact@identrail.com>';
     mockCompanyDomainDNS(false);
     const fetchMock = vi.fn(async () => ({ ok: true }));
     vi.stubGlobal('fetch', fetchMock);
@@ -235,8 +235,8 @@ describe('web/api/leads handler', () => {
 
   it('rejects invalid public repository URLs for read-only scan requests', async () => {
     process.env.RESEND_API_KEY = 're_test_key';
-    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
-    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    process.env.LEAD_NOTIFY_TO = 'contact@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <contact@identrail.com>';
     const fetchMock = vi.fn(async () => ({ ok: true }));
     vi.stubGlobal('fetch', fetchMock);
 
@@ -267,8 +267,8 @@ describe('web/api/leads handler', () => {
 
   it('rejects non-string public repository URL values without throwing', async () => {
     process.env.RESEND_API_KEY = 're_test_key';
-    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
-    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    process.env.LEAD_NOTIFY_TO = 'contact@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <contact@identrail.com>';
     const fetchMock = vi.fn(async () => ({ ok: true }));
     vi.stubGlobal('fetch', fetchMock);
 
@@ -299,8 +299,8 @@ describe('web/api/leads handler', () => {
 
   it('rejects non-web public repository URL schemes', async () => {
     process.env.RESEND_API_KEY = 're_test_key';
-    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
-    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    process.env.LEAD_NOTIFY_TO = 'contact@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <contact@identrail.com>';
     const fetchMock = vi.fn(async () => ({ ok: true }));
     vi.stubGlobal('fetch', fetchMock);
 
@@ -331,8 +331,8 @@ describe('web/api/leads handler', () => {
 
   it('treats a stalled DNS resolver as no public records instead of hanging', async () => {
     process.env.RESEND_API_KEY = 're_test_key';
-    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
-    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    process.env.LEAD_NOTIFY_TO = 'contact@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <contact@identrail.com>';
     resolve4Mock.mockReset();
     resolve6Mock.mockReset();
     resolveMxMock.mockReset();
@@ -557,8 +557,8 @@ describe('web/api/leads handler', () => {
 
   it('sends internal and confirmation emails through Resend when configured', async () => {
     process.env.RESEND_API_KEY = 're_test_key';
-    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com, security@identrail.com';
-    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    process.env.LEAD_NOTIFY_TO = 'contact@identrail.com, marketing@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <contact@identrail.com>';
     const fetchMock = vi.fn(async () => ({ ok: true }));
     vi.stubGlobal('fetch', fetchMock);
 
@@ -597,8 +597,8 @@ describe('web/api/leads handler', () => {
     expect(notificationHeaders['Idempotency-Key']).toMatch(/lead-notification$/);
     const notificationBody = JSON.parse(String(notificationInit.body));
     expect(notificationBody).toMatchObject({
-      from: 'Identrail <scan@identrail.com>',
-      to: ['sales@identrail.com', 'security@identrail.com'],
+      from: 'Identrail <contact@identrail.com>',
+      to: ['contact@identrail.com', 'marketing@identrail.com'],
       reply_to: 'security@company.com',
       subject: '[Identrail] New risk scan request from Company Inc (security@company.com)'
     });
@@ -612,16 +612,16 @@ describe('web/api/leads handler', () => {
     const confirmationHeaders = (confirmationInit.headers ?? {}) as Record<string, string>;
     expect(confirmationHeaders['Idempotency-Key']).toMatch(/lead-confirmation$/);
     expect(JSON.parse(String(confirmationInit.body))).toMatchObject({
-      from: 'Identrail <scan@identrail.com>',
+      from: 'Identrail <contact@identrail.com>',
       to: 'security@company.com',
-      reply_to: 'sales@identrail.com',
+      reply_to: 'contact@identrail.com',
       subject: 'We received your Identrail risk scan request'
     });
   });
 
   it('requires an explicit sender address for Resend delivery', async () => {
     process.env.RESEND_API_KEY = 're_test_key';
-    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
+    process.env.LEAD_NOTIFY_TO = 'contact@identrail.com';
     const fetchMock = vi.fn(async () => ({ ok: true }));
     vi.stubGlobal('fetch', fetchMock);
 
@@ -644,8 +644,8 @@ describe('web/api/leads handler', () => {
 
   it('can disable requester confirmation while still notifying the team', async () => {
     process.env.RESEND_API_KEY = 're_test_key';
-    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
-    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    process.env.LEAD_NOTIFY_TO = 'contact@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <contact@identrail.com>';
     process.env.LEAD_CONFIRMATION_ENABLED = 'false';
     const fetchMock = vi.fn(async () => ({ ok: true }));
     vi.stubGlobal('fetch', fetchMock);
@@ -668,8 +668,8 @@ describe('web/api/leads handler', () => {
 
   it('accepts the lead when requester confirmation fails after notifying the team', async () => {
     process.env.RESEND_API_KEY = 're_test_key';
-    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
-    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    process.env.LEAD_NOTIFY_TO = 'contact@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <contact@identrail.com>';
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: true })
@@ -699,8 +699,8 @@ describe('web/api/leads handler', () => {
 
   it('returns 502 when Resend email delivery fails', async () => {
     process.env.RESEND_API_KEY = 're_test_key';
-    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
-    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    process.env.LEAD_NOTIFY_TO = 'contact@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <contact@identrail.com>';
     const fetchMock = vi.fn(async () => ({ ok: false }));
     vi.stubGlobal('fetch', fetchMock);
 
@@ -722,8 +722,8 @@ describe('web/api/leads handler', () => {
 
   it('still forwards to the webhook when Resend email delivery fails', async () => {
     process.env.RESEND_API_KEY = 're_test_key';
-    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
-    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    process.env.LEAD_NOTIFY_TO = 'contact@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <contact@identrail.com>';
     process.env.LEAD_WEBHOOK_URL = 'https://example.test/webhook';
     const fetchMock = vi
       .fn()
@@ -763,8 +763,8 @@ describe('web/api/leads handler', () => {
 
   it('accepts the lead when Resend succeeds and optional webhook forwarding fails', async () => {
     process.env.RESEND_API_KEY = 're_test_key';
-    process.env.LEAD_NOTIFY_TO = 'sales@identrail.com';
-    process.env.LEAD_EMAIL_FROM = 'Identrail <scan@identrail.com>';
+    process.env.LEAD_NOTIFY_TO = 'contact@identrail.com';
+    process.env.LEAD_EMAIL_FROM = 'Identrail <contact@identrail.com>';
     process.env.LEAD_CONFIRMATION_ENABLED = 'false';
     process.env.LEAD_WEBHOOK_URL = 'https://example.test/webhook';
     const fetchMock = vi

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -628,9 +628,9 @@ describe('App', () => {
     expect(screen.getByRole('heading', { level: 3, name: /Google sign-in data accessed/i })).toBeInTheDocument();
     expect(screen.getByText(/Identrail does not use Google sign-in to access Gmail/i)).toBeInTheDocument();
     expect(screen.getByText(/Google API Services User Data Policy/i)).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /security@identrail.com/i })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /support@identrail.com/i })).toHaveAttribute(
       'href',
-      'mailto:security@identrail.com?subject=Privacy%20Request'
+      'mailto:support@identrail.com?subject=Privacy%20Request'
     );
   });
 
@@ -643,7 +643,7 @@ describe('App', () => {
     expect(screen.getByRole('heading', { level: 3, name: /Acceptance and scope/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 3, name: /Acceptable use/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 3, name: /Customer data and integrations/i })).toBeInTheDocument();
-    expect(screen.getByText(/Questions about these Terms of Use can be sent to security@identrail.com/i)).toBeInTheDocument();
+    expect(screen.getByText(/Questions about these Terms of Use can be sent to support@identrail.com/i)).toBeInTheDocument();
   });
 
   it('guards product shell routes and redirects unauthenticated users to sign-in', async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,6 +18,7 @@ import { SignInPage } from './pages/SignInPage';
 import { SignUpPage } from './pages/SignUpPage';
 import { WorkOSMFAPage } from './pages/WorkOSMFAPage';
 import { WhyNoPasswordsPage } from './pages/WhyNoPasswordsPage';
+import { siteEmails } from './siteConfig';
 import { ConnectPage } from './pages/onboarding/ConnectPage';
 import { InvitePage } from './pages/onboarding/InvitePage';
 import { OrgPage } from './pages/onboarding/OrgPage';
@@ -64,6 +65,8 @@ const DOCS_REPO = 'https://github.com/identrail/identrail/tree/dev/docs';
 const DISCORD_URL = 'https://discord.gg/7jSUSnQC';
 const LINKEDIN_URL = 'https://www.linkedin.com/company/identrail/';
 const X_URL = 'https://x.com/identrail';
+const SUPPORT_EMAIL = siteEmails.support;
+const SECURITY_EMAIL = siteEmails.security;
 const DEMO_BOOKING_PATH = '/demo#book-demo';
 const THEME_STORAGE_KEY = 'identrail-theme';
 const SCAN_CTA_LABEL = 'Request Trust Path Review';
@@ -4245,7 +4248,7 @@ function ResponsibleDisclosurePage() {
         variant="enterprise"
         actions={
           <>
-            <a className="idt-btn idt-btn-primary" href="mailto:security@identrail.com">
+            <a className="idt-btn idt-btn-primary" href={`mailto:${SECURITY_EMAIL}`}>
               Email Security
             </a>
             <Link to="/security" className="idt-btn idt-btn-dark">
@@ -4260,7 +4263,7 @@ function ResponsibleDisclosurePage() {
             <h2>How to report</h2>
             <ul>
               <li>
-                Email <a href="mailto:security@identrail.com">security@identrail.com</a> with detailed findings and
+                Email <a href={`mailto:${SECURITY_EMAIL}`}>{SECURITY_EMAIL}</a> with detailed findings and
                 proof-of-concept steps
               </li>
               <li>Include reproduction steps, affected components, and potential impact</li>
@@ -4409,7 +4412,7 @@ function LegalPage({ title, body }: { title: string; body: string }) {
         variant="docs"
         actions={
           <>
-            <a className="idt-btn idt-btn-primary" href="mailto:security@identrail.com?subject=Privacy%20Choices">
+            <a className="idt-btn idt-btn-primary" href={`mailto:${SUPPORT_EMAIL}?subject=Privacy%20Choices`}>
               Contact Privacy
             </a>
             <Link to="/privacy" className="idt-btn idt-btn-dark">
@@ -4471,7 +4474,7 @@ const PRIVACY_POLICY_SECTIONS = [
     title: 'Retention and deletion',
     body: [
       'We retain Google-derived account data while your Identrail account is active or as needed to provide the service, comply with legal obligations, resolve disputes, enforce agreements, preserve security logs, and maintain backups.',
-      'You can request deletion of your account or Google-derived user data by emailing security@identrail.com with the subject Privacy Request. After verifying the request, we delete or de-identify applicable account data unless retention is required for security, legal, or operational reasons. Backup and log copies expire under our normal retention schedules.'
+      `You can request deletion of your account or Google-derived user data by emailing ${SUPPORT_EMAIL} with the subject Privacy Request. After verifying the request, we delete or de-identify applicable account data unless retention is required for security, legal, or operational reasons. Backup and log copies expire under our normal retention schedules.`
     ]
   },
   {
@@ -4536,7 +4539,7 @@ const TERMS_OF_USE_SECTIONS = [
     title: 'Changes and contact',
     body: [
       'We may update these terms as the product, legal requirements, or operating model changes. Material changes will be reflected on this page or communicated through appropriate product or account channels.',
-      'Questions about these Terms of Use can be sent to security@identrail.com.'
+      `Questions about these Terms of Use can be sent to ${SUPPORT_EMAIL}.`
     ]
   }
 ] as const;
@@ -4691,12 +4694,12 @@ function PrivacyPage() {
       summaryItems={[
         'Google sign-in is used for identity and account access, not for Gmail, Drive, Calendar, Contacts, or Workspace content.',
         'We do not sell personal data or use Google user data for advertising, retargeting, data brokerage, or credit decisions.',
-        'Deletion and privacy requests go directly to the security team so they can be verified and handled with care.'
+        'Deletion and privacy requests go directly to support so they can be verified and handled with care.'
       ]}
       meta={[
         { label: 'Last updated', value: 'May 18, 2026' },
         { label: 'Applies to', value: 'Website, sign-in, account, and hosted product experiences' },
-        { label: 'Primary contact', value: 'security@identrail.com' }
+        { label: 'Primary contact', value: SUPPORT_EMAIL }
       ]}
       sectionsTitle="Google user data disclosure"
       sectionsIntro="This section documents how Identrail interacts with Google user data when a user signs in or signs up with Google."
@@ -4705,11 +4708,11 @@ function PrivacyPage() {
       contactBody={
         <>
           For privacy questions, account deletion requests, or requests about Google-derived user data, email{' '}
-          <a href="mailto:security@identrail.com?subject=Privacy%20Request">security@identrail.com</a> with the
+          <a href={`mailto:${SUPPORT_EMAIL}?subject=Privacy%20Request`}>{SUPPORT_EMAIL}</a> with the
           subject Privacy Request.
         </>
       }
-      contactHref="mailto:security@identrail.com?subject=Privacy%20Request"
+      contactHref={`mailto:${SUPPORT_EMAIL}?subject=Privacy%20Request`}
       contactLabel="Start privacy request"
     />
   );
@@ -4744,9 +4747,9 @@ function TermsPage() {
       sectionsIntro="This page summarizes the obligations, restrictions, and operational expectations that apply when you use Identrail."
       sections={TERMS_OF_USE_SECTIONS}
       contactTitle="Terms questions"
-      contactBody="For questions about these terms, procurement reviews, or security-testing boundaries, email the Identrail security contact."
-      contactHref="mailto:security@identrail.com?subject=Terms%20of%20Use"
-      contactLabel="Email legal contact"
+      contactBody="For questions about these terms, procurement reviews, or security-testing boundaries, email Identrail support."
+      contactHref={`mailto:${SUPPORT_EMAIL}?subject=Terms%20of%20Use`}
+      contactLabel="Email support"
     />
   );
 }

--- a/web/src/components/layout/Footer.tsx
+++ b/web/src/components/layout/Footer.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import { SafeLink } from '../SafeLink';
-import { siteLinks } from '../../siteConfig';
+import { siteEmails, siteLinks } from '../../siteConfig';
 
 function GitHubIcon() {
   return (
@@ -57,6 +57,7 @@ export const FOOTER_TRUST_LINKS = [
   { label: 'FAQ', to: '/faq', external: false },
   { label: 'Privacy', to: '/privacy', external: false },
   { label: 'Terms', to: '/terms', external: false },
+  { label: 'Contact', to: `mailto:${siteEmails.contact}`, external: true },
   { label: 'Responsible Disclosure', to: '/responsible-disclosure', external: false },
   { label: 'Changelog', to: siteLinks.changelog, external: true }
 ] as const;

--- a/web/src/siteConfig.ts
+++ b/web/src/siteConfig.ts
@@ -1,3 +1,11 @@
+export const siteEmails = {
+  contact: 'contact@identrail.com',
+  support: 'support@identrail.com',
+  security: 'security@identrail.com',
+  marketing: 'marketing@identrail.com',
+  founder: 'founder@identrail.com'
+} as const;
+
 export const siteLinks = {
   app: '/app',
   signIn: '/signin',
@@ -41,7 +49,7 @@ export const siteLinks = {
   legalCookies: '/privacy-choices',
   security: '/security',
   trustCenter: '/security', // TODO: add dedicated /trust-center route later.
-  contact: '/responsible-disclosure',
+  contact: `mailto:${siteEmails.contact}`,
   changelog: 'https://github.com/identrail/identrail/blob/dev/CHANGELOG.md',
   linkedin: 'https://www.linkedin.com/company/identrail',
   x: 'https://x.com/identrail'


### PR DESCRIPTION
No issue: aligns public and operational contact routes with the newly configured Identrail mailboxes.

## What changed
- Added a centralized `siteEmails` map for `contact`, `support`, `security`, `marketing`, and `founder` addresses.
- Routed website footer contact links to `contact@identrail.com`.
- Kept responsible disclosure on `security@identrail.com` and moved privacy, deletion, terms, and support surfaces to `support@identrail.com`.
- Updated lead-capture examples/tests to use `contact@identrail.com` as the sender and `contact@identrail.com,marketing@identrail.com` as internal recipients.
- Added `docs/email-routing.md` to document where each mailbox should be used.
- Updated GitHub issue-template support guidance to point account/access help to `support@identrail.com`.

## Why
The project now has real Identrail mailboxes in Zoho. This prevents `security@identrail.com` from becoming a catch-all address and gives each public/product surface a clear owner.

## Impact and risk
- Public security reporting remains unchanged.
- Privacy and terms requests now route to support instead of security.
- Lead notification examples now match the configured inboxes.
- Risk is low; this is routing/copy/configuration documentation plus matching tests.

## Validation
- `npm test -- --run src/App.test.tsx api/leads.test.ts` - 88 tests passed
- `npm run build` - Vite build and 41-route prerender passed
- `git diff --check` - passed
- Push hooks passed: merge-conflict check, YAML check, EOF/whitespace checks, gofmt check, go vet, local env token hygiene, Vercel artifact hygiene

## AI-assisted disclosure
- AI-assisted: yes
- Tools used: Codex
- Where used: repository inspection, implementation, test updates, documentation, validation, and PR preparation
- Human verification performed: reviewed the scoped diff and ran the validation commands listed above


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized email routing and updated public contact paths to Identrail’s new mailboxes. Security reports stay on `security@identrail.com`; privacy, terms, deletion, and support now route to `support@identrail.com`.

- **New Features**
  - Added `siteEmails` map for `contact`, `support`, `security`, `marketing`, and `founder`.
  - Footer “Contact” now links to `contact@identrail.com`; responsible disclosure still uses `security@identrail.com`.
  - Lead-capture defaults set to `Identrail <contact@identrail.com>` and notify `contact@identrail.com,marketing@identrail.com` (examples/tests aligned).
  - Added `docs/email-routing.md` and linked it in docs; updated configuration reference.
  - Issue template now directs account/access questions to `support@identrail.com`.

<sup>Written for commit 8b4619aa75f49d8866cef7ff0a520dfc68419b8a. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1319?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

