### PR TITLE
Restore sidebar flyout menus

### DIFF
--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -978,6 +978,8 @@ describe('ProductShellLayout', () => {
 
     expect(await screen.findByRole('heading', { level: 2, name: /Reports content/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Reports' })).toHaveClass('active');
+    const resizeHandle = screen.getByRole('separator', { name: /sidebar/i });
+    expect(resizeHandle).toHaveAttribute('tabindex', '0');
 
     fireEvent.click(screen.getByRole('button', { name: 'AWS' }));
 
@@ -987,11 +989,15 @@ describe('ProductShellLayout', () => {
     const sidebarBackdrop = container.querySelector('.idt-domain-flyout-sidebar-backdrop');
     expect(sidebarBackdrop).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'AWS' }).closest('.idt-app-domain-nav-item')).toHaveClass('is-open');
+    expect(resizeHandle).toHaveClass('is-domain-flyout-blocked');
+    expect(resizeHandle).toHaveAttribute('tabindex', '-1');
 
     fireEvent.click(sidebarBackdrop as Element);
 
     expect(screen.queryByRole('dialog', { name: 'AWS' })).not.toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Reports' })).toHaveClass('active');
+    expect(resizeHandle).not.toHaveClass('is-domain-flyout-blocked');
+    expect(resizeHandle).toHaveAttribute('tabindex', '0');
 
     fireEvent.click(screen.getByRole('button', { name: 'GitHub' }));
 

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -966,7 +966,7 @@ describe('ProductShellLayout', () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     const { ProductShellLayout } = await import('./productShell');
 
-    render(
+    const { container } = render(
       <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/reports']}>
         <Routes>
           <Route path="/app/:tenantID/:workspaceID" element={<ProductShellLayout />}>
@@ -984,6 +984,14 @@ describe('ProductShellLayout', () => {
     expect(screen.getByRole('link', { name: 'Reports' })).not.toHaveClass('active');
     expect(screen.getByRole('button', { name: 'AWS' })).toHaveClass('is-open');
     expect(screen.getByRole('button', { name: 'AWS' })).toHaveAttribute('aria-expanded', 'true');
+    const sidebarBackdrop = container.querySelector('.idt-domain-flyout-sidebar-backdrop');
+    expect(sidebarBackdrop).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'AWS' }).closest('.idt-app-domain-nav-item')).toHaveClass('is-open');
+
+    fireEvent.click(sidebarBackdrop as Element);
+
+    expect(screen.queryByRole('dialog', { name: 'AWS' })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Reports' })).toHaveClass('active');
 
     fireEvent.click(screen.getByRole('button', { name: 'GitHub' }));
 

--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -897,7 +897,7 @@ describe('ProductShellLayout', () => {
     fireEvent.keyDown(window, { key: 'Escape' });
 
     fireEvent.click(screen.getByRole('button', { name: 'GitHub' }));
-    const githubFlyout = screen.getByRole('region', { name: 'GitHub' });
+    const githubFlyout = screen.getByRole('dialog', { name: 'GitHub' });
     expect(within(githubFlyout).queryByText('Section')).not.toBeInTheDocument();
     expect(within(githubFlyout).queryByRole('heading', { name: 'GitHub' })).not.toBeInTheDocument();
     expect(within(githubFlyout).getByRole('link', { name: 'GitHub Control center' })).toBeInTheDocument();
@@ -952,7 +952,7 @@ describe('ProductShellLayout', () => {
     const githubButton = screen.getByRole('button', { name: 'GitHub' });
     expect(githubButton).not.toBeDisabled();
     fireEvent.click(githubButton);
-    expect(screen.getByRole('region', { name: 'GitHub' })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'GitHub' })).toBeInTheDocument();
 
     fireEvent.keyDown(window, { key: '/' });
     expect(screen.getByRole('dialog', { name: /Workspace finder/i })).toBeInTheDocument();
@@ -2775,7 +2775,7 @@ describe('Domain-first app routes', () => {
     expect(payload.project_id).not.toBe('default-environment');
   });
 
-  it('opens nested GitHub AI risk routes inline from the sidebar domain flyout', async () => {
+  it('opens nested GitHub AI risk routes from the sidebar domain flyout', async () => {
     mockConnectorFeatureFlags({ github: true, kubernetes: true });
     mockBackendFeatures({ github: true, kubernetes: true });
     const { ProductShellLayout } = await import('./productShell');
@@ -2793,41 +2793,13 @@ describe('Domain-first app routes', () => {
     expect(await screen.findByRole('heading', { level: 2, name: /MCP tools content/i })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'GitHub' }));
 
-    const githubFlyout = screen.getByRole('region', { name: 'GitHub' });
+    const githubFlyout = screen.getByRole('dialog', { name: 'GitHub' });
     expect(within(githubFlyout).getAllByText('AI / Agentic Risk').length).toBeGreaterThan(0);
     expect(within(githubFlyout).getByRole('link', { name: 'GitHub AI / Agentic Risk MCP / tools' })).toHaveAttribute(
       'aria-current',
       'page'
     );
-    expect(screen.queryByRole('dialog', { name: 'GitHub' })).not.toBeInTheDocument();
-    expect(container.querySelector('.idt-domain-flyout-backdrop')).not.toBeInTheDocument();
     expect(container.querySelector('details.idt-domain-flyout-nested')).toHaveAttribute('open');
-  });
-
-  it('expands the collapsed sidebar before opening an inline domain flyout', async () => {
-    window.localStorage.setItem('idt:sidebar:collapsed', '1');
-    mockConnectorFeatureFlags({ github: true, kubernetes: true });
-    mockBackendFeatures({ github: true, kubernetes: true });
-    const { ProductShellLayout } = await import('./productShell');
-
-    const { container } = render(
-      <MemoryRouter initialEntries={['/app/tenant-a/workspace-a']}>
-        <Routes>
-          <Route path="/app/:tenantID/:workspaceID" element={<ProductShellLayout />}>
-            <Route index element={<h2>Overview content</h2>} />
-          </Route>
-        </Routes>
-      </MemoryRouter>
-    );
-
-    const sidebar = container.querySelector('.idt-app-sidebar');
-    expect(sidebar).toHaveAttribute('data-collapsed', 'true');
-
-    fireEvent.click(screen.getByRole('button', { name: 'AWS' }));
-
-    await waitFor(() => expect(sidebar).toHaveAttribute('data-collapsed', 'false'));
-    expect(screen.getByRole('region', { name: 'AWS' })).toBeInTheDocument();
-    expect(container.querySelector('.idt-domain-flyout-backdrop')).not.toBeInTheDocument();
   });
 });
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -2354,7 +2354,8 @@ function ProductDomainFlyout({
       id={`idt-${domain}-domain-flyout`}
       ref={panelRef}
       className={`idt-domain-flyout is-${domain}`}
-      role="region"
+      role="dialog"
+      aria-modal="true"
       aria-labelledby={labelledBy}
     >
       <div className="idt-domain-flyout-section">
@@ -9357,6 +9358,12 @@ export function ProductShellLayout() {
     }
     setAccountMenuOpen(false);
     setWorkspaceMenuOpen(false);
+    const focusFrame = window.requestAnimationFrame(() => {
+      const firstAction = domainFlyoutRef.current?.querySelector<HTMLElement>(
+        '[data-domain-flyout-primary="true"], a[href], button:not([disabled]), summary'
+      );
+      firstAction?.focus();
+    });
     const handleKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         event.preventDefault();
@@ -9365,9 +9372,31 @@ export function ProductShellLayout() {
         window.requestAnimationFrame(() => trigger?.focus());
         return;
       }
+      if (event.key === 'Tab' && domainFlyoutRef.current) {
+        const focusable = Array.from(
+          domainFlyoutRef.current.querySelectorAll<HTMLElement>(
+            'a[href], button:not([disabled]), summary, [tabindex]:not([tabindex="-1"])'
+          )
+        ).filter((element) => element.offsetParent !== null || element.tagName === 'SUMMARY');
+        if (!focusable.length) {
+          return;
+        }
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+          return;
+        }
+        if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
     };
     window.addEventListener('keydown', handleKey);
     return () => {
+      window.cancelAnimationFrame(focusFrame);
       window.removeEventListener('keydown', handleKey);
     };
   }, [openDomainFlyout]);
@@ -9377,6 +9406,23 @@ export function ProductShellLayout() {
       setOpenDomainFlyout(null);
     }
   }, [commandOpen]);
+
+  useEffect(() => {
+    if (!openDomainFlyout || typeof document === 'undefined') {
+      return undefined;
+    }
+
+    const root = document.documentElement;
+    const body = document.body;
+    const previousRootOverflow = root.style.overflow;
+    const previousBodyOverflow = body.style.overflow;
+    root.style.overflow = 'hidden';
+    body.style.overflow = 'hidden';
+    return () => {
+      root.style.overflow = previousRootOverflow;
+      body.style.overflow = previousBodyOverflow;
+    };
+  }, [openDomainFlyout]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -9698,9 +9744,6 @@ export function ProductShellLayout() {
     setAccountMenuOpen(false);
     setWorkspaceMenuOpen(false);
     setCommandOpen(false);
-    if (sidebarCollapsed) {
-      setSidebarCollapsedPref(false);
-    }
     setOpenDomainFlyout((current) => (current === domain ? null : domain));
   };
 
@@ -9833,6 +9876,7 @@ export function ProductShellLayout() {
                     type="button"
                     className={`idt-app-nav-domain-trigger${isActive ? ' is-active' : ''}${isOpen ? ' is-open' : ''}`}
                     data-connector-available={availability.available ? 'true' : 'false'}
+                    aria-haspopup="dialog"
                     aria-expanded={isOpen}
                     aria-controls={isOpen ? `idt-${domain}-domain-flyout` : undefined}
                     aria-label={config.navLabel}
@@ -9951,6 +9995,15 @@ export function ProductShellLayout() {
             </div>
           </div>
         </aside>
+
+        {openDomainFlyout ? (
+          <button
+            type="button"
+            className="idt-domain-flyout-backdrop"
+            aria-label="Close domain section menu"
+            onClick={closeDomainFlyout}
+          />
+        ) : null}
 
         <div className="idt-app-console">
           <main className="idt-app-shell-main">

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -9766,9 +9766,9 @@ export function ProductShellLayout() {
           data-collapsed={sidebarCollapsed ? 'true' : 'false'}
         >
           <div
-            className={`idt-app-sidebar-resize-handle${isDraggingSidebar ? ' is-dragging' : ''}${isSidebarEdgeFocused ? ' is-focused' : ''}`}
+            className={`idt-app-sidebar-resize-handle${isDraggingSidebar ? ' is-dragging' : ''}${isSidebarEdgeFocused ? ' is-focused' : ''}${openDomainFlyout ? ' is-domain-flyout-blocked' : ''}`}
             role="separator"
-            tabIndex={0}
+            tabIndex={openDomainFlyout ? -1 : 0}
             aria-orientation="vertical"
             aria-label={`${sidebarCollapsed ? 'Expand' : 'Collapse'} sidebar. Drag to resize.`}
             data-sidebar-action={sidebarCollapsed ? 'Click to expand' : 'Click to collapse'}

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -9846,6 +9846,16 @@ export function ProductShellLayout() {
             <kbd className="idt-app-quick-find-key">⌘K</kbd>
           </button>
 
+          {openDomainFlyout ? (
+            <button
+              type="button"
+              className="idt-domain-flyout-sidebar-backdrop"
+              aria-hidden="true"
+              tabIndex={-1}
+              onClick={closeDomainFlyout}
+            />
+          ) : null}
+
           <nav className="idt-app-shell-nav" aria-label="App sections">
             <NavLink
               to={basePath}
@@ -9867,7 +9877,7 @@ export function ProductShellLayout() {
               const isActive = activeDomain === domain && (!openDomainFlyout || isOpen);
               const triggerID = `idt-${domain}-domain-trigger`;
               return (
-                <div key={domain} className="idt-app-domain-nav-item">
+                <div key={domain} className={`idt-app-domain-nav-item${isOpen ? ' is-open' : ''}`}>
                   <button
                     id={triggerID}
                     ref={(node) => {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -26995,12 +26995,31 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   touch-action: none;
 }
 
+.idt-domain-flyout-sidebar-backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 40;
+  border: 0;
+  padding: 0;
+  background: rgba(5, 7, 10, 0.54);
+  cursor: default;
+  touch-action: none;
+}
+
 .idt-app-console-layout.is-domain-flyout-open .idt-app-sidebar {
   z-index: 35;
 }
 
 .idt-app-console-layout.is-domain-flyout-open .idt-app-shell-nav {
   overflow: visible;
+}
+
+.idt-app-console-layout.is-domain-flyout-open .idt-app-domain-nav-item.is-open {
+  z-index: 45;
+}
+
+.idt-app-console-layout.is-domain-flyout-open .idt-app-nav-domain-trigger.is-open {
+  z-index: 46;
 }
 
 .idt-domain-flyout {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -27022,6 +27022,12 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   z-index: 46;
 }
 
+.idt-app-console-layout.is-domain-flyout-open .idt-app-sidebar-resize-handle,
+.idt-app-sidebar-resize-handle.is-domain-flyout-blocked {
+  z-index: 30;
+  pointer-events: none;
+}
+
 .idt-domain-flyout {
   position: absolute;
   top: -0.45rem;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -26982,37 +26982,63 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   color: #ffffff;
 }
 
+.idt-domain-flyout-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  border: 0;
+  padding: 0;
+  background: rgba(5, 7, 10, 0.58);
+  -webkit-backdrop-filter: blur(22px) saturate(0.84) brightness(0.72);
+  backdrop-filter: blur(22px) saturate(0.84) brightness(0.72);
+  cursor: default;
+  touch-action: none;
+}
+
 .idt-app-console-layout.is-domain-flyout-open .idt-app-sidebar {
-  z-index: auto;
+  z-index: 35;
 }
 
 .idt-app-console-layout.is-domain-flyout-open .idt-app-shell-nav {
-  overflow-y: auto;
+  overflow: visible;
 }
 
 .idt-domain-flyout {
-  --idt-domain-flyout-indent: 1.08rem;
-  position: static;
-  z-index: auto;
+  position: absolute;
+  top: -0.45rem;
+  left: calc(100% + 0.72rem);
+  z-index: 50;
   display: grid;
-  gap: 0.46rem;
-  box-sizing: border-box;
-  width: calc(100% - var(--idt-domain-flyout-indent));
-  max-height: none;
-  overflow: visible;
-  border: 0;
-  border-left: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 0;
-  margin: 0.34rem 0 0.45rem var(--idt-domain-flyout-indent);
-  padding: 0.15rem 0 0.2rem 0.58rem;
-  background: transparent;
-  box-shadow: none;
+  gap: 0.58rem;
+  width: min(27rem, calc(100vw - var(--idt-sidebar-width, 15.5rem) - 1.8rem));
+  max-height: min(78vh, 42rem);
+  overflow: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  border: 1px solid rgba(255, 255, 255, 0.13);
+  border-radius: 8px;
+  padding: 0.68rem;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.045), transparent 8rem),
+    #050607;
+  box-shadow:
+    0 28px 90px rgba(0, 0, 0, 0.62),
+    0 0 0 1px rgba(255, 255, 255, 0.04) inset;
   transform-origin: top left;
   animation: idtFlyoutRevealIn var(--idt-motion-slow) var(--idt-motion-ease) both;
 }
 
 .idt-domain-flyout::before {
-  display: none;
+  content: '';
+  position: absolute;
+  top: 1.25rem;
+  left: -0.45rem;
+  width: 0.85rem;
+  height: 0.85rem;
+  border-left: 1px solid rgba(255, 255, 255, 0.13);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.13);
+  background: #050607;
+  transform: rotate(45deg);
 }
 
 .idt-domain-flyout-section-label {
@@ -27028,7 +27054,7 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 .idt-domain-flyout-list,
 .idt-domain-flyout-nested-body {
   display: grid;
-  gap: 0.1rem;
+  gap: 0.12rem;
 }
 
 .idt-domain-flyout-section {
@@ -27048,10 +27074,10 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 0.55rem;
   align-items: center;
-  min-height: 2.06rem;
+  min-height: 2.28rem;
   border: 1px solid transparent;
   border-radius: 7px;
-  padding: 0.36rem 0.48rem;
+  padding: 0.44rem 0.54rem;
   color: #dce3eb;
   text-decoration: none;
   transition: background-color 0.12s ease, border-color 0.12s ease, color 0.12s ease;
@@ -27060,8 +27086,8 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 .idt-domain-flyout-link:hover,
 .idt-domain-flyout-link:focus-visible,
 .idt-domain-flyout-link.is-active {
-  border-color: rgba(255, 255, 255, 0.09);
-  background: #101318;
+  border-color: rgba(255, 255, 255, 0.12);
+  background: #10141a;
   color: #ffffff;
   outline: none;
 }
@@ -27093,10 +27119,10 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 }
 
 .idt-domain-flyout-nested {
-  border: 0;
-  border-radius: 0;
-  padding: 0;
-  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 8px;
+  padding: 0.36rem;
+  background: rgba(255, 255, 255, 0.018);
 }
 
 .idt-domain-flyout-nested summary {
@@ -27157,10 +27183,6 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
 }
 
 .idt-app-console-layout.is-sidebar-collapsed .idt-app-nav-disclosure {
-  display: none;
-}
-
-.idt-app-console-layout.is-sidebar-collapsed .idt-domain-flyout {
   display: none;
 }
 
@@ -27902,6 +27924,16 @@ html[data-theme='light'] .idt-app-console-layout .idt-overview-header {
   }
   /* Collapsed mode is forced off on narrow viewports by JS because the rail
    * becomes a top bar where the desktop edge affordance is not useful. */
+
+  .idt-domain-flyout {
+    position: fixed;
+    top: auto;
+    right: 1rem;
+    bottom: 1rem;
+    left: 1rem;
+    width: auto;
+    max-height: min(76vh, 42rem);
+  }
 
   .idt-domain-flyout::before {
     display: none;


### PR DESCRIPTION
Refs #1389

## Summary
- Restore domain sidebar sections to floating dialog-style flyouts with a backdrop instead of inline rail expansion.
- Bring back focus trapping, scroll locking, and dialog semantics for the domain flyout menu.
- Update product shell tests to protect the restored flyout behavior while preserving the newer motion animation hooks from `dev`.

## Validation
- `npm test -- --run src/productShell.test.tsx`
- `git diff --cached --check`
- Push hooks: merge conflict check, whitespace checks, gofmt, go vet, token hygiene, Vercel artifact hygiene.

## AI disclosure usage
No
