### PR TITLE
fix: bump Go to 1.25.11 to clear stdlib advisories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,3 +62,24 @@ updates:
         applies-to: version-updates
         patterns:
           - "*"
+
+  - package-ecosystem: docker
+    directory: "/deploy/docker"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:45"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - deps/docker
+    groups:
+      docker-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      docker-version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,6 @@ updates:
       - dependencies
       - deps/go
     groups:
-      go-security-updates:
-        applies-to: security-updates
-        patterns:
-          - "*"
       go-version-updates:
         applies-to: version-updates
         patterns:
@@ -33,10 +29,6 @@ updates:
       - dependencies
       - deps/npm
     groups:
-      npm-security-updates:
-        applies-to: security-updates
-        patterns:
-          - "*"
       npm-version-updates:
         applies-to: version-updates
         patterns:
@@ -54,10 +46,6 @@ updates:
       - dependencies
       - deps/github-actions
     groups:
-      gha-security-updates:
-        applies-to: security-updates
-        patterns:
-          - "*"
       gha-version-updates:
         applies-to: version-updates
         patterns:
@@ -75,10 +63,6 @@ updates:
       - dependencies
       - deps/docker
     groups:
-      docker-security-updates:
-        applies-to: security-updates
-        patterns:
-          - "*"
       docker-version-updates:
         applies-to: version-updates
         patterns:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## Unreleased
+- Bumped the Go toolchain to `1.25.11` and the backend builder image to the
+  matching `golang:1.25.11-alpine` digest to clear stdlib advisories
+  GO-2026-5037 and GO-2026-5039, which the daily OSV scan was failing on.
+  Added a `docker` ecosystem entry to `.github/dependabot.yml` for
+  `deploy/docker/` so future base-image bumps are opened as PRs automatically.
 - Added the owner-only workspace Danger Zone on Settings (PR 3 of #1420).
   Workspace owners now see Suspend / Reactivate / Delete / Restore rows
   appended into the existing Danger Zone card alongside the user-account

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   GO-2026-5037 and GO-2026-5039, which the daily OSV scan was failing on.
   Added a `docker` ecosystem entry to `.github/dependabot.yml` for
   `deploy/docker/` so future base-image bumps are opened as PRs automatically.
+  Dropped the `*-security-updates` groups from every ecosystem so Dependabot
+  opens security PRs the moment an advisory fires instead of batching them
+  for the weekly Monday run; routine version bumps stay batched as before.
 - Added the owner-only workspace Danger Zone on Settings (PR 3 of #1420).
   Workspace owners now see Suspend / Reactivate / Delete / Restore rows
   appended into the existing Danger Zone card alongside the user-account

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Prerequisites
 
-- Go `1.25.10` (see `go.mod`)
+- Go `1.25.11` (see `go.mod`)
 - Node.js `24` for `web/`
 - Docker + Docker Compose for local stack and integration tests
 - PostgreSQL (or Docker) for integration tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Good contributions include:
 ## Before You Start
 
 Prerequisites:
-- Go `1.25.10` (see `go.mod`)
+- Go `1.25.11` (see `go.mod`)
 - Node.js `24` for `web/`
 - Docker for local Compose and image validation
 - PostgreSQL (or Docker) for integration test flows

--- a/deploy/docker/Dockerfile.backend
+++ b/deploy/docker/Dockerfile.backend
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.25.10-alpine@sha256:8d22e29d960bc50cd025d93d5b7c7d220b1ee9aa7a239b3c8f55a57e987e8d45 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.11-alpine@sha256:cd2fb3559df6e13bc93b7f0734a4eabe1d21e7b64eec211ed90784f00a17a56a AS builder
 WORKDIR /src
 
 RUN apk add --no-cache ca-certificates tzdata git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/identrail/identrail
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
## Summary
- Bump the Go toolchain pin (`go.mod`, prereq notes, `golang:1.25.11-alpine` digest) to clear stdlib advisories [GO-2026-5037](https://osv.dev/GO-2026-5037) and [GO-2026-5039](https://osv.dev/GO-2026-5039), both fixed in `1.25.11`.
- Add a `docker` ecosystem entry to `.github/dependabot.yml` for `deploy/docker/` so future base-image bumps are PR'd automatically.
- Drop the `*-security-updates` groups from every ecosystem in `.github/dependabot.yml` so Dependabot opens security PRs the moment an advisory fires instead of batching them for the weekly Monday run. Routine version bumps stay batched as before.

No issue: surfaced via the Security tab (OSV scanner) rather than a GitHub issue. The failing daily scan on `dev` is the source of record — see [run 26851605275](https://github.com/identrail/identrail/actions/runs/26851605275).

## Context
The daily OSV scan on `dev` has been failing since the advisories landed:

```
| OSV URL                      | ECOSYSTEM | PACKAGE | VERSION | FIXED VERSION |
| https://osv.dev/GO-2026-5037 | Go        | stdlib  | 1.25.10 | 1.25.11       |
| https://osv.dev/GO-2026-5039 | Go        | stdlib  | 1.25.10 | 1.25.11       |
```

The reusable workflow runs with `fail-on-vuln=true`, which surfaces in the Security tab as "Workflow runs failing" under the `osv-scanner` configuration.

## Preventing recurrence
Two related Dependabot changes in the same diff:
- **Docker ecosystem added.** The Alpine base image in `deploy/docker/Dockerfile.backend` was the one pin Dependabot wasn't watching. Now it is.
- **Security-update groups removed.** Wrapping security updates in a group with `applies-to: security-updates` causes Dependabot to batch them and hold each PR until the weekly Monday run — that's why the GO-2026-5037/5039 fix never auto-PR'd before the OSV scan started failing. Without the group, Dependabot reverts to its default: a security PR opens within hours of an advisory firing. Routine version bumps still flow through the `*-version-updates` groups, so Monday's batched PR noise is unchanged.

## Test plan
- [ ] CI green on this PR (OSV scan in particular).
- [ ] After merge, the next push to `dev` no longer fails the `osv-default / osv-scan` job.

## AI disclosure
- AI-assisted: yes
- Tools used: Claude Code (Opus 4.7)
- Where used: identified the failing job, located the version pins (`go.mod`, `CONTRIBUTING.md`, `CLAUDE.md`, `deploy/docker/Dockerfile.backend`), looked up the matching multi-arch digest for `golang:1.25.11-alpine`, drafted the Dependabot changes.
- Human verification performed: Docker Hub tag listing confirmed `1.25.11-alpine` is published; digest `sha256:cd2fb3559df6e13bc93b7f0734a4eabe1d21e7b64eec211ed90784f00a17a56a` was pulled directly from the `library/golang` repository manifest endpoint.