### PR TITLE
Add GitHub PR review command foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
   labels from all-caps to sentence case, styled the new metric captions, the
   scan-health banner, and the failed-scan state actions, and set the summary
   grid to the consolidated four-column layout.
+- Added the GitHub PR review foundation: the app manifest now requests narrow
+  reviewer permissions for PR comments and check runs, subscribes to review
+  events, and `@identrail review` / `/identrail review` PR comments enqueue a
+  project-scoped repository scan.
+- Removed the temporary blank "Opening GitHub..." tab from hosted GitHub App
+  setup; the app now opens GitHub only after the install URL is ready and keeps
+  the in-app fallback button for browsers that block the popup.
 - Simplified hosted GitHub App setup to rely on GitHub's native account picker
   instead of duplicating personal-account and organization selection in the app.
   The versioned GitHub App manifest now includes the callback URL and setup URL,

--- a/deploy/connectors/github/app-manifest.json
+++ b/deploy/connectors/github/app-manifest.json
@@ -15,10 +15,12 @@
   "default_permissions": {
     "actions": "read",
     "administration": "read",
+    "checks": "write",
     "contents": "read",
     "environments": "read",
+    "issues": "read",
     "metadata": "read",
-    "pull_requests": "read",
+    "pull_requests": "write",
     "repository_hooks": "read",
     "secret_scanning_alerts": "read",
     "security_events": "read",
@@ -27,8 +29,12 @@
   "default_events": [
     "installation",
     "installation_repositories",
+    "issue_comment",
     "push",
     "pull_request",
+    "pull_request_review",
+    "pull_request_review_comment",
+    "pull_request_review_thread",
     "repository",
     "code_scanning_alert"
   ]

--- a/docs/auth/github-connector.md
+++ b/docs/auth/github-connector.md
@@ -69,6 +69,41 @@ must also confirm in the GitHub App settings that:
   `installation_repositories` webhook.
 - "Where can this GitHub App be installed?" is set to Any account.
 
+## Pull Request Review Foundation
+
+The same GitHub App can act as an Identrail reviewer when the app registration
+uses the versioned manifest permissions and events. The review surface is
+intentionally narrower than a full fix agent:
+
+- `contents: read` lets Identrail read repository content and changed files.
+- `pull_requests: write` lets Identrail participate in PR review surfaces.
+- `issues: read` lets Identrail receive PR conversation commands, which arrive
+  through the Issues event surface.
+- `checks: write` lets Identrail publish review or scan check runs.
+- `actions: read` and `administration: read` provide CI and branch-protection
+  context without granting source mutation.
+
+Do not grant `contents: write` for this path unless Identrail is explicitly
+running a future fix-PR workflow. Likewise, keep `issues` at `read` until a
+future reviewer flow needs to post top-level PR conversation comments. The
+current reviewer foundation is read-first:
+pull-request webhooks already queue repository scans for selected repositories,
+and a PR comment containing `@identrail review` or `/identrail review` queues a
+project-scoped quick scan for that repository. Inline review comments with the
+same command queue a PR delta scan when GitHub includes same-repository base and
+head revisions.
+
+The production app should subscribe to:
+
+- `pull_request`
+- `pull_request_review`
+- `pull_request_review_comment`
+- `pull_request_review_thread`
+- `issue_comment`
+
+These events are in addition to installation, repository, push, and code
+scanning events used by the scanner connector.
+
 For Identrail Cloud, the AWS API manual deploy workflow exposes first-class
 inputs for this path:
 

--- a/internal/api/github_connect.go
+++ b/internal/api/github_connect.go
@@ -40,6 +40,7 @@ const (
 )
 
 var githubRepositoryPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
+var githubReviewCommandPattern = regexp.MustCompile(`(?i)(?:^|\s)(?:@identrail|/identrail)\s+review(?:\s|$)`)
 
 // ErrInvalidGitHubConnectionRequest indicates invalid GitHub connect request input.
 var ErrInvalidGitHubConnectionRequest = errors.New("invalid github connection request")
@@ -261,9 +262,19 @@ type githubProjectConnection struct {
 }
 
 type githubWebhookEnvelope struct {
+	Action  string `json:"action"`
 	Before  string `json:"before"`
 	After   string `json:"after"`
 	Deleted bool   `json:"deleted"`
+	Comment struct {
+		Body string `json:"body"`
+	} `json:"comment"`
+	Issue struct {
+		Number      int `json:"number"`
+		PullRequest struct {
+			URL string `json:"url"`
+		} `json:"pull_request"`
+	} `json:"issue"`
 	Commits []struct {
 		ID       string   `json:"id"`
 		Added    []string `json:"added"`
@@ -997,7 +1008,8 @@ func (s *Service) HandleGitHubWebhook(ctx context.Context, eventType string, del
 	}
 
 	scanContext, scanContextOK := githubWebhookRepoScanContext(normalizedEventType, envelope)
-	result, err := s.processGitHubWebhookConnections(ctx, span, normalizedEventType, deliveryID, repository, scanContext, scanContextOK, validConnections)
+	scanTriggerEvent := githubWebhookTriggersScan(normalizedEventType, envelope)
+	result, err := s.processGitHubWebhookConnections(ctx, span, normalizedEventType, deliveryID, repository, scanContext, scanContextOK, scanTriggerEvent, validConnections)
 	if err != nil {
 		return GitHubWebhookResult{}, err
 	}
@@ -1047,10 +1059,11 @@ func (s *Service) HandleGitHubAppWebhook(ctx context.Context, eventType string, 
 	ctx, span := otel.Tracer("identrail/automation").Start(ctx, "automation.github_app_webhook")
 	defer span.End()
 	scanContext, scanContextOK := githubWebhookRepoScanContext(normalizedEventType, envelope)
-	return s.processGitHubWebhookConnections(ctx, span, normalizedEventType, deliveryID, repository, scanContext, scanContextOK, candidates)
+	scanTriggerEvent := githubWebhookTriggersScan(normalizedEventType, envelope)
+	return s.processGitHubWebhookConnections(ctx, span, normalizedEventType, deliveryID, repository, scanContext, scanContextOK, scanTriggerEvent, candidates)
 }
 
-func (s *Service) processGitHubWebhookConnections(ctx context.Context, span trace.Span, eventType string, deliveryID string, repository string, scanContext db.RepoScanContext, scanContextOK bool, connections []githubProjectConnection) (GitHubWebhookResult, error) {
+func (s *Service) processGitHubWebhookConnections(ctx context.Context, span trace.Span, eventType string, deliveryID string, repository string, scanContext db.RepoScanContext, scanContextOK bool, scanTriggerEvent bool, connections []githubProjectConnection) (GitHubWebhookResult, error) {
 	result := GitHubWebhookResult{
 		EventType:       eventType,
 		Repository:      repository,
@@ -1059,8 +1072,6 @@ func (s *Service) processGitHubWebhookConnections(ctx context.Context, span trac
 
 	now := s.Now().UTC()
 	normalizedDeliveryID := strings.TrimSpace(deliveryID)
-	scanTriggerEvent := githubWebhookTriggersScan(eventType)
-
 	for _, connection := range connections {
 		replayed := s.isGitHubWebhookReplay(connection, normalizedDeliveryID, now)
 		if replayed && scanTriggerEvent {
@@ -2050,10 +2061,14 @@ func validateGitHubWebhookSignature(secret string, payload []byte, signature str
 	return subtle.ConstantTimeCompare([]byte(expected), []byte(provided)) == 1
 }
 
-func githubWebhookTriggersScan(eventType string) bool {
+func githubWebhookTriggersScan(eventType string, envelope githubWebhookEnvelope) bool {
 	switch strings.ToLower(strings.TrimSpace(eventType)) {
 	case "push", "pull_request", "repository_dispatch", "workflow_dispatch":
 		return true
+	case "issue_comment":
+		return githubWebhookIssueCommentOnPullRequest(envelope) && githubWebhookReviewCommand(envelope)
+	case "pull_request_review_comment":
+		return githubWebhookReviewCommand(envelope)
 	default:
 		return false
 	}
@@ -2076,28 +2091,54 @@ func githubWebhookRepoScanContext(eventType string, envelope githubWebhookEnvelo
 			ChangedPaths: githubWebhookChangedPaths(envelope),
 		}), true
 	case "pull_request":
-		if !githubPullRequestHeadAvailableInBaseRepo(envelope) {
-			return db.NormalizeRepoScanContext(db.RepoScanContext{ScanMode: db.RepoScanModeQuick}), true
+		return githubWebhookPullRequestScanContext(envelope)
+	case "issue_comment":
+		if !githubWebhookIssueCommentOnPullRequest(envelope) || !githubWebhookReviewCommand(envelope) {
+			return db.NormalizeRepoScanContext(db.RepoScanContext{ScanMode: db.RepoScanModeQuick}), false
 		}
-		headRevision := strings.TrimSpace(envelope.PullRequest.Head.SHA)
-		if headRevision == "" || webhookZeroRevision(headRevision) {
-			return db.NormalizeRepoScanContext(db.RepoScanContext{ScanMode: db.RepoScanModeDelta}), false
+		return db.NormalizeRepoScanContext(db.RepoScanContext{ScanMode: db.RepoScanModeQuick}), true
+	case "pull_request_review_comment":
+		if !githubWebhookReviewCommand(envelope) {
+			return db.NormalizeRepoScanContext(db.RepoScanContext{ScanMode: db.RepoScanModeQuick}), false
 		}
-		baseRevision := strings.TrimSpace(envelope.PullRequest.Base.SHA)
-		if webhookZeroRevision(baseRevision) {
-			baseRevision = ""
-		}
-		return db.NormalizeRepoScanContext(db.RepoScanContext{
-			ScanMode:     db.RepoScanModeDelta,
-			BaseRevision: baseRevision,
-			HeadRevision: headRevision,
-			ChangedPaths: githubWebhookChangedPaths(envelope),
-		}), true
+		return githubWebhookPullRequestScanContext(envelope)
 	case "repository_dispatch", "workflow_dispatch":
 		return db.NormalizeRepoScanContext(db.RepoScanContext{ScanMode: db.RepoScanModeQuick}), true
 	default:
 		return db.NormalizeRepoScanContext(db.RepoScanContext{ScanMode: db.RepoScanModeDeep}), false
 	}
+}
+
+func githubWebhookPullRequestScanContext(envelope githubWebhookEnvelope) (db.RepoScanContext, bool) {
+	if !githubPullRequestHeadAvailableInBaseRepo(envelope) {
+		return db.NormalizeRepoScanContext(db.RepoScanContext{ScanMode: db.RepoScanModeQuick}), true
+	}
+	headRevision := strings.TrimSpace(envelope.PullRequest.Head.SHA)
+	if headRevision == "" || webhookZeroRevision(headRevision) {
+		return db.NormalizeRepoScanContext(db.RepoScanContext{ScanMode: db.RepoScanModeDelta}), false
+	}
+	baseRevision := strings.TrimSpace(envelope.PullRequest.Base.SHA)
+	if webhookZeroRevision(baseRevision) {
+		baseRevision = ""
+	}
+	return db.NormalizeRepoScanContext(db.RepoScanContext{
+		ScanMode:     db.RepoScanModeDelta,
+		BaseRevision: baseRevision,
+		HeadRevision: headRevision,
+		ChangedPaths: githubWebhookChangedPaths(envelope),
+	}), true
+}
+
+func githubWebhookIssueCommentOnPullRequest(envelope githubWebhookEnvelope) bool {
+	return strings.TrimSpace(envelope.Issue.PullRequest.URL) != ""
+}
+
+func githubWebhookReviewCommand(envelope githubWebhookEnvelope) bool {
+	action := strings.ToLower(strings.TrimSpace(envelope.Action))
+	if action != "" && action != "created" {
+		return false
+	}
+	return githubReviewCommandPattern.MatchString(envelope.Comment.Body)
 }
 
 func githubPullRequestHeadAvailableInBaseRepo(envelope githubWebhookEnvelope) bool {

--- a/internal/api/github_connect_test.go
+++ b/internal/api/github_connect_test.go
@@ -57,15 +57,31 @@ func githubPushWebhookPayload(repository string, installationID int64) []byte {
 func TestGitHubWebhookTriggersScan(t *testing.T) {
 	scanEvents := []string{"push", "pull_request", "repository_dispatch", "workflow_dispatch", "PUSH", " Pull_Request "}
 	for _, event := range scanEvents {
-		if !githubWebhookTriggersScan(event) {
+		if !githubWebhookTriggersScan(event, githubWebhookEnvelope{}) {
 			t.Errorf("githubWebhookTriggersScan(%q) = false, want true", event)
 		}
 	}
 	nonScanEvents := []string{"installation", "ping", "star", "fork", "issues", ""}
 	for _, event := range nonScanEvents {
-		if githubWebhookTriggersScan(event) {
+		if githubWebhookTriggersScan(event, githubWebhookEnvelope{}) {
 			t.Errorf("githubWebhookTriggersScan(%q) = true, want false", event)
 		}
+	}
+	var reviewCommand githubWebhookEnvelope
+	reviewCommand.Action = "created"
+	reviewCommand.Issue.PullRequest.URL = "https://api.github.com/repos/owner/repo/pulls/12"
+	reviewCommand.Comment.Body = "@identrail review"
+	if !githubWebhookTriggersScan("issue_comment", reviewCommand) {
+		t.Fatal("expected @identrail review PR comment to trigger a scan")
+	}
+	reviewCommand.Comment.Body = "looks good"
+	if githubWebhookTriggersScan("issue_comment", reviewCommand) {
+		t.Fatal("expected ordinary PR comment not to trigger a scan")
+	}
+	reviewCommand.Comment.Body = "@identrail review"
+	reviewCommand.Issue.PullRequest.URL = ""
+	if githubWebhookTriggersScan("issue_comment", reviewCommand) {
+		t.Fatal("expected issue comment outside a PR not to trigger a scan")
 	}
 }
 
@@ -100,6 +116,38 @@ func TestGitHubWebhookRepoScanContextPullRequestForkFallsBackToQuick(t *testing.
 	}
 	if scanContext.ScanMode != db.RepoScanModeQuick || scanContext.HeadRevision != "" || scanContext.BaseRevision != "" {
 		t.Fatalf("expected fork pull_request to fall back to quick scan, got %+v", scanContext)
+	}
+}
+
+func TestGitHubWebhookRepoScanContextReviewCommand(t *testing.T) {
+	var issueComment githubWebhookEnvelope
+	issueComment.Action = "created"
+	issueComment.Issue.PullRequest.URL = "https://api.github.com/repos/owner/repo/pulls/7"
+	issueComment.Comment.Body = "/identrail review"
+
+	scanContext, ok := githubWebhookRepoScanContext("issue_comment", issueComment)
+	if !ok {
+		t.Fatal("expected review command issue comment to queue a scan")
+	}
+	if scanContext.ScanMode != db.RepoScanModeQuick {
+		t.Fatalf("expected issue comment review command to queue quick scan, got %+v", scanContext)
+	}
+
+	var reviewComment githubWebhookEnvelope
+	reviewComment.Action = "created"
+	reviewComment.Repository.FullName = "owner/repo"
+	reviewComment.PullRequest.Base.SHA = "1111111111111111111111111111111111111111"
+	reviewComment.PullRequest.Base.Repo.FullName = "owner/repo"
+	reviewComment.PullRequest.Head.SHA = "2222222222222222222222222222222222222222"
+	reviewComment.PullRequest.Head.Repo.FullName = "owner/repo"
+	reviewComment.Comment.Body = "@identrail review"
+
+	scanContext, ok = githubWebhookRepoScanContext("pull_request_review_comment", reviewComment)
+	if !ok {
+		t.Fatal("expected review command inline comment to queue a scan")
+	}
+	if scanContext.ScanMode != db.RepoScanModeDelta || scanContext.HeadRevision != reviewComment.PullRequest.Head.SHA {
+		t.Fatalf("expected review comment command to queue PR delta scan, got %+v", scanContext)
 	}
 }
 

--- a/internal/api/github_connector_v2_test.go
+++ b/internal/api/github_connector_v2_test.go
@@ -367,7 +367,9 @@ func TestRouterGitHubConnectorV2WebhookQueuesAndDisconnects(t *testing.T) {
 		repositories: []githubconnector.Repository{{FullName: "identrail/api", Private: true}},
 	}
 	store := db.NewMemoryStore()
-	r := newGitHubConnectorV2TestRouterWithStore(t, store, &fakeGitHubPATValidator{}, lister)
+	r, svc := newGitHubConnectorV2ConfiguredTestRouterWithStore(t, store, &fakeGitHubPATValidator{}, lister)
+	svc.RepoScanEnabled = true
+	svc.RepoScanAllowedTargets = []string{"identrail/*"}
 
 	startResp := doAWSConnectionAPI(t, r, http.MethodPost, "/v1/connectors/github", `{
 		"workspace_id":"workspace-a",
@@ -469,6 +471,71 @@ func TestRouterGitHubConnectorV2WebhookQueuesAndDisconnects(t *testing.T) {
 	}
 	if postDeleteBody.Webhook.MatchedProjects != 0 {
 		t.Fatalf("expected deleted installation to stop matching webhook, got %+v", postDeleteBody.Webhook)
+	}
+}
+
+func TestRouterGitHubConnectorV2ReviewCommandQueuesScan(t *testing.T) {
+	lister := &fakeGitHubRepositoryLister{
+		repositories: []githubconnector.Repository{{FullName: "identrail/api", Private: true}},
+	}
+	store := db.NewMemoryStore()
+	r, svc := newGitHubConnectorV2ConfiguredTestRouterWithStore(t, store, &fakeGitHubPATValidator{}, lister)
+	svc.RepoScanEnabled = true
+	svc.RepoScanAllowedTargets = []string{"identrail/*"}
+
+	startResp := doAWSConnectionAPI(t, r, http.MethodPost, "/v1/connectors/github", `{
+		"workspace_id":"workspace-a",
+		"project_id":"project-1",
+		"redirect_uri":"https://app.identrail.com/app/github/callback"
+	}`)
+	if startResp.Code != http.StatusOK {
+		t.Fatalf("expected github connector start 200, got %d body=%s", startResp.Code, startResp.Body.String())
+	}
+	var startBody GitHubConnectorStartResponse
+	if err := json.Unmarshal(startResp.Body.Bytes(), &startBody); err != nil {
+		t.Fatalf("decode start response: %v", err)
+	}
+	completeResp := doAWSConnectionAPI(t, r, http.MethodPost, "/v1/connectors/github/complete", fmt.Sprintf(`{
+		"state":%q,
+		"installation_id":12345
+	}`, startBody.State))
+	if completeResp.Code != http.StatusOK {
+		t.Fatalf("expected github connector complete 200, got %d body=%s", completeResp.Code, completeResp.Body.String())
+	}
+
+	commentPayload := []byte(`{
+		"action":"created",
+		"repository":{"full_name":"identrail/api"},
+		"installation":{"id":12345},
+		"issue":{"number":17,"pull_request":{"url":"https://api.github.com/repos/identrail/api/pulls/17"}},
+		"comment":{"body":"@identrail review"}
+	}`)
+	commentResp := doGitHubWebhook(t, r, "/auth/webhooks/github", "issue_comment", "delivery-review-command", "global-webhook-secret", commentPayload)
+	if commentResp.Code != http.StatusAccepted {
+		t.Fatalf("expected github review command webhook 202, got %d body=%s", commentResp.Code, commentResp.Body.String())
+	}
+	var commentBody struct {
+		Webhook GitHubWebhookResult `json:"webhook"`
+	}
+	if err := json.Unmarshal(commentResp.Body.Bytes(), &commentBody); err != nil {
+		t.Fatalf("decode review command webhook response: %v", err)
+	}
+	if commentBody.Webhook.MatchedProjects != 1 || commentBody.Webhook.QueuedScans != 1 || commentBody.Webhook.SkippedScans != 0 {
+		t.Fatalf("expected review command to queue one scan, got %+v", commentBody.Webhook)
+	}
+
+	scansResp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/repo-scans", "")
+	if scansResp.Code != http.StatusOK {
+		t.Fatalf("expected repo scan list 200, got %d body=%s", scansResp.Code, scansResp.Body.String())
+	}
+	var scansBody struct {
+		Items []db.RepoScanRecord `json:"items"`
+	}
+	if err := json.Unmarshal(scansResp.Body.Bytes(), &scansBody); err != nil {
+		t.Fatalf("decode repo scans response: %v", err)
+	}
+	if len(scansBody.Items) != 1 || scansBody.Items[0].Repository != "identrail/api" || scansBody.Items[0].ScanMode != db.RepoScanModeQuick {
+		t.Fatalf("expected queued quick scan for review command, got %+v", scansBody.Items)
 	}
 }
 

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -412,17 +412,8 @@ describe('ProductProjectDetailPage', () => {
   });
 
   it('opens GitHub installation in a new tab through GitHub account picker', async () => {
-    const assign = vi.fn();
-    const close = vi.fn();
-    const popup = {
-      closed: false,
-      opener: {},
-      document: { title: '', body: { innerHTML: '' } },
-      location: { assign },
-      close
-    } as unknown as Window;
     const userAgent = vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue('Mozilla/5.0');
-    const open = vi.spyOn(window, 'open').mockReturnValue(popup);
+    const open = vi.spyOn(window, 'open').mockReturnValue({} as Window);
     const { startGitHubConnector } = await renderProjectDetail(true);
 
     expect(await screen.findByText('Install the GitHub App')).toBeInTheDocument();
@@ -434,8 +425,12 @@ describe('ProductProjectDetailPage', () => {
         expect.any(Object)
       )
     );
-    expect(open).toHaveBeenCalledWith('', '_blank');
-    expect(assign).toHaveBeenCalledWith('https://github.com/apps/identrail/installations/select_target?state=github-state');
+    expect(open).toHaveBeenCalledWith(
+      'https://github.com/apps/identrail/installations/select_target?state=github-state',
+      '_blank',
+      'noopener,noreferrer'
+    );
+    expect(open).not.toHaveBeenCalledWith('', '_blank');
     expect(await screen.findByText(/GitHub opened in a new tab/i)).toBeInTheDocument();
 
     userAgent.mockRestore();

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -675,68 +675,17 @@ function sourceAvailabilityTone(
   return availability.available ? connectionTone(status) : 'error';
 }
 
-function openPendingGitHubInstallWindow(): Window | null {
-  if (typeof window === 'undefined') {
-    return null;
-  }
-  if (/jsdom/i.test(window.navigator.userAgent)) {
-    return null;
-  }
-  let popup: Window | null = null;
-  try {
-    popup = window.open('', '_blank');
-  } catch {
-    return null;
-  }
-  if (!popup) {
-    return null;
-  }
-  try {
-    popup.opener = null;
-    popup.document.title = 'Opening GitHub';
-    if (popup.document.body) {
-      popup.document.body.innerHTML =
-        '<main style="font:16px system-ui,sans-serif;padding:24px;color:#111827">Opening GitHub...</main>';
-    }
-  } catch {
-    // The tab is still useful even if the browser blocks temporary about:blank edits.
-  }
-  return popup;
-}
-
-function openGitHubInstallURL(installURL: string, popup?: Window | null) {
+function openGitHubInstallURL(installURL: string) {
   if (typeof window === 'undefined' || !installURL) {
     return false;
   }
   if (/jsdom/i.test(window.navigator.userAgent)) {
     return false;
   }
-  if (popup && !popup.closed) {
-    try {
-      popup.location.assign(installURL);
-      return true;
-    } catch {
-      closeGitHubInstallWindow(popup);
-      // Fall through to opening a fresh tab if the pre-opened tab is no longer writable.
-    }
-  }
   try {
     return window.open(installURL, '_blank', 'noopener,noreferrer') !== null;
   } catch {
     return false;
-  }
-}
-
-function closeGitHubInstallWindow(popup: Window | null) {
-  if (!popup) {
-    return;
-  }
-  try {
-    if (!popup.closed) {
-      popup.close();
-    }
-  } catch {
-    // Ignore browser restrictions after the tab has navigated away.
   }
 }
 
@@ -4183,7 +4132,6 @@ export function ProductProjectDetailPage() {
     setSuccessMessage('');
     setSourceErrors((current) => ({ ...current, github: undefined }));
     const requestSequence = refreshSequenceRef.current;
-    const installWindow = openPendingGitHubInstallWindow();
     try {
       const auth = buildProductAuthContext(scope);
       const redirectURI =
@@ -4198,19 +4146,17 @@ export function ProductProjectDetailPage() {
         auth
       );
       if (isStaleRequestSequence(requestSequence)) {
-        closeGitHubInstallWindow(installWindow);
         return;
       }
       setGitHubStart(response);
       setConnections((current) => ({ ...current, github: response.connection }));
-      const opened = openGitHubInstallURL(response.install_url, installWindow);
+      const opened = openGitHubInstallURL(response.install_url);
       setSuccessMessage(
         opened
           ? 'GitHub opened in a new tab. Finish the installation there to complete setup.'
           : 'GitHub installation is ready. Continue with the GitHub button below.'
       );
     } catch (error) {
-      closeGitHubInstallWindow(installWindow);
       if (isStaleRequestSequence(requestSequence)) {
         return;
       }


### PR DESCRIPTION
Fixes #1323

## Summary

- expand the versioned GitHub App manifest for reviewer workflows with `checks: write`, `pull_requests: write`, `issues: read`, and PR review/comment webhook events
- let PR comments containing `@identrail review` or `/identrail review` queue a project-scoped quick repository scan for the selected repo
- let inline PR review comments with that command reuse the existing PR delta-scan context when GitHub provides same-repository base/head revisions
- remove the temporary blank `Opening GitHub...` tab from hosted GitHub App setup; the app now opens GitHub only after the real install URL is ready and keeps the fallback button if the popup is blocked
- document the least-privilege boundary: no `contents: write`, and no `issues: write` until a future flow needs to post top-level PR conversation comments

## Validation

- `npm ci --prefix web`
- `npm run test:ci --prefix web`
- `npm run build --prefix web`
- `go test ./internal/api -run 'TestGitHubWebhook|TestRouterGitHubConnectorV2ReviewCommandQueuesScan' -count=1`
- `go test ./... -count=1`
- `git diff --check`

AI-assisted: yes
