### PR TITLE
Tighten onboarding workspace copy

### DIFF
--- a/web/src/components/common/EnterSubmitHint.tsx
+++ b/web/src/components/common/EnterSubmitHint.tsx
@@ -1,9 +1,7 @@
-import { CornerDownLeft } from 'lucide-react';
-
 export function EnterSubmitHint() {
   return (
     <span className="idt-btn-enter-cue" aria-hidden="true">
-      <CornerDownLeft size={15} strokeWidth={2.45} />
+      ↵
     </span>
   );
 }

--- a/web/src/pages/onboarding/ConnectPage.tsx
+++ b/web/src/pages/onboarding/ConnectPage.tsx
@@ -193,9 +193,7 @@ export function ConnectPage() {
   return (
     <OnboardingFrame
       step="connect"
-      eyebrow="Source"
-      title="Connect one source"
-      description="Start read-only. Add more sources later."
+      title="Connect source"
     >
       {loading ? <p className="idt-muted-strong">Checking available connectors...</p> : null}
       {error ? (

--- a/web/src/pages/onboarding/InvitePage.tsx
+++ b/web/src/pages/onboarding/InvitePage.tsx
@@ -133,9 +133,7 @@ export function InvitePage() {
   return (
     <OnboardingFrame
       step="invite"
-      eyebrow="Team"
-      title="Invite reviewers"
-      description="Add teammates who will own findings."
+      title="Invite team"
     >
       {loading ? <p className="idt-muted-strong">Preparing invite controls...</p> : null}
       {error ? (

--- a/web/src/pages/onboarding/ScanPage.tsx
+++ b/web/src/pages/onboarding/ScanPage.tsx
@@ -130,9 +130,7 @@ export function ScanPage() {
   return (
     <OnboardingFrame
       step="scan"
-      eyebrow="First scan"
-      title="Run a baseline scan"
-      description="Confirm the source, queue, and findings path."
+      title="Run scan"
     >
       {loading ? <p className="idt-muted-strong">Loading scan readiness...</p> : null}
       {error ? (

--- a/web/src/pages/onboarding/WorkspacePage.tsx
+++ b/web/src/pages/onboarding/WorkspacePage.tsx
@@ -96,9 +96,7 @@ export function WorkspacePage() {
   return (
     <OnboardingFrame
       step="workspace"
-      eyebrow="Workspace"
-      title="Name your first workspace"
-      description="Keep scans, sources, projects, and members in one scope."
+      title="Name workspace"
     >
       {loading ? <p className="idt-muted-strong">Loading workspace setup...</p> : null}
       {error ? (
@@ -131,7 +129,7 @@ export function WorkspacePage() {
           </div>
         </div>
         <div className="idt-onboarding-field">
-          <label htmlFor="project-name">First project</label>
+          <label htmlFor="project-name">Project name</label>
           <div className={projectNameError ? 'idt-onboarding-input-wrap has-error' : 'idt-onboarding-input-wrap'}>
             <input
               id="project-name"

--- a/web/src/pages/onboarding/onboarding.test.tsx
+++ b/web/src/pages/onboarding/onboarding.test.tsx
@@ -100,6 +100,21 @@ describe('onboarding pages', () => {
     setFeatureFlagEnv(false);
   });
 
+  it('shows dashboard as the terminal next step after onboarding is complete', async () => {
+    vi.resetModules();
+    const { OnboardingFrame } = await import('./onboardingUtils');
+
+    renderOnboarding(
+      <OnboardingFrame step="complete" title="Ready">
+        <div />
+      </OnboardingFrame>,
+      '/onboarding/complete'
+    );
+
+    expect(screen.getByLabelText('Next steps')).toHaveTextContent('Open dashboard');
+    expect(screen.queryByText('Create boundary')).not.toBeInTheDocument();
+  });
+
   it('creates an organization and routes to workspace setup', async () => {
     const { apiClient, OrgPage } = await loadOnboardingModules();
     const startState = state({ current_step: 'org' });

--- a/web/src/pages/onboarding/onboarding.test.tsx
+++ b/web/src/pages/onboarding/onboarding.test.tsx
@@ -163,9 +163,9 @@ describe('onboarding pages', () => {
 
     renderOnboarding(<WorkspacePage />, '/onboarding/workspace');
 
-    expect(await screen.findByRole('heading', { name: 'Name your first workspace' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Name workspace' })).toBeInTheDocument();
     const workspaceInput = screen.getByLabelText('Workspace name');
-    const projectInput = screen.getByLabelText('First project');
+    const projectInput = screen.getByLabelText('Project name');
     expect(workspaceInput).toHaveValue('');
     expect(projectInput).toHaveValue('');
     fireEvent.click(screen.getByRole('button', { name: 'Create workspace' }));
@@ -202,7 +202,7 @@ describe('onboarding pages', () => {
     renderOnboarding(<WorkspacePage />, '/onboarding/workspace');
 
     const workspaceInput = await screen.findByLabelText('Workspace name');
-    const projectInput = screen.getByLabelText('First project');
+    const projectInput = screen.getByLabelText('Project name');
     fireEvent.change(workspaceInput, { target: { value: 'Production' } });
     fireEvent.change(projectInput, { target: { value: 'Identity Control Plane' } });
     fireEvent.click(screen.getByRole('button', { name: 'Create workspace' }));

--- a/web/src/pages/onboarding/onboardingUtils.tsx
+++ b/web/src/pages/onboarding/onboardingUtils.tsx
@@ -123,7 +123,19 @@ export async function loadOrStartOnboarding(): Promise<OnboardingState> {
   return (await loadOrStartOnboardingResponse()).state;
 }
 
-const NEXT_STEPS = ['Create boundary', 'Name workspace', 'Connect source', 'Run scan'];
+const NEXT_STEPS: Array<{ id: OnboardingStep; label: string }> = [
+  { id: 'org', label: 'Create boundary' },
+  { id: 'workspace', label: 'Name workspace' },
+  { id: 'connect', label: 'Connect source' },
+  { id: 'scan', label: 'Run scan' },
+  { id: 'invite', label: 'Invite team' }
+];
+
+function nextStepsFor(step: OnboardingStep): Array<{ id: OnboardingStep | 'dashboard'; label: string }> {
+  const currentIndex = NEXT_STEPS.findIndex((item) => item.id === step);
+  const remaining = currentIndex >= 0 ? NEXT_STEPS.slice(currentIndex + 1) : NEXT_STEPS;
+  return remaining.length > 0 ? remaining : [{ id: 'dashboard', label: 'Open dashboard' }];
+}
 
 export function OnboardingFrame({
   step,
@@ -138,6 +150,8 @@ export function OnboardingFrame({
   description?: string;
   children: ReactNode;
 }) {
+  const remainingSteps = nextStepsFor(step);
+
   return (
     <section className="idt-onboarding-shell">
       <header className="idt-onboarding-topbar">
@@ -168,12 +182,12 @@ export function OnboardingFrame({
             {description ? <p>{description}</p> : null}
             {children}
           </div>
-          <aside className="idt-onboarding-outcome" aria-label="What happens next">
-            <p className="idt-onboarding-outcome-label">What happens next</p>
+          <aside className="idt-onboarding-outcome" aria-label="Next steps">
+            <p className="idt-onboarding-outcome-label">Next</p>
             <ol>
-              {NEXT_STEPS.map((item) => (
-                <li key={item}>
-                  <span>{item}</span>
+              {remainingSteps.map((item) => (
+                <li key={item.id}>
+                  <span>{item.label}</span>
                   <ArrowRight size={14} strokeWidth={2.2} aria-hidden="true" />
                 </li>
               ))}

--- a/web/src/pages/onboarding/onboardingUtils.tsx
+++ b/web/src/pages/onboarding/onboardingUtils.tsx
@@ -133,7 +133,10 @@ const NEXT_STEPS: Array<{ id: OnboardingStep; label: string }> = [
 
 function nextStepsFor(step: OnboardingStep): Array<{ id: OnboardingStep | 'dashboard'; label: string }> {
   const currentIndex = NEXT_STEPS.findIndex((item) => item.id === step);
-  const remaining = currentIndex >= 0 ? NEXT_STEPS.slice(currentIndex + 1) : NEXT_STEPS;
+  if (currentIndex < 0) {
+    return [{ id: 'dashboard', label: 'Open dashboard' }];
+  }
+  const remaining = NEXT_STEPS.slice(currentIndex + 1);
   return remaining.length > 0 ? remaining : [{ id: 'dashboard', label: 'Open dashboard' }];
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -16162,9 +16162,9 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
 
 .idt-onboarding-form input:focus-visible,
 .idt-onboarding-form textarea:focus-visible {
-  outline: 2px solid #ffffff;
-  outline-offset: 2px;
-  border-color: #ffffff;
+  outline: 0;
+  border-color: rgba(142, 167, 255, 0.78);
+  box-shadow: 0 0 0 3px rgba(142, 167, 255, 0.14);
 }
 
 .idt-onboarding-form textarea {
@@ -16207,22 +16207,20 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   align-items: center;
   justify-content: center;
   flex: none;
-  width: 1em;
-  height: 1em;
+  min-width: 1.3rem;
+  height: 1.16rem;
+  padding: 0 0.28rem;
   margin-left: 0;
+  border: 1px solid color-mix(in srgb, currentColor 28%, transparent);
+  border-radius: 6px;
+  background: color-mix(in srgb, currentColor 10%, transparent);
   color: currentColor;
-  font-size: 1em;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.72rem;
   font-weight: 900;
   line-height: 1;
   opacity: 1;
-  transform: translateY(0.02em);
-}
-
-.idt-btn-enter-cue svg {
-  display: block;
-  width: 100%;
-  height: 100%;
-  stroke: currentColor;
+  transform: translateY(0.01em);
 }
 
 .idt-onboarding-shell .idt-btn-primary {


### PR DESCRIPTION
## Summary
- shorten workspace and later onboarding step copy to remove repeated labels
- make the onboarding side rail show only remaining steps
- replace the enter cue with a GitHub-style return key glyph and soften onboarding focus rings

## Tests
- npm run test:ci --prefix web
- npm run build --prefix web

No issue: follow-up polish after merged onboarding redesign PR #1412.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished onboarding: shorter step titles and labels, a smarter Next rail that only shows what’s left (and the dashboard at the end), and a cleaner return-key cue with softer focus rings.

- **New Features**
  - Shortened page titles and labels (e.g., “Name workspace”, “Project name”, “Connect source”, “Run scan”, “Invite team”).
  - Next rail now shows only remaining steps with a “Next” label; adds “Invite team” and shows “Open dashboard” when complete.
  - Replaced `lucide-react` enter icon with a return-key glyph and restyled the cue.
  - Softened input focus rings; updated tests for the new copy and completed-step behavior.

<sup>Written for commit a03cf2520c5351ef07c2730aa57e54008ad4239c. Summary will update on new commits. <a href="https://cubic.dev/pr/identrail/identrail/pull/1415?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

