### PR TITLE
Polish AI risk repository hotspots

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1553,7 +1553,7 @@ describe('App', () => {
     setCurrentPath('/app/tenant-a/workspace-a/ai-risks');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { name: /AI Risks/i })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole('heading', { name: /AI Risks/i })).toBeInTheDocument());
     const summary = await screen.findByLabelText(/AI Risks summary/i);
     const openMetric = within(summary).getByText('Open').closest('article') as HTMLElement;
     const repoMetric = within(summary).getByText('Repos').closest('article') as HTMLElement;
@@ -1638,7 +1638,7 @@ describe('App', () => {
     setCurrentPath('/app/tenant-a/workspace-a/ai-risks');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { level: 2, name: /AI Risks/i })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole('heading', { name: /AI Risks/i })).toBeInTheDocument());
     expect(await screen.findByText(/MCP server exposes sensitive environment references/i)).toBeInTheDocument();
     expect(await screen.findByText(/Trend unavailable/i)).toBeInTheDocument();
     expect(screen.queryByText(/No AI Risks yet/i)).not.toBeInTheDocument();

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -6060,7 +6060,7 @@ export function ProductAIRisksPage() {
           <h2>AI Risks</h2>
           <p>AI, MCP, workflow, runner, GitHub alert, and fix-ready signals.</p>
           <div className="idt-overview-source-strip">
-            <SourceLogoMark provider="github" />
+            <SourceLogoMark provider="github" className="is-ai-risk-source" />
             <span>{latestScanLabel}</span>
           </div>
         </div>
@@ -6173,7 +6173,7 @@ export function ProductAIRisksPage() {
           )}
         </section>
 
-        <aside className="idt-github-intelligence-panel">
+        <aside className="idt-github-intelligence-panel idt-github-intelligence-hotspot-panel">
           <div className="idt-github-intelligence-panel-head">
             <h3>Repository hotspots</h3>
             <span>{repositoryRows.length ? formatCountLabel(repositoryRows.length, 'repo') : 'No hotspots'}</span>
@@ -6185,15 +6185,30 @@ export function ProductAIRisksPage() {
             />
           ) : (
             <div className="idt-github-intelligence-hotspots">
-              {repositoryRows.map((row) => (
-                <article key={row.repository}>
-                  <div>
-                    <strong>{row.repository}</strong>
-                    <span>{row.open} open · {row.total} total</span>
-                  </div>
-                  <b>{row.criticalHigh}</b>
-                </article>
-              ))}
+              {repositoryRows.map((row) => {
+                const priorityShare = Math.round((row.criticalHigh / Math.max(row.total, 1)) * 100);
+                return (
+                  <Link className="idt-github-intelligence-hotspot-row" to={findingsPath} key={row.repository}>
+                    <div className="idt-github-intelligence-hotspot-row-top">
+                      <div className="idt-github-intelligence-hotspot-identity">
+                        <SourceLogoMark provider="github" className="is-hotspot" />
+                        <div>
+                          <strong>{row.repository}</strong>
+                          <span>{formatCountLabel(row.open, 'open finding')}</span>
+                        </div>
+                      </div>
+                      <span className="idt-github-intelligence-hotspot-score">{row.criticalHigh}</span>
+                    </div>
+                    <div className="idt-github-intelligence-hotspot-meta">
+                      <span>{formatCountLabel(row.total, 'total signal')}</span>
+                      <span>{formatCountLabel(row.criticalHigh, 'high-priority signal')}</span>
+                    </div>
+                    <div className="idt-github-intelligence-hotspot-meter" aria-hidden="true">
+                      <span style={{ width: `${priorityShare}%` }} />
+                    </div>
+                  </Link>
+                );
+              })}
             </div>
           )}
         </aside>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4949,7 +4949,7 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
 
 .idt-github-intelligence-hotspot-identity strong {
   overflow: hidden;
-  color: #f6f8ff;
+  color: var(--app-text);
   font-size: 0.96rem;
   line-height: 1.25;
   text-overflow: ellipsis;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4993,7 +4993,7 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
 .idt-github-intelligence-hotspot-meter span {
   display: block;
   height: 100%;
-  min-width: 0.25rem;
+  min-width: 0;
   border-radius: inherit;
   background: linear-gradient(90deg, rgba(255, 196, 135, 0.82), rgba(255, 107, 107, 0.9));
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4868,6 +4868,10 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   gap: 0.75rem;
 }
 
+.idt-github-intelligence-hotspot-panel {
+  align-self: start;
+}
+
 .idt-github-intelligence-panel-head h3 {
   margin: 0;
 }
@@ -4891,7 +4895,6 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   margin: 0;
 }
 
-.idt-github-intelligence-hotspots article,
 .idt-github-intelligence-trend article {
   border: 1px solid rgba(126, 157, 211, 0.18);
   border-radius: 8px;
@@ -4899,14 +4902,100 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   background: rgba(255, 255, 255, 0.03);
 }
 
-.idt-github-intelligence-hotspots b {
+.idt-github-intelligence-hotspot-row {
+  display: grid;
+  gap: 0.58rem;
+  border: 1px solid rgba(126, 157, 211, 0.2);
+  border-radius: 8px;
+  padding: 0.72rem;
+  background: rgba(255, 255, 255, 0.035);
+  color: inherit;
+  text-decoration: none;
+  transition:
+    border-color 0.18s ease,
+    background 0.18s ease,
+    transform 0.18s ease;
+}
+
+.idt-github-intelligence-hotspot-row:hover,
+.idt-github-intelligence-hotspot-row:focus-visible {
+  border-color: rgba(177, 191, 255, 0.42);
+  background: rgba(255, 255, 255, 0.055);
+  transform: translateY(-1px);
+}
+
+.idt-github-intelligence-hotspot-row-top,
+.idt-github-intelligence-hotspot-identity,
+.idt-github-intelligence-hotspot-meta {
+  display: flex;
+  align-items: center;
+}
+
+.idt-github-intelligence-hotspot-row-top {
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.idt-github-intelligence-hotspot-identity {
+  min-width: 0;
+  gap: 0.62rem;
+}
+
+.idt-github-intelligence-hotspot-identity > div {
+  min-width: 0;
+  display: grid;
+  gap: 0.14rem;
+}
+
+.idt-github-intelligence-hotspot-identity strong {
+  overflow: hidden;
+  color: #f6f8ff;
+  font-size: 0.96rem;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.idt-github-intelligence-hotspot-identity span,
+.idt-github-intelligence-hotspot-meta span {
+  color: #9da8ba;
+  font-size: 0.74rem;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.idt-github-intelligence-hotspots .idt-github-intelligence-hotspot-score {
   display: inline-grid;
-  min-width: 2rem;
-  height: 2rem;
+  min-width: 1.9rem;
+  height: 1.9rem;
+  flex: 0 0 auto;
   place-items: center;
   border-radius: 999px;
-  background: rgba(255, 107, 107, 0.14);
+  border: 1px solid rgba(255, 160, 160, 0.2);
+  background: rgba(255, 107, 107, 0.18);
   color: #ffc3c3;
+  font-size: 0.86rem;
+  font-weight: 900;
+}
+
+.idt-github-intelligence-hotspot-meta {
+  justify-content: space-between;
+  gap: 0.65rem;
+}
+
+.idt-github-intelligence-hotspot-meter {
+  overflow: hidden;
+  height: 0.28rem;
+  border-radius: 999px;
+  background: rgba(126, 157, 211, 0.16);
+}
+
+.idt-github-intelligence-hotspot-meter span {
+  display: block;
+  height: 100%;
+  min-width: 0.25rem;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(255, 196, 135, 0.82), rgba(255, 107, 107, 0.9));
 }
 
 .idt-github-intelligence-trend article {
@@ -21271,6 +21360,37 @@ html[data-theme='light'] .idt-app-shell-screen select {
   height: 2rem;
 }
 
+.idt-source-logo-mark.is-ai-risk-source,
+.idt-source-logo-mark.is-hotspot {
+  border-color: rgba(255, 255, 255, 0.34);
+  background: #ffffff;
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.32),
+    0 8px 18px rgba(0, 0, 0, 0.28);
+}
+
+.idt-source-logo-mark.is-ai-risk-source img,
+.idt-source-logo-mark.is-hotspot img {
+  opacity: 1;
+  filter: none;
+}
+
+.idt-source-logo-mark.is-ai-risk-source {
+  width: 1.95rem;
+  height: 1.95rem;
+}
+
+.idt-source-logo-mark.is-hotspot {
+  width: 1.7rem;
+  height: 1.7rem;
+  border-radius: 7px;
+}
+
+.idt-source-logo-mark.is-hotspot img {
+  width: 0.98rem;
+  height: 0.98rem;
+}
+
 .idt-source-logo-stack {
   display: flex;
   align-items: center;
@@ -26072,11 +26192,29 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
     grid-template-columns: minmax(0, 1fr);
   }
 
+  .idt-app-console-layout .idt-repo-findings-header.idt-github-intelligence-header .idt-overview-source-strip {
+    display: flex;
+    align-items: center;
+  }
+
   .idt-app-console-layout .idt-repo-findings-header .idt-overview-source-strip > span,
   html[data-theme='light'] .idt-app-console-layout .idt-repo-findings-header .idt-overview-source-strip > span {
     display: block;
     width: 100%;
     overflow-wrap: anywhere;
+  }
+
+  .idt-app-console-layout .idt-repo-findings-header.idt-github-intelligence-header .idt-overview-source-strip > .idt-source-logo-mark.is-ai-risk-source {
+    display: inline-grid;
+    width: 1.95rem;
+    max-width: 1.95rem;
+  }
+
+  .idt-app-console-layout .idt-repo-findings-header.idt-github-intelligence-header .idt-overview-source-strip > span:not(.idt-source-logo-mark),
+  html[data-theme='light'] .idt-app-console-layout .idt-repo-findings-header.idt-github-intelligence-header .idt-overview-source-strip > span:not(.idt-source-logo-mark) {
+    width: auto;
+    min-width: 0;
+    flex: 1 1 auto;
   }
 
   .idt-app-console-layout .idt-app-sidebar-footer,


### PR DESCRIPTION
## What changed
- Redesign the AI Risks repository hotspots panel as a compact, content-height list instead of a stretched empty panel.
- Add clearer hotspot row labels, GitHub source identity, high-priority count, and a subtle priority meter.
- Increase contrast for the GitHub source mark in the AI Risks scan source chip and preserve compact wrapping on mobile.
- Harden the AI Risks tests against detached heading nodes during route rendering.

## Why
The previous hotspot card left too much unused vertical space when there was only one repository, and the GitHub mark in the latest scan source chip was visually buried on the dark surface.

## Impact and risk
Low-risk UI polish scoped to the AI Risks dashboard. No API or data contract changes.

## Validation
- `npm test -- --run App.test.tsx` from `web/` - 62 passed
- `npm run build` from `web/` - passed, prerendered 39 routes
- Visual QA through localhost at desktop and mobile widths

AI-assisted: yes
Tools used: Codex
Where used: web/src/productShell.tsx, web/src/styles.css, web/src/App.test.tsx
Human verification performed: local test run, production build, desktop and mobile visual QA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the AI Risks repository hotspots into a compact, content-height list with clear labels, GitHub identity, high-priority counts, and a visual priority meter. Increased contrast and responsiveness for GitHub source marks in the header and rows, and fixed zero-count meters.

- **New Features**
  - Compact hotspot rows with GitHub mark, repo name, open/total labels, high-priority badge, and a visual meter; each row links to findings.
  - Stronger GitHub source chip contrast in the header and hotspot rows with improved mobile wrapping.

- **Bug Fixes**
  - Hotspot meter allows zero-width fill for repos with no high-priority signals.
  - Improved hotspot label contrast across themes.
  - Stabilized AI Risks tests by waiting for the heading to render to avoid detached node errors.

<sup>Written for commit b61dd6bf9b020fcbafc8b02d048e2f1fe3b4eb13. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1393?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

