### PR TITLE
Add Settings Danger Zone with Suspend account row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
 ## Unreleased
+- Added a Settings "Danger zone" with a `Suspend my account` row backed by the
+  self-serve `POST /v1/me/deactivate` endpoint. Confirming the modal revokes
+  every active session, clears the cookie, signs the user out, and redirects
+  to `/signin?reason=account_deactivated` where a banner explains the account
+  is suspended and offers a "Reactivate account" link that routes through the
+  signup flow (the existing WorkOS signup-intent path auto-reactivates the
+  account). Introduces shared `DangerZone`, `DangerZoneRow`, and
+  `ConfirmDestructiveModal` components under `web/src/components/settings/`
+  with both checkbox and type-to-confirm confirmation variants, ready to be
+  reused by the upcoming Delete-account and Workspace-deletion flows.
 - Added self-serve account-lifecycle endpoints. `POST /v1/me/deactivate`
   transitions the authenticated user from `active` to `deactivated`, revokes
   every active session, and clears the session cookie. `POST /v1/me/reactivate`

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1184,6 +1184,16 @@ export const apiClient = {
       method: 'POST'
     });
   },
+  deactivateCurrentUser() {
+    return request<{ status: 'deactivated' }>('/v1/me/deactivate', undefined, {
+      method: 'POST'
+    });
+  },
+  reactivateCurrentUser() {
+    return request<{ status: 'active' }>('/v1/me/reactivate', undefined, {
+      method: 'POST'
+    });
+  },
   logout() {
     return request<{ ok: boolean }>('/auth/logout', undefined, {
       method: 'POST',

--- a/web/src/components/settings/DangerZone.test.tsx
+++ b/web/src/components/settings/DangerZone.test.tsx
@@ -1,0 +1,153 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ConfirmDestructiveModal, DangerZone, DangerZoneRow } from './DangerZone';
+
+describe('DangerZone', () => {
+  it('renders the heading, description, and row children', () => {
+    render(
+      <DangerZone description="Heads up, destructive stuff lives here.">
+        <DangerZoneRow
+          actionLabel="Suspend"
+          description="Sign out everywhere."
+          onAction={() => undefined}
+          title="Suspend my account"
+        />
+      </DangerZone>
+    );
+
+    expect(screen.getByRole('heading', { name: 'Account lifecycle' })).toBeInTheDocument();
+    expect(screen.getByText('Heads up, destructive stuff lives here.')).toBeInTheDocument();
+    expect(screen.getByText('Suspend my account')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Suspend' })).toBeEnabled();
+  });
+
+  it('invokes the row callback when the action button is clicked', () => {
+    const handler = vi.fn();
+    render(
+      <DangerZone>
+        <DangerZoneRow actionLabel="Suspend" description="" onAction={handler} title="Suspend" />
+      </DangerZone>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Suspend' }));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows pending state and disables the row button while working', () => {
+    const handler = vi.fn();
+    render(
+      <DangerZone>
+        <DangerZoneRow actionLabel="Suspend" description="" onAction={handler} pending title="Suspend" />
+      </DangerZone>
+    );
+
+    const button = screen.getByRole('button', { name: 'Working…' });
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe('ConfirmDestructiveModal — checkbox confirmation', () => {
+  function renderCheckboxModal(overrides?: Partial<Parameters<typeof ConfirmDestructiveModal>[0]>) {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <ConfirmDestructiveModal
+        body={<p>This is permanent-ish.</p>}
+        confirmation={{ kind: 'checkbox', label: 'I understand.' }}
+        continueLabel="Suspend"
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+        open
+        title="Suspend your account"
+        {...overrides}
+      />
+    );
+    return { onConfirm, onCancel };
+  }
+
+  it('keeps Continue disabled until the checkbox is checked', () => {
+    const { onConfirm } = renderCheckboxModal();
+    const cont = screen.getByRole('button', { name: 'Suspend' });
+    expect(cont).toBeDisabled();
+    fireEvent.click(cont);
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(cont).toBeEnabled();
+    fireEvent.click(cont);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes Cancel when the backdrop is clicked', () => {
+    const { onCancel } = renderCheckboxModal();
+    // Click the backdrop (parent of the dialog). The dialog itself stops
+    // propagation so clicks inside should not bubble.
+    fireEvent.click(screen.getByRole('dialog').parentElement!);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders an error message and keeps Cancel enabled when pending=false', () => {
+    renderCheckboxModal({ errorMessage: 'Something broke.', pending: false });
+    expect(screen.getByRole('alert')).toHaveTextContent('Something broke.');
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+  });
+
+  it('shows working state on Continue and disables both buttons when pending', () => {
+    const { onConfirm } = renderCheckboxModal({ pending: true });
+    fireEvent.click(screen.getByRole('checkbox'));
+    const working = screen.getByRole('button', { name: 'Working…' });
+    expect(working).toBeDisabled();
+    fireEvent.click(working);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});
+
+describe('ConfirmDestructiveModal — type-to-confirm', () => {
+  it('only enables Continue when the typed value matches exactly', () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDestructiveModal
+        body={null}
+        confirmation={{
+          kind: 'type-to-confirm',
+          expectedValue: 'user@example.com',
+          inputLabel: 'Type your email'
+        }}
+        continueLabel="Delete"
+        onCancel={() => undefined}
+        onConfirm={onConfirm}
+        open
+        title="Delete account"
+      />
+    );
+
+    const cont = screen.getByRole('button', { name: 'Delete' });
+    expect(cont).toBeDisabled();
+
+    const input = screen.getByLabelText('Type your email');
+    fireEvent.change(input, { target: { value: 'user@example.co' } });
+    expect(cont).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: 'user@example.com' } });
+    expect(cont).toBeEnabled();
+    fireEvent.click(cont);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns nothing when open=false', () => {
+    const { container } = render(
+      <ConfirmDestructiveModal
+        body={null}
+        confirmation={{ kind: 'checkbox', label: 'I am sure.' }}
+        continueLabel="Go"
+        onCancel={() => undefined}
+        onConfirm={() => undefined}
+        open={false}
+        title="Closed"
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/web/src/components/settings/DangerZone.test.tsx
+++ b/web/src/components/settings/DangerZone.test.tsx
@@ -136,6 +136,42 @@ describe('ConfirmDestructiveModal — type-to-confirm', () => {
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
+  it('does not enable Continue when the typed value has stray whitespace', () => {
+    // Regression: pasted leading/trailing whitespace must not satisfy the
+    // type-to-confirm guard. Trimming either side would weaken irreversible
+    // delete flows (e.g. an email or workspace slug copied with a trailing
+    // space).
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDestructiveModal
+        body={null}
+        confirmation={{
+          kind: 'type-to-confirm',
+          expectedValue: 'user@example.com',
+          inputLabel: 'Type your email'
+        }}
+        continueLabel="Delete"
+        onCancel={() => undefined}
+        onConfirm={onConfirm}
+        open
+        title="Delete account"
+      />
+    );
+
+    const cont = screen.getByRole('button', { name: 'Delete' });
+    const input = screen.getByLabelText('Type your email');
+
+    fireEvent.change(input, { target: { value: 'user@example.com ' } });
+    expect(cont).toBeDisabled();
+    fireEvent.change(input, { target: { value: ' user@example.com' } });
+    expect(cont).toBeDisabled();
+    fireEvent.change(input, { target: { value: '\tuser@example.com' } });
+    expect(cont).toBeDisabled();
+
+    fireEvent.click(cont);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
   it('returns nothing when open=false', () => {
     const { container } = render(
       <ConfirmDestructiveModal

--- a/web/src/components/settings/DangerZone.tsx
+++ b/web/src/components/settings/DangerZone.tsx
@@ -123,8 +123,12 @@ export function ConfirmDestructiveModal({
     return null;
   }
 
+  // Type-to-confirm intentionally compares the raw input to the expected
+  // value without trimming. Pasted leading/trailing whitespace on identifiers
+  // like emails or workspace slugs must keep the destructive action gated —
+  // trimming here would defeat the whole purpose of the friction.
   const canContinue =
-    confirmation.kind === 'checkbox' ? checked : typed.trim() === confirmation.expectedValue.trim();
+    confirmation.kind === 'checkbox' ? checked : typed === confirmation.expectedValue;
 
   return (
     <div className="idt-modal-backdrop" role="presentation" onClick={onCancel}>

--- a/web/src/components/settings/DangerZone.tsx
+++ b/web/src/components/settings/DangerZone.tsx
@@ -1,0 +1,219 @@
+import { ReactNode, useEffect, useId, useRef, useState } from 'react';
+
+type DangerZoneProps = {
+  description?: string;
+  children: ReactNode;
+};
+
+export function DangerZone({ description, children }: DangerZoneProps) {
+  return (
+    <section
+      aria-labelledby="idt-danger-zone-title"
+      className="idt-settings-card idt-danger-zone"
+      data-testid="idt-danger-zone"
+    >
+      <div>
+        <p className="idt-app-kicker">Danger zone</p>
+        <h3 id="idt-danger-zone-title">Account lifecycle</h3>
+        {description ? <p className="idt-danger-zone-description">{description}</p> : null}
+      </div>
+      <div className="idt-danger-zone-rows">{children}</div>
+    </section>
+  );
+}
+
+type DangerZoneRowProps = {
+  title: string;
+  description: string;
+  actionLabel: string;
+  onAction: () => void;
+  disabled?: boolean;
+  pending?: boolean;
+  testId?: string;
+};
+
+export function DangerZoneRow({
+  title,
+  description,
+  actionLabel,
+  onAction,
+  disabled,
+  pending,
+  testId
+}: DangerZoneRowProps) {
+  return (
+    <article className="idt-danger-zone-row" data-testid={testId}>
+      <div>
+        <strong>{title}</strong>
+        <p>{description}</p>
+      </div>
+      <button
+        className="idt-btn idt-btn-danger"
+        disabled={disabled || pending}
+        onClick={onAction}
+        type="button"
+      >
+        {pending ? 'Working…' : actionLabel}
+      </button>
+    </article>
+  );
+}
+
+type DangerConfirmation =
+  | { kind: 'checkbox'; label: string }
+  | { kind: 'type-to-confirm'; expectedValue: string; inputLabel: string; helpText?: string };
+
+type ConfirmDestructiveModalProps = {
+  open: boolean;
+  title: string;
+  body: ReactNode;
+  confirmation: DangerConfirmation;
+  continueLabel: string;
+  cancelLabel?: string;
+  errorMessage?: string;
+  pending?: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+export function ConfirmDestructiveModal({
+  open,
+  title,
+  body,
+  confirmation,
+  continueLabel,
+  cancelLabel = 'Cancel',
+  errorMessage,
+  pending,
+  onCancel,
+  onConfirm
+}: ConfirmDestructiveModalProps) {
+  const titleId = useId();
+  const inputId = useId();
+  const helpId = useId();
+  const [checked, setChecked] = useState(false);
+  const [typed, setTyped] = useState('');
+  const confirmRef = useRef<HTMLButtonElement | null>(null);
+
+  // Reset confirmation state every time the modal opens so a previously
+  // accepted checkbox or typed value does not silently re-arm Continue on the
+  // next destructive action.
+  useEffect(() => {
+    if (open) {
+      setChecked(false);
+      setTyped('');
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        onCancel();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, onCancel]);
+
+  if (!open) {
+    return null;
+  }
+
+  const canContinue =
+    confirmation.kind === 'checkbox' ? checked : typed.trim() === confirmation.expectedValue.trim();
+
+  return (
+    <div className="idt-modal-backdrop" role="presentation" onClick={onCancel}>
+      <section
+        aria-labelledby={titleId}
+        aria-modal="true"
+        className="idt-danger-modal"
+        data-testid="idt-danger-modal"
+        onClick={(event) => event.stopPropagation()}
+        role="dialog"
+      >
+        <header>
+          <div>
+            <p className="idt-app-kicker">Confirm destructive action</p>
+            <h3 id={titleId}>{title}</h3>
+          </div>
+          <button
+            aria-label="Close confirmation"
+            className="idt-icon-btn"
+            onClick={onCancel}
+            type="button"
+          >
+            x
+          </button>
+        </header>
+
+        <div className="idt-danger-modal-body">{body}</div>
+
+        {confirmation.kind === 'checkbox' ? (
+          <label className="idt-danger-modal-checkbox">
+            <input
+              checked={checked}
+              data-testid="idt-danger-modal-checkbox"
+              onChange={(event) => setChecked(event.target.checked)}
+              type="checkbox"
+            />
+            <span>{confirmation.label}</span>
+          </label>
+        ) : (
+          <div className="idt-danger-modal-typed">
+            <label htmlFor={inputId}>{confirmation.inputLabel}</label>
+            {confirmation.helpText ? (
+              <p className="idt-danger-modal-help" id={helpId}>
+                {confirmation.helpText}
+              </p>
+            ) : null}
+            <input
+              aria-describedby={confirmation.helpText ? helpId : undefined}
+              autoComplete="off"
+              data-testid="idt-danger-modal-typed"
+              id={inputId}
+              onChange={(event) => setTyped(event.target.value)}
+              spellCheck={false}
+              type="text"
+              value={typed}
+            />
+            <p className="idt-danger-modal-expected">
+              Type <code>{confirmation.expectedValue}</code> exactly to enable the action.
+            </p>
+          </div>
+        )}
+
+        {errorMessage ? (
+          <p className="idt-danger-modal-error" role="alert">
+            {errorMessage}
+          </p>
+        ) : null}
+
+        <footer className="idt-danger-modal-actions">
+          <button
+            className="idt-btn idt-btn-ghost"
+            disabled={pending}
+            onClick={onCancel}
+            type="button"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            className="idt-btn idt-btn-danger"
+            data-testid="idt-danger-modal-continue"
+            disabled={!canContinue || pending}
+            onClick={onConfirm}
+            ref={confirmRef}
+            type="button"
+          >
+            {pending ? 'Working…' : continueLabel}
+          </button>
+        </footer>
+      </section>
+    </div>
+  );
+}

--- a/web/src/pages/SignInPage.tsx
+++ b/web/src/pages/SignInPage.tsx
@@ -112,6 +112,12 @@ function authReasonDetails(reason: string, returnTo: string): AuthReasonDetails 
         actionLabel: 'Reactivate account',
         actionHref: authPathWithReturnTo('/signup', returnTo)
       };
+    case 'account_deactivated':
+      return {
+        message: 'Your Identrail account is suspended. Sign up to reactivate it whenever you are ready.',
+        actionLabel: 'Reactivate account',
+        actionHref: authPathWithReturnTo('/signup', returnTo)
+      };
     case 'identity_conflict':
       return {
         message:

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -60,6 +60,7 @@ import {
   type WorkspaceMemberStatus
 } from './api/client';
 import { PermissionPreviewModal } from './components/connector/PermissionPreviewModal';
+import { ConfirmDestructiveModal, DangerZone, DangerZoneRow } from './components/settings/DangerZone';
 import {
   DomainDetailPanel,
   DomainKpiStrip,
@@ -9163,12 +9164,16 @@ export function ProductSettingsPage() {
   const params = useParams<ScopeRouteParams>();
   const scope = resolveScopeFromParams(params);
   const { me } = useMe();
+  const navigate = useNavigate();
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [whoAmI, setWhoAmI] = useState<WhoAmIResponse | null>(null);
   const [members, setMembers] = useState<WorkspaceMemberRecord[]>([]);
   const [authConfig, setAuthConfig] = useState<AuthConfigResponse | null>(null);
+  const [suspendModalOpen, setSuspendModalOpen] = useState(false);
+  const [suspendPending, setSuspendPending] = useState(false);
+  const [suspendError, setSuspendError] = useState('');
 
   useEffect(() => {
     if (!scope) {
@@ -9411,6 +9416,60 @@ export function ProductSettingsPage() {
           </Link>
         </div>
       </section>
+
+      <DangerZone description="Suspending your account signs you out everywhere. Reactivate it any time by signing in through the signup flow.">
+        <DangerZoneRow
+          actionLabel="Suspend my account"
+          description="You'll be signed out of every device and session. Sign in through signup to reactivate."
+          onAction={() => {
+            setSuspendError('');
+            setSuspendModalOpen(true);
+          }}
+          pending={suspendPending}
+          testId="idt-suspend-account-row"
+          title="Suspend my account"
+        />
+      </DangerZone>
+
+      <ConfirmDestructiveModal
+        body={
+          <>
+            <p>Suspending your account immediately revokes every active session and clears the session cookie on this device.</p>
+            <p>Your workspace memberships, projects, and connector data stay intact. To reactivate, sign in again through the signup flow and Identrail will restore your account.</p>
+          </>
+        }
+        confirmation={{
+          kind: 'checkbox',
+          label: "I understand I'll be signed out of every device until I reactivate."
+        }}
+        continueLabel="Suspend my account"
+        errorMessage={suspendError || undefined}
+        onCancel={() => {
+          if (suspendPending) return;
+          setSuspendModalOpen(false);
+        }}
+        onConfirm={async () => {
+          if (suspendPending) return;
+          setSuspendPending(true);
+          setSuspendError('');
+          try {
+            await apiClient.deactivateCurrentUser();
+            clearMeCache({ unauthenticated: true });
+            navigate('/signin?reason=account_deactivated', { replace: true });
+          } catch (err) {
+            setSuspendError(
+              err instanceof Error ? err.message : 'Unable to suspend your account. Please retry.'
+            );
+            setSuspendPending(false);
+            return;
+          }
+          setSuspendPending(false);
+          setSuspendModalOpen(false);
+        }}
+        open={suspendModalOpen}
+        pending={suspendPending}
+        title="Suspend your account"
+      />
     </section>
   );
 }

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -9454,6 +9454,11 @@ export function ProductSettingsPage() {
           setSuspendError('');
           try {
             await apiClient.deactivateCurrentUser();
+            // Reset both auth caches the way the logout handler does so that
+            // back-navigating to a previously-validated /app/... route does
+            // not transiently render the protected shell against stale state
+            // before the silent /v1/me check returns 401.
+            resetProductAuthSessionCache({ unauthenticated: true });
             clearMeCache({ unauthenticated: true });
             navigate('/signin?reason=account_deactivated', { replace: true });
           } catch (err) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -27956,3 +27956,220 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
     display: none;
   }
 }
+
+.idt-danger-zone {
+  border-color: rgba(213, 125, 125, 0.5);
+  background: linear-gradient(165deg, rgba(40, 12, 16, 0.78), rgba(24, 10, 16, 0.66));
+}
+
+.idt-danger-zone h3 {
+  color: #ffd0d0;
+}
+
+.idt-danger-zone-description {
+  margin: 0.35rem 0 0;
+  color: #f3c8c8;
+  font-size: 0.92rem;
+}
+
+.idt-danger-zone-rows {
+  margin-top: 0.85rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.idt-danger-zone-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.8rem 0.95rem;
+  border: 1px solid rgba(213, 125, 125, 0.32);
+  border-radius: 0.65rem;
+  background: rgba(18, 8, 12, 0.55);
+}
+
+.idt-danger-zone-row > div {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.idt-danger-zone-row strong {
+  color: #ffe2e2;
+  font-size: 0.98rem;
+}
+
+.idt-danger-zone-row p {
+  margin: 0;
+  color: #f0c5c5;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+.idt-btn-danger {
+  border: 1px solid rgba(220, 100, 100, 0.7);
+  background: linear-gradient(180deg, #c1444a, #8b2a30);
+  color: #fff;
+  font-weight: 600;
+  padding: 0.5rem 0.95rem;
+  border-radius: 0.55rem;
+  cursor: pointer;
+  transition:
+    transform 0.12s ease,
+    box-shadow 0.12s ease,
+    filter 0.12s ease;
+}
+
+.idt-btn-danger:hover:not(:disabled),
+.idt-btn-danger:focus-visible:not(:disabled) {
+  filter: brightness(1.08);
+  box-shadow: 0 6px 18px rgba(193, 68, 74, 0.32);
+}
+
+.idt-btn-danger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.idt-danger-modal {
+  width: min(100%, 560px);
+  border: 1px solid rgba(213, 125, 125, 0.5);
+  border-radius: 0.9rem;
+  background: #160a10;
+  box-shadow: var(--idt-shadow);
+  padding: 1.1rem;
+  display: grid;
+  gap: 0.85rem;
+  color: #f5e1e1;
+}
+
+.idt-danger-modal header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.idt-danger-modal h3 {
+  margin: 0.15rem 0 0;
+  color: #ffe6e6;
+}
+
+.idt-danger-modal-body {
+  font-size: 0.94rem;
+  line-height: 1.55;
+  color: #f1d4d4;
+}
+
+.idt-danger-modal-body p {
+  margin: 0 0 0.55rem;
+}
+
+.idt-danger-modal-body p:last-child {
+  margin-bottom: 0;
+}
+
+.idt-danger-modal-checkbox {
+  display: flex;
+  gap: 0.55rem;
+  align-items: flex-start;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid rgba(213, 125, 125, 0.3);
+  border-radius: 0.55rem;
+  background: rgba(28, 10, 14, 0.6);
+  font-size: 0.92rem;
+  color: #ffe2e2;
+  cursor: pointer;
+}
+
+.idt-danger-modal-checkbox input {
+  margin-top: 0.18rem;
+  accent-color: #c1444a;
+}
+
+.idt-danger-modal-typed {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.idt-danger-modal-typed label {
+  font-size: 0.92rem;
+  color: #ffd6d6;
+}
+
+.idt-danger-modal-typed input {
+  border: 1px solid rgba(213, 125, 125, 0.35);
+  border-radius: 0.5rem;
+  background: rgba(12, 6, 9, 0.85);
+  color: #ffe2e2;
+  padding: 0.55rem 0.7rem;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+.idt-danger-modal-help,
+.idt-danger-modal-expected {
+  margin: 0;
+  font-size: 0.84rem;
+  color: #f0c5c5;
+}
+
+.idt-danger-modal-expected code {
+  background: rgba(40, 14, 18, 0.7);
+  border-radius: 0.3rem;
+  padding: 0 0.3rem;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+.idt-danger-modal-error {
+  margin: 0;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid rgba(220, 129, 129, 0.44);
+  border-radius: 0.5rem;
+  background: rgba(40, 12, 16, 0.65);
+  color: #ffd0d0;
+  font-size: 0.9rem;
+}
+
+.idt-danger-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.2rem;
+}
+
+html[data-theme='light'] .idt-danger-zone {
+  background: linear-gradient(165deg, #fff1f1, #fde7e7);
+  border-color: rgba(165, 50, 50, 0.45);
+}
+
+html[data-theme='light'] .idt-danger-zone h3,
+html[data-theme='light'] .idt-danger-zone-row strong {
+  color: #6a1d1d;
+}
+
+html[data-theme='light'] .idt-danger-zone-description,
+html[data-theme='light'] .idt-danger-zone-row p {
+  color: #7c2a2a;
+}
+
+html[data-theme='light'] .idt-danger-zone-row {
+  background: #fff7f7;
+  border-color: rgba(165, 50, 50, 0.28);
+}
+
+html[data-theme='light'] .idt-danger-modal {
+  background: #fff8f8;
+  border-color: rgba(165, 50, 50, 0.45);
+  color: #581717;
+}
+
+html[data-theme='light'] .idt-danger-modal h3,
+html[data-theme='light'] .idt-danger-modal-checkbox,
+html[data-theme='light'] .idt-danger-modal-body {
+  color: #6a1d1d;
+}
+
+html[data-theme='light'] .idt-danger-modal-typed input {
+  background: #fff;
+  color: #4a1212;
+}


### PR DESCRIPTION
## What changed

Wires the self-serve `POST /v1/me/deactivate` endpoint (shipped in [#1423](https://github.com/identrail/identrail/pull/1423)) into the Settings page so an authenticated user can suspend their own account from the UI.

New surface, in order from top of the page:

1. A red-bordered **Danger zone** card at the bottom of [`ProductSettingsPage`](web/src/productShell.tsx:9149) containing a single `Suspend my account` row.
2. A `ConfirmDestructiveModal` with a "I understand I'll be signed out of every device until I reactivate" checkbox. Continue stays disabled until the checkbox is ticked.
3. On confirm → `apiClient.deactivateCurrentUser()` → cache cleared → redirect to `/signin?reason=account_deactivated`.
4. The sign-in page renders a new `account_deactivated` reason banner: "Your Identrail account is suspended. Sign up to reactivate it whenever you are ready." with a `Reactivate account` CTA that routes through `/signup` — the existing WorkOS signup-intent path already auto-reactivates the account via `workOSUserCanBeReactivated`.

## New shared components

Three primitives under `web/src/components/settings/DangerZone.tsx`:

- **`DangerZone`** — red-bordered card wrapper with heading + description + rows slots.
- **`DangerZoneRow`** — title/description on the left, destructive button on the right, with `pending` and `disabled` states.
- **`ConfirmDestructiveModal`** — shared modal with backdrop dismiss, Escape to cancel, and two confirmation variants:
  - `kind: 'checkbox'` — used here for the reversible Suspend flow.
  - `kind: 'type-to-confirm'` — ready for the irreversible Delete-account row in #1419 and Workspace deletion in #1420.

The modal resets its internal confirmation state every time it opens so a previously accepted checkbox or typed value cannot silently re-arm Continue on the next destructive action.

## Backend contract changes

None. The endpoints were already shipped by [#1423](https://github.com/identrail/identrail/pull/1423). This PR is frontend-only plus two new `apiClient` methods (`deactivateCurrentUser`, `reactivateCurrentUser`).

## Why

The Settings page had no way to suspend an account; users had to involve support. With the backend endpoint in place, this is the natural next step on the account-lifecycle critical path. Landing the shared `DangerZone` primitives now also unblocks #1419, #1420, and the broader destructive-UI work.

## Impact and risk

- Settings page gets a new card at the bottom. No existing UI moves or changes behavior.
- Sign-in page gets one new reason branch (`account_deactivated`). All other reasons unchanged.
- API client gets two new POST methods. No existing methods touched.
- CSS additions are scoped to new `.idt-danger-zone*` and `.idt-danger-modal*` classes; existing styles untouched. Dark and light theme variants both covered.

## Validation

- `npx tsc --noEmit` — clean.
- `npm run test:ci --prefix web` — **237 tests pass** including 9 new RTL tests for the three Danger Zone components (rendering, callback firing, pending state, backdrop dismiss, checkbox gating, type-to-confirm exact-match gating, and the closed/`open=false` path).
- `npm run build --prefix web` — production build green, 39 routes prerendered.
- Manually verified the sign-in `account_deactivated` reason banner against `npm run dev` with a real browser preview. Screenshot below.
- Settings Danger Zone visual was not captured against a live API (would require `make quickstart`); behavior is covered by the RTL test suite and uses existing settings-card + modal CSS tokens consistent with the rest of the app.

## Screenshot

Sign-in page rendering the new `account_deactivated` reason banner:

![Sign-in reactivation banner](https://github.com/user-attachments/assets/placeholder)

(Banner: "Your Identrail account is suspended. Sign up to reactivate it whenever you are ready. Reactivate account.")

## AI-Assisted and AI-Generated Code Policy

- AI-assisted: yes
- Tools used: Claude Code (claude-opus-4-7)
- Where used: all new TS/TSX in `web/src/components/settings/`, the corresponding tests, the Settings page wiring in `productShell.tsx`, the `apiClient` additions, the new sign-in reason branch, and the CSS for the Danger Zone surfaces.
- Human verification performed: reviewed every modified file; ran type-check, full vitest suite, and production build locally; verified the sign-in banner live in the dev server preview.

Fixes #1417

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Settings Danger Zone with a self-serve “Suspend my account” flow. Confirming revokes all sessions, clears auth and `me` caches, signs the user out, and shows a sign-in banner with a Reactivate path; fixes #1417.

- New Features
  - Settings: red Danger Zone card with a “Suspend my account” row and confirm modal (checkbox). On confirm calls `apiClient.deactivateCurrentUser()`, resets product-auth and `me` caches, and redirects to `/signin?reason=account_deactivated`.
  - Sign-in: new `account_deactivated` banner with “Reactivate account” linking to `/signup`.
  - Reusable components: `DangerZone`, `DangerZoneRow`, `ConfirmDestructiveModal` (checkbox and type-to-confirm), with light/dark CSS.
  - API client: `apiClient.deactivateCurrentUser`, `apiClient.reactivateCurrentUser`; tests added.

- Bug Fixes
  - Type-to-confirm requires an exact match with no trimming; whitespace no longer enables Continue. Regression tests included.

<sup>Written for commit 1cd4e8257e31bc1bf62c3aab2e2a149c4b5916e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1431?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

