### PR TITLE
fix(repo): pin repo scan DNS resolution

### DIFF
--- a/docs/repo-exposure.md
+++ b/docs/repo-exposure.md
@@ -597,6 +597,10 @@ the scan as skipped instead of queueing duplicate work.
   - comma-separated list of allowed target patterns
   - supports prefix wildcard with `*` (example: `trusted-org/*`)
   - set `*` only if you intentionally want open target scope
+- Direct remote scans accept GitHub `owner/repo` shorthand and HTTPS URLs only.
+  SSH/SCP-style remotes are rejected because the scanner pins validated HTTPS
+  DNS answers into Git before network access and cannot apply the same guard to
+  an external SSH subprocess.
 - Optional worker scheduling:
   - `IDENTRAIL_WORKER_REPO_SCAN_ENABLED` (`false` by default)
   - `IDENTRAIL_WORKER_REPO_SCAN_RUN_NOW` (`false` by default)

--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -37,6 +37,16 @@ const (
 var hunkHeaderPattern = regexp.MustCompile(`@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@`)
 var fullHexRevisionPattern = regexp.MustCompile(`(?i)^[0-9a-f]{40}$`)
 var repositorySharedAddressRange = mustParseCIDR("100.64.0.0/10")
+var gitProxyEnvOverrides = []string{
+	"HTTPS_PROXY=",
+	"https_proxy=",
+	"HTTP_PROXY=",
+	"http_proxy=",
+	"ALL_PROXY=",
+	"all_proxy=",
+	"NO_PROXY=*",
+	"no_proxy=*",
+}
 var repositoryHostLookupIPs = func(ctx context.Context, host string) ([]net.IP, error) {
 	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
 	if err != nil {
@@ -581,6 +591,7 @@ func (s *Scanner) cloneCommandRunner(ctx context.Context, workdir string, cloneU
 		"IDENTRAIL_GIT_USERNAME=" + credential.Username,
 		"IDENTRAIL_GIT_PASSWORD=" + credential.Password,
 	}
+	env = appendGitProxyEnvOverrides(env)
 	runner := func(ctx context.Context, name string, args ...string) ([]byte, error) {
 		output, runErr := s.runEnv(ctx, env, name, args...)
 		if runErr != nil {
@@ -607,8 +618,8 @@ func pinGitHTTPSCommandArgs(name string, args []string, pin gitHTTPSResolvePin) 
 	if strings.TrimSpace(name) != defaultRepositoryCommand || !pin.valid() || !gitCommandMayResolveRemote(args) {
 		return args
 	}
-	pinned := make([]string, 0, len(args)+2)
-	pinned = append(pinned, "-c", pin.gitConfigValue())
+	pinned := make([]string, 0, len(args)+4)
+	pinned = append(pinned, "-c", pin.gitConfigValue(), "-c", "http.proxy=")
 	pinned = append(pinned, args...)
 	return pinned
 }
@@ -1742,6 +1753,7 @@ func severityRank(severity domain.FindingSeverity) int {
 
 func defaultCommandRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
 	cmd := newRepositoryCommand(ctx, name, args...)
+	cmd.Env = appendGitProxyEnvOverrides(os.Environ())
 	output, err := cmd.CombinedOutput()
 	if err != nil && ctx.Err() != nil {
 		return output, ctx.Err()
@@ -1757,6 +1769,13 @@ func defaultEnvCommandRunner(ctx context.Context, env []string, name string, arg
 		return output, ctx.Err()
 	}
 	return output, err
+}
+
+func appendGitProxyEnvOverrides(env []string) []string {
+	merged := make([]string, 0, len(env)+len(gitProxyEnvOverrides))
+	merged = append(merged, env...)
+	merged = append(merged, gitProxyEnvOverrides...)
+	return merged
 }
 
 func sanitizeError(err error, secrets ...string) error {

--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -633,8 +633,8 @@ func pinGitHTTPSCommandArgs(name string, args []string, pin gitHTTPSResolvePin) 
 	if strings.TrimSpace(name) != defaultRepositoryCommand || !pin.valid() || !gitCommandMayResolveRemote(args) {
 		return args
 	}
-	pinned := make([]string, 0, len(args)+4)
-	pinned = append(pinned, "-c", pin.gitConfigValue(), "-c", "http.proxy=")
+	pinned := make([]string, 0, len(args)+6)
+	pinned = append(pinned, "-c", pin.gitConfigValue(), "-c", "http.proxy=", "-c", "remote.origin.proxy=")
 	pinned = append(pinned, args...)
 	return pinned
 }

--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -394,7 +394,7 @@ func (s *Scanner) cloneRemoteRepository(ctx context.Context, workdir string, clo
 }
 
 func (s *Scanner) cloneRemoteRepositoryWithOptions(ctx context.Context, workdir string, cloneURL string, repoPath string, options ScanOptions) error {
-	runner, cleanup, err := s.cloneCommandRunner(workdir, cloneURL)
+	runner, cleanup, err := s.cloneCommandRunner(ctx, workdir, cloneURL)
 	if err != nil {
 		return err
 	}
@@ -531,13 +531,41 @@ func appendBoundedFetchDepthArgs(args []string, depth int) []string {
 	return append(args, "--depth", strconv.Itoa(depth))
 }
 
-func (s *Scanner) cloneCommandRunner(workdir string, cloneURL string) (CommandRunner, func(), error) {
+type gitHTTPSResolvePin struct {
+	Host string
+	Port string
+	IP   net.IP
+}
+
+func (p gitHTTPSResolvePin) valid() bool {
+	return p.Host != "" && p.Port != "" && p.IP != nil
+}
+
+func (p gitHTTPSResolvePin) gitConfigValue() string {
+	return "http.curloptResolve=" + p.Host + ":" + p.Port + ":" + curlResolveIPAddress(p.IP)
+}
+
+func curlResolveIPAddress(ip net.IP) string {
+	if ip == nil {
+		return ""
+	}
+	if ipv4 := ip.To4(); ipv4 != nil {
+		return ipv4.String()
+	}
+	return "[" + ip.String() + "]"
+}
+
+func (s *Scanner) cloneCommandRunner(ctx context.Context, workdir string, cloneURL string) (CommandRunner, func(), error) {
+	resolvePin, err := gitHTTPSResolvePinForCloneURL(ctx, cloneURL)
+	if err != nil {
+		return nil, nil, err
+	}
 	credential, useCredential, err := s.credentialForCloneURL(cloneURL)
 	if err != nil {
 		return nil, nil, err
 	}
 	if !useCredential {
-		return s.run, func() {}, nil
+		return withGitHTTPSResolvePin(s.run, resolvePin), func() {}, nil
 	}
 	if s.runEnv == nil {
 		s.runEnv = defaultEnvCommandRunner
@@ -553,7 +581,7 @@ func (s *Scanner) cloneCommandRunner(workdir string, cloneURL string) (CommandRu
 		"IDENTRAIL_GIT_USERNAME=" + credential.Username,
 		"IDENTRAIL_GIT_PASSWORD=" + credential.Password,
 	}
-	return func(ctx context.Context, name string, args ...string) ([]byte, error) {
+	runner := func(ctx context.Context, name string, args ...string) ([]byte, error) {
 		output, runErr := s.runEnv(ctx, env, name, args...)
 		if runErr != nil {
 			if errors.Is(runErr, context.Canceled) || errors.Is(runErr, context.DeadlineExceeded) {
@@ -562,7 +590,37 @@ func (s *Scanner) cloneCommandRunner(workdir string, cloneURL string) (CommandRu
 			return output, sanitizeError(runErr, credential.Password)
 		}
 		return output, nil
-	}, cleanup, nil
+	}
+	return withGitHTTPSResolvePin(runner, resolvePin), cleanup, nil
+}
+
+func withGitHTTPSResolvePin(runner CommandRunner, pin gitHTTPSResolvePin) CommandRunner {
+	if runner == nil || !pin.valid() {
+		return runner
+	}
+	return func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		return runner(ctx, name, pinGitHTTPSCommandArgs(name, args, pin)...)
+	}
+}
+
+func pinGitHTTPSCommandArgs(name string, args []string, pin gitHTTPSResolvePin) []string {
+	if strings.TrimSpace(name) != defaultRepositoryCommand || !pin.valid() || !gitCommandMayResolveRemote(args) {
+		return args
+	}
+	pinned := make([]string, 0, len(args)+2)
+	pinned = append(pinned, "-c", pin.gitConfigValue())
+	pinned = append(pinned, args...)
+	return pinned
+}
+
+func gitCommandMayResolveRemote(args []string) bool {
+	for _, arg := range args {
+		switch arg {
+		case "ls-remote", "fetch":
+			return true
+		}
+	}
+	return false
 }
 
 func parseRemoteRepositoryRefs(output []byte) ([]remoteRepositoryRef, string) {
@@ -1390,13 +1448,16 @@ func validateCloneURL(cloneURL string) error {
 
 	lower := strings.ToLower(trimmed)
 	if strings.HasPrefix(lower, "http://") {
-		return fmt.Errorf("insecure repository url scheme http is not allowed; use https or ssh")
+		return fmt.Errorf("insecure repository url scheme http is not allowed; use https")
 	}
 	if !strings.Contains(lower, "://") {
 		if host, ok := parseGitSCPTargetHost(trimmed); ok {
-			return validateRepositoryHost(host)
+			if err := validateRepositoryHost(host); err != nil {
+				return err
+			}
+			return fmt.Errorf("remote ssh repository targets are not supported; use https")
 		}
-		return nil
+		return fmt.Errorf("unsupported repository target; use owner/repo shorthand or an https URL")
 	}
 
 	parsed, err := url.Parse(trimmed)
@@ -1418,7 +1479,10 @@ func validateCloneURL(cloneURL string) error {
 				return fmt.Errorf("repository target must not include credentials in URL userinfo")
 			}
 		}
-		return validateRepositoryHost(parsed.Hostname())
+		if err := validateRepositoryHost(parsed.Hostname()); err != nil {
+			return err
+		}
+		return fmt.Errorf("remote ssh repository targets are not supported; use https")
 	default:
 		return fmt.Errorf("unsupported repository url scheme %q", parsed.Scheme)
 	}
@@ -1475,13 +1539,18 @@ func parseGitSCPTargetHost(target string) (string, bool) {
 }
 
 func validateRepositoryHost(host string) error {
+	_, _, err := resolveAllowedRepositoryHost(context.Background(), host)
+	return err
+}
+
+func resolveAllowedRepositoryHost(ctx context.Context, host string) (string, []net.IP, error) {
 	normalizedHost := strings.TrimSpace(host)
 	if normalizedHost == "" {
-		return fmt.Errorf("repository target host is required")
+		return "", nil, fmt.Errorf("repository target host is required")
 	}
 	lowerHost := strings.TrimSuffix(strings.ToLower(normalizedHost), ".")
 	if lowerHost == "localhost" || strings.HasSuffix(lowerHost, ".localhost") {
-		return fmt.Errorf("repository target host %q is not allowed", normalizedHost)
+		return "", nil, fmt.Errorf("repository target host %q is not allowed", normalizedHost)
 	}
 	ipCandidate := lowerHost
 	if zoneIndex := strings.Index(ipCandidate, "%"); zoneIndex != -1 {
@@ -1493,24 +1562,50 @@ func validateRepositoryHost(host string) error {
 	}
 	if ip != nil {
 		if isBlockedRepositoryIP(ip) {
-			return fmt.Errorf("repository target host %q is not allowed", normalizedHost)
+			return "", nil, fmt.Errorf("repository target host %q is not allowed", normalizedHost)
 		}
-		return nil
+		return lowerHost, []net.IP{ip}, nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	lookupCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
-	resolvedIPs, err := repositoryHostLookupIPs(ctx, lowerHost)
+	resolvedIPs, err := repositoryHostLookupIPs(lookupCtx, lowerHost)
 	if err != nil {
-		return fmt.Errorf("repository target host %q could not be resolved: %w", normalizedHost, err)
+		return "", nil, fmt.Errorf("repository target host %q could not be resolved: %w", normalizedHost, err)
+	}
+	if len(resolvedIPs) == 0 {
+		return "", nil, fmt.Errorf("repository target host %q could not be resolved", normalizedHost)
 	}
 	for _, resolvedIP := range resolvedIPs {
 		if isBlockedRepositoryIP(resolvedIP) {
-			return fmt.Errorf("repository target host %q is not allowed", normalizedHost)
+			return "", nil, fmt.Errorf("repository target host %q is not allowed", normalizedHost)
 		}
 	}
-	return nil
+	return lowerHost, resolvedIPs, nil
+}
+
+func gitHTTPSResolvePinForCloneURL(ctx context.Context, cloneURL string) (gitHTTPSResolvePin, error) {
+	parsed, err := url.Parse(strings.TrimSpace(cloneURL))
+	if err != nil || parsed == nil || !strings.EqualFold(parsed.Scheme, "https") {
+		return gitHTTPSResolvePin{}, nil
+	}
+	host := parsed.Hostname()
+	if parseRepositoryHostIP(host) != nil {
+		return gitHTTPSResolvePin{}, validateRepositoryHost(host)
+	}
+	normalizedHost, resolvedIPs, err := resolveAllowedRepositoryHost(ctx, host)
+	if err != nil {
+		return gitHTTPSResolvePin{}, err
+	}
+	port := strings.TrimSpace(parsed.Port())
+	if port == "" {
+		port = "443"
+	}
+	return gitHTTPSResolvePin{Host: normalizedHost, Port: port, IP: resolvedIPs[0]}, nil
 }
 
 func isBlockedRepositoryIP(ip net.IP) bool {
@@ -1524,6 +1619,18 @@ func isBlockedRepositoryIP(ip net.IP) bool {
 		ip.IsMulticast() ||
 		ip.IsUnspecified() ||
 		repositorySharedAddressRange.Contains(ip)
+}
+
+func parseRepositoryHostIP(host string) net.IP {
+	ipCandidate := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	if zoneIndex := strings.Index(ipCandidate, "%"); zoneIndex != -1 {
+		ipCandidate = ipCandidate[:zoneIndex]
+	}
+	ip := net.ParseIP(ipCandidate)
+	if ip != nil {
+		return ip
+	}
+	return parseLegacyIPv4Host(ipCandidate)
 }
 
 func parseLegacyIPv4Host(host string) net.IP {

--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -92,6 +92,7 @@ type Option func(*Scanner)
 type Scanner struct {
 	run             CommandRunner
 	runEnv          EnvCommandRunner
+	runIsDefault    bool
 	now             func() time.Time
 	historyLimit    int
 	maxFindings     int
@@ -124,12 +125,14 @@ type ScanResult struct {
 
 // NewScanner builds a repo exposure scanner with secure defaults.
 func NewScanner(runner CommandRunner, options ...Option) *Scanner {
+	runIsDefault := runner == nil
 	if runner == nil {
 		runner = defaultCommandRunner
 	}
 	s := &Scanner{
 		run:          runner,
 		runEnv:       defaultEnvCommandRunner,
+		runIsDefault: runIsDefault,
 		now:          time.Now,
 		historyLimit: defaultHistoryLimit,
 		maxFindings:  defaultMaxFindings,
@@ -597,7 +600,17 @@ func (s *Scanner) cloneCommandRunner(ctx context.Context, workdir string, cloneU
 		return nil, nil, err
 	}
 	if !useCredential {
-		return withGitHTTPSResolvePin(s.run, resolvePin), func() {}, nil
+		runner := s.run
+		if s.runIsDefault {
+			if s.runEnv == nil {
+				s.runEnv = defaultEnvCommandRunner
+			}
+			env := appendGitScanEnvOverrides(nil)
+			runner = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				return s.runEnv(ctx, env, name, args...)
+			}
+		}
+		return withGitHTTPSResolvePin(runner, resolvePin), func() {}, nil
 	}
 	if s.runEnv == nil {
 		s.runEnv = defaultEnvCommandRunner
@@ -1775,7 +1788,7 @@ func severityRank(severity domain.FindingSeverity) int {
 
 func defaultCommandRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
 	cmd := newRepositoryCommand(ctx, name, args...)
-	cmd.Env = appendGitScanEnvOverrides(os.Environ())
+	cmd.Env = appendGitProxyEnvOverrides(os.Environ())
 	output, err := cmd.CombinedOutput()
 	if err != nil && ctx.Err() != nil {
 		return output, ctx.Err()
@@ -1793,10 +1806,15 @@ func defaultEnvCommandRunner(ctx context.Context, env []string, name string, arg
 	return output, err
 }
 
-func appendGitScanEnvOverrides(env []string) []string {
-	merged := make([]string, 0, len(env)+len(gitProxyEnvOverrides)+len(gitConfigIsolationEnvOverrides))
+func appendGitProxyEnvOverrides(env []string) []string {
+	merged := make([]string, 0, len(env)+len(gitProxyEnvOverrides))
 	merged = append(merged, env...)
 	merged = append(merged, gitProxyEnvOverrides...)
+	return merged
+}
+
+func appendGitScanEnvOverrides(env []string) []string {
+	merged := appendGitProxyEnvOverrides(env)
 	merged = append(merged, gitConfigIsolationEnvOverrides...)
 	return merged
 }

--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -47,6 +47,13 @@ var gitProxyEnvOverrides = []string{
 	"NO_PROXY=*",
 	"no_proxy=*",
 }
+var gitConfigIsolationEnvOverrides = []string{
+	"GIT_CONFIG_NOSYSTEM=1",
+	"GIT_CONFIG_GLOBAL=" + os.DevNull,
+	"GIT_CONFIG_SYSTEM=" + os.DevNull,
+	"GIT_CONFIG_COUNT=0",
+	"GIT_CONFIG_PARAMETERS=",
+}
 var repositoryHostLookupIPs = func(ctx context.Context, host string) ([]net.IP, error) {
 	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
 	if err != nil {
@@ -606,7 +613,7 @@ func (s *Scanner) cloneCommandRunner(ctx context.Context, workdir string, cloneU
 		"IDENTRAIL_GIT_USERNAME=" + credential.Username,
 		"IDENTRAIL_GIT_PASSWORD=" + credential.Password,
 	}
-	env = appendGitProxyEnvOverrides(env)
+	env = appendGitScanEnvOverrides(env)
 	runner := func(ctx context.Context, name string, args ...string) ([]byte, error) {
 		output, runErr := s.runEnv(ctx, env, name, args...)
 		if runErr != nil {
@@ -1768,7 +1775,7 @@ func severityRank(severity domain.FindingSeverity) int {
 
 func defaultCommandRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
 	cmd := newRepositoryCommand(ctx, name, args...)
-	cmd.Env = appendGitProxyEnvOverrides(os.Environ())
+	cmd.Env = appendGitScanEnvOverrides(os.Environ())
 	output, err := cmd.CombinedOutput()
 	if err != nil && ctx.Err() != nil {
 		return output, ctx.Err()
@@ -1786,10 +1793,11 @@ func defaultEnvCommandRunner(ctx context.Context, env []string, name string, arg
 	return output, err
 }
 
-func appendGitProxyEnvOverrides(env []string) []string {
-	merged := make([]string, 0, len(env)+len(gitProxyEnvOverrides))
+func appendGitScanEnvOverrides(env []string) []string {
+	merged := make([]string, 0, len(env)+len(gitProxyEnvOverrides)+len(gitConfigIsolationEnvOverrides))
 	merged = append(merged, env...)
 	merged = append(merged, gitProxyEnvOverrides...)
+	merged = append(merged, gitConfigIsolationEnvOverrides...)
 	return merged
 }
 

--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -544,15 +544,30 @@ func appendBoundedFetchDepthArgs(args []string, depth int) []string {
 type gitHTTPSResolvePin struct {
 	Host string
 	Port string
-	IP   net.IP
+	IPs  []net.IP
 }
 
 func (p gitHTTPSResolvePin) valid() bool {
-	return p.Host != "" && p.Port != "" && p.IP != nil
+	if p.Host == "" || p.Port == "" {
+		return false
+	}
+	for _, ip := range p.IPs {
+		if ip != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func (p gitHTTPSResolvePin) gitConfigValue() string {
-	return "http.curloptResolve=" + p.Host + ":" + p.Port + ":" + curlResolveIPAddress(p.IP)
+	ips := make([]string, 0, len(p.IPs))
+	for _, ip := range p.IPs {
+		formatted := curlResolveIPAddress(ip)
+		if formatted != "" {
+			ips = append(ips, formatted)
+		}
+	}
+	return "http.curloptResolve=" + p.Host + ":" + p.Port + ":" + strings.Join(ips, ",")
 }
 
 func curlResolveIPAddress(ip net.IP) string {
@@ -1619,7 +1634,7 @@ func gitHTTPSResolvePinForCloneURL(ctx context.Context, cloneURL string) (gitHTT
 	if port == "" {
 		port = "443"
 	}
-	return gitHTTPSResolvePin{Host: normalizedHost, Port: port, IP: resolvedIPs[0]}, nil
+	return gitHTTPSResolvePin{Host: normalizedHost, Port: port, IPs: resolvedIPs}, nil
 }
 
 func isBlockedRepositoryIP(ip net.IP) bool {

--- a/internal/repoexposure/scanner.go
+++ b/internal/repoexposure/scanner.go
@@ -1548,6 +1548,9 @@ func resolveAllowedRepositoryHost(ctx context.Context, host string) (string, []n
 	if normalizedHost == "" {
 		return "", nil, fmt.Errorf("repository target host is required")
 	}
+	if strings.HasSuffix(normalizedHost, ".") {
+		return "", nil, fmt.Errorf("repository target host %q is not allowed", normalizedHost)
+	}
 	lowerHost := strings.TrimSuffix(strings.ToLower(normalizedHost), ".")
 	if lowerHost == "localhost" || strings.HasSuffix(lowerHost, ".localhost") {
 		return "", nil, fmt.Errorf("repository target host %q is not allowed", normalizedHost)

--- a/internal/repoexposure/scanner_test.go
+++ b/internal/repoexposure/scanner_test.go
@@ -929,6 +929,25 @@ func TestCloneRemoteRepositoryRejectsReboundPrivateHostBeforeGit(t *testing.T) {
 	}
 }
 
+func TestCloneRemoteRepositoryRejectsTrailingDotHTTPSHostBeforeGit(t *testing.T) {
+	stubRepositoryHostLookup(t, map[string][]net.IP{
+		"rebind.example": {net.ParseIP("93.184.216.34")},
+	})
+	cloneCalled := false
+	scanner := NewScanner(func(context.Context, string, ...string) ([]byte, error) {
+		cloneCalled = true
+		return nil, errors.New("git should not run")
+	})
+
+	err := scanner.cloneRemoteRepository(context.Background(), t.TempDir(), "https://rebind.example./owner/repo.git", filepath.Join(t.TempDir(), "repo.git"))
+	if err == nil {
+		t.Fatal("expected trailing-dot HTTPS host to be rejected")
+	}
+	if cloneCalled {
+		t.Fatal("expected git runner not to run for trailing-dot HTTPS host")
+	}
+}
+
 func TestCloneRemoteRepositoryPinsHTTPSHostResolutionWithExplicitPort(t *testing.T) {
 	stubRepositoryHostLookup(t, map[string][]net.IP{
 		"example.com": {net.ParseIP("93.184.216.34")},
@@ -1421,6 +1440,7 @@ func TestValidateCloneURL(t *testing.T) {
 		{name: "unsupported file scheme", target: "file:///tmp/repo.git", expectErr: true},
 		{name: "credentials in https url", target: "https://token@example.com/owner/repo.git", expectErr: true},
 		{name: "credentials in ssh url", target: "ssh://git:password@example.com/owner/repo.git", expectErr: true},
+		{name: "trailing dot https host", target: "https://github.com./owner/repo.git", expectErr: true},
 		{name: "loopback ip host", target: "https://127.0.0.1/owner/repo.git", expectErr: true},
 		{name: "private ip host", target: "https://10.0.0.8/owner/repo.git", expectErr: true},
 		{name: "shared address ip host", target: "https://100.64.0.1/owner/repo.git", expectErr: true},

--- a/internal/repoexposure/scanner_test.go
+++ b/internal/repoexposure/scanner_test.go
@@ -973,6 +973,9 @@ func TestCloneRemoteRepositoryPinsHTTPSHostResolutionWithExplicitPort(t *testing
 	if len(gotCommands) == 0 || !reflect.DeepEqual(gotCommands[0], pinnedGitCommand("example.com", "8443", "93.184.216.34", "ls-remote", "--symref", "https://example.com:8443/owner/repo.git")) {
 		t.Fatalf("expected first git command to pin HTTPS host resolution, got %+v", gotCommands)
 	}
+	if !hasArg(gotCommands[0], "http.proxy=") {
+		t.Fatalf("expected pinned HTTPS git command to disable proxy config, got %+v", gotCommands[0])
+	}
 }
 
 func TestCloneRemoteRepositoryFetchesRequiredDeltaRef(t *testing.T) {
@@ -1354,6 +1357,11 @@ func TestCloneRemoteRepositoryUsesAskPassCredentialWithoutCommandArgLeak(t *test
 	if envValue(gotEnv, "GIT_TERMINAL_PROMPT") != "0" {
 		t.Fatalf("expected terminal prompts to be disabled, got %+v", gotEnv)
 	}
+	for _, expected := range gitProxyEnvOverrides {
+		if !hasEnvEntry(gotEnv, expected) {
+			t.Fatalf("expected authenticated clone environment to include %q, got %+v", expected, gotEnv)
+		}
+	}
 }
 
 func TestCloneRemoteRepositoryRedactsCredentialFromErrors(t *testing.T) {
@@ -1517,6 +1525,15 @@ func envValue(env []string, key string) string {
 	return ""
 }
 
+func hasEnvEntry(env []string, want string) bool {
+	for _, item := range env {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}
+
 func stubRepositoryHostLookup(t *testing.T, responses map[string][]net.IP) {
 	t.Helper()
 	originalLookup := repositoryHostLookupIPs
@@ -1532,7 +1549,7 @@ func stubRepositoryHostLookup(t *testing.T, responses map[string][]net.IP) {
 }
 
 func pinnedGitCommand(host string, port string, ip string, args ...string) []string {
-	command := []string{"git", "-c", "http.curloptResolve=" + host + ":" + port + ":" + ip}
+	command := []string{"git", "-c", "http.curloptResolve=" + host + ":" + port + ":" + ip, "-c", "http.proxy="}
 	return append(command, args...)
 }
 

--- a/internal/repoexposure/scanner_test.go
+++ b/internal/repoexposure/scanner_test.go
@@ -1396,6 +1396,11 @@ func TestCloneRemoteRepositoryUsesAskPassCredentialWithoutCommandArgLeak(t *test
 			t.Fatalf("expected authenticated clone environment to include %q, got %+v", expected, gotEnv)
 		}
 	}
+	for _, expected := range gitConfigIsolationEnvOverrides {
+		if !hasEnvEntry(gotEnv, expected) {
+			t.Fatalf("expected authenticated clone environment to include %q, got %+v", expected, gotEnv)
+		}
+	}
 }
 
 func TestCloneRemoteRepositoryRedactsCredentialFromErrors(t *testing.T) {

--- a/internal/repoexposure/scanner_test.go
+++ b/internal/repoexposure/scanner_test.go
@@ -864,12 +864,15 @@ func TestPrepareRepositoryRejectsInsecureHTTPRepositoryURL(t *testing.T) {
 }
 
 func TestCloneRemoteRepositoryUsesBoundedFetchPlan(t *testing.T) {
+	stubRepositoryHostLookup(t, map[string][]net.IP{
+		"github.com": {net.ParseIP("140.82.112.3")},
+	})
 	var gotCommands [][]string
 	scanner := NewScanner(
 		func(_ context.Context, name string, args ...string) ([]byte, error) {
 			command := append([]string{name}, args...)
 			gotCommands = append(gotCommands, command)
-			if reflect.DeepEqual(command, []string{"git", "ls-remote", "--symref", "https://github.com/owner/repo.git"}) {
+			if reflect.DeepEqual(command, pinnedGitCommand("github.com", "443", "140.82.112.3", "ls-remote", "--symref", "https://github.com/owner/repo.git")) {
 				return []byte(strings.Join([]string{
 					"ref: refs/heads/main\tHEAD",
 					"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\tHEAD",
@@ -890,11 +893,11 @@ func TestCloneRemoteRepositoryUsesBoundedFetchPlan(t *testing.T) {
 	}
 
 	expected := [][]string{
-		{"git", "ls-remote", "--symref", "https://github.com/owner/repo.git"},
+		pinnedGitCommand("github.com", "443", "140.82.112.3", "ls-remote", "--symref", "https://github.com/owner/repo.git"),
 		{"git", "init", "--bare", "--quiet", repoPath},
 		{"git", "--git-dir", repoPath, "remote", "add", "origin", "https://github.com/owner/repo.git"},
-		{"git", "--git-dir", repoPath, "fetch", "--quiet", "--no-tags", "--depth", "2", "origin", "+refs/tags/release-keep:refs/tags/release-keep", "+refs/identrail/archive:refs/identrail/archive"},
-		{"git", "--git-dir", repoPath, "fetch", "--quiet", "--no-tags", "--depth", "33", "origin", "+refs/heads/main:refs/heads/main"},
+		pinnedGitCommand("github.com", "443", "140.82.112.3", "--git-dir", repoPath, "fetch", "--quiet", "--no-tags", "--depth", "2", "origin", "+refs/tags/release-keep:refs/tags/release-keep", "+refs/identrail/archive:refs/identrail/archive"),
+		pinnedGitCommand("github.com", "443", "140.82.112.3", "--git-dir", repoPath, "fetch", "--quiet", "--no-tags", "--depth", "33", "origin", "+refs/heads/main:refs/heads/main"),
 		{"git", "--git-dir", repoPath, "symbolic-ref", "HEAD", "refs/heads/main"},
 	}
 	if !reflect.DeepEqual(gotCommands, expected) {
@@ -907,14 +910,63 @@ func TestCloneRemoteRepositoryUsesBoundedFetchPlan(t *testing.T) {
 	}
 }
 
+func TestCloneRemoteRepositoryRejectsReboundPrivateHostBeforeGit(t *testing.T) {
+	stubRepositoryHostLookup(t, map[string][]net.IP{
+		"rebind.example": {net.ParseIP("169.254.169.254")},
+	})
+	cloneCalled := false
+	scanner := NewScanner(func(context.Context, string, ...string) ([]byte, error) {
+		cloneCalled = true
+		return nil, errors.New("git should not run")
+	})
+
+	err := scanner.cloneRemoteRepository(context.Background(), t.TempDir(), "https://rebind.example/owner/repo.git", filepath.Join(t.TempDir(), "repo.git"))
+	if err == nil {
+		t.Fatal("expected private rebound host to be rejected")
+	}
+	if cloneCalled {
+		t.Fatal("expected git runner not to run for private rebound host")
+	}
+}
+
+func TestCloneRemoteRepositoryPinsHTTPSHostResolutionWithExplicitPort(t *testing.T) {
+	stubRepositoryHostLookup(t, map[string][]net.IP{
+		"example.com": {net.ParseIP("93.184.216.34")},
+	})
+	var gotCommands [][]string
+	scanner := NewScanner(func(_ context.Context, name string, args ...string) ([]byte, error) {
+		command := append([]string{name}, args...)
+		gotCommands = append(gotCommands, command)
+		if reflect.DeepEqual(command, pinnedGitCommand("example.com", "8443", "93.184.216.34", "ls-remote", "--symref", "https://example.com:8443/owner/repo.git")) {
+			return []byte(strings.Join([]string{
+				"ref: refs/heads/main\tHEAD",
+				"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\tHEAD",
+				"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\trefs/heads/main",
+			}, "\n")), nil
+		}
+		return []byte("ok"), nil
+	})
+
+	err := scanner.cloneRemoteRepository(context.Background(), t.TempDir(), "https://example.com:8443/owner/repo.git", filepath.Join(t.TempDir(), "repo.git"))
+	if err != nil {
+		t.Fatalf("clone remote repository: %v", err)
+	}
+	if len(gotCommands) == 0 || !reflect.DeepEqual(gotCommands[0], pinnedGitCommand("example.com", "8443", "93.184.216.34", "ls-remote", "--symref", "https://example.com:8443/owner/repo.git")) {
+		t.Fatalf("expected first git command to pin HTTPS host resolution, got %+v", gotCommands)
+	}
+}
+
 func TestCloneRemoteRepositoryFetchesRequiredDeltaRef(t *testing.T) {
+	stubRepositoryHostLookup(t, map[string][]net.IP{
+		"github.com": {net.ParseIP("140.82.112.3")},
+	})
 	head := strings.Repeat("b", 40)
 	var gotCommands [][]string
 	scanner := NewScanner(
 		func(_ context.Context, name string, args ...string) ([]byte, error) {
 			command := append([]string{name}, args...)
 			gotCommands = append(gotCommands, command)
-			if reflect.DeepEqual(command, []string{"git", "ls-remote", "--symref", "https://github.com/owner/repo.git"}) {
+			if reflect.DeepEqual(command, pinnedGitCommand("github.com", "443", "140.82.112.3", "ls-remote", "--symref", "https://github.com/owner/repo.git")) {
 				return []byte(strings.Join([]string{
 					"ref: refs/heads/main\tHEAD",
 					strings.Repeat("a", 40) + "\tHEAD",
@@ -939,12 +991,12 @@ func TestCloneRemoteRepositoryFetchesRequiredDeltaRef(t *testing.T) {
 	}
 
 	expected := [][]string{
-		{"git", "ls-remote", "--symref", "https://github.com/owner/repo.git"},
+		pinnedGitCommand("github.com", "443", "140.82.112.3", "ls-remote", "--symref", "https://github.com/owner/repo.git"),
 		{"git", "init", "--bare", "--quiet", repoPath},
 		{"git", "--git-dir", repoPath, "remote", "add", "origin", "https://github.com/owner/repo.git"},
-		{"git", "--git-dir", repoPath, "fetch", "--quiet", "--no-tags", "--depth", "2", "origin", "+refs/tags/release-keep:refs/tags/release-keep"},
-		{"git", "--git-dir", repoPath, "fetch", "--quiet", "--no-tags", "--depth", "2", "origin", "+refs/heads/main:refs/heads/main"},
-		{"git", "--git-dir", repoPath, "fetch", "--quiet", "--no-tags", "--depth", "4", "origin", "+refs/heads/feature:refs/heads/feature"},
+		pinnedGitCommand("github.com", "443", "140.82.112.3", "--git-dir", repoPath, "fetch", "--quiet", "--no-tags", "--depth", "2", "origin", "+refs/tags/release-keep:refs/tags/release-keep"),
+		pinnedGitCommand("github.com", "443", "140.82.112.3", "--git-dir", repoPath, "fetch", "--quiet", "--no-tags", "--depth", "2", "origin", "+refs/heads/main:refs/heads/main"),
+		pinnedGitCommand("github.com", "443", "140.82.112.3", "--git-dir", repoPath, "fetch", "--quiet", "--no-tags", "--depth", "4", "origin", "+refs/heads/feature:refs/heads/feature"),
 		{"git", "--git-dir", repoPath, "cat-file", "-e", head + "^{commit}"},
 		{"git", "--git-dir", repoPath, "symbolic-ref", "HEAD", "refs/heads/main"},
 	}
@@ -1230,6 +1282,9 @@ func TestBuildRemoteRepositoryClonePlanKeepsDefaultTipScannable(t *testing.T) {
 }
 
 func TestCloneRemoteRepositoryUsesAskPassCredentialWithoutCommandArgLeak(t *testing.T) {
+	stubRepositoryHostLookup(t, map[string][]net.IP{
+		"github.com": {net.ParseIP("140.82.112.3")},
+	})
 	const secret = "ghs_secret_token"
 	var gotEnv []string
 	var gotCommands [][]string
@@ -1254,7 +1309,7 @@ func TestCloneRemoteRepositoryUsesAskPassCredentialWithoutCommandArgLeak(t *test
 			if _, err := os.Stat(askPass); err != nil {
 				t.Fatalf("expected askpass helper to exist during clone: %v", err)
 			}
-			if reflect.DeepEqual(command, []string{"git", "ls-remote", "--symref", "https://github.com/owner/repo.git"}) {
+			if reflect.DeepEqual(command, pinnedGitCommand("github.com", "443", "140.82.112.3", "ls-remote", "--symref", "https://github.com/owner/repo.git")) {
 				return []byte(strings.Join([]string{
 					"ref: refs/heads/main\tHEAD",
 					"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\tHEAD",
@@ -1283,6 +1338,9 @@ func TestCloneRemoteRepositoryUsesAskPassCredentialWithoutCommandArgLeak(t *test
 }
 
 func TestCloneRemoteRepositoryRedactsCredentialFromErrors(t *testing.T) {
+	stubRepositoryHostLookup(t, map[string][]net.IP{
+		"github.com": {net.ParseIP("140.82.112.3")},
+	})
 	const secret = "ghs_secret_token"
 	scanner := NewScanner(nil,
 		WithHTTPSCloneCredential(HTTPSCloneCredential{
@@ -1305,6 +1363,9 @@ func TestCloneRemoteRepositoryRedactsCredentialFromErrors(t *testing.T) {
 }
 
 func TestCloneRemoteRepositoryRejectsCredentialHostMismatch(t *testing.T) {
+	stubRepositoryHostLookup(t, map[string][]net.IP{
+		"gitlab.com": {net.ParseIP("172.65.251.78")},
+	})
 	called := false
 	scanner := NewScanner(nil,
 		WithHTTPSCloneCredential(HTTPSCloneCredential{
@@ -1353,8 +1414,9 @@ func TestValidateCloneURL(t *testing.T) {
 		expectErr bool
 	}{
 		{name: "github shorthand", target: "https://github.com/owner/repo.git"},
-		{name: "ssh url", target: "ssh://git@github.com/owner/repo.git"},
-		{name: "git scp form", target: "git@github.com:owner/repo.git"},
+		{name: "ssh url", target: "ssh://git@github.com/owner/repo.git", expectErr: true},
+		{name: "git scp form", target: "git@github.com:owner/repo.git", expectErr: true},
+		{name: "argument-like target", target: "--upload-pack=/bin/echo", expectErr: true},
 		{name: "insecure http", target: "http://github.com/owner/repo.git", expectErr: true},
 		{name: "unsupported file scheme", target: "file:///tmp/repo.git", expectErr: true},
 		{name: "credentials in https url", target: "https://token@example.com/owner/repo.git", expectErr: true},
@@ -1433,6 +1495,25 @@ func envValue(env []string, key string) string {
 		}
 	}
 	return ""
+}
+
+func stubRepositoryHostLookup(t *testing.T, responses map[string][]net.IP) {
+	t.Helper()
+	originalLookup := repositoryHostLookupIPs
+	repositoryHostLookupIPs = func(_ context.Context, host string) ([]net.IP, error) {
+		if ips, ok := responses[strings.ToLower(strings.TrimSpace(host))]; ok {
+			return append([]net.IP(nil), ips...), nil
+		}
+		return nil, &net.DNSError{Err: "no such host", Name: host, IsNotFound: true}
+	}
+	t.Cleanup(func() {
+		repositoryHostLookupIPs = originalLookup
+	})
+}
+
+func pinnedGitCommand(host string, port string, ip string, args ...string) []string {
+	command := []string{"git", "-c", "http.curloptResolve=" + host + ":" + port + ":" + ip}
+	return append(command, args...)
 }
 
 func TestHelperFunctions(t *testing.T) {

--- a/internal/repoexposure/scanner_test.go
+++ b/internal/repoexposure/scanner_test.go
@@ -976,6 +976,9 @@ func TestCloneRemoteRepositoryPinsHTTPSHostResolutionWithExplicitPort(t *testing
 	if !hasArg(gotCommands[0], "http.proxy=") {
 		t.Fatalf("expected pinned HTTPS git command to disable proxy config, got %+v", gotCommands[0])
 	}
+	if !hasArg(gotCommands[0], "remote.origin.proxy=") {
+		t.Fatalf("expected pinned HTTPS git command to disable per-remote proxy config, got %+v", gotCommands[0])
+	}
 }
 
 func TestCloneRemoteRepositoryPinsAllHTTPSHostResolutions(t *testing.T) {
@@ -1584,7 +1587,7 @@ func pinnedGitCommand(host string, port string, ip string, args ...string) []str
 }
 
 func pinnedGitCommandWithIPs(host string, port string, ips []string, args ...string) []string {
-	command := []string{"git", "-c", "http.curloptResolve=" + host + ":" + port + ":" + strings.Join(ips, ","), "-c", "http.proxy="}
+	command := []string{"git", "-c", "http.curloptResolve=" + host + ":" + port + ":" + strings.Join(ips, ","), "-c", "http.proxy=", "-c", "remote.origin.proxy="}
 	return append(command, args...)
 }
 

--- a/internal/repoexposure/scanner_test.go
+++ b/internal/repoexposure/scanner_test.go
@@ -981,6 +981,47 @@ func TestCloneRemoteRepositoryPinsHTTPSHostResolutionWithExplicitPort(t *testing
 	}
 }
 
+func TestCloneRemoteRepositoryIsolatesGitConfigForDefaultRemoteClone(t *testing.T) {
+	stubRepositoryHostLookup(t, map[string][]net.IP{
+		"github.com": {net.ParseIP("140.82.112.3")},
+	})
+	var gotEnv []string
+	var gotCommands [][]string
+	scanner := NewScanner(nil,
+		WithEnvCommandRunner(func(_ context.Context, env []string, name string, args ...string) ([]byte, error) {
+			gotEnv = append([]string(nil), env...)
+			command := append([]string{name}, args...)
+			gotCommands = append(gotCommands, command)
+			if reflect.DeepEqual(command, pinnedGitCommand("github.com", "443", "140.82.112.3", "ls-remote", "--symref", "https://github.com/owner/repo.git")) {
+				return []byte(strings.Join([]string{
+					"ref: refs/heads/main\tHEAD",
+					"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\tHEAD",
+					"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\trefs/heads/main",
+				}, "\n")), nil
+			}
+			return []byte("ok"), nil
+		}),
+	)
+
+	err := scanner.cloneRemoteRepository(context.Background(), t.TempDir(), "https://github.com/owner/repo.git", filepath.Join(t.TempDir(), "repo.git"))
+	if err != nil {
+		t.Fatalf("clone remote repository: %v", err)
+	}
+	if len(gotCommands) == 0 {
+		t.Fatal("expected clone commands to run")
+	}
+	for _, expected := range gitProxyEnvOverrides {
+		if !hasEnvEntry(gotEnv, expected) {
+			t.Fatalf("expected default remote clone environment to include %q, got %+v", expected, gotEnv)
+		}
+	}
+	for _, expected := range gitConfigIsolationEnvOverrides {
+		if !hasEnvEntry(gotEnv, expected) {
+			t.Fatalf("expected default remote clone environment to include %q, got %+v", expected, gotEnv)
+		}
+	}
+}
+
 func TestCloneRemoteRepositoryPinsAllHTTPSHostResolutions(t *testing.T) {
 	stubRepositoryHostLookup(t, map[string][]net.IP{
 		"multi.example": {

--- a/internal/repoexposure/scanner_test.go
+++ b/internal/repoexposure/scanner_test.go
@@ -978,6 +978,37 @@ func TestCloneRemoteRepositoryPinsHTTPSHostResolutionWithExplicitPort(t *testing
 	}
 }
 
+func TestCloneRemoteRepositoryPinsAllHTTPSHostResolutions(t *testing.T) {
+	stubRepositoryHostLookup(t, map[string][]net.IP{
+		"multi.example": {
+			net.ParseIP("93.184.216.34"),
+			net.ParseIP("93.184.216.35"),
+		},
+	})
+	var gotCommands [][]string
+	expectedLSRemote := pinnedGitCommandWithIPs("multi.example", "443", []string{"93.184.216.34", "93.184.216.35"}, "ls-remote", "--symref", "https://multi.example/owner/repo.git")
+	scanner := NewScanner(func(_ context.Context, name string, args ...string) ([]byte, error) {
+		command := append([]string{name}, args...)
+		gotCommands = append(gotCommands, command)
+		if reflect.DeepEqual(command, expectedLSRemote) {
+			return []byte(strings.Join([]string{
+				"ref: refs/heads/main\tHEAD",
+				"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\tHEAD",
+				"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\trefs/heads/main",
+			}, "\n")), nil
+		}
+		return []byte("ok"), nil
+	})
+
+	err := scanner.cloneRemoteRepository(context.Background(), t.TempDir(), "https://multi.example/owner/repo.git", filepath.Join(t.TempDir(), "repo.git"))
+	if err != nil {
+		t.Fatalf("clone remote repository: %v", err)
+	}
+	if len(gotCommands) == 0 || !reflect.DeepEqual(gotCommands[0], expectedLSRemote) {
+		t.Fatalf("expected first git command to pin all HTTPS host resolutions, got %+v", gotCommands)
+	}
+}
+
 func TestCloneRemoteRepositoryFetchesRequiredDeltaRef(t *testing.T) {
 	stubRepositoryHostLookup(t, map[string][]net.IP{
 		"github.com": {net.ParseIP("140.82.112.3")},
@@ -1549,7 +1580,11 @@ func stubRepositoryHostLookup(t *testing.T, responses map[string][]net.IP) {
 }
 
 func pinnedGitCommand(host string, port string, ip string, args ...string) []string {
-	command := []string{"git", "-c", "http.curloptResolve=" + host + ":" + port + ":" + ip, "-c", "http.proxy="}
+	return pinnedGitCommandWithIPs(host, port, []string{ip}, args...)
+}
+
+func pinnedGitCommandWithIPs(host string, port string, ips []string, args ...string) []string {
+	command := []string{"git", "-c", "http.curloptResolve=" + host + ":" + port + ":" + strings.Join(ips, ","), "-c", "http.proxy="}
 	return append(command, args...)
 }
 


### PR DESCRIPTION
No issue: security hardening for a user-reported direct repository scanner finding before a tracker issue existed.

## Summary
- Pin HTTPS repo-scan Git network commands with `http.curloptResolve` after validating the resolved host IPs.
- Reject direct SSH/SCP-style and option-like remote targets because they cannot receive the same DNS pinning guard before Git delegates to SSH.
- Document the HTTPS-only behavior for direct remote scans.

## Security impact
This closes the conditional DNS-rebinding SSRF gap for direct repository scans: Identrail validates the repository host immediately before Git network access, rejects private/link-local/loopback resolutions, and pins the accepted HTTPS DNS answer into Git for `ls-remote` and `fetch`.

## Tests
- `go test ./internal/repoexposure`
- `go test ./internal/api ./internal/repoexposure`
- `go test ./...`
- `git -c http.curloptResolve=github.com:443:140.82.112.4 ls-remote --symref https://github.com/git/git.git HEAD`

## AI Assistance Disclosure

No