### PR TITLE
Enable hosted user data exports

### DIFF
--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -20,6 +20,7 @@ When `create_api_hosting_resources=true`, the root can also create:
   HTTP-to-HTTPS redirect
 - API load balancer and ECS service security groups
 - task execution and task IAM roles
+- a private S3 bucket for self-serve account data export bundles
 
 When `create_worker_hosting_resources=true`, the root also creates:
 
@@ -63,6 +64,14 @@ service.
 The task role includes the read-only IAM discovery calls required by that live
 collector. Optional `sts:AssumeRole` access is limited to ARNs listed in
 `api_connector_role_arns`.
+Hosted API plans create and wire `IDENTRAIL_USER_DATA_EXPORT_S3_*` settings by
+default so "Download my data" can store bundles in S3 instead of local task
+disk. The API and worker task roles can access only objects under the configured
+export prefix. The bucket blocks public access, uses server-side encryption,
+and expires completed export objects after `user_data_export_retention_days`
+days. Export ZIPs contain `manifest.json`, `user.json`, `workspaces.json`,
+`audit.json`, and `sessions.json`; they do not include session token material
+or session ID hashes.
 
 ## Safe Defaults
 

--- a/deploy/aws/terraform/api_hosting.tf
+++ b/deploy/aws/terraform/api_hosting.tf
@@ -27,7 +27,19 @@ locals {
     IDENTRAIL_RUN_MIGRATIONS_ONLY  = "false"
     IDENTRAIL_TRUSTED_PROXIES      = local.api_trusted_proxies
   }
-  api_runtime_environment_variables = merge(local.api_default_environment_variables, var.api_environment_variables)
+  user_data_export_bucket_enabled = var.create_api_hosting_resources && var.user_data_export_bucket_enabled
+  user_data_export_bucket_name = (
+    trimspace(var.user_data_export_bucket_name) != "" ?
+    trimspace(var.user_data_export_bucket_name) :
+    "${local.api_name_prefix}-exports"
+  )
+  user_data_export_s3_prefix = trimsuffix(trim(trimspace(var.user_data_export_s3_prefix), "/"), "/") == "" ? "" : "${trimsuffix(trim(trimspace(var.user_data_export_s3_prefix), "/"), "/")}/"
+  api_user_data_export_environment_variables = local.user_data_export_bucket_enabled ? {
+    IDENTRAIL_USER_DATA_EXPORT_S3_BUCKET = local.user_data_export_bucket_name
+    IDENTRAIL_USER_DATA_EXPORT_S3_PREFIX = local.user_data_export_s3_prefix
+    IDENTRAIL_USER_DATA_EXPORT_S3_REGION = var.aws_region
+  } : {}
+  api_runtime_environment_variables = merge(local.api_default_environment_variables, local.api_user_data_export_environment_variables, var.api_environment_variables)
   api_config_names                  = toset(concat(keys(local.api_runtime_environment_variables), keys(var.api_secrets)))
   api_secret_config_names           = toset(keys(var.api_secrets))
   api_secret_resource_arns = toset([
@@ -623,6 +635,7 @@ resource "aws_ecs_service" "api" {
     aws_iam_role_policy_attachment.api_task_execution,
     aws_iam_role_policy.api_task_execution_secrets,
     aws_iam_role_policy.api_task_aws_collector,
+    aws_iam_role_policy.api_task_user_data_exports,
     aws_lb_listener.api_https,
   ]
 }

--- a/deploy/aws/terraform/api_hosting.tf
+++ b/deploy/aws/terraform/api_hosting.tf
@@ -1,4 +1,6 @@
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+  count = local.user_data_export_bucket_enabled && trimspace(var.user_data_export_bucket_name) == "" ? 1 : 0
+}
 
 locals {
   api_service_name     = "${var.name_prefix}-${var.environment}-api"
@@ -33,7 +35,10 @@ locals {
   user_data_export_bucket_name = (
     trimspace(var.user_data_export_bucket_name) != "" ?
     trimspace(var.user_data_export_bucket_name) :
-    "${data.aws_caller_identity.current.account_id}-${local.api_name_prefix}-exports"
+    (local.user_data_export_bucket_enabled ?
+      "${data.aws_caller_identity.current[0].account_id}-${local.api_name_prefix}-exports" :
+      ""
+    )
   )
   user_data_export_s3_prefix = trimsuffix(trim(trimspace(var.user_data_export_s3_prefix), "/"), "/") == "" ? "" : "${trimsuffix(trim(trimspace(var.user_data_export_s3_prefix), "/"), "/")}/"
   api_user_data_export_environment_variables = local.user_data_export_bucket_enabled ? {

--- a/deploy/aws/terraform/api_hosting.tf
+++ b/deploy/aws/terraform/api_hosting.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 locals {
   api_service_name     = "${var.name_prefix}-${var.environment}-api"
   api_name_hash        = substr(sha1(local.api_service_name), 0, 8)
@@ -27,11 +29,11 @@ locals {
     IDENTRAIL_RUN_MIGRATIONS_ONLY  = "false"
     IDENTRAIL_TRUSTED_PROXIES      = local.api_trusted_proxies
   }
-  user_data_export_bucket_enabled = var.create_api_hosting_resources && var.user_data_export_bucket_enabled
+  user_data_export_bucket_enabled = var.create_api_hosting_resources && var.user_data_export_bucket_enabled && var.create_worker_hosting_resources
   user_data_export_bucket_name = (
     trimspace(var.user_data_export_bucket_name) != "" ?
     trimspace(var.user_data_export_bucket_name) :
-    "${local.api_name_prefix}-exports"
+    "${data.aws_caller_identity.current.account_id}-${local.api_name_prefix}-exports"
   )
   user_data_export_s3_prefix = trimsuffix(trim(trimspace(var.user_data_export_s3_prefix), "/"), "/") == "" ? "" : "${trimsuffix(trim(trimspace(var.user_data_export_s3_prefix), "/"), "/")}/"
   api_user_data_export_environment_variables = local.user_data_export_bucket_enabled ? {

--- a/deploy/aws/terraform/outputs.tf
+++ b/deploy/aws/terraform/outputs.tf
@@ -33,6 +33,11 @@ output "api_service_name" {
   value       = try(aws_ecs_service.api[0].name, local.api_service_name)
 }
 
+output "user_data_export_bucket_name" {
+  description = "S3 bucket used for self-serve account data export bundles when enabled."
+  value       = try(aws_s3_bucket.user_data_exports[0].bucket, null)
+}
+
 output "worker_hosting_enabled" {
   description = "Whether this plan creates the AWS worker hosting layer."
   value       = var.create_worker_hosting_resources

--- a/deploy/aws/terraform/user_data_exports.tf
+++ b/deploy/aws/terraform/user_data_exports.tf
@@ -1,0 +1,84 @@
+resource "aws_s3_bucket" "user_data_exports" {
+  count = local.user_data_export_bucket_enabled ? 1 : 0
+
+  bucket = local.user_data_export_bucket_name
+
+  tags = merge(var.tags, {
+    Name      = local.user_data_export_bucket_name
+    Component = "user-data-exports"
+  })
+}
+
+resource "aws_s3_bucket_public_access_block" "user_data_exports" {
+  count = local.user_data_export_bucket_enabled ? 1 : 0
+
+  bucket                  = aws_s3_bucket.user_data_exports[0].id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "user_data_exports" {
+  count = local.user_data_export_bucket_enabled ? 1 : 0
+
+  bucket = aws_s3_bucket.user_data_exports[0].id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "user_data_exports" {
+  count = local.user_data_export_bucket_enabled ? 1 : 0
+
+  bucket = aws_s3_bucket.user_data_exports[0].id
+
+  rule {
+    id     = "expire-user-data-exports"
+    status = "Enabled"
+
+    filter {
+      prefix = local.user_data_export_s3_prefix
+    }
+
+    expiration {
+      days = var.user_data_export_retention_days
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+}
+
+data "aws_iam_policy_document" "user_data_exports" {
+  count = local.user_data_export_bucket_enabled ? 1 : 0
+
+  statement {
+    actions = [
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+    resources = ["${aws_s3_bucket.user_data_exports[0].arn}/${local.user_data_export_s3_prefix}*"]
+  }
+}
+
+resource "aws_iam_role_policy" "api_task_user_data_exports" {
+  count = local.user_data_export_bucket_enabled ? 1 : 0
+
+  name   = "${local.api_policy_name_base}-user-exports"
+  role   = aws_iam_role.api_task[0].id
+  policy = data.aws_iam_policy_document.user_data_exports[0].json
+}
+
+resource "aws_iam_role_policy" "worker_task_user_data_exports" {
+  count = local.user_data_export_bucket_enabled && var.create_worker_hosting_resources ? 1 : 0
+
+  name   = "${local.worker_policy_name_base}-user-exports"
+  role   = aws_iam_role.worker_task[0].id
+  policy = data.aws_iam_policy_document.user_data_exports[0].json
+}

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -341,6 +341,51 @@ variable "api_connector_role_arns" {
   }
 }
 
+variable "user_data_export_bucket_enabled" {
+  description = "Create and wire an S3 bucket for self-serve account data export bundles when API hosting is enabled."
+  type        = bool
+  default     = true
+}
+
+variable "user_data_export_bucket_name" {
+  description = "Optional explicit S3 bucket name for self-serve account data exports. Defaults to a deterministic Identrail API name when blank."
+  type        = string
+  default     = ""
+  validation {
+    condition = length(trimspace(var.user_data_export_bucket_name)) == 0 || (
+      length(trimspace(var.user_data_export_bucket_name)) >= 3 &&
+      length(trimspace(var.user_data_export_bucket_name)) <= 63 &&
+      can(regex("^[a-z0-9][a-z0-9-]*[a-z0-9]$", trimspace(var.user_data_export_bucket_name)))
+    )
+    error_message = "user_data_export_bucket_name must be blank or a 3-63 character lowercase S3 bucket name using letters, numbers, and dashes."
+  }
+}
+
+variable "user_data_export_s3_prefix" {
+  description = "S3 object prefix for self-serve account data export bundles."
+  type        = string
+  default     = "user-data-exports/"
+  validation {
+    condition = (
+      length(trimspace(var.user_data_export_s3_prefix)) == length(var.user_data_export_s3_prefix) &&
+      !startswith(trimspace(var.user_data_export_s3_prefix), "/") &&
+      !strcontains(trimspace(var.user_data_export_s3_prefix), "..") &&
+      !strcontains(trimspace(var.user_data_export_s3_prefix), "\\")
+    )
+    error_message = "user_data_export_s3_prefix must not have surrounding whitespace, start with '/', contain '..', or contain backslashes."
+  }
+}
+
+variable "user_data_export_retention_days" {
+  description = "Days before completed account data export objects expire from S3."
+  type        = number
+  default     = 8
+  validation {
+    condition     = var.user_data_export_retention_days >= 1 && var.user_data_export_retention_days <= 30
+    error_message = "user_data_export_retention_days must be between 1 and 30."
+  }
+}
+
 variable "api_container_insights_enabled" {
   description = "Enable ECS Container Insights for the API cluster."
   type        = bool

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -370,9 +370,11 @@ variable "user_data_export_s3_prefix" {
       length(trimspace(var.user_data_export_s3_prefix)) == length(var.user_data_export_s3_prefix) &&
       !startswith(trimspace(var.user_data_export_s3_prefix), "/") &&
       !strcontains(trimspace(var.user_data_export_s3_prefix), "..") &&
-      !strcontains(trimspace(var.user_data_export_s3_prefix), "\\")
+      !strcontains(trimspace(var.user_data_export_s3_prefix), "\\") &&
+      !strcontains(trimspace(var.user_data_export_s3_prefix), "*") &&
+      !strcontains(trimspace(var.user_data_export_s3_prefix), "?")
     )
-    error_message = "user_data_export_s3_prefix must not have surrounding whitespace, start with '/', contain '..', or contain backslashes."
+    error_message = "user_data_export_s3_prefix must not have surrounding whitespace, start with '/', contain '..', contain backslashes, '*' or '?'."
   }
 }
 

--- a/deploy/aws/terraform/worker_hosting.tf
+++ b/deploy/aws/terraform/worker_hosting.tf
@@ -231,5 +231,6 @@ resource "aws_ecs_service" "worker" {
     aws_iam_role_policy_attachment.worker_task_execution,
     aws_iam_role_policy.worker_task_execution_secrets,
     aws_iam_role_policy.worker_task_aws_collector,
+    aws_iam_role_policy.worker_task_user_data_exports,
   ]
 }

--- a/docs/aws-api-hosting.md
+++ b/docs/aws-api-hosting.md
@@ -15,6 +15,7 @@ When `create_api_hosting_resources=true`, `deploy/aws/terraform` can create:
   traffic from the load balancer to the API tasks
 - task execution and task IAM roles
 - CloudWatch logs for API runtime output
+- a private S3 bucket for self-serve account data export bundles
 
 When `create_worker_hosting_resources=true`, the same Terraform root also
 creates a private ECS/Fargate worker service in the API cluster. The hosted
@@ -45,6 +46,15 @@ The worker task has its own execution role, task role, and egress-only security
 group. It inherits `api_secrets` and may receive worker-only overrides through
 `worker_secrets`; secret values still stay in Secrets Manager rather than
 Terraform state.
+
+The hosted API plan also creates and wires `IDENTRAIL_USER_DATA_EXPORT_S3_*`
+settings by default. The API and worker task roles can read, write, and delete
+objects only under the configured export prefix. The bucket blocks public
+access, uses server-side encryption, and expires completed export objects after
+`user_data_export_retention_days` days. A downloaded ZIP contains
+`manifest.json`, `user.json`, `workspaces.json`, `audit.json`, and
+`sessions.json`; it does not include session token material or session ID
+hashes.
 
 ## Required Operator Inputs
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -93,6 +93,22 @@ Production deployment templates set `IDENTRAIL_REQUIRE_LIVE_SOURCES=true` with `
 - `IDENTRAIL_LOCK_BACKEND` (`auto|inmemory|postgres`)
 - `IDENTRAIL_LOCK_NAMESPACE`
 
+## User Data Export
+
+- `IDENTRAIL_USER_DATA_EXPORT_PATH` (local-disk export storage for dev/test)
+- `IDENTRAIL_USER_DATA_EXPORT_S3_BUCKET` (hosted export storage bucket)
+- `IDENTRAIL_USER_DATA_EXPORT_S3_PREFIX` (optional S3 object prefix)
+- `IDENTRAIL_USER_DATA_EXPORT_S3_REGION` (optional override; defaults to `IDENTRAIL_AWS_REGION` when set by deployment templates)
+- `IDENTRAIL_WORKER_USER_EXPORT_GC_ENABLED` (default: `true`)
+- `IDENTRAIL_WORKER_USER_EXPORT_GC_INTERVAL` (default: `1h`)
+
+Set exactly one export storage backend. Use `IDENTRAIL_USER_DATA_EXPORT_PATH`
+for a single local API/worker process. Use the S3 settings for hosted or
+multi-process deployments so the worker can write the ZIP and any API task can
+serve the signed download. Completed export bundles contain
+`manifest.json`, `user.json`, `workspaces.json`, `audit.json`, and
+`sessions.json`; session token material and session ID hashes are not included.
+
 ## App-Mode Feature Flags
 
 App-mode feature flags are supported runtime configuration for API and worker processes. They are disabled by default and must be explicitly enabled; dependent feature flags fail validation unless their parent flag is enabled.

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.20
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.19
 	github.com/aws/aws-sdk-go-v2/service/iam v1.54.0
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.102.2
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.3
 	github.com/aws/smithy-go v1.26.0
 	github.com/beevik/etree v1.6.0
@@ -35,12 +36,15 @@ require (
 require (
 	github.com/agext/levenshtein v1.2.1 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.11 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.25 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.25 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.25 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.26 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.10 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.18 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.25 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.25 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.1.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.19 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.36.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/aws/aws-sdk-go-v2 v1.41.9 h1:/rYeyO2+HrMztAmxAq9++XJtFMqSIpSsNA0yDGALYq4=
 github.com/aws/aws-sdk-go-v2 v1.41.9/go.mod h1:+HsoOEX80qAVUitj1A2DhCNTjmb3edVyuDypb6LNEeo=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.11 h1:h5+3VT69KUBK24grGuuA5saDJTj2IIjLb9au668Fo5I=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.11/go.mod h1:dnakxebH6UwFvcvujL0LVggYQ8nEvBGjU4G/V79Nv94=
 github.com/aws/aws-sdk-go-v2/config v1.32.20 h1:8VMDnWc/kEzxsI/1ngGM9mG81a8IGmIHD8KLcYGwagc=
 github.com/aws/aws-sdk-go-v2/config v1.32.20/go.mod h1:PuwEpciweIXGULWeOeSTXtSbH4CW9mWdWrhdCKQI1sM=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.19 h1:yuFzSV1U0aRNYCQGVaTY2zW2M/L93pYHnXnrJUphYhU=
@@ -22,8 +24,14 @@ github.com/aws/aws-sdk-go-v2/service/iam v1.54.0 h1:i3YpG+QUhBF2WFAB4+xeuazlkk7w
 github.com/aws/aws-sdk-go-v2/service/iam v1.54.0/go.mod h1:nLv8xEWcYrOTFwomMo1ItTUFuG1HNjvU6ZaX0ZDB1BU=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.10 h1:d5/908OJ4bXg8lyjeMPvXetEKqoDoLi5Owy1zNue3yg=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.10/go.mod h1:a57l7Hwh+FWI+we50g5NPJHYUKeJKfXbc4w8SyXu8Ig=
+github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.18 h1:W/EyPFl9A5rXrtoilfwHYEvzHER+K4SpBPtMXi24Mos=
+github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.18/go.mod h1:UG50K+pvd/uy6xExbobg0rjqFBFZe6I3l75EPDZw4tg=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.25 h1:dD3dhHNglpd98gs72my22Ndqi1hqQGllFFg1F+twfxg=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.25/go.mod h1:0yAbjPfd64gG7mj85RW+fMEYdfBgCRZw8g/oWcL1pjc=
+github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.25 h1:2pQEbwf+/6EDbiit/GcBE2K4IUpMZymaA0kOz3xK978=
+github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.25/go.mod h1:KvT6NCcQ0EZ+ZkVRrlBMt04Po3ok23YELEp7WimhLhM=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.102.2 h1:ie4ElCmUKS26pzrZcIk/lmt4yWjAqLLcawstyQCh298=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.102.2/go.mod h1:zjsomFeX5duj+4PlMB+o4JoWTIx+G0XMyzjYrUbQkN0=
 github.com/aws/aws-sdk-go-v2/service/signin v1.1.1 h1:1VwbP3qMNfxUDEXWki4rCE5iA+44VA1lokTz9HasGzw=
 github.com/aws/aws-sdk-go-v2/service/signin v1.1.1/go.mod h1:vUtyoSj0OPji3kjIVSc/GlKuWEiL33f/WFxl6dmpy/A=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.19 h1:N6pIsdFOW1Kd9S4KyFKXdGRBojPPxkP32+uHFWLv4Hc=

--- a/internal/api/me_export_routes.go
+++ b/internal/api/me_export_routes.go
@@ -223,7 +223,7 @@ func downloadMeExportHandler(logger *zap.Logger, svc *Service) gin.HandlerFunc {
 			c.JSON(http.StatusGone, gin.H{"error": "export bundle has been purged"})
 			return
 		}
-		f, err := svc.UserExportStorage.Open(userexport.StorageKey(job))
+		f, err := svc.UserExportStorage.Open(ctx, userexport.StorageKey(job))
 		if err != nil {
 			if logger != nil {
 				logger.Error("open export bundle", telemetry.ZapError(err))

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -205,9 +205,9 @@ type Service struct {
 // that the data-export handlers depend on. Local here so Service tests don't
 // have to import the userexport package.
 type UserExportStorage interface {
-	Put(key string, r io.Reader) (string, error)
-	Open(key string) (io.ReadCloser, error)
-	Delete(key string) error
+	Put(ctx context.Context, key string, r io.Reader) (string, error)
+	Open(ctx context.Context, key string) (io.ReadCloser, error)
+	Delete(ctx context.Context, key string) error
 }
 
 // RepoScanQueueEvent reports visible lifecycle transitions for repository scans

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -214,10 +214,13 @@ type Config struct {
 	AppModeWorkspaceAllowlist     []string
 	WorkerHeartbeatPath           string
 	// UserDataExportPath is the on-disk base directory for self-serve
-	// "Download my data" bundles (#1421). Empty disables the feature so
-	// dev deployments without a configured path are obvious rather than
-	// silently writing to /tmp.
-	UserDataExportPath string
+	// "Download my data" bundles (#1421). Empty disables the local-disk
+	// backend so dev deployments without a configured path are obvious rather
+	// than silently writing to /tmp.
+	UserDataExportPath     string
+	UserDataExportS3Bucket string
+	UserDataExportS3Prefix string
+	UserDataExportS3Region string
 	// WorkerUserExportGCEnabled controls whether the worker runs the
 	// retention-window GC pass for completed export bundles.
 	WorkerUserExportGCEnabled bool
@@ -339,6 +342,9 @@ func Load() Config {
 		WorkerWorkspacePurgeInterval:  durationEnv("IDENTRAIL_WORKER_WORKSPACE_PURGE_INTERVAL", defaultWorkerWorkspacePurgeInterval),
 		WorkerWorkspacePurgeBatchSize: parseInt(getEnv("IDENTRAIL_WORKER_WORKSPACE_PURGE_BATCH_SIZE", "100"), defaultWorkerWorkspacePurgeBatchSize),
 		UserDataExportPath:            strings.TrimSpace(getEnv("IDENTRAIL_USER_DATA_EXPORT_PATH", "")),
+		UserDataExportS3Bucket:        strings.TrimSpace(getEnv("IDENTRAIL_USER_DATA_EXPORT_S3_BUCKET", "")),
+		UserDataExportS3Prefix:        strings.TrimSpace(getEnv("IDENTRAIL_USER_DATA_EXPORT_S3_PREFIX", "")),
+		UserDataExportS3Region:        strings.TrimSpace(getEnv("IDENTRAIL_USER_DATA_EXPORT_S3_REGION", "")),
 		WorkerUserExportGCEnabled:     boolEnv("IDENTRAIL_WORKER_USER_EXPORT_GC_ENABLED", defaultWorkerUserExportGCEnabled),
 		WorkerUserExportGCInterval:    durationEnv("IDENTRAIL_WORKER_USER_EXPORT_GC_INTERVAL", defaultWorkerUserExportGCInterval),
 		WorkerHeartbeatPath:           strings.TrimSpace(getEnv("IDENTRAIL_WORKER_HEARTBEAT_PATH", "")),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -74,6 +74,10 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("IDENTRAIL_WORKER_API_JOB_QUEUE_ENABLED", "")
 	t.Setenv("IDENTRAIL_WORKER_API_JOB_QUEUE_INTERVAL", "")
 	t.Setenv("IDENTRAIL_WORKER_API_JOB_QUEUE_BATCH_SIZE", "")
+	t.Setenv("IDENTRAIL_USER_DATA_EXPORT_PATH", "")
+	t.Setenv("IDENTRAIL_USER_DATA_EXPORT_S3_BUCKET", "")
+	t.Setenv("IDENTRAIL_USER_DATA_EXPORT_S3_PREFIX", "")
+	t.Setenv("IDENTRAIL_USER_DATA_EXPORT_S3_REGION", "")
 	t.Setenv("IDENTRAIL_LOCK_BACKEND", "")
 	t.Setenv("IDENTRAIL_LOCK_NAMESPACE", "")
 	t.Setenv("IDENTRAIL_DEFAULT_TENANT_ID", "")
@@ -118,6 +122,9 @@ func TestLoadDefaults(t *testing.T) {
 	}
 	if cfg.AllowMemoryStore {
 		t.Fatal("expected memory store opt-in to be false by default")
+	}
+	if cfg.UserDataExportPath != "" || cfg.UserDataExportS3Bucket != "" || cfg.UserDataExportS3Prefix != "" || cfg.UserDataExportS3Region != "" {
+		t.Fatalf("expected data export storage defaults to be empty, got path=%q bucket=%q prefix=%q region=%q", cfg.UserDataExportPath, cfg.UserDataExportS3Bucket, cfg.UserDataExportS3Prefix, cfg.UserDataExportS3Region)
 	}
 	if cfg.AWSSource != defaultAWSSource {
 		t.Fatalf("expected default aws source %q, got %q", defaultAWSSource, cfg.AWSSource)
@@ -824,6 +831,24 @@ func TestParseIntAllowZero(t *testing.T) {
 	}
 	if got := parseIntAllowZero("bad", 9); got != 9 {
 		t.Fatalf("expected fallback 9, got %d", got)
+	}
+}
+
+func TestLoadUserDataExportStorageFromEnv(t *testing.T) {
+	t.Setenv("IDENTRAIL_USER_DATA_EXPORT_PATH", "")
+	t.Setenv("IDENTRAIL_USER_DATA_EXPORT_S3_BUCKET", "identrail-dev-user-data-exports")
+	t.Setenv("IDENTRAIL_USER_DATA_EXPORT_S3_PREFIX", "exports/")
+	t.Setenv("IDENTRAIL_USER_DATA_EXPORT_S3_REGION", "us-east-2")
+
+	cfg := Load()
+	if cfg.UserDataExportS3Bucket != "identrail-dev-user-data-exports" {
+		t.Fatalf("unexpected export s3 bucket %q", cfg.UserDataExportS3Bucket)
+	}
+	if cfg.UserDataExportS3Prefix != "exports/" {
+		t.Fatalf("unexpected export s3 prefix %q", cfg.UserDataExportS3Prefix)
+	}
+	if cfg.UserDataExportS3Region != "us-east-2" {
+		t.Fatalf("unexpected export s3 region %q", cfg.UserDataExportS3Region)
 	}
 }
 

--- a/internal/runtime/service_builder.go
+++ b/internal/runtime/service_builder.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/identrail/identrail/internal/api"
 	"github.com/identrail/identrail/internal/app"
 	"github.com/identrail/identrail/internal/config"
@@ -162,18 +164,14 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 		WorkspaceID: cfg.DefaultWorkspaceID,
 	}.Normalize()
 	svc.LockNamespace = strings.TrimSpace(cfg.LockNamespace)
-	// Self-serve "Download my data" (#1421). Bundle storage is opt-in via
-	// IDENTRAIL_USER_DATA_EXPORT_PATH; leaving it empty keeps the feature
-	// disabled instead of silently choosing a path the operator did not
-	// consent to. The API signs download URLs with the session key when it is
-	// configured, while workers can still build bundles without token-signing
-	// material.
-	if exportPath := strings.TrimSpace(cfg.UserDataExportPath); exportPath != "" {
-		storage, storageErr := userexport.NewLocalDiskStorage(exportPath)
-		if storageErr != nil {
-			_ = store.Close()
-			return nil, nil, fmt.Errorf("initialize user export storage: %w", storageErr)
-		}
+	// Self-serve "Download my data" (#1421). Bundle storage is opt-in via a
+	// local path for dev/test or S3 for hosted API+worker deployments.
+	storage, storageErr := buildUserExportStorage(ctx, cfg)
+	if storageErr != nil {
+		_ = store.Close()
+		return nil, nil, storageErr
+	}
+	if storage != nil {
 		svc.UserExportStorage = storage
 		if sessionKey := strings.TrimSpace(cfg.SessionKey); sessionKey != "" {
 			if keyErr := config.ValidateSessionKeyMaterial("IDENTRAIL_SESSION_KEY", sessionKey); keyErr != nil {
@@ -255,6 +253,46 @@ func BuildScanServiceWithContext(ctx context.Context, cfg config.Config) (*api.S
 func parseInt64Config(value string) int64 {
 	parsed, _ := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
 	return parsed
+}
+
+func buildUserExportStorage(ctx context.Context, cfg config.Config) (userexport.Storage, error) {
+	exportPath := strings.TrimSpace(cfg.UserDataExportPath)
+	exportBucket := strings.TrimSpace(cfg.UserDataExportS3Bucket)
+	if exportPath != "" && exportBucket != "" {
+		return nil, fmt.Errorf("IDENTRAIL_USER_DATA_EXPORT_PATH and IDENTRAIL_USER_DATA_EXPORT_S3_BUCKET cannot both be set")
+	}
+	if exportBucket != "" {
+		loadOptions := []func(*awsconfig.LoadOptions) error{}
+		if region := firstNonEmpty(cfg.UserDataExportS3Region, cfg.AWSRegion); region != "" {
+			loadOptions = append(loadOptions, awsconfig.WithRegion(region))
+		}
+		awsCfg, err := awsconfig.LoadDefaultConfig(ctx, loadOptions...)
+		if err != nil {
+			return nil, fmt.Errorf("initialize user export s3 config: %w", err)
+		}
+		storage, err := userexport.NewS3Storage(s3.NewFromConfig(awsCfg), exportBucket, cfg.UserDataExportS3Prefix)
+		if err != nil {
+			return nil, fmt.Errorf("initialize user export s3 storage: %w", err)
+		}
+		return storage, nil
+	}
+	if exportPath != "" {
+		storage, err := userexport.NewLocalDiskStorage(exportPath)
+		if err != nil {
+			return nil, fmt.Errorf("initialize user export storage: %w", err)
+		}
+		return storage, nil
+	}
+	return nil, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }
 
 func newAWSScanner(iamAPI awsprovider.IAMAPI, accountID string, region string) app.Scanner {

--- a/internal/runtime/service_builder_test.go
+++ b/internal/runtime/service_builder_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	goruntime "runtime"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/identrail/identrail/internal/config"
 	"github.com/identrail/identrail/internal/providers/aws"
 	"github.com/identrail/identrail/internal/scheduler"
+	"github.com/identrail/identrail/internal/userexport"
 )
 
 func TestBuildScanServiceMemoryStore(t *testing.T) {
@@ -129,6 +131,44 @@ func TestBuildScanServiceRejectsWeakUserExportSigningKey(t *testing.T) {
 	}
 	if _, _, err := BuildScanService(cfg); err == nil {
 		t.Fatal("expected weak export signing key error")
+	}
+}
+
+func TestBuildScanServiceInitializesS3UserExportStorage(t *testing.T) {
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	cfg := config.Config{
+		Provider:               "aws",
+		AllowMemoryStore:       true,
+		AWSFixturePath:         []string{"testdata/aws/role_with_policies.json"},
+		AWSRegion:              "us-east-1",
+		UserDataExportS3Bucket: "identrail-dev-user-data-exports",
+		UserDataExportS3Prefix: "exports/",
+		UserDataExportS3Region: "us-east-1",
+	}
+	svc, closeFn, err := BuildScanService(cfg)
+	if err != nil {
+		t.Fatalf("build service failed: %v", err)
+	}
+	defer func() { _ = closeFn() }()
+	storage, ok := svc.UserExportStorage.(*userexport.S3Storage)
+	if !ok {
+		t.Fatalf("expected s3 export storage, got %T", svc.UserExportStorage)
+	}
+	if storage.Bucket != "identrail-dev-user-data-exports" || storage.Prefix != "exports/" {
+		t.Fatalf("unexpected s3 storage bucket=%q prefix=%q", storage.Bucket, storage.Prefix)
+	}
+}
+
+func TestBuildScanServiceRejectsMultipleUserExportStorageBackends(t *testing.T) {
+	cfg := config.Config{
+		Provider:               "aws",
+		AllowMemoryStore:       true,
+		AWSFixturePath:         []string{"testdata/aws/role_with_policies.json"},
+		UserDataExportPath:     filepath.Join(t.TempDir(), "exports"),
+		UserDataExportS3Bucket: "identrail-dev-user-data-exports",
+	}
+	if _, _, err := BuildScanService(cfg); err == nil || !strings.Contains(err.Error(), "cannot both be set") {
+		t.Fatalf("expected multiple export backend error, got %v", err)
 	}
 }
 

--- a/internal/userexport/gc.go
+++ b/internal/userexport/gc.go
@@ -60,7 +60,7 @@ func (g *GCRunner) RunOnce(ctx context.Context) (GCResult, error) {
 		// the next pass picks the row up again and Delete is a no-op for a
 		// missing file — net effect is one retried DB write, no leaked bytes.
 		key := StorageKey(job)
-		if delErr := g.Storage.Delete(key); delErr != nil {
+		if delErr := g.Storage.Delete(ctx, key); delErr != nil {
 			result.Errors++
 			continue
 		}

--- a/internal/userexport/gc_test.go
+++ b/internal/userexport/gc_test.go
@@ -154,7 +154,7 @@ func TestGCRunnerHandlesMarkErrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("storage: %v", err)
 	}
-	if err := storage.Delete(userexport.StorageKey(job)); err != nil {
+	if err := storage.Delete(context.Background(), userexport.StorageKey(job)); err != nil {
 		t.Fatalf("cleanup: %v", err)
 	}
 	result, err := (&userexport.GCRunner{
@@ -223,28 +223,28 @@ type failingStorage struct {
 	err error
 }
 
-func (s *failingStorage) Put(string, io.Reader) (string, error) {
+func (s *failingStorage) Put(_ context.Context, _ string, _ io.Reader) (string, error) {
 	return "", s.err
 }
 
-func (s *failingStorage) Open(string) (io.ReadCloser, error) {
+func (s *failingStorage) Open(_ context.Context, _ string) (io.ReadCloser, error) {
 	return nil, s.err
 }
 
-func (s *failingStorage) Delete(string) error {
+func (s *failingStorage) Delete(_ context.Context, _ string) error {
 	return s.err
 }
 
 type fakeStorage struct{}
 
-func (s *fakeStorage) Put(string, io.Reader) (string, error) {
+func (s *fakeStorage) Put(_ context.Context, _ string, _ io.Reader) (string, error) {
 	return "", nil
 }
 
-func (s *fakeStorage) Open(string) (io.ReadCloser, error) {
+func (s *fakeStorage) Open(_ context.Context, _ string) (io.ReadCloser, error) {
 	return nil, nil
 }
 
-func (s *fakeStorage) Delete(string) error {
+func (s *fakeStorage) Delete(_ context.Context, _ string) error {
 	return nil
 }

--- a/internal/userexport/queue.go
+++ b/internal/userexport/queue.go
@@ -68,7 +68,7 @@ func (q *QueueRunner) RunOnce(ctx context.Context) (QueueResult, error) {
 	}
 	result.StaleFailed = len(staleFailed)
 	for _, job := range staleFailed {
-		if err := q.Runner.Storage.Delete(StorageKey(job)); err != nil {
+		if err := q.Runner.Storage.Delete(ctx, StorageKey(job)); err != nil {
 			// Best effort: mark stale jobs as failed first so the worker UI can
 			// progress, even if cleanup gets delayed or a backend mount is unavailable.
 			continue

--- a/internal/userexport/queue_test.go
+++ b/internal/userexport/queue_test.go
@@ -243,7 +243,7 @@ type testStorage struct {
 	deleteErr error
 }
 
-func (s *testStorage) Put(key string, r io.Reader) (string, error) {
+func (s *testStorage) Put(_ context.Context, key string, r io.Reader) (string, error) {
 	contents, err := io.ReadAll(r)
 	if err != nil {
 		return "", err
@@ -252,7 +252,7 @@ func (s *testStorage) Put(key string, r io.Reader) (string, error) {
 	return key, nil
 }
 
-func (s *testStorage) Open(key string) (io.ReadCloser, error) {
+func (s *testStorage) Open(_ context.Context, key string) (io.ReadCloser, error) {
 	contents, ok := s.stored[key]
 	if !ok {
 		return nil, os.ErrNotExist
@@ -260,7 +260,7 @@ func (s *testStorage) Open(key string) (io.ReadCloser, error) {
 	return io.NopCloser(bytes.NewReader(contents)), nil
 }
 
-func (s *testStorage) Delete(key string) error {
+func (s *testStorage) Delete(_ context.Context, key string) error {
 	if s.deleteErr != nil {
 		return s.deleteErr
 	}

--- a/internal/userexport/runner.go
+++ b/internal/userexport/runner.go
@@ -47,7 +47,7 @@ func (r *Runner) Run(ctx context.Context, job db.UserDataExport) (db.UserDataExp
 		return r.fail(ctx, job, fmt.Errorf("build bundle: %w", buildErr), now)
 	}
 	key := StorageKey(job)
-	path, putErr := r.Storage.Put(key, bytes.NewReader(buf.Bytes()))
+	path, putErr := r.Storage.Put(ctx, key, bytes.NewReader(buf.Bytes()))
 	if putErr != nil {
 		return r.fail(ctx, job, fmt.Errorf("write bundle: %w", putErr), now)
 	}
@@ -56,7 +56,7 @@ func (r *Runner) Run(ctx context.Context, job db.UserDataExport) (db.UserDataExp
 	saved, err := r.Store.CompleteUserDataExport(ctx, job.ID, path, result.SizeBytes, result.SHA256, now, expiresAt, purgeAfter)
 	if err != nil {
 		completeErr := fmt.Errorf("complete job: %w", err)
-		deleteErr := r.Storage.Delete(key)
+		deleteErr := r.Storage.Delete(ctx, key)
 		if _, failErr := r.Store.FailUserDataExport(ctx, job.ID, completeErr.Error(), now); failErr != nil {
 			if deleteErr != nil {
 				return db.UserDataExport{}, fmt.Errorf("%w (and could not mark job failed: %v; and could not delete export bundle: %v)", completeErr, failErr, deleteErr)

--- a/internal/userexport/runner_test.go
+++ b/internal/userexport/runner_test.go
@@ -50,7 +50,7 @@ func TestRunnerHappyPath(t *testing.T) {
 	if saved.PurgeAfter == nil || !saved.PurgeAfter.After(*saved.DownloadExpiresAt) {
 		t.Fatalf("purge after must be later than download expiry: %+v", saved)
 	}
-	rc, err := storage.Open(userexport.StorageKey(saved))
+	rc, err := storage.Open(context.Background(), userexport.StorageKey(saved))
 	if err != nil {
 		t.Fatalf("open bundle: %v", err)
 	}
@@ -122,7 +122,7 @@ func TestRunnerMarksFailedWhenCompletionWriteFails(t *testing.T) {
 	if saved.Status != db.UserDataExportStatusFailed {
 		t.Fatalf("expected failed after completion write error, got %+v", saved)
 	}
-	if _, err := storage.Open(userexport.StorageKey(job)); err == nil {
+	if _, err := storage.Open(context.Background(), userexport.StorageKey(job)); err == nil {
 		t.Fatal("expected bundle to be deleted after failed completion write")
 	}
 }
@@ -152,7 +152,7 @@ func TestRunnerDeletesBundleEvenWhenFailureMarkFails(t *testing.T) {
 	if _, err := runner.Run(context.Background(), job); err == nil {
 		t.Fatal("expected completion write + mark error")
 	}
-	if _, err := storage.Open(userexport.StorageKey(job)); err == nil {
+	if _, err := storage.Open(context.Background(), userexport.StorageKey(job)); err == nil {
 		t.Fatal("expected bundle to be deleted when failure marking also fails")
 	}
 }

--- a/internal/userexport/s3_storage.go
+++ b/internal/userexport/s3_storage.go
@@ -1,0 +1,120 @@
+package userexport
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// S3API is the subset of the AWS S3 client used by S3Storage.
+type S3API interface {
+	PutObject(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+	GetObject(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	DeleteObject(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+}
+
+// S3Storage persists bundles in S3 so API and worker tasks can share completed
+// exports across process and host boundaries.
+type S3Storage struct {
+	Client S3API
+	Bucket string
+	Prefix string
+}
+
+// NewS3Storage returns a storage backend rooted at bucket/prefix.
+func NewS3Storage(client S3API, bucket string, prefix string) (*S3Storage, error) {
+	if client == nil {
+		return nil, errors.New("userexport: s3 client is required")
+	}
+	bucket = strings.TrimSpace(bucket)
+	if bucket == "" {
+		return nil, errors.New("userexport: s3 bucket is required")
+	}
+	return &S3Storage{
+		Client: client,
+		Bucket: bucket,
+		Prefix: normalizeS3Prefix(prefix),
+	}, nil
+}
+
+// Put writes a bundle to S3 and returns its object URI.
+func (s *S3Storage) Put(key string, r io.Reader) (string, error) {
+	objectKey, err := s.objectKey(key)
+	if err != nil {
+		return "", err
+	}
+	if r == nil {
+		r = bytes.NewReader(nil)
+	}
+	_, err = s.Client.PutObject(context.Background(), &s3.PutObjectInput{
+		Bucket:      aws.String(s.Bucket),
+		Key:         aws.String(objectKey),
+		Body:        r,
+		ContentType: aws.String("application/zip"),
+	})
+	if err != nil {
+		return "", fmt.Errorf("put export object: %w", err)
+	}
+	return "s3://" + s.Bucket + "/" + objectKey, nil
+}
+
+// Open returns a read handle for an existing S3 bundle.
+func (s *S3Storage) Open(key string) (io.ReadCloser, error) {
+	objectKey, err := s.objectKey(key)
+	if err != nil {
+		return nil, err
+	}
+	out, err := s.Client.GetObject(context.Background(), &s3.GetObjectInput{
+		Bucket: aws.String(s.Bucket),
+		Key:    aws.String(objectKey),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("open export object: %w", err)
+	}
+	return out.Body, nil
+}
+
+// Delete removes a bundle. S3 DeleteObject is idempotent for missing keys.
+func (s *S3Storage) Delete(key string) error {
+	objectKey, err := s.objectKey(key)
+	if err != nil {
+		return err
+	}
+	if _, err := s.Client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+		Bucket: aws.String(s.Bucket),
+		Key:    aws.String(objectKey),
+	}); err != nil {
+		return fmt.Errorf("delete export object: %w", err)
+	}
+	return nil
+}
+
+func (s *S3Storage) objectKey(key string) (string, error) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return "", errors.New("userexport: key is required")
+	}
+	if strings.Contains(key, "..") || strings.HasPrefix(key, "/") || strings.Contains(key, "\x00") {
+		return "", fmt.Errorf("userexport: invalid key %q", key)
+	}
+	cleaned := path.Clean(key)
+	if cleaned == "." || strings.HasPrefix(cleaned, "../") || cleaned == ".." {
+		return "", fmt.Errorf("userexport: invalid key %q", key)
+	}
+	return s.Prefix + cleaned, nil
+}
+
+func normalizeS3Prefix(prefix string) string {
+	prefix = strings.Trim(strings.TrimSpace(prefix), "/")
+	if prefix == "" {
+		return ""
+	}
+	return path.Clean(prefix) + "/"
+}

--- a/internal/userexport/s3_storage.go
+++ b/internal/userexport/s3_storage.go
@@ -45,7 +45,7 @@ func NewS3Storage(client S3API, bucket string, prefix string) (*S3Storage, error
 }
 
 // Put writes a bundle to S3 and returns its object URI.
-func (s *S3Storage) Put(key string, r io.Reader) (string, error) {
+func (s *S3Storage) Put(ctx context.Context, key string, r io.Reader) (string, error) {
 	objectKey, err := s.objectKey(key)
 	if err != nil {
 		return "", err
@@ -53,7 +53,10 @@ func (s *S3Storage) Put(key string, r io.Reader) (string, error) {
 	if r == nil {
 		r = bytes.NewReader(nil)
 	}
-	_, err = s.Client.PutObject(context.Background(), &s3.PutObjectInput{
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	_, err = s.Client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:      aws.String(s.Bucket),
 		Key:         aws.String(objectKey),
 		Body:        r,
@@ -66,12 +69,15 @@ func (s *S3Storage) Put(key string, r io.Reader) (string, error) {
 }
 
 // Open returns a read handle for an existing S3 bundle.
-func (s *S3Storage) Open(key string) (io.ReadCloser, error) {
+func (s *S3Storage) Open(ctx context.Context, key string) (io.ReadCloser, error) {
 	objectKey, err := s.objectKey(key)
 	if err != nil {
 		return nil, err
 	}
-	out, err := s.Client.GetObject(context.Background(), &s3.GetObjectInput{
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	out, err := s.Client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(s.Bucket),
 		Key:    aws.String(objectKey),
 	})
@@ -82,12 +88,15 @@ func (s *S3Storage) Open(key string) (io.ReadCloser, error) {
 }
 
 // Delete removes a bundle. S3 DeleteObject is idempotent for missing keys.
-func (s *S3Storage) Delete(key string) error {
+func (s *S3Storage) Delete(ctx context.Context, key string) error {
 	objectKey, err := s.objectKey(key)
 	if err != nil {
 		return err
 	}
-	if _, err := s.Client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, err := s.Client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(s.Bucket),
 		Key:    aws.String(objectKey),
 	}); err != nil {

--- a/internal/userexport/s3_storage_test.go
+++ b/internal/userexport/s3_storage_test.go
@@ -1,0 +1,112 @@
+package userexport_test
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/identrail/identrail/internal/userexport"
+)
+
+type fakeS3Client struct {
+	putBucket    string
+	putKey       string
+	putBody      string
+	getBucket    string
+	getKey       string
+	deleteBucket string
+	deleteKey    string
+}
+
+func (f *fakeS3Client) PutObject(_ context.Context, input *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	f.putBucket = *input.Bucket
+	f.putKey = *input.Key
+	if input.Body != nil {
+		body, err := io.ReadAll(input.Body)
+		if err != nil {
+			return nil, err
+		}
+		f.putBody = string(body)
+	}
+	return &s3.PutObjectOutput{}, nil
+}
+
+func (f *fakeS3Client) GetObject(_ context.Context, input *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	f.getBucket = *input.Bucket
+	f.getKey = *input.Key
+	return &s3.GetObjectOutput{Body: io.NopCloser(strings.NewReader("bundle"))}, nil
+}
+
+func (f *fakeS3Client) DeleteObject(_ context.Context, input *s3.DeleteObjectInput, _ ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+	f.deleteBucket = *input.Bucket
+	f.deleteKey = *input.Key
+	return &s3.DeleteObjectOutput{}, nil
+}
+
+func TestS3StorageRejectsInvalidInputs(t *testing.T) {
+	if _, err := userexport.NewS3Storage(nil, "bucket", "prefix"); err == nil {
+		t.Fatal("expected missing client error")
+	}
+	storage, err := userexport.NewS3Storage(&fakeS3Client{}, "  ", "prefix")
+	if err == nil || storage != nil {
+		t.Fatal("expected blank bucket error")
+	}
+	storage, err = userexport.NewS3Storage(&fakeS3Client{}, "exports", "prefix")
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	for _, key := range []string{"", " ../escape.zip ", "/absolute.zip", "nested/../escape.zip", "bad\x00key.zip"} {
+		if _, err := storage.Put(key, strings.NewReader("data")); err == nil {
+			t.Fatalf("expected Put to reject key %q", key)
+		}
+		if _, err := storage.Open(key); err == nil {
+			t.Fatalf("expected Open to reject key %q", key)
+		}
+		if err := storage.Delete(key); err == nil {
+			t.Fatalf("expected Delete to reject key %q", key)
+		}
+	}
+}
+
+func TestS3StorageRoundTrip(t *testing.T) {
+	client := &fakeS3Client{}
+	storage, err := userexport.NewS3Storage(client, "exports", "/tenant-data/")
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	location, err := storage.Put("user/job.zip", strings.NewReader("bundle"))
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if location != "s3://exports/tenant-data/user/job.zip" {
+		t.Fatalf("unexpected location %q", location)
+	}
+	if client.putBucket != "exports" || client.putKey != "tenant-data/user/job.zip" || client.putBody != "bundle" {
+		t.Fatalf("unexpected put bucket=%q key=%q body=%q", client.putBucket, client.putKey, client.putBody)
+	}
+
+	rc, err := storage.Open("user/job.zip")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	body, err := io.ReadAll(rc)
+	rc.Close()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(body) != "bundle" {
+		t.Fatalf("unexpected body %q", body)
+	}
+	if client.getBucket != "exports" || client.getKey != "tenant-data/user/job.zip" {
+		t.Fatalf("unexpected get bucket=%q key=%q", client.getBucket, client.getKey)
+	}
+
+	if err := storage.Delete("user/job.zip"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if client.deleteBucket != "exports" || client.deleteKey != "tenant-data/user/job.zip" {
+		t.Fatalf("unexpected delete bucket=%q key=%q", client.deleteBucket, client.deleteKey)
+	}
+}

--- a/internal/userexport/s3_storage_test.go
+++ b/internal/userexport/s3_storage_test.go
@@ -58,13 +58,13 @@ func TestS3StorageRejectsInvalidInputs(t *testing.T) {
 		t.Fatalf("storage: %v", err)
 	}
 	for _, key := range []string{"", " ../escape.zip ", "/absolute.zip", "nested/../escape.zip", "bad\x00key.zip"} {
-		if _, err := storage.Put(key, strings.NewReader("data")); err == nil {
+		if _, err := storage.Put(context.Background(), key, strings.NewReader("data")); err == nil {
 			t.Fatalf("expected Put to reject key %q", key)
 		}
-		if _, err := storage.Open(key); err == nil {
+		if _, err := storage.Open(context.Background(), key); err == nil {
 			t.Fatalf("expected Open to reject key %q", key)
 		}
-		if err := storage.Delete(key); err == nil {
+		if err := storage.Delete(context.Background(), key); err == nil {
 			t.Fatalf("expected Delete to reject key %q", key)
 		}
 	}
@@ -76,7 +76,7 @@ func TestS3StorageRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("storage: %v", err)
 	}
-	location, err := storage.Put("user/job.zip", strings.NewReader("bundle"))
+	location, err := storage.Put(context.Background(), "user/job.zip", strings.NewReader("bundle"))
 	if err != nil {
 		t.Fatalf("put: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestS3StorageRoundTrip(t *testing.T) {
 		t.Fatalf("unexpected put bucket=%q key=%q body=%q", client.putBucket, client.putKey, client.putBody)
 	}
 
-	rc, err := storage.Open("user/job.zip")
+	rc, err := storage.Open(context.Background(), "user/job.zip")
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestS3StorageRoundTrip(t *testing.T) {
 		t.Fatalf("unexpected get bucket=%q key=%q", client.getBucket, client.getKey)
 	}
 
-	if err := storage.Delete("user/job.zip"); err != nil {
+	if err := storage.Delete(context.Background(), "user/job.zip"); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
 	if client.deleteBucket != "exports" || client.deleteKey != "tenant-data/user/job.zip" {

--- a/internal/userexport/storage.go
+++ b/internal/userexport/storage.go
@@ -1,6 +1,7 @@
 package userexport
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -15,12 +16,12 @@ import (
 // adapter can be added later without touching API/worker code.
 type Storage interface {
 	// Put writes the bundle from r at the given key.
-	Put(key string, r io.Reader) (string, error)
+	Put(ctx context.Context, key string, r io.Reader) (string, error)
 	// Open returns a read handle for a bundle previously written via Put.
-	Open(key string) (io.ReadCloser, error)
+	Open(ctx context.Context, key string) (io.ReadCloser, error)
 	// Delete removes the bundle. Missing keys must not error so the worker
 	// can re-run after a crash without spurious failures.
-	Delete(key string) error
+	Delete(ctx context.Context, key string) error
 }
 
 // LocalDiskStorage persists bundles under a base directory. Files are
@@ -44,7 +45,7 @@ func NewLocalDiskStorage(baseDir string) (*LocalDiskStorage, error) {
 }
 
 // Put writes a bundle from r to baseDir/key and returns the absolute path.
-func (s *LocalDiskStorage) Put(key string, r io.Reader) (path string, err error) {
+func (s *LocalDiskStorage) Put(_ context.Context, key string, r io.Reader) (path string, err error) {
 	path, err = s.resolve(key)
 	if err != nil {
 		return "", err
@@ -71,7 +72,7 @@ func (s *LocalDiskStorage) Put(key string, r io.Reader) (path string, err error)
 }
 
 // Open returns a read handle for an existing bundle.
-func (s *LocalDiskStorage) Open(key string) (io.ReadCloser, error) {
+func (s *LocalDiskStorage) Open(_ context.Context, key string) (io.ReadCloser, error) {
 	path, err := s.resolve(key)
 	if err != nil {
 		return nil, err
@@ -80,7 +81,7 @@ func (s *LocalDiskStorage) Open(key string) (io.ReadCloser, error) {
 }
 
 // Delete removes a bundle. Missing files are not an error.
-func (s *LocalDiskStorage) Delete(key string) error {
+func (s *LocalDiskStorage) Delete(_ context.Context, key string) error {
 	path, err := s.resolve(key)
 	if err != nil {
 		return err

--- a/internal/userexport/storage_test.go
+++ b/internal/userexport/storage_test.go
@@ -1,6 +1,7 @@
 package userexport_test
 
 import (
+	"context"
 	"io"
 	"path/filepath"
 	"strings"
@@ -18,13 +19,13 @@ func TestLocalDiskStorageRejectsInvalidInputs(t *testing.T) {
 		t.Fatalf("storage: %v", err)
 	}
 	for _, key := range []string{"", " ../escape.zip ", "/absolute.zip", "nested/../escape.zip", "bad\x00key.zip"} {
-		if _, err := storage.Put(key, strings.NewReader("data")); err == nil {
+		if _, err := storage.Put(context.Background(), key, strings.NewReader("data")); err == nil {
 			t.Fatalf("expected Put to reject key %q", key)
 		}
-		if _, err := storage.Open(key); err == nil {
+		if _, err := storage.Open(context.Background(), key); err == nil {
 			t.Fatalf("expected Open to reject key %q", key)
 		}
-		if err := storage.Delete(key); err == nil {
+		if err := storage.Delete(context.Background(), key); err == nil {
 			t.Fatalf("expected Delete to reject key %q", key)
 		}
 	}
@@ -35,14 +36,14 @@ func TestLocalDiskStorageRoundTripAndDeleteMissing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("storage: %v", err)
 	}
-	path, err := storage.Put("user/job.zip", strings.NewReader("bundle"))
+	path, err := storage.Put(context.Background(), "user/job.zip", strings.NewReader("bundle"))
 	if err != nil {
 		t.Fatalf("put: %v", err)
 	}
 	if !strings.HasSuffix(path, filepath.Join("user", "job.zip")) {
 		t.Fatalf("unexpected storage path: %s", path)
 	}
-	rc, err := storage.Open("user/job.zip")
+	rc, err := storage.Open(context.Background(), "user/job.zip")
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -54,10 +55,10 @@ func TestLocalDiskStorageRoundTripAndDeleteMissing(t *testing.T) {
 	if string(body) != "bundle" {
 		t.Fatalf("unexpected body %q", body)
 	}
-	if err := storage.Delete("user/job.zip"); err != nil {
+	if err := storage.Delete(context.Background(), "user/job.zip"); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
-	if err := storage.Delete("user/job.zip"); err != nil {
+	if err := storage.Delete(context.Background(), "user/job.zip"); err != nil {
 		t.Fatalf("delete missing should be idempotent: %v", err)
 	}
 }

--- a/internal/userexport/userexport_test.go
+++ b/internal/userexport/userexport_test.go
@@ -86,7 +86,7 @@ type fakeStorage struct {
 	deletedKeys []string
 }
 
-func (s *fakeStorage) Put(key string, r io.Reader) (string, error) {
+func (s *fakeStorage) Put(_ context.Context, key string, r io.Reader) (string, error) {
 	if s.stored == nil {
 		s.stored = map[string][]byte{}
 	}
@@ -101,7 +101,7 @@ func (s *fakeStorage) Put(key string, r io.Reader) (string, error) {
 	return key, nil
 }
 
-func (s *fakeStorage) Open(key string) (io.ReadCloser, error) {
+func (s *fakeStorage) Open(_ context.Context, key string) (io.ReadCloser, error) {
 	s.openedKeys = append(s.openedKeys, key)
 	if s.openErr != nil {
 		return nil, s.openErr
@@ -113,7 +113,7 @@ func (s *fakeStorage) Open(key string) (io.ReadCloser, error) {
 	return io.NopCloser(bytes.NewReader(contents)), nil
 }
 
-func (s *fakeStorage) Delete(key string) error {
+func (s *fakeStorage) Delete(_ context.Context, key string) error {
 	s.deletedKeys = append(s.deletedKeys, key)
 	if s.deleteErr != nil {
 		return s.deleteErr
@@ -373,17 +373,17 @@ func TestStoragePutOpenDeleteFlow(t *testing.T) {
 		t.Fatalf("new storage: %v", err)
 	}
 
-	if _, err := storage.Put("../bad", strings.NewReader("x")); err == nil {
+	if _, err := storage.Put(context.Background(), "../bad", strings.NewReader("x")); err == nil {
 		t.Fatalf("expected invalid key rejection")
 	}
-	path, err := storage.Put("user-a/export.zip", strings.NewReader("export"))
+	path, err := storage.Put(context.Background(), "user-a/export.zip", strings.NewReader("export"))
 	if err != nil {
 		t.Fatalf("put: %v", err)
 	}
 	if want := filepath.Join(temp, "user-a", "export.zip"); path != want {
 		t.Fatalf("expected path %s got %s", want, path)
 	}
-	f, err := storage.Open("user-a/export.zip")
+	f, err := storage.Open(context.Background(), "user-a/export.zip")
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -398,14 +398,14 @@ func TestStoragePutOpenDeleteFlow(t *testing.T) {
 		t.Fatalf("close: %v", err)
 	}
 
-	if err := storage.Delete("user-a/export.zip"); err != nil {
+	if err := storage.Delete(context.Background(), "user-a/export.zip"); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
-	if _, err := storage.Open("user-a/export.zip"); err == nil {
+	if _, err := storage.Open(context.Background(), "user-a/export.zip"); err == nil {
 		t.Fatalf("expected file deleted")
 	}
 
-	if err := storage.Delete("user-a/missing.zip"); err != nil {
+	if err := storage.Delete(context.Background(), "user-a/missing.zip"); err != nil {
 		t.Fatalf("delete missing should be no-op")
 	}
 	if _, err := NewLocalDiskStorage("   "); err == nil {
@@ -420,7 +420,7 @@ func TestStorageCloseErrorPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new storage: %v", err)
 	}
-	if _, err := storage.Put("user-a/data", readerErr); err == nil {
+	if _, err := storage.Put(context.Background(), "user-a/data", readerErr); err == nil {
 		t.Fatalf("expected io copy error")
 	}
 }

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -2632,7 +2632,9 @@ describe('App', () => {
     const exportRow = await screen.findByTestId('idt-export-account-row');
     fireEvent.click(within(exportRow).getByRole('button', { name: /Download my data/i }));
 
-    expect(await within(exportRow).findByRole('alert')).toHaveTextContent(/data export is not configured/i);
+    expect(await within(exportRow).findByRole('alert')).toHaveTextContent(
+      'Data export is not available on this deployment yet.'
+    );
     expect(screen.getByRole('heading', { level: 2, name: /Settings/i })).toBeInTheDocument();
   });
 
@@ -2649,7 +2651,7 @@ describe('App', () => {
     fireEvent.click(within(exportRow).getByRole('button', { name: /Download my data/i }));
 
     expect(await within(exportRow).findByRole('alert')).toHaveTextContent(
-      'Data export is not available on this deployment yet. Deploy the latest API image, then try again.'
+      'Data export is not available on this deployment yet.'
     );
     expect(screen.getByRole('heading', { level: 2, name: /Settings/i })).toBeInTheDocument();
   });
@@ -2667,7 +2669,7 @@ describe('App', () => {
     fireEvent.click(within(exportRow).getByRole('button', { name: /Download my data/i }));
 
     expect(await within(exportRow).findByRole('alert')).toHaveTextContent('export job not found');
-    expect(within(exportRow).getByRole('alert')).not.toHaveTextContent('Deploy the latest API image');
+    expect(within(exportRow).getByRole('alert')).not.toHaveTextContent('deployment');
   });
 
   it('highlights the suspend confirmation phrase distinctly', async () => {

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -15939,8 +15939,12 @@ function isAbortError(err: unknown): boolean {
 }
 
 function formatDataExportError(err: unknown): string {
-  if (err instanceof ApiError && err.status === 404 && err.payload === undefined) {
-    return 'Data export is not available on this deployment yet. Deploy the latest API image, then try again.';
+  if (
+    err instanceof ApiError &&
+    ((err.status === 404 && err.payload === undefined) ||
+      (err.status === 503 && /data export is not configured/i.test(err.message)))
+  ) {
+    return 'Data export is not available on this deployment yet.';
   }
   return err instanceof Error ? err.message : 'Unable to start the export.';
 }


### PR DESCRIPTION
Closes #1387

## Summary
- add S3-backed storage for self-serve user data export bundles
- wire the AWS hosted API/worker Terraform to create a private encrypted export bucket with short retention and least-privilege access
- replace the raw deployment error in Settings with a concise product message

## What users download
The ZIP contains manifest.json, user.json, workspaces.json, audit.json, and sessions.json. It does not include session token material or session ID hashes.

## Validation
- go test ./internal/userexport ./internal/config ./internal/runtime ./internal/api
- npm run test --prefix web -- --run src/App.test.tsx
- npm run build --prefix web
- terraform -chdir=deploy/aws/terraform fmt -check -recursive
- terraform -chdir=deploy/aws/terraform validate
- terraform -chdir=deploy/aws/terraform plan -refresh=false -input=false -var-file=environments/dev/terraform.tfvars.example
- live browser check of Settings > Download my data with a 503 mock API response

AI disclosure: No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables hosted “Download my data” by storing export ZIPs in S3 and provisioning a private, short‑retention bucket in Terraform. Adds a safe, context‑aware S3 storage backend and a simpler Settings message when exports aren’t available.

- New Features
  - Terraform: creates a private, encrypted S3 bucket with public access blocked, prefix‑scoped IAM for API/worker, and lifecycle expiry (default 8 days). Wires `IDENTRAIL_USER_DATA_EXPORT_S3_*`, validates bucket/prefix/retention, exposes `user_data_export_bucket_name`, creates the bucket only when API and worker hosting are enabled, and guards `aws_caller_identity` lookup when an explicit bucket name is set.
  - Runtime/UI: adds an S3 storage backend (local path remains for dev/test). Storage ops take `context.Context`, sanitize S3 keys/prefixes, reject configs that set both backends, and auto‑configure region from `IDENTRAIL_USER_DATA_EXPORT_S3_REGION` or `IDENTRAIL_AWS_REGION`. API/worker use contexts end‑to‑end for storage and cleanup. The Settings error is simplified and now covers 404 (unconfigured) and 503 responses.

- Dependencies
  - Add `github.com/aws/aws-sdk-go-v2/service/s3` (and related indirect modules).

<sup>Written for commit 7245b167b5cab2fb20b406a62a69bcbe1f2bf175. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

