### PR TITLE
Refine WorkOS MFA verification copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Refined the WorkOS MFA verification copy: the heading is now "Enter
+  verification code" (replacing the redundant "Verify your sign-in"), the code
+  input placeholder reads "6-digit code" instead of a greyed-out "000000", and
+  the submit button reads "Continue" instead of "Verify and continue".
 - Tightened the WorkOS MFA verification screen: the authenticator code entry now
   appears immediately without the intermediate "Preparing your authenticator
   challenge..." flash (the challenge starts silently in the background, with the

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -2986,7 +2986,7 @@ describe('App', () => {
 
     expect(await screen.findByAltText(/Authenticator QR code/i)).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText(/Authentication code/i), { target: { value: '123456' } });
-    fireEvent.click(screen.getByRole('button', { name: /Verify and continue/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^Continue$/i }));
 
     expect(await screen.findByRole('heading', { level: 2, name: /Overview/i })).toBeInTheDocument();
     expect(window.location.pathname).toBe('/app/tenant-a/workspace-a');
@@ -3015,12 +3015,12 @@ describe('App', () => {
     setCurrentPath('/auth/mfa?return_to=%2Fapp');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { level: 1, name: /Verify your sign-in/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 1, name: /Enter verification code/i })).toBeInTheDocument();
     expect(await screen.findByLabelText(/Authentication code/i)).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Use authenticator app/i })).not.toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText(/Authentication code/i), { target: { value: '123456' } });
-    fireEvent.click(screen.getByRole('button', { name: /Verify and continue/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^Continue$/i }));
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(

--- a/web/src/pages/WorkOSMFAPage.tsx
+++ b/web/src/pages/WorkOSMFAPage.tsx
@@ -212,7 +212,7 @@ export function WorkOSMFAPage() {
       </div>
 
       <article className="idt-auth-panel idt-auth-panel-login idt-auth-mfa-panel">
-        <h1>{isEnrollment ? 'Set up two-factor authentication' : 'Verify your sign-in'}</h1>
+        <h1>{isEnrollment ? 'Set up two-factor authentication' : 'Enter verification code'}</h1>
         {pending?.user_email ? <p className="idt-auth-mfa-subtitle">{pending.user_email}</p> : null}
         {error ? <p className="idt-app-alert idt-app-alert-error">{error}</p> : null}
         {loading ? <p className="idt-auth-mfa-subtitle">Loading verification...</p> : null}
@@ -262,12 +262,12 @@ export function WorkOSMFAPage() {
               maxLength={6}
               onChange={(event) => setCode(event.target.value)}
               pattern="[0-9]*"
-              placeholder="000000"
+              placeholder="6-digit code"
               required
               value={code}
             />
             <button className="idt-btn idt-btn-primary" type="submit" disabled={busy || !canEnterCode}>
-              {busy ? 'Verifying...' : 'Verify and continue'}
+              {busy ? 'Verifying...' : 'Continue'}
             </button>
           </form>
         ) : null}


### PR DESCRIPTION
## Summary

The MFA verification screen had two redundancies:
- Heading "Verify your sign-in" + button "Verify and continue" both led with the same verb.
- The greyed-out `000000` input placeholder didn't tell the user what they were entering — it looked like prefilled zeros, not a placeholder.

This PR rewords the screen so the heading describes the situation, the placeholder describes the input, and the button describes the next action.

| Element | Before | After |
| --- | --- | --- |
| Heading | Verify your sign-in | Enter verification code |
| Email line | (unchanged) | (unchanged) |
| Input placeholder | `000000` | `6-digit code` |
| Submit button | Verify and continue | Continue |
| Footer link | (unchanged) | (unchanged) |

The enrollment ("Set up two-factor authentication") variant of the heading is untouched. This is a follow-up to the MFA polish work in #1402.

## Test plan

- [x] `npx vitest run src/App.test.tsx -t "MFA"` — the two existing MFA flow tests assert on the rendered heading and submit button text; updated to match the new copy and passing.
- [ ] Manual: trigger an MFA challenge against a WorkOS-backed account and confirm the heading, placeholder, and button render the new strings.

## AI-Assisted Disclosure

- AI-assisted: yes
- Tools used: Claude Code (claude-opus-4-7)
- Where used: copy decisions and edits in `web/src/pages/WorkOSMFAPage.tsx`, matching test updates in `web/src/App.test.tsx`, and `CHANGELOG.md` entry.
- Human verification performed: ran the MFA vitest suite locally (3 passed, 66 skipped) and confirmed no remaining references to the old strings via grep.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refined the WorkOS MFA verification screen copy to make the flow clearer and reduce confusion. The heading now reads "Enter verification code", the input placeholder shows "6-digit code", and the submit button is "Continue".

<sup>Written for commit 1a412b100b601554bd89565b4f00a902c3c280d2. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1408?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

