### PR TITLE
Fix WorkOS MFA enrollment challenge persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Fixed WorkOS MFA enrollment so the browser keeps the pending challenge after
+  showing the authenticator QR code, preventing valid setup codes from failing
+  with "mfa challenge has not started".
 - Added an internal AWS account and region coverage registry for tenant-scoped connector estate coverage, including migration, store methods, service helpers, tests, and documentation.
 - Added typed AWS connector capability modes (`discovery`, `runtime_evidence`,
   `remediation_plan`, `approved_remediation`, `authorization_advisory`,

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -529,7 +529,7 @@ func workOSMFAEnrollHandler(logger *zap.Logger, opts authSessionRouteOptions) gi
 			c.JSON(http.StatusBadRequest, gin.H{"error": "mfa enrollment is not pending"})
 			return
 		}
-		if state.TOTP != nil && state.ChallengeID != "" {
+		if strings.TrimSpace(state.ChallengeID) != "" {
 			c.JSON(http.StatusOK, workOSMFAEnrollResponse(state))
 			return
 		}
@@ -556,16 +556,21 @@ func workOSMFAEnrollHandler(logger *zap.Logger, opts authSessionRouteOptions) gi
 			ID:   enrolled.FactorID,
 			Type: enrolled.FactorType,
 		}}
-		state.TOTP = &sessionauth.WorkOSPendingTOTP{
+		state.ExpiresAt = 0
+		responseState := state
+		responseState.TOTP = &sessionauth.WorkOSPendingTOTP{
 			FactorID: enrolled.FactorID,
 			QRCode:   enrolled.TOTPQRCode,
 			Secret:   enrolled.TOTPSecret,
 			URI:      enrolled.TOTPURI,
 		}
+		// Real WorkOS QR payloads can exceed browser cookie limits once sealed.
+		// Keep the bulky setup material in the immediate response only; the
+		// cookie only needs the challenge id to verify the code.
 		if !writeWorkOSMFAPendingState(c, logger, opts, state) {
 			return
 		}
-		c.JSON(http.StatusOK, workOSMFAEnrollResponse(state))
+		c.JSON(http.StatusOK, workOSMFAEnrollResponse(responseState))
 	}
 }
 
@@ -602,6 +607,7 @@ func workOSMFAChallengeHandler(logger *zap.Logger, opts authSessionRouteOptions)
 		}
 		state.ChallengeID = challenge.ChallengeID
 		state.ChallengeExpiresAt = challenge.ExpiresAt
+		state.ExpiresAt = 0
 		if !writeWorkOSMFAPendingState(c, logger, opts, state) {
 			return
 		}

--- a/internal/api/workos_auth_routes_test.go
+++ b/internal/api/workos_auth_routes_test.go
@@ -656,6 +656,8 @@ func TestWorkOSCallbackContinuesMFAEnrollment(t *testing.T) {
 	svc := NewService(store, fakeScanner{}, "aws")
 	svc.Now = func() time.Time { return now }
 	sink := &recordingAuditSink{}
+	secret := strings.Repeat("a", 64)
+	largeQRCode := "data:image/png;base64," + strings.Repeat("A", 6000)
 	workOS := &fakeWorkOSClient{
 		err: &sessionauth.WorkOSMFARequired{
 			Mode:                       sessionauth.WorkOSMFAModeEnrollment,
@@ -674,6 +676,14 @@ func TestWorkOSCallbackContinuesMFAEnrollment(t *testing.T) {
 			},
 			AuthenticationMethod: "GitHubOAuth",
 		},
+		enrollResponse: sessionauth.WorkOSMFAEnrollResponse{
+			FactorID:    "auth_factor_1",
+			FactorType:  "totp",
+			ChallengeID: "auth_challenge_1",
+			TOTPQRCode:  largeQRCode,
+			TOTPSecret:  "secret",
+			TOTPURI:     "otpauth://totp/Identrail:mfa@example.com",
+		},
 	}
 	router := NewRouter(zap.NewNop(), telemetry.NewMetrics(), svc, RouterOptions{
 		FeatureNewAuth:     true,
@@ -681,7 +691,7 @@ func TestWorkOSCallbackContinuesMFAEnrollment(t *testing.T) {
 		PublicBaseURL:      "https://api.identrail.test",
 		CORSAllowedOrigins: []string{"https://app.identrail.test"},
 		AuditSink:          sink,
-		SessionKey:         strings.Repeat("a", 64),
+		SessionKey:         secret,
 		WorkOSClientID:     "client_123",
 		WorkOSAuthClient:   workOS,
 		RateLimitRPM:       1000,
@@ -722,12 +732,40 @@ func TestWorkOSCallbackContinuesMFAEnrollment(t *testing.T) {
 	enrollReq.AddCookie(pendingCookie)
 	enrollResp := httptest.NewRecorder()
 	router.ServeHTTP(enrollResp, enrollReq)
-	if enrollResp.Code != http.StatusOK || !strings.Contains(enrollResp.Body.String(), `"qr_code":"data:image/png;base64,qr"`) {
+	if enrollResp.Code != http.StatusOK {
 		t.Fatalf("unexpected enroll response: code=%d body=%s", enrollResp.Code, enrollResp.Body.String())
+	}
+	var enrollPayload struct {
+		ChallengeStarted bool `json:"challenge_started"`
+		TOTP             struct {
+			FactorID string `json:"factor_id"`
+			QRCode   string `json:"qr_code"`
+			Secret   string `json:"secret"`
+			URI      string `json:"uri"`
+		} `json:"totp"`
+	}
+	if err := json.NewDecoder(enrollResp.Body).Decode(&enrollPayload); err != nil {
+		t.Fatalf("decode enroll payload: %v", err)
+	}
+	if !enrollPayload.ChallengeStarted || enrollPayload.TOTP.QRCode != largeQRCode || enrollPayload.TOTP.Secret != "secret" {
+		t.Fatalf("unexpected enroll payload: %+v", enrollPayload)
 	}
 	updatedPendingCookie := findTestCookie(enrollResp.Result().Cookies(), sessionauth.PendingMFACookieName)
 	if updatedPendingCookie == nil || updatedPendingCookie.Value == "" {
 		t.Fatalf("expected refreshed pending mfa cookie, got %+v", enrollResp.Result().Cookies())
+	}
+	if got := len(updatedPendingCookie.Value); got >= 4096 {
+		t.Fatalf("pending mfa cookie should stay below browser cookie limits, got %d bytes", got)
+	}
+	openedPending, err := sessionauth.NewMFAPendingStateManager(secret, nil).Open(updatedPendingCookie.Value)
+	if err != nil {
+		t.Fatalf("open refreshed pending cookie: %v", err)
+	}
+	if openedPending.ChallengeID != "auth_challenge_1" {
+		t.Fatalf("expected challenge id in refreshed pending cookie, got %q", openedPending.ChallengeID)
+	}
+	if openedPending.TOTP != nil {
+		t.Fatalf("pending mfa cookie should not persist qr material, got %+v", openedPending.TOTP)
 	}
 
 	verifyReq := httptest.NewRequest(http.MethodPost, "/auth/mfa/verify", strings.NewReader(`{"code":"123456"}`))
@@ -737,6 +775,9 @@ func TestWorkOSCallbackContinuesMFAEnrollment(t *testing.T) {
 	router.ServeHTTP(verifyResp, verifyReq)
 	if verifyResp.Code != http.StatusOK || !strings.Contains(verifyResp.Body.String(), `"redirect_to":"https://app.identrail.test/app"`) {
 		t.Fatalf("unexpected verify response: code=%d body=%s", verifyResp.Code, verifyResp.Body.String())
+	}
+	if workOS.verifyInput.AuthenticationChallengeID != "auth_challenge_1" {
+		t.Fatalf("expected verify to use refreshed challenge id, got %q", workOS.verifyInput.AuthenticationChallengeID)
 	}
 	if workOS.verifyInput.PendingAuthenticationToken != "pending-token" || workOS.verifyInput.AuthenticationChallengeID != "auth_challenge_1" || workOS.verifyInput.Code != "123456" {
 		t.Fatalf("unexpected verify input: %+v", workOS.verifyInput)

--- a/web/src/pages/WorkOSMFAPage.tsx
+++ b/web/src/pages/WorkOSMFAPage.tsx
@@ -125,6 +125,7 @@ export function WorkOSMFAPage() {
 
   const isEnrollment = pending?.mode === 'enrollment';
   const needsChallengeStart = pending?.mode === 'challenge' && !pending.challenge_started;
+  const enrollmentChallengeStarted = Boolean(isEnrollment && pending?.challenge_started && !pending.totp);
   const canEnterCode = Boolean(pending?.challenge_started || pending?.totp);
 
   return (
@@ -145,10 +146,16 @@ export function WorkOSMFAPage() {
         {error ? <p className="idt-app-alert idt-app-alert-error">{error}</p> : null}
         {loading ? <p className="idt-auth-mfa-subtitle">Loading verification...</p> : null}
 
-        {!loading && pending && isEnrollment && !pending.totp ? (
+        {!loading && pending && isEnrollment && !pending.totp && !pending.challenge_started ? (
           <button className="idt-btn idt-btn-primary idt-auth-mfa-full" type="button" onClick={startEnrollment} disabled={busy}>
             {busy ? 'Starting setup...' : 'Set up authenticator app'}
           </button>
+        ) : null}
+
+        {!loading && pending && enrollmentChallengeStarted ? (
+          <p className="idt-auth-mfa-subtitle">
+            Enter the code from the authenticator app you just added. Start sign-in again if you need a fresh QR code.
+          </p>
         ) : null}
 
         {!loading && pending?.totp ? (


### PR DESCRIPTION
Fixes #1375

## Summary
- Keep the large WorkOS TOTP QR/secret setup payload out of the sealed pending MFA cookie while still returning it to the setup page.
- Refresh the pending MFA challenge state with the WorkOS challenge ID before users submit their authenticator code.
- Show a clearer reload state when the setup QR is no longer available but the enrollment challenge is active.

## Root cause
WorkOS was starting the MFA enrollment challenge, but the app stored the full QR payload in the pending MFA cookie. Real QR payloads can be large enough that browsers drop the refreshed cookie, so `/auth/mfa/verify` could receive the old pending state without a `challenge_id` and return `mfa challenge has not started`.

## Validation
- `go test ./internal/api -run 'TestWorkOSCallbackContinuesMFAEnrollment|TestWorkOSMFAEndpointErrorBranches' -count=1`
- `npm --prefix web test -- --run WorkOSMFAPage`
- pre-push hooks: merge conflict check, end-of-file check, trailing whitespace, gofmt, `go vet`, local env token hygiene, Vercel artifact hygiene

AI-assisted: Yes
Tools used: Codex
Where used: MFA auth route, MFA page, tests, changelog
Human verification performed: reviewed diff and ran the validation above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WorkOS MFA enrollment so the pending MFA cookie stays small and the challenge persists, preventing “mfa challenge has not started” errors. The QR/secret is returned only in the enroll response, while the cookie stores just the challenge ID.

- **Bug Fixes**
  - Store only the WorkOS `challenge_id` in the pending MFA cookie; return TOTP QR/secret in the enroll response to avoid cookie size limits.
  - Refresh the pending challenge by ID before verification; verification uses the refreshed ID (handles trimmed IDs).
  - Update MFA setup UI to hide the start button once the challenge has started and guide users when the QR is no longer available.
  - Add tests for large QR payloads, cookie size (<4KB), no TOTP data in the cookie, and verify flow using the refreshed challenge ID.

<sup>Written for commit 75fee67817a39ffb5b9d1550160a6e7b4437c356. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1374?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

