### PR TITLE
Make sidebar flyout backdrop fully black

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -27097,9 +27097,9 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   z-index: 20;
   border: 0;
   padding: 0;
-  background: rgba(5, 7, 10, 0.58);
-  -webkit-backdrop-filter: blur(22px) saturate(0.84) brightness(0.72);
-  backdrop-filter: blur(22px) saturate(0.84) brightness(0.72);
+  background: #000000;
+  -webkit-backdrop-filter: blur(28px) saturate(0.84) brightness(0.48);
+  backdrop-filter: blur(28px) saturate(0.84) brightness(0.48);
   cursor: default;
   touch-action: none;
 }
@@ -27110,7 +27110,7 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   z-index: 40;
   border: 0;
   padding: 0;
-  background: rgba(5, 7, 10, 0.54);
+  background: #000000;
   cursor: default;
   touch-action: none;
 }


### PR DESCRIPTION
Refs #1389

## Summary
- Make the domain flyout page backdrop fully black while retaining the stronger blur/dim filter.
- Make the sidebar-local flyout backdrop fully black so the opened section no longer shows translucent background color.

## Validation
- `git diff --check`
- `npm test -- --run src/productShell.test.tsx`
- Browser check on `http://127.0.0.1:5174/app/tenant-a/workspace-a`: opened the AWS flyout and confirmed both backdrop layers compute to `rgb(0, 0, 0)` at opacity `1`.

## AI disclosure usage
No