### PR TITLE
[codex] Add environment scope plumbing

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1340,7 +1340,7 @@ describe('App', () => {
     setCurrentPath('/app/tenant-a/workspace-a/projects/project-1');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { level: 2, name: /Connect project sources/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: /Connect environment sources/i })).toBeInTheDocument();
     expect(screen.getByRole('navigation', { name: /App sections/i })).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Projects' })).not.toBeInTheDocument();
   });

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -807,6 +807,18 @@ describe('Domain-first app routes', () => {
         updated_at: '2026-01-02T00:00:00Z'
       }))
     });
+    vi.spyOn(api.apiClient, 'getProject').mockResolvedValue({
+      project: {
+        tenant_id: 'tenant-a',
+        workspace_id: 'workspace-a',
+        project_id: 'older-production',
+        name: 'Older Production',
+        slug: 'older-production',
+        description: 'Long-lived production boundary.',
+        created_at: '2025-01-01T00:00:00Z',
+        updated_at: '2025-01-02T00:00:00Z'
+      }
+    });
 
     const { ProductAWSConnectPage } = await import('./productShell');
     function LocationProbe() {
@@ -827,6 +839,60 @@ describe('Domain-first app routes', () => {
       '/app/tenant-a/workspace-a/projects/older-production?source=aws'
     );
     expect(listProjects).not.toHaveBeenCalled();
+  });
+
+  it('falls back to an active environment when the requested environment is archived', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'active-production',
+          name: 'Active Production',
+          slug: 'active-production',
+          description: 'Active production boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getProject').mockResolvedValue({
+      project: {
+        tenant_id: 'tenant-a',
+        workspace_id: 'workspace-a',
+        project_id: 'archived-production',
+        name: 'Archived Production',
+        slug: 'archived-production',
+        description: 'Retired boundary.',
+        archived_at: '2026-01-03T00:00:00Z',
+        created_at: '2025-01-01T00:00:00Z',
+        updated_at: '2026-01-03T00:00:00Z'
+      }
+    });
+
+    const { ProductDomainRoutePage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/identities?environment=archived-production']}>
+        <Routes>
+          <Route
+            path="/app/:tenantID/:workspaceID/aws/identities"
+            element={<ProductDomainRoutePage domain="aws" routeID="identities" />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(screen.getByRole('combobox', { name: 'Environment' })).toHaveValue('active-production'));
+    expect(screen.getByRole('link', { name: /Connect AWS/i })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/aws/connect?environment=active-production'
+    );
+    expect(screen.getByRole('link', { name: /AWS findings/i })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/aws/findings?environment=active-production'
+    );
   });
 
   it('creates a new unique environment key instead of overwriting an existing environment', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -736,6 +736,159 @@ describe('Domain-first app routes', () => {
     );
   });
 
+  it('routes connect actions to the selected environment even when it is outside the first page', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    const api = await import('./api/client');
+    const listProjects = vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: Array.from({ length: 50 }, (_, index) => ({
+        tenant_id: 'tenant-a',
+        workspace_id: 'workspace-a',
+        project_id: `recent-environment-${index + 1}`,
+        name: `Recent Environment ${index + 1}`,
+        slug: `recent-environment-${index + 1}`,
+        description: '',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-02T00:00:00Z'
+      }))
+    });
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+    function LocationProbe() {
+      const location = useLocation();
+      return <p data-testid="location">{`${location.pathname}${location.search}`}</p>;
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=older-production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+          <Route path="/app/:tenantID/:workspaceID/projects/:projectID" element={<LocationProbe />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByTestId('location')).toHaveTextContent(
+      '/app/tenant-a/workspace-a/projects/older-production?source=aws'
+    );
+    expect(listProjects).not.toHaveBeenCalled();
+  });
+
+  it('creates a new unique environment key instead of overwriting an existing environment', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    const api = await import('./api/client');
+    const existingProject = {
+      tenant_id: 'tenant-a',
+      workspace_id: 'workspace-a',
+      project_id: 'production-platform',
+      name: 'Production Platform',
+      slug: 'production-platform',
+      description: 'Existing production boundary.',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-02T00:00:00Z'
+    };
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({ items: [existingProject] });
+    vi.spyOn(api.apiClient, 'upsertProject').mockImplementation(async (_workspaceID, payload: any) => ({
+      project: {
+        tenant_id: 'tenant-a',
+        workspace_id: 'workspace-a',
+        project_id: payload.project_id,
+        name: payload.name,
+        slug: payload.slug,
+        description: payload.description ?? '',
+        created_at: '2026-01-03T00:00:00Z',
+        updated_at: '2026-01-03T00:00:00Z'
+      }
+    }));
+
+    const { ProductProjectsPage } = await import('./productShell');
+    function LocationProbe() {
+      const location = useLocation();
+      return <p data-testid="location">{`${location.pathname}${location.search}`}</p>;
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/projects?source=aws']}>
+        <Routes>
+          <Route
+            path="/app/:tenantID/:workspaceID/projects"
+            element={
+              <>
+                <LocationProbe />
+                <ProductProjectsPage />
+              </>
+            }
+          />
+          <Route path="/app/:tenantID/:workspaceID/projects/:projectID" element={<LocationProbe />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 2, name: 'Environments' })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText(/Environment name/i), { target: { value: 'Production Platform' } });
+    fireEvent.click(screen.getByRole('button', { name: /Create environment/i }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('location')).toHaveTextContent(
+        '/app/tenant-a/workspace-a/projects/production-platform-2?source=aws'
+      )
+    );
+    expect(api.apiClient.upsertProject).toHaveBeenCalledWith(
+      'workspace-a',
+      expect.objectContaining({ project_id: 'production-platform-2', slug: 'production-platform-2' }),
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+  });
+
+  it('creates stable hidden keys for non-ASCII environment names', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({ items: [] });
+    vi.spyOn(api.apiClient, 'upsertProject').mockImplementation(async (_workspaceID, payload: any) => ({
+      project: {
+        tenant_id: 'tenant-a',
+        workspace_id: 'workspace-a',
+        project_id: payload.project_id,
+        name: payload.name,
+        slug: payload.slug,
+        description: payload.description ?? '',
+        created_at: '2026-01-03T00:00:00Z',
+        updated_at: '2026-01-03T00:00:00Z'
+      }
+    }));
+
+    const { ProductProjectsPage } = await import('./productShell');
+    function LocationProbe() {
+      const location = useLocation();
+      return <p data-testid="location">{`${location.pathname}${location.search}`}</p>;
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/projects?source=github']}>
+        <Routes>
+          <Route
+            path="/app/:tenantID/:workspaceID/projects"
+            element={
+              <>
+                <LocationProbe />
+                <ProductProjectsPage />
+              </>
+            }
+          />
+          <Route path="/app/:tenantID/:workspaceID/projects/:projectID" element={<LocationProbe />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 2, name: 'Environments' })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText(/Environment name/i), { target: { value: '本番環境' } });
+    fireEvent.click(screen.getByRole('button', { name: /Create environment/i }));
+
+    await waitFor(() => expect(screen.getByTestId('location')).toHaveTextContent('/projects/environment-'));
+    const payload = (api.apiClient.upsertProject as any).mock.calls[0][1];
+    expect(payload.project_id).toMatch(/^environment-[a-z0-9]+$/);
+    expect(payload.project_id).not.toBe('default-environment');
+  });
+
   it('opens nested GitHub AI risk routes from the sidebar domain flyout', async () => {
     mockConnectorFeatureFlags({ github: true, kubernetes: true });
     mockBackendFeatures({ github: true, kubernetes: true });

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -285,7 +285,7 @@ async function renderProjectDetail(
         <ProductProjectDetailPage />
         {options.withProjectSwitcher ? (
           <button type="button" onClick={() => navigate('/app/tenant-a/workspace-a/projects/project-2')}>
-            Open project 2
+            Open environment 2
           </button>
         ) : null}
       </>
@@ -612,15 +612,49 @@ describe('Domain-first app routes', () => {
     expect(DOMAIN_APP_ROUTE_MANIFEST).not.toContain('/app/:tenantID/:workspaceID/findings');
   });
 
-  it('renders premium domain route shells with provider marks without an in-page subsection rail', async () => {
+  it('renders premium domain route shells with provider marks and environment scope', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production-platform',
+          name: 'Production Platform',
+          slug: 'production-platform',
+          description: 'Production identity boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        },
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'staging-platform',
+          name: 'Staging Platform',
+          slug: 'staging-platform',
+          description: 'Staging identity boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-03T00:00:00Z'
+        }
+      ]
+    });
     const { ProductDomainRoutePage } = await import('./productShell');
+    function LocationProbe() {
+      const location = useLocation();
+      return <p data-testid="location">{`${location.pathname}${location.search}`}</p>;
+    }
 
     render(
-      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/github/agentic-risk/mcp-tools']}>
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/github/agentic-risk/mcp-tools?environment=staging-platform']}>
         <Routes>
           <Route
             path="/app/:tenantID/:workspaceID/github/agentic-risk/mcp-tools"
-            element={<ProductDomainRoutePage domain="github" routeID="agentic-risk-mcp-tools" />}
+            element={
+              <>
+                <LocationProbe />
+                <ProductDomainRoutePage domain="github" routeID="agentic-risk-mcp-tools" />
+              </>
+            }
           />
         </Routes>
       </MemoryRouter>
@@ -629,10 +663,22 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByRole('heading', { level: 2, name: /MCP tools/i })).toBeInTheDocument();
     expect(screen.getByRole('img', { name: 'GitHub' })).toBeInTheDocument();
     expect(screen.queryByRole('navigation', { name: /GitHub sections/i })).not.toBeInTheDocument();
+    expect(await screen.findByRole('option', { name: 'Staging Platform' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Environment' })).toHaveValue('staging-platform');
+    expect(screen.getByRole('link', { name: /Connect GitHub/i })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/github/connect?environment=staging-platform'
+    );
+    fireEvent.change(screen.getByRole('combobox', { name: 'Environment' }), {
+      target: { value: 'production-platform' }
+    });
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/app/tenant-a/workspace-a/github/agentic-risk/mcp-tools?environment=production-platform'
+    );
     expect(screen.getByText('Route contract')).toBeInTheDocument();
   });
 
-  it('preserves the requested domain source when creating the first project from connect', async () => {
+  it('preserves the requested domain source when creating the first environment from connect', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     const api = await import('./api/client');
     const project = {
@@ -672,11 +718,11 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByRole('heading', { level: 2, name: 'Projects' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: 'Environments' })).toBeInTheDocument();
     expect(screen.getByTestId('location')).toHaveTextContent('/app/tenant-a/workspace-a/projects?source=aws');
 
-    fireEvent.change(screen.getByLabelText(/Project name/i), { target: { value: 'Production Platform' } });
-    fireEvent.click(screen.getByRole('button', { name: /Create project/i }));
+    fireEvent.change(screen.getByLabelText(/Environment name/i), { target: { value: 'Production Platform' } });
+    fireEvent.click(screen.getByRole('button', { name: /Create environment/i }));
 
     await waitFor(() =>
       expect(screen.getByTestId('location')).toHaveTextContent(
@@ -1035,8 +1081,8 @@ describe('ProductProjectDetailPage', () => {
     fireEvent.click(firstQueueButton);
     expect(await screen.findByRole('button', { name: /Queueing/i })).toBeDisabled();
 
-    fireEvent.click(screen.getByRole('button', { name: /Open project 2/i }));
-    expect(await screen.findByRole('heading', { name: /Connect project sources/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Open environment 2/i }));
+    expect(await screen.findByRole('heading', { name: /Connect environment sources/i })).toBeInTheDocument();
     const secondQueueButton = await screen.findByRole('button', { name: /Queue first scan/i });
     await waitFor(() => expect(secondQueueButton).not.toBeDisabled());
     fireEvent.click(secondQueueButton);

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -678,6 +678,62 @@ describe('Domain-first app routes', () => {
     expect(screen.getByText('Route contract')).toBeInTheDocument();
   });
 
+  it('keeps a requested environment selected when it is outside the first selector page', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: Array.from({ length: 50 }, (_, index) => ({
+        tenant_id: 'tenant-a',
+        workspace_id: 'workspace-a',
+        project_id: `recent-environment-${index + 1}`,
+        name: `Recent Environment ${index + 1}`,
+        slug: `recent-environment-${index + 1}`,
+        description: '',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-02T00:00:00Z'
+      }))
+    });
+    vi.spyOn(api.apiClient, 'getProject').mockResolvedValue({
+      project: {
+        tenant_id: 'tenant-a',
+        workspace_id: 'workspace-a',
+        project_id: 'older-production',
+        name: 'Older Production',
+        slug: 'older-production',
+        description: 'Long-lived production boundary.',
+        created_at: '2025-01-01T00:00:00Z',
+        updated_at: '2025-01-02T00:00:00Z'
+      }
+    });
+
+    const { ProductDomainRoutePage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/github/repositories?environment=older-production']}>
+        <Routes>
+          <Route
+            path="/app/:tenantID/:workspaceID/github/repositories"
+            element={<ProductDomainRoutePage domain="github" routeID="repositories" />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(screen.getByRole('combobox', { name: 'Environment' })).toHaveValue('older-production'));
+    expect(api.apiClient.getProject).toHaveBeenCalledWith(
+      'workspace-a',
+      'older-production',
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
+    expect(screen.getByRole('link', { name: /Connect GitHub/i })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/github/connect?environment=older-production'
+    );
+    expect(screen.getByRole('link', { name: /GitHub findings/i })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/github/findings?environment=older-production'
+    );
+  });
+
   it('preserves the requested domain source when creating the first environment from connect', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     const api = await import('./api/client');
@@ -776,6 +832,16 @@ describe('Domain-first app routes', () => {
   it('creates a new unique environment key instead of overwriting an existing environment', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     const api = await import('./api/client');
+    const firstPageProjects = Array.from({ length: 50 }, (_, index) => ({
+      tenant_id: 'tenant-a',
+      workspace_id: 'workspace-a',
+      project_id: `recent-environment-${index + 1}`,
+      name: `Recent Environment ${index + 1}`,
+      slug: `recent-environment-${index + 1}`,
+      description: '',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-02T00:00:00Z'
+    }));
     const existingProject = {
       tenant_id: 'tenant-a',
       workspace_id: 'workspace-a',
@@ -786,7 +852,15 @@ describe('Domain-first app routes', () => {
       created_at: '2026-01-01T00:00:00Z',
       updated_at: '2026-01-02T00:00:00Z'
     };
-    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({ items: [existingProject] });
+    vi.spyOn(api.apiClient, 'listProjects').mockImplementation(async (_workspaceID, filters: any) => {
+      if (filters?.limit === 50) {
+        return { items: firstPageProjects };
+      }
+      if (filters?.cursor === 'older-page') {
+        return { items: [existingProject] };
+      }
+      return { items: firstPageProjects, next_cursor: 'older-page' };
+    });
     vi.spyOn(api.apiClient, 'upsertProject').mockImplementation(async (_workspaceID, payload: any) => ({
       project: {
         tenant_id: 'tenant-a',

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -841,6 +841,75 @@ describe('Domain-first app routes', () => {
     expect(listProjects).not.toHaveBeenCalled();
   });
 
+  it('keeps requested environment selected when getProject check fails for a transient error', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: Array.from({ length: 50 }, (_, index) => ({
+        tenant_id: 'tenant-a',
+        workspace_id: 'workspace-a',
+        project_id: `recent-environment-${index + 1}`,
+        name: `Recent Environment ${index + 1}`,
+        slug: `recent-environment-${index + 1}`,
+        description: '',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-02T00:00:00Z'
+      }))
+    });
+    vi.spyOn(api.apiClient, 'getProject').mockRejectedValue(new api.ApiError('temporary outage', 503));
+
+    const { ProductDomainRoutePage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/github/repositories?environment=older-production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/github/repositories" element={<ProductDomainRoutePage domain="github" routeID="repositories" />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('combobox', { name: 'Environment' })).toHaveValue('older-production');
+    expect(screen.getByRole('link', { name: /Connect GitHub/i })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/github/connect?environment=older-production'
+    );
+    expect(await screen.findByText(/Unable to verify selected environment older-production/i)).toBeInTheDocument();
+  });
+
+  it('does not silently route AWS connect to fallback environment when getProject check fails transiently', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    const api = await import('./api/client');
+    const listProjects = vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'active-production',
+          name: 'Active Production',
+          slug: 'active-production',
+          description: 'Active production boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getProject').mockRejectedValue(new api.ApiError('temporary outage', 503));
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=older-production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 2, name: /Unable to open AWS setup/i })).toBeInTheDocument();
+    expect(screen.getByText(/temporary outage/i)).toBeInTheDocument();
+    expect(listProjects).not.toHaveBeenCalled();
+  });
+
   it('falls back to an active environment when the requested environment is archived', async () => {
     const api = await import('./api/client');
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -2239,7 +2239,9 @@ function useEnvironmentScope(scope: ProductSession | null, requestedEnvironmentI
               return;
             }
             if (isTransientProjectLookupError(requestError)) {
-              setError(formatAPIError(requestError, `Unable to verify selected environment ${requestedID}.`));
+              const requestedErrorMessage = normalizeValue(formatAPIError(requestError, ''));
+              const fallbackMessage = `Unable to verify selected environment ${requestedID}.`;
+              setError(requestedErrorMessage ? `${fallbackMessage} ${requestedErrorMessage}` : fallbackMessage);
             } else {
               rejectedID = requestedID;
             }

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -985,6 +985,10 @@ function projectEnvironmentLabel(project: ProjectRecord): string {
   return environmentFallbackLabel(project.project_id);
 }
 
+function isProjectArchived(project: ProjectRecord): boolean {
+  return Boolean(normalizeValue(project.archived_at ?? ''));
+}
+
 function environmentFallbackLabel(projectID: string | undefined): string {
   const normalized = normalizeValue(projectID ?? '');
   if (!normalized || /^project(?:[-_]\d+)?$/i.test(normalized) || /^legacy[-_]project$/i.test(normalized)) {
@@ -2177,18 +2181,21 @@ function useEnvironmentScope(scope: ProductSession | null, requestedEnvironmentI
   const [items, setItems] = useState<ProjectRecord[]>([]);
   const [loading, setLoading] = useState(Boolean(scope));
   const [error, setError] = useState('');
+  const [rejectedRequestedID, setRejectedRequestedID] = useState('');
 
   useEffect(() => {
     if (!scope) {
       setItems([]);
       setLoading(false);
       setError('');
+      setRejectedRequestedID('');
       return undefined;
     }
 
     let active = true;
     setLoading(true);
     setError('');
+    setRejectedRequestedID('');
 
     const loadEnvironments = async () => {
       try {
@@ -2207,6 +2214,7 @@ function useEnvironmentScope(scope: ProductSession | null, requestedEnvironmentI
           return;
         }
         let nextItems = response.items ?? [];
+        let rejectedID = '';
         if (requestedID && !nextItems.some((item) => item.project_id === requestedID)) {
           try {
             const requestedResponse = await apiClient.getProject(
@@ -2217,21 +2225,26 @@ function useEnvironmentScope(scope: ProductSession | null, requestedEnvironmentI
             if (!active) {
               return;
             }
-            if (!normalizeValue(requestedResponse.project.archived_at ?? '')) {
+            if (isProjectArchived(requestedResponse.project)) {
+              rejectedID = requestedID;
+            } else {
               nextItems = [requestedResponse.project, ...nextItems];
             }
           } catch {
             if (!active) {
               return;
             }
+            rejectedID = requestedID;
           }
         }
+        setRejectedRequestedID(rejectedID);
         setItems(nextItems);
       } catch (loadError) {
         if (!active) {
           return;
         }
         setItems([]);
+        setRejectedRequestedID('');
         setError(loadError instanceof Error ? loadError.message : 'Unable to load environments.');
       } finally {
         if (active) {
@@ -2247,11 +2260,8 @@ function useEnvironmentScope(scope: ProductSession | null, requestedEnvironmentI
     };
   }, [requestedEnvironmentID, scope?.tenantID, scope?.workspaceID]);
 
-  const selected = useMemo(() => {
-    const requested = normalizeValue(requestedEnvironmentID);
-    return items.find((item) => item.project_id === requested) ?? null;
-  }, [items, requestedEnvironmentID]);
-  const selectedID = normalizeValue(requestedEnvironmentID) || selected?.project_id || items[0]?.project_id || '';
+  const requestedID = normalizeValue(requestedEnvironmentID);
+  const selectedID = requestedID && rejectedRequestedID !== requestedID ? requestedID : items[0]?.project_id || '';
 
   return { items, selectedID, loading, error };
 }
@@ -2457,8 +2467,24 @@ function ProductConnectorConnectPage({ provider, providerLabel }: ConnectorConne
       try {
         const requestedProjectID = normalizeValue(requestedEnvironmentID);
         if (requestedProjectID) {
-          setTargetPath(appendSourceQuery(buildProjectPath(scope, requestedProjectID), provider));
-          return;
+          try {
+            const requestedResponse = await apiClient.getProject(
+              scope.workspaceID,
+              requestedProjectID,
+              buildProductAuthContext(scope)
+            );
+            if (!active) {
+              return;
+            }
+            if (!isProjectArchived(requestedResponse.project)) {
+              setTargetPath(appendSourceQuery(buildProjectPath(scope, requestedProjectID), provider));
+              return;
+            }
+          } catch {
+            if (!active) {
+              return;
+            }
+          }
         }
         const response = await apiClient.listProjects(
           scope.workspaceID,

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -2192,6 +2192,7 @@ function useEnvironmentScope(scope: ProductSession | null, requestedEnvironmentI
 
     const loadEnvironments = async () => {
       try {
+        const requestedID = normalizeValue(requestedEnvironmentID);
         const response = await apiClient.listProjects(
           scope.workspaceID,
           {
@@ -2205,7 +2206,27 @@ function useEnvironmentScope(scope: ProductSession | null, requestedEnvironmentI
         if (!active) {
           return;
         }
-        setItems(response.items ?? []);
+        let nextItems = response.items ?? [];
+        if (requestedID && !nextItems.some((item) => item.project_id === requestedID)) {
+          try {
+            const requestedResponse = await apiClient.getProject(
+              scope.workspaceID,
+              requestedID,
+              buildProductAuthContext(scope)
+            );
+            if (!active) {
+              return;
+            }
+            if (!normalizeValue(requestedResponse.project.archived_at ?? '')) {
+              nextItems = [requestedResponse.project, ...nextItems];
+            }
+          } catch {
+            if (!active) {
+              return;
+            }
+          }
+        }
+        setItems(nextItems);
       } catch (loadError) {
         if (!active) {
           return;
@@ -2224,13 +2245,13 @@ function useEnvironmentScope(scope: ProductSession | null, requestedEnvironmentI
     return () => {
       active = false;
     };
-  }, [scope?.tenantID, scope?.workspaceID]);
+  }, [requestedEnvironmentID, scope?.tenantID, scope?.workspaceID]);
 
   const selected = useMemo(() => {
     const requested = normalizeValue(requestedEnvironmentID);
-    return items.find((item) => item.project_id === requested) ?? items[0] ?? null;
+    return items.find((item) => item.project_id === requested) ?? null;
   }, [items, requestedEnvironmentID]);
-  const selectedID = selected?.project_id ?? normalizeValue(requestedEnvironmentID);
+  const selectedID = normalizeValue(requestedEnvironmentID) || selected?.project_id || items[0]?.project_id || '';
 
   return { items, selectedID, loading, error };
 }
@@ -2243,16 +2264,19 @@ function ProductEnvironmentSelector({
   onChange: (environmentID: string) => void;
 }) {
   const hasEnvironments = state.items.length > 0;
+  const selectedID = normalizeValue(state.selectedID);
+  const selectedIsLoaded = state.items.some((item) => item.project_id === selectedID);
 
   return (
     <label className="idt-environment-selector">
       <span>Environment</span>
       <select
         aria-label="Environment"
-        value={hasEnvironments ? state.selectedID : ''}
-        disabled={state.loading || !hasEnvironments}
+        value={selectedID}
+        disabled={state.loading || (!hasEnvironments && !selectedID)}
         onChange={(event) => onChange(event.target.value)}
       >
+        {selectedID && !selectedIsLoaded ? <option value={selectedID}>{environmentFallbackLabel(selectedID)}</option> : null}
         {hasEnvironments ? (
           state.items.map((item) => (
             <option key={item.project_id} value={item.project_id}>
@@ -2263,7 +2287,7 @@ function ProductEnvironmentSelector({
           <option value="">Default environment</option>
         )}
       </select>
-      <small>{state.loading ? 'Loading...' : state.error || !hasEnvironments ? 'Default environment' : 'Active scope'}</small>
+      <small>{state.loading ? 'Loading...' : state.error ? state.error : selectedID ? 'Active scope' : 'Default environment'}</small>
     </label>
   );
 }
@@ -4913,16 +4937,10 @@ export function ProductProjectsPage() {
     event.preventDefault();
 
     const name = normalizeValue(draftName);
-    const projectID = uniqueEnvironmentToken(name, projects);
-    const slug = projectID;
     const description = normalizeValue(draftDescription);
 
     if (!name) {
       setError('Environment name is required.');
-      return;
-    }
-    if (!projectID) {
-      setError('Enter a readable environment name.');
       return;
     }
 
@@ -4931,6 +4949,13 @@ export function ProductProjectsPage() {
 
     try {
       const auth = buildProductAuthContext(scope);
+      const knownProjects = await listOverviewProjects(scope.workspaceID, { include_archived: true }, auth);
+      const projectID = uniqueEnvironmentToken(name, knownProjects);
+      const slug = projectID;
+      if (!projectID) {
+        setError('Enter a readable environment name.');
+        return;
+      }
       const response = await apiClient.upsertProject(
         scope.workspaceID,
         {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -217,10 +217,12 @@ const REPO_FINDING_SEVERITY_FILTERS = ['all', 'critical', 'high', 'medium', 'low
 const REPO_FINDING_TYPE_FILTERS = ['all', 'secret_exposure', 'repo_misconfiguration'] as const;
 const REPO_FINDING_SORT_FIELDS = ['severity', 'created_at', 'type', 'title'] as const;
 const REPO_FINDING_STATUS_FILTERS = ['all', 'open', 'ack', 'suppressed', 'resolved'] as const;
+const ENVIRONMENT_QUERY_PARAM = 'environment';
 const OVERVIEW_FINDING_LIMIT = 50;
 const OVERVIEW_RISK_DISPLAY_LIMIT = 8;
 const OVERVIEW_SCAN_LIMIT = 5;
 const OVERVIEW_PROJECT_PAGE_LIMIT = 100;
+const ENVIRONMENT_SELECTOR_LIMIT = 50;
 const AI_RISKS_REPO_FINDINGS_PAGE_LIMIT = 100;
 const EXECUTIVE_REPORT_SEVERITY_ORDER = ['critical', 'high', 'medium', 'low', 'info'] as const;
 
@@ -520,7 +522,7 @@ async function listOverviewProjects(
       break;
     }
     if (seenCursors.has(nextCursor)) {
-      throw new Error('Project pagination returned a repeated cursor');
+      throw new Error('Environment pagination returned a repeated cursor');
     }
     seenCursors.add(nextCursor);
     cursor = nextCursor;
@@ -940,6 +942,51 @@ function formatTokenLabel(value: string): string {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ');
+}
+
+function projectEnvironmentLabel(project: ProjectRecord): string {
+  const name = normalizeValue(project.name);
+  if (name) {
+    return name;
+  }
+  const slug = normalizeValue(project.slug);
+  if (slug) {
+    return formatTokenLabel(slug);
+  }
+  return environmentFallbackLabel(project.project_id);
+}
+
+function environmentFallbackLabel(projectID: string | undefined): string {
+  const normalized = normalizeValue(projectID ?? '');
+  if (!normalized || /^project(?:[-_]\d+)?$/i.test(normalized) || /^legacy[-_]project$/i.test(normalized)) {
+    return 'Default environment';
+  }
+  return formatTokenLabel(normalized);
+}
+
+function environmentIDFromSearch(search: string): string {
+  return normalizeValue(new URLSearchParams(search).get(ENVIRONMENT_QUERY_PARAM));
+}
+
+function environmentSearch(search: string, environmentID: string): string {
+  const params = new URLSearchParams(search);
+  const normalized = normalizeValue(environmentID);
+  if (normalized) {
+    params.set(ENVIRONMENT_QUERY_PARAM, normalized);
+  } else {
+    params.delete(ENVIRONMENT_QUERY_PARAM);
+  }
+  const next = params.toString();
+  return next ? `?${next}` : '';
+}
+
+function appendEnvironmentQuery(path: string, environmentID: string | undefined): string {
+  const normalized = normalizeValue(environmentID ?? '');
+  if (!normalized) {
+    return path;
+  }
+  const [pathname, rawSearch = ''] = path.split('?');
+  return `${pathname}${environmentSearch(rawSearch, normalized)}`;
 }
 
 function canonicalGitHubRepositoryDisplay(value: string): string {
@@ -2090,6 +2137,108 @@ function ProductDomainFlyout({
   );
 }
 
+type EnvironmentScopeState = {
+  items: ProjectRecord[];
+  selectedID: string;
+  loading: boolean;
+  error: string;
+};
+
+function useEnvironmentScope(scope: ProductSession | null, requestedEnvironmentID: string): EnvironmentScopeState {
+  const [items, setItems] = useState<ProjectRecord[]>([]);
+  const [loading, setLoading] = useState(Boolean(scope));
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!scope) {
+      setItems([]);
+      setLoading(false);
+      setError('');
+      return undefined;
+    }
+
+    let active = true;
+    setLoading(true);
+    setError('');
+
+    const loadEnvironments = async () => {
+      try {
+        const response = await apiClient.listProjects(
+          scope.workspaceID,
+          {
+            limit: ENVIRONMENT_SELECTOR_LIMIT,
+            sort_by: 'updated_at',
+            sort_order: 'desc',
+            include_archived: false
+          },
+          buildProductAuthContext(scope)
+        );
+        if (!active) {
+          return;
+        }
+        setItems(response.items ?? []);
+      } catch (loadError) {
+        if (!active) {
+          return;
+        }
+        setItems([]);
+        setError(loadError instanceof Error ? loadError.message : 'Unable to load environments.');
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void loadEnvironments();
+
+    return () => {
+      active = false;
+    };
+  }, [scope?.tenantID, scope?.workspaceID]);
+
+  const selected = useMemo(() => {
+    const requested = normalizeValue(requestedEnvironmentID);
+    return items.find((item) => item.project_id === requested) ?? items[0] ?? null;
+  }, [items, requestedEnvironmentID]);
+  const selectedID = selected?.project_id ?? normalizeValue(requestedEnvironmentID);
+
+  return { items, selectedID, loading, error };
+}
+
+function ProductEnvironmentSelector({
+  state,
+  onChange
+}: {
+  state: EnvironmentScopeState;
+  onChange: (environmentID: string) => void;
+}) {
+  const hasEnvironments = state.items.length > 0;
+
+  return (
+    <label className="idt-environment-selector">
+      <span>Environment</span>
+      <select
+        aria-label="Environment"
+        value={hasEnvironments ? state.selectedID : ''}
+        disabled={state.loading || !hasEnvironments}
+        onChange={(event) => onChange(event.target.value)}
+      >
+        {hasEnvironments ? (
+          state.items.map((item) => (
+            <option key={item.project_id} value={item.project_id}>
+              {projectEnvironmentLabel(item)}
+            </option>
+          ))
+        ) : (
+          <option value="">Default environment</option>
+        )}
+      </select>
+      <small>{state.loading ? 'Loading...' : state.error || !hasEnvironments ? 'Default environment' : 'Active scope'}</small>
+    </label>
+  );
+}
+
 function ProductRouteReadinessList({ route }: { route: ProductDomainRoute }) {
   return (
     <section className="idt-domain-status-panel idt-domain-readiness-list" aria-label={`${route.title} route readiness`}>
@@ -2123,7 +2272,11 @@ export function ProductDomainRoutePage({
   routeID?: ProductDomainRouteID;
 }) {
   const params = useParams<ScopeRouteParams>();
+  const location = useLocation();
+  const navigate = useNavigate();
   const scope = resolveScopeFromParams(params);
+  const requestedEnvironmentID = useMemo(() => environmentIDFromSearch(location.search), [location.search]);
+  const environmentScope = useEnvironmentScope(scope, requestedEnvironmentID);
 
   if (!scope) {
     return (
@@ -2137,9 +2290,23 @@ export function ProductDomainRoutePage({
 
   const config = PRODUCT_DOMAIN_CONFIGS[domain];
   const route = findDomainRoute(domain, routeID);
-  const domainBasePath = buildScopedPath(scope, config.routePrefix);
-  const connectPath = domainRoutePath(scope, domain, findDomainRoute(domain, config.connectRouteID));
+  const selectedEnvironmentID = environmentScope.selectedID;
+  const domainBasePath = appendEnvironmentQuery(buildScopedPath(scope, config.routePrefix), selectedEnvironmentID);
+  const connectPath = appendEnvironmentQuery(
+    domainRoutePath(scope, domain, findDomainRoute(domain, config.connectRouteID)),
+    selectedEnvironmentID
+  );
+  const findingsPath = appendEnvironmentQuery(buildScopedPath(scope, `${config.routePrefix}/findings`), selectedEnvironmentID);
   const sectionPath = domainRoutePath(scope, domain, route);
+  const handleEnvironmentChange = (environmentID: string) => {
+    navigate(
+      {
+        pathname: location.pathname,
+        search: environmentSearch(location.search, environmentID)
+      },
+      { replace: false }
+    );
+  };
 
   return (
     <DomainPageShell
@@ -2147,7 +2314,7 @@ export function ProductDomainRoutePage({
       eyebrow={route.eyebrow}
       title={route.title}
       description={route.description}
-      scope={`${formatScopeDisplay(scope.tenantID)} / ${formatScopeDisplay(scope.workspaceID)}`}
+      scope={<ProductEnvironmentSelector state={environmentScope} onChange={handleEnvironmentChange} />}
       status={route.status}
       statusTone="success"
       primaryAction={
@@ -2155,7 +2322,7 @@ export function ProductDomainRoutePage({
           ? { label: `${config.navLabel} home`, to: domainBasePath, variant: 'secondary' }
           : { label: `Connect ${config.navLabel}`, to: connectPath, variant: 'primary' }
       }
-      secondaryActions={route.id === 'findings' ? [] : [{ label: `${config.navLabel} findings`, to: buildScopedPath(scope, `${config.routePrefix}/findings`) }]}
+      secondaryActions={route.id === 'findings' ? [] : [{ label: `${config.navLabel} findings`, to: findingsPath }]}
       aside={
         <DomainDetailPanel title="Route contract" eyebrow={config.navLabel}>
           <dl className="idt-domain-route-facts">
@@ -2199,7 +2366,9 @@ type ConnectorConnectPageProps = {
 
 function ProductConnectorConnectPage({ provider, providerLabel }: ConnectorConnectPageProps) {
   const params = useParams<ScopeRouteParams>();
+  const location = useLocation();
   const scope = resolveScopeFromParams(params);
+  const requestedEnvironmentID = useMemo(() => environmentIDFromSearch(location.search), [location.search]);
   const shouldLoadBackendFeatures =
     provider === 'github' ? FEATURE_CONNECTOR_GITHUB_V2 : provider === 'kubernetes' ? FEATURE_CONNECTOR_K8S : false;
   const { features: backendFeatures, loading: backendFeaturesLoading } = useBackendFeatures({
@@ -2236,7 +2405,7 @@ function ProductConnectorConnectPage({ provider, providerLabel }: ConnectorConne
         const response = await apiClient.listProjects(
           scope.workspaceID,
           {
-            limit: 1,
+            limit: ENVIRONMENT_SELECTOR_LIMIT,
             sort_by: 'updated_at',
             sort_order: 'desc',
             include_archived: false
@@ -2246,7 +2415,8 @@ function ProductConnectorConnectPage({ provider, providerLabel }: ConnectorConne
         if (!active) {
           return;
         }
-        const projectID = normalizeValue(response.items[0]?.project_id ?? '');
+        const requestedProject = response.items.find((item) => item.project_id === requestedEnvironmentID);
+        const projectID = normalizeValue((requestedProject ?? response.items[0])?.project_id ?? '');
         setTargetPath(
           projectID
             ? appendSourceQuery(buildProjectPath(scope, projectID), provider)
@@ -2272,6 +2442,7 @@ function ProductConnectorConnectPage({ provider, providerLabel }: ConnectorConne
     providerAvailability.unavailableMessage,
     providerAvailability.visible,
     providerLabel,
+    requestedEnvironmentID,
     scope?.tenantID,
     scope?.workspaceID
   ]);
@@ -4636,11 +4807,7 @@ export function ProductProjectsPage() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [draftName, setDraftName] = useState('');
-  const [draftProjectID, setDraftProjectID] = useState('');
-  const [draftSlug, setDraftSlug] = useState('');
   const [draftDescription, setDraftDescription] = useState('');
-  const [projectIDEdited, setProjectIDEdited] = useState(false);
-  const [slugEdited, setSlugEdited] = useState(false);
 
   useEffect(() => {
     if (!scope) {
@@ -4675,7 +4842,7 @@ export function ProductProjectsPage() {
         if (!active) {
           return;
         }
-        setError(loadError instanceof Error ? loadError.message : 'Unable to load workspace projects.');
+        setError(loadError instanceof Error ? loadError.message : 'Unable to load workspace environments.');
       } finally {
         if (active) {
           setLoading(false);
@@ -4703,41 +4870,26 @@ export function ProductProjectsPage() {
   if (loading) {
     return (
       <AppRouteLoadingState
-        title="Preparing project registry"
-        body="Keeping the workspace shell ready while project boundaries refresh."
+        title="Preparing environments"
+        body="Keeping workspace scope ready while environment boundaries refresh."
       />
     );
   }
-
-  const handleNameChange = (value: string) => {
-    setDraftName(value);
-    const token = deriveProjectToken(value);
-    if (!projectIDEdited) {
-      setDraftProjectID(token);
-    }
-    if (!slugEdited) {
-      setDraftSlug(token);
-    }
-  };
 
   const handleCreateProject = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     const name = normalizeValue(draftName);
-    const projectID = normalizeValue(draftProjectID) || deriveProjectToken(name);
-    const slug = normalizeValue(draftSlug) || deriveProjectToken(name);
+    const projectID = deriveProjectToken(name, 'default-environment');
+    const slug = projectID;
     const description = normalizeValue(draftDescription);
 
     if (!name) {
-      setError('Project name is required.');
+      setError('Environment name is required.');
       return;
     }
     if (!projectID) {
-      setError('Project ID is required.');
-      return;
-    }
-    if (!slug) {
-      setError('Project slug is required.');
+      setError('Enter a readable environment name.');
       return;
     }
 
@@ -4761,14 +4913,10 @@ export function ProductProjectsPage() {
         return [response.project, ...remaining];
       });
       setDraftName('');
-      setDraftProjectID('');
-      setDraftSlug('');
       setDraftDescription('');
-      setProjectIDEdited(false);
-      setSlugEdited(false);
       navigate(appendSourceQuery(buildProjectPath(scope, response.project.project_id), requestedSource));
     } catch (saveError) {
-      setError(saveError instanceof Error ? saveError.message : 'Unable to save project.');
+      setError(saveError instanceof Error ? saveError.message : 'Unable to save environment.');
     } finally {
       setSaving(false);
     }
@@ -4778,9 +4926,9 @@ export function ProductProjectsPage() {
     <section className="idt-app-panel idt-projects-page">
       <div className="idt-projects-header">
         <div>
-          <p className="idt-app-kicker">Workspace registry</p>
-          <h2>Projects</h2>
-          <p>Create project boundaries for repository, workflow, and cloud identity signals.</p>
+          <p className="idt-app-kicker">Workspace scope</p>
+          <h2>Environments</h2>
+          <p>Choose the operating boundary for repository, workflow, cloud, and cluster identity signals.</p>
         </div>
         <div className="idt-inline-actions">
           <Link className="idt-btn idt-btn-ghost" to={buildScopedPath(scope)}>
@@ -4794,13 +4942,13 @@ export function ProductProjectsPage() {
           <div className="idt-overview-metric-top">
             <span>{projects.length}</span>
           </div>
-          <p>Total projects</p>
+          <p>Total environments</p>
         </article>
         <article>
           <div className="idt-overview-metric-top">
             <span>{activeProjectCount}</span>
           </div>
-          <p>Active projects</p>
+          <p>Active environments</p>
         </article>
         <article>
           <div className="idt-overview-metric-top">
@@ -4816,19 +4964,19 @@ export function ProductProjectsPage() {
         <article className="idt-projects-list">
           <div className="idt-projects-section-header">
             <div>
-              <h3>Project registry</h3>
+              <h3>Environment list</h3>
               <p>
                 {archivedProjectCount > 0
                   ? `${activeProjectCount} active, ${archivedProjectCount} archived.`
-                  : 'Open a project to manage source connections and scans.'}
+                  : 'Open an environment to manage source connections and scans.'}
               </p>
             </div>
           </div>
 
           {projects.length === 0 ? (
             <AppShellEmptyState
-              title="No projects yet"
-              body="Create the first project boundary for this workspace."
+              title="No environments yet"
+              body="Create the first workspace boundary for this source."
             />
           ) : (
             <div className="idt-project-card-list">
@@ -4841,7 +4989,7 @@ export function ProductProjectsPage() {
                         <div className="idt-project-card-title">
                           <h4>{project.name}</h4>
                         </div>
-                        <p>{project.description || 'Scope source connections, scans, and findings for this boundary.'}</p>
+                        <p>{project.description || 'Scope source connections, scans, and findings for this environment.'}</p>
                       </div>
                       <span
                         className={`idt-source-status-pill ${archived ? 'is-warning' : 'is-success'}`}
@@ -4851,10 +4999,10 @@ export function ProductProjectsPage() {
                     </div>
 
                     <details className="idt-project-card-details">
-                      <summary>Project details</summary>
+                      <summary>Environment details</summary>
                       <dl className="idt-project-card-meta">
                         <div>
-                          <dt>Project ID</dt>
+                          <dt>Internal key</dt>
                           <dd>{project.project_id}</dd>
                         </div>
                         <div>
@@ -4873,7 +5021,7 @@ export function ProductProjectsPage() {
                         className="idt-btn idt-btn-primary"
                         to={appendSourceQuery(buildProjectPath(scope, project.project_id), requestedSource)}
                       >
-                        Open project
+                        Open environment
                       </Link>
                     </div>
                   </article>
@@ -4886,47 +5034,21 @@ export function ProductProjectsPage() {
         <article className="idt-project-composer">
           <div className="idt-projects-section-header">
             <div>
-              <h3>New project</h3>
-              <p>Project ID and slug auto-fill from the name and can be adjusted before creation.</p>
+              <h3>New environment</h3>
+              <p>Name the boundary once. Identrail keeps the internal key behind the scenes.</p>
             </div>
           </div>
 
           <form className="idt-app-form" onSubmit={handleCreateProject}>
             <label>
-              Project name
+              Environment name
               <input
                 value={draftName}
-                onChange={(event) => handleNameChange(event.target.value)}
+                onChange={(event) => setDraftName(event.target.value)}
                 placeholder="Production platform"
                 required
               />
             </label>
-            <div className="idt-project-inline-fields">
-              <label>
-                Project ID
-                <input
-                  value={draftProjectID}
-                  onChange={(event) => {
-                    setProjectIDEdited(true);
-                    setDraftProjectID(normalizeProjectToken(event.target.value));
-                  }}
-                  placeholder="production-platform"
-                  required
-                />
-              </label>
-              <label>
-                Slug
-                <input
-                  value={draftSlug}
-                  onChange={(event) => {
-                    setSlugEdited(true);
-                    setDraftSlug(normalizeProjectToken(event.target.value));
-                  }}
-                  placeholder="production-platform"
-                  required
-                />
-              </label>
-            </div>
             <label>
               Description
               <textarea
@@ -4936,7 +5058,7 @@ export function ProductProjectsPage() {
               />
             </label>
             <button className="idt-btn idt-btn-primary" type="submit" disabled={saving}>
-              {saving ? 'Creating project...' : 'Create project'}
+              {saving ? 'Creating environment...' : 'Create environment'}
             </button>
           </form>
         </article>
@@ -5427,14 +5549,14 @@ export function ProductProjectDetailPage() {
   }, [githubHasActiveRepoScan, scope?.tenantID, scope?.workspaceID]);
 
   if (!scope || !projectID) {
-    return <AppShellLoading message="Resolving project scope" />;
+    return <AppShellLoading message="Resolving environment scope" />;
   }
 
   if (loading) {
     return (
       <AppRouteLoadingState
         title="Preparing source connections"
-        body="Keeping the project workspace visible while connector status refreshes."
+        body="Keeping the environment visible while connector status refreshes."
       />
     );
   }
@@ -5444,7 +5566,7 @@ export function ProductProjectDetailPage() {
   const selectedAvailability = sourceAvailability[selectedSource] ?? { visible: true, available: true };
   const selectedUnavailable = !selectedAvailability.available;
   const sourceScopeProfile = sourceScope ? SOURCE_PROFILES[sourceScope] : null;
-  const sourcePageTitle = sourceScopeProfile ? `Connect ${sourceScopeProfile.name}` : 'Connect project sources';
+  const sourcePageTitle = sourceScopeProfile ? `Connect ${sourceScopeProfile.name}` : 'Connect environment sources';
   const sourcePageBody =
     sourceScopeProfile?.summary ?? 'Install source connections to collect repository, workflow, and cloud identity signals.';
 
@@ -5953,10 +6075,10 @@ export function ProductProjectDetailPage() {
           </div>
         ) : (
           <div>
-            <p className="idt-app-kicker">Project sources</p>
+            <p className="idt-app-kicker">Environment sources</p>
             <h2>{sourcePageTitle}</h2>
             <p>
-              {sourcePageBody} Project <strong>{projectID}</strong>.
+              {sourcePageBody} Environment <strong>{environmentFallbackLabel(projectID)}</strong>.
             </p>
           </div>
         )}

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -298,7 +298,7 @@ function productDomainRoute(
     eyebrow,
     description,
     phase: options.phase ?? 'Route foundation',
-    status: options.status ?? 'Shell ready',
+    status: options.status ?? 'Route live',
     metrics:
       options.metrics ?? [
         { label: 'Route', value: 'Live', detail: 'Scoped workspace entry point is registered.', tone: 'success' },
@@ -927,8 +927,37 @@ function normalizeProjectToken(value: string): string {
     .slice(0, 64);
 }
 
-function deriveProjectToken(value: string, fallback = 'project'): string {
-  return normalizeProjectToken(value) || fallback;
+function tokenWithNumericSuffix(base: string, suffix: number): string {
+  const suffixToken = `-${suffix}`;
+  return `${base.slice(0, Math.max(1, 64 - suffixToken.length))}${suffixToken}`;
+}
+
+function stableEnvironmentTokenHash(value: string): string {
+  let hash = 2166136261;
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    hash ^= codePoint;
+    hash = Math.imul(hash, 16777619) >>> 0;
+  }
+  return hash.toString(36);
+}
+
+function uniqueEnvironmentToken(name: string, existingProjects: ProjectRecord[]): string {
+  const existingIDs = new Set(existingProjects.map((project) => normalizeValue(project.project_id)).filter(Boolean));
+  const base = normalizeProjectToken(name) || `environment-${stableEnvironmentTokenHash(name)}`;
+
+  if (base && !existingIDs.has(base)) {
+    return base;
+  }
+
+  for (let suffix = 2; suffix < 1000; suffix += 1) {
+    const candidate = tokenWithNumericSuffix(base, suffix);
+    if (!existingIDs.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  return tokenWithNumericSuffix(base, Date.now());
 }
 
 function formatTokenLabel(value: string): string {
@@ -2402,6 +2431,11 @@ function ProductConnectorConnectPage({ provider, providerLabel }: ConnectorConne
 
     const resolveConnectorSetup = async () => {
       try {
+        const requestedProjectID = normalizeValue(requestedEnvironmentID);
+        if (requestedProjectID) {
+          setTargetPath(appendSourceQuery(buildProjectPath(scope, requestedProjectID), provider));
+          return;
+        }
         const response = await apiClient.listProjects(
           scope.workspaceID,
           {
@@ -2415,8 +2449,7 @@ function ProductConnectorConnectPage({ provider, providerLabel }: ConnectorConne
         if (!active) {
           return;
         }
-        const requestedProject = response.items.find((item) => item.project_id === requestedEnvironmentID);
-        const projectID = normalizeValue((requestedProject ?? response.items[0])?.project_id ?? '');
+        const projectID = normalizeValue(response.items[0]?.project_id ?? '');
         setTargetPath(
           projectID
             ? appendSourceQuery(buildProjectPath(scope, projectID), provider)
@@ -2520,7 +2553,7 @@ export function ProductReportsPage() {
           <p>Designed for executive posture and remediation outcome summaries.</p>
         </article>
       </div>
-      <DomainStatusPanel eyebrow="Reporting foundation" title="Outcome views are staged" status="Shell ready" tone="success">
+      <DomainStatusPanel eyebrow="Reporting foundation" title="Outcome views are staged" status="Staged" tone="success">
         <p>
           This route keeps the IA complete while the deeper executive outcome, domain coverage, and remediation reporting
           experiences arrive in their planned sequence.
@@ -4491,7 +4524,7 @@ export function ProductWorkspacesPage() {
     return (
       <AppRouteLoadingState
         title="Preparing workspace access"
-        body="Keeping the workspace shell ready while member access details refresh."
+        body="Refreshing member access details for this workspace."
       />
     );
   }
@@ -4880,7 +4913,7 @@ export function ProductProjectsPage() {
     event.preventDefault();
 
     const name = normalizeValue(draftName);
-    const projectID = deriveProjectToken(name, 'default-environment');
+    const projectID = uniqueEnvironmentToken(name, projects);
     const slug = projectID;
     const description = normalizeValue(draftDescription);
 
@@ -8356,7 +8389,7 @@ export function ProductFindingsPage() {
     return (
       <AppRouteLoadingState
         title="Preparing GitHub findings"
-        body="Keeping the workspace shell ready while finding and trend data refresh."
+        body="Refreshing finding and trend data for this workspace."
       />
     );
   }

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -989,6 +989,10 @@ function isProjectArchived(project: ProjectRecord): boolean {
   return Boolean(normalizeValue(project.archived_at ?? ''));
 }
 
+function isTransientProjectLookupError(error: unknown): boolean {
+  return !(error instanceof ApiError) || error.status !== 404;
+}
+
 function environmentFallbackLabel(projectID: string | undefined): string {
   const normalized = normalizeValue(projectID ?? '');
   if (!normalized || /^project(?:[-_]\d+)?$/i.test(normalized) || /^legacy[-_]project$/i.test(normalized)) {
@@ -2230,11 +2234,15 @@ function useEnvironmentScope(scope: ProductSession | null, requestedEnvironmentI
             } else {
               nextItems = [requestedResponse.project, ...nextItems];
             }
-          } catch {
+          } catch (requestError) {
             if (!active) {
               return;
             }
-            rejectedID = requestedID;
+            if (isTransientProjectLookupError(requestError)) {
+              setError(formatAPIError(requestError, `Unable to verify selected environment ${requestedID}.`));
+            } else {
+              rejectedID = requestedID;
+            }
           }
         }
         setRejectedRequestedID(rejectedID);
@@ -2480,8 +2488,12 @@ function ProductConnectorConnectPage({ provider, providerLabel }: ConnectorConne
               setTargetPath(appendSourceQuery(buildProjectPath(scope, requestedProjectID), provider));
               return;
             }
-          } catch {
+          } catch (requestError) {
             if (!active) {
+              return;
+            }
+            if (isTransientProjectLookupError(requestError)) {
+              setError(formatAPIError(requestError, `Unable to resolve ${providerLabel} connector setup.`));
               return;
             }
           }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -22220,6 +22220,59 @@ html[data-theme='light'] .idt-app-shell-screen select {
   font-weight: 800;
 }
 
+.idt-environment-selector {
+  position: relative;
+  display: grid;
+  gap: 0.28rem;
+  min-width: min(16rem, 100%);
+}
+
+.idt-environment-selector span {
+  color: var(--app-muted);
+  font-size: 0.68rem;
+  font-weight: 800;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.idt-environment-selector select {
+  width: 100%;
+  min-height: 1.9rem;
+  border: 0;
+  border-radius: 6px;
+  padding: 0 1.9rem 0 0;
+  appearance: none;
+  background:
+    linear-gradient(45deg, transparent 50%, rgba(255, 255, 255, 0.74) 50%) calc(100% - 0.8rem) 50% / 0.36rem 0.36rem no-repeat,
+    linear-gradient(135deg, rgba(255, 255, 255, 0.74) 50%, transparent 50%) calc(100% - 0.58rem) 50% / 0.36rem 0.36rem no-repeat,
+    transparent;
+  color: #ffffff;
+  font: inherit;
+  font-size: 0.88rem;
+  font-weight: 850;
+  outline: none;
+}
+
+.idt-environment-selector select:focus-visible {
+  box-shadow: 0 0 0 2px rgba(124, 97, 255, 0.52);
+}
+
+.idt-environment-selector select:disabled {
+  color: rgba(255, 255, 255, 0.72);
+  cursor: default;
+}
+
+.idt-environment-selector option {
+  color: #0f1117;
+  background: #ffffff;
+}
+
+.idt-environment-selector small {
+  color: var(--app-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
 .idt-domain-status-summary.is-success {
   border-color: rgba(88, 214, 141, 0.5);
   color: #acf2c4;


### PR DESCRIPTION
Fixes #1380

## What changed
- Added a quiet Environment selector to AWS, GitHub, and Kubernetes domain route shells.
- Preserved the existing `project_id` backend contract while routing domain Connect/Finding actions with the selected environment in query state.
- Reworded the hidden source boundary setup surfaces from user-facing Projects language to Environment language.
- Removed visible technical project ID/slug inputs from the first-environment setup flow; the app now derives the internal key behind the scenes.
- Added coverage for Environment selector rendering, environment query updates, source routing, and existing `project_id` payload preservation.

## Why
The redesigned app is domain-first. Users should operate AWS, GitHub, and Kubernetes sections directly, while the current project model stays as internal scope plumbing until the backend is ready for a deeper rename.

## Impact and risk
- UI impact: domain shells now show the active Environment without introducing a new top-level Projects area.
- Compatibility: existing AWS/GitHub/Kubernetes connector and scan calls still pass `project_id` where current APIs require it.
- Risk is low and isolated to the web shell, route copy, and tests; no database or public API contract rename is included.

## Screenshots
- AWS domain shell with Environment selector: captured in local visual QA at `tmp/issue-1380-aws-environment-selector.png`.

## Validation
- `npm test --prefix web -- --run src/productShell.test.tsx src/App.test.tsx` - 107 tests passed.
- `npm run test:ci --prefix web` - 226 tests passed.
- `npm run build --prefix web` - build succeeded and prerendered 39 routes.
- Local visual QA with a mock API confirmed the AWS Environment selector renders selected environments, updates the URL, preserves Connect/Finding links, and logs no browser console errors.

## AI-assisted disclosure
- AI-assisted: yes
- Tools used: Codex
- Where used: `web/src/productShell.tsx`, `web/src/styles.css`, `web/src/productShell.test.tsx`, `web/src/App.test.tsx`
- Human verification performed: reviewed the diff, ran focused web tests, full web CI tests, production build/prerender, and local browser visual QA.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Environment scope selector to AWS, GitHub, and Kubernetes shells, synced with the `?environment=` query, so users work by Environment while backend calls still use `project_id`. Improves routing and resilience for Connect/Findings with the selected Environment per 1380.

- New Features
  - Selector reads/writes `?environment=`, loads off-page selections via `getProject`, rejects archived ones, preserves pagination, and updates the URL; Connect and Findings links carry `?environment=`.
  - Connect routes directly to the provided Environment when valid; otherwise defaults to a recent active one.
  - Projects → Environments throughout the UI; new Environment form is name + optional description only. Internal keys auto-generated, unique across the workspace (numeric suffixes), and stable for non-ASCII names.
  - Route status copy set to “Route live,” Reports to “Staged,” and loading messages simplified.

- Bug Fixes
  - On transient `getProject` failures, keep the requested Environment selected with clearer errors, and do not auto-route Connect to a fallback Environment.

<sup>Written for commit 1ee1b2ccefe3a9b878b9ef38c34282f289637126. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1432?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

