### PR TITLE
[codex] Tighten project source setup UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,10 @@
   repository list as the scoped target guard, so personal and organization repos
   selected in GitHub no longer require a per-repo deployment allowlist update
   before the first scan can be queued.
-- Polished the project source setup surface: the GitHub App install card now
-  separates the account/repository flow into compact steps, scan limits are
-  presented as an actionable advanced control, and verbose GitHub repository
-  posture diagnostics stay collapsed behind a summary until operators need the
-  details.
+- Tightened the project source setup surface: the GitHub App install card now
+  uses one clear action, optional scan limits and installation details stay
+  compact, and repository posture summaries keep raw checks collapsed with
+  restored dark-console contrast.
 - Ingest open GitHub secret-scanning and Dependabot vulnerability alerts as
   first-class repository findings during GitHub App-backed repo scans, alongside
   the existing code-scanning import. Secret-scanning alerts become redacted

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -408,7 +408,7 @@ describe('ProductProjectDetailPage', () => {
 
     expect((await screen.findAllByText('identrail/identrail')).length).toBeGreaterThan(0);
     expect(within(screen.getByLabelText('Source types')).getByRole('button', { name: /GitHub/i })).not.toBeDisabled();
-    expect(screen.getByText('Installation 12345')).toBeInTheDocument();
+    expect(screen.getByText(/Installation 12345/i)).toBeInTheDocument();
     expect(getGitHubConnectorStatus).toHaveBeenCalledWith(
       'workspace-a',
       'project-1',
@@ -450,11 +450,11 @@ describe('ProductProjectDetailPage', () => {
     fireEvent.click(screen.getByText('GitHub Enterprise fallback'));
     expect(screen.getByLabelText(/Personal access token/i)).toBeVisible();
 
-    const scanLimits = screen.getByText('Advanced scan limits').closest('details');
+    const scanLimits = screen.getByText('Scan limits').closest('details');
     expect(scanLimits).not.toBeNull();
     expect(within(scanLimits as HTMLElement).getByLabelText(/History limit/i)).not.toBeVisible();
 
-    fireEvent.click(within(scanLimits as HTMLElement).getByText('Advanced scan limits'));
+    fireEvent.click(within(scanLimits as HTMLElement).getByText('Scan limits'));
     expect(within(scanLimits as HTMLElement).getByLabelText(/History limit/i)).toBeVisible();
 
     expect(screen.getByText('Scan policy editor')).toBeInTheDocument();
@@ -468,7 +468,7 @@ describe('ProductProjectDetailPage', () => {
     const { getGitHubConnectorRepositoryPosture } = await renderProjectDetail(true);
 
     expect(await screen.findByText('Repository posture')).toBeInTheDocument();
-    const postureDetails = await screen.findByText(/1 posture check needs attention/i);
+    const postureDetails = await screen.findByText(/Review 1 check/i);
     expect(screen.getByText(/Actions token can write by default/i)).not.toBeVisible();
     fireEvent.click(postureDetails);
     expect(screen.getByText(/Actions token can write by default/i)).toBeVisible();

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -4742,24 +4742,7 @@ export function ProductProjectDetailPage() {
                 <div className="idt-source-primary-copy">
                   <p className="idt-app-kicker">Recommended setup</p>
                   <h4>Install Identrail on GitHub</h4>
-                  <p>Connect once, then choose the personal account or organization and repositories Identrail can read.</p>
-                  <ol className="idt-source-mini-steps" aria-label="GitHub installation flow">
-                    <li>
-                      <span>1</span>
-                      <strong>Pick account</strong>
-                      <small>Personal or organization</small>
-                    </li>
-                    <li>
-                      <span>2</span>
-                      <strong>Select repos</strong>
-                      <small>Only the repositories in scope</small>
-                    </li>
-                    <li>
-                      <span>3</span>
-                      <strong>Return here</strong>
-                      <small>Refresh status after GitHub completes</small>
-                    </li>
-                  </ol>
+                  <p>Choose an account and the repositories Identrail can read.</p>
                 </div>
                 <form className="idt-app-form" onSubmit={handleGitHubStart}>
                   <label>
@@ -4851,7 +4834,7 @@ export function ProductProjectDetailPage() {
                   <article className="idt-source-install-card idt-repo-scan-launch-card">
                     <div>
                       <h4>First repository scan</h4>
-                      <p>Queue a repository exposure scan from the connected GitHub source.</p>
+                      <p>Scan the selected repository.</p>
                     </div>
                     <Link className="idt-btn idt-btn-ghost" to={repoScanFindingsPath}>
                       View findings
@@ -4905,8 +4888,8 @@ export function ProductProjectDetailPage() {
                   <details className="idt-source-advanced idt-scan-limits-details">
                     <summary>
                       <span>
-                        <strong>Advanced scan limits</strong>
-                        <small>Override history depth or finding volume for this scan.</small>
+                        <strong>Scan limits</strong>
+                        <small>Optional</small>
                       </span>
                     </summary>
                     <div className="idt-source-inline-fields">
@@ -4942,7 +4925,7 @@ export function ProductProjectDetailPage() {
                   </button>
 
                   <div className="idt-source-diagnostics idt-repo-scan-activity" aria-label="recent repository scan activity">
-                    <p>Recent repository scan activity</p>
+                    <p>Scan activity</p>
                     {githubRecentRepoScans.length > 0 ? (
                       githubRecentRepoScans.map((scan) => (
                         <article key={scan.id}>
@@ -4968,9 +4951,8 @@ export function ProductProjectDetailPage() {
                       ))
                     ) : (
                       <article>
-                        <strong>{effectiveRepoScanRepository || 'No repository selected'}</strong>
-                        <span className="idt-source-status-pill is-neutral">Not queued</span>
-                        <p>Repository scan activity will appear here after the first scan is queued.</p>
+                        <strong>No scans yet</strong>
+                        <p>Run the first scan to populate history.</p>
                       </article>
                     )}
                     {githubHasActiveRepoScan ? <p>Refreshing while a scan is queued or running.</p> : null}
@@ -5224,38 +5206,33 @@ export function ProductProjectDetailPage() {
 
           {selectedSource === 'github' && connections.github ? (
             <div className="idt-source-diagnostics">
-              <article className="idt-source-connection-summary">
-                <div>
-                  <strong>Connected GitHub App</strong>
+              <details className="idt-source-advanced idt-source-compact-details idt-source-connection-details">
+                <summary>
+                  <span>
+                    <strong>GitHub installation</strong>
+                    <small>
+                      {githubSelectedRepositories.length > 0
+                        ? formatCountLabel(githubSelectedRepositories.length, 'repository', 'repositories')
+                        : 'Connected'}
+                    </small>
+                  </span>
+                </summary>
+                <div className="idt-source-connection-body">
                   <p>
                     {connections.github.account_login ? `Installed on ${connections.github.account_login}` : 'Installation active'}
-                    {githubSelectedRepositories.length > 0
-                      ? ` · ${formatCountLabel(githubSelectedRepositories.length, 'repository', 'repositories')} selected`
-                      : ''}
+                    {connections.github.installation_id ? ` · Installation ${connections.github.installation_id}` : ''}
                   </p>
+                  {githubSelectedRepositories.length > 0 ? (
+                    <div className="idt-source-chip-list">
+                      {githubSelectedRepositories.map((repository) => (
+                        <span key={repository}>{repository}</span>
+                      ))}
+                    </div>
+                  ) : null}
                 </div>
-                <span className={`idt-source-status-pill is-${connectionHealth(connections.github) === 'healthy' ? 'success' : 'warning'}`}>
-                  {connectionHealth(connections.github)}
-                </span>
-                {connections.github.installation_id ? <small>Installation {connections.github.installation_id}</small> : null}
-              </article>
+              </details>
               {connections.github.webhook_secret_rotation_due_at ? (
                 <p>Webhook rotation due {formatConnectionTime(connections.github.webhook_secret_rotation_due_at)}</p>
-              ) : null}
-              {githubSelectedRepositories.length > 0 ? (
-                <details className="idt-source-advanced idt-source-compact-details">
-                  <summary>
-                    <span>
-                      <strong>Selected repositories</strong>
-                      <small>{formatCountLabel(githubSelectedRepositories.length, 'repository', 'repositories')} in scope</small>
-                    </span>
-                  </summary>
-                  <div className="idt-source-chip-list">
-                    {githubSelectedRepositories.map((repository) => (
-                      <span key={repository}>{repository}</span>
-                    ))}
-                  </div>
-                </details>
               ) : null}
               {githubPostureLoading ? (
                 <article>
@@ -5301,30 +5278,26 @@ export function ProductProjectDetailPage() {
                         <dd>{githubPostureUnavailableCount}</dd>
                       </div>
                     </dl>
-                    {githubPosture.rate_limit?.remaining !== undefined ? (
-                      <small>
-                        GitHub API remaining {githubPosture.rate_limit.remaining}
-                        {githubPosture.rate_limit.limit ? ` of ${githubPosture.rate_limit.limit}` : ''}
-                      </small>
-                    ) : null}
                   </article>
                   <details className="idt-source-advanced idt-github-posture-details">
                     <summary>
                       <span>
                         <strong>
                           {githubPostureNeedsAttentionCount > 0
-                            ? `${formatCountLabel(githubPostureNeedsAttentionCount, 'posture check', 'posture checks')} ${
-                                githubPostureNeedsAttentionCount === 1 ? 'needs' : 'need'
-                              } attention`
-                            : 'Posture checks look clear'}
+                            ? `Review ${formatCountLabel(githubPostureNeedsAttentionCount, 'check', 'checks')}`
+                            : 'Review checks'}
                         </strong>
                         <small>
-                          {githubPostureNeedsAttentionCount > 0
-                            ? 'Open to review branch, Actions, and security control details.'
-                            : 'Open to inspect the collected GitHub signals.'}
+                          {githubPostureNeedsAttentionCount > 0 ? 'Branch, Actions, security' : 'Collected GitHub signals'}
                         </small>
                       </span>
                     </summary>
+                    {githubPosture.rate_limit?.remaining !== undefined ? (
+                      <p className="idt-github-posture-rate-limit">
+                        GitHub API remaining {githubPosture.rate_limit.remaining}
+                        {githubPosture.rate_limit.limit ? ` of ${githubPosture.rate_limit.limit}` : ''}
+                      </p>
+                    ) : null}
                     <div className="idt-github-posture-checks">
                       {githubPostureDetailChecks.slice(0, 6).map((check) => (
                         <article key={check.id}>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5905,62 +5905,8 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
 }
 
 .idt-source-primary-copy > p:not(.idt-app-kicker) {
-  max-width: 62ch;
+  max-width: 44ch;
   line-height: 1.45;
-}
-
-.idt-source-mini-steps {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.5rem;
-  margin: 0.2rem 0 0;
-  padding: 0;
-  list-style: none;
-}
-
-.idt-source-mini-steps li {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 0.12rem 0.42rem;
-  align-items: start;
-  min-width: 0;
-  border: 1px solid rgba(130, 160, 214, 0.18);
-  border-radius: 0.55rem;
-  padding: 0.55rem;
-  background: rgba(9, 15, 26, 0.46);
-}
-
-.idt-source-mini-steps span {
-  grid-row: 1 / 3;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.35rem;
-  height: 1.35rem;
-  border: 1px solid rgba(184, 243, 214, 0.3);
-  border-radius: 999px;
-  color: #dffce9;
-  background: rgba(28, 89, 50, 0.22);
-  font-size: 0.76rem;
-  font-weight: 900;
-}
-
-.idt-source-mini-steps strong,
-.idt-source-mini-steps small {
-  min-width: 0;
-  overflow-wrap: anywhere;
-}
-
-.idt-source-mini-steps strong {
-  color: #f2f7ff;
-  font-size: 0.83rem;
-  line-height: 1.2;
-}
-
-.idt-source-mini-steps small {
-  color: #9fb8de;
-  font-size: 0.75rem;
-  line-height: 1.3;
 }
 
 .idt-source-advanced summary {
@@ -6084,19 +6030,13 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   background: rgba(10, 18, 32, 0.78);
 }
 
-.idt-source-connection-summary {
+.idt-source-connection-body {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 0.1rem 0.75rem;
-  align-items: start;
+  gap: 0.65rem;
 }
 
-.idt-source-connection-summary p {
-  margin-top: 0.22rem;
-}
-
-.idt-source-connection-summary small {
-  grid-column: 1 / -1;
+.idt-source-connection-body p {
+  margin: 0;
 }
 
 .idt-scan-limits-details,
@@ -6168,7 +6108,7 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
 }
 
 .idt-scan-limits-details .idt-source-inline-fields,
-.idt-source-compact-details .idt-source-chip-list,
+.idt-source-compact-details .idt-source-connection-body,
 .idt-github-posture-details .idt-github-posture-checks {
   margin-top: 0;
   border-top: 1px solid rgba(130, 160, 214, 0.2);
@@ -6234,6 +6174,11 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   color: #f2f7ff;
   font-size: 1rem;
   font-weight: 900;
+}
+
+.idt-github-posture-rate-limit {
+  margin: 0.75rem 0 0;
+  padding: 0 0.95rem;
 }
 
 .idt-github-posture-checks {
@@ -6358,7 +6303,6 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
     display: grid;
   }
 
-  .idt-source-mini-steps,
   .idt-github-posture-stats {
     grid-template-columns: 1fr;
   }
@@ -7504,7 +7448,6 @@ html[data-theme='light'] .idt-source-meta div,
 html[data-theme='light'] .idt-source-install-card,
 html[data-theme='light'] .idt-source-advanced,
 html[data-theme='light'] .idt-source-diagnostics article,
-html[data-theme='light'] .idt-source-mini-steps li,
 html[data-theme='light'] .idt-github-posture-stats div,
 html[data-theme='light'] .idt-permission-preview-modal,
 html[data-theme='light'] .idt-permission-preview-list article,
@@ -7564,7 +7507,6 @@ html[data-theme='light'] .idt-source-stepper li {
 
 html[data-theme='light'] .idt-source-card-topline > span:first-child,
 html[data-theme='light'] .idt-source-meta dt,
-html[data-theme='light'] .idt-source-mini-steps small,
 html[data-theme='light'] .idt-github-posture-stats dt,
 html[data-theme='light'] .idt-scan-limits-details summary small,
 html[data-theme='light'] .idt-source-compact-details summary small,
@@ -7572,19 +7514,12 @@ html[data-theme='light'] .idt-github-posture-details summary small {
   color: #4c6f9f;
 }
 
-html[data-theme='light'] .idt-source-mini-steps strong,
 html[data-theme='light'] .idt-github-posture-stats dd,
 html[data-theme='light'] .idt-scan-limits-details summary strong,
 html[data-theme='light'] .idt-source-compact-details summary strong,
 html[data-theme='light'] .idt-github-posture-details summary strong,
 html[data-theme='light'] .idt-source-chip-list span {
   color: #17345f;
-}
-
-html[data-theme='light'] .idt-source-mini-steps span {
-  color: #17613d;
-  background: rgba(218, 245, 229, 0.9);
-  border-color: rgba(33, 124, 83, 0.28);
 }
 
 html[data-theme='light'] .idt-source-chip-list span {
@@ -20527,6 +20462,7 @@ html[data-theme='light'] .idt-app-shell-screen select {
   resize: vertical;
 }
 
+
 .idt-app-console-layout select:disabled,
 .idt-app-console-layout input:disabled,
 .idt-app-console-layout textarea:disabled,
@@ -23728,4 +23664,32 @@ html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-procure
   html[data-theme='light'] .idt-pricing-decision-console .idt-pricing-hero-matrix {
     overflow-x: auto;
   }
+}
+
+html[data-theme='light'] .idt-app-console-layout .idt-source-advanced summary,
+html[data-theme='light'] .idt-app-console-layout .idt-scan-limits-details summary,
+html[data-theme='light'] .idt-app-console-layout .idt-source-compact-details summary,
+html[data-theme='light'] .idt-app-console-layout .idt-github-posture-details summary {
+  color: var(--app-text);
+}
+
+html[data-theme='light'] .idt-app-console-layout .idt-scan-limits-details summary small,
+html[data-theme='light'] .idt-app-console-layout .idt-source-compact-details summary small,
+html[data-theme='light'] .idt-app-console-layout .idt-github-posture-details summary small,
+html[data-theme='light'] .idt-app-console-layout .idt-github-posture-stats dt {
+  color: var(--app-muted);
+}
+
+html[data-theme='light'] .idt-app-console-layout .idt-scan-limits-details summary strong,
+html[data-theme='light'] .idt-app-console-layout .idt-source-compact-details summary strong,
+html[data-theme='light'] .idt-app-console-layout .idt-github-posture-details summary strong,
+html[data-theme='light'] .idt-app-console-layout .idt-github-posture-stats dd {
+  color: var(--app-text);
+}
+
+html[data-theme='light'] .idt-app-console-layout .idt-github-posture-stats div,
+html[data-theme='light'] .idt-app-console-layout .idt-source-chip-list span {
+  border-color: var(--app-border);
+  background: var(--app-panel-strong);
+  color: var(--app-text);
 }


### PR DESCRIPTION
## Summary
- remove the noisy GitHub install mini-step tiles and tighten setup, scan, and empty-state copy
- collapse GitHub installation/repository details into one compact disclosure instead of separate repeated panels
- restore dark-console contrast for scan limit controls, repository chips, and posture summary tiles while keeping raw posture checks collapsed

Fixes #1346

## Validation
- npm run test --prefix web -- --run src/productShell.test.tsx
- npm run build --prefix web
- local browser smoke check against the project source route with a mock API: confirmed the new labels render, old labels are absent, and no console warnings/errors were emitted

AI-assisted: No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamlined the GitHub project source setup with clearer copy, tighter empty states, and improved console contrast for scan-related controls. Fixes Linear #1346.

- Refactors
  - Collapsed GitHub installation and selected repositories into one compact disclosure with counts.
  - Renamed labels and copy: “Scan limits” (optional), “Scan activity,” and “Review n check(s)” for posture.
  - Moved GitHub API rate-limit info into posture details; raw checks remain collapsed by default.
  - Simplified first-scan empty state: “No scans yet” with a short prompt.
  - Restored console contrast for scan limits, repository chips, and posture stats in the app console (light theme) and updated tests to match.

<sup>Written for commit 0e809ad1a683caa3e69903c6b1b5670a3c8e85d6. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1347?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

