### PR TITLE
[codex] fix workos session creation sql

### DIFF
--- a/internal/db/postgres_auth.go
+++ b/internal/db/postgres_auth.go
@@ -454,6 +454,24 @@ const sessionUserSelect = `s.id, s.user_id::text, s.current_org_id, s.current_wo
        s.last_seen_at, s.revoked_at, s.created_at,
        u.id::text, u.primary_email::text, u.display_name, u.avatar_url, u.status, u.created_at, u.updated_at, u.deleted_at`
 
+const createSessionQuery = `WITH inserted AS (
+		     INSERT INTO sessions (
+		       id, user_id, current_org_id, current_workspace_id, current_project_id, auth_method,
+		       ip, user_agent, idle_expires_at, absolute_expires_at, last_seen_at, revoked_at, created_at
+		     )
+		     SELECT $1::bytea, NULLIF($2::text, '')::uuid, NULLIF($3::text, ''), NULLIF($4::text, ''), NULLIF($5::text, ''),
+		            $6::text, NULLIF($7::text, '')::inet, NULLIF($8::text, ''), $9::timestamptz, $10::timestamptz,
+		            $11::timestamptz, $12::timestamptz, $13::timestamptz
+		     FROM users u
+		     WHERE u.id = NULLIF($2::text, '')::uuid
+		       AND u.deleted_at IS NULL
+		       AND u.status = 'active'
+		     RETURNING *
+		   )
+		   SELECT ` + sessionUserSelect + `
+		   FROM inserted s
+		   JOIN users u ON u.id = s.user_id`
+
 // CreateSession persists one server-side session.
 func (p *PostgresStore) CreateSession(ctx context.Context, session Session) (Session, error) {
 	normalized, err := NormalizeSessionForWrite(session)
@@ -462,21 +480,7 @@ func (p *PostgresStore) CreateSession(ctx context.Context, session Session) (Ses
 	}
 	row := p.queryRowContextAnyScope(
 		ctx,
-		`WITH inserted AS (
-		     INSERT INTO sessions (
-		       id, user_id, current_org_id, current_workspace_id, current_project_id, auth_method,
-		       ip, user_agent, idle_expires_at, absolute_expires_at, last_seen_at, revoked_at, created_at
-		     )
-		     SELECT $1, $2, $3, $4, $5, $6, NULLIF($7, '')::inet, $8, $9, $10, $11, $12, $13
-		     FROM users u
-		     WHERE u.id = NULLIF($2, '')::uuid
-		       AND u.deleted_at IS NULL
-		       AND u.status = 'active'
-		     RETURNING *
-		   )
-		   SELECT `+sessionUserSelect+`
-		   FROM inserted s
-		   JOIN users u ON u.id = s.user_id`,
+		createSessionQuery,
 		normalized.ID,
 		normalized.UserID,
 		nullString(normalized.CurrentOrgID),

--- a/internal/db/postgres_auth_test.go
+++ b/internal/db/postgres_auth_test.go
@@ -5,11 +5,26 @@ import (
 	"context"
 	"crypto/sha256"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 )
+
+func TestCreateSessionQueryCastsUserIDParameterConsistently(t *testing.T) {
+	if strings.Contains(createSessionQuery, "SELECT $1, $2,") {
+		t.Fatal("create session query must not use raw $2 alongside NULLIF($2, '')::uuid")
+	}
+	for _, want := range []string{
+		"NULLIF($2::text, '')::uuid",
+		"WHERE u.id = NULLIF($2::text, '')::uuid",
+	} {
+		if !strings.Contains(createSessionQuery, want) {
+			t.Fatalf("create session query is missing %q", want)
+		}
+	}
+}
 
 func TestPostgresAuthUserIdentityAndSessionLifecycle(t *testing.T) {
 	rawDB, mock, err := sqlmock.New()


### PR DESCRIPTION
## Summary

- Cast the `CreateSession` user ID parameter consistently in the Postgres session insert.
- Add a regression check so the query cannot reintroduce the raw `$2` / `NULLIF($2, '')::uuid` type conflict.

## Root Cause

Production WorkOS login was completing provider auth, then failing during Identrail session creation with Postgres `SQLSTATE 42P08`: `inconsistent types deduced for parameter $2`. The session insert used `$2` as both the raw `sessions.user_id` value and inside `NULLIF($2, '')::uuid`, leaving Postgres to infer incompatible parameter types.

## Impact

This fixes the common post-provider-auth failure path for Google, GitHub, signup, and MFA completion. Once merged, wait for the image publish workflow, then run Deploy to prod from `dev`.

## Validation

- `go test ./internal/db`
- `go test ./internal/api`
- `go test ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix WorkOS session creation by consistently casting `user_id` in the Postgres insert, resolving 42P08 type errors and unblocking Google/GitHub/signup/MFA logins. Adds a regression test to prevent the mixed `$2`/`NULLIF($2, '')::uuid` pattern from returning.

- Bug Fixes
  - Replace raw `$2` with `NULLIF($2::text, '')::uuid` and add explicit casts across `createSessionQuery` (now a const in `internal/db/postgres_auth.go`).
  - Add `TestCreateSessionQueryCastsUserIDParameterConsistently` in `internal/db/postgres_auth_test.go` to lock the SQL casting.

<sup>Written for commit 6875d88e18d3775e213912c6c1af04659e2566f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

