### PR TITLE
Move GitHub setup into the GitHub domain section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@
   outcome rather than preferring an older successful one. The Connect page
   renders an `Open GitHub` fallback link with the App install URL when the
   browser blocks `window.open` after the install request. The Repositories
-  activity timeline is scoped to selected repositories.
+  activity timeline is scoped to selected repositories. The Connect page
+  also forwards `redirect_uri` (`${origin}/app/github/callback`) when
+  starting the GitHub App install so completion lands back on the Identrail
+  callback handler instead of GitHub's default setup URL. The Repositories
+  page disables `Queue scan` and `Cancel scan` while environment data is
+  reloading to prevent acting on stale repository rows after switching
+  environments.
 - Moved GitHub setup, repository scan operation, and the Actions/OIDC
   posture surface out of the legacy `/projects/:projectID` source tab into a
   domain-owned GitHub section. The new `/app/:tenant/:workspace/github`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
 ## Unreleased
+- Moved GitHub setup, repository scan operation, and the Actions/OIDC
+  posture surface out of the legacy `/projects/:projectID` source tab into a
+  domain-owned GitHub section. The new `/app/:tenant/:workspace/github`
+  Control Center surfaces connection status, installation summary, selected
+  repository coverage, recent scan activity, and recommended next actions.
+  `/github/connect` owns the GitHub App install entry point and the
+  Enterprise/PAT fallback link; `/github/repositories` owns selected
+  repository inventory plus repository scan launch and cancel; and
+  `/github/actions` is the premium waiting-for-coverage shell for workflow
+  permissions, OIDC trust paths, and runner posture. Existing GitHub
+  connector, repository scan, and project-scoped API contracts are preserved
+  — the new pages call the same `getGitHubConnectorStatus`,
+  `startGitHubConnector`, `listRepoScans`, `runRepoScan`, and
+  `cancelRepoScan` endpoints, including the internal `project_id` scope, so
+  backend behavior is unchanged.
 - Extended the shared domain page framework in `web/src/components/app/DomainFoundation.tsx`
   with typed `DomainStatusBadge` variants (connected, disconnected, needs-attention,
   degraded, running-scan, missing-permissions, coming-soon), `DomainCoverageCard`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
 ## Unreleased
+- Hardened the new GitHub domain pages to address review feedback: the
+  Control Center now surfaces a `Unable to load GitHub status` error when
+  listing recent repository scans fails instead of silently showing an empty
+  timeline, scopes the `Recent scans` panel and `Latest scan` KPI strictly to
+  scans for the selected GitHub App repositories (no fallback to all scans),
+  and the `Latest scan` KPI reflects the newest completed scan's actual
+  outcome rather than preferring an older successful one. The Connect page
+  renders an `Open GitHub` fallback link with the App install URL when the
+  browser blocks `window.open` after the install request. The Repositories
+  activity timeline is scoped to selected repositories.
 - Moved GitHub setup, repository scan operation, and the Actions/OIDC
   posture surface out of the legacy `/projects/:projectID` source tab into a
   domain-owned GitHub section. The new `/app/:tenant/:workspace/github`

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1419,8 +1419,8 @@ describe('App', () => {
     setCurrentPath('/app/tenant-a/workspace-a/github/connect');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { level: 2, name: /Unable to open GitHub setup/i })).toBeInTheDocument();
-    expect(screen.getByText(/GitHub connector is not available in this build/i)).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: /^Connect GitHub$/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 3, name: /GitHub is not available on this API/i })).toBeInTheDocument();
     expect(window.location.pathname).toBe('/app/tenant-a/workspace-a/github/connect');
     expect(screen.queryByRole('link', { name: 'Projects' })).not.toBeInTheDocument();
   });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -33,7 +33,10 @@ import {
   ProductAWSConnectPage,
   ProductExecutiveReportPage,
   ProductFindingsPage,
+  ProductGitHubActionsPage,
   ProductGitHubCallbackPage,
+  ProductGitHubControlCenterPage,
+  ProductGitHubRepositoriesPage,
   ProductKubernetesConnectPage,
   ProductGitHubConnectPage,
   ProductLoginPage,
@@ -4783,10 +4786,10 @@ export function RoutedSite() {
             <Route path="aws/findings" element={<ProductDomainRoutePage domain="aws" routeID="findings" />} />
             <Route path="aws/remediation" element={<ProductDomainRoutePage domain="aws" routeID="remediation" />} />
             <Route path="aws/governance" element={<ProductDomainRoutePage domain="aws" routeID="governance" />} />
-            <Route path="github" element={<ProductDomainRoutePage domain="github" />} />
+            <Route path="github" element={<ProductGitHubControlCenterPage />} />
             <Route path="github/connect" element={<ProductGitHubConnectPage />} />
-            <Route path="github/repositories" element={<ProductDomainRoutePage domain="github" routeID="repositories" />} />
-            <Route path="github/actions" element={<ProductDomainRoutePage domain="github" routeID="actions" />} />
+            <Route path="github/repositories" element={<ProductGitHubRepositoriesPage />} />
+            <Route path="github/actions" element={<ProductGitHubActionsPage />} />
             <Route path="github/findings" element={<ProductFindingsPage />} />
             <Route path="github/remediation" element={<ProductDomainRoutePage domain="github" routeID="remediation" />} />
             <Route path="github/agentic-risk" element={<ProductAIRisksPage />} />

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -1958,7 +1958,11 @@ describe('GitHub domain pages (#1382)', () => {
 
     await waitFor(() =>
       expect(mocks.startGitHubConnector).toHaveBeenCalledWith(
-        expect.objectContaining({ project_id: 'production-platform', install_account_type: 'any' }),
+        expect.objectContaining({
+          project_id: 'production-platform',
+          install_account_type: 'any',
+          redirect_uri: expect.stringMatching(/\/app\/github\/callback$/)
+        }),
         expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
       )
     );
@@ -2171,5 +2175,31 @@ describe('GitHub domain pages (#1382)', () => {
     await screen.findByRole('heading', { level: 3, name: /Recent repository scan activity/i });
     expect(screen.getByText(/0 scans loaded/i)).toBeInTheDocument();
     expect(screen.queryByText(/someone-else\/other-repo/i)).not.toBeInTheDocument();
+  });
+
+  it('Repositories page disables Queue scan while environment data is reloading', async () => {
+    const mocks = await renderGitHubPage('repositories', { scans: [] });
+
+    const queueButton = await screen.findByRole('button', { name: 'Queue scan for identrail/identrail' });
+    expect(queueButton).not.toBeDisabled();
+
+    let resolvePending: ((value: { items: RepoScanRecord[] }) => void) | null = null;
+    mocks.listRepoScans.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePending = resolve;
+        })
+    );
+
+    fireEvent.click(queueButton);
+    await waitFor(() => expect(mocks.runRepoScan).toHaveBeenCalledTimes(1));
+
+    await waitFor(() => expect(queueButton).toBeDisabled());
+    expect(queueButton).toHaveTextContent(/Refreshing|Queuing/i);
+
+    await act(async () => {
+      resolvePending?.({ items: [] });
+      await Promise.resolve();
+    });
   });
 });

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -2070,4 +2070,106 @@ describe('GitHub domain pages (#1382)', () => {
     await screen.findByRole('heading', { level: 2, name: 'GitHub Actions / OIDC' });
     await screen.findByRole('heading', { level: 3, name: /GitHub is not available on this API/i });
   });
+
+  it('Control Center surfaces an error when listing repository scans fails', async () => {
+    const api = await import('./api/client');
+    mockConnectorFeatureFlags({ aws: false, github: true, kubernetes: false });
+    mockBackendFeatures({ github: true });
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({ items: [productionProject] });
+    vi.spyOn(api.apiClient, 'getProject').mockResolvedValue({ project: productionProject });
+    vi.spyOn(api.apiClient, 'getGitHubConnectorStatus').mockResolvedValue({ connection: connectedGitHub });
+    vi.spyOn(api.apiClient, 'listRepoScans').mockRejectedValue(
+      new api.ApiError('rate limited', 429)
+    );
+
+    const productShell = await import('./productShell');
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/github']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/github" element={<productShell.ProductGitHubControlCenterPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub Control Center' });
+    await screen.findByRole('heading', { level: 3, name: /Unable to load GitHub status/i });
+  });
+
+  it('Control Center hides recent scans when no repositories are selected', async () => {
+    const unrelatedScan: RepoScanRecord = {
+      ...succeededRepoScan,
+      id: 'repo-scan-unrelated',
+      repository: 'someone-else/other-repo'
+    };
+    await renderGitHubPage('control-center', {
+      githubConnection: { ...connectedGitHub, selected_repositories: [] },
+      scans: [unrelatedScan]
+    });
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub Control Center' });
+    expect(screen.queryByText(/Last \d+ repository scans/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/someone-else\/other-repo/i)).not.toBeInTheDocument();
+    await screen.findByRole('heading', { level: 3, name: /No repository scans yet/i });
+  });
+
+  it('Control Center latest-scan KPI reflects the newest scan even when it failed', async () => {
+    const olderSucceeded: RepoScanRecord = {
+      ...succeededRepoScan,
+      id: 'repo-scan-older-success',
+      started_at: '2026-05-16T10:00:00Z',
+      finished_at: '2026-05-16T10:05:00Z'
+    };
+    const newerFailed: RepoScanRecord = {
+      ...succeededRepoScan,
+      id: 'repo-scan-newer-failed',
+      status: 'failed',
+      started_at: '2026-05-17T12:00:00Z',
+      finished_at: '2026-05-17T12:05:00Z',
+      error_message: 'scan exploded',
+      finding_count: 0
+    };
+    await renderGitHubPage('control-center', { scans: [newerFailed, olderSucceeded] });
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub Control Center' });
+    await screen.findAllByText(/scan exploded/i);
+    const kpiStrip = screen.getByLabelText('GitHub control center metrics');
+    expect(within(kpiStrip).getByText(/scan exploded/i)).toBeInTheDocument();
+  });
+
+  it('Connect page renders an Open GitHub fallback link when the install popup is blocked', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    await renderGitHubPage('connect', {
+      githubConnection: {
+        ...connectedGitHub,
+        connected: false,
+        account_login: undefined,
+        installation_id: undefined,
+        selected_repositories: []
+      }
+    });
+
+    const installButton = (await screen.findAllByRole('button', { name: 'Install GitHub App' }))[0];
+    fireEvent.click(installButton);
+
+    const fallback = await screen.findByRole('link', { name: 'Open GitHub' });
+    expect(fallback.getAttribute('href')).toBe(
+      'https://github.com/apps/identrail/installations/select_target?state=github-state'
+    );
+    expect(openSpy).toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+
+  it('Repositories page activity timeline ignores scans for unselected repositories', async () => {
+    const unrelatedScan: RepoScanRecord = {
+      ...succeededRepoScan,
+      id: 'repo-scan-unrelated',
+      repository: 'someone-else/other-repo'
+    };
+    await renderGitHubPage('repositories', { scans: [unrelatedScan] });
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub repositories' });
+    await screen.findByRole('heading', { level: 3, name: /Recent repository scan activity/i });
+    expect(screen.getByText(/0 scans loaded/i)).toBeInTheDocument();
+    expect(screen.queryByText(/someone-else\/other-repo/i)).not.toBeInTheDocument();
+  });
 });

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -1809,6 +1809,7 @@ describe('GitHub domain pages (#1382)', () => {
     options: {
       githubConnection?: GitHubConnectionStatus | null;
       scans?: RepoScanRecord[];
+      listRepoScans?: () => Promise<{ items: RepoScanRecord[]; next_cursor?: string }>;
       githubFeatureFlag?: boolean;
       githubBackend?: BackendFeatureState;
       runRepoScanError?: { message: string; status: number };
@@ -1825,9 +1826,12 @@ describe('GitHub domain pages (#1382)', () => {
     const getGitHubConnectorStatus = vi
       .spyOn(api.apiClient, 'getGitHubConnectorStatus')
       .mockResolvedValue({ connection: options.githubConnection ?? connectedGitHub });
-    const listRepoScans = vi
-      .spyOn(api.apiClient, 'listRepoScans')
-      .mockResolvedValue({ items: options.scans ?? [] });
+    const listRepoScans = vi.spyOn(api.apiClient, 'listRepoScans');
+    if (options.listRepoScans) {
+      listRepoScans.mockImplementation(() => options.listRepoScans?.() ?? Promise.resolve({ items: [] }));
+    } else {
+      listRepoScans.mockResolvedValue({ items: options.scans ?? [] });
+    }
     const runRepoScan = vi.spyOn(api.apiClient, 'runRepoScan');
     if (options.runRepoScanError) {
       runRepoScan.mockRejectedValue(new api.ApiError(options.runRepoScanError.message, options.runRepoScanError.status));
@@ -2177,13 +2181,114 @@ describe('GitHub domain pages (#1382)', () => {
     expect(screen.queryByText(/someone-else\/other-repo/i)).not.toBeInTheDocument();
   });
 
+  it('Repositories page fetches additional scan pages until selected-repository activity is available', async () => {
+    const unrelatedRepoScans: RepoScanRecord[] = Array.from({ length: 3 }).map((_, index) => ({
+      ...succeededRepoScan,
+      id: `repo-scan-unrelated-${index}`,
+      repository: `team-${index + 1}/unrelated`
+    }));
+    const selectedRepoScan: RepoScanRecord = {
+      ...queuedRepoScan,
+      id: 'repo-scan-selected',
+      repository: 'identrail/identrail',
+      status: 'completed',
+      started_at: '2026-05-18T10:00:00Z',
+      finished_at: '2026-05-18T10:03:00Z',
+      finding_count: 2,
+      files_scanned: 17
+    };
+
+    let pageCalls = 0;
+    const mocks = await renderGitHubPage('repositories', {
+      listRepoScans: () => {
+        pageCalls += 1;
+        if (pageCalls === 1) {
+          return Promise.resolve({
+            items: unrelatedRepoScans,
+            next_cursor: 'repo-page-2'
+          });
+        }
+        return Promise.resolve({
+          items: [selectedRepoScan]
+        });
+      }
+    });
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub repositories' });
+    await waitFor(() => expect(mocks.listRepoScans).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByText(/1 scan loaded/i)).toBeInTheDocument());
+    expect(screen.getAllByText(/identrail\/identrail/i)).toHaveLength(2);
+  });
+
+  it('Repositories page clears stale GitHub connection data when a reloading environment status fails', async () => {
+    const api = await import('./api/client');
+    mockConnectorFeatureFlags({ aws: false, github: true, kubernetes: false });
+    mockBackendFeatures({ github: true });
+
+    const activeProject = productionProject;
+    const staleProject = {
+      ...productionProject,
+      project_id: 'staging-platform',
+      name: 'Staging Platform',
+      slug: 'staging-platform'
+    };
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [activeProject, staleProject]
+    });
+    vi.spyOn(api.apiClient, 'getProject').mockImplementation(async (_workspaceID, projectID) => ({
+      project:
+        projectID === staleProject.project_id
+          ? staleProject
+          : activeProject
+    }));
+
+    const getGitHubConnectorStatus = vi
+      .spyOn(api.apiClient, 'getGitHubConnectorStatus')
+      .mockResolvedValueOnce({ connection: connectedGitHub })
+      .mockRejectedValue(new api.ApiError('status endpoint unavailable', 503));
+    vi.spyOn(api.apiClient, 'listRepoScans').mockResolvedValue({ items: [queuedRepoScan] });
+    vi.spyOn(api.apiClient, 'runRepoScan').mockResolvedValue({ repo_scan: queuedRepoScan });
+    vi.spyOn(api.apiClient, 'cancelRepoScan').mockResolvedValue({ repo_scan: canceledRepoScan });
+
+    const { ProductGitHubRepositoriesPage } = await import('./productShell');
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/github/repositories?environment=production-platform']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/github/repositories" element={<ProductGitHubRepositoriesPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub repositories' });
+    await waitFor(() => expect(screen.getByRole('combobox', { name: 'Environment' })).toHaveValue('production-platform'));
+    expect(await screen.findByRole('button', { name: 'Queue scan for identrail/identrail' })).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.change(screen.getByRole('combobox', { name: 'Environment' }), {
+        target: { value: 'staging-platform' }
+      });
+    });
+
+    await screen.findByRole('heading', { level: 3, name: /Unable to load repository status/i });
+    expect(screen.queryByRole('button', { name: 'Queue scan for identrail/identrail' })).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: /Connect GitHub to manage repositories/i })).toBeInTheDocument();
+
+    expect(getGitHubConnectorStatus).toHaveBeenCalledTimes(2);
+  });
+
   it('Repositories page disables Queue scan while environment data is reloading', async () => {
     const mocks = await renderGitHubPage('repositories', { scans: [] });
 
-    const queueButton = await screen.findByRole('button', { name: 'Queue scan for identrail/identrail' });
-    expect(queueButton).not.toBeDisabled();
+    expect(await screen.findByRole('button', { name: 'Queue scan for identrail/identrail' })).not.toBeDisabled();
 
+    let resolveQueued: ((value: { repo_scan: RepoScanRecord }) => void) | null = null;
     let resolvePending: ((value: { items: RepoScanRecord[] }) => void) | null = null;
+    mocks.runRepoScan.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveQueued = resolve;
+        })
+    );
     mocks.listRepoScans.mockImplementation(
       () =>
         new Promise((resolve) => {
@@ -2191,12 +2296,17 @@ describe('GitHub domain pages (#1382)', () => {
         })
     );
 
-    fireEvent.click(queueButton);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Queue scan for identrail/identrail' }));
+    });
     await waitFor(() => expect(mocks.runRepoScan).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Queue scan for identrail/identrail' })).toBeDisabled());
+    expect(screen.getByRole('button', { name: 'Queue scan for identrail/identrail' })).toHaveTextContent(/Refreshing|Queuing/i);
 
-    await waitFor(() => expect(queueButton).toBeDisabled());
-    expect(queueButton).toHaveTextContent(/Refreshing|Queuing/i);
-
+    await act(async () => {
+      resolveQueued?.({ repo_scan: queuedRepoScan });
+      await Promise.resolve();
+    });
     await act(async () => {
       resolvePending?.({ items: [] });
       await Promise.resolve();

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -1771,3 +1771,303 @@ describe('ProductFindingsPage states', () => {
     expect(screen.queryByRole('dialog', { name: /IAM role with wildcard trust/i })).not.toBeInTheDocument();
   });
 });
+
+describe('GitHub domain pages (#1382)', () => {
+  const productionProject = {
+    tenant_id: 'tenant-a',
+    workspace_id: 'workspace-a',
+    project_id: 'production-platform',
+    name: 'Production Platform',
+    slug: 'production-platform',
+    description: 'Production identity boundary.',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-02T00:00:00Z'
+  };
+
+  const succeededRepoScan: RepoScanRecord = {
+    id: 'repo-scan-succeeded',
+    repository: 'identrail/identrail',
+    status: 'succeeded',
+    started_at: '2026-05-17T10:50:00Z',
+    finished_at: '2026-05-17T10:55:00Z',
+    commits_scanned: 12,
+    files_scanned: 340,
+    finding_count: 3,
+    truncated: false,
+    scan_mode: 'quick'
+  };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.doUnmock('./hooks/useBackendFeatures');
+    vi.doUnmock('./pages/onboarding/onboardingUtils');
+    vi.resetModules();
+  });
+
+  async function renderGitHubPage(
+    pageName: 'control-center' | 'connect' | 'repositories' | 'actions',
+    options: {
+      githubConnection?: GitHubConnectionStatus | null;
+      scans?: RepoScanRecord[];
+      githubFeatureFlag?: boolean;
+      githubBackend?: BackendFeatureState;
+      runRepoScanError?: { message: string; status: number };
+      cancelRepoScanError?: { message: string; status: number };
+      initialEntry?: string;
+    } = {}
+  ) {
+    mockConnectorFeatureFlags({ aws: false, github: options.githubFeatureFlag ?? true, kubernetes: false });
+    mockBackendFeatures({ github: options.githubBackend ?? true });
+
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({ items: [productionProject] });
+    vi.spyOn(api.apiClient, 'getProject').mockResolvedValue({ project: productionProject });
+    const getGitHubConnectorStatus = vi
+      .spyOn(api.apiClient, 'getGitHubConnectorStatus')
+      .mockResolvedValue({ connection: options.githubConnection ?? connectedGitHub });
+    const listRepoScans = vi
+      .spyOn(api.apiClient, 'listRepoScans')
+      .mockResolvedValue({ items: options.scans ?? [] });
+    const runRepoScan = vi.spyOn(api.apiClient, 'runRepoScan');
+    if (options.runRepoScanError) {
+      runRepoScan.mockRejectedValue(new api.ApiError(options.runRepoScanError.message, options.runRepoScanError.status));
+    } else {
+      runRepoScan.mockResolvedValue({ repo_scan: queuedRepoScan });
+    }
+    const cancelRepoScan = vi.spyOn(api.apiClient, 'cancelRepoScan');
+    if (options.cancelRepoScanError) {
+      cancelRepoScan.mockRejectedValue(
+        new api.ApiError(options.cancelRepoScanError.message, options.cancelRepoScanError.status)
+      );
+    } else {
+      cancelRepoScan.mockResolvedValue({ repo_scan: canceledRepoScan });
+    }
+    const startGitHubConnector = vi.spyOn(api.apiClient, 'startGitHubConnector').mockResolvedValue({
+      connection: {
+        provider: 'github_app',
+        connected: false,
+        connector_id: 'github-app',
+        display_name: 'Identrail',
+        status: 'pending',
+        health_status: 'unknown',
+        webhook_secret_rotation_required: false,
+        selected_repositories: []
+      },
+      connector_id: 'github-app',
+      state: 'github-state',
+      install_url: 'https://github.com/apps/identrail/installations/select_target?state=github-state',
+      install_account_type: 'any',
+      webhook_url: '/auth/webhooks/github',
+      expires_at: '2026-05-17T10:10:00Z'
+    });
+
+    const productShell = await import('./productShell');
+    const page =
+      pageName === 'control-center' ? <productShell.ProductGitHubControlCenterPage /> :
+      pageName === 'connect' ? <productShell.ProductGitHubConnectPage /> :
+      pageName === 'repositories' ? <productShell.ProductGitHubRepositoriesPage /> :
+      <productShell.ProductGitHubActionsPage />;
+
+    const routePath =
+      pageName === 'control-center' ? 'github' :
+      pageName === 'connect' ? 'github/connect' :
+      pageName === 'repositories' ? 'github/repositories' :
+      'github/actions';
+
+    render(
+      <MemoryRouter initialEntries={[options.initialEntry ?? `/app/tenant-a/workspace-a/${routePath}`]}>
+        <Routes>
+          <Route path={`/app/:tenantID/:workspaceID/${routePath}`} element={page} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    return { getGitHubConnectorStatus, listRepoScans, runRepoScan, cancelRepoScan, startGitHubConnector };
+  }
+
+  it('Control Center loads the GitHub connection and surfaces premium status', async () => {
+    const mocks = await renderGitHubPage('control-center', { scans: [succeededRepoScan] });
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub Control Center' });
+    await waitFor(() => expect(mocks.getGitHubConnectorStatus).toHaveBeenCalledWith(
+      'workspace-a',
+      'production-platform',
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    ));
+    await screen.findByText(/Connected as identrail/i);
+    await waitFor(() => {
+      const openRepos = screen
+        .getAllByRole('link', { name: /Open Repositories/i })
+        .find((link) => link.getAttribute('href')?.startsWith('/app/tenant-a/workspace-a/github/repositories'));
+      expect(openRepos).toBeDefined();
+    });
+    const connectLinks = screen
+      .getAllByRole('link', { name: /Connect GitHub/i })
+      .filter((link) => link.getAttribute('href')?.startsWith('/app/tenant-a/workspace-a/github/connect'));
+    expect(connectLinks.length).toBeGreaterThan(0);
+    const findingsLinks = screen
+      .getAllByRole('link', { name: /GitHub findings/i })
+      .filter((link) => link.getAttribute('href')?.startsWith('/app/tenant-a/workspace-a/github/findings'));
+    expect(findingsLinks.length).toBeGreaterThan(0);
+    expect(screen.getByText(/Last 1 repository scans/i)).toBeInTheDocument();
+  });
+
+  it('Control Center prompts to connect when not connected', async () => {
+    await renderGitHubPage('control-center', {
+      githubConnection: {
+        ...connectedGitHub,
+        connected: false,
+        account_login: undefined,
+        installation_id: undefined,
+        selected_repositories: []
+      },
+      scans: []
+    });
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub Control Center' });
+    await screen.findByText(/GitHub is not connected for this environment yet/i);
+    await waitFor(() => {
+      const heroConnect = screen
+        .getAllByRole('link', { name: /Connect GitHub/i })
+        .find((link) => link.getAttribute('href')?.startsWith('/app/tenant-a/workspace-a/github/connect'));
+      expect(heroConnect).toBeDefined();
+    });
+  });
+
+  it('Control Center shows the unavailable shell when the GitHub connector is gated off', async () => {
+    await renderGitHubPage('control-center', { githubFeatureFlag: false, githubBackend: false });
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub Control Center' });
+    await screen.findByRole('heading', { level: 3, name: /GitHub is not available on this API/i });
+  });
+
+  it('Connect page calls startGitHubConnector and opens the install URL', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const mocks = await renderGitHubPage('connect', {
+      githubConnection: {
+        ...connectedGitHub,
+        connected: false,
+        account_login: undefined,
+        installation_id: undefined,
+        selected_repositories: []
+      }
+    });
+
+    const installButton = (await screen.findAllByRole('button', { name: 'Install GitHub App' }))[0];
+    fireEvent.click(installButton);
+
+    await waitFor(() =>
+      expect(mocks.startGitHubConnector).toHaveBeenCalledWith(
+        expect.objectContaining({ project_id: 'production-platform', install_account_type: 'any' }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    await waitFor(() =>
+      expect(openSpy).toHaveBeenCalledWith(
+        'https://github.com/apps/identrail/installations/select_target?state=github-state',
+        '_blank',
+        'noopener,noreferrer'
+      )
+    );
+
+    const enterpriseLinks = screen
+      .getAllByRole('link', { name: /Manage Enterprise \/ PAT/i })
+      .filter((link) => link.getAttribute('href')?.startsWith('/app/tenant-a/workspace-a/projects/production-platform'));
+    expect(enterpriseLinks.length).toBeGreaterThan(0);
+    expect(enterpriseLinks[0].getAttribute('href')).toContain('source=github');
+    openSpy.mockRestore();
+  });
+
+  it('Repositories page launches a scan via the existing API', async () => {
+    const mocks = await renderGitHubPage('repositories', { scans: [] });
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub repositories' });
+    const queueButton = await screen.findByRole('button', { name: 'Queue scan for identrail/identrail' });
+    fireEvent.click(queueButton);
+
+    await waitFor(() =>
+      expect(mocks.runRepoScan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          repository: 'identrail/identrail',
+          project_id: 'production-platform',
+          connector_id: 'github-app'
+        }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    await screen.findByText(/Repository scan queued for identrail\/identrail/i);
+  });
+
+  it('Repositories page cancels an active scan via the existing API', async () => {
+    const mocks = await renderGitHubPage('repositories', { scans: [queuedRepoScan] });
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub repositories' });
+    const cancelButton = await screen.findByRole('button', { name: 'Cancel scan for identrail/identrail' });
+    fireEvent.click(cancelButton);
+
+    await waitFor(() =>
+      expect(mocks.cancelRepoScan).toHaveBeenCalledWith(
+        'repo-scan-queued',
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    await screen.findByText(/Repository scan canceled for identrail\/identrail/i);
+  });
+
+  it('Repositories page shows the empty state when no repositories are selected', async () => {
+    await renderGitHubPage('repositories', {
+      githubConnection: { ...connectedGitHub, selected_repositories: [] }
+    });
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub repositories' });
+    await screen.findByRole('heading', { level: 3, name: /Select repositories for Identrail to watch/i });
+    await waitFor(() => {
+      const selectLink = screen
+        .getAllByRole('link')
+        .find((link) => link.textContent?.includes('Select repositories'));
+      expect(selectLink).toBeDefined();
+      expect(selectLink?.getAttribute('href')).toMatch(/^\/app\/tenant-a\/workspace-a\/github\/connect/);
+    });
+  });
+
+  it('Repositories page surfaces a scan error inline without breaking navigation', async () => {
+    await renderGitHubPage('repositories', {
+      runRepoScanError: { message: 'rate limited', status: 429 }
+    });
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub repositories' });
+    const queueButton = await screen.findByRole('button', { name: 'Queue scan for identrail/identrail' });
+    fireEvent.click(queueButton);
+
+    await screen.findByRole('heading', { level: 3, name: /Repository scan error/i });
+    const homeLink = screen
+      .getAllByRole('link', { name: /GitHub home/i })
+      .find((link) => link.getAttribute('href')?.startsWith('/app/tenant-a/workspace-a/github'));
+    expect(homeLink).toBeDefined();
+  });
+
+  it('Actions page renders the premium waiting-for-coverage shell', async () => {
+    await renderGitHubPage('actions');
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub Actions / OIDC' });
+    await screen.findByRole('heading', { level: 3, name: /Workflow and OIDC posture is rolling out/i });
+    expect(screen.getAllByText(/Workflow inventory/i).length).toBeGreaterThan(0);
+    await waitFor(() => {
+      const openReposLink = screen
+        .getAllByRole('link', { name: /Open Repositories/i })
+        .find((link) => link.getAttribute('href')?.startsWith('/app/tenant-a/workspace-a/github/repositories'));
+      expect(openReposLink).toBeDefined();
+    });
+    const homeLink = screen
+      .getAllByRole('link', { name: /GitHub home/i })
+      .find((link) => link.getAttribute('href')?.startsWith('/app/tenant-a/workspace-a/github'));
+    expect(homeLink).toBeDefined();
+  });
+
+  it('Actions page renders the unavailable shell when the GitHub connector is gated off', async () => {
+    await renderGitHubPage('actions', { githubFeatureFlag: false, githubBackend: false });
+
+    await screen.findByRole('heading', { level: 2, name: 'GitHub Actions / OIDC' });
+    await screen.findByRole('heading', { level: 3, name: /GitHub is not available on this API/i });
+  });
+});

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -2713,15 +2713,22 @@ function useGitHubDomainData(
           return;
         }
         const statusResult = results[0];
+        const scansResult = results[1];
+        let nextError = '';
         if (statusResult.status === 'fulfilled') {
           setConnection(statusResult.value.connection ?? null);
         } else if (trimmedProject) {
-          setError(formatAPIError(statusResult.reason, 'Unable to load GitHub connection status.'));
+          nextError = formatAPIError(statusResult.reason, 'Unable to load GitHub connection status.');
         }
-        const scansResult = results[1];
         if (scansResult.status === 'fulfilled') {
           setScans(scansResult.value.items ?? []);
+        } else {
+          setScans([]);
+          if (!nextError) {
+            nextError = formatAPIError(scansResult.reason, 'Unable to load recent repository scans.');
+          }
         }
+        setError(nextError);
       })
       .finally(() => {
         if (active) {
@@ -2736,13 +2743,16 @@ function useGitHubDomainData(
   return { loading, error, connection, scans, reload };
 }
 
-function gitHubRecentScans(scans: RepoScanRecord[], selectedRepositories: string[], limit: number): RepoScanRecord[] {
+function gitHubScansForSelectedRepositories(scans: RepoScanRecord[], selectedRepositories: string[]): RepoScanRecord[] {
   if (!selectedRepositories.length) {
-    return scans.slice(0, limit);
+    return [];
   }
   const allowed = new Set(selectedRepositories.map((repo) => canonicalGitHubRepositoryDisplay(repo).toLowerCase()));
-  const filtered = scans.filter((scan) => allowed.has(canonicalGitHubRepositoryDisplay(scan.repository).toLowerCase()));
-  return filtered.length > 0 ? filtered.slice(0, limit) : scans.slice(0, limit);
+  return scans.filter((scan) => allowed.has(canonicalGitHubRepositoryDisplay(scan.repository).toLowerCase()));
+}
+
+function gitHubRecentScans(scans: RepoScanRecord[], selectedRepositories: string[], limit: number): RepoScanRecord[] {
+  return gitHubScansForSelectedRepositories(scans, selectedRepositories).slice(0, limit);
 }
 
 function gitHubRecentScansTimeline(scans: RepoScanRecord[]): DomainTimelineEntry[] {
@@ -2820,8 +2830,8 @@ function buildGitHubControlCenterMetrics(
   recentScans: RepoScanRecord[]
 ) {
   const activeScans = recentScans.filter((scan) => isActiveScanStatus(scan.status)).length;
-  const latestSucceeded = recentScans.find((scan) => isCompletedScanStatus(scan.status) && !isFailedScanStatus(scan.status));
-  const latestFailed = recentScans.find((scan) => isFailedScanStatus(scan.status));
+  const latestCompleted = recentScans.find((scan) => isCompletedScanStatus(scan.status));
+  const latestCompletedFailed = latestCompleted ? isFailedScanStatus(latestCompleted.status) : false;
   return [
     {
       label: 'Connection',
@@ -2843,17 +2853,15 @@ function buildGitHubControlCenterMetrics(
     },
     {
       label: 'Latest scan',
-      value: latestSucceeded
-        ? formatRelativeTime(latestSucceeded.finished_at || latestSucceeded.started_at)
-        : latestFailed
-          ? formatRelativeTime(latestFailed.finished_at || latestFailed.started_at)
-          : '—',
-      detail: latestSucceeded
-        ? `${latestSucceeded.finding_count} findings · ${canonicalGitHubRepositoryDisplay(latestSucceeded.repository) || latestSucceeded.repository}`
-        : latestFailed
-          ? summarizeScanFailure(latestFailed)
-          : 'Run a scan from the Repositories page.',
-      tone: latestSucceeded ? 'success' : latestFailed ? 'danger' : 'neutral'
+      value: latestCompleted
+        ? formatRelativeTime(latestCompleted.finished_at || latestCompleted.started_at)
+        : '—',
+      detail: latestCompleted
+        ? latestCompletedFailed
+          ? summarizeScanFailure(latestCompleted)
+          : `${latestCompleted.finding_count} findings · ${canonicalGitHubRepositoryDisplay(latestCompleted.repository) || latestCompleted.repository}`
+        : 'Run a scan from the Repositories page.',
+      tone: latestCompleted ? (latestCompletedFailed ? 'danger' : 'success') : 'neutral'
     }
   ] as const;
 }
@@ -3213,6 +3221,7 @@ export function ProductGitHubConnectPage() {
   const data = useGitHubDomainData(scope, selectedEnvironmentID, availability.available, GITHUB_CONTROL_CENTER_RECENT_SCANS_LIMIT);
   const [installError, setInstallError] = useState('');
   const [installing, setInstalling] = useState(false);
+  const [pendingInstallURL, setPendingInstallURL] = useState('');
 
   if (!scope) {
     return (
@@ -3269,6 +3278,7 @@ export function ProductGitHubConnectPage() {
 
   const handleInstall = async () => {
     setInstallError('');
+    setPendingInstallURL('');
     setInstalling(true);
     try {
       const response = await apiClient.startGitHubConnector(
@@ -3278,8 +3288,15 @@ export function ProductGitHubConnectPage() {
         },
         buildProductAuthContext(scope)
       );
-      if (typeof window !== 'undefined' && response.install_url) {
-        window.open(response.install_url, '_blank', 'noopener,noreferrer');
+      const installURL = response.install_url ?? '';
+      if (installURL) {
+        let opened: Window | null = null;
+        if (typeof window !== 'undefined') {
+          opened = window.open(installURL, '_blank', 'noopener,noreferrer');
+        }
+        if (!opened) {
+          setPendingInstallURL(installURL);
+        }
       }
       data.reload();
     } catch (error) {
@@ -3332,6 +3349,24 @@ export function ProductGitHubConnectPage() {
       }
     >
       {installError ? <DomainErrorState title="Unable to start install" body={installError} retryAction={{ label: 'Try again', onClick: handleInstall }} /> : null}
+      {pendingInstallURL ? (
+        <DomainStatusPanel
+          eyebrow="Install GitHub App"
+          title="Browser blocked the install popup"
+          tone="warning"
+        >
+          <p>Open the GitHub App install page directly to finish connecting Identrail.</p>
+          <a
+            className="idt-btn idt-btn-primary"
+            href={pendingInstallURL}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Open GitHub"
+          >
+            Open GitHub
+          </a>
+        </DomainStatusPanel>
+      ) : null}
       {data.error ? <DomainErrorState title="Unable to load connection status" body={data.error} retryAction={{ label: 'Retry', onClick: data.reload }} /> : null}
       <DomainStatusPanel
         eyebrow="Status"
@@ -3479,6 +3514,7 @@ export function ProductGitHubRepositoriesPage() {
   const findingsPath = appendEnvironmentQuery(buildScopedPath(scope, 'github/findings'), selectedEnvironmentID);
   const selectedRepositories = uniqueGitHubRepositories(data.connection?.selected_repositories ?? []);
   const rows = buildGitHubRepositoryRows(selectedRepositories, data.scans);
+  const selectedRepositoryScans = gitHubScansForSelectedRepositories(data.scans, selectedRepositories);
 
   const connected = Boolean(data.connection?.connected);
   const statusVariant = gitHubConnectionStatusVariantFor(data.connection, data.loading);
@@ -3647,16 +3683,16 @@ export function ProductGitHubRepositoriesPage() {
               <p className="idt-app-kicker">Activity</p>
               <h3>Recent repository scan activity</h3>
             </div>
-            <span>{`${data.scans.length} scan${data.scans.length === 1 ? '' : 's'} loaded`}</span>
+            <span>{`${selectedRepositoryScans.length} scan${selectedRepositoryScans.length === 1 ? '' : 's'} loaded`}</span>
           </header>
-          {data.scans.length === 0 ? (
+          {selectedRepositoryScans.length === 0 ? (
             <DomainEmptyState
               eyebrow="No activity"
               title="No repository scans recorded yet"
               body="Queue a scan for a selected repository to seed activity here."
             />
           ) : (
-            <DomainTimeline label="Recent repository scan activity" entries={gitHubRecentScansTimeline(data.scans.slice(0, GITHUB_CONTROL_CENTER_RECENT_SCANS_LIMIT * 2))} />
+            <DomainTimeline label="Recent repository scan activity" entries={gitHubRecentScansTimeline(selectedRepositoryScans.slice(0, GITHUB_CONTROL_CENTER_RECENT_SCANS_LIMIT * 2))} />
           )}
         </section>
       ) : null}

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -2593,6 +2593,7 @@ export function ProductKubernetesConnectPage() {
 
 const GITHUB_CONTROL_CENTER_RECENT_SCANS_LIMIT = 5;
 const GITHUB_REPOSITORIES_SCANS_LIMIT = 50;
+const GITHUB_MAX_SCAN_PAGE_FETCHES = 50;
 
 type GitHubAvailability = {
   loading: boolean;

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -2676,6 +2676,55 @@ type GitHubDomainDataState = {
   reload: () => void;
 };
 
+async function listRepoScansForSelectedRepositories(
+  selectedRepositories: string[],
+  scanLimit: number,
+  auth: RequestAuthContext
+): Promise<RepoScanRecord[]> {
+  if (!selectedRepositories.length || scanLimit <= 0) {
+    return [];
+  }
+
+  const allowed = new Set(selectedRepositories.map((repository) => canonicalGitHubRepositoryDisplay(repository).toLowerCase()));
+  const matches: RepoScanRecord[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+
+  do {
+    const response = (await apiClient.listRepoScans(
+      {
+        limit: scanLimit,
+        cursor,
+        sort_by: 'started_at',
+        sort_order: 'desc'
+      },
+      auth
+    )) as { items: RepoScanRecord[]; next_cursor?: string };
+
+    for (const scan of response.items) {
+      if (allowed.has(canonicalGitHubRepositoryDisplay(scan.repository).toLowerCase())) {
+        matches.push(scan);
+      }
+    }
+
+    if (matches.length >= scanLimit) {
+      break;
+    }
+
+    const nextCursor = response.next_cursor?.trim();
+    if (!nextCursor) {
+      break;
+    }
+    if (seenCursors.has(nextCursor)) {
+      throw new Error('Repository scan pagination returned a repeated cursor');
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  } while (cursor);
+
+  return matches.slice(0, scanLimit);
+}
+
 function useGitHubDomainData(
   scope: ProductSession | null,
   projectID: string | undefined,
@@ -2701,40 +2750,53 @@ function useGitHubDomainData(
     let active = true;
     setLoading(true);
     setError('');
+    setConnection(null);
+    setScans([]);
     const auth = buildProductAuthContext(scope);
     const trimmedProject = normalizeValue(projectID);
     const statusRequest = trimmedProject
       ? apiClient.getGitHubConnectorStatus(scope.workspaceID, trimmedProject, auth)
       : Promise.resolve<{ connection: GitHubConnectionStatus | null }>({ connection: null });
-    const scansRequest = apiClient.listRepoScans({ limit: scanLimit }, auth);
-    Promise.allSettled([statusRequest, scansRequest])
-      .then((results) => {
+
+    statusRequest
+      .then((statusResult) => statusResult.connection ?? null)
+      .then(async (connectionResult) => {
         if (!active) {
           return;
         }
-        const statusResult = results[0];
-        const scansResult = results[1];
         let nextError = '';
-        if (statusResult.status === 'fulfilled') {
-          setConnection(statusResult.value.connection ?? null);
-        } else if (trimmedProject) {
-          nextError = formatAPIError(statusResult.reason, 'Unable to load GitHub connection status.');
+        const nextConnection = connectionResult;
+
+        let nextScans: RepoScanRecord[] = [];
+        try {
+          nextScans = await listRepoScansForSelectedRepositories(
+            nextConnection?.selected_repositories ?? [],
+            scanLimit,
+            auth
+          );
+        } catch (error) {
+          nextError = formatAPIError(error, 'Unable to load recent repository scans.');
         }
-        if (scansResult.status === 'fulfilled') {
-          setScans(scansResult.value.items ?? []);
-        } else {
-          setScans([]);
-          if (!nextError) {
-            nextError = formatAPIError(scansResult.reason, 'Unable to load recent repository scans.');
-          }
+
+        if (!active) {
+          return;
         }
+        setConnection(nextConnection);
+        setScans(nextScans);
         setError(nextError);
+      })
+      .catch((error) => {
+        if (!active) {
+          return;
+        }
+        setError(formatAPIError(error, 'Unable to load GitHub connection status.'));
       })
       .finally(() => {
         if (active) {
           setLoading(false);
         }
       });
+
     return () => {
       active = false;
     };

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -2689,8 +2689,14 @@ async function listRepoScansForSelectedRepositories(
   const matches: RepoScanRecord[] = [];
   const seenCursors = new Set<string>();
   let cursor: string | undefined;
+  let pagesFetched = 0;
 
   do {
+    if (pagesFetched >= GITHUB_MAX_SCAN_PAGE_FETCHES) {
+      break;
+    }
+    pagesFetched += 1;
+
     const response = (await apiClient.listRepoScans(
       {
         limit: scanLimit,

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -3281,10 +3281,13 @@ export function ProductGitHubConnectPage() {
     setPendingInstallURL('');
     setInstalling(true);
     try {
+      const redirectURI =
+        typeof window !== 'undefined' ? `${window.location.origin}/app/github/callback` : undefined;
       const response = await apiClient.startGitHubConnector(
         {
           project_id: selectedEnvironmentID,
-          install_account_type: 'any'
+          install_account_type: 'any',
+          redirect_uri: redirectURI
         },
         buildProductAuthContext(scope)
       );
@@ -3653,17 +3656,23 @@ export function ProductGitHubRepositoriesPage() {
                       type="button"
                       className="idt-btn idt-btn-primary"
                       onClick={() => launchScan(row.repository)}
-                      disabled={submitting || Boolean(row.activeScan)}
+                      disabled={submitting || Boolean(row.activeScan) || data.loading}
                       aria-label={`Queue scan for ${row.repository}`}
                     >
-                      {submitting ? 'Queuing...' : row.activeScan ? 'Scan in progress' : 'Queue scan'}
+                      {data.loading && !submitting
+                        ? 'Refreshing...'
+                        : submitting
+                          ? 'Queuing...'
+                          : row.activeScan
+                            ? 'Scan in progress'
+                            : 'Queue scan'}
                     </button>
                     {canCancel && row.activeScan ? (
                       <button
                         type="button"
                         className="idt-btn idt-btn-ghost"
                         onClick={() => cancelScan(row.activeScan as RepoScanRecord)}
-                        disabled={cancelingThis}
+                        disabled={cancelingThis || data.loading}
                         aria-label={`Cancel scan for ${row.repository}`}
                       >
                         {cancelingThis ? 'Canceling...' : 'Cancel scan'}

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1,4 +1,4 @@
-import { Component, FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
+import { Component, FormEvent, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type {
   CSSProperties,
   KeyboardEvent as ReactKeyboardEvent,
@@ -63,11 +63,17 @@ import { PermissionPreviewModal } from './components/connector/PermissionPreview
 import { ConfirmDestructiveModal, DangerZone, DangerZoneRow } from './components/settings/DangerZone';
 import {
   DomainDetailPanel,
+  DomainEmptyState,
+  DomainErrorState,
   DomainKpiStrip,
+  DomainLoadingState,
   DomainLogoMark,
   DomainLogoStack,
   DomainPageShell,
-  DomainStatusPanel
+  DomainStatusBadge,
+  DomainStatusPanel,
+  DomainTimeline,
+  type DomainTimelineEntry
 } from './components/app/DomainFoundation';
 import { getDomainAsset, type DomainAssetKey } from './design/domainAssets';
 import { clearMeCache, primeMeCache, useMe } from './hooks/useMe';
@@ -2567,16 +2573,1224 @@ function ProductConnectorConnectPage({ provider, providerLabel }: ConnectorConne
   );
 }
 
-export function ProductGitHubConnectPage() {
-  return <ProductConnectorConnectPage provider="github" providerLabel="GitHub" />;
-}
-
 export function ProductAWSConnectPage() {
   return <ProductConnectorConnectPage provider="aws" providerLabel="AWS" />;
 }
 
 export function ProductKubernetesConnectPage() {
   return <ProductConnectorConnectPage provider="kubernetes" providerLabel="Kubernetes" />;
+}
+
+// =====================================================
+// GitHub domain pages (issue #1382 — GitHub Control Center)
+// -----------------------------------------------------
+// These four pages move GitHub setup, repository scan operation, and the
+// Actions/OIDC posture surface out of the legacy /projects/:projectID source
+// tab and into a domain-owned section. The repository scan launch, cancel,
+// and connector status APIs are unchanged — these pages call them with the
+// existing project_id-scoped contract so backend behavior is preserved.
+// =====================================================
+
+const GITHUB_CONTROL_CENTER_RECENT_SCANS_LIMIT = 5;
+const GITHUB_REPOSITORIES_SCANS_LIMIT = 50;
+
+type GitHubAvailability = {
+  loading: boolean;
+  available: boolean;
+  unavailableMessage?: string;
+};
+
+function useGitHubAvailability(): GitHubAvailability {
+  const { features, loading } = useBackendFeatures({ enabled: FEATURE_CONNECTOR_GITHUB_V2 });
+  const availability = useMemo(() => buildSourceAvailability(features), [features]);
+  return {
+    loading,
+    available: availability.github.available,
+    unavailableMessage: availability.github.unavailableMessage
+  };
+}
+
+type GitHubDomainScopeState = {
+  scope: ProductSession | null;
+  environmentScope: EnvironmentScopeState;
+  selectedEnvironmentID: string;
+  onChangeEnvironment: (environmentID: string) => void;
+};
+
+function useGitHubDomainScope(): GitHubDomainScopeState {
+  const params = useParams<ScopeRouteParams>();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const scope = resolveScopeFromParams(params);
+  const requestedEnvironmentID = useMemo(() => environmentIDFromSearch(location.search), [location.search]);
+  const environmentScope = useEnvironmentScope(scope, requestedEnvironmentID);
+  const onChangeEnvironment = useCallback(
+    (environmentID: string) => {
+      navigate(
+        {
+          pathname: location.pathname,
+          search: environmentSearch(location.search, environmentID)
+        },
+        { replace: false }
+      );
+    },
+    [location.pathname, location.search, navigate]
+  );
+  return {
+    scope,
+    environmentScope,
+    selectedEnvironmentID: environmentScope.selectedID,
+    onChangeEnvironment
+  };
+}
+
+type GitHubSectionLink = {
+  id: string;
+  label: string;
+  description: string;
+  to: string;
+};
+
+function buildGitHubSectionLinks(scope: ProductSession, environmentID: string | undefined): GitHubSectionLink[] {
+  const link = (id: string, suffix: string, label: string, description: string): GitHubSectionLink => ({
+    id,
+    label,
+    description,
+    to: appendEnvironmentQuery(buildScopedPath(scope, `github/${suffix}`), environmentID)
+  });
+  return [
+    link('connect', 'connect', 'Connect GitHub', 'Manage the GitHub App installation, account scope, and PAT fallback.'),
+    link('repositories', 'repositories', 'Repositories', 'Launch, monitor, and cancel repository scans for the connected installation.'),
+    link('actions', 'actions', 'Actions / OIDC', 'Workflow permissions, runner posture, and OIDC trust path coverage.'),
+    link('findings', 'findings', 'Findings', 'Repository, workflow, and secret findings detected by Identrail.'),
+    link('remediation', 'remediation', 'Remediation', 'Stage repository fix PRs, lifecycle review, and verification.'),
+    link('agentic-risk', 'agentic-risk', 'AI / Agentic Risk', 'Agent identities, MCP tools, prompts, secrets, and workflow trust paths.')
+  ];
+}
+
+type GitHubDomainDataState = {
+  loading: boolean;
+  error: string;
+  connection: GitHubConnectionStatus | null;
+  scans: RepoScanRecord[];
+  reload: () => void;
+};
+
+function useGitHubDomainData(
+  scope: ProductSession | null,
+  projectID: string | undefined,
+  available: boolean,
+  scanLimit: number
+): GitHubDomainDataState {
+  const [connection, setConnection] = useState<GitHubConnectionStatus | null>(null);
+  const [scans, setScans] = useState<RepoScanRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [reloadToken, setReloadToken] = useState(0);
+
+  const reload = useCallback(() => setReloadToken((current) => current + 1), []);
+
+  useEffect(() => {
+    if (!scope || !available) {
+      setConnection(null);
+      setScans([]);
+      setError('');
+      setLoading(false);
+      return undefined;
+    }
+    let active = true;
+    setLoading(true);
+    setError('');
+    const auth = buildProductAuthContext(scope);
+    const trimmedProject = normalizeValue(projectID);
+    const statusRequest = trimmedProject
+      ? apiClient.getGitHubConnectorStatus(scope.workspaceID, trimmedProject, auth)
+      : Promise.resolve<{ connection: GitHubConnectionStatus | null }>({ connection: null });
+    const scansRequest = apiClient.listRepoScans({ limit: scanLimit }, auth);
+    Promise.allSettled([statusRequest, scansRequest])
+      .then((results) => {
+        if (!active) {
+          return;
+        }
+        const statusResult = results[0];
+        if (statusResult.status === 'fulfilled') {
+          setConnection(statusResult.value.connection ?? null);
+        } else if (trimmedProject) {
+          setError(formatAPIError(statusResult.reason, 'Unable to load GitHub connection status.'));
+        }
+        const scansResult = results[1];
+        if (scansResult.status === 'fulfilled') {
+          setScans(scansResult.value.items ?? []);
+        }
+      })
+      .finally(() => {
+        if (active) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [available, projectID, reloadToken, scanLimit, scope?.tenantID, scope?.workspaceID]);
+
+  return { loading, error, connection, scans, reload };
+}
+
+function gitHubRecentScans(scans: RepoScanRecord[], selectedRepositories: string[], limit: number): RepoScanRecord[] {
+  if (!selectedRepositories.length) {
+    return scans.slice(0, limit);
+  }
+  const allowed = new Set(selectedRepositories.map((repo) => canonicalGitHubRepositoryDisplay(repo).toLowerCase()));
+  const filtered = scans.filter((scan) => allowed.has(canonicalGitHubRepositoryDisplay(scan.repository).toLowerCase()));
+  return filtered.length > 0 ? filtered.slice(0, limit) : scans.slice(0, limit);
+}
+
+function gitHubRecentScansTimeline(scans: RepoScanRecord[]): DomainTimelineEntry[] {
+  return scans.map((scan) => {
+    const repo = canonicalGitHubRepositoryDisplay(scan.repository) || scan.repository;
+    const tone = repoScanStatusTone(scan.status);
+    const statusLabel = formatTokenLabel(scan.status);
+    const detail = isCompletedScanStatus(scan.status)
+      ? scan.error_message
+        ? summarizeScanFailure(scan)
+        : `${scan.finding_count} findings · ${scan.files_scanned} files`
+      : `${scan.scan_mode ?? 'scan'} queued`;
+    return {
+      id: scan.id,
+      timestamp: formatRelativeTime(scan.finished_at || scan.started_at),
+      title: (
+        <>
+          <strong>{repo}</strong> · {statusLabel}
+        </>
+      ),
+      detail,
+      tone: tone === 'warning' ? 'warning' : tone === 'error' ? 'danger' : tone === 'success' ? 'success' : 'neutral'
+    };
+  });
+}
+
+function gitHubConnectionTone(status: GitHubConnectionStatus | null, loading: boolean): 'success' | 'warning' | 'danger' | 'neutral' {
+  if (loading) {
+    return 'neutral';
+  }
+  if (!status || !status.connected) {
+    return 'neutral';
+  }
+  const tone = connectionTone(status);
+  if (tone === 'error') {
+    return 'danger';
+  }
+  return tone;
+}
+
+function gitHubConnectionSummary(status: GitHubConnectionStatus | null): string {
+  if (!status || !status.connected) {
+    return 'GitHub is not connected for this environment yet.';
+  }
+  const account = normalizeValue(status.account_login);
+  const installation = status.installation_id ? `installation ${status.installation_id}` : '';
+  const parts = [account ? `Connected as ${account}` : 'Connected'];
+  if (installation) {
+    parts.push(installation);
+  }
+  parts.push(`health ${formatTokenLabel(connectionHealth(status))}`);
+  return `${parts.join(' · ')}.`;
+}
+
+function gitHubConnectionStatusVariantFor(status: GitHubConnectionStatus | null, loading: boolean) {
+  if (loading) {
+    return 'coming-soon' as const;
+  }
+  if (!status || !status.connected) {
+    return 'disconnected' as const;
+  }
+  const tone = connectionTone(status);
+  if (tone === 'error') {
+    return 'missing-permissions' as const;
+  }
+  if (tone === 'warning') {
+    return 'needs-attention' as const;
+  }
+  return 'connected' as const;
+}
+
+function buildGitHubControlCenterMetrics(
+  status: GitHubConnectionStatus | null,
+  selectedRepositories: string[],
+  recentScans: RepoScanRecord[]
+) {
+  const activeScans = recentScans.filter((scan) => isActiveScanStatus(scan.status)).length;
+  const latestSucceeded = recentScans.find((scan) => isCompletedScanStatus(scan.status) && !isFailedScanStatus(scan.status));
+  const latestFailed = recentScans.find((scan) => isFailedScanStatus(scan.status));
+  return [
+    {
+      label: 'Connection',
+      value: status?.connected ? formatTokenLabel(connectionLifecycle(status)) : 'Not connected',
+      detail: status?.connected ? `Health ${formatTokenLabel(connectionHealth(status))}` : 'Install the GitHub App to begin.',
+      tone: gitHubConnectionTone(status, false) === 'danger' ? 'danger' : status?.connected ? 'success' : 'neutral'
+    },
+    {
+      label: 'Repositories',
+      value: selectedRepositories.length,
+      detail: selectedRepositories.length === 0 ? 'No repositories selected yet.' : `${formatCountLabel(selectedRepositories.length, 'repo')} in scope.`,
+      tone: selectedRepositories.length > 0 ? 'success' : 'neutral'
+    },
+    {
+      label: 'Active scans',
+      value: activeScans,
+      detail: activeScans > 0 ? 'Queued or running right now.' : 'No scans waiting.',
+      tone: activeScans > 0 ? 'warning' : 'neutral'
+    },
+    {
+      label: 'Latest scan',
+      value: latestSucceeded
+        ? formatRelativeTime(latestSucceeded.finished_at || latestSucceeded.started_at)
+        : latestFailed
+          ? formatRelativeTime(latestFailed.finished_at || latestFailed.started_at)
+          : '—',
+      detail: latestSucceeded
+        ? `${latestSucceeded.finding_count} findings · ${canonicalGitHubRepositoryDisplay(latestSucceeded.repository) || latestSucceeded.repository}`
+        : latestFailed
+          ? summarizeScanFailure(latestFailed)
+          : 'Run a scan from the Repositories page.',
+      tone: latestSucceeded ? 'success' : latestFailed ? 'danger' : 'neutral'
+    }
+  ] as const;
+}
+
+function GitHubSectionLinksGrid({ links }: { links: GitHubSectionLink[] }) {
+  return (
+    <section className="idt-domain-status-panel idt-github-section-links" aria-label="GitHub subsections">
+      <header>
+        <div>
+          <p className="idt-app-kicker">Domain map</p>
+          <h3>Where to go next inside GitHub</h3>
+        </div>
+        <span>{`${links.length} sections`}</span>
+      </header>
+      <div className="idt-domain-readiness-items">
+        {links.map((link) => (
+          <Link key={link.id} to={link.to} className="idt-github-section-link" aria-label={link.label}>
+            <div>
+              <strong>{link.label}</strong>
+              <p>{link.description}</p>
+            </div>
+            <span aria-hidden="true">→</span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function GitHubControlCenterNextActions({
+  connected,
+  selectedRepositories,
+  recentScans,
+  connectPath,
+  repositoriesPath,
+  findingsPath
+}: {
+  connected: boolean;
+  selectedRepositories: string[];
+  recentScans: RepoScanRecord[];
+  connectPath: string;
+  repositoriesPath: string;
+  findingsPath: string;
+}) {
+  const failedScan = recentScans.find((scan) => isFailedScanStatus(scan.status));
+  const actions: Array<{ id: string; title: string; detail: string; to: string }> = [];
+  if (!connected) {
+    actions.push({
+      id: 'connect',
+      title: 'Connect GitHub',
+      detail: 'Install the GitHub App or paste an Enterprise PAT to enable repository scanning.',
+      to: connectPath
+    });
+  }
+  if (connected && selectedRepositories.length === 0) {
+    actions.push({
+      id: 'select-repositories',
+      title: 'Select repositories to scan',
+      detail: 'Pick the repositories Identrail should watch for exposure, secrets, and workflow risk.',
+      to: connectPath
+    });
+  }
+  if (connected && selectedRepositories.length > 0 && !recentScans.some((scan) => isCompletedScanStatus(scan.status))) {
+    actions.push({
+      id: 'run-first-scan',
+      title: 'Run a first repository scan',
+      detail: 'Queue a scan to seed the findings pipeline for the selected repositories.',
+      to: repositoriesPath
+    });
+  }
+  if (failedScan) {
+    actions.push({
+      id: 'review-failed-scan',
+      title: 'Investigate the most recent failed scan',
+      detail: `${canonicalGitHubRepositoryDisplay(failedScan.repository) || failedScan.repository}: ${summarizeScanFailure(failedScan)}`,
+      to: repositoriesPath
+    });
+  }
+  if (connected && recentScans.some((scan) => isCompletedScanStatus(scan.status) && scan.finding_count > 0)) {
+    actions.push({
+      id: 'triage-findings',
+      title: 'Triage GitHub findings',
+      detail: 'Open the GitHub findings queue to review repository and workflow risk.',
+      to: findingsPath
+    });
+  }
+  if (actions.length === 0) {
+    return null;
+  }
+  return (
+    <section className="idt-domain-status-panel idt-github-next-actions" aria-label="GitHub next actions">
+      <header>
+        <div>
+          <p className="idt-app-kicker">Next actions</p>
+          <h3>{`${actions.length} thing${actions.length === 1 ? '' : 's'} to do`}</h3>
+        </div>
+        <span>Recommended</span>
+      </header>
+      <ol className="idt-github-next-actions-list">
+        {actions.map((action) => (
+          <li key={action.id}>
+            <Link to={action.to}>
+              <strong>{action.title}</strong>
+              <p>{action.detail}</p>
+            </Link>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function legacyProjectSetupPath(scope: ProductSession, projectID: string | undefined): string {
+  const trimmed = normalizeValue(projectID);
+  if (!trimmed) {
+    return appendSourceQuery(buildProjectsPath(scope), 'github');
+  }
+  return appendSourceQuery(buildProjectPath(scope, trimmed), 'github');
+}
+
+function GitHubUnavailableShell({
+  title,
+  scope,
+  environmentScope,
+  selectedEnvironmentID,
+  onEnvironmentChange,
+  unavailableMessage
+}: {
+  title: string;
+  scope: ProductSession;
+  environmentScope: EnvironmentScopeState;
+  selectedEnvironmentID: string;
+  onEnvironmentChange: (id: string) => void;
+  unavailableMessage?: string;
+}) {
+  const basePath = appendEnvironmentQuery(buildScopedPath(scope, 'github'), selectedEnvironmentID);
+  return (
+    <DomainPageShell
+      domain="github"
+      eyebrow="GitHub"
+      title={title}
+      description="The GitHub connector is not enabled on this Identrail build."
+      scope={<ProductEnvironmentSelector state={environmentScope} onChange={onEnvironmentChange} />}
+      status={<DomainStatusBadge variant="coming-soon" label="Unavailable" />}
+      statusTone="neutral"
+      primaryAction={{ label: 'GitHub home', to: basePath, variant: 'secondary' }}
+    >
+      <DomainErrorState
+        title="GitHub is not available on this API"
+        body={unavailableMessage ?? 'Ask your operator to enable the GitHub connector to unlock this page.'}
+      />
+      <OnboardingUnavailableNotice />
+    </DomainPageShell>
+  );
+}
+
+function GitHubMissingEnvironmentShell({
+  title,
+  scope,
+  environmentScope,
+  selectedEnvironmentID,
+  onEnvironmentChange
+}: {
+  title: string;
+  scope: ProductSession;
+  environmentScope: EnvironmentScopeState;
+  selectedEnvironmentID: string;
+  onEnvironmentChange: (id: string) => void;
+}) {
+  const projectsPath = appendSourceQuery(buildProjectsPath(scope), 'github');
+  const basePath = appendEnvironmentQuery(buildScopedPath(scope, 'github'), selectedEnvironmentID);
+  return (
+    <DomainPageShell
+      domain="github"
+      eyebrow="GitHub"
+      title={title}
+      description="Pick an environment to scope GitHub to a project boundary."
+      scope={<ProductEnvironmentSelector state={environmentScope} onChange={onEnvironmentChange} />}
+      status={<DomainStatusBadge variant="coming-soon" label="Pick environment" />}
+      statusTone="neutral"
+      primaryAction={{ label: 'Create environment', to: projectsPath, variant: 'primary' }}
+      secondaryActions={[{ label: 'GitHub home', to: basePath }]}
+    >
+      <DomainEmptyState
+        eyebrow="Environment required"
+        title="Choose an environment for GitHub"
+        body="GitHub installations are scoped per project. Create or pick an environment to load connection status, repository coverage, and scan activity."
+      />
+    </DomainPageShell>
+  );
+}
+
+export function ProductGitHubControlCenterPage() {
+  const { scope, environmentScope, selectedEnvironmentID, onChangeEnvironment } = useGitHubDomainScope();
+  const availability = useGitHubAvailability();
+  const data = useGitHubDomainData(
+    scope,
+    selectedEnvironmentID,
+    availability.available,
+    GITHUB_CONTROL_CENTER_RECENT_SCANS_LIMIT
+  );
+
+  if (!scope) {
+    return (
+      <section className="idt-app-panel idt-app-panel-error" role="alert">
+        <p className="idt-app-kicker">GitHub</p>
+        <h2>Workspace route context is missing</h2>
+        <p>Choose a tenant and workspace before loading the GitHub control center.</p>
+      </section>
+    );
+  }
+
+  if (availability.loading) {
+    return (
+      <DomainPageShell
+        domain="github"
+        eyebrow="GitHub"
+        title="GitHub Control Center"
+        description="Loading GitHub availability for this build."
+        scope={<ProductEnvironmentSelector state={environmentScope} onChange={onChangeEnvironment} />}
+      >
+        <DomainLoadingState label="Loading GitHub availability" />
+      </DomainPageShell>
+    );
+  }
+
+  if (!availability.available) {
+    return (
+      <GitHubUnavailableShell
+        title="GitHub Control Center"
+        scope={scope}
+        environmentScope={environmentScope}
+        selectedEnvironmentID={selectedEnvironmentID}
+        onEnvironmentChange={onChangeEnvironment}
+        unavailableMessage={availability.unavailableMessage}
+      />
+    );
+  }
+
+  if (!selectedEnvironmentID) {
+    return (
+      <GitHubMissingEnvironmentShell
+        title="GitHub Control Center"
+        scope={scope}
+        environmentScope={environmentScope}
+        selectedEnvironmentID={selectedEnvironmentID}
+        onEnvironmentChange={onChangeEnvironment}
+      />
+    );
+  }
+
+  const links = buildGitHubSectionLinks(scope, selectedEnvironmentID);
+  const connectPath = appendEnvironmentQuery(buildScopedPath(scope, 'github/connect'), selectedEnvironmentID);
+  const repositoriesPath = appendEnvironmentQuery(buildScopedPath(scope, 'github/repositories'), selectedEnvironmentID);
+  const findingsPath = appendEnvironmentQuery(buildScopedPath(scope, 'github/findings'), selectedEnvironmentID);
+  const selectedRepositories = uniqueGitHubRepositories(data.connection?.selected_repositories ?? []);
+  const recentScans = gitHubRecentScans(data.scans, selectedRepositories, GITHUB_CONTROL_CENTER_RECENT_SCANS_LIMIT);
+  const metrics = buildGitHubControlCenterMetrics(data.connection, selectedRepositories, recentScans);
+  const statusVariant = gitHubConnectionStatusVariantFor(data.connection, data.loading);
+
+  return (
+    <DomainPageShell
+      domain="github"
+      eyebrow="GitHub"
+      title="GitHub Control Center"
+      description="Operate repository, workflow, OIDC, and AI/agentic risk coverage from one premium control surface."
+      scope={<ProductEnvironmentSelector state={environmentScope} onChange={onChangeEnvironment} />}
+      status={
+        <DomainStatusBadge
+          variant={statusVariant}
+          detail={data.connection?.account_login ? `@${data.connection.account_login}` : undefined}
+        />
+      }
+      statusTone={gitHubConnectionTone(data.connection, data.loading)}
+      primaryAction={
+        data.connection?.connected
+          ? { label: 'Open Repositories', to: repositoriesPath, variant: 'primary' }
+          : { label: 'Connect GitHub', to: connectPath, variant: 'primary' }
+      }
+      secondaryActions={[{ label: 'GitHub findings', to: findingsPath }]}
+      aside={
+        <DomainDetailPanel title="What GitHub owns" eyebrow="Domain charter">
+          <ul className="idt-domain-charter-list">
+            <li>Repository exposure and secret risk</li>
+            <li>GitHub Actions workflow permissions</li>
+            <li>OIDC trust paths and runner identity posture</li>
+            <li>AI/agentic repo configuration risk</li>
+          </ul>
+        </DomainDetailPanel>
+      }
+    >
+      {data.error ? <DomainErrorState title="Unable to load GitHub status" body={data.error} retryAction={{ label: 'Retry', onClick: data.reload }} /> : null}
+      <DomainKpiStrip label="GitHub control center metrics" items={metrics.map((metric) => ({ ...metric }))} />
+      <DomainStatusPanel
+        eyebrow="Connection"
+        title={data.connection?.connected ? `${data.connection.account_login ?? 'GitHub'} installation` : 'GitHub not connected'}
+        status={<DomainStatusBadge variant={statusVariant} />}
+        tone={gitHubConnectionTone(data.connection, data.loading) === 'danger' ? 'danger' : data.connection?.connected ? 'success' : 'neutral'}
+      >
+        <p>{gitHubConnectionSummary(data.connection)}</p>
+        {data.connection?.connected ? (
+          <dl className="idt-domain-route-facts">
+            <div>
+              <dt>Account</dt>
+              <dd>{data.connection.account_login ?? '—'}</dd>
+            </div>
+            <div>
+              <dt>Installation</dt>
+              <dd>{data.connection.installation_id ?? '—'}</dd>
+            </div>
+            <div>
+              <dt>Lifecycle</dt>
+              <dd>{formatTokenLabel(connectionLifecycle(data.connection))}</dd>
+            </div>
+            <div>
+              <dt>Health</dt>
+              <dd>{formatTokenLabel(connectionHealth(data.connection))}</dd>
+            </div>
+          </dl>
+        ) : null}
+      </DomainStatusPanel>
+      {recentScans.length > 0 ? (
+        <section className="idt-domain-status-panel" aria-label="Recent repository scans">
+          <header>
+            <div>
+              <p className="idt-app-kicker">Recent scans</p>
+              <h3>Last {recentScans.length} repository scans</h3>
+            </div>
+            <Link to={repositoriesPath}>Manage scans</Link>
+          </header>
+          <DomainTimeline label="Recent repository scans" entries={gitHubRecentScansTimeline(recentScans)} />
+        </section>
+      ) : (
+        <DomainEmptyState
+          eyebrow="Recent scans"
+          title="No repository scans yet"
+          body="Connect GitHub and queue the first repository scan to populate the activity timeline."
+          nextAction={{ label: 'Open Repositories', to: repositoriesPath }}
+        />
+      )}
+      <GitHubControlCenterNextActions
+        connected={Boolean(data.connection?.connected)}
+        selectedRepositories={selectedRepositories}
+        recentScans={recentScans}
+        connectPath={connectPath}
+        repositoriesPath={repositoriesPath}
+        findingsPath={findingsPath}
+      />
+      <GitHubSectionLinksGrid links={links} />
+    </DomainPageShell>
+  );
+}
+
+export function ProductGitHubConnectPage() {
+  const { scope, environmentScope, selectedEnvironmentID, onChangeEnvironment } = useGitHubDomainScope();
+  const availability = useGitHubAvailability();
+  const data = useGitHubDomainData(scope, selectedEnvironmentID, availability.available, GITHUB_CONTROL_CENTER_RECENT_SCANS_LIMIT);
+  const [installError, setInstallError] = useState('');
+  const [installing, setInstalling] = useState(false);
+
+  if (!scope) {
+    return (
+      <section className="idt-app-panel idt-app-panel-error" role="alert">
+        <p className="idt-app-kicker">Connect GitHub</p>
+        <h2>Workspace route context is missing</h2>
+        <p>Choose a tenant and workspace before loading the GitHub connector setup.</p>
+      </section>
+    );
+  }
+
+  if (availability.loading) {
+    return (
+      <DomainPageShell
+        domain="github"
+        eyebrow="GitHub"
+        title="Connect GitHub"
+        description="Loading GitHub availability for this build."
+        scope={<ProductEnvironmentSelector state={environmentScope} onChange={onChangeEnvironment} />}
+      >
+        <DomainLoadingState label="Loading GitHub availability" />
+      </DomainPageShell>
+    );
+  }
+
+  if (!availability.available) {
+    return (
+      <GitHubUnavailableShell
+        title="Connect GitHub"
+        scope={scope}
+        environmentScope={environmentScope}
+        selectedEnvironmentID={selectedEnvironmentID}
+        onEnvironmentChange={onChangeEnvironment}
+        unavailableMessage={availability.unavailableMessage}
+      />
+    );
+  }
+
+  if (!selectedEnvironmentID) {
+    return (
+      <GitHubMissingEnvironmentShell
+        title="Connect GitHub"
+        scope={scope}
+        environmentScope={environmentScope}
+        selectedEnvironmentID={selectedEnvironmentID}
+        onEnvironmentChange={onChangeEnvironment}
+      />
+    );
+  }
+
+  const basePath = appendEnvironmentQuery(buildScopedPath(scope, 'github'), selectedEnvironmentID);
+  const legacyPath = legacyProjectSetupPath(scope, selectedEnvironmentID);
+  const repositoriesPath = appendEnvironmentQuery(buildScopedPath(scope, 'github/repositories'), selectedEnvironmentID);
+
+  const handleInstall = async () => {
+    setInstallError('');
+    setInstalling(true);
+    try {
+      const response = await apiClient.startGitHubConnector(
+        {
+          project_id: selectedEnvironmentID,
+          install_account_type: 'any'
+        },
+        buildProductAuthContext(scope)
+      );
+      if (typeof window !== 'undefined' && response.install_url) {
+        window.open(response.install_url, '_blank', 'noopener,noreferrer');
+      }
+      data.reload();
+    } catch (error) {
+      setInstallError(formatAPIError(error, 'Unable to start GitHub App installation.'));
+    } finally {
+      setInstalling(false);
+    }
+  };
+
+  const statusVariant = gitHubConnectionStatusVariantFor(data.connection, data.loading);
+  const connected = Boolean(data.connection?.connected);
+
+  return (
+    <DomainPageShell
+      domain="github"
+      eyebrow="GitHub App onboarding"
+      title="Connect GitHub"
+      description="GitHub App installation, account scope, and Enterprise/PAT fallback live in the GitHub section."
+      scope={<ProductEnvironmentSelector state={environmentScope} onChange={onChangeEnvironment} />}
+      status={
+        <DomainStatusBadge
+          variant={statusVariant}
+          detail={data.connection?.account_login ? `@${data.connection.account_login}` : undefined}
+        />
+      }
+      statusTone={gitHubConnectionTone(data.connection, data.loading)}
+      primaryAction={
+        connected
+          ? { label: 'Open Repositories', to: repositoriesPath, variant: 'primary' }
+          : {
+              label: installing ? 'Opening install...' : 'Install GitHub App',
+              onClick: handleInstall,
+              disabled: installing,
+              variant: 'primary'
+            }
+      }
+      secondaryActions={[
+        { label: 'Manage Enterprise / PAT', to: legacyPath },
+        { label: 'GitHub home', to: basePath }
+      ]}
+      aside={
+        <DomainDetailPanel title="Why connect GitHub" eyebrow="Coverage">
+          <ul className="idt-domain-charter-list">
+            <li>Inventory repositories Identrail should monitor.</li>
+            <li>Queue repository scans for exposure and secret risk.</li>
+            <li>Detect risky GitHub Actions workflow permissions.</li>
+            <li>Map OIDC trust paths used by deploy automation.</li>
+          </ul>
+        </DomainDetailPanel>
+      }
+    >
+      {installError ? <DomainErrorState title="Unable to start install" body={installError} retryAction={{ label: 'Try again', onClick: handleInstall }} /> : null}
+      {data.error ? <DomainErrorState title="Unable to load connection status" body={data.error} retryAction={{ label: 'Retry', onClick: data.reload }} /> : null}
+      <DomainStatusPanel
+        eyebrow="Status"
+        title={connected ? `${data.connection?.account_login ?? 'GitHub'} installation` : 'Not connected yet'}
+        status={<DomainStatusBadge variant={statusVariant} />}
+        tone={connected ? 'success' : 'neutral'}
+      >
+        <p>{gitHubConnectionSummary(data.connection)}</p>
+        {connected ? (
+          <dl className="idt-domain-route-facts">
+            <div>
+              <dt>Account</dt>
+              <dd>{data.connection?.account_login ?? '—'}</dd>
+            </div>
+            <div>
+              <dt>Installation</dt>
+              <dd>{data.connection?.installation_id ?? '—'}</dd>
+            </div>
+            <div>
+              <dt>Selected repositories</dt>
+              <dd>{uniqueGitHubRepositories(data.connection?.selected_repositories ?? []).length}</dd>
+            </div>
+          </dl>
+        ) : null}
+      </DomainStatusPanel>
+      <section className="idt-domain-status-panel" aria-label="Connection paths">
+        <header>
+          <div>
+            <p className="idt-app-kicker">Connection paths</p>
+            <h3>Pick how to attach GitHub</h3>
+          </div>
+          <span>{`Environment ${selectedEnvironmentID}`}</span>
+        </header>
+        <div className="idt-domain-connection-paths">
+          <article>
+            <h4>GitHub App (recommended)</h4>
+            <p>Install the Identrail GitHub App to grant scoped repository and Actions access.</p>
+            <button
+              type="button"
+              className="idt-btn idt-btn-primary"
+              onClick={handleInstall}
+              disabled={installing}
+              aria-label="Install GitHub App"
+            >
+              {installing ? 'Opening install...' : 'Install GitHub App'}
+            </button>
+          </article>
+          <article>
+            <h4>Enterprise host or PAT</h4>
+            <p>For GitHub Enterprise Server or PAT-only environments, manage credentials on the project setup view.</p>
+            <Link to={legacyPath} className="idt-btn idt-btn-dark">
+              Open Enterprise / PAT setup
+            </Link>
+          </article>
+          <article>
+            <h4>Selected repositories</h4>
+            <p>Repository selection lives on the project setup view today and will move into this section in a follow-up PR.</p>
+            <Link to={legacyPath} className="idt-btn idt-btn-ghost">
+              Manage selected repositories
+            </Link>
+          </article>
+        </div>
+      </section>
+    </DomainPageShell>
+  );
+}
+
+type GitHubRepositoryRow = {
+  repository: string;
+  scans: RepoScanRecord[];
+  latest?: RepoScanRecord;
+  activeScan?: RepoScanRecord;
+};
+
+function buildGitHubRepositoryRows(selectedRepositories: string[], scans: RepoScanRecord[]): GitHubRepositoryRow[] {
+  return selectedRepositories.map((repository) => {
+    const lower = repository.toLowerCase();
+    const matching = scans.filter((scan) => canonicalGitHubRepositoryDisplay(scan.repository).toLowerCase() === lower);
+    const latest = [...matching].sort((left, right) => scanCompletionSortValue(right) - scanCompletionSortValue(left))[0];
+    const activeScan = matching.find((scan) => isActiveScanStatus(scan.status));
+    return { repository, scans: matching, latest, activeScan };
+  });
+}
+
+export function ProductGitHubRepositoriesPage() {
+  const { scope, environmentScope, selectedEnvironmentID, onChangeEnvironment } = useGitHubDomainScope();
+  const availability = useGitHubAvailability();
+  const data = useGitHubDomainData(scope, selectedEnvironmentID, availability.available, GITHUB_REPOSITORIES_SCANS_LIMIT);
+  const [scanError, setScanError] = useState('');
+  const [scanInfo, setScanInfo] = useState('');
+  const [submittingRepository, setSubmittingRepository] = useState('');
+  const [cancelingScanID, setCancelingScanID] = useState('');
+
+  if (!scope) {
+    return (
+      <section className="idt-app-panel idt-app-panel-error" role="alert">
+        <p className="idt-app-kicker">GitHub repositories</p>
+        <h2>Workspace route context is missing</h2>
+        <p>Choose a tenant and workspace before loading the GitHub repositories page.</p>
+      </section>
+    );
+  }
+
+  if (availability.loading) {
+    return (
+      <DomainPageShell
+        domain="github"
+        eyebrow="GitHub"
+        title="GitHub repositories"
+        description="Loading GitHub availability for this build."
+        scope={<ProductEnvironmentSelector state={environmentScope} onChange={onChangeEnvironment} />}
+      >
+        <DomainLoadingState label="Loading GitHub availability" />
+      </DomainPageShell>
+    );
+  }
+
+  if (!availability.available) {
+    return (
+      <GitHubUnavailableShell
+        title="GitHub repositories"
+        scope={scope}
+        environmentScope={environmentScope}
+        selectedEnvironmentID={selectedEnvironmentID}
+        onEnvironmentChange={onChangeEnvironment}
+        unavailableMessage={availability.unavailableMessage}
+      />
+    );
+  }
+
+  if (!selectedEnvironmentID) {
+    return (
+      <GitHubMissingEnvironmentShell
+        title="GitHub repositories"
+        scope={scope}
+        environmentScope={environmentScope}
+        selectedEnvironmentID={selectedEnvironmentID}
+        onEnvironmentChange={onChangeEnvironment}
+      />
+    );
+  }
+
+  const connectPath = appendEnvironmentQuery(buildScopedPath(scope, 'github/connect'), selectedEnvironmentID);
+  const basePath = appendEnvironmentQuery(buildScopedPath(scope, 'github'), selectedEnvironmentID);
+  const findingsPath = appendEnvironmentQuery(buildScopedPath(scope, 'github/findings'), selectedEnvironmentID);
+  const selectedRepositories = uniqueGitHubRepositories(data.connection?.selected_repositories ?? []);
+  const rows = buildGitHubRepositoryRows(selectedRepositories, data.scans);
+
+  const connected = Boolean(data.connection?.connected);
+  const statusVariant = gitHubConnectionStatusVariantFor(data.connection, data.loading);
+  const hasRepositories = selectedRepositories.length > 0;
+
+  const launchScan = async (repository: string) => {
+    if (!data.connection?.connected) {
+      setScanError('Connect GitHub before queueing a repository scan.');
+      return;
+    }
+    setScanError('');
+    setScanInfo('');
+    setSubmittingRepository(repository);
+    try {
+      const request: RepoScanRequest = { repository };
+      if (data.connection.provider === 'github_app') {
+        request.project_id = selectedEnvironmentID;
+        if (data.connection.connector_id) {
+          request.connector_id = data.connection.connector_id;
+        }
+      }
+      await apiClient.runRepoScan(request, buildProductAuthContext(scope));
+      setScanInfo(`Repository scan queued for ${repository}.`);
+      data.reload();
+    } catch (error) {
+      setScanError(formatRepoScanSubmitError(error));
+    } finally {
+      setSubmittingRepository((current) => (current === repository ? '' : current));
+    }
+  };
+
+  const cancelScan = async (scan: RepoScanRecord) => {
+    if (!isActiveScanStatus(scan.status)) {
+      setScanError('Only queued or running repository scans can be canceled.');
+      return;
+    }
+    setScanError('');
+    setScanInfo('');
+    setCancelingScanID(scan.id);
+    try {
+      await apiClient.cancelRepoScan(scan.id, buildProductAuthContext(scope));
+      setScanInfo(`Repository scan canceled for ${canonicalGitHubRepositoryDisplay(scan.repository) || scan.repository}.`);
+      data.reload();
+    } catch (error) {
+      setScanError(formatRepoScanCancelError(error));
+    } finally {
+      setCancelingScanID((current) => (current === scan.id ? '' : current));
+    }
+  };
+
+  return (
+    <DomainPageShell
+      domain="github"
+      eyebrow="Repository inventory"
+      title="GitHub repositories"
+      description="Launch, monitor, and cancel repository scans for the selected installation."
+      scope={<ProductEnvironmentSelector state={environmentScope} onChange={onChangeEnvironment} />}
+      status={
+        <DomainStatusBadge
+          variant={statusVariant}
+          detail={data.connection?.account_login ? `@${data.connection.account_login}` : undefined}
+        />
+      }
+      statusTone={gitHubConnectionTone(data.connection, data.loading)}
+      primaryAction={
+        connected
+          ? { label: 'Manage connection', to: connectPath, variant: 'secondary' }
+          : { label: 'Connect GitHub', to: connectPath, variant: 'primary' }
+      }
+      secondaryActions={[{ label: 'GitHub findings', to: findingsPath }, { label: 'GitHub home', to: basePath }]}
+      aside={
+        <DomainDetailPanel title="Scan operations" eyebrow="Reference">
+          <ul className="idt-domain-charter-list">
+            <li>Scans use the existing repository scan APIs.</li>
+            <li>Cancel is only available while a scan is queued or running.</li>
+            <li>Repository scope mirrors the GitHub App selection.</li>
+          </ul>
+        </DomainDetailPanel>
+      }
+    >
+      {data.error ? <DomainErrorState title="Unable to load repository status" body={data.error} retryAction={{ label: 'Retry', onClick: data.reload }} /> : null}
+      {scanError ? <DomainErrorState title="Repository scan error" body={scanError} /> : null}
+      {scanInfo ? (
+        <DomainStatusPanel eyebrow="Scan activity" title="Update" tone="info">
+          <p>{scanInfo}</p>
+        </DomainStatusPanel>
+      ) : null}
+      {!connected ? (
+        <DomainEmptyState
+          eyebrow="Not connected"
+          title="Connect GitHub to manage repositories"
+          body="Install the GitHub App or paste an Enterprise PAT to populate the repository inventory."
+          nextAction={{ label: 'Connect GitHub', to: connectPath }}
+        />
+      ) : !hasRepositories ? (
+        <DomainEmptyState
+          eyebrow="No repositories selected"
+          title="Select repositories for Identrail to watch"
+          body="Pick repositories on the connection page so Identrail can queue scans and detect risk."
+          nextAction={{ label: 'Select repositories', to: connectPath }}
+        />
+      ) : (
+        <section className="idt-domain-status-panel" aria-label="Selected repositories">
+          <header>
+            <div>
+              <p className="idt-app-kicker">Selected repositories</p>
+              <h3>{`${rows.length} ${rows.length === 1 ? 'repository' : 'repositories'} in scope`}</h3>
+            </div>
+            <span>{`Environment ${selectedEnvironmentID}`}</span>
+          </header>
+          <ul className="idt-github-repository-list">
+            {rows.map((row) => {
+              const submitting = submittingRepository === row.repository;
+              const canCancel = Boolean(row.activeScan);
+              const cancelingThis = canCancel && cancelingScanID === row.activeScan?.id;
+              return (
+                <li key={row.repository} className="idt-github-repository-row">
+                  <div>
+                    <strong>{row.repository}</strong>
+                    {row.latest ? (
+                      <small>
+                        Last scan {formatRelativeTime(row.latest.finished_at || row.latest.started_at)} ·{' '}
+                        {formatTokenLabel(row.latest.status)} ·{' '}
+                        {isCompletedScanStatus(row.latest.status) && !isFailedScanStatus(row.latest.status)
+                          ? `${row.latest.finding_count} findings`
+                          : isFailedScanStatus(row.latest.status)
+                            ? summarizeScanFailure(row.latest)
+                            : `${row.latest.scan_mode ?? 'scan'} in flight`}
+                      </small>
+                    ) : (
+                      <small>No scans yet.</small>
+                    )}
+                  </div>
+                  <div className="idt-inline-actions">
+                    <button
+                      type="button"
+                      className="idt-btn idt-btn-primary"
+                      onClick={() => launchScan(row.repository)}
+                      disabled={submitting || Boolean(row.activeScan)}
+                      aria-label={`Queue scan for ${row.repository}`}
+                    >
+                      {submitting ? 'Queuing...' : row.activeScan ? 'Scan in progress' : 'Queue scan'}
+                    </button>
+                    {canCancel && row.activeScan ? (
+                      <button
+                        type="button"
+                        className="idt-btn idt-btn-ghost"
+                        onClick={() => cancelScan(row.activeScan as RepoScanRecord)}
+                        disabled={cancelingThis}
+                        aria-label={`Cancel scan for ${row.repository}`}
+                      >
+                        {cancelingThis ? 'Canceling...' : 'Cancel scan'}
+                      </button>
+                    ) : null}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      )}
+      {connected && hasRepositories ? (
+        <section className="idt-domain-status-panel" aria-label="Recent repository scan activity">
+          <header>
+            <div>
+              <p className="idt-app-kicker">Activity</p>
+              <h3>Recent repository scan activity</h3>
+            </div>
+            <span>{`${data.scans.length} scan${data.scans.length === 1 ? '' : 's'} loaded`}</span>
+          </header>
+          {data.scans.length === 0 ? (
+            <DomainEmptyState
+              eyebrow="No activity"
+              title="No repository scans recorded yet"
+              body="Queue a scan for a selected repository to seed activity here."
+            />
+          ) : (
+            <DomainTimeline label="Recent repository scan activity" entries={gitHubRecentScansTimeline(data.scans.slice(0, GITHUB_CONTROL_CENTER_RECENT_SCANS_LIMIT * 2))} />
+          )}
+        </section>
+      ) : null}
+    </DomainPageShell>
+  );
+}
+
+export function ProductGitHubActionsPage() {
+  const { scope, environmentScope, selectedEnvironmentID, onChangeEnvironment } = useGitHubDomainScope();
+  const availability = useGitHubAvailability();
+
+  if (!scope) {
+    return (
+      <section className="idt-app-panel idt-app-panel-error" role="alert">
+        <p className="idt-app-kicker">GitHub Actions / OIDC</p>
+        <h2>Workspace route context is missing</h2>
+        <p>Choose a tenant and workspace before loading GitHub Actions / OIDC.</p>
+      </section>
+    );
+  }
+
+  if (availability.loading) {
+    return (
+      <DomainPageShell
+        domain="github"
+        eyebrow="Workflow trust"
+        title="GitHub Actions / OIDC"
+        description="Loading GitHub availability for this build."
+        scope={<ProductEnvironmentSelector state={environmentScope} onChange={onChangeEnvironment} />}
+      >
+        <DomainLoadingState label="Loading GitHub availability" />
+      </DomainPageShell>
+    );
+  }
+
+  if (!availability.available) {
+    return (
+      <GitHubUnavailableShell
+        title="GitHub Actions / OIDC"
+        scope={scope}
+        environmentScope={environmentScope}
+        selectedEnvironmentID={selectedEnvironmentID}
+        onEnvironmentChange={onChangeEnvironment}
+        unavailableMessage={availability.unavailableMessage}
+      />
+    );
+  }
+
+  const basePath = appendEnvironmentQuery(buildScopedPath(scope, 'github'), selectedEnvironmentID);
+  const connectPath = appendEnvironmentQuery(buildScopedPath(scope, 'github/connect'), selectedEnvironmentID);
+  const repositoriesPath = appendEnvironmentQuery(buildScopedPath(scope, 'github/repositories'), selectedEnvironmentID);
+  const findingsPath = appendEnvironmentQuery(buildScopedPath(scope, 'github/findings'), selectedEnvironmentID);
+
+  const surfaces = [
+    {
+      id: 'workflows',
+      title: 'Workflow inventory',
+      body: 'Track which repositories run GitHub Actions, what triggers them, and which workflows ship secrets to runners.'
+    },
+    {
+      id: 'permissions',
+      title: 'Actions permissions',
+      body: 'Surface repositories that allow write workflow tokens, broad GITHUB_TOKEN scopes, or unrestricted action sources.'
+    },
+    {
+      id: 'oidc',
+      title: 'OIDC trust paths',
+      body: 'Map AWS, GCP, and Azure roles that trust GitHub Actions OIDC claims, including branch and environment scoping.'
+    },
+    {
+      id: 'runners',
+      title: 'Runner posture',
+      body: 'Inventory self-hosted runners, label scoping, and ephemerality posture so risky reuse is easy to spot.'
+    }
+  ];
+
+  return (
+    <DomainPageShell
+      domain="github"
+      eyebrow="Workflow trust"
+      title="GitHub Actions / OIDC"
+      description="Workflow permissions, OIDC trust paths, Actions runners, and automation identity posture for GitHub."
+      scope={<ProductEnvironmentSelector state={environmentScope} onChange={onChangeEnvironment} />}
+      status={<DomainStatusBadge variant="coming-soon" label="Coverage incoming" />}
+      statusTone="neutral"
+      primaryAction={{ label: 'Connect GitHub', to: connectPath, variant: 'primary' }}
+      secondaryActions={[
+        { label: 'Open Repositories', to: repositoriesPath },
+        { label: 'GitHub findings', to: findingsPath },
+        { label: 'GitHub home', to: basePath }
+      ]}
+      aside={
+        <DomainDetailPanel title="Why this page exists" eyebrow="Domain charter">
+          <p>
+            GitHub Actions own the most powerful CI identities in many environments. Identrail will track workflow tokens,
+            OIDC trust, and runner posture here so security teams can reason about them as first-class machine identities.
+          </p>
+        </DomainDetailPanel>
+      }
+    >
+      <DomainStatusPanel
+        eyebrow="Coverage status"
+        title="Workflow and OIDC posture is rolling out"
+        status={<DomainStatusBadge variant="coming-soon" label="Premium preview" />}
+        tone="info"
+      >
+        <p>
+          The Identrail GitHub collector already ingests workflow and OIDC signal. The triage UI surfaces — workflow
+          inventory, permission posture, OIDC trust analysis, and runner inventory — land here as they ship so this page
+          stays the single home for Actions and automation identity in GitHub.
+        </p>
+      </DomainStatusPanel>
+      <section className="idt-domain-status-panel" aria-label="Surfaces planned here">
+        <header>
+          <div>
+            <p className="idt-app-kicker">Surfaces in this page</p>
+            <h3>What lands on Actions / OIDC</h3>
+          </div>
+          <span>4 surfaces</span>
+        </header>
+        <div className="idt-domain-readiness-items">
+          {surfaces.map((surface) => (
+            <article key={surface.id}>
+              <div>
+                <strong>{surface.title}</strong>
+                <p>{surface.body}</p>
+              </div>
+              <span>Planned</span>
+            </article>
+          ))}
+        </div>
+      </section>
+    </DomainPageShell>
+  );
 }
 
 export function ProductReportsPage() {


### PR DESCRIPTION
Fixes #1382

## Summary
Move GitHub setup, repository scan operation, and the Actions/OIDC posture surface out of the legacy `/projects/:projectID` source tab and into the domain-owned GitHub section introduced by #1381 and #1396. The four `/github*` routes now render real GitHub pages instead of the framework placeholder.

## What changed
- **`/github` GitHub Control Center** — renders connection status (account, installation, lifecycle, health), selected repository coverage, active and latest scan KPIs, a recent scan timeline, recommended next actions (connect → select repos → first scan → investigate failures → triage findings), and a subsection map with links into Connect, Repositories, Actions/OIDC, Findings, Remediation, and AI/Agentic Risk.
- **`/github/connect` Connect GitHub** — replaces the silent redirect to legacy setup with a premium Connect page. Has an inline `Install GitHub App` action that calls `startGitHubConnector` and opens the install URL in a new tab, a clear Enterprise/PAT fallback link to the existing project setup view, and a link out to selected-repository management (still on the legacy view for now, planned for a follow-up).
- **`/github/repositories` Repositories** — lists selected repositories with last-scan summary, per-repo `Queue scan` and `Cancel scan` buttons wired to `runRepoScan` / `cancelRepoScan`, plus a "Recent repository scan activity" timeline. Empty state when no repos are selected, error state for scan launch/cancel failures.
- **`/github/actions` Actions / OIDC** — premium waiting-for-coverage shell that explains the four surfaces this page will own (workflow inventory, Actions permissions, OIDC trust paths, runner posture).
- **Shared gating** — all four pages reuse `useBackendFeatures` + `FEATURE_ONBOARDING_CONNECTOR_GITHUB` so they render a clear "GitHub is not available on this API" shell with the existing `OnboardingUnavailableNotice` when the connector is gated off, instead of crashing or redirecting through the legacy flow.
- **Routing** — `web/src/App.tsx` now points `/github`, `/github/repositories`, and `/github/actions` at the new page components. `/github/connect` continues to be served by `ProductGitHubConnectPage`, which is now a real page rather than a redirect.
- **Tests** — added `GitHub domain pages (#1382)` describe block in `productShell.test.tsx` covering connection loading, scan launching, scan canceling, the no-repositories empty state, scan error state, the Actions premium shell, and the unavailable-feature shell. Updated the existing App.test.tsx gating test to assert the new in-domain unavailable copy.
- **CHANGELOG** — added an Unreleased entry describing the move.

## Why
PR #1396 routed the GitHub domain entry points to the legacy `/projects/:id?source=github` flow as a stopgap. The acceptance criteria for #1382 require this domain section to actually own GitHub — installation, repository operation, and the Actions/OIDC home — rather than redirect into the Projects-first UI. This PR makes `/github` feel like a first-class Identrail product area while keeping Findings, Remediation, and AI/Agentic Risk for follow-up PRs as the issue scopes.

## Impact and risk
- Backend contracts are unchanged. The new pages call the same `getGitHubConnectorStatus`, `startGitHubConnector`, `listRepoScans`, `runRepoScan`, and `cancelRepoScan` endpoints with the same `project_id`-scoped payloads as the legacy project page, so connector and repo-scan behavior is preserved.
- Repository *selection* still lives on the legacy project setup view (linked from `/github/connect`) and will move into the GitHub section in a follow-up PR alongside the remaining migration work.
- The Vite-only `VITE_FEATURE_CONNECTOR_GITHUB_V2` flag and the backend `connectors.github` advertisement continue to gate the GitHub connector. When either is off, the new pages render a premium "GitHub is not available on this API" shell instead of attempting any API call.

## Validation
- `npm run test:ci --prefix web` — `265 passed (265)`; coverage 79.69% lines, 78.83% statements.
- `npm run build --prefix web` — production build succeeds; 39 routes prerendered.
- `npx tsc --noEmit -p web` — clean.

## Screenshots
Not captured for this iteration — pages were verified through tests and the build. Happy to attach screenshots on request.

## AI-assisted disclosure
- AI-assisted: yes
- Tools used: Claude Sonnet 4.5 via Claude Code
- Where used: `web/src/productShell.tsx` new GitHub domain components and helpers, `web/src/productShell.test.tsx` new test block, `web/src/App.tsx` route wiring, `web/src/App.test.tsx` gating test update, `CHANGELOG.md`
- Human verification performed: read and edited every generated change inline; ran `npx tsc --noEmit`, `npm run test:ci --prefix web`, and `npm run build --prefix web` locally; iterated on test assertions until all 265 tests pass without warnings beyond expected `act()` informational notices

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved GitHub connection, repository scans, and Actions/OIDC into first-class `/github` pages with safer install, stricter scoping, and clearer errors. Completes Linear #1382 with no backend contract changes.

- **New Features**
  - Control Center: connection status, selected repo coverage, newest completed scan KPI, recent scans timeline, next actions, and links to Connect/Repositories/Actions/Findings/Remediation/AI Risk.
  - Connect: inline “Install GitHub App” via `startGitHubConnector` with `redirect_uri` to `/app/github/callback`, plus “Open GitHub” fallback when popups are blocked and an Enterprise/PAT link.
  - Repositories: selected repos with per-repo Queue/Cancel using `runRepoScan`/`cancelRepoScan`, activity timeline scoped to selected repos, and empty/error states.
  - Actions: premium shell for workflows, permissions, OIDC trust paths, and runner posture.
  - Routing: `/github`, `/github/repositories`, and `/github/actions` render `ProductGitHubControlCenterPage`, `ProductGitHubRepositoriesPage`, and `ProductGitHubActionsPage`.

- **Bug Fixes**
  - Control Center shows “Unable to load GitHub status” on scan list failures.
  - KPIs and Recent scans are strictly filtered to selected repositories and the current project; Latest scan uses the newest completed scan and shows failures.
  - Repositories activity paginates until selected-repo scans are found, ignores unselected repos, and disables Queue/Cancel during environment reloads; clears stale data on reload failure.
  - Install flow is resilient: forwards `redirect_uri` and shows an “Open GitHub” fallback when `window.open` is blocked.

<sup>Written for commit 19aafc075f30d462877213c058a903f78d7be019. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

