### PR TITLE
GitHub intelligence: add organization policy posture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## Unreleased
+- Added GitHub organization-level security policy posture as inherited context
+  for repository posture. GitHub App-backed posture now distinguishes repository
+  controls from organization policy controls such as enforced code security
+  configurations, Actions policy, workflow token defaults, reusable-workflow
+  allowlists, and central code security posture, with explicit `unsupported` and
+  `unknown` states when GitHub cannot prove the control.
 - Added structured repository scan diagnostics to API errors and the hosted app
   so enqueue/list failures can distinguish disabled scans, allowlist or
   selected-repository rejection, queue pressure, missing migrations, GitHub App

--- a/docs/auth/github-connector.md
+++ b/docs/auth/github-connector.md
@@ -221,6 +221,39 @@ The manifest permissions that support this collection are read-only:
 If one of these permissions is missing, the corresponding posture check should
 return `permission_limited` instead of failing the whole collection.
 
+## Organization Policy Posture
+
+Repository posture answers what is configured on one selected repository.
+GitHub App-backed posture collection also attempts to collect the organization
+security policy inherited by that repository owner, when GitHub exposes it to
+the installation.
+
+Organization posture is returned separately from repository posture so callers
+can distinguish a local repository gap from an inherited policy-plane gap. The
+collector currently evaluates:
+
+- organization secret scanning and push protection policy through
+  organization-scoped enforced code security configurations
+- organization Actions policy, including whether all actions are allowed
+- organization default workflow token permissions and whether Actions can
+  approve pull requests
+- selected-actions / reusable-workflow allowlist posture when applicable
+- organization code security configurations, including whether a central
+  organization-scoped configuration is enforced and enables protective controls
+  such as secret scanning or push protection
+
+Organization checks use the same normalized states as repository checks:
+`secure`, `insecure`, `permission_limited`, `unavailable`, `unsupported`, and
+`unknown`. `permission_limited`, `unsupported`, and `unknown` are never treated
+as passing controls. They indicate that GitHub did not expose enough information
+for Identrail to prove the policy is safe.
+
+Organization posture is best-effort enrichment. If the repository owner is a
+personal account, the installation lacks organization read permissions, the
+account plan does not expose a control, or GitHub returns an unavailable
+endpoint, repository posture still returns normally and the affected
+organization checks record the most precise non-secure state available.
+
 ## Imported GitHub Alert Findings
 
 Repository posture answers whether a security feature is configured. Connector-

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -5397,6 +5397,8 @@ components:
           enum: [github_app]
         posture:
           $ref: "#/components/schemas/GitHubRepositoryPosture"
+        organization_posture:
+          $ref: "#/components/schemas/GitHubOrganizationPosture"
     GitHubRepositoryPosture:
       type: object
       required: [repository, collected_at, checks]
@@ -5404,6 +5406,26 @@ components:
         repository:
           type: string
           description: Normalized selected repository in `owner/name` form.
+        installation_id:
+          type: integer
+          format: int64
+          minimum: 1
+        collected_at:
+          type: string
+          format: date-time
+        checks:
+          type: array
+          items:
+            $ref: "#/components/schemas/GitHubRepositoryPostureCheck"
+        rate_limit:
+          $ref: "#/components/schemas/GitHubRateLimitState"
+    GitHubOrganizationPosture:
+      type: object
+      required: [organization, collected_at, checks]
+      properties:
+        organization:
+          type: string
+          description: Normalized GitHub organization login that owns the selected repository.
         installation_id:
           type: integer
           format: int64
@@ -5429,7 +5451,7 @@ components:
           example: branch_protection
         state:
           type: string
-          enum: [secure, insecure, unavailable, permission_limited]
+          enum: [secure, insecure, unavailable, permission_limited, unsupported, unknown]
         reason:
           type: string
           example: protection_enforced

--- a/internal/api/github_connect.go
+++ b/internal/api/github_connect.go
@@ -82,9 +82,11 @@ type GitHubRepositoryLister interface {
 	ListInstallationRepositories(ctx context.Context, installationID int64) ([]githubconnector.Repository, error)
 }
 
-// GitHubRepositoryPostureCollector collects GitHub repository posture through an installation token.
+// GitHubRepositoryPostureCollector collects GitHub repository and organization
+// posture through an installation token.
 type GitHubRepositoryPostureCollector interface {
 	CollectRepositoryPosture(ctx context.Context, installationID int64, repository string) (githubconnector.RepositoryPosture, error)
+	CollectOrganizationPosture(ctx context.Context, installationID int64, organization string, repository string) (githubconnector.OrganizationPosture, error)
 }
 
 // GitHubConnectorStartRequest captures the flat connector GitHub App bootstrap request.
@@ -149,11 +151,15 @@ type GitHubRepositoryListResponse struct {
 	Repositories []GitHubRepositoryStatus `json:"repositories"`
 }
 
-// GitHubRepositoryPostureResponse returns normalized posture for one selected repository.
+// GitHubRepositoryPostureResponse returns normalized posture for one selected
+// repository plus the organization-level policy it inherits. The organization
+// posture is omitted when it could not be collected, so existing repository
+// posture consumers are unaffected.
 type GitHubRepositoryPostureResponse struct {
-	ConnectorID string                            `json:"connector_id"`
-	Provider    string                            `json:"provider"`
-	Posture     githubconnector.RepositoryPosture `json:"posture"`
+	ConnectorID         string                               `json:"connector_id"`
+	Provider            string                               `json:"provider"`
+	Posture             githubconnector.RepositoryPosture    `json:"posture"`
+	OrganizationPosture *githubconnector.OrganizationPosture `json:"organization_posture,omitempty"`
 }
 
 // GitHubConnectionStartRequest captures one project-scoped connection bootstrap request.
@@ -741,11 +747,35 @@ func (s *Service) GetGitHubConnectorRepositoryPosture(ctx context.Context, conne
 	if err != nil {
 		return GitHubRepositoryPostureResponse{}, fmt.Errorf("%w: collect github repository posture: %w", ErrGitHubRepositoryPostureUnavailable, err)
 	}
-	return GitHubRepositoryPostureResponse{
+	response := GitHubRepositoryPostureResponse{
 		ConnectorID: stored.Connector.ConnectorID,
 		Provider:    provider,
 		Posture:     posture,
-	}, nil
+	}
+	if owner, _, ok := strings.Cut(target, "/"); ok && strings.TrimSpace(owner) != "" {
+		if orgPosture, orgErr := s.GitHubRepositoryPostureCollector.CollectOrganizationPosture(ctx, installationID, owner, target); orgErr == nil {
+			if githubOrganizationPostureAvailable(orgPosture) {
+				response.OrganizationPosture = &orgPosture
+			}
+		}
+	}
+	return response, nil
+}
+
+func githubOrganizationPostureAvailable(posture githubconnector.OrganizationPosture) bool {
+	if strings.TrimSpace(posture.Organization) == "" || len(posture.Checks) == 0 {
+		return false
+	}
+	notOrganization := true
+	for _, check := range posture.Checks {
+		if check.State != githubconnector.RepositoryPostureStateUnsupported {
+			return true
+		}
+		if check.Reason != "not_an_organization" {
+			notOrganization = false
+		}
+	}
+	return !notOrganization
 }
 
 func (s *Service) CompleteGitHubConnection(ctx context.Context, workspaceID string, projectID string, request GitHubConnectionCompleteRequest) (GitHubConnectionStatus, error) {

--- a/internal/api/github_connector_v2_test.go
+++ b/internal/api/github_connector_v2_test.go
@@ -48,10 +48,14 @@ func (f *fakeGitHubRepositoryLister) ListInstallationRepositories(ctx context.Co
 }
 
 type fakeGitHubRepositoryPostureCollector struct {
-	seenInstallationID int64
-	seenRepository     string
-	posture            githubconnector.RepositoryPosture
-	err                error
+	seenInstallationID   int64
+	seenRepository       string
+	seenOrganization     string
+	seenOrganizationRepo string
+	posture              githubconnector.RepositoryPosture
+	organizationPosture  githubconnector.OrganizationPosture
+	err                  error
+	organizationErr      error
 }
 
 func (f *fakeGitHubRepositoryPostureCollector) CollectRepositoryPosture(ctx context.Context, installationID int64, repository string) (githubconnector.RepositoryPosture, error) {
@@ -61,6 +65,16 @@ func (f *fakeGitHubRepositoryPostureCollector) CollectRepositoryPosture(ctx cont
 		return githubconnector.RepositoryPosture{}, f.err
 	}
 	return f.posture, nil
+}
+
+func (f *fakeGitHubRepositoryPostureCollector) CollectOrganizationPosture(ctx context.Context, installationID int64, organization string, repository string) (githubconnector.OrganizationPosture, error) {
+	f.seenInstallationID = installationID
+	f.seenOrganization = organization
+	f.seenOrganizationRepo = repository
+	if f.organizationErr != nil {
+		return githubconnector.OrganizationPosture{}, f.organizationErr
+	}
+	return f.organizationPosture, nil
 }
 
 func TestRouterGitHubConnectorV2StartsAppInstall(t *testing.T) {
@@ -221,6 +235,20 @@ func TestRouterGitHubConnectorV2CollectsRepositoryPosture(t *testing.T) {
 				},
 			},
 		},
+		organizationPosture: githubconnector.OrganizationPosture{
+			Organization:   "identrail",
+			InstallationID: 12345,
+			CollectedAt:    time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC),
+			Checks: []githubconnector.RepositoryPostureCheck{
+				{
+					ID:       "org_secret_scanning_policy",
+					Category: "secret_scanning",
+					State:    githubconnector.RepositoryPostureStateInsecure,
+					Reason:   "secret_scanning_policy_weak",
+					Summary:  "Organization does not enforce secret scanning and push protection for new repositories.",
+				},
+			},
+		},
 	}
 	store := db.NewMemoryStore()
 	r, svc := newGitHubConnectorV2ConfiguredTestRouterWithStore(t, store, &fakeGitHubPATValidator{}, lister)
@@ -254,11 +282,69 @@ func TestRouterGitHubConnectorV2CollectsRepositoryPosture(t *testing.T) {
 	if err := json.Unmarshal(postureResp.Body.Bytes(), &postureBody); err != nil {
 		t.Fatalf("decode posture response: %v", err)
 	}
-	if collector.seenInstallationID != 12345 || collector.seenRepository != "identrail/api" {
-		t.Fatalf("unexpected collector call installation=%d repository=%q", collector.seenInstallationID, collector.seenRepository)
+	if collector.seenInstallationID != 12345 || collector.seenRepository != "identrail/api" || collector.seenOrganization != "identrail" || collector.seenOrganizationRepo != "identrail/api" {
+		t.Fatalf("unexpected collector call installation=%d repository=%q organization=%q organizationRepo=%q", collector.seenInstallationID, collector.seenRepository, collector.seenOrganization, collector.seenOrganizationRepo)
 	}
 	if postureBody.ConnectorID != githubConnectorID || postureBody.Provider != "github_app" || postureBody.Posture.Repository != "identrail/api" {
 		t.Fatalf("unexpected posture response %+v", postureBody)
+	}
+	if postureBody.OrganizationPosture == nil || postureBody.OrganizationPosture.Organization != "identrail" || len(postureBody.OrganizationPosture.Checks) != 1 {
+		t.Fatalf("expected organization posture in response, got %+v", postureBody.OrganizationPosture)
+	}
+	if postureBody.OrganizationPosture.Checks[0].State != githubconnector.RepositoryPostureStateInsecure {
+		t.Fatalf("expected org secret scanning insecure, got %+v", postureBody.OrganizationPosture.Checks[0])
+	}
+
+	collector.organizationPosture = githubconnector.OrganizationPosture{
+		Organization:   "identrail",
+		InstallationID: 12345,
+		CollectedAt:    time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC),
+		Checks: []githubconnector.RepositoryPostureCheck{
+			{
+				ID:       "org_secret_scanning_policy",
+				Category: "secret_scanning",
+				State:    githubconnector.RepositoryPostureStateUnsupported,
+				Reason:   "not_an_organization",
+				Summary:  "Repository owner is a user account, so organization secret scanning policy does not apply.",
+			},
+		},
+	}
+	userOwnedResp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/connectors/github/github-app/posture?workspace_id=workspace-a&project_id=project-1&repository=Identrail/API", "")
+	if userOwnedResp.Code != http.StatusOK {
+		t.Fatalf("expected user-owned github posture 200, got %d body=%s", userOwnedResp.Code, userOwnedResp.Body.String())
+	}
+	var userOwnedBody GitHubRepositoryPostureResponse
+	if err := json.Unmarshal(userOwnedResp.Body.Bytes(), &userOwnedBody); err != nil {
+		t.Fatalf("decode user-owned posture response: %v", err)
+	}
+	if userOwnedBody.OrganizationPosture != nil {
+		t.Fatalf("expected unsupported organization posture to be omitted, got %+v", userOwnedBody.OrganizationPosture)
+	}
+
+	collector.organizationPosture = githubconnector.OrganizationPosture{
+		Organization:   "identrail",
+		InstallationID: 12345,
+		CollectedAt:    time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC),
+		Checks: []githubconnector.RepositoryPostureCheck{
+			{
+				ID:       "org_secret_scanning_policy",
+				Category: "secret_scanning",
+				State:    githubconnector.RepositoryPostureStateUnsupported,
+				Reason:   "plan_unavailable",
+				Summary:  "Organization code security configurations are not available for this account or plan.",
+			},
+		},
+	}
+	planLimitedResp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/connectors/github/github-app/posture?workspace_id=workspace-a&project_id=project-1&repository=Identrail/API", "")
+	if planLimitedResp.Code != http.StatusOK {
+		t.Fatalf("expected plan-limited github posture 200, got %d body=%s", planLimitedResp.Code, planLimitedResp.Body.String())
+	}
+	var planLimitedBody GitHubRepositoryPostureResponse
+	if err := json.Unmarshal(planLimitedResp.Body.Bytes(), &planLimitedBody); err != nil {
+		t.Fatalf("decode plan-limited posture response: %v", err)
+	}
+	if planLimitedBody.OrganizationPosture == nil || planLimitedBody.OrganizationPosture.Checks[0].Reason != "plan_unavailable" {
+		t.Fatalf("expected plan-limited organization posture to be preserved, got %+v", planLimitedBody.OrganizationPosture)
 	}
 
 	unselectedResp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/connectors/github/github-app/posture?workspace_id=workspace-a&project_id=project-1&repository=identrail/other", "")

--- a/internal/cli/repo_intelligence.go
+++ b/internal/cli/repo_intelligence.go
@@ -841,26 +841,59 @@ func renderRepoRiskGraphOutput(out io.Writer, graph domain.RepoRiskGraph) error 
 
 func renderRepoPostureOutput(out io.Writer, response api.GitHubRepositoryPostureResponse) error {
 	posture := response.Posture
-	insecure, limited, unavailable := countPostureStates(posture.Checks)
+	counts := countPostureStates(posture.Checks)
 	if _, err := fmt.Fprintf(
 		out,
-		"GitHub posture: repo=%s connector=%s provider=%s checks=%d insecure=%d permission_limited=%d unavailable=%d collected_at=%s\n",
+		"GitHub posture: repo=%s connector=%s provider=%s checks=%d insecure=%d permission_limited=%d unavailable=%d unsupported=%d unknown=%d collected_at=%s\n",
 		posture.Repository,
 		response.ConnectorID,
 		response.Provider,
 		len(posture.Checks),
-		insecure,
-		limited,
-		unavailable,
+		counts.insecure,
+		counts.limited,
+		counts.unavailable,
+		counts.unsupported,
+		counts.unknown,
 		posture.CollectedAt.Format(time.RFC3339),
 	); err != nil {
 		return err
 	}
 	if len(posture.Checks) == 0 {
-		_, err := fmt.Fprintln(out, "No posture checks.")
+		if _, err := fmt.Fprintln(out, "No posture checks."); err != nil {
+			return err
+		}
+	}
+	if err := renderPostureChecks(out, posture.Checks); err != nil {
 		return err
 	}
-	for i, check := range posture.Checks {
+	return renderOrgPostureSection(out, response.OrganizationPosture)
+}
+
+func renderOrgPostureSection(out io.Writer, posture *githubconnector.OrganizationPosture) error {
+	if posture == nil {
+		_, err := fmt.Fprintln(out, "Organization posture: not collected (repository owner is not an accessible organization).")
+		return err
+	}
+	counts := countPostureStates(posture.Checks)
+	if _, err := fmt.Fprintf(
+		out,
+		"Organization posture (inherited): org=%s checks=%d insecure=%d permission_limited=%d unavailable=%d unsupported=%d unknown=%d collected_at=%s\n",
+		posture.Organization,
+		len(posture.Checks),
+		counts.insecure,
+		counts.limited,
+		counts.unavailable,
+		counts.unsupported,
+		counts.unknown,
+		posture.CollectedAt.Format(time.RFC3339),
+	); err != nil {
+		return err
+	}
+	return renderPostureChecks(out, posture.Checks)
+}
+
+func renderPostureChecks(out io.Writer, checks []githubconnector.RepositoryPostureCheck) error {
+	for i, check := range checks {
 		if _, err := fmt.Fprintf(
 			out,
 			"%d. [%s] %s/%s - %s\n",
@@ -881,19 +914,31 @@ func renderRepoPostureOutput(out io.Writer, response api.GitHubRepositoryPosture
 	return nil
 }
 
-func countPostureStates(checks []githubconnector.RepositoryPostureCheck) (int, int, int) {
-	var insecure, limited, unavailable int
+type postureStateCounts struct {
+	insecure    int
+	limited     int
+	unavailable int
+	unsupported int
+	unknown     int
+}
+
+func countPostureStates(checks []githubconnector.RepositoryPostureCheck) postureStateCounts {
+	var counts postureStateCounts
 	for _, check := range checks {
 		switch check.State {
 		case githubconnector.RepositoryPostureStateInsecure:
-			insecure++
+			counts.insecure++
 		case githubconnector.RepositoryPostureStatePermissionLimited:
-			limited++
+			counts.limited++
 		case githubconnector.RepositoryPostureStateUnavailable:
-			unavailable++
+			counts.unavailable++
+		case githubconnector.RepositoryPostureStateUnsupported:
+			counts.unsupported++
+		case githubconnector.RepositoryPostureStateUnknown:
+			counts.unknown++
 		}
 	}
-	return insecure, limited, unavailable
+	return counts
 }
 
 func renderRepoRemediationPreviewOutput(out io.Writer, response api.RepoFindingRemediationPreview) error {

--- a/internal/connectors/github/org_posture.go
+++ b/internal/connectors/github/org_posture.go
@@ -1,0 +1,826 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// OrganizationPosture describes organization-level GitHub security policy that
+// is inherited by every repository in the organization. It is collected
+// separately from RepositoryPosture so consumers can distinguish risk that is
+// local to a repository from risk inherited from the organization policy plane.
+type OrganizationPosture struct {
+	Organization   string                   `json:"organization"`
+	InstallationID int64                    `json:"installation_id,omitempty"`
+	CollectedAt    time.Time                `json:"collected_at"`
+	Checks         []RepositoryPostureCheck `json:"checks"`
+	RateLimit      *GitHubRateLimitState    `json:"rate_limit,omitempty"`
+}
+
+type organizationActionsPermissions struct {
+	EnabledRepositories string `json:"enabled_repositories"`
+	AllowedActions      string `json:"allowed_actions"`
+}
+
+type organizationWorkflowPermissions struct {
+	DefaultWorkflowPermissions   string `json:"default_workflow_permissions"`
+	CanApprovePullRequestReviews bool   `json:"can_approve_pull_request_reviews"`
+}
+
+type organizationActionsRepositoryPage struct {
+	TotalCount   int `json:"total_count"`
+	Repositories []struct {
+		FullName string `json:"full_name"`
+	} `json:"repositories"`
+}
+
+var errStopOrgActionsRepositoryPaging = errors.New("stop org actions repository paging")
+
+type organizationSelectedActions struct {
+	GitHubOwnedAllowed *bool    `json:"github_owned_allowed"`
+	VerifiedAllowed    *bool    `json:"verified_allowed"`
+	PatternsAllowed    []string `json:"patterns_allowed"`
+}
+
+type organizationCodeSecurityConfiguration struct {
+	ID                           int64  `json:"id"`
+	Name                         string `json:"name"`
+	TargetType                   string `json:"target_type"`
+	Enforcement                  string `json:"enforcement"`
+	SecretScanning               string `json:"secret_scanning"`
+	SecretScanningPushProtection string `json:"secret_scanning_push_protection"`
+	DependabotAlerts             string `json:"dependabot_alerts"`
+	CodeScanningDefaultSetup     string `json:"code_scanning_default_setup"`
+}
+
+type organizationCodeSecurityConfigurationItem struct {
+	organizationCodeSecurityConfiguration
+	Configuration organizationCodeSecurityConfiguration `json:"configuration"`
+}
+
+type repositoryCodeSecurityConfiguration struct {
+	Status        string                                `json:"status"`
+	Configuration organizationCodeSecurityConfiguration `json:"configuration"`
+}
+
+// CollectOrganizationPosture collects normalized organization-level security
+// posture for the organization that owns a scanned repository. Each endpoint
+// contributes one check; permission-limited, unavailable, unsupported, and
+// unknown states are reported explicitly and never collapse into "secure".
+func (c RepositoryClient) CollectOrganizationPosture(ctx context.Context, installationID int64, organization string, repository string) (OrganizationPosture, error) {
+	if c.TokenClient == nil {
+		return OrganizationPosture{}, fmt.Errorf("github installation token client is required")
+	}
+	org, err := normalizeOrganizationName(organization)
+	if err != nil {
+		return OrganizationPosture{}, err
+	}
+	normalizedRepository, err := normalizeRepositoryName(repository)
+	if err != nil {
+		return OrganizationPosture{}, err
+	}
+	if owner, _, ok := strings.Cut(normalizedRepository, "/"); !ok || owner != org {
+		return OrganizationPosture{}, fmt.Errorf("github repository must belong to organization %q", org)
+	}
+	token, err := c.TokenClient.Mint(ctx, installationID)
+	if err != nil {
+		return OrganizationPosture{}, err
+	}
+
+	posture := OrganizationPosture{
+		Organization:   org,
+		InstallationID: installationID,
+		CollectedAt:    c.now().UTC(),
+		Checks:         make([]RepositoryPostureCheck, 0, 5),
+	}
+	updateRate := func(limit *GitHubRateLimitState) {
+		if limit != nil {
+			posture.RateLimit = limit
+		}
+	}
+
+	codeSecurityConfigurations, codeSecurityErr := c.collectOrgCodeSecurityConfigurations(ctx, token.Token, org, updateRate)
+	var repositoryCodeSecurity *repositoryCodeSecurityConfiguration
+	var repositoryCodeSecurityErr error
+	if codeSecurityErr == nil && shouldCollectRepositoryCodeSecurityConfiguration(codeSecurityConfigurations) {
+		repositoryCodeSecurity, repositoryCodeSecurityErr = c.collectRepositoryCodeSecurityConfiguration(ctx, token.Token, normalizedRepository, updateRate)
+	}
+	posture.Checks = append(posture.Checks, collectOrgSecretScanningPolicy(org, normalizedRepository, codeSecurityConfigurations, codeSecurityErr, repositoryCodeSecurity, repositoryCodeSecurityErr))
+	actionsPolicy := c.collectOrgActionsPolicy(ctx, token.Token, org, normalizedRepository, updateRate)
+	posture.Checks = append(posture.Checks, actionsPolicy)
+	posture.Checks = append(posture.Checks, c.collectOrgWorkflowPermissions(ctx, token.Token, org, actionsPolicy, updateRate))
+	posture.Checks = append(posture.Checks, c.collectOrgReusableWorkflowPolicy(ctx, token.Token, org, actionsPolicy, updateRate))
+	posture.Checks = append(posture.Checks, collectOrgCodeSecurityConfiguration(org, normalizedRepository, codeSecurityConfigurations, codeSecurityErr, repositoryCodeSecurity, repositoryCodeSecurityErr))
+
+	return posture, nil
+}
+
+func collectOrgSecretScanningPolicy(org string, repository string, configurations []organizationCodeSecurityConfiguration, err error, repositoryConfiguration *repositoryCodeSecurityConfiguration, repositoryErr error) RepositoryPostureCheck {
+	if err != nil {
+		return checkFromAPIError(
+			"org_secret_scanning_policy",
+			"secret_scanning",
+			err,
+			RepositoryPostureStateUnsupported,
+			"plan_unavailable",
+			"Organization code security configurations are not available for this account or plan.",
+		)
+	}
+	evidence := orgCodeSecurityConfigurationEvidence(org, configurations)
+	if enforcedSecretScanningPolicyCount(configurations) == 0 {
+		return RepositoryPostureCheck{
+			ID:       "org_secret_scanning_policy",
+			Category: "secret_scanning",
+			State:    RepositoryPostureStateInsecure,
+			Reason:   "secret_scanning_policy_weak",
+			Summary:  "Organization does not enforce secret scanning and push protection through an organization code security configuration.",
+			Evidence: evidence,
+		}
+	}
+	if repositoryErr != nil {
+		return checkFromAPIError(
+			"org_secret_scanning_policy",
+			"secret_scanning",
+			repositoryErr,
+			RepositoryPostureStateInsecure,
+			"secret_scanning_policy_weak",
+			"GitHub did not report an organization code security configuration for this repository.",
+		)
+	}
+	evidence = addRepositoryCodeSecurityConfigurationEvidence(evidence, repository, repositoryConfiguration)
+	if !repositoryCodeSecurityConfigurationApplies(repositoryConfiguration) || !organizationSecretScanningConfigurationProtective(repositoryConfiguration.Configuration) {
+		return RepositoryPostureCheck{
+			ID:       "org_secret_scanning_policy",
+			Category: "secret_scanning",
+			State:    RepositoryPostureStateInsecure,
+			Reason:   "secret_scanning_policy_weak",
+			Summary:  "Scanned repository is not attached to an enforced organization code security configuration with secret scanning and push protection.",
+			Evidence: evidence,
+		}
+	}
+	return RepositoryPostureCheck{
+		ID:       "org_secret_scanning_policy",
+		Category: "secret_scanning",
+		State:    RepositoryPostureStateSecure,
+		Reason:   "secret_scanning_policy_enforced",
+		Summary:  "Scanned repository inherits secret scanning and push protection from an enforced organization code security configuration.",
+		Evidence: evidence,
+	}
+}
+
+func (c RepositoryClient) collectOrgActionsPolicy(ctx context.Context, token string, org string, repository string, updateRate func(*GitHubRateLimitState)) RepositoryPostureCheck {
+	var permissions organizationActionsPermissions
+	rateLimit, err := c.getJSON(ctx, token, c.orgEndpoint(org, "/actions/permissions"), &permissions)
+	updateRate(rateLimit)
+	if err != nil {
+		return checkFromAPIError(
+			"org_actions_policy",
+			"actions",
+			err,
+			RepositoryPostureStateUnsupported,
+			"organization_policy_unavailable",
+			"GitHub did not expose an organization Actions policy for this account.",
+		)
+	}
+	allowed := strings.ToLower(strings.TrimSpace(permissions.AllowedActions))
+	enabledRepos := strings.ToLower(strings.TrimSpace(permissions.EnabledRepositories))
+	evidence := map[string]any{
+		"organization":         org,
+		"repository":           repository,
+		"allowed_actions":      allowed,
+		"enabled_repositories": enabledRepos,
+	}
+	if enabledRepos == "none" {
+		return RepositoryPostureCheck{
+			ID:       "org_actions_policy",
+			Category: "actions",
+			State:    RepositoryPostureStateSecure,
+			Reason:   "actions_disabled",
+			Summary:  "Organization disables GitHub Actions for all repositories.",
+			Evidence: evidence,
+		}
+	}
+	if enabledRepos == "selected" {
+		selected, err := c.orgActionsRepositorySelected(ctx, token, org, repository, updateRate)
+		if err != nil {
+			return checkFromAPIError(
+				"org_actions_policy",
+				"actions",
+				err,
+				RepositoryPostureStateUnsupported,
+				"organization_selected_repositories_unavailable",
+				"GitHub did not expose the organization Actions selected-repository list for this account.",
+			)
+		}
+		evidence["repository_selected"] = selected
+		if !selected {
+			return RepositoryPostureCheck{
+				ID:       "org_actions_policy",
+				Category: "actions",
+				State:    RepositoryPostureStateSecure,
+				Reason:   "actions_not_enabled_for_repository",
+				Summary:  "Organization enables GitHub Actions only for selected repositories, and this repository is not selected.",
+				Evidence: evidence,
+			}
+		}
+	}
+	if allowed == "" {
+		return RepositoryPostureCheck{
+			ID:       "org_actions_policy",
+			Category: "actions",
+			State:    RepositoryPostureStateUnknown,
+			Reason:   "policy_unclassified",
+			Summary:  "Organization Actions policy did not report an allowed-actions setting.",
+			Evidence: evidence,
+		}
+	}
+	if allowed == "all" {
+		return RepositoryPostureCheck{
+			ID:       "org_actions_policy",
+			Category: "actions",
+			State:    RepositoryPostureStateInsecure,
+			Reason:   "broad_actions_policy",
+			Summary:  "Organization allows any action, including untrusted third-party actions.",
+			Evidence: evidence,
+		}
+	}
+	return RepositoryPostureCheck{
+		ID:       "org_actions_policy",
+		Category: "actions",
+		State:    RepositoryPostureStateSecure,
+		Reason:   "restricted_actions_policy",
+		Summary:  "Organization restricts which actions may run.",
+		Evidence: evidence,
+	}
+}
+
+func (c RepositoryClient) collectOrgWorkflowPermissions(ctx context.Context, token string, org string, actionsPolicy RepositoryPostureCheck, updateRate func(*GitHubRateLimitState)) RepositoryPostureCheck {
+	if orgActionsUnavailable(actionsPolicy) {
+		return RepositoryPostureCheck{
+			ID:       "org_workflow_permissions",
+			Category: "actions",
+			State:    RepositoryPostureStateSecure,
+			Reason:   actionsPolicy.Reason,
+			Summary:  "Organization Actions policy does not enable Actions for this repository, so workflow token permissions cannot be exercised.",
+			Evidence: orgActionsEvidence(org, actionsPolicy),
+		}
+	}
+	var workflow organizationWorkflowPermissions
+	rateLimit, err := c.getJSON(ctx, token, c.orgEndpoint(org, "/actions/permissions/workflow"), &workflow)
+	updateRate(rateLimit)
+	if err != nil {
+		return checkFromAPIError(
+			"org_workflow_permissions",
+			"actions",
+			err,
+			RepositoryPostureStateUnsupported,
+			"organization_policy_unavailable",
+			"GitHub did not expose organization default workflow permissions for this account.",
+		)
+	}
+	defaultPermissions := strings.ToLower(strings.TrimSpace(workflow.DefaultWorkflowPermissions))
+	evidence := map[string]any{
+		"organization":                     org,
+		"default_workflow_permissions":     defaultPermissions,
+		"can_approve_pull_request_reviews": workflow.CanApprovePullRequestReviews,
+	}
+	if defaultPermissions == "" {
+		return RepositoryPostureCheck{
+			ID:       "org_workflow_permissions",
+			Category: "actions",
+			State:    RepositoryPostureStateUnknown,
+			Reason:   "policy_unclassified",
+			Summary:  "Organization workflow policy did not report a default token permission.",
+			Evidence: evidence,
+		}
+	}
+	if defaultPermissions == "write" || workflow.CanApprovePullRequestReviews {
+		return RepositoryPostureCheck{
+			ID:       "org_workflow_permissions",
+			Category: "actions",
+			State:    RepositoryPostureStateInsecure,
+			Reason:   "write_token_or_pr_approval",
+			Summary:  "Organization grants write-scoped default workflow tokens or lets Actions approve pull requests.",
+			Evidence: evidence,
+		}
+	}
+	return RepositoryPostureCheck{
+		ID:       "org_workflow_permissions",
+		Category: "actions",
+		State:    RepositoryPostureStateSecure,
+		Reason:   "least_privilege_workflows",
+		Summary:  "Organization default workflow tokens are read-only and cannot approve pull requests.",
+		Evidence: evidence,
+	}
+}
+
+func (c RepositoryClient) orgActionsRepositorySelected(ctx context.Context, token string, org string, repository string, updateRate func(*GitHubRateLimitState)) (bool, error) {
+	repository = strings.ToLower(strings.TrimSpace(repository))
+	selected := false
+	endpoint := c.orgEndpoint(org, "/actions/permissions/repositories?per_page=100")
+	rateLimit, err := c.getJSONPages(ctx, token, endpoint, func(body []byte) error {
+		var page organizationActionsRepositoryPage
+		if err := json.Unmarshal(body, &page); err != nil {
+			return err
+		}
+		if selected {
+			return nil
+		}
+		for _, repo := range page.Repositories {
+			if strings.EqualFold(strings.TrimSpace(repo.FullName), repository) {
+				selected = true
+				return errStopOrgActionsRepositoryPaging
+			}
+		}
+		return nil
+	})
+	updateRate(rateLimit)
+	if errors.Is(err, errStopOrgActionsRepositoryPaging) {
+		err = nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return selected, nil
+}
+
+func orgActionsUnavailable(actionsPolicy RepositoryPostureCheck) bool {
+	return actionsPolicy.ID == "org_actions_policy" && (actionsPolicy.Reason == "actions_disabled" || actionsPolicy.Reason == "actions_not_enabled_for_repository")
+}
+
+func orgActionsEvidence(org string, actionsPolicy RepositoryPostureCheck) map[string]any {
+	evidence := map[string]any{"organization": org}
+	for _, key := range []string{"repository", "enabled_repositories", "allowed_actions", "repository_selected"} {
+		if value, ok := actionsPolicy.Evidence[key]; ok {
+			evidence[key] = value
+		}
+	}
+	return evidence
+}
+
+func (c RepositoryClient) collectOrgReusableWorkflowPolicy(ctx context.Context, token string, org string, actionsPolicy RepositoryPostureCheck, updateRate func(*GitHubRateLimitState)) RepositoryPostureCheck {
+	if selectedActionsApplicable, known := orgSelectedActionsPolicyApplicable(actionsPolicy); known && !selectedActionsApplicable {
+		return orgReusableWorkflowPolicyNotApplicable(org, actionsPolicy)
+	}
+	var selected organizationSelectedActions
+	rateLimit, err := c.getJSON(ctx, token, c.orgEndpoint(org, "/actions/permissions/selected-actions"), &selected)
+	updateRate(rateLimit)
+	if err != nil {
+		if apiErr, ok := asGitHubAPIError(err); ok && apiErr.StatusCode == http.StatusConflict {
+			return orgReusableWorkflowPolicyNotApplicable(org, actionsPolicy)
+		}
+		return checkFromAPIError(
+			"org_reusable_workflow_policy",
+			"actions",
+			err,
+			RepositoryPostureStateUnsupported,
+			"organization_policy_unavailable",
+			"GitHub did not expose an organization reusable workflow allowlist for this account.",
+		)
+	}
+	if selected.GitHubOwnedAllowed == nil && selected.VerifiedAllowed == nil {
+		return RepositoryPostureCheck{
+			ID:       "org_reusable_workflow_policy",
+			Category: "actions",
+			State:    RepositoryPostureStateUnknown,
+			Reason:   "policy_unclassified",
+			Summary:  "Organization selected-actions policy did not report allowlist settings.",
+			Evidence: map[string]any{"organization": org},
+		}
+	}
+	verified := boolValue(selected.VerifiedAllowed)
+	evidence := map[string]any{
+		"organization":          org,
+		"github_owned_allowed":  boolValue(selected.GitHubOwnedAllowed),
+		"verified_allowed":      verified,
+		"allowed_pattern_count": len(selected.PatternsAllowed),
+	}
+	if verified {
+		return RepositoryPostureCheck{
+			ID:       "org_reusable_workflow_policy",
+			Category: "actions",
+			State:    RepositoryPostureStateInsecure,
+			Reason:   "verified_creators_allowed",
+			Summary:  "Organization allows all verified-creator actions instead of an explicit pinned allowlist.",
+			Evidence: evidence,
+		}
+	}
+	if riskyPatterns := riskySelectedActionPatterns(selected.PatternsAllowed); len(riskyPatterns) > 0 {
+		evidence["risky_pattern_count"] = len(riskyPatterns)
+		evidence["risky_pattern_examples"] = sampleStrings(riskyPatterns, 3)
+		return RepositoryPostureCheck{
+			ID:       "org_reusable_workflow_policy",
+			Category: "actions",
+			State:    RepositoryPostureStateInsecure,
+			Reason:   "broad_action_allowlist",
+			Summary:  "Organization selected-actions allowlist includes broad or unpinned patterns.",
+			Evidence: evidence,
+		}
+	}
+	return RepositoryPostureCheck{
+		ID:       "org_reusable_workflow_policy",
+		Category: "actions",
+		State:    RepositoryPostureStateSecure,
+		Reason:   "restricted_action_sources",
+		Summary:  "Organization restricts actions to GitHub-owned actions and an explicit allowlist.",
+		Evidence: evidence,
+	}
+}
+
+func orgSelectedActionsPolicyApplicable(actionsPolicy RepositoryPostureCheck) (bool, bool) {
+	if actionsPolicy.ID != "org_actions_policy" {
+		return true, false
+	}
+	enabledRepos, hasEnabledRepos := stringEvidence(actionsPolicy.Evidence, "enabled_repositories")
+	if hasEnabledRepos && enabledRepos == "none" {
+		return false, true
+	}
+	if hasEnabledRepos && enabledRepos == "selected" {
+		if selected, ok := boolEvidence(actionsPolicy.Evidence, "repository_selected"); ok && !selected {
+			return false, true
+		}
+	}
+	allowedActions, hasAllowedActions := stringEvidence(actionsPolicy.Evidence, "allowed_actions")
+	if hasAllowedActions {
+		if allowedActions == "" {
+			return true, false
+		}
+		return allowedActions == "selected", true
+	}
+	return true, false
+}
+
+func orgReusableWorkflowPolicyNotApplicable(org string, actionsPolicy RepositoryPostureCheck) RepositoryPostureCheck {
+	evidence := map[string]any{"organization": org}
+	for _, key := range []string{"repository", "enabled_repositories", "allowed_actions", "repository_selected"} {
+		if value, ok := actionsPolicy.Evidence[key]; ok {
+			evidence[key] = value
+		}
+	}
+	return RepositoryPostureCheck{
+		ID:       "org_reusable_workflow_policy",
+		Category: "actions",
+		State:    RepositoryPostureStateSecure,
+		Reason:   "not_applicable",
+		Summary:  "Reusable workflow allowlist applies only when the organization Actions policy is set to selected actions.",
+		Evidence: evidence,
+	}
+}
+
+func stringEvidence(evidence map[string]any, key string) (string, bool) {
+	value, ok := evidence[key]
+	if !ok {
+		return "", false
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", false
+	}
+	return strings.ToLower(strings.TrimSpace(text)), true
+}
+
+func boolEvidence(evidence map[string]any, key string) (bool, bool) {
+	value, ok := evidence[key]
+	if !ok {
+		return false, false
+	}
+	enabled, ok := value.(bool)
+	return enabled, ok
+}
+
+func riskySelectedActionPatterns(patterns []string) []string {
+	risky := make([]string, 0)
+	for _, pattern := range patterns {
+		pattern = strings.TrimSpace(pattern)
+		if pattern == "" {
+			continue
+		}
+		if selectedActionPatternRisky(pattern) {
+			risky = append(risky, pattern)
+		}
+	}
+	return risky
+}
+
+func selectedActionPatternRisky(pattern string) bool {
+	if strings.Contains(pattern, "*") {
+		return true
+	}
+	_, ref, ok := strings.Cut(pattern, "@")
+	if !ok || strings.TrimSpace(ref) == "" {
+		return true
+	}
+	return !isFullCommitSHA(ref)
+}
+
+func isFullCommitSHA(ref string) bool {
+	ref = strings.TrimSpace(ref)
+	if len(ref) != 40 && len(ref) != 64 {
+		return false
+	}
+	for _, char := range ref {
+		if (char >= '0' && char <= '9') || (char >= 'a' && char <= 'f') || (char >= 'A' && char <= 'F') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func sampleStrings(values []string, limit int) []string {
+	if len(values) <= limit {
+		return values
+	}
+	return values[:limit]
+}
+
+func collectOrgCodeSecurityConfiguration(org string, repository string, configurations []organizationCodeSecurityConfiguration, err error, repositoryConfiguration *repositoryCodeSecurityConfiguration, repositoryErr error) RepositoryPostureCheck {
+	if err != nil {
+		return checkFromAPIError(
+			"org_code_security_configuration",
+			"code_security",
+			err,
+			RepositoryPostureStateUnsupported,
+			"plan_unavailable",
+			"Organization code security configurations are not available for this account or plan.",
+		)
+	}
+	evidence := orgCodeSecurityConfigurationEvidence(org, configurations)
+	orgScoped := intEvidence(evidence, "organization_configuration_count")
+	enforced := intEvidence(evidence, "enforced_configuration_count")
+	protective := intEvidence(evidence, "protective_configurations")
+	if len(configurations) == 0 {
+		return RepositoryPostureCheck{
+			ID:       "org_code_security_configuration",
+			Category: "code_security",
+			State:    RepositoryPostureStateInsecure,
+			Reason:   "no_central_configuration",
+			Summary:  "Organization has no central code security configuration to enforce repository controls.",
+			Evidence: evidence,
+		}
+	}
+	if orgScoped == 0 {
+		return RepositoryPostureCheck{
+			ID:       "org_code_security_configuration",
+			Category: "code_security",
+			State:    RepositoryPostureStateInsecure,
+			Reason:   "no_central_configuration",
+			Summary:  "Organization has no organization-scoped code security configuration to enforce repository controls.",
+			Evidence: evidence,
+		}
+	}
+	if enforced == 0 {
+		return RepositoryPostureCheck{
+			ID:       "org_code_security_configuration",
+			Category: "code_security",
+			State:    RepositoryPostureStateInsecure,
+			Reason:   "configuration_not_enforced",
+			Summary:  "Organization code security configurations are present but not enforced.",
+			Evidence: evidence,
+		}
+	}
+	if protective == 0 {
+		return RepositoryPostureCheck{
+			ID:       "org_code_security_configuration",
+			Category: "code_security",
+			State:    RepositoryPostureStateInsecure,
+			Reason:   "configuration_not_protective",
+			Summary:  "Organization code security configurations do not enable secret scanning or push protection.",
+			Evidence: evidence,
+		}
+	}
+	if repositoryErr != nil {
+		return checkFromAPIError(
+			"org_code_security_configuration",
+			"code_security",
+			repositoryErr,
+			RepositoryPostureStateInsecure,
+			"configuration_not_applied",
+			"GitHub did not report an organization code security configuration for this repository.",
+		)
+	}
+	evidence = addRepositoryCodeSecurityConfigurationEvidence(evidence, repository, repositoryConfiguration)
+	if !repositoryCodeSecurityConfigurationApplies(repositoryConfiguration) {
+		return RepositoryPostureCheck{
+			ID:       "org_code_security_configuration",
+			Category: "code_security",
+			State:    RepositoryPostureStateInsecure,
+			Reason:   "configuration_not_applied",
+			Summary:  "Scanned repository is not attached to an enforced organization code security configuration.",
+			Evidence: evidence,
+		}
+	}
+	if !organizationCodeSecurityConfigurationEnforced(repositoryConfiguration.Configuration) {
+		return RepositoryPostureCheck{
+			ID:       "org_code_security_configuration",
+			Category: "code_security",
+			State:    RepositoryPostureStateInsecure,
+			Reason:   "configuration_not_enforced",
+			Summary:  "Scanned repository is attached to an organization code security configuration that is not enforced.",
+			Evidence: evidence,
+		}
+	}
+	if !organizationCodeSecurityConfigurationProtective(repositoryConfiguration.Configuration) {
+		return RepositoryPostureCheck{
+			ID:       "org_code_security_configuration",
+			Category: "code_security",
+			State:    RepositoryPostureStateInsecure,
+			Reason:   "configuration_not_protective",
+			Summary:  "Scanned repository's organization code security configuration does not enable secret scanning or push protection.",
+			Evidence: evidence,
+		}
+	}
+	return RepositoryPostureCheck{
+		ID:       "org_code_security_configuration",
+		Category: "code_security",
+		State:    RepositoryPostureStateSecure,
+		Reason:   "central_configuration_present",
+		Summary:  "Scanned repository is attached to an enforced organization code security configuration.",
+		Evidence: evidence,
+	}
+}
+
+func shouldCollectRepositoryCodeSecurityConfiguration(configurations []organizationCodeSecurityConfiguration) bool {
+	for _, configuration := range configurations {
+		if !organizationCodeSecurityConfigurationScoped(configuration) {
+			continue
+		}
+		if organizationCodeSecurityConfigurationEnforced(configuration) && organizationCodeSecurityConfigurationProtective(configuration) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c RepositoryClient) collectRepositoryCodeSecurityConfiguration(ctx context.Context, token string, repository string, updateRate func(*GitHubRateLimitState)) (*repositoryCodeSecurityConfiguration, error) {
+	body, rateLimit, _, err := c.doGitHubRequestRaw(ctx, token, http.MethodGet, c.repositoryEndpoint(repository, "/code-security-configuration"))
+	updateRate(rateLimit)
+	if err != nil {
+		return nil, err
+	}
+	if len(strings.TrimSpace(string(body))) == 0 {
+		return nil, nil
+	}
+	var configuration repositoryCodeSecurityConfiguration
+	if err := json.Unmarshal(body, &configuration); err != nil {
+		return nil, fmt.Errorf("decode github repository code security configuration: %w", err)
+	}
+	return &configuration, nil
+}
+
+func (c RepositoryClient) collectOrgCodeSecurityConfigurations(ctx context.Context, token string, org string, updateRate func(*GitHubRateLimitState)) ([]organizationCodeSecurityConfiguration, error) {
+	configurations := []organizationCodeSecurityConfiguration{}
+	rateLimit, err := c.getJSONPages(ctx, token, c.orgEndpoint(org, "/code-security/configurations?per_page=100"), func(body []byte) error {
+		var page []organizationCodeSecurityConfigurationItem
+		if err := json.Unmarshal(body, &page); err != nil {
+			return err
+		}
+		for _, item := range page {
+			configurations = append(configurations, item.configuration())
+		}
+		return nil
+	})
+	updateRate(rateLimit)
+	return configurations, err
+}
+
+func (item organizationCodeSecurityConfigurationItem) configuration() organizationCodeSecurityConfiguration {
+	configuration := item.organizationCodeSecurityConfiguration
+	nested := item.Configuration
+	if configuration.ID == 0 {
+		configuration.ID = nested.ID
+	}
+	if configuration.Name == "" {
+		configuration.Name = nested.Name
+	}
+	if configuration.TargetType == "" {
+		configuration.TargetType = nested.TargetType
+	}
+	if configuration.Enforcement == "" {
+		configuration.Enforcement = nested.Enforcement
+	}
+	if configuration.SecretScanning == "" {
+		configuration.SecretScanning = nested.SecretScanning
+	}
+	if configuration.SecretScanningPushProtection == "" {
+		configuration.SecretScanningPushProtection = nested.SecretScanningPushProtection
+	}
+	if configuration.DependabotAlerts == "" {
+		configuration.DependabotAlerts = nested.DependabotAlerts
+	}
+	if configuration.CodeScanningDefaultSetup == "" {
+		configuration.CodeScanningDefaultSetup = nested.CodeScanningDefaultSetup
+	}
+	return configuration
+}
+
+func addRepositoryCodeSecurityConfigurationEvidence(evidence map[string]any, repository string, repositoryConfiguration *repositoryCodeSecurityConfiguration) map[string]any {
+	evidence["repository"] = repository
+	if repositoryConfiguration == nil {
+		evidence["repository_configuration_applied"] = false
+		return evidence
+	}
+	evidence["repository_configuration_applied"] = true
+	evidence["repository_configuration_status"] = strings.ToLower(strings.TrimSpace(repositoryConfiguration.Status))
+	evidence["repository_configuration_id"] = repositoryConfiguration.Configuration.ID
+	evidence["repository_configuration_target_type"] = strings.ToLower(strings.TrimSpace(repositoryConfiguration.Configuration.TargetType))
+	return evidence
+}
+
+func repositoryCodeSecurityConfigurationApplies(repositoryConfiguration *repositoryCodeSecurityConfiguration) bool {
+	if repositoryConfiguration == nil {
+		return false
+	}
+	status := strings.ToLower(strings.TrimSpace(repositoryConfiguration.Status))
+	if status != "" && status != "attached" && status != "enforced" {
+		return false
+	}
+	return organizationCodeSecurityConfigurationScoped(repositoryConfiguration.Configuration)
+}
+
+func organizationCodeSecurityConfigurationScoped(configuration organizationCodeSecurityConfiguration) bool {
+	return strings.EqualFold(strings.TrimSpace(configuration.TargetType), "organization")
+}
+
+func organizationCodeSecurityConfigurationEnforced(configuration organizationCodeSecurityConfiguration) bool {
+	return strings.EqualFold(strings.TrimSpace(configuration.Enforcement), "enforced")
+}
+
+func organizationCodeSecurityConfigurationProtective(configuration organizationCodeSecurityConfiguration) bool {
+	secretScanning := strings.EqualFold(strings.TrimSpace(configuration.SecretScanning), "enabled")
+	pushProtection := strings.EqualFold(strings.TrimSpace(configuration.SecretScanningPushProtection), "enabled")
+	return secretScanning || pushProtection
+}
+
+func organizationSecretScanningConfigurationProtective(configuration organizationCodeSecurityConfiguration) bool {
+	secretScanning := strings.EqualFold(strings.TrimSpace(configuration.SecretScanning), "enabled")
+	pushProtection := strings.EqualFold(strings.TrimSpace(configuration.SecretScanningPushProtection), "enabled")
+	return secretScanning && pushProtection
+}
+
+func orgCodeSecurityConfigurationEvidence(org string, configurations []organizationCodeSecurityConfiguration) map[string]any {
+	global := 0
+	orgScoped := 0
+	enforced := 0
+	unenforced := 0
+	protective := 0
+	secretScanningPolicy := 0
+	for _, configuration := range configurations {
+		targetType := strings.ToLower(strings.TrimSpace(configuration.TargetType))
+		if targetType == "global" {
+			global++
+			continue
+		}
+		if !organizationCodeSecurityConfigurationScoped(configuration) {
+			continue
+		}
+		orgScoped++
+		if !organizationCodeSecurityConfigurationEnforced(configuration) {
+			unenforced++
+			continue
+		}
+		enforced++
+		if organizationCodeSecurityConfigurationProtective(configuration) {
+			protective++
+		}
+		if organizationSecretScanningConfigurationProtective(configuration) {
+			secretScanningPolicy++
+		}
+	}
+	return map[string]any{
+		"organization":                                   org,
+		"configuration_count":                            len(configurations),
+		"global_template_count":                          global,
+		"organization_configuration_count":               orgScoped,
+		"enforced_configuration_count":                   enforced,
+		"unenforced_configuration_count":                 unenforced,
+		"protective_configurations":                      protective,
+		"secret_scanning_push_protection_configurations": secretScanningPolicy,
+	}
+}
+
+func enforcedSecretScanningPolicyCount(configurations []organizationCodeSecurityConfiguration) int {
+	return intEvidence(orgCodeSecurityConfigurationEvidence("", configurations), "secret_scanning_push_protection_configurations")
+}
+
+func intEvidence(evidence map[string]any, key string) int {
+	value, _ := evidence[key].(int)
+	return value
+}
+
+func normalizeOrganizationName(organization string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(organization))
+	if normalized == "" || strings.ContainsAny(normalized, "/ ") {
+		return "", fmt.Errorf("github organization must be a single login")
+	}
+	return normalized, nil
+}
+
+func boolValue(value *bool) bool {
+	return value != nil && *value
+}

--- a/internal/connectors/github/org_posture_test.go
+++ b/internal/connectors/github/org_posture_test.go
@@ -1,0 +1,539 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+const pinnedSelectedActionPattern = "acme/reusable@0123456789abcdef0123456789abcdef01234567"
+
+func TestCollectOrganizationPostureSecure(t *testing.T) {
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	codeSecurityCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer inst-token" {
+			t.Errorf("missing installation token for %s", r.URL.String())
+			return
+		}
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("X-RateLimit-Remaining", "4990")
+		switch r.URL.Path {
+		case "/orgs/acme":
+			_, _ = w.Write([]byte(`{
+				"login":"acme",
+				"secret_scanning_enabled_for_new_repositories":true,
+				"secret_scanning_push_protection_enabled_for_new_repositories":true,
+				"secret_scanning_validity_checks_enabled":true,
+				"advanced_security_enabled_for_new_repositories":true
+			}`))
+		case "/orgs/acme/actions/permissions":
+			_, _ = w.Write([]byte(`{"enabled_repositories":"selected","allowed_actions":"selected"}`))
+		case "/orgs/acme/actions/permissions/repositories":
+			_, _ = w.Write([]byte(`{"total_count":1,"repositories":[{"full_name":"acme/repo"}]}`))
+		case "/orgs/acme/actions/permissions/workflow":
+			_, _ = w.Write([]byte(`{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}`))
+		case "/orgs/acme/actions/permissions/selected-actions":
+			_, _ = w.Write([]byte(`{"github_owned_allowed":true,"verified_allowed":false,"patterns_allowed":["` + pinnedSelectedActionPattern + `"]}`))
+		case "/orgs/acme/code-security/configurations":
+			codeSecurityCalls++
+			_, _ = w.Write([]byte(`[{"id":1,"name":"baseline","target_type":"organization","enforcement":"enforced","secret_scanning":"enabled","secret_scanning_push_protection":"enabled","dependabot_alerts":"enabled"}]`))
+		case "/repos/acme/repo/code-security-configuration":
+			_, _ = w.Write([]byte(`{"status":"attached","configuration":{"id":1,"name":"baseline","target_type":"organization","enforcement":"enforced","secret_scanning":"enabled","secret_scanning_push_protection":"enabled","dependabot_alerts":"enabled"}}`))
+		default:
+			t.Errorf("unexpected org posture path %s", r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	posture, err := (RepositoryClient{
+		TokenClient: minter,
+		APIBaseURL:  server.URL,
+		Now:         func() time.Time { return time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC) },
+	}).CollectOrganizationPosture(context.Background(), 321, "ACME", "acme/repo")
+	if err != nil {
+		t.Fatalf("collect org posture: %v", err)
+	}
+	if posture.Organization != "acme" || posture.InstallationID != 321 || len(posture.Checks) != 5 {
+		t.Fatalf("unexpected org posture summary: %+v", posture)
+	}
+	for _, id := range []string{
+		"org_secret_scanning_policy",
+		"org_actions_policy",
+		"org_workflow_permissions",
+		"org_reusable_workflow_policy",
+		"org_code_security_configuration",
+	} {
+		if check := orgPostureCheckByID(posture, id); check.State != RepositoryPostureStateSecure {
+			t.Fatalf("expected %s secure, got %+v", id, check)
+		}
+	}
+	if posture.RateLimit == nil || posture.RateLimit.Remaining != 4990 {
+		t.Fatalf("expected rate limit headers captured, got %+v", posture.RateLimit)
+	}
+	if codeSecurityCalls != 1 {
+		t.Fatalf("expected code security configurations to be fetched once, got %d calls", codeSecurityCalls)
+	}
+}
+
+func TestCollectOrganizationPostureParsesNestedCodeSecurityConfigurations(t *testing.T) {
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/orgs/acme/actions/permissions":
+			_, _ = w.Write([]byte(`{"enabled_repositories":"selected","allowed_actions":"selected"}`))
+		case "/orgs/acme/actions/permissions/repositories":
+			_, _ = w.Write([]byte(`{"total_count":1,"repositories":[{"full_name":"acme/repo"}]}`))
+		case "/orgs/acme/actions/permissions/workflow":
+			_, _ = w.Write([]byte(`{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}`))
+		case "/orgs/acme/actions/permissions/selected-actions":
+			_, _ = w.Write([]byte(`{"github_owned_allowed":true,"verified_allowed":false,"patterns_allowed":["` + pinnedSelectedActionPattern + `"]}`))
+		case "/orgs/acme/code-security/configurations":
+			_, _ = w.Write([]byte(`[{
+				"id": 100,
+				"configuration": {
+					"id": 1,
+					"name": "baseline",
+					"target_type": "organization",
+					"enforcement": "enforced",
+					"secret_scanning": "enabled",
+					"secret_scanning_push_protection": "enabled",
+					"dependabot_alerts": "enabled"
+				}
+			}]`))
+		case "/repos/acme/repo/code-security-configuration":
+			_, _ = w.Write([]byte(`{"status":"attached","configuration":{"id":1,"name":"baseline","target_type":"organization","enforcement":"enforced","secret_scanning":"enabled","secret_scanning_push_protection":"enabled","dependabot_alerts":"enabled"}}`))
+		default:
+			t.Errorf("unexpected org posture path %s", r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	posture, err := (RepositoryClient{TokenClient: minter, APIBaseURL: server.URL}).CollectOrganizationPosture(context.Background(), 321, "acme", "acme/repo")
+	if err != nil {
+		t.Fatalf("collect org posture: %v", err)
+	}
+	if check := orgPostureCheckByID(posture, "org_code_security_configuration"); check.State != RepositoryPostureStateSecure {
+		t.Fatalf("expected nested code security configuration to be secure, got %+v", check)
+	}
+	if check := orgPostureCheckByID(posture, "org_secret_scanning_policy"); check.State != RepositoryPostureStateSecure {
+		t.Fatalf("expected nested code security configuration to prove secret scanning policy, got %+v", check)
+	}
+}
+
+func TestCollectOrganizationPostureFlagsBroadSelectedActionPatterns(t *testing.T) {
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/orgs/acme/actions/permissions":
+			_, _ = w.Write([]byte(`{"enabled_repositories":"selected","allowed_actions":"selected"}`))
+		case "/orgs/acme/actions/permissions/repositories":
+			_, _ = w.Write([]byte(`{"total_count":1,"repositories":[{"full_name":"acme/repo"}]}`))
+		case "/orgs/acme/actions/permissions/workflow":
+			_, _ = w.Write([]byte(`{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}`))
+		case "/orgs/acme/actions/permissions/selected-actions":
+			_, _ = w.Write([]byte(`{"github_owned_allowed":true,"verified_allowed":false,"patterns_allowed":["acme/*@main","partner/action@v1"]}`))
+		case "/orgs/acme/code-security/configurations":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Errorf("unexpected org posture path %s", r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	posture, err := (RepositoryClient{TokenClient: minter, APIBaseURL: server.URL}).CollectOrganizationPosture(context.Background(), 321, "acme", "acme/repo")
+	if err != nil {
+		t.Fatalf("collect org posture: %v", err)
+	}
+	check := orgPostureCheckByID(posture, "org_reusable_workflow_policy")
+	if check.State != RepositoryPostureStateInsecure || check.Reason != "broad_action_allowlist" {
+		t.Fatalf("expected broad selected-actions patterns to be insecure, got %+v", check)
+	}
+	if count, ok := check.Evidence["risky_pattern_count"].(int); !ok || count != 2 {
+		t.Fatalf("expected risky pattern count evidence, got %+v", check.Evidence)
+	}
+}
+
+func TestCollectOrganizationPostureRequiresRepositoryCodeSecurityConfiguration(t *testing.T) {
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/orgs/acme/actions/permissions":
+			_, _ = w.Write([]byte(`{"enabled_repositories":"selected","allowed_actions":"selected"}`))
+		case "/orgs/acme/actions/permissions/repositories":
+			_, _ = w.Write([]byte(`{"total_count":1,"repositories":[{"full_name":"acme/repo"}]}`))
+		case "/orgs/acme/actions/permissions/workflow":
+			_, _ = w.Write([]byte(`{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}`))
+		case "/orgs/acme/actions/permissions/selected-actions":
+			_, _ = w.Write([]byte(`{"github_owned_allowed":true,"verified_allowed":false,"patterns_allowed":["` + pinnedSelectedActionPattern + `"]}`))
+		case "/orgs/acme/code-security/configurations":
+			_, _ = w.Write([]byte(`[{"id":1,"name":"baseline","target_type":"organization","enforcement":"enforced","secret_scanning":"enabled","secret_scanning_push_protection":"enabled","default_for_new_repos":"public"}]`))
+		case "/repos/acme/repo/code-security-configuration":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected org posture path %s", r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	posture, err := (RepositoryClient{TokenClient: minter, APIBaseURL: server.URL}).CollectOrganizationPosture(context.Background(), 321, "acme", "acme/repo")
+	if err != nil {
+		t.Fatalf("collect org posture: %v", err)
+	}
+	if check := orgPostureCheckByID(posture, "org_code_security_configuration"); check.State != RepositoryPostureStateInsecure || check.Reason != "configuration_not_applied" {
+		t.Fatalf("expected unattached repository config not to count as secure, got %+v", check)
+	}
+	if check := orgPostureCheckByID(posture, "org_secret_scanning_policy"); check.State != RepositoryPostureStateInsecure || check.Reason != "secret_scanning_policy_weak" {
+		t.Fatalf("expected unattached repository config not to prove secret scanning policy, got %+v", check)
+	}
+}
+
+func TestCollectOrganizationPostureInsecure(t *testing.T) {
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/orgs/acme":
+			_, _ = w.Write([]byte(`{"login":"acme","secret_scanning_enabled_for_new_repositories":true,"secret_scanning_push_protection_enabled_for_new_repositories":false}`))
+		case "/orgs/acme/actions/permissions":
+			_, _ = w.Write([]byte(`{"enabled_repositories":"all","allowed_actions":"all"}`))
+		case "/orgs/acme/actions/permissions/workflow":
+			_, _ = w.Write([]byte(`{"default_workflow_permissions":"write","can_approve_pull_request_reviews":true}`))
+		case "/orgs/acme/actions/permissions/selected-actions":
+			t.Errorf("selected-actions allowlist should not be requested when allowed_actions is all")
+		case "/orgs/acme/code-security/configurations":
+			_, _ = w.Write([]byte(`[{"id":1,"name":"baseline","target_type":"organization","enforcement":"enforced","secret_scanning":"disabled","secret_scanning_push_protection":"disabled"}]`))
+		default:
+			t.Errorf("unexpected org posture path %s", r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	posture, err := (RepositoryClient{TokenClient: minter, APIBaseURL: server.URL}).CollectOrganizationPosture(context.Background(), 321, "acme", "acme/repo")
+	if err != nil {
+		t.Fatalf("collect org posture: %v", err)
+	}
+	for _, id := range []string{
+		"org_secret_scanning_policy",
+		"org_actions_policy",
+		"org_workflow_permissions",
+		"org_code_security_configuration",
+	} {
+		if check := orgPostureCheckByID(posture, id); check.State != RepositoryPostureStateInsecure {
+			t.Fatalf("expected %s insecure, got %+v", id, check)
+		}
+	}
+	if check := orgPostureCheckByID(posture, "org_reusable_workflow_policy"); check.State != RepositoryPostureStateSecure || check.Reason != "not_applicable" {
+		t.Fatalf("expected reusable workflow secure/not_applicable, got %+v", check)
+	}
+}
+
+func TestCollectOrganizationPostureActionsDisabledIsNotBroadActionsRisk(t *testing.T) {
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/orgs/acme":
+			_, _ = w.Write([]byte(`{"login":"acme","secret_scanning_enabled_for_new_repositories":true,"secret_scanning_push_protection_enabled_for_new_repositories":true}`))
+		case "/orgs/acme/actions/permissions":
+			_, _ = w.Write([]byte(`{"enabled_repositories":"none","allowed_actions":"all"}`))
+		case "/orgs/acme/actions/permissions/workflow":
+			t.Errorf("workflow permissions should not be requested when Actions is disabled")
+		case "/orgs/acme/actions/permissions/selected-actions":
+			t.Errorf("selected-actions allowlist should not be requested when Actions is disabled")
+		case "/orgs/acme/code-security/configurations":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Errorf("unexpected org posture path %s", r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	posture, err := (RepositoryClient{TokenClient: minter, APIBaseURL: server.URL}).CollectOrganizationPosture(context.Background(), 321, "acme", "acme/repo")
+	if err != nil {
+		t.Fatalf("collect org posture: %v", err)
+	}
+	if check := orgPostureCheckByID(posture, "org_actions_policy"); check.State != RepositoryPostureStateSecure || check.Reason != "actions_disabled" {
+		t.Fatalf("expected disabled actions to be secure/actions_disabled, got %+v", check)
+	}
+	if check := orgPostureCheckByID(posture, "org_workflow_permissions"); check.State != RepositoryPostureStateSecure || check.Reason != "actions_disabled" {
+		t.Fatalf("expected disabled actions to skip workflow risk scoring, got %+v", check)
+	}
+	if check := orgPostureCheckByID(posture, "org_reusable_workflow_policy"); check.State != RepositoryPostureStateSecure || check.Reason != "not_applicable" {
+		t.Fatalf("expected disabled actions to skip reusable workflow risk scoring, got %+v", check)
+	}
+}
+
+func TestCollectOrganizationPostureSelectedActionsRepoMembershipGatesActionsRisk(t *testing.T) {
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/orgs/acme":
+			_, _ = w.Write([]byte(`{"login":"acme","secret_scanning_enabled_for_new_repositories":true,"secret_scanning_push_protection_enabled_for_new_repositories":true}`))
+		case "/orgs/acme/actions/permissions":
+			_, _ = w.Write([]byte(`{"enabled_repositories":"selected","allowed_actions":"all"}`))
+		case "/orgs/acme/actions/permissions/repositories":
+			_, _ = w.Write([]byte(`{"total_count":1,"repositories":[{"full_name":"acme/other"}]}`))
+		case "/orgs/acme/actions/permissions/workflow":
+			t.Errorf("workflow permissions should not be requested when repository is not selected for Actions")
+		case "/orgs/acme/actions/permissions/selected-actions":
+			t.Errorf("selected-actions allowlist should not be requested when repository is not selected for Actions")
+		case "/orgs/acme/code-security/configurations":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Errorf("unexpected org posture path %s", r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	posture, err := (RepositoryClient{TokenClient: minter, APIBaseURL: server.URL}).CollectOrganizationPosture(context.Background(), 321, "acme", "acme/repo")
+	if err != nil {
+		t.Fatalf("collect org posture: %v", err)
+	}
+	if check := orgPostureCheckByID(posture, "org_actions_policy"); check.State != RepositoryPostureStateSecure || check.Reason != "actions_not_enabled_for_repository" {
+		t.Fatalf("expected unselected repository to skip org actions risk, got %+v", check)
+	}
+	if check := orgPostureCheckByID(posture, "org_workflow_permissions"); check.State != RepositoryPostureStateSecure || check.Reason != "actions_not_enabled_for_repository" {
+		t.Fatalf("expected unselected repository to skip workflow risk scoring, got %+v", check)
+	}
+	if check := orgPostureCheckByID(posture, "org_reusable_workflow_policy"); check.State != RepositoryPostureStateSecure || check.Reason != "not_applicable" {
+		t.Fatalf("expected unselected repository to skip reusable workflow risk scoring, got %+v", check)
+	}
+}
+
+func TestCollectOrganizationPostureSelectedActionsRepoMembershipStopsAfterMatch(t *testing.T) {
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	selectedRepoCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/orgs/acme":
+			_, _ = w.Write([]byte(`{"login":"acme","secret_scanning_enabled_for_new_repositories":true,"secret_scanning_push_protection_enabled_for_new_repositories":true}`))
+		case "/orgs/acme/actions/permissions":
+			_, _ = w.Write([]byte(`{"enabled_repositories":"selected","allowed_actions":"all"}`))
+		case "/orgs/acme/actions/permissions/repositories":
+			selectedRepoCalls++
+			if selectedRepoCalls > 1 {
+				t.Errorf("selected repository pagination should stop after the repository is found")
+			}
+			w.Header().Set("Link", `<`+serverURLFromRequest(r)+`/orgs/acme/actions/permissions/repositories?per_page=100&page=2>; rel="next"`)
+			_, _ = w.Write([]byte(`{"total_count":2,"repositories":[{"full_name":"acme/repo"}]}`))
+		case "/orgs/acme/actions/permissions/workflow":
+			_, _ = w.Write([]byte(`{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}`))
+		case "/orgs/acme/code-security/configurations":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Errorf("unexpected org posture path %s", r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	posture, err := (RepositoryClient{TokenClient: minter, APIBaseURL: server.URL}).CollectOrganizationPosture(context.Background(), 321, "acme", "acme/repo")
+	if err != nil {
+		t.Fatalf("collect org posture: %v", err)
+	}
+	if selectedRepoCalls != 1 {
+		t.Fatalf("expected one selected repository page request, got %d", selectedRepoCalls)
+	}
+	if check := orgPostureCheckByID(posture, "org_actions_policy"); check.Reason == "actions_not_enabled_for_repository" {
+		t.Fatalf("expected matched repository to keep actions policy applicable, got %+v", check)
+	}
+	if check := orgPostureCheckByID(posture, "org_workflow_permissions"); check.State != RepositoryPostureStateSecure || check.Reason != "least_privilege_workflows" {
+		t.Fatalf("expected matched repository to keep workflow policy applicable, got %+v", check)
+	}
+}
+
+func TestCollectOrganizationPosturePermissionAndRateLimitStates(t *testing.T) {
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/orgs/acme":
+			http.Error(w, `{"message":"Resource not accessible by integration"}`, http.StatusForbidden)
+		case "/orgs/acme/actions/permissions":
+			w.Header().Set("X-RateLimit-Remaining", "0")
+			w.Header().Set("X-RateLimit-Reset", "1780000000")
+			http.Error(w, `{"message":"API rate limit exceeded"}`, http.StatusForbidden)
+		case "/orgs/acme/actions/permissions/workflow":
+			http.Error(w, `{"message":"Resource not accessible by integration"}`, http.StatusForbidden)
+		case "/orgs/acme/actions/permissions/selected-actions":
+			http.Error(w, `{"message":"Resource not accessible by integration"}`, http.StatusForbidden)
+		case "/orgs/acme/code-security/configurations":
+			http.Error(w, `{"message":"Resource not accessible by integration"}`, http.StatusForbidden)
+		default:
+			t.Errorf("unexpected org posture path %s", r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	posture, err := (RepositoryClient{TokenClient: minter, APIBaseURL: server.URL}).CollectOrganizationPosture(context.Background(), 321, "acme", "acme/repo")
+	if err != nil {
+		t.Fatalf("collect org posture: %v", err)
+	}
+	if check := orgPostureCheckByID(posture, "org_secret_scanning_policy"); check.State != RepositoryPostureStatePermissionLimited {
+		t.Fatalf("expected secret scanning permission limited, got %+v", check)
+	}
+	if check := orgPostureCheckByID(posture, "org_actions_policy"); check.State != RepositoryPostureStateUnavailable || check.Reason != "rate_limited" {
+		t.Fatalf("expected actions policy rate limited, got %+v", check)
+	}
+	if check := orgPostureCheckByID(posture, "org_code_security_configuration"); check.State != RepositoryPostureStatePermissionLimited {
+		t.Fatalf("expected code security permission limited, got %+v", check)
+	}
+}
+
+func TestCollectOrganizationPostureUnsupportedAndUnknownStates(t *testing.T) {
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/orgs/acme":
+			http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)
+		case "/orgs/acme/actions/permissions":
+			_, _ = w.Write([]byte(`{"enabled_repositories":"all","allowed_actions":""}`))
+		case "/orgs/acme/actions/permissions/workflow":
+			_, _ = w.Write([]byte(`{"default_workflow_permissions":"","can_approve_pull_request_reviews":false}`))
+		case "/orgs/acme/actions/permissions/selected-actions":
+			http.Error(w, `{"message":"Allowed actions must be set to selected"}`, http.StatusConflict)
+		case "/orgs/acme/code-security/configurations":
+			http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)
+		default:
+			t.Errorf("unexpected org posture path %s", r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	posture, err := (RepositoryClient{TokenClient: minter, APIBaseURL: server.URL}).CollectOrganizationPosture(context.Background(), 321, "acme", "acme/repo")
+	if err != nil {
+		t.Fatalf("collect org posture: %v", err)
+	}
+	if check := orgPostureCheckByID(posture, "org_secret_scanning_policy"); check.State != RepositoryPostureStateUnsupported || check.Reason != "plan_unavailable" {
+		t.Fatalf("expected secret scanning unsupported/plan_unavailable, got %+v", check)
+	}
+	if check := orgPostureCheckByID(posture, "org_actions_policy"); check.State != RepositoryPostureStateUnknown {
+		t.Fatalf("expected actions policy unknown, got %+v", check)
+	}
+	if check := orgPostureCheckByID(posture, "org_workflow_permissions"); check.State != RepositoryPostureStateUnknown {
+		t.Fatalf("expected workflow permissions unknown, got %+v", check)
+	}
+	if check := orgPostureCheckByID(posture, "org_reusable_workflow_policy"); check.State != RepositoryPostureStateSecure || check.Reason != "not_applicable" {
+		t.Fatalf("expected reusable workflow secure/not_applicable, got %+v", check)
+	}
+	if check := orgPostureCheckByID(posture, "org_code_security_configuration"); check.State != RepositoryPostureStateUnsupported || check.Reason != "plan_unavailable" {
+		t.Fatalf("expected code security unsupported/plan_unavailable, got %+v", check)
+	}
+}
+
+func TestCollectOrganizationPostureSecretScanningPolicyWeakWithoutCentralConfiguration(t *testing.T) {
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/orgs/acme":
+			_, _ = w.Write([]byte(`{"login":"acme"}`))
+		case "/orgs/acme/actions/permissions":
+			_, _ = w.Write([]byte(`{"enabled_repositories":"selected","allowed_actions":"local_only"}`))
+		case "/orgs/acme/actions/permissions/repositories":
+			_, _ = w.Write([]byte(`{"total_count":1,"repositories":[{"full_name":"acme/repo"}]}`))
+		case "/orgs/acme/actions/permissions/workflow":
+			_, _ = w.Write([]byte(`{"default_workflow_permissions":"read"}`))
+		case "/orgs/acme/actions/permissions/selected-actions":
+			t.Errorf("selected-actions allowlist should not be requested when allowed_actions is local_only")
+		case "/orgs/acme/code-security/configurations":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Errorf("unexpected org posture path %s", r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	posture, err := (RepositoryClient{TokenClient: minter, APIBaseURL: server.URL}).CollectOrganizationPosture(context.Background(), 321, "acme", "acme/repo")
+	if err != nil {
+		t.Fatalf("collect org posture: %v", err)
+	}
+	if check := orgPostureCheckByID(posture, "org_secret_scanning_policy"); check.State != RepositoryPostureStateInsecure || check.Reason != "secret_scanning_policy_weak" {
+		t.Fatalf("expected secret scanning insecure/secret_scanning_policy_weak, got %+v", check)
+	}
+	if check := orgPostureCheckByID(posture, "org_reusable_workflow_policy"); check.State != RepositoryPostureStateSecure || check.Reason != "not_applicable" {
+		t.Fatalf("expected reusable workflow secure/not_applicable, got %+v", check)
+	}
+}
+
+func TestCollectOrganizationPostureIgnoresGlobalCodeSecurityTemplates(t *testing.T) {
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/orgs/acme/actions/permissions":
+			_, _ = w.Write([]byte(`{"enabled_repositories":"selected","allowed_actions":"selected"}`))
+		case "/orgs/acme/actions/permissions/repositories":
+			_, _ = w.Write([]byte(`{"total_count":1,"repositories":[{"full_name":"acme/repo"}]}`))
+		case "/orgs/acme/actions/permissions/workflow":
+			_, _ = w.Write([]byte(`{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}`))
+		case "/orgs/acme/actions/permissions/selected-actions":
+			_, _ = w.Write([]byte(`{"github_owned_allowed":true,"verified_allowed":false,"patterns_allowed":["` + pinnedSelectedActionPattern + `"]}`))
+		case "/orgs/acme/code-security/configurations":
+			_, _ = w.Write([]byte(`[{"id":1,"name":"recommended","target_type":"global","enforcement":"enforced","secret_scanning":"enabled","secret_scanning_push_protection":"enabled"}]`))
+		default:
+			t.Errorf("unexpected org posture path %s", r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	posture, err := (RepositoryClient{TokenClient: minter, APIBaseURL: server.URL}).CollectOrganizationPosture(context.Background(), 321, "acme", "acme/repo")
+	if err != nil {
+		t.Fatalf("collect org posture: %v", err)
+	}
+	if check := orgPostureCheckByID(posture, "org_code_security_configuration"); check.State != RepositoryPostureStateInsecure || check.Reason != "no_central_configuration" {
+		t.Fatalf("expected global template not to count as central config, got %+v", check)
+	}
+	if check := orgPostureCheckByID(posture, "org_secret_scanning_policy"); check.State != RepositoryPostureStateInsecure {
+		t.Fatalf("expected global template not to prove secret scanning policy, got %+v", check)
+	}
+}
+
+func TestCollectOrganizationPostureRequiresEnforcedCodeSecurityConfiguration(t *testing.T) {
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/orgs/acme/actions/permissions":
+			_, _ = w.Write([]byte(`{"enabled_repositories":"selected","allowed_actions":"selected"}`))
+		case "/orgs/acme/actions/permissions/repositories":
+			_, _ = w.Write([]byte(`{"total_count":1,"repositories":[{"full_name":"acme/repo"}]}`))
+		case "/orgs/acme/actions/permissions/workflow":
+			_, _ = w.Write([]byte(`{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}`))
+		case "/orgs/acme/actions/permissions/selected-actions":
+			_, _ = w.Write([]byte(`{"github_owned_allowed":true,"verified_allowed":false,"patterns_allowed":["` + pinnedSelectedActionPattern + `"]}`))
+		case "/orgs/acme/code-security/configurations":
+			_, _ = w.Write([]byte(`[{"id":1,"name":"baseline","target_type":"organization","enforcement":"unenforced","secret_scanning":"enabled","secret_scanning_push_protection":"enabled"}]`))
+		default:
+			t.Errorf("unexpected org posture path %s", r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	posture, err := (RepositoryClient{TokenClient: minter, APIBaseURL: server.URL}).CollectOrganizationPosture(context.Background(), 321, "acme", "acme/repo")
+	if err != nil {
+		t.Fatalf("collect org posture: %v", err)
+	}
+	if check := orgPostureCheckByID(posture, "org_code_security_configuration"); check.State != RepositoryPostureStateInsecure || check.Reason != "configuration_not_enforced" {
+		t.Fatalf("expected unenforced config not to count as secure, got %+v", check)
+	}
+	if check := orgPostureCheckByID(posture, "org_secret_scanning_policy"); check.State != RepositoryPostureStateInsecure {
+		t.Fatalf("expected unenforced config not to prove secret scanning policy, got %+v", check)
+	}
+}
+
+func TestCollectOrganizationPostureInputErrors(t *testing.T) {
+	if _, err := (RepositoryClient{}).CollectOrganizationPosture(context.Background(), 1, "acme", "acme/repo"); err == nil {
+		t.Fatal("expected missing token client error")
+	}
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	if _, err := (RepositoryClient{TokenClient: minter}).CollectOrganizationPosture(context.Background(), 1, "owner/repo", "owner/repo"); err == nil || !strings.Contains(err.Error(), "single login") {
+		t.Fatalf("expected organization validation error, got %v", err)
+	}
+}
+
+func orgPostureCheckByID(posture OrganizationPosture, id string) RepositoryPostureCheck {
+	for _, check := range posture.Checks {
+		if check.ID == id {
+			return check
+		}
+	}
+	return RepositoryPostureCheck{}
+}

--- a/internal/connectors/github/posture.go
+++ b/internal/connectors/github/posture.go
@@ -21,6 +21,13 @@ const (
 	RepositoryPostureStateInsecure          RepositoryPostureState = "insecure"
 	RepositoryPostureStateUnavailable       RepositoryPostureState = "unavailable"
 	RepositoryPostureStatePermissionLimited RepositoryPostureState = "permission_limited"
+	// RepositoryPostureStateUnsupported marks a control GitHub does not expose
+	// for the repository/account plan (for example a GHAS-only org setting on a
+	// plan without GitHub Advanced Security).
+	RepositoryPostureStateUnsupported RepositoryPostureState = "unsupported"
+	// RepositoryPostureStateUnknown marks a control that was reachable but could
+	// not be classified from the response GitHub returned.
+	RepositoryPostureStateUnknown RepositoryPostureState = "unknown"
 )
 
 // RepositoryPosture describes GitHub-hosted repository security settings that

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -843,7 +843,13 @@ export type GitHubRepositoryListResponse = {
   repositories: GitHubRepositoryStatus[];
 };
 
-export type GitHubRepositoryPostureState = 'secure' | 'insecure' | 'unavailable' | 'permission_limited';
+export type GitHubRepositoryPostureState =
+  | 'secure'
+  | 'insecure'
+  | 'unavailable'
+  | 'permission_limited'
+  | 'unsupported'
+  | 'unknown';
 
 export type GitHubRepositoryPostureCheck = {
   id: string;
@@ -868,10 +874,19 @@ export type GitHubRepositoryPosture = {
   rate_limit?: GitHubRateLimitState;
 };
 
+export type GitHubOrganizationPosture = {
+  organization: string;
+  installation_id?: number;
+  collected_at: string;
+  checks: GitHubRepositoryPostureCheck[];
+  rate_limit?: GitHubRateLimitState;
+};
+
 export type GitHubRepositoryPostureResponse = {
   connector_id: string;
   provider: string;
   posture: GitHubRepositoryPosture;
+  organization_posture?: GitHubOrganizationPosture;
 };
 
 export type GitHubConnectionCompleteRequest = {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -33,6 +33,7 @@ import {
   type FindingLifecycleStatus,
   type GitHubConnectorStartResponse,
   type GitHubConnectionStatus,
+  type GitHubOrganizationPosture,
   type GitHubRepositoryPosture,
   type GitHubRepositoryPostureCheck,
   type KubernetesConnectorStartResponse,
@@ -561,11 +562,14 @@ function githubPostureStateTone(state: GitHubRepositoryPostureCheck['state']): '
   if (state === 'permission_limited') {
     return 'warning';
   }
+  if (state === 'unsupported' || state === 'unknown') {
+    return 'warning';
+  }
   return 'neutral';
 }
 
 function countGitHubPostureChecks(
-  posture: GitHubRepositoryPosture | null,
+  posture: GitHubRepositoryPosture | GitHubOrganizationPosture | null,
   state: GitHubRepositoryPostureCheck['state']
 ): number {
   return posture?.checks.filter((check) => check.state === state).length ?? 0;
@@ -3735,6 +3739,7 @@ export function ProductProjectDetailPage() {
   const [repoScanCancelingID, setRepoScanCancelingID] = useState('');
   const [repoScanError, setRepoScanError] = useState('');
   const [githubPosture, setGitHubPosture] = useState<GitHubRepositoryPosture | null>(null);
+  const [githubOrganizationPosture, setGitHubOrganizationPosture] = useState<GitHubOrganizationPosture | null>(null);
   const [githubPostureLoading, setGitHubPostureLoading] = useState(false);
   const [githubPostureError, setGitHubPostureError] = useState('');
   const [awsForm, setAWSForm] = useState({
@@ -3795,6 +3800,14 @@ export function ProductProjectDetailPage() {
   const githubPostureAttentionCount = countGitHubPostureChecks(githubPosture, 'insecure');
   const githubPostureLimitedCount = countGitHubPostureChecks(githubPosture, 'permission_limited');
   const githubPostureUnavailableCount = countGitHubPostureChecks(githubPosture, 'unavailable');
+  const githubPostureUnsupportedCount = countGitHubPostureChecks(githubPosture, 'unsupported');
+  const githubPostureUnknownCount = countGitHubPostureChecks(githubPosture, 'unknown');
+  const githubOrganizationPostureSecureCount = countGitHubPostureChecks(githubOrganizationPosture, 'secure');
+  const githubOrganizationPostureAttentionCount = countGitHubPostureChecks(githubOrganizationPosture, 'insecure');
+  const githubOrganizationPostureLimitedCount = countGitHubPostureChecks(githubOrganizationPosture, 'permission_limited');
+  const githubOrganizationPostureUnavailableCount = countGitHubPostureChecks(githubOrganizationPosture, 'unavailable');
+  const githubOrganizationPostureUnsupportedCount = countGitHubPostureChecks(githubOrganizationPosture, 'unsupported');
+  const githubOrganizationPostureUnknownCount = countGitHubPostureChecks(githubOrganizationPosture, 'unknown');
   const githubPostureAttentionChecks = useMemo(
     () => githubPosture?.checks.filter((check) => check.state !== 'secure') ?? [],
     [githubPosture]
@@ -3802,7 +3815,19 @@ export function ProductProjectDetailPage() {
   const githubPostureDetailChecks =
     githubPostureAttentionChecks.length > 0 ? githubPostureAttentionChecks : (githubPosture?.checks ?? []);
   const githubPostureNeedsAttentionCount =
-    githubPostureAttentionCount + githubPostureLimitedCount + githubPostureUnavailableCount;
+    githubPostureAttentionCount +
+    githubPostureLimitedCount +
+    githubPostureUnavailableCount +
+    githubPostureUnsupportedCount +
+    githubPostureUnknownCount;
+  const githubOrganizationPostureAttentionChecks = useMemo(
+    () => githubOrganizationPosture?.checks.filter((check) => check.state !== 'secure') ?? [],
+    [githubOrganizationPosture]
+  );
+  const githubOrganizationPostureDetailChecks =
+    githubOrganizationPostureAttentionChecks.length > 0
+      ? githubOrganizationPostureAttentionChecks
+      : (githubOrganizationPosture?.checks ?? []);
   const githubHasActiveRepoScan = githubRecentRepoScans.some((scan) => isActiveScanStatus(scan.status));
   const githubHasActiveSelectedRepoScan =
     effectiveRepoScanRepositoryKey !== '' &&
@@ -4060,12 +4085,14 @@ export function ProductProjectDetailPage() {
       setGitHubPosture(null);
       setGitHubPostureLoading(false);
       setGitHubPostureError('');
+      setGitHubOrganizationPosture(null);
       return undefined;
     }
 
     setGitHubPostureLoading(true);
     setGitHubPostureError('');
     setGitHubPosture(null);
+    setGitHubOrganizationPosture(null);
     void apiClient
       .getGitHubConnectorRepositoryPosture(
         connection.connector_id,
@@ -4079,12 +4106,14 @@ export function ProductProjectDetailPage() {
           return;
         }
         setGitHubPosture(response.posture);
+        setGitHubOrganizationPosture(response.organization_posture ?? null);
       })
       .catch((error) => {
         if (githubPostureRequestRef.current !== requestID) {
           return;
         }
         setGitHubPosture(null);
+        setGitHubOrganizationPosture(null);
         setGitHubPostureError(error instanceof Error ? error.message : 'Unable to load GitHub repository posture.');
       })
       .finally(() => {
@@ -5311,6 +5340,43 @@ export function ProductProjectDetailPage() {
                       ))}
                       {githubPostureDetailChecks.length > 6 ? (
                         <p>{formatCountLabel(githubPostureDetailChecks.length - 6, 'additional check', 'additional checks')} hidden.</p>
+                      ) : null}
+                      {githubOrganizationPosture ? (
+                        <>
+                          <article>
+                            <strong>Organization posture</strong>
+                            <span>{formatConnectionTime(githubOrganizationPosture.collected_at)}</span>
+                            <p>
+                              {githubOrganizationPostureSecureCount} secure · {githubOrganizationPostureAttentionCount}{' '}
+                              attention · {githubOrganizationPostureLimitedCount} permission limited ·{' '}
+                              {githubOrganizationPostureUnavailableCount} unavailable
+                            </p>
+                            <small>
+                              {githubOrganizationPostureUnsupportedCount} unsupported ·{' '}
+                              {githubOrganizationPostureUnknownCount} unknown
+                            </small>
+                          </article>
+                          {githubOrganizationPostureDetailChecks.slice(0, 5).map((check) => (
+                            <article key={`org-${check.id}`}>
+                              <strong>{formatTokenLabel(check.category || check.id)}</strong>
+                              <span className={`idt-source-status-pill is-${githubPostureStateTone(check.state)}`}>
+                                {formatTokenLabel(check.state)}
+                              </span>
+                              <p>{check.summary}</p>
+                              {check.reason ? <small>{formatTokenLabel(check.reason)}</small> : null}
+                            </article>
+                          ))}
+                          {githubOrganizationPostureDetailChecks.length > 5 ? (
+                            <p>
+                              {formatCountLabel(
+                                githubOrganizationPostureDetailChecks.length - 5,
+                                'additional organization check',
+                                'additional organization checks'
+                              )}{' '}
+                              hidden.
+                            </p>
+                          ) : null}
+                        </>
                       ) : null}
                     </div>
                   </details>


### PR DESCRIPTION
Fixes #1328

## What changed

- Added GitHub organization-level posture collection for inherited security policy controls.
- Added normalized `unsupported` and `unknown` posture states so plan/API limitations and unclassified responses do not look secure.
- Collected organization secret-scanning defaults, Actions policy, workflow token defaults, selected-actions/reusable-workflow posture, and central code-security configurations.
- Returned organization posture alongside repository posture without replacing the existing repository posture model.
- Updated CLI output, OpenAPI, app API types, and app GitHub posture rendering to include inherited organization posture.
- Documented organization posture behavior, supported controls, and non-secure uncertainty states.

## Why it changed

Repository-level posture alone cannot explain inherited GitHub organization policy. Many machine-identity controls live at the organization layer: secret scanning defaults, push protection, Actions policy, workflow token defaults, reusable workflow restrictions, and central code security configurations.

## Impact and risk

- Repository posture remains the primary response field and existing consumers can keep reading it.
- Organization posture is additive and omitted when unavailable at the response level.
- Individual organization checks distinguish secure, insecure, permission-limited, unavailable, unsupported, and unknown states.
- No mutation APIs are added; this remains read-only GitHub posture intelligence.

## Validation performed

- `gofmt -w internal/api/github_connect.go internal/api/github_connector_v2_test.go internal/cli/repo_intelligence.go internal/connectors/github/org_posture.go internal/connectors/github/org_posture_test.go internal/connectors/github/posture.go`
- `go test ./internal/connectors/github ./internal/api ./internal/cli`
- `npm ci --prefix web`
- `npm run test:ci --prefix web` => 12 files passed, 184 tests passed
- `go test ./... -coverprofile=coverage.out`
- `go tool cover -func=coverage.out` => total coverage `80.2%`
- `npm run build --prefix web` => build succeeded and prerendered 41 routes
- pre-commit hooks during commit: merge-conflict check, YAML check, end-of-file check, trailing whitespace, gofmt, Vercel artifact hygiene
- pre-push hooks during push: merge-conflict check, YAML check, end-of-file check, trailing whitespace, gofmt, `go vet`, local env token hygiene, Vercel artifact hygiene

AI-assisted: yes
Tools used: Codex
Where used: GitHub organization posture implementation, tests, docs, OpenAPI, app wiring, validation, and PR preparation
Human verification performed: Reviewed the focused diff and ran the validation commands listed above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds organization-level security policy posture to repository posture so inherited org controls are visible and never counted as secure, addressing Linear #1328. The API returns an optional `organization_posture`, and the `CLI`/`web` render it with counts and a warning tone for `unsupported` and `unknown`.

- **New Features**
  - Collects org policy: Actions (disabled and selected-repo membership), workflow token defaults/PR approval, selected-actions/reusable-workflow allowlist, and central code-security configurations; derives secret-scanning policy only from enforced org-scoped configurations and ignores global templates.
  - Adds `unsupported` and `unknown` states; never treated as secure; `CLI` includes them in counts and shows an org posture section (omits it when the owner is a user with `unsupported/not_an_organization`, preserves plan-limited `unsupported` like `plan_unavailable`); `web` adds an org posture panel with summary and details.
  - API includes `organization_posture` when available; OpenAPI adds `GitHubOrganizationPosture` and extends the state enum; docs updated.

- **Migration**
  - Additive change: repository posture remains primary; `organization_posture` may be absent.
  - New enum states (`unsupported`, `unknown`) may appear; treat as non-passing.

<sup>Written for commit bbe3efab46511a40f7712b1bdb2225829a89d384. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1334?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

