### PR TITLE
docs: sync Docker Hub overview

### DIFF
--- a/.github/workflows/sync-dockerhub-description.yml
+++ b/.github/workflows/sync-dockerhub-description.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   sync:
     name: Sync identrail/identrail overview
-    if: github.repository == 'identrail/identrail'
+    if: github.repository == 'identrail/identrail' && github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/sync-dockerhub-description.yml
+++ b/.github/workflows/sync-dockerhub-description.yml
@@ -1,0 +1,67 @@
+name: Sync Docker Hub Description
+
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - docs/dockerhub/identrail.md
+      - .github/workflows/sync-dockerhub-description.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  DOCKERHUB_README: docs/dockerhub/identrail.md
+  DOCKERHUB_SHORT_DESCRIPTION: Machine identity security for AWS IAM, Kubernetes, GitHub/OIDC, and repo exposure
+
+jobs:
+  sync:
+    name: Sync identrail/identrail overview
+    if: github.repository == 'identrail/identrail'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Validate Docker Hub metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ ! -f "${DOCKERHUB_README}" ]; then
+            echo "Missing Docker Hub README at ${DOCKERHUB_README}." >&2
+            exit 1
+          fi
+
+          readme_bytes="$(wc -c < "${DOCKERHUB_README}" | tr -d '[:space:]')"
+          short_description_bytes="$(printf '%s' "${DOCKERHUB_SHORT_DESCRIPTION}" | wc -c | tr -d '[:space:]')"
+
+          if [ "${readme_bytes}" -eq 0 ]; then
+            echo "Docker Hub README must not be empty." >&2
+            exit 1
+          fi
+
+          if [ "${readme_bytes}" -gt 25000 ]; then
+            echo "Docker Hub README is ${readme_bytes} bytes; Docker Hub allows at most 25000 bytes." >&2
+            exit 1
+          fi
+
+          if [ "${short_description_bytes}" -gt 100 ]; then
+            echo "Docker Hub short description is ${short_description_bytes} bytes; Docker Hub allows at most 100 bytes." >&2
+            exit 1
+          fi
+
+          echo "Docker Hub README is ${readme_bytes} bytes."
+          echo "Docker Hub short description is ${short_description_bytes} bytes."
+
+      - name: Sync Docker Hub repository description
+        uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae # v4.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: identrail/identrail
+          short-description: ${{ env.DOCKERHUB_SHORT_DESCRIPTION }}
+          readme-filepath: ${{ env.DOCKERHUB_README }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Added a Docker Hub repository overview source and sync workflow so
+  `identrail/identrail` presents a maintained, container-focused description on
+  Docker Hub instead of relying on indexed image layer pages.
 - Added GitHub Actions AI-agent prompt-injection detection for workflows that
   feed untrusted PR, issue, review, comment, workflow_run, or repository
   prompt-file content into LLM/agent steps with repository write, secret, OIDC,

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -37,6 +37,9 @@ Manual setup:
 
 `docker pull` only downloads an image into Docker's image store. It does not
 create a project folder, `.env` file, or runnable multi-service stack on disk.
+The public Docker Hub overview for `identrail/identrail` is maintained in
+`docs/dockerhub/identrail.md` and synced by the Docker Hub description workflow
+after changes merge to `dev`.
 
 For a no-clone, no-build evaluation path, download the published Compose file
 and run it directly. The public stack pulls from Docker Hub by default:

--- a/docs/dockerhub/identrail.md
+++ b/docs/dockerhub/identrail.md
@@ -1,0 +1,108 @@
+# Identrail
+
+Identrail is a machine identity security platform for AWS IAM, Kubernetes,
+GitHub/OIDC, and repository exposure signals. It helps teams discover risky
+trust paths, exposed automation credentials, over-privileged workflows, and
+cloud or cluster identity posture issues with evidence-backed findings.
+
+This Docker Hub repository publishes the primary Identrail API image. Use it
+directly for API evaluation, or run the public Compose stack when you want the
+API, worker, web UI, and database together.
+
+## Quick start with public images
+
+The fastest no-clone path is the public Compose profile:
+
+```bash
+mkdir identrail-docker && cd identrail-docker
+curl -fsSLO https://raw.githubusercontent.com/identrail/identrail/dev/deploy/docker/docker-compose.public.yml
+docker compose -f docker-compose.public.yml up -d
+```
+
+Check the API and then open the web UI:
+
+```bash
+curl http://localhost:8080/healthz
+```
+
+Web UI: `http://localhost:8081`
+
+The public stack is intended for local evaluation. It binds the API and web UI
+to `127.0.0.1`, keeps Postgres inside the Docker network, and enables local
+manual-mode onboarding so you can create a disposable workspace without a
+hosted identity provider.
+
+## Pull the main image
+
+```bash
+docker pull docker.io/identrail/identrail:dev
+```
+
+Run the API by itself with disposable in-memory storage:
+
+```bash
+docker run --rm -p 8080:8080 \
+  -e IDENTRAIL_ALLOW_MEMORY_STORE=true \
+  -e IDENTRAIL_RUN_MIGRATIONS=false \
+  -e IDENTRAIL_API_KEYS=identrail-local-read-key-change-me,identrail-local-write-key-change-me \
+  -e IDENTRAIL_WRITE_API_KEYS=identrail-local-write-key-change-me \
+  docker.io/identrail/identrail:dev
+```
+
+Then verify:
+
+```bash
+curl http://localhost:8080/healthz
+```
+
+## Images
+
+| Image | Purpose |
+| --- | --- |
+| `identrail/identrail` | Primary API server and machine identity engine |
+| `identrail/identrail-api` | API alias for deployments that prefer explicit service naming |
+| `identrail/identrail-worker` | Background scan worker for repository and posture jobs |
+| `identrail/identrail-web` | Local web dashboard image |
+| `identrail/identrail-cli` | Command-line scanner |
+| `identrail/identrail-agent` | Kubernetes connector agent |
+
+GHCR mirrors are also published under `ghcr.io/identrail`.
+
+## Tags
+
+| Tag | Use |
+| --- | --- |
+| `dev` | Moving image from the `dev` branch. Useful for local evaluation. |
+| `sha-<12-char-sha>` | Immutable image for a specific source commit. Prefer this for reviewed deployments. |
+| `vX.Y.Z` | Release image when a versioned release is cut. Prefer this for stable installs. |
+
+Avoid using a moving tag for production-like deployments. Pin either a release
+tag or an immutable `sha-...` tag so the running container can be traced back to
+the exact source commit.
+
+## Platforms
+
+Identrail images are published for:
+
+- `linux/amd64`
+- `linux/arm64`
+
+Native Windows container images are not published. Windows users can run these
+Linux images with Docker Desktop and WSL2, which is the normal container setup
+for local evaluation.
+
+## Security notes
+
+- Rotate all example API keys, session keys, and database passwords before any
+  non-local deployment.
+- Do not expose the local evaluation stack directly to the internet.
+- For production-style single-host deployments, use TLS, a real Postgres
+  database, and the hardening examples in the repository deployment docs.
+- Repository exposure scans use read-only GitHub evidence collection and do not
+  store raw secret values.
+
+## Links
+
+- Website: https://identrail.com
+- Source: https://github.com/identrail/identrail
+- Docker deployment docs: https://github.com/identrail/identrail/blob/dev/deploy/docker/README.md


### PR DESCRIPTION
## Summary

Adds a maintained Docker Hub overview for `identrail/identrail` and a pinned GitHub Actions workflow that syncs that copy to Docker Hub after changes merge to `dev`.

## Why

Google and Docker Hub can currently surface technical image-layer pages before a polished repository overview. This gives the primary Docker Hub image a product-ready, container-focused description with quickstart commands, tag guidance, supported platforms, and links back to the source and deployment docs.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed

Risk is low: this does not change image builds or runtime behavior. It only adds Docker Hub presentation copy and a workflow that uses the existing Docker Hub credentials already required by image publishing.

## Validation

```bash
git diff --check
python3 - <<'PY'
from pathlib import Path
import yaml
with Path('.github/workflows/sync-dockerhub-description.yml').open() as f:
    yaml.safe_load(f)
print('workflow yaml ok')
PY
readme_bytes=$(wc -c < docs/dockerhub/identrail.md | tr -d '[:space:]'); short_bytes=$(printf '%s' 'Machine identity security for AWS IAM, Kubernetes, GitHub/OIDC, and repo exposure' | wc -c | tr -d '[:space:]'); test "$readme_bytes" -le 25000; test "$short_bytes" -le 100
go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 && actionlint -shellcheck= .github/workflows/sync-dockerhub-description.yml
```

Local results: whitespace check passed, YAML parsed, Docker Hub byte-limit checks passed (`3675` byte README, `81` byte short description), and actionlint passed. Commit/push hooks also passed.

The local Docker-based actionlint path could not run because no Docker daemon was available on this machine, so the actionlint Go binary was used instead.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

No runtime tests were added because this is docs/workflow metadata only.

## AI Assistance Disclosure

- AI-assisted: yes
- Tools used: Codex
- Areas where used: Docker Hub description copy, GitHub Actions workflow, documentation note, changelog entry
- Human verification performed: reviewed diff, ran YAML parse, actionlint, byte-limit checks, git whitespace check, and repository hooks

## Related Issues

No issue: Docker Hub presentation and metadata sync polish requested directly by maintainer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a maintained Docker Hub overview for `identrail/identrail` and a workflow that syncs it to Docker Hub when `dev` updates. Tightens execution to the main repo and `dev` branch only; no build or runtime changes.

- New Features
  - Added `docs/dockerhub/identrail.md` with quickstart, tag guidance, supported platforms, and links.
  - Added `.github/workflows/sync-dockerhub-description.yml` to validate size limits (README ≤ 25 KB, short description ≤ 100 bytes) and sync via `peter-evans/dockerhub-description`; runs on `dev` updates and manual dispatch but is restricted to `refs/heads/dev` in the main repo; uses existing Docker Hub secrets.
  - Noted the source-of-truth in `deploy/docker/README.md` and updated `CHANGELOG.md`.

<sup>Written for commit f55d5fa3bcaba2b4835a3023dd886cd2cce0a03c. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1359?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

