### PR TITLE
Polish domain navigation flyouts

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1497,7 +1497,8 @@ describe('App', () => {
 
     await waitFor(() => expect(window.location.pathname).toBe('/app/tenant-a/workspace-a/projects/project-1'));
     expect(window.location.search).toBe('?source=aws');
-    expect(await screen.findByRole('heading', { level: 2, name: /Connect project sources/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: /Connect AWS/i })).toBeInTheDocument();
+    expect(within(screen.getByLabelText('AWS source')).queryByRole('button', { name: /GitHub/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Projects' })).not.toBeInTheDocument();
   });
 

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -174,6 +174,7 @@ async function renderProjectDetail(
   githubBackend: BackendFeatureState,
   githubConnection = connectedGitHub,
   options: {
+    initialEntry?: string;
     repoScanError?: { message: string; status: number; code?: string; detail?: string };
     repoScans?: RepoScanRecord[];
     listRepoScans?: () => Promise<{ items: RepoScanRecord[] }>;
@@ -292,7 +293,7 @@ async function renderProjectDetail(
   }
 
   render(
-    <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/projects/project-1']}>
+    <MemoryRouter initialEntries={[options.initialEntry ?? '/app/tenant-a/workspace-a/projects/project-1']}>
       <Routes>
         <Route path="/app/:tenantID/:workspaceID/projects/:projectID" element={<ProjectDetailHarness />} />
       </Routes>
@@ -358,7 +359,7 @@ describe('ProductShellLayout', () => {
     vi.resetModules();
   });
 
-  it('limits default source logo stacks to feature-enabled connectors', async () => {
+  it('keeps source logo stacks feature-scoped while domain sections stay discoverable', async () => {
     vi.resetModules();
     vi.doMock('./pages/onboarding/onboardingUtils', async (importOriginal) => {
       const actual = await importOriginal<typeof import('./pages/onboarding/onboardingUtils')>();
@@ -395,8 +396,8 @@ describe('ProductShellLayout', () => {
     expect(screen.getAllByRole('img', { name: 'AWS' }).length).toBeGreaterThan(0);
     expect(screen.queryByRole('img', { name: 'GitHub' })).not.toBeInTheDocument();
     expect(screen.queryByRole('img', { name: 'Kubernetes' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'GitHub' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Kubernetes' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'GitHub' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Kubernetes' })).toBeInTheDocument();
   });
 });
 
@@ -432,6 +433,12 @@ describe('ProductShellLayout', () => {
     expect(screen.queryByRole('link', { name: 'Projects' })).not.toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Findings' })).not.toBeInTheDocument();
 
+    expect(screen.getByRole('link', { name: 'Overview' })).toHaveClass('active');
+    fireEvent.click(screen.getByRole('button', { name: 'AWS' }));
+    expect(screen.getByRole('link', { name: 'Overview' })).not.toHaveClass('active');
+    expect(screen.getByRole('button', { name: 'AWS' })).toHaveClass('is-open');
+    fireEvent.keyDown(window, { key: 'Escape' });
+
     fireEvent.click(screen.getByRole('button', { name: 'GitHub' }));
     const githubFlyout = screen.getByRole('dialog', { name: 'GitHub' });
     expect(within(githubFlyout).getByRole('link', { name: /Open GitHub Control Center/i })).toBeInTheDocument();
@@ -450,7 +457,7 @@ describe('ProductShellLayout', () => {
     expect(await screen.findByRole('heading', { level: 2, name: /GitHub findings content/i })).toBeInTheDocument();
   });
 
-  it('disables GitHub domain navigation when the API does not advertise the connector', async () => {
+  it('keeps GitHub domain navigation open when the connector is unavailable', async () => {
     vi.resetModules();
     vi.doMock('./pages/onboarding/onboardingUtils', async (importOriginal) => {
       const actual = await importOriginal<typeof import('./pages/onboarding/onboardingUtils')>();
@@ -474,14 +481,15 @@ describe('ProductShellLayout', () => {
       </MemoryRouter>
     );
 
-    const githubButton = screen.getByRole('button', { name: /GitHub: Not available on this API server/i });
-    expect(githubButton).toBeDisabled();
+    const githubButton = screen.getByRole('button', { name: 'GitHub' });
+    expect(githubButton).not.toBeDisabled();
     fireEvent.click(githubButton);
-    expect(screen.queryByRole('dialog', { name: 'GitHub' })).not.toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'GitHub' })).toBeInTheDocument();
 
     fireEvent.keyDown(window, { key: '/' });
     expect(screen.getByRole('dialog', { name: /Go to anything/i })).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText(/Search workspace commands/i), { target: { value: 'github' } });
+    expect(screen.getAllByRole('option', { name: /^GitHub\b/i }).length).toBeGreaterThan(0);
     expect(screen.queryByRole('option', { name: /Connect GitHub/i })).not.toBeInTheDocument();
   });
 });
@@ -674,6 +682,18 @@ describe('ProductProjectDetailPage', () => {
       'project-1',
       expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
     );
+  });
+
+  it('scopes domain connect pages to the requested provider', async () => {
+    await renderProjectDetail(true, connectedGitHub, {
+      initialEntry: '/app/tenant-a/workspace-a/projects/project-1?source=github'
+    });
+
+    expect(await screen.findByRole('heading', { level: 2, name: 'Connect GitHub' })).toBeInTheDocument();
+    const picker = screen.getByLabelText('GitHub source');
+    expect(within(picker).getByRole('button', { name: /GitHub/i })).toBeInTheDocument();
+    expect(within(picker).queryByRole('button', { name: /AWS/i })).not.toBeInTheDocument();
+    expect(within(picker).queryByRole('button', { name: /Kubernetes/i })).not.toBeInTheDocument();
   });
 
   it('opens GitHub installation in a new tab through GitHub account picker', async () => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1145,7 +1145,7 @@ function sourceConnection(connections: SourceConnectionMap, provider: SourceProv
 function buildSourceAvailability(backendFeatures: BackendFeatures): Record<SourceProvider, SourceAvailability> {
   return {
     github: {
-      visible: FEATURE_CONNECTOR_GITHUB_V2,
+      visible: true,
       available: isFeatureAvailable(FEATURE_CONNECTOR_GITHUB_V2, backendFeatures.connectors.github),
       unavailableMessage: backendFeatures.connectors.github === false ? 'Not available on this API server.' : undefined
     },
@@ -1154,7 +1154,7 @@ function buildSourceAvailability(backendFeatures: BackendFeatures): Record<Sourc
       available: true
     },
     kubernetes: {
-      visible: FEATURE_CONNECTOR_K8S,
+      visible: true,
       available: isFeatureAvailable(FEATURE_CONNECTOR_K8S, backendFeatures.connectors.kubernetes),
       unavailableMessage: backendFeatures.connectors.kubernetes === false ? 'Not available on this API server.' : undefined
     }
@@ -1925,7 +1925,16 @@ function findActiveDomainRouteID(
 
 function SidebarDomainIcon({ domain }: { domain: SourceProvider }) {
   const asset = getDomainAsset(domain);
-  return <img src={asset.logoSrc} alt="" aria-hidden="true" loading="lazy" decoding="async" />;
+  return (
+    <img
+      className={`idt-sidebar-domain-logo is-${domain}`}
+      src={asset.logoSrc}
+      alt=""
+      aria-hidden="true"
+      loading="lazy"
+      decoding="async"
+    />
+  );
 }
 
 function ProductDomainFlyoutRouteLink({
@@ -1957,15 +1966,17 @@ function ProductDomainFlyoutRouteLink({
     >
       <span className="idt-domain-flyout-link-copy">
         <strong>{route.label}</strong>
-        <span>{route.eyebrow}</span>
-      </span>
-      <span className="idt-domain-flyout-link-meta">
-        {route.id === 'connect' ? 'Connect / scan' : route.id.includes('findings') ? 'Findings' : route.phase}
       </span>
       <ChevronRight size={14} strokeWidth={1.8} aria-hidden="true" />
     </Link>
   );
 }
+
+const DOMAIN_FLYOUT_SUMMARIES: Record<SourceProvider, string> = {
+  aws: 'Machine identities, resources, runtime, risk.',
+  github: 'Repositories, Actions, agentic surfaces, risk.',
+  kubernetes: 'Clusters, workloads, service accounts, RBAC.'
+};
 
 function ProductDomainFlyout({
   domain,
@@ -2008,23 +2019,28 @@ function ProductDomainFlyout({
           <img src={asset.logoSrc} alt="" loading="lazy" decoding="async" />
         </span>
         <div>
-          <p>{config.navLabel} section</p>
+          <p>Section</p>
           <h2>{config.navLabel}</h2>
-          <span>{config.description}</span>
+          <span>{DOMAIN_FLYOUT_SUMMARIES[domain]}</span>
         </div>
       </header>
 
       <div className="idt-domain-flyout-actions">
-        <Link data-domain-flyout-primary="true" to={domainHome} onClick={onClose}>
-          Open {config.navLabel} Control Center
+        <Link
+          data-domain-flyout-primary="true"
+          to={domainHome}
+          aria-label={`Open ${config.navLabel} Control Center`}
+          onClick={onClose}
+        >
+          Control Center
         </Link>
-        <Link to={connectPath} onClick={onClose}>
-          Connect / scan
+        <Link to={connectPath} aria-label={`Connect ${config.navLabel}`} onClick={onClose}>
+          Connect
         </Link>
       </div>
 
       <div className="idt-domain-flyout-section">
-        <span className="idt-domain-flyout-section-label">Start here</span>
+        <span className="idt-domain-flyout-section-label">Start</span>
         <div className="idt-domain-flyout-list">
           {startRoutes.map((route) => (
             <ProductDomainFlyoutRouteLink
@@ -2041,7 +2057,7 @@ function ProductDomainFlyout({
 
       {surfaceRoutes.length ? (
         <div className="idt-domain-flyout-section">
-          <span className="idt-domain-flyout-section-label">Inventory and evidence</span>
+          <span className="idt-domain-flyout-section-label">Inventory</span>
           <div className="idt-domain-flyout-list">
             {surfaceRoutes.map((route) => (
               <ProductDomainFlyoutRouteLink
@@ -2064,7 +2080,7 @@ function ProductDomainFlyout({
             <summary>
               <span>
                 <strong>{route.label}</strong>
-                <small>{route.eyebrow}</small>
+                <small>Agent surfaces</small>
               </span>
               <ChevronDown size={14} strokeWidth={1.8} aria-hidden="true" />
             </summary>
@@ -2094,7 +2110,7 @@ function ProductDomainFlyout({
 
       {riskRoutes.length ? (
         <div className="idt-domain-flyout-section">
-          <span className="idt-domain-flyout-section-label">Findings and action</span>
+          <span className="idt-domain-flyout-section-label">Risk</span>
           <div className="idt-domain-flyout-list">
             {riskRoutes.map((route) => (
               <ProductDomainFlyoutRouteLink
@@ -2489,7 +2505,7 @@ export function ProductShellLayout() {
       }
     ];
 
-    if (sourceAvailability.aws.available) {
+    if (sourceAvailability.aws.visible) {
       items.push({
         id: 'aws',
         label: 'AWS',
@@ -2498,35 +2514,30 @@ export function ProductShellLayout() {
         path: `${basePath}/aws`
       });
       items.push({
-        id: 'aws-connect',
-        label: 'Connect AWS',
-        description: 'Start AWS account and identity onboarding',
-        keywords: ['aws', 'connect', 'account', 'role'],
-        path: `${basePath}/aws/connect`
-      });
-      items.push({
         id: 'aws-findings',
         label: 'AWS findings',
         description: 'Domain-scoped AWS risk queue',
         keywords: ['aws', 'findings', 'risk', 'iam'],
         path: `${basePath}/aws/findings`
       });
+      if (sourceAvailability.aws.available) {
+        items.push({
+          id: 'aws-connect',
+          label: 'Connect AWS',
+          description: 'Start AWS account and identity onboarding',
+          keywords: ['aws', 'connect', 'account', 'role'],
+          path: `${basePath}/aws/connect`
+        });
+      }
     }
 
-    if (sourceAvailability.github.available) {
+    if (sourceAvailability.github.visible) {
       items.push({
         id: 'github',
         label: 'GitHub',
         description: 'Repositories, Actions/OIDC, and agentic risk',
         keywords: ['github', 'repositories', 'actions', 'oidc'],
         path: `${basePath}/github`
-      });
-      items.push({
-        id: 'github-connect',
-        label: 'Connect GitHub',
-        description: 'Start GitHub App onboarding',
-        keywords: ['github', 'connect', 'app', 'install'],
-        path: `${basePath}/github/connect`
       });
       items.push({
         id: 'github-findings',
@@ -2543,9 +2554,18 @@ export function ProductShellLayout() {
         keywords: ['github', 'agentic', 'ai', 'mcp', 'tools', 'prompts', 'secrets', 'workflow'],
         path: `${basePath}/github/agentic-risk`
       });
+      if (sourceAvailability.github.available) {
+        items.push({
+          id: 'github-connect',
+          label: 'Connect GitHub',
+          description: 'Start GitHub App onboarding',
+          keywords: ['github', 'connect', 'app', 'install'],
+          path: `${basePath}/github/connect`
+        });
+      }
     }
 
-    if (sourceAvailability.kubernetes.available) {
+    if (sourceAvailability.kubernetes.visible) {
       items.push({
         id: 'kubernetes',
         label: 'Kubernetes',
@@ -2554,19 +2574,21 @@ export function ProductShellLayout() {
         path: `${basePath}/kubernetes`
       });
       items.push({
-        id: 'kubernetes-connect',
-        label: 'Connect Kubernetes',
-        description: 'Start cluster onboarding',
-        keywords: ['kubernetes', 'k8s', 'connect', 'cluster'],
-        path: `${basePath}/kubernetes/connect`
-      });
-      items.push({
         id: 'kubernetes-findings',
         label: 'Kubernetes findings',
         description: 'Cluster and service-account risk queue',
         keywords: ['kubernetes', 'k8s', 'findings', 'rbac'],
         path: `${basePath}/kubernetes/findings`
       });
+      if (sourceAvailability.kubernetes.available) {
+        items.push({
+          id: 'kubernetes-connect',
+          label: 'Connect Kubernetes',
+          description: 'Start cluster onboarding',
+          keywords: ['kubernetes', 'k8s', 'connect', 'cluster'],
+          path: `${basePath}/kubernetes/connect`
+        });
+      }
     }
 
     items.push(
@@ -2669,10 +2691,21 @@ export function ProductShellLayout() {
   }, [commandOpen]);
 
   useEffect(() => {
-    if (openDomainFlyout && !sourceAvailability[openDomainFlyout].available) {
-      setOpenDomainFlyout(null);
+    if (!openDomainFlyout || typeof document === 'undefined') {
+      return undefined;
     }
-  }, [openDomainFlyout, sourceAvailability]);
+
+    const root = document.documentElement;
+    const body = document.body;
+    const previousRootOverflow = root.style.overflow;
+    const previousBodyOverflow = body.style.overflow;
+    root.style.overflow = 'hidden';
+    body.style.overflow = 'hidden';
+    return () => {
+      root.style.overflow = previousRootOverflow;
+      body.style.overflow = previousBodyOverflow;
+    };
+  }, [openDomainFlyout]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -2991,7 +3024,14 @@ export function ProductShellLayout() {
 
           <nav className="idt-app-shell-nav" aria-label="App sections">
             <div className="idt-app-nav-group-label" aria-hidden={sidebarCollapsed}>Control plane</div>
-            <NavLink to={basePath} end aria-label="Overview" title={sidebarCollapsed ? 'Overview' : undefined} onClick={closeDomainFlyout}>
+            <NavLink
+              to={basePath}
+              end
+              aria-label="Overview"
+              title={sidebarCollapsed ? 'Overview' : undefined}
+              className={({ isActive }) => (isActive && !openDomainFlyout ? 'active' : undefined)}
+              onClick={closeDomainFlyout}
+            >
               <span className="idt-app-nav-icon" aria-hidden="true">
                 <LayoutDashboard size={16} strokeWidth={1.75} />
               </span>
@@ -3000,7 +3040,6 @@ export function ProductShellLayout() {
             {visibleDomainOrder.map((domain) => {
               const config = PRODUCT_DOMAIN_CONFIGS[domain];
               const availability = sourceAvailability[domain];
-              const isAvailable = availability.available;
               const isActive = activeDomain === domain;
               const isOpen = openDomainFlyout === domain;
               const triggerID = `idt-${domain}-domain-trigger`;
@@ -3012,20 +3051,16 @@ export function ProductShellLayout() {
                       domainTriggerRefs.current[domain] = node;
                     }}
                     type="button"
-                    className={`idt-app-nav-domain-trigger${isActive ? ' is-active' : ''}${isOpen ? ' is-open' : ''}${isAvailable ? '' : ' is-unavailable'}`}
-                    disabled={!isAvailable}
+                    className={`idt-app-nav-domain-trigger${isActive ? ' is-active' : ''}${isOpen ? ' is-open' : ''}`}
+                    data-connector-available={availability.available ? 'true' : 'false'}
                     aria-haspopup="dialog"
                     aria-expanded={isOpen}
                     aria-controls={isOpen ? `idt-${domain}-domain-flyout` : undefined}
-                    aria-label={
-                      isAvailable
-                        ? config.navLabel
-                        : `${config.navLabel}: ${availability.unavailableMessage ?? 'Unavailable'}`
-                    }
+                    aria-label={config.navLabel}
                     title={
                       sidebarCollapsed
                         ? config.navLabel
-                        : !isAvailable
+                        : !availability.available
                           ? availability.unavailableMessage ?? 'Unavailable'
                           : undefined
                     }
@@ -4952,9 +4987,18 @@ export function ProductProjectDetailPage() {
   const repoScanSubmitSequenceRef = useRef(0);
   const githubPostureRequestRef = useRef(0);
   const sourceAvailability = useMemo(() => buildSourceAvailability(backendFeatures), [backendFeatures]);
+  const selectedSourceFromConnect = useMemo(() => {
+    return normalizeSourceProvider(new URLSearchParams(location.search).get('source'));
+  }, [location.search]);
+  const sourceScope = useMemo(() => {
+    if (!selectedSourceFromConnect || !sourceAvailability[selectedSourceFromConnect]?.visible) {
+      return null;
+    }
+    return selectedSourceFromConnect;
+  }, [selectedSourceFromConnect, sourceAvailability]);
   const sourceOrder = useMemo(
-    () => SOURCE_ORDER.filter((provider) => sourceAvailability[provider].visible),
-    [sourceAvailability]
+    () => (sourceScope ? [sourceScope] : SOURCE_ORDER.filter((provider) => sourceAvailability[provider].visible)),
+    [sourceAvailability, sourceScope]
   );
   const actionableSourceOrder = useMemo(
     () => sourceOrder.filter((provider) => sourceAvailability[provider].available),
@@ -4966,10 +5010,9 @@ export function ProductProjectDetailPage() {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [submitting, setSubmitting] = useState<SourceProvider | ''>('');
-  const [selectedSource, setSelectedSource] = useState<SourceProvider>(SOURCE_ORDER[0] ?? 'aws');
-  const selectedSourceFromConnect = useMemo(() => {
-    return normalizeSourceProvider(new URLSearchParams(location.search).get('source'));
-  }, [location.search]);
+  const [selectedSource, setSelectedSource] = useState<SourceProvider>(
+    selectedSourceFromConnect ?? SOURCE_ORDER[0] ?? 'aws'
+  );
   const [successMessage, setSuccessMessage] = useState('');
   const [githubStart, setGitHubStart] = useState<GitHubConnectorStartResponse | null>(null);
   const [githubAppForm, setGitHubAppForm] = useState({
@@ -5298,18 +5341,18 @@ export function ProductProjectDetailPage() {
   ]);
 
   useEffect(() => {
-    if (backendFeaturesLoading || sourceAvailability[selectedSource]?.available) {
+    if (backendFeaturesLoading || sourceScope || sourceAvailability[selectedSource]?.available) {
       return;
     }
     setSelectedSource(actionableSourceOrder[0] ?? 'aws');
-  }, [actionableSourceOrder, backendFeaturesLoading, selectedSource, sourceAvailability]);
+  }, [actionableSourceOrder, backendFeaturesLoading, selectedSource, sourceAvailability, sourceScope]);
 
   useEffect(() => {
     if (!selectedSourceFromConnect || backendFeaturesLoading) {
       return;
     }
 
-    if (sourceAvailability[selectedSourceFromConnect]?.available) {
+    if (sourceAvailability[selectedSourceFromConnect]?.visible) {
       setSelectedSource(selectedSourceFromConnect);
     }
   }, [backendFeaturesLoading, selectedSourceFromConnect, sourceAvailability]);
@@ -5430,6 +5473,12 @@ export function ProductProjectDetailPage() {
   const selectedProfile = SOURCE_PROFILES[selectedSource];
   const selectedAvailability = sourceAvailability[selectedSource] ?? { visible: true, available: true };
   const selectedUnavailable = !selectedAvailability.available;
+  const sourceScopeProfile = sourceScope ? SOURCE_PROFILES[sourceScope] : null;
+  const sourcePageKicker = sourceScopeProfile ? `${sourceScopeProfile.name} source` : 'Project sources';
+  const sourcePageTitle = sourceScopeProfile ? `Connect ${sourceScopeProfile.name}` : 'Connect project sources';
+  const sourcePageBody = sourceScopeProfile
+    ? `${sourceScopeProfile.summary} This page is scoped to ${sourceScopeProfile.name}.`
+    : 'Install source connections to collect repository, workflow, and cloud identity signals.';
 
   const handleGitHubStart = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -5924,13 +5973,19 @@ export function ProductProjectDetailPage() {
   };
 
   return (
-    <section className="idt-app-panel idt-source-onboarding">
+    <section className={`idt-app-panel idt-source-onboarding${sourceScope ? ' is-source-scoped' : ''}`}>
       <div className="idt-source-onboarding-header">
         <div>
-          <p className="idt-app-kicker">Project sources</p>
-          <h2>Connect project sources</h2>
+          <p className="idt-app-kicker">{sourcePageKicker}</p>
+          <h2>{sourcePageTitle}</h2>
           <p>
-            Install source connections for <strong>{projectID}</strong> to collect repository, workflow, and cloud identity signals.
+            {sourceScopeProfile ? (
+              sourcePageBody
+            ) : (
+              <>
+                {sourcePageBody} Project <strong>{projectID}</strong>.
+              </>
+            )}
           </p>
         </div>
         <button
@@ -5952,7 +6007,7 @@ export function ProductProjectDetailPage() {
       ) : null}
 
       <div className="idt-source-wizard-grid">
-        <aside className="idt-source-picker" aria-label="Source types">
+        <aside className="idt-source-picker" aria-label={sourceScopeProfile ? `${sourceScopeProfile.name} source` : 'Source types'}>
           {sourceOrder.map((provider) => {
             const profile = SOURCE_PROFILES[provider];
             const status = sourceConnection(connections, provider);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -24958,9 +24958,10 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   padding: 0.48rem 0.6rem;
   gap: 0.55rem;
   font-weight: 600;
-  background: transparent;
+  background: rgba(255, 255, 255, 0.035);
   border-color: var(--app-border-soft);
-  color: #d4d4dc;
+  color: #aeb7c2;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.018);
 }
 
 .idt-app-console-layout .idt-app-quick-find-icon {
@@ -24971,7 +24972,7 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 .idt-app-console-layout .idt-app-quick-find-label {
   flex: 1 1 auto;
   font-size: 0.86rem;
-  color: #d4d4dc;
+  color: #8f98a4;
 }
 
 .idt-app-console-layout .idt-app-quick-find-key {
@@ -24987,7 +24988,8 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 .idt-app-console-layout .idt-app-quick-find:hover,
 .idt-app-console-layout .idt-app-quick-find:focus-visible {
   border-color: var(--app-border);
-  background: #0d0d10;
+  background: #101419;
+  color: #dbe2ea;
 }
 
 .idt-app-console-layout .idt-app-shell-nav {
@@ -25037,8 +25039,9 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   display: block;
   width: 16px;
   height: 16px;
-  filter: invert(0.62);
-  opacity: 0.95;
+  object-fit: contain;
+  filter: none;
+  opacity: 1;
 }
 
 .idt-app-console-layout .idt-app-shell-nav a:hover .idt-app-nav-icon,
@@ -25050,7 +25053,7 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 .idt-app-console-layout .idt-app-shell-nav a:hover .idt-app-nav-icon img,
 .idt-app-console-layout .idt-app-shell-nav a:focus-visible .idt-app-nav-icon img,
 .idt-app-console-layout .idt-app-shell-nav a.active .idt-app-nav-icon img {
-  filter: invert(1);
+  filter: none;
   opacity: 1;
 }
 
@@ -25133,11 +25136,28 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   color: #ffffff;
 }
 
+.idt-app-console-layout .idt-app-nav-domain-trigger .idt-app-nav-icon {
+  width: 1.35rem;
+  height: 1.35rem;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 5px;
+  background: #ffffff;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.22);
+}
+
+.idt-app-console-layout .idt-app-nav-domain-trigger .idt-sidebar-domain-logo {
+  width: 0.95rem;
+  height: 0.95rem;
+  object-fit: contain;
+  filter: none;
+  opacity: 1;
+}
+
 .idt-app-console-layout .idt-app-nav-domain-trigger:hover .idt-app-nav-icon img,
 .idt-app-console-layout .idt-app-nav-domain-trigger:focus-visible .idt-app-nav-icon img,
 .idt-app-console-layout .idt-app-nav-domain-trigger.is-active .idt-app-nav-icon img,
 .idt-app-console-layout .idt-app-nav-domain-trigger.is-open .idt-app-nav-icon img {
-  filter: invert(1);
+  filter: none;
   opacity: 1;
 }
 
@@ -25163,6 +25183,7 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   -webkit-backdrop-filter: blur(22px) saturate(0.84) brightness(0.72);
   backdrop-filter: blur(22px) saturate(0.84) brightness(0.72);
   cursor: default;
+  touch-action: none;
 }
 
 .idt-app-console-layout.is-domain-flyout-open .idt-app-sidebar {
@@ -25179,15 +25200,17 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   left: calc(100% + 0.72rem);
   z-index: 50;
   display: grid;
-  gap: 0.75rem;
-  width: min(34rem, calc(100vw - var(--idt-sidebar-width, 15.5rem) - 1.8rem));
-  max-height: min(82vh, 46rem);
+  gap: 0.68rem;
+  width: min(30rem, calc(100vw - var(--idt-sidebar-width, 15.5rem) - 1.8rem));
+  max-height: min(78vh, 42rem);
   overflow: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
   border: 1px solid rgba(255, 255, 255, 0.13);
   border-radius: 8px;
-  padding: 0.78rem;
+  padding: 0.68rem;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.045), transparent 12rem),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.055), transparent 10rem),
     #050607;
   box-shadow:
     0 28px 90px rgba(0, 0, 0, 0.62),
@@ -25211,18 +25234,18 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   position: relative;
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
-  gap: 0.75rem;
+  gap: 0.68rem;
   align-items: start;
   border: 1px solid rgba(255, 255, 255, 0.09);
   border-radius: 8px;
-  padding: 0.72rem;
+  padding: 0.66rem;
   background: #080a0d;
 }
 
 .idt-domain-flyout-logo {
   display: grid;
-  width: 2.45rem;
-  height: 2.45rem;
+  width: 2.15rem;
+  height: 2.15rem;
   place-items: center;
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 8px;
@@ -25231,14 +25254,14 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 
 .idt-domain-flyout-logo img {
   display: block;
-  max-width: 1.45rem;
-  max-height: 1.45rem;
+  max-width: 1.32rem;
+  max-height: 1.32rem;
 }
 
 .idt-domain-flyout-header p,
 .idt-domain-flyout-section-label {
   margin: 0;
-  color: #8d96a3;
+  color: #9aa4af;
   font-size: 0.68rem;
   font-weight: 800;
   line-height: 1.2;
@@ -25255,7 +25278,7 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 
 .idt-domain-flyout-header span {
   display: block;
-  color: #b6bec8;
+  color: #aeb7c2;
   font-size: 0.82rem;
   line-height: 1.35;
 }
@@ -25273,7 +25296,7 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   min-height: 2.25rem;
   border: 1px solid rgba(255, 255, 255, 0.14);
   border-radius: 7px;
-  padding: 0.44rem 0.7rem;
+  padding: 0.42rem 0.66rem;
   background: #11151b;
   color: #ffffff;
   font-size: 0.82rem;
@@ -25298,23 +25321,30 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 .idt-domain-flyout-list,
 .idt-domain-flyout-nested-body {
   display: grid;
-  gap: 0.38rem;
+  gap: 0.12rem;
 }
 
 .idt-domain-flyout-section {
-  gap: 0.48rem;
+  gap: 0.34rem;
+  padding-top: 0.24rem;
+}
+
+.idt-domain-flyout-section + .idt-domain-flyout-section,
+.idt-domain-flyout-nested + .idt-domain-flyout-section {
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+  padding-top: 0.62rem;
 }
 
 .idt-domain-flyout-link {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
-  gap: 0.6rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.55rem;
   align-items: center;
-  min-height: 2.7rem;
+  min-height: 2.28rem;
   border: 1px solid transparent;
-  border-radius: 8px;
-  padding: 0.58rem 0.62rem;
-  color: #d5dbe3;
+  border-radius: 7px;
+  padding: 0.44rem 0.54rem;
+  color: #dce3eb;
   text-decoration: none;
   transition: background-color 0.12s ease, border-color 0.12s ease, color 0.12s ease;
 }
@@ -25329,8 +25359,8 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 }
 
 .idt-domain-flyout-link.is-child {
-  margin-left: 0.55rem;
-  padding-left: 0.72rem;
+  margin-left: 0.48rem;
+  padding-left: 0.62rem;
   border-left-color: rgba(255, 255, 255, 0.12);
 }
 
@@ -25341,13 +25371,12 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 
 .idt-domain-flyout-link-copy strong {
   color: inherit;
-  font-size: 0.88rem;
+  font-size: 0.86rem;
   font-weight: 750;
   line-height: 1.2;
 }
 
 .idt-domain-flyout-link-copy span,
-.idt-domain-flyout-link-meta,
 .idt-domain-flyout-nested small {
   color: #8f98a4;
   font-size: 0.72rem;
@@ -25355,17 +25384,10 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   line-height: 1.2;
 }
 
-.idt-domain-flyout-link-meta {
-  border: 1px solid rgba(255, 255, 255, 0.09);
-  border-radius: 999px;
-  padding: 0.16rem 0.42rem;
-  white-space: nowrap;
-}
-
 .idt-domain-flyout-nested {
   border: 1px solid rgba(255, 255, 255, 0.09);
   border-radius: 8px;
-  padding: 0.42rem;
+  padding: 0.36rem;
   background: rgba(255, 255, 255, 0.018);
 }
 
@@ -26550,13 +26572,21 @@ html[data-theme='light'] .idt-app-console-layout .idt-app-sidebar {
   box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.035);
 }
 
-.idt-app-console-layout .idt-app-quick-find,
 .idt-app-console-layout .idt-app-sidebar-workspace-trigger,
 .idt-app-console-layout .idt-app-sidebar-account-trigger,
-html[data-theme='light'] .idt-app-console-layout .idt-app-quick-find {
+html[data-theme='light'] .idt-app-console-layout .idt-app-sidebar-workspace-trigger,
+html[data-theme='light'] .idt-app-console-layout .idt-app-sidebar-account-trigger {
   background: transparent;
   border-color: transparent;
   color: #d8dde4;
+}
+
+.idt-app-console-layout .idt-app-quick-find,
+html[data-theme='light'] .idt-app-console-layout .idt-app-quick-find {
+  background: rgba(255, 255, 255, 0.035);
+  border-color: var(--app-border-soft);
+  color: #aeb7c2;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.018);
 }
 
 .idt-app-console-layout .idt-app-quick-find:hover,


### PR DESCRIPTION
Fixes #1424

## What changed

- Made AWS, GitHub, and Kubernetes always visible as domain sections while keeping connector execution gated by feature/API availability.
- Reworked the domain flyouts into compact Start / Inventory / Risk groups with minimal labels, consistent official logo assets, and full accessible action names.
- Restored a visible premium Find command box and prevented Overview from staying visually active while a domain flyout is open.
- Locked document scrolling while a domain flyout is open so only the flyout can scroll.
- Scoped domain connect pages to the requested provider so `?source=github` renders only GitHub instead of showing AWS beside it.

## Why

The domain-first app shell needs to feel intentional before the next sequencing PRs land. These changes fix the user-visible issues from the first redesign pass without expanding backend connector scope.

## Impact and risk

- UI-only/product-shell change; no API contract or backend behavior changes.
- Connector availability still gates actual connect execution and command-palette connect actions.
- Domain sections are now discoverable even when a connector is unavailable, which matches the new IA direction.

## Validation

- `npm test -- --run src/productShell.test.tsx src/design/domainAssets.test.ts` — 39 passed
- `npm test -- --run src/App.test.tsx` — 69 passed
- `npm run build` — passed; prerendered 39 routes
- Browser verification with mocked API responses confirmed: visible Find box, enabled AWS/GitHub/Kubernetes sections, AWS flyout scroll lock, Kubernetes flyout routes, official logo paths, and GitHub-scoped source picker only showing GitHub.

## AI assistance

- AI-assisted: yes
- Tools used: Codex
- Where used: `web/src/productShell.tsx`, `web/src/styles.css`, `web/src/productShell.test.tsx`, `web/src/App.test.tsx`
- Human verification performed: reviewed the diff, ran focused shell tests, app route tests, production build, and browser verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the domain navigation and flyouts to improve clarity, accessibility, and scoping. AWS, GitHub, and Kubernetes are always visible; flyouts are compact with Start, Inventory, and Risk groups.

- **New Features**
  - Always show AWS/GitHub/Kubernetes; connector actions remain gated by backend availability.
  - Compact flyouts with Start / Inventory / Risk, official logos, and accessible action names.
  - Lock page scroll while a flyout is open; Overview no longer stays active when a flyout is open.
  - Command palette and connect flows are scoped: domain items visible, "Connect" only when available, and ?source= shows only the selected provider.
  - Restored the Find command box and refined sidebar/logo styles.

<sup>Written for commit 84517f1ddd01b502e4b4248a6d0c47519ce2ed52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1425?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

