### PR TITLE
Gate GitHub webhook scans behind event policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## Unreleased
+- Stopped GitHub App webhooks from queueing repository scans unless the project
+  has an enabled `event` or `hybrid` scan policy. Manual projects still record
+  webhook deliveries without starting scans, low-value pull-request metadata
+  events are ignored, and explicit `@identrail review` / `/identrail review`
+  commands continue to queue scans.
 - Fixed WorkOS MFA enrollment so the browser keeps the pending challenge after
   showing the authenticator QR code, preventing valid setup codes from failing
   with "mfa challenge has not started".

--- a/docs/auth/github-connector.md
+++ b/docs/auth/github-connector.md
@@ -141,16 +141,21 @@ This fallback is for self-hosted GitHub Enterprise and development environments.
 
 `POST /auth/webhooks/github` verifies the global GitHub App HMAC secret before processing events.
 
-Installation lifecycle events can mark matching connectors disconnected. Repository events are matched by installation ID and the GitHub App selected-repository list before queueing scans.
+Installation lifecycle events can mark matching connectors disconnected. Repository events are matched by installation ID and the GitHub App selected-repository list before any scan is considered.
 
-Webhook-triggered scans still honor the GitHub App selected-repository guard,
-per-repository cursor, and queue controls. Push and pull-request events enqueue
-`delta` scans when GitHub supplies a usable head revision. Push events use
-`before` and `after` as the base/head revisions and fold commit `added`,
-`modified`, and `removed` paths into the scan request. Duplicate delivery IDs,
-burst-window repeats, queue pressure, disabled scanning, target-deny decisions,
-and already-current cursors are recorded as skipped work instead of creating
-unbounded duplicate queue entries.
+Automatic webhook-triggered scans require an enabled project scan policy with
+`trigger_mode=event` or `trigger_mode=hybrid`. Manual policies keep GitHub
+webhook activity recorded without queueing repository scans. Push and high-value
+pull-request events enqueue `delta` scans when GitHub supplies a usable head
+revision; low-value pull-request metadata changes such as labels are ignored.
+Explicit `@identrail review` or `/identrail review` commands still queue a
+scan as an operator action. Webhook-triggered scans continue to honor the
+GitHub App selected-repository guard, per-repository cursor, and queue controls.
+Push events use `before` and `after` as the base/head revisions and fold commit
+`added`, `modified`, and `removed` paths into the scan request. Duplicate
+delivery IDs, burst-window repeats, queue pressure, disabled scanning,
+target-deny decisions, and already-current cursors are recorded as skipped work
+instead of creating unbounded duplicate queue entries.
 Before enabling direct API or worker repo scans for hosted production, set an
 explicit `IDENTRAIL_REPO_SCAN_ALLOWLIST`. GitHub App-backed scans use the
 per-installation selected repository list as their scoped target guard.
@@ -173,10 +178,10 @@ API responses. The worker mints a short-lived installation token immediately
 before cloning and passes it to git through an askpass helper so the token does
 not appear in clone URLs or command-line arguments.
 
-Scheduled policy scans enqueue `deep` scans, while GitHub webhook-triggered
-scans attach the project/connector source context and enqueue `delta` or
-`quick` scans depending on event metadata. Private repositories use the same
-short-lived GitHub App path as manually queued connector-backed scans.
+Scheduled policy scans enqueue `deep` scans. Event or hybrid policy scans attach
+the project/connector source context and enqueue `delta` or `quick` scans
+depending on event metadata. Private repositories use the same short-lived
+GitHub App path as manually queued connector-backed scans.
 
 ## Repository Posture Collection
 

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -26,8 +26,9 @@ Scan modes:
 - `deep`: bounded full-history scan plus HEAD configuration inspection. Manual
   API requests default to this mode and scheduled policies enqueue this mode.
 - `delta`: commit-range scan scoped by `base_revision`, `head_revision`, and
-  optional `changed_paths`. GitHub push and pull-request webhooks enqueue this
-  mode when revision metadata is present.
+  optional `changed_paths`. GitHub push and pull-request webhooks can enqueue
+  this mode when an enabled `event` or `hybrid` scan policy allows automatic
+  event scans and revision metadata is present.
 - `quick`: HEAD-focused scan mode for lightweight event refreshes.
 
 API behavior:

--- a/internal/api/github_connect.go
+++ b/internal/api/github_connect.go
@@ -1059,7 +1059,8 @@ func (s *Service) HandleGitHubWebhook(ctx context.Context, eventType string, del
 
 	scanContext, scanContextOK := githubWebhookRepoScanContext(normalizedEventType, envelope)
 	scanTriggerEvent := githubWebhookTriggersScan(normalizedEventType, envelope)
-	result, err := s.processGitHubWebhookConnections(ctx, span, normalizedEventType, deliveryID, repository, scanContext, scanContextOK, scanTriggerEvent, validConnections)
+	explicitScanCommand := githubWebhookExplicitScanCommand(normalizedEventType, envelope)
+	result, err := s.processGitHubWebhookConnections(ctx, span, normalizedEventType, deliveryID, repository, scanContext, scanContextOK, scanTriggerEvent, explicitScanCommand, validConnections)
 	if err != nil {
 		return GitHubWebhookResult{}, err
 	}
@@ -1110,10 +1111,11 @@ func (s *Service) HandleGitHubAppWebhook(ctx context.Context, eventType string, 
 	defer span.End()
 	scanContext, scanContextOK := githubWebhookRepoScanContext(normalizedEventType, envelope)
 	scanTriggerEvent := githubWebhookTriggersScan(normalizedEventType, envelope)
-	return s.processGitHubWebhookConnections(ctx, span, normalizedEventType, deliveryID, repository, scanContext, scanContextOK, scanTriggerEvent, candidates)
+	explicitScanCommand := githubWebhookExplicitScanCommand(normalizedEventType, envelope)
+	return s.processGitHubWebhookConnections(ctx, span, normalizedEventType, deliveryID, repository, scanContext, scanContextOK, scanTriggerEvent, explicitScanCommand, candidates)
 }
 
-func (s *Service) processGitHubWebhookConnections(ctx context.Context, span trace.Span, eventType string, deliveryID string, repository string, scanContext db.RepoScanContext, scanContextOK bool, scanTriggerEvent bool, connections []githubProjectConnection) (GitHubWebhookResult, error) {
+func (s *Service) processGitHubWebhookConnections(ctx context.Context, span trace.Span, eventType string, deliveryID string, repository string, scanContext db.RepoScanContext, scanContextOK bool, scanTriggerEvent bool, explicitScanCommand bool, connections []githubProjectConnection) (GitHubWebhookResult, error) {
 	result := GitHubWebhookResult{
 		EventType:       eventType,
 		Repository:      repository,
@@ -1141,6 +1143,20 @@ func (s *Service) processGitHubWebhookConnections(ctx context.Context, span trac
 			s.recordGitHubWebhookDelivery(ctx, connection, eventType, normalizedDeliveryID, now)
 			continue
 		}
+		scopedCtx := db.WithScope(ctx, db.Scope{TenantID: connection.TenantID, WorkspaceID: connection.WorkspaceID})
+		if !explicitScanCommand {
+			eventScanAllowed, err := s.githubWebhookEventScanAllowed(scopedCtx, connection)
+			if err != nil {
+				return result, err
+			}
+			if !eventScanAllowed {
+				result.SkippedScans++
+				s.recordAutomationRun("event", "github", "skipped")
+				s.recordRepoScanSkipped(scanContext.ScanMode, "event_policy_disabled")
+				s.recordGitHubWebhookDelivery(ctx, connection, eventType, normalizedDeliveryID, now)
+				continue
+			}
+		}
 		if s.shouldThrottleGitHubWebhookScan(connection, repository, now) {
 			result.SkippedScans++
 			s.recordAutomationRun("event", "github", "skipped")
@@ -1149,7 +1165,6 @@ func (s *Service) processGitHubWebhookConnections(ctx context.Context, span trac
 			continue
 		}
 
-		scopedCtx := db.WithScope(ctx, db.Scope{TenantID: connection.TenantID, WorkspaceID: connection.WorkspaceID})
 		_, err := s.EnqueueRepoScan(scopedCtx, RepoScanRequest{
 			Repository:   repository,
 			ProjectID:    connection.ProjectID,
@@ -1194,6 +1209,24 @@ func (s *Service) processGitHubWebhookConnections(ctx context.Context, span trac
 		attribute.Int("automation.skipped_scans", result.SkippedScans),
 	)
 	return result, nil
+}
+
+func (s *Service) githubWebhookEventScanAllowed(ctx context.Context, connection githubProjectConnection) (bool, error) {
+	store, err := s.resolveScanPolicyStore()
+	if err != nil {
+		return false, fmt.Errorf("resolve scan policy store: %w", err)
+	}
+	enabled := true
+	for _, triggerMode := range []domain.ScanTriggerMode{domain.ScanTriggerModeEvent, domain.ScanTriggerModeHybrid} {
+		policies, err := store.ListTenancyScanPolicies(ctx, connection.WorkspaceID, connection.ProjectID, triggerMode, &enabled, "updated_at", true, 1)
+		if err != nil {
+			return false, fmt.Errorf("list github webhook scan policies: %w", err)
+		}
+		if len(policies) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (s *Service) verifyGitHubWebhookSignatureForInstallation(installationID int64, payload []byte, signature string) bool {
@@ -2113,12 +2146,34 @@ func validateGitHubWebhookSignature(secret string, payload []byte, signature str
 
 func githubWebhookTriggersScan(eventType string, envelope githubWebhookEnvelope) bool {
 	switch strings.ToLower(strings.TrimSpace(eventType)) {
-	case "push", "pull_request", "repository_dispatch", "workflow_dispatch":
+	case "push", "repository_dispatch", "workflow_dispatch":
 		return true
+	case "pull_request":
+		return githubWebhookPullRequestActionTriggersScan(envelope.Action)
 	case "issue_comment":
 		return githubWebhookIssueCommentOnPullRequest(envelope) && githubWebhookReviewCommand(envelope)
 	case "pull_request_review_comment":
 		return githubWebhookReviewCommand(envelope)
+	default:
+		return false
+	}
+}
+
+func githubWebhookExplicitScanCommand(eventType string, envelope githubWebhookEnvelope) bool {
+	switch strings.ToLower(strings.TrimSpace(eventType)) {
+	case "issue_comment":
+		return githubWebhookIssueCommentOnPullRequest(envelope) && githubWebhookReviewCommand(envelope)
+	case "pull_request_review_comment":
+		return githubWebhookReviewCommand(envelope)
+	default:
+		return false
+	}
+}
+
+func githubWebhookPullRequestActionTriggersScan(action string) bool {
+	switch strings.ToLower(strings.TrimSpace(action)) {
+	case "", "opened", "reopened", "synchronize", "ready_for_review":
+		return true
 	default:
 		return false
 	}

--- a/internal/api/github_connect_test.go
+++ b/internal/api/github_connect_test.go
@@ -54,6 +54,38 @@ func githubPushWebhookPayload(repository string, installationID int64) []byte {
 	return []byte(fmt.Sprintf(`{"before":"1111111111111111111111111111111111111111","after":"2222222222222222222222222222222222222222","commits":[{"id":"2222222222222222222222222222222222222222","added":["app.env"],"modified":[".github/workflows/build.yml"],"removed":[]}],"repository":{"full_name":%q},"installation":{"id":%d}}`, repository, installationID))
 }
 
+func seedGitHubWebhookEventScanPolicy(t *testing.T, store db.Store, ctx context.Context, projectID string) {
+	t.Helper()
+	scope, err := db.RequireScope(ctx)
+	if err != nil {
+		t.Fatalf("resolve scope: %v", err)
+	}
+	if err := store.UpsertTenancyScanPolicy(ctx, db.TenancyScanPolicy{
+		TenantID:           scope.TenantID,
+		WorkspaceID:        scope.WorkspaceID,
+		ProjectID:          projectID,
+		PolicyID:           "github-event-scans",
+		Name:               "GitHub event scans",
+		Enabled:            true,
+		TriggerMode:        domain.ScanTriggerModeEvent,
+		MaxConcurrentScans: 1,
+	}); err != nil {
+		t.Fatalf("seed github event scan policy: %v", err)
+	}
+}
+
+type githubWebhookPolicyListErrorStore struct {
+	db.Store
+	err error
+}
+
+func (s githubWebhookPolicyListErrorStore) ListTenancyScanPolicies(context.Context, string, string, domain.ScanTriggerMode, *bool, string, bool, int) ([]db.TenancyScanPolicy, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return nil, errors.New("scan policy list failed")
+}
+
 func TestGitHubWebhookTriggersScan(t *testing.T) {
 	scanEvents := []string{"push", "pull_request", "repository_dispatch", "workflow_dispatch", "PUSH", " Pull_Request "}
 	for _, event := range scanEvents {
@@ -82,6 +114,12 @@ func TestGitHubWebhookTriggersScan(t *testing.T) {
 	reviewCommand.Issue.PullRequest.URL = ""
 	if githubWebhookTriggersScan("issue_comment", reviewCommand) {
 		t.Fatal("expected issue comment outside a PR not to trigger a scan")
+	}
+
+	var metadataOnlyPR githubWebhookEnvelope
+	metadataOnlyPR.Action = "labeled"
+	if githubWebhookTriggersScan("pull_request", metadataOnlyPR) {
+		t.Fatal("expected pull_request labeled event not to trigger a scan")
 	}
 }
 
@@ -435,6 +473,134 @@ func TestGitHubConnectionPersistsAcrossServiceInstances(t *testing.T) {
 	}
 }
 
+func TestHandleGitHubWebhookRequiresEventScanPolicyForAutomaticEvents(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+	svc.RepoScanEnabled = true
+	svc.RepoScanAllowedTargets = []string{"owner/*"}
+
+	ctx := db.WithScope(context.Background(), db.Scope{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+	})
+	seedDefaultProject(t, store, ctx, "project-1")
+	start, err := svc.StartGitHubConnection(ctx, "workspace-a", "project-1", GitHubConnectionStartRequest{})
+	if err != nil {
+		t.Fatalf("start github connection: %v", err)
+	}
+	if _, err := svc.CompleteGitHubConnection(ctx, "workspace-a", "project-1", GitHubConnectionCompleteRequest{
+		State:                  start.State,
+		InstallationID:         77,
+		AccountLogin:           "identrail",
+		TokenReference:         "vault://token",
+		WebhookSecret:          "persisted-secret",
+		WebhookSecretReference: "vault://secret/v1",
+		SelectedRepositories:   []string{"owner/repo"},
+	}); err != nil {
+		t.Fatalf("complete github connection: %v", err)
+	}
+
+	webhookPayload := githubPushWebhookPayload("owner/repo", 77)
+	signature := githubWebhookSignature("persisted-secret", webhookPayload)
+	result, err := svc.HandleGitHubWebhook(ctx, "push", "delivery-1", signature, webhookPayload)
+	if err != nil {
+		t.Fatalf("handle webhook without event policy: %v", err)
+	}
+	if result.QueuedScans != 0 || result.SkippedScans != 1 {
+		t.Fatalf("expected automatic webhook scan to skip without event policy, got %+v", result)
+	}
+	scans, err := svc.ListRepoScans(ctx, 10)
+	if err != nil {
+		t.Fatalf("list repo scans: %v", err)
+	}
+	if len(scans) != 0 {
+		t.Fatalf("expected no queued repo scans without event policy, got %+v", scans)
+	}
+}
+
+func TestHandleGitHubWebhookPolicyLookupFailureReturnsRetryableError(t *testing.T) {
+	baseStore := db.NewMemoryStore()
+	policyErr := errors.New("policy database unavailable")
+	svc := NewService(githubWebhookPolicyListErrorStore{Store: baseStore, err: policyErr}, routerScanner{}, "aws")
+	svc.RepoScanEnabled = true
+	svc.RepoScanAllowedTargets = []string{"owner/*"}
+
+	ctx := db.WithScope(context.Background(), db.Scope{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+	})
+	seedDefaultProject(t, baseStore, ctx, "project-1")
+	start, err := svc.StartGitHubConnection(ctx, "workspace-a", "project-1", GitHubConnectionStartRequest{})
+	if err != nil {
+		t.Fatalf("start github connection: %v", err)
+	}
+	if _, err := svc.CompleteGitHubConnection(ctx, "workspace-a", "project-1", GitHubConnectionCompleteRequest{
+		State:                  start.State,
+		InstallationID:         77,
+		AccountLogin:           "identrail",
+		TokenReference:         "vault://token",
+		WebhookSecret:          "persisted-secret",
+		WebhookSecretReference: "vault://secret/v1",
+		SelectedRepositories:   []string{"owner/repo"},
+	}); err != nil {
+		t.Fatalf("complete github connection: %v", err)
+	}
+
+	webhookPayload := githubPushWebhookPayload("owner/repo", 77)
+	signature := githubWebhookSignature("persisted-secret", webhookPayload)
+	if _, err := svc.HandleGitHubWebhook(ctx, "push", "delivery-1", signature, webhookPayload); !errors.Is(err, policyErr) {
+		t.Fatalf("expected policy lookup error, got %v", err)
+	}
+
+	seedGitHubWebhookEventScanPolicy(t, baseStore, ctx, "project-1")
+	svc.Store = baseStore
+	result, err := svc.HandleGitHubWebhook(ctx, "push", "delivery-1", signature, webhookPayload)
+	if err != nil {
+		t.Fatalf("expected failed policy lookup delivery to be retryable, got %v", err)
+	}
+	if result.QueuedScans != 1 || result.SkippedScans != 0 {
+		t.Fatalf("expected retried delivery to queue after policy lookup recovery, got %+v", result)
+	}
+}
+
+func TestHandleGitHubWebhookReviewCommandBypassesEventPolicyGate(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, routerScanner{}, "aws")
+	svc.RepoScanEnabled = true
+	svc.RepoScanAllowedTargets = []string{"owner/*"}
+
+	ctx := db.WithScope(context.Background(), db.Scope{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+	})
+	seedDefaultProject(t, store, ctx, "project-1")
+	start, err := svc.StartGitHubConnection(ctx, "workspace-a", "project-1", GitHubConnectionStartRequest{})
+	if err != nil {
+		t.Fatalf("start github connection: %v", err)
+	}
+	if _, err := svc.CompleteGitHubConnection(ctx, "workspace-a", "project-1", GitHubConnectionCompleteRequest{
+		State:                  start.State,
+		InstallationID:         77,
+		AccountLogin:           "identrail",
+		TokenReference:         "vault://token",
+		WebhookSecret:          "persisted-secret",
+		WebhookSecretReference: "vault://secret/v1",
+		SelectedRepositories:   []string{"owner/repo"},
+	}); err != nil {
+		t.Fatalf("complete github connection: %v", err)
+	}
+
+	webhookPayload := []byte(`{"action":"created","repository":{"full_name":"owner/repo"},"installation":{"id":77},"issue":{"pull_request":{"url":"https://api.github.com/repos/owner/repo/pulls/7"}},"comment":{"body":"/identrail review"}}`)
+	signature := githubWebhookSignature("persisted-secret", webhookPayload)
+	result, err := svc.HandleGitHubWebhook(ctx, "issue_comment", "delivery-review", signature, webhookPayload)
+	if err != nil {
+		t.Fatalf("handle review command webhook: %v", err)
+	}
+	if result.QueuedScans != 1 || result.SkippedScans != 0 {
+		t.Fatalf("expected explicit review command to queue without event policy, got %+v", result)
+	}
+}
+
 func TestHandleGitHubWebhookReplayDeliverySkipsDuplicateScan(t *testing.T) {
 	store := db.NewMemoryStore()
 	svc := NewService(store, routerScanner{}, "aws")
@@ -484,6 +650,7 @@ func TestHandleGitHubWebhookReplayDeliverySkipsDuplicateScan(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("complete github connection: %v", err)
 	}
+	seedGitHubWebhookEventScanPolicy(t, store, ctx, "project-1")
 
 	webhookPayload := githubPushWebhookPayload("owner/repo", 77)
 	signature := githubWebhookSignature("persisted-secret", webhookPayload)
@@ -582,6 +749,7 @@ func TestHandleGitHubWebhookReplayWindowExpiresPersistedDeliveryID(t *testing.T)
 	}); err != nil {
 		t.Fatalf("complete github connection: %v", err)
 	}
+	seedGitHubWebhookEventScanPolicy(t, store, ctx, "project-1")
 
 	connectionKey := githubConnectionKey("tenant-a", "workspace-a", "project-1")
 	oldEventAt := now.Add(-2 * time.Minute)
@@ -753,6 +921,7 @@ func TestHandleGitHubWebhookRetryDeliveryAfterTransientEnqueueFailure(t *testing
 	}); err != nil {
 		t.Fatalf("complete github connection: %v", err)
 	}
+	seedGitHubWebhookEventScanPolicy(t, store, ctx, "project-1")
 
 	webhookPayload := githubPushWebhookPayload("owner/repo", 77)
 	signature := githubWebhookSignature("persisted-secret", webhookPayload)
@@ -837,6 +1006,7 @@ func TestHandleGitHubWebhookRetryDeliveryAfterQueueFull(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("complete github connection: %v", err)
 	}
+	seedGitHubWebhookEventScanPolicy(t, store, ctx, "project-1")
 
 	webhookPayload := githubPushWebhookPayload("owner/repo", 77)
 	signature := githubWebhookSignature("persisted-secret", webhookPayload)
@@ -922,6 +1092,7 @@ func TestHandleGitHubWebhookBurstControlSkipsRapidRepeatedQueues(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("complete github connection: %v", err)
 	}
+	seedGitHubWebhookEventScanPolicy(t, store, ctx, "project-1")
 
 	webhookPayload := githubPushWebhookPayload("owner/repo", 88)
 	signature := githubWebhookSignature("burst-secret", webhookPayload)

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -3924,6 +3924,10 @@ func TestRouterGitHubConnectionAndWebhookFlow(t *testing.T) {
 	if reposResp.Code != http.StatusOK {
 		t.Fatalf("update github repositories expected 200, got %d body=%s", reposResp.Code, reposResp.Body.String())
 	}
+	policyResp := doAPI(http.MethodPost, "/v1/workspaces/workspace-a/projects/project-1/scan-policies", `{"policy_id":"github-event-scans","name":"GitHub event scans","trigger_mode":"event","enabled":true}`)
+	if policyResp.Code != http.StatusOK {
+		t.Fatalf("enable github event scan policy expected 200, got %d body=%s", policyResp.Code, policyResp.Body.String())
+	}
 
 	statusResp := doAPI(http.MethodGet, "/v1/workspaces/workspace-a/projects/project-1/github/connection", "")
 	if statusResp.Code != http.StatusOK {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -5589,6 +5589,9 @@ export function ProductProjectDetailPage() {
               </select>
             </label>
           </div>
+          <p className="idt-form-note">
+            Manual keeps GitHub events from starting scans. Event and hybrid modes allow selected-repository webhooks to queue scans.
+          </p>
           {policyForm.triggerMode === 'scheduled' || policyForm.triggerMode === 'hybrid' ? (
             <label>
               Cron schedule

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4286,6 +4286,13 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   font-size: 0.95rem;
 }
 
+.idt-form-note {
+  margin: -0.15rem 0 0;
+  color: #9fb0c9;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
 .idt-app-form input {
   border: 1px solid rgba(126, 157, 211, 0.35);
   border-radius: 0.55rem;


### PR DESCRIPTION
Fixes #1392

## What changed
- Require an enabled `event` or `hybrid` scan policy before GitHub App push / pull-request / dispatch webhooks can queue repository scans.
- Keep explicit `@identrail review` and `/identrail review` comments as manual operator-triggered scans.
- Ignore low-value pull request metadata events such as labels, and record skipped webhook deliveries instead of starting scans for manual projects.
- Update docs, changelog, and the scan policy editor copy so operators can see that Manual mode blocks webhook-started scans.

## Why
GitHub App webhooks were queueing scans whenever a selected repository emitted a scan-capable event. That made projects scan repositories even when no one pressed the queue button and the project was effectively in manual mode.

## Impact and risk
- Manual projects stop auto-scanning from GitHub events after the API/worker image containing this change is deployed.
- Projects that intentionally want event-driven scans must have an enabled `event` or `hybrid` policy.
- Explicit review commands still queue scans without requiring an event policy.

## Validation
- `go test ./internal/api -count=1`
- `go test ./...`
- `npm run test:ci --prefix web`
- `npm run build --prefix web`
- `git diff --check`

## AI disclosure
- AI-assisted: yes
- Tools used: Codex
- Where used: GitHub webhook scan gating, tests, docs, and small scan-policy editor copy
- Human verification performed: diff review, focused API tests, full Go suite, web test suite, web production build, whitespace check
