### PR TITLE
Add interaction feedback polish

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -2758,7 +2758,7 @@ describe('App', () => {
     fireEvent.change(within(modal).getByLabelText(/Confirm primary email/i), {
       target: { value: 'owner@example.com' }
     });
-    fireEvent.click(within(modal).getByRole('button', { name: 'Delete account' }));
+    fireEvent.click(within(modal).getByRole('button', { name: 'Hold Delete account' }));
 
     const blocker = await within(modal).findByTestId('idt-delete-sole-owner-workspaces');
     expect(blocker).toHaveTextContent(/Transfer ownership for these workspaces/i);

--- a/web/src/components/app/DomainFoundation.test.tsx
+++ b/web/src/components/app/DomainFoundation.test.tsx
@@ -393,6 +393,22 @@ describe('DomainFoundation', () => {
     expect(document.activeElement).toBe(opener);
   });
 
+  it('closes the drawer when swiped off screen on touch devices', () => {
+    const onClose = vi.fn();
+    render(
+      <DomainDetailDrawer open title="Identity detail" onClose={onClose}>
+        <p>payload</p>
+      </DomainDetailDrawer>
+    );
+
+    const drawer = screen.getByText('payload').closest('.idt-domain-drawer')!;
+    fireEvent.pointerDown(drawer, { button: 0, clientX: 20, clientY: 12, pointerId: 1, pointerType: 'touch' });
+    fireEvent.pointerMove(drawer, { clientX: 180, clientY: 16, pointerId: 1, pointerType: 'touch' });
+    fireEvent.pointerUp(drawer, { clientX: 180, clientY: 16, pointerId: 1, pointerType: 'touch' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   it('does not render the drawer when closed', () => {
     const { queryByRole } = render(
       <DomainDetailDrawer open={false} title="Hidden" onClose={() => undefined}>

--- a/web/src/components/app/DomainFoundation.tsx
+++ b/web/src/components/app/DomainFoundation.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useId, useRef } from 'react';
-import type { FormEvent, KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import type { CSSProperties, FormEvent, KeyboardEvent as ReactKeyboardEvent, PointerEvent as ReactPointerEvent, ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { DOMAIN_ASSET_ORDER, getDomainAsset, type DomainAssetKey } from '../../design/domainAssets';
 
@@ -848,6 +848,16 @@ export function DomainDetailDrawer({
 }) {
   const drawerRef = useRef<HTMLElement | null>(null);
   const restoreFocusRef = useRef<HTMLElement | null>(null);
+  const [dragOffset, setDragOffset] = useState(0);
+  const [isSwiping, setIsSwiping] = useState(false);
+  const dragOffsetRef = useRef(0);
+  const dragRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    startTime: number;
+    active: boolean;
+  } | null>(null);
 
   const onCloseRef = useRef(onClose);
   useEffect(() => {
@@ -864,6 +874,15 @@ export function DomainDetailDrawer({
     return () => {
       restoreFocusRef.current?.focus?.();
     };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) {
+      setDragOffset(0);
+      dragOffsetRef.current = 0;
+      setIsSwiping(false);
+      dragRef.current = null;
+    }
   }, [open]);
 
   const handleKeyDown = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
@@ -897,13 +916,88 @@ export function DomainDetailDrawer({
     }
   }, []);
 
+  const finishSwipe = useCallback((event?: ReactPointerEvent<HTMLElement>) => {
+    const drag = dragRef.current;
+    if (!drag) {
+      return;
+    }
+    const finalOffset = dragOffsetRef.current;
+    const elapsed = Math.max(1, Date.now() - drag.startTime);
+    const velocity = finalOffset / elapsed;
+    dragRef.current = null;
+    event?.currentTarget.releasePointerCapture?.(drag.pointerId);
+    setIsSwiping(false);
+    if (finalOffset > 112 || (finalOffset > 52 && velocity > 0.45)) {
+      onCloseRef.current();
+      return;
+    }
+    dragOffsetRef.current = 0;
+    setDragOffset(0);
+  }, []);
+
+  const handleDrawerPointerDown = (event: ReactPointerEvent<HTMLElement>) => {
+    if (event.pointerType === 'mouse' || event.button !== 0) {
+      return;
+    }
+    dragRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      startTime: Date.now(),
+      active: false
+    };
+    dragOffsetRef.current = 0;
+    setDragOffset(0);
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+  };
+
+  const handleDrawerPointerMove = (event: ReactPointerEvent<HTMLElement>) => {
+    const drag = dragRef.current;
+    if (!drag) {
+      return;
+    }
+    const deltaX = event.clientX - drag.startX;
+    const deltaY = event.clientY - drag.startY;
+    if (!drag.active) {
+      if (Math.abs(deltaY) > Math.abs(deltaX) && Math.abs(deltaY) > 12) {
+        dragRef.current = null;
+        dragOffsetRef.current = 0;
+        setDragOffset(0);
+        event.currentTarget.releasePointerCapture?.(drag.pointerId);
+        return;
+      }
+      if (deltaX < 12 || deltaX < Math.abs(deltaY)) {
+        return;
+      }
+      drag.active = true;
+      setIsSwiping(true);
+    }
+    event.preventDefault();
+    const nextOffset = Math.min(260, Math.max(0, deltaX));
+    dragOffsetRef.current = nextOffset;
+    setDragOffset(nextOffset);
+  };
+
+  const drawerStyle = {
+    '--idt-domain-drawer-swipe-x': `${dragOffset}px`
+  } as CSSProperties;
+
   if (!open) {
     return null;
   }
   return (
     <div className="idt-domain-drawer-root" role="dialog" aria-modal="true" aria-label={title} onKeyDown={handleKeyDown}>
       <button type="button" className="idt-domain-drawer-scrim" aria-hidden="true" tabIndex={-1} onClick={onClose} />
-      <aside className="idt-domain-drawer" ref={drawerRef} tabIndex={-1}>
+      <aside
+        className={classNames(['idt-domain-drawer', isSwiping ? 'is-swiping' : ''])}
+        onPointerCancel={() => finishSwipe()}
+        onPointerDown={handleDrawerPointerDown}
+        onPointerMove={handleDrawerPointerMove}
+        onPointerUp={finishSwipe}
+        ref={drawerRef}
+        style={drawerStyle}
+        tabIndex={-1}
+      >
         <header>
           <div>
             {eyebrow ? <p className="idt-app-kicker">{eyebrow}</p> : null}

--- a/web/src/components/settings/DangerZone.test.tsx
+++ b/web/src/components/settings/DangerZone.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ConfirmDestructiveModal, DangerZone, DangerZoneRow } from './DangerZone';
 
 describe('DangerZone', () => {
@@ -49,6 +49,14 @@ describe('DangerZone', () => {
 });
 
 describe('ConfirmDestructiveModal — checkbox confirmation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   function renderCheckboxModal(overrides?: Partial<Parameters<typeof ConfirmDestructiveModal>[0]>) {
     const onConfirm = vi.fn();
     const onCancel = vi.fn();
@@ -67,7 +75,7 @@ describe('ConfirmDestructiveModal — checkbox confirmation', () => {
     return { onConfirm, onCancel };
   }
 
-  it('keeps Continue disabled until the checkbox is checked', () => {
+  it('keeps Continue disabled until the checkbox is checked, then requires a hold', () => {
     const { onConfirm } = renderCheckboxModal();
     const cont = screen.getByRole('button', { name: 'Suspend' });
     expect(cont).toBeDisabled();
@@ -75,9 +83,36 @@ describe('ConfirmDestructiveModal — checkbox confirmation', () => {
     expect(onConfirm).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('checkbox'));
-    expect(cont).toBeEnabled();
-    fireEvent.click(cont);
+    const armed = screen.getByRole('button', { name: 'Hold Suspend' });
+    expect(armed).toBeEnabled();
+    fireEvent.click(armed);
+    expect(onConfirm).not.toHaveBeenCalled();
+    fireEvent.pointerDown(armed, { button: 0 });
+    act(() => {
+      vi.advanceTimersByTime(899);
+    });
+    expect(onConfirm).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
     expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not confirm when the hold is released early', () => {
+    const { onConfirm } = renderCheckboxModal();
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    const cont = screen.getByRole('button', { name: 'Hold Suspend' });
+    fireEvent.pointerDown(cont, { button: 0 });
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    fireEvent.pointerUp(cont);
+    act(() => {
+      vi.advanceTimersByTime(900);
+    });
+
+    expect(onConfirm).not.toHaveBeenCalled();
   });
 
   it('invokes Cancel when the backdrop is clicked', () => {
@@ -105,6 +140,14 @@ describe('ConfirmDestructiveModal — checkbox confirmation', () => {
 });
 
 describe('ConfirmDestructiveModal — type-to-confirm', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('only enables Continue when the typed value matches exactly', () => {
     const onConfirm = vi.fn();
     render(
@@ -131,8 +174,12 @@ describe('ConfirmDestructiveModal — type-to-confirm', () => {
     expect(cont).toBeDisabled();
 
     fireEvent.change(input, { target: { value: 'user@example.com' } });
-    expect(cont).toBeEnabled();
-    fireEvent.click(cont);
+    const armed = screen.getByRole('button', { name: 'Hold Delete' });
+    expect(armed).toBeEnabled();
+    fireEvent.pointerDown(armed, { button: 0 });
+    act(() => {
+      vi.advanceTimersByTime(900);
+    });
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 

--- a/web/src/components/settings/DangerZone.test.tsx
+++ b/web/src/components/settings/DangerZone.test.tsx
@@ -75,7 +75,7 @@ describe('ConfirmDestructiveModal — checkbox confirmation', () => {
     return { onConfirm, onCancel };
   }
 
-  it('keeps Continue disabled until the checkbox is checked, then requires a hold', () => {
+  it('keeps Continue disabled until the checkbox is checked, then completes via a pointer hold', () => {
     const { onConfirm } = renderCheckboxModal();
     const cont = screen.getByRole('button', { name: 'Suspend' });
     expect(cont).toBeDisabled();
@@ -85,8 +85,6 @@ describe('ConfirmDestructiveModal — checkbox confirmation', () => {
     fireEvent.click(screen.getByRole('checkbox'));
     const armed = screen.getByRole('button', { name: 'Hold Suspend' });
     expect(armed).toBeEnabled();
-    fireEvent.click(armed);
-    expect(onConfirm).not.toHaveBeenCalled();
     fireEvent.pointerDown(armed, { button: 0 });
     act(() => {
       vi.advanceTimersByTime(899);
@@ -95,6 +93,17 @@ describe('ConfirmDestructiveModal — checkbox confirmation', () => {
     act(() => {
       vi.advanceTimersByTime(1);
     });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('confirms on a bare click so assistive-tech activations remain operable', () => {
+    // Assistive tech (screen readers, voice control) often activates buttons
+    // by dispatching a click without any preceding pointerdown/keydown. The
+    // hold gate would lock those users out of the destructive flow, so a
+    // bare click after the checkbox guard must still confirm.
+    const { onConfirm } = renderCheckboxModal();
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByRole('button', { name: 'Hold Suspend' }));
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 

--- a/web/src/components/settings/DangerZone.test.tsx
+++ b/web/src/components/settings/DangerZone.test.tsx
@@ -96,6 +96,45 @@ describe('ConfirmDestructiveModal — checkbox confirmation', () => {
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
+  it('cancels a pending hold timer when the modal closes mid-hold', () => {
+    // Regression: if the destructive dialog is dismissed (Escape/Cancel or a
+    // parent state change) while a hold is in progress, the pending 900ms
+    // timeout must not fire onConfirm after the modal has been closed.
+    const onConfirm = vi.fn();
+    const { rerender } = render(
+      <ConfirmDestructiveModal
+        body={<p>This is permanent-ish.</p>}
+        confirmation={{ kind: 'checkbox', label: 'I understand.' }}
+        continueLabel="Suspend"
+        onCancel={() => undefined}
+        onConfirm={onConfirm}
+        open
+        title="Suspend your account"
+      />
+    );
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Hold Suspend' }), { button: 0 });
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    rerender(
+      <ConfirmDestructiveModal
+        body={<p>This is permanent-ish.</p>}
+        confirmation={{ kind: 'checkbox', label: 'I understand.' }}
+        continueLabel="Suspend"
+        onCancel={() => undefined}
+        onConfirm={onConfirm}
+        open={false}
+        title="Suspend your account"
+      />
+    );
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
   it('confirms on a bare click so assistive-tech activations remain operable', () => {
     // Assistive tech (screen readers, voice control) often activates buttons
     // by dispatching a click without any preceding pointerdown/keydown. The

--- a/web/src/components/settings/DangerZone.tsx
+++ b/web/src/components/settings/DangerZone.tsx
@@ -1,4 +1,7 @@
-import { ReactNode, useEffect, useId, useRef, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useId, useRef, useState } from 'react';
+
+const HOLD_TO_CONFIRM_MS = 900;
+const HOLD_REJECT_RESET_MS = 320;
 
 type DangerZoneProps = {
   description?: string;
@@ -92,7 +95,25 @@ export function ConfirmDestructiveModal({
   const helpId = useId();
   const [checked, setChecked] = useState(false);
   const [typed, setTyped] = useState('');
+  const [holding, setHolding] = useState(false);
+  const [rejectedHold, setRejectedHold] = useState(false);
   const confirmRef = useRef<HTMLButtonElement | null>(null);
+  const holdTimerRef = useRef<number | null>(null);
+  const rejectTimerRef = useRef<number | null>(null);
+
+  const clearHoldTimer = useCallback(() => {
+    if (holdTimerRef.current !== null) {
+      window.clearTimeout(holdTimerRef.current);
+      holdTimerRef.current = null;
+    }
+  }, []);
+
+  const clearRejectTimer = useCallback(() => {
+    if (rejectTimerRef.current !== null) {
+      window.clearTimeout(rejectTimerRef.current);
+      rejectTimerRef.current = null;
+    }
+  }, []);
 
   // Reset confirmation state every time the modal opens so a previously
   // accepted checkbox or typed value does not silently re-arm Continue on the
@@ -101,8 +122,19 @@ export function ConfirmDestructiveModal({
     if (open) {
       setChecked(false);
       setTyped('');
+      setHolding(false);
+      setRejectedHold(false);
+      clearHoldTimer();
+      clearRejectTimer();
     }
-  }, [open]);
+  }, [clearHoldTimer, clearRejectTimer, open]);
+
+  useEffect(() => {
+    return () => {
+      clearHoldTimer();
+      clearRejectTimer();
+    };
+  }, [clearHoldTimer, clearRejectTimer]);
 
   useEffect(() => {
     if (!open) {
@@ -128,6 +160,45 @@ export function ConfirmDestructiveModal({
   // trimming here would defeat the whole purpose of the friction.
   const canContinue =
     confirmation.kind === 'checkbox' ? checked : typed === confirmation.expectedValue;
+
+  const startConfirmHold = () => {
+    if (!canContinue || pending || holdTimerRef.current !== null) {
+      return;
+    }
+    clearRejectTimer();
+    setRejectedHold(false);
+    setHolding(true);
+    holdTimerRef.current = window.setTimeout(() => {
+      holdTimerRef.current = null;
+      setHolding(false);
+      onConfirm();
+    }, HOLD_TO_CONFIRM_MS);
+  };
+
+  const cancelConfirmHold = (showRejection = true) => {
+    if (holdTimerRef.current === null) {
+      return;
+    }
+    clearHoldTimer();
+    setHolding(false);
+    if (!showRejection) {
+      return;
+    }
+    setRejectedHold(true);
+    clearRejectTimer();
+    rejectTimerRef.current = window.setTimeout(() => {
+      rejectTimerRef.current = null;
+      setRejectedHold(false);
+    }, HOLD_REJECT_RESET_MS);
+  };
+
+  const confirmButtonClassName = [
+    'idt-btn',
+    'idt-btn-danger',
+    'idt-hold-confirm',
+    holding ? 'is-holding' : '',
+    rejectedHold ? 'is-rejected' : ''
+  ].filter(Boolean).join(' ');
 
   return (
     <div className="idt-modal-backdrop idt-danger-modal-backdrop" role="presentation" onClick={onCancel}>
@@ -202,14 +273,35 @@ export function ConfirmDestructiveModal({
             {cancelLabel}
           </button>
           <button
-            className="idt-btn idt-btn-danger"
+            className={confirmButtonClassName}
             data-testid="idt-danger-modal-continue"
             disabled={!canContinue || pending}
-            onClick={onConfirm}
+            onClick={(event) => event.preventDefault()}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                startConfirmHold();
+              }
+            }}
+            onKeyUp={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                cancelConfirmHold();
+              }
+            }}
+            onPointerCancel={() => cancelConfirmHold(false)}
+            onPointerDown={(event) => {
+              if (event.button !== 0) {
+                return;
+              }
+              startConfirmHold();
+            }}
+            onPointerLeave={() => cancelConfirmHold(false)}
+            onPointerUp={() => cancelConfirmHold()}
             ref={confirmRef}
             type="button"
           >
-            {pending ? 'Working…' : continueLabel}
+            <span>{pending ? 'Working…' : canContinue ? `Hold ${continueLabel}` : continueLabel}</span>
           </button>
         </footer>
       </section>

--- a/web/src/components/settings/DangerZone.tsx
+++ b/web/src/components/settings/DangerZone.tsx
@@ -100,6 +100,11 @@ export function ConfirmDestructiveModal({
   const confirmRef = useRef<HTMLButtonElement | null>(null);
   const holdTimerRef = useRef<number | null>(null);
   const rejectTimerRef = useRef<number | null>(null);
+  // Tracks whether the current activation was initiated through the
+  // pointer/keyboard hold flow. If a click arrives without this flag set
+  // (assistive tech, voice control, programmatic .click()), we fall back to
+  // a direct confirmation so those flows remain operable.
+  const holdInteractionRef = useRef(false);
 
   const clearHoldTimer = useCallback(() => {
     if (holdTimerRef.current !== null) {
@@ -124,6 +129,7 @@ export function ConfirmDestructiveModal({
       setTyped('');
       setHolding(false);
       setRejectedHold(false);
+      holdInteractionRef.current = false;
       clearHoldTimer();
       clearRejectTimer();
     }
@@ -276,10 +282,21 @@ export function ConfirmDestructiveModal({
             className={confirmButtonClassName}
             data-testid="idt-danger-modal-continue"
             disabled={!canContinue || pending}
-            onClick={(event) => event.preventDefault()}
+            onClick={(event) => {
+              event.preventDefault();
+              if (holdInteractionRef.current) {
+                holdInteractionRef.current = false;
+                return;
+              }
+              if (!canContinue || pending) {
+                return;
+              }
+              onConfirm();
+            }}
             onKeyDown={(event) => {
               if (event.key === 'Enter' || event.key === ' ') {
                 event.preventDefault();
+                holdInteractionRef.current = true;
                 startConfirmHold();
               }
             }}
@@ -294,6 +311,7 @@ export function ConfirmDestructiveModal({
               if (event.button !== 0) {
                 return;
               }
+              holdInteractionRef.current = true;
               startConfirmHold();
             }}
             onPointerLeave={() => cancelConfirmHold(false)}

--- a/web/src/components/settings/DangerZone.tsx
+++ b/web/src/components/settings/DangerZone.tsx
@@ -124,15 +124,22 @@ export function ConfirmDestructiveModal({
   // accepted checkbox or typed value does not silently re-arm Continue on the
   // next destructive action.
   useEffect(() => {
-    if (open) {
-      setChecked(false);
-      setTyped('');
-      setHolding(false);
-      setRejectedHold(false);
-      holdInteractionRef.current = false;
+    if (!open) {
+      // The component can stay mounted across an open→close transition (the
+      // parent re-renders with open=false). Any hold timer started before the
+      // close would otherwise still fire onConfirm after the destructive
+      // dialog was dismissed.
       clearHoldTimer();
       clearRejectTimer();
+      return;
     }
+    setChecked(false);
+    setTyped('');
+    setHolding(false);
+    setRejectedHold(false);
+    holdInteractionRef.current = false;
+    clearHoldTimer();
+    clearRejectTimer();
   }, [clearHoldTimer, clearRejectTimer, open]);
 
   useEffect(() => {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -126,6 +126,51 @@ a {
   }
 }
 
+@keyframes idtRejectShake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+
+  18% {
+    transform: translateX(-0.24rem);
+  }
+
+  38% {
+    transform: translateX(0.22rem);
+  }
+
+  58% {
+    transform: translateX(-0.14rem);
+  }
+
+  78% {
+    transform: translateX(0.1rem);
+  }
+}
+
+@keyframes idtPressRipple {
+  from {
+    opacity: 0.24;
+    transform: translate(-50%, -50%) scale(0.15);
+  }
+
+  to {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(1);
+  }
+}
+
+@keyframes idtHoldConfirmFill {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .idt-modal-backdrop,
   .idt-modal,
@@ -155,7 +200,9 @@ a {
   .idt-auth-mfa-setup,
   .idt-auth-provider-stack,
   .idt-settings-disclosure[open] .idt-settings-disclosure-body,
-  .idt-settings-inline-disclosure[open] .idt-settings-disclosure-body {
+  .idt-settings-inline-disclosure[open] .idt-settings-disclosure-body,
+  .idt-hold-confirm.is-holding::before,
+  .idt-hold-confirm.is-rejected {
     animation: none !important;
   }
 }
@@ -328,7 +375,50 @@ a {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
   transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease, background-color 0.18s ease;
+}
+
+.idt-btn::before,
+.idt-esc-close::before,
+.idt-modal-close::before,
+.idt-domain-drawer-close::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  z-index: 0;
+  width: 135%;
+  aspect-ratio: 1;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, -50%) scale(0);
+}
+
+.idt-esc-close,
+.idt-modal-close,
+.idt-domain-drawer-close {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.idt-btn:active:not(:disabled)::before,
+.idt-esc-close:active::before,
+.idt-modal-close:active::before,
+.idt-domain-drawer-close:active::before {
+  animation: idtPressRipple 360ms ease-out;
+}
+
+.idt-btn:active:not(:disabled),
+.idt-esc-close:active,
+.idt-modal-close:active,
+.idt-domain-drawer-close:active {
+  transform: translateY(0) scale(0.985);
 }
 
 .idt-btn:hover,
@@ -1553,7 +1643,9 @@ h3 {
   margin: 0;
   color: #ffb4b1;
   font-size: 0.85rem;
-  animation: idtStatusFadeIn var(--idt-motion-standard) var(--idt-motion-ease) both;
+  animation:
+    idtStatusFadeIn var(--idt-motion-standard) var(--idt-motion-ease) both,
+    idtRejectShake 280ms var(--idt-motion-ease) both;
 }
 
 .idt-form-success {
@@ -4478,6 +4570,9 @@ html[data-theme='light'] .idt-intake-grid select:focus-visible {
 .idt-app-alert-error {
   border-color: rgba(220, 129, 129, 0.44);
   color: #ffd0d0;
+  animation:
+    idtStatusFadeIn var(--idt-motion-standard) var(--idt-motion-ease) both,
+    idtRejectShake 280ms var(--idt-motion-ease) both;
 }
 
 .idt-app-alert-success {
@@ -16648,6 +16743,7 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
 .idt-onboarding-input-wrap.has-error input,
 .idt-onboarding-input-wrap.has-error textarea {
   border-color: #ef4444;
+  animation: idtRejectShake 280ms var(--idt-motion-ease) both;
 }
 
 .idt-onboarding-input-error {
@@ -16679,6 +16775,7 @@ html[data-theme='light'] .idt-onboarding-shell .idt-app-kicker {
   font-style: italic;
   font-weight: 650;
   line-height: 1.25;
+  animation: idtRejectShake 280ms var(--idt-motion-ease) both;
 }
 
 .idt-onboarding-panel-main > .idt-onboarding-inline-error {
@@ -24358,6 +24455,13 @@ button.idt-domain-finding-card:focus-visible {
   color: var(--app-text);
   box-shadow: -16px 0 32px rgba(0, 0, 0, 0.32);
   animation: idtDrawerSlideIn var(--idt-motion-slow) var(--idt-motion-pop) both;
+  touch-action: pan-y;
+  transform: translateX(var(--idt-domain-drawer-swipe-x, 0));
+  transition: transform 180ms var(--idt-motion-ease);
+}
+
+.idt-domain-drawer.is-swiping {
+  transition: none !important;
 }
 
 .idt-domain-drawer header {
@@ -29942,7 +30046,9 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
   background: rgba(70, 14, 18, 0.55);
   color: #ffd7d7;
   font-size: 0.9rem;
-  animation: idtStatusFadeIn var(--idt-motion-standard) var(--idt-motion-ease) both;
+  animation:
+    idtStatusFadeIn var(--idt-motion-standard) var(--idt-motion-ease) both,
+    idtRejectShake 280ms var(--idt-motion-ease) both;
 }
 
 .idt-danger-modal-blocker {
@@ -29952,7 +30058,65 @@ html[data-theme='light'] .idt-docs-page .idt-booking-prompt-slot-row span {
   border-radius: 0.5rem;
   background: rgba(40, 12, 16, 0.65);
   color: #ffd0d0;
-  animation: idtStatusFadeIn var(--idt-motion-standard) var(--idt-motion-ease) both;
+  animation:
+    idtStatusFadeIn var(--idt-motion-standard) var(--idt-motion-ease) both,
+    idtRejectShake 280ms var(--idt-motion-ease) both;
+}
+
+.idt-hold-confirm {
+  --idt-hold-confirm-duration: 900ms;
+  min-width: 9.5rem;
+}
+
+.idt-hold-confirm::before {
+  inset: 0;
+  top: 0;
+  left: 0;
+  z-index: 0;
+  width: 100%;
+  height: 100%;
+  aspect-ratio: auto;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.34), rgba(255, 255, 255, 0.18));
+  opacity: 0;
+  transform: scaleX(0);
+  transform-origin: left center;
+}
+
+.idt-hold-confirm > span {
+  position: relative;
+  z-index: 1;
+}
+
+.idt-hold-confirm.is-holding::before {
+  opacity: 1;
+  animation: idtHoldConfirmFill var(--idt-hold-confirm-duration) linear forwards;
+}
+
+.idt-hold-confirm.is-rejected {
+  animation: idtRejectShake 280ms var(--idt-motion-ease) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .idt-btn::before,
+  .idt-esc-close::before,
+  .idt-modal-close::before,
+  .idt-domain-drawer-close::before,
+  .idt-hold-confirm::before,
+  .idt-onboarding-input-wrap.has-error input,
+  .idt-onboarding-input-wrap.has-error textarea,
+  .idt-onboarding-inline-error {
+    animation: none !important;
+    transition: none !important;
+  }
+
+  .idt-btn:active:not(:disabled),
+  .idt-esc-close:active,
+  .idt-modal-close:active,
+  .idt-domain-drawer-close:active,
+  .idt-domain-drawer {
+    transform: none !important;
+  }
 }
 
 .idt-danger-modal-blocker ul {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -24462,6 +24462,11 @@ button.idt-domain-finding-card:focus-visible {
 
 .idt-domain-drawer.is-swiping {
   transition: none !important;
+  /* The entry animation uses animation-fill-mode: both, which keeps
+     pinning transform: translateX(0) after the slide-in finishes and
+     would override the swipe-offset transform. Cancel the animation
+     while swiping so the JS-driven transform takes effect. */
+  animation: none !important;
 }
 
 .idt-domain-drawer header {


### PR DESCRIPTION
## Summary

Adds restrained interaction feedback to the Identrail frontend where it improves clarity without changing product data or backend behavior.

Changes included:

- Adds press/tap feedback and a subtle ripple treatment for shared buttons and close controls.
- Adds shake feedback for rejected/error states across form errors, app alerts, onboarding validation, and danger modal blockers.
- Updates destructive confirmation modals so the final destructive button requires a short hold after the existing checkbox or type-to-confirm guard is satisfied.
- Adds a swipe-to-dismiss touch interaction for domain detail drawers, with snap-back when the swipe is too small.
- Preserves reduced-motion behavior by disabling the new shake, ripple, hold, and drawer transform motion for users who request reduced motion.

## Why

Identrail has several places where users benefit from clearer feedback: clickable controls should feel responsive, rejected inputs should be obvious, destructive actions should be harder to trigger accidentally, and touch drawer dismissal should feel natural on mobile.

## Scope

- [x] Focused frontend interaction polish only
- [x] No backend, auth, permissions, scan, or data model changes
- [x] Existing confirmation requirements preserved and strengthened
- [x] Reduced-motion users respected

## Validation

```bash
npm ci --prefix web
npm test --prefix web -- --run src/components/settings/DangerZone.test.tsx src/components/app/DomainFoundation.test.tsx
npm run build --prefix web
git diff --check
```

Browser smoke check:

- Started Vite at `http://127.0.0.1:5174/`.
- Opened the home page and confirmed it renders.
- Opened the trust-path review modal and confirmed the modal/backdrop still mount correctly.
- Confirmed the new press-ripple and hold-confirm CSS rules are loaded.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated for user/operator-facing changes
- [x] `CHANGELOG.md` updated when relevant
- [x] No secrets, credentials, or sensitive data included

## AI Assistance Disclosure

No

## Related Issues

No issue: scoped interaction polish requested directly in this workspace.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds restrained interaction feedback across the Identrail web app to improve clarity and prevent accidental destructive actions. Includes press ripples, error shakes, a 900ms hold‑to‑confirm with an assistive‑tech fallback, and swipe‑to‑dismiss for the domain drawer with reduced‑motion support.

- New Features
  - Press ripple and gentle press scale on `.idt-btn` and drawer/modal close buttons.
  - Shake feedback for errors across forms, app alerts, onboarding, and danger modal blockers.
  - Destructive modals: 900ms hold after checkbox/type guard; shows a fill and “Hold <label>”; cancels on early release/leave; supports Enter/Space.
  - Domain detail drawer: touch/pointer swipe-to-dismiss with distance/velocity thresholds; cancels entry animation and transition while swiping so the transform applies; snaps back on short or vertical swipes.
  - Reduced-motion: disables ripple, shake, hold-fill, and drawer transforms.

- Bug Fixes
  - Preserve assistive-tech activation: a bare click (e.g., screen readers/voice control) confirms without the hold; pointer/keyboard interactions still require the 900ms hold.
  - Clear destructive hold timer when the modal closes mid-hold so confirm does not fire after dismissal.

<sup>Written for commit 7680477cb7525ae4cfca466d0afca90dc764894b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

