### PR TITLE
Keep sidebar flyout overlay unchanged

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -27110,7 +27110,7 @@ html[data-theme='light'] .idt-book-demo-modal-body .idt-lead-form p {
   z-index: 40;
   border: 0;
   padding: 0;
-  background: #000000;
+  background: rgba(5, 7, 10, 0.54);
   cursor: default;
   touch-action: none;
 }


### PR DESCRIPTION
Refs #1389
Follow-up to #1464.

## Summary
- Restore the sidebar-local flyout backdrop to the original translucent overlay.
- Keep the main page backdrop fully black with the current blur/dim treatment.

## Validation
- `git diff --check`
- `npm test -- --run src/productShell.test.tsx`
- Browser check on `http://127.0.0.1:5174/app/tenant-a/workspace-a`: opened the GitHub flyout and confirmed the page backdrop computes to `rgb(0, 0, 0)` with blur while the sidebar backdrop computes to `rgba(5, 7, 10, 0.54)`.

## AI disclosure usage
No