### PR TITLE
Add premium app foundation primitives

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1635,6 +1635,7 @@ describe('App', () => {
     setCurrentPath('/app/tenant-a/workspace-a/ai-risks');
     render(<App />);
 
+    await waitFor(() => expect(fetchMock.mock.calls.some(([input]) => String(input).includes('/v1/repo-findings'))).toBe(true));
     expect(await screen.findByRole('heading', { level: 2, name: /AI Risks/i })).toBeInTheDocument();
     expect(await screen.findByText(/MCP server exposes sensitive environment references/i)).toBeInTheDocument();
     expect(await screen.findByText(/Trend unavailable/i)).toBeInTheDocument();

--- a/web/src/components/app/DomainFoundation.test.tsx
+++ b/web/src/components/app/DomainFoundation.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import {
@@ -106,6 +106,25 @@ describe('DomainFoundation', () => {
     expect(screen.getByText('AI / Agentic Risk')).toBeInTheDocument();
   });
 
+  it('auto-opens parent subnav when a nested child is active', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <DomainSubnav
+          label="GitHub sections"
+          items={[
+            {
+              id: 'agentic-risk',
+              label: 'AI / Agentic Risk',
+              children: [{ id: 'tools', label: 'MCP / tools / secrets', to: '/github/agentic-risk/tools', active: true }]
+            }
+          ]}
+        />
+      </MemoryRouter>
+    );
+
+    expect(container.querySelector('details.idt-domain-subnav-group')).toHaveAttribute('open');
+  });
+
   it('covers operational states, dense tables, filters, evidence, and action footers', () => {
     render(
       <MemoryRouter>
@@ -159,5 +178,18 @@ describe('DomainFoundation', () => {
     expect(screen.getByRole('status')).toHaveTextContent('Loading GitHub repositories');
     expect(screen.getByText('{"Effect":"Allow"}')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Approve plan' })).toBeInTheDocument();
+  });
+
+  it('always prevents native submit in filter bar handlers', () => {
+    let eventWasPrevented = false;
+    const handleSubmit = vi.fn((event: { defaultPrevented: boolean }) => {
+      eventWasPrevented = event.defaultPrevented;
+    });
+
+    render(<DomainFilterBar onSubmit={handleSubmit} />);
+
+    fireEvent.submit(screen.getByRole('search', { name: 'Filter domain data' }));
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
+    expect(eventWasPrevented).toBe(true);
   });
 });

--- a/web/src/components/app/DomainFoundation.test.tsx
+++ b/web/src/components/app/DomainFoundation.test.tsx
@@ -1,0 +1,163 @@
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DomainActionFooter,
+  DomainDataTable,
+  DomainDetailPanel,
+  DomainEmptyState,
+  DomainErrorState,
+  DomainEvidencePanel,
+  DomainFilterBar,
+  DomainHeader,
+  DomainKpiStrip,
+  DomainLoadingState,
+  DomainLogoMark,
+  DomainLogoStack,
+  DomainPageShell,
+  DomainStatusPanel,
+  DomainSubnav
+} from './DomainFoundation';
+
+describe('DomainFoundation', () => {
+  it('renders meaningful and decorative official domain marks accessibly', () => {
+    const { container } = render(
+      <>
+        <DomainLogoMark domain="aws" />
+        <DomainLogoMark domain="github" decorative />
+      </>
+    );
+
+    expect(screen.getByRole('img', { name: 'AWS' })).toBeInTheDocument();
+    expect(screen.queryByRole('img', { name: 'GitHub' })).not.toBeInTheDocument();
+    expect(container.querySelector('img[src="/brand-logos/aws.svg"]')).toBeInTheDocument();
+    expect(container.querySelector('.idt-domain-logo-mark.is-github')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('renders the provider logo stack through the same domain registry', () => {
+    render(<DomainLogoStack domains={['aws', 'github', 'kubernetes']} label="Machine identity surfaces" />);
+
+    const stack = screen.getByRole('group', { name: 'Machine identity surfaces' });
+    expect(stack.querySelectorAll('.idt-domain-logo-mark')).toHaveLength(3);
+  });
+
+  it('provides a reusable domain page shell with header, actions, subnav, content, and aside', () => {
+    render(
+      <MemoryRouter>
+        <DomainPageShell
+          domain="aws"
+          eyebrow="AWS Control Center"
+          title="AWS machine identities"
+          description="Connect accounts, inspect machine identities, and triage cloud findings."
+          scope={<span>Production account</span>}
+          status={<span>Healthy</span>}
+          statusTone="success"
+          primaryAction={{ label: 'Connect AWS', to: '/connect/aws', variant: 'primary' }}
+          secondaryActions={[{ label: 'Refresh', onClick: vi.fn() }]}
+          subnav={[
+            {
+              id: 'inventory',
+              label: 'Inventory',
+              defaultOpen: true,
+              children: [
+                { id: 'roles', label: 'Roles', to: '/aws/roles', active: true },
+                { id: 'agents', label: 'Agents', to: '/aws/agents', badge: 'Soon' }
+              ]
+            },
+            { id: 'findings', label: 'Findings', to: '/aws/findings', status: '7 open' }
+          ]}
+          aside={<DomainDetailPanel title="Coverage">3 regions scanned</DomainDetailPanel>}
+        >
+          <DomainKpiStrip items={[{ label: 'Identities', value: '128', detail: 'Across 3 accounts' }]} />
+        </DomainPageShell>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { name: 'AWS machine identities' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Connect AWS' })).toHaveAttribute('href', '/connect/aws');
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
+    expect(screen.getByRole('navigation', { name: 'Domain sections' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Roles' })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByText('3 regions scanned')).toBeInTheDocument();
+    expect(screen.getByText('128')).toBeInTheDocument();
+  });
+
+  it('renders subsection navigation groups as native collapsible sections', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <DomainSubnav
+          label="GitHub sections"
+          items={[
+            {
+              id: 'agentic-risk',
+              label: 'AI / Agentic Risk',
+              badge: 'GitHub',
+              defaultOpen: false,
+              children: [{ id: 'tools', label: 'MCP / tools / secrets', to: '/github/agentic-risk/tools' }]
+            }
+          ]}
+        />
+      </MemoryRouter>
+    );
+
+    const details = container.querySelector('details.idt-domain-subnav-group');
+    expect(details).toBeInTheDocument();
+    expect(details).not.toHaveAttribute('open');
+    expect(screen.getByText('AI / Agentic Risk')).toBeInTheDocument();
+  });
+
+  it('covers operational states, dense tables, filters, evidence, and action footers', () => {
+    render(
+      <MemoryRouter>
+        <DomainHeader
+          domain="github"
+          title="GitHub posture"
+          description="Repository-native security posture."
+          status="Degraded"
+          statusTone="warning"
+        />
+        <DomainStatusPanel title="Collector health" status="Healthy" tone="success">
+          Webhook delivery is current.
+        </DomainStatusPanel>
+        <DomainFilterBar>
+          <label>
+            Search
+            <input aria-label="Search identities" />
+          </label>
+        </DomainFilterBar>
+        <DomainDataTable
+          label="Identity inventory"
+          columns={[
+            { key: 'name', header: 'Identity', render: (row: { id: string; name: string }) => row.name },
+            { key: 'risk', header: 'Risk', align: 'right', render: () => 'High' }
+          ]}
+          rows={[{ id: 'role-1', name: 'Deploy role' }]}
+          getRowKey={(row) => row.id}
+        />
+        <DomainDataTable
+          label="Empty inventory"
+          columns={[{ key: 'name', header: 'Identity', render: (row: { id: string; name: string }) => row.name }]}
+          rows={[]}
+          getRowKey={(row) => row.id}
+        />
+        <DomainEmptyState title="Nothing connected" body="Connect a provider to begin." />
+        <DomainErrorState title="Sync failed" body="Retry the collector." />
+        <DomainLoadingState label="Loading GitHub repositories" />
+        <DomainEvidencePanel title="Trust policy evidence" code={'{"Effect":"Allow"}'} language="json" />
+        <DomainActionFooter>
+          <button type="button">Approve plan</button>
+        </DomainActionFooter>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { name: 'GitHub posture' })).toBeInTheDocument();
+    expect(screen.getByText('Webhook delivery is current.')).toBeInTheDocument();
+    expect(screen.getByRole('search', { name: 'Filter domain data' })).toBeInTheDocument();
+    expect(within(screen.getByRole('table', { name: 'Identity inventory' })).getByText('Deploy role')).toBeInTheDocument();
+    expect(screen.getByText('No records yet')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent('Sync failed');
+    expect(screen.getByRole('status')).toHaveTextContent('Loading GitHub repositories');
+    expect(screen.getByText('{"Effect":"Allow"}')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Approve plan' })).toBeInTheDocument();
+  });
+});

--- a/web/src/components/app/DomainFoundation.tsx
+++ b/web/src/components/app/DomainFoundation.tsx
@@ -351,7 +351,7 @@ export function DomainFilterBar({
   onSubmit
 }: {
   label?: string;
-  children: ReactNode;
+  children?: ReactNode;
   actions?: ReactNode;
   onSubmit?: (event: FormEvent<HTMLFormElement>) => void;
 }) {

--- a/web/src/components/app/DomainFoundation.tsx
+++ b/web/src/components/app/DomainFoundation.tsx
@@ -1,0 +1,472 @@
+import { useId } from 'react';
+import type { FormEvent, ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { DOMAIN_ASSET_ORDER, getDomainAsset, type DomainAssetKey } from '../../design/domainAssets';
+
+type Tone = 'neutral' | 'success' | 'warning' | 'danger' | 'info';
+
+function classNames(values: Array<string | false | null | undefined>): string {
+  return values.filter(Boolean).join(' ');
+}
+
+export function DomainLogoMark({
+  domain,
+  className = '',
+  size = 'default',
+  decorative = false,
+  label
+}: {
+  domain: DomainAssetKey;
+  className?: string;
+  size?: 'compact' | 'default' | 'row' | 'hero';
+  decorative?: boolean;
+  label?: string;
+}) {
+  const asset = getDomainAsset(domain);
+  const classes = classNames([
+    'idt-domain-logo-mark',
+    'idt-source-logo-mark',
+    `is-${domain}`,
+    size !== 'default' ? `is-${size}` : '',
+    className
+  ]);
+
+  if (decorative) {
+    return (
+      <span className={classes} aria-hidden="true">
+        <img src={asset.logoSrc} alt="" aria-hidden="true" loading="lazy" decoding="async" />
+      </span>
+    );
+  }
+
+  return (
+    <span className={classes} role="img" aria-label={label ?? asset.label}>
+      <img src={asset.logoSrc} alt="" aria-hidden="true" loading="lazy" decoding="async" />
+    </span>
+  );
+}
+
+export function DomainLogoStack({
+  domains = DOMAIN_ASSET_ORDER,
+  label = 'Domain coverage stack',
+  className = ''
+}: {
+  domains?: readonly DomainAssetKey[];
+  label?: string;
+  className?: string;
+}) {
+  return (
+    <div className={classNames(['idt-domain-logo-stack', 'idt-source-logo-stack', className])} role="group" aria-label={label}>
+      {domains.map((domain) => (
+        <DomainLogoMark key={domain} domain={domain} decorative />
+      ))}
+    </div>
+  );
+}
+
+export type DomainAction = {
+  id?: string;
+  label: string;
+  to?: string;
+  href?: string;
+  onClick?: () => void;
+  variant?: 'primary' | 'secondary' | 'ghost';
+  disabled?: boolean;
+  ariaLabel?: string;
+  target?: string;
+  rel?: string;
+  icon?: ReactNode;
+};
+
+function renderDomainAction(action: DomainAction, key: string) {
+  const variant = action.variant === 'primary' ? 'idt-btn-primary' : action.variant === 'secondary' ? 'idt-btn-dark' : 'idt-btn-ghost';
+  const className = classNames(['idt-btn', variant, 'idt-domain-action']);
+  const content = (
+    <>
+      {action.icon ? <span className="idt-domain-action-icon" aria-hidden="true">{action.icon}</span> : null}
+      <span>{action.label}</span>
+    </>
+  );
+
+  if (action.disabled) {
+    return (
+      <span key={key} className={className} aria-disabled="true" role="link" aria-label={action.ariaLabel ?? action.label}>
+        {content}
+      </span>
+    );
+  }
+
+  if (action.to) {
+    return (
+      <Link key={key} className={className} to={action.to} aria-label={action.ariaLabel}>
+        {content}
+      </Link>
+    );
+  }
+
+  if (action.href) {
+    return (
+      <a
+        key={key}
+        className={className}
+        href={action.href}
+        target={action.target}
+        rel={action.rel ?? (action.target === '_blank' ? 'noreferrer' : undefined)}
+        aria-label={action.ariaLabel}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <button key={key} className={className} type="button" onClick={action.onClick} aria-label={action.ariaLabel}>
+      {content}
+    </button>
+  );
+}
+
+export type DomainHeaderProps = {
+  domain: DomainAssetKey;
+  eyebrow?: string;
+  title: string;
+  description: ReactNode;
+  scope?: ReactNode;
+  status?: ReactNode;
+  statusTone?: Tone;
+  primaryAction?: DomainAction;
+  secondaryActions?: DomainAction[];
+  titleId?: string;
+};
+
+export function DomainHeader({
+  domain,
+  eyebrow,
+  title,
+  description,
+  scope,
+  status,
+  statusTone = 'neutral',
+  primaryAction,
+  secondaryActions = [],
+  titleId
+}: DomainHeaderProps) {
+  const asset = getDomainAsset(domain);
+  const actions = primaryAction ? [primaryAction, ...secondaryActions] : secondaryActions;
+
+  return (
+    <header className={classNames(['idt-domain-header', `is-${domain}`])}>
+      <div className="idt-domain-header-main">
+        <DomainLogoMark domain={domain} size="hero" />
+        <div>
+          <p className="idt-app-kicker">{eyebrow ?? asset.description}</p>
+          <h2 id={titleId}>{title}</h2>
+          <p>{description}</p>
+        </div>
+      </div>
+      <div className="idt-domain-header-aside">
+        {scope ? <div className="idt-domain-scope-slot">{scope}</div> : null}
+        {status ? <div className={classNames(['idt-domain-status-summary', `is-${statusTone}`])}>{status}</div> : null}
+        {actions.length > 0 ? (
+          <div className="idt-domain-header-actions">
+            {actions.map((action) => renderDomainAction(action, action.id ?? action.label))}
+          </div>
+        ) : null}
+      </div>
+    </header>
+  );
+}
+
+export type DomainSubnavItem = {
+  id: string;
+  label: string;
+  to?: string;
+  active?: boolean;
+  badge?: string;
+  status?: string;
+  children?: DomainSubnavItem[];
+  defaultOpen?: boolean;
+};
+
+function renderSubnavLabel(item: DomainSubnavItem) {
+  return (
+    <>
+      <span>{item.label}</span>
+      {item.badge ? <small>{item.badge}</small> : null}
+      {item.status ? <em>{item.status}</em> : null}
+    </>
+  );
+}
+
+function renderSubnavItem(item: DomainSubnavItem): ReactNode {
+  if (item.children?.length) {
+    const detailsOpenProps = item.defaultOpen ?? item.active ? { open: true } : {};
+    return (
+      <details key={item.id} className="idt-domain-subnav-group" {...detailsOpenProps}>
+        <summary>{renderSubnavLabel(item)}</summary>
+        <div className="idt-domain-subnav-children">{item.children.map((child) => renderSubnavItem(child))}</div>
+      </details>
+    );
+  }
+
+  if (item.to) {
+    return (
+      <Link key={item.id} className={classNames(['idt-domain-subnav-item', item.active ? 'is-active' : ''])} to={item.to} aria-current={item.active ? 'page' : undefined}>
+        {renderSubnavLabel(item)}
+      </Link>
+    );
+  }
+
+  return (
+    <span key={item.id} className={classNames(['idt-domain-subnav-item', item.active ? 'is-active' : ''])}>
+      {renderSubnavLabel(item)}
+    </span>
+  );
+}
+
+export function DomainSubnav({ label = 'Domain sections', items }: { label?: string; items: DomainSubnavItem[] }) {
+  return (
+    <nav className="idt-domain-subnav" aria-label={label}>
+      {items.map((item) => renderSubnavItem(item))}
+    </nav>
+  );
+}
+
+export type DomainPageShellProps = DomainHeaderProps & {
+  subnav?: DomainSubnavItem[];
+  subnavLabel?: string;
+  aside?: ReactNode;
+  children: ReactNode;
+};
+
+export function DomainPageShell({ subnav, subnavLabel, aside, children, ...headerProps }: DomainPageShellProps) {
+  const generatedId = useId();
+  const titleId = headerProps.titleId ?? `idt-domain-title-${generatedId}`;
+
+  return (
+    <section className={classNames(['idt-domain-page-shell', `is-${headerProps.domain}`])} aria-labelledby={titleId}>
+      <DomainHeader {...headerProps} titleId={titleId} />
+      <div className={classNames(['idt-domain-page-body', subnav?.length ? 'has-subnav' : '', aside ? 'has-aside' : ''])}>
+        {subnav?.length ? <DomainSubnav label={subnavLabel} items={subnav} /> : null}
+        <div className="idt-domain-page-content">{children}</div>
+        {aside ? <aside className="idt-domain-page-aside">{aside}</aside> : null}
+      </div>
+    </section>
+  );
+}
+
+export type DomainKpiItem = {
+  label: string;
+  value: ReactNode;
+  detail?: ReactNode;
+  tone?: Tone;
+};
+
+export function DomainKpiStrip({ label = 'Domain metrics', items }: { label?: string; items: DomainKpiItem[] }) {
+  return (
+    <section className="idt-domain-kpi-strip" aria-label={label}>
+      {items.map((item) => (
+        <article key={item.label} className={classNames(['idt-domain-kpi', item.tone ? `is-${item.tone}` : ''])}>
+          <span>{item.label}</span>
+          <strong>{item.value}</strong>
+          {item.detail ? <p>{item.detail}</p> : null}
+        </article>
+      ))}
+    </section>
+  );
+}
+
+export function DomainStatusPanel({
+  eyebrow,
+  title,
+  status,
+  tone = 'neutral',
+  children,
+  actions
+}: {
+  eyebrow?: string;
+  title: string;
+  status?: ReactNode;
+  tone?: Tone;
+  children: ReactNode;
+  actions?: DomainAction[];
+}) {
+  return (
+    <article className={classNames(['idt-domain-status-panel', `is-${tone}`])}>
+      <header>
+        <div>
+          {eyebrow ? <p className="idt-app-kicker">{eyebrow}</p> : null}
+          <h3>{title}</h3>
+        </div>
+        {status ? <span>{status}</span> : null}
+      </header>
+      <div className="idt-domain-panel-body">{children}</div>
+      {actions?.length ? <footer>{actions.map((action) => renderDomainAction(action, action.id ?? action.label))}</footer> : null}
+    </article>
+  );
+}
+
+export function DomainEmptyState({ eyebrow, title, body, children }: { eyebrow?: string; title: string; body: ReactNode; children?: ReactNode }) {
+  return (
+    <article className="idt-domain-empty-state">
+      {eyebrow ? <p className="idt-app-kicker">{eyebrow}</p> : null}
+      <h3>{title}</h3>
+      <p>{body}</p>
+      {children ? <div className="idt-inline-actions">{children}</div> : null}
+    </article>
+  );
+}
+
+export function DomainErrorState({ title, body, children }: { title: string; body: ReactNode; children?: ReactNode }) {
+  return (
+    <article className="idt-domain-error-state" role="alert">
+      <p className="idt-app-kicker">Needs attention</p>
+      <h3>{title}</h3>
+      <p>{body}</p>
+      {children ? <div className="idt-inline-actions">{children}</div> : null}
+    </article>
+  );
+}
+
+export function DomainLoadingState({ label = 'Loading domain data' }: { label?: string }) {
+  return (
+    <div className="idt-domain-loading-state" role="status" aria-live="polite">
+      <span aria-hidden="true" />
+      <p>{label}</p>
+    </div>
+  );
+}
+
+export function DomainFilterBar({
+  label = 'Filter domain data',
+  children,
+  actions,
+  onSubmit
+}: {
+  label?: string;
+  children: ReactNode;
+  actions?: ReactNode;
+  onSubmit?: (event: FormEvent<HTMLFormElement>) => void;
+}) {
+  return (
+    <form
+      className="idt-domain-filter-bar"
+      role="search"
+      aria-label={label}
+      onSubmit={(event) => {
+        if (onSubmit) {
+          onSubmit(event);
+          return;
+        }
+        event.preventDefault();
+      }}
+    >
+      <div className="idt-domain-filter-fields">{children}</div>
+      {actions ? <div className="idt-domain-filter-actions">{actions}</div> : null}
+    </form>
+  );
+}
+
+export type DomainDataTableColumn<Row> = {
+  key: string;
+  header: string;
+  render: (row: Row) => ReactNode;
+  align?: 'left' | 'right';
+};
+
+export function DomainDataTable<Row>({
+  label,
+  columns,
+  rows,
+  getRowKey,
+  emptyState
+}: {
+  label: string;
+  columns: DomainDataTableColumn<Row>[];
+  rows: Row[];
+  getRowKey: (row: Row) => string;
+  emptyState?: ReactNode;
+}) {
+  return (
+    <div className="idt-domain-table-wrap">
+      <table className="idt-domain-data-table" aria-label={label}>
+        <thead>
+          <tr>
+            {columns.map((column) => (
+              <th key={column.key} scope="col" className={column.align === 'right' ? 'is-right' : undefined}>
+                {column.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={getRowKey(row)}>
+              {columns.map((column) => (
+                <td key={column.key} className={column.align === 'right' ? 'is-right' : undefined}>
+                  {column.render(row)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {rows.length === 0 ? (
+        <div className="idt-domain-table-empty">
+          {emptyState ?? <DomainEmptyState title="No records yet" body="Connect the domain or adjust filters to populate this table." />}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function DomainDetailPanel({
+  title,
+  eyebrow,
+  children,
+  footer
+}: {
+  title: string;
+  eyebrow?: string;
+  children: ReactNode;
+  footer?: ReactNode;
+}) {
+  return (
+    <aside className="idt-domain-detail-panel" aria-label={title}>
+      <header>
+        {eyebrow ? <p className="idt-app-kicker">{eyebrow}</p> : null}
+        <h3>{title}</h3>
+      </header>
+      <div>{children}</div>
+      {footer ? <footer>{footer}</footer> : null}
+    </aside>
+  );
+}
+
+export function DomainEvidencePanel({
+  title,
+  code,
+  language = 'text',
+  caption
+}: {
+  title: string;
+  code: string;
+  language?: string;
+  caption?: ReactNode;
+}) {
+  return (
+    <figure className="idt-domain-evidence-panel">
+      <figcaption>
+        <strong>{title}</strong>
+        {caption ? <span>{caption}</span> : null}
+      </figcaption>
+      <pre>
+        <code className={`language-${language}`}>{code}</code>
+      </pre>
+    </figure>
+  );
+}
+
+export function DomainActionFooter({ children }: { children: ReactNode }) {
+  return <footer className="idt-domain-action-footer">{children}</footer>;
+}

--- a/web/src/components/app/DomainFoundation.tsx
+++ b/web/src/components/app/DomainFoundation.tsx
@@ -169,7 +169,7 @@ export function DomainHeader({
         {status ? <div className={classNames(['idt-domain-status-summary', `is-${statusTone}`])}>{status}</div> : null}
         {actions.length > 0 ? (
           <div className="idt-domain-header-actions">
-            {actions.map((action) => renderDomainAction(action, action.id ?? action.label))}
+            {actions.map((action, index) => renderDomainAction(action, action.id ?? `${action.label}-${index}`))}
           </div>
         ) : null}
       </div>
@@ -198,9 +198,14 @@ function renderSubnavLabel(item: DomainSubnavItem) {
   );
 }
 
+function hasActiveDescendant(item: DomainSubnavItem): boolean {
+  return item.children?.some((child) => child.active || hasActiveDescendant(child)) ?? false;
+}
+
 function renderSubnavItem(item: DomainSubnavItem): ReactNode {
   if (item.children?.length) {
-    const detailsOpenProps = item.defaultOpen ?? item.active ? { open: true } : {};
+    const shouldOpen = item.defaultOpen || item.active || hasActiveDescendant(item);
+    const detailsOpenProps = shouldOpen ? { open: true } : {};
     return (
       <details key={item.id} className="idt-domain-subnav-group" {...detailsOpenProps}>
         <summary>{renderSubnavLabel(item)}</summary>
@@ -301,7 +306,9 @@ export function DomainStatusPanel({
         {status ? <span>{status}</span> : null}
       </header>
       <div className="idt-domain-panel-body">{children}</div>
-      {actions?.length ? <footer>{actions.map((action) => renderDomainAction(action, action.id ?? action.label))}</footer> : null}
+      {actions?.length ? (
+        <footer>{actions.map((action, index) => renderDomainAction(action, action.id ?? `${action.label}-${index}`))}</footer>
+      ) : null}
     </article>
   );
 }
@@ -354,11 +361,10 @@ export function DomainFilterBar({
       role="search"
       aria-label={label}
       onSubmit={(event) => {
+        event.preventDefault();
         if (onSubmit) {
           onSubmit(event);
-          return;
         }
-        event.preventDefault();
       }}
     >
       <div className="idt-domain-filter-fields">{children}</div>

--- a/web/src/design/domainAssets.test.ts
+++ b/web/src/design/domainAssets.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { DOMAIN_ASSET_ORDER, DOMAIN_ASSETS, getDomainAsset, isDomainAssetKey } from './domainAssets';
+
+describe('domain asset registry', () => {
+  it('keeps the first app redesign domains in a stable section order', () => {
+    expect(DOMAIN_ASSET_ORDER).toEqual(['aws', 'github', 'kubernetes']);
+  });
+
+  it('centralizes official provider logo paths and source references', () => {
+    for (const key of DOMAIN_ASSET_ORDER) {
+      const asset = DOMAIN_ASSETS[key];
+
+      expect(asset.logoSrc).toBe(`/brand-logos/${key}.svg`);
+      expect(asset.logoAlt).toMatch(asset.label === 'GitHub' ? /GitHub/ : new RegExp(asset.label, 'i'));
+      expect(asset.officialSourceUrl).toMatch(/^https:\/\//);
+      expect(asset.brandGuidanceUrl).toMatch(/^https:\/\//);
+      expect(asset.primaryTone).toMatch(/^#[0-9a-f]{6}$/i);
+      expect(asset.darkPanelTone).toBe('#080809');
+    }
+  });
+
+  it('resolves known domains and rejects unsupported values', () => {
+    expect(getDomainAsset('aws').officialSourceLabel).toBe('AWS Architecture Icons');
+    expect(getDomainAsset('github').officialSourceLabel).toBe('GitHub Brand Toolkit');
+    expect(getDomainAsset('kubernetes').officialSourceLabel).toBe('CNCF Kubernetes Artwork');
+    expect(isDomainAssetKey('aws')).toBe(true);
+    expect(isDomainAssetKey('azure')).toBe(false);
+  });
+});

--- a/web/src/design/domainAssets.ts
+++ b/web/src/design/domainAssets.ts
@@ -1,0 +1,71 @@
+export const DOMAIN_ASSET_ORDER = ['aws', 'github', 'kubernetes'] as const;
+
+export type DomainAssetKey = (typeof DOMAIN_ASSET_ORDER)[number];
+
+export type DomainAsset = {
+  key: DomainAssetKey;
+  label: string;
+  shortLabel: string;
+  logoSrc: string;
+  logoAlt: string;
+  officialSourceLabel: string;
+  officialSourceUrl: string;
+  brandGuidanceUrl: string;
+  description: string;
+  primaryTone: string;
+  darkPanelTone: string;
+  accentTone: string;
+};
+
+export const DOMAIN_ASSETS: Record<DomainAssetKey, DomainAsset> = {
+  aws: {
+    key: 'aws',
+    label: 'AWS',
+    shortLabel: 'AWS',
+    logoSrc: '/brand-logos/aws.svg',
+    logoAlt: 'AWS logo',
+    officialSourceLabel: 'AWS Architecture Icons',
+    officialSourceUrl: 'https://aws.amazon.com/architecture/icons/',
+    brandGuidanceUrl: 'https://aws.amazon.com/trademark-guidelines/',
+    description: 'Cloud accounts, regions, resources, workloads, and machine identities.',
+    primaryTone: '#ff9900',
+    darkPanelTone: '#080809',
+    accentTone: '#f5c451'
+  },
+  github: {
+    key: 'github',
+    label: 'GitHub',
+    shortLabel: 'GitHub',
+    logoSrc: '/brand-logos/github.svg',
+    logoAlt: 'GitHub Octomark',
+    officialSourceLabel: 'GitHub Brand Toolkit',
+    officialSourceUrl: 'https://brand.github.com/foundations/logo',
+    brandGuidanceUrl: 'https://docs.github.com/articles/github-logo-policy',
+    description: 'Repositories, workflows, code security, agent surfaces, and remediation flow.',
+    primaryTone: '#f5f5f5',
+    darkPanelTone: '#080809',
+    accentTone: '#8b949e'
+  },
+  kubernetes: {
+    key: 'kubernetes',
+    label: 'Kubernetes',
+    shortLabel: 'K8s',
+    logoSrc: '/brand-logos/kubernetes.svg',
+    logoAlt: 'Kubernetes logo',
+    officialSourceLabel: 'CNCF Kubernetes Artwork',
+    officialSourceUrl: 'https://github.com/cncf/artwork/tree/main/projects/kubernetes',
+    brandGuidanceUrl: 'https://www.cncf.io/brand-guidelines/',
+    description: 'Clusters, service accounts, RBAC, workloads, and runtime identity posture.',
+    primaryTone: '#326ce5',
+    darkPanelTone: '#080809',
+    accentTone: '#7aa2ff'
+  }
+};
+
+export function getDomainAsset(key: DomainAssetKey): DomainAsset {
+  return DOMAIN_ASSETS[key];
+}
+
+export function isDomainAssetKey(value: string): value is DomainAssetKey {
+  return DOMAIN_ASSET_ORDER.includes(value as DomainAssetKey);
+}

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -60,6 +60,8 @@ import {
   type WorkspaceMemberStatus
 } from './api/client';
 import { PermissionPreviewModal } from './components/connector/PermissionPreviewModal';
+import { DomainLogoMark, DomainLogoStack } from './components/app/DomainFoundation';
+import { getDomainAsset, type DomainAssetKey } from './design/domainAssets';
 import { clearMeCache, primeMeCache, useMe } from './hooks/useMe';
 import { isFeatureAvailable, useBackendFeatures } from './hooks/useBackendFeatures';
 import {
@@ -88,7 +90,7 @@ type ScopeRouteParams = {
   projectID?: string;
 };
 
-type SourceProvider = 'github' | 'aws' | 'kubernetes';
+type SourceProvider = DomainAssetKey;
 
 type SourceConnectionMap = {
   github?: GitHubConnectionStatus;
@@ -103,7 +105,6 @@ type SourceProfile = {
   summary: string;
   primarySignal: string;
   requiredAccess: string;
-  logo: string;
 };
 
 type SourceAvailability = {
@@ -159,30 +160,27 @@ const MEMBER_STATUS_OPTIONS: WorkspaceMemberStatus[] = ['invited', 'active', 'su
 const SOURCE_PROFILES: Record<SourceProvider, SourceProfile> = {
   github: {
     provider: 'github',
-    name: 'GitHub',
+    name: getDomainAsset('github').label,
     eyebrow: 'Repositories and workflows',
     summary: 'Install Identrail on selected repositories so scans can read repository, workflow, and review signals.',
     primarySignal: 'Repository, workflow, and pull request signals',
-    requiredAccess: 'GitHub App with selected repository access',
-    logo: '/brand-logos/github.svg'
+    requiredAccess: 'GitHub App with selected repository access'
   },
   aws: {
     provider: 'aws',
-    name: 'AWS',
+    name: getDomainAsset('aws').label,
     eyebrow: 'Cloud IAM identity',
     summary: 'Connect a read-only IAM role so Identrail can inspect roles, trust policies, and account context.',
     primarySignal: 'IAM roles, trust policies, and account context',
-    requiredAccess: 'Read-only IAM role ARN',
-    logo: '/brand-logos/aws.svg'
+    requiredAccess: 'Read-only IAM role ARN'
   },
   kubernetes: {
     provider: 'kubernetes',
-    name: 'Kubernetes',
+    name: getDomainAsset('kubernetes').label,
     eyebrow: 'Cluster identity',
     summary: 'Enroll a read-only agent or kubeconfig fallback for service account and RBAC signals.',
     primarySignal: 'Service accounts, RBAC bindings, and pods',
-    requiredAccess: 'Read-only ClusterRole through the Identrail agent',
-    logo: '/brand-logos/kubernetes.svg'
+    requiredAccess: 'Read-only ClusterRole through the Identrail agent'
   }
 };
 const GITHUB_REPOSITORY_SPLIT_PATTERN = /[\n,]+/;
@@ -260,13 +258,7 @@ export function SourceLogoMark({ provider, className = '' }: { provider: SourceP
     return null;
   }
 
-  const profile = SOURCE_PROFILES[enabledProvider];
-  const classes = ['idt-source-logo-mark', `is-${enabledProvider}`, className].filter(Boolean).join(' ');
-  return (
-    <span className={classes} role="img" aria-label={profile.name}>
-      <img src={profile.logo} alt="" aria-hidden="true" loading="lazy" />
-    </span>
-  );
+  return <DomainLogoMark domain={enabledProvider} className={className} />;
 }
 
 function SourceLogoStack({
@@ -278,14 +270,7 @@ function SourceLogoStack({
   label?: string;
   className?: string;
 }) {
-  const classes = ['idt-source-logo-stack', className].filter(Boolean).join(' ');
-  return (
-    <div className={classes} role="group" aria-label={label}>
-      {providers.map((provider) => (
-        <SourceLogoMark key={provider} provider={provider} />
-      ))}
-    </div>
-  );
+  return <DomainLogoStack domains={providers} label={label} className={className} />;
 }
 
 function formatSourceNameList(providers: SourceProvider[]): string {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -19242,18 +19242,6 @@ html[data-theme='light'] .idt-legal-contact-panel .idt-btn-primary {
 .idt-account-security-page,
 .idt-app-shell-screen,
 .idt-executive-report-shell {
-  --app-bg: #0d1117;
-  --app-panel: #080809;
-  --app-panel-strong: #0b0b0d;
-  --app-border: #30363d;
-  --app-border-soft: #21262d;
-  --app-text: #f0f6fc;
-  --app-muted: #c9d1d9;
-  --app-dim: #8b949e;
-  --app-accent: #58a6ff;
-  --app-success: #58d68d;
-  --app-warning: #f5c451;
-  --app-danger: #ff6b6b;
   color: var(--app-text);
   font-size: 1rem;
   line-height: 1.5;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -19231,25 +19231,26 @@ html[data-theme='light'] .idt-legal-contact-panel .idt-btn-primary {
 /* Product app console redesign */
 #main-content:has(.idt-app-console-layout),
 #main-content:has(.idt-account-security-page),
+#main-content:has(.idt-app-shell-screen),
 #main-content:has(.idt-executive-report-shell) {
   min-height: 100dvh;
   overflow-x: clip;
-  background: #000000;
+  background: #0d1117;
 }
 
 .idt-app-console-layout,
 .idt-account-security-page,
 .idt-app-shell-screen,
 .idt-executive-report-shell {
-  --app-bg: #050506;
-  --app-panel: #0a0a0b;
-  --app-panel-strong: #101013;
-  --app-border: #252529;
-  --app-border-soft: #191919;
-  --app-text: #f5f5f5;
-  --app-muted: #b8b8c0;
-  --app-dim: #85858f;
-  --app-accent: #702ce1;
+  --app-bg: #0d1117;
+  --app-panel: #080809;
+  --app-panel-strong: #0b0b0d;
+  --app-border: #30363d;
+  --app-border-soft: #21262d;
+  --app-text: #f0f6fc;
+  --app-muted: #c9d1d9;
+  --app-dim: #8b949e;
+  --app-accent: #58a6ff;
   --app-success: #58d68d;
   --app-warning: #f5c451;
   --app-danger: #ff6b6b;
@@ -19299,7 +19300,7 @@ html[data-theme='light'] .idt-legal-contact-panel .idt-btn-primary {
    * vertical scroll when there are more nav items than fit. */
   overflow: visible;
   border-right: 1px solid var(--app-border);
-  background: #050506;
+  background: #080809;
 }
 
 .idt-app-console-layout .idt-app-shell-nav {
@@ -19577,7 +19578,7 @@ html[data-theme='light'] .idt-app-quick-find {
   border: 0;
   border-bottom: 1px solid var(--app-border);
   border-radius: 0;
-  background: #050506;
+  background: #0d1117;
 }
 
 .idt-app-console-layout .idt-app-shell-header h1,
@@ -20908,8 +20909,8 @@ html[data-theme='light'] .idt-app-shell-screen select {
 .idt-app-shell-screen,
 .idt-executive-report-shell {
   --source-github: #f5f5f5;
-  --source-aws: #8f8f95;
-  --source-kubernetes: #8f8f95;
+  --source-aws: #ff9900;
+  --source-kubernetes: #326ce5;
   --app-ink: #050505;
   --app-paper: #0a0a0b;
   --app-paper-muted: #b8b8c0;
@@ -21003,6 +21004,550 @@ html[data-theme='light'] .idt-app-shell-screen select {
 .idt-source-logo-stack .idt-source-logo-mark img {
   width: 1.05rem;
   height: 1.05rem;
+}
+
+.idt-domain-logo-mark {
+  position: relative;
+}
+
+.idt-domain-logo-mark.is-compact {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 7px;
+}
+
+.idt-domain-logo-mark.is-compact img {
+  width: 0.92rem;
+  height: 0.92rem;
+}
+
+.idt-domain-logo-mark.is-aws {
+  box-shadow: inset 0 -2px 0 rgba(255, 153, 0, 0.62);
+}
+
+.idt-domain-logo-mark.is-github {
+  box-shadow: inset 0 -2px 0 rgba(36, 41, 47, 0.42);
+}
+
+.idt-domain-logo-mark.is-kubernetes {
+  box-shadow: inset 0 -2px 0 rgba(50, 108, 229, 0.58);
+}
+
+.idt-domain-logo-mark.is-kubernetes img {
+  width: 1.18rem;
+  height: 1.18rem;
+}
+
+.idt-domain-logo-mark.is-hero.is-kubernetes img {
+  width: 2.1rem;
+  height: 2.1rem;
+}
+
+.idt-domain-page-shell {
+  display: grid;
+  gap: 1rem;
+  color: var(--app-text);
+}
+
+.idt-domain-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(16rem, auto);
+  gap: 1rem;
+  align-items: start;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 1.1rem;
+  background: #080809;
+}
+
+.idt-domain-header-main {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.9rem;
+}
+
+.idt-domain-header h2,
+.idt-domain-status-panel h3,
+.idt-domain-empty-state h3,
+.idt-domain-error-state h3,
+.idt-domain-detail-panel h3 {
+  margin: 0.16rem 0 0.35rem;
+  color: #ffffff;
+  font-family: var(--idt-display);
+  line-height: 1.04;
+  text-wrap: balance;
+}
+
+.idt-domain-header h2 {
+  font-size: clamp(1.7rem, 2.2vw, 2.25rem);
+}
+
+.idt-domain-header p,
+.idt-domain-status-panel p,
+.idt-domain-empty-state p,
+.idt-domain-error-state p,
+.idt-domain-detail-panel p {
+  margin: 0;
+  color: var(--app-muted);
+}
+
+.idt-domain-header-aside {
+  display: grid;
+  gap: 0.65rem;
+  justify-items: end;
+}
+
+.idt-domain-scope-slot,
+.idt-domain-status-summary {
+  max-width: 100%;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 0.55rem 0.65rem;
+  background: #050505;
+  color: #ffffff;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.idt-domain-status-summary.is-success {
+  border-color: rgba(88, 214, 141, 0.5);
+  color: #acf2c4;
+}
+
+.idt-domain-status-summary.is-warning {
+  border-color: rgba(245, 196, 81, 0.55);
+  color: #ffe3a3;
+}
+
+.idt-domain-status-summary.is-danger {
+  border-color: rgba(255, 107, 107, 0.56);
+  color: #ffb3b3;
+}
+
+.idt-domain-status-summary.is-info {
+  border-color: rgba(88, 166, 255, 0.52);
+  color: #b9d7ff;
+}
+
+.idt-domain-header-actions,
+.idt-domain-filter-actions,
+.idt-domain-action-footer,
+.idt-domain-status-panel footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  justify-content: flex-end;
+}
+
+.idt-domain-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.38rem;
+  min-height: 2.35rem;
+}
+
+.idt-domain-action-icon {
+  display: inline-flex;
+}
+
+.idt-domain-page-body {
+  display: grid;
+  gap: 1rem;
+}
+
+.idt-domain-page-body.has-subnav {
+  grid-template-columns: minmax(11rem, 14rem) minmax(0, 1fr);
+}
+
+.idt-domain-page-body.has-subnav.has-aside {
+  grid-template-columns: minmax(11rem, 14rem) minmax(0, 1fr) minmax(15rem, 0.34fr);
+}
+
+.idt-domain-page-content {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.idt-domain-page-aside {
+  min-width: 0;
+}
+
+.idt-domain-subnav {
+  align-self: start;
+  display: grid;
+  gap: 0.35rem;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 0.55rem;
+  background: #080809;
+}
+
+.idt-domain-subnav a,
+.idt-domain-subnav-item,
+.idt-domain-subnav summary {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-height: 2.2rem;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 0.52rem 0.62rem;
+  color: #a3a3a3;
+  font-size: 0.86rem;
+  font-weight: 800;
+  line-height: 1.2;
+  text-decoration: none;
+}
+
+.idt-domain-subnav summary {
+  cursor: pointer;
+}
+
+.idt-domain-subnav a:hover,
+.idt-domain-subnav a:focus-visible,
+.idt-domain-subnav summary:hover,
+.idt-domain-subnav summary:focus-visible {
+  border-color: var(--app-border);
+  background: #111113;
+  color: #ffffff;
+  outline: none;
+}
+
+.idt-domain-subnav a.is-active,
+.idt-domain-subnav-item.is-active {
+  border-color: rgba(255, 255, 255, 0.3);
+  background: #111113;
+  color: #ffffff;
+}
+
+.idt-domain-subnav small,
+.idt-domain-subnav em {
+  margin-left: auto;
+  border: 1px solid var(--app-border);
+  border-radius: 999px;
+  padding: 0.12rem 0.42rem;
+  color: var(--app-muted);
+  font-size: 0.68rem;
+  font-style: normal;
+  font-weight: 900;
+}
+
+.idt-domain-subnav-children {
+  display: grid;
+  gap: 0.25rem;
+  margin-top: 0.25rem;
+  padding-left: 0.42rem;
+}
+
+.idt-domain-kpi-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11.5rem, 1fr));
+  gap: 0.75rem;
+}
+
+.idt-domain-kpi,
+.idt-domain-status-panel,
+.idt-domain-empty-state,
+.idt-domain-error-state,
+.idt-domain-detail-panel,
+.idt-domain-evidence-panel,
+.idt-domain-filter-bar,
+.idt-domain-action-footer,
+.idt-domain-table-wrap {
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: #080809;
+  color: var(--app-text);
+}
+
+.idt-domain-kpi {
+  min-height: 7rem;
+  display: grid;
+  align-content: space-between;
+  gap: 0.65rem;
+  padding: 0.95rem;
+}
+
+.idt-domain-kpi span {
+  color: var(--app-dim);
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+.idt-domain-kpi strong {
+  color: #ffffff;
+  font-size: clamp(1.65rem, 2vw, 2.1rem);
+  line-height: 1;
+}
+
+.idt-domain-kpi p {
+  margin: 0;
+  color: var(--app-muted);
+  font-size: 0.84rem;
+}
+
+.idt-domain-kpi.is-success,
+.idt-domain-status-panel.is-success {
+  border-color: rgba(88, 214, 141, 0.38);
+}
+
+.idt-domain-kpi.is-warning,
+.idt-domain-status-panel.is-warning {
+  border-color: rgba(245, 196, 81, 0.4);
+}
+
+.idt-domain-kpi.is-danger,
+.idt-domain-status-panel.is-danger {
+  border-color: rgba(255, 107, 107, 0.4);
+}
+
+.idt-domain-status-panel,
+.idt-domain-empty-state,
+.idt-domain-error-state,
+.idt-domain-detail-panel,
+.idt-domain-action-footer {
+  padding: 1rem;
+}
+
+.idt-domain-status-panel {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.idt-domain-status-panel header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.idt-domain-status-panel header > span {
+  align-self: start;
+  border: 1px solid var(--app-border);
+  border-radius: 999px;
+  padding: 0.2rem 0.48rem;
+  background: #050505;
+  color: #ffffff;
+  font-size: 0.72rem;
+  font-weight: 900;
+}
+
+.idt-domain-panel-body {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.idt-domain-error-state {
+  border-color: rgba(255, 107, 107, 0.46);
+}
+
+.idt-domain-empty-state,
+.idt-domain-error-state {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.idt-domain-loading-state {
+  min-height: 5.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  border: 1px dashed var(--app-border);
+  border-radius: 8px;
+  padding: 1rem;
+  background: #080809;
+  color: var(--app-muted);
+}
+
+.idt-domain-loading-state span {
+  width: 0.8rem;
+  height: 0.8rem;
+  border: 2px solid rgba(255, 255, 255, 0.2);
+  border-top-color: #ffffff;
+  border-radius: 999px;
+  animation: idt-domain-spin 0.82s linear infinite;
+}
+
+@keyframes idt-domain-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.idt-domain-filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.85rem;
+}
+
+.idt-domain-filter-fields {
+  display: flex;
+  flex: 1 1 22rem;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.idt-domain-filter-fields label {
+  display: grid;
+  gap: 0.25rem;
+  min-width: min(100%, 12rem);
+  color: var(--app-muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.idt-domain-filter-fields input,
+.idt-domain-filter-fields select {
+  min-height: 2.35rem;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 0.52rem 0.62rem;
+  background: #050505;
+  color: #ffffff;
+  font: inherit;
+}
+
+.idt-domain-filter-fields input:focus-visible,
+.idt-domain-filter-fields select:focus-visible {
+  border-color: #ffffff;
+  outline: none;
+}
+
+.idt-domain-table-wrap {
+  overflow-x: auto;
+}
+
+.idt-domain-data-table {
+  width: 100%;
+  min-width: 42rem;
+  border-collapse: collapse;
+}
+
+.idt-domain-data-table th,
+.idt-domain-data-table td {
+  border-bottom: 1px solid var(--app-border-soft);
+  padding: 0.74rem 0.82rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.idt-domain-data-table th {
+  color: var(--app-dim);
+  font-size: 0.74rem;
+  font-weight: 900;
+}
+
+.idt-domain-data-table td {
+  color: var(--app-muted);
+  font-size: 0.88rem;
+}
+
+.idt-domain-data-table .is-right {
+  text-align: right;
+}
+
+.idt-domain-table-empty {
+  border-top: 1px solid var(--app-border-soft);
+  padding: 0.8rem;
+}
+
+.idt-domain-detail-panel {
+  display: grid;
+  align-content: start;
+  gap: 0.8rem;
+}
+
+.idt-domain-detail-panel footer {
+  border-top: 1px solid var(--app-border-soft);
+  padding-top: 0.8rem;
+}
+
+.idt-domain-evidence-panel {
+  margin: 0;
+  overflow: hidden;
+}
+
+.idt-domain-evidence-panel figcaption {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  border-bottom: 1px solid var(--app-border-soft);
+  padding: 0.75rem 0.85rem;
+}
+
+.idt-domain-evidence-panel figcaption strong {
+  color: #ffffff;
+}
+
+.idt-domain-evidence-panel figcaption span {
+  color: var(--app-dim);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.idt-domain-evidence-panel pre {
+  max-height: 24rem;
+  margin: 0;
+  overflow: auto;
+  padding: 0.9rem;
+  background: #050505;
+  color: #f0f6fc;
+  font-family: var(--idt-mono);
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+.idt-domain-action-footer {
+  position: sticky;
+  bottom: 1rem;
+  z-index: 4;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+@media (max-width: 1100px) {
+  .idt-domain-header,
+  .idt-domain-page-body.has-subnav,
+  .idt-domain-page-body.has-subnav.has-aside {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-domain-header-aside {
+    justify-items: start;
+  }
+}
+
+@media (max-width: 720px) {
+  .idt-domain-header-main,
+  .idt-domain-status-panel header,
+  .idt-domain-filter-bar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .idt-domain-header-actions,
+  .idt-domain-filter-actions,
+  .idt-domain-action-footer,
+  .idt-domain-status-panel footer {
+    justify-content: stretch;
+  }
+
+  .idt-domain-action,
+  .idt-domain-header-actions .idt-btn,
+  .idt-domain-filter-actions .idt-btn,
+  .idt-domain-action-footer .idt-btn {
+    width: 100%;
+  }
+
+  .idt-domain-data-table {
+    min-width: 34rem;
+  }
 }
 
 .idt-app-header-stack,
@@ -24384,6 +24929,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
 /* Product shell depth palette */
 #main-content:has(.idt-app-console-layout),
 #main-content:has(.idt-account-security-page),
+#main-content:has(.idt-app-shell-screen),
 #main-content:has(.idt-executive-report-shell) {
   background: #121518;
 }
@@ -24424,6 +24970,26 @@ html[data-theme='light'] .idt-app-shell-screen,
 html[data-theme='light'] .idt-executive-report-shell {
   background: linear-gradient(180deg, #15191d 0%, #121518 42%, #111417 100%);
   color: var(--app-text);
+}
+
+.idt-app-shell-screen .idt-app-panel h1,
+html[data-theme='light'] .idt-app-shell-screen .idt-app-panel h1 {
+  color: #ffffff;
+  font-size: clamp(1.85rem, 5vw, 3.1rem);
+  line-height: 1.02;
+  letter-spacing: 0;
+  text-transform: none;
+  overflow-wrap: anywhere;
+}
+
+.idt-app-shell-screen .idt-app-panel p,
+html[data-theme='light'] .idt-app-shell-screen .idt-app-panel p {
+  color: var(--app-muted);
+}
+
+.idt-app-shell-screen .idt-app-panel .idt-app-kicker,
+html[data-theme='light'] .idt-app-shell-screen .idt-app-panel .idt-app-kicker {
+  color: var(--app-dim);
 }
 
 .idt-app-console-layout .idt-app-console,


### PR DESCRIPTION
Fixes #1378

## What changed

- Added a centralized typed domain asset registry for AWS, GitHub, and Kubernetes with logo paths, official source references, brand guidance links, provider descriptions, and domain tones.
- Added reusable app-domain foundation primitives: domain page shell, domain header, subsection navigation, KPI strip, status panels, dense data table, empty/error/loading states, filter bar, detail panel, evidence panel, action footer, logo mark, and logo stack.
- Updated the existing product shell source logo rendering to consume the shared domain logo primitives instead of scattering raw logo paths in `productShell.tsx`.
- Refined the app visual foundation so the app canvas uses the GitHub/WorkOS-style dark background while panel, evidence, and fallback surfaces retain the deeper black treatment.
- Stabilized the existing AI Risks trend-failure test by waiting for the repo findings request before asserting the dashboard state.

## Why it changed

This is the first foundation PR for the domain-first app redesign. Future AWS, GitHub, Kubernetes, Reports, and Settings pages need consistent section identity, accessible logo handling, subsection patterns, operational tables, panel states, and remediation/evidence surfaces before routes start moving.

## Impact and risk

- No product IA migration is included here: Projects, Findings, AWS, GitHub, and Kubernetes routes are not moved.
- Existing source onboarding and shell routes keep using their current components, with logo rendering delegated to the new foundation primitives.
- The main visual impact is foundational styling: dark app canvas, black panels, improved provider accents, and readable app fallback states.
- Risk is mostly CSS surface area. It is mitigated by existing shell tests, new component/asset tests, production build validation, and browser smoke verification.

## Validation performed

- `npm run test --prefix web -- DomainFoundation App.test.tsx -t "DomainFoundation|keeps the AI Risks dashboard usable when trend loading fails"` - passed.
- `npm run test:ci --prefix web` - passed, 14 test files / 203 tests.
- `npm run build --prefix web` - passed, including TypeScript, Vite production build, and 39 prerendered routes.
- Pre-push hooks passed: merge conflict check, YAML check, EOF/whitespace, gofmt, go vet, local env token hygiene, and Vercel artifact hygiene.
- Browser smoke checked `http://127.0.0.1:4178/app` without a backend session: verified the fallback app shell uses the dark canvas with black panel treatment and readable heading contrast.

## Screenshots

- Local browser smoke screenshot: `/tmp/identrail-1378-app-shell-smoke.png`.

## AI disclosure

AI-assisted: yes
Tools used: OpenAI Codex
Where used: implementation planning, code edits, tests, validation, and PR preparation
Human verification performed: reviewed the diff, ran the listed test/build commands, verified the browser-rendered app shell fallback, and confirmed the branch was rebased on current `origin/dev` before publishing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a domain-first UI foundation with a typed provider asset registry and reusable primitives for AWS, GitHub, and Kubernetes, plus a refreshed dark app canvas and provider-accurate accents. Fixes #1378.

- New Features
  - Typed domain asset registry (logos, alt text, official sources, brand guidance, descriptions, tones) for `aws`, `github`, and `kubernetes`.
  - Reusable primitives: page shell, header, native collapsible subnav, KPI strip, status/empty/error/loading states, dense table, filter bar, detail/evidence panels, action footer, and accessible logo mark/stack.
  - `productShell.tsx` now uses shared domain logo components and `DomainAssetKey` typing.
  - Visual refresh: darker app canvas and updated provider accent tokens.

- Bug Fixes
  - Stabilized the AI Risks trend test by waiting for the repo findings request before asserting.
  - Fixed `DomainFilterBar` submit typing to match the `onSubmit` handler signature.

<sup>Written for commit 8c63fd229595a89edee2312482f5b7a8d483041b. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1390?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

