### PR TITLE
Workspace Danger Zone frontend (PR 3 of #1420)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
 ## Unreleased
+- Added the owner-only workspace Danger Zone on Settings (PR 3 of #1420).
+  Workspace owners now see Suspend / Reactivate / Delete / Restore rows
+  appended into the existing Danger Zone card alongside the user-account
+  rows, with copy that matches the existing account modals: a
+  type-to-confirm `SUSPEND` token on Suspend, a type-to-confirm workspace
+  slug on Delete, and lightweight checkbox modals on the restorative
+  Reactivate and Restore. The rows swap based on
+  `tenancy_workspaces.status` (`active` → Suspend + Delete, `suspended` →
+  Reactivate + Delete, `deleted` → Restore only) so the visible action
+  always matches the next valid transition. Non-owners see exactly the
+  two account rows that shipped before, with no layout change. A
+  `409 sole_owner_requires_transfer` response renders an inline block
+  inside the open modal listing the affected members + a deep link to the
+  workspace member-management screen, so an owner can promote another
+  owner and retry without losing the destructive flow. The frontend role
+  gate is convenience; the backend `policyActionTenancyOwner` action
+  shipped in PR 1 remains the authoritative 403.
 - Added workspace hard-delete worker (PR 2 of #1420). A daily scheduled
   pass in `internal/workspacepurge` drains soft-deleted workspaces past
   the 30-day grace window: it explicitly purges `scans`, `repo_scans`,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -352,6 +352,8 @@ export type IdentrailScopeHeaders = {
 export type WorkspaceMemberRole = 'owner' | 'admin' | 'analyst' | 'viewer';
 export type WorkspaceMemberStatus = 'invited' | 'active' | 'suspended' | 'removed';
 
+export type WorkspaceLifecycleStatus = 'active' | 'suspended' | 'deleted';
+
 export type WorkspaceRecord = {
   tenant_id: string;
   workspace_id: string;
@@ -359,6 +361,40 @@ export type WorkspaceRecord = {
   slug: string;
   created_at: string;
   updated_at: string;
+  status?: WorkspaceLifecycleStatus;
+  suspended_at?: string | null;
+  deleted_at?: string | null;
+};
+
+export type WorkspaceSuspendResponse = {
+  workspace: WorkspaceRecord;
+  status: WorkspaceLifecycleStatus;
+  suspended_at?: string | null;
+};
+
+export type WorkspaceReactivateResponse = {
+  workspace: WorkspaceRecord;
+  status: WorkspaceLifecycleStatus;
+};
+
+export type WorkspaceDeleteResponse = {
+  workspace: WorkspaceRecord;
+  status: WorkspaceLifecycleStatus;
+  deleted_at?: string | null;
+  hard_delete_after?: string;
+  grace_period_hours?: number;
+};
+
+export type WorkspaceCancelDeletionResponse = {
+  workspace: WorkspaceRecord;
+  status: WorkspaceLifecycleStatus;
+};
+
+export type WorkspaceSoleOwnerAffectedMember = {
+  member_id: string;
+  user_id: string;
+  email?: string;
+  role: string;
 };
 
 export type WorkspaceMemberRecord = {
@@ -1456,6 +1492,34 @@ export const apiClient = {
       {
         method: 'DELETE'
       }
+    );
+  },
+  suspendWorkspace(workspaceID: string, auth?: RequestAuthContext) {
+    return request<WorkspaceSuspendResponse>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/suspend`,
+      auth,
+      { method: 'POST' }
+    );
+  },
+  reactivateWorkspace(workspaceID: string, auth?: RequestAuthContext) {
+    return request<WorkspaceReactivateResponse>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/reactivate`,
+      auth,
+      { method: 'POST' }
+    );
+  },
+  deleteWorkspace(workspaceID: string, auth?: RequestAuthContext) {
+    return request<WorkspaceDeleteResponse>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}`,
+      auth,
+      { method: 'DELETE' }
+    );
+  },
+  cancelWorkspaceDeletion(workspaceID: string, auth?: RequestAuthContext) {
+    return request<WorkspaceCancelDeletionResponse>(
+      `/v1/workspaces/${encodeURIComponent(workspaceID)}/cancel-deletion`,
+      auth,
+      { method: 'POST' }
     );
   },
   getFindingsSummary(auth?: RequestAuthContext) {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -366,20 +366,25 @@ export type WorkspaceRecord = {
   deleted_at?: string | null;
 };
 
+// Each lifecycle endpoint deterministically transitions the workspace to a
+// single terminal state, so the top-level `status` is narrowed to that
+// literal (cubic PR #1456 P3). The broader `WorkspaceLifecycleStatus` still
+// lives on `workspace.status` via `WorkspaceRecord` because that field
+// reflects whatever the backend serialized for the workspace as a whole.
 export type WorkspaceSuspendResponse = {
   workspace: WorkspaceRecord;
-  status: WorkspaceLifecycleStatus;
+  status: 'suspended';
   suspended_at?: string | null;
 };
 
 export type WorkspaceReactivateResponse = {
   workspace: WorkspaceRecord;
-  status: WorkspaceLifecycleStatus;
+  status: 'active';
 };
 
 export type WorkspaceDeleteResponse = {
   workspace: WorkspaceRecord;
-  status: WorkspaceLifecycleStatus;
+  status: 'deleted';
   deleted_at?: string | null;
   hard_delete_after?: string;
   grace_period_hours?: number;
@@ -387,7 +392,7 @@ export type WorkspaceDeleteResponse = {
 
 export type WorkspaceCancelDeletionResponse = {
   workspace: WorkspaceRecord;
-  status: WorkspaceLifecycleStatus;
+  status: 'active';
 };
 
 export type WorkspaceSoleOwnerAffectedMember = {

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -4166,6 +4166,42 @@ describe('Workspace Danger Zone (#1420)', () => {
     await screen.findByTestId('idt-reactivate-workspace-row');
   });
 
+  it('still renders a fallback sole-owner blocker when affected_members is empty', async () => {
+    // Regression for cubic PR #1456 P2: previously a 409 with a missing or
+    // malformed affected_members array would set the stranded list to []
+    // and the blocker (which keyed off length > 0) would not render at all,
+    // leaving the actor with a closed pending state and no feedback.
+    const { suspendWorkspace, api } = await renderProductSettingsPage({ me: ownerMe });
+    await screen.findByTestId('idt-suspend-workspace-row');
+    suspendWorkspace.mockRejectedValue(
+      new api.ApiError('sole owner requires transfer', 409, {
+        code: 'sole_owner_requires_transfer',
+        payload: { code: 'sole_owner_requires_transfer' }
+      })
+    );
+
+    await act(async () => {
+      fireEvent.click(
+        within(screen.getByTestId('idt-suspend-workspace-row')).getByRole('button')
+      );
+    });
+    const modal = await screen.findByTestId('idt-danger-modal');
+    await act(async () => {
+      fireEvent.change(within(modal).getByTestId('idt-danger-modal-typed'), {
+        target: { value: 'SUSPEND' }
+      });
+    });
+    await act(async () => {
+      fireEvent.click(within(modal).getByTestId('idt-danger-modal-continue'));
+    });
+    const block = await screen.findByTestId('idt-suspend-workspace-sole-owner-block');
+    // Fallback copy must surface even with no affected-member list.
+    expect(block.textContent).toMatch(/only one owner/i);
+    expect(
+      within(block).getByRole('link', { name: /manage members/i }).getAttribute('href')
+    ).toBe('/app/tenant-a/workspace-a/workspaces');
+  });
+
   it('renders the sole-owner inline block with a link to manage members', async () => {
     const { suspendWorkspace, api } = await renderProductSettingsPage({ me: ownerMe });
     await screen.findByTestId('idt-suspend-workspace-row');

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -313,6 +313,8 @@ async function renderProductSettingsPage(options: {
   authConfig?: AuthConfigResponse;
   updateMe?: CurrentUserContext | Error;
   updateMeApiError?: { message: string; status: number };
+  workspaceStatus?: 'active' | 'suspended' | 'deleted';
+  workspaceSlug?: string;
 } = {}) {
   vi.resetModules();
   const me = options.me ?? loggedInWithWorkspace;
@@ -331,6 +333,16 @@ async function renderProductSettingsPage(options: {
 
   const api = await import('./api/client');
   const whoAmI = settingsWhoAmI(me);
+  // Workspace lifecycle status drives which Danger Zone rows render for owners
+  // (PR 3 of #1420). The fixture seeds the active_workspace snapshot so the
+  // component sees the same shape it would after PR 1 shipped the new fields.
+  if (whoAmI.active_workspace) {
+    whoAmI.active_workspace.workspace = {
+      ...whoAmI.active_workspace.workspace,
+      status: options.workspaceStatus ?? 'active',
+      slug: options.workspaceSlug ?? whoAmI.active_workspace.workspace.slug
+    };
+  }
   vi.spyOn(api.apiClient, 'getWhoAmI').mockResolvedValue(whoAmI);
   vi.spyOn(api.apiClient, 'listWorkspaceMembers').mockResolvedValue({
     items: whoAmI.active_workspace?.member ? [whoAmI.active_workspace.member] : []
@@ -345,17 +357,33 @@ async function renderProductSettingsPage(options: {
   } else {
     updateMe.mockResolvedValue({ me: options.updateMe ?? me });
   }
+  const suspendWorkspace = vi.spyOn(api.apiClient, 'suspendWorkspace');
+  const reactivateWorkspace = vi.spyOn(api.apiClient, 'reactivateWorkspace');
+  const deleteWorkspace = vi.spyOn(api.apiClient, 'deleteWorkspace');
+  const cancelWorkspaceDeletion = vi.spyOn(api.apiClient, 'cancelWorkspaceDeletion');
 
   const { ProductSettingsPage } = await import('./productShell');
   render(
     <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/settings']}>
       <Routes>
         <Route path="/app/:tenantID/:workspaceID/settings" element={<ProductSettingsPage />} />
+        <Route
+          path="/app/:tenantID/:workspaceID/workspaces"
+          element={<h2>Workspace members</h2>}
+        />
       </Routes>
     </MemoryRouter>
   );
 
-  return { primeMeCache, updateMe };
+  return {
+    primeMeCache,
+    updateMe,
+    api,
+    suspendWorkspace,
+    reactivateWorkspace,
+    deleteWorkspace,
+    cancelWorkspaceDeletion
+  };
 }
 
 async function renderProjectDetail(
@@ -4047,5 +4075,235 @@ describe('GitHub domain pages (#1382)', () => {
       resolvePending?.({ items: [] });
       await Promise.resolve();
     });
+  });
+});
+
+// Workspace Danger Zone — PR 3 of #1420.
+//
+// These cover the owner-only workspace lifecycle controls appended to the
+// existing Settings Danger Zone card: which rows show per role + lifecycle
+// state, the type-to-confirm gate on Suspend/Delete, the checkbox confirm
+// on the restorative Reactivate/Restore, and the inline sole-owner block
+// (with deep link to the member-management screen) when the backend
+// returns `409 sole_owner_requires_transfer`.
+describe('Workspace Danger Zone (#1420)', () => {
+  const ownerWorkspaceFixture = {
+    tenant_id: 'tenant-a',
+    workspace_id: 'workspace-a',
+    display_name: 'Workspace A',
+    slug: 'workspace-a',
+    created_at: '2026-05-16T10:00:00Z',
+    updated_at: '2026-05-16T10:00:00Z'
+  };
+  const ownerMe: CurrentUserContext = {
+    ...loggedInWithWorkspace,
+    role: 'owner',
+    workspace: ownerWorkspaceFixture
+  };
+
+  it('hides the workspace rows entirely for non-owner members', async () => {
+    await renderProductSettingsPage();
+    await screen.findByTestId('idt-suspend-account-row');
+    expect(screen.queryByTestId('idt-suspend-workspace-row')).toBeNull();
+    expect(screen.queryByTestId('idt-delete-workspace-row')).toBeNull();
+    expect(screen.queryByTestId('idt-reactivate-workspace-row')).toBeNull();
+    expect(screen.queryByTestId('idt-restore-workspace-row')).toBeNull();
+  });
+
+  it('shows Suspend + Delete workspace rows for owners on an active workspace', async () => {
+    await renderProductSettingsPage({ me: ownerMe });
+    await screen.findByTestId('idt-suspend-workspace-row');
+    expect(screen.getByTestId('idt-delete-workspace-row')).toBeTruthy();
+    expect(screen.queryByTestId('idt-reactivate-workspace-row')).toBeNull();
+    expect(screen.queryByTestId('idt-restore-workspace-row')).toBeNull();
+  });
+
+  it('swaps Suspend → Reactivate when the workspace is already suspended', async () => {
+    await renderProductSettingsPage({ me: ownerMe, workspaceStatus: 'suspended' });
+    await screen.findByTestId('idt-reactivate-workspace-row');
+    expect(screen.getByTestId('idt-delete-workspace-row')).toBeTruthy();
+    expect(screen.queryByTestId('idt-suspend-workspace-row')).toBeNull();
+  });
+
+  it('collapses to a single Restore row when the workspace is soft-deleted', async () => {
+    await renderProductSettingsPage({ me: ownerMe, workspaceStatus: 'deleted' });
+    await screen.findByTestId('idt-restore-workspace-row');
+    expect(screen.queryByTestId('idt-suspend-workspace-row')).toBeNull();
+    expect(screen.queryByTestId('idt-reactivate-workspace-row')).toBeNull();
+    expect(screen.queryByTestId('idt-delete-workspace-row')).toBeNull();
+  });
+
+  it('suspends the workspace after typing SUSPEND in the modal', async () => {
+    const { suspendWorkspace } = await renderProductSettingsPage({ me: ownerMe });
+    suspendWorkspace.mockResolvedValue({
+      workspace: { ...ownerWorkspaceFixture, status: 'suspended' },
+      status: 'suspended'
+    });
+    await screen.findByTestId('idt-suspend-workspace-row');
+
+    await act(async () => {
+      fireEvent.click(
+        within(screen.getByTestId('idt-suspend-workspace-row')).getByRole('button')
+      );
+    });
+    const modal = await screen.findByTestId('idt-danger-modal');
+    const continueBtn = within(modal).getByTestId('idt-danger-modal-continue');
+    // Gate stays armed until the user types the exact token.
+    expect(continueBtn).toBeDisabled();
+    await act(async () => {
+      fireEvent.change(within(modal).getByTestId('idt-danger-modal-typed'), {
+        target: { value: 'SUSPEND' }
+      });
+    });
+    expect(continueBtn).not.toBeDisabled();
+    await act(async () => {
+      fireEvent.click(continueBtn);
+    });
+    await waitFor(() =>
+      expect(suspendWorkspace).toHaveBeenCalledWith('workspace-a', expect.anything())
+    );
+    // Row swaps to Reactivate once the response lands.
+    await screen.findByTestId('idt-reactivate-workspace-row');
+  });
+
+  it('renders the sole-owner inline block with a link to manage members', async () => {
+    const { suspendWorkspace, api } = await renderProductSettingsPage({ me: ownerMe });
+    await screen.findByTestId('idt-suspend-workspace-row');
+    suspendWorkspace.mockRejectedValue(
+      new api.ApiError(
+        'workspace has additional active members but only one owner; transfer ownership before suspending or deleting',
+        409,
+        {
+          code: 'sole_owner_requires_transfer',
+          payload: {
+            code: 'sole_owner_requires_transfer',
+            affected_members: [
+              {
+                member_id: 'member-b',
+                user_id: 'user-b',
+                email: 'user-b@example.com',
+                role: 'admin'
+              }
+            ]
+          }
+        }
+      )
+    );
+
+    await act(async () => {
+      fireEvent.click(
+        within(screen.getByTestId('idt-suspend-workspace-row')).getByRole('button')
+      );
+    });
+    const modal = await screen.findByTestId('idt-danger-modal');
+    await act(async () => {
+      fireEvent.change(within(modal).getByTestId('idt-danger-modal-typed'), {
+        target: { value: 'SUSPEND' }
+      });
+    });
+    await act(async () => {
+      fireEvent.click(within(modal).getByTestId('idt-danger-modal-continue'));
+    });
+    const block = await screen.findByTestId('idt-suspend-workspace-sole-owner-block');
+    expect(block.textContent).toContain('user-b@example.com');
+    const manageLink = within(block).getByRole('link', { name: /manage members/i });
+    expect(manageLink.getAttribute('href')).toBe('/app/tenant-a/workspace-a/workspaces');
+  });
+
+  it('keeps Delete workspace gated until the slug is typed exactly', async () => {
+    const { deleteWorkspace } = await renderProductSettingsPage({ me: ownerMe });
+    deleteWorkspace.mockResolvedValue({
+      workspace: { ...ownerWorkspaceFixture, status: 'deleted', deleted_at: '2026-05-20T10:00:00Z' },
+      status: 'deleted',
+      hard_delete_after: '2026-06-19T10:00:00Z',
+      grace_period_hours: 720
+    });
+    await screen.findByTestId('idt-delete-workspace-row');
+
+    await act(async () => {
+      fireEvent.click(
+        within(screen.getByTestId('idt-delete-workspace-row')).getByRole('button')
+      );
+    });
+    const modal = await screen.findByTestId('idt-danger-modal');
+    const continueBtn = within(modal).getByTestId('idt-danger-modal-continue');
+    expect(continueBtn).toBeDisabled();
+    await act(async () => {
+      fireEvent.change(within(modal).getByTestId('idt-danger-modal-typed'), {
+        target: { value: 'wrong-slug' }
+      });
+    });
+    expect(continueBtn).toBeDisabled();
+    await act(async () => {
+      fireEvent.change(within(modal).getByTestId('idt-danger-modal-typed'), {
+        target: { value: 'workspace-a' }
+      });
+    });
+    expect(continueBtn).not.toBeDisabled();
+    await act(async () => {
+      fireEvent.click(continueBtn);
+    });
+    await waitFor(() =>
+      expect(deleteWorkspace).toHaveBeenCalledWith('workspace-a', expect.anything())
+    );
+    await screen.findByTestId('idt-restore-workspace-row');
+  });
+
+  it('reactivates a suspended workspace through the checkbox modal', async () => {
+    const { reactivateWorkspace } = await renderProductSettingsPage({
+      me: ownerMe,
+      workspaceStatus: 'suspended'
+    });
+    reactivateWorkspace.mockResolvedValue({
+      workspace: { ...ownerWorkspaceFixture, status: 'active' },
+      status: 'active'
+    });
+    await screen.findByTestId('idt-reactivate-workspace-row');
+
+    await act(async () => {
+      fireEvent.click(
+        within(screen.getByTestId('idt-reactivate-workspace-row')).getByRole('button')
+      );
+    });
+    const modal = await screen.findByTestId('idt-danger-modal');
+    await act(async () => {
+      fireEvent.click(within(modal).getByTestId('idt-danger-modal-checkbox'));
+    });
+    await act(async () => {
+      fireEvent.click(within(modal).getByTestId('idt-danger-modal-continue'));
+    });
+    await waitFor(() =>
+      expect(reactivateWorkspace).toHaveBeenCalledWith('workspace-a', expect.anything())
+    );
+    await screen.findByTestId('idt-suspend-workspace-row');
+  });
+
+  it('restores a soft-deleted workspace through the checkbox modal', async () => {
+    const { cancelWorkspaceDeletion } = await renderProductSettingsPage({
+      me: ownerMe,
+      workspaceStatus: 'deleted'
+    });
+    cancelWorkspaceDeletion.mockResolvedValue({
+      workspace: { ...ownerWorkspaceFixture, status: 'active' },
+      status: 'active'
+    });
+    await screen.findByTestId('idt-restore-workspace-row');
+
+    await act(async () => {
+      fireEvent.click(
+        within(screen.getByTestId('idt-restore-workspace-row')).getByRole('button')
+      );
+    });
+    const modal = await screen.findByTestId('idt-danger-modal');
+    await act(async () => {
+      fireEvent.click(within(modal).getByTestId('idt-danger-modal-checkbox'));
+    });
+    await act(async () => {
+      fireEvent.click(within(modal).getByTestId('idt-danger-modal-continue'));
+    });
+    await waitFor(() =>
+      expect(cancelWorkspaceDeletion).toHaveBeenCalledWith('workspace-a', expect.anything())
+    );
+    await screen.findByTestId('idt-suspend-workspace-row');
   });
 });

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -56,9 +56,12 @@ import {
   type ScanTriggerMode,
   type SessionListItem,
   type WhoAmIResponse,
+  type WorkspaceDeleteResponse,
   type WorkspaceMemberRecord,
   type WorkspaceMemberRole,
-  type WorkspaceMemberStatus
+  type WorkspaceMemberStatus,
+  type WorkspaceRecord,
+  type WorkspaceSoleOwnerAffectedMember
 } from './api/client';
 import { SessionsList } from './components/auth/SessionsList';
 import { PermissionPreviewModal } from './components/connector/PermissionPreviewModal';
@@ -16062,6 +16065,38 @@ function accountDeletionSignInPath(hardDeleteAfter?: string): string {
   return `/signin?${query.toString()}`;
 }
 
+// Extracts the affected-member array from a sole-owner 409 payload so the
+// destructive modal can render an inline block listing who would be stranded
+// and a deep link to the workspace member-management screen.
+function workspaceSoleOwnerMembersFromError(error: ApiError): WorkspaceSoleOwnerAffectedMember[] {
+  const payload = error.payload as { affected_members?: unknown } | undefined;
+  if (!Array.isArray(payload?.affected_members)) {
+    return [];
+  }
+  return payload.affected_members.filter(
+    (member): member is WorkspaceSoleOwnerAffectedMember => {
+      if (!member || typeof member !== 'object') {
+        return false;
+      }
+      const record = member as Partial<WorkspaceSoleOwnerAffectedMember>;
+      return (
+        typeof record.member_id === 'string' &&
+        record.member_id.trim() !== '' &&
+        typeof record.user_id === 'string' &&
+        typeof record.role === 'string'
+      );
+    }
+  );
+}
+
+function workspaceSoleOwnerMemberLabel(member: WorkspaceSoleOwnerAffectedMember): string {
+  const email = member.email?.trim();
+  if (email) {
+    return `${email} (${member.role})`;
+  }
+  return `${member.user_id || member.member_id} (${member.role})`;
+}
+
 export function ProductSettingsPage() {
   const params = useParams<ScopeRouteParams>();
   const scope = resolveScopeFromParams(params);
@@ -16085,6 +16120,25 @@ export function ProductSettingsPage() {
   const [deletePending, setDeletePending] = useState(false);
   const [deleteError, setDeleteError] = useState('');
   const [deleteSoleOwnerWorkspaces, setDeleteSoleOwnerWorkspaces] = useState<AccountDeletionWorkspace[]>([]);
+  const [workspaceLifecycle, setWorkspaceLifecycle] = useState<WorkspaceRecord | null>(null);
+  const [workspaceSuspendModalOpen, setWorkspaceSuspendModalOpen] = useState(false);
+  const [workspaceSuspendPending, setWorkspaceSuspendPending] = useState(false);
+  const [workspaceSuspendError, setWorkspaceSuspendError] = useState('');
+  const [workspaceSuspendStranded, setWorkspaceSuspendStranded] = useState<
+    WorkspaceSoleOwnerAffectedMember[]
+  >([]);
+  const [workspaceReactivateModalOpen, setWorkspaceReactivateModalOpen] = useState(false);
+  const [workspaceReactivatePending, setWorkspaceReactivatePending] = useState(false);
+  const [workspaceReactivateError, setWorkspaceReactivateError] = useState('');
+  const [workspaceDeleteModalOpen, setWorkspaceDeleteModalOpen] = useState(false);
+  const [workspaceDeletePending, setWorkspaceDeletePending] = useState(false);
+  const [workspaceDeleteError, setWorkspaceDeleteError] = useState('');
+  const [workspaceDeleteStranded, setWorkspaceDeleteStranded] = useState<
+    WorkspaceSoleOwnerAffectedMember[]
+  >([]);
+  const [workspaceRestoreModalOpen, setWorkspaceRestoreModalOpen] = useState(false);
+  const [workspaceRestorePending, setWorkspaceRestorePending] = useState(false);
+  const [workspaceRestoreError, setWorkspaceRestoreError] = useState('');
   const [exportPending, setExportPending] = useState(false);
   const [exportError, setExportError] = useState('');
   const [exportStatus, setExportStatus] = useState<
@@ -16177,6 +16231,15 @@ export function ProductSettingsPage() {
         setWhoAmI(whoAmIResponse);
         setMembers(memberResponse.items);
         setAuthConfig(authConfigResponse);
+        // Seed the workspace lifecycle banner + row state from whoAmI so the
+        // Danger Zone reflects the current status before any mutation lands.
+        const snapshotWorkspace =
+          whoAmIResponse.active_workspace?.workspace ??
+          whoAmIResponse.workspaces?.find(
+            (item) => item.workspace.workspace_id === scope.workspaceID
+          )?.workspace ??
+          null;
+        setWorkspaceLifecycle(snapshotWorkspace);
       } catch (err) {
         if (!mounted) {
           return;
@@ -16234,6 +16297,14 @@ export function ProductSettingsPage() {
     whoAmI?.workspaces?.find((item) => item.workspace.workspace_id === scope?.workspaceID)?.member;
   const activeRole = activeMember?.role ?? me?.role ?? 'viewer';
   const workspaceDisplayName = activeWorkspace?.display_name ?? scope?.workspaceID ?? 'Workspace';
+  // Prefer the mutated lifecycle copy (refreshed after suspend/delete/etc.)
+  // and fall back to whatever whoAmI seeded. Defaults to 'active' so a
+  // legacy backend that omits the field still renders the same rows it
+  // would have rendered before #1420 shipped.
+  const workspaceLifecycleStatus =
+    workspaceLifecycle?.status ?? activeWorkspace?.status ?? 'active';
+  const workspaceSlugValue = (workspaceLifecycle?.slug ?? activeWorkspace?.slug ?? '').trim();
+  const isWorkspaceOwner = activeRole === 'owner';
   const authProviders = authConfig?.auth.providers ?? [];
   const scopes = Array.isArray(whoAmI?.scopes) ? whoAmI.scopes : [];
   const workspacesPath = scope ? buildScopedPath(scope, 'workspaces') : '/app';
@@ -16479,6 +16550,158 @@ export function ProductSettingsPage() {
       }
     } finally {
       setDeletePending(false);
+    }
+  };
+
+  // ---------------------------------------------------------------
+  // Workspace lifecycle handlers (PR 3 of #1420).
+  //
+  // Every destructive transition first opens a ConfirmDestructiveModal so the
+  // owner has to consciously confirm (type-to-confirm for Suspend/Delete,
+  // checkbox for the restorative Reactivate/Restore). The button on the row
+  // itself never fires the API — that always happens from inside the modal —
+  // so an accidental click on the row only opens the dialog.
+  //
+  // Sole-owner 409 from the backend is rendered inline in the open modal
+  // (not a toast, not a navigation) so the owner can see who would be
+  // stranded, promote another owner, and retry without losing their place.
+  // The non-destructive `ApiError` branches fall through to errorMessage on
+  // the same modal.
+  const handleOpenWorkspaceSuspendModal = () => {
+    setWorkspaceSuspendError('');
+    setWorkspaceSuspendStranded([]);
+    setWorkspaceSuspendModalOpen(true);
+  };
+  const handleCancelWorkspaceSuspendModal = () => {
+    if (workspaceSuspendPending) return;
+    setWorkspaceSuspendModalOpen(false);
+    setWorkspaceSuspendError('');
+    setWorkspaceSuspendStranded([]);
+  };
+  const handleSuspendWorkspace = async () => {
+    if (workspaceSuspendPending || !scope) return;
+    setWorkspaceSuspendPending(true);
+    setWorkspaceSuspendError('');
+    setWorkspaceSuspendStranded([]);
+    try {
+      const response = await apiClient.suspendWorkspace(
+        scope.workspaceID,
+        buildProductAuthContext(scope)
+      );
+      setWorkspaceLifecycle(response.workspace);
+      setWorkspaceSuspendModalOpen(false);
+    } catch (err) {
+      if (
+        err instanceof ApiError &&
+        err.status === 409 &&
+        err.code === 'sole_owner_requires_transfer'
+      ) {
+        setWorkspaceSuspendStranded(workspaceSoleOwnerMembersFromError(err));
+      } else {
+        setWorkspaceSuspendError(
+          err instanceof Error ? err.message : 'Unable to suspend the workspace. Please retry.'
+        );
+      }
+    } finally {
+      setWorkspaceSuspendPending(false);
+    }
+  };
+
+  const handleOpenWorkspaceReactivateModal = () => {
+    setWorkspaceReactivateError('');
+    setWorkspaceReactivateModalOpen(true);
+  };
+  const handleCancelWorkspaceReactivateModal = () => {
+    if (workspaceReactivatePending) return;
+    setWorkspaceReactivateModalOpen(false);
+    setWorkspaceReactivateError('');
+  };
+  const handleReactivateWorkspace = async () => {
+    if (workspaceReactivatePending || !scope) return;
+    setWorkspaceReactivatePending(true);
+    setWorkspaceReactivateError('');
+    try {
+      const response = await apiClient.reactivateWorkspace(
+        scope.workspaceID,
+        buildProductAuthContext(scope)
+      );
+      setWorkspaceLifecycle(response.workspace);
+      setWorkspaceReactivateModalOpen(false);
+    } catch (err) {
+      setWorkspaceReactivateError(
+        err instanceof Error ? err.message : 'Unable to reactivate the workspace. Please retry.'
+      );
+    } finally {
+      setWorkspaceReactivatePending(false);
+    }
+  };
+
+  const handleOpenWorkspaceDeleteModal = () => {
+    setWorkspaceDeleteError('');
+    setWorkspaceDeleteStranded([]);
+    setWorkspaceDeleteModalOpen(true);
+  };
+  const handleCancelWorkspaceDeleteModal = () => {
+    if (workspaceDeletePending) return;
+    setWorkspaceDeleteModalOpen(false);
+    setWorkspaceDeleteError('');
+    setWorkspaceDeleteStranded([]);
+  };
+  const handleDeleteWorkspace = async () => {
+    if (workspaceDeletePending || !scope) return;
+    setWorkspaceDeletePending(true);
+    setWorkspaceDeleteError('');
+    setWorkspaceDeleteStranded([]);
+    try {
+      const response: WorkspaceDeleteResponse = await apiClient.deleteWorkspace(
+        scope.workspaceID,
+        buildProductAuthContext(scope)
+      );
+      setWorkspaceLifecycle(response.workspace);
+      setWorkspaceDeleteModalOpen(false);
+    } catch (err) {
+      if (
+        err instanceof ApiError &&
+        err.status === 409 &&
+        err.code === 'sole_owner_requires_transfer'
+      ) {
+        setWorkspaceDeleteStranded(workspaceSoleOwnerMembersFromError(err));
+      } else {
+        setWorkspaceDeleteError(
+          err instanceof Error ? err.message : 'Unable to delete the workspace. Please retry.'
+        );
+      }
+    } finally {
+      setWorkspaceDeletePending(false);
+    }
+  };
+
+  const handleOpenWorkspaceRestoreModal = () => {
+    setWorkspaceRestoreError('');
+    setWorkspaceRestoreModalOpen(true);
+  };
+  const handleCancelWorkspaceRestoreModal = () => {
+    if (workspaceRestorePending) return;
+    setWorkspaceRestoreModalOpen(false);
+    setWorkspaceRestoreError('');
+  };
+  const handleRestoreWorkspace = async () => {
+    if (workspaceRestorePending || !scope) return;
+    setWorkspaceRestorePending(true);
+    setWorkspaceRestoreError('');
+    try {
+      const response = await apiClient.cancelWorkspaceDeletion(
+        scope.workspaceID,
+        buildProductAuthContext(scope)
+      );
+      setWorkspaceLifecycle(response.workspace);
+      setWorkspaceRestoreModalOpen(false);
+    } catch (err) {
+      setWorkspaceRestoreError(
+        err instanceof Error ? err.message : 'Unable to restore the workspace. Please retry.'
+      );
+    } finally {
+      setWorkspaceRestorePending(false);
     }
   };
 
@@ -16828,6 +17051,48 @@ export function ProductSettingsPage() {
           testId="idt-delete-account-row"
           title="Delete account"
         />
+        {/* Owner-only workspace rows (PR 3 of #1420). Appended into the same */}
+        {/* DangerZone card on purpose: a second card with an identical title */}
+        {/* would feel like the page lost the plot, and the row titles already */}
+        {/* state the scope (Suspend workspace vs Suspend account). Non-owners */}
+        {/* render exactly the two account rows above, no layout change. */}
+        {isWorkspaceOwner && workspaceLifecycleStatus === 'active' ? (
+          <DangerZoneRow
+            actionLabel="Suspend workspace"
+            onAction={handleOpenWorkspaceSuspendModal}
+            pending={workspaceSuspendPending}
+            testId="idt-suspend-workspace-row"
+            title="Suspend workspace"
+          />
+        ) : null}
+        {isWorkspaceOwner && workspaceLifecycleStatus === 'suspended' ? (
+          <DangerZoneRow
+            actionLabel="Reactivate workspace"
+            onAction={handleOpenWorkspaceReactivateModal}
+            pending={workspaceReactivatePending}
+            testId="idt-reactivate-workspace-row"
+            title="Reactivate workspace"
+          />
+        ) : null}
+        {isWorkspaceOwner && workspaceLifecycleStatus !== 'deleted' ? (
+          <DangerZoneRow
+            actionLabel="Delete workspace"
+            disabled={!workspaceSlugValue}
+            onAction={handleOpenWorkspaceDeleteModal}
+            pending={workspaceDeletePending}
+            testId="idt-delete-workspace-row"
+            title="Delete workspace"
+          />
+        ) : null}
+        {isWorkspaceOwner && workspaceLifecycleStatus === 'deleted' ? (
+          <DangerZoneRow
+            actionLabel="Restore workspace"
+            onAction={handleOpenWorkspaceRestoreModal}
+            pending={workspaceRestorePending}
+            testId="idt-restore-workspace-row"
+            title="Restore workspace"
+          />
+        ) : null}
       </DangerZone>
 
       <ConfirmDestructiveModal
@@ -16933,6 +17198,139 @@ export function ProductSettingsPage() {
         open={deleteModalOpen}
         pending={deletePending}
         title="Delete account"
+      />
+
+      {/* --- Workspace lifecycle confirmation modals (PR 3 of #1420). --- */}
+      {/* Body copy mirrors the account-side patterns above: two short      */}
+      {/* sentences, monospaced token chip for type-to-confirm, ESC + cancel*/}
+      {/* affordances. Sole-owner 409 renders inline so the owner can fix   */}
+      {/* the stranding and retry without losing the modal context.        */}
+      <ConfirmDestructiveModal
+        body={
+          <>
+            <p>Connectors, scans, and webhooks will pause.</p>
+            <p>Member access and stored data remain intact.</p>
+            {workspaceSuspendStranded.length > 0 ? (
+              <div
+                className="idt-danger-modal-blocker"
+                data-testid="idt-suspend-workspace-sole-owner-block"
+                role="alert"
+              >
+                <p>
+                  Promote another owner before suspending so these members are not
+                  stranded.
+                </p>
+                <ul>
+                  {workspaceSuspendStranded.map((member) => (
+                    <li key={member.member_id}>{workspaceSoleOwnerMemberLabel(member)}</li>
+                  ))}
+                </ul>
+                <Link to={workspacesPath}>Manage members</Link>
+              </div>
+            ) : null}
+          </>
+        }
+        confirmation={{
+          kind: 'type-to-confirm',
+          expectedValue: 'SUSPEND',
+          inputLabel: (
+            <>
+              Type <em className="idt-danger-confirm-value">SUSPEND</em> to continue
+            </>
+          )
+        }}
+        continueLabel="Suspend workspace"
+        errorMessage={workspaceSuspendError || undefined}
+        onCancel={handleCancelWorkspaceSuspendModal}
+        onConfirm={handleSuspendWorkspace}
+        open={workspaceSuspendModalOpen}
+        pending={workspaceSuspendPending}
+        title="Suspend workspace"
+      />
+
+      <ConfirmDestructiveModal
+        body={
+          <>
+            <p>Connectors, scans, and webhooks will resume.</p>
+          </>
+        }
+        confirmation={{
+          kind: 'checkbox',
+          label: 'Resume connectors, scans, and webhooks for this workspace.'
+        }}
+        continueLabel="Reactivate workspace"
+        errorMessage={workspaceReactivateError || undefined}
+        onCancel={handleCancelWorkspaceReactivateModal}
+        onConfirm={handleReactivateWorkspace}
+        open={workspaceReactivateModalOpen}
+        pending={workspaceReactivatePending}
+        title="Reactivate workspace"
+      />
+
+      <ConfirmDestructiveModal
+        body={
+          <>
+            <p>This starts a 30-day recovery window and disables the workspace.</p>
+            <p>After the window, the workspace and all its data are permanently purged.</p>
+            {workspaceDeleteStranded.length > 0 ? (
+              <div
+                className="idt-danger-modal-blocker"
+                data-testid="idt-delete-workspace-sole-owner-block"
+                role="alert"
+              >
+                <p>
+                  Promote another owner before deleting so these members are not
+                  stranded.
+                </p>
+                <ul>
+                  {workspaceDeleteStranded.map((member) => (
+                    <li key={member.member_id}>{workspaceSoleOwnerMemberLabel(member)}</li>
+                  ))}
+                </ul>
+                <Link to={workspacesPath}>Manage members</Link>
+              </div>
+            ) : null}
+          </>
+        }
+        confirmation={{
+          kind: 'type-to-confirm',
+          expectedValue: workspaceSlugValue,
+          inputLabel: 'Confirm workspace slug',
+          helpText: workspaceSlugValue ? (
+            <>
+              Enter <em className="idt-danger-confirm-value">{workspaceSlugValue}</em>{' '}
+              exactly.
+            </>
+          ) : (
+            'Workspace slug is unavailable; reload the page before retrying.'
+          )
+        }}
+        continueLabel="Delete workspace"
+        errorMessage={workspaceDeleteError || undefined}
+        onCancel={handleCancelWorkspaceDeleteModal}
+        onConfirm={handleDeleteWorkspace}
+        open={workspaceDeleteModalOpen}
+        pending={workspaceDeletePending}
+        title="Delete workspace"
+      />
+
+      <ConfirmDestructiveModal
+        body={
+          <>
+            <p>Restores the workspace and cancels the scheduled deletion.</p>
+          </>
+        }
+        confirmation={{
+          kind: 'checkbox',
+          label: 'Cancel the scheduled deletion and restore this workspace.'
+        }}
+        continueLabel="Restore workspace"
+        errorMessage={workspaceRestoreError || undefined}
+        onCancel={handleCancelWorkspaceRestoreModal}
+        onConfirm={handleRestoreWorkspace}
+        open={workspaceRestoreModalOpen}
+        pending={workspaceRestorePending}
+        title="Restore workspace"
       />
     </section>
   );

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -16127,6 +16127,11 @@ export function ProductSettingsPage() {
   const [workspaceSuspendStranded, setWorkspaceSuspendStranded] = useState<
     WorkspaceSoleOwnerAffectedMember[]
   >([]);
+  // Sticky 409 flag (cubic PR #1456 P2): a malformed or empty `affected_members`
+  // payload would otherwise leave `workspaceSuspendStranded` empty and silently
+  // hide the blocker. Track the sole-owner 409 explicitly so the inline block
+  // still renders with fallback copy + the Manage-members deep link.
+  const [workspaceSuspendSoleOwner, setWorkspaceSuspendSoleOwner] = useState(false);
   const [workspaceReactivateModalOpen, setWorkspaceReactivateModalOpen] = useState(false);
   const [workspaceReactivatePending, setWorkspaceReactivatePending] = useState(false);
   const [workspaceReactivateError, setWorkspaceReactivateError] = useState('');
@@ -16136,6 +16141,8 @@ export function ProductSettingsPage() {
   const [workspaceDeleteStranded, setWorkspaceDeleteStranded] = useState<
     WorkspaceSoleOwnerAffectedMember[]
   >([]);
+  // Mirrors `workspaceSuspendSoleOwner` for the Delete flow (cubic PR #1456 P2).
+  const [workspaceDeleteSoleOwner, setWorkspaceDeleteSoleOwner] = useState(false);
   const [workspaceRestoreModalOpen, setWorkspaceRestoreModalOpen] = useState(false);
   const [workspaceRestorePending, setWorkspaceRestorePending] = useState(false);
   const [workspaceRestoreError, setWorkspaceRestoreError] = useState('');
@@ -16570,6 +16577,7 @@ export function ProductSettingsPage() {
   const handleOpenWorkspaceSuspendModal = () => {
     setWorkspaceSuspendError('');
     setWorkspaceSuspendStranded([]);
+    setWorkspaceSuspendSoleOwner(false);
     setWorkspaceSuspendModalOpen(true);
   };
   const handleCancelWorkspaceSuspendModal = () => {
@@ -16577,12 +16585,14 @@ export function ProductSettingsPage() {
     setWorkspaceSuspendModalOpen(false);
     setWorkspaceSuspendError('');
     setWorkspaceSuspendStranded([]);
+    setWorkspaceSuspendSoleOwner(false);
   };
   const handleSuspendWorkspace = async () => {
     if (workspaceSuspendPending || !scope) return;
     setWorkspaceSuspendPending(true);
     setWorkspaceSuspendError('');
     setWorkspaceSuspendStranded([]);
+    setWorkspaceSuspendSoleOwner(false);
     try {
       const response = await apiClient.suspendWorkspace(
         scope.workspaceID,
@@ -16596,6 +16606,11 @@ export function ProductSettingsPage() {
         err.status === 409 &&
         err.code === 'sole_owner_requires_transfer'
       ) {
+        // Latch the 409 flag even when affected_members fails to parse
+        // (cubic PR #1456 P2) so the inline blocker still renders with a
+        // fallback message — otherwise the modal would close the pending
+        // state with no visible error and the actor would be left guessing.
+        setWorkspaceSuspendSoleOwner(true);
         setWorkspaceSuspendStranded(workspaceSoleOwnerMembersFromError(err));
       } else {
         setWorkspaceSuspendError(
@@ -16639,6 +16654,7 @@ export function ProductSettingsPage() {
   const handleOpenWorkspaceDeleteModal = () => {
     setWorkspaceDeleteError('');
     setWorkspaceDeleteStranded([]);
+    setWorkspaceDeleteSoleOwner(false);
     setWorkspaceDeleteModalOpen(true);
   };
   const handleCancelWorkspaceDeleteModal = () => {
@@ -16646,12 +16662,14 @@ export function ProductSettingsPage() {
     setWorkspaceDeleteModalOpen(false);
     setWorkspaceDeleteError('');
     setWorkspaceDeleteStranded([]);
+    setWorkspaceDeleteSoleOwner(false);
   };
   const handleDeleteWorkspace = async () => {
     if (workspaceDeletePending || !scope) return;
     setWorkspaceDeletePending(true);
     setWorkspaceDeleteError('');
     setWorkspaceDeleteStranded([]);
+    setWorkspaceDeleteSoleOwner(false);
     try {
       const response: WorkspaceDeleteResponse = await apiClient.deleteWorkspace(
         scope.workspaceID,
@@ -16665,6 +16683,9 @@ export function ProductSettingsPage() {
         err.status === 409 &&
         err.code === 'sole_owner_requires_transfer'
       ) {
+        // See suspend handler — keep the blocker visible even with an empty
+        // or malformed affected_members payload (cubic PR #1456 P2).
+        setWorkspaceDeleteSoleOwner(true);
         setWorkspaceDeleteStranded(workspaceSoleOwnerMembersFromError(err));
       } else {
         setWorkspaceDeleteError(
@@ -17210,21 +17231,35 @@ export function ProductSettingsPage() {
           <>
             <p>Connectors, scans, and webhooks will pause.</p>
             <p>Member access and stored data remain intact.</p>
-            {workspaceSuspendStranded.length > 0 ? (
+            {workspaceSuspendSoleOwner ? (
               <div
                 className="idt-danger-modal-blocker"
                 data-testid="idt-suspend-workspace-sole-owner-block"
                 role="alert"
               >
-                <p>
-                  Promote another owner before suspending so these members are not
-                  stranded.
-                </p>
-                <ul>
-                  {workspaceSuspendStranded.map((member) => (
-                    <li key={member.member_id}>{workspaceSoleOwnerMemberLabel(member)}</li>
-                  ))}
-                </ul>
+                {workspaceSuspendStranded.length > 0 ? (
+                  <>
+                    <p>
+                      Promote another owner before suspending so these members are not
+                      stranded.
+                    </p>
+                    <ul>
+                      {workspaceSuspendStranded.map((member) => (
+                        <li key={member.member_id}>
+                          {workspaceSoleOwnerMemberLabel(member)}
+                        </li>
+                      ))}
+                    </ul>
+                  </>
+                ) : (
+                  // Backend confirmed sole-owner stranding but the affected-member
+                  // list didn't parse — still surface the blocker so the actor
+                  // knows what to do (cubic PR #1456 P2).
+                  <p>
+                    This workspace has only one owner. Promote another owner before
+                    suspending so other members are not stranded.
+                  </p>
+                )}
                 <Link to={workspacesPath}>Manage members</Link>
               </div>
             ) : null}
@@ -17272,21 +17307,32 @@ export function ProductSettingsPage() {
           <>
             <p>This starts a 30-day recovery window and disables the workspace.</p>
             <p>After the window, the workspace and all its data are permanently purged.</p>
-            {workspaceDeleteStranded.length > 0 ? (
+            {workspaceDeleteSoleOwner ? (
               <div
                 className="idt-danger-modal-blocker"
                 data-testid="idt-delete-workspace-sole-owner-block"
                 role="alert"
               >
-                <p>
-                  Promote another owner before deleting so these members are not
-                  stranded.
-                </p>
-                <ul>
-                  {workspaceDeleteStranded.map((member) => (
-                    <li key={member.member_id}>{workspaceSoleOwnerMemberLabel(member)}</li>
-                  ))}
-                </ul>
+                {workspaceDeleteStranded.length > 0 ? (
+                  <>
+                    <p>
+                      Promote another owner before deleting so these members are not
+                      stranded.
+                    </p>
+                    <ul>
+                      {workspaceDeleteStranded.map((member) => (
+                        <li key={member.member_id}>
+                          {workspaceSoleOwnerMemberLabel(member)}
+                        </li>
+                      ))}
+                    </ul>
+                  </>
+                ) : (
+                  <p>
+                    This workspace has only one owner. Promote another owner before
+                    deleting so other members are not stranded.
+                  </p>
+                )}
                 <Link to={workspacesPath}>Manage members</Link>
               </div>
             ) : null}


### PR DESCRIPTION
## Summary

Final PR in the #1420 series. Appends owner-only **Suspend / Reactivate / Delete / Restore** rows into the existing user-account Danger Zone card on `ProductSettingsPage`, calling the four workspace lifecycle endpoints PR 1 shipped (#1445) and the soft-delete state that PR 2 then sweeps (#1450).

**Design decisions worth flagging:**

- **One Danger Zone card, not two.** Workspace rows are appended into the same `<DangerZone>` that hosts *Suspend account* / *Delete account*. A second card with an identical heading would be confusing, and the row titles already carry the scope (*Suspend workspace* vs *Suspend account*).
- **State-driven row swaps.** Rows render against `tenancy_workspaces.status` from `whoAmI`:
  - `active` → *Suspend workspace* + *Delete workspace*
  - `suspended` → *Reactivate workspace* + *Delete workspace*
  - `deleted` → *Restore workspace* only
- **Non-owners see no change.** The whole workspace-row block is wrapped in `activeRole === 'owner' && (…)` so non-owners render exactly the two account rows already in production. No disabled-button teasing.
- **Tightened copy.** Each modal body fits in ≤2 short sentences, mirroring the existing account-side vocabulary (ESC chip, monospaced token, type-to-confirm). See the CHANGELOG entry for the full wording.
- **Sole-owner inline.** `409 sole_owner_requires_transfer` keeps the destructive modal open and renders the affected-member list + a deep link to the workspace member-management screen, so an owner can promote another owner and retry without losing the flow.
- **Authoritative gate is the backend.** Frontend role gate is convenience; `policyActionTenancyOwner` (PR 1) still 403s any non-owner request, and the sole-owner stranding guard still 409s irrespective of UI state.

**Footprint:** 4 files, +739 / −2.

- `web/src/api/client.ts` — 4 typed endpoint wrappers + `WorkspaceLifecycleStatus`, response shapes, `WorkspaceSoleOwnerAffectedMember`.
- `web/src/productShell.tsx` — workspace lifecycle state hooks, hydration from `whoAmI`, 4 row instances, 4 `<ConfirmDestructiveModal>` instances.
- `web/src/productShell.test.tsx` — 9 new cases covering role gate, state swaps, type-to-confirm, checkbox confirm, sole-owner inline block + member-management link.
- `CHANGELOG.md` — Unreleased entry above PR 2's.

## Test plan

- [x] `make ci` (fmt-check, vet, Go tests + coverage, web tests + coverage, build, prerender) — passes locally
- [x] `npx vitest run productShell.test.tsx` — 109/109
- [x] Full web suite — 340/340
- [x] `npm run build --prefix web` — clean, 39 prerendered routes
- [ ] Visual smoke test on the running app: owner sees 4 rows, role-swap toggles correctly across `active` / `suspended` / `deleted`
- [ ] Sole-owner 409 path verified end-to-end in a workspace with a single owner + extra members

## AI disclosure

This change was implemented with Claude (Anthropic) as an AI-assisted contribution. All code, copy, and tests were reviewed and committed by the human author. See \`CONTRIBUTING.md\`.

Closes #1420.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds owner-only workspace lifecycle controls (Suspend, Reactivate, Delete, Restore) to the Settings Danger Zone. Rows swap with workspace status and use clear confirmations, with inline guidance for sole‑owner cases that stays visible even when the backend omits details.

- **New Features**
  - Appends workspace rows to the same Danger Zone; non-owners see no change.
  - Status-driven actions from `whoAmI` (`active`: Suspend + Delete, `suspended`: Reactivate + Delete, `deleted`: Restore).
  - Reuses confirmation modals: type-to-confirm "SUSPEND" and workspace slug; checkboxes for Reactivate/Restore.
  - Adds typed `apiClient` wrappers: `suspendWorkspace`, `reactivateWorkspace`, `deleteWorkspace`, `cancelWorkspaceDeletion`.

- **Bug Fixes**
  - Sole-owner 409 now shows a persistent inline blocker even when `affected_members` is missing/malformed, with a link to the workspace members screen.
  - Disables Delete until the workspace slug is available and defaults status to `active` if absent, ensuring consistent rendering with legacy `whoAmI` responses.

<sup>Written for commit a0a2a8adc173d92fe70562dc046893d92f452c1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

