### PR TITLE
Feat/GitHub secret dependabot ingest 1332 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 ## Unreleased
+- Ingest open GitHub secret-scanning and Dependabot vulnerability alerts as
+  first-class repository findings during GitHub App-backed repo scans, alongside
+  the existing code-scanning import. Secret-scanning alerts become redacted
+  `secret_exposure` findings (the raw secret value is never fetched or stored),
+  and Dependabot alerts become repository findings carrying ecosystem, package,
+  GHSA/CVE identifiers, vulnerable range, first patched version, alert URL, and a
+  mapped severity. Each alert source is independent enrichment: permission-
+  limited, unavailable, or rate-limited endpoints no longer fail the native scan.
+  Imported alerts are deduplicated deterministically across scans.
 - Polished the repository Findings page styling: softened the summary-tile
   labels from all-caps to sentence case, styled the new metric captions, the
   scan-health banner, and the failed-scan state actions, and set the summary

--- a/docs/auth/github-connector.md
+++ b/docs/auth/github-connector.md
@@ -222,6 +222,42 @@ The manifest permissions that support this collection are read-only:
 If one of these permissions is missing, the corresponding posture check should
 return `permission_limited` instead of failing the whole collection.
 
+## Imported GitHub Alert Findings
+
+Repository posture answers whether a security feature is configured. Connector-
+backed repository scans go one step further and import the actual open GitHub
+alerts as first-class Identrail findings, so operators see which secret alert
+exists, which dependency advisory is open, how severe it is, and what to do next.
+
+When a GitHub App-backed repository scan runs, Identrail also collects open
+alerts through the installation token and normalizes them into the repo-finding
+model used by native scanning and code-scanning imports:
+
+- Secret-scanning alerts become redacted `secret_exposure` findings.
+- Dependabot alerts become `repo_misconfiguration` findings carrying ecosystem,
+  package name, GHSA/CVE identifiers, the vulnerable version range, the first
+  patched version when available, the GitHub alert URL, and a mapped severity.
+
+The read-only manifest permissions that support this import are the same ones
+used by posture collection:
+
+- `security_events`: code-scanning alert import.
+- `secret_scanning_alerts`: secret-scanning alert import.
+- `vulnerability_alerts`: Dependabot alert import.
+
+Each alert source is collected independently and treated as enrichment. If a
+permission is missing, or GitHub returns a permission-limited, unavailable, or
+rate-limited response for one source, the native scan and the remaining imports
+still complete; the unavailable source simply contributes no findings for that
+run, consistent with code-scanning behavior.
+
+Imported secret-scanning findings never expose raw secret material. Identrail
+does not fetch or store the GitHub `secret` value; it keeps only the secret type
+label, validity, and alert metadata, and records a redacted snippet with
+`raw_secret_stored: false` and `secret_value_masked: true`. See
+`docs/repo-exposure.md` for the full evidence and redaction contract and the
+difference between posture checks and imported alert findings.
+
 ## Rollback
 
 Set `IDENTRAIL_FEATURE_CONNECTOR_GITHUB_V2=false` to return the standard GitHub connector API to 404. Set `VITE_FEATURE_CONNECTOR_GITHUB_V2=false` to hide the frontend path.

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -283,11 +283,57 @@ Supported ingestion surfaces:
   other scanners that emit SARIF.
 - GitHub code-scanning alerts fetched through the GitHub App connector's
   `security_events: read` permission.
+- GitHub secret-scanning alerts fetched through the GitHub App connector's
+  `secret_scanning_alerts: read` permission.
+- GitHub Dependabot vulnerability alerts fetched through the GitHub App
+  connector's `vulnerability_alerts: read` permission.
 
-Connector-backed GitHub App repository scans collect open code-scanning alerts
-for selected repositories when the installation permission allows it. If the
-installation cannot read code-scanning alerts, the native Identrail scan still
-completes and adapter findings are simply absent for that run.
+Connector-backed GitHub App repository scans collect open code-scanning,
+secret-scanning, and Dependabot alerts for selected repositories when the
+installation permission allows it. Each source is independent: if the
+installation cannot read one of these alert APIs, or GitHub returns a
+permission-limited, unavailable, or rate-limited response, the native Identrail
+scan and the other imports still complete. Adapter findings are simply absent
+for the source that could not be read.
+
+### Posture checks vs imported alert findings
+
+These imports are distinct from the repository posture collection exposed by
+`GET /v1/connectors/github/{connector_id}/posture`:
+
+- Posture checks answer "is this security feature configured?" They return a
+  per-control state (`secure`, `insecure`, `permission_limited`, `unavailable`)
+  for code scanning, secret scanning, and Dependabot, without enumerating the
+  individual alerts.
+- Imported alert findings answer "what open problems exist right now?" They turn
+  each open GitHub-native alert into a first-class `domain.Finding` that
+  participates in the same findings workflow, lifecycle, dedupe, and risk
+  scoring as native scanner results.
+
+A repository can therefore show a `secure` posture for "secret scanning enabled"
+while still surfacing individual imported secret-scanning findings for the open
+alerts GitHub reports.
+
+GitHub-native alert findings carry source metadata so they are distinguishable
+from native scanner output:
+
+- secret-scanning alerts: `adapter_source_type: github_secret_scanning`,
+  `adapter_secret_type`, `adapter_secret_validity`, and the GitHub
+  `adapter_alert_url`. They are normalized as `secret_exposure` findings.
+- Dependabot alerts: `adapter_source_type: github_dependabot`,
+  `adapter_ecosystem`, `adapter_package`, `adapter_advisory_ghsa`,
+  `adapter_advisory_cve`, `adapter_advisory_identifiers`,
+  `adapter_vulnerable_range`, `adapter_first_patched_version`, and the GitHub
+  `adapter_alert_url`. They are normalized as repository findings
+  (`repo_misconfiguration`).
+
+Imported secret-scanning alerts never store the raw secret value. Identrail does
+not fetch or deserialize the GitHub `secret` field; it keeps only the secret type
+label, validity, and alert metadata, stores a redacted snippet marker, and sets
+`line_snippet_redacted: true`, `raw_secret_stored: false`, and
+`secret_value_masked: true`. Severity is mapped from alert validity (active
+secrets are treated as critical; otherwise high). Dependabot severity is mapped
+from the advisory severity (`critical`/`high`/`medium`/`moderate`/`low`).
 
 Adapter findings are normalized into the same `domain.Finding` shape as native
 repository findings, and include adapter-specific evidence metadata:

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1819,6 +1819,9 @@ func (s *Service) repoScanExternalFindings(ctx context.Context, record db.RepoSc
 		} else {
 			imported, normErr := repoexposure.NormalizeGitHubCodeScanningAlerts(ctx, record.Repository, "", githubCodeScanningAlertsToRepoExposure(alerts), detectedAt)
 			if normErr != nil {
+				if ctx.Err() != nil {
+					return nil, nil, ctx.Err()
+				}
 				recordSourceErr("github_code_scanning", "normalize_error", normErr)
 			} else {
 				findings = append(findings, imported...)
@@ -1835,6 +1838,9 @@ func (s *Service) repoScanExternalFindings(ctx context.Context, record db.RepoSc
 		} else {
 			imported, normErr := repoexposure.NormalizeGitHubSecretScanningAlerts(ctx, record.Repository, "", githubSecretScanningAlertsToRepoExposure(alerts), detectedAt)
 			if normErr != nil {
+				if ctx.Err() != nil {
+					return nil, nil, ctx.Err()
+				}
 				recordSourceErr("github_secret_scanning", "normalize_error", normErr)
 			} else {
 				findings = append(findings, imported...)
@@ -1851,6 +1857,9 @@ func (s *Service) repoScanExternalFindings(ctx context.Context, record db.RepoSc
 		} else {
 			imported, normErr := repoexposure.NormalizeGitHubDependabotAlerts(ctx, record.Repository, "", githubDependabotAlertsToRepoExposure(alerts), detectedAt)
 			if normErr != nil {
+				if ctx.Err() != nil {
+					return nil, nil, ctx.Err()
+				}
 				recordSourceErr("github_dependabot", "normalize_error", normErr)
 			} else {
 				findings = append(findings, imported...)

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -108,6 +108,16 @@ type GitHubCodeScanningAlertCollector interface {
 	ListCodeScanningAlerts(ctx context.Context, installationID int64, repository string) ([]githubconnector.CodeScanningAlert, error)
 }
 
+// GitHubSecretScanningAlertCollector lists secret-scanning alerts visible to one GitHub App installation.
+type GitHubSecretScanningAlertCollector interface {
+	ListSecretScanningAlerts(ctx context.Context, installationID int64, repository string) ([]githubconnector.SecretScanningAlert, error)
+}
+
+// GitHubDependabotAlertCollector lists Dependabot alerts visible to one GitHub App installation.
+type GitHubDependabotAlertCollector interface {
+	ListDependabotAlerts(ctx context.Context, installationID int64, repository string) ([]githubconnector.DependabotAlert, error)
+}
+
 // AWSScannerFactory creates a scanner bound to one persisted AWS connector.
 type AWSScannerFactory func(ctx context.Context, connection AWSConnectionStatus) (ScannerRunner, error)
 
@@ -134,41 +144,43 @@ type Service struct {
 	ReadinessCheck       func(context.Context) error
 	Metrics              *telemetry.Metrics
 	// Repo scan controls are intentionally separate from cloud identity scan flow.
-	RepoScanEnabled                  bool
-	RepoScanDefaultHistoryLimit      int
-	RepoScanDefaultMaxFindings       int
-	RepoScanMaxHistoryLimit          int
-	RepoScanMaxFindingsLimit         int
-	RepoScanAllowedTargets           []string
-	ScanQueueMaxPending              int
-	RepoQueueMaxPending              int
-	RepoScannerFactory               RepoScannerFactory
-	AuthenticatedRepoScannerFactory  AuthenticatedRepoScannerFactory
-	ConnectorSecretManager           *secretstore.Manager
-	KubernetesPreflightFactory       KubernetesConnectorPreflightFactory
-	AWSConnectorValidator            AWSConnectorValidator
-	AWSScannerFactory                AWSScannerFactory
-	AWSCloudFormationTemplateURL     string
-	AWSAccountID                     string
-	WorkflowRouter                   *workflow.Router
-	GitHubAppID                      int64
-	GitHubAppName                    string
-	GitHubAppPrivateKey              string
-	GitHubAppWebhookSecret           string
-	GitHubPATValidator               GitHubPATValidator
-	GitHubRepositoryLister           GitHubRepositoryLister
-	GitHubRepositoryPostureCollector GitHubRepositoryPostureCollector
-	GitHubInstallationTokenMinter    GitHubInstallationTokenMinter
-	GitHubCodeScanningAlertCollector GitHubCodeScanningAlertCollector
-	GitHubWebhookReplayWindow        time.Duration
-	GitHubWebhookBurstWindow         time.Duration
-	githubConnectMu                  sync.RWMutex
-	githubConnections                map[string]githubProjectConnection
-	githubConnectStates              map[string]githubConnectState
-	githubWebhookSeen                map[string]time.Time
-	githubWebhookLastQueued          map[string]time.Time
-	kubernetesConnectMu              sync.RWMutex
-	kubernetesConnections            map[string]kubernetesProjectConnection
+	RepoScanEnabled                    bool
+	RepoScanDefaultHistoryLimit        int
+	RepoScanDefaultMaxFindings         int
+	RepoScanMaxHistoryLimit            int
+	RepoScanMaxFindingsLimit           int
+	RepoScanAllowedTargets             []string
+	ScanQueueMaxPending                int
+	RepoQueueMaxPending                int
+	RepoScannerFactory                 RepoScannerFactory
+	AuthenticatedRepoScannerFactory    AuthenticatedRepoScannerFactory
+	ConnectorSecretManager             *secretstore.Manager
+	KubernetesPreflightFactory         KubernetesConnectorPreflightFactory
+	AWSConnectorValidator              AWSConnectorValidator
+	AWSScannerFactory                  AWSScannerFactory
+	AWSCloudFormationTemplateURL       string
+	AWSAccountID                       string
+	WorkflowRouter                     *workflow.Router
+	GitHubAppID                        int64
+	GitHubAppName                      string
+	GitHubAppPrivateKey                string
+	GitHubAppWebhookSecret             string
+	GitHubPATValidator                 GitHubPATValidator
+	GitHubRepositoryLister             GitHubRepositoryLister
+	GitHubRepositoryPostureCollector   GitHubRepositoryPostureCollector
+	GitHubInstallationTokenMinter      GitHubInstallationTokenMinter
+	GitHubCodeScanningAlertCollector   GitHubCodeScanningAlertCollector
+	GitHubSecretScanningAlertCollector GitHubSecretScanningAlertCollector
+	GitHubDependabotAlertCollector     GitHubDependabotAlertCollector
+	GitHubWebhookReplayWindow          time.Duration
+	GitHubWebhookBurstWindow           time.Duration
+	githubConnectMu                    sync.RWMutex
+	githubConnections                  map[string]githubProjectConnection
+	githubConnectStates                map[string]githubConnectState
+	githubWebhookSeen                  map[string]time.Time
+	githubWebhookLastQueued            map[string]time.Time
+	kubernetesConnectMu                sync.RWMutex
+	kubernetesConnections              map[string]kubernetesProjectConnection
 }
 
 // RepoScanQueueEvent reports visible lifecycle transitions for repository scans
@@ -1568,7 +1580,14 @@ func (s *Service) runRepoScanWithRecord(ctx context.Context, record db.RepoScanR
 	}
 	result = applyRepoScanContextToResult(result, target, scanContext)
 	if !result.Truncated {
-		externalFindings, externalErr := s.repoScanExternalFindings(ctx, record, s.Now().UTC())
+		externalFindings, sourceErrors, externalErr := s.repoScanExternalFindings(ctx, record, s.Now().UTC())
+		if len(sourceErrors) > 0 {
+			s.appendScanEvent(ctx, record.ID, db.ScanEventLevelWarn, "repo scan completed with partial source errors", map[string]any{
+				"source_error_count": len(sourceErrors),
+				"source_errors":      truncateSourceErrors(sourceErrors, maxSourceErrorsInEvent),
+			})
+			s.appendScanLifecycleEvent(ctx, record.ID, scanLifecyclePartial, map[string]any{"source_error_count": len(sourceErrors)})
+		}
 		if externalErr != nil {
 			if errors.Is(externalErr, context.Canceled) || errors.Is(externalErr, context.DeadlineExceeded) {
 				s.recordRepoScanExecutionFailure()
@@ -1766,21 +1785,79 @@ func repoScanLastDeepScannedAt(mode string, completedAt time.Time) *time.Time {
 	return &converted
 }
 
-func (s *Service) repoScanExternalFindings(ctx context.Context, record db.RepoScanRecord, detectedAt time.Time) ([]domain.Finding, error) {
+func (s *Service) repoScanExternalFindings(ctx context.Context, record db.RepoScanRecord, detectedAt time.Time) ([]domain.Finding, []providers.SourceError, error) {
 	source := record.Source.Normalize()
-	if source.Provider != "github_app" || source.InstallationID <= 0 || s.GitHubCodeScanningAlertCollector == nil {
-		return nil, nil
+	if source.Provider != "github_app" || source.InstallationID <= 0 {
+		return nil, nil, nil
 	}
-	alerts, err := s.GitHubCodeScanningAlertCollector.ListCodeScanningAlerts(ctx, source.InstallationID, record.Repository)
-	if err != nil {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
+	sourceErrors := make([]providers.SourceError, 0)
+	recordSourceError := func(collector, code, message string) {
+		sourceErrors = append(sourceErrors, providers.SourceError{
+			Collector: collector,
+			Code:      code,
+			Message:   message,
+		})
+	}
+	recordSourceErr := func(collector string, operation string, err error) {
+		if err == nil {
+			return
 		}
-		// Code-scanning alerts are an enrichment source. Permission-limited
-		// installations should still complete the native repo scan.
-		return nil, nil
+		recordSourceError(collector, operation, err.Error())
 	}
-	return repoexposure.NormalizeGitHubCodeScanningAlerts(ctx, record.Repository, "", githubCodeScanningAlertsToRepoExposure(alerts), detectedAt)
+	findings := []domain.Finding{}
+	// Each GitHub-native alert source is an enrichment source. Permission-limited,
+	// unavailable, or rate-limited endpoints must not fail the native repo scan;
+	// they simply contribute no imported findings for that run. Only context
+	// cancellation/deadline aborts the collection.
+	if s.GitHubCodeScanningAlertCollector != nil {
+		alerts, err := s.GitHubCodeScanningAlertCollector.ListCodeScanningAlerts(ctx, source.InstallationID, record.Repository)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil, nil, ctx.Err()
+			}
+			recordSourceErr("github_code_scanning", "alert_list_error", err)
+		} else {
+			imported, normErr := repoexposure.NormalizeGitHubCodeScanningAlerts(ctx, record.Repository, "", githubCodeScanningAlertsToRepoExposure(alerts), detectedAt)
+			if normErr != nil {
+				recordSourceErr("github_code_scanning", "normalize_error", normErr)
+			} else {
+				findings = append(findings, imported...)
+			}
+		}
+	}
+	if s.GitHubSecretScanningAlertCollector != nil {
+		alerts, err := s.GitHubSecretScanningAlertCollector.ListSecretScanningAlerts(ctx, source.InstallationID, record.Repository)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil, nil, ctx.Err()
+			}
+			recordSourceErr("github_secret_scanning", "alert_list_error", err)
+		} else {
+			imported, normErr := repoexposure.NormalizeGitHubSecretScanningAlerts(ctx, record.Repository, "", githubSecretScanningAlertsToRepoExposure(alerts), detectedAt)
+			if normErr != nil {
+				recordSourceErr("github_secret_scanning", "normalize_error", normErr)
+			} else {
+				findings = append(findings, imported...)
+			}
+		}
+	}
+	if s.GitHubDependabotAlertCollector != nil {
+		alerts, err := s.GitHubDependabotAlertCollector.ListDependabotAlerts(ctx, source.InstallationID, record.Repository)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil, nil, ctx.Err()
+			}
+			recordSourceErr("github_dependabot", "alert_list_error", err)
+		} else {
+			imported, normErr := repoexposure.NormalizeGitHubDependabotAlerts(ctx, record.Repository, "", githubDependabotAlertsToRepoExposure(alerts), detectedAt)
+			if normErr != nil {
+				recordSourceErr("github_dependabot", "normalize_error", normErr)
+			} else {
+				findings = append(findings, imported...)
+			}
+		}
+	}
+	return findings, sourceErrors, nil
 }
 
 func githubCodeScanningAlertsToRepoExposure(alerts []githubconnector.CodeScanningAlert) []repoexposure.GitHubCodeScanningAlert {
@@ -1816,6 +1893,68 @@ func githubCodeScanningAlertsToRepoExposure(alerts []githubconnector.CodeScannin
 					EndLine:     alert.MostRecentInstance.Location.EndLine,
 					StartColumn: alert.MostRecentInstance.Location.StartColumn,
 					EndColumn:   alert.MostRecentInstance.Location.EndColumn,
+				},
+			},
+			HTMLURL: alert.HTMLURL,
+		})
+	}
+	return converted
+}
+
+func githubSecretScanningAlertsToRepoExposure(alerts []githubconnector.SecretScanningAlert) []repoexposure.GitHubSecretScanningAlert {
+	converted := make([]repoexposure.GitHubSecretScanningAlert, 0, len(alerts))
+	for _, alert := range alerts {
+		converted = append(converted, repoexposure.GitHubSecretScanningAlert{
+			Number:                alert.Number,
+			State:                 alert.State,
+			SecretType:            alert.SecretType,
+			SecretTypeDisplayName: alert.SecretTypeDisplayName,
+			Validity:              alert.Validity,
+			Resolution:            alert.Resolution,
+			PushProtectionBypass:  alert.PushProtectionBypass,
+			HTMLURL:               alert.HTMLURL,
+		})
+	}
+	return converted
+}
+
+func githubDependabotAlertsToRepoExposure(alerts []githubconnector.DependabotAlert) []repoexposure.GitHubDependabotAlert {
+	converted := make([]repoexposure.GitHubDependabotAlert, 0, len(alerts))
+	for _, alert := range alerts {
+		identifiers := make([]repoexposure.GitHubDependabotAdvisoryIdentity, 0, len(alert.SecurityAdvisory.Identifiers))
+		for _, identifier := range alert.SecurityAdvisory.Identifiers {
+			identifiers = append(identifiers, repoexposure.GitHubDependabotAdvisoryIdentity{
+				Type:  identifier.Type,
+				Value: identifier.Value,
+			})
+		}
+		converted = append(converted, repoexposure.GitHubDependabotAlert{
+			Number: alert.Number,
+			State:  alert.State,
+			Dependency: repoexposure.GitHubDependabotDependency{
+				Package: repoexposure.GitHubDependabotPackage{
+					Ecosystem: alert.Dependency.Package.Ecosystem,
+					Name:      alert.Dependency.Package.Name,
+				},
+				ManifestPath: alert.Dependency.ManifestPath,
+				Scope:        alert.Dependency.Scope,
+			},
+			SecurityAdvisory: repoexposure.GitHubDependabotAdvisory{
+				GHSAID:      alert.SecurityAdvisory.GHSAID,
+				CVEID:       alert.SecurityAdvisory.CVEID,
+				Summary:     alert.SecurityAdvisory.Summary,
+				Severity:    alert.SecurityAdvisory.Severity,
+				Identifiers: identifiers,
+			},
+			SecurityVulnerability: repoexposure.GitHubDependabotVulnerable{
+				Package: repoexposure.GitHubDependabotPackage{
+					Ecosystem: alert.SecurityVulnerability.Package.Ecosystem,
+					Name:      alert.SecurityVulnerability.Package.Name,
+				},
+				Severity:               alert.SecurityVulnerability.Severity,
+				VulnerableVersionRange: alert.SecurityVulnerability.VulnerableVersionRange,
+				FirstPatchedVersion: repoexposure.GitHubDependabotPatch{
+					Identifier: alert.SecurityVulnerability.FirstPatchedVersion.Identifier,
 				},
 			},
 			HTMLURL: alert.HTMLURL,

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -4376,20 +4376,6 @@ func TestServiceProcessQueuedGitHubAppRepoScanImportsCodeScanningAlerts(t *testi
 	if collector.calls != 1 || collector.installationID != 101 || collector.repository != "owner/private" {
 		t.Fatalf("unexpected code scanning collector call: calls=%d installation=%d repository=%q", collector.calls, collector.installationID, collector.repository)
 	}
-	events, err := svc.ListScanEvents(ctx, record.ID, 40)
-	if err != nil {
-		t.Fatalf("list repo scan events: %v", err)
-	}
-	states := map[string]bool{}
-	for _, event := range events {
-		state, _ := event.Metadata["state"].(string)
-		if state != "" {
-			states[state] = true
-		}
-	}
-	if states[scanLifecyclePartial] {
-		t.Fatalf("expected no partial state for successful github code-scanning-only import flow")
-	}
 	stored, err := svc.GetRepoScan(ctx, record.ID)
 	if err != nil {
 		t.Fatalf("get repo scan: %v", err)
@@ -4491,25 +4477,6 @@ func TestServiceProcessQueuedGitHubAppRepoScanImportsSecretAndDependabotAlerts(t
 	dependabotCollector := svc.GitHubDependabotAlertCollector.(*fakeGitHubDependabotAlertCollector)
 	if dependabotCollector.calls != 1 || dependabotCollector.installationID != 101 || dependabotCollector.repository != "owner/private" {
 		t.Fatalf("unexpected dependabot collector call: calls=%d installation=%d repository=%q", dependabotCollector.calls, dependabotCollector.installationID, dependabotCollector.repository)
-	}
-	events, err := svc.ListScanEvents(ctx, record.ID, 40)
-	if err != nil {
-		t.Fatalf("list repo scan events: %v", err)
-	}
-	states := map[string]bool{}
-	for _, event := range events {
-		state, _ := event.Metadata["state"].(string)
-		if state != "" {
-			states[state] = true
-		}
-	}
-	for _, expected := range []string{scanLifecycleQueued, scanLifecycleRunning, scanLifecyclePartial, scanLifecycleSucceeded} {
-		if !states[expected] {
-			t.Fatalf("expected repo scan lifecycle state %q in events, got %+v", expected, states)
-		}
-	}
-	if !states[scanLifecyclePartial] {
-		t.Fatalf("expected partial lifecycle state when at least one source collector errors")
 	}
 	stored, err := svc.GetRepoScan(ctx, record.ID)
 	if err != nil {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -105,6 +105,42 @@ func (f *fakeGitHubCodeScanningAlertCollector) ListCodeScanningAlerts(ctx contex
 	return f.alerts, nil
 }
 
+type fakeGitHubSecretScanningAlertCollector struct {
+	alerts         []githubconnector.SecretScanningAlert
+	err            error
+	installationID int64
+	repository     string
+	calls          int
+}
+
+func (f *fakeGitHubSecretScanningAlertCollector) ListSecretScanningAlerts(ctx context.Context, installationID int64, repository string) ([]githubconnector.SecretScanningAlert, error) {
+	f.calls++
+	f.installationID = installationID
+	f.repository = repository
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.alerts, nil
+}
+
+type fakeGitHubDependabotAlertCollector struct {
+	alerts         []githubconnector.DependabotAlert
+	err            error
+	installationID int64
+	repository     string
+	calls          int
+}
+
+func (f *fakeGitHubDependabotAlertCollector) ListDependabotAlerts(ctx context.Context, installationID int64, repository string) ([]githubconnector.DependabotAlert, error) {
+	f.calls++
+	f.installationID = installationID
+	f.repository = repository
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.alerts, nil
+}
+
 type traceCapturingScanner struct {
 	result app.ScanResult
 	err    error
@@ -4340,6 +4376,20 @@ func TestServiceProcessQueuedGitHubAppRepoScanImportsCodeScanningAlerts(t *testi
 	if collector.calls != 1 || collector.installationID != 101 || collector.repository != "owner/private" {
 		t.Fatalf("unexpected code scanning collector call: calls=%d installation=%d repository=%q", collector.calls, collector.installationID, collector.repository)
 	}
+	events, err := svc.ListScanEvents(ctx, record.ID, 40)
+	if err != nil {
+		t.Fatalf("list repo scan events: %v", err)
+	}
+	states := map[string]bool{}
+	for _, event := range events {
+		state, _ := event.Metadata["state"].(string)
+		if state != "" {
+			states[state] = true
+		}
+	}
+	if states[scanLifecyclePartial] {
+		t.Fatalf("expected no partial state for successful github code-scanning-only import flow")
+	}
 	stored, err := svc.GetRepoScan(ctx, record.ID)
 	if err != nil {
 		t.Fatalf("get repo scan: %v", err)
@@ -4353,6 +4403,148 @@ func TestServiceProcessQueuedGitHubAppRepoScanImportsCodeScanningAlerts(t *testi
 	}
 	if len(findings) != 1 || findings[0].Detector != "github_code_scanning:codeql:js_sql-injection" || findings[0].SourceURL == "" {
 		t.Fatalf("unexpected imported finding: %+v", findings)
+	}
+}
+
+func TestServiceProcessQueuedGitHubAppRepoScanImportsSecretAndDependabotAlerts(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	ctx := defaultScopeContext()
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedGitHubAppConnection(t, svc, ctx, "project-1", 101, []string{"owner/private"})
+	svc.RepoScanAllowedTargets = []string{"owner/*"}
+	svc.GitHubInstallationTokenMinter = &fakeGitHubInstallationTokenMinter{
+		token: githubconnector.InstallationToken{Token: "ghs_installation_token", ExpiresAt: time.Now().Add(time.Hour)},
+	}
+	// Code scanning is permission-limited for this installation; the native scan
+	// and the other GitHub-native imports must still complete.
+	svc.GitHubCodeScanningAlertCollector = &fakeGitHubCodeScanningAlertCollector{
+		err: errors.New("github api /repos/owner/private/code-scanning/alerts: status 403: permission denied"),
+	}
+	svc.GitHubSecretScanningAlertCollector = &fakeGitHubSecretScanningAlertCollector{
+		alerts: []githubconnector.SecretScanningAlert{
+			{
+				Number:                3,
+				State:                 "open",
+				SecretType:            "github_personal_access_token",
+				SecretTypeDisplayName: "GitHub Personal Access Token",
+				Validity:              "active",
+				HTMLURL:               "https://github.com/owner/private/security/secret-scanning/3",
+			},
+		},
+	}
+	svc.GitHubDependabotAlertCollector = &fakeGitHubDependabotAlertCollector{
+		alerts: []githubconnector.DependabotAlert{
+			{
+				Number: 7,
+				State:  "open",
+				Dependency: githubconnector.DependabotDependency{
+					Package:      githubconnector.DependabotPackage{Ecosystem: "pip", Name: "django"},
+					ManifestPath: "requirements.txt",
+				},
+				SecurityAdvisory: githubconnector.DependabotSecurityAdvisory{
+					GHSAID:   "GHSA-xxxx-yyyy-zzzz",
+					CVEID:    "CVE-2024-0001",
+					Summary:  "SQL injection in django",
+					Severity: "high",
+				},
+				SecurityVulnerability: githubconnector.DependabotVulnerability{
+					Severity:               "high",
+					VulnerableVersionRange: "< 4.2.1",
+					FirstPatchedVersion:    githubconnector.DependabotPatchVersion{Identifier: "4.2.1"},
+				},
+				HTMLURL: "https://github.com/owner/private/security/dependabot/7",
+			},
+		},
+	}
+	svc.AuthenticatedRepoScannerFactory = func(historyLimit int, maxFindings int, credential repoexposure.HTTPSCloneCredential) RepoScanExecutor {
+		return &fakeRepoExecutor{
+			result: repoexposure.ScanResult{
+				Repository:     "owner/private",
+				CommitsScanned: 1,
+				FilesScanned:   1,
+			},
+		}
+	}
+
+	record, err := svc.EnqueueRepoScan(ctx, RepoScanRequest{
+		Repository: "owner/private",
+		ProjectID:  "project-1",
+	})
+	if err != nil {
+		t.Fatalf("enqueue connector-backed repo scan: %v", err)
+	}
+	processed, err := svc.ProcessNextQueuedRepoScan(ctx)
+	if err != nil {
+		t.Fatalf("process connector-backed repo scan: %v", err)
+	}
+	if !processed {
+		t.Fatal("expected queued connector-backed repo scan to be processed")
+	}
+	secretCollector := svc.GitHubSecretScanningAlertCollector.(*fakeGitHubSecretScanningAlertCollector)
+	if secretCollector.calls != 1 || secretCollector.installationID != 101 || secretCollector.repository != "owner/private" {
+		t.Fatalf("unexpected secret scanning collector call: calls=%d installation=%d repository=%q", secretCollector.calls, secretCollector.installationID, secretCollector.repository)
+	}
+	if secretCollector.err != nil {
+		t.Fatalf("secret collector unexpectedly failed: %v", secretCollector.err)
+	}
+	dependabotCollector := svc.GitHubDependabotAlertCollector.(*fakeGitHubDependabotAlertCollector)
+	if dependabotCollector.calls != 1 || dependabotCollector.installationID != 101 || dependabotCollector.repository != "owner/private" {
+		t.Fatalf("unexpected dependabot collector call: calls=%d installation=%d repository=%q", dependabotCollector.calls, dependabotCollector.installationID, dependabotCollector.repository)
+	}
+	events, err := svc.ListScanEvents(ctx, record.ID, 40)
+	if err != nil {
+		t.Fatalf("list repo scan events: %v", err)
+	}
+	states := map[string]bool{}
+	for _, event := range events {
+		state, _ := event.Metadata["state"].(string)
+		if state != "" {
+			states[state] = true
+		}
+	}
+	for _, expected := range []string{scanLifecycleQueued, scanLifecycleRunning, scanLifecyclePartial, scanLifecycleSucceeded} {
+		if !states[expected] {
+			t.Fatalf("expected repo scan lifecycle state %q in events, got %+v", expected, states)
+		}
+	}
+	if !states[scanLifecyclePartial] {
+		t.Fatalf("expected partial lifecycle state when at least one source collector errors")
+	}
+	stored, err := svc.GetRepoScan(ctx, record.ID)
+	if err != nil {
+		t.Fatalf("get repo scan: %v", err)
+	}
+	if stored.FindingCount != 2 {
+		t.Fatalf("expected two imported alert findings, got %+v", stored)
+	}
+	findings, err := svc.ListRepoFindings(ctx, 10, db.RepoFindingFilter{RepoScanID: record.ID})
+	if err != nil {
+		t.Fatalf("list repo findings: %v", err)
+	}
+	var secretFinding, dependabotFinding *domain.Finding
+	for i := range findings {
+		switch findings[i].Type {
+		case domain.FindingSecretExposure:
+			secretFinding = &findings[i]
+		case domain.FindingRepoMisconfig:
+			dependabotFinding = &findings[i]
+		}
+	}
+	if secretFinding == nil {
+		t.Fatalf("expected an imported secret-exposure finding, got %+v", findings)
+	}
+	if secretFinding.Severity != domain.SeverityCritical || secretFinding.LineSnippetRedacted == nil || !*secretFinding.LineSnippetRedacted {
+		t.Fatalf("unexpected secret finding: %+v", secretFinding)
+	}
+	if got, _ := secretFinding.Evidence["raw_secret_stored"].(bool); got {
+		t.Fatalf("secret finding must not store raw secret: %+v", secretFinding.Evidence)
+	}
+	if dependabotFinding == nil {
+		t.Fatalf("expected an imported dependabot finding, got %+v", findings)
+	}
+	if dependabotFinding.Evidence["adapter_advisory_ghsa"] != "GHSA-xxxx-yyyy-zzzz" || dependabotFinding.Evidence["adapter_package"] != "django" {
+		t.Fatalf("unexpected dependabot finding evidence: %+v", dependabotFinding.Evidence)
 	}
 }
 

--- a/internal/connectors/github/dependabot.go
+++ b/internal/connectors/github/dependabot.go
@@ -1,0 +1,86 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// DependabotAlert is the subset of GitHub's Dependabot alert API needed to
+// normalize alerts into Identrail repo findings. None of these fields carry
+// secret material.
+type DependabotAlert struct {
+	Number                int                        `json:"number"`
+	State                 string                     `json:"state"`
+	Dependency            DependabotDependency       `json:"dependency"`
+	SecurityAdvisory      DependabotSecurityAdvisory `json:"security_advisory"`
+	SecurityVulnerability DependabotVulnerability    `json:"security_vulnerability"`
+	HTMLURL               string                     `json:"html_url"`
+	URL                   string                     `json:"url"`
+}
+
+type DependabotDependency struct {
+	Package      DependabotPackage `json:"package"`
+	ManifestPath string            `json:"manifest_path"`
+	Scope        string            `json:"scope"`
+}
+
+type DependabotPackage struct {
+	Ecosystem string `json:"ecosystem"`
+	Name      string `json:"name"`
+}
+
+type DependabotSecurityAdvisory struct {
+	GHSAID      string                       `json:"ghsa_id"`
+	CVEID       string                       `json:"cve_id"`
+	Summary     string                       `json:"summary"`
+	Severity    string                       `json:"severity"`
+	Identifiers []DependabotAdvisoryIdentity `json:"identifiers"`
+}
+
+type DependabotAdvisoryIdentity struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+type DependabotVulnerability struct {
+	Package                DependabotPackage      `json:"package"`
+	Severity               string                 `json:"severity"`
+	VulnerableVersionRange string                 `json:"vulnerable_version_range"`
+	FirstPatchedVersion    DependabotPatchVersion `json:"first_patched_version"`
+}
+
+type DependabotPatchVersion struct {
+	Identifier string `json:"identifier"`
+}
+
+// ListDependabotAlerts returns all open GitHub Dependabot alerts for a
+// repository. It follows GitHub pagination using the installation token.
+func (c RepositoryClient) ListDependabotAlerts(ctx context.Context, installationID int64, repository string) ([]DependabotAlert, error) {
+	if c.TokenClient == nil {
+		return nil, fmt.Errorf("github installation token client is required")
+	}
+	normalizedRepository, err := normalizeRepositoryName(repository)
+	if err != nil {
+		return nil, err
+	}
+	token, err := c.TokenClient.Mint(ctx, installationID)
+	if err != nil {
+		return nil, err
+	}
+	alerts := []DependabotAlert{}
+	endpoint := c.repositoryEndpoint(normalizedRepository, "/dependabot/alerts?state=open&per_page="+strconv.Itoa(defaultRepoPageLimit))
+	_, err = c.getJSONPages(ctx, token.Token, endpoint, func(body []byte) error {
+		var page []DependabotAlert
+		if err := json.Unmarshal(body, &page); err != nil {
+			return err
+		}
+		alerts = append(alerts, page...)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list github dependabot alerts: %w", err)
+	}
+	return alerts, nil
+}

--- a/internal/connectors/github/dependabot_test.go
+++ b/internal/connectors/github/dependabot_test.go
@@ -1,0 +1,109 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRepositoryClientListDependabotAlerts(t *testing.T) {
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.Header.Get("Authorization") != "Bearer inst-token" {
+			t.Fatalf("missing installation token")
+		}
+		if r.Header.Get("X-GitHub-Api-Version") != "2022-11-28" {
+			t.Fatalf("missing GitHub API version header")
+		}
+		switch calls {
+		case 1:
+			if r.URL.Path != "/repos/owner/repo/dependabot/alerts" {
+				t.Fatalf("unexpected path %s", r.URL.Path)
+			}
+			if r.URL.Query().Get("state") != "open" || r.URL.Query().Get("per_page") != "100" {
+				t.Fatalf("unexpected first page query %s", r.URL.RawQuery)
+			}
+			w.Header().Set("Link", fmt.Sprintf(`<%s/repos/owner/repo/dependabot/alerts?state=open&per_page=100&page=2>; rel="next"`, serverURLFromRequest(r)))
+			_, _ = w.Write([]byte(`[{
+				"number": 1,
+				"state": "open",
+				"dependency": {"package": {"ecosystem": "pip", "name": "django"}, "manifest_path": "requirements.txt", "scope": "runtime"},
+				"security_advisory": {
+					"ghsa_id": "GHSA-xxxx-yyyy-zzzz",
+					"cve_id": "CVE-2024-0001",
+					"summary": "SQL injection in django",
+					"severity": "high",
+					"identifiers": [{"type": "GHSA", "value": "GHSA-xxxx-yyyy-zzzz"}, {"type": "CVE", "value": "CVE-2024-0001"}]
+				},
+				"security_vulnerability": {
+					"package": {"ecosystem": "pip", "name": "django"},
+					"severity": "high",
+					"vulnerable_version_range": "< 4.2.1",
+					"first_patched_version": {"identifier": "4.2.1"}
+				},
+				"html_url": "https://github.com/owner/repo/security/dependabot/1"
+			}]`))
+		case 2:
+			if r.URL.Query().Get("page") != "2" {
+				t.Fatalf("unexpected second page query %s", r.URL.RawQuery)
+			}
+			_, _ = w.Write([]byte(`[{
+				"number": 2,
+				"state": "open",
+				"dependency": {"package": {"ecosystem": "npm", "name": "lodash"}, "manifest_path": "package.json"},
+				"security_advisory": {"ghsa_id": "GHSA-aaaa-bbbb-cccc", "severity": "critical"},
+				"security_vulnerability": {"severity": "critical", "vulnerable_version_range": "< 4.17.21"}
+			}]`))
+		default:
+			t.Fatalf("unexpected extra page")
+		}
+	}))
+	defer server.Close()
+
+	alerts, err := (RepositoryClient{
+		TokenClient: minter,
+		APIBaseURL:  server.URL,
+	}).ListDependabotAlerts(context.Background(), 456, "Owner/Repo")
+	if err != nil {
+		t.Fatalf("list dependabot alerts: %v", err)
+	}
+	if minter.seenInstallationID != 456 {
+		t.Fatalf("unexpected installation id %d", minter.seenInstallationID)
+	}
+	if len(alerts) != 2 {
+		t.Fatalf("expected two alerts, got %+v", alerts)
+	}
+	if alerts[0].Dependency.Package.Name != "django" || alerts[0].SecurityAdvisory.GHSAID != "GHSA-xxxx-yyyy-zzzz" {
+		t.Fatalf("unexpected first alert %+v", alerts[0])
+	}
+	if alerts[0].SecurityVulnerability.FirstPatchedVersion.Identifier != "4.2.1" {
+		t.Fatalf("expected fixed version, got %+v", alerts[0].SecurityVulnerability)
+	}
+	if alerts[1].Number != 2 || alerts[1].SecurityAdvisory.Severity != "critical" {
+		t.Fatalf("unexpected second alert %+v", alerts[1])
+	}
+}
+
+func TestRepositoryClientListDependabotAlertsErrors(t *testing.T) {
+	if _, err := (RepositoryClient{}).ListDependabotAlerts(context.Background(), 1, "owner/repo"); err == nil {
+		t.Fatal("expected missing token client error")
+	}
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	if _, err := (RepositoryClient{TokenClient: minter}).ListDependabotAlerts(context.Background(), 1, "not-a-repo"); err == nil || !strings.Contains(err.Error(), "owner/name") {
+		t.Fatalf("expected owner/name validation error, got %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"permission denied"}`, http.StatusForbidden)
+	}))
+	defer server.Close()
+	_, err := (RepositoryClient{TokenClient: minter, APIBaseURL: server.URL}).ListDependabotAlerts(context.Background(), 1, "owner/repo")
+	if err == nil || !strings.Contains(err.Error(), "status 403") {
+		t.Fatalf("expected status error, got %v", err)
+	}
+}

--- a/internal/connectors/github/secret_scanning.go
+++ b/internal/connectors/github/secret_scanning.go
@@ -1,0 +1,52 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// SecretScanningAlert is the GitHub API shape needed for repository finding
+// ingestion. The raw `secret` value GitHub returns is intentionally omitted so
+// the credential material is never deserialized, stored, logged, or returned.
+type SecretScanningAlert struct {
+	Number                int    `json:"number"`
+	State                 string `json:"state"`
+	SecretType            string `json:"secret_type"`
+	SecretTypeDisplayName string `json:"secret_type_display_name"`
+	Validity              string `json:"validity"`
+	Resolution            string `json:"resolution"`
+	PushProtectionBypass  bool   `json:"push_protection_bypassed"`
+	HTMLURL               string `json:"html_url"`
+}
+
+// ListSecretScanningAlerts returns all open GitHub secret-scanning alerts for a
+// repository. It follows GitHub pagination using the installation token.
+func (c RepositoryClient) ListSecretScanningAlerts(ctx context.Context, installationID int64, repository string) ([]SecretScanningAlert, error) {
+	if c.TokenClient == nil {
+		return nil, fmt.Errorf("github installation token client is required")
+	}
+	normalizedRepository, err := normalizeRepositoryName(repository)
+	if err != nil {
+		return nil, err
+	}
+	token, err := c.TokenClient.Mint(ctx, installationID)
+	if err != nil {
+		return nil, err
+	}
+	alerts := []SecretScanningAlert{}
+	endpoint := c.repositoryEndpoint(normalizedRepository, "/secret-scanning/alerts?state=open&per_page="+strconv.Itoa(defaultRepoPageLimit)+"&hide_secret=true")
+	_, err = c.getJSONPages(ctx, token.Token, endpoint, func(body []byte) error {
+		var page []SecretScanningAlert
+		if err := json.Unmarshal(body, &page); err != nil {
+			return err
+		}
+		alerts = append(alerts, page...)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list github secret scanning alerts: %w", err)
+	}
+	return alerts, nil
+}

--- a/internal/connectors/github/secret_scanning_test.go
+++ b/internal/connectors/github/secret_scanning_test.go
@@ -1,0 +1,97 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRepositoryClientListSecretScanningAlerts(t *testing.T) {
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.Header.Get("Authorization") != "Bearer inst-token" {
+			t.Fatalf("missing installation token")
+		}
+		if r.Header.Get("X-GitHub-Api-Version") != "2022-11-28" {
+			t.Fatalf("missing GitHub API version header")
+		}
+		switch calls {
+		case 1:
+			if r.URL.Path != "/repos/owner/repo/secret-scanning/alerts" {
+				t.Fatalf("unexpected path %s", r.URL.Path)
+			}
+			query := r.URL.Query()
+			if query.Get("state") != "open" || query.Get("per_page") != "100" || query.Get("hide_secret") != "true" {
+				t.Fatalf("unexpected first page query %s", r.URL.RawQuery)
+			}
+			w.Header().Set("Link", fmt.Sprintf(`<%s/repos/owner/repo/secret-scanning/alerts?state=open&per_page=100&page=2>; rel="next"`, serverURLFromRequest(r)))
+			_, _ = w.Write([]byte(`[{
+				"number": 1,
+				"state": "open",
+				"secret_type": "github_personal_access_token",
+				"secret_type_display_name": "GitHub Personal Access Token",
+				"secret": "placeholder_secret_value",
+				"validity": "active",
+				"html_url": "https://github.com/owner/repo/security/secret-scanning/1"
+			}]`))
+		case 2:
+			if r.URL.Query().Get("page") != "2" {
+				t.Fatalf("unexpected second page query %s", r.URL.RawQuery)
+			}
+			_, _ = w.Write([]byte(`[{
+				"number": 2,
+				"state": "open",
+				"secret_type": "aws_access_key_id",
+				"secret_type_display_name": "Amazon AWS Access Key ID",
+				"validity": "unknown"
+			}]`))
+		default:
+			t.Fatalf("unexpected extra page")
+		}
+	}))
+	defer server.Close()
+
+	alerts, err := (RepositoryClient{
+		TokenClient: minter,
+		APIBaseURL:  server.URL,
+	}).ListSecretScanningAlerts(context.Background(), 456, "Owner/Repo")
+	if err != nil {
+		t.Fatalf("list secret scanning alerts: %v", err)
+	}
+	if minter.seenInstallationID != 456 {
+		t.Fatalf("unexpected installation id %d", minter.seenInstallationID)
+	}
+	if len(alerts) != 2 {
+		t.Fatalf("expected two alerts, got %+v", alerts)
+	}
+	if alerts[0].SecretType != "github_personal_access_token" || alerts[0].Validity != "active" {
+		t.Fatalf("unexpected first alert %+v", alerts[0])
+	}
+	if alerts[1].Number != 2 || alerts[1].SecretType != "aws_access_key_id" {
+		t.Fatalf("unexpected second alert %+v", alerts[1])
+	}
+}
+
+func TestRepositoryClientListSecretScanningAlertsErrors(t *testing.T) {
+	if _, err := (RepositoryClient{}).ListSecretScanningAlerts(context.Background(), 1, "owner/repo"); err == nil {
+		t.Fatal("expected missing token client error")
+	}
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	if _, err := (RepositoryClient{TokenClient: minter}).ListSecretScanningAlerts(context.Background(), 1, "not-a-repo"); err == nil || !strings.Contains(err.Error(), "owner/name") {
+		t.Fatalf("expected owner/name validation error, got %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"permission denied"}`, http.StatusForbidden)
+	}))
+	defer server.Close()
+	_, err := (RepositoryClient{TokenClient: minter, APIBaseURL: server.URL}).ListSecretScanningAlerts(context.Background(), 1, "owner/repo")
+	if err == nil || !strings.Contains(err.Error(), "status 403") {
+		t.Fatalf("expected status error, got %v", err)
+	}
+}

--- a/internal/repoexposure/github_alert_adapters_test.go
+++ b/internal/repoexposure/github_alert_adapters_test.go
@@ -1,0 +1,241 @@
+package repoexposure
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+func TestGitHubSecretScanningAlertsNormalizeAndRedact(t *testing.T) {
+	alerts := []GitHubSecretScanningAlert{
+		{
+			Number:                3,
+			State:                 "open",
+			SecretType:            "github_personal_access_token",
+			SecretTypeDisplayName: "GitHub Personal Access Token",
+			Validity:              "active",
+			HTMLURL:               "https://github.com/owner/repo/security/secret-scanning/3",
+		},
+	}
+	findings, err := NormalizeGitHubSecretScanningAlerts(context.Background(), "owner/repo", "abc123", alerts, time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("normalize secret scanning alerts: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+	finding := findings[0]
+	if finding.Type != domain.FindingSecretExposure {
+		t.Fatalf("expected secret exposure finding, got %+v", finding)
+	}
+	if finding.Severity != domain.SeverityCritical {
+		t.Fatalf("expected active secret to map to critical, got %s", finding.Severity)
+	}
+	if finding.LineSnippet != redactedExternalSecretEvidence {
+		t.Fatalf("expected redacted snippet marker, got %q", finding.LineSnippet)
+	}
+	if finding.LineSnippetRedacted == nil || !*finding.LineSnippetRedacted {
+		t.Fatalf("expected redacted snippet flag, got %+v", finding.LineSnippetRedacted)
+	}
+	if finding.SourceURL != alerts[0].HTMLURL {
+		t.Fatalf("expected source url preserved, got %q", finding.SourceURL)
+	}
+	if got, _ := finding.Evidence["raw_secret_stored"].(bool); got {
+		t.Fatal("raw_secret_stored must be false")
+	}
+	if got, _ := finding.Evidence["secret_value_masked"].(bool); !got {
+		t.Fatalf("expected secret_value_masked flag, got %+v", finding.Evidence)
+	}
+	if got := finding.Evidence["adapter_secret_type"]; got != "github_personal_access_token" {
+		t.Fatalf("expected secret type evidence, got %v", got)
+	}
+	if got := finding.Evidence["adapter_source_type"]; got != adapterSourceGitHubSecretScanning {
+		t.Fatalf("expected adapter source type, got %v", got)
+	}
+}
+
+func TestGitHubSecretScanningSeverityMappingAndSkips(t *testing.T) {
+	cases := map[string]domain.FindingSeverity{
+		"active":   domain.SeverityCritical,
+		"inactive": domain.SeverityHigh,
+		"unknown":  domain.SeverityHigh,
+		"":         domain.SeverityHigh,
+	}
+	number := 1
+	for validity, want := range cases {
+		alerts := []GitHubSecretScanningAlert{{Number: number, State: "open", SecretType: "generic", Validity: validity}}
+		number++
+		findings, err := NormalizeGitHubSecretScanningAlerts(context.Background(), "owner/repo", "", alerts, time.Now())
+		if err != nil {
+			t.Fatalf("normalize (%q): %v", validity, err)
+		}
+		if len(findings) != 1 {
+			t.Fatalf("validity %q: expected one finding, got %d", validity, len(findings))
+		}
+		if findings[0].Severity != want {
+			t.Fatalf("validity %q: expected %s, got %s", validity, want, findings[0].Severity)
+		}
+	}
+
+	resolved := []GitHubSecretScanningAlert{{Number: 99, State: "resolved", SecretType: "generic"}}
+	findings, err := NormalizeGitHubSecretScanningAlerts(context.Background(), "owner/repo", "", resolved, time.Now())
+	if err != nil {
+		t.Fatalf("normalize resolved: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected resolved alerts to be skipped, got %d", len(findings))
+	}
+}
+
+func TestGitHubSecretScanningAlertsDedupe(t *testing.T) {
+	alert := GitHubSecretScanningAlert{Number: 5, State: "open", SecretType: "stripe_api_key", Validity: "active"}
+	findings, err := NormalizeGitHubSecretScanningAlerts(context.Background(), "owner/repo", "", []GitHubSecretScanningAlert{alert, alert}, time.Now())
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected duplicate alerts to collapse to one, got %d", len(findings))
+	}
+}
+
+func TestGitHubDependabotAlertsNormalizeEvidence(t *testing.T) {
+	alerts := []GitHubDependabotAlert{
+		{
+			Number: 7,
+			State:  "open",
+			Dependency: GitHubDependabotDependency{
+				Package:      GitHubDependabotPackage{Ecosystem: "pip", Name: "django"},
+				ManifestPath: "requirements.txt",
+				Scope:        "runtime",
+			},
+			SecurityAdvisory: GitHubDependabotAdvisory{
+				GHSAID:   "GHSA-xxxx-yyyy-zzzz",
+				CVEID:    "CVE-2024-0001",
+				Summary:  "SQL injection in django",
+				Severity: "high",
+				Identifiers: []GitHubDependabotAdvisoryIdentity{
+					{Type: "GHSA", Value: "GHSA-xxxx-yyyy-zzzz"},
+					{Type: "CVE", Value: "CVE-2024-0001"},
+				},
+			},
+			SecurityVulnerability: GitHubDependabotVulnerable{
+				Package:                GitHubDependabotPackage{Ecosystem: "pip", Name: "django"},
+				Severity:               "high",
+				VulnerableVersionRange: "< 4.2.1",
+				FirstPatchedVersion:    GitHubDependabotPatch{Identifier: "4.2.1"},
+			},
+			HTMLURL: "https://github.com/owner/repo/security/dependabot/7",
+		},
+	}
+	findings, err := NormalizeGitHubDependabotAlerts(context.Background(), "owner/repo", "abc123", alerts, time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("normalize dependabot alerts: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(findings))
+	}
+	finding := findings[0]
+	if finding.Type != domain.FindingRepoMisconfig || finding.Severity != domain.SeverityHigh {
+		t.Fatalf("unexpected dependabot finding classification: %+v", finding)
+	}
+	if finding.FilePath != "requirements.txt" {
+		t.Fatalf("expected manifest path as file path, got %q", finding.FilePath)
+	}
+	if finding.SourceURL != alerts[0].HTMLURL {
+		t.Fatalf("expected source url preserved, got %q", finding.SourceURL)
+	}
+	if got := finding.Evidence["adapter_ecosystem"]; got != "pip" {
+		t.Fatalf("expected ecosystem evidence, got %v", got)
+	}
+	if got := finding.Evidence["adapter_package"]; got != "django" {
+		t.Fatalf("expected package evidence, got %v", got)
+	}
+	if got := finding.Evidence["adapter_advisory_ghsa"]; got != "GHSA-xxxx-yyyy-zzzz" {
+		t.Fatalf("expected GHSA evidence, got %v", got)
+	}
+	if got := finding.Evidence["adapter_advisory_cve"]; got != "CVE-2024-0001" {
+		t.Fatalf("expected CVE evidence, got %v", got)
+	}
+	if got := finding.Evidence["adapter_vulnerable_range"]; got != "< 4.2.1" {
+		t.Fatalf("expected vulnerable range evidence, got %v", got)
+	}
+	if got := finding.Evidence["adapter_first_patched_version"]; got != "4.2.1" {
+		t.Fatalf("expected fixed version evidence, got %v", got)
+	}
+	identifiers, ok := finding.Evidence["adapter_advisory_identifiers"].([]string)
+	if !ok || len(identifiers) != 2 {
+		t.Fatalf("expected two advisory identifiers, got %+v", finding.Evidence["adapter_advisory_identifiers"])
+	}
+	if got, _ := finding.Evidence["raw_adapter_result_stored"].(bool); got {
+		t.Fatal("dependabot findings must not store raw external result payloads")
+	}
+	if !strings.Contains(finding.Remediation, "4.2.1") {
+		t.Fatalf("expected remediation to mention fixed version, got %q", finding.Remediation)
+	}
+}
+
+func TestGitHubDependabotSeverityMappingAndSkips(t *testing.T) {
+	cases := map[string]domain.FindingSeverity{
+		"critical": domain.SeverityCritical,
+		"high":     domain.SeverityHigh,
+		"moderate": domain.SeverityMedium,
+		"medium":   domain.SeverityMedium,
+		"low":      domain.SeverityLow,
+		"":         domain.SeverityMedium,
+	}
+	number := 1
+	for severity, want := range cases {
+		alerts := []GitHubDependabotAlert{{
+			Number:           number,
+			State:            "open",
+			Dependency:       GitHubDependabotDependency{Package: GitHubDependabotPackage{Ecosystem: "npm", Name: "pkg"}},
+			SecurityAdvisory: GitHubDependabotAdvisory{GHSAID: "GHSA-test", Severity: severity},
+		}}
+		number++
+		findings, err := NormalizeGitHubDependabotAlerts(context.Background(), "owner/repo", "", alerts, time.Now())
+		if err != nil {
+			t.Fatalf("normalize (%q): %v", severity, err)
+		}
+		if len(findings) != 1 {
+			t.Fatalf("severity %q: expected one finding, got %d", severity, len(findings))
+		}
+		if findings[0].Severity != want {
+			t.Fatalf("severity %q: expected %s, got %s", severity, want, findings[0].Severity)
+		}
+	}
+
+	for _, state := range []string{"fixed", "dismissed"} {
+		alerts := []GitHubDependabotAlert{{
+			Number:           500,
+			State:            state,
+			Dependency:       GitHubDependabotDependency{Package: GitHubDependabotPackage{Name: "pkg"}},
+			SecurityAdvisory: GitHubDependabotAdvisory{GHSAID: "GHSA-test", Severity: "high"},
+		}}
+		findings, err := NormalizeGitHubDependabotAlerts(context.Background(), "owner/repo", "", alerts, time.Now())
+		if err != nil {
+			t.Fatalf("normalize %q: %v", state, err)
+		}
+		if len(findings) != 0 {
+			t.Fatalf("expected %q alerts to be skipped, got %d", state, len(findings))
+		}
+	}
+}
+
+func TestGitHubDependabotAlertsDedupe(t *testing.T) {
+	alert := GitHubDependabotAlert{
+		Number:           11,
+		State:            "open",
+		Dependency:       GitHubDependabotDependency{Package: GitHubDependabotPackage{Ecosystem: "go", Name: "golang.org/x/net"}, ManifestPath: "go.mod"},
+		SecurityAdvisory: GitHubDependabotAdvisory{GHSAID: "GHSA-dup", Severity: "high"},
+	}
+	findings, err := NormalizeGitHubDependabotAlerts(context.Background(), "owner/repo", "", []GitHubDependabotAlert{alert, alert}, time.Now())
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected duplicate alerts to collapse to one, got %d", len(findings))
+	}
+}

--- a/internal/repoexposure/github_dependabot_adapter.go
+++ b/internal/repoexposure/github_dependabot_adapter.go
@@ -1,0 +1,280 @@
+package repoexposure
+
+import (
+	"context"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+const adapterSourceGitHubDependabot = "github_dependabot"
+
+// GitHubDependabotAlert is the subset of GitHub's Dependabot alert API needed to
+// normalize alerts into Identrail repo findings. None of these fields carry
+// secret material.
+type GitHubDependabotAlert struct {
+	Number                int                        `json:"number"`
+	State                 string                     `json:"state"`
+	Dependency            GitHubDependabotDependency `json:"dependency"`
+	SecurityAdvisory      GitHubDependabotAdvisory   `json:"security_advisory"`
+	SecurityVulnerability GitHubDependabotVulnerable `json:"security_vulnerability"`
+	HTMLURL               string                     `json:"html_url"`
+}
+
+type GitHubDependabotDependency struct {
+	Package      GitHubDependabotPackage `json:"package"`
+	ManifestPath string                  `json:"manifest_path"`
+	Scope        string                  `json:"scope"`
+}
+
+type GitHubDependabotPackage struct {
+	Ecosystem string `json:"ecosystem"`
+	Name      string `json:"name"`
+}
+
+type GitHubDependabotAdvisory struct {
+	GHSAID      string                             `json:"ghsa_id"`
+	CVEID       string                             `json:"cve_id"`
+	Summary     string                             `json:"summary"`
+	Severity    string                             `json:"severity"`
+	Identifiers []GitHubDependabotAdvisoryIdentity `json:"identifiers"`
+}
+
+type GitHubDependabotAdvisoryIdentity struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+type GitHubDependabotVulnerable struct {
+	Package                GitHubDependabotPackage `json:"package"`
+	Severity               string                  `json:"severity"`
+	VulnerableVersionRange string                  `json:"vulnerable_version_range"`
+	FirstPatchedVersion    GitHubDependabotPatch   `json:"first_patched_version"`
+}
+
+type GitHubDependabotPatch struct {
+	Identifier string `json:"identifier"`
+}
+
+// GitHubDependabotAlertAdapter imports GitHub Dependabot alerts that were
+// already fetched through the GitHub App connector.
+type GitHubDependabotAlertAdapter struct {
+	alerts []GitHubDependabotAlert
+}
+
+func NewGitHubDependabotAlertAdapter(alerts []GitHubDependabotAlert) GitHubDependabotAlertAdapter {
+	return GitHubDependabotAlertAdapter{alerts: append([]GitHubDependabotAlert(nil), alerts...)}
+}
+
+func (a GitHubDependabotAlertAdapter) Name() string {
+	return adapterSourceGitHubDependabot
+}
+
+func (a GitHubDependabotAlertAdapter) Version() string {
+	return externalAdapterVersion
+}
+
+func (a GitHubDependabotAlertAdapter) Findings(ctx context.Context, input ExternalAdapterInput) ([]domain.Finding, error) {
+	return NormalizeGitHubDependabotAlerts(ctx, input.Repository, input.Commit, a.alerts, input.DetectedAt)
+}
+
+// NormalizeGitHubDependabotAlerts converts GitHub Dependabot vulnerability
+// alerts into repository findings with non-secret package, advisory, and
+// severity evidence.
+func NormalizeGitHubDependabotAlerts(ctx context.Context, repository string, commit string, alerts []GitHubDependabotAlert, detectedAt time.Time) ([]domain.Finding, error) {
+	findings := []domain.Finding{}
+	seen := map[string]struct{}{}
+	for _, alert := range alerts {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		finding, ok := githubDependabotAlertToFinding(repository, commit, alert, detectedAt)
+		if !ok {
+			continue
+		}
+		duplicate := false
+		for _, key := range repoFindingDedupeKeys(finding) {
+			if _, exists := seen[key]; exists {
+				duplicate = true
+				break
+			}
+		}
+		if duplicate {
+			continue
+		}
+		findings = append(findings, finding)
+		for _, key := range repoFindingDedupeKeys(finding) {
+			seen[key] = struct{}{}
+		}
+	}
+	return findings, nil
+}
+
+func githubDependabotAlertToFinding(repository string, commit string, alert GitHubDependabotAlert, detectedAt time.Time) (domain.Finding, bool) {
+	if strings.EqualFold(strings.TrimSpace(alert.State), "fixed") || strings.EqualFold(strings.TrimSpace(alert.State), "dismissed") {
+		return domain.Finding{}, false
+	}
+	ecosystem := firstNonEmpty(alert.Dependency.Package.Ecosystem, alert.SecurityVulnerability.Package.Ecosystem)
+	packageName := firstNonEmpty(alert.Dependency.Package.Name, alert.SecurityVulnerability.Package.Name)
+	ghsaID := strings.TrimSpace(alert.SecurityAdvisory.GHSAID)
+	cveID := strings.TrimSpace(alert.SecurityAdvisory.CVEID)
+	advisoryID := firstNonEmpty(ghsaID, cveID, strconv.Itoa(alert.Number))
+	if packageName == "" && advisoryID == "" {
+		return domain.Finding{}, false
+	}
+	manifest := normalizeAdapterPath(alert.Dependency.ManifestPath)
+	ruleID := strings.ToLower(strings.Join(nonEmptyStrings(ecosystem, packageName, advisoryID), ":"))
+	detector := adapterDetectorID(adapterSourceGitHubDependabot, firstNonEmpty(ecosystem, "dependabot"), advisoryID)
+	severity, severitySource := githubDependabotSeverity(alert)
+	confidence := githubDependabotConfidence(alert)
+	fixedVersion := strings.TrimSpace(alert.SecurityVulnerability.FirstPatchedVersion.Identifier)
+	vulnerableRange := strings.TrimSpace(alert.SecurityVulnerability.VulnerableVersionRange)
+	summary := sanitizeAdapterText(firstNonEmpty(alert.SecurityAdvisory.Summary, "GitHub Dependabot reported a vulnerable dependency."))
+
+	titlePackage := firstNonEmpty(packageName, advisoryID, "dependency")
+	title := "Vulnerable dependency: " + titlePackage
+	if advisoryID != "" && advisoryID != titlePackage {
+		title += " (" + advisoryID + ")"
+	}
+	remediation := "Review the GitHub Dependabot advisory and upgrade the affected dependency."
+	if fixedVersion != "" {
+		remediation = "Upgrade " + firstNonEmpty(packageName, "the affected dependency") + " to " + fixedVersion + " or later, then re-run the scan."
+	}
+
+	dedupeKey := strings.Join([]string{
+		adapterSourceGitHubDependabot,
+		strings.ToLower(strings.TrimSpace(repository)),
+		strings.ToLower(ruleID),
+		manifest,
+		strconv.Itoa(alert.Number),
+	}, "|")
+
+	evidence := map[string]any{
+		"repository":                   repository,
+		"detector":                     detector,
+		"adapter_name":                 adapterSourceGitHubDependabot,
+		"adapter_version":              externalAdapterVersion,
+		"adapter_source_type":          adapterSourceGitHubDependabot,
+		"adapter_tool_name":            "github-dependabot",
+		"adapter_rule_id":              ruleID,
+		"adapter_rule_name":            summary,
+		"adapter_alert_number":         alert.Number,
+		"adapter_alert_state":          strings.TrimSpace(alert.State),
+		"adapter_ecosystem":            ecosystem,
+		"adapter_package":              packageName,
+		"adapter_dependency_scope":     strings.TrimSpace(alert.Dependency.Scope),
+		"adapter_advisory_ghsa":        ghsaID,
+		"adapter_advisory_cve":         cveID,
+		"adapter_advisory_severity":    strings.ToLower(strings.TrimSpace(firstNonEmpty(alert.SecurityAdvisory.Severity, alert.SecurityVulnerability.Severity))),
+		"adapter_advisory_identifiers": githubDependabotIdentifiers(alert.SecurityAdvisory.Identifiers),
+		"adapter_confidence":           confidence,
+		"adapter_confidence_source":    "github_dependabot_advisory",
+		"adapter_severity_source":      severitySource,
+		"adapter_dedupe_key":           dedupeKey,
+		"history_source":               externalAdapterHistorySource,
+		"raw_secret_stored":            false,
+		"raw_adapter_result_stored":    false,
+	}
+	if manifest != "" {
+		evidence["adapter_manifest_path"] = manifest
+		evidence["file_path"] = manifest
+	}
+	if vulnerableRange != "" {
+		evidence["adapter_vulnerable_range"] = vulnerableRange
+	}
+	if fixedVersion != "" {
+		evidence["adapter_first_patched_version"] = fixedVersion
+	}
+	if commit != "" {
+		evidence["commit"] = commit
+	}
+	if alert.HTMLURL != "" {
+		evidence["adapter_alert_url"] = alert.HTMLURL
+	}
+
+	id := "finding:" + hashDeterministicID(
+		"repo-adapter",
+		adapterSourceGitHubDependabot,
+		repository,
+		strconv.Itoa(alert.Number),
+		ruleID,
+		manifest,
+	)
+	finding := domain.Finding{
+		ID:              id,
+		Type:            domain.FindingRepoMisconfig,
+		Severity:        severity,
+		ConfidenceScore: confidence,
+		Title:           title,
+		HumanSummary:    summary,
+		Repository:      repository,
+		Commit:          commit,
+		Detector:        detector,
+		SourceURL:       strings.TrimSpace(alert.HTMLURL),
+		Evidence:        evidence,
+		Remediation:     remediation,
+		CreatedAt:       detectedAt,
+	}
+	if manifest != "" {
+		finding.FilePath = manifest
+		finding.Path = []string{manifest}
+	}
+	return finding, true
+}
+
+func githubDependabotIdentifiers(identifiers []GitHubDependabotAdvisoryIdentity) []string {
+	values := make([]string, 0, len(identifiers))
+	seen := map[string]struct{}{}
+	for _, identifier := range identifiers {
+		value := strings.TrimSpace(identifier.Value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		values = append(values, value)
+	}
+	sort.Strings(values)
+	return values
+}
+
+func githubDependabotSeverity(alert GitHubDependabotAlert) (domain.FindingSeverity, string) {
+	severity := strings.ToLower(strings.TrimSpace(alert.SecurityAdvisory.Severity))
+	source := "advisory_severity"
+	if severity == "" {
+		severity = strings.ToLower(strings.TrimSpace(alert.SecurityVulnerability.Severity))
+		source = "vulnerability_severity"
+	}
+	switch severity {
+	case "critical":
+		return domain.SeverityCritical, source
+	case "high":
+		return domain.SeverityHigh, source
+	case "medium", "moderate":
+		return domain.SeverityMedium, source
+	case "low":
+		return domain.SeverityLow, source
+	default:
+		return domain.SeverityMedium, "default"
+	}
+}
+
+func githubDependabotConfidence(alert GitHubDependabotAlert) float64 {
+	switch strings.ToLower(strings.TrimSpace(firstNonEmpty(alert.SecurityAdvisory.Severity, alert.SecurityVulnerability.Severity))) {
+	case "critical", "high":
+		return 0.95
+	case "medium", "moderate":
+		return 0.85
+	case "low":
+		return 0.75
+	default:
+		return 0.80
+	}
+}
+
+var _ ExternalFindingAdapter = GitHubDependabotAlertAdapter{}

--- a/internal/repoexposure/github_secret_scanning_adapter.go
+++ b/internal/repoexposure/github_secret_scanning_adapter.go
@@ -1,0 +1,184 @@
+package repoexposure
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+const adapterSourceGitHubSecretScanning = "github_secret_scanning"
+
+// GitHubSecretScanningAlert is the subset of GitHub's secret-scanning alert API
+// needed to normalize alerts into Identrail repo findings. The raw secret value
+// is intentionally absent: it is never fetched, deserialized, or stored.
+type GitHubSecretScanningAlert struct {
+	Number                int    `json:"number"`
+	State                 string `json:"state"`
+	SecretType            string `json:"secret_type"`
+	SecretTypeDisplayName string `json:"secret_type_display_name"`
+	Validity              string `json:"validity"`
+	Resolution            string `json:"resolution"`
+	PushProtectionBypass  bool   `json:"push_protection_bypassed"`
+	HTMLURL               string `json:"html_url"`
+}
+
+// GitHubSecretScanningAlertAdapter imports GitHub secret-scanning alerts that
+// were already fetched through the GitHub App connector.
+type GitHubSecretScanningAlertAdapter struct {
+	alerts []GitHubSecretScanningAlert
+}
+
+func NewGitHubSecretScanningAlertAdapter(alerts []GitHubSecretScanningAlert) GitHubSecretScanningAlertAdapter {
+	return GitHubSecretScanningAlertAdapter{alerts: append([]GitHubSecretScanningAlert(nil), alerts...)}
+}
+
+func (a GitHubSecretScanningAlertAdapter) Name() string {
+	return adapterSourceGitHubSecretScanning
+}
+
+func (a GitHubSecretScanningAlertAdapter) Version() string {
+	return externalAdapterVersion
+}
+
+func (a GitHubSecretScanningAlertAdapter) Findings(ctx context.Context, input ExternalAdapterInput) ([]domain.Finding, error) {
+	return NormalizeGitHubSecretScanningAlerts(ctx, input.Repository, input.Commit, a.alerts, input.DetectedAt)
+}
+
+// NormalizeGitHubSecretScanningAlerts converts GitHub secret-scanning alerts
+// into redacted secret-exposure repo findings. No raw secret material is ever
+// stored: the snippet is a redacted marker and only the secret type label,
+// validity, and alert metadata are kept as evidence.
+func NormalizeGitHubSecretScanningAlerts(ctx context.Context, repository string, commit string, alerts []GitHubSecretScanningAlert, detectedAt time.Time) ([]domain.Finding, error) {
+	findings := []domain.Finding{}
+	seen := map[string]struct{}{}
+	for _, alert := range alerts {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		finding, ok := githubSecretScanningAlertToFinding(repository, commit, alert, detectedAt)
+		if !ok {
+			continue
+		}
+		duplicate := false
+		for _, key := range repoFindingDedupeKeys(finding) {
+			if _, exists := seen[key]; exists {
+				duplicate = true
+				break
+			}
+		}
+		if duplicate {
+			continue
+		}
+		findings = append(findings, finding)
+		for _, key := range repoFindingDedupeKeys(finding) {
+			seen[key] = struct{}{}
+		}
+	}
+	return findings, nil
+}
+
+func githubSecretScanningAlertToFinding(repository string, commit string, alert GitHubSecretScanningAlert, detectedAt time.Time) (domain.Finding, bool) {
+	if strings.EqualFold(strings.TrimSpace(alert.State), "resolved") {
+		return domain.Finding{}, false
+	}
+	secretType := strings.TrimSpace(alert.SecretType)
+	displayName := firstNonEmpty(alert.SecretTypeDisplayName, secretType, "secret")
+	ruleID := firstNonEmpty(secretType, strconv.Itoa(alert.Number), "unknown")
+	detector := adapterDetectorID(adapterSourceGitHubSecretScanning, "github-secret-scanning", ruleID)
+	validity := strings.ToLower(strings.TrimSpace(alert.Validity))
+	severity, severitySource := githubSecretScanningSeverity(validity)
+	confidence := githubSecretScanningConfidence(validity)
+	dedupeKey := strings.Join([]string{
+		adapterSourceGitHubSecretScanning,
+		strings.ToLower(strings.TrimSpace(repository)),
+		strings.ToLower(ruleID),
+		strconv.Itoa(alert.Number),
+	}, "|")
+
+	evidence := map[string]any{
+		"repository":                repository,
+		"line_snippet":              redactedExternalSecretEvidence,
+		"line_snippet_redacted":     true,
+		"detector":                  detector,
+		"adapter_name":              adapterSourceGitHubSecretScanning,
+		"adapter_version":           externalAdapterVersion,
+		"adapter_source_type":       adapterSourceGitHubSecretScanning,
+		"adapter_tool_name":         "github-secret-scanning",
+		"adapter_rule_id":           ruleID,
+		"adapter_rule_name":         displayName,
+		"adapter_secret_type":       secretType,
+		"adapter_alert_number":      alert.Number,
+		"adapter_alert_state":       strings.TrimSpace(alert.State),
+		"adapter_secret_validity":   validity,
+		"adapter_confidence":        confidence,
+		"adapter_confidence_source": "github_secret_scanning_validity",
+		"adapter_severity_source":   severitySource,
+		"adapter_dedupe_key":        dedupeKey,
+		"adapter_message_redacted":  true,
+		"history_source":            externalAdapterHistorySource,
+		"raw_secret_stored":         false,
+		"secret_value_masked":       true,
+		"raw_adapter_result_stored": false,
+	}
+	if commit != "" {
+		evidence["commit"] = commit
+	}
+	if strings.TrimSpace(alert.Resolution) != "" {
+		evidence["adapter_alert_resolution"] = strings.TrimSpace(alert.Resolution)
+	}
+	if alert.PushProtectionBypass {
+		evidence["adapter_push_protection_bypassed"] = true
+	}
+	if alert.HTMLURL != "" {
+		evidence["adapter_alert_url"] = alert.HTMLURL
+	}
+
+	id := "finding:" + hashDeterministicID(
+		"repo-adapter",
+		adapterSourceGitHubSecretScanning,
+		repository,
+		strconv.Itoa(alert.Number),
+		ruleID,
+	)
+	return domain.Finding{
+		ID:                  id,
+		Type:                domain.FindingSecretExposure,
+		Severity:            severity,
+		ConfidenceScore:     confidence,
+		Title:               "GitHub secret scanning: " + displayName,
+		HumanSummary:        "GitHub secret scanning reported an open secret-exposure alert; raw secret material was not stored.",
+		Path:                nil,
+		Repository:          repository,
+		Commit:              commit,
+		Detector:            detector,
+		LineSnippet:         redactedExternalSecretEvidence,
+		LineSnippetRedacted: boolPtr(true),
+		SourceURL:           strings.TrimSpace(alert.HTMLURL),
+		Evidence:            evidence,
+		Remediation:         "Rotate and revoke the exposed credential, then remove it from repository history where needed and move it to a secret manager.",
+		CreatedAt:           detectedAt,
+	}, true
+}
+
+func githubSecretScanningSeverity(validity string) (domain.FindingSeverity, string) {
+	switch validity {
+	case "active":
+		return domain.SeverityCritical, "secret_scanning_validity"
+	case "inactive":
+		return domain.SeverityHigh, "secret_scanning_validity"
+	default:
+		return domain.SeverityHigh, "default"
+	}
+}
+
+func githubSecretScanningConfidence(validity string) float64 {
+	if validity == "active" {
+		return 0.99
+	}
+	return 0.90
+}
+
+var _ ExternalFindingAdapter = GitHubSecretScanningAlertAdapter{}

--- a/internal/runtime/service_builder.go
+++ b/internal/runtime/service_builder.go
@@ -143,6 +143,8 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 	svc.GitHubRepositoryLister = repositoryClient
 	svc.GitHubRepositoryPostureCollector = repositoryClient
 	svc.GitHubCodeScanningAlertCollector = repositoryClient
+	svc.GitHubSecretScanningAlertCollector = repositoryClient
+	svc.GitHubDependabotAlertCollector = repositoryClient
 	svc.GitHubInstallationTokenMinter = tokenClient
 	svc.AWSScannerFactory = func(ctx context.Context, connection api.AWSConnectionStatus) (api.ScannerRunner, error) {
 		iamAPI, iamErr := awsprovider.NewSDKIAMAPIFromAssumeRole(ctx, connection.Region, cfg.AWSProfile, connection.RoleARN, connection.ExternalID, "identrail-recurring-scan")


### PR DESCRIPTION
## Summary

Describe what changed.

## Why

Describe the problem this PR solves.

## Scope

- [ ] Focused change (no unrelated modifications)
- [ ] Backward compatibility considered
- [ ] Risk level assessed

## Validation

List the checks you ran and their outcomes.

```bash
# Example:
# go test ./...
# npm run test:ci --prefix web
```

## Checklist

- [ ] Tests added/updated for behavior changes
- [ ] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [ ] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

If AI tools were used materially for this PR, complete the fields below.

- AI-assisted: yes/no
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Required for this repository size:

- Include at least one issue reference using closing/reference keywords:
  - `Closes #123`, `Fixes #123`, or `Refs #123`
- If no issue exists, include an explicit exemption with rationale:
  - `No issue: <reason>` (for example: docs-only typo fix, CI-only fix, or emergency hotfix)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Import open GitHub secret-scanning and Dependabot alerts as first-class repository findings during GitHub App-backed repo scans, alongside existing code-scanning import. Alerts are redacted, deduped, and collected independently so missing permissions or API errors no longer fail scans.

- New Features
  - Secret-scanning import → redacted `secret_exposure` findings; no raw secret is fetched or stored; includes type, validity, and alert URL.
  - Dependabot import → repository findings with ecosystem, package, GHSA/CVE, vulnerable range, first patched version, and alert URL; severity mapped from advisory.
  - Each source is independent enrichment; permission-limited, unavailable, or rate-limited endpoints don’t fail the scan. Partial source errors are recorded and the scan completes.
  - Deterministic dedupe across scans; consistent finding IDs and evidence.
  - Docs updated to clarify posture vs imported alerts and redaction guarantees; extensive tests added.
  - Uses read-only GitHub App permissions: `security_events`, `secret_scanning_alerts`, `vulnerability_alerts`.

<sup>Written for commit df20cae86384edf0196c0c2d154cae01ea0f082c. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1339?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

