### PR TITLE
Redesign onboarding setup experience

### DIFF
--- a/web/src/components/onboarding/Stepper.tsx
+++ b/web/src/components/onboarding/Stepper.tsx
@@ -1,12 +1,12 @@
 import type { OnboardingStep } from '../../api/client';
-import { CheckCircle2, Circle, CircleDot } from 'lucide-react';
+import { Building2, PanelsTopLeft, PlugZap, ScanSearch, UserPlus, type LucideIcon } from 'lucide-react';
 
-const STEP_ITEMS: Array<{ id: Exclude<OnboardingStep, 'complete'>; label: string; detail: string }> = [
-  { id: 'org', label: 'Organization', detail: 'Security boundary' },
-  { id: 'workspace', label: 'Workspace', detail: 'First environment' },
-  { id: 'connect', label: 'Connect source', detail: 'Read-only signal' },
-  { id: 'scan', label: 'First scan', detail: 'Findings baseline' },
-  { id: 'invite', label: 'Invite team', detail: 'Reviewer access' }
+const STEP_ITEMS: Array<{ id: Exclude<OnboardingStep, 'complete'>; label: string; detail: string; icon: LucideIcon }> = [
+  { id: 'org', label: 'Organization', detail: 'Tenant root', icon: Building2 },
+  { id: 'workspace', label: 'Workspace', detail: 'Project scope', icon: PanelsTopLeft },
+  { id: 'connect', label: 'Connect source', detail: 'GitHub, AWS, K8s', icon: PlugZap },
+  { id: 'scan', label: 'First scan', detail: 'Evidence baseline', icon: ScanSearch },
+  { id: 'invite', label: 'Invite team', detail: 'Reviewer access', icon: UserPlus }
 ];
 
 export function OnboardingStepper({ currentStep }: { currentStep: OnboardingStep }) {
@@ -17,7 +17,7 @@ export function OnboardingStepper({ currentStep }: { currentStep: OnboardingStep
     <nav className="idt-onboarding-stepper" aria-label="Onboarding progress">
       {STEP_ITEMS.map((step, index) => {
         const state = index < activeIndex ? 'complete' : index === activeIndex ? 'current' : 'pending';
-        const StepIcon = state === 'complete' ? CheckCircle2 : state === 'current' ? CircleDot : Circle;
+        const StepIcon = step.icon;
         return (
           <div className={`idt-onboarding-step is-${state}`} key={step.id} aria-current={state === 'current' ? 'step' : undefined}>
             <span className="idt-onboarding-step-icon" aria-hidden="true">

--- a/web/src/components/onboarding/Stepper.tsx
+++ b/web/src/components/onboarding/Stepper.tsx
@@ -1,27 +1,32 @@
 import type { OnboardingStep } from '../../api/client';
+import { CheckCircle2, Circle, CircleDot } from 'lucide-react';
 
-const STEP_ITEMS: Array<{ id: Exclude<OnboardingStep, 'complete'>; label: string }> = [
-  { id: 'org', label: 'Organization' },
-  { id: 'workspace', label: 'Workspace' },
-  { id: 'connect', label: 'Connect' },
-  { id: 'scan', label: 'Scan' },
-  { id: 'invite', label: 'Invite' }
+const STEP_ITEMS: Array<{ id: Exclude<OnboardingStep, 'complete'>; label: string; detail: string }> = [
+  { id: 'org', label: 'Organization', detail: 'Security boundary' },
+  { id: 'workspace', label: 'Workspace', detail: 'First environment' },
+  { id: 'connect', label: 'Connect source', detail: 'Read-only signal' },
+  { id: 'scan', label: 'First scan', detail: 'Findings baseline' },
+  { id: 'invite', label: 'Invite team', detail: 'Reviewer access' }
 ];
 
 export function OnboardingStepper({ currentStep }: { currentStep: OnboardingStep }) {
-  const activeIndex = Math.max(
-    0,
-    STEP_ITEMS.findIndex((step) => step.id === currentStep)
-  );
+  const currentIndex = STEP_ITEMS.findIndex((step) => step.id === currentStep);
+  const activeIndex = currentStep === 'complete' ? STEP_ITEMS.length : Math.max(0, currentIndex);
 
   return (
     <nav className="idt-onboarding-stepper" aria-label="Onboarding progress">
       {STEP_ITEMS.map((step, index) => {
         const state = index < activeIndex ? 'complete' : index === activeIndex ? 'current' : 'pending';
+        const StepIcon = state === 'complete' ? CheckCircle2 : state === 'current' ? CircleDot : Circle;
         return (
           <div className={`idt-onboarding-step is-${state}`} key={step.id} aria-current={state === 'current' ? 'step' : undefined}>
-            <span>{String(index + 1).padStart(2, '0')}</span>
-            <strong>{step.label}</strong>
+            <span className="idt-onboarding-step-icon" aria-hidden="true">
+              <StepIcon size={18} strokeWidth={2.2} />
+            </span>
+            <span className="idt-onboarding-step-copy">
+              <strong>{step.label}</strong>
+              <small>{step.detail}</small>
+            </span>
           </div>
         );
       })}

--- a/web/src/pages/onboarding/OrgPage.tsx
+++ b/web/src/pages/onboarding/OrgPage.tsx
@@ -80,13 +80,13 @@ export function OrgPage() {
   return (
     <OnboardingFrame
       step="org"
-      eyebrow="Account setup"
-      title="Create your organization boundary"
-      description="This becomes the tenant root for every workspace, connector, scan, policy, and teammate you add later."
+      eyebrow="Secure onboarding"
+      title="Create your organization"
+      description="This is the security boundary for your workspaces, repositories, scans, findings, and team access."
       aside={
         <div className="idt-onboarding-assurance">
-          <strong>Server-owned setup</strong>
-          <span>Progress is stored in Identrail, so refreshes and second devices resume safely.</span>
+          <strong>Enterprise-ready setup</strong>
+          <span>Progress is saved in Identrail, so refreshes and second devices continue from the same place.</span>
         </div>
       }
     >
@@ -97,14 +97,18 @@ export function OrgPage() {
         </div>
       ) : null}
       <form className="idt-onboarding-form" onSubmit={submit}>
-        <label htmlFor="org-name">Organization name</label>
-        <input
-          id="org-name"
-          value={orgName}
-          onChange={(event) => setOrgName(event.target.value)}
-          placeholder="Acme Security"
-          autoComplete="organization"
-        />
+        <div className="idt-onboarding-field">
+          <label htmlFor="org-name">Organization name</label>
+          <p id="org-name-hint">Use the company or security program name your team will recognize.</p>
+          <input
+            id="org-name"
+            value={orgName}
+            onChange={(event) => setOrgName(event.target.value)}
+            placeholder="Acme Security"
+            autoComplete="organization"
+            aria-describedby="org-name-hint"
+          />
+        </div>
         <div className="idt-onboarding-actions">
           <button type="submit" className="idt-btn idt-btn-primary" disabled={saving || loading || !orgName.trim()}>
             {saving ? 'Saving...' : state?.org_id ? 'Continue' : 'Create organization'}

--- a/web/src/pages/onboarding/onboardingUtils.tsx
+++ b/web/src/pages/onboarding/onboardingUtils.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import { Link, NavigateFunction } from 'react-router-dom';
+import { ArrowRight, GitBranch, LockKeyhole, LogOut, ShieldCheck } from 'lucide-react';
 import {
   apiClient,
   ApiError,
@@ -122,6 +123,21 @@ export async function loadOrStartOnboarding(): Promise<OnboardingState> {
   return (await loadOrStartOnboardingResponse()).state;
 }
 
+const SETUP_GUARANTEES = [
+  {
+    icon: LockKeyhole,
+    title: 'Read-only first',
+    detail: 'Connectors begin with discovery paths before any enforcement workflow.'
+  },
+  {
+    icon: GitBranch,
+    title: 'Scoped by design',
+    detail: 'Workspaces, projects, scans, and findings stay inside one tenant boundary.'
+  }
+];
+
+const NEXT_STEPS = ['Create the security boundary', 'Name the first workspace', 'Connect a source', 'Run the first scan'];
+
 export function OnboardingFrame({
   step,
   eyebrow,
@@ -140,27 +156,74 @@ export function OnboardingFrame({
   return (
     <section className="idt-onboarding-shell">
       <header className="idt-onboarding-topbar">
-        <Link to="/" className="idt-logo-link" aria-label="Identrail home">
+        <Link to="/" className="idt-onboarding-brand" aria-label="Identrail home">
           <span className="idt-onboarding-logo-mark">
             <img src="/identrail-logo.png" alt="" aria-hidden="true" />
           </span>
-          <span>Identrail</span>
+          <span className="idt-onboarding-brand-copy">
+            <strong>Identrail</strong>
+            <span>Secure setup</span>
+          </span>
         </Link>
-        <Link to="/app/logout" className="idt-btn idt-btn-ghost">
-          Sign out
+        <Link to="/app/logout" className="idt-onboarding-signout">
+          <LogOut size={15} strokeWidth={2.1} aria-hidden="true" />
+          <span>Sign out</span>
         </Link>
       </header>
       <div className="idt-onboarding-grid">
         <aside className="idt-onboarding-rail">
-          <p className="idt-onboarding-rail-label">Setup progress</p>
+          <div className="idt-onboarding-rail-intro">
+            <span className="idt-onboarding-rail-icon">
+              <ShieldCheck size={18} strokeWidth={2.2} aria-hidden="true" />
+            </span>
+            <div>
+              <p className="idt-onboarding-rail-label">Setup progress</p>
+              <strong>Launch path</strong>
+            </div>
+          </div>
           <OnboardingStepper currentStep={step} />
           {aside}
+          <div className="idt-onboarding-rail-note">
+            <span>Setup model</span>
+            <strong>Server-saved progress with read-only security checks first.</strong>
+          </div>
         </aside>
         <article className="idt-onboarding-panel">
-          <p className="idt-app-kicker">{eyebrow}</p>
-          <h1>{title}</h1>
-          <p>{description}</p>
-          {children}
+          <div className="idt-onboarding-panel-main">
+            <p className="idt-app-kicker">{eyebrow}</p>
+            <h1>{title}</h1>
+            <p>{description}</p>
+            <div className="idt-onboarding-guarantees" aria-label="Setup guarantees">
+              {SETUP_GUARANTEES.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <div className="idt-onboarding-guarantee" key={item.title}>
+                    <Icon size={16} strokeWidth={2.1} aria-hidden="true" />
+                    <div>
+                      <strong>{item.title}</strong>
+                      <span>{item.detail}</span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+            {children}
+          </div>
+          <aside className="idt-onboarding-outcome" aria-label="What happens next">
+            <p className="idt-onboarding-outcome-label">What happens next</p>
+            <ol>
+              {NEXT_STEPS.map((item) => (
+                <li key={item}>
+                  <span>{item}</span>
+                  <ArrowRight size={14} strokeWidth={2.2} aria-hidden="true" />
+                </li>
+              ))}
+            </ol>
+            <div className="idt-onboarding-outcome-note">
+              <strong>Designed for security teams</strong>
+              <span>Short setup, explicit scope, and a findings dashboard ready after the first scan.</span>
+            </div>
+          </aside>
         </article>
       </div>
     </section>

--- a/web/src/pages/onboarding/onboardingUtils.tsx
+++ b/web/src/pages/onboarding/onboardingUtils.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { Link, NavigateFunction } from 'react-router-dom';
-import { ArrowRight, GitBranch, LockKeyhole, LogOut, ShieldCheck } from 'lucide-react';
+import { ArrowRight, Eye, LogOut, Network } from 'lucide-react';
 import {
   apiClient,
   ApiError,
@@ -125,12 +125,12 @@ export async function loadOrStartOnboarding(): Promise<OnboardingState> {
 
 const SETUP_GUARANTEES = [
   {
-    icon: LockKeyhole,
+    icon: Eye,
     title: 'Read-only first',
     detail: 'Connectors begin with discovery paths before any enforcement workflow.'
   },
   {
-    icon: GitBranch,
+    icon: Network,
     title: 'Scoped by design',
     detail: 'Workspaces, projects, scans, and findings stay inside one tenant boundary.'
   }
@@ -165,7 +165,7 @@ export function OnboardingFrame({
             <span>Secure setup</span>
           </span>
         </Link>
-        <Link to="/app/logout" className="idt-onboarding-signout">
+        <Link to="/app/logout" className="idt-onboarding-signout" aria-label="Sign out">
           <LogOut size={15} strokeWidth={2.1} aria-hidden="true" />
           <span>Sign out</span>
         </Link>
@@ -173,9 +173,6 @@ export function OnboardingFrame({
       <div className="idt-onboarding-grid">
         <aside className="idt-onboarding-rail">
           <div className="idt-onboarding-rail-intro">
-            <span className="idt-onboarding-rail-icon">
-              <ShieldCheck size={18} strokeWidth={2.2} aria-hidden="true" />
-            </span>
             <div>
               <p className="idt-onboarding-rail-label">Setup progress</p>
               <strong>Launch path</strong>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15478,6 +15478,8 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
 
 .idt-onboarding-shell {
   min-height: 100vh;
+  width: 100%;
+  max-width: 100vw;
   background: #000000;
   color: #f5f7fb;
   padding: 24px clamp(16px, 4vw, 56px) 56px;
@@ -15490,6 +15492,7 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
+  min-width: 0;
   width: 100%;
   max-width: 1320px;
   margin: 0 auto 30px;
@@ -15504,12 +15507,14 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
 
 .idt-onboarding-brand {
   gap: 12px;
+  min-width: 0;
   color: #f8fafc;
 }
 
 .idt-onboarding-brand-copy {
   display: grid;
   gap: 2px;
+  min-width: 0;
 }
 
 .idt-onboarding-brand-copy strong {
@@ -15567,7 +15572,7 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
   grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
   gap: 24px;
   width: 100%;
-  max-width: 1320px;
+  max-width: min(1320px, 100%);
   margin: 0 auto;
   align-items: start;
 }
@@ -15585,12 +15590,16 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
   padding: 22px;
   position: sticky;
   top: 24px;
+  width: 100%;
+  max-width: 100%;
 }
 
 .idt-onboarding-panel {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
   min-height: 35rem;
+  width: 100%;
+  max-width: 100%;
   overflow: hidden;
 }
 
@@ -15601,21 +15610,7 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
 }
 
 .idt-onboarding-rail-intro {
-  display: flex;
-  align-items: center;
-  gap: 12px;
   margin-bottom: 22px;
-}
-
-.idt-onboarding-rail-icon {
-  display: grid;
-  width: 38px;
-  height: 38px;
-  place-items: center;
-  border: 1px solid #242424;
-  border-radius: 8px;
-  background: #050505;
-  color: #8fb6ff;
 }
 
 .idt-onboarding-rail-label {
@@ -15635,6 +15630,7 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
 }
 
 .idt-onboarding-panel h1 {
+  width: 100%;
   max-width: 640px;
   margin: 0;
   color: #ffffff;
@@ -15695,7 +15691,7 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
 .idt-onboarding-guarantee svg {
   flex: 0 0 auto;
   margin-top: 3px;
-  color: #86efac;
+  color: #a3a3a3;
 }
 
 .idt-onboarding-guarantee div {
@@ -15733,12 +15729,12 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
 .idt-onboarding-step-icon {
   display: grid;
   place-items: center;
-  width: 32px;
-  height: 32px;
-  border-radius: 999px;
+  width: 34px;
+  height: 34px;
+  border-radius: 7px;
   border: 1px solid #2a2a2a;
-  background: #050505;
-  color: #737373;
+  background: #000000;
+  color: #8a8a8a;
 }
 
 .idt-onboarding-step-copy {
@@ -15767,8 +15763,8 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
 }
 
 .idt-onboarding-step.is-current .idt-onboarding-step-icon {
-  border-color: #8ea7ff;
-  background: #050505;
+  border-color: #4b5563;
+  background: #080808;
   color: #ffffff;
 }
 
@@ -15777,9 +15773,9 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
 }
 
 .idt-onboarding-step.is-complete .idt-onboarding-step-icon {
-  border-color: rgba(134, 239, 172, 0.35);
-  background: rgba(34, 197, 94, 0.1);
-  color: #86efac;
+  border-color: #3a3a3a;
+  background: #050505;
+  color: #d4d4d4;
 }
 
 .idt-onboarding-assurance {
@@ -15827,6 +15823,7 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
 .idt-onboarding-form {
   display: grid;
   gap: 16px;
+  width: 100%;
   max-width: 560px;
   margin-top: 32px;
 }
@@ -16078,7 +16075,7 @@ html[data-theme='light'] .idt-onboarding-shell .idt-btn-primary:focus-visible {
   }
 
   .idt-onboarding-step {
-    grid-template-columns: 32px minmax(0, 1fr);
+    grid-template-columns: 34px minmax(0, 1fr);
   }
 
   .idt-onboarding-outcome {
@@ -16093,7 +16090,12 @@ html[data-theme='light'] .idt-onboarding-shell .idt-btn-primary:focus-visible {
   }
 
   .idt-onboarding-topbar {
+    gap: 12px;
     margin-bottom: 18px;
+  }
+
+  .idt-onboarding-signout span {
+    display: none;
   }
 
   .idt-onboarding-panel-main,
@@ -16102,7 +16104,17 @@ html[data-theme='light'] .idt-onboarding-shell .idt-btn-primary:focus-visible {
   }
 
   .idt-onboarding-panel h1 {
-    font-size: 2.2rem;
+    max-width: 100%;
+    font-size: 2rem;
+  }
+
+  .idt-onboarding-form {
+    max-width: 100%;
+  }
+
+  .idt-onboarding-actions .idt-btn {
+    justify-content: center;
+    width: 100%;
   }
 
   .idt-onboarding-guarantees {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15478,7 +15478,7 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
 
 .idt-onboarding-shell {
   min-height: 100vh;
-  background: linear-gradient(180deg, #14181d 0%, #101317 52%, #0c0f12 100%);
+  background: #000000;
   color: #f5f7fb;
   padding: 24px clamp(16px, 4vw, 56px) 56px;
   font-family: 'Geist', 'Inter', sans-serif;
@@ -15518,7 +15518,7 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
 }
 
 .idt-onboarding-brand-copy span {
-  color: #8f99a8;
+  color: #8a8a8a;
   font-size: 0.74rem;
   font-weight: 700;
   letter-spacing: 0.03em;
@@ -15528,10 +15528,10 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
   gap: 8px;
   min-height: 36px;
   padding: 0 13px;
-  border: 1px solid #252b33;
+  border: 1px solid #242424;
   border-radius: 999px;
-  background: rgba(5, 6, 7, 0.72);
-  color: #aeb6c4;
+  background: #050505;
+  color: #b4b4b4;
   font-size: 0.82rem;
   font-weight: 800;
   transition: background-color 0.18s ease, border-color 0.18s ease, color 0.18s ease;
@@ -15539,8 +15539,8 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
 
 .idt-onboarding-signout:hover,
 .idt-onboarding-signout:focus-visible {
-  border-color: #3a424d;
-  background: #050607;
+  border-color: #3a3a3a;
+  background: #0a0a0a;
   color: #ffffff;
 }
 
@@ -15575,10 +15575,10 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
 .idt-onboarding-rail,
 .idt-onboarding-panel {
   min-width: 0;
-  border: 1px solid #222832;
-  background: #050607;
+  border: 1px solid #1f1f1f;
+  background: #000000;
   border-radius: 8px;
-  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.26);
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.42);
 }
 
 .idt-onboarding-rail {
@@ -15597,6 +15597,7 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
 .idt-onboarding-panel-main {
   min-width: 0;
   padding: clamp(34px, 5vw, 64px);
+  background: #000000;
 }
 
 .idt-onboarding-rail-intro {
@@ -15611,15 +15612,15 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
   width: 38px;
   height: 38px;
   place-items: center;
-  border: 1px solid #26303b;
+  border: 1px solid #242424;
   border-radius: 8px;
-  background: #090d12;
+  background: #050505;
   color: #8fb6ff;
 }
 
 .idt-onboarding-rail-label {
   margin: 0;
-  color: #8f8f95;
+  color: #8a8a8a;
   font-size: 0.72rem;
   font-weight: 800;
   letter-spacing: 0.07em;
@@ -15629,7 +15630,7 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
 .idt-onboarding-rail-intro strong {
   display: block;
   margin-top: 2px;
-  color: #f8fafc;
+  color: #ffffff;
   font-size: 1.02rem;
 }
 
@@ -15654,7 +15655,7 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
 .idt-onboarding-panel-main > p {
   max-width: 650px;
   margin: 18px 0 0;
-  color: #b8c0cc;
+  color: #b4b4b4;
   font-size: 1.02rem;
   line-height: 1.72;
 }
@@ -15680,15 +15681,15 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   max-width: 720px;
   margin-top: 28px;
   padding: 18px 0;
-  border-top: 1px solid #1e252d;
-  border-bottom: 1px solid #1e252d;
+  border-top: 1px solid #1f1f1f;
+  border-bottom: 1px solid #1f1f1f;
 }
 
 .idt-onboarding-guarantee {
   display: flex;
   gap: 11px;
   min-width: 0;
-  color: #8fa0b4;
+  color: #a1a1aa;
 }
 
 .idt-onboarding-guarantee svg {
@@ -15703,7 +15704,7 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
 }
 
 .idt-onboarding-guarantee strong {
-  color: #f8fafc;
+  color: #ffffff;
   font-size: 0.9rem;
 }
 
@@ -15726,7 +15727,7 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   padding: 9px 8px;
   border: 1px solid transparent;
   border-radius: 7px;
-  color: #8f99a8;
+  color: #8a8a8a;
 }
 
 .idt-onboarding-step-icon {
@@ -15735,9 +15736,9 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   width: 32px;
   height: 32px;
   border-radius: 999px;
-  border: 1px solid #252b33;
-  background: #0a0d11;
-  color: #647286;
+  border: 1px solid #2a2a2a;
+  background: #050505;
+  color: #737373;
 }
 
 .idt-onboarding-step-copy {
@@ -15748,12 +15749,12 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
 
 .idt-onboarding-step strong {
   font-size: 0.92rem;
-  color: #cbd5e1;
+  color: #d4d4d4;
 }
 
 .idt-onboarding-step small {
   overflow: hidden;
-  color: #707b8b;
+  color: #737373;
   font-size: 0.76rem;
   font-weight: 700;
   text-overflow: ellipsis;
@@ -15761,13 +15762,13 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
 }
 
 .idt-onboarding-step.is-current {
-  border-color: #303947;
-  background: #111822;
+  border-color: #333333;
+  background: #0a0a0a;
 }
 
 .idt-onboarding-step.is-current .idt-onboarding-step-icon {
   border-color: #8ea7ff;
-  background: #151f31;
+  background: #050505;
   color: #ffffff;
 }
 
@@ -15786,8 +15787,8 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   gap: 8px;
   margin-top: 22px;
   padding-top: 18px;
-  border-top: 1px solid #1f252d;
-  color: #95a1b0;
+  border-top: 1px solid #1f1f1f;
+  color: #a1a1aa;
   line-height: 1.55;
 }
 
@@ -15804,12 +15805,12 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   gap: 6px;
   margin-top: 22px;
   padding-top: 18px;
-  border-top: 1px solid #1f252d;
+  border-top: 1px solid #1f1f1f;
 }
 
 .idt-onboarding-rail-note span,
 .idt-onboarding-outcome-label {
-  color: #788395;
+  color: #737373;
   font-size: 0.72rem;
   font-weight: 900;
   letter-spacing: 0.1em;
@@ -15817,7 +15818,7 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
 }
 
 .idt-onboarding-rail-note strong {
-  color: #d7dde8;
+  color: #e5e5e5;
   font-size: 0.9rem;
   line-height: 1.5;
   overflow-wrap: anywhere;
@@ -15842,7 +15843,7 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
 
 .idt-onboarding-field p {
   margin: 0;
-  color: #8d98a9;
+  color: #8a8a8a;
   font-size: 0.86rem;
   line-height: 1.5;
 }
@@ -15850,12 +15851,12 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
 .idt-onboarding-form input,
 .idt-onboarding-form textarea {
   width: 100%;
-  border: 1px solid #2a313b;
+  border: 1px solid #2a2a2a;
   border-radius: 8px;
   padding: 14px 16px;
   font: inherit;
   color: #ffffff;
-  background: #090c10;
+  background: #050505;
   box-shadow: none;
 }
 
@@ -15900,8 +15901,8 @@ html[data-theme='light'] .idt-onboarding-shell .idt-btn-primary:focus-visible {
 
 .idt-onboarding-shell .idt-btn-secondary,
 .idt-onboarding-shell .idt-btn-ghost {
-  border-color: #2b333e;
-  background: #0d1117;
+  border-color: #2a2a2a;
+  background: #050505;
   color: #e5e7eb;
 }
 
@@ -15918,10 +15919,10 @@ html[data-theme='light'] .idt-onboarding-shell .idt-btn-primary:focus-visible {
   gap: 10px;
   align-content: start;
   text-align: left;
-  border: 1px solid #26262a;
+  border: 1px solid #2a2a2a;
   border-radius: 8px;
   padding: 18px;
-  background: #090c10;
+  background: #050505;
   color: #f5f5f5;
   cursor: pointer;
 }
@@ -15929,7 +15930,7 @@ html[data-theme='light'] .idt-onboarding-shell .idt-btn-primary:focus-visible {
 .idt-onboarding-provider:hover,
 .idt-onboarding-provider.is-selected {
   border-color: #ffffff;
-  background: #111720;
+  background: #0a0a0a;
   box-shadow: none;
 }
 
@@ -15961,8 +15962,8 @@ html[data-theme='light'] .idt-onboarding-shell .idt-btn-primary:focus-visible {
   margin-top: 32px;
   padding: 20px;
   border-radius: 8px;
-  border: 1px solid #2a313b;
-  background: #090c10;
+  border: 1px solid #2a2a2a;
+  background: #050505;
 }
 
 .idt-onboarding-scan-status span {
@@ -15984,8 +15985,8 @@ html[data-theme='light'] .idt-onboarding-shell .idt-btn-primary:focus-visible {
   align-content: start;
   gap: 22px;
   min-width: 0;
-  border-left: 1px solid #202731;
-  background: #07090c;
+  border-left: 1px solid #1f1f1f;
+  background: #050505;
   padding: clamp(28px, 4vw, 40px);
 }
 
@@ -16003,26 +16004,26 @@ html[data-theme='light'] .idt-onboarding-shell .idt-btn-primary:focus-visible {
   justify-content: space-between;
   gap: 14px;
   padding: 13px 0;
-  border-bottom: 1px solid #1d232b;
-  color: #d7dde8;
+  border-bottom: 1px solid #1f1f1f;
+  color: #e5e5e5;
   font-size: 0.9rem;
   font-weight: 750;
 }
 
 .idt-onboarding-outcome li:first-child {
-  border-top: 1px solid #1d232b;
+  border-top: 1px solid #1f1f1f;
 }
 
 .idt-onboarding-outcome li svg {
   flex: 0 0 auto;
-  color: #7f8ea3;
+  color: #8a8a8a;
 }
 
 .idt-onboarding-outcome-note {
   display: grid;
   gap: 8px;
   margin-top: 4px;
-  color: #95a1b0;
+  color: #a1a1aa;
   font-size: 0.88rem;
   line-height: 1.55;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15484,7 +15484,6 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
   color: #f5f7fb;
   padding: 24px clamp(16px, 4vw, 56px) 56px;
   font-family: 'Geist', 'Inter', sans-serif;
-  overflow-x: hidden;
 }
 
 .idt-onboarding-topbar {
@@ -16057,7 +16056,7 @@ html[data-theme='light'] .idt-onboarding-shell .idt-btn-primary:focus-visible {
   color: #c8c8ce;
 }
 
-@media (max-width: 900px) {
+@media (max-width: 1180px) {
   .idt-onboarding-grid,
   .idt-onboarding-panel,
   .idt-onboarding-provider-grid {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15478,9 +15478,11 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
 
 .idt-onboarding-shell {
   min-height: 100vh;
-  background: #050506;
-  color: #f5f5f5;
-  padding: 24px clamp(16px, 4vw, 56px) 48px;
+  background: linear-gradient(180deg, #14181d 0%, #101317 52%, #0c0f12 100%);
+  color: #f5f7fb;
+  padding: 24px clamp(16px, 4vw, 56px) 56px;
+  font-family: 'Geist', 'Inter', sans-serif;
+  overflow-x: hidden;
 }
 
 .idt-onboarding-topbar {
@@ -15488,19 +15490,70 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  max-width: 1180px;
-  margin: 0 auto 32px;
+  width: 100%;
+  max-width: 1320px;
+  margin: 0 auto 30px;
+}
+
+.idt-onboarding-brand,
+.idt-onboarding-signout {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+}
+
+.idt-onboarding-brand {
+  gap: 12px;
+  color: #f8fafc;
+}
+
+.idt-onboarding-brand-copy {
+  display: grid;
+  gap: 2px;
+}
+
+.idt-onboarding-brand-copy strong {
+  font-size: 0.98rem;
+  letter-spacing: 0;
+}
+
+.idt-onboarding-brand-copy span {
+  color: #8f99a8;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+
+.idt-onboarding-signout {
+  gap: 8px;
+  min-height: 36px;
+  padding: 0 13px;
+  border: 1px solid #252b33;
+  border-radius: 999px;
+  background: rgba(5, 6, 7, 0.72);
+  color: #aeb6c4;
+  font-size: 0.82rem;
+  font-weight: 800;
+  transition: background-color 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+}
+
+.idt-onboarding-signout:hover,
+.idt-onboarding-signout:focus-visible {
+  border-color: #3a424d;
+  background: #050607;
+  color: #ffffff;
 }
 
 .idt-onboarding-logo-mark {
   display: inline-grid;
-  width: 2.3rem;
-  height: 2.3rem;
+  width: 2.1rem;
+  height: 2.1rem;
   place-items: center;
   overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.26);
   border-radius: 8px;
   background: #ffffff;
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.28);
 }
 
 .idt-onboarding-logo-mark img {
@@ -15511,56 +15564,83 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
 
 .idt-onboarding-grid {
   display: grid;
-  grid-template-columns: minmax(240px, 300px) minmax(0, 1fr);
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
   gap: 24px;
-  max-width: 1180px;
+  width: 100%;
+  max-width: 1320px;
   margin: 0 auto;
   align-items: start;
 }
 
 .idt-onboarding-rail,
 .idt-onboarding-panel {
-  border: 1px solid #242424;
-  background: #0a0a0b;
+  min-width: 0;
+  border: 1px solid #222832;
+  background: #050607;
   border-radius: 8px;
-  box-shadow: none;
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.26);
 }
 
 .idt-onboarding-rail {
-  padding: 20px;
+  padding: 22px;
   position: sticky;
   top: 24px;
 }
 
 .idt-onboarding-panel {
-  min-height: 34rem;
-  padding: clamp(28px, 5vw, 56px);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
+  min-height: 35rem;
+  overflow: hidden;
+}
+
+.idt-onboarding-panel-main {
+  min-width: 0;
+  padding: clamp(34px, 5vw, 64px);
+}
+
+.idt-onboarding-rail-intro {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 22px;
+}
+
+.idt-onboarding-rail-icon {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border: 1px solid #26303b;
+  border-radius: 8px;
+  background: #090d12;
+  color: #8fb6ff;
 }
 
 .idt-onboarding-rail-label {
-  margin: 0 0 12px;
+  margin: 0;
   color: #8f8f95;
   font-size: 0.72rem;
   font-weight: 800;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.07em;
   text-transform: uppercase;
 }
 
+.idt-onboarding-rail-intro strong {
+  display: block;
+  margin-top: 2px;
+  color: #f8fafc;
+  font-size: 1.02rem;
+}
+
 .idt-onboarding-panel h1 {
-  max-width: 680px;
+  max-width: 640px;
   margin: 0;
   color: #ffffff;
-  font-size: clamp(2.45rem, 5vw, 4rem);
-  line-height: 0.98;
+  font-size: clamp(2.4rem, 5vw, 4.35rem);
+  line-height: 1;
   letter-spacing: 0;
-}
-
-html[data-theme='light'] .idt-onboarding-shell .idt-onboarding-panel h1 {
-  color: #ffffff;
-}
-
-html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
-  color: #8f6fff;
+  overflow-wrap: anywhere;
 }
 
 .idt-onboarding-panel > p {
@@ -15571,63 +15651,143 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   line-height: 1.7;
 }
 
+.idt-onboarding-panel-main > p {
+  max-width: 650px;
+  margin: 18px 0 0;
+  color: #b8c0cc;
+  font-size: 1.02rem;
+  line-height: 1.72;
+}
+
+.idt-onboarding-shell .idt-app-kicker {
+  color: #8ea7ff;
+  letter-spacing: 0.15em;
+}
+
+html[data-theme='light'] .idt-onboarding-shell,
+html[data-theme='light'] .idt-onboarding-shell .idt-onboarding-panel h1 {
+  color: #ffffff;
+}
+
+html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
+  color: #8ea7ff;
+}
+
+.idt-onboarding-guarantees {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+  max-width: 720px;
+  margin-top: 28px;
+  padding: 18px 0;
+  border-top: 1px solid #1e252d;
+  border-bottom: 1px solid #1e252d;
+}
+
+.idt-onboarding-guarantee {
+  display: flex;
+  gap: 11px;
+  min-width: 0;
+  color: #8fa0b4;
+}
+
+.idt-onboarding-guarantee svg {
+  flex: 0 0 auto;
+  margin-top: 3px;
+  color: #86efac;
+}
+
+.idt-onboarding-guarantee div {
+  display: grid;
+  gap: 4px;
+}
+
+.idt-onboarding-guarantee strong {
+  color: #f8fafc;
+  font-size: 0.9rem;
+}
+
+.idt-onboarding-guarantee span {
+  font-size: 0.84rem;
+  line-height: 1.55;
+}
+
 .idt-onboarding-stepper {
   display: grid;
-  gap: 10px;
+  gap: 7px;
 }
 
 .idt-onboarding-step {
   display: grid;
-  grid-template-columns: 44px 1fr;
+  grid-template-columns: 34px 1fr;
   align-items: center;
-  gap: 12px;
-  min-height: 48px;
-  padding: 8px;
-  border-radius: 8px;
-  color: #8f8f95;
+  gap: 10px;
+  min-height: 54px;
+  padding: 9px 8px;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  color: #8f99a8;
 }
 
-.idt-onboarding-step span {
+.idt-onboarding-step-icon {
   display: grid;
   place-items: center;
-  width: 36px;
-  height: 36px;
+  width: 32px;
+  height: 32px;
   border-radius: 999px;
-  background: #171719;
-  font-weight: 800;
-  color: #a6a6ad;
+  border: 1px solid #252b33;
+  background: #0a0d11;
+  color: #647286;
+}
+
+.idt-onboarding-step-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
 }
 
 .idt-onboarding-step strong {
   font-size: 0.92rem;
+  color: #cbd5e1;
+}
+
+.idt-onboarding-step small {
+  overflow: hidden;
+  color: #707b8b;
+  font-size: 0.76rem;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .idt-onboarding-step.is-current {
-  background: #ffffff;
-  color: #ffffff;
+  border-color: #303947;
+  background: #111822;
 }
 
-.idt-onboarding-step.is-current span {
-  background: #000000;
+.idt-onboarding-step.is-current .idt-onboarding-step-icon {
+  border-color: #8ea7ff;
+  background: #151f31;
   color: #ffffff;
 }
 
 .idt-onboarding-step.is-current strong {
-  color: #000000;
+  color: #ffffff;
 }
 
-.idt-onboarding-step.is-complete span {
-  background: rgba(112, 44, 225, 0.18);
-  color: #d8c7ff;
+.idt-onboarding-step.is-complete .idt-onboarding-step-icon {
+  border-color: rgba(134, 239, 172, 0.35);
+  background: rgba(34, 197, 94, 0.1);
+  color: #86efac;
 }
 
 .idt-onboarding-assurance {
   display: grid;
   gap: 8px;
-  margin-top: 24px;
-  padding-top: 20px;
-  border-top: 1px solid #242424;
-  color: #a6a6ad;
+  margin-top: 22px;
+  padding-top: 18px;
+  border-top: 1px solid #1f252d;
+  color: #95a1b0;
   line-height: 1.55;
 }
 
@@ -15635,11 +15795,44 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   color: #ffffff;
 }
 
+.idt-onboarding-assurance span {
+  font-size: 0.9rem;
+}
+
+.idt-onboarding-rail-note {
+  display: grid;
+  gap: 6px;
+  margin-top: 22px;
+  padding-top: 18px;
+  border-top: 1px solid #1f252d;
+}
+
+.idt-onboarding-rail-note span,
+.idt-onboarding-outcome-label {
+  color: #788395;
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.idt-onboarding-rail-note strong {
+  color: #d7dde8;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
 .idt-onboarding-form {
   display: grid;
-  gap: 12px;
+  gap: 16px;
   max-width: 560px;
   margin-top: 32px;
+}
+
+.idt-onboarding-field {
+  display: grid;
+  gap: 8px;
 }
 
 .idt-onboarding-form label {
@@ -15647,15 +15840,22 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   font-weight: 800;
 }
 
+.idt-onboarding-field p {
+  margin: 0;
+  color: #8d98a9;
+  font-size: 0.86rem;
+  line-height: 1.5;
+}
+
 .idt-onboarding-form input,
 .idt-onboarding-form textarea {
   width: 100%;
-  border: 1px solid #2c2c30;
+  border: 1px solid #2a313b;
   border-radius: 8px;
   padding: 14px 16px;
   font: inherit;
   color: #ffffff;
-  background: #050506;
+  background: #090c10;
   box-shadow: none;
 }
 
@@ -15678,6 +15878,33 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   margin-top: 24px;
 }
 
+.idt-onboarding-shell .idt-btn-primary {
+  border-color: #ffffff;
+  background: #ffffff;
+  color: #050607;
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.35);
+}
+
+.idt-onboarding-shell .idt-btn-primary:hover,
+.idt-onboarding-shell .idt-btn-primary:focus-visible {
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.42);
+}
+
+html[data-theme='light'] .idt-onboarding-shell .idt-btn-primary,
+html[data-theme='light'] .idt-onboarding-shell .idt-btn-primary:hover,
+html[data-theme='light'] .idt-onboarding-shell .idt-btn-primary:focus-visible {
+  border-color: #ffffff;
+  background: #ffffff;
+  color: #050607;
+}
+
+.idt-onboarding-shell .idt-btn-secondary,
+.idt-onboarding-shell .idt-btn-ghost {
+  border-color: #2b333e;
+  background: #0d1117;
+  color: #e5e7eb;
+}
+
 .idt-onboarding-provider-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -15694,7 +15921,7 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   border: 1px solid #26262a;
   border-radius: 8px;
   padding: 18px;
-  background: #070708;
+  background: #090c10;
   color: #f5f5f5;
   cursor: pointer;
 }
@@ -15702,7 +15929,7 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
 .idt-onboarding-provider:hover,
 .idt-onboarding-provider.is-selected {
   border-color: #ffffff;
-  background: #111113;
+  background: #111720;
   box-shadow: none;
 }
 
@@ -15734,8 +15961,8 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   margin-top: 32px;
   padding: 20px;
   border-radius: 8px;
-  border: 1px solid #26262a;
-  background: #070708;
+  border: 1px solid #2a313b;
+  background: #090c10;
 }
 
 .idt-onboarding-scan-status span {
@@ -15749,6 +15976,58 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
 .idt-onboarding-scan-status strong {
   font-size: 2rem;
   letter-spacing: 0;
+  color: #ffffff;
+}
+
+.idt-onboarding-outcome {
+  display: grid;
+  align-content: start;
+  gap: 22px;
+  min-width: 0;
+  border-left: 1px solid #202731;
+  background: #07090c;
+  padding: clamp(28px, 4vw, 40px);
+}
+
+.idt-onboarding-outcome ol {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.idt-onboarding-outcome li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 13px 0;
+  border-bottom: 1px solid #1d232b;
+  color: #d7dde8;
+  font-size: 0.9rem;
+  font-weight: 750;
+}
+
+.idt-onboarding-outcome li:first-child {
+  border-top: 1px solid #1d232b;
+}
+
+.idt-onboarding-outcome li svg {
+  flex: 0 0 auto;
+  color: #7f8ea3;
+}
+
+.idt-onboarding-outcome-note {
+  display: grid;
+  gap: 8px;
+  margin-top: 4px;
+  color: #95a1b0;
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+.idt-onboarding-outcome-note strong {
   color: #ffffff;
 }
 
@@ -15782,6 +16061,7 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
 
 @media (max-width: 900px) {
   .idt-onboarding-grid,
+  .idt-onboarding-panel,
   .idt-onboarding-provider-grid {
     grid-template-columns: 1fr;
   }
@@ -15791,13 +16071,18 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   }
 
   .idt-onboarding-stepper {
-    grid-template-columns: repeat(5, minmax(0, 1fr));
+    grid-template-columns: repeat(5, minmax(128px, 1fr));
+    overflow-x: auto;
+    padding-bottom: 2px;
   }
 
   .idt-onboarding-step {
-    grid-template-columns: 1fr;
-    justify-items: center;
-    text-align: center;
+    grid-template-columns: 32px minmax(0, 1fr);
+  }
+
+  .idt-onboarding-outcome {
+    border-top: 1px solid #202731;
+    border-left: 0;
   }
 }
 
@@ -15810,12 +16095,17 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
     margin-bottom: 18px;
   }
 
-  .idt-onboarding-panel {
+  .idt-onboarding-panel-main,
+  .idt-onboarding-outcome {
     padding: 22px;
   }
 
   .idt-onboarding-panel h1 {
-    font-size: 2.1rem;
+    font-size: 2.2rem;
+  }
+
+  .idt-onboarding-guarantees {
+    grid-template-columns: 1fr;
   }
 
   .idt-onboarding-stepper {
@@ -15826,6 +16116,10 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
     grid-template-columns: 38px 1fr;
     justify-items: start;
     text-align: left;
+  }
+
+  .idt-onboarding-step small {
+    white-space: normal;
   }
 }
 


### PR DESCRIPTION
## Summary

- Rework the onboarding shell into a WorkOS/Vercel-style setup experience with a proper Identrail brand lockup, subtle sign-out action, dark product panels, and clearer page hierarchy.
- Replace the raw numbered progress list with icon-led setup states, short step descriptions, and a launch-path rail.
- Rewrite the organization step copy so the tenant/security boundary is clear, add setup guarantees, and add a "what happens next" sequence for the first-run flow.

## Why

The onboarding page looked unfinished: the logo/header treatment was awkward, the sign-out action was oversized, the setup copy read too internal, and the main form felt like a raw dark box. This pass makes the page feel closer to mature enterprise onboarding patterns used by WorkOS, Clerk, and Vercel while keeping Identrail's security-first language.

## Scope

- [x] Focused change: onboarding UI, copy, and responsive styling
- [x] Backward compatibility considered: no API or onboarding state contract changes
- [x] Risk level assessed: low; visual/content shell changes with existing form behavior preserved

## Validation

```bash
git diff --check
npm exec -- vitest run src/pages/onboarding/onboarding.test.tsx src/components/onboarding/OnboardingAvailability.test.tsx
npm exec -- tsc -b --pretty false
npm run build --prefix web
```

Results:
- Diff whitespace check passed.
- Onboarding tests passed: 2 files, 12 tests.
- TypeScript project build passed.
- Production web build completed and prerendered 39 routes.
- Local visual QA covered the onboarding org route at desktop and narrow browser widths with a mock API.

## Screenshots

Local visual QA artifacts:
- `/tmp/identrail-onboarding-redesign.png`
- `/tmp/identrail-onboarding-redesign-500.png`

## Checklist

- [x] Tests added/updated for behavior changes: existing onboarding behavior coverage remains green
- [x] Docs updated for user/operator-facing changes: not needed, product UI copy/polish only
- [x] `CHANGELOG.md` updated when relevant: not needed, no API/operator behavior change
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

- AI-assisted: yes
- Tools used: Codex
- Where used: onboarding React components, copy, CSS, local visual QA, PR preparation
- Human verification performed: reviewed diff scope, ran targeted onboarding tests, ran TypeScript/build checks, and inspected local desktop/narrow screenshots

## Related Issues

No issue: product-design follow-up from live onboarding review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the onboarding into a guided, enterprise-ready flow with product-specific step icons, clearer copy, and a Vercel-style black UI. Behavior is unchanged; no API or onboarding state changes, and medium viewport layout issues are fixed.

- **New Features**
  - Stepper now uses product-specific `lucide-react` icons with short details; clearer states (complete/current/pending) and improved a11y.
  - Branded top bar with Identrail lockup and “Secure setup”; sticky progress rail with “Launch path” and a server-saved progress note.
  - Setup guarantees (“Read-only first”, “Scoped by design”), a “What happens next” panel, and an org name hint with `aria-describedby`.

- **Bug Fixes**
  - Fixed medium viewport layout: panel stacks correctly, outcome rail switches to a top border, and stepper supports horizontal scroll.
  - Header and actions scale better on smaller screens (compact sign-out, full-width buttons/forms).

<sup>Written for commit c6973acb9c70dc959e9a3df7f1533ad192e58857. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1395?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

