### PR TITLE
Polish project source setup UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## Unreleased
+- Polished the project source setup surface: the GitHub App install card now
+  separates the account/repository flow into compact steps, scan limits are
+  presented as an actionable advanced control, and verbose GitHub repository
+  posture diagnostics stay collapsed behind a summary until operators need the
+  details.
 - Ingest open GitHub secret-scanning and Dependabot vulnerability alerts as
   first-class repository findings during GitHub App-backed repo scans, alongside
   the existing code-scanning import. Secret-scanning alerts become redacted

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -445,6 +445,13 @@ describe('ProductProjectDetailPage', () => {
     fireEvent.click(screen.getByText('GitHub Enterprise fallback'));
     expect(screen.getByLabelText(/Personal access token/i)).toBeVisible();
 
+    const scanLimits = screen.getByText('Advanced scan limits').closest('details');
+    expect(scanLimits).not.toBeNull();
+    expect(within(scanLimits as HTMLElement).getByLabelText(/History limit/i)).not.toBeVisible();
+
+    fireEvent.click(within(scanLimits as HTMLElement).getByText('Advanced scan limits'));
+    expect(within(scanLimits as HTMLElement).getByLabelText(/History limit/i)).toBeVisible();
+
     expect(screen.getByText('Scan policy editor')).toBeInTheDocument();
     expect(screen.getByLabelText(/Trigger mode/i)).not.toBeVisible();
 
@@ -456,7 +463,10 @@ describe('ProductProjectDetailPage', () => {
     const { getGitHubConnectorRepositoryPosture } = await renderProjectDetail(true);
 
     expect(await screen.findByText('Repository posture')).toBeInTheDocument();
-    expect(await screen.findByText(/Actions token can write by default/i)).toBeInTheDocument();
+    const postureDetails = await screen.findByText(/1 posture check needs attention/i);
+    expect(screen.getByText(/Actions token can write by default/i)).not.toBeVisible();
+    fireEvent.click(postureDetails);
+    expect(screen.getByText(/Actions token can write by default/i)).toBeVisible();
     expect(getGitHubConnectorRepositoryPosture).toHaveBeenCalledWith(
       'github-app',
       'workspace-a',

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -571,6 +571,10 @@ function countGitHubPostureChecks(
   return posture?.checks.filter((check) => check.state === state).length ?? 0;
 }
 
+function formatCountLabel(count: number, singular: string, plural: string): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
 function sortRepoRiskGraphScores(scores: RepoRiskGraphFindingScore[]): RepoRiskGraphFindingScore[] {
   return [...scores].sort((left, right) => {
     if (right.score !== left.score) {
@@ -3758,6 +3762,14 @@ export function ProductProjectDetailPage() {
   const githubPostureAttentionCount = countGitHubPostureChecks(githubPosture, 'insecure');
   const githubPostureLimitedCount = countGitHubPostureChecks(githubPosture, 'permission_limited');
   const githubPostureUnavailableCount = countGitHubPostureChecks(githubPosture, 'unavailable');
+  const githubPostureAttentionChecks = useMemo(
+    () => githubPosture?.checks.filter((check) => check.state !== 'secure') ?? [],
+    [githubPosture]
+  );
+  const githubPostureDetailChecks =
+    githubPostureAttentionChecks.length > 0 ? githubPostureAttentionChecks : (githubPosture?.checks ?? []);
+  const githubPostureNeedsAttentionCount =
+    githubPostureAttentionCount + githubPostureLimitedCount + githubPostureUnavailableCount;
   const githubHasActiveRepoScan = githubRecentRepoScans.some((scan) => isActiveScanStatus(scan.status));
   const githubHasActiveSelectedRepoScan =
     effectiveRepoScanRepositoryKey !== '' &&
@@ -4694,10 +4706,27 @@ export function ProductProjectDetailPage() {
           {selectedSource === 'github' && !selectedUnavailable ? (
             <div className="idt-source-form-stack">
               <article className="idt-source-install-card idt-source-primary-action">
-                <div>
+                <div className="idt-source-primary-copy">
                   <p className="idt-app-kicker">Recommended setup</p>
                   <h4>Install Identrail on GitHub</h4>
-                  <p>Choose a personal account or organization on GitHub, then select the repositories Identrail can read.</p>
+                  <p>Connect once, then choose the personal account or organization and repositories Identrail can read.</p>
+                  <ol className="idt-source-mini-steps" aria-label="GitHub installation flow">
+                    <li>
+                      <span>1</span>
+                      <strong>Pick account</strong>
+                      <small>Personal or organization</small>
+                    </li>
+                    <li>
+                      <span>2</span>
+                      <strong>Select repos</strong>
+                      <small>Only the repositories in scope</small>
+                    </li>
+                    <li>
+                      <span>3</span>
+                      <strong>Return here</strong>
+                      <small>Refresh status after GitHub completes</small>
+                    </li>
+                  </ol>
                 </div>
                 <form className="idt-app-form" onSubmit={handleGitHubStart}>
                   <label>
@@ -4840,8 +4869,13 @@ export function ProductProjectDetailPage() {
                     )}
                   </div>
 
-                  <details className="idt-source-advanced">
-                    <summary>Scan limits</summary>
+                  <details className="idt-source-advanced idt-scan-limits-details">
+                    <summary>
+                      <span>
+                        <strong>Advanced scan limits</strong>
+                        <small>Override history depth or finding volume for this scan.</small>
+                      </span>
+                    </summary>
                     <div className="idt-source-inline-fields">
                       <label>
                         History limit
@@ -4902,7 +4936,7 @@ export function ProductProjectDetailPage() {
                     ) : (
                       <article>
                         <strong>{effectiveRepoScanRepository || 'No repository selected'}</strong>
-                        <span>Not queued</span>
+                        <span className="idt-source-status-pill is-neutral">Not queued</span>
                         <p>Repository scan activity will appear here after the first scan is queued.</p>
                       </article>
                     )}
@@ -5157,17 +5191,39 @@ export function ProductProjectDetailPage() {
 
           {selectedSource === 'github' && connections.github ? (
             <div className="idt-source-diagnostics">
-              {connections.github.account_login ? <p>Account {connections.github.account_login}</p> : null}
-              {connections.github.installation_id ? <p>Installation {connections.github.installation_id}</p> : null}
+              <article className="idt-source-connection-summary">
+                <div>
+                  <strong>Connected GitHub App</strong>
+                  <p>
+                    {connections.github.account_login ? `Installed on ${connections.github.account_login}` : 'Installation active'}
+                    {githubSelectedRepositories.length > 0
+                      ? ` · ${formatCountLabel(githubSelectedRepositories.length, 'repository', 'repositories')} selected`
+                      : ''}
+                  </p>
+                </div>
+                <span className={`idt-source-status-pill is-${connectionHealth(connections.github) === 'healthy' ? 'success' : 'warning'}`}>
+                  {connectionHealth(connections.github)}
+                </span>
+                {connections.github.installation_id ? <small>Installation {connections.github.installation_id}</small> : null}
+              </article>
               {connections.github.webhook_secret_rotation_due_at ? (
                 <p>Webhook rotation due {formatConnectionTime(connections.github.webhook_secret_rotation_due_at)}</p>
               ) : null}
-              {connections.github.selected_repositories.map((repository) => (
-                <article key={repository}>
-                  <strong>{repository}</strong>
-                  <span>Selected</span>
-                </article>
-              ))}
+              {githubSelectedRepositories.length > 0 ? (
+                <details className="idt-source-advanced idt-source-compact-details">
+                  <summary>
+                    <span>
+                      <strong>Selected repositories</strong>
+                      <small>{formatCountLabel(githubSelectedRepositories.length, 'repository', 'repositories')} in scope</small>
+                    </span>
+                  </summary>
+                  <div className="idt-source-chip-list">
+                    {githubSelectedRepositories.map((repository) => (
+                      <span key={repository}>{repository}</span>
+                    ))}
+                  </div>
+                </details>
+              ) : null}
               {githubPostureLoading ? (
                 <article>
                   <strong>{effectiveRepoScanRepository || 'Selected repository'}</strong>
@@ -5182,13 +5238,36 @@ export function ProductProjectDetailPage() {
               ) : null}
               {githubPosture ? (
                 <>
-                  <article>
-                    <strong>Repository posture</strong>
-                    <span>{formatConnectionTime(githubPosture.collected_at)}</span>
-                    <p>
-                      {githubPostureSecureCount} secure · {githubPostureAttentionCount} attention ·{' '}
-                      {githubPostureLimitedCount} permission limited · {githubPostureUnavailableCount} unavailable
-                    </p>
+                  <article className="idt-github-posture-card">
+                    <div className="idt-github-posture-card-head">
+                      <div>
+                        <strong>Repository posture</strong>
+                        <p>Collected {formatConnectionTime(githubPosture.collected_at)}</p>
+                      </div>
+                      <span className={`idt-source-status-pill is-${githubPostureNeedsAttentionCount > 0 ? 'warning' : 'success'}`}>
+                        {githubPostureNeedsAttentionCount > 0
+                          ? formatCountLabel(githubPostureNeedsAttentionCount, 'check', 'checks')
+                          : 'Secure'}
+                      </span>
+                    </div>
+                    <dl className="idt-github-posture-stats" aria-label="GitHub posture summary">
+                      <div>
+                        <dt>Secure</dt>
+                        <dd>{githubPostureSecureCount}</dd>
+                      </div>
+                      <div>
+                        <dt>Attention</dt>
+                        <dd>{githubPostureAttentionCount}</dd>
+                      </div>
+                      <div>
+                        <dt>Limited</dt>
+                        <dd>{githubPostureLimitedCount}</dd>
+                      </div>
+                      <div>
+                        <dt>Unavailable</dt>
+                        <dd>{githubPostureUnavailableCount}</dd>
+                      </div>
+                    </dl>
                     {githubPosture.rate_limit?.remaining !== undefined ? (
                       <small>
                         GitHub API remaining {githubPosture.rate_limit.remaining}
@@ -5196,16 +5275,39 @@ export function ProductProjectDetailPage() {
                       </small>
                     ) : null}
                   </article>
-                  {githubPosture.checks.slice(0, 6).map((check) => (
-                    <article key={check.id}>
-                      <strong>{formatTokenLabel(check.category || check.id)}</strong>
-                      <span className={`idt-source-status-pill is-${githubPostureStateTone(check.state)}`}>
-                        {formatTokenLabel(check.state)}
+                  <details className="idt-source-advanced idt-github-posture-details">
+                    <summary>
+                      <span>
+                        <strong>
+                          {githubPostureNeedsAttentionCount > 0
+                            ? `${formatCountLabel(githubPostureNeedsAttentionCount, 'posture check', 'posture checks')} ${
+                                githubPostureNeedsAttentionCount === 1 ? 'needs' : 'need'
+                              } attention`
+                            : 'Posture checks look clear'}
+                        </strong>
+                        <small>
+                          {githubPostureNeedsAttentionCount > 0
+                            ? 'Open to review branch, Actions, and security control details.'
+                            : 'Open to inspect the collected GitHub signals.'}
+                        </small>
                       </span>
-                      <p>{check.summary}</p>
-                      {check.reason ? <small>{formatTokenLabel(check.reason)}</small> : null}
-                    </article>
-                  ))}
+                    </summary>
+                    <div className="idt-github-posture-checks">
+                      {githubPostureDetailChecks.slice(0, 6).map((check) => (
+                        <article key={check.id}>
+                          <strong>{formatTokenLabel(check.category || check.id)}</strong>
+                          <span className={`idt-source-status-pill is-${githubPostureStateTone(check.state)}`}>
+                            {formatTokenLabel(check.state)}
+                          </span>
+                          <p>{check.summary}</p>
+                          {check.reason ? <small>{formatTokenLabel(check.reason)}</small> : null}
+                        </article>
+                      ))}
+                      {githubPostureDetailChecks.length > 6 ? (
+                        <p>{formatCountLabel(githubPostureDetailChecks.length - 6, 'additional check', 'additional checks')} hidden.</p>
+                      ) : null}
+                    </div>
+                  </details>
                 </>
               ) : null}
             </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5893,6 +5893,76 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   color: #c2d4f0;
 }
 
+.idt-source-primary-copy {
+  display: grid;
+  gap: 0.55rem;
+  align-self: center;
+  min-width: 0;
+}
+
+.idt-source-primary-copy h4 {
+  line-height: 1.15;
+}
+
+.idt-source-primary-copy > p:not(.idt-app-kicker) {
+  max-width: 62ch;
+  line-height: 1.45;
+}
+
+.idt-source-mini-steps {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+  margin: 0.2rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.idt-source-mini-steps li {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.12rem 0.42rem;
+  align-items: start;
+  min-width: 0;
+  border: 1px solid rgba(130, 160, 214, 0.18);
+  border-radius: 0.55rem;
+  padding: 0.55rem;
+  background: rgba(9, 15, 26, 0.46);
+}
+
+.idt-source-mini-steps span {
+  grid-row: 1 / 3;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.35rem;
+  height: 1.35rem;
+  border: 1px solid rgba(184, 243, 214, 0.3);
+  border-radius: 999px;
+  color: #dffce9;
+  background: rgba(28, 89, 50, 0.22);
+  font-size: 0.76rem;
+  font-weight: 900;
+}
+
+.idt-source-mini-steps strong,
+.idt-source-mini-steps small {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.idt-source-mini-steps strong {
+  color: #f2f7ff;
+  font-size: 0.83rem;
+  line-height: 1.2;
+}
+
+.idt-source-mini-steps small {
+  color: #9fb8de;
+  font-size: 0.75rem;
+  line-height: 1.3;
+}
+
 .idt-source-advanced summary {
   cursor: pointer;
   color: #dce9fb;
@@ -6001,6 +6071,174 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
 .idt-source-diagnostics small {
   margin: 0.3rem 0 0;
   color: #c6d5ec;
+}
+
+.idt-source-diagnostics .idt-source-status-pill {
+  display: inline-flex;
+  margin-top: 0;
+}
+
+.idt-source-diagnostics .idt-source-status-pill.is-neutral {
+  color: #cbd9ef;
+  border-color: rgba(130, 160, 214, 0.3);
+  background: rgba(10, 18, 32, 0.78);
+}
+
+.idt-source-connection-summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.1rem 0.75rem;
+  align-items: start;
+}
+
+.idt-source-connection-summary p {
+  margin-top: 0.22rem;
+}
+
+.idt-source-connection-summary small {
+  grid-column: 1 / -1;
+}
+
+.idt-scan-limits-details,
+.idt-source-compact-details,
+.idt-github-posture-details {
+  padding: 0;
+  overflow: hidden;
+}
+
+.idt-scan-limits-details summary,
+.idt-source-compact-details summary,
+.idt-github-posture-details summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 0.95rem;
+  list-style: none;
+}
+
+.idt-scan-limits-details summary::-webkit-details-marker,
+.idt-source-compact-details summary::-webkit-details-marker,
+.idt-github-posture-details summary::-webkit-details-marker {
+  display: none;
+}
+
+.idt-scan-limits-details summary::after,
+.idt-source-compact-details summary::after,
+.idt-github-posture-details summary::after {
+  content: '';
+  width: 0.62rem;
+  height: 0.62rem;
+  flex: 0 0 auto;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  color: #e5eefc;
+  transform: rotate(45deg);
+  transition: transform 0.16s ease;
+}
+
+.idt-scan-limits-details[open] summary::after,
+.idt-source-compact-details[open] summary::after,
+.idt-github-posture-details[open] summary::after {
+  transform: rotate(225deg);
+}
+
+.idt-scan-limits-details summary span,
+.idt-source-compact-details summary span,
+.idt-github-posture-details summary span {
+  display: grid;
+  gap: 0.18rem;
+  min-width: 0;
+  text-transform: none;
+}
+
+.idt-scan-limits-details summary strong,
+.idt-source-compact-details summary strong,
+.idt-github-posture-details summary strong {
+  color: #f2f7ff;
+}
+
+.idt-scan-limits-details summary small,
+.idt-source-compact-details summary small,
+.idt-github-posture-details summary small {
+  color: #9fb8de;
+  font-size: 0.82rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.idt-scan-limits-details .idt-source-inline-fields,
+.idt-source-compact-details .idt-source-chip-list,
+.idt-github-posture-details .idt-github-posture-checks {
+  margin-top: 0;
+  border-top: 1px solid rgba(130, 160, 214, 0.2);
+  padding: 0.85rem 0.95rem;
+}
+
+.idt-source-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.idt-source-chip-list span {
+  display: inline-flex;
+  max-width: 100%;
+  border: 1px solid rgba(130, 160, 214, 0.24);
+  border-radius: 999px;
+  padding: 0.28rem 0.55rem;
+  color: #dce9fb;
+  background: rgba(9, 15, 26, 0.58);
+  font-size: 0.8rem;
+  font-weight: 800;
+  text-transform: none;
+  overflow-wrap: anywhere;
+}
+
+.idt-github-posture-card {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.idt-github-posture-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.idt-github-posture-stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.45rem;
+  margin: 0;
+}
+
+.idt-github-posture-stats div {
+  min-width: 0;
+  border: 1px solid rgba(130, 160, 214, 0.18);
+  border-radius: 0.55rem;
+  padding: 0.5rem;
+  background: rgba(9, 15, 26, 0.42);
+}
+
+.idt-github-posture-stats dt {
+  color: #9fb8de;
+  font-size: 0.7rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.idt-github-posture-stats dd {
+  margin: 0.18rem 0 0;
+  color: #f2f7ff;
+  font-size: 1rem;
+  font-weight: 900;
+}
+
+.idt-github-posture-checks {
+  display: grid;
+  gap: 0.55rem;
 }
 
 .idt-repo-scan-launch {
@@ -6118,6 +6356,11 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   .idt-executive-severity-list article,
   .idt-executive-type-list article {
     display: grid;
+  }
+
+  .idt-source-mini-steps,
+  .idt-github-posture-stats {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -7261,6 +7504,8 @@ html[data-theme='light'] .idt-source-meta div,
 html[data-theme='light'] .idt-source-install-card,
 html[data-theme='light'] .idt-source-advanced,
 html[data-theme='light'] .idt-source-diagnostics article,
+html[data-theme='light'] .idt-source-mini-steps li,
+html[data-theme='light'] .idt-github-posture-stats div,
 html[data-theme='light'] .idt-permission-preview-modal,
 html[data-theme='light'] .idt-permission-preview-list article,
 html[data-theme='light'] .idt-icon-btn {
@@ -7318,8 +7563,33 @@ html[data-theme='light'] .idt-source-stepper li {
 }
 
 html[data-theme='light'] .idt-source-card-topline > span:first-child,
-html[data-theme='light'] .idt-source-meta dt {
+html[data-theme='light'] .idt-source-meta dt,
+html[data-theme='light'] .idt-source-mini-steps small,
+html[data-theme='light'] .idt-github-posture-stats dt,
+html[data-theme='light'] .idt-scan-limits-details summary small,
+html[data-theme='light'] .idt-source-compact-details summary small,
+html[data-theme='light'] .idt-github-posture-details summary small {
   color: #4c6f9f;
+}
+
+html[data-theme='light'] .idt-source-mini-steps strong,
+html[data-theme='light'] .idt-github-posture-stats dd,
+html[data-theme='light'] .idt-scan-limits-details summary strong,
+html[data-theme='light'] .idt-source-compact-details summary strong,
+html[data-theme='light'] .idt-github-posture-details summary strong,
+html[data-theme='light'] .idt-source-chip-list span {
+  color: #17345f;
+}
+
+html[data-theme='light'] .idt-source-mini-steps span {
+  color: #17613d;
+  background: rgba(218, 245, 229, 0.9);
+  border-color: rgba(33, 124, 83, 0.28);
+}
+
+html[data-theme='light'] .idt-source-chip-list span {
+  background: rgba(255, 255, 255, 0.92);
+  border-color: rgba(42, 71, 119, 0.24);
 }
 
 html[data-theme='light'] .idt-app-form textarea,


### PR DESCRIPTION
Fixes #1344

## Summary
- separate the GitHub App install guidance into compact, scannable setup steps so the card no longer feels cramped
- make scan limits read as an actionable advanced control instead of a washed-out collapsed row
- collapse verbose GitHub repository posture checks behind a summary while keeping connection, selected-repo, and posture counts visible
- document the user-facing polish in the Unreleased changelog

## Verification
- `npm run test --prefix web -- --run src/productShell.test.tsx`
- `npm run build --prefix web`
- `npm run test:ci --prefix web`
- Browser check with mocked API on the project source page at desktop and mobile widths: setup card rendered, advanced scan limits visible, posture details collapsed by default, and no horizontal overflow on mobile.

## AI-assisted disclosure
- AI-assisted: yes
- Tools used: Codex
- Where used: `web/src/productShell.tsx`, `web/src/styles.css`, `web/src/productShell.test.tsx`, `CHANGELOG.md`
- Human verification performed: reviewed the diff, ran the tests/build above, and checked the page behavior in browser automation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the project source setup UI to make GitHub setup clearer and reduce clutter. This adds actionable scan limit controls and a compact posture summary that expands when needed.

- **UI Improvements**
  - Install card now shows 3 mini steps: pick account, select repos, return to refresh.
  - Advanced scan limits moved to a clear collapsible control with history and finding limits.
  - Connection summary shows installation target, selected repo count, and a health status pill.
  - Selected repositories are displayed as chips behind a compact expandable summary.
  - Repository posture shows a concise summary with counts and a status pill; detailed checks are collapsed by default with rate limit info preserved.
  - Fixed mobile layout to avoid horizontal overflow.

<sup>Written for commit 3d92b09570109eff932badede4cd630f1f4a626f. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1345?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

