### PR TITLE
Polish repository findings dashboard UX

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1378,12 +1378,23 @@ describe('App', () => {
     }
     expect(within(missingSeverityRow).getByText('Unknown')).toBeInTheDocument();
 
+    const linkedFinding = await screen.findByText(/Potential AWS access key exposed in commit history/i);
+    const linkedFindingRow = linkedFinding.closest('button');
+    expect(linkedFindingRow).not.toBeNull();
+    if (!linkedFindingRow) {
+      throw new Error('linked finding row');
+    }
+    fireEvent.click(linkedFindingRow);
+
+    const findingDialog = await screen.findByRole('dialog', {
+      name: /Potential AWS access key exposed in commit history/i
+    });
     const openInGitHub = await screen.findByRole('link', { name: /Open in GitHub/i });
     expect(openInGitHub).toHaveAttribute('href', 'https://github.com/owner/repo/blob/abc123/config/app.env#L7');
-    expect((await screen.findAllByText('config/app.env:7')).length).toBeGreaterThan(0);
-    expect((await screen.findAllByText('owner/repo')).length).toBeGreaterThan(0);
+    expect(within(findingDialog).getAllByText('config/app.env:7').length).toBeGreaterThan(0);
+    expect(within(findingDialog).getAllByText('owner/repo').length).toBeGreaterThan(0);
 
-    fireEvent.click(screen.getByRole('button', { name: /Preview remediation plan/i }));
+    fireEvent.click(within(findingDialog).getByRole('button', { name: /Preview remediation plan/i }));
     expect(await screen.findByText(/Rotate exposed AWS credential/i)).toBeInTheDocument();
     expect(await screen.findByText(/Revoke the leaked access key/i)).toBeInTheDocument();
     expect(await screen.findByText(/Secret rotation required/i)).toBeInTheDocument();
@@ -1706,7 +1717,17 @@ describe('App', () => {
     setCurrentPath('/app/tenant-a/workspace-a/findings');
     render(<App />);
 
-    const workflowControls = (await screen.findByText(/Workflow controls/i)).closest('.idt-repo-finding-triage-form');
+    const findingRow = (await screen.findByText(/Potential AWS access key exposed in commit history/i)).closest('button');
+    expect(findingRow).not.toBeNull();
+    if (!findingRow) {
+      throw new Error('finding row');
+    }
+    fireEvent.click(findingRow);
+
+    const findingDialog = await screen.findByRole('dialog', {
+      name: /Potential AWS access key exposed in commit history/i
+    });
+    const workflowControls = within(findingDialog).getByText(/Workflow controls/i).closest('.idt-repo-finding-triage-form');
     expect(workflowControls).toBeInTheDocument();
 
     fireEvent.change(within(workflowControls as HTMLElement).getByLabelText(/Assignee/i), { target: { value: 'platform' } });

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -937,6 +937,47 @@ describe('ProductFindingsPage states', () => {
     expect(screen.queryByText('Your last repository scan failed')).not.toBeInTheDocument();
   });
 
+  it('restores focus to the triggering row when the finding detail dialog closes', async () => {
+    const scan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-with-findings',
+      status: 'succeeded',
+      finished_at: '2026-05-17T11:06:00Z',
+      finding_count: 1
+    };
+
+    const finding: Finding = {
+      id: 'finding-1',
+      scan_id: scan.id,
+      type: 'aws_access_key',
+      severity: 'critical',
+      title: 'IAM role with wildcard trust',
+      human_summary: 'AssumeRole trust policy allows any principal.',
+      remediation: 'Tighten trust policy principals.',
+      created_at: '2026-05-17T11:06:00Z'
+    };
+
+    await renderFindings({ repoScans: [scan], repoFindings: [finding] });
+
+    const rowButton = (await screen.findAllByRole('listitem')).find((node) =>
+      node.textContent?.includes('IAM role with wildcard trust')
+    ) as HTMLButtonElement | undefined;
+    expect(rowButton).toBeDefined();
+    if (!rowButton) return;
+    rowButton.focus();
+    fireEvent.click(rowButton);
+
+    const closeButton = await screen.findByRole('button', { name: /Close finding detail/i });
+    fireEvent.click(closeButton);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /Close finding detail/i })).not.toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(rowButton);
+    });
+  });
+
   it('keeps visible filters when active filters match no findings', async () => {
     const scan: RepoScanRecord = {
       ...queuedRepoScan,

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -919,7 +919,7 @@ describe('ProductFindingsPage states', () => {
 
     expect(screen.queryByText('Your last repository scan failed')).not.toBeInTheDocument();
     expect(await screen.findByText('Completed scans')).toBeInTheDocument();
-    expect(await screen.findByRole('heading', { name: 'Legacy finding' })).toBeInTheDocument();
+    expect(await screen.findByText('Legacy finding')).toBeInTheDocument();
   });
 
   it('does not report cancellation as a failed scan', async () => {
@@ -937,7 +937,7 @@ describe('ProductFindingsPage states', () => {
     expect(screen.queryByText('Your last repository scan failed')).not.toBeInTheDocument();
   });
 
-  it('keeps the finding detail pane visible when filters are active but no findings match', async () => {
+  it('keeps visible filters when active filters match no findings', async () => {
     const scan: RepoScanRecord = {
       ...queuedRepoScan,
       id: 'repo-scan-with-findings',
@@ -964,13 +964,13 @@ describe('ProductFindingsPage states', () => {
 
     expect((await screen.findAllByText('IAM role with wildcard trust')).length).toBeGreaterThan(0);
 
-    const filtersSummary = await screen.findByText('Filters and sorting');
-    fireEvent.click(filtersSummary);
+    expect(await screen.findByText('Filters and sorting')).toBeInTheDocument();
 
     const severityFilter = screen.getByLabelText('Severity');
     fireEvent.change(severityFilter, { target: { value: 'high' } });
 
     expect(await screen.findByText('No findings match the current filters.')).toBeInTheDocument();
-    expect(screen.getByText('Select a finding')).toBeInTheDocument();
+    expect(screen.getByLabelText('Repository finding filters and sorting')).toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: /IAM role with wildcard trust/i })).not.toBeInTheDocument();
   });
 });

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -211,6 +211,8 @@ const SORT_LABEL_BY_FIELD: Record<(typeof REPO_FINDING_SORT_FIELDS)[number], str
   type: 'Finding type',
   title: 'Finding title'
 };
+const MODAL_FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 const TREND_POINTS = 10;
 const PRODUCT_AUTH_SESSION_SCOPE_KEY = '__product_session__';
@@ -6283,6 +6285,7 @@ export function ProductFindingsPage() {
   const remediationPreviewRequestRef = useRef(0);
   const remediationPublishRequestRef = useRef(0);
   const findingDetailCloseRef = useRef<HTMLButtonElement | null>(null);
+  const findingDetailModalRef = useRef<HTMLElement | null>(null);
 
   const hasTriageAccess = Boolean(me?.role === 'owner' || me?.role === 'admin');
 
@@ -6303,6 +6306,50 @@ export function ProductFindingsPage() {
       }
       return { ...current, [level]: nextKeys, initialized: true };
     });
+  };
+
+  const handleFindingDetailModalKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      setFindingDetailOpen(false);
+      return;
+    }
+
+    if (event.key !== 'Tab') {
+      return;
+    }
+
+    const modal = findingDetailModalRef.current;
+    if (!modal) {
+      return;
+    }
+
+    const focusableElements = Array.from(modal.querySelectorAll<HTMLElement>(MODAL_FOCUSABLE_SELECTOR)).filter(
+      (element) => element.getAttribute('aria-hidden') !== 'true'
+    );
+    if (focusableElements.length === 0) {
+      event.preventDefault();
+      modal.focus();
+      return;
+    }
+
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+    const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const focusIsOutsideModal = !activeElement || !modal.contains(activeElement);
+
+    if (event.shiftKey) {
+      if (focusIsOutsideModal || activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus();
+      }
+      return;
+    }
+
+    if (focusIsOutsideModal || activeElement === lastElement) {
+      event.preventDefault();
+      firstElement.focus();
+    }
   };
 
   const trendMaxTotal = useMemo(() => {
@@ -7362,13 +7409,10 @@ export function ProductFindingsPage() {
             aria-modal="true"
             aria-labelledby="repo-finding-detail-title"
             className="idt-repo-finding-detail-modal"
+            ref={findingDetailModalRef}
             role="dialog"
-            onKeyDown={(event) => {
-              if (event.key === 'Escape') {
-                event.preventDefault();
-                setFindingDetailOpen(false);
-              }
-            }}
+            tabIndex={-1}
+            onKeyDown={handleFindingDetailModalKeyDown}
             onMouseDown={(event) => event.stopPropagation()}
           >
             <header className="idt-repo-finding-detail-modal-header">

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -6308,9 +6308,10 @@ export function ProductFindingsPage() {
           'Repository unavailable',
         scanDateForFinding: (finding) => repoFindingScanDateLabel(finding, repoScansByID),
         scanSortValueForFinding: (finding) => repoFindingScanTimestamp(finding, repoScansByID),
+        sortBy,
         sortOrder
       }),
-    [filteredFindings, repoScansByID, sortOrder]
+    [filteredFindings, repoScansByID, sortBy, sortOrder]
   );
 
   const selectedFinding = useMemo(
@@ -7152,7 +7153,9 @@ export function ProductFindingsPage() {
                 const highCount = repositoryGroup.findings.filter(
                   (finding) => normalizeValue(finding.severity).toLowerCase() === 'high'
                 ).length;
-                const latestScanLabel = repositoryGroup.scanGroups[0]?.label ?? 'Scan date unavailable';
+                const latestScanLabel =
+                  [...repositoryGroup.scanGroups].sort((left, right) => right.sortValue - left.sortValue)[0]?.label ??
+                  'Scan date unavailable';
 
                 return (
                   <details

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -6244,6 +6244,17 @@ export function ProductFindingsPage() {
   const [sortBy, setSortBy] = useState<(typeof REPO_FINDING_SORT_FIELDS)[number]>('severity');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const [filtersExpanded, setFiltersExpanded] = useState(true);
+  const [hierarchyOpenState, setHierarchyOpenState] = useState<{
+    repositories: Set<string>;
+    scans: Set<string>;
+    severities: Set<string>;
+    initialized: boolean;
+  }>({
+    repositories: new Set(),
+    scans: new Set(),
+    severities: new Set(),
+    initialized: false
+  });
   const [selectedFindingKey, setSelectedFindingKey] = useState('');
   const [findingDetailOpen, setFindingDetailOpen] = useState(false);
   const [workflowStatus, setWorkflowStatus] = useState<FindingLifecycleStatus>('open');
@@ -6274,6 +6285,25 @@ export function ProductFindingsPage() {
   const findingDetailCloseRef = useRef<HTMLButtonElement | null>(null);
 
   const hasTriageAccess = Boolean(me?.role === 'owner' || me?.role === 'admin');
+
+  const updateHierarchyOpenState = (
+    level: 'repositories' | 'scans' | 'severities',
+    key: string,
+    open: boolean
+  ) => {
+    setHierarchyOpenState((current) => {
+      if (current[level].has(key) === open) {
+        return current;
+      }
+      const nextKeys = new Set(current[level]);
+      if (open) {
+        nextKeys.add(key);
+      } else {
+        nextKeys.delete(key);
+      }
+      return { ...current, [level]: nextKeys, initialized: true };
+    });
+  };
 
   const trendMaxTotal = useMemo(() => {
     const totals = trendPoints.map((point) => point.total);
@@ -6314,6 +6344,26 @@ export function ProductFindingsPage() {
       }),
     [filteredFindings, repoScansByID, sortBy, sortOrder]
   );
+
+  useEffect(() => {
+    if (findingHierarchy.length === 0) {
+      return;
+    }
+    setHierarchyOpenState((current) => {
+      if (current.initialized) {
+        return current;
+      }
+      const firstRepository = findingHierarchy[0];
+      const firstScan = firstRepository.scanGroups[0];
+      const firstSeverity = firstScan?.severityGroups[0];
+      return {
+        repositories: new Set(firstRepository ? [firstRepository.key] : []),
+        scans: new Set(firstScan ? [firstScan.key] : []),
+        severities: new Set(firstSeverity ? [firstSeverity.key] : []),
+        initialized: true
+      };
+    });
+  }, [findingHierarchy]);
 
   const selectedFinding = useMemo(
     () => findRepoFindingBySelectionKey(filteredFindings, selectedFindingKey),
@@ -7167,7 +7217,10 @@ export function ProductFindingsPage() {
                   <details
                     className="idt-repo-finding-bucket idt-repo-finding-repository"
                     key={repositoryGroup.key}
-                    {...(repositoryIndex === 0 ? { open: true } : {})}
+                    open={hierarchyOpenState.repositories.has(repositoryGroup.key)}
+                    onToggle={(event) =>
+                      updateHierarchyOpenState('repositories', repositoryGroup.key, event.currentTarget.open)
+                    }
                   >
                     <summary className="idt-repo-repository-summary">
                       <span className="idt-repo-summary-main">
@@ -7199,7 +7252,10 @@ export function ProductFindingsPage() {
                         <details
                           className="idt-repo-finding-bucket idt-repo-finding-scan"
                           key={scanGroup.key}
-                          {...(repositoryIndex === 0 && scanIndex === 0 ? { open: true } : {})}
+                          open={hierarchyOpenState.scans.has(scanGroup.key)}
+                          onToggle={(event) =>
+                            updateHierarchyOpenState('scans', scanGroup.key, event.currentTarget.open)
+                          }
                         >
                           <summary className="idt-repo-scan-summary">
                             <span className="idt-repo-scan-node" aria-hidden="true" />
@@ -7217,9 +7273,10 @@ export function ProductFindingsPage() {
                               <details
                                 className={`idt-repo-finding-bucket idt-repo-finding-severity-group is-${severityGroup.label}`}
                                 key={severityGroup.key}
-                                {...(repositoryIndex === 0 && scanIndex === 0 && severityIndex === 0
-                                  ? { open: true }
-                                  : {})}
+                                open={hierarchyOpenState.severities.has(severityGroup.key)}
+                                onToggle={(event) =>
+                                  updateHierarchyOpenState('severities', severityGroup.key, event.currentTarget.open)
+                                }
                               >
                                 <summary className="idt-repo-severity-summary">
                                   <span className="idt-repo-severity-copy">

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -6243,6 +6243,7 @@ export function ProductFindingsPage() {
   const [minConfidenceFilter, setMinConfidenceFilter] = useState('');
   const [sortBy, setSortBy] = useState<(typeof REPO_FINDING_SORT_FIELDS)[number]>('severity');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+  const [filtersExpanded, setFiltersExpanded] = useState(true);
   const [selectedFindingKey, setSelectedFindingKey] = useState('');
   const [findingDetailOpen, setFindingDetailOpen] = useState(false);
   const [workflowStatus, setWorkflowStatus] = useState<FindingLifecycleStatus>('open');
@@ -7016,7 +7017,12 @@ export function ProductFindingsPage() {
       </div>
 
       {filteredFindings.length > 0 || filtersActive ? (
-        <details className="idt-repo-filter-panel" aria-label="Repository finding filters and sorting" open>
+        <details
+          className="idt-repo-filter-panel"
+          aria-label="Repository finding filters and sorting"
+          open={filtersExpanded}
+          onToggle={(event) => setFiltersExpanded(event.currentTarget.open)}
+        >
           <summary className="idt-repo-filter-panel-header">
             <span>Filters and sorting</span>
             <small>{filteredFindings.length ? `${filteredFindings.length} findings shown` : 'No findings in scope'}</small>

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -9,6 +9,7 @@ import {
   BarChart3,
   ChevronDown,
   ChevronUp,
+  ExternalLink,
   FolderKanban,
   HelpCircle,
   LayoutDashboard,
@@ -18,7 +19,8 @@ import {
   Search,
   Settings as SettingsIcon,
   Shield,
-  Users
+  Users,
+  X
 } from 'lucide-react';
 import {
   ApiError,
@@ -70,7 +72,7 @@ import { OnboardingUnavailableNotice, useOnboardingAvailable } from './component
 import {
   buildRepoFindingSelectionKey,
   findRepoFindingBySelectionKey,
-  groupRepoFindingsForDisplay,
+  groupRepoFindingsByRepositoryDateSeverity,
   mergeUpdatedRepoFinding
 } from './repoFindingDisplay';
 
@@ -540,6 +542,30 @@ function repoFindingLocationLabel(finding: ApiFinding): string {
     return finding.file_path;
   }
   return 'Location unavailable';
+}
+
+function repoFindingScanTimestamp(finding: ApiFinding, repoScansByID: Record<string, RepoScanRecord>): number {
+  const scan = repoScansByID[finding.scan_id];
+  const timestamp =
+    normalizeValue(scan?.finished_at) ||
+    normalizeValue(scan?.started_at) ||
+    normalizeValue(finding.last_seen_at) ||
+    normalizeValue(finding.first_seen_at) ||
+    normalizeValue(finding.created_at);
+  const parsed = new Date(timestamp);
+  return Number.isNaN(parsed.getTime()) ? 0 : parsed.getTime();
+}
+
+function repoFindingScanDateLabel(finding: ApiFinding, repoScansByID: Record<string, RepoScanRecord>): string {
+  const timestamp = repoFindingScanTimestamp(finding, repoScansByID);
+  if (!timestamp) {
+    return 'Scan date unavailable';
+  }
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric'
+  });
 }
 
 function repoFindingSeverityClass(severity: string): string {
@@ -6218,6 +6244,7 @@ export function ProductFindingsPage() {
   const [sortBy, setSortBy] = useState<(typeof REPO_FINDING_SORT_FIELDS)[number]>('severity');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const [selectedFindingKey, setSelectedFindingKey] = useState('');
+  const [findingDetailOpen, setFindingDetailOpen] = useState(false);
   const [workflowStatus, setWorkflowStatus] = useState<FindingLifecycleStatus>('open');
   const [workflowAssignee, setWorkflowAssignee] = useState('');
   const [workflowComment, setWorkflowComment] = useState('');
@@ -6243,6 +6270,7 @@ export function ProductFindingsPage() {
   const signalRequestRef = useRef(0);
   const remediationPreviewRequestRef = useRef(0);
   const remediationPublishRequestRef = useRef(0);
+  const findingDetailCloseRef = useRef<HTMLButtonElement | null>(null);
 
   const hasTriageAccess = Boolean(me?.role === 'owner' || me?.role === 'admin');
 
@@ -6272,13 +6300,21 @@ export function ProductFindingsPage() {
     });
   }, [repoFindings, statusFilter, assigneeFilter]);
 
-  const findingGroups = useMemo(
-    () => groupRepoFindingsForDisplay(filteredFindings, sortBy, sortOrder),
-    [filteredFindings, sortBy, sortOrder]
+  const findingHierarchy = useMemo(
+    () =>
+      groupRepoFindingsByRepositoryDateSeverity(filteredFindings, {
+        repositoryForFinding: (finding) =>
+          canonicalGitHubRepositoryDisplay(repoFindingRepositoryValue(finding, repoScansByID)) ||
+          'Repository unavailable',
+        scanDateForFinding: (finding) => repoFindingScanDateLabel(finding, repoScansByID),
+        scanSortValueForFinding: (finding) => repoFindingScanTimestamp(finding, repoScansByID),
+        sortOrder
+      }),
+    [filteredFindings, repoScansByID, sortOrder]
   );
 
   const selectedFinding = useMemo(
-    () => findRepoFindingBySelectionKey(filteredFindings, selectedFindingKey) ?? filteredFindings[0] ?? null,
+    () => findRepoFindingBySelectionKey(filteredFindings, selectedFindingKey),
     [filteredFindings, selectedFindingKey]
   );
 
@@ -6577,10 +6613,11 @@ export function ProductFindingsPage() {
   // itself, so a slow response cannot land on a newly selected finding. Bumping
   // the guards here closes the race window that exists if invalidation is left
   // to a post-render effect.
-  const selectRepoFinding = (key: string) => {
+  const selectRepoFinding = (key: string, openDetail = true) => {
     remediationPreviewRequestRef.current += 1;
     remediationPublishRequestRef.current += 1;
     setSelectedFindingKey(key);
+    setFindingDetailOpen(Boolean(key) && openDetail);
   };
 
   const handlePublishRemediation = async () => {
@@ -6715,14 +6752,36 @@ export function ProductFindingsPage() {
   useEffect(() => {
     if (filteredFindings.length === 0) {
       if (selectedFindingKey) {
-        selectRepoFinding('');
+        selectRepoFinding('', false);
       }
       return;
     }
-    if (!findRepoFindingBySelectionKey(filteredFindings, selectedFindingKey)) {
-      selectRepoFinding(buildRepoFindingSelectionKey(filteredFindings[0]));
+    if (selectedFindingKey && !findRepoFindingBySelectionKey(filteredFindings, selectedFindingKey)) {
+      selectRepoFinding('', false);
     }
   }, [filteredFindings, selectedFindingKey]);
+
+  useEffect(() => {
+    if (!findingDetailOpen || typeof document === 'undefined') {
+      return undefined;
+    }
+    const root = document.documentElement;
+    const previousOverflow = root.style.overflow;
+    root.style.overflow = 'hidden';
+    return () => {
+      root.style.overflow = previousOverflow;
+    };
+  }, [findingDetailOpen]);
+
+  useEffect(() => {
+    if (!findingDetailOpen || typeof window === 'undefined') {
+      return undefined;
+    }
+    const frame = window.requestAnimationFrame(() => {
+      findingDetailCloseRef.current?.focus();
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [findingDetailOpen, selectedFindingKey]);
 
   if (!scope) {
     return (
@@ -6913,11 +6972,6 @@ export function ProductFindingsPage() {
           >
             {refreshing || signalsRefreshing ? 'Refreshing...' : 'Refresh'}
           </button>
-          {selectedFinding?.source_url ? (
-            <a className="idt-btn idt-btn-primary" href={selectedFinding.source_url} target="_blank" rel="noreferrer">
-              Open in GitHub
-            </a>
-          ) : null}
         </div>
       </div>
 
@@ -6961,114 +7015,118 @@ export function ProductFindingsPage() {
       </div>
 
       {filteredFindings.length > 0 || filtersActive ? (
-      <details className="idt-repo-filter-panel">
-        <summary>
-          <span>Filters and sorting</span>
-          <small>{filteredFindings.length ? `${filteredFindings.length} findings shown` : 'No findings in scope'}</small>
-        </summary>
-        <div className="idt-repo-finding-filters">
-          <label>
-            Repository scan
-            <select value={repoScanFilter} onChange={(event) => setRepoScanFilter(event.target.value)}>
-              <option value="">All repository scans</option>
-              {repoScans.map((scan) => (
-                <option key={scan.id} value={scan.id}>
-                  {canonicalGitHubRepositoryDisplay(scan.repository)} · {formatTokenLabel(scan.status)}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label>
-            Severity
-            <select
-              value={severityFilter}
-              onChange={(event) => setSeverityFilter(event.target.value as (typeof REPO_FINDING_SEVERITY_FILTERS)[number])}
-            >
-              {REPO_FINDING_SEVERITY_FILTERS.map((value) => (
-                <option key={value} value={value}>
-                  {value === 'all' ? 'All severities' : formatTokenLabel(value)}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label>
-            Type
-            <select value={typeFilter} onChange={(event) => setTypeFilter(event.target.value as (typeof REPO_FINDING_TYPE_FILTERS)[number])}>
-              {REPO_FINDING_TYPE_FILTERS.map((value) => (
-                <option key={value} value={value}>
-                  {value === 'all' ? 'All finding types' : formatTokenLabel(value)}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label>
-            Sort by
-            <select value={sortBy} onChange={(event) => setSortBy(event.target.value as (typeof REPO_FINDING_SORT_FIELDS)[number])}>
-              {REPO_FINDING_SORT_FIELDS.map((value) => (
-                <option key={value} value={value}>
-                  {SORT_LABEL_BY_FIELD[value]}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label>
-            Sort order
-            <select value={sortOrder} onChange={(event) => setSortOrder(event.target.value as 'asc' | 'desc')}>
-              <option value="asc">Ascending</option>
-              <option value="desc">Descending</option>
-            </select>
-          </label>
-          <label>
-            Lifecycle status
-            <select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value as (typeof REPO_FINDING_STATUS_FILTERS)[number])}>
-              {REPO_FINDING_STATUS_FILTERS.map((value) => (
-                <option key={value} value={value}>
-                  {formatTokenLabel(value)}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label>
-            Assignee
-            <input
-              type="text"
-              placeholder="Filter by assignee"
-              value={assigneeFilter}
-              onChange={(event) => setAssigneeFilter(event.target.value)}
-            />
-          </label>
-          <label>
-            Source
-            <input
-              type="text"
-              placeholder="Filter by source (for example github_secret_scanning)"
-              value={sourceFilter}
-              onChange={(event) => setSourceFilter(event.target.value)}
-            />
-          </label>
-          <label>
-            Min confidence
-            <input
-              type="number"
-              step="0.01"
-              min="0"
-              max="1"
-              placeholder="e.g. 0.7"
-              value={minConfidenceFilter}
-              onChange={(event) => setMinConfidenceFilter(event.target.value)}
-            />
-          </label>
-        </div>
-      </details>
+        <details className="idt-repo-filter-panel" aria-label="Repository finding filters and sorting" open>
+          <summary className="idt-repo-filter-panel-header">
+            <span>Filters and sorting</span>
+            <small>{filteredFindings.length ? `${filteredFindings.length} findings shown` : 'No findings in scope'}</small>
+          </summary>
+          <div className="idt-repo-finding-filters">
+            <label>
+              Repository scan
+              <select value={repoScanFilter} onChange={(event) => setRepoScanFilter(event.target.value)}>
+                <option value="">All repository scans</option>
+                {repoScans.map((scan) => (
+                  <option key={scan.id} value={scan.id}>
+                    {canonicalGitHubRepositoryDisplay(scan.repository)} · {formatTokenLabel(scan.status)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Severity
+              <select
+                value={severityFilter}
+                onChange={(event) => setSeverityFilter(event.target.value as (typeof REPO_FINDING_SEVERITY_FILTERS)[number])}
+              >
+                {REPO_FINDING_SEVERITY_FILTERS.map((value) => (
+                  <option key={value} value={value}>
+                    {value === 'all' ? 'All severities' : formatTokenLabel(value)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Type
+              <select value={typeFilter} onChange={(event) => setTypeFilter(event.target.value as (typeof REPO_FINDING_TYPE_FILTERS)[number])}>
+                {REPO_FINDING_TYPE_FILTERS.map((value) => (
+                  <option key={value} value={value}>
+                    {value === 'all' ? 'All finding types' : formatTokenLabel(value)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Sort by
+              <select value={sortBy} onChange={(event) => setSortBy(event.target.value as (typeof REPO_FINDING_SORT_FIELDS)[number])}>
+                {REPO_FINDING_SORT_FIELDS.map((value) => (
+                  <option key={value} value={value}>
+                    {SORT_LABEL_BY_FIELD[value]}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Sort order
+              <select value={sortOrder} onChange={(event) => setSortOrder(event.target.value as 'asc' | 'desc')}>
+                <option value="asc">Ascending</option>
+                <option value="desc">Descending</option>
+              </select>
+            </label>
+            <label>
+              Lifecycle status
+              <select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value as (typeof REPO_FINDING_STATUS_FILTERS)[number])}>
+                {REPO_FINDING_STATUS_FILTERS.map((value) => (
+                  <option key={value} value={value}>
+                    {formatTokenLabel(value)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Assignee
+              <input
+                type="text"
+                placeholder="Filter by assignee"
+                value={assigneeFilter}
+                onChange={(event) => setAssigneeFilter(event.target.value)}
+              />
+            </label>
+            <label>
+              Source
+              <input
+                type="text"
+                placeholder="Source name"
+                value={sourceFilter}
+                onChange={(event) => setSourceFilter(event.target.value)}
+              />
+            </label>
+            <label>
+              Min confidence
+              <input
+                type="number"
+                step="0.01"
+                min="0"
+                max="1"
+                placeholder="e.g. 0.7"
+                value={minConfidenceFilter}
+                onChange={(event) => setMinConfidenceFilter(event.target.value)}
+              />
+            </label>
+          </div>
+        </details>
       ) : null}
 
       <div className="idt-repo-finding-layout">
         <div className="idt-repo-finding-list">
           <div className="idt-repo-finding-list-header">
             <h3>Repository findings</h3>
-            <p>{filteredFindings.length ? `${filteredFindings.length} findings in scope` : 'No findings match the current filters.'}</p>
+            <p>
+              {filteredFindings.length
+                ? `${findingHierarchy.length} repositories grouped by scan date and severity`
+                : 'No findings match the current filters.'}
+            </p>
           </div>
-          {findingGroups.length === 0 ? (
+          {findingHierarchy.length === 0 ? (
             filtersActive ? (
               <AppShellEmptyState
                 title="No findings match these filters"
@@ -7086,81 +7144,197 @@ export function ProductFindingsPage() {
               />
             )
           ) : (
-            <div>
-              {findingGroups.map((group) => {
-                const items = (
-                  <div className="idt-repo-finding-items" role="list">
-                    {group.findings.map((finding) => {
-                      const repositoryValue = repoFindingRepositoryValue(finding, repoScansByID);
-                      const repositoryLabel = canonicalGitHubRepositoryDisplay(repositoryValue) || 'Repository unavailable';
-                      const selectionKey = buildRepoFindingSelectionKey(finding);
-                      const isSelected = selectedFindingKey === selectionKey;
-                      const lifecycle = normalizeRepoFindingLifecycleStatus(finding.lifecycle_status);
-                      const triageStatus = normalizeFindingStatus(finding.triage?.status);
-                      return (
-                        <button
-                          key={selectionKey}
-                          type="button"
-                          role="listitem"
-                          className={`idt-repo-finding-row${isSelected ? ' is-selected' : ''}`}
-                          onClick={() => selectRepoFinding(selectionKey)}
-                        >
-                          <SourceLogoMark provider="github" className="is-row" />
-                          <div className="idt-repo-finding-row-copy">
-                            <div className="idt-repo-finding-row-top">
-                              <strong>{finding.title}</strong>
-                              <span className={repoFindingSeverityClass(finding.severity)}>{formatTokenLabel(finding.severity)}</span>
-                            </div>
-                            <p>{finding.human_summary}</p>
-                            <div className="idt-repo-finding-row-meta">
-                              <span>{repositoryLabel}</span>
-                              <span>{repoFindingLocationLabel(finding)}</span>
-                              <span>{formatTokenLabel(finding.type)}</span>
-                              <span>{`Confidence ${formatConfidenceScore(finding.confidence_score)}`}</span>
-                            </div>
-                            <div className="idt-repo-finding-row-meta">
-                              <span className={repoFindingStatusClass(lifecycle)}>{formatTokenLabel(lifecycle)}</span>
-                              <span>{`Source ${finding.adapter_source || 'native'}`}</span>
-                              <span>{`Owner ${finding.owner || finding.triage?.assignee || 'Unassigned'}`}</span>
-                              <span>{`Triage ${formatTokenLabel(triageStatus)}`}</span>
-                            </div>
-                          </div>
-                        </button>
-                      );
-                    })}
-                  </div>
-                );
-
-                if (!group.label) {
-                  return <div key={group.key}>{items}</div>;
-                }
+            <div className="idt-repo-finding-hierarchy">
+              {findingHierarchy.map((repositoryGroup, repositoryIndex) => {
+                const criticalCount = repositoryGroup.findings.filter(
+                  (finding) => normalizeValue(finding.severity).toLowerCase() === 'critical'
+                ).length;
+                const highCount = repositoryGroup.findings.filter(
+                  (finding) => normalizeValue(finding.severity).toLowerCase() === 'high'
+                ).length;
+                const latestScanLabel = repositoryGroup.scanGroups[0]?.label ?? 'Scan date unavailable';
 
                 return (
-                  <section className="idt-repo-finding-group" key={group.key}>
-                    <h4>
-                      {formatTokenLabel(group.label)} · {group.findings.length}
-                    </h4>
-                    {items}
-                  </section>
+                  <details
+                    className="idt-repo-finding-bucket idt-repo-finding-repository"
+                    key={repositoryGroup.key}
+                    {...(repositoryIndex === 0 ? { open: true } : {})}
+                  >
+                    <summary className="idt-repo-repository-summary">
+                      <span className="idt-repo-summary-main">
+                        <span className="idt-repo-summary-icon" aria-hidden="true">
+                          <FolderKanban size={18} strokeWidth={2} />
+                        </span>
+                        <span>
+                          <span className="idt-repo-summary-label">Repository</span>
+                          <strong>{repositoryGroup.label}</strong>
+                        </span>
+                      </span>
+                      <span className="idt-repo-summary-metrics" aria-label="Repository finding summary">
+                        <span>
+                          <strong>{repositoryGroup.findings.length}</strong>
+                          <small>Findings</small>
+                        </span>
+                        <span>
+                          <strong>{criticalCount + highCount}</strong>
+                          <small>High risk</small>
+                        </span>
+                        <span>
+                          <strong>{latestScanLabel}</strong>
+                          <small>Latest scan</small>
+                        </span>
+                      </span>
+                    </summary>
+                    <div className="idt-repo-finding-bucket-body idt-repo-scan-timeline">
+                      {repositoryGroup.scanGroups.map((scanGroup, scanIndex) => (
+                        <details
+                          className="idt-repo-finding-bucket idt-repo-finding-scan"
+                          key={scanGroup.key}
+                          {...(repositoryIndex === 0 && scanIndex === 0 ? { open: true } : {})}
+                        >
+                          <summary className="idt-repo-scan-summary">
+                            <span className="idt-repo-scan-node" aria-hidden="true" />
+                            <span className="idt-repo-scan-copy">
+                              <span>Scan date</span>
+                              <strong>{scanGroup.label}</strong>
+                            </span>
+                            <span className="idt-repo-scan-meta">
+                              <span>{scanGroup.findings.length} findings</span>
+                              <span>{scanGroup.severityGroups.length} severity groups</span>
+                            </span>
+                          </summary>
+                          <div className="idt-repo-finding-bucket-body idt-repo-severity-lanes">
+                            {scanGroup.severityGroups.map((severityGroup, severityIndex) => (
+                              <details
+                                className={`idt-repo-finding-bucket idt-repo-finding-severity-group is-${severityGroup.label}`}
+                                key={severityGroup.key}
+                                {...(repositoryIndex === 0 && scanIndex === 0 && severityIndex === 0
+                                  ? { open: true }
+                                  : {})}
+                              >
+                                <summary className="idt-repo-severity-summary">
+                                  <span className="idt-repo-severity-copy">
+                                    <span className={repoFindingSeverityClass(severityGroup.label)}>
+                                      {formatTokenLabel(severityGroup.label)}
+                                    </span>
+                                    <strong>{severityGroup.label === 'critical' ? 'Immediate attention' : `${formatTokenLabel(severityGroup.label)} risk`}</strong>
+                                  </span>
+                                  <span className="idt-repo-severity-count">
+                                    <strong>{severityGroup.findings.length}</strong>
+                                    <small>findings</small>
+                                  </span>
+                                </summary>
+                                <div className="idt-repo-finding-items" role="list">
+                                  {severityGroup.findings.map((finding) => {
+                                    const repositoryValue = repoFindingRepositoryValue(finding, repoScansByID);
+                                    const repositoryLabel =
+                                      canonicalGitHubRepositoryDisplay(repositoryValue) || 'Repository unavailable';
+                                    const selectionKey = buildRepoFindingSelectionKey(finding);
+                                    const isSelected = selectedFindingKey === selectionKey;
+                                    const lifecycle = normalizeRepoFindingLifecycleStatus(finding.lifecycle_status);
+                                    const triageStatus = normalizeFindingStatus(finding.triage?.status);
+                                    return (
+                                      <button
+                                        key={selectionKey}
+                                        type="button"
+                                        role="listitem"
+                                        aria-haspopup="dialog"
+                                        className={`idt-repo-finding-row${isSelected ? ' is-selected' : ''}`}
+                                        onClick={() => selectRepoFinding(selectionKey)}
+                                      >
+                                        <SourceLogoMark provider="github" className="is-row" />
+                                        <div className="idt-repo-finding-row-copy">
+                                          <div className="idt-repo-finding-row-top">
+                                            <strong>{finding.title}</strong>
+                                            <span className={repoFindingSeverityClass(finding.severity)}>
+                                              {formatTokenLabel(finding.severity)}
+                                            </span>
+                                          </div>
+                                          <p>{finding.human_summary}</p>
+                                          <div className="idt-repo-finding-row-meta">
+                                            <span>{repositoryLabel}</span>
+                                            <span>{repoFindingLocationLabel(finding)}</span>
+                                            <span>{formatTokenLabel(finding.type)}</span>
+                                            <span>{`Confidence ${formatConfidenceScore(finding.confidence_score)}`}</span>
+                                          </div>
+                                          <div className="idt-repo-finding-row-meta">
+                                            <span className={repoFindingStatusClass(lifecycle)}>{formatTokenLabel(lifecycle)}</span>
+                                            <span>{`Source ${finding.adapter_source || 'native'}`}</span>
+                                            <span>{`Owner ${finding.owner || finding.triage?.assignee || 'Unassigned'}`}</span>
+                                            <span>{`Triage ${formatTokenLabel(triageStatus)}`}</span>
+                                          </div>
+                                        </div>
+                                      </button>
+                                    );
+                                  })}
+                                </div>
+                              </details>
+                            ))}
+                          </div>
+                        </details>
+                      ))}
+                    </div>
+                  </details>
                 );
               })}
             </div>
           )}
         </div>
+      </div>
 
-        {findingGroups.length > 0 || filtersActive ? (
-        <aside className="idt-repo-finding-detail">
-          {selectedFinding ? (
-            <>
-              <div className="idt-repo-finding-detail-copy">
-                <div className="idt-source-config-title">
-                  <SourceLogoMark provider="github" className="is-hero" />
-                  <div>
-                    <p className="idt-app-kicker">Finding detail</p>
-                    <h3>{selectedFinding.title}</h3>
-                    <p>{selectedFinding.human_summary}</p>
-                  </div>
+      {findingDetailOpen && selectedFinding ? (
+        <div
+          className="idt-modal-backdrop idt-repo-finding-modal-backdrop"
+          role="presentation"
+          onMouseDown={(event) => {
+            if (event.target === event.currentTarget) {
+              setFindingDetailOpen(false);
+            }
+          }}
+        >
+          <section
+            aria-modal="true"
+            aria-labelledby="repo-finding-detail-title"
+            className="idt-repo-finding-detail-modal"
+            role="dialog"
+            onKeyDown={(event) => {
+              if (event.key === 'Escape') {
+                event.preventDefault();
+                setFindingDetailOpen(false);
+              }
+            }}
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <header className="idt-repo-finding-detail-modal-header">
+              <div className="idt-source-config-title">
+                <SourceLogoMark provider="github" className="is-hero" />
+                <div>
+                  <p className="idt-app-kicker">Finding detail</p>
+                  <h3 id="repo-finding-detail-title">{selectedFinding.title}</h3>
+                  <p>{selectedFinding.human_summary}</p>
                 </div>
+              </div>
+              <button
+                ref={findingDetailCloseRef}
+                className="idt-icon-btn idt-repo-finding-modal-close"
+                type="button"
+                aria-label="Close finding detail"
+                autoFocus
+                onClick={() => setFindingDetailOpen(false)}
+              >
+                <X size={16} strokeWidth={2} aria-hidden="true" />
+              </button>
+            </header>
+
+            <div className="idt-repo-finding-detail-modal-body">
+              <div className="idt-repo-finding-detail-pills" aria-label="Finding status summary">
+                <span className={repoFindingSeverityClass(selectedFinding.severity)}>
+                  {formatTokenLabel(selectedFinding.severity)}
+                </span>
+                <span className={repoFindingStatusClass(normalizeRepoFindingLifecycleStatus(selectedFinding.lifecycle_status))}>
+                  {formatTokenLabel(normalizeRepoFindingLifecycleStatus(selectedFinding.lifecycle_status))}
+                </span>
+                <span>{`Confidence ${formatConfidenceScore(selectedFinding.confidence_score)}`}</span>
               </div>
 
               <dl className="idt-repo-finding-facts">
@@ -7169,8 +7343,8 @@ export function ProductFindingsPage() {
                   <dd>{canonicalGitHubRepositoryDisplay(repoFindingRepositoryValue(selectedFinding, repoScansByID)) || 'Unavailable'}</dd>
                 </div>
                 <div>
-                  <dt>Confidence</dt>
-                  <dd>{formatConfidenceScore(selectedFinding.confidence_score)}</dd>
+                  <dt>Scan date</dt>
+                  <dd>{repoFindingScanDateLabel(selectedFinding, repoScansByID)}</dd>
                 </div>
                 <div>
                   <dt>Location</dt>
@@ -7181,12 +7355,12 @@ export function ProductFindingsPage() {
                   <dd>{selectedFinding.commit || 'Unavailable'}</dd>
                 </div>
                 <div>
-                  <dt>Lifecycle status</dt>
-                  <dd>{formatTokenLabel(normalizeRepoFindingLifecycleStatus(selectedFinding.lifecycle_status))}</dd>
-                </div>
-                <div>
                   <dt>Owner</dt>
                   <dd>{selectedFinding.owner || selectedFinding.triage?.assignee || 'Unassigned'}</dd>
+                </div>
+                <div>
+                  <dt>Triage status</dt>
+                  <dd>{formatTokenLabel(normalizeFindingStatus(selectedFinding.triage?.status))}</dd>
                 </div>
                 <div>
                   <dt>First seen</dt>
@@ -7201,10 +7375,6 @@ export function ProductFindingsPage() {
                   <dd>{selectedFinding.fixed_at ? formatDateLabel(selectedFinding.fixed_at) : 'Not fixed yet'}</dd>
                 </div>
                 <div>
-                  <dt>Triage status</dt>
-                  <dd>{formatTokenLabel(normalizeFindingStatus(selectedFinding.triage?.status))}</dd>
-                </div>
-                <div>
                   <dt>Detector</dt>
                   <dd>{selectedFinding.detector ? formatTokenLabel(selectedFinding.detector) : 'Unavailable'}</dd>
                 </div>
@@ -7212,26 +7382,43 @@ export function ProductFindingsPage() {
                   <dt>Last triage update</dt>
                   <dd>{selectedFinding.triage?.updated_at ? formatDateLabel(selectedFinding.triage.updated_at) : 'Never'}</dd>
                 </div>
+                <div>
+                  <dt>Source</dt>
+                  <dd>{selectedFinding.adapter_source || 'native'}</dd>
+                </div>
               </dl>
 
-              {selectedFinding.source_url ? (
-                <a className="idt-repo-finding-link" href={selectedFinding.source_url} target="_blank" rel="noreferrer">
-                  {selectedFinding.source_url}
-                </a>
-              ) : (
-                <div className="idt-app-alert">GitHub line link unavailable for this finding. Rescan the repository to refresh line-link metadata.</div>
-              )}
-
-              {selectedFinding.line_snippet ? (
-                <div className="idt-repo-finding-code">
-                  <span>Evidence line</span>
-                  <pre>
-                    <code>{selectedFinding.line_snippet}</code>
-                  </pre>
+              <section className="idt-repo-finding-detail-section">
+                <div className="idt-repo-finding-section-head">
+                  <div>
+                    <h4>Evidence</h4>
+                    <p>{repoFindingLocationLabel(selectedFinding)}</p>
+                  </div>
+                  {selectedFinding.source_url ? (
+                    <a className="idt-btn idt-btn-primary" href={selectedFinding.source_url} target="_blank" rel="noreferrer">
+                      <ExternalLink size={14} strokeWidth={2} aria-hidden="true" />
+                      Open in GitHub
+                    </a>
+                  ) : null}
                 </div>
-              ) : null}
+                {selectedFinding.source_url ? (
+                  <a className="idt-repo-finding-link" href={selectedFinding.source_url} target="_blank" rel="noreferrer">
+                    {selectedFinding.source_url}
+                  </a>
+                ) : (
+                  <div className="idt-app-alert">GitHub line link unavailable for this finding. Rescan the repository to refresh line-link metadata.</div>
+                )}
+                {selectedFinding.line_snippet ? (
+                  <div className="idt-repo-finding-code">
+                    <span>Evidence line</span>
+                    <pre>
+                      <code>{selectedFinding.line_snippet}</code>
+                    </pre>
+                  </div>
+                ) : null}
+              </section>
 
-              <div className="idt-repo-finding-remediation">
+              <section className="idt-repo-finding-detail-section idt-repo-finding-remediation">
                 <h4>Remediation</h4>
                 <p>{selectedFinding.remediation}</p>
                 <button
@@ -7357,9 +7544,9 @@ export function ProductFindingsPage() {
                     ) : null}
                   </div>
                 ) : null}
-              </div>
+              </section>
 
-              <div className="idt-repo-finding-triage-form">
+              <section className="idt-repo-finding-detail-section idt-repo-finding-triage-form">
                 <h4>Workflow controls</h4>
                 {workflowError ? <div className="idt-app-alert idt-app-alert-error">{workflowError}</div> : null}
                 {workflowSuccess ? <div className="idt-app-alert idt-app-alert-success">{workflowSuccess}</div> : null}
@@ -7430,20 +7617,14 @@ export function ProductFindingsPage() {
                 >
                   {workflowLoading ? 'Saving...' : 'Apply workflow'}
                 </button>
-              </div>
-            </>
-          ) : (
-            <AppShellEmptyState
-              title="Select a finding"
-              body="Choose one repository finding to inspect commit, detector, and GitHub line-link context."
-            />
-          )}
-        </aside>
-        ) : null}
-      </div>
+              </section>
+            </div>
+          </section>
+        </div>
+      ) : null}
 
-      <div className="idt-repo-finding-trend" aria-label="Repository risk graph summary">
-        <div className="idt-repo-finding-trend-head">
+      <details className="idt-repo-finding-trend idt-repo-analysis-panel" aria-label="Repository risk graph summary">
+        <summary className="idt-repo-finding-trend-head">
           <h3>Risk graph</h3>
           {trendDisplayLoading ? <span className="idt-app-alert idt-app-alert-success">Loading graph</span> : null}
           <span className="idt-repo-finding-trend-subtitle">
@@ -7451,7 +7632,7 @@ export function ProductFindingsPage() {
               ? `${repoRiskGraph.nodes.length} nodes · ${repoRiskGraph.edges.length} paths · ${canonicalGitHubRepositoryDisplay(repoRiskGraph.repository) || repoRiskGraph.repository || 'repository scope'}`
               : 'No graph loaded yet'}
           </span>
-        </div>
+        </summary>
         {riskGraphSummary ? (
           <div className="idt-repo-finding-trend-rows">
             <article className="idt-repo-finding-trend-row">
@@ -7494,14 +7675,14 @@ export function ProductFindingsPage() {
             body="Run a repository exposure scan so machine-identity paths and finding risk scores can appear here."
           />
         )}
-      </div>
+      </details>
 
-      <div className="idt-repo-finding-trend">
-        <div className="idt-repo-finding-trend-head">
+      <details className="idt-repo-finding-trend idt-repo-analysis-panel">
+        <summary className="idt-repo-finding-trend-head">
           <h3>Finding trend</h3>
           {trendDisplayLoading ? <span className="idt-app-alert idt-app-alert-success">Loading trend</span> : null}
           <span className="idt-repo-finding-trend-subtitle">{totalTrendItems > 0 ? `${totalTrendItems} total events in window` : 'No trend items yet'}</span>
-        </div>
+        </summary>
         <div className="idt-repo-finding-trend-rows">
           {totalTrendItems === 0 ? (
             <AppShellEmptyState
@@ -7525,7 +7706,7 @@ export function ProductFindingsPage() {
             ))
           )}
         </div>
-      </div>
+      </details>
     </section>
   );
 }

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -6286,6 +6286,7 @@ export function ProductFindingsPage() {
   const remediationPublishRequestRef = useRef(0);
   const findingDetailCloseRef = useRef<HTMLButtonElement | null>(null);
   const findingDetailModalRef = useRef<HTMLElement | null>(null);
+  const findingDetailOpenerRef = useRef<HTMLElement | null>(null);
 
   const hasTriageAccess = Boolean(me?.role === 'owner' || me?.role === 'admin');
 
@@ -6311,7 +6312,7 @@ export function ProductFindingsPage() {
   const handleFindingDetailModalKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
     if (event.key === 'Escape') {
       event.preventDefault();
-      setFindingDetailOpen(false);
+      closeFindingDetail();
       return;
     }
 
@@ -6712,11 +6713,19 @@ export function ProductFindingsPage() {
   // itself, so a slow response cannot land on a newly selected finding. Bumping
   // the guards here closes the race window that exists if invalidation is left
   // to a post-render effect.
-  const selectRepoFinding = (key: string, openDetail = true) => {
+  const selectRepoFinding = (key: string, openDetail = true, opener: HTMLElement | null = null) => {
     remediationPreviewRequestRef.current += 1;
     remediationPublishRequestRef.current += 1;
+    const willOpenDialog = Boolean(key) && openDetail;
+    if (willOpenDialog) {
+      findingDetailOpenerRef.current =
+        opener ??
+        (typeof document !== 'undefined' && document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null);
+    }
     setSelectedFindingKey(key);
-    setFindingDetailOpen(Boolean(key) && openDetail);
+    setFindingDetailOpen(willOpenDialog);
   };
 
   const handlePublishRemediation = async () => {
@@ -6881,6 +6890,18 @@ export function ProductFindingsPage() {
     });
     return () => window.cancelAnimationFrame(frame);
   }, [findingDetailOpen, selectedFindingKey]);
+
+  const closeFindingDetail = () => {
+    setFindingDetailOpen(false);
+    if (typeof document === 'undefined') {
+      return;
+    }
+    const opener = findingDetailOpenerRef.current;
+    findingDetailOpenerRef.current = null;
+    if (opener && document.contains(opener) && typeof opener.focus === 'function') {
+      opener.focus();
+    }
+  };
 
   if (!scope) {
     return (
@@ -7353,7 +7374,7 @@ export function ProductFindingsPage() {
                                         role="listitem"
                                         aria-haspopup="dialog"
                                         className={`idt-repo-finding-row${isSelected ? ' is-selected' : ''}`}
-                                        onClick={() => selectRepoFinding(selectionKey)}
+                                        onClick={(event) => selectRepoFinding(selectionKey, true, event.currentTarget)}
                                       >
                                         <SourceLogoMark provider="github" className="is-row" />
                                         <div className="idt-repo-finding-row-copy">
@@ -7401,7 +7422,7 @@ export function ProductFindingsPage() {
           role="presentation"
           onMouseDown={(event) => {
             if (event.target === event.currentTarget) {
-              setFindingDetailOpen(false);
+              closeFindingDetail();
             }
           }}
         >
@@ -7430,7 +7451,7 @@ export function ProductFindingsPage() {
                 type="button"
                 aria-label="Close finding detail"
                 autoFocus
-                onClick={() => setFindingDetailOpen(false)}
+                onClick={() => closeFindingDetail()}
               >
                 <X size={16} strokeWidth={2} aria-hidden="true" />
               </button>

--- a/web/src/repoFindingDisplay.test.ts
+++ b/web/src/repoFindingDisplay.test.ts
@@ -3,6 +3,7 @@ import type { Finding as ApiFinding } from './api/client';
 import {
   buildRepoFindingSelectionKey,
   findRepoFindingBySelectionKey,
+  groupRepoFindingsByRepositoryDateSeverity,
   groupRepoFindingsForDisplay,
   mergeUpdatedRepoFinding
 } from './repoFindingDisplay';
@@ -133,5 +134,69 @@ describe('groupRepoFindingsForDisplay', () => {
     expect(merged[1].title).toBe('updated second finding');
     expect(merged[1].repository).toBe('owner/repo-b');
     expect(merged[1].scan_id).toBe('scan-2');
+  });
+});
+
+describe('groupRepoFindingsByRepositoryDateSeverity', () => {
+  it('groups findings by repository, scan date, and severity', () => {
+    const findings = [
+      {
+        ...finding('repo-b-medium', 'medium'),
+        repository: 'owner/repo-b',
+        created_at: '2026-05-14T00:00:00Z'
+      },
+      {
+        ...finding('repo-a-critical', 'critical'),
+        repository: 'owner/repo-a',
+        created_at: '2026-05-15T00:00:00Z'
+      },
+      {
+        ...finding('repo-a-high', 'high'),
+        repository: 'owner/repo-a',
+        created_at: '2026-05-15T01:00:00Z'
+      }
+    ];
+
+    const groups = groupRepoFindingsByRepositoryDateSeverity(findings, {
+      scanDateForFinding: (item) => (item.repository === 'owner/repo-b' ? 'May 14, 2026' : 'May 15, 2026'),
+      scanSortValueForFinding: (item) => new Date(item.created_at).getTime()
+    });
+
+    expect(groups.map((group) => group.label)).toEqual(['owner/repo-a', 'owner/repo-b']);
+    expect(groups[0].findings.map((item) => item.id)).toEqual(['repo-a-critical', 'repo-a-high']);
+    expect(groups[0].scanGroups).toHaveLength(1);
+    expect(groups[0].scanGroups[0].label).toBe('May 15, 2026');
+    expect(groups[0].scanGroups[0].severityGroups.map((group) => group.label)).toEqual(['critical', 'high']);
+    expect(groups[1].scanGroups[0].severityGroups.map((group) => group.label)).toEqual(['medium']);
+  });
+
+  it('keeps unknown severities last for descending triage order', () => {
+    const groups = groupRepoFindingsByRepositoryDateSeverity(
+      [
+        { ...finding('unknown-item', 'unexpected'), repository: 'owner/repo' },
+        { ...finding('critical-item', 'critical'), repository: 'owner/repo' }
+      ],
+      {
+        scanDateForFinding: () => 'May 15, 2026',
+        scanSortValueForFinding: () => 1
+      }
+    );
+
+    expect(groups[0].scanGroups[0].severityGroups.map((group) => group.label)).toEqual(['critical', 'unknown']);
+  });
+
+  it('puts repositories with the newest scans before alphabetic order', () => {
+    const groups = groupRepoFindingsByRepositoryDateSeverity(
+      [
+        { ...finding('alpha-older', 'critical'), repository: 'alpha/repo', created_at: '2026-05-24T00:00:00Z' },
+        { ...finding('zeta-newer', 'high'), repository: 'zeta/repo', created_at: '2026-05-25T00:00:00Z' }
+      ],
+      {
+        scanDateForFinding: (item) => (item.repository === 'alpha/repo' ? 'May 24, 2026' : 'May 25, 2026'),
+        scanSortValueForFinding: (item) => new Date(item.created_at).getTime()
+      }
+    );
+
+    expect(groups.map((group) => group.label)).toEqual(['zeta/repo', 'alpha/repo']);
   });
 });

--- a/web/src/repoFindingDisplay.test.ts
+++ b/web/src/repoFindingDisplay.test.ts
@@ -199,4 +199,36 @@ describe('groupRepoFindingsByRepositoryDateSeverity', () => {
 
     expect(groups.map((group) => group.label)).toEqual(['zeta/repo', 'alpha/repo']);
   });
+
+  it('honors ascending order when ranking repositories by scan date', () => {
+    const groups = groupRepoFindingsByRepositoryDateSeverity(
+      [
+        { ...finding('alpha-older', 'critical'), repository: 'alpha/repo', created_at: '2026-05-24T00:00:00Z' },
+        { ...finding('zeta-newer', 'high'), repository: 'zeta/repo', created_at: '2026-05-25T00:00:00Z' }
+      ],
+      {
+        scanDateForFinding: (item) => (item.repository === 'alpha/repo' ? 'May 24, 2026' : 'May 25, 2026'),
+        scanSortValueForFinding: (item) => new Date(item.created_at).getTime(),
+        sortOrder: 'asc'
+      }
+    );
+
+    expect(groups.map((group) => group.label)).toEqual(['alpha/repo', 'zeta/repo']);
+  });
+
+  it('honors ascending order when ranking scan groups inside a repository', () => {
+    const groups = groupRepoFindingsByRepositoryDateSeverity(
+      [
+        { ...finding('newer-scan', 'critical'), repository: 'owner/repo', created_at: '2026-05-25T00:00:00Z' },
+        { ...finding('older-scan', 'high'), repository: 'owner/repo', created_at: '2026-05-24T00:00:00Z' }
+      ],
+      {
+        scanDateForFinding: (item) => (item.id === 'older-scan' ? 'May 24, 2026' : 'May 25, 2026'),
+        scanSortValueForFinding: (item) => new Date(item.created_at).getTime(),
+        sortOrder: 'asc'
+      }
+    );
+
+    expect(groups[0].scanGroups.map((group) => group.label)).toEqual(['May 24, 2026', 'May 25, 2026']);
+  });
 });

--- a/web/src/repoFindingDisplay.test.ts
+++ b/web/src/repoFindingDisplay.test.ts
@@ -159,7 +159,8 @@ describe('groupRepoFindingsByRepositoryDateSeverity', () => {
 
     const groups = groupRepoFindingsByRepositoryDateSeverity(findings, {
       scanDateForFinding: (item) => (item.repository === 'owner/repo-b' ? 'May 14, 2026' : 'May 15, 2026'),
-      scanSortValueForFinding: (item) => new Date(item.created_at).getTime()
+      scanSortValueForFinding: (item) => new Date(item.created_at).getTime(),
+      sortBy: 'severity'
     });
 
     expect(groups.map((group) => group.label)).toEqual(['owner/repo-a', 'owner/repo-b']);
@@ -230,5 +231,79 @@ describe('groupRepoFindingsByRepositoryDateSeverity', () => {
     );
 
     expect(groups[0].scanGroups.map((group) => group.label)).toEqual(['May 24, 2026', 'May 25, 2026']);
+  });
+
+  it('honors severity sort when ranking repository groups', () => {
+    const groups = groupRepoFindingsByRepositoryDateSeverity(
+      [
+        { ...finding('newer-high', 'high'), repository: 'alpha/repo', created_at: '2026-05-25T00:00:00Z' },
+        { ...finding('older-critical', 'critical'), repository: 'zeta/repo', created_at: '2026-05-24T00:00:00Z' }
+      ],
+      {
+        scanDateForFinding: (item) => (item.repository === 'alpha/repo' ? 'May 25, 2026' : 'May 24, 2026'),
+        scanSortValueForFinding: (item) => new Date(item.created_at).getTime(),
+        sortBy: 'severity',
+        sortOrder: 'desc'
+      }
+    );
+
+    expect(groups.map((group) => group.label)).toEqual(['zeta/repo', 'alpha/repo']);
+  });
+
+  it('honors title sort when ranking repository and scan groups', () => {
+    const groups = groupRepoFindingsByRepositoryDateSeverity(
+      [
+        {
+          ...finding('newer-zulu', 'critical'),
+          repository: 'zeta/repo',
+          title: 'Zulu workflow issue',
+          created_at: '2026-05-25T00:00:00Z'
+        },
+        {
+          ...finding('older-alpha', 'high'),
+          repository: 'alpha/repo',
+          title: 'Alpha token exposure',
+          created_at: '2026-05-24T00:00:00Z'
+        },
+        {
+          ...finding('same-repo-beta', 'medium'),
+          repository: 'alpha/repo',
+          title: 'Beta database secret',
+          created_at: '2026-05-23T00:00:00Z'
+        }
+      ],
+      {
+        scanDateForFinding: (item) => {
+          if (item.id === 'same-repo-beta') return 'May 23, 2026';
+          return item.repository === 'alpha/repo' ? 'May 24, 2026' : 'May 25, 2026';
+        },
+        scanSortValueForFinding: (item) => new Date(item.created_at).getTime(),
+        sortBy: 'title',
+        sortOrder: 'asc'
+      }
+    );
+
+    expect(groups.map((group) => group.label)).toEqual(['alpha/repo', 'zeta/repo']);
+    expect(groups[0].scanGroups.map((group) => group.label)).toEqual(['May 24, 2026', 'May 23, 2026']);
+  });
+
+  it('sorts findings inside severity lanes by the selected field', () => {
+    const groups = groupRepoFindingsByRepositoryDateSeverity(
+      [
+        { ...finding('zulu-item', 'high'), repository: 'owner/repo', title: 'Zulu secret' },
+        { ...finding('alpha-item', 'high'), repository: 'owner/repo', title: 'Alpha secret' }
+      ],
+      {
+        scanDateForFinding: () => 'May 25, 2026',
+        scanSortValueForFinding: () => 1,
+        sortBy: 'title',
+        sortOrder: 'asc'
+      }
+    );
+
+    expect(groups[0].scanGroups[0].severityGroups[0].findings.map((item) => item.id)).toEqual([
+      'alpha-item',
+      'zulu-item'
+    ]);
   });
 });

--- a/web/src/repoFindingDisplay.ts
+++ b/web/src/repoFindingDisplay.ts
@@ -132,13 +132,14 @@ export function groupRepoFindingsByRepositoryDateSeverity(
   }
 
   const severityBuckets = options.sortOrder === 'asc' ? [...SEVERITY_ORDER].reverse() : [...SEVERITY_ORDER];
+  const sortDirection = options.sortOrder === 'asc' ? 1 : -1;
   const repositories = new Map<string, RepoFindingDisplayRepositoryGroup>();
   const scansByRepository = new Map<string, Map<string, RepoFindingDisplayScanGroup>>();
 
   for (const finding of findings) {
     const repositoryLabel =
       normalizeDisplayValue(options.repositoryForFinding?.(finding)) || fallbackRepositoryLabel(finding);
-    const repositoryKey = `repo:${repositoryLabel.toLowerCase() || stableFallbackFingerprint([finding.id, finding.scan_id])}`;
+    const repositoryKey = `repo:${repositoryLabel.toLowerCase()}`;
     let repositoryGroup = repositories.get(repositoryKey);
     if (!repositoryGroup) {
       repositoryGroup = {
@@ -171,14 +172,17 @@ export function groupRepoFindingsByRepositoryDateSeverity(
       repositoryGroup.scanGroups.push(scanGroup);
     }
 
-    scanGroup.sortValue = Math.max(scanGroup.sortValue, scanSortValue);
+    scanGroup.sortValue =
+      options.sortOrder === 'asc'
+        ? Math.min(scanGroup.sortValue, scanSortValue)
+        : Math.max(scanGroup.sortValue, scanSortValue);
     scanGroup.findings.push(finding);
   }
 
   for (const repositoryGroup of repositories.values()) {
     repositoryGroup.scanGroups.sort((left, right) => {
-      if (right.sortValue !== left.sortValue) {
-        return right.sortValue - left.sortValue;
+      if (left.sortValue !== right.sortValue) {
+        return (left.sortValue - right.sortValue) * sortDirection;
       }
       return left.label.localeCompare(right.label);
     });
@@ -206,10 +210,16 @@ export function groupRepoFindingsByRepositoryDateSeverity(
   return [...repositories.values()].sort((left, right) => {
     if (left.label === 'Repository unavailable') return 1;
     if (right.label === 'Repository unavailable') return -1;
-    const leftNewestScan = left.scanGroups[0]?.sortValue ?? 0;
-    const rightNewestScan = right.scanGroups[0]?.sortValue ?? 0;
-    if (rightNewestScan !== leftNewestScan) {
-      return rightNewestScan - leftNewestScan;
+    const leftScanSortValue =
+      options.sortOrder === 'asc'
+        ? Math.min(...left.scanGroups.map((group) => group.sortValue))
+        : Math.max(...left.scanGroups.map((group) => group.sortValue));
+    const rightScanSortValue =
+      options.sortOrder === 'asc'
+        ? Math.min(...right.scanGroups.map((group) => group.sortValue))
+        : Math.max(...right.scanGroups.map((group) => group.sortValue));
+    if (leftScanSortValue !== rightScanSortValue) {
+      return (leftScanSortValue - rightScanSortValue) * sortDirection;
     }
     const leftHighestSeverity = Math.min(...left.findings.map((finding) => severityRank(finding.severity)));
     const rightHighestSeverity = Math.min(...right.findings.map((finding) => severityRank(finding.severity)));

--- a/web/src/repoFindingDisplay.ts
+++ b/web/src/repoFindingDisplay.ts
@@ -11,6 +11,34 @@ export type RepoFindingDisplayGroup = {
   findings: ApiFinding[];
 };
 
+export type RepoFindingDisplaySeverityGroup = {
+  key: string;
+  label: string;
+  findings: ApiFinding[];
+};
+
+export type RepoFindingDisplayScanGroup = {
+  key: string;
+  label: string;
+  sortValue: number;
+  findings: ApiFinding[];
+  severityGroups: RepoFindingDisplaySeverityGroup[];
+};
+
+export type RepoFindingDisplayRepositoryGroup = {
+  key: string;
+  label: string;
+  findings: ApiFinding[];
+  scanGroups: RepoFindingDisplayScanGroup[];
+};
+
+type RepoFindingHierarchyOptions = {
+  repositoryForFinding?: (finding: ApiFinding) => string;
+  scanDateForFinding?: (finding: ApiFinding) => string;
+  scanSortValueForFinding?: (finding: ApiFinding) => number;
+  sortOrder?: RepoFindingSortOrder;
+};
+
 export type RepoFindingSelection = Partial<
   Pick<
     ApiFinding,
@@ -49,6 +77,42 @@ function normalizeSeverityBucket(value: unknown): (typeof SEVERITY_ORDER)[number
   return 'unknown';
 }
 
+function severityRank(value: unknown): number {
+  const rank = SEVERITY_ORDER.indexOf(normalizeSeverityBucket(value));
+  return rank === -1 ? SEVERITY_ORDER.length : rank;
+}
+
+function evidenceRepositoryValue(finding: ApiFinding): string {
+  const repository = finding.evidence?.repository;
+  return typeof repository === 'string' ? normalizeDisplayValue(repository) : '';
+}
+
+function fallbackRepositoryLabel(finding: ApiFinding): string {
+  return normalizeDisplayValue(finding.repository) || evidenceRepositoryValue(finding) || 'Repository unavailable';
+}
+
+function fallbackScanDateLabel(finding: ApiFinding): string {
+  const timestamp =
+    normalizeDisplayValue(finding.first_seen_at) ||
+    normalizeDisplayValue(finding.created_at) ||
+    'Scan date unavailable';
+  const parsed = new Date(timestamp);
+  if (Number.isNaN(parsed.getTime())) {
+    return timestamp;
+  }
+  return parsed.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric'
+  });
+}
+
+function fallbackScanSortValue(finding: ApiFinding): number {
+  const timestamp = normalizeDisplayValue(finding.first_seen_at) || normalizeDisplayValue(finding.created_at);
+  const parsed = new Date(timestamp);
+  return Number.isNaN(parsed.getTime()) ? 0 : parsed.getTime();
+}
+
 function stableFallbackFingerprint(values: string[]): string {
   const source = values.join('\u001f');
   let hash = 0x811c9dc5;
@@ -57,6 +121,103 @@ function stableFallbackFingerprint(values: string[]): string {
     hash = Math.imul(hash, 0x01000193);
   }
   return (hash >>> 0).toString(36);
+}
+
+export function groupRepoFindingsByRepositoryDateSeverity(
+  findings: ApiFinding[],
+  options: RepoFindingHierarchyOptions = {}
+): RepoFindingDisplayRepositoryGroup[] {
+  if (findings.length === 0) {
+    return [];
+  }
+
+  const severityBuckets = options.sortOrder === 'asc' ? [...SEVERITY_ORDER].reverse() : [...SEVERITY_ORDER];
+  const repositories = new Map<string, RepoFindingDisplayRepositoryGroup>();
+  const scansByRepository = new Map<string, Map<string, RepoFindingDisplayScanGroup>>();
+
+  for (const finding of findings) {
+    const repositoryLabel =
+      normalizeDisplayValue(options.repositoryForFinding?.(finding)) || fallbackRepositoryLabel(finding);
+    const repositoryKey = `repo:${repositoryLabel.toLowerCase() || stableFallbackFingerprint([finding.id, finding.scan_id])}`;
+    let repositoryGroup = repositories.get(repositoryKey);
+    if (!repositoryGroup) {
+      repositoryGroup = {
+        key: repositoryKey,
+        label: repositoryLabel,
+        findings: [],
+        scanGroups: []
+      };
+      repositories.set(repositoryKey, repositoryGroup);
+      scansByRepository.set(repositoryKey, new Map());
+    }
+
+    repositoryGroup.findings.push(finding);
+
+    const scanLabel = normalizeDisplayValue(options.scanDateForFinding?.(finding)) || fallbackScanDateLabel(finding);
+    const scanSortValue = options.scanSortValueForFinding?.(finding) ?? fallbackScanSortValue(finding);
+    const scanKey = `scan:${scanLabel.toLowerCase()}`;
+    const repositoryScans = scansByRepository.get(repositoryKey) ?? new Map<string, RepoFindingDisplayScanGroup>();
+    let scanGroup = repositoryScans.get(scanKey);
+    if (!scanGroup) {
+      scanGroup = {
+        key: `${repositoryKey}:${scanKey}`,
+        label: scanLabel,
+        sortValue: scanSortValue,
+        findings: [],
+        severityGroups: []
+      };
+      repositoryScans.set(scanKey, scanGroup);
+      scansByRepository.set(repositoryKey, repositoryScans);
+      repositoryGroup.scanGroups.push(scanGroup);
+    }
+
+    scanGroup.sortValue = Math.max(scanGroup.sortValue, scanSortValue);
+    scanGroup.findings.push(finding);
+  }
+
+  for (const repositoryGroup of repositories.values()) {
+    repositoryGroup.scanGroups.sort((left, right) => {
+      if (right.sortValue !== left.sortValue) {
+        return right.sortValue - left.sortValue;
+      }
+      return left.label.localeCompare(right.label);
+    });
+
+    for (const scanGroup of repositoryGroup.scanGroups) {
+      const severityMap = new Map<string, ApiFinding[]>();
+      for (const finding of scanGroup.findings) {
+        const severity = normalizeSeverityBucket(finding.severity);
+        severityMap.set(severity, [...(severityMap.get(severity) ?? []), finding]);
+      }
+      scanGroup.severityGroups = severityBuckets.reduce<RepoFindingDisplaySeverityGroup[]>((groups, severity) => {
+        const severityFindings = severityMap.get(severity);
+        if (severityFindings && severityFindings.length > 0) {
+          groups.push({
+            key: `${scanGroup.key}:severity:${severity}`,
+            label: severity,
+            findings: severityFindings
+          });
+        }
+        return groups;
+      }, []);
+    }
+  }
+
+  return [...repositories.values()].sort((left, right) => {
+    if (left.label === 'Repository unavailable') return 1;
+    if (right.label === 'Repository unavailable') return -1;
+    const leftNewestScan = left.scanGroups[0]?.sortValue ?? 0;
+    const rightNewestScan = right.scanGroups[0]?.sortValue ?? 0;
+    if (rightNewestScan !== leftNewestScan) {
+      return rightNewestScan - leftNewestScan;
+    }
+    const leftHighestSeverity = Math.min(...left.findings.map((finding) => severityRank(finding.severity)));
+    const rightHighestSeverity = Math.min(...right.findings.map((finding) => severityRank(finding.severity)));
+    if (leftHighestSeverity !== rightHighestSeverity) {
+      return leftHighestSeverity - rightHighestSeverity;
+    }
+    return left.label.localeCompare(right.label);
+  });
 }
 
 export function groupRepoFindingsForDisplay(

--- a/web/src/repoFindingDisplay.ts
+++ b/web/src/repoFindingDisplay.ts
@@ -36,6 +36,7 @@ type RepoFindingHierarchyOptions = {
   repositoryForFinding?: (finding: ApiFinding) => string;
   scanDateForFinding?: (finding: ApiFinding) => string;
   scanSortValueForFinding?: (finding: ApiFinding) => number;
+  sortBy?: RepoFindingSortField;
   sortOrder?: RepoFindingSortOrder;
 };
 
@@ -113,6 +114,82 @@ function fallbackScanSortValue(finding: ApiFinding): number {
   return Number.isNaN(parsed.getTime()) ? 0 : parsed.getTime();
 }
 
+function findingCreatedAtSortValue(finding: ApiFinding): number {
+  const timestamp =
+    normalizeDisplayValue(finding.created_at) ||
+    normalizeDisplayValue(finding.first_seen_at) ||
+    normalizeDisplayValue(finding.last_seen_at);
+  const parsed = new Date(timestamp);
+  return Number.isNaN(parsed.getTime()) ? 0 : parsed.getTime();
+}
+
+function compareTextValue(left: string, right: string, sortOrder: RepoFindingSortOrder): number {
+  const leftValue = left.toLowerCase();
+  const rightValue = right.toLowerCase();
+  if (!leftValue && rightValue) return 1;
+  if (leftValue && !rightValue) return -1;
+  const compared = leftValue.localeCompare(rightValue);
+  return sortOrder === 'asc' ? compared : compared * -1;
+}
+
+function compareNumberValue(left: number, right: number, sortOrder: RepoFindingSortOrder): number {
+  const compared = left - right;
+  return sortOrder === 'asc' ? compared : compared * -1;
+}
+
+function compareFindingsBySortField(
+  left: ApiFinding,
+  right: ApiFinding,
+  sortBy: RepoFindingSortField,
+  sortOrder: RepoFindingSortOrder
+): number {
+  if (sortBy === 'severity') {
+    const compared = severityRank(left.severity) - severityRank(right.severity);
+    if (compared !== 0) {
+      return sortOrder === 'asc' ? compared * -1 : compared;
+    }
+  }
+
+  if (sortBy === 'created_at') {
+    const compared = compareNumberValue(findingCreatedAtSortValue(left), findingCreatedAtSortValue(right), sortOrder);
+    if (compared !== 0) return compared;
+  }
+
+  if (sortBy === 'type') {
+    const compared = compareTextValue(normalizeDisplayValue(left.type), normalizeDisplayValue(right.type), sortOrder);
+    if (compared !== 0) return compared;
+  }
+
+  if (sortBy === 'title') {
+    const compared = compareTextValue(normalizeDisplayValue(left.title), normalizeDisplayValue(right.title), sortOrder);
+    if (compared !== 0) return compared;
+  }
+
+  const severityCompared = severityRank(left.severity) - severityRank(right.severity);
+  if (severityCompared !== 0) return severityCompared;
+
+  const createdCompared = compareNumberValue(findingCreatedAtSortValue(left), findingCreatedAtSortValue(right), 'desc');
+  if (createdCompared !== 0) return createdCompared;
+
+  const titleCompared = compareTextValue(normalizeDisplayValue(left.title), normalizeDisplayValue(right.title), 'asc');
+  if (titleCompared !== 0) return titleCompared;
+
+  return compareTextValue(normalizeDisplayValue(left.id), normalizeDisplayValue(right.id), 'asc');
+}
+
+function compareFindingGroupOrder(
+  leftFindings: ApiFinding[],
+  rightFindings: ApiFinding[],
+  compareFindings: (left: ApiFinding, right: ApiFinding) => number
+): number {
+  const leftTopFinding = leftFindings[0];
+  const rightTopFinding = rightFindings[0];
+  if (!leftTopFinding && rightTopFinding) return 1;
+  if (leftTopFinding && !rightTopFinding) return -1;
+  if (!leftTopFinding || !rightTopFinding) return 0;
+  return compareFindings(leftTopFinding, rightTopFinding);
+}
+
 function stableFallbackFingerprint(values: string[]): string {
   const source = values.join('\u001f');
   let hash = 0x811c9dc5;
@@ -131,8 +208,12 @@ export function groupRepoFindingsByRepositoryDateSeverity(
     return [];
   }
 
-  const severityBuckets = options.sortOrder === 'asc' ? [...SEVERITY_ORDER].reverse() : [...SEVERITY_ORDER];
-  const sortDirection = options.sortOrder === 'asc' ? 1 : -1;
+  const sortBy = options.sortBy ?? 'created_at';
+  const sortOrder = options.sortOrder ?? 'desc';
+  const severityBuckets = sortBy === 'severity' && sortOrder === 'asc' ? [...SEVERITY_ORDER].reverse() : [...SEVERITY_ORDER];
+  const compareFindings = (left: ApiFinding, right: ApiFinding) =>
+    compareFindingsBySortField(left, right, sortBy, sortOrder);
+  const sortDirection = sortOrder === 'asc' ? 1 : -1;
   const repositories = new Map<string, RepoFindingDisplayRepositoryGroup>();
   const scansByRepository = new Map<string, Map<string, RepoFindingDisplayScanGroup>>();
 
@@ -173,14 +254,24 @@ export function groupRepoFindingsByRepositoryDateSeverity(
     }
 
     scanGroup.sortValue =
-      options.sortOrder === 'asc'
+      sortOrder === 'asc'
         ? Math.min(scanGroup.sortValue, scanSortValue)
         : Math.max(scanGroup.sortValue, scanSortValue);
     scanGroup.findings.push(finding);
   }
 
   for (const repositoryGroup of repositories.values()) {
+    repositoryGroup.findings.sort(compareFindings);
+
+    for (const scanGroup of repositoryGroup.scanGroups) {
+      scanGroup.findings.sort(compareFindings);
+    }
+
     repositoryGroup.scanGroups.sort((left, right) => {
+      const findingCompared = compareFindingGroupOrder(left.findings, right.findings, compareFindings);
+      if (findingCompared !== 0) {
+        return findingCompared;
+      }
       if (left.sortValue !== right.sortValue) {
         return (left.sortValue - right.sortValue) * sortDirection;
       }
@@ -210,12 +301,16 @@ export function groupRepoFindingsByRepositoryDateSeverity(
   return [...repositories.values()].sort((left, right) => {
     if (left.label === 'Repository unavailable') return 1;
     if (right.label === 'Repository unavailable') return -1;
+    const findingCompared = compareFindingGroupOrder(left.findings, right.findings, compareFindings);
+    if (findingCompared !== 0) {
+      return findingCompared;
+    }
     const leftScanSortValue =
-      options.sortOrder === 'asc'
+      sortOrder === 'asc'
         ? Math.min(...left.scanGroups.map((group) => group.sortValue))
         : Math.max(...left.scanGroups.map((group) => group.sortValue));
     const rightScanSortValue =
-      options.sortOrder === 'asc'
+      sortOrder === 'asc'
         ? Math.min(...right.scanGroups.map((group) => group.sortValue))
         : Math.max(...right.scanGroups.map((group) => group.sortValue));
     if (leftScanSortValue !== rightScanSortValue) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -21467,10 +21467,6 @@ html[data-theme='light'] .idt-source-policy-panel details {
   text-align: left;
 }
 
-.idt-app-console-layout .idt-repo-finding-hierarchy {
-  gap: 0.75rem;
-}
-
 .idt-app-console-layout .idt-repo-finding-bucket {
   background: #080809;
 }
@@ -22017,12 +22013,6 @@ html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-severity-grou
   .idt-app-console-layout .idt-app-sidebar {
     padding: 0.8rem 0.75rem 0.65rem;
     gap: 0.55rem;
-  }
-
-  .idt-app-console-layout .idt-app-sidebar-footer,
-  .idt-app-console-layout .idt-app-sidebar-collapse,
-  .idt-app-console-layout .idt-app-sidebar-resize-handle {
-    display: none;
   }
 
   .idt-app-console-layout .idt-repo-findings-header {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -21572,19 +21572,24 @@ html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-modal-close {
 .idt-app-console-layout .idt-repo-finding-bucket > summary,
 html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-bucket > summary,
 .idt-app-console-layout .idt-repo-filter-panel > summary,
-html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel > summary {
+html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel > summary,
+.idt-app-console-layout .idt-repo-analysis-panel > summary,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-analysis-panel > summary {
   list-style: none;
 }
 
 .idt-app-console-layout .idt-repo-finding-bucket > summary::-webkit-details-marker,
-.idt-app-console-layout .idt-repo-filter-panel > summary::-webkit-details-marker {
+.idt-app-console-layout .idt-repo-filter-panel > summary::-webkit-details-marker,
+.idt-app-console-layout .idt-repo-analysis-panel > summary::-webkit-details-marker {
   display: none;
 }
 
 .idt-app-console-layout .idt-repo-finding-bucket > summary::after,
 html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-bucket > summary::after,
 .idt-app-console-layout .idt-repo-filter-panel > summary::after,
-html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel > summary::after {
+html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel > summary::after,
+.idt-app-console-layout .idt-repo-analysis-panel > summary::after,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-analysis-panel > summary::after {
   content: "";
   display: inline-grid;
   place-items: center;
@@ -21608,14 +21613,18 @@ html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel > summar
 .idt-app-console-layout .idt-repo-finding-bucket:not([open]) > summary::after,
 html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-bucket:not([open]) > summary::after,
 .idt-app-console-layout .idt-repo-filter-panel:not([open]) > summary::after,
-html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel:not([open]) > summary::after {
+html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel:not([open]) > summary::after,
+.idt-app-console-layout .idt-repo-analysis-panel:not([open]) > summary::after,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-analysis-panel:not([open]) > summary::after {
   transform: rotate(0deg);
 }
 
 .idt-app-console-layout .idt-repo-finding-bucket[open] > summary::after,
 html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-bucket[open] > summary::after,
 .idt-app-console-layout .idt-repo-filter-panel[open] > summary::after,
-html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel[open] > summary::after {
+html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel[open] > summary::after,
+.idt-app-console-layout .idt-repo-analysis-panel[open] > summary::after,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-analysis-panel[open] > summary::after {
   background:
     url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5 11L9 7L13 11' stroke='%23E5E7EB' stroke-width='1.9' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")
       center / 0.86rem 0.86rem no-repeat,
@@ -21632,10 +21641,14 @@ html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel:not([ope
 .idt-app-console-layout .idt-repo-finding-bucket > summary:focus-visible::after,
 .idt-app-console-layout .idt-repo-filter-panel > summary:hover::after,
 .idt-app-console-layout .idt-repo-filter-panel > summary:focus-visible::after,
+.idt-app-console-layout .idt-repo-analysis-panel > summary:hover::after,
+.idt-app-console-layout .idt-repo-analysis-panel > summary:focus-visible::after,
 html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-bucket > summary:hover::after,
 html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-bucket > summary:focus-visible::after,
 html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel > summary:hover::after,
-html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel > summary:focus-visible::after {
+html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel > summary:focus-visible::after,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-analysis-panel > summary:hover::after,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-analysis-panel > summary:focus-visible::after {
   border-color: #52525b;
   background:
     url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5 7L9 11L13 7' stroke='%23FFFFFF' stroke-width='1.9' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")
@@ -21650,14 +21663,39 @@ html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel > summar
 .idt-app-console-layout .idt-repo-finding-bucket[open] > summary:focus-visible::after,
 .idt-app-console-layout .idt-repo-filter-panel[open] > summary:hover::after,
 .idt-app-console-layout .idt-repo-filter-panel[open] > summary:focus-visible::after,
+.idt-app-console-layout .idt-repo-analysis-panel[open] > summary:hover::after,
+.idt-app-console-layout .idt-repo-analysis-panel[open] > summary:focus-visible::after,
 html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-bucket[open] > summary:hover::after,
 html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-bucket[open] > summary:focus-visible::after,
 html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel[open] > summary:hover::after,
-html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel[open] > summary:focus-visible::after {
+html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel[open] > summary:focus-visible::after,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-analysis-panel[open] > summary:hover::after,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-analysis-panel[open] > summary:focus-visible::after {
   background:
     url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5 11L9 7L13 11' stroke='%23FFFFFF' stroke-width='1.9' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")
       center / 0.86rem 0.86rem no-repeat,
     #1c1c20;
+}
+
+.idt-app-console-layout .idt-repo-analysis-panel > summary,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-analysis-panel > summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) var(--repo-disclosure-column);
+  align-items: center;
+  gap: 0.22rem 0.75rem;
+}
+
+.idt-app-console-layout .idt-repo-analysis-panel > summary::after,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-analysis-panel > summary::after {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+}
+
+.idt-app-console-layout .idt-repo-analysis-panel > summary h3,
+.idt-app-console-layout .idt-repo-analysis-panel > summary .idt-repo-finding-trend-subtitle,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-analysis-panel > summary h3,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-analysis-panel > summary .idt-repo-finding-trend-subtitle {
+  grid-column: 1;
 }
 
 .idt-app-console-layout .idt-repo-finding-hierarchy {
@@ -21972,14 +22010,161 @@ html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-severity-grou
 }
 
 @media (max-width: 640px) {
+  .idt-app-console-layout {
+    overflow-x: hidden;
+  }
+
+  .idt-app-console-layout .idt-app-sidebar {
+    padding: 0.8rem 0.75rem 0.65rem;
+    gap: 0.55rem;
+  }
+
+  .idt-app-console-layout .idt-app-sidebar-footer,
+  .idt-app-console-layout .idt-app-sidebar-collapse,
+  .idt-app-console-layout .idt-app-sidebar-resize-handle {
+    display: none;
+  }
+
+  .idt-app-console-layout .idt-repo-findings-header {
+    padding: 1rem;
+  }
+
+  .idt-app-console-layout .idt-repo-findings-header > div:first-child,
+  .idt-app-console-layout .idt-repo-findings-header .idt-overview-source-strip,
+  .idt-app-console-layout .idt-repo-findings-header .idt-inline-actions {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .idt-app-console-layout .idt-repo-findings-header .idt-overview-source-strip > span,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-findings-header .idt-overview-source-strip > span {
+    max-width: 100%;
+    border-radius: 8px;
+    white-space: normal;
+  }
+
+  .idt-app-console-layout .idt-repo-filter-panel summary,
+  .idt-app-console-layout .idt-repo-filter-panel-header,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel summary,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel-header {
+    grid-template-columns: minmax(0, 1fr) var(--repo-disclosure-column);
+    gap: 0.35rem 0.75rem;
+  }
+
+  .idt-app-console-layout .idt-repo-filter-panel small,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel small {
+    grid-column: 1;
+    grid-row: 2;
+    justify-self: start;
+  }
+
   .idt-app-console-layout .idt-repo-summary-metrics,
   html[data-theme='light'] .idt-app-console-layout .idt-repo-summary-metrics {
     grid-template-columns: 1fr;
   }
 
+  .idt-app-console-layout .idt-repo-summary-metrics > span,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-summary-metrics > span {
+    min-width: 0;
+  }
+
+  .idt-app-console-layout .idt-repo-summary-metrics strong,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-summary-metrics strong {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
+  .idt-app-console-layout .idt-repo-scan-summary,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-summary {
+    grid-template-columns: auto minmax(0, 1fr) var(--repo-disclosure-column);
+    gap: 0.55rem 0.65rem;
+    padding-left: 1rem;
+  }
+
+  .idt-app-console-layout .idt-repo-scan-node,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-node {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .idt-app-console-layout .idt-repo-scan-copy,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-copy {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .idt-app-console-layout .idt-repo-scan-meta,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-meta {
+    grid-column: 2;
+    grid-row: 2;
+    padding-left: 0;
+  }
+
+  .idt-app-console-layout .idt-repo-finding-scan > summary::after,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-scan > summary::after {
+    grid-column: 3;
+    grid-row: 1 / span 2;
+  }
+
+  .idt-app-console-layout .idt-repo-scan-meta span,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-meta span {
+    white-space: normal;
+  }
+
+  .idt-app-console-layout .idt-repo-severity-summary,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-severity-summary {
+    grid-template-columns: minmax(0, 1fr) var(--repo-disclosure-column);
+    gap: 0.4rem 0.65rem;
+  }
+
+  .idt-app-console-layout .idt-repo-severity-copy,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-severity-copy {
+    min-width: 0;
+  }
+
+  .idt-app-console-layout .idt-repo-severity-copy strong,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-severity-copy strong {
+    overflow-wrap: anywhere;
+  }
+
+  .idt-app-console-layout .idt-repo-severity-count,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-severity-count {
+    grid-column: 1;
+    grid-row: 2;
+    justify-self: start;
+  }
+
+  .idt-app-console-layout .idt-repo-finding-bucket > summary::after,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-bucket > summary::after,
+  .idt-app-console-layout .idt-repo-filter-panel > summary::after,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel > summary::after {
+    grid-column: 2;
+    grid-row: 1 / span 2;
+  }
+
   .idt-app-console-layout .idt-repo-severity-lanes,
   html[data-theme='light'] .idt-app-console-layout .idt-repo-severity-lanes {
     padding-left: 1rem;
+  }
+
+  .idt-app-console-layout .idt-repo-finding-row {
+    gap: 0.7rem;
+    padding: 0.85rem;
+  }
+
+  .idt-app-console-layout .idt-repo-finding-row-copy,
+  .idt-app-console-layout .idt-repo-finding-row-top,
+  .idt-app-console-layout .idt-repo-finding-row-meta,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-row-copy,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-row-top,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-row-meta {
+    min-width: 0;
+  }
+
+  .idt-app-console-layout .idt-repo-finding-row-meta span,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-row-meta span {
+    max-width: 100%;
+    overflow-wrap: anywhere;
   }
 
   .idt-app-console-layout .idt-repo-finding-scan::before,
@@ -25124,5 +25309,56 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
   .idt-docs-page .idt-booking-prompt-shell,
   html[data-theme='light'] .idt-docs-page .idt-booking-prompt-shell {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .idt-app-console-layout .idt-app-sidebar {
+    grid-template-rows: auto auto auto;
+    overflow: hidden;
+  }
+
+  .idt-app-console-layout .idt-app-shell-nav {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.18rem;
+    overflow: visible;
+    padding-bottom: 0;
+  }
+
+  .idt-app-console-layout .idt-app-shell-nav a {
+    min-width: 0;
+    width: 100%;
+    justify-content: flex-start;
+    padding: 0.52rem 0.6rem;
+  }
+
+  .idt-app-console-layout .idt-app-nav-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .idt-app-console-layout .idt-app-shell-main {
+    padding: 1.15rem 1.15rem 2.5rem;
+  }
+
+  .idt-app-console-layout .idt-repo-findings-header .idt-overview-source-strip {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .idt-app-console-layout .idt-repo-findings-header .idt-overview-source-strip > span,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-findings-header .idt-overview-source-strip > span {
+    display: block;
+    width: 100%;
+    overflow-wrap: anywhere;
+  }
+
+  .idt-app-console-layout .idt-app-sidebar-footer,
+  .idt-app-console-layout .idt-app-sidebar-collapse,
+  .idt-app-console-layout .idt-app-sidebar-resize-handle {
+    display: none;
   }
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4991,6 +4991,16 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   gap: 0.58rem;
 }
 
+.idt-repo-analysis-panel summary {
+  cursor: pointer;
+  list-style-position: inside;
+}
+
+.idt-repo-analysis-panel[open] summary {
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid rgba(126, 157, 211, 0.2);
+}
+
 .idt-repo-finding-trend-head h3 {
   margin: 0;
 }
@@ -5055,6 +5065,49 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   text-transform: uppercase;
 }
 
+.idt-repo-finding-hierarchy {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.idt-repo-finding-bucket {
+  border: 1px solid rgba(126, 157, 211, 0.24);
+  border-radius: 0.75rem;
+  background: rgba(8, 13, 22, 0.72);
+  overflow: hidden;
+}
+
+.idt-repo-finding-bucket summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.85rem 0.95rem;
+  color: #f4f8ff;
+  cursor: pointer;
+  font-weight: 800;
+  list-style-position: inside;
+}
+
+.idt-repo-finding-bucket summary small {
+  color: #9fb5d8;
+  font-size: 0.78rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.idt-repo-finding-bucket-body {
+  display: grid;
+  gap: 0.75rem;
+  border-top: 1px solid rgba(126, 157, 211, 0.18);
+  padding: 0.85rem;
+}
+
+.idt-repo-finding-scan,
+.idt-repo-finding-severity-group {
+  background: rgba(5, 9, 17, 0.58);
+}
+
 .idt-repo-finding-status {
   display: inline-flex;
   align-items: center;
@@ -5117,7 +5170,7 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
 .idt-repo-finding-layout {
   margin-top: 1rem;
   display: grid;
-  grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+  grid-template-columns: minmax(0, 1fr);
   gap: 1rem;
   align-items: start;
 }
@@ -5298,6 +5351,85 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
 .idt-repo-finding-remediation {
   display: grid;
   gap: 0.35rem;
+}
+
+.idt-repo-finding-modal-backdrop {
+  align-items: start;
+  overflow-y: auto;
+}
+
+.idt-repo-finding-detail-modal {
+  width: min(100%, 74rem);
+  max-height: calc(100dvh - 2rem);
+  margin: auto 0;
+  border: 1px solid rgba(126, 157, 211, 0.32);
+  border-radius: 0.9rem;
+  background: #080d16;
+  color: #f4f8ff;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.56);
+  overflow: hidden;
+}
+
+.idt-repo-finding-detail-modal-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+  border-bottom: 1px solid rgba(126, 157, 211, 0.24);
+  padding: 1rem;
+}
+
+.idt-repo-finding-modal-close {
+  flex: 0 0 auto;
+}
+
+.idt-repo-finding-detail-modal-body {
+  max-height: calc(100dvh - 9rem);
+  overflow-y: auto;
+  padding: 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.idt-repo-finding-detail-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.idt-repo-finding-detail-pills > span:not(.idt-repo-finding-severity):not(.idt-repo-finding-status) {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid rgba(126, 157, 211, 0.24);
+  border-radius: 999px;
+  padding: 0.24rem 0.58rem;
+  color: #dce9ff;
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.idt-repo-finding-detail-section {
+  display: grid;
+  gap: 0.7rem;
+  border: 1px solid rgba(126, 157, 211, 0.2);
+  border-radius: 0.8rem;
+  background: rgba(5, 9, 17, 0.56);
+  padding: 1rem;
+}
+
+.idt-repo-finding-section-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.idt-repo-finding-section-head h4 {
+  margin: 0;
+}
+
+.idt-repo-finding-section-head p {
+  margin: 0.2rem 0 0;
 }
 
 .idt-repo-remediation-preview {
@@ -19744,7 +19876,7 @@ html[data-theme='light'] .idt-executive-report-shell .idt-executive-report-metri
 
 .idt-app-console-layout .idt-repo-finding-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(22rem, 0.72fr);
+  grid-template-columns: minmax(0, 1fr);
   gap: 1rem;
 }
 
@@ -19760,6 +19892,9 @@ html[data-theme='light'] .idt-executive-report-shell .idt-executive-report-metri
 .idt-app-console-layout .idt-repo-finding-list,
 .idt-app-console-layout .idt-repo-finding-detail,
 .idt-app-console-layout .idt-repo-finding-trend,
+.idt-app-console-layout .idt-repo-finding-bucket,
+.idt-app-console-layout .idt-repo-finding-detail-section,
+.idt-app-console-layout .idt-repo-finding-detail-modal,
 .idt-app-console-layout .idt-repo-finding-row,
 .idt-app-console-layout .idt-github-intelligence-card,
 .idt-app-console-layout .idt-github-intelligence-panel,
@@ -19784,6 +19919,9 @@ html[data-theme='light'] .idt-app-console-layout .idt-source-diagnostics article
 html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-list,
 html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-detail,
 html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-trend,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-bucket,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-detail-section,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-detail-modal,
 html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-row,
 html[data-theme='light'] .idt-app-console-layout .idt-github-intelligence-card,
 html[data-theme='light'] .idt-app-console-layout .idt-github-intelligence-panel,
@@ -20025,7 +20163,8 @@ html[data-theme='light'] .idt-account-security-page label {
 
 .idt-workspace-member-details summary,
 .idt-project-card-details summary,
-.idt-repo-filter-panel summary {
+.idt-repo-filter-panel summary,
+.idt-repo-filter-panel-header {
   cursor: pointer;
   color: #ffffff;
   font-weight: 900;
@@ -20097,15 +20236,17 @@ html[data-theme='light'] .idt-app-console-layout .idt-project-card-meta div {
   padding: 0;
 }
 
-.idt-repo-filter-panel summary {
-  display: flex;
+.idt-repo-filter-panel summary,
+.idt-repo-filter-panel-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto var(--repo-disclosure-column);
   align-items: center;
-  justify-content: space-between;
   gap: 1rem;
   padding: 0.85rem 1rem;
 }
 
-.idt-repo-filter-panel[open] summary {
+.idt-repo-filter-panel[open] summary,
+.idt-repo-filter-panel[open] .idt-repo-filter-panel-header {
   border-bottom: 1px solid var(--app-border);
 }
 
@@ -20151,6 +20292,40 @@ html[data-theme='light'] .idt-app-console-layout .idt-project-card-meta div {
 .idt-app-console-layout .idt-source-status-pill {
   border-radius: 999px;
   letter-spacing: 0;
+}
+
+.idt-app-console-layout .idt-repo-finding-status,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-status {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  font-weight: 900;
+}
+
+.idt-app-console-layout .idt-repo-finding-status.is-open,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-status.is-open {
+  border-color: rgba(125, 186, 255, 0.62);
+  background: rgba(59, 130, 246, 0.24);
+  color: #dbeafe;
+}
+
+.idt-app-console-layout .idt-repo-finding-status.is-ack,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-status.is-ack {
+  border-color: rgba(251, 191, 36, 0.58);
+  background: rgba(180, 83, 9, 0.28);
+  color: #fde68a;
+}
+
+.idt-app-console-layout .idt-repo-finding-status.is-suppressed,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-status.is-suppressed {
+  border-color: rgba(203, 213, 225, 0.42);
+  background: rgba(71, 85, 105, 0.34);
+  color: #e2e8f0;
+}
+
+.idt-app-console-layout .idt-repo-finding-status.is-resolved,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-status.is-resolved {
+  border-color: rgba(74, 222, 128, 0.52);
+  background: rgba(22, 101, 52, 0.3);
+  color: #bbf7d0;
 }
 
 .idt-app-console-layout .idt-source-status-pill.is-success {
@@ -20566,6 +20741,9 @@ html[data-theme='light'] .idt-app-console-layout .idt-source-diagnostics article
 html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-list,
 html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-detail,
 html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-trend,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-bucket,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-detail-section,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-detail-modal,
 html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-row,
 html[data-theme='light'] .idt-app-console-layout .idt-overview-risk-row,
 html[data-theme='light'] .idt-app-console-layout .idt-overview-scan-row,
@@ -21289,6 +21467,31 @@ html[data-theme='light'] .idt-source-policy-panel details {
   text-align: left;
 }
 
+.idt-app-console-layout .idt-repo-finding-hierarchy {
+  gap: 0.75rem;
+}
+
+.idt-app-console-layout .idt-repo-finding-bucket {
+  background: #080809;
+}
+
+.idt-app-console-layout .idt-repo-finding-bucket summary {
+  color: #ffffff;
+}
+
+.idt-app-console-layout .idt-repo-finding-bucket summary small {
+  color: var(--app-muted);
+}
+
+.idt-app-console-layout .idt-repo-finding-bucket-body {
+  border-top-color: var(--app-border);
+}
+
+.idt-app-console-layout .idt-repo-finding-scan,
+.idt-app-console-layout .idt-repo-finding-severity-group {
+  background: #050505;
+}
+
 .idt-app-console-layout .idt-repo-finding-row.is-selected {
   border-color: #ffffff;
   background: #111113;
@@ -21303,8 +21506,486 @@ html[data-theme='light'] .idt-source-policy-panel details {
   background: var(--app-panel);
 }
 
+.idt-app-console-layout .idt-repo-analysis-panel summary {
+  cursor: pointer;
+}
+
+.idt-app-console-layout .idt-repo-analysis-panel[open] summary {
+  border-bottom-color: var(--app-border);
+}
+
 .idt-app-console-layout .idt-repo-finding-trend-bar {
   background: #ffffff;
+}
+
+.idt-app-console-layout .idt-repo-finding-detail-modal {
+  width: min(100%, 74rem);
+  background: #080809;
+}
+
+.idt-app-console-layout .idt-repo-finding-detail-modal-header,
+.idt-app-console-layout .idt-repo-finding-detail-section {
+  border-color: var(--app-border);
+}
+
+.idt-app-console-layout .idt-repo-finding-detail-section {
+  background: #050505;
+}
+
+.idt-app-console-layout .idt-repo-finding-detail-modal .idt-btn-primary,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-detail-modal .idt-btn-primary {
+  border-color: rgba(147, 197, 253, 0.78);
+  background: linear-gradient(180deg, #2f6fed 0%, #1d4ed8 100%);
+  color: #ffffff;
+  box-shadow: 0 12px 28px rgba(29, 78, 216, 0.28);
+}
+
+.idt-app-console-layout .idt-repo-finding-detail-modal .idt-btn-primary:hover,
+.idt-app-console-layout .idt-repo-finding-detail-modal .idt-btn-primary:focus-visible,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-detail-modal .idt-btn-primary:hover,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-detail-modal .idt-btn-primary:focus-visible {
+  border-color: rgba(191, 219, 254, 0.95);
+  background: linear-gradient(180deg, #3b82f6 0%, #2563eb 100%);
+}
+
+.idt-app-console-layout .idt-repo-finding-modal-close,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-modal-close {
+  border-color: var(--app-border);
+  background: #111113;
+  color: #ffffff;
+}
+
+.idt-app-console-layout .idt-repo-finding-detail-pills > span:not(.idt-repo-finding-severity):not(.idt-repo-finding-status) {
+  border-color: var(--app-border);
+  color: #ffffff;
+}
+
+.idt-app-console-layout .idt-repo-finding-section-head {
+  flex-wrap: wrap;
+}
+
+.idt-app-console-layout {
+  --repo-disclosure-column: 2rem;
+  --repo-disclosure-size: 1.35rem;
+}
+
+.idt-app-console-layout .idt-repo-finding-bucket > summary,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-bucket > summary,
+.idt-app-console-layout .idt-repo-filter-panel > summary,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel > summary {
+  list-style: none;
+}
+
+.idt-app-console-layout .idt-repo-finding-bucket > summary::-webkit-details-marker,
+.idt-app-console-layout .idt-repo-filter-panel > summary::-webkit-details-marker {
+  display: none;
+}
+
+.idt-app-console-layout .idt-repo-finding-bucket > summary::after,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-bucket > summary::after,
+.idt-app-console-layout .idt-repo-filter-panel > summary::after,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel > summary::after {
+  content: "";
+  display: inline-grid;
+  place-items: center;
+  grid-column: -1;
+  justify-self: end;
+  align-self: center;
+  flex: 0 0 var(--repo-disclosure-size);
+  width: var(--repo-disclosure-size);
+  height: var(--repo-disclosure-size);
+  border: 1px solid #34343a;
+  border-radius: 999px;
+  background:
+    url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5 7L9 11L13 7' stroke='%23E5E7EB' stroke-width='1.9' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")
+      center / 0.86rem 0.86rem no-repeat,
+    #141416;
+  color: #ffffff;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  transition: border-color 0.18s ease, background-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.idt-app-console-layout .idt-repo-finding-bucket:not([open]) > summary::after,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-bucket:not([open]) > summary::after,
+.idt-app-console-layout .idt-repo-filter-panel:not([open]) > summary::after,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel:not([open]) > summary::after {
+  transform: rotate(0deg);
+}
+
+.idt-app-console-layout .idt-repo-finding-bucket[open] > summary::after,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-bucket[open] > summary::after,
+.idt-app-console-layout .idt-repo-filter-panel[open] > summary::after,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel[open] > summary::after {
+  background:
+    url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5 11L9 7L13 11' stroke='%23E5E7EB' stroke-width='1.9' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")
+      center / 0.86rem 0.86rem no-repeat,
+    #141416;
+  transform: rotate(0deg);
+}
+
+.idt-app-console-layout .idt-repo-filter-panel:not([open]) .idt-repo-finding-filters,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel:not([open]) .idt-repo-finding-filters {
+  display: none;
+}
+
+.idt-app-console-layout .idt-repo-finding-bucket > summary:hover::after,
+.idt-app-console-layout .idt-repo-finding-bucket > summary:focus-visible::after,
+.idt-app-console-layout .idt-repo-filter-panel > summary:hover::after,
+.idt-app-console-layout .idt-repo-filter-panel > summary:focus-visible::after,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-bucket > summary:hover::after,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-bucket > summary:focus-visible::after,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel > summary:hover::after,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel > summary:focus-visible::after {
+  border-color: #52525b;
+  background:
+    url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5 7L9 11L13 7' stroke='%23FFFFFF' stroke-width='1.9' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")
+      center / 0.86rem 0.86rem no-repeat,
+    #1c1c20;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 0 0 3px rgba(255, 255, 255, 0.04);
+}
+
+.idt-app-console-layout .idt-repo-finding-bucket[open] > summary:hover::after,
+.idt-app-console-layout .idt-repo-finding-bucket[open] > summary:focus-visible::after,
+.idt-app-console-layout .idt-repo-filter-panel[open] > summary:hover::after,
+.idt-app-console-layout .idt-repo-filter-panel[open] > summary:focus-visible::after,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-bucket[open] > summary:hover::after,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-bucket[open] > summary:focus-visible::after,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel[open] > summary:hover::after,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-filter-panel[open] > summary:focus-visible::after {
+  background:
+    url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5 11L9 7L13 11' stroke='%23FFFFFF' stroke-width='1.9' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")
+      center / 0.86rem 0.86rem no-repeat,
+    #1c1c20;
+}
+
+.idt-app-console-layout .idt-repo-finding-hierarchy {
+  gap: 1rem;
+}
+
+.idt-app-console-layout .idt-repo-finding-repository,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-repository {
+  border-color: #303036;
+  background: #09090a;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.idt-app-console-layout .idt-repo-repository-summary,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-repository-summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(21rem, auto) var(--repo-disclosure-column);
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0)),
+    #0c0c0e;
+}
+
+.idt-app-console-layout .idt-repo-summary-main,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-summary-main {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.idt-app-console-layout .idt-repo-summary-icon,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-summary-icon {
+  display: inline-grid;
+  place-items: center;
+  flex: 0 0 auto;
+  width: 2.35rem;
+  height: 2.35rem;
+  border: 1px solid #303036;
+  border-radius: 8px;
+  background: #050505;
+  color: #ffffff;
+}
+
+.idt-app-console-layout .idt-repo-summary-main > span:last-child {
+  display: grid;
+  gap: 0.18rem;
+  min-width: 0;
+}
+
+.idt-app-console-layout .idt-repo-summary-label,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-summary-label {
+  color: #a3a3a3;
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.idt-app-console-layout .idt-repo-summary-main strong,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-summary-main strong {
+  color: #ffffff;
+  font-size: 1.08rem;
+  line-height: 1.15;
+  overflow-wrap: anywhere;
+}
+
+.idt-app-console-layout .idt-repo-summary-metrics,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-summary-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.idt-app-console-layout .idt-repo-summary-metrics > span,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-summary-metrics > span {
+  min-width: 5.5rem;
+  border: 1px solid #242429;
+  border-radius: 8px;
+  padding: 0.58rem 0.7rem;
+  background: #050505;
+}
+
+.idt-app-console-layout .idt-repo-summary-metrics strong,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-summary-metrics strong {
+  display: block;
+  color: #ffffff;
+  font-size: 1rem;
+  line-height: 1.1;
+  white-space: nowrap;
+}
+
+.idt-app-console-layout .idt-repo-summary-metrics small,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-summary-metrics small {
+  display: block;
+  margin-top: 0.2rem;
+  color: #a3a3a3;
+  font-size: 0.7rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.idt-app-console-layout .idt-repo-scan-timeline,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-timeline {
+  gap: 0;
+  padding: 0.25rem 0 0;
+  border-top-color: #242429;
+}
+
+.idt-app-console-layout .idt-repo-finding-scan,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-scan {
+  position: relative;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  overflow: visible;
+}
+
+.idt-app-console-layout .idt-repo-finding-scan::before,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-scan::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 2rem;
+  width: 1px;
+  background: #2b2b30;
+}
+
+.idt-app-console-layout .idt-repo-scan-summary,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-summary {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto var(--repo-disclosure-column);
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.9rem 1rem 0.75rem 1.55rem;
+  background: #09090a;
+}
+
+.idt-app-console-layout .idt-repo-scan-node,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-node {
+  position: relative;
+  z-index: 1;
+  width: 0.9rem;
+  height: 0.9rem;
+  border: 2px solid #93c5fd;
+  border-radius: 999px;
+  background: #1d4ed8;
+  box-shadow: 0 0 0 0.35rem #09090a;
+}
+
+.idt-app-console-layout .idt-repo-scan-copy,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-copy {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.idt-app-console-layout .idt-repo-scan-copy > span,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-copy > span {
+  color: #a3a3a3;
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.idt-app-console-layout .idt-repo-scan-copy strong,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-copy strong {
+  color: #ffffff;
+  font-size: 0.98rem;
+}
+
+.idt-app-console-layout .idt-repo-scan-meta,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.4rem;
+}
+
+.idt-app-console-layout .idt-repo-scan-meta span,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-meta span {
+  border: 1px solid #242429;
+  border-radius: 999px;
+  padding: 0.28rem 0.55rem;
+  background: #050505;
+  color: #d4d4d8;
+  font-size: 0.76rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.idt-app-console-layout .idt-repo-severity-lanes,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-severity-lanes {
+  gap: 0.7rem;
+  border-top: 0;
+  padding: 0.2rem 0 1rem 3.15rem;
+}
+
+.idt-app-console-layout .idt-repo-finding-severity-group,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-severity-group {
+  border-color: #242429;
+  border-left-width: 4px;
+  border-radius: 8px;
+  background: #070708;
+}
+
+.idt-app-console-layout .idt-repo-finding-severity-group.is-critical,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-severity-group.is-critical {
+  border-left-color: #ef4444;
+}
+
+.idt-app-console-layout .idt-repo-finding-severity-group.is-high,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-severity-group.is-high {
+  border-left-color: #f97316;
+}
+
+.idt-app-console-layout .idt-repo-finding-severity-group.is-medium,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-severity-group.is-medium {
+  border-left-color: #eab308;
+}
+
+.idt-app-console-layout .idt-repo-finding-severity-group.is-low,
+.idt-app-console-layout .idt-repo-finding-severity-group.is-info,
+.idt-app-console-layout .idt-repo-finding-severity-group.is-unknown,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-severity-group.is-low,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-severity-group.is-info,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-severity-group.is-unknown {
+  border-left-color: #60a5fa;
+}
+
+.idt-app-console-layout .idt-repo-severity-summary,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-severity-summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto var(--repo-disclosure-column);
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.72rem 1rem 0.72rem 0.85rem;
+  background: #0b0b0d;
+}
+
+.idt-app-console-layout .idt-repo-severity-copy,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-severity-copy {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.55rem;
+  min-width: 0;
+}
+
+.idt-app-console-layout .idt-repo-severity-copy strong,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-severity-copy strong {
+  color: #ffffff;
+  font-size: 0.9rem;
+}
+
+.idt-app-console-layout .idt-repo-severity-count,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-severity-count {
+  display: flex;
+  align-items: baseline;
+  gap: 0.3rem;
+  color: #d4d4d8;
+  white-space: nowrap;
+}
+
+.idt-app-console-layout .idt-repo-severity-count strong,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-severity-count strong {
+  color: #ffffff;
+}
+
+.idt-app-console-layout .idt-repo-severity-count small,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-severity-count small {
+  color: #a3a3a3;
+  font-weight: 800;
+}
+
+.idt-app-console-layout .idt-repo-finding-severity-group > .idt-repo-finding-items,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-severity-group > .idt-repo-finding-items {
+  padding: 0 0.75rem 0.75rem;
+}
+
+@media (max-width: 940px) {
+  .idt-app-console-layout .idt-repo-repository-summary,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-repository-summary {
+    grid-template-columns: minmax(0, 1fr) var(--repo-disclosure-column);
+  }
+
+  .idt-app-console-layout .idt-repo-summary-metrics,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-summary-metrics {
+    grid-column: 1 / -1;
+  }
+
+  .idt-app-console-layout .idt-repo-scan-summary,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-summary {
+    grid-template-columns: auto minmax(0, 1fr) var(--repo-disclosure-column);
+  }
+
+  .idt-app-console-layout .idt-repo-severity-summary,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-severity-summary {
+    grid-template-columns: minmax(0, 1fr) auto var(--repo-disclosure-column);
+  }
+
+  .idt-app-console-layout .idt-repo-scan-meta,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-meta {
+    grid-column: 2 / -2;
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 640px) {
+  .idt-app-console-layout .idt-repo-summary-metrics,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-summary-metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-app-console-layout .idt-repo-severity-lanes,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-severity-lanes {
+    padding-left: 1rem;
+  }
+
+  .idt-app-console-layout .idt-repo-finding-scan::before,
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-scan::before {
+    display: none;
+  }
 }
 
 @media (max-width: 700px) {


### PR DESCRIPTION
## Summary

- Group repository findings by repository, scan date, and severity so customers can see the real structure without scrolling through one long flat list.
- Make filters and sorting visible by default, collapsible on demand, and easier to scan.
- Move finding details into a modal-style flow with a cleaner evidence, remediation, metadata, and workflow layout.
- Collapse secondary risk graph and finding trend sections, and polish dashboard disclosure controls so they align consistently and feel less oversized.

## Why

The Findings page was making customers scroll through raw-looking rows before they could understand what was found. Filters existed, but the primary findings hierarchy was not doing enough work. This change makes the page behave more like a mature security dashboard: repository first, then scan date, then severity, with details available when someone intentionally opens them.

## Scope

- [x] Focused change (no unrelated modifications)
- [x] Backward compatibility considered
- [x] Risk level assessed: low; frontend display, grouping, modal, and tests only

## Validation

```bash
npm run test:ci --prefix web
npm run build --prefix web
```

Results:
- 12 web test files passed, 185 tests passed.
- Production build completed.
- Route prerender completed for 39 routes.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes: not needed, product UI polish only
- [x] `CHANGELOG.md` updated when relevant: not needed, no API/operator behavior change
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: yes
- Tools used: Codex
- Areas where used: web Findings page grouping, modal UI, collapse controls, styles, and tests
- Human verification performed: reviewed diff scope, ran web test CI, ran production build/prerender, and checked the page locally during implementation

## Related Issues

No issue: product feedback from live app review; no separate tracker issue exists yet.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the Findings dashboard with a nested repository → scan date → severity view and an accessible modal for details. Filters and the hierarchy remember their state, the dialog traps focus and restores it on close, and the layout is cleaner and more responsive.

- **New Features**
  - Hierarchical grouping via `groupRepoFindingsByRepositoryDateSeverity` with repository metrics and latest scan; respects selected sort and puts unknown severities last in desc.
  - Collapsible repository/scan-date/severity lanes that persist open/closed; header shows “{n} repositories grouped by scan date and severity.”
  - Finding dialog adds status pills and facts (Scan date, Source); Evidence includes “Open in GitHub,” and line links/snippets are scoped to the dialog.

- **Refactors**
  - Replaced side pane with an accessible modal (Escape/backdrop close, X button, body scroll lock, initial focus on Close, trapped focus, and restores focus to the triggering row on close).
  - Filters panel is open by default and labeled “Repository finding filters and sorting”; remembers its collapse state and stays visible when no results match.
  - Risk graph and Finding trend use consistent disclosure controls; responsive and CSS polish for the new hierarchy.

<sup>Written for commit 1f112906fd25c0e4026837cd83e3aefdf2800902. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1369?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

