### PR TITLE
Add AWS account region coverage registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Added an internal AWS account and region coverage registry for tenant-scoped connector estate coverage, including migration, store methods, service helpers, tests, and documentation.
 - Added typed AWS connector capability modes (`discovery`, `runtime_evidence`,
   `remediation_plan`, `approved_remediation`, `authorization_advisory`,
   `authorization_enforcement`). Connector status now reports requested,

--- a/docs/auth/aws-connector.md
+++ b/docs/auth/aws-connector.md
@@ -37,3 +37,19 @@ When a persistent database is configured and AWS connector setup is enabled, `ID
 5. The API uses the stored External ID, assumes the role with STS, verifies caller identity, checks scanner-critical IAM read access, and marks the connector active or degraded.
 
 The read-only policy and rationale live together under `deploy/connectors/aws/policies/`.
+
+## Account and Region Coverage Registry
+
+AWS connector health answers whether Identrail can assume the configured connector role. The account and region coverage registry answers a separate product question: which AWS accounts and regions are currently in scope, covered, pending, or blocked.
+
+The registry is intentionally internal for now because the UI flow is not ready. Services can write coverage rows through the AWS service layer after discovering organization accounts, selected regions, or scan outcomes. Each row is scoped by tenant, workspace, project, connector, account ID, and region, and can store organization metadata, the connector role ARN, coverage status, the last successful scan time, the last scan error, a scan cursor, and account/region availability flags.
+
+Use the registry when a scanner, connector workflow, or future UI needs to distinguish these states:
+
+- `covered`: Identrail has successfully scanned the account and region.
+- `pending`: the account and region are known but not scanned yet.
+- `gap`: the account and region should be covered but are not currently covered.
+- `error`: the latest scan failed and `last_scan_error` should explain why.
+- `suspended`, `disabled`, or `unreachable`: AWS reported the account or region cannot currently be scanned.
+
+See [AWS account and region coverage](../aws-account-region-coverage.md) for the storage contract and operating notes.

--- a/docs/aws-account-region-coverage.md
+++ b/docs/aws-account-region-coverage.md
@@ -1,0 +1,41 @@
+# AWS Account and Region Coverage
+
+Identrail tracks AWS connector health and AWS estate coverage separately. Connector health confirms that the configured AWS connector can be used. Coverage records describe which AWS accounts and regions are known, expected, covered, pending, or blocked for a project.
+
+## Scope
+
+The registry is tenant-, workspace-, project-, and connector-scoped. A coverage row is uniquely identified by:
+
+- connector ID
+- AWS account ID
+- AWS region
+
+The registry also stores optional organization context, including account name, organization ID, organizational unit ID, AWS partition, and connector role ARN. This lets scanner and onboarding workflows keep AWS Organizations discovery separate from the eventual public UI.
+
+## Coverage status
+
+Use these statuses consistently:
+
+- `unknown`: the account and region are known, but Identrail does not have enough scan state yet.
+- `pending`: the account and region are queued or expected to be scanned.
+- `covered`: Identrail completed a successful scan for the account and region.
+- `gap`: the account and region should be covered but are not currently covered.
+- `error`: the latest scan failed. Store a concise operator-facing reason in `last_scan_error`.
+- `suspended`: AWS reports the account is suspended.
+- `disabled`: the AWS region is disabled for the account.
+- `unreachable`: Identrail cannot currently reach the account or region.
+
+## Stored scan state
+
+Coverage rows can include:
+
+- `last_successful_scan_at` for the most recent successful account/region scan.
+- `last_scan_error` for the latest failure reason.
+- `scan_cursor` for scanner-owned pagination or incremental state.
+- `account_suspended`, `region_disabled`, and `region_unreachable` booleans for explicit blocked states.
+
+The scan cursor is an internal JSON object and should not contain secrets.
+
+## Public API posture
+
+The first implementation keeps this registry behind store and service methods. Public HTTP endpoints can be added later when the UI is ready to show AWS estate coverage. Until then, scanner and connector workflows should write and read coverage through the scoped service methods.

--- a/internal/api/aws_connect.go
+++ b/internal/api/aws_connect.go
@@ -504,6 +504,32 @@ func (s *Service) GetAWSConnection(ctx context.Context, workspaceID string, proj
 	return s.awsConnectionStatusFromStored(ctx, items[0]), nil
 }
 
+// UpsertAWSAccountRegionCoverage stores account/region coverage for future AWS fan-out.
+func (s *Service) UpsertAWSAccountRegionCoverage(ctx context.Context, workspaceID string, projectID string, coverage db.AWSAccountRegionCoverage) (db.AWSAccountRegionCoverage, error) {
+	project, scope, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return db.AWSAccountRegionCoverage{}, err
+	}
+	coverage.TenantID = scope.TenantID
+	coverage.WorkspaceID = project.WorkspaceID
+	coverage.ProjectID = project.ProjectID
+	if strings.TrimSpace(coverage.ConnectorID) == "" {
+		return db.AWSAccountRegionCoverage{}, ErrInvalidAWSConnectionRequest
+	}
+	return s.Store.UpsertAWSAccountRegionCoverage(ctx, coverage)
+}
+
+// ListAWSAccountRegionCoverages lists project-scoped account/region targets for future AWS fan-out.
+func (s *Service) ListAWSAccountRegionCoverages(ctx context.Context, workspaceID string, projectID string, filter db.AWSAccountRegionCoverageFilter) ([]db.AWSAccountRegionCoverage, error) {
+	project, _, err := s.requireScopedProject(ctx, workspaceID, projectID)
+	if err != nil {
+		return nil, err
+	}
+	filter.WorkspaceID = project.WorkspaceID
+	filter.ProjectID = project.ProjectID
+	return s.Store.ListAWSAccountRegionCoverages(ctx, filter)
+}
+
 func normalizeAWSConnectionRequest(request AWSConnectionUpsertRequest) (AWSConnectionUpsertRequest, error) {
 	normalized := request
 	normalized.RoleARN = strings.TrimSpace(request.RoleARN)

--- a/internal/api/aws_connect_test.go
+++ b/internal/api/aws_connect_test.go
@@ -186,6 +186,83 @@ func TestAWSConnectionClearsPersistedExternalID(t *testing.T) {
 	}
 }
 
+func TestAWSAccountRegionCoverageServiceMethods(t *testing.T) {
+	store := db.NewMemoryStore()
+	ctx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	seedDefaultProject(t, store, ctx, "project-1")
+	svc := NewService(store, routerScanner{}, "aws")
+	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+
+	if err := store.UpsertTenancyConnector(ctx, db.TenancyConnector{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "aws-prod",
+		Type:        domain.ConnectorTypeAWS,
+		DisplayName: "Production AWS",
+		Status:      domain.ConnectorStatusActive,
+	}, db.TenancyConnectorState{
+		WorkspaceID:  "workspace-a",
+		ProjectID:    "project-1",
+		ConnectorID:  "aws-prod",
+		HealthStatus: "healthy",
+	}); err != nil {
+		t.Fatalf("seed connector: %v", err)
+	}
+
+	coverage, err := svc.UpsertAWSAccountRegionCoverage(ctx, "workspace-a", "project-1", db.AWSAccountRegionCoverage{
+		ConnectorID:          "aws-prod",
+		AccountID:            "123456789012",
+		AccountAlias:         "Production",
+		OrganizationID:       "o-example",
+		OUPath:               "root/prod",
+		Partition:            "aws",
+		Region:               "us-east-1",
+		RoleARN:              "arn:aws:iam::123456789012:role/IdentrailReadOnly",
+		CoverageStatus:       db.AWSAccountRegionCoverageCovered,
+		LastSuccessfulScanAt: &now,
+		ScanCursor: map[string]any{
+			"next_token": "abc",
+		},
+	})
+	if err != nil {
+		t.Fatalf("upsert coverage: %v", err)
+	}
+	if got, want := coverage.TenantID, "tenant-a"; got != want {
+		t.Fatalf("tenant id = %q, want %q", got, want)
+	}
+	if got, want := coverage.WorkspaceID, "workspace-a"; got != want {
+		t.Fatalf("workspace id = %q, want %q", got, want)
+	}
+	if got, want := coverage.ProjectID, "project-1"; got != want {
+		t.Fatalf("project id = %q, want %q", got, want)
+	}
+	if got, want := coverage.CoverageStatus, db.AWSAccountRegionCoverageCovered; got != want {
+		t.Fatalf("coverage status = %q, want %q", got, want)
+	}
+
+	records, err := svc.ListAWSAccountRegionCoverages(ctx, "workspace-a", "project-1", db.AWSAccountRegionCoverageFilter{ConnectorID: "aws-prod"})
+	if err != nil {
+		t.Fatalf("list coverage: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records len = %d, want 1", len(records))
+	}
+	if got, want := records[0].AccountID, "123456789012"; got != want {
+		t.Fatalf("account id = %q, want %q", got, want)
+	}
+	if got, want := records[0].Region, "us-east-1"; got != want {
+		t.Fatalf("region = %q, want %q", got, want)
+	}
+
+	_, err = svc.UpsertAWSAccountRegionCoverage(ctx, "workspace-a", "project-1", db.AWSAccountRegionCoverage{
+		AccountID: "123456789012",
+		Region:    "us-west-2",
+	})
+	if !errors.Is(err, ErrInvalidAWSConnectionRequest) {
+		t.Fatalf("missing connector err = %v, want ErrInvalidAWSConnectionRequest", err)
+	}
+}
+
 func TestRouterAWSConnectionOnboardingReturnsTrustRemediation(t *testing.T) {
 	validator := &fakeAWSConnectorValidator{
 		result: AWSConnectionValidationResult{

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -45,6 +45,7 @@ type MemoryStore struct {
 	connectors                    map[string]TenancyConnector
 	connStates                    map[string]TenancyConnectorState
 	connSecrets                   map[string]TenancyConnectorSecretEnvelope
+	awsCoverages                  map[string]AWSAccountRegionCoverage
 	users                         map[string]User
 	userIdentityByID              map[string]UserIdentity
 	userIdentityByProviderSubject map[string]string
@@ -95,6 +96,7 @@ func NewMemoryStore() *MemoryStore {
 		connectors:                    map[string]TenancyConnector{},
 		connStates:                    map[string]TenancyConnectorState{},
 		connSecrets:                   map[string]TenancyConnectorSecretEnvelope{},
+		awsCoverages:                  map[string]AWSAccountRegionCoverage{},
 		users:                         map[string]User{},
 		userIdentityByID:              map[string]UserIdentity{},
 		userIdentityByProviderSubject: map[string]string{},

--- a/internal/db/memory_tenancy.go
+++ b/internal/db/memory_tenancy.go
@@ -101,6 +101,11 @@ func (m *MemoryStore) DeleteOrganization(ctx context.Context) error {
 			delete(m.connSecrets, secretKey)
 		}
 	}
+	for coverageKey, coverage := range m.awsCoverages {
+		if coverage.TenantID == scope.TenantID {
+			delete(m.awsCoverages, coverageKey)
+		}
+	}
 	m.mu.Unlock()
 
 	audit.WriteAction(ctx, audit.AuditEvent{
@@ -243,6 +248,11 @@ func (m *MemoryStore) DeleteWorkspace(ctx context.Context, workspaceID string) e
 	for secretKey, secret := range m.connSecrets {
 		if secret.TenantID == scope.TenantID && secret.WorkspaceID == normalizedWorkspaceID {
 			delete(m.connSecrets, secretKey)
+		}
+	}
+	for coverageKey, coverage := range m.awsCoverages {
+		if coverage.TenantID == scope.TenantID && coverage.WorkspaceID == normalizedWorkspaceID {
+			delete(m.awsCoverages, coverageKey)
 		}
 	}
 	m.mu.Unlock()
@@ -604,6 +614,11 @@ func (m *MemoryStore) DeleteProject(ctx context.Context, workspaceID string, pro
 	for secretKey, secret := range m.connSecrets {
 		if secret.TenantID == scope.TenantID && secret.WorkspaceID == resolvedWorkspaceID && secret.ProjectID == projectID {
 			delete(m.connSecrets, secretKey)
+		}
+	}
+	for coverageKey, coverage := range m.awsCoverages {
+		if coverage.TenantID == scope.TenantID && coverage.WorkspaceID == resolvedWorkspaceID && coverage.ProjectID == projectID {
+			delete(m.awsCoverages, coverageKey)
 		}
 	}
 	m.mu.Unlock()
@@ -1101,7 +1116,6 @@ func (m *MemoryStore) UpsertAWSAccountRegionCoverage(ctx context.Context, covera
 		return AWSAccountRegionCoverage{}, err
 	}
 	coverage.WorkspaceID = resolvedWorkspaceID
-	createdAtWasZero := coverage.CreatedAt.IsZero()
 	normalized, err := NormalizeAWSAccountRegionCoverageForWrite(coverage)
 	if err != nil {
 		return AWSAccountRegionCoverage{}, err
@@ -1111,7 +1125,7 @@ func (m *MemoryStore) UpsertAWSAccountRegionCoverage(ctx context.Context, covera
 		return AWSAccountRegionCoverage{}, ErrNotFound
 	}
 	key := awsAccountRegionCoverageKey(normalized.TenantID, normalized.WorkspaceID, normalized.ProjectID, normalized.ConnectorID, normalized.AccountID, normalized.Region)
-	if existing, exists := m.awsCoverages[key]; exists && createdAtWasZero {
+	if existing, exists := m.awsCoverages[key]; exists {
 		normalized.CreatedAt = existing.CreatedAt
 	}
 	m.awsCoverages[key] = normalized

--- a/internal/db/memory_tenancy.go
+++ b/internal/db/memory_tenancy.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -885,6 +886,10 @@ func tenancyScanPolicyKey(tenantID string, workspaceID string, projectID string,
 	return tenancyCompositeKey(strings.TrimSpace(tenantID), strings.TrimSpace(workspaceID), strings.TrimSpace(projectID), strings.TrimSpace(policyID))
 }
 
+func awsAccountRegionCoverageKey(tenantID string, workspaceID string, projectID string, connectorID string, accountID string, region string) string {
+	return tenancyCompositeKey(strings.TrimSpace(tenantID), strings.TrimSpace(workspaceID), strings.TrimSpace(projectID), strings.TrimSpace(connectorID), strings.TrimSpace(accountID), strings.ToLower(strings.TrimSpace(region)))
+}
+
 // UpsertTenancyConnector persists one connector and its latest state atomically.
 func (m *MemoryStore) UpsertTenancyConnector(ctx context.Context, connector TenancyConnector, state TenancyConnectorState) error {
 	m.mu.Lock()
@@ -1079,6 +1084,103 @@ func (m *MemoryStore) ListTenancyConnectorsUnscoped(_ context.Context, connector
 // ListAllTenancyConnectorsByType returns connectors across all scopes for internal runtime matching.
 func (m *MemoryStore) ListAllTenancyConnectorsByType(ctx context.Context, connectorType domain.ConnectorType, limit int) ([]TenancyConnectorWithState, error) {
 	return m.ListTenancyConnectorsUnscoped(ctx, connectorType, limit)
+}
+
+// UpsertAWSAccountRegionCoverage persists one account/region coverage row for a scoped AWS connector.
+func (m *MemoryStore) UpsertAWSAccountRegionCoverage(ctx context.Context, coverage AWSAccountRegionCoverage) (AWSAccountRegionCoverage, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return AWSAccountRegionCoverage{}, err
+	}
+	coverage.TenantID = scope.TenantID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, coverage.WorkspaceID)
+	if err != nil {
+		return AWSAccountRegionCoverage{}, err
+	}
+	coverage.WorkspaceID = resolvedWorkspaceID
+	createdAtWasZero := coverage.CreatedAt.IsZero()
+	normalized, err := NormalizeAWSAccountRegionCoverageForWrite(coverage)
+	if err != nil {
+		return AWSAccountRegionCoverage{}, err
+	}
+	connectorKey := tenancyConnectorKey(normalized.TenantID, normalized.WorkspaceID, normalized.ProjectID, normalized.ConnectorID)
+	if connector, exists := m.connectors[connectorKey]; !exists || connector.Type != domain.ConnectorTypeAWS {
+		return AWSAccountRegionCoverage{}, ErrNotFound
+	}
+	key := awsAccountRegionCoverageKey(normalized.TenantID, normalized.WorkspaceID, normalized.ProjectID, normalized.ConnectorID, normalized.AccountID, normalized.Region)
+	if existing, exists := m.awsCoverages[key]; exists && createdAtWasZero {
+		normalized.CreatedAt = existing.CreatedAt
+	}
+	m.awsCoverages[key] = normalized
+	return cloneAWSAccountRegionCoverage(normalized), nil
+}
+
+// ListAWSAccountRegionCoverages returns deterministic scoped AWS account/region coverage rows.
+func (m *MemoryStore) ListAWSAccountRegionCoverages(ctx context.Context, filter AWSAccountRegionCoverageFilter) ([]AWSAccountRegionCoverage, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, filter.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+	projectID := strings.TrimSpace(filter.ProjectID)
+	if projectID == "" {
+		return nil, fmt.Errorf("project id is required")
+	}
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	connectorID := strings.TrimSpace(filter.ConnectorID)
+	accountID := strings.TrimSpace(filter.AccountID)
+	region := strings.ToLower(strings.TrimSpace(filter.Region))
+	results := make([]AWSAccountRegionCoverage, 0, limit)
+	for _, coverage := range m.awsCoverages {
+		if coverage.TenantID != scope.TenantID || coverage.WorkspaceID != resolvedWorkspaceID || coverage.ProjectID != projectID {
+			continue
+		}
+		if connectorID != "" && coverage.ConnectorID != connectorID {
+			continue
+		}
+		if accountID != "" && coverage.AccountID != accountID {
+			continue
+		}
+		if region != "" && coverage.Region != region {
+			continue
+		}
+		results = append(results, cloneAWSAccountRegionCoverage(coverage))
+	}
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].ConnectorID != results[j].ConnectorID {
+			return results[i].ConnectorID < results[j].ConnectorID
+		}
+		if results[i].AccountID != results[j].AccountID {
+			return results[i].AccountID < results[j].AccountID
+		}
+		return results[i].Region < results[j].Region
+	})
+	if len(results) > limit {
+		results = results[:limit]
+	}
+	return results, nil
+}
+
+func cloneAWSAccountRegionCoverage(coverage AWSAccountRegionCoverage) AWSAccountRegionCoverage {
+	cloned := coverage
+	cloned.ScanCursor = cloneMetadataMap(coverage.ScanCursor)
+	if coverage.LastSuccessfulScanAt != nil {
+		scanned := coverage.LastSuccessfulScanAt.UTC()
+		cloned.LastSuccessfulScanAt = &scanned
+	}
+	return cloned
 }
 
 // UpsertTenancyConnectorSecretEnvelope persists one encrypted connector secret envelope.

--- a/internal/db/memory_tenancy_test.go
+++ b/internal/db/memory_tenancy_test.go
@@ -465,7 +465,6 @@ func TestMemoryStoreAWSAccountRegionCoverageRegistry(t *testing.T) {
 		LastObservedErrorCode:    "access_denied",
 		LastObservedErrorMessage: "AssumeRole denied for this account.",
 		ScanCursor:               map[string]any{"cursor": "blocked"},
-		Unreachable:              true,
 	}); err != nil {
 		t.Fatalf("upsert errored coverage: %v", err)
 	}
@@ -484,7 +483,8 @@ func TestMemoryStoreAWSAccountRegionCoverageRegistry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("update coverage: %v", err)
 	}
-	if updated.LastObservedErrorCode != "timeout" || updated.ScanCursor["retry_after"] == "" {
+	retryAfter, retryAfterOK := updated.ScanCursor["retry_after"].(string)
+	if updated.LastObservedErrorCode != "timeout" || !retryAfterOK || retryAfter == "" {
 		t.Fatalf("expected clean last-observed update, got %+v", updated)
 	}
 	if _, err := store.UpsertAWSAccountRegionCoverage(ctx, AWSAccountRegionCoverage{

--- a/internal/db/memory_tenancy_test.go
+++ b/internal/db/memory_tenancy_test.go
@@ -381,6 +381,169 @@ func TestMemoryStoreConnectorSecretEnvelopeCRUD(t *testing.T) {
 	}
 }
 
+func TestMemoryStoreAWSAccountRegionCoverageRegistry(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	tenantB := WithScope(context.Background(), Scope{TenantID: "tenant-b", WorkspaceID: "workspace-b"})
+	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+
+	if err := store.UpsertOrganization(ctx, TenancyOrganization{DisplayName: "Tenant A", Slug: "tenant-a"}); err != nil {
+		t.Fatalf("upsert organization: %v", err)
+	}
+	if err := store.UpsertWorkspace(ctx, TenancyWorkspace{WorkspaceID: "workspace-a", DisplayName: "Workspace A", Slug: "workspace-a"}); err != nil {
+		t.Fatalf("upsert workspace: %v", err)
+	}
+	for _, projectID := range []string{"project-1", "project-2"} {
+		if err := store.UpsertProject(ctx, TenancyProject{WorkspaceID: "workspace-a", ProjectID: projectID, Name: projectID, Slug: projectID}); err != nil {
+			t.Fatalf("upsert project %s: %v", projectID, err)
+		}
+	}
+	if err := store.UpsertTenancyConnector(ctx, TenancyConnector{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "aws-prod",
+		Type:        domain.ConnectorTypeAWS,
+		DisplayName: "Production AWS",
+		Status:      domain.ConnectorStatusActive,
+	}, TenancyConnectorState{WorkspaceID: "workspace-a", ProjectID: "project-1", ConnectorID: "aws-prod", HealthStatus: "healthy"}); err != nil {
+		t.Fatalf("upsert connector: %v", err)
+	}
+	if err := store.UpsertTenancyConnector(ctx, TenancyConnector{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-2",
+		ConnectorID: "aws-prod",
+		Type:        domain.ConnectorTypeAWS,
+		DisplayName: "Other AWS",
+		Status:      domain.ConnectorStatusActive,
+	}, TenancyConnectorState{WorkspaceID: "workspace-a", ProjectID: "project-2", ConnectorID: "aws-prod", HealthStatus: "healthy"}); err != nil {
+		t.Fatalf("upsert project-2 connector: %v", err)
+	}
+	if err := store.UpsertOrganization(tenantB, TenancyOrganization{DisplayName: "Tenant B", Slug: "tenant-b"}); err != nil {
+		t.Fatalf("upsert tenant-b organization: %v", err)
+	}
+	if err := store.UpsertWorkspace(tenantB, TenancyWorkspace{WorkspaceID: "workspace-b", DisplayName: "Workspace B", Slug: "workspace-b"}); err != nil {
+		t.Fatalf("upsert tenant-b workspace: %v", err)
+	}
+	if err := store.UpsertProject(tenantB, TenancyProject{WorkspaceID: "workspace-b", ProjectID: "project-1", Name: "Project B", Slug: "project-b"}); err != nil {
+		t.Fatalf("upsert tenant-b project: %v", err)
+	}
+	if err := store.UpsertTenancyConnector(tenantB, TenancyConnector{
+		WorkspaceID: "workspace-b",
+		ProjectID:   "project-1",
+		ConnectorID: "aws-prod",
+		Type:        domain.ConnectorTypeAWS,
+		DisplayName: "Tenant B AWS",
+		Status:      domain.ConnectorStatusActive,
+	}, TenancyConnectorState{WorkspaceID: "workspace-b", ProjectID: "project-1", ConnectorID: "aws-prod", HealthStatus: "healthy"}); err != nil {
+		t.Fatalf("upsert tenant-b connector: %v", err)
+	}
+
+	if _, err := store.UpsertAWSAccountRegionCoverage(ctx, AWSAccountRegionCoverage{
+		WorkspaceID:          "workspace-a",
+		ProjectID:            "project-1",
+		ConnectorID:          "aws-prod",
+		AccountID:            "222222222222",
+		AccountAlias:         "Analytics",
+		OrganizationID:       "o-example",
+		OUPath:               "/Root/Prod",
+		Partition:            "aws",
+		Region:               "us-east-1",
+		RoleARN:              "arn:aws:iam::222222222222:role/IdentrailReadOnly",
+		CoverageStatus:       AWSAccountRegionCoverageCovered,
+		LastSuccessfulScanAt: &now,
+		ScanCursor:           map[string]any{"cursor": "one"},
+	}); err != nil {
+		t.Fatalf("upsert coverage: %v", err)
+	}
+	if _, err := store.UpsertAWSAccountRegionCoverage(ctx, AWSAccountRegionCoverage{
+		WorkspaceID:              "workspace-a",
+		ProjectID:                "project-1",
+		ConnectorID:              "aws-prod",
+		AccountID:                "111111111111",
+		Region:                   "us-west-2",
+		CoverageStatus:           AWSAccountRegionCoverageError,
+		LastObservedErrorCode:    "access_denied",
+		LastObservedErrorMessage: "AssumeRole denied for this account.",
+		ScanCursor:               map[string]any{"cursor": "blocked"},
+		Unreachable:              true,
+	}); err != nil {
+		t.Fatalf("upsert errored coverage: %v", err)
+	}
+	updated, err := store.UpsertAWSAccountRegionCoverage(ctx, AWSAccountRegionCoverage{
+		WorkspaceID:              "workspace-a",
+		ProjectID:                "project-1",
+		ConnectorID:              "aws-prod",
+		AccountID:                "111111111111",
+		Region:                   "us-west-2",
+		CoverageStatus:           AWSAccountRegionCoverageUnreachable,
+		LastObservedErrorCode:    "timeout",
+		LastObservedErrorMessage: "Timed out listing IAM roles.",
+		ScanCursor:               map[string]any{"retry_after": "2026-05-12T12:05:00Z"},
+		Unreachable:              true,
+	})
+	if err != nil {
+		t.Fatalf("update coverage: %v", err)
+	}
+	if updated.LastObservedErrorCode != "timeout" || updated.ScanCursor["retry_after"] == "" {
+		t.Fatalf("expected clean last-observed update, got %+v", updated)
+	}
+	if _, err := store.UpsertAWSAccountRegionCoverage(ctx, AWSAccountRegionCoverage{
+		WorkspaceID:    "workspace-a",
+		ProjectID:      "project-2",
+		ConnectorID:    "aws-prod",
+		AccountID:      "333333333333",
+		Region:         "eu-west-1",
+		CoverageStatus: AWSAccountRegionCoverageCovered,
+	}); err != nil {
+		t.Fatalf("upsert project-2 coverage: %v", err)
+	}
+	if _, err := store.UpsertAWSAccountRegionCoverage(tenantB, AWSAccountRegionCoverage{
+		WorkspaceID:    "workspace-b",
+		ProjectID:      "project-1",
+		ConnectorID:    "aws-prod",
+		AccountID:      "444444444444",
+		Region:         "us-east-1",
+		CoverageStatus: AWSAccountRegionCoverageCovered,
+	}); err != nil {
+		t.Fatalf("upsert tenant-b coverage: %v", err)
+	}
+
+	records, err := store.ListAWSAccountRegionCoverages(ctx, AWSAccountRegionCoverageFilter{WorkspaceID: "workspace-a", ProjectID: "project-1", ConnectorID: "aws-prod", Limit: 10})
+	if err != nil {
+		t.Fatalf("list coverage: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("expected two project-scoped records, got %+v", records)
+	}
+	if records[0].AccountID != "111111111111" || records[1].AccountID != "222222222222" {
+		t.Fatalf("expected deterministic account ordering, got %+v", records)
+	}
+	if records[0].CoverageStatus != AWSAccountRegionCoverageUnreachable {
+		t.Fatalf("expected idempotent update to replace status, got %+v", records[0])
+	}
+	records[0].ScanCursor["retry_after"] = "mutated"
+	reloaded, err := store.ListAWSAccountRegionCoverages(ctx, AWSAccountRegionCoverageFilter{WorkspaceID: "workspace-a", ProjectID: "project-1", AccountID: "111111111111"})
+	if err != nil {
+		t.Fatalf("reload coverage: %v", err)
+	}
+	if reloaded[0].ScanCursor["retry_after"] == "mutated" {
+		t.Fatalf("expected scan cursor to be copied defensively")
+	}
+	if other, err := store.ListAWSAccountRegionCoverages(ctx, AWSAccountRegionCoverageFilter{WorkspaceID: "workspace-a", ProjectID: "project-2"}); err != nil || len(other) != 1 || other[0].AccountID != "333333333333" {
+		t.Fatalf("expected project isolation, got records=%+v err=%v", other, err)
+	}
+	if tenantBRecords, err := store.ListAWSAccountRegionCoverages(tenantB, AWSAccountRegionCoverageFilter{WorkspaceID: "workspace-b", ProjectID: "project-1"}); err != nil || len(tenantBRecords) != 1 || tenantBRecords[0].AccountID != "444444444444" {
+		t.Fatalf("expected tenant isolation, got records=%+v err=%v", tenantBRecords, err)
+	}
+	connector, err := store.GetTenancyConnector(ctx, "workspace-a", "project-1", "aws-prod")
+	if err != nil {
+		t.Fatalf("reload connector: %v", err)
+	}
+	if connector.Connector.Status != domain.ConnectorStatusActive || connector.State.HealthStatus != "healthy" {
+		t.Fatalf("account-level coverage error should not disconnect connector, got %+v", connector)
+	}
+}
+
 func TestMemoryStoreTenancyScopeIsolation(t *testing.T) {
 	store := NewMemoryStore()
 	tenantA := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -574,6 +574,35 @@ func TestFourteenthMigrationContainsConnectorSecretEnvelopeSchema(t *testing.T) 
 	}
 }
 
+func TestThirtyFourthMigrationContainsAWSCoverageRegistry(t *testing.T) {
+	path := filepath.Join("..", "..", "migrations", "000034_aws_account_region_coverage.up.sql")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	sql := string(content)
+	required := []string{
+		"CREATE TABLE IF NOT EXISTS aws_account_region_coverages",
+		"account_id TEXT NOT NULL",
+		"region TEXT NOT NULL",
+		"organization_id TEXT",
+		"ou_path TEXT",
+		"coverage_status TEXT NOT NULL DEFAULT 'unknown'",
+		"last_successful_scan_at TIMESTAMPTZ",
+		"scan_cursor JSONB NOT NULL DEFAULT '{}'::jsonb",
+		"FOREIGN KEY (tenant_id, workspace_id, project_id, connector_id)",
+		"ALTER TABLE aws_account_region_coverages ENABLE ROW LEVEL SECURITY",
+		"identrail_rls_scope_matches(tenant_id, workspace_id)",
+		"CREATE INDEX IF NOT EXISTS idx_aws_account_region_coverages_account_region",
+		"CREATE INDEX IF NOT EXISTS idx_aws_account_region_coverages_scope_status",
+	}
+	for _, item := range required {
+		if !strings.Contains(sql, item) {
+			t.Fatalf("expected AWS coverage registry migration item %q", item)
+		}
+	}
+}
+
 func TestFifteenthMigrationContainsDatabaseConstraintGuardrails(t *testing.T) {
 	path := filepath.Join("..", "..", "migrations", "000015_db_constraints_guardrails.up.sql")
 	content, err := os.ReadFile(path)

--- a/internal/db/postgres_tenancy.go
+++ b/internal/db/postgres_tenancy.go
@@ -1476,6 +1476,189 @@ func (p *PostgresStore) ListAllTenancyConnectorsByType(ctx context.Context, conn
 	return p.ListTenancyConnectorsUnscoped(ctx, connectorType, limit)
 }
 
+// UpsertAWSAccountRegionCoverage persists one account/region coverage row for a scoped AWS connector.
+func (p *PostgresStore) UpsertAWSAccountRegionCoverage(ctx context.Context, coverage AWSAccountRegionCoverage) (AWSAccountRegionCoverage, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return AWSAccountRegionCoverage{}, err
+	}
+	coverage.TenantID = scope.TenantID
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, coverage.WorkspaceID)
+	if err != nil {
+		return AWSAccountRegionCoverage{}, err
+	}
+	coverage.WorkspaceID = resolvedWorkspaceID
+	normalized, err := NormalizeAWSAccountRegionCoverageForWrite(coverage)
+	if err != nil {
+		return AWSAccountRegionCoverage{}, err
+	}
+	cursorPayload, err := json.Marshal(normalized.ScanCursor)
+	if err != nil {
+		return AWSAccountRegionCoverage{}, fmt.Errorf("marshal aws coverage scan cursor: %w", err)
+	}
+	rows, err := p.queryContext(
+		ctx,
+		`INSERT INTO aws_account_region_coverages (
+		     tenant_id, workspace_id, project_id, connector_id, account_id, account_alias,
+		     organization_id, ou_path, partition, region, role_arn, coverage_status,
+		     last_successful_scan_at, last_observed_error_code, last_observed_error_message,
+		     scan_cursor, suspended, disabled, unreachable, created_at, updated_at
+		 )
+		 VALUES ($1, $2, $3, $4, $5, NULLIF($6, ''), NULLIF($7, ''), NULLIF($8, ''), $9, $10, NULLIF($11, ''), $12, $13, NULLIF($14, ''), NULLIF($15, ''), $16::jsonb, $17, $18, $19, $20, $21)
+		 ON CONFLICT (tenant_id, workspace_id, project_id, connector_id, account_id, region) DO UPDATE
+		 SET account_alias = EXCLUDED.account_alias,
+		     organization_id = EXCLUDED.organization_id,
+		     ou_path = EXCLUDED.ou_path,
+		     partition = EXCLUDED.partition,
+		     role_arn = EXCLUDED.role_arn,
+		     coverage_status = EXCLUDED.coverage_status,
+		     last_successful_scan_at = EXCLUDED.last_successful_scan_at,
+		     last_observed_error_code = EXCLUDED.last_observed_error_code,
+		     last_observed_error_message = EXCLUDED.last_observed_error_message,
+		     scan_cursor = EXCLUDED.scan_cursor,
+		     suspended = EXCLUDED.suspended,
+		     disabled = EXCLUDED.disabled,
+		     unreachable = EXCLUDED.unreachable,
+		     updated_at = EXCLUDED.updated_at
+		 RETURNING tenant_id, workspace_id, project_id, connector_id, account_id, COALESCE(account_alias, ''), COALESCE(organization_id, ''), COALESCE(ou_path, ''), partition, region, COALESCE(role_arn, ''), coverage_status, last_successful_scan_at, COALESCE(last_observed_error_code, ''), COALESCE(last_observed_error_message, ''), scan_cursor, suspended, disabled, unreachable, created_at, updated_at`,
+		normalized.TenantID,
+		normalized.WorkspaceID,
+		normalized.ProjectID,
+		normalized.ConnectorID,
+		normalized.AccountID,
+		normalized.AccountAlias,
+		normalized.OrganizationID,
+		normalized.OUPath,
+		normalized.Partition,
+		normalized.Region,
+		normalized.RoleARN,
+		normalized.CoverageStatus,
+		normalized.LastSuccessfulScanAt,
+		normalized.LastObservedErrorCode,
+		normalized.LastObservedErrorMessage,
+		cursorPayload,
+		normalized.Suspended,
+		normalized.Disabled,
+		normalized.Unreachable,
+		normalized.CreatedAt,
+		normalized.UpdatedAt,
+	)
+	if isTenancyFKViolation(err) {
+		return AWSAccountRegionCoverage{}, ErrNotFound
+	}
+	if err != nil {
+		return AWSAccountRegionCoverage{}, fmt.Errorf("upsert aws account region coverage: %w", err)
+	}
+	defer rows.Close()
+	records, err := scanAWSAccountRegionCoverageRows(rows)
+	if err != nil {
+		return AWSAccountRegionCoverage{}, err
+	}
+	if len(records) == 0 {
+		return AWSAccountRegionCoverage{}, ErrNotFound
+	}
+	return records[0], nil
+}
+
+// ListAWSAccountRegionCoverages returns deterministic scoped AWS account/region coverage rows.
+func (p *PostgresStore) ListAWSAccountRegionCoverages(ctx context.Context, filter AWSAccountRegionCoverageFilter) ([]AWSAccountRegionCoverage, error) {
+	scope, err := RequireScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resolvedWorkspaceID, err := ResolveScopedWorkspaceID(scope, filter.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+	projectID := strings.TrimSpace(filter.ProjectID)
+	if projectID == "" {
+		return nil, fmt.Errorf("project id is required")
+	}
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	query := `SELECT tenant_id, workspace_id, project_id, connector_id, account_id, COALESCE(account_alias, ''), COALESCE(organization_id, ''), COALESCE(ou_path, ''), partition, region, COALESCE(role_arn, ''), coverage_status, last_successful_scan_at, COALESCE(last_observed_error_code, ''), COALESCE(last_observed_error_message, ''), scan_cursor, suspended, disabled, unreachable, created_at, updated_at
+		 FROM aws_account_region_coverages
+		 WHERE tenant_id = $1
+		   AND workspace_id = $2
+		   AND project_id = $3`
+	args := []any{scope.TenantID, resolvedWorkspaceID, projectID}
+	nextArg := 4
+	if connectorID := strings.TrimSpace(filter.ConnectorID); connectorID != "" {
+		query += fmt.Sprintf(" AND connector_id = $%d", nextArg)
+		args = append(args, connectorID)
+		nextArg++
+	}
+	if accountID := strings.TrimSpace(filter.AccountID); accountID != "" {
+		query += fmt.Sprintf(" AND account_id = $%d", nextArg)
+		args = append(args, accountID)
+		nextArg++
+	}
+	if region := strings.ToLower(strings.TrimSpace(filter.Region)); region != "" {
+		query += fmt.Sprintf(" AND region = $%d", nextArg)
+		args = append(args, region)
+		nextArg++
+	}
+	query += fmt.Sprintf(" ORDER BY connector_id ASC, account_id ASC, region ASC LIMIT $%d", nextArg)
+	args = append(args, limit)
+
+	rows, err := p.queryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query aws account region coverages: %w", err)
+	}
+	defer rows.Close()
+	return scanAWSAccountRegionCoverageRows(rows)
+}
+
+func scanAWSAccountRegionCoverageRows(rows rowsScanner) ([]AWSAccountRegionCoverage, error) {
+	results := []AWSAccountRegionCoverage{}
+	for rows.Next() {
+		var item AWSAccountRegionCoverage
+		var lastSuccessfulScanAt sql.NullTime
+		var cursorPayload []byte
+		if err := rows.Scan(
+			&item.TenantID,
+			&item.WorkspaceID,
+			&item.ProjectID,
+			&item.ConnectorID,
+			&item.AccountID,
+			&item.AccountAlias,
+			&item.OrganizationID,
+			&item.OUPath,
+			&item.Partition,
+			&item.Region,
+			&item.RoleARN,
+			&item.CoverageStatus,
+			&lastSuccessfulScanAt,
+			&item.LastObservedErrorCode,
+			&item.LastObservedErrorMessage,
+			&cursorPayload,
+			&item.Suspended,
+			&item.Disabled,
+			&item.Unreachable,
+			&item.CreatedAt,
+			&item.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan aws account region coverage row: %w", err)
+		}
+		if lastSuccessfulScanAt.Valid {
+			value := lastSuccessfulScanAt.Time.UTC()
+			item.LastSuccessfulScanAt = &value
+		}
+		if len(cursorPayload) > 0 {
+			if err := json.Unmarshal(cursorPayload, &item.ScanCursor); err != nil {
+				return nil, fmt.Errorf("decode aws coverage scan cursor: %w", err)
+			}
+		}
+		if item.ScanCursor == nil {
+			item.ScanCursor = map[string]any{}
+		}
+		results = append(results, item)
+	}
+	return results, rows.Err()
+}
+
 func (p *PostgresStore) listTenancyConnectorRows(ctx context.Context, tenantID string, workspaceID string, projectID string, connectorID string, connectorType string, limit int) ([]TenancyConnectorWithState, error) {
 	query := `SELECT
 		     c.tenant_id, c.workspace_id, c.project_id, c.connector_id, c.type, c.display_name, c.status,

--- a/internal/db/postgres_tenancy.go
+++ b/internal/db/postgres_tenancy.go
@@ -1492,28 +1492,13 @@ func (p *PostgresStore) UpsertAWSAccountRegionCoverage(ctx context.Context, cove
 	if err != nil {
 		return AWSAccountRegionCoverage{}, err
 	}
-	var connectorType string
-	if err := p.queryRowContext(
-		ctx,
-		`SELECT type FROM tenancy_connectors
-		 WHERE tenant_id = $1 AND workspace_id = $2 AND project_id = $3 AND connector_id = $4`,
-		normalized.TenantID,
-		normalized.WorkspaceID,
-		normalized.ProjectID,
-		normalized.ConnectorID,
-	).Scan(&connectorType); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return AWSAccountRegionCoverage{}, ErrNotFound
-		}
-		return AWSAccountRegionCoverage{}, fmt.Errorf("lookup connector for aws coverage: %w", err)
-	}
-	if domain.ConnectorType(connectorType) != domain.ConnectorTypeAWS {
-		return AWSAccountRegionCoverage{}, ErrNotFound
-	}
 	cursorPayload, err := json.Marshal(normalized.ScanCursor)
 	if err != nil {
 		return AWSAccountRegionCoverage{}, fmt.Errorf("marshal aws coverage scan cursor: %w", err)
 	}
+	// The INSERT ... SELECT ... WHERE c.type = 'aws' keeps the connector-type
+	// guard and the upsert atomic within one statement so a concurrent
+	// connector type change cannot race the type check.
 	rows, err := p.queryContext(
 		ctx,
 		`INSERT INTO aws_account_region_coverages (
@@ -1522,7 +1507,13 @@ func (p *PostgresStore) UpsertAWSAccountRegionCoverage(ctx context.Context, cove
 		     last_successful_scan_at, last_observed_error_code, last_observed_error_message,
 		     scan_cursor, suspended, disabled, unreachable, created_at, updated_at
 		 )
-		 VALUES ($1, $2, $3, $4, $5, NULLIF($6, ''), NULLIF($7, ''), NULLIF($8, ''), $9, $10, NULLIF($11, ''), $12, $13, NULLIF($14, ''), NULLIF($15, ''), $16::jsonb, $17, $18, $19, $20, $21)
+		 SELECT $1, $2, $3, $4, $5, NULLIF($6, ''), NULLIF($7, ''), NULLIF($8, ''), $9, $10, NULLIF($11, ''), $12, $13, NULLIF($14, ''), NULLIF($15, ''), $16::jsonb, $17, $18, $19, $20, $21
+		 FROM tenancy_connectors c
+		 WHERE c.tenant_id = $1
+		   AND c.workspace_id = $2
+		   AND c.project_id = $3
+		   AND c.connector_id = $4
+		   AND c.type = $22
 		 ON CONFLICT (tenant_id, workspace_id, project_id, connector_id, account_id, region) DO UPDATE
 		 SET account_alias = EXCLUDED.account_alias,
 		     organization_id = EXCLUDED.organization_id,
@@ -1560,6 +1551,7 @@ func (p *PostgresStore) UpsertAWSAccountRegionCoverage(ctx context.Context, cove
 		normalized.Unreachable,
 		normalized.CreatedAt,
 		normalized.UpdatedAt,
+		string(domain.ConnectorTypeAWS),
 	)
 	if isTenancyFKViolation(err) {
 		return AWSAccountRegionCoverage{}, ErrNotFound

--- a/internal/db/postgres_tenancy.go
+++ b/internal/db/postgres_tenancy.go
@@ -1492,6 +1492,24 @@ func (p *PostgresStore) UpsertAWSAccountRegionCoverage(ctx context.Context, cove
 	if err != nil {
 		return AWSAccountRegionCoverage{}, err
 	}
+	var connectorType string
+	if err := p.queryRowContext(
+		ctx,
+		`SELECT type FROM tenancy_connectors
+		 WHERE tenant_id = $1 AND workspace_id = $2 AND project_id = $3 AND connector_id = $4`,
+		normalized.TenantID,
+		normalized.WorkspaceID,
+		normalized.ProjectID,
+		normalized.ConnectorID,
+	).Scan(&connectorType); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return AWSAccountRegionCoverage{}, ErrNotFound
+		}
+		return AWSAccountRegionCoverage{}, fmt.Errorf("lookup connector for aws coverage: %w", err)
+	}
+	if domain.ConnectorType(connectorType) != domain.ConnectorTypeAWS {
+		return AWSAccountRegionCoverage{}, ErrNotFound
+	}
 	cursorPayload, err := json.Marshal(normalized.ScanCursor)
 	if err != nil {
 		return AWSAccountRegionCoverage{}, fmt.Errorf("marshal aws coverage scan cursor: %w", err)

--- a/internal/db/postgres_tenancy_test.go
+++ b/internal/db/postgres_tenancy_test.go
@@ -214,10 +214,6 @@ func TestPostgresStoreAWSAccountRegionCoverageRegistry(t *testing.T) {
 	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
 	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
 
-	mock.ExpectQuery(`SELECT type FROM tenancy_connectors`).
-		WithArgs("tenant-a", "workspace-a", "project-1", "aws-prod").
-		WillReturnRows(sqlmock.NewRows([]string{"type"}).AddRow("aws"))
-
 	upsertRows := sqlmock.NewRows([]string{
 		"tenant_id", "workspace_id", "project_id", "connector_id", "account_id", "account_alias",
 		"organization_id", "ou_path", "partition", "region", "role_arn", "coverage_status",
@@ -228,7 +224,7 @@ func TestPostgresStoreAWSAccountRegionCoverageRegistry(t *testing.T) {
 		"o-example", "/Root/Prod", "aws", "us-west-2", "arn:aws:iam::123456789012:role/IdentrailReadOnly", "covered",
 		now, "", "", []byte(`{"next_token":"abc"}`), false, false, false, now, now,
 	)
-	mock.ExpectQuery("INSERT INTO aws_account_region_coverages").
+	mock.ExpectQuery(`(?s)INSERT INTO aws_account_region_coverages.*FROM tenancy_connectors c.*c\.type = \$22.*ON CONFLICT.*RETURNING`).
 		WithArgs(
 			"tenant-a",
 			"workspace-a",
@@ -251,6 +247,7 @@ func TestPostgresStoreAWSAccountRegionCoverageRegistry(t *testing.T) {
 			false,
 			sqlmock.AnyArg(),
 			sqlmock.AnyArg(),
+			string(domain.ConnectorTypeAWS),
 		).
 		WillReturnRows(upsertRows)
 

--- a/internal/db/postgres_tenancy_test.go
+++ b/internal/db/postgres_tenancy_test.go
@@ -203,6 +203,105 @@ func TestPostgresStoreListTenancyConnectors(t *testing.T) {
 	}
 }
 
+func TestPostgresStoreAWSAccountRegionCoverageRegistry(t *testing.T) {
+	rawDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer rawDB.Close()
+
+	store := NewPostgresStoreWithDB(rawDB)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+
+	upsertRows := sqlmock.NewRows([]string{
+		"tenant_id", "workspace_id", "project_id", "connector_id", "account_id", "account_alias",
+		"organization_id", "ou_path", "partition", "region", "role_arn", "coverage_status",
+		"last_successful_scan_at", "last_observed_error_code", "last_observed_error_message",
+		"scan_cursor", "suspended", "disabled", "unreachable", "created_at", "updated_at",
+	}).AddRow(
+		"tenant-a", "workspace-a", "project-1", "aws-prod", "123456789012", "Production",
+		"o-example", "/Root/Prod", "aws", "us-west-2", "arn:aws:iam::123456789012:role/IdentrailReadOnly", "covered",
+		now, "", "", []byte(`{"next_token":"abc"}`), false, false, false, now, now,
+	)
+	mock.ExpectQuery("INSERT INTO aws_account_region_coverages").
+		WithArgs(
+			"tenant-a",
+			"workspace-a",
+			"project-1",
+			"aws-prod",
+			"123456789012",
+			"Production",
+			"o-example",
+			"/Root/Prod",
+			"aws",
+			"us-west-2",
+			"arn:aws:iam::123456789012:role/IdentrailReadOnly",
+			"covered",
+			sqlmock.AnyArg(),
+			"",
+			"",
+			sqlmock.AnyArg(),
+			false,
+			false,
+			false,
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+		).
+		WillReturnRows(upsertRows)
+
+	coverage, err := store.UpsertAWSAccountRegionCoverage(ctx, AWSAccountRegionCoverage{
+		WorkspaceID:          "workspace-a",
+		ProjectID:            "project-1",
+		ConnectorID:          "aws-prod",
+		AccountID:            "123456789012",
+		AccountAlias:         "Production",
+		OrganizationID:       "o-example",
+		OUPath:               "/Root/Prod",
+		Region:               "us-west-2",
+		RoleARN:              "arn:aws:iam::123456789012:role/IdentrailReadOnly",
+		CoverageStatus:       AWSAccountRegionCoverageCovered,
+		LastSuccessfulScanAt: &now,
+		ScanCursor:           map[string]any{"next_token": "abc"},
+	})
+	if err != nil {
+		t.Fatalf("upsert aws coverage: %v", err)
+	}
+	if coverage.AccountID != "123456789012" || coverage.ScanCursor["next_token"] != "abc" {
+		t.Fatalf("unexpected upserted coverage: %+v", coverage)
+	}
+
+	listRows := sqlmock.NewRows([]string{
+		"tenant_id", "workspace_id", "project_id", "connector_id", "account_id", "account_alias",
+		"organization_id", "ou_path", "partition", "region", "role_arn", "coverage_status",
+		"last_successful_scan_at", "last_observed_error_code", "last_observed_error_message",
+		"scan_cursor", "suspended", "disabled", "unreachable", "created_at", "updated_at",
+	}).AddRow(
+		"tenant-a", "workspace-a", "project-1", "aws-prod", "123456789012", "Production",
+		"o-example", "/Root/Prod", "aws", "us-west-2", "arn:aws:iam::123456789012:role/IdentrailReadOnly", "covered",
+		now, "", "", []byte(`{"next_token":"abc"}`), false, false, false, now, now,
+	)
+	mock.ExpectQuery(`(?s)SELECT.*FROM aws_account_region_coverages.*connector_id = \$4.*ORDER BY connector_id ASC, account_id ASC, region ASC LIMIT \$5`).
+		WithArgs("tenant-a", "workspace-a", "project-1", "aws-prod", 10).
+		WillReturnRows(listRows)
+
+	records, err := store.ListAWSAccountRegionCoverages(ctx, AWSAccountRegionCoverageFilter{
+		WorkspaceID: "workspace-a",
+		ProjectID:   "project-1",
+		ConnectorID: "aws-prod",
+		Limit:       10,
+	})
+	if err != nil {
+		t.Fatalf("list aws coverage: %v", err)
+	}
+	if len(records) != 1 || records[0].AccountID != "123456789012" {
+		t.Fatalf("unexpected coverage rows: %+v", records)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestPostgresStoreKubernetesEnrollmentTokenClaim(t *testing.T) {
 	rawDB, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/db/postgres_tenancy_test.go
+++ b/internal/db/postgres_tenancy_test.go
@@ -214,6 +214,10 @@ func TestPostgresStoreAWSAccountRegionCoverageRegistry(t *testing.T) {
 	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
 	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
 
+	mock.ExpectQuery(`SELECT type FROM tenancy_connectors`).
+		WithArgs("tenant-a", "workspace-a", "project-1", "aws-prod").
+		WillReturnRows(sqlmock.NewRows([]string{"type"}).AddRow("aws"))
+
 	upsertRows := sqlmock.NewRows([]string{
 		"tenant_id", "workspace_id", "project_id", "connector_id", "account_id", "account_alias",
 		"organization_id", "ou_path", "partition", "region", "role_arn", "coverage_status",

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -848,6 +848,56 @@ type TenancyConnectorWithState struct {
 	State     TenancyConnectorState `json:"state"`
 }
 
+const (
+	AWSAccountRegionCoverageUnknown     = "unknown"
+	AWSAccountRegionCoveragePending     = "pending"
+	AWSAccountRegionCoverageCovered     = "covered"
+	AWSAccountRegionCoverageGap         = "gap"
+	AWSAccountRegionCoverageError       = "error"
+	AWSAccountRegionCoverageSuspended   = "suspended"
+	AWSAccountRegionCoverageDisabled    = "disabled"
+	AWSAccountRegionCoverageUnreachable = "unreachable"
+)
+
+// AWSAccountRegionCoverage stores account/region inventory and scan readiness
+// for one project-scoped AWS connector. Connector health describes whether
+// Identrail can use the connector role; coverage describes each target account
+// and region reachable through that connector.
+type AWSAccountRegionCoverage struct {
+	TenantID                 string         `json:"tenant_id"`
+	WorkspaceID              string         `json:"workspace_id"`
+	ProjectID                string         `json:"project_id"`
+	ConnectorID              string         `json:"connector_id"`
+	AccountID                string         `json:"account_id"`
+	AccountAlias             string         `json:"account_alias,omitempty"`
+	OrganizationID           string         `json:"organization_id,omitempty"`
+	OUPath                   string         `json:"ou_path,omitempty"`
+	Partition                string         `json:"partition"`
+	Region                   string         `json:"region"`
+	RoleARN                  string         `json:"role_arn,omitempty"`
+	CoverageStatus           string         `json:"coverage_status"`
+	LastSuccessfulScanAt     *time.Time     `json:"last_successful_scan_at,omitempty"`
+	LastObservedErrorCode    string         `json:"last_observed_error_code,omitempty"`
+	LastObservedErrorMessage string         `json:"last_observed_error_message,omitempty"`
+	ScanCursor               map[string]any `json:"scan_cursor"`
+	Suspended                bool           `json:"suspended"`
+	Disabled                 bool           `json:"disabled"`
+	Unreachable              bool           `json:"unreachable"`
+	CreatedAt                time.Time      `json:"created_at"`
+	UpdatedAt                time.Time      `json:"updated_at"`
+}
+
+// AWSAccountRegionCoverageFilter constrains account/region coverage reads to a
+// scoped project and optionally one connector, account, or region.
+type AWSAccountRegionCoverageFilter struct {
+	WorkspaceID string
+	ProjectID   string
+	ConnectorID string
+	AccountID   string
+	Region      string
+	Limit       int
+}
+
 // TenancyConnectorSecretEnvelope stores one encrypted connector secret envelope.
 type TenancyConnectorSecretEnvelope struct {
 	TenantID        string               `json:"tenant_id"`
@@ -1954,6 +2004,105 @@ func NormalizeTenancyConnectorStateForWrite(state TenancyConnectorState) (Tenanc
 	return normalized, nil
 }
 
+// NormalizeAWSAccountRegionCoverageForWrite validates and canonicalizes one AWS
+// account/region coverage record before persistence.
+func NormalizeAWSAccountRegionCoverageForWrite(coverage AWSAccountRegionCoverage) (AWSAccountRegionCoverage, error) {
+	normalized := coverage
+	normalized.TenantID = strings.TrimSpace(coverage.TenantID)
+	if normalized.TenantID == "" {
+		return AWSAccountRegionCoverage{}, fmt.Errorf("tenant id is required")
+	}
+	normalized.WorkspaceID = strings.TrimSpace(coverage.WorkspaceID)
+	if normalized.WorkspaceID == "" {
+		return AWSAccountRegionCoverage{}, fmt.Errorf("workspace id is required")
+	}
+	normalized.ProjectID = strings.TrimSpace(coverage.ProjectID)
+	if normalized.ProjectID == "" {
+		return AWSAccountRegionCoverage{}, fmt.Errorf("project id is required")
+	}
+	normalized.ConnectorID = strings.TrimSpace(coverage.ConnectorID)
+	if normalized.ConnectorID == "" {
+		return AWSAccountRegionCoverage{}, fmt.Errorf("connector id is required")
+	}
+	normalized.AccountID = strings.TrimSpace(coverage.AccountID)
+	if !validAWSAccountID(normalized.AccountID) {
+		return AWSAccountRegionCoverage{}, fmt.Errorf("aws account id must be 12 digits")
+	}
+	normalized.AccountAlias = strings.TrimSpace(coverage.AccountAlias)
+	normalized.OrganizationID = strings.TrimSpace(coverage.OrganizationID)
+	normalized.OUPath = strings.TrimSpace(coverage.OUPath)
+	normalized.Partition = strings.ToLower(strings.TrimSpace(coverage.Partition))
+	if normalized.Partition == "" {
+		normalized.Partition = "aws"
+	}
+	normalized.Region = strings.ToLower(strings.TrimSpace(coverage.Region))
+	if normalized.Region == "" {
+		return AWSAccountRegionCoverage{}, fmt.Errorf("region is required")
+	}
+	normalized.RoleARN = strings.TrimSpace(coverage.RoleARN)
+	normalized.CoverageStatus = strings.ToLower(strings.TrimSpace(coverage.CoverageStatus))
+	if normalized.CoverageStatus == "" {
+		switch {
+		case normalized.Suspended:
+			normalized.CoverageStatus = AWSAccountRegionCoverageSuspended
+		case normalized.Disabled:
+			normalized.CoverageStatus = AWSAccountRegionCoverageDisabled
+		case normalized.Unreachable:
+			normalized.CoverageStatus = AWSAccountRegionCoverageUnreachable
+		case strings.TrimSpace(coverage.LastObservedErrorCode) != "" || strings.TrimSpace(coverage.LastObservedErrorMessage) != "":
+			normalized.CoverageStatus = AWSAccountRegionCoverageError
+		default:
+			normalized.CoverageStatus = AWSAccountRegionCoverageUnknown
+		}
+	}
+	switch normalized.CoverageStatus {
+	case AWSAccountRegionCoverageUnknown,
+		AWSAccountRegionCoveragePending,
+		AWSAccountRegionCoverageCovered,
+		AWSAccountRegionCoverageGap,
+		AWSAccountRegionCoverageError,
+		AWSAccountRegionCoverageSuspended,
+		AWSAccountRegionCoverageDisabled,
+		AWSAccountRegionCoverageUnreachable:
+	default:
+		return AWSAccountRegionCoverage{}, fmt.Errorf("invalid aws coverage status")
+	}
+	if normalized.LastSuccessfulScanAt != nil {
+		scanned := normalized.LastSuccessfulScanAt.UTC()
+		normalized.LastSuccessfulScanAt = &scanned
+	}
+	normalized.LastObservedErrorCode = strings.TrimSpace(coverage.LastObservedErrorCode)
+	normalized.LastObservedErrorMessage = strings.TrimSpace(coverage.LastObservedErrorMessage)
+	if normalized.ScanCursor == nil {
+		normalized.ScanCursor = map[string]any{}
+	} else {
+		normalized.ScanCursor = cloneMetadataMap(normalized.ScanCursor)
+	}
+	if normalized.CreatedAt.IsZero() {
+		normalized.CreatedAt = time.Now().UTC()
+	} else {
+		normalized.CreatedAt = normalized.CreatedAt.UTC()
+	}
+	if normalized.UpdatedAt.IsZero() {
+		normalized.UpdatedAt = normalized.CreatedAt
+	} else {
+		normalized.UpdatedAt = normalized.UpdatedAt.UTC()
+	}
+	return normalized, nil
+}
+
+func validAWSAccountID(accountID string) bool {
+	if len(accountID) != 12 {
+		return false
+	}
+	for _, char := range accountID {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 // NormalizeTenancyConnectorSecretEnvelopeForWrite validates one connector secret envelope record.
 func NormalizeTenancyConnectorSecretEnvelopeForWrite(secret TenancyConnectorSecretEnvelope) (TenancyConnectorSecretEnvelope, error) {
 	normalized := secret
@@ -2403,6 +2552,8 @@ type Store interface {
 	GetTenancyConnector(ctx context.Context, workspaceID string, projectID string, connectorID string) (TenancyConnectorWithState, error)
 	ListTenancyConnectors(ctx context.Context, workspaceID string, projectID string, connectorType domain.ConnectorType, limit int) ([]TenancyConnectorWithState, error)
 	ListTenancyConnectorsUnscoped(ctx context.Context, connectorType domain.ConnectorType, limit int) ([]TenancyConnectorWithState, error)
+	UpsertAWSAccountRegionCoverage(ctx context.Context, coverage AWSAccountRegionCoverage) (AWSAccountRegionCoverage, error)
+	ListAWSAccountRegionCoverages(ctx context.Context, filter AWSAccountRegionCoverageFilter) ([]AWSAccountRegionCoverage, error)
 	ClaimKubernetesEnrollmentToken(ctx context.Context, workspaceID string, projectID string, connectorID string, expectedEnrollmentTokenHash string, updatedMetadata map[string]any, status domain.ConnectorStatus, health string, lastErrorCode string, lastErrorMessage string, observedAt time.Time, updatedAt time.Time) (bool, error)
 	UpsertTenancyScanPolicy(ctx context.Context, policy TenancyScanPolicy) error
 	GetTenancyScanPolicy(ctx context.Context, workspaceID string, projectID string, policyID string) (TenancyScanPolicy, error)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2067,6 +2067,24 @@ func NormalizeAWSAccountRegionCoverageForWrite(coverage AWSAccountRegionCoverage
 	default:
 		return AWSAccountRegionCoverage{}, fmt.Errorf("invalid aws coverage status")
 	}
+	switch normalized.CoverageStatus {
+	case AWSAccountRegionCoverageSuspended:
+		if !normalized.Suspended || normalized.Disabled || normalized.Unreachable {
+			return AWSAccountRegionCoverage{}, fmt.Errorf("aws coverage status %q requires only the suspended flag", normalized.CoverageStatus)
+		}
+	case AWSAccountRegionCoverageDisabled:
+		if !normalized.Disabled || normalized.Suspended || normalized.Unreachable {
+			return AWSAccountRegionCoverage{}, fmt.Errorf("aws coverage status %q requires only the disabled flag", normalized.CoverageStatus)
+		}
+	case AWSAccountRegionCoverageUnreachable:
+		if !normalized.Unreachable || normalized.Suspended || normalized.Disabled {
+			return AWSAccountRegionCoverage{}, fmt.Errorf("aws coverage status %q requires only the unreachable flag", normalized.CoverageStatus)
+		}
+	default:
+		if normalized.Suspended || normalized.Disabled || normalized.Unreachable {
+			return AWSAccountRegionCoverage{}, fmt.Errorf("aws coverage status %q must not set blocked-state flags", normalized.CoverageStatus)
+		}
+	}
 	if normalized.LastSuccessfulScanAt != nil {
 		scanned := normalized.LastSuccessfulScanAt.UTC()
 		normalized.LastSuccessfulScanAt = &scanned

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -219,6 +219,72 @@ func TestNormalizeTenancyConnectorStateForWrite(t *testing.T) {
 	}
 }
 
+func TestNormalizeAWSAccountRegionCoverageForWrite(t *testing.T) {
+	scanned := time.Date(2026, 5, 10, 12, 0, 0, 0, time.FixedZone("WAT", 60*60))
+	normalized, err := NormalizeAWSAccountRegionCoverageForWrite(AWSAccountRegionCoverage{
+		TenantID:                 " tenant-a ",
+		WorkspaceID:              " workspace-a ",
+		ProjectID:                " project-1 ",
+		ConnectorID:              " aws-prod ",
+		AccountID:                " 123456789012 ",
+		AccountAlias:             " Production ",
+		OrganizationID:           " o-example ",
+		OUPath:                   " /Root/Prod ",
+		Partition:                " AWS ",
+		Region:                   " US-WEST-2 ",
+		RoleARN:                  " arn:aws:iam::123456789012:role/IdentrailReadOnly ",
+		CoverageStatus:           " COVERED ",
+		LastSuccessfulScanAt:     &scanned,
+		LastObservedErrorCode:    " ",
+		LastObservedErrorMessage: " ",
+		ScanCursor:               map[string]any{"next_token": "abc"},
+	})
+	if err != nil {
+		t.Fatalf("normalize aws coverage: %v", err)
+	}
+	if normalized.Partition != "aws" || normalized.Region != "us-west-2" || normalized.CoverageStatus != AWSAccountRegionCoverageCovered {
+		t.Fatalf("unexpected normalized coverage: %+v", normalized)
+	}
+	if normalized.LastSuccessfulScanAt == nil || normalized.LastSuccessfulScanAt.Location() != time.UTC {
+		t.Fatalf("expected scan time in UTC, got %+v", normalized.LastSuccessfulScanAt)
+	}
+	normalized.ScanCursor["next_token"] = "changed"
+	if got := normalized.ScanCursor["next_token"]; got != "changed" {
+		t.Fatalf("expected mutable copied cursor, got %v", got)
+	}
+
+	errored, err := NormalizeAWSAccountRegionCoverageForWrite(AWSAccountRegionCoverage{
+		TenantID:              "tenant-a",
+		WorkspaceID:           "workspace-a",
+		ProjectID:             "project-1",
+		ConnectorID:           "aws-prod",
+		AccountID:             "123456789012",
+		Region:                "us-east-1",
+		LastObservedErrorCode: "access_denied",
+	})
+	if err != nil {
+		t.Fatalf("normalize errored coverage: %v", err)
+	}
+	if errored.CoverageStatus != AWSAccountRegionCoverageError || errored.Partition != "aws" || errored.ScanCursor == nil {
+		t.Fatalf("expected defaults for errored coverage, got %+v", errored)
+	}
+
+	invalids := []AWSAccountRegionCoverage{
+		{WorkspaceID: "workspace-a", ProjectID: "project-1", ConnectorID: "aws", AccountID: "123456789012", Region: "us-east-1"},
+		{TenantID: "tenant-a", ProjectID: "project-1", ConnectorID: "aws", AccountID: "123456789012", Region: "us-east-1"},
+		{TenantID: "tenant-a", WorkspaceID: "workspace-a", ConnectorID: "aws", AccountID: "123456789012", Region: "us-east-1"},
+		{TenantID: "tenant-a", WorkspaceID: "workspace-a", ProjectID: "project-1", AccountID: "123456789012", Region: "us-east-1"},
+		{TenantID: "tenant-a", WorkspaceID: "workspace-a", ProjectID: "project-1", ConnectorID: "aws", AccountID: "not-account", Region: "us-east-1"},
+		{TenantID: "tenant-a", WorkspaceID: "workspace-a", ProjectID: "project-1", ConnectorID: "aws", AccountID: "123456789012"},
+		{TenantID: "tenant-a", WorkspaceID: "workspace-a", ProjectID: "project-1", ConnectorID: "aws", AccountID: "123456789012", Region: "us-east-1", CoverageStatus: "bad"},
+	}
+	for _, invalid := range invalids {
+		if _, err := NormalizeAWSAccountRegionCoverageForWrite(invalid); err == nil {
+			t.Fatalf("expected invalid aws coverage error for %+v", invalid)
+		}
+	}
+}
+
 func TestNormalizeAuthzEntityAttributesForWrite(t *testing.T) {
 	normalized, err := NormalizeAuthzEntityAttributesForWrite(AuthzEntityAttributes{
 		EntityKind:     "RESOURCE",

--- a/migrations/000034_aws_account_region_coverage.down.sql
+++ b/migrations/000034_aws_account_region_coverage.down.sql
@@ -1,0 +1,7 @@
+DROP POLICY IF EXISTS aws_account_region_coverages_scope_isolation ON aws_account_region_coverages;
+ALTER TABLE aws_account_region_coverages NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE aws_account_region_coverages DISABLE ROW LEVEL SECURITY;
+
+DROP INDEX IF EXISTS idx_aws_account_region_coverages_account_region;
+DROP INDEX IF EXISTS idx_aws_account_region_coverages_scope_status;
+DROP TABLE IF EXISTS aws_account_region_coverages;

--- a/migrations/000034_aws_account_region_coverage.up.sql
+++ b/migrations/000034_aws_account_region_coverage.up.sql
@@ -1,0 +1,45 @@
+CREATE TABLE IF NOT EXISTS aws_account_region_coverages (
+    tenant_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    connector_id TEXT NOT NULL,
+    account_id TEXT NOT NULL,
+    account_alias TEXT,
+    organization_id TEXT,
+    ou_path TEXT,
+    partition TEXT NOT NULL DEFAULT 'aws',
+    region TEXT NOT NULL,
+    role_arn TEXT,
+    coverage_status TEXT NOT NULL DEFAULT 'unknown',
+    last_successful_scan_at TIMESTAMPTZ,
+    last_observed_error_code TEXT,
+    last_observed_error_message TEXT,
+    scan_cursor JSONB NOT NULL DEFAULT '{}'::jsonb,
+    suspended BOOLEAN NOT NULL DEFAULT FALSE,
+    disabled BOOLEAN NOT NULL DEFAULT FALSE,
+    unreachable BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, workspace_id, project_id, connector_id, account_id, region),
+    FOREIGN KEY (tenant_id, workspace_id, project_id, connector_id)
+        REFERENCES tenancy_connectors(tenant_id, workspace_id, project_id, connector_id)
+        ON DELETE CASCADE,
+    CHECK (account_id ~ '^[0-9]{12}$'),
+    CHECK (LENGTH(TRIM(partition)) > 0),
+    CHECK (LENGTH(TRIM(region)) > 0),
+    CHECK (coverage_status IN ('unknown', 'pending', 'covered', 'gap', 'error', 'suspended', 'disabled', 'unreachable')),
+    CHECK (jsonb_typeof(scan_cursor) = 'object')
+);
+
+CREATE INDEX IF NOT EXISTS idx_aws_account_region_coverages_scope_status
+    ON aws_account_region_coverages (tenant_id, workspace_id, project_id, connector_id, coverage_status, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_aws_account_region_coverages_account_region
+    ON aws_account_region_coverages (tenant_id, workspace_id, account_id, region);
+
+ALTER TABLE aws_account_region_coverages ENABLE ROW LEVEL SECURITY;
+ALTER TABLE aws_account_region_coverages FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS aws_account_region_coverages_scope_isolation ON aws_account_region_coverages;
+CREATE POLICY aws_account_region_coverages_scope_isolation ON aws_account_region_coverages
+USING (identrail_rls_scope_matches(tenant_id, workspace_id))
+WITH CHECK (identrail_rls_scope_matches(tenant_id, workspace_id));


### PR DESCRIPTION
Fixes #1357

## Summary
- Add a tenant/workspace/project-scoped AWS account and region coverage registry with coverage statuses, scan cursors, error state, and blocked-state flags.
- Implement memory and Postgres store read/write paths plus AWS service helpers for scanner/connector workflows.
- Add migration coverage, store/service tests, AWS connector documentation, a focused coverage-registry doc, and changelog entry.

## Validation
- `go test ./internal/db ./internal/api`
- Push hooks: merge-conflict check, EOF/whitespace, gofmt check, `go vet`, local env token hygiene, Vercel artifact hygiene

## Risk / rollout
- Public API remains unchanged; this is an internal store/service registry for scanner and future UI use.
- Migration creates a new table with scoped foreign key cleanup and RLS protection.

## AI disclosure
- AI-assisted: Yes
- Tooling: Codex
- Human verification: issue dependency checked, CONTRIBUTING.md followed, DCO sign-off included, focused tests and push hooks passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an internal registry to track AWS account and region coverage per tenant/workspace/project/connector, with statuses, scan cursors, and blocked/error flags. Exposes project‑scoped store/service methods, adds migration/docs/tests, and keeps the public API unchanged. Fixes #1357.

- **New Features**
  - Upsert/list coverage in memory and Postgres with normalization, connector type check (must be AWS), and project-scoped reads; Postgres uses a single atomic type‑guarded upsert to prevent races.
  - Service methods: UpsertAWSAccountRegionCoverage and ListAWSAccountRegionCoverages; require a connector ID.
  - Statuses: unknown, pending, covered, gap, error, suspended, disabled, unreachable; store last_successful_scan_at, last_observed_error_code/message, and JSON scan_cursor; reject contradictory status/blocked-state flag combos.
  - Consistency: preserve CreatedAt on upsert; deterministic ordering; cascade-delete on tenant/workspace/project deletes to mirror FK behavior.

- **Migration**
  - New table `aws_account_region_coverages` with composite PK (tenant, workspace, project, connector, account, region), FK to `tenancy_connectors` (cascade delete), RLS via `identrail_rls_scope_matches` (forced), indexes for scope/status and account/region, and constraints for account ID format, allowed statuses, and JSON cursor. No public HTTP API changes.

<sup>Written for commit ab4c2541004a4dd4030bb94a944f6d6738380f07. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1372?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

