### PR TITLE
Implement AWS inventory pages

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,9 +29,13 @@ import {
   ProductAppIndexRedirect,
   ProductAuthCallbackRedirectPage,
   ProductAIRisksPage,
+  ProductAWSAccountsPage,
+  ProductAWSAgentsPage,
   ProductAWSControlCenterPage,
   ProductDomainRoutePage,
   ProductAWSConnectPage,
+  ProductAWSIdentitiesPage,
+  ProductAWSResourcesPage,
   ProductExecutiveReportPage,
   ProductFindingsPage,
   ProductGitHubActionsPage,
@@ -4779,10 +4783,10 @@ export function RoutedSite() {
             <Route path="ai-risks" element={<LegacyScopedAppRedirect target="github/agentic-risk" />} />
             <Route path="aws" element={<ProductAWSControlCenterPage />} />
             <Route path="aws/connect" element={<ProductAWSConnectPage />} />
-            <Route path="aws/accounts" element={<ProductDomainRoutePage domain="aws" routeID="accounts" />} />
-            <Route path="aws/identities" element={<ProductDomainRoutePage domain="aws" routeID="identities" />} />
-            <Route path="aws/agents" element={<ProductDomainRoutePage domain="aws" routeID="agents" />} />
-            <Route path="aws/resources" element={<ProductDomainRoutePage domain="aws" routeID="resources" />} />
+            <Route path="aws/accounts" element={<ProductAWSAccountsPage />} />
+            <Route path="aws/identities" element={<ProductAWSIdentitiesPage />} />
+            <Route path="aws/agents" element={<ProductAWSAgentsPage />} />
+            <Route path="aws/resources" element={<ProductAWSResourcesPage />} />
             <Route path="aws/runtime" element={<ProductDomainRoutePage domain="aws" routeID="runtime" />} />
             <Route path="aws/graph" element={<ProductDomainRoutePage domain="aws" routeID="graph" />} />
             <Route path="aws/findings" element={<ProductDomainRoutePage domain="aws" routeID="findings" />} />

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -1063,6 +1063,142 @@ describe('Domain-first app routes', () => {
     expect(screen.queryByText('Production AWS')).not.toBeInTheDocument();
   });
 
+  it('renders AWS account and region inventory with current connector coverage', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+
+    const { ProductAWSAccountsPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/accounts?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/accounts" element={<ProductAWSAccountsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 2, name: 'AWS accounts and regions' })).toBeInTheDocument();
+    expect(screen.getByRole('table', { name: 'AWS account and region coverage' })).toBeInTheDocument();
+    expect(screen.getAllByText(/AWS account 123456789012/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Region us-east-1/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole('link', { name: /Open Connect AWS/i })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/aws/connect?environment=production'
+    );
+  });
+
+  it('renders AWS machine identity inventory with the current IAM role and future workload rows', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: connectedAWS });
+
+    const { ProductAWSIdentitiesPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/identities?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/identities" element={<ProductAWSIdentitiesPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 2, name: 'AWS machine identities' })).toBeInTheDocument();
+    expect(screen.getByRole('search', { name: /AWS machine identities filters/i })).toBeInTheDocument();
+    expect(screen.getByRole('table', { name: 'AWS machine identity inventory' })).toBeInTheDocument();
+    expect(screen.getAllByText('arn:aws:iam::123456789012:role/IdentrailReadOnly').length).toBeGreaterThan(0);
+    expect(screen.getByText(/EC2 instance profiles/i)).toBeInTheDocument();
+    expect(screen.getByText(/Risk score/i)).toBeInTheDocument();
+    expect(screen.getByText(/Unscored until AWS findings land/i)).toBeInTheDocument();
+  });
+
+  it('renders AWS agent identity inventory as an honest reserved surface', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({
+      items: [
+        {
+          tenant_id: 'tenant-a',
+          workspace_id: 'workspace-a',
+          project_id: 'production',
+          name: 'Production',
+          slug: 'production',
+          description: 'Production AWS boundary.',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z'
+        }
+      ]
+    });
+    vi.spyOn(api.apiClient, 'getAWSProjectConnection').mockResolvedValue({ connection: disconnectedAWS });
+
+    const { ProductAWSAgentsPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/agents?environment=production']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/agents" element={<ProductAWSAgentsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 2, name: 'AWS agent identities' })).toBeInTheDocument();
+    expect(screen.getAllByText(/Connect AWS to populate current inventory anchors/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Bedrock agents/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/AgentCore runtime and gateway identity/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Secret metadata only, no value reads/i)).toBeInTheDocument();
+  });
+
+  it('keeps AWS resources inventory metadata-only when no environment exists', async () => {
+    const api = await import('./api/client');
+    vi.spyOn(api.apiClient, 'listProjects').mockResolvedValue({ items: [] });
+    const getAWSProjectConnection = vi.spyOn(api.apiClient, 'getAWSProjectConnection');
+
+    const { ProductAWSResourcesPage } = await import('./productShell');
+
+    render(
+      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/aws/resources']}>
+        <Routes>
+          <Route path="/app/:tenantID/:workspaceID/aws/resources" element={<ProductAWSResourcesPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { level: 2, name: 'AWS resources and credentials' })).toBeInTheDocument();
+    expect(screen.getByText(/Create an environment before inventory can resolve/i)).toBeInTheDocument();
+    expect(screen.getByText(/No secret value reads/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Secrets Manager metadata/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole('link', { name: /Open environments/i })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/projects?source=aws'
+    );
+    expect(getAWSProjectConnection).not.toHaveBeenCalled();
+  });
+
   it('keeps AWS connect on the domain page when no environment exists', async () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     const api = await import('./api/client');

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -2834,8 +2834,7 @@ const AWS_INVENTORY_FILTERS: AWSInventoryFilterConfigMap = {
         { label: 'All relationships', value: 'all' },
         { label: 'Agent to role', value: 'agent-to-role' },
         { label: 'Agent to tool', value: 'agent-to-tool' },
-        { label: 'Agent to secret', value: 'agent-to-secret' },
-        { label: 'Agent to user', value: 'agent-to-user' }
+        { label: 'Agent to secret', value: 'agent-to-secret' }
       ]
     },
     {
@@ -2863,7 +2862,6 @@ const AWS_INVENTORY_FILTERS: AWSInventoryFilterConfigMap = {
       options: [
         { label: 'All sensitivity', value: 'all' },
         { label: 'Credential reference', value: 'credential-reference' },
-        { label: 'Production', value: 'production' },
         { label: 'Customer data', value: 'customer-data' },
         { label: 'Secret-bearing', value: 'secret-bearing' },
         { label: 'KMS-admin', value: 'kms-admin' },

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -2768,9 +2768,9 @@ function useAWSInventoryData(): AWSInventoryDataState {
     const requestID = ++connectionRequestRef.current;
     const requestEnvironmentID = selectedEnvironmentID;
     const requestScopeKey = scopeKeyRef.current;
+    setConnection(null);
+    setConnectionError('');
     if (!scope || !requestEnvironmentID) {
-      setConnection(null);
-      setConnectionError('');
       setConnectionLoading(false);
       return;
     }
@@ -3123,7 +3123,7 @@ function AWSMachineIdentitiesContent({ connection }: { connection: AWSConnection
             category: 'IAM role',
             scope: awsAccountRegionLabel(connection),
             status: connection.connected ? 'wired now' : 'pending validation',
-            stage: 'wired' as AWSCapabilityStage,
+            stage: connection.connected ? ('wired' as AWSCapabilityStage) : ('coming' as AWSCapabilityStage),
             detail: connection.principal_arn ?? 'Role principal will appear after validation.'
           }
         ]

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1,4 +1,4 @@
-import { Component, FormEvent, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ChangeEvent, Component, FormEvent, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type {
   CSSProperties,
   KeyboardEvent as ReactKeyboardEvent,
@@ -2727,7 +2727,27 @@ type AWSInventoryDataState = {
   refreshConnection: () => void;
 };
 
-type AWSInventoryTableRow = {
+type AWSInventoryFilterState = Record<string, string>;
+
+type AWSInventoryFilterConfigOption = {
+  label: string;
+  value: string;
+};
+
+type AWSInventoryFilterConfig = {
+  id: string;
+  label: string;
+  options: AWSInventoryFilterConfigOption[];
+};
+
+type AWSInventoryFilterConfigMap = Record<AWSInventoryRouteID, AWSInventoryFilterConfig[]>;
+
+type AWSInventoryFilterable = {
+  filters: Record<string, string>;
+  searchText: string;
+};
+
+type AWSInventoryTableRow = AWSInventoryFilterable & {
   id: string;
   name: string;
   category: string;
@@ -2737,7 +2757,7 @@ type AWSInventoryTableRow = {
   detail: string;
 };
 
-type AWSInventoryCoverageRow = {
+type AWSInventoryCoverageRow = AWSInventoryFilterable & {
   id: string;
   category: string;
   coverage: string;
@@ -2745,6 +2765,149 @@ type AWSInventoryCoverageRow = {
   status: string;
   detail: string;
 };
+
+const AWS_INVENTORY_FILTER_DEFAULTS: Record<AWSInventoryRouteID, AWSInventoryFilterState> = {
+  accounts: { account: 'all', region: 'all', coverage: 'all', search: '' },
+  identities: { identityType: 'all', service: 'all', risk: 'all', status: 'all', search: '' },
+  agents: { surface: 'all', relationship: 'all', status: 'all', search: '' },
+  resources: { category: 'all', sensitivity: 'all', readPosture: 'all', search: '' }
+};
+
+const AWS_INVENTORY_FILTERS: AWSInventoryFilterConfigMap = {
+  accounts: [
+    { id: 'account', label: 'Account', options: [{ label: 'All accounts', value: 'all' }, { label: 'Connected account', value: 'connected' }, { label: 'Planned accounts', value: 'planned' }] },
+    { id: 'region', label: 'Region', options: [{ label: 'All regions', value: 'all' }, { label: 'Current region', value: 'current' }, { label: 'Uncovered regions', value: 'uncovered' }] },
+    {
+      id: 'coverage',
+      label: 'Coverage',
+      options: [
+        { label: 'All coverage', value: 'all' },
+        { label: 'Covered', value: 'covered' },
+        { label: 'Missing', value: 'missing' },
+        { label: 'Degraded', value: 'degraded' },
+        { label: 'Not yet available', value: 'not-yet-available' }
+      ]
+    }
+  ],
+  identities: [
+    {
+      id: 'identityType',
+      label: 'Identity type',
+      options: [
+        { label: 'All types', value: 'all' },
+        { label: 'IAM role', value: 'iam-role' },
+        { label: 'Instance profile', value: 'instance-profile' },
+        { label: 'ECS task role', value: 'ecs-task-role' },
+        { label: 'Lambda role', value: 'lambda-role' },
+        { label: 'EKS identity', value: 'eks-identity' },
+        { label: 'CI/CD role', value: 'cicd-role' }
+      ]
+    },
+    { id: 'service', label: 'Service', options: [{ label: 'All services', value: 'all' }, { label: 'IAM', value: 'iam' }, { label: 'EC2', value: 'ec2' }, { label: 'ECS', value: 'ecs' }, { label: 'Lambda', value: 'lambda' }, { label: 'EKS', value: 'eks' }, { label: 'OIDC', value: 'oidc' }] },
+    {
+      id: 'risk',
+      label: 'Risk',
+      options: [{ label: 'All risk', value: 'all' }, { label: 'Unscored', value: 'unscored' }, { label: 'High', value: 'high' }, { label: 'Medium', value: 'medium' }, { label: 'Low', value: 'low' }]
+    },
+    {
+      id: 'status',
+      label: 'Status',
+      options: [{ label: 'All status', value: 'all' }, { label: 'Wired now', value: 'wired-now' }, { label: 'Coming', value: 'coming' }, { label: 'Not yet available', value: 'not-yet-available' }]
+    }
+  ],
+  agents: [
+    {
+      id: 'surface',
+      label: 'Agent surface',
+      options: [
+        { label: 'All surfaces', value: 'all' },
+        { label: 'Bedrock agents', value: 'bedrock-agents' },
+        { label: 'AgentCore runtime', value: 'agentcore-runtime' },
+        { label: 'MCP gateway', value: 'mcp-gateway' },
+        { label: 'External provider keys', value: 'external-provider-keys' }
+      ]
+    },
+    {
+      id: 'relationship',
+      label: 'Relationship',
+      options: [
+        { label: 'All relationships', value: 'all' },
+        { label: 'Agent to role', value: 'agent-to-role' },
+        { label: 'Agent to tool', value: 'agent-to-tool' },
+        { label: 'Agent to secret', value: 'agent-to-secret' },
+        { label: 'Agent to user', value: 'agent-to-user' }
+      ]
+    },
+    {
+      id: 'status',
+      label: 'Status',
+      options: [{ label: 'All status', value: 'all' }, { label: 'Role anchor', value: 'role-anchor' }, { label: 'Coming', value: 'coming' }, { label: 'Not yet available', value: 'not-yet-available' }]
+    }
+  ],
+  resources: [
+    {
+      id: 'category',
+      label: 'Category',
+      options: [
+        { label: 'All categories', value: 'all' },
+        { label: 'Secrets Manager', value: 'secrets-manager' },
+        { label: 'SSM Parameter', value: 'ssm-parameter' },
+        { label: 'KMS', value: 'kms' },
+        { label: 'S3', value: 's3' },
+        { label: 'Control plane', value: 'control-plane' }
+      ]
+    },
+    {
+      id: 'sensitivity',
+      label: 'Sensitivity',
+      options: [
+        { label: 'All sensitivity', value: 'all' },
+        { label: 'Production', value: 'production' },
+        { label: 'Customer data', value: 'customer-data' },
+        { label: 'Secret-bearing', value: 'secret-bearing' },
+        { label: 'KMS-admin', value: 'kms-admin' },
+        { label: 'Control-plane', value: 'control-plane' }
+      ]
+    },
+    {
+      id: 'readPosture',
+      label: 'Read posture',
+      options: [{ label: 'All postures', value: 'all' }, { label: 'Metadata only', value: 'metadata-only' }, { label: 'No secret values', value: 'no-secret-values' }]
+    }
+  ]
+};
+
+function normalizeFilterValue(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function inventorySearchText(parts: Array<string | undefined>): string {
+  return parts
+    .filter((value): value is string => Boolean(value && value.length > 0))
+    .join(' ')
+    .toLowerCase();
+}
+
+function filterAWSInventoryRows<RowType extends AWSInventoryFilterable>(rows: RowType[], filters: AWSInventoryFilterState): RowType[] {
+  const query = normalizeFilterValue(filters.search ?? '');
+  return rows.filter((row) => {
+    for (const [filterID, selectedValue] of Object.entries(filters)) {
+      if (filterID === 'search') {
+        continue;
+      }
+      if (!selectedValue || selectedValue === 'all') {
+        continue;
+      }
+      if ((row.filters[filterID] ?? 'all') !== selectedValue) {
+        return false;
+      }
+    }
+    if (!query) {
+      return true;
+    }
+    return row.searchText.includes(query);
+  });
+}
 
 function useAWSInventoryData(): AWSInventoryDataState {
   const params = useParams<ScopeRouteParams>();
@@ -2865,46 +3028,43 @@ function AWSInventoryPill({
   return <span className={`idt-aws-inventory-pill is-${awsInventoryPillTone(stage)}`}>{label ?? awsStageLabel(stage)}</span>;
 }
 
-function AWSInventoryFilterSet({ routeID }: { routeID: AWSInventoryRouteID }) {
-  const routeFilters: Record<AWSInventoryRouteID, Array<{ label: string; value: string; options: string[] }>> = {
-    accounts: [
-      { label: 'Account', value: 'all', options: ['All accounts', 'Connected account', 'Planned accounts'] },
-      { label: 'Region', value: 'all', options: ['All regions', 'Current region', 'Uncovered regions'] },
-      { label: 'Coverage', value: 'all', options: ['All coverage', 'Covered', 'Missing', 'Degraded', 'Not yet available'] }
-    ],
-    identities: [
-      { label: 'Identity type', value: 'all', options: ['All types', 'IAM role', 'Instance profile', 'ECS task role', 'Lambda role', 'EKS identity', 'CI/CD role'] },
-      { label: 'Service', value: 'all', options: ['All services', 'IAM', 'EC2', 'ECS', 'Lambda', 'EKS', 'OIDC'] },
-      { label: 'Risk', value: 'all', options: ['All risk', 'Unscored', 'High', 'Medium', 'Low'] },
-      { label: 'Status', value: 'all', options: ['All status', 'Wired now', 'Coming', 'Not yet available'] }
-    ],
-    agents: [
-      { label: 'Agent surface', value: 'all', options: ['All surfaces', 'Bedrock agents', 'AgentCore runtime', 'MCP gateway', 'External provider keys'] },
-      { label: 'Relationship', value: 'all', options: ['All relationships', 'Agent to role', 'Agent to tool', 'Agent to secret', 'Agent to user'] },
-      { label: 'Status', value: 'all', options: ['All status', 'Role anchor', 'Coming', 'Not yet available'] }
-    ],
-    resources: [
-      { label: 'Category', value: 'all', options: ['All categories', 'Secrets Manager', 'SSM Parameter', 'KMS', 'S3', 'Control plane'] },
-      { label: 'Sensitivity', value: 'all', options: ['All sensitivity', 'Production', 'Customer data', 'Secret-bearing', 'KMS-admin', 'Control-plane'] },
-      { label: 'Read posture', value: 'metadata', options: ['Metadata only', 'No secret values'] }
-    ]
-  };
+function AWSInventoryFilterSet({
+  routeID,
+  filters,
+  onChange
+}: {
+  routeID: AWSInventoryRouteID;
+  filters: AWSInventoryFilterState;
+  onChange: (nextFilters: AWSInventoryFilterState) => void;
+}) {
   const searchPlaceholder: Record<AWSInventoryRouteID, string> = {
     accounts: 'Search account or region',
     identities: 'Search identity ARN',
     agents: 'Search agent surface',
     resources: 'Search resource metadata'
   };
+  const onFilterChange = (id: string, value: string): void => {
+    onChange({
+      ...filters,
+      [id]: value
+    });
+  };
+  const onSearchChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    onChange({
+      ...filters,
+      search: event.target.value
+    });
+  };
 
   return (
     <DomainFilterBar label={`${AWS_INVENTORY_PAGE_COPY[routeID].title} filters`}>
-      {routeFilters[routeID].map((filter) => (
+      {AWS_INVENTORY_FILTERS[routeID].map((filter) => (
         <label key={filter.label}>
           {filter.label}
-          <select defaultValue={filter.value}>
-            {filter.options.map((option, index) => (
-              <option key={option} value={index === 0 ? filter.value : option.toLowerCase().replace(/[^a-z0-9]+/g, '-')}>
-                {option}
+          <select value={filters[filter.id] ?? 'all'} onChange={(event) => onFilterChange(filter.id, event.target.value)}>
+            {filter.options.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
               </option>
             ))}
           </select>
@@ -2912,7 +3072,12 @@ function AWSInventoryFilterSet({ routeID }: { routeID: AWSInventoryRouteID }) {
       ))}
       <label>
         Search
-        <input placeholder={searchPlaceholder[routeID]} />
+        <input
+          placeholder={searchPlaceholder[routeID]}
+          value={filters.search ?? ''}
+          onChange={onSearchChange}
+          aria-label={`${AWS_INVENTORY_PAGE_COPY[routeID].title} search`}
+        />
       </label>
     </DomainFilterBar>
   );
@@ -3036,19 +3201,32 @@ function AWSInventoryPrerequisites({
 
 function AWSAccountsInventoryContent({
   connection,
-  connectPath
+  connectPath,
+  filters,
+  onFiltersChange
 }: {
   connection: AWSConnectionStatus | null;
   connectPath: string;
+  filters: AWSInventoryFilterState;
+  onFiltersChange: (nextFilters: AWSInventoryFilterState) => void;
 }) {
+  const accountCoverage = awsCoverageState(connection);
+  const currentCoverageFilter = accountCoverage === 'covered' ? 'covered' : accountCoverage === 'degraded' ? 'degraded' : 'missing';
   const rows: AWSInventoryCoverageRow[] = [
     {
       id: 'current-account',
       category: connection?.account_id ? `AWS account ${connection.account_id}` : 'Selected AWS account',
-      coverage: awsCoverageState(connection),
+      coverage: accountCoverage,
       source: connection?.display_name ?? 'Connect AWS',
       status: connection?.connected ? 'covered' : 'missing',
-      detail: connection?.region ? `Validated in ${connection.region}` : 'Region coverage starts after validation.'
+      detail: connection?.region ? `Validated in ${connection.region}` : 'Region coverage starts after validation.',
+      filters: {
+        account: connection?.account_id ? 'connected' : 'planned',
+        region: connection?.region ? 'current' : 'uncovered',
+        coverage: currentCoverageFilter,
+        search: ''
+      },
+      searchText: inventorySearchText([connection?.account_id, connection?.region, connection?.display_name, 'current account', 'covered', 'missing'])
     },
     {
       id: 'current-region',
@@ -3056,7 +3234,14 @@ function AWSAccountsInventoryContent({
       coverage: connection?.region ? 'covered' : 'missing',
       source: 'AWS connector payload',
       status: connection?.region ? 'covered' : 'missing',
-      detail: connection?.last_validated_at ? `Last validation ${formatConnectionTime(connection.last_validated_at)}` : 'No validation time yet.'
+      detail: connection?.last_validated_at ? `Last validation ${formatConnectionTime(connection.last_validated_at)}` : 'No validation time yet.',
+      filters: {
+        account: connection?.account_id ? 'connected' : 'planned',
+        region: connection?.region ? 'current' : 'uncovered',
+        coverage: connection?.region ? 'covered' : 'missing',
+        search: ''
+      },
+      searchText: inventorySearchText([connection?.region, 'region', 'coverage', 'region coverage'])
     },
     {
       id: 'org-planner',
@@ -3064,7 +3249,19 @@ function AWSAccountsInventoryContent({
       coverage: 'not yet available',
       source: 'Future AWS inventory API',
       status: 'not yet available',
-      detail: 'Will track account enrollment, incremental cursors, and partial account failure.'
+      detail: 'Will track account enrollment, incremental cursors, and partial account failure.',
+      filters: {
+        account: 'planned',
+        region: 'uncovered',
+        coverage: 'not-yet-available',
+        search: ''
+      },
+      searchText: inventorySearchText([
+        'organization',
+        'planner',
+        'account',
+        'not yet available'
+      ])
     },
     {
       id: 'region-planner',
@@ -3072,15 +3269,30 @@ function AWSAccountsInventoryContent({
       coverage: 'not yet available',
       source: 'Future AWS inventory API',
       status: 'not yet available',
-      detail: 'Will track service-by-region coverage and degraded or unreachable regions.'
+      detail: 'Will track service-by-region coverage and degraded or unreachable regions.',
+      filters: {
+        account: 'planned',
+        region: 'uncovered',
+        coverage: 'not-yet-available',
+        search: ''
+      },
+      searchText: inventorySearchText([
+        'multi-region',
+        'planner',
+        'coverage',
+        'not yet available',
+        'degraded',
+        'region'
+      ])
     }
   ];
   const passedChecks = connection?.permission_checks.filter((check) => check.passed).length ?? 0;
   const totalChecks = connection?.permission_checks.length ?? 0;
+  const displayedRows = filterAWSInventoryRows(rows, filters);
 
   return (
     <>
-      <AWSInventoryFilterSet routeID="accounts" />
+      <AWSInventoryFilterSet routeID="accounts" filters={filters} onChange={onFiltersChange} />
       <section className="idt-aws-inventory-coverage" aria-label="AWS account and region coverage map">
         <DomainCoverageCard label="Account coverage" scanned={connection?.account_id ? 1 : 0} total={1} detail="Selected environment" />
         <DomainCoverageCard label="Region coverage" scanned={connection?.region ? 1 : 0} total={1} detail={connection?.region ?? 'Pending'} />
@@ -3088,7 +3300,7 @@ function AWSAccountsInventoryContent({
       </section>
       <DomainDataTable
         label="AWS account and region coverage"
-        rows={rows}
+        rows={displayedRows}
         getRowKey={(row) => row.id}
         columns={[
           { key: 'category', header: 'Coverage scope', render: (row) => <strong>{row.category}</strong> },
@@ -3113,7 +3325,15 @@ function AWSAccountsInventoryContent({
   );
 }
 
-function AWSMachineIdentitiesContent({ connection }: { connection: AWSConnectionStatus | null }) {
+function AWSMachineIdentitiesContent({
+  connection,
+  filters,
+  onFiltersChange
+}: {
+  connection: AWSConnectionStatus | null;
+  filters: AWSInventoryFilterState;
+  onFiltersChange: (nextFilters: AWSInventoryFilterState) => void;
+}) {
   const rows: AWSInventoryTableRow[] = [
     ...(connection?.role_arn
       ? [
@@ -3124,7 +3344,15 @@ function AWSMachineIdentitiesContent({ connection }: { connection: AWSConnection
             scope: awsAccountRegionLabel(connection),
             status: connection.connected ? 'wired now' : 'pending validation',
             stage: connection.connected ? ('wired' as AWSCapabilityStage) : ('coming' as AWSCapabilityStage),
-            detail: connection.principal_arn ?? 'Role principal will appear after validation.'
+            detail: connection.principal_arn ?? 'Role principal will appear after validation.',
+            filters: {
+              identityType: 'iam-role',
+              service: 'iam',
+              risk: 'unscored',
+              status: connection.connected ? 'wired-now' : 'coming',
+              search: ''
+            },
+            searchText: inventorySearchText([connection.role_arn, awsAccountRegionLabel(connection), 'iam', 'identity'])
           }
         ]
       : []),
@@ -3135,7 +3363,9 @@ function AWSMachineIdentitiesContent({ connection }: { connection: AWSConnection
       scope: 'Account and region expansion',
       status: 'coming',
       stage: 'coming',
-      detail: 'Instance profile inventory will map roles back to EC2 workloads.'
+      detail: 'Instance profile inventory will map roles back to EC2 workloads.',
+      filters: { identityType: 'instance-profile', service: 'ec2', risk: 'unscored', status: 'coming', search: '' },
+      searchText: inventorySearchText(['ec2', 'instance profile', 'workload identity', 'inventory'])
     },
     {
       id: 'ecs-lambda',
@@ -3144,7 +3374,9 @@ function AWSMachineIdentitiesContent({ connection }: { connection: AWSConnection
       scope: 'ECS / Lambda',
       status: 'coming',
       stage: 'coming',
-      detail: 'Future collectors will identify workload ownership and attached policies.'
+      detail: 'Future collectors will identify workload ownership and attached policies.',
+      filters: { identityType: 'ecs-task-role', service: 'ecs', risk: 'unscored', status: 'coming', search: '' },
+      searchText: inventorySearchText(['ecs', 'lambda', 'task roles', 'execution roles', 'service identity'])
     },
     {
       id: 'eks-irsa',
@@ -3153,7 +3385,9 @@ function AWSMachineIdentitiesContent({ connection }: { connection: AWSConnection
       scope: 'EKS',
       status: 'coming',
       stage: 'coming',
-      detail: 'EKS identity mapping belongs here once Kubernetes and AWS graphs join.'
+      detail: 'EKS identity mapping belongs here once Kubernetes and AWS graphs join.',
+      filters: { identityType: 'eks-identity', service: 'eks', risk: 'unscored', status: 'coming', search: '' },
+      searchText: inventorySearchText(['eks', 'irsa', 'pod identity', 'federated identity'])
     },
     {
       id: 'cicd-oidc',
@@ -3162,17 +3396,20 @@ function AWSMachineIdentitiesContent({ connection }: { connection: AWSConnection
       scope: 'GitHub and external CI',
       status: 'coming',
       stage: 'coming',
-      detail: 'Deployment trust paths will connect repository evidence to AWS role assumption.'
+      detail: 'Deployment trust paths will connect repository evidence to AWS role assumption.',
+      filters: { identityType: 'cicd-role', service: 'oidc', risk: 'unscored', status: 'coming', search: '' },
+      searchText: inventorySearchText(['ci', 'cd', 'cicd', 'oidc'])
     }
   ];
+  const displayedRows = filterAWSInventoryRows(rows, filters);
 
   return (
     <>
-      <AWSInventoryFilterSet routeID="identities" />
+      <AWSInventoryFilterSet routeID="identities" filters={filters} onChange={onFiltersChange} />
       <section className="idt-aws-inventory-split">
         <DomainDataTable
           label="AWS machine identity inventory"
-          rows={rows}
+          rows={displayedRows}
           getRowKey={(row) => row.id}
           columns={[
             {
@@ -3215,7 +3452,15 @@ function AWSMachineIdentitiesContent({ connection }: { connection: AWSConnection
   );
 }
 
-function AWSAgentIdentitiesContent({ connection }: { connection: AWSConnectionStatus | null }) {
+function AWSAgentIdentitiesContent({
+  connection,
+  filters,
+  onFiltersChange
+}: {
+  connection: AWSConnectionStatus | null;
+  filters: AWSInventoryFilterState;
+  onFiltersChange: (nextFilters: AWSInventoryFilterState) => void;
+}) {
   const rows: AWSInventoryTableRow[] = [
     {
       id: 'role-anchor',
@@ -3224,7 +3469,14 @@ function AWSAgentIdentitiesContent({ connection }: { connection: AWSConnectionSt
       scope: awsAccountRegionLabel(connection),
       status: connection?.role_arn ? 'role anchor' : 'not yet available',
       stage: connection?.role_arn ? 'wired' : 'not-available',
-      detail: 'Future agent inventory can attach Bedrock or external agent execution back to this AWS role context.'
+      detail: 'Future agent inventory can attach Bedrock or external agent execution back to this AWS role context.',
+      filters: {
+        surface: 'agentcore-runtime',
+        relationship: 'agent-to-role',
+        status: connection?.role_arn ? 'role-anchor' : 'not-yet-available',
+        search: ''
+      },
+      searchText: inventorySearchText(['agent to role', 'agent', 'role anchor', 'role relationship'])
     },
     {
       id: 'bedrock-agents',
@@ -3233,7 +3485,9 @@ function AWSAgentIdentitiesContent({ connection }: { connection: AWSConnectionSt
       scope: 'Bedrock',
       status: 'coming',
       stage: 'coming',
-      detail: 'Agent identity, action groups, tool use, and role relationship slots are reserved here.'
+      detail: 'Agent identity, action groups, tool use, and role relationship slots are reserved here.',
+      filters: { surface: 'bedrock-agents', relationship: 'agent-to-tool', status: 'coming', search: '' },
+      searchText: inventorySearchText(['bedrock', 'agent surface', 'tools'])
     },
     {
       id: 'agentcore',
@@ -3242,7 +3496,9 @@ function AWSAgentIdentitiesContent({ connection }: { connection: AWSConnectionSt
       scope: 'Runtime / gateway',
       status: 'coming',
       stage: 'coming',
-      detail: 'Will map AgentCore runtime, gateway, identity metadata, MCP gateway, and tool relationships.'
+      detail: 'Will map AgentCore runtime, gateway, identity metadata, MCP gateway, and tool relationships.',
+      filters: { surface: 'agentcore-runtime', relationship: 'agent-to-tool', status: 'coming', search: '' },
+      searchText: inventorySearchText(['agentcore', 'runtime', 'gateway', 'identity'])
     },
     {
       id: 'external-provider-keys',
@@ -3251,13 +3507,21 @@ function AWSAgentIdentitiesContent({ connection }: { connection: AWSConnectionSt
       scope: 'Secrets metadata only',
       status: 'not yet available',
       stage: 'not-available',
-      detail: 'OpenAI, Anthropic, and Claude Platform usage mapping will use safe metadata, never secret values.'
+      detail: 'OpenAI, Anthropic, and Claude Platform usage mapping will use safe metadata, never secret values.',
+      filters: {
+        surface: 'external-provider-keys',
+        relationship: 'agent-to-secret',
+        status: 'not-yet-available',
+        search: ''
+      },
+      searchText: inventorySearchText(['external', 'provider', 'keys', 'agent'])
     }
   ];
+  const displayedRows = filterAWSInventoryRows(rows, filters);
 
   return (
     <>
-      <AWSInventoryFilterSet routeID="agents" />
+      <AWSInventoryFilterSet routeID="agents" filters={filters} onChange={onFiltersChange} />
       <section className="idt-aws-agent-relationship-grid" aria-label="AWS agent relationship slots">
         {[
           ['Agent to role', connection?.role_arn ? 'Role anchor available' : 'Waiting for role validation'],
@@ -3273,7 +3537,7 @@ function AWSAgentIdentitiesContent({ connection }: { connection: AWSConnectionSt
       </section>
       <DomainDataTable
         label="AWS agent identity inventory"
-        rows={rows}
+        rows={displayedRows}
         getRowKey={(row) => row.id}
         columns={[
           { key: 'name', header: 'Agent surface', render: (row) => <strong>{row.name}</strong> },
@@ -3287,7 +3551,15 @@ function AWSAgentIdentitiesContent({ connection }: { connection: AWSConnectionSt
   );
 }
 
-function AWSResourcesInventoryContent({ connection }: { connection: AWSConnectionStatus | null }) {
+function AWSResourcesInventoryContent({
+  connection,
+  filters,
+  onFiltersChange
+}: {
+  connection: AWSConnectionStatus | null;
+  filters: AWSInventoryFilterState;
+  onFiltersChange: (nextFilters: AWSInventoryFilterState) => void;
+}) {
   const rows: AWSInventoryTableRow[] = [
     {
       id: 'secrets-manager',
@@ -3296,7 +3568,9 @@ function AWSResourcesInventoryContent({ connection }: { connection: AWSConnectio
       scope: connection?.account_id ? `Account ${connection.account_id}` : 'Account pending',
       status: 'coming',
       stage: 'coming',
-      detail: 'Name, tags, rotation, policy, and reference metadata only. Secret values are out of scope.'
+      detail: 'Name, tags, rotation, policy, and reference metadata only. Secret values are out of scope.',
+      filters: { category: 'secrets-manager', sensitivity: 'secret-bearing', readPosture: 'metadata-only', search: '' },
+      searchText: inventorySearchText(['secrets manager', 'secret', 'metadata', 'category'])
     },
     {
       id: 'ssm-parameters',
@@ -3305,7 +3579,9 @@ function AWSResourcesInventoryContent({ connection }: { connection: AWSConnectio
       scope: connection?.region ?? 'Region pending',
       status: 'coming',
       stage: 'coming',
-      detail: 'Parameter paths, tags, encryption metadata, and reachability hints without value reads.'
+      detail: 'Parameter paths, tags, encryption metadata, and reachability hints without value reads.',
+      filters: { category: 'ssm-parameter', sensitivity: 'credential reference', readPosture: 'metadata-only', search: '' },
+      searchText: inventorySearchText(['ssm parameter', 'reference', 'tags', 'encryption'])
     },
     {
       id: 'kms',
@@ -3314,7 +3590,9 @@ function AWSResourcesInventoryContent({ connection }: { connection: AWSConnectio
       scope: 'Policies and grants',
       status: 'coming',
       stage: 'coming',
-      detail: 'Key policy and grant reachability will highlight decrypt/admin blast radius.'
+      detail: 'Key policy and grant reachability will highlight decrypt/admin blast radius.',
+      filters: { category: 'kms', sensitivity: 'kms-admin', readPosture: 'metadata-only', search: '' },
+      searchText: inventorySearchText(['kms', 'key', 'reachability', 'policy', 'grants'])
     },
     {
       id: 's3',
@@ -3323,7 +3601,9 @@ function AWSResourcesInventoryContent({ connection }: { connection: AWSConnectio
       scope: 'Bucket metadata',
       status: 'coming',
       stage: 'coming',
-      detail: 'Bucket policy, public access, tags, and sensitivity labels land with resource coverage.'
+      detail: 'Bucket policy, public access, tags, and sensitivity labels land with resource coverage.',
+      filters: { category: 's3', sensitivity: 'customer-data', readPosture: 'metadata-only', search: '' },
+      searchText: inventorySearchText(['s3', 'bucket', 'customer data', 'sensitivity', 'metadata'])
     },
     {
       id: 'secret-values',
@@ -3332,13 +3612,16 @@ function AWSResourcesInventoryContent({ connection }: { connection: AWSConnectio
       scope: 'Never read',
       status: 'not requested',
       stage: 'not-available',
-      detail: 'Identrail inventory pages do not request, store, or display secret values.'
+      detail: 'Identrail inventory pages do not request, store, or display secret values.',
+      filters: { category: 'control-plane', sensitivity: 'control-plane', readPosture: 'no-secret-values', search: '' },
+      searchText: inventorySearchText(['secret values', 'not requested', 'metadata only', 'not read'])
     }
   ];
+  const displayedRows = filterAWSInventoryRows(rows, filters);
 
   return (
     <>
-      <AWSInventoryFilterSet routeID="resources" />
+      <AWSInventoryFilterSet routeID="resources" filters={filters} onChange={onFiltersChange} />
       <section className="idt-aws-resource-coverage-grid" aria-label="AWS resource category coverage">
         <DomainCoverageCard label="Secrets metadata" scanned={0} total={1} detail="Coming wave" />
         <DomainCoverageCard label="KMS reachability" scanned={0} total={1} detail="Coming wave" />
@@ -3352,7 +3635,7 @@ function AWSResourcesInventoryContent({ connection }: { connection: AWSConnectio
       </DomainStatusPanel>
       <DomainDataTable
         label="AWS resource and credential reachability"
-        rows={rows}
+        rows={displayedRows}
         getRowKey={(row) => row.id}
         columns={[
           { key: 'name', header: 'Resource category', render: (row) => <strong>{row.name}</strong> },
@@ -3370,6 +3653,17 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
   const data = useAWSInventoryData();
   const { scope, environmentScope, selectedEnvironmentID, connection, connectionLoading, connectionError } = data;
   const copy = AWS_INVENTORY_PAGE_COPY[routeID];
+  const [activeFilters, setActiveFilters] = useState<AWSInventoryFilterState>(() => ({
+    ...AWS_INVENTORY_FILTER_DEFAULTS[routeID]
+  }));
+
+  const onFiltersChange = (nextFilters: AWSInventoryFilterState): void => {
+    setActiveFilters(nextFilters);
+  };
+
+  useEffect(() => {
+    setActiveFilters({ ...AWS_INVENTORY_FILTER_DEFAULTS[routeID] });
+  }, [routeID]);
 
   if (!scope) {
     return (
@@ -3442,10 +3736,18 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
         </div>
       </DomainStatusPanel>
 
-      {routeID === 'accounts' ? <AWSAccountsInventoryContent connection={connection} connectPath={connectPath} /> : null}
-      {routeID === 'identities' ? <AWSMachineIdentitiesContent connection={connection} /> : null}
-      {routeID === 'agents' ? <AWSAgentIdentitiesContent connection={connection} /> : null}
-      {routeID === 'resources' ? <AWSResourcesInventoryContent connection={connection} /> : null}
+      {routeID === 'accounts' ? (
+        <AWSAccountsInventoryContent connection={connection} connectPath={connectPath} filters={activeFilters} onFiltersChange={onFiltersChange} />
+      ) : null}
+      {routeID === 'identities' ? (
+        <AWSMachineIdentitiesContent connection={connection} filters={activeFilters} onFiltersChange={onFiltersChange} />
+      ) : null}
+      {routeID === 'agents' ? (
+        <AWSAgentIdentitiesContent connection={connection} filters={activeFilters} onFiltersChange={onFiltersChange} />
+      ) : null}
+      {routeID === 'resources' ? (
+        <AWSResourcesInventoryContent connection={connection} filters={activeFilters} onFiltersChange={onFiltersChange} />
+      ) : null}
     </DomainPageShell>
   );
 }

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -2862,6 +2862,7 @@ const AWS_INVENTORY_FILTERS: AWSInventoryFilterConfigMap = {
       label: 'Sensitivity',
       options: [
         { label: 'All sensitivity', value: 'all' },
+        { label: 'Credential reference', value: 'credential-reference' },
         { label: 'Production', value: 'production' },
         { label: 'Customer data', value: 'customer-data' },
         { label: 'Secret-bearing', value: 'secret-bearing' },
@@ -3509,7 +3510,7 @@ function AWSAgentIdentitiesContent({
       status: 'coming',
       stage: 'coming',
       detail: 'Will map AgentCore runtime, gateway, identity metadata, MCP gateway, and tool relationships.',
-      filters: { surface: 'agentcore-runtime', relationship: 'agent-to-tool', status: 'coming', search: '' },
+      filters: { surface: 'agentcore-runtime,mcp-gateway', relationship: 'agent-to-tool', status: 'coming', search: '' },
       searchText: inventorySearchText(['agentcore', 'runtime', 'gateway', 'identity'])
     },
     {
@@ -3592,7 +3593,7 @@ function AWSResourcesInventoryContent({
       status: 'coming',
       stage: 'coming',
       detail: 'Parameter paths, tags, encryption metadata, and reachability hints without value reads.',
-      filters: { category: 'ssm-parameter', sensitivity: 'credential reference', readPosture: 'metadata-only', search: '' },
+      filters: { category: 'ssm-parameter', sensitivity: 'credential-reference', readPosture: 'metadata-only', search: '' },
       searchText: inventorySearchText(['ssm parameter', 'reference', 'tags', 'encryption'])
     },
     {
@@ -3728,12 +3729,14 @@ function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) 
         />
       ) : null}
 
-      <AWSInventoryPrerequisites
-        scope={scope}
-        selectedEnvironmentID={selectedEnvironmentID}
-        connection={connection}
-        connectPath={connectPath}
-      />
+      {!environmentScope.loading && !connectionLoading && !connectionError ? (
+        <AWSInventoryPrerequisites
+          scope={scope}
+          selectedEnvironmentID={selectedEnvironmentID}
+          connection={connection}
+          connectPath={connectPath}
+        />
+      ) : null}
 
       <DomainStatusPanel eyebrow="Current vs planned" title="Inventory capability boundary" status={copy.statusLabel} tone="info">
         <div className="idt-aws-inventory-boundary">

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -3241,22 +3241,22 @@ function AWSAccountsInventoryContent({
         search: ''
       },
       searchText: inventorySearchText([connection?.account_id, connection?.region, connection?.display_name, 'current account', 'covered', 'missing'])
-    },
-    {
-      id: 'current-region',
-      category: connection?.region ? `Region ${connection.region}` : 'Current region',
-      coverage: connection?.region ? 'covered' : 'missing',
-      source: 'AWS connector payload',
-      status: connection?.region ? 'covered' : 'missing',
-      detail: connection?.last_validated_at ? `Last validation ${formatConnectionTime(connection.last_validated_at)}` : 'No validation time yet.',
-      filters: {
-        account: connection?.account_id ? 'connected' : 'planned',
-        region: connection?.region ? 'current' : 'uncovered',
-        coverage: connection?.region ? 'covered' : 'missing',
-        search: ''
       },
-      searchText: inventorySearchText([connection?.region, 'region', 'coverage', 'region coverage'])
-    },
+      {
+        id: 'current-region',
+        category: connection?.region ? `Region ${connection.region}` : 'Current region',
+        coverage: accountCoverage,
+        source: 'AWS connector payload',
+        status: accountCoverage,
+        detail: connection?.last_validated_at ? `Last validation ${formatConnectionTime(connection.last_validated_at)}` : 'No validation time yet.',
+        filters: {
+          account: connection?.account_id ? 'connected' : 'planned',
+          region: connection?.region ? 'current' : 'uncovered',
+          coverage: currentCoverageFilter,
+          search: ''
+        },
+        searchText: inventorySearchText([connection?.region, 'region', 'coverage', 'region coverage'])
+      },
     {
       id: 'org-planner',
       category: 'Organization account planner',

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -69,8 +69,11 @@ import { PermissionPreviewModal } from './components/connector/PermissionPreview
 import { ConfirmDestructiveModal, DangerZone, DangerZoneRow } from './components/settings/DangerZone';
 import {
   DomainDetailPanel,
+  DomainCoverageCard,
+  DomainDataTable,
   DomainEmptyState,
   DomainErrorState,
+  DomainFilterBar,
   DomainKpiStrip,
   DomainLoadingState,
   DomainLogoMark,
@@ -2651,6 +2654,816 @@ function AWSConnectionDiagnostics({
       ))}
     </>
   );
+}
+
+type AWSInventoryRouteID = Extract<ProductDomainRouteID, 'accounts' | 'identities' | 'agents' | 'resources'>;
+
+type AWSInventoryPageCopy = {
+  routeID: AWSInventoryRouteID;
+  title: string;
+  eyebrow: string;
+  description: string;
+  statusLabel: string;
+  primaryKpi: string;
+  currentCapability: string;
+  plannedCapability: string;
+};
+
+const AWS_INVENTORY_PAGE_COPY: Record<AWSInventoryRouteID, AWSInventoryPageCopy> = {
+  accounts: {
+    routeID: 'accounts',
+    title: 'AWS accounts and regions',
+    eyebrow: 'Coverage inventory',
+    description:
+      'Track the selected AWS account, active region, connector coverage, scan readiness, and the account/region planner that will support future scale.',
+    statusLabel: 'Coverage shell',
+    primaryKpi: 'Account scope',
+    currentCapability: 'Current connector account and region from AWS role validation.',
+    plannedCapability: 'Organization account discovery, multi-region cursor state, and partial-failure reporting.'
+  },
+  identities: {
+    routeID: 'identities',
+    title: 'AWS machine identities',
+    eyebrow: 'Identity inventory',
+    description:
+      'Inspect the IAM role Identrail can see today while reserving first-class inventory space for workload, CI/CD, and federation identities.',
+    statusLabel: 'Inventory shell',
+    primaryKpi: 'Identity anchor',
+    currentCapability: 'Current IAM role ARN, principal ARN, account, region, and permission diagnostics.',
+    plannedCapability: 'Instance profiles, ECS task roles, Lambda roles, EKS IRSA/Pod Identity, and deploy roles.'
+  },
+  agents: {
+    routeID: 'agents',
+    title: 'AWS agent identities',
+    eyebrow: 'Agent inventory',
+    description:
+      'Reserve a first-class AWS agent identity workspace for Bedrock, AgentCore, tool, MCP, and agent-to-role relationship coverage.',
+    statusLabel: 'Reserved surface',
+    primaryKpi: 'Agent graph',
+    currentCapability: 'Current AWS role context is visible as the future agent-to-role anchor.',
+    plannedCapability: 'Bedrock agents, AgentCore runtime/gateway identity, MCP tools, and external AI key metadata.'
+  },
+  resources: {
+    routeID: 'resources',
+    title: 'AWS resources and credentials',
+    eyebrow: 'Reachability inventory',
+    description:
+      'Map the resource and credential metadata Identrail will reason about without requesting or displaying secret values.',
+    statusLabel: 'Reachability shell',
+    primaryKpi: 'Resource scope',
+    currentCapability: 'Current account, region, role, permission checks, and diagnostics frame the reachability boundary.',
+    plannedCapability: 'Secrets Manager metadata, SSM Parameter metadata, KMS policies/grants, S3 sensitivity, and credential references.'
+  }
+};
+
+type AWSInventoryDataState = {
+  scope: ProductSession | null;
+  environmentScope: EnvironmentScopeState;
+  selectedEnvironmentID: string;
+  connection: AWSConnectionStatus | null;
+  connectionLoading: boolean;
+  connectionError: string;
+  onChangeEnvironment: (environmentID: string) => void;
+  refreshConnection: () => void;
+};
+
+type AWSInventoryTableRow = {
+  id: string;
+  name: string;
+  category: string;
+  scope: string;
+  status: string;
+  stage: AWSCapabilityStage;
+  detail: string;
+};
+
+type AWSInventoryCoverageRow = {
+  id: string;
+  category: string;
+  coverage: string;
+  source: string;
+  status: string;
+  detail: string;
+};
+
+function useAWSInventoryData(): AWSInventoryDataState {
+  const params = useParams<ScopeRouteParams>();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const scope = resolveScopeFromParams(params);
+  const requestedEnvironmentID = useMemo(() => environmentIDFromSearch(location.search), [location.search]);
+  const environmentScope = useEnvironmentScope(scope, requestedEnvironmentID);
+  const selectedEnvironmentID = environmentScope.selectedID;
+  const [connection, setConnection] = useState<AWSConnectionStatus | null>(null);
+  const [connectionLoading, setConnectionLoading] = useState(false);
+  const [connectionError, setConnectionError] = useState('');
+  const connectionRequestRef = useRef(0);
+  const selectedEnvironmentIDRef = useRef(selectedEnvironmentID);
+  const scopeKey = scope ? `${scope.tenantID}::${scope.workspaceID}` : '';
+  const scopeKeyRef = useRef(scopeKey);
+  selectedEnvironmentIDRef.current = selectedEnvironmentID;
+  scopeKeyRef.current = scopeKey;
+
+  const refreshConnection = useCallback(async () => {
+    const requestID = ++connectionRequestRef.current;
+    const requestEnvironmentID = selectedEnvironmentID;
+    const requestScopeKey = scopeKeyRef.current;
+    if (!scope || !requestEnvironmentID) {
+      setConnection(null);
+      setConnectionError('');
+      setConnectionLoading(false);
+      return;
+    }
+    const isStale = () =>
+      requestID !== connectionRequestRef.current ||
+      selectedEnvironmentIDRef.current !== requestEnvironmentID ||
+      scopeKeyRef.current !== requestScopeKey;
+    setConnectionLoading(true);
+    setConnectionError('');
+    try {
+      const response = await apiClient.getAWSProjectConnection(
+        scope.workspaceID,
+        requestEnvironmentID,
+        buildProductAuthContext(scope)
+      );
+      if (isStale()) {
+        return;
+      }
+      setConnection(response.connection);
+    } catch (error) {
+      if (isStale()) {
+        return;
+      }
+      setConnection(null);
+      setConnectionError(formatAPIError(error, 'Unable to load AWS inventory status.'));
+    } finally {
+      if (!isStale()) {
+        setConnectionLoading(false);
+      }
+    }
+  }, [scope?.tenantID, scope?.workspaceID, selectedEnvironmentID]);
+
+  useEffect(() => {
+    void refreshConnection();
+    return () => {
+      connectionRequestRef.current += 1;
+    };
+  }, [refreshConnection]);
+
+  const onChangeEnvironment = useCallback(
+    (environmentID: string) => {
+      connectionRequestRef.current += 1;
+      setConnection(null);
+      setConnectionError('');
+      navigate(
+        {
+          pathname: location.pathname,
+          search: environmentSearch(location.search, environmentID)
+        },
+        { replace: false }
+      );
+    },
+    [location.pathname, location.search, navigate]
+  );
+
+  return {
+    scope,
+    environmentScope,
+    selectedEnvironmentID,
+    connection,
+    connectionLoading,
+    connectionError,
+    onChangeEnvironment,
+    refreshConnection: () => void refreshConnection()
+  };
+}
+
+function awsCoverageState(connection: AWSConnectionStatus | null): string {
+  if (!connection) {
+    return 'missing';
+  }
+  if (!connection.connected) {
+    return 'degraded';
+  }
+  if (connection.permission_checks.some((check) => !check.passed)) {
+    return 'degraded';
+  }
+  return 'covered';
+}
+
+function awsInventoryPillTone(stage: AWSCapabilityStage): 'success' | 'warning' | 'neutral' {
+  return awsStageTone(stage);
+}
+
+function AWSInventoryPill({
+  stage,
+  label
+}: {
+  stage: AWSCapabilityStage;
+  label?: string;
+}) {
+  return <span className={`idt-aws-inventory-pill is-${awsInventoryPillTone(stage)}`}>{label ?? awsStageLabel(stage)}</span>;
+}
+
+function AWSInventoryFilterSet({ routeID }: { routeID: AWSInventoryRouteID }) {
+  const routeFilters: Record<AWSInventoryRouteID, Array<{ label: string; value: string; options: string[] }>> = {
+    accounts: [
+      { label: 'Account', value: 'all', options: ['All accounts', 'Connected account', 'Planned accounts'] },
+      { label: 'Region', value: 'all', options: ['All regions', 'Current region', 'Uncovered regions'] },
+      { label: 'Coverage', value: 'all', options: ['All coverage', 'Covered', 'Missing', 'Degraded', 'Not yet available'] }
+    ],
+    identities: [
+      { label: 'Identity type', value: 'all', options: ['All types', 'IAM role', 'Instance profile', 'ECS task role', 'Lambda role', 'EKS identity', 'CI/CD role'] },
+      { label: 'Service', value: 'all', options: ['All services', 'IAM', 'EC2', 'ECS', 'Lambda', 'EKS', 'OIDC'] },
+      { label: 'Risk', value: 'all', options: ['All risk', 'Unscored', 'High', 'Medium', 'Low'] },
+      { label: 'Status', value: 'all', options: ['All status', 'Wired now', 'Coming', 'Not yet available'] }
+    ],
+    agents: [
+      { label: 'Agent surface', value: 'all', options: ['All surfaces', 'Bedrock agents', 'AgentCore runtime', 'MCP gateway', 'External provider keys'] },
+      { label: 'Relationship', value: 'all', options: ['All relationships', 'Agent to role', 'Agent to tool', 'Agent to secret', 'Agent to user'] },
+      { label: 'Status', value: 'all', options: ['All status', 'Role anchor', 'Coming', 'Not yet available'] }
+    ],
+    resources: [
+      { label: 'Category', value: 'all', options: ['All categories', 'Secrets Manager', 'SSM Parameter', 'KMS', 'S3', 'Control plane'] },
+      { label: 'Sensitivity', value: 'all', options: ['All sensitivity', 'Production', 'Customer data', 'Secret-bearing', 'KMS-admin', 'Control-plane'] },
+      { label: 'Read posture', value: 'metadata', options: ['Metadata only', 'No secret values'] }
+    ]
+  };
+  const searchPlaceholder: Record<AWSInventoryRouteID, string> = {
+    accounts: 'Search account or region',
+    identities: 'Search identity ARN',
+    agents: 'Search agent surface',
+    resources: 'Search resource metadata'
+  };
+
+  return (
+    <DomainFilterBar label={`${AWS_INVENTORY_PAGE_COPY[routeID].title} filters`}>
+      {routeFilters[routeID].map((filter) => (
+        <label key={filter.label}>
+          {filter.label}
+          <select defaultValue={filter.value}>
+            {filter.options.map((option, index) => (
+              <option key={option} value={index === 0 ? filter.value : option.toLowerCase().replace(/[^a-z0-9]+/g, '-')}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </label>
+      ))}
+      <label>
+        Search
+        <input placeholder={searchPlaceholder[routeID]} />
+      </label>
+    </DomainFilterBar>
+  );
+}
+
+function buildAWSInventoryKpis(routeID: AWSInventoryRouteID, connection: AWSConnectionStatus | null) {
+  const permissionTotal = connection?.permission_checks.length ?? 0;
+  const permissionPassed = connection?.permission_checks.filter((check) => check.passed).length ?? 0;
+  const primaryValue =
+    routeID === 'accounts'
+      ? connection?.account_id
+        ? '1 account'
+        : 'Pending'
+      : routeID === 'identities'
+        ? connection?.role_arn
+          ? '1 role'
+          : 'Pending'
+        : routeID === 'agents'
+          ? 'Reserved'
+          : 'Metadata only';
+
+  return [
+    {
+      label: AWS_INVENTORY_PAGE_COPY[routeID].primaryKpi,
+      value: primaryValue,
+      detail:
+        routeID === 'resources'
+          ? 'Secret values are not requested or displayed.'
+          : connection?.display_name ?? 'Connect AWS to populate current inventory anchors.',
+      tone: connection?.connected || routeID === 'resources' ? 'success' : 'warning'
+    },
+    {
+      label: 'Account / region',
+      value: connection?.account_id ? 'Scoped' : 'Missing',
+      detail: awsAccountRegionLabel(connection),
+      tone: connection?.account_id ? 'success' : 'warning'
+    },
+    {
+      label: 'Permission checks',
+      value: permissionTotal > 0 ? `${permissionPassed}/${permissionTotal}` : 'Not run',
+      detail: permissionTotal > 0 ? 'Connector validation evidence available.' : 'Validation evidence is not available for this environment.',
+      tone: permissionTotal > 0 && permissionPassed === permissionTotal ? 'success' : permissionTotal > 0 ? 'warning' : 'neutral'
+    },
+    {
+      label: 'Backend wave',
+      value: 'Future-ready',
+      detail: AWS_INVENTORY_PAGE_COPY[routeID].plannedCapability,
+      tone: 'info'
+    }
+  ] satisfies ProductDomainRoute['metrics'];
+}
+
+function AWSInventoryRouteAside({
+  copy,
+  connection,
+  selectedEnvironmentID
+}: {
+  copy: AWSInventoryPageCopy;
+  connection: AWSConnectionStatus | null;
+  selectedEnvironmentID: string;
+}) {
+  return (
+    <DomainDetailPanel title="Inventory contract" eyebrow={copy.eyebrow}>
+      <dl className="idt-domain-route-facts">
+        <div>
+          <dt>Environment</dt>
+          <dd>{selectedEnvironmentID ? environmentFallbackLabel(selectedEnvironmentID) : 'Not selected'}</dd>
+        </div>
+        <div>
+          <dt>Current data</dt>
+          <dd>{copy.currentCapability}</dd>
+        </div>
+        <div>
+          <dt>Connector</dt>
+          <dd>{connection?.connector_id ?? 'Not assigned'}</dd>
+        </div>
+        <div>
+          <dt>Secret posture</dt>
+          <dd>No secret values requested</dd>
+        </div>
+      </dl>
+    </DomainDetailPanel>
+  );
+}
+
+function AWSInventoryPrerequisites({
+  scope,
+  selectedEnvironmentID,
+  connection,
+  connectPath
+}: {
+  scope: ProductSession;
+  selectedEnvironmentID: string;
+  connection: AWSConnectionStatus | null;
+  connectPath: string;
+}) {
+  if (!selectedEnvironmentID) {
+    return (
+      <DomainEmptyState
+        eyebrow="Environment required"
+        title="Create an environment before inventory can resolve"
+        body="AWS inventory is scoped through the existing workspace and environment contract. Create or pick an environment, then return to this AWS page."
+        nextAction={{ label: 'Open environments', to: appendSourceQuery(buildProjectsPath(scope), 'aws') }}
+      />
+    );
+  }
+
+  if (!connection?.connected) {
+    return (
+      <DomainEmptyState
+        eyebrow="Connector prerequisite"
+        title="Connect AWS to populate current inventory anchors"
+        body="These pages stay honest until the read-only AWS role is validated. The planned tables remain visible, but current account, region, role, permission, and diagnostic data come from Connect AWS."
+        nextAction={{ label: 'Connect AWS', to: connectPath }}
+      />
+    );
+  }
+
+  return null;
+}
+
+function AWSAccountsInventoryContent({
+  connection,
+  connectPath
+}: {
+  connection: AWSConnectionStatus | null;
+  connectPath: string;
+}) {
+  const rows: AWSInventoryCoverageRow[] = [
+    {
+      id: 'current-account',
+      category: connection?.account_id ? `AWS account ${connection.account_id}` : 'Selected AWS account',
+      coverage: awsCoverageState(connection),
+      source: connection?.display_name ?? 'Connect AWS',
+      status: connection?.connected ? 'covered' : 'missing',
+      detail: connection?.region ? `Validated in ${connection.region}` : 'Region coverage starts after validation.'
+    },
+    {
+      id: 'current-region',
+      category: connection?.region ? `Region ${connection.region}` : 'Current region',
+      coverage: connection?.region ? 'covered' : 'missing',
+      source: 'AWS connector payload',
+      status: connection?.region ? 'covered' : 'missing',
+      detail: connection?.last_validated_at ? `Last validation ${formatConnectionTime(connection.last_validated_at)}` : 'No validation time yet.'
+    },
+    {
+      id: 'org-planner',
+      category: 'Organization account planner',
+      coverage: 'not yet available',
+      source: 'Future AWS inventory API',
+      status: 'not yet available',
+      detail: 'Will track account enrollment, incremental cursors, and partial account failure.'
+    },
+    {
+      id: 'region-planner',
+      category: 'Multi-region scan planner',
+      coverage: 'not yet available',
+      source: 'Future AWS inventory API',
+      status: 'not yet available',
+      detail: 'Will track service-by-region coverage and degraded or unreachable regions.'
+    }
+  ];
+  const passedChecks = connection?.permission_checks.filter((check) => check.passed).length ?? 0;
+  const totalChecks = connection?.permission_checks.length ?? 0;
+
+  return (
+    <>
+      <AWSInventoryFilterSet routeID="accounts" />
+      <section className="idt-aws-inventory-coverage" aria-label="AWS account and region coverage map">
+        <DomainCoverageCard label="Account coverage" scanned={connection?.account_id ? 1 : 0} total={1} detail="Selected environment" />
+        <DomainCoverageCard label="Region coverage" scanned={connection?.region ? 1 : 0} total={1} detail={connection?.region ?? 'Pending'} />
+        <DomainCoverageCard label="Permission evidence" scanned={passedChecks} total={Math.max(totalChecks, 1)} detail="Read-only validation" />
+      </section>
+      <DomainDataTable
+        label="AWS account and region coverage"
+        rows={rows}
+        getRowKey={(row) => row.id}
+        columns={[
+          { key: 'category', header: 'Coverage scope', render: (row) => <strong>{row.category}</strong> },
+          { key: 'coverage', header: 'Coverage', render: (row) => <AWSInventoryPill stage={row.coverage === 'covered' ? 'wired' : row.coverage === 'not yet available' ? 'not-available' : 'coming'} label={formatTokenLabel(row.coverage)} /> },
+          { key: 'source', header: 'Source', render: (row) => row.source },
+          { key: 'detail', header: 'Detail', render: (row) => row.detail }
+        ]}
+      />
+      <DomainStatusPanel
+        eyebrow="Connector dependency"
+        title="Coverage is scoped by the read-only AWS role"
+        status={connection?.connected ? 'Current account visible' : 'Setup required'}
+        tone={connection?.connected ? 'success' : 'warning'}
+        actions={[{ label: 'Open Connect AWS', to: connectPath, variant: 'secondary' }]}
+      >
+        <p>
+          Account and region coverage uses the current AWS connector when it exists. Organization-wide scale, cursor health,
+          and partial-region failure reporting stay labeled as future AWS inventory work.
+        </p>
+      </DomainStatusPanel>
+    </>
+  );
+}
+
+function AWSMachineIdentitiesContent({ connection }: { connection: AWSConnectionStatus | null }) {
+  const rows: AWSInventoryTableRow[] = [
+    ...(connection?.role_arn
+      ? [
+          {
+            id: 'current-role',
+            name: connection.role_arn,
+            category: 'IAM role',
+            scope: awsAccountRegionLabel(connection),
+            status: connection.connected ? 'wired now' : 'pending validation',
+            stage: 'wired' as AWSCapabilityStage,
+            detail: connection.principal_arn ?? 'Role principal will appear after validation.'
+          }
+        ]
+      : []),
+    {
+      id: 'instance-profiles',
+      name: 'EC2 instance profiles',
+      category: 'Workload identity',
+      scope: 'Account and region expansion',
+      status: 'coming',
+      stage: 'coming',
+      detail: 'Instance profile inventory will map roles back to EC2 workloads.'
+    },
+    {
+      id: 'ecs-lambda',
+      name: 'ECS task roles and Lambda execution roles',
+      category: 'Service identity',
+      scope: 'ECS / Lambda',
+      status: 'coming',
+      stage: 'coming',
+      detail: 'Future collectors will identify workload ownership and attached policies.'
+    },
+    {
+      id: 'eks-irsa',
+      name: 'EKS IRSA and Pod Identity associations',
+      category: 'Federated identity',
+      scope: 'EKS',
+      status: 'coming',
+      stage: 'coming',
+      detail: 'EKS identity mapping belongs here once Kubernetes and AWS graphs join.'
+    },
+    {
+      id: 'cicd-oidc',
+      name: 'CI/CD deploy and OIDC roles',
+      category: 'Deployment identity',
+      scope: 'GitHub and external CI',
+      status: 'coming',
+      stage: 'coming',
+      detail: 'Deployment trust paths will connect repository evidence to AWS role assumption.'
+    }
+  ];
+
+  return (
+    <>
+      <AWSInventoryFilterSet routeID="identities" />
+      <section className="idt-aws-inventory-split">
+        <DomainDataTable
+          label="AWS machine identity inventory"
+          rows={rows}
+          getRowKey={(row) => row.id}
+          columns={[
+            {
+              key: 'name',
+              header: 'Identity',
+              render: (row) => (
+                <div className="idt-aws-inventory-table-cell">
+                  <strong>{row.name}</strong>
+                  <p>{row.detail}</p>
+                </div>
+              )
+            },
+            { key: 'category', header: 'Type', render: (row) => row.category },
+            { key: 'scope', header: 'Account / region / service', render: (row) => row.scope },
+            { key: 'status', header: 'Status', render: (row) => <AWSInventoryPill stage={row.stage} label={formatTokenLabel(row.status)} /> }
+          ]}
+        />
+        <DomainDetailPanel title="Selected identity detail" eyebrow="Current data">
+          <dl className="idt-domain-route-facts">
+            <div>
+              <dt>Role ARN</dt>
+              <dd>{connection?.role_arn ?? 'Not available yet'}</dd>
+            </div>
+            <div>
+              <dt>Principal</dt>
+              <dd>{connection?.principal_arn ?? 'Pending validation'}</dd>
+            </div>
+            <div>
+              <dt>Trust policy</dt>
+              <dd>{connection?.external_id_configured ? 'External ID configured' : 'External ID not configured'}</dd>
+            </div>
+            <div>
+              <dt>Risk score</dt>
+              <dd>Unscored until AWS findings land</dd>
+            </div>
+          </dl>
+        </DomainDetailPanel>
+      </section>
+    </>
+  );
+}
+
+function AWSAgentIdentitiesContent({ connection }: { connection: AWSConnectionStatus | null }) {
+  const rows: AWSInventoryTableRow[] = [
+    {
+      id: 'role-anchor',
+      name: connection?.role_arn ?? 'AWS role anchor',
+      category: 'Agent-to-role anchor',
+      scope: awsAccountRegionLabel(connection),
+      status: connection?.role_arn ? 'role anchor' : 'not yet available',
+      stage: connection?.role_arn ? 'wired' : 'not-available',
+      detail: 'Future agent inventory can attach Bedrock or external agent execution back to this AWS role context.'
+    },
+    {
+      id: 'bedrock-agents',
+      name: 'Bedrock agents',
+      category: 'AWS-native agent',
+      scope: 'Bedrock',
+      status: 'coming',
+      stage: 'coming',
+      detail: 'Agent identity, action groups, tool use, and role relationship slots are reserved here.'
+    },
+    {
+      id: 'agentcore',
+      name: 'AgentCore runtime and gateway identity',
+      category: 'AgentCore',
+      scope: 'Runtime / gateway',
+      status: 'coming',
+      stage: 'coming',
+      detail: 'Will map AgentCore runtime, gateway, identity metadata, MCP gateway, and tool relationships.'
+    },
+    {
+      id: 'external-provider-keys',
+      name: 'External AI provider key metadata',
+      category: 'Safe metadata',
+      scope: 'Secrets metadata only',
+      status: 'not yet available',
+      stage: 'not-available',
+      detail: 'OpenAI, Anthropic, and Claude Platform usage mapping will use safe metadata, never secret values.'
+    }
+  ];
+
+  return (
+    <>
+      <AWSInventoryFilterSet routeID="agents" />
+      <section className="idt-aws-agent-relationship-grid" aria-label="AWS agent relationship slots">
+        {[
+          ['Agent to role', connection?.role_arn ? 'Role anchor available' : 'Waiting for role validation'],
+          ['Agent to tool', 'Tool and MCP gateway coverage reserved'],
+          ['Agent to secret', 'Secret metadata only, no value reads'],
+          ['Agent to user', 'Human owner mapping reserved for governance waves']
+        ].map(([label, detail]) => (
+          <article key={label}>
+            <strong>{label}</strong>
+            <p>{detail}</p>
+          </article>
+        ))}
+      </section>
+      <DomainDataTable
+        label="AWS agent identity inventory"
+        rows={rows}
+        getRowKey={(row) => row.id}
+        columns={[
+          { key: 'name', header: 'Agent surface', render: (row) => <strong>{row.name}</strong> },
+          { key: 'category', header: 'Category', render: (row) => row.category },
+          { key: 'scope', header: 'Scope', render: (row) => row.scope },
+          { key: 'status', header: 'Status', render: (row) => <AWSInventoryPill stage={row.stage} label={formatTokenLabel(row.status)} /> },
+          { key: 'detail', header: 'Relationship slot', render: (row) => row.detail }
+        ]}
+      />
+    </>
+  );
+}
+
+function AWSResourcesInventoryContent({ connection }: { connection: AWSConnectionStatus | null }) {
+  const rows: AWSInventoryTableRow[] = [
+    {
+      id: 'secrets-manager',
+      name: 'Secrets Manager metadata',
+      category: 'Secret-bearing',
+      scope: connection?.account_id ? `Account ${connection.account_id}` : 'Account pending',
+      status: 'coming',
+      stage: 'coming',
+      detail: 'Name, tags, rotation, policy, and reference metadata only. Secret values are out of scope.'
+    },
+    {
+      id: 'ssm-parameters',
+      name: 'SSM Parameter metadata',
+      category: 'Credential reference',
+      scope: connection?.region ?? 'Region pending',
+      status: 'coming',
+      stage: 'coming',
+      detail: 'Parameter paths, tags, encryption metadata, and reachability hints without value reads.'
+    },
+    {
+      id: 'kms',
+      name: 'KMS key reachability',
+      category: 'KMS-admin',
+      scope: 'Policies and grants',
+      status: 'coming',
+      stage: 'coming',
+      detail: 'Key policy and grant reachability will highlight decrypt/admin blast radius.'
+    },
+    {
+      id: 's3',
+      name: 'S3 bucket sensitivity',
+      category: 'Customer data',
+      scope: 'Bucket metadata',
+      status: 'coming',
+      stage: 'coming',
+      detail: 'Bucket policy, public access, tags, and sensitivity labels land with resource coverage.'
+    },
+    {
+      id: 'secret-values',
+      name: 'Secret values',
+      category: 'Protected value',
+      scope: 'Never read',
+      status: 'not requested',
+      stage: 'not-available',
+      detail: 'Identrail inventory pages do not request, store, or display secret values.'
+    }
+  ];
+
+  return (
+    <>
+      <AWSInventoryFilterSet routeID="resources" />
+      <section className="idt-aws-resource-coverage-grid" aria-label="AWS resource category coverage">
+        <DomainCoverageCard label="Secrets metadata" scanned={0} total={1} detail="Coming wave" />
+        <DomainCoverageCard label="KMS reachability" scanned={0} total={1} detail="Coming wave" />
+        <DomainCoverageCard label="S3 sensitivity" scanned={0} total={1} detail="Coming wave" />
+      </section>
+      <DomainStatusPanel eyebrow="Safety posture" title="No secret value reads" status="Metadata only" tone="success">
+        <p>
+          Resource inventory is designed around reachability and metadata. Secrets Manager, SSM Parameter, and external AI
+          provider key mapping must use safe metadata and credential references, not credential values.
+        </p>
+      </DomainStatusPanel>
+      <DomainDataTable
+        label="AWS resource and credential reachability"
+        rows={rows}
+        getRowKey={(row) => row.id}
+        columns={[
+          { key: 'name', header: 'Resource category', render: (row) => <strong>{row.name}</strong> },
+          { key: 'category', header: 'Sensitivity', render: (row) => row.category },
+          { key: 'scope', header: 'Scope', render: (row) => row.scope },
+          { key: 'status', header: 'Status', render: (row) => <AWSInventoryPill stage={row.stage} label={formatTokenLabel(row.status)} /> },
+          { key: 'detail', header: 'Coverage note', render: (row) => row.detail }
+        ]}
+      />
+    </>
+  );
+}
+
+function ProductAWSInventoryPage({ routeID }: { routeID: AWSInventoryRouteID }) {
+  const data = useAWSInventoryData();
+  const { scope, environmentScope, selectedEnvironmentID, connection, connectionLoading, connectionError } = data;
+  const copy = AWS_INVENTORY_PAGE_COPY[routeID];
+
+  if (!scope) {
+    return (
+      <section className="idt-app-panel idt-app-panel-error" role="alert">
+        <p className="idt-app-kicker">{copy.title}</p>
+        <h2>Workspace route context is missing</h2>
+        <p>Choose a tenant and workspace before loading AWS inventory.</p>
+      </section>
+    );
+  }
+
+  const statusTone = awsDomainTone(connection, environmentScope.loading || connectionLoading);
+  const connectPath = awsRouteLink(scope, 'connect', selectedEnvironmentID);
+  const homePath = appendEnvironmentQuery(buildScopedPath(scope, 'aws'), selectedEnvironmentID);
+  const findingsPath = awsRouteLink(scope, 'findings', selectedEnvironmentID);
+  const status =
+    environmentScope.loading || connectionLoading
+      ? 'Loading inventory'
+      : connectionError
+        ? 'Needs retry'
+        : connection?.connected
+          ? copy.statusLabel
+          : 'Setup required';
+
+  return (
+    <DomainPageShell
+      domain="aws"
+      eyebrow={copy.eyebrow}
+      title={copy.title}
+      description={copy.description}
+      scope={<ProductEnvironmentSelector state={environmentScope} onChange={data.onChangeEnvironment} />}
+      status={status}
+      statusTone={connectionError ? 'danger' : statusTone}
+      primaryAction={{ label: 'Connect AWS', to: connectPath, variant: connection?.connected ? 'secondary' : 'primary' }}
+      secondaryActions={[
+        { label: 'AWS home', to: homePath },
+        { label: 'AWS findings', to: findingsPath }
+      ]}
+      aside={<AWSInventoryRouteAside copy={copy} connection={connection} selectedEnvironmentID={selectedEnvironmentID} />}
+    >
+      <DomainKpiStrip label={`${copy.title} status`} items={buildAWSInventoryKpis(routeID, connection)} />
+
+      {environmentScope.loading || connectionLoading ? <DomainLoadingState label={`Loading ${copy.title.toLowerCase()}`} /> : null}
+
+      {connectionError ? (
+        <DomainErrorState
+          title="AWS inventory status could not load"
+          body={connectionError}
+          retryAction={{ label: 'Retry AWS status', onClick: data.refreshConnection }}
+        />
+      ) : null}
+
+      <AWSInventoryPrerequisites
+        scope={scope}
+        selectedEnvironmentID={selectedEnvironmentID}
+        connection={connection}
+        connectPath={connectPath}
+      />
+
+      <DomainStatusPanel eyebrow="Current vs planned" title="Inventory capability boundary" status={copy.statusLabel} tone="info">
+        <div className="idt-aws-inventory-boundary">
+          <article>
+            <strong>Wired now</strong>
+            <p>{copy.currentCapability}</p>
+          </article>
+          <article>
+            <strong>Planned coverage</strong>
+            <p>{copy.plannedCapability}</p>
+          </article>
+        </div>
+      </DomainStatusPanel>
+
+      {routeID === 'accounts' ? <AWSAccountsInventoryContent connection={connection} connectPath={connectPath} /> : null}
+      {routeID === 'identities' ? <AWSMachineIdentitiesContent connection={connection} /> : null}
+      {routeID === 'agents' ? <AWSAgentIdentitiesContent connection={connection} /> : null}
+      {routeID === 'resources' ? <AWSResourcesInventoryContent connection={connection} /> : null}
+    </DomainPageShell>
+  );
+}
+
+export function ProductAWSAccountsPage() {
+  return <ProductAWSInventoryPage routeID="accounts" />;
+}
+
+export function ProductAWSIdentitiesPage() {
+  return <ProductAWSInventoryPage routeID="identities" />;
+}
+
+export function ProductAWSAgentsPage() {
+  return <ProductAWSInventoryPage routeID="agents" />;
+}
+
+export function ProductAWSResourcesPage() {
+  return <ProductAWSInventoryPage routeID="resources" />;
 }
 
 export function ProductAWSControlCenterPage() {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -3019,6 +3019,9 @@ function awsCoverageState(connection: AWSConnectionStatus | null): string {
   if (!connection.connected) {
     return 'degraded';
   }
+  if (connection.health_status === 'warning' || connection.status === 'degraded') {
+    return 'degraded';
+  }
   if (connection.permission_checks.some((check) => !check.passed)) {
     return 'degraded';
   }

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -3481,13 +3481,13 @@ function AWSAgentIdentitiesContent({
       name: connection?.role_arn ?? 'AWS role anchor',
       category: 'Agent-to-role anchor',
       scope: awsAccountRegionLabel(connection),
-      status: connection?.role_arn ? 'role anchor' : 'not yet available',
-      stage: connection?.role_arn ? 'wired' : 'not-available',
+      status: connection?.connected ? 'role anchor' : 'not yet available',
+      stage: connection?.connected ? 'wired' : 'not-available',
       detail: 'Future agent inventory can attach Bedrock or external agent execution back to this AWS role context.',
       filters: {
         surface: 'agentcore-runtime',
         relationship: 'agent-to-role',
-        status: connection?.role_arn ? 'role-anchor' : 'not-yet-available',
+        status: connection?.connected ? 'role-anchor' : 'not-yet-available',
         search: ''
       },
       searchText: inventorySearchText(['agent to role', 'agent', 'role anchor', 'role relationship'])

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -2881,6 +2881,18 @@ function normalizeFilterValue(value: string): string {
   return value.trim().toLowerCase();
 }
 
+function matchesFilterCell(rowValue: string | undefined, selectedValue: string): boolean {
+  const normalizedSelectedValue = normalizeFilterValue(selectedValue);
+  if (!rowValue) {
+    return false;
+  }
+  const values = rowValue
+    .split(',')
+    .map((value) => normalizeFilterValue(value))
+    .filter((value) => value.length > 0);
+  return values.includes(normalizedSelectedValue);
+}
+
 function inventorySearchText(parts: Array<string | undefined>): string {
   return parts
     .filter((value): value is string => Boolean(value && value.length > 0))
@@ -2898,7 +2910,7 @@ function filterAWSInventoryRows<RowType extends AWSInventoryFilterable>(rows: Ro
       if (!selectedValue || selectedValue === 'all') {
         continue;
       }
-      if ((row.filters[filterID] ?? 'all') !== selectedValue) {
+      if (!matchesFilterCell(row.filters[filterID], selectedValue)) {
         return false;
       }
     }
@@ -3375,7 +3387,7 @@ function AWSMachineIdentitiesContent({
       status: 'coming',
       stage: 'coming',
       detail: 'Future collectors will identify workload ownership and attached policies.',
-      filters: { identityType: 'ecs-task-role', service: 'ecs', risk: 'unscored', status: 'coming', search: '' },
+      filters: { identityType: 'ecs-task-role,lambda-role', service: 'ecs,lambda', risk: 'unscored', status: 'coming', search: '' },
       searchText: inventorySearchText(['ecs', 'lambda', 'task roles', 'execution roles', 'service identity'])
     },
     {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -3225,6 +3225,7 @@ function AWSAccountsInventoryContent({
   onFiltersChange: (nextFilters: AWSInventoryFilterState) => void;
 }) {
   const accountCoverage = awsCoverageState(connection);
+  const hasHealthyCoverage = accountCoverage === 'covered';
   const currentCoverageFilter = accountCoverage === 'covered' ? 'covered' : accountCoverage === 'degraded' ? 'degraded' : 'missing';
   const rows: AWSInventoryCoverageRow[] = [
     {
@@ -3308,8 +3309,8 @@ function AWSAccountsInventoryContent({
     <>
       <AWSInventoryFilterSet routeID="accounts" filters={filters} onChange={onFiltersChange} />
       <section className="idt-aws-inventory-coverage" aria-label="AWS account and region coverage map">
-        <DomainCoverageCard label="Account coverage" scanned={connection?.account_id ? 1 : 0} total={1} detail="Selected environment" />
-        <DomainCoverageCard label="Region coverage" scanned={connection?.region ? 1 : 0} total={1} detail={connection?.region ?? 'Pending'} />
+        <DomainCoverageCard label="Account coverage" scanned={hasHealthyCoverage ? 1 : 0} total={1} detail="Selected environment" />
+        <DomainCoverageCard label="Region coverage" scanned={hasHealthyCoverage ? 1 : 0} total={1} detail={hasHealthyCoverage ? connection?.region ?? 'Pending' : 'Pending'} />
         <DomainCoverageCard label="Permission evidence" scanned={passedChecks} total={Math.max(totalChecks, 1)} detail="Read-only validation" />
       </section>
       <DomainDataTable

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -23075,6 +23075,86 @@ html[data-theme='light'] .idt-app-shell-screen select {
   font-weight: 850;
 }
 
+.idt-aws-inventory-boundary,
+.idt-aws-inventory-coverage,
+.idt-aws-resource-coverage-grid,
+.idt-aws-agent-relationship-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(13.5rem, 1fr));
+  gap: 0.75rem;
+}
+
+.idt-aws-inventory-boundary article,
+.idt-aws-agent-relationship-grid article {
+  border: 1px solid var(--app-border-soft);
+  border-radius: 8px;
+  padding: 0.78rem;
+  background: #050505;
+}
+
+.idt-aws-inventory-boundary strong,
+.idt-aws-agent-relationship-grid strong,
+.idt-domain-data-table strong {
+  color: #ffffff;
+}
+
+.idt-aws-inventory-boundary p,
+.idt-aws-agent-relationship-grid p {
+  margin-top: 0.22rem;
+}
+
+.idt-aws-inventory-table-cell {
+  display: grid;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.idt-aws-inventory-table-cell strong,
+.idt-aws-inventory-table-cell p {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.idt-aws-inventory-table-cell p {
+  margin: 0;
+  color: var(--app-muted);
+}
+
+.idt-aws-inventory-split {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(16rem, 0.55fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.idt-aws-inventory-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.55rem;
+  border: 1px solid var(--app-border);
+  border-radius: 999px;
+  padding: 0.18rem 0.52rem;
+  background: #050505;
+  color: #ffffff;
+  font-size: 0.72rem;
+  font-weight: 900;
+  white-space: nowrap;
+}
+
+.idt-aws-inventory-pill.is-success {
+  border-color: rgba(88, 214, 141, 0.5);
+  color: #acf2c4;
+}
+
+.idt-aws-inventory-pill.is-warning {
+  border-color: rgba(255, 153, 0, 0.48);
+  color: #ffdca8;
+}
+
+.idt-aws-inventory-pill.is-neutral {
+  color: var(--app-muted);
+}
+
 html[data-theme='light'] .idt-app-console-layout .idt-permission-preview-modal,
 html[data-theme='light'] .idt-app-console-layout .idt-permission-preview-list article,
 html[data-theme='light'] .idt-app-console-layout .idt-permission-tier {
@@ -23102,13 +23182,14 @@ html[data-theme='light'] .idt-app-console-layout .idt-permission-tier .idt-badge
 @media (max-width: 1100px) {
   .idt-domain-header,
   .idt-domain-page-body.has-subnav,
-  .idt-domain-page-body.has-subnav.has-aside,
-  .idt-aws-status-grid,
-  .idt-aws-connect-layout,
-  .idt-app-console-layout .idt-aws-connect-panel .idt-source-meta,
-  .idt-aws-next-actions {
-    grid-template-columns: 1fr;
-  }
+	  .idt-domain-page-body.has-subnav.has-aside,
+	  .idt-aws-status-grid,
+	  .idt-aws-connect-layout,
+	  .idt-aws-inventory-split,
+	  .idt-app-console-layout .idt-aws-connect-panel .idt-source-meta,
+	  .idt-aws-next-actions {
+	    grid-template-columns: 1fr;
+	  }
 
   .idt-domain-header-aside {
     justify-items: start;


### PR DESCRIPTION
Fixes #1386

## Summary
- Replaces the generic AWS inventory placeholders with dedicated account/region, machine identity, agent identity, and resource/credential inventory pages.
- Adds an environment-scoped AWS inventory data loader that uses the current connector state while keeping disconnected and no-environment states explicit.
- Builds premium AWS inventory surfaces with filters, KPIs, current-vs-planned capability boundaries, metadata-only resource posture, and clear Connect AWS handoffs.
- Adds route-level coverage for the four new AWS inventory pages.

## Validation
- `npm --prefix web test -- --run src/productShell.test.tsx`
- `npm run test:ci --prefix web` (15 files, 293 tests; jsdom printed its known navigation notice and exited 0)
- `npm run build --prefix web` (prerendered 39 routes)
- `git diff --check`
- Visual pass with Playwright + Chrome against a connected AWS workspace mock:
  - `/tmp/identrail-issue-1386-screenshots/aws-accounts.png`
  - `/tmp/identrail-issue-1386-screenshots/aws-identities.png`
  - `/tmp/identrail-issue-1386-screenshots/aws-agents.png`
  - `/tmp/identrail-issue-1386-screenshots/aws-resources.png`

## AI-Assisted and AI-Generated Code Policy
- `AI-assisted: yes`
- `Tools used:` OpenAI GPT-5 coding assistant
- `Where used:` AWS inventory page implementation, route wiring, tests, and validation scripting
- `Human verification performed:` local code review, automated tests, production build, and visual screenshot inspection

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements dedicated AWS inventory pages with environment-scoped data, wired filters/search, and gated coverage visuals. Replaces placeholder routes for accounts/regions, machine identities, agent identities, and resources, addressing #1386.

- New Features
  - New pages for `aws/accounts`, `aws/identities`, `aws/agents`, and `aws/resources` with environment selector, KPI strip, coverage/relationship grids, filter bar, and accessible tables.
  - Filters and search drive table rows; the ECS/Lambda identity row maps to both identity and service filters.
  - Prerequisites are gated: “Open environments” when none selected and “Connect AWS” when disconnected; AWS links preserve the selected environment.
  - Resources remain metadata-only with a “No secret value reads” safety panel and permission-evidence KPIs.

- Bug Fixes
  - Router mounts the new AWS inventory components instead of placeholder routes.
  - Skips AWS connection fetch when no environment; clearer loading and retryable error states.
  - Removed the unresolved “agent-to-user” filter option; aligned agent/resource filter sets and improved responsive styles.
  - Coverage state drives both account and current-region rows; shows “Degraded” when connection health is warning or status is degraded.
  - Account/region coverage cards are gated on a healthy connection; scanned counts show only when coverage is “Covered.”
  - Agent role anchor is shown only when the AWS connection is connected.

<sup>Written for commit 61edfbda7fe41e7588f5644ca134664e76e7c63a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

