### PR TITLE
Tighten domain flyout active states

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -814,7 +814,7 @@ describe('App', () => {
     const meCallsBeforeNavigation = fetchMock.mock.calls.filter(([url]) => typeof url === 'string' && url.endsWith('/v1/me')).length;
 
     fireEvent.click(screen.getByRole('button', { name: 'AWS' }));
-    fireEvent.click(await screen.findByRole('link', { name: /Open AWS Control Center/i }));
+    fireEvent.click(await screen.findByRole('link', { name: /AWS Control center/i }));
 
     expect(screen.queryByText(/Validating session/i)).not.toBeInTheDocument();
     expect(screen.getByRole('navigation', { name: /App sections/i })).toBeInTheDocument();
@@ -915,7 +915,7 @@ describe('App', () => {
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'AWS' }));
-    fireEvent.click(await screen.findByRole('link', { name: /Open AWS Control Center/i }));
+    fireEvent.click(await screen.findByRole('link', { name: /AWS Control center/i }));
 
     expect(screen.queryByText(/Validating session/i)).not.toBeInTheDocument();
     expect(await screen.findByRole('heading', { level: 1, name: /Log in to Identrail/i })).toBeInTheDocument();

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -432,6 +432,7 @@ describe('ProductShellLayout', () => {
     expect(screen.getByRole('button', { name: 'Kubernetes' })).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Projects' })).not.toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Findings' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Control plane')).not.toBeInTheDocument();
 
     expect(screen.getByRole('link', { name: 'Overview' })).toHaveClass('active');
     fireEvent.click(screen.getByRole('button', { name: 'AWS' }));
@@ -441,7 +442,9 @@ describe('ProductShellLayout', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'GitHub' }));
     const githubFlyout = screen.getByRole('dialog', { name: 'GitHub' });
-    expect(within(githubFlyout).getByRole('link', { name: /Open GitHub Control Center/i })).toBeInTheDocument();
+    expect(within(githubFlyout).queryByText('Section')).not.toBeInTheDocument();
+    expect(within(githubFlyout).queryByRole('heading', { name: 'GitHub' })).not.toBeInTheDocument();
+    expect(within(githubFlyout).getByRole('link', { name: 'GitHub Control center' })).toBeInTheDocument();
     expect(within(githubFlyout).getByRole('link', { name: 'GitHub Findings' })).toBeInTheDocument();
     expect(within(githubFlyout).getAllByText('AI / Agentic Risk').length).toBeGreaterThan(0);
 
@@ -491,6 +494,61 @@ describe('ProductShellLayout', () => {
     fireEvent.change(screen.getByLabelText(/Search workspace commands/i), { target: { value: 'github' } });
     expect(screen.getAllByRole('option', { name: /^GitHub\b/i }).length).toBeGreaterThan(0);
     expect(screen.queryByRole('option', { name: /Connect GitHub/i })).not.toBeInTheDocument();
+  });
+
+  it('lets an open domain flyout own the sidebar highlight over Reports routes', async () => {
+    mockConnectorFeatureFlags({ github: true, kubernetes: true });
+    mockBackendFeatures({ github: true, kubernetes: true });
+    const { ProductShellLayout } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/reports']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID" element={<ProductShellLayout />}>
+            <Route path="reports" element={<h2>Reports content</h2>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 2, name: /Reports content/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Reports' })).toHaveClass('active');
+
+    fireEvent.click(screen.getByRole('button', { name: 'AWS' }));
+
+    expect(screen.getByRole('link', { name: 'Reports' })).not.toHaveClass('active');
+    expect(screen.getByRole('button', { name: 'AWS' })).toHaveClass('is-open');
+    expect(screen.getByRole('button', { name: 'AWS' })).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(screen.getByRole('button', { name: 'GitHub' }));
+
+    expect(screen.getByRole('link', { name: 'Reports' })).not.toHaveClass('active');
+    expect(screen.getByRole('button', { name: 'AWS' })).not.toHaveClass('is-active');
+    expect(screen.getByRole('button', { name: 'GitHub' })).toHaveClass('is-open');
+  });
+
+  it('removes Settings active styling while a domain flyout is open', async () => {
+    mockConnectorFeatureFlags({ github: true, kubernetes: true });
+    mockBackendFeatures({ github: true, kubernetes: true });
+    const { ProductShellLayout } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/settings']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID" element={<ProductShellLayout />}>
+            <Route path="settings" element={<h2>Settings content</h2>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 2, name: /Settings content/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Settings' })).toHaveClass('active');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Kubernetes' }));
+
+    expect(screen.getByRole('link', { name: 'Settings' })).not.toHaveClass('active');
+    expect(screen.getByRole('button', { name: 'Kubernetes' })).toHaveClass('is-open');
   });
 });
 

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -449,10 +449,19 @@ describe('ProductShellLayout', () => {
     expect(within(githubFlyout).getAllByText('AI / Agentic Risk').length).toBeGreaterThan(0);
 
     fireEvent.keyDown(window, { key: '/' });
-    expect(screen.getByRole('dialog', { name: /Go to anything/i })).toBeInTheDocument();
+    const finder = screen.getByRole('dialog', { name: /Workspace finder/i });
+    expect(finder).toBeInTheDocument();
+    expect(within(finder).queryByText('Workspace finder')).not.toBeInTheDocument();
+    expect(within(finder).queryByText('Go to anything')).not.toBeInTheDocument();
 
     expect(screen.queryByRole('option', { name: /^Projects\b/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('option', { name: /^Findings\b/i })).not.toBeInTheDocument();
+    expect(
+      within(within(finder).getByRole('option', { name: /^OverviewDomain/i })).queryByText('O')
+    ).not.toBeInTheDocument();
+    expect(
+      within(within(finder).getByRole('option', { name: /^GitHub findingsRepository/i })).queryByText('F')
+    ).not.toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText(/Search workspace commands/i), { target: { value: 'github findings' } });
     fireEvent.keyDown(screen.getByLabelText(/Search workspace commands/i), { key: 'Enter' });
@@ -490,7 +499,7 @@ describe('ProductShellLayout', () => {
     expect(screen.getByRole('dialog', { name: 'GitHub' })).toBeInTheDocument();
 
     fireEvent.keyDown(window, { key: '/' });
-    expect(screen.getByRole('dialog', { name: /Go to anything/i })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: /Workspace finder/i })).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText(/Search workspace commands/i), { target: { value: 'github' } });
     expect(screen.getAllByRole('option', { name: /^GitHub\b/i }).length).toBeGreaterThan(0);
     expect(screen.queryByRole('option', { name: /Connect GitHub/i })).not.toBeInTheDocument();

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1502,7 +1502,7 @@ function CommandPalette({
         className="idt-command-palette"
         role="dialog"
         aria-modal="true"
-        aria-labelledby="idt-command-palette-title"
+        aria-label="Workspace finder"
         onKeyDown={(event) => {
           if (event.defaultPrevented) {
             return;
@@ -1513,23 +1513,19 @@ function CommandPalette({
           }
         }}
       >
-        <header>
-          <div>
-            <p className="idt-app-kicker">Workspace finder</p>
-            <h2 id="idt-command-palette-title">Go to anything</h2>
-          </div>
+        <div className="idt-command-palette-search-row">
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={handleInputKeyDown}
+            placeholder="Search views, reports, settings, and actions"
+            aria-label="Search workspace commands"
+          />
           <button type="button" className="idt-command-palette-close" onClick={onClose} aria-label="Close workspace finder">
             Esc
           </button>
-        </header>
-        <input
-          ref={inputRef}
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-          onKeyDown={handleInputKeyDown}
-          placeholder="Search views, reports, settings, and actions"
-          aria-label="Search workspace commands"
-        />
+        </div>
         <div className="idt-command-palette-results" role="listbox" aria-label="Workspace commands">
           {filteredItems.length > 0 ? (
             filteredItems.map((item) => (
@@ -2465,7 +2461,6 @@ export function ProductShellLayout() {
         label: 'Overview',
         description: 'Domain coverage, recent scans, and next actions',
         keywords: ['home', 'dashboard', 'workspace', 'domains'],
-        shortcut: 'O',
         path: basePath
       }
     ];
@@ -2509,7 +2504,6 @@ export function ProductShellLayout() {
         label: 'GitHub findings',
         description: 'Repository risk inside the GitHub section',
         keywords: ['github', 'findings', 'repository', 'triage'],
-        shortcut: 'F',
         path: `${basePath}/github/findings`
       });
       items.push({

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1972,12 +1972,6 @@ function ProductDomainFlyoutRouteLink({
   );
 }
 
-const DOMAIN_FLYOUT_SUMMARIES: Record<SourceProvider, string> = {
-  aws: 'Machine identities, resources, runtime, risk.',
-  github: 'Repositories, Actions, agentic surfaces, risk.',
-  kubernetes: 'Clusters, workloads, service accounts, RBAC.'
-};
-
 function ProductDomainFlyout({
   domain,
   scope,
@@ -1994,16 +1988,12 @@ function ProductDomainFlyout({
   onClose: () => void;
 }) {
   const config = PRODUCT_DOMAIN_CONFIGS[domain];
-  const asset = getDomainAsset(domain);
   const startRoutes = config.routes.filter((route) => route.id === 'overview' || route.id === 'connect');
   const nestedRoutes = config.routes.filter((route) => route.children?.length);
   const riskRoutes = config.routes.filter((route) => ['findings', 'remediation', 'governance'].includes(route.id));
   const surfaceRoutes = config.routes.filter(
     (route) => !startRoutes.includes(route) && !nestedRoutes.includes(route) && !riskRoutes.includes(route)
   );
-  const domainHome = domainRoutePath(scope, domain, config.routes[0]);
-  const connectRoute = findDomainRoute(domain, config.connectRouteID);
-  const connectPath = domainRoutePath(scope, domain, connectRoute);
 
   return (
     <div
@@ -2014,31 +2004,6 @@ function ProductDomainFlyout({
       aria-modal="true"
       aria-labelledby={labelledBy}
     >
-      <header className="idt-domain-flyout-header">
-        <span className="idt-domain-flyout-logo" aria-hidden="true">
-          <img src={asset.logoSrc} alt="" loading="lazy" decoding="async" />
-        </span>
-        <div>
-          <p>Section</p>
-          <h2>{config.navLabel}</h2>
-          <span>{DOMAIN_FLYOUT_SUMMARIES[domain]}</span>
-        </div>
-      </header>
-
-      <div className="idt-domain-flyout-actions">
-        <Link
-          data-domain-flyout-primary="true"
-          to={domainHome}
-          aria-label={`Open ${config.navLabel} Control Center`}
-          onClick={onClose}
-        >
-          Control Center
-        </Link>
-        <Link to={connectPath} aria-label={`Connect ${config.navLabel}`} onClick={onClose}>
-          Connect
-        </Link>
-      </div>
-
       <div className="idt-domain-flyout-section">
         <span className="idt-domain-flyout-section-label">Start</span>
         <div className="idt-domain-flyout-list">
@@ -3023,7 +2988,6 @@ export function ProductShellLayout() {
           </button>
 
           <nav className="idt-app-shell-nav" aria-label="App sections">
-            <div className="idt-app-nav-group-label" aria-hidden={sidebarCollapsed}>Control plane</div>
             <NavLink
               to={basePath}
               end
@@ -3040,8 +3004,8 @@ export function ProductShellLayout() {
             {visibleDomainOrder.map((domain) => {
               const config = PRODUCT_DOMAIN_CONFIGS[domain];
               const availability = sourceAvailability[domain];
-              const isActive = activeDomain === domain;
               const isOpen = openDomainFlyout === domain;
+              const isActive = activeDomain === domain && (!openDomainFlyout || isOpen);
               const triggerID = `idt-${domain}-domain-trigger`;
               return (
                 <div key={domain} className="idt-app-domain-nav-item">
@@ -3085,13 +3049,25 @@ export function ProductShellLayout() {
                 </div>
               );
             })}
-            <NavLink to={`${basePath}/reports`} aria-label="Reports" title={sidebarCollapsed ? 'Reports' : undefined} onClick={closeDomainFlyout}>
+            <NavLink
+              to={`${basePath}/reports`}
+              aria-label="Reports"
+              title={sidebarCollapsed ? 'Reports' : undefined}
+              className={({ isActive }) => (isActive && !openDomainFlyout ? 'active' : undefined)}
+              onClick={closeDomainFlyout}
+            >
               <span className="idt-app-nav-icon" aria-hidden="true">
                 <BarChart3 size={16} strokeWidth={1.75} />
               </span>
               <span className="idt-app-nav-label">Reports</span>
             </NavLink>
-            <NavLink to={`${basePath}/settings`} aria-label="Settings" title={sidebarCollapsed ? 'Settings' : undefined} onClick={closeDomainFlyout}>
+            <NavLink
+              to={`${basePath}/settings`}
+              aria-label="Settings"
+              title={sidebarCollapsed ? 'Settings' : undefined}
+              className={({ isActive }) => (isActive && !openDomainFlyout ? 'active' : undefined)}
+              onClick={closeDomainFlyout}
+            >
               <span className="idt-app-nav-icon" aria-hidden="true">
                 <SettingsIcon size={16} strokeWidth={1.75} />
               </span>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -20468,7 +20468,7 @@ html[data-theme='light'] .idt-app-quick-find {
   z-index: 1100;
   display: grid;
   place-items: start center;
-  padding: min(12vh, 7rem) 1rem 1rem;
+  padding: min(8vh, 5rem) 1rem 1rem;
   background: rgba(0, 0, 0, 0.72);
   backdrop-filter: blur(12px);
 }
@@ -20481,13 +20481,14 @@ html[data-theme='light'] .idt-app-quick-find {
   width: min(100%, 42rem);
   border: 1px solid var(--app-border);
   border-radius: 8px;
-  padding: 0.9rem;
-  background: var(--app-panel);
+  padding: 0.72rem;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0.01) 42%, rgba(255, 255, 255, 0)),
+    var(--app-panel);
   color: #ffffff;
   box-shadow: 0 24px 80px rgba(0, 0, 0, 0.55);
 }
 
-.idt-command-palette header,
 .idt-command-palette-results button {
   display: flex;
   align-items: center;
@@ -20495,35 +20496,40 @@ html[data-theme='light'] .idt-app-quick-find {
   gap: 1rem;
 }
 
-.idt-command-palette h2 {
-  margin: 0.15rem 0 0;
-  color: #ffffff;
-  font-family: var(--idt-display);
-  font-size: 1.45rem;
-  line-height: 1.05;
-}
-
-.idt-command-palette .idt-app-kicker {
-  color: #a3a3a3;
+.idt-command-palette-search-row {
+  display: flex;
+  align-items: stretch;
+  gap: 0.55rem;
 }
 
 .idt-command-palette-close {
   border: 1px solid var(--app-border);
-  border-radius: 999px;
-  padding: 0.35rem 0.55rem;
-  background: #111113;
+  border-radius: 8px;
+  min-width: 3.35rem;
+  padding: 0 0.7rem;
+  background: #101012;
   color: #ffffff;
   font: inherit;
   font-size: 0.78rem;
   font-weight: 900;
+  cursor: pointer;
+}
+
+.idt-command-palette-close:hover,
+.idt-command-palette-close:focus-visible {
+  border-color: #ffffff;
+  background: #151518;
+  outline: none;
 }
 
 .idt-command-palette input {
+  flex: 1 1 auto;
+  min-width: 0;
   width: 100%;
-  margin: 0.95rem 0 0.75rem;
+  margin: 0;
   border: 1px solid var(--app-border);
   border-radius: 8px;
-  padding: 0.85rem 0.9rem;
+  padding: 0.82rem 0.9rem;
   background: #050505;
   color: #ffffff;
   font: inherit;
@@ -20539,6 +20545,7 @@ html[data-theme='light'] .idt-app-quick-find {
   gap: 0.35rem;
   flex: 1;
   min-height: 0;
+  margin-top: 0.68rem;
   overflow-y: auto;
   overscroll-behavior: contain;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -20313,7 +20313,7 @@ html[data-theme='light'] .idt-legal-contact-panel .idt-btn-primary {
   height: 100dvh;
   display: grid;
   grid-template-rows: auto auto auto minmax(0, 1fr) auto;
-  gap: 1rem;
+  gap: 0.8rem;
   padding: 1rem;
   /* Sidebar must allow overflow so flyout menus (workspace switcher / account
    * menu) can render outside the rail in collapsed mode without being clipped
@@ -25200,8 +25200,8 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   left: calc(100% + 0.72rem);
   z-index: 50;
   display: grid;
-  gap: 0.68rem;
-  width: min(30rem, calc(100vw - var(--idt-sidebar-width, 15.5rem) - 1.8rem));
+  gap: 0.58rem;
+  width: min(27rem, calc(100vw - var(--idt-sidebar-width, 15.5rem) - 1.8rem));
   max-height: min(78vh, 42rem);
   overflow: auto;
   overscroll-behavior: contain;
@@ -25210,7 +25210,7 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   border-radius: 8px;
   padding: 0.68rem;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.055), transparent 10rem),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.045), transparent 8rem),
     #050607;
   box-shadow:
     0 28px 90px rgba(0, 0, 0, 0.62),
@@ -25230,35 +25230,6 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   transform: rotate(45deg);
 }
 
-.idt-domain-flyout-header {
-  position: relative;
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 0.68rem;
-  align-items: start;
-  border: 1px solid rgba(255, 255, 255, 0.09);
-  border-radius: 8px;
-  padding: 0.66rem;
-  background: #080a0d;
-}
-
-.idt-domain-flyout-logo {
-  display: grid;
-  width: 2.15rem;
-  height: 2.15rem;
-  place-items: center;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 8px;
-  background: #ffffff;
-}
-
-.idt-domain-flyout-logo img {
-  display: block;
-  max-width: 1.32rem;
-  max-height: 1.32rem;
-}
-
-.idt-domain-flyout-header p,
 .idt-domain-flyout-section-label {
   margin: 0;
   color: #9aa4af;
@@ -25266,55 +25237,6 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   font-weight: 800;
   line-height: 1.2;
   text-transform: uppercase;
-}
-
-.idt-domain-flyout-header h2 {
-  margin: 0.12rem 0 0.12rem;
-  color: #ffffff;
-  font-size: 1.02rem;
-  font-weight: 700;
-  line-height: 1.15;
-}
-
-.idt-domain-flyout-header span {
-  display: block;
-  color: #aeb7c2;
-  font-size: 0.82rem;
-  line-height: 1.35;
-}
-
-.idt-domain-flyout-actions {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 0.5rem;
-}
-
-.idt-domain-flyout-actions a {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 2.25rem;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 7px;
-  padding: 0.42rem 0.66rem;
-  background: #11151b;
-  color: #ffffff;
-  font-size: 0.82rem;
-  font-weight: 800;
-  line-height: 1.2;
-  text-align: center;
-  text-decoration: none;
-}
-
-.idt-domain-flyout-actions a[data-domain-flyout-primary='true'] {
-  background: #ffffff;
-  color: #050607;
-}
-
-.idt-domain-flyout-actions a:hover,
-.idt-domain-flyout-actions a:focus-visible {
-  border-color: rgba(255, 255, 255, 0.34);
-  outline: none;
 }
 
 .idt-domain-flyout-section,
@@ -25326,7 +25248,7 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 
 .idt-domain-flyout-section {
   gap: 0.34rem;
-  padding-top: 0.24rem;
+  padding-top: 0;
 }
 
 .idt-domain-flyout-section + .idt-domain-flyout-section,
@@ -26034,10 +25956,6 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
   .idt-app-console-layout.is-sidebar-collapsed {
     grid-template-columns: 1fr;
   }
-  /* Section labels add no value in the horizontal mobile nav. */
-  .idt-app-console-layout .idt-app-nav-group-label {
-    display: none;
-  }
   /* Collapsed mode is forced off on narrow viewports by JS (the rail becomes a
    * top bar, where "collapsed" has no useful meaning). The toggle button is
    * still rendered so a user who resizes back to desktop has an obvious path
@@ -26112,7 +26030,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
   padding: 0;
 }
 
-/* === Workspace switcher, nav groups, a11y label rescue === */
+/* === Workspace switcher, nav, a11y label rescue === */
 
 .idt-app-sidebar-workspace {
   position: relative;
@@ -26267,20 +26185,6 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
   background: #1c1c22;
   color: #ffffff;
   outline: none;
-}
-
-/* Nav section labels */
-.idt-app-nav-group-label {
-  padding: 0.65rem 0.6rem 0.25rem;
-  color: #5a5a62;
-  font-size: 0.7rem;
-  font-weight: 600;
-  letter-spacing: 0;
-  text-transform: none;
-}
-
-.idt-app-console-layout.is-sidebar-collapsed .idt-app-nav-group-label {
-  display: none;
 }
 
 /* a11y: keep nav labels available to AT in collapsed mode */


### PR DESCRIPTION
Fixes #1426\n\n## Summary\n- make the open AWS/GitHub/Kubernetes flyout the only active sidebar owner while it is open\n- remove redundant flyout provider header chrome, repeated logos/names, the "Section" label, and duplicated top action row\n- remove the visible "Control plane" label and tighten sidebar/flyout spacing\n\n## Validation\n- npm test -- --run src/productShell.test.tsx src/App.test.tsx\n- npm run build\n- git diff --check origin/dev...HEAD\n- Browser verification against local dev server confirmed Reports/Settings lose active styling while flyouts are open, only the open domain is highlighted, and flyouts have no header/action duplication

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens sidebar active state so the open domain flyout is the only highlighted owner, cleans up redundant flyout UI, and polishes the workspace finder.

- **Bug Fixes**
  - Sidebar active state follows the open domain flyout (AWS/GitHub/Kubernetes).
  - Reports and Settings lose active styling while a flyout is open.
  - Prevents multiple domains from appearing active at once.
  - Standardized link labels to "AWS Control center"/"GitHub Control center".

- **Refactors**
  - Removed flyout header chrome, duplicated logos/names, "Section" label, and top action row.
  - Reduced flyout width/spacing; subtle gradient, gap, and padding tweaks.
  - Workspace finder: compact search row + close button, dialog labeled "Workspace finder"; removed "Go to anything" header and shortcut badges.
  - Removed the sidebar "Control plane" label and tightened sidebar/flyout spacing.
  - Added tests for active-state behavior, workspace finder a11y/labels, and updated flyout content expectations.

<sup>Written for commit dd092294de407d63dd6580cff933134c2a12a429. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1427?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

