### PR TITLE
[codex] Deduplicate source connect pages

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1497,8 +1497,10 @@ describe('App', () => {
 
     await waitFor(() => expect(window.location.pathname).toBe('/app/tenant-a/workspace-a/projects/project-1'));
     expect(window.location.search).toBe('?source=aws');
-    expect(await screen.findByRole('heading', { level: 2, name: /Connect AWS/i })).toBeInTheDocument();
-    expect(within(screen.getByLabelText('AWS source')).queryByRole('button', { name: /GitHub/i })).not.toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 1, name: /Connect AWS/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText('AWS source')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Source types')).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 3, name: 'AWS' })).not.toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Projects' })).not.toBeInTheDocument();
   });
 

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -756,11 +756,13 @@ describe('ProductProjectDetailPage', () => {
       initialEntry: '/app/tenant-a/workspace-a/projects/project-1?source=github'
     });
 
-    expect(await screen.findByRole('heading', { level: 2, name: 'Connect GitHub' })).toBeInTheDocument();
-    const picker = screen.getByLabelText('GitHub source');
-    expect(within(picker).getByRole('button', { name: /GitHub/i })).toBeInTheDocument();
-    expect(within(picker).queryByRole('button', { name: /AWS/i })).not.toBeInTheDocument();
-    expect(within(picker).queryByRole('button', { name: /Kubernetes/i })).not.toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 1, name: 'Connect GitHub' })).toBeInTheDocument();
+    expect(screen.queryByLabelText('GitHub source')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Source types')).not.toBeInTheDocument();
+    expect(screen.queryByText('This page is scoped to GitHub.')).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 3, name: 'GitHub' })).not.toBeInTheDocument();
+    expect(screen.getByText('Setup')).toBeInTheDocument();
+    expect(screen.queryByText('Recommended setup')).not.toBeInTheDocument();
   });
 
   it('opens GitHub installation in a new tab through GitHub account picker', async () => {
@@ -804,10 +806,10 @@ describe('ProductProjectDetailPage', () => {
     fireEvent.click(within(scanLimits as HTMLElement).getByText('Scan limits'));
     expect(within(scanLimits as HTMLElement).getByLabelText(/History limit/i)).toBeVisible();
 
-    expect(screen.getByText('Scan policy editor')).toBeInTheDocument();
+    expect(screen.getByText('Scan policy')).toBeInTheDocument();
     expect(screen.getByLabelText(/Trigger mode/i)).not.toBeVisible();
 
-    fireEvent.click(screen.getByText('Scan policy editor'));
+    fireEvent.click(screen.getByText('Scan policy'));
     expect(screen.getByLabelText(/Trigger mode/i)).toBeVisible();
   });
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1253,7 +1253,7 @@ function formatRepoScanSubmitError(error: unknown): string {
     }
     if (error.status === 403) {
       return appendAPIDetail(
-        'That repository is not currently allowed for this project. For GitHub App sources, select it during installation and refresh status; for PAT-backed scans, ask an operator to allow that owner/repo target.',
+        'That repository is not currently allowed for this GitHub source. Select it during installation and refresh status, or ask an operator to allow that owner/repo target for PAT-backed scans.',
         error
       );
     }
@@ -5237,7 +5237,7 @@ export function ProductProjectDetailPage() {
       setScanPolicyError(
         scanPolicyResult.reason instanceof Error
           ? scanPolicyResult.reason.message
-          : 'Unable to load scan policies for this project.'
+          : 'Unable to load scan policies for this source.'
       );
       setScanPolicies([]);
     }
@@ -5444,11 +5444,9 @@ export function ProductProjectDetailPage() {
   const selectedAvailability = sourceAvailability[selectedSource] ?? { visible: true, available: true };
   const selectedUnavailable = !selectedAvailability.available;
   const sourceScopeProfile = sourceScope ? SOURCE_PROFILES[sourceScope] : null;
-  const sourcePageKicker = sourceScopeProfile ? `${sourceScopeProfile.name} source` : 'Project sources';
   const sourcePageTitle = sourceScopeProfile ? `Connect ${sourceScopeProfile.name}` : 'Connect project sources';
-  const sourcePageBody = sourceScopeProfile
-    ? `${sourceScopeProfile.summary} This page is scoped to ${sourceScopeProfile.name}.`
-    : 'Install source connections to collect repository, workflow, and cloud identity signals.';
+  const sourcePageBody =
+    sourceScopeProfile?.summary ?? 'Install source connections to collect repository, workflow, and cloud identity signals.';
 
   const handleGitHubStart = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -5945,29 +5943,40 @@ export function ProductProjectDetailPage() {
   return (
     <section className={`idt-app-panel idt-source-onboarding${sourceScope ? ' is-source-scoped' : ''}`}>
       <div className="idt-source-onboarding-header">
-        <div>
-          <p className="idt-app-kicker">{sourcePageKicker}</p>
-          <h2>{sourcePageTitle}</h2>
-          <p>
-            {sourceScopeProfile ? (
-              sourcePageBody
-            ) : (
-              <>
-                {sourcePageBody} Project <strong>{projectID}</strong>.
-              </>
-            )}
-          </p>
+        {sourceScopeProfile ? (
+          <div className="idt-source-onboarding-title-row">
+            <SourceLogoMark provider={selectedSource} className="is-hero" />
+            <div>
+              <h1>{sourcePageTitle}</h1>
+              <p>{sourcePageBody}</p>
+            </div>
+          </div>
+        ) : (
+          <div>
+            <p className="idt-app-kicker">Project sources</p>
+            <h2>{sourcePageTitle}</h2>
+            <p>
+              {sourcePageBody} Project <strong>{projectID}</strong>.
+            </p>
+          </div>
+        )}
+        <div className="idt-source-onboarding-actions">
+          {sourceScopeProfile ? (
+            <span className={`idt-source-status-pill is-${sourceAvailabilityTone(selectedAvailability, selectedStatus)}`}>
+              {selectedUnavailable ? 'Unavailable' : connectionLifecycle(selectedStatus)}
+            </span>
+          ) : null}
+          <button
+            type="button"
+            className="idt-btn idt-btn-ghost"
+            onClick={() => {
+              void refreshConnections(true);
+            }}
+            disabled={backendFeaturesLoading || refreshing || submitting !== '' || repoScanSubmitting}
+          >
+            {refreshing ? 'Refreshing...' : 'Refresh status'}
+          </button>
         </div>
-        <button
-          type="button"
-          className="idt-btn idt-btn-ghost"
-          onClick={() => {
-            void refreshConnections(true);
-          }}
-          disabled={backendFeaturesLoading || refreshing || submitting !== '' || repoScanSubmitting}
-        >
-          {refreshing ? 'Refreshing...' : 'Refresh status'}
-        </button>
       </div>
 
       {successMessage ? (
@@ -5977,54 +5986,58 @@ export function ProductProjectDetailPage() {
       ) : null}
 
       <div className="idt-source-wizard-grid">
-        <aside className="idt-source-picker" aria-label={sourceScopeProfile ? `${sourceScopeProfile.name} source` : 'Source types'}>
-          {sourceOrder.map((provider) => {
-            const profile = SOURCE_PROFILES[provider];
-            const status = sourceConnection(connections, provider);
-            const error = sourceErrors[provider];
-            const availability = sourceAvailability[provider];
-            return (
-              <button
-                key={provider}
-                type="button"
-                className={`idt-source-card is-provider-${provider} ${selectedSource === provider ? 'is-selected' : ''} ${
-                  availability.available ? '' : 'is-unavailable'
-                }`}
-                aria-pressed={selectedSource === provider}
-                aria-disabled={!availability.available}
-                onClick={() => setSelectedSource(provider)}
-                disabled={!availability.available}
-              >
-                <span className="idt-source-card-topline">
-                  <span className="idt-source-card-identity">
-                    <SourceLogoMark provider={provider} />
-                    <span>{profile.eyebrow}</span>
+        {sourceScopeProfile ? null : (
+          <aside className="idt-source-picker" aria-label="Source types">
+            {sourceOrder.map((provider) => {
+              const profile = SOURCE_PROFILES[provider];
+              const status = sourceConnection(connections, provider);
+              const error = sourceErrors[provider];
+              const availability = sourceAvailability[provider];
+              return (
+                <button
+                  key={provider}
+                  type="button"
+                  className={`idt-source-card is-provider-${provider} ${selectedSource === provider ? 'is-selected' : ''} ${
+                    availability.available ? '' : 'is-unavailable'
+                  }`}
+                  aria-pressed={selectedSource === provider}
+                  aria-disabled={!availability.available}
+                  onClick={() => setSelectedSource(provider)}
+                  disabled={!availability.available}
+                >
+                  <span className="idt-source-card-topline">
+                    <span className="idt-source-card-identity">
+                      <SourceLogoMark provider={provider} />
+                      <span>{profile.eyebrow}</span>
+                    </span>
+                    <span className={`idt-source-status-pill is-${sourceAvailabilityTone(availability, status)}`}>
+                      {!availability.available ? 'Unavailable' : error ? 'Needs retry' : connectionLifecycle(status)}
+                    </span>
                   </span>
-                  <span className={`idt-source-status-pill is-${sourceAvailabilityTone(availability, status)}`}>
-                    {!availability.available ? 'Unavailable' : error ? 'Needs retry' : connectionLifecycle(status)}
-                  </span>
-                </span>
-                <strong>{profile.name}</strong>
-                <small>{availability.unavailableMessage ?? profile.primarySignal}</small>
-              </button>
-            );
-          })}
-        </aside>
+                  <strong>{profile.name}</strong>
+                  <small>{availability.unavailableMessage ?? profile.primarySignal}</small>
+                </button>
+              );
+            })}
+          </aside>
+        )}
 
         <div className="idt-source-config">
-          <div className="idt-source-config-header">
-            <div className="idt-source-config-title">
-              <SourceLogoMark provider={selectedSource} className="is-hero" />
-              <div>
-                <p className="idt-app-kicker">{selectedProfile.eyebrow}</p>
-                <h3>{selectedProfile.name}</h3>
-                <p>{selectedProfile.summary}</p>
+          {sourceScopeProfile ? null : (
+            <div className="idt-source-config-header">
+              <div className="idt-source-config-title">
+                <SourceLogoMark provider={selectedSource} className="is-hero" />
+                <div>
+                  <p className="idt-app-kicker">{selectedProfile.eyebrow}</p>
+                  <h3>{selectedProfile.name}</h3>
+                  <p>{selectedProfile.summary}</p>
+                </div>
               </div>
+              <span className={`idt-source-status-pill is-${sourceAvailabilityTone(selectedAvailability, selectedStatus)}`}>
+                {selectedUnavailable ? 'Unavailable' : connectionLifecycle(selectedStatus)}
+              </span>
             </div>
-            <span className={`idt-source-status-pill is-${sourceAvailabilityTone(selectedAvailability, selectedStatus)}`}>
-              {selectedUnavailable ? 'Unavailable' : connectionLifecycle(selectedStatus)}
-            </span>
-          </div>
+          )}
 
           <dl className="idt-source-meta">
             <div>
@@ -6059,9 +6072,9 @@ export function ProductProjectDetailPage() {
             <div className="idt-source-form-stack">
               <article className="idt-source-install-card idt-source-primary-action">
                 <div className="idt-source-primary-copy">
-                  <p className="idt-app-kicker">Recommended setup</p>
+                  <p className="idt-app-kicker">Setup</p>
                   <h4>Install Identrail on GitHub</h4>
-                  <p>Choose an account and the repositories Identrail can read.</p>
+                  <p>Choose the account and repositories to scan.</p>
                 </div>
                 <form className="idt-app-form" onSubmit={handleGitHubStart}>
                   <label>
@@ -6152,8 +6165,8 @@ export function ProductProjectDetailPage() {
                 <form className="idt-app-form idt-repo-scan-launch" onSubmit={handleRepoScanSubmit}>
                   <article className="idt-source-install-card idt-repo-scan-launch-card">
                     <div>
-                      <h4>First repository scan</h4>
-                      <p>Scan the selected repository.</p>
+                      <h4>Run scan</h4>
+                      <p>Scan a selected repository and route results to GitHub findings.</p>
                     </div>
                     <Link className="idt-btn idt-btn-ghost" to={repoScanFindingsPath}>
                       View findings
@@ -6286,8 +6299,8 @@ export function ProductProjectDetailPage() {
               {FEATURE_CONNECTOR_AWS ? (
                 <article className="idt-source-install-card idt-aws-launch-card">
                   <div>
-                    <h4>CloudFormation setup</h4>
-                    <p>{awsCloudFormationStart ? 'Stack launch generated.' : 'Generate a least-privilege stack launch.'}</p>
+                    <h4>Launch read-only stack</h4>
+                    <p>{awsCloudFormationStart ? 'Stack launch generated.' : 'Generate the read-only role and trust policy.'}</p>
                   </div>
                   <div className="idt-source-actions">
                     <button className="idt-btn idt-btn-dark" type="button" onClick={handleAWSCloudFormationStart} disabled={submitting !== ''}>
@@ -6682,8 +6695,8 @@ export function ProductProjectDetailPage() {
           <summary className="idt-source-policy-summary">
             <div>
               <p className="idt-app-kicker">Automation policies</p>
-              <h3>Scan policy editor</h3>
-              <p>Define trigger mode, schedule cadence, and scan limits for this project.</p>
+              <h3>Scan policy</h3>
+              <p>Define trigger mode, cadence, and limits for this source.</p>
             </div>
             <span className="idt-source-status-pill is-warning">Advanced</span>
           </summary>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -24064,6 +24064,77 @@ html[data-theme='light'] .idt-app-console-layout .idt-source-meta div {
   padding: 0.95rem 1rem;
 }
 
+.idt-source-onboarding-title-row,
+.idt-source-onboarding-actions {
+  display: flex;
+  align-items: center;
+}
+
+.idt-source-onboarding-title-row {
+  min-width: 0;
+  gap: 0.9rem;
+}
+
+.idt-source-onboarding-title-row > div {
+  min-width: 0;
+}
+
+.idt-source-onboarding-actions {
+  flex: 0 0 auto;
+  justify-content: flex-end;
+  gap: 0.6rem;
+}
+
+.idt-app-console-layout .idt-source-onboarding.is-source-scoped .idt-source-onboarding-header,
+html[data-theme='light'] .idt-app-console-layout .idt-source-onboarding.is-source-scoped .idt-source-onboarding-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  border: 0;
+  padding: 0.15rem 0 0.35rem;
+  background: transparent;
+  box-shadow: none;
+}
+
+.idt-app-console-layout .idt-source-onboarding.is-source-scoped .idt-source-onboarding-header h1,
+html[data-theme='light'] .idt-app-console-layout .idt-source-onboarding.is-source-scoped .idt-source-onboarding-header h1 {
+  margin: 0 0 0.35rem;
+  color: #ffffff;
+  font-family: var(--idt-display);
+  font-size: clamp(2rem, 3vw, 2.8rem);
+  line-height: 1;
+  letter-spacing: 0;
+  text-transform: none;
+  text-wrap: balance;
+}
+
+.idt-app-console-layout .idt-source-onboarding.is-source-scoped .idt-source-onboarding-header p,
+html[data-theme='light'] .idt-app-console-layout .idt-source-onboarding.is-source-scoped .idt-source-onboarding-header p {
+  max-width: 76ch;
+  color: var(--app-muted);
+}
+
+.idt-app-console-layout .idt-source-onboarding.is-source-scoped .idt-source-logo-mark.is-hero {
+  width: 3.25rem;
+  height: 3.25rem;
+  border-color: var(--app-border-soft);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04), 0 18px 36px rgba(0, 0, 0, 0.22);
+}
+
+.idt-app-console-layout .idt-source-onboarding.is-source-scoped .idt-source-wizard-grid {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.idt-app-console-layout .idt-source-onboarding.is-source-scoped .idt-source-config {
+  gap: 1rem;
+  width: 100%;
+  padding: 1.15rem;
+}
+
+.idt-app-console-layout .idt-source-onboarding.is-source-scoped .idt-source-meta {
+  grid-template-columns: minmax(0, 1.25fr) minmax(10rem, 0.45fr) minmax(13rem, 0.62fr);
+}
+
 @media (max-width: 980px) {
   .idt-app-console-layout .idt-projects-summary,
   .idt-app-console-layout .idt-projects-grid,
@@ -24084,6 +24155,19 @@ html[data-theme='light'] .idt-app-console-layout .idt-source-meta div {
 
   .idt-app-console-layout .idt-source-card {
     min-height: 0;
+  }
+
+  .idt-source-onboarding-title-row,
+  .idt-source-onboarding-actions {
+    align-items: flex-start;
+  }
+
+  .idt-source-onboarding-actions {
+    justify-content: flex-start;
+  }
+
+  .idt-app-console-layout .idt-source-onboarding.is-source-scoped .idt-source-onboarding-header {
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
Fixes #1428

## Summary
- Deduplicates scoped AWS and GitHub connect pages so the provider identity appears once in the top H1, not again in a source picker and inner config header.
- Keeps the generic multi-source picker intact for unscoped project-source onboarding, while scoped pages now use a full-width form/status panel.
- Tightens source setup, scan, policy, and source-specific error copy so the page reads like a premium domain control surface instead of a project selector.
- Updates ProductProjectDetailPage coverage for the new scoped-page behavior.

## Validation
- `npm test -- --run src/productShell.test.tsx` (38 tests passed)
- `npm run build` (Vite build completed and prerendered 39 routes)
- `git diff --check`
- Browser QA against local mock API: verified scoped GitHub and AWS pages render one H1, no `Source types` picker, no duplicate inner provider heading, and no `This page is scoped...` copy.
- Push hooks passed: merge-conflict check, YAML check, EOF/whitespace, gofmt check, go vet, local env token hygiene, Vercel artifact hygiene.

## AI disclosure
- AI-assisted: yes
- Tools used: Codex
- Where used: `web/src/productShell.tsx`, `web/src/productShell.test.tsx`, `web/src/styles.css`
- Human verification performed: focused product shell tests, production web build, diff hygiene check, browser QA for scoped AWS/GitHub pages

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies connect pages by deduplicating provider identity on scoped routes. Scoped pages now show a single H1 with provider branding and a full-width config/status panel; unscoped flows keep the multi-source picker.

- **Refactors**
  - Scoped pages: H1 “Connect {Provider}”, hero logo, status pill + Refresh in header; hide “Source types” picker and inner provider header; remove “This page is scoped...” copy.
  - Unscoped pages: keep multi-source picker and h2 header.
  - Copy: “Recommended setup” → “Setup”; GitHub install copy simplified; “First repository scan” → “Run scan” with findings routing; AWS card → “Launch read-only stack” with role/trust copy; “Scan policy editor” → “Scan policy” for this source; errors now say “source”; GitHub repo error clarifies App vs PAT.
  - Layout/CSS: new scoped header grid and actions row, single-column scoped grid, hero logo polish, responsive tweaks.
  - Tests: updated for H1 level, removed picker/inner header/scoped copy, and renamed policy/setup labels.

<sup>Written for commit 2ea7ff4700bb865f820dac1350a57acde6cd6228. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1429?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

