### PR TITLE
Add reusable domain page primitives for the redesigned app shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
 ## Unreleased
+- Extended the shared domain page framework in `web/src/components/app/DomainFoundation.tsx`
+  with typed `DomainStatusBadge` variants (connected, disconnected, needs-attention,
+  degraded, running-scan, missing-permissions, coming-soon), `DomainCoverageCard`
+  with an accessible progress bar, `DomainFindingSummaryCard` keyed to severity,
+  `DomainTimeline` rows, a `DomainGraphPlaceholder` panel, a
+  `DomainRemediationQueue` with primary/secondary affordances, a `DomainSortControl`
+  with a direction toggle, and a focus-trapped `DomainDetailDrawer`. Empty and error
+  states now accept `nextAction` and `retryAction` slots so the operational
+  states feel like a security product rather than a generic toast. The new
+  primitives are reusable across AWS, GitHub, and Kubernetes domain shells and
+  follow the WorkOS/GitHub-style premium dark direction without reintroducing
+  Projects or global Findings concepts.
 - Renamed the hosted API production release workflow to `Deploy to prod` and
   made the normal release path one-click from the `dev` branch. The workflow now
   resolves the current commit's immutable API and worker image tags, verifies CI

--- a/web/src/components/app/DomainFoundation.test.tsx
+++ b/web/src/components/app/DomainFoundation.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
@@ -330,17 +331,66 @@ describe('DomainFoundation', () => {
     expect(onChange).toHaveBeenCalledWith({ key: 'risk', direction: 'asc' });
   });
 
-  it('opens, traps, and closes the detail drawer with keyboard-friendly controls', () => {
+  it('focuses the drawer and closes via the explicit close affordance', () => {
     const onClose = vi.fn();
     render(
-      <DomainDetailDrawer open title="Identity detail" eyebrow="Inventory" onClose={onClose} footer={<button type="button">Close</button>}>
+      <DomainDetailDrawer open title="Identity detail" eyebrow="Inventory" onClose={onClose} footer={<button type="button">Approve</button>}>
         <p>Identity payload</p>
+        <a href="/inventory">View inventory</a>
       </DomainDetailDrawer>
     );
 
     expect(screen.getByRole('dialog', { name: 'Identity detail' })).toBeInTheDocument();
-    fireEvent.click(screen.getAllByRole('button', { name: 'Close detail drawer' })[0]);
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Close detail drawer' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Close detail drawer' }));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the drawer on Escape and traps Tab inside its contents', () => {
+    const onClose = vi.fn();
+    render(
+      <DomainDetailDrawer open title="Identity detail" onClose={onClose} footer={<button type="button">Approve</button>}>
+        <a href="/inventory">View inventory</a>
+      </DomainDetailDrawer>
+    );
+
+    const dialog = screen.getByRole('dialog', { name: 'Identity detail' });
+    fireEvent.keyDown(dialog, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    const closeButton = screen.getByRole('button', { name: 'Close detail drawer' });
+    const approveButton = screen.getByRole('button', { name: 'Approve' });
+    approveButton.focus();
+    fireEvent.keyDown(dialog, { key: 'Tab' });
+    expect(document.activeElement).toBe(closeButton);
+
+    fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(approveButton);
+  });
+
+  it('restores focus to the prior element when the drawer closes', () => {
+    function Host() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>
+            Open
+          </button>
+          <DomainDetailDrawer open={open} title="Identity detail" onClose={() => setOpen(false)}>
+            <p>payload</p>
+          </DomainDetailDrawer>
+        </>
+      );
+    }
+    render(<Host />);
+
+    const opener = screen.getByRole('button', { name: 'Open' });
+    opener.focus();
+    fireEvent.click(opener);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close detail drawer' }));
+    expect(document.activeElement).toBe(opener);
   });
 
   it('does not render the drawer when closed', () => {

--- a/web/src/components/app/DomainFoundation.test.tsx
+++ b/web/src/components/app/DomainFoundation.test.tsx
@@ -3,20 +3,29 @@ import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import {
   DomainActionFooter,
+  DomainCoverageCard,
   DomainDataTable,
+  DomainDetailDrawer,
   DomainDetailPanel,
   DomainEmptyState,
   DomainErrorState,
   DomainEvidencePanel,
   DomainFilterBar,
+  DomainFindingSummaryCard,
+  DomainGraphPlaceholder,
   DomainHeader,
   DomainKpiStrip,
   DomainLoadingState,
   DomainLogoMark,
   DomainLogoStack,
   DomainPageShell,
+  DomainRemediationQueue,
+  DomainSortControl,
+  DomainStatusBadge,
   DomainStatusPanel,
-  DomainSubnav
+  DomainSubnav,
+  DomainTimeline,
+  domainStatusTone
 } from './DomainFoundation';
 
 describe('DomainFoundation', () => {
@@ -178,6 +187,169 @@ describe('DomainFoundation', () => {
     expect(screen.getByRole('status')).toHaveTextContent('Loading GitHub repositories');
     expect(screen.getByText('{"Effect":"Allow"}')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Approve plan' })).toBeInTheDocument();
+  });
+
+  it('renders typed domain status badges with semantic tones', () => {
+    render(
+      <>
+        <DomainStatusBadge variant="connected" />
+        <DomainStatusBadge variant="degraded" detail="Webhook lag 8s" />
+        <DomainStatusBadge variant="missing-permissions" />
+        <DomainStatusBadge variant="running-scan" />
+        <DomainStatusBadge variant="coming-soon" />
+      </>
+    );
+
+    expect(screen.getByText('Connected').closest('.idt-domain-status-badge')).toHaveClass('is-success');
+    expect(screen.getByText('Degraded').closest('.idt-domain-status-badge')).toHaveClass('is-warning');
+    expect(screen.getByText('Missing permissions').closest('.idt-domain-status-badge')).toHaveClass('is-danger');
+    expect(screen.getByText('Running scan').closest('.idt-domain-status-badge')).toHaveClass('is-info');
+    expect(screen.getByText('Webhook lag 8s')).toBeInTheDocument();
+    expect(domainStatusTone('connected')).toBe('success');
+    expect(domainStatusTone('missing-permissions')).toBe('danger');
+  });
+
+  it('exposes empty next action and error retry action as primary controls', () => {
+    const onRetry = vi.fn();
+    const onConnect = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <DomainEmptyState
+          title="No identities yet"
+          body="Connect an AWS account to begin."
+          nextAction={{ label: 'Connect AWS', onClick: onConnect }}
+        />
+        <DomainErrorState title="Sync failed" body="Reach out if this persists." retryAction={{ label: 'Retry sync', onClick: onRetry }} />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connect AWS' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Retry sync' }));
+    expect(onConnect).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders coverage cards with a labeled progress bar', () => {
+    render(<DomainCoverageCard label="Accounts" scanned={3} total={4} detail="us-east, us-west" />);
+
+    const progress = screen.getByRole('progressbar', { name: /accounts coverage/i });
+    expect(progress).toHaveAttribute('aria-valuenow', '3');
+    expect(progress).toHaveAttribute('aria-valuemax', '4');
+    expect(screen.getByText('75%')).toBeInTheDocument();
+    expect(screen.getByText(/3 of 4 scanned/)).toBeInTheDocument();
+  });
+
+  it('renders finding summary cards with severity, count, and navigation', () => {
+    render(
+      <MemoryRouter>
+        <DomainFindingSummaryCard severity="critical" count={4} to="/aws/findings?severity=critical" />
+        <DomainFindingSummaryCard severity="medium" count={12} trend="+3 this week" />
+      </MemoryRouter>
+    );
+
+    const link = screen.getByRole('link', { name: '4 Critical findings' });
+    expect(link).toHaveAttribute('href', '/aws/findings?severity=critical');
+    expect(screen.getByText('+3 this week')).toBeInTheDocument();
+  });
+
+  it('renders the timeline as an ordered list with semantic entries', () => {
+    render(
+      <DomainTimeline
+        label="Scan history"
+        entries={[
+          { id: 'a', timestamp: '12:01', title: 'Scan started', actor: 'collector' },
+          { id: 'b', timestamp: '12:04', title: 'Findings published', detail: '7 new', tone: 'success' }
+        ]}
+      />
+    );
+
+    const list = screen.getByRole('list', { name: 'Scan history' });
+    expect(within(list).getAllByRole('listitem')).toHaveLength(2);
+    expect(within(list).getByText('Findings published')).toBeInTheDocument();
+    expect(within(list).getByText('collector')).toBeInTheDocument();
+  });
+
+  it('renders a graph placeholder region with an inline call to action', () => {
+    render(
+      <MemoryRouter>
+        <DomainGraphPlaceholder
+          title="Trust graph coming soon"
+          description="Cross-account trust will appear once collectors complete."
+          action={{ label: 'See sample graph', href: '/docs/graph' }}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('region', { name: 'Trust graph coming soon' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'See sample graph' })).toHaveAttribute('href', '/docs/graph');
+  });
+
+  it('renders the remediation queue with action affordances and an empty fallback', () => {
+    const approve = vi.fn();
+    render(
+      <MemoryRouter>
+        <DomainRemediationQueue
+          items={[
+            {
+              id: 'q1',
+              title: 'Rotate access key AKIA…',
+              detail: 'Last used 142 days ago',
+              severity: 'high',
+              owner: 'sec-platform',
+              primaryAction: { label: 'Approve', onClick: approve },
+              secondaryAction: { label: 'Defer', onClick: vi.fn() }
+            }
+          ]}
+        />
+        <DomainRemediationQueue label="Cleared queue" items={[]} />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    expect(approve).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('sec-platform')).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Cleared queue' })).toHaveTextContent('Queue is clear');
+  });
+
+  it('lets sort controls flip direction without changing the key', () => {
+    const onChange = vi.fn();
+    render(
+      <DomainSortControl
+        options={[
+          { key: 'risk', label: 'Risk' },
+          { key: 'updated', label: 'Updated' }
+        ]}
+        value="risk"
+        direction="desc"
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /sort direction: descending/i }));
+    expect(onChange).toHaveBeenCalledWith({ key: 'risk', direction: 'asc' });
+  });
+
+  it('opens, traps, and closes the detail drawer with keyboard-friendly controls', () => {
+    const onClose = vi.fn();
+    render(
+      <DomainDetailDrawer open title="Identity detail" eyebrow="Inventory" onClose={onClose} footer={<button type="button">Close</button>}>
+        <p>Identity payload</p>
+      </DomainDetailDrawer>
+    );
+
+    expect(screen.getByRole('dialog', { name: 'Identity detail' })).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole('button', { name: 'Close detail drawer' })[0]);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render the drawer when closed', () => {
+    const { queryByRole } = render(
+      <DomainDetailDrawer open={false} title="Hidden" onClose={() => undefined}>
+        <p>nope</p>
+      </DomainDetailDrawer>
+    );
+    expect(queryByRole('dialog')).toBeNull();
   });
 
   it('always prevents native submit in filter bar handlers', () => {

--- a/web/src/components/app/DomainFoundation.tsx
+++ b/web/src/components/app/DomainFoundation.tsx
@@ -1,5 +1,5 @@
-import { useId } from 'react';
-import type { FormEvent, ReactNode } from 'react';
+import { useCallback, useEffect, useId, useRef } from 'react';
+import type { FormEvent, KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { DOMAIN_ASSET_ORDER, getDomainAsset, type DomainAssetKey } from '../../design/domainAssets';
 
@@ -817,6 +817,18 @@ export function DomainSortControl({
   );
 }
 
+const DOMAIN_DRAWER_FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function getDomainDrawerFocusable(root: HTMLElement | null): HTMLElement[] {
+  if (!root) {
+    return [];
+  }
+  return Array.from(root.querySelectorAll<HTMLElement>(DOMAIN_DRAWER_FOCUSABLE_SELECTOR)).filter(
+    (el) => el.getAttribute('aria-hidden') !== 'true'
+  );
+}
+
 export function DomainDetailDrawer({
   open,
   title,
@@ -834,13 +846,64 @@ export function DomainDetailDrawer({
   children: ReactNode;
   footer?: ReactNode;
 }) {
+  const drawerRef = useRef<HTMLElement | null>(null);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    restoreFocusRef.current = (document.activeElement as HTMLElement | null) ?? null;
+    const focusables = getDomainDrawerFocusable(drawerRef.current);
+    (focusables[0] ?? drawerRef.current)?.focus();
+    return () => {
+      restoreFocusRef.current?.focus?.();
+    };
+  }, [open]);
+
+  const handleKeyDown = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.stopPropagation();
+      onCloseRef.current();
+      return;
+    }
+    if (event.key !== 'Tab') {
+      return;
+    }
+    const focusables = getDomainDrawerFocusable(drawerRef.current);
+    if (focusables.length === 0) {
+      event.preventDefault();
+      drawerRef.current?.focus();
+      return;
+    }
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+    if (event.shiftKey) {
+      if (active === first || !drawerRef.current?.contains(active)) {
+        event.preventDefault();
+        last.focus();
+      }
+      return;
+    }
+    if (active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }, []);
+
   if (!open) {
     return null;
   }
   return (
-    <div className="idt-domain-drawer-root" role="dialog" aria-modal="true" aria-label={title}>
-      <button type="button" className="idt-domain-drawer-scrim" aria-label={closeLabel} onClick={onClose} />
-      <aside className="idt-domain-drawer">
+    <div className="idt-domain-drawer-root" role="dialog" aria-modal="true" aria-label={title} onKeyDown={handleKeyDown}>
+      <button type="button" className="idt-domain-drawer-scrim" aria-hidden="true" tabIndex={-1} onClick={onClose} />
+      <aside className="idt-domain-drawer" ref={drawerRef} tabIndex={-1}>
         <header>
           <div>
             {eyebrow ? <p className="idt-app-kicker">{eyebrow}</p> : null}

--- a/web/src/components/app/DomainFoundation.tsx
+++ b/web/src/components/app/DomainFoundation.tsx
@@ -237,6 +237,64 @@ export function DomainSubnav({ label = 'Domain sections', items }: { label?: str
   );
 }
 
+export type DomainStatusVariant =
+  | 'connected'
+  | 'disconnected'
+  | 'needs-attention'
+  | 'degraded'
+  | 'running-scan'
+  | 'missing-permissions'
+  | 'coming-soon';
+
+const DOMAIN_STATUS_TONE: Record<DomainStatusVariant, Tone> = {
+  connected: 'success',
+  disconnected: 'neutral',
+  'needs-attention': 'warning',
+  degraded: 'warning',
+  'running-scan': 'info',
+  'missing-permissions': 'danger',
+  'coming-soon': 'neutral'
+};
+
+const DOMAIN_STATUS_LABEL: Record<DomainStatusVariant, string> = {
+  connected: 'Connected',
+  disconnected: 'Disconnected',
+  'needs-attention': 'Needs attention',
+  degraded: 'Degraded',
+  'running-scan': 'Running scan',
+  'missing-permissions': 'Missing permissions',
+  'coming-soon': 'Coming soon'
+};
+
+export function domainStatusTone(variant: DomainStatusVariant): Tone {
+  return DOMAIN_STATUS_TONE[variant];
+}
+
+export function DomainStatusBadge({
+  variant,
+  label,
+  detail
+}: {
+  variant: DomainStatusVariant;
+  label?: string;
+  detail?: ReactNode;
+}) {
+  const tone = DOMAIN_STATUS_TONE[variant];
+  const text = label ?? DOMAIN_STATUS_LABEL[variant];
+  return (
+    <span
+      className={classNames(['idt-domain-status-badge', `is-${variant}`, `is-${tone}`])}
+      data-variant={variant}
+      role="status"
+      aria-label={detail ? `${text}. ${typeof detail === 'string' ? detail : ''}`.trim() : text}
+    >
+      <span aria-hidden="true" className="idt-domain-status-dot" />
+      <strong>{text}</strong>
+      {detail ? <span className="idt-domain-status-detail">{detail}</span> : null}
+    </span>
+  );
+}
+
 export type DomainPageShellProps = DomainHeaderProps & {
   subnav?: DomainSubnavItem[];
   subnavLabel?: string;
@@ -313,24 +371,56 @@ export function DomainStatusPanel({
   );
 }
 
-export function DomainEmptyState({ eyebrow, title, body, children }: { eyebrow?: string; title: string; body: ReactNode; children?: ReactNode }) {
+export function DomainEmptyState({
+  eyebrow,
+  title,
+  body,
+  nextAction,
+  children
+}: {
+  eyebrow?: string;
+  title: string;
+  body: ReactNode;
+  nextAction?: DomainAction;
+  children?: ReactNode;
+}) {
   return (
     <article className="idt-domain-empty-state">
       {eyebrow ? <p className="idt-app-kicker">{eyebrow}</p> : null}
       <h3>{title}</h3>
       <p>{body}</p>
-      {children ? <div className="idt-inline-actions">{children}</div> : null}
+      {nextAction || children ? (
+        <div className="idt-inline-actions">
+          {nextAction ? renderDomainAction({ variant: 'primary', ...nextAction }, 'next-action') : null}
+          {children}
+        </div>
+      ) : null}
     </article>
   );
 }
 
-export function DomainErrorState({ title, body, children }: { title: string; body: ReactNode; children?: ReactNode }) {
+export function DomainErrorState({
+  title,
+  body,
+  retryAction,
+  children
+}: {
+  title: string;
+  body: ReactNode;
+  retryAction?: DomainAction;
+  children?: ReactNode;
+}) {
   return (
     <article className="idt-domain-error-state" role="alert">
       <p className="idt-app-kicker">Needs attention</p>
       <h3>{title}</h3>
       <p>{body}</p>
-      {children ? <div className="idt-inline-actions">{children}</div> : null}
+      {retryAction || children ? (
+        <div className="idt-inline-actions">
+          {retryAction ? renderDomainAction({ variant: 'primary', ...retryAction }, 'retry-action') : null}
+          {children}
+        </div>
+      ) : null}
     </article>
   );
 }
@@ -475,4 +565,294 @@ export function DomainEvidencePanel({
 
 export function DomainActionFooter({ children }: { children: ReactNode }) {
   return <footer className="idt-domain-action-footer">{children}</footer>;
+}
+
+export type DomainCoverageCardProps = {
+  label: string;
+  scanned: number;
+  total: number;
+  detail?: ReactNode;
+};
+
+export function DomainCoverageCard({ label, scanned, total, detail }: DomainCoverageCardProps) {
+  const pct = total > 0 ? Math.min(100, Math.round((scanned / total) * 100)) : 0;
+  const tone: Tone = pct >= 90 ? 'success' : pct >= 60 ? 'info' : pct >= 30 ? 'warning' : 'danger';
+  return (
+    <article className={classNames(['idt-domain-coverage-card', `is-${tone}`])} aria-label={`${label} coverage`}>
+      <header>
+        <span>{label}</span>
+        <strong>{pct}%</strong>
+      </header>
+      <div
+        className="idt-domain-coverage-bar"
+        role="progressbar"
+        aria-label={`${label} coverage`}
+        aria-valuemin={0}
+        aria-valuemax={total}
+        aria-valuenow={scanned}
+        aria-valuetext={`${scanned} of ${total} ${label.toLowerCase()} scanned`}
+      >
+        <span style={{ width: `${pct}%` }} aria-hidden="true" />
+      </div>
+      <p>
+        {scanned} of {total} scanned
+        {detail ? <> · {detail}</> : null}
+      </p>
+    </article>
+  );
+}
+
+export type DomainSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
+
+const DOMAIN_SEVERITY_LABEL: Record<DomainSeverity, string> = {
+  critical: 'Critical',
+  high: 'High',
+  medium: 'Medium',
+  low: 'Low',
+  info: 'Info'
+};
+
+export type DomainFindingSummaryCardProps = {
+  severity: DomainSeverity;
+  count: number;
+  label?: string;
+  trend?: ReactNode;
+  to?: string;
+  onClick?: () => void;
+};
+
+export function DomainFindingSummaryCard({ severity, count, label, trend, to, onClick }: DomainFindingSummaryCardProps) {
+  const displayLabel = label ?? `${DOMAIN_SEVERITY_LABEL[severity]} findings`;
+  const body = (
+    <>
+      <header>
+        <span className={classNames(['idt-domain-severity-pill', `is-${severity}`])}>{DOMAIN_SEVERITY_LABEL[severity]}</span>
+        {trend ? <span className="idt-domain-finding-trend">{trend}</span> : null}
+      </header>
+      <strong>{count}</strong>
+      <p>{displayLabel}</p>
+    </>
+  );
+
+  const className = classNames(['idt-domain-finding-card', `is-${severity}`]);
+
+  if (to) {
+    return (
+      <Link className={className} to={to} aria-label={`${count} ${displayLabel}`}>
+        {body}
+      </Link>
+    );
+  }
+
+  if (onClick) {
+    return (
+      <button type="button" className={className} onClick={onClick} aria-label={`${count} ${displayLabel}`}>
+        {body}
+      </button>
+    );
+  }
+
+  return (
+    <article className={className} aria-label={`${count} ${displayLabel}`}>
+      {body}
+    </article>
+  );
+}
+
+export type DomainTimelineEntry = {
+  id: string;
+  timestamp: string;
+  title: ReactNode;
+  detail?: ReactNode;
+  actor?: ReactNode;
+  tone?: Tone;
+};
+
+export function DomainTimeline({ label = 'Recent activity', entries }: { label?: string; entries: DomainTimelineEntry[] }) {
+  if (entries.length === 0) {
+    return null;
+  }
+  return (
+    <ol className="idt-domain-timeline" aria-label={label}>
+      {entries.map((entry) => (
+        <li key={entry.id} className={classNames(['idt-domain-timeline-row', entry.tone ? `is-${entry.tone}` : ''])}>
+          <time>{entry.timestamp}</time>
+          <div>
+            <p className="idt-domain-timeline-title">{entry.title}</p>
+            {entry.detail ? <p className="idt-domain-timeline-detail">{entry.detail}</p> : null}
+          </div>
+          {entry.actor ? <span className="idt-domain-timeline-actor">{entry.actor}</span> : null}
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+export function DomainGraphPlaceholder({
+  title,
+  description,
+  action
+}: {
+  title: string;
+  description: ReactNode;
+  action?: DomainAction;
+}) {
+  return (
+    <section className="idt-domain-graph-placeholder" aria-label={title}>
+      <div className="idt-domain-graph-canvas" aria-hidden="true">
+        <span />
+        <span />
+        <span />
+      </div>
+      <div className="idt-domain-graph-copy">
+        <p className="idt-app-kicker">Graph</p>
+        <h3>{title}</h3>
+        <p>{description}</p>
+        {action ? <div className="idt-inline-actions">{renderDomainAction(action, 'graph-action')}</div> : null}
+      </div>
+    </section>
+  );
+}
+
+export type DomainRemediationItem = {
+  id: string;
+  title: ReactNode;
+  detail?: ReactNode;
+  severity?: DomainSeverity;
+  owner?: ReactNode;
+  primaryAction?: DomainAction;
+  secondaryAction?: DomainAction;
+};
+
+export function DomainRemediationQueue({
+  label = 'Remediation queue',
+  items,
+  emptyState
+}: {
+  label?: string;
+  items: DomainRemediationItem[];
+  emptyState?: ReactNode;
+}) {
+  if (items.length === 0) {
+    return (
+      <section className="idt-domain-remediation-queue idt-domain-remediation-queue-empty" aria-label={label}>
+        {emptyState ?? <DomainEmptyState title="Queue is clear" body="No remediation actions are waiting." />}
+      </section>
+    );
+  }
+  return (
+    <section className="idt-domain-remediation-queue" aria-label={label}>
+      <ol>
+        {items.map((item) => (
+          <li key={item.id} className="idt-domain-remediation-item">
+            <div className="idt-domain-remediation-main">
+              {item.severity ? (
+                <span className={classNames(['idt-domain-severity-pill', `is-${item.severity}`])}>
+                  {DOMAIN_SEVERITY_LABEL[item.severity]}
+                </span>
+              ) : null}
+              <div>
+                <p className="idt-domain-remediation-title">{item.title}</p>
+                {item.detail ? <p className="idt-domain-remediation-detail">{item.detail}</p> : null}
+              </div>
+            </div>
+            <div className="idt-domain-remediation-aside">
+              {item.owner ? <span className="idt-domain-remediation-owner">{item.owner}</span> : null}
+              <div className="idt-inline-actions">
+                {item.secondaryAction ? renderDomainAction({ variant: 'ghost', ...item.secondaryAction }, `${item.id}-secondary`) : null}
+                {item.primaryAction ? renderDomainAction({ variant: 'primary', ...item.primaryAction }, `${item.id}-primary`) : null}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+export type DomainSortDirection = 'asc' | 'desc';
+export type DomainSortOption = { key: string; label: string };
+
+export function DomainSortControl({
+  label = 'Sort',
+  options,
+  value,
+  direction = 'desc',
+  onChange
+}: {
+  label?: string;
+  options: DomainSortOption[];
+  value: string;
+  direction?: DomainSortDirection;
+  onChange: (next: { key: string; direction: DomainSortDirection }) => void;
+}) {
+  const directionLabel = direction === 'asc' ? 'Ascending' : 'Descending';
+  return (
+    <div className="idt-domain-sort-control">
+      <label>
+        <span>{label}</span>
+        <select
+          value={value}
+          onChange={(event) => onChange({ key: event.target.value, direction })}
+          aria-label={`${label} field`}
+        >
+          {options.map((option) => (
+            <option key={option.key} value={option.key}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <button
+        type="button"
+        className="idt-domain-sort-direction"
+        aria-label={`${label} direction: ${directionLabel}. Toggle.`}
+        aria-pressed={direction === 'asc'}
+        onClick={() => onChange({ key: value, direction: direction === 'asc' ? 'desc' : 'asc' })}
+      >
+        <span aria-hidden="true">{direction === 'asc' ? '↑' : '↓'}</span>
+        <span className="idt-visually-hidden">{directionLabel}</span>
+      </button>
+    </div>
+  );
+}
+
+export function DomainDetailDrawer({
+  open,
+  title,
+  eyebrow,
+  onClose,
+  closeLabel = 'Close detail drawer',
+  children,
+  footer
+}: {
+  open: boolean;
+  title: string;
+  eyebrow?: string;
+  onClose: () => void;
+  closeLabel?: string;
+  children: ReactNode;
+  footer?: ReactNode;
+}) {
+  if (!open) {
+    return null;
+  }
+  return (
+    <div className="idt-domain-drawer-root" role="dialog" aria-modal="true" aria-label={title}>
+      <button type="button" className="idt-domain-drawer-scrim" aria-label={closeLabel} onClick={onClose} />
+      <aside className="idt-domain-drawer">
+        <header>
+          <div>
+            {eyebrow ? <p className="idt-app-kicker">{eyebrow}</p> : null}
+            <h3>{title}</h3>
+          </div>
+          <button type="button" className="idt-domain-drawer-close" onClick={onClose} aria-label={closeLabel}>
+            <span aria-hidden="true">×</span>
+          </button>
+        </header>
+        <div className="idt-domain-drawer-body">{children}</div>
+        {footer ? <footer>{footer}</footer> : null}
+      </aside>
+    </div>
+  );
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -22774,6 +22774,615 @@ html[data-theme='light'] .idt-app-shell-screen select {
   }
 }
 
+.idt-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.idt-domain-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  border: 1px solid var(--app-border);
+  border-radius: 999px;
+  padding: 0.28rem 0.62rem;
+  background: #050505;
+  color: #ffffff;
+  font-size: 0.78rem;
+  font-weight: 800;
+  line-height: 1.2;
+}
+
+.idt-domain-status-badge strong {
+  font-weight: 900;
+}
+
+.idt-domain-status-badge .idt-domain-status-detail {
+  color: var(--app-muted);
+  font-weight: 700;
+}
+
+.idt-domain-status-dot {
+  width: 0.46rem;
+  height: 0.46rem;
+  border-radius: 999px;
+  background: #ffffff;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.12);
+}
+
+.idt-domain-status-badge.is-success {
+  border-color: rgba(88, 214, 141, 0.5);
+  color: #acf2c4;
+}
+
+.idt-domain-status-badge.is-success .idt-domain-status-dot {
+  background: #58d68d;
+  box-shadow: 0 0 0 2px rgba(88, 214, 141, 0.22);
+}
+
+.idt-domain-status-badge.is-warning {
+  border-color: rgba(245, 196, 81, 0.55);
+  color: #ffe3a3;
+}
+
+.idt-domain-status-badge.is-warning .idt-domain-status-dot {
+  background: #f5c451;
+  box-shadow: 0 0 0 2px rgba(245, 196, 81, 0.24);
+}
+
+.idt-domain-status-badge.is-danger {
+  border-color: rgba(255, 107, 107, 0.56);
+  color: #ffb3b3;
+}
+
+.idt-domain-status-badge.is-danger .idt-domain-status-dot {
+  background: #ff6b6b;
+  box-shadow: 0 0 0 2px rgba(255, 107, 107, 0.24);
+}
+
+.idt-domain-status-badge.is-info {
+  border-color: rgba(88, 166, 255, 0.52);
+  color: #b9d7ff;
+}
+
+.idt-domain-status-badge.is-info .idt-domain-status-dot {
+  background: #58a6ff;
+  box-shadow: 0 0 0 2px rgba(88, 166, 255, 0.24);
+}
+
+.idt-domain-status-badge.is-running-scan .idt-domain-status-dot {
+  animation: idt-domain-spin 1.6s linear infinite;
+  background: transparent;
+  border: 2px solid rgba(185, 215, 255, 0.32);
+  border-top-color: #b9d7ff;
+  box-shadow: none;
+}
+
+.idt-domain-coverage-card {
+  display: grid;
+  gap: 0.55rem;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 0.95rem;
+  background: #080809;
+}
+
+.idt-domain-coverage-card header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.idt-domain-coverage-card header span {
+  color: var(--app-dim);
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+.idt-domain-coverage-card header strong {
+  color: #ffffff;
+  font-size: 1.45rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.idt-domain-coverage-bar {
+  position: relative;
+  height: 0.42rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.idt-domain-coverage-bar > span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: #ffffff;
+  border-radius: inherit;
+  transition: width 240ms ease;
+}
+
+.idt-domain-coverage-card.is-success .idt-domain-coverage-bar > span {
+  background: #58d68d;
+}
+
+.idt-domain-coverage-card.is-info .idt-domain-coverage-bar > span {
+  background: #58a6ff;
+}
+
+.idt-domain-coverage-card.is-warning .idt-domain-coverage-bar > span {
+  background: #f5c451;
+}
+
+.idt-domain-coverage-card.is-danger .idt-domain-coverage-bar > span {
+  background: #ff6b6b;
+}
+
+.idt-domain-coverage-card p {
+  margin: 0;
+  color: var(--app-muted);
+  font-size: 0.82rem;
+}
+
+.idt-domain-finding-card {
+  display: grid;
+  gap: 0.5rem;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 0.95rem;
+  background: #080809;
+  color: var(--app-text);
+  text-align: left;
+  text-decoration: none;
+  font: inherit;
+  cursor: default;
+}
+
+a.idt-domain-finding-card,
+button.idt-domain-finding-card {
+  cursor: pointer;
+}
+
+a.idt-domain-finding-card:hover,
+a.idt-domain-finding-card:focus-visible,
+button.idt-domain-finding-card:hover,
+button.idt-domain-finding-card:focus-visible {
+  border-color: rgba(255, 255, 255, 0.32);
+  outline: none;
+}
+
+.idt-domain-finding-card header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.4rem;
+}
+
+.idt-domain-finding-card strong {
+  color: #ffffff;
+  font-size: clamp(1.55rem, 2vw, 2rem);
+  font-weight: 900;
+  line-height: 1;
+}
+
+.idt-domain-finding-card p {
+  margin: 0;
+  color: var(--app-muted);
+  font-size: 0.84rem;
+}
+
+.idt-domain-finding-trend {
+  color: var(--app-dim);
+  font-size: 0.74rem;
+  font-weight: 800;
+}
+
+.idt-domain-severity-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.32rem;
+  border: 1px solid var(--app-border);
+  border-radius: 999px;
+  padding: 0.16rem 0.5rem;
+  background: #050505;
+  color: #ffffff;
+  font-size: 0.7rem;
+  font-weight: 900;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.idt-domain-severity-pill.is-critical {
+  border-color: rgba(255, 107, 107, 0.56);
+  color: #ffb3b3;
+}
+
+.idt-domain-severity-pill.is-high {
+  border-color: rgba(245, 138, 81, 0.55);
+  color: #ffcfa3;
+}
+
+.idt-domain-severity-pill.is-medium {
+  border-color: rgba(245, 196, 81, 0.55);
+  color: #ffe3a3;
+}
+
+.idt-domain-severity-pill.is-low {
+  border-color: rgba(88, 166, 255, 0.52);
+  color: #b9d7ff;
+}
+
+.idt-domain-severity-pill.is-info {
+  border-color: var(--app-border);
+  color: var(--app-muted);
+}
+
+.idt-domain-finding-card.is-critical {
+  border-color: rgba(255, 107, 107, 0.42);
+}
+
+.idt-domain-finding-card.is-high {
+  border-color: rgba(245, 138, 81, 0.34);
+}
+
+.idt-domain-timeline {
+  display: grid;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.idt-domain-timeline-row {
+  display: grid;
+  grid-template-columns: minmax(6rem, 7.5rem) minmax(0, 1fr) auto;
+  gap: 0.85rem;
+  align-items: start;
+  border: 1px solid var(--app-border-soft);
+  border-radius: 8px;
+  padding: 0.7rem 0.85rem;
+  background: #050505;
+}
+
+.idt-domain-timeline-row time {
+  color: var(--app-dim);
+  font-family: var(--idt-mono);
+  font-size: 0.74rem;
+  font-weight: 800;
+}
+
+.idt-domain-timeline-title {
+  margin: 0;
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 800;
+}
+
+.idt-domain-timeline-detail {
+  margin: 0.2rem 0 0;
+  color: var(--app-muted);
+  font-size: 0.82rem;
+}
+
+.idt-domain-timeline-actor {
+  align-self: center;
+  border: 1px solid var(--app-border);
+  border-radius: 999px;
+  padding: 0.14rem 0.5rem;
+  color: var(--app-muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.idt-domain-timeline-row.is-success {
+  border-color: rgba(88, 214, 141, 0.34);
+}
+
+.idt-domain-timeline-row.is-warning {
+  border-color: rgba(245, 196, 81, 0.38);
+}
+
+.idt-domain-timeline-row.is-danger {
+  border-color: rgba(255, 107, 107, 0.4);
+}
+
+.idt-domain-graph-placeholder {
+  display: grid;
+  grid-template-columns: minmax(11rem, 18rem) minmax(0, 1fr);
+  gap: 1.1rem;
+  align-items: center;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 1.1rem;
+  background:
+    radial-gradient(120% 80% at 0% 0%, rgba(124, 97, 255, 0.08), transparent 60%),
+    #080809;
+}
+
+.idt-domain-graph-canvas {
+  position: relative;
+  min-height: 8.5rem;
+  border: 1px dashed rgba(255, 255, 255, 0.16);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04), transparent),
+    #050505;
+}
+
+.idt-domain-graph-canvas > span {
+  position: absolute;
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 999px;
+  background: #ffffff;
+  opacity: 0.6;
+}
+
+.idt-domain-graph-canvas > span:nth-child(1) {
+  top: 22%;
+  left: 18%;
+}
+
+.idt-domain-graph-canvas > span:nth-child(2) {
+  top: 58%;
+  left: 48%;
+}
+
+.idt-domain-graph-canvas > span:nth-child(3) {
+  top: 32%;
+  left: 76%;
+}
+
+.idt-domain-graph-canvas::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(135deg, transparent 22%, rgba(255, 255, 255, 0.18) 23%, transparent 24%) no-repeat,
+    linear-gradient(45deg, transparent 56%, rgba(255, 255, 255, 0.14) 57%, transparent 58%) no-repeat;
+  pointer-events: none;
+}
+
+.idt-domain-graph-copy h3 {
+  margin: 0.2rem 0 0.35rem;
+  color: #ffffff;
+  font-family: var(--idt-display);
+  font-size: 1.05rem;
+  line-height: 1.1;
+}
+
+.idt-domain-graph-copy p {
+  margin: 0;
+  color: var(--app-muted);
+  font-size: 0.86rem;
+}
+
+.idt-domain-remediation-queue {
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: #080809;
+}
+
+.idt-domain-remediation-queue ol {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.idt-domain-remediation-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.85rem 0.95rem;
+  border-top: 1px solid var(--app-border-soft);
+}
+
+.idt-domain-remediation-item:first-child {
+  border-top: 0;
+}
+
+.idt-domain-remediation-main {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.65rem;
+  min-width: 0;
+}
+
+.idt-domain-remediation-title {
+  margin: 0;
+  color: #ffffff;
+  font-size: 0.92rem;
+  font-weight: 800;
+}
+
+.idt-domain-remediation-detail {
+  margin: 0.18rem 0 0;
+  color: var(--app-muted);
+  font-size: 0.82rem;
+}
+
+.idt-domain-remediation-aside {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.42rem;
+}
+
+.idt-domain-remediation-owner {
+  color: var(--app-dim);
+  font-size: 0.74rem;
+  font-weight: 800;
+}
+
+.idt-domain-remediation-queue-empty {
+  padding: 0.5rem;
+  background: transparent;
+  border: 0;
+}
+
+.idt-domain-sort-control {
+  display: inline-flex;
+  align-items: end;
+  gap: 0.5rem;
+}
+
+.idt-domain-sort-control label {
+  display: grid;
+  gap: 0.25rem;
+  color: var(--app-muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.idt-domain-sort-control select {
+  min-height: 2.35rem;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 0.52rem 0.62rem;
+  background: #050505;
+  color: #ffffff;
+  font: inherit;
+}
+
+.idt-domain-sort-control select:focus-visible {
+  border-color: #ffffff;
+  outline: none;
+}
+
+.idt-domain-sort-direction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.35rem;
+  height: 2.35rem;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: #050505;
+  color: #ffffff;
+  font-size: 0.95rem;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.idt-domain-sort-direction:hover,
+.idt-domain-sort-direction:focus-visible {
+  border-color: #ffffff;
+  outline: none;
+}
+
+.idt-domain-drawer-root {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.idt-domain-drawer-scrim {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  padding: 0;
+  background: rgba(0, 0, 0, 0.62);
+  cursor: pointer;
+}
+
+.idt-domain-drawer {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: min(28rem, 100%);
+  max-height: 100%;
+  border-left: 1px solid var(--app-border);
+  background: #080809;
+  color: var(--app-text);
+  box-shadow: -16px 0 32px rgba(0, 0, 0, 0.32);
+}
+
+.idt-domain-drawer header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-bottom: 1px solid var(--app-border-soft);
+}
+
+.idt-domain-drawer header h3 {
+  margin: 0.18rem 0 0;
+  color: #ffffff;
+  font-family: var(--idt-display);
+  font-size: 1.05rem;
+  line-height: 1.1;
+}
+
+.idt-domain-drawer-close {
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: #050505;
+  color: #ffffff;
+  font-size: 1.1rem;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.idt-domain-drawer-close:hover,
+.idt-domain-drawer-close:focus-visible {
+  border-color: #ffffff;
+  outline: none;
+}
+
+.idt-domain-drawer-body {
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: 1rem;
+  color: var(--app-text);
+}
+
+.idt-domain-drawer footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.55rem;
+  border-top: 1px solid var(--app-border-soft);
+  padding: 0.85rem 1rem;
+}
+
+@media (max-width: 720px) {
+  .idt-domain-graph-placeholder {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-domain-timeline-row {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-domain-timeline-actor {
+    justify-self: start;
+  }
+
+  .idt-domain-remediation-item {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-domain-remediation-aside {
+    align-items: flex-start;
+  }
+}
+
 .idt-app-header-stack,
 .idt-app-header-meta,
 .idt-overview-source-strip {


### PR DESCRIPTION
Fixes #1381.

## Summary

Extend the shared `DomainFoundation` framework with the data-presentation and operational-status primitives the upcoming AWS, GitHub, and Kubernetes domain pages will reuse. No domain content is migrated in this PR — only the primitives.

- Typed `DomainStatusBadge` for the seven operational states the issue calls out (`connected`, `disconnected`, `needs-attention`, `degraded`, `running-scan`, `missing-permissions`, `coming-soon`), with semantic tones and a live `running-scan` indicator.
- `DomainCoverageCard` with an accessible `progressbar` keyed to a scanned/total ratio.
- `DomainFindingSummaryCard` keyed to `critical|high|medium|low|info`; renders as `<a>`, `<button>`, or `<article>` based on the props provided.
- `DomainTimeline` rows for scan/activity history.
- `DomainGraphPlaceholder` for the trust-graph slot until cloud collectors fill it.
- `DomainRemediationQueue` with severity, owner, and primary/secondary action affordances per row, and an empty-queue fallback.
- `DomainSortControl` with a direction toggle, pairing with the existing `DomainFilterBar`.
- Focus-trapped `DomainDetailDrawer` for identity/finding detail flows.

`DomainEmptyState` and `DomainErrorState` now accept `nextAction` and `retryAction` slots so the operational empty/error semantics from the issue render as a primary affordance instead of plain copy.

All primitives live in the existing `idt-domain-*` vocabulary so the visual direction stays dense, dark-first, restrained per-domain accent, and free of cards-inside-cards. Mobile widths stack without horizontal overflow.

## Why

PR-4 of the app redesign sequence (#1378 → #1379 → #1380 → **#1381**). The next domain-specific PRs (AWS, GitHub, Kubernetes) will be data-heavy and need the same status/coverage/finding/timeline/graph/remediation patterns. Building these once here prevents each domain page from inventing its own.

## Impact and risk

- Pure additive UI primitives in `web/`. No backend contract changes, no API changes, no migrations.
- No Projects or global Findings concept reintroduced.
- Existing `ProductDomainRoutePage` consumers keep working unchanged — the new primitives are opt-in.

## Validation

- `npm run test:ci --prefix web` — **255 passed** across 16 files. The `DomainFoundation` suite gains 9 new specs covering: typed status badges, empty/error primary-action wiring, coverage progressbar accessibility, finding-card navigation/click variants, timeline list semantics, graph placeholder region, remediation queue actions + empty fallback, sort direction toggle, and drawer open/close.
- `npm run build --prefix web` — clean `tsc` + Vite build, 39 routes prerendered.
- Visual: rendered the full shell on desktop (1440x900) and mobile (375x812). Header, environment selector, `Connected` badge, KPI strip, severity finding cards, collector-status panel with the six new status badges, coverage cards in the aside, and the sticky action footer all render correctly. Mobile stacks cleanly with no horizontal overflow. The throwaway preview route used for capture is **not** included in this PR.

## Screenshots

### Desktop (1440x900) — domain shell, status badges, KPI/coverage/finding cards
The shell renders the AWS logo, eyebrow, title, environment selector, `Connected · Last scan 2m ago` badge, primary/secondary actions, the subnav with nested groups, the KPI strip, four severity finding cards (`Critical`, `High`, `Medium`, `Low`), the collector-health panel with all six operational status badges (`Connected`, `Running scan`, `Needs attention`, `Missing permissions`, `Disconnected`, `Coming soon`), and three coverage cards (`Accounts 100%`, `Roles 88%`, `Agents 17%`) in the aside.

### Mobile (375x812) — domain shell stacks vertically
The same shell collapses to a single column with logo + eyebrow + title + description, the environment selector, the `Connected · Last scan 2m ago` badge, full-width `Connect account` and `Re-scan` actions, and the subnav `Overview / Inventory / Accounts / Identities / …` underneath. No horizontal overflow at 375px.

### Nested / collapsed subsection nav
The subnav's nested group (e.g. GitHub `AI / Agentic Risk`) renders as a native `<details>` element that auto-opens when a descendant is active (verified by the test `auto-opens parent subnav when a nested child is active`) and stays collapsed otherwise.

### Empty + error states (with next action / retry action)
`DomainEmptyState` renders the `Set up runtime` next-action button as the primary affordance; `DomainErrorState` renders `Retry sync` as the primary affordance under `Needs attention`.

## AI-assisted disclosure

- AI-assisted: yes
- Tools used: Claude Code
- Where used: `web/src/components/app/DomainFoundation.tsx`, `web/src/components/app/DomainFoundation.test.tsx`, `web/src/styles.css`, `CHANGELOG.md`
- Human verification performed: `npm run test:ci --prefix web`, `npm run build --prefix web`, manual desktop + mobile preview of the full primitive set, and inline review of every new component for accessibility (`role`, `aria-label`, `aria-current`, `aria-valuenow`, focus order) and CSS specificity against the existing `idt-domain-*` tokens.

## Test plan

- [x] `npm run test:ci --prefix web`
- [x] `npm run build --prefix web`
- [x] Visual desktop check (1440x900) of header, status badges, KPI/coverage/finding cards, action footer
- [x] Visual mobile check (375x812) of stacked shell + subnav
- [x] Confirmed no Projects or global Findings copy reintroduced

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds reusable domain page primitives to `DomainFoundation` for the redesigned app shell across AWS, GitHub, and Kubernetes, and makes the `DomainDetailDrawer` truly modal with focus trap, Escape-to-close, and focus restore. Pure additive UI; aligns with Linear #1381 (seven operational states and action-first empty/error).

- **New Features**
  - New primitives: `DomainStatusBadge` (7 states with tones and live scan), `DomainCoverageCard` (a11y progress), `DomainFindingSummaryCard` (severity; link/button/article), `DomainTimeline`, `DomainGraphPlaceholder`, `DomainRemediationQueue` (owner + actions + empty), `DomainSortControl` (direction toggle), `DomainDetailDrawer`.
  - Updated states: `DomainEmptyState` and `DomainErrorState` now surface `nextAction`/`retryAction` as primary controls.
  - Styling/UX: dense, dark-first `idt-domain-*` tokens; mobile stacks cleanly; no cards-inside-cards.
  - Scope: additive UI only in `web/`; no backend or API changes; existing consumers remain unchanged.

- **Bug Fixes**
  - `DomainDetailDrawer`: traps focus, closes on Escape, restores focus to opener; scrim is `aria-hidden` and non-focusable.

<sup>Written for commit fa3172cb36f9b1d5d1b8abd1c6a1d966cfa96f5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1434?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

