### PR TITLE
Use GitHub native app install picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@
   grid to the consolidated four-column layout.
 - Simplified hosted GitHub App setup to rely on GitHub's native account picker
   instead of duplicating personal-account and organization selection in the app.
-  The versioned GitHub App manifest now includes the callback URL, setup URL,
-  and redirect-on-update flag, and operators can compare live app settings with
+  The versioned GitHub App manifest now includes the callback URL and setup URL,
+  keeps update redirects disabled (repository selection changes sync through the
+  `installation_repositories` webhook rather than a stateless redirect that the
+  callback cannot complete), and operators can compare live app settings with
   `scripts/check_github_app_manifest.py`.
 - Reworked the repository Findings page information architecture. Consolidated
   the ten summary tiles into four (open, critical, mean-time-to-fix, completed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
   labels from all-caps to sentence case, styled the new metric captions, the
   scan-health banner, and the failed-scan state actions, and set the summary
   grid to the consolidated four-column layout.
+- Simplified hosted GitHub App setup to rely on GitHub's native account picker
+  instead of duplicating personal-account and organization selection in the app.
+  The versioned GitHub App manifest now includes the callback URL, setup URL,
+  and redirect-on-update flag, and operators can compare live app settings with
+  `scripts/check_github_app_manifest.py`.
 - Reworked the repository Findings page information architecture. Consolidated
   the ten summary tiles into four (open, critical, mean-time-to-fix, completed
   scans) with supporting detail in captions, led with the findings table by
@@ -54,9 +59,8 @@
   instead of raw JSON, login no longer provisions unknown identities, signup can
   reactivate a deactivated/deleted account that still owns the same email, login
   now points retained removed accounts to the reactivation signup path, and the
-  GitHub App setup now opens GitHub's account selector in a new tab with an
-  explicit personal account versus organization choice, backed by a public app
-  manifest for Any-account installation.
+  GitHub App setup now opens GitHub's account selector in a new tab, backed by a
+  public app manifest for Any-account installation.
 - Fixed app workspace navigation so route changes inside an already-validated
   workspace no longer rerun the full session gate, and hardened repository
   finding display helpers against partially populated API records.

--- a/deploy/connectors/github/app-manifest.json
+++ b/deploy/connectors/github/app-manifest.json
@@ -6,6 +6,11 @@
     "active": true
   },
   "redirect_url": "https://app.identrail.com/app/github/callback",
+  "callback_urls": [
+    "https://app.identrail.com/app/github/callback"
+  ],
+  "setup_url": "https://app.identrail.com/app/github/callback",
+  "setup_on_update": true,
   "public": true,
   "default_permissions": {
     "actions": "read",

--- a/deploy/connectors/github/app-manifest.json
+++ b/deploy/connectors/github/app-manifest.json
@@ -10,7 +10,7 @@
     "https://app.identrail.com/app/github/callback"
   ],
   "setup_url": "https://app.identrail.com/app/github/callback",
-  "setup_on_update": true,
+  "setup_on_update": false,
   "public": true,
   "default_permissions": {
     "actions": "read",

--- a/docs/auth/github-connector.md
+++ b/docs/auth/github-connector.md
@@ -22,12 +22,12 @@ Older project-scoped GitHub routes are not the product path. They remain interna
 ## Hosted GitHub.com Flow
 
 `POST /v1/connectors/github` creates a pending connector and returns a GitHub
-App target-picker URL. The product asks whether the user expects to install on a
-personal account or an organization, opens GitHub in a new tab, and keeps a
+App target-picker URL. The product opens GitHub in a new tab and keeps a
 fallback button visible if the browser blocks navigation. The URL starts at
-GitHub's account selector (`/installations/select_target`) so GitHub shows the
-personal-account or organization choice before the selected-repository screen.
-The product sends GitHub back to `/app/github/callback`, and that callback calls
+GitHub's account selector (`/installations/select_target`) so GitHub, not
+Identrail, shows the personal-account or organization choice before the
+selected-repository screen. The product sends GitHub back to
+`/app/github/callback`, and that callback calls
 `POST /v1/connectors/github/complete` with the returned state and installation
 ID. The backend owns the GitHub App slug and webhook secret through environment
 variables, so users do not paste app credentials into the browser.
@@ -42,7 +42,31 @@ Required runtime configuration for the hosted GitHub App flow:
   `IDENTRAIL_CONNECTOR_SECRET_KEYS_REQUIRED=true` for durable connector
   credential storage
 
-The GitHub App manifest lives at `deploy/connectors/github/app-manifest.json`. It requests read-only permissions for repository metadata, contents, pull requests, administration settings, Actions settings, repository environments, code scanning alerts, secret scanning alerts, Dependabot alerts, and repository webhooks. The manifest is public so GitHub can offer both personal-account and organization installation targets; production app settings should keep "Where can this GitHub App be installed?" on "Any account" rather than "Only on this account." If the production app remains private, GitHub may still only offer the app owner account even when Identrail starts at the account selector.
+The GitHub App manifest lives at `deploy/connectors/github/app-manifest.json`.
+It requests read-only permissions for repository metadata, contents, pull
+requests, administration settings, Actions settings, repository environments,
+code scanning alerts, secret scanning alerts, Dependabot alerts, and repository
+webhooks. The manifest is public so GitHub can offer both personal-account and
+organization installation targets; production app settings should keep "Where
+can this GitHub App be installed?" on "Any account" rather than "Only on this
+account." If the production app remains private, GitHub may still only offer the
+app owner account even when Identrail starts at the account selector.
+
+Before launching or after changing GitHub App settings, compare the public app
+registration against the manifest:
+
+```bash
+python3 scripts/check_github_app_manifest.py --slug identrail
+```
+
+This check intentionally uses GitHub's public app endpoint. A private app or
+wrong slug should fail even if a maintainer can view the app while signed in.
+GitHub does not expose every setting through that public endpoint, so operators
+must also confirm in the GitHub App settings that:
+
+- Setup URL is `https://app.identrail.com/app/github/callback`.
+- Redirect on update is enabled.
+- "Where can this GitHub App be installed?" is set to Any account.
 
 For Identrail Cloud, the AWS API manual deploy workflow exposes first-class
 inputs for this path:

--- a/docs/auth/github-connector.md
+++ b/docs/auth/github-connector.md
@@ -65,7 +65,8 @@ GitHub does not expose every setting through that public endpoint, so operators
 must also confirm in the GitHub App settings that:
 
 - Setup URL is `https://app.identrail.com/app/github/callback`.
-- Redirect on update is enabled.
+- Redirect on update is disabled; repository-access changes sync through the
+  `installation_repositories` webhook.
 - "Where can this GitHub App be installed?" is set to Any account.
 
 For Identrail Cloud, the AWS API manual deploy workflow exposes first-class

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -150,6 +150,16 @@ deploys. Configure these values before running the manual workflow, or set
   the durable `IDENTRAIL_CONNECTOR_SECRET_KEYS` keyset used to encrypt connector
   credentials.
 
+The GitHub App itself must be public / installable on Any account for GitHub to
+show the account picker with personal and organization targets. The app settings
+must also use `https://app.identrail.com/app/github/callback` as the setup URL
+and enable redirect-on-update so repository selection changes return to
+Identrail. Run this before a production deploy when GitHub App settings change:
+
+```bash
+python3 scripts/check_github_app_manifest.py --slug "${API_GITHUB_APP_NAME}"
+```
+
 The workflow dispatch input `api_container_image` must be immutable, such as
 `ghcr.io/identrail/identrail-api:sha-<commit>`. Do not deploy the mutable `dev`
 tag to this hosted API path.

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -152,9 +152,12 @@ deploys. Configure these values before running the manual workflow, or set
 
 The GitHub App itself must be public / installable on Any account for GitHub to
 show the account picker with personal and organization targets. The app settings
-must also use `https://app.identrail.com/app/github/callback` as the setup URL
-and enable redirect-on-update so repository selection changes return to
-Identrail. Run this before a production deploy when GitHub App settings change:
+must also use `https://app.identrail.com/app/github/callback` as the setup URL.
+Leave "Redirect on update" disabled: update redirects do not carry the install
+state token the callback requires, so enabling it would route users to an error
+page — repository selection changes are reconciled through the
+`installation_repositories` webhook instead. Run this before a production deploy
+when GitHub App settings change:
 
 ```bash
 python3 scripts/check_github_app_manifest.py --slug "${API_GITHUB_APP_NAME}"

--- a/scripts/check_github_app_manifest.py
+++ b/scripts/check_github_app_manifest.py
@@ -105,8 +105,12 @@ def compare(manifest: dict[str, Any], live: dict[str, Any]) -> list[str]:
         failures.append("manifest setup_url is required so GitHub can return users after install")
     if setup_url and setup_url not in callback_urls:
         failures.append("manifest callback_urls must include setup_url")
-    if manifest.get("setup_on_update") is not True:
-        failures.append("manifest setup_on_update must be true so repository selection updates return to Identrail")
+    if manifest.get("setup_on_update") is not False:
+        failures.append(
+            "manifest setup_on_update must be false: update redirects arrive without an install "
+            "state token, and the callback requires one, so enabling it sends users to an error "
+            "page. Repository selection changes already sync via the installation_repositories webhook."
+        )
 
     expected_name = str(manifest.get("name", "")).strip()
     live_name = str(live.get("name", "")).strip()

--- a/scripts/check_github_app_manifest.py
+++ b/scripts/check_github_app_manifest.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Check the production GitHub App against the versioned manifest.
+
+This intentionally uses GitHub's unauthenticated public app endpoint. A private
+or owner-only app should fail this check even if a maintainer token could see it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import ssl
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_MANIFEST = Path("deploy/connectors/github/app-manifest.json")
+APP_SLUG_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,98}[a-z0-9])?$")
+SYSTEM_CA_FILES = (
+    "/etc/ssl/cert.pem",
+    "/usr/local/etc/openssl@3/cert.pem",
+    "/opt/homebrew/etc/openssl@3/cert.pem",
+)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def app_slug(manifest: dict[str, Any], explicit: str) -> str:
+    if explicit:
+        slug = explicit.strip().lower()
+    else:
+        name = str(manifest.get("name", "")).strip().lower()
+        slug = re.sub(r"[^a-z0-9]+", "-", name).strip("-")
+    if not APP_SLUG_PATTERN.fullmatch(slug):
+        raise ValueError(f"invalid GitHub App slug: {slug!r}")
+    return slug
+
+
+def ssl_context() -> ssl.SSLContext:
+    paths = ssl.get_default_verify_paths()
+    if paths.cafile:
+        return ssl.create_default_context()
+    for candidate in SYSTEM_CA_FILES:
+        path = Path(candidate)
+        if path.exists():
+            return ssl.create_default_context(cafile=str(path))
+    return ssl.create_default_context()
+
+
+def fetch_public_app(slug: str) -> dict[str, Any]:
+    request = urllib.request.Request(
+        f"https://api.github.com/apps/{slug}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "identrail-github-app-manifest-check",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15, context=ssl_context()) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            raise RuntimeError(
+                f"GitHub App {slug!r} is not visible from the public app endpoint. "
+                "Check that the production app slug is correct and that the app is public / installable on Any account."
+            ) from error
+        raise
+    if not isinstance(payload, dict):
+        raise RuntimeError("GitHub returned an unexpected app payload")
+    return payload
+
+
+def sorted_strings(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return sorted(str(item).strip() for item in value if str(item).strip())
+
+
+def string_map(value: Any) -> dict[str, str]:
+    if not isinstance(value, dict):
+        return {}
+    return {str(key): str(item) for key, item in value.items()}
+
+
+def compare(manifest: dict[str, Any], live: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    if manifest.get("public") is not True:
+        failures.append("manifest public must be true so GitHub can show personal and organization install targets")
+
+    setup_url = str(manifest.get("setup_url", "")).strip()
+    callback_urls = sorted_strings(manifest.get("callback_urls"))
+    if not setup_url:
+        failures.append("manifest setup_url is required so GitHub can return users after install")
+    if setup_url and setup_url not in callback_urls:
+        failures.append("manifest callback_urls must include setup_url")
+    if manifest.get("setup_on_update") is not True:
+        failures.append("manifest setup_on_update must be true so repository selection updates return to Identrail")
+
+    expected_name = str(manifest.get("name", "")).strip()
+    live_name = str(live.get("name", "")).strip()
+    if expected_name and live_name and expected_name != live_name:
+        failures.append(f"app name mismatch: manifest={expected_name!r} live={live_name!r}")
+
+    expected_url = str(manifest.get("url", "")).strip().rstrip("/")
+    live_url = str(live.get("external_url", "")).strip().rstrip("/")
+    if expected_url and live_url and expected_url != live_url:
+        failures.append(f"homepage URL mismatch: manifest={expected_url!r} live={live_url!r}")
+
+    expected_permissions = string_map(manifest.get("default_permissions"))
+    live_permissions = string_map(live.get("permissions"))
+    if expected_permissions != live_permissions:
+        failures.append(
+            "permission mismatch:\n"
+            f"  manifest={json.dumps(expected_permissions, sort_keys=True)}\n"
+            f"  live={json.dumps(live_permissions, sort_keys=True)}"
+        )
+
+    expected_events = sorted_strings(manifest.get("default_events"))
+    live_events = sorted_strings(live.get("events"))
+    if expected_events != live_events:
+        failures.append(
+            "event subscription mismatch:\n"
+            f"  manifest={json.dumps(expected_events)}\n"
+            f"  live={json.dumps(live_events)}"
+        )
+
+    if setup_url:
+        warnings.append("GitHub's public app endpoint does not expose setup_url; confirm it in GitHub App settings.")
+
+    return failures + [f"warning: {warning}" for warning in warnings]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--slug", default="", help="GitHub App slug. Defaults to the manifest name slug.")
+    args = parser.parse_args()
+
+    try:
+        manifest = load_json(args.manifest)
+        slug = app_slug(manifest, args.slug)
+        live = fetch_public_app(slug)
+        messages = compare(manifest, live)
+    except Exception as error:  # noqa: BLE001 - command-line diagnostics should be direct.
+        print(f"GitHub App manifest check failed: {error}", file=sys.stderr)
+        return 1
+
+    failures = [message for message in messages if not message.startswith("warning: ")]
+    warnings = [message for message in messages if message.startswith("warning: ")]
+    for warning in warnings:
+        print(warning, file=sys.stderr)
+    if failures:
+        print("GitHub App manifest check failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+    print(f"GitHub App {slug!r} matches {args.manifest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -411,7 +411,7 @@ describe('ProductProjectDetailPage', () => {
     );
   });
 
-  it('opens GitHub installation in a new tab for the selected account type', async () => {
+  it('opens GitHub installation in a new tab through GitHub account picker', async () => {
     const assign = vi.fn();
     const close = vi.fn();
     const popup = {
@@ -426,14 +426,11 @@ describe('ProductProjectDetailPage', () => {
     const { startGitHubConnector } = await renderProjectDetail(true);
 
     expect(await screen.findByText('Install the GitHub App')).toBeInTheDocument();
-    const installTarget = screen.getByRole('group', { name: /Install on/i });
-    fireEvent.click(within(installTarget).getByRole('radio', { name: /Organization/i }));
-    expect(within(installTarget).getByRole('radio', { name: /Organization/i })).toBeChecked();
     fireEvent.click(screen.getByRole('button', { name: /Continue to GitHub/i }));
 
     await waitFor(() =>
       expect(startGitHubConnector).toHaveBeenCalledWith(
-        expect.objectContaining({ install_account_type: 'organization' }),
+        expect.not.objectContaining({ install_account_type: expect.anything() }),
         expect.any(Object)
       )
     );

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -84,7 +84,6 @@ type ScopeRouteParams = {
 };
 
 type SourceProvider = 'github' | 'aws' | 'kubernetes';
-type GitHubInstallAccountType = 'personal' | 'organization';
 
 type SourceConnectionMap = {
   github?: GitHubConnectionStatus;
@@ -739,16 +738,6 @@ function closeGitHubInstallWindow(popup: Window | null) {
   } catch {
     // Ignore browser restrictions after the tab has navigated away.
   }
-}
-
-function describeGitHubInstallAccountType(value: GitHubConnectorStartResponse['install_account_type']) {
-  if (value === 'organization') {
-    return 'an organization';
-  }
-  if (value === 'personal') {
-    return 'a personal account';
-  }
-  return 'a personal account or organization';
 }
 
 function formatRepoScanSubmitError(error: unknown): string {
@@ -3753,8 +3742,7 @@ export function ProductProjectDetailPage() {
   const [successMessage, setSuccessMessage] = useState('');
   const [githubStart, setGitHubStart] = useState<GitHubConnectorStartResponse | null>(null);
   const [githubAppForm, setGitHubAppForm] = useState({
-    displayName: 'GitHub App',
-    installAccountType: 'personal' as GitHubInstallAccountType
+    displayName: 'GitHub App'
   });
   const [githubPATForm, setGitHubPATForm] = useState({
     displayName: 'GitHub Enterprise',
@@ -4205,7 +4193,6 @@ export function ProductProjectDetailPage() {
           workspace_id: scope.workspaceID,
           project_id: projectID,
           display_name: normalizeValue(githubAppForm.displayName) || undefined,
-          install_account_type: githubAppForm.installAccountType,
           redirect_uri: redirectURI
         },
         auth
@@ -4834,7 +4821,7 @@ export function ProductProjectDetailPage() {
                 <div>
                   <p className="idt-app-kicker">Recommended setup</p>
                   <h4>Install the GitHub App</h4>
-                  <p>Choose a personal account or organization on GitHub, then select the repositories Identrail can read.</p>
+                  <p>GitHub will ask whether to install on your personal account or an organization, then let you choose repositories.</p>
                 </div>
                 <form className="idt-app-form" onSubmit={handleGitHubStart}>
                   <label>
@@ -4847,40 +4834,6 @@ export function ProductProjectDetailPage() {
                       placeholder="GitHub App"
                     />
                   </label>
-                  <fieldset className="idt-source-account-choice" aria-describedby="github-install-target-help">
-                    <legend>Install on</legend>
-                    <p id="github-install-target-help">
-                      GitHub opens an account picker next. Choose where the repositories live.
-                    </p>
-                    <div className="idt-source-account-options">
-                      {(
-                        [
-                          ['personal', 'Personal account', 'Repos owned by your GitHub user'],
-                          ['organization', 'Organization', 'Repos owned by a GitHub organization']
-                        ] as const
-                      ).map(([value, label, caption]) => (
-                        <label
-                          key={value}
-                          className={githubAppForm.installAccountType === value ? 'is-selected' : ''}
-                        >
-                          <input
-                            type="radio"
-                            name="github-install-account-type"
-                            value={value}
-                            checked={githubAppForm.installAccountType === value}
-                            disabled={submitting !== ''}
-                            onChange={() =>
-                              setGitHubAppForm((current) => ({ ...current, installAccountType: value }))
-                            }
-                          />
-                          <span className="idt-source-account-radio" aria-hidden="true" />
-                          <strong>{label}</strong>
-                          <span className="idt-source-account-caption">{caption}</span>
-                          <em>{githubAppForm.installAccountType === value ? 'Selected' : 'Choose'}</em>
-                        </label>
-                      ))}
-                    </div>
-                  </fieldset>
                   <button className="idt-btn idt-btn-primary" type="submit" disabled={submitting !== ''}>
                     {submitting === 'github' ? 'Preparing GitHub...' : 'Continue to GitHub'}
                   </button>
@@ -4892,8 +4845,7 @@ export function ProductProjectDetailPage() {
                   <div>
                     <h4>GitHub did not open automatically?</h4>
                     <p>
-                      Continue with {describeGitHubInstallAccountType(githubStart.install_account_type)}.
-                      State expires {formatConnectionTime(githubStart.expires_at)}.
+                      Open GitHub's account picker. State expires {formatConnectionTime(githubStart.expires_at)}.
                     </p>
                   </div>
                   <a className="idt-btn idt-btn-dark" href={githubStart.install_url} target="_blank" rel="noreferrer">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5847,129 +5847,6 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.idt-source-account-choice {
-  display: grid;
-  gap: 0.45rem;
-  margin: 0;
-  padding: 0;
-  border: 0;
-}
-
-.idt-source-account-choice legend {
-  padding: 0;
-  color: #2b456c;
-  font-size: 0.95rem;
-  font-weight: 800;
-}
-
-.idt-source-account-choice p {
-  margin: 0;
-  color: #35598d;
-  font-size: 0.88rem;
-  line-height: 1.45;
-}
-
-html:not([data-theme='light']) .idt-source-account-choice legend {
-  color: #e8f1ff;
-}
-
-html:not([data-theme='light']) .idt-source-account-choice p {
-  color: #aebfda;
-}
-
-.idt-source-account-options {
-  display: grid;
-  gap: 0.65rem;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.idt-source-account-options label {
-  position: relative;
-  min-height: 5rem;
-  border: 1px solid rgba(130, 160, 214, 0.38);
-  border-radius: 0.55rem;
-  background: rgba(10, 16, 28, 0.96);
-  color: #f4f8ff;
-  cursor: pointer;
-  display: grid;
-  gap: 0.2rem 0.65rem;
-  grid-template-columns: 1.1rem minmax(0, 1fr) auto;
-  grid-template-areas:
-    "radio title state"
-    "radio caption caption";
-  align-items: start;
-  padding: 0.75rem 0.85rem;
-  text-align: left;
-  transition:
-    background 0.16s ease,
-    border-color 0.16s ease,
-    box-shadow 0.16s ease;
-}
-
-.idt-source-account-options label:hover,
-.idt-source-account-options label:has(input:focus-visible) {
-  border-color: rgba(143, 190, 255, 0.88);
-  box-shadow: 0 0 0 3px rgba(69, 125, 218, 0.22);
-}
-
-.idt-source-account-options label.is-selected {
-  border-color: rgba(79, 219, 145, 0.82);
-  background: rgba(16, 72, 51, 0.72);
-  box-shadow: 0 0 0 1px rgba(79, 219, 145, 0.22);
-}
-
-.idt-source-account-options input {
-  position: absolute;
-  opacity: 0;
-  pointer-events: none;
-}
-
-.idt-source-account-radio {
-  grid-area: radio;
-  width: 1rem;
-  height: 1rem;
-  border: 2px solid rgba(180, 200, 231, 0.78);
-  border-radius: 999px;
-  margin-top: 0.16rem;
-  background: rgba(5, 9, 16, 0.85);
-}
-
-.idt-source-account-options label.is-selected .idt-source-account-radio {
-  border-color: #7df0b3;
-  box-shadow: inset 0 0 0 3px rgba(10, 16, 28, 0.96);
-  background: #7df0b3;
-}
-
-.idt-source-account-options strong {
-  grid-area: title;
-  display: block;
-  color: #ffffff;
-  font-size: 0.95rem;
-  line-height: 1.25;
-}
-
-.idt-source-account-caption {
-  grid-area: caption;
-  color: #9eb4d5;
-  display: block;
-  font-size: 0.85rem;
-  line-height: 1.3;
-}
-
-.idt-source-account-options em {
-  grid-area: state;
-  color: #9eb4d5;
-  font-size: 0.75rem;
-  font-style: normal;
-  font-weight: 800;
-  line-height: 1.25;
-}
-
-.idt-source-account-options label.is-selected .idt-source-account-caption,
-.idt-source-account-options label.is-selected em {
-  color: #d8ffea;
-}
-
 .idt-app-form textarea,
 .idt-app-form select {
   border: 1px solid rgba(126, 157, 211, 0.35);
@@ -6268,22 +6145,6 @@ html[data-theme='light'] .idt-app-kicker {
 
 html[data-theme='light'] .idt-app-form label {
   color: #2b456c;
-}
-
-html[data-theme='light'] .idt-source-account-choice legend {
-  color: #2b456c;
-}
-
-html[data-theme='light'] .idt-source-account-choice p {
-  color: #35598d;
-}
-
-html[data-theme='light'] .idt-app-console-layout .idt-source-account-choice legend {
-  color: #e8f1ff;
-}
-
-html[data-theme='light'] .idt-app-console-layout .idt-source-account-choice p {
-  color: #aebfda;
 }
 
 html[data-theme='light'] .idt-app-form input {
@@ -7466,41 +7327,6 @@ html[data-theme='light'] .idt-app-form select {
   color: #1c355d;
   background: #ffffff;
   border-color: rgba(42, 71, 119, 0.32);
-}
-
-html[data-theme='light'] .idt-source-account-options label {
-  color: #f4f8ff;
-  background: rgba(10, 16, 28, 0.96);
-  border-color: rgba(130, 160, 214, 0.38);
-}
-
-html[data-theme='light'] .idt-source-account-options label:hover,
-html[data-theme='light'] .idt-source-account-options label:has(input:focus-visible) {
-  border-color: rgba(143, 190, 255, 0.88);
-  box-shadow: 0 0 0 3px rgba(69, 125, 218, 0.22);
-}
-
-html[data-theme='light'] .idt-source-account-options label.is-selected {
-  background: rgba(16, 72, 51, 0.72);
-  border-color: rgba(79, 219, 145, 0.82);
-  box-shadow: 0 0 0 1px rgba(79, 219, 145, 0.22);
-}
-
-html[data-theme='light'] .idt-source-account-options strong {
-  color: #ffffff;
-}
-
-html[data-theme='light'] .idt-source-account-caption {
-  color: #9eb4d5;
-}
-
-html[data-theme='light'] .idt-source-account-options em {
-  color: #9eb4d5;
-}
-
-html[data-theme='light'] .idt-source-account-options label.is-selected .idt-source-account-caption,
-html[data-theme='light'] .idt-source-account-options label.is-selected em {
-  color: #d8ffea;
 }
 
 html[data-theme='light'] .idt-source-diagnostics span {


### PR DESCRIPTION
Fixes #1322

## Summary

- remove the local personal/organization selector from the GitHub connector UI
- keep the product on GitHub's native account-picker install flow
- add callback/setup URL settings and explicitly keep GitHub App update redirects disabled
- add a manifest verifier for checking the live public GitHub App configuration

## Why

GitHub controls whether users can choose a personal account or organization. A local selector cannot fix a private or owner-only GitHub App, and it made the setup screen noisier without changing the real install target.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation

```bash
npm run test:ci --prefix web
npm run build --prefix web
git diff --check
python3 -m py_compile scripts/check_github_app_manifest.py
python3 scripts/check_github_app_manifest.py --slug identrail
```

`python3 scripts/check_github_app_manifest.py --slug identrail` currently fails as expected because the live production app is not visible from GitHub's public app endpoint; that is the operator signal this PR adds.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: yes
- Areas where used: implementation, tests, docs, validation
- Human verification performed: local tests and diff review

## Related Issues

Fixes #1322

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch GitHub App setup to GitHub’s native account picker and remove our in-app account selector. Add a public manifest checker, set `callback_urls`/`setup_url`, and keep update redirects disabled so repo access edits sync via `installation_repositories` (Fixes #1322).

- New Features
  - Added `scripts/check_github_app_manifest.py` to compare the live public app against `deploy/connectors/github/app-manifest.json` and enforce `setup_on_update: false`.
  - Manifest now sets `callback_urls` and `setup_url`; docs note the app must be public/Any-account and that repository updates reconcile via `installation_repositories` rather than update redirects.

- Refactors
  - Removed the local personal/org selector UI, tests, and styles; we now open GitHub’s account picker in a new tab and updated fallback copy to “Open GitHub’s account picker.”
  - Dropped `install_account_type` from the connector start payload and adjusted tests and text accordingly.

<sup>Written for commit 8e0f82f5aa09412a0ce0cba50895b5ad6dc6856e. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1324?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

