### PR TITLE
fix: use github-script v9 binding for branch-protection enforce

### DIFF
--- a/.github/workflows/enforce-branch-protection.yml
+++ b/.github/workflows/enforce-branch-protection.yml
@@ -1,6 +1,6 @@
 # Requires two repo secrets, sourced from a dedicated GitHub App installed on
 # this repository (see CONTRIBUTING.md → "Repo secrets" for setup):
-#   BRANCH_PROTECTION_APP_ID          - the App's numeric App ID
+#   BRANCH_PROTECTION_APP_CLIENT_ID   - the App's Client ID (Iv23li...)
 #   BRANCH_PROTECTION_APP_PRIVATE_KEY - the App's private key (.pem contents)
 # The App needs Repository permissions: Administration (Read & write),
 # Contents (Read-only), Metadata (Read-only). Nothing else.
@@ -49,7 +49,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.BRANCH_PROTECTION_APP_ID }}
+          client-id: ${{ secrets.BRANCH_PROTECTION_APP_CLIENT_ID }}
           private-key: ${{ secrets.BRANCH_PROTECTION_APP_PRIVATE_KEY }}
 
       - name: Audit drift and optionally apply protection

--- a/.github/workflows/enforce-branch-protection.yml
+++ b/.github/workflows/enforce-branch-protection.yml
@@ -55,9 +55,14 @@ jobs:
       - name: Audit drift and optionally apply protection
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          REPO_ADMIN_TOKEN: ${{ steps.app-token.outputs.token }}
           MODE: ${{ env.MODE }}
         with:
+          # The `github` script binding below is an Octokit instance already
+          # authenticated with this token, so calls like
+          # `github.rest.repos.getBranchProtection(...)` use the App's
+          # installation token (admin scope) rather than the default
+          # GITHUB_TOKEN (read-only contents).
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs');
 
@@ -65,7 +70,6 @@ jobs:
             const repo = context.repo.repo;
             const branch = 'dev';
             const mode = (process.env.MODE || 'dry-run').trim();
-            const token = (process.env.REPO_ADMIN_TOKEN || '').trim();
 
             const desiredRaw = JSON.parse(
               fs.readFileSync('.github/branch-protection/dev.json', 'utf8')
@@ -143,21 +147,10 @@ jobs:
               `desired policy: ${JSON.stringify(desiredNormalized, null, 2)}`
             );
 
-            if (!token) {
-              core.setFailed(
-                'Missing installation token. Verify BRANCH_PROTECTION_APP_ID and ' +
-                'BRANCH_PROTECTION_APP_PRIVATE_KEY repo secrets are set and that ' +
-                'the GitHub App is installed on this repository.'
-              );
-              return;
-            }
-
-            const adminOctokit = github.getOctokit(token);
-
             let liveNormalized = null;
             let branchUnprotected = false;
             try {
-              const liveResponse = await adminOctokit.rest.repos.getBranchProtection({
+              const liveResponse = await github.rest.repos.getBranchProtection({
                 owner,
                 repo,
                 branch
@@ -201,14 +194,14 @@ jobs:
               return;
             }
 
-            await adminOctokit.rest.repos.updateBranchProtection({
+            await github.rest.repos.updateBranchProtection({
               owner,
               repo,
               branch,
               ...desiredRaw
             });
 
-            const postApply = await adminOctokit.rest.repos.getBranchProtection({
+            const postApply = await github.rest.repos.getBranchProtection({
               owner,
               repo,
               branch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,7 +173,7 @@ maintainers must configure outside the codebase. The current list:
 
 | Secret | Used by | Purpose |
 |---|---|---|
-| `BRANCH_PROTECTION_APP_ID` | `enforce-branch-protection.yml` | Numeric App ID of the dedicated branch-protection GitHub App installed on this repo. |
+| `BRANCH_PROTECTION_APP_CLIENT_ID` | `enforce-branch-protection.yml` | Client ID of the dedicated branch-protection GitHub App installed on this repo (visible on the App's General page, format `Iv23li…`). |
 | `BRANCH_PROTECTION_APP_PRIVATE_KEY` | `enforce-branch-protection.yml` | Private key (`.pem` contents) for the same App. The workflow exchanges these two values for a short-lived installation token at runtime. |
 
 The branch-protection App must be installed on `identrail/identrail` with


### PR DESCRIPTION
## Summary
Follow-up fix to #1469. The App token mint works, but the script step then hit `TypeError: github.getOctokit is not a function` on manual run #39. In `actions/github-script@v9` the `github` binding is itself a pre-instantiated authenticated Octokit client (not the `@actions/github` package), so the old `github.getOctokit(token)` pattern is gone. Pass the App installation token via the `github-token` input instead, and use `github.rest.*` directly throughout.

No issue: surfaced via the failing manual run on `dev` of the `Enforce Branch Protection` workflow, not a GitHub issue.

## Why this slipped past the previous PR
The previous PR moved the *source* of the token (PAT → App) without touching the script body, on the assumption that the `github.getOctokit(token)` call was still valid. It isn't, in v9. The fix is purely the script-side handoff:

- Drop `REPO_ADMIN_TOKEN` env var on the step.
- Pass `github-token: ${{ steps.app-token.outputs.token }}` to `actions/github-script` so the default `github` binding is the admin-scoped client.
- Replace `adminOctokit` with `github` throughout the script.
- Drop the in-script "missing token" guard — the `actions/create-github-app-token` step already fails fast and clearly if either secret is missing or the App isn't installed.

## Test plan
- [ ] CI green on this PR.
- [ ] After merge: Actions → "Enforce Branch Protection" → Run workflow (manual, dry-run) → expect a green run that prints either "Branch protection is already aligned with repo policy" or a real drift report (not `TypeError`).
- [ ] Tomorrow's 03:23 UTC cron is also green.

## Known follow-up (not in this PR)
- `actions/create-github-app-token` warns `Input 'app-id' has been deprecated with message: Use 'client-id' instead.` Still functional. Switching to `client-id` is a one-line input rename plus updating the secret value from the App ID number to the Client ID string (visible on the App's General page, format `Iv23li...`). Happy to do that in a separate small PR if you grab the Client ID.
- Silent cron-failure detection (the original "this drifted for weeks before being noticed" problem) — still open.

## AI disclosure
- AI-assisted: yes
- Tools used: Claude Code (Opus 4.7)
- Where used: diagnosed the TypeError as the v9 API change, drafted the script-side refactor.
- Human verification performed: workflow_dispatch run on `dev` after merge will confirm; secrets remain valid from the prior PR setup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Enforce Branch Protection workflow by using `actions/github-script@v9`’s pre-authenticated `github` client with the App installation token via `github-token`, resolving `TypeError: github.getOctokit is not a function`. Also switches `actions/create-github-app-token@v3.2.0` to `client-id` to remove the deprecation warning.

- **Bug Fixes**
  - Pass the App token through `github-token` and call `github.rest.*` directly.
  - Remove `REPO_ADMIN_TOKEN` and the in-script token guard; drop `adminOctokit` usage.
  - Update workflow and CONTRIBUTING comments to document the new auth flow.

- **Migration**
  - Set `BRANCH_PROTECTION_APP_CLIENT_ID` and `BRANCH_PROTECTION_APP_PRIVATE_KEY` repo secrets.
  - Ensure the App is installed with Administration: Read & write; Contents: Read-only; Metadata: Read-only.
  - `BRANCH_PROTECTION_APP_ID` is now unused and can be deleted.

<sup>Written for commit db6806c494652d4687474c7b1b9ca73393eb208f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/identrail/identrail/pull/1470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

