### PR TITLE
Tighten onboarding header and progress rail

### DIFF
--- a/web/src/components/common/EnterSubmitHint.tsx
+++ b/web/src/components/common/EnterSubmitHint.tsx
@@ -1,0 +1,7 @@
+export function EnterSubmitHint() {
+  return (
+    <span className="idt-btn-enter-cue" aria-hidden="true">
+      ↵
+    </span>
+  );
+}

--- a/web/src/pages/WorkOSMFAPage.tsx
+++ b/web/src/pages/WorkOSMFAPage.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 're
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { OTPInput, REGEXP_ONLY_DIGITS } from 'input-otp';
 import { ApiError, apiClient, type WorkOSMFAPendingResponse } from '../api/client';
+import { EnterSubmitHint } from '../components/common/EnterSubmitHint';
 
 function sameOriginPath(value: string | null | undefined, fallback: string, pathPrefix?: string): string {
   const candidate = value?.trim();
@@ -292,7 +293,14 @@ export function WorkOSMFAPage() {
               )}
             />
             <button className="idt-btn idt-btn-primary" type="submit" disabled={busy || !canEnterCode || code.length < 6}>
-              {busy ? 'Verifying...' : 'Continue'}
+              {busy ? (
+                'Verifying...'
+              ) : (
+                <>
+                  Continue
+                  <EnterSubmitHint />
+                </>
+              )}
             </button>
           </form>
         ) : null}

--- a/web/src/pages/onboarding/ConnectPage.tsx
+++ b/web/src/pages/onboarding/ConnectPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { apiClient } from '../../api/client';
+import { EnterSubmitHint } from '../../components/common/EnterSubmitHint';
 import { SkipForNow } from '../../components/onboarding/SkipForNow';
 import { isFeatureAvailable, useBackendFeatures } from '../../hooks/useBackendFeatures';
 import {
@@ -235,7 +236,14 @@ export function ConnectPage() {
       ) : null}
       <div className="idt-onboarding-actions">
         <button type="button" className="idt-btn idt-btn-primary" disabled={saving || loading} onClick={continueToScan}>
-          {saving ? 'Saving...' : 'Continue'}
+          {saving ? (
+            'Saving...'
+          ) : (
+            <>
+              Continue
+              <EnterSubmitHint />
+            </>
+          )}
         </button>
         <button type="button" className="idt-btn idt-btn-secondary" disabled={saving || loading} onClick={openConnectorSetup}>
           Open setup

--- a/web/src/pages/onboarding/OrgPage.tsx
+++ b/web/src/pages/onboarding/OrgPage.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useEffect, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { apiClient, type OnboardingState } from '../../api/client';
+import { EnterSubmitHint } from '../../components/common/EnterSubmitHint';
 import { FEATURE_ONBOARDING_WIZARD, OnboardingFrame, routeAfterOnboardingResponse, routeToOnboardingStep } from './onboardingUtils';
 
 export function OrgPage() {
@@ -77,7 +78,7 @@ export function OrgPage() {
   return (
     <OnboardingFrame
       step="org"
-      title="Set up your organization"
+      title="Define your boundary"
     >
       {loading ? <p className="idt-muted-strong">Preparing your account...</p> : null}
       {error ? (
@@ -112,7 +113,14 @@ export function OrgPage() {
         </div>
         <div className="idt-onboarding-actions">
           <button type="submit" className="idt-btn idt-btn-primary" disabled={saving || loading}>
-            {saving ? 'Saving...' : state?.org_id ? 'Continue' : 'Create organization'}
+            {saving ? (
+              'Saving...'
+            ) : (
+              <>
+                {state?.org_id ? 'Continue' : 'Create boundary'}
+                <EnterSubmitHint />
+              </>
+            )}
           </button>
         </div>
       </form>

--- a/web/src/pages/onboarding/ScanPage.tsx
+++ b/web/src/pages/onboarding/ScanPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { apiClient, type OnboardingState, type ScanRecord, type ScanRequest } from '../../api/client';
+import { EnterSubmitHint } from '../../components/common/EnterSubmitHint';
 import { SkipForNow } from '../../components/onboarding/SkipForNow';
 import {
   FEATURE_ONBOARDING_WIZARD,
@@ -152,6 +153,7 @@ export function ScanPage() {
         ) : null}
         <button type="button" className="idt-btn idt-btn-secondary" disabled={saving || loading || !canContinue} onClick={continueToInvite}>
           Continue
+          <EnterSubmitHint />
         </button>
         {canSkip ? <SkipForNow disabled={saving || loading} onSkip={skipScan} label="Skip scan" /> : null}
       </div>

--- a/web/src/pages/onboarding/WorkspacePage.tsx
+++ b/web/src/pages/onboarding/WorkspacePage.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useEffect, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { apiClient, type OnboardingState } from '../../api/client';
+import { EnterSubmitHint } from '../../components/common/EnterSubmitHint';
 import {
   FEATURE_ONBOARDING_WIZARD,
   OnboardingFrame,
@@ -154,7 +155,14 @@ export function WorkspacePage() {
         </div>
         <div className="idt-onboarding-actions">
           <button type="submit" className="idt-btn idt-btn-primary" disabled={saving || loading}>
-            {saving ? 'Creating...' : state?.workspace_id ? 'Continue' : 'Create workspace'}
+            {saving ? (
+              'Creating...'
+            ) : (
+              <>
+                {state?.workspace_id ? 'Continue' : 'Create workspace'}
+                <EnterSubmitHint />
+              </>
+            )}
           </button>
         </div>
       </form>

--- a/web/src/pages/onboarding/onboarding.test.tsx
+++ b/web/src/pages/onboarding/onboarding.test.tsx
@@ -113,13 +113,13 @@ describe('onboarding pages', () => {
 
     const input = await screen.findByLabelText('Organization name');
     expect(input).toHaveValue('');
-    fireEvent.click(screen.getByRole('button', { name: 'Create organization' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create boundary' }));
     expect(await screen.findByRole('alert')).toHaveTextContent('Enter an organization name');
     expect(update).not.toHaveBeenCalled();
 
     fireEvent.change(input, { target: { value: 'Aurelius Security' } });
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'Create organization' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create boundary' }));
 
     await waitFor(() => {
       expect(update).toHaveBeenCalledWith({ current_step: 'org', org_name: 'Aurelius Security' });
@@ -138,12 +138,12 @@ describe('onboarding pages', () => {
 
     const input = await screen.findByLabelText('Organization name');
     fireEvent.change(input, { target: { value: 'Aurelius Security' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Create organization' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create boundary' }));
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Organization save failed');
 
     fireEvent.change(input, { target: { value: '' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Create organization' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create boundary' }));
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Enter an organization name');
     expect(screen.queryByText('Organization save failed')).not.toBeInTheDocument();

--- a/web/src/pages/onboarding/onboardingUtils.tsx
+++ b/web/src/pages/onboarding/onboardingUtils.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { Link, NavigateFunction } from 'react-router-dom';
-import { ArrowRight, Eye, LogOut, Network } from 'lucide-react';
+import { ArrowRight, LogOut } from 'lucide-react';
 import {
   apiClient,
   ApiError,
@@ -123,19 +123,6 @@ export async function loadOrStartOnboarding(): Promise<OnboardingState> {
   return (await loadOrStartOnboardingResponse()).state;
 }
 
-const SETUP_GUARANTEES = [
-  {
-    icon: Eye,
-    title: 'Read-only first',
-    detail: 'Discovery before enforcement.'
-  },
-  {
-    icon: Network,
-    title: 'Scoped by design',
-    detail: 'One boundary for every asset.'
-  }
-];
-
 const NEXT_STEPS = ['Create boundary', 'Name workspace', 'Connect source', 'Run scan'];
 
 export function OnboardingFrame({
@@ -160,7 +147,6 @@ export function OnboardingFrame({
           </span>
           <span className="idt-onboarding-brand-copy">
             <strong>Identrail</strong>
-            <span>Secure setup</span>
           </span>
         </Link>
         <Link to="/app/logout" className="idt-onboarding-signout" aria-label="Sign out">
@@ -171,10 +157,7 @@ export function OnboardingFrame({
       <div className="idt-onboarding-grid">
         <aside className="idt-onboarding-rail">
           <div className="idt-onboarding-rail-intro">
-            <div>
-              <p className="idt-onboarding-rail-label">Setup progress</p>
-              <strong>Launch path</strong>
-            </div>
+            <p className="idt-onboarding-rail-label">Setup progress</p>
           </div>
           <OnboardingStepper currentStep={step} />
         </aside>
@@ -183,20 +166,6 @@ export function OnboardingFrame({
             {eyebrow ? <p className="idt-app-kicker">{eyebrow}</p> : null}
             <h1>{title}</h1>
             {description ? <p>{description}</p> : null}
-            <div className="idt-onboarding-guarantees" aria-label="Setup guarantees">
-              {SETUP_GUARANTEES.map((item) => {
-                const Icon = item.icon;
-                return (
-                  <div className="idt-onboarding-guarantee" key={item.title}>
-                    <Icon size={16} strokeWidth={2.1} aria-hidden="true" />
-                    <div>
-                      <strong>{item.title}</strong>
-                      <span>{item.detail}</span>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
             {children}
           </div>
           <aside className="idt-onboarding-outcome" aria-label="What happens next">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15783,21 +15783,15 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
 }
 
 .idt-onboarding-brand-copy {
-  display: grid;
-  gap: 2px;
+  display: flex;
+  align-items: center;
   min-width: 0;
 }
 
 .idt-onboarding-brand-copy strong {
-  font-size: 0.98rem;
+  font-size: 1rem;
+  line-height: 1;
   letter-spacing: 0;
-}
-
-.idt-onboarding-brand-copy span {
-  color: #8a8a8a;
-  font-size: 0.74rem;
-  font-weight: 700;
-  letter-spacing: 0.03em;
 }
 
 .idt-onboarding-signout {
@@ -15879,12 +15873,12 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
 
 .idt-onboarding-panel-main {
   min-width: 0;
-  padding: clamp(24px, 3vw, 34px) clamp(28px, 3.4vw, 40px) clamp(28px, 3.4vw, 40px);
+  padding: clamp(20px, 2.2vw, 26px) clamp(28px, 3.4vw, 40px) clamp(28px, 3.4vw, 40px);
   background: #000000;
 }
 
 .idt-onboarding-rail-intro {
-  margin-bottom: 18px;
+  margin-bottom: 16px;
 }
 
 .idt-onboarding-rail-label {
@@ -15894,13 +15888,6 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
   font-weight: 800;
   letter-spacing: 0.07em;
   text-transform: uppercase;
-}
-
-.idt-onboarding-rail-intro strong {
-  display: block;
-  margin-top: 2px;
-  color: #ffffff;
-  font-size: 1.02rem;
 }
 
 .idt-onboarding-panel h1 {
@@ -15937,7 +15924,10 @@ html[data-theme='light'] .idt-hero-proof-pill:focus-visible::after {
   letter-spacing: 0.15em;
 }
 
-html[data-theme='light'] .idt-onboarding-shell,
+html[data-theme='light'] .idt-onboarding-shell {
+  color: #ffffff;
+}
+
 html[data-theme='light'] .idt-onboarding-shell .idt-onboarding-panel h1 {
   color: #ffffff;
 }
@@ -15946,51 +15936,17 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   color: #8ea7ff;
 }
 
-.idt-onboarding-guarantees {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-  max-width: 520px;
-  margin-top: 20px;
-  padding: 14px 0;
-  border-top: 1px solid #1f1f1f;
-  border-bottom: 1px solid #1f1f1f;
-}
-
-.idt-onboarding-guarantee {
-  display: flex;
-  gap: 10px;
-  min-width: 0;
-  color: #a1a1aa;
-}
-
-.idt-onboarding-guarantee svg {
-  flex: 0 0 auto;
-  margin-top: 3px;
-  color: #a3a3a3;
-}
-
-.idt-onboarding-guarantee div {
-  display: grid;
-  gap: 4px;
-}
-
-.idt-onboarding-guarantee strong {
-  color: #ffffff;
-  font-size: 0.88rem;
-}
-
-.idt-onboarding-guarantee span {
-  font-size: 0.8rem;
-  line-height: 1.45;
-}
-
 .idt-onboarding-stepper {
   display: grid;
   gap: 6px;
 }
 
 .idt-onboarding-step {
+  --step-accent: #ffffff;
+  --step-accent-bg: rgba(255, 255, 255, 0.045);
+  --step-accent-border: rgba(255, 255, 255, 0.28);
+  --step-accent-glow: rgba(255, 255, 255, 0.16);
+
   display: grid;
   grid-template-columns: 34px 1fr;
   align-items: center;
@@ -16002,15 +15958,43 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   color: #8a8a8a;
 }
 
+.idt-onboarding-step:nth-child(2) {
+  --step-accent: #9aa9d8;
+  --step-accent-bg: rgba(122, 144, 197, 0.055);
+  --step-accent-border: rgba(122, 144, 197, 0.18);
+  --step-accent-glow: rgba(122, 144, 197, 0.12);
+}
+
+.idt-onboarding-step:nth-child(3) {
+  --step-accent: #86c49f;
+  --step-accent-bg: rgba(105, 168, 130, 0.055);
+  --step-accent-border: rgba(105, 168, 130, 0.16);
+  --step-accent-glow: rgba(105, 168, 130, 0.1);
+}
+
+.idt-onboarding-step:nth-child(4) {
+  --step-accent: #c99f6f;
+  --step-accent-bg: rgba(184, 138, 82, 0.055);
+  --step-accent-border: rgba(184, 138, 82, 0.16);
+  --step-accent-glow: rgba(184, 138, 82, 0.1);
+}
+
+.idt-onboarding-step:nth-child(5) {
+  --step-accent: #d7908b;
+  --step-accent-bg: rgba(190, 109, 106, 0.055);
+  --step-accent-border: rgba(190, 109, 106, 0.16);
+  --step-accent-glow: rgba(190, 109, 106, 0.1);
+}
+
 .idt-onboarding-step-icon {
   display: grid;
   place-items: center;
   width: 34px;
   height: 34px;
   border-radius: 7px;
-  border: 1px solid #2a2a2a;
-  background: #000000;
-  color: #8a8a8a;
+  border: 1px solid var(--step-accent-border);
+  background: var(--step-accent-bg);
+  color: var(--step-accent);
 }
 
 .idt-onboarding-step-copy {
@@ -16039,9 +16023,10 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
 }
 
 .idt-onboarding-step.is-current .idt-onboarding-step-icon {
-  border-color: #4b5563;
-  background: #080808;
-  color: #ffffff;
+  border-color: var(--step-accent);
+  background: var(--step-accent-bg);
+  color: var(--step-accent);
+  box-shadow: 0 0 18px var(--step-accent-glow);
 }
 
 .idt-onboarding-step.is-current strong {
@@ -16049,9 +16034,9 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
 }
 
 .idt-onboarding-step.is-complete .idt-onboarding-step-icon {
-  border-color: #3a3a3a;
-  background: #050505;
-  color: #d4d4d4;
+  border-color: var(--step-accent-border);
+  background: var(--step-accent-bg);
+  color: var(--step-accent);
 }
 
 .idt-onboarding-outcome-label {
@@ -16068,7 +16053,7 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   gap: 14px;
   width: 100%;
   max-width: 480px;
-  margin-top: 22px;
+  margin-top: clamp(28px, 3.8vw, 44px);
 }
 
 .idt-onboarding-field {
@@ -16166,8 +16151,21 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  justify-content: flex-end;
   gap: 12px;
   margin-top: 12px;
+}
+
+.idt-btn-enter-cue {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 8px;
+  color: currentColor;
+  font-size: 0.98em;
+  font-weight: 900;
+  line-height: 1;
+  opacity: 0.52;
 }
 
 .idt-onboarding-shell .idt-btn-primary {
@@ -16396,10 +16394,6 @@ html[data-theme='light'] .idt-onboarding-shell .idt-btn-primary:focus-visible {
   .idt-onboarding-actions .idt-btn {
     justify-content: center;
     width: 100%;
-  }
-
-  .idt-onboarding-guarantees {
-    grid-template-columns: 1fr;
   }
 
   .idt-onboarding-stepper {


### PR DESCRIPTION
No issue: follow-up onboarding polish after #1407 merged.

## Summary
- Removed the topbar "Secure setup" subtitle and kept the Identrail wordmark vertically centered with the logo.
- Removed the left-rail "Launch path" heading so the stepper starts closer to "Setup progress," matching the right-side spacing rhythm.
- Shifted the main onboarding title upward and changed onboarding H1 text to a restrained purple tint aligned with the marketing-site purple system.
- Added subtle per-step accent colors to the onboarding step icons while keeping the rail minimal and premium.

## Impact
- Frontend-only visual polish for the onboarding shell.
- No onboarding API, persistence, or route behavior changes.

## Validation
- `git diff --check origin/dev...HEAD`
- `npm run test:ci --prefix web` (222 tests passed)
- `npm run build --prefix web` (39 routes prerendered)
- Local visual check on `/onboarding/org` with a mock API/session: confirmed "Secure setup" and "Launch path" are gone, the brand text aligns with the logo center, the title moved up, and the rail spacing now mirrors the "What happens next" column.

## AI Disclosure
- AI-assisted: yes
- Tools used: Codex
- Where used: onboarding frame markup and onboarding CSS polish
- Human verification performed: diff review, full web tests/build, and local browser visual verification with mocked onboarding API responses

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refined the onboarding shell and layout: tighter header and panel spacing, centered Identrail wordmark, removed “Secure setup,” “Launch path,” and the guarantees block, added subtle per‑step accent colors, and right‑aligned action buttons.

Added an Enter‑key submit hint via the new `EnterSubmitHint` component to primary actions across onboarding pages and `WorkOSMFAPage`, and retitled the Org step to “Define your boundary” with a “Create boundary” action; visual-only with no API, persistence, or routing changes.

<sup>Written for commit 37a06aabda202c4ffadefae150aaa5eaf0b4a443. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1409?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

