### PR TITLE
Fix website booking prompt contrast

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -246,6 +246,16 @@ describe('App', () => {
     expect(document.querySelector('a[href*="calendly"]')).not.toBeInTheDocument();
   });
 
+  it('routes shared sales CTAs to the marketing mailbox', () => {
+    setCurrentPath('/enterprise');
+    render(<App />);
+
+    expect(screen.getByRole('link', { name: /Talk to Sales/i })).toHaveAttribute(
+      'href',
+      'mailto:marketing@identrail.com?subject=Identrail%20demo%20and%20sales%20conversation'
+    );
+  });
+
   it.each([
     ['l', '/signin'],
     ['S', '/signup']

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -67,7 +67,9 @@ const LINKEDIN_URL = 'https://www.linkedin.com/company/identrail/';
 const X_URL = 'https://x.com/identrail';
 const SUPPORT_EMAIL = siteEmails.support;
 const SECURITY_EMAIL = siteEmails.security;
+const MARKETING_EMAIL = siteEmails.marketing;
 const DEMO_BOOKING_PATH = '/demo#book-demo';
+const SALES_MAILTO = `mailto:${MARKETING_EMAIL}?subject=Identrail%20demo%20and%20sales%20conversation`;
 const THEME_STORAGE_KEY = 'identrail-theme';
 const SCAN_CTA_LABEL = 'Request Trust Path Review';
 const INTAKE_TOTAL_STEPS = 4;
@@ -1582,9 +1584,9 @@ function BookingPrompt() {
             <Link to={DEMO_BOOKING_PATH} className="idt-btn idt-btn-primary">
               Choose Demo Time
             </Link>
-            <Link to="/enterprise" className="idt-btn idt-btn-dark">
+            <a href={SALES_MAILTO} className="idt-btn idt-btn-dark">
               Talk to Sales
-            </Link>
+            </a>
           </div>
         </article>
         <aside className="idt-booking-prompt-preview" aria-label="Demo agenda preview">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -17419,6 +17419,23 @@ html[data-theme='light'] .idt-modern-public-page .idt-blog-section h2 {
   color: #ffffff;
 }
 
+/* Keep the shared booking prompt legible when it sits inside modern public pages. */
+html[data-theme='light'] .idt-modern-public-page .idt-booking-prompt .idt-section-title h2 {
+  color: #183056;
+}
+
+html[data-theme='light'] .idt-modern-public-page .idt-booking-prompt .idt-section-title p,
+html[data-theme='light'] .idt-modern-public-page .idt-booking-prompt-note,
+html[data-theme='light'] .idt-modern-public-page .idt-booking-prompt-checklist,
+html[data-theme='light'] .idt-modern-public-page .idt-booking-prompt-preview ol {
+  color: #2f486f;
+}
+
+html[data-theme='light'] .idt-modern-public-page .idt-booking-prompt .idt-section-title .idt-eyebrow,
+html[data-theme='light'] .idt-modern-public-page .idt-booking-prompt-preview .idt-eyebrow {
+  color: #5d79a4;
+}
+
 .idt-modern-public-page .idt-card,
 .idt-modern-public-page .idt-lead-form,
 .idt-modern-public-page .idt-table-wrap,


### PR DESCRIPTION
No issue: direct website polish request for washed-out booking CTA contrast.

## What changed
- Kept the shared booking prompt readable inside modern public pages in light theme.
- Routed the shared `Talk to Sales` CTA to `mailto:marketing@identrail.com` with a sales/demo subject.
- Added regression coverage for the shared sales CTA target.

## Why it changed
The modern public page heading rule forced shared section titles to white. On the pale booking prompt card, that made the main heading look washed out and hard to read. Sales/demo conversations should also go to the marketing mailbox instead of support, since support is better for existing-user help.

## Impact and risk
Low. The CSS override is scoped to the reusable booking prompt in light theme, and the CTA change only affects that shared sales link.

## Validation
- [x] New/changed behavior has test coverage
- [x] Docs and changelog are updated when needed: not needed for website polish
- [x] CI-relevant checks were run locally for touched areas
- [x] No secrets or credentials are present in code, tests, or logs

Commands run:
- `npm run test --prefix web -- --run src/App.test.tsx`
- `npm run build --prefix web`
- `git diff --check`

## AI disclosure
- `AI-assisted: yes`
- `Tools used: Codex`
- `Where used: web/src/App.tsx, web/src/App.test.tsx, web/src/styles.css`
- `Human verification performed: reviewed the scoped diff, ran the App test suite, ran the production web build/prerender, and checked whitespace with git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes washed-out contrast in the booking prompt on modern public pages (light theme) and routes the Talk to Sales CTA to the marketing mailbox with a demo/sales subject. Improves readability and sends inquiries to the right team.

- **Bug Fixes**
  - Scoped CSS keeps booking prompt titles and copy readable in light theme.
  - "Talk to Sales" now opens mailto:marketing@identrail.com with the demo/sales subject.
  - Added regression test for the CTA target.

<sup>Written for commit e487a0cc093d546ee6beff498bf5349ca0aad8bb. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1321?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

