### PR TITLE
Detect MCP and AI-agent repository exposures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@
   mapped severity. Each alert source is independent enrichment: permission-
   limited, unavailable, or rate-limited endpoints no longer fail the native scan.
   Imported alerts are deduplicated deterministically across scans.
+- Added MCP and AI-agent repository exposure detection for committed agent
+  configs, sensitive environment-variable references, dangerous tool
+  capabilities, and raw provider-shaped secrets in agent config without storing
+  raw secret values.
 - Polished the repository Findings page styling: softened the summary-tile
   labels from all-caps to sentence case, styled the new metric captions, the
   scan-health banner, and the failed-scan state actions, and set the summary

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -253,6 +253,11 @@ The scanner uses a versioned secret detector registry for commit-history secret 
   - Terraform public S3 ACL
   - Terraform SSH/RDP open to world (`0.0.0.0/0`)
   - Docker `FROM ...:latest`
+  - MCP and AI-agent configuration:
+    - committed local MCP/agent config files such as `.mcp.json`, `.cursor/mcp.json`, `.continue/*`, `.codex/*`, and `.claude/*`
+    - raw provider-shaped secret values inside agent config, emitted as redacted secret findings
+    - sensitive environment-variable references such as GitHub, cloud, package registry, database, signing, and AI provider tokens
+    - shell, filesystem, browser, network, cloud, cluster, and deployment tool capabilities exposed through repository-defined agent config
 
 ## Registry model
 
@@ -305,6 +310,23 @@ write permissions is emitted as a critical workflow attack path.
 | `workflow_artifact_poisoning` | PR or `workflow_run` context can upload artifacts or release assets consumed later. | Medium to high | Keep untrusted artifacts isolated, verify provenance before reuse, and publish releases only from protected contexts. |
 | `workflow_self_hosted_runner` | Self-hosted runner usage has no obvious org-level controls and can route untrusted jobs to shared infrastructure. | Medium | Enforce repository-level self-hosted runner restrictions, dedicated groups, and minimal permissions before enabling untrusted pull-request execution. |
 | `workflow_self_hosted_runner_unresolved` | Self-hosted runner-group visibility is permission-limited or unavailable, leaving posture state uncertain. | Medium | Grant the GitHub App read access to org runner groups or route high-risk repos to managed GitHub-hosted runners. |
+
+### MCP And AI-Agent Detectors
+
+Identrail treats MCP servers and AI-agent tool definitions as repository
+machine-identity exposure surfaces. The scanner inspects common committed
+configuration paths without executing agent tools or contacting external
+services.
+
+| Detector | Signal | Typical severity | Recommended remediation |
+| --- | --- | --- | --- |
+| `ai_agent_sensitive_env_reference` | Agent config references credential-like environment variables such as GitHub, cloud, package registry, database, signing, or AI provider tokens. | Medium | Scope the agent runtime environment, move values to secret-manager injection, and use low-privilege agent-specific credentials. |
+| `ai_agent_dangerous_tool_capability` | Agent config exposes shell, filesystem, network, browser, cloud, cluster, or deployment tools. | Medium to high | Restrict tool allowlists, sandbox execution, separate read-only tools from write-capable tools, and gate cloud/deploy commands. |
+| `ai_agent_committed_local_config` | Developer-local MCP or AI-agent config is committed to the repo. | Low | Move local config to ignored files and commit only reviewed non-secret templates. |
+
+Raw secret-like values found in these files are emitted through the existing
+secret detectors with `ai_agent_surface: true`, redacted snippets,
+`raw_secret_stored: false`, and provider-specific rotation guidance.
 
 To add a new secret detector, add a new entry to the registry with a unique ID, a new version if needed for compatibility, and test fixtures.
 

--- a/internal/findings/standards/repo_remediation.go
+++ b/internal/findings/standards/repo_remediation.go
@@ -71,7 +71,8 @@ func SuggestRepoExposureRemediation(finding domain.Finding) (RepoExposureRemedia
 			if strings.HasPrefix(detector, "workflow_") ||
 				strings.HasPrefix(detector, "terraform_") ||
 				strings.HasPrefix(detector, "docker_") ||
-				strings.HasPrefix(detector, "k8s_") {
+				strings.HasPrefix(detector, "k8s_") ||
+				strings.HasPrefix(detector, "ai_agent_") {
 				finding.Type = domain.FindingRepoMisconfig
 				return repoMisconfigRemediation(finding)
 			}
@@ -151,9 +152,18 @@ func repoMisconfigRemediation(finding domain.Finding) (RepoExposureRemediation, 
 		return terraformOpenManagementPortRemediation(finding, detector), true
 	case "docker_latest_tag":
 		return dockerLatestTagRemediation(finding, detector), true
+	case "ai_agent_sensitive_env_reference":
+		return aiAgentSensitiveEnvRemediation(finding, detector), true
+	case "ai_agent_dangerous_tool_capability":
+		return aiAgentDangerousToolRemediation(finding, detector), true
+	case "ai_agent_committed_local_config":
+		return aiAgentCommittedConfigRemediation(finding, detector), true
 	default:
 		if strings.HasPrefix(detector, "workflow_") {
 			return workflowGenericRemediation(finding, detector), true
+		}
+		if strings.HasPrefix(detector, "ai_agent_") {
+			return aiAgentGenericRemediation(finding, detector), true
 		}
 		return RepoExposureRemediation{}, false
 	}
@@ -540,6 +550,85 @@ func dockerLatestTagRemediation(finding domain.Finding, detector string) RepoExp
 		},
 		"FROM <image>:<pinned-version-or-digest>",
 		"Docker image pinning requires an operator-selected tested version or digest")
+}
+
+func aiAgentSensitiveEnvRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return guidanceRepoRemediation(finding, detector,
+		"Constrain sensitive environment variables exposed to MCP or AI-agent tools.",
+		"Agent configuration references credential-like environment variables that may be reachable by tool execution.",
+		[]string{
+			"Move sensitive values to a secret manager or runtime injection path that is not committed to the repository.",
+			"Scope the agent runtime environment to only the variables each server or tool requires.",
+			"Use separate low-privilege tokens for agent tooling instead of developer or deployment credentials.",
+		},
+		[]string{
+			"Environment variable names are not raw secrets, but they identify machine identities that should be reviewed.",
+			"Do not paste the current variable values into remediation notes, issues, or generated PRs.",
+		},
+		[]string{
+			"Run the agent with a minimal environment and confirm the intended tools still work.",
+			"Review provider audit logs for the referenced token or key families.",
+		},
+		"agent environment exposure requires operator review of runtime secret injection")
+}
+
+func aiAgentDangerousToolRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return guidanceRepoRemediation(finding, detector,
+		"Restrict dangerous MCP or AI-agent tool capabilities.",
+		"Agent configuration exposes shell, filesystem, browser, network, cloud, cluster, or deployment capabilities that can expand machine-identity blast radius.",
+		[]string{
+			"Remove arbitrary shell or command-runner access unless it is isolated in a sandbox with explicit approval.",
+			"Limit filesystem roots, network access, browser automation, cloud CLIs, and deployment commands to reviewed allowlists.",
+			"Separate read-only analysis tools from write-capable deployment or infrastructure tools.",
+		},
+		[]string{
+			"Do not auto-publish capability changes without an owner reviewing expected agent workflows.",
+			"Treat any agent with shell plus secrets as a privileged machine identity.",
+		},
+		[]string{
+			"Run the agent in a dry-run or sandbox mode and verify blocked tools fail closed.",
+			"Confirm cloud, GitHub, package, and deployment providers show no unexpected writes from agent credentials.",
+		},
+		"dangerous agent capability changes need workflow-owner review and sandbox design")
+}
+
+func aiAgentCommittedConfigRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return guidanceRepoRemediation(finding, detector,
+		"Move local MCP or AI-agent configuration out of source control.",
+		"Committed local agent configuration can expose tool definitions, internal endpoints, and sensitive environment expectations.",
+		[]string{
+			"Move developer-local agent configuration to ignored files or per-user secret storage.",
+			"Commit only reviewed templates that contain placeholders and no internal endpoints or credentials.",
+			"Add ignore rules and pre-commit checks for local MCP/agent config variants.",
+		},
+		[]string{
+			"Some team-managed agent templates are safe to commit when reviewed; prefer explicit template filenames.",
+			"Do not remove shared configuration until owners confirm it is not required for CI or onboarding.",
+		},
+		[]string{
+			"Re-run the repository scanner and confirm only safe templates remain.",
+			"Confirm local developer setup still works through documented non-secret configuration.",
+		},
+		"local agent config cleanup needs repository-owner review")
+}
+
+func aiAgentGenericRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return guidanceRepoRemediation(finding, detector,
+		"Harden MCP or AI-agent repository configuration.",
+		firstNonEmpty(finding.HumanSummary, "The repository contains AI-agent configuration that can affect machine identity exposure."),
+		[]string{
+			"Review the affected agent server, tool command, environment variables, filesystem roots, and network access.",
+			"Separate trusted automation from developer-local tooling and remove secrets from committed configuration.",
+			"Run write-capable agent tools only inside isolated, auditable approval flows.",
+		},
+		[]string{
+			"Agent configuration can behave like machine identity policy; review changes with the same rigor as CI credentials.",
+		},
+		[]string{
+			"Re-run repository scanning after reducing tool and secret exposure.",
+			"Confirm provider logs show expected agent credential usage only.",
+		},
+		"generic agent remediation requires detector-specific owner review")
 }
 
 func deterministicRepoRemediation(

--- a/internal/findings/standards/repo_remediation_test.go
+++ b/internal/findings/standards/repo_remediation_test.go
@@ -30,6 +30,9 @@ func TestSuggestRepoExposureRemediationSupportsMisconfigDetectors(t *testing.T) 
 		{"terraform_public_s3_acl", true, true},
 		{"terraform_open_ssh_rdp", false, true},
 		{"docker_latest_tag", false, true},
+		{"ai_agent_sensitive_env_reference", false, false},
+		{"ai_agent_dangerous_tool_capability", false, false},
+		{"ai_agent_committed_local_config", false, false},
 	}
 
 	for _, tc := range cases {

--- a/internal/repoexposure/ai_agent_analyzer.go
+++ b/internal/repoexposure/ai_agent_analyzer.go
@@ -1,0 +1,529 @@
+package repoexposure
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+const aiAgentAnalyzerVersion = "2026.05"
+
+var envTokenPattern = regexp.MustCompile(`\b[A-Za-z][A-Za-z0-9_]{2,}\b`)
+
+type aiAgentCapability struct {
+	Name     string
+	Kind     string
+	Severity domain.FindingSeverity
+	Summary  string
+}
+
+func detectAIAgentConfigFindings(repo string, commit string, path string, content []byte, seen map[string]struct{}, detectedAt time.Time, options ...secretFindingOption) []domain.Finding {
+	if !isAIAgentConfigPath(path) {
+		return nil
+	}
+
+	findings := []domain.Finding{}
+	lines := strings.Split(string(content), "\n")
+	// Structured (JSON/YAML) configs are analyzed by structuredAIAgentSurfaces.
+	// Running line-level capability/env heuristics on successfully parsed structured
+	// configs can duplicate findings, so we skip those once parser-backed findings
+	// are available.
+	structuredPossible := isStructuredAgentConfig(path)
+	resolver := newAgentLineResolver(lines)
+	structuredSurfaces := []aiAgentStructuredFinding{}
+	if structuredPossible {
+		structuredSurfaces = structuredAIAgentSurfaces(path, content, resolver)
+	}
+	for index, line := range lines {
+		lineNumber := index + 1
+		secretFindings := detectSecretFindings(repo, commit, path, lineNumber, line, detectedAt, options...)
+		for _, finding := range secretFindings {
+			finding.Evidence["history_source"] = "head_snapshot"
+			finding.Evidence["ai_agent_surface"] = true
+			finding.Evidence["detector_category"] = firstNonEmptyString(anyString(finding.Evidence["detector_category"]), "ai_agent_secret")
+			finding.Evidence["agent_config_path"] = path
+			findings = append(findings, finding)
+		}
+		if len(secretFindings) > 0 {
+			continue
+		}
+
+		// If structured parsing succeeds, it already captures command/env evidence
+		// more precisely than plain text matching.
+		if len(structuredSurfaces) > 0 {
+			continue
+		}
+		// For non-structured AI surfaces (for example copilot instructions), only
+		// secret scanning is intended at this stage.
+		if !structuredPossible {
+			continue
+		}
+
+		variables := sensitiveEnvReferences(line)
+		if len(variables) > 0 {
+			appendAIAgentFinding(&findings, seen, repo, commit, path, lineNumber, "ai_agent_sensitive_env_reference", domain.SeverityMedium,
+				"AI agent configuration references sensitive environment variables",
+				"An MCP or AI-agent configuration references credential-like environment variables that may be reachable by tool execution.",
+				"Keep sensitive values in a secret manager, scope agent runtime environment variables to the smallest needed set, and avoid committing local agent configs.",
+				sanitizeAgentSnippet(line), detectedAt, map[string]any{
+					"agent_config_path": path,
+					"env_variables":     variables,
+					"raw_secret_data":   false,
+				})
+		}
+		for _, capability := range dangerousAgentCapabilities(line) {
+			appendAIAgentFinding(&findings, seen, repo, commit, path, lineNumber, "ai_agent_dangerous_tool_capability", capability.Severity,
+				"AI agent configuration exposes dangerous tool capability",
+				capability.Summary,
+				"Restrict the tool allowlist, isolate agent execution, remove broad shell/filesystem/network access, and gate deploy or cloud commands behind reviewed workflows.",
+				sanitizeAgentSnippet(line), detectedAt, map[string]any{
+					"agent_config_path": path,
+					"capability":        capability.Kind,
+					"tool_name":         capability.Name,
+					"raw_secret_data":   false,
+				})
+		}
+	}
+
+	for _, surface := range structuredSurfaces {
+		appendAIAgentFinding(&findings, seen, repo, commit, path, surface.Line, surface.Detector, surface.Severity,
+			surface.Title, surface.Summary, surface.Remediation, surface.Snippet, detectedAt, surface.Evidence)
+	}
+
+	if isCommittedLocalAIAgentConfig(path) {
+		appendAIAgentFinding(&findings, seen, repo, commit, path, 1, "ai_agent_committed_local_config", domain.SeverityLow,
+			"Local AI agent configuration is committed to the repository",
+			"A local MCP or AI-agent configuration file is present in source control, which can expose tool definitions, environment expectations, internal endpoints, or developer-only automation behavior.",
+			"Move local agent configuration to ignored developer files, commit only reviewed team-safe templates, and document required secrets through non-secret examples.",
+			path, detectedAt, map[string]any{
+				"agent_config_path": path,
+				"raw_secret_data":   false,
+			})
+	}
+
+	return findings
+}
+
+type aiAgentStructuredFinding struct {
+	Detector    string
+	Severity    domain.FindingSeverity
+	Title       string
+	Summary     string
+	Remediation string
+	Line        int
+	Snippet     string
+	Evidence    map[string]any
+}
+
+func structuredAIAgentSurfaces(path string, content []byte, resolver *agentLineResolver) []aiAgentStructuredFinding {
+	lower := strings.ToLower(strings.TrimSpace(path))
+	if !strings.HasSuffix(lower, ".json") && !strings.HasSuffix(lower, ".yaml") && !strings.HasSuffix(lower, ".yml") {
+		return nil
+	}
+
+	var root any
+	if strings.HasSuffix(lower, ".json") {
+		if err := json.Unmarshal(content, &root); err != nil {
+			return nil
+		}
+	} else {
+		if err := yaml.Unmarshal(content, &root); err != nil {
+			return nil
+		}
+		root = normalizeYAMLValue(root)
+	}
+
+	findings := []aiAgentStructuredFinding{}
+	walkAIAgentValue(root, nil, resolver, &findings)
+	return findings
+}
+
+func walkAIAgentValue(value any, trail []string, resolver *agentLineResolver, findings *[]aiAgentStructuredFinding) {
+	switch typed := value.(type) {
+	case map[string]any:
+		name := firstAIAgentName(typed, trail)
+		for key, child := range typed {
+			lowerKey := strings.ToLower(strings.TrimSpace(key))
+			childTrail := append(append([]string(nil), trail...), key)
+			switch {
+			case lowerKey == "command" || lowerKey == "args" || lowerKey == "arguments":
+				for _, command := range agentStringValues(child) {
+					appendAgentCapabilityFindings(resolver, findings, command, childTrail, name)
+				}
+			case isEnvContainerKey(lowerKey):
+				envVars := sensitiveEnvValues(child)
+				if len(envVars) > 0 {
+					*findings = append(*findings, aiAgentStructuredFinding{
+						Detector:    "ai_agent_sensitive_env_reference",
+						Severity:    domain.SeverityMedium,
+						Title:       "AI agent configuration references sensitive environment variables",
+						Summary:     "An MCP or AI-agent configuration references credential-like environment variables that may be reachable by tool execution.",
+						Remediation: "Keep sensitive values in a secret manager, scope agent runtime environment variables to the smallest needed set, and avoid committing local agent configs.",
+						Line:        resolver.lineFor(envVars[0]),
+						Snippet:     "env: " + strings.Join(envVars, ", "),
+						Evidence: map[string]any{
+							"config_tree_path": strings.Join(childTrail, "."),
+							"env_variables":    envVars,
+							"tool_name":        name,
+							"raw_secret_data":  false,
+						},
+					})
+				}
+			}
+			walkAIAgentValue(child, childTrail, resolver, findings)
+		}
+	case []any:
+		for _, child := range typed {
+			walkAIAgentValue(child, trail, resolver, findings)
+		}
+	}
+}
+
+func appendAgentCapabilityFindings(resolver *agentLineResolver, findings *[]aiAgentStructuredFinding, value string, trail []string, name string) {
+	for _, capability := range dangerousAgentCapabilities(value) {
+		*findings = append(*findings, aiAgentStructuredFinding{
+			Detector:    "ai_agent_dangerous_tool_capability",
+			Severity:    capability.Severity,
+			Title:       "AI agent configuration exposes dangerous tool capability",
+			Summary:     capability.Summary,
+			Remediation: "Restrict the tool allowlist, isolate agent execution, remove broad shell/filesystem/network access, and gate deploy or cloud commands behind reviewed workflows.",
+			Line:        resolver.lineFor(capability.Name),
+			// The capability name is part of the snippet so multiple risky tools
+			// in the same command (for example "aws ... && vercel ...") are not
+			// collapsed by snippet-aware deduplication.
+			Snippet: capability.Name + ": " + sanitizeAgentSnippet(value),
+			Evidence: map[string]any{
+				"config_tree_path": strings.Join(trail, "."),
+				"capability":       capability.Kind,
+				"tool_name":        firstNonEmptyString(name, capability.Name),
+				"raw_secret_data":  false,
+			},
+		})
+	}
+}
+
+func agentStringValues(value any) []string {
+	switch typed := value.(type) {
+	case string:
+		if strings.TrimSpace(typed) != "" {
+			return []string{typed}
+		}
+	case []any:
+		values := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if str, ok := item.(string); ok && strings.TrimSpace(str) != "" {
+				values = append(values, str)
+			}
+		}
+		return values
+	}
+	return nil
+}
+
+// agentLineResolver maps a structured finding back to a best-effort source line
+// in the raw config. Repeated lookups of the same token advance a per-token
+// cursor so distinct occurrences (for example identical commands in two servers)
+// resolve to distinct lines instead of all collapsing onto line 1.
+type agentLineResolver struct {
+	lower  []string
+	cursor map[string]int
+}
+
+func newAgentLineResolver(lines []string) *agentLineResolver {
+	lower := make([]string, len(lines))
+	for index, line := range lines {
+		lower[index] = strings.ToLower(line)
+	}
+	return &agentLineResolver{lower: lower, cursor: map[string]int{}}
+}
+
+func (r *agentLineResolver) lineFor(needle string) int {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	if needle == "" {
+		return 1
+	}
+	for index := r.cursor[needle]; index < len(r.lower); index++ {
+		if strings.Contains(r.lower[index], needle) {
+			r.cursor[needle] = index + 1
+			return index + 1
+		}
+	}
+	for index := 0; index < len(r.lower); index++ {
+		if strings.Contains(r.lower[index], needle) {
+			return index + 1
+		}
+	}
+	return 1
+}
+
+func appendAIAgentFinding(
+	findings *[]domain.Finding,
+	seen map[string]struct{},
+	repo string,
+	revision string,
+	path string,
+	line int,
+	ruleID string,
+	severity domain.FindingSeverity,
+	title string,
+	summary string,
+	remediation string,
+	snippet string,
+	detectedAt time.Time,
+	extraEvidence map[string]any,
+) {
+	if line < 1 {
+		line = 1
+	}
+	evidence := map[string]any{
+		"ai_agent_surface":      true,
+		"agent_config_path":     path,
+		"detector_version":      aiAgentAnalyzerVersion,
+		"detector_category":     "ai_agent_config",
+		"line_snippet":          snippet,
+		"line_snippet_redacted": false,
+	}
+	for key, value := range extraEvidence {
+		evidence[key] = value
+	}
+	appendMisconfigFinding(findings, seen, repo, revision, path, line, ruleID, severity, title, summary, remediation, snippet, detectedAt, evidence)
+}
+
+func sensitiveEnvReferences(line string) []string {
+	tokens := envTokenPattern.FindAllString(line, -1)
+	return filterSensitiveEnvNames(tokens)
+}
+
+func sensitiveEnvValues(value any) []string {
+	var tokens []string
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			tokens = append(tokens, strings.ToUpper(strings.TrimSpace(key)))
+			tokens = append(tokens, sensitiveEnvValues(child)...)
+		}
+	case []any:
+		for _, child := range typed {
+			tokens = append(tokens, sensitiveEnvValues(child)...)
+		}
+	case string:
+		tokens = append(tokens, sensitiveEnvReferences(typed)...)
+	}
+	return filterSensitiveEnvNames(tokens)
+}
+
+func filterSensitiveEnvNames(tokens []string) []string {
+	seen := map[string]struct{}{}
+	values := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		token = strings.TrimSpace(strings.ToUpper(token))
+		if !isSensitiveEnvName(token) {
+			continue
+		}
+		if _, exists := seen[token]; exists {
+			continue
+		}
+		seen[token] = struct{}{}
+		values = append(values, token)
+	}
+	sort.Strings(values)
+	return values
+}
+
+func isSensitiveEnvName(name string) bool {
+	if name == "" {
+		return false
+	}
+	name = strings.ToUpper(strings.TrimSpace(name))
+	switch name {
+	case "GITHUB_TOKEN", "GH_TOKEN", "GITLAB_TOKEN", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "NPM_TOKEN", "NODE_AUTH_TOKEN",
+		"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "GOOGLE_APPLICATION_CREDENTIALS", "AZURE_CLIENT_SECRET",
+		"DATABASE_URL", "DB_URL", "PRIVATE_KEY", "WEBHOOK_SECRET", "SLACK_BOT_TOKEN", "VERCEL_TOKEN", "CLOUDFLARE_API_TOKEN":
+		return true
+	}
+	if !strings.Contains(name, "_") {
+		return false
+	}
+	lower := strings.ToLower(name)
+	return strings.Contains(lower, "token") ||
+		strings.Contains(lower, "secret") ||
+		strings.Contains(lower, "password") ||
+		strings.Contains(lower, "private_key") ||
+		strings.Contains(lower, "access_key") ||
+		strings.Contains(lower, "credential")
+}
+
+func dangerousAgentCapabilities(line string) []aiAgentCapability {
+	lower := strings.ToLower(line)
+	capabilities := []aiAgentCapability{}
+	for _, item := range []aiAgentCapability{
+		{Name: "shell", Kind: "shell_execution", Severity: domain.SeverityHigh, Summary: "An MCP or AI-agent tool can invoke a shell or arbitrary command runner from repository-defined configuration."},
+		{Name: "bash", Kind: "shell_execution", Severity: domain.SeverityHigh, Summary: "An MCP or AI-agent tool can invoke a shell or arbitrary command runner from repository-defined configuration."},
+		{Name: "sh", Kind: "shell_execution", Severity: domain.SeverityHigh, Summary: "An MCP or AI-agent tool can invoke a shell or arbitrary command runner from repository-defined configuration."},
+		{Name: "powershell", Kind: "shell_execution", Severity: domain.SeverityHigh, Summary: "An MCP or AI-agent tool can invoke a shell or arbitrary command runner from repository-defined configuration."},
+		{Name: "cmd.exe", Kind: "shell_execution", Severity: domain.SeverityHigh, Summary: "An MCP or AI-agent tool can invoke a shell or arbitrary command runner from repository-defined configuration."},
+		{Name: "aws", Kind: "cloud_cli", Severity: domain.SeverityHigh, Summary: "An MCP or AI-agent tool can invoke cloud or deployment CLIs that may mutate infrastructure or consume machine credentials."},
+		{Name: "gcloud", Kind: "cloud_cli", Severity: domain.SeverityHigh, Summary: "An MCP or AI-agent tool can invoke cloud or deployment CLIs that may mutate infrastructure or consume machine credentials."},
+		{Name: "az", Kind: "cloud_cli", Severity: domain.SeverityHigh, Summary: "An MCP or AI-agent tool can invoke cloud or deployment CLIs that may mutate infrastructure or consume machine credentials."},
+		{Name: "kubectl", Kind: "cluster_cli", Severity: domain.SeverityHigh, Summary: "An MCP or AI-agent tool can invoke cluster administration commands from repository-defined configuration."},
+		{Name: "vercel", Kind: "deployment_cli", Severity: domain.SeverityHigh, Summary: "An MCP or AI-agent tool can invoke deployment commands from repository-defined configuration."},
+		{Name: "curl", Kind: "network_fetch", Severity: domain.SeverityMedium, Summary: "An MCP or AI-agent tool can fetch network resources, which increases exfiltration or tool-supply-chain risk when secrets are also reachable."},
+		{Name: "wget", Kind: "network_fetch", Severity: domain.SeverityMedium, Summary: "An MCP or AI-agent tool can fetch network resources, which increases exfiltration or tool-supply-chain risk when secrets are also reachable."},
+		{Name: "playwright", Kind: "browser_automation", Severity: domain.SeverityMedium, Summary: "An MCP or AI-agent tool can automate browsers from repository-defined configuration, which can reach authenticated sessions or internal services."},
+		{Name: "filesystem", Kind: "filesystem_access", Severity: domain.SeverityMedium, Summary: "An MCP or AI-agent tool exposes broad filesystem access from repository-defined configuration."},
+	} {
+		if agentLineMentionsCommand(lower, item.Name) {
+			capabilities = append(capabilities, item)
+		}
+	}
+	return capabilities
+}
+
+func agentLineMentionsCommand(line string, command string) bool {
+	if command == "" {
+		return false
+	}
+	lowerCommand := regexp.QuoteMeta(strings.ToLower(command))
+	pattern := regexp.MustCompile(`(?:^|[^a-z0-9_.-])` + lowerCommand + `(?:$|[^a-z0-9_.-])`)
+	return pattern.MatchString(line)
+}
+
+func sanitizeAgentSnippet(line string) string {
+	trimmed := strings.TrimSpace(line)
+	if len(trimmed) > 220 {
+		trimmed = trimmed[:220] + "..."
+	}
+	return trimmed
+}
+
+func isEnvContainerKey(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "env", "environment", "envs", "secrets":
+		return true
+	default:
+		return false
+	}
+}
+
+func firstAIAgentName(values map[string]any, trail []string) string {
+	for _, key := range []string{"name", "id", "server", "tool"} {
+		if value, ok := values[key].(string); ok && strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	if len(trail) > 0 {
+		return trail[len(trail)-1]
+	}
+	return ""
+}
+
+func normalizeYAMLValue(value any) any {
+	switch typed := value.(type) {
+	case map[any]any:
+		normalized := map[string]any{}
+		for key, child := range typed {
+			normalized[strings.TrimSpace(toString(key))] = normalizeYAMLValue(child)
+		}
+		return normalized
+	case map[string]any:
+		normalized := map[string]any{}
+		for key, child := range typed {
+			normalized[key] = normalizeYAMLValue(child)
+		}
+		return normalized
+	case []any:
+		normalized := make([]any, 0, len(typed))
+		for _, child := range typed {
+			normalized = append(normalized, normalizeYAMLValue(child))
+		}
+		return normalized
+	default:
+		return value
+	}
+}
+
+func toString(value any) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
+}
+
+func isAIAgentConfigPath(path string) bool {
+	lower := strings.ToLower(strings.TrimSpace(path))
+	if lower == "" {
+		return false
+	}
+	switch {
+	case lower == ".mcp.json",
+		lower == "mcp.json",
+		lower == ".cursor/mcp.json",
+		strings.HasPrefix(lower, ".cursor/rules/"),
+		strings.HasPrefix(lower, ".continue/"),
+		strings.HasPrefix(lower, ".codex/"),
+		strings.HasPrefix(lower, ".claude/"),
+		lower == ".github/copilot-instructions.md":
+		return true
+	case isKnownAIAgentStructuredConfig(lower):
+		return true
+	default:
+		return false
+	}
+}
+
+func isStructuredAgentConfig(path string) bool {
+	lower := strings.ToLower(strings.TrimSpace(path))
+	if lower == "" {
+		return false
+	}
+	return strings.HasSuffix(lower, ".json") || strings.HasSuffix(lower, ".yaml") || strings.HasSuffix(lower, ".yml")
+}
+
+func isKnownAIAgentStructuredConfig(path string) bool {
+	lower := strings.ToLower(strings.TrimSpace(path))
+	if lower == "" {
+		return false
+	}
+	base := strings.ToLower(filepathBase(path))
+	return strings.HasPrefix(base, ".mcp") || strings.HasPrefix(base, "mcp")
+}
+
+func isCommittedLocalAIAgentConfig(path string) bool {
+	lower := strings.ToLower(strings.TrimSpace(path))
+	return lower == ".mcp.json" ||
+		lower == ".cursor/mcp.json" ||
+		strings.HasPrefix(lower, ".continue/") ||
+		strings.HasPrefix(lower, ".codex/") ||
+		strings.HasPrefix(lower, ".claude/")
+}
+
+func filepathBase(path string) string {
+	path = strings.TrimRight(path, "/")
+	if idx := strings.LastIndex(path, "/"); idx >= 0 {
+		return path[idx+1:]
+	}
+	return path
+}
+
+func anyString(value any) string {
+	if typed, ok := value.(string); ok {
+		return strings.TrimSpace(typed)
+	}
+	return ""
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/internal/repoexposure/ai_agent_analyzer.go
+++ b/internal/repoexposure/ai_agent_analyzer.go
@@ -16,6 +16,7 @@ import (
 const aiAgentAnalyzerVersion = "2026.05"
 
 var envTokenPattern = regexp.MustCompile(`\b[A-Za-z][A-Za-z0-9_]{2,}\b`)
+var aiKnownAIAgentConfigNamePattern = regexp.MustCompile(`(?i)^\.?mcp(?:[-.][^/.]+)?\.(?:json|ya?ml)$`)
 
 type aiAgentCapability struct {
 	Name     string
@@ -149,7 +150,13 @@ func walkAIAgentValue(value any, trail []string, resolver *agentLineResolver, fi
 	switch typed := value.(type) {
 	case map[string]any:
 		name := firstAIAgentName(typed, trail)
-		for key, child := range typed {
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			child := typed[key]
 			lowerKey := strings.ToLower(strings.TrimSpace(key))
 			childTrail := append(append([]string(nil), trail...), key)
 			switch {
@@ -194,7 +201,7 @@ func appendAgentCapabilityFindings(resolver *agentLineResolver, findings *[]aiAg
 			Title:       "AI agent configuration exposes dangerous tool capability",
 			Summary:     capability.Summary,
 			Remediation: "Restrict the tool allowlist, isolate agent execution, remove broad shell/filesystem/network access, and gate deploy or cloud commands behind reviewed workflows.",
-			Line:        resolver.lineFor(capability.Name),
+			Line:        resolver.lineForContext(value, capability.Name),
 			// The capability name is part of the snippet so multiple risky tools
 			// in the same command (for example "aws ... && vercel ...") are not
 			// collapsed by snippet-aware deduplication.
@@ -261,6 +268,16 @@ func (r *agentLineResolver) lineFor(needle string) int {
 		}
 	}
 	return 1
+}
+
+func (r *agentLineResolver) lineForContext(needle string, fallback string) int {
+	if line := r.lineFor(needle); line != 1 {
+		return line
+	}
+	if fallback == "" {
+		return 1
+	}
+	return r.lineFor(fallback)
 }
 
 func appendAIAgentFinding(
@@ -491,8 +508,15 @@ func isKnownAIAgentStructuredConfig(path string) bool {
 	if lower == "" {
 		return false
 	}
+	if isAIAgentGitHubWorkflowPath(lower) {
+		return false
+	}
 	base := strings.ToLower(filepathBase(path))
-	return strings.HasPrefix(base, ".mcp") || strings.HasPrefix(base, "mcp")
+	return aiKnownAIAgentConfigNamePattern.MatchString(base)
+}
+
+func isAIAgentGitHubWorkflowPath(path string) bool {
+	return strings.HasPrefix(path, ".github/workflows/") || strings.Contains(path, "/.github/workflows/")
 }
 
 func isCommittedLocalAIAgentConfig(path string) bool {

--- a/internal/repoexposure/ai_agent_analyzer.go
+++ b/internal/repoexposure/ai_agent_analyzer.go
@@ -56,14 +56,10 @@ func detectAIAgentConfigFindings(repo string, commit string, path string, conten
 			continue
 		}
 
-		// If structured parsing succeeds, it already captures command/env evidence
-		// more precisely than plain text matching.
-		if len(structuredSurfaces) > 0 {
-			continue
-		}
-		// For non-structured AI surfaces (for example copilot instructions), only
-		// secret scanning is intended at this stage.
-		if !structuredPossible {
+		// For structured surfaces, rely on structured parsing for capability capture,
+		// but still scan plain text for env placeholders in command arguments.
+		skipLineCapabilities := len(structuredSurfaces) > 0
+		if !skipLineCapabilities && !structuredPossible {
 			continue
 		}
 
@@ -79,17 +75,19 @@ func detectAIAgentConfigFindings(repo string, commit string, path string, conten
 					"raw_secret_data":   false,
 				})
 		}
-		for _, capability := range dangerousAgentCapabilities(line) {
-			appendAIAgentFinding(&findings, seen, repo, commit, path, lineNumber, "ai_agent_dangerous_tool_capability", capability.Severity,
-				"AI agent configuration exposes dangerous tool capability",
-				capability.Summary,
-				"Restrict the tool allowlist, isolate agent execution, remove broad shell/filesystem/network access, and gate deploy or cloud commands behind reviewed workflows.",
-				sanitizeAgentSnippet(line), detectedAt, map[string]any{
+		if !skipLineCapabilities {
+			for _, capability := range dangerousAgentCapabilities(line) {
+				appendAIAgentFinding(&findings, seen, repo, commit, path, lineNumber, "ai_agent_dangerous_tool_capability", capability.Severity,
+					"AI agent configuration exposes dangerous tool capability",
+					capability.Summary,
+					"Restrict the tool allowlist, isolate agent execution, remove broad shell/filesystem/network access, and gate deploy or cloud commands behind reviewed workflows.",
+					sanitizeAgentSnippet(line), detectedAt, map[string]any{
 					"agent_config_path": path,
 					"capability":        capability.Kind,
 					"tool_name":         capability.Name,
 					"raw_secret_data":   false,
 				})
+			}
 		}
 	}
 
@@ -173,7 +171,7 @@ func walkAIAgentValue(value any, trail []string, resolver *agentLineResolver, fi
 						Title:       "AI agent configuration references sensitive environment variables",
 						Summary:     "An MCP or AI-agent configuration references credential-like environment variables that may be reachable by tool execution.",
 						Remediation: "Keep sensitive values in a secret manager, scope agent runtime environment variables to the smallest needed set, and avoid committing local agent configs.",
-						Line:        resolver.lineFor(envVars[0]),
+					Line:        resolver.lineForContext(envVars[0], envVars[0]),
 						Snippet:     "env: " + strings.Join(envVars, ", "),
 						Evidence: map[string]any{
 							"config_tree_path": strings.Join(childTrail, "."),
@@ -254,7 +252,7 @@ func newAgentLineResolver(lines []string) *agentLineResolver {
 func (r *agentLineResolver) lineFor(needle string) int {
 	needle = strings.ToLower(strings.TrimSpace(needle))
 	if needle == "" {
-		return 1
+		return -1
 	}
 	for index := r.cursor[needle]; index < len(r.lower); index++ {
 		if strings.Contains(r.lower[index], needle) {
@@ -267,17 +265,20 @@ func (r *agentLineResolver) lineFor(needle string) int {
 			return index + 1
 		}
 	}
-	return 1
+	return -1
 }
 
 func (r *agentLineResolver) lineForContext(needle string, fallback string) int {
-	if line := r.lineFor(needle); line != 1 {
+	if line := r.lineFor(needle); line != -1 {
 		return line
 	}
 	if fallback == "" {
 		return 1
 	}
-	return r.lineFor(fallback)
+	if line := r.lineFor(fallback); line != -1 {
+		return line
+	}
+	return 1
 }
 
 func appendAIAgentFinding(

--- a/internal/repoexposure/ai_agent_analyzer.go
+++ b/internal/repoexposure/ai_agent_analyzer.go
@@ -82,11 +82,11 @@ func detectAIAgentConfigFindings(repo string, commit string, path string, conten
 					capability.Summary,
 					"Restrict the tool allowlist, isolate agent execution, remove broad shell/filesystem/network access, and gate deploy or cloud commands behind reviewed workflows.",
 					sanitizeAgentSnippet(line), detectedAt, map[string]any{
-					"agent_config_path": path,
-					"capability":        capability.Kind,
-					"tool_name":         capability.Name,
-					"raw_secret_data":   false,
-				})
+						"agent_config_path": path,
+						"capability":        capability.Kind,
+						"tool_name":         capability.Name,
+						"raw_secret_data":   false,
+					})
 			}
 		}
 	}
@@ -171,7 +171,7 @@ func walkAIAgentValue(value any, trail []string, resolver *agentLineResolver, fi
 						Title:       "AI agent configuration references sensitive environment variables",
 						Summary:     "An MCP or AI-agent configuration references credential-like environment variables that may be reachable by tool execution.",
 						Remediation: "Keep sensitive values in a secret manager, scope agent runtime environment variables to the smallest needed set, and avoid committing local agent configs.",
-					Line:        resolver.lineForContext(envVars[0], envVars[0]),
+						Line:        resolver.lineForContext(envVars[0], envVars[0]),
 						Snippet:     "env: " + strings.Join(envVars, ", "),
 						Evidence: map[string]any{
 							"config_tree_path": strings.Join(childTrail, "."),

--- a/internal/repoexposure/ai_agent_analyzer_test.go
+++ b/internal/repoexposure/ai_agent_analyzer_test.go
@@ -106,6 +106,32 @@ func TestDetectAIAgentConfigFindingsSkipsLineHeuristicForCopilotSurfaces(t *test
 	}
 }
 
+func TestDetectMisconfigFindingsSkipsParserFindingsForAIAgentConfigSurfaces(t *testing.T) {
+	findings := detectMisconfigFindings(
+		"octo-org/octo-repo",
+		"HEAD",
+		".continue/config.yaml",
+		[]byte(`permissions:
+  contents: write-all
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - name: shell
+      securityContext:
+        privileged: true
+`),
+		time.Time{},
+	)
+
+	for _, finding := range findings {
+		switch finding.Detector {
+		case "workflow_write_all_permissions", "workflow_pull_request_target", "k8s_privileged_true":
+			t.Fatalf("expected AI-agent parser surface to skip YAML parser findings, got %+v", finding)
+		}
+	}
+}
+
 func TestAIAgentConfigPathSelection(t *testing.T) {
 	for _, path := range []string{
 		".mcp.json",

--- a/internal/repoexposure/ai_agent_analyzer_test.go
+++ b/internal/repoexposure/ai_agent_analyzer_test.go
@@ -1,6 +1,8 @@
 package repoexposure
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -149,6 +151,9 @@ func TestAIAgentConfigPathSelection(t *testing.T) {
 	if isAIAgentConfigPath("ops/deploy-agent.yaml") {
 		t.Fatal("expected non-agent filenames containing 'agent' to be skipped")
 	}
+	if isAIAgentConfigPath(".github/workflows/mcp.yml") {
+		t.Fatal("expected workflows path to be skipped from AI-agent scanning")
+	}
 	if isAIAgentConfigPath("docs/agent-notes.md") {
 		t.Fatal("expected non-agent markdown notes to be skipped")
 	}
@@ -279,4 +284,57 @@ func TestStructuredAIAgentFindingsUseSourceLineNumbers(t *testing.T) {
 	if envLines == 0 {
 		t.Fatalf("expected structured env reference finding, got %+v", findings)
 	}
+}
+
+func TestStructuredAIAgentFindingsUseDeterministicTraversalAndLineMapping(t *testing.T) {
+	content := []byte(`{
+  "mcpServers": {
+    "shellServer": {
+      "command": "bash",
+      "env": {
+        "CACHE": "true"
+      }
+    },
+    "deployServer": {
+      "command": "vercel",
+      "args": ["--token", "deploy"]
+    },
+    "networkServer": {
+      "command": "curl",
+      "args": ["https://example.com"]
+    },
+    "cloudServer": {
+      "command": "aws",
+      "args": ["s3", "ls"]
+    }
+  }
+}`)
+	pass1 := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".cursor/mcp.json", content, time.Time{})
+	pass2 := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".cursor/mcp.json", content, time.Time{})
+
+	sig1 := structuredCapabilitySignatures(pass1)
+	sig2 := structuredCapabilitySignatures(pass2)
+	sort.Strings(sig1)
+	sort.Strings(sig2)
+	if len(sig1) != len(sig2) {
+		t.Fatalf("expected deterministic signatures, got %d vs %d. pass1=%v pass2=%v", len(sig1), len(sig2), sig1, sig2)
+	}
+	for i := range sig1 {
+		if sig1[i] != sig2[i] {
+			t.Fatalf("expected deterministic ordering and line mapping, got %v vs %v", sig1, sig2)
+		}
+	}
+}
+
+func structuredCapabilitySignatures(findings []domain.Finding) []string {
+	signatures := make([]string, 0)
+	for _, finding := range findings {
+		if finding.Detector != "ai_agent_dangerous_tool_capability" {
+			continue
+		}
+		tool, _ := finding.Evidence["tool_name"].(string)
+		capability, _ := finding.Evidence["capability"].(string)
+		signatures = append(signatures, fmt.Sprintf("%s|%s|%d|%s", capability, tool, finding.LineNumber, finding.LineSnippet))
+	}
+	return signatures
 }

--- a/internal/repoexposure/ai_agent_analyzer_test.go
+++ b/internal/repoexposure/ai_agent_analyzer_test.go
@@ -326,6 +326,44 @@ func TestStructuredAIAgentFindingsUseDeterministicTraversalAndLineMapping(t *tes
 	}
 }
 
+func TestStructuredAIAgentLineHeuristicStillCatchesEnvRefsInArgs(t *testing.T) {
+	content := []byte(`{
+  "mcpServers": {
+    "shellServer": {
+      "command": "bash",
+      "args": [
+        "-lc",
+        "echo ${OPENAI_API_KEY} && echo ${GH_TOKEN}"
+      ]
+    }
+  }
+}`)
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".cursor/mcp.json", content, time.Time{})
+
+	found := false
+	foundVars := map[string]struct{}{}
+	for _, finding := range findings {
+		if finding.Detector == "ai_agent_sensitive_env_reference" {
+			found = true
+			vars, _ := finding.Evidence["env_variables"].([]string)
+			if len(vars) < 2 {
+				t.Fatalf("expected both env placeholders to be included, got %+v", finding)
+			}
+			for _, v := range vars {
+				foundVars[v] = struct{}{}
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected env reference finding for args placeholders, got %+v", findings)
+	}
+	for _, expected := range []string{"OPENAI_API_KEY", "GH_TOKEN"} {
+		if _, ok := foundVars[expected]; !ok {
+			t.Fatalf("expected env placeholder %q to be detected in args, got %+v", expected, findings)
+		}
+	}
+}
+
 func structuredCapabilitySignatures(findings []domain.Finding) []string {
 	signatures := make([]string, 0)
 	for _, finding := range findings {

--- a/internal/repoexposure/ai_agent_analyzer_test.go
+++ b/internal/repoexposure/ai_agent_analyzer_test.go
@@ -1,0 +1,256 @@
+package repoexposure
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+func TestDetectAIAgentConfigFindingsDetectsSecretsEnvAndDangerousTools(t *testing.T) {
+	content := []byte(`{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["@modelcontextprotocol/server-filesystem", "/"],
+      "env": {
+        "GITHUB_TOKEN": "${GITHUB_TOKEN}",
+        "OPENAI_API_KEY": "sk-proj-` + strings.Repeat("a", 40) + `"
+      }
+    },
+    "deploy": {
+      "command": "bash",
+      "args": ["-lc", "aws s3 ls && vercel deploy"]
+    }
+  }
+}`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".cursor/mcp.json", content, time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC))
+
+	seen := map[string]domain.Finding{}
+	for _, finding := range findings {
+		seen[finding.Detector] = finding
+	}
+	if secret := seen["openai_api_key"]; secret.ID == "" || secret.Type != domain.FindingSecretExposure {
+		t.Fatalf("expected redacted OpenAI secret finding, got %+v", findings)
+	} else if strings.Contains(secret.LineSnippet, "sk-proj-") || secret.LineSnippetRedacted == nil || !*secret.LineSnippetRedacted {
+		t.Fatalf("expected secret line to be redacted, got %+v", secret)
+	} else if rawStored, _ := secret.Evidence["raw_secret_stored"].(bool); rawStored {
+		t.Fatalf("raw secret data must not be stored: %+v", secret.Evidence)
+	} else if aiSurface, _ := secret.Evidence["ai_agent_surface"].(bool); !aiSurface {
+		t.Fatalf("expected AI-agent secret evidence marker, got %+v", secret.Evidence)
+	}
+
+	if env := seen["ai_agent_sensitive_env_reference"]; env.ID == "" || env.Type != domain.FindingRepoMisconfig {
+		t.Fatalf("expected sensitive environment reference finding, got %+v", findings)
+	} else if vars, _ := env.Evidence["env_variables"].([]string); len(vars) == 0 || vars[0] != "GITHUB_TOKEN" {
+		t.Fatalf("expected env variable evidence, got %+v", env.Evidence)
+	}
+
+	if capability := seen["ai_agent_dangerous_tool_capability"]; capability.ID == "" || capability.Severity != domain.SeverityHigh {
+		t.Fatalf("expected high-severity dangerous capability finding, got %+v", findings)
+	}
+
+	if local := seen["ai_agent_committed_local_config"]; local.ID == "" {
+		t.Fatalf("expected committed local agent config finding, got %+v", findings)
+	}
+}
+
+func TestDetectAIAgentConfigFindingsIgnoresBenignAgentTemplate(t *testing.T) {
+	content := []byte(`name: local-helper
+command: node
+env:
+  PATH: /usr/local/bin
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", "agent-template.yaml", content, time.Time{})
+	if len(findings) != 0 {
+		t.Fatalf("expected benign agent template to produce zero findings, got %+v", findings)
+	}
+}
+
+func TestDetectMisconfigFindingsSkipsGenericRulesForAIAgentConfigSurfaces(t *testing.T) {
+	findings := detectMisconfigFindings(
+		"octo-org/octo-repo",
+		"HEAD",
+		".github/copilot-instructions.md",
+		[]byte("permissions: write-all"),
+		time.Time{},
+	)
+
+	if len(findings) != 0 {
+		for _, finding := range findings {
+			if finding.Detector == "workflow_write_all_permissions" {
+				t.Fatalf("expected AI-agent-only surface to skip workflow-level generic misconfiguration rule, got %+v", finding)
+			}
+		}
+		t.Fatalf("expected no findings for plain Copilot instructions content, got %+v", findings)
+	}
+}
+
+func TestDetectAIAgentConfigFindingsSkipsLineHeuristicForCopilotSurfaces(t *testing.T) {
+	findings := detectMisconfigFindings(
+		"octo-org/octo-repo",
+		"HEAD",
+		".github/copilot-instructions.md",
+		[]byte("Here is a suggestion: run bash and kubectl for diagnostics when debugging."),
+		time.Time{},
+	)
+
+	for _, finding := range findings {
+		switch finding.Detector {
+		case "ai_agent_dangerous_tool_capability", "ai_agent_sensitive_env_reference":
+			t.Fatalf("expected non-structured AI-agent surfaces to skip line heuristics, got %+v", finding)
+		}
+	}
+}
+
+func TestAIAgentConfigPathSelection(t *testing.T) {
+	for _, path := range []string{
+		".mcp.json",
+		".cursor/mcp.json",
+		".continue/config.yaml",
+		".github/copilot-instructions.md",
+		"mcp.config.yaml",
+		"mcp-server.yml",
+	} {
+		if !isAIAgentConfigPath(path) {
+			t.Fatalf("expected %s to be detected as AI-agent config surface", path)
+		}
+	}
+
+	if isAIAgentConfigPath("ops/deploy-agent.yaml") {
+		t.Fatal("expected non-agent filenames containing 'agent' to be skipped")
+	}
+	if isAIAgentConfigPath("docs/agent-notes.md") {
+		t.Fatal("expected non-agent markdown notes to be skipped")
+	}
+}
+
+func TestSensitiveEnvReferencesIgnoresFreeText(t *testing.T) {
+	found := sensitiveEnvReferences("The token is revoked and the secret is updated.")
+	if len(found) != 0 {
+		t.Fatalf("expected free text not to be treated as env variable references, got %#v", found)
+	}
+
+	found = sensitiveEnvReferences("Use ${github_token} and ${openai_api_key} in local config")
+	if len(found) != 2 || found[0] != "GITHUB_TOKEN" || found[1] != "OPENAI_API_KEY" {
+		t.Fatalf("expected lowercase env placeholders to still be recognized, got %#v", found)
+	}
+}
+
+func TestDetectAIAgentConfigFindingsHonorsSecretAllowlistPolicy(t *testing.T) {
+	content := []byte(`{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "env": {
+        "OPENAI_API_KEY": "sk-proj-` + strings.Repeat("a", 40) + `"
+      }
+    }
+  }
+}`)
+	detectedAt := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+
+	baseline := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".cursor/mcp.json", content, detectedAt)
+	var fingerprint string
+	for _, finding := range baseline {
+		if finding.Type == domain.FindingSecretExposure {
+			fingerprint, _ = finding.Evidence["secret_fingerprint"].(string)
+			break
+		}
+	}
+	if fingerprint == "" {
+		t.Fatalf("expected a secret fingerprint in baseline findings, got %+v", baseline)
+	}
+
+	allowlisted := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".cursor/mcp.json", content, detectedAt,
+		withSecretFindingPolicy(secretFindingPolicy{AllowlistedFingerprints: map[string]struct{}{fingerprint: {}}}))
+
+	var secret domain.Finding
+	for _, finding := range allowlisted {
+		if finding.Type == domain.FindingSecretExposure {
+			secret = finding
+			break
+		}
+	}
+	if secret.ID == "" {
+		t.Fatalf("expected a secret finding when allowlist policy is applied, got %+v", allowlisted)
+	}
+	if got := secret.Evidence["confidence_state"]; got != secretClassificationAllowlisted {
+		t.Fatalf("expected allowlisted classification on AI-agent secret path, got %v in %+v", got, secret.Evidence)
+	}
+	if got, _ := secret.Evidence["secret_allowlisted"].(bool); !got {
+		t.Fatalf("expected allowlisted evidence flag on AI-agent secret path, got %+v", secret.Evidence)
+	}
+}
+
+func TestAppendAIAgentFindingPreservesMultipleCommandFindingsFromConfigTree(t *testing.T) {
+	content := []byte(`{
+  "mcpServers": {
+    "shellServer": {
+      "command": "bash"
+    },
+    "networkServer": {
+      "command": "curl"
+    }
+  }
+}`)
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".cursor/mcp.json", content, time.Time{})
+	seen := map[string]int{}
+	for _, finding := range findings {
+		seen[finding.Detector]++
+	}
+
+	if seen["ai_agent_dangerous_tool_capability"] < 2 {
+		t.Fatalf("expected at least two AI dangerous capability findings, got %+v", seen)
+	}
+	if seen["ai_agent_committed_local_config"] != 1 {
+		t.Fatalf("expected local-config finding once, got %+v", seen)
+	}
+}
+
+func TestStructuredAIAgentFindingsUseSourceLineNumbers(t *testing.T) {
+	content := []byte(`{
+  "mcpServers": {
+    "shellServer": {
+      "command": "bash"
+    },
+    "cloudServer": {
+      "args": ["-lc", "aws s3 ls && vercel deploy"]
+    },
+    "browserServer": {
+      "env": {
+        "OPENAI_API_KEY": "${OPENAI_API_KEY}",
+        "AZURE_CLIENT_SECRET": "${AZURE_CLIENT_SECRET}"
+      }
+    }
+  }
+}`)
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".cursor/mcp.json", content, time.Time{})
+
+	commandLines := map[string]int{}
+	envLines := 0
+	for _, finding := range findings {
+		if finding.Detector == "ai_agent_dangerous_tool_capability" {
+			tool, _ := finding.Evidence["tool_name"].(string)
+			commandLines[tool] = finding.LineNumber
+			if finding.LineNumber == 1 {
+				t.Fatalf("expected structured command finding to avoid defaulting to line 1, got %+v", finding)
+			}
+		}
+		if finding.Detector == "ai_agent_sensitive_env_reference" {
+			envLines = finding.LineNumber
+			if finding.LineNumber == 1 {
+				t.Fatalf("expected structured env finding to avoid defaulting to line 1, got %+v", finding)
+			}
+		}
+	}
+	if len(commandLines) < 2 {
+		t.Fatalf("expected multiple structured capability findings from one config file, got %+v", findings)
+	}
+	if envLines == 0 {
+		t.Fatalf("expected structured env reference finding, got %+v", findings)
+	}
+}

--- a/internal/repoexposure/rules.go
+++ b/internal/repoexposure/rules.go
@@ -889,12 +889,14 @@ func detectMisconfigFindings(repo string, commit string, path string, content []
 		revision = "HEAD"
 	}
 
+	if isAIAgentConfigPath(path) {
+		findings = append(findings, detectAIAgentConfigFindings(repo, revision, path, content, seen, detectedAt, options...)...)
+		return findings
+	}
+
 	parserFindings, parserUsed := detectMisconfigFindingsWithParsers(repo, revision, path, content, seen, detectedAt)
 	findings = append(findings, parserFindings...)
 	findings = append(findings, detectAIAgentConfigFindings(repo, revision, path, content, seen, detectedAt, options...)...)
-	if isAIAgentConfigPath(path) {
-		return findings
-	}
 
 	for _, rule := range lineMisconfigRules {
 		if parserUsed && shouldSkipLineRuleByParser(rule.ID, path) {

--- a/internal/repoexposure/rules.go
+++ b/internal/repoexposure/rules.go
@@ -880,7 +880,7 @@ func entropy(value string) float64 {
 	return entropy
 }
 
-func detectMisconfigFindings(repo string, commit string, path string, content []byte, detectedAt time.Time) []domain.Finding {
+func detectMisconfigFindings(repo string, commit string, path string, content []byte, detectedAt time.Time, options ...secretFindingOption) []domain.Finding {
 	data := string(content)
 	findings := []domain.Finding{}
 	seen := map[string]struct{}{}
@@ -891,6 +891,10 @@ func detectMisconfigFindings(repo string, commit string, path string, content []
 
 	parserFindings, parserUsed := detectMisconfigFindingsWithParsers(repo, revision, path, content, seen, detectedAt)
 	findings = append(findings, parserFindings...)
+	findings = append(findings, detectAIAgentConfigFindings(repo, revision, path, content, seen, detectedAt, options...)...)
+	if isAIAgentConfigPath(path) {
+		return findings
+	}
 
 	for _, rule := range lineMisconfigRules {
 		if parserUsed && shouldSkipLineRuleByParser(rule.ID, path) {
@@ -1035,7 +1039,7 @@ func appendMisconfigFinding(
 	detectedAt time.Time,
 	extraEvidence map[string]any,
 ) {
-	key := fmt.Sprintf("%s:%d:%s", path, line, ruleID)
+	key := fmt.Sprintf("%s:%d:%s:%q", path, line, ruleID, strings.TrimSpace(snippet))
 	if _, exists := seen[key]; exists {
 		return
 	}
@@ -1860,6 +1864,9 @@ func shouldInspectMisconfiguration(path string) bool {
 	}
 	base := strings.ToLower(filepath.Base(lower))
 	if strings.HasPrefix(lower, ".github/workflows/") {
+		return true
+	}
+	if isAIAgentConfigPath(lower) {
 		return true
 	}
 	if base == "dockerfile" || strings.HasPrefix(base, "dockerfile.") {

--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -276,7 +276,7 @@ func (s *Scanner) ScanRepositoryWithOptions(ctx context.Context, target string, 
 				continue
 			}
 			filesScanned++
-			for _, finding := range detectMisconfigFindings(location.Display, headCommit, filePath, content, started) {
+			for _, finding := range detectMisconfigFindings(location.Display, headCommit, filePath, content, started, secretOptions...) {
 				if _, exists := seen[finding.ID]; exists {
 					continue
 				}


### PR DESCRIPTION
Fixes #1330

## Summary
- Added MCP and AI-agent config analysis for committed agent surfaces such as `.mcp.json`, `.cursor/mcp.json`, `.continue/*`, `.codex/*`, `.claude/*`, Copilot instructions, and low-risk agent config filenames.
- Emit redacted secret findings for provider-shaped secrets inside agent config while marking them with `ai_agent_surface: true` and preserving the existing no-raw-secret storage guarantees.
- Added non-secret posture findings for sensitive environment-variable references, dangerous tool capabilities, and committed local agent configuration.
- Added remediation guidance and docs so preview output explains rotation, runtime secret scoping, sandboxing, tool allowlists, and local-config cleanup.

## Validation
- `go test ./internal/repoexposure ./internal/findings/standards`
- `go test ./... -coverprofile=coverage.out`
- `go tool cover -func=coverage.out` (total: 80.2%)
- pre-commit hooks: merge conflict check, EOF fix, trailing whitespace, gofmt, Vercel artifact hygiene
- pre-push hooks: merge conflict check, EOF fix, trailing whitespace, gofmt, go vet, local env token hygiene, Vercel artifact hygiene

## AI Assistance
AI-assisted: Yes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a static MCP/AI‑agent config analyzer that flags redacted provider‑shaped secrets, sensitive env references, dangerous tool capabilities, and committed local configs. Integrates into repo misconfig scanning with deterministic line mapping, snippet‑aware de‑dupe, and early exits on AI‑agent surfaces; fixes #1330.

- **New Features**
  - Parse JSON/YAML agent configs; emit redacted secret findings with `ai_agent_surface: true`, `raw_secret_stored: false`, `detector_category: ai_agent_secret`; honor secret fingerprint allowlists; include a detector version.
  - Detect dangerous tools (shell, cloud/cluster/deploy CLIs, network fetch, browser, filesystem) and sensitive env references; map findings to source lines; snippet-based de‑dupe yields distinct findings for multi‑tool commands; recognize common MCP/agent filenames; exclude `.github/workflows/*`.
  - Add remediation guidance and docs for `ai_agent_sensitive_env_reference`, `ai_agent_dangerous_tool_capability`, and `ai_agent_committed_local_config`; wire into remediation routing.

- **Bug Fixes**
  - Return early on AI‑agent surfaces to bypass generic YAML/K8s/workflow and line rules; skip parser rules on these files; propagate secret‑policy options into the agent analyzer.
  - Keep env‑reference findings for structured configs (including placeholders in command args).
  - Stabilize capability attribution with word‑boundary command matching and a deterministic line resolver; disable capability/env heuristics on non‑structured surfaces (e.g., Copilot instructions) so only redacted secrets are reported.

<sup>Written for commit 90510a3919a169c4d4ce4cc19bce35cbb7743d54. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1336?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

