### PR TITLE
Self-serve account permanent delete with 30-day grace and hard-delete worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Changelog
 
 ## Unreleased
+- Added self-serve account permanent deletion with a 30-day reversible grace
+  window. `DELETE /v1/me` soft-deletes the authenticated user (status flips to
+  `deleted`, `deleted_at` is stamped, every session is revoked, the cookie is
+  cleared) and returns the scheduled hard-delete date. `POST /v1/me/cancel-deletion`
+  reverses the soft-delete during the grace window. The endpoints refuse with a
+  structured `409 sole_owner` listing affected workspaces when the user is the
+  sole owner of any workspace, so deletion never orphans an unowned tenant.
+  WorkOS sign-in with `intent=login` against a soft-deleted account is refused
+  with `ErrAuthAccountPendingDeletion` (mapped to `403 account_pending_deletion`)
+  so the frontend can offer cancellation; a new `intent=cancel_deletion` revives
+  the row server-side as part of the sign-in. A daily worker pass
+  (`IDENTRAIL_WORKER_USER_PURGE_ENABLED`, default on) hard-deletes accounts past
+  the grace window: PII is tombstoned (synthetic `deleted-user+<uuid>` email,
+  display name and avatar cleared), provider identities and session rows are
+  removed, the users row stays so audit references by UUID remain valid. The
+  pass is idempotent — already-tombstoned rows are filtered out so re-running
+  is a no-op. New audit actions: `auth.account.delete`, `auth.account.delete.cancel`,
+  `auth.account.pending_deletion`, `auth.user.delete`, `auth.user.delete.cancel`,
+  `auth.user.hard_delete`.
 - Renamed the hosted API production release workflow to `Deploy to prod` and
   made the normal release path one-click from the `dev` branch. The workflow now
   resolves the current commit's immutable API and worker image tags, verifies CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@
 ## Unreleased
 - Added self-serve account permanent deletion with a 30-day reversible grace
   window. `DELETE /v1/me` soft-deletes the authenticated user (status flips to
-  `deleted`, `deleted_at` is stamped, every session is revoked, the cookie is
-  cleared) and returns the scheduled hard-delete date. `POST /v1/me/cancel-deletion`
-  reverses the soft-delete during the grace window. The endpoints refuse with a
+  `deleted`, `deleted_at` is stamped, every other session is revoked, and the
+  sole-owner workspace check is rerun atomically after the write to close the
+  pre-flight race) and returns the scheduled hard-delete date. The calling
+  cookie is intentionally preserved as the recovery cookie: every other route
+  refuses it (status is no longer `active`) but `POST /v1/me/cancel-deletion`
+  accepts it through a path-scoped lenient session lookup so the user can
+  reverse the deletion from the same browser without re-authenticating. The endpoints refuse with a
   structured `409 sole_owner` listing affected workspaces when the user is the
   sole owner of any workspace, so deletion never orphans an unowned tenant.
   WorkOS sign-in with `intent=login` against a soft-deleted account is refused

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -1560,13 +1560,18 @@ paths:
           $ref: "#/components/responses/Unauthorized"
     delete:
       tags: [Authorization]
-      summary: Permanently delete the current user account
+      summary: Schedule the current user account for permanent deletion
       description: |
         Soft-deletes the authenticated user account: transitions status to
-        `deleted`, stamps `deleted_at`, revokes every active session, clears
-        the session cookie, and schedules a hard-delete worker pass 30 days
-        out. Idempotent — a repeat call against an already-deleted account
-        returns the originally-scheduled `hard_delete_after` timestamp.
+        `deleted`, stamps `deleted_at`, revokes every other active session,
+        soft-deletes the row, and schedules a hard-delete worker pass 30 days
+        out. The calling session is intentionally preserved as the recovery
+        cookie — every other route refuses it (status is no longer `active`)
+        but `POST /v1/me/cancel-deletion` accepts it through a lenient
+        session lookup so the user can reverse the deletion from the same
+        browser without needing to re-authenticate. Idempotent — a repeat
+        call against an already-deleted account returns the
+        originally-scheduled `hard_delete_after` timestamp.
 
         Returns 409 with code `sole_owner` and the affected workspaces when
         the account is the sole owner of one or more workspaces, so ownership

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -175,6 +175,14 @@ x-identrail-route-authorizations:
     path: /v1/me/reactivate
     action: me.write
     resource_type: user
+  - method: DELETE
+    path: /v1/me
+    action: me.write
+    resource_type: user
+  - method: POST
+    path: /v1/me/cancel-deletion
+    action: me.write
+    resource_type: user
   - method: POST
     path: /v1/onboarding/start
     action: onboarding.write
@@ -1550,6 +1558,109 @@ paths:
                     $ref: "#/components/schemas/CurrentUserContext"
         "401":
           $ref: "#/components/responses/Unauthorized"
+    delete:
+      tags: [Authorization]
+      summary: Permanently delete the current user account
+      description: |
+        Soft-deletes the authenticated user account: transitions status to
+        `deleted`, stamps `deleted_at`, revokes every active session, clears
+        the session cookie, and schedules a hard-delete worker pass 30 days
+        out. Idempotent — a repeat call against an already-deleted account
+        returns the originally-scheduled `hard_delete_after` timestamp.
+
+        Returns 409 with code `sole_owner` and the affected workspaces when
+        the account is the sole owner of one or more workspaces, so ownership
+        must be transferred before deletion can proceed.
+      operationId: deleteCurrentUser
+      security:
+        - CookieAuth: []
+      responses:
+        "200":
+          description: Account scheduled for permanent deletion
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: [deleted]
+                  deleted_at:
+                    type: string
+                    format: date-time
+                  hard_delete_after:
+                    type: string
+                    format: date-time
+                  grace_period_hours:
+                    type: integer
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          description: Account is sole owner of one or more workspaces
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                    enum: [sole_owner]
+                  workspaces:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        tenant_id:
+                          type: string
+                        workspace_id:
+                          type: string
+                        display_name:
+                          type: string
+                        slug:
+                          type: string
+  /v1/me/cancel-deletion:
+    parameters:
+      - $ref: "#/components/parameters/scopeTenantID"
+      - $ref: "#/components/parameters/scopeWorkspaceID"
+    post:
+      tags: [Authorization]
+      summary: Cancel a pending account deletion
+      description: |
+        Reverses a pending soft-delete during the 30-day grace window:
+        transitions status back to `active` and clears `deleted_at`. Requires
+        a signed-in session; the typical flow for a signed-out deleted user is
+        to re-authenticate through the WorkOS `cancel_deletion` intent.
+        Returns 410 once the grace window has elapsed.
+      operationId: cancelCurrentUserDeletion
+      security:
+        - CookieAuth: []
+      responses:
+        "200":
+          description: Deletion cancelled, account reactivated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: [active]
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "410":
+          description: Grace period has expired
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                    enum: [grace_period_expired]
   /v1/me/sessions:
     parameters:
       - $ref: "#/components/parameters/scopeTenantID"

--- a/internal/api/auth/session.go
+++ b/internal/api/auth/session.go
@@ -35,6 +35,12 @@ type Manager struct {
 	Store         db.Store
 	PublicBaseURL string
 	Now           func() time.Time
+	// PendingDeletionPaths lists request paths that may accept session
+	// cookies belonging to a soft-deleted-within-grace user. The default is
+	// the strict policy (every path refuses deleted users); the router opts
+	// in `/v1/me/cancel-deletion` so the post-delete recovery flow can reach
+	// its handler. Keys are exact match against `r.URL.Path`.
+	PendingDeletionPaths map[string]struct{}
 }
 
 func (m Manager) now() time.Time {
@@ -105,7 +111,10 @@ func (m Manager) CreateSession(ctx context.Context, session db.Session) (string,
 	return cookieValue, saved, nil
 }
 
-// LookupRequest resolves the request cookie into a current session.
+// LookupRequest resolves the request cookie into a current session. When the
+// request path is on the Manager's pending-deletion allowlist, the lookup uses
+// the lenient TouchSessionAllowingPendingDeletion variant so users in their
+// soft-delete grace window can reach the recovery endpoint.
 func (m Manager) LookupRequest(r *http.Request) (CurrentSession, error) {
 	if m.Store == nil || r == nil {
 		return CurrentSession{}, db.ErrNotFound
@@ -118,11 +127,20 @@ func (m Manager) LookupRequest(r *http.Request) (CurrentSession, error) {
 	if err != nil {
 		return CurrentSession{}, err
 	}
-	session, err := m.Store.TouchSession(r.Context(), hash, m.now())
+	session, err := m.touch(r, hash)
 	if err != nil {
 		return CurrentSession{}, err
 	}
 	return CurrentSession{Session: session, IDHash: hash}, nil
+}
+
+func (m Manager) touch(r *http.Request, hash []byte) (db.Session, error) {
+	if r != nil && m.PendingDeletionPaths != nil {
+		if _, ok := m.PendingDeletionPaths[r.URL.Path]; ok {
+			return m.Store.TouchSessionAllowingPendingDeletion(r.Context(), hash, m.now())
+		}
+	}
+	return m.Store.TouchSession(r.Context(), hash, m.now())
 }
 
 // Cookie returns the Set-Cookie value for a live session.

--- a/internal/api/auth/session.go
+++ b/internal/api/auth/session.go
@@ -135,7 +135,11 @@ func (m Manager) LookupRequest(r *http.Request) (CurrentSession, error) {
 }
 
 func (m Manager) touch(r *http.Request, hash []byte) (db.Session, error) {
-	if r != nil && m.PendingDeletionPaths != nil {
+	// r and r.URL are both guarded: callers from production go through
+	// `http.Request` instances whose URL is always populated, but defensive
+	// programming here keeps a malformed or synthetic *http.Request from
+	// panicking in the middleware path.
+	if r != nil && r.URL != nil && m.PendingDeletionPaths != nil {
 		if _, ok := m.PendingDeletionPaths[r.URL.Path]; ok {
 			return m.Store.TouchSessionAllowingPendingDeletion(r.Context(), hash, m.now())
 		}

--- a/internal/api/auth/session_test.go
+++ b/internal/api/auth/session_test.go
@@ -243,3 +243,78 @@ func TestMiddlewareOnlyAddsActiveWorkspaceMemberRole(t *testing.T) {
 		t.Fatalf("expected authenticated role to remain, got %s", w.Body.String())
 	}
 }
+
+func TestMiddlewareLenientLookupAcceptsPendingDeletionUserOnAllowlistedPath(t *testing.T) {
+	// The PendingDeletionPaths allowlist routes the cookie lookup through
+	// TouchSessionAllowingPendingDeletion, so a soft-deleted-within-grace
+	// user can still reach the recovery endpoint while every other path
+	// keeps refusing.
+	gin.SetMode(gin.TestMode)
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	user, err := store.UpsertUser(context.Background(), db.User{
+		ID:           "11111111-1111-1111-1111-111111111111",
+		PrimaryEmail: "alice@example.com",
+		CreatedAt:    now,
+	})
+	if err != nil {
+		t.Fatalf("upsert user: %v", err)
+	}
+	manager := Manager{
+		Store: store,
+		Now:   func() time.Time { return now },
+		PendingDeletionPaths: map[string]struct{}{
+			"/recovery": {},
+		},
+	}
+	cookieValue, _, err := manager.CreateSession(context.Background(), db.Session{
+		UserID:     user.ID,
+		AuthMethod: "manual",
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	// Flip the user to soft-deleted-within-grace AFTER session creation; the
+	// strict TouchSession would refuse the cookie now.
+	deletedAt := now.Add(-time.Hour)
+	if _, err := store.SoftDeleteUser(context.Background(), user.ID, deletedAt); err != nil {
+		t.Fatalf("soft delete: %v", err)
+	}
+
+	router := gin.New()
+	router.Use(manager.Middleware())
+	router.GET("/recovery", func(c *gin.Context) {
+		current, ok := CurrentFromGin(c)
+		if !ok {
+			c.String(http.StatusUnauthorized, "no session")
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"user_id": current.Session.UserID})
+	})
+	router.GET("/strict", func(c *gin.Context) {
+		current, ok := CurrentFromGin(c)
+		if !ok {
+			c.String(http.StatusUnauthorized, "no session")
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"user_id": current.Session.UserID})
+	})
+
+	// Allowlisted path: the lenient lookup admits the deleted-within-grace user.
+	recoveryReq := httptest.NewRequest(http.MethodGet, "/recovery", nil)
+	recoveryReq.AddCookie(manager.Cookie(cookieValue))
+	recoveryResp := httptest.NewRecorder()
+	router.ServeHTTP(recoveryResp, recoveryReq)
+	if recoveryResp.Code != http.StatusOK {
+		t.Fatalf("expected lenient lookup 200, got %d body=%s", recoveryResp.Code, recoveryResp.Body.String())
+	}
+
+	// Strict path: the standard TouchSession refuses the deleted user.
+	strictReq := httptest.NewRequest(http.MethodGet, "/strict", nil)
+	strictReq.AddCookie(manager.Cookie(cookieValue))
+	strictResp := httptest.NewRecorder()
+	router.ServeHTTP(strictResp, strictReq)
+	if strictResp.Code != http.StatusUnauthorized {
+		t.Fatalf("expected strict lookup 401, got %d body=%s", strictResp.Code, strictResp.Body.String())
+	}
+}

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -464,6 +464,10 @@ func completeWorkOSLogin(c *gin.Context, logger *zap.Logger, svc *Service, manag
 			writeWorkOSLoginFailure(c, opts, failureMode, state.ReturnTo, authFailureReasonReactivationNeeded, http.StatusForbidden, "account reactivation requires signup")
 			return "", false
 		}
+		if errors.Is(err, ErrAuthAccountPendingDeletion) {
+			writeWorkOSLoginFailure(c, opts, failureMode, state.ReturnTo, authFailureReasonAccountDeleted, http.StatusForbidden, "account is scheduled for permanent deletion")
+			return "", false
+		}
 		if logger != nil {
 			logger.Error("upsert workos user", telemetry.ZapError(err))
 		}
@@ -1415,6 +1419,163 @@ func registerMeRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service, man
 			}
 		}
 		auditAuthAction(c.Request.Context(), "auth.account.reactivate", user.ID, "success")
+		c.JSON(http.StatusOK, gin.H{"status": "active"})
+	})
+
+	v1.DELETE("/me", func(c *gin.Context) {
+		current, ok := sessionauth.CurrentFromGin(c)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "session required"})
+			return
+		}
+		now := time.Now().UTC()
+		if svc.Now != nil {
+			now = svc.Now().UTC()
+		}
+		user, err := svc.Store.GetUser(c.Request.Context(), current.Session.UserID)
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+				return
+			}
+			if logger != nil {
+				logger.Error("delete account get user", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete account"})
+			return
+		}
+		if user.Status == "deleted" {
+			// Idempotent: a repeat DELETE returns the originally-scheduled
+			// purge date so the UI does not silently extend the window.
+			scheduled := time.Time{}
+			if user.DeletedAt != nil {
+				scheduled = user.DeletedAt.UTC().Add(db.UserDeletionGracePeriod)
+			}
+			c.JSON(http.StatusOK, gin.H{
+				"status":             "deleted",
+				"deleted_at":         user.DeletedAt,
+				"hard_delete_after":  scheduled,
+				"grace_period_hours": int(db.UserDeletionGracePeriod / time.Hour),
+			})
+			return
+		}
+		// Sole-owner check runs before any state mutation: a 409 here must
+		// leave the account untouched so the user can transfer ownership and
+		// retry. Returning the workspaces in the body lets the UI render the
+		// transfer prompt without a second round-trip.
+		soleOwned, err := svc.Store.ListSoleOwnerWorkspaces(c.Request.Context(), user.ID)
+		if err != nil {
+			if logger != nil {
+				logger.Error("delete account sole owner lookup", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete account"})
+			return
+		}
+		if len(soleOwned) > 0 {
+			workspaces := make([]gin.H, 0, len(soleOwned))
+			for _, ws := range soleOwned {
+				workspaces = append(workspaces, gin.H{
+					"tenant_id":    ws.TenantID,
+					"workspace_id": ws.WorkspaceID,
+					"display_name": ws.DisplayName,
+					"slug":         ws.Slug,
+				})
+			}
+			auditAuthAction(c.Request.Context(), "auth.account.delete", user.ID, "denied")
+			c.JSON(http.StatusConflict, gin.H{
+				"error":      "user is the sole owner of one or more workspaces",
+				"code":       "sole_owner",
+				"workspaces": workspaces,
+			})
+			return
+		}
+		// Mirror the deactivate three-step sandwich: revoke sessions, persist
+		// the soft-delete (with deleted_at), revoke again. Step 3 closes the
+		// race where a concurrent sign-in committed a new session row in the
+		// gap between (1) and (2), since the deletion check happens at sign-in
+		// rather than session creation for the cancel_deletion intent.
+		if _, err := svc.Store.RevokeAllUserSessions(c.Request.Context(), user.ID, now); err != nil {
+			if logger != nil {
+				logger.Error("delete account revoke sessions", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete account"})
+			return
+		}
+		saved, err := svc.Store.SoftDeleteUser(c.Request.Context(), user.ID, now)
+		if err != nil {
+			if logger != nil {
+				logger.Error("delete account soft delete", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete account"})
+			return
+		}
+		if _, err := svc.Store.RevokeAllUserSessions(c.Request.Context(), user.ID, now); err != nil {
+			if logger != nil {
+				logger.Error("delete account revoke sessions post-status", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete account"})
+			return
+		}
+		auditAuthAction(c.Request.Context(), "auth.account.delete", saved.ID, "success")
+		http.SetCookie(c.Writer, manager.ClearCookie())
+		hardDeleteAfter := now.Add(db.UserDeletionGracePeriod)
+		if saved.DeletedAt != nil {
+			hardDeleteAfter = saved.DeletedAt.UTC().Add(db.UserDeletionGracePeriod)
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"status":             "deleted",
+			"deleted_at":         saved.DeletedAt,
+			"hard_delete_after":  hardDeleteAfter,
+			"grace_period_hours": int(db.UserDeletionGracePeriod / time.Hour),
+		})
+	})
+
+	v1.POST("/me/cancel-deletion", func(c *gin.Context) {
+		current, ok := sessionauth.CurrentFromGin(c)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "session required"})
+			return
+		}
+		now := time.Now().UTC()
+		if svc.Now != nil {
+			now = svc.Now().UTC()
+		}
+		user, err := svc.Store.GetUser(c.Request.Context(), current.Session.UserID)
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+				return
+			}
+			if logger != nil {
+				logger.Error("cancel deletion get user", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to cancel deletion"})
+			return
+		}
+		// Past the grace window the worker is authoritative for the purge; the
+		// API must refuse so a stale UI cannot resurrect an account the user
+		// already lost the option to keep.
+		if user.DeletedAt != nil && userDeletionGraceExpired(user, now) {
+			auditAuthAction(c.Request.Context(), "auth.user.delete.cancel", user.ID, "denied")
+			c.JSON(http.StatusGone, gin.H{
+				"error": "deletion grace period has expired",
+				"code":  "grace_period_expired",
+			})
+			return
+		}
+		if user.Status == "active" && user.DeletedAt == nil {
+			c.JSON(http.StatusOK, gin.H{"status": "active"})
+			return
+		}
+		saved, err := svc.Store.CancelUserDeletion(c.Request.Context(), user.ID, now)
+		if err != nil {
+			if logger != nil {
+				logger.Error("cancel deletion store", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to cancel deletion"})
+			return
+		}
+		auditAuthAction(c.Request.Context(), "auth.account.delete.cancel", saved.ID, "success")
 		c.JSON(http.StatusOK, gin.H{"status": "active"})
 	})
 }

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -1444,21 +1444,12 @@ func registerMeRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service, man
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete account"})
 			return
 		}
-		if user.Status == "deleted" {
-			// Idempotent: a repeat DELETE returns the originally-scheduled
-			// purge date so the UI does not silently extend the window.
-			scheduled := time.Time{}
-			if user.DeletedAt != nil {
-				scheduled = user.DeletedAt.UTC().Add(db.UserDeletionGracePeriod)
-			}
-			c.JSON(http.StatusOK, gin.H{
-				"status":             "deleted",
-				"deleted_at":         user.DeletedAt,
-				"hard_delete_after":  scheduled,
-				"grace_period_hours": int(db.UserDeletionGracePeriod / time.Hour),
-			})
-			return
-		}
+		// Repeat-call idempotency: a soft-deleted user's cookie cannot reach
+		// this strict-mode route — TouchSession refuses pending-deletion
+		// sessions, and the cancel-deletion route is the only one in the
+		// lenient PendingDeletionPaths allowlist. The store-level COALESCE in
+		// SoftDeleteUser still guarantees that a concurrent re-entry preserves
+		// the original deleted_at and therefore the hard-delete deadline.
 		// First sole-owner check: cheap pre-flight that returns the structured
 		// 409 to the UI immediately when ownership transfer is already
 		// required. The authoritative check happens after the soft-delete
@@ -1529,8 +1520,16 @@ func registerMeRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service, man
 			return
 		}
 		if len(soleOwnedAfter) > 0 {
-			if _, err := svc.Store.CancelUserDeletion(c.Request.Context(), saved.ID, now); err != nil && logger != nil {
-				logger.Error("delete account rollback after sole-owner race", telemetry.ZapError(err))
+			if _, cancelErr := svc.Store.CancelUserDeletion(c.Request.Context(), saved.ID, now); cancelErr != nil {
+				// Rollback failed — the account is still soft-deleted but we
+				// cannot honor the sole-owner contract for the caller. Surface
+				// 500 instead of 409 so the client does not conclude the
+				// account is still active when it is not.
+				if logger != nil {
+					logger.Error("delete account rollback after sole-owner race", telemetry.ZapError(cancelErr))
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete account"})
+				return
 			}
 			workspaces := make([]gin.H, 0, len(soleOwnedAfter))
 			for _, ws := range soleOwnedAfter {

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -1459,10 +1459,10 @@ func registerMeRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service, man
 			})
 			return
 		}
-		// Sole-owner check runs before any state mutation: a 409 here must
-		// leave the account untouched so the user can transfer ownership and
-		// retry. Returning the workspaces in the body lets the UI render the
-		// transfer prompt without a second round-trip.
+		// First sole-owner check: cheap pre-flight that returns the structured
+		// 409 to the UI immediately when ownership transfer is already
+		// required. The authoritative check happens after the soft-delete
+		// below to close the race window.
 		soleOwned, err := svc.Store.ListSoleOwnerWorkspaces(c.Request.Context(), user.ID)
 		if err != nil {
 			if logger != nil {
@@ -1489,12 +1489,16 @@ func registerMeRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service, man
 			})
 			return
 		}
-		// Mirror the deactivate three-step sandwich: revoke sessions, persist
-		// the soft-delete (with deleted_at), revoke again. Step 3 closes the
-		// race where a concurrent sign-in committed a new session row in the
-		// gap between (1) and (2), since the deletion check happens at sign-in
-		// rather than session creation for the cancel_deletion intent.
-		if _, err := svc.Store.RevokeAllUserSessions(c.Request.Context(), user.ID, now); err != nil {
+		// Revoke every OTHER session and persist the soft-delete. The calling
+		// session is intentionally preserved so the user can still reach
+		// `/v1/me/cancel-deletion` from the same browser within the grace
+		// window — that route is mounted with the lenient
+		// `TouchSessionAllowingPendingDeletion` lookup and accepts cookies
+		// belonging to deleted-within-grace users. The "active" guarantee
+		// from the issue still holds for every other device: their session
+		// rows are revoked here, and a sign-in attempt from anywhere is
+		// refused with `account_pending_deletion` regardless of cookie state.
+		if _, err := svc.Store.RevokeOtherUserSessions(c.Request.Context(), user.ID, current.IDHash, now); err != nil {
 			if logger != nil {
 				logger.Error("delete account revoke sessions", telemetry.ZapError(err))
 			}
@@ -1509,7 +1513,46 @@ func registerMeRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service, man
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete account"})
 			return
 		}
-		if _, err := svc.Store.RevokeAllUserSessions(c.Request.Context(), user.ID, now); err != nil {
+		// Authoritative sole-owner re-check: between the pre-flight and the
+		// soft-delete a concurrent membership change (another owner being
+		// removed, or this user being promoted to owner of a new workspace)
+		// can leave the account as a fresh sole owner. Detect it and revert
+		// the soft delete, restoring sessions is impractical so we surface
+		// 409 and rely on the caller to re-sign-in to recover the session
+		// (which will succeed since status is back to active).
+		soleOwnedAfter, recheckErr := svc.Store.ListSoleOwnerWorkspaces(c.Request.Context(), user.ID)
+		if recheckErr != nil {
+			if logger != nil {
+				logger.Error("delete account sole owner re-check", telemetry.ZapError(recheckErr))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete account"})
+			return
+		}
+		if len(soleOwnedAfter) > 0 {
+			if _, err := svc.Store.CancelUserDeletion(c.Request.Context(), saved.ID, now); err != nil && logger != nil {
+				logger.Error("delete account rollback after sole-owner race", telemetry.ZapError(err))
+			}
+			workspaces := make([]gin.H, 0, len(soleOwnedAfter))
+			for _, ws := range soleOwnedAfter {
+				workspaces = append(workspaces, gin.H{
+					"tenant_id":    ws.TenantID,
+					"workspace_id": ws.WorkspaceID,
+					"display_name": ws.DisplayName,
+					"slug":         ws.Slug,
+				})
+			}
+			auditAuthAction(c.Request.Context(), "auth.account.delete", user.ID, "denied")
+			c.JSON(http.StatusConflict, gin.H{
+				"error":      "user became sole owner of one or more workspaces concurrently with deletion",
+				"code":       "sole_owner",
+				"workspaces": workspaces,
+			})
+			return
+		}
+		// Second-pass other-session revoke closes the race where a concurrent
+		// sign-in committed a new session row in the gap between the first
+		// revoke and the status flip.
+		if _, err := svc.Store.RevokeOtherUserSessions(c.Request.Context(), user.ID, current.IDHash, now); err != nil {
 			if logger != nil {
 				logger.Error("delete account revoke sessions post-status", telemetry.ZapError(err))
 			}
@@ -1517,7 +1560,10 @@ func registerMeRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service, man
 			return
 		}
 		auditAuthAction(c.Request.Context(), "auth.account.delete", saved.ID, "success")
-		http.SetCookie(c.Writer, manager.ClearCookie())
+		// The calling session's cookie is intentionally not cleared: it is
+		// the recovery cookie that the cancel-deletion route accepts via
+		// `TouchSessionAllowingPendingDeletion`. The cookie is invalidated
+		// server-side when the hard-delete worker purges the session row.
 		hardDeleteAfter := now.Add(db.UserDeletionGracePeriod)
 		if saved.DeletedAt != nil {
 			hardDeleteAfter = saved.DeletedAt.UTC().Add(db.UserDeletionGracePeriod)

--- a/internal/api/auth_session_test.go
+++ b/internal/api/auth_session_test.go
@@ -854,6 +854,21 @@ func TestCurrentSessionCancelDeletionViaRecoveryCookieAfterDelete(t *testing.T) 
 	if deleteResp.Code != http.StatusOK {
 		t.Fatalf("expected delete 200, got %d body=%s", deleteResp.Code, deleteResp.Body.String())
 	}
+	// The recovery cookie must NOT be cleared on DELETE — if the handler
+	// regresses to issuing `manager.ClearCookie()` here, the browser drops
+	// the cookie and the subsequent cancel-deletion request can no longer
+	// authenticate. Asserting on the Set-Cookie header pins that contract.
+	for _, setCookie := range deleteResp.Header().Values("Set-Cookie") {
+		if strings.HasPrefix(setCookie, sessionauth.CookieName+"=;") {
+			t.Fatalf("DELETE /v1/me must not clear the recovery cookie, got Set-Cookie=%q", setCookie)
+		}
+		// A zeroed MaxAge or a far-past Expires also clears the cookie in
+		// most browsers; treat either as a regression.
+		if strings.Contains(setCookie, sessionauth.CookieName+"=") &&
+			(strings.Contains(setCookie, "Max-Age=0") || strings.Contains(setCookie, "Max-Age=-1")) {
+			t.Fatalf("DELETE /v1/me must not zero the cookie max-age, got Set-Cookie=%q", setCookie)
+		}
+	}
 	cancelResp := httptest.NewRecorder()
 	harness.router.ServeHTTP(cancelResp, cancelDeletionRequest(cookieValue))
 	if cancelResp.Code != http.StatusOK {

--- a/internal/api/auth_session_test.go
+++ b/internal/api/auth_session_test.go
@@ -830,16 +830,45 @@ func TestCurrentSessionDeleteAccountSchedulesPurgeAndRevokesSessions(t *testing.
 	if !strings.Contains(w.Body.String(), `"hard_delete_after"`) {
 		t.Fatalf("expected hard_delete_after in body, got %s", w.Body.String())
 	}
-	if !strings.Contains(w.Header().Get("Set-Cookie"), sessionauth.CookieName+"=;") {
-		t.Fatalf("expected delete to clear session cookie, got %q", w.Header().Get("Set-Cookie"))
-	}
-	// Cookie should be revoked at the store layer too.
+	// The calling cookie is intentionally preserved as the recovery cookie:
+	// strict-mode routes still refuse it (status=deleted), but the
+	// pending-deletion-allowlisted cancel-deletion route accepts it.
 	meReq := httptest.NewRequest(http.MethodGet, "/v1/me", nil)
 	meReq.AddCookie(&http.Cookie{Name: sessionauth.CookieName, Value: cookieValue})
 	meW := httptest.NewRecorder()
 	harness.router.ServeHTTP(meW, meReq)
 	if meW.Code != http.StatusUnauthorized {
 		t.Fatalf("expected /v1/me 401 after delete, got %d body=%s", meW.Code, meW.Body.String())
+	}
+}
+
+func TestCurrentSessionCancelDeletionViaRecoveryCookieAfterDelete(t *testing.T) {
+	// Cubic review (#1435): DELETE /v1/me must leave the recovery cookie
+	// usable for the cancel-deletion endpoint, otherwise the documented
+	// post-delete reversal path is unreachable from the browser that did the
+	// deletion. The lenient TouchSessionAllowingPendingDeletion lookup mounted
+	// only on this route makes the cookie work within the grace window.
+	harness, cookieValue, _ := setupSessionRouter(t)
+	deleteResp := httptest.NewRecorder()
+	harness.router.ServeHTTP(deleteResp, deleteAccountRequest(cookieValue))
+	if deleteResp.Code != http.StatusOK {
+		t.Fatalf("expected delete 200, got %d body=%s", deleteResp.Code, deleteResp.Body.String())
+	}
+	cancelResp := httptest.NewRecorder()
+	harness.router.ServeHTTP(cancelResp, cancelDeletionRequest(cookieValue))
+	if cancelResp.Code != http.StatusOK {
+		t.Fatalf("expected cancel-deletion 200 via recovery cookie, got %d body=%s", cancelResp.Code, cancelResp.Body.String())
+	}
+	if !strings.Contains(cancelResp.Body.String(), `"status":"active"`) {
+		t.Fatalf("expected active status in body, got %s", cancelResp.Body.String())
+	}
+	// After cancellation the cookie regains full access; /v1/me must succeed.
+	meReq := httptest.NewRequest(http.MethodGet, "/v1/me", nil)
+	meReq.AddCookie(&http.Cookie{Name: sessionauth.CookieName, Value: cookieValue})
+	meResp := httptest.NewRecorder()
+	harness.router.ServeHTTP(meResp, meReq)
+	if meResp.Code != http.StatusOK {
+		t.Fatalf("expected /v1/me 200 after cancellation, got %d body=%s", meResp.Code, meResp.Body.String())
 	}
 }
 

--- a/internal/api/auth_session_test.go
+++ b/internal/api/auth_session_test.go
@@ -858,16 +858,23 @@ func TestCurrentSessionCancelDeletionViaRecoveryCookieAfterDelete(t *testing.T) 
 	// The recovery cookie must NOT be cleared on DELETE — if the handler
 	// regresses to issuing `manager.ClearCookie()` here, the browser drops
 	// the cookie and the subsequent cancel-deletion request can no longer
-	// authenticate. Asserting on the Set-Cookie header pins that contract.
-	for _, setCookie := range deleteResp.Header().Values("Set-Cookie") {
-		if strings.HasPrefix(setCookie, sessionauth.CookieName+"=;") {
-			t.Fatalf("DELETE /v1/me must not clear the recovery cookie, got Set-Cookie=%q", setCookie)
+	// authenticate. Parse every Set-Cookie via http.Response so we catch
+	// every form of "clear this cookie": empty value, zero/negative MaxAge,
+	// or a past Expires timestamp. A textual MaxAge-only check would miss
+	// the Expires variant, which is exactly the regression worth catching.
+	parsed := (&http.Response{Header: deleteResp.Header()}).Cookies()
+	for _, ck := range parsed {
+		if ck.Name != sessionauth.CookieName {
+			continue
 		}
-		// A zeroed MaxAge or a far-past Expires also clears the cookie in
-		// most browsers; treat either as a regression.
-		if strings.Contains(setCookie, sessionauth.CookieName+"=") &&
-			(strings.Contains(setCookie, "Max-Age=0") || strings.Contains(setCookie, "Max-Age=-1")) {
-			t.Fatalf("DELETE /v1/me must not zero the cookie max-age, got Set-Cookie=%q", setCookie)
+		if ck.Value == "" {
+			t.Fatalf("DELETE /v1/me must not clear the recovery cookie (empty value), got %+v", ck)
+		}
+		if ck.MaxAge < 0 {
+			t.Fatalf("DELETE /v1/me must not negate the cookie MaxAge, got %+v", ck)
+		}
+		if !ck.Expires.IsZero() && !ck.Expires.After(time.Now()) {
+			t.Fatalf("DELETE /v1/me must not set the cookie Expires in the past, got %+v", ck)
 		}
 	}
 	cancelResp := httptest.NewRecorder()

--- a/internal/api/auth_session_test.go
+++ b/internal/api/auth_session_test.go
@@ -85,12 +85,13 @@ func setupSessionRouter(t *testing.T) (*ginlessSessionHarness, string, string) {
 		RateLimitRPM:   1000,
 		RateLimitBurst: 1000,
 	})
-	return &ginlessSessionHarness{router: router, manager: manager}, cookieValue, sessionauth.EncodePublicSessionID(current.ID)
+	return &ginlessSessionHarness{router: router, manager: manager, svc: svc}, cookieValue, sessionauth.EncodePublicSessionID(current.ID)
 }
 
 type ginlessSessionHarness struct {
 	router  http.Handler
 	manager sessionauth.Manager
+	svc     *Service
 }
 
 func TestCurrentSessionMeAndSessionList(t *testing.T) {
@@ -981,44 +982,79 @@ func TestCurrentSessionCancelDeletionPastGraceReturns410(t *testing.T) {
 	}
 }
 
+// raceSoleOwnerStore wraps a db.Store and stages a sole-owner race: the first
+// ListSoleOwnerWorkspaces call (the handler's pre-flight) returns clean, while
+// the second (the authoritative post-soft-delete re-check) returns one
+// workspace — simulating a concurrent membership change between the two
+// checks. Every other Store method delegates to the embedded backend.
+type raceSoleOwnerStore struct {
+	db.Store
+	callCount int
+	racedWith []db.TenancyWorkspace
+}
+
+func (s *raceSoleOwnerStore) ListSoleOwnerWorkspaces(ctx context.Context, userUUID string) ([]db.TenancyWorkspace, error) {
+	s.callCount++
+	if s.callCount == 1 {
+		return nil, nil
+	}
+	return s.racedWith, nil
+}
+
 func TestCurrentSessionDeleteAccountSoleOwnerRaceRollsBack(t *testing.T) {
 	// When the pre-flight sole-owner check is clean but a concurrent
-	// membership change between the pre-flight and the soft-delete leaves
-	// the user as a fresh sole owner, the authoritative re-check fires and
-	// CancelUserDeletion rolls back. Simulate the race by inserting a sole
-	// owner membership AFTER the handler reads the pre-flight result; the
-	// way the handler is layered, simply seeding the sole owner state up
-	// front is sufficient — both checks will see it. To exercise the
-	// re-check branch specifically, seed the user as the only owner BEFORE
-	// the request: the pre-flight already returns 409. To hit the post-write
-	// branch we instead pre-promote AFTER pre-flight, which test harnesses
-	// cannot interleave, so the rollback path is covered indirectly through
-	// the integration test of memory store cancel + re-delete.
+	// membership change leaves the user as a fresh sole owner before the
+	// authoritative re-check, the handler must roll back the soft-delete via
+	// CancelUserDeletion and return 409 sole_owner. Exercises DELETE /v1/me
+	// end-to-end with a wrapping store that stages the race deterministically.
 	harness, cookieValue, _ := setupSessionRouter(t)
-	store, ok := harness.manager.Store.(*db.MemoryStore)
+	inner, ok := harness.svc.Store.(*db.MemoryStore)
 	if !ok {
-		t.Fatalf("expected memory store, got %T", harness.manager.Store)
+		t.Fatalf("expected memory store, got %T", harness.svc.Store)
 	}
-	user, err := store.GetUserByPrimaryEmail(context.Background(), "user@example.com")
+	user, err := inner.GetUserByPrimaryEmail(context.Background(), "user@example.com")
 	if err != nil {
 		t.Fatalf("get user: %v", err)
 	}
-	// Soft-delete then immediately cancel through the store, simulating the
-	// rollback path the handler takes on a race.
-	if _, err := store.SoftDeleteUser(context.Background(), user.ID, time.Now().UTC()); err != nil {
-		t.Fatalf("soft delete: %v", err)
+	racer := &raceSoleOwnerStore{
+		Store: inner,
+		racedWith: []db.TenancyWorkspace{{
+			TenantID:    "tenant-a",
+			WorkspaceID: "workspace-a",
+			DisplayName: "Workspace A",
+			Slug:        "workspace-a",
+		}},
 	}
-	if _, err := store.CancelUserDeletion(context.Background(), user.ID, time.Now().UTC()); err != nil {
-		t.Fatalf("cancel deletion rollback: %v", err)
+	harness.svc.Store = racer
+
+	w := httptest.NewRecorder()
+	harness.router.ServeHTTP(w, deleteAccountRequest(cookieValue))
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected delete 409, got %d body=%s", w.Code, w.Body.String())
 	}
-	refreshed, err := store.GetUser(context.Background(), user.ID)
+	if !strings.Contains(w.Body.String(), `"code":"sole_owner"`) {
+		t.Fatalf("expected sole_owner code in body, got %s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"workspace_id":"workspace-a"`) {
+		t.Fatalf("expected racing workspace in body, got %s", w.Body.String())
+	}
+	if racer.callCount < 2 {
+		t.Fatalf("expected handler to hit pre-flight + re-check sole-owner calls, got %d", racer.callCount)
+	}
+
+	// The handler must have rolled the soft-delete back through CancelUserDeletion.
+	refreshed, err := inner.GetUser(context.Background(), user.ID)
 	if err != nil {
 		t.Fatalf("get refreshed user: %v", err)
 	}
 	if refreshed.Status != "active" || refreshed.DeletedAt != nil {
 		t.Fatalf("expected rolled-back user to be active, got %+v", refreshed)
 	}
-	// And the cookie should resolve again on the strict path.
+
+	// And the cookie should resolve again on the strict path. Restore the
+	// underlying store so the strict /v1/me lookup uses the unwrapped backend
+	// (avoiding the stubbed sole-owner method, which is irrelevant here).
+	harness.svc.Store = inner
 	meReq := httptest.NewRequest(http.MethodGet, "/v1/me", nil)
 	meReq.AddCookie(&http.Cookie{Name: sessionauth.CookieName, Value: cookieValue})
 	meResp := httptest.NewRecorder()

--- a/internal/api/auth_session_test.go
+++ b/internal/api/auth_session_test.go
@@ -936,6 +936,83 @@ func TestCurrentSessionCancelDeletionWhenActiveIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestCurrentSessionCancelDeletionPastGraceReturns410(t *testing.T) {
+	// Once the 30-day grace window has elapsed, the worker is authoritative
+	// for the purge — the API must refuse so a stale UI cannot resurrect an
+	// account the user already lost the option to keep. The fixed harness
+	// clock means we have to seed deleted_at relative to that clock, not
+	// real wall time.
+	harness, cookieValue, _ := setupSessionRouter(t)
+	store, ok := harness.manager.Store.(*db.MemoryStore)
+	if !ok {
+		t.Fatalf("expected memory store, got %T", harness.manager.Store)
+	}
+	user, err := store.GetUserByPrimaryEmail(context.Background(), "user@example.com")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	harnessNow := harness.manager.Now()
+	pastGrace := harnessNow.Add(-(db.UserDeletionGracePeriod + 24*time.Hour))
+	if _, err := store.SoftDeleteUser(context.Background(), user.ID, pastGrace); err != nil {
+		t.Fatalf("seed past-grace soft delete: %v", err)
+	}
+	w := httptest.NewRecorder()
+	harness.router.ServeHTTP(w, cancelDeletionRequest(cookieValue))
+	if w.Code != http.StatusGone {
+		t.Fatalf("expected cancel-deletion 410, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"code":"grace_period_expired"`) {
+		t.Fatalf("expected grace_period_expired code in body, got %s", w.Body.String())
+	}
+}
+
+func TestCurrentSessionDeleteAccountSoleOwnerRaceRollsBack(t *testing.T) {
+	// When the pre-flight sole-owner check is clean but a concurrent
+	// membership change between the pre-flight and the soft-delete leaves
+	// the user as a fresh sole owner, the authoritative re-check fires and
+	// CancelUserDeletion rolls back. Simulate the race by inserting a sole
+	// owner membership AFTER the handler reads the pre-flight result; the
+	// way the handler is layered, simply seeding the sole owner state up
+	// front is sufficient — both checks will see it. To exercise the
+	// re-check branch specifically, seed the user as the only owner BEFORE
+	// the request: the pre-flight already returns 409. To hit the post-write
+	// branch we instead pre-promote AFTER pre-flight, which test harnesses
+	// cannot interleave, so the rollback path is covered indirectly through
+	// the integration test of memory store cancel + re-delete.
+	harness, cookieValue, _ := setupSessionRouter(t)
+	store, ok := harness.manager.Store.(*db.MemoryStore)
+	if !ok {
+		t.Fatalf("expected memory store, got %T", harness.manager.Store)
+	}
+	user, err := store.GetUserByPrimaryEmail(context.Background(), "user@example.com")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	// Soft-delete then immediately cancel through the store, simulating the
+	// rollback path the handler takes on a race.
+	if _, err := store.SoftDeleteUser(context.Background(), user.ID, time.Now().UTC()); err != nil {
+		t.Fatalf("soft delete: %v", err)
+	}
+	if _, err := store.CancelUserDeletion(context.Background(), user.ID, time.Now().UTC()); err != nil {
+		t.Fatalf("cancel deletion rollback: %v", err)
+	}
+	refreshed, err := store.GetUser(context.Background(), user.ID)
+	if err != nil {
+		t.Fatalf("get refreshed user: %v", err)
+	}
+	if refreshed.Status != "active" || refreshed.DeletedAt != nil {
+		t.Fatalf("expected rolled-back user to be active, got %+v", refreshed)
+	}
+	// And the cookie should resolve again on the strict path.
+	meReq := httptest.NewRequest(http.MethodGet, "/v1/me", nil)
+	meReq.AddCookie(&http.Cookie{Name: sessionauth.CookieName, Value: cookieValue})
+	meResp := httptest.NewRecorder()
+	harness.router.ServeHTTP(meResp, meReq)
+	if meResp.Code != http.StatusOK {
+		t.Fatalf("expected /v1/me 200 after rollback, got %d body=%s", meResp.Code, meResp.Body.String())
+	}
+}
+
 func TestCurrentSessionDeactivatedUserCannotReuseCookie(t *testing.T) {
 	// The deactivate handler revokes every session and clears the cookie, but
 	// even if the cookie were replayed before that completes, TouchSession

--- a/internal/api/auth_session_test.go
+++ b/internal/api/auth_session_test.go
@@ -801,6 +801,112 @@ func TestCurrentSessionAccountLifecycleRoutesRequireSession(t *testing.T) {
 	}
 }
 
+// deleteAccountRequest issues DELETE /v1/me with the supplied session cookie.
+func deleteAccountRequest(cookieValue string) *http.Request {
+	req := httptest.NewRequest(http.MethodDelete, "/v1/me", nil)
+	req.Header.Set("Origin", "http://localhost:8080")
+	req.AddCookie(&http.Cookie{Name: sessionauth.CookieName, Value: cookieValue})
+	return req
+}
+
+// cancelDeletionRequest issues POST /v1/me/cancel-deletion with the cookie.
+func cancelDeletionRequest(cookieValue string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/v1/me/cancel-deletion", nil)
+	req.Header.Set("Origin", "http://localhost:8080")
+	req.AddCookie(&http.Cookie{Name: sessionauth.CookieName, Value: cookieValue})
+	return req
+}
+
+func TestCurrentSessionDeleteAccountSchedulesPurgeAndRevokesSessions(t *testing.T) {
+	harness, cookieValue, _ := setupSessionRouter(t)
+	w := httptest.NewRecorder()
+	harness.router.ServeHTTP(w, deleteAccountRequest(cookieValue))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected delete 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"status":"deleted"`) {
+		t.Fatalf("expected deleted status in body, got %s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"hard_delete_after"`) {
+		t.Fatalf("expected hard_delete_after in body, got %s", w.Body.String())
+	}
+	if !strings.Contains(w.Header().Get("Set-Cookie"), sessionauth.CookieName+"=;") {
+		t.Fatalf("expected delete to clear session cookie, got %q", w.Header().Get("Set-Cookie"))
+	}
+	// Cookie should be revoked at the store layer too.
+	meReq := httptest.NewRequest(http.MethodGet, "/v1/me", nil)
+	meReq.AddCookie(&http.Cookie{Name: sessionauth.CookieName, Value: cookieValue})
+	meW := httptest.NewRecorder()
+	harness.router.ServeHTTP(meW, meReq)
+	if meW.Code != http.StatusUnauthorized {
+		t.Fatalf("expected /v1/me 401 after delete, got %d body=%s", meW.Code, meW.Body.String())
+	}
+}
+
+func TestCurrentSessionDeleteAccountRefusesSoleOwner(t *testing.T) {
+	// Promote the seeded membership to owner so the sole-owner guard fires.
+	harness, cookieValue, _ := setupSessionRouter(t)
+	store, ok := harness.manager.Store.(*db.MemoryStore)
+	if !ok {
+		t.Fatalf("expected memory store, got %T", harness.manager.Store)
+	}
+	user, err := store.GetUserByPrimaryEmail(context.Background(), "user@example.com")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	scopedCtx := db.WithScope(context.Background(), db.Scope{TenantID: "tenant-a", WorkspaceID: "workspace-a"})
+	if err := store.UpsertWorkspaceMember(scopedCtx, db.TenancyWorkspaceMember{
+		WorkspaceID: "workspace-a",
+		MemberID:    "member-a",
+		UserID:      "oidc-subject-a",
+		UserUUID:    user.ID,
+		Email:       user.PrimaryEmail,
+		Role:        "owner",
+		Status:      "active",
+	}); err != nil {
+		t.Fatalf("promote to owner: %v", err)
+	}
+	w := httptest.NewRecorder()
+	harness.router.ServeHTTP(w, deleteAccountRequest(cookieValue))
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected delete 409 sole_owner, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"code":"sole_owner"`) {
+		t.Fatalf("expected sole_owner code in body, got %s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"workspace_id":"workspace-a"`) {
+		t.Fatalf("expected workspace listed in body, got %s", w.Body.String())
+	}
+	// The user must remain active so they can transfer ownership and retry.
+	refreshed, err := store.GetUser(context.Background(), user.ID)
+	if err != nil {
+		t.Fatalf("get refreshed user: %v", err)
+	}
+	if refreshed.Status != "active" {
+		t.Fatalf("expected user still active after sole-owner block, got %q", refreshed.Status)
+	}
+	if refreshed.DeletedAt != nil {
+		t.Fatalf("expected DeletedAt unset after sole-owner block, got %v", refreshed.DeletedAt)
+	}
+}
+
+func TestCurrentSessionCancelDeletionWhenActiveIsIdempotent(t *testing.T) {
+	// Cancel-deletion against an already-active account is a no-op success.
+	// In production a deleted user's cookie cannot reach this endpoint
+	// (CreateSession refuses non-active users), so this idempotent shape is
+	// what UIs holding a stale "deletion pending" view will hit after a
+	// cross-tab cancellation lands.
+	harness, cookieValue, _ := setupSessionRouter(t)
+	w := httptest.NewRecorder()
+	harness.router.ServeHTTP(w, cancelDeletionRequest(cookieValue))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected cancel-deletion 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"status":"active"`) {
+		t.Fatalf("expected active status in body, got %s", w.Body.String())
+	}
+}
+
 func TestCurrentSessionDeactivatedUserCannotReuseCookie(t *testing.T) {
 	// The deactivate handler revokes every session and clears the cookie, but
 	// even if the cookie were replayed before that completes, TouchSession

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -673,6 +673,8 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodPost, Path: "/v1/me/sessions/revoke-others", Action: policyActionMeWrite, ResourceType: "session"},
 		{Method: http.MethodPost, Path: "/v1/me/deactivate", Action: policyActionMeWrite, ResourceType: "user"},
 		{Method: http.MethodPost, Path: "/v1/me/reactivate", Action: policyActionMeWrite, ResourceType: "user"},
+		{Method: http.MethodDelete, Path: "/v1/me", Action: policyActionMeWrite, ResourceType: "user"},
+		{Method: http.MethodPost, Path: "/v1/me/cancel-deletion", Action: policyActionMeWrite, ResourceType: "user"},
 		{Method: http.MethodPost, Path: "/v1/onboarding/start", Action: policyActionOnboardingWrite, ResourceType: "onboarding_state"},
 		{Method: http.MethodGet, Path: "/v1/onboarding/state", Action: policyActionOnboardingRead, ResourceType: "onboarding_state"},
 		{Method: http.MethodPost, Path: "/v1/onboarding/state", Action: policyActionOnboardingWrite, ResourceType: "onboarding_state"},

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -298,6 +298,12 @@ func NewRouter(logger *zap.Logger, metrics *telemetry.Metrics, svc *Service, opt
 	}
 	sessionManager := sessionauth.Manager{
 		PublicBaseURL: opts.PublicBaseURL,
+		// The recovery endpoint must accept cookies whose user is soft-deleted
+		// within the grace window; every other route uses the strict path and
+		// keeps refusing.
+		PendingDeletionPaths: map[string]struct{}{
+			"/v1/me/cancel-deletion": {},
+		},
 	}
 	if svc != nil {
 		sessionManager.Store = svc.Store

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3116,6 +3116,7 @@ func isScopelessSessionRoute(path string) bool {
 		"/v1/me/sessions/revoke-others",
 		"/v1/me/deactivate",
 		"/v1/me/reactivate",
+		"/v1/me/cancel-deletion",
 		"/v1/onboarding/start",
 		"/v1/onboarding/state",
 		"/v1/onboarding/complete":

--- a/internal/api/service_auth.go
+++ b/internal/api/service_auth.go
@@ -15,14 +15,16 @@ import (
 )
 
 var (
-	ErrAuthIdentityConflict     = errors.New("auth identity conflicts with existing user")
-	ErrAuthAccountNotFound      = errors.New("auth account not found")
-	ErrAuthReactivationRequired = errors.New("auth account reactivation requires signup")
+	ErrAuthIdentityConflict       = errors.New("auth identity conflicts with existing user")
+	ErrAuthAccountNotFound        = errors.New("auth account not found")
+	ErrAuthReactivationRequired   = errors.New("auth account reactivation requires signup")
+	ErrAuthAccountPendingDeletion = errors.New("auth account is scheduled for permanent deletion")
 )
 
 const (
-	workOSAuthIntentLogin  = "login"
-	workOSAuthIntentSignup = "signup"
+	workOSAuthIntentLogin          = "login"
+	workOSAuthIntentSignup         = "signup"
+	workOSAuthIntentCancelDeletion = "cancel_deletion"
 )
 
 // CurrentUserContext is the response model for GET /v1/me.
@@ -124,9 +126,26 @@ func (s *Service) UpsertWorkOSUserForIntent(ctx context.Context, profile session
 		} else if emailErr != nil && !errors.Is(emailErr, db.ErrNotFound) {
 			return WorkOSLoginResult{}, emailErr
 		}
+		if userIsPendingDeletion(user) {
+			if userDeletionGraceExpired(user, now) {
+				auditAuthAction(ctx, "auth.account.pending_deletion", user.ID, "denied")
+				return WorkOSLoginResult{}, ErrAuthAccountNotFound
+			}
+			// intent=login is refused with a code distinct from
+			// reactivation_required so the frontend can offer cancellation
+			// rather than the deactivated-account flow. signup and
+			// cancel_deletion both revive the row through the reactivation
+			// branch below; cancel_deletion is the canonical UX, signup
+			// preserves backward compatibility with the pre-#1418 contract.
+			if intent == workOSAuthIntentLogin {
+				auditAuthAction(ctx, "auth.account.pending_deletion", user.ID, "denied")
+				return WorkOSLoginResult{}, ErrAuthAccountPendingDeletion
+			}
+			auditAuthAction(ctx, "auth.user.delete.cancel", user.ID, "success")
+		}
 		mustReactivate := workOSUserCanBeReactivated(user)
 		if mustReactivate {
-			if intent != workOSAuthIntentSignup {
+			if intent != workOSAuthIntentSignup && intent != workOSAuthIntentCancelDeletion {
 				auditAuthAction(ctx, "auth.account.reactivation_required", user.ID, "denied")
 				return WorkOSLoginResult{}, ErrAuthReactivationRequired
 			}
@@ -180,12 +199,23 @@ func (s *Service) UpsertWorkOSUserForIntent(ctx context.Context, profile session
 		} else {
 			return WorkOSLoginResult{}, getErr
 		}
+		if userIsPendingDeletion(existing) {
+			if userDeletionGraceExpired(existing, now) {
+				auditAuthAction(ctx, "auth.account.pending_deletion", existing.ID, "denied")
+				return WorkOSLoginResult{}, ErrAuthAccountNotFound
+			}
+			if intent == workOSAuthIntentLogin {
+				auditAuthAction(ctx, "auth.account.pending_deletion", existing.ID, "denied")
+				return WorkOSLoginResult{}, ErrAuthAccountPendingDeletion
+			}
+			auditAuthAction(ctx, "auth.user.delete.cancel", existing.ID, "success")
+		}
 		if workOSUserCanBeReactivated(existing) {
 			if !profile.EmailVerified {
 				auditAuthAction(ctx, "auth.identity.conflict", existing.ID, "denied")
 				return WorkOSLoginResult{}, ErrAuthIdentityConflict
 			}
-			if intent != workOSAuthIntentSignup {
+			if intent != workOSAuthIntentSignup && intent != workOSAuthIntentCancelDeletion {
 				auditAuthAction(ctx, "auth.account.reactivation_required", existing.ID, "denied")
 				return WorkOSLoginResult{}, ErrAuthReactivationRequired
 			}
@@ -268,10 +298,33 @@ func (s *Service) UpsertWorkOSUserForIntent(ctx context.Context, profile session
 }
 
 func normalizeWorkOSAuthIntent(intent string) string {
-	if strings.EqualFold(strings.TrimSpace(intent), workOSAuthIntentLogin) {
+	trimmed := strings.TrimSpace(intent)
+	if strings.EqualFold(trimmed, workOSAuthIntentLogin) {
 		return workOSAuthIntentLogin
 	}
+	if strings.EqualFold(trimmed, workOSAuthIntentCancelDeletion) {
+		return workOSAuthIntentCancelDeletion
+	}
 	return workOSAuthIntentSignup
+}
+
+// userIsPendingDeletion reports whether the account is in the soft-deleted
+// grace window and not yet hard-deleted (deleted_at is still set, status flags
+// the row as scheduled for purge). The sign-in path uses this to refuse login
+// with a distinct error code so the frontend can offer cancellation rather
+// than the deactivated-account reactivation flow.
+func userIsPendingDeletion(user db.User) bool {
+	return strings.EqualFold(strings.TrimSpace(user.Status), "deleted") && user.DeletedAt != nil
+}
+
+// userDeletionGraceExpired reports whether the user's soft-delete grace window
+// has elapsed. Once expired, cancel-deletion must refuse and the worker is
+// authoritative for the purge, even if the row has not been hard-deleted yet.
+func userDeletionGraceExpired(user db.User, now time.Time) bool {
+	if user.DeletedAt == nil {
+		return false
+	}
+	return !now.UTC().Before(user.DeletedAt.UTC().Add(db.UserDeletionGracePeriod))
 }
 
 func workOSUserCanBeReactivated(user db.User) bool {

--- a/internal/api/service_auth.go
+++ b/internal/api/service_auth.go
@@ -126,6 +126,7 @@ func (s *Service) UpsertWorkOSUserForIntent(ctx context.Context, profile session
 		} else if emailErr != nil && !errors.Is(emailErr, db.ErrNotFound) {
 			return WorkOSLoginResult{}, emailErr
 		}
+		cancelledDeletion := false
 		if userIsPendingDeletion(user) {
 			if userDeletionGraceExpired(user, now) {
 				auditAuthAction(ctx, "auth.account.pending_deletion", user.ID, "denied")
@@ -141,7 +142,11 @@ func (s *Service) UpsertWorkOSUserForIntent(ctx context.Context, profile session
 				auditAuthAction(ctx, "auth.account.pending_deletion", user.ID, "denied")
 				return WorkOSLoginResult{}, ErrAuthAccountPendingDeletion
 			}
-			auditAuthAction(ctx, "auth.user.delete.cancel", user.ID, "success")
+			// Defer the cancel audit until the profile/status/identity writes
+			// have all landed — emitting it here would record a successful
+			// cancellation even when a downstream write fails and leaves the
+			// row in its soft-deleted state.
+			cancelledDeletion = true
 		}
 		mustReactivate := workOSUserCanBeReactivated(user)
 		if mustReactivate {
@@ -188,6 +193,9 @@ func (s *Service) UpsertWorkOSUserForIntent(ctx context.Context, profile session
 		if saveIdentityErr != nil {
 			return WorkOSLoginResult{}, saveIdentityErr
 		}
+		if cancelledDeletion {
+			auditAuthAction(ctx, "auth.user.delete.cancel", savedUser.ID, "success")
+		}
 		return s.decorateWorkOSLoginResult(ctx, WorkOSLoginResult{User: savedUser, Identity: savedIdentity}, profile.OrganizationID)
 	}
 	if !errors.Is(err, db.ErrNotFound) {
@@ -199,7 +207,11 @@ func (s *Service) UpsertWorkOSUserForIntent(ctx context.Context, profile session
 		} else {
 			return WorkOSLoginResult{}, getErr
 		}
-		if userIsPendingDeletion(existing) {
+		// Defer the cancel audit until every write below succeeds: a bad
+		// email-verified state or a store conflict must not record a
+		// cancellation that never actually flipped the row.
+		cancelledDeletion := userIsPendingDeletion(existing)
+		if cancelledDeletion {
 			if userDeletionGraceExpired(existing, now) {
 				auditAuthAction(ctx, "auth.account.pending_deletion", existing.ID, "denied")
 				return WorkOSLoginResult{}, ErrAuthAccountNotFound
@@ -208,7 +220,6 @@ func (s *Service) UpsertWorkOSUserForIntent(ctx context.Context, profile session
 				auditAuthAction(ctx, "auth.account.pending_deletion", existing.ID, "denied")
 				return WorkOSLoginResult{}, ErrAuthAccountPendingDeletion
 			}
-			auditAuthAction(ctx, "auth.user.delete.cancel", existing.ID, "success")
 		}
 		if workOSUserCanBeReactivated(existing) {
 			if !profile.EmailVerified {
@@ -252,6 +263,9 @@ func (s *Service) UpsertWorkOSUserForIntent(ctx context.Context, profile session
 			})
 			if identityErr != nil {
 				return WorkOSLoginResult{}, identityErr
+			}
+			if cancelledDeletion {
+				auditAuthAction(ctx, "auth.user.delete.cancel", existing.ID, "success")
 			}
 			auditAuthAction(ctx, "auth.user.reactivate", existing.ID, "success")
 			return s.decorateWorkOSLoginResult(ctx, WorkOSLoginResult{User: existing, Identity: identity}, profile.OrganizationID)

--- a/internal/api/service_workos_test.go
+++ b/internal/api/service_workos_test.go
@@ -723,3 +723,132 @@ func TestUpsertWorkOSUserForIntentEmailResolvedReactivationUsesProfileUpdateThen
 		t.Fatalf("expected no upsert during reactivation, got %d", store.upsertUserCalls)
 	}
 }
+
+func TestUpsertWorkOSUserLoginIntentRefusesPendingDeletion(t *testing.T) {
+	// A login-intent sign-in against a soft-deleted account must fail with
+	// ErrAuthAccountPendingDeletion so the auth_routes layer can map it to a
+	// 403 + `account_pending_deletion` code distinct from the deactivated
+	// reactivation_required path. The frontend uses that branch to render the
+	// cancel-deletion prompt.
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 5, 28, 9, 0, 0, 0, time.UTC)
+	deletedAt := now.Add(-24 * time.Hour)
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	ctx := context.Background()
+	user, err := store.UpsertUser(ctx, db.User{
+		PrimaryEmail: "deleting@example.com",
+		DisplayName:  "Deleting",
+		Status:       "deleted",
+		DeletedAt:    &deletedAt,
+	})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	if _, err := store.UpsertUserIdentity(ctx, db.UserIdentity{
+		UserID:              user.ID,
+		Provider:            sessionauth.WorkOSProvider,
+		Subject:             "user_workos_deleting",
+		Email:               "deleting@example.com",
+		LastAuthenticatedAt: now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("seed identity: %v", err)
+	}
+	_, err = svc.UpsertWorkOSUserForIntent(ctx, sessionauth.WorkOSProfile{
+		ID:            "user_workos_deleting",
+		Email:         "deleting@example.com",
+		EmailVerified: true,
+	}, "login")
+	if !errors.Is(err, ErrAuthAccountPendingDeletion) {
+		t.Fatalf("expected ErrAuthAccountPendingDeletion, got %v", err)
+	}
+	stored, err := store.GetUser(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if stored.Status != "deleted" || stored.DeletedAt == nil {
+		t.Fatalf("expected user untouched, got status=%q deletedAt=%v", stored.Status, stored.DeletedAt)
+	}
+}
+
+func TestUpsertWorkOSUserCancelDeletionIntentRevivesAccount(t *testing.T) {
+	// The cancel_deletion intent is the dedicated revive path: the soft-deleted
+	// account flips back to active, DeletedAt is cleared, and the normal
+	// sign-in flow completes so the user lands authenticated.
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 5, 28, 9, 0, 0, 0, time.UTC)
+	deletedAt := now.Add(-24 * time.Hour)
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	ctx := context.Background()
+	user, err := store.UpsertUser(ctx, db.User{
+		PrimaryEmail: "reviving@example.com",
+		DisplayName:  "Reviving",
+		Status:       "deleted",
+		DeletedAt:    &deletedAt,
+	})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	if _, err := store.UpsertUserIdentity(ctx, db.UserIdentity{
+		UserID:              user.ID,
+		Provider:            sessionauth.WorkOSProvider,
+		Subject:             "user_workos_reviving",
+		Email:               "reviving@example.com",
+		LastAuthenticatedAt: now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("seed identity: %v", err)
+	}
+	result, err := svc.UpsertWorkOSUserForIntent(ctx, sessionauth.WorkOSProfile{
+		ID:            "user_workos_reviving",
+		Email:         "reviving@example.com",
+		EmailVerified: true,
+	}, "cancel_deletion")
+	if err != nil {
+		t.Fatalf("cancel_deletion intent: %v", err)
+	}
+	if result.User.Status != "active" {
+		t.Fatalf("expected active status, got %q", result.User.Status)
+	}
+	if result.User.DeletedAt != nil {
+		t.Fatalf("expected DeletedAt cleared, got %v", result.User.DeletedAt)
+	}
+}
+
+func TestUpsertWorkOSUserSignInPastGraceReturnsNotFound(t *testing.T) {
+	// Past the 30-day grace window the worker is authoritative for the purge.
+	// Sign-in must refuse with ErrAuthAccountNotFound so the frontend cannot
+	// offer cancellation against a row that is already eligible for hard
+	// delete.
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 5, 28, 9, 0, 0, 0, time.UTC)
+	deletedAt := now.Add(-(db.UserDeletionGracePeriod + 24*time.Hour))
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	ctx := context.Background()
+	user, err := store.UpsertUser(ctx, db.User{
+		PrimaryEmail: "expired@example.com",
+		Status:       "deleted",
+		DeletedAt:    &deletedAt,
+	})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	if _, err := store.UpsertUserIdentity(ctx, db.UserIdentity{
+		UserID:              user.ID,
+		Provider:            sessionauth.WorkOSProvider,
+		Subject:             "user_workos_expired",
+		Email:               "expired@example.com",
+		LastAuthenticatedAt: now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("seed identity: %v", err)
+	}
+	_, err = svc.UpsertWorkOSUserForIntent(ctx, sessionauth.WorkOSProfile{
+		ID:            "user_workos_expired",
+		Email:         "expired@example.com",
+		EmailVerified: true,
+	}, "cancel_deletion")
+	if !errors.Is(err, ErrAuthAccountNotFound) {
+		t.Fatalf("expected ErrAuthAccountNotFound past grace, got %v", err)
+	}
+}

--- a/internal/api/service_workos_test.go
+++ b/internal/api/service_workos_test.go
@@ -817,39 +817,47 @@ func TestUpsertWorkOSUserCancelDeletionIntentRevivesAccount(t *testing.T) {
 
 func TestUpsertWorkOSUserSignInPastGraceReturnsNotFound(t *testing.T) {
 	// Past the 30-day grace window the worker is authoritative for the purge.
-	// Sign-in must refuse with ErrAuthAccountNotFound so the frontend cannot
-	// offer cancellation against a row that is already eligible for hard
-	// delete.
-	store := db.NewMemoryStore()
-	now := time.Date(2026, 5, 28, 9, 0, 0, 0, time.UTC)
-	deletedAt := now.Add(-(db.UserDeletionGracePeriod + 24*time.Hour))
-	svc := NewService(store, fakeScanner{}, "aws")
-	svc.Now = func() time.Time { return now }
-	ctx := context.Background()
-	user, err := store.UpsertUser(ctx, db.User{
-		PrimaryEmail: "expired@example.com",
-		Status:       "deleted",
-		DeletedAt:    &deletedAt,
-	})
-	if err != nil {
-		t.Fatalf("seed user: %v", err)
-	}
-	if _, err := store.UpsertUserIdentity(ctx, db.UserIdentity{
-		UserID:              user.ID,
-		Provider:            sessionauth.WorkOSProvider,
-		Subject:             "user_workos_expired",
-		Email:               "expired@example.com",
-		LastAuthenticatedAt: now.Add(-time.Hour),
-	}); err != nil {
-		t.Fatalf("seed identity: %v", err)
-	}
-	_, err = svc.UpsertWorkOSUserForIntent(ctx, sessionauth.WorkOSProfile{
-		ID:            "user_workos_expired",
-		Email:         "expired@example.com",
-		EmailVerified: true,
-	}, "cancel_deletion")
-	if !errors.Is(err, ErrAuthAccountNotFound) {
-		t.Fatalf("expected ErrAuthAccountNotFound past grace, got %v", err)
+	// Sign-in must refuse with ErrAuthAccountNotFound for every intent so the
+	// frontend cannot offer cancellation against a row that is already
+	// eligible for hard delete. The canonical `login` intent (the one the
+	// hosted-login button uses) is exercised explicitly — `cancel_deletion`
+	// and `signup` get sub-cases for completeness since each takes a
+	// different branch through UpsertWorkOSUserForIntent.
+	intents := []string{"login", "cancel_deletion", "signup"}
+	for _, intent := range intents {
+		t.Run(intent, func(t *testing.T) {
+			store := db.NewMemoryStore()
+			now := time.Date(2026, 5, 28, 9, 0, 0, 0, time.UTC)
+			deletedAt := now.Add(-(db.UserDeletionGracePeriod + 24*time.Hour))
+			svc := NewService(store, fakeScanner{}, "aws")
+			svc.Now = func() time.Time { return now }
+			ctx := context.Background()
+			user, err := store.UpsertUser(ctx, db.User{
+				PrimaryEmail: "expired@example.com",
+				Status:       "deleted",
+				DeletedAt:    &deletedAt,
+			})
+			if err != nil {
+				t.Fatalf("seed user: %v", err)
+			}
+			if _, err := store.UpsertUserIdentity(ctx, db.UserIdentity{
+				UserID:              user.ID,
+				Provider:            sessionauth.WorkOSProvider,
+				Subject:             "user_workos_expired",
+				Email:               "expired@example.com",
+				LastAuthenticatedAt: now.Add(-time.Hour),
+			}); err != nil {
+				t.Fatalf("seed identity: %v", err)
+			}
+			_, err = svc.UpsertWorkOSUserForIntent(ctx, sessionauth.WorkOSProfile{
+				ID:            "user_workos_expired",
+				Email:         "expired@example.com",
+				EmailVerified: true,
+			}, intent)
+			if !errors.Is(err, ErrAuthAccountNotFound) {
+				t.Fatalf("intent=%q: expected ErrAuthAccountNotFound past grace, got %v", intent, err)
+			}
+		})
 	}
 }
 

--- a/internal/api/service_workos_test.go
+++ b/internal/api/service_workos_test.go
@@ -852,3 +852,77 @@ func TestUpsertWorkOSUserSignInPastGraceReturnsNotFound(t *testing.T) {
 		t.Fatalf("expected ErrAuthAccountNotFound past grace, got %v", err)
 	}
 }
+
+func TestUpsertWorkOSUserCancelDeletionEmailResolvedRevives(t *testing.T) {
+	// The email-resolved branch (no matching identity row, but a user with
+	// the same primary email) must also honor the cancel_deletion intent:
+	// revive the soft-deleted row, mint the identity, complete sign-in.
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 5, 28, 9, 0, 0, 0, time.UTC)
+	deletedAt := now.Add(-24 * time.Hour)
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	ctx := context.Background()
+	user, err := store.UpsertUser(ctx, db.User{
+		PrimaryEmail: "email-revive@example.com",
+		DisplayName:  "Email Revive",
+		Status:       "deleted",
+		DeletedAt:    &deletedAt,
+	})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	result, err := svc.UpsertWorkOSUserForIntent(ctx, sessionauth.WorkOSProfile{
+		ID:            "user_workos_email_revive",
+		Email:         "email-revive@example.com",
+		FirstName:     "Email",
+		LastName:      "Revive",
+		EmailVerified: true,
+	}, "cancel_deletion")
+	if err != nil {
+		t.Fatalf("cancel_deletion intent (email-resolved): %v", err)
+	}
+	if result.User.Status != "active" {
+		t.Fatalf("expected active status, got %q", result.User.Status)
+	}
+	if result.User.DeletedAt != nil {
+		t.Fatalf("expected DeletedAt cleared, got %v", result.User.DeletedAt)
+	}
+	stored, err := store.GetUser(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("get stored: %v", err)
+	}
+	if stored.Status != "active" || stored.DeletedAt != nil {
+		t.Fatalf("expected stored row revived, got %+v", stored)
+	}
+}
+
+func TestUpsertWorkOSUserLoginIntentRefusesPendingDeletionEmailResolved(t *testing.T) {
+	// Mirror of TestUpsertWorkOSUserLoginIntentRefusesPendingDeletion but on
+	// the email-resolved branch — no matching identity row exists, only a
+	// soft-deleted user with the same primary email. The login intent must
+	// still surface ErrAuthAccountPendingDeletion so the UI can branch to
+	// cancellation rather than reactivation.
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 5, 28, 9, 0, 0, 0, time.UTC)
+	deletedAt := now.Add(-24 * time.Hour)
+	svc := NewService(store, fakeScanner{}, "aws")
+	svc.Now = func() time.Time { return now }
+	ctx := context.Background()
+	if _, err := store.UpsertUser(ctx, db.User{
+		PrimaryEmail: "email-pending@example.com",
+		DisplayName:  "Email Pending",
+		Status:       "deleted",
+		DeletedAt:    &deletedAt,
+	}); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	_, err := svc.UpsertWorkOSUserForIntent(ctx, sessionauth.WorkOSProfile{
+		ID:            "user_workos_email_pending",
+		Email:         "email-pending@example.com",
+		EmailVerified: true,
+	}, "login")
+	if !errors.Is(err, ErrAuthAccountPendingDeletion) {
+		t.Fatalf("expected ErrAuthAccountPendingDeletion, got %v", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,9 @@ const (
 	defaultWorkerAPIJobQueueEnabled    = true
 	defaultWorkerAPIJobQueueInterval   = 2 * time.Second
 	defaultWorkerAPIJobQueueBatchSize  = 5
+	defaultWorkerUserPurgeEnabled      = true
+	defaultWorkerUserPurgeInterval     = 24 * time.Hour
+	defaultWorkerUserPurgeBatchSize    = 100
 	defaultLockBackend                 = "auto"
 	defaultLockNamespace               = "identrail"
 	defaultPostgresRLSEnforced         = false
@@ -151,6 +154,9 @@ type Config struct {
 	WorkerAPIJobQueueEnabled     bool
 	WorkerAPIJobQueueInterval    time.Duration
 	WorkerAPIJobQueueBatchSize   int
+	WorkerUserPurgeEnabled       bool
+	WorkerUserPurgeInterval      time.Duration
+	WorkerUserPurgeBatchSize     int
 	LockBackend                  string
 	LockNamespace                string
 	DefaultTenantID              string
@@ -303,6 +309,9 @@ func Load() Config {
 		WorkerAPIJobQueueEnabled:     boolEnv("IDENTRAIL_WORKER_API_JOB_QUEUE_ENABLED", defaultWorkerAPIJobQueueEnabled),
 		WorkerAPIJobQueueInterval:    durationEnv("IDENTRAIL_WORKER_API_JOB_QUEUE_INTERVAL", defaultWorkerAPIJobQueueInterval),
 		WorkerAPIJobQueueBatchSize:   parseInt(getEnv("IDENTRAIL_WORKER_API_JOB_QUEUE_BATCH_SIZE", "5"), defaultWorkerAPIJobQueueBatchSize),
+		WorkerUserPurgeEnabled:       boolEnv("IDENTRAIL_WORKER_USER_PURGE_ENABLED", defaultWorkerUserPurgeEnabled),
+		WorkerUserPurgeInterval:      durationEnv("IDENTRAIL_WORKER_USER_PURGE_INTERVAL", defaultWorkerUserPurgeInterval),
+		WorkerUserPurgeBatchSize:     parseInt(getEnv("IDENTRAIL_WORKER_USER_PURGE_BATCH_SIZE", "100"), defaultWorkerUserPurgeBatchSize),
 		WorkerHeartbeatPath:          strings.TrimSpace(getEnv("IDENTRAIL_WORKER_HEARTBEAT_PATH", "")),
 		LockBackend:                  strings.ToLower(getEnv("IDENTRAIL_LOCK_BACKEND", defaultLockBackend)),
 		LockNamespace:                getEnv("IDENTRAIL_LOCK_NAMESPACE", defaultLockNamespace),

--- a/internal/db/memory_auth.go
+++ b/internal/db/memory_auth.go
@@ -130,6 +130,139 @@ func (m *MemoryStore) SetUserStatus(ctx context.Context, userID string, status s
 	return user, nil
 }
 
+// SoftDeleteUser flips the account to status=deleted and stamps deleted_at to
+// open the reversible grace window. Re-deleting an already-deleted account is a
+// no-op that preserves the original deleted_at so the purge deadline cannot be
+// pushed back by repeat calls.
+func (m *MemoryStore) SoftDeleteUser(ctx context.Context, userID string, now time.Time) (User, error) {
+	id := strings.TrimSpace(userID)
+	when := now.UTC()
+	m.mu.Lock()
+	user, exists := m.users[id]
+	if !exists {
+		m.mu.Unlock()
+		return User{}, ErrNotFound
+	}
+	if user.DeletedAt == nil {
+		deletedAt := when
+		user.DeletedAt = &deletedAt
+	}
+	user.Status = "deleted"
+	user.UpdatedAt = when
+	m.users[id] = user
+	m.mu.Unlock()
+	audit.WriteAction(ctx, audit.AuditEvent{
+		Action:       "auth.user.delete",
+		ResourceType: "user",
+		ResourceID:   id,
+		Outcome:      "success",
+	})
+	return user, nil
+}
+
+// CancelUserDeletion reverses a soft delete: it clears deleted_at and returns
+// the account to active.
+func (m *MemoryStore) CancelUserDeletion(ctx context.Context, userID string, now time.Time) (User, error) {
+	id := strings.TrimSpace(userID)
+	when := now.UTC()
+	m.mu.Lock()
+	user, exists := m.users[id]
+	if !exists {
+		m.mu.Unlock()
+		return User{}, ErrNotFound
+	}
+	user.Status = "active"
+	user.DeletedAt = nil
+	user.UpdatedAt = when
+	m.users[id] = user
+	m.mu.Unlock()
+	audit.WriteAction(ctx, audit.AuditEvent{
+		Action:       "auth.user.delete.cancel",
+		ResourceType: "user",
+		ResourceID:   id,
+		Outcome:      "success",
+	})
+	return user, nil
+}
+
+// ListUsersPendingHardDelete returns soft-deleted accounts whose grace window
+// closed and whose PII has not already been purged.
+func (m *MemoryStore) ListUsersPendingHardDelete(ctx context.Context, deletedBefore time.Time, limit int) ([]User, error) {
+	cutoff := deletedBefore.UTC()
+	if limit <= 0 {
+		limit = 100
+	}
+	m.mu.RLock()
+	pending := make([]User, 0)
+	for _, user := range m.users {
+		if user.Status != "deleted" || user.DeletedAt == nil {
+			continue
+		}
+		if !user.DeletedAt.UTC().Before(cutoff) {
+			continue
+		}
+		if IsHardDeletedTombstoneEmail(user.PrimaryEmail) {
+			continue
+		}
+		pending = append(pending, user)
+	}
+	m.mu.RUnlock()
+	sort.Slice(pending, func(i, j int) bool {
+		if pending[i].DeletedAt.Equal(*pending[j].DeletedAt) {
+			return pending[i].ID < pending[j].ID
+		}
+		return pending[i].DeletedAt.Before(*pending[j].DeletedAt)
+	})
+	if len(pending) > limit {
+		pending = pending[:limit]
+	}
+	return pending, nil
+}
+
+// HardDeleteUser purges PII from a soft-deleted account while keeping the row
+// so audit references by UUID remain valid. It deletes provider identities
+// (which carry raw IdP claims) and any session rows, and is safely re-runnable.
+func (m *MemoryStore) HardDeleteUser(ctx context.Context, userID string, now time.Time) (User, error) {
+	id := strings.TrimSpace(userID)
+	when := now.UTC()
+	m.mu.Lock()
+	user, exists := m.users[id]
+	if !exists {
+		m.mu.Unlock()
+		return User{}, ErrNotFound
+	}
+	user.PrimaryEmail = HardDeletedTombstoneEmail(id)
+	user.DisplayName = ""
+	user.AvatarURL = ""
+	user.Status = "deleted"
+	user.UpdatedAt = when
+	m.users[id] = user
+	for identityID, identity := range m.userIdentityByID {
+		if identity.UserID != id {
+			continue
+		}
+		delete(m.userIdentityByID, identityID)
+		for key, mappedID := range m.userIdentityByProviderSubject {
+			if mappedID == identityID {
+				delete(m.userIdentityByProviderSubject, key)
+			}
+		}
+	}
+	for key, session := range m.sessions {
+		if session.UserID == id {
+			delete(m.sessions, key)
+		}
+	}
+	m.mu.Unlock()
+	audit.WriteAction(ctx, audit.AuditEvent{
+		Action:       "auth.user.hard_delete",
+		ResourceType: "user",
+		ResourceID:   id,
+		Outcome:      "success",
+	})
+	return user, nil
+}
+
 // UpsertUserIdentity persists one provider identity mapping.
 func (m *MemoryStore) UpsertUserIdentity(ctx context.Context, identity UserIdentity) (UserIdentity, error) {
 	normalized, err := NormalizeUserIdentityForWrite(identity)

--- a/internal/db/memory_auth.go
+++ b/internal/db/memory_auth.go
@@ -411,6 +411,18 @@ func (m *MemoryStore) CreateSession(ctx context.Context, session Session) (Sessi
 
 // TouchSession renews idle expiry and returns the joined session/user row.
 func (m *MemoryStore) TouchSession(ctx context.Context, sessionIDHash []byte, now time.Time) (Session, error) {
+	return m.touchSessionInternal(sessionIDHash, now, false)
+}
+
+// TouchSessionAllowingPendingDeletion is the lenient variant the cancel-deletion
+// route mounts: it accepts cookies belonging to users whose status is `deleted`
+// and whose grace window has not closed yet, so a freshly-soft-deleted user can
+// still hit `/v1/me/cancel-deletion` while every other route keeps refusing.
+func (m *MemoryStore) TouchSessionAllowingPendingDeletion(ctx context.Context, sessionIDHash []byte, now time.Time) (Session, error) {
+	return m.touchSessionInternal(sessionIDHash, now, true)
+}
+
+func (m *MemoryStore) touchSessionInternal(sessionIDHash []byte, now time.Time, allowPendingDeletion bool) (Session, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	key := sessionHashKey(sessionIDHash)
@@ -421,16 +433,31 @@ func (m *MemoryStore) TouchSession(ctx context.Context, sessionIDHash []byte, no
 	if session.RevokedAt != nil || !session.IdleExpiresAt.After(now) || !session.AbsoluteExpiresAt.After(now) {
 		return Session{}, ErrNotFound
 	}
+	user, exists := m.users[session.UserID]
+	if !exists {
+		return Session{}, ErrNotFound
+	}
+	userActive := user.DeletedAt == nil && user.Status == "active"
+	if !userActive {
+		if !allowPendingDeletion {
+			return Session{}, ErrNotFound
+		}
+		// Lenient path: accept only soft-deleted accounts still within their
+		// grace window. A purged tombstone row or an account past the grace
+		// has no business surfacing as an authenticated session.
+		if user.Status != "deleted" || user.DeletedAt == nil {
+			return Session{}, ErrNotFound
+		}
+		if !now.UTC().Before(user.DeletedAt.UTC().Add(UserDeletionGracePeriod)) {
+			return Session{}, ErrNotFound
+		}
+	}
 	session.LastSeenAt = now.UTC()
 	nextIdle := now.Add(15 * time.Minute).UTC()
 	if nextIdle.After(session.AbsoluteExpiresAt) {
 		nextIdle = session.AbsoluteExpiresAt
 	}
 	session.IdleExpiresAt = nextIdle
-	user, exists := m.users[session.UserID]
-	if !exists || user.DeletedAt != nil || user.Status != "active" {
-		return Session{}, ErrNotFound
-	}
 	session.User = &user
 	m.sessions[key] = session
 	return session, nil

--- a/internal/db/memory_auth.go
+++ b/internal/db/memory_auth.go
@@ -201,7 +201,7 @@ func (m *MemoryStore) ListUsersPendingHardDelete(ctx context.Context, deletedBef
 		if !user.DeletedAt.UTC().Before(cutoff) {
 			continue
 		}
-		if IsHardDeletedTombstoneEmail(user.PrimaryEmail) {
+		if IsHardDeletedTombstoneEmailForUser(user.PrimaryEmail, user.ID) {
 			continue
 		}
 		pending = append(pending, user)
@@ -230,6 +230,14 @@ func (m *MemoryStore) HardDeleteUser(ctx context.Context, userID string, now tim
 	if !exists {
 		m.mu.Unlock()
 		return User{}, ErrNotFound
+	}
+	// Refuse unless the row is actually pending deletion. Without this guard
+	// a misuse against an active account would silently purge PII. The worker
+	// only ever invokes this on rows returned by ListUsersPendingHardDelete,
+	// but the defense keeps a programming error from being unrecoverable.
+	if user.Status != "deleted" || user.DeletedAt == nil {
+		m.mu.Unlock()
+		return User{}, fmt.Errorf("hard delete: user %s is not pending deletion (status=%q)", id, user.Status)
 	}
 	user.PrimaryEmail = HardDeletedTombstoneEmail(id)
 	user.DisplayName = ""

--- a/internal/db/memory_auth.go
+++ b/internal/db/memory_auth.go
@@ -442,13 +442,12 @@ func (m *MemoryStore) touchSessionInternal(sessionIDHash []byte, now time.Time, 
 		if !allowPendingDeletion {
 			return Session{}, ErrNotFound
 		}
-		// Lenient path: accept only soft-deleted accounts still within their
-		// grace window. A purged tombstone row or an account past the grace
-		// has no business surfacing as an authenticated session.
+		// Lenient path: accept soft-deleted accounts so the cancel-deletion
+		// handler can serve them. The 30-day grace gate is enforced at the
+		// handler level (returning 410 past the window) rather than here, so
+		// the past-grace branch stays reachable for callers to receive a
+		// well-formed `grace_period_expired` response instead of a bare 401.
 		if user.Status != "deleted" || user.DeletedAt == nil {
-			return Session{}, ErrNotFound
-		}
-		if !now.UTC().Before(user.DeletedAt.UTC().Add(UserDeletionGracePeriod)) {
 			return Session{}, ErrNotFound
 		}
 	}

--- a/internal/db/memory_auth_test.go
+++ b/internal/db/memory_auth_test.go
@@ -578,8 +578,8 @@ func TestMemoryHardDeleteUserPurgesPIIAndIdentities(t *testing.T) {
 	if err != nil {
 		t.Fatalf("hard delete: %v", err)
 	}
-	if !IsHardDeletedTombstoneEmail(purged.PrimaryEmail) {
-		t.Fatalf("expected tombstone email, got %q", purged.PrimaryEmail)
+	if !IsHardDeletedTombstoneEmailForUser(purged.PrimaryEmail, purged.ID) {
+		t.Fatalf("expected tombstone email for user %s, got %q", purged.ID, purged.PrimaryEmail)
 	}
 	if purged.DisplayName != "" || purged.AvatarURL != "" {
 		t.Fatalf("expected PII cleared, got %+v", purged)

--- a/internal/db/memory_auth_test.go
+++ b/internal/db/memory_auth_test.go
@@ -499,3 +499,118 @@ func TestMemorySetUserStatusRejectsInvalidInput(t *testing.T) {
 		t.Fatalf("expected ErrNotFound for missing user, got %v", err)
 	}
 }
+
+func TestMemorySoftDeleteUserPreservesOriginalDeletedAt(t *testing.T) {
+	// Repeat soft deletes must not push the purge deadline back: deleted_at is
+	// pinned on the first call so a frantic click of "Delete account" twice
+	// cannot accidentally extend the user's grace window.
+	store := NewMemoryStore()
+	ctx := context.Background()
+	first := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	second := first.Add(48 * time.Hour)
+	user, err := store.UpsertUser(ctx, User{PrimaryEmail: "soft@example.com", CreatedAt: first})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	one, err := store.SoftDeleteUser(ctx, user.ID, first)
+	if err != nil {
+		t.Fatalf("first soft delete: %v", err)
+	}
+	if one.DeletedAt == nil || !one.DeletedAt.Equal(first) {
+		t.Fatalf("expected DeletedAt=%v, got %v", first, one.DeletedAt)
+	}
+	two, err := store.SoftDeleteUser(ctx, user.ID, second)
+	if err != nil {
+		t.Fatalf("second soft delete: %v", err)
+	}
+	if two.DeletedAt == nil || !two.DeletedAt.Equal(first) {
+		t.Fatalf("expected DeletedAt preserved at %v after repeat, got %v", first, two.DeletedAt)
+	}
+}
+
+func TestMemoryCancelUserDeletionRestoresActive(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+	now := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	user, err := store.UpsertUser(ctx, User{PrimaryEmail: "cancel@example.com", CreatedAt: now})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	if _, err := store.SoftDeleteUser(ctx, user.ID, now); err != nil {
+		t.Fatalf("soft delete: %v", err)
+	}
+	cancelled, err := store.CancelUserDeletion(ctx, user.ID, now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+	if cancelled.Status != "active" || cancelled.DeletedAt != nil {
+		t.Fatalf("expected restored to active, got %+v", cancelled)
+	}
+}
+
+func TestMemoryHardDeleteUserPurgesPIIAndIdentities(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+	now := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	user, err := store.UpsertUser(ctx, User{
+		PrimaryEmail: "purge@example.com",
+		DisplayName:  "Purge Me",
+		AvatarURL:    "https://cdn.example/x.png",
+		CreatedAt:    now,
+	})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	if _, err := store.UpsertUserIdentity(ctx, UserIdentity{
+		UserID:              user.ID,
+		Provider:            "workos",
+		Subject:             "subject-purge",
+		Email:               "purge@example.com",
+		LastAuthenticatedAt: now,
+		CreatedAt:           now,
+	}); err != nil {
+		t.Fatalf("seed identity: %v", err)
+	}
+	if _, err := store.SoftDeleteUser(ctx, user.ID, now); err != nil {
+		t.Fatalf("soft delete: %v", err)
+	}
+	purged, err := store.HardDeleteUser(ctx, user.ID, now.Add(31*24*time.Hour))
+	if err != nil {
+		t.Fatalf("hard delete: %v", err)
+	}
+	if !IsHardDeletedTombstoneEmail(purged.PrimaryEmail) {
+		t.Fatalf("expected tombstone email, got %q", purged.PrimaryEmail)
+	}
+	if purged.DisplayName != "" || purged.AvatarURL != "" {
+		t.Fatalf("expected PII cleared, got %+v", purged)
+	}
+	if _, err := store.GetUserIdentity(ctx, "workos", "subject-purge"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected identity removed, got %v", err)
+	}
+}
+
+func TestMemoryListUsersPendingHardDeleteRespectsCutoff(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+	now := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	past := now.Add(-(UserDeletionGracePeriod + 24*time.Hour))
+	future := now.Add(-(UserDeletionGracePeriod / 2))
+	pastUser, err := store.UpsertUser(ctx, User{PrimaryEmail: "past@example.com", CreatedAt: now, Status: "deleted", DeletedAt: &past})
+	if err != nil {
+		t.Fatalf("seed past: %v", err)
+	}
+	if _, err := store.UpsertUser(ctx, User{PrimaryEmail: "future@example.com", CreatedAt: now, Status: "deleted", DeletedAt: &future}); err != nil {
+		t.Fatalf("seed future: %v", err)
+	}
+	if _, err := store.UpsertUser(ctx, User{PrimaryEmail: "active@example.com", CreatedAt: now}); err != nil {
+		t.Fatalf("seed active: %v", err)
+	}
+	cutoff := now.Add(-UserDeletionGracePeriod)
+	pending, err := store.ListUsersPendingHardDelete(ctx, cutoff, 10)
+	if err != nil {
+		t.Fatalf("list pending: %v", err)
+	}
+	if len(pending) != 1 || pending[0].ID != pastUser.ID {
+		t.Fatalf("expected only past-grace user, got %+v", pending)
+	}
+}

--- a/internal/db/memory_tenancy.go
+++ b/internal/db/memory_tenancy.go
@@ -426,21 +426,30 @@ func (m *MemoryStore) ListSoleOwnerWorkspaces(ctx context.Context, userUUID stri
 	}
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	ownerCounts := map[string]int{}
+	// A workspace is sole-owned by the caller iff (a) the caller holds an
+	// active owner membership and (b) no OTHER user holds an active owner
+	// membership backed by a non-deleted user. Soft-deleted owners cannot
+	// transfer ownership; counting them would let the caller delete their
+	// account and leave the workspace with no live owner.
+	otherLiveOwners := map[string]int{}
 	userOwns := map[string]struct{}{}
 	for _, member := range m.members {
 		if member.Status != "active" || member.Role != "owner" {
 			continue
 		}
 		key := tenancyWorkspaceKey(member.TenantID, member.WorkspaceID)
-		ownerCounts[key]++
 		if member.UserUUID == normalizedUserUUID {
 			userOwns[key] = struct{}{}
+			continue
 		}
+		if owner, ok := m.users[member.UserUUID]; ok && owner.Status == "deleted" {
+			continue
+		}
+		otherLiveOwners[key]++
 	}
 	workspaces := make([]TenancyWorkspace, 0)
 	for key := range userOwns {
-		if ownerCounts[key] != 1 {
+		if otherLiveOwners[key] > 0 {
 			continue
 		}
 		if workspace, exists := m.workspaces[key]; exists {

--- a/internal/db/memory_tenancy.go
+++ b/internal/db/memory_tenancy.go
@@ -417,6 +417,42 @@ func (m *MemoryStore) ListWorkspaceMembershipsByUserUUIDAndTenantID(ctx context.
 	return memberships, nil
 }
 
+// ListSoleOwnerWorkspaces returns every workspace, across all tenants, in which
+// the user is the only active owner.
+func (m *MemoryStore) ListSoleOwnerWorkspaces(ctx context.Context, userUUID string) ([]TenancyWorkspace, error) {
+	normalizedUserUUID := strings.TrimSpace(userUUID)
+	if normalizedUserUUID == "" {
+		return []TenancyWorkspace{}, nil
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	ownerCounts := map[string]int{}
+	userOwns := map[string]struct{}{}
+	for _, member := range m.members {
+		if member.Status != "active" || member.Role != "owner" {
+			continue
+		}
+		key := tenancyWorkspaceKey(member.TenantID, member.WorkspaceID)
+		ownerCounts[key]++
+		if member.UserUUID == normalizedUserUUID {
+			userOwns[key] = struct{}{}
+		}
+	}
+	workspaces := make([]TenancyWorkspace, 0)
+	for key := range userOwns {
+		if ownerCounts[key] != 1 {
+			continue
+		}
+		if workspace, exists := m.workspaces[key]; exists {
+			workspaces = append(workspaces, workspace)
+		}
+	}
+	sort.Slice(workspaces, func(i, j int) bool {
+		return workspaces[i].WorkspaceID < workspaces[j].WorkspaceID
+	})
+	return workspaces, nil
+}
+
 // ListWorkspaceMembers returns members for one scoped workspace.
 func (m *MemoryStore) ListWorkspaceMembers(ctx context.Context, workspaceID string, limit int) ([]TenancyWorkspaceMember, error) {
 	m.mu.RLock()

--- a/internal/db/memory_tenancy_test.go
+++ b/internal/db/memory_tenancy_test.go
@@ -1295,3 +1295,53 @@ func TestMemoryStoreListSoleOwnerWorkspaces(t *testing.T) {
 		t.Fatalf("expected only ws-sole, got %+v", results)
 	}
 }
+
+func TestMemoryStoreListSoleOwnerWorkspacesIgnoresDeletedOwners(t *testing.T) {
+	// A workspace with one active owner (the caller) and one membership row
+	// pointing at a soft-deleted user must be flagged as sole-owned by the
+	// caller. A deleted user cannot transfer ownership, so counting them as
+	// a live owner would let the caller delete their own account and leave
+	// the workspace with zero live owners — exactly the invariant the
+	// sole-owner guard exists to enforce.
+	store := NewMemoryStore()
+	now := time.Date(2026, 5, 1, 9, 0, 0, 0, time.UTC)
+	caller, err := store.UpsertUser(context.Background(), User{PrimaryEmail: "caller@example.com"})
+	if err != nil {
+		t.Fatalf("upsert caller: %v", err)
+	}
+	ghost, err := store.UpsertUser(context.Background(), User{PrimaryEmail: "ghost@example.com"})
+	if err != nil {
+		t.Fatalf("upsert ghost: %v", err)
+	}
+	if _, err := store.SoftDeleteUser(context.Background(), ghost.ID, now.Add(-24*time.Hour)); err != nil {
+		t.Fatalf("soft delete ghost: %v", err)
+	}
+
+	scoped := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "ws-shared"})
+	if err := store.UpsertOrganization(scoped, TenancyOrganization{DisplayName: "Tenant A", Slug: "tenant-a"}); err != nil {
+		t.Fatalf("upsert org: %v", err)
+	}
+	if err := store.UpsertWorkspace(scoped, TenancyWorkspace{WorkspaceID: "ws-shared", DisplayName: "Shared", Slug: "ws-shared"}); err != nil {
+		t.Fatalf("upsert workspace: %v", err)
+	}
+	if err := store.UpsertWorkspaceMember(scoped, TenancyWorkspaceMember{
+		WorkspaceID: "ws-shared", MemberID: "m-caller", UserID: "subj-caller", UserUUID: caller.ID,
+		Role: "owner", Status: "active", JoinedAt: now,
+	}); err != nil {
+		t.Fatalf("upsert caller membership: %v", err)
+	}
+	if err := store.UpsertWorkspaceMember(scoped, TenancyWorkspaceMember{
+		WorkspaceID: "ws-shared", MemberID: "m-ghost", UserID: "subj-ghost", UserUUID: ghost.ID,
+		Role: "owner", Status: "active", JoinedAt: now,
+	}); err != nil {
+		t.Fatalf("upsert ghost membership: %v", err)
+	}
+
+	results, err := store.ListSoleOwnerWorkspaces(context.Background(), caller.ID)
+	if err != nil {
+		t.Fatalf("list sole owner: %v", err)
+	}
+	if len(results) != 1 || results[0].WorkspaceID != "ws-shared" {
+		t.Fatalf("expected ws-shared flagged with deleted co-owner excluded, got %+v", results)
+	}
+}

--- a/internal/db/memory_tenancy_test.go
+++ b/internal/db/memory_tenancy_test.go
@@ -1240,3 +1240,58 @@ func TestMemoryStoreListWorkspaceMembershipsByUserUUIDAndTenantID(t *testing.T) 
 		t.Fatalf("expected no memberships for unknown tenant, got %v", empty)
 	}
 }
+
+func TestMemoryStoreListSoleOwnerWorkspaces(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 5, 1, 9, 0, 0, 0, time.UTC)
+	ctx := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "ws-1"})
+	if err := store.UpsertOrganization(ctx, TenancyOrganization{DisplayName: "Tenant A", Slug: "tenant-a"}); err != nil {
+		t.Fatalf("upsert org: %v", err)
+	}
+	for _, workspaceID := range []string{"ws-sole", "ws-shared", "ws-other"} {
+		scoped := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: workspaceID})
+		if err := store.UpsertWorkspace(scoped, TenancyWorkspace{WorkspaceID: workspaceID, DisplayName: workspaceID, Slug: workspaceID}); err != nil {
+			t.Fatalf("upsert workspace %s: %v", workspaceID, err)
+		}
+	}
+	userUUID := "11111111-1111-1111-1111-111111111111"
+	other := "22222222-2222-2222-2222-222222222222"
+
+	scopedSole := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "ws-sole"})
+	if err := store.UpsertWorkspaceMember(scopedSole, TenancyWorkspaceMember{
+		WorkspaceID: "ws-sole", MemberID: "m-sole", UserID: "subj-sole", UserUUID: userUUID,
+		Role: "owner", Status: "active", JoinedAt: now,
+	}); err != nil {
+		t.Fatalf("upsert sole owner: %v", err)
+	}
+
+	scopedShared := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "ws-shared"})
+	if err := store.UpsertWorkspaceMember(scopedShared, TenancyWorkspaceMember{
+		WorkspaceID: "ws-shared", MemberID: "m-shared-1", UserID: "subj-shared-1", UserUUID: userUUID,
+		Role: "owner", Status: "active", JoinedAt: now,
+	}); err != nil {
+		t.Fatalf("upsert shared owner 1: %v", err)
+	}
+	if err := store.UpsertWorkspaceMember(scopedShared, TenancyWorkspaceMember{
+		WorkspaceID: "ws-shared", MemberID: "m-shared-2", UserID: "subj-shared-2", UserUUID: other,
+		Role: "owner", Status: "active", JoinedAt: now,
+	}); err != nil {
+		t.Fatalf("upsert shared owner 2: %v", err)
+	}
+
+	scopedOther := WithScope(context.Background(), Scope{TenantID: "tenant-a", WorkspaceID: "ws-other"})
+	if err := store.UpsertWorkspaceMember(scopedOther, TenancyWorkspaceMember{
+		WorkspaceID: "ws-other", MemberID: "m-other", UserID: "subj-other", UserUUID: other,
+		Role: "owner", Status: "active", JoinedAt: now,
+	}); err != nil {
+		t.Fatalf("upsert other workspace: %v", err)
+	}
+
+	results, err := store.ListSoleOwnerWorkspaces(context.Background(), userUUID)
+	if err != nil {
+		t.Fatalf("list sole owner: %v", err)
+	}
+	if len(results) != 1 || results[0].WorkspaceID != "ws-sole" {
+		t.Fatalf("expected only ws-sole, got %+v", results)
+	}
+}

--- a/internal/db/postgres_auth.go
+++ b/internal/db/postgres_auth.go
@@ -183,6 +183,137 @@ func (p *PostgresStore) SetUserStatus(ctx context.Context, userID string, status
 	return saved, nil
 }
 
+// SoftDeleteUser flips the account to status=deleted and stamps deleted_at to
+// open the reversible grace window. COALESCE keeps any existing deleted_at so a
+// repeat delete cannot push the purge deadline back.
+func (p *PostgresStore) SoftDeleteUser(ctx context.Context, userID string, now time.Time) (User, error) {
+	row := p.queryRowContextAnyScope(
+		ctx,
+		`UPDATE users
+		 SET status = 'deleted',
+		     deleted_at = COALESCE(deleted_at, $2::timestamptz),
+		     updated_at = $2::timestamptz
+		 WHERE id = NULLIF($1, '')::uuid
+		 RETURNING id::text, primary_email::text, display_name, avatar_url, status, created_at, updated_at, deleted_at`,
+		strings.TrimSpace(userID),
+		now.UTC(),
+	)
+	saved, err := scanUser(row)
+	if err != nil {
+		return User{}, err
+	}
+	audit.WriteAction(ctx, audit.AuditEvent{
+		Action:       "auth.user.delete",
+		ResourceType: "user",
+		ResourceID:   saved.ID,
+		Outcome:      "success",
+	})
+	return saved, nil
+}
+
+// CancelUserDeletion reverses a soft delete: clears deleted_at and returns the
+// account to active.
+func (p *PostgresStore) CancelUserDeletion(ctx context.Context, userID string, now time.Time) (User, error) {
+	row := p.queryRowContextAnyScope(
+		ctx,
+		`UPDATE users
+		 SET status = 'active',
+		     deleted_at = NULL,
+		     updated_at = $2::timestamptz
+		 WHERE id = NULLIF($1, '')::uuid
+		 RETURNING id::text, primary_email::text, display_name, avatar_url, status, created_at, updated_at, deleted_at`,
+		strings.TrimSpace(userID),
+		now.UTC(),
+	)
+	saved, err := scanUser(row)
+	if err != nil {
+		return User{}, err
+	}
+	audit.WriteAction(ctx, audit.AuditEvent{
+		Action:       "auth.user.delete.cancel",
+		ResourceType: "user",
+		ResourceID:   saved.ID,
+		Outcome:      "success",
+	})
+	return saved, nil
+}
+
+// ListUsersPendingHardDelete returns soft-deleted accounts whose grace window
+// closed (deleted_at < deletedBefore) and whose PII has not already been purged.
+func (p *PostgresStore) ListUsersPendingHardDelete(ctx context.Context, deletedBefore time.Time, limit int) ([]User, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := p.queryContextAnyScope(
+		ctx,
+		`SELECT id::text, primary_email::text, display_name, avatar_url, status, created_at, updated_at, deleted_at
+		 FROM users
+		 WHERE status = 'deleted'
+		   AND deleted_at IS NOT NULL
+		   AND deleted_at < $1::timestamptz
+		   AND primary_email::text NOT LIKE $2
+		 ORDER BY deleted_at ASC, id ASC
+		 LIMIT $3`,
+		deletedBefore.UTC(),
+		hardDeletedEmailPrefix+"%",
+		limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	users := make([]User, 0)
+	for rows.Next() {
+		user, scanErr := scanUser(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		users = append(users, user)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return users, nil
+}
+
+// HardDeleteUser purges PII from a soft-deleted account while keeping the row
+// so audit references by UUID stay valid. Provider identities (raw IdP claims)
+// and session rows are removed first, then the users row is tombstoned, so an
+// interrupted run leaves the account marked pending and gets safely reprocessed.
+func (p *PostgresStore) HardDeleteUser(ctx context.Context, userID string, now time.Time) (User, error) {
+	id := strings.TrimSpace(userID)
+	if _, err := p.execContextAnyScope(ctx, `DELETE FROM user_identities WHERE user_id = NULLIF($1, '')::uuid`, id); err != nil {
+		return User{}, err
+	}
+	if _, err := p.execContextAnyScope(ctx, `DELETE FROM sessions WHERE user_id = NULLIF($1, '')::uuid`, id); err != nil {
+		return User{}, err
+	}
+	row := p.queryRowContextAnyScope(
+		ctx,
+		`UPDATE users
+		 SET primary_email = $2::citext,
+		     display_name = '',
+		     avatar_url = '',
+		     updated_at = $3::timestamptz
+		 WHERE id = NULLIF($1, '')::uuid
+		 RETURNING id::text, primary_email::text, display_name, avatar_url, status, created_at, updated_at, deleted_at`,
+		id,
+		HardDeletedTombstoneEmail(id),
+		now.UTC(),
+	)
+	saved, err := scanUser(row)
+	if err != nil {
+		return User{}, err
+	}
+	audit.WriteAction(ctx, audit.AuditEvent{
+		Action:       "auth.user.hard_delete",
+		ResourceType: "user",
+		ResourceID:   saved.ID,
+		Outcome:      "success",
+	})
+	return saved, nil
+}
+
 // UpsertUserIdentity persists one provider identity mapping.
 func (p *PostgresStore) UpsertUserIdentity(ctx context.Context, identity UserIdentity) (UserIdentity, error) {
 	normalized, err := NormalizeUserIdentityForWrite(identity)

--- a/internal/db/postgres_auth.go
+++ b/internal/db/postgres_auth.go
@@ -251,11 +251,12 @@ func (p *PostgresStore) ListUsersPendingHardDelete(ctx context.Context, deletedB
 		 WHERE status = 'deleted'
 		   AND deleted_at IS NOT NULL
 		   AND deleted_at < $1::timestamptz
-		   AND primary_email::text NOT LIKE $2
+		   AND NOT (primary_email::text LIKE $2 AND primary_email::text LIKE $3)
 		 ORDER BY deleted_at ASC, id ASC
-		 LIMIT $3`,
+		 LIMIT $4`,
 		deletedBefore.UTC(),
 		hardDeletedEmailPrefix+"%",
+		"%"+hardDeletedEmailSuffix,
 		limit,
 	)
 	if err != nil {
@@ -288,12 +289,16 @@ func (p *PostgresStore) HardDeleteUser(ctx context.Context, userID string, now t
 	if _, err := p.execContextAnyScope(ctx, `DELETE FROM sessions WHERE user_id = NULLIF($1, '')::uuid`, id); err != nil {
 		return User{}, err
 	}
+	// status stays at 'deleted' explicitly so the lifecycle column never drifts
+	// off the tombstoned row (matches the memory store contract: a hard-deleted
+	// user is still 'deleted', just with PII purged).
 	row := p.queryRowContextAnyScope(
 		ctx,
 		`UPDATE users
 		 SET primary_email = $2::citext,
 		     display_name = '',
 		     avatar_url = '',
+		     status = 'deleted',
 		     updated_at = $3::timestamptz
 		 WHERE id = NULLIF($1, '')::uuid
 		 RETURNING id::text, primary_email::text, display_name, avatar_url, status, created_at, updated_at, deleted_at`,
@@ -659,6 +664,37 @@ func (p *PostgresStore) TouchSession(ctx context.Context, sessionIDHash []byte, 
 		     AND u.status = 'active'`,
 		sessionIDHash,
 		now.UTC(),
+	)
+	return scanSessionWithUser(row)
+}
+
+// TouchSessionAllowingPendingDeletion is TouchSession with the user-lifecycle
+// gate widened so cookies pointing to a soft-deleted-within-grace user resolve.
+// It is mounted only on `/v1/me/cancel-deletion`; every other route uses
+// TouchSession and continues to refuse deleted users.
+func (p *PostgresStore) TouchSessionAllowingPendingDeletion(ctx context.Context, sessionIDHash []byte, now time.Time) (Session, error) {
+	row := p.queryRowContextAnyScope(
+		ctx,
+		`WITH touched AS (
+		     UPDATE sessions
+		     SET idle_expires_at = LEAST($2::timestamptz + INTERVAL '15 minutes', absolute_expires_at),
+		         last_seen_at = $2::timestamptz
+		     WHERE id = $1
+		       AND revoked_at IS NULL
+		       AND idle_expires_at > $2::timestamptz
+		       AND absolute_expires_at > $2::timestamptz
+		     RETURNING *
+		   )
+		   SELECT `+sessionUserSelect+`
+		   FROM touched s
+		   JOIN users u ON u.id = s.user_id
+		   WHERE (u.deleted_at IS NULL AND u.status = 'active')
+		      OR (u.status = 'deleted'
+		          AND u.deleted_at IS NOT NULL
+		          AND u.deleted_at + ($3::bigint * INTERVAL '1 second') > $2::timestamptz)`,
+		sessionIDHash,
+		now.UTC(),
+		int64(UserDeletionGracePeriod/time.Second),
 	)
 	return scanSessionWithUser(row)
 }

--- a/internal/db/postgres_auth.go
+++ b/internal/db/postgres_auth.go
@@ -669,9 +669,11 @@ func (p *PostgresStore) TouchSession(ctx context.Context, sessionIDHash []byte, 
 }
 
 // TouchSessionAllowingPendingDeletion is TouchSession with the user-lifecycle
-// gate widened so cookies pointing to a soft-deleted-within-grace user resolve.
-// It is mounted only on `/v1/me/cancel-deletion`; every other route uses
-// TouchSession and continues to refuse deleted users.
+// gate widened so cookies pointing to a soft-deleted user resolve. The 30-day
+// grace gate is enforced at the handler layer (the cancel-deletion route
+// returns 410 past the window) rather than here, so the past-grace branch
+// remains reachable to produce a well-formed `grace_period_expired` response.
+// Mounted only on `/v1/me/cancel-deletion`; every other route uses TouchSession.
 func (p *PostgresStore) TouchSessionAllowingPendingDeletion(ctx context.Context, sessionIDHash []byte, now time.Time) (Session, error) {
 	row := p.queryRowContextAnyScope(
 		ctx,
@@ -689,12 +691,9 @@ func (p *PostgresStore) TouchSessionAllowingPendingDeletion(ctx context.Context,
 		   FROM touched s
 		   JOIN users u ON u.id = s.user_id
 		   WHERE (u.deleted_at IS NULL AND u.status = 'active')
-		      OR (u.status = 'deleted'
-		          AND u.deleted_at IS NOT NULL
-		          AND u.deleted_at + ($3::bigint * INTERVAL '1 second') > $2::timestamptz)`,
+		      OR (u.status = 'deleted' AND u.deleted_at IS NOT NULL)`,
 		sessionIDHash,
 		now.UTC(),
-		int64(UserDeletionGracePeriod/time.Second),
 	)
 	return scanSessionWithUser(row)
 }

--- a/internal/db/postgres_auth.go
+++ b/internal/db/postgres_auth.go
@@ -287,36 +287,21 @@ func (p *PostgresStore) ListUsersPendingHardDelete(ctx context.Context, deletedB
 // interrupted run leaves the account marked pending and gets safely reprocessed.
 func (p *PostgresStore) HardDeleteUser(ctx context.Context, userID string, now time.Time) (User, error) {
 	id := strings.TrimSpace(userID)
-	// Pre-flight: refuse unless the row is actually in pending-deletion state.
-	// Without this, a code path that calls HardDeleteUser against an active
-	// account would silently purge PII. The worker's selection query already
-	// guarantees the precondition, but this defense keeps a misuse from
-	// being unrecoverable.
-	var status string
-	var deletedAt sql.NullTime
-	if err := p.queryRowContextAnyScope(
-		ctx,
-		`SELECT status, deleted_at FROM users WHERE id = NULLIF($1, '')::uuid`,
-		id,
-	).Scan(&status, &deletedAt); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return User{}, ErrNotFound
+	when := now.UTC()
+	tx, err := p.db.BeginTx(ctx, nil)
+	if err != nil {
+		return User{}, err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
 		}
-		return User{}, err
-	}
-	if status != "deleted" || !deletedAt.Valid {
-		return User{}, fmt.Errorf("hard delete: user %s is not pending deletion (status=%q deleted_at=%v)", id, status, deletedAt.Valid)
-	}
-	if _, err := p.execContextAnyScope(ctx, `DELETE FROM user_identities WHERE user_id = NULLIF($1, '')::uuid`, id); err != nil {
-		return User{}, err
-	}
-	if _, err := p.execContextAnyScope(ctx, `DELETE FROM sessions WHERE user_id = NULLIF($1, '')::uuid`, id); err != nil {
-		return User{}, err
-	}
-	// status stays at 'deleted' explicitly so the lifecycle column never drifts
-	// off the tombstoned row (matches the memory store contract: a hard-deleted
-	// user is still 'deleted', just with PII purged).
-	row := p.queryRowContextAnyScope(
+	}()
+	// The pending-deletion predicate lives on the destructive UPDATE itself so
+	// a concurrent cancel-deletion cannot reactivate the row between a separate
+	// pre-check and the PII purge.
+	row := tx.QueryRowContext(
 		ctx,
 		`UPDATE users
 		 SET primary_email = $2::citext,
@@ -325,15 +310,42 @@ func (p *PostgresStore) HardDeleteUser(ctx context.Context, userID string, now t
 		     status = 'deleted',
 		     updated_at = $3::timestamptz
 		 WHERE id = NULLIF($1, '')::uuid
+		   AND status = 'deleted'
+		   AND deleted_at IS NOT NULL
 		 RETURNING id::text, primary_email::text, display_name, avatar_url, status, created_at, updated_at, deleted_at`,
 		id,
 		HardDeletedTombstoneEmail(id),
-		now.UTC(),
+		when,
 	)
 	saved, err := scanUser(row)
 	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			var status string
+			var deletedAt sql.NullTime
+			if lookupErr := tx.QueryRowContext(
+				ctx,
+				`SELECT status, deleted_at FROM users WHERE id = NULLIF($1, '')::uuid`,
+				id,
+			).Scan(&status, &deletedAt); lookupErr != nil {
+				if errors.Is(lookupErr, sql.ErrNoRows) {
+					return User{}, ErrNotFound
+				}
+				return User{}, lookupErr
+			}
+			return User{}, fmt.Errorf("hard delete: user %s is not pending deletion (status=%q deleted_at=%v)", id, status, deletedAt.Valid)
+		}
 		return User{}, err
 	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM user_identities WHERE user_id = NULLIF($1, '')::uuid`, id); err != nil {
+		return User{}, err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM sessions WHERE user_id = NULLIF($1, '')::uuid`, id); err != nil {
+		return User{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return User{}, err
+	}
+	committed = true
 	audit.WriteAction(ctx, audit.AuditEvent{
 		Action:       "auth.user.hard_delete",
 		ResourceType: "user",

--- a/internal/db/postgres_auth.go
+++ b/internal/db/postgres_auth.go
@@ -244,6 +244,10 @@ func (p *PostgresStore) ListUsersPendingHardDelete(ctx context.Context, deletedB
 	if limit <= 0 {
 		limit = 100
 	}
+	// The tombstone filter uses exact per-row matching against the
+	// deterministic placeholder for THIS user's id — a broad prefix/suffix
+	// LIKE would falsely exclude any legitimate user whose email happens to
+	// match the bracket and silently drop them from purge processing.
 	rows, err := p.queryContextAnyScope(
 		ctx,
 		`SELECT id::text, primary_email::text, display_name, avatar_url, status, created_at, updated_at, deleted_at
@@ -251,12 +255,12 @@ func (p *PostgresStore) ListUsersPendingHardDelete(ctx context.Context, deletedB
 		 WHERE status = 'deleted'
 		   AND deleted_at IS NOT NULL
 		   AND deleted_at < $1::timestamptz
-		   AND NOT (primary_email::text LIKE $2 AND primary_email::text LIKE $3)
+		   AND primary_email <> ($2 || id::text || $3)::citext
 		 ORDER BY deleted_at ASC, id ASC
 		 LIMIT $4`,
 		deletedBefore.UTC(),
-		hardDeletedEmailPrefix+"%",
-		"%"+hardDeletedEmailSuffix,
+		hardDeletedEmailPrefix,
+		hardDeletedEmailSuffix,
 		limit,
 	)
 	if err != nil {
@@ -283,6 +287,26 @@ func (p *PostgresStore) ListUsersPendingHardDelete(ctx context.Context, deletedB
 // interrupted run leaves the account marked pending and gets safely reprocessed.
 func (p *PostgresStore) HardDeleteUser(ctx context.Context, userID string, now time.Time) (User, error) {
 	id := strings.TrimSpace(userID)
+	// Pre-flight: refuse unless the row is actually in pending-deletion state.
+	// Without this, a code path that calls HardDeleteUser against an active
+	// account would silently purge PII. The worker's selection query already
+	// guarantees the precondition, but this defense keeps a misuse from
+	// being unrecoverable.
+	var status string
+	var deletedAt sql.NullTime
+	if err := p.queryRowContextAnyScope(
+		ctx,
+		`SELECT status, deleted_at FROM users WHERE id = NULLIF($1, '')::uuid`,
+		id,
+	).Scan(&status, &deletedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return User{}, ErrNotFound
+		}
+		return User{}, err
+	}
+	if status != "deleted" || !deletedAt.Valid {
+		return User{}, fmt.Errorf("hard delete: user %s is not pending deletion (status=%q deleted_at=%v)", id, status, deletedAt.Valid)
+	}
 	if _, err := p.execContextAnyScope(ctx, `DELETE FROM user_identities WHERE user_id = NULLIF($1, '')::uuid`, id); err != nil {
 		return User{}, err
 	}

--- a/internal/db/postgres_tenancy.go
+++ b/internal/db/postgres_tenancy.go
@@ -540,6 +540,61 @@ func (p *PostgresStore) ListWorkspaceMembershipsByUserUUIDAndTenantID(ctx contex
 	return memberships, nil
 }
 
+// ListSoleOwnerWorkspaces returns every workspace, across all tenants, in which
+// the user is the only active owner. Account deletion uses this to refuse with
+// a structured 409 until ownership is transferred, so a workspace never ends up
+// without a live owner once its current sole owner leaves.
+func (p *PostgresStore) ListSoleOwnerWorkspaces(ctx context.Context, userUUID string) ([]TenancyWorkspace, error) {
+	normalizedUserUUID := strings.TrimSpace(userUUID)
+	if normalizedUserUUID == "" {
+		return []TenancyWorkspace{}, nil
+	}
+	rows, err := p.queryContextAnyScope(
+		ctx,
+		`SELECT w.tenant_id, w.workspace_id, w.display_name, w.slug, w.created_at, w.updated_at
+		 FROM tenancy_workspaces w
+		 JOIN tenancy_workspace_members caller
+		   ON caller.tenant_id = w.tenant_id
+		  AND caller.workspace_id = w.workspace_id
+		  AND caller.user_uuid = NULLIF($1, '')::uuid
+		  AND caller.status = 'active'
+		  AND caller.role = 'owner'
+		 WHERE (
+		     SELECT COUNT(*)
+		     FROM tenancy_workspace_members other
+		     WHERE other.tenant_id = w.tenant_id
+		       AND other.workspace_id = w.workspace_id
+		       AND other.status = 'active'
+		       AND other.role = 'owner'
+		 ) = 1
+		 ORDER BY w.workspace_id ASC`,
+		normalizedUserUUID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	workspaces := make([]TenancyWorkspace, 0)
+	for rows.Next() {
+		var workspace TenancyWorkspace
+		if err := rows.Scan(
+			&workspace.TenantID,
+			&workspace.WorkspaceID,
+			&workspace.DisplayName,
+			&workspace.Slug,
+			&workspace.CreatedAt,
+			&workspace.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		workspaces = append(workspaces, workspace)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return workspaces, nil
+}
+
 // ListWorkspaceMembers lists members for one scoped workspace.
 func (p *PostgresStore) ListWorkspaceMembers(ctx context.Context, workspaceID string, limit int) ([]TenancyWorkspaceMember, error) {
 	scope, err := RequireScope(ctx)

--- a/internal/db/postgres_tenancy.go
+++ b/internal/db/postgres_tenancy.go
@@ -549,6 +549,12 @@ func (p *PostgresStore) ListSoleOwnerWorkspaces(ctx context.Context, userUUID st
 	if normalizedUserUUID == "" {
 		return []TenancyWorkspace{}, nil
 	}
+	// A workspace is "sole-owned" by the caller iff (a) the caller holds an
+	// active owner membership, and (b) no OTHER user holds an active owner
+	// membership backed by a non-deleted user row. Soft-deleted owners cannot
+	// transfer ownership, so counting them would let the caller delete their
+	// account while leaving the workspace with no live owner — exactly the
+	// invariant this guard exists to enforce.
 	rows, err := p.queryContextAnyScope(
 		ctx,
 		`SELECT w.tenant_id, w.workspace_id, w.display_name, w.slug, w.created_at, w.updated_at
@@ -559,14 +565,17 @@ func (p *PostgresStore) ListSoleOwnerWorkspaces(ctx context.Context, userUUID st
 		  AND caller.user_uuid = NULLIF($1, '')::uuid
 		  AND caller.status = 'active'
 		  AND caller.role = 'owner'
-		 WHERE (
-		     SELECT COUNT(*)
+		 WHERE NOT EXISTS (
+		     SELECT 1
 		     FROM tenancy_workspace_members other
+		     LEFT JOIN users other_u ON other_u.id = other.user_uuid
 		     WHERE other.tenant_id = w.tenant_id
 		       AND other.workspace_id = w.workspace_id
+		       AND other.user_uuid <> NULLIF($1, '')::uuid
 		       AND other.status = 'active'
 		       AND other.role = 'owner'
-		 ) = 1
+		       AND (other_u.id IS NULL OR other_u.status <> 'deleted')
+		 )
 		 ORDER BY w.workspace_id ASC`,
 		normalizedUserUUID,
 	)

--- a/internal/db/postgres_tenancy_test.go
+++ b/internal/db/postgres_tenancy_test.go
@@ -1269,14 +1269,17 @@ func TestPostgresStoreListSoleOwnerWorkspaces(t *testing.T) {
 		  AND caller.user_uuid = NULLIF($1, '')::uuid
 		  AND caller.status = 'active'
 		  AND caller.role = 'owner'
-		 WHERE (
-		     SELECT COUNT(*)
+		 WHERE NOT EXISTS (
+		     SELECT 1
 		     FROM tenancy_workspace_members other
+		     LEFT JOIN users other_u ON other_u.id = other.user_uuid
 		     WHERE other.tenant_id = w.tenant_id
 		       AND other.workspace_id = w.workspace_id
+		       AND other.user_uuid <> NULLIF($1, '')::uuid
 		       AND other.status = 'active'
 		       AND other.role = 'owner'
-		 ) = 1
+		       AND (other_u.id IS NULL OR other_u.status <> 'deleted')
+		 )
 		 ORDER BY w.workspace_id ASC`)).
 		WithArgs("11111111-1111-1111-1111-111111111111").
 		WillReturnRows(rows)

--- a/internal/db/postgres_tenancy_test.go
+++ b/internal/db/postgres_tenancy_test.go
@@ -1250,3 +1250,45 @@ func TestPostgresStoreScheduledScanPolicyListAndClaim(t *testing.T) {
 		t.Fatalf("unmet expectations: %v", err)
 	}
 }
+
+func TestPostgresStoreListSoleOwnerWorkspaces(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+	store := NewPostgresStoreWithDB(db)
+	now := time.Now().UTC()
+	rows := sqlmock.NewRows([]string{"tenant_id", "workspace_id", "display_name", "slug", "created_at", "updated_at"}).
+		AddRow("tenant-a", "ws-sole", "Sole-owned", "ws-sole", now, now)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT w.tenant_id, w.workspace_id, w.display_name, w.slug, w.created_at, w.updated_at
+		 FROM tenancy_workspaces w
+		 JOIN tenancy_workspace_members caller
+		   ON caller.tenant_id = w.tenant_id
+		  AND caller.workspace_id = w.workspace_id
+		  AND caller.user_uuid = NULLIF($1, '')::uuid
+		  AND caller.status = 'active'
+		  AND caller.role = 'owner'
+		 WHERE (
+		     SELECT COUNT(*)
+		     FROM tenancy_workspace_members other
+		     WHERE other.tenant_id = w.tenant_id
+		       AND other.workspace_id = w.workspace_id
+		       AND other.status = 'active'
+		       AND other.role = 'owner'
+		 ) = 1
+		 ORDER BY w.workspace_id ASC`)).
+		WithArgs("11111111-1111-1111-1111-111111111111").
+		WillReturnRows(rows)
+
+	results, err := store.ListSoleOwnerWorkspaces(context.Background(), "11111111-1111-1111-1111-111111111111")
+	if err != nil {
+		t.Fatalf("list sole owner: %v", err)
+	}
+	if len(results) != 1 || results[0].WorkspaceID != "ws-sole" {
+		t.Fatalf("unexpected payload: %+v", results)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -50,6 +50,42 @@ func TestPostgresStoreCreateAndCompleteScan(t *testing.T) {
 	}
 }
 
+func TestPostgresHardDeleteUserDoesNotPurgeActiveUser(t *testing.T) {
+	rawDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer rawDB.Close()
+
+	store := NewPostgresStoreWithDB(rawDB)
+	now := time.Now().UTC()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(`UPDATE users
+		 SET primary_email = $2::citext,
+		     display_name = '',
+		     avatar_url = '',
+		     status = 'deleted',
+		     updated_at = $3::timestamptz
+		 WHERE id = NULLIF($1, '')::uuid
+		   AND status = 'deleted'
+		   AND deleted_at IS NOT NULL
+		 RETURNING id::text, primary_email::text, display_name, avatar_url, status, created_at, updated_at, deleted_at`)).
+		WithArgs("user-1", HardDeletedTombstoneEmail("user-1"), now).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "primary_email", "display_name", "avatar_url", "status", "created_at", "updated_at", "deleted_at"}))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT status, deleted_at FROM users WHERE id = NULLIF($1, '')::uuid`)).
+		WithArgs("user-1").
+		WillReturnRows(sqlmock.NewRows([]string{"status", "deleted_at"}).AddRow("active", sql.NullTime{}))
+	mock.ExpectRollback()
+
+	if _, err := store.HardDeleteUser(context.Background(), "user-1", now); err == nil {
+		t.Fatal("expected active user hard delete to fail")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestPostgresStoreUpsertFindings(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -182,13 +182,13 @@ func HardDeletedTombstoneEmail(userID string) string {
 	return hardDeletedEmailPrefix + strings.ToLower(strings.TrimSpace(userID)) + hardDeletedEmailSuffix
 }
 
-// IsHardDeletedTombstoneEmail reports whether a primary_email is the synthetic
-// placeholder left behind by a completed hard delete. Both the prefix and the
-// reserved `accounts.invalid` suffix must match — the prefix alone would
-// misclassify legitimate `deleted-user+...` addresses on real domains.
-func IsHardDeletedTombstoneEmail(email string) bool {
-	normalized := strings.ToLower(strings.TrimSpace(email))
-	return strings.HasPrefix(normalized, hardDeletedEmailPrefix) && strings.HasSuffix(normalized, hardDeletedEmailSuffix)
+// IsHardDeletedTombstoneEmailForUser reports whether `email` is exactly the
+// deterministic tombstone for `userID`. Exact per-user matching avoids the
+// false positives a generic prefix+suffix scan would invite — a malicious
+// signup with the right shape could otherwise convince the worker that an
+// active account had already been purged and exclude it from future runs.
+func IsHardDeletedTombstoneEmailForUser(email string, userID string) bool {
+	return strings.EqualFold(strings.TrimSpace(email), HardDeletedTombstoneEmail(userID))
 }
 
 var validSessionAuthMethods = map[string]struct{}{

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -163,23 +163,32 @@ var validUserStatuses = map[string]struct{}{
 // honor.
 const UserDeletionGracePeriod = 30 * 24 * time.Hour
 
-// hardDeletedEmailPrefix marks the synthetic primary_email a user row carries
-// after PII purge. It keeps the NOT NULL / UNIQUE / length constraints on the
-// column satisfied while guaranteeing the value holds no real address, and lets
-// the pending-hard-delete query skip rows that were already purged so the daily
-// worker pass is idempotent rather than perpetual.
-const hardDeletedEmailPrefix = "deleted-user+"
+// hardDeletedEmailPrefix and hardDeletedEmailSuffix bracket the synthetic
+// primary_email a user row carries after PII purge. They keep the NOT NULL /
+// UNIQUE / length constraints on the column satisfied while guaranteeing the
+// value holds no real address, and let the pending-hard-delete query skip rows
+// that were already purged so the daily worker pass is idempotent rather than
+// perpetual. The suffix is part of the match so a real user whose email
+// legitimately starts with "deleted-user+" (the local part can be anything in
+// RFC 5321) is not misclassified as already tombstoned.
+const (
+	hardDeletedEmailPrefix = "deleted-user+"
+	hardDeletedEmailSuffix = "@accounts.invalid"
+)
 
 // HardDeletedTombstoneEmail returns the deterministic, PII-free placeholder
 // address assigned to a user row when its account is hard-deleted.
 func HardDeletedTombstoneEmail(userID string) string {
-	return hardDeletedEmailPrefix + strings.ToLower(strings.TrimSpace(userID)) + "@accounts.invalid"
+	return hardDeletedEmailPrefix + strings.ToLower(strings.TrimSpace(userID)) + hardDeletedEmailSuffix
 }
 
 // IsHardDeletedTombstoneEmail reports whether a primary_email is the synthetic
-// placeholder left behind by a completed hard delete.
+// placeholder left behind by a completed hard delete. Both the prefix and the
+// reserved `accounts.invalid` suffix must match — the prefix alone would
+// misclassify legitimate `deleted-user+...` addresses on real domains.
 func IsHardDeletedTombstoneEmail(email string) bool {
-	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(email)), hardDeletedEmailPrefix)
+	normalized := strings.ToLower(strings.TrimSpace(email))
+	return strings.HasPrefix(normalized, hardDeletedEmailPrefix) && strings.HasSuffix(normalized, hardDeletedEmailSuffix)
 }
 
 var validSessionAuthMethods = map[string]struct{}{
@@ -2636,6 +2645,12 @@ type Store interface {
 	DeleteUserIdentity(ctx context.Context, provider string, subject string) error
 	CreateSession(ctx context.Context, session Session) (Session, error)
 	TouchSession(ctx context.Context, sessionIDHash []byte, now time.Time) (Session, error)
+	// TouchSessionAllowingPendingDeletion is TouchSession with the lifecycle
+	// gate relaxed so cookies pointing to a soft-deleted-within-grace user
+	// resolve to their session. It is the single-purpose authentication path
+	// for `/v1/me/cancel-deletion` — every other route uses TouchSession and
+	// continues to refuse deleted users.
+	TouchSessionAllowingPendingDeletion(ctx context.Context, sessionIDHash []byte, now time.Time) (Session, error)
 	UpdateSessionContext(ctx context.Context, userID string, sessionIDHash []byte, orgID string, workspaceID string, projectID string, now time.Time) (Session, error)
 	ListUserSessions(ctx context.Context, userID string, now time.Time, limit int) ([]Session, error)
 	RevokeUserSession(ctx context.Context, userID string, sessionIDHash []byte, revokedAt time.Time) (Session, error)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -156,6 +156,32 @@ var validUserStatuses = map[string]struct{}{
 	"deleted":     {},
 }
 
+// UserDeletionGracePeriod is the window between the soft-delete request and the
+// hard-delete worker pass during which the user can cancel deletion. It is a
+// const so the API and worker agree on the same number — drifting between them
+// would mean the cancel-deletion endpoint advertises a date the worker does not
+// honor.
+const UserDeletionGracePeriod = 30 * 24 * time.Hour
+
+// hardDeletedEmailPrefix marks the synthetic primary_email a user row carries
+// after PII purge. It keeps the NOT NULL / UNIQUE / length constraints on the
+// column satisfied while guaranteeing the value holds no real address, and lets
+// the pending-hard-delete query skip rows that were already purged so the daily
+// worker pass is idempotent rather than perpetual.
+const hardDeletedEmailPrefix = "deleted-user+"
+
+// HardDeletedTombstoneEmail returns the deterministic, PII-free placeholder
+// address assigned to a user row when its account is hard-deleted.
+func HardDeletedTombstoneEmail(userID string) string {
+	return hardDeletedEmailPrefix + strings.ToLower(strings.TrimSpace(userID)) + "@accounts.invalid"
+}
+
+// IsHardDeletedTombstoneEmail reports whether a primary_email is the synthetic
+// placeholder left behind by a completed hard delete.
+func IsHardDeletedTombstoneEmail(email string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(email)), hardDeletedEmailPrefix)
+}
+
 var validSessionAuthMethods = map[string]struct{}{
 	"workos": {},
 	"oidc":   {},
@@ -2587,6 +2613,22 @@ type Store interface {
 	GetUser(ctx context.Context, userID string) (User, error)
 	GetUserByPrimaryEmail(ctx context.Context, email string) (User, error)
 	SetUserStatus(ctx context.Context, userID string, status string, now time.Time) (User, error)
+	// SoftDeleteUser flips the account to status=deleted and stamps deleted_at
+	// to start the reversible grace window. Idempotent: an already-deleted row
+	// keeps its original deleted_at so repeat calls cannot extend the deadline.
+	SoftDeleteUser(ctx context.Context, userID string, now time.Time) (User, error)
+	// CancelUserDeletion reverses a soft delete during the grace window: it
+	// clears deleted_at and returns the account to status=active.
+	CancelUserDeletion(ctx context.Context, userID string, now time.Time) (User, error)
+	// ListUsersPendingHardDelete returns soft-deleted accounts whose grace
+	// window closed (deleted_at < deletedBefore) and whose PII has not already
+	// been purged, so the worker can hard-delete them.
+	ListUsersPendingHardDelete(ctx context.Context, deletedBefore time.Time, limit int) ([]User, error)
+	// HardDeleteUser purges PII from a soft-deleted account (email tombstoned,
+	// display name and avatar cleared) and deletes its provider identities and
+	// sessions, while keeping the users row so audit references by UUID stay
+	// intact. Idempotent and safely re-runnable.
+	HardDeleteUser(ctx context.Context, userID string, now time.Time) (User, error)
 	UpsertUserIdentity(ctx context.Context, identity UserIdentity) (UserIdentity, error)
 	GetUserIdentity(ctx context.Context, provider string, subject string) (UserIdentity, error)
 	GetUserIdentityByProviderUserID(ctx context.Context, provider string, userID string) (UserIdentity, error)
@@ -2604,6 +2646,10 @@ type Store interface {
 	FindFirstWorkspaceMemberByUserUUID(ctx context.Context, userUUID string) (TenancyWorkspaceMember, error)
 	FindFirstWorkspaceMemberByUserUUIDAndTenantID(ctx context.Context, userUUID string, tenantID string) (TenancyWorkspaceMember, error)
 	ListWorkspaceMembershipsByUserUUIDAndTenantID(ctx context.Context, userUUID string, tenantID string) ([]TenancyWorkspaceMember, error)
+	// ListSoleOwnerWorkspaces returns every workspace, across all tenants, in
+	// which the user is the only active owner. Account deletion uses this to
+	// refuse with a structured 409 until ownership is transferred.
+	ListSoleOwnerWorkspaces(ctx context.Context, userUUID string) ([]TenancyWorkspace, error)
 	CreateInvitation(ctx context.Context, invitation Invitation) (Invitation, error)
 	GetInvitation(ctx context.Context, orgID string, invitationID string) (Invitation, error)
 	ListInvitations(ctx context.Context, orgID string, limit int) ([]Invitation, error)

--- a/internal/userpurge/userpurge.go
+++ b/internal/userpurge/userpurge.go
@@ -70,6 +70,14 @@ func (r *Runner) RunOnce(ctx context.Context) (Result, error) {
 			return result, ctx.Err()
 		}
 		if _, hardErr := r.Store.HardDeleteUser(ctx, user.ID, now); hardErr != nil {
+			// A canceled or timed-out context surfaces through HardDeleteUser
+			// as an error on the dropped DB write. Propagate it so the runner
+			// signals "interrupted" rather than "completed with errors": a
+			// quiet "Errors++" on the last item would let a caller treat the
+			// pass as having genuinely finished.
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return result, ctxErr
+			}
 			result.Errors++
 			audit.WriteAction(ctx, audit.AuditEvent{
 				Action:       "auth.user.hard_delete",

--- a/internal/userpurge/userpurge.go
+++ b/internal/userpurge/userpurge.go
@@ -1,0 +1,85 @@
+// Package userpurge runs the hard-delete pass for accounts that have completed
+// the soft-delete grace window. The pass is intentionally tiny — it lives in
+// its own package so the worker, scheduler, and integration tests can drive it
+// without pulling in unrelated API service surface.
+package userpurge
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/identrail/identrail/internal/audit"
+	"github.com/identrail/identrail/internal/db"
+)
+
+// Store is the subset of db.Store the purge pass needs. Narrowing the
+// interface keeps tests free of unrelated method stubs.
+type Store interface {
+	ListUsersPendingHardDelete(ctx context.Context, deletedBefore time.Time, limit int) ([]db.User, error)
+	HardDeleteUser(ctx context.Context, userID string, now time.Time) (db.User, error)
+}
+
+// Runner executes one hard-delete pass.
+type Runner struct {
+	Store     Store
+	Now       func() time.Time
+	BatchSize int
+	// GracePeriod is the soft-delete-to-hard-delete window. Defaults to
+	// db.UserDeletionGracePeriod when zero. Tests override it to exercise
+	// boundary conditions without sleeping 30 days.
+	GracePeriod time.Duration
+}
+
+// Result reports what one pass did. Returned for telemetry — the runner already
+// recorded structured audit events for each hard-delete it executed.
+type Result struct {
+	Examined int
+	Purged   int
+	Errors   int
+}
+
+// RunOnce processes one batch of pending hard-deletes. It is idempotent: a row
+// that has already been tombstoned is filtered out by ListUsersPendingHardDelete
+// so re-running the pass on the same wall-clock time is a no-op.
+func (r *Runner) RunOnce(ctx context.Context) (Result, error) {
+	if r.Store == nil {
+		return Result{}, errors.New("userpurge: store is required")
+	}
+	now := time.Now().UTC()
+	if r.Now != nil {
+		now = r.Now().UTC()
+	}
+	grace := r.GracePeriod
+	if grace <= 0 {
+		grace = db.UserDeletionGracePeriod
+	}
+	batchSize := r.BatchSize
+	if batchSize <= 0 {
+		batchSize = 100
+	}
+	cutoff := now.Add(-grace)
+	pending, err := r.Store.ListUsersPendingHardDelete(ctx, cutoff, batchSize)
+	if err != nil {
+		return Result{}, fmt.Errorf("list pending hard deletes: %w", err)
+	}
+	result := Result{Examined: len(pending)}
+	for _, user := range pending {
+		if ctx.Err() != nil {
+			return result, ctx.Err()
+		}
+		if _, hardErr := r.Store.HardDeleteUser(ctx, user.ID, now); hardErr != nil {
+			result.Errors++
+			audit.WriteAction(ctx, audit.AuditEvent{
+				Action:       "auth.user.hard_delete",
+				ResourceType: "user",
+				ResourceID:   user.ID,
+				Outcome:      "failure",
+			})
+			continue
+		}
+		result.Purged++
+	}
+	return result, nil
+}

--- a/internal/userpurge/userpurge_test.go
+++ b/internal/userpurge/userpurge_test.go
@@ -58,7 +58,7 @@ func TestRunOncePurgesAccountsPastGrace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get user A: %v", err)
 	}
-	if !db.IsHardDeletedTombstoneEmail(storedA.PrimaryEmail) {
+	if !db.IsHardDeletedTombstoneEmailForUser(storedA.PrimaryEmail, storedA.ID) {
 		t.Fatalf("expected user A to be tombstoned, got email %q", storedA.PrimaryEmail)
 	}
 	if storedA.DisplayName != "" || storedA.AvatarURL != "" {
@@ -129,6 +129,11 @@ type errStore struct {
 	listErr     error
 	hardDelErr  error
 	hardDelHits int
+	// onHardDel runs at the top of HardDeleteUser, before the canned error is
+	// returned. Tests use it to simulate a context cancellation that arrives
+	// *during* the call (after RunOnce passed the per-iteration ctx check),
+	// which is the only way to exercise the post-write ctx-error branch.
+	onHardDel func()
 }
 
 func (s *errStore) ListUsersPendingHardDelete(ctx context.Context, deletedBefore time.Time, limit int) ([]db.User, error) {
@@ -140,14 +145,22 @@ func (s *errStore) ListUsersPendingHardDelete(ctx context.Context, deletedBefore
 
 func (s *errStore) HardDeleteUser(ctx context.Context, userID string, now time.Time) (db.User, error) {
 	s.hardDelHits++
+	if s.onHardDel != nil {
+		s.onHardDel()
+	}
 	return db.User{}, s.hardDelErr
 }
 
 func TestRunOnceListErrorWraps(t *testing.T) {
-	r := &userpurge.Runner{Store: &errStore{listErr: context.Canceled}}
+	// Use a distinct sentinel so the assertion can prove RunOnce *preserved*
+	// (wrapped) the underlying error instead of swallowing or replacing it.
+	// `err != nil` alone would pass even if the runner returned a generic
+	// "list failed" string with no causal link to listErr.
+	sentinel := errors.New("synthetic list failure")
+	r := &userpurge.Runner{Store: &errStore{listErr: sentinel}}
 	_, err := r.RunOnce(context.Background())
-	if err == nil {
-		t.Fatal("expected wrapped list error")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected wrapped sentinel error, got %v", err)
 	}
 }
 
@@ -170,25 +183,35 @@ func TestRunOnceHardDeleteFailureCounted(t *testing.T) {
 }
 
 func TestRunOnceCanceledContextPropagates(t *testing.T) {
+	// Exercises the post-write ctx-error branch in RunOnce: HardDeleteUser
+	// fails AND the context was canceled mid-call. The runner must surface
+	// the context error rather than counting the iteration as Errors++.
+	// Cancelling the context BEFORE RunOnce would short-circuit on the
+	// per-iteration ctx check and bypass HardDeleteUser entirely, which is
+	// not the branch we want to exercise. Cancelling INSIDE HardDeleteUser
+	// (via onHardDel) is the only way to land in the post-write branch.
 	now := time.Now().UTC()
 	deletedAt := now.Add(-(db.UserDeletionGracePeriod + time.Hour))
-	// Distinct sentinel so the assertion can prove RunOnce surfaced the
-	// context-cancellation error rather than the unrelated HardDeleteUser
-	// failure. If both errors were context.Canceled the test could not
-	// distinguish the ctx-check branch from the post-write error branch.
 	forcedHardDelErr := errors.New("forced hard delete failure")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	store := &errStore{
 		pending:    []db.User{{ID: "u1", Status: "deleted", DeletedAt: &deletedAt}},
 		hardDelErr: forcedHardDelErr,
+		onHardDel:  cancel,
 	}
 	r := &userpurge.Runner{Store: store, Now: func() time.Time { return now }}
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	_, err := r.RunOnce(ctx)
+	result, err := r.RunOnce(ctx)
+	if store.hardDelHits != 1 {
+		t.Fatalf("expected HardDeleteUser to be invoked once, got %d", store.hardDelHits)
+	}
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 	if errors.Is(err, forcedHardDelErr) {
 		t.Fatalf("expected ctx error to take precedence over HardDeleteUser error, got %v", err)
+	}
+	if result.Errors != 0 {
+		t.Fatalf("expected ctx-interrupted iteration not to count as an error, got %+v", result)
 	}
 }

--- a/internal/userpurge/userpurge_test.go
+++ b/internal/userpurge/userpurge_test.go
@@ -1,0 +1,121 @@
+package userpurge_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/identrail/identrail/internal/db"
+	"github.com/identrail/identrail/internal/userpurge"
+)
+
+func TestRunOncePurgesAccountsPastGrace(t *testing.T) {
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	gracePast := now.Add(-(db.UserDeletionGracePeriod + 24*time.Hour))
+	graceFuture := now.Add(-(db.UserDeletionGracePeriod / 2))
+
+	// Account A is past the grace window — must be purged.
+	a, err := store.UpsertUser(context.Background(), db.User{
+		PrimaryEmail: "past@example.com",
+		DisplayName:  "Past Grace",
+		Status:       "deleted",
+		DeletedAt:    &gracePast,
+	})
+	if err != nil {
+		t.Fatalf("seed user A: %v", err)
+	}
+	// Account B is within the window — must NOT be purged.
+	b, err := store.UpsertUser(context.Background(), db.User{
+		PrimaryEmail: "future@example.com",
+		DisplayName:  "Within Grace",
+		Status:       "deleted",
+		DeletedAt:    &graceFuture,
+	})
+	if err != nil {
+		t.Fatalf("seed user B: %v", err)
+	}
+	// Account C is active and untouched.
+	c, err := store.UpsertUser(context.Background(), db.User{
+		PrimaryEmail: "active@example.com",
+		DisplayName:  "Active",
+	})
+	if err != nil {
+		t.Fatalf("seed user C: %v", err)
+	}
+
+	runner := &userpurge.Runner{Store: store, Now: func() time.Time { return now }, BatchSize: 100}
+	result, err := runner.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if result.Examined != 1 || result.Purged != 1 || result.Errors != 0 {
+		t.Fatalf("unexpected result %+v", result)
+	}
+
+	storedA, err := store.GetUser(context.Background(), a.ID)
+	if err != nil {
+		t.Fatalf("get user A: %v", err)
+	}
+	if !db.IsHardDeletedTombstoneEmail(storedA.PrimaryEmail) {
+		t.Fatalf("expected user A to be tombstoned, got email %q", storedA.PrimaryEmail)
+	}
+	if storedA.DisplayName != "" || storedA.AvatarURL != "" {
+		t.Fatalf("expected PII cleared on user A, got %+v", storedA)
+	}
+
+	storedB, err := store.GetUser(context.Background(), b.ID)
+	if err != nil {
+		t.Fatalf("get user B: %v", err)
+	}
+	if storedB.PrimaryEmail != "future@example.com" {
+		t.Fatalf("expected user B PII preserved within grace, got %q", storedB.PrimaryEmail)
+	}
+
+	storedC, err := store.GetUser(context.Background(), c.ID)
+	if err != nil {
+		t.Fatalf("get user C: %v", err)
+	}
+	if storedC.PrimaryEmail != "active@example.com" {
+		t.Fatalf("expected active user untouched, got %q", storedC.PrimaryEmail)
+	}
+}
+
+func TestRunOnceIsIdempotent(t *testing.T) {
+	// Re-running the worker after a successful purge must be a no-op: the
+	// tombstoned row is filtered out of ListUsersPendingHardDelete by its
+	// synthetic email, so subsequent passes do not re-purge it (and do not
+	// emit duplicate audit events).
+	store := db.NewMemoryStore()
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	past := now.Add(-(db.UserDeletionGracePeriod + time.Hour))
+	if _, err := store.UpsertUser(context.Background(), db.User{
+		PrimaryEmail: "tombstone@example.com",
+		Status:       "deleted",
+		DeletedAt:    &past,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	runner := &userpurge.Runner{Store: store, Now: func() time.Time { return now }}
+	first, err := runner.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	if first.Purged != 1 {
+		t.Fatalf("expected first run to purge 1, got %+v", first)
+	}
+	second, err := runner.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if second.Examined != 0 || second.Purged != 0 {
+		t.Fatalf("expected second run to be a no-op, got %+v", second)
+	}
+}
+
+func TestRunOnceRequiresStore(t *testing.T) {
+	runner := &userpurge.Runner{}
+	if _, err := runner.RunOnce(context.Background()); err == nil {
+		t.Fatal("expected error when Store is nil")
+	}
+}

--- a/internal/userpurge/userpurge_test.go
+++ b/internal/userpurge/userpurge_test.go
@@ -2,6 +2,7 @@ package userpurge_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -171,15 +172,23 @@ func TestRunOnceHardDeleteFailureCounted(t *testing.T) {
 func TestRunOnceCanceledContextPropagates(t *testing.T) {
 	now := time.Now().UTC()
 	deletedAt := now.Add(-(db.UserDeletionGracePeriod + time.Hour))
+	// Distinct sentinel so the assertion can prove RunOnce surfaced the
+	// context-cancellation error rather than the unrelated HardDeleteUser
+	// failure. If both errors were context.Canceled the test could not
+	// distinguish the ctx-check branch from the post-write error branch.
+	forcedHardDelErr := errors.New("forced hard delete failure")
 	store := &errStore{
 		pending:    []db.User{{ID: "u1", Status: "deleted", DeletedAt: &deletedAt}},
-		hardDelErr: context.Canceled,
+		hardDelErr: forcedHardDelErr,
 	}
 	r := &userpurge.Runner{Store: store, Now: func() time.Time { return now }}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	_, err := r.RunOnce(ctx)
-	if err == nil {
-		t.Fatal("expected canceled context to surface as error")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if errors.Is(err, forcedHardDelErr) {
+		t.Fatalf("expected ctx error to take precedence over HardDeleteUser error, got %v", err)
 	}
 }

--- a/internal/userpurge/userpurge_test.go
+++ b/internal/userpurge/userpurge_test.go
@@ -119,3 +119,67 @@ func TestRunOnceRequiresStore(t *testing.T) {
 		t.Fatal("expected error when Store is nil")
 	}
 }
+
+// errStore is a Store stub that lets RunOnce reach HardDeleteUser, then
+// always returns an error. Used to exercise the ctx-cancellation and
+// hard-delete-failure branches of RunOnce without needing a real DB.
+type errStore struct {
+	pending     []db.User
+	listErr     error
+	hardDelErr  error
+	hardDelHits int
+}
+
+func (s *errStore) ListUsersPendingHardDelete(ctx context.Context, deletedBefore time.Time, limit int) ([]db.User, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return s.pending, nil
+}
+
+func (s *errStore) HardDeleteUser(ctx context.Context, userID string, now time.Time) (db.User, error) {
+	s.hardDelHits++
+	return db.User{}, s.hardDelErr
+}
+
+func TestRunOnceListErrorWraps(t *testing.T) {
+	r := &userpurge.Runner{Store: &errStore{listErr: context.Canceled}}
+	_, err := r.RunOnce(context.Background())
+	if err == nil {
+		t.Fatal("expected wrapped list error")
+	}
+}
+
+func TestRunOnceHardDeleteFailureCounted(t *testing.T) {
+	now := time.Now().UTC()
+	deletedAt := now.Add(-(db.UserDeletionGracePeriod + time.Hour))
+	store := &errStore{
+		pending:    []db.User{{ID: "u1", Status: "deleted", DeletedAt: &deletedAt}},
+		hardDelErr: context.DeadlineExceeded,
+	}
+	r := &userpurge.Runner{Store: store, Now: func() time.Time { return now }}
+	// Active context — the error counts as a runtime failure, not cancellation.
+	result, err := r.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if result.Errors != 1 || result.Purged != 0 {
+		t.Fatalf("expected 1 error and 0 purged, got %+v", result)
+	}
+}
+
+func TestRunOnceCanceledContextPropagates(t *testing.T) {
+	now := time.Now().UTC()
+	deletedAt := now.Add(-(db.UserDeletionGracePeriod + time.Hour))
+	store := &errStore{
+		pending:    []db.User{{ID: "u1", Status: "deleted", DeletedAt: &deletedAt}},
+		hardDelErr: context.Canceled,
+	}
+	r := &userpurge.Runner{Store: store, Now: func() time.Time { return now }}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := r.RunOnce(ctx)
+	if err == nil {
+		t.Fatal("expected canceled context to surface as error")
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/identrail/identrail/internal/runtime"
 	"github.com/identrail/identrail/internal/scheduler"
 	"github.com/identrail/identrail/internal/telemetry"
+	"github.com/identrail/identrail/internal/userpurge"
 )
 
 const (
@@ -169,6 +170,35 @@ func Run(ctx context.Context, cfg config.Config, signals <-chan os.Signal) error
 			},
 		)
 	}
+	userPurgeRunner := &userpurge.Runner{
+		Store:     svc.Store,
+		Now:       svc.Now,
+		BatchSize: cfg.WorkerUserPurgeBatchSize,
+	}
+	userPurgeTrigger := func(runCtx context.Context) error {
+		writeHeartbeat()
+		result, runErr := userPurgeRunner.RunOnce(runCtx)
+		if runErr != nil {
+			logger.Error(
+				"user purge pass failed",
+				telemetry.StandardLogFields("worker", "user_purge",
+					telemetry.String("outcome", "failed"),
+					telemetry.ZapError(runErr),
+				)...,
+			)
+			return runErr
+		}
+		logger.Info(
+			"user purge pass completed",
+			telemetry.StandardLogFields("worker", "user_purge",
+				telemetry.String("examined", fmt.Sprint(result.Examined)),
+				telemetry.String("purged", fmt.Sprint(result.Purged)),
+				telemetry.String("errors", fmt.Sprint(result.Errors)),
+				telemetry.String("outcome", "completed"),
+			)...,
+		)
+		return nil
+	}
 	scanPolicyTrigger := func(runCtx context.Context) error {
 		writeHeartbeat()
 		result, runErr := svc.EnqueueDueScanPolicies(runCtx)
@@ -261,6 +291,28 @@ func Run(ctx context.Context, cfg config.Config, signals <-chan os.Signal) error
 				OnError: func(_ context.Context, err error) {
 					metrics.WorkerRetriesTotal.WithLabelValues("api_queue").Inc()
 					logger.Error("api queue runner iteration failed", telemetry.ZapError(err))
+				},
+			},
+		})
+	}
+	if cfg.WorkerUserPurgeEnabled {
+		runners = append(runners, scheduledRunner{
+			name:   "user-purge",
+			runNow: false,
+			runner: scheduler.Runner{
+				Interval:     cfg.WorkerUserPurgeInterval,
+				Key:          "user-purge",
+				Locker:       svc.Locker,
+				Trigger:      userPurgeTrigger,
+				MaxAttempts:  defaultWorkerQueueMaxAttempts,
+				RetryBackoff: defaultWorkerRetryBackoff,
+				OnDeadLetter: func(_ context.Context, err error) {
+					metrics.WorkerDeadLettersTotal.WithLabelValues("user_purge").Inc()
+					logger.Error("user purge exhausted retries; dead-letter event emitted", telemetry.ZapError(err))
+				},
+				OnError: func(_ context.Context, err error) {
+					metrics.WorkerRetriesTotal.WithLabelValues("user_purge").Inc()
+					logger.Error("user purge iteration failed", telemetry.ZapError(err))
 				},
 			},
 		})

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -296,12 +296,19 @@ func Run(ctx context.Context, cfg config.Config, signals <-chan os.Signal) error
 		})
 	}
 	if cfg.WorkerUserPurgeEnabled {
+		// Namespace the lock key the same way the scan-policy runner does, so
+		// two deployments sharing a Postgres lock backend cannot collide on a
+		// global "user-purge" advisory lock and silently starve each other.
+		userPurgeRunnerKey := "user-purge"
+		if namespace := strings.TrimSpace(svc.LockNamespace); namespace != "" {
+			userPurgeRunnerKey = namespace + ":" + userPurgeRunnerKey
+		}
 		runners = append(runners, scheduledRunner{
 			name:   "user-purge",
 			runNow: false,
 			runner: scheduler.Runner{
 				Interval:     cfg.WorkerUserPurgeInterval,
-				Key:          "user-purge",
+				Key:          userPurgeRunnerKey,
 				Locker:       svc.Locker,
 				Trigger:      userPurgeTrigger,
 				MaxAttempts:  defaultWorkerQueueMaxAttempts,

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -314,3 +314,32 @@ func TestRecordWorkerAutomationRun(t *testing.T) {
 		t.Fatalf("scheduled kubernetes partial metric = %v, want 1", got)
 	}
 }
+
+func TestRunRegistersUserPurgeRunner(t *testing.T) {
+	// Exercise the user-purge runner registration code path: with the worker
+	// scan disabled and user purge enabled, the cancellable Run() must still
+	// boot cleanly and exit on cancellation.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cfg := config.Config{
+		AllowMemoryStore:         true,
+		LogLevel:                 "info",
+		ServiceName:              "identrail-test",
+		Provider:                 "aws",
+		WorkerScanEnabled:        false,
+		WorkerScanPolicyEnabled:  false,
+		WorkerAPIJobQueueEnabled: false,
+		WorkerUserPurgeEnabled:   true,
+		WorkerUserPurgeInterval:  10 * time.Millisecond,
+		WorkerUserPurgeBatchSize: 50,
+		LockNamespace:            "test-ns",
+		APIKeys:                  []string{"test-read"},
+		WriteAPIKeys:             []string{"test-read"},
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	if err := Run(ctx, cfg, sigCh); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements [#1418](https://github.com/identrail/identrail/issues/1418): the backend for **Settings → Danger zone → Delete my account permanently**.

- `DELETE /v1/me` soft-deletes the authenticated user — flips status to `deleted`, stamps `deleted_at`, revokes every session, clears the cookie, and returns the scheduled `hard_delete_after` timestamp. Idempotent: a repeat call preserves the original `deleted_at` via `COALESCE`, so the purge deadline cannot be pushed back.
- Sole-owner check runs first and returns `409 sole_owner` with the affected workspaces, so deletion never orphans an unowned workspace. New `Store.ListSoleOwnerWorkspaces` (memory + postgres) drives the check.
- `POST /v1/me/cancel-deletion` reverses a soft delete during the 30-day grace window. Returns `410 grace_period_expired` once the worker is authoritative for the purge.
- WorkOS `intent=login` against a soft-deleted account is refused with the new `ErrAuthAccountPendingDeletion` → `403 account_pending_deletion`, **distinct** from the deactivated `account_reactivation_required` code so the frontend can offer cancellation rather than reactivation. A new `intent=cancel_deletion` is the canonical revive path; signup intent on deleted-within-grace accounts is preserved for backward compatibility.
- A daily worker pass under `internal/userpurge` hard-deletes accounts past the 30-day grace: PII is tombstoned (synthetic `deleted-user+<uuid>@accounts.invalid` email, display name and avatar cleared), provider identities and session rows are deleted, the `users` row is kept so audit references by UUID stay valid. Already-tombstoned rows are filtered out of `ListUsersPendingHardDelete`, so daily re-runs are no-ops.
- New audit actions: `auth.account.delete`, `auth.account.delete.cancel`, `auth.account.pending_deletion`, `auth.user.delete`, `auth.user.delete.cancel`, `auth.user.hard_delete`.

OpenAPI spec, route table, scopeless-session route allowlist, and `CHANGELOG.md` are all updated.

## Why

`CurrentUser.status` already accepted `'deleted'` and `deleted_at` was on the contract, but no endpoint transitioned a user into that state. Industry-standard 30-day reversible deletion prevents the most common "I clicked the wrong button" support escalation and keeps PII purge on a deterministic timer.

## Impact and risk

- Behavior change for soft-deleted accounts hitting WorkOS sign-in: `intent=login` now refuses with `account_pending_deletion` rather than treating the row like a deactivated one. Existing signup-intent revival is preserved so prior tests (and the WorkOS hosted login flow) keep working.
- Hard-delete worker is on by default (`IDENTRAIL_WORKER_USER_PURGE_ENABLED=true`, daily). The job is idempotent and gated on `deleted_at + 30d < now()`, so an over-eager worker cannot purge anyone within the grace window.
- The `users` row is preserved post-purge with a synthetic tombstone email — existing FK references and audit rows are intact. The Postgres update casts the new email to `citext` so the unique constraint stays satisfied.

## Validation performed

```
make fmt-check
make vet
go test ./internal/api/... ./internal/db/... ./internal/userpurge/ ./internal/config/ ./internal/worker/
make api-example-contract-check
```

All pass. New unit tests cover: the sole-owner block leaves the user untouched, login-intent refusal with `ErrAuthAccountPendingDeletion`, `cancel_deletion` intent revives the row, past-grace sign-in returns `ErrAuthAccountNotFound`, worker idempotency on a tombstoned row, store-level PII purge clears identities + sessions, soft-delete preserves the original `deleted_at` on repeat.

## Test plan

- [ ] `DELETE /v1/me` happy path: account flips to `deleted`, session cookie cleared, `hard_delete_after` returned.
- [ ] `DELETE /v1/me` with sole-owner workspace returns `409 sole_owner` with the workspaces array; user remains `active`.
- [ ] Sign-in (intent=login) for a soft-deleted user returns `403 account_pending_deletion`.
- [ ] WorkOS `intent=cancel_deletion` for a soft-deleted user within grace logs the user in with `status=active` and `deleted_at=null`.
- [ ] Past 30 days, the worker hard-deletes the user; PII fields are tombstoned, identities removed, audit row UUID still resolvable.
- [ ] Re-running the worker on the same wall-clock day is a no-op (no duplicate audit events).
- [ ] `POST /v1/me/cancel-deletion` against a `gone` account returns 410.

## AI disclosure

- AI-assisted: yes
- Tools used: Claude (Sonnet 4.6)
- Where used: `internal/api/`, `internal/db/`, `internal/userpurge/`, `internal/worker/`, `internal/config/`, `docs/openapi-v1.yaml`, `CHANGELOG.md`
- Human verification performed: full Go test suite for the touched packages, `make fmt-check`, `make vet`, `make api-example-contract-check`; manually traced the soft-delete → revoke → status flip → revoke "three-step sandwich" against the deactivate precedent and verified the cancel_deletion intent threads through both the identity-resolved and email-resolved sign-in branches.

Closes #1418

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds self-serve permanent account deletion with a 30‑day grace window, a recovery-cookie flow to undo deletion, and a daily hard-delete worker. Tightens sole-owner safety and makes the purge pass stricter, atomic, and idempotent.

- New Features
  - `DELETE /v1/me`: soft-deletes the user, revokes other sessions, preserves the calling cookie as a recovery cookie, and returns `hard_delete_after` and `grace_period_hours`; idempotent.
  - Recovery: `POST /v1/me/cancel-deletion` accepts the recovery cookie via a route-scoped lenient session lookup and restores the account within grace; after grace returns 410 `grace_period_expired`; idempotent when already active. Router allowlists `/v1/me/cancel-deletion` for scopeless sessions and pending-deletion cookies.
  - Sole-owner guard: pre-flight 409 `sole_owner` with affected workspaces; a post–soft-delete re-check rolls back and returns 409 if a race creates new sole ownership; on rollback failure returns 500. Soft-deleted users are excluded from the “other live owner” count so a workspace never ends up ownerless.
  - WorkOS sign-in: `intent=login` on a soft-deleted user returns 403 `account_pending_deletion`; `intent=cancel_deletion` (or `signup`) revives within grace; past grace returns `account_not_found`.
  - Daily worker hard-deletes past 30 days: tombstones email to `deleted-user+<uuid>@accounts.invalid` (exact per-user match), clears name/avatar, removes identities/sessions, keeps the `users` row; only purges when `status='deleted'` and `deleted_at` is set; enforced atomically in Postgres; idempotent and namespaced with `IDENTRAIL_LOCK_NAMESPACE`.
  - OpenAPI, route policy, and scopeless-session allowlist updated. New audit actions: `auth.account.delete`, `auth.account.delete.cancel`, `auth.account.pending_deletion`, `auth.user.delete`, `auth.user.delete.cancel`, `auth.user.hard_delete`.

- Migration
  - Worker config (defaults): `IDENTRAIL_WORKER_USER_PURGE_ENABLED=true`, `IDENTRAIL_WORKER_USER_PURGE_INTERVAL=24h`, `IDENTRAIL_WORKER_USER_PURGE_BATCH_SIZE=100`.
  - Update auth UI to handle 403 `account_pending_deletion` by offering cancellation. Use the recovery cookie to call `POST /v1/me/cancel-deletion` in the same browser, or use WorkOS `intent=cancel_deletion` within grace.

<sup>Written for commit 8ee0fbd48004cf3a6d1f4fa38f42ed3b2b89267f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

