### PR TITLE
Polish settings account controls

### DIFF
--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -5240,8 +5240,8 @@ components:
           description: Trimmed display name. Control and bidirectional formatting characters are rejected.
         avatar_url:
           type: string
-          pattern: '^$|^[Hh][Tt][Tt][Pp][Ss]://([A-Za-z0-9-]+\.)*(avatars\.githubusercontent\.com|githubusercontent\.com|googleusercontent\.com|gravatar\.com|identrail\.com|identrail\.io)(:[0-9]+)?(/.*)?$'
-          description: Blank to clear, otherwise an allowed https avatar URL hosted under githubusercontent.com, googleusercontent.com, gravatar.com, identrail.com, or identrail.io.
+          pattern: '^$|^[Hh][Tt][Tt][Pp][Ss]://([A-Za-z0-9-]+\.)*(avatars\.githubusercontent\.com|githubusercontent\.com|googleusercontent\.com|gravatar\.com|identrail\.com|identrail\.io)(:[0-9]+)?(/.*)?$|^data:image/(png|jpe?g|webp|gif);base64,[A-Za-z0-9+/]+={0,2}$'
+          description: Blank to clear, an allowed https avatar URL, or a base64 image data URL for PNG, JPG, WebP, or GIF under 512 KB.
     CurrentUserContext:
       type: object
       properties:

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -5240,8 +5240,8 @@ components:
           description: Trimmed display name. Control and bidirectional formatting characters are rejected.
         avatar_url:
           type: string
-          pattern: '^$|^[Hh][Tt][Tt][Pp][Ss]://([A-Za-z0-9-]+\.)*(avatars\.githubusercontent\.com|githubusercontent\.com|googleusercontent\.com|gravatar\.com|identrail\.com|identrail\.io)(:[0-9]+)?(/.*)?$|^data:image/(png|jpe?g|webp|gif);base64,[A-Za-z0-9+/]+={0,2}$'
-          description: Blank to clear, an allowed https avatar URL, or a base64 image data URL for PNG, JPG, WebP, or GIF under 512 KB.
+          pattern: '^$|^[Hh][Tt][Tt][Pp][Ss]://([A-Za-z0-9-]+\.)*(avatars\.githubusercontent\.com|githubusercontent\.com|googleusercontent\.com|gravatar\.com|identrail\.com|identrail\.io)(:[0-9]+)?(/.*)?$|^data:image/(png|jpeg|webp|gif);base64,[A-Za-z0-9+/]+={0,2}$'
+          description: Blank to clear, an allowed https avatar URL, or a base64 image data URL for PNG, JPEG, WebP, or GIF under 512 KB.
     CurrentUserContext:
       type: object
       properties:

--- a/internal/api/auth_session_test.go
+++ b/internal/api/auth_session_test.go
@@ -163,6 +163,26 @@ func TestCurrentSessionUpdateCurrentUserProfile(t *testing.T) {
 	}
 }
 
+func TestCurrentSessionUpdateCurrentUserProfileAcceptsImageDataAvatar(t *testing.T) {
+	harness, cookieValue, _ := setupSessionRouter(t)
+	avatarDataURL := "data:image/png;base64,YXZhdGFy"
+	req := patchCurrentUserProfileRequest(cookieValue, `{"avatar_url":"`+avatarDataURL+`"}`)
+	w := httptest.NewRecorder()
+	harness.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected PATCH /v1/me 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var response struct {
+		Me CurrentUserContext `json:"me"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("decode profile update response: %v", err)
+	}
+	if response.Me.User.AvatarURL != avatarDataURL {
+		t.Fatalf("unexpected avatar_url: %q", response.Me.User.AvatarURL)
+	}
+}
+
 func TestCurrentSessionUpdateCurrentUserProfileRejectsInvalidPayloads(t *testing.T) {
 	cases := []struct {
 		name string
@@ -174,7 +194,7 @@ func TestCurrentSessionUpdateCurrentUserProfileRejectsInvalidPayloads(t *testing
 		{name: "control character display name", body: `{"display_name":"Bad\nName"}`},
 		{name: "bidirectional formatting display name", body: `{"display_name":"evil\u202eadmin"}`},
 		{name: "arabic letter mark display name", body: `{"display_name":"evil\u061cadmin"}`},
-		{name: "data uri avatar", body: `{"avatar_url":"data:image/png;base64,abc"}`},
+		{name: "invalid data uri avatar", body: `{"avatar_url":"data:text/plain;base64,abc"}`},
 		{name: "http avatar", body: `{"avatar_url":"http://avatars.githubusercontent.com/u/1"}`},
 		{name: "disallowed avatar host", body: `{"avatar_url":"https://example.com/avatar.png"}`},
 		{name: "empty body", body: ``},

--- a/internal/api/service_auth.go
+++ b/internal/api/service_auth.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"net/url"
@@ -1003,14 +1004,26 @@ var currentUserAvatarAllowedHostSuffixes = []string{
 	"identrail.io",
 }
 
+var currentUserAvatarAllowedDataTypes = map[string]struct{}{
+	"image/gif":  {},
+	"image/jpeg": {},
+	"image/png":  {},
+	"image/webp": {},
+}
+
+const currentUserAvatarMaxDataBytes = 512 * 1024
+
 func normalizeCurrentUserAvatarURL(raw string) (string, error) {
 	avatarURL := strings.TrimSpace(raw)
 	if avatarURL == "" {
 		return "", nil
 	}
+	if len(avatarURL) >= len("data:") && strings.EqualFold(avatarURL[:len("data:")], "data:") {
+		return normalizeCurrentUserAvatarDataURL(avatarURL)
+	}
 	parsed, err := url.Parse(avatarURL)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-		return "", invalidCurrentUserProfileUpdate("avatar_url must be a valid https URL")
+		return "", invalidCurrentUserProfileUpdate("avatar_url must be a valid https URL or image data URL")
 	}
 	if !strings.EqualFold(parsed.Scheme, "https") {
 		return "", invalidCurrentUserProfileUpdate("avatar_url must use https")
@@ -1022,6 +1035,39 @@ func normalizeCurrentUserAvatarURL(raw string) (string, error) {
 		return "", invalidCurrentUserProfileUpdate("avatar_url host is not allowed")
 	}
 	return avatarURL, nil
+}
+
+func normalizeCurrentUserAvatarDataURL(raw string) (string, error) {
+	header, encoded, ok := strings.Cut(raw, ",")
+	if !ok {
+		return "", invalidCurrentUserProfileUpdate("avatar_url must be a valid image data URL")
+	}
+	if len(header) < len("data:") || !strings.EqualFold(header[:len("data:")], "data:") {
+		return "", invalidCurrentUserProfileUpdate("avatar_url must be a valid image data URL")
+	}
+	mediaType := header[len("data:"):]
+	parts := strings.Split(mediaType, ";")
+	if len(parts) < 2 || !strings.EqualFold(parts[len(parts)-1], "base64") {
+		return "", invalidCurrentUserProfileUpdate("avatar_url must be a base64 image data URL")
+	}
+	contentType := strings.ToLower(strings.TrimSpace(parts[0]))
+	if _, ok := currentUserAvatarAllowedDataTypes[contentType]; !ok {
+		return "", invalidCurrentUserProfileUpdate("avatar_url image type must be PNG, JPG, WebP, or GIF")
+	}
+	if len(encoded) == 0 {
+		return "", invalidCurrentUserProfileUpdate("avatar_url image data is required")
+	}
+	if len(encoded) > base64.StdEncoding.EncodedLen(currentUserAvatarMaxDataBytes) {
+		return "", invalidCurrentUserProfileUpdate("avatar_url image must be smaller than 512 KB")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", invalidCurrentUserProfileUpdate("avatar_url must be valid base64 image data")
+	}
+	if len(decoded) > currentUserAvatarMaxDataBytes {
+		return "", invalidCurrentUserProfileUpdate("avatar_url image must be smaller than 512 KB")
+	}
+	return raw, nil
 }
 
 func currentUserAvatarHostAllowed(rawHost string) bool {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -2513,16 +2513,20 @@ describe('App', () => {
     fireEvent.click(within(dangerZone).getByRole('button', { name: /Delete account/i }));
 
     const modal = await screen.findByRole('dialog', { name: /Delete account/i });
-    const continueButton = within(modal).getByRole('button', { name: 'Continue' });
+    expect(modal).toHaveTextContent('This starts a 30-day recovery window and blocks normal sign-in.');
+    expect(modal).toHaveTextContent('Need an archive? Download my data before deleting.');
+    expect(modal).toHaveTextContent('Enter owner@example.com exactly.');
+    expect(modal).not.toHaveTextContent('recovery cookie');
+    const continueButton = within(modal).getByRole('button', { name: 'Delete account' });
     expect(continueButton).toBeDisabled();
 
-    fireEvent.change(within(modal).getByLabelText(/Type your primary email/i), {
+    fireEvent.change(within(modal).getByLabelText(/Confirm primary email/i), {
       target: { value: 'owner@example.co' }
     });
     expect(continueButton).toBeDisabled();
     expect(fetchMock.mock.calls.filter(([url, init]) => String(url).endsWith('/v1/me') && init?.method === 'DELETE')).toHaveLength(0);
 
-    fireEvent.change(within(modal).getByLabelText(/Type your primary email/i), {
+    fireEvent.change(within(modal).getByLabelText(/Confirm primary email/i), {
       target: { value: 'owner@example.com' }
     });
     expect(continueButton).toBeEnabled();
@@ -2564,13 +2568,13 @@ describe('App', () => {
     fireEvent.click(within(dangerZone).getByRole('button', { name: /Delete account/i }));
 
     const modal = await screen.findByRole('dialog', { name: /Delete account/i });
-    fireEvent.change(within(modal).getByLabelText(/Type your primary email/i), {
+    fireEvent.change(within(modal).getByLabelText(/Confirm primary email/i), {
       target: { value: 'owner@example.com' }
     });
-    fireEvent.click(within(modal).getByRole('button', { name: 'Continue' }));
+    fireEvent.click(within(modal).getByRole('button', { name: 'Delete account' }));
 
     const blocker = await within(modal).findByTestId('idt-delete-sole-owner-workspaces');
-    expect(blocker).toHaveTextContent(/Promote another owner from member management/i);
+    expect(blocker).toHaveTextContent(/Transfer ownership for these workspaces/i);
     expect(blocker).toHaveTextContent(/Security Workspace/i);
     expect(within(blocker).getByRole('link', { name: /Manage members/i })).toHaveAttribute(
       'href',

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -2350,10 +2350,11 @@ describe('App', () => {
 
     expect(await screen.findByText(/Security Workspace/i)).toBeInTheDocument();
     expect(await screen.findByRole('heading', { level: 2, name: /Settings/i })).toBeInTheDocument();
-    expect(await screen.findByText(/Hosted WorkOS login/i)).toBeInTheDocument();
-    expect(await screen.findByText(/^None$/i)).toBeInTheDocument();
+    expect(await screen.findByText(/GitHub, Google/i)).toBeInTheDocument();
+    expect(await screen.findAllByText(/Hosted login/i)).toHaveLength(2);
+    expect(await screen.findByText(/Not configured/i)).toBeInTheDocument();
+    expect(screen.getByText(/Developer details/i)).toBeInTheDocument();
     expect(await screen.findByText(/Total members/i)).toBeInTheDocument();
-    expect(await screen.findByRole('heading', { level: 3, name: /1 active session/i })).toBeInTheDocument();
     expect(screen.getByText(/Manage sessions/i)).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /Account security/i })).not.toBeInTheDocument();
   });
@@ -2429,8 +2430,7 @@ describe('App', () => {
     setCurrentPath('/app/tenant-a/workspace-a/settings');
     render(<App />);
 
-    const dangerZone = await screen.findByTestId('idt-danger-zone');
-    const exportRow = within(dangerZone).getByTestId('idt-export-account-row');
+    const exportRow = await screen.findByTestId('idt-export-account-row');
     fireEvent.click(within(exportRow).getByRole('button', { name: /Download my data/i }));
 
     expect(await within(exportRow).findByTestId('idt-export-ready')).toHaveTextContent(/Your data export is ready/i);
@@ -2512,7 +2512,7 @@ describe('App', () => {
     const dangerZone = await screen.findByTestId('idt-danger-zone');
     fireEvent.click(within(dangerZone).getByRole('button', { name: /Delete account/i }));
 
-    const modal = await screen.findByRole('dialog', { name: /Delete my account permanently/i });
+    const modal = await screen.findByRole('dialog', { name: /Delete account/i });
     const continueButton = within(modal).getByRole('button', { name: 'Continue' });
     expect(continueButton).toBeDisabled();
 
@@ -2563,7 +2563,7 @@ describe('App', () => {
     const dangerZone = await screen.findByTestId('idt-danger-zone');
     fireEvent.click(within(dangerZone).getByRole('button', { name: /Delete account/i }));
 
-    const modal = await screen.findByRole('dialog', { name: /Delete my account permanently/i });
+    const modal = await screen.findByRole('dialog', { name: /Delete account/i });
     fireEvent.change(within(modal).getByLabelText(/Type your primary email/i), {
       target: { value: 'owner@example.com' }
     });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2597,7 +2597,7 @@ function ScanIntakeModal({ onClose }: { onClose: () => void }) {
   return (
     <ModalShell titleId="scan-intake-title" onClose={onClose} className="idt-scan-modal">
       <button type="button" className="idt-modal-close" onClick={onClose} aria-label="Close dialog">
-        x
+        ESC
       </button>
       <div className="idt-scan-modal-shell">
         <aside className="idt-scan-modal-guide" aria-label="Scan request guidance">
@@ -3485,7 +3485,7 @@ function PricingPage() {
             aria-label="Close"
             onClick={() => setSalesModalOpen(false)}
           >
-            x
+            ESC
           </button>
           <h3 id="sales-modal-title">Contact Enterprise Sales</h3>
           <p>Tell us your environment size and compliance goals. We will tailor a deployment and pricing plan.</p>

--- a/web/src/components/app/DomainFoundation.tsx
+++ b/web/src/components/app/DomainFoundation.tsx
@@ -910,7 +910,7 @@ export function DomainDetailDrawer({
             <h3>{title}</h3>
           </div>
           <button type="button" className="idt-domain-drawer-close" onClick={onClose} aria-label={closeLabel}>
-            <span aria-hidden="true">×</span>
+            ESC
           </button>
         </header>
         <div className="idt-domain-drawer-body">{children}</div>

--- a/web/src/components/connector/PermissionPreviewModal.tsx
+++ b/web/src/components/connector/PermissionPreviewModal.tsx
@@ -52,8 +52,8 @@ export function PermissionPreviewModal({ open, title, items, tiers, onClose }: P
             <p className="idt-app-kicker">Permission preview</p>
             <h3 id="permission-preview-title">{title}</h3>
           </div>
-          <button className="idt-icon-btn" type="button" aria-label="Close permission preview" onClick={onClose}>
-            x
+          <button className="idt-esc-close" type="button" aria-label="Close permission preview" onClick={onClose}>
+            ESC
           </button>
         </header>
         {tiers && tiers.length > 0 ? (

--- a/web/src/components/settings/DangerZone.tsx
+++ b/web/src/components/settings/DangerZone.tsx
@@ -23,7 +23,7 @@ export function DangerZone({ description, children }: DangerZoneProps) {
 
 type DangerZoneRowProps = {
   title: string;
-  description: string;
+  description?: string;
   actionLabel: string;
   onAction: () => void;
   disabled?: boolean;
@@ -44,7 +44,7 @@ export function DangerZoneRow({
     <article className="idt-danger-zone-row" data-testid={testId}>
       <div>
         <strong>{title}</strong>
-        <p>{description}</p>
+        {description ? <p>{description}</p> : null}
       </div>
       <button
         className="idt-btn idt-btn-danger"
@@ -130,7 +130,7 @@ export function ConfirmDestructiveModal({
     confirmation.kind === 'checkbox' ? checked : typed === confirmation.expectedValue;
 
   return (
-    <div className="idt-modal-backdrop" role="presentation" onClick={onCancel}>
+    <div className="idt-modal-backdrop idt-danger-modal-backdrop" role="presentation" onClick={onCancel}>
       <section
         aria-labelledby={titleId}
         aria-modal="true"
@@ -141,16 +141,15 @@ export function ConfirmDestructiveModal({
       >
         <header>
           <div>
-            <p className="idt-app-kicker">Confirm destructive action</p>
             <h3 id={titleId}>{title}</h3>
           </div>
           <button
             aria-label="Close confirmation"
-            className="idt-icon-btn"
+            className="idt-esc-close"
             onClick={onCancel}
             type="button"
           >
-            x
+            ESC
           </button>
         </header>
 
@@ -184,9 +183,6 @@ export function ConfirmDestructiveModal({
               type="text"
               value={typed}
             />
-            <p className="idt-danger-modal-expected">
-              Type <code>{confirmation.expectedValue}</code> exactly to enable the action.
-            </p>
           </div>
         )}
 

--- a/web/src/pages/onboarding/onboarding.test.tsx
+++ b/web/src/pages/onboarding/onboarding.test.tsx
@@ -128,7 +128,9 @@ describe('onboarding pages', () => {
 
     const input = await screen.findByLabelText('Organization name');
     expect(input).toHaveValue('');
-    fireEvent.click(screen.getByRole('button', { name: 'Create boundary' }));
+    const createButton = await screen.findByRole('button', { name: 'Create boundary' });
+    await waitFor(() => expect(createButton).toBeEnabled());
+    fireEvent.click(createButton);
     expect(await screen.findByRole('alert')).toHaveTextContent('Enter an organization name');
     expect(update).not.toHaveBeenCalled();
 

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -275,6 +275,7 @@ function settingsWhoAmI(me: CurrentUserContext): WhoAmIResponse {
 
 async function renderProductSettingsPage(options: {
   me?: CurrentUserContext;
+  authConfig?: AuthConfigResponse;
   updateMe?: CurrentUserContext | Error;
 } = {}) {
   vi.resetModules();
@@ -298,7 +299,7 @@ async function renderProductSettingsPage(options: {
   vi.spyOn(api.apiClient, 'listWorkspaceMembers').mockResolvedValue({
     items: whoAmI.active_workspace?.member ? [whoAmI.active_workspace.member] : []
   });
-  vi.spyOn(api.apiClient, 'getAuthConfig').mockResolvedValue(settingsAuthConfig);
+  vi.spyOn(api.apiClient, 'getAuthConfig').mockResolvedValue(options.authConfig ?? settingsAuthConfig);
   vi.spyOn(api.apiClient, 'listCurrentUserSessions').mockResolvedValue({ items: [] });
   const updateMe = vi.spyOn(api.apiClient, 'updateMe');
   if (options.updateMe instanceof Error) {
@@ -519,10 +520,10 @@ describe('ProductSettingsPage profile', () => {
     };
     const { primeMeCache, updateMe } = await renderProductSettingsPage({ updateMe: updatedMe });
 
-    expect(await screen.findByRole('heading', { name: 'Owner User' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Profile' })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Edit profile' }));
     fireEvent.change(screen.getByLabelText('Display name'), { target: { value: '  Updated Owner  ' } });
-    fireEvent.change(screen.getByLabelText('Avatar URL'), {
+    fireEvent.change(screen.getByLabelText('Photo URL'), {
       target: { value: 'https://avatars.githubusercontent.com/u/42?v=4' }
     });
     fireEvent.click(screen.getByRole('button', { name: 'Save profile' }));
@@ -545,15 +546,60 @@ describe('ProductSettingsPage profile', () => {
     await waitFor(() => expect(primeMeCache).toHaveBeenLastCalledWith(updatedMe));
   });
 
+  it('keeps unsaved profile edits when deleting the profile photo', async () => {
+    const updatedMe: CurrentUserContext = {
+      ...loggedInWithWorkspace,
+      user: {
+        ...loggedInWithWorkspace.user,
+        avatar_url: '',
+        updated_at: '2026-05-17T10:00:00Z'
+      }
+    };
+    const { updateMe } = await renderProductSettingsPage({ updateMe: updatedMe });
+
+    expect(await screen.findByRole('heading', { name: 'Profile' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Edit profile' }));
+    fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Unsaved Owner' } });
+    fireEvent.change(screen.getByLabelText('Photo URL'), {
+      target: { value: 'https://avatars.githubusercontent.com/u/99?v=4' }
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Update or delete profile photo/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Delete photo' }));
+
+    await waitFor(() => expect(updateMe).toHaveBeenCalledWith({ avatar_url: '' }));
+    expect(screen.getByLabelText('Display name')).toHaveValue('Unsaved Owner');
+    expect(screen.getByLabelText('Photo URL')).toHaveValue('');
+    expect(screen.getByRole('button', { name: 'Save profile' })).toBeInTheDocument();
+  });
+
+  it('keeps unsaved profile edits when reopening the photo editor', async () => {
+    await renderProductSettingsPage();
+
+    expect(await screen.findByRole('heading', { name: 'Profile' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Edit profile' }));
+    fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Draft Owner' } });
+    fireEvent.change(screen.getByLabelText('Photo URL'), {
+      target: { value: 'https://avatars.githubusercontent.com/u/99?v=4' }
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Update or delete profile photo/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Update photo' }));
+
+    expect(screen.getByLabelText('Display name')).toHaveValue('Draft Owner');
+    expect(screen.getByLabelText('Photo URL')).toHaveValue('https://avatars.githubusercontent.com/u/99?v=4');
+    await waitFor(() => expect(screen.getByLabelText('Photo URL')).toHaveFocus());
+  });
+
   it('rolls back the optimistic profile update when saving fails', async () => {
     const { primeMeCache, updateMe } = await renderProductSettingsPage({
       updateMe: new Error('avatar_url host is not allowed')
     });
 
-    expect(await screen.findByRole('heading', { name: 'Owner User' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Profile' })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Edit profile' }));
     fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Blocked Owner' } });
-    fireEvent.change(screen.getByLabelText('Avatar URL'), { target: { value: 'https://example.com/avatar.png' } });
+    fireEvent.change(screen.getByLabelText('Photo URL'), { target: { value: 'https://example.com/avatar.png' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save profile' }));
 
     await waitFor(() => expect(updateMe).toHaveBeenCalled());
@@ -564,7 +610,7 @@ describe('ProductSettingsPage profile', () => {
   it('validates display name before submitting a profile update', async () => {
     const { primeMeCache, updateMe } = await renderProductSettingsPage();
 
-    expect(await screen.findByRole('heading', { name: 'Owner User' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Profile' })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Edit profile' }));
     fireEvent.change(screen.getByLabelText('Display name'), { target: { value: '   ' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save profile' }));
@@ -572,6 +618,39 @@ describe('ProductSettingsPage profile', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent('Display name must be 1-80 characters.');
     expect(updateMe).not.toHaveBeenCalled();
     expect(primeMeCache).not.toHaveBeenCalled();
+  });
+
+  it('labels empty manual auth config without advertising hosted login', async () => {
+    await renderProductSettingsPage({
+      authConfig: {
+        ...settingsAuthConfig,
+        auth: {
+          manual_mode: true,
+          workos_login_enabled: false,
+          native_saml_enabled: false,
+          providers: []
+        }
+      }
+    });
+
+    expect(await screen.findByText('Manual development')).toBeInTheDocument();
+    expect(screen.queryByText('GitHub, Google')).not.toBeInTheDocument();
+  });
+
+  it('closes the avatar menu with Escape and outside clicks', async () => {
+    await renderProductSettingsPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Update or delete profile photo/i }));
+    expect(screen.getByRole('menuitem', { name: /Update photo/i })).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('menuitem', { name: /Update photo/i })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Update or delete profile photo/i }));
+    expect(screen.getByRole('menuitem', { name: /Update photo/i })).toBeInTheDocument();
+
+    fireEvent.pointerDown(document.body);
+    expect(screen.queryByRole('menuitem', { name: /Update photo/i })).not.toBeInTheDocument();
   });
 });
 

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -514,7 +514,6 @@ describe('ProductSettingsPage profile', () => {
       user: {
         ...loggedInWithWorkspace.user,
         display_name: 'Updated Owner',
-        avatar_url: 'https://avatars.githubusercontent.com/u/42?v=4',
         updated_at: '2026-05-17T10:00:00Z'
       }
     };
@@ -523,27 +522,48 @@ describe('ProductSettingsPage profile', () => {
     expect(await screen.findByRole('heading', { name: 'Profile' })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Edit profile' }));
     fireEvent.change(screen.getByLabelText('Display name'), { target: { value: '  Updated Owner  ' } });
-    fireEvent.change(screen.getByLabelText('Photo URL'), {
-      target: { value: 'https://avatars.githubusercontent.com/u/42?v=4' }
-    });
+    expect(screen.queryByLabelText('Photo URL')).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Save profile' }));
 
-    await waitFor(() =>
-      expect(updateMe).toHaveBeenCalledWith({
-        display_name: 'Updated Owner',
-        avatar_url: 'https://avatars.githubusercontent.com/u/42?v=4'
-      })
-    );
+    await waitFor(() => expect(updateMe).toHaveBeenCalledWith({ display_name: 'Updated Owner' }));
     expect(primeMeCache).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
         user: expect.objectContaining({
-          display_name: 'Updated Owner',
-          avatar_url: 'https://avatars.githubusercontent.com/u/42?v=4'
+          display_name: 'Updated Owner'
         })
       })
     );
     await waitFor(() => expect(primeMeCache).toHaveBeenLastCalledWith(updatedMe));
+  });
+
+  it('uploads profile photos from the avatar menu without exposing a URL field', async () => {
+    const updatedMe: CurrentUserContext = {
+      ...loggedInWithWorkspace,
+      user: {
+        ...loggedInWithWorkspace.user,
+        avatar_url: 'data:image/png;base64,YXZhdGFy',
+        updated_at: '2026-05-17T10:00:00Z'
+      }
+    };
+    const { updateMe } = await renderProductSettingsPage({ updateMe: updatedMe });
+
+    expect(await screen.findByRole('heading', { name: 'Profile' })).toBeInTheDocument();
+    expect(screen.queryByLabelText('Photo URL')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Update or delete profile photo/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Update photo' }));
+
+    const avatarInput = document.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(avatarInput).toBeTruthy();
+    fireEvent.change(avatarInput!, {
+      target: { files: [new File(['avatar'], 'avatar.png', { type: 'image/png' })] }
+    });
+
+    await waitFor(() =>
+      expect(updateMe).toHaveBeenCalledWith({
+        avatar_url: expect.stringMatching(/^data:image\/png;base64,/)
+      })
+    );
   });
 
   it('keeps unsaved profile edits when deleting the profile photo', async () => {
@@ -560,50 +580,56 @@ describe('ProductSettingsPage profile', () => {
     expect(await screen.findByRole('heading', { name: 'Profile' })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Edit profile' }));
     fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Unsaved Owner' } });
-    fireEvent.change(screen.getByLabelText('Photo URL'), {
-      target: { value: 'https://avatars.githubusercontent.com/u/99?v=4' }
-    });
 
     fireEvent.click(screen.getByRole('button', { name: /Update or delete profile photo/i }));
     fireEvent.click(screen.getByRole('menuitem', { name: 'Delete photo' }));
 
     await waitFor(() => expect(updateMe).toHaveBeenCalledWith({ avatar_url: '' }));
     expect(screen.getByLabelText('Display name')).toHaveValue('Unsaved Owner');
-    expect(screen.getByLabelText('Photo URL')).toHaveValue('');
+    expect(screen.queryByLabelText('Photo URL')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Save profile' })).toBeInTheDocument();
   });
 
-  it('keeps unsaved profile edits when reopening the photo editor', async () => {
-    await renderProductSettingsPage();
+  it('keeps unsaved profile edits when updating the profile photo', async () => {
+    const updatedMe: CurrentUserContext = {
+      ...loggedInWithWorkspace,
+      user: {
+        ...loggedInWithWorkspace.user,
+        avatar_url: 'data:image/png;base64,YXZhdGFy',
+        updated_at: '2026-05-17T10:00:00Z'
+      }
+    };
+    const { updateMe } = await renderProductSettingsPage({ updateMe: updatedMe });
 
     expect(await screen.findByRole('heading', { name: 'Profile' })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Edit profile' }));
     fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Draft Owner' } });
-    fireEvent.change(screen.getByLabelText('Photo URL'), {
-      target: { value: 'https://avatars.githubusercontent.com/u/99?v=4' }
-    });
 
     fireEvent.click(screen.getByRole('button', { name: /Update or delete profile photo/i }));
     fireEvent.click(screen.getByRole('menuitem', { name: 'Update photo' }));
+    const avatarInput = document.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(avatarInput).toBeTruthy();
+    fireEvent.change(avatarInput!, {
+      target: { files: [new File(['avatar'], 'avatar.png', { type: 'image/png' })] }
+    });
 
+    await waitFor(() => expect(updateMe).toHaveBeenCalledWith({ avatar_url: expect.any(String) }));
     expect(screen.getByLabelText('Display name')).toHaveValue('Draft Owner');
-    expect(screen.getByLabelText('Photo URL')).toHaveValue('https://avatars.githubusercontent.com/u/99?v=4');
-    await waitFor(() => expect(screen.getByLabelText('Photo URL')).toHaveFocus());
+    expect(screen.queryByLabelText('Photo URL')).not.toBeInTheDocument();
   });
 
   it('rolls back the optimistic profile update when saving fails', async () => {
     const { primeMeCache, updateMe } = await renderProductSettingsPage({
-      updateMe: new Error('avatar_url host is not allowed')
+      updateMe: new Error('profile update failed')
     });
 
     expect(await screen.findByRole('heading', { name: 'Profile' })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Edit profile' }));
     fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Blocked Owner' } });
-    fireEvent.change(screen.getByLabelText('Photo URL'), { target: { value: 'https://example.com/avatar.png' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save profile' }));
 
     await waitFor(() => expect(updateMe).toHaveBeenCalled());
-    expect(await screen.findByRole('alert')).toHaveTextContent('avatar_url host is not allowed');
+    expect(await screen.findByRole('alert')).toHaveTextContent('profile update failed');
     expect(primeMeCache).toHaveBeenLastCalledWith(loggedInWithWorkspace);
   });
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -7557,7 +7557,12 @@ export function ProductShellLayout() {
     window.addEventListener('scroll', scheduleUpdate, { passive: true });
     window.addEventListener('resize', scheduleUpdate);
 
-    const observer = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(scheduleUpdate);
+    const observer =
+      typeof ResizeObserver === 'undefined'
+        ? null
+        : new ResizeObserver((_entries, _observer) => {
+            scheduleUpdate();
+          });
     observer?.observe(document.documentElement);
     observer?.observe(document.body);
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -14962,14 +14962,9 @@ export function ProductSettingsPage() {
       <ConfirmDestructiveModal
         body={
           <>
+            <p>This starts a 30-day recovery window and blocks normal sign-in.</p>
             <p>
-              Deleting your account immediately marks it for deletion and blocks normal sign-in. Identrail
-              keeps a recovery cookie in this browser so you can cancel deletion during the 30-day grace
-              window.
-            </p>
-            <p>
-              Permanent hard deletion happens after the grace period. Download your account archive first if
-              you need profile, workspace, session, or audit data.{' '}
+              After the window, the account is permanently deleted. Need an archive?{' '}
               <button
                 className="idt-inline-button-link"
                 disabled={exportPending}
@@ -14977,8 +14972,8 @@ export function ProductSettingsPage() {
                 type="button"
               >
                 {exportPending ? 'Preparing export' : 'Download my data'}
-              </button>
-              .
+              </button>{' '}
+              before deleting.
             </p>
             {deleteSoleOwnerWorkspaces.length > 0 ? (
               <div
@@ -14987,8 +14982,7 @@ export function ProductSettingsPage() {
                 role="alert"
               >
                 <p>
-                  You are the sole owner of these workspaces. Promote another owner from member management
-                  before deleting your account.
+                  Transfer ownership for these workspaces before deleting this account.
                 </p>
                 <ul>
                   {deleteSoleOwnerWorkspaces.map((workspace) => (
@@ -15005,10 +14999,10 @@ export function ProductSettingsPage() {
         confirmation={{
           kind: 'type-to-confirm',
           expectedValue: primaryEmail,
-          inputLabel: 'Type your primary email',
-          helpText: 'Use the primary email shown in your account profile.'
+          inputLabel: 'Confirm primary email',
+          helpText: primaryEmail ? `Enter ${primaryEmail} exactly.` : undefined
         }}
-        continueLabel="Continue"
+        continueLabel="Delete account"
         errorMessage={deleteError || undefined}
         onCancel={handleCancelDeleteModal}
         onConfirm={handleDeleteAccount}

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -8,7 +8,6 @@ import type {
 import { Link, Navigate, NavLink, Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
 import {
   BarChart3,
-  Check,
   ChevronDown,
   ChevronRight,
   ChevronUp,
@@ -21,8 +20,7 @@ import {
   PanelLeftOpen,
   Pencil,
   Search,
-  Settings as SettingsIcon,
-  X
+  Settings as SettingsIcon
 } from 'lucide-react';
 import {
   ApiError,
@@ -64,7 +62,7 @@ import {
   type WorkspaceMemberRole,
   type WorkspaceMemberStatus
 } from './api/client';
-import { formatSessionDevice, SessionsList } from './components/auth/SessionsList';
+import { SessionsList } from './components/auth/SessionsList';
 import { PermissionPreviewModal } from './components/connector/PermissionPreviewModal';
 import { ConfirmDestructiveModal, DangerZone, DangerZoneRow } from './components/settings/DangerZone';
 import {
@@ -1267,6 +1265,41 @@ function formatProfileInitials(me: CurrentUserContext | null | undefined): strin
   return initials || 'U';
 }
 
+function formatSettingsAuthProvider(provider: string): string {
+  const normalized = provider.toLowerCase();
+  if (normalized.includes('github')) {
+    return 'GitHub';
+  }
+  if (normalized.includes('google')) {
+    return 'Google';
+  }
+  if (normalized.includes('saml')) {
+    return 'SAML SSO';
+  }
+  if (normalized.includes('workos') || normalized.includes('authkit')) {
+    return 'Hosted login';
+  }
+  return formatTokenLabel(provider.replace(/_oauth$/i, ''));
+}
+
+function formatSettingsAuthProviders(config: AuthConfigResponse | null): string {
+  const providers = config?.auth.providers ?? [];
+  const labels = Array.from(new Set(providers.map(formatSettingsAuthProvider))).filter((label) => label !== 'Hosted login');
+  if (labels.length) {
+    return labels.join(', ');
+  }
+  if (config?.auth.workos_login_enabled) {
+    return 'Hosted login';
+  }
+  if (config?.auth.native_saml_enabled) {
+    return 'SAML SSO';
+  }
+  if (config?.auth.manual_mode) {
+    return 'Manual development';
+  }
+  return 'Session-only';
+}
+
 function validateProfileDraft(draft: ProfileDraft, options: { validateAvatarUrl?: boolean } = {}): string {
   const displayName = draft.displayName.trim();
   if (!displayName || Array.from(displayName).length > 80) {
@@ -1285,13 +1318,13 @@ function validateProfileDraft(draft: ProfileDraft, options: { validateAvatarUrl?
   try {
     const parsed = new URL(avatarUrl);
     if (parsed.protocol !== 'https:') {
-      return 'Avatar URL must use https.';
+      return 'Photo URL must use https.';
     }
     if (parsed.username || parsed.password) {
-      return 'Avatar URL cannot include credentials.';
+      return 'Photo URL cannot include credentials.';
     }
   } catch {
-    return 'Avatar URL must be a valid https URL.';
+    return 'Photo URL must be a valid https URL.';
   }
   return '';
 }
@@ -1711,7 +1744,7 @@ function CommandPalette({
             aria-label="Search workspace commands"
           />
           <button type="button" className="idt-command-palette-close" onClick={onClose} aria-label="Close workspace finder">
-            Esc
+            ESC
           </button>
         </div>
         <div className="idt-command-palette-results" role="listbox" aria-label="Workspace commands">
@@ -13440,13 +13473,13 @@ export function ProductFindingsPage({ agenticOnly = false }: { agenticOnly?: boo
               </div>
               <button
                 ref={findingDetailCloseRef}
-                className="idt-icon-btn idt-repo-finding-modal-close"
+                className="idt-esc-close idt-repo-finding-modal-close"
                 type="button"
                 aria-label="Close finding detail"
                 autoFocus
                 onClick={() => closeFindingDetail()}
               >
-                <X size={16} strokeWidth={2} aria-hidden="true" />
+                ESC
               </button>
             </header>
 
@@ -14017,7 +14050,10 @@ export function ProductSettingsPage() {
     | { kind: 'ready'; downloadURL: string; expiresAt?: string }
   >({ kind: 'idle' });
   const exportAbortRef = useRef<AbortController | null>(null);
+  const avatarControlRef = useRef<HTMLDivElement | null>(null);
+  const profilePhotoInputRef = useRef<HTMLInputElement | null>(null);
   const [profileEditing, setProfileEditing] = useState(false);
+  const [avatarMenuOpen, setAvatarMenuOpen] = useState(false);
   const [profileDraft, setProfileDraft] = useState<ProfileDraft>(() => profileDraftFromMe(me));
   const [profileSaving, setProfileSaving] = useState(false);
   const [profileError, setProfileError] = useState('');
@@ -14125,6 +14161,30 @@ export function ProductSettingsPage() {
     }
   }, [me?.user.display_name, me?.user.avatar_url, profileEditing, profileSaving]);
 
+  useEffect(() => {
+    if (!avatarMenuOpen) {
+      return;
+    }
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target;
+      if (target instanceof Node && avatarControlRef.current?.contains(target)) {
+        return;
+      }
+      setAvatarMenuOpen(false);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setAvatarMenuOpen(false);
+      }
+    };
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [avatarMenuOpen]);
+
   const activeWorkspace = whoAmI?.active_workspace?.workspace ?? me?.workspace;
   const activeMember =
     whoAmI?.active_workspace?.member ??
@@ -14132,27 +14192,38 @@ export function ProductSettingsPage() {
   const activeRole = activeMember?.role ?? me?.role ?? 'viewer';
   const workspaceDisplayName = activeWorkspace?.display_name ?? scope?.workspaceID ?? 'Workspace';
   const authProviders = authConfig?.auth.providers ?? [];
-  const authModeLabel = authConfig?.auth.workos_login_enabled
-    ? 'Hosted WorkOS login'
-    : authConfig?.auth.native_saml_enabled
-      ? 'Native SAML login'
-    : authConfig?.auth.manual_mode
-      ? 'Manual development login'
-      : 'Session-only';
   const scopes = Array.isArray(whoAmI?.scopes) ? whoAmI.scopes : [];
-  const awsPath = scope ? buildScopedPath(scope, 'aws') : '/app';
-  const githubFindingsPath = scope ? buildScopedPath(scope, 'github/findings') : '/app';
-  const kubernetesPath = scope ? buildScopedPath(scope, 'kubernetes') : '/app';
   const workspacesPath = scope ? buildScopedPath(scope, 'workspaces') : '/app';
   const primaryEmail = me?.user.primary_email?.trim() ?? '';
   const profileDisplayName = formatProfileDisplayName(me);
   const profileAvatarURL = me?.user.avatar_url?.trim() ?? '';
   const profileInitials = formatProfileInitials(me);
+  const activeMembers = countMembersByStatus(members, 'active');
+  const invitedMembers = countMembersByStatus(members, 'invited');
+  const adminMembers = countMembersByRole(members, 'owner') + countMembersByRole(members, 'admin');
+  const signInMethods = formatSettingsAuthProviders(authConfig);
+  const hostedLoginStatus = authConfig?.auth.workos_login_enabled ? 'Enabled' : 'Disabled';
+  const samlStatus = authConfig?.auth.native_saml_enabled ? 'Configured' : 'Not configured';
+  const mfaStatus = authConfig?.auth.workos_login_enabled ? 'Hosted login' : 'Not configured';
+  const developerScopeLabel = scopes.length ? scopes.map(formatTokenLabel).join(', ') : 'No custom restrictions';
+  const developerProviderLabel = authProviders.length ? authProviders.join(', ') : 'None advertised';
+
+  const focusProfilePhotoInput = () => {
+    window.requestAnimationFrame(() => profilePhotoInputRef.current?.focus());
+  };
 
   const handleProfileEdit = () => {
+    if (profileEditing) {
+      setProfileError('');
+      setAvatarMenuOpen(false);
+      focusProfilePhotoInput();
+      return;
+    }
     setProfileDraft(profileDraftFromMe(me));
     setProfileError('');
     setProfileEditing(true);
+    setAvatarMenuOpen(false);
+    focusProfilePhotoInput();
   };
 
   const handleProfileCancel = () => {
@@ -14160,6 +14231,47 @@ export function ProductSettingsPage() {
     setProfileDraft(profileDraftFromMe(me));
     setProfileError('');
     setProfileEditing(false);
+    setAvatarMenuOpen(false);
+  };
+
+  const handleAvatarDelete = async () => {
+    if (!me || profileSaving || !profileAvatarURL) {
+      return;
+    }
+    const previousMe = me;
+    const previousDraft = profileDraft;
+    const wasProfileEditing = profileEditing;
+    const optimisticMe: CurrentUserContext = {
+      ...previousMe,
+      user: {
+        ...previousMe.user,
+        avatar_url: '',
+        updated_at: new Date().toISOString()
+      }
+    };
+    setAvatarMenuOpen(false);
+    setProfileSaving(true);
+    setProfileError('');
+    primeMeCache(optimisticMe);
+    if (wasProfileEditing) {
+      setProfileDraft({ ...previousDraft, avatarUrl: '' });
+    }
+    try {
+      const response = await apiClient.updateMe({ avatar_url: '' });
+      primeMeCache(response.me);
+      if (wasProfileEditing) {
+        setProfileDraft((draft) => ({ ...draft, avatarUrl: '' }));
+      } else {
+        setProfileDraft(profileDraftFromMe(response.me));
+        setProfileEditing(false);
+      }
+    } catch (err) {
+      primeMeCache(previousMe);
+      setProfileDraft(wasProfileEditing ? previousDraft : profileDraftFromMe(previousMe));
+      setProfileError(err instanceof Error ? err.message : 'Unable to delete profile photo.');
+    } finally {
+      setProfileSaving(false);
+    }
   };
 
   const handleProfileSubmit = async (event: FormEvent) => {
@@ -14214,15 +14326,6 @@ export function ProductSettingsPage() {
       setProfileSaving(false);
     }
   };
-
-  const primarySession = sessions.find((session) => session.current) ?? sessions[0];
-  const sessionsSummary = sessionsLoading
-    ? 'Checking active browsers.'
-    : sessionsError
-      ? 'Session details need a refresh.'
-      : primarySession
-        ? formatSessionDevice(primarySession.user_agent)
-        : 'No active browser session.';
 
   const handleRevokeSession = async (sessionID: string, isCurrent: boolean) => {
     setBusySessionID(sessionID);
@@ -14296,7 +14399,6 @@ export function ProductSettingsPage() {
     return (
       <section className="idt-app-panel" aria-busy="true" aria-live="polite">
         <h2>Settings</h2>
-        <p>Loading workspace identity, members, authentication, and sessions.</p>
       </section>
     );
   }
@@ -14315,42 +14417,72 @@ export function ProductSettingsPage() {
       <header className="idt-settings-header">
         <div>
           <h2>Settings</h2>
-          <p>Workspace access, sign-in, sessions, and account controls.</p>
-        </div>
-        <div className="idt-inline-actions">
-          <Link className="idt-btn idt-btn-primary" to={workspacesPath}>
-            Manage members
-          </Link>
         </div>
       </header>
 
       <section className="idt-settings-card idt-profile-card" aria-labelledby="idt-profile-heading">
         <div className="idt-settings-card-header">
           <div>
-            <p className="idt-app-kicker">Account profile</p>
-            <h3 id="idt-profile-heading">{profileDisplayName}</h3>
+            <h3 id="idt-profile-heading">Profile</h3>
           </div>
-          {profileEditing ? null : (
-            <button
-              type="button"
-              className="idt-icon-btn idt-profile-icon-btn"
-              aria-label="Edit profile"
-              title="Edit profile"
-              onClick={handleProfileEdit}
-              disabled={!me}
-            >
-              <Pencil size={16} aria-hidden="true" />
-            </button>
-          )}
+          {profileEditing ? (
+            <div className="idt-profile-actions">
+              <button
+                type="submit"
+                form="idt-profile-form"
+                className="idt-btn idt-btn-primary"
+                disabled={profileSaving}
+              >
+                {profileSaving ? 'Saving...' : 'Save profile'}
+              </button>
+              <button
+                type="button"
+                className="idt-btn idt-btn-ghost"
+                onClick={handleProfileCancel}
+                disabled={profileSaving}
+              >
+                Cancel
+              </button>
+            </div>
+          ) : null}
         </div>
 
         <div className="idt-profile-body">
-          <div className="idt-profile-avatar" aria-hidden="true">
-            {profileAvatarURL ? <img src={profileAvatarURL} alt="" /> : <span>{profileInitials}</span>}
+          <div
+            className="idt-profile-avatar-control"
+            data-menu-open={avatarMenuOpen ? 'true' : 'false'}
+            ref={avatarControlRef}
+          >
+            <button
+              type="button"
+              className="idt-profile-avatar"
+              aria-expanded={avatarMenuOpen}
+              aria-haspopup="menu"
+              aria-label={profileAvatarURL ? 'Update or delete profile photo' : 'Upload profile photo'}
+              onClick={() => setAvatarMenuOpen((open) => !open)}
+              disabled={!me}
+            >
+              {profileAvatarURL ? <img src={profileAvatarURL} alt="" /> : <span>{profileInitials}</span>}
+              <span className="idt-profile-avatar-edit" aria-hidden="true">
+                <Pencil size={14} />
+              </span>
+            </button>
+            {avatarMenuOpen ? (
+              <div className="idt-profile-avatar-menu" role="menu">
+                <button type="button" role="menuitem" onClick={handleProfileEdit}>
+                  {profileAvatarURL ? 'Update photo' : 'Upload photo'}
+                </button>
+                {profileAvatarURL ? (
+                  <button type="button" role="menuitem" onClick={() => void handleAvatarDelete()} disabled={profileSaving}>
+                    Delete photo
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
           </div>
 
           {profileEditing ? (
-            <form className="idt-app-form idt-profile-form" onSubmit={handleProfileSubmit}>
+            <form id="idt-profile-form" className="idt-app-form idt-profile-form" onSubmit={handleProfileSubmit}>
               <label>
                 Display name
                 <input
@@ -14363,8 +14495,9 @@ export function ProductSettingsPage() {
                 />
               </label>
               <label>
-                Avatar URL
+                Photo URL
                 <input
+                  ref={profilePhotoInputRef}
                   type="url"
                   value={profileDraft.avatarUrl}
                   onChange={(event) => setProfileDraft((draft) => ({ ...draft, avatarUrl: event.target.value }))}
@@ -14372,27 +14505,6 @@ export function ProductSettingsPage() {
                   placeholder="https://..."
                 />
               </label>
-              <div className="idt-profile-actions">
-                <button
-                  type="submit"
-                  className="idt-icon-btn idt-profile-icon-btn"
-                  aria-label="Save profile"
-                  title="Save profile"
-                  disabled={profileSaving}
-                >
-                  <Check size={16} aria-hidden="true" />
-                </button>
-                <button
-                  type="button"
-                  className="idt-icon-btn idt-profile-icon-btn"
-                  aria-label="Cancel profile editing"
-                  title="Cancel profile editing"
-                  onClick={handleProfileCancel}
-                  disabled={profileSaving}
-                >
-                  <X size={16} aria-hidden="true" />
-                </button>
-              </div>
               {profileError ? (
                 <p className="idt-app-alert idt-app-alert-error" role="alert">
                   {profileError}
@@ -14402,32 +14514,177 @@ export function ProductSettingsPage() {
           ) : (
             <dl className="idt-settings-facts idt-profile-facts">
               <div>
+                <dt>Name</dt>
+                <dd>{profileDisplayName}</dd>
+              </div>
+              <div>
                 <dt>Email</dt>
                 <dd>{me?.user.primary_email ?? 'Unavailable'}</dd>
               </div>
               <div>
-                <dt>Avatar</dt>
-                <dd>{profileAvatarURL || 'Not set'}</dd>
-              </div>
-              <div>
-                <dt>Status</dt>
+                <dt>Account status</dt>
                 <dd>{me?.user.status ? formatTokenLabel(me.user.status) : 'Unavailable'}</dd>
-              </div>
-              <div>
-                <dt>Updated</dt>
-                <dd>{me?.user.updated_at ? formatDateLabel(me.user.updated_at) : 'Unavailable'}</dd>
               </div>
             </dl>
           )}
         </div>
+
+        {!profileEditing && profileError ? (
+          <p className="idt-app-alert idt-app-alert-error" role="alert">
+            {profileError}
+          </p>
+        ) : null}
+
+        <div className="idt-settings-action-stack">
+          {!profileEditing ? (
+            <button
+              aria-label="Edit profile"
+              className="idt-settings-action-row"
+              onClick={handleProfileEdit}
+              type="button"
+              disabled={!me}
+            >
+              <span>
+                <strong>Edit profile</strong>
+              </span>
+              <ChevronRight size={16} aria-hidden="true" />
+            </button>
+          ) : null}
+          <div className="idt-settings-action-item" data-testid="idt-export-account-row">
+            <button
+              aria-label="Download my data"
+              className="idt-settings-action-row"
+              data-testid="idt-export-account-button"
+              disabled={exportPending}
+              onClick={startDataExport}
+              type="button"
+            >
+              <span>
+                <strong>Download my data</strong>
+              </span>
+              <ChevronRight size={16} aria-hidden="true" />
+            </button>
+            {exportStatus.kind === 'ready' ? (
+              <p className="idt-settings-inline-status idt-danger-zone-success" data-testid="idt-export-ready">
+                Your data export is ready.{' '}
+                <a href={exportStatus.downloadURL} rel="noopener noreferrer">
+                  Download the ZIP
+                </a>
+                {exportStatus.expiresAt ? ` - link expires ${new Date(exportStatus.expiresAt).toLocaleString()}` : ''}.
+              </p>
+            ) : exportStatus.kind === 'preparing' ? (
+              <p className="idt-settings-inline-status idt-danger-zone-status" data-testid="idt-export-preparing">
+                {exportStatus.message}
+              </p>
+            ) : null}
+            {exportError ? (
+              <p className="idt-settings-inline-status idt-danger-zone-error" role="alert">
+                {exportError}
+              </p>
+            ) : null}
+          </div>
+        </div>
       </section>
 
       <div className="idt-settings-grid">
-        <section className="idt-settings-card">
-          <div>
-            <p className="idt-app-kicker">Workspace</p>
-            <h3>{workspaceDisplayName}</h3>
+        <section className="idt-settings-card idt-settings-security-card">
+          <div className="idt-settings-card-header">
+            <div>
+              <h3>Security</h3>
+            </div>
           </div>
+          <dl className="idt-settings-facts">
+            <div>
+              <dt>Sign-in methods</dt>
+              <dd>{signInMethods}</dd>
+            </div>
+            <div>
+              <dt>2FA</dt>
+              <dd>{mfaStatus}</dd>
+            </div>
+            <div>
+              <dt>SAML SSO</dt>
+              <dd>{samlStatus}</dd>
+            </div>
+          </dl>
+          <details className="idt-settings-inline-disclosure idt-settings-sessions-card">
+            <summary className="idt-settings-action-row idt-settings-action-summary">
+              <span>
+                <strong>Manage sessions</strong>
+              </span>
+              <ChevronRight size={16} aria-hidden="true" />
+            </summary>
+            <div className="idt-settings-disclosure-body">
+              {sessionsLoading ? <p className="idt-app-alert">Loading active sessions...</p> : null}
+              {sessionsError ? (
+                <p className="idt-app-alert idt-app-alert-error" role="alert">
+                  {sessionsError}
+                </p>
+              ) : null}
+              {!sessionsLoading ? (
+                <SessionsList
+                  busySessionID={busySessionID}
+                  revokingOthers={revokingOthers}
+                  sessions={sessions}
+                  onRevoke={handleRevokeSession}
+                  onRevokeOthers={handleRevokeOtherSessions}
+                />
+              ) : null}
+            </div>
+          </details>
+        </section>
+
+        <section className="idt-settings-card idt-settings-workspace-card">
+          <div className="idt-settings-card-header">
+            <div>
+              <h3>Workspace</h3>
+            </div>
+          </div>
+          <dl className="idt-settings-facts">
+            <div>
+              <dt>Name</dt>
+              <dd>{workspaceDisplayName}</dd>
+            </div>
+            <div>
+              <dt>Your access</dt>
+              <dd>{formatTokenLabel(activeRole)}</dd>
+            </div>
+            <div>
+              <dt>Admins</dt>
+              <dd>{adminMembers}</dd>
+            </div>
+          </dl>
+          <div className="idt-settings-counts">
+            <article>
+              <strong>{members.length}</strong>
+              <span>Total members</span>
+            </article>
+            <article>
+              <strong>{activeMembers}</strong>
+              <span>Active</span>
+            </article>
+            <article>
+              <strong>{invitedMembers}</strong>
+              <span>Invited</span>
+            </article>
+          </div>
+          <Link className="idt-settings-action-row" to={workspacesPath}>
+            <span>
+              <strong>Manage members</strong>
+            </span>
+            <ChevronRight size={16} aria-hidden="true" />
+          </Link>
+        </section>
+      </div>
+
+      <details className="idt-settings-card idt-settings-disclosure">
+        <summary className="idt-settings-disclosure-summary">
+          <div>
+            <h3>Developer details</h3>
+          </div>
+          <span aria-hidden="true"><ChevronRight size={14} /></span>
+        </summary>
+        <div className="idt-settings-disclosure-body">
           <dl className="idt-settings-facts">
             <div>
               <dt>Tenant ID</dt>
@@ -14438,229 +14695,57 @@ export function ProductSettingsPage() {
               <dd>{scope?.workspaceID ?? 'Unavailable'}</dd>
             </div>
             <div>
-              <dt>Scope</dt>
-              <dd>{scope?.projectID ?? me?.project_id ?? 'All scopes'}</dd>
+              <dt>Principal ID</dt>
+              <dd>{whoAmI ? `${formatTokenLabel(whoAmI.principal.type)} - ${whoAmI.principal.id}` : 'Unavailable'}</dd>
             </div>
             <div>
-              <dt>Updated</dt>
-              <dd>{activeWorkspace?.updated_at ? formatDateLabel(activeWorkspace.updated_at) : 'Unavailable'}</dd>
+              <dt>Custom scopes</dt>
+              <dd>{developerScopeLabel}</dd>
             </div>
-          </dl>
-        </section>
-
-        <section className="idt-settings-card">
-          <div>
-            <p className="idt-app-kicker">Access</p>
-            <h3>{formatTokenLabel(activeRole)}</h3>
-          </div>
-          <dl className="idt-settings-facts">
-            <div>
-              <dt>User</dt>
-              <dd>{me?.user?.primary_email ?? whoAmI?.principal.id ?? 'Unavailable'}</dd>
-            </div>
-            <div>
-              <dt>Status</dt>
-              <dd>{me?.user?.status ? formatTokenLabel(me.user.status) : 'Unavailable'}</dd>
-            </div>
-            <div>
-              <dt>Principal</dt>
-              <dd>{whoAmI ? `${formatTokenLabel(whoAmI.principal.type)} · ${whoAmI.principal.id}` : 'Unavailable'}</dd>
-            </div>
-            <div>
-              <dt>Scopes</dt>
-              <dd>{scopes.length ? scopes.map(formatTokenLabel).join(', ') : 'None'}</dd>
-            </div>
-          </dl>
-        </section>
-      </div>
-
-      <div className="idt-settings-grid">
-        <section className="idt-settings-card">
-          <div className="idt-settings-card-header">
-            <div>
-              <p className="idt-app-kicker">Members</p>
-              <h3>{formatCountLabel(members.length, 'member')}</h3>
-            </div>
-            <Link to={workspacesPath}>Manage</Link>
-          </div>
-          <div className="idt-settings-counts">
-            <article>
-              <strong>{members.length}</strong>
-              <span>Total members</span>
-            </article>
-            <article>
-              <strong>{countMembersByStatus(members, 'active')}</strong>
-              <span>Active</span>
-            </article>
-            <article>
-              <strong>{countMembersByStatus(members, 'invited')}</strong>
-              <span>Invited</span>
-            </article>
-            <article>
-              <strong>{countMembersByRole(members, 'owner') + countMembersByRole(members, 'admin')}</strong>
-              <span>Admins</span>
-            </article>
-          </div>
-        </section>
-
-        <section className="idt-settings-card">
-          <div className="idt-settings-card-header">
-            <div>
-              <p className="idt-app-kicker">Authentication</p>
-              <h3>{authModeLabel}</h3>
-            </div>
-          </div>
-          <dl className="idt-settings-facts">
             <div>
               <dt>Hosted login</dt>
-              <dd>{authConfig?.auth.workos_login_enabled ? 'Enabled' : 'Disabled'}</dd>
+              <dd>{hostedLoginStatus}</dd>
             </div>
             <div>
-              <dt>Native SAML</dt>
-              <dd>{authConfig?.auth.native_saml_enabled ? 'Enabled' : 'Disabled'}</dd>
-            </div>
-            <div>
-              <dt>Manual mode</dt>
-              <dd>{authConfig?.auth.manual_mode ? 'Enabled' : 'Disabled'}</dd>
-            </div>
-            <div>
-              <dt>Providers</dt>
-              <dd>{authProviders.length ? authProviders.map(formatTokenLabel).join(', ') : 'None advertised'}</dd>
+              <dt>Auth providers</dt>
+              <dd>{developerProviderLabel}</dd>
             </div>
           </dl>
-        </section>
-      </div>
-
-      <details className="idt-settings-card idt-settings-disclosure">
-        <summary className="idt-settings-disclosure-summary">
-          <div>
-            <p className="idt-app-kicker">Areas</p>
-            <h3>Related areas</h3>
-            <p>Domain controls and member access.</p>
-          </div>
-          <span>Show areas</span>
-        </summary>
-        <div className="idt-settings-route-grid idt-settings-disclosure-body">
-          <Link to={awsPath}>
-            <strong>AWS</strong>
-            <span>Accounts, identities, findings, fixes.</span>
-          </Link>
-          <Link to={githubFindingsPath}>
-            <strong>GitHub findings</strong>
-            <span>Repository risk and evidence.</span>
-          </Link>
-          <Link to={kubernetesPath}>
-            <strong>Kubernetes</strong>
-            <span>Clusters, workloads, service accounts, RBAC.</span>
-          </Link>
-          <Link to={workspacesPath}>
-            <strong>Members</strong>
-            <span>Invites, roles, workspace access.</span>
-          </Link>
         </div>
       </details>
 
-      <details className="idt-settings-card idt-settings-disclosure idt-settings-sessions-card">
-        <summary className="idt-settings-disclosure-summary">
-          <div>
-            <p className="idt-app-kicker">Sessions</p>
-            <h3>{sessionsLoading ? 'Loading sessions' : formatCountLabel(sessions.length, 'active session')}</h3>
-            <p>{sessionsSummary}</p>
-          </div>
-          <span>Manage sessions</span>
-        </summary>
-        <div className="idt-settings-disclosure-body">
-          {sessionsLoading ? <p className="idt-app-alert">Loading active sessions...</p> : null}
-          {sessionsError ? (
-            <p className="idt-app-alert idt-app-alert-error" role="alert">
-              {sessionsError}
-            </p>
-          ) : null}
-          {!sessionsLoading ? (
-            <SessionsList
-              busySessionID={busySessionID}
-              revokingOthers={revokingOthers}
-              sessions={sessions}
-              onRevoke={handleRevokeSession}
-              onRevokeOthers={handleRevokeOtherSessions}
-            />
-          ) : null}
-        </div>
-      </details>
-
-      <DangerZone description="Export your data first, suspend access temporarily, or schedule permanent account deletion after the 30-day grace window.">
-        <article
-          className="idt-danger-zone-row idt-danger-zone-row--neutral"
-          data-testid="idt-export-account-row"
-        >
-          <div>
-            <strong>Download my data</strong>
-            <p>
-              Export a ZIP of your profile, workspaces, sessions, and audit activity. The download link is
-              valid for 24 hours.
-            </p>
-            {exportStatus.kind === 'ready' ? (
-              <p className="idt-danger-zone-success" data-testid="idt-export-ready">
-                Your data export is ready.{' '}
-                <a href={exportStatus.downloadURL} rel="noopener noreferrer">
-                  Download the ZIP
-                </a>
-                {exportStatus.expiresAt ? ` (link expires ${new Date(exportStatus.expiresAt).toLocaleString()})` : ''}.
-              </p>
-            ) : exportStatus.kind === 'preparing' ? (
-              <p className="idt-danger-zone-status" data-testid="idt-export-preparing">
-                {exportStatus.message}
-              </p>
-            ) : null}
-            {exportError ? (
-              <p className="idt-danger-zone-error" role="alert">
-                {exportError}
-              </p>
-            ) : null}
-          </div>
-          <button
-            className="idt-btn idt-btn-secondary"
-            data-testid="idt-export-account-button"
-            disabled={exportPending}
-            onClick={startDataExport}
-            type="button"
-          >
-            {exportPending ? 'Preparing…' : 'Download my data'}
-          </button>
-        </article>
-
+      <DangerZone>
         <DangerZoneRow
           actionLabel="Suspend account"
-          description="Ends all sessions until you sign in again."
           onAction={() => {
             setSuspendError('');
             setSuspendModalOpen(true);
           }}
           pending={suspendPending}
           testId="idt-suspend-account-row"
-          title="Account access"
+          title="Suspend account"
         />
         <DangerZoneRow
           actionLabel="Delete account"
-          description="Schedules permanent account deletion, revokes every other session, and removes your access to all workspaces after the recovery window."
           disabled={!primaryEmail}
           onAction={handleOpenDeleteModal}
           pending={deletePending}
           testId="idt-delete-account-row"
-          title="Delete my account permanently"
+          title="Delete account"
         />
       </DangerZone>
 
       <ConfirmDestructiveModal
         body={
           <>
-            <p>This revokes every active session and clears this device.</p>
-            <p>Your memberships, projects, and connector data stay intact.</p>
+            <p>You will be signed out on all devices.</p>
+            <p>Your workspace, projects, memberships, and connector data will remain intact.</p>
           </>
         }
         confirmation={{
-          kind: 'checkbox',
-          label: 'I understand this signs me out everywhere.'
+          kind: 'type-to-confirm',
+          expectedValue: 'SUSPEND',
+          inputLabel: 'Type SUSPEND to continue'
         }}
         continueLabel="Suspend account"
         errorMessage={suspendError || undefined}
@@ -14750,7 +14835,7 @@ export function ProductSettingsPage() {
         onConfirm={handleDeleteAccount}
         open={deleteModalOpen}
         pending={deletePending}
-        title="Delete my account permanently"
+        title="Delete account"
       />
     </section>
   );

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -1237,13 +1237,11 @@ function countMembersByRole(members: WorkspaceMemberRecord[], role: WorkspaceMem
 
 type ProfileDraft = {
   displayName: string;
-  avatarUrl: string;
 };
 
 function profileDraftFromMe(me: CurrentUserContext | null | undefined): ProfileDraft {
   return {
-    displayName: me?.user.display_name ?? '',
-    avatarUrl: me?.user.avatar_url ?? ''
+    displayName: me?.user.display_name ?? ''
   };
 }
 
@@ -1300,7 +1298,10 @@ function formatSettingsAuthProviders(config: AuthConfigResponse | null): string 
   return 'Session-only';
 }
 
-function validateProfileDraft(draft: ProfileDraft, options: { validateAvatarUrl?: boolean } = {}): string {
+const PROFILE_AVATAR_MAX_BYTES = 512 * 1024;
+const PROFILE_AVATAR_ALLOWED_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif']);
+
+function validateProfileDraft(draft: ProfileDraft): string {
   const displayName = draft.displayName.trim();
   if (!displayName || Array.from(displayName).length > 80) {
     return 'Display name must be 1-80 characters.';
@@ -1308,25 +1309,32 @@ function validateProfileDraft(draft: ProfileDraft, options: { validateAvatarUrl?
   if (Array.from(displayName).some(isUnsafeProfileNameCharacter)) {
     return 'Display name cannot contain control or bidirectional formatting characters.';
   }
-  const avatarUrl = draft.avatarUrl.trim();
-  if (options.validateAvatarUrl === false) {
-    return '';
+  return '';
+}
+
+function validateProfileAvatarFile(file: File): string {
+  if (!PROFILE_AVATAR_ALLOWED_TYPES.has(file.type)) {
+    return 'Profile photo must be PNG, JPG, WebP, or GIF.';
   }
-  if (!avatarUrl) {
-    return '';
-  }
-  try {
-    const parsed = new URL(avatarUrl);
-    if (parsed.protocol !== 'https:') {
-      return 'Photo URL must use https.';
-    }
-    if (parsed.username || parsed.password) {
-      return 'Photo URL cannot include credentials.';
-    }
-  } catch {
-    return 'Photo URL must be a valid https URL.';
+  if (file.size > PROFILE_AVATAR_MAX_BYTES) {
+    return 'Profile photo must be smaller than 512 KB.';
   }
   return '';
+}
+
+function readProfileAvatarFile(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === 'string') {
+        resolve(reader.result);
+        return;
+      }
+      reject(new Error('Unable to read profile photo.'));
+    };
+    reader.onerror = () => reject(new Error('Unable to read profile photo.'));
+    reader.readAsDataURL(file);
+  });
 }
 
 function isUnsafeProfileNameCharacter(char: string): boolean {
@@ -7588,7 +7596,6 @@ export function ProductShellLayout() {
               </span>
               <span className="idt-app-sidebar-workspace-copy">
                 <strong>{workspaceDisplayName}</strong>
-                <span>Identrail</span>
               </span>
               <span className="idt-app-sidebar-workspace-caret" aria-hidden="true">
                 <ChevronDown size={12} strokeWidth={2} />
@@ -14051,7 +14058,7 @@ export function ProductSettingsPage() {
   >({ kind: 'idle' });
   const exportAbortRef = useRef<AbortController | null>(null);
   const avatarControlRef = useRef<HTMLDivElement | null>(null);
-  const profilePhotoInputRef = useRef<HTMLInputElement | null>(null);
+  const avatarFileInputRef = useRef<HTMLInputElement | null>(null);
   const [profileEditing, setProfileEditing] = useState(false);
   const [avatarMenuOpen, setAvatarMenuOpen] = useState(false);
   const [profileDraft, setProfileDraft] = useState<ProfileDraft>(() => profileDraftFromMe(me));
@@ -14159,7 +14166,7 @@ export function ProductSettingsPage() {
       setProfileDraft(profileDraftFromMe(me));
       setProfileError('');
     }
-  }, [me?.user.display_name, me?.user.avatar_url, profileEditing, profileSaving]);
+  }, [me?.user.display_name, profileEditing, profileSaving]);
 
   useEffect(() => {
     if (!avatarMenuOpen) {
@@ -14208,22 +14215,16 @@ export function ProductSettingsPage() {
   const developerScopeLabel = scopes.length ? scopes.map(formatTokenLabel).join(', ') : 'No custom restrictions';
   const developerProviderLabel = authProviders.length ? authProviders.join(', ') : 'None advertised';
 
-  const focusProfilePhotoInput = () => {
-    window.requestAnimationFrame(() => profilePhotoInputRef.current?.focus());
-  };
-
   const handleProfileEdit = () => {
     if (profileEditing) {
       setProfileError('');
       setAvatarMenuOpen(false);
-      focusProfilePhotoInput();
       return;
     }
     setProfileDraft(profileDraftFromMe(me));
     setProfileError('');
     setProfileEditing(true);
     setAvatarMenuOpen(false);
-    focusProfilePhotoInput();
   };
 
   const handleProfileCancel = () => {
@@ -14253,14 +14254,11 @@ export function ProductSettingsPage() {
     setProfileSaving(true);
     setProfileError('');
     primeMeCache(optimisticMe);
-    if (wasProfileEditing) {
-      setProfileDraft({ ...previousDraft, avatarUrl: '' });
-    }
     try {
       const response = await apiClient.updateMe({ avatar_url: '' });
       primeMeCache(response.me);
       if (wasProfileEditing) {
-        setProfileDraft((draft) => ({ ...draft, avatarUrl: '' }));
+        setProfileDraft(previousDraft);
       } else {
         setProfileDraft(profileDraftFromMe(response.me));
         setProfileEditing(false);
@@ -14274,6 +14272,64 @@ export function ProductSettingsPage() {
     }
   };
 
+  const handleAvatarUploadClick = () => {
+    if (!me || profileSaving) {
+      return;
+    }
+    setAvatarMenuOpen(false);
+    setProfileError('');
+    avatarFileInputRef.current?.click();
+  };
+
+  const handleAvatarFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.currentTarget.files?.[0];
+    event.currentTarget.value = '';
+    if (!file || !me || profileSaving) {
+      return;
+    }
+    const validationError = validateProfileAvatarFile(file);
+    if (validationError) {
+      setProfileError(validationError);
+      return;
+    }
+    const previousMe = me;
+    const previousDraft = profileDraft;
+    const wasProfileEditing = profileEditing;
+    let nextAvatarURL = '';
+    try {
+      nextAvatarURL = await readProfileAvatarFile(file);
+    } catch (err) {
+      setProfileError(err instanceof Error ? err.message : 'Unable to read profile photo.');
+      return;
+    }
+    const optimisticMe: CurrentUserContext = {
+      ...previousMe,
+      user: {
+        ...previousMe.user,
+        avatar_url: nextAvatarURL,
+        updated_at: new Date().toISOString()
+      }
+    };
+    setProfileSaving(true);
+    setProfileError('');
+    primeMeCache(optimisticMe);
+    try {
+      const response = await apiClient.updateMe({ avatar_url: nextAvatarURL });
+      primeMeCache(response.me);
+      if (wasProfileEditing) {
+        setProfileDraft(previousDraft);
+      } else {
+        setProfileDraft(profileDraftFromMe(response.me));
+      }
+    } catch (err) {
+      primeMeCache(previousMe);
+      setProfileDraft(wasProfileEditing ? previousDraft : profileDraftFromMe(previousMe));
+      setProfileError(err instanceof Error ? err.message : 'Unable to update profile photo.');
+    } finally {
+      setProfileSaving(false);
+    }
+  };
+
   const handleProfileSubmit = async (event: FormEvent) => {
     event.preventDefault();
     if (!me) {
@@ -14282,17 +14338,14 @@ export function ProductSettingsPage() {
     }
     const previousMe = me;
     const previousDisplayName = previousMe.user.display_name?.trim() ?? '';
-    const previousAvatarURL = previousMe.user.avatar_url?.trim() ?? '';
     const nextDisplayName = profileDraft.displayName.trim();
-    const nextAvatarURL = profileDraft.avatarUrl.trim();
     const displayNameChanged = nextDisplayName !== previousDisplayName;
-    const avatarURLChanged = nextAvatarURL !== previousAvatarURL;
-    const validationError = validateProfileDraft(profileDraft, { validateAvatarUrl: avatarURLChanged });
+    const validationError = validateProfileDraft(profileDraft);
     if (validationError) {
       setProfileError(validationError);
       return;
     }
-    if (!displayNameChanged && !avatarURLChanged) {
+    if (!displayNameChanged) {
       setProfileError('');
       setProfileEditing(false);
       return;
@@ -14302,7 +14355,6 @@ export function ProductSettingsPage() {
       user: {
         ...previousMe.user,
         display_name: nextDisplayName,
-        avatar_url: nextAvatarURL,
         updated_at: new Date().toISOString()
       }
     };
@@ -14311,8 +14363,7 @@ export function ProductSettingsPage() {
     primeMeCache(optimisticMe);
     try {
       const payload = {
-        ...(displayNameChanged ? { display_name: nextDisplayName } : {}),
-        ...(avatarURLChanged ? { avatar_url: nextAvatarURL } : {})
+        display_name: nextDisplayName
       };
       const response = await apiClient.updateMe(payload);
       primeMeCache(response.me);
@@ -14453,6 +14504,15 @@ export function ProductSettingsPage() {
             data-menu-open={avatarMenuOpen ? 'true' : 'false'}
             ref={avatarControlRef}
           >
+            <input
+              ref={avatarFileInputRef}
+              type="file"
+              accept="image/png,image/jpeg,image/webp,image/gif"
+              hidden
+              onChange={(event) => {
+                void handleAvatarFileChange(event);
+              }}
+            />
             <button
               type="button"
               className="idt-profile-avatar"
@@ -14469,7 +14529,7 @@ export function ProductSettingsPage() {
             </button>
             {avatarMenuOpen ? (
               <div className="idt-profile-avatar-menu" role="menu">
-                <button type="button" role="menuitem" onClick={handleProfileEdit}>
+                <button type="button" role="menuitem" onClick={handleAvatarUploadClick} disabled={profileSaving}>
                   {profileAvatarURL ? 'Update photo' : 'Upload photo'}
                 </button>
                 {profileAvatarURL ? (
@@ -14495,14 +14555,12 @@ export function ProductSettingsPage() {
                 />
               </label>
               <label>
-                Photo URL
+                Email
                 <input
-                  ref={profilePhotoInputRef}
-                  type="url"
-                  value={profileDraft.avatarUrl}
-                  onChange={(event) => setProfileDraft((draft) => ({ ...draft, avatarUrl: event.target.value }))}
-                  disabled={profileSaving}
-                  placeholder="https://..."
+                  type="email"
+                  value={primaryEmail || 'Unavailable'}
+                  disabled
+                  readOnly
                 />
               </label>
               {profileError ? (

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -7560,7 +7560,7 @@ export function ProductShellLayout() {
     const observer =
       typeof ResizeObserver === 'undefined'
         ? null
-        : new ResizeObserver((_entries, _observer) => {
+        : new ResizeObserver(() => {
             scheduleUpdate();
           });
     observer?.observe(document.documentElement);

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -16,8 +16,6 @@ import {
   HelpCircle,
   LayoutDashboard,
   LogOut,
-  PanelLeftClose,
-  PanelLeftOpen,
   Pencil,
   Search,
   Settings as SettingsIcon
@@ -797,7 +795,7 @@ function buildExecutiveReportHtml(report: ExecutiveReport, highPriorityFindings:
         border: 1px solid #e6e9ee;
         border-radius: 4px;
       }
-      h1 { font-family: 'Georgia','Times New Roman',serif; font-weight: 600; letter-spacing: -0.01em; margin: 0 0 0.55rem; font-size: 1.95rem; color: #10141a; }
+      h1 { font-family: 'Georgia','Times New Roman',serif; font-weight: 600; letter-spacing: 0; margin: 0 0 0.55rem; font-size: 1.95rem; color: #10141a; }
       h2 { font-family: 'Georgia','Times New Roman',serif; font-weight: 600; font-size: 1.05rem; margin: 0 0 0.65rem; color: #10141a; }
       p { margin: 0; }
       .eyebrow { color: #5e6776; font-size: 0.72rem; font-weight: 600; letter-spacing: 0.16em; text-transform: uppercase; margin-bottom: 0.55rem; }
@@ -7039,6 +7037,14 @@ const SIDEBAR_MIN_EXPANDED_WIDTH = 196;
 const SIDEBAR_MAX_WIDTH = 360;
 const SIDEBAR_COLLAPSE_THRESHOLD = 140; // dragging below this snaps to collapsed
 const SIDEBAR_COLLAPSED_WIDTH = 60;
+const SCROLL_NAVIGATOR_MIN_THUMB_HEIGHT = 88;
+const SCROLL_NAVIGATOR_MAX_THUMB_HEIGHT = 168;
+
+type ScrollNavigatorMetrics = {
+  visible: boolean;
+  thumbHeight: number;
+  thumbTop: number;
+};
 
 function readSidebarCollapsed(): boolean {
   if (typeof window === 'undefined') {
@@ -7095,6 +7101,12 @@ export function ProductShellLayout() {
   const [sidebarCollapsedPref, setSidebarCollapsedPref] = useState<boolean>(() => readSidebarCollapsed());
   const [sidebarWidth, setSidebarWidth] = useState<number>(() => readSidebarWidth());
   const [isDraggingSidebar, setIsDraggingSidebar] = useState(false);
+  const [isSidebarEdgeFocused, setIsSidebarEdgeFocused] = useState(false);
+  const [scrollNavigator, setScrollNavigator] = useState<ScrollNavigatorMetrics>({
+    visible: false,
+    thumbHeight: 0,
+    thumbTop: 0
+  });
   const [isNarrowViewport, setIsNarrowViewport] = useState<boolean>(() => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
       return false;
@@ -7120,6 +7132,7 @@ export function ProductShellLayout() {
     kubernetes: null
   });
   const sidebarRef = useRef<HTMLElement | null>(null);
+  const sidebarResizeMovedRef = useRef(false);
   const basePath = scope ? buildScopedPath(scope) : '/app';
   const activeDomain = scope ? findActiveDomain(scope, location.pathname) : null;
   const activeDomainRouteID =
@@ -7381,13 +7394,25 @@ export function ProductShellLayout() {
     }
   }, [sidebarWidth]);
 
+  const toggleSidebarCollapsed = useCallback(() => {
+    if (isNarrowViewport) {
+      return;
+    }
+    setSidebarCollapsedPref((current) => !current);
+  }, [isNarrowViewport]);
+
   const handleSidebarResizeStart = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (isNarrowViewport) {
+      return;
+    }
+    if (event.button !== 0) {
       return;
     }
     event.preventDefault();
     const handleEl = event.currentTarget;
     const pointerId = event.pointerId;
+    const startClientX = event.clientX;
+    sidebarResizeMovedRef.current = false;
     // Capture the pointer so every subsequent move / up / cancel for this
     // gesture is delivered to the handle even if the user releases outside the
     // viewport, the OS steals focus, or the browser fires `pointercancel`.
@@ -7407,6 +7432,9 @@ export function ProductShellLayout() {
       if (moveEvent.pointerId !== pointerId) {
         return;
       }
+      if (Math.abs(moveEvent.clientX - startClientX) > 4) {
+        sidebarResizeMovedRef.current = true;
+      }
       const proposed = moveEvent.clientX - startLeft;
       if (proposed < SIDEBAR_COLLAPSE_THRESHOLD) {
         setSidebarCollapsedPref(true);
@@ -7420,11 +7448,15 @@ export function ProductShellLayout() {
       if (cleanupEvent && cleanupEvent.pointerId !== pointerId) {
         return;
       }
+      const shouldToggle = cleanupEvent?.type === 'pointerup' && !sidebarResizeMovedRef.current;
       setIsDraggingSidebar(false);
       handleEl.removeEventListener('pointermove', handlePointerMove);
       handleEl.removeEventListener('pointerup', cleanup);
       handleEl.removeEventListener('pointercancel', cleanup);
       handleEl.removeEventListener('lostpointercapture', cleanup);
+      if (shouldToggle) {
+        toggleSidebarCollapsed();
+      }
     };
     handleEl.addEventListener('pointermove', handlePointerMove);
     handleEl.addEventListener('pointerup', cleanup);
@@ -7433,6 +7465,14 @@ export function ProductShellLayout() {
     // including the OS canceling the gesture or the element being unmounted
     // by React. It is the most reliable final cleanup signal.
     handleEl.addEventListener('lostpointercapture', cleanup);
+  };
+
+  const handleSidebarResizeKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'Enter' && event.key !== ' ') {
+      return;
+    }
+    event.preventDefault();
+    toggleSidebarCollapsed();
   };
 
   // Safety net: any time we leave the dragging state, ensure the body style
@@ -7455,6 +7495,81 @@ export function ProductShellLayout() {
     document.body.style.removeProperty('user-select');
     return undefined;
   }, [isDraggingSidebar]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      return;
+    }
+
+    let frameID: number | undefined;
+    const requestFrame =
+      window.requestAnimationFrame ?? ((callback: FrameRequestCallback) => window.setTimeout(callback, 16));
+    const cancelFrame = window.cancelAnimationFrame ?? window.clearTimeout;
+    const updateMetrics = () => {
+      frameID = undefined;
+      const scrollingElement = document.scrollingElement ?? document.documentElement;
+      const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+      const scrollHeight = Math.max(
+        scrollingElement.scrollHeight,
+        document.documentElement.scrollHeight,
+        document.body.scrollHeight
+      );
+      const scrollRange = scrollHeight - viewportHeight;
+
+      if (scrollRange <= 24 || viewportHeight <= 0) {
+        setScrollNavigator((current) =>
+          current.visible ? { visible: false, thumbHeight: 0, thumbTop: 0 } : current
+        );
+        return;
+      }
+
+      const trackTop = Math.min(112, Math.max(80, viewportHeight * 0.13));
+      const trackBottom = Math.min(56, Math.max(36, viewportHeight * 0.05));
+      const trackHeight = Math.max(120, viewportHeight - trackTop - trackBottom);
+      const thumbHeight = Math.round(
+        Math.min(
+          SCROLL_NAVIGATOR_MAX_THUMB_HEIGHT,
+          Math.max(SCROLL_NAVIGATOR_MIN_THUMB_HEIGHT, trackHeight * 0.22)
+        )
+      );
+      const scrollProgress = Math.min(1, Math.max(0, scrollingElement.scrollTop / scrollRange));
+      const thumbTop = Math.round(trackTop + (trackHeight - thumbHeight) * scrollProgress);
+
+      setScrollNavigator((current) => {
+        if (
+          current.visible &&
+          current.thumbHeight === thumbHeight &&
+          Math.abs(current.thumbTop - thumbTop) <= 1
+        ) {
+          return current;
+        }
+        return { visible: true, thumbHeight, thumbTop };
+      });
+    };
+    const scheduleUpdate = () => {
+      if (frameID !== undefined) {
+        cancelFrame(frameID);
+      }
+      frameID = requestFrame(updateMetrics);
+    };
+
+    updateMetrics();
+    window.addEventListener('scroll', scheduleUpdate, { passive: true });
+    window.addEventListener('resize', scheduleUpdate);
+
+    const observer = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(scheduleUpdate);
+    observer?.observe(document.documentElement);
+    observer?.observe(document.body);
+
+    return () => {
+      if (frameID !== undefined) {
+        cancelFrame(frameID);
+      }
+      window.removeEventListener('scroll', scheduleUpdate);
+      window.removeEventListener('resize', scheduleUpdate);
+      observer?.disconnect();
+    };
+  }, [location.pathname]);
 
   useEffect(() => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
@@ -7531,7 +7646,6 @@ export function ProductShellLayout() {
   const userEmail = '';
   const userInitial = (workspaceDisplayName.charAt(0) || 'A').toUpperCase();
   const collapseShortcut = isMacPlatform() ? '⌘B' : 'Ctrl+B';
-  const collapseHint = `${sidebarCollapsed ? 'Expand' : 'Collapse'} sidebar (${collapseShortcut})`;
   const runCommand = (item: CommandPaletteItem) => {
     setCommandOpen(false);
     setOpenDomainFlyout(null);
@@ -7568,15 +7682,17 @@ export function ProductShellLayout() {
           data-collapsed={sidebarCollapsed ? 'true' : 'false'}
         >
           <div
-            className={`idt-app-sidebar-resize-handle${isDraggingSidebar ? ' is-dragging' : ''}`}
+            className={`idt-app-sidebar-resize-handle${isDraggingSidebar ? ' is-dragging' : ''}${isSidebarEdgeFocused ? ' is-focused' : ''}`}
             role="separator"
+            tabIndex={0}
             aria-orientation="vertical"
-            aria-label="Resize sidebar (drag, or use ⌘B to collapse)"
+            aria-label={`${sidebarCollapsed ? 'Expand' : 'Collapse'} sidebar. Drag to resize.`}
+            data-sidebar-action={sidebarCollapsed ? 'Click to expand' : 'Click to collapse'}
+            data-sidebar-shortcut={collapseShortcut}
             onPointerDown={handleSidebarResizeStart}
-            onDoubleClick={() => {
-              setSidebarCollapsedPref(false);
-              setSidebarWidth(SIDEBAR_DEFAULT_WIDTH);
-            }}
+            onKeyDown={handleSidebarResizeKeyDown}
+            onFocus={() => setIsSidebarEdgeFocused(true)}
+            onBlur={() => setIsSidebarEdgeFocused(false)}
           />
           <div className="idt-app-sidebar-workspace" ref={workspaceMenuRef}>
             <button
@@ -7793,20 +7909,6 @@ export function ProductShellLayout() {
                 </div>
               ) : null}
             </div>
-            <button
-              type="button"
-              className="idt-app-sidebar-collapse"
-              aria-label={collapseHint}
-              aria-pressed={sidebarCollapsed}
-              title={collapseHint}
-              onClick={() => setSidebarCollapsedPref((current) => !current)}
-            >
-              {sidebarCollapsed ? (
-                <PanelLeftOpen size={16} strokeWidth={1.75} aria-hidden="true" />
-              ) : (
-                <PanelLeftClose size={16} strokeWidth={1.75} aria-hidden="true" />
-              )}
-            </button>
           </div>
         </aside>
 
@@ -7824,6 +7926,20 @@ export function ProductShellLayout() {
             <Outlet />
           </main>
         </div>
+        {scrollNavigator.visible ? (
+          <div
+            className="idt-app-scroll-navigator"
+            aria-hidden="true"
+            style={
+              {
+                '--idt-scroll-navigator-thumb-height': `${scrollNavigator.thumbHeight}px`,
+                '--idt-scroll-navigator-thumb-top': `${scrollNavigator.thumbTop}px`
+              } as CSSProperties
+            }
+          >
+            <span className="idt-app-scroll-navigator-thumb" />
+          </div>
+        ) : null}
       </div>
       <CommandPalette
         open={commandOpen}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2245,13 +2245,35 @@ h2 {
   position: absolute;
   top: 0.6rem;
   right: 0.6rem;
-  border: 1px solid var(--idt-line);
-  border-radius: 999px;
-  width: 32px;
-  height: 32px;
+}
+
+.idt-esc-close,
+.idt-modal-close {
+  display: inline-grid;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 7px;
+  min-width: 2.45rem;
+  height: 1.8rem;
+  padding: 0 0.55rem;
   font-weight: 700;
-  background: transparent;
-  color: #fff;
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  background: rgba(255, 255, 255, 0.045);
+  color: rgba(245, 247, 248, 0.86);
+  cursor: pointer;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.idt-esc-close:hover,
+.idt-esc-close:focus-visible,
+.idt-modal-close:hover,
+.idt-modal-close:focus-visible {
+  border-color: rgba(255, 255, 255, 0.34);
+  background: rgba(255, 255, 255, 0.085);
+  color: #ffffff;
+  outline: none;
 }
 
 .idt-hero-copy {
@@ -4437,9 +4459,20 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   align-items: start;
 }
 
+.idt-profile-avatar-control {
+  position: relative;
+  width: 4.5rem;
+}
+
+.idt-profile-avatar-control[data-menu-open='true'] {
+  width: min(12rem, 100%);
+}
+
 .idt-profile-avatar {
   width: 4.5rem;
   aspect-ratio: 1;
+  padding: 0;
+  position: relative;
   overflow: hidden;
   display: grid;
   place-items: center;
@@ -4450,6 +4483,16 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   font-family: var(--idt-display);
   font-size: 1.2rem;
   font-weight: 800;
+  cursor: pointer;
+  transition: border-color 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.idt-profile-avatar:hover,
+.idt-profile-avatar:focus-visible {
+  border-color: rgba(255, 255, 255, 0.52);
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.045);
+  outline: none;
+  transform: translateY(-1px);
 }
 
 .idt-profile-avatar img {
@@ -4459,9 +4502,54 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   object-fit: cover;
 }
 
+.idt-profile-avatar-edit {
+  position: absolute;
+  right: 0.3rem;
+  bottom: 0.3rem;
+  display: inline-grid;
+  place-items: center;
+  width: 1.55rem;
+  height: 1.55rem;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 999px;
+  background: rgba(5, 5, 6, 0.82);
+  color: #ffffff;
+}
+
+.idt-profile-avatar-menu {
+  position: static;
+  z-index: 5;
+  margin-top: 0.55rem;
+  width: 12rem;
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.35rem;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: #070708;
+  box-shadow: var(--idt-console-shadow);
+}
+
+.idt-profile-avatar-menu button {
+  border: 0;
+  border-radius: 6px;
+  padding: 0.55rem 0.65rem;
+  background: transparent;
+  color: #f6f7f8;
+  font-weight: 700;
+  text-align: left;
+  cursor: pointer;
+}
+
+.idt-profile-avatar-menu button:hover,
+.idt-profile-avatar-menu button:focus-visible {
+  background: rgba(255, 255, 255, 0.07);
+  outline: none;
+}
+
 .idt-profile-form {
   margin-top: 0;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1.25fr) auto;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.25fr);
   align-items: end;
 }
 
@@ -4473,7 +4561,7 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   display: flex;
   gap: 0.45rem;
   align-items: center;
-  padding-bottom: 0.05rem;
+  flex-wrap: wrap;
 }
 
 .idt-profile-icon-btn {
@@ -4490,7 +4578,7 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
 
 .idt-profile-facts {
   align-self: stretch;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .idt-profile-form .idt-app-alert {
@@ -4605,6 +4693,101 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   margin: 0.18rem 0 0;
   color: #e1ebfb;
   overflow-wrap: anywhere;
+}
+
+.idt-settings-action-stack {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.idt-settings-action-item {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.idt-settings-action-row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border: 1px solid var(--app-border-soft, rgba(130, 160, 214, 0.22));
+  border-radius: 8px;
+  padding: 0.8rem 0.9rem;
+  background: rgba(255, 255, 255, 0.025);
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+  transition: border-color 0.18s ease, background-color 0.18s ease, transform 0.18s ease;
+}
+
+.idt-settings-action-row:hover,
+.idt-settings-action-row:focus-visible {
+  border-color: rgba(255, 255, 255, 0.34);
+  background: rgba(255, 255, 255, 0.06);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.idt-settings-action-row:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+  transform: none;
+}
+
+.idt-settings-action-row span:first-child {
+  min-width: 0;
+  display: grid;
+  gap: 0.12rem;
+}
+
+.idt-settings-action-row strong {
+  color: #f6f7f8;
+  font-size: 0.94rem;
+}
+
+.idt-settings-action-row small {
+  color: var(--app-muted, #a5adba);
+  font-size: 0.86rem;
+  line-height: 1.4;
+}
+
+.idt-settings-action-row svg {
+  flex: 0 0 auto;
+  color: rgba(255, 255, 255, 0.58);
+  transition: transform 0.18s ease, color 0.18s ease;
+}
+
+.idt-settings-action-row:hover svg,
+.idt-settings-action-row:focus-visible svg,
+.idt-settings-disclosure[open] .idt-settings-disclosure-summary svg,
+.idt-settings-inline-disclosure[open] .idt-settings-action-summary svg {
+  color: #ffffff;
+  transform: translateX(2px);
+}
+
+.idt-settings-inline-status {
+  margin: 0;
+  font-size: 0.86rem;
+}
+
+.idt-settings-inline-disclosure {
+  border: 0;
+  background: transparent;
+}
+
+.idt-settings-inline-disclosure .idt-settings-disclosure-body {
+  margin: 0.6rem 0 0;
+}
+
+.idt-settings-security-card .idt-settings-facts {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.idt-settings-workspace-card .idt-settings-facts {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .idt-executive-report-shell {
@@ -7386,6 +7569,10 @@ html[data-theme='light'] .idt-auth-mfa-form input {
 
   .idt-profile-avatar {
     width: 4rem;
+  }
+
+  .idt-profile-avatar-menu {
+    width: min(12rem, calc(100vw - 3rem));
   }
 
   .idt-workspace-stats,
@@ -23777,20 +23964,26 @@ button.idt-domain-finding-card:focus-visible {
 }
 
 .idt-domain-drawer-close {
-  width: 2rem;
-  height: 2rem;
-  border: 1px solid var(--app-border);
-  border-radius: 8px;
-  background: #050505;
-  color: #ffffff;
-  font-size: 1.1rem;
-  font-weight: 900;
+  display: inline-grid;
+  place-items: center;
+  min-width: 2.45rem;
+  height: 1.8rem;
+  padding: 0 0.55rem;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 7px;
+  background: rgba(255, 255, 255, 0.045);
+  color: rgba(245, 247, 248, 0.86);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
   cursor: pointer;
 }
 
 .idt-domain-drawer-close:hover,
 .idt-domain-drawer-close:focus-visible {
-  border-color: #ffffff;
+  border-color: rgba(255, 255, 255, 0.34);
+  background: rgba(255, 255, 255, 0.085);
+  color: #ffffff;
   outline: none;
 }
 
@@ -29069,9 +29262,9 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
 }
 
 .idt-danger-zone {
-  border-color: rgba(248, 113, 113, 0.34);
+  border-color: rgba(248, 81, 73, 0.42);
   background:
-    linear-gradient(180deg, rgba(127, 29, 29, 0.18), rgba(127, 29, 29, 0.04) 48%),
+    linear-gradient(180deg, rgba(80, 18, 18, 0.2), rgba(10, 10, 11, 0.02) 52%),
     var(--idt-console-surface, #090b0e);
 }
 
@@ -29084,7 +29277,7 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
 .idt-danger-zone-description {
   max-width: 68ch;
   margin: 0.28rem 0 0;
-  color: #d8b4b4;
+  color: #b7bdc8;
   font-size: 0.9rem;
 }
 
@@ -29101,9 +29294,9 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
   gap: 1rem;
   min-height: 4.25rem;
   padding: 0.78rem 0.9rem;
-  border: 1px solid rgba(248, 113, 113, 0.28);
+  border: 1px solid rgba(248, 81, 73, 0.32);
   border-radius: 8px;
-  background: rgba(12, 6, 8, 0.48);
+  background: rgba(8, 8, 9, 0.78);
 }
 
 .idt-danger-zone-row > div {
@@ -29113,13 +29306,13 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
 }
 
 .idt-danger-zone-row strong {
-  color: #fff1f2;
+  color: #ffffff;
   font-size: 0.96rem;
 }
 
 .idt-danger-zone-row p {
   margin: 0;
-  color: #d8b4b4;
+  color: #b7bdc8;
   font-size: 0.88rem;
   line-height: 1.42;
 }
@@ -29155,8 +29348,8 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
 }
 
 .idt-btn-danger {
-  border: 1px solid rgba(220, 100, 100, 0.7);
-  background: linear-gradient(180deg, #c1444a, #8b2a30);
+  border: 1px solid rgba(248, 81, 73, 0.72);
+  background: linear-gradient(180deg, #b4232a, #7f1d1d);
   color: #fff;
   font-weight: 600;
   padding: 0.5rem 0.95rem;
@@ -29171,24 +29364,30 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
 .idt-btn-danger:hover:not(:disabled),
 .idt-btn-danger:focus-visible:not(:disabled) {
   filter: brightness(1.08);
-  box-shadow: 0 6px 18px rgba(193, 68, 74, 0.32);
+  box-shadow: 0 8px 22px rgba(180, 35, 42, 0.3);
 }
 
 .idt-btn-danger:disabled {
-  opacity: 0.5;
+  opacity: 0.42;
   cursor: not-allowed;
 }
 
+.idt-danger-modal-backdrop {
+  background: #020204;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+}
+
 .idt-danger-modal {
-  width: min(100%, 560px);
-  border: 1px solid rgba(213, 125, 125, 0.5);
-  border-radius: 0.9rem;
-  background: #160a10;
-  box-shadow: var(--idt-shadow);
-  padding: 1.1rem;
+  width: min(100%, 520px);
+  border: 1px solid rgba(248, 81, 73, 0.42);
+  border-radius: 8px;
+  background: #09090a;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.72);
+  padding: 1.05rem;
   display: grid;
-  gap: 0.85rem;
-  color: #f5e1e1;
+  gap: 0.9rem;
+  color: #f6f7f8;
 }
 
 .idt-danger-modal header {
@@ -29200,13 +29399,13 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
 
 .idt-danger-modal h3 {
   margin: 0.15rem 0 0;
-  color: #ffe6e6;
+  color: #ffffff;
 }
 
 .idt-danger-modal-body {
   font-size: 0.94rem;
   line-height: 1.55;
-  color: #f1d4d4;
+  color: #c7cdd7;
 }
 
 .idt-danger-modal-body p {
@@ -29222,17 +29421,17 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
   gap: 0.55rem;
   align-items: flex-start;
   padding: 0.65rem 0.75rem;
-  border: 1px solid rgba(213, 125, 125, 0.3);
+  border: 1px solid rgba(248, 81, 73, 0.28);
   border-radius: 0.55rem;
-  background: rgba(28, 10, 14, 0.6);
+  background: rgba(18, 18, 20, 0.84);
   font-size: 0.92rem;
-  color: #ffe2e2;
+  color: #f6f7f8;
   cursor: pointer;
 }
 
 .idt-danger-modal-checkbox input {
   margin-top: 0.18rem;
-  accent-color: #c1444a;
+  accent-color: #b4232a;
 }
 
 .idt-danger-modal-typed {
@@ -29242,14 +29441,14 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
 
 .idt-danger-modal-typed label {
   font-size: 0.92rem;
-  color: #ffd6d6;
+  color: #f6f7f8;
 }
 
 .idt-danger-modal-typed input {
-  border: 1px solid rgba(213, 125, 125, 0.35);
+  border: 1px solid rgba(248, 81, 73, 0.42);
   border-radius: 0.5rem;
-  background: rgba(12, 6, 9, 0.85);
-  color: #ffe2e2;
+  background: #030304;
+  color: #ffffff;
   padding: 0.55rem 0.7rem;
   font-family: 'JetBrains Mono', ui-monospace, monospace;
 }
@@ -29258,11 +29457,12 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
 .idt-danger-modal-expected {
   margin: 0;
   font-size: 0.84rem;
-  color: #f0c5c5;
+  color: #aeb5c1;
 }
 
 .idt-danger-modal-expected code {
-  background: rgba(40, 14, 18, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
   border-radius: 0.3rem;
   padding: 0 0.3rem;
   font-family: 'JetBrains Mono', ui-monospace, monospace;
@@ -29271,10 +29471,10 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
 .idt-danger-modal-error {
   margin: 0;
   padding: 0.55rem 0.7rem;
-  border: 1px solid rgba(220, 129, 129, 0.44);
+  border: 1px solid rgba(248, 81, 73, 0.44);
   border-radius: 0.5rem;
-  background: rgba(40, 12, 16, 0.65);
-  color: #ffd0d0;
+  background: rgba(70, 14, 18, 0.55);
+  color: #ffd7d7;
   font-size: 0.9rem;
 }
 
@@ -29306,24 +29506,24 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
 
 html[data-theme='light'] .idt-danger-zone {
   background:
-    linear-gradient(180deg, rgba(127, 29, 29, 0.18), rgba(127, 29, 29, 0.04) 48%),
+    linear-gradient(180deg, rgba(80, 18, 18, 0.2), rgba(10, 10, 11, 0.02) 52%),
     var(--idt-console-surface, #090b0e);
-  border-color: rgba(248, 113, 113, 0.34);
+  border-color: rgba(248, 81, 73, 0.42);
 }
 
 html[data-theme='light'] .idt-danger-zone h3,
 html[data-theme='light'] .idt-danger-zone-row strong {
-  color: #fff1f2;
+  color: #ffffff;
 }
 
 html[data-theme='light'] .idt-danger-zone-description,
 html[data-theme='light'] .idt-danger-zone-row p {
-  color: #d8b4b4;
+  color: #b7bdc8;
 }
 
 html[data-theme='light'] .idt-danger-zone-row {
-  background: rgba(12, 6, 8, 0.48);
-  border-color: rgba(248, 113, 113, 0.28);
+  background: rgba(8, 8, 9, 0.78);
+  border-color: rgba(248, 81, 73, 0.32);
 }
 
 .idt-app-console-layout .idt-settings-page {
@@ -29383,6 +29583,9 @@ html[data-theme='light'] .idt-app-console-layout .idt-settings-header h2 {
 
 .idt-settings-disclosure-summary > span {
   flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
   border: 1px solid var(--app-border-soft);
   border-radius: 999px;
   padding: 0.36rem 0.64rem;
@@ -29399,6 +29602,14 @@ html[data-theme='light'] .idt-app-console-layout .idt-settings-header h2 {
   border-color: rgba(255, 255, 255, 0.24);
   background: rgba(255, 255, 255, 0.07);
   color: #f5f7f8;
+}
+
+.idt-settings-action-summary {
+  list-style: none;
+}
+
+.idt-settings-action-summary::-webkit-details-marker {
+  display: none;
 }
 
 .idt-settings-disclosure-summary:focus-visible {
@@ -29571,9 +29782,9 @@ html[data-theme='light'] .idt-settings-sessions-card .idt-session-row {
   }
 
   .idt-settings-disclosure-summary {
-    align-items: stretch;
-    flex-direction: column;
-    gap: 0.85rem;
+    align-items: center;
+    flex-direction: row;
+    gap: 1rem;
   }
 
   .idt-settings-disclosure-summary > span {
@@ -29598,18 +29809,18 @@ html[data-theme='light'] .idt-settings-sessions-card .idt-session-row {
 }
 
 html[data-theme='light'] .idt-danger-modal {
-  background: #fff8f8;
-  border-color: rgba(165, 50, 50, 0.45);
-  color: #581717;
+  background: #09090a;
+  border-color: rgba(248, 81, 73, 0.42);
+  color: #f6f7f8;
 }
 
 html[data-theme='light'] .idt-danger-modal h3,
 html[data-theme='light'] .idt-danger-modal-checkbox,
 html[data-theme='light'] .idt-danger-modal-body {
-  color: #6a1d1d;
+  color: #f6f7f8;
 }
 
 html[data-theme='light'] .idt-danger-modal-typed input {
-  background: #fff;
-  color: #4a1212;
+  background: #030304;
+  color: #ffffff;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -29382,16 +29382,19 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
 .idt-btn-danger:hover:not(:disabled),
 .idt-btn-danger:focus-visible:not(:disabled) {
   filter: brightness(1.08);
-  box-shadow: 0 8px 22px rgba(180, 35, 42, 0.3);
+  box-shadow: none;
 }
 
 .idt-btn-danger:disabled {
-  opacity: 0.42;
+  opacity: 1;
+  border-color: rgba(248, 81, 73, 0.22);
+  background: #1d1012;
+  color: #8c929c;
   cursor: not-allowed;
 }
 
 .idt-danger-modal-backdrop {
-  background: #020204;
+  background: #000000;
   -webkit-backdrop-filter: none;
   backdrop-filter: none;
 }
@@ -29423,7 +29426,7 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
 .idt-danger-modal-body {
   font-size: 0.94rem;
   line-height: 1.55;
-  color: #c7cdd7;
+  color: #d8dde6;
 }
 
 .idt-danger-modal-body p {
@@ -29475,7 +29478,7 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
 .idt-danger-modal-expected {
   margin: 0;
   font-size: 0.84rem;
-  color: #aeb5c1;
+  color: #e0e4ec;
 }
 
 .idt-danger-modal-expected code {
@@ -29836,6 +29839,10 @@ html[data-theme='light'] .idt-danger-modal h3,
 html[data-theme='light'] .idt-danger-modal-checkbox,
 html[data-theme='light'] .idt-danger-modal-body {
   color: #f6f7f8;
+}
+
+html[data-theme='light'] .idt-danger-modal .idt-danger-modal-help {
+  color: #e0e4ec;
 }
 
 html[data-theme='light'] .idt-danger-modal-typed input {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -215,7 +215,7 @@ a {
   background: var(--idt-cta);
   color: #030303;
   border-color: rgba(255, 255, 255, 0.85);
-  box-shadow: 0 10px 26px rgba(0, 0, 0, 0.42);
+  box-shadow: none;
 }
 
 .idt-btn-dark {
@@ -3178,7 +3178,7 @@ html[data-theme='light'] .idt-nav a.is-active {
 html[data-theme='light'] .idt-btn-primary {
   color: #eef3ff;
   border-color: rgba(9, 20, 38, 0.18);
-  box-shadow: 0 10px 24px rgba(30, 48, 88, 0.2);
+  box-shadow: none;
 }
 
 html[data-theme='light'] .idt-btn-dark,
@@ -3669,7 +3669,7 @@ html[data-theme='light'] .idt-btn-primary {
   background: linear-gradient(120deg, #152a4f 0%, #213b66 100%);
   border-color: rgba(15, 32, 59, 0.25);
   color: #f5f9ff;
-  box-shadow: 0 12px 30px rgba(32, 52, 92, 0.22);
+  box-shadow: none;
 }
 
 html[data-theme='light'] .idt-btn-dark,
@@ -4464,10 +4464,6 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
   width: 4.5rem;
 }
 
-.idt-profile-avatar-control[data-menu-open='true'] {
-  width: min(12rem, 100%);
-}
-
 .idt-profile-avatar {
   width: 4.5rem;
   aspect-ratio: 1;
@@ -4517,9 +4513,10 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
 }
 
 .idt-profile-avatar-menu {
-  position: static;
+  position: absolute;
+  top: calc(100% + 0.55rem);
+  left: 0;
   z-index: 5;
-  margin-top: 0.55rem;
   width: 12rem;
   display: grid;
   gap: 0.25rem;
@@ -9085,7 +9082,7 @@ body {
   background: #edf3e6;
   color: #09100d;
   border-color: #edf3e6;
-  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.28);
+  box-shadow: none;
 }
 
 .idt-hero .idt-btn-dark {
@@ -10296,7 +10293,7 @@ html[data-theme='light'] .idt-hero .idt-btn-primary,
   background: linear-gradient(135deg, #823cf2 0%, #6428cd 100%);
   border-color: transparent;
   color: #ffffff;
-  box-shadow: 0 12px 26px rgba(101, 43, 208, 0.24);
+  box-shadow: none;
 }
 
 html[data-theme='light'] .idt-btn-dark,
@@ -16611,12 +16608,12 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   border-color: #ffffff;
   background: #ffffff;
   color: #050607;
-  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.35);
+  box-shadow: none;
 }
 
 .idt-onboarding-shell .idt-btn-primary:hover,
 .idt-onboarding-shell .idt-btn-primary:focus-visible {
-  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.42);
+  box-shadow: none;
 }
 
 html[data-theme='light'] .idt-onboarding-shell .idt-btn-primary,
@@ -24553,7 +24550,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-repo-finding-detail-modal 
   border-color: rgba(147, 197, 253, 0.78);
   background: linear-gradient(180deg, #2f6fed 0%, #1d4ed8 100%);
   color: #ffffff;
-  box-shadow: 0 12px 28px rgba(29, 78, 216, 0.28);
+  box-shadow: none;
 }
 
 .idt-app-console-layout .idt-repo-finding-detail-modal .idt-btn-primary:hover,
@@ -27436,7 +27433,8 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
   align-items: center;
   gap: 0.6rem;
   width: 100%;
-  padding: 0.4rem 0.45rem;
+  min-height: 2.7rem;
+  padding: 0.48rem 0.45rem;
   border: 1px solid transparent;
   border-radius: 7px;
   background: transparent;
@@ -27474,10 +27472,11 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
 }
 
 .idt-app-sidebar-workspace-copy {
-  display: grid;
-  gap: 0.05rem;
+  display: flex;
+  align-items: center;
   min-width: 0;
   flex: 1 1 auto;
+  min-height: 1.7rem;
 }
 
 .idt-app-sidebar-workspace-copy strong {
@@ -27488,13 +27487,8 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
   color: #ffffff;
   font-size: 0.92rem;
   font-weight: 600;
-  letter-spacing: -0.005em;
-}
-
-.idt-app-sidebar-workspace-copy span {
-  display: block;
-  color: #85858f;
-  font-size: 0.74rem;
+  letter-spacing: 0;
+  line-height: 1.15;
 }
 
 .idt-app-sidebar-workspace-caret {
@@ -28118,7 +28112,7 @@ html[data-theme='light'] .idt-executive-report-shell .idt-btn-primary {
   border-color: rgba(139, 124, 255, 0.92);
   background: linear-gradient(180deg, #8173ff 0%, #5d50ef 100%);
   color: #ffffff;
-  box-shadow: 0 12px 30px rgba(93, 80, 239, 0.26);
+  box-shadow: none;
 }
 
 .idt-app-console-layout .idt-btn-primary:hover,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4822,7 +4822,7 @@ html[data-theme] .idt-executive-report-shell .idt-exec-report__header h1 {
   font-family: var(--idt-display);
   font-size: clamp(1.85rem, 3.4vw, 2.4rem);
   font-weight: 600;
-  letter-spacing: -0.014em;
+  letter-spacing: 0;
   line-height: 1.1;
   color: rgba(245, 247, 248, 0.97);
   text-transform: none;
@@ -4904,7 +4904,7 @@ html[data-theme] .idt-executive-report-shell .idt-exec-kpi dd {
   font-family: var(--idt-display);
   font-size: clamp(1.65rem, 2.6vw, 2rem);
   font-weight: 600;
-  letter-spacing: -0.018em;
+  letter-spacing: 0;
   line-height: 1.05;
   color: rgba(245, 247, 248, 0.98);
   font-variant-numeric: tabular-nums;
@@ -4927,7 +4927,7 @@ html[data-theme] .idt-executive-report-shell .idt-exec-section h2 {
   font-family: var(--idt-display);
   font-size: 1.1rem;
   font-weight: 600;
-  letter-spacing: -0.005em;
+  letter-spacing: 0;
   color: rgba(245, 247, 248, 0.94);
   text-transform: none;
 }
@@ -11618,7 +11618,7 @@ html[data-theme='light'] .idt-trust-strip,
   color: rgba(21, 25, 34, 0.38);
   font-size: clamp(1.6rem, 2.35vw, 2.55rem);
   font-weight: 800;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
   line-height: 1;
   white-space: nowrap;
   filter: grayscale(1);
@@ -15752,38 +15752,17 @@ html[data-theme='light'] body::-webkit-scrollbar-thumb:hover {
   background: #98a3b3;
 }
 
-/* Dark app shell: the global page scrollbar otherwise inherits the light-theme
-   colours (a near-white track), which reads as a heavy white bar on the dark
-   dashboard. Scope a slim, subtle scrollbar to pages that render the app shell. */
+/* Dark app shell: the native page scrollbar grows almost full-height on short
+   app pages, so the console renders its own fixed-size navigator instead. */
 html:has(.idt-app-console-layout),
 html:has(.idt-app-console-layout) body {
-  scrollbar-width: thin;
-  scrollbar-color: rgba(255, 255, 255, 0.22) transparent;
+  scrollbar-width: none;
 }
 
 html:has(.idt-app-console-layout)::-webkit-scrollbar,
 html:has(.idt-app-console-layout) body::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
-
-html:has(.idt-app-console-layout)::-webkit-scrollbar-track,
-html:has(.idt-app-console-layout) body::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-html:has(.idt-app-console-layout)::-webkit-scrollbar-thumb,
-html:has(.idt-app-console-layout) body::-webkit-scrollbar-thumb {
-  border: 2px solid transparent;
-  border-radius: 999px;
-  background-color: rgba(255, 255, 255, 0.18);
-  background-clip: padding-box;
-}
-
-html:has(.idt-app-console-layout)::-webkit-scrollbar-thumb:hover,
-html:has(.idt-app-console-layout) body::-webkit-scrollbar-thumb:hover {
-  background-color: rgba(255, 255, 255, 0.32);
-  background-clip: padding-box;
+  width: 0;
+  height: 0;
 }
 
 .idt-btn,
@@ -26309,7 +26288,7 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 
 .idt-app-console-layout .idt-app-sidebar-brand-copy strong {
   font-size: 0.95rem;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
 }
 
 .idt-app-console-layout .idt-app-sidebar-brand-copy span {
@@ -26400,7 +26379,7 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   color: #a3a3ac;
   font-size: 0.9rem;
   font-weight: 500;
-  letter-spacing: -0.005em;
+  letter-spacing: 0;
   transition: background-color 0.12s ease, color 0.12s ease;
 }
 
@@ -26765,14 +26744,14 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 }
 
 .idt-app-console-layout .idt-app-sidebar-footer {
-  align-self: end;
+  align-self: stretch;
   display: grid;
   gap: 0.4rem;
-  padding: 0;
+  margin-top: auto;
+  padding: 0.65rem 0 0;
   border: none;
-  background: transparent;
   border-top: 1px solid var(--app-border-soft);
-  padding-top: 0.6rem;
+  background: transparent;
 }
 
 .idt-app-sidebar-account {
@@ -26782,11 +26761,12 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 .idt-app-console-layout .idt-app-sidebar-account-trigger {
   display: flex;
   align-items: center;
-  gap: 0.55rem;
+  gap: 0.62rem;
   width: 100%;
-  padding: 0.4rem 0.45rem;
+  min-height: 2.65rem;
+  padding: 0.48rem 0.5rem;
   border: 1px solid transparent;
-  border-radius: 7px;
+  border-radius: 8px;
   background: transparent;
   color: inherit;
   font: inherit;
@@ -26807,12 +26787,12 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.7rem;
-  height: 1.7rem;
+  width: 1.9rem;
+  height: 1.9rem;
   border-radius: 999px;
   background: #1f1f26;
   color: #ffffff;
-  font-size: 0.78rem;
+  font-size: 0.82rem;
   font-weight: 700;
   flex: 0 0 auto;
 }
@@ -26918,35 +26898,6 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   outline: none;
 }
 
-.idt-app-console-layout .idt-app-sidebar-collapse {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.85rem;
-  height: 1.85rem;
-  margin-left: auto;
-  border: 1px solid transparent;
-  border-radius: 6px;
-  background: transparent;
-  color: #85858f;
-  cursor: pointer;
-  transition: background-color 0.12s ease, color 0.12s ease, border-color 0.12s ease;
-}
-
-.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-collapse {
-  margin-left: 0;
-  align-self: center;
-  justify-self: center;
-}
-
-.idt-app-console-layout .idt-app-sidebar-collapse:hover,
-.idt-app-console-layout .idt-app-sidebar-collapse:focus-visible {
-  background: #131318;
-  color: #ffffff;
-  border-color: var(--app-border-soft);
-  outline: none;
-}
-
 /* Console main area */
 
 .idt-app-console-layout .idt-app-console {
@@ -27021,7 +26972,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
   font-size: 1.05rem;
   font-weight: 600;
   color: #ffffff;
-  letter-spacing: -0.005em;
+  letter-spacing: 0;
 }
 
 .idt-app-console-layout .idt-overview-checklist header p {
@@ -27149,7 +27100,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
   font-size: 1.85rem;
   font-weight: 500;
   font-variant-numeric: tabular-nums;
-  letter-spacing: -0.02em;
+  letter-spacing: 0;
   color: #ffffff;
   margin: 0;
   line-height: 1;
@@ -27221,7 +27172,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
   font-family: var(--idt-display);
   font-size: 1.05rem;
   font-weight: 600;
-  letter-spacing: -0.005em;
+  letter-spacing: 0;
   color: #ffffff;
 }
 
@@ -27334,7 +27285,11 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
 }
 
 .idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-footer {
-  justify-items: center;
+  justify-items: stretch;
+}
+
+.idt-app-console-layout.is-sidebar-collapsed .idt-app-sidebar-account {
+  width: 100%;
 }
 
 @media (max-width: 960px) {
@@ -27348,10 +27303,8 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
   .idt-app-console-layout.is-sidebar-collapsed {
     grid-template-columns: 1fr;
   }
-  /* Collapsed mode is forced off on narrow viewports by JS (the rail becomes a
-   * top bar, where "collapsed" has no useful meaning). The toggle button is
-   * still rendered so a user who resizes back to desktop has an obvious path
-   * out of any previously-persisted collapsed preference. */
+  /* Collapsed mode is forced off on narrow viewports by JS because the rail
+   * becomes a top bar where the desktop edge affordance is not useful. */
 
   .idt-domain-flyout {
     position: fixed;
@@ -27410,7 +27363,7 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
 .idt-app-console-layout .idt-overview-header h2 {
   font-size: clamp(1.85rem, 2.4vw, 2.25rem);
   font-weight: 600;
-  letter-spacing: -0.02em;
+  letter-spacing: 0;
 }
 
 /* Collapsed quick-find: visually match nav icons */
@@ -27691,8 +27644,8 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
 .idt-app-sidebar-resize-handle {
   position: absolute;
   top: 0;
-  right: -3px;
-  width: 6px;
+  right: -5px;
+  width: 10px;
   height: 100%;
   cursor: col-resize;
   z-index: 30;
@@ -27701,22 +27654,86 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
   touch-action: none;
 }
 
+.idt-app-sidebar-resize-handle:focus,
+.idt-app-sidebar-resize-handle:focus-visible {
+  outline: none;
+}
+
+.idt-app-sidebar-resize-handle::before {
+  content: attr(data-sidebar-action) " " attr(data-sidebar-shortcut) "\A Drag to resize";
+  position: absolute;
+  top: 50%;
+  left: calc(100% + 0.8rem);
+  z-index: 2;
+  min-width: 10.8rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 0.5rem 0.64rem;
+  background: rgba(0, 0, 0, 0.94);
+  color: #ffffff;
+  font-size: 0.84rem;
+  font-weight: 500;
+  line-height: 1.28;
+  white-space: pre;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-50%) translateX(-0.2rem);
+  transition: opacity 0.12s ease, transform 0.12s ease;
+  box-shadow: 0 14px 42px rgba(0, 0, 0, 0.45);
+}
+
 .idt-app-sidebar-resize-handle::after {
   content: '';
   position: absolute;
-  top: 0;
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%);
-  width: 2px;
-  height: 100%;
-  background: transparent;
-  transition: background-color 0.12s ease;
+  width: 4px;
+  height: min(8.4rem, 26vh);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0);
+  transform: translate(-50%, -50%);
+  transition: background-color 0.12s ease, height 0.12s ease;
+}
+
+.idt-app-sidebar-resize-handle:hover::before,
+.idt-app-sidebar-resize-handle:focus::before,
+.idt-app-sidebar-resize-handle:focus-visible::before,
+.idt-app-sidebar-resize-handle.is-focused::before,
+.idt-app-sidebar-resize-handle.is-dragging::before {
+  opacity: 1;
+  transform: translateY(-50%) translateX(0);
 }
 
 .idt-app-sidebar-resize-handle:hover::after,
+.idt-app-sidebar-resize-handle:focus::after,
+.idt-app-sidebar-resize-handle:focus-visible::after,
+.idt-app-sidebar-resize-handle.is-focused::after,
 .idt-app-sidebar-resize-handle.is-dragging::after,
 .idt-app-console-layout.is-sidebar-dragging .idt-app-sidebar-resize-handle::after {
-  background: #3a3a45;
+  background: rgba(235, 239, 245, 0.72);
+}
+
+.idt-app-scroll-navigator {
+  position: fixed;
+  top: 0;
+  right: 0.34rem;
+  bottom: 0;
+  z-index: 70;
+  width: 0.82rem;
+  pointer-events: none;
+}
+
+.idt-app-scroll-navigator-thumb {
+  position: absolute;
+  top: var(--idt-scroll-navigator-thumb-top);
+  right: 0.18rem;
+  width: 0.38rem;
+  height: var(--idt-scroll-navigator-thumb-height);
+  border-radius: 999px;
+  background: rgba(236, 241, 247, 0.54);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 10px 24px rgba(0, 0, 0, 0.42);
 }
 
 /* Hide the drag handle on narrow viewports — the rail becomes a top bar. */
@@ -27819,6 +27836,10 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
   --idt-console-surface-deep: #030405;
   --idt-console-focus: #7c6dff;
   --idt-console-shadow: 0 18px 48px rgba(0, 0, 0, 0.26);
+  --idt-product-font: -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", "Segoe UI", sans-serif;
+  --idt-body: var(--idt-product-font);
+  --idt-display: var(--idt-product-font);
+  --idt-nav-font: var(--idt-product-font);
 }
 
 .idt-app-console-layout,
@@ -27831,6 +27852,10 @@ html[data-theme='light'] .idt-app-shell-screen,
 html[data-theme='light'] .idt-executive-report-shell {
   background: linear-gradient(180deg, #15191d 0%, #121518 42%, #111417 100%);
   color: var(--app-text);
+  font-family: var(--idt-product-font);
+  font-size: 16px;
+  line-height: 1.45;
+  letter-spacing: 0;
 }
 
 .idt-app-shell-screen .idt-app-panel h1,
@@ -28813,7 +28838,7 @@ html[data-theme='light'] .idt-home-after-stack .idt-command-surface {
 
 .idt-product-card-metric {
   font-size: 19px;
-  letter-spacing: -0.02em;
+  letter-spacing: 0;
 }
 
 .idt-inline-button-link {
@@ -29249,7 +29274,6 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
   }
 
   .idt-app-console-layout .idt-app-sidebar-footer,
-  .idt-app-console-layout .idt-app-sidebar-collapse,
   .idt-app-console-layout .idt-app-sidebar-resize-handle {
     display: none;
   }


### PR DESCRIPTION
## Summary
- Tightens the settings page to keep only important profile, security, workspace, developer, and danger-zone information visible by default.
- Reworks profile photo controls so the pencil lives on the photo tile and opens contextual upload/update/delete actions.
- Redesigns destructive account suspension confirmation with a fully dark backdrop, restrained danger treatment, tighter wording, type-to-confirm flow, and visible `ESC` close controls across the app.
- Moves account export into the profile/account area and keeps developer IDs/auth implementation details behind a disclosure.

## Visual QA
- Desktop settings: inspected profile/security/workspace hierarchy, removed redundant raw IDs and duplicate action surfaces.
- Avatar menu: inspected the opened menu, caught overlap with the email field, changed it to open inline under the profile photo, then re-tested.
- Profile editor: inspected the edit state with `Photo URL` wording and save/cancel controls.
- Developer details: inspected collapsed and expanded states.
- Suspension modal: inspected full dark backdrop, no pink treatment, tighter copy, `ESC` close control, and disabled destructive action before typing `SUSPEND`.
- Mobile settings: inspected the stacked layout at 390px width.
- Export ready state: inspected the completed data-export row after suppressing browser download navigation.

## Validation
- `npm --prefix web test -- --run`
- `npm --prefix web run build`
- `git diff --check`
- Visual screenshots generated under `/tmp/identrail-settings-premium-polish-final`.

No issue: User-requested settings and suspension polish from product/design review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes Settings with a simpler Profile and Security plus a tighter destructive flow. Adds inline avatar upload/delete with base64 image data URL support, clearer sign-in labels, sessions under “Manage sessions,” standard “ESC” closes, and a darker delete/suspend modal.

- **New Features**
  - Profile photo control: pencil opens an inline menu to upload (PNG/JPG/WebP/GIF, ≤512 KB) or delete; uploads saved as data URLs; menu closes on Escape/outside clicks; changes apply immediately; unsaved edits are preserved.
  - Profile editor is simpler: removed “Photo URL”; Save/Cancel show only in edit; “Download my data” moved into Profile with inline preparing/ready/error status.
  - Security summarizes sign-in methods with normalized labels (“GitHub, Google”, “Hosted login”, “SAML SSO”, “Manual development”, “Session-only”); sessions live under a collapsible “Manage sessions”; developer details behind a disclosure; SAML shows “Not configured” when absent.

- **Refactors**
  - API and OpenAPI: `avatar_url` supports allowed https URLs or base64 image data URLs; validates type/size (PNG/JPEG/WebP/GIF, ≤512 KB); rejects non-image data URIs, http URLs, and disallowed hosts; OpenAPI pattern aligned; server tests added for data URL acceptance.
  - UI polish: standardized visible “ESC” close across modals/drawers (scan intake, sales, domain drawer, permission preview); destructive dialogs (suspend, delete account) use a darker backdrop; suspend uses type-to-confirm (“SUSPEND”); delete flow title is “Delete account”; button shadows flattened; Danger Zone description is optional.
  - Tests: stabilized onboarding by waiting for “Create boundary” to enable; updated settings tests to new labels and layout.

<sup>Written for commit 38102a088d61694c1aa3ed0c0094b4cd761eff68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

