### PR TITLE
Fix sidebar flyout highlight handoff

### DIFF
--- a/web/src/productShell.test.tsx
+++ b/web/src/productShell.test.tsx
@@ -961,7 +961,7 @@ describe('ProductShellLayout', () => {
     expect(screen.queryByRole('option', { name: /Connect GitHub/i })).not.toBeInTheDocument();
   });
 
-  it('lets an open domain flyout own the sidebar highlight over Reports routes', async () => {
+  it('lets a recently opened domain flyout own the sidebar highlight over Reports routes', async () => {
     mockConnectorFeatureFlags({ github: true, kubernetes: true });
     mockBackendFeatures({ github: true, kubernetes: true });
     const { ProductShellLayout } = await import('./productShell');
@@ -995,9 +995,15 @@ describe('ProductShellLayout', () => {
     fireEvent.click(sidebarBackdrop as Element);
 
     expect(screen.queryByRole('dialog', { name: 'AWS' })).not.toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Reports' })).toHaveClass('active');
+    expect(screen.getByRole('link', { name: 'Reports' })).not.toHaveClass('active');
+    expect(screen.getByRole('button', { name: 'AWS' })).toHaveClass('is-active');
     expect(resizeHandle).not.toHaveClass('is-domain-flyout-blocked');
     expect(resizeHandle).toHaveAttribute('tabindex', '0');
+
+    fireEvent.click(screen.getByRole('link', { name: 'Reports' }));
+
+    expect(screen.getByRole('link', { name: 'Reports' })).toHaveClass('active');
+    expect(screen.getByRole('button', { name: 'AWS' })).not.toHaveClass('is-active');
 
     fireEvent.click(screen.getByRole('button', { name: 'GitHub' }));
 
@@ -1011,7 +1017,7 @@ describe('ProductShellLayout', () => {
     mockBackendFeatures({ github: true, kubernetes: true });
     const { ProductShellLayout } = await import('./productShell');
 
-    render(
+    const { container } = render(
       <MemoryRouter initialEntries={['/app/tenant-a/workspace-a/settings']}>
         <Routes>
           <Route path="/app/:tenantID/:workspaceID" element={<ProductShellLayout />}>
@@ -1028,6 +1034,14 @@ describe('ProductShellLayout', () => {
 
     expect(screen.getByRole('link', { name: 'Settings' })).not.toHaveClass('active');
     expect(screen.getByRole('button', { name: 'Kubernetes' })).toHaveClass('is-open');
+
+    const sidebarBackdrop = container.querySelector('.idt-domain-flyout-sidebar-backdrop');
+    fireEvent.click(sidebarBackdrop as Element);
+
+    expect(screen.queryByRole('dialog', { name: 'Kubernetes' })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Settings' })).not.toHaveClass('active');
+    expect(screen.getByRole('button', { name: 'Kubernetes' })).toHaveClass('is-active');
+    expect(screen.getByRole('button', { name: 'Kubernetes' })).not.toHaveClass('is-open');
   });
 });
 

--- a/web/src/productShell.tsx
+++ b/web/src/productShell.tsx
@@ -9177,6 +9177,7 @@ export function ProductShellLayout() {
   const [accountMenuOpen, setAccountMenuOpen] = useState(false);
   const [workspaceMenuOpen, setWorkspaceMenuOpen] = useState(false);
   const [openDomainFlyout, setOpenDomainFlyout] = useState<SourceProvider | null>(null);
+  const [lastOpenedDomainFlyout, setLastOpenedDomainFlyout] = useState<SourceProvider | null>(null);
   const [sidebarCollapsedPref, setSidebarCollapsedPref] = useState<boolean>(() => readSidebarCollapsed());
   const [sidebarWidth, setSidebarWidth] = useState<number>(() => readSidebarWidth());
   const [isDraggingSidebar, setIsDraggingSidebar] = useState(false);
@@ -9350,6 +9351,7 @@ export function ProductShellLayout() {
 
   useEffect(() => {
     setOpenDomainFlyout(null);
+    setLastOpenedDomainFlyout(null);
   }, [location.pathname]);
 
   useEffect(() => {
@@ -9733,6 +9735,7 @@ export function ProductShellLayout() {
   const runCommand = (item: CommandPaletteItem) => {
     setCommandOpen(false);
     setOpenDomainFlyout(null);
+    setLastOpenedDomainFlyout(null);
     if (item.path) {
       navigate(item.path);
       return;
@@ -9740,12 +9743,20 @@ export function ProductShellLayout() {
     item.action?.();
   };
   const closeDomainFlyout = () => setOpenDomainFlyout(null);
+  const resetDomainFlyoutHighlight = () => {
+    setOpenDomainFlyout(null);
+    setLastOpenedDomainFlyout(null);
+  };
   const toggleDomainFlyout = (domain: SourceProvider) => {
     setAccountMenuOpen(false);
     setWorkspaceMenuOpen(false);
     setCommandOpen(false);
+    setLastOpenedDomainFlyout(domain);
     setOpenDomainFlyout((current) => (current === domain ? null : domain));
   };
+  const rememberedDomainHighlight =
+    lastOpenedDomainFlyout && visibleDomainOrder.includes(lastOpenedDomainFlyout) ? lastOpenedDomainFlyout : null;
+  const domainFlyoutOwnsRouteHighlight = Boolean(openDomainFlyout || (!activeDomain && rememberedDomainHighlight));
 
   return (
     <ProductErrorBoundary>
@@ -9810,21 +9821,30 @@ export function ProductShellLayout() {
                 <Link
                   role="menuitem"
                   to={`${basePath}/workspaces`}
-                  onClick={() => setWorkspaceMenuOpen(false)}
+                  onClick={() => {
+                    setWorkspaceMenuOpen(false);
+                    resetDomainFlyoutHighlight();
+                  }}
                 >
                   Switch workspace
                 </Link>
                 <Link
                   role="menuitem"
                   to={`${basePath}/settings`}
-                  onClick={() => setWorkspaceMenuOpen(false)}
+                  onClick={() => {
+                    setWorkspaceMenuOpen(false);
+                    resetDomainFlyoutHighlight();
+                  }}
                 >
                   Settings
                 </Link>
                 <Link
                   role="menuitem"
                   to="/onboarding/org"
-                  onClick={() => setWorkspaceMenuOpen(false)}
+                  onClick={() => {
+                    setWorkspaceMenuOpen(false);
+                    resetDomainFlyoutHighlight();
+                  }}
                 >
                   Create a workspace
                 </Link>
@@ -9862,8 +9882,8 @@ export function ProductShellLayout() {
               end
               aria-label="Overview"
               title={sidebarCollapsed ? 'Overview' : undefined}
-              className={({ isActive }) => (isActive && !openDomainFlyout ? 'active' : undefined)}
-              onClick={closeDomainFlyout}
+              className={({ isActive }) => (isActive && !domainFlyoutOwnsRouteHighlight ? 'active' : undefined)}
+              onClick={resetDomainFlyoutHighlight}
             >
               <span className="idt-app-nav-icon" aria-hidden="true">
                 <LayoutDashboard size={16} strokeWidth={1.75} />
@@ -9874,7 +9894,9 @@ export function ProductShellLayout() {
               const config = PRODUCT_DOMAIN_CONFIGS[domain];
               const availability = sourceAvailability[domain];
               const isOpen = openDomainFlyout === domain;
-              const isActive = activeDomain === domain && (!openDomainFlyout || isOpen);
+              const isActive =
+                (activeDomain === domain && (!openDomainFlyout || isOpen)) ||
+                (!openDomainFlyout && !activeDomain && rememberedDomainHighlight === domain);
               const triggerID = `idt-${domain}-domain-trigger`;
               return (
                 <div key={domain} className={`idt-app-domain-nav-item${isOpen ? ' is-open' : ''}`}>
@@ -9922,8 +9944,8 @@ export function ProductShellLayout() {
               to={`${basePath}/reports`}
               aria-label="Reports"
               title={sidebarCollapsed ? 'Reports' : undefined}
-              className={({ isActive }) => (isActive && !openDomainFlyout ? 'active' : undefined)}
-              onClick={closeDomainFlyout}
+              className={({ isActive }) => (isActive && !domainFlyoutOwnsRouteHighlight ? 'active' : undefined)}
+              onClick={resetDomainFlyoutHighlight}
             >
               <span className="idt-app-nav-icon" aria-hidden="true">
                 <BarChart3 size={16} strokeWidth={1.75} />
@@ -9934,8 +9956,8 @@ export function ProductShellLayout() {
               to={`${basePath}/settings`}
               aria-label="Settings"
               title={sidebarCollapsed ? 'Settings' : undefined}
-              className={({ isActive }) => (isActive && !openDomainFlyout ? 'active' : undefined)}
-              onClick={closeDomainFlyout}
+              className={({ isActive }) => (isActive && !domainFlyoutOwnsRouteHighlight ? 'active' : undefined)}
+              onClick={resetDomainFlyoutHighlight}
             >
               <span className="idt-app-nav-icon" aria-hidden="true">
                 <SettingsIcon size={16} strokeWidth={1.75} />


### PR DESCRIPTION
Refs #1389.
Follow-up to #1468.

## Summary
- Keep the last opened domain section highlighted after its flyout closes on non-domain routes.
- Prevent Overview, Reports, or Settings from reclaiming the active sidebar highlight until the user explicitly clicks/navigates back to one of those sections.
- Add Reports and Settings regression coverage for closing a domain flyout by clicking away.

## Validation
- `git diff --check`
- `npm test -- --run src/productShell.test.tsx`
- `npm run build`
- Browser check on local Vite with a stub API: Settings -> Kubernetes -> close flyout leaves Kubernetes `is-active`, Settings inactive; clicking Settings restores Settings `active`; no console errors.

## AI disclosure usage
No
