### PR TITLE
Darken product shell panels

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -24393,23 +24393,23 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
 .idt-app-shell-screen,
 .idt-executive-report-shell {
   --app-bg: #121518;
-  --app-panel: #181b1f;
-  --app-panel-strong: #111417;
+  --app-panel: #090b0e;
+  --app-panel-strong: #050607;
   --app-border: #2b3037;
-  --app-border-soft: #23282e;
+  --app-border-soft: #20252b;
   --app-text: #f5f7f8;
   --app-muted: #adb5bf;
   --app-dim: #7f8792;
-  --app-ink: #101317;
-  --app-paper: #171a1e;
+  --app-ink: #050607;
+  --app-paper: #090b0e;
   --app-paper-muted: #aeb6c0;
-  --app-blueprint: #111827;
-  --idt-console-rail: #191d21;
-  --idt-console-rail-hover: #23282e;
-  --idt-console-surface: #181b1f;
-  --idt-console-surface-raised: #1b1f24;
-  --idt-console-surface-quiet: #15191d;
-  --idt-console-surface-deep: #101317;
+  --app-blueprint: #070c14;
+  --idt-console-rail: #050607;
+  --idt-console-rail-hover: #101318;
+  --idt-console-surface: #090b0e;
+  --idt-console-surface-raised: #0f1217;
+  --idt-console-surface-quiet: #07090c;
+  --idt-console-surface-deep: #030405;
   --idt-console-focus: #7c6dff;
   --idt-console-shadow: 0 18px 48px rgba(0, 0, 0, 0.26);
 }
@@ -24474,7 +24474,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a:focus-visi
 
 .idt-app-console-layout .idt-app-shell-nav a.active,
 html[data-theme='light'] .idt-app-console-layout .idt-app-shell-nav a.active {
-  background: #293039;
+  background: #171b22;
   color: #ffffff;
 }
 
@@ -24499,7 +24499,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-sidebar-account-menu {
 .idt-app-sidebar-account-menu a:focus-visible,
 .idt-app-sidebar-account-menu button:hover,
 .idt-app-sidebar-account-menu button:focus-visible {
-  background: #252b32;
+  background: #171b22;
 }
 
 .idt-app-console-layout .idt-overview-header,
@@ -24663,7 +24663,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-row:hover,
 html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-row:focus-visible,
 html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-row.is-selected {
   border-color: #4c5664;
-  background: #161b21;
+  background: #0f141a;
 }
 
 .idt-app-console-layout .idt-btn-primary,


### PR DESCRIPTION
## Summary

- Push the product side rail and elevated panels to a near-black Vercel-style surface.
- Keep the main workspace on the softer charcoal canvas from #1373 so the page still has depth instead of going flat black everywhere.
- Tone active/hover states and selected finding rows to sit naturally on the darker panel shell.

## Why

Follow-up feedback after #1373: the side panel still read too gray. This makes the panel side intentionally extremely dark while preserving readable hierarchy across the dashboard.

## Scope

- [x] Focused change: CSS-only product shell palette adjustment
- [x] Backward compatibility considered
- [x] Risk level assessed: low; visual styling only

## Validation

```bash
git diff --check
npm --prefix web exec -- vitest run src/repoFindingDisplay.test.ts
npm run build --prefix web
```

Results:
- Diff whitespace check passed.
- Findings display tests passed: 1 file, 16 tests.
- Production web build completed and prerendered 39 routes.
- Visual QA confirmed the sidebar rail and panels now render near-black against the charcoal canvas.

## Checklist

- [x] Tests added/updated for behavior changes: not needed, CSS-only visual refinement
- [x] Docs updated for user/operator-facing changes: not needed, product UI polish only
- [x] `CHANGELOG.md` updated when relevant: not needed, no API/operator behavior change
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: yes
- Tools used: Codex
- Areas where used: product shell CSS palette and visual QA
- Human verification performed: reviewed diff scope, ran targeted findings display tests, ran production build/prerender, and checked the local overview screenshot

## Related Issues

No issue: follow-up product feedback from live app review after #1373.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Darkened the product shell side rail and elevated panels to a near-black Vercel-style surface while keeping the main workspace on the charcoal canvas for depth and contrast. Updated active/hover states and selected finding rows to match the darker shell.

<sup>Written for commit 8bc04ffe91303b5027ef044d7367e9c549addafa. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1377?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

