### PR TITLE
Expand normalized identity graph relationship contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Expanded the normalized identity graph contract with precise AWS machine and
+  agent relationship semantics for workload execution, secrets, KMS decrypt,
+  role passing, invocations, tool calls, delegated users, runtime sessions, and
+  observed actions, with domain metadata, endpoint validation, tests, and docs.
 - Added GitHub Actions AI-agent prompt-injection detection for workflows that
   feed untrusted PR, issue, review, comment, workflow_run, or repository
   prompt-file content into LLM/agent steps with repository write, secret, OIDC,

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -288,9 +288,9 @@ This file tracks major decisions in simple terms.
 
 ## ADR-048: Freeze Graph Semantics with Explicit Relationship Contract
 - Date: 2026-03-19
-- Decision: Explicitly define supported relationship semantics (`can_assume`, `attached_policy`, `attached_to`, `bound_to`, `can_access`, `can_impersonate`) and validate relationship types against this contract.
+- Decision: Explicitly define supported relationship semantics (`can_assume`, `attached_policy`, `attached_to`, `bound_to`, `can_access`, `can_impersonate`, `runs_as`, `uses_secret`, `can_decrypt`, `can_pass_role`, `invokes`, `calls_tool`, `acts_for_user`, `has_runtime_session`, `observed_action`) and validate relationship types against this contract.
 - Why: Prevent silent graph-schema drift that would break findings logic, API consumers, and path analysis semantics.
-- Tradeoff: New relationship types require explicit contract updates before rollout.
+- Tradeoff: New relationship types require explicit contract updates before rollout, and precise AWS/agent semantics must carry endpoint-specific evidence instead of being collapsed into generic `can_access` edges.
 
 ## ADR-049: Enforce Deterministic Risk Evidence Ordering
 - Date: 2026-03-19

--- a/docs/aws-normalizer-graph.md
+++ b/docs/aws-normalizer-graph.md
@@ -19,6 +19,14 @@ This module converts raw IAM role assets into normalized domain entities and gra
    - `can_assume` (principal -> identity)
    - `can_access` (identity -> access node)
 
+The wider graph contract also supports precise AWS machine and agent identity
+edges such as `runs_as`, `uses_secret`, `can_decrypt`, `can_pass_role`,
+`invokes`, `calls_tool`, `acts_for_user`, `has_runtime_session`, and
+`observed_action`. The current IAM graph builder only emits edges it can prove
+from collected IAM role and policy evidence; later collectors should use the
+precise edge types instead of overloading `can_access` when runtime, secret,
+KMS, agent, or delegation evidence is available.
+
 ## Key Decisions
 
 - Trust and permission policies are retained as normalized policy records, preserving explainability.

--- a/docs/graph-relationship-contract.md
+++ b/docs/graph-relationship-contract.md
@@ -1,0 +1,41 @@
+# Graph Relationship Contract
+
+The normalized graph contract defines the only relationship semantics that
+provider pipelines may emit. Relationship types are canonical in
+`internal/domain/types.go`, contract metadata is canonical in
+`internal/domain/relationship_contract.go`, and endpoint validation is enforced
+by `internal/providers/graph_contract.go`.
+
+Provider collectors should prefer precise relationship types whenever the
+source evidence proves a specific semantic. Use `can_access` only for a generic
+permission on an action/resource tuple when no more precise edge type applies.
+For example, use `can_decrypt` for KMS decrypt capability, `can_pass_role` for
+AWS role delegation, and `uses_secret` for explicit secret material usage
+instead of collapsing those edges into generic `can_access`.
+
+## Supported relationships
+
+| Relationship | Direction | Required endpoints | Evidence expectation |
+| --- | --- | --- | --- |
+| `can_assume` | principal or identity -> identity | source is an existing identity or `aws:principal:` node; target is an existing identity | Trust policy, federation mapping, or provider delegation record naming the target identity. |
+| `attached_policy` | identity -> policy | source is an existing identity; target is an existing policy | Provider policy attachment or inline policy source. |
+| `attached_to` | workload -> identity | source is an existing workload; target is an existing identity | Provider workload-to-identity attachment record. |
+| `bound_to` | workload -> identity | source is an existing workload; target is an existing identity | Provider binding record such as Kubernetes RBAC or service-account binding. |
+| `can_access` | identity -> access node | source is an existing identity; target starts with `aws:access:` or `k8s:access:` | Normalized permission statement granting the action/resource pair. |
+| `can_impersonate` | identity or workload -> identity | source is an existing identity or workload; target is an existing identity | Provider impersonation, token exchange, or workload identity binding evidence. |
+| `runs_as` | workload -> identity | source is an existing workload; target is an existing identity | Runtime or workload configuration proving the identity used at execution time. |
+| `uses_secret` | actor -> secret node | source is an existing identity, existing workload, or `agent:` node; target starts with `secret:`, `aws:secret:`, or `k8s:secret:` | Secret reference, environment mount, runtime configuration, or observed secret fetch. |
+| `can_decrypt` | identity -> KMS key node | source is an existing identity; target starts with `kms:` or `aws:kms:` | Key policy or permission statement granting decrypt on the key. |
+| `can_pass_role` | identity -> role identity | source is an existing identity; target is an existing `role` identity | Permission statement granting `iam:PassRole` or provider-equivalent delegation. |
+| `invokes` | actor -> invocable node | source is an existing identity, existing workload, or `agent:` node; target is an existing workload or starts with `invocable:`, `aws:lambda:`, `aws:service:`, `aws:resource:`, `k8s:workload:`, or `agent:` | Permission, trigger, trace, or runtime event proving the invocation path. |
+| `calls_tool` | actor -> tool node | source is an existing identity, existing workload, or `agent:` node; target starts with `tool:`, `mcp:tool:`, or `agent:tool:` | Agent configuration, MCP manifest, trace, or runtime event proving the tool call. |
+| `acts_for_user` | actor -> user identity | source is an existing identity, existing workload, or `agent:` node; target is an existing `user` identity | Delegation token, session binding, audit event, or authorization grant naming the user. |
+| `has_runtime_session` | actor -> runtime session node | source is an existing identity, existing workload, or `agent:` node; target starts with `session:`, `runtime:session:`, `aws:session:`, or `k8s:session:` | Runtime session, STS credential session, pod execution, or trace correlation record. |
+| `observed_action` | actor or runtime session -> action node | source is an existing identity, existing workload, `agent:` node, or runtime session node; target is an access node or starts with `action:`, `aws:action:`, or `k8s:action:` | Audit log, trace span, runtime event, or provider activity record. |
+
+## Compatibility
+
+Existing AWS and Kubernetes graph emitters remain compatible. This contract
+change reserves and validates the expanded relationship vocabulary; it does not
+require collectors to emit new edges until follow-up collector work has concrete
+source evidence.

--- a/docs/threat_model.md
+++ b/docs/threat_model.md
@@ -234,7 +234,7 @@ Simple threat list for current system.
 
 ## 47) Graph Semantic Drift
 - Threat: New or mistyped relationship names can silently enter storage and break path logic and findings.
-- Fix: Validate relationships against an explicit supported semantic contract and enforce fixture-based contract tests.
+- Fix: Validate relationships against an explicit supported semantic contract, including precise AWS machine and agent identity edge types, and enforce fixture-based contract tests.
 - Status: Implemented.
 
 ## 48) Non-Deterministic Finding Evidence

--- a/docs/v1_scope_and_baseline.md
+++ b/docs/v1_scope_and_baseline.md
@@ -42,6 +42,15 @@ contract.
   - `bound_to`
   - `can_access`
   - `can_impersonate`
+  - `runs_as`
+  - `uses_secret`
+  - `can_decrypt`
+  - `can_pass_role`
+  - `invokes`
+  - `calls_tool`
+  - `acts_for_user`
+  - `has_runtime_session`
+  - `observed_action`
 - Fixture-based contract tests verify normalized identities and relationship types for AWS and Kubernetes pipelines.
 
 ## 5) Risk Engine Productionization
@@ -83,6 +92,10 @@ contract.
   - relationship ID uniqueness
   - semantic tuple uniqueness (`type + from + to`)
   - required discovery timestamp on all edges
+- Precise AWS machine and agent identity semantics are reserved in the contract
+  so future collectors can model secrets, KMS decrypt capability, role passing,
+  invocations, tool calls, delegated users, runtime sessions, and observed
+  actions without overloading generic `can_access` edges.
 - AWS and Kubernetes graph snapshots were added as regression fixtures.
 
 ## 10) Risk Rule Reliability Baseline

--- a/internal/domain/relationship_contract.go
+++ b/internal/domain/relationship_contract.go
@@ -1,0 +1,159 @@
+package domain
+
+// RelationshipEndpointKind names the endpoint shape required by a relationship
+// semantic in the normalized graph contract.
+type RelationshipEndpointKind string
+
+const (
+	RelationshipEndpointIdentity             RelationshipEndpointKind = "identity"
+	RelationshipEndpointIdentityOrPrincipal  RelationshipEndpointKind = "identity_or_aws_principal"
+	RelationshipEndpointIdentityOrWorkload   RelationshipEndpointKind = "identity_or_workload"
+	RelationshipEndpointWorkload             RelationshipEndpointKind = "workload"
+	RelationshipEndpointPolicy               RelationshipEndpointKind = "policy"
+	RelationshipEndpointAccess               RelationshipEndpointKind = "access"
+	RelationshipEndpointSecret               RelationshipEndpointKind = "secret"
+	RelationshipEndpointKMSKey               RelationshipEndpointKind = "kms_key"
+	RelationshipEndpointRoleIdentity         RelationshipEndpointKind = "role_identity"
+	RelationshipEndpointActor                RelationshipEndpointKind = "identity_workload_or_agent"
+	RelationshipEndpointInvocable            RelationshipEndpointKind = "invocable"
+	RelationshipEndpointTool                 RelationshipEndpointKind = "tool"
+	RelationshipEndpointUserIdentity         RelationshipEndpointKind = "user_identity"
+	RelationshipEndpointRuntimeSession       RelationshipEndpointKind = "runtime_session"
+	RelationshipEndpointActorOrRuntime       RelationshipEndpointKind = "identity_workload_agent_or_runtime_session"
+	RelationshipEndpointObservedActionTarget RelationshipEndpointKind = "observed_action_target"
+)
+
+// RelationshipContract documents the direction, required endpoint kinds, and
+// evidence expectation for a supported graph relationship semantic.
+type RelationshipContract struct {
+	Type        RelationshipType
+	From        RelationshipEndpointKind
+	To          RelationshipEndpointKind
+	Evidence    string
+	Description string
+}
+
+var relationshipContracts = map[RelationshipType]RelationshipContract{
+	RelationshipCanAssume: {
+		Type:        RelationshipCanAssume,
+		From:        RelationshipEndpointIdentityOrPrincipal,
+		To:          RelationshipEndpointIdentity,
+		Evidence:    "trust policy, federation mapping, or provider delegation record naming the target identity",
+		Description: "A principal or identity is allowed to assume another identity.",
+	},
+	RelationshipAttachedPolicy: {
+		Type:        RelationshipAttachedPolicy,
+		From:        RelationshipEndpointIdentity,
+		To:          RelationshipEndpointPolicy,
+		Evidence:    "provider policy attachment or inline policy source",
+		Description: "A policy document is attached to an identity.",
+	},
+	RelationshipAttachedTo: {
+		Type:        RelationshipAttachedTo,
+		From:        RelationshipEndpointWorkload,
+		To:          RelationshipEndpointIdentity,
+		Evidence:    "provider workload-to-identity attachment record",
+		Description: "A workload is attached to an identity by platform configuration.",
+	},
+	RelationshipBoundTo: {
+		Type:        RelationshipBoundTo,
+		From:        RelationshipEndpointWorkload,
+		To:          RelationshipEndpointIdentity,
+		Evidence:    "provider binding record such as Kubernetes RBAC or service-account binding",
+		Description: "A workload is bound to an identity through an authorization binding.",
+	},
+	RelationshipCanAccess: {
+		Type:        RelationshipCanAccess,
+		From:        RelationshipEndpointIdentity,
+		To:          RelationshipEndpointAccess,
+		Evidence:    "normalized permission statement granting the action/resource pair",
+		Description: "An identity can access an action/resource tuple when no more precise edge applies.",
+	},
+	RelationshipCanImpersonate: {
+		Type:        RelationshipCanImpersonate,
+		From:        RelationshipEndpointIdentityOrWorkload,
+		To:          RelationshipEndpointIdentity,
+		Evidence:    "provider impersonation, token exchange, or workload identity binding evidence",
+		Description: "An identity or workload can impersonate another identity.",
+	},
+	RelationshipRunsAs: {
+		Type:        RelationshipRunsAs,
+		From:        RelationshipEndpointWorkload,
+		To:          RelationshipEndpointIdentity,
+		Evidence:    "runtime or workload configuration proving the identity used at execution time",
+		Description: "A workload executes as the target machine identity.",
+	},
+	RelationshipUsesSecret: {
+		Type:        RelationshipUsesSecret,
+		From:        RelationshipEndpointActor,
+		To:          RelationshipEndpointSecret,
+		Evidence:    "secret reference, environment mount, runtime configuration, or observed secret fetch",
+		Description: "An actor uses a secret material source.",
+	},
+	RelationshipCanDecrypt: {
+		Type:        RelationshipCanDecrypt,
+		From:        RelationshipEndpointIdentity,
+		To:          RelationshipEndpointKMSKey,
+		Evidence:    "key policy or permission statement granting decrypt on the key",
+		Description: "An identity can decrypt data with a cryptographic key.",
+	},
+	RelationshipCanPassRole: {
+		Type:        RelationshipCanPassRole,
+		From:        RelationshipEndpointIdentity,
+		To:          RelationshipEndpointRoleIdentity,
+		Evidence:    "permission statement granting iam:PassRole or provider-equivalent delegation",
+		Description: "An identity can pass a role identity to another AWS service or workload.",
+	},
+	RelationshipInvokes: {
+		Type:        RelationshipInvokes,
+		From:        RelationshipEndpointActor,
+		To:          RelationshipEndpointInvocable,
+		Evidence:    "permission, trigger, trace, or runtime event proving the invocation path",
+		Description: "An actor invokes a workload, function, service, or agent endpoint.",
+	},
+	RelationshipCallsTool: {
+		Type:        RelationshipCallsTool,
+		From:        RelationshipEndpointActor,
+		To:          RelationshipEndpointTool,
+		Evidence:    "agent configuration, MCP manifest, trace, or runtime event proving the tool call",
+		Description: "An agent-capable actor can call a tool.",
+	},
+	RelationshipActsForUser: {
+		Type:        RelationshipActsForUser,
+		From:        RelationshipEndpointActor,
+		To:          RelationshipEndpointUserIdentity,
+		Evidence:    "delegation token, session binding, audit event, or authorization grant naming the user",
+		Description: "An actor performs work delegated by or on behalf of a user identity.",
+	},
+	RelationshipRuntimeSession: {
+		Type:        RelationshipRuntimeSession,
+		From:        RelationshipEndpointActor,
+		To:          RelationshipEndpointRuntimeSession,
+		Evidence:    "runtime session, STS credential session, pod execution, or trace correlation record",
+		Description: "An actor has an observed runtime session.",
+	},
+	RelationshipObservedAction: {
+		Type:        RelationshipObservedAction,
+		From:        RelationshipEndpointActorOrRuntime,
+		To:          RelationshipEndpointObservedActionTarget,
+		Evidence:    "audit log, trace span, runtime event, or provider activity record",
+		Description: "An actor or runtime session was observed performing an action.",
+	},
+}
+
+// RelationshipContractFor returns the canonical contract metadata for a
+// supported relationship semantic.
+func RelationshipContractFor(rel RelationshipType) (RelationshipContract, bool) {
+	contract, ok := relationshipContracts[rel]
+	return contract, ok
+}
+
+// RelationshipContracts returns a copy of the canonical relationship contract
+// metadata so callers cannot mutate the package-level contract.
+func RelationshipContracts() map[RelationshipType]RelationshipContract {
+	contracts := make(map[RelationshipType]RelationshipContract, len(relationshipContracts))
+	for rel, contract := range relationshipContracts {
+		contracts[rel] = contract
+	}
+	return contracts
+}

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -31,6 +31,15 @@ const (
 	RelationshipBoundTo        RelationshipType = "bound_to"
 	RelationshipCanAccess      RelationshipType = "can_access"
 	RelationshipCanImpersonate RelationshipType = "can_impersonate"
+	RelationshipRunsAs         RelationshipType = "runs_as"
+	RelationshipUsesSecret     RelationshipType = "uses_secret"
+	RelationshipCanDecrypt     RelationshipType = "can_decrypt"
+	RelationshipCanPassRole    RelationshipType = "can_pass_role"
+	RelationshipInvokes        RelationshipType = "invokes"
+	RelationshipCallsTool      RelationshipType = "calls_tool"
+	RelationshipActsForUser    RelationshipType = "acts_for_user"
+	RelationshipRuntimeSession RelationshipType = "has_runtime_session"
+	RelationshipObservedAction RelationshipType = "observed_action"
 )
 
 // FindingSeverity aligns risk scoring with operator expectations.

--- a/internal/domain/validation.go
+++ b/internal/domain/validation.go
@@ -2,19 +2,10 @@ package domain
 
 import "strings"
 
-var supportedRelationshipTypes = map[RelationshipType]struct{}{
-	RelationshipCanAssume:      {},
-	RelationshipAttachedPolicy: {},
-	RelationshipAttachedTo:     {},
-	RelationshipBoundTo:        {},
-	RelationshipCanAccess:      {},
-	RelationshipCanImpersonate: {},
-}
-
 // IsSupportedRelationshipType reports whether the relationship semantic is part
 // of the v1 graph contract.
 func IsSupportedRelationshipType(rel RelationshipType) bool {
-	_, ok := supportedRelationshipTypes[rel]
+	_, ok := RelationshipContractFor(rel)
 	return ok
 }
 

--- a/internal/domain/validation_test.go
+++ b/internal/domain/validation_test.go
@@ -28,6 +28,50 @@ func TestRelationshipValidate(t *testing.T) {
 	}
 }
 
+func TestRelationshipContractSupportsExpandedTypes(t *testing.T) {
+	supported := []RelationshipType{
+		RelationshipCanAssume,
+		RelationshipAttachedPolicy,
+		RelationshipAttachedTo,
+		RelationshipBoundTo,
+		RelationshipCanAccess,
+		RelationshipCanImpersonate,
+		RelationshipRunsAs,
+		RelationshipUsesSecret,
+		RelationshipCanDecrypt,
+		RelationshipCanPassRole,
+		RelationshipInvokes,
+		RelationshipCallsTool,
+		RelationshipActsForUser,
+		RelationshipRuntimeSession,
+		RelationshipObservedAction,
+	}
+
+	for _, relationshipType := range supported {
+		if !IsSupportedRelationshipType(relationshipType) {
+			t.Fatalf("expected %s to be supported", relationshipType)
+		}
+		contract, ok := RelationshipContractFor(relationshipType)
+		if !ok {
+			t.Fatalf("expected contract for %s", relationshipType)
+		}
+		if contract.Type != relationshipType || contract.From == "" || contract.To == "" || contract.Evidence == "" {
+			t.Fatalf("incomplete contract for %s: %+v", relationshipType, contract)
+		}
+	}
+
+	if IsSupportedRelationshipType(RelationshipType("custom_rel")) {
+		t.Fatal("expected custom relationship to be unsupported")
+	}
+
+	contracts := RelationshipContracts()
+	contracts[RelationshipRunsAs] = RelationshipContract{}
+	contract, ok := RelationshipContractFor(RelationshipRunsAs)
+	if !ok || contract.From == "" {
+		t.Fatal("expected RelationshipContracts to return a defensive copy")
+	}
+}
+
 func TestFindingValidate(t *testing.T) {
 	valid := Finding{ID: "1", Type: FindingEscalationPath, Severity: SeverityHigh, Title: "Escalation path found"}
 	if !valid.Validate() {

--- a/internal/providers/contracts_validation_test.go
+++ b/internal/providers/contracts_validation_test.go
@@ -360,6 +360,7 @@ func TestValidateGraphContractCoverageBranches(t *testing.T) {
 		Identities: []domain.Identity{
 			{ID: "id-a", Provider: domain.ProviderAWS, Type: domain.IdentityTypeRole, Name: "a"},
 			{ID: "id-b", Provider: domain.ProviderAWS, Type: domain.IdentityTypeRole, Name: "b"},
+			{ID: "user-a", Provider: domain.ProviderAWS, Type: domain.IdentityTypeUser, Name: "human-a"},
 		},
 		Workloads: []domain.Workload{
 			{ID: "wl-a", Provider: domain.ProviderKubernetes, Type: "pod", Name: "api"},
@@ -390,6 +391,15 @@ func TestValidateGraphContractCoverageBranches(t *testing.T) {
 		{ID: "r4", Type: domain.RelationshipCanAssume, FromNodeID: "aws:principal:111122223333:root", ToNodeID: "id-a", DiscoveredAt: now},
 		{ID: "r5", Type: domain.RelationshipCanImpersonate, FromNodeID: "wl-a", ToNodeID: "id-a", DiscoveredAt: now},
 		{ID: "r6", Type: domain.RelationshipCanAccess, FromNodeID: "id-a", ToNodeID: "k8s:access:get:pods", DiscoveredAt: now},
+		{ID: "r7", Type: domain.RelationshipRunsAs, FromNodeID: "wl-a", ToNodeID: "id-a", DiscoveredAt: now},
+		{ID: "r8", Type: domain.RelationshipUsesSecret, FromNodeID: "id-a", ToNodeID: "aws:secret:secretsmanager:prod/db", DiscoveredAt: now},
+		{ID: "r9", Type: domain.RelationshipCanDecrypt, FromNodeID: "id-a", ToNodeID: "aws:kms:key/abcd", DiscoveredAt: now},
+		{ID: "r10", Type: domain.RelationshipCanPassRole, FromNodeID: "id-a", ToNodeID: "id-b", DiscoveredAt: now},
+		{ID: "r11", Type: domain.RelationshipInvokes, FromNodeID: "wl-a", ToNodeID: "aws:lambda:function:rotate", DiscoveredAt: now},
+		{ID: "r12", Type: domain.RelationshipCallsTool, FromNodeID: "agent:bedrock:reviewer", ToNodeID: "tool:mcp:github.search", DiscoveredAt: now},
+		{ID: "r13", Type: domain.RelationshipActsForUser, FromNodeID: "agent:bedrock:reviewer", ToNodeID: "user-a", DiscoveredAt: now},
+		{ID: "r14", Type: domain.RelationshipRuntimeSession, FromNodeID: "id-a", ToNodeID: "aws:session:sts:session-1", DiscoveredAt: now},
+		{ID: "r15", Type: domain.RelationshipObservedAction, FromNodeID: "aws:session:sts:session-1", ToNodeID: "aws:access:s3%3AGetObject:arn%3Aaws%3As3%3A%3A%3Aprod%2F%2A", DiscoveredAt: now},
 	}
 	if err := ValidateGraphContract(bundle, valid); err != nil {
 		t.Fatalf("expected valid relationships, got %v", err)
@@ -436,6 +446,34 @@ func TestValidateGraphContractCoverageBranches(t *testing.T) {
 				{ID: "y", Type: domain.RelationshipCanImpersonate, FromNodeID: "missing", ToNodeID: "id-a", DiscoveredAt: now},
 			},
 			needle: "unknown source",
+		},
+		{
+			name: "bad uses_secret target",
+			relationships: []domain.Relationship{
+				{ID: "secret", Type: domain.RelationshipUsesSecret, FromNodeID: "id-a", ToNodeID: "plain-secret", DiscoveredAt: now},
+			},
+			needle: "invalid secret node",
+		},
+		{
+			name: "bad can_pass_role target",
+			relationships: []domain.Relationship{
+				{ID: "pass", Type: domain.RelationshipCanPassRole, FromNodeID: "id-a", ToNodeID: "user-a", DiscoveredAt: now},
+			},
+			needle: "target role identity",
+		},
+		{
+			name: "bad acts_for_user target",
+			relationships: []domain.Relationship{
+				{ID: "delegate", Type: domain.RelationshipActsForUser, FromNodeID: "agent:bedrock:reviewer", ToNodeID: "id-a", DiscoveredAt: now},
+			},
+			needle: "target user identity",
+		},
+		{
+			name: "bad observed_action target",
+			relationships: []domain.Relationship{
+				{ID: "observed", Type: domain.RelationshipObservedAction, FromNodeID: "aws:session:sts:session-1", ToNodeID: "plain-action", DiscoveredAt: now},
+			},
+			needle: "invalid action node",
 		},
 	}
 	for _, tc := range tests {

--- a/internal/providers/graph_contract.go
+++ b/internal/providers/graph_contract.go
@@ -11,8 +11,10 @@ import (
 // across normalized entities and graph edges.
 func ValidateGraphContract(bundle NormalizedBundle, relationships []domain.Relationship) error {
 	identityIDs := map[string]struct{}{}
+	identityTypes := map[string]domain.IdentityType{}
 	for _, identity := range bundle.Identities {
 		identityIDs[identity.ID] = struct{}{}
+		identityTypes[identity.ID] = identity.Type
 	}
 	workloadIDs := map[string]struct{}{}
 	for _, workload := range bundle.Workloads {
@@ -43,7 +45,7 @@ func ValidateGraphContract(bundle NormalizedBundle, relationships []domain.Relat
 		}
 		seenSemantics[semanticKey] = struct{}{}
 
-		if err := validateRelationshipEndpoints(relationship, identityIDs, workloadIDs, policyIDs); err != nil {
+		if err := validateRelationshipEndpoints(relationship, identityIDs, identityTypes, workloadIDs, policyIDs); err != nil {
 			return err
 		}
 	}
@@ -53,6 +55,7 @@ func ValidateGraphContract(bundle NormalizedBundle, relationships []domain.Relat
 func validateRelationshipEndpoints(
 	relationship domain.Relationship,
 	identityIDs map[string]struct{},
+	identityTypes map[string]domain.IdentityType,
 	workloadIDs map[string]struct{},
 	policyIDs map[string]struct{},
 ) error {
@@ -67,6 +70,45 @@ func validateRelationshipEndpoints(
 	hasPolicy := func(id string) bool {
 		_, ok := policyIDs[id]
 		return ok
+	}
+	hasIdentityType := func(id string, identityType domain.IdentityType) bool {
+		got, ok := identityTypes[id]
+		return ok && got == identityType
+	}
+	hasAnyPrefix := func(id string, prefixes ...string) bool {
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(id, prefix) {
+				return true
+			}
+		}
+		return false
+	}
+	hasAgent := func(id string) bool {
+		return hasAnyPrefix(id, "agent:", "ai:agent:", "aws:agent:")
+	}
+	hasActor := func(id string) bool {
+		return hasIdentity(id) || hasWorkload(id) || hasAgent(id)
+	}
+	hasAccessNode := func(id string) bool {
+		return hasAnyPrefix(id, "aws:access:", "k8s:access:")
+	}
+	hasActionNode := func(id string) bool {
+		return hasAccessNode(id) || hasAnyPrefix(id, "action:", "aws:action:", "k8s:action:")
+	}
+	hasSecretNode := func(id string) bool {
+		return hasAnyPrefix(id, "secret:", "aws:secret:", "k8s:secret:")
+	}
+	hasKMSKeyNode := func(id string) bool {
+		return hasAnyPrefix(id, "kms:", "aws:kms:")
+	}
+	hasRuntimeSession := func(id string) bool {
+		return hasAnyPrefix(id, "session:", "runtime:session:", "aws:session:", "k8s:session:")
+	}
+	hasInvocable := func(id string) bool {
+		return hasWorkload(id) || hasAnyPrefix(id, "invocable:", "aws:lambda:", "aws:service:", "aws:resource:", "k8s:workload:", "agent:")
+	}
+	hasTool := func(id string) bool {
+		return hasAnyPrefix(id, "tool:", "mcp:tool:", "agent:tool:")
 	}
 
 	switch relationship.Type {
@@ -114,10 +156,73 @@ func validateRelationshipEndpoints(
 		if !hasIdentity(relationship.FromNodeID) {
 			return fmt.Errorf("can_access relationship %q has unknown source identity %q", relationship.ID, relationship.FromNodeID)
 		}
-		if strings.HasPrefix(relationship.ToNodeID, "aws:access:") || strings.HasPrefix(relationship.ToNodeID, "k8s:access:") {
+		if hasAccessNode(relationship.ToNodeID) {
 			return nil
 		}
 		return fmt.Errorf("can_access relationship %q has invalid access node %q", relationship.ID, relationship.ToNodeID)
+	case domain.RelationshipRunsAs:
+		if !hasWorkload(relationship.FromNodeID) {
+			return fmt.Errorf("runs_as relationship %q has unknown workload %q", relationship.ID, relationship.FromNodeID)
+		}
+		if !hasIdentity(relationship.ToNodeID) {
+			return fmt.Errorf("runs_as relationship %q has unknown target identity %q", relationship.ID, relationship.ToNodeID)
+		}
+	case domain.RelationshipUsesSecret:
+		if !hasActor(relationship.FromNodeID) {
+			return fmt.Errorf("uses_secret relationship %q has unknown source actor %q", relationship.ID, relationship.FromNodeID)
+		}
+		if !hasSecretNode(relationship.ToNodeID) {
+			return fmt.Errorf("uses_secret relationship %q has invalid secret node %q", relationship.ID, relationship.ToNodeID)
+		}
+	case domain.RelationshipCanDecrypt:
+		if !hasIdentity(relationship.FromNodeID) {
+			return fmt.Errorf("can_decrypt relationship %q has unknown source identity %q", relationship.ID, relationship.FromNodeID)
+		}
+		if !hasKMSKeyNode(relationship.ToNodeID) {
+			return fmt.Errorf("can_decrypt relationship %q has invalid key node %q", relationship.ID, relationship.ToNodeID)
+		}
+	case domain.RelationshipCanPassRole:
+		if !hasIdentity(relationship.FromNodeID) {
+			return fmt.Errorf("can_pass_role relationship %q has unknown source identity %q", relationship.ID, relationship.FromNodeID)
+		}
+		if !hasIdentityType(relationship.ToNodeID, domain.IdentityTypeRole) {
+			return fmt.Errorf("can_pass_role relationship %q has unknown target role identity %q", relationship.ID, relationship.ToNodeID)
+		}
+	case domain.RelationshipInvokes:
+		if !hasActor(relationship.FromNodeID) {
+			return fmt.Errorf("invokes relationship %q has unknown source actor %q", relationship.ID, relationship.FromNodeID)
+		}
+		if !hasInvocable(relationship.ToNodeID) {
+			return fmt.Errorf("invokes relationship %q has invalid invocable node %q", relationship.ID, relationship.ToNodeID)
+		}
+	case domain.RelationshipCallsTool:
+		if !hasActor(relationship.FromNodeID) {
+			return fmt.Errorf("calls_tool relationship %q has unknown source actor %q", relationship.ID, relationship.FromNodeID)
+		}
+		if !hasTool(relationship.ToNodeID) {
+			return fmt.Errorf("calls_tool relationship %q has invalid tool node %q", relationship.ID, relationship.ToNodeID)
+		}
+	case domain.RelationshipActsForUser:
+		if !hasActor(relationship.FromNodeID) {
+			return fmt.Errorf("acts_for_user relationship %q has unknown source actor %q", relationship.ID, relationship.FromNodeID)
+		}
+		if !hasIdentityType(relationship.ToNodeID, domain.IdentityTypeUser) {
+			return fmt.Errorf("acts_for_user relationship %q has unknown target user identity %q", relationship.ID, relationship.ToNodeID)
+		}
+	case domain.RelationshipRuntimeSession:
+		if !hasActor(relationship.FromNodeID) {
+			return fmt.Errorf("has_runtime_session relationship %q has unknown source actor %q", relationship.ID, relationship.FromNodeID)
+		}
+		if !hasRuntimeSession(relationship.ToNodeID) {
+			return fmt.Errorf("has_runtime_session relationship %q has invalid runtime session node %q", relationship.ID, relationship.ToNodeID)
+		}
+	case domain.RelationshipObservedAction:
+		if !hasActor(relationship.FromNodeID) && !hasRuntimeSession(relationship.FromNodeID) {
+			return fmt.Errorf("observed_action relationship %q has unknown source actor or runtime session %q", relationship.ID, relationship.FromNodeID)
+		}
+		if !hasActionNode(relationship.ToNodeID) {
+			return fmt.Errorf("observed_action relationship %q has invalid action node %q", relationship.ID, relationship.ToNodeID)
+		}
 	default:
 		return fmt.Errorf("unsupported relationship type %q", relationship.Type)
 	}


### PR DESCRIPTION
Fixes #1354

## What changed
- Added canonical domain constants and contract metadata for precise graph relationship semantics: `runs_as`, `uses_secret`, `can_decrypt`, `can_pass_role`, `invokes`, `calls_tool`, `acts_for_user`, `has_runtime_session`, and `observed_action`.
- Expanded graph contract validation so each new edge type enforces directionality and endpoint semantics instead of accepting generic node shapes.
- Added tests proving the expanded relationship contract is supported, valid new edge shapes pass, and invalid shapes fail.
- Documented when to use precise edge types instead of generic `can_access`, and updated the baseline, ADR, threat model, AWS graph docs, and changelog.

## Why it changed
The existing graph contract was intentionally small for IAM-focused AWS and Kubernetes graph outputs. This establishes the contract foundation for AWS machine identities, runtime sessions, agents, tools, delegated users, secrets, KMS, and privilege paths without requiring collector expansion in this PR.

## Impact and risk
- Backward compatible with existing relationship types and current AWS/Kubernetes emitters.
- No new collectors emit the expanded edge types yet; this only reserves and validates the contract vocabulary.
- Future collector work can now model precise semantics instead of overloading `can_access`.

## Validation performed
- `go test ./internal/domain ./internal/providers` passed.
- `go test ./internal/providers/aws ./internal/providers/kubernetes` passed.
- Commit/push hooks passed, including merge-conflict checks, whitespace checks, gofmt check, `go vet`, local env token hygiene, and Vercel artifact hygiene.

## AI disclosure
- AI-assisted: yes
- Tools used: Codex
- Where used: implementation and documentation edits in `internal/domain`, `internal/providers`, `docs`, and `CHANGELOG.md`
- Human verification performed: reviewed issue requirements, followed `CONTRIBUTING.md`, ran the validation commands listed above, and signed the commit for DCO.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the normalized graph relationship contract with precise edge types and strict endpoint validation. Satisfies Linear #1354 and keeps current AWS/Kubernetes emitters backward compatible.

- New Features
  - Added relationship types: `runs_as`, `uses_secret`, `can_decrypt`, `can_pass_role`, `invokes`, `calls_tool`, `acts_for_user`, `has_runtime_session`, `observed_action`.
  - Added canonical contract metadata and endpoint rules in `internal/domain/relationship_contract.go`; enforced in `internal/providers/graph_contract.go`.
  - Validation now checks direction and endpoint shapes (identity, workload, secret, KMS key, tool, session, action), supports `agent:` actors and invocable targets, and enforces role-only targets for `can_pass_role` and user-only for `acts_for_user`.
  - Added tests and docs, including `docs/graph-relationship-contract.md`; updated AWS graph docs and ADR to prefer precise edges over `can_access` when evidence exists.

<sup>Written for commit 7619c3c8234c7f4936d9f52eddc272c3b68ab148. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1360?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

