### PR TITLE
GitHub intelligence: add self-hosted runner posture

### DIFF
--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -3902,6 +3902,10 @@ paths:
           name: owner
           schema: { type: string }
         - in: query
+          name: source
+          schema: { type: string }
+          description: Adapter source identifier (for example `github_secret_scanning`).
+        - in: query
           name: confidence
           schema:
             type: number
@@ -3909,6 +3913,14 @@ paths:
             minimum: 0
             maximum: 1
           description: Minimum confidence score to include.
+        - in: query
+          name: min_confidence
+          schema:
+            type: number
+            format: double
+            minimum: 0
+            maximum: 1
+          description: Alias for `confidence` minimum threshold.
         - in: query
           name: age_days
           schema:

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -81,7 +81,7 @@ Read APIs:
 
 - `GET /v1/repo-scans`
 - `GET /v1/repo-scans/:repo_scan_id`
-- `GET /v1/repo-findings?repo_scan_id=&repository=&status=&severity=&type=&detector=&owner=&confidence=&age_days=`
+- `GET /v1/repo-findings?repo_scan_id=&repository=&status=&severity=&type=&detector=&owner=&source=&confidence=&min_confidence=&age_days=`
 - `POST /v1/repo-findings/:finding_id/remediation/preview?repo_scan_id=`
 - `GET /v1/repo-finding-clusters?repo_scan_id=&severity=&type=`
 - `GET /v1/repo-risk-graph?repo_scan_id=&repository=&default_branch=&severity=&type=`
@@ -213,6 +213,8 @@ The scanner uses a versioned secret detector registry for commit-history secret 
     - broad OIDC credential-minting context
     - cache keys or restore paths influenced by untrusted PR context
     - artifact or release publishing reachable from untrusted inputs
+    - self-hosted runner jobs reachable from untrusted events
+    - runner placement that cannot be statically audited (expression, matrix, or broad labels)
   - Kubernetes `privileged: true`
   - Terraform public S3 ACL
   - Terraform SSH/RDP open to world (`0.0.0.0/0`)
@@ -267,6 +269,8 @@ write permissions is emitted as a critical workflow attack path.
 | `workflow_oidc_broad_trust` | `id-token: write` is available from untrusted events, `workflow_run`, or broad all-branch push deploys. | High | Restrict cloud trust policies to protected branches and environments, and avoid OIDC on untrusted workflow paths. |
 | `workflow_cache_poisoning` | Cache keys or restore paths are influenced by PR-controlled context, or broad restore keys are used on untrusted events. | Medium | Separate untrusted PR caches from trusted build caches and avoid broad restore keys in privileged jobs. |
 | `workflow_artifact_poisoning` | PR or `workflow_run` context can upload artifacts or release assets consumed later. | Medium to high | Keep untrusted artifacts isolated, verify provenance before reuse, and publish releases only from protected contexts. |
+| `workflow_self_hosted_runner` | Self-hosted runner usage has no obvious org-level controls and can route untrusted jobs to shared infrastructure. | Medium | Enforce repository-level self-hosted runner restrictions, dedicated groups, and minimal permissions before enabling untrusted pull-request execution. |
+| `workflow_self_hosted_runner_unresolved` | Self-hosted runner-group visibility is permission-limited or unavailable, leaving posture state uncertain. | Medium | Grant the GitHub App read access to org runner groups or route high-risk repos to managed GitHub-hosted runners. |
 
 To add a new secret detector, add a new entry to the registry with a unique ID, a new version if needed for compatibility, and test fixtures.
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -955,6 +955,7 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 			Status:          strings.TrimSpace(firstNonEmpty(firstNonEmpty(c.Query("repo_lifecycle_status"), c.Query("repo_status")), c.Query("status"))),
 			Detector:        strings.TrimSpace(c.Query("detector")),
 			Owner:           strings.TrimSpace(c.Query("owner")),
+			Source:          strings.TrimSpace(c.Query("source")),
 			MinConfidence:   minConfidence,
 			MinAgeDays:      minAgeDays,
 			LifecycleStatus: strings.TrimSpace(c.Query("lifecycle_status")),

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -875,6 +875,7 @@ func TestRouterRepoFindingsCanBeFilteredByTriageState(t *testing.T) {
 			HumanSummary:    "ack finding",
 			Detector:        "workflow_pull_request_target",
 			Owner:           "platform",
+			AdapterSource:   "github_secret_scanning",
 			CreatedAt:       now.Add(-10 * 24 * time.Hour),
 		},
 	}); err != nil {
@@ -900,7 +901,7 @@ func TestRouterRepoFindingsCanBeFilteredByTriageState(t *testing.T) {
 
 	filteredReq := httptest.NewRequest(
 		http.MethodGet,
-		"/v1/repo-findings?repo_scan_id="+repoScan.ID+"&repo_lifecycle_status=open&detector=workflow_pull_request_target&owner=platform&confidence=0.9&age_days=7&lifecycle_status=ack&assignee=platform&limit=50",
+		"/v1/repo-findings?repo_scan_id="+repoScan.ID+"&repo_lifecycle_status=open&detector=workflow_pull_request_target&owner=platform&source=github_secret_scanning&confidence=0.9&age_days=7&lifecycle_status=ack&assignee=platform&limit=50",
 		nil,
 	)
 	filteredW := httptest.NewRecorder()

--- a/internal/connectors/github/posture.go
+++ b/internal/connectors/github/posture.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -162,6 +163,48 @@ type repositoryEnvironment struct {
 	} `json:"protection_rules"`
 }
 
+type actionsRunnerPage struct {
+	TotalCount int             `json:"total_count"`
+	Runners    []actionsRunner `json:"runners"`
+}
+
+type actionsRunner struct {
+	ID     int64                `json:"id"`
+	Name   string               `json:"name"`
+	OS     string               `json:"os"`
+	Status string               `json:"status"`
+	Busy   bool                 `json:"busy"`
+	Labels []actionsRunnerLabel `json:"labels"`
+}
+
+type actionsRunnerLabel struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+type orgRunnerGroupPage struct {
+	TotalCount   int              `json:"total_count"`
+	RunnerGroups []orgRunnerGroup `json:"runner_groups"`
+}
+
+type orgRunnerGroupRepositoryPage struct {
+	TotalCount   int                        `json:"total_count"`
+	Repositories []orgRunnerGroupRepository `json:"repositories"`
+}
+
+type orgRunnerGroupRepository struct {
+	FullName string `json:"full_name"`
+}
+
+type orgRunnerGroup struct {
+	ID                       int64  `json:"id"`
+	Name                     string `json:"name"`
+	Visibility               string `json:"visibility"`
+	AllowsPublicRepositories bool   `json:"allows_public_repositories"`
+	Default                  bool   `json:"default"`
+	RestrictedToWorkflows    bool   `json:"restricted_to_workflows"`
+}
+
 // CollectRepositoryPosture collects normalized security posture from GitHub API
 // endpoints that require an installation token. Each endpoint contributes a
 // check even when the setting is unavailable or permission-limited.
@@ -182,7 +225,7 @@ func (c RepositoryClient) CollectRepositoryPosture(ctx context.Context, installa
 		Repository:     normalizedRepository,
 		InstallationID: installationID,
 		CollectedAt:    c.now().UTC(),
-		Checks:         make([]RepositoryPostureCheck, 0, 10),
+		Checks:         make([]RepositoryPostureCheck, 0, 11),
 	}
 	updateRate := func(limit *GitHubRateLimitState) {
 		if limit != nil {
@@ -222,6 +265,7 @@ func (c RepositoryClient) CollectRepositoryPosture(ctx context.Context, installa
 	posture.Checks = append(posture.Checks, c.collectDeployKeys(ctx, token.Token, normalizedRepository, updateRate))
 	posture.Checks = append(posture.Checks, c.collectWebhooks(ctx, token.Token, normalizedRepository, updateRate))
 	posture.Checks = append(posture.Checks, c.collectEnvironments(ctx, token.Token, normalizedRepository, updateRate))
+	posture.Checks = append(posture.Checks, c.collectSelfHostedRunners(ctx, token.Token, normalizedRepository, updateRate))
 
 	return posture, nil
 }
@@ -654,6 +698,252 @@ func (c RepositoryClient) collectEnvironments(ctx context.Context, token string,
 	}
 }
 
+// collectSelfHostedRunners reports whether the repository can run jobs on
+// self-hosted GitHub Actions runners. Self-hosted runners are a machine-identity
+// risk boundary because they can hold persistent cloud, deployment, registry, or
+// internal-network credentials. The repository runner list is the authoritative
+// repo-scope signal; organization runner-group breadth is collected best-effort
+// and recorded as evidence rather than failing the whole check when the App
+// lacks organization permission. Evidence is summary-shaped: it never includes
+// runner registration tokens, runner host names, or other secret-bearing values.
+func (c RepositoryClient) collectSelfHostedRunners(ctx context.Context, token string, repository string, updateRate func(*GitHubRateLimitState)) RepositoryPostureCheck {
+	runners := []actionsRunner{}
+	rateLimit, err := c.getJSONPages(ctx, token, c.repositoryEndpoint(repository, "/actions/runners?per_page=100"), func(body []byte) error {
+		var page actionsRunnerPage
+		if err := json.Unmarshal(body, &page); err != nil {
+			return err
+		}
+		runners = append(runners, page.Runners...)
+		return nil
+	})
+	updateRate(rateLimit)
+	if err != nil {
+		return checkFromAPIError("self_hosted_runners", "runners", err, RepositoryPostureStateUnavailable, "api_unavailable", "Self-hosted runner posture could not be collected.")
+	}
+
+	online, offline, busy := 0, 0, 0
+	labelSet := map[string]struct{}{}
+	osSet := map[string]struct{}{}
+	for _, runner := range runners {
+		switch strings.ToLower(strings.TrimSpace(runner.Status)) {
+		case "online":
+			online++
+		case "offline":
+			offline++
+		}
+		if runner.Busy {
+			busy++
+		}
+		for _, label := range runner.Labels {
+			if name := strings.TrimSpace(label.Name); name != "" {
+				labelSet[name] = struct{}{}
+			}
+		}
+		if os := strings.TrimSpace(runner.OS); os != "" {
+			osSet[os] = struct{}{}
+		}
+	}
+
+	evidence := map[string]any{
+		"repository":               repository,
+		"self_hosted_runner_count": len(runners),
+		"online_runners":           online,
+		"offline_runners":          offline,
+		"busy_runners":             busy,
+	}
+	if len(labelSet) > 0 {
+		evidence["runner_labels"] = sortedStringSet(labelSet)
+	}
+	if len(osSet) > 0 {
+		evidence["runner_os"] = sortedStringSet(osSet)
+	}
+
+	groupsState, broadGroups, publicRepoGroups, groupCount := c.collectOrgRunnerGroupBreadth(ctx, token, repository, updateRate)
+	evidence["runner_groups_state"] = string(groupsState)
+	if groupsState == RepositoryPostureStateSecure || groupsState == RepositoryPostureStateInsecure {
+		evidence["org_runner_groups"] = groupCount
+		evidence["broadly_available_runner_groups"] = broadGroups
+		evidence["public_repository_runner_groups"] = publicRepoGroups
+	}
+
+	if len(runners) > 0 || broadGroups > 0 || publicRepoGroups > 0 {
+		reason := "self_hosted_runners_present"
+		summary := "Repository can use self-hosted GitHub Actions runners, which hold persistent credentials and require isolation from untrusted workflows."
+		if len(runners) == 0 {
+			reason = "broad_runner_groups_available"
+			summary = "Organization runner groups available to this repository are broadly shared or allow public repositories."
+		}
+		return RepositoryPostureCheck{
+			ID:       "self_hosted_runners",
+			Category: "runners",
+			State:    RepositoryPostureStateInsecure,
+			Reason:   reason,
+			Summary:  summary,
+			Evidence: evidence,
+		}
+	}
+	if groupsState != RepositoryPostureStateSecure {
+		summary := "Self-hosted runner group visibility is not fully observable, so repository runner posture could not be fully verified."
+		return RepositoryPostureCheck{
+			ID:       "self_hosted_runners",
+			Category: "runners",
+			State:    groupsState,
+			Reason:   "runner_group_visibility_unknown",
+			Summary:  summary,
+			Evidence: evidence,
+		}
+	}
+	return RepositoryPostureCheck{
+		ID:       "self_hosted_runners",
+		Category: "runners",
+		State:    RepositoryPostureStateSecure,
+		Reason:   "no_self_hosted_runners",
+		Summary:  "No self-hosted runners or broadly shared runner groups were visible to the installation.",
+		Evidence: evidence,
+	}
+}
+
+// collectOrgRunnerGroupBreadth inspects organization runner groups available to
+// the repository. It returns a normalized state plus broad/public/total counts.
+// Personal repositories and installations without organization permission return
+// permission_limited; rate limits and other failures return unavailable.
+func (c RepositoryClient) collectOrgRunnerGroupBreadth(ctx context.Context, token string, repository string, updateRate func(*GitHubRateLimitState)) (RepositoryPostureState, int, int, int) {
+	normalizedRepository, err := normalizeRepositoryName(repository)
+	if err != nil {
+		return RepositoryPostureStateUnavailable, 0, 0, 0
+	}
+	groupEndpoint := c.repositoryEndpoint(normalizedRepository, "/actions/runner-groups?per_page=100")
+	org := strings.SplitN(normalizedRepository, "/", 2)[0]
+	fallbackToOrg := false
+	groups := []orgRunnerGroup{}
+	fetchGroups := func(endpoint string) (*GitHubRateLimitState, error) {
+		groups = []orgRunnerGroup{}
+		rateLimit, err := c.getJSONPages(ctx, token, endpoint, func(body []byte) error {
+			var page orgRunnerGroupPage
+			if err := json.Unmarshal(body, &page); err != nil {
+				return err
+			}
+			groups = append(groups, page.RunnerGroups...)
+			return nil
+		})
+		updateRate(rateLimit)
+		return rateLimit, err
+	}
+
+	_, err = fetchGroups(groupEndpoint)
+	if err != nil {
+		apiErr, ok := asGitHubAPIError(err)
+		if !ok {
+			return RepositoryPostureStateUnavailable, 0, 0, 0
+		}
+		if apiErr.StatusCode == http.StatusNotFound {
+			_, err = fetchGroups(c.orgEndpoint(org, "/actions/runner-groups?per_page=100"))
+			fallbackToOrg = true
+		} else {
+			if apiErr.RateLimited {
+				return RepositoryPostureStateUnavailable, 0, 0, 0
+			}
+			switch apiErr.StatusCode {
+			case http.StatusForbidden, http.StatusUnauthorized:
+				return RepositoryPostureStatePermissionLimited, 0, 0, 0
+			case http.StatusNotFound:
+				return RepositoryPostureStateUnavailable, 0, 0, 0
+			default:
+				return RepositoryPostureStateUnavailable, 0, 0, 0
+			}
+		}
+	}
+	if err != nil {
+		apiErr, ok := asGitHubAPIError(err)
+		if !ok {
+			return RepositoryPostureStateUnavailable, 0, 0, 0
+		}
+		if apiErr.RateLimited {
+			return RepositoryPostureStateUnavailable, 0, 0, 0
+		}
+		switch apiErr.StatusCode {
+		case http.StatusForbidden, http.StatusUnauthorized:
+			return RepositoryPostureStatePermissionLimited, 0, 0, 0
+		case http.StatusNotFound:
+			return RepositoryPostureStateUnavailable, 0, 0, 0
+		default:
+			return RepositoryPostureStateUnavailable, 0, 0, 0
+		}
+	}
+	broad := 0
+	publicRepoGroups := 0
+	for _, group := range groups {
+		if fallbackToOrg && strings.EqualFold(strings.TrimSpace(group.Visibility), "selected") {
+			hasAccess, accessErr := c.repositoryInOrgRunnerGroup(ctx, token, org, group.ID, normalizedRepository, updateRate)
+			if accessErr != nil {
+				if apiErr, ok := asGitHubAPIError(accessErr); ok {
+					if apiErr.RateLimited {
+						return RepositoryPostureStateUnavailable, 0, 0, 0
+					}
+					switch apiErr.StatusCode {
+					case http.StatusForbidden, http.StatusUnauthorized:
+						return RepositoryPostureStatePermissionLimited, 0, 0, 0
+					case http.StatusNotFound:
+						return RepositoryPostureStateUnavailable, 0, 0, 0
+					default:
+						return RepositoryPostureStateUnavailable, 0, 0, 0
+					}
+				}
+				return RepositoryPostureStateUnavailable, 0, 0, 0
+			}
+			if !hasAccess {
+				continue
+			}
+		}
+
+		if strings.EqualFold(strings.TrimSpace(group.Visibility), "all") {
+			broad++
+		}
+		if group.AllowsPublicRepositories {
+			publicRepoGroups++
+		}
+	}
+	state := RepositoryPostureStateSecure
+	if broad > 0 || publicRepoGroups > 0 {
+		state = RepositoryPostureStateInsecure
+	}
+	return state, broad, publicRepoGroups, len(groups)
+}
+
+func (c RepositoryClient) repositoryInOrgRunnerGroup(
+	ctx context.Context,
+	token string,
+	org string,
+	groupID int64,
+	repository string,
+	updateRate func(*GitHubRateLimitState),
+) (bool, error) {
+	repository = strings.ToLower(strings.TrimSpace(repository))
+	groupReposEndpoint := c.orgEndpoint(org, fmt.Sprintf("/actions/runner-groups/%d/repositories?per_page=100", groupID))
+	groupHasRepo := false
+	rateLimit, err := c.getJSONPages(ctx, token, groupReposEndpoint, func(body []byte) error {
+		var page orgRunnerGroupRepositoryPage
+		if err := json.Unmarshal(body, &page); err != nil {
+			return err
+		}
+		if groupHasRepo {
+			return nil
+		}
+		for _, repo := range page.Repositories {
+			if strings.EqualFold(strings.TrimSpace(repo.FullName), repository) {
+				groupHasRepo = true
+				return nil
+			}
+		}
+		return nil
+	})
+	updateRate(rateLimit)
+	if err != nil {
+		return false, err
+	}
+	return groupHasRepo, nil
+}
+
 func (c RepositoryClient) featureStatus(ctx context.Context, token string, endpoint string) (bool, *GitHubRateLimitState, error) {
 	rateLimit, err := c.doGitHubRequest(ctx, token, http.MethodGet, endpoint, nil)
 	if err != nil {
@@ -852,6 +1142,19 @@ func parseHeaderInt(value string) (int, bool) {
 func (c RepositoryClient) repositoryEndpoint(repository string, suffix string) string {
 	parts := strings.Split(repository, "/")
 	return strings.TrimRight(c.apiBaseURL(), "/") + "/repos/" + url.PathEscape(parts[0]) + "/" + url.PathEscape(parts[1]) + suffix
+}
+
+func (c RepositoryClient) orgEndpoint(org string, suffix string) string {
+	return strings.TrimRight(c.apiBaseURL(), "/") + "/orgs/" + url.PathEscape(org) + suffix
+}
+
+func sortedStringSet(set map[string]struct{}) []string {
+	keys := make([]string, 0, len(set))
+	for key := range set {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func normalizeRepositoryName(repository string) (string, error) {

--- a/internal/connectors/github/posture_test.go
+++ b/internal/connectors/github/posture_test.go
@@ -68,6 +68,12 @@ func TestRepositoryClientCollectRepositoryPostureHappyPath(t *testing.T) {
 				return
 			}
 			_, _ = w.Write([]byte(`{"total_count":2,"environments":[{"name":"staging","protection_rules":[{"type":"required_reviewers"}]}]}`))
+		case "/repos/owner/repo/actions/runners":
+			_, _ = w.Write([]byte(`{"total_count":0,"runners":[]}`))
+		case "/repos/owner/repo/actions/runner-groups":
+			_, _ = w.Write([]byte(`{"total_count":0,"runner_groups":[]}`))
+		case "/orgs/owner/actions/runner-groups":
+			_, _ = w.Write([]byte(`{"total_count":0,"runner_groups":[]}`))
 		default:
 			t.Errorf("unexpected posture path %s", r.URL.String())
 			return
@@ -86,7 +92,7 @@ func TestRepositoryClientCollectRepositoryPostureHappyPath(t *testing.T) {
 	if minter.seenInstallationID != 123 {
 		t.Fatalf("expected installation 123, got %d", minter.seenInstallationID)
 	}
-	if posture.Repository != "owner/repo" || posture.InstallationID != 123 || len(posture.Checks) != 10 {
+	if posture.Repository != "owner/repo" || posture.InstallationID != 123 || len(posture.Checks) != 11 {
 		t.Fatalf("unexpected posture summary: %+v", posture)
 	}
 	for _, id := range []string{
@@ -100,6 +106,7 @@ func TestRepositoryClientCollectRepositoryPostureHappyPath(t *testing.T) {
 		"deploy_keys",
 		"webhooks",
 		"deployment_environments",
+		"self_hosted_runners",
 	} {
 		if check := postureCheckByID(posture, id); check.State != RepositoryPostureStateSecure {
 			t.Fatalf("expected %s to be secure, got %+v", id, check)
@@ -132,6 +139,12 @@ func TestRepositoryClientCollectRepositoryPostureClassifiesWeakSettings(t *testi
 			_, _ = w.Write([]byte(`[{"id":1,"active":true,"config":{"insecure_ssl":"1"},"last_response":{"code":500,"status":"failed"}}]`))
 		case "/repos/owner/repo/environments":
 			_, _ = w.Write([]byte(`{"total_count":1,"environments":[{"name":"production","protection_rules":[]}]}`))
+		case "/repos/owner/repo/actions/runners":
+			_, _ = w.Write([]byte(`{"total_count":1,"runners":[{"id":1,"os":"linux","status":"online","busy":false,"labels":[{"name":"self-hosted","type":"read-only"},{"name":"x64","type":"read-only"}]}]}`))
+		case "/repos/owner/repo/actions/runner-groups":
+			_, _ = w.Write([]byte(`{"total_count":1,"runner_groups":[{"id":1,"name":"default","visibility":"all","allows_public_repositories":true}]}`))
+		case "/orgs/owner/actions/runner-groups":
+			_, _ = w.Write([]byte(`{"total_count":1,"runner_groups":[{"id":1,"name":"default","visibility":"all","allows_public_repositories":true}]}`))
 		default:
 			t.Errorf("unexpected posture path %s", r.URL.String())
 			return
@@ -154,10 +167,26 @@ func TestRepositoryClientCollectRepositoryPostureClassifiesWeakSettings(t *testi
 		"deploy_keys",
 		"webhooks",
 		"deployment_environments",
+		"self_hosted_runners",
 	} {
 		if check := postureCheckByID(posture, id); check.State != RepositoryPostureStateInsecure {
 			t.Fatalf("expected %s to be insecure, got %+v", id, check)
 		}
+	}
+
+	runners := postureCheckByID(posture, "self_hosted_runners")
+	if count, _ := runners.Evidence["self_hosted_runner_count"].(int); count != 1 {
+		t.Fatalf("expected one self-hosted runner, got %+v", runners.Evidence)
+	}
+	labels, _ := runners.Evidence["runner_labels"].([]string)
+	if len(labels) != 2 || labels[0] != "self-hosted" || labels[1] != "x64" {
+		t.Fatalf("expected sorted self-hosted runner labels, got %+v", runners.Evidence)
+	}
+	if broad, _ := runners.Evidence["broadly_available_runner_groups"].(int); broad != 1 {
+		t.Fatalf("expected one broadly available runner group, got %+v", runners.Evidence)
+	}
+	if public, _ := runners.Evidence["public_repository_runner_groups"].(int); public != 1 {
+		t.Fatalf("expected one public-repository runner group, got %+v", runners.Evidence)
 	}
 }
 
@@ -182,6 +211,8 @@ func TestRepositoryClientCollectRepositoryPosturePermissionAndRateLimitStates(t 
 			http.Error(w, `{"message":"Resource not accessible by integration"}`, http.StatusForbidden)
 		case "/repos/owner/repo/environments":
 			_, _ = w.Write([]byte(`{"total_count":0,"environments":[]}`))
+		case "/repos/owner/repo/actions/runners":
+			http.Error(w, `{"message":"Resource not accessible by integration"}`, http.StatusForbidden)
 		default:
 			t.Errorf("unexpected posture path %s", r.URL.String())
 			return
@@ -201,6 +232,161 @@ func TestRepositoryClientCollectRepositoryPosturePermissionAndRateLimitStates(t 
 	}
 	if check := postureCheckByID(posture, "actions_permissions"); check.State != RepositoryPostureStateUnavailable || check.Reason != "rate_limited" {
 		t.Fatalf("expected actions secondary rate limit, got %+v", check)
+	}
+	if check := postureCheckByID(posture, "self_hosted_runners"); check.State != RepositoryPostureStatePermissionLimited {
+		t.Fatalf("expected self-hosted runner posture permission-limited, got %+v", check)
+	}
+}
+
+func TestRepositoryClientCollectSelfHostedRunnerPostureOrgGroupPermissionLimited(t *testing.T) {
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo":
+			_, _ = w.Write([]byte(`{"full_name":"owner/repo","default_branch":"main","has_security_policy":true}`))
+		case "/repos/owner/repo/branches/main/protection":
+			_, _ = w.Write([]byte(`{"required_pull_request_reviews":{"required_approving_review_count":2},"required_status_checks":{"contexts":["test"]},"enforce_admins":{"enabled":true},"allow_force_pushes":{"enabled":false},"allow_deletions":{"enabled":false}}`))
+		case "/repos/owner/repo/rulesets":
+			_, _ = w.Write([]byte(`[{"id":1,"enforcement":"active"}]`))
+		case "/repos/owner/repo/actions/permissions":
+			_, _ = w.Write([]byte(`{"enabled":true,"allowed_actions":"selected","default_workflow_permissions":"read"}`))
+		case "/repos/owner/repo/vulnerability-alerts", "/repos/owner/repo/automated-security-fixes":
+			w.WriteHeader(http.StatusNoContent)
+		case "/repos/owner/repo/code-scanning/alerts", "/repos/owner/repo/secret-scanning/alerts", "/repos/owner/repo/keys", "/repos/owner/repo/hooks":
+			_, _ = w.Write([]byte(`[]`))
+		case "/repos/owner/repo/environments":
+			_, _ = w.Write([]byte(`{"total_count":0,"environments":[]}`))
+		case "/repos/owner/repo/actions/runners":
+			_, _ = w.Write([]byte(`{"total_count":1,"runners":[{"id":7,"os":"linux","status":"offline","busy":false,"labels":[{"name":"self-hosted"}]}]}`))
+		case "/repos/owner/repo/actions/runner-groups":
+			http.Error(w, `{"message":"Resource not accessible by integration"}`, http.StatusForbidden)
+		case "/orgs/owner/actions/runner-groups":
+			http.Error(w, `{"message":"Resource not accessible by integration"}`, http.StatusForbidden)
+		default:
+			t.Errorf("unexpected posture path %s", r.URL.String())
+			return
+		}
+	}))
+	defer server.Close()
+
+	posture, err := (RepositoryClient{TokenClient: minter, APIBaseURL: server.URL}).CollectRepositoryPosture(context.Background(), 123, "owner/repo")
+	if err != nil {
+		t.Fatalf("collect posture: %v", err)
+	}
+	check := postureCheckByID(posture, "self_hosted_runners")
+	if check.State != RepositoryPostureStateInsecure || check.Reason != "self_hosted_runners_present" {
+		t.Fatalf("expected insecure self-hosted runner state, got %+v", check)
+	}
+	if state, _ := check.Evidence["runner_groups_state"].(string); state != string(RepositoryPostureStatePermissionLimited) {
+		t.Fatalf("expected permission-limited org runner-group state evidence, got %+v", check.Evidence)
+	}
+	if _, present := check.Evidence["broadly_available_runner_groups"]; present {
+		t.Fatalf("expected no runner-group counts when org read is permission-limited, got %+v", check.Evidence)
+	}
+	if offline, _ := check.Evidence["offline_runners"].(int); offline != 1 {
+		t.Fatalf("expected one offline runner, got %+v", check.Evidence)
+	}
+}
+
+func TestRepositoryClientCollectSelfHostedRunnerPostureOrgGroupPermissionLimitedWithoutLocalRunners(t *testing.T) {
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo":
+			_, _ = w.Write([]byte(`{"full_name":"owner/repo","default_branch":"main","has_security_policy":true}`))
+		case "/repos/owner/repo/branches/main/protection":
+			_, _ = w.Write([]byte(`{"required_pull_request_reviews":{"required_approving_review_count":2},"required_status_checks":{"contexts":["test"]},"enforce_admins":{"enabled":true},"allow_force_pushes":{"enabled":false},"allow_deletions":{"enabled":false}}`))
+		case "/repos/owner/repo/rulesets":
+			_, _ = w.Write([]byte(`[{"id":1,"enforcement":"active"}]`))
+		case "/repos/owner/repo/actions/permissions":
+			_, _ = w.Write([]byte(`{"enabled":true,"allowed_actions":"selected","default_workflow_permissions":"read"}`))
+		case "/repos/owner/repo/vulnerability-alerts", "/repos/owner/repo/automated-security-fixes":
+			w.WriteHeader(http.StatusNoContent)
+		case "/repos/owner/repo/code-scanning/alerts", "/repos/owner/repo/secret-scanning/alerts", "/repos/owner/repo/keys", "/repos/owner/repo/hooks":
+			_, _ = w.Write([]byte(`[]`))
+		case "/repos/owner/repo/environments":
+			_, _ = w.Write([]byte(`{"total_count":0,"environments":[]}`))
+		case "/repos/owner/repo/actions/runners":
+			_, _ = w.Write([]byte(`{"total_count":0,"runners":[]}`))
+		case "/repos/owner/repo/actions/runner-groups":
+			http.Error(w, `{"message":"Resource not accessible by integration"}`, http.StatusForbidden)
+		case "/orgs/owner/actions/runner-groups":
+			http.Error(w, `{"message":"Resource not accessible by integration"}`, http.StatusForbidden)
+		default:
+			t.Errorf("unexpected posture path %s", r.URL.String())
+			return
+		}
+	}))
+	defer server.Close()
+
+	posture, err := (RepositoryClient{TokenClient: minter, APIBaseURL: server.URL}).CollectRepositoryPosture(context.Background(), 123, "owner/repo")
+	if err != nil {
+		t.Fatalf("collect posture: %v", err)
+	}
+	check := postureCheckByID(posture, "self_hosted_runners")
+	if check.State != RepositoryPostureStatePermissionLimited {
+		t.Fatalf("expected permission-limited self-hosted runner state, got %+v", check)
+	}
+	if check.Reason != "runner_group_visibility_unknown" {
+		t.Fatalf("expected runner-group visibility reason, got %+v", check)
+	}
+	if state, _ := check.Evidence["runner_groups_state"].(string); state != string(RepositoryPostureStatePermissionLimited) {
+		t.Fatalf("expected permission-limited runner-group state evidence, got %+v", check.Evidence)
+	}
+	if _, present := check.Evidence["runner_groups_state"]; !present {
+		t.Fatalf("expected runner group state evidence to be present, got %+v", check.Evidence)
+	}
+}
+
+func TestRepositoryClientCollectSelfHostedRunnerPostureFiltersSelectedOrgGroupsWithoutRepositoryMembership(t *testing.T) {
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo":
+			_, _ = w.Write([]byte(`{"full_name":"owner/repo","default_branch":"main","has_security_policy":true}`))
+		case "/repos/owner/repo/branches/main/protection":
+			_, _ = w.Write([]byte(`{"required_pull_request_reviews":{"required_approving_review_count":2},"required_status_checks":{"contexts":["test"]},"enforce_admins":{"enabled":true},"allow_force_pushes":{"enabled":false},"allow_deletions":{"enabled":false}}`))
+		case "/repos/owner/repo/rulesets":
+			_, _ = w.Write([]byte(`[{"id":1,"enforcement":"active"}]`))
+		case "/repos/owner/repo/actions/permissions":
+			_, _ = w.Write([]byte(`{"enabled":true,"allowed_actions":"selected","default_workflow_permissions":"read"}`))
+		case "/repos/owner/repo/vulnerability-alerts", "/repos/owner/repo/automated-security-fixes":
+			w.WriteHeader(http.StatusNoContent)
+		case "/repos/owner/repo/code-scanning/alerts", "/repos/owner/repo/secret-scanning/alerts", "/repos/owner/repo/keys", "/repos/owner/repo/hooks":
+			_, _ = w.Write([]byte(`[]`))
+		case "/repos/owner/repo/environments":
+			_, _ = w.Write([]byte(`{"total_count":0,"environments":[]}`))
+		case "/repos/owner/repo/actions/runners":
+			_, _ = w.Write([]byte(`{"total_count":0,"runners":[]}`))
+		case "/repos/owner/repo/actions/runner-groups":
+			http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)
+		case "/orgs/owner/actions/runner-groups":
+			_, _ = w.Write([]byte(`{"total_count":1,"runner_groups":[{"id":11,"name":"public-shared","visibility":"selected","allows_public_repositories":true}]}`))
+		case "/orgs/owner/actions/runner-groups/11/repositories":
+			_, _ = w.Write([]byte(`{"total_count":1,"repositories":[{"full_name":"owner/other-repo"}]}`))
+		default:
+			t.Errorf("unexpected posture path %s", r.URL.String())
+			return
+		}
+	}))
+	defer server.Close()
+
+	posture, err := (RepositoryClient{TokenClient: minter, APIBaseURL: server.URL}).CollectRepositoryPosture(context.Background(), 123, "owner/repo")
+	if err != nil {
+		t.Fatalf("collect posture: %v", err)
+	}
+	check := postureCheckByID(posture, "self_hosted_runners")
+	if check.State != RepositoryPostureStateSecure {
+		t.Fatalf("expected secure self-hosted runner state, got %+v", check)
+	}
+	if check.Reason != "no_self_hosted_runners" {
+		t.Fatalf("expected secure self-hosted runner reason, got %+v", check)
+	}
+	if broad, _ := check.Evidence["broadly_available_runner_groups"].(int); broad != 0 {
+		t.Fatalf("expected no broadly available groups, got %+v", check.Evidence)
+	}
+	if public, _ := check.Evidence["public_repository_runner_groups"].(int); public != 0 {
+		t.Fatalf("expected no public-repository groups, got %+v", check.Evidence)
 	}
 }
 

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -2563,6 +2563,9 @@ func repoFindingMatchesFilter(finding domain.Finding, filter RepoFindingFilter) 
 	if filter.Owner != "" && strings.ToLower(strings.TrimSpace(finding.Owner)) != filter.Owner {
 		return false
 	}
+	if filter.Source != "" && strings.ToLower(strings.TrimSpace(finding.AdapterSource)) != filter.Source {
+		return false
+	}
 	if filter.MinConfidence > 0 && finding.ConfidenceScore < filter.MinConfidence {
 		return false
 	}

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -3656,6 +3656,9 @@ func (p *PostgresStore) ListRepoFindings(ctx context.Context, filter RepoFinding
 	if normalized.Owner != "" {
 		outerConditions = append(outerConditions, fmt.Sprintf("LOWER(f.owner) = %s", addArg(normalized.Owner)))
 	}
+	if normalized.Source != "" {
+		outerConditions = append(outerConditions, fmt.Sprintf("LOWER(f.adapter_source) = %s", addArg(normalized.Source)))
+	}
 	if normalized.MinConfidence > 0 {
 		outerConditions = append(outerConditions, fmt.Sprintf("f.confidence_score >= %s", addArg(normalized.MinConfidence)))
 	}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2075,6 +2075,7 @@ type RepoFindingFilter struct {
 	Status            string
 	Detector          string
 	Owner             string
+	Source            string
 	MinConfidence     float64
 	MinAgeDays        int
 	LifecycleStatus   string
@@ -2202,6 +2203,7 @@ func NormalizeRepoFindingFilter(filter RepoFindingFilter) RepoFindingFilter {
 		Status:            strings.ToLower(strings.TrimSpace(filter.Status)),
 		Detector:          strings.ToLower(strings.TrimSpace(filter.Detector)),
 		Owner:             strings.ToLower(strings.TrimSpace(filter.Owner)),
+		Source:            strings.ToLower(strings.TrimSpace(filter.Source)),
 		MinConfidence:     minConfidence,
 		MinAgeDays:        filter.MinAgeDays,
 		LifecycleStatus:   strings.ToLower(strings.TrimSpace(filter.LifecycleStatus)),

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -59,6 +59,7 @@ func TestNormalizeRepoFindingFilter(t *testing.T) {
 		Type:            " SECRET_EXPOSURE ",
 		LifecycleStatus: " ACK ",
 		Assignee:        " Platform ",
+		Source:          " Github_Secret_Scanning ",
 		SortBy:          "severity",
 		SortDesc:        true,
 	})
@@ -70,6 +71,9 @@ func TestNormalizeRepoFindingFilter(t *testing.T) {
 	}
 	if normalized.LifecycleStatus != "ack" || normalized.Assignee != "platform" {
 		t.Fatalf("expected normalized triage filters, got %+v", normalized)
+	}
+	if normalized.Source != "github_secret_scanning" {
+		t.Fatalf("expected normalized source filter, got %+v", normalized)
 	}
 	if normalized.SortBy != "severity" || !normalized.SortDesc {
 		t.Fatalf("expected explicit sort controls to pass through, got %+v", normalized)

--- a/internal/findings/standards/repo_remediation.go
+++ b/internal/findings/standards/repo_remediation.go
@@ -139,6 +139,10 @@ func repoMisconfigRemediation(finding domain.Finding) (RepoExposureRemediation, 
 		return workflowCachePoisoningRemediation(finding, detector), true
 	case "workflow_artifact_poisoning":
 		return workflowArtifactPoisoningRemediation(finding, detector), true
+	case "workflow_self_hosted_runner":
+		return workflowSelfHostedRunnerRemediation(finding, detector), true
+	case "workflow_self_hosted_runner_unresolved":
+		return workflowUnresolvedRunnerRemediation(finding, detector), true
 	case "k8s_privileged_true":
 		return k8sPrivilegedRemediation(finding, detector), true
 	case "terraform_public_s3_acl":
@@ -386,6 +390,44 @@ func workflowArtifactPoisoningRemediation(finding domain.Finding, detector strin
 			"Verify release jobs require protected branch or environment context.",
 		},
 		"artifact remediation depends on producer and consumer workflow pairing")
+}
+
+func workflowSelfHostedRunnerRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return guidanceRepoRemediation(finding, detector,
+		"Keep untrusted workflows off self-hosted runners and isolate the runner pool.",
+		"A job on self-hosted GitHub Actions runners is reachable from untrusted events, so attacker-influenced input can run on infrastructure that may hold cloud, deployment, registry, or internal-network credentials.",
+		[]string{
+			"Run pull_request, issue, review, comment, and workflow_run jobs on ephemeral GitHub-hosted runners instead of self-hosted runners.",
+			"Move secrets, write tokens, id-token: write, cloud authentication, deploy environments, and release publishing off self-hosted jobs that untrusted events can reach.",
+			"Restrict self-hosted runner placement to protected branches or reviewed environments, and prefer ephemeral, single-use self-hosted runners over persistent ones.",
+		},
+		[]string{
+			"Self-hosted runners can retain credentials and state between jobs; treat any untrusted job that reached them as a potential compromise until reviewed.",
+			"Confirm runner-group visibility and required-approval settings on the GitHub side because repository workflow changes alone may not close the path.",
+		},
+		[]string{
+			"Open a fork pull request and confirm it cannot schedule onto self-hosted runners.",
+			"Review GitHub Actions runner-group and environment settings to verify untrusted events cannot reach privileged runners.",
+		},
+		"self-hosted runner remediation requires both workflow changes and runner/runner-group isolation review")
+}
+
+func workflowUnresolvedRunnerRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return guidanceRepoRemediation(finding, detector,
+		"Make runner placement auditable for untrusted-event jobs.",
+		"A job reachable from untrusted events selects its runner through an expression, matrix, or broad custom label, so reviewers cannot prove whether it runs on ephemeral GitHub-hosted or persistent self-hosted infrastructure.",
+		[]string{
+			"Pin untrusted-event jobs to explicit GitHub-hosted runner labels such as ubuntu-latest.",
+			"If a matrix or expression is required, constrain it so untrusted combinations cannot resolve to self-hosted runners.",
+			"Document and isolate any self-hosted runner pool the job can target so placement is reviewable.",
+		},
+		[]string{
+			"Dynamic labels can silently change which infrastructure runs untrusted code; re-review after any matrix or label change.",
+		},
+		[]string{
+			"Resolve the matrix and expression locally and confirm no untrusted combination lands on self-hosted runners.",
+		},
+		"runner-label remediation depends on the project's matrix and runner inventory")
 }
 
 func workflowGenericRemediation(finding domain.Finding, detector string) RepoExposureRemediation {

--- a/internal/findings/standards/repo_remediation_test.go
+++ b/internal/findings/standards/repo_remediation_test.go
@@ -24,6 +24,8 @@ func TestSuggestRepoExposureRemediationSupportsMisconfigDetectors(t *testing.T) 
 		{"workflow_oidc_broad_trust", false, false},
 		{"workflow_cache_poisoning", false, false},
 		{"workflow_artifact_poisoning", false, false},
+		{"workflow_self_hosted_runner", false, false},
+		{"workflow_self_hosted_runner_unresolved", false, false},
 		{"k8s_privileged_true", true, true},
 		{"terraform_public_s3_acl", true, true},
 		{"terraform_open_ssh_rdp", false, true},

--- a/internal/repoexposure/workflow_analyzer.go
+++ b/internal/repoexposure/workflow_analyzer.go
@@ -16,6 +16,9 @@ const workflowAnalyzerVersion = "2026.05"
 
 var gitHubActionCommitRefPattern = regexp.MustCompile(`^[a-f0-9]{40}$`)
 var workflowSecretsExpressionPattern = regexp.MustCompile(`\$\{\{\s*secrets\s*(?:\.|\[)`)
+var workflowExpressionPattern = regexp.MustCompile(`\$\{\{.*\}\}`)
+var workflowMatrixReferencePattern = regexp.MustCompile(`\$\{\{\s*matrix\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}`)
+var workflowMatrixBracketReferencePattern = regexp.MustCompile(`\$\{\{\s*matrix\[\s*['"]([a-zA-Z_][a-zA-Z0-9_-]*)\s*['"]\s*\]\s*\}\}`)
 
 type githubWorkflowModel struct {
 	Events      map[string]*yaml.Node
@@ -42,7 +45,23 @@ type githubWorkflowJob struct {
 	Secrets     map[string]string
 	SecretsRaw  string
 	Permissions workflowPermissions
+	RunsOn      workflowRunsOn
+	Environment string
 	Steps       []githubWorkflowStep
+}
+
+// workflowRunsOn captures a normalized view of a job's runner placement. It
+// records the literal labels for safe evidence and classifies whether the job
+// confidently targets self-hosted runners or whether the placement cannot be
+// resolved statically (expression-driven, matrix-driven, or broad custom
+// labels). It never stores runner credentials or registration tokens.
+type workflowRunsOn struct {
+	Configured bool
+	Line       int
+	Labels     []string
+	Group      string
+	SelfHosted bool
+	Unresolved bool
 }
 
 type githubWorkflowStep struct {
@@ -145,6 +164,48 @@ func analyzeGitHubWorkflowFindings(repo string, commit string, path string, ast 
 					"permission_summary": effectivePermissions.summary(),
 					"cloud_auth_action":  job.cloudAuthAction(),
 					"oidc_risk_context":  oidcContext,
+				}))
+		}
+
+		if untrustedEvent && job.RunsOn.SelfHosted {
+			amplifiers := job.selfHostedRiskAmplifiers(workflow.Env, effectivePermissions)
+			severity := domain.SeverityHigh
+			if len(amplifiers) > 0 {
+				severity = domain.SeverityCritical
+			}
+			evidence := map[string]any{
+				"self_hosted_runner": true,
+				"runner_labels":      job.RunsOn.labelEvidence(),
+				"labels_unresolved":  job.RunsOn.Unresolved,
+				"risk_amplifiers":    amplifiers,
+				"runner_capability":  runnerCapabilitySummary(amplifiers),
+				"permission_summary": effectivePermissions.summary(),
+				"references_secrets": jobSecrets,
+			}
+			if job.RunsOn.Group != "" {
+				evidence["runner_group"] = job.RunsOn.Group
+			}
+			if environment := strings.TrimSpace(job.Environment); environment != "" {
+				evidence["deployment_environment"] = environment
+			}
+			if action := job.cloudAuthAction(); action != "" {
+				evidence["cloud_auth_action"] = action
+			}
+			appendWorkflowFinding(&findings, seen, repo, commit, path, job.RunsOn.Line, "workflow_self_hosted_runner", severity,
+				"Self-hosted runner reachable from untrusted workflow context",
+				"A job that targets self-hosted GitHub Actions runners is reachable from pull request, issue, review, comment, or workflow_run triggers, so untrusted input can execute on infrastructure that may hold cloud, deployment, registry, or internal-network credentials.",
+				"Run untrusted-event jobs on ephemeral GitHub-hosted runners, isolate self-hosted runners behind protected branches or environments, and keep secrets, write tokens, and id-token: write off self-hosted jobs that untrusted events can reach.",
+				job.RunsOn.summary(), detectedAt, workflowEvidence(eventNames, job.ID, 0, "", evidence))
+		} else if untrustedEvent && job.RunsOn.Unresolved {
+			appendWorkflowFinding(&findings, seen, repo, commit, path, job.RunsOn.Line, "workflow_self_hosted_runner_unresolved", domain.SeverityMedium,
+				"Workflow runner placement cannot be statically audited",
+				"A job reachable from untrusted events selects its runner through an expression, matrix, or broad custom label, so Identrail cannot prove whether it lands on ephemeral GitHub-hosted or persistent self-hosted infrastructure.",
+				"Pin untrusted-event jobs to explicit GitHub-hosted runner labels, or document and isolate the self-hosted runner pool so reviewers can audit where untrusted code executes.",
+				job.RunsOn.summary(), detectedAt, workflowEvidence(eventNames, job.ID, 0, "", map[string]any{
+					"self_hosted_runner": false,
+					"runner_labels":      job.RunsOn.labelEvidence(),
+					"labels_unresolved":  true,
+					"permission_summary": effectivePermissions.summary(),
 				}))
 		}
 
@@ -256,6 +317,12 @@ func parseWorkflowJobs(node *yaml.Node) []githubWorkflowJob {
 		}
 		if permissionsNode, ok := yamlMappingValue(value, "permissions"); ok {
 			job.Permissions = parseWorkflowPermissions(permissionsNode)
+		}
+		if runsOnNode, ok := yamlMappingValue(value, "runs-on"); ok {
+			job.RunsOn = parseWorkflowRunsOn(runsOnNode, workflowJobMatrixValues(value))
+		}
+		if environmentNode, ok := yamlMappingValue(value, "environment"); ok {
+			job.Environment = parseWorkflowEnvironment(environmentNode)
 		}
 		if stepsNode, ok := yamlMappingValue(value, "steps"); ok && stepsNode.Kind == yaml.SequenceNode {
 			job.Steps = parseWorkflowSteps(stepsNode)
@@ -381,6 +448,223 @@ func parseWorkflowPermissions(node *yaml.Node) workflowPermissions {
 	return permissions
 }
 
+func parseWorkflowRunsOn(node *yaml.Node, matrixValues map[string][]string) workflowRunsOn {
+	runsOn := workflowRunsOn{Configured: node != nil, Line: workflowLine(node)}
+	if node == nil {
+		return runsOn
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		runsOn.Labels = append(runsOn.Labels, strings.TrimSpace(node.Value))
+	case yaml.SequenceNode:
+		for _, item := range node.Content {
+			if item != nil && item.Kind == yaml.ScalarNode {
+				if label := strings.TrimSpace(item.Value); label != "" {
+					runsOn.Labels = append(runsOn.Labels, label)
+				}
+			}
+		}
+	case yaml.MappingNode:
+		if groupNode, ok := yamlMappingValue(node, "group"); ok {
+			runsOn.Group = yamlScalarValue(groupNode)
+		}
+		if labelsNode, ok := yamlMappingValue(node, "labels"); ok {
+			switch labelsNode.Kind {
+			case yaml.ScalarNode:
+				if label := strings.TrimSpace(labelsNode.Value); label != "" {
+					runsOn.Labels = append(runsOn.Labels, label)
+				}
+			case yaml.SequenceNode:
+				for _, item := range labelsNode.Content {
+					if item != nil && item.Kind == yaml.ScalarNode {
+						if label := strings.TrimSpace(item.Value); label != "" {
+							runsOn.Labels = append(runsOn.Labels, label)
+						}
+					}
+				}
+			}
+		}
+	}
+	runsOn.classify(matrixValues)
+	return runsOn
+}
+
+func (runsOn *workflowRunsOn) classify(matrixValues map[string][]string) {
+	hasExpression := false
+	matrixExpressionKeys := map[string]struct{}{}
+	hasSelfHostedLabel := false
+	hasUnclassifiedLabel := false
+	for _, label := range runsOn.Labels {
+		lower := strings.ToLower(strings.TrimSpace(label))
+		switch {
+		case workflowExpressionPattern.MatchString(label):
+			hasExpression = true
+			for _, key := range workflowMatrixExpressionKeys(label) {
+				if strings.TrimSpace(key) != "" {
+					matrixExpressionKeys[key] = struct{}{}
+				}
+			}
+		case lower == "self-hosted":
+			hasSelfHostedLabel = true
+		case workflowHostedRunnerLabel(lower):
+			// Known GitHub-hosted runner image; no placement ambiguity.
+		default:
+			hasUnclassifiedLabel = true
+		}
+	}
+	if hasSelfHostedLabel {
+		runsOn.SelfHosted = true
+	}
+	if hasExpression && !runsOn.SelfHosted && workflowMatrixValuesIncludeReferencedSelfHosted(matrixValues, matrixExpressionKeys) {
+		runsOn.SelfHosted = true
+	}
+	if runsOn.Group != "" && !runsOn.SelfHosted {
+		runsOn.Unresolved = true
+	}
+	if !runsOn.SelfHosted && (hasExpression || hasUnclassifiedLabel) {
+		runsOn.Unresolved = true
+	}
+}
+
+func (runsOn workflowRunsOn) summary() string {
+	parts := []string{}
+	if runsOn.Group != "" {
+		parts = append(parts, "group:"+runsOn.Group)
+	}
+	if len(runsOn.Labels) > 0 {
+		parts = append(parts, "labels:"+strings.Join(runsOn.Labels, ","))
+	}
+	if len(parts) == 0 {
+		return "runs-on"
+	}
+	return "runs-on " + strings.Join(parts, " ")
+}
+
+func (runsOn workflowRunsOn) labelEvidence() []string {
+	if len(runsOn.Labels) == 0 {
+		return []string{}
+	}
+	return append([]string(nil), runsOn.Labels...)
+}
+
+func parseWorkflowEnvironment(node *yaml.Node) string {
+	if node == nil {
+		return ""
+	}
+	if node.Kind == yaml.ScalarNode {
+		return strings.TrimSpace(node.Value)
+	}
+	if node.Kind == yaml.MappingNode {
+		if nameNode, ok := yamlMappingValue(node, "name"); ok {
+			return yamlScalarValue(nameNode)
+		}
+	}
+	return ""
+}
+
+func workflowJobMatrixValues(jobNode *yaml.Node) map[string][]string {
+	strategyNode, ok := yamlMappingValue(jobNode, "strategy")
+	if !ok {
+		return map[string][]string{}
+	}
+	matrixNode, ok := yamlMappingValue(strategyNode, "matrix")
+	if !ok {
+		return map[string][]string{}
+	}
+	return collectWorkflowMatrixValues(matrixNode)
+}
+
+func collectWorkflowMatrixValues(node *yaml.Node) map[string][]string {
+	valuesByKey := map[string][]string{}
+	if node == nil || node.Kind != yaml.MappingNode {
+		return valuesByKey
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		valueNode := node.Content[i+1]
+		if keyNode == nil || valueNode == nil {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(keyNode.Value))
+		if key == "" {
+			continue
+		}
+		values := valuesByKey[key]
+		collectWorkflowMatrixScalarValues(valueNode, &values)
+		valuesByKey[key] = values
+	}
+	return valuesByKey
+}
+
+func collectWorkflowMatrixScalarValues(node *yaml.Node, values *[]string) {
+	if node == nil {
+		return
+	}
+	if node.Kind == yaml.ScalarNode {
+		if value := strings.TrimSpace(node.Value); value != "" {
+			*values = append(*values, value)
+		}
+		return
+	}
+	if node.Kind != yaml.SequenceNode {
+		return
+	}
+	for _, child := range node.Content {
+		if child != nil && child.Kind == yaml.ScalarNode {
+			if value := strings.TrimSpace(child.Value); value != "" {
+				*values = append(*values, value)
+			}
+		}
+	}
+}
+
+func workflowMatrixExpressionKeys(label string) []string {
+	keys := []string{}
+	for _, match := range workflowMatrixReferencePattern.FindAllStringSubmatch(label, -1) {
+		if len(match) >= 2 && strings.TrimSpace(match[1]) != "" {
+			keys = append(keys, strings.ToLower(strings.TrimSpace(match[1])))
+		}
+	}
+	for _, match := range workflowMatrixBracketReferencePattern.FindAllStringSubmatch(label, -1) {
+		if len(match) >= 2 && strings.TrimSpace(match[1]) != "" {
+			keys = append(keys, strings.ToLower(strings.TrimSpace(match[1])))
+		}
+	}
+	return keys
+}
+
+func workflowMatrixValuesIncludeReferencedSelfHosted(valuesByKey map[string][]string, keys map[string]struct{}) bool {
+	if len(keys) == 0 {
+		return false
+	}
+	for key := range keys {
+		if workflowMatrixValuesIncludeSelfHosted(valuesByKey[key]) {
+			return true
+		}
+	}
+	return false
+}
+
+func workflowMatrixValuesIncludeSelfHosted(values []string) bool {
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), "self-hosted") {
+			return true
+		}
+	}
+	return false
+}
+
+func workflowHostedRunnerLabel(label string) bool {
+	switch strings.ToLower(strings.TrimSpace(label)) {
+	case "ubuntu-latest", "ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04",
+		"windows-latest", "windows-2019", "windows-2022",
+		"macos-latest", "macos-13", "macos-14":
+		return true
+	default:
+		return false
+	}
+}
+
 func (workflow githubWorkflowModel) effectivePermissions(job githubWorkflowJob) workflowPermissions {
 	if job.Permissions.configured() {
 		return job.Permissions
@@ -487,6 +771,54 @@ func (job githubWorkflowJob) usesReleaseOrCloudStep() bool {
 		}
 	}
 	return false
+}
+
+func (job githubWorkflowJob) usesReleaseStep() bool {
+	for _, step := range job.Steps {
+		if step.usesReleaseBehavior() {
+			return true
+		}
+	}
+	return false
+}
+
+func (job githubWorkflowJob) usesUntrustedCheckout() bool {
+	for _, step := range job.Steps {
+		if step.checkoutUsesUntrustedHead() {
+			return true
+		}
+	}
+	return false
+}
+
+// selfHostedRiskAmplifiers returns the safe capability labels that make a
+// self-hosted runner job more dangerous when reached from untrusted events. The
+// list is deterministic and never includes secret values.
+func (job githubWorkflowJob) selfHostedRiskAmplifiers(workflowEnv map[string]string, permissions workflowPermissions) []string {
+	amplifiers := []string{}
+	if job.referencesSecrets(workflowEnv) {
+		amplifiers = append(amplifiers, "secrets")
+	}
+	if permissions.hasBroadGitHubTokenWrite() {
+		amplifiers = append(amplifiers, "write_token")
+	}
+	if permissions.idTokenWrite() {
+		amplifiers = append(amplifiers, "id_token")
+	}
+	if job.usesCloudAuthAction() {
+		amplifiers = append(amplifiers, "cloud_auth")
+	}
+	if strings.TrimSpace(job.Environment) != "" {
+		amplifiers = append(amplifiers, "environment")
+	}
+	if job.usesReleaseStep() {
+		amplifiers = append(amplifiers, "release")
+	}
+	if job.usesUntrustedCheckout() {
+		amplifiers = append(amplifiers, "untrusted_checkout")
+	}
+	sort.Strings(amplifiers)
+	return amplifiers
 }
 
 func (step githubWorkflowStep) checkoutUsesUntrustedHead() bool {
@@ -866,6 +1198,13 @@ func truncateWorkflowSnippet(value string) string {
 		return trimmed[:240] + "..."
 	}
 	return trimmed
+}
+
+func runnerCapabilitySummary(amplifiers []string) string {
+	if len(amplifiers) == 0 {
+		return "untrusted_reachable"
+	}
+	return "untrusted_privileged"
 }
 
 func firstNonEmptyWorkflowString(values ...string) string {

--- a/internal/repoexposure/workflow_analyzer.go
+++ b/internal/repoexposure/workflow_analyzer.go
@@ -17,8 +17,27 @@ const workflowAnalyzerVersion = "2026.05"
 var gitHubActionCommitRefPattern = regexp.MustCompile(`^[a-f0-9]{40}$`)
 var workflowSecretsExpressionPattern = regexp.MustCompile(`\$\{\{\s*secrets\s*(?:\.|\[)`)
 var workflowExpressionPattern = regexp.MustCompile(`\$\{\{.*\}\}`)
-var workflowMatrixReferencePattern = regexp.MustCompile(`\$\{\{\s*matrix\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}`)
-var workflowMatrixBracketReferencePattern = regexp.MustCompile(`\$\{\{\s*matrix\[\s*['"]([a-zA-Z_][a-zA-Z0-9_-]*)\s*['"]\s*\]\s*\}\}`)
+var workflowMatrixReferencePattern = regexp.MustCompile(`\$\{\{\s*matrix\.([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*)\s*\}\}`)
+var workflowMatrixBracketReferencePattern = regexp.MustCompile(`\$\{\{\s*matrix((?:\[\s*['\"][a-zA-Z_][a-zA-Z0-9_-]*['\"]\s*\])+)\s*\}\}`)
+var workflowMatrixBracketSegmentPattern = regexp.MustCompile(`\[\s*['\"]([a-zA-Z_][a-zA-Z0-9_-]*)['\"]\s*\]`)
+
+var workflowHostedRunnerLabels = map[string]struct{}{
+	"ubuntu-latest":    {},
+	"ubuntu-20.04":     {},
+	"ubuntu-22.04":     {},
+	"ubuntu-24.04":     {},
+	"ubuntu-24.04-arm": {},
+	"ubuntu-slim":      {},
+	"windows-latest":   {},
+	"windows-2019":     {},
+	"windows-2022":     {},
+	"windows-2025":     {},
+	"windows-11-arm":   {},
+	"macos-latest":     {},
+	"macos-13":         {},
+	"macos-14":         {},
+	"macos-15":         {},
+}
 
 type githubWorkflowModel struct {
 	Events      map[string]*yaml.Node
@@ -589,31 +608,36 @@ func collectWorkflowMatrixValues(node *yaml.Node) map[string][]string {
 		if key == "" {
 			continue
 		}
-		values := valuesByKey[key]
-		collectWorkflowMatrixScalarValues(valueNode, &values)
-		valuesByKey[key] = values
+		collectWorkflowMatrixValuesForPath(valueNode, key, valuesByKey)
 	}
 	return valuesByKey
 }
 
-func collectWorkflowMatrixScalarValues(node *yaml.Node, values *[]string) {
+func collectWorkflowMatrixValuesForPath(node *yaml.Node, path string, valuesByKey map[string][]string) {
 	if node == nil {
 		return
 	}
-	if node.Kind == yaml.ScalarNode {
+	switch node.Kind {
+	case yaml.ScalarNode:
 		if value := strings.TrimSpace(node.Value); value != "" {
-			*values = append(*values, value)
+			valuesByKey[path] = append(valuesByKey[path], value)
 		}
-		return
-	}
-	if node.Kind != yaml.SequenceNode {
-		return
-	}
-	for _, child := range node.Content {
-		if child != nil && child.Kind == yaml.ScalarNode {
-			if value := strings.TrimSpace(child.Value); value != "" {
-				*values = append(*values, value)
+	case yaml.SequenceNode:
+		for _, child := range node.Content {
+			collectWorkflowMatrixValuesForPath(child, path, valuesByKey)
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			childKeyNode := node.Content[i]
+			childValueNode := node.Content[i+1]
+			if childKeyNode == nil || childValueNode == nil {
+				continue
 			}
+			childKey := strings.ToLower(strings.TrimSpace(childKeyNode.Value))
+			if childKey == "" {
+				continue
+			}
+			collectWorkflowMatrixValuesForPath(childValueNode, path+"."+childKey, valuesByKey)
 		}
 	}
 }
@@ -626,8 +650,18 @@ func workflowMatrixExpressionKeys(label string) []string {
 		}
 	}
 	for _, match := range workflowMatrixBracketReferencePattern.FindAllStringSubmatch(label, -1) {
-		if len(match) >= 2 && strings.TrimSpace(match[1]) != "" {
-			keys = append(keys, strings.ToLower(strings.TrimSpace(match[1])))
+		if len(match) < 2 || strings.TrimSpace(match[1]) == "" {
+			continue
+		}
+		parts := []string{}
+		for _, segmentMatch := range workflowMatrixBracketSegmentPattern.FindAllStringSubmatch(match[1], -1) {
+			if len(segmentMatch) < 2 || strings.TrimSpace(segmentMatch[1]) == "" {
+				continue
+			}
+			parts = append(parts, strings.ToLower(strings.TrimSpace(segmentMatch[1])))
+		}
+		if len(parts) > 0 {
+			keys = append(keys, strings.Join(parts, "."))
 		}
 	}
 	return keys
@@ -655,14 +689,8 @@ func workflowMatrixValuesIncludeSelfHosted(values []string) bool {
 }
 
 func workflowHostedRunnerLabel(label string) bool {
-	switch strings.ToLower(strings.TrimSpace(label)) {
-	case "ubuntu-latest", "ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04",
-		"windows-latest", "windows-2019", "windows-2022",
-		"macos-latest", "macos-13", "macos-14":
-		return true
-	default:
-		return false
-	}
+	_, ok := workflowHostedRunnerLabels[strings.ToLower(strings.TrimSpace(label))]
+	return ok
 }
 
 func (workflow githubWorkflowModel) effectivePermissions(job githubWorkflowJob) workflowPermissions {

--- a/internal/repoexposure/workflow_analyzer_test.go
+++ b/internal/repoexposure/workflow_analyzer_test.go
@@ -464,6 +464,279 @@ jobs:
 	})
 }
 
+func TestGitHubWorkflowAnalyzerFlagsPrivilegedSelfHostedRunner(t *testing.T) {
+	content := []byte(`name: pr-target-self-hosted
+on: pull_request_target
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  deploy:
+    runs-on: self-hosted
+    environment: production
+    steps:
+      - uses: aws-actions/configure-aws-credentials@f00dbabe1234567890abcdef1234567890abcdef
+      - run: ./deploy.sh
+        env:
+          TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/self-hosted.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	assertWorkflowDetectors(t, findings, []string{
+		"workflow_self_hosted_runner",
+	})
+
+	runner := firstDetectorFinding(t, findings, "workflow_self_hosted_runner")
+	if runner.Severity != domain.SeverityCritical {
+		t.Fatalf("expected privileged self-hosted runner to be critical, got %+v", runner)
+	}
+	if labels, _ := runner.Evidence["runner_labels"].([]string); len(labels) != 1 || labels[0] != "self-hosted" {
+		t.Fatalf("expected self-hosted label evidence, got %+v", runner.Evidence)
+	}
+	if selfHosted, _ := runner.Evidence["self_hosted_runner"].(bool); !selfHosted {
+		t.Fatalf("expected self_hosted_runner evidence true, got %+v", runner.Evidence)
+	}
+	if env, _ := runner.Evidence["deployment_environment"].(string); env != "production" {
+		t.Fatalf("expected production environment evidence, got %+v", runner.Evidence)
+	}
+	for _, amplifier := range []string{"cloud_auth", "environment", "id_token", "secrets"} {
+		if !workflowEvidenceHasString(runner.Evidence["risk_amplifiers"], amplifier) {
+			t.Fatalf("expected risk amplifier %s, got %+v", amplifier, runner.Evidence["risk_amplifiers"])
+		}
+	}
+	if capability, _ := runner.Evidence["runner_capability"].(string); capability != "untrusted_privileged" {
+		t.Fatalf("expected untrusted_privileged capability, got %+v", runner.Evidence)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerFlagsArraySelfHostedRunnerWithoutAmplifiers(t *testing.T) {
+	content := []byte(`name: pr-self-hosted-array
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: [self-hosted, linux, x64, prod]
+    steps:
+      - run: make test
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/array.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	runner := firstDetectorFinding(t, findings, "workflow_self_hosted_runner")
+	if runner.Severity != domain.SeverityHigh {
+		t.Fatalf("expected unamplified self-hosted runner to be high, got %+v", runner)
+	}
+	if unresolved, _ := runner.Evidence["labels_unresolved"].(bool); unresolved {
+		t.Fatalf("expected explicit self-hosted array labels to be resolved, got %+v", runner.Evidence)
+	}
+	labels, _ := runner.Evidence["runner_labels"].([]string)
+	if len(labels) != 4 || labels[0] != "self-hosted" || labels[3] != "prod" {
+		t.Fatalf("expected ordered array label evidence, got %+v", runner.Evidence)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerFlagsRunnerGroupAsSelfHosted(t *testing.T) {
+	content := []byte(`name: group-runner
+on: pull_request_target
+permissions:
+  contents: write
+jobs:
+  build:
+    runs-on:
+      group: gpu-runners
+      labels: [self-hosted, gpu]
+    steps:
+      - run: make build
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/group.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	runner := firstDetectorFinding(t, findings, "workflow_self_hosted_runner")
+	if runner.Severity != domain.SeverityCritical {
+		t.Fatalf("expected write-token self-hosted runner to be critical, got %+v", runner)
+	}
+	if group, _ := runner.Evidence["runner_group"].(string); group != "gpu-runners" {
+		t.Fatalf("expected runner group evidence, got %+v", runner.Evidence)
+	}
+	if !workflowEvidenceHasString(runner.Evidence["risk_amplifiers"], "write_token") {
+		t.Fatalf("expected write_token amplifier, got %+v", runner.Evidence["risk_amplifiers"])
+	}
+}
+
+func TestGitHubWorkflowAnalyzerTreatsRunnerGroupWithoutSelfHostedLabelAsUnresolved(t *testing.T) {
+	content := []byte(`name: group-runner-unresolved
+on:
+  pull_request
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on:
+      group: gpu-runners
+      labels: [linux, x64]
+    steps:
+      - run: make build
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/group.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	if containsDetector(findings, "workflow_self_hosted_runner") {
+		t.Fatalf("expected group runner without explicit self-hosted label to be unresolved, got %+v", findings)
+	}
+	unresolved := firstDetectorFinding(t, findings, "workflow_self_hosted_runner_unresolved")
+	if unresolved.Severity != domain.SeverityMedium {
+		t.Fatalf("expected unresolved group-runner finding to be medium, got %+v", unresolved)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerResolvesMatrixSelfHostedRunner(t *testing.T) {
+	content := []byte(`name: matrix-self-hosted
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  test:
+    strategy:
+      matrix:
+        runner: [ubuntu-latest, self-hosted]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - run: make test
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/matrix-self-hosted.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	assertWorkflowDetectors(t, findings, []string{
+		"workflow_self_hosted_runner",
+	})
+	if containsDetector(findings, "workflow_self_hosted_runner_unresolved") {
+		t.Fatalf("expected matrix self-hosted value to resolve to self-hosted, got %+v", findings)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerRespectsReferencedMatrixKeyForSelfHostedResolution(t *testing.T) {
+	content := []byte(`name: matrix-different-axis
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        runner: [self-hosted]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - run: make test
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/matrix-other-axis.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	assertWorkflowDetectors(t, findings, []string{
+		"workflow_self_hosted_runner_unresolved",
+	})
+	if containsDetector(findings, "workflow_self_hosted_runner") {
+		t.Fatalf("expected referenced matrix key isolation to avoid false positive self-hosted, got %+v", findings)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerTreatsExpressionRunnerAsUnresolved(t *testing.T) {
+	content := []byte(`name: matrix-runner
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - run: make test
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/matrix.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	assertWorkflowDetectors(t, findings, []string{
+		"workflow_self_hosted_runner_unresolved",
+	})
+	if containsDetector(findings, "workflow_self_hosted_runner") {
+		t.Fatalf("expected unresolved matrix runner not to assert self-hosted, got %+v", findings)
+	}
+	unresolved := firstDetectorFinding(t, findings, "workflow_self_hosted_runner_unresolved")
+	if unresolved.Severity != domain.SeverityMedium {
+		t.Fatalf("expected unresolved runner finding to be medium, got %+v", unresolved)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerTreatsBroadCustomLabelAsUnresolved(t *testing.T) {
+	content := []byte(`name: custom-runner
+on: issue_comment
+permissions:
+  contents: read
+jobs:
+  triage:
+    runs-on: my-fleet
+    steps:
+      - run: make triage
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/custom.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	assertWorkflowDetectors(t, findings, []string{
+		"workflow_self_hosted_runner_unresolved",
+	})
+}
+
+func TestGitHubWorkflowAnalyzerDoesNotFlagTrustedSelfHostedRunner(t *testing.T) {
+	content := []byte(`name: push-self-hosted
+on:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: [self-hosted, linux]
+    steps:
+      - run: make build
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/push-self-hosted.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	for _, detector := range []string{"workflow_self_hosted_runner", "workflow_self_hosted_runner_unresolved"} {
+		if containsDetector(findings, detector) {
+			t.Fatalf("expected trusted-only self-hosted runner not to emit %s, got %+v", detector, findings)
+		}
+	}
+}
+
+func TestGitHubWorkflowAnalyzerDoesNotFlagGitHubHostedRunner(t *testing.T) {
+	content := []byte(`name: pr-hosted
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: make test
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/hosted.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	for _, detector := range []string{"workflow_self_hosted_runner", "workflow_self_hosted_runner_unresolved"} {
+		if containsDetector(findings, detector) {
+			t.Fatalf("expected GitHub-hosted runner not to emit %s, got %+v", detector, findings)
+		}
+	}
+}
+
+func workflowEvidenceHasString(value any, want string) bool {
+	values, ok := value.([]string)
+	if !ok {
+		return false
+	}
+	for _, candidate := range values {
+		if candidate == want {
+			return true
+		}
+	}
+	return false
+}
+
 func assertWorkflowDetectors(t *testing.T, findings []domain.Finding, detectors []string) {
 	t.Helper()
 	for _, detector := range detectors {

--- a/internal/repoexposure/workflow_analyzer_test.go
+++ b/internal/repoexposure/workflow_analyzer_test.go
@@ -611,6 +611,32 @@ jobs:
 	}
 }
 
+func TestGitHubWorkflowAnalyzerResolvesNestedMatrixSelfHostedRunner(t *testing.T) {
+	content := []byte(`name: matrix-object-self-hosted
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  test:
+    strategy:
+      matrix:
+        target:
+          - runner: ubuntu-latest
+          - runner: self-hosted
+    runs-on: ${{ matrix.target.runner }}
+    steps:
+      - run: make test
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/matrix-object-self-hosted.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	assertWorkflowDetectors(t, findings, []string{
+		"workflow_self_hosted_runner",
+	})
+	if containsDetector(findings, "workflow_self_hosted_runner_unresolved") {
+		t.Fatalf("expected nested matrix self-hosted value to resolve to self-hosted, got %+v", findings)
+	}
+}
+
 func TestGitHubWorkflowAnalyzerRespectsReferencedMatrixKeyForSelfHostedResolution(t *testing.T) {
 	content := []byte(`name: matrix-different-axis
 on: pull_request
@@ -661,6 +687,26 @@ jobs:
 	unresolved := firstDetectorFinding(t, findings, "workflow_self_hosted_runner_unresolved")
 	if unresolved.Severity != domain.SeverityMedium {
 		t.Fatalf("expected unresolved runner finding to be medium, got %+v", unresolved)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerRecognizesAdditionalGitHubHostedRunnerLabels(t *testing.T) {
+	content := []byte(`name: hosted-arm
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - run: make test
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/hosted-arm.yml", content, time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC))
+	for _, detector := range []string{"workflow_self_hosted_runner", "workflow_self_hosted_runner_unresolved"} {
+		if containsDetector(findings, detector) {
+			t.Fatalf("expected additional hosted runner labels not to emit %s, got %+v", detector, findings)
+		}
 	}
 }
 

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1527,11 +1527,11 @@ describe('App', () => {
 
     await waitFor(() => {
       expect(
-        fetchMock.mock.calls.some(([url]) => typeof url === 'string' && url.includes('/v1/findings/repo-f1/triage'))
+        fetchMock.mock.calls.some(([url]) => String(url).includes('/v1/findings/repo-f1/triage'))
       ).toBe(true);
     });
 
-    const triageCall = fetchMock.mock.calls.find(([url]) => typeof url === 'string' && url.includes('/v1/findings/repo-f1/triage'));
+    const triageCall = fetchMock.mock.calls.find(([url]) => String(url).includes('/v1/findings/repo-f1/triage'));
     const payload = JSON.parse(String((triageCall?.[1] as RequestInit | undefined)?.body));
     expect(payload.assignee).toBe('platform');
     expect(payload.comment).toBeUndefined();

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -282,13 +282,17 @@ describe('apiClient', () => {
       {
         repo_scan_id: 'repo-scan-1',
         severity: 'high',
-        type: 'secret_exposure'
+        type: 'secret_exposure',
+        source: 'github_secret_scanning',
+        min_confidence: 0.8
       },
       { apiKey: 'reader' }
     );
 
     const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toContain('/v1/repo-findings?sort_by=created_at&sort_order=desc&repo_scan_id=repo-scan-1&severity=high&type=secret_exposure');
+    expect(url).toContain(
+      '/v1/repo-findings?sort_by=created_at&sort_order=desc&repo_scan_id=repo-scan-1&severity=high&type=secret_exposure&source=github_secret_scanning&min_confidence=0.8'
+    );
     const headers = new Headers(options.headers);
     expect(headers.get('x-api-key')).toBe('reader');
   });

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1371,6 +1371,7 @@ export const apiClient = {
       repository?: string;
       severity?: string;
       type?: string;
+      source?: string;
       repo_lifecycle_status?: RepoFindingLifecycleStatus;
       detector?: string;
       owner?: string;

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -5420,6 +5420,8 @@ export function ProductFindingsPage() {
   const [typeFilter, setTypeFilter] = useState<(typeof REPO_FINDING_TYPE_FILTERS)[number]>('all');
   const [statusFilter, setStatusFilter] = useState<(typeof REPO_FINDING_STATUS_FILTERS)[number]>('all');
   const [assigneeFilter, setAssigneeFilter] = useState('');
+  const [sourceFilter, setSourceFilter] = useState('');
+  const [minConfidenceFilter, setMinConfidenceFilter] = useState('');
   const [sortBy, setSortBy] = useState<(typeof REPO_FINDING_SORT_FIELDS)[number]>('severity');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const [selectedFindingKey, setSelectedFindingKey] = useState('');
@@ -5541,6 +5543,8 @@ export function ProductFindingsPage() {
     setError('');
     try {
       const auth = buildProductAuthContext(targetScope);
+      const sourceFilterValue = normalizeValue(sourceFilter).toLowerCase();
+      const normalizedMinConfidence = Number.parseFloat(normalizeValue(minConfidenceFilter));
       const [repoScanResponse, repoFindingResponse] = await Promise.all([
         apiClient.listRepoScans({ limit: 50 }, auth),
         apiClient.listRepoFindings(
@@ -5549,8 +5553,10 @@ export function ProductFindingsPage() {
             repo_scan_id: normalizeValue(repoScanFilter) || undefined,
             severity: severityFilter !== 'all' ? severityFilter : undefined,
             type: typeFilter !== 'all' ? typeFilter : undefined,
+            source: sourceFilterValue || undefined,
             lifecycle_status: statusFilter !== 'all' ? statusFilter : undefined,
             assignee: normalizeValue(assigneeFilter) || undefined,
+            min_confidence: Number.isFinite(normalizedMinConfidence) ? normalizedMinConfidence : undefined,
             sort_by: sortBy,
             sort_order: sortOrder
           },
@@ -5772,6 +5778,8 @@ export function ProductFindingsPage() {
     typeFilter,
     statusFilter,
     assigneeFilter,
+    sourceFilter,
+    minConfidenceFilter,
     sortBy,
     sortOrder
   ]);
@@ -5878,7 +5886,9 @@ export function ProductFindingsPage() {
     severityFilter !== 'all' ||
     typeFilter !== 'all' ||
     statusFilter !== 'all' ||
-    normalizeValue(assigneeFilter) !== '';
+    normalizeValue(assigneeFilter) !== '' ||
+    normalizeValue(sourceFilter) !== '' ||
+    normalizeValue(minConfidenceFilter) !== '';
 
   const formatScanDate = (scan: RepoScanRecord | null): string => {
     if (!scan) {
@@ -6132,6 +6142,27 @@ export function ProductFindingsPage() {
               onChange={(event) => setAssigneeFilter(event.target.value)}
             />
           </label>
+          <label>
+            Source
+            <input
+              type="text"
+              placeholder="Filter by source (for example github_secret_scanning)"
+              value={sourceFilter}
+              onChange={(event) => setSourceFilter(event.target.value)}
+            />
+          </label>
+          <label>
+            Min confidence
+            <input
+              type="number"
+              step="0.01"
+              min="0"
+              max="1"
+              placeholder="e.g. 0.7"
+              value={minConfidenceFilter}
+              onChange={(event) => setMinConfidenceFilter(event.target.value)}
+            />
+          </label>
         </div>
       </details>
       ) : null}
@@ -6194,6 +6225,7 @@ export function ProductFindingsPage() {
                             </div>
                             <div className="idt-repo-finding-row-meta">
                               <span className={repoFindingStatusClass(lifecycle)}>{formatTokenLabel(lifecycle)}</span>
+                              <span>{`Source ${finding.adapter_source || 'native'}`}</span>
                               <span>{`Owner ${finding.owner || finding.triage?.assignee || 'Unassigned'}`}</span>
                               <span>{`Triage ${formatTokenLabel(triageStatus)}`}</span>
                             </div>


### PR DESCRIPTION
Fixes #1327

## What changed

- Added static GitHub Actions analysis for self-hosted runner usage reachable from untrusted events.
- Added `workflow_self_hosted_runner` and `workflow_self_hosted_runner_unresolved` findings with safe runner-label, event, job, permission, environment, and risk-amplifier evidence.
- Added repository posture collection for visible self-hosted runners and best-effort organization runner-group breadth.
- Added remediation guidance for explicit self-hosted runner findings and unresolved runner placement findings.
- Updated repo exposure docs to list self-hosted runner and unresolved runner placement coverage.

## Why it changed

Self-hosted GitHub Actions runners are a machine-identity boundary. They can hold persistent cloud, deployment, registry, and internal-network credentials. Identrail already understands risky workflow permissions and untrusted event inputs; this extends that workflow intelligence to runner placement.

## Impact and risk

- Untrusted-event workflows that explicitly target self-hosted runners now produce actionable findings.
- Dynamic, matrix-driven, or custom runner labels that cannot be statically audited produce a medium-severity unresolved-placement finding rather than false confidence.
- GitHub posture now includes a `self_hosted_runners` check with permission-limited/unavailable handling through the existing posture model.
- Evidence is intentionally summary-shaped and does not include runner credentials or registration tokens.

## Validation performed

- `gofmt -w internal/connectors/github/posture.go internal/connectors/github/posture_test.go internal/findings/standards/repo_remediation.go internal/findings/standards/repo_remediation_test.go internal/repoexposure/workflow_analyzer.go internal/repoexposure/workflow_analyzer_test.go`
- `go test ./internal/repoexposure ./internal/connectors/github ./internal/findings/standards`
- `go test ./... -coverprofile=coverage.out`
- `go tool cover -func=coverage.out` => total coverage `80.3%`
- pre-commit hooks during commit: merge-conflict check, end-of-file check, trailing whitespace, gofmt, Vercel artifact hygiene
- pre-push hooks during push: merge-conflict check, end-of-file check, trailing whitespace, gofmt, `go vet`, local env token hygiene, Vercel artifact hygiene

AI-assisted: yes
Tools used: Codex
Where used: GitHub self-hosted runner posture implementation, tests, docs, validation, and PR preparation
Human verification performed: Reviewed the focused diff and ran the validation commands listed above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds self-hosted runner posture and workflow analysis to flag risky runner placement from untrusted events, with tighter runner classification to reduce false positives. Implements #1327 and adds `source`/`min_confidence` repo‑finding filters in the API and product UI.

- **New Features**
  - Workflow analysis: detects self-hosted runners reachable from untrusted events; treats expressions/matrix/broad labels as unresolved; resolves matrix only when the referenced key includes `self-hosted`; runner groups without an explicit `self-hosted` label are unresolved; expands GitHub‑hosted labels (e.g. `ubuntu-24.04-arm`, `ubuntu-slim`, `windows-2025`, `windows-11-arm`, `macos-13/14/15`); raises to critical when amplifiers are present (secrets, write token, `id-token`, cloud auth, environment, release, untrusted_checkout).
  - Findings: `workflow_self_hosted_runner` and `workflow_self_hosted_runner_unresolved` with concise evidence (runner labels/group, capability `untrusted_reachable` vs `untrusted_privileged`, permission summary).
  - GitHub posture: new `self_hosted_runners` check with repo runner inventory (online/offline/busy, labels, OS) and org runner‑group breadth; filters `selected` org groups by repository membership; handles permission‑limited/unavailable and records group visibility in evidence.
  - API/UI: repo findings API/DB add `source` and `min_confidence` filters; product adds Source and Min confidence filters and shows Source on finding rows; docs and OpenAPI document both params; remediation added for both runner findings.

- **Bug Fixes**
  - Tests: stabilize triage fetch assertions to handle URL object inputs.

<sup>Written for commit 863579d371e99da18b06724d8b544321664e065c. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1333?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

