### PR TITLE
Harden command execution paths for SAST findings

### DIFF
--- a/internal/providers/kubernetes/kubectl_collector.go
+++ b/internal/providers/kubernetes/kubectl_collector.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -58,6 +59,9 @@ var _ providers.DiagnosticCollector = (*KubectlCollector)(nil)
 func NewKubectlCollector(kubectlPath string, contextName string, runner CommandRunner, opts ...KubectlOption) *KubectlCollector {
 	path := strings.TrimSpace(kubectlPath)
 	if path == "" {
+		path = defaultKubectlPath
+	}
+	if !isSafeKubectlCommandPath(path) {
 		path = defaultKubectlPath
 	}
 	if runner == nil {
@@ -365,8 +369,37 @@ func (c *KubectlCollector) list(ctx context.Context, resource string, allNamespa
 }
 
 func defaultCommandRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, name, args...)
+	cmd := exec.CommandContext(ctx, sanitizeKubectlCommandPath(name), args...)
 	return cmd.CombinedOutput()
+}
+
+func sanitizeKubectlCommandPath(raw string) string {
+	path := strings.TrimSpace(raw)
+	if path == "" {
+		return defaultKubectlPath
+	}
+	if !isSafeKubectlCommandPath(path) {
+		return defaultKubectlPath
+	}
+	return path
+}
+
+func isSafeKubectlCommandPath(raw string) bool {
+	if strings.IndexAny(raw, "\x00\r\n") >= 0 {
+		return false
+	}
+	clean := filepath.Clean(strings.TrimSpace(raw))
+	if clean == "." || clean == ".." {
+		return false
+	}
+	if strings.IndexAny(clean, "&;<>$(){}[]*?\"'\t ") >= 0 {
+		return false
+	}
+	if strings.ContainsRune(clean, '`') {
+		return false
+	}
+	base := strings.ToLower(filepath.Base(clean))
+	return base == defaultKubectlPath || base == defaultKubectlPath+".exe"
 }
 
 func defaultKubectlSleeper(ctx context.Context, delay time.Duration) error {

--- a/internal/providers/kubernetes/kubectl_collector.go
+++ b/internal/providers/kubernetes/kubectl_collector.go
@@ -392,14 +392,17 @@ func isSafeKubectlCommandPath(raw string) bool {
 	if clean == "." || clean == ".." {
 		return false
 	}
-	if strings.IndexAny(clean, "&;<>$(){}[]*?\"'\t ") >= 0 {
+	if strings.IndexAny(clean, "&;<>$(){}[]*?\"'\t") >= 0 {
 		return false
 	}
 	if strings.ContainsRune(clean, '`') {
 		return false
 	}
 	base := strings.ToLower(filepath.Base(clean))
-	return base == defaultKubectlPath || base == defaultKubectlPath+".exe"
+	if base != defaultKubectlPath && base != defaultKubectlPath+".exe" {
+		return false
+	}
+	return clean == base || filepath.IsAbs(clean)
 }
 
 func defaultKubectlSleeper(ctx context.Context, delay time.Duration) error {

--- a/internal/providers/kubernetes/kubectl_collector_test.go
+++ b/internal/providers/kubernetes/kubectl_collector_test.go
@@ -71,6 +71,31 @@ func TestKubectlCollectorCollect(t *testing.T) {
 	}
 }
 
+func TestKubectlCollectorRejectsUnsafeCommandPath(t *testing.T) {
+	exec := &fakeCommandExec{}
+	collector := NewKubectlCollector("kubectl; rm -rf /", "dev", exec.run)
+	if _, err := collector.Collect(context.Background()); err == nil {
+		t.Fatalf("expected command failure for unsafe command path")
+	}
+}
+
+func TestKubectlCollectorAllowsDefaultPath(t *testing.T) {
+	exec := &fakeCommandExec{
+		responses: map[string][]byte{
+			"kubectl --context dev get serviceaccounts --all-namespaces -o json": []byte(`{"items":[]}`),
+			"kubectl --context dev get rolebindings --all-namespaces -o json":    []byte(`{"items":[]}`),
+			"kubectl --context dev get clusterrolebindings -o json":              []byte(`{"items":[]}`),
+			"kubectl --context dev get roles --all-namespaces -o json":           []byte(`{"items":[]}`),
+			"kubectl --context dev get clusterroles -o json":                     []byte(`{"items":[]}`),
+			"kubectl --context dev get pods --all-namespaces -o json":            []byte(`{"items":[]}`),
+		},
+	}
+	collector := NewKubectlCollector("kubectl", "dev", exec.run)
+	if _, err := collector.Collect(context.Background()); err != nil {
+		t.Fatalf("collect failed: %v", err)
+	}
+}
+
 func TestKubectlCollectorUsesDefaults(t *testing.T) {
 	exec := &fakeCommandExec{
 		responses: map[string][]byte{

--- a/internal/providers/kubernetes/kubectl_collector_test.go
+++ b/internal/providers/kubernetes/kubectl_collector_test.go
@@ -279,3 +279,15 @@ func TestIsRetryableKubectlError(t *testing.T) {
 		t.Fatal("forbidden should not be retryable")
 	}
 }
+
+func TestIsSafeKubectlCommandPathRejectsRelativePath(t *testing.T) {
+	if isSafeKubectlCommandPath("../usr/bin/kubectl") {
+		t.Fatal("expected relative path with kubectl basename to be rejected")
+	}
+}
+
+func TestIsSafeKubectlCommandPathAcceptsAbsolutePathWithSpaces(t *testing.T) {
+	if !isSafeKubectlCommandPath("/tmp/kubectl with spaces/bin/kubectl") {
+		t.Fatal("expected absolute path with spaces to be accepted")
+	}
+}

--- a/internal/providers/kubernetes/preflight.go
+++ b/internal/providers/kubernetes/preflight.go
@@ -85,6 +85,9 @@ func NewKubectlPreflightDriver(kubectlPath string, contextName string, runner Co
 	if path == "" {
 		path = defaultKubectlPath
 	}
+	if !isSafeKubectlCommandPath(path) {
+		path = defaultKubectlPath
+	}
 	if runner == nil {
 		runner = defaultCommandRunner
 	}

--- a/internal/repoexposure/command.go
+++ b/internal/repoexposure/command.go
@@ -3,17 +3,28 @@ package repoexposure
 import (
 	"context"
 	"os/exec"
+	"strings"
 	"time"
 )
 
 const defaultCommandWaitDelay = 5 * time.Second
+const defaultRepositoryCommand = "git"
 
 func newRepositoryCommand(ctx context.Context, name string, args ...string) *exec.Cmd {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	cmd := exec.CommandContext(ctx, name, args...)
+	command := repositoryCommandName(name)
+	cmd := exec.CommandContext(ctx, command, args...)
 	cmd.WaitDelay = defaultCommandWaitDelay
 	configureRepositoryCommand(cmd)
 	return cmd
+}
+
+func repositoryCommandName(raw string) string {
+	command := strings.TrimSpace(raw)
+	if command == defaultRepositoryCommand {
+		return command
+	}
+	return defaultRepositoryCommand
 }

--- a/internal/repoexposure/command_test.go
+++ b/internal/repoexposure/command_test.go
@@ -1,0 +1,17 @@
+package repoexposure
+
+import "testing"
+
+func TestRepositoryCommandName(t *testing.T) {
+	t.Run("accepts git", func(t *testing.T) {
+		if got := repositoryCommandName("git"); got != "git" {
+			t.Fatalf("expected 'git', got %q", got)
+		}
+	})
+
+	t.Run("falls back on invalid command", func(t *testing.T) {
+		if got := repositoryCommandName("/usr/bin/bash"); got != defaultRepositoryCommand {
+			t.Fatalf("expected fallback %q, got %q", defaultRepositoryCommand, got)
+		}
+	})
+}

--- a/internal/repoexposure/command_unix_test.go
+++ b/internal/repoexposure/command_unix_test.go
@@ -16,7 +16,7 @@ func TestDefaultCommandRunnerCancelsDescendantProcess(t *testing.T) {
 
 	started := time.Now()
 	cmd := exec.CommandContext(ctx, "sh", "-c", "(sleep 30) & wait")
-	cmd.WaitDelay = defaultCommandWaitDelay
+	configureRepositoryCommand(cmd)
 	_, err := cmd.CombinedOutput()
 	if err == nil || !errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		t.Fatalf("expected command cancellation after deadline, err=%v ctx=%v", err, ctx.Err())

--- a/internal/repoexposure/command_unix_test.go
+++ b/internal/repoexposure/command_unix_test.go
@@ -5,6 +5,7 @@ package repoexposure
 import (
 	"context"
 	"errors"
+	"os/exec"
 	"testing"
 	"time"
 )
@@ -14,7 +15,9 @@ func TestDefaultCommandRunnerCancelsDescendantProcess(t *testing.T) {
 	defer cancel()
 
 	started := time.Now()
-	_, err := defaultCommandRunner(ctx, "sh", "-c", "(sleep 30) & wait")
+	cmd := exec.CommandContext(ctx, "sh", "-c", "(sleep 30) & wait")
+	cmd.WaitDelay = defaultCommandWaitDelay
+	_, err := cmd.CombinedOutput()
 	if err == nil || !errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		t.Fatalf("expected command cancellation after deadline, err=%v ctx=%v", err, ctx.Err())
 	}

--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -1632,13 +1632,21 @@ func severityRank(severity domain.FindingSeverity) int {
 
 func defaultCommandRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
 	cmd := newRepositoryCommand(ctx, name, args...)
-	return cmd.CombinedOutput()
+	output, err := cmd.CombinedOutput()
+	if err != nil && ctx.Err() != nil {
+		return output, ctx.Err()
+	}
+	return output, err
 }
 
 func defaultEnvCommandRunner(ctx context.Context, env []string, name string, args ...string) ([]byte, error) {
 	cmd := newRepositoryCommand(ctx, name, args...)
 	cmd.Env = append(os.Environ(), env...)
-	return cmd.CombinedOutput()
+	output, err := cmd.CombinedOutput()
+	if err != nil && ctx.Err() != nil {
+		return output, ctx.Err()
+	}
+	return output, err
 }
 
 func sanitizeError(err error, secrets ...string) error {


### PR DESCRIPTION
## Summary

- Restrict repo scanning command execution to a validated `git` command.
- Add validation for kubectl binary paths before execution.
- Add tests for command-name/path validation and fallback behavior.

This patch addresses open SAST findings related to command execution.

No issue: SAST remediation for code-scanning alert 115 (command execution hardening).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened command execution paths to address SAST findings. Repo scans now force `git`, `kubectl` path validation is strict with safe fallbacks, and canceled runs return context errors.

- **Bug Fixes**
  - Always use `git` for repository commands; ignore custom names.
  - Validate/sanitize `kubectl` paths in collectors and preflight (reject control chars, shell metacharacters/backticks, relative/traversal paths, and non-`kubectl` basenames; allow absolute paths, including with spaces, or plain `kubectl`; fallback to default).
  - Sanitize the command path in the collector’s default runner.
  - Propagate context cancellation errors for repo commands; keep 5s wait delay; add tests for unsafe/default `kubectl` paths, relative rejection, absolute-with-spaces acceptance, and command fallback.

<sup>Written for commit c6e5f4974b688f070caeec27d83bfd6894ca9746. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1361?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

