### PR TITLE
Detect AI-agent workflow prompt-injection paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Added GitHub Actions AI-agent prompt-injection detection for workflows that
+  feed untrusted PR, issue, review, comment, workflow_run, or repository
+  prompt-file content into LLM/agent steps with repository write, secret, OIDC,
+  cloud, release, or mutation capabilities.
 - Added approval-gated remediation PR publishing for repository findings across
   the API, CLI, and app, so deterministic GitHub exposure fixes can open a
   branch and pull request only after explicit operator approval and a

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -247,6 +247,10 @@ The scanner uses a versioned secret detector registry for commit-history secret 
     - broad OIDC credential-minting context
     - cache keys or restore paths influenced by untrusted PR context
     - artifact or release publishing reachable from untrusted inputs
+    - AI-agent prompt-injection paths where untrusted PR, issue, review,
+      comment, workflow_run, or repository prompt-file content reaches an
+      LLM/agent step with write, secret, OIDC, cloud, release, or repository
+      mutation capability
     - self-hosted runner jobs reachable from untrusted events
     - runner placement that cannot be statically audited (expression, matrix, or broad labels)
   - Kubernetes `privileged: true`
@@ -303,8 +307,16 @@ write permissions is emitted as a critical workflow attack path.
 | `workflow_oidc_broad_trust` | `id-token: write` is available from untrusted events, `workflow_run`, or broad all-branch push deploys. | High | Restrict cloud trust policies to protected branches and environments, and avoid OIDC on untrusted workflow paths. |
 | `workflow_cache_poisoning` | Cache keys or restore paths are influenced by PR-controlled context, or broad restore keys are used on untrusted events. | Medium | Separate untrusted PR caches from trusted build caches and avoid broad restore keys in privileged jobs. |
 | `workflow_artifact_poisoning` | PR or `workflow_run` context can upload artifacts or release assets consumed later. | Medium to high | Keep untrusted artifacts isolated, verify provenance before reuse, and publish releases only from protected contexts. |
+| `workflow_ai_agent_prompt_injection` | An AI-agent or LLM workflow step consumes untrusted PR/issue/review/comment/workflow_run text or repository prompt files. | Medium to critical | Keep untrusted prompt processing read-only, remove secrets/write scopes from agent jobs, and gate autofix or repository mutation behind review. |
 | `workflow_self_hosted_runner` | Self-hosted runner usage has no obvious org-level controls and can route untrusted jobs to shared infrastructure. | Medium | Enforce repository-level self-hosted runner restrictions, dedicated groups, and minimal permissions before enabling untrusted pull-request execution. |
 | `workflow_self_hosted_runner_unresolved` | Self-hosted runner-group visibility is permission-limited or unavailable, leaving posture state uncertain. | Medium | Grant the GitHub App read access to org runner groups or route high-risk repos to managed GitHub-hosted runners. |
+
+`workflow_ai_agent_prompt_injection` complements
+`workflow_shell_injection_user_context`. Shell-injection findings cover direct
+interpolation into shell commands. AI-agent prompt-injection findings cover
+cases where the shell may be quoted safely, but untrusted text still becomes
+instructions for an agent that can read files, call tools, create PRs, comment,
+push branches, mint OIDC tokens, use secrets, or trigger cloud/deploy behavior.
 
 To add a new secret detector, add a new entry to the registry with a unique ID, a new version if needed for compatibility, and test fixtures.
 

--- a/internal/findings/standards/repo_remediation.go
+++ b/internal/findings/standards/repo_remediation.go
@@ -139,6 +139,8 @@ func repoMisconfigRemediation(finding domain.Finding) (RepoExposureRemediation, 
 		return workflowCachePoisoningRemediation(finding, detector), true
 	case "workflow_artifact_poisoning":
 		return workflowArtifactPoisoningRemediation(finding, detector), true
+	case "workflow_ai_agent_prompt_injection":
+		return workflowAIAgentPromptInjectionRemediation(finding, detector), true
 	case "workflow_self_hosted_runner":
 		return workflowSelfHostedRunnerRemediation(finding, detector), true
 	case "workflow_self_hosted_runner_unresolved":
@@ -390,6 +392,28 @@ func workflowArtifactPoisoningRemediation(finding domain.Finding, detector strin
 			"Verify release jobs require protected branch or environment context.",
 		},
 		"artifact remediation depends on producer and consumer workflow pairing")
+}
+
+func workflowAIAgentPromptInjectionRemediation(finding domain.Finding, detector string) RepoExposureRemediation {
+	return guidanceRepoRemediation(finding, detector,
+		"Separate untrusted prompt input from privileged AI-agent workflow actions.",
+		"An AI-agent or LLM workflow step consumes untrusted repository text or prompt files in a path that may also hold write permissions, secrets, OIDC, cloud, release, or repository-write behavior.",
+		[]string{
+			"Run AI prompt processing from untrusted PR, issue, review, or comment text in a read-only job with no secrets and no repository write scopes.",
+			"Split autofix, branch push, PR creation, release, deployment, and cloud steps into a reviewed follow-up workflow or environment approval gate.",
+			"Treat repository prompt files from pull requests as untrusted input unless they come from a protected branch.",
+			"Pin AI actions and log prompt provenance without storing sensitive prompt context or secrets.",
+		},
+		[]string{
+			"Prompt injection is distinct from shell injection; quoted shell arguments can still steer an agent that has tools or credentials.",
+			"Do not pass secrets, OIDC credentials, deployment tokens, or write-capable GitHub tokens to an agent that consumes untrusted prompt content.",
+		},
+		[]string{
+			"Run a fork PR or issue-comment test and confirm the AI job receives read-only permissions and no secrets.",
+			"Verify any write-capable follow-up workflow requires maintainer approval or protected-branch/environment gates.",
+			"Inspect workflow logs to confirm prompt source, action ref, and permissions are visible for review.",
+		},
+		"AI-agent prompt paths need workflow-owner review before a safe generated source patch can be published")
 }
 
 func workflowSelfHostedRunnerRemediation(finding domain.Finding, detector string) RepoExposureRemediation {

--- a/internal/findings/standards/repo_remediation_test.go
+++ b/internal/findings/standards/repo_remediation_test.go
@@ -24,6 +24,7 @@ func TestSuggestRepoExposureRemediationSupportsMisconfigDetectors(t *testing.T) 
 		{"workflow_oidc_broad_trust", false, false},
 		{"workflow_cache_poisoning", false, false},
 		{"workflow_artifact_poisoning", false, false},
+		{"workflow_ai_agent_prompt_injection", false, false},
 		{"workflow_self_hosted_runner", false, false},
 		{"workflow_self_hosted_runner_unresolved", false, false},
 		{"k8s_privileged_true", true, true},

--- a/internal/repoexposure/workflow_analyzer.go
+++ b/internal/repoexposure/workflow_analyzer.go
@@ -16,6 +16,8 @@ const workflowAnalyzerVersion = "2026.05"
 
 var gitHubActionCommitRefPattern = regexp.MustCompile(`^[a-f0-9]{40}$`)
 var workflowSecretsExpressionPattern = regexp.MustCompile(`\$\{\{\s*secrets\s*(?:\.|\[)`)
+var workflowEnvReferencePattern = regexp.MustCompile(`(?i)env\.([a-z_][a-z0-9_-]*)`)
+var workflowEnvBracketReferencePattern = regexp.MustCompile(`(?i)env\[\s*['"]([a-z_][a-z0-9_-]*)['"]\s*\]`)
 var workflowExpressionPattern = regexp.MustCompile(`\$\{\{.*\}\}`)
 var workflowMatrixReferencePattern = regexp.MustCompile(`\$\{\{\s*matrix\.([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*)\s*\}\}`)
 var workflowMatrixBracketReferencePattern = regexp.MustCompile(`\$\{\{\s*matrix((?:\[\s*['\"][a-zA-Z_][a-zA-Z0-9_-]*['\"]\s*\])+)\s*\}\}`)
@@ -106,6 +108,7 @@ func analyzeGitHubWorkflowFindings(repo string, commit string, path string, ast 
 	}
 
 	eventNames := sortedWorkflowEventNames(workflow.Events)
+	pullRequest := workflowHasEvent(workflow, "pull_request")
 	pullRequestTarget := workflowHasEvent(workflow, "pull_request_target")
 	workflowRun := workflowHasEvent(workflow, "workflow_run")
 	untrustedEvent := workflowHasUntrustedEvent(workflow)
@@ -124,6 +127,15 @@ func analyzeGitHubWorkflowFindings(repo string, commit string, path string, ast 
 
 	for _, job := range workflow.Jobs {
 		effectivePermissions := workflow.effectivePermissions(job)
+		// Repository file contents (and therefore repository prompt files) are
+		// only attacker-controlled after a workflow has checked out attacker
+		// content. pull_request checkouts receive PR-controlled repository
+		// files, while pull_request_target starts from trusted base code and
+		// becomes tainted only after an earlier step checks out the untrusted PR
+		// head. Issue, comment, review, and workflow_run triggers expose
+		// untrusted event text but not attacker-authored repository files.
+		repoFilesUntrusted := false
+		pullRequestTargetRepoFilesUntrusted := false
 		if job.Permissions.hasBroadGitHubTokenWrite() {
 			appendWorkflowFinding(&findings, seen, repo, commit, path, job.Permissions.Line, "workflow_broad_token_permissions", domain.SeverityHigh,
 				"GitHub workflow grants broad token write permissions",
@@ -230,7 +242,8 @@ func analyzeGitHubWorkflowFindings(repo string, commit string, path string, ast 
 
 		for _, step := range job.Steps {
 			action := normalizeWorkflowUses(step.Uses)
-			if pullRequestTarget && step.checkoutUsesUntrustedHead() {
+			untrustedCheckout := pullRequestTarget && step.checkoutUsesUntrustedHead()
+			if untrustedCheckout {
 				appendWorkflowFinding(&findings, seen, repo, commit, path, stepLine(step), "workflow_pull_request_target_untrusted_checkout", domain.SeverityCritical,
 					"pull_request_target checks out untrusted PR code",
 					"A pull_request_target job checks out the contributor-controlled PR head, which can run attacker code in a privileged workflow context.",
@@ -284,6 +297,41 @@ func analyzeGitHubWorkflowFindings(repo string, commit string, path string, ast 
 					firstNonEmptyWorkflowString(step.Uses, truncateWorkflowSnippet(step.Run)), detectedAt, workflowEvidence(eventNames, job.ID, step.Index, action, map[string]any{
 						"publishes_release": step.usesReleaseBehavior(),
 					}))
+			}
+
+			inheritedEnv := workflowMergedEnv(workflow.Env, job.Env, step.Env)
+			if signal, promptTokens := step.aiAgentPromptInjectionSignal(untrustedEvent || workflowRun, repoFilesUntrusted, inheritedEnv); signal != "" && len(promptTokens) > 0 {
+				capabilities := workflowAIAgentPrivilegedCapabilities(job, step, effectivePermissions, jobSecrets)
+				if pullRequestTarget && effectivePermissions.implicitGitHubTokenWritePossible() && workflowPromptTokensReachPullRequestTarget(promptTokens, pullRequestTargetRepoFilesUntrusted) {
+					capabilities = append(capabilities, "github_token_write_default")
+				}
+				capabilities = uniqueSortedWorkflowTokens(capabilities)
+				severity := domain.SeverityMedium
+				if len(capabilities) > 0 {
+					severity = domain.SeverityHigh
+				}
+				if pullRequestTarget && len(capabilities) > 0 && workflowPromptTokensReachPullRequestTarget(promptTokens, pullRequestTargetRepoFilesUntrusted) {
+					severity = domain.SeverityCritical
+				}
+				appendWorkflowFinding(&findings, seen, repo, commit, path, stepLine(step), "workflow_ai_agent_prompt_injection", severity,
+					"AI-agent workflow consumes untrusted prompt input",
+					"An AI-agent or LLM workflow step consumes PR, issue, review, comment, workflow_run, or repository prompt-file input that can influence privileged repository automation.",
+					"Keep AI-agent prompts on trusted events, avoid passing untrusted repository text directly to write-capable agents, and gate autofix or PR-writing behavior behind review.",
+					firstNonEmptyWorkflowString(step.Uses, truncateWorkflowSnippet(step.Run), signal), detectedAt, workflowEvidence(eventNames, job.ID, step.Index, action, map[string]any{
+						"ai_agent_signal":          signal,
+						"untrusted_prompt_context": promptTokens,
+						"permission_summary":       effectivePermissions.summary(),
+						"privileged_capabilities":  capabilities,
+						"references_secrets":       jobSecrets,
+					}))
+			}
+
+			if pullRequest && step.checksOutRepositoryContents() {
+				repoFilesUntrusted = true
+			}
+			if untrustedCheckout {
+				repoFilesUntrusted = true
+				pullRequestTargetRepoFilesUntrusted = true
 			}
 		}
 	}
@@ -717,6 +765,10 @@ func (permissions workflowPermissions) hasBroadGitHubTokenWrite() bool {
 	return false
 }
 
+func (permissions workflowPermissions) implicitGitHubTokenWritePossible() bool {
+	return !permissions.configured()
+}
+
 func (permissions workflowPermissions) idTokenWrite() bool {
 	if permissions.WriteAll {
 		return true
@@ -850,7 +902,7 @@ func (job githubWorkflowJob) selfHostedRiskAmplifiers(workflowEnv map[string]str
 }
 
 func (step githubWorkflowStep) checkoutUsesUntrustedHead() bool {
-	if !workflowActionMatches(normalizeWorkflowUses(step.Uses), "actions/checkout") {
+	if !step.checksOutRepositoryContents() {
 		return false
 	}
 	for _, key := range []string{"ref", "repository"} {
@@ -860,6 +912,10 @@ func (step githubWorkflowStep) checkoutUsesUntrustedHead() bool {
 		}
 	}
 	return false
+}
+
+func (step githubWorkflowStep) checksOutRepositoryContents() bool {
+	return workflowActionMatches(normalizeWorkflowUses(step.Uses), "actions/checkout")
 }
 
 func (step githubWorkflowStep) untrustedExpressionTokens(untrustedEvent bool) []string {
@@ -901,6 +957,189 @@ func (step githubWorkflowStep) usesReleaseBehavior() bool {
 		workflowActionMatches(action, "actions/upload-release-asset") ||
 		strings.Contains(lowerRun, "gh release upload") ||
 		strings.Contains(lowerRun, "gh release create")
+}
+
+func (step githubWorkflowStep) aiAgentPromptInjectionSignal(untrustedEvent bool, repoFilesUntrusted bool, inheritedEnv map[string]string) (string, []string) {
+	if !untrustedEvent {
+		return "", nil
+	}
+	signal := step.aiAgentSignal()
+	if signal == "" {
+		return "", nil
+	}
+	// Resolve env.* indirection from inherited workflow/job/step scopes so
+	// untrusted text routed through env (for example, a job env value of
+	// ${{ github.event.pull_request.body }} referenced via ${{ env.PROMPT }})
+	// still taints the prompt context.
+	context := workflowResolveEnvReferences(step.promptContext(), inheritedEnv)
+	tokens := workflowUserControlledTokens(context)
+	if workflowStringReferencesWorkflowRun(context) {
+		tokens = append(tokens, "github.event.workflow_run")
+	}
+	if repoFilesUntrusted && workflowReferencesRepositoryPromptFile(context) {
+		tokens = append(tokens, "repository_prompt_file")
+	}
+	tokens = uniqueSortedWorkflowTokens(tokens)
+	if len(tokens) == 0 {
+		return "", nil
+	}
+	return signal, tokens
+}
+
+func (step githubWorkflowStep) aiAgentSignal() string {
+	action := strings.ToLower(normalizeWorkflowUses(step.Uses))
+	if action != "" {
+		for _, token := range []string{
+			"anthropic", "claude", "openai", "codex", "copilot", "gemini", "aider", "continue-dev", "cursor", "llm",
+		} {
+			if strings.Contains(action, token) {
+				return "action:" + action
+			}
+		}
+	}
+
+	text := strings.ToLower(step.Name + "\n" + step.Run + "\n" + stringMapValues(step.With) + "\n" + stringMapValues(step.Env))
+	for _, token := range []string{
+		"anthropic", "claude", "openai", "codex", "copilot", "gemini", "aider", "continue-dev", "cursor", "llm",
+		"chat completions", "responses api", "prompt-file", "prompt_file",
+	} {
+		if strings.Contains(text, token) {
+			return "step:" + token
+		}
+	}
+	return ""
+}
+
+func (step githubWorkflowStep) promptContext() string {
+	return step.Run + "\n" + stringMapValues(step.With) + "\n" + stringMapValues(step.Env)
+}
+
+// workflowMergedEnv combines env scopes in precedence order (later scopes win),
+// used to resolve env.* references that a step inherits from its job or workflow.
+func workflowMergedEnv(scopes ...map[string]string) map[string]string {
+	merged := map[string]string{}
+	for _, scope := range scopes {
+		for key, value := range scope {
+			merged[key] = value
+		}
+	}
+	return merged
+}
+
+// workflowResolveEnvReferences appends the values of any env.* references found
+// in context (transitively, guarding against cycles) so taint analysis can see
+// untrusted sources that reach a step only through inherited env indirection.
+func workflowResolveEnvReferences(context string, env map[string]string) string {
+	if len(env) == 0 {
+		return context
+	}
+	resolved := strings.Builder{}
+	resolved.WriteString(context)
+	visited := map[string]struct{}{}
+	queue := workflowEnvReferenceNames(context)
+	for len(queue) > 0 {
+		name := queue[0]
+		queue = queue[1:]
+		if _, seen := visited[name]; seen {
+			continue
+		}
+		visited[name] = struct{}{}
+		value, ok := env[name]
+		if !ok {
+			continue
+		}
+		resolved.WriteString("\n")
+		resolved.WriteString(value)
+		queue = append(queue, workflowEnvReferenceNames(value)...)
+	}
+	return resolved.String()
+}
+
+func workflowEnvReferenceNames(value string) []string {
+	names := []string{}
+	for _, pattern := range []*regexp.Regexp{workflowEnvReferencePattern, workflowEnvBracketReferencePattern} {
+		for _, match := range pattern.FindAllStringSubmatch(value, -1) {
+			names = append(names, strings.ToLower(match[1]))
+		}
+	}
+	return names
+}
+
+func workflowReferencesRepositoryPromptFile(context string) bool {
+	text := strings.ToLower(context)
+	if !strings.Contains(text, "prompt") && !strings.Contains(text, "instruction") {
+		return false
+	}
+	for _, suffix := range []string{".md", ".txt", ".yaml", ".yml", ".json"} {
+		if strings.Contains(text, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func workflowPromptTokensReachPullRequestTarget(tokens []string, repoFilesUntrusted bool) bool {
+	for _, token := range tokens {
+		if token == "repository_prompt_file" {
+			if repoFilesUntrusted {
+				return true
+			}
+			continue
+		}
+		if workflowPromptTokenReachableFromPullRequestTarget(token) {
+			return true
+		}
+	}
+	return false
+}
+
+func workflowPromptTokenReachableFromPullRequestTarget(token string) bool {
+	token = strings.TrimSpace(strings.ToLower(token))
+	return token == "github.head_ref" || strings.HasPrefix(token, "github.event.pull_request.")
+}
+
+func workflowAIAgentPrivilegedCapabilities(job githubWorkflowJob, step githubWorkflowStep, permissions workflowPermissions, jobSecrets bool) []string {
+	capabilities := []string{}
+	if permissions.hasBroadGitHubTokenWrite() {
+		capabilities = append(capabilities, "github_token_write")
+	}
+	if permissions.idTokenWrite() {
+		capabilities = append(capabilities, "oidc_token_write")
+	}
+	if jobSecrets {
+		capabilities = append(capabilities, "secrets")
+	}
+	if job.usesCloudAuthAction() || step.usesCloudOrDeployCommand() {
+		capabilities = append(capabilities, "cloud_or_deploy")
+	}
+	if step.usesReleaseBehavior() {
+		capabilities = append(capabilities, "release_publish")
+	}
+	if step.usesRepositoryWriteCommand() {
+		capabilities = append(capabilities, "repository_write")
+	}
+	return uniqueSortedWorkflowTokens(capabilities)
+}
+
+func (step githubWorkflowStep) usesCloudOrDeployCommand() bool {
+	text := strings.ToLower(step.Run + "\n" + step.Uses)
+	for _, token := range []string{"aws ", "gcloud ", "az ", "kubectl ", "vercel ", "flyctl ", "terraform apply", "pulumi up"} {
+		if strings.Contains(text, token) {
+			return true
+		}
+	}
+	return false
+}
+
+func (step githubWorkflowStep) usesRepositoryWriteCommand() bool {
+	text := strings.ToLower(step.Run)
+	for _, token := range []string{"gh pr create", "gh pr comment", "gh pr merge", "gh issue comment", "git push", "create-pull-request"} {
+		if strings.Contains(text, token) {
+			return true
+		}
+	}
+	action := strings.ToLower(normalizeWorkflowUses(step.Uses))
+	return strings.Contains(action, "create-pull-request") || strings.Contains(action, "peter-evans/create-pull-request")
 }
 
 func workflowEvidence(events []string, job string, stepIndex int, action string, extra map[string]any) map[string]any {
@@ -1139,6 +1378,10 @@ func workflowStringReferencesSecrets(value string) bool {
 	return workflowSecretsExpressionPattern.MatchString(strings.ToLower(value))
 }
 
+func workflowStringReferencesWorkflowRun(value string) bool {
+	return strings.Contains(strings.ToLower(value), "github.event.workflow_run")
+}
+
 func workflowStringMapReferencesSecrets(values map[string]string) bool {
 	for _, value := range values {
 		if workflowStringReferencesSecrets(value) {
@@ -1191,12 +1434,44 @@ func workflowUserControlledTokens(value string) []string {
 		"github.event.issue.body",
 		"github.event.review.body",
 		"github.event.comment.body",
+		"github.event.pull_request_review.body",
+		"github.event.pull_request_review_comment.body",
 	} {
 		if strings.Contains(lower, token) {
 			tokens = append(tokens, token)
 		}
 	}
 	return tokens
+}
+
+func uniqueSortedWorkflowTokens(tokens []string) []string {
+	seen := map[string]struct{}{}
+	unique := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			continue
+		}
+		if _, exists := seen[token]; exists {
+			continue
+		}
+		seen[token] = struct{}{}
+		unique = append(unique, token)
+	}
+	sort.Strings(unique)
+	return unique
+}
+
+func stringMapValues(values map[string]string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(values))
+	for key, value := range values {
+		parts = append(parts, key+"="+value)
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "\n")
 }
 
 func isGitHubWorkflowPath(path string) bool {

--- a/internal/repoexposure/workflow_analyzer_test.go
+++ b/internal/repoexposure/workflow_analyzer_test.go
@@ -259,6 +259,384 @@ jobs:
 	}
 }
 
+func TestGitHubWorkflowAnalyzerDetectsAIPromptInjectionWithWriteToken(t *testing.T) {
+	content := []byte(`name: ai-review
+on: pull_request
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          prompt: ${{ github.event.pull_request.body }}
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/ai-review.yml", content, time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC))
+	assertWorkflowDetectors(t, findings, []string{
+		"workflow_broad_token_permissions",
+		"workflow_ai_agent_prompt_injection",
+	})
+
+	prompt := firstDetectorFinding(t, findings, "workflow_ai_agent_prompt_injection")
+	if prompt.Severity != domain.SeverityHigh {
+		t.Fatalf("expected high severity for write-capable agent prompt path, got %+v", prompt)
+	}
+	if tokens, _ := prompt.Evidence["untrusted_prompt_context"].([]string); len(tokens) == 0 || tokens[0] != "github.event.pull_request.body" {
+		t.Fatalf("expected PR body prompt evidence, got %+v", prompt.Evidence)
+	}
+	if capabilities, _ := prompt.Evidence["privileged_capabilities"].([]string); len(capabilities) == 0 || capabilities[0] != "github_token_write" {
+		t.Fatalf("expected write-token capability evidence, got %+v", prompt.Evidence)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerDetectsAIPromptInjectionThroughIssueAndReviewText(t *testing.T) {
+	cases := []struct {
+		name  string
+		event string
+		token string
+	}{
+		{name: "issue", event: "issues", token: "github.event.issue.body"},
+		{name: "comment", event: "issue_comment", token: "github.event.comment.body"},
+		{name: "review", event: "pull_request_review", token: "github.event.review.body"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			content := []byte(`name: ai-triage
+on: ` + tc.event + `
+permissions:
+  issues: write
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: openai/triage-action@v1
+        with:
+          prompt: ${{ ` + tc.token + ` }}
+`)
+			findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/ai-"+tc.name+".yml", content, time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC))
+			assertWorkflowDetectors(t, findings, []string{"workflow_ai_agent_prompt_injection"})
+			prompt := firstDetectorFinding(t, findings, "workflow_ai_agent_prompt_injection")
+			if tokens, _ := prompt.Evidence["untrusted_prompt_context"].([]string); len(tokens) == 0 || tokens[0] != tc.token {
+				t.Fatalf("expected %s prompt evidence, got %+v", tc.token, prompt.Evidence)
+			}
+		})
+	}
+}
+
+func TestGitHubWorkflowAnalyzerDetectsRepositoryPromptFileForAIAgent(t *testing.T) {
+	content := []byte(`name: ai-autofix
+on: pull_request
+permissions:
+  contents: write
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anthropics/claude-code-action@v1
+        with:
+          prompt_file: prompts/autofix.md
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/ai-autofix.yml", content, time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC))
+	assertWorkflowDetectors(t, findings, []string{"workflow_ai_agent_prompt_injection"})
+	prompt := firstDetectorFinding(t, findings, "workflow_ai_agent_prompt_injection")
+	if tokens, _ := prompt.Evidence["untrusted_prompt_context"].([]string); len(tokens) == 0 || tokens[0] != "repository_prompt_file" {
+		t.Fatalf("expected repository prompt file evidence, got %+v", prompt.Evidence)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerDoesNotFlagRepositoryPromptFileBeforeCheckoutOnPullRequest(t *testing.T) {
+	content := []byte(`name: ai-autofix
+on: pull_request
+permissions:
+  contents: write
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          prompt_file: prompts/autofix.md
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/ai-autofix.yml", content, time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC))
+	if containsDetector(findings, "workflow_ai_agent_prompt_injection") {
+		t.Fatalf("expected pull_request prompt file without checkout not to be treated as attacker-controlled, got %+v", findings)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerResolvesEnvRoutedRepositoryPromptFile(t *testing.T) {
+	content := []byte(`name: ai-autofix
+on: pull_request
+permissions:
+  contents: write
+env:
+  PROMPT_FILE: prompts/autofix.md
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anthropics/claude-code-action@v1
+        with:
+          prompt_file: ${{ env.PROMPT_FILE }}
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/ai-autofix.yml", content, time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC))
+	assertWorkflowDetectors(t, findings, []string{"workflow_ai_agent_prompt_injection"})
+	prompt := firstDetectorFinding(t, findings, "workflow_ai_agent_prompt_injection")
+	if tokens, _ := prompt.Evidence["untrusted_prompt_context"].([]string); len(tokens) == 0 || tokens[0] != "repository_prompt_file" {
+		t.Fatalf("expected env-routed repository prompt file evidence, got %+v", prompt.Evidence)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerClassifiesUnprivilegedAIPromptPathAsMedium(t *testing.T) {
+	content := []byte(`name: ai-summary
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  summarize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: openai/summary-action@v1
+        with:
+          prompt: ${{ github.event.pull_request.body }}
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/ai-summary.yml", content, time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC))
+	prompt := firstDetectorFinding(t, findings, "workflow_ai_agent_prompt_injection")
+	if prompt.Severity != domain.SeverityMedium {
+		t.Fatalf("expected medium severity without privileged capabilities, got %+v", prompt)
+	}
+	if capabilities, _ := prompt.Evidence["privileged_capabilities"].([]string); len(capabilities) != 0 {
+		t.Fatalf("expected no privileged capability evidence, got %+v", prompt.Evidence)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerDoesNotFlagTrustedLeastPrivilegeAIJob(t *testing.T) {
+	content := []byte(`name: trusted-ai
+on:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: openai/docs-action@f00dbabe1234567890abcdef1234567890abcdef
+        with:
+          prompt: Summarize the latest generated docs.
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/trusted-ai.yml", content, time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC))
+	if containsDetector(findings, "workflow_ai_agent_prompt_injection") {
+		t.Fatalf("expected trusted least-privilege AI job not to emit prompt injection finding, got %+v", findings)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerResolvesEnvRoutedUntrustedPromptInput(t *testing.T) {
+	cases := []struct {
+		name      string
+		reference string
+	}{
+		{name: "dot", reference: "${{ env.PROMPT }}"},
+		{name: "bracket-single", reference: "${{ env['PROMPT'] }}"},
+		{name: "bracket-double", reference: `${{ env["PROMPT"] }}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			content := []byte(`name: ai-review
+on: pull_request
+permissions:
+  contents: write
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    env:
+      PROMPT: ${{ github.event.pull_request.body }}
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          prompt: ` + tc.reference + `
+`)
+
+			findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/ai-review.yml", content, time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC))
+			if !containsDetector(findings, "workflow_ai_agent_prompt_injection") {
+				t.Fatalf("expected env-routed untrusted prompt to be detected, got %+v", findings)
+			}
+			prompt := firstDetectorFinding(t, findings, "workflow_ai_agent_prompt_injection")
+			if tokens, _ := prompt.Evidence["untrusted_prompt_context"].([]string); len(tokens) == 0 || tokens[0] != "github.event.pull_request.body" {
+				t.Fatalf("expected PR body prompt evidence resolved through inherited env, got %+v", prompt.Evidence)
+			}
+		})
+	}
+}
+
+func TestGitHubWorkflowAnalyzerDoesNotFlagRepositoryPromptFileOnIssueOnlyTrigger(t *testing.T) {
+	content := []byte(`name: ai-triage
+on: issue_comment
+permissions:
+  contents: write
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          prompt_file: prompts/triage.md
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/ai-triage.yml", content, time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC))
+	if containsDetector(findings, "workflow_ai_agent_prompt_injection") {
+		t.Fatalf("expected repository prompt file on issue-only trigger not to be treated as attacker-controlled, got %+v", findings)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerDoesNotFlagRepositoryPromptFileOnTrustedPullRequestTarget(t *testing.T) {
+	content := []byte(`name: ai-autofix
+on: pull_request_target
+permissions:
+  contents: write
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anthropics/claude-code-action@v1
+        with:
+          prompt_file: prompts/autofix.md
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/ai-autofix.yml", content, time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC))
+	if containsDetector(findings, "workflow_ai_agent_prompt_injection") {
+		t.Fatalf("expected trusted base-ref pull_request_target prompt file not to be treated as attacker-controlled, got %+v", findings)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerDoesNotTaintEarlierPromptFileFromLaterUntrustedCheckoutPullRequestTarget(t *testing.T) {
+	content := []byte(`name: ai-autofix
+on: pull_request_target
+permissions:
+  contents: write
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anthropics/claude-code-action@v1
+        with:
+          prompt_file: prompts/autofix.md
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/ai-autofix.yml", content, time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC))
+	if containsDetector(findings, "workflow_ai_agent_prompt_injection") {
+		t.Fatalf("expected later untrusted checkout not to taint earlier AI prompt file step, got %+v", findings)
+	}
+	if !containsDetector(findings, "workflow_pull_request_target_untrusted_checkout") {
+		t.Fatalf("expected later untrusted checkout to still be reported, got %+v", findings)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerDoesNotEscalatePullRequestOnlyPromptFilePathToTargetCritical(t *testing.T) {
+	content := []byte(`name: ai-autofix
+on:
+  pull_request:
+  pull_request_target:
+permissions:
+  contents: write
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anthropics/claude-code-action@v1
+        with:
+          prompt_file: prompts/autofix.md
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/ai-autofix.yml", content, time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC))
+	prompt := firstDetectorFinding(t, findings, "workflow_ai_agent_prompt_injection")
+	if prompt.Severity != domain.SeverityHigh {
+		t.Fatalf("expected pull_request-only repository prompt file path to stay high severity, got %+v", prompt)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerEscalatesPullRequestTargetPromptBodyPathToCritical(t *testing.T) {
+	content := []byte(`name: ai-autofix
+on: pull_request_target
+permissions:
+  contents: write
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          prompt: ${{ github.event.pull_request.body }}
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/ai-autofix.yml", content, time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC))
+	prompt := firstDetectorFinding(t, findings, "workflow_ai_agent_prompt_injection")
+	if prompt.Severity != domain.SeverityCritical {
+		t.Fatalf("expected pull_request_target prompt body path to stay critical severity, got %+v", prompt)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerTreatsImplicitTargetTokenAsPrivilegedForAIPromptPath(t *testing.T) {
+	content := []byte(`name: ai-autofix
+on: pull_request_target
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          prompt: ${{ github.event.pull_request.body }}
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/ai-autofix.yml", content, time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC))
+	prompt := firstDetectorFinding(t, findings, "workflow_ai_agent_prompt_injection")
+	if prompt.Severity != domain.SeverityCritical {
+		t.Fatalf("expected implicit pull_request_target token write path to be critical severity, got %+v", prompt)
+	}
+	if capabilities, _ := prompt.Evidence["privileged_capabilities"].([]string); len(capabilities) == 0 || capabilities[0] != "github_token_write_default" {
+		t.Fatalf("expected implicit token write capability evidence, got %+v", prompt.Evidence)
+	}
+}
+
+func TestGitHubWorkflowAnalyzerFlagsRepositoryPromptFileOnUntrustedCheckoutPullRequestTarget(t *testing.T) {
+	content := []byte(`name: ai-autofix
+on: pull_request_target
+permissions:
+  contents: write
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: anthropics/claude-code-action@v1
+        with:
+          prompt_file: prompts/autofix.md
+`)
+
+	findings := detectMisconfigFindings("octo-org/octo-repo", "HEAD", ".github/workflows/ai-autofix.yml", content, time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC))
+	prompt := firstDetectorFinding(t, findings, "workflow_ai_agent_prompt_injection")
+	if tokens, _ := prompt.Evidence["untrusted_prompt_context"].([]string); len(tokens) == 0 || tokens[0] != "repository_prompt_file" {
+		t.Fatalf("expected repository prompt file evidence when PR head is checked out, got %+v", prompt.Evidence)
+	}
+}
+
 func TestGitHubWorkflowAnalyzerDoesNotTreatHeadSHAAsShellInjection(t *testing.T) {
 	content := []byte(`name: pr-info
 on: pull_request


### PR DESCRIPTION
Fixes #1331

## Summary
- Added `workflow_ai_agent_prompt_injection` detection for GitHub Actions steps that combine AI/LLM agent signals with untrusted PR, issue, review, comment, workflow_run, or repository prompt-file input.
- Classified severity by reachable capability: medium for read-only unresolved prompt paths, high for write/secrets/OIDC/cloud/release/repository mutation, and critical when the same pattern occurs under privileged `pull_request_target`.
- Added evidence for agent signal, untrusted prompt source, permission summary, privileged capabilities, workflow job, step index, action, and secret reachability.
- Added remediation guidance and documentation that explains why prompt injection is distinct from shell injection and how to split read-only prompt processing from privileged follow-up work.

## Validation
- `go test ./internal/repoexposure ./internal/findings/standards`
- `go test ./... -coverprofile=coverage.out`
- `go tool cover -func=coverage.out` (total: 80.2%)
- pre-commit hooks: merge conflict check, EOF fix, trailing whitespace, gofmt, Vercel artifact hygiene
- pre-push hooks: merge conflict check, EOF fix, trailing whitespace, gofmt, go vet, local env token hygiene, Vercel artifact hygiene

## AI Assistance
AI-assisted: Yes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds detection for AI‑agent prompt‑injection paths in GitHub Actions. Flags LLM/agent steps that consume untrusted PR/issue/review/comment/`workflow_run` text or PR‑controlled repository prompt files, with severity based on privileges and `pull_request_target` reachability.

- **New Features**
  - Detects `workflow_ai_agent_prompt_injection` when agent steps read PR/issue/review/comment/`workflow_run` text, or repository prompt files after a PR checkout (or after an untrusted checkout under `pull_request_target`).
  - Resolves `env.*` indirection (dot and bracket) across workflow/job/step scopes so env‑routed prompts are tainted.
  - Severity: medium for read‑only; high when write/secrets/OIDC/cloud/release/repo‑write are reachable; critical under `pull_request_target` when the prompt path is reachable and privileged (including implicit default token write).
  - Evidence includes agent signal, prompt‑source tokens (e.g., `github.event.pull_request.body`, `repository_prompt_file`), permission summary, privileged capabilities, job/step/action, and secret reachability; adds remediation guidance, docs clarifying shell vs prompt injection, tests, and changelog updates.

<sup>Written for commit 65bf1e74d3b241bd8ea7480354d91d76600ae975. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1337?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

