### PR TITLE
feat: add aws composite collector scaffold

### DIFF
--- a/docs/aws-collector.md
+++ b/docs/aws-collector.md
@@ -2,29 +2,79 @@
 
 ## Purpose
 
-The AWS collector is the first provider ingestion module in Identrail. It reads IAM roles in a strictly read-only mode and emits provider-native raw assets for downstream normalization.
+The AWS collector family now uses a composable service collection layer. IAM stays
+the current implementation and default first service, while new services can be added
+without modifying IAM collector behavior.
+
+## Composite Architecture
+
+The collection path is:
+
+- `AWSCompositeCollector` (`internal/providers/aws/composite_collector.go`)
+  orchestrates multiple AWS service collectors sequentially.
+- `AWSCollectorScope` carries shared context (`account_id`, `region`, `service`)
+  for each service invocation.
+- `iamCollectorAdapter` wraps the existing IAM collector and preserves existing IAM
+  retry and pagination semantics unchanged.
+
+Behavior:
+
+1. Build service scope from config/connector context.
+2. Run each registered service collector in order.
+3. Aggregate all service assets and deduplicate deterministically by kind + source ID.
+4. Continue collection when a service fails non-fatally (all non-context cancellations/deadlines).
+5. Emit source diagnostics for non-fatal service failures with retryable context.
+6. Stop immediately on context cancellation/deadline errors.
 
 ## Why This Design
 
-- Provider API calls are abstracted behind `IAMAPI` so collector logic is testable and independent from SDK wiring details.
-- Retry logic is built into collection to handle transient IAM throttling and rate-limit responses.
-- Pagination includes a max-page guard to prevent runaway scans in failure scenarios.
-- Output is deduplicated by role ARN to keep collection idempotent and stable on reruns.
+- Keeps IAM semantics unchanged for existing behavior and risk controls.
+- Provides deterministic execution order and a clean extension point for future services.
+- Prevents a single service outage from aborting all AWS collection output.
+- Preserves context cancellation behavior for operator-stopped or timed-out scans.
+
+## How to add a new service collector
+
+To add a new AWS service collector:
+
+1. Implement `awsServiceCollector` in `internal/providers/aws`:
+   - `ServiceName() string`
+   - `CollectWithDiagnostics(ctx, scope AWSCollectorScope) ([]providers.RawAsset, []providers.SourceError, error)`
+2. Append the service in `NewAWSCompositeCollector(...)`.
+3. Add unit tests proving:
+   - success path and returned assets
+   - non-fatal failure path
+   - context-propagation (`account`, `region`) to the service.
+
+No behavior rewrite is required inside the existing IAM collector.
+
+## Service-level Diagnostics Contract
+
+- IAM diagnostics are preserved through the adapter and enriched with service/account/region context where possible.
+- Service collection failures produce:
+  - `Code: "service_collection_failed"`
+  - `Collector: "aws_<service>/<collector>"` (or `"aws_<service>"` when collector name is unavailable)
+  - contextual message suffix including `[service=<service> account=<account_id> region=<region>]`
+  - `Retryable: true`
+- `context.Canceled` and `context.DeadlineExceeded` are treated as hard failures and
+  terminate collection immediately.
 
 ## Key Contracts
 
 - `IAMAPI.ListRoles(ctx, nextToken, pageSize)`
 - `Collector.Collect(ctx) ([]providers.RawAsset, error)`
+- `providers.DiagnosticCollector` contract through `CollectWithDiagnostics(ctx)`
 
-`RawAsset` payload uses `kind=iam_role` and stores the full role JSON for auditability.
+`RawAsset` payloads from composite collection are deduplicated and deterministically
+ordered by `kind`, then `source_id`.
 
 ## Edge Cases Handled
 
-- API throttling with exponential backoff
+- IAM throttling with exponential backoff
 - Non-retryable IAM errors fail fast
-- Context cancellation during retries
-- Duplicate roles across pages
-- Missing ARN rows are ignored as invalid identifiers
+- Context cancellation during IAM retries and composite execution
+- Duplicate roles/assets across pages and services
+- Missing identifiers are handled with diagnostics where appropriate
 
 ## Security Posture
 
@@ -34,8 +84,6 @@ The AWS collector is the first provider ingestion module in Identrail. It reads 
 
 ## Current Implementation State
 
-- IAM role collection is implemented through a concrete AWS SDK adapter.
-- The collector output flows into the normalizer pipeline as `kind=iam_role` raw assets.
-- Connectors currently assume the onboarded read-only role at scan time, then perform IAM-only collection.
-- Runtime behavior stays IAM-focused and read-only; no live remediation or policy enforcement is executed during collection.
-- Cross-service expansion is expected through the separate composite-connector roadmap, not through this IAM collector path today.
+- IAM role collection remains implemented through the existing AWS SDK IAM adapter.
+- AWS SDK CLI and runtime paths now use `NewAWSScanner`, which wires the composite collector.
+- The composite layer is now the extension point for future AWS service collection in the CLI/runtime path.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -594,13 +594,9 @@ func buildScannerForProvider(cfg config.Config, fixtures []string, staleAfterDay
 			if err != nil {
 				return app.Scanner{}, fmt.Errorf("initialize aws sdk collector: %w", err)
 			}
-			return app.Scanner{
-				Collector:            awsprovider.NewCollector(iamAPI),
-				Normalizer:           awsprovider.NewRoleNormalizer(),
-				PermissionResolver:   awsprovider.NewPolicyPermissionResolver(),
-				RelationshipResolver: awsprovider.NewRelationshipBuilder(),
-				RiskRuleSet:          awsprovider.NewRuleSet(awsprovider.WithStaleAfter(time.Duration(staleAfterDays) * 24 * time.Hour)),
-			}, nil
+			return awsprovider.NewAWSScanner(iamAPI, cfg.AWSAccountID, cfg.AWSRegion, awsprovider.NewRuleSet(
+				awsprovider.WithStaleAfter(time.Duration(staleAfterDays) * 24 * time.Hour),
+			)), nil
 		default:
 			return app.Scanner{}, fmt.Errorf("unsupported aws source %q", cfg.AWSSource)
 		}

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/identrail/identrail/internal/config"
 	"github.com/identrail/identrail/internal/domain"
+	awsprovider "github.com/identrail/identrail/internal/providers/aws"
 )
 
 func TestExecuteScanAndFindingsTable(t *testing.T) {
@@ -469,6 +470,28 @@ func TestExecuteAWSUnsupportedSource(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unsupported aws source") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuildScannerForProviderAWSUsesCompositeCollector(t *testing.T) {
+	cfg := config.Config{
+		Provider:    "aws",
+		AWSSource:   "sdk",
+		AWSRegion:   "eu-west-2",
+		AWSAccountID: "123456789012",
+	}
+	t.Setenv("AWS_ACCESS_KEY_ID", "ASIAXXXXXXXXXXXXXXXX")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "example-secret-key-replace-me")
+	scanner, err := buildScannerForProvider(cfg, nil, 3)
+	if err != nil {
+		t.Fatalf("build scanner for provider failed: %v", err)
+	}
+	composite, ok := scanner.Collector.(*awsprovider.AWSCompositeCollector)
+	if !ok {
+		t.Fatalf("expected aws composite collector, got %T", scanner.Collector)
+	}
+	if composite.AccountID() != cfg.AWSAccountID || composite.Region() != cfg.AWSRegion {
+		t.Fatalf("unexpected composite scope account=%q region=%q", composite.AccountID(), composite.Region())
 	}
 }
 

--- a/internal/providers/aws/composite_collector.go
+++ b/internal/providers/aws/composite_collector.go
@@ -1,0 +1,237 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/identrail/identrail/internal/app"
+	"github.com/identrail/identrail/internal/providers"
+)
+
+var _ providers.DiagnosticCollector = (*AWSCompositeCollector)(nil)
+
+// AWSCollectorScope carries service context used by each service-level collector.
+type AWSCollectorScope struct {
+	AccountID string
+	Region    string
+	Service   string
+}
+
+// awsServiceCollector defines the internal contract for collectable AWS service modules.
+type awsServiceCollector interface {
+	ServiceName() string
+	CollectWithDiagnostics(ctx context.Context, scope AWSCollectorScope) ([]providers.RawAsset, []providers.SourceError, error)
+}
+
+// AWSCompositeCollector runs a sequence of AWS service collectors with partial-failure tolerance.
+type AWSCompositeCollector struct {
+	accountID string
+	region    string
+	services  []awsServiceCollector
+}
+
+func (c *AWSCompositeCollector) AccountID() string {
+	if c == nil {
+		return ""
+	}
+	return c.accountID
+}
+
+func (c *AWSCompositeCollector) Region() string {
+	if c == nil {
+		return ""
+	}
+	return c.region
+}
+
+// NewAWSCompositeCollector creates a composite AWS collector that runs IAM first by default
+// and accepts optional additional service collectors for future extension.
+func NewAWSCompositeCollector(iamAPI IAMAPI, accountID string, region string, additionalServices ...awsServiceCollector) *AWSCompositeCollector {
+	services := make([]awsServiceCollector, 0, 1+len(additionalServices))
+	services = append(services, &iamCollectorAdapter{collector: NewCollector(iamAPI)})
+	for _, service := range additionalServices {
+		if service == nil {
+			continue
+		}
+		services = append(services, service)
+	}
+	return &AWSCompositeCollector{
+		accountID: strings.TrimSpace(accountID),
+		region:    strings.TrimSpace(region),
+		services:  services,
+	}
+}
+
+// NewAWSScanner creates the canonical AWS app scanner wiring for shared runtime and CLI construction.
+func NewAWSScanner(iamAPI IAMAPI, accountID string, region string, ruleSet ...providers.RiskRuleSet) app.Scanner {
+	var resolvedRuleSet providers.RiskRuleSet = NewRuleSet()
+	if len(ruleSet) > 0 && ruleSet[0] != nil {
+		resolvedRuleSet = ruleSet[0]
+	}
+
+	return app.Scanner{
+		Collector:            NewAWSCompositeCollector(iamAPI, accountID, region),
+		Normalizer:           NewRoleNormalizer(),
+		PermissionResolver:   NewPolicyPermissionResolver(),
+		RelationshipResolver: NewRelationshipBuilder(),
+		RiskRuleSet:          resolvedRuleSet,
+	}
+}
+
+// CollectWithDiagnostics executes all service collectors sequentially, de-duplicates assets,
+// and returns service-level diagnostics while continuing on non-fatal service failures.
+func (c *AWSCompositeCollector) CollectWithDiagnostics(ctx context.Context) ([]providers.RawAsset, []providers.SourceError, error) {
+	if c == nil {
+		return nil, nil, errors.New("aws composite collector is not initialized")
+	}
+
+	var (
+		assets      []providers.RawAsset
+		sourceErrors []providers.SourceError
+	)
+	for _, service := range c.services {
+		if service == nil {
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+
+		scope := AWSCollectorScope{
+			AccountID: c.accountID,
+			Region:    c.region,
+			Service:   service.ServiceName(),
+		}
+
+		serviceAssets, serviceSourceErrors, err := service.CollectWithDiagnostics(ctx, scope)
+		if len(serviceAssets) > 0 {
+			assets = append(assets, serviceAssets...)
+		}
+		for _, sourceError := range serviceSourceErrors {
+			sourceErrors = append(sourceErrors, enrichSourceError(scope, sourceError))
+		}
+
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return nil, nil, err
+			}
+			sourceErrors = append(sourceErrors, sourceServiceFailureDiagnostic(scope, err))
+		}
+	}
+
+	return dedupeAndSortAssets(assets), sourceErrors, nil
+}
+
+// Collect preserves compatibility with providers.Collector by dropping diagnostics.
+func (c *AWSCompositeCollector) Collect(ctx context.Context) ([]providers.RawAsset, error) {
+	assets, _, err := c.CollectWithDiagnostics(ctx)
+	return assets, err
+}
+
+func enrichSourceError(scope AWSCollectorScope, sourceError providers.SourceError) providers.SourceError {
+	sourceError.Collector = compositeCollectorName(scope.Service, sourceError.Collector)
+	sourceError.Message = appendSourceContextToMessage(scope, sourceError.Message)
+	if strings.TrimSpace(sourceError.SourceID) == "" {
+		sourceError.SourceID = compositeSourceID(scope, "")
+	} else {
+		sourceError.SourceID = compositeSourceID(scope, sourceError.SourceID)
+	}
+	return sourceError
+}
+
+func sourceServiceFailureDiagnostic(scope AWSCollectorScope, err error) providers.SourceError {
+	return providers.SourceError{
+		Collector: compositeCollectorName(scope.Service, ""),
+		Code:      "service_collection_failed",
+		Message:   appendSourceContextToMessage(scope, err.Error()),
+		SourceID:  compositeSourceID(scope, ""),
+		Retryable: true,
+	}
+}
+
+func compositeCollectorName(serviceName string, collector string) string {
+	trimmed := strings.TrimSpace(strings.ToLower(serviceName))
+	if trimmed == "" {
+		trimmed = "aws"
+	}
+	if strings.TrimSpace(collector) == "" {
+		return "aws_" + trimmed
+	}
+	return "aws_" + trimmed + "/" + strings.TrimSpace(collector)
+}
+
+func appendSourceContextToMessage(scope AWSCollectorScope, message string) string {
+	contextSuffix := serviceContextFromScope(scope)
+	if message == "" {
+		return contextSuffix
+	}
+	if strings.Contains(message, contextSuffix) {
+		return message
+	}
+	return message + " " + contextSuffix
+}
+
+func serviceContextFromScope(scope AWSCollectorScope) string {
+	return fmt.Sprintf("[service=%s account=%s region=%s]", serviceNameOrUnknown(scope.Service), strings.TrimSpace(scope.AccountID), strings.TrimSpace(scope.Region))
+}
+
+func serviceNameOrUnknown(serviceName string) string {
+	trimmed := strings.TrimSpace(strings.ToLower(serviceName))
+	if trimmed == "" {
+		return "unknown"
+	}
+	return trimmed
+}
+
+func compositeSourceID(scope AWSCollectorScope, sourceID string) string {
+	if strings.TrimSpace(sourceID) == "" {
+		sourceID = "source"
+	}
+	return fmt.Sprintf("service=%s|account=%s|region=%s|source=%s", serviceNameOrUnknown(scope.Service), strings.TrimSpace(scope.AccountID), strings.TrimSpace(scope.Region), sourceID)
+}
+
+func dedupeAndSortAssets(assets []providers.RawAsset) []providers.RawAsset {
+	sort.SliceStable(assets, func(i, j int) bool {
+		leftKind := strings.TrimSpace(assets[i].Kind)
+		rightKind := strings.TrimSpace(assets[j].Kind)
+		if leftKind != rightKind {
+			return leftKind < rightKind
+		}
+		return strings.TrimSpace(assets[i].SourceID) < strings.TrimSpace(assets[j].SourceID)
+	})
+
+	seen := make(map[string]struct{}, len(assets))
+	deduped := make([]providers.RawAsset, 0, len(assets))
+	for _, asset := range assets {
+		kind := strings.TrimSpace(asset.Kind)
+		sourceID := strings.TrimSpace(asset.SourceID)
+		key := kind + "\x00" + sourceID
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		deduped = append(deduped, asset)
+	}
+	return deduped
+}
+
+// iamCollectorAdapter wraps the existing IAM collector without changing behavior.
+type iamCollectorAdapter struct {
+	collector *Collector
+}
+
+func (a *iamCollectorAdapter) ServiceName() string {
+	return "iam"
+}
+
+func (a *iamCollectorAdapter) CollectWithDiagnostics(ctx context.Context, _ AWSCollectorScope) ([]providers.RawAsset, []providers.SourceError, error) {
+	if a == nil || a.collector == nil {
+		return nil, nil, errors.New("iam collector is not initialized")
+	}
+	return a.collector.CollectWithDiagnostics(ctx)
+}
+
+var _ awsServiceCollector = (*iamCollectorAdapter)(nil)

--- a/internal/providers/aws/composite_collector_test.go
+++ b/internal/providers/aws/composite_collector_test.go
@@ -1,0 +1,177 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/identrail/identrail/internal/providers"
+)
+
+type fakeAWSServiceCollector struct {
+	name           string
+	assets         []providers.RawAsset
+	diagnostics    []providers.SourceError
+	err            error
+	onCollect      func(scope AWSCollectorScope)
+	calls          int
+	capturedScopes []AWSCollectorScope
+}
+
+func (f *fakeAWSServiceCollector) ServiceName() string {
+	return f.name
+}
+
+func (f *fakeAWSServiceCollector) CollectWithDiagnostics(_ context.Context, scope AWSCollectorScope) ([]providers.RawAsset, []providers.SourceError, error) {
+	f.calls++
+	f.capturedScopes = append(f.capturedScopes, scope)
+	if f.onCollect != nil {
+		f.onCollect(scope)
+	}
+	return append([]providers.RawAsset(nil), f.assets...), append([]providers.SourceError(nil), f.diagnostics...), f.err
+}
+
+func sortKeys(assets []providers.RawAsset) []string {
+	keys := make([]string, 0, len(assets))
+	for _, asset := range assets {
+		keys = append(keys, asset.Kind+"|"+asset.SourceID)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func TestAWSCompositeCollectorSuccessWithIAMAndSecondServiceAndDeterministicOrdering(t *testing.T) {
+	api := &fakeIAMClient{listFn: func(_ context.Context, _ string, _ int32) (ListRolesPage, error) {
+		return ListRolesPage{Roles: []IAMRole{
+			{ARN: "arn:aws:iam::123:role/one", Name: "one"},
+			{ARN: "arn:aws:iam::123:role/shared", Name: "shared"},
+		}}, nil
+	}}
+
+	secondService := &fakeAWSServiceCollector{
+		name: "ecs",
+		assets: []providers.RawAsset{
+			{Kind: "aws_ecs_task", SourceID: "task/beta"},
+			{Kind: "iam_role", SourceID: "arn:aws:iam::123:role/shared"},
+			{Kind: "aws_ecs_cluster", SourceID: "cluster/alpha"},
+		},
+	}
+
+	composite := NewAWSCompositeCollector(api, "123456789012", "us-east-1", secondService)
+	firstRunAssets, _, err := composite.CollectWithDiagnostics(context.Background())
+	if err != nil {
+		t.Fatalf("collect first run: %v", err)
+	}
+	secondRunAssets, _, err := composite.CollectWithDiagnostics(context.Background())
+	if err != nil {
+		t.Fatalf("collect second run: %v", err)
+	}
+
+	expected := []string{
+		"aws_ecs_cluster|cluster/alpha",
+		"aws_ecs_task|task/beta",
+		"iam_role|arn:aws:iam::123:role/one",
+		"iam_role|arn:aws:iam::123:role/shared",
+	}
+	if got := sortKeys(firstRunAssets); strings.Join(got, ",") != strings.Join(expected, ",") {
+		t.Fatalf("unexpected first-run keys=%v", got)
+	}
+	if got := sortKeys(secondRunAssets); strings.Join(got, ",") != strings.Join(expected, ",") {
+		t.Fatalf("unexpected second-run keys=%v", got)
+	}
+}
+
+func TestAWSCompositeCollectorNonFatalServiceFailureContinuesAndRecordsDiagnostic(t *testing.T) {
+	api := &fakeIAMClient{listFn: func(_ context.Context, _ string, _ int32) (ListRolesPage, error) {
+		return ListRolesPage{Roles: []IAMRole{{ARN: "arn:aws:iam::123:role/safe", Name: "safe"}}}, nil
+	}}
+
+	secondService := &fakeAWSServiceCollector{
+		name: "ecs",
+		err:  errors.New("temporary downstream failure"),
+	}
+	composite := NewAWSCompositeCollector(api, "123", "eu-west-1", secondService)
+	assets, sourceErrors, err := composite.CollectWithDiagnostics(context.Background())
+	if err != nil {
+		t.Fatalf("expected non-fatal service error to be ignored, got %v", err)
+	}
+	if len(assets) != 1 {
+		t.Fatalf("expected one IAM asset to remain, got %d", len(assets))
+	}
+	if assets[0].SourceID != "arn:aws:iam::123:role/safe" {
+		t.Fatalf("unexpected asset source id %q", assets[0].SourceID)
+	}
+	if len(sourceErrors) != 1 {
+		t.Fatalf("expected one synthetic failure diagnostic, got %d", len(sourceErrors))
+	}
+	if sourceErrors[0].Code != "service_collection_failed" {
+		t.Fatalf("unexpected diagnostic code %q", sourceErrors[0].Code)
+	}
+	if sourceErrors[0].Collector != "aws_ecs" {
+		t.Fatalf("unexpected diagnostic collector %q", sourceErrors[0].Collector)
+	}
+	if sourceErrors[0].SourceID != "service=ecs|account=123|region=eu-west-1|source=source" {
+		t.Fatalf("unexpected diagnostic source id %q", sourceErrors[0].SourceID)
+	}
+	if sourceErrors[0].Retryable != true {
+		t.Fatalf("expected retryable diagnostic for service failure")
+	}
+	if sourceErrors[0].Message == "" || sourceErrors[0].Message != "temporary downstream failure [service=ecs account=123 region=eu-west-1]" {
+		t.Fatalf("unexpected diagnostic message %q", sourceErrors[0].Message)
+	}
+}
+
+func TestAWSCompositeCollectorPassesAccountAndRegionScopeToServices(t *testing.T) {
+	api := &fakeIAMClient{listFn: func(_ context.Context, _ string, _ int32) (ListRolesPage, error) {
+		return ListRolesPage{Roles: []IAMRole{{ARN: "arn:aws:iam::123:role/safe", Name: "safe"}}}, nil
+	}}
+
+	captured := AWSCollectorScope{}
+	secondService := &fakeAWSServiceCollector{
+		name: "ec2",
+		onCollect: func(scope AWSCollectorScope) {
+			captured = scope
+		},
+	}
+	composite := NewAWSCompositeCollector(api, "account-abc", "us-west-2", secondService)
+	_, _, err := composite.CollectWithDiagnostics(context.Background())
+	if err != nil {
+		t.Fatalf("collect failed: %v", err)
+	}
+	if captured.AccountID != "account-abc" || captured.Region != "us-west-2" {
+		t.Fatalf("unexpected forwarded scope: %+v", captured)
+	}
+	if captured.Service != "ec2" {
+		t.Fatalf("unexpected service context: %s", captured.Service)
+	}
+}
+
+func TestAWSCompositeCollectorContextCancellationStopsImmediately(t *testing.T) {
+	api := &fakeIAMClient{listFn: func(_ context.Context, _ string, _ int32) (ListRolesPage, error) {
+		return ListRolesPage{Roles: []IAMRole{{ARN: "arn:aws:iam::123:role/safe", Name: "safe"}}}, nil
+	}}
+
+	cancelService := &fakeAWSServiceCollector{
+		name: "ec2",
+		err:  context.Canceled,
+		onCollect: func(_ AWSCollectorScope) {
+		},
+	}
+	rabbitService := &fakeAWSServiceCollector{name: "lambda"}
+	composite := NewAWSCompositeCollector(api, "", "", cancelService, rabbitService)
+	assets, sourceErrors, err := composite.CollectWithDiagnostics(context.Background())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled error, got %v", err)
+	}
+	if len(assets) != 0 || len(sourceErrors) != 0 {
+		t.Fatalf("expected no returned assets/diagnostics on canceled hard-failure, got %d assets and %d diagnostics", len(assets), len(sourceErrors))
+	}
+	if cancelService.calls != 1 {
+		t.Fatalf("expected canceling service to run once, got %d", cancelService.calls)
+	}
+	if rabbitService.calls != 0 {
+		t.Fatalf("expected cancellation to short-circuit remaining services, rabbit calls=%d", rabbitService.calls)
+	}
+}

--- a/internal/runtime/service_builder.go
+++ b/internal/runtime/service_builder.go
@@ -70,7 +70,7 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 				_ = store.Close()
 				return nil, nil, fmt.Errorf("initialize aws sdk collector: %w", iamErr)
 			}
-			scanner = newAWSScanner(iamAPI)
+			scanner = newAWSScanner(iamAPI, cfg.AWSAccountID, cfg.AWSRegion)
 		default:
 			_ = store.Close()
 			return nil, nil, fmt.Errorf("unsupported aws source %q", cfg.AWSSource)
@@ -153,7 +153,7 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 		if iamErr != nil {
 			return nil, iamErr
 		}
-		scanner := newAWSScanner(iamAPI)
+		scanner := newAWSScanner(iamAPI, connection.AccountID, connection.Region)
 		return scanner, nil
 	}
 	svc.DefaultScope = db.Scope{
@@ -235,14 +235,8 @@ func parseInt64Config(value string) int64 {
 	return parsed
 }
 
-func newAWSScanner(iamAPI awsprovider.IAMAPI) app.Scanner {
-	return app.Scanner{
-		Collector:            awsprovider.NewCollector(iamAPI),
-		Normalizer:           awsprovider.NewRoleNormalizer(),
-		PermissionResolver:   awsprovider.NewPolicyPermissionResolver(),
-		RelationshipResolver: awsprovider.NewRelationshipBuilder(),
-		RiskRuleSet:          awsprovider.NewRuleSet(),
-	}
+func newAWSScanner(iamAPI awsprovider.IAMAPI, accountID string, region string) app.Scanner {
+	return awsprovider.NewAWSScanner(iamAPI, accountID, region)
 }
 
 // NewStore returns memory store by default, Postgres when database URL is provided.

--- a/internal/runtime/service_builder_test.go
+++ b/internal/runtime/service_builder_test.go
@@ -10,7 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/identrail/identrail/internal/app"
 	"github.com/identrail/identrail/internal/config"
+	"github.com/identrail/identrail/internal/providers/aws"
 	"github.com/identrail/identrail/internal/scheduler"
 )
 
@@ -31,6 +33,25 @@ func TestBuildScanServiceMemoryStore(t *testing.T) {
 	}
 	if err := closeFn(); err != nil {
 		t.Fatalf("close failed: %v", err)
+	}
+}
+
+type noopIAMCollectorAPI struct{}
+
+func (noopIAMCollectorAPI) ListRoles(context.Context, string, int32) (aws.ListRolesPage, error) {
+	return aws.ListRolesPage{}, nil
+}
+
+func TestNewAWSScannerUsesCompositeCollectorScope(t *testing.T) {
+	// list roles never called in this test, but the composite collector should
+	// be constructed with exactly the account/region scope from the call site.
+	scanner := newAWSScanner(noopIAMCollectorAPI{}, "account-xyz", "us-east-2")
+	composite, ok := scanner.Collector.(*aws.AWSCompositeCollector)
+	if !ok {
+		t.Fatalf("expected aws composite collector, got %T", scanner.Collector)
+	}
+	if composite.AccountID() != "account-xyz" || composite.Region() != "us-east-2" {
+		t.Fatalf("unexpected composite scope account=%q region=%q", composite.AccountID(), composite.Region())
 	}
 }
 
@@ -172,13 +193,25 @@ func TestBuildScanServiceAWSSDKMode(t *testing.T) {
 		AllowMemoryStore: true,
 		AWSSource:        "sdk",
 		AWSRegion:        "us-east-1",
+		AWSAccountID:     "123456789012",
 	}
+	t.Setenv("AWS_ACCESS_KEY_ID", "ASIAXXXXXXXXXXXXXXXX")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "example-secret-key-replace-me")
 	svc, closeFn, err := BuildScanService(cfg)
 	if err != nil {
 		t.Fatalf("build service failed: %v", err)
 	}
 	if svc == nil || closeFn == nil {
 		t.Fatal("expected non-nil service and close function")
+	}
+	scannerRunner, ok := svc.Scanner.(app.Scanner)
+	if !ok {
+		t.Fatalf("expected app.Scanner scanner runner, got %T", svc.Scanner)
+	}
+	if composite, ok := scannerRunner.Collector.(*aws.AWSCompositeCollector); !ok {
+		t.Fatalf("expected composite collector, got %T", scannerRunner.Collector)
+	} else if composite.AccountID() != cfg.AWSAccountID || composite.Region() != cfg.AWSRegion {
+		t.Fatalf("unexpected composite scope: account=%q region=%q", composite.AccountID(), composite.Region())
 	}
 	if err := closeFn(); err != nil {
 		t.Fatalf("close failed: %v", err)


### PR DESCRIPTION
## Summary

Describe what changed.

## Why

Describe the problem this PR solves.

## Scope

- [ ] Focused change (no unrelated modifications)
- [ ] Backward compatibility considered
- [ ] Risk level assessed

## Validation

List the checks you ran and their outcomes.

```bash
# Example:
# go test ./...
# npm run test:ci --prefix web
```

## Checklist

- [ ] Tests added/updated for behavior changes
- [ ] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [ ] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

If AI tools were used materially for this PR, complete the fields below.

- AI-assisted: yes/no
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Required for this repository size:

- Include at least one issue reference using closing/reference keywords:
  - `Closes #123`, `Fixes #123`, or `Refs #123`
- If no issue exists, include an explicit exemption with rationale:
  - `No issue: <reason>` (for example: docs-only typo fix, CI-only fix, or emergency hotfix)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces an AWS composite collector that orchestrates multiple service collectors with IAM as the first/default service, and updates the CLI/runtime to use it. This keeps existing IAM behavior unchanged while adding partial-failure tolerance and deterministic asset output.

- **New Features**
  - `AWSCompositeCollector` runs service collectors in order and aggregates results.
  - IAM wrapped via `iamCollectorAdapter` to preserve retries, pagination, and semantics.
  - Deduplicates assets by `kind` + `source_id` with stable ordering.
  - Non-fatal service errors produce diagnostics and do not stop the run.
  - Stops immediately on `context.Canceled` or deadline.
  - Clear diagnostics contract and service scope (`account_id`, `region`, `service`).

- **Refactors**
  - CLI and runtime now build scanners via `NewAWSScanner`, wiring the composite collector with `account_id` and `region`.
  - Added tests to confirm composite wiring, scope propagation, deterministic output, and cancellation behavior.
  - Updated `docs/aws-collector.md` with the composite architecture and extension guide.

<sup>Written for commit e4f69fa552a0ef49218557a879117205a8bd165a. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1370?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

