### PR TITLE
Implement AWS Control Center and Connect AWS pages

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1425,7 +1425,7 @@ describe('App', () => {
     expect(screen.queryByRole('link', { name: 'Projects' })).not.toBeInTheDocument();
   });
 
-  it('routes the AWS connect domain entry to the working connector setup', async () => {
+  it('routes the AWS connect domain entry to the AWS-owned setup page', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString();
       if (url.endsWith('/v1/me')) {
@@ -1503,9 +1503,10 @@ describe('App', () => {
     setCurrentPath('/app/tenant-a/workspace-a/aws/connect');
     render(<App />);
 
-    await waitFor(() => expect(window.location.pathname).toBe('/app/tenant-a/workspace-a/projects/project-1'));
-    expect(window.location.search).toBe('?source=aws');
-    expect(await screen.findByRole('heading', { level: 1, name: /Connect AWS/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: /Connect AWS/i })).toBeInTheDocument();
+    expect(window.location.pathname).toBe('/app/tenant-a/workspace-a/aws/connect');
+    expect(await screen.findByRole('heading', { level: 3, name: /AWS read-only connector/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /AWS home/i })).toHaveAttribute('href', '/app/tenant-a/workspace-a/aws?environment=project-1');
     expect(screen.queryByLabelText('AWS source')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Source types')).not.toBeInTheDocument();
     expect(screen.queryByRole('heading', { level: 3, name: 'AWS' })).not.toBeInTheDocument();

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,6 +29,7 @@ import {
   ProductAppIndexRedirect,
   ProductAuthCallbackRedirectPage,
   ProductAIRisksPage,
+  ProductAWSControlCenterPage,
   ProductAgenticRiskSurfacePage,
   ProductDomainRoutePage,
   ProductAWSConnectPage,
@@ -4777,7 +4778,7 @@ export function RoutedSite() {
             <Route path="projects/:projectID" element={<ProductProjectDetailPage />} />
             <Route path="findings" element={<LegacyScopedAppRedirect target="github/findings" />} />
             <Route path="ai-risks" element={<LegacyScopedAppRedirect target="github/agentic-risk" />} />
-            <Route path="aws" element={<ProductDomainRoutePage domain="aws" />} />
+            <Route path="aws" element={<ProductAWSControlCenterPage />} />
             <Route path="aws/connect" element={<ProductAWSConnectPage />} />
             <Route path="aws/accounts" element={<ProductDomainRoutePage domain="aws" routeID="accounts" />} />
             <Route path="aws/identities" element={<ProductDomainRoutePage domain="aws" routeID="identities" />} />

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -1241,6 +1241,142 @@ describe('Domain-first app routes', () => {
     expect(screen.queryByRole('button', { name: /Preview permissions/i })).not.toBeInTheDocument();
   });
 
+  it('ignores stale AWS poll responses after switching environments', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        },
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'staging',
+          name: 'Staging',
+          slug: 'staging',
+          description: 'Staging AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-03T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockImplementation((_workspaceID, projectID) =>
+      Promise.resolve({ connection: projectID === 'production' ? connectedAWS : disconnectedAWS })
+    );
+    const pollResponse = deferred<{ connection: AWSConnectionStatus }>();
+    vi.spyOn(api.apiClient, 'pollAWSConnector').mockReturnValue(pollResponse.promise);
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 3, name: /AWS read-only connector/i })).toBeInTheDocument();
+    const refreshButton = within(screen.getByLabelText('AWS connector setup')).getByRole('button', {
+      name: /Refresh status/i
+    });
+    fireEvent.click(refreshButton);
+    await waitFor(() =>
+      expect(api.apiClient.pollAWSConnector).toHaveBeenCalledWith(
+        'aws-connector-1',
+        'workspace-a',
+        'production',
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    fireEvent.change(screen.getByRole('combobox', { name: 'Environment' }), { target: { value: 'staging' } });
+
+    await act(async () => {
+      pollResponse.resolve({
+        connection: { ...connectedAWS, display_name: 'Production poll AWS', account_id: '111111111111' }
+      });
+    });
+
+    expect(await screen.findByRole('combobox', { name: 'Environment' })).toHaveValue('staging');
+    expect(screen.queryByText('AWS connector is active.')).not.toBeInTheDocument();
+    expect(screen.queryByText('Production poll AWS')).not.toBeInTheDocument();
+  });
+
+  it('ignores stale AWS validation responses after switching environments', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        },
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'staging',
+          name: 'Staging',
+          slug: 'staging',
+          description: 'Staging AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-03T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockImplementation((_workspaceID, projectID) =>
+      Promise.resolve({ connection: projectID === 'production' ? connectedAWS : disconnectedAWS })
+    );
+    const validationResponse = deferred<{ connection: AWSConnectionStatus }>();
+    vi.spyOn(api.apiClient, 'validateAWSConnector').mockReturnValue(validationResponse.promise);
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const submitButton = await screen.findByRole('button', { name: /Validate and save AWS/i });
+    fireEvent.click(submitButton);
+    await waitFor(() =>
+      expect(api.apiClient.validateAWSConnector).toHaveBeenCalledWith(
+        'aws-connector-1',
+        expect.objectContaining({ project_id: 'production' }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    fireEvent.change(screen.getByRole('combobox', { name: 'Environment' }), { target: { value: 'staging' } });
+
+    await act(async () => {
+      validationResponse.resolve({
+        connection: { ...connectedAWS, display_name: 'Validated production AWS', account_id: '111111111111' }
+      });
+    });
+
+    expect(await screen.findByRole('combobox', { name: 'Environment' })).toHaveValue('staging');
+    expect(screen.queryByText('AWS connector is active.')).not.toBeInTheDocument();
+    expect(screen.queryByText('Validated production AWS')).not.toBeInTheDocument();
+  });
+
   it('loads AWS connect actions for the selected environment even when it is outside the first page', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     const api = await import('./api/client');

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-rou
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type {
   AuthConfigResponse,
+  AWSConnectorStartResponse,
   AWSConnectionStatus,
   CurrentUserContext,
   Finding,
@@ -999,6 +1000,68 @@ describe('Domain-first app routes', () => {
     );
   });
 
+  it('ignores stale AWS Control Center status loads after switching environments', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        },
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'staging',
+          name: 'Staging',
+          slug: 'staging',
+          description: 'Staging AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-03T00:00:00Z'
+        }
+      ]
+    });
+    const productionStatus = deferred<{ connection: AWSConnectionStatus }>();
+    const stagingStatus = deferred<{ connection: AWSConnectionStatus }>();
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockImplementation((_workspaceID, projectID) =>
+      projectID === 'production' ? productionStatus.promise : stagingStatus.promise
+    );
+
+    const { ProductAWSControlCenterPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws" element={<ProductAWSControlCenterPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('combobox', { name: 'Environment' })).toHaveValue('production');
+    fireEvent.change(screen.getByRole('combobox', { name: 'Environment' }), { target: { value: 'staging' } });
+
+    await act(async () => {
+      stagingStatus.resolve({
+        connection: { ...connectedAWS, display_name: 'Staging AWS', account_id: '222222222222', region: 'us-west-2' }
+      });
+    });
+    expect(await screen.findByText('Staging AWS')).toBeInTheDocument();
+    expect(screen.getAllByText(/Account 222222222222/i).length).toBeGreaterThan(0);
+
+    await act(async () => {
+      productionStatus.resolve({
+        connection: { ...connectedAWS, display_name: 'Production AWS', account_id: '111111111111', region: 'us-east-1' }
+      });
+    });
+    expect(screen.getByText('Staging AWS')).toBeInTheDocument();
+    expect(screen.queryByText('Production AWS')).not.toBeInTheDocument();
+  });
+
   it('keeps AWS connect on the domain page when no environment exists', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     const api = await import('./api/client');
@@ -1031,8 +1094,151 @@ describe('Domain-first app routes', () => {
     expect(screen.getByRole('heading', { level: 3, name: /Create an environment before connecting AWS/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Open environments/i })).toHaveAttribute(
       'href',
-      '/app/tenant-a/workspace-a/projects'
+      '/app/tenant-a/workspace-a/projects?source=aws'
     );
+  });
+
+  it('clears stale AWS connect form values when the selected environment changes', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        },
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'staging',
+          name: 'Staging',
+          slug: 'staging',
+          description: 'Staging AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-03T00:00:00Z'
+        }
+      ]
+    });
+    const productionStatus = deferred<{ connection: AWSConnectionStatus }>();
+    const stagingStatus = deferred<{ connection: AWSConnectionStatus }>();
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockImplementation((_workspaceID, projectID) =>
+      projectID === 'production' ? productionStatus.promise : stagingStatus.promise
+    );
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('combobox', { name: 'Environment' })).toHaveValue('production');
+    fireEvent.change(screen.getByRole('combobox', { name: 'Environment' }), { target: { value: 'staging' } });
+
+    await act(async () => {
+      stagingStatus.resolve({
+        connection: {
+          ...disconnectedAWS,
+          permission_checks: [],
+          diagnostics: []
+        }
+      });
+    });
+
+    expect(await screen.findByRole('heading', { level: 3, name: /AWS read-only connector/i })).toBeInTheDocument();
+    expect(screen.getByLabelText('Role ARN')).toHaveValue('');
+    expect(screen.getByLabelText('Display name')).toHaveValue('');
+    expect(screen.getByLabelText('Region')).toHaveValue('us-east-1');
+
+    await act(async () => {
+      productionStatus.resolve({ connection: connectedAWS });
+    });
+    expect(screen.getByLabelText('Role ARN')).toHaveValue('');
+    expect(screen.queryByDisplayValue('Production AWS')).not.toBeInTheDocument();
+  });
+
+  it('ignores stale AWS CloudFormation start responses after switching environments', async () => {
+    mockBackendFeatures({ github: true, kubernetes: true });
+    mockConnectorFeatureFlags({ aws: true, github: true, kubernetes: true });
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        },
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'staging',
+          name: 'Staging',
+          slug: 'staging',
+          description: 'Staging AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-03T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+    const startResponse = deferred<AWSConnectorStartResponse>();
+    vi.spyOn(api.apiClient, 'startAWSConnector').mockReturnValue(startResponse.promise);
+
+    const { ProductAWSConnectPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const launchButton = await screen.findByRole('button', { name: /Launch stack/i });
+    fireEvent.click(launchButton);
+    await waitFor(() =>
+      expect(api.apiClient.startAWSConnector).toHaveBeenCalledWith(
+        expect.objectContaining({ project_id: 'production' }),
+        expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+      )
+    );
+    fireEvent.change(screen.getByRole('combobox', { name: 'Environment' }), { target: { value: 'staging' } });
+
+    await act(async () => {
+      startResponse.resolve({
+        connection: connectedAWS,
+        connector_id: 'aws-connector-1',
+        external_id: 'stale-external-id',
+        launch_url: 'https://console.aws.amazon.com/cloudformation',
+        template_url: 'https://example.com/template.yaml',
+        role_name: 'IdentrailReadOnly',
+        stack_name: 'identrail-readonly-connector',
+        policy_hash: 'sha256:example',
+        permission_preview: [
+          { service: 'IAM', actions: ['iam:GetRole'], resources: ['*'], reason: 'Inspect role metadata.' }
+        ],
+        permission_tiers: []
+      });
+    });
+
+    expect(await screen.findByRole('combobox', { name: 'Environment' })).toHaveValue('staging');
+    expect(screen.getByLabelText('External ID')).toHaveValue('');
+    expect(screen.queryByText(/AWS CloudFormation launch is ready/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Preview permissions/i })).not.toBeInTheDocument();
   });
 
   it('loads AWS connect actions for the selected environment even when it is outside the first page', async () => {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -104,6 +104,37 @@ const disconnectedAWS: AWSConnectionStatus = {
   capabilities: { requested: ['discovery'], validated: ['discovery'], effective: ['discovery'], unavailable: [] }
 };
 
+const connectedAWS: AWSConnectionStatus = {
+  provider: 'aws',
+  connected: true,
+  connector_id: 'aws-connector-1',
+  display_name: 'Production AWS',
+  status: 'active',
+  health_status: 'healthy',
+  role_arn: 'arn:aws:iam::123456789012:role/IdentrailReadOnly',
+  external_id_configured: true,
+  account_id: '123456789012',
+  principal_arn: 'arn:aws:sts::123456789012:assumed-role/IdentrailReadOnly/identrail',
+  region: 'us-east-1',
+  permission_checks: [
+    {
+      name: 'iam:GetRole',
+      passed: true,
+      message: 'Role metadata can be inspected.'
+    }
+  ],
+  diagnostics: [
+    {
+      code: 'cloudtrail_pending',
+      message: 'Runtime evidence is not wired for this environment yet.',
+      remediation: 'No action required for connector setup.'
+    }
+  ],
+  capabilities: { requested: ['discovery'], validated: ['discovery'], effective: ['discovery'], unavailable: [] },
+  updated_at: '2026-05-17T10:00:00Z',
+  last_validated_at: '2026-05-17T10:00:00Z'
+};
+
 const connectedGitHub: GitHubConnectionStatus = {
   provider: 'github_app',
   connected: true,
@@ -925,23 +956,55 @@ describe('Domain-first app routes', () => {
     );
   });
 
-  it('preserves the requested domain source when creating the first environment from connect', async () => {
+  it('renders the AWS Control Center with current and future capability labels', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+
+    const { ProductAWSControlCenterPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws" element={<ProductAWSControlCenterPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 2, name: 'AWS Control Center' })).toBeInTheDocument();
+    expect((await screen.findAllByText(/Account 123456789012/i)).length).toBeGreaterThan(0);
+    expect(screen.getByRole('link', { name: /Connect AWS/i })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/aws/connect?environment=production'
+    );
+    expect(screen.getAllByText('Wired now').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Coming').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Not yet available').length).toBeGreaterThan(0);
+    expect(screen.getByRole('link', { name: /Resources and secrets/i })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/aws/resources?environment=production'
+    );
+  });
+
+  it('keeps AWS connect on the domain page when no environment exists', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     const api = await import('./api/client');
-    const project = {
-      tenant_id: 'tenant-a',
-      workspace_id: 'workspace-a',
-      project_id: 'production-platform',
-      name: 'Production Platform',
-      slug: 'production-platform',
-      description: 'Production identity boundary.',
-      created_at: '2026-01-01T00:00:00Z',
-      updated_at: '2026-01-02T00:00:00Z'
-    };
     vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({ items: [] });
-    vi.spyOn(api.apiClient, 'upsertProject').mockResolvedValue({ project });
 
-    const { ProductAWSConnectPage, ProductProjectsPage } = await import('./productShell');
+    const { ProductAWSConnectPage } = await import('./productShell');
     function LocationProbe() {
       const location = useLocation();
       return <p data-testid="location">{`${location.pathname}${location.search}`}</p>;
@@ -950,40 +1013,29 @@ describe('Domain-first app routes', () => {
     render(
       <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect']}>
         <Routes>
-          <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
           <Route
-            path="/app/:tenantID/:workspaceID/projects"
+            path="/app/:tenantID/:workspaceID/aws/connect"
             element={
               <>
                 <LocationProbe />
-                <ProductProjectsPage />
+                <ProductAWSConnectPage />
               </>
             }
           />
-          <Route path="/app/:tenantID/:workspaceID/projects/:projectID" element={<LocationProbe />} />
         </Routes>
       </MemoryRouter>
     );
 
-    expect(await screen.findByRole('heading', { level: 2, name: 'Environments' })).toBeInTheDocument();
-    expect(screen.getByTestId('location')).toHaveTextContent('/app/tenant-a/workspace-a/projects?source=aws');
-
-    fireEvent.change(screen.getByLabelText(/Environment name/i), { target: { value: 'Production Platform' } });
-    fireEvent.click(screen.getByRole('button', { name: /Create environment/i }));
-
-    await waitFor(() =>
-      expect(screen.getByTestId('location')).toHaveTextContent(
-        '/app/tenant-a/workspace-a/projects/production-platform?source=aws'
-      )
-    );
-    expect(api.apiClient.upsertProject).toHaveBeenCalledWith(
-      'workspace-a',
-      expect.objectContaining({ project_id: 'production-platform' }),
-      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    expect(await screen.findByRole('heading', { level: 2, name: 'Connect AWS' })).toBeInTheDocument();
+    expect(screen.getByTestId('location')).toHaveTextContent('/app/tenant-a/workspace-a/aws/connect');
+    expect(screen.getByRole('heading', { level: 3, name: /Create an environment before connecting AWS/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Open environments/i })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/projects'
     );
   });
 
-  it('routes connect actions to the selected environment even when it is outside the first page', async () => {
+  it('loads AWS connect actions for the selected environment even when it is outside the first page', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     const api = await import('./api/client');
     const listProjects = vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
@@ -1010,26 +1062,35 @@ describe('Domain-first app routes', () => {
         updated_at: '2025-01-02T00:00:00Z'
       }
     });
+    const getAWSProjectConnection = vi
+      .spyOn(api.apiClient, 'getAWSProjectConnection')
+      .mockResolvedValue({ connection: connectedAWS });
 
     const { ProductAWSConnectPage } = await import('./productShell');
-    function LocationProbe() {
-      const location = useLocation();
-      return <p data-testid="location">{`${location.pathname}${location.search}`}</p>;
-    }
 
     render(
       <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/connect?environment=older-production']}>
         <Routes>
           <Route path="/app/:tenantID/:workspaceID/aws/connect" element={<ProductAWSConnectPage />} />
-          <Route path="/app/:tenantID/:workspaceID/projects/:projectID" element={<LocationProbe />} />
         </Routes>
       </MemoryRouter>
     );
 
-    expect(await screen.findByTestId('location')).toHaveTextContent(
-      '/app/tenant-a/workspace-a/projects/older-production?source=aws'
+    expect(await screen.findByRole('combobox', { name: 'Environment' })).toHaveValue('older-production');
+    expect(await screen.findByRole('heading', { level: 3, name: /AWS read-only connector/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /AWS home/i })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/aws?environment=older-production'
     );
-    expect(listProjects).not.toHaveBeenCalled();
+    const setupPayload = screen.getByLabelText('Setup payload');
+    expect(within(setupPayload).getByText('workspace-a')).toBeInTheDocument();
+    expect(within(setupPayload).getByText('older-production')).toBeInTheDocument();
+    expect(listProjects).toHaveBeenCalled();
+    expect(getAWSProjectConnection).toHaveBeenCalledWith(
+      'workspace-a',
+      'older-production',
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
   });
 
   it('keeps requested environment selected when getProject check fails for a transient error', async () => {
@@ -1067,7 +1128,7 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByText(/Unable to verify selected environment older-production/i)).toBeInTheDocument();
   });
 
-  it('does not silently route AWS connect to fallback environment when getProject check fails transiently', async () => {
+  it('does not silently switch AWS connect to a fallback environment when getProject check fails transiently', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     const api = await import('./api/client');
     const listProjects = vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
@@ -1085,6 +1146,9 @@ describe('Domain-first app routes', () => {
       ]
     });
     vi.spyOn(api.apiClient, 'getProject').mockRejectedValue(new api.ApiError('temporary outage', 503));
+    const getAWSProjectConnection = vi
+      .spyOn(api.apiClient, 'getAWSProjectConnection')
+      .mockResolvedValue({ connection: disconnectedAWS });
 
     const { ProductAWSConnectPage } = await import('./productShell');
 
@@ -1096,9 +1160,16 @@ describe('Domain-first app routes', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByRole('heading', { level: 2, name: /Unable to open AWS setup/i })).toBeInTheDocument();
-    expect(screen.getByText(/temporary outage/i)).toBeInTheDocument();
-    expect(listProjects).not.toHaveBeenCalled();
+    expect(await screen.findByRole('heading', { level: 2, name: 'Connect AWS' })).toBeInTheDocument();
+    expect(await screen.findByRole('combobox', { name: 'Environment' })).toHaveValue('older-production');
+    expect(screen.getByText(/Unable to verify selected environment older-production/i)).toBeInTheDocument();
+    expect(screen.getByText('older-production')).toBeInTheDocument();
+    expect(listProjects).toHaveBeenCalled();
+    expect(getAWSProjectConnection).toHaveBeenCalledWith(
+      'workspace-a',
+      'older-production',
+      expect.objectContaining({ tenantID: 'tenant-a', workspaceID: 'workspace-a' })
+    );
   });
 
   it('falls back to an active environment when the requested environment is archived', async () => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -2621,8 +2621,8 @@ function AWSConnectionDiagnostics({
           {check.remediation ? <small>{check.remediation}</small> : null}
         </article>
       ))}
-      {diagnostics.map((diagnostic) => (
-        <article key={diagnostic.code}>
+      {diagnostics.map((diagnostic, index) => (
+        <article key={`${diagnostic.code}-${index}`}>
           <strong>{formatTokenLabel(diagnostic.code)}</strong>
           <span className="idt-source-status-pill is-warning">Diagnostic</span>
           <p>{diagnostic.message}</p>
@@ -2644,33 +2644,50 @@ export function ProductAWSControlCenterPage() {
   const [connection, setConnection] = useState<AWSConnectionStatus | null>(null);
   const [connectionLoading, setConnectionLoading] = useState(false);
   const [connectionError, setConnectionError] = useState('');
+  const connectionRequestRef = useRef(0);
+  const selectedEnvironmentIDRef = useRef(selectedEnvironmentID);
+  selectedEnvironmentIDRef.current = selectedEnvironmentID;
 
   const refreshConnection = useCallback(async () => {
-    if (!scope || !selectedEnvironmentID) {
+    const requestID = ++connectionRequestRef.current;
+    const requestEnvironmentID = selectedEnvironmentID;
+    if (!scope || !requestEnvironmentID) {
       setConnection(null);
       setConnectionError('');
       setConnectionLoading(false);
       return;
     }
+    const isStale = () => requestID !== connectionRequestRef.current || selectedEnvironmentIDRef.current !== requestEnvironmentID;
     setConnectionLoading(true);
     setConnectionError('');
     try {
       const response = await apiClient.getAWSProjectConnection(
         scope.workspaceID,
-        selectedEnvironmentID,
+        requestEnvironmentID,
         buildProductAuthContext(scope)
       );
+      if (isStale()) {
+        return;
+      }
       setConnection(response.connection);
     } catch (error) {
+      if (isStale()) {
+        return;
+      }
       setConnection(null);
       setConnectionError(formatAPIError(error, 'Unable to load AWS connection status.'));
     } finally {
-      setConnectionLoading(false);
+      if (!isStale()) {
+        setConnectionLoading(false);
+      }
     }
   }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
 
   useEffect(() => {
     void refreshConnection();
+    return () => {
+      connectionRequestRef.current += 1;
+    };
   }, [refreshConnection]);
 
   if (!scope) {
@@ -2684,6 +2701,9 @@ export function ProductAWSControlCenterPage() {
   }
 
   const handleEnvironmentChange = (environmentID: string) => {
+    connectionRequestRef.current += 1;
+    setConnection(null);
+    setConnectionError('');
     navigate(
       {
         pathname: location.pathname,
@@ -3114,16 +3134,30 @@ export function ProductAWSConnectPage() {
   const [awsPermissionPreview, setAWSPermissionPreview] = useState<AWSPermissionPreviewItem[]>([]);
   const [awsPermissionTiers, setAWSPermissionTiers] = useState<AWSCapabilityPermissionTier[]>([]);
   const [awsPreviewOpen, setAWSPreviewOpen] = useState(false);
+  const connectionRequestRef = useRef(0);
+  const awsStartRequestRef = useRef(0);
+  const selectedEnvironmentIDRef = useRef(selectedEnvironmentID);
+  const scopeKey = scope ? `${scope.tenantID}::${scope.workspaceID}` : '';
+  const scopeKeyRef = useRef(scopeKey);
+  selectedEnvironmentIDRef.current = selectedEnvironmentID;
+  scopeKeyRef.current = scopeKey;
 
   const refreshConnection = useCallback(
     async (mode: 'initial' | 'manual' = 'initial') => {
-      if (!scope || !selectedEnvironmentID) {
+      const requestID = ++connectionRequestRef.current;
+      const requestEnvironmentID = selectedEnvironmentID;
+      const requestScopeKey = scopeKeyRef.current;
+      if (!scope || !requestEnvironmentID) {
         setConnection(null);
         setErrorMessage('');
         setLoadingConnection(false);
         setRefreshingConnection(false);
         return;
       }
+      const isStale = () =>
+        requestID !== connectionRequestRef.current ||
+        selectedEnvironmentIDRef.current !== requestEnvironmentID ||
+        scopeKeyRef.current !== requestScopeKey;
       if (mode === 'manual') {
         setRefreshingConnection(true);
       } else {
@@ -3133,36 +3167,57 @@ export function ProductAWSConnectPage() {
       try {
         const response = await apiClient.getAWSProjectConnection(
           scope.workspaceID,
-          selectedEnvironmentID,
+          requestEnvironmentID,
           buildProductAuthContext(scope)
         );
+        if (isStale()) {
+          return;
+        }
         setConnection(response.connection);
         setAWSForm((current) => ({
           ...current,
-          roleARN: response.connection.role_arn ?? current.roleARN,
-          region: response.connection.region ?? current.region,
-          displayName: response.connection.display_name ?? current.displayName
+          roleARN: response.connection.role_arn ?? '',
+          region: response.connection.region ?? 'us-east-1',
+          displayName: response.connection.display_name ?? ''
         }));
       } catch (error) {
+        if (isStale()) {
+          return;
+        }
         setConnection(null);
         setErrorMessage(formatAPIError(error, 'Unable to load AWS connection.'));
       } finally {
-        setLoadingConnection(false);
-        setRefreshingConnection(false);
+        if (!isStale()) {
+          setLoadingConnection(false);
+          setRefreshingConnection(false);
+        }
       }
     },
     [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]
   );
 
   useEffect(() => {
+    connectionRequestRef.current += 1;
+    awsStartRequestRef.current += 1;
     setSuccessMessage('');
     setErrorMessage('');
+    setSubmitting(false);
     setAWSCloudFormationStart(null);
     setAWSPermissionPreview([]);
     setAWSPermissionTiers([]);
     setAWSPreviewOpen(false);
-    setAWSForm((current) => ({ ...current, externalID: '' }));
+    setAWSForm((current) => ({
+      ...current,
+      roleARN: '',
+      externalID: '',
+      region: 'us-east-1',
+      displayName: ''
+    }));
     void refreshConnection('initial');
+    return () => {
+      connectionRequestRef.current += 1;
+      awsStartRequestRef.current += 1;
+    };
   }, [refreshConnection]);
 
   if (!scope) {
@@ -3176,6 +3231,9 @@ export function ProductAWSConnectPage() {
   }
 
   const handleEnvironmentChange = (environmentID: string) => {
+    connectionRequestRef.current += 1;
+    awsStartRequestRef.current += 1;
+    setConnection(null);
     navigate(
       {
         pathname: location.pathname,
@@ -3199,11 +3257,18 @@ export function ProductAWSConnectPage() {
     setSubmitting(true);
     setSuccessMessage('');
     setErrorMessage('');
+    const requestID = ++awsStartRequestRef.current;
+    const requestEnvironmentID = selectedEnvironmentID;
+    const requestScopeKey = scopeKeyRef.current;
+    const isStale = () =>
+      requestID !== awsStartRequestRef.current ||
+      selectedEnvironmentIDRef.current !== requestEnvironmentID ||
+      scopeKeyRef.current !== requestScopeKey;
     try {
       const response = await apiClient.startAWSConnector(
         {
           workspace_id: scope.workspaceID,
-          project_id: selectedEnvironmentID,
+          project_id: requestEnvironmentID,
           display_name: normalizeValue(awsForm.displayName) || undefined,
           region: normalizeValue(awsForm.region) || 'us-east-1',
           role_name: normalizeValue(awsForm.roleName) || undefined,
@@ -3211,6 +3276,9 @@ export function ProductAWSConnectPage() {
         },
         buildProductAuthContext(scope)
       );
+      if (isStale()) {
+        return;
+      }
       setAWSCloudFormationStart(response);
       setAWSPermissionPreview(response.permission_preview);
       setAWSPermissionTiers(response.permission_tiers ?? []);
@@ -3221,9 +3289,14 @@ export function ProductAWSConnectPage() {
         window.open(response.launch_url, '_blank', 'noopener,noreferrer');
       }
     } catch (error) {
+      if (isStale()) {
+        return;
+      }
       setErrorMessage(formatAPIError(error, 'Unable to start AWS connector setup.'));
     } finally {
-      setSubmitting(false);
+      if (!isStale()) {
+        setSubmitting(false);
+      }
     }
   };
 
@@ -3363,7 +3436,7 @@ export function ProductAWSConnectPage() {
           eyebrow="Environment required"
           title="Create an environment before connecting AWS"
           body="The AWS connector still writes through workspace and project-scoped APIs. Pick or create an environment, then return to this page."
-          nextAction={{ label: 'Open environments', to: buildProjectsPath(scope) }}
+          nextAction={{ label: 'Open environments', to: appendSourceQuery(buildProjectsPath(scope), 'aws') }}
         />
       ) : null}
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -3136,6 +3136,8 @@ export function ProductAWSConnectPage() {
   const [awsPreviewOpen, setAWSPreviewOpen] = useState(false);
   const connectionRequestRef = useRef(0);
   const awsStartRequestRef = useRef(0);
+  const awsPollRequestRef = useRef(0);
+  const awsValidationRequestRef = useRef(0);
   const selectedEnvironmentIDRef = useRef(selectedEnvironmentID);
   const scopeKey = scope ? `${scope.tenantID}::${scope.workspaceID}` : '';
   const scopeKeyRef = useRef(scopeKey);
@@ -3199,6 +3201,8 @@ export function ProductAWSConnectPage() {
   useEffect(() => {
     connectionRequestRef.current += 1;
     awsStartRequestRef.current += 1;
+    awsPollRequestRef.current += 1;
+    awsValidationRequestRef.current += 1;
     setSuccessMessage('');
     setErrorMessage('');
     setSubmitting(false);
@@ -3217,6 +3221,8 @@ export function ProductAWSConnectPage() {
     return () => {
       connectionRequestRef.current += 1;
       awsStartRequestRef.current += 1;
+      awsPollRequestRef.current += 1;
+      awsValidationRequestRef.current += 1;
     };
   }, [refreshConnection]);
 
@@ -3233,6 +3239,8 @@ export function ProductAWSConnectPage() {
   const handleEnvironmentChange = (environmentID: string) => {
     connectionRequestRef.current += 1;
     awsStartRequestRef.current += 1;
+    awsPollRequestRef.current += 1;
+    awsValidationRequestRef.current += 1;
     setConnection(null);
     navigate(
       {
@@ -3307,19 +3315,35 @@ export function ProductAWSConnectPage() {
     }
     setSubmitting(true);
     setErrorMessage('');
+    const requestID = ++awsPollRequestRef.current;
+    const requestEnvironmentID = selectedEnvironmentID;
+    const requestScopeKey = scopeKeyRef.current;
+    const requestConnectorID = activeConnectorID;
+    const isStale = () =>
+      requestID !== awsPollRequestRef.current ||
+      selectedEnvironmentIDRef.current !== requestEnvironmentID ||
+      scopeKeyRef.current !== requestScopeKey;
     try {
       const response = await apiClient.pollAWSConnector(
-        activeConnectorID,
+        requestConnectorID,
         scope.workspaceID,
-        selectedEnvironmentID,
+        requestEnvironmentID,
         buildProductAuthContext(scope)
       );
+      if (isStale()) {
+        return;
+      }
       setConnection(response.connection);
       setSuccessMessage(response.connection.connected ? 'AWS connector is active.' : 'AWS status refreshed.');
     } catch (error) {
+      if (isStale()) {
+        return;
+      }
       setErrorMessage(formatAPIError(error, 'Unable to poll AWS connector setup.'));
     } finally {
-      setSubmitting(false);
+      if (!isStale()) {
+        setSubmitting(false);
+      }
     }
   };
 
@@ -3332,6 +3356,14 @@ export function ProductAWSConnectPage() {
     setSubmitting(true);
     setSuccessMessage('');
     setErrorMessage('');
+    const requestID = ++awsValidationRequestRef.current;
+    const requestEnvironmentID = selectedEnvironmentID;
+    const requestScopeKey = scopeKeyRef.current;
+    const requestConnectorID = activeConnectorID;
+    const isStale = () =>
+      requestID !== awsValidationRequestRef.current ||
+      selectedEnvironmentIDRef.current !== requestEnvironmentID ||
+      scopeKeyRef.current !== requestScopeKey;
     try {
       const roleARN = normalizeValue(awsForm.roleARN);
       if (!AWS_ROLE_ARN_PATTERN.test(roleARN)) {
@@ -3346,12 +3378,12 @@ export function ProductAWSConnectPage() {
       };
       const auth = buildProductAuthContext(scope);
       const response =
-        FEATURE_CONNECTOR_AWS && activeConnectorID
+        FEATURE_CONNECTOR_AWS && requestConnectorID
           ? await apiClient.validateAWSConnector(
-              activeConnectorID,
+              requestConnectorID,
               {
                 workspace_id: scope.workspaceID,
-                project_id: selectedEnvironmentID,
+                project_id: requestEnvironmentID,
                 role_arn: payload.role_arn,
                 external_id: payload.external_id,
                 region: payload.region,
@@ -3359,15 +3391,23 @@ export function ProductAWSConnectPage() {
               },
               auth
             )
-          : await apiClient.upsertAWSProjectConnection(scope.workspaceID, selectedEnvironmentID, payload, auth);
+          : await apiClient.upsertAWSProjectConnection(scope.workspaceID, requestEnvironmentID, payload, auth);
+      if (isStale()) {
+        return;
+      }
       setConnection(response.connection);
       setSuccessMessage(
         response.connection.connected ? 'AWS connector is active.' : 'AWS connector saved with diagnostics to resolve.'
       );
     } catch (error) {
+      if (isStale()) {
+        return;
+      }
       setErrorMessage(formatAPIError(error, 'Unable to validate AWS connection.'));
     } finally {
-      setSubmitting(false);
+      if (!isStale()) {
+        setSubmitting(false);
+      }
     }
   };
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -2418,6 +2418,446 @@ function ProductRouteReadinessList({ route }: { route: ProductDomainRoute }) {
   );
 }
 
+type AWSCapabilityStage = 'wired' | 'coming' | 'not-available';
+
+type AWSControlCard = {
+  id: string;
+  label: string;
+  routeID: ProductDomainRouteID;
+  stage: AWSCapabilityStage;
+  metric: string;
+  detail: string;
+};
+
+const AWS_CONTROL_CARDS: AWSControlCard[] = [
+  {
+    id: 'connect',
+    label: 'Connection and validation',
+    routeID: 'connect',
+    stage: 'wired',
+    metric: 'Wired now',
+    detail: 'CloudFormation launch, role ARN validation, permission preview, polling, and diagnostics.'
+  },
+  {
+    id: 'accounts',
+    label: 'Accounts and regions',
+    routeID: 'accounts',
+    stage: 'coming',
+    metric: 'Coming wave',
+    detail: 'Organization, account, and region coverage will land after inventory scale support.'
+  },
+  {
+    id: 'identities',
+    label: 'Machine identities',
+    routeID: 'identities',
+    stage: 'coming',
+    metric: 'Coming wave',
+    detail: 'IAM roles, instance profiles, task roles, Lambda roles, EKS identities, and CI/CD roles.'
+  },
+  {
+    id: 'agents',
+    label: 'Agent identities',
+    routeID: 'agents',
+    stage: 'coming',
+    metric: 'Coming wave',
+    detail: 'Bedrock, AgentCore, MCP, tool, and agent-to-role mapping surfaces.'
+  },
+  {
+    id: 'resources',
+    label: 'Resources and secrets',
+    routeID: 'resources',
+    stage: 'coming',
+    metric: 'Coming wave',
+    detail: 'Secrets metadata, SSM parameters, KMS, S3, and sensitive control-plane reachability.'
+  },
+  {
+    id: 'runtime',
+    label: 'Runtime evidence',
+    routeID: 'runtime',
+    stage: 'coming',
+    metric: 'Coming wave',
+    detail: 'CloudTrail, STS session resolution, secret reads, KMS decrypts, and agent tool activity.'
+  },
+  {
+    id: 'findings',
+    label: 'AWS findings',
+    routeID: 'findings',
+    stage: 'not-available',
+    metric: 'Not yet available',
+    detail: 'Domain-scoped findings will appear here after AWS collectors and reasoning engines land.'
+  },
+  {
+    id: 'remediation',
+    label: 'Remediation and governance',
+    routeID: 'remediation',
+    stage: 'not-available',
+    metric: 'Not yet available',
+    detail: 'Approved IAM diffs, trust hardening, verification, and runtime guardrails are staged for later PRs.'
+  }
+];
+
+function awsStageLabel(stage: AWSCapabilityStage): string {
+  if (stage === 'wired') {
+    return 'Wired now';
+  }
+  if (stage === 'coming') {
+    return 'Coming';
+  }
+  return 'Not yet available';
+}
+
+function awsStageTone(stage: AWSCapabilityStage): 'success' | 'warning' | 'neutral' {
+  if (stage === 'wired') {
+    return 'success';
+  }
+  if (stage === 'coming') {
+    return 'warning';
+  }
+  return 'neutral';
+}
+
+function awsDomainTone(connection: AWSConnectionStatus | null, loading = false): 'success' | 'warning' | 'danger' | 'neutral' | 'info' {
+  if (loading) {
+    return 'info';
+  }
+  const tone = connectionTone(connection ?? undefined);
+  if (tone === 'error') {
+    return 'danger';
+  }
+  if (tone === 'success' || tone === 'warning') {
+    return tone;
+  }
+  return 'neutral';
+}
+
+function awsStatusVariant(connection: AWSConnectionStatus | null): 'connected' | 'disconnected' | 'degraded' | 'missing-permissions' {
+  if (!connection) {
+    return 'disconnected';
+  }
+  const failedChecks = connection.permission_checks.filter((check) => !check.passed).length;
+  if (failedChecks > 0) {
+    return 'missing-permissions';
+  }
+  if (connection.health_status === 'warning' || connection.status === 'degraded') {
+    return 'degraded';
+  }
+  return connection.connected ? 'connected' : 'disconnected';
+}
+
+function awsPermissionSummary(connection: AWSConnectionStatus | null): string {
+  if (!connection || connection.permission_checks.length === 0) {
+    return 'Not validated';
+  }
+  const passed = connection.permission_checks.filter((check) => check.passed).length;
+  return `${passed}/${connection.permission_checks.length} passed`;
+}
+
+function awsDiagnosticSummary(connection: AWSConnectionStatus | null): string {
+  if (!connection || connection.diagnostics.length === 0) {
+    return connection?.connected ? 'Clear' : 'No diagnostics';
+  }
+  return formatCountLabel(connection.diagnostics.length, 'item');
+}
+
+function awsAccountRegionLabel(connection: AWSConnectionStatus | null): string {
+  if (!connection?.account_id && !connection?.region) {
+    return 'Pending';
+  }
+  return [connection.account_id ? `Account ${connection.account_id}` : '', connection.region ? `Region ${connection.region}` : '']
+    .filter(Boolean)
+    .join(' · ');
+}
+
+function awsConnectionLabel(connection: AWSConnectionStatus | null): string {
+  if (!connection) {
+    return 'Not loaded';
+  }
+  return connection.connected ? 'Connected' : connectionLifecycle(connection);
+}
+
+function awsRouteLink(scope: ProductSession, routeID: ProductDomainRouteID, environmentID: string): string {
+  return appendEnvironmentQuery(domainRoutePath(scope, 'aws', findDomainRoute('aws', routeID)), environmentID);
+}
+
+function AWSConnectionDiagnostics({
+  connection,
+  emptyLabel = 'No diagnostics reported for this environment.'
+}: {
+  connection: AWSConnectionStatus | null;
+  emptyLabel?: string;
+}) {
+  if (!connection) {
+    return (
+      <article>
+        <strong>Connection not loaded</strong>
+        <span>Waiting</span>
+        <p>Select an environment to load AWS status.</p>
+      </article>
+    );
+  }
+
+  const checks = connection.permission_checks;
+  const diagnostics = connection.diagnostics;
+
+  if (checks.length === 0 && diagnostics.length === 0) {
+    return (
+      <article>
+        <strong>AWS diagnostics</strong>
+        <span>{connection.connected ? 'Clear' : 'Pending'}</span>
+        <p>{emptyLabel}</p>
+      </article>
+    );
+  }
+
+  return (
+    <>
+      {checks.map((check) => (
+        <article key={check.name}>
+          <strong>{check.name}</strong>
+          <span className={`idt-source-status-pill is-${check.passed ? 'success' : 'warning'}`}>
+            {check.passed ? 'Passed' : 'Needs attention'}
+          </span>
+          <p>{check.message}</p>
+          {check.remediation ? <small>{check.remediation}</small> : null}
+        </article>
+      ))}
+      {diagnostics.map((diagnostic) => (
+        <article key={diagnostic.code}>
+          <strong>{formatTokenLabel(diagnostic.code)}</strong>
+          <span className="idt-source-status-pill is-warning">Diagnostic</span>
+          <p>{diagnostic.message}</p>
+          {diagnostic.remediation ? <small>{diagnostic.remediation}</small> : null}
+        </article>
+      ))}
+    </>
+  );
+}
+
+export function ProductAWSControlCenterPage() {
+  const params = useParams<ScopeRouteParams>();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const scope = resolveScopeFromParams(params);
+  const requestedEnvironmentID = useMemo(() => environmentIDFromSearch(location.search), [location.search]);
+  const environmentScope = useEnvironmentScope(scope, requestedEnvironmentID);
+  const selectedEnvironmentID = environmentScope.selectedID;
+  const [connection, setConnection] = useState<AWSConnectionStatus | null>(null);
+  const [connectionLoading, setConnectionLoading] = useState(false);
+  const [connectionError, setConnectionError] = useState('');
+
+  const refreshConnection = useCallback(async () => {
+    if (!scope || !selectedEnvironmentID) {
+      setConnection(null);
+      setConnectionError('');
+      setConnectionLoading(false);
+      return;
+    }
+    setConnectionLoading(true);
+    setConnectionError('');
+    try {
+      const response = await apiClient.getAWSProjectConnection(
+        scope.workspaceID,
+        selectedEnvironmentID,
+        buildProductAuthContext(scope)
+      );
+      setConnection(response.connection);
+    } catch (error) {
+      setConnection(null);
+      setConnectionError(formatAPIError(error, 'Unable to load AWS connection status.'));
+    } finally {
+      setConnectionLoading(false);
+    }
+  }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
+
+  useEffect(() => {
+    void refreshConnection();
+  }, [refreshConnection]);
+
+  if (!scope) {
+    return (
+      <section className="idt-app-panel idt-app-panel-error" role="alert">
+        <p className="idt-app-kicker">AWS Control Center</p>
+        <h2>Workspace route context is missing</h2>
+        <p>Choose a tenant and workspace before loading AWS.</p>
+      </section>
+    );
+  }
+
+  const handleEnvironmentChange = (environmentID: string) => {
+    navigate(
+      {
+        pathname: location.pathname,
+        search: environmentSearch(location.search, environmentID)
+      },
+      { replace: false }
+    );
+  };
+
+  const connectPath = awsRouteLink(scope, 'connect', selectedEnvironmentID);
+  const accountsPath = awsRouteLink(scope, 'accounts', selectedEnvironmentID);
+  const findingsPath = awsRouteLink(scope, 'findings', selectedEnvironmentID);
+  const failedChecks = connection?.permission_checks.filter((check) => !check.passed).length ?? 0;
+  const effectiveCapabilities = connection?.capabilities.effective.length ?? 0;
+  const statusTone = awsDomainTone(connection, connectionLoading || environmentScope.loading);
+  const statusLabel = environmentScope.loading
+    ? 'Loading scope'
+    : connectionLoading
+      ? 'Loading status'
+      : connectionError
+        ? 'Needs retry'
+        : awsConnectionLabel(connection);
+
+  return (
+    <DomainPageShell
+      domain="aws"
+      eyebrow="AWS machine identity"
+      title="AWS Control Center"
+      description="Operate AWS connection health, account and region scope, permission posture, and the AWS machine-identity roadmap from one domain-owned surface."
+      scope={<ProductEnvironmentSelector state={environmentScope} onChange={handleEnvironmentChange} />}
+      status={statusLabel}
+      statusTone={statusTone}
+      primaryAction={{ label: 'Connect AWS', to: connectPath, variant: 'primary' }}
+      secondaryActions={[
+        { label: 'Accounts', to: accountsPath },
+        { label: 'Findings', to: findingsPath }
+      ]}
+      aside={
+        <DomainDetailPanel title="AWS scope" eyebrow="Workspace contract">
+          <dl className="idt-domain-route-facts">
+            <div>
+              <dt>Environment</dt>
+              <dd>{selectedEnvironmentID ? environmentFallbackLabel(selectedEnvironmentID) : 'Default environment'}</dd>
+            </div>
+            <div>
+              <dt>Account / region</dt>
+              <dd>{awsAccountRegionLabel(connection)}</dd>
+            </div>
+            <div>
+              <dt>Connector</dt>
+              <dd>{connection?.connector_id ?? 'Not assigned'}</dd>
+            </div>
+          </dl>
+        </DomainDetailPanel>
+      }
+    >
+      <DomainKpiStrip
+        label="AWS status summary"
+        items={[
+          {
+            label: 'Connection',
+            value: awsConnectionLabel(connection),
+            detail: connection?.display_name ?? (selectedEnvironmentID ? 'AWS connector status for selected environment' : 'Choose an environment'),
+            tone: statusTone === 'danger' ? 'danger' : statusTone
+          },
+          {
+            label: 'Account / region',
+            value: connection?.account_id ? '1 account' : 'Pending',
+            detail: awsAccountRegionLabel(connection),
+            tone: connection?.account_id ? 'success' : 'warning'
+          },
+          {
+            label: 'Permissions',
+            value: awsPermissionSummary(connection),
+            detail: failedChecks > 0 ? `${failedChecks} check${failedChecks === 1 ? '' : 's'} need attention` : 'Validation status from AWS connector',
+            tone: failedChecks > 0 ? 'warning' : connection?.permission_checks.length ? 'success' : 'neutral'
+          },
+          {
+            label: 'Runtime and actions',
+            value: effectiveCapabilities > 0 ? `${effectiveCapabilities} active` : 'Planned',
+            detail: 'Runtime evidence, remediation, and governance waves are labeled honestly below.',
+            tone: effectiveCapabilities > 0 ? 'success' : 'info'
+          }
+        ]}
+      />
+
+      {environmentScope.loading || connectionLoading ? <DomainLoadingState label="Loading AWS control center status" /> : null}
+
+      {connectionError ? (
+        <DomainErrorState
+          title="AWS status could not load"
+          body={connectionError}
+          retryAction={{ label: 'Retry status', onClick: () => void refreshConnection() }}
+        />
+      ) : null}
+
+      {!selectedEnvironmentID && !environmentScope.loading ? (
+        <DomainEmptyState
+          eyebrow="Environment required"
+          title="Create an environment before connecting AWS"
+          body="AWS connection payloads remain scoped to a workspace environment, so setup needs an environment before validation can run."
+          nextAction={{ label: 'Open environments', to: buildProjectsPath(scope) }}
+        />
+      ) : null}
+
+      <DomainStatusPanel
+        eyebrow="Connection health"
+        title="AWS connector status and diagnostics"
+        status={<DomainStatusBadge variant={awsStatusVariant(connection)} detail={connection?.health_status ?? 'unknown'} />}
+        tone={statusTone === 'danger' ? 'danger' : statusTone}
+        actions={[
+          { label: 'Refresh status', onClick: () => void refreshConnection(), variant: 'secondary', disabled: connectionLoading },
+          { label: 'Open setup', to: connectPath, variant: 'ghost' }
+        ]}
+      >
+        <div className="idt-aws-status-grid">
+          <dl>
+            <div>
+              <dt>Lifecycle</dt>
+              <dd>{connection ? connectionLifecycle(connection) : 'Not connected'}</dd>
+            </div>
+            <div>
+              <dt>Last validation</dt>
+              <dd>{formatConnectionTime(connection?.last_validated_at ?? connection?.updated_at)}</dd>
+            </div>
+            <div>
+              <dt>External ID</dt>
+              <dd>{connection?.external_id_configured ? 'Configured' : 'Not configured'}</dd>
+            </div>
+            <div>
+              <dt>Role ARN</dt>
+              <dd>{connection?.role_arn ?? 'Not saved'}</dd>
+            </div>
+          </dl>
+          <div className="idt-source-diagnostics idt-aws-control-diagnostics" aria-label="AWS diagnostics summary">
+            <AWSConnectionDiagnostics connection={connection} />
+          </div>
+        </div>
+      </DomainStatusPanel>
+
+      <section className="idt-aws-control-grid" aria-label="AWS capability map">
+        {AWS_CONTROL_CARDS.map((card) => (
+          <Link
+            key={card.id}
+            className={`idt-aws-capability-card is-${card.stage}`}
+            to={awsRouteLink(scope, card.routeID, selectedEnvironmentID)}
+          >
+            <span className={`idt-domain-status-badge is-${awsStageTone(card.stage)}`}>
+              <span aria-hidden="true" className="idt-domain-status-dot" />
+              <strong>{awsStageLabel(card.stage)}</strong>
+            </span>
+            <strong>{card.label}</strong>
+            <span>{card.metric}</span>
+            <p>{card.detail}</p>
+          </Link>
+        ))}
+      </section>
+
+      <DomainStatusPanel eyebrow="Next actions" title="What AWS can do today" status={awsDiagnosticSummary(connection)} tone="info">
+        <div className="idt-aws-next-actions">
+          <article>
+            <strong>Wired now</strong>
+            <p>Use Connect AWS to launch the read-only stack, validate the role ARN, inspect permissions, and review diagnostics.</p>
+          </article>
+          <article>
+            <strong>Coming waves</strong>
+            <p>Account and region coverage, identity inventory, resource reachability, runtime evidence, findings, remediation, and governance stay clearly labeled until their APIs land.</p>
+          </article>
+        </div>
+      </DomainStatusPanel>
+    </DomainPageShell>
+  );
+}
+
 export function ProductDomainRoutePage({
   domain,
   routeID = 'overview'
@@ -2648,7 +3088,480 @@ function ProductConnectorConnectPage({ provider, providerLabel }: ConnectorConne
 }
 
 export function ProductAWSConnectPage() {
-  return <ProductConnectorConnectPage provider="aws" providerLabel="AWS" />;
+  const params = useParams<ScopeRouteParams>();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const scope = resolveScopeFromParams(params);
+  const requestedEnvironmentID = useMemo(() => environmentIDFromSearch(location.search), [location.search]);
+  const environmentScope = useEnvironmentScope(scope, requestedEnvironmentID);
+  const selectedEnvironmentID = environmentScope.selectedID;
+  const [connection, setConnection] = useState<AWSConnectionStatus | null>(null);
+  const [loadingConnection, setLoadingConnection] = useState(false);
+  const [refreshingConnection, setRefreshingConnection] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [successMessage, setSuccessMessage] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+  const [awsForm, setAWSForm] = useState({
+    roleARN: '',
+    externalID: '',
+    region: 'us-east-1',
+    displayName: '',
+    sessionName: 'identrail-connector-validation',
+    roleName: 'IdentrailReadOnly',
+    stackName: 'identrail-readonly-connector'
+  });
+  const [awsCloudFormationStart, setAWSCloudFormationStart] = useState<AWSConnectorStartResponse | null>(null);
+  const [awsPermissionPreview, setAWSPermissionPreview] = useState<AWSPermissionPreviewItem[]>([]);
+  const [awsPermissionTiers, setAWSPermissionTiers] = useState<AWSCapabilityPermissionTier[]>([]);
+  const [awsPreviewOpen, setAWSPreviewOpen] = useState(false);
+
+  const refreshConnection = useCallback(
+    async (mode: 'initial' | 'manual' = 'initial') => {
+      if (!scope || !selectedEnvironmentID) {
+        setConnection(null);
+        setErrorMessage('');
+        setLoadingConnection(false);
+        setRefreshingConnection(false);
+        return;
+      }
+      if (mode === 'manual') {
+        setRefreshingConnection(true);
+      } else {
+        setLoadingConnection(true);
+      }
+      setErrorMessage('');
+      try {
+        const response = await apiClient.getAWSProjectConnection(
+          scope.workspaceID,
+          selectedEnvironmentID,
+          buildProductAuthContext(scope)
+        );
+        setConnection(response.connection);
+        setAWSForm((current) => ({
+          ...current,
+          roleARN: response.connection.role_arn ?? current.roleARN,
+          region: response.connection.region ?? current.region,
+          displayName: response.connection.display_name ?? current.displayName
+        }));
+      } catch (error) {
+        setConnection(null);
+        setErrorMessage(formatAPIError(error, 'Unable to load AWS connection.'));
+      } finally {
+        setLoadingConnection(false);
+        setRefreshingConnection(false);
+      }
+    },
+    [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]
+  );
+
+  useEffect(() => {
+    setSuccessMessage('');
+    setErrorMessage('');
+    setAWSCloudFormationStart(null);
+    setAWSPermissionPreview([]);
+    setAWSPermissionTiers([]);
+    setAWSPreviewOpen(false);
+    setAWSForm((current) => ({ ...current, externalID: '' }));
+    void refreshConnection('initial');
+  }, [refreshConnection]);
+
+  if (!scope) {
+    return (
+      <section className="idt-app-panel idt-app-panel-error" role="alert">
+        <p className="idt-app-kicker">Connect AWS</p>
+        <h2>Workspace route context is missing</h2>
+        <p>Choose a tenant and workspace before loading AWS setup.</p>
+      </section>
+    );
+  }
+
+  const handleEnvironmentChange = (environmentID: string) => {
+    navigate(
+      {
+        pathname: location.pathname,
+        search: environmentSearch(location.search, environmentID)
+      },
+      { replace: false }
+    );
+  };
+
+  const controlPath = appendEnvironmentQuery(buildScopedPath(scope, 'aws'), selectedEnvironmentID);
+  const findingsPath = awsRouteLink(scope, 'findings', selectedEnvironmentID);
+  const statusTone = awsDomainTone(connection, loadingConnection || refreshingConnection || environmentScope.loading);
+  const canSubmit = !submitting && !loadingConnection && Boolean(selectedEnvironmentID);
+  const activeConnectorID = awsCloudFormationStart?.connector_id ?? connection?.connector_id ?? '';
+
+  const handleAWSCloudFormationStart = async () => {
+    if (!selectedEnvironmentID) {
+      setErrorMessage('Choose an environment before launching the AWS stack.');
+      return;
+    }
+    setSubmitting(true);
+    setSuccessMessage('');
+    setErrorMessage('');
+    try {
+      const response = await apiClient.startAWSConnector(
+        {
+          workspace_id: scope.workspaceID,
+          project_id: selectedEnvironmentID,
+          display_name: normalizeValue(awsForm.displayName) || undefined,
+          region: normalizeValue(awsForm.region) || 'us-east-1',
+          role_name: normalizeValue(awsForm.roleName) || undefined,
+          stack_name: normalizeValue(awsForm.stackName) || undefined
+        },
+        buildProductAuthContext(scope)
+      );
+      setAWSCloudFormationStart(response);
+      setAWSPermissionPreview(response.permission_preview);
+      setAWSPermissionTiers(response.permission_tiers ?? []);
+      setAWSForm((current) => ({ ...current, externalID: response.external_id }));
+      setConnection(response.connection);
+      setSuccessMessage('AWS CloudFormation launch is ready. Open the stack, then refresh status or validate the role.');
+      if (typeof window !== 'undefined' && !/jsdom/i.test(window.navigator.userAgent)) {
+        window.open(response.launch_url, '_blank', 'noopener,noreferrer');
+      }
+    } catch (error) {
+      setErrorMessage(formatAPIError(error, 'Unable to start AWS connector setup.'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleAWSPoll = async () => {
+    if (!selectedEnvironmentID || !activeConnectorID) {
+      setErrorMessage('Launch the stack or save a connector before polling AWS status.');
+      return;
+    }
+    setSubmitting(true);
+    setErrorMessage('');
+    try {
+      const response = await apiClient.pollAWSConnector(
+        activeConnectorID,
+        scope.workspaceID,
+        selectedEnvironmentID,
+        buildProductAuthContext(scope)
+      );
+      setConnection(response.connection);
+      setSuccessMessage(response.connection.connected ? 'AWS connector is active.' : 'AWS status refreshed.');
+    } catch (error) {
+      setErrorMessage(formatAPIError(error, 'Unable to poll AWS connector setup.'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleAWSSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!selectedEnvironmentID) {
+      setErrorMessage('Choose an environment before validating AWS.');
+      return;
+    }
+    setSubmitting(true);
+    setSuccessMessage('');
+    setErrorMessage('');
+    try {
+      const roleARN = normalizeValue(awsForm.roleARN);
+      if (!AWS_ROLE_ARN_PATTERN.test(roleARN)) {
+        throw new Error('Enter a valid IAM role ARN, for example arn:aws:iam::123456789012:role/IdentrailReadOnly.');
+      }
+      const payload = {
+        role_arn: roleARN,
+        external_id: normalizeValue(awsForm.externalID) || undefined,
+        region: normalizeValue(awsForm.region) || 'us-east-1',
+        display_name: normalizeValue(awsForm.displayName) || undefined,
+        session_name: normalizeValue(awsForm.sessionName) || undefined
+      };
+      const auth = buildProductAuthContext(scope);
+      const response =
+        FEATURE_CONNECTOR_AWS && activeConnectorID
+          ? await apiClient.validateAWSConnector(
+              activeConnectorID,
+              {
+                workspace_id: scope.workspaceID,
+                project_id: selectedEnvironmentID,
+                role_arn: payload.role_arn,
+                external_id: payload.external_id,
+                region: payload.region,
+                session_name: payload.session_name
+              },
+              auth
+            )
+          : await apiClient.upsertAWSProjectConnection(scope.workspaceID, selectedEnvironmentID, payload, auth);
+      setConnection(response.connection);
+      setSuccessMessage(
+        response.connection.connected ? 'AWS connector is active.' : 'AWS connector saved with diagnostics to resolve.'
+      );
+    } catch (error) {
+      setErrorMessage(formatAPIError(error, 'Unable to validate AWS connection.'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <DomainPageShell
+      domain="aws"
+      eyebrow="Read-only account onboarding"
+      title="Connect AWS"
+      description="Connect AWS with the existing read-only role flow while keeping environment scope, permission health, diagnostics, and CloudFormation status visible."
+      scope={<ProductEnvironmentSelector state={environmentScope} onChange={handleEnvironmentChange} />}
+      status={loadingConnection || environmentScope.loading ? 'Loading status' : awsConnectionLabel(connection)}
+      statusTone={statusTone}
+      primaryAction={{ label: 'AWS home', to: controlPath, variant: 'secondary' }}
+      secondaryActions={[{ label: 'AWS findings', to: findingsPath }]}
+      aside={
+        <DomainDetailPanel title="Setup payload" eyebrow="Scoped contract">
+          <dl className="idt-domain-route-facts">
+            <div>
+              <dt>Workspace</dt>
+              <dd>{scope.workspaceID}</dd>
+            </div>
+            <div>
+              <dt>Environment</dt>
+              <dd>{selectedEnvironmentID || 'Not selected'}</dd>
+            </div>
+            <div>
+              <dt>Connector</dt>
+              <dd>{activeConnectorID || 'Created during setup'}</dd>
+            </div>
+          </dl>
+        </DomainDetailPanel>
+      }
+    >
+      <DomainKpiStrip
+        label="Connect AWS status"
+        items={[
+          {
+            label: 'Connection',
+            value: awsConnectionLabel(connection),
+            detail: connection?.display_name ?? 'Read-only IAM role connector',
+            tone: statusTone === 'danger' ? 'danger' : statusTone
+          },
+          {
+            label: 'Permission checks',
+            value: awsPermissionSummary(connection),
+            detail: 'Role validation and diagnostics stay visible after save.',
+            tone: connection?.permission_checks.some((check) => !check.passed)
+              ? 'warning'
+              : connection?.permission_checks.length
+                ? 'success'
+                : 'neutral'
+          },
+          {
+            label: 'Account / region',
+            value: connection?.account_id ?? 'Pending',
+            detail: connection?.region ? `Default region ${connection.region}` : `Default region ${awsForm.region || 'us-east-1'}`,
+            tone: connection?.account_id ? 'success' : 'info'
+          }
+        ]}
+      />
+
+      {loadingConnection || environmentScope.loading ? <DomainLoadingState label="Loading AWS setup state" /> : null}
+
+      {!selectedEnvironmentID && !environmentScope.loading ? (
+        <DomainEmptyState
+          eyebrow="Environment required"
+          title="Create an environment before connecting AWS"
+          body="The AWS connector still writes through workspace and project-scoped APIs. Pick or create an environment, then return to this page."
+          nextAction={{ label: 'Open environments', to: buildProjectsPath(scope) }}
+        />
+      ) : null}
+
+      {successMessage ? (
+        <p role="status" className="idt-app-alert idt-app-alert-success">
+          {successMessage}
+        </p>
+      ) : null}
+      {errorMessage ? (
+        <p role="alert" className="idt-app-alert idt-app-alert-error">
+          {errorMessage}
+        </p>
+      ) : null}
+
+      {selectedEnvironmentID ? (
+        <div className="idt-aws-connect-layout">
+          <section className="idt-source-config idt-aws-connect-panel" aria-label="AWS connector setup">
+            <div className="idt-source-config-header">
+              <div className="idt-source-config-title">
+                <SourceLogoMark provider="aws" className="is-hero" />
+                <div>
+                  <p className="idt-app-kicker">Wired now</p>
+                  <h3>AWS read-only connector</h3>
+                  <p>Launch the role stack or validate an existing role ARN for this environment.</p>
+                </div>
+              </div>
+              <DomainStatusBadge variant={awsStatusVariant(connection)} detail={connection?.health_status ?? 'unknown'} />
+            </div>
+
+            <dl className="idt-source-meta">
+              <div>
+                <dt>Required access</dt>
+                <dd>Read-only IAM role ARN</dd>
+              </div>
+              <div>
+                <dt>Health</dt>
+                <dd>{connectionHealth(connection ?? undefined)}</dd>
+              </div>
+              <div>
+                <dt>Last validation</dt>
+                <dd>{formatConnectionTime(connection?.last_validated_at ?? connection?.updated_at)}</dd>
+              </div>
+            </dl>
+
+            <form className="idt-app-form idt-aws-connect-form" onSubmit={handleAWSSubmit}>
+              {FEATURE_CONNECTOR_AWS ? (
+                <article className="idt-source-install-card idt-aws-launch-card">
+                  <div>
+                    <h4>Launch read-only stack</h4>
+                    <p>
+                      {awsCloudFormationStart
+                        ? 'Stack launch generated with external ID and permission preview.'
+                        : 'Generate the IAM role, trust policy, and read-only permissions for this environment.'}
+                    </p>
+                  </div>
+                  <div className="idt-source-actions">
+                    <button
+                      className="idt-btn idt-btn-dark"
+                      type="button"
+                      onClick={handleAWSCloudFormationStart}
+                      disabled={!canSubmit}
+                    >
+                      {submitting ? 'Preparing...' : 'Launch stack'}
+                    </button>
+                    {awsCloudFormationStart ? (
+                      <a className="idt-btn idt-btn-dark" href={awsCloudFormationStart.launch_url} target="_blank" rel="noreferrer">
+                        <ExternalLink size={15} strokeWidth={1.8} aria-hidden="true" />
+                        <span>Open stack</span>
+                      </a>
+                    ) : null}
+                    {awsPermissionPreview.length > 0 ? (
+                      <button className="idt-btn idt-btn-ghost" type="button" onClick={() => setAWSPreviewOpen(true)}>
+                        Preview permissions
+                      </button>
+                    ) : null}
+                    {activeConnectorID ? (
+                      <button className="idt-btn idt-btn-ghost" type="button" onClick={handleAWSPoll} disabled={submitting}>
+                        {submitting ? 'Refreshing...' : 'Refresh status'}
+                      </button>
+                    ) : null}
+                  </div>
+                </article>
+              ) : (
+                <article className="idt-source-install-card idt-aws-launch-card">
+                  <div>
+                    <h4>CloudFormation launch unavailable</h4>
+                    <p>This build still supports direct role ARN validation and save.</p>
+                  </div>
+                </article>
+              )}
+
+              <label>
+                Role ARN
+                <input
+                  value={awsForm.roleARN}
+                  onChange={(event) => setAWSForm((current) => ({ ...current, roleARN: event.target.value }))}
+                  placeholder="arn:aws:iam::123456789012:role/IdentrailReadOnly"
+                  required
+                />
+              </label>
+              <div className="idt-source-inline-fields">
+                <label>
+                  External ID
+                  <input
+                    value={awsForm.externalID}
+                    onChange={(event) => setAWSForm((current) => ({ ...current, externalID: event.target.value }))}
+                    placeholder="optional trust-policy guard"
+                  />
+                </label>
+                <label>
+                  Region
+                  <input
+                    value={awsForm.region}
+                    onChange={(event) => setAWSForm((current) => ({ ...current, region: event.target.value }))}
+                    placeholder="us-east-1"
+                  />
+                </label>
+              </div>
+              <div className="idt-source-inline-fields">
+                {FEATURE_CONNECTOR_AWS ? (
+                  <>
+                    <label>
+                      Role name
+                      <input
+                        value={awsForm.roleName}
+                        onChange={(event) => setAWSForm((current) => ({ ...current, roleName: event.target.value }))}
+                        placeholder="IdentrailReadOnly"
+                      />
+                    </label>
+                    <label>
+                      Stack name
+                      <input
+                        value={awsForm.stackName}
+                        onChange={(event) => setAWSForm((current) => ({ ...current, stackName: event.target.value }))}
+                        placeholder="identrail-readonly-connector"
+                      />
+                    </label>
+                  </>
+                ) : null}
+                <label>
+                  Display name
+                  <input
+                    value={awsForm.displayName}
+                    onChange={(event) => setAWSForm((current) => ({ ...current, displayName: event.target.value }))}
+                    placeholder="Production AWS"
+                  />
+                </label>
+                <label>
+                  Session name
+                  <input
+                    value={awsForm.sessionName}
+                    onChange={(event) => setAWSForm((current) => ({ ...current, sessionName: event.target.value }))}
+                    placeholder="identrail-connector-validation"
+                  />
+                </label>
+              </div>
+              <button className="idt-btn idt-btn-primary" type="submit" disabled={!canSubmit}>
+                {submitting ? 'Validating...' : 'Validate and save AWS'}
+              </button>
+            </form>
+          </section>
+
+          <div className="idt-aws-connect-side">
+            <DomainStatusPanel
+              eyebrow="Validation"
+              title="Permission health and diagnostics"
+              status={awsDiagnosticSummary(connection)}
+              tone={statusTone === 'danger' ? 'danger' : statusTone}
+              actions={[{ label: 'Refresh status', onClick: () => void refreshConnection('manual'), disabled: refreshingConnection }]}
+            >
+              <div className="idt-source-diagnostics" aria-label="AWS permission diagnostics">
+                <AWSConnectionDiagnostics connection={connection} emptyLabel="Validate the role to populate permission checks." />
+              </div>
+            </DomainStatusPanel>
+
+            <DomainStatusPanel eyebrow="Coming later" title="AWS capability expansion" status="Labeled" tone="info">
+              <div className="idt-aws-mini-roadmap">
+                <span>Accounts / regions</span>
+                <span>Machine identities</span>
+                <span>Resources / secrets</span>
+                <span>Runtime evidence</span>
+                <span>Findings</span>
+                <span>Remediation</span>
+              </div>
+            </DomainStatusPanel>
+          </div>
+        </div>
+      ) : null}
+
+      <PermissionPreviewModal
+        open={awsPreviewOpen}
+        title="AWS read-only connector policy"
+        items={awsPermissionPreview}
+        tiers={awsPermissionTiers}
+        onClose={() => setAWSPreviewOpen(false)}
+      />
+    </DomainPageShell>
+  );
 }
 
 export function ProductKubernetesConnectPage() {
@@ -4199,6 +5112,7 @@ export function ProductGitHubRemediationPage() {
         return;
       }
       setRemediationPreview(preview);
+      setRemediationPreviewFindingKey(selectionKey);
       setRemediationPublishBaseBranch(preview.fix_pr_plan?.base_branch || 'main');
     } catch (requestError) {
       if (requestID !== remediationPreviewRequestRef.current) {
@@ -4306,8 +5220,6 @@ export function ProductGitHubRemediationPage() {
   }, [queueSelectionKeys, remediationQueue, selectedFinding, selectedFindingKey]);
 
   useEffect(() => {
-    remediationPreviewRequestRef.current += 1;
-    remediationPublishRequestRef.current += 1;
     setRemediationPreview(null);
     setRemediationPreviewFindingKey('');
     setRemediationPreviewLoading(false);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -23196,10 +23196,181 @@ html[data-theme='light'] .idt-app-shell-screen select {
   justify-content: flex-end;
 }
 
+.idt-aws-status-grid,
+.idt-aws-connect-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(18rem, 0.65fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.idt-aws-status-grid dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+  margin: 0;
+}
+
+.idt-aws-status-grid dl div,
+.idt-aws-next-actions article {
+  border: 1px solid var(--app-border-soft);
+  border-radius: 8px;
+  padding: 0.78rem;
+  background: #050505;
+}
+
+.idt-aws-status-grid dt {
+  color: var(--app-dim);
+  font-size: 0.72rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.idt-aws-status-grid dd {
+  min-width: 0;
+  margin: 0.18rem 0 0;
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 800;
+  overflow-wrap: anywhere;
+}
+
+.idt-aws-control-diagnostics {
+  margin: 0;
+}
+
+.idt-aws-control-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 0.75rem;
+}
+
+.idt-aws-capability-card {
+  display: grid;
+  gap: 0.55rem;
+  min-height: 12rem;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 0.9rem;
+  background: #080809;
+  color: var(--app-muted);
+  text-decoration: none;
+}
+
+.idt-aws-capability-card:hover,
+.idt-aws-capability-card:focus-visible {
+  border-color: rgba(255, 255, 255, 0.32);
+  background: #111113;
+  color: #ffffff;
+  outline: none;
+}
+
+.idt-aws-capability-card.is-wired {
+  border-color: rgba(88, 214, 141, 0.36);
+}
+
+.idt-aws-capability-card.is-coming {
+  border-color: rgba(255, 153, 0, 0.34);
+}
+
+.idt-aws-capability-card > strong {
+  color: #ffffff;
+  font-size: 1rem;
+}
+
+.idt-aws-capability-card > span:not(.idt-domain-status-badge) {
+  color: var(--app-dim);
+  font-size: 0.76rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.idt-aws-capability-card p {
+  margin: 0;
+  color: var(--app-muted);
+  font-size: 0.86rem;
+}
+
+.idt-aws-next-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.idt-aws-next-actions strong {
+  color: #ffffff;
+}
+
+.idt-aws-next-actions p {
+  margin-top: 0.22rem;
+}
+
+.idt-aws-connect-panel {
+  min-width: 0;
+}
+
+.idt-app-console-layout .idt-aws-connect-panel .idt-source-meta {
+  grid-template-columns: minmax(0, 1fr) minmax(8rem, 0.55fr) minmax(12.5rem, 0.8fr);
+}
+
+.idt-aws-connect-form {
+  gap: 0.85rem;
+}
+
+.idt-aws-connect-side {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.idt-aws-mini-roadmap {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.idt-aws-mini-roadmap span {
+  border: 1px solid var(--app-border-soft);
+  border-radius: 999px;
+  padding: 0.3rem 0.55rem;
+  background: #050505;
+  color: var(--app-muted);
+  font-size: 0.76rem;
+  font-weight: 850;
+}
+
+html[data-theme='light'] .idt-app-console-layout .idt-permission-preview-modal,
+html[data-theme='light'] .idt-app-console-layout .idt-permission-preview-list article,
+html[data-theme='light'] .idt-app-console-layout .idt-permission-tier {
+  border-color: var(--app-border);
+  background: #080809;
+}
+
+html[data-theme='light'] .idt-app-console-layout .idt-permission-preview-modal h3,
+html[data-theme='light'] .idt-app-console-layout .idt-permission-preview-list strong,
+html[data-theme='light'] .idt-app-console-layout .idt-permission-tier strong {
+  color: #ffffff;
+}
+
+html[data-theme='light'] .idt-app-console-layout .idt-permission-preview-modal p,
+html[data-theme='light'] .idt-app-console-layout .idt-permission-preview-list p,
+html[data-theme='light'] .idt-app-console-layout .idt-permission-tier p {
+  color: var(--app-muted);
+}
+
+html[data-theme='light'] .idt-app-console-layout .idt-permission-preview-list code,
+html[data-theme='light'] .idt-app-console-layout .idt-permission-tier .idt-badge {
+  color: #b9d7ff;
+}
+
 @media (max-width: 1100px) {
   .idt-domain-header,
   .idt-domain-page-body.has-subnav,
-  .idt-domain-page-body.has-subnav.has-aside {
+  .idt-domain-page-body.has-subnav.has-aside,
+  .idt-aws-status-grid,
+  .idt-aws-connect-layout,
+  .idt-app-console-layout .idt-aws-connect-panel .idt-source-meta,
+  .idt-aws-next-actions {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
Fixes #1385

## What changed
- Added a first-class AWS Control Center at `/app/:tenantID/:workspaceID/aws`.
- Moved AWS connector setup and status into `/app/:tenantID/:workspaceID/aws/connect` without redirecting through Projects.
- Preserved CloudFormation launch, role ARN validation, external ID, region and naming fields, permission preview tiers, polling, diagnostics, backend feature availability checks, and workspace/project-scoped payloads.
- Added premium AWS-specific control center, setup, diagnostics, and permission modal styling.
- Updated route and product shell tests for the new domain-owned AWS behavior.
- Kept a small GitHub remediation preview race fix required after the latest `dev` merge, so the current `dev` test suite stays green.

## Why
AWS is becoming a machine-identity product surface, not just a project connector. This gives account, region, inventory, runtime, findings, remediation, and governance work a durable AWS home while keeping unsupported capabilities clearly labeled.

## Impact and risk
- AWS connector API contracts remain workspace/project scoped.
- `/aws/connect` now owns the AWS setup experience instead of redirecting to `/projects/:projectID?source=aws`.
- Later AWS subsection pages remain clearly labeled as coming or not yet available.

## Validation
- `npm --prefix web test -- --run src/productShell.test.tsx src/App.test.tsx` - 143 tests passed.
- `npm run test:ci --prefix web` - 284 tests passed; line coverage 80.36%.
- `npm run build --prefix web` - TypeScript, Vite build, and prerender passed; 39 routes prerendered.
- Visual QA with local Vite plus mock API: AWS Control Center, Connect AWS, and permission preview rendered correctly; browser console errors: none.
- GitHub PR checks: DCO, Web Build, Go Quality, Go Tests, Go Integration (Postgres), Deploy Portability, Vercel, CodeQL, dependency review, gitleaks, OSV, and linked-issue checks are passing.

AI-assisted: yes