### PR TITLE
Add connector capability modes for AWS discovery, runtime evidence, remediation, and authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
 ## Unreleased
+- Added typed AWS connector capability modes (`discovery`, `runtime_evidence`,
+  `remediation_plan`, `approved_remediation`, `authorization_advisory`,
+  `authorization_enforcement`). Connector status now reports requested,
+  validated, and effective capabilities; the read-only CloudFormation flow stays
+  pinned to `discovery`; permission preview is grouped by capability tier so
+  read-only discovery is visibly separate from future write/remediation/
+  enforcement tiers; and validation emits a capability-scoped diagnostic naming
+  any requested tier the deployment gate denies. Write-capable tiers are gated
+  behind `IDENTRAIL_AWS_CONNECTOR_CAPABILITIES` and a dedicated write role, and
+  no live remediation or enforcement executor is added. See
+  `docs/connector-capabilities.md`.
 - Added GitHub Actions AI-agent prompt-injection detection for workflows that
   feed untrusted PR, issue, review, comment, workflow_run, or repository
   prompt-file content into LLM/agent steps with repository write, secret, OIDC,

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -53,6 +53,7 @@ AWS:
 - `IDENTRAIL_AWS_REGION`
 - `IDENTRAIL_AWS_PROFILE`
 - `IDENTRAIL_AWS_FIXTURES`
+- `IDENTRAIL_AWS_CONNECTOR_CAPABILITIES` (comma-separated connector capability tiers to permit beyond the read-only `discovery` default; unknown values are ignored. Write-capable tiers stay gated until listed here _and_ provisioned with a dedicated write role. See [connector-capabilities.md](connector-capabilities.md).)
 
 Kubernetes:
 - `IDENTRAIL_K8S_SOURCE` (`fixture|kubectl`)

--- a/docs/connector-capabilities.md
+++ b/docs/connector-capabilities.md
@@ -1,0 +1,85 @@
+# Connector Capability Modes
+
+Identrail connectors are read-only by default. The AWS machine-identity
+control-plane roadmap, however, needs more than one permission tier: discovery,
+runtime evidence, remediation planning, approved remediation, advisory
+authorization, and eventually limited enforcement.
+
+Rather than silently widening the read-only role or blurring write-capable
+permissions into the existing connector path, capabilities are modeled
+explicitly. Every connector tracks which capabilities were **requested**,
+**validated**, and are **effective**, and any requested-but-denied tier surfaces
+a precise diagnostic.
+
+## Capability tiers
+
+| Capability | Tier | Available today | Purpose |
+|---|---|---|---|
+| `discovery` | read-only | yes (default) | Inventory and machine-identity graph collection. Granted by the one-click read-only CloudFormation role. |
+| `runtime_evidence` | read-only | no | Runtime activity (last-used data, CloudTrail, access-analyzer findings) proving whether risky permissions are exercised. |
+| `remediation_plan` | read-only | no | Generates proposed least-privilege fixes by simulation only. Never applies changes. |
+| `authorization_advisory` | read-only | no | Recommends session-policy / boundary decisions without applying them. |
+| `approved_remediation` | **write** | no | Applies operator-approved IAM fixes. |
+| `authorization_enforcement` | **write** | no | Enforces authorization via permission boundaries or SCPs. |
+
+`discovery` is always the baseline. It is the only tier the default connector
+flow grants, and it is the only tier currently available; the others are modeled
+now so write behavior can be added later without reshaping the connector model.
+
+## Why each tier is separate
+
+- **Blast radius is explicit.** Read-only tiers can never mutate the connected
+  account. Write-capable tiers (`approved_remediation`,
+  `authorization_enforcement`) are clearly marked and gated.
+- **No accidental escalation.** The read-only CloudFormation onboarding flow
+  always starts a connector at `discovery`. Write-capable tiers cannot be
+  requested through that path.
+- **Defense in depth.** Even when a tier is requested, it only becomes effective
+  if the deployment's capability gate permits it. `effective` never exceeds
+  `validated`.
+
+## Enabling additional tiers
+
+Capabilities beyond `discovery` are gated by
+`IDENTRAIL_AWS_CONNECTOR_CAPABILITIES`, a comma-separated list of tier names. For
+example, to allow runtime evidence collection:
+
+```
+IDENTRAIL_AWS_CONNECTOR_CAPABILITIES=runtime_evidence
+```
+
+Unknown names are ignored so a typo cannot widen access. Write-capable tiers
+require both an entry here **and** a dedicated write-capable role; the read-only
+connector role never grants them. No live remediation or enforcement executor
+ships with this capability model — enabling a write tier only makes the request
+representable and validated, not executed.
+
+## API surface
+
+`AWSConnectionStatus` includes a `capabilities` object:
+
+```json
+{
+  "capabilities": {
+    "requested": ["discovery", "approved_remediation"],
+    "validated": ["discovery"],
+    "effective": ["discovery"],
+    "unavailable": [
+      {
+        "capability": "approved_remediation",
+        "tier": "write",
+        "reason": "write-capable capability approved_remediation is disabled; it requires a dedicated write role and an explicit feature gate, and is never granted by the read-only connector"
+      }
+    ]
+  }
+}
+```
+
+When a requested capability is unavailable, validation also emits an
+`aws_capability_unavailable` diagnostic that names the specific tier and how to
+enable it, so a failure is never reported as a generic connector error.
+
+The connector start and policy responses additionally return `permission_tiers`,
+which group the AWS actions each capability needs and flag whether each tier is
+available today. This lets operators see read-only discovery separately from the
+future write/remediation/enforcement tiers before granting anything.

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -5154,6 +5154,11 @@ components:
         session_name:
           type: string
           default: identrail-connector-validation
+        capabilities:
+          type: array
+          description: Optional requested capability tiers. Defaults to discovery (read-only).
+          items:
+            $ref: "#/components/schemas/ConnectorCapability"
     AWSConnectorPollRequest:
       type: object
       properties:
@@ -5187,6 +5192,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSPermissionPreviewItem"
+        permission_tiers:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSCapabilityPermissionTier"
     AWSConnectorPolicyResponse:
       type: object
       properties:
@@ -5198,6 +5207,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSPermissionPreviewItem"
+        permission_tiers:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSCapabilityPermissionTier"
     AWSPermissionPreviewItem:
       type: object
       properties:
@@ -5211,6 +5224,68 @@ components:
           items: { type: string }
         reason:
           type: string
+    ConnectorCapability:
+      type: string
+      description: >-
+        Typed connector permission tier. discovery is the read-only default;
+        runtime_evidence, remediation_plan, and authorization_advisory are
+        additional read-only tiers; approved_remediation and
+        authorization_enforcement are write-capable and gated.
+      enum:
+        - discovery
+        - runtime_evidence
+        - remediation_plan
+        - approved_remediation
+        - authorization_advisory
+        - authorization_enforcement
+    AWSCapabilityPermissionTier:
+      type: object
+      description: AWS permissions grouped by connector capability tier.
+      properties:
+        capability:
+          $ref: "#/components/schemas/ConnectorCapability"
+        tier:
+          type: string
+          enum: [read_only, write]
+        available:
+          type: boolean
+          description: Whether the tier is grantable today. Only discovery is currently available.
+        summary:
+          type: string
+        permissions:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSPermissionPreviewItem"
+    AWSConnectorCapabilityUnavailable:
+      type: object
+      properties:
+        capability:
+          $ref: "#/components/schemas/ConnectorCapability"
+        tier:
+          type: string
+          enum: [read_only, write]
+        reason:
+          type: string
+    AWSConnectorCapabilities:
+      type: object
+      description: Requested, validated, and effective connector capability tiers.
+      properties:
+        requested:
+          type: array
+          items:
+            $ref: "#/components/schemas/ConnectorCapability"
+        validated:
+          type: array
+          items:
+            $ref: "#/components/schemas/ConnectorCapability"
+        effective:
+          type: array
+          items:
+            $ref: "#/components/schemas/ConnectorCapability"
+        unavailable:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSConnectorCapabilityUnavailable"
     AWSConnectionUpsertRequest:
       type: object
       required: [role_arn]
@@ -5231,6 +5306,11 @@ components:
         session_name:
           type: string
           default: identrail-connector-validation
+        capabilities:
+          type: array
+          description: Optional requested capability tiers. Defaults to discovery (read-only).
+          items:
+            $ref: "#/components/schemas/ConnectorCapability"
     AWSConnectionDiagnostic:
       type: object
       properties:
@@ -5289,6 +5369,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSConnectionDiagnostic"
+        capabilities:
+          $ref: "#/components/schemas/AWSConnectorCapabilities"
         remediation_message:
           type: string
         launch_url:

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -43,12 +43,13 @@ type AWSConnectorValidator interface {
 
 // AWSConnectionUpsertRequest captures one project AWS connector onboarding request.
 type AWSConnectionUpsertRequest struct {
-	ConnectorID string `json:"connector_id,omitempty"`
-	DisplayName string `json:"display_name,omitempty"`
-	RoleARN     string `json:"role_arn"`
-	ExternalID  string `json:"external_id,omitempty"`
-	Region      string `json:"region,omitempty"`
-	SessionName string `json:"session_name,omitempty"`
+	ConnectorID  string                       `json:"connector_id,omitempty"`
+	DisplayName  string                       `json:"display_name,omitempty"`
+	RoleARN      string                       `json:"role_arn"`
+	ExternalID   string                       `json:"external_id,omitempty"`
+	Region       string                       `json:"region,omitempty"`
+	SessionName  string                       `json:"session_name,omitempty"`
+	Capabilities []domain.ConnectorCapability `json:"capabilities,omitempty"`
 }
 
 // AWSConnectorStartRequest starts the CloudFormation-based AWS connector flow.
@@ -64,12 +65,13 @@ type AWSConnectorStartRequest struct {
 
 // AWSConnectorValidateRequest validates a CloudFormation-created AWS connector role.
 type AWSConnectorValidateRequest struct {
-	WorkspaceID string `json:"workspace_id,omitempty"`
-	ProjectID   string `json:"project_id,omitempty"`
-	RoleARN     string `json:"role_arn"`
-	ExternalID  string `json:"external_id,omitempty"`
-	Region      string `json:"region,omitempty"`
-	SessionName string `json:"session_name,omitempty"`
+	WorkspaceID  string                       `json:"workspace_id,omitempty"`
+	ProjectID    string                       `json:"project_id,omitempty"`
+	RoleARN      string                       `json:"role_arn"`
+	ExternalID   string                       `json:"external_id,omitempty"`
+	Region       string                       `json:"region,omitempty"`
+	SessionName  string                       `json:"session_name,omitempty"`
+	Capabilities []domain.ConnectorCapability `json:"capabilities,omitempty"`
 }
 
 // AWSConnectorPollRequest resolves project scope for the flat connector poll API.
@@ -80,22 +82,24 @@ type AWSConnectorPollRequest struct {
 
 // AWSConnectorStartResponse returns launch data for the one-click AWS setup flow.
 type AWSConnectorStartResponse struct {
-	Connection        AWSConnectionStatus                  `json:"connection"`
-	ConnectorID       string                               `json:"connector_id"`
-	ExternalID        string                               `json:"external_id"`
-	LaunchURL         string                               `json:"launch_url"`
-	TemplateURL       string                               `json:"template_url"`
-	RoleName          string                               `json:"role_name"`
-	StackName         string                               `json:"stack_name"`
-	PolicyHash        string                               `json:"policy_hash"`
-	PermissionPreview []awsconnector.PermissionPreviewItem `json:"permission_preview"`
+	Connection        AWSConnectionStatus                     `json:"connection"`
+	ConnectorID       string                                  `json:"connector_id"`
+	ExternalID        string                                  `json:"external_id"`
+	LaunchURL         string                                  `json:"launch_url"`
+	TemplateURL       string                                  `json:"template_url"`
+	RoleName          string                                  `json:"role_name"`
+	StackName         string                                  `json:"stack_name"`
+	PolicyHash        string                                  `json:"policy_hash"`
+	PermissionPreview []awsconnector.PermissionPreviewItem    `json:"permission_preview"`
+	PermissionTiers   []awsconnector.CapabilityPermissionTier `json:"permission_tiers"`
 }
 
 // AWSConnectorPolicyResponse exposes the expected read-only policy for review.
 type AWSConnectorPolicyResponse struct {
-	PolicyHash        string                               `json:"policy_hash"`
-	PolicyDocument    json.RawMessage                      `json:"policy_document"`
-	PermissionPreview []awsconnector.PermissionPreviewItem `json:"permission_preview"`
+	PolicyHash        string                                  `json:"policy_hash"`
+	PolicyDocument    json.RawMessage                         `json:"policy_document"`
+	PermissionPreview []awsconnector.PermissionPreviewItem    `json:"permission_preview"`
+	PermissionTiers   []awsconnector.CapabilityPermissionTier `json:"permission_tiers"`
 }
 
 // AWSConnectionValidationRequest is passed to the provider validator.
@@ -119,6 +123,26 @@ type AWSConnectionPermissionCheck struct {
 	Passed      bool   `json:"passed"`
 	Message     string `json:"message"`
 	Remediation string `json:"remediation,omitempty"`
+}
+
+// AWSConnectorCapabilityUnavailable names a requested capability that could not be
+// granted and explains why, so a validation failure points at the specific tier
+// rather than a generic connector error.
+type AWSConnectorCapabilityUnavailable struct {
+	Capability domain.ConnectorCapability     `json:"capability"`
+	Tier       domain.ConnectorCapabilityTier `json:"tier"`
+	Reason     string                         `json:"reason"`
+}
+
+// AWSConnectorCapabilities reports the requested, validated, and effective
+// connector capability tiers for one AWS connector. Effective never exceeds what
+// the deployment's capability gate validated, so write-capable tiers cannot be
+// granted implicitly.
+type AWSConnectorCapabilities struct {
+	Requested   []domain.ConnectorCapability        `json:"requested"`
+	Validated   []domain.ConnectorCapability        `json:"validated"`
+	Effective   []domain.ConnectorCapability        `json:"effective"`
+	Unavailable []AWSConnectorCapabilityUnavailable `json:"unavailable"`
 }
 
 // AWSConnectionValidationResult contains the live AWS metadata and diagnostics.
@@ -149,6 +173,7 @@ type AWSConnectionStatus struct {
 	ExternalID           string                         `json:"-"`
 	PermissionChecks     []AWSConnectionPermissionCheck `json:"permission_checks"`
 	Diagnostics          []AWSConnectionDiagnostic      `json:"diagnostics"`
+	Capabilities         AWSConnectorCapabilities       `json:"capabilities"`
 	RemediationMessage   string                         `json:"remediation_message,omitempty"`
 	LaunchURL            string                         `json:"launch_url,omitempty"`
 	TemplateURL          string                         `json:"template_url,omitempty"`
@@ -200,6 +225,14 @@ func (s *Service) StartAWSConnector(ctx context.Context, request AWSConnectorSta
 		return AWSConnectorStartResponse{}, err
 	}
 
+	// The one-click CloudFormation flow provisions the read-only role only, so it
+	// always starts at the discovery baseline. Write-capable tiers can never be
+	// requested through this path.
+	capabilities, _, err := s.resolveAWSConnectorCapabilities(domain.DefaultConnectorCapabilities())
+	if err != nil {
+		return AWSConnectorStartResponse{}, err
+	}
+
 	metadata := map[string]any{
 		"external_id_configured": true,
 		"region":                 region,
@@ -210,6 +243,7 @@ func (s *Service) StartAWSConnector(ctx context.Context, request AWSConnectorSta
 		"policy_hash":            policyHash,
 		"permission_checks":      []AWSConnectionPermissionCheck{},
 		"diagnostics":            []AWSConnectionDiagnostic{},
+		"capabilities":           capabilities,
 		"last_started_at":        now.Format(time.RFC3339Nano),
 	}
 	connector := db.TenancyConnector{
@@ -258,6 +292,7 @@ func (s *Service) StartAWSConnector(ctx context.Context, request AWSConnectorSta
 		StackName:         stackName,
 		PolicyHash:        policyHash,
 		PermissionPreview: awsconnector.PermissionPreview(),
+		PermissionTiers:   awsconnector.CapabilityPermissionTiers(),
 	}, nil
 }
 
@@ -281,13 +316,18 @@ func (s *Service) ValidateAWSConnector(ctx context.Context, connectorID string, 
 	if externalID == "" {
 		externalID = s.awsExternalIDFromStored(ctx, stored)
 	}
+	requestedCapabilities := request.Capabilities
+	if len(requestedCapabilities) == 0 {
+		requestedCapabilities = awsMetadataCapabilities(stored.State.Metadata, "capabilities").Requested
+	}
 	return s.UpsertAWSConnection(ctx, project.WorkspaceID, project.ProjectID, AWSConnectionUpsertRequest{
-		ConnectorID: connectorID,
-		DisplayName: stored.Connector.DisplayName,
-		RoleARN:     request.RoleARN,
-		ExternalID:  externalID,
-		Region:      firstNonEmptyAWSValue(strings.TrimSpace(request.Region), awsMetadataString(stored.State.Metadata, "region")),
-		SessionName: request.SessionName,
+		ConnectorID:  connectorID,
+		DisplayName:  stored.Connector.DisplayName,
+		RoleARN:      request.RoleARN,
+		ExternalID:   externalID,
+		Region:       firstNonEmptyAWSValue(strings.TrimSpace(request.Region), awsMetadataString(stored.State.Metadata, "region")),
+		SessionName:  request.SessionName,
+		Capabilities: requestedCapabilities,
 	})
 }
 
@@ -324,6 +364,7 @@ func (s *Service) AWSConnectorPolicy(ctx context.Context, connectorID string, re
 		PolicyHash:        hash,
 		PolicyDocument:    json.RawMessage(policy),
 		PermissionPreview: awsconnector.PermissionPreview(),
+		PermissionTiers:   awsconnector.CapabilityPermissionTiers(),
 	}, nil
 }
 
@@ -368,6 +409,16 @@ func (s *Service) UpsertAWSConnection(ctx context.Context, workspaceID string, p
 			Message: "Role assumption succeeded.",
 		}}
 	}
+
+	// Capability resolution is independent of role-assumption health: a requested
+	// tier that the deployment gate denies surfaces as a capability-scoped
+	// diagnostic, but it does not degrade a healthy read-only connector.
+	capabilities, capabilityDiagnostics, err := s.resolveAWSConnectorCapabilities(normalized.Capabilities)
+	if err != nil {
+		return AWSConnectionStatus{}, err
+	}
+	diagnostics := append(copyAWSDiagnostics(validation.Diagnostics), capabilityDiagnostics...)
+
 	metadata := map[string]any{
 		"role_arn":               normalized.RoleARN,
 		"external_id_configured": normalized.ExternalID != "",
@@ -376,7 +427,8 @@ func (s *Service) UpsertAWSConnection(ctx context.Context, workspaceID string, p
 		"user_id":                strings.TrimSpace(validation.UserID),
 		"region":                 firstNonEmptyAWSValue(strings.TrimSpace(validation.Region), normalized.Region),
 		"permission_checks":      checks,
-		"diagnostics":            copyAWSDiagnostics(validation.Diagnostics),
+		"diagnostics":            diagnostics,
+		"capabilities":           capabilities,
 		"last_validated_at":      now.Format(time.RFC3339Nano),
 	}
 	state := db.TenancyConnectorState{
@@ -446,6 +498,7 @@ func (s *Service) GetAWSConnection(ctx context.Context, workspaceID string, proj
 			HealthStatus:     "unknown",
 			PermissionChecks: []AWSConnectionPermissionCheck{},
 			Diagnostics:      []AWSConnectionDiagnostic{},
+			Capabilities:     defaultAWSConnectorCapabilities(),
 		}, nil
 	}
 	return s.awsConnectionStatusFromStored(ctx, items[0]), nil
@@ -513,6 +566,7 @@ func awsConnectionStatusFromStored(stored db.TenancyConnectorWithState) AWSConne
 		Region:               awsMetadataString(metadata, "region"),
 		PermissionChecks:     awsMetadataPermissionChecks(metadata, "permission_checks"),
 		Diagnostics:          awsMetadataDiagnostics(metadata, "diagnostics"),
+		Capabilities:         awsMetadataCapabilities(metadata, "capabilities"),
 		LaunchURL:            awsMetadataString(metadata, "launch_url"),
 		TemplateURL:          awsMetadataString(metadata, "template_url"),
 		PolicyHash:           awsMetadataString(metadata, "policy_hash"),
@@ -746,4 +800,78 @@ func accountIDFromRoleARN(roleARN string) string {
 		return parts[4]
 	}
 	return "unknown"
+}
+
+// awsCapabilityPolicy returns the configured capability gate, falling back to the
+// safe read-only default when the service has none configured.
+func (s *Service) awsCapabilityPolicy() awsconnector.CapabilityPolicy {
+	if s != nil && s.AWSConnectorCapabilityPolicy.Configured() {
+		return s.AWSConnectorCapabilityPolicy
+	}
+	return awsconnector.DefaultCapabilityPolicy()
+}
+
+// resolveAWSConnectorCapabilities resolves a requested capability set against the
+// deployment gate and returns both the capability summary and capability-scoped
+// diagnostics for any tier that could not be granted. The diagnostics name the
+// specific capability so a validation failure is never reported generically.
+func (s *Service) resolveAWSConnectorCapabilities(requested []domain.ConnectorCapability) (AWSConnectorCapabilities, []AWSConnectionDiagnostic, error) {
+	resolution, err := domain.ResolveConnectorCapabilities(requested, s.awsCapabilityPolicy())
+	if err != nil {
+		return AWSConnectorCapabilities{}, nil, fmt.Errorf("%w: %v", ErrInvalidAWSConnectionRequest, err)
+	}
+
+	capabilities := AWSConnectorCapabilities{
+		Requested:   resolution.Requested,
+		Validated:   resolution.Validated,
+		Effective:   resolution.Effective,
+		Unavailable: make([]AWSConnectorCapabilityUnavailable, 0, len(resolution.Unavailable)),
+	}
+	diagnostics := make([]AWSConnectionDiagnostic, 0, len(resolution.Unavailable))
+	for _, unavailable := range resolution.Unavailable {
+		capabilities.Unavailable = append(capabilities.Unavailable, AWSConnectorCapabilityUnavailable{
+			Capability: unavailable.Capability,
+			Tier:       unavailable.Tier,
+			Reason:     unavailable.Reason,
+		})
+		diagnostics = append(diagnostics, AWSConnectionDiagnostic{
+			Code:        "aws_capability_unavailable",
+			Message:     fmt.Sprintf("requested capability %q is unavailable: %s", unavailable.Capability, unavailable.Reason),
+			Remediation: fmt.Sprintf("Enable the %q capability gate for this deployment before requesting it; write-capable tiers also require a dedicated write role.", unavailable.Capability),
+		})
+	}
+	return capabilities, diagnostics, nil
+}
+
+// defaultAWSConnectorCapabilities returns the read-only discovery baseline used
+// for connectors persisted before capability tracking existed.
+func defaultAWSConnectorCapabilities() AWSConnectorCapabilities {
+	base := domain.DefaultConnectorCapabilities()
+	return AWSConnectorCapabilities{
+		Requested:   base,
+		Validated:   base,
+		Effective:   base,
+		Unavailable: []AWSConnectorCapabilityUnavailable{},
+	}
+}
+
+func awsMetadataCapabilities(metadata map[string]any, key string) AWSConnectorCapabilities {
+	if metadata == nil || metadata[key] == nil {
+		return defaultAWSConnectorCapabilities()
+	}
+	payload, err := json.Marshal(metadata[key])
+	if err != nil {
+		return defaultAWSConnectorCapabilities()
+	}
+	var capabilities AWSConnectorCapabilities
+	if err := json.Unmarshal(payload, &capabilities); err != nil {
+		return defaultAWSConnectorCapabilities()
+	}
+	if len(capabilities.Effective) == 0 {
+		return defaultAWSConnectorCapabilities()
+	}
+	if capabilities.Unavailable == nil {
+		capabilities.Unavailable = []AWSConnectorCapabilityUnavailable{}
+	}
+	return capabilities
 }

--- a/internal/api/aws_connect_capabilities_test.go
+++ b/internal/api/aws_connect_capabilities_test.go
@@ -1,0 +1,203 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	awsconnector "github.com/identrail/identrail/internal/connectors/aws"
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/domain"
+	"github.com/identrail/identrail/internal/secretstore"
+)
+
+func newAWSCapabilityService(t *testing.T) (*Service, context.Context) {
+	t.Helper()
+	store := db.NewMemoryStore()
+	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	seedDefaultProject(t, store, ctx, "project-1")
+	manager, err := secretstore.NewManager([]secretstore.KeyMaterial{{Version: "test-v1", Key: bytes.Repeat([]byte{5}, 32)}})
+	if err != nil {
+		t.Fatalf("build connector secret manager: %v", err)
+	}
+	svc := NewService(store, routerScanner{}, "aws")
+	svc.AWSConnectorValidator = &fakeAWSConnectorValidator{
+		result: AWSConnectionValidationResult{
+			AccountID: "123456789012",
+			Region:    "us-west-2",
+			PermissionChecks: []AWSConnectionPermissionCheck{
+				{Name: "sts:AssumeRole", Passed: true, Message: "Role assumption succeeded."},
+			},
+		},
+	}
+	svc.ConnectorSecretManager = manager
+	return svc, ctx
+}
+
+func capabilitySet(capabilities []domain.ConnectorCapability) map[domain.ConnectorCapability]bool {
+	set := make(map[domain.ConnectorCapability]bool, len(capabilities))
+	for _, capability := range capabilities {
+		set[capability] = true
+	}
+	return set
+}
+
+// Default read-only behavior: a connector created without requesting any extra
+// tier stays at discovery, healthy, and reports no unavailable capabilities.
+func TestUpsertAWSConnectionDefaultsToDiscoveryReadOnly(t *testing.T) {
+	svc, ctx := newAWSCapabilityService(t)
+
+	status, err := svc.UpsertAWSConnection(ctx, "workspace-a", "project-1", AWSConnectionUpsertRequest{
+		RoleARN: "arn:aws:iam::123456789012:role/IdentrailReadOnly",
+		Region:  "us-west-2",
+	})
+	if err != nil {
+		t.Fatalf("upsert aws connection: %v", err)
+	}
+	if !status.Connected || status.Status != domain.ConnectorStatusActive {
+		t.Fatalf("expected active read-only connection, got %+v", status)
+	}
+	wantEffective := []domain.ConnectorCapability{domain.ConnectorCapabilityDiscovery}
+	if got := status.Capabilities.Effective; len(got) != 1 || got[0] != domain.ConnectorCapabilityDiscovery {
+		t.Fatalf("effective capabilities = %v, want %v", got, wantEffective)
+	}
+	if len(status.Capabilities.Unavailable) != 0 {
+		t.Fatalf("expected no unavailable capabilities, got %+v", status.Capabilities.Unavailable)
+	}
+	for _, diagnostic := range status.Diagnostics {
+		if diagnostic.Code == "aws_capability_unavailable" {
+			t.Fatalf("did not expect capability diagnostics for default connector, got %+v", status.Diagnostics)
+		}
+	}
+}
+
+// Requesting a gated write capability surfaces a capability-scoped diagnostic that
+// names the tier, but does not degrade the otherwise-healthy read-only connector.
+func TestUpsertAWSConnectionReportsUnavailableWriteCapability(t *testing.T) {
+	svc, ctx := newAWSCapabilityService(t)
+
+	status, err := svc.UpsertAWSConnection(ctx, "workspace-a", "project-1", AWSConnectionUpsertRequest{
+		RoleARN:      "arn:aws:iam::123456789012:role/IdentrailReadOnly",
+		Region:       "us-west-2",
+		Capabilities: []domain.ConnectorCapability{domain.ConnectorCapabilityApprovedRemediation},
+	})
+	if err != nil {
+		t.Fatalf("upsert aws connection: %v", err)
+	}
+
+	// Discovery stays in force and the connector is still healthy.
+	if !status.Connected || status.Status != domain.ConnectorStatusActive {
+		t.Fatalf("expected healthy connector despite gated capability, got %+v", status)
+	}
+	effective := capabilitySet(status.Capabilities.Effective)
+	if !effective[domain.ConnectorCapabilityDiscovery] || effective[domain.ConnectorCapabilityApprovedRemediation] {
+		t.Fatalf("effective capabilities must keep discovery and exclude write tier, got %+v", status.Capabilities.Effective)
+	}
+
+	if len(status.Capabilities.Unavailable) != 1 {
+		t.Fatalf("expected one unavailable capability, got %+v", status.Capabilities.Unavailable)
+	}
+	unavailable := status.Capabilities.Unavailable[0]
+	if unavailable.Capability != domain.ConnectorCapabilityApprovedRemediation {
+		t.Fatalf("unavailable capability = %q, want approved_remediation", unavailable.Capability)
+	}
+	if unavailable.Tier != domain.ConnectorCapabilityTierWrite {
+		t.Fatalf("unavailable tier = %q, want write", unavailable.Tier)
+	}
+
+	var capabilityDiagnostic *AWSConnectionDiagnostic
+	for i := range status.Diagnostics {
+		if status.Diagnostics[i].Code == "aws_capability_unavailable" {
+			capabilityDiagnostic = &status.Diagnostics[i]
+			break
+		}
+	}
+	if capabilityDiagnostic == nil {
+		t.Fatalf("expected a capability-scoped diagnostic, got %+v", status.Diagnostics)
+	}
+	if capabilityDiagnostic.Remediation == "" {
+		t.Fatalf("expected remediation guidance on capability diagnostic, got %+v", capabilityDiagnostic)
+	}
+}
+
+// A read-only tier enabled by the deployment gate is validated and becomes
+// effective.
+func TestUpsertAWSConnectionGrantsGatedReadOnlyCapability(t *testing.T) {
+	svc, ctx := newAWSCapabilityService(t)
+	svc.AWSConnectorCapabilityPolicy = awsconnector.NewCapabilityPolicy([]domain.ConnectorCapability{
+		domain.ConnectorCapabilityRuntimeEvidence,
+	})
+
+	status, err := svc.UpsertAWSConnection(ctx, "workspace-a", "project-1", AWSConnectionUpsertRequest{
+		RoleARN:      "arn:aws:iam::123456789012:role/IdentrailReadOnly",
+		Region:       "us-west-2",
+		Capabilities: []domain.ConnectorCapability{domain.ConnectorCapabilityRuntimeEvidence},
+	})
+	if err != nil {
+		t.Fatalf("upsert aws connection: %v", err)
+	}
+	effective := capabilitySet(status.Capabilities.Effective)
+	if !effective[domain.ConnectorCapabilityDiscovery] || !effective[domain.ConnectorCapabilityRuntimeEvidence] {
+		t.Fatalf("expected discovery + runtime_evidence effective, got %+v", status.Capabilities.Effective)
+	}
+	if len(status.Capabilities.Unavailable) != 0 {
+		t.Fatalf("expected no unavailable capabilities, got %+v", status.Capabilities.Unavailable)
+	}
+}
+
+func TestUpsertAWSConnectionRejectsInvalidCapability(t *testing.T) {
+	svc, ctx := newAWSCapabilityService(t)
+
+	_, err := svc.UpsertAWSConnection(ctx, "workspace-a", "project-1", AWSConnectionUpsertRequest{
+		RoleARN:      "arn:aws:iam::123456789012:role/IdentrailReadOnly",
+		Region:       "us-west-2",
+		Capabilities: []domain.ConnectorCapability{"bogus"},
+	})
+	if !errors.Is(err, ErrInvalidAWSConnectionRequest) {
+		t.Fatalf("expected invalid capability request error, got %v", err)
+	}
+}
+
+// The one-click CloudFormation start flow only ever provisions the read-only role,
+// so its connector always begins at the discovery baseline and advertises the
+// gated tiers via the grouped permission preview.
+func TestStartAWSConnectorIsDiscoveryOnly(t *testing.T) {
+	svc, ctx := newAWSCapabilityService(t)
+	svc.AWSCloudFormationTemplateURL = "https://cdn.identrail.example/connectors/aws/identrail-readonly.yaml"
+	svc.AWSAccountID = "999999999999"
+
+	started, err := svc.StartAWSConnector(ctx, AWSConnectorStartRequest{ProjectID: "project-1"})
+	if err != nil {
+		t.Fatalf("start aws connector: %v", err)
+	}
+	if got := started.Connection.Capabilities.Effective; len(got) != 1 || got[0] != domain.ConnectorCapabilityDiscovery {
+		t.Fatalf("start flow must be discovery-only, got %+v", got)
+	}
+	if len(started.PermissionTiers) != len(domain.ConnectorCapabilityOrder()) {
+		t.Fatalf("expected grouped permission tiers, got %d", len(started.PermissionTiers))
+	}
+	for _, tier := range started.PermissionTiers {
+		wantAvailable := tier.Capability == domain.ConnectorCapabilityDiscovery
+		if tier.Available != wantAvailable {
+			t.Fatalf("tier %q available = %v, want %v", tier.Capability, tier.Available, wantAvailable)
+		}
+	}
+}
+
+// Existing connectors persisted before capability tracking still report the safe
+// discovery baseline rather than an empty capability set.
+func TestGetAWSConnectionBackfillsDefaultCapabilities(t *testing.T) {
+	svc, ctx := newAWSCapabilityService(t)
+
+	status, err := svc.GetAWSConnection(ctx, "workspace-a", "project-1")
+	if err != nil {
+		t.Fatalf("get aws connection: %v", err)
+	}
+	if got := status.Capabilities.Effective; len(got) != 1 || got[0] != domain.ConnectorCapabilityDiscovery {
+		t.Fatalf("expected discovery baseline for empty connection, got %+v", got)
+	}
+	if status.Capabilities.Unavailable == nil {
+		t.Fatalf("expected non-nil unavailable slice for stable JSON output")
+	}
+}

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/identrail/identrail/internal/app"
 	"github.com/identrail/identrail/internal/audit"
+	awsconnector "github.com/identrail/identrail/internal/connectors/aws"
 	githubconnector "github.com/identrail/identrail/internal/connectors/github"
 	"github.com/identrail/identrail/internal/db"
 	"github.com/identrail/identrail/internal/domain"
@@ -166,6 +167,7 @@ type Service struct {
 	AWSScannerFactory                  AWSScannerFactory
 	AWSCloudFormationTemplateURL       string
 	AWSAccountID                       string
+	AWSConnectorCapabilityPolicy       awsconnector.CapabilityPolicy
 	WorkflowRouter                     *workflow.Router
 	GitHubAppID                        int64
 	GitHubAppName                      string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,6 +91,7 @@ type Config struct {
 	AWSProfile                   string
 	AWSCloudFormationTemplateURL string
 	AWSAccountID                 string
+	AWSConnectorCapabilities     []string
 	AWSFixturePath               []string
 	KubernetesFixturePath        []string
 	KubernetesSource             string
@@ -243,6 +244,7 @@ func Load() Config {
 		AWSProfile:                   getEnv("IDENTRAIL_AWS_PROFILE", ""),
 		AWSCloudFormationTemplateURL: getEnv("IDENTRAIL_AWS_CFN_TEMPLATE_URL", ""),
 		AWSAccountID:                 getEnv("IDENTRAIL_AWS_ACCOUNT_ID", ""),
+		AWSConnectorCapabilities:     parseCommaSeparated(getEnv("IDENTRAIL_AWS_CONNECTOR_CAPABILITIES", "")),
 		AWSFixturePath:               parseCommaSeparated(getEnv("IDENTRAIL_AWS_FIXTURES", defaultAWSFixtures)),
 		KubernetesFixturePath:        parseCommaSeparated(getEnv("IDENTRAIL_K8S_FIXTURES", defaultK8sFixtures)),
 		KubernetesSource:             strings.ToLower(getEnv("IDENTRAIL_K8S_SOURCE", defaultK8sSource)),

--- a/internal/connectors/aws/capabilities.go
+++ b/internal/connectors/aws/capabilities.go
@@ -1,0 +1,216 @@
+package aws
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+// CapabilityPermissionTier describes the AWS permissions a single connector
+// capability tier needs, grouped so operators can see read-only discovery apart
+// from the future write/remediation/enforcement tiers before granting anything.
+type CapabilityPermissionTier struct {
+	Capability  domain.ConnectorCapability     `json:"capability"`
+	Tier        domain.ConnectorCapabilityTier `json:"tier"`
+	Available   bool                           `json:"available"`
+	Summary     string                         `json:"summary"`
+	Permissions []PermissionPreviewItem        `json:"permissions"`
+}
+
+// CapabilityPermissionTiers returns the AWS permission groups for every connector
+// capability in canonical privilege order. Only discovery is available today; the
+// remaining tiers are advertised so the boundary between read-only collection and
+// future write/enforcement access is explicit, and so write tiers are visibly
+// gated rather than silently folded into the read-only role.
+func CapabilityPermissionTiers() []CapabilityPermissionTier {
+	return []CapabilityPermissionTier{
+		{
+			Capability:  domain.ConnectorCapabilityDiscovery,
+			Tier:        domain.ConnectorCapabilityTierReadOnly,
+			Available:   true,
+			Summary:     "Read-only inventory and machine-identity graph collection. This is the default and the only tier the one-click CloudFormation role grants.",
+			Permissions: PermissionPreview(),
+		},
+		{
+			Capability: domain.ConnectorCapabilityRuntimeEvidence,
+			Tier:       domain.ConnectorCapabilityTierReadOnly,
+			Available:  false,
+			Summary:    "Read-only runtime activity used to prove whether risky permissions are actually exercised. Requires a separate read grant and is not enabled by the read-only stack.",
+			Permissions: []PermissionPreviewItem{
+				{
+					Service:   "IAM",
+					Actions:   []string{"iam:GenerateServiceLastAccessedDetails", "iam:GetServiceLastAccessedDetails"},
+					Resources: []string{"*"},
+					Reason:    "Confirms which services a machine identity has actually used so unused high-risk permissions can be flagged.",
+				},
+				{
+					Service:   "CloudTrail",
+					Actions:   []string{"cloudtrail:LookupEvents"},
+					Resources: []string{"*"},
+					Reason:    "Correlates recent API activity with the identities that performed it.",
+				},
+				{
+					Service:   "AccessAnalyzer",
+					Actions:   []string{"access-analyzer:ListFindings", "access-analyzer:GetFinding"},
+					Resources: []string{"*"},
+					Reason:    "Reads external-access findings that indicate runtime exposure of an identity.",
+				},
+			},
+		},
+		{
+			Capability: domain.ConnectorCapabilityRemediationPlan,
+			Tier:       domain.ConnectorCapabilityTierReadOnly,
+			Available:  false,
+			Summary:    "Generates proposed least-privilege fixes by simulation only. It never applies changes; applying requires the separate approved_remediation tier.",
+			Permissions: []PermissionPreviewItem{
+				{
+					Service:   "IAM",
+					Actions:   []string{"iam:SimulateCustomPolicy", "iam:GetContextKeysForPrincipalPolicy"},
+					Resources: []string{"*"},
+					Reason:    "Models the effect of a proposed policy before it is ever applied.",
+				},
+				{
+					Service:   "AccessAnalyzer",
+					Actions:   []string{"access-analyzer:ValidatePolicy", "access-analyzer:CheckNoNewAccess"},
+					Resources: []string{"*"},
+					Reason:    "Validates a proposed policy and proves it grants no new access.",
+				},
+			},
+		},
+		{
+			Capability: domain.ConnectorCapabilityAuthorizationAdvisory,
+			Tier:       domain.ConnectorCapabilityTierReadOnly,
+			Available:  false,
+			Summary:    "Advisory authorization brokering: recommends session-policy or boundary decisions without applying them. Read-only.",
+			Permissions: []PermissionPreviewItem{
+				{
+					Service:   "IAM",
+					Actions:   []string{"iam:GetRolePolicy", "iam:ListRolePolicies", "iam:SimulatePrincipalPolicy"},
+					Resources: []string{"*"},
+					Reason:    "Evaluates effective permissions to recommend a scoped-down authorization decision.",
+				},
+				{
+					Service:   "Organizations",
+					Actions:   []string{"organizations:DescribePolicy", "organizations:ListPoliciesForTarget"},
+					Resources: []string{"*"},
+					Reason:    "Reads existing service control policies to advise on safe boundaries.",
+				},
+			},
+		},
+		{
+			Capability: domain.ConnectorCapabilityApprovedRemediation,
+			Tier:       domain.ConnectorCapabilityTierWrite,
+			Available:  false,
+			Summary:    "WRITE: applies operator-approved least-privilege fixes to IAM. Must be granted with a dedicated write role; never granted by the read-only stack.",
+			Permissions: []PermissionPreviewItem{
+				{
+					Service:   "IAM",
+					Actions:   []string{"iam:PutRolePolicy", "iam:DeleteRolePolicy", "iam:AttachRolePolicy", "iam:DetachRolePolicy"},
+					Resources: []string{"*"},
+					Reason:    "Applies an approved remediation to a role's inline or attached policies.",
+				},
+			},
+		},
+		{
+			Capability: domain.ConnectorCapabilityAuthorizationEnforcement,
+			Tier:       domain.ConnectorCapabilityTierWrite,
+			Available:  false,
+			Summary:    "WRITE: enforces authorization decisions via permission boundaries or SCPs. Must be granted with a dedicated write role; never granted by the read-only stack.",
+			Permissions: []PermissionPreviewItem{
+				{
+					Service:   "IAM",
+					Actions:   []string{"iam:PutRolePermissionsBoundary", "iam:DeleteRolePermissionsBoundary"},
+					Resources: []string{"*"},
+					Reason:    "Applies or removes a permission boundary to enforce an authorization decision.",
+				},
+				{
+					Service:   "Organizations",
+					Actions:   []string{"organizations:AttachPolicy", "organizations:DetachPolicy"},
+					Resources: []string{"*"},
+					Reason:    "Attaches or detaches a service control policy to enforce an organization-wide boundary.",
+				},
+			},
+		},
+	}
+}
+
+// CapabilityPolicy gates which connector capabilities a deployment permits. The
+// read-only discovery tier is always allowed; every other tier (including all
+// write-capable tiers) is denied unless explicitly enabled, so remediation and
+// enforcement can never be turned on by accident. It satisfies the
+// domain.CapabilityGate contract.
+type CapabilityPolicy struct {
+	enabled map[domain.ConnectorCapability]bool
+}
+
+// DefaultCapabilityPolicy returns the safe baseline: only read-only discovery is
+// permitted.
+func DefaultCapabilityPolicy() CapabilityPolicy {
+	return CapabilityPolicy{enabled: map[domain.ConnectorCapability]bool{
+		domain.ConnectorCapabilityDiscovery: true,
+	}}
+}
+
+// NewCapabilityPolicy builds a policy that permits discovery plus any additional
+// valid capabilities supplied (for example from a feature flag). Unknown or empty
+// entries are ignored so misconfiguration cannot widen access unexpectedly.
+func NewCapabilityPolicy(enabled []domain.ConnectorCapability) CapabilityPolicy {
+	policy := DefaultCapabilityPolicy()
+	for _, capability := range enabled {
+		normalized := domain.ConnectorCapability(strings.TrimSpace(string(capability)))
+		if domain.ValidConnectorCapability(normalized) {
+			policy.enabled[normalized] = true
+		}
+	}
+	return policy
+}
+
+// NewCapabilityPolicyFromStrings builds a policy from raw capability names (for
+// example a comma-separated feature-flag value). Invalid names are ignored so a
+// typo cannot widen access.
+func NewCapabilityPolicyFromStrings(enabled []string) CapabilityPolicy {
+	capabilities := make([]domain.ConnectorCapability, 0, len(enabled))
+	for _, name := range enabled {
+		capabilities = append(capabilities, domain.ConnectorCapability(strings.TrimSpace(name)))
+	}
+	return NewCapabilityPolicy(capabilities)
+}
+
+// Configured reports whether the policy has been initialized. The zero value of
+// CapabilityPolicy is not configured, so callers can detect it and fall back to
+// the safe default.
+func (p CapabilityPolicy) Configured() bool {
+	return len(p.enabled) > 0
+}
+
+// Enabled returns the permitted capabilities in canonical privilege order.
+func (p CapabilityPolicy) Enabled() []domain.ConnectorCapability {
+	out := make([]domain.ConnectorCapability, 0, len(p.enabled))
+	for capability, on := range p.enabled {
+		if on {
+			out = append(out, capability)
+		}
+	}
+	order := domain.ConnectorCapabilityOrder()
+	rank := make(map[domain.ConnectorCapability]int, len(order))
+	for index, capability := range order {
+		rank[capability] = index
+	}
+	sort.SliceStable(out, func(i, j int) bool { return rank[out[i]] < rank[out[j]] })
+	return out
+}
+
+// CapabilityAllowed implements domain.CapabilityGate.
+func (p CapabilityPolicy) CapabilityAllowed(capability domain.ConnectorCapability) (bool, string) {
+	if capability == domain.ConnectorCapabilityDiscovery {
+		return true, ""
+	}
+	if p.enabled[capability] {
+		return true, ""
+	}
+	if capability.IsWriteCapable() {
+		return false, "write-capable capability " + string(capability) + " is disabled; it requires a dedicated write role and an explicit feature gate, and is never granted by the read-only connector"
+	}
+	return false, "capability " + string(capability) + " is not enabled for this deployment"
+}

--- a/internal/connectors/aws/capabilities_test.go
+++ b/internal/connectors/aws/capabilities_test.go
@@ -1,0 +1,110 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/identrail/identrail/internal/domain"
+)
+
+func TestCapabilityPermissionTiersCoverAllCapabilities(t *testing.T) {
+	tiers := CapabilityPermissionTiers()
+	if len(tiers) != len(domain.ConnectorCapabilityOrder()) {
+		t.Fatalf("expected one tier per capability, got %d tiers for %d capabilities", len(tiers), len(domain.ConnectorCapabilityOrder()))
+	}
+
+	seen := map[domain.ConnectorCapability]bool{}
+	for index, tier := range tiers {
+		if tier.Capability != domain.ConnectorCapabilityOrder()[index] {
+			t.Fatalf("tier %d capability = %q, want canonical order %q", index, tier.Capability, domain.ConnectorCapabilityOrder()[index])
+		}
+		seen[tier.Capability] = true
+		if tier.Tier != tier.Capability.Tier() {
+			t.Fatalf("tier classification for %q = %q, want %q", tier.Capability, tier.Tier, tier.Capability.Tier())
+		}
+		if len(tier.Permissions) == 0 {
+			t.Fatalf("tier %q has no permissions", tier.Capability)
+		}
+	}
+	for _, capability := range domain.ConnectorCapabilityOrder() {
+		if !seen[capability] {
+			t.Fatalf("capability %q missing from permission tiers", capability)
+		}
+	}
+}
+
+func TestCapabilityPermissionTiersOnlyDiscoveryAvailable(t *testing.T) {
+	for _, tier := range CapabilityPermissionTiers() {
+		wantAvailable := tier.Capability == domain.ConnectorCapabilityDiscovery
+		if tier.Available != wantAvailable {
+			t.Fatalf("capability %q available = %v, want %v", tier.Capability, tier.Available, wantAvailable)
+		}
+	}
+}
+
+func TestDiscoveryTierMatchesReadOnlyPreview(t *testing.T) {
+	tiers := CapabilityPermissionTiers()
+	if tiers[0].Capability != domain.ConnectorCapabilityDiscovery {
+		t.Fatalf("expected discovery first, got %q", tiers[0].Capability)
+	}
+	if len(tiers[0].Permissions) != len(PermissionPreview()) {
+		t.Fatalf("discovery tier permissions = %d, want read-only preview length %d", len(tiers[0].Permissions), len(PermissionPreview()))
+	}
+}
+
+func TestDefaultCapabilityPolicyAllowsOnlyDiscovery(t *testing.T) {
+	policy := DefaultCapabilityPolicy()
+	if allowed, _ := policy.CapabilityAllowed(domain.ConnectorCapabilityDiscovery); !allowed {
+		t.Fatal("discovery must always be allowed")
+	}
+	for _, capability := range domain.ConnectorCapabilityOrder() {
+		if capability == domain.ConnectorCapabilityDiscovery {
+			continue
+		}
+		allowed, reason := policy.CapabilityAllowed(capability)
+		if allowed {
+			t.Fatalf("capability %q should be denied by default", capability)
+		}
+		if reason == "" {
+			t.Fatalf("capability %q denial must include a reason", capability)
+		}
+	}
+}
+
+func TestNewCapabilityPolicyEnablesReadOnlyTierButGatesWrite(t *testing.T) {
+	policy := NewCapabilityPolicy([]domain.ConnectorCapability{
+		domain.ConnectorCapabilityRuntimeEvidence,
+		"bogus",
+	})
+	if allowed, _ := policy.CapabilityAllowed(domain.ConnectorCapabilityRuntimeEvidence); !allowed {
+		t.Fatal("runtime_evidence should be allowed once enabled")
+	}
+	// Unknown entries must be ignored, not silently widen access.
+	if allowed, _ := policy.CapabilityAllowed(domain.ConnectorCapability("bogus")); allowed {
+		t.Fatal("unknown capability must never be allowed")
+	}
+	// Write tiers stay gated unless explicitly enabled.
+	if allowed, reason := policy.CapabilityAllowed(domain.ConnectorCapabilityApprovedRemediation); allowed || reason == "" {
+		t.Fatalf("approved_remediation should remain gated, got allowed=%v reason=%q", allowed, reason)
+	}
+}
+
+func TestCapabilityPolicyEnabledOrdered(t *testing.T) {
+	policy := NewCapabilityPolicy([]domain.ConnectorCapability{
+		domain.ConnectorCapabilityApprovedRemediation,
+		domain.ConnectorCapabilityRuntimeEvidence,
+	})
+	enabled := policy.Enabled()
+	want := []domain.ConnectorCapability{
+		domain.ConnectorCapabilityDiscovery,
+		domain.ConnectorCapabilityRuntimeEvidence,
+		domain.ConnectorCapabilityApprovedRemediation,
+	}
+	if len(enabled) != len(want) {
+		t.Fatalf("enabled = %v, want %v", enabled, want)
+	}
+	for i := range want {
+		if enabled[i] != want[i] {
+			t.Fatalf("enabled[%d] = %q, want %q", i, enabled[i], want[i])
+		}
+	}
+}

--- a/internal/domain/connector_capability.go
+++ b/internal/domain/connector_capability.go
@@ -1,0 +1,202 @@
+package domain
+
+import (
+	"fmt"
+	"sort"
+)
+
+// ConnectorCapability enumerates the typed permission tiers a connector can be
+// granted. The default machine-identity connector is intentionally read-only
+// (discovery). Higher tiers are modeled explicitly so write-capable behavior is
+// never blended into the read-only path.
+type ConnectorCapability string
+
+const (
+	// ConnectorCapabilityDiscovery is the read-only baseline: inventory and graph
+	// collection. It is always available and is the default for every connector.
+	ConnectorCapabilityDiscovery ConnectorCapability = "discovery"
+	// ConnectorCapabilityRuntimeEvidence reads runtime activity (access analyzer,
+	// CloudTrail, last-used data) to enrich findings. Read-only.
+	ConnectorCapabilityRuntimeEvidence ConnectorCapability = "runtime_evidence"
+	// ConnectorCapabilityRemediationPlan generates proposed fixes without applying
+	// them. Read-only: it simulates and diffs, it does not mutate.
+	ConnectorCapabilityRemediationPlan ConnectorCapability = "remediation_plan"
+	// ConnectorCapabilityApprovedRemediation applies approved fixes to the account.
+	// Write-capable.
+	ConnectorCapabilityApprovedRemediation ConnectorCapability = "approved_remediation"
+	// ConnectorCapabilityAuthorizationAdvisory brokers advisory authorization
+	// decisions (recommendations only). Read-only.
+	ConnectorCapabilityAuthorizationAdvisory ConnectorCapability = "authorization_advisory"
+	// ConnectorCapabilityAuthorizationEnforcement applies authorization decisions
+	// such as session policies, SCPs, or permission boundaries. Write-capable.
+	ConnectorCapabilityAuthorizationEnforcement ConnectorCapability = "authorization_enforcement"
+)
+
+// ConnectorCapabilityTier classifies a capability by blast radius.
+type ConnectorCapabilityTier string
+
+const (
+	// ConnectorCapabilityTierReadOnly describes capabilities that never mutate the
+	// connected account.
+	ConnectorCapabilityTierReadOnly ConnectorCapabilityTier = "read_only"
+	// ConnectorCapabilityTierWrite describes capabilities that can mutate the
+	// connected account and therefore require explicit enablement.
+	ConnectorCapabilityTierWrite ConnectorCapabilityTier = "write"
+)
+
+// connectorCapabilityOrder is the canonical low-to-high privilege ordering used
+// for stable, deterministic output.
+var connectorCapabilityOrder = []ConnectorCapability{
+	ConnectorCapabilityDiscovery,
+	ConnectorCapabilityRuntimeEvidence,
+	ConnectorCapabilityRemediationPlan,
+	ConnectorCapabilityAuthorizationAdvisory,
+	ConnectorCapabilityApprovedRemediation,
+	ConnectorCapabilityAuthorizationEnforcement,
+}
+
+var connectorCapabilityRank = func() map[ConnectorCapability]int {
+	ranks := make(map[ConnectorCapability]int, len(connectorCapabilityOrder))
+	for index, capability := range connectorCapabilityOrder {
+		ranks[capability] = index
+	}
+	return ranks
+}()
+
+// ConnectorCapabilityOrder returns capabilities in canonical privilege order.
+func ConnectorCapabilityOrder() []ConnectorCapability {
+	out := make([]ConnectorCapability, len(connectorCapabilityOrder))
+	copy(out, connectorCapabilityOrder)
+	return out
+}
+
+// DefaultConnectorCapabilities returns the read-only baseline granted to every
+// connector unless higher tiers are explicitly requested and permitted.
+func DefaultConnectorCapabilities() []ConnectorCapability {
+	return []ConnectorCapability{ConnectorCapabilityDiscovery}
+}
+
+// ValidConnectorCapability reports whether the capability is a known tier.
+func ValidConnectorCapability(capability ConnectorCapability) bool {
+	_, ok := connectorCapabilityRank[capability]
+	return ok
+}
+
+// IsWriteCapable reports whether enabling the capability allows mutating the
+// connected account. Write-capable tiers must never be granted implicitly.
+func (c ConnectorCapability) IsWriteCapable() bool {
+	switch c {
+	case ConnectorCapabilityApprovedRemediation, ConnectorCapabilityAuthorizationEnforcement:
+		return true
+	default:
+		return false
+	}
+}
+
+// Tier returns the blast-radius classification for the capability.
+func (c ConnectorCapability) Tier() ConnectorCapabilityTier {
+	if c.IsWriteCapable() {
+		return ConnectorCapabilityTierWrite
+	}
+	return ConnectorCapabilityTierReadOnly
+}
+
+// NormalizeConnectorCapabilities validates, de-duplicates, and canonically
+// orders a requested capability set. Discovery is always included because it is
+// the read-only baseline every connector retains. Unknown capabilities are an
+// error so callers cannot silently request undefined tiers.
+func NormalizeConnectorCapabilities(requested []ConnectorCapability) ([]ConnectorCapability, error) {
+	seen := map[ConnectorCapability]bool{ConnectorCapabilityDiscovery: true}
+	for _, capability := range requested {
+		if !ValidConnectorCapability(capability) {
+			return nil, fmt.Errorf("connector capability %q is invalid", capability)
+		}
+		seen[capability] = true
+	}
+	return sortedCapabilities(seen), nil
+}
+
+// CapabilityGate decides whether a capability may be enabled for a connector and,
+// when it may not, explains why. Implementations live at the policy/feature-flag
+// boundary so the domain stays free of configuration concerns.
+type CapabilityGate interface {
+	// CapabilityAllowed reports whether the capability is permitted. When it is
+	// not, the returned reason explains why so diagnostics can name the tier.
+	CapabilityAllowed(capability ConnectorCapability) (allowed bool, reason string)
+}
+
+// ConnectorCapabilityUnavailable records a requested capability that could not be
+// granted, along with the reason and its tier so callers can surface a precise
+// diagnostic rather than a generic connector failure.
+type ConnectorCapabilityUnavailable struct {
+	Capability ConnectorCapability     `json:"capability"`
+	Tier       ConnectorCapabilityTier `json:"tier"`
+	Reason     string                  `json:"reason"`
+}
+
+// ConnectorCapabilityResolution captures the lifecycle of a capability request:
+// what was asked for, what the gate validated as permitted, what is effectively
+// in force, and which requested tiers were rejected and why.
+type ConnectorCapabilityResolution struct {
+	Requested   []ConnectorCapability            `json:"requested"`
+	Validated   []ConnectorCapability            `json:"validated"`
+	Effective   []ConnectorCapability            `json:"effective"`
+	Unavailable []ConnectorCapabilityUnavailable `json:"unavailable,omitempty"`
+}
+
+// ResolveConnectorCapabilities computes the validated, effective, and unavailable
+// sets for a requested capability list against a gate. Discovery is always
+// requested and always effective (read-only baseline). A requested capability is
+// validated only when the gate permits it; rejected tiers are reported as
+// unavailable with the gate's reason. Effective never exceeds validated, so a
+// write-capable tier can never be granted unless the gate explicitly allows it.
+func ResolveConnectorCapabilities(requested []ConnectorCapability, gate CapabilityGate) (ConnectorCapabilityResolution, error) {
+	normalizedRequested, err := NormalizeConnectorCapabilities(requested)
+	if err != nil {
+		return ConnectorCapabilityResolution{}, err
+	}
+
+	validated := map[ConnectorCapability]bool{}
+	unavailable := make([]ConnectorCapabilityUnavailable, 0)
+	for _, capability := range normalizedRequested {
+		if capability == ConnectorCapabilityDiscovery {
+			validated[capability] = true
+			continue
+		}
+		allowed, reason := true, ""
+		if gate != nil {
+			allowed, reason = gate.CapabilityAllowed(capability)
+		}
+		if allowed {
+			validated[capability] = true
+			continue
+		}
+		if reason == "" {
+			reason = fmt.Sprintf("capability %q is not enabled for this deployment", capability)
+		}
+		unavailable = append(unavailable, ConnectorCapabilityUnavailable{
+			Capability: capability,
+			Tier:       capability.Tier(),
+			Reason:     reason,
+		})
+	}
+
+	effective := sortedCapabilities(validated)
+	return ConnectorCapabilityResolution{
+		Requested:   normalizedRequested,
+		Validated:   effective,
+		Effective:   effective,
+		Unavailable: unavailable,
+	}, nil
+}
+
+func sortedCapabilities(set map[ConnectorCapability]bool) []ConnectorCapability {
+	out := make([]ConnectorCapability, 0, len(set))
+	for capability := range set {
+		out = append(out, capability)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return connectorCapabilityRank[out[i]] < connectorCapabilityRank[out[j]]
+	})
+	return out
+}

--- a/internal/domain/connector_capability_test.go
+++ b/internal/domain/connector_capability_test.go
@@ -1,0 +1,150 @@
+package domain
+
+import (
+	"reflect"
+	"testing"
+)
+
+type stubCapabilityGate struct {
+	allow  map[ConnectorCapability]bool
+	reason string
+}
+
+func (g stubCapabilityGate) CapabilityAllowed(capability ConnectorCapability) (bool, string) {
+	if g.allow[capability] {
+		return true, ""
+	}
+	return false, g.reason
+}
+
+func TestValidConnectorCapability(t *testing.T) {
+	for _, capability := range ConnectorCapabilityOrder() {
+		if !ValidConnectorCapability(capability) {
+			t.Fatalf("expected %q to be valid", capability)
+		}
+	}
+	if ValidConnectorCapability(ConnectorCapability("nonsense")) {
+		t.Fatal("expected unknown capability to be invalid")
+	}
+}
+
+func TestCapabilityWriteClassification(t *testing.T) {
+	readOnly := []ConnectorCapability{
+		ConnectorCapabilityDiscovery,
+		ConnectorCapabilityRuntimeEvidence,
+		ConnectorCapabilityRemediationPlan,
+		ConnectorCapabilityAuthorizationAdvisory,
+	}
+	for _, capability := range readOnly {
+		if capability.IsWriteCapable() {
+			t.Fatalf("expected %q to be read-only", capability)
+		}
+		if capability.Tier() != ConnectorCapabilityTierReadOnly {
+			t.Fatalf("expected %q tier read_only, got %q", capability, capability.Tier())
+		}
+	}
+	write := []ConnectorCapability{
+		ConnectorCapabilityApprovedRemediation,
+		ConnectorCapabilityAuthorizationEnforcement,
+	}
+	for _, capability := range write {
+		if !capability.IsWriteCapable() {
+			t.Fatalf("expected %q to be write-capable", capability)
+		}
+		if capability.Tier() != ConnectorCapabilityTierWrite {
+			t.Fatalf("expected %q tier write, got %q", capability, capability.Tier())
+		}
+	}
+}
+
+func TestDefaultConnectorCapabilitiesIsDiscoveryOnly(t *testing.T) {
+	got := DefaultConnectorCapabilities()
+	want := []ConnectorCapability{ConnectorCapabilityDiscovery}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("default capabilities = %v, want %v", got, want)
+	}
+}
+
+func TestNormalizeConnectorCapabilities(t *testing.T) {
+	got, err := NormalizeConnectorCapabilities([]ConnectorCapability{
+		ConnectorCapabilityApprovedRemediation,
+		ConnectorCapabilityDiscovery,
+		ConnectorCapabilityApprovedRemediation,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []ConnectorCapability{ConnectorCapabilityDiscovery, ConnectorCapabilityApprovedRemediation}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalized = %v, want %v (deduped, discovery-first, canonical order)", got, want)
+	}
+
+	if _, err := NormalizeConnectorCapabilities([]ConnectorCapability{"bogus"}); err == nil {
+		t.Fatal("expected error for unknown capability")
+	}
+}
+
+func TestNormalizeAlwaysIncludesDiscovery(t *testing.T) {
+	got, err := NormalizeConnectorCapabilities(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, []ConnectorCapability{ConnectorCapabilityDiscovery}) {
+		t.Fatalf("expected discovery baseline, got %v", got)
+	}
+}
+
+func TestResolveConnectorCapabilitiesDefaultReadOnly(t *testing.T) {
+	resolution, err := ResolveConnectorCapabilities(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []ConnectorCapability{ConnectorCapabilityDiscovery}
+	if !reflect.DeepEqual(resolution.Effective, want) {
+		t.Fatalf("effective = %v, want %v", resolution.Effective, want)
+	}
+	if !reflect.DeepEqual(resolution.Validated, want) {
+		t.Fatalf("validated = %v, want %v", resolution.Validated, want)
+	}
+	if len(resolution.Unavailable) != 0 {
+		t.Fatalf("expected no unavailable capabilities, got %v", resolution.Unavailable)
+	}
+}
+
+func TestResolveConnectorCapabilitiesGatesWriteTier(t *testing.T) {
+	gate := stubCapabilityGate{
+		allow:  map[ConnectorCapability]bool{ConnectorCapabilityRuntimeEvidence: true},
+		reason: "feature flag disabled",
+	}
+	resolution, err := ResolveConnectorCapabilities([]ConnectorCapability{
+		ConnectorCapabilityRuntimeEvidence,
+		ConnectorCapabilityApprovedRemediation,
+	}, gate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantEffective := []ConnectorCapability{ConnectorCapabilityDiscovery, ConnectorCapabilityRuntimeEvidence}
+	if !reflect.DeepEqual(resolution.Effective, wantEffective) {
+		t.Fatalf("effective = %v, want %v", resolution.Effective, wantEffective)
+	}
+	if len(resolution.Unavailable) != 1 {
+		t.Fatalf("expected one unavailable capability, got %v", resolution.Unavailable)
+	}
+	unavailable := resolution.Unavailable[0]
+	if unavailable.Capability != ConnectorCapabilityApprovedRemediation {
+		t.Fatalf("unavailable capability = %q, want approved_remediation", unavailable.Capability)
+	}
+	if unavailable.Tier != ConnectorCapabilityTierWrite {
+		t.Fatalf("unavailable tier = %q, want write", unavailable.Tier)
+	}
+	if unavailable.Reason != "feature flag disabled" {
+		t.Fatalf("unavailable reason = %q, want gate reason", unavailable.Reason)
+	}
+}
+
+func TestResolveConnectorCapabilitiesRejectsInvalid(t *testing.T) {
+	if _, err := ResolveConnectorCapabilities([]ConnectorCapability{"bogus"}, nil); err == nil {
+		t.Fatal("expected error for invalid requested capability")
+	}
+}

--- a/internal/runtime/service_builder.go
+++ b/internal/runtime/service_builder.go
@@ -10,6 +10,7 @@ import (
 	"github.com/identrail/identrail/internal/api"
 	"github.com/identrail/identrail/internal/app"
 	"github.com/identrail/identrail/internal/config"
+	awsconnector "github.com/identrail/identrail/internal/connectors/aws"
 	githubconnector "github.com/identrail/identrail/internal/connectors/github"
 	"github.com/identrail/identrail/internal/db"
 	awsprovider "github.com/identrail/identrail/internal/providers/aws"
@@ -127,6 +128,7 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 	svc.AWSConnectorValidator = awsprovider.NewConnectionValidator(cfg.AWSRegion, cfg.AWSProfile)
 	svc.AWSCloudFormationTemplateURL = cfg.AWSCloudFormationTemplateURL
 	svc.AWSAccountID = cfg.AWSAccountID
+	svc.AWSConnectorCapabilityPolicy = awsconnector.NewCapabilityPolicyFromStrings(cfg.AWSConnectorCapabilities)
 	svc.GitHubAppID = parseInt64Config(cfg.GitHubAppID)
 	svc.GitHubAppName = cfg.GitHubAppName
 	svc.GitHubAppPrivateKey = cfg.GitHubAppPrivateKey

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -661,6 +661,37 @@ export type AWSPermissionPreviewItem = {
   reason: string;
 };
 
+export type ConnectorCapability =
+  | 'discovery'
+  | 'runtime_evidence'
+  | 'remediation_plan'
+  | 'approved_remediation'
+  | 'authorization_advisory'
+  | 'authorization_enforcement';
+
+export type ConnectorCapabilityTier = 'read_only' | 'write';
+
+export type AWSCapabilityPermissionTier = {
+  capability: ConnectorCapability;
+  tier: ConnectorCapabilityTier;
+  available: boolean;
+  summary: string;
+  permissions: AWSPermissionPreviewItem[];
+};
+
+export type AWSConnectorCapabilityUnavailable = {
+  capability: ConnectorCapability;
+  tier: ConnectorCapabilityTier;
+  reason: string;
+};
+
+export type AWSConnectorCapabilities = {
+  requested: ConnectorCapability[];
+  validated: ConnectorCapability[];
+  effective: ConnectorCapability[];
+  unavailable: AWSConnectorCapabilityUnavailable[];
+};
+
 export type AWSConnectionStatus = {
   provider: 'aws';
   connected: boolean;
@@ -676,6 +707,7 @@ export type AWSConnectionStatus = {
   region?: string;
   permission_checks: AWSConnectionPermissionCheck[];
   diagnostics: AWSConnectionDiagnostic[];
+  capabilities: AWSConnectorCapabilities;
   remediation_message?: string;
   launch_url?: string;
   template_url?: string;
@@ -692,6 +724,7 @@ export type AWSConnectionUpsertRequest = {
   external_id?: string;
   region?: string;
   session_name?: string;
+  capabilities?: ConnectorCapability[];
 };
 
 export type AWSConnectorStartRequest = {
@@ -714,6 +747,7 @@ export type AWSConnectorStartResponse = {
   stack_name: string;
   policy_hash: string;
   permission_preview: AWSPermissionPreviewItem[];
+  permission_tiers: AWSCapabilityPermissionTier[];
 };
 
 export type AWSConnectorValidateRequest = {
@@ -723,12 +757,14 @@ export type AWSConnectorValidateRequest = {
   external_id?: string;
   region?: string;
   session_name?: string;
+  capabilities?: ConnectorCapability[];
 };
 
 export type AWSConnectorPolicyResponse = {
   policy_hash: string;
   policy_document: Record<string, unknown>;
   permission_preview: AWSPermissionPreviewItem[];
+  permission_tiers: AWSCapabilityPermissionTier[];
 };
 
 export type KubernetesPermissionCheck = {

--- a/web/src/components/connector/PermissionPreviewModal.tsx
+++ b/web/src/components/connector/PermissionPreviewModal.tsx
@@ -1,13 +1,39 @@
-import type { AWSPermissionPreviewItem } from '../../api/client';
+import type { AWSCapabilityPermissionTier, AWSPermissionPreviewItem } from '../../api/client';
 
 type PermissionPreviewModalProps = {
   open: boolean;
   title: string;
   items: AWSPermissionPreviewItem[];
+  tiers?: AWSCapabilityPermissionTier[];
   onClose: () => void;
 };
 
-export function PermissionPreviewModal({ open, title, items, onClose }: PermissionPreviewModalProps) {
+const CAPABILITY_LABELS: Record<string, string> = {
+  discovery: 'Discovery',
+  runtime_evidence: 'Runtime evidence',
+  remediation_plan: 'Remediation plan',
+  approved_remediation: 'Approved remediation',
+  authorization_advisory: 'Authorization advisory',
+  authorization_enforcement: 'Authorization enforcement',
+};
+
+function PermissionList({ items }: { items: AWSPermissionPreviewItem[] }) {
+  return (
+    <div className="idt-permission-preview-list">
+      {items.map((item) => (
+        <article key={item.service}>
+          <div>
+            <strong>{item.service}</strong>
+            <p>{item.reason}</p>
+          </div>
+          <code>{item.actions.join(', ')}</code>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+export function PermissionPreviewModal({ open, title, items, tiers, onClose }: PermissionPreviewModalProps) {
   if (!open) {
     return null;
   }
@@ -30,17 +56,25 @@ export function PermissionPreviewModal({ open, title, items, onClose }: Permissi
             x
           </button>
         </header>
-        <div className="idt-permission-preview-list">
-          {items.map((item) => (
-            <article key={item.service}>
-              <div>
-                <strong>{item.service}</strong>
-                <p>{item.reason}</p>
-              </div>
-              <code>{item.actions.join(', ')}</code>
-            </article>
-          ))}
-        </div>
+        {tiers && tiers.length > 0 ? (
+          <div className="idt-permission-tier-list">
+            {tiers.map((tier) => (
+              <section key={tier.capability} className="idt-permission-tier" data-tier={tier.tier}>
+                <header className="idt-permission-tier-header">
+                  <strong>{CAPABILITY_LABELS[tier.capability] ?? tier.capability}</strong>
+                  <span className="idt-permission-tier-badges">
+                    <span className="idt-badge">{tier.tier === 'write' ? 'Write' : 'Read-only'}</span>
+                    <span className="idt-badge">{tier.available ? 'Available now' : 'Not yet enabled'}</span>
+                  </span>
+                </header>
+                <p>{tier.summary}</p>
+                <PermissionList items={tier.permissions} />
+              </section>
+            ))}
+          </div>
+        ) : (
+          <PermissionList items={items} />
+        )}
       </section>
     </div>
   );

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -72,7 +72,8 @@ const disconnectedAWS: AWSConnectionStatus = {
   health_status: 'unknown',
   external_id_configured: false,
   permission_checks: [],
-  diagnostics: []
+  diagnostics: [],
+  capabilities: { requested: ['discovery'], validated: ['discovery'], effective: ['discovery'], unavailable: [] }
 };
 
 const connectedGitHub: GitHubConnectionStatus = {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -24,6 +24,7 @@ import {
   ApiError,
   apiClient,
   type AuthConfigResponse,
+  type AWSCapabilityPermissionTier,
   type AWSConnectorStartResponse,
   type AWSConnectionStatus,
   type AWSPermissionPreviewItem,
@@ -3754,6 +3755,7 @@ export function ProductProjectDetailPage() {
   });
   const [awsCloudFormationStart, setAWSCloudFormationStart] = useState<AWSConnectorStartResponse | null>(null);
   const [awsPermissionPreview, setAWSPermissionPreview] = useState<AWSPermissionPreviewItem[]>([]);
+  const [awsPermissionTiers, setAWSPermissionTiers] = useState<AWSCapabilityPermissionTier[]>([]);
   const [awsPreviewOpen, setAWSPreviewOpen] = useState(false);
   const [kubernetesForm, setKubernetesForm] = useState({
     displayName: '',
@@ -4024,6 +4026,7 @@ export function ProductProjectDetailPage() {
     setGitHubPostureError('');
     setAWSCloudFormationStart(null);
     setAWSPermissionPreview([]);
+    setAWSPermissionTiers([]);
     setAWSPreviewOpen(false);
     setAWSForm((current) => ({ ...current, externalID: '' }));
     if (backendFeaturesLoading) {
@@ -4349,6 +4352,7 @@ export function ProductProjectDetailPage() {
       }
       setAWSCloudFormationStart(response);
       setAWSPermissionPreview(response.permission_preview);
+      setAWSPermissionTiers(response.permission_tiers ?? []);
       setAWSForm((current) => ({ ...current, externalID: response.external_id }));
       setConnections((current) => ({ ...current, aws: response.connection }));
       setSuccessMessage('AWS stack launch is ready.');
@@ -5566,6 +5570,7 @@ export function ProductProjectDetailPage() {
         open={awsPreviewOpen}
         title="AWS read-only connector policy"
         items={awsPermissionPreview}
+        tiers={awsPermissionTiers}
         onClose={() => setAWSPreviewOpen(false)}
       />
     </section>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6016,6 +6016,44 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   color: #b9d3ff;
 }
 
+.idt-permission-tier-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.idt-permission-tier {
+  border: 1px solid rgba(126, 157, 211, 0.26);
+  border-radius: 0.7rem;
+  padding: 0.85rem;
+  background: rgba(12, 22, 35, 0.55);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.idt-permission-tier[data-tier='write'] {
+  border-color: rgba(214, 130, 5, 0.5);
+}
+
+.idt-permission-tier-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.idt-permission-tier-badges {
+  display: inline-flex;
+  gap: 0.4rem;
+}
+
+.idt-permission-tier .idt-badge {
+  border: 1px solid rgba(126, 157, 211, 0.4);
+  border-radius: 999px;
+  padding: 0.1rem 0.55rem;
+  font-size: 0.72rem;
+  color: #c2d4f0;
+}
+
 .idt-source-diagnostics {
   display: grid;
   gap: 0.55rem;


### PR DESCRIPTION
Fixes #1353

## What changed
Introduces an explicit, typed connector **capability model** for AWS so write-capable behavior is never blended into the read-only path before remediation/authorization work lands.

- **Domain (`internal/domain/connector_capability.go`)** — `ConnectorCapability` enum with the six tiers (`discovery`, `runtime_evidence`, `remediation_plan`, `approved_remediation`, `authorization_advisory`, `authorization_enforcement`), read-only vs write classification, a discovery-only default, a `CapabilityGate` interface, and a pure resolver producing `requested`/`validated`/`effective` sets plus per-tier unavailability reasons.
- **AWS connector (`internal/connectors/aws/capabilities.go`)** — AWS action groups per tier for a capability-grouped permission preview, and a `CapabilityPolicy` gate that only permits `discovery` unless tiers are explicitly enabled (write tiers stay denied with an explanatory reason).
- **API (`internal/api/aws_connect.go`)** — `AWSConnectionStatus.capabilities` exposes requested/validated/effective + unavailable; the CloudFormation start flow is pinned to `discovery`; validation emits an `aws_capability_unavailable` diagnostic that names the affected tier **without** degrading a healthy read-only connector; legacy connectors backfill the discovery baseline (no client breakage). Start/policy responses gain `permission_tiers`.
- **Config/runtime** — `IDENTRAIL_AWS_CONNECTOR_CAPABILITIES` feature gate wired into the service.
- **OpenAPI + web** — capability schemas, API client types, and a tier-grouped permission-preview display surface.
- **Docs** — `docs/connector-capabilities.md`, configuration reference, and CHANGELOG.

## Why
The AWS connector must remain read-only by default, but the control-plane roadmap needs multiple permission tiers. Modeling them explicitly prevents silently widening the read-only role and makes write-capable tiers visibly gated.

## Acceptance criteria
- [x] AWS connector status exposes capability information without breaking existing clients (legacy metadata backfills `discovery`).
- [x] Existing read-only connector setup remains read-only by default.
- [x] Permission preview separates read-only discovery from future write/remediation/enforcement tiers.
- [x] Validation failures identify the affected capability (`aws_capability_unavailable`), not a generic connector error.
- [x] Tests cover default read-only behavior and an unavailable capability diagnostic.
- [x] No live remediation or enforcement action is added.

## Impact and risk
Additive. Default behavior is unchanged (discovery-only, read-only). Write tiers are gated behind a feature flag and a dedicated write role; no executors ship here.

## Validation performed
- `gofmt -l` (clean) and `go vet` on touched packages — clean.
- `go test ./internal/domain/ ./internal/connectors/aws/ ./internal/api/ ./internal/config/ ./internal/runtime/` — pass (includes the OpenAPI contract test in `internal/api`).
- `go build ./...` — pass.
- `npm run test:ci --prefix web` — 182 passed; `npm run build --prefix web` (tsc + vite + prerender) — pass.

## AI assistance disclosure
- **AI-assisted:** yes
- **Tools used:** Claude Code
- **Where used:** domain capability model, AWS capability tiers/gate, API wiring, OpenAPI, web client types/UI, docs/changelog, and tests under the listed packages.
- **Human verification performed:** reviewed the generated diff; ran `gofmt`/`go vet`/Go package tests (incl. OpenAPI contract), full module build, and web test + build locally as listed above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds typed capability modes to the AWS connector so it stays read-only by default and clearly gates future write behavior. Surfaces requested/validated/effective tiers in the API and UI, with a tier-grouped permission preview.

- New Features
  - Domain: `ConnectorCapability` enum (six tiers) with read/write classification, `CapabilityGate`, and a resolver returning requested/validated/effective plus unavailability reasons.
  - AWS: capability‑grouped permission preview and a `CapabilityPolicy` that allows only `discovery` unless tiers are explicitly enabled.
  - API: `AWSConnectionStatus.capabilities`; capability‑scoped `aws_capability_unavailable` diagnostics that don’t degrade a healthy read‑only connector; upsert/validate accept optional `capabilities`; CloudFormation start is pinned to `discovery`; start/policy responses include `permission_tiers`; legacy connectors backfill `discovery`.
  - Config/runtime: feature flag `IDENTRAIL_AWS_CONNECTOR_CAPABILITIES` wired in the service builder to permit tiers beyond `discovery`.
  - OpenAPI + web: capability schemas/types and a tier‑grouped permission preview in the UI.
  - Docs: added `docs/connector-capabilities.md` and updated configuration reference/CHANGELOG.

- Migration
  - No action required; existing connectors remain discovery‑only and read‑only.
  - To enable more tiers, set `IDENTRAIL_AWS_CONNECTOR_CAPABILITIES` (e.g., `runtime_evidence`); write tiers also require a dedicated write role.

<sup>Written for commit 20eb2c9b37ea0280582f0b979d4ee3c129016b2c. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1362?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

