### PR TITLE
Backup/pr1402 before dco fix 20260527144824

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 ## Unreleased
+- Tightened the WorkOS MFA verification screen: the authenticator code entry now
+  appears immediately without the intermediate "Preparing your authenticator
+  challenge..." flash (the challenge starts silently in the background, with the
+  verify button held disabled for the brief window until it is ready), and the
+  layout was simplified to a single centered code input — removing the
+  redundant "Enter the code..." helper line, the visible "Authentication code"
+  label, and the nested bordered form container that previously sat on top of
+  the auth panel.
 - Stopped GitHub App webhooks from queueing repository scans unless the project
   has an enabled `event` or `hybrid` scan policy. Manual projects still record
   webhook deliveries without starting scans, low-value pull-request metadata

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -2637,6 +2637,64 @@ describe('App', () => {
     expect(window.location.pathname).toBe('/app/tenant-a/workspace-a');
   });
 
+  it('defers WorkOS MFA verify until the silent challenge completes when the form is programmatically submitted', async () => {
+    let resolveChallenge: ((value: Response) => void) | null = null;
+    const challengeResponse = okJSON({ challenge_started: true, factor_id: 'auth_factor_1' });
+    const pendingChallenge = new Promise<Response>((resolve) => {
+      resolveChallenge = resolve;
+    });
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        okJSON({
+          mode: 'challenge',
+          user_email: 'owner@example.com',
+          challenge_started: false,
+          factors: [{ id: 'auth_factor_1', type: 'totp' }]
+        })
+      )
+      .mockReturnValueOnce(pendingChallenge)
+      .mockResolvedValueOnce(okJSON({ ok: true, redirect_to: '/app/tenant-a/workspace-a' }))
+      .mockResolvedValueOnce(okJSON(currentMePayload('tenant-a', 'workspace-a')));
+    vi.stubGlobal('fetch', fetchMock);
+
+    setCurrentPath('/auth/mfa?return_to=%2Fapp');
+    render(<App />);
+
+    const input = await screen.findByLabelText(/Authentication code/i);
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:8080/auth/mfa/challenge',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    fireEvent.change(input, { target: { value: '123456' } });
+    // Simulate an OTP autofill helper or programmatic submit (Enter / form.requestSubmit)
+    // that bypasses the disabled submit button while the challenge is in flight.
+    const form = input.closest('form');
+    expect(form).not.toBeNull();
+    fireEvent.submit(form as HTMLFormElement);
+
+    // Verify must not fire yet — the silent challenge is still pending.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      'http://localhost:8080/auth/mfa/verify',
+      expect.anything()
+    );
+
+    // Resolve the challenge; verify should then proceed and the app should land.
+    resolveChallenge?.(challengeResponse);
+
+    expect(await screen.findByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:8080/auth/mfa/verify',
+      expect.objectContaining({ body: JSON.stringify({ code: '123456' }), credentials: 'include', method: 'POST' })
+    );
+    expect(window.location.pathname).toBe('/app/tenant-a/workspace-a');
+  });
+
   it('lists account security sessions and revokes other browsers', async () => {
     const fetchMock = vi
       .fn()

--- a/web/src/pages/WorkOSMFAPage.tsx
+++ b/web/src/pages/WorkOSMFAPage.tsx
@@ -101,8 +101,11 @@ export function WorkOSMFAPage() {
     }
   };
 
-  const startChallenge = useCallback(async (factorID: string) => {
-    setBusy(true);
+  const startChallenge = useCallback(async (factorID: string, options?: { silent?: boolean }) => {
+    const silent = options?.silent === true;
+    if (!silent) {
+      setBusy(true);
+    }
     setError('');
     try {
       await apiClient.challengeWorkOSMFA(factorID);
@@ -110,7 +113,9 @@ export function WorkOSMFAPage() {
     } catch (challengeError) {
       setError(mfaErrorMessage(challengeError));
     } finally {
-      setBusy(false);
+      if (!silent) {
+        setBusy(false);
+      }
     }
   }, []);
 
@@ -145,7 +150,7 @@ export function WorkOSMFAPage() {
       return;
     }
     setAutoChallengeFactorID(autoChallengeFactorIDCandidate);
-    void startChallenge(autoChallengeFactorIDCandidate);
+    void startChallenge(autoChallengeFactorIDCandidate, { silent: true });
   }, [autoChallengeFactorID, autoChallengeFactorIDCandidate, startChallenge]);
 
   return (
@@ -165,11 +170,6 @@ export function WorkOSMFAPage() {
         {pending?.user_email ? <p className="idt-auth-mfa-subtitle">{pending.user_email}</p> : null}
         {error ? <p className="idt-app-alert idt-app-alert-error">{error}</p> : null}
         {loading ? <p className="idt-auth-mfa-subtitle">Loading verification...</p> : null}
-        {!loading && autoChallengeStarting ? (
-          <p className="idt-auth-mfa-note" role="status">
-            Preparing your authenticator challenge...
-          </p>
-        ) : null}
 
         {!loading && pending && isEnrollment && !pending.totp && !pending.challenge_started ? (
           <button className="idt-btn idt-btn-primary idt-auth-mfa-full" type="button" onClick={startEnrollment} disabled={busy}>
@@ -190,10 +190,6 @@ export function WorkOSMFAPage() {
           </div>
         ) : null}
 
-        {!loading && pending && !isEnrollment && canEnterCode ? (
-          <p className="idt-auth-mfa-note">Enter the code from your authenticator app to finish signing in.</p>
-        ) : null}
-
         {showChallengePicker ? (
           <div className="idt-auth-provider-stack">
             {availableTOTPFactors.map((factor) => (
@@ -210,24 +206,21 @@ export function WorkOSMFAPage() {
           </div>
         ) : null}
 
-        {!loading && pending && canEnterCode ? (
+        {!loading && pending && (canEnterCode || autoChallengeStarting) ? (
           <form className="idt-auth-manual-form idt-auth-mfa-form" onSubmit={submitCode}>
-            <label>
-              Authentication code
-              <input
-                aria-label="Authentication code"
-                autoFocus
-                autoComplete="one-time-code"
-                inputMode="numeric"
-                maxLength={6}
-                onChange={(event) => setCode(event.target.value)}
-                pattern="[0-9]*"
-                placeholder="000000"
-                required
-                value={code}
-              />
-            </label>
-            <button className="idt-btn idt-btn-primary" type="submit" disabled={busy}>
+            <input
+              aria-label="Authentication code"
+              autoFocus
+              autoComplete="one-time-code"
+              inputMode="numeric"
+              maxLength={6}
+              onChange={(event) => setCode(event.target.value)}
+              pattern="[0-9]*"
+              placeholder="000000"
+              required
+              value={code}
+            />
+            <button className="idt-btn idt-btn-primary" type="submit" disabled={busy || !canEnterCode}>
               {busy ? 'Verifying...' : 'Verify and continue'}
             </button>
           </form>

--- a/web/src/pages/WorkOSMFAPage.tsx
+++ b/web/src/pages/WorkOSMFAPage.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { ApiError, apiClient, type WorkOSMFAPendingResponse } from '../api/client';
 
@@ -61,6 +61,7 @@ export function WorkOSMFAPage() {
   const [error, setError] = useState('');
   const [code, setCode] = useState('');
   const [autoChallengeFactorID, setAutoChallengeFactorID] = useState('');
+  const challengeRequestRef = useRef<Promise<boolean> | null>(null);
 
   useEffect(() => {
     let mounted = true;
@@ -107,13 +108,25 @@ export function WorkOSMFAPage() {
       setBusy(true);
     }
     setError('');
+    const task: Promise<boolean> = (async () => {
+      try {
+        await apiClient.challengeWorkOSMFA(factorID);
+        setPending((current) => (current ? { ...current, challenge_started: true } : current));
+        return true;
+      } catch (challengeError) {
+        setError(mfaErrorMessage(challengeError));
+        return false;
+      }
+    })();
+    if (silent) {
+      challengeRequestRef.current = task;
+    }
     try {
-      await apiClient.challengeWorkOSMFA(factorID);
-      setPending((current) => (current ? { ...current, challenge_started: true } : current));
-    } catch (challengeError) {
-      setError(mfaErrorMessage(challengeError));
+      await task;
     } finally {
-      if (!silent) {
+      if (silent) {
+        challengeRequestRef.current = null;
+      } else {
         setBusy(false);
       }
     }
@@ -121,9 +134,24 @@ export function WorkOSMFAPage() {
 
   const submitCode = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    if (busy) {
+      return;
+    }
     setBusy(true);
     setError('');
     try {
+      // If the auto-challenge POST is still in flight (rare: an OTP autofill
+      // helper, assistive tech, or Enter in the single-input form may submit
+      // before challenge_started flips), wait for it before verifying so the
+      // backend does not reject with "mfa challenge has not started".
+      const inFlightChallenge = challengeRequestRef.current;
+      if (inFlightChallenge) {
+        const challengeOk = await inFlightChallenge;
+        if (!challengeOk) {
+          // startChallenge already surfaced the error to state; abort verify.
+          return;
+        }
+      }
       const response = await apiClient.verifyWorkOSMFA(code);
       redirectToCompletedSession(response.redirect_to || returnTo, navigate);
     } catch (verifyError) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6086,20 +6086,10 @@ html[data-theme] .idt-executive-report-shell .idt-exec-report__footer p {
 
 .idt-auth-mfa-subtitle {
   max-width: 25rem;
-  margin: -0.45rem 0 0.35rem;
+  margin: -0.35rem 0 0.15rem;
   color: var(--auth-muted, #525252);
   font-size: 0.95rem;
   line-height: 1.4;
-  text-align: center;
-  overflow-wrap: anywhere;
-}
-
-.idt-auth-mfa-note {
-  max-width: 25rem;
-  margin: -0.15rem 0 0.15rem;
-  color: var(--auth-muted, #525252);
-  font-size: 0.92rem;
-  line-height: 1.45;
   text-align: center;
   overflow-wrap: anywhere;
 }
@@ -6139,28 +6129,13 @@ html[data-theme] .idt-executive-report-shell .idt-exec-report__footer p {
 .idt-auth-mfa-form {
   display: grid;
   width: 100%;
-  gap: 0.9rem;
+  gap: 0.7rem;
   margin-top: 0;
-  border: 1px solid var(--auth-line);
-  border-radius: 12px;
-  background: var(--auth-surface);
-  padding: 1rem;
-  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.2);
-}
-
-.idt-auth-mfa-form label,
-html[data-theme='light'] .idt-auth-mfa-form label {
-  display: grid;
-  gap: 0.48rem;
-  color: var(--auth-muted);
-  font-size: 0.86rem;
-  font-weight: 650;
-}
-
-.idt-auth-page[data-auth-theme='light'] .idt-auth-mfa-form,
-html[data-theme='light'] .idt-auth-page[data-auth-theme='light'] .idt-auth-mfa-form {
-  background: rgba(255, 255, 255, 0.82);
-  box-shadow: 0 22px 54px rgba(15, 23, 42, 0.08);
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  box-shadow: none;
 }
 
 .idt-auth-mfa-form input,
@@ -6168,9 +6143,14 @@ html[data-theme='light'] .idt-auth-mfa-form input {
   min-height: 3.45rem;
   border-radius: 8px;
   text-align: center;
-  font-size: 1.3rem;
+  font-size: 1.35rem;
   font-variant-numeric: tabular-nums;
-  letter-spacing: 0;
+  letter-spacing: 0.32em;
+  padding-left: 0.32em;
+}
+
+.idt-auth-mfa-form input::placeholder {
+  letter-spacing: 0.32em;
 }
 
 .idt-auth-mfa-form .idt-btn {
@@ -8064,25 +8044,26 @@ html[data-theme='light'] .idt-auth-manual-form input {
 .idt-auth-manual-form.idt-auth-mfa-form,
 html[data-theme='light'] .idt-auth-manual-form.idt-auth-mfa-form {
   margin-top: 0;
-  border: 1px solid var(--auth-line);
-  border-radius: 12px;
-  padding: 1rem;
-}
-
-.idt-auth-manual-form.idt-auth-mfa-form label,
-html[data-theme='light'] .idt-auth-manual-form.idt-auth-mfa-form label {
-  gap: 0.48rem;
-  font-size: 0.86rem;
-  font-weight: 650;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+  background: transparent;
+  box-shadow: none;
 }
 
 .idt-auth-manual-form.idt-auth-mfa-form input,
 html[data-theme='light'] .idt-auth-manual-form.idt-auth-mfa-form input {
   min-height: 3.45rem;
   text-align: center;
-  font-size: 1.3rem;
+  font-size: 1.35rem;
   font-variant-numeric: tabular-nums;
-  letter-spacing: 0;
+  letter-spacing: 0.32em;
+  padding-left: 0.32em;
+}
+
+.idt-auth-manual-form.idt-auth-mfa-form input::placeholder,
+html[data-theme='light'] .idt-auth-manual-form.idt-auth-mfa-form input::placeholder {
+  letter-spacing: 0.32em;
 }
 
 .idt-auth-page .idt-auth-footer-line,


### PR DESCRIPTION
## Summary

Describe what changed.

## Why

Describe the problem this PR solves.

## Scope

- [ ] Focused change (no unrelated modifications)
- [ ] Backward compatibility considered
- [ ] Risk level assessed

## Validation

List the checks you ran and their outcomes.

```bash
# Example:
# go test ./...
# npm run test:ci --prefix web
```

## Checklist

- [ ] Tests added/updated for behavior changes
- [ ] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [ ] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

If AI tools were used materially for this PR, complete the fields below.

- AI-assisted: yes/no
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Required for this repository size:

- Include at least one issue reference using closing/reference keywords:
  - `Closes #123`, `Fixes #123`, or `Refs #123`
- If no issue exists, include an explicit exemption with rationale:
  - `No issue: <reason>` (for example: docs-only typo fix, CI-only fix, or emergency hotfix)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the WorkOS MFA verification flow: the TOTP code input renders immediately while the challenge starts silently, and verify waits until the challenge is ready. This removes the "Preparing..." flash and fixes a race where programmatic submits could verify too early.

- **Bug Fixes**
  - Guard verify against an in-flight silent challenge by awaiting a tracked promise, preventing "mfa challenge has not started" errors.
  - Added a regression test that programmatically submits during a pending challenge and confirms verify only fires after it completes.

- **UI Improvements**
  - Show the code input on first paint; keep the Verify button disabled until the challenge is ready.
  - Simplified the layout: removed the helper line, visible "Authentication code" label, and the bordered/shadowed container.
  - Tightened the OTP input styling with centered text and letter spacing; adjusted subtitle margins and placeholder spacing.

<sup>Written for commit 688a4aab01868e8c8cdd475989a4c8aa08f3790b. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1403?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

