### PR TITLE
Tighten onboarding layout

### DIFF
--- a/web/src/components/onboarding/Stepper.tsx
+++ b/web/src/components/onboarding/Stepper.tsx
@@ -2,11 +2,11 @@ import type { OnboardingStep } from '../../api/client';
 import { Building2, PanelsTopLeft, PlugZap, ScanSearch, UserPlus, type LucideIcon } from 'lucide-react';
 
 const STEP_ITEMS: Array<{ id: Exclude<OnboardingStep, 'complete'>; label: string; detail: string; icon: LucideIcon }> = [
-  { id: 'org', label: 'Organization', detail: 'Tenant root', icon: Building2 },
-  { id: 'workspace', label: 'Workspace', detail: 'Project scope', icon: PanelsTopLeft },
-  { id: 'connect', label: 'Connect source', detail: 'GitHub, AWS, K8s', icon: PlugZap },
-  { id: 'scan', label: 'First scan', detail: 'Evidence baseline', icon: ScanSearch },
-  { id: 'invite', label: 'Invite team', detail: 'Reviewer access', icon: UserPlus }
+  { id: 'org', label: 'Organization', detail: 'Boundary', icon: Building2 },
+  { id: 'workspace', label: 'Workspace', detail: 'Scope', icon: PanelsTopLeft },
+  { id: 'connect', label: 'Source', detail: 'AWS, GitHub, K8s', icon: PlugZap },
+  { id: 'scan', label: 'Scan', detail: 'Baseline', icon: ScanSearch },
+  { id: 'invite', label: 'Team', detail: 'Access', icon: UserPlus }
 ];
 
 export function OnboardingStepper({ currentStep }: { currentStep: OnboardingStep }) {

--- a/web/src/pages/onboarding/ConnectPage.tsx
+++ b/web/src/pages/onboarding/ConnectPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
-import { apiClient, type OnboardingState } from '../../api/client';
+import { apiClient } from '../../api/client';
 import { SkipForNow } from '../../components/onboarding/SkipForNow';
 import { isFeatureAvailable, useBackendFeatures } from '../../hooks/useBackendFeatures';
 import {
@@ -26,22 +26,22 @@ const PROVIDER_META: Array<{
   {
     id: 'aws',
     name: 'AWS',
-    signal: 'IAM roles, trust policies, account paths',
-    detail: 'Best first source for cloud identity blast-radius discovery.',
+    signal: 'IAM roles and trust policies',
+    detail: 'Best for cloud identity paths.',
     viteFlag: FEATURE_ONBOARDING_CONNECTOR_AWS
   },
   {
     id: 'kubernetes',
     name: 'Kubernetes',
-    signal: 'Service accounts, RBAC, workload identity',
-    detail: 'Use when cluster access and service account paths matter most.',
+    signal: 'Service accounts and RBAC',
+    detail: 'Best for workload identity.',
     viteFlag: FEATURE_ONBOARDING_CONNECTOR_K8S
   },
   {
     id: 'github',
     name: 'GitHub',
-    signal: 'Repositories, workflow identity, webhook scans',
-    detail: 'Use when code and OIDC workflow access are the first security boundary.',
+    signal: 'Repos and workflow identity',
+    detail: 'Best for code-to-cloud paths.',
     viteFlag: FEATURE_ONBOARDING_CONNECTOR_GITHUB
   }
 ];
@@ -58,8 +58,7 @@ export function ConnectPage() {
     [features]
   );
   const enabledProviders = useMemo(() => providers.filter((provider) => provider.enabled), [providers]);
-  const [state, setState] = useState<OnboardingState | null>(null);
-  const [selectedProvider, setSelectedProvider] = useState<OnboardingProvider>('aws');
+  const [selectedProvider, setSelectedProvider] = useState<OnboardingProvider | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
@@ -67,11 +66,9 @@ export function ConnectPage() {
   const enabledProviderIdsRef = useRef<OnboardingProvider[]>([]);
   enabledProviderIdsRef.current = enabledProviders.map((provider) => provider.id);
 
-  // Keep the selection on an actionable connector once API-discovered
-  // availability resolves (the bundle may ship a connector the API lacks).
   useEffect(() => {
-    if (enabledProviders.length && !enabledProviders.some((provider) => provider.id === selectedProvider)) {
-      setSelectedProvider(enabledProviders[0].id);
+    if (selectedProvider && !enabledProviders.some((provider) => provider.id === selectedProvider)) {
+      setSelectedProvider(null);
     }
   }, [enabledProviders, selectedProvider]);
 
@@ -89,7 +86,6 @@ export function ConnectPage() {
         if (!mounted) {
           return;
         }
-        setState(nextState);
         if (!nextState.org_id || !nextState.workspace_id || !nextState.project_id) {
           navigate('/onboarding/workspace', { replace: true });
           return;
@@ -123,17 +119,22 @@ export function ConnectPage() {
 
   const continueToScan = async () => {
     if (!enabledProviders.length) {
-      return skipConnector();
+      setError('No sources are available. Skip for now to continue.');
+      return;
+    }
+    const provider = selectedProvider;
+    if (!provider || !enabledProviders.some((enabledProvider) => enabledProvider.id === provider)) {
+      setError('Please choose an available source to continue.');
+      return;
     }
     setSaving(true);
     setError('');
     try {
       const response = await apiClient.updateOnboardingState({
         current_step: 'connect',
-        connector_type: selectedProvider,
+        connector_type: provider,
         connector_skipped: false
       });
-      setState(response.state);
       routeAfterOnboardingResponse(navigate, response.redirect_path, '/onboarding/scan');
     } catch (requestError) {
       setError(requestError instanceof Error ? requestError.message : 'Unable to save connector choice.');
@@ -144,6 +145,12 @@ export function ConnectPage() {
 
   const openConnectorSetup = async () => {
     if (!enabledProviders.length) {
+      setError('No sources are available. Skip for now to continue.');
+      return;
+    }
+    const provider = selectedProvider;
+    if (!provider || !enabledProviders.some((enabledProvider) => enabledProvider.id === provider)) {
+      setError('Please choose an available source to open setup.');
       return;
     }
     setSaving(true);
@@ -151,10 +158,9 @@ export function ConnectPage() {
     try {
       const response = await apiClient.updateOnboardingState({
         current_step: 'connect',
-        connector_type: selectedProvider,
+        connector_type: provider,
         connector_skipped: false
       });
-      setState(response.state);
       navigate(onboardingProjectPath(response.state));
     } catch (requestError) {
       setError(requestError instanceof Error ? requestError.message : 'Unable to open connector setup.');
@@ -171,7 +177,6 @@ export function ConnectPage() {
         current_step: 'connect',
         connector_skipped: true
       });
-      setState(response.state);
       routeAfterOnboardingResponse(navigate, response.redirect_path, '/onboarding/scan');
     } catch (requestError) {
       setError(requestError instanceof Error ? requestError.message : 'Unable to skip connector setup.');
@@ -183,15 +188,9 @@ export function ConnectPage() {
   return (
     <OnboardingFrame
       step="connect"
-      eyebrow="Connect source"
-      title="Choose the first identity source"
-      description="Start with one read-only source. You can add the rest after the first scan proves the workflow."
-      aside={
-        <div className="idt-onboarding-assurance">
-          <strong>Least privilege first</strong>
-          <span>Connector setup uses the same project-scoped AWS, Kubernetes, and GitHub flows already reviewed in the product.</span>
-        </div>
-      }
+      eyebrow="Source"
+      title="Connect one source"
+      description="Start read-only. Add more sources later."
     >
       {loading ? <p className="idt-muted-strong">Checking available connectors...</p> : null}
       {error ? (
@@ -221,17 +220,14 @@ export function ConnectPage() {
         ))}
       </div>
       <div className="idt-onboarding-actions">
-        <button type="button" className="idt-btn idt-btn-primary" disabled={saving || loading || !enabledProviders.length} onClick={continueToScan}>
+        <button type="button" className="idt-btn idt-btn-primary" disabled={saving || loading} onClick={continueToScan}>
           {saving ? 'Saving...' : 'Continue'}
         </button>
-        <button type="button" className="idt-btn idt-btn-secondary" disabled={saving || loading || !enabledProviders.length} onClick={openConnectorSetup}>
+        <button type="button" className="idt-btn idt-btn-secondary" disabled={saving || loading} onClick={openConnectorSetup}>
           Open setup
         </button>
         <SkipForNow disabled={saving || loading} onSkip={skipConnector} />
       </div>
-      {state?.project_id ? (
-        <p className="idt-muted-strong">Setup target: {state.workspace_id}/{state.project_id}</p>
-      ) : null}
     </OnboardingFrame>
   );
 }

--- a/web/src/pages/onboarding/InvitePage.tsx
+++ b/web/src/pages/onboarding/InvitePage.tsx
@@ -95,6 +95,10 @@ export function InvitePage() {
       setError('Workspace context is required before inviting teammates.');
       return;
     }
+    if (!invitees.length) {
+      setError('Please enter at least one valid email address, or finish without invites.');
+      return;
+    }
     setSaving(true);
     setError('');
     try {
@@ -127,14 +131,8 @@ export function InvitePage() {
     <OnboardingFrame
       step="invite"
       eyebrow="Team"
-      title="Invite the first reviewers"
-      description="Bring platform, security, or IAM teammates into the workspace so findings have owners from day one."
-      aside={
-        <div className="idt-onboarding-assurance">
-          <strong>Least access</strong>
-          <span>New teammates start as invited viewers; owners can adjust roles in workspace settings later.</span>
-        </div>
-      }
+      title="Invite reviewers"
+      description="Add teammates who will own findings."
     >
       {loading ? <p className="idt-muted-strong">Preparing invite controls...</p> : null}
       {error ? (
@@ -148,12 +146,10 @@ export function InvitePage() {
           id="invite-emails"
           value={emails}
           onChange={(event) => setEmails(event.target.value)}
-          placeholder="analyst@example.com, platform@example.com"
           rows={5}
         />
-        <p className="idt-muted-strong">{invitees.length ? `${invitees.length} valid invitee${invitees.length === 1 ? '' : 's'} ready` : 'You can skip this and invite teammates later.'}</p>
         <div className="idt-onboarding-actions">
-          <button type="submit" className="idt-btn idt-btn-primary" disabled={saving || loading || invitees.length === 0}>
+          <button type="submit" className="idt-btn idt-btn-primary" disabled={saving || loading}>
             {saving ? 'Finishing...' : 'Invite and finish'}
           </button>
           <SkipForNow disabled={saving || loading} onSkip={complete} label="Finish without invites" />

--- a/web/src/pages/onboarding/OrgPage.tsx
+++ b/web/src/pages/onboarding/OrgPage.tsx
@@ -20,10 +20,7 @@ export function OrgPage() {
       setLoading(true);
       setError('');
       try {
-        const [started, current] = await Promise.all([
-          apiClient.startOnboarding(),
-          apiClient.getMe({ redirectOnUnauthorized: false })
-        ]);
+        const started = await apiClient.startOnboarding();
         if (!mounted) {
           return;
         }
@@ -31,8 +28,6 @@ export function OrgPage() {
           return;
         }
         setState(started.state);
-        const displayName = current.me.user.display_name || current.me.user.primary_email?.split('@')[0] || '';
-        setOrgName(displayName ? `${displayName} Security` : 'Production Security');
       } catch (requestError) {
         if (!mounted) {
           return;
@@ -58,7 +53,7 @@ export function OrgPage() {
     event.preventDefault();
     const name = orgName.trim();
     if (!name) {
-      setError('Organization name is required.');
+      setError('Please enter an organization name to continue.');
       return;
     }
     setSaving(true);
@@ -81,14 +76,8 @@ export function OrgPage() {
     <OnboardingFrame
       step="org"
       eyebrow="Secure onboarding"
-      title="Create your organization"
-      description="This is the security boundary for your workspaces, repositories, scans, findings, and team access."
-      aside={
-        <div className="idt-onboarding-assurance">
-          <strong>Enterprise-ready setup</strong>
-          <span>Progress is saved in Identrail, so refreshes and second devices continue from the same place.</span>
-        </div>
-      }
+      title="Set up your organization"
+      description="Create one boundary for workspaces, sources, scans, findings, and access."
     >
       {loading ? <p className="idt-muted-strong">Preparing your account...</p> : null}
       {error ? (
@@ -99,18 +88,17 @@ export function OrgPage() {
       <form className="idt-onboarding-form" onSubmit={submit}>
         <div className="idt-onboarding-field">
           <label htmlFor="org-name">Organization name</label>
-          <p id="org-name-hint">Use the company or security program name your team will recognize.</p>
+          <p id="org-name-hint">Use a recognizable company or program name.</p>
           <input
             id="org-name"
             value={orgName}
             onChange={(event) => setOrgName(event.target.value)}
-            placeholder="Acme Security"
             autoComplete="organization"
             aria-describedby="org-name-hint"
           />
         </div>
         <div className="idt-onboarding-actions">
-          <button type="submit" className="idt-btn idt-btn-primary" disabled={saving || loading || !orgName.trim()}>
+          <button type="submit" className="idt-btn idt-btn-primary" disabled={saving || loading}>
             {saving ? 'Saving...' : state?.org_id ? 'Continue' : 'Create organization'}
           </button>
         </div>

--- a/web/src/pages/onboarding/ScanPage.tsx
+++ b/web/src/pages/onboarding/ScanPage.tsx
@@ -130,14 +130,8 @@ export function ScanPage() {
     <OnboardingFrame
       step="scan"
       eyebrow="First scan"
-      title="Run the first identity scan"
-      description="The first scan proves that the workspace, connector boundary, queue, and findings path are connected end to end."
-      aside={
-        <div className="idt-onboarding-assurance">
-          <strong>Queue backed</strong>
-          <span>Scan creation uses the same authenticated scan endpoint as the dashboard and API clients.</span>
-        </div>
-      }
+      title="Run a baseline scan"
+      description="Confirm the source, queue, and findings path."
     >
       {loading ? <p className="idt-muted-strong">Loading scan readiness...</p> : null}
       {error ? (

--- a/web/src/pages/onboarding/WorkspacePage.tsx
+++ b/web/src/pages/onboarding/WorkspacePage.tsx
@@ -12,8 +12,8 @@ import {
 export function WorkspacePage() {
   const navigate = useNavigate();
   const [state, setState] = useState<OnboardingState | null>(null);
-  const [workspaceName, setWorkspaceName] = useState('Production');
-  const [projectName, setProjectName] = useState('Production');
+  const [workspaceName, setWorkspaceName] = useState('');
+  const [projectName, setProjectName] = useState('');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
@@ -64,7 +64,11 @@ export function WorkspacePage() {
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!workspaceName.trim()) {
-      setError('Workspace name is required.');
+      setError('Please enter a workspace name to continue.');
+      return;
+    }
+    if (!projectName.trim()) {
+      setError('Please enter a project name to continue.');
       return;
     }
     setSaving(true);
@@ -73,7 +77,7 @@ export function WorkspacePage() {
       const response = await apiClient.updateOnboardingState({
         current_step: 'workspace',
         workspace_name: workspaceName.trim(),
-        project_name: projectName.trim() || workspaceName.trim()
+        project_name: projectName.trim()
       });
       setState(response.state);
       routeAfterOnboardingResponse(navigate, response.redirect_path, '/onboarding/connect');
@@ -88,14 +92,8 @@ export function WorkspacePage() {
     <OnboardingFrame
       step="workspace"
       eyebrow="Workspace"
-      title="Name the environment you will secure first"
-      description="A workspace keeps scans, connectors, projects, members, and findings inside one operating boundary."
-      aside={
-        <div className="idt-onboarding-assurance">
-          <strong>Default project included</strong>
-          <span>Identrail creates the first project automatically so connector setup has a safe scope immediately.</span>
-        </div>
-      }
+      title="Name your first workspace"
+      description="Keep scans, sources, projects, and members in one scope."
     >
       {loading ? <p className="idt-muted-strong">Loading workspace setup...</p> : null}
       {error ? (
@@ -109,7 +107,6 @@ export function WorkspacePage() {
           id="workspace-name"
           value={workspaceName}
           onChange={(event) => setWorkspaceName(event.target.value)}
-          placeholder="Production"
           autoComplete="off"
         />
         <label htmlFor="project-name">First project</label>
@@ -117,11 +114,10 @@ export function WorkspacePage() {
           id="project-name"
           value={projectName}
           onChange={(event) => setProjectName(event.target.value)}
-          placeholder="Production"
           autoComplete="off"
         />
         <div className="idt-onboarding-actions">
-          <button type="submit" className="idt-btn idt-btn-primary" disabled={saving || loading || !workspaceName.trim()}>
+          <button type="submit" className="idt-btn idt-btn-primary" disabled={saving || loading}>
             {saving ? 'Creating...' : state?.workspace_id ? 'Continue' : 'Create workspace'}
           </button>
         </div>

--- a/web/src/pages/onboarding/onboarding.test.tsx
+++ b/web/src/pages/onboarding/onboarding.test.tsx
@@ -104,18 +104,6 @@ describe('onboarding pages', () => {
     const { apiClient, OrgPage } = await loadOnboardingModules();
     const startState = state({ current_step: 'org' });
     vi.spyOn(apiClient, 'startOnboarding').mockResolvedValue({ state: startState, redirect_path: '/onboarding/org' });
-    vi.spyOn(apiClient, 'getMe').mockResolvedValue({
-      me: {
-        user: {
-          id: 'user-1',
-          primary_email: 'owner@example.com',
-          display_name: 'Owner User',
-          status: 'active',
-          created_at: '2026-05-14T10:00:00Z',
-          updated_at: '2026-05-14T10:00:00Z'
-        }
-      }
-    });
     const update = vi.spyOn(apiClient, 'updateOnboardingState').mockResolvedValue({
       state: state({ current_step: 'workspace', org_id: 'owner-user-security' }),
       redirect_path: '/onboarding/workspace'
@@ -124,6 +112,11 @@ describe('onboarding pages', () => {
     renderOnboarding(<OrgPage />, '/onboarding/org');
 
     const input = await screen.findByLabelText('Organization name');
+    expect(input).toHaveValue('');
+    fireEvent.click(screen.getByRole('button', { name: 'Create organization' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Please enter an organization name to continue.');
+    expect(update).not.toHaveBeenCalled();
+
     fireEvent.change(input, { target: { value: 'Aurelius Security' } });
     fireEvent.click(screen.getByRole('button', { name: 'Create organization' }));
 
@@ -145,9 +138,17 @@ describe('onboarding pages', () => {
 
     renderOnboarding(<WorkspacePage />, '/onboarding/workspace');
 
-    expect(await screen.findByRole('heading', { name: 'Name the environment you will secure first' })).toBeInTheDocument();
-    fireEvent.change(screen.getByLabelText('Workspace name'), { target: { value: 'Production' } });
-    fireEvent.change(screen.getByLabelText('First project'), { target: { value: 'Identity Control Plane' } });
+    expect(await screen.findByRole('heading', { name: 'Name your first workspace' })).toBeInTheDocument();
+    const workspaceInput = screen.getByLabelText('Workspace name');
+    const projectInput = screen.getByLabelText('First project');
+    expect(workspaceInput).toHaveValue('');
+    expect(projectInput).toHaveValue('');
+    fireEvent.click(screen.getByRole('button', { name: 'Create workspace' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Please enter a workspace name to continue.');
+    expect(update).not.toHaveBeenCalled();
+
+    fireEvent.change(workspaceInput, { target: { value: 'Production' } });
+    fireEvent.change(projectInput, { target: { value: 'Identity Control Plane' } });
     fireEvent.click(screen.getByRole('button', { name: 'Create workspace' }));
 
     await waitFor(() => {
@@ -183,7 +184,11 @@ describe('onboarding pages', () => {
 
     renderOnboarding(<ConnectPage />, '/onboarding/connect');
 
-    fireEvent.click(await screen.findByRole('button', { name: /GitHubRepositories/i }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Continue' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Please choose an available source to continue.');
+    expect(update).not.toHaveBeenCalled();
+
+    fireEvent.click(await screen.findByRole('button', { name: /GitHubRepos/i }));
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
 
     await waitFor(() => {
@@ -227,6 +232,57 @@ describe('onboarding pages', () => {
 
     const awsButton = screen.getByRole('button', { name: /AWS/i });
     expect(awsButton).toBeEnabled();
+  });
+
+  it('clears a selected connector when backend availability removes it', async () => {
+    const { apiClient, ConnectPage } = await loadOnboardingModules();
+    const { resetBackendFeaturesCacheForTests } = await import('../../hooks/useBackendFeatures');
+    resetBackendFeaturesCacheForTests();
+
+    let resolveConfig: (value: Awaited<ReturnType<typeof apiClient.getAuthConfig>>) => void = () => {};
+    const configPromise = new Promise<Awaited<ReturnType<typeof apiClient.getAuthConfig>>>((resolve) => {
+      resolveConfig = resolve;
+    });
+    vi.spyOn(apiClient, 'getAuthConfig').mockReturnValue(configPromise);
+    vi.spyOn(apiClient, 'getOnboardingState').mockResolvedValue({
+      state: state({
+        current_step: 'connect',
+        org_id: 'tenant-a',
+        workspace_id: 'production',
+        project_id: 'production'
+      }),
+      redirect_path: '/onboarding/connect'
+    });
+    const update = vi.spyOn(apiClient, 'updateOnboardingState').mockResolvedValue({
+      state: state({
+        current_step: 'scan',
+        org_id: 'tenant-a',
+        workspace_id: 'production',
+        project_id: 'production'
+      }),
+      redirect_path: '/onboarding/scan'
+    });
+
+    renderOnboarding(<ConnectPage />, '/onboarding/connect');
+
+    const githubButton = await screen.findByRole('button', { name: /GitHubRepos/i });
+    fireEvent.click(githubButton);
+
+    resolveConfig({
+      auth: { manual_mode: false, workos_login_enabled: true, native_saml_enabled: false, providers: [] },
+      features: {
+        onboarding_wizard: true,
+        connectors: { github: false, aws: true, kubernetes: false }
+      }
+    });
+
+    await waitFor(() => {
+      expect(githubButton).toBeDisabled();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Please choose an available source to continue.');
+    expect(update).not.toHaveBeenCalled();
   });
 
   it('continues after a successful first scan', async () => {
@@ -299,6 +355,11 @@ describe('onboarding pages', () => {
     });
 
     renderOnboarding(<InvitePage />, '/onboarding/invite');
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Invite and finish' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Please enter at least one valid email address');
+    expect(invite).not.toHaveBeenCalled();
+    expect(complete).not.toHaveBeenCalled();
 
     fireEvent.change(await screen.findByLabelText('Email addresses'), { target: { value: 'analyst@example.com' } });
     fireEvent.click(screen.getByRole('button', { name: 'Invite and finish' }));

--- a/web/src/pages/onboarding/onboardingUtils.tsx
+++ b/web/src/pages/onboarding/onboardingUtils.tsx
@@ -127,31 +127,29 @@ const SETUP_GUARANTEES = [
   {
     icon: Eye,
     title: 'Read-only first',
-    detail: 'Connectors begin with discovery paths before any enforcement workflow.'
+    detail: 'Discovery before enforcement.'
   },
   {
     icon: Network,
     title: 'Scoped by design',
-    detail: 'Workspaces, projects, scans, and findings stay inside one tenant boundary.'
+    detail: 'One boundary for every asset.'
   }
 ];
 
-const NEXT_STEPS = ['Create the security boundary', 'Name the first workspace', 'Connect a source', 'Run the first scan'];
+const NEXT_STEPS = ['Create boundary', 'Name workspace', 'Connect source', 'Run scan'];
 
 export function OnboardingFrame({
   step,
   eyebrow,
   title,
   description,
-  children,
-  aside
+  children
 }: {
   step: OnboardingStep;
   eyebrow: string;
   title: string;
   description: string;
   children: ReactNode;
-  aside?: ReactNode;
 }) {
   return (
     <section className="idt-onboarding-shell">
@@ -179,11 +177,6 @@ export function OnboardingFrame({
             </div>
           </div>
           <OnboardingStepper currentStep={step} />
-          {aside}
-          <div className="idt-onboarding-rail-note">
-            <span>Setup model</span>
-            <strong>Server-saved progress with read-only security checks first.</strong>
-          </div>
         </aside>
         <article className="idt-onboarding-panel">
           <div className="idt-onboarding-panel-main">
@@ -216,10 +209,6 @@ export function OnboardingFrame({
                 </li>
               ))}
             </ol>
-            <div className="idt-onboarding-outcome-note">
-              <strong>Designed for security teams</strong>
-              <span>Short setup, explicit scope, and a findings dashboard ready after the first scan.</span>
-            </div>
           </aside>
         </article>
       </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15707,7 +15707,7 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
   max-width: 100vw;
   background: #000000;
   color: #f5f7fb;
-  padding: 24px clamp(16px, 4vw, 56px) 56px;
+  padding: 22px clamp(16px, 3vw, 40px) 48px;
   font-family: 'Geist', 'Inter', sans-serif;
 }
 
@@ -15718,8 +15718,8 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
   gap: 16px;
   min-width: 0;
   width: 100%;
-  max-width: 1320px;
-  margin: 0 auto 30px;
+  max-width: 1180px;
+  margin: 0 auto 22px;
 }
 
 .idt-onboarding-brand,
@@ -15793,12 +15793,12 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
 
 .idt-onboarding-grid {
   display: grid;
-  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
-  gap: 24px;
+  grid-template-columns: minmax(248px, 280px) minmax(0, 880px);
+  gap: 18px;
   width: 100%;
-  max-width: min(1320px, 100%);
+  max-width: min(1180px, 100%);
   margin: 0 auto;
-  align-items: start;
+  align-items: stretch;
 }
 
 .idt-onboarding-rail,
@@ -15807,11 +15807,14 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
   border: 1px solid #1f1f1f;
   background: #000000;
   border-radius: 8px;
-  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.42);
+  box-shadow: 0 22px 62px rgba(0, 0, 0, 0.36);
 }
 
 .idt-onboarding-rail {
-  padding: 22px;
+  display: grid;
+  align-content: start;
+  align-self: stretch;
+  padding: 24px 20px;
   position: sticky;
   top: 24px;
   width: 100%;
@@ -15820,8 +15823,8 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
 
 .idt-onboarding-panel {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
-  min-height: 35rem;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 270px);
+  min-height: 30rem;
   width: 100%;
   max-width: 100%;
   overflow: hidden;
@@ -15829,12 +15832,12 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
 
 .idt-onboarding-panel-main {
   min-width: 0;
-  padding: clamp(34px, 5vw, 64px);
+  padding: clamp(28px, 3.4vw, 40px);
   background: #000000;
 }
 
 .idt-onboarding-rail-intro {
-  margin-bottom: 22px;
+  margin-bottom: 18px;
 }
 
 .idt-onboarding-rail-label {
@@ -15855,13 +15858,15 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
 
 .idt-onboarding-panel h1 {
   width: 100%;
-  max-width: 640px;
+  max-width: 540px;
   margin: 0;
   color: #ffffff;
-  font-size: clamp(2.4rem, 5vw, 4.35rem);
-  line-height: 1;
+  font-size: clamp(2.05rem, 3.2vw, 2.85rem);
+  line-height: 1.05;
   letter-spacing: 0;
-  overflow-wrap: anywhere;
+  overflow-wrap: normal;
+  text-wrap: balance;
+  word-break: normal;
 }
 
 .idt-onboarding-panel > p {
@@ -15873,11 +15878,11 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
 }
 
 .idt-onboarding-panel-main > p {
-  max-width: 650px;
-  margin: 18px 0 0;
+  max-width: 520px;
+  margin: 12px 0 0;
   color: #b4b4b4;
-  font-size: 1.02rem;
-  line-height: 1.72;
+  font-size: 0.95rem;
+  line-height: 1.55;
 }
 
 .idt-onboarding-shell .idt-app-kicker {
@@ -15897,17 +15902,17 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
 .idt-onboarding-guarantees {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 18px;
-  max-width: 720px;
-  margin-top: 28px;
-  padding: 18px 0;
+  gap: 12px;
+  max-width: 520px;
+  margin-top: 20px;
+  padding: 14px 0;
   border-top: 1px solid #1f1f1f;
   border-bottom: 1px solid #1f1f1f;
 }
 
 .idt-onboarding-guarantee {
   display: flex;
-  gap: 11px;
+  gap: 10px;
   min-width: 0;
   color: #a1a1aa;
 }
@@ -15925,17 +15930,17 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
 
 .idt-onboarding-guarantee strong {
   color: #ffffff;
-  font-size: 0.9rem;
+  font-size: 0.88rem;
 }
 
 .idt-onboarding-guarantee span {
-  font-size: 0.84rem;
-  line-height: 1.55;
+  font-size: 0.8rem;
+  line-height: 1.45;
 }
 
 .idt-onboarding-stepper {
   display: grid;
-  gap: 7px;
+  gap: 6px;
 }
 
 .idt-onboarding-step {
@@ -15943,8 +15948,8 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   grid-template-columns: 34px 1fr;
   align-items: center;
   gap: 10px;
-  min-height: 54px;
-  padding: 9px 8px;
+  min-height: 48px;
+  padding: 8px;
   border: 1px solid transparent;
   border-radius: 7px;
   color: #8a8a8a;
@@ -15968,7 +15973,7 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
 }
 
 .idt-onboarding-step strong {
-  font-size: 0.92rem;
+  font-size: 0.9rem;
   color: #d4d4d4;
 }
 
@@ -16002,34 +16007,8 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   color: #d4d4d4;
 }
 
-.idt-onboarding-assurance {
-  display: grid;
-  gap: 8px;
-  margin-top: 22px;
-  padding-top: 18px;
-  border-top: 1px solid #1f1f1f;
-  color: #a1a1aa;
-  line-height: 1.55;
-}
-
-.idt-onboarding-assurance strong {
-  color: #ffffff;
-}
-
-.idt-onboarding-assurance span {
-  font-size: 0.9rem;
-}
-
-.idt-onboarding-rail-note {
-  display: grid;
-  gap: 6px;
-  margin-top: 22px;
-  padding-top: 18px;
-  border-top: 1px solid #1f1f1f;
-}
-
-.idt-onboarding-rail-note span,
 .idt-onboarding-outcome-label {
+  margin: 0;
   color: #737373;
   font-size: 0.72rem;
   font-weight: 900;
@@ -16037,24 +16016,17 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   text-transform: uppercase;
 }
 
-.idt-onboarding-rail-note strong {
-  color: #e5e5e5;
-  font-size: 0.9rem;
-  line-height: 1.5;
-  overflow-wrap: anywhere;
-}
-
 .idt-onboarding-form {
   display: grid;
-  gap: 16px;
+  gap: 14px;
   width: 100%;
-  max-width: 560px;
-  margin-top: 32px;
+  max-width: 480px;
+  margin-top: 22px;
 }
 
 .idt-onboarding-field {
   display: grid;
-  gap: 8px;
+  gap: 6px;
 }
 
 .idt-onboarding-form label {
@@ -16074,7 +16046,7 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   width: 100%;
   border: 1px solid #2a2a2a;
   border-radius: 8px;
-  padding: 14px 16px;
+  padding: 13px 15px;
   font: inherit;
   color: #ffffff;
   background: #050505;
@@ -16097,7 +16069,7 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   flex-wrap: wrap;
   align-items: center;
   gap: 12px;
-  margin-top: 24px;
+  margin-top: 12px;
 }
 
 .idt-onboarding-shell .idt-btn-primary {
@@ -16130,12 +16102,12 @@ html[data-theme='light'] .idt-onboarding-shell .idt-btn-primary:focus-visible {
 .idt-onboarding-provider-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 14px;
-  margin-top: 32px;
+  gap: 12px;
+  margin-top: 24px;
 }
 
 .idt-onboarding-provider {
-  min-height: 180px;
+  min-height: 160px;
   display: grid;
   gap: 10px;
   align-content: start;
@@ -16179,8 +16151,8 @@ html[data-theme='light'] .idt-onboarding-shell .idt-btn-primary:focus-visible {
 .idt-onboarding-scan-status {
   display: grid;
   gap: 8px;
-  max-width: 560px;
-  margin-top: 32px;
+  max-width: 520px;
+  margin-top: 24px;
   padding: 20px;
   border-radius: 8px;
   border: 1px solid #2a2a2a;
@@ -16204,11 +16176,11 @@ html[data-theme='light'] .idt-onboarding-shell .idt-btn-primary:focus-visible {
 .idt-onboarding-outcome {
   display: grid;
   align-content: start;
-  gap: 22px;
+  gap: 16px;
   min-width: 0;
   border-left: 1px solid #1f1f1f;
   background: #050505;
-  padding: clamp(28px, 4vw, 40px);
+  padding: 24px 26px;
 }
 
 .idt-onboarding-outcome ol {
@@ -16224,10 +16196,10 @@ html[data-theme='light'] .idt-onboarding-shell .idt-btn-primary:focus-visible {
   align-items: center;
   justify-content: space-between;
   gap: 14px;
-  padding: 13px 0;
+  padding: 10px 0;
   border-bottom: 1px solid #1f1f1f;
   color: #e5e5e5;
-  font-size: 0.9rem;
+  font-size: 0.86rem;
   font-weight: 750;
 }
 
@@ -16238,19 +16210,6 @@ html[data-theme='light'] .idt-onboarding-shell .idt-btn-primary:focus-visible {
 .idt-onboarding-outcome li svg {
   flex: 0 0 auto;
   color: #8a8a8a;
-}
-
-.idt-onboarding-outcome-note {
-  display: grid;
-  gap: 8px;
-  margin-top: 4px;
-  color: #a1a1aa;
-  font-size: 0.88rem;
-  line-height: 1.55;
-}
-
-.idt-onboarding-outcome-note strong {
-  color: #ffffff;
 }
 
 .idt-onboarding-tour {


### PR DESCRIPTION
No issue: follow-up to the merged onboarding redesign based on product review feedback.

## Summary
- Removed the remaining left-rail setup note and the right-rail marketing note so the onboarding frame stays cleaner and more minimal.
- Kept the setup rail and main/right container aligned on the same top and bottom line.
- Removed automatic form suggestions: organization, workspace, project, and invite fields now start blank with no sample placeholders.
- Changed required-input handling so primary actions remain clickable after loading and show a simple inline prompt only after a user tries to continue with missing input.
- Removed the default AWS source selection; users now explicitly choose a source before continuing.
- Validated selected connector choices against live backend availability so stale unavailable selections are cleared and cannot be saved.

## Impact
- Frontend-only onboarding layout, copy, and validation polish.
- No onboarding API, persistence, or route behavior changes.

## Validation
- `git diff --check`
- `npm run test:ci --prefix web` (207 tests passed, including the connector-availability regression)
- `npm run build --prefix web`
- Browser geometry check at `/onboarding/org` with the mock API: setup rail and main panel both measured with `railPanelBottomDelta=0`; organization input value was empty, placeholder was absent, and removed note copy was absent.

## AI Disclosure
- AI-assisted: yes
- Tools used: Codex
- Where used: onboarding CSS, shared onboarding frame, stepper labels, onboarding page copy, and validation behavior
- Human verification performed: diff review, full web tests/build, and browser geometry/screenshot verification
