### PR TITLE
Add AWS connector capability modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Added typed AWS connector capability modes so the API, UI, OpenAPI contract,
+  and permission preview can report requested, validated, effective, and gated
+  capabilities while keeping discovery read-only by default.
 - Added GitHub Actions AI-agent prompt-injection detection for workflows that
   feed untrusted PR, issue, review, comment, workflow_run, or repository
   prompt-file content into LLM/agent steps with repository write, secret, OIDC,

--- a/deploy/connectors/aws/policies/identrail-readonly-policy.md
+++ b/deploy/connectors/aws/policies/identrail-readonly-policy.md
@@ -2,6 +2,8 @@
 
 This policy is intentionally narrower than AWS managed `ReadOnlyAccess`. It grants only the read calls Identrail needs to validate a connector and build the first machine identity trust graph.
 
+Capability tier: `discovery`. This policy does not enable runtime evidence collection, remediation execution, authorization advisory decisions, or authorization enforcement.
+
 | Service | Actions | Why Identrail needs it |
 | --- | --- | --- |
 | STS | `sts:GetCallerIdentity` | Confirms the assumed-role identity during setup and recurring scans. |

--- a/docs/auth/aws-connector.md
+++ b/docs/auth/aws-connector.md
@@ -36,4 +36,14 @@ When a persistent database is configured and AWS connector setup is enabled, `ID
 4. The user pastes the created role ARN back into Identrail.
 5. The API uses the stored External ID, assumes the role with STS, verifies caller identity, checks scanner-critical IAM read access, and marks the connector active or degraded.
 
+## Capability modes
+
+AWS connectors report typed capability modes so operators can distinguish what was requested, what validation proved, and what is actually effective:
+
+- `discovery` is the default and remains the only capability enabled by the read-only CloudFormation stack.
+- `runtime_evidence`, `remediation_plan`, `approved_remediation`, `authorization_advisory`, and `authorization_enforcement` are modeled for future workflows, but stay unavailable unless deployment policy gates explicitly enable them.
+- Write-capable modes such as `approved_remediation` and `authorization_enforcement` are never enabled by the current read-only stack.
+
+The permission preview groups AWS actions by capability tier and marks future tiers as gated, so teams can review the extra policy surface before enabling any non-discovery workflow.
+
 The read-only policy and rationale live together under `deploy/connectors/aws/policies/`.

--- a/docs/auth/env-vars-reference.md
+++ b/docs/auth/env-vars-reference.md
@@ -71,6 +71,11 @@ for their deployment.
 | --- | --- | --- | --- |
 | `IDENTRAIL_AWS_CFN_TEMPLATE_URL` | empty | Required for the CFN one-click flow. Points at the CDN-hosted template. | AWS connector |
 | `IDENTRAIL_AWS_ACCOUNT_ID` | empty | Required. The Identrail-side AWS account that the customer's role trusts. | AWS connector |
+| `IDENTRAIL_AWS_CAPABILITY_RUNTIME_EVIDENCE` | `false` | Optional gate for future AWS runtime-evidence collection. The read-only stack does not enable this by default. | AWS connector |
+| `IDENTRAIL_AWS_CAPABILITY_REMEDIATION_PLAN` | `false` | Optional gate for future AWS remediation planning workflows. | AWS connector |
+| `IDENTRAIL_AWS_CAPABILITY_APPROVED_REMEDIATION` | `false` | Optional gate for write-capable approved remediation. Keep disabled unless an explicit approval workflow and IAM policy are configured. | AWS connector |
+| `IDENTRAIL_AWS_CAPABILITY_AUTHORIZATION_ADVISORY` | `false` | Optional gate for future AWS authorization advisory workflows. | AWS connector |
+| `IDENTRAIL_AWS_CAPABILITY_AUTHORIZATION_ENFORCEMENT` | `false` | Optional gate for write-capable authorization enforcement. Keep disabled unless private tenancy, approvals, and write-capable IAM policy controls are configured. | AWS connector |
 
 ### GitHub Connector
 

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -5135,6 +5135,11 @@ components:
         stack_name:
           type: string
           default: identrail-readonly-connector
+        requested_capabilities:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSConnectorCapability"
+          default: [discovery]
     AWSConnectorValidateRequest:
       type: object
       required: [role_arn]
@@ -5154,12 +5159,37 @@ components:
         session_name:
           type: string
           default: identrail-connector-validation
+        requested_capabilities:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSConnectorCapability"
+          default: [discovery]
     AWSConnectorPollRequest:
       type: object
       properties:
         workspace_id:
           type: string
         project_id:
+          type: string
+    AWSConnectorCapability:
+      type: string
+      enum:
+        - discovery
+        - runtime_evidence
+        - remediation_plan
+        - approved_remediation
+        - authorization_advisory
+        - authorization_enforcement
+    AWSUnavailableCapability:
+      type: object
+      properties:
+        capability:
+          $ref: "#/components/schemas/AWSConnectorCapability"
+        reason:
+          type: string
+        gate:
+          type: string
+        remediation:
           type: string
     AWSConnectorStartResponse:
       type: object
@@ -5211,6 +5241,14 @@ components:
           items: { type: string }
         reason:
           type: string
+        capability:
+          $ref: "#/components/schemas/AWSConnectorCapability"
+        tier:
+          type: string
+        included:
+          type: boolean
+        gate:
+          type: string
     AWSConnectionUpsertRequest:
       type: object
       required: [role_arn]
@@ -5231,6 +5269,11 @@ components:
         session_name:
           type: string
           default: identrail-connector-validation
+        requested_capabilities:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSConnectorCapability"
+          default: [discovery]
     AWSConnectionDiagnostic:
       type: object
       properties:
@@ -5240,6 +5283,8 @@ components:
           type: string
         remediation:
           type: string
+        capability:
+          $ref: "#/components/schemas/AWSConnectorCapability"
     AWSConnectionPermissionCheck:
       type: object
       properties:
@@ -5251,6 +5296,8 @@ components:
           type: string
         remediation:
           type: string
+        capability:
+          $ref: "#/components/schemas/AWSConnectorCapability"
     AWSConnectionStatus:
       type: object
       properties:
@@ -5289,6 +5336,22 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AWSConnectionDiagnostic"
+        requested_capabilities:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSConnectorCapability"
+        validated_capabilities:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSConnectorCapability"
+        effective_capabilities:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSConnectorCapability"
+        unavailable_capabilities:
+          type: array
+          items:
+            $ref: "#/components/schemas/AWSUnavailableCapability"
         remediation_message:
           type: string
         launch_url:

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -43,33 +43,36 @@ type AWSConnectorValidator interface {
 
 // AWSConnectionUpsertRequest captures one project AWS connector onboarding request.
 type AWSConnectionUpsertRequest struct {
-	ConnectorID string `json:"connector_id,omitempty"`
-	DisplayName string `json:"display_name,omitempty"`
-	RoleARN     string `json:"role_arn"`
-	ExternalID  string `json:"external_id,omitempty"`
-	Region      string `json:"region,omitempty"`
-	SessionName string `json:"session_name,omitempty"`
+	ConnectorID           string                    `json:"connector_id,omitempty"`
+	DisplayName           string                    `json:"display_name,omitempty"`
+	RoleARN               string                    `json:"role_arn"`
+	ExternalID            string                    `json:"external_id,omitempty"`
+	Region                string                    `json:"region,omitempty"`
+	SessionName           string                    `json:"session_name,omitempty"`
+	RequestedCapabilities []awsconnector.Capability `json:"requested_capabilities,omitempty"`
 }
 
 // AWSConnectorStartRequest starts the CloudFormation-based AWS connector flow.
 type AWSConnectorStartRequest struct {
-	WorkspaceID string `json:"workspace_id,omitempty"`
-	ProjectID   string `json:"project_id,omitempty"`
-	ConnectorID string `json:"connector_id,omitempty"`
-	DisplayName string `json:"display_name,omitempty"`
-	Region      string `json:"region,omitempty"`
-	RoleName    string `json:"role_name,omitempty"`
-	StackName   string `json:"stack_name,omitempty"`
+	WorkspaceID           string                    `json:"workspace_id,omitempty"`
+	ProjectID             string                    `json:"project_id,omitempty"`
+	ConnectorID           string                    `json:"connector_id,omitempty"`
+	DisplayName           string                    `json:"display_name,omitempty"`
+	Region                string                    `json:"region,omitempty"`
+	RoleName              string                    `json:"role_name,omitempty"`
+	StackName             string                    `json:"stack_name,omitempty"`
+	RequestedCapabilities []awsconnector.Capability `json:"requested_capabilities,omitempty"`
 }
 
 // AWSConnectorValidateRequest validates a CloudFormation-created AWS connector role.
 type AWSConnectorValidateRequest struct {
-	WorkspaceID string `json:"workspace_id,omitempty"`
-	ProjectID   string `json:"project_id,omitempty"`
-	RoleARN     string `json:"role_arn"`
-	ExternalID  string `json:"external_id,omitempty"`
-	Region      string `json:"region,omitempty"`
-	SessionName string `json:"session_name,omitempty"`
+	WorkspaceID           string                    `json:"workspace_id,omitempty"`
+	ProjectID             string                    `json:"project_id,omitempty"`
+	RoleARN               string                    `json:"role_arn"`
+	ExternalID            string                    `json:"external_id,omitempty"`
+	Region                string                    `json:"region,omitempty"`
+	SessionName           string                    `json:"session_name,omitempty"`
+	RequestedCapabilities []awsconnector.Capability `json:"requested_capabilities,omitempty"`
 }
 
 // AWSConnectorPollRequest resolves project scope for the flat connector poll API.
@@ -100,62 +103,70 @@ type AWSConnectorPolicyResponse struct {
 
 // AWSConnectionValidationRequest is passed to the provider validator.
 type AWSConnectionValidationRequest struct {
-	RoleARN     string
-	ExternalID  string
-	Region      string
-	SessionName string
+	RoleARN               string
+	ExternalID            string
+	Region                string
+	SessionName           string
+	RequestedCapabilities []awsconnector.Capability
 }
 
 // AWSConnectionDiagnostic explains one validation outcome and how to remediate it.
 type AWSConnectionDiagnostic struct {
-	Code        string `json:"code"`
-	Message     string `json:"message"`
-	Remediation string `json:"remediation,omitempty"`
+	Code        string                  `json:"code"`
+	Message     string                  `json:"message"`
+	Remediation string                  `json:"remediation,omitempty"`
+	Capability  awsconnector.Capability `json:"capability,omitempty"`
 }
 
 // AWSConnectionPermissionCheck captures one connector permission sanity check.
 type AWSConnectionPermissionCheck struct {
-	Name        string `json:"name"`
-	Passed      bool   `json:"passed"`
-	Message     string `json:"message"`
-	Remediation string `json:"remediation,omitempty"`
+	Name        string                  `json:"name"`
+	Passed      bool                    `json:"passed"`
+	Message     string                  `json:"message"`
+	Remediation string                  `json:"remediation,omitempty"`
+	Capability  awsconnector.Capability `json:"capability,omitempty"`
 }
 
 // AWSConnectionValidationResult contains the live AWS metadata and diagnostics.
 type AWSConnectionValidationResult struct {
-	AccountID        string                         `json:"account_id,omitempty"`
-	PrincipalARN     string                         `json:"principal_arn,omitempty"`
-	UserID           string                         `json:"user_id,omitempty"`
-	RoleARN          string                         `json:"role_arn,omitempty"`
-	Region           string                         `json:"region,omitempty"`
-	PermissionChecks []AWSConnectionPermissionCheck `json:"permission_checks"`
-	Diagnostics      []AWSConnectionDiagnostic      `json:"diagnostics"`
+	AccountID             string                         `json:"account_id,omitempty"`
+	PrincipalARN          string                         `json:"principal_arn,omitempty"`
+	UserID                string                         `json:"user_id,omitempty"`
+	RoleARN               string                         `json:"role_arn,omitempty"`
+	Region                string                         `json:"region,omitempty"`
+	PermissionChecks      []AWSConnectionPermissionCheck `json:"permission_checks"`
+	Diagnostics           []AWSConnectionDiagnostic      `json:"diagnostics"`
+	ValidatedCapabilities []awsconnector.Capability      `json:"validated_capabilities"`
 }
 
 // AWSConnectionStatus describes current AWS connector state for one project.
 type AWSConnectionStatus struct {
-	Provider             string                         `json:"provider"`
-	Connected            bool                           `json:"connected"`
-	ConnectorID          string                         `json:"connector_id,omitempty"`
-	DisplayName          string                         `json:"display_name,omitempty"`
-	Status               domain.ConnectorStatus         `json:"status"`
-	HealthStatus         string                         `json:"health_status"`
-	RoleARN              string                         `json:"role_arn,omitempty"`
-	ExternalIDConfigured bool                           `json:"external_id_configured"`
-	AccountID            string                         `json:"account_id,omitempty"`
-	PrincipalARN         string                         `json:"principal_arn,omitempty"`
-	UserID               string                         `json:"user_id,omitempty"`
-	Region               string                         `json:"region,omitempty"`
-	ExternalID           string                         `json:"-"`
-	PermissionChecks     []AWSConnectionPermissionCheck `json:"permission_checks"`
-	Diagnostics          []AWSConnectionDiagnostic      `json:"diagnostics"`
-	RemediationMessage   string                         `json:"remediation_message,omitempty"`
-	LaunchURL            string                         `json:"launch_url,omitempty"`
-	TemplateURL          string                         `json:"template_url,omitempty"`
-	PolicyHash           string                         `json:"policy_hash,omitempty"`
-	CreatedAt            *time.Time                     `json:"created_at,omitempty"`
-	UpdatedAt            *time.Time                     `json:"updated_at,omitempty"`
-	LastValidatedAt      *time.Time                     `json:"last_validated_at,omitempty"`
+	Provider                string                               `json:"provider"`
+	Connected               bool                                 `json:"connected"`
+	ConnectorID             string                               `json:"connector_id,omitempty"`
+	DisplayName             string                               `json:"display_name,omitempty"`
+	Status                  domain.ConnectorStatus               `json:"status"`
+	HealthStatus            string                               `json:"health_status"`
+	RoleARN                 string                               `json:"role_arn,omitempty"`
+	ExternalIDConfigured    bool                                 `json:"external_id_configured"`
+	AccountID               string                               `json:"account_id,omitempty"`
+	PrincipalARN            string                               `json:"principal_arn,omitempty"`
+	UserID                  string                               `json:"user_id,omitempty"`
+	Region                  string                               `json:"region,omitempty"`
+	ExternalID              string                               `json:"-"`
+	PermissionChecks        []AWSConnectionPermissionCheck       `json:"permission_checks"`
+	Diagnostics             []AWSConnectionDiagnostic            `json:"diagnostics"`
+	RequestedCapabilities   []awsconnector.Capability            `json:"requested_capabilities"`
+	ValidatedCapabilities   []awsconnector.Capability            `json:"validated_capabilities"`
+	EffectiveCapabilities   []awsconnector.Capability            `json:"effective_capabilities"`
+	UnavailableCapabilities []awsconnector.CapabilityUnavailable `json:"unavailable_capabilities"`
+	RemediationMessage      string                               `json:"remediation_message,omitempty"`
+	LaunchURL               string                               `json:"launch_url,omitempty"`
+	TemplateURL             string                               `json:"template_url,omitempty"`
+	PolicyHash              string                               `json:"policy_hash,omitempty"`
+	CreatedAt               *time.Time                           `json:"created_at,omitempty"`
+	UpdatedAt               *time.Time                           `json:"updated_at,omitempty"`
+	LastValidatedAt         *time.Time                           `json:"last_validated_at,omitempty"`
 }
 
 func (s *Service) StartAWSConnector(ctx context.Context, request AWSConnectorStartRequest) (AWSConnectorStartResponse, error) {
@@ -199,18 +210,23 @@ func (s *Service) StartAWSConnector(ctx context.Context, request AWSConnectorSta
 	if err != nil {
 		return AWSConnectorStartResponse{}, err
 	}
+	requestedCapabilities, validatedCapabilities, effectiveCapabilities, unavailableCapabilities := s.pendingAWSCapabilityState(request.RequestedCapabilities)
 
 	metadata := map[string]any{
-		"external_id_configured": true,
-		"region":                 region,
-		"role_name":              roleName,
-		"stack_name":             stackName,
-		"template_url":           templateURL,
-		"launch_url":             launchURL,
-		"policy_hash":            policyHash,
-		"permission_checks":      []AWSConnectionPermissionCheck{},
-		"diagnostics":            []AWSConnectionDiagnostic{},
-		"last_started_at":        now.Format(time.RFC3339Nano),
+		"external_id_configured":   true,
+		"region":                   region,
+		"role_name":                roleName,
+		"stack_name":               stackName,
+		"template_url":             templateURL,
+		"launch_url":               launchURL,
+		"policy_hash":              policyHash,
+		"permission_checks":        []AWSConnectionPermissionCheck{},
+		"diagnostics":              []AWSConnectionDiagnostic{},
+		"requested_capabilities":   requestedCapabilities,
+		"validated_capabilities":   validatedCapabilities,
+		"effective_capabilities":   effectiveCapabilities,
+		"unavailable_capabilities": unavailableCapabilities,
+		"last_started_at":          now.Format(time.RFC3339Nano),
 	}
 	connector := db.TenancyConnector{
 		TenantID:            scope.TenantID,
@@ -281,13 +297,18 @@ func (s *Service) ValidateAWSConnector(ctx context.Context, connectorID string, 
 	if externalID == "" {
 		externalID = s.awsExternalIDFromStored(ctx, stored)
 	}
+	requestedCapabilities := request.RequestedCapabilities
+	if len(requestedCapabilities) == 0 {
+		requestedCapabilities = awsMetadataRequestedCapabilities(stored.State.Metadata, "requested_capabilities")
+	}
 	return s.UpsertAWSConnection(ctx, project.WorkspaceID, project.ProjectID, AWSConnectionUpsertRequest{
-		ConnectorID: connectorID,
-		DisplayName: stored.Connector.DisplayName,
-		RoleARN:     request.RoleARN,
-		ExternalID:  externalID,
-		Region:      firstNonEmptyAWSValue(strings.TrimSpace(request.Region), awsMetadataString(stored.State.Metadata, "region")),
-		SessionName: request.SessionName,
+		ConnectorID:           connectorID,
+		DisplayName:           stored.Connector.DisplayName,
+		RoleARN:               request.RoleARN,
+		ExternalID:            externalID,
+		Region:                firstNonEmptyAWSValue(strings.TrimSpace(request.Region), awsMetadataString(stored.State.Metadata, "region")),
+		SessionName:           request.SessionName,
+		RequestedCapabilities: requestedCapabilities,
 	})
 }
 
@@ -341,10 +362,11 @@ func (s *Service) UpsertAWSConnection(ctx context.Context, workspaceID string, p
 	}
 
 	validation, err := s.AWSConnectorValidator.ValidateAWSConnection(ctx, AWSConnectionValidationRequest{
-		RoleARN:     normalized.RoleARN,
-		ExternalID:  normalized.ExternalID,
-		Region:      normalized.Region,
-		SessionName: normalized.SessionName,
+		RoleARN:               normalized.RoleARN,
+		ExternalID:            normalized.ExternalID,
+		Region:                normalized.Region,
+		SessionName:           normalized.SessionName,
+		RequestedCapabilities: normalized.RequestedCapabilities,
 	})
 	if err != nil {
 		return AWSConnectionStatus{}, err
@@ -363,21 +385,31 @@ func (s *Service) UpsertAWSConnection(ctx context.Context, workspaceID string, p
 	checks := copyAWSPermissionChecks(validation.PermissionChecks)
 	if connected && len(checks) == 0 {
 		checks = []AWSConnectionPermissionCheck{{
-			Name:    "sts:AssumeRole",
-			Passed:  true,
-			Message: "Role assumption succeeded.",
+			Name:       "sts:AssumeRole",
+			Passed:     true,
+			Message:    "Role assumption succeeded.",
+			Capability: awsconnector.CapabilityDiscovery,
 		}}
 	}
+	requestedCapabilities, validatedCapabilities, effectiveCapabilities, unavailableCapabilities := s.validatedAWSCapabilityState(
+		normalized.RequestedCapabilities,
+		connected,
+		validation.ValidatedCapabilities,
+	)
 	metadata := map[string]any{
-		"role_arn":               normalized.RoleARN,
-		"external_id_configured": normalized.ExternalID != "",
-		"account_id":             strings.TrimSpace(validation.AccountID),
-		"principal_arn":          strings.TrimSpace(validation.PrincipalARN),
-		"user_id":                strings.TrimSpace(validation.UserID),
-		"region":                 firstNonEmptyAWSValue(strings.TrimSpace(validation.Region), normalized.Region),
-		"permission_checks":      checks,
-		"diagnostics":            copyAWSDiagnostics(validation.Diagnostics),
-		"last_validated_at":      now.Format(time.RFC3339Nano),
+		"role_arn":                 normalized.RoleARN,
+		"external_id_configured":   normalized.ExternalID != "",
+		"account_id":               strings.TrimSpace(validation.AccountID),
+		"principal_arn":            strings.TrimSpace(validation.PrincipalARN),
+		"user_id":                  strings.TrimSpace(validation.UserID),
+		"region":                   firstNonEmptyAWSValue(strings.TrimSpace(validation.Region), normalized.Region),
+		"permission_checks":        checks,
+		"diagnostics":              copyAWSDiagnostics(validation.Diagnostics),
+		"requested_capabilities":   requestedCapabilities,
+		"validated_capabilities":   validatedCapabilities,
+		"effective_capabilities":   effectiveCapabilities,
+		"unavailable_capabilities": unavailableCapabilities,
+		"last_validated_at":        now.Format(time.RFC3339Nano),
 	}
 	state := db.TenancyConnectorState{
 		TenantID:     scope.TenantID,
@@ -440,12 +472,16 @@ func (s *Service) GetAWSConnection(ctx context.Context, workspaceID string, proj
 	}
 	if len(items) == 0 {
 		return AWSConnectionStatus{
-			Provider:         "aws",
-			Connected:        false,
-			Status:           domain.ConnectorStatusPending,
-			HealthStatus:     "unknown",
-			PermissionChecks: []AWSConnectionPermissionCheck{},
-			Diagnostics:      []AWSConnectionDiagnostic{},
+			Provider:                "aws",
+			Connected:               false,
+			Status:                  domain.ConnectorStatusPending,
+			HealthStatus:            "unknown",
+			PermissionChecks:        []AWSConnectionPermissionCheck{},
+			Diagnostics:             []AWSConnectionDiagnostic{},
+			RequestedCapabilities:   awsconnector.DefaultCapabilities(),
+			ValidatedCapabilities:   awsconnector.EmptyCapabilities(),
+			EffectiveCapabilities:   awsconnector.EmptyCapabilities(),
+			UnavailableCapabilities: awsconnector.CopyUnavailableCapabilities(nil),
 		}, nil
 	}
 	return s.awsConnectionStatusFromStored(ctx, items[0]), nil
@@ -466,6 +502,7 @@ func normalizeAWSConnectionRequest(request AWSConnectionUpsertRequest) (AWSConne
 	if normalized.SessionName == "" {
 		normalized.SessionName = "identrail-connector-validation"
 	}
+	normalized.RequestedCapabilities = awsconnector.NormalizeCapabilities(request.RequestedCapabilities)
 	normalized.ConnectorID = strings.TrimSpace(request.ConnectorID)
 	if normalized.ConnectorID == "" {
 		normalized.ConnectorID = "aws-" + accountIDFromRoleARN(normalized.RoleARN)
@@ -497,28 +534,42 @@ func awsConnectionStatusFromStored(stored db.TenancyConnectorWithState) AWSConne
 		observed := stored.State.ObservedAt
 		validatedAt = &observed
 	}
+	connected := stored.Connector.Status == domain.ConnectorStatusActive && stored.State.HealthStatus == "healthy"
+	requestedCapabilities := awsMetadataRequestedCapabilities(metadata, "requested_capabilities")
+	validatedCapabilities := awsMetadataCapabilities(metadata, "validated_capabilities")
+	effectiveCapabilities := awsMetadataCapabilities(metadata, "effective_capabilities")
+	if connected && len(validatedCapabilities) == 0 {
+		validatedCapabilities = awsconnector.DefaultCapabilities()
+	}
+	if connected && len(effectiveCapabilities) == 0 {
+		effectiveCapabilities = awsconnector.DefaultCapabilities()
+	}
 	status := AWSConnectionStatus{
-		Provider:             "aws",
-		Connected:            stored.Connector.Status == domain.ConnectorStatusActive && stored.State.HealthStatus == "healthy",
-		ConnectorID:          stored.Connector.ConnectorID,
-		DisplayName:          stored.Connector.DisplayName,
-		Status:               stored.Connector.Status,
-		HealthStatus:         firstNonEmptyAWSValue(stored.State.HealthStatus, "unknown"),
-		RoleARN:              awsMetadataString(metadata, "role_arn"),
-		ExternalID:           awsMetadataString(metadata, "external_id"),
-		ExternalIDConfigured: awsMetadataBool(metadata, "external_id_configured"),
-		AccountID:            awsMetadataString(metadata, "account_id"),
-		PrincipalARN:         awsMetadataString(metadata, "principal_arn"),
-		UserID:               awsMetadataString(metadata, "user_id"),
-		Region:               awsMetadataString(metadata, "region"),
-		PermissionChecks:     awsMetadataPermissionChecks(metadata, "permission_checks"),
-		Diagnostics:          awsMetadataDiagnostics(metadata, "diagnostics"),
-		LaunchURL:            awsMetadataString(metadata, "launch_url"),
-		TemplateURL:          awsMetadataString(metadata, "template_url"),
-		PolicyHash:           awsMetadataString(metadata, "policy_hash"),
-		CreatedAt:            &createdAt,
-		UpdatedAt:            &updatedAt,
-		LastValidatedAt:      validatedAt,
+		Provider:                "aws",
+		Connected:               connected,
+		ConnectorID:             stored.Connector.ConnectorID,
+		DisplayName:             stored.Connector.DisplayName,
+		Status:                  stored.Connector.Status,
+		HealthStatus:            firstNonEmptyAWSValue(stored.State.HealthStatus, "unknown"),
+		RoleARN:                 awsMetadataString(metadata, "role_arn"),
+		ExternalID:              awsMetadataString(metadata, "external_id"),
+		ExternalIDConfigured:    awsMetadataBool(metadata, "external_id_configured"),
+		AccountID:               awsMetadataString(metadata, "account_id"),
+		PrincipalARN:            awsMetadataString(metadata, "principal_arn"),
+		UserID:                  awsMetadataString(metadata, "user_id"),
+		Region:                  awsMetadataString(metadata, "region"),
+		PermissionChecks:        awsMetadataPermissionChecks(metadata, "permission_checks"),
+		Diagnostics:             awsMetadataDiagnostics(metadata, "diagnostics"),
+		RequestedCapabilities:   requestedCapabilities,
+		ValidatedCapabilities:   validatedCapabilities,
+		EffectiveCapabilities:   effectiveCapabilities,
+		UnavailableCapabilities: awsMetadataUnavailableCapabilities(metadata, "unavailable_capabilities"),
+		LaunchURL:               awsMetadataString(metadata, "launch_url"),
+		TemplateURL:             awsMetadataString(metadata, "template_url"),
+		PolicyHash:              awsMetadataString(metadata, "policy_hash"),
+		CreatedAt:               &createdAt,
+		UpdatedAt:               &updatedAt,
+		LastValidatedAt:         validatedAt,
 	}
 	status.RemediationMessage = firstAWSRemediation(status.Diagnostics, status.PermissionChecks)
 	return status
@@ -658,6 +709,120 @@ func copyAWSDiagnostics(diagnostics []AWSConnectionDiagnostic) []AWSConnectionDi
 	return copied
 }
 
+func (s *Service) pendingAWSCapabilityState(requested []awsconnector.Capability) ([]awsconnector.Capability, []awsconnector.Capability, []awsconnector.Capability, []awsconnector.CapabilityUnavailable) {
+	normalized := awsconnector.NormalizeCapabilities(requested)
+	unavailable := make([]awsconnector.CapabilityUnavailable, 0)
+	for _, capability := range normalized {
+		if awsconnector.IsDiscoveryCapability(capability) {
+			continue
+		}
+		if allowed, unavailableCapability := s.awsCapabilityAvailability(capability); !allowed {
+			unavailable = append(unavailable, unavailableCapability)
+		}
+	}
+	return normalized, awsconnector.EmptyCapabilities(), awsconnector.EmptyCapabilities(), awsconnector.CopyUnavailableCapabilities(unavailable)
+}
+
+func (s *Service) validatedAWSCapabilityState(requested []awsconnector.Capability, connected bool, validated []awsconnector.Capability) ([]awsconnector.Capability, []awsconnector.Capability, []awsconnector.Capability, []awsconnector.CapabilityUnavailable) {
+	normalizedRequested := awsconnector.NormalizeCapabilities(requested)
+	normalizedValidated := awsconnector.EmptyCapabilities()
+	if connected {
+		normalizedValidated = awsconnector.NormalizeCapabilities(validated)
+	}
+	effective := make([]awsconnector.Capability, 0, len(normalizedRequested))
+	unavailable := make([]awsconnector.CapabilityUnavailable, 0)
+
+	for _, capability := range normalizedRequested {
+		if !connected {
+			unavailable = append(unavailable, awsconnector.CapabilityUnavailable{
+				Capability:  capability,
+				Reason:      "AWS connector validation must pass before this capability can become effective.",
+				Gate:        "aws_connector_validation",
+				Remediation: "Resolve the AWS connector diagnostics and validate the role again.",
+			})
+			continue
+		}
+		if allowed, unavailableCapability := s.awsCapabilityAvailability(capability); !allowed {
+			unavailable = append(unavailable, unavailableCapability)
+			continue
+		}
+		if !awsCapabilityInSet(normalizedValidated, capability) {
+			unavailable = append(unavailable, awsconnector.CapabilityUnavailable{
+				Capability:  capability,
+				Reason:      "The live AWS validation flow did not validate this capability.",
+				Gate:        "aws_connector_validation",
+				Remediation: "Re-run connector validation after enabling the capability-specific validator.",
+			})
+			continue
+		}
+		effective = append(effective, capability)
+	}
+
+	normalizedEffective := awsconnector.EmptyCapabilities()
+	if len(effective) > 0 {
+		normalizedEffective = awsconnector.NormalizeCapabilities(effective)
+	}
+	return normalizedRequested, normalizedValidated, normalizedEffective, awsconnector.CopyUnavailableCapabilities(unavailable)
+}
+
+func awsCapabilityInSet(values []awsconnector.Capability, capability awsconnector.Capability) bool {
+	for _, value := range values {
+		if value == capability {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Service) awsCapabilityAvailability(capability awsconnector.Capability) (bool, awsconnector.CapabilityUnavailable) {
+	switch capability {
+	case awsconnector.CapabilityDiscovery:
+		return true, awsconnector.CapabilityUnavailable{}
+	case awsconnector.CapabilityRuntimeEvidence:
+		return s != nil && s.AWSRuntimeEvidenceEnabled, awsconnector.CapabilityUnavailable{
+			Capability:  capability,
+			Reason:      "Runtime evidence collection is not enabled for this deployment.",
+			Gate:        "aws_runtime_evidence_capability",
+			Remediation: "Enable the runtime evidence capability gate and deploy an IAM policy that grants the additional read actions.",
+		}
+	case awsconnector.CapabilityRemediationPlan:
+		return s != nil && s.AWSRemediationPlanEnabled, awsconnector.CapabilityUnavailable{
+			Capability:  capability,
+			Reason:      "Remediation planning is not enabled for this deployment.",
+			Gate:        "aws_remediation_plan_capability",
+			Remediation: "Enable the remediation planning gate before requesting remediation-plan capability.",
+		}
+	case awsconnector.CapabilityApprovedRemediation:
+		return s != nil && s.AWSApprovedRemediationEnabled, awsconnector.CapabilityUnavailable{
+			Capability:  capability,
+			Reason:      "Approved remediation is write-capable and is disabled by default.",
+			Gate:        "aws_approved_remediation_capability",
+			Remediation: "Enable the approved remediation gate only after an explicit operator approval workflow and write-capable IAM policy are configured.",
+		}
+	case awsconnector.CapabilityAuthorizationAdvisory:
+		return s != nil && s.AWSAuthzAdvisoryEnabled, awsconnector.CapabilityUnavailable{
+			Capability:  capability,
+			Reason:      "Authorization advisory is not enabled for this deployment.",
+			Gate:        "aws_authorization_advisory_capability",
+			Remediation: "Enable the authorization advisory gate before requesting advisory decisions.",
+		}
+	case awsconnector.CapabilityAuthorizationEnforcement:
+		return s != nil && s.AWSAuthzEnforcementEnabled, awsconnector.CapabilityUnavailable{
+			Capability:  capability,
+			Reason:      "Authorization enforcement is write-capable and is disabled by default.",
+			Gate:        "aws_authorization_enforcement_capability",
+			Remediation: "Enable the enforcement gate only after private tenancy, approvals, and write-capable IAM policy controls are configured.",
+		}
+	default:
+		return false, awsconnector.CapabilityUnavailable{
+			Capability:  capability,
+			Reason:      "The requested AWS connector capability is not recognized.",
+			Gate:        "aws_connector_capability",
+			Remediation: "Request one of the documented AWS connector capabilities.",
+		}
+	}
+}
+
 func firstNonEmptyAWSValue(values ...string) string {
 	for _, value := range values {
 		if value != "" {
@@ -738,6 +903,47 @@ func awsMetadataDiagnostics(metadata map[string]any, key string) []AWSConnection
 		return []AWSConnectionDiagnostic{}
 	}
 	return copyAWSDiagnostics(diagnostics)
+}
+
+func awsMetadataCapabilities(metadata map[string]any, key string) []awsconnector.Capability {
+	if metadata == nil || metadata[key] == nil {
+		return awsconnector.EmptyCapabilities()
+	}
+	var capabilities []awsconnector.Capability
+	payload, err := json.Marshal(metadata[key])
+	if err != nil {
+		return awsconnector.EmptyCapabilities()
+	}
+	if err := json.Unmarshal(payload, &capabilities); err != nil {
+		return awsconnector.EmptyCapabilities()
+	}
+	if len(capabilities) == 0 {
+		return awsconnector.EmptyCapabilities()
+	}
+	return awsconnector.NormalizeCapabilities(capabilities)
+}
+
+func awsMetadataRequestedCapabilities(metadata map[string]any, key string) []awsconnector.Capability {
+	capabilities := awsMetadataCapabilities(metadata, key)
+	if len(capabilities) == 0 {
+		return awsconnector.DefaultCapabilities()
+	}
+	return capabilities
+}
+
+func awsMetadataUnavailableCapabilities(metadata map[string]any, key string) []awsconnector.CapabilityUnavailable {
+	if metadata == nil || metadata[key] == nil {
+		return awsconnector.CopyUnavailableCapabilities(nil)
+	}
+	var unavailable []awsconnector.CapabilityUnavailable
+	payload, err := json.Marshal(metadata[key])
+	if err != nil {
+		return awsconnector.CopyUnavailableCapabilities(nil)
+	}
+	if err := json.Unmarshal(payload, &unavailable); err != nil {
+		return awsconnector.CopyUnavailableCapabilities(nil)
+	}
+	return awsconnector.CopyUnavailableCapabilities(unavailable)
 }
 
 func accountIDFromRoleARN(roleARN string) string {

--- a/internal/api/aws_connect_test.go
+++ b/internal/api/aws_connect_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	awsconnector "github.com/identrail/identrail/internal/connectors/aws"
 	"github.com/identrail/identrail/internal/db"
 	"github.com/identrail/identrail/internal/domain"
 	"github.com/identrail/identrail/internal/secretstore"
@@ -69,10 +70,64 @@ func TestRouterAWSConnectionOnboardingActive(t *testing.T) {
 	if validator.seen.ExternalID != "tenant-external-id" || validator.seen.Region != "us-west-2" {
 		t.Fatalf("validator did not receive normalized request: %+v", validator.seen)
 	}
+	if len(body.Connection.RequestedCapabilities) != 1 || body.Connection.RequestedCapabilities[0] != awsconnector.CapabilityDiscovery {
+		t.Fatalf("expected discovery requested by default, got %+v", body.Connection.RequestedCapabilities)
+	}
+	if len(body.Connection.EffectiveCapabilities) != 1 || body.Connection.EffectiveCapabilities[0] != awsconnector.CapabilityDiscovery {
+		t.Fatalf("expected discovery effective by default, got %+v", body.Connection.EffectiveCapabilities)
+	}
+	if len(body.Connection.UnavailableCapabilities) != 0 {
+		t.Fatalf("expected no unavailable capabilities for default discovery, got %+v", body.Connection.UnavailableCapabilities)
+	}
 
 	statusResp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/workspaces/workspace-a/projects/project-1/aws/connection", "")
 	if statusResp.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d body=%s", statusResp.Code, statusResp.Body.String())
+	}
+}
+
+func TestRouterAWSConnectionReportsUnavailableRequestedCapability(t *testing.T) {
+	validator := &fakeAWSConnectorValidator{
+		result: AWSConnectionValidationResult{
+			AccountID:             "123456789012",
+			PrincipalARN:          "arn:aws:sts::123456789012:assumed-role/IdentrailReadOnly/identrail-connector-validation",
+			UserID:                "AROATEST:identrail-connector-validation",
+			Region:                "us-west-2",
+			ValidatedCapabilities: awsconnector.DefaultCapabilities(),
+			PermissionChecks: []AWSConnectionPermissionCheck{
+				{Name: "sts:AssumeRole", Passed: true, Message: "Role assumption succeeded.", Capability: awsconnector.CapabilityDiscovery},
+				{Name: "iam:ReadRolePolicies", Passed: true, Message: "IAM read is available.", Capability: awsconnector.CapabilityDiscovery},
+			},
+		},
+	}
+	r := newAWSConnectionTestRouter(t, validator)
+
+	resp := doAWSConnectionAPI(t, r, http.MethodPost, "/v1/workspaces/workspace-a/projects/project-1/aws/connection", `{
+		"connector_id":"aws-prod",
+		"display_name":"Production AWS",
+		"role_arn":"arn:aws:iam::123456789012:role/IdentrailReadOnly",
+		"region":"us-west-2",
+		"requested_capabilities":["discovery","approved_remediation"]
+	}`)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected active connection 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+
+	var body struct {
+		Connection AWSConnectionStatus `json:"connection"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(body.Connection.EffectiveCapabilities) != 1 || body.Connection.EffectiveCapabilities[0] != awsconnector.CapabilityDiscovery {
+		t.Fatalf("expected only discovery effective, got %+v", body.Connection.EffectiveCapabilities)
+	}
+	if len(body.Connection.UnavailableCapabilities) != 1 {
+		t.Fatalf("expected approved remediation unavailable, got %+v", body.Connection.UnavailableCapabilities)
+	}
+	unavailable := body.Connection.UnavailableCapabilities[0]
+	if unavailable.Capability != awsconnector.CapabilityApprovedRemediation || unavailable.Gate != "aws_approved_remediation_capability" {
+		t.Fatalf("expected approved remediation gate, got %+v", unavailable)
 	}
 }
 
@@ -279,6 +334,21 @@ func TestRouterAWSConnectorCloudFormationFlow(t *testing.T) {
 	}
 	if startBody.Connection.Status != domain.ConnectorStatusPending || !startBody.Connection.ExternalIDConfigured {
 		t.Fatalf("expected pending connector with external id configured, got %+v", startBody.Connection)
+	}
+	if len(startBody.Connection.RequestedCapabilities) != 1 || startBody.Connection.RequestedCapabilities[0] != awsconnector.CapabilityDiscovery {
+		t.Fatalf("expected CloudFormation flow to default to discovery, got %+v", startBody.Connection.RequestedCapabilities)
+	}
+	previewHasGatedTier := false
+	for _, item := range startBody.PermissionPreview {
+		if !item.Included {
+			previewHasGatedTier = true
+		}
+		if item.Included && item.Capability != awsconnector.CapabilityDiscovery {
+			t.Fatalf("read-only preview included non-discovery capability: %+v", item)
+		}
+	}
+	if !previewHasGatedTier {
+		t.Fatalf("expected preview to describe gated future capability tiers, got %+v", startBody.PermissionPreview)
 	}
 
 	pollResp := doAWSConnectionAPI(t, r, http.MethodGet, "/v1/connectors/aws/"+startBody.ConnectorID+"/poll?workspace_id=workspace-a&project_id=project-1", "")

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -165,6 +165,11 @@ type Service struct {
 	AWSConnectorValidator              AWSConnectorValidator
 	AWSScannerFactory                  AWSScannerFactory
 	AWSCloudFormationTemplateURL       string
+	AWSRuntimeEvidenceEnabled          bool
+	AWSRemediationPlanEnabled          bool
+	AWSApprovedRemediationEnabled      bool
+	AWSAuthzAdvisoryEnabled            bool
+	AWSAuthzEnforcementEnabled         bool
 	AWSAccountID                       string
 	WorkflowRouter                     *workflow.Router
 	GitHubAppID                        int64

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,6 +91,11 @@ type Config struct {
 	AWSProfile                   string
 	AWSCloudFormationTemplateURL string
 	AWSAccountID                 string
+	AWSRuntimeEvidence           bool
+	AWSRemediationPlan           bool
+	AWSApprovedRemediation       bool
+	AWSAuthorizationAdvisory     bool
+	AWSAuthorizationEnforcement  bool
 	AWSFixturePath               []string
 	KubernetesFixturePath        []string
 	KubernetesSource             string
@@ -243,6 +248,11 @@ func Load() Config {
 		AWSProfile:                   getEnv("IDENTRAIL_AWS_PROFILE", ""),
 		AWSCloudFormationTemplateURL: getEnv("IDENTRAIL_AWS_CFN_TEMPLATE_URL", ""),
 		AWSAccountID:                 getEnv("IDENTRAIL_AWS_ACCOUNT_ID", ""),
+		AWSRuntimeEvidence:           boolEnv("IDENTRAIL_AWS_CAPABILITY_RUNTIME_EVIDENCE", false),
+		AWSRemediationPlan:           boolEnv("IDENTRAIL_AWS_CAPABILITY_REMEDIATION_PLAN", false),
+		AWSApprovedRemediation:       boolEnv("IDENTRAIL_AWS_CAPABILITY_APPROVED_REMEDIATION", false),
+		AWSAuthorizationAdvisory:     boolEnv("IDENTRAIL_AWS_CAPABILITY_AUTHORIZATION_ADVISORY", false),
+		AWSAuthorizationEnforcement:  boolEnv("IDENTRAIL_AWS_CAPABILITY_AUTHORIZATION_ENFORCEMENT", false),
 		AWSFixturePath:               parseCommaSeparated(getEnv("IDENTRAIL_AWS_FIXTURES", defaultAWSFixtures)),
 		KubernetesFixturePath:        parseCommaSeparated(getEnv("IDENTRAIL_K8S_FIXTURES", defaultK8sFixtures)),
 		KubernetesSource:             strings.ToLower(getEnv("IDENTRAIL_K8S_SOURCE", defaultK8sSource)),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -381,6 +381,11 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("IDENTRAIL_AWS_PROFILE", "engineering")
 	t.Setenv("IDENTRAIL_AWS_CFN_TEMPLATE_URL", "https://cdn.identrail.example/connectors/aws/identrail-readonly.yaml")
 	t.Setenv("IDENTRAIL_AWS_ACCOUNT_ID", "123456789012")
+	t.Setenv("IDENTRAIL_AWS_CAPABILITY_RUNTIME_EVIDENCE", "true")
+	t.Setenv("IDENTRAIL_AWS_CAPABILITY_REMEDIATION_PLAN", "true")
+	t.Setenv("IDENTRAIL_AWS_CAPABILITY_APPROVED_REMEDIATION", "true")
+	t.Setenv("IDENTRAIL_AWS_CAPABILITY_AUTHORIZATION_ADVISORY", "true")
+	t.Setenv("IDENTRAIL_AWS_CAPABILITY_AUTHORIZATION_ENFORCEMENT", "true")
 	t.Setenv("IDENTRAIL_AWS_FIXTURES", "fixtures/a.json,fixtures/b.json")
 	t.Setenv("IDENTRAIL_K8S_FIXTURES", "fixtures/sa.json,fixtures/rb.json")
 	t.Setenv("IDENTRAIL_K8S_SOURCE", "kubectl")
@@ -499,6 +504,9 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.AWSAccountID != "123456789012" {
 		t.Fatalf("unexpected aws account id: %q", cfg.AWSAccountID)
+	}
+	if !cfg.AWSRuntimeEvidence || !cfg.AWSRemediationPlan || !cfg.AWSApprovedRemediation || !cfg.AWSAuthorizationAdvisory || !cfg.AWSAuthorizationEnforcement {
+		t.Fatalf("expected all aws capability gates enabled, got runtime=%v remediation_plan=%v approved_remediation=%v authorization_advisory=%v authorization_enforcement=%v", cfg.AWSRuntimeEvidence, cfg.AWSRemediationPlan, cfg.AWSApprovedRemediation, cfg.AWSAuthorizationAdvisory, cfg.AWSAuthorizationEnforcement)
 	}
 	if len(cfg.AWSFixturePath) != 2 || cfg.AWSFixturePath[0] != "fixtures/a.json" || cfg.AWSFixturePath[1] != "fixtures/b.json" {
 		t.Fatalf("unexpected fixture paths: %+v", cfg.AWSFixturePath)

--- a/internal/connectors/aws/capabilities.go
+++ b/internal/connectors/aws/capabilities.go
@@ -1,0 +1,102 @@
+package aws
+
+import "strings"
+
+// Capability describes the level of AWS connector behavior a workspace is
+// requesting. Discovery is the safe default; higher tiers stay gated until a
+// deployment explicitly enables the workflow and required IAM policy surface.
+type Capability string
+
+const (
+	CapabilityDiscovery                Capability = "discovery"
+	CapabilityRuntimeEvidence          Capability = "runtime_evidence"
+	CapabilityRemediationPlan          Capability = "remediation_plan"
+	CapabilityApprovedRemediation      Capability = "approved_remediation"
+	CapabilityAuthorizationAdvisory    Capability = "authorization_advisory"
+	CapabilityAuthorizationEnforcement Capability = "authorization_enforcement"
+)
+
+var capabilityOrder = []Capability{
+	CapabilityDiscovery,
+	CapabilityRuntimeEvidence,
+	CapabilityRemediationPlan,
+	CapabilityApprovedRemediation,
+	CapabilityAuthorizationAdvisory,
+	CapabilityAuthorizationEnforcement,
+}
+
+var knownCapabilities = map[Capability]struct{}{
+	CapabilityDiscovery:                {},
+	CapabilityRuntimeEvidence:          {},
+	CapabilityRemediationPlan:          {},
+	CapabilityApprovedRemediation:      {},
+	CapabilityAuthorizationAdvisory:    {},
+	CapabilityAuthorizationEnforcement: {},
+}
+
+// CapabilityUnavailable records a requested connector capability that cannot be
+// made effective in the current deployment or validation state.
+type CapabilityUnavailable struct {
+	Capability  Capability `json:"capability"`
+	Reason      string     `json:"reason"`
+	Gate        string     `json:"gate,omitempty"`
+	Remediation string     `json:"remediation,omitempty"`
+}
+
+// DefaultCapabilities returns the read-only capability set every AWS connector
+// receives unless the caller requests a narrower or broader future mode.
+func DefaultCapabilities() []Capability {
+	return []Capability{CapabilityDiscovery}
+}
+
+// NormalizeCapabilities removes unknown entries, de-duplicates known entries,
+// and returns capabilities in stable product order. An empty request falls back
+// to discovery so legacy clients stay read-only by default.
+func NormalizeCapabilities(values []Capability) []Capability {
+	if len(values) == 0 {
+		return DefaultCapabilities()
+	}
+
+	seen := map[Capability]struct{}{}
+	for _, value := range values {
+		capability := Capability(strings.ToLower(strings.TrimSpace(string(value))))
+		if _, ok := knownCapabilities[capability]; !ok {
+			continue
+		}
+		seen[capability] = struct{}{}
+	}
+	if len(seen) == 0 {
+		return DefaultCapabilities()
+	}
+
+	normalized := make([]Capability, 0, len(seen))
+	for _, capability := range capabilityOrder {
+		if _, ok := seen[capability]; ok {
+			normalized = append(normalized, capability)
+		}
+	}
+	return normalized
+}
+
+// EmptyCapabilities returns a non-nil empty capability slice for metadata and
+// API responses where defaulting to discovery would be misleading.
+func EmptyCapabilities() []Capability {
+	return []Capability{}
+}
+
+// CopyUnavailableCapabilities returns a non-nil defensive copy for status
+// responses.
+func CopyUnavailableCapabilities(values []CapabilityUnavailable) []CapabilityUnavailable {
+	if len(values) == 0 {
+		return []CapabilityUnavailable{}
+	}
+	copied := make([]CapabilityUnavailable, len(values))
+	copy(copied, values)
+	return copied
+}
+
+// IsDiscoveryCapability reports whether the capability is covered by the
+// current read-only CloudFormation policy and validation flow.
+func IsDiscoveryCapability(capability Capability) bool {
+	return capability == CapabilityDiscovery
+}

--- a/internal/connectors/aws/iam_policy.go
+++ b/internal/connectors/aws/iam_policy.go
@@ -69,10 +69,14 @@ const readOnlyPolicyJSON = `{
 
 // PermissionPreviewItem explains one AWS permission family before launch.
 type PermissionPreviewItem struct {
-	Service   string   `json:"service"`
-	Actions   []string `json:"actions"`
-	Resources []string `json:"resources"`
-	Reason    string   `json:"reason"`
+	Service    string     `json:"service"`
+	Actions    []string   `json:"actions"`
+	Resources  []string   `json:"resources"`
+	Reason     string     `json:"reason"`
+	Capability Capability `json:"capability"`
+	Tier       string     `json:"tier"`
+	Included   bool       `json:"included"`
+	Gate       string     `json:"gate,omitempty"`
 }
 
 // ReadOnlyPolicyDocument returns the validated collector policy JSON.
@@ -99,13 +103,19 @@ func ReadOnlyPolicyHash() (string, error) {
 func PermissionPreview() []PermissionPreviewItem {
 	return []PermissionPreviewItem{
 		{
-			Service:   "STS",
-			Actions:   []string{"sts:GetCallerIdentity"},
-			Resources: []string{"*"},
-			Reason:    "Confirms Identrail is using the expected assumed role during validation and recurring scans.",
+			Service:    "STS",
+			Actions:    []string{"sts:GetCallerIdentity"},
+			Resources:  []string{"*"},
+			Reason:     "Confirms Identrail is using the expected assumed role during validation and recurring scans.",
+			Capability: CapabilityDiscovery,
+			Tier:       "read_only_discovery",
+			Included:   true,
 		},
 		{
-			Service: "IAM",
+			Service:    "IAM",
+			Capability: CapabilityDiscovery,
+			Tier:       "read_only_discovery",
+			Included:   true,
 			Actions: []string{
 				"iam:GetAccountSummary",
 				"iam:ListAccountAliases",
@@ -122,22 +132,90 @@ func PermissionPreview() []PermissionPreviewItem {
 			Reason:    "Reads role trust policies, attached policy documents, and effective permissions for machine identity graph analysis.",
 		},
 		{
-			Service:   "EC2",
-			Actions:   []string{"ec2:DescribeInstances", "ec2:DescribeIamInstanceProfileAssociations", "ec2:DescribeRegions"},
-			Resources: []string{"*"},
-			Reason:    "Maps compute workloads back to the IAM roles and instance profiles they can use.",
+			Service:    "EC2",
+			Actions:    []string{"ec2:DescribeInstances", "ec2:DescribeIamInstanceProfileAssociations", "ec2:DescribeRegions"},
+			Resources:  []string{"*"},
+			Reason:     "Maps compute workloads back to the IAM roles and instance profiles they can use.",
+			Capability: CapabilityDiscovery,
+			Tier:       "read_only_discovery",
+			Included:   true,
 		},
 		{
-			Service:   "S3",
-			Actions:   []string{"s3:GetBucketAcl", "s3:GetBucketPolicy", "s3:GetBucketPublicAccessBlock", "s3:ListAllMyBuckets"},
-			Resources: []string{"*"},
-			Reason:    "Checks bucket access policies that can expose or constrain machine identities.",
+			Service:    "S3",
+			Actions:    []string{"s3:GetBucketAcl", "s3:GetBucketPolicy", "s3:GetBucketPublicAccessBlock", "s3:ListAllMyBuckets"},
+			Resources:  []string{"*"},
+			Reason:     "Checks bucket access policies that can expose or constrain machine identities.",
+			Capability: CapabilityDiscovery,
+			Tier:       "read_only_discovery",
+			Included:   true,
 		},
 		{
-			Service:   "KMS",
-			Actions:   []string{"kms:DescribeKey", "kms:GetKeyPolicy", "kms:ListKeys"},
-			Resources: []string{"*"},
-			Reason:    "Reads key policies that can grant sensitive machine identities decrypt or administration paths.",
+			Service:    "KMS",
+			Actions:    []string{"kms:DescribeKey", "kms:GetKeyPolicy", "kms:ListKeys"},
+			Resources:  []string{"*"},
+			Reason:     "Reads key policies that can grant sensitive machine identities decrypt or administration paths.",
+			Capability: CapabilityDiscovery,
+			Tier:       "read_only_discovery",
+			Included:   true,
+		},
+		{
+			Service:    "CloudTrail",
+			Actions:    []string{"cloudtrail:LookupEvents"},
+			Resources:  []string{"*"},
+			Reason:     "Runtime evidence is intentionally gated and is not granted by the read-only discovery stack.",
+			Capability: CapabilityRuntimeEvidence,
+			Tier:       "runtime_evidence",
+			Included:   false,
+			Gate:       "aws_runtime_evidence_capability",
+		},
+		{
+			Service:    "Access Analyzer",
+			Actions:    []string{"access-analyzer:ValidatePolicy"},
+			Resources:  []string{"*"},
+			Reason:     "Remediation planning remains advisory-only until the deployment enables the planning workflow.",
+			Capability: CapabilityRemediationPlan,
+			Tier:       "remediation_plan",
+			Included:   false,
+			Gate:       "aws_remediation_plan_capability",
+		},
+		{
+			Service: "IAM",
+			Actions: []string{
+				"iam:DeleteRolePolicy",
+				"iam:DetachRolePolicy",
+				"iam:PutRolePolicy",
+				"iam:UpdateAssumeRolePolicy",
+			},
+			Resources:  []string{"*"},
+			Reason:     "Approved remediation is write-capable and must be explicitly enabled outside the read-only stack.",
+			Capability: CapabilityApprovedRemediation,
+			Tier:       "approved_remediation",
+			Included:   false,
+			Gate:       "aws_approved_remediation_capability",
+		},
+		{
+			Service:    "IAM",
+			Actions:    []string{"iam:SimulatePrincipalPolicy"},
+			Resources:  []string{"*"},
+			Reason:     "Authorization advisory is kept behind its own product gate even when discovery can read IAM policy state.",
+			Capability: CapabilityAuthorizationAdvisory,
+			Tier:       "authorization_advisory",
+			Included:   false,
+			Gate:       "aws_authorization_advisory_capability",
+		},
+		{
+			Service: "Organizations",
+			Actions: []string{
+				"organizations:AttachPolicy",
+				"organizations:DetachPolicy",
+				"organizations:UpdatePolicy",
+			},
+			Resources:  []string{"*"},
+			Reason:     "Authorization enforcement is a future write-capable mode and is never enabled by the read-only stack.",
+			Capability: CapabilityAuthorizationEnforcement,
+			Tier:       "authorization_enforcement",
+			Included:   false,
+			Gate:       "aws_authorization_enforcement_capability",
 		},
 	}
 }

--- a/internal/providers/aws/connector_validation.go
+++ b/internal/providers/aws/connector_validation.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/smithy-go"
 	api "github.com/identrail/identrail/internal/api"
+	awsconnector "github.com/identrail/identrail/internal/connectors/aws"
 )
 
 // ConnectionValidator validates AWS connector setup with read-only AWS calls.
@@ -78,9 +79,10 @@ func (v *ConnectionValidator) ValidateAWSConnection(ctx context.Context, request
 		RoleARN: strings.TrimSpace(request.RoleARN),
 		Region:  region,
 		PermissionChecks: []api.AWSConnectionPermissionCheck{{
-			Name:    "sts:AssumeRole",
-			Passed:  false,
-			Message: "Role assumption has not completed.",
+			Name:       "sts:AssumeRole",
+			Passed:     false,
+			Message:    "Role assumption has not completed.",
+			Capability: awsconnector.CapabilityDiscovery,
 		}},
 		Diagnostics: []api.AWSConnectionDiagnostic{},
 	}
@@ -104,6 +106,7 @@ func (v *ConnectionValidator) ValidateAWSConnection(ctx context.Context, request
 			Code:        classifyAWSError(err, "aws_assume_role_failed"),
 			Message:     "Unable to assume the AWS connector role.",
 			Remediation: result.PermissionChecks[0].Remediation,
+			Capability:  awsconnector.CapabilityDiscovery,
 		})
 		return result, nil
 	}
@@ -114,6 +117,7 @@ func (v *ConnectionValidator) ValidateAWSConnection(ctx context.Context, request
 			Code:        "aws_assume_role_empty_credentials",
 			Message:     "AssumeRole did not return temporary credentials.",
 			Remediation: result.PermissionChecks[0].Remediation,
+			Capability:  awsconnector.CapabilityDiscovery,
 		})
 		return result, nil
 	}
@@ -138,6 +142,7 @@ func (v *ConnectionValidator) ValidateAWSConnection(ctx context.Context, request
 			Code:        classifyAWSError(err, "aws_identity_metadata_failed"),
 			Message:     "Unable to read caller identity metadata after assuming the connector role.",
 			Remediation: "Verify the assumed-role credentials are usable and not blocked by an organization SCP or session policy.",
+			Capability:  awsconnector.CapabilityDiscovery,
 		})
 		return result, nil
 	}
@@ -155,18 +160,23 @@ func (v *ConnectionValidator) ValidateAWSConnection(ctx context.Context, request
 			Code:        classifyAWSError(iamCheckError(iamCheck), "aws_iam_read_failed"),
 			Message:     "AWS IAM permission sanity check failed.",
 			Remediation: iamCheck.Remediation,
+			Capability:  awsconnector.CapabilityDiscovery,
 		})
 	}
 	result.PermissionChecks = append(result.PermissionChecks, iamCheck)
+	if iamCheck.Passed && len(result.Diagnostics) == 0 {
+		result.ValidatedCapabilities = awsconnector.DefaultCapabilities()
+	}
 
 	return result, nil
 }
 
 func validateIAMReadPermissions(ctx context.Context, client iamValidationAPI) api.AWSConnectionPermissionCheck {
 	check := api.AWSConnectionPermissionCheck{
-		Name:    "iam:ReadRolePolicies",
-		Passed:  true,
-		Message: "IAM role and policy read permissions are available.",
+		Name:       "iam:ReadRolePolicies",
+		Passed:     true,
+		Message:    "IAM role and policy read permissions are available.",
+		Capability: awsconnector.CapabilityDiscovery,
 	}
 	roles, err := client.ListRoles(ctx, &iam.ListRolesInput{MaxItems: awsv2.Int32(1)})
 	if err != nil {

--- a/internal/providers/aws/connector_validation_test.go
+++ b/internal/providers/aws/connector_validation_test.go
@@ -13,6 +13,7 @@ import (
 	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
 	"github.com/aws/smithy-go"
 	api "github.com/identrail/identrail/internal/api"
+	awsconnector "github.com/identrail/identrail/internal/connectors/aws"
 )
 
 type fakeSTSAssumeRoleClient struct {
@@ -123,6 +124,12 @@ func TestConnectionValidatorValidateAWSConnectionActive(t *testing.T) {
 		if !check.Passed {
 			t.Fatalf("expected check %s to pass: %+v", check.Name, result.PermissionChecks)
 		}
+		if check.Capability != awsconnector.CapabilityDiscovery {
+			t.Fatalf("expected discovery capability on check %s, got %+v", check.Name, check.Capability)
+		}
+	}
+	if len(result.ValidatedCapabilities) != 1 || result.ValidatedCapabilities[0] != awsconnector.CapabilityDiscovery {
+		t.Fatalf("expected discovery validation capability, got %+v", result.ValidatedCapabilities)
 	}
 	if assume.seen == nil || awsv2.ToString(assume.seen.ExternalId) != "external" || awsv2.ToString(assume.seen.RoleSessionName) != "session" {
 		t.Fatalf("assume role request was not populated correctly: %+v", assume.seen)
@@ -171,6 +178,9 @@ func TestConnectionValidatorValidateAWSConnectionIAMPermissionFailure(t *testing
 	}
 	if len(result.Diagnostics) != 1 || result.Diagnostics[0].Code != "aws_iam_read_failed" {
 		t.Fatalf("expected iam diagnostic, got %+v", result.Diagnostics)
+	}
+	if result.Diagnostics[0].Capability != awsconnector.CapabilityDiscovery {
+		t.Fatalf("expected discovery capability diagnostic, got %+v", result.Diagnostics[0])
 	}
 	if len(result.PermissionChecks) != 2 || result.PermissionChecks[1].Passed {
 		t.Fatalf("expected failed iam check, got %+v", result.PermissionChecks)

--- a/internal/runtime/service_builder.go
+++ b/internal/runtime/service_builder.go
@@ -127,6 +127,11 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 	svc.AWSConnectorValidator = awsprovider.NewConnectionValidator(cfg.AWSRegion, cfg.AWSProfile)
 	svc.AWSCloudFormationTemplateURL = cfg.AWSCloudFormationTemplateURL
 	svc.AWSAccountID = cfg.AWSAccountID
+	svc.AWSRuntimeEvidenceEnabled = cfg.AWSRuntimeEvidence
+	svc.AWSRemediationPlanEnabled = cfg.AWSRemediationPlan
+	svc.AWSApprovedRemediationEnabled = cfg.AWSApprovedRemediation
+	svc.AWSAuthzAdvisoryEnabled = cfg.AWSAuthorizationAdvisory
+	svc.AWSAuthzEnforcementEnabled = cfg.AWSAuthorizationEnforcement
 	svc.GitHubAppID = parseInt64Config(cfg.GitHubAppID)
 	svc.GitHubAppName = cfg.GitHubAppName
 	svc.GitHubAppPrivateKey = cfg.GitHubAppPrivateKey

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -640,18 +640,34 @@ export type FindingTriageRequest = {
 
 export type ConnectorLifecycleStatus = 'pending' | 'active' | 'degraded' | 'disconnected';
 export type ConnectorHealthStatus = 'unknown' | 'healthy' | 'warning' | 'error';
+export type AWSConnectorCapability =
+  | 'discovery'
+  | 'runtime_evidence'
+  | 'remediation_plan'
+  | 'approved_remediation'
+  | 'authorization_advisory'
+  | 'authorization_enforcement';
+
+export type AWSUnavailableCapability = {
+  capability: AWSConnectorCapability;
+  reason: string;
+  gate?: string;
+  remediation?: string;
+};
 
 export type AWSConnectionPermissionCheck = {
   name: string;
   passed: boolean;
   message: string;
   remediation?: string;
+  capability?: AWSConnectorCapability;
 };
 
 export type AWSConnectionDiagnostic = {
   code: string;
   message: string;
   remediation?: string;
+  capability?: AWSConnectorCapability;
 };
 
 export type AWSPermissionPreviewItem = {
@@ -659,6 +675,10 @@ export type AWSPermissionPreviewItem = {
   actions: string[];
   resources: string[];
   reason: string;
+  capability: AWSConnectorCapability;
+  tier: string;
+  included: boolean;
+  gate?: string;
 };
 
 export type AWSConnectionStatus = {
@@ -676,6 +696,10 @@ export type AWSConnectionStatus = {
   region?: string;
   permission_checks: AWSConnectionPermissionCheck[];
   diagnostics: AWSConnectionDiagnostic[];
+  requested_capabilities: AWSConnectorCapability[];
+  validated_capabilities: AWSConnectorCapability[];
+  effective_capabilities: AWSConnectorCapability[];
+  unavailable_capabilities: AWSUnavailableCapability[];
   remediation_message?: string;
   launch_url?: string;
   template_url?: string;
@@ -692,6 +716,7 @@ export type AWSConnectionUpsertRequest = {
   external_id?: string;
   region?: string;
   session_name?: string;
+  requested_capabilities?: AWSConnectorCapability[];
 };
 
 export type AWSConnectorStartRequest = {
@@ -702,6 +727,7 @@ export type AWSConnectorStartRequest = {
   region?: string;
   role_name?: string;
   stack_name?: string;
+  requested_capabilities?: AWSConnectorCapability[];
 };
 
 export type AWSConnectorStartResponse = {
@@ -723,6 +749,7 @@ export type AWSConnectorValidateRequest = {
   external_id?: string;
   region?: string;
   session_name?: string;
+  requested_capabilities?: AWSConnectorCapability[];
 };
 
 export type AWSConnectorPolicyResponse = {

--- a/web/src/components/connector/PermissionPreviewModal.tsx
+++ b/web/src/components/connector/PermissionPreviewModal.tsx
@@ -12,6 +12,8 @@ export function PermissionPreviewModal({ open, title, items, onClose }: Permissi
     return null;
   }
 
+  const formatTier = (tier: string) => tier.replace(/_/g, ' ');
+
   return (
     <div className="idt-modal-backdrop" role="presentation" onClick={onClose}>
       <section
@@ -32,10 +34,12 @@ export function PermissionPreviewModal({ open, title, items, onClose }: Permissi
         </header>
         <div className="idt-permission-preview-list">
           {items.map((item) => (
-            <article key={item.service}>
+            <article key={`${item.capability}-${item.service}-${item.tier}`} className={item.included ? '' : 'idt-preview-excluded'}>
               <div>
                 <strong>{item.service}</strong>
+                <span>{item.included ? formatTier(item.tier) : `Gated: ${formatTier(item.tier)}`}</span>
                 <p>{item.reason}</p>
+                {item.gate ? <small>Gate: {item.gate}</small> : null}
               </div>
               <code>{item.actions.join(', ')}</code>
             </article>

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -72,7 +72,11 @@ const disconnectedAWS: AWSConnectionStatus = {
   health_status: 'unknown',
   external_id_configured: false,
   permission_checks: [],
-  diagnostics: []
+  diagnostics: [],
+  requested_capabilities: ['discovery'],
+  validated_capabilities: [],
+  effective_capabilities: [],
+  unavailable_capabilities: []
 };
 
 const connectedGitHub: GitHubConnectionStatus = {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -24,6 +24,7 @@ import {
   ApiError,
   apiClient,
   type AuthConfigResponse,
+  type AWSConnectorCapability,
   type AWSConnectorStartResponse,
   type AWSConnectionStatus,
   type AWSPermissionPreviewItem,
@@ -184,6 +185,7 @@ const SOURCE_PROFILES: Record<SourceProvider, SourceProfile> = {
 };
 const GITHUB_REPOSITORY_SPLIT_PATTERN = /[\n,]+/;
 const AWS_ROLE_ARN_PATTERN = /^arn:(aws|aws-us-gov|aws-cn):iam::[0-9]{12}:role\/[A-Za-z0-9+=,.@_/-]{1,512}$/;
+const AWS_DEFAULT_CAPABILITIES: AWSConnectorCapability[] = ['discovery'];
 const SOURCE_ORDER: SourceProvider[] = [
   ...(FEATURE_CONNECTOR_GITHUB_V2 ? (['github'] as SourceProvider[]) : []),
   'aws',
@@ -4282,12 +4284,13 @@ export function ProductProjectDetailPage() {
       }
       const auth = buildProductAuthContext(scope);
       const payload = {
-          role_arn: roleARN,
-          external_id: normalizeValue(awsForm.externalID) || undefined,
-          region: normalizeValue(awsForm.region) || 'us-east-1',
-          display_name: normalizeValue(awsForm.displayName) || undefined,
-          session_name: normalizeValue(awsForm.sessionName) || undefined
-        };
+        role_arn: roleARN,
+        external_id: normalizeValue(awsForm.externalID) || undefined,
+        region: normalizeValue(awsForm.region) || 'us-east-1',
+        display_name: normalizeValue(awsForm.displayName) || undefined,
+        session_name: normalizeValue(awsForm.sessionName) || undefined,
+        requested_capabilities: AWS_DEFAULT_CAPABILITIES
+      };
       const response =
         FEATURE_CONNECTOR_AWS && awsCloudFormationStart?.connector_id
           ? await apiClient.validateAWSConnector(
@@ -4298,7 +4301,8 @@ export function ProductProjectDetailPage() {
                 role_arn: payload.role_arn,
                 external_id: payload.external_id,
                 region: payload.region,
-                session_name: payload.session_name
+                session_name: payload.session_name,
+                requested_capabilities: payload.requested_capabilities
               },
               auth
             )
@@ -4340,7 +4344,8 @@ export function ProductProjectDetailPage() {
           display_name: normalizeValue(awsForm.displayName) || undefined,
           region: normalizeValue(awsForm.region) || 'us-east-1',
           role_name: normalizeValue(awsForm.roleName) || undefined,
-          stack_name: normalizeValue(awsForm.stackName) || undefined
+          stack_name: normalizeValue(awsForm.stackName) || undefined,
+          requested_capabilities: AWS_DEFAULT_CAPABILITIES
         },
         auth
       );
@@ -5185,10 +5190,26 @@ export function ProductProjectDetailPage() {
             <div className="idt-source-diagnostics">
               {connections.aws.account_id ? <p>Account {connections.aws.account_id}</p> : null}
               {connections.aws.principal_arn ? <p>Principal {connections.aws.principal_arn}</p> : null}
+              <article>
+                <strong>AWS connector capabilities</strong>
+                <span>Effective: {connections.aws.effective_capabilities.join(', ') || 'none yet'}</span>
+                <p>Requested: {connections.aws.requested_capabilities.join(', ') || 'discovery'}</p>
+                {connections.aws.unavailable_capabilities.length > 0 ? (
+                  <small>
+                    Unavailable:{' '}
+                    {connections.aws.unavailable_capabilities
+                      .map((capability) => `${capability.capability} (${capability.gate || 'validation'})`)
+                      .join(', ')}
+                  </small>
+                ) : null}
+              </article>
               {connections.aws.permission_checks.map((check) => (
                 <article key={check.name}>
                   <strong>{check.name}</strong>
-                  <span>{check.passed ? 'Passed' : 'Needs attention'}</span>
+                  <span>
+                    {check.passed ? 'Passed' : 'Needs attention'}
+                    {check.capability ? ` - ${check.capability}` : ''}
+                  </span>
                   <p>{check.message}</p>
                   {check.remediation ? <small>{check.remediation}</small> : null}
                 </article>
@@ -5196,7 +5217,7 @@ export function ProductProjectDetailPage() {
               {connections.aws.diagnostics.map((diagnostic) => (
                 <article key={diagnostic.code}>
                   <strong>{diagnostic.code}</strong>
-                  <span>Diagnostic</span>
+                  <span>{diagnostic.capability ? `Diagnostic - ${diagnostic.capability}` : 'Diagnostic'}</span>
                   <p>{diagnostic.message}</p>
                   {diagnostic.remediation ? <small>{diagnostic.remediation}</small> : null}
                 </article>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6010,6 +6010,22 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   color: #c2d4f0;
 }
 
+.idt-permission-preview-list span,
+.idt-permission-preview-list small {
+  display: block;
+  margin-top: 0.2rem;
+  color: #8fa5c3;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.idt-permission-preview-list article.idt-preview-excluded {
+  border-style: dashed;
+  opacity: 0.78;
+}
+
 .idt-permission-preview-list code {
   max-width: 48%;
   white-space: normal;


### PR DESCRIPTION
Fixes #1353

## Summary
- Added typed AWS connector capability modes for `discovery`, runtime evidence, remediation planning, approved remediation, authorization advisory, and authorization enforcement.
- Persisted and returned requested, validated, effective, and unavailable AWS capabilities on connector status.
- Kept the default AWS connector read-only: CloudFormation and manual validation request only `discovery`, while future non-discovery tiers stay gated.
- Grouped AWS permission preview entries by capability tier and marked future tiers as gated rather than included.
- Updated OpenAPI, web client types, connector UI display, AWS connector docs, env var docs, read-only policy docs, and changelog.

## Why
- Operators need a clear contract for what an AWS connector can do today versus what future workflows may require.
- This avoids accidentally treating the existing read-only stack as write-capable while still making future runtime/remediation/authorization modes visible and reviewable.

## Scope
- Backend API/status model and validation diagnostics.
- AWS connector permission preview model.
- False-by-default deployment policy gates for future capability modes.
- Web connector diagnostics and permission preview rendering.
- Docs, OpenAPI, and tests.

## Safety notes
- No live remediation or authorization enforcement executors were added.
- The existing CloudFormation policy remains read-only and only enables `discovery`.
- Write-capable capabilities are reported as unavailable unless both validation and deployment gates allow them.

## Validation
- `git diff --check`
- `go test ./internal/api ./internal/config ./internal/runtime ./internal/providers/aws && go vet ./...`
- `go test ./... -coverprofile=coverage.out` with total coverage `80.4%`
- `npm run test:ci --prefix web` - 12 files passed, 182 tests passed
- `npm run build --prefix web` - production build and 39 prerendered routes passed
- Push hooks passed: merge-conflict check, YAML check, EOF/whitespace, gofmt, go vet, local env token hygiene, Vercel artifact hygiene

## Checklist
- [x] Branch is based on `dev`.
- [x] PR is focused on issue #1353.
- [x] Tests were added or updated for new behavior.
- [x] Docs and OpenAPI were updated for operator/API-facing changes.
- [x] Commit is DCO signed off.

## AI disclosure
- AI-assisted: yes
- Tools used: Codex
- Areas where used: implementation, tests, documentation, and validation loop
- Human verification performed: automated validation listed above and review of issue acceptance criteria

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add typed AWS connector capability modes with clear gating and status reporting. Defaults stay read‑only (discovery only) while future tiers are visible and opt‑in, meeting #1353.

- **New Features**
  - Added capability types: `discovery`, `runtime_evidence`, `remediation_plan`, `approved_remediation`, `authorization_advisory`, `authorization_enforcement`.
  - API now accepts `requested_capabilities` and returns requested, validated, effective, and unavailable capabilities. OpenAPI and web client types updated.
  - Validation checks and diagnostics include a `capability` field for clearer context.
  - Permission preview groups entries by capability tier and marks future tiers as gated.
  - Service gates added and wired to config/env for non‑discovery modes.

- **Migration**
  - No changes needed for existing setups; discovery remains the only enabled mode.
  - To enable future modes, set:
    - `IDENTRAIL_AWS_CAPABILITY_RUNTIME_EVIDENCE`
    - `IDENTRAIL_AWS_CAPABILITY_REMEDIATION_PLAN`
    - `IDENTRAIL_AWS_CAPABILITY_APPROVED_REMEDIATION`
    - `IDENTRAIL_AWS_CAPABILITY_AUTHORIZATION_ADVISORY`
    - `IDENTRAIL_AWS_CAPABILITY_AUTHORIZATION_ENFORCEMENT`
  - The read‑only CloudFormation policy is unchanged; write‑capable tiers stay disabled unless gates are enabled and validation passes.

<sup>Written for commit b0a755cf3b053c97333f59eadcbd35ccb9ff8780. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1363?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

