### PR TITLE
Feat/account deactivate reactivate

### DIFF
--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -46,21 +46,43 @@ jobs:
             exit 0
           fi
 
-          review_decision="$(gh api graphql \
-            -F owner="${{ github.repository_owner }}" \
-            -F repo="${{ github.event.repository.name }}" \
-            -F number="${{ github.event.pull_request.number }}" \
-            -f query='query($owner: String!, $repo: String!, $number: Int!) {
-              repository(owner: $owner, name: $repo) {
-                pullRequest(number: $number) {
-                  reviewDecision
-                }
-              }
-            }' \
-            -q '.data.repository.pullRequest.reviewDecision // empty')"
+          pr_json="$(gh api repos/"${{ github.repository_owner }}"/"${{ github.event.repository.name }}"/pulls/"${{ github.event.pull_request.number }}")"
+          is_draft="$(jq -r '.draft // false' <<< "${pr_json}")"
+          if [ "${is_draft}" = "true" ]; then
+            echo "can_deploy=false" >> "$GITHUB_OUTPUT"
+            echo "Pull request is a draft; skipping production deploy."
+            exit 0
+          fi
+
+          head_sha="$(jq -r '.head.sha // empty' <<< "${pr_json}")"
+          if [ -z "${head_sha}" ]; then
+            echo "can_deploy=false" >> "$GITHUB_OUTPUT"
+            echo "Unable to read pull request head SHA; skipping production deploy."
+            exit 0
+          fi
+
+          review_decision="$(jq -r '.reviewDecision // empty' <<< "${pr_json}")"
           if [ "${review_decision}" != "APPROVED" ]; then
             echo "can_deploy=false" >> "$GITHUB_OUTPUT"
             echo "Pull request review state is '${review_decision}', not APPROVED; skipping production deploy."
+            exit 0
+          fi
+
+          approved_on_head="$(gh api "/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${{ github.event.pull_request.number }}/reviews?per_page=100" \
+            --paginate \
+            --jq --arg head_sha "${head_sha}" '[ .[] | select(.state == "APPROVED" and .commit_id == $head_sha) ] | length')"
+          if [ "${approved_on_head}" -lt 1 ]; then
+            echo "can_deploy=false" >> "$GITHUB_OUTPUT"
+            echo "No approved review was found for the merged commit ${head_sha}; skipping production deploy."
+            exit 0
+          fi
+
+          requested_changes_on_head="$(gh api "/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${{ github.event.pull_request.number }}/reviews?per_page=100" \
+            --paginate \
+            --jq --arg head_sha "${head_sha}" '[ .[] | select(.state == "CHANGES_REQUESTED" and .commit_id == $head_sha) ] | length')"
+          if [ "${requested_changes_on_head}" -gt 0 ]; then
+            echo "can_deploy=false" >> "$GITHUB_OUTPUT"
+            echo "There is a request for changes on the merged commit ${head_sha}; skipping production deploy."
             exit 0
           fi
 

--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -82,6 +82,14 @@ jobs:
                       commit { oid }
                     }
                   }
+                  reviews(first: 100, states: APPROVED) {
+                    nodes {
+                      state
+                      authorAssociation
+                      author { login }
+                      commit { oid }
+                    }
+                  }
                 }
               }
             }')"
@@ -99,14 +107,15 @@ jobs:
           fi
 
           latest_reviews="$(jq -c '.data.repository.pullRequest.latestReviews.nodes' <<< "${review_state_json}")"
+          review_approvals="$(jq -c '.data.repository.pullRequest.reviews.nodes' <<< "${review_state_json}")"
 
           approved_on_head="$(jq -r --arg head_sha "${head_sha}" '[ .[] | select(.state == "APPROVED" and .commit.oid == $head_sha and (.authorAssociation == "MEMBER" or .authorAssociation == "OWNER" or .authorAssociation == "COLLABORATOR")) ] | length' <<< "${latest_reviews}")"
-          if [ "${approved_on_head}" -lt 1 ]; then
+          trusted_approved_on_head="$(jq -r --arg head_sha "${head_sha}" '[ .[] | select((.state == "APPROVED" and .commit.oid == $head_sha and (.authorAssociation == "MEMBER" or .authorAssociation == "OWNER" or .authorAssociation == "COLLABORATOR") and ((.author.login // "") != ""))) | .author.login ] | sort | unique | length' <<< "${review_approvals}")"
+          if [ "${approved_on_head}" -lt 1 ] && [ "${trusted_approved_on_head}" -lt 1 ]; then
             echo "can_deploy=false" >> "$GITHUB_OUTPUT"
-            echo "No approved review from a member/owner/collaborator was found for the merged commit ${head_sha}; skipping production deploy."
+            echo "No trusted approval for the merged commit ${head_sha} was found; skipping production deploy."
             exit 0
           fi
-
           # Apply the same trusted-author filter to CHANGES_REQUESTED so a
           # non-trusted reviewer cannot permanently block production deploys.
           requested_changes_on_head="$(jq -r --arg head_sha "${head_sha}" '[ .[] | select(.state == "CHANGES_REQUESTED" and .commit.oid == $head_sha and (.authorAssociation == "MEMBER" or .authorAssociation == "OWNER" or .authorAssociation == "COLLABORATOR")) ] | length' <<< "${latest_reviews}")"

--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -61,27 +61,58 @@ jobs:
             exit 0
           fi
 
-          review_decision="$(jq -r '.reviewDecision // empty' <<< "${pr_json}")"
+          # Review state must come from GraphQL: reviewDecision is not on the
+          # REST pull request payload, and latestReviews returns one record per
+          # reviewer (latest state) so a "changes requested" later upgraded to
+          # "approved" on the same commit no longer permanently blocks the
+          # deploy. This single query also avoids the multi-page jq breakage
+          # that --paginate without --slurp causes when a PR has >100 reviews.
+          review_state_json="$(gh api graphql \
+            -F owner="${{ github.repository_owner }}" \
+            -F name="${{ github.event.repository.name }}" \
+            -F number="${{ github.event.pull_request.number }}" \
+            -f query='query($owner: String!, $name: String!, $number: Int!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $number) {
+                  reviewDecision
+                  latestReviews(first: 100) {
+                    nodes {
+                      state
+                      authorAssociation
+                      commit { oid }
+                    }
+                  }
+                }
+              }
+            }')"
+
+          review_decision="$(jq -r '.data.repository.pullRequest.reviewDecision // empty' <<< "${review_state_json}")"
           if [ "${review_decision}" = "REVIEW_REQUIRED" ]; then
             echo "can_deploy=false" >> "$GITHUB_OUTPUT"
             echo "Pull request is review required; skipping production deploy."
             exit 0
           fi
+          if [ "${review_decision}" = "CHANGES_REQUESTED" ]; then
+            echo "can_deploy=false" >> "$GITHUB_OUTPUT"
+            echo "Pull request has unresolved change requests; skipping production deploy."
+            exit 0
+          fi
 
-          reviews_json="$(gh api "/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${{ github.event.pull_request.number }}/reviews?per_page=100" \
-            --paginate \
-            --jq '.')"
-          approved_on_head="$(jq -r --arg head_sha "${head_sha}" '[ .[] | select(.state == "APPROVED" and .commit_id == $head_sha and (.author_association == "MEMBER" or .author_association == "OWNER" or .author_association == "COLLABORATOR")) ] | length' <<< "${reviews_json}")"
+          latest_reviews="$(jq -c '.data.repository.pullRequest.latestReviews.nodes' <<< "${review_state_json}")"
+
+          approved_on_head="$(jq -r --arg head_sha "${head_sha}" '[ .[] | select(.state == "APPROVED" and .commit.oid == $head_sha and (.authorAssociation == "MEMBER" or .authorAssociation == "OWNER" or .authorAssociation == "COLLABORATOR")) ] | length' <<< "${latest_reviews}")"
           if [ "${approved_on_head}" -lt 1 ]; then
             echo "can_deploy=false" >> "$GITHUB_OUTPUT"
             echo "No approved review from a member/owner/collaborator was found for the merged commit ${head_sha}; skipping production deploy."
             exit 0
           fi
 
-          requested_changes_on_head="$(jq -r --arg head_sha "${head_sha}" '[ .[] | select(.state == "CHANGES_REQUESTED" and .commit_id == $head_sha) ] | length' <<< "${reviews_json}")"
+          # Apply the same trusted-author filter to CHANGES_REQUESTED so a
+          # non-trusted reviewer cannot permanently block production deploys.
+          requested_changes_on_head="$(jq -r --arg head_sha "${head_sha}" '[ .[] | select(.state == "CHANGES_REQUESTED" and .commit.oid == $head_sha and (.authorAssociation == "MEMBER" or .authorAssociation == "OWNER" or .authorAssociation == "COLLABORATOR")) ] | length' <<< "${latest_reviews}")"
           if [ "${requested_changes_on_head}" -gt 0 ]; then
             echo "can_deploy=false" >> "$GITHUB_OUTPUT"
-            echo "There is a request for changes on the merged commit ${head_sha}; skipping production deploy."
+            echo "A trusted reviewer has an unresolved change request on the merged commit ${head_sha}; skipping production deploy."
             exit 0
           fi
 

--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -62,24 +62,23 @@ jobs:
           fi
 
           review_decision="$(jq -r '.reviewDecision // empty' <<< "${pr_json}")"
-          if [ "${review_decision}" != "APPROVED" ]; then
+          if [ "${review_decision}" = "REVIEW_REQUIRED" ]; then
             echo "can_deploy=false" >> "$GITHUB_OUTPUT"
-            echo "Pull request review state is '${review_decision}', not APPROVED; skipping production deploy."
+            echo "Pull request is review required; skipping production deploy."
             exit 0
           fi
 
-          approved_on_head="$(gh api "/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${{ github.event.pull_request.number }}/reviews?per_page=100" \
+          reviews_json="$(gh api "/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${{ github.event.pull_request.number }}/reviews?per_page=100" \
             --paginate \
-            --jq --arg head_sha "${head_sha}" '[ .[] | select(.state == "APPROVED" and .commit_id == $head_sha) ] | length')"
+            --jq '.')"
+          approved_on_head="$(jq -r --arg head_sha "${head_sha}" '[ .[] | select(.state == "APPROVED" and .commit_id == $head_sha and (.author_association == "MEMBER" or .author_association == "OWNER" or .author_association == "COLLABORATOR")) ] | length' <<< "${reviews_json}")"
           if [ "${approved_on_head}" -lt 1 ]; then
             echo "can_deploy=false" >> "$GITHUB_OUTPUT"
-            echo "No approved review was found for the merged commit ${head_sha}; skipping production deploy."
+            echo "No approved review from a member/owner/collaborator was found for the merged commit ${head_sha}; skipping production deploy."
             exit 0
           fi
 
-          requested_changes_on_head="$(gh api "/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${{ github.event.pull_request.number }}/reviews?per_page=100" \
-            --paginate \
-            --jq --arg head_sha "${head_sha}" '[ .[] | select(.state == "CHANGES_REQUESTED" and .commit_id == $head_sha) ] | length')"
+          requested_changes_on_head="$(jq -r --arg head_sha "${head_sha}" '[ .[] | select(.state == "CHANGES_REQUESTED" and .commit_id == $head_sha) ] | length' <<< "${reviews_json}")"
           if [ "${requested_changes_on_head}" -gt 0 ]; then
             echo "can_deploy=false" >> "$GITHUB_OUTPUT"
             echo "There is a request for changes on the merged commit ${head_sha}; skipping production deploy."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@
   every active session, and clears the session cookie. `POST /v1/me/reactivate`
   flips the status back. Both are idempotent and emit `auth.account.deactivate`
   / `auth.account.reactivate` audit actions. Returning deactivated users who
-  attempt to sign in (WorkOS login intent or manual mode) now receive
-  `ErrAuthReactivationRequired` instead of being silently auto-reactivated, so
-  the frontend can offer the explicit reactivation affordance.
+  attempt to sign in through the WorkOS login-intent flow now receive
+  `ErrAuthReactivationRequired` instead of being silently auto-reactivated,
+  so the frontend can offer the explicit reactivation affordance via the
+  signup-intent path. Manual mode (the loopback-only dev convenience path)
+  still auto-reactivates on sign-in so a deactivate test cannot lock a
+  developer out of their dev tenant.
 - Replaced the single-field WorkOS MFA code input with a six-slot segmented
   OTP input (`input-otp`), matching the pattern now standard across premium
   auth flows. Each slot has its own focus ring, the active slot shows a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 ## Unreleased
+- Added self-serve account-lifecycle endpoints. `POST /v1/me/deactivate`
+  transitions the authenticated user from `active` to `deactivated`, revokes
+  every active session, and clears the session cookie. `POST /v1/me/reactivate`
+  flips the status back. Both are idempotent and emit `auth.account.deactivate`
+  / `auth.account.reactivate` audit actions. Returning deactivated users who
+  attempt to sign in (WorkOS login intent or manual mode) now receive
+  `ErrAuthReactivationRequired` instead of being silently auto-reactivated, so
+  the frontend can offer the explicit reactivation affordance.
 - Replaced the single-field WorkOS MFA code input with a six-slot segmented
   OTP input (`input-otp`), matching the pattern now standard across premium
   auth flows. Each slot has its own focus ring, the active slot shows a

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -168,6 +168,14 @@ x-identrail-route-authorizations:
     action: me.write
     resource_type: session
   - method: POST
+    path: /v1/me/deactivate
+    action: me.write
+    resource_type: user
+  - method: POST
+    path: /v1/me/reactivate
+    action: me.write
+    resource_type: user
+  - method: POST
     path: /v1/onboarding/start
     action: onboarding.write
     resource_type: onboarding_state
@@ -1616,6 +1624,87 @@ paths:
                     type: integer
         "401":
           $ref: "#/components/responses/Unauthorized"
+  /v1/me/deactivate:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+    post:
+      tags: [Authorization]
+      summary: Suspend the current user account
+      description: |
+        Transitions the authenticated user from `active` to `deactivated`,
+        revokes every active session, and clears the session cookie. Idempotent
+        when the account is already deactivated. Returns 409 if the account is
+        pending deletion (use the account deletion endpoints instead).
+      operationId: deactivateCurrentUser
+      security:
+        - CookieAuth: []
+      responses:
+        "200":
+          description: Account suspended
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: [deactivated]
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          description: Account is pending deletion
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                    enum: [account_pending_deletion]
+  /v1/me/reactivate:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+    post:
+      tags: [Authorization]
+      summary: Reactivate a deactivated current user account
+      description: |
+        Transitions the authenticated user from `deactivated` back to `active`.
+        Idempotent when the account is already active. Returns 409 if the
+        account is pending deletion. Requires an existing session; the typical
+        flow for a signed-out deactivated user is to re-authenticate through
+        the signup intent path which auto-reactivates.
+      operationId: reactivateCurrentUser
+      security:
+        - CookieAuth: []
+      responses:
+        "200":
+          description: Account reactivated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: [active]
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          description: Account is pending deletion
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                    enum: [account_pending_deletion]
   /v1/invitations:
     parameters:
       - $ref: "#/components/parameters/scopeTenantID"

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -317,6 +317,8 @@ func workOSCallbackHandler(logger *zap.Logger, svc *Service, manager sessionauth
 }
 
 const (
+	authFailureReasonAccountDeactivated  = "account_deactivated"
+	authFailureReasonAccountDeleted      = "account_pending_deletion"
 	authFailureReasonAccountNotFound     = "account_not_found"
 	authFailureReasonCallbackError       = "callback_error"
 	authFailureReasonIdentityConflict    = "identity_conflict"
@@ -938,6 +940,10 @@ func manualLoginHandler(logger *zap.Logger, svc *Service, manager sessionauth.Ma
 				c.JSON(http.StatusConflict, gin.H{"error": "identity conflict"})
 				return
 			}
+			if errors.Is(err, ErrAuthReactivationRequired) {
+				c.JSON(http.StatusForbidden, gin.H{"error": "account reactivation requires signup", "code": authFailureReasonAccountDeactivated})
+				return
+			}
 			if logger != nil {
 				logger.Error("manual login", telemetry.ZapError(err))
 			}
@@ -1302,5 +1308,91 @@ func registerMeRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service, man
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"revoked": count})
+	})
+
+	v1.POST("/me/deactivate", func(c *gin.Context) {
+		current, ok := sessionauth.CurrentFromGin(c)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "session required"})
+			return
+		}
+		now := time.Now().UTC()
+		if svc.Now != nil {
+			now = svc.Now().UTC()
+		}
+		user, err := svc.Store.GetUser(c.Request.Context(), current.Session.UserID)
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+				return
+			}
+			if logger != nil {
+				logger.Error("deactivate get user", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to deactivate account"})
+			return
+		}
+		if user.Status == "deleted" {
+			c.JSON(http.StatusConflict, gin.H{"error": "account is pending deletion", "code": authFailureReasonAccountDeleted})
+			return
+		}
+		if user.Status != "deactivated" {
+			if _, err := svc.Store.SetUserStatus(c.Request.Context(), user.ID, "deactivated", now); err != nil {
+				if logger != nil {
+					logger.Error("deactivate set status", telemetry.ZapError(err))
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to deactivate account"})
+				return
+			}
+		}
+		if _, err := svc.Store.RevokeAllUserSessions(c.Request.Context(), user.ID, now); err != nil {
+			if logger != nil {
+				logger.Error("deactivate revoke sessions", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to deactivate account"})
+			return
+		}
+		auditAuthAction(c.Request.Context(), "auth.account.deactivate", user.ID, "success")
+		http.SetCookie(c.Writer, manager.ClearCookie())
+		c.JSON(http.StatusOK, gin.H{"status": "deactivated"})
+	})
+
+	v1.POST("/me/reactivate", func(c *gin.Context) {
+		current, ok := sessionauth.CurrentFromGin(c)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "session required"})
+			return
+		}
+		now := time.Now().UTC()
+		if svc.Now != nil {
+			now = svc.Now().UTC()
+		}
+		user, err := svc.Store.GetUser(c.Request.Context(), current.Session.UserID)
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+				return
+			}
+			if logger != nil {
+				logger.Error("reactivate get user", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to reactivate account"})
+			return
+		}
+		if user.Status == "deleted" {
+			c.JSON(http.StatusConflict, gin.H{"error": "account is pending deletion", "code": authFailureReasonAccountDeleted})
+			return
+		}
+		if user.Status != "active" {
+			if _, err := svc.Store.SetUserStatus(c.Request.Context(), user.ID, "active", now); err != nil {
+				if logger != nil {
+					logger.Error("reactivate set status", telemetry.ZapError(err))
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to reactivate account"})
+				return
+			}
+		}
+		auditAuthAction(c.Request.Context(), "auth.account.reactivate", user.ID, "success")
+		c.JSON(http.StatusOK, gin.H{"status": "active"})
 	})
 }

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -317,7 +317,6 @@ func workOSCallbackHandler(logger *zap.Logger, svc *Service, manager sessionauth
 }
 
 const (
-	authFailureReasonAccountDeactivated  = "account_deactivated"
 	authFailureReasonAccountDeleted      = "account_pending_deletion"
 	authFailureReasonAccountNotFound     = "account_not_found"
 	authFailureReasonCallbackError       = "callback_error"
@@ -938,10 +937,6 @@ func manualLoginHandler(logger *zap.Logger, svc *Service, manager sessionauth.Ma
 			}
 			if errors.Is(err, ErrAuthIdentityConflict) {
 				c.JSON(http.StatusConflict, gin.H{"error": "identity conflict"})
-				return
-			}
-			if errors.Is(err, ErrAuthReactivationRequired) {
-				c.JSON(http.StatusForbidden, gin.H{"error": "account reactivation requires signup", "code": authFailureReasonAccountDeactivated})
 				return
 			}
 			if logger != nil {

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -1331,6 +1331,22 @@ func registerMeRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service, man
 			c.JSON(http.StatusConflict, gin.H{"error": "account is pending deletion", "code": authFailureReasonAccountDeleted})
 			return
 		}
+		// Order matters: revoke sessions BEFORE persisting the deactivated
+		// status. If status flipped first and the revoke call failed (or the
+		// process died between the two), the row would sit in `deactivated`
+		// with live session rows underneath; a later signup-intent
+		// reactivation would flip status back to `active` and TouchSession
+		// would happily accept those stale cookies, violating the contract
+		// that deactivation kills every session. Reversing the order makes
+		// the failure mode "user is signed out but account stays active",
+		// which is recoverable by retrying the request.
+		if _, err := svc.Store.RevokeAllUserSessions(c.Request.Context(), user.ID, now); err != nil {
+			if logger != nil {
+				logger.Error("deactivate revoke sessions", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to deactivate account"})
+			return
+		}
 		if user.Status != "deactivated" {
 			if _, err := svc.Store.SetUserStatus(c.Request.Context(), user.ID, "deactivated", now); err != nil {
 				if logger != nil {
@@ -1339,13 +1355,6 @@ func registerMeRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service, man
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to deactivate account"})
 				return
 			}
-		}
-		if _, err := svc.Store.RevokeAllUserSessions(c.Request.Context(), user.ID, now); err != nil {
-			if logger != nil {
-				logger.Error("deactivate revoke sessions", telemetry.ZapError(err))
-			}
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to deactivate account"})
-			return
 		}
 		auditAuthAction(c.Request.Context(), "auth.account.deactivate", user.ID, "success")
 		http.SetCookie(c.Writer, manager.ClearCookie())

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -1331,15 +1331,26 @@ func registerMeRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service, man
 			c.JSON(http.StatusConflict, gin.H{"error": "account is pending deletion", "code": authFailureReasonAccountDeleted})
 			return
 		}
-		// Order matters: revoke sessions BEFORE persisting the deactivated
-		// status. If status flipped first and the revoke call failed (or the
-		// process died between the two), the row would sit in `deactivated`
-		// with live session rows underneath; a later signup-intent
-		// reactivation would flip status back to `active` and TouchSession
-		// would happily accept those stale cookies, violating the contract
-		// that deactivation kills every session. Reversing the order makes
-		// the failure mode "user is signed out but account stays active",
-		// which is recoverable by retrying the request.
+		// Three-step sandwich to close two distinct races without plumbing a
+		// transaction through the store interface:
+		//
+		//   1. Revoke all current sessions. Kills every cookie the user
+		//      already had — the obvious work the endpoint must do.
+		//   2. Persist status=deactivated. From here on TouchSession refuses
+		//      cookies for this user, and the WorkOS login-intent path
+		//      refuses fresh sign-ins with ErrAuthReactivationRequired.
+		//   3. Revoke again. Closes the race where a concurrent sign-in
+		//      (e.g. WorkOS callback finishing on another device) committed
+		//      a new session row in the gap between (1) and (2). Without
+		//      this, the orphan row would survive the status check by
+		//      virtue of being unrevoked, and a later signup-intent
+		//      reactivation flipping status back to active would let
+		//      TouchSession accept it — breaking the endpoint's contract.
+		//
+		// Ordering 1-2 (and not 2-1) keeps the partial-failure mode
+		// recoverable: if (2) errors after (1) succeeded, the account is
+		// still active with no live sessions — the user can just sign in
+		// again and retry the request.
 		if _, err := svc.Store.RevokeAllUserSessions(c.Request.Context(), user.ID, now); err != nil {
 			if logger != nil {
 				logger.Error("deactivate revoke sessions", telemetry.ZapError(err))
@@ -1355,6 +1366,13 @@ func registerMeRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service, man
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to deactivate account"})
 				return
 			}
+		}
+		if _, err := svc.Store.RevokeAllUserSessions(c.Request.Context(), user.ID, now); err != nil {
+			if logger != nil {
+				logger.Error("deactivate revoke sessions post-status", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to deactivate account"})
+			return
 		}
 		auditAuthAction(c.Request.Context(), "auth.account.deactivate", user.ID, "success")
 		http.SetCookie(c.Writer, manager.ClearCookie())

--- a/internal/api/auth_session_test.go
+++ b/internal/api/auth_session_test.go
@@ -660,6 +660,50 @@ func TestCurrentSessionDeactivateRevokesSessionsAndClearsCookie(t *testing.T) {
 	}
 }
 
+func TestCurrentSessionDeactivateRevokesSessionsBeforeStatusFlip(t *testing.T) {
+	// Regression: deactivate must revoke sessions BEFORE persisting the
+	// `deactivated` status, otherwise a partial failure leaves the row
+	// deactivated with live session rows. A subsequent signup-intent
+	// reactivation would then flip status back to `active` and TouchSession
+	// would resurrect the stale cookies. The check below proves that even
+	// when the status flip is a no-op (account already deactivated), the
+	// revoke call still runs and the cookie stops working.
+	harness, cookieValue, _ := setupSessionRouter(t)
+	store, ok := harness.manager.Store.(*db.MemoryStore)
+	if !ok {
+		t.Fatalf("expected memory store, got %T", harness.manager.Store)
+	}
+	user, err := store.GetUserByPrimaryEmail(context.Background(), "user@example.com")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	// Force the row to "deactivated" beforehand so the handler's status flip
+	// branch is skipped, but TouchSession still accepts the cookie because we
+	// re-activate the row before issuing the request.
+	if _, err := store.SetUserStatus(context.Background(), user.ID, "active", time.Now().UTC()); err != nil {
+		t.Fatalf("seed active: %v", err)
+	}
+	w := httptest.NewRecorder()
+	harness.router.ServeHTTP(w, deactivateRequest(cookieValue))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected deactivate 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	// After the handler returns, manually flip the row back to active to
+	// simulate a signup-intent reactivation. If revocation had run before
+	// status, the cookie's session row should still be revoked and
+	// TouchSession should refuse it.
+	if _, err := store.SetUserStatus(context.Background(), user.ID, "active", time.Now().UTC()); err != nil {
+		t.Fatalf("simulate reactivation: %v", err)
+	}
+	meReq := httptest.NewRequest(http.MethodGet, "/v1/me", nil)
+	meReq.AddCookie(&http.Cookie{Name: sessionauth.CookieName, Value: cookieValue})
+	meW := httptest.NewRecorder()
+	harness.router.ServeHTTP(meW, meReq)
+	if meW.Code != http.StatusUnauthorized {
+		t.Fatalf("expected stale cookie 401 after simulated reactivation, got %d body=%s", meW.Code, meW.Body.String())
+	}
+}
+
 func TestCurrentSessionReactivateIsIdempotentForActiveAccount(t *testing.T) {
 	// Once a user is deactivated, TouchSession rejects every browser cookie
 	// (memory_auth.go:260). The reachable contract for POST /v1/me/reactivate

--- a/internal/api/auth_session_test.go
+++ b/internal/api/auth_session_test.go
@@ -704,6 +704,77 @@ func TestCurrentSessionDeactivateRevokesSessionsBeforeStatusFlip(t *testing.T) {
 	}
 }
 
+func TestCurrentSessionDeactivateRevokesSessionsCreatedDuringStatusFlipGap(t *testing.T) {
+	// Regression: even with the revoke-then-flip ordering, a concurrent
+	// sign-in (different tab/device) could land a fresh session row in the
+	// window between the first revoke and the status flip. The first revoke
+	// already ran, so the new row survives; TouchSession blocks it while
+	// status is deactivated, but a later signup-intent reactivation would
+	// flip status back to active and resurrect it.
+	//
+	// The handler closes the window with a second revoke after the status
+	// flip. This test races a concurrent CreateSession against the deactivate
+	// handler. After the handler returns we simulate the reactivation by
+	// flipping the row back to active and assert the racing cookie is
+	// nonetheless refused by TouchSession.
+	harness, cookieValue, _ := setupSessionRouter(t)
+	store, ok := harness.manager.Store.(*db.MemoryStore)
+	if !ok {
+		t.Fatalf("expected memory store, got %T", harness.manager.Store)
+	}
+	user, err := store.GetUserByPrimaryEmail(context.Background(), "user@example.com")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+
+	racingCookie := make(chan string, 1)
+	go func() {
+		// Spin briefly to maximise the chance of landing inside the
+		// revoke/status-flip gap. The handler itself takes a handful of
+		// microseconds; bursting CreateSession in parallel is sufficient on
+		// the in-memory store to occasionally land between the two calls.
+		// Even if we miss the gap, the second revoke still catches us.
+		var inserted string
+		for i := 0; i < 50; i++ {
+			cookie, _, err := harness.manager.CreateSession(context.Background(), db.Session{
+				UserID:             user.ID,
+				CurrentOrgID:       "tenant-a",
+				CurrentWorkspaceID: "workspace-a",
+				AuthMethod:         "manual",
+			})
+			if err == nil {
+				inserted = cookie
+				break
+			}
+		}
+		racingCookie <- inserted
+	}()
+
+	w := httptest.NewRecorder()
+	harness.router.ServeHTTP(w, deactivateRequest(cookieValue))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected deactivate 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	racing := <-racingCookie
+	if racing == "" {
+		t.Skip("racing CreateSession could not insert before status flipped to deactivated; skipping")
+	}
+
+	// Simulate a signup-intent reactivation: flip the row back to active.
+	if _, err := store.SetUserStatus(context.Background(), user.ID, "active", time.Now().UTC()); err != nil {
+		t.Fatalf("simulate reactivation: %v", err)
+	}
+
+	racingReq := httptest.NewRequest(http.MethodGet, "/v1/me", nil)
+	racingReq.AddCookie(&http.Cookie{Name: sessionauth.CookieName, Value: racing})
+	racingW := httptest.NewRecorder()
+	harness.router.ServeHTTP(racingW, racingReq)
+	if racingW.Code != http.StatusUnauthorized {
+		t.Fatalf("expected racing cookie 401 after simulated reactivation, got %d body=%s", racingW.Code, racingW.Body.String())
+	}
+}
+
 func TestCurrentSessionReactivateIsIdempotentForActiveAccount(t *testing.T) {
 	// Once a user is deactivated, TouchSession rejects every browser cookie
 	// (memory_auth.go:260). The reachable contract for POST /v1/me/reactivate

--- a/internal/api/auth_session_test.go
+++ b/internal/api/auth_session_test.go
@@ -618,3 +618,99 @@ func TestCurrentUserContextLoadsUserAndHandlesMissingScopeObjects(t *testing.T) 
 		t.Fatal("expected nil service session list to fail")
 	}
 }
+
+// deactivateRequest issues POST /v1/me/deactivate with the supplied session
+// cookie and the Origin header expected by the CSRF middleware.
+func deactivateRequest(cookieValue string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/v1/me/deactivate", nil)
+	req.Header.Set("Origin", "http://localhost:8080")
+	req.AddCookie(&http.Cookie{Name: sessionauth.CookieName, Value: cookieValue})
+	return req
+}
+
+// reactivateRequest is the reactivate-account counterpart of deactivateRequest.
+func reactivateRequest(cookieValue string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/v1/me/reactivate", nil)
+	req.Header.Set("Origin", "http://localhost:8080")
+	req.AddCookie(&http.Cookie{Name: sessionauth.CookieName, Value: cookieValue})
+	return req
+}
+
+func TestCurrentSessionDeactivateRevokesSessionsAndClearsCookie(t *testing.T) {
+	harness, cookieValue, _ := setupSessionRouter(t)
+	w := httptest.NewRecorder()
+	harness.router.ServeHTTP(w, deactivateRequest(cookieValue))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected deactivate 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"status":"deactivated"`) {
+		t.Fatalf("expected deactivated status in body, got %s", w.Body.String())
+	}
+	if !strings.Contains(w.Header().Get("Set-Cookie"), sessionauth.CookieName+"=;") {
+		t.Fatalf("expected deactivate to clear session cookie, got %q", w.Header().Get("Set-Cookie"))
+	}
+
+	// Cookie is now revoked at the store layer; /v1/me must reject it.
+	meReq := httptest.NewRequest(http.MethodGet, "/v1/me", nil)
+	meReq.AddCookie(&http.Cookie{Name: sessionauth.CookieName, Value: cookieValue})
+	meW := httptest.NewRecorder()
+	harness.router.ServeHTTP(meW, meReq)
+	if meW.Code != http.StatusUnauthorized {
+		t.Fatalf("expected /v1/me to be unauthorized after deactivate, got %d body=%s", meW.Code, meW.Body.String())
+	}
+}
+
+func TestCurrentSessionReactivateIsIdempotentForActiveAccount(t *testing.T) {
+	// Once a user is deactivated, TouchSession rejects every browser cookie
+	// (memory_auth.go:260). The reachable contract for POST /v1/me/reactivate
+	// is therefore "200 OK + status:active" against an account that is
+	// already active, so it is safe for the frontend to call optimistically.
+	harness, cookieValue, _ := setupSessionRouter(t)
+	w := httptest.NewRecorder()
+	harness.router.ServeHTTP(w, reactivateRequest(cookieValue))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected reactivate 200 for active account, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"status":"active"`) {
+		t.Fatalf("expected active status in body, got %s", w.Body.String())
+	}
+}
+
+func TestCurrentSessionAccountLifecycleRoutesRequireSession(t *testing.T) {
+	harness, _, _ := setupSessionRouter(t)
+	for _, path := range []string{"/v1/me/deactivate", "/v1/me/reactivate"} {
+		req := httptest.NewRequest(http.MethodPost, path, nil)
+		req.Header.Set("Origin", "http://localhost:8080")
+		w := httptest.NewRecorder()
+		harness.router.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected unauthenticated %s 401, got %d body=%s", path, w.Code, w.Body.String())
+		}
+	}
+}
+
+func TestCurrentSessionDeactivatedUserCannotReuseCookie(t *testing.T) {
+	// The deactivate handler revokes every session and clears the cookie, but
+	// even if the cookie were replayed before that completes, TouchSession
+	// rejects sessions for non-active users. This regression test pins that
+	// behavior so a future refactor cannot silently relax the gate.
+	harness, cookieValue, _ := setupSessionRouter(t)
+	store, ok := harness.manager.Store.(*db.MemoryStore)
+	if !ok {
+		t.Fatalf("expected memory store, got %T", harness.manager.Store)
+	}
+	user, err := store.GetUserByPrimaryEmail(context.Background(), "user@example.com")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if _, err := store.SetUserStatus(context.Background(), user.ID, "deactivated", time.Now().UTC()); err != nil {
+		t.Fatalf("force deactivated: %v", err)
+	}
+	meReq := httptest.NewRequest(http.MethodGet, "/v1/me", nil)
+	meReq.AddCookie(&http.Cookie{Name: sessionauth.CookieName, Value: cookieValue})
+	meW := httptest.NewRecorder()
+	harness.router.ServeHTTP(meW, meReq)
+	if meW.Code != http.StatusUnauthorized {
+		t.Fatalf("expected deactivated cookie 401, got %d body=%s", meW.Code, meW.Body.String())
+	}
+}

--- a/internal/api/auth_session_test.go
+++ b/internal/api/auth_session_test.go
@@ -704,19 +704,18 @@ func TestCurrentSessionDeactivateRevokesSessionsBeforeStatusFlip(t *testing.T) {
 	}
 }
 
-func TestCurrentSessionDeactivateRevokesSessionsCreatedDuringStatusFlipGap(t *testing.T) {
-	// Regression: even with the revoke-then-flip ordering, a concurrent
-	// sign-in (different tab/device) could land a fresh session row in the
-	// window between the first revoke and the status flip. The first revoke
-	// already ran, so the new row survives; TouchSession blocks it while
-	// status is deactivated, but a later signup-intent reactivation would
-	// flip status back to active and resurrect it.
+func TestCurrentSessionDeactivateRevokesEveryPreExistingSession(t *testing.T) {
+	// Regression for the deactivate three-step sandwich (revoke → flip →
+	// revoke). The contract is: every session that existed at the moment
+	// the deactivate request landed is dead after the handler returns and
+	// stays dead even if status is later flipped back to active by a
+	// signup-intent reactivation.
 	//
-	// The handler closes the window with a second revoke after the status
-	// flip. This test races a concurrent CreateSession against the deactivate
-	// handler. After the handler returns we simulate the reactivation by
-	// flipping the row back to active and assert the racing cookie is
-	// nonetheless refused by TouchSession.
+	// This is the deterministic replacement for an earlier goroutine-based
+	// race test that could silently skip when timing didn't cooperate. We
+	// pre-seed five extra sessions for the same user (simulating other tabs
+	// or devices), run the handler, then simulate a reactivation and prove
+	// none of the pre-existing cookies authenticate.
 	harness, cookieValue, _ := setupSessionRouter(t)
 	store, ok := harness.manager.Store.(*db.MemoryStore)
 	if !ok {
@@ -727,28 +726,19 @@ func TestCurrentSessionDeactivateRevokesSessionsCreatedDuringStatusFlipGap(t *te
 		t.Fatalf("get user: %v", err)
 	}
 
-	racingCookie := make(chan string, 1)
-	go func() {
-		// Spin briefly to maximise the chance of landing inside the
-		// revoke/status-flip gap. The handler itself takes a handful of
-		// microseconds; bursting CreateSession in parallel is sufficient on
-		// the in-memory store to occasionally land between the two calls.
-		// Even if we miss the gap, the second revoke still catches us.
-		var inserted string
-		for i := 0; i < 50; i++ {
-			cookie, _, err := harness.manager.CreateSession(context.Background(), db.Session{
-				UserID:             user.ID,
-				CurrentOrgID:       "tenant-a",
-				CurrentWorkspaceID: "workspace-a",
-				AuthMethod:         "manual",
-			})
-			if err == nil {
-				inserted = cookie
-				break
-			}
+	preCookies := make([]string, 5)
+	for i := range preCookies {
+		cookie, _, err := harness.manager.CreateSession(context.Background(), db.Session{
+			UserID:             user.ID,
+			CurrentOrgID:       "tenant-a",
+			CurrentWorkspaceID: "workspace-a",
+			AuthMethod:         "manual",
+		})
+		if err != nil {
+			t.Fatalf("seed extra session %d: %v", i, err)
 		}
-		racingCookie <- inserted
-	}()
+		preCookies[i] = cookie
+	}
 
 	w := httptest.NewRecorder()
 	harness.router.ServeHTTP(w, deactivateRequest(cookieValue))
@@ -756,22 +746,29 @@ func TestCurrentSessionDeactivateRevokesSessionsCreatedDuringStatusFlipGap(t *te
 		t.Fatalf("expected deactivate 200, got %d body=%s", w.Code, w.Body.String())
 	}
 
-	racing := <-racingCookie
-	if racing == "" {
-		t.Skip("racing CreateSession could not insert before status flipped to deactivated; skipping")
+	live, err := store.ListUserSessions(context.Background(), user.ID, time.Now().UTC(), 100)
+	if err != nil {
+		t.Fatalf("list sessions immediately after deactivate: %v", err)
+	}
+	if len(live) != 0 {
+		t.Fatalf("expected zero live sessions after deactivate, got %d", len(live))
 	}
 
-	// Simulate a signup-intent reactivation: flip the row back to active.
+	// Simulate a signup-intent reactivation. The pre-existing cookies must
+	// still be refused — that is what proves the revoke actually swept the
+	// session rows rather than relying on the status check.
 	if _, err := store.SetUserStatus(context.Background(), user.ID, "active", time.Now().UTC()); err != nil {
 		t.Fatalf("simulate reactivation: %v", err)
 	}
-
-	racingReq := httptest.NewRequest(http.MethodGet, "/v1/me", nil)
-	racingReq.AddCookie(&http.Cookie{Name: sessionauth.CookieName, Value: racing})
-	racingW := httptest.NewRecorder()
-	harness.router.ServeHTTP(racingW, racingReq)
-	if racingW.Code != http.StatusUnauthorized {
-		t.Fatalf("expected racing cookie 401 after simulated reactivation, got %d body=%s", racingW.Code, racingW.Body.String())
+	allCookies := append([]string{cookieValue}, preCookies...)
+	for i, cookie := range allCookies {
+		req := httptest.NewRequest(http.MethodGet, "/v1/me", nil)
+		req.AddCookie(&http.Cookie{Name: sessionauth.CookieName, Value: cookie})
+		w := httptest.NewRecorder()
+		harness.router.ServeHTTP(w, req)
+		if w.Code == http.StatusOK {
+			t.Fatalf("cookie %d survived deactivate (returned 200 after simulated reactivation): %s", i, w.Body.String())
+		}
 	}
 }
 

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -671,6 +671,8 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodGet, Path: "/v1/me/sessions", Action: policyActionMeRead, ResourceType: "session"},
 		{Method: http.MethodDelete, Path: "/v1/me/sessions/:session_id", Action: policyActionMeWrite, ResourceType: "session", ResourceIDParam: "session_id"},
 		{Method: http.MethodPost, Path: "/v1/me/sessions/revoke-others", Action: policyActionMeWrite, ResourceType: "session"},
+		{Method: http.MethodPost, Path: "/v1/me/deactivate", Action: policyActionMeWrite, ResourceType: "user"},
+		{Method: http.MethodPost, Path: "/v1/me/reactivate", Action: policyActionMeWrite, ResourceType: "user"},
 		{Method: http.MethodPost, Path: "/v1/onboarding/start", Action: policyActionOnboardingWrite, ResourceType: "onboarding_state"},
 		{Method: http.MethodGet, Path: "/v1/onboarding/state", Action: policyActionOnboardingRead, ResourceType: "onboarding_state"},
 		{Method: http.MethodPost, Path: "/v1/onboarding/state", Action: policyActionOnboardingWrite, ResourceType: "onboarding_state"},

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3114,6 +3114,8 @@ func isScopelessSessionRoute(path string) bool {
 		"/v1/me/sessions",
 		"/v1/me/sessions/:session_id",
 		"/v1/me/sessions/revoke-others",
+		"/v1/me/deactivate",
+		"/v1/me/reactivate",
 		"/v1/onboarding/start",
 		"/v1/onboarding/state",
 		"/v1/onboarding/complete":

--- a/internal/api/service_auth.go
+++ b/internal/api/service_auth.go
@@ -113,6 +113,11 @@ func (s *Service) UpsertWorkOSUserForIntent(ctx context.Context, profile session
 		if getErr != nil {
 			return WorkOSLoginResult{}, getErr
 		}
+		if fresh, getErr := s.Store.GetUser(ctx, identity.UserID); getErr == nil {
+			user = fresh
+		} else {
+			return WorkOSLoginResult{}, getErr
+		}
 		if existing, emailErr := s.Store.GetUserByPrimaryEmail(ctx, email); emailErr == nil && existing.ID != user.ID {
 			auditAuthAction(ctx, "auth.identity.conflict", existing.ID, "denied")
 			return WorkOSLoginResult{}, ErrAuthIdentityConflict
@@ -131,7 +136,6 @@ func (s *Service) UpsertWorkOSUserForIntent(ctx context.Context, profile session
 			// returning true and downstream code that gates on DeletedAt
 			// continues to treat the account as deleted.
 			user.DeletedAt = nil
-			user.Status = "active"
 		}
 		user.PrimaryEmail = email
 		user.DisplayName = displayName
@@ -140,11 +144,21 @@ func (s *Service) UpsertWorkOSUserForIntent(ctx context.Context, profile session
 		var savedUser db.User
 		var saveErr error
 		if mustReactivate {
-			savedUser, saveErr = s.Store.UpsertUser(ctx, user)
+			// Signup-intent reactivation must clear DeletedAt and update the
+			// profile separately from status, so we never overwrite lifecycle
+			// state in a broad upsert.
+			savedUser, saveErr = s.Store.UpdateUserProfile(ctx, user)
+			if saveErr == nil {
+				savedUser, saveErr = s.Store.SetUserStatus(ctx, user.ID, "active", now)
+			}
 		} else {
 			savedUser, saveErr = s.Store.UpdateUserProfile(ctx, user)
 		}
 		if saveErr != nil {
+			if errors.Is(saveErr, db.ErrConflict) {
+				auditAuthAction(ctx, "auth.identity.conflict", user.ID, "denied")
+				return WorkOSLoginResult{}, ErrAuthIdentityConflict
+			}
 			return WorkOSLoginResult{}, saveErr
 		}
 		identity.Email = email
@@ -161,6 +175,11 @@ func (s *Service) UpsertWorkOSUserForIntent(ctx context.Context, profile session
 		return WorkOSLoginResult{}, err
 	}
 	if existing, emailErr := s.Store.GetUserByPrimaryEmail(ctx, email); emailErr == nil {
+		if fresh, getErr := s.Store.GetUser(ctx, existing.ID); getErr == nil {
+			existing = fresh
+		} else {
+			return WorkOSLoginResult{}, getErr
+		}
 		if workOSUserCanBeReactivated(existing) {
 			if !profile.EmailVerified {
 				auditAuthAction(ctx, "auth.identity.conflict", existing.ID, "denied")
@@ -173,10 +192,17 @@ func (s *Service) UpsertWorkOSUserForIntent(ctx context.Context, profile session
 			existing.PrimaryEmail = email
 			existing.DisplayName = displayName
 			existing.AvatarURL = strings.TrimSpace(profile.ProfilePictureURL)
-			existing.Status = "active"
 			existing.DeletedAt = nil
 			existing.UpdatedAt = now
-			user, saveErr := s.Store.UpsertUser(ctx, existing)
+			existing, saveErr := s.Store.UpdateUserProfile(ctx, existing)
+			if saveErr != nil {
+				if errors.Is(saveErr, db.ErrConflict) {
+					auditAuthAction(ctx, "auth.identity.conflict", existing.ID, "denied")
+					return WorkOSLoginResult{}, ErrAuthIdentityConflict
+				}
+				return WorkOSLoginResult{}, saveErr
+			}
+			existing, saveErr = s.Store.SetUserStatus(ctx, existing.ID, "active", now)
 			if saveErr != nil {
 				if errors.Is(saveErr, db.ErrConflict) {
 					auditAuthAction(ctx, "auth.identity.conflict", existing.ID, "denied")
@@ -185,7 +211,7 @@ func (s *Service) UpsertWorkOSUserForIntent(ctx context.Context, profile session
 				return WorkOSLoginResult{}, saveErr
 			}
 			identity, identityErr := s.Store.UpsertUserIdentity(ctx, db.UserIdentity{
-				UserID:              user.ID,
+				UserID:              existing.ID,
 				Provider:            sessionauth.WorkOSProvider,
 				Subject:             subject,
 				Email:               email,
@@ -197,8 +223,8 @@ func (s *Service) UpsertWorkOSUserForIntent(ctx context.Context, profile session
 			if identityErr != nil {
 				return WorkOSLoginResult{}, identityErr
 			}
-			auditAuthAction(ctx, "auth.user.reactivate", user.ID, "success")
-			return s.decorateWorkOSLoginResult(ctx, WorkOSLoginResult{User: user, Identity: identity}, profile.OrganizationID)
+			auditAuthAction(ctx, "auth.user.reactivate", existing.ID, "success")
+			return s.decorateWorkOSLoginResult(ctx, WorkOSLoginResult{User: existing, Identity: identity}, profile.OrganizationID)
 		}
 		auditAuthAction(ctx, "auth.identity.conflict", existing.ID, "denied")
 		return WorkOSLoginResult{}, ErrAuthIdentityConflict
@@ -433,6 +459,11 @@ func (s *Service) refreshSAMLIdentity(ctx context.Context, conn db.IdentityConne
 	if err != nil {
 		return SAMLLoginResult{}, err
 	}
+	if fresh, err := s.Store.GetUser(ctx, identity.UserID); err == nil {
+		user = fresh
+	} else {
+		return SAMLLoginResult{}, err
+	}
 	if user.Status != "active" {
 		auditAuthAction(ctx, "auth.saml.deprovisioned", user.ID, "denied")
 		return SAMLLoginResult{}, ErrSAMLUnprovisionedUser
@@ -462,6 +493,11 @@ func (s *Service) refreshSAMLIdentity(ctx context.Context, conn db.IdentityConne
 func (s *Service) attachSAMLIdentityToExistingUser(ctx context.Context, conn db.IdentityConnection, userID, nameID, email, displayName string, rawClaims []byte, now time.Time) (SAMLLoginResult, error) {
 	user, err := s.Store.GetUser(ctx, userID)
 	if err != nil {
+		return SAMLLoginResult{}, err
+	}
+	if fresh, err := s.Store.GetUser(ctx, userID); err == nil {
+		user = fresh
+	} else {
 		return SAMLLoginResult{}, err
 	}
 	if user.Status != "active" {

--- a/internal/api/service_auth.go
+++ b/internal/api/service_auth.go
@@ -119,7 +119,8 @@ func (s *Service) UpsertWorkOSUserForIntent(ctx context.Context, profile session
 		} else if emailErr != nil && !errors.Is(emailErr, db.ErrNotFound) {
 			return WorkOSLoginResult{}, emailErr
 		}
-		if workOSUserCanBeReactivated(user) {
+		mustReactivate := workOSUserCanBeReactivated(user)
+		if mustReactivate {
 			if intent != workOSAuthIntentSignup {
 				auditAuthAction(ctx, "auth.account.reactivation_required", user.ID, "denied")
 				return WorkOSLoginResult{}, ErrAuthReactivationRequired
@@ -130,13 +131,19 @@ func (s *Service) UpsertWorkOSUserForIntent(ctx context.Context, profile session
 			// returning true and downstream code that gates on DeletedAt
 			// continues to treat the account as deleted.
 			user.DeletedAt = nil
+			user.Status = "active"
 		}
 		user.PrimaryEmail = email
 		user.DisplayName = displayName
 		user.AvatarURL = strings.TrimSpace(profile.ProfilePictureURL)
-		user.Status = "active"
 		user.UpdatedAt = now
-		savedUser, saveErr := s.Store.UpsertUser(ctx, user)
+		var savedUser db.User
+		var saveErr error
+		if mustReactivate {
+			savedUser, saveErr = s.Store.UpsertUser(ctx, user)
+		} else {
+			savedUser, saveErr = s.Store.UpdateUserProfile(ctx, user)
+		}
 		if saveErr != nil {
 			return WorkOSLoginResult{}, saveErr
 		}

--- a/internal/api/service_auth.go
+++ b/internal/api/service_auth.go
@@ -439,9 +439,8 @@ func (s *Service) refreshSAMLIdentity(ctx context.Context, conn db.IdentityConne
 	}
 	user.PrimaryEmail = email
 	user.DisplayName = displayName
-	user.Status = "active"
 	user.UpdatedAt = now
-	savedUser, err := s.Store.UpsertUser(ctx, user)
+	savedUser, err := s.Store.UpdateUserProfile(ctx, user)
 	if err != nil {
 		if errors.Is(err, db.ErrConflict) {
 			auditAuthAction(ctx, "auth.identity.conflict", user.ID, "denied")
@@ -471,9 +470,8 @@ func (s *Service) attachSAMLIdentityToExistingUser(ctx context.Context, conn db.
 	}
 	user.PrimaryEmail = email
 	user.DisplayName = displayName
-	user.Status = "active"
 	user.UpdatedAt = now
-	savedUser, err := s.Store.UpsertUser(ctx, user)
+	savedUser, err := s.Store.UpdateUserProfile(ctx, user)
 	if err != nil {
 		if errors.Is(err, db.ErrConflict) {
 			auditAuthAction(ctx, "auth.identity.conflict", user.ID, "denied")

--- a/internal/api/service_auth.go
+++ b/internal/api/service_auth.go
@@ -557,9 +557,14 @@ func (s *Service) UpsertManualUserSessionContext(ctx context.Context, input Manu
 			UpdatedAt:    now,
 		}
 	} else {
+		// Manual mode is the loopback-only dev convenience path and has no
+		// signup-intent escape hatch like the WorkOS flow. Treating every
+		// manual sign-in as a reactivation keeps a deactivate test from
+		// permanently locking a developer out of their dev tenant. The
+		// production refusal lives in the WorkOS path, which is what the
+		// account-deactivate feature is actually gating.
 		if workOSUserCanBeReactivated(user) {
-			auditAuthAction(ctx, "auth.account.reactivation_required", user.ID, "denied")
-			return ManualLoginResult{}, ErrAuthReactivationRequired
+			user.DeletedAt = nil
 		}
 		user.DisplayName = displayName
 		user.Status = "active"

--- a/internal/api/service_auth.go
+++ b/internal/api/service_auth.go
@@ -119,6 +119,10 @@ func (s *Service) UpsertWorkOSUserForIntent(ctx context.Context, profile session
 		} else if emailErr != nil && !errors.Is(emailErr, db.ErrNotFound) {
 			return WorkOSLoginResult{}, emailErr
 		}
+		if workOSUserCanBeReactivated(user) && intent != workOSAuthIntentSignup {
+			auditAuthAction(ctx, "auth.account.reactivation_required", user.ID, "denied")
+			return WorkOSLoginResult{}, ErrAuthReactivationRequired
+		}
 		user.PrimaryEmail = email
 		user.DisplayName = displayName
 		user.AvatarURL = strings.TrimSpace(profile.ProfilePictureURL)
@@ -545,6 +549,10 @@ func (s *Service) UpsertManualUserSessionContext(ctx context.Context, input Manu
 			UpdatedAt:    now,
 		}
 	} else {
+		if workOSUserCanBeReactivated(user) {
+			auditAuthAction(ctx, "auth.account.reactivation_required", user.ID, "denied")
+			return ManualLoginResult{}, ErrAuthReactivationRequired
+		}
 		user.DisplayName = displayName
 		user.Status = "active"
 		user.UpdatedAt = now

--- a/internal/api/service_auth.go
+++ b/internal/api/service_auth.go
@@ -119,9 +119,17 @@ func (s *Service) UpsertWorkOSUserForIntent(ctx context.Context, profile session
 		} else if emailErr != nil && !errors.Is(emailErr, db.ErrNotFound) {
 			return WorkOSLoginResult{}, emailErr
 		}
-		if workOSUserCanBeReactivated(user) && intent != workOSAuthIntentSignup {
-			auditAuthAction(ctx, "auth.account.reactivation_required", user.ID, "denied")
-			return WorkOSLoginResult{}, ErrAuthReactivationRequired
+		if workOSUserCanBeReactivated(user) {
+			if intent != workOSAuthIntentSignup {
+				auditAuthAction(ctx, "auth.account.reactivation_required", user.ID, "denied")
+				return WorkOSLoginResult{}, ErrAuthReactivationRequired
+			}
+			// Mirror the unbound-identity reactivation branch below: a
+			// signup-intent sign-in that revives a soft-deleted row must
+			// clear DeletedAt, otherwise workOSUserCanBeReactivated keeps
+			// returning true and downstream code that gates on DeletedAt
+			// continues to treat the account as deleted.
+			user.DeletedAt = nil
 		}
 		user.PrimaryEmail = email
 		user.DisplayName = displayName

--- a/internal/api/service_workos_test.go
+++ b/internal/api/service_workos_test.go
@@ -415,31 +415,45 @@ func TestUpsertWorkOSUserSignupIntentClearsDeletedAtOnIdentityResolvedPath(t *te
 	}
 }
 
-func TestUpsertManualUserSessionContextRefusesDeactivatedAccount(t *testing.T) {
+func TestUpsertManualUserSessionContextAutoReactivatesDeactivatedAccount(t *testing.T) {
+	// Manual mode is the loopback-only dev convenience path and has no
+	// signup-intent escape hatch like the WorkOS flow. Treating manual
+	// sign-in as an implicit reactivation keeps a deactivate test from
+	// permanently locking a developer out of their dev tenant. The
+	// production refusal lives in the WorkOS path and is covered by
+	// TestUpsertWorkOSUserLoginIntentRefusesReturningDeactivatedIdentity.
 	store := db.NewMemoryStore()
 	svc := NewService(store, fakeScanner{}, "aws")
 	ctx := context.Background()
+	deletedAt := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
 	user, err := store.UpsertUser(ctx, db.User{
 		PrimaryEmail: "manual@example.com",
 		DisplayName:  "Manual",
 		Status:       "deactivated",
+		DeletedAt:    &deletedAt,
 	})
 	if err != nil {
 		t.Fatalf("seed user: %v", err)
 	}
-	_, err = svc.UpsertManualUserSessionContext(ctx, ManualLoginInput{
+	result, err := svc.UpsertManualUserSessionContext(ctx, ManualLoginInput{
 		TenantID:    "tenant-a",
 		WorkspaceID: "workspace-a",
 		Email:       "manual@example.com",
 	})
-	if !errors.Is(err, ErrAuthReactivationRequired) {
-		t.Fatalf("expected reactivation required, got %v", err)
-	}
-	unchanged, err := store.GetUser(ctx, user.ID)
 	if err != nil {
-		t.Fatalf("load user: %v", err)
+		t.Fatalf("manual reactivation: %v", err)
 	}
-	if unchanged.Status != "deactivated" {
-		t.Fatalf("manual login must not auto-reactivate, got %q", unchanged.Status)
+	if result.User.Status != "active" {
+		t.Fatalf("expected manual reactivation to flip status, got %q", result.User.Status)
+	}
+	if result.User.DeletedAt != nil {
+		t.Fatalf("expected manual reactivation to clear DeletedAt, got %v", result.User.DeletedAt)
+	}
+	stored, err := store.GetUser(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("load reactivated user: %v", err)
+	}
+	if stored.Status != "active" || stored.DeletedAt != nil {
+		t.Fatalf("expected stored row reactivated, got status=%q deleted_at=%v", stored.Status, stored.DeletedAt)
 	}
 }

--- a/internal/api/service_workos_test.go
+++ b/internal/api/service_workos_test.go
@@ -457,3 +457,94 @@ func TestUpsertManualUserSessionContextAutoReactivatesDeactivatedAccount(t *test
 		t.Fatalf("expected stored row reactivated, got status=%q deleted_at=%v", stored.Status, stored.DeletedAt)
 	}
 }
+
+type samlProfileUpdateStore struct {
+	*db.MemoryStore
+	upsertUserCalls    int
+	updateProfileCalls int
+}
+
+func (s *samlProfileUpdateStore) UpsertUser(ctx context.Context, user db.User) (db.User, error) {
+	s.upsertUserCalls++
+	// Simulate a racing deactivation happening after stale status was read but before
+	// the write is persisted.
+	user.Status = "deactivated"
+	return s.MemoryStore.UpsertUser(ctx, user)
+}
+
+func (s *samlProfileUpdateStore) UpdateUserProfile(ctx context.Context, user db.User) (db.User, error) {
+	s.updateProfileCalls++
+	return s.MemoryStore.UpdateUserProfile(ctx, user)
+}
+
+func TestRefreshSAMLIdentityPreservesLifecycleStatus(t *testing.T) {
+	base := db.NewMemoryStore()
+	store := &samlProfileUpdateStore{MemoryStore: base}
+	svc := NewService(store, fakeScanner{}, "aws")
+	now := time.Date(2026, 5, 28, 10, 0, 0, 0, time.UTC)
+	ctx := context.Background()
+	user, err := base.UpsertUser(ctx, db.User{
+		PrimaryEmail: "saml-refresh@example.com",
+		DisplayName:  "SAML Refresh",
+		Status:       "active",
+	})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	identity, err := base.UpsertUserIdentity(ctx, db.UserIdentity{
+		UserID:              user.ID,
+		Provider:            "saml:conn-refresh",
+		Subject:             "name-id-refresh",
+		Email:               "saml-refresh@example.com",
+		EmailVerified:       true,
+		LastAuthenticatedAt: now,
+		CreatedAt:           now,
+	})
+	if err != nil {
+		t.Fatalf("seed identity: %v", err)
+	}
+
+	result, err := svc.refreshSAMLIdentity(ctx, db.IdentityConnection{ID: "conn-refresh"}, identity, "saml-refresh@example.com", "SAML Refresh New", []byte("{}"), now)
+	if err != nil {
+		t.Fatalf("refresh SAML identity: %v", err)
+	}
+	if result.User.Status != "active" {
+		t.Fatalf("expected lifecycle status preserved as active, got %q", result.User.Status)
+	}
+	if store.updateProfileCalls != 1 {
+		t.Fatalf("expected UpdateUserProfile to be called, got %d", store.updateProfileCalls)
+	}
+	if store.upsertUserCalls != 0 {
+		t.Fatalf("expected UpsertUser to not be used by SAML refresh path, got %d", store.upsertUserCalls)
+	}
+}
+
+func TestAttachSAMLIdentityToExistingUserPreservesLifecycleStatus(t *testing.T) {
+	base := db.NewMemoryStore()
+	store := &samlProfileUpdateStore{MemoryStore: base}
+	svc := NewService(store, fakeScanner{}, "aws")
+	now := time.Date(2026, 5, 28, 11, 0, 0, 0, time.UTC)
+	ctx := context.Background()
+	user, err := base.UpsertUser(ctx, db.User{
+		PrimaryEmail: "saml-attach@example.com",
+		DisplayName:  "SAML Attach",
+		Status:       "active",
+	})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	result, err := svc.attachSAMLIdentityToExistingUser(ctx, db.IdentityConnection{ID: "conn-attach"}, user.ID, "name-id-attach", "saml-attach@example.com", "SAML Attach New", []byte("{}"), now)
+	if err != nil {
+		t.Fatalf("attach SAML identity: %v", err)
+	}
+	if result.User.Status != "active" {
+		t.Fatalf("expected lifecycle status preserved as active, got %q", result.User.Status)
+	}
+	if store.updateProfileCalls != 1 {
+		t.Fatalf("expected UpdateUserProfile to be called, got %d", store.updateProfileCalls)
+	}
+	if store.upsertUserCalls != 0 {
+		t.Fatalf("expected UpsertUser to not be used by SAML attach path, got %d", store.upsertUserCalls)
+	}
+}

--- a/internal/api/service_workos_test.go
+++ b/internal/api/service_workos_test.go
@@ -361,6 +361,60 @@ func TestUpsertWorkOSUserLoginIntentRefusesReturningDeactivatedIdentity(t *testi
 	}
 }
 
+func TestUpsertWorkOSUserSignupIntentClearsDeletedAtOnIdentityResolvedPath(t *testing.T) {
+	// Regression: when a returning user already has a WorkOS identity row and
+	// the underlying account was previously soft-deleted, signup-intent must
+	// clear DeletedAt as well as flipping status. Without that, downstream
+	// callers of workOSUserCanBeReactivated keep treating the account as
+	// reactivatable and the soft-delete sentinel survives.
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 5, 28, 9, 0, 0, 0, time.UTC)
+	deletedAt := now.Add(-24 * time.Hour)
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	ctx := context.Background()
+	user, err := store.UpsertUser(ctx, db.User{
+		PrimaryEmail: "returning@example.com",
+		DisplayName:  "Returning",
+		Status:       "deleted",
+		DeletedAt:    &deletedAt,
+	})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	if _, err := store.UpsertUserIdentity(ctx, db.UserIdentity{
+		UserID:              user.ID,
+		Provider:            sessionauth.WorkOSProvider,
+		Subject:             "user_workos_returning_softdeleted",
+		Email:               "returning@example.com",
+		LastAuthenticatedAt: now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("seed identity: %v", err)
+	}
+
+	result, err := svc.UpsertWorkOSUserForIntent(ctx, sessionauth.WorkOSProfile{
+		ID:            "user_workos_returning_softdeleted",
+		Email:         "returning@example.com",
+		EmailVerified: true,
+	}, "signup")
+	if err != nil {
+		t.Fatalf("signup-intent reactivation: %v", err)
+	}
+	if result.User.Status != "active" {
+		t.Fatalf("expected status=active after reactivation, got %q", result.User.Status)
+	}
+	if result.User.DeletedAt != nil {
+		t.Fatalf("expected DeletedAt cleared after reactivation, got %v", result.User.DeletedAt)
+	}
+	stored, err := store.GetUser(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("load reactivated user: %v", err)
+	}
+	if stored.DeletedAt != nil {
+		t.Fatalf("expected stored DeletedAt cleared, got %v", stored.DeletedAt)
+	}
+}
+
 func TestUpsertManualUserSessionContextRefusesDeactivatedAccount(t *testing.T) {
 	store := db.NewMemoryStore()
 	svc := NewService(store, fakeScanner{}, "aws")

--- a/internal/api/service_workos_test.go
+++ b/internal/api/service_workos_test.go
@@ -317,3 +317,75 @@ func TestUpdateWorkOSUserEmailRejectsConflictingEmail(t *testing.T) {
 		t.Fatalf("expected identity conflict, got %v", err)
 	}
 }
+
+func TestUpsertWorkOSUserLoginIntentRefusesReturningDeactivatedIdentity(t *testing.T) {
+	// A user with an existing WorkOS identity who has been deactivated must
+	// not be auto-reactivated on a subsequent login-intent sign-in. The
+	// frontend uses ErrAuthReactivationRequired to surface the dedicated
+	// reactivation affordance instead.
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	ctx := context.Background()
+	user, err := store.UpsertUser(ctx, db.User{
+		PrimaryEmail: "returning@example.com",
+		DisplayName:  "Returning User",
+		Status:       "deactivated",
+	})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	if _, err := store.UpsertUserIdentity(ctx, db.UserIdentity{
+		UserID:              user.ID,
+		Provider:            sessionauth.WorkOSProvider,
+		Subject:             "user_workos_returning",
+		Email:               "returning@example.com",
+		LastAuthenticatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed identity: %v", err)
+	}
+
+	_, err = svc.UpsertWorkOSUserForIntent(ctx, sessionauth.WorkOSProfile{
+		ID:            "user_workos_returning",
+		Email:         "returning@example.com",
+		EmailVerified: true,
+	}, "login")
+	if !errors.Is(err, ErrAuthReactivationRequired) {
+		t.Fatalf("expected reactivation required, got %v", err)
+	}
+	unchanged, err := store.GetUser(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("load user: %v", err)
+	}
+	if unchanged.Status != "deactivated" {
+		t.Fatalf("login intent must not auto-reactivate, got %q", unchanged.Status)
+	}
+}
+
+func TestUpsertManualUserSessionContextRefusesDeactivatedAccount(t *testing.T) {
+	store := db.NewMemoryStore()
+	svc := NewService(store, fakeScanner{}, "aws")
+	ctx := context.Background()
+	user, err := store.UpsertUser(ctx, db.User{
+		PrimaryEmail: "manual@example.com",
+		DisplayName:  "Manual",
+		Status:       "deactivated",
+	})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	_, err = svc.UpsertManualUserSessionContext(ctx, ManualLoginInput{
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-a",
+		Email:       "manual@example.com",
+	})
+	if !errors.Is(err, ErrAuthReactivationRequired) {
+		t.Fatalf("expected reactivation required, got %v", err)
+	}
+	unchanged, err := store.GetUser(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("load user: %v", err)
+	}
+	if unchanged.Status != "deactivated" {
+		t.Fatalf("manual login must not auto-reactivate, got %q", unchanged.Status)
+	}
+}

--- a/internal/api/service_workos_test.go
+++ b/internal/api/service_workos_test.go
@@ -548,3 +548,178 @@ func TestAttachSAMLIdentityToExistingUserPreservesLifecycleStatus(t *testing.T) 
 		t.Fatalf("expected UpsertUser to not be used by SAML attach path, got %d", store.upsertUserCalls)
 	}
 }
+
+type workOSReactivationStore struct {
+	*db.MemoryStore
+	upsertUserCalls    int
+	updateProfileCalls int
+	setStatusCalls     int
+}
+
+type staleReadWorkOSStore struct {
+	*db.MemoryStore
+	getUserCalls int
+}
+
+func (s *workOSReactivationStore) UpsertUser(ctx context.Context, user db.User) (db.User, error) {
+	s.upsertUserCalls++
+	return s.MemoryStore.UpsertUser(ctx, user)
+}
+
+func (s *workOSReactivationStore) UpdateUserProfile(ctx context.Context, user db.User) (db.User, error) {
+	s.updateProfileCalls++
+	return s.MemoryStore.UpdateUserProfile(ctx, user)
+}
+
+func (s *staleReadWorkOSStore) GetUser(ctx context.Context, userID string) (db.User, error) {
+	user, err := s.MemoryStore.GetUser(ctx, userID)
+	if err != nil {
+		return db.User{}, err
+	}
+	s.getUserCalls++
+	if s.getUserCalls == 1 {
+		user.Status = "active"
+	}
+	return user, nil
+}
+
+func (s *workOSReactivationStore) SetUserStatus(ctx context.Context, userID string, status string, now time.Time) (db.User, error) {
+	s.setStatusCalls++
+	return s.MemoryStore.SetUserStatus(ctx, userID, status, now)
+}
+
+func TestUpsertWorkOSUserForIntentSignupReactivationUsesProfileUpdateThenStatusUpdate(t *testing.T) {
+	base := db.NewMemoryStore()
+	store := &workOSReactivationStore{MemoryStore: base}
+	svc := NewService(store, fakeScanner{}, "aws")
+	now := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+	svc.Now = func() time.Time { return now }
+	ctx := context.Background()
+	user, err := base.UpsertUser(ctx, db.User{
+		PrimaryEmail: "reactivating@example.com",
+		DisplayName:  "Reacting",
+		Status:       "deactivated",
+	})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	if _, err := base.UpsertUserIdentity(ctx, db.UserIdentity{
+		UserID:              user.ID,
+		Provider:            sessionauth.WorkOSProvider,
+		Subject:             "user_workos_reactivate_identity",
+		Email:               "reactivating@example.com",
+		EmailVerified:       true,
+		LastAuthenticatedAt: now.Add(-time.Hour),
+		CreatedAt:           now,
+	}); err != nil {
+		t.Fatalf("seed identity: %v", err)
+	}
+
+	result, err := svc.UpsertWorkOSUserForIntent(ctx, sessionauth.WorkOSProfile{
+		ID:                "user_workos_reactivate_identity",
+		Email:             "reactivating-new@example.com",
+		FirstName:         "Active",
+		LastName:          "Tester",
+		EmailVerified:     true,
+		ProfilePictureURL: "https://cdn.example/reactivated.png",
+	}, "signup")
+	if err != nil {
+		t.Fatalf("signup reactivation: %v", err)
+	}
+	if result.User.Status != "active" {
+		t.Fatalf("expected active status, got %q", result.User.Status)
+	}
+	if store.updateProfileCalls != 1 {
+		t.Fatalf("expected one profile update, got %d", store.updateProfileCalls)
+	}
+	if store.setStatusCalls != 1 {
+		t.Fatalf("expected one status update, got %d", store.setStatusCalls)
+	}
+	if store.upsertUserCalls != 0 {
+		t.Fatalf("expected no upsert during reactivation, got %d", store.upsertUserCalls)
+	}
+	if result.User.PrimaryEmail != "reactivating-new@example.com" {
+		t.Fatalf("expected refreshed primary email, got %q", result.User.PrimaryEmail)
+	}
+}
+
+func TestUpsertWorkOSUserForIntentLoginUsesFreshStateBeforeSessionFlip(t *testing.T) {
+	base := db.NewMemoryStore()
+	store := &staleReadWorkOSStore{MemoryStore: base}
+	svc := NewService(store, fakeScanner{}, "aws")
+	ctx := context.Background()
+	user, err := base.UpsertUser(ctx, db.User{
+		PrimaryEmail: "stale@example.com",
+		DisplayName:  "Stale User",
+		Status:       "deactivated",
+	})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	if _, err := base.UpsertUserIdentity(ctx, db.UserIdentity{
+		UserID:              user.ID,
+		Provider:            sessionauth.WorkOSProvider,
+		Subject:             "workos-stale",
+		Email:               "stale@example.com",
+		LastAuthenticatedAt: time.Now().UTC(),
+		CreatedAt:           time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed identity: %v", err)
+	}
+
+	_, err = svc.UpsertWorkOSUserForIntent(ctx, sessionauth.WorkOSProfile{
+		ID:            "workos-stale",
+		Email:         "stale@example.com",
+		EmailVerified: true,
+	}, "login")
+	if !errors.Is(err, ErrAuthReactivationRequired) {
+		t.Fatalf("expected reactivation required after fresh read catches deactivation, got %v", err)
+	}
+	stored, err := base.GetUser(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("load stored user: %v", err)
+	}
+	if stored.Status != "deactivated" {
+		t.Fatalf("expected stored user to remain deactivated, got %q", stored.Status)
+	}
+}
+
+func TestUpsertWorkOSUserForIntentEmailResolvedReactivationUsesProfileUpdateThenStatusUpdate(t *testing.T) {
+	base := db.NewMemoryStore()
+	store := &workOSReactivationStore{MemoryStore: base}
+	svc := NewService(store, fakeScanner{}, "aws")
+	now := time.Date(2026, 6, 2, 9, 0, 0, 0, time.UTC)
+	svc.Now = func() time.Time { return now }
+	ctx := context.Background()
+	if _, err := base.UpsertUser(ctx, db.User{
+		PrimaryEmail: "rea-email@example.com",
+		DisplayName:  "Email React",
+		Status:       "deactivated",
+	}); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	result, err := svc.UpsertWorkOSUserForIntent(ctx, sessionauth.WorkOSProfile{
+		ID:                "rea-email-subject",
+		Email:             "rea-email@example.com",
+		FirstName:         "Email",
+		LastName:          "Reactivated",
+		EmailVerified:     true,
+		ProfilePictureURL: "https://cdn.example/rea.png",
+	}, "signup")
+	if err != nil {
+		t.Fatalf("signup reactivation by email: %v", err)
+	}
+	if result.User.Status != "active" {
+		t.Fatalf("expected active status, got %q", result.User.Status)
+	}
+	if store.updateProfileCalls != 1 {
+		t.Fatalf("expected one profile update, got %d", store.updateProfileCalls)
+	}
+	if store.setStatusCalls != 1 {
+		t.Fatalf("expected one status update, got %d", store.setStatusCalls)
+	}
+	if store.upsertUserCalls != 0 {
+		t.Fatalf("expected no upsert during reactivation, got %d", store.upsertUserCalls)
+	}
+}

--- a/internal/db/memory_auth.go
+++ b/internal/db/memory_auth.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -65,6 +66,34 @@ func (m *MemoryStore) GetUserByPrimaryEmail(ctx context.Context, email string) (
 		}
 	}
 	return User{}, ErrNotFound
+}
+
+// SetUserStatus transitions one account between lifecycle states. Calling with
+// the user's current status is a no-op write and still returns the row, so the
+// API layer can treat double-clicks as idempotent successes.
+func (m *MemoryStore) SetUserStatus(ctx context.Context, userID string, status string, now time.Time) (User, error) {
+	normalizedStatus := strings.ToLower(strings.TrimSpace(status))
+	if _, ok := validUserStatuses[normalizedStatus]; !ok {
+		return User{}, fmt.Errorf("invalid user status")
+	}
+	id := strings.TrimSpace(userID)
+	m.mu.Lock()
+	user, exists := m.users[id]
+	if !exists {
+		m.mu.Unlock()
+		return User{}, ErrNotFound
+	}
+	user.Status = normalizedStatus
+	user.UpdatedAt = now.UTC()
+	m.users[id] = user
+	m.mu.Unlock()
+	audit.WriteAction(ctx, audit.AuditEvent{
+		Action:       "auth.user.status.update",
+		ResourceType: "user",
+		ResourceID:   id,
+		Outcome:      "success",
+	})
+	return user, nil
 }
 
 // UpsertUserIdentity persists one provider identity mapping.

--- a/internal/db/memory_auth.go
+++ b/internal/db/memory_auth.go
@@ -44,6 +44,40 @@ func (m *MemoryStore) UpsertUser(ctx context.Context, user User) (User, error) {
 	return normalized, nil
 }
 
+// UpdateUserProfile refreshes user metadata without changing account status.
+func (m *MemoryStore) UpdateUserProfile(ctx context.Context, user User) (User, error) {
+	normalized, err := NormalizeUserForWrite(user)
+	if err != nil {
+		return User{}, err
+	}
+	m.mu.Lock()
+	existing, exists := m.users[normalized.ID]
+	if !exists {
+		m.mu.Unlock()
+		return User{}, ErrNotFound
+	}
+	for id, other := range m.users {
+		if other.PrimaryEmail == normalized.PrimaryEmail && id != normalized.ID {
+			m.mu.Unlock()
+			return User{}, ErrConflict
+		}
+	}
+	existing.PrimaryEmail = normalized.PrimaryEmail
+	existing.DisplayName = normalized.DisplayName
+	existing.AvatarURL = normalized.AvatarURL
+	existing.UpdatedAt = normalized.UpdatedAt
+	existing.DeletedAt = normalized.DeletedAt
+	m.users[normalized.ID] = existing
+	m.mu.Unlock()
+	audit.WriteAction(ctx, audit.AuditEvent{
+		Action:       "auth.user.profile_update",
+		ResourceType: "user",
+		ResourceID:   normalized.ID,
+		Outcome:      "success",
+	})
+	return existing, nil
+}
+
 // GetUser returns one account by UUID.
 func (m *MemoryStore) GetUser(ctx context.Context, userID string) (User, error) {
 	m.mu.RLock()
@@ -223,6 +257,10 @@ func (m *MemoryStore) CreateSession(ctx context.Context, session Session) (Sessi
 	m.mu.Lock()
 	user, exists := m.users[normalized.UserID]
 	if !exists {
+		m.mu.Unlock()
+		return Session{}, ErrNotFound
+	}
+	if user.DeletedAt != nil || user.Status != "active" {
 		m.mu.Unlock()
 		return Session{}, ErrNotFound
 	}

--- a/internal/db/memory_auth_test.go
+++ b/internal/db/memory_auth_test.go
@@ -263,6 +263,97 @@ func TestMemoryAuthRejectsMissingRecordsAndExpiredSessions(t *testing.T) {
 	}
 }
 
+func TestMemoryCreateSessionRejectsInactiveUsers(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	sessionHash := sha256.Sum256([]byte("inactive-user-session"))
+	user, err := store.UpsertUser(ctx, User{
+		ID:           "11111111-1111-1111-1111-111111111111",
+		PrimaryEmail: "inactive@example.com",
+		CreatedAt:    now,
+	})
+	if err != nil {
+		t.Fatalf("upsert user: %v", err)
+	}
+	if _, err := store.CreateSession(ctx, Session{
+		ID:                sessionHash[:],
+		UserID:            user.ID,
+		AuthMethod:        "manual",
+		IdleExpiresAt:     now.Add(15 * time.Minute),
+		AbsoluteExpiresAt: now.Add(time.Hour),
+		CreatedAt:         now,
+	}); err != nil {
+		t.Fatalf("create session for active user: %v", err)
+	}
+	if _, err := store.SetUserStatus(ctx, user.ID, "deactivated", now.Add(time.Minute)); err != nil {
+		t.Fatalf("deactivate user: %v", err)
+	}
+	sessionHash2 := sha256.Sum256([]byte("deactivated-user-session"))
+	if _, err := store.CreateSession(ctx, Session{
+		ID:                sessionHash2[:],
+		UserID:            user.ID,
+		AuthMethod:        "manual",
+		IdleExpiresAt:     now.Add(15 * time.Minute),
+		AbsoluteExpiresAt: now.Add(time.Hour),
+		CreatedAt:         now,
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected deactivated user session to return ErrNotFound, got %v", err)
+	}
+
+	deletedAt := now.Add(-time.Minute)
+	if _, err := store.UpsertUser(ctx, User{
+		ID:           user.ID,
+		PrimaryEmail: "inactive@example.com",
+		Status:       "deleted",
+		DeletedAt:    &deletedAt,
+		UpdatedAt:    now.Add(2 * time.Minute),
+		CreatedAt:    user.CreatedAt,
+	}); err != nil {
+		t.Fatalf("mark user deleted: %v", err)
+	}
+	sessionHash3 := sha256.Sum256([]byte("deleted-user-session"))
+	if _, err := store.CreateSession(ctx, Session{
+		ID:                sessionHash3[:],
+		UserID:            user.ID,
+		AuthMethod:        "manual",
+		IdleExpiresAt:     now.Add(15 * time.Minute),
+		AbsoluteExpiresAt: now.Add(time.Hour),
+		CreatedAt:         now,
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected deleted user session to return ErrNotFound, got %v", err)
+	}
+}
+
+func TestMemoryUpdateUserProfilePreservesStatus(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+	now := time.Date(2026, 5, 12, 13, 0, 0, 0, time.UTC)
+	user, err := store.UpsertUser(ctx, User{
+		ID:           "11111111-1111-1111-1111-111111111111",
+		PrimaryEmail: "status-pinned@example.com",
+		CreatedAt:    now,
+	})
+	if err != nil {
+		t.Fatalf("upsert user: %v", err)
+	}
+	if _, err := store.SetUserStatus(ctx, user.ID, "deactivated", now.Add(time.Minute)); err != nil {
+		t.Fatalf("deactivate user: %v", err)
+	}
+	updated, err := store.UpdateUserProfile(ctx, User{
+		ID:           user.ID,
+		PrimaryEmail: "status-pinned@example.com",
+		DisplayName:  "Updated",
+		UpdatedAt:    now.Add(2 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("update user profile: %v", err)
+	}
+	if updated.Status != "deactivated" {
+		t.Fatalf("expected status to remain deactivated, got %q", updated.Status)
+	}
+}
+
 func TestAuthNormalizationRejectsInvalidInputs(t *testing.T) {
 	now := time.Date(2026, 5, 12, 11, 0, 0, 0, time.UTC)
 	if _, err := NormalizeUserForWrite(User{ID: "not-a-uuid", PrimaryEmail: "user@example.com"}); err == nil {

--- a/internal/db/memory_auth_test.go
+++ b/internal/db/memory_auth_test.go
@@ -343,3 +343,68 @@ func TestAuthNormalizationRejectsInvalidInputs(t *testing.T) {
 		t.Fatal("expected missing idle expiry to fail")
 	}
 }
+
+func TestMemorySetUserStatusTransitionsAndIdempotency(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+	created := time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC)
+	user, err := store.UpsertUser(ctx, User{
+		ID:           "11111111-1111-1111-1111-111111111111",
+		PrimaryEmail: "carol@example.com",
+		DisplayName:  "Carol",
+		CreatedAt:    created,
+	})
+	if err != nil {
+		t.Fatalf("upsert user: %v", err)
+	}
+
+	deactivatedAt := created.Add(time.Hour)
+	deactivated, err := store.SetUserStatus(ctx, user.ID, "deactivated", deactivatedAt)
+	if err != nil {
+		t.Fatalf("deactivate: %v", err)
+	}
+	if deactivated.Status != "deactivated" {
+		t.Fatalf("expected status=deactivated, got %q", deactivated.Status)
+	}
+	if !deactivated.UpdatedAt.Equal(deactivatedAt) {
+		t.Fatalf("expected updated_at=%s, got %s", deactivatedAt, deactivated.UpdatedAt)
+	}
+
+	// Idempotent: setting the same status returns the row without error.
+	again, err := store.SetUserStatus(ctx, user.ID, "deactivated", deactivatedAt.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("repeat deactivate: %v", err)
+	}
+	if again.Status != "deactivated" {
+		t.Fatalf("expected idempotent deactivate, got %q", again.Status)
+	}
+
+	reactivated, err := store.SetUserStatus(ctx, user.ID, "active", deactivatedAt.Add(2*time.Hour))
+	if err != nil {
+		t.Fatalf("reactivate: %v", err)
+	}
+	if reactivated.Status != "active" {
+		t.Fatalf("expected status=active after reactivate, got %q", reactivated.Status)
+	}
+}
+
+func TestMemorySetUserStatusRejectsInvalidInput(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+	now := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	user, err := store.UpsertUser(ctx, User{
+		ID:           "11111111-1111-1111-1111-111111111111",
+		PrimaryEmail: "dan@example.com",
+		CreatedAt:    now,
+	})
+	if err != nil {
+		t.Fatalf("upsert user: %v", err)
+	}
+
+	if _, err := store.SetUserStatus(ctx, user.ID, "locked", now); err == nil {
+		t.Fatal("expected invalid status to fail")
+	}
+	if _, err := store.SetUserStatus(ctx, "22222222-2222-2222-2222-222222222222", "deactivated", now); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for missing user, got %v", err)
+	}
+}

--- a/internal/db/postgres_auth.go
+++ b/internal/db/postgres_auth.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -110,6 +111,37 @@ func (p *PostgresStore) GetUserByPrimaryEmail(ctx context.Context, email string)
 		 WHERE primary_email = NULLIF($1, '')::citext`,
 		strings.ToLower(strings.TrimSpace(email)),
 	))
+}
+
+// SetUserStatus transitions one account between lifecycle states. Setting the
+// status the row already has is allowed so the API layer can treat repeated
+// requests as idempotent successes.
+func (p *PostgresStore) SetUserStatus(ctx context.Context, userID string, status string, now time.Time) (User, error) {
+	normalizedStatus := strings.ToLower(strings.TrimSpace(status))
+	if _, ok := validUserStatuses[normalizedStatus]; !ok {
+		return User{}, fmt.Errorf("invalid user status")
+	}
+	row := p.queryRowContextAnyScope(
+		ctx,
+		`UPDATE users
+		 SET status = $2, updated_at = $3::timestamptz
+		 WHERE id = NULLIF($1, '')::uuid
+		 RETURNING id::text, primary_email::text, display_name, avatar_url, status, created_at, updated_at, deleted_at`,
+		strings.TrimSpace(userID),
+		normalizedStatus,
+		now.UTC(),
+	)
+	saved, err := scanUser(row)
+	if err != nil {
+		return User{}, err
+	}
+	audit.WriteAction(ctx, audit.AuditEvent{
+		Action:       "auth.user.status.update",
+		ResourceType: "user",
+		ResourceID:   saved.ID,
+		Outcome:      "success",
+	})
+	return saved, nil
 }
 
 // UpsertUserIdentity persists one provider identity mapping.

--- a/internal/db/postgres_auth.go
+++ b/internal/db/postgres_auth.go
@@ -91,6 +91,42 @@ func (p *PostgresStore) UpsertUser(ctx context.Context, user User) (User, error)
 	return saved, nil
 }
 
+// UpdateUserProfile refreshes one account row without changing lifecycle status.
+func (p *PostgresStore) UpdateUserProfile(ctx context.Context, user User) (User, error) {
+	normalized, err := NormalizeUserForWrite(user)
+	if err != nil {
+		return User{}, err
+	}
+	row := p.queryRowContextAnyScope(
+		ctx,
+		`UPDATE users
+		 SET primary_email = $2,
+		     display_name = $3,
+		     avatar_url = $4,
+		     updated_at = $5,
+		     deleted_at = $6
+		 WHERE id = NULLIF($1, '')::uuid
+		 RETURNING id::text, primary_email::text, display_name, avatar_url, status, created_at, updated_at, deleted_at`,
+		normalized.ID,
+		normalized.PrimaryEmail,
+		normalized.DisplayName,
+		normalized.AvatarURL,
+		normalized.UpdatedAt,
+		nullTime(normalized.DeletedAt),
+	)
+	saved, err := scanUser(row)
+	if err != nil {
+		return User{}, err
+	}
+	audit.WriteAction(ctx, audit.AuditEvent{
+		Action:       "auth.user.profile_update",
+		ResourceType: "user",
+		ResourceID:   saved.ID,
+		Outcome:      "success",
+	})
+	return saved, nil
+}
+
 // GetUser returns one account by UUID.
 func (p *PostgresStore) GetUser(ctx context.Context, userID string) (User, error) {
 	return scanUser(p.queryRowContextAnyScope(
@@ -428,7 +464,11 @@ func (p *PostgresStore) CreateSession(ctx context.Context, session Session) (Ses
 		       id, user_id, current_org_id, current_workspace_id, current_project_id, auth_method,
 		       ip, user_agent, idle_expires_at, absolute_expires_at, last_seen_at, revoked_at, created_at
 		     )
-		     VALUES ($1, $2, $3, $4, $5, $6, NULLIF($7, '')::inet, $8, $9, $10, $11, $12, $13)
+		     SELECT $1, $2, $3, $4, $5, $6, NULLIF($7, '')::inet, $8, $9, $10, $11, $12, $13
+		     FROM users u
+		     WHERE u.id = NULLIF($2, '')::uuid
+		       AND u.deleted_at IS NULL
+		       AND u.status = 'active'
 		     RETURNING *
 		   )
 		   SELECT `+sessionUserSelect+`

--- a/internal/db/postgres_auth.go
+++ b/internal/db/postgres_auth.go
@@ -116,6 +116,9 @@ func (p *PostgresStore) UpdateUserProfile(ctx context.Context, user User) (User,
 	)
 	saved, err := scanUser(row)
 	if err != nil {
+		if isTenancyUniqueViolation(err) {
+			return User{}, ErrConflict
+		}
 		return User{}, err
 	}
 	audit.WriteAction(ctx, audit.AuditEvent{

--- a/internal/db/postgres_auth_test.go
+++ b/internal/db/postgres_auth_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"errors"
 	"testing"
 	"time"
 
@@ -291,6 +292,211 @@ func TestPostgresAuthMethodsBypassScopeRLS(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	if _, err := store.RevokeAllUserSessions(ctx, userID, now.Add(time.Minute)); err != nil {
 		t.Fatalf("revoke all sessions without scope under rls: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresAuthCreateSessionRejectsInactiveAndDeletedUsers(t *testing.T) {
+	rawDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer rawDB.Close()
+	store := NewPostgresStoreWithDB(rawDB)
+	ctx := context.Background()
+	now := time.Date(2026, 5, 12, 15, 0, 0, 0, time.UTC)
+	userID := "11111111-1111-1111-1111-111111111111"
+	sessionHash := sha256.Sum256([]byte("inactive-postgres-session"))
+
+	mock.ExpectQuery("INSERT INTO users").
+		WithArgs(userID, "inactive@example.com", "Alice", "", "active", sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(postgresAuthUserRows(now).AddRow(userID, "inactive@example.com", "Alice", "", "active", now, now, nil))
+	_, err = store.UpsertUser(ctx, User{
+		ID:           userID,
+		PrimaryEmail: "inactive@example.com",
+		DisplayName:  "Alice",
+		Status:       "active",
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	})
+	if err != nil {
+		t.Fatalf("upsert user: %v", err)
+	}
+
+	mock.ExpectQuery("UPDATE users").
+		WithArgs(userID, "deactivated", now.Add(time.Minute)).
+		WillReturnRows(postgresAuthUserRows(now).AddRow(userID, "inactive@example.com", "Alice", "", "deactivated", now, now.Add(time.Minute), nil))
+	if _, err := store.SetUserStatus(ctx, userID, "deactivated", now.Add(time.Minute)); err != nil {
+		t.Fatalf("deactivate user: %v", err)
+	}
+
+	mock.ExpectQuery("WITH inserted AS").
+		WithArgs(
+			sessionHash[:],
+			userID,
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			"manual",
+			"",
+			sqlmock.AnyArg(),
+			now.Add(15*time.Minute),
+			now.Add(24*time.Hour),
+			now,
+			sqlmock.AnyArg(),
+			now,
+		).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id",
+			"user_id",
+			"current_org_id",
+			"current_workspace_id",
+			"current_project_id",
+			"auth_method",
+			"ip",
+			"user_agent",
+			"idle_expires_at",
+			"absolute_expires_at",
+			"last_seen_at",
+			"revoked_at",
+			"created_at",
+			"user_id_text",
+			"primary_email",
+			"display_name",
+			"avatar_url",
+			"status",
+			"user_created_at",
+			"user_updated_at",
+			"deleted_at",
+		}))
+	if _, err := store.CreateSession(ctx, Session{
+		ID:                sessionHash[:],
+		UserID:            userID,
+		AuthMethod:        "manual",
+		IdleExpiresAt:     now.Add(15 * time.Minute),
+		AbsoluteExpiresAt: now.Add(24 * time.Hour),
+		LastSeenAt:        now,
+		CreatedAt:         now,
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected inactive user to block session creation, got %v", err)
+	}
+
+	mock.ExpectQuery("INSERT INTO users").
+		WithArgs(userID, "inactive@example.com", "Alice", "", "deleted", sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(postgresAuthUserRows(now).AddRow(userID, "inactive@example.com", "Alice", "", "deleted", now, now, now.Add(-time.Hour)))
+	_, err = store.UpsertUser(ctx, User{
+		ID:           userID,
+		PrimaryEmail: "inactive@example.com",
+		DisplayName:  "Alice",
+		Status:       "deleted",
+		DeletedAt:    func() *time.Time { at := now.Add(-time.Hour); return &at }(),
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	})
+	if err != nil {
+		t.Fatalf("mark user deleted: %v", err)
+	}
+
+	sessionHash2 := sha256.Sum256([]byte("deleted-postgres-session"))
+	mock.ExpectQuery("WITH inserted AS").
+		WithArgs(
+			sessionHash2[:],
+			userID,
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			"manual",
+			"",
+			sqlmock.AnyArg(),
+			now.Add(15*time.Minute),
+			now.Add(24*time.Hour),
+			now,
+			sqlmock.AnyArg(),
+			now,
+		).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id",
+			"user_id",
+			"current_org_id",
+			"current_workspace_id",
+			"current_project_id",
+			"auth_method",
+			"ip",
+			"user_agent",
+			"idle_expires_at",
+			"absolute_expires_at",
+			"last_seen_at",
+			"revoked_at",
+			"created_at",
+			"user_id_text",
+			"primary_email",
+			"display_name",
+			"avatar_url",
+			"status",
+			"user_created_at",
+			"user_updated_at",
+			"deleted_at",
+		}))
+	if _, err := store.CreateSession(ctx, Session{
+		ID:                sessionHash2[:],
+		UserID:            userID,
+		AuthMethod:        "manual",
+		IdleExpiresAt:     now.Add(15 * time.Minute),
+		AbsoluteExpiresAt: now.Add(24 * time.Hour),
+		LastSeenAt:        now,
+		CreatedAt:         now,
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected deleted user to block session creation, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresUpdateUserProfilePreservesStatus(t *testing.T) {
+	rawDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer rawDB.Close()
+	store := NewPostgresStoreWithDB(rawDB)
+	ctx := context.Background()
+	now := time.Date(2026, 5, 12, 16, 0, 0, 0, time.UTC)
+	userID := "11111111-1111-1111-1111-111111111111"
+
+	mock.ExpectQuery("INSERT INTO users").
+		WithArgs(userID, "active@example.com", "Alice", "", "deactivated", sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(postgresAuthUserRows(now).AddRow(userID, "active@example.com", "Alice", "", "deactivated", now, now, nil))
+	_, err = store.UpsertUser(ctx, User{
+		ID:           userID,
+		PrimaryEmail: "active@example.com",
+		DisplayName:  "Alice",
+		Status:       "deactivated",
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	mock.ExpectQuery("UPDATE users").
+		WithArgs(userID, "active@example.com", "Active Profile", "", now.Add(time.Minute), sqlmock.AnyArg()).
+		WillReturnRows(postgresAuthUserRows(now).AddRow(userID, "active@example.com", "Active Profile", "", "deactivated", now, now.Add(time.Minute), nil))
+	updated, err := store.UpdateUserProfile(ctx, User{
+		ID:           userID,
+		PrimaryEmail: "active@example.com",
+		DisplayName:  "Active Profile",
+		UpdatedAt:    now.Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("update user profile: %v", err)
+	}
+	if updated.Status != "deactivated" {
+		t.Fatalf("expected status to remain deactivated, got %q", updated.Status)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2583,6 +2583,7 @@ type Store interface {
 	GetTenancyConnectorSecretEnvelope(ctx context.Context, workspaceID string, projectID string, connectorID string, secretName string) (TenancyConnectorSecretEnvelope, error)
 	DeleteTenancyConnectorSecretEnvelope(ctx context.Context, workspaceID string, projectID string, connectorID string, secretName string) error
 	UpsertUser(ctx context.Context, user User) (User, error)
+	UpdateUserProfile(ctx context.Context, user User) (User, error)
 	GetUser(ctx context.Context, userID string) (User, error)
 	GetUserByPrimaryEmail(ctx context.Context, email string) (User, error)
 	SetUserStatus(ctx context.Context, userID string, status string, now time.Time) (User, error)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2585,6 +2585,7 @@ type Store interface {
 	UpsertUser(ctx context.Context, user User) (User, error)
 	GetUser(ctx context.Context, userID string) (User, error)
 	GetUserByPrimaryEmail(ctx context.Context, email string) (User, error)
+	SetUserStatus(ctx context.Context, userID string, status string, now time.Time) (User, error)
 	UpsertUserIdentity(ctx context.Context, identity UserIdentity) (UserIdentity, error)
 	GetUserIdentity(ctx context.Context, provider string, subject string) (UserIdentity, error)
 	GetUserIdentityByProviderUserID(ctx context.Context, provider string, userID string) (UserIdentity, error)


### PR DESCRIPTION
## Summary

Describe what changed.

## Why

Describe the problem this PR solves.

## Scope

- [ ] Focused change (no unrelated modifications)
- [ ] Backward compatibility considered
- [ ] Risk level assessed

## Validation

List the checks you ran and their outcomes.

```bash
# Example:
# go test ./...
# npm run test:ci --prefix web
```

## Checklist

- [ ] Tests added/updated for behavior changes
- [ ] Docs updated for user/operator-facing changes
- [ ] `CHANGELOG.md` updated when relevant
- [ ] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

If AI tools were used materially for this PR, complete the fields below.

- AI-assisted: yes/no
- Tools used:
- Areas where used:
- Human verification performed:

## Related Issues

Required for this repository size:

- Include at least one issue reference using closing/reference keywords:
  - `Closes #123`, `Fixes #123`, or `Refs #123`
- If no issue exists, include an explicit exemption with rationale:
  - `No issue: <reason>` (for example: docs-only typo fix, CI-only fix, or emergency hotfix)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds self-serve account deactivate/reactivate and tightens auth lifecycle so deactivated users can’t sign in unless explicitly reactivated. Also hardens the production deploy workflow with stricter review checks.

- New Features
  - POST /v1/me/deactivate: sets status to deactivated, revokes all sessions, clears the cookie, emits audit, idempotent; returns 409 if pending deletion.
  - POST /v1/me/reactivate: flips status back to active, emits audit, idempotent; returns 409 if pending deletion.
  - WorkOS login-intent refuses deactivated users with ErrAuthReactivationRequired; signup-intent path reactivates. Manual dev mode auto-reactivates to avoid lockouts.
  - OpenAPI docs, route policy, and router exemptions updated for both endpoints.

- Refactors
  - Added Store methods: UpdateUserProfile (no status changes) and SetUserStatus (status-only, idempotent).
  - Session creation now rejects deleted/inactive users (memory and Postgres); Postgres query enforces status=active and deleted_at IS NULL.
  - SAML refresh/attach and WorkOS flows preserve lifecycle status and use profile-update then status-update on reactivation.
  - CI: production deploy job now skips drafts, requires trusted approval on the PR head SHA, and ignores untrusted change requests.

<sup>Written for commit 69e5e8ed12982649a59ffa916f1fd3d78ddaa930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1430?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

