### PR TITLE
Implement account deletion danger zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## Unreleased
+- Added the Settings Danger Zone UI for self-serve permanent account deletion:
+  a "Delete my account permanently" row, primary-email type-to-confirm modal,
+  data-export prompt, structured `sole_owner` workspace blocker, success
+  redirect to a pending-deletion recovery banner, and sign-in cancellation via
+  `POST /v1/me/cancel-deletion`.
 - Added self-serve "Download my data" exports. `POST /v1/me/export`
   enqueues an authenticated user export, `GET /v1/me/export/:job_id`
   polls job state and returns a 24-hour signed download URL once ready, and

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -196,7 +196,7 @@ function settingsSessionsPayload() {
 
 function settingsFetchMock(options: {
   onDelete?: () => ReturnType<typeof okJSON> | { ok: false; status: number; json: () => Promise<unknown> };
-  onCancelDeletion?: () => ReturnType<typeof okJSON>;
+  onCancelDeletion?: () => ReturnType<typeof okJSON> | { ok: false; status: number; json: () => Promise<unknown> };
 } = {}) {
   return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === 'string' ? input : input.toString();
@@ -2593,6 +2593,38 @@ describe('App', () => {
 
     await waitFor(() => expect(window.location.pathname).toBe('/app/tenant-a/workspace-a/settings'));
     expect(fetchMock.mock.calls.some(([url, init]) => String(url).endsWith('/v1/me/cancel-deletion') && init?.method === 'POST')).toBe(true);
+  });
+
+  it('offers hosted recovery when the pending-deletion recovery cookie is unavailable', async () => {
+    const fetchMock = settingsFetchMock({
+      onCancelDeletion: () => ({
+        ok: false,
+        status: 401,
+        json: async () => ({ error: 'session required' })
+      })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    setCurrentPath('/signin?reason=account_pending_deletion&return_to=%2Fapp%2Fteam%2Fworkspace');
+    render(<App />);
+
+    const expectedRecoveryURL = `http://localhost:8080/auth/signup?return_to=${encodeURIComponent(
+      `${window.location.origin}/app/team/workspace`
+    )}`;
+    expect(await screen.findByText(/scheduled for permanent deletion/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Continue with hosted recovery/i })).toHaveAttribute(
+      'href',
+      expectedRecoveryURL
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Cancel account deletion/i }));
+
+    expect(await screen.findByText(/no longer has the recovery session/i)).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: /Continue with hosted recovery/i })[0]).toHaveAttribute(
+      'href',
+      expectedRecoveryURL
+    );
+    expect(window.location.pathname).toBe('/signin');
   });
 
   it('supports workspace member invite workflow from app shell administration route', async () => {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -145,6 +145,94 @@ function currentMePayload(tenantID = 'default', workspaceID = 'default', role = 
   };
 }
 
+function settingsWhoAmIPayload(tenantID = 'tenant-a', workspaceID = 'workspace-a', role = 'admin') {
+  return {
+    principal: { type: 'subject', id: 'owner-user' },
+    roles: ['owner'],
+    scopes: ['read', 'write', 'admin'],
+    scope: { tenant_id: tenantID, workspace_id: workspaceID },
+    active_workspace: {
+      workspace: {
+        tenant_id: tenantID,
+        workspace_id: workspaceID,
+        display_name: 'Security Workspace',
+        slug: 'security-workspace',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-03T00:00:00Z'
+      },
+      member: {
+        tenant_id: tenantID,
+        workspace_id: workspaceID,
+        member_id: 'member-user-1',
+        user_id: 'user-1',
+        email: 'owner@example.com',
+        role,
+        status: 'active',
+        joined_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-03T00:00:00Z'
+      },
+      is_active: true
+    },
+    workspaces: []
+  };
+}
+
+function settingsSessionsPayload() {
+  return {
+    items: [
+      {
+        id: 'current-session',
+        ip: '127.0.0.1',
+        user_agent: 'current browser',
+        auth_method: 'workos',
+        created_at: '2026-01-01T00:00:00Z',
+        last_seen_at: '2026-01-01T00:00:00Z',
+        idle_expires_at: '2026-01-01T00:15:00Z',
+        current: true
+      }
+    ]
+  };
+}
+
+function settingsFetchMock(options: {
+  onDelete?: () => ReturnType<typeof okJSON> | { ok: false; status: number; json: () => Promise<unknown> };
+  onCancelDeletion?: () => ReturnType<typeof okJSON>;
+} = {}) {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const method = init?.method ?? 'GET';
+    if (url.endsWith('/v1/me') && method === 'DELETE') {
+      return options.onDelete
+        ? options.onDelete()
+        : okJSON({
+            status: 'deleted',
+            deleted_at: '2026-06-01T12:00:00.000Z',
+            hard_delete_after: '2026-07-01T12:00:00.000Z',
+            grace_period_hours: 720
+          });
+    }
+    if (url.endsWith('/v1/me/cancel-deletion') && method === 'POST') {
+      return options.onCancelDeletion ? options.onCancelDeletion() : okJSON({ status: 'active' });
+    }
+    if (url.endsWith('/v1/me') && method === 'GET') {
+      return okJSON(currentMePayload('tenant-a', 'workspace-a', 'admin'));
+    }
+    if (url.endsWith('/v1/whoami')) {
+      return okJSON(settingsWhoAmIPayload());
+    }
+    if (url.includes('/v1/workspaces/workspace-a/members')) {
+      return okJSON({ items: [] });
+    }
+    if (url.endsWith('/v1/auth/config')) {
+      return authConfig(false, true);
+    }
+    if (url.endsWith('/v1/me/sessions')) {
+      return okJSON(settingsSessionsPayload());
+    }
+    throw new Error(`Unexpected URL ${url}`);
+  });
+}
+
 function setCurrentPath(pathname: string) {
   act(() => {
     window.history.pushState({}, '', pathname);
@@ -2412,6 +2500,99 @@ describe('App', () => {
 
     expect(await within(exportRow).findByRole('alert')).toHaveTextContent(/data export is not configured/i);
     expect(screen.getByRole('heading', { level: 2, name: /Settings/i })).toBeInTheDocument();
+  });
+
+  it('gates permanent account deletion on exact primary email and redirects to recovery banner', async () => {
+    const fetchMock = settingsFetchMock();
+    vi.stubGlobal('fetch', fetchMock);
+
+    setCurrentPath('/app/tenant-a/workspace-a/settings');
+    render(<App />);
+
+    const dangerZone = await screen.findByTestId('idt-danger-zone');
+    fireEvent.click(within(dangerZone).getByRole('button', { name: /Delete account/i }));
+
+    const modal = await screen.findByRole('dialog', { name: /Delete my account permanently/i });
+    const continueButton = within(modal).getByRole('button', { name: 'Continue' });
+    expect(continueButton).toBeDisabled();
+
+    fireEvent.change(within(modal).getByLabelText(/Type your primary email/i), {
+      target: { value: 'owner@example.co' }
+    });
+    expect(continueButton).toBeDisabled();
+    expect(fetchMock.mock.calls.filter(([url, init]) => String(url).endsWith('/v1/me') && init?.method === 'DELETE')).toHaveLength(0);
+
+    fireEvent.change(within(modal).getByLabelText(/Type your primary email/i), {
+      target: { value: 'owner@example.com' }
+    });
+    expect(continueButton).toBeEnabled();
+    fireEvent.click(continueButton);
+
+    await waitFor(() => expect(window.location.pathname).toBe('/signin'));
+    const redirectQuery = new URLSearchParams(window.location.search);
+    expect(redirectQuery.get('reason')).toBe('account_pending_deletion');
+    expect(redirectQuery.get('hard_delete_after')).toBe('2026-07-01T12:00:00.000Z');
+    expect(await screen.findByText(/scheduled for permanent deletion on/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Cancel account deletion/i })).toBeInTheDocument();
+  });
+
+  it('renders sole-owner workspace blockers without deleting the account', async () => {
+    const fetchMock = settingsFetchMock({
+      onDelete: () => ({
+        ok: false,
+        status: 409,
+        json: async () => ({
+          error: 'user is the sole owner of one or more workspaces',
+          code: 'sole_owner',
+          workspaces: [
+            {
+              tenant_id: 'tenant-a',
+              workspace_id: 'workspace-a',
+              display_name: 'Security Workspace',
+              slug: 'security-workspace'
+            }
+          ]
+        })
+      })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    setCurrentPath('/app/tenant-a/workspace-a/settings');
+    render(<App />);
+
+    const dangerZone = await screen.findByTestId('idt-danger-zone');
+    fireEvent.click(within(dangerZone).getByRole('button', { name: /Delete account/i }));
+
+    const modal = await screen.findByRole('dialog', { name: /Delete my account permanently/i });
+    fireEvent.change(within(modal).getByLabelText(/Type your primary email/i), {
+      target: { value: 'owner@example.com' }
+    });
+    fireEvent.click(within(modal).getByRole('button', { name: 'Continue' }));
+
+    const blocker = await within(modal).findByTestId('idt-delete-sole-owner-workspaces');
+    expect(blocker).toHaveTextContent(/Promote another owner from member management/i);
+    expect(blocker).toHaveTextContent(/Security Workspace/i);
+    expect(within(blocker).getByRole('link', { name: /Manage members/i })).toHaveAttribute(
+      'href',
+      '/app/tenant-a/workspace-a/workspaces'
+    );
+    expect(window.location.pathname).toBe('/app/tenant-a/workspace-a/settings');
+  });
+
+  it('cancels pending account deletion from the sign-in recovery banner', async () => {
+    const fetchMock = settingsFetchMock();
+    vi.stubGlobal('fetch', fetchMock);
+
+    setCurrentPath(
+      '/signin?reason=account_pending_deletion&hard_delete_after=2026-07-01T12%3A00%3A00.000Z&return_to=%2Fapp%2Ftenant-a%2Fworkspace-a%2Fsettings'
+    );
+    render(<App />);
+
+    expect(await screen.findByText(/scheduled for permanent deletion on/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Cancel account deletion/i }));
+
+    await waitFor(() => expect(window.location.pathname).toBe('/app/tenant-a/workspace-a/settings'));
+    expect(fetchMock.mock.calls.some(([url, init]) => String(url).endsWith('/v1/me/cancel-deletion') && init?.method === 'POST')).toBe(true);
   });
 
   it('supports workspace member invite workflow from app shell administration route', async () => {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -439,6 +439,24 @@ export type CurrentUserProfileUpdate = {
   avatar_url?: string;
 };
 
+export type AccountDeletionWorkspace = {
+  tenant_id: string;
+  workspace_id: string;
+  display_name?: string;
+  slug?: string;
+};
+
+export type DeleteCurrentUserResponse = {
+  status: 'deleted';
+  deleted_at?: string | null;
+  hard_delete_after?: string;
+  grace_period_hours?: number;
+};
+
+export type CancelCurrentUserDeletionResponse = {
+  status: 'active';
+};
+
 export type OnboardingStep = 'org' | 'workspace' | 'connect' | 'scan' | 'invite' | 'complete';
 
 export type OnboardingState = {
@@ -1069,13 +1087,15 @@ export class ApiError extends Error {
   status: number;
   code?: string;
   detail?: string;
+  payload?: unknown;
 
-  constructor(message: string, status: number, options: { code?: string; detail?: string } = {}) {
+  constructor(message: string, status: number, options: { code?: string; detail?: string; payload?: unknown } = {}) {
     super(message);
     this.name = 'ApiError';
     this.status = status;
     this.code = options.code;
     this.detail = options.detail;
+    this.payload = options.payload;
   }
 }
 
@@ -1151,20 +1171,27 @@ async function request<T>(path: string, auth?: RequestAuthContext, init: Identra
     let message = `Request failed (${res.status})`;
     let code: string | undefined;
     let detail: string | undefined;
+    let payload: unknown;
     try {
-      const payload = (await res.json()) as { error?: string; error_code?: string; error_detail?: string };
-      if (payload?.error) {
-        message = payload.error;
+      payload = await res.json();
+      const errorPayload = payload as {
+        error?: string;
+        error_code?: string;
+        error_detail?: string;
+        code?: string;
+      };
+      if (errorPayload?.error) {
+        message = errorPayload.error;
       }
-      code = payload?.error_code;
-      detail = payload?.error_detail;
+      code = errorPayload?.error_code ?? errorPayload?.code;
+      detail = errorPayload?.error_detail;
     } catch {
       // Keep status-based message when server does not return a JSON error body.
     }
     if (res.status === 401 && redirectOnUnauthorized) {
       redirectToSignInForUnauthorized();
     }
-    throw new ApiError(message, res.status, { code, detail });
+    throw new ApiError(message, res.status, { code, detail, payload });
   }
   if (res.status === 204) {
     return undefined as T;
@@ -1218,6 +1245,17 @@ export const apiClient = {
   reactivateCurrentUser() {
     return request<{ status: 'active' }>('/v1/me/reactivate', undefined, {
       method: 'POST'
+    });
+  },
+  deleteMe() {
+    return request<DeleteCurrentUserResponse>('/v1/me', undefined, {
+      method: 'DELETE'
+    });
+  },
+  cancelCurrentUserDeletion() {
+    return request<CancelCurrentUserDeletionResponse>('/v1/me/cancel-deletion', undefined, {
+      method: 'POST',
+      redirectOnUnauthorized: false
     });
   },
   enqueueDataExport(init: RequestInit = {}) {

--- a/web/src/pages/SignInPage.tsx
+++ b/web/src/pages/SignInPage.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { apiClient, buildAPIURL, type AuthConfigResponse } from '../api/client';
 import { getCachedAuthConfig, loadAuthConfig } from '../authConfigCache';
+import { clearMeCache } from '../hooks/useMe';
 
 type AuthIntent = 'login' | 'signup';
 
@@ -81,6 +82,7 @@ type AuthReasonDetails = {
   message: string;
   actionLabel?: string;
   actionHref?: string;
+  actionKind?: 'cancel-deletion';
 };
 
 function authPathWithReturnTo(path: string, returnTo: string): string {
@@ -92,7 +94,15 @@ function authPathWithReturnTo(path: string, returnTo: string): string {
   return encoded ? `${path}?${encoded}` : path;
 }
 
-function authReasonDetails(reason: string, returnTo: string): AuthReasonDetails | null {
+function formatAuthDateLabel(value: string | null): string {
+  const parsed = new Date(value ?? '');
+  if (Number.isNaN(parsed.getTime())) {
+    return '';
+  }
+  return parsed.toLocaleString();
+}
+
+function authReasonDetails(reason: string, returnTo: string, hardDeleteAfter: string | null): AuthReasonDetails | null {
   switch (reason) {
     case 'session_expired':
       return { message: 'Your session expired. Sign in again to continue.' };
@@ -118,6 +128,16 @@ function authReasonDetails(reason: string, returnTo: string): AuthReasonDetails 
         actionLabel: 'Reactivate account',
         actionHref: authPathWithReturnTo('/signup', returnTo)
       };
+    case 'account_pending_deletion': {
+      const deletionDate = formatAuthDateLabel(hardDeleteAfter);
+      return {
+        message: deletionDate
+          ? `Your Identrail account is scheduled for permanent deletion on ${deletionDate}.`
+          : 'Your Identrail account is scheduled for permanent deletion.',
+        actionLabel: 'Cancel account deletion',
+        actionKind: 'cancel-deletion'
+      };
+    }
     case 'identity_conflict':
       return {
         message:
@@ -192,13 +212,19 @@ export function AuthChoicePage({ intent }: AuthChoicePageProps) {
   const query = useMemo(() => new URLSearchParams(location.search), [location.search]);
   const returnTo = normalizeReturnTo(query.get('return_to') ?? query.get('next'));
   const signedOut = query.get('signed_out') === '1';
-  const reason = authReasonDetails(query.get('reason') ?? '', returnTo);
+  const reason = authReasonDetails(
+    query.get('reason') ?? '',
+    returnTo,
+    query.get('hard_delete_after') ?? query.get('delete_at')
+  );
   const initialConfig = getCachedAuthConfig();
   const [config, setConfig] = useState<AuthConfigResponse | null>(initialConfig);
   const [loadingConfig, setLoadingConfig] = useState(!initialConfig);
   const [configError, setConfigError] = useState('');
   const [manualSubmitting, setManualSubmitting] = useState(false);
   const [manualError, setManualError] = useState('');
+  const [cancelDeletionPending, setCancelDeletionPending] = useState(false);
+  const [cancelDeletionError, setCancelDeletionError] = useState('');
   const [authTheme, setAuthTheme] = useState<AuthTheme>('dark');
   const [themeMenuOpen, setThemeMenuOpen] = useState(false);
   const [prefersDark, setPrefersDark] = useState(true);
@@ -278,6 +304,21 @@ export function AuthChoicePage({ intent }: AuthChoicePageProps) {
     }
   };
 
+  const handleCancelDeletion = async () => {
+    if (cancelDeletionPending) return;
+    setCancelDeletionPending(true);
+    setCancelDeletionError('');
+    try {
+      await apiClient.cancelCurrentUserDeletion();
+      clearMeCache();
+      navigate(returnTo, { replace: true });
+    } catch (error) {
+      setCancelDeletionError(error instanceof Error ? error.message : 'Unable to cancel account deletion.');
+    } finally {
+      setCancelDeletionPending(false);
+    }
+  };
+
   const providerIDs = config?.auth.providers ?? [];
   const hostedProviders =
     config?.auth.workos_login_enabled === true
@@ -307,16 +348,30 @@ export function AuthChoicePage({ intent }: AuthChoicePageProps) {
 
           {signedOut ? <p className="idt-app-alert idt-app-alert-success">Signed out successfully.</p> : null}
           {reason ? (
-            <p className="idt-app-alert">
+            <div className="idt-app-alert">
               {reason.message}
-              {reason.actionHref && reason.actionLabel ? (
+              {reason.actionKind === 'cancel-deletion' && reason.actionLabel ? (
+                <>
+                  {' '}
+                  <button
+                    className="idt-inline-button-link"
+                    disabled={cancelDeletionPending}
+                    onClick={handleCancelDeletion}
+                    type="button"
+                  >
+                    {cancelDeletionPending ? 'Canceling deletion...' : reason.actionLabel}
+                  </button>
+                  .
+                </>
+              ) : reason.actionHref && reason.actionLabel ? (
                 <>
                   {' '}
                   <Link to={reason.actionHref}>{reason.actionLabel}</Link>.
                 </>
               ) : null}
-            </p>
+            </div>
           ) : null}
+          {cancelDeletionError ? <p className="idt-app-alert idt-app-alert-error">{cancelDeletionError}</p> : null}
 
           {configError ? <p className="idt-app-alert idt-app-alert-error">{configError}</p> : null}
 

--- a/web/src/pages/SignInPage.tsx
+++ b/web/src/pages/SignInPage.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { apiClient, buildAPIURL, type AuthConfigResponse } from '../api/client';
+import { ApiError, apiClient, buildAPIURL, type AuthConfigResponse } from '../api/client';
 import { getCachedAuthConfig, loadAuthConfig } from '../authConfigCache';
 import { clearMeCache } from '../hooks/useMe';
 
@@ -83,6 +83,8 @@ type AuthReasonDetails = {
   actionLabel?: string;
   actionHref?: string;
   actionKind?: 'cancel-deletion';
+  recoveryHref?: string;
+  recoveryLabel?: string;
 };
 
 function authPathWithReturnTo(path: string, returnTo: string): string {
@@ -100,6 +102,13 @@ function formatAuthDateLabel(value: string | null): string {
     return '';
   }
   return parsed.toLocaleString();
+}
+
+function accountDeletionRecoveryHref(returnTo: string): string {
+  const query = new URLSearchParams();
+  const webReturnTo = typeof window === 'undefined' ? returnTo : new URL(returnTo, window.location.origin).toString();
+  query.set('return_to', webReturnTo);
+  return buildAPIURL(`/auth/signup?${query.toString()}`);
 }
 
 function authReasonDetails(reason: string, returnTo: string, hardDeleteAfter: string | null): AuthReasonDetails | null {
@@ -135,7 +144,9 @@ function authReasonDetails(reason: string, returnTo: string, hardDeleteAfter: st
           ? `Your Identrail account is scheduled for permanent deletion on ${deletionDate}.`
           : 'Your Identrail account is scheduled for permanent deletion.',
         actionLabel: 'Cancel account deletion',
-        actionKind: 'cancel-deletion'
+        actionKind: 'cancel-deletion',
+        recoveryHref: accountDeletionRecoveryHref(returnTo),
+        recoveryLabel: 'Continue with hosted recovery'
       };
     }
     case 'identity_conflict':
@@ -225,6 +236,7 @@ export function AuthChoicePage({ intent }: AuthChoicePageProps) {
   const [manualError, setManualError] = useState('');
   const [cancelDeletionPending, setCancelDeletionPending] = useState(false);
   const [cancelDeletionError, setCancelDeletionError] = useState('');
+  const [cancelDeletionNeedsRecovery, setCancelDeletionNeedsRecovery] = useState(false);
   const [authTheme, setAuthTheme] = useState<AuthTheme>('dark');
   const [themeMenuOpen, setThemeMenuOpen] = useState(false);
   const [prefersDark, setPrefersDark] = useState(true);
@@ -308,12 +320,24 @@ export function AuthChoicePage({ intent }: AuthChoicePageProps) {
     if (cancelDeletionPending) return;
     setCancelDeletionPending(true);
     setCancelDeletionError('');
+    setCancelDeletionNeedsRecovery(false);
     try {
       await apiClient.cancelCurrentUserDeletion();
       clearMeCache();
       navigate(returnTo, { replace: true });
     } catch (error) {
-      setCancelDeletionError(error instanceof Error ? error.message : 'Unable to cancel account deletion.');
+      if (error instanceof ApiError && error.status === 401) {
+        const recoveryHref = reason?.recoveryHref;
+        setCancelDeletionNeedsRecovery(true);
+        setCancelDeletionError(
+          'This browser no longer has the recovery session. Continue with hosted recovery to cancel deletion.'
+        );
+        if (recoveryHref) {
+          window.location.assign(recoveryHref);
+        }
+      } else {
+        setCancelDeletionError(error instanceof Error ? error.message : 'Unable to cancel account deletion.');
+      }
     } finally {
       setCancelDeletionPending(false);
     }
@@ -369,9 +393,22 @@ export function AuthChoicePage({ intent }: AuthChoicePageProps) {
                   <Link to={reason.actionHref}>{reason.actionLabel}</Link>.
                 </>
               ) : null}
+              {reason.recoveryHref && reason.recoveryLabel ? (
+                <>
+                  {' '}
+                  <span className="idt-auth-recovery-fallback">
+                    No recovery cookie? <a href={reason.recoveryHref}>{reason.recoveryLabel}</a>.
+                  </span>
+                </>
+              ) : null}
             </div>
           ) : null}
           {cancelDeletionError ? <p className="idt-app-alert idt-app-alert-error">{cancelDeletionError}</p> : null}
+          {cancelDeletionNeedsRecovery && reason?.recoveryHref && reason.recoveryLabel ? (
+            <p className="idt-app-alert">
+              <a href={reason.recoveryHref}>{reason.recoveryLabel}</a>
+            </p>
+          ) : null}
 
           {configError ? <p className="idt-app-alert idt-app-alert-error">{configError}</p> : null}
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -28,6 +28,7 @@ import {
   ApiError,
   apiClient,
   buildAPIURL,
+  type AccountDeletionWorkspace,
   type AuthConfigResponse,
   type AWSCapabilityPermissionTier,
   type AWSConnectorStartResponse,
@@ -12820,6 +12821,34 @@ async function requestDataExport({ signal, setExportPending, setExportError, set
   }
 }
 
+function accountDeletionWorkspacesFromError(error: ApiError): AccountDeletionWorkspace[] {
+  const payload = error.payload as { workspaces?: unknown } | undefined;
+  if (!Array.isArray(payload?.workspaces)) {
+    return [];
+  }
+  return payload.workspaces.filter((workspace): workspace is AccountDeletionWorkspace => {
+    if (!workspace || typeof workspace !== 'object') {
+      return false;
+    }
+    const record = workspace as Partial<AccountDeletionWorkspace>;
+    return typeof record.workspace_id === 'string' && record.workspace_id.trim() !== '';
+  });
+}
+
+function accountDeletionWorkspaceLabel(workspace: AccountDeletionWorkspace): string {
+  const displayName = workspace.display_name?.trim();
+  const slug = workspace.slug?.trim();
+  return displayName || slug || workspace.workspace_id;
+}
+
+function accountDeletionSignInPath(hardDeleteAfter?: string): string {
+  const query = new URLSearchParams({ reason: 'account_pending_deletion' });
+  if (hardDeleteAfter?.trim()) {
+    query.set('hard_delete_after', hardDeleteAfter);
+  }
+  return `/signin?${query.toString()}`;
+}
+
 export function ProductSettingsPage() {
   const params = useParams<ScopeRouteParams>();
   const scope = resolveScopeFromParams(params);
@@ -12839,6 +12868,10 @@ export function ProductSettingsPage() {
   const [suspendModalOpen, setSuspendModalOpen] = useState(false);
   const [suspendPending, setSuspendPending] = useState(false);
   const [suspendError, setSuspendError] = useState('');
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [deletePending, setDeletePending] = useState(false);
+  const [deleteError, setDeleteError] = useState('');
+  const [deleteSoleOwnerWorkspaces, setDeleteSoleOwnerWorkspaces] = useState<AccountDeletionWorkspace[]>([]);
   const [exportPending, setExportPending] = useState(false);
   const [exportError, setExportError] = useState('');
   const [exportStatus, setExportStatus] = useState<
@@ -12974,6 +13007,7 @@ export function ProductSettingsPage() {
   const githubFindingsPath = scope ? buildScopedPath(scope, 'github/findings') : '/app';
   const kubernetesPath = scope ? buildScopedPath(scope, 'kubernetes') : '/app';
   const workspacesPath = scope ? buildScopedPath(scope, 'workspaces') : '/app';
+  const primaryEmail = me?.user.primary_email?.trim() ?? '';
   const profileDisplayName = formatProfileDisplayName(me);
   const profileAvatarURL = me?.user.avatar_url?.trim() ?? '';
   const profileInitials = formatProfileInitials(me);
@@ -13083,6 +13117,41 @@ export function ProductSettingsPage() {
       setSessionsError(message);
     } finally {
       setRevokingOthers(false);
+    }
+  };
+
+  const handleOpenDeleteModal = () => {
+    setDeleteError('');
+    setDeleteSoleOwnerWorkspaces([]);
+    setDeleteModalOpen(true);
+  };
+
+  const handleCancelDeleteModal = () => {
+    if (deletePending) return;
+    setDeleteModalOpen(false);
+    setDeleteError('');
+    setDeleteSoleOwnerWorkspaces([]);
+  };
+
+  const handleDeleteAccount = async () => {
+    if (deletePending) return;
+    setDeletePending(true);
+    setDeleteError('');
+    setDeleteSoleOwnerWorkspaces([]);
+    try {
+      const response = await apiClient.deleteMe();
+      resetProductAuthSessionCache({ unauthenticated: true });
+      clearMeCache({ unauthenticated: true });
+      navigate(accountDeletionSignInPath(response.hard_delete_after), { replace: true });
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409 && err.code === 'sole_owner') {
+        setDeleteSoleOwnerWorkspaces(accountDeletionWorkspacesFromError(err));
+        setDeleteError('');
+      } else {
+        setDeleteError(err instanceof Error ? err.message : 'Unable to delete your account. Please retry.');
+      }
+    } finally {
+      setDeletePending(false);
     }
   };
 
@@ -13354,74 +13423,74 @@ export function ProductSettingsPage() {
         </div>
       </details>
 
-<details className="idt-settings-card idt-settings-disclosure idt-settings-sessions-card">
-  <summary className="idt-settings-disclosure-summary">
-    <div>
-      <p className="idt-app-kicker">Sessions</p>
-      <h3>{sessionsLoading ? 'Loading sessions' : formatCountLabel(sessions.length, 'active session')}</h3>
-      <p>{sessionsSummary}</p>
-    </div>
-    <span>Manage sessions</span>
-  </summary>
-  <div className="idt-settings-disclosure-body">
-    {sessionsLoading ? <p className="idt-app-alert">Loading active sessions...</p> : null}
-    {sessionsError ? (
-      <p className="idt-app-alert idt-app-alert-error" role="alert">
-        {sessionsError}
-      </p>
-    ) : null}
-    {!sessionsLoading ? (
-      <SessionsList
-        busySessionID={busySessionID}
-        revokingOthers={revokingOthers}
-        sessions={sessions}
-        onRevoke={handleRevokeSession}
-        onRevokeOthers={handleRevokeOtherSessions}
-      />
-    ) : null}
-  </div>
-</details>
+      <details className="idt-settings-card idt-settings-disclosure idt-settings-sessions-card">
+        <summary className="idt-settings-disclosure-summary">
+          <div>
+            <p className="idt-app-kicker">Sessions</p>
+            <h3>{sessionsLoading ? 'Loading sessions' : formatCountLabel(sessions.length, 'active session')}</h3>
+            <p>{sessionsSummary}</p>
+          </div>
+          <span>Manage sessions</span>
+        </summary>
+        <div className="idt-settings-disclosure-body">
+          {sessionsLoading ? <p className="idt-app-alert">Loading active sessions...</p> : null}
+          {sessionsError ? (
+            <p className="idt-app-alert idt-app-alert-error" role="alert">
+              {sessionsError}
+            </p>
+          ) : null}
+          {!sessionsLoading ? (
+            <SessionsList
+              busySessionID={busySessionID}
+              revokingOthers={revokingOthers}
+              sessions={sessions}
+              onRevoke={handleRevokeSession}
+              onRevokeOthers={handleRevokeOtherSessions}
+            />
+          ) : null}
+        </div>
+      </details>
 
-<DangerZone description="Suspending your account signs you out everywhere. Reactivate it any time by signing in through the signup flow.">
-  <article
-    className="idt-danger-zone-row idt-danger-zone-row--neutral"
-    data-testid="idt-export-account-row"
-  >
-    <div>
-      <strong>Download my data</strong>
-      <p>
-        Export a ZIP of your profile, workspaces, sessions, and audit activity.
-        The download link is valid for 24 hours.
-      </p>
-      {exportStatus.kind === 'ready' ? (
-        <p className="idt-danger-zone-success" data-testid="idt-export-ready">
-          Your data export is ready.{' '}
-          <a href={exportStatus.downloadURL} rel="noopener noreferrer">
-            Download the ZIP
-          </a>
-          {exportStatus.expiresAt ? ` (link expires ${new Date(exportStatus.expiresAt).toLocaleString()})` : ''}.
-        </p>
-      ) : exportStatus.kind === 'preparing' ? (
-        <p className="idt-danger-zone-status" data-testid="idt-export-preparing">
-          {exportStatus.message}
-        </p>
-      ) : null}
-      {exportError ? (
-        <p className="idt-danger-zone-error" role="alert">
-          {exportError}
-        </p>
-      ) : null}
-    </div>
-    <button
-      className="idt-btn idt-btn-secondary"
-      data-testid="idt-export-account-button"
-      disabled={exportPending}
-      onClick={startDataExport}
-      type="button"
-    >
-      {exportPending ? 'Preparing…' : 'Download my data'}
-    </button>
-  </article>
+      <DangerZone description="Export your data first, suspend access temporarily, or schedule permanent account deletion after the 30-day grace window.">
+        <article
+          className="idt-danger-zone-row idt-danger-zone-row--neutral"
+          data-testid="idt-export-account-row"
+        >
+          <div>
+            <strong>Download my data</strong>
+            <p>
+              Export a ZIP of your profile, workspaces, sessions, and audit activity. The download link is
+              valid for 24 hours.
+            </p>
+            {exportStatus.kind === 'ready' ? (
+              <p className="idt-danger-zone-success" data-testid="idt-export-ready">
+                Your data export is ready.{' '}
+                <a href={exportStatus.downloadURL} rel="noopener noreferrer">
+                  Download the ZIP
+                </a>
+                {exportStatus.expiresAt ? ` (link expires ${new Date(exportStatus.expiresAt).toLocaleString()})` : ''}.
+              </p>
+            ) : exportStatus.kind === 'preparing' ? (
+              <p className="idt-danger-zone-status" data-testid="idt-export-preparing">
+                {exportStatus.message}
+              </p>
+            ) : null}
+            {exportError ? (
+              <p className="idt-danger-zone-error" role="alert">
+                {exportError}
+              </p>
+            ) : null}
+          </div>
+          <button
+            className="idt-btn idt-btn-secondary"
+            data-testid="idt-export-account-button"
+            disabled={exportPending}
+            onClick={startDataExport}
+            type="button"
+          >
+            {exportPending ? 'Preparing…' : 'Download my data'}
+          </button>
+        </article>
 
         <DangerZoneRow
           actionLabel="Suspend account"
@@ -13433,6 +13502,15 @@ export function ProductSettingsPage() {
           pending={suspendPending}
           testId="idt-suspend-account-row"
           title="Account access"
+        />
+        <DangerZoneRow
+          actionLabel="Delete account"
+          description="Schedules permanent account deletion, revokes every other session, and removes your access to all workspaces after the recovery window."
+          disabled={!primaryEmail}
+          onAction={handleOpenDeleteModal}
+          pending={deletePending}
+          testId="idt-delete-account-row"
+          title="Delete my account permanently"
         />
       </DangerZone>
 
@@ -13479,6 +13557,63 @@ export function ProductSettingsPage() {
         open={suspendModalOpen}
         pending={suspendPending}
         title="Suspend account"
+      />
+      <ConfirmDestructiveModal
+        body={
+          <>
+            <p>
+              Deleting your account immediately marks it for deletion and blocks normal sign-in. Identrail
+              keeps a recovery cookie in this browser so you can cancel deletion during the 30-day grace
+              window.
+            </p>
+            <p>
+              Permanent hard deletion happens after the grace period. Download your account archive first if
+              you need profile, workspace, session, or audit data.{' '}
+              <button
+                className="idt-inline-button-link"
+                disabled={exportPending}
+                onClick={startDataExport}
+                type="button"
+              >
+                {exportPending ? 'Preparing export' : 'Download my data'}
+              </button>
+              .
+            </p>
+            {deleteSoleOwnerWorkspaces.length > 0 ? (
+              <div
+                className="idt-danger-modal-blocker"
+                data-testid="idt-delete-sole-owner-workspaces"
+                role="alert"
+              >
+                <p>
+                  You are the sole owner of these workspaces. Promote another owner from member management
+                  before deleting your account.
+                </p>
+                <ul>
+                  {deleteSoleOwnerWorkspaces.map((workspace) => (
+                    <li key={`${workspace.tenant_id}:${workspace.workspace_id}`}>
+                      {accountDeletionWorkspaceLabel(workspace)}
+                    </li>
+                  ))}
+                </ul>
+                <Link to={workspacesPath}>Manage members</Link>
+              </div>
+            ) : null}
+          </>
+        }
+        confirmation={{
+          kind: 'type-to-confirm',
+          expectedValue: primaryEmail,
+          inputLabel: 'Type your primary email',
+          helpText: 'Use the primary email shown in your account profile.'
+        }}
+        continueLabel="Continue"
+        errorMessage={deleteError || undefined}
+        onCancel={handleCancelDeleteModal}
+        onConfirm={handleDeleteAccount}
+        open={deleteModalOpen}
+        pending={deletePending}
+        title="Delete my account permanently"
       />
     </section>
   );

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -12831,7 +12831,12 @@ function accountDeletionWorkspacesFromError(error: ApiError): AccountDeletionWor
       return false;
     }
     const record = workspace as Partial<AccountDeletionWorkspace>;
-    return typeof record.workspace_id === 'string' && record.workspace_id.trim() !== '';
+    return (
+      typeof record.tenant_id === 'string' &&
+      record.tenant_id.trim() !== '' &&
+      typeof record.workspace_id === 'string' &&
+      record.workspace_id.trim() !== ''
+    );
   });
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -29197,6 +29197,25 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
   font-size: 0.9rem;
 }
 
+.idt-danger-modal-blocker {
+  margin-top: 0.65rem;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid rgba(220, 129, 129, 0.44);
+  border-radius: 0.5rem;
+  background: rgba(40, 12, 16, 0.65);
+  color: #ffd0d0;
+}
+
+.idt-danger-modal-blocker ul {
+  margin: 0.35rem 0 0.45rem;
+  padding-left: 1.1rem;
+}
+
+.idt-danger-modal-blocker a {
+  color: #ffffff;
+  font-weight: 750;
+}
+
 .idt-danger-modal-actions {
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
## Summary
- Add the Settings Danger Zone delete-account row with primary-email type-to-confirm, data export prompt, and structured sole-owner workspace guidance.
- Add account deletion/cancel-deletion client methods while preserving structured API error payloads.
- Add the sign-in pending-deletion recovery banner with a cancel-deletion action and focused coverage for success, blocking, and recovery flows.

## Validation
- `npm run build` in `web/`
- `npm run test:ci` in `web/` (293 tests passed; jsdom printed `Not implemented: navigation to another Document` but exited successfully)

Fixes #1419

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Settings Danger Zone to let users schedule permanent account deletion with a primary‑email type‑to‑confirm modal and a sign‑in recovery banner to cancel within the 30‑day grace window. Handles sole‑owner workspace blockers and adds client APIs for delete/cancel with structured error details. Fixes #1419.

- **New Features**
  - Delete account row with a modal that requires typing your exact primary email; includes a one‑click “Download my data” action.
  - After delete, redirect to `/signin?reason=account_pending_deletion&hard_delete_after=...`; the banner shows the deletion date, lets you “Cancel account deletion,” and offers hosted recovery if the recovery cookie is missing.
  - Sole‑owner blockers: on `409 sole_owner`, show affected workspaces and link to “Manage members.”
  - API: `apiClient.deleteMe()` (`DELETE /v1/me`) and `apiClient.cancelCurrentUserDeletion()` (`POST /v1/me/cancel-deletion`); `ApiError` now preserves structured error `payload` and `code`.

<sup>Written for commit fe74d14fe1b9c51656c82ad4fe6802ae7c59da36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

