### PR TITLE
docs: align AWS onboarding docs with connector flow

### DIFF
--- a/docs/aws-collector.md
+++ b/docs/aws-collector.md
@@ -32,6 +32,10 @@ The AWS collector is the first provider ingestion module in Identrail. It reads 
 - No credential persistence in collector module
 - No mutation API calls
 
-## Next Step
+## Current Implementation State
 
-Wire this collector to a concrete AWS SDK adapter and pass outputs into the normalizer module.
+- IAM role collection is implemented through a concrete AWS SDK adapter.
+- The collector output flows into the normalizer pipeline as `kind=iam_role` raw assets.
+- Connectors currently assume the onboarded read-only role at scan time, then perform IAM-only collection.
+- Runtime behavior stays IAM-focused and read-only; no live remediation or policy enforcement is executed during collection.
+- Cross-service expansion is expected through the separate composite-connector roadmap, not through this IAM collector path today.

--- a/docs/source-onboarding.md
+++ b/docs/source-onboarding.md
@@ -4,7 +4,7 @@ Identrail source onboarding is available from the authenticated product shell at
 
 `/app/{tenant_id}/{workspace_id}/projects/{project_id}`
 
-The project detail view presents a guided connect-source wizard for GitHub, AWS, and Kubernetes. It reads current source status first, then runs the existing project-scoped connector APIs when an operator validates or saves a source.
+The project detail view presents a guided connect-source wizard for GitHub, AWS, and Kubernetes. It reads current source status first, then uses the current connector onboarding path for AWS, while the other provider flows still use their established project-scoped routes where applicable.
 
 ## GitHub
 
@@ -26,11 +26,33 @@ The action uses the tenant/workspace scope headers from the product session, sho
 
 ## AWS
 
-The wizard validates and saves one read-only IAM role through:
+AWS onboarding now follows the CloudFormation connector flow:
+
+```text
+POST /v1/connectors/aws
+GET  /v1/connectors/aws/{connector_id}/poll
+POST /v1/connectors/aws/{connector_id}/validate
+POST /v1/connectors/aws/{connector_id}/refresh-policy
+```
+
+`POST /v1/connectors/aws` starts onboarding and returns an AWS launch URL plus permission preview.
+`GET /v1/connectors/aws/{connector_id}/poll` returns status for long-running setup.
+`POST /v1/connectors/aws/{connector_id}/validate` validates the role created by that flow with scanner-critical IAM checks, permission checks, and diagnostics that are surfaced in the connector status.
+`POST /v1/connectors/aws/{connector_id}/refresh-policy` regenerates the read-only policy preview and capability matrix for the same connector.
+
+Current product behavior remains IAM-focused and read-only. CloudFormation creates a role with scanner-only permissions and does not execute cloud-side mutation or remediation.
+
+Keep in mind the older project-scoped route remains for compatibility only:
 
 `POST /v1/workspaces/{workspace_id}/projects/{project_id}/aws/connection`
 
-Validation returns account identity, permission checks, diagnostics, and remediation text. A successful validation marks the connector active; failed checks leave the connector diagnosable instead of hiding the issue.
+This path is not the default product onboarding flow and is maintained only for legacy clients that still call it.
+
+For required environment and policy references, see:
+
+- [`docs/auth/aws-connector.md`](./auth/aws-connector.md)
+- [`docs/auth/env-vars-reference.md`](./auth/env-vars-reference.md) (AWS connector env vars)
+- [`../deploy/connectors/aws/policies/identrail-readonly-policy.md`](../deploy/connectors/aws/policies/identrail-readonly-policy.md)
 
 ## Kubernetes
 


### PR DESCRIPTION
Fixes #1358

## Summary
- Update AWS collector documentation to reflect shipped connector implementation state (SDK-backed IAM collection + scan-time assume-role flow) and avoid describing it as a future step.
- Refresh source onboarding docs to make the CloudFormation connector API the documented AWS product path.
- Mark the project-scoped AWS `/v1/workspaces/{workspace_id}/projects/{project_id}/aws/connection` route as compatibility/legacy only.
- Add cross-links to AWS connector docs, AWS connector environment variables, and read-only policy preview docs.

## Why
Issue #1358 flagged stale AWS onboarding docs. The docs were still describing a deprecated project-scoped flow and older assumptions about connector readiness.

## Scope
- [x] Focused change (docs only)
- [x] Backward compatibility considered (legacy route explicitly called out)
- [x] Risk level assessed (user-facing documentation clarity improvements only)

## Validation
- `git diff --check`

No behavior-changing code paths were edited.

## Checklist
- [x] Docs updated for user/operator-facing behavior
- [ ] CHANGELOG.md updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure
- AI-assisted: yes
- Tools used: ChatGPT/Codex
- Areas where used: docs/aws-collector.md, docs/source-onboarding.md
- Human verification performed: reviewed issue requirements + current API routes before committing; validated final diff against acceptance criteria.

## Related Issues
- Fixes #1358


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes AWS onboarding docs to match the CloudFormation connector flow and current IAM-only collector behavior. Addresses #1358 by marking the project-scoped route as legacy and adding links to connector, env vars, and read-only policy docs.

- **Docs**
  - Make CloudFormation connector the default AWS path: `POST /v1/connectors/aws` (+ poll, validate, refresh-policy).
  - Clarify collector state: SDK-backed IAM role collection, scan-time assume-role, read-only, normalized as `kind=iam_role`.
  - Mark `POST /v1/workspaces/{workspace_id}/projects/{project_id}/aws/connection` as compatibility-only.
  - Add cross-links to AWS connector docs, AWS connector env vars, and policy preview.

<sup>Written for commit c76907b3b4abbf75b123d2211e27c39e2904797d. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1366?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

