### PR TITLE
Add self-serve profile editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ## Unreleased
+- Added self-serve account profile editing in Settings. Authenticated users can
+  now `PATCH /v1/me` with `display_name` and/or `avatar_url`; the endpoint
+  rejects unknown fields, trims and validates display names, restricts avatars
+  to blank or allowed `https://` hosts, registers `me:write` authz coverage,
+  and returns the refreshed `CurrentUserContext`. The Settings page now shows an
+  Account profile card before workspace settings, with inline editing,
+  optimistic cache updates, and rollback on save failure.
 - Added self-serve account permanent deletion with a 30-day reversible grace
   window. `DELETE /v1/me` soft-deletes the authenticated user (status flips to
   `deleted`, `deleted_at` is stamped, every other session is revoked, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 ## Unreleased
 - Added self-serve account profile editing in Settings. Authenticated users can
   now `PATCH /v1/me` with `display_name` and/or `avatar_url`; the endpoint
-  rejects unknown fields, trims and validates display names, restricts avatars
-  to blank or allowed `https://` hosts, registers `me:write` authz coverage,
-  and returns the refreshed `CurrentUserContext`. The Settings page now shows an
-  Account profile card before workspace settings, with inline editing,
-  optimistic cache updates, and rollback on save failure.
+  rejects unknown fields, trims and validates display names, blocks control and
+  bidirectional formatting characters, restricts avatars to blank or allowed
+  `https://` hosts, registers `me:write` authz coverage, and returns the
+  refreshed `CurrentUserContext` without touching account lifecycle fields. The
+  Settings page now shows an Account profile card before workspace settings,
+  with inline editing, optimistic cache updates, and rollback on save failure.
 - Added self-serve account permanent deletion with a 30-day reversible grace
   window. `DELETE /v1/me` soft-deletes the authenticated user (status flips to
   `deleted`, `deleted_at` is stamped, every other session is revoked, and the

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -4888,11 +4888,11 @@ components:
           type: string
           minLength: 1
           maxLength: 80
-          description: Trimmed display name. Control characters are rejected.
+          description: Trimmed display name. Control and bidirectional formatting characters are rejected.
         avatar_url:
           type: string
-          pattern: "^$|^https://"
-          description: Blank to clear, otherwise an allowed https avatar URL.
+          pattern: '^$|^[Hh][Tt][Tt][Pp][Ss]://([A-Za-z0-9-]+\.)*(avatars\.githubusercontent\.com|githubusercontent\.com|googleusercontent\.com|gravatar\.com|identrail\.com|identrail\.io)(:[0-9]+)?(/.*)?$'
+          description: Blank to clear, otherwise an allowed https avatar URL hosted under githubusercontent.com, googleusercontent.com, gravatar.com, identrail.com, or identrail.io.
     CurrentUserContext:
       type: object
       properties:

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -154,6 +154,10 @@ x-identrail-route-authorizations:
     path: /v1/me
     action: me.read
     resource_type: user
+  - method: PATCH
+    path: /v1/me
+    action: me.write
+    resource_type: user
   - method: GET
     path: /v1/me/sessions
     action: me.read
@@ -1558,6 +1562,36 @@ paths:
                     $ref: "#/components/schemas/CurrentUserContext"
         "401":
           $ref: "#/components/responses/Unauthorized"
+    patch:
+      tags: [Authorization]
+      summary: Update current user profile
+      operationId: updateCurrentUserProfile
+      security:
+        - CookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CurrentUserProfileUpdateRequest"
+      responses:
+        "200":
+          description: Updated current user and session context
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  me:
+                    $ref: "#/components/schemas/CurrentUserContext"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
     delete:
       tags: [Authorization]
       summary: Schedule the current user account for permanent deletion
@@ -4845,6 +4879,20 @@ components:
         deleted_at:
           type: string
           format: date-time
+    CurrentUserProfileUpdateRequest:
+      type: object
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        display_name:
+          type: string
+          minLength: 1
+          maxLength: 80
+          description: Trimmed display name. Control characters are rejected.
+        avatar_url:
+          type: string
+          pattern: "^$|^https://"
+          description: Blank to clear, otherwise an allowed https avatar URL.
     CurrentUserContext:
       type: object
       properties:

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -1231,7 +1231,7 @@ func decodeCurrentUserProfileUpdateRequest(body io.Reader) (CurrentUserProfileUp
 		}
 		return CurrentUserProfileUpdate{}, err
 	}
-	if err := decoder.Decode(&struct{}{}); err != nil && !errors.Is(err, io.EOF) {
+	if err := decoder.Decode(&struct{}{}); err == nil || !errors.Is(err, io.EOF) {
 		return CurrentUserProfileUpdate{}, errors.New("profile update request must contain a single JSON object")
 	}
 	return CurrentUserProfileUpdate{

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -1216,6 +1216,30 @@ func authReturnToOrigin(raw string) (string, bool) {
 	return strings.ToLower(parsed.Scheme + "://" + parsed.Host), true
 }
 
+type currentUserProfileUpdateRequest struct {
+	DisplayName *string `json:"display_name,omitempty"`
+	AvatarURL   *string `json:"avatar_url,omitempty"`
+}
+
+func decodeCurrentUserProfileUpdateRequest(body io.Reader) (CurrentUserProfileUpdate, error) {
+	var request currentUserProfileUpdateRequest
+	decoder := json.NewDecoder(body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		if errors.Is(err, io.EOF) {
+			return CurrentUserProfileUpdate{}, errors.New("profile update request body is required")
+		}
+		return CurrentUserProfileUpdate{}, err
+	}
+	if err := decoder.Decode(&struct{}{}); err != nil && !errors.Is(err, io.EOF) {
+		return CurrentUserProfileUpdate{}, errors.New("profile update request must contain a single JSON object")
+	}
+	return CurrentUserProfileUpdate{
+		DisplayName: request.DisplayName,
+		AvatarURL:   request.AvatarURL,
+	}, nil
+}
+
 func registerMeRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service, manager sessionauth.Manager) {
 	v1.GET("/me", func(c *gin.Context) {
 		current, ok := sessionauth.CurrentFromGin(c)
@@ -1235,6 +1259,37 @@ func registerMeRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service, man
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get current user"})
 			return
 		}
+		c.JSON(http.StatusOK, gin.H{"me": contextSnapshot})
+	})
+
+	v1.PATCH("/me", func(c *gin.Context) {
+		current, ok := sessionauth.CurrentFromGin(c)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "session required"})
+			return
+		}
+		update, err := decodeCurrentUserProfileUpdateRequest(c.Request.Body)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		contextSnapshot, err := svc.UpdateCurrentUserProfile(c.Request.Context(), current, update)
+		if err != nil {
+			if errors.Is(err, ErrAuthInvalidProfileUpdate) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
+			if errors.Is(err, db.ErrNotFound) {
+				c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+				return
+			}
+			if logger != nil {
+				logger.Error("update current user profile", telemetry.ZapError(err))
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update current user profile"})
+			return
+		}
+		auditAuthAction(c.Request.Context(), "auth.user.profile_update", current.Session.UserID, "success")
 		c.JSON(http.StatusOK, gin.H{"me": contextSnapshot})
 	})
 

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -1289,7 +1289,6 @@ func registerMeRoutes(v1 *gin.RouterGroup, logger *zap.Logger, svc *Service, man
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update current user profile"})
 			return
 		}
-		auditAuthAction(c.Request.Context(), "auth.user.profile_update", current.Session.UserID, "success")
 		c.JSON(http.StatusOK, gin.H{"me": contextSnapshot})
 	})
 

--- a/internal/api/auth_session_test.go
+++ b/internal/api/auth_session_test.go
@@ -178,6 +178,7 @@ func TestCurrentSessionUpdateCurrentUserProfileRejectsInvalidPayloads(t *testing
 		{name: "http avatar", body: `{"avatar_url":"http://avatars.githubusercontent.com/u/1"}`},
 		{name: "disallowed avatar host", body: `{"avatar_url":"https://example.com/avatar.png"}`},
 		{name: "empty body", body: ``},
+		{name: "trailing json value", body: `{"display_name":"Trailing"} {}`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/api/auth_session_test.go
+++ b/internal/api/auth_session_test.go
@@ -173,6 +173,7 @@ func TestCurrentSessionUpdateCurrentUserProfileRejectsInvalidPayloads(t *testing
 		{name: "blank display name", body: `{"display_name":"   "}`},
 		{name: "control character display name", body: `{"display_name":"Bad\nName"}`},
 		{name: "bidirectional formatting display name", body: `{"display_name":"evil\u202eadmin"}`},
+		{name: "arabic letter mark display name", body: `{"display_name":"evil\u061cadmin"}`},
 		{name: "data uri avatar", body: `{"avatar_url":"data:image/png;base64,abc"}`},
 		{name: "http avatar", body: `{"avatar_url":"http://avatars.githubusercontent.com/u/1"}`},
 		{name: "disallowed avatar host", body: `{"avatar_url":"https://example.com/avatar.png"}`},

--- a/internal/api/auth_session_test.go
+++ b/internal/api/auth_session_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -94,6 +95,14 @@ type ginlessSessionHarness struct {
 	svc     *Service
 }
 
+func patchCurrentUserProfileRequest(cookieValue string, body string) *http.Request {
+	req := httptest.NewRequest(http.MethodPatch, "/v1/me", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://localhost:8080")
+	req.AddCookie(&http.Cookie{Name: sessionauth.CookieName, Value: cookieValue})
+	return req
+}
+
 func TestCurrentSessionMeAndSessionList(t *testing.T) {
 	harness, cookieValue, currentPublicID := setupSessionRouter(t)
 	req := httptest.NewRequest(http.MethodGet, "/v1/me", nil)
@@ -116,6 +125,75 @@ func TestCurrentSessionMeAndSessionList(t *testing.T) {
 	}
 	if !strings.Contains(listW.Body.String(), currentPublicID) || !strings.Contains(listW.Body.String(), `"current":true`) {
 		t.Fatalf("session list did not include current session: %s", listW.Body.String())
+	}
+}
+
+func TestCurrentSessionUpdateCurrentUserProfile(t *testing.T) {
+	harness, cookieValue, _ := setupSessionRouter(t)
+	req := patchCurrentUserProfileRequest(cookieValue, `{"display_name":"  Updated User  ","avatar_url":"https://avatars.githubusercontent.com/u/1?v=4"}`)
+	w := httptest.NewRecorder()
+	harness.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected PATCH /v1/me 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var response struct {
+		Me CurrentUserContext `json:"me"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("decode profile update response: %v", err)
+	}
+	if response.Me.User.DisplayName != "Updated User" {
+		t.Fatalf("expected trimmed display name, got %q", response.Me.User.DisplayName)
+	}
+	if response.Me.User.AvatarURL != "https://avatars.githubusercontent.com/u/1?v=4" {
+		t.Fatalf("unexpected avatar_url: %q", response.Me.User.AvatarURL)
+	}
+	if response.Me.Role != "admin" || response.Me.WorkspaceID != "workspace-a" {
+		t.Fatalf("expected current context to be preserved, got %+v", response.Me)
+	}
+	stored, err := harness.svc.Store.GetUser(context.Background(), response.Me.User.ID)
+	if err != nil {
+		t.Fatalf("get stored user: %v", err)
+	}
+	if stored.PrimaryEmail != "user@example.com" || stored.Status != "active" {
+		t.Fatalf("profile update changed immutable user fields: %+v", stored)
+	}
+	if stored.DisplayName != "Updated User" || stored.AvatarURL != "https://avatars.githubusercontent.com/u/1?v=4" {
+		t.Fatalf("profile update was not persisted: %+v", stored)
+	}
+}
+
+func TestCurrentSessionUpdateCurrentUserProfileRejectsInvalidPayloads(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "unknown field", body: `{"primary_email":"attacker@example.com","display_name":"User Two"}`},
+		{name: "other user id", body: `{"id":"00000000-0000-0000-0000-000000000000","display_name":"User Two"}`},
+		{name: "blank display name", body: `{"display_name":"   "}`},
+		{name: "control character display name", body: `{"display_name":"Bad\nName"}`},
+		{name: "data uri avatar", body: `{"avatar_url":"data:image/png;base64,abc"}`},
+		{name: "http avatar", body: `{"avatar_url":"http://avatars.githubusercontent.com/u/1"}`},
+		{name: "disallowed avatar host", body: `{"avatar_url":"https://example.com/avatar.png"}`},
+		{name: "empty body", body: ``},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			harness, cookieValue, _ := setupSessionRouter(t)
+			req := patchCurrentUserProfileRequest(cookieValue, tc.body)
+			w := httptest.NewRecorder()
+			harness.router.ServeHTTP(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected PATCH /v1/me 400, got %d body=%s", w.Code, w.Body.String())
+			}
+			stored, err := harness.svc.Store.GetUserByPrimaryEmail(context.Background(), "user@example.com")
+			if err != nil {
+				t.Fatalf("get stored user: %v", err)
+			}
+			if stored.DisplayName != "User One" || stored.AvatarURL != "" {
+				t.Fatalf("invalid profile update changed stored user: %+v", stored)
+			}
+		})
 	}
 }
 

--- a/internal/api/auth_session_test.go
+++ b/internal/api/auth_session_test.go
@@ -172,6 +172,7 @@ func TestCurrentSessionUpdateCurrentUserProfileRejectsInvalidPayloads(t *testing
 		{name: "other user id", body: `{"id":"00000000-0000-0000-0000-000000000000","display_name":"User Two"}`},
 		{name: "blank display name", body: `{"display_name":"   "}`},
 		{name: "control character display name", body: `{"display_name":"Bad\nName"}`},
+		{name: "bidirectional formatting display name", body: `{"display_name":"evil\u202eadmin"}`},
 		{name: "data uri avatar", body: `{"avatar_url":"data:image/png;base64,abc"}`},
 		{name: "http avatar", body: `{"avatar_url":"http://avatars.githubusercontent.com/u/1"}`},
 		{name: "disallowed avatar host", body: `{"avatar_url":"https://example.com/avatar.png"}`},

--- a/internal/api/authz_policy_bundle_runtime.go
+++ b/internal/api/authz_policy_bundle_runtime.go
@@ -668,6 +668,7 @@ func defaultBuiltInRoutePolicyDefinitions() []routePolicyDefinition {
 		{Method: http.MethodPost, Path: "/v1/authz/policies/simulate", Action: policyActionAuthzSimulate, ResourceType: "authz_policy"},
 		{Method: http.MethodPost, Path: "/v1/authz/policies/rollback", Action: policyActionAuthzRollback, ResourceType: "authz_policy"},
 		{Method: http.MethodGet, Path: "/v1/me", Action: policyActionMeRead, ResourceType: "user"},
+		{Method: http.MethodPatch, Path: "/v1/me", Action: policyActionMeWrite, ResourceType: "user"},
 		{Method: http.MethodGet, Path: "/v1/me/sessions", Action: policyActionMeRead, ResourceType: "session"},
 		{Method: http.MethodDelete, Path: "/v1/me/sessions/:session_id", Action: policyActionMeWrite, ResourceType: "session", ResourceIDParam: "session_id"},
 		{Method: http.MethodPost, Path: "/v1/me/sessions/revoke-others", Action: policyActionMeWrite, ResourceType: "session"},

--- a/internal/api/service_auth.go
+++ b/internal/api/service_auth.go
@@ -964,8 +964,7 @@ func (s *Service) UpdateCurrentUserProfile(ctx context.Context, current sessiona
 	if s.Now != nil {
 		now = s.Now().UTC()
 	}
-	user.UpdatedAt = now
-	updated, err := s.Store.UpdateUserProfile(ctx, user)
+	updated, err := s.Store.UpdateCurrentUserProfile(ctx, user.ID, user.DisplayName, user.AvatarURL, now)
 	if err != nil {
 		return CurrentUserContext{}, err
 	}
@@ -982,11 +981,18 @@ func normalizeCurrentUserDisplayName(raw string) (string, error) {
 		return "", invalidCurrentUserProfileUpdate("display_name must be 1-80 characters")
 	}
 	for _, r := range displayName {
-		if unicode.IsControl(r) {
-			return "", invalidCurrentUserProfileUpdate("display_name cannot contain control characters")
+		if unicode.IsControl(r) || isBidirectionalFormattingRune(r) {
+			return "", invalidCurrentUserProfileUpdate("display_name cannot contain control or bidirectional formatting characters")
 		}
 	}
 	return displayName, nil
+}
+
+func isBidirectionalFormattingRune(r rune) bool {
+	return r == '\u200e' ||
+		r == '\u200f' ||
+		(r >= '\u202a' && r <= '\u202e') ||
+		(r >= '\u2066' && r <= '\u2069')
 }
 
 var currentUserAvatarAllowedHostSuffixes = []string{

--- a/internal/api/service_auth.go
+++ b/internal/api/service_auth.go
@@ -942,29 +942,27 @@ func (s *Service) UpdateCurrentUserProfile(ctx context.Context, current sessiona
 	if update.DisplayName == nil && update.AvatarURL == nil {
 		return CurrentUserContext{}, invalidCurrentUserProfileUpdate("profile update must include display_name or avatar_url")
 	}
-	user, err := s.Store.GetUser(ctx, current.Session.UserID)
-	if err != nil {
-		return CurrentUserContext{}, err
-	}
+	var displayName *string
 	if update.DisplayName != nil {
-		displayName, err := normalizeCurrentUserDisplayName(*update.DisplayName)
+		normalized, err := normalizeCurrentUserDisplayName(*update.DisplayName)
 		if err != nil {
 			return CurrentUserContext{}, err
 		}
-		user.DisplayName = displayName
+		displayName = &normalized
 	}
+	var avatarURL *string
 	if update.AvatarURL != nil {
-		avatarURL, err := normalizeCurrentUserAvatarURL(*update.AvatarURL)
+		normalized, err := normalizeCurrentUserAvatarURL(*update.AvatarURL)
 		if err != nil {
 			return CurrentUserContext{}, err
 		}
-		user.AvatarURL = avatarURL
+		avatarURL = &normalized
 	}
 	now := time.Now().UTC()
 	if s.Now != nil {
 		now = s.Now().UTC()
 	}
-	updated, err := s.Store.UpdateCurrentUserProfile(ctx, user.ID, user.DisplayName, user.AvatarURL, now)
+	updated, err := s.Store.UpdateCurrentUserProfile(ctx, current.Session.UserID, displayName, avatarURL, now)
 	if err != nil {
 		return CurrentUserContext{}, err
 	}
@@ -989,7 +987,8 @@ func normalizeCurrentUserDisplayName(raw string) (string, error) {
 }
 
 func isBidirectionalFormattingRune(r rune) bool {
-	return r == '\u200e' ||
+	return r == '\u061c' ||
+		r == '\u200e' ||
 		r == '\u200f' ||
 		(r >= '\u202a' && r <= '\u202e') ||
 		(r >= '\u2066' && r <= '\u2069')

--- a/internal/api/service_auth.go
+++ b/internal/api/service_auth.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	sessionauth "github.com/identrail/identrail/internal/api/auth"
 	"github.com/identrail/identrail/internal/audit"
@@ -19,6 +21,7 @@ var (
 	ErrAuthAccountNotFound        = errors.New("auth account not found")
 	ErrAuthReactivationRequired   = errors.New("auth account reactivation requires signup")
 	ErrAuthAccountPendingDeletion = errors.New("auth account is scheduled for permanent deletion")
+	ErrAuthInvalidProfileUpdate   = errors.New("invalid current user profile update")
 )
 
 const (
@@ -74,6 +77,27 @@ type ManualLoginResult struct {
 	CurrentWorkspaceID string
 	CurrentProjectID   string
 	RedirectPath       string
+}
+
+type CurrentUserProfileUpdate struct {
+	DisplayName *string
+	AvatarURL   *string
+}
+
+type invalidCurrentUserProfileUpdateError struct {
+	message string
+}
+
+func (e invalidCurrentUserProfileUpdateError) Error() string {
+	return e.message
+}
+
+func (e invalidCurrentUserProfileUpdateError) Is(target error) bool {
+	return target == ErrAuthInvalidProfileUpdate
+}
+
+func invalidCurrentUserProfileUpdate(message string) error {
+	return invalidCurrentUserProfileUpdateError{message: message}
 }
 
 var ErrAuthInvalidManualLogin = errors.New("manual login requires tenant and workspace")
@@ -907,6 +931,105 @@ func (s *Service) GetCurrentUserContext(ctx context.Context, current sessionauth
 		}
 	}
 	return result, nil
+}
+
+// UpdateCurrentUserProfile updates only the authenticated user's mutable
+// profile fields and returns a fresh CurrentUserContext snapshot.
+func (s *Service) UpdateCurrentUserProfile(ctx context.Context, current sessionauth.CurrentSession, update CurrentUserProfileUpdate) (CurrentUserContext, error) {
+	if s == nil || s.Store == nil {
+		return CurrentUserContext{}, errors.New("service unavailable")
+	}
+	if update.DisplayName == nil && update.AvatarURL == nil {
+		return CurrentUserContext{}, invalidCurrentUserProfileUpdate("profile update must include display_name or avatar_url")
+	}
+	user, err := s.Store.GetUser(ctx, current.Session.UserID)
+	if err != nil {
+		return CurrentUserContext{}, err
+	}
+	if update.DisplayName != nil {
+		displayName, err := normalizeCurrentUserDisplayName(*update.DisplayName)
+		if err != nil {
+			return CurrentUserContext{}, err
+		}
+		user.DisplayName = displayName
+	}
+	if update.AvatarURL != nil {
+		avatarURL, err := normalizeCurrentUserAvatarURL(*update.AvatarURL)
+		if err != nil {
+			return CurrentUserContext{}, err
+		}
+		user.AvatarURL = avatarURL
+	}
+	now := time.Now().UTC()
+	if s.Now != nil {
+		now = s.Now().UTC()
+	}
+	user.UpdatedAt = now
+	updated, err := s.Store.UpdateUserProfile(ctx, user)
+	if err != nil {
+		return CurrentUserContext{}, err
+	}
+	current.Session.User = &updated
+	return s.GetCurrentUserContext(ctx, current)
+}
+
+func normalizeCurrentUserDisplayName(raw string) (string, error) {
+	displayName := strings.TrimSpace(raw)
+	if displayName == "" {
+		return "", invalidCurrentUserProfileUpdate("display_name must be 1-80 characters")
+	}
+	if utf8.RuneCountInString(displayName) > 80 {
+		return "", invalidCurrentUserProfileUpdate("display_name must be 1-80 characters")
+	}
+	for _, r := range displayName {
+		if unicode.IsControl(r) {
+			return "", invalidCurrentUserProfileUpdate("display_name cannot contain control characters")
+		}
+	}
+	return displayName, nil
+}
+
+var currentUserAvatarAllowedHostSuffixes = []string{
+	"avatars.githubusercontent.com",
+	"githubusercontent.com",
+	"googleusercontent.com",
+	"gravatar.com",
+	"identrail.com",
+	"identrail.io",
+}
+
+func normalizeCurrentUserAvatarURL(raw string) (string, error) {
+	avatarURL := strings.TrimSpace(raw)
+	if avatarURL == "" {
+		return "", nil
+	}
+	parsed, err := url.Parse(avatarURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", invalidCurrentUserProfileUpdate("avatar_url must be a valid https URL")
+	}
+	if !strings.EqualFold(parsed.Scheme, "https") {
+		return "", invalidCurrentUserProfileUpdate("avatar_url must use https")
+	}
+	if parsed.User != nil {
+		return "", invalidCurrentUserProfileUpdate("avatar_url cannot include credentials")
+	}
+	if !currentUserAvatarHostAllowed(parsed.Hostname()) {
+		return "", invalidCurrentUserProfileUpdate("avatar_url host is not allowed")
+	}
+	return avatarURL, nil
+}
+
+func currentUserAvatarHostAllowed(rawHost string) bool {
+	host := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(rawHost), "."))
+	if host == "" {
+		return false
+	}
+	for _, allowed := range currentUserAvatarAllowedHostSuffixes {
+		if host == allowed || strings.HasSuffix(host, "."+allowed) {
+			return true
+		}
+	}
+	return false
 }
 
 // ListCurrentUserSessions returns active sessions scoped to the current user.

--- a/internal/db/memory_auth.go
+++ b/internal/db/memory_auth.go
@@ -78,6 +78,30 @@ func (m *MemoryStore) UpdateUserProfile(ctx context.Context, user User) (User, e
 	return existing, nil
 }
 
+// UpdateCurrentUserProfile updates only self-service mutable profile fields.
+// It leaves email and lifecycle fields untouched and requires an active row.
+func (m *MemoryStore) UpdateCurrentUserProfile(ctx context.Context, userID string, displayName string, avatarURL string, updatedAt time.Time) (User, error) {
+	id := strings.TrimSpace(userID)
+	m.mu.Lock()
+	existing, exists := m.users[id]
+	if !exists || existing.Status != "active" {
+		m.mu.Unlock()
+		return User{}, ErrNotFound
+	}
+	existing.DisplayName = strings.TrimSpace(displayName)
+	existing.AvatarURL = strings.TrimSpace(avatarURL)
+	existing.UpdatedAt = updatedAt.UTC()
+	m.users[id] = existing
+	m.mu.Unlock()
+	audit.WriteAction(ctx, audit.AuditEvent{
+		Action:       "auth.user.profile_update",
+		ResourceType: "user",
+		ResourceID:   id,
+		Outcome:      "success",
+	})
+	return existing, nil
+}
+
 // GetUser returns one account by UUID.
 func (m *MemoryStore) GetUser(ctx context.Context, userID string) (User, error) {
 	m.mu.RLock()

--- a/internal/db/memory_auth.go
+++ b/internal/db/memory_auth.go
@@ -80,7 +80,7 @@ func (m *MemoryStore) UpdateUserProfile(ctx context.Context, user User) (User, e
 
 // UpdateCurrentUserProfile updates only self-service mutable profile fields.
 // It leaves email and lifecycle fields untouched and requires an active row.
-func (m *MemoryStore) UpdateCurrentUserProfile(ctx context.Context, userID string, displayName string, avatarURL string, updatedAt time.Time) (User, error) {
+func (m *MemoryStore) UpdateCurrentUserProfile(ctx context.Context, userID string, displayName *string, avatarURL *string, updatedAt time.Time) (User, error) {
 	id := strings.TrimSpace(userID)
 	m.mu.Lock()
 	existing, exists := m.users[id]
@@ -88,8 +88,12 @@ func (m *MemoryStore) UpdateCurrentUserProfile(ctx context.Context, userID strin
 		m.mu.Unlock()
 		return User{}, ErrNotFound
 	}
-	existing.DisplayName = strings.TrimSpace(displayName)
-	existing.AvatarURL = strings.TrimSpace(avatarURL)
+	if displayName != nil {
+		existing.DisplayName = strings.TrimSpace(*displayName)
+	}
+	if avatarURL != nil {
+		existing.AvatarURL = strings.TrimSpace(*avatarURL)
+	}
 	existing.UpdatedAt = updatedAt.UTC()
 	m.users[id] = existing
 	m.mu.Unlock()

--- a/internal/db/memory_auth_test.go
+++ b/internal/db/memory_auth_test.go
@@ -372,7 +372,9 @@ func TestMemoryUpdateCurrentUserProfileRequiresActiveUserAndPreservesDeletionSta
 	if err != nil {
 		t.Fatalf("soft delete user: %v", err)
 	}
-	if _, err := store.UpdateCurrentUserProfile(ctx, user.ID, "Profile Race", "https://avatars.githubusercontent.com/u/1", now.Add(2*time.Minute)); !errors.Is(err, ErrNotFound) {
+	displayName := "Profile Race"
+	avatarURL := "https://avatars.githubusercontent.com/u/1"
+	if _, err := store.UpdateCurrentUserProfile(ctx, user.ID, &displayName, &avatarURL, now.Add(2*time.Minute)); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected inactive profile update to return ErrNotFound, got %v", err)
 	}
 	stored, err := store.GetUser(ctx, user.ID)
@@ -384,6 +386,39 @@ func TestMemoryUpdateCurrentUserProfileRequiresActiveUserAndPreservesDeletionSta
 	}
 	if stored.DisplayName != "Race User" || stored.AvatarURL != "" {
 		t.Fatalf("inactive profile update changed mutable fields: %+v", stored)
+	}
+}
+
+func TestMemoryUpdateCurrentUserProfilePreservesOmittedFields(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+	now := time.Date(2026, 5, 12, 13, 0, 0, 0, time.UTC)
+	user, err := store.UpsertUser(ctx, User{
+		ID:           "11111111-1111-1111-1111-111111111111",
+		PrimaryEmail: "partial@example.com",
+		DisplayName:  "Partial User",
+		AvatarURL:    "https://avatars.githubusercontent.com/u/1",
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	})
+	if err != nil {
+		t.Fatalf("upsert user: %v", err)
+	}
+	displayName := "Renamed User"
+	updated, err := store.UpdateCurrentUserProfile(ctx, user.ID, &displayName, nil, now.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("update display name: %v", err)
+	}
+	if updated.DisplayName != "Renamed User" || updated.AvatarURL != "https://avatars.githubusercontent.com/u/1" {
+		t.Fatalf("expected omitted avatar_url to be preserved, got %+v", updated)
+	}
+	avatarURL := ""
+	updated, err = store.UpdateCurrentUserProfile(ctx, user.ID, nil, &avatarURL, now.Add(2*time.Minute))
+	if err != nil {
+		t.Fatalf("clear avatar: %v", err)
+	}
+	if updated.DisplayName != "Renamed User" || updated.AvatarURL != "" {
+		t.Fatalf("expected omitted display_name to be preserved while clearing avatar_url, got %+v", updated)
 	}
 }
 

--- a/internal/db/memory_auth_test.go
+++ b/internal/db/memory_auth_test.go
@@ -354,6 +354,39 @@ func TestMemoryUpdateUserProfilePreservesStatus(t *testing.T) {
 	}
 }
 
+func TestMemoryUpdateCurrentUserProfileRequiresActiveUserAndPreservesDeletionState(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+	now := time.Date(2026, 5, 12, 13, 0, 0, 0, time.UTC)
+	user, err := store.UpsertUser(ctx, User{
+		ID:           "11111111-1111-1111-1111-111111111111",
+		PrimaryEmail: "race@example.com",
+		DisplayName:  "Race User",
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	})
+	if err != nil {
+		t.Fatalf("upsert user: %v", err)
+	}
+	deleted, err := store.SoftDeleteUser(ctx, user.ID, now.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("soft delete user: %v", err)
+	}
+	if _, err := store.UpdateCurrentUserProfile(ctx, user.ID, "Profile Race", "https://avatars.githubusercontent.com/u/1", now.Add(2*time.Minute)); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected inactive profile update to return ErrNotFound, got %v", err)
+	}
+	stored, err := store.GetUser(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if stored.Status != "deleted" || stored.DeletedAt == nil || deleted.DeletedAt == nil || !stored.DeletedAt.Equal(*deleted.DeletedAt) {
+		t.Fatalf("expected deleted lifecycle fields to survive profile update race, got %+v", stored)
+	}
+	if stored.DisplayName != "Race User" || stored.AvatarURL != "" {
+		t.Fatalf("inactive profile update changed mutable fields: %+v", stored)
+	}
+}
+
 func TestAuthNormalizationRejectsInvalidInputs(t *testing.T) {
 	now := time.Date(2026, 5, 12, 11, 0, 0, 0, time.UTC)
 	if _, err := NormalizeUserForWrite(User{ID: "not-a-uuid", PrimaryEmail: "user@example.com"}); err == nil {

--- a/internal/db/postgres_auth.go
+++ b/internal/db/postgres_auth.go
@@ -17,6 +17,13 @@ func nullString(value string) sql.NullString {
 	return sql.NullString{String: trimmed, Valid: trimmed != ""}
 }
 
+func optionalString(value *string) sql.NullString {
+	if value == nil {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: strings.TrimSpace(*value), Valid: true}
+}
+
 func nullTime(value *time.Time) sql.NullTime {
 	if value == nil {
 		return sql.NullTime{}
@@ -133,19 +140,19 @@ func (p *PostgresStore) UpdateUserProfile(ctx context.Context, user User) (User,
 // UpdateCurrentUserProfile updates only self-service mutable profile fields.
 // It leaves email and lifecycle fields untouched and requires the account to
 // still be active, so a concurrent account delete cannot lose deleted_at.
-func (p *PostgresStore) UpdateCurrentUserProfile(ctx context.Context, userID string, displayName string, avatarURL string, updatedAt time.Time) (User, error) {
+func (p *PostgresStore) UpdateCurrentUserProfile(ctx context.Context, userID string, displayName *string, avatarURL *string, updatedAt time.Time) (User, error) {
 	row := p.queryRowContextAnyScope(
 		ctx,
 		`UPDATE users
-		 SET display_name = $2,
-		     avatar_url = $3,
+		 SET display_name = COALESCE($2, display_name),
+		     avatar_url = COALESCE($3, avatar_url),
 		     updated_at = $4
 		 WHERE id = NULLIF($1, '')::uuid
 		   AND status = 'active'
 		 RETURNING id::text, primary_email::text, display_name, avatar_url, status, created_at, updated_at, deleted_at`,
 		strings.TrimSpace(userID),
-		strings.TrimSpace(displayName),
-		strings.TrimSpace(avatarURL),
+		optionalString(displayName),
+		optionalString(avatarURL),
 		updatedAt.UTC(),
 	)
 	saved, err := scanUser(row)

--- a/internal/db/postgres_auth.go
+++ b/internal/db/postgres_auth.go
@@ -130,6 +130,37 @@ func (p *PostgresStore) UpdateUserProfile(ctx context.Context, user User) (User,
 	return saved, nil
 }
 
+// UpdateCurrentUserProfile updates only self-service mutable profile fields.
+// It leaves email and lifecycle fields untouched and requires the account to
+// still be active, so a concurrent account delete cannot lose deleted_at.
+func (p *PostgresStore) UpdateCurrentUserProfile(ctx context.Context, userID string, displayName string, avatarURL string, updatedAt time.Time) (User, error) {
+	row := p.queryRowContextAnyScope(
+		ctx,
+		`UPDATE users
+		 SET display_name = $2,
+		     avatar_url = $3,
+		     updated_at = $4
+		 WHERE id = NULLIF($1, '')::uuid
+		   AND status = 'active'
+		 RETURNING id::text, primary_email::text, display_name, avatar_url, status, created_at, updated_at, deleted_at`,
+		strings.TrimSpace(userID),
+		strings.TrimSpace(displayName),
+		strings.TrimSpace(avatarURL),
+		updatedAt.UTC(),
+	)
+	saved, err := scanUser(row)
+	if err != nil {
+		return User{}, err
+	}
+	audit.WriteAction(ctx, audit.AuditEvent{
+		Action:       "auth.user.profile_update",
+		ResourceType: "user",
+		ResourceID:   saved.ID,
+		Outcome:      "success",
+	})
+	return saved, nil
+}
+
 // GetUser returns one account by UUID.
 func (p *PostgresStore) GetUser(ctx context.Context, userID string) (User, error) {
 	return scanUser(p.queryRowContextAnyScope(

--- a/internal/db/postgres_auth_test.go
+++ b/internal/db/postgres_auth_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"errors"
 	"strings"
 	"testing"
@@ -530,15 +531,16 @@ func TestPostgresUpdateCurrentUserProfileGuardsActiveStatus(t *testing.T) {
 	now := time.Date(2026, 5, 12, 16, 0, 0, 0, time.UTC)
 	userID := "11111111-1111-1111-1111-111111111111"
 
-	mock.ExpectQuery("(?s)UPDATE users.*AND status = 'active'").
-		WithArgs(userID, "Active Profile", "https://avatars.githubusercontent.com/u/1", now.Add(time.Minute)).
+	displayName := "Active Profile"
+	mock.ExpectQuery("(?s)UPDATE users.*display_name = COALESCE\\(\\$2, display_name\\).*avatar_url = COALESCE\\(\\$3, avatar_url\\).*AND status = 'active'").
+		WithArgs(userID, sql.NullString{String: "Active Profile", Valid: true}, sql.NullString{}, now.Add(time.Minute)).
 		WillReturnRows(postgresAuthUserRows(now).AddRow(userID, "active@example.com", "Active Profile", "https://avatars.githubusercontent.com/u/1", "active", now, now.Add(time.Minute), nil))
-	updated, err := store.UpdateCurrentUserProfile(ctx, userID, "Active Profile", "https://avatars.githubusercontent.com/u/1", now.Add(time.Minute))
+	updated, err := store.UpdateCurrentUserProfile(ctx, userID, &displayName, nil, now.Add(time.Minute))
 	if err != nil {
 		t.Fatalf("update current user profile: %v", err)
 	}
-	if updated.PrimaryEmail != "active@example.com" || updated.Status != "active" || updated.DeletedAt != nil {
-		t.Fatalf("expected lifecycle fields returned from existing row, got %+v", updated)
+	if updated.PrimaryEmail != "active@example.com" || updated.Status != "active" || updated.DeletedAt != nil || updated.AvatarURL != "https://avatars.githubusercontent.com/u/1" {
+		t.Fatalf("expected lifecycle and omitted fields returned from existing row, got %+v", updated)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/internal/db/postgres_auth_test.go
+++ b/internal/db/postgres_auth_test.go
@@ -519,6 +519,33 @@ func TestPostgresUpdateUserProfilePreservesStatus(t *testing.T) {
 	}
 }
 
+func TestPostgresUpdateCurrentUserProfileGuardsActiveStatus(t *testing.T) {
+	rawDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer rawDB.Close()
+	store := NewPostgresStoreWithDB(rawDB)
+	ctx := context.Background()
+	now := time.Date(2026, 5, 12, 16, 0, 0, 0, time.UTC)
+	userID := "11111111-1111-1111-1111-111111111111"
+
+	mock.ExpectQuery("(?s)UPDATE users.*AND status = 'active'").
+		WithArgs(userID, "Active Profile", "https://avatars.githubusercontent.com/u/1", now.Add(time.Minute)).
+		WillReturnRows(postgresAuthUserRows(now).AddRow(userID, "active@example.com", "Active Profile", "https://avatars.githubusercontent.com/u/1", "active", now, now.Add(time.Minute), nil))
+	updated, err := store.UpdateCurrentUserProfile(ctx, userID, "Active Profile", "https://avatars.githubusercontent.com/u/1", now.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("update current user profile: %v", err)
+	}
+	if updated.PrimaryEmail != "active@example.com" || updated.Status != "active" || updated.DeletedAt != nil {
+		t.Fatalf("expected lifecycle fields returned from existing row, got %+v", updated)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func postgresAuthUserRows(time.Time) *sqlmock.Rows {
 	return sqlmock.NewRows([]string{"id", "primary_email", "display_name", "avatar_url", "status", "created_at", "updated_at", "deleted_at"})
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2619,7 +2619,7 @@ type Store interface {
 	DeleteTenancyConnectorSecretEnvelope(ctx context.Context, workspaceID string, projectID string, connectorID string, secretName string) error
 	UpsertUser(ctx context.Context, user User) (User, error)
 	UpdateUserProfile(ctx context.Context, user User) (User, error)
-	UpdateCurrentUserProfile(ctx context.Context, userID string, displayName string, avatarURL string, updatedAt time.Time) (User, error)
+	UpdateCurrentUserProfile(ctx context.Context, userID string, displayName *string, avatarURL *string, updatedAt time.Time) (User, error)
 	GetUser(ctx context.Context, userID string) (User, error)
 	GetUserByPrimaryEmail(ctx context.Context, email string) (User, error)
 	SetUserStatus(ctx context.Context, userID string, status string, now time.Time) (User, error)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2619,6 +2619,7 @@ type Store interface {
 	DeleteTenancyConnectorSecretEnvelope(ctx context.Context, workspaceID string, projectID string, connectorID string, secretName string) error
 	UpsertUser(ctx context.Context, user User) (User, error)
 	UpdateUserProfile(ctx context.Context, user User) (User, error)
+	UpdateCurrentUserProfile(ctx context.Context, userID string, displayName string, avatarURL string, updatedAt time.Time) (User, error)
 	GetUser(ctx context.Context, userID string) (User, error)
 	GetUserByPrimaryEmail(ctx context.Context, email string) (User, error)
 	SetUserStatus(ctx context.Context, userID string, status string, now time.Time) (User, error)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -434,6 +434,11 @@ export type CurrentUserContext = {
   project?: ProjectRecord;
 };
 
+export type CurrentUserProfileUpdate = {
+  display_name?: string;
+  avatar_url?: string;
+};
+
 export type OnboardingStep = 'org' | 'workspace' | 'connect' | 'scan' | 'invite' | 'complete';
 
 export type OnboardingState = {
@@ -1169,6 +1174,12 @@ export const apiClient = {
   getMe(options: { redirectOnUnauthorized?: boolean } = {}) {
     return request<{ me: CurrentUserContext }>('/v1/me', undefined, {
       redirectOnUnauthorized: options.redirectOnUnauthorized ?? false
+    });
+  },
+  updateMe(payload: CurrentUserProfileUpdate) {
+    return request<{ me: CurrentUserContext }>('/v1/me', undefined, {
+      method: 'PATCH',
+      body: JSON.stringify(payload)
     });
   },
   listCurrentUserSessions() {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -2,11 +2,13 @@ import { act, fireEvent, render, screen, waitFor, within } from '@testing-librar
 import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type {
+  AuthConfigResponse,
   AWSConnectionStatus,
   CurrentUserContext,
   Finding,
   GitHubConnectionStatus,
-  RepoScanRecord
+  RepoScanRecord,
+  WhoAmIResponse
 } from './api/client';
 import type { BackendFeatureState } from './hooks/useBackendFeatures';
 
@@ -16,6 +18,30 @@ const loggedInWithoutWorkspace: CurrentUserContext = {
     primary_email: 'owner@example.com',
     display_name: 'Owner User',
     status: 'active',
+    created_at: '2026-05-16T10:00:00Z',
+    updated_at: '2026-05-16T10:00:00Z'
+  }
+};
+
+const loggedInWithWorkspace: CurrentUserContext = {
+  user: {
+    id: 'user-1',
+    primary_email: 'owner@example.com',
+    display_name: 'Owner User',
+    avatar_url: 'https://avatars.githubusercontent.com/u/1?v=4',
+    status: 'active',
+    created_at: '2026-05-16T10:00:00Z',
+    updated_at: '2026-05-16T10:00:00Z'
+  },
+  org_id: 'tenant-a',
+  workspace_id: 'workspace-a',
+  project_id: 'project-a',
+  role: 'admin',
+  workspace: {
+    tenant_id: 'tenant-a',
+    workspace_id: 'workspace-a',
+    display_name: 'Workspace A',
+    slug: 'workspace-a',
     created_at: '2026-05-16T10:00:00Z',
     updated_at: '2026-05-16T10:00:00Z'
   }
@@ -168,6 +194,94 @@ function mockConnectorFeatureFlags({
       FEATURE_ONBOARDING_CONNECTOR_K8S: kubernetes
     };
   });
+}
+
+const settingsAuthConfig: AuthConfigResponse = {
+  auth: {
+    manual_mode: false,
+    workos_login_enabled: true,
+    native_saml_enabled: false,
+    providers: ['github_oauth', 'google_oauth']
+  },
+  features: {
+    onboarding_wizard: true,
+    connectors: { github: true, aws: true, kubernetes: true }
+  }
+};
+
+function settingsWhoAmI(me: CurrentUserContext): WhoAmIResponse {
+  const workspace = me.workspace ?? {
+    tenant_id: 'tenant-a',
+    workspace_id: 'workspace-a',
+    display_name: 'Workspace A',
+    slug: 'workspace-a',
+    created_at: '2026-05-16T10:00:00Z',
+    updated_at: '2026-05-16T10:00:00Z'
+  };
+  const member = {
+    tenant_id: workspace.tenant_id,
+    workspace_id: workspace.workspace_id,
+    member_id: 'member-a',
+    user_id: 'oidc-subject-a',
+    email: me.user.primary_email,
+    role: me.role ?? 'admin',
+    status: 'active' as const,
+    joined_at: '2026-05-16T10:00:00Z',
+    updated_at: '2026-05-16T10:00:00Z'
+  };
+  return {
+    principal: { type: 'subject', id: 'oidc-subject-a' },
+    roles: [member.role],
+    scopes: ['me:read', 'me:write'],
+    scope: { tenant_id: workspace.tenant_id, workspace_id: workspace.workspace_id },
+    active_workspace: { workspace, member, is_active: true },
+    workspaces: [{ workspace, member, is_active: true }]
+  };
+}
+
+async function renderProductSettingsPage(options: {
+  me?: CurrentUserContext;
+  updateMe?: CurrentUserContext | Error;
+} = {}) {
+  vi.resetModules();
+  const me = options.me ?? loggedInWithWorkspace;
+  const primeMeCache = vi.fn();
+  vi.doMock('./hooks/useMe', () => ({
+    useMe: () => ({
+      me,
+      loading: false,
+      error: '',
+      unauthenticated: false,
+      refresh: vi.fn()
+    }),
+    primeMeCache,
+    clearMeCache: vi.fn()
+  }));
+
+  const api = await import('./api/client');
+  const whoAmI = settingsWhoAmI(me);
+  vi.spyOn(api.apiClient, 'getWhoAmI').mockResolvedValue(whoAmI);
+  vi.spyOn(api.apiClient, 'listWorkspaceMembers').mockResolvedValue({
+    items: whoAmI.active_workspace?.member ? [whoAmI.active_workspace.member] : []
+  });
+  vi.spyOn(api.apiClient, 'getAuthConfig').mockResolvedValue(settingsAuthConfig);
+  const updateMe = vi.spyOn(api.apiClient, 'updateMe');
+  if (options.updateMe instanceof Error) {
+    updateMe.mockRejectedValue(options.updateMe);
+  } else {
+    updateMe.mockResolvedValue({ me: options.updateMe ?? me });
+  }
+
+  const { ProductSettingsPage } = await import('./productShell');
+  render(
+    <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/settings']}>
+      <Routes>
+        <Route path="/app/:tenantID/:workspaceID/settings" element={<ProductSettingsPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+  return { primeMeCache, updateMe };
 }
 
 async function renderProjectDetail(
@@ -348,6 +462,81 @@ describe('ProductAppIndexRedirect', () => {
     await renderProductIndexRedirect(false, undefined);
 
     expect(await screen.findByRole('heading', { level: 1, name: /No workspace is attached yet/i })).toBeInTheDocument();
+  });
+});
+
+describe('ProductSettingsPage profile', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.doUnmock('./hooks/useMe');
+    vi.resetModules();
+  });
+
+  it('updates profile fields optimistically from settings', async () => {
+    const updatedMe: CurrentUserContext = {
+      ...loggedInWithWorkspace,
+      user: {
+        ...loggedInWithWorkspace.user,
+        display_name: 'Updated Owner',
+        avatar_url: 'https://avatars.githubusercontent.com/u/42?v=4',
+        updated_at: '2026-05-17T10:00:00Z'
+      }
+    };
+    const { primeMeCache, updateMe } = await renderProductSettingsPage({ updateMe: updatedMe });
+
+    expect(await screen.findByRole('heading', { name: 'Owner User' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Edit profile' }));
+    fireEvent.change(screen.getByLabelText('Display name'), { target: { value: '  Updated Owner  ' } });
+    fireEvent.change(screen.getByLabelText('Avatar URL'), {
+      target: { value: 'https://avatars.githubusercontent.com/u/42?v=4' }
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save profile' }));
+
+    await waitFor(() =>
+      expect(updateMe).toHaveBeenCalledWith({
+        display_name: 'Updated Owner',
+        avatar_url: 'https://avatars.githubusercontent.com/u/42?v=4'
+      })
+    );
+    expect(primeMeCache).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        user: expect.objectContaining({
+          display_name: 'Updated Owner',
+          avatar_url: 'https://avatars.githubusercontent.com/u/42?v=4'
+        })
+      })
+    );
+    await waitFor(() => expect(primeMeCache).toHaveBeenLastCalledWith(updatedMe));
+  });
+
+  it('rolls back the optimistic profile update when saving fails', async () => {
+    const { primeMeCache, updateMe } = await renderProductSettingsPage({
+      updateMe: new Error('avatar_url host is not allowed')
+    });
+
+    expect(await screen.findByRole('heading', { name: 'Owner User' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Edit profile' }));
+    fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Blocked Owner' } });
+    fireEvent.change(screen.getByLabelText('Avatar URL'), { target: { value: 'https://example.com/avatar.png' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save profile' }));
+
+    await waitFor(() => expect(updateMe).toHaveBeenCalled());
+    expect(await screen.findByRole('alert')).toHaveTextContent('avatar_url host is not allowed');
+    expect(primeMeCache).toHaveBeenLastCalledWith(loggedInWithWorkspace);
+  });
+
+  it('validates display name before submitting a profile update', async () => {
+    const { primeMeCache, updateMe } = await renderProductSettingsPage();
+
+    expect(await screen.findByRole('heading', { name: 'Owner User' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Edit profile' }));
+    fireEvent.change(screen.getByLabelText('Display name'), { target: { value: '   ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save profile' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Display name must be 1-80 characters.');
+    expect(updateMe).not.toHaveBeenCalled();
+    expect(primeMeCache).not.toHaveBeenCalled();
   });
 });
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1272,6 +1272,7 @@ function isUnsafeProfileNameCharacter(char: string): boolean {
   return (
     code < 32 ||
     code === 127 ||
+    code === 0x061c ||
     code === 0x200e ||
     code === 0x200f ||
     (code >= 0x202a && code <= 0x202e) ||

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -8,6 +8,7 @@ import type {
 import { Link, Navigate, NavLink, Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
 import {
   BarChart3,
+  Check,
   ChevronDown,
   ChevronRight,
   ChevronUp,
@@ -18,6 +19,7 @@ import {
   LogOut,
   PanelLeftClose,
   PanelLeftOpen,
+  Pencil,
   Search,
   Settings as SettingsIcon,
   X
@@ -1204,6 +1206,70 @@ function countMembersByStatus(members: WorkspaceMemberRecord[], status: Workspac
 
 function countMembersByRole(members: WorkspaceMemberRecord[], role: WorkspaceMemberRole): number {
   return members.filter((member) => member.role === role).length;
+}
+
+type ProfileDraft = {
+  displayName: string;
+  avatarUrl: string;
+};
+
+function profileDraftFromMe(me: CurrentUserContext | null | undefined): ProfileDraft {
+  return {
+    displayName: me?.user.display_name ?? '',
+    avatarUrl: me?.user.avatar_url ?? ''
+  };
+}
+
+function formatProfileDisplayName(me: CurrentUserContext | null | undefined): string {
+  const displayName = me?.user.display_name?.trim();
+  if (displayName) {
+    return displayName;
+  }
+  return me?.user.primary_email ?? 'Current user';
+}
+
+function formatProfileInitials(me: CurrentUserContext | null | undefined): string {
+  const source = formatProfileDisplayName(me).split('@')[0] || 'U';
+  const parts = source
+    .split(/[\s._-]+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const initials = (parts.length > 1 ? parts[0][0] + parts[1][0] : source.slice(0, 2)).toUpperCase();
+  return initials || 'U';
+}
+
+function validateProfileDraft(draft: ProfileDraft, options: { validateAvatarUrl?: boolean } = {}): string {
+  const displayName = draft.displayName.trim();
+  if (!displayName || Array.from(displayName).length > 80) {
+    return 'Display name must be 1-80 characters.';
+  }
+  if (
+    Array.from(displayName).some((char) => {
+      const code = char.charCodeAt(0);
+      return code < 32 || code === 127;
+    })
+  ) {
+    return 'Display name cannot contain control characters.';
+  }
+  const avatarUrl = draft.avatarUrl.trim();
+  if (options.validateAvatarUrl === false) {
+    return '';
+  }
+  if (!avatarUrl) {
+    return '';
+  }
+  try {
+    const parsed = new URL(avatarUrl);
+    if (parsed.protocol !== 'https:') {
+      return 'Avatar URL must use https.';
+    }
+    if (parsed.username || parsed.password) {
+      return 'Avatar URL cannot include credentials.';
+    }
+  } catch {
+    return 'Avatar URL must be a valid https URL.';
+  }
+  return '';
 }
 
 function hasWorkspaceAdminAccess(scope: ProductSession, whoAmI: WhoAmIResponse | null): boolean {
@@ -9394,6 +9460,10 @@ export function ProductSettingsPage() {
   const [suspendModalOpen, setSuspendModalOpen] = useState(false);
   const [suspendPending, setSuspendPending] = useState(false);
   const [suspendError, setSuspendError] = useState('');
+  const [profileEditing, setProfileEditing] = useState(false);
+  const [profileDraft, setProfileDraft] = useState<ProfileDraft>(() => profileDraftFromMe(me));
+  const [profileSaving, setProfileSaving] = useState(false);
+  const [profileError, setProfileError] = useState('');
 
   useEffect(() => {
     if (!scope) {
@@ -9438,6 +9508,13 @@ export function ProductSettingsPage() {
     };
   }, [scope?.tenantID, scope?.workspaceID, scope?.projectID]);
 
+  useEffect(() => {
+    if (!profileEditing && !profileSaving) {
+      setProfileDraft(profileDraftFromMe(me));
+      setProfileError('');
+    }
+  }, [me?.user.display_name, me?.user.avatar_url, profileEditing, profileSaving]);
+
   const activeWorkspace = whoAmI?.active_workspace?.workspace ?? me?.workspace;
   const activeMember =
     whoAmI?.active_workspace?.member ??
@@ -9457,6 +9534,75 @@ export function ProductSettingsPage() {
   const githubFindingsPath = scope ? buildScopedPath(scope, 'github/findings') : '/app';
   const kubernetesPath = scope ? buildScopedPath(scope, 'kubernetes') : '/app';
   const workspacesPath = scope ? buildScopedPath(scope, 'workspaces') : '/app';
+  const profileDisplayName = formatProfileDisplayName(me);
+  const profileAvatarURL = me?.user.avatar_url?.trim() ?? '';
+  const profileInitials = formatProfileInitials(me);
+
+  const handleProfileEdit = () => {
+    setProfileDraft(profileDraftFromMe(me));
+    setProfileError('');
+    setProfileEditing(true);
+  };
+
+  const handleProfileCancel = () => {
+    if (profileSaving) return;
+    setProfileDraft(profileDraftFromMe(me));
+    setProfileError('');
+    setProfileEditing(false);
+  };
+
+  const handleProfileSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!me) {
+      setProfileError('Current user is unavailable.');
+      return;
+    }
+    const previousMe = me;
+    const previousDisplayName = previousMe.user.display_name?.trim() ?? '';
+    const previousAvatarURL = previousMe.user.avatar_url?.trim() ?? '';
+    const nextDisplayName = profileDraft.displayName.trim();
+    const nextAvatarURL = profileDraft.avatarUrl.trim();
+    const displayNameChanged = nextDisplayName !== previousDisplayName;
+    const avatarURLChanged = nextAvatarURL !== previousAvatarURL;
+    const validationError = validateProfileDraft(profileDraft, { validateAvatarUrl: avatarURLChanged });
+    if (validationError) {
+      setProfileError(validationError);
+      return;
+    }
+    if (!displayNameChanged && !avatarURLChanged) {
+      setProfileError('');
+      setProfileEditing(false);
+      return;
+    }
+    const optimisticMe: CurrentUserContext = {
+      ...previousMe,
+      user: {
+        ...previousMe.user,
+        display_name: nextDisplayName,
+        avatar_url: nextAvatarURL,
+        updated_at: new Date().toISOString()
+      }
+    };
+    setProfileSaving(true);
+    setProfileError('');
+    primeMeCache(optimisticMe);
+    try {
+      const payload = {
+        ...(displayNameChanged ? { display_name: nextDisplayName } : {}),
+        ...(avatarURLChanged ? { avatar_url: nextAvatarURL } : {})
+      };
+      const response = await apiClient.updateMe(payload);
+      primeMeCache(response.me);
+      setProfileDraft(profileDraftFromMe(response.me));
+      setProfileEditing(false);
+    } catch (err) {
+      primeMeCache(previousMe);
+      setProfileDraft(profileDraftFromMe(previousMe));
+      setProfileError(err instanceof Error ? err.message : 'Unable to update profile.');
+    } finally {
+      setProfileSaving(false);
+    }
+  };
 
   if (loading) {
     return (
@@ -9497,6 +9643,104 @@ export function ProductSettingsPage() {
           </Link>
         </div>
       </header>
+
+      <section className="idt-settings-card idt-profile-card" aria-labelledby="idt-profile-heading">
+        <div className="idt-settings-card-header">
+          <div>
+            <p className="idt-app-kicker">Account profile</p>
+            <h3 id="idt-profile-heading">{profileDisplayName}</h3>
+          </div>
+          {profileEditing ? null : (
+            <button
+              type="button"
+              className="idt-icon-btn idt-profile-icon-btn"
+              aria-label="Edit profile"
+              title="Edit profile"
+              onClick={handleProfileEdit}
+              disabled={!me}
+            >
+              <Pencil size={16} aria-hidden="true" />
+            </button>
+          )}
+        </div>
+
+        <div className="idt-profile-body">
+          <div className="idt-profile-avatar" aria-hidden="true">
+            {profileAvatarURL ? <img src={profileAvatarURL} alt="" /> : <span>{profileInitials}</span>}
+          </div>
+
+          {profileEditing ? (
+            <form className="idt-app-form idt-profile-form" onSubmit={handleProfileSubmit}>
+              <label>
+                Display name
+                <input
+                  type="text"
+                  value={profileDraft.displayName}
+                  onChange={(event) => setProfileDraft((draft) => ({ ...draft, displayName: event.target.value }))}
+                  maxLength={80}
+                  disabled={profileSaving}
+                  required
+                />
+              </label>
+              <label>
+                Avatar URL
+                <input
+                  type="url"
+                  value={profileDraft.avatarUrl}
+                  onChange={(event) => setProfileDraft((draft) => ({ ...draft, avatarUrl: event.target.value }))}
+                  disabled={profileSaving}
+                  placeholder="https://..."
+                />
+              </label>
+              <div className="idt-profile-actions">
+                <button
+                  type="submit"
+                  className="idt-icon-btn idt-profile-icon-btn"
+                  aria-label="Save profile"
+                  title="Save profile"
+                  disabled={profileSaving}
+                >
+                  <Check size={16} aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  className="idt-icon-btn idt-profile-icon-btn"
+                  aria-label="Cancel profile editing"
+                  title="Cancel profile editing"
+                  onClick={handleProfileCancel}
+                  disabled={profileSaving}
+                >
+                  <X size={16} aria-hidden="true" />
+                </button>
+              </div>
+              {profileError ? (
+                <p className="idt-app-alert idt-app-alert-error" role="alert">
+                  {profileError}
+                </p>
+              ) : null}
+            </form>
+          ) : (
+            <dl className="idt-settings-facts idt-profile-facts">
+              <div>
+                <dt>Email</dt>
+                <dd>{me?.user.primary_email ?? 'Unavailable'}</dd>
+              </div>
+              <div>
+                <dt>Avatar</dt>
+                <dd>{profileAvatarURL || 'Not set'}</dd>
+              </div>
+              <div>
+                <dt>Status</dt>
+                <dd>{me?.user.status ? formatTokenLabel(me.user.status) : 'Unavailable'}</dd>
+              </div>
+              <div>
+                <dt>Updated</dt>
+                <dd>{me?.user.updated_at ? formatDateLabel(me.user.updated_at) : 'Unavailable'}</dd>
+              </div>
+            </dl>
+          )}
+        </div>
+      </section>
 
       <div className="idt-settings-grid">
         <section className="idt-settings-card">

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1243,13 +1243,8 @@ function validateProfileDraft(draft: ProfileDraft, options: { validateAvatarUrl?
   if (!displayName || Array.from(displayName).length > 80) {
     return 'Display name must be 1-80 characters.';
   }
-  if (
-    Array.from(displayName).some((char) => {
-      const code = char.charCodeAt(0);
-      return code < 32 || code === 127;
-    })
-  ) {
-    return 'Display name cannot contain control characters.';
+  if (Array.from(displayName).some(isUnsafeProfileNameCharacter)) {
+    return 'Display name cannot contain control or bidirectional formatting characters.';
   }
   const avatarUrl = draft.avatarUrl.trim();
   if (options.validateAvatarUrl === false) {
@@ -1270,6 +1265,18 @@ function validateProfileDraft(draft: ProfileDraft, options: { validateAvatarUrl?
     return 'Avatar URL must be a valid https URL.';
   }
   return '';
+}
+
+function isUnsafeProfileNameCharacter(char: string): boolean {
+  const code = char.codePointAt(0) ?? 0;
+  return (
+    code < 32 ||
+    code === 127 ||
+    code === 0x200e ||
+    code === 0x200f ||
+    (code >= 0x202a && code <= 0x202e) ||
+    (code >= 0x2066 && code <= 0x2069)
+  );
 }
 
 function hasWorkspaceAdminAccess(scope: ProductSession, whoAmI: WhoAmIResponse | null): boolean {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4426,6 +4426,78 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   padding: 1rem;
 }
 
+.idt-profile-card {
+  border-radius: 8px;
+}
+
+.idt-profile-body {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.idt-profile-avatar {
+  width: 4.5rem;
+  aspect-ratio: 1;
+  overflow: hidden;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(126, 157, 211, 0.35);
+  border-radius: 8px;
+  background: linear-gradient(135deg, rgba(35, 48, 72, 0.95), rgba(20, 112, 86, 0.78));
+  color: #ffffff;
+  font-family: var(--idt-display);
+  font-size: 1.2rem;
+  font-weight: 800;
+}
+
+.idt-profile-avatar img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+}
+
+.idt-profile-form {
+  margin-top: 0;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.25fr) auto;
+  align-items: end;
+}
+
+.idt-profile-form label {
+  min-width: 0;
+}
+
+.idt-profile-actions {
+  display: flex;
+  gap: 0.45rem;
+  align-items: center;
+  padding-bottom: 0.05rem;
+}
+
+.idt-profile-icon-btn {
+  display: inline-grid;
+  place-items: center;
+  flex: 0 0 2rem;
+  cursor: pointer;
+}
+
+.idt-profile-icon-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.56;
+}
+
+.idt-profile-facts {
+  align-self: stretch;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.idt-profile-form .idt-app-alert {
+  grid-column: 1 / -1;
+  margin: 0;
+}
+
 .idt-overview-card-header a,
 .idt-settings-card-header a {
   color: #b8cef0;
@@ -7173,11 +7245,16 @@ html[data-theme='light'] .idt-auth-mfa-form input {
   .idt-workspace-member-toolbar,
   .idt-projects-grid,
   .idt-source-wizard-grid,
+  .idt-profile-form,
   .idt-overview-grid,
   .idt-executive-report-grid,
   .idt-executive-narrative,
   .idt-settings-grid {
     grid-template-columns: 1fr;
+  }
+
+  .idt-profile-actions {
+    padding-bottom: 0;
   }
 }
 
@@ -7189,6 +7266,14 @@ html[data-theme='light'] .idt-auth-mfa-form input {
   .idt-session-row,
   .idt-security-section-header {
     display: grid;
+  }
+
+  .idt-profile-body {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-profile-avatar {
+    width: 4rem;
   }
 
   .idt-workspace-stats,


### PR DESCRIPTION
## Summary
- add authenticated PATCH /v1/me for display name and avatar URL updates with strict field validation and me:write authz registration
- add Settings account profile card with inline edits, optimistic /v1/me cache updates, and rollback on save failure
- document the new OpenAPI contract and cover backend/frontend flows

Closes #1422

## Tests
- go test ./internal/api
- go test ./internal/api -run 'TestCurrentSessionUpdateCurrentUserProfile|TestOpenAPIV1SpecDocumentsRouteAuthorizationMetadata'\n- npm test -- --run src/productShell.test.tsx\n- npm run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds self-serve profile editing in Settings and an authenticated PATCH `\v1\me` to update display name and avatar with strict validation, optimistic UI, and rollback on failure. Satisfies #1422.

- **New Features**
  - Backend: `PATCH /v1/me` decodes a single JSON object, rejects unknown fields and trailing JSON values, requires at least one field; trims and validates names (1–80 chars, no control/bidi chars); avatars must be blank or `https` without credentials and hosted under `avatars.githubusercontent.com`, `githubusercontent.com`, `googleusercontent.com`, `gravatar.com`, `identrail.com`, or `identrail.io`; preserves omitted fields; active users only; persists via `Store.UpdateCurrentUserProfile`; audits `auth.user.profile_update`; returns refreshed `CurrentUserContext`.
  - AuthZ/OpenAPI: added `me:write` and route policy for `PATCH /v1/me`; documented request/response with `CurrentUserProfileUpdateRequest` (`additionalProperties: false`, `minProperties: 1`, allowlisted avatar URL regex); standard error responses.
  - Frontend: Settings “Account profile” card before workspace settings with inline edit; client-side validation (name length/characters, `https` avatar URL); avatar preview with initials fallback; optimistic `me` cache prime and rollback on failure; added `apiClient.updateMe`.
  - Tests: API tests for happy path, invalid payloads, and trailing JSON; store tests for active-only updates and preserving omitted fields; OpenAPI route auth metadata coverage; UI tests for optimistic update, rollback, and pre-submit validation.

- **Bug Fixes**
  - Removed a duplicate `auth.user.profile_update` audit event.

<sup>Written for commit 2b1362863ed6d1b6ec46eea47423d48235fd3e89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

