### PR TITLE
Polish AI risk scan health

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1570,6 +1570,9 @@ describe('App', () => {
     expect((await screen.findAllByText(/AI workflow prompt injection can reach Claude/i)).length).toBeGreaterThan(0);
     expect(await screen.findByText(/Repository hotspots/i)).toBeInTheDocument();
     expect((await screen.findAllByText(/owner\/repo/i)).length).toBeGreaterThan(0);
+    expect(await screen.findByText(/Scan health/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Success rate/i)).toBeInTheDocument();
+    expect((await screen.findAllByText(/3 high priority/i)).length).toBeGreaterThan(0);
   });
 
   it('keeps the AI Risks dashboard usable when trend loading fails', async () => {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1553,7 +1553,7 @@ describe('App', () => {
     setCurrentPath('/app/tenant-a/workspace-a/ai-risks');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { level: 2, name: /AI Risks/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /AI Risks/i })).toBeInTheDocument();
     const summary = await screen.findByLabelText(/AI Risks summary/i);
     const openMetric = within(summary).getByText('Open').closest('article') as HTMLElement;
     const repoMetric = within(summary).getByText('Repos').closest('article') as HTMLElement;

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -600,6 +600,16 @@ function isFailedScanStatus(status: string): boolean {
   return normalized === 'failed';
 }
 
+function scanCompletionSortValue(scan: RepoScanRecord): number {
+  const finishedAt = new Date(scan.finished_at ?? '');
+  if (!Number.isNaN(finishedAt.getTime())) {
+    return finishedAt.getTime();
+  }
+
+  const startedAt = new Date(scan.started_at ?? '');
+  return Number.isNaN(startedAt.getTime()) ? -Infinity : startedAt.getTime();
+}
+
 function repoScanStatusTone(status: string): 'success' | 'warning' | 'error' | 'neutral' {
   const normalized = normalizeValue(status).toLowerCase();
   if (normalized === 'succeeded' || normalized === 'completed') {
@@ -5993,15 +6003,17 @@ export function ProductAIRisksPage() {
   const scansByRecency = [...repoScans].sort(
     (left, right) => new Date(right.started_at).getTime() - new Date(left.started_at).getTime()
   );
+  const scansByCompletion = [...repoScans].sort(
+    (left, right) => scanCompletionSortValue(right) - scanCompletionSortValue(left)
+  );
   const latestScan = scansByRecency[0] ?? null;
-  const latestScanFailed = latestScan ? isFailedScanStatus(latestScan.status) : false;
-  const latestScanSucceeded = latestScan ? repoScanStatusTone(latestScan.status) === 'success' : false;
+  const latestScanTone = latestScan ? repoScanStatusTone(latestScan.status) : 'neutral';
   const activeScanCount = repoScans.filter((scan) => isActiveScanStatus(scan.status)).length;
   const failedScanCount = repoScans.filter((scan) => isFailedScanStatus(scan.status)).length;
   const completedScanCount = scansByRecency.filter((scan) => isCompletedScanStatus(scan.status)).length;
   const successfulScanCount = scansByRecency.filter((scan) => repoScanStatusTone(scan.status) === 'success').length;
-  const latestCompletedScan = scansByRecency.find((scan) => isCompletedScanStatus(scan.status)) ?? null;
-  const latestSuccessfulScan = scansByRecency.find((scan) => repoScanStatusTone(scan.status) === 'success') ?? null;
+  const latestCompletedScan = scansByCompletion.find((scan) => isCompletedScanStatus(scan.status)) ?? null;
+  const latestSuccessfulScan = scansByCompletion.find((scan) => repoScanStatusTone(scan.status) === 'success') ?? null;
   const scanSuccessRate = completedScanCount > 0 ? Math.round((successfulScanCount / completedScanCount) * 100) : null;
   const totalFilesScanned = scansByRecency.reduce((acc, scan) => acc + (scan.files_scanned ?? 0), 0);
   const totalScanFindings = scansByRecency.reduce((acc, scan) => acc + (scan.finding_count ?? 0), 0);
@@ -6016,11 +6028,11 @@ export function ProductAIRisksPage() {
   const latestScanLabel = latestScan
     ? `${canonicalGitHubRepositoryDisplay(latestScan.repository) || latestScan.repository} · ${formatTokenLabel(latestScan.status)}`
     : 'No repository scans yet';
-  const scanHealthTone = latestScanFailed
+  const scanHealthTone = latestScanTone === 'error'
     ? 'error'
     : activeScanCount > 0
       ? 'warning'
-      : latestScanSucceeded
+      : latestScanTone === 'success'
         ? 'success'
         : 'neutral';
   const scanHealthStatusLabel =

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -5894,16 +5894,15 @@ export function ProductAIRisksPage() {
     const maxTotal = Math.max(...trendPoints.map((point) => point.total), 0);
     return trendPoints.slice(-6).map((point, index) => {
       const startedAt = new Date(point.started_at);
+      const priority = (point.by_severity?.critical ?? 0) + (point.by_severity?.high ?? 0);
       return {
         key: `${point.started_at}-${index}`,
         label: Number.isNaN(startedAt.getTime())
           ? 'Unknown'
-          : startedAt.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }),
+          : startedAt.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }),
         total: point.total,
         percentage: maxTotal > 0 ? Math.round((point.total / maxTotal) * 100) : 0,
-        high:
-          (point.by_severity?.critical ?? 0) +
-          (point.by_severity?.high ?? 0)
+        priority
       };
     });
   }, [trendPoints]);
@@ -5995,8 +5994,17 @@ export function ProductAIRisksPage() {
     (left, right) => new Date(right.started_at).getTime() - new Date(left.started_at).getTime()
   );
   const latestScan = scansByRecency[0] ?? null;
+  const latestScanFailed = latestScan ? isFailedScanStatus(latestScan.status) : false;
+  const latestScanSucceeded = latestScan ? repoScanStatusTone(latestScan.status) === 'success' : false;
   const activeScanCount = repoScans.filter((scan) => isActiveScanStatus(scan.status)).length;
   const failedScanCount = repoScans.filter((scan) => isFailedScanStatus(scan.status)).length;
+  const completedScanCount = scansByRecency.filter((scan) => isCompletedScanStatus(scan.status)).length;
+  const successfulScanCount = scansByRecency.filter((scan) => repoScanStatusTone(scan.status) === 'success').length;
+  const latestCompletedScan = scansByRecency.find((scan) => isCompletedScanStatus(scan.status)) ?? null;
+  const latestSuccessfulScan = scansByRecency.find((scan) => repoScanStatusTone(scan.status) === 'success') ?? null;
+  const scanSuccessRate = completedScanCount > 0 ? Math.round((successfulScanCount / completedScanCount) * 100) : null;
+  const totalFilesScanned = scansByRecency.reduce((acc, scan) => acc + (scan.files_scanned ?? 0), 0);
+  const totalScanFindings = scansByRecency.reduce((acc, scan) => acc + (scan.finding_count ?? 0), 0);
   const openFindingCount = openFindings.length;
   const highPriorityCount = openFindings.filter((finding) => {
     const severity = normalizeValue(finding.severity).toLowerCase();
@@ -6008,6 +6016,29 @@ export function ProductAIRisksPage() {
   const latestScanLabel = latestScan
     ? `${canonicalGitHubRepositoryDisplay(latestScan.repository) || latestScan.repository} · ${formatTokenLabel(latestScan.status)}`
     : 'No repository scans yet';
+  const scanHealthTone = latestScanFailed
+    ? 'error'
+    : activeScanCount > 0
+      ? 'warning'
+      : latestScanSucceeded
+        ? 'success'
+        : 'neutral';
+  const scanHealthStatusLabel =
+    scanHealthTone === 'error'
+      ? 'Action needed'
+      : scanHealthTone === 'warning'
+        ? 'Running'
+        : scanHealthTone === 'success'
+          ? 'Healthy'
+          : 'No completed scan';
+  const scanHealthSummary =
+    scanHealthTone === 'error'
+      ? latestScan?.error_message || 'Latest scan needs operator attention.'
+      : scanHealthTone === 'warning'
+        ? 'A repository scan is currently queued or running.'
+        : latestSuccessfulScan
+          ? `Latest successful scan finished ${formatRelativeTime(latestSuccessfulScan.finished_at || latestSuccessfulScan.started_at)}.`
+          : 'Waiting for a completed repository scan.';
 
   return (
     <section className="idt-app-panel idt-github-intelligence-page">
@@ -6157,22 +6188,63 @@ export function ProductAIRisksPage() {
       </div>
 
       <div className="idt-github-intelligence-main">
-        <section className="idt-github-intelligence-panel">
-          <div className="idt-github-intelligence-panel-head">
-            <h3>Scan health</h3>
-            <Link to={projectsPath}>Manage scans</Link>
+        <section className="idt-github-intelligence-panel idt-repo-scan-health-panel" aria-label="Repository scan health">
+          <div className="idt-repo-scan-health-head">
+            <div>
+              <h3>Scan health</h3>
+              <p>{scanHealthSummary}</p>
+            </div>
+            <div className="idt-repo-scan-health-actions">
+              <span className={`idt-repo-scan-health-status is-${scanHealthTone}`}>
+                {scanHealthStatusLabel}
+              </span>
+              <Link to={projectsPath}>Manage scans</Link>
+            </div>
           </div>
           {latestScan ? (
-            <div className="idt-github-intelligence-scan">
-              <span className={`idt-source-status-pill is-${repoScanStatusTone(latestScan.status)}`}>
-                {formatTokenLabel(latestScan.status)}
-              </span>
-              <strong>{canonicalGitHubRepositoryDisplay(latestScan.repository) || latestScan.repository}</strong>
-              <p>
-                {formatCountLabel(latestScan.finding_count, 'finding')} · {formatCountLabel(latestScan.files_scanned, 'file')} · {formatDateLabel(latestScan.started_at)}
-              </p>
-              {latestScan.error_message ? <p>{latestScan.error_message}</p> : null}
-            </div>
+            <>
+              <div className="idt-repo-scan-health-grid">
+                <div>
+                  <span>Success rate</span>
+                  <strong>{scanSuccessRate === null ? 'N/A' : `${scanSuccessRate}%`}</strong>
+                  <small>{formatCountLabel(completedScanCount, 'completed scan')}</small>
+                </div>
+                <div>
+                  <span>Last completed</span>
+                  <strong>{latestCompletedScan ? formatRelativeTime(latestCompletedScan.finished_at || latestCompletedScan.started_at) : 'N/A'}</strong>
+                  <small>{latestCompletedScan ? formatTokenLabel(latestCompletedScan.status) : 'No finished scan'}</small>
+                </div>
+                <div>
+                  <span>Files covered</span>
+                  <strong>{totalFilesScanned.toLocaleString()}</strong>
+                  <small>{formatCountLabel(scansByRecency.length, 'recent scan')}</small>
+                </div>
+                <div>
+                  <span>Findings surfaced</span>
+                  <strong>{totalScanFindings.toLocaleString()}</strong>
+                  <small>{formatCountLabel(highPriorityCount, 'high priority', 'high priority')}</small>
+                </div>
+              </div>
+              <div className="idt-repo-scan-health-timeline" aria-label="Recent repository scan events">
+                {scansByRecency.slice(0, 4).map((scan) => {
+                  const tone = repoScanStatusTone(scan.status);
+                  const repositoryLabel = canonicalGitHubRepositoryDisplay(scan.repository) || scan.repository || 'Repository unavailable';
+                  const scanTime = scan.finished_at || scan.started_at;
+                  return (
+                    <article key={scan.id} className={`idt-repo-scan-health-event is-${tone}`}>
+                      <span className="idt-repo-scan-health-dot" aria-hidden="true" />
+                      <div>
+                        <strong>{repositoryLabel}</strong>
+                        <span>
+                          {formatTokenLabel(scan.status)} · {formatCountLabel(scan.finding_count, 'finding')} · {formatCountLabel(scan.files_scanned, 'file')}
+                        </span>
+                      </div>
+                      <time dateTime={scanTime}>{formatRelativeTime(scanTime)}</time>
+                    </article>
+                  );
+                })}
+              </div>
+            </>
           ) : (
             <AppShellEmptyState
               title="No scans yet"
@@ -6207,7 +6279,7 @@ export function ProductAIRisksPage() {
                   <div className="idt-repo-finding-trend-bar-track" role="img" aria-label={`AI Risks trend ${row.label}`}>
                     <div className="idt-repo-finding-trend-bar" style={{ width: `${row.percentage}%` }} />
                   </div>
-                  <small>{formatCountLabel(row.high, 'high priority', 'high priority')}</small>
+                  <small>{formatCountLabel(row.priority, 'high priority', 'high priority')}</small>
                 </article>
               ))}
             </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -23841,7 +23841,7 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 
 .idt-app-console-layout .idt-overview-header {
   align-items: flex-start;
-  padding: clamp(0.85rem, 1.4vw, 1.05rem) 0 clamp(0.95rem, 1.6vw, 1.2rem);
+  padding: clamp(0.85rem, 1.4vw, 1.05rem) clamp(1rem, 1.7vw, 1.4rem) clamp(0.95rem, 1.6vw, 1.2rem);
   border: none;
   border-radius: 0;
   background: transparent;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4914,6 +4914,16 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   gap: 0.45rem;
 }
 
+.idt-github-intelligence-trend .idt-repo-finding-trend-bar-track {
+  height: 0.42rem;
+  border: 0;
+  background: rgba(126, 157, 211, 0.16);
+}
+
+.idt-github-intelligence-trend .idt-repo-finding-trend-bar {
+  background: rgba(244, 248, 255, 0.88);
+}
+
 .idt-repo-finding-stat-note {
   margin-top: 0.1rem;
   color: var(--app-dim, #6f86ad);
@@ -4934,6 +4944,229 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
 .idt-repo-scan-health a {
   white-space: nowrap;
   font-weight: 600;
+}
+
+.idt-repo-scan-health-panel {
+  gap: 0.9rem;
+}
+
+.idt-repo-scan-health-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.idt-repo-scan-health-head h3 {
+  margin: 0;
+}
+
+.idt-repo-scan-health-head p {
+  margin: 0.22rem 0 0;
+  color: #9fb5d8;
+  font-size: 0.88rem;
+}
+
+.idt-repo-scan-health-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.idt-repo-scan-health-actions a {
+  color: #f4f8ff;
+  font-size: 0.82rem;
+  font-weight: 800;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.idt-repo-scan-health-actions a:hover,
+.idt-repo-scan-health-actions a:focus-visible {
+  text-decoration: underline;
+}
+
+.idt-repo-scan-health-status {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid rgba(126, 157, 211, 0.26);
+  border-radius: 999px;
+  padding: 0.22rem 0.58rem;
+  background: rgba(255, 255, 255, 0.06);
+  color: #dce9ff;
+  font-size: 0.74rem;
+  font-weight: 800;
+  line-height: 1.2;
+}
+
+.idt-repo-scan-health-status.is-success {
+  border-color: rgba(88, 214, 141, 0.42);
+  background: rgba(88, 214, 141, 0.11);
+  color: #b9f6ce;
+}
+
+.idt-repo-scan-health-status.is-warning {
+  border-color: rgba(245, 196, 81, 0.42);
+  background: rgba(245, 196, 81, 0.11);
+  color: #ffe5a3;
+}
+
+.idt-repo-scan-health-status.is-error {
+  border-color: rgba(255, 107, 107, 0.5);
+  background: rgba(255, 107, 107, 0.12);
+  color: #ffc3c3;
+}
+
+.idt-repo-scan-health-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border: 1px solid rgba(126, 157, 211, 0.18);
+  border-radius: 8px;
+  background: rgba(6, 11, 20, 0.6);
+  overflow: hidden;
+}
+
+.idt-repo-scan-health-grid div {
+  min-width: 0;
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.75rem 0.85rem;
+  border-right: 1px solid rgba(126, 157, 211, 0.18);
+}
+
+.idt-repo-scan-health-grid div:last-child {
+  border-right: 0;
+}
+
+.idt-repo-scan-health-grid span,
+.idt-repo-scan-health-grid small {
+  color: #9fb5d8;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.idt-repo-scan-health-grid span {
+  text-transform: uppercase;
+}
+
+.idt-repo-scan-health-grid strong {
+  color: #f4f8ff;
+  font-size: 1.18rem;
+  line-height: 1.1;
+  font-variant-numeric: tabular-nums;
+}
+
+.idt-repo-scan-health-timeline {
+  display: grid;
+  gap: 0.42rem;
+}
+
+.idt-repo-scan-health-event {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.65rem;
+  border: 1px solid rgba(126, 157, 211, 0.18);
+  border-radius: 8px;
+  padding: 0.56rem 0.65rem;
+  background: rgba(6, 11, 20, 0.42);
+}
+
+.idt-repo-scan-health-dot {
+  width: 0.48rem;
+  height: 0.48rem;
+  border-radius: 999px;
+  background: #9fb5d8;
+  box-shadow: 0 0 0 0.22rem rgba(159, 181, 216, 0.12);
+}
+
+.idt-repo-scan-health-event.is-success .idt-repo-scan-health-dot {
+  background: #58d68d;
+  box-shadow: 0 0 0 0.22rem rgba(88, 214, 141, 0.12);
+}
+
+.idt-repo-scan-health-event.is-warning .idt-repo-scan-health-dot {
+  background: #f5c451;
+  box-shadow: 0 0 0 0.22rem rgba(245, 196, 81, 0.12);
+}
+
+.idt-repo-scan-health-event.is-error .idt-repo-scan-health-dot {
+  background: #ff6b6b;
+  box-shadow: 0 0 0 0.22rem rgba(255, 107, 107, 0.12);
+}
+
+.idt-repo-scan-health-event div {
+  min-width: 0;
+  display: grid;
+  gap: 0.12rem;
+}
+
+.idt-repo-scan-health-event strong {
+  color: #f4f8ff;
+  font-size: 0.9rem;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+}
+
+.idt-repo-scan-health-event span:not(.idt-repo-scan-health-dot),
+.idt-repo-scan-health-event time {
+  color: #9fb5d8;
+  font-size: 0.76rem;
+  line-height: 1.35;
+}
+
+.idt-repo-scan-health-event time {
+  justify-self: end;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 980px) {
+  .idt-repo-scan-health-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .idt-repo-scan-health-grid div:nth-child(2) {
+    border-right: 0;
+  }
+
+  .idt-repo-scan-health-grid div:nth-child(-n + 2) {
+    border-bottom: 1px solid rgba(126, 157, 211, 0.18);
+  }
+}
+
+@media (max-width: 640px) {
+  .idt-repo-scan-health-head {
+    display: grid;
+  }
+
+  .idt-repo-scan-health-actions {
+    justify-content: flex-start;
+  }
+
+  .idt-repo-scan-health-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .idt-repo-scan-health-grid div,
+  .idt-repo-scan-health-grid div:nth-child(2) {
+    border-right: 0;
+  }
+
+  .idt-repo-scan-health-grid div:not(:last-child) {
+    border-bottom: 1px solid rgba(126, 157, 211, 0.18);
+  }
+
+  .idt-repo-scan-health-event {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .idt-repo-scan-health-event time {
+    grid-column: 2;
+    justify-self: start;
+  }
 }
 
 .idt-repo-scan-failure-state .idt-inline-actions {
@@ -20374,6 +20607,58 @@ html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-trend-bar-tra
   background: #ffffff;
 }
 
+.idt-app-console-layout .idt-repo-scan-health-head h3,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-health-head h3 {
+  color: #ffffff;
+}
+
+.idt-app-console-layout .idt-repo-scan-health-head p,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-health-head p,
+.idt-app-console-layout .idt-repo-scan-health-grid span,
+.idt-app-console-layout .idt-repo-scan-health-grid small,
+.idt-app-console-layout .idt-repo-scan-health-event span:not(.idt-repo-scan-health-dot),
+.idt-app-console-layout .idt-repo-scan-health-event time,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-health-grid span,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-health-grid small,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-health-event span:not(.idt-repo-scan-health-dot),
+html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-health-event time {
+  color: var(--app-dim);
+}
+
+.idt-app-console-layout .idt-repo-scan-health-actions a,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-health-actions a,
+.idt-app-console-layout .idt-repo-scan-health-grid strong,
+.idt-app-console-layout .idt-repo-scan-health-event strong,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-health-grid strong,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-health-event strong {
+  color: #ffffff;
+}
+
+.idt-app-console-layout .idt-repo-scan-health-grid,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-health-grid,
+.idt-app-console-layout .idt-repo-scan-health-event,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-health-event {
+  border-color: var(--app-border);
+  background: #050505;
+}
+
+.idt-app-console-layout .idt-repo-scan-health-grid div,
+html[data-theme='light'] .idt-app-console-layout .idt-repo-scan-health-grid div {
+  border-color: var(--app-border);
+}
+
+.idt-app-console-layout .idt-github-intelligence-trend .idt-repo-finding-trend-bar-track,
+html[data-theme='light'] .idt-app-console-layout .idt-github-intelligence-trend .idt-repo-finding-trend-bar-track {
+  height: 0.42rem;
+  border: 0;
+  background: #1b1b1f;
+}
+
+.idt-app-console-layout .idt-github-intelligence-trend .idt-repo-finding-trend-bar,
+html[data-theme='light'] .idt-app-console-layout .idt-github-intelligence-trend .idt-repo-finding-trend-bar {
+  background: rgba(255, 255, 255, 0.86);
+}
+
 .idt-app-console-layout .idt-executive-bar,
 .idt-executive-report-shell .idt-executive-bar {
   background: #151515;
@@ -23555,8 +23840,8 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 }
 
 .idt-app-console-layout .idt-overview-header {
-  align-items: center;
-  padding: 0.5rem 0 0.75rem;
+  align-items: flex-start;
+  padding: clamp(0.85rem, 1.4vw, 1.05rem) 0 clamp(0.95rem, 1.6vw, 1.2rem);
   border: none;
   border-radius: 0;
   background: transparent;
@@ -23575,13 +23860,13 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
   font-family: var(--idt-display);
   font-size: clamp(1.55rem, 2vw, 1.95rem);
   font-weight: 600;
-  letter-spacing: -0.015em;
+  letter-spacing: 0;
   color: #ffffff;
   line-height: 1.1;
 }
 
 .idt-app-console-layout .idt-overview-header p {
-  margin: 0.35rem 0 0;
+  margin: 0.48rem 0 0;
   color: var(--app-muted);
   font-size: 0.92rem;
 }


### PR DESCRIPTION
No linked issue supplied.

## What changed
- Redesigned the AI Risks scan health area into a compact operational panel with status, success rate, scan coverage, surfaced findings, and recent scan events.
- Tightened AI Risks trend rows with timestamped points, quieter bars, and high-priority counts.
- Added more breathing room to the Overview header so the title and latest-activity subtitle do not sit on the edge.

## Validation
- npm test -- --run src/App.test.tsx src/productShell.test.tsx
- npm run build
- Browser QA with local mock data for AI Risks scan health and Overview header spacing

## AI disclosure
- AI-assisted: yes
- Tools used: Codex
- Where used: web/src/productShell.tsx, web/src/styles.css, web/src/App.test.tsx
- Human verification performed: focused tests, production build, and local browser visual QA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the AI Risks “Scan health” into a compact, responsive panel with clear status, key metrics, and a recent-events timeline. Refined trend visuals (date+time points, softer bars) and adjusted Overview header spacing.

- **New Features**
  - Compact scan health with status pill (Healthy/Running/Action needed/No completed scan), contextual summary, and “Manage scans”.
  - Metrics: success rate (% of completed scans), last completed time/status, totals for files covered and findings with high‑priority count.
  - Recent scan events (last 4) with repository, status, counts, and relative time; trend rows now show date + time.

- **Bug Fixes**
  - “Last completed” now sorts by actual completion time to avoid in‑progress scans.
  - Accessibility, theming, and responsiveness: ARIA labels for panel/timeline, refined heading semantics, console layout color/spacing polish.

<sup>Written for commit ce4a8a829f762cc70cfb63104aa8e06e5af5af1a. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1376?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

