### PR TITLE
Polish WorkOS MFA challenge flow

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -2593,6 +2593,50 @@ describe('App', () => {
     );
   });
 
+  it('starts a WorkOS MFA authenticator challenge before asking for the code', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        okJSON({
+          mode: 'challenge',
+          user_email: 'owner@example.com',
+          challenge_started: false,
+          factors: [{ id: 'auth_factor_1', type: 'totp' }]
+        })
+      )
+      .mockResolvedValueOnce(okJSON({ challenge_started: true, factor_id: 'auth_factor_1' }))
+      .mockResolvedValueOnce(okJSON({ ok: true, redirect_to: '/app/tenant-a/workspace-a' }))
+      .mockResolvedValueOnce(okJSON(currentMePayload('tenant-a', 'workspace-a')));
+    vi.stubGlobal('fetch', fetchMock);
+
+    setCurrentPath('/auth/mfa?return_to=%2Fapp');
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { level: 1, name: /Verify your sign-in/i })).toBeInTheDocument();
+    expect(await screen.findByLabelText(/Authentication code/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Use authenticator app/i })).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/Authentication code/i), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: /Verify and continue/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:8080/auth/mfa/challenge',
+        expect.objectContaining({
+          body: JSON.stringify({ factor_id: 'auth_factor_1' }),
+          credentials: 'include',
+          method: 'POST'
+        })
+      );
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:8080/auth/mfa/verify',
+      expect.objectContaining({ body: JSON.stringify({ code: '123456' }), credentials: 'include', method: 'POST' })
+    );
+    expect(await screen.findByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
+    expect(window.location.pathname).toBe('/app/tenant-a/workspace-a');
+  });
+
   it('lists account security sessions and revokes other browsers', async () => {
     const fetchMock = vi
       .fn()

--- a/web/src/pages/WorkOSMFAPage.tsx
+++ b/web/src/pages/WorkOSMFAPage.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { ApiError, apiClient, type WorkOSMFAPendingResponse } from '../api/client';
 
@@ -46,6 +46,10 @@ export function mfaErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : 'Unable to continue verification.';
 }
 
+function totpFactors(pending: WorkOSMFAPendingResponse | null) {
+  return pending?.factors.filter((factor) => factor.type === 'totp') ?? [];
+}
+
 export function WorkOSMFAPage() {
   const location = useLocation();
   const navigate = useNavigate();
@@ -56,6 +60,7 @@ export function WorkOSMFAPage() {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
   const [code, setCode] = useState('');
+  const [autoChallengeFactorID, setAutoChallengeFactorID] = useState('');
 
   useEffect(() => {
     let mounted = true;
@@ -96,7 +101,7 @@ export function WorkOSMFAPage() {
     }
   };
 
-  const startChallenge = async (factorID: string) => {
+  const startChallenge = useCallback(async (factorID: string) => {
     setBusy(true);
     setError('');
     try {
@@ -107,7 +112,7 @@ export function WorkOSMFAPage() {
     } finally {
       setBusy(false);
     }
-  };
+  }, []);
 
   const submitCode = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -127,6 +132,21 @@ export function WorkOSMFAPage() {
   const needsChallengeStart = pending?.mode === 'challenge' && !pending.challenge_started;
   const enrollmentChallengeStarted = Boolean(isEnrollment && pending?.challenge_started && !pending.totp);
   const canEnterCode = Boolean(pending?.challenge_started || pending?.totp);
+  const availableTOTPFactors = totpFactors(pending);
+  const autoChallengeFactorIDCandidate =
+    !loading && needsChallengeStart && availableTOTPFactors.length === 1 ? availableTOTPFactors[0].id : '';
+  const autoChallengeStarting = Boolean(autoChallengeFactorIDCandidate && !error && !canEnterCode);
+  const showChallengePicker = Boolean(
+    !loading && pending && needsChallengeStart && (!autoChallengeFactorIDCandidate || error)
+  );
+
+  useEffect(() => {
+    if (!autoChallengeFactorIDCandidate || autoChallengeFactorID === autoChallengeFactorIDCandidate) {
+      return;
+    }
+    setAutoChallengeFactorID(autoChallengeFactorIDCandidate);
+    void startChallenge(autoChallengeFactorIDCandidate);
+  }, [autoChallengeFactorID, autoChallengeFactorIDCandidate, startChallenge]);
 
   return (
     <section className="idt-auth-page idt-auth-page-login">
@@ -145,6 +165,11 @@ export function WorkOSMFAPage() {
         {pending?.user_email ? <p className="idt-auth-mfa-subtitle">{pending.user_email}</p> : null}
         {error ? <p className="idt-app-alert idt-app-alert-error">{error}</p> : null}
         {loading ? <p className="idt-auth-mfa-subtitle">Loading verification...</p> : null}
+        {!loading && autoChallengeStarting ? (
+          <p className="idt-auth-mfa-note" role="status">
+            Preparing your authenticator challenge...
+          </p>
+        ) : null}
 
         {!loading && pending && isEnrollment && !pending.totp && !pending.challenge_started ? (
           <button className="idt-btn idt-btn-primary idt-auth-mfa-full" type="button" onClick={startEnrollment} disabled={busy}>
@@ -165,21 +190,23 @@ export function WorkOSMFAPage() {
           </div>
         ) : null}
 
-        {!loading && pending && needsChallengeStart ? (
+        {!loading && pending && !isEnrollment && canEnterCode ? (
+          <p className="idt-auth-mfa-note">Enter the code from your authenticator app to finish signing in.</p>
+        ) : null}
+
+        {showChallengePicker ? (
           <div className="idt-auth-provider-stack">
-            {pending.factors
-              .filter((factor) => factor.type === 'totp')
-              .map((factor) => (
-                <button
-                  className="idt-auth-provider idt-auth-provider-plain"
-                  key={factor.id}
-                  type="button"
-                  onClick={() => startChallenge(factor.id)}
-                  disabled={busy}
-                >
-                  Use authenticator app
-                </button>
-              ))}
+            {availableTOTPFactors.map((factor) => (
+              <button
+                className="idt-auth-provider idt-auth-provider-plain"
+                key={factor.id}
+                type="button"
+                onClick={() => startChallenge(factor.id)}
+                disabled={busy}
+              >
+                {busy ? 'Preparing challenge...' : 'Use authenticator app'}
+              </button>
+            ))}
           </div>
         ) : null}
 
@@ -188,10 +215,14 @@ export function WorkOSMFAPage() {
             <label>
               Authentication code
               <input
+                aria-label="Authentication code"
+                autoFocus
                 autoComplete="one-time-code"
                 inputMode="numeric"
-                maxLength={10}
+                maxLength={6}
                 onChange={(event) => setCode(event.target.value)}
+                pattern="[0-9]*"
+                placeholder="000000"
                 required
                 value={code}
               />

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5771,10 +5771,21 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
 }
 
 .idt-auth-mfa-subtitle {
+  max-width: 25rem;
   margin: -0.45rem 0 0.35rem;
   color: var(--auth-muted, #525252);
   font-size: 0.95rem;
   line-height: 1.4;
+  text-align: center;
+  overflow-wrap: anywhere;
+}
+
+.idt-auth-mfa-note {
+  max-width: 25rem;
+  margin: -0.15rem 0 0.15rem;
+  color: var(--auth-muted, #525252);
+  font-size: 0.92rem;
+  line-height: 1.45;
   text-align: center;
   overflow-wrap: anywhere;
 }
@@ -5813,13 +5824,43 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
 
 .idt-auth-mfa-form {
   display: grid;
-  gap: 0.85rem;
+  width: 100%;
+  gap: 0.9rem;
+  margin-top: 0;
+  border: 1px solid var(--auth-line);
+  border-radius: 12px;
+  background: var(--auth-surface);
+  padding: 1rem;
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.2);
 }
 
-.idt-auth-mfa-form input {
+.idt-auth-mfa-form label,
+html[data-theme='light'] .idt-auth-mfa-form label {
+  display: grid;
+  gap: 0.48rem;
+  color: var(--auth-muted);
+  font-size: 0.86rem;
+  font-weight: 650;
+}
+
+.idt-auth-page[data-auth-theme='light'] .idt-auth-mfa-form,
+html[data-theme='light'] .idt-auth-page[data-auth-theme='light'] .idt-auth-mfa-form {
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 22px 54px rgba(15, 23, 42, 0.08);
+}
+
+.idt-auth-mfa-form input,
+html[data-theme='light'] .idt-auth-mfa-form input {
+  min-height: 3.45rem;
+  border-radius: 8px;
   text-align: center;
-  font-size: 1.18rem;
+  font-size: 1.3rem;
+  font-variant-numeric: tabular-nums;
   letter-spacing: 0;
+}
+
+.idt-auth-mfa-form .idt-btn {
+  min-height: 3.35rem;
 }
 
 .idt-dev-mode-banner {
@@ -7392,7 +7433,8 @@ html[data-theme='light'] .idt-auth-panel {
 
 .idt-auth-mfa-panel,
 html[data-theme='light'] .idt-auth-mfa-panel {
-  width: min(100%, 25rem);
+  width: min(100%, 26.5rem);
+  gap: 0.95rem;
 }
 
 .idt-auth-panel-signup,
@@ -7703,6 +7745,30 @@ html[data-theme='light'] .idt-auth-manual-form input {
   background: var(--auth-button-muted);
   color: var(--auth-text);
   padding: 0.7rem 0.85rem;
+}
+
+.idt-auth-manual-form.idt-auth-mfa-form,
+html[data-theme='light'] .idt-auth-manual-form.idt-auth-mfa-form {
+  margin-top: 0;
+  border: 1px solid var(--auth-line);
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+.idt-auth-manual-form.idt-auth-mfa-form label,
+html[data-theme='light'] .idt-auth-manual-form.idt-auth-mfa-form label {
+  gap: 0.48rem;
+  font-size: 0.86rem;
+  font-weight: 650;
+}
+
+.idt-auth-manual-form.idt-auth-mfa-form input,
+html[data-theme='light'] .idt-auth-manual-form.idt-auth-mfa-form input {
+  min-height: 3.45rem;
+  text-align: center;
+  font-size: 1.3rem;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0;
 }
 
 .idt-auth-page .idt-auth-footer-line,


### PR DESCRIPTION
Fixes #1398

## What changed
- Auto-starts the single authenticator-app MFA challenge so the code field appears immediately during non-SSO sign-in.
- Keeps the method picker fallback for multiple factors or retry after a challenge start error.
- Tightens the MFA code panel styling and numeric input affordance without changing the larger AuthKit layout.

## Why
The previous flow added an unnecessary click in the common case where the user only has one authenticator-app factor.

## Impact and risk
Non-SSO MFA sign-in is one step shorter. MFA enrollment still stays explicit because it must show the QR setup step, and multi-factor fallback behavior remains available.

## Validation
- `git diff --check`
- `npm run test --prefix web -- App.test.tsx --run -t "starts a WorkOS MFA authenticator challenge"`
- `npm run build --prefix web`

AI-assisted: No
Tools used: N/A
Where used: N/A
Human verification performed: diff check, focused regression test, and web build
