### PR TITLE
Polish settings page controls

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1037,6 +1037,41 @@ describe('App', () => {
     expect(await screen.findByRole('heading', { level: 2, name: 'AWS Control Center' })).toBeInTheDocument();
   });
 
+  it('keeps account security available without a selected workspace', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/v1/me')) {
+        return okJSON(currentMePayload('', ''));
+      }
+      if (url.endsWith('/v1/me/sessions')) {
+        return okJSON({
+          items: [
+            {
+              id: 'current-session',
+              ip: '127.0.0.1',
+              user_agent: 'current browser',
+              auth_method: 'workos',
+              created_at: '2026-01-01T00:00:00Z',
+              last_seen_at: '2026-01-01T00:00:00Z',
+              idle_expires_at: '2026-01-01T00:15:00Z',
+              current: true
+            }
+          ]
+        });
+      }
+      throw new Error(`Unexpected URL ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    setCurrentPath('/app/account/security');
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { level: 1, name: /Owner User/i })).toBeInTheDocument();
+    expect(await screen.findByText(/No workspace selected yet/i)).toBeInTheDocument();
+    expect(await screen.findByText(/current browser/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Back to app/i })).toHaveAttribute('href', '/app');
+  });
+
   it('revalidates session after same-workspace navigation from an auth error', async () => {
     let meCalls = 0;
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
@@ -2365,6 +2400,22 @@ describe('App', () => {
       if (url.endsWith('/v1/auth/config')) {
         return authConfig(false, true);
       }
+      if (url.endsWith('/v1/me/sessions')) {
+        return okJSON({
+          items: [
+            {
+              id: 'current-session',
+              ip: '127.0.0.1',
+              user_agent: 'current browser',
+              auth_method: 'workos',
+              created_at: '2026-01-01T00:00:00Z',
+              last_seen_at: '2026-01-01T00:00:00Z',
+              idle_expires_at: '2026-01-01T00:15:00Z',
+              current: true
+            }
+          ]
+        });
+      }
       throw new Error(`Unexpected URL ${url}`);
     });
     vi.stubGlobal('fetch', fetchMock);
@@ -2375,10 +2426,11 @@ describe('App', () => {
     expect(await screen.findByText(/Security Workspace/i)).toBeInTheDocument();
     expect(await screen.findByRole('heading', { level: 2, name: /Settings/i })).toBeInTheDocument();
     expect(await screen.findByText(/Hosted WorkOS login/i)).toBeInTheDocument();
-    expect(await screen.findByText(/None granted/i)).toBeInTheDocument();
+    expect(await screen.findByText(/^None$/i)).toBeInTheDocument();
     expect(await screen.findByText(/Total members/i)).toBeInTheDocument();
-    const accountSecurityLinks = await screen.findAllByRole('link', { name: /Account security/i });
-    expect(accountSecurityLinks.some((link) => link.getAttribute('href') === '/app/account/security')).toBe(true);
+    expect(await screen.findByRole('heading', { level: 3, name: /1 active session/i })).toBeInTheDocument();
+    expect(screen.getByText(/Manage sessions/i)).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Account security/i })).not.toBeInTheDocument();
   });
 
   it('supports workspace member invite workflow from app shell administration route', async () => {
@@ -2508,11 +2560,11 @@ describe('App', () => {
     setCurrentPath('/app/default/default/workspaces');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { level: 2, name: /Members and roles/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: /^Members$/i })).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText('User ID'), { target: { value: 'analyst@example.com' } });
     fireEvent.change(screen.getByLabelText('Email (optional)'), { target: { value: 'analyst@example.com' } });
-    fireEvent.click(screen.getByRole('button', { name: /Invite member/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Send invite/i }));
 
     await screen.findByText(/Member invitation saved/i);
     expect(screen.getAllByText('analyst@example.com').length).toBeGreaterThan(0);
@@ -2649,7 +2701,7 @@ describe('App', () => {
     setCurrentPath('/app/default/default/workspaces');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { level: 2, name: /Members and roles/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: /^Members$/i })).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText('Workspace'), { target: { value: 'payments' } });
     fireEvent.click(screen.getByRole('button', { name: /Switch workspace/i }));
 
@@ -2735,7 +2787,7 @@ describe('App', () => {
     setCurrentPath('/app/default/payments/workspaces');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { level: 2, name: /Members and roles/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: /^Members$/i })).toBeInTheDocument();
     const activeWorkspaceCallIndex = fetchMock.mock.calls.findIndex(([url, options]) => {
       return typeof url === 'string' && url.includes('/v1/workspaces/active') && options?.method === 'POST';
     });
@@ -2926,7 +2978,7 @@ describe('App', () => {
       window.dispatchEvent(new PopStateEvent('popstate'));
     });
 
-    expect(await screen.findByRole('heading', { level: 2, name: /Members and roles/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: /^Members$/i })).toBeInTheDocument();
 
     resolveInitialMembers?.({
       ok: true,
@@ -3048,12 +3100,12 @@ describe('App', () => {
     setCurrentPath('/app/default/default/workspaces');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { level: 2, name: /Members and roles/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: /^Members$/i })).toBeInTheDocument();
     expect(screen.getByText('owner-user')).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText('User ID'), { target: { value: 'analyst@example.com' } });
     fireEvent.change(screen.getByLabelText('Email (optional)'), { target: { value: 'analyst@example.com' } });
-    fireEvent.click(screen.getByRole('button', { name: /Invite member/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Send invite/i }));
 
     const alert = await screen.findByRole('alert');
     expect(alert).toHaveTextContent(/invite rejected/i);
@@ -3375,60 +3427,102 @@ describe('App', () => {
     expect(window.location.pathname).toBe('/app/tenant-a/workspace-a');
   });
 
-  it('lists account security sessions and revokes other browsers', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(okJSON(currentMePayload('default', 'default')))
-      .mockResolvedValueOnce(okJSON(currentMePayload('default', 'default')))
-      .mockResolvedValueOnce(
-        okJSON({
-          items: [
-            {
-              id: 'current-session',
-              ip: '127.0.0.1',
-              user_agent: 'current browser',
-              auth_method: 'workos',
+  it('lists settings sessions and revokes other browsers', async () => {
+    let sessionsRevoked = false;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/v1/me')) {
+        return okJSON(currentMePayload('default', 'default'));
+      }
+      if (url.endsWith('/v1/whoami')) {
+        return okJSON({
+          principal: { type: 'subject', id: 'owner-user' },
+          roles: ['owner'],
+          scopes: ['read', 'write', 'admin'],
+          scope: { tenant_id: 'default', workspace_id: 'default' },
+          active_workspace: {
+            workspace: {
+              tenant_id: 'default',
+              workspace_id: 'default',
+              display_name: 'Default',
+              slug: 'default',
               created_at: '2026-01-01T00:00:00Z',
-              last_seen_at: '2026-01-01T00:00:00Z',
-              idle_expires_at: '2026-01-01T00:15:00Z',
-              current: true
+              updated_at: '2026-01-01T00:00:00Z'
             },
-            {
-              id: 'other-session',
-              ip: '127.0.0.2',
-              user_agent: 'other browser',
-              auth_method: 'workos',
-              created_at: '2026-01-01T00:00:00Z',
-              last_seen_at: '2026-01-01T00:00:00Z',
-              idle_expires_at: '2026-01-01T00:15:00Z',
-              current: false
-            }
-          ]
-        })
-      )
-      .mockResolvedValueOnce(okJSON({ ok: true, revoked: 1 }))
-      .mockResolvedValueOnce(
-        okJSON({
-          items: [
-            {
-              id: 'current-session',
-              ip: '127.0.0.1',
-              user_agent: 'current browser',
-              auth_method: 'workos',
-              created_at: '2026-01-01T00:00:00Z',
-              last_seen_at: '2026-01-01T00:00:00Z',
-              idle_expires_at: '2026-01-01T00:15:00Z',
-              current: true
-            }
-          ]
-        })
-      );
+            member: {
+              tenant_id: 'default',
+              workspace_id: 'default',
+              member_id: 'member-owner-user',
+              user_id: 'owner-user',
+              email: 'owner@example.com',
+              role: 'owner',
+              status: 'active',
+              joined_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-01T00:00:00Z'
+            },
+            is_active: true
+          },
+          workspaces: []
+        });
+      }
+      if (url.includes('/v1/workspaces/default/members')) {
+        return okJSON({ items: [] });
+      }
+      if (url.endsWith('/v1/auth/config')) {
+        return authConfig(false, true);
+      }
+      if (url.endsWith('/v1/me/sessions/revoke-others')) {
+        sessionsRevoked = true;
+        return okJSON({ ok: true, revoked: 1 });
+      }
+      if (url.endsWith('/v1/me/sessions')) {
+        return okJSON({
+          items: sessionsRevoked
+            ? [
+                {
+                  id: 'current-session',
+                  ip: '127.0.0.1',
+                  user_agent: 'current browser',
+                  auth_method: 'workos',
+                  created_at: '2026-01-01T00:00:00Z',
+                  last_seen_at: '2026-01-01T00:00:00Z',
+                  idle_expires_at: '2026-01-01T00:15:00Z',
+                  current: true
+                }
+              ]
+            : [
+                {
+                  id: 'current-session',
+                  ip: '127.0.0.1',
+                  user_agent: 'current browser',
+                  auth_method: 'workos',
+                  created_at: '2026-01-01T00:00:00Z',
+                  last_seen_at: '2026-01-01T00:00:00Z',
+                  idle_expires_at: '2026-01-01T00:15:00Z',
+                  current: true
+                },
+                {
+                  id: 'other-session',
+                  ip: '127.0.0.2',
+                  user_agent: 'other browser',
+                  auth_method: 'workos',
+                  created_at: '2026-01-01T00:00:00Z',
+                  last_seen_at: '2026-01-01T00:00:00Z',
+                  idle_expires_at: '2026-01-01T00:15:00Z',
+                  current: false
+                }
+              ]
+        });
+      }
+      throw new Error(`Unexpected URL ${url}`);
+    });
     vi.stubGlobal('fetch', fetchMock);
 
-    setCurrentPath('/app/account/security');
+    setCurrentPath('/app/default/default/settings');
     render(<App />);
 
-    expect(await screen.findByRole('heading', { level: 1, name: /Owner User/i })).toBeInTheDocument();
+    await screen.findByRole('heading', { level: 2, name: /Settings/i });
+    fireEvent.click(await screen.findByText(/Manage sessions/i));
     expect(await screen.findByText(/other browser/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /Revoke others/i }));
 

--- a/web/src/components/auth/SessionsList.tsx
+++ b/web/src/components/auth/SessionsList.tsx
@@ -22,15 +22,41 @@ function formatDate(value: string): string {
   }).format(date);
 }
 
-function compactUserAgent(value?: string): string {
+export function formatSessionDevice(value?: string): string {
   if (!value) {
     return 'Unknown device';
   }
   const normalized = value.replace(/\s+/g, ' ').trim();
-  if (normalized.length <= 96) {
+  const browser = normalized.includes('Edg/')
+    ? 'Edge'
+    : normalized.includes('Chrome/')
+      ? 'Chrome'
+      : normalized.includes('Firefox/')
+        ? 'Firefox'
+        : normalized.includes('Safari/')
+          ? 'Safari'
+          : '';
+  const platform = /Macintosh|Mac OS X/i.test(normalized)
+    ? 'macOS'
+    : /Windows/i.test(normalized)
+      ? 'Windows'
+      : /iPhone|iPad/i.test(normalized)
+        ? 'iOS'
+        : /Android/i.test(normalized)
+          ? 'Android'
+          : /Linux/i.test(normalized)
+            ? 'Linux'
+            : '';
+  if (browser && platform) {
+    return `${browser} on ${platform}`;
+  }
+  if (browser) {
+    return browser;
+  }
+  if (normalized.length <= 56) {
     return normalized;
   }
-  return `${normalized.slice(0, 93)}...`;
+  return `${normalized.slice(0, 53)}...`;
 }
 
 export function SessionsList({
@@ -54,27 +80,25 @@ export function SessionsList({
 
   return (
     <section className="idt-sessions-list" aria-label="Active account sessions">
-      <div className="idt-security-section-header">
-        <div>
-          <p className="idt-app-kicker">Sessions</p>
-          <h2>Active browser sessions</h2>
+      {hasOtherSessions ? (
+        <div className="idt-session-toolbar">
+          <button
+            className="idt-btn idt-btn-ghost"
+            type="button"
+            disabled={revokingOthers}
+            onClick={onRevokeOthers}
+          >
+            {revokingOthers ? 'Revoking...' : 'Revoke others'}
+          </button>
         </div>
-        <button
-          className="idt-btn idt-btn-ghost"
-          type="button"
-          disabled={!hasOtherSessions || revokingOthers}
-          onClick={onRevokeOthers}
-        >
-          {revokingOthers ? 'Revoking...' : 'Revoke others'}
-        </button>
-      </div>
+      ) : null}
 
       <div className="idt-session-stack">
         {sessions.map((session) => (
           <article className="idt-session-row" key={session.id}>
             <div>
               <div className="idt-session-title">
-                <strong>{compactUserAgent(session.user_agent)}</strong>
+                <strong>{formatSessionDevice(session.user_agent)}</strong>
                 {session.current ? <span>Current</span> : null}
               </div>
               <p>
@@ -89,7 +113,7 @@ export function SessionsList({
               disabled={busySessionID === session.id}
               onClick={() => onRevoke(session.id, session.current)}
             >
-              {busySessionID === session.id ? 'Revoking...' : session.current ? 'Sign out here' : 'Revoke'}
+              {busySessionID === session.id ? 'Revoking...' : session.current ? 'Sign out' : 'Revoke'}
             </button>
           </article>
         ))}

--- a/web/src/components/settings/DangerZone.test.tsx
+++ b/web/src/components/settings/DangerZone.test.tsx
@@ -10,14 +10,14 @@ describe('DangerZone', () => {
           actionLabel="Suspend"
           description="Sign out everywhere."
           onAction={() => undefined}
-          title="Suspend my account"
+          title="Account access"
         />
       </DangerZone>
     );
 
-    expect(screen.getByRole('heading', { name: 'Account lifecycle' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Danger zone' })).toBeInTheDocument();
     expect(screen.getByText('Heads up, destructive stuff lives here.')).toBeInTheDocument();
-    expect(screen.getByText('Suspend my account')).toBeInTheDocument();
+    expect(screen.getByText('Account access')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Suspend' })).toBeEnabled();
   });
 

--- a/web/src/components/settings/DangerZone.tsx
+++ b/web/src/components/settings/DangerZone.tsx
@@ -13,8 +13,7 @@ export function DangerZone({ description, children }: DangerZoneProps) {
       data-testid="idt-danger-zone"
     >
       <div>
-        <p className="idt-app-kicker">Danger zone</p>
-        <h3 id="idt-danger-zone-title">Account lifecycle</h3>
+        <h3 id="idt-danger-zone-title">Danger zone</h3>
         {description ? <p className="idt-danger-zone-description">{description}</p> : null}
       </div>
       <div className="idt-danger-zone-rows">{children}</div>

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -299,6 +299,7 @@ async function renderProductSettingsPage(options: {
     items: whoAmI.active_workspace?.member ? [whoAmI.active_workspace.member] : []
   });
   vi.spyOn(api.apiClient, 'getAuthConfig').mockResolvedValue(settingsAuthConfig);
+  vi.spyOn(api.apiClient, 'listCurrentUserSessions').mockResolvedValue({ items: [] });
   const updateMe = vi.spyOn(api.apiClient, 'updateMe');
   if (options.updateMe instanceof Error) {
     updateMe.mockRejectedValue(options.updateMe);

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -56,11 +56,13 @@ import {
   type RequestAuthContext,
   type ScanPolicyRecord,
   type ScanTriggerMode,
+  type SessionListItem,
   type WhoAmIResponse,
   type WorkspaceMemberRecord,
   type WorkspaceMemberRole,
   type WorkspaceMemberStatus
 } from './api/client';
+import { formatSessionDevice, SessionsList } from './components/auth/SessionsList';
 import { PermissionPreviewModal } from './components/connector/PermissionPreviewModal';
 import { ConfirmDestructiveModal, DangerZone, DangerZoneRow } from './components/settings/DangerZone';
 import {
@@ -6041,16 +6043,9 @@ export function ProductShellLayout() {
       {
         id: 'settings',
         label: 'Settings',
-        description: 'Workspace identity, access model, and routes',
-        keywords: ['identity', 'access', 'authentication'],
+        description: 'Workspace identity, members, sessions, and lifecycle',
+        keywords: ['identity', 'access', 'authentication', 'members', 'sessions'],
         path: `${basePath}/settings`
-      },
-      {
-        id: 'security',
-        label: 'Account security',
-        description: 'Current session, access scope, and sign-out controls',
-        keywords: ['account', 'session', 'security'],
-        path: '/app/account/security'
       },
       {
         id: 'marketing-site',
@@ -6434,7 +6429,7 @@ export function ProductShellLayout() {
                   to={`${basePath}/settings`}
                   onClick={() => setWorkspaceMenuOpen(false)}
                 >
-                  Workspace settings
+                  Settings
                 </Link>
                 <Link
                   role="menuitem"
@@ -6580,14 +6575,6 @@ export function ProductShellLayout() {
                     <strong>{userDisplayName}</strong>
                     {userEmail ? <span>{userEmail}</span> : null}
                   </div>
-                  <Link
-                    role="menuitem"
-                    to={`${basePath}/settings`}
-                    onClick={() => setAccountMenuOpen(false)}
-                  >
-                    <SettingsIcon size={14} strokeWidth={1.75} aria-hidden="true" />
-                    Workspace settings
-                  </Link>
                   <a
                     role="menuitem"
                     href="https://github.com/identrail/identrail/issues"
@@ -6599,6 +6586,7 @@ export function ProductShellLayout() {
                     Help &amp; feedback
                   </a>
                   <Link role="menuitem" to="/" onClick={() => setAccountMenuOpen(false)}>
+                    <ExternalLink size={14} strokeWidth={1.75} aria-hidden="true" />
                     Marketing site
                   </Link>
                   <button
@@ -7811,9 +7799,8 @@ export function ProductWorkspacesPage() {
     <section className="idt-app-panel idt-workspace-admin">
       <header className="idt-workspace-admin-header">
         <div>
-          <p className="idt-app-kicker">Workspace administration</p>
-          <h2>Members and roles</h2>
-          <p>Invite members, update roles instantly, and switch active workspace scope without leaving the app shell.</p>
+          <h2>Members</h2>
+          <p>Invite teammates, set roles, and keep workspace access current.</p>
         </div>
       </header>
 
@@ -7848,14 +7835,18 @@ export function ProductWorkspacesPage() {
         </article>
         <article>
           <h3>{roleCounts.owner + roleCounts.admin}</h3>
-          <p>Privileged roles</p>
+          <p>Admins</p>
         </article>
       </div>
 
       <div className="idt-workspace-admin-grid">
-        <article className="idt-app-empty-state">
-          <h3>Switch active workspace</h3>
-          <p>Change context to another workspace you can access.</p>
+        <article className="idt-workspace-card">
+          <header className="idt-workspace-card-header">
+            <div>
+              <h3>Workspace</h3>
+              <p>Change the workspace context for this session.</p>
+            </div>
+          </header>
           <div className="idt-workspace-switcher">
             <label htmlFor="workspace-switch-select">Workspace</label>
             <select
@@ -7884,9 +7875,14 @@ export function ProductWorkspacesPage() {
           </div>
         </article>
 
-        <article className="idt-app-empty-state">
-          <h3>Invite member</h3>
-          <form className="idt-app-form" onSubmit={handleInviteMember}>
+        <article className="idt-workspace-card">
+          <header className="idt-workspace-card-header">
+            <div>
+              <h3>Invite member</h3>
+              <p>Set the initial role and status before access is granted.</p>
+            </div>
+          </header>
+          <form className="idt-app-form idt-workspace-invite-form" onSubmit={handleInviteMember}>
             <label>
               User ID
               <input
@@ -7942,7 +7938,7 @@ export function ProductWorkspacesPage() {
               </label>
             </div>
             <button className="idt-btn idt-btn-primary" type="submit" disabled={!canAdmin || inviting}>
-              {inviting ? 'Saving...' : 'Invite member'}
+              {inviting ? 'Saving...' : 'Send invite'}
             </button>
           </form>
         </article>
@@ -13271,6 +13267,11 @@ export function ProductSettingsPage() {
   const [whoAmI, setWhoAmI] = useState<WhoAmIResponse | null>(null);
   const [members, setMembers] = useState<WorkspaceMemberRecord[]>([]);
   const [authConfig, setAuthConfig] = useState<AuthConfigResponse | null>(null);
+  const [sessions, setSessions] = useState<SessionListItem[]>([]);
+  const [sessionsLoading, setSessionsLoading] = useState(true);
+  const [sessionsError, setSessionsError] = useState('');
+  const [busySessionID, setBusySessionID] = useState('');
+  const [revokingOthers, setRevokingOthers] = useState(false);
   const [suspendModalOpen, setSuspendModalOpen] = useState(false);
   const [suspendPending, setSuspendPending] = useState(false);
   const [suspendError, setSuspendError] = useState('');
@@ -13278,6 +13279,36 @@ export function ProductSettingsPage() {
   const [profileDraft, setProfileDraft] = useState<ProfileDraft>(() => profileDraftFromMe(me));
   const [profileSaving, setProfileSaving] = useState(false);
   const [profileError, setProfileError] = useState('');
+  const settingsMountedRef = useRef(true);
+
+  useEffect(() => {
+    settingsMountedRef.current = true;
+    return () => {
+      settingsMountedRef.current = false;
+    };
+  }, []);
+
+  const loadSessions = async () => {
+    setSessionsLoading(true);
+    setSessionsError('');
+    try {
+      const response = await apiClient.listCurrentUserSessions();
+      if (!settingsMountedRef.current) {
+        return;
+      }
+      setSessions(response.items);
+    } catch (sessionError) {
+      if (!settingsMountedRef.current) {
+        return;
+      }
+      const message = sessionError instanceof Error ? sessionError.message : 'Unable to load active sessions.';
+      setSessionsError(message);
+    } finally {
+      if (settingsMountedRef.current) {
+        setSessionsLoading(false);
+      }
+    }
+  };
 
   useEffect(() => {
     if (!scope) {
@@ -13316,6 +13347,7 @@ export function ProductSettingsPage() {
     };
 
     void loadSettings();
+    void loadSessions();
 
     return () => {
       mounted = false;
@@ -13418,12 +13450,53 @@ export function ProductSettingsPage() {
     }
   };
 
+  const primarySession = sessions.find((session) => session.current) ?? sessions[0];
+  const sessionsSummary = sessionsLoading
+    ? 'Checking active browsers.'
+    : sessionsError
+      ? 'Session details need a refresh.'
+      : primarySession
+        ? formatSessionDevice(primarySession.user_agent)
+        : 'No active browser session.';
+
+  const handleRevokeSession = async (sessionID: string, isCurrent: boolean) => {
+    setBusySessionID(sessionID);
+    setSessionsError('');
+    try {
+      await apiClient.revokeCurrentUserSession(sessionID);
+      if (isCurrent) {
+        resetProductAuthSessionCache({ unauthenticated: true });
+        navigate('/signin?signed_out=1', { replace: true });
+        return;
+      }
+      await loadSessions();
+    } catch (sessionError) {
+      const message = sessionError instanceof Error ? sessionError.message : 'Unable to revoke session.';
+      setSessionsError(message);
+    } finally {
+      setBusySessionID('');
+    }
+  };
+
+  const handleRevokeOtherSessions = async () => {
+    setRevokingOthers(true);
+    setSessionsError('');
+    try {
+      await apiClient.revokeOtherCurrentUserSessions();
+      await loadSessions();
+    } catch (sessionError) {
+      const message = sessionError instanceof Error ? sessionError.message : 'Unable to revoke other sessions.';
+      setSessionsError(message);
+    } finally {
+      setRevokingOthers(false);
+    }
+  };
+
   if (loading) {
     return (
       <section className="idt-app-panel" aria-busy="true" aria-live="polite">
-        <p className="idt-app-kicker">Workspace settings</p>
         <h2>Settings</h2>
-        <p>Loading workspace identity, access, and authentication state.</p>
+        <p>Loading workspace identity, members, authentication, and sessions.</p>
       </section>
     );
   }
@@ -13431,7 +13504,6 @@ export function ProductSettingsPage() {
   if (error) {
     return (
       <section className="idt-app-panel idt-app-panel-error" role="alert">
-        <p className="idt-app-kicker">Workspace settings</p>
         <h2>Settings</h2>
         <p>{error}</p>
       </section>
@@ -13442,18 +13514,12 @@ export function ProductSettingsPage() {
     <section className="idt-app-panel idt-settings-page">
       <header className="idt-settings-header">
         <div>
-          <p className="idt-app-kicker">Workspace settings</p>
           <h2>Settings</h2>
-          <p>
-            Review the live workspace, access model, authentication mode, and the real routes that manage this tenant.
-          </p>
+          <p>Workspace access, sign-in, sessions, and account controls.</p>
         </div>
         <div className="idt-inline-actions">
           <Link className="idt-btn idt-btn-primary" to={workspacesPath}>
             Manage members
-          </Link>
-          <Link className="idt-btn idt-btn-ghost" to="/app/account/security">
-            Account security
           </Link>
         </div>
       </header>
@@ -13559,20 +13625,20 @@ export function ProductSettingsPage() {
       <div className="idt-settings-grid">
         <section className="idt-settings-card">
           <div>
-            <p className="idt-app-kicker">Workspace identity</p>
+            <p className="idt-app-kicker">Workspace</p>
             <h3>{workspaceDisplayName}</h3>
           </div>
           <dl className="idt-settings-facts">
             <div>
-              <dt>Tenant</dt>
+              <dt>Tenant ID</dt>
               <dd>{scope?.tenantID ?? 'Unavailable'}</dd>
             </div>
             <div>
-              <dt>Workspace</dt>
+              <dt>Workspace ID</dt>
               <dd>{scope?.workspaceID ?? 'Unavailable'}</dd>
             </div>
             <div>
-              <dt>Scope context</dt>
+              <dt>Scope</dt>
               <dd>{scope?.projectID ?? me?.project_id ?? 'All scopes'}</dd>
             </div>
             <div>
@@ -13584,7 +13650,7 @@ export function ProductSettingsPage() {
 
         <section className="idt-settings-card">
           <div>
-            <p className="idt-app-kicker">Your access</p>
+            <p className="idt-app-kicker">Access</p>
             <h3>{formatTokenLabel(activeRole)}</h3>
           </div>
           <dl className="idt-settings-facts">
@@ -13602,7 +13668,7 @@ export function ProductSettingsPage() {
             </div>
             <div>
               <dt>Scopes</dt>
-              <dd>{scopes.length ? scopes.map(formatTokenLabel).join(', ') : 'None granted'}</dd>
+              <dd>{scopes.length ? scopes.map(formatTokenLabel).join(', ') : 'None'}</dd>
             </div>
           </dl>
         </section>
@@ -13613,9 +13679,9 @@ export function ProductSettingsPage() {
           <div className="idt-settings-card-header">
             <div>
               <p className="idt-app-kicker">Members</p>
-              <h3>Access model</h3>
+              <h3>{formatCountLabel(members.length, 'member')}</h3>
             </div>
-            <Link to={workspacesPath}>Open workspaces</Link>
+            <Link to={workspacesPath}>Manage</Link>
           </div>
           <div className="idt-settings-counts">
             <article>
@@ -13643,7 +13709,6 @@ export function ProductSettingsPage() {
               <p className="idt-app-kicker">Authentication</p>
               <h3>{authModeLabel}</h3>
             </div>
-            <Link to="/app/account/security">Security</Link>
           </div>
           <dl className="idt-settings-facts">
             <div>
@@ -13666,61 +13731,89 @@ export function ProductSettingsPage() {
         </section>
       </div>
 
-      <section className="idt-settings-card">
-        <div>
-          <p className="idt-app-kicker">Operating routes</p>
-          <h3>Where changes happen</h3>
-        </div>
-        <div className="idt-settings-route-grid">
+      <details className="idt-settings-card idt-settings-disclosure">
+        <summary className="idt-settings-disclosure-summary">
+          <div>
+            <p className="idt-app-kicker">Areas</p>
+            <h3>Related areas</h3>
+            <p>Domain controls and member access.</p>
+          </div>
+          <span>Show areas</span>
+        </summary>
+        <div className="idt-settings-route-grid idt-settings-disclosure-body">
           <Link to={awsPath}>
-            <strong>AWS control center</strong>
-            <span>Connect accounts, expand identity inventory, and prepare AWS findings and remediation.</span>
+            <strong>AWS</strong>
+            <span>Accounts, identities, findings, fixes.</span>
           </Link>
           <Link to={githubFindingsPath}>
             <strong>GitHub findings</strong>
-            <span>Inspect repository risk, open line evidence, and keep triage inside the GitHub section.</span>
+            <span>Repository risk and evidence.</span>
           </Link>
           <Link to={kubernetesPath}>
-            <strong>Kubernetes control center</strong>
-            <span>Prepare cluster, workload, service-account, RBAC, and remediation routes.</span>
+            <strong>Kubernetes</strong>
+            <span>Clusters, workloads, service accounts, RBAC.</span>
           </Link>
           <Link to={workspacesPath}>
-            <strong>Workspace members</strong>
-            <span>Invite users, adjust roles, suspend stale access, and switch active workspaces.</span>
-          </Link>
-          <Link to="/app/account/security">
-            <strong>Account sessions</strong>
-            <span>Review active sessions, revoke access, and sign out cleanly.</span>
+            <strong>Members</strong>
+            <span>Invites, roles, workspace access.</span>
           </Link>
         </div>
-      </section>
+      </details>
 
-      <DangerZone description="Suspending your account signs you out everywhere. Reactivate it any time by signing in through the signup flow.">
+      <details className="idt-settings-card idt-settings-disclosure idt-settings-sessions-card">
+        <summary className="idt-settings-disclosure-summary">
+          <div>
+            <p className="idt-app-kicker">Sessions</p>
+            <h3>{sessionsLoading ? 'Loading sessions' : formatCountLabel(sessions.length, 'active session')}</h3>
+            <p>{sessionsSummary}</p>
+          </div>
+          <span>Manage sessions</span>
+        </summary>
+        <div className="idt-settings-disclosure-body">
+          {sessionsLoading ? <p className="idt-app-alert">Loading active sessions...</p> : null}
+          {sessionsError ? (
+            <p className="idt-app-alert idt-app-alert-error" role="alert">
+              {sessionsError}
+            </p>
+          ) : null}
+          {!sessionsLoading ? (
+            <SessionsList
+              busySessionID={busySessionID}
+              revokingOthers={revokingOthers}
+              sessions={sessions}
+              onRevoke={handleRevokeSession}
+              onRevokeOthers={handleRevokeOtherSessions}
+            />
+          ) : null}
+        </div>
+      </details>
+
+      <DangerZone description="For immediate account suspension. Workspace data stays intact.">
         <DangerZoneRow
-          actionLabel="Suspend my account"
-          description="You'll be signed out of every device and session. Sign in through signup to reactivate."
+          actionLabel="Suspend account"
+          description="Ends all sessions until you sign in again."
           onAction={() => {
             setSuspendError('');
             setSuspendModalOpen(true);
           }}
           pending={suspendPending}
           testId="idt-suspend-account-row"
-          title="Suspend my account"
+          title="Account access"
         />
       </DangerZone>
 
       <ConfirmDestructiveModal
         body={
           <>
-            <p>Suspending your account immediately revokes every active session and clears the session cookie on this device.</p>
-            <p>Your workspace memberships, projects, and connector data stay intact. To reactivate, sign in again through the signup flow and Identrail will restore your account.</p>
+            <p>This revokes every active session and clears this device.</p>
+            <p>Your memberships, projects, and connector data stay intact.</p>
           </>
         }
         confirmation={{
           kind: 'checkbox',
-          label: "I understand I'll be signed out of every device until I reactivate."
+          label: 'I understand this signs me out everywhere.'
         }}
-        continueLabel="Suspend my account"
+        continueLabel="Suspend account"
         errorMessage={suspendError || undefined}
         onCancel={() => {
           if (suspendPending) return;
@@ -13751,7 +13844,7 @@ export function ProductSettingsPage() {
         }}
         open={suspendModalOpen}
         pending={suspendPending}
-        title="Suspend your account"
+        title="Suspend account"
       />
     </section>
   );

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6677,12 +6677,10 @@ html[data-theme='light'] .idt-auth-mfa-form input {
   gap: 1rem;
 }
 
-.idt-security-section-header {
+.idt-session-toolbar {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 1rem;
+  justify-content: flex-end;
+  margin-bottom: 0.75rem;
 }
 
 .idt-session-stack {
@@ -7639,8 +7637,7 @@ html[data-theme='light'] .idt-auth-mfa-form input {
     grid-template-columns: 1fr;
   }
 
-  .idt-session-row,
-  .idt-security-section-header {
+  .idt-session-row {
     display: grid;
   }
 
@@ -29252,24 +29249,29 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
 }
 
 .idt-danger-zone {
-  border-color: rgba(213, 125, 125, 0.5);
-  background: linear-gradient(165deg, rgba(40, 12, 16, 0.78), rgba(24, 10, 16, 0.66));
+  border-color: rgba(248, 113, 113, 0.34);
+  background:
+    linear-gradient(180deg, rgba(127, 29, 29, 0.18), rgba(127, 29, 29, 0.04) 48%),
+    var(--idt-console-surface, #090b0e);
 }
 
 .idt-danger-zone h3 {
-  color: #ffd0d0;
+  margin: 0;
+  color: #ffffff;
+  font-size: 1.05rem;
 }
 
 .idt-danger-zone-description {
-  margin: 0.35rem 0 0;
-  color: #f3c8c8;
-  font-size: 0.92rem;
+  max-width: 68ch;
+  margin: 0.28rem 0 0;
+  color: #d8b4b4;
+  font-size: 0.9rem;
 }
 
 .idt-danger-zone-rows {
-  margin-top: 0.85rem;
+  margin-top: 0.7rem;
   display: grid;
-  gap: 0.6rem;
+  gap: 0.55rem;
 }
 
 .idt-danger-zone-row {
@@ -29277,27 +29279,45 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  padding: 0.8rem 0.95rem;
-  border: 1px solid rgba(213, 125, 125, 0.32);
-  border-radius: 0.65rem;
-  background: rgba(18, 8, 12, 0.55);
+  min-height: 4.25rem;
+  padding: 0.78rem 0.9rem;
+  border: 1px solid rgba(248, 113, 113, 0.28);
+  border-radius: 8px;
+  background: rgba(12, 6, 8, 0.48);
 }
 
 .idt-danger-zone-row > div {
   display: grid;
-  gap: 0.2rem;
+  gap: 0.18rem;
+  min-width: 0;
 }
 
 .idt-danger-zone-row strong {
-  color: #ffe2e2;
-  font-size: 0.98rem;
+  color: #fff1f2;
+  font-size: 0.96rem;
 }
 
 .idt-danger-zone-row p {
   margin: 0;
-  color: #f0c5c5;
+  color: #d8b4b4;
   font-size: 0.88rem;
+  line-height: 1.42;
+}
+
+.idt-danger-zone-status,
+.idt-danger-zone-success,
+.idt-danger-zone-error {
+  margin-top: 0.45rem;
+  font-size: 0.85rem;
   line-height: 1.45;
+}
+
+.idt-danger-zone-success {
+  color: #a3e6b6;
+}
+
+.idt-danger-zone-error {
+  color: #ffb3b3;
 }
 
 .idt-btn-danger {
@@ -29432,23 +29452,296 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
 }
 
 html[data-theme='light'] .idt-danger-zone {
-  background: linear-gradient(165deg, #fff1f1, #fde7e7);
-  border-color: rgba(165, 50, 50, 0.45);
+  background:
+    linear-gradient(180deg, rgba(127, 29, 29, 0.18), rgba(127, 29, 29, 0.04) 48%),
+    var(--idt-console-surface, #090b0e);
+  border-color: rgba(248, 113, 113, 0.34);
 }
 
 html[data-theme='light'] .idt-danger-zone h3,
 html[data-theme='light'] .idt-danger-zone-row strong {
-  color: #6a1d1d;
+  color: #fff1f2;
 }
 
 html[data-theme='light'] .idt-danger-zone-description,
 html[data-theme='light'] .idt-danger-zone-row p {
-  color: #7c2a2a;
+  color: #d8b4b4;
 }
 
 html[data-theme='light'] .idt-danger-zone-row {
-  background: #fff7f7;
-  border-color: rgba(165, 50, 50, 0.28);
+  background: rgba(12, 6, 8, 0.48);
+  border-color: rgba(248, 113, 113, 0.28);
+}
+
+.idt-app-console-layout .idt-settings-page {
+  margin-top: -0.3rem;
+  gap: 0.95rem;
+}
+
+.idt-app-console-layout .idt-settings-header {
+  align-items: center;
+  padding-top: 0;
+}
+
+.idt-app-console-layout .idt-settings-header h2,
+html[data-theme='light'] .idt-app-console-layout .idt-settings-header h2 {
+  margin-top: 0;
+  margin-bottom: 0.32rem;
+}
+
+.idt-app-console-layout .idt-settings-header p {
+  max-width: 58ch;
+}
+
+.idt-app-console-layout .idt-settings-disclosure {
+  padding: 0;
+  overflow: hidden;
+}
+
+.idt-settings-disclosure-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 4.75rem;
+  padding: 1rem 1.15rem;
+  list-style: none;
+  cursor: pointer;
+}
+
+.idt-settings-disclosure-summary::-webkit-details-marker {
+  display: none;
+}
+
+.idt-settings-disclosure-summary > div {
+  min-width: 0;
+}
+
+.idt-settings-disclosure-summary h3 {
+  margin: 0.08rem 0 0.14rem;
+}
+
+.idt-settings-disclosure-summary p:last-child {
+  margin: 0;
+  max-width: 48ch;
+  color: var(--app-muted);
+  font-size: 0.9rem;
+}
+
+.idt-settings-disclosure-summary > span {
+  flex: 0 0 auto;
+  border: 1px solid var(--app-border-soft);
+  border-radius: 999px;
+  padding: 0.36rem 0.64rem;
+  background: rgba(255, 255, 255, 0.035);
+  color: #d7dce2;
+  font-size: 0.78rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.idt-settings-disclosure-summary:hover > span,
+.idt-settings-disclosure-summary:focus-visible > span,
+.idt-settings-disclosure[open] .idt-settings-disclosure-summary > span {
+  border-color: rgba(255, 255, 255, 0.24);
+  background: rgba(255, 255, 255, 0.07);
+  color: #f5f7f8;
+}
+
+.idt-settings-disclosure-summary:focus-visible {
+  outline: 2px solid rgba(124, 92, 255, 0.78);
+  outline-offset: -2px;
+}
+
+.idt-settings-disclosure-body {
+  margin: 0 1.15rem 1.15rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--app-border-soft);
+}
+
+.idt-settings-sessions-card .idt-session-stack {
+  gap: 0.55rem;
+}
+
+.idt-settings-sessions-card .idt-session-row,
+html[data-theme='light'] .idt-settings-sessions-card .idt-session-row {
+  border-color: var(--app-border-soft);
+  background: var(--idt-console-surface-deep);
+  box-shadow: none;
+}
+
+.idt-settings-sessions-card .idt-session-row p {
+  margin: 0.12rem 0 0;
+  color: var(--app-muted);
+  font-size: 0.86rem;
+}
+
+.idt-settings-sessions-card .idt-session-row .idt-btn {
+  min-width: 7.5rem;
+  white-space: nowrap;
+}
+
+.idt-app-console-layout .idt-workspace-admin {
+  gap: 1rem;
+}
+
+.idt-app-console-layout .idt-workspace-admin-header {
+  align-items: center;
+  padding-top: 0;
+}
+
+.idt-app-console-layout .idt-workspace-admin-header h2 {
+  margin-top: 0;
+  margin-bottom: 0.32rem;
+}
+
+.idt-app-console-layout .idt-workspace-admin-grid > article {
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: #050506;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.035), var(--idt-console-shadow);
+}
+
+.idt-app-console-layout .idt-workspace-admin-grid > article h3 {
+  margin-bottom: 0.2rem;
+  font-size: 1.02rem;
+}
+
+.idt-app-console-layout .idt-workspace-admin-header p {
+  max-width: 44rem;
+}
+
+.idt-app-console-layout .idt-workspace-stats article {
+  min-height: 5.2rem;
+  display: grid;
+  align-content: center;
+  gap: 0.1rem;
+  background: #070708;
+}
+
+.idt-app-console-layout .idt-workspace-stats h3 {
+  font-size: 1.55rem;
+  line-height: 1;
+}
+
+.idt-app-console-layout .idt-workspace-stats p {
+  margin: 0;
+  color: var(--app-muted);
+  font-size: 0.94rem;
+}
+
+.idt-app-console-layout .idt-workspace-card {
+  display: grid;
+  align-self: start;
+  align-content: start;
+  gap: 1rem;
+  min-height: 0;
+  padding: 1rem;
+}
+
+.idt-workspace-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.idt-workspace-card-header h3,
+.idt-workspace-card-header p {
+  margin: 0;
+}
+
+.idt-workspace-card-header p {
+  color: var(--app-muted);
+  font-size: 0.9rem;
+}
+
+.idt-app-console-layout .idt-workspace-switcher {
+  align-items: end;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.idt-app-console-layout .idt-workspace-switcher label {
+  min-width: 0;
+}
+
+.idt-app-console-layout .idt-workspace-switcher .idt-btn {
+  min-height: 2.75rem;
+  white-space: nowrap;
+}
+
+.idt-workspace-invite-form {
+  display: grid;
+  align-items: end;
+  gap: 0.75rem;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.idt-workspace-invite-form .idt-workspace-inline-fields {
+  grid-column: 1 / -1;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.idt-workspace-invite-form .idt-btn {
+  justify-self: end;
+  min-height: 2.75rem;
+  min-width: 13rem;
+}
+
+.idt-app-console-layout .idt-workspace-member-toolbar {
+  align-items: end;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 0.85rem;
+  background: #050506;
+}
+
+.idt-app-console-layout .idt-workspace-table-wrap {
+  border-radius: 8px;
+  background: #050506;
+}
+
+.idt-app-console-layout .idt-workspace-table th,
+.idt-app-console-layout .idt-workspace-table td {
+  padding: 0.75rem 0.85rem;
+}
+
+.idt-app-console-layout .idt-workspace-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+@media (max-width: 720px) {
+  .idt-danger-zone-row,
+  .idt-settings-sessions-card .idt-session-row {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .idt-settings-disclosure-summary {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 0.85rem;
+  }
+
+  .idt-settings-disclosure-summary > span {
+    text-align: center;
+  }
+
+  .idt-settings-disclosure-body {
+    margin-right: 0.9rem;
+    margin-left: 0.9rem;
+  }
+
+  .idt-app-console-layout .idt-workspace-switcher,
+  .idt-workspace-invite-form,
+  .idt-workspace-invite-form .idt-workspace-inline-fields {
+    grid-template-columns: 1fr;
+  }
+
+  .idt-workspace-invite-form .idt-btn {
+    justify-self: stretch;
+    min-width: 0;
+  }
 }
 
 html[data-theme='light'] .idt-danger-modal {


### PR DESCRIPTION
## Summary
- keep #1442 scoped to Settings/app-shell polish only; removed the account-export backend/API/worker/migration/docs work from this branch
- keep /app/account/security available for workspace-less account controls while moving the primary scoped session controls into Settings
- tighten Settings copy, keep Manage members as the primary action, collapse related areas/sessions, and keep the shorter Danger zone visible
- format sessions as readable device labels instead of raw user-agent strings

No issue: direct settings-page polish and PR repair requested.

## Validation
- `npm test -- --run src/components/settings/DangerZone.test.tsx src/App.test.tsx`
- `npm run build`

## Scope check
- Changed files are only under `web/src/...`; no `internal/`, `migrations/`, `docs/openapi-v1.yaml`, or export API client changes remain in this PR.
- The account data export work should live in PR #1441, not here.