### PR TITLE
Make Deploy to prod one click

### DIFF
--- a/.github/workflows/aws-api-manual-deploy.yml
+++ b/.github/workflows/aws-api-manual-deploy.yml
@@ -19,6 +19,11 @@ on:
         description: "Immutable API image, for example ghcr.io/identrail/identrail-api:sha-<commit>."
         required: true
         type: string
+      worker_container_image:
+        description: "Immutable worker image, for example ghcr.io/identrail/identrail-worker:sha-<commit>."
+        required: false
+        type: string
+        default: ""
       api_vpc_id:
         description: "VPC ID. Leave blank to use repository variable API_VPC_ID."
         required: false
@@ -64,6 +69,11 @@ on:
         description: "Immutable API image, for example ghcr.io/identrail/identrail-api:sha-<commit>."
         required: true
         type: string
+      worker_container_image:
+        description: "Immutable worker image, for example ghcr.io/identrail/identrail-worker:sha-<commit>."
+        required: false
+        type: string
+        default: ""
       api_vpc_id:
         description: "VPC ID. Leave blank to use repository variable API_VPC_ID."
         required: false
@@ -127,7 +137,7 @@ jobs:
       API_CERTIFICATE_ARN: ${{ inputs.api_certificate_arn || vars.API_CERTIFICATE_ARN }}
       API_CONTAINER_IMAGE: ${{ inputs.api_container_image }}
       API_WORKER_ENABLED: ${{ vars.API_WORKER_ENABLED || 'true' }}
-      API_WORKER_CONTAINER_IMAGE: ${{ vars.API_WORKER_CONTAINER_IMAGE || '' }}
+      API_WORKER_CONTAINER_IMAGE: ${{ inputs.worker_container_image || vars.API_WORKER_CONTAINER_IMAGE || '' }}
       API_WORKER_DESIRED_COUNT: ${{ vars.API_WORKER_DESIRED_COUNT || '1' }}
       API_WORKER_TASK_CPU: ${{ vars.API_WORKER_TASK_CPU || '256' }}
       API_WORKER_TASK_MEMORY: ${{ vars.API_WORKER_TASK_MEMORY || '512' }}

--- a/.github/workflows/aws-production-release.yml
+++ b/.github/workflows/aws-production-release.yml
@@ -1,70 +1,30 @@
-name: AWS Production Release
+name: Deploy to prod
 
 on:
   workflow_dispatch:
-    inputs:
-      confirm_release:
-        description: "Required: type release-api.identrail.com"
-        required: true
-        type: string
-      api_container_image:
-        description: "Current-commit API image, for example ghcr.io/identrail/identrail-api:sha-<current-dev-commit>."
-        required: true
-        type: string
-      api_base_url:
-        description: "Public API base URL for post-deploy smoke checks."
-        required: true
-        type: string
-        default: https://api.identrail.com
-      database_url_secret_arn:
-        description: "Optional Secrets Manager ARN. Blank uses repository secret API_DATABASE_URL_SECRET_ARN."
-        required: false
-        type: string
-      migrations_dir:
-        description: "Migration directory to apply before deploying the API and worker."
-        required: true
-        type: string
-        default: migrations
-      api_vpc_id:
-        description: "VPC ID. Leave blank to use repository variable API_VPC_ID."
-        required: false
-        type: string
-      api_public_subnet_ids_json:
-        description: "JSON array of two public subnet IDs. Leave blank to use repository variable API_PUBLIC_SUBNET_IDS_JSON."
-        required: false
-        type: string
-      api_task_subnet_ids_json:
-        description: "Optional JSON array of task subnet IDs. Blank uses the public subnets for low-cost bootstrap mode."
-        required: false
-        type: string
-      api_certificate_arn:
-        description: "ACM certificate ARN. Leave blank to use repository variable API_CERTIFICATE_ARN."
-        required: false
-        type: string
-      terraform_state_bucket:
-        description: "S3 bucket for Terraform state. Leave blank to use repository variable AWS_TERRAFORM_STATE_BUCKET."
-        required: false
-        type: string
 
 permissions:
   contents: read
+  actions: read
+  packages: read
 
 concurrency:
-  group: aws-production-release
+  group: deploy-to-prod
   cancel-in-progress: false
 
 jobs:
-  validate:
-    name: Validate release inputs
+  resolve:
+    name: Resolve production release
     if: github.repository == 'identrail/identrail'
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    env:
-      CONFIRM_RELEASE: ${{ inputs.confirm_release }}
-      API_CONTAINER_IMAGE: ${{ inputs.api_container_image }}
-      API_BASE_URL: ${{ inputs.api_base_url }}
+    outputs:
+      api_container_image: ${{ steps.release.outputs.api_container_image }}
+      api_base_url: ${{ steps.release.outputs.api_base_url }}
+      migrations_dir: ${{ steps.release.outputs.migrations_dir }}
     steps:
-      - name: Validate release request
+      - name: Resolve release metadata
+        id: release
         shell: bash
         run: |
           set -euo pipefail
@@ -74,53 +34,117 @@ jobs:
             exit 1
           fi
 
-          if [ "${CONFIRM_RELEASE}" != "release-api.identrail.com" ]; then
-            echo "To release the hosted API, type release-api.identrail.com in the confirmation field."
-            exit 1
-          fi
+          short_sha="${GITHUB_SHA::12}"
+          api_container_image="ghcr.io/identrail/identrail-api:sha-${short_sha}"
+          worker_container_image="ghcr.io/identrail/identrail-worker:sha-${short_sha}"
+          api_base_url="https://api.identrail.com"
+          migrations_dir="migrations"
 
-          if ! [[ "${API_CONTAINER_IMAGE}" =~ ^ghcr\.io/identrail/identrail-api:sha-([0-9a-f]{12,40})$ ]]; then
-            echo "api_container_image must be a current-commit ghcr.io/identrail/identrail-api:sha-<commit> image so migrations and deployed code come from the same source."
-            exit 1
-          fi
-
-          image_sha="${BASH_REMATCH[1]}"
-          if [[ "${GITHUB_SHA}" != "${image_sha}"* ]]; then
-            echo "api_container_image sha tag must match this workflow commit (${GITHUB_SHA}) so migrations and deployed code stay in lockstep."
-            exit 1
-          fi
-
-          api_base_url="${API_BASE_URL%/}"
           if ! [[ "${api_base_url}" =~ ^https://[^/[:space:]]+(:[0-9]+)?$ ]]; then
             echo "api_base_url must be a bare HTTPS origin such as https://api.identrail.com."
             exit 1
           fi
 
           {
-            echo "## AWS production release"
+            echo "api_container_image=${api_container_image}"
+            echo "worker_container_image=${worker_container_image}"
+            echo "api_base_url=${api_base_url}"
+            echo "migrations_dir=${migrations_dir}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Verify release gates passed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          runs_json="$(
+            curl -fsSL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/runs?branch=dev&head_sha=${GITHUB_SHA}&status=success&per_page=100"
+          )"
+
+          required_workflows=("CI" "Publish Container Images")
+          for workflow in "${required_workflows[@]}"; do
+            if ! jq -e --arg workflow "${workflow}" '.workflow_runs[] | select(.name == $workflow and .conclusion == "success")' >/dev/null <<< "${runs_json}"; then
+              echo "Required workflow ${workflow} has not completed successfully for ${GITHUB_SHA}."
+              echo "Wait for dev checks and image publishing to finish, then run Deploy to prod again."
+              exit 1
+            fi
+          done
+
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Verify release images exist
+        env:
+          API_CONTAINER_IMAGE: ${{ steps.release.outputs.api_container_image }}
+          WORKER_CONTAINER_IMAGE: ${{ steps.release.outputs.worker_container_image }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          docker manifest inspect "${API_CONTAINER_IMAGE}" >/dev/null
+          docker manifest inspect "${WORKER_CONTAINER_IMAGE}" >/dev/null
+
+      - name: Publish release summary
+        env:
+          API_CONTAINER_IMAGE: ${{ steps.release.outputs.api_container_image }}
+          WORKER_CONTAINER_IMAGE: ${{ steps.release.outputs.worker_container_image }}
+          API_BASE_URL: ${{ steps.release.outputs.api_base_url }}
+          MIGRATIONS_DIR: ${{ steps.release.outputs.migrations_dir }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          {
+            echo "## Deploy to prod"
             echo
             echo "- API image: \`${API_CONTAINER_IMAGE}\`"
+            echo "- Worker image: \`${WORKER_CONTAINER_IMAGE}\`"
             echo "- Source commit: \`${GITHUB_SHA}\`"
-            echo "- API base URL: \`${api_base_url}\`"
+            echo "- API base URL: \`${API_BASE_URL}\`"
+            echo "- Migrations directory: \`${MIGRATIONS_DIR}\`"
+            echo "- Verified gates: \`CI\`, \`Publish Container Images\`"
             echo "- Next step: run database migrations before deploying API and worker."
           } >> "${GITHUB_STEP_SUMMARY}"
 
+  approve:
+    name: Approve production deploy
+    needs: resolve
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Record production approval
+        run: echo "Production deployment approved for ${{ github.sha }}."
+
   migrate:
     name: Run database migrations
-    needs: validate
+    needs:
+      - resolve
+      - approve
     permissions:
       contents: read
       id-token: write
     uses: ./.github/workflows/aws-api-database-migrations.yml
     with:
       confirm_migrations: run-api-migrations
-      database_url_secret_arn: ${{ inputs.database_url_secret_arn || '' }}
-      migrations_dir: ${{ inputs.migrations_dir }}
+      database_url_secret_arn: ''
+      migrations_dir: ${{ needs.resolve.outputs.migrations_dir }}
     secrets: inherit
 
   deploy:
     name: Deploy API and worker
-    needs: migrate
+    needs:
+      - resolve
+      - migrate
     permissions:
       contents: read
       id-token: write
@@ -128,23 +152,25 @@ jobs:
     with:
       operation: apply
       confirm_apply: apply-api.identrail.com
-      api_container_image: ${{ inputs.api_container_image }}
-      api_vpc_id: ${{ inputs.api_vpc_id }}
-      api_public_subnet_ids_json: ${{ inputs.api_public_subnet_ids_json }}
-      api_task_subnet_ids_json: ${{ inputs.api_task_subnet_ids_json }}
-      api_certificate_arn: ${{ inputs.api_certificate_arn }}
-      database_url_secret_arn: ${{ inputs.database_url_secret_arn || '' }}
-      terraform_state_bucket: ${{ inputs.terraform_state_bucket || '' }}
+      api_container_image: ${{ needs.resolve.outputs.api_container_image }}
+      api_vpc_id: ''
+      api_public_subnet_ids_json: ''
+      api_task_subnet_ids_json: ''
+      api_certificate_arn: ''
+      database_url_secret_arn: ''
+      terraform_state_bucket: ''
       terraform_state_key: ${{ vars.AWS_TERRAFORM_STATE_KEY || '' }}
     secrets: inherit
 
   smoke:
     name: Verify hosted API
-    needs: deploy
+    needs:
+      - resolve
+      - deploy
     runs-on: ubuntu-latest
     timeout-minutes: 8
     env:
-      API_BASE_URL: ${{ inputs.api_base_url }}
+      API_BASE_URL: ${{ needs.resolve.outputs.api_base_url }}
     steps:
       - name: Run API smoke checks
         shell: bash

--- a/.github/workflows/aws-production-release.yml
+++ b/.github/workflows/aws-production-release.yml
@@ -20,6 +20,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       api_container_image: ${{ steps.release.outputs.api_container_image }}
+      worker_container_image: ${{ steps.release.outputs.worker_container_image }}
       api_base_url: ${{ steps.release.outputs.api_base_url }}
       migrations_dir: ${{ steps.release.outputs.migrations_dir }}
     steps:
@@ -153,6 +154,7 @@ jobs:
       operation: apply
       confirm_apply: apply-api.identrail.com
       api_container_image: ${{ needs.resolve.outputs.api_container_image }}
+      worker_container_image: ${{ needs.resolve.outputs.worker_container_image }}
       api_vpc_id: ''
       api_public_subnet_ids_json: ''
       api_task_subnet_ids_json: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ## Unreleased
+- Renamed the hosted API production release workflow to `Deploy to prod` and
+  made the normal release path one-click from the `dev` branch. The workflow now
+  resolves the current commit's immutable API and worker image tags, verifies CI
+  and image publishing succeeded for that exact commit, confirms the GHCR image
+  tags exist, records a `production` environment gate, and then runs migrations,
+  deploys the API and worker, and smokes the hosted API without requiring
+  operators to type confirmation text or paste image tags.
 - Added self-serve account-lifecycle endpoints. `POST /v1/me/deactivate`
   transitions the authenticated user from `active` to `deactivated`, revokes
   every active session, and clears the session cookie. `POST /v1/me/reactivate`

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -98,13 +98,18 @@ Run it from the `dev` branch because the AWS OIDC deployment role trust is
 intentionally scoped to that branch.
 
 For routine hosted API releases after an immutable image for the current `dev`
-commit has been published, prefer the `AWS Production Release` workflow. It is
-still manually approved, but it runs the database migration workflow first,
-deploys the API and worker with the matching
-`ghcr.io/identrail/identrail-api:sha-<current-dev-commit>` image, and then
-checks `/healthz`, `/readyz`, and `/v1/auth/config`. This keeps hosted API
-code, worker code, and the database schema in the same release boundary instead
-of requiring operators to remember the migration and deploy order by hand.
+commit has been published, use the `Deploy to prod` workflow. Operators only
+select the `dev` branch and click **Run workflow**. The workflow resolves the
+matching `ghcr.io/identrail/identrail-api:sha-<current-dev-commit>` and
+`ghcr.io/identrail/identrail-worker:sha-<current-dev-commit>` images, verifies
+that `CI` and `Publish Container Images` passed for that exact commit, confirms
+both immutable image tags exist in GHCR, waits for the `production` GitHub
+Environment approval when environment protection is configured, runs the
+database migration workflow, deploys the API and worker, and then checks
+`/healthz`, `/readyz`, and `/v1/auth/config`. This keeps hosted API code,
+worker code, and the database schema in the same release boundary instead of
+requiring operators to remember image tags or the migration and deploy order by
+hand.
 
 Repository configuration required before the workflow can plan:
 
@@ -163,9 +168,11 @@ when GitHub App settings change:
 python3 scripts/check_github_app_manifest.py --slug "${API_GITHUB_APP_NAME}"
 ```
 
-The workflow dispatch input `api_container_image` must be immutable, such as
-`ghcr.io/identrail/identrail-api:sha-<commit>`. Do not deploy the mutable `dev`
-tag to this hosted API path.
+The `Deploy to prod` workflow always deploys an immutable current-commit image,
+such as `ghcr.io/identrail/identrail-api:sha-<commit>`. Do not deploy the
+mutable `dev` tag to this hosted API path. Use `AWS API Manual Deploy` only for
+lower-level planning, explicit rollback, or emergency overrides that require a
+specific immutable image.
 
 Worker hosting is enabled by default in this manual workflow through
 `API_WORKER_ENABLED=true`. If `API_WORKER_CONTAINER_IMAGE` is omitted, the

--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -92,11 +92,12 @@ Portable deployment profiles:
 ## 2) Deploy Sequence
 
 1. Ensure CI is green on `dev` (`Go Quality`, `Go Tests`, `Go Integration (Postgres)`, `Web Build`).
-2. For hosted AWS API releases, prefer the `AWS Production Release` workflow
-   after the immutable image for the current `dev` commit is published. It runs
-   migrations, deploys the API and worker with the matching
-   `sha-<current-dev-commit>` image, and performs hosted API smoke checks in one
-   ordered manual release.
+2. For hosted AWS API releases, use the `Deploy to prod` workflow after the
+   immutable image for the current `dev` commit is published. Operators only
+   select the `dev` branch and click **Run workflow**. The workflow resolves the
+   matching `sha-<current-dev-commit>` API and worker images, verifies CI and
+   image publishing passed for that exact commit, runs migrations, deploys the
+   API and worker, and performs hosted API smoke checks in one ordered release.
 3. For non-AWS or lower-level deployments, run migrations once using the
    dedicated migration job:
    - Kubernetes manifests: apply `deploy/kubernetes/migration-job.yaml` and wait for job completion.

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -29,6 +29,14 @@ function errorJSON(status: number, error: string) {
   };
 }
 
+function getLinkByPath(path: string) {
+  const link = screen.getAllByRole('link').find((item) => item.getAttribute('href') === path);
+  if (!link) {
+    throw new Error(`Expected link with href "${path}"`);
+  }
+  return link;
+}
+
 function authConfig(manualMode = false, workOSLoginEnabled = true) {
   return okJSON({
     auth: {
@@ -814,7 +822,7 @@ describe('App', () => {
     const meCallsBeforeNavigation = fetchMock.mock.calls.filter(([url]) => typeof url === 'string' && url.endsWith('/v1/me')).length;
 
     fireEvent.click(screen.getByRole('button', { name: 'AWS' }));
-    fireEvent.click(await screen.findByRole('link', { name: /AWS Control center/i }));
+    fireEvent.click(await waitFor(() => getLinkByPath('/app/tenant-a/workspace-a/aws')));
 
     expect(screen.queryByText(/Validating session/i)).not.toBeInTheDocument();
     expect(screen.getByRole('navigation', { name: /App sections/i })).toBeInTheDocument();
@@ -915,7 +923,7 @@ describe('App', () => {
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'AWS' }));
-    fireEvent.click(await screen.findByRole('link', { name: /AWS Control center/i }));
+    fireEvent.click(await waitFor(() => getLinkByPath('/app/tenant-a/workspace-a/aws')));
 
     expect(screen.queryByText(/Validating session/i)).not.toBeInTheDocument();
     expect(await screen.findByRole('heading', { level: 1, name: /Log in to Identrail/i })).toBeInTheDocument();


### PR DESCRIPTION
No issue: operator-hardening follow-up after the production release form required manually typed confirmation and image values.

## What changed
- Renamed the hosted API production workflow to `Deploy to prod` so the Actions UI matches the operator task.
- Removed routine workflow-dispatch inputs; operators now select `dev` and click **Run workflow**.
- Added a release resolver that derives the immutable API and worker images from the workflow commit, verifies `CI` and `Publish Container Images` succeeded for that exact SHA, logs into GHCR, and confirms both image tags exist before migrations or deployment start.
- Added a `production` GitHub Environment gate before migrations/deploy so the repo can use first-class environment approvals instead of a fragile typed confirmation field.
- Updated the AWS hosting and deployment runbook docs, plus the changelog, to describe the one-click promotion path and keep `AWS API Manual Deploy` as the lower-level rollback/override path.

## Why it changed
The old `AWS Production Release` workflow asked operators to type `release-api.identrail.com` and paste `ghcr.io/identrail/identrail-api:sha-<current-dev-commit>`. A leading space in the confirmation value caused a failed release before validation could proceed. The production workflow should promote the verified immutable artifact for the selected `dev` commit instead of relying on manual copy/paste.

## Impact and risk
- Normal production releases become one-click from `dev` after CI and image publishing are green.
- Production still deploys immutable `sha-...` images, never mutable `dev` or `latest` tags.
- If CI or image publishing has not completed for the selected commit, the workflow fails early with a clear message before migrations or Terraform apply.
- If the `production` environment has required reviewers configured, GitHub will pause at the environment gate before migrations and deployment.
- Emergency image overrides remain available through `AWS API Manual Deploy`; they are intentionally not part of the routine production path.

## Validation performed
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/aws-production-release.yml"); puts "workflow yaml ok"'` -> passed
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/aws-production-release.yml` -> passed
- `git diff --check` -> passed
- Pre-commit hooks during commit -> passed (`check yaml`, merge-conflict check, EOF/whitespace, gofmt check, Vercel artifact hygiene)
- Pre-push hooks during push -> passed (`check yaml`, merge-conflict check, EOF/whitespace, gofmt check, `go vet`, local env token hygiene, Vercel artifact hygiene)

AI-assisted: yes
Tools used: Codex, ChatGPT
Where used: `.github/workflows/aws-production-release.yml`, deployment docs, changelog
Human verification performed: reviewed workflow wiring, ran YAML parsing, actionlint, diff whitespace check, commit hooks, and push hooks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make production deploys one click from `dev` by renaming the workflow to `Deploy to prod` and automating image resolution, verification, environment approval, migrations, deploy, and smoke checks.

- **New Features**
  - Resolve and pass immutable API and worker images for the current commit; verify `CI` and `Publish Container Images` passed and GHCR tags exist.
  - Add a `production` GitHub Environment approval before migrations and deploy.
  - Remove manual inputs; operators select `dev` and click Run.
  - Enforce immutable `sha-*` tags and fail early if gates are not met.
  - Extend `AWS API Manual Deploy` to accept a worker image; update docs and changelog; keep it for rollback/overrides.

- **Bug Fixes**
  - Stabilize session auth tests by selecting the AWS link via its `href` and waiting with `waitFor`, reducing brittle text-based failures.

<sup>Written for commit f162297d83e47976a35f3727f9ce5fb5179d3eca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1433?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

