### PR TITLE
Polish onboarding organization validation

### DIFF
--- a/web/src/pages/onboarding/ConnectPage.tsx
+++ b/web/src/pages/onboarding/ConnectPage.tsx
@@ -62,6 +62,7 @@ export function ConnectPage() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
+  const [providerError, setProviderError] = useState('');
 
   const enabledProviderIdsRef = useRef<OnboardingProvider[]>([]);
   enabledProviderIdsRef.current = enabledProviders.map((provider) => provider.id);
@@ -124,11 +125,12 @@ export function ConnectPage() {
     }
     const provider = selectedProvider;
     if (!provider || !enabledProviders.some((enabledProvider) => enabledProvider.id === provider)) {
-      setError('Please choose an available source to continue.');
+      setProviderError('Choose a source');
       return;
     }
     setSaving(true);
     setError('');
+    setProviderError('');
     try {
       const response = await apiClient.updateOnboardingState({
         current_step: 'connect',
@@ -150,11 +152,12 @@ export function ConnectPage() {
     }
     const provider = selectedProvider;
     if (!provider || !enabledProviders.some((enabledProvider) => enabledProvider.id === provider)) {
-      setError('Please choose an available source to open setup.');
+      setProviderError('Choose a source');
       return;
     }
     setSaving(true);
     setError('');
+    setProviderError('');
     try {
       const response = await apiClient.updateOnboardingState({
         current_step: 'connect',
@@ -205,7 +208,12 @@ export function ConnectPage() {
             key={provider.id}
             className={`idt-onboarding-provider ${selectedProvider === provider.id ? 'is-selected' : ''}`}
             disabled={!provider.enabled || saving || loading}
-            onClick={() => setSelectedProvider(provider.id)}
+            onClick={() => {
+              setSelectedProvider(provider.id);
+              if (providerError) {
+                setProviderError('');
+              }
+            }}
           >
             <span>{provider.name}</span>
             <strong>{provider.signal}</strong>
@@ -219,6 +227,11 @@ export function ConnectPage() {
           </button>
         ))}
       </div>
+      {providerError ? (
+        <p className="idt-onboarding-inline-error" role="alert">
+          {providerError}
+        </p>
+      ) : null}
       <div className="idt-onboarding-actions">
         <button type="button" className="idt-btn idt-btn-primary" disabled={saving || loading} onClick={continueToScan}>
           {saving ? 'Saving...' : 'Continue'}

--- a/web/src/pages/onboarding/ConnectPage.tsx
+++ b/web/src/pages/onboarding/ConnectPage.tsx
@@ -119,6 +119,8 @@ export function ConnectPage() {
   }
 
   const continueToScan = async () => {
+    setError('');
+    setProviderError('');
     if (!enabledProviders.length) {
       setError('No sources are available. Skip for now to continue.');
       return;
@@ -129,8 +131,6 @@ export function ConnectPage() {
       return;
     }
     setSaving(true);
-    setError('');
-    setProviderError('');
     try {
       const response = await apiClient.updateOnboardingState({
         current_step: 'connect',
@@ -146,6 +146,8 @@ export function ConnectPage() {
   };
 
   const openConnectorSetup = async () => {
+    setError('');
+    setProviderError('');
     if (!enabledProviders.length) {
       setError('No sources are available. Skip for now to continue.');
       return;
@@ -156,8 +158,6 @@ export function ConnectPage() {
       return;
     }
     setSaving(true);
-    setError('');
-    setProviderError('');
     try {
       const response = await apiClient.updateOnboardingState({
         current_step: 'connect',
@@ -175,6 +175,7 @@ export function ConnectPage() {
   const skipConnector = async () => {
     setSaving(true);
     setError('');
+    setProviderError('');
     try {
       const response = await apiClient.updateOnboardingState({
         current_step: 'connect',

--- a/web/src/pages/onboarding/InvitePage.tsx
+++ b/web/src/pages/onboarding/InvitePage.tsx
@@ -30,6 +30,7 @@ export function InvitePage() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
+  const [emailsError, setEmailsError] = useState('');
   const invitees = useMemo(() => parseInviteEmails(emails), [emails]);
 
   useEffect(() => {
@@ -96,11 +97,12 @@ export function InvitePage() {
       return;
     }
     if (!invitees.length) {
-      setError('Please enter at least one valid email address, or finish without invites.');
+      setEmailsError('Enter a valid email');
       return;
     }
     setSaving(true);
     setError('');
+    setEmailsError('');
     try {
       const auth = onboardingAuth(state);
       for (const email of invitees) {
@@ -141,13 +143,29 @@ export function InvitePage() {
         </div>
       ) : null}
       <form className="idt-onboarding-form" onSubmit={submit}>
-        <label htmlFor="invite-emails">Email addresses</label>
-        <textarea
-          id="invite-emails"
-          value={emails}
-          onChange={(event) => setEmails(event.target.value)}
-          rows={5}
-        />
+        <div className="idt-onboarding-field">
+          <label htmlFor="invite-emails">Email addresses</label>
+          <div className={emailsError ? 'idt-onboarding-input-wrap has-error' : 'idt-onboarding-input-wrap'}>
+            <textarea
+              id="invite-emails"
+              value={emails}
+              onChange={(event) => {
+                setEmails(event.target.value);
+                if (emailsError) {
+                  setEmailsError('');
+                }
+              }}
+              rows={5}
+              aria-invalid={emailsError ? 'true' : undefined}
+              aria-describedby={emailsError ? 'invite-emails-error' : undefined}
+            />
+            {emailsError ? (
+              <span id="invite-emails-error" className="idt-onboarding-input-error" role="alert">
+                {emailsError}
+              </span>
+            ) : null}
+          </div>
+        </div>
         <div className="idt-onboarding-actions">
           <button type="submit" className="idt-btn idt-btn-primary" disabled={saving || loading}>
             {saving ? 'Finishing...' : 'Invite and finish'}

--- a/web/src/pages/onboarding/InvitePage.tsx
+++ b/web/src/pages/onboarding/InvitePage.tsx
@@ -92,6 +92,8 @@ export function InvitePage() {
 
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    setError('');
+    setEmailsError('');
     if (!state?.workspace_id) {
       setError('Workspace context is required before inviting teammates.');
       return;
@@ -101,8 +103,6 @@ export function InvitePage() {
       return;
     }
     setSaving(true);
-    setError('');
-    setEmailsError('');
     try {
       const auth = onboardingAuth(state);
       for (const email of invitees) {

--- a/web/src/pages/onboarding/InvitePage.tsx
+++ b/web/src/pages/onboarding/InvitePage.tsx
@@ -79,6 +79,7 @@ export function InvitePage() {
   const complete = async () => {
     setSaving(true);
     setError('');
+    setEmailsError('');
     try {
       const response = await apiClient.completeOnboarding();
       setState(response.state);

--- a/web/src/pages/onboarding/OrgPage.tsx
+++ b/web/src/pages/onboarding/OrgPage.tsx
@@ -10,6 +10,7 @@ export function OrgPage() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
+  const [orgNameError, setOrgNameError] = useState('');
 
   useEffect(() => {
     if (!FEATURE_ONBOARDING_WIZARD) {
@@ -53,11 +54,12 @@ export function OrgPage() {
     event.preventDefault();
     const name = orgName.trim();
     if (!name) {
-      setError('Please enter an organization name to continue.');
+      setOrgNameError('Enter an organization name');
       return;
     }
     setSaving(true);
     setError('');
+    setOrgNameError('');
     try {
       const response = await apiClient.updateOnboardingState({
         current_step: 'org',
@@ -75,9 +77,7 @@ export function OrgPage() {
   return (
     <OnboardingFrame
       step="org"
-      eyebrow="Secure onboarding"
       title="Set up your organization"
-      description="Create one boundary for workspaces, sources, scans, findings, and access."
     >
       {loading ? <p className="idt-muted-strong">Preparing your account...</p> : null}
       {error ? (
@@ -89,13 +89,26 @@ export function OrgPage() {
         <div className="idt-onboarding-field">
           <label htmlFor="org-name">Organization name</label>
           <p id="org-name-hint">Use a recognizable company or program name.</p>
-          <input
-            id="org-name"
-            value={orgName}
-            onChange={(event) => setOrgName(event.target.value)}
-            autoComplete="organization"
-            aria-describedby="org-name-hint"
-          />
+          <div className={orgNameError ? 'idt-onboarding-input-wrap has-error' : 'idt-onboarding-input-wrap'}>
+            <input
+              id="org-name"
+              value={orgName}
+              onChange={(event) => {
+                setOrgName(event.target.value);
+                if (orgNameError) {
+                  setOrgNameError('');
+                }
+              }}
+              autoComplete="organization"
+              aria-invalid={orgNameError ? 'true' : undefined}
+              aria-describedby={orgNameError ? 'org-name-hint org-name-error' : 'org-name-hint'}
+            />
+            {orgNameError ? (
+              <span id="org-name-error" className="idt-onboarding-input-error" role="alert">
+                {orgNameError}
+              </span>
+            ) : null}
+          </div>
         </div>
         <div className="idt-onboarding-actions">
           <button type="submit" className="idt-btn idt-btn-primary" disabled={saving || loading}>

--- a/web/src/pages/onboarding/OrgPage.tsx
+++ b/web/src/pages/onboarding/OrgPage.tsx
@@ -52,14 +52,14 @@ export function OrgPage() {
 
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    setError('');
+    setOrgNameError('');
     const name = orgName.trim();
     if (!name) {
       setOrgNameError('Enter an organization name');
       return;
     }
     setSaving(true);
-    setError('');
-    setOrgNameError('');
     try {
       const response = await apiClient.updateOnboardingState({
         current_step: 'org',

--- a/web/src/pages/onboarding/WorkspacePage.tsx
+++ b/web/src/pages/onboarding/WorkspacePage.tsx
@@ -17,6 +17,8 @@ export function WorkspacePage() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
+  const [workspaceNameError, setWorkspaceNameError] = useState('');
+  const [projectNameError, setProjectNameError] = useState('');
 
   useEffect(() => {
     if (!FEATURE_ONBOARDING_WIZARD) {
@@ -64,15 +66,17 @@ export function WorkspacePage() {
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!workspaceName.trim()) {
-      setError('Please enter a workspace name to continue.');
+      setWorkspaceNameError('Enter a workspace name');
       return;
     }
     if (!projectName.trim()) {
-      setError('Please enter a project name to continue.');
+      setProjectNameError('Enter a project name');
       return;
     }
     setSaving(true);
     setError('');
+    setWorkspaceNameError('');
+    setProjectNameError('');
     try {
       const response = await apiClient.updateOnboardingState({
         current_step: 'workspace',
@@ -102,20 +106,52 @@ export function WorkspacePage() {
         </div>
       ) : null}
       <form className="idt-onboarding-form" onSubmit={submit}>
-        <label htmlFor="workspace-name">Workspace name</label>
-        <input
-          id="workspace-name"
-          value={workspaceName}
-          onChange={(event) => setWorkspaceName(event.target.value)}
-          autoComplete="off"
-        />
-        <label htmlFor="project-name">First project</label>
-        <input
-          id="project-name"
-          value={projectName}
-          onChange={(event) => setProjectName(event.target.value)}
-          autoComplete="off"
-        />
+        <div className="idt-onboarding-field">
+          <label htmlFor="workspace-name">Workspace name</label>
+          <div className={workspaceNameError ? 'idt-onboarding-input-wrap has-error' : 'idt-onboarding-input-wrap'}>
+            <input
+              id="workspace-name"
+              value={workspaceName}
+              onChange={(event) => {
+                setWorkspaceName(event.target.value);
+                if (workspaceNameError) {
+                  setWorkspaceNameError('');
+                }
+              }}
+              autoComplete="off"
+              aria-invalid={workspaceNameError ? 'true' : undefined}
+              aria-describedby={workspaceNameError ? 'workspace-name-error' : undefined}
+            />
+            {workspaceNameError ? (
+              <span id="workspace-name-error" className="idt-onboarding-input-error" role="alert">
+                {workspaceNameError}
+              </span>
+            ) : null}
+          </div>
+        </div>
+        <div className="idt-onboarding-field">
+          <label htmlFor="project-name">First project</label>
+          <div className={projectNameError ? 'idt-onboarding-input-wrap has-error' : 'idt-onboarding-input-wrap'}>
+            <input
+              id="project-name"
+              value={projectName}
+              onChange={(event) => {
+                setProjectName(event.target.value);
+                if (projectNameError) {
+                  setProjectNameError('');
+                }
+              }}
+              autoComplete="off"
+              aria-invalid={projectNameError ? 'true' : undefined}
+              aria-describedby={projectNameError ? 'project-name-error' : undefined}
+            />
+            {projectNameError ? (
+              <span id="project-name-error" className="idt-onboarding-input-error" role="alert">
+                {projectNameError}
+              </span>
+            ) : null}
+          </div>
+        </div>
         <div className="idt-onboarding-actions">
           <button type="submit" className="idt-btn idt-btn-primary" disabled={saving || loading}>
             {saving ? 'Creating...' : state?.workspace_id ? 'Continue' : 'Create workspace'}

--- a/web/src/pages/onboarding/WorkspacePage.tsx
+++ b/web/src/pages/onboarding/WorkspacePage.tsx
@@ -65,6 +65,9 @@ export function WorkspacePage() {
 
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    setError('');
+    setWorkspaceNameError('');
+    setProjectNameError('');
     if (!workspaceName.trim()) {
       setWorkspaceNameError('Enter a workspace name');
       return;
@@ -74,9 +77,6 @@ export function WorkspacePage() {
       return;
     }
     setSaving(true);
-    setError('');
-    setWorkspaceNameError('');
-    setProjectNameError('');
     try {
       const response = await apiClient.updateOnboardingState({
         current_step: 'workspace',

--- a/web/src/pages/onboarding/onboarding.test.tsx
+++ b/web/src/pages/onboarding/onboarding.test.tsx
@@ -126,6 +126,30 @@ describe('onboarding pages', () => {
     });
   });
 
+  it('clears stale organization save errors before inline validation', async () => {
+    const { apiClient, OrgPage } = await loadOnboardingModules();
+    vi.spyOn(apiClient, 'startOnboarding').mockResolvedValue({
+      state: state({ current_step: 'org' }),
+      redirect_path: '/onboarding/org'
+    });
+    const update = vi.spyOn(apiClient, 'updateOnboardingState').mockRejectedValue(new Error('Organization save failed'));
+
+    renderOnboarding(<OrgPage />, '/onboarding/org');
+
+    const input = await screen.findByLabelText('Organization name');
+    fireEvent.change(input, { target: { value: 'Aurelius Security' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create organization' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Organization save failed');
+
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create organization' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Enter an organization name');
+    expect(screen.queryByText('Organization save failed')).not.toBeInTheDocument();
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+
   it('creates the workspace and default project', async () => {
     const { apiClient, WorkspacePage } = await loadOnboardingModules();
     vi.spyOn(apiClient, 'getOnboardingState').mockResolvedValue({
@@ -165,6 +189,44 @@ describe('onboarding pages', () => {
         project_name: 'Identity Control Plane'
       });
     });
+  });
+
+  it('clears stale workspace save errors before inline validation', async () => {
+    const { apiClient, WorkspacePage } = await loadOnboardingModules();
+    vi.spyOn(apiClient, 'getOnboardingState').mockResolvedValue({
+      state: state({ current_step: 'workspace', org_id: 'tenant-a' }),
+      redirect_path: '/onboarding/workspace'
+    });
+    const update = vi.spyOn(apiClient, 'updateOnboardingState').mockRejectedValue(new Error('Workspace save failed'));
+
+    renderOnboarding(<WorkspacePage />, '/onboarding/workspace');
+
+    const workspaceInput = await screen.findByLabelText('Workspace name');
+    const projectInput = screen.getByLabelText('First project');
+    fireEvent.change(workspaceInput, { target: { value: 'Production' } });
+    fireEvent.change(projectInput, { target: { value: 'Identity Control Plane' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create workspace' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Workspace save failed');
+
+    fireEvent.change(workspaceInput, { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create workspace' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Enter a workspace name');
+    expect(screen.queryByText('Workspace save failed')).not.toBeInTheDocument();
+    expect(update).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(workspaceInput, { target: { value: 'Production' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create workspace' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Workspace save failed');
+
+    fireEvent.change(projectInput, { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create workspace' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Enter a project name');
+    expect(screen.queryByText('Workspace save failed')).not.toBeInTheDocument();
+    expect(update).toHaveBeenCalledTimes(2);
   });
 
   it('records the selected connector source', async () => {
@@ -381,5 +443,39 @@ describe('onboarding pages', () => {
       );
       expect(complete).toHaveBeenCalled();
     });
+  });
+
+  it('clears stale invite errors before inline email validation', async () => {
+    const { apiClient, InvitePage } = await loadOnboardingModules();
+    vi.spyOn(apiClient, 'getOnboardingState').mockResolvedValue({
+      state: state({
+        current_step: 'invite',
+        org_id: 'tenant-a',
+        workspace_id: 'production',
+        project_id: 'production'
+      }),
+      redirect_path: '/onboarding/invite'
+    });
+    const invite = vi.spyOn(apiClient, 'upsertWorkspaceMember').mockRejectedValue(new Error('Invite failed'));
+    const complete = vi.spyOn(apiClient, 'completeOnboarding').mockResolvedValue({
+      state: state({ current_step: 'complete', org_id: 'tenant-a', workspace_id: 'production' }),
+      redirect_path: '/app/tenant-a/production'
+    });
+
+    renderOnboarding(<InvitePage />, '/onboarding/invite');
+
+    const emailInput = await screen.findByLabelText('Email addresses');
+    fireEvent.change(emailInput, { target: { value: 'analyst@example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Invite and finish' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Invite failed');
+
+    fireEvent.change(emailInput, { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Invite and finish' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Enter a valid email');
+    expect(screen.queryByText('Invite failed')).not.toBeInTheDocument();
+    expect(invite).toHaveBeenCalledTimes(1);
+    expect(complete).not.toHaveBeenCalled();
   });
 });

--- a/web/src/pages/onboarding/onboarding.test.tsx
+++ b/web/src/pages/onboarding/onboarding.test.tsx
@@ -478,4 +478,29 @@ describe('onboarding pages', () => {
     expect(invite).toHaveBeenCalledTimes(1);
     expect(complete).not.toHaveBeenCalled();
   });
+
+  it('clears stale email validation before finishing without invites', async () => {
+    const { apiClient, InvitePage } = await loadOnboardingModules();
+    vi.spyOn(apiClient, 'getOnboardingState').mockResolvedValue({
+      state: state({
+        current_step: 'invite',
+        org_id: 'tenant-a',
+        workspace_id: 'production',
+        project_id: 'production'
+      }),
+      redirect_path: '/onboarding/invite'
+    });
+    const complete = vi.spyOn(apiClient, 'completeOnboarding').mockRejectedValue(new Error('Unable to finish'));
+
+    renderOnboarding(<InvitePage />, '/onboarding/invite');
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Invite and finish' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Enter a valid email');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Finish without invites' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Unable to finish');
+    expect(screen.queryByText('Enter a valid email')).not.toBeInTheDocument();
+    expect(complete).toHaveBeenCalledTimes(1);
+  });
 });

--- a/web/src/pages/onboarding/onboarding.test.tsx
+++ b/web/src/pages/onboarding/onboarding.test.tsx
@@ -114,10 +114,11 @@ describe('onboarding pages', () => {
     const input = await screen.findByLabelText('Organization name');
     expect(input).toHaveValue('');
     fireEvent.click(screen.getByRole('button', { name: 'Create organization' }));
-    expect(await screen.findByRole('alert')).toHaveTextContent('Please enter an organization name to continue.');
+    expect(await screen.findByRole('alert')).toHaveTextContent('Enter an organization name');
     expect(update).not.toHaveBeenCalled();
 
     fireEvent.change(input, { target: { value: 'Aurelius Security' } });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Create organization' }));
 
     await waitFor(() => {
@@ -144,11 +145,17 @@ describe('onboarding pages', () => {
     expect(workspaceInput).toHaveValue('');
     expect(projectInput).toHaveValue('');
     fireEvent.click(screen.getByRole('button', { name: 'Create workspace' }));
-    expect(await screen.findByRole('alert')).toHaveTextContent('Please enter a workspace name to continue.');
+    expect(await screen.findByRole('alert')).toHaveTextContent('Enter a workspace name');
     expect(update).not.toHaveBeenCalled();
 
     fireEvent.change(workspaceInput, { target: { value: 'Production' } });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Create workspace' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Enter a project name');
+    expect(update).not.toHaveBeenCalled();
+
     fireEvent.change(projectInput, { target: { value: 'Identity Control Plane' } });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Create workspace' }));
 
     await waitFor(() => {
@@ -185,10 +192,11 @@ describe('onboarding pages', () => {
     renderOnboarding(<ConnectPage />, '/onboarding/connect');
 
     fireEvent.click(await screen.findByRole('button', { name: 'Continue' }));
-    expect(await screen.findByRole('alert')).toHaveTextContent('Please choose an available source to continue.');
+    expect(await screen.findByRole('alert')).toHaveTextContent('Choose a source');
     expect(update).not.toHaveBeenCalled();
 
     fireEvent.click(await screen.findByRole('button', { name: /GitHubRepos/i }));
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
 
     await waitFor(() => {
@@ -281,7 +289,7 @@ describe('onboarding pages', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
 
-    expect(await screen.findByRole('alert')).toHaveTextContent('Please choose an available source to continue.');
+    expect(await screen.findByRole('alert')).toHaveTextContent('Choose a source');
     expect(update).not.toHaveBeenCalled();
   });
 
@@ -357,11 +365,12 @@ describe('onboarding pages', () => {
     renderOnboarding(<InvitePage />, '/onboarding/invite');
 
     fireEvent.click(await screen.findByRole('button', { name: 'Invite and finish' }));
-    expect(await screen.findByRole('alert')).toHaveTextContent('Please enter at least one valid email address');
+    expect(await screen.findByRole('alert')).toHaveTextContent('Enter a valid email');
     expect(invite).not.toHaveBeenCalled();
     expect(complete).not.toHaveBeenCalled();
 
     fireEvent.change(await screen.findByLabelText('Email addresses'), { target: { value: 'analyst@example.com' } });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Invite and finish' }));
 
     await waitFor(() => {

--- a/web/src/pages/onboarding/onboardingUtils.tsx
+++ b/web/src/pages/onboarding/onboardingUtils.tsx
@@ -146,9 +146,9 @@ export function OnboardingFrame({
   children
 }: {
   step: OnboardingStep;
-  eyebrow: string;
+  eyebrow?: string;
   title: string;
-  description: string;
+  description?: string;
   children: ReactNode;
 }) {
   return (
@@ -180,9 +180,9 @@ export function OnboardingFrame({
         </aside>
         <article className="idt-onboarding-panel">
           <div className="idt-onboarding-panel-main">
-            <p className="idt-app-kicker">{eyebrow}</p>
+            {eyebrow ? <p className="idt-app-kicker">{eyebrow}</p> : null}
             <h1>{title}</h1>
-            <p>{description}</p>
+            {description ? <p>{description}</p> : null}
             <div className="idt-onboarding-guarantees" aria-label="Setup guarantees">
               {SETUP_GUARANTEES.map((item) => {
                 const Icon = item.icon;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15813,7 +15813,7 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
 
 .idt-onboarding-panel-main {
   min-width: 0;
-  padding: clamp(28px, 3.4vw, 40px);
+  padding: clamp(24px, 3vw, 34px) clamp(28px, 3.4vw, 40px) clamp(28px, 3.4vw, 40px);
   background: #000000;
 }
 
@@ -16032,6 +16032,55 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   color: #ffffff;
   background: #050505;
   box-shadow: none;
+}
+
+.idt-onboarding-input-wrap {
+  position: relative;
+}
+
+.idt-onboarding-input-wrap input,
+.idt-onboarding-input-wrap textarea {
+  display: block;
+}
+
+.idt-onboarding-input-wrap.has-error input,
+.idt-onboarding-input-wrap.has-error textarea {
+  border-color: #ef4444;
+}
+
+.idt-onboarding-input-error {
+  position: absolute;
+  inset: 0;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  padding: 0 15px;
+  color: #ff5a5f;
+  font-size: 0.78rem;
+  font-style: italic;
+  font-weight: 650;
+  line-height: 1.25;
+  pointer-events: none;
+}
+
+.idt-onboarding-input-wrap textarea + .idt-onboarding-input-error {
+  align-items: flex-start;
+  padding-top: 13px;
+}
+
+.idt-onboarding-inline-error {
+  margin: 10px 0 0;
+  color: #ff5a5f;
+  font-size: 0.78rem;
+  font-style: italic;
+  font-weight: 650;
+  line-height: 1.25;
+}
+
+.idt-onboarding-panel-main > .idt-onboarding-inline-error {
+  color: #ff5a5f;
+  font-size: 0.78rem;
+  line-height: 1.25;
 }
 
 .idt-onboarding-form input:focus-visible,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -16064,8 +16064,10 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
 }
 
 .idt-onboarding-input-wrap textarea + .idt-onboarding-input-error {
-  align-items: flex-start;
-  padding-top: 13px;
+  position: static;
+  display: block;
+  margin-top: 7px;
+  padding: 0 1px;
 }
 
 .idt-onboarding-inline-error {


### PR DESCRIPTION
No issue: follow-up polish after #1401 merged.

## Summary
- Removed the organization-step eyebrow and description copy so the page stays minimal.
- Moved the organization title slightly higher by tightening the main panel top padding.
- Changed required onboarding prompts to compact red italic inline messages that clear immediately when the user types or selects the missing item.
- Applied the prompt pattern across organization, workspace, project, source choice, and invite email validation.

## Impact
- Frontend-only onboarding copy, spacing, and validation polish.
- No onboarding API, persistence, or route behavior changes.

## Validation
- `git diff --check`
- `npm run test:ci --prefix web` (207 tests passed)
- `npm run build --prefix web`
- Local browser verification across `/onboarding/workspace`, `/onboarding/connect`, and `/onboarding/invite`: workspace, project, source, and invite prompts rendered as red 12.48px italic text and cleared after typing or selection. Organization prompt was verified in the earlier local browser pass.

## AI Disclosure
- AI-assisted: yes
- Tools used: Codex
- Where used: onboarding organization, workspace, connect, invite validation behavior, shared onboarding frame options, and CSS spacing/states
- Human verification performed: diff review, full web tests/build, and local browser screenshot/behavior verification
