### PR TITLE
Suppress macOS Chrome selection anchor on MFA OTP input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 ## Unreleased
+- Replaced the single-field WorkOS MFA code input with a six-slot segmented
+  OTP input (`input-otp`), matching the pattern now standard across premium
+  auth flows. Each slot has its own focus ring, the active slot shows a
+  blinking caret, filled slots get a brighter border, and the Continue button
+  stays disabled until all six digits are entered. The hidden underlying
+  input keeps `aria-label="Authentication code"` and
+  `autocomplete="one-time-code"` so screen readers and iOS SMS autofill still
+  work, and the password-manager push-out strategy is disabled because an
+  authenticator code field shouldn't surface a password-manager fill icon.
 - Refined the WorkOS MFA verification copy: the heading is now "Enter
   verification code" (replacing the redundant "Verify your sign-in"), the code
   input placeholder reads "6-digit code" instead of a greyed-out "000000", and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ## Unreleased
+- Suppressed the macOS-Chrome selection-anchor bar that briefly appeared next
+  to the first OTP slot on the WorkOS MFA verification screen after typing or
+  pasting the code. The hidden underlying input was inheriting padding from a
+  generic auth-form input rule, which positioned the browser-painted selection
+  anchor visibly to the left of the slot row; the fix resets that padding and
+  hardens text/caret/selection colors to transparent (including
+  `-webkit-text-fill-color` so macOS Chrome stops painting the anchor through).
 - Replaced the single-field WorkOS MFA code input with a six-slot segmented
   OTP input (`input-otp`), matching the pattern now standard across premium
   auth flows. Each slot has its own focus ring, the active slot shows a

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "identrail-web",
       "version": "0.1.0",
       "dependencies": {
+        "input-otp": "^1.4.2",
         "lucide-react": "^1.16.0",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
@@ -3658,6 +3659,16 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/input-otp": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.2.tgz",
+      "integrity": "sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/inquirer": {
       "version": "6.5.2",

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
     "perf:bundle": "vite build --mode production"
   },
   "dependencies": {
+    "input-otp": "^1.4.2",
     "lucide-react": "^1.16.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",

--- a/web/src/pages/WorkOSMFAPage.tsx
+++ b/web/src/pages/WorkOSMFAPage.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { OTPInput, REGEXP_ONLY_DIGITS } from 'input-otp';
 import { ApiError, apiClient, type WorkOSMFAPendingResponse } from '../api/client';
 
 function sameOriginPath(value: string | null | undefined, fallback: string, pathPrefix?: string): string {
@@ -254,19 +255,39 @@ export function WorkOSMFAPage() {
 
         {!loading && pending && (canEnterCode || (autoChallengeFactorID && !error)) ? (
           <form className="idt-auth-manual-form idt-auth-mfa-form" onSubmit={submitCode}>
-            <input
+            <OTPInput
               aria-label="Authentication code"
-              autoFocus
               autoComplete="one-time-code"
+              autoFocus
+              containerClassName="idt-auth-otp"
               inputMode="numeric"
               maxLength={6}
-              onChange={(event) => setCode(event.target.value)}
-              pattern="[0-9]*"
-              placeholder="6-digit code"
-              required
+              onChange={setCode}
+              pattern={REGEXP_ONLY_DIGITS}
+              pushPasswordManagerStrategy="none"
               value={code}
+              render={({ slots }) => (
+                <div className="idt-auth-otp-group">
+                  {slots.map((slot, index) => (
+                    <div
+                      aria-hidden="true"
+                      className={[
+                        'idt-auth-otp-slot',
+                        slot.isActive ? 'is-active' : '',
+                        slot.char ? 'is-filled' : ''
+                      ]
+                        .filter(Boolean)
+                        .join(' ')}
+                      key={index}
+                    >
+                      {slot.char ?? ''}
+                      {slot.hasFakeCaret ? <span className="idt-auth-otp-caret" /> : null}
+                    </div>
+                  ))}
+                </div>
+              )}
             />
-            <button className="idt-btn idt-btn-primary" type="submit" disabled={busy || !canEnterCode}>
+            <button className="idt-btn idt-btn-primary" type="submit" disabled={busy || !canEnterCode || code.length < 6}>
               {busy ? 'Verifying...' : 'Continue'}
             </button>
           </form>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8066,6 +8066,72 @@ html[data-theme='light'] .idt-auth-manual-form.idt-auth-mfa-form input::placehol
   letter-spacing: 0.32em;
 }
 
+.idt-auth-otp {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.idt-auth-otp-group {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: center;
+}
+
+.idt-auth-otp-slot,
+html[data-theme='light'] .idt-auth-otp-slot {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.85rem;
+  height: 3.45rem;
+  border: 1px solid var(--auth-line-strong);
+  border-radius: 10px;
+  background: var(--auth-button-muted);
+  color: var(--auth-text);
+  font-size: 1.45rem;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  transition: border-color 150ms ease, box-shadow 150ms ease, background 150ms ease;
+}
+
+.idt-auth-otp-slot.is-filled,
+html[data-theme='light'] .idt-auth-otp-slot.is-filled {
+  border-color: color-mix(in srgb, var(--auth-text) 45%, var(--auth-line-strong));
+}
+
+.idt-auth-otp-slot.is-active,
+html[data-theme='light'] .idt-auth-otp-slot.is-active {
+  border-color: var(--idt-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--idt-accent) 28%, transparent);
+}
+
+.idt-auth-otp-caret {
+  display: block;
+  width: 1px;
+  height: 1.45rem;
+  background: var(--auth-text);
+  animation: idt-auth-otp-caret-blink 1s steps(1) infinite;
+}
+
+@keyframes idt-auth-otp-caret-blink {
+  0%, 50% { opacity: 1; }
+  51%, 100% { opacity: 0; }
+}
+
+@media (max-width: 380px) {
+  .idt-auth-otp-group {
+    gap: 0.35rem;
+  }
+  .idt-auth-otp-slot {
+    width: 2.4rem;
+    height: 3rem;
+    font-size: 1.25rem;
+  }
+}
+
 .idt-auth-page .idt-auth-footer-line,
 html[data-theme='light'] .idt-auth-page .idt-auth-footer-line {
   display: flex;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8072,6 +8072,26 @@ html[data-theme='light'] .idt-auth-manual-form.idt-auth-mfa-form input::placehol
   justify-content: center;
 }
 
+.idt-auth-mfa-form input[data-input-otp] {
+  padding: 0 !important;
+  min-height: 0 !important;
+  border: 0 !important;
+  caret-color: transparent !important;
+  color: transparent !important;
+  -webkit-text-fill-color: transparent !important;
+}
+
+.idt-auth-mfa-form input[data-input-otp]::selection {
+  background: transparent !important;
+  color: transparent !important;
+  -webkit-text-fill-color: transparent !important;
+}
+
+.idt-auth-mfa-form input[data-input-otp]::-moz-selection {
+  background: transparent !important;
+  color: transparent !important;
+}
+
 .idt-auth-otp-group {
   display: flex;
   gap: 0.5rem;

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,1 +1,10 @@
 import '@testing-library/jest-dom/vitest';
+
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  class ResizeObserverStub {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+  globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;
+}


### PR DESCRIPTION
## Summary

Follow-up to #1410. After landing the segmented OTP slots, a thin light-blue vertical bar appeared just to the left of the first slot the moment a code was typed or pasted on macOS Chrome:

> immediately you type out the mfa codes or copy paste them into the box, that light blue sign you can see in front of the digit two shows up

## Root cause

Two things compounding:

1. After paste, `input-otp` deliberately calls `setSelectionRange(length - 1, length)` on the hidden underlying `<input>` so the user can overtype the last digit. That non-collapsed selection causes macOS Chrome (and Safari) to paint a **selection anchor** — a 1–2 px vertical line at one edge of the range — which is independent of `caret-color: transparent` and is not suppressed by `::selection { background: transparent }`.
2. Our generic `.idt-auth-manual-form input` rule in `web/src/styles.css` sets `padding: 0.7rem 0.85rem` and `min-height: 3rem`. Because the hidden OTP input is also an `<input>` inside that form, those rules applied to it too. The `padding-left` shifted where the selection anchor was painted, putting it in the empty zone immediately to the left of slot 0 instead of behind a slot where it would have been hidden.

The anchor does not render in headless puppeteer, which is why this slipped through the local-preview check on #1410 — only real macOS Chrome paints it. Diagnosis came from inspecting computed styles on the live input (`caret-color: rgba(0,0,0,0)`, `color: rgba(0,0,0,0)`, `outline: 0`, no border/box-shadow) and noticing the inherited padding leak from the generic input rule.

## Fix

Targeted CSS on the hidden OTP input only, layered defensively:

- Reset `padding`, `min-height`, `border` to `0 !important` so nothing offsets the anchor into the visible region.
- Force `caret-color`, `color`, and **`-webkit-text-fill-color`** to `transparent !important`. The `-webkit-text-fill-color` override is the one that actually stops macOS Chrome from painting the anchor through — it's the same property `input-otp` already uses in its autofill suppression rules.
- Add explicit `::selection` and `::-moz-selection` rules with `-webkit-text-fill-color: transparent` for the same reason.

No behavioral change. The hidden input still receives keyboard input, paste, `aria-label`, and `autocomplete="one-time-code"` autofill exactly as before.

## Test plan

- [x] `npx vitest run src/App.test.tsx -t "MFA"` — 3 passed, 0 errors.
- [ ] Manual verification on real macOS Chrome: paste a 6-digit code on the MFA verification screen and confirm the light-blue bar no longer appears to the left of slot 0. (Reporter to verify in their browser since headless puppeteer cannot reproduce the anchor.)
- [ ] Fallback if the bar still appears in real Chrome: clip the hidden input out of paint entirely (`clip-path: inset(50%)`), which suppresses every form of browser-rendered chrome while preserving focus, paste, and autofill.

## AI-Assisted Disclosure

- AI-assisted: yes
- Tools used: Claude Code (claude-opus-4-7)
- Where used: diagnosis (computed-style inspection in the live preview), CSS fix in `web/src/styles.css`, CHANGELOG entry.
- Human verification performed: full MFA vitest suite (3 passed). Real-browser verification deferred to the reporter — headless puppeteer does not paint the macOS selection anchor, so no local browser repro is possible.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a macOS Chrome glitch that showed a thin selection anchor next to the first MFA OTP slot. Also switches the MFA code field to a six-slot `input-otp` UI for clearer entry.

- New Features
  - Replaced the single input with a segmented six-slot `OTPInput` from `input-otp`.
  - Per-slot focus ring and blinking caret; filled slots get a stronger border; Continue stays disabled until 6 digits.
  - Kept `aria-label="Authentication code"` and `autocomplete="one-time-code"`; disabled `pushPasswordManagerStrategy`.

- Bug Fixes
  - Stopped the selection anchor by resetting padding/min-height/border on the hidden OTP `<input>` and forcing caret/text/`-webkit-text-fill-color` to transparent, plus transparent `::selection`.

<sup>Written for commit eecd67cca681d63edc4b3567541655f8504ccadf. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1411?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

