### PR TITLE
Fix org posture omission for user-owned repos

### DIFF
--- a/internal/connectors/github/org_posture.go
+++ b/internal/connectors/github/org_posture.go
@@ -117,6 +117,13 @@ func (c RepositoryClient) CollectOrganizationPosture(ctx context.Context, instal
 	posture.Checks = append(posture.Checks, c.collectOrgReusableWorkflowPolicy(ctx, token.Token, org, actionsPolicy, updateRate))
 	posture.Checks = append(posture.Checks, collectOrgCodeSecurityConfiguration(org, normalizedRepository, codeSecurityConfigurations, codeSecurityErr, repositoryCodeSecurity, repositoryCodeSecurityErr))
 
+	if organizationPostureMayBeUserOwner(posture) {
+		exists, existsErr := c.githubOrganizationExists(ctx, token.Token, org, updateRate)
+		if existsErr == nil && !exists {
+			return organizationPostureNotAnOrganization(posture), nil
+		}
+	}
+
 	return posture, nil
 }
 
@@ -643,6 +650,49 @@ func collectOrgCodeSecurityConfiguration(org string, repository string, configur
 		Summary:  "Scanned repository is attached to an enforced organization code security configuration.",
 		Evidence: evidence,
 	}
+}
+
+func organizationPostureMayBeUserOwner(posture OrganizationPosture) bool {
+	if len(posture.Checks) == 0 {
+		return false
+	}
+	for _, check := range posture.Checks {
+		if check.State != RepositoryPostureStateUnsupported {
+			return false
+		}
+		switch check.Reason {
+		case "plan_unavailable", "organization_policy_unavailable":
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func (c RepositoryClient) githubOrganizationExists(ctx context.Context, token string, org string, updateRate func(*GitHubRateLimitState)) (bool, error) {
+	rateLimit, err := c.getJSON(ctx, token, c.orgEndpoint(org, ""), nil)
+	updateRate(rateLimit)
+	if err == nil {
+		return true, nil
+	}
+	if apiErr, ok := asGitHubAPIError(err); ok && apiErr.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	return false, err
+}
+
+func organizationPostureNotAnOrganization(posture OrganizationPosture) OrganizationPosture {
+	for index := range posture.Checks {
+		check := &posture.Checks[index]
+		check.State = RepositoryPostureStateUnsupported
+		check.Reason = "not_an_organization"
+		check.Summary = "Repository owner is a user account, so organization-level GitHub policy does not apply."
+		if check.Evidence == nil {
+			check.Evidence = map[string]any{}
+		}
+		check.Evidence["organization"] = posture.Organization
+	}
+	return posture
 }
 
 func shouldCollectRepositoryCodeSecurityConfiguration(configurations []organizationCodeSecurityConfiguration) bool {

--- a/internal/connectors/github/org_posture_test.go
+++ b/internal/connectors/github/org_posture_test.go
@@ -380,6 +380,65 @@ func TestCollectOrganizationPosturePermissionAndRateLimitStates(t *testing.T) {
 	}
 }
 
+func TestCollectOrganizationPostureMarksUserOwnerNotAnOrganization(t *testing.T) {
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	orgLookupCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/orgs/octocat/actions/permissions", "/orgs/octocat/actions/permissions/workflow", "/orgs/octocat/actions/permissions/selected-actions", "/orgs/octocat/code-security/configurations":
+			http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)
+		case "/orgs/octocat":
+			orgLookupCalls++
+			http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)
+		default:
+			t.Errorf("unexpected org posture path %s", r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	posture, err := (RepositoryClient{TokenClient: minter, APIBaseURL: server.URL}).CollectOrganizationPosture(context.Background(), 321, "octocat", "octocat/repo")
+	if err != nil {
+		t.Fatalf("collect org posture: %v", err)
+	}
+	if orgLookupCalls != 1 {
+		t.Fatalf("expected organization existence check once, got %d", orgLookupCalls)
+	}
+	if len(posture.Checks) == 0 {
+		t.Fatal("expected non-organization posture checks")
+	}
+	for _, check := range posture.Checks {
+		if check.State != RepositoryPostureStateUnsupported || check.Reason != "not_an_organization" {
+			t.Fatalf("expected non-organization check, got %+v", check)
+		}
+	}
+}
+
+func TestCollectOrganizationPosturePreservesPlanLimitedOrganization(t *testing.T) {
+	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/orgs/acme/actions/permissions", "/orgs/acme/actions/permissions/workflow", "/orgs/acme/actions/permissions/selected-actions", "/orgs/acme/code-security/configurations":
+			http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)
+		case "/orgs/acme":
+			_, _ = w.Write([]byte(`{"login":"acme"}`))
+		default:
+			t.Errorf("unexpected org posture path %s", r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	posture, err := (RepositoryClient{TokenClient: minter, APIBaseURL: server.URL}).CollectOrganizationPosture(context.Background(), 321, "acme", "acme/repo")
+	if err != nil {
+		t.Fatalf("collect org posture: %v", err)
+	}
+	if check := orgPostureCheckByID(posture, "org_secret_scanning_policy"); check.State != RepositoryPostureStateUnsupported || check.Reason != "plan_unavailable" {
+		t.Fatalf("expected organization plan-limited posture to be preserved, got %+v", check)
+	}
+	if check := orgPostureCheckByID(posture, "org_actions_policy"); check.State != RepositoryPostureStateUnsupported || check.Reason != "organization_policy_unavailable" {
+		t.Fatalf("expected organization policy unavailable posture to be preserved, got %+v", check)
+	}
+}
+
 func TestCollectOrganizationPostureUnsupportedAndUnknownStates(t *testing.T) {
 	minter := &fakeInstallationTokenMinter{token: InstallationToken{Token: "inst-token", ExpiresAt: time.Now().Add(time.Hour)}}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Fixes #1349

## What changed

- Added a collector-side organization existence check for ambiguous all-unsupported organization posture results.
- Marked user-owned repository owners as `not_an_organization` after GitHub confirms `/orgs/{owner}` is absent.
- Preserved plan/API-limited posture for real organizations so unsupported inherited controls remain visible.
- Added regressions for user-owned repository omission and plan-limited organization preservation.

## Why it changed

A post-merge review on #1334 found that API omission logic expected `not_an_organization`, but production collection never emitted it. User-owned repositories could therefore show pseudo organization posture with generic unavailable reasons.

## Impact and risk

- User-owned repositories omit organization posture instead of implying inherited organization policy coverage.
- Real organizations with limited GitHub plan/API support still return unsupported posture checks.
- The change is read-only and limited to GitHub organization posture classification.

## Validation performed

- `go test ./internal/connectors/github -run 'OrganizationPosture(MarksUserOwnerNotAnOrganization|PreservesPlanLimitedOrganization)' -count=1`\n- `go test ./internal/connectors/github`\n- `go test ./internal/api`\n- `git diff --check`\n- pre-commit hooks during commit: merge-conflict check, end-of-file check, trailing whitespace, gofmt, Vercel artifact hygiene\n- pre-push hooks during push: merge-conflict check, end-of-file check, trailing whitespace, gofmt, `go vet`, local env token hygiene, Vercel artifact hygiene\n\nAI-assisted: yes\nTools used: Codex\nWhere used: follow-up implementation, tests, validation, and PR preparation\nHuman verification performed: Reviewed focused diff and ran the validation commands above\n\nFollow-up to merged PR #1334.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes org posture for user-owned repositories by checking if the owner is an actual organization and marking results as `not_an_organization` when it’s a user. Real organizations keep plan/API-limited unsupported checks.

- **Bug Fixes**
  - Added a collector-side `/orgs/{owner}` existence check; 404 marks all checks as `not_an_organization` with evidence.
  - Preserved `plan_unavailable` and `organization_policy_unavailable` for real orgs.
  - Added tests for user-owned repos and plan-limited orgs.

<sup>Written for commit c10aba22e2e8c8205e3f56fb1536c5aad05ccdc7. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1350?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

