### PR TITLE
Allow selected GitHub App repositories to queue scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Let GitHub App-backed project scans use the app installation's selected
+  repository list as the scoped target guard, so personal and organization repos
+  selected in GitHub no longer require a per-repo deployment allowlist update
+  before the first scan can be queued.
 - Ingest open GitHub secret-scanning and Dependabot vulnerability alerts as
   first-class repository findings during GitHub App-backed repo scans, alongside
   the existing code-scanning import. Secret-scanning alerts become redacted

--- a/docs/auth/github-connector.md
+++ b/docs/auth/github-connector.md
@@ -125,9 +125,8 @@ operator sees a specific setup problem.
 
 Personal repositories and organization repositories follow the same completion
 path. After callback, Identrail lists repositories selected for that
-installation and accepts any `owner/repo` in the selected list, subject to the
-hosted repo scan allowlist described below. A repository that was not selected
-during installation or was not allowlisted should produce a targeted product
+installation and accepts any `owner/repo` in the selected list. A repository
+that was not selected during installation should produce a targeted product
 message instead of a generic 404.
 
 ## GitHub Enterprise Fallback
@@ -142,19 +141,19 @@ This fallback is for self-hosted GitHub Enterprise and development environments.
 
 `POST /auth/webhooks/github` verifies the global GitHub App HMAC secret before processing events.
 
-Installation lifecycle events can mark matching connectors disconnected. Repository events are matched by installation ID and repository allowlist before queueing scans.
+Installation lifecycle events can mark matching connectors disconnected. Repository events are matched by installation ID and the GitHub App selected-repository list before queueing scans.
 
-Webhook-triggered scans still honor the repo scan allowlist, per-repository
-cursor, and queue controls. Push and pull-request events enqueue `delta` scans
-when GitHub supplies a usable head revision. Push events use `before` and
-`after` as the base/head revisions and fold commit `added`, `modified`, and
-`removed` paths into the scan request. Duplicate delivery IDs, burst-window
-repeats, queue pressure, disabled scanning, target-deny decisions, and
-already-current cursors are recorded as skipped work instead of creating
+Webhook-triggered scans still honor the GitHub App selected-repository guard,
+per-repository cursor, and queue controls. Push and pull-request events enqueue
+`delta` scans when GitHub supplies a usable head revision. Push events use
+`before` and `after` as the base/head revisions and fold commit `added`,
+`modified`, and `removed` paths into the scan request. Duplicate delivery IDs,
+burst-window repeats, queue pressure, disabled scanning, target-deny decisions,
+and already-current cursors are recorded as skipped work instead of creating
 unbounded duplicate queue entries.
-Before enabling `IDENTRAIL_REPO_SCAN_ENABLED=true` for hosted production, set an
-explicit `IDENTRAIL_REPO_SCAN_ALLOWLIST` or equivalent scoped target guard so a
-GitHub webhook cannot enqueue scans outside approved repositories.
+Before enabling direct API or worker repo scans for hosted production, set an
+explicit `IDENTRAIL_REPO_SCAN_ALLOWLIST`. GitHub App-backed scans use the
+per-installation selected repository list as their scoped target guard.
 For the AWS-hosted API workflow, use the first-class repository variables
 `API_REPO_SCAN_ENABLED=true` and `API_REPO_SCAN_ALLOWLIST=<owner/repo>` instead
 of hiding the same runtime values inside `API_EXTRA_ENVIRONMENT_JSON`.
@@ -164,8 +163,8 @@ of hiding the same runtime values inside `API_EXTRA_ENVIRONMENT_JSON`.
 GitHub App connections can now back private repository exposure scans. When a
 repo scan request includes `project_id`, Identrail verifies that the scoped
 project has an active GitHub App connection, that the requested repository is in
-the selected repository list, and that the normal repo-scan allowlist still
-permits the target.
+the selected repository list, and that the scan source matches the stored
+connector context.
 
 Queued scans store only non-secret source metadata: provider, project id,
 connector id, and installation id. The API and worker never store the raw

--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -74,8 +74,9 @@ curl -X POST http://localhost:8080/v1/repo-scans \
 ```
 
 Connector-backed scans require the repository to be selected on the project's
-GitHub App connection and still honor `IDENTRAIL_REPO_SCAN_ALLOWLIST`, queue
-capacity, and per-repository concurrency controls.
+GitHub App connection and still honor queue capacity and per-repository
+concurrency controls. Direct non-connector scans continue to use
+`IDENTRAIL_REPO_SCAN_ALLOWLIST` for their target guard.
 
 Read APIs:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -40,9 +40,10 @@ Checks:
 
 Checks:
 1. `IDENTRAIL_REPO_SCAN_ENABLED=true`.
-2. `IDENTRAIL_REPO_SCAN_ALLOWLIST` is set and includes the target.
-3. API target is remote (`owner/repo`, `https://...`, or `ssh://...`) and not a local filesystem path.
-4. Request uses write-authorized API key/scope.
+2. For GitHub App-backed project scans, the repository is selected on that project's GitHub App installation.
+3. For direct non-connector scans, `IDENTRAIL_REPO_SCAN_ALLOWLIST` is set and includes the target.
+4. API target is remote (`owner/repo`, `https://...`, or `ssh://...`) and not a local filesystem path.
+5. Request uses write-authorized API key/scope.
 
 ## GitHub Action says missing `VITE_IDENTRAIL_API_URL`
 

--- a/internal/api/scan_policy_scheduler_test.go
+++ b/internal/api/scan_policy_scheduler_test.go
@@ -244,9 +244,14 @@ func TestEnqueueDueScanPolicyCountsInProgressRepoTowardConcurrency(t *testing.T)
 	}
 }
 
-func TestEnqueueDueScanPolicyDoesNotCountDisallowedRepoTowardConcurrency(t *testing.T) {
+func TestEnqueueDueScanPolicyDoesNotCountDisallowedPATRepoTowardConcurrency(t *testing.T) {
 	now := time.Date(2026, 5, 12, 12, 5, 0, 0, time.UTC)
 	svc, store, ctx := newScanPolicySchedulerTestService(t, now, []string{"owner/repo-a", "owner/repo-b"})
+	connection := svc.githubConnections[githubConnectionKey("default", "default", "project-1")]
+	connection.Provider = "github_pat"
+	connection.ConnectorID = "pat-connector"
+	connection.InstallationID = 0
+	svc.githubConnections[githubConnectionKey("default", "default", "project-1")] = connection
 	svc.RepoScanAllowedTargets = []string{"owner/repo-b"}
 
 	upsertTestScanPolicy(t, store, ctx, now.Add(-time.Hour), 1)

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1434,10 +1434,6 @@ func (s *Service) validateRepoScanRequest(ctx context.Context, request RepoScanR
 			return "", db.RepoScanSource{}, db.RepoScanContext{}, 0, 0, err
 		}
 
-		if !repoTargetAllowed(target, s.RepoScanAllowedTargets) {
-			s.recordServiceAuthzDenial(ctx, "repo_scans.run", "repo_scan_target", target)
-			return "", db.RepoScanSource{}, db.RepoScanContext{}, 0, 0, ErrRepoTargetNotAllowed
-		}
 		return target, source, scanContext, historyLimit, maxFindings, nil
 	}
 	if !repoTargetAllowed(target, s.RepoScanAllowedTargets) {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -4248,6 +4248,33 @@ func TestServiceEnqueueRepoScanWithGitHubAppSourceCanonicalizesGitHubTarget(t *t
 	}
 }
 
+func TestServiceEnqueueRepoScanWithGitHubAppSourceUsesSelectedRepositoriesAsTargetGuard(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	ctx := defaultScopeContext()
+	seedDefaultProject(t, store, ctx, "project-1")
+	seedGitHubAppConnection(t, svc, ctx, "project-1", 101, []string{"Oluwatobi-Mustapha/iam-fuzzer"})
+
+	record, err := svc.EnqueueRepoScan(ctx, RepoScanRequest{
+		Repository: "oluwatobi-mustapha/iam-fuzzer",
+		ProjectID:  "project-1",
+	})
+	if err != nil {
+		t.Fatalf("expected selected GitHub App repository to queue without global repo scan allowlist: %v", err)
+	}
+	if record.Repository != "oluwatobi-mustapha/iam-fuzzer" || record.Source.Provider != "github_app" {
+		t.Fatalf("expected connector-backed scan for selected repository, got %+v", record)
+	}
+
+	_, err = svc.EnqueueRepoScan(ctx, RepoScanRequest{
+		Repository: "oluwatobi-mustapha/other",
+		ProjectID:  "project-1",
+	})
+	if !errors.Is(err, ErrRepoTargetNotAllowed) {
+		t.Fatalf("expected unselected GitHub App repository to remain denied, got %v", err)
+	}
+}
+
 func TestServiceEnqueueRepoScanUnknownProjectIDIsInvalidRequest(t *testing.T) {
 	store := db.NewMemoryStore()
 	svc := NewService(store, fakeScanner{}, "aws")

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -693,7 +693,7 @@ describe('ProductProjectDetailPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: /Queue first scan/i })).not.toBeDisabled());
   });
 
-  it('explains selected-repository failures when the first repository scan is not permitted', async () => {
+  it('explains selected-repository and allowlist failures when the first repository scan is not permitted', async () => {
     const { runRepoScan } = await renderProjectDetail(true, connectedGitHub, {
       repoScanError: { message: 'repo target not allowed', status: 403 }
     });
@@ -704,8 +704,9 @@ describe('ProductProjectDetailPage', () => {
 
     await waitFor(() => expect(runRepoScan).toHaveBeenCalled());
     expect(
-      await screen.findByText(/not selected for this project's GitHub App installation/i)
+      await screen.findByText(/select it during installation and refresh status/i)
     ).toBeInTheDocument();
+    expect(screen.getByText(/ask an operator to allow that owner\/repo target/i)).toBeInTheDocument();
   });
 });
 

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -693,7 +693,7 @@ describe('ProductProjectDetailPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: /Queue first scan/i })).not.toBeDisabled());
   });
 
-  it('explains allowlist failures when the first repository scan is not permitted', async () => {
+  it('explains selected-repository failures when the first repository scan is not permitted', async () => {
     const { runRepoScan } = await renderProjectDetail(true, connectedGitHub, {
       repoScanError: { message: 'repo target not allowed', status: 403 }
     });
@@ -704,7 +704,7 @@ describe('ProductProjectDetailPage', () => {
 
     await waitFor(() => expect(runRepoScan).toHaveBeenCalled());
     expect(
-      await screen.findByText(/not currently allowed for this project/i)
+      await screen.findByText(/not selected for this project's GitHub App installation/i)
     ).toBeInTheDocument();
   });
 });

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -694,7 +694,7 @@ function formatRepoScanSubmitError(error: unknown): string {
       return 'Choose a valid owner/repo repository target before queueing a scan.';
     }
     if (error.status === 403) {
-      return "That repository is not selected for this project's GitHub App installation. Add it in GitHub, refresh status, then queue the scan again.";
+      return "That repository is not allowed for this project. For GitHub App sources, select it during installation and refresh status; for PAT-backed scans, ask an operator to allow that owner/repo target.";
     }
     if (error.status === 409) {
       return 'A scan is already queued or running for this repository. Watch recent scan activity below.';

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -694,7 +694,7 @@ function formatRepoScanSubmitError(error: unknown): string {
       return 'Choose a valid owner/repo repository target before queueing a scan.';
     }
     if (error.status === 403) {
-      return 'That repository is not currently allowed for this project. Choose a repository selected during GitHub App installation, or ask an operator to allow that owner/repo target.';
+      return "That repository is not selected for this project's GitHub App installation. Add it in GitHub, refresh status, then queue the scan again.";
     }
     if (error.status === 409) {
       return 'A scan is already queued or running for this repository. Watch recent scan activity below.';


### PR DESCRIPTION
Fixes #1342

## What changed
- Treat the GitHub App installation selected-repository list as the scoped target guard for project-scoped GitHub App repo scans.
- Keep the deployment repo-scan allowlist on direct non-connector scans and PAT/direct scheduled scan paths.
- Update the first-scan error copy so users are sent back to GitHub repository selection instead of being told to ask an operator for per-repo allowlisting.
- Update docs and the changelog to match the new behavior.

## Why
Users who install Identrail on a personal or organization repository should be able to queue the first scan for that selected repository without a separate operator env-var change. The previous flow passed the GitHub App selected-repo check and then failed the deployment-wide allowlist check, which produced the confusing `repo target not allowed` message.

## Validation
- `go test ./internal/api -run 'TestServiceEnqueueRepoScanWithGitHubAppSource|TestEnqueueDueScanPolicyDoesNotCountDisallowedPATRepoTowardConcurrency|TestRepositorySelected|TestRepoTargetAllowed' -count=1`
- `go test ./internal/api -count=1`
- `go test ./...`
- `npm run test:ci --prefix web`
- `npm run build --prefix web`
- `git diff --check`

## AI-assisted
- AI-assisted: yes
- Tools used: Codex
- Where used: backend scan authorization, tests, docs, frontend copy
- Human verification performed: reviewed the diff and ran the validation commands above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow GitHub App-backed scans to use the installation’s selected repository list as the target guard. Selected repos can queue their first scan without changing `IDENTRAIL_REPO_SCAN_ALLOWLIST`; direct and PAT scans still use the allowlist.

- **Bug Fixes**
  - Removed the extra allowlist check for GitHub App scans to prevent false “repo target not allowed” errors.
  - Clarified 403 guidance: for GitHub App scans, select the repo during installation and refresh; for PAT/direct scans, ask an operator to allow the owner/repo target.
  - Updated docs: webhooks and project-scoped scans honor the selected-repo list; non-connector scans still use `IDENTRAIL_REPO_SCAN_ALLOWLIST`.

<sup>Written for commit 5b1699995177d6e05f872b4b1b37f4193691278d. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1343?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

