### PR TITLE
[codex] Fix queued GitHub App repo scan authorization

### DIFF
--- a/internal/api/github_connect.go
+++ b/internal/api/github_connect.go
@@ -858,12 +858,32 @@ func (s *Service) CompleteGitHubConnection(ctx context.Context, workspaceID stri
 }
 
 func (s *Service) GetGitHubConnection(ctx context.Context, workspaceID string, projectID string) (GitHubConnectionStatus, error) {
+	return s.githubConnectionStatus(ctx, workspaceID, projectID, false)
+}
+
+func (s *Service) refreshGitHubConnection(ctx context.Context, workspaceID string, projectID string) (GitHubConnectionStatus, error) {
+	return s.githubConnectionStatus(ctx, workspaceID, projectID, true)
+}
+
+func (s *Service) githubConnectionStatus(ctx context.Context, workspaceID string, projectID string, refresh bool) (GitHubConnectionStatus, error) {
 	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
 	if err != nil {
 		return GitHubConnectionStatus{}, err
 	}
 
 	key := githubConnectionKey(scope.TenantID, project.WorkspaceID, project.ProjectID)
+	if refresh {
+		loaded, loadErr := s.loadGitHubConnection(ctx, scope, project.WorkspaceID, project.ProjectID)
+		if loadErr != nil && !errors.Is(loadErr, db.ErrNotFound) {
+			return GitHubConnectionStatus{}, loadErr
+		}
+		if !loaded {
+			s.githubConnectMu.Lock()
+			delete(s.githubConnections, key)
+			s.githubConnectMu.Unlock()
+			return s.GetGitHubConnectorStatus(ctx, project.WorkspaceID, project.ProjectID)
+		}
+	}
 	s.githubConnectMu.RLock()
 	connection, exists := s.githubConnections[key]
 	s.githubConnectMu.RUnlock()

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1973,7 +1973,10 @@ func (s *Service) githubAppRepoScanCredential(ctx context.Context, record db.Rep
 	if source.ProjectID == "" || source.InstallationID <= 0 {
 		return repoexposure.HTTPSCloneCredential{}, ErrInvalidRepoScanRequest
 	}
-	status, err := s.GetGitHubConnection(ctx, record.WorkspaceID, source.ProjectID)
+	// Workers run in a separate process from the API that completed the install
+	// flow. Reload persisted connector state so repository selection changes are
+	// honored before minting a short-lived installation token.
+	status, err := s.refreshGitHubConnection(ctx, record.WorkspaceID, source.ProjectID)
 	if err != nil {
 		if errors.Is(err, ErrInvalidGitHubConnectionRequest) || errors.Is(err, ErrGitHubConnectionNotFound) || errors.Is(err, db.ErrNotFound) {
 			return repoexposure.HTTPSCloneCredential{}, ErrRepoTargetNotAllowed

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -502,16 +502,32 @@ func seedGitHubAppConnection(t *testing.T, svc *Service, ctx context.Context, pr
 	if err != nil {
 		t.Fatalf("resolve scope: %v", err)
 	}
-	svc.githubConnections[githubConnectionKey(scope.TenantID, scope.WorkspaceID, projectID)] = githubProjectConnection{
-		TenantID:             scope.TenantID,
-		WorkspaceID:          scope.WorkspaceID,
-		ProjectID:            projectID,
-		ConnectorID:          githubConnectorID,
-		Status:               domain.ConnectorStatusActive,
-		HealthStatus:         "healthy",
-		Provider:             "github_app",
-		InstallationID:       installationID,
-		SelectedRepositories: repositories,
+	now := time.Now().UTC()
+	envelope, err := svc.encryptGitHubWebhookSecret(scope, projectID, "test-github-webhook-secret")
+	if err != nil {
+		t.Fatalf("encrypt github webhook secret: %v", err)
+	}
+	connection := githubProjectConnection{
+		TenantID:               scope.TenantID,
+		WorkspaceID:            scope.WorkspaceID,
+		ProjectID:              projectID,
+		ConnectorID:            githubConnectorID,
+		DisplayName:            githubConnectorDisplayName,
+		Status:                 domain.ConnectorStatusActive,
+		HealthStatus:           "healthy",
+		Provider:               "github_app",
+		InstallationID:         installationID,
+		TokenReference:         fmt.Sprintf("github-app-installation:%d", installationID),
+		WebhookSecretReference: "github-app:webhook",
+		WebhookSecretEnvelope:  envelope,
+		WebhookSecretRotatedAt: now,
+		SelectedRepositories:   repositories,
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}
+	svc.githubConnections[githubConnectionKey(scope.TenantID, scope.WorkspaceID, projectID)] = connection
+	if err := svc.persistGitHubConnection(ctx, connection); err != nil {
+		t.Fatalf("persist github connection: %v", err)
 	}
 }
 
@@ -4339,6 +4355,54 @@ func TestServiceProcessQueuedGitHubAppRepoScanUsesInstallationToken(t *testing.T
 	}
 	if gotCredential.Host != "github.com" || gotCredential.Username != "x-access-token" || gotCredential.Password != "ghs_installation_token" {
 		t.Fatalf("unexpected clone credential %+v", gotCredential)
+	}
+}
+
+func TestServiceProcessQueuedGitHubAppRepoScanRefreshesStaleWorkerConnection(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := defaultScopeContext()
+	seedDefaultProject(t, store, ctx, "project-1")
+
+	apiSvc := NewService(store, fakeScanner{}, "aws")
+	workerSvc := NewService(store, fakeScanner{}, "aws")
+	seedGitHubAppConnection(t, workerSvc, ctx, "project-1", 101, []string{"owner/old-private"})
+	seedGitHubAppConnection(t, apiSvc, ctx, "project-1", 101, []string{"owner/new-private"})
+	workerSvc.GitHubInstallationTokenMinter = &fakeGitHubInstallationTokenMinter{
+		token: githubconnector.InstallationToken{Token: "ghs_installation_token", ExpiresAt: time.Now().Add(time.Hour)},
+	}
+	workerSvc.AuthenticatedRepoScannerFactory = func(historyLimit int, maxFindings int, credential repoexposure.HTTPSCloneCredential) RepoScanExecutor {
+		return &fakeRepoExecutor{
+			result: repoexposure.ScanResult{
+				Repository:     "owner/new-private",
+				CommitsScanned: 1,
+				FilesScanned:   1,
+			},
+		}
+	}
+
+	if _, err := apiSvc.EnqueueRepoScan(ctx, RepoScanRequest{
+		Repository: "owner/new-private",
+		ProjectID:  "project-1",
+	}); err != nil {
+		t.Fatalf("enqueue connector-backed repo scan: %v", err)
+	}
+	processed, err := workerSvc.ProcessNextQueuedRepoScan(ctx)
+	if err != nil {
+		t.Fatalf("process connector-backed repo scan with stale worker cache: %v", err)
+	}
+	if !processed {
+		t.Fatal("expected queued connector-backed repo scan to be processed")
+	}
+	minter := workerSvc.GitHubInstallationTokenMinter.(*fakeGitHubInstallationTokenMinter)
+	if minter.calls != 1 || minter.installationID != 101 {
+		t.Fatalf("expected one token mint for refreshed installation 101, got calls=%d installation=%d", minter.calls, minter.installationID)
+	}
+	records, err := store.ListRepoScans(ctx, 10)
+	if err != nil {
+		t.Fatalf("list repo scans: %v", err)
+	}
+	if len(records) != 1 || records[0].Status != "succeeded" {
+		t.Fatalf("expected refreshed worker connection to complete scan, got %+v", records)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Refresh persisted GitHub App connector state before a worker authorizes queued repository scans.
- Persist GitHub App connection test fixtures so service tests exercise the same API/worker process boundary as production.
- Add a regression test for a worker with stale selected-repository cache processing a newly selected GitHub App repository.

## Why

The production worker was failing queued personal-account repository scans with `repo target is not allowed` even after the API accepted the selected GitHub App repository. The API process can have fresh connector state from install/refresh, while the worker process can keep an older in-memory GitHub connection. This PR makes the worker reload persisted connector state before minting the installation token.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

## Validation

```bash
go test ./internal/api ./internal/worker
```

## Checklist

- [x] Tests added/updated for behavior changes
- [ ] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: yes
- Tools used: OpenAI Codex
- Areas where used: production log diagnosis, backend patch, regression test
- Human verification performed: local Go tests and diff review

## Related Issues

No issue: production hotfix for user-reported queued GitHub App repository scan failures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes queued GitHub App repo scans failing with "repo target is not allowed" by reloading persisted connection state in the worker and evicting stale cache before minting installation tokens. Ensures newly selected repositories are honored across API/worker boundaries.

- **Bug Fixes**
  - Worker refreshes persisted GitHub App connection before authorization to sync selected repositories.
  - Added a refresh path that reloads from the store and clears stale in-memory state, used during token minting.
  - Persisted connection in tests and added a regression test that verifies stale worker cache is refreshed and the correct installation token is minted.

<sup>Written for commit d5f9a4c1d228a35700b90f7cf13cf3ae10ae040e. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1351?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

